### PR TITLE
agent/documentation 1759071891686 6v8qks

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ emdash is a UI layer for running multiple Codex CLI agents in parallel, each iso
 - Download for macOS (Apple Silicon): https://github.com/generalaction/stagehand/releases/latest/download/emdash-arm64.dmg
 - Download for macOS (Intel x64): https://github.com/generalaction/stagehand/releases/latest/download/emdash-x64.dmg
 
+Either download the DMG from Releases (or click the link above), or run the app locally — see Requirements and Getting Started below.
+
 Note: Builds are unsigned by default. On first launch, right‑click the app, choose Open, then confirm to bypass Gatekeeper. For signed/notarized builds, add Apple Developer credentials to GitHub Actions (see CI section below).
 
 ## Requirements


### PR DESCRIPTION
- **ci(release): harden mac release (sign+notarize app, staple+validate app,   best‑effort DMG stapling, dry_run support, auto‑publish, strict integrity checks)**
- **ci(release): fix dry_run gating in release-mac; ensure artifacts upload**
- **ci(release): notarize + staple DMGs; end-to-end Gatekeeper check; fix YAML   quoting**
- **fix(build): Vite base='./' for prod; notarize+staple DMGs; end‑to‑end Gatekeeper   check**
- **app: fix PATH for packaged app (gh/codex); prod asset base**
- **deps: add fix-path for PATH normalization**
- **chore: bump version to 0.1.2**
- **chore: bump version to 0.1.3**
- **release: DMG-only notarization; end-to-end DMG check; lockfile update**
- **add download for mac os button**
- **Update README.md**
- **Fix image filename for macOS download link**
- **chore: apply workspace changes**
- **chore: apply workspace changes**
- **Update README.md**
- **delete old screenshot**
- **fix(workspaces): add Create Workspace input validation and duplicate checks**
- **ux(toast): neutralize error toast styling and add warning icon**
- **chore: apply workspace changes**
