### PR TITLE
agent/editreadmeproviders 1759823974323

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ Either download the DMG from Releases (or click the link above), or run the app 
 - One or more providers (install as needed):
   - [OpenAI Codex CLI](https://github.com/openai/codex) (install + authenticate)
   - Optional: [Claude Code CLI](https://www.npmjs.com/package/@anthropic-ai/claude-code) (install + authenticate)
+  - Optional: [Droid (Factory CLI)](https://github.com/factory-ai/droid) (install + authenticate)
+  - Optional: [Gemini CLI](https://github.com/google/generative-ai-cli) (install + authenticate)
+  - Optional: [Cursor CLI](https://cursor.sh/) (install + authenticate)
 - Optional: [GitHub CLI](https://docs.github.com/en/github-cli/github-cli/quickstart) for PRs, badges, and repo info
 
 ### Codex CLI
@@ -66,6 +69,40 @@ claude
 # then use /login inside the CLI
 ```
 
+### Droid (Factory CLI) (optional)
+
+Install the Droid CLI and authenticate it:
+
+```bash
+npm install -g @factory-ai/droid
+
+# authenticate
+droid login
+```
+
+### Gemini CLI (optional)
+
+Install the Gemini CLI and authenticate it:
+
+```bash
+npm install -g @google/generative-ai-cli
+
+# authenticate
+gemini auth login
+```
+
+### Cursor CLI (optional)
+
+Install the Cursor CLI and authenticate it:
+
+```bash
+# Install from Cursor website
+# Visit https://cursor.sh/ and download the CLI
+
+# authenticate
+cursor auth login
+```
+
 ### GitHub CLI
 
 Install and authenticate GitHub CLI for GitHub features:
@@ -85,13 +122,13 @@ gh auth login
 ## Getting Started
 
 1. Ensure Node.js 18+ and Git are installed
-2. Install and authenticate at least one provider (Codex or Claude Code)
+2. Install and authenticate at least one provider (Codex, Claude Code, Droid, Gemini, or Cursor CLI)
 3. (Optional) Install and authenticate [GitHub CLI](https://docs.github.com/en/github-cli/github-cli/quickstart)
 4. Clone this repository
 5. Install dependencies: `npm install`
 6. Run the app: `npm run dev`
 
-In the chat input, use the provider selector to switch between Codex and Claude Code. Once a chat has started with Codex or Claude, the provider is locked for that chat.
+In the chat input, use the provider selector to switch between available providers. Once a chat has started with a specific provider, the provider is locked for that chat.
 
 ## Demos
 
@@ -247,7 +284,7 @@ find "$HOME" -type f -name 'emdash.db*' -print
 
 ## What's Next
 
-- [ ] Additional providers (e.g., Gemini CLI, aider, Warp)
+- [ ] Additional providers (e.g., Warp, AMP)
 - [ ] Workspace lifecycle hooks to run custom scripts on create, run, and archive (e.g., install deps, copy env files, clean up resources)
 - [ ] Planning chat with controlled execution (draft actions in a separate chat, then run them one by one)
 - [ ] Linear integration to track and close out issues


### PR DESCRIPTION
- **ci(release): harden mac release (sign+notarize app, staple+validate app,   best‑effort DMG stapling, dry_run support, auto‑publish, strict integrity checks)**
- **ci(release): fix dry_run gating in release-mac; ensure artifacts upload**
- **ci(release): notarize + staple DMGs; end-to-end Gatekeeper check; fix YAML   quoting**
- **fix(build): Vite base='./' for prod; notarize+staple DMGs; end‑to‑end Gatekeeper   check**
- **app: fix PATH for packaged app (gh/codex); prod asset base**
- **deps: add fix-path for PATH normalization**
- **chore: bump version to 0.1.2**
- **chore: bump version to 0.1.3**
- **release: DMG-only notarization; end-to-end DMG check; lockfile update**
- **add download for mac os button**
- **Update README.md**
- **Fix image filename for macOS download link**
- **chore: apply workspace changes**
- **chore: apply workspace changes**
- **Update README.md**
- **delete old screenshot**
- **fix(workspaces): add Create Workspace input validation and duplicate checks**
- **ux(toast): neutralize error toast styling and add warning icon**
- **chore: apply workspace changes**
- **refactor(git): extract GitService and move status/diff IPC out of Codex**
- **Update README.md**
- **feat(ui): show agent/PR status and +/− changes in project workspace list**
- **feat(ui): add shadcn tooltip and show GitHub auth tooltip in sidebar**
- **feat(ui): add shadcn tooltip and extract GithubStatus from LeftSidebar**
- **feat(agent): add generic agent IPC and AgentService (codex bridged)**
- **feat(ui): provider select, lock after chat starts, and tooltip when disabled**
- **feat(factory): add Droid provider with embedded terminal and aligned width**
- **fix(claude): persist provider per conversation and lock correctly;   improve streaming indicator**
- **editBanner**
- **fix: detect GitHub CLI auth via CLI token**
- **add info to banner**
- **feat(chat): persist locked provider per chat (Claude/Codex), avoid restoring Droid; fix provider lock in Droid mode; add   clickable Factory CLI Quickstart and state note**
- **fix(ui): keep frame fixed; make Project view content scrollable**
- **bump version**
- **README:edits**
- **ui(droid): invert terminal colors; remove border**
- **feat(renderer): light-mode Droid terminal and banner cleanup**
- **new .icns / no icon load at runtime**
- **Update README.md**
- **version**
- **refactor(app): extract RequirementsNotice component and remove duplicate inline block**
- **bump version**
- **add discord link to readme**
- **Improve spacing in README.md**
- **Persist Droid terminal sessions and lock provider per chat**
- **Update README.md**
- **chore: gitignore AI assistant instruction files**
- **fix(worktree): use execFile and stable IDs for shell safety**
- **fix(worktree): stable ID from path hash; ensure execFile argv; dynamic default branch via remote HEAD**
- **fix(codex): honor CODEX_SANDBOX_MODE env var for sandbox selection; default to workspace-write**
- **fix(codex): use --dangerously-bypass-approvals-and-sandbox when env opts out; support CODEX_APPROVAL_POLICY as optional override**
- **moved sidebarProvider to App. added sidebarTrigger**
- **added titlebar and moved sidebar toggle there**
- **removed extra header in chatInterface**
- **removed border below fileschangespanel**
- **docs: update node version in README, add npm run d command to unify insstallation and server starting**
- **scaffold right sidebar provider (state only)**
- **add static PanelRight toggle in titlebar**
- **always-mount right sidebar with empty state and workspace content**
- **toggle tooltips**
- **remove phantom scroll**
- **fix(db): preserve project id on upsert and prevent workspace cascade deletes\n\nUse UPSERT on UNIQUE(path) instead of REPLACE to update fields in-place and keep the existing project id. This avoids unintended ON DELETE CASCADE of workspaces when re-adding the same repo path with a new id.\n\n- Preserve created_at (only bump updated_at)\n- Do not modify id/path on conflict\n\nManual test plan:\n1) Open a repo as a project (creates project P1, workspaces W1..).\n2) Re-add the same path with a different id (simulates a fresh app state).\n   Before: workspaces would be deleted due to REPLACE.\n   After: row updates in-place; workspaces remain.\n3) Verify getProjects() still returns the updated metadata and the same id.\n\nType-check: npm run type-check\nLint: known issue in local setup; no code-style changes introduced.**
- **go home = workspace null**
- **perf(chat): debounce @-mention search and memoize side panels\n\n- Debounce file index search in ChatInput to reduce UI work while typing\n- Memoize FileChangesPanel and WorkspaceTerminalPanel to avoid unnecessary renders\n\nThis addresses severe typing lag in large repos by cutting redundant computation and isolating re-renders.\n\nTest plan:\n- Open a large repo (5k+ indexed entries)\n- Type in chat input with and without '@' mentions; typing remains responsive\n- Verify mention dropdown appears after brief pause and navigation works\n- Confirm right panels do not flicker or re-render on every keystroke\n**
- **chore: bump version to 0.1.2**
- **chore: bump version to 0.1.3**
- **release: DMG-only notarization; end-to-end DMG check; lockfile update**
- **add download for mac os button**
- **Update README.md**
- **Fix image filename for macOS download link**
- **chore: apply workspace changes**
- **chore: apply workspace changes**
- **Update README.md**
- **delete old screenshot**
- **fix(workspaces): add Create Workspace input validation and duplicate checks**
- **ux(toast): neutralize error toast styling and add warning icon**
- **chore: apply workspace changes**
- **refactor(git): extract GitService and move status/diff IPC out of Codex**
- **Update README.md**
- **feat(ui): show agent/PR status and +/− changes in project workspace list**
- **feat(ui): add shadcn tooltip and show GitHub auth tooltip in sidebar**
- **feat(ui): add shadcn tooltip and extract GithubStatus from LeftSidebar**
- **feat(agent): add generic agent IPC and AgentService (codex bridged)**
- **feat(ui): provider select, lock after chat starts, and tooltip when disabled**
- **feat(factory): add Droid provider with embedded terminal and aligned width**
- **editBanner**
- **add info to banner**
- **feat(chat): persist locked provider per chat (Claude/Codex), avoid restoring Droid; fix provider lock in Droid mode; add   clickable Factory CLI Quickstart and state note**
- **fix(claude): persist provider per conversation and lock correctly;   improve streaming indicator**
- **fix: detect GitHub CLI auth via CLI token**
- **fix(ui): keep frame fixed; make Project view content scrollable**
- **bump version**
- **README:edits**
- **ui(droid): invert terminal colors; remove border**
- **feat(renderer): light-mode Droid terminal and banner cleanup**
- **Update README.md**
- **version**
- **new .icns / no icon load at runtime**
- **refactor(app): extract RequirementsNotice component and remove duplicate inline block**
- **bump version**
- **add discord link to readme**
- **Improve spacing in README.md**
- **Persist Droid terminal sessions and lock provider per chat**
- **Update README.md**
- **chore: gitignore AI assistant instruction files**
- **fix(codex): honor CODEX_SANDBOX_MODE env var for sandbox selection; default to workspace-write**
- **fix(codex): use --dangerously-bypass-approvals-and-sandbox when env opts out; support CODEX_APPROVAL_POLICY as optional override**
- **fix(worktree): use execFile and stable IDs for shell safety**
- **fix(worktree): stable ID from path hash; ensure execFile argv; dynamic default branch via remote HEAD**
- **docs: update node version in README, add npm run d command to unify insstallation and server starting**
- **moved sidebarProvider to App. added sidebarTrigger**
- **added titlebar and moved sidebar toggle there**
- **removed extra header in chatInterface**
- **removed border below fileschangespanel**
- **refactor: format file, remove unused code**
- **feat: add chevron for agent/provider selector**
- **fix: made agent chevron match worktree chevron**
- **Delete src/renderer/components/titlebar/SidebarToggleButton.tsx**
- ** prettier config and format**
- **feat(gemini): add Gemini CLI provider and   terminal**
- **prettier**
- **add vitest**
- **added gh service test**
- **fix test error**
- **added resizeable**
- **add persistence helper**
- **build(tsconfig): exclude .test/.spec from   Electron main build**
- **resizeable left sidebar**
- **sidebar width and max width**
- **fix merge conflict gh test**
- **fix: change chevron direction**
- **refactor: move provider selection into component**
- **refactor: clean up provider typing**
- **Update README.md**
- **add cursor cli**
- **add cursorlogo to select element**
- **feat(cursor): add Cursor CLI provider with   embedded terminal**
- **fix(diff-modal): portal modal to body with opaque overlay to block   sidebar bleed-through**
- **move workspace notice**
- **refactor(ui): extract TerminalModeBanner +   WorkspaceNotice and centralize provider meta**
- **refactor(provider-select): use ProviderSelector   in ChatInput; add Cursor; remove inline Select and unused imports**
- **bump version**
- **Update README.md**
- **Update README.md**
- **fix(terminal): hide xterm viewport scrollbar to   remove gray bar**
- **feat: inital prompt is saved in db after workspace creation**
- **feat: the prompt form the workspace creation is now send to codex**
- **feat: improve inital prompt placeholder**
- **feat: provider selector works, workspace a created with the correct provider selected**
- **feat: improve UI of WorkspaceModal**
- **fix: only show inital prompt for codex and claude as the other providers are CLIs (Terminals)**
- **fix sidebar bleed through**
- **recenter main**
- **right default collapsed**
- **right side resizeable**
- **right sidebar width**
- **pill not cut off**
- **align left/right widths**
- **deleted merge markers**
- **fixed flicker / simplified rightsidebar rendering**
- **delete legacy RightPanel**
- **chore: apply workspace changes**
