### PR TITLE
agent/releaseslink 1758664746636 l9bna1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <p align="left">
   <img src="./src/assets/images/emdash/emdash.iconset/icon_512x512.png#gh-light-mode-only" alt="Emdash" height="40" style="vertical-align:middle;margin-right:12px;">
   <img src="./src/assets/images/emdash/emdash.iconset/icon_512x512.png#gh-dark-mode-only" alt="Emdash" height="40" style="vertical-align:middle;margin-right:12px;">
-  <a href="https://github.com/generalaction/stagehand/releases/latest">
+  <a href="https://github.com/generalaction/emdash/releases">
     <img src="./docs/media/downloadformacos.png" alt="Download app for macOS" height="40" style="vertical-align:middle;">
   </a>
 


### PR DESCRIPTION
- **ci(release): harden mac release (sign+notarize app, staple+validate app,   best‑effort DMG stapling, dry_run support, auto‑publish, strict integrity checks)**
- **ci(release): fix dry_run gating in release-mac; ensure artifacts upload**
- **ci(release): notarize + staple DMGs; end-to-end Gatekeeper check; fix YAML   quoting**
- **fix(build): Vite base='./' for prod; notarize+staple DMGs; end‑to‑end Gatekeeper   check**
- **app: fix PATH for packaged app (gh/codex); prod asset base**
- **deps: add fix-path for PATH normalization**
- **chore: bump version to 0.1.2**
- **chore: bump version to 0.1.3**
- **release: DMG-only notarization; end-to-end DMG check; lockfile update**
- **add download for mac os button**
- **Update README.md**
- **Fix image filename for macOS download link**
- **chore: apply workspace changes**
