### PR TITLE
feat: add chevron for agent/provider selector

### DIFF
--- a/src/renderer/components/ChatInput.tsx
+++ b/src/renderer/components/ChatInput.tsx
@@ -4,7 +4,8 @@ import { Button } from './ui/button';
 import { ArrowRight } from 'lucide-react';
 import { useFileIndex } from '../hooks/useFileIndex';
 import FileTypeIcon from './ui/file-type-icon';
-import { ProviderSelector, type Provider } from './ProviderSelector';
+import { ProviderSelector } from './ProviderSelector';
+import { type Provider } from '../types';
 
 interface ChatInputProps {
   value: string;

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -1,13 +1,11 @@
 import React, { useEffect, useRef, useState } from 'react';
-import { Folder } from 'lucide-react';
 import { useToast } from '../hooks/use-toast';
 import ChatInput from './ChatInput';
 import { TerminalPane } from './TerminalPane';
 import MessageList from './MessageList';
 import useCodexStream from '../hooks/useCodexStream';
 import useClaudeStream from '../hooks/useClaudeStream';
-import { useProviderPreference } from '../hooks/useProviderPreference';
-import { type Provider } from './ProviderSelector';
+import { type Provider } from '../types';
 import { buildAttachmentsSection } from '../lib/attachments';
 import { Workspace, Message } from '../types/chat';
 

--- a/src/renderer/components/ProviderSelector.tsx
+++ b/src/renderer/components/ProviderSelector.tsx
@@ -9,12 +9,11 @@ import {
 } from './ui/select';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import { ChevronUp } from 'lucide-react';
+import { type Provider } from '../types';
 import openaiLogo from '../../assets/images/openai.png';
 import claudeLogo from '../../assets/images/claude.png';
 import factoryLogo from '../../assets/images/factorydroid.png';
 import geminiLogo from '../../assets/images/gemini.png';
-
-export type Provider = 'codex' | 'claude' | 'droid' | 'gemini';
 
 interface ProviderSelectorProps {
   value: Provider;

--- a/src/renderer/types/index.ts
+++ b/src/renderer/types/index.ts
@@ -44,3 +44,5 @@ export interface Workspace {
   name: string;
   repos: Repo[];
 }
+
+export type Provider = 'codex' | 'claude' | 'droid' | 'gemini';


### PR DESCRIPTION
personally it wasn't really clear for me that I should click this button to select the coding agent i wan to use so i added a chevron to make this more obvious.

https://github.com/user-attachments/assets/129690c3-bf17-41de-8dee-4f587e4c54c8

changes look pretty dramatic but this is only since the page wasn't really formatted, if you wan an easier review just look at commit [41f673ec91c09b9acff191998f2a74922d264557](41f673ec91c09b9acff191998f2a74922d264557) there is the little change I actually made :) 
