### PR TITLE
fix(db): preserve project id on upsert and prevent workspace cascade deletes

### DIFF
--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -176,26 +176,44 @@ export class DatabaseService {
   async saveProject(project: Omit<Project, 'createdAt' | 'updatedAt'>): Promise<void> {
     if (!this.db) throw new Error('Database not initialized');
 
+    // Important: avoid INSERT OR REPLACE on projects. REPLACE deletes the existing
+    // row to satisfy UNIQUE(path) which can cascade-delete related workspaces
+    // (workspaces.project_id ON DELETE CASCADE). Use an UPSERT on the unique
+    // path constraint that updates fields in-place and preserves the existing id.
+    //
+    // Semantics:
+    // - If no row exists for this path: insert with the provided id.
+    // - If a row exists for this path: update fields; do NOT change id or path.
+    // - created_at remains intact on updates; updated_at is bumped.
     return new Promise((resolve, reject) => {
-      this.db!.run(`
-        INSERT OR REPLACE INTO projects 
-        (id, name, path, git_remote, git_branch, github_repository, github_connected, updated_at)
-        VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
-      `, [
-        project.id,
-        project.name,
-        project.path,
-        project.gitInfo.remote || null,
-        project.gitInfo.branch || null,
-        project.githubInfo?.repository || null,
-        project.githubInfo?.connected ? 1 : 0
-      ], (err) => {
-        if (err) {
-          reject(err);
-        } else {
-          resolve();
+      this.db!.run(
+        `INSERT INTO projects (id, name, path, git_remote, git_branch, github_repository, github_connected, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+         ON CONFLICT(path) DO UPDATE SET
+           name = excluded.name,
+           git_remote = excluded.git_remote,
+           git_branch = excluded.git_branch,
+           github_repository = excluded.github_repository,
+           github_connected = excluded.github_connected,
+           updated_at = CURRENT_TIMESTAMP
+        `,
+        [
+          project.id,
+          project.name,
+          project.path,
+          project.gitInfo.remote || null,
+          project.gitInfo.branch || null,
+          project.githubInfo?.repository || null,
+          project.githubInfo?.connected ? 1 : 0,
+        ],
+        (err) => {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
         }
-      });
+      );
     });
   }
 


### PR DESCRIPTION
This PR fixes a data-loss bug in project upserts.

Problem
- `saveProject` used `INSERT OR REPLACE` against `projects` where `path` is `UNIQUE`.
- When the same path is added again with a different `id`, SQLite performs a REPLACE, deleting the existing row to satisfy `UNIQUE(path)`.
- Because `workspaces.project_id` has `ON DELETE CASCADE`, this deletes all workspaces for that project.
- It also resets `created_at` unintentionally on re-insert.

Fix
- Use a proper UPSERT keyed by `UNIQUE(path)`:

```
INSERT INTO projects (...)
ON CONFLICT(path) DO UPDATE SET
  name = excluded.name,
  git_remote = excluded.git_remote,
  git_branch = excluded.git_branch,
  github_repository = excluded.github_repository,
  github_connected = excluded.github_connected,
  updated_at = CURRENT_TIMESTAMP
```

Semantics
- Insert when the path is new.
- Update in-place when the path already exists (preserves `id` and `created_at`).
- Avoids unintended ON DELETE CASCADE of `workspaces`.

Verification
- Type-check: `npm run type-check` ✅
- Lint: local config issue (ESLint shared config missing); no style changes in this PR.

Manual Test Plan
1. Open a repository as a project (creates project P1 and any workspaces W1…).
2. Re-add the same path with a different `id` (simulate fresh app state opening existing path).
   - Before: workspaces were deleted due to REPLACE.
   - After: project row updates in-place; workspaces remain intact.
3. Confirm `getProjects()` shows updated metadata and the same project `id`.

Notes
- Narrow, surgical change; no behavior changes elsewhere.
- Future improvement (optional): enable SQLite `PRAGMA foreign_keys=ON; PRAGMA journal_mode=WAL;` on open for resilience.
