### PR TITLE
Persist Droid (Factory CLI) sessions across chat switches and lock provider once active

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -22,6 +22,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on(channel, wrapped)
     return () => ipcRenderer.removeListener(channel, wrapped)
   },
+  onPtyHistory: (id: string, listener: (data: string) => void) => {
+    const channel = `pty:history:${id}`
+    const wrapped = (_: Electron.IpcRendererEvent, data: string) => listener(data)
+    ipcRenderer.on(channel, wrapped)
+    return () => ipcRenderer.removeListener(channel, wrapped)
+  },
   onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => {
     const channel = `pty:exit:${id}`
     const wrapped = (_: Electron.IpcRendererEvent, info: { exitCode: number; signal?: number }) => listener(info)
@@ -168,6 +174,7 @@ export interface ElectronAPI {
   ptyResize: (args: { id: string; cols: number; rows: number }) => void
   ptyKill: (id: string) => void
   onPtyData: (id: string, listener: (data: string) => void) => () => void
+  onPtyHistory: (id: string, listener: (data: string) => void) => () => void
   onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => () => void
   // Worktree management
   worktreeCreate: (args: { projectPath: string; workspaceName: string; projectId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -1,7 +1,24 @@
 import { ipcMain, WebContents } from 'electron'
-import { startPty, writePty, resizePty, killPty } from './ptyManager'
+import { startPty, writePty, resizePty, killPty, getPty } from './ptyManager'
 
 const owners = new Map<string, WebContents>()
+const listeners = new Set<string>()
+
+// Simple scrollback buffer per PTY id, to replay when re-attaching
+const buffers = new Map<string, string[]>()
+const MAX_BUFFER_BYTES = 200_000 // ~200 KB
+
+function appendBuffer(id: string, chunk: string) {
+  const arr = buffers.get(id) ?? []
+  arr.push(chunk)
+  // Trim if over byte budget
+  let total = arr.reduce((n, s) => n + Buffer.byteLength(s, 'utf8'), 0)
+  while (arr.length > 1 && total > MAX_BUFFER_BYTES) {
+    const removed = arr.shift()!
+    total -= Buffer.byteLength(removed, 'utf8')
+  }
+  buffers.set(id, arr)
+}
 
 export function registerPtyIpc(): void {
   ipcMain.handle('pty:start', (event, args: {
@@ -14,19 +31,34 @@ export function registerPtyIpc(): void {
   }) => {
     try {
       const { id, cwd, shell, env, cols, rows } = args
-      const proc = startPty({ id, cwd, shell, env, cols, rows })
-      console.log('pty:start OK', { id, cwd, shell, cols, rows })
+      // Reuse existing PTY if present; otherwise create new
+      const existing = getPty(id)
+      const proc = existing ?? startPty({ id, cwd, shell, env, cols, rows })
+      console.log('pty:start OK', { id, cwd, shell, cols, rows, reused: !!existing })
       const wc = event.sender
       owners.set(id, wc)
 
-      proc.onData((data) => {
-        owners.get(id)?.send(`pty:data:${id}`, data)
-      })
+      // Attach listeners once per PTY id
+      if (!listeners.has(id)) {
+        proc.onData((data) => {
+          appendBuffer(id, data)
+          owners.get(id)?.send(`pty:data:${id}`, data)
+        })
 
-      proc.onExit(({ exitCode, signal }) => {
-        owners.get(id)?.send(`pty:exit:${id}`, { exitCode, signal })
-        owners.delete(id)
-      })
+        proc.onExit(({ exitCode, signal }) => {
+          owners.get(id)?.send(`pty:exit:${id}`, { exitCode, signal })
+          owners.delete(id)
+          listeners.delete(id)
+          buffers.delete(id)
+        })
+        listeners.add(id)
+      }
+
+      // If there's buffered history, replay it to the current owner
+      const history = buffers.get(id)
+      if (history && history.length) {
+        try { wc.send(`pty:history:${id}`, history.join('')) } catch {}
+      }
 
       return { ok: true }
     } catch (err: any) {
@@ -54,6 +86,9 @@ export function registerPtyIpc(): void {
   ipcMain.on('pty:kill', (_event, args: { id: string }) => {
     try {
       killPty(args.id)
+      owners.delete(args.id)
+      listeners.delete(args.id)
+      buffers.delete(args.id)
     } catch (e) {
       console.error('pty:kill error', e)
     }

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -69,3 +69,7 @@ export function killPty(id: string): void {
 export function hasPty(id: string): boolean {
   return ptys.has(id)
 }
+
+export function getPty(id: string): IPty | undefined {
+  return ptys.get(id)?.proc
+}

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -53,6 +53,8 @@ const ChatInterface: React.FC<Props> = ({
   const [provider, setProvider] = useState<"codex" | "claude" | "droid">(
     "codex"
   );
+  const [lockedProvider, setLockedProvider] = useState<"codex" | "claude" | "droid" | null>(null)
+  const [hasDroidActivity, setHasDroidActivity] = useState(false)
   const initializedConversationRef = useRef<string | null>(null);
 
   const codexStream = useCodexStream({
@@ -71,40 +73,64 @@ const ChatInterface: React.FC<Props> = ({
     initializedConversationRef.current = null;
   }, [workspace.id]);
 
-  // On workspace change, restore locked provider if present; otherwise default to Codex.
+  // On workspace change, restore last-selected provider (including Droid).
+  // If a locked provider exists (including Droid), prefer locked.
   useEffect(() => {
     try {
-      const key = `provider:locked:${workspace.id}`;
-      const saved = window.localStorage.getItem(key) as
+      const lastKey = `provider:last:${workspace.id}`
+      const lockedKey = `provider:locked:${workspace.id}`
+      const last = window.localStorage.getItem(lastKey) as
         | "codex"
         | "claude"
         | "droid"
-        | null;
-      if (saved === "claude" || saved === "codex") {
-        setProvider(saved);
+        | null
+      const locked = window.localStorage.getItem(lockedKey) as
+        | "codex"
+        | "claude"
+        | "droid"
+        | null
+
+      setLockedProvider(locked)
+      setHasDroidActivity(locked === 'droid')
+
+      if (locked === 'droid') {
+        setProvider('droid')
+      } else if (last === 'droid') {
+        setProvider('droid')
+      } else if (locked === 'codex' || locked === 'claude') {
+        setProvider(locked)
+      } else if (last === 'codex' || last === 'claude') {
+        setProvider(last)
       } else {
-        setProvider("codex");
+        setProvider('codex')
       }
     } catch {
-      setProvider("codex");
+      setProvider('codex')
     }
-  }, [workspace.id]);
+  }, [workspace.id])
 
-  // When a chat becomes locked (first user message sent), persist the provider (excluding Droid)
+  // Persist last-selected provider per workspace (including Droid)
   useEffect(() => {
     try {
-      const hasLockedProvider =
-        provider !== "droid" &&
+      window.localStorage.setItem(`provider:last:${workspace.id}`, provider)
+    } catch {}
+  }, [provider, workspace.id])
+
+  // When a chat becomes locked (first user message sent or Droid activity), persist the provider
+  useEffect(() => {
+    try {
+      const userLocked =
+        provider !== 'droid' &&
         activeStream.messages &&
-        activeStream.messages.some((m) => m.sender === "user");
-      if (hasLockedProvider) {
-        window.localStorage.setItem(
-          `provider:locked:${workspace.id}`,
-          provider
-        );
+        activeStream.messages.some((m) => m.sender === 'user')
+      const droidLocked = provider === 'droid' && hasDroidActivity
+
+      if (userLocked || droidLocked) {
+        window.localStorage.setItem(`provider:locked:${workspace.id}`, provider)
+        setLockedProvider(provider)
       }
     } catch {}
-  }, [provider, workspace.id, activeStream.messages]);
+  }, [provider, workspace.id, activeStream.messages, hasDroidActivity]);
 
   // Check Claude Code installation when selected
   useEffect(() => {
@@ -306,11 +332,7 @@ const ChatInterface: React.FC<Props> = ({
       ? activeStream.streamingOutput
       : null;
   // Allow switching providers freely while in Droid mode
-  const providerLocked =
-    provider !== "droid" &&
-    (activeStream.isStreaming ||
-      (activeStream.messages &&
-        activeStream.messages.some((m) => m.sender === "user")));
+  const providerLocked = lockedProvider !== null
 
   return (
     <div
@@ -348,9 +370,9 @@ const ChatInterface: React.FC<Props> = ({
                   https://docs.factory.ai/cli/getting-started/quickstart
                 </button>
                 <div className="mt-2 text-xs opacity-90">
-                  Note: Chat state for Factory CLI sessions isn’t persisted;
-                  switching chats closes the terminal and its state is not
-                  restored.
+                  Note: The Droid terminal session now persists while the app is open;
+                  leaving and returning to this chat will restore its output. Closing the app
+                  will terminate the session.
                 </div>
               </div>
             </div>
@@ -361,6 +383,14 @@ const ChatInterface: React.FC<Props> = ({
                 id={`droid-main-${workspace.id}`}
                 cwd={workspace.path}
                 shell="droid"
+                keepAlive={true}
+                onActivity={() => {
+                  try {
+                    setHasDroidActivity(true)
+                    window.localStorage.setItem(`provider:locked:${workspace.id}`, 'droid')
+                    setLockedProvider('droid')
+                  } catch {}
+                }}
                 variant="light"
                 className="h-full w-full"
               />


### PR DESCRIPTION
- Keep Droid PTY alive across view changes via keepAlive and PTY reuse by ID.
- Add scrollback buffer in main process (~200KB) and replay via pty:history:<id> on reattach.
- Expose onPtyHistory in preload; wire renderer to consume and render history before live output.
- Add onActivity hook in TerminalPane; first keystroke in Droid locks provider to droid.
- Persist provider:locked:<workspaceId> for Droid; restore it when returning to the chat. 
- Remember last-selected provider per workspace; prefer locked provider if present.
- Only Droid uses keepAlive; other terminals keep existing lifecycle (killed on unmount).
- Clean up listeners/buffers on PTY exit/kill; avoid duplicate event handlers.
- Update UI note to reflect session persistence while the app is open.
