### PR TITLE
macOS: fix startup segfault (sqlite3/node‑pty)

### DIFF
--- a/package.json
+++ b/package.json
@@ -111,6 +111,11 @@
       "dist/**/*",
       "node_modules/**/*"
     ],
+    "asarUnpack": [
+      "node_modules/sqlite3/**",
+      "node_modules/node-pty/**",
+      "node_modules/keytar/**"
+    ],
     "mac": {
       "category": "public.app-category.developer-tools",
       "target": [


### PR DESCRIPTION
- Fix: defer sqlite3 and node‑pty; add EMDASH_DISABLE_NATIVE_DB; avoid top‑level native loads
- Build: explicit asarUnpack for sqlite3/node‑pty/keytar so natives ship outside asar