### PR TITLE
fix: detect GitHub CLI auth via CLI token

### DIFF
--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -116,8 +116,15 @@ export class GitHubService {
    */
   async isAuthenticated(): Promise<boolean> {
     try {
-      const token = await this.getStoredToken();
-      if (!token) return false;
+      let token = await this.getStoredToken();
+
+      if (!token) {
+        const authResult = await this.authenticate();
+        if (!authResult.success || !authResult.token) {
+          return false;
+        }
+        token = authResult.token;
+      }
 
       // Test the token by making a simple API call
       const user = await this.getUserInfo(token);


### PR DESCRIPTION
GitHub CLI authentication status was being checked solely via a cached keytar token, so fresh installs (or wiped keychains) showed "GitHub Connection Failed" even though `gh auth status` reported a login. The fix makes `GitHubService.isAuthenticated` fall back to `gh auth status / gh auth token`, store the token, and validate via gh api user, eliminating the false failure toast.

Fixes #54.