### PR TITLE
fix: SIGSEGV crashes from native module ABI mismatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,12 +59,6 @@ jobs:
           npm_config_python: ${{ env.python }}
         run: npm ci || npm install
 
-      - name: Rebuild native modules for Electron
-        run: |
-          echo "Rebuilding native modules (node-pty, sqlite3, keytar) for Electron..."
-          npx electron-rebuild -f -w node-pty -w sqlite3 -w keytar
-          echo "Native module rebuild complete"
-
       - name: Build app (ts + vite)
         run: npm run build
 
@@ -144,12 +138,6 @@ jobs:
         env:
           npm_config_python: ${{ env.python }}
         run: npm ci || npm install
-
-      - name: Rebuild native modules for Electron
-        run: |
-          echo "Rebuilding native modules (node-pty, sqlite3, keytar) for Electron..."
-          npx electron-rebuild -f -w node-pty -w sqlite3 -w keytar
-          echo "Native module rebuild complete"
 
       - name: Build app (ts + vite)
         run: npm run build
@@ -245,12 +233,6 @@ jobs:
         with:
           p12-file-base64: ${{ secrets.CERTIFICATE_P12 }}
           p12-password: ${{ secrets.CERTIFICATE_PASSWORD }}
-
-      - name: Rebuild native modules for Electron
-        run: |
-          echo "Rebuilding native modules (node-pty, sqlite3, keytar) for Electron..."
-          npx electron-rebuild -f -w node-pty -w sqlite3 -w keytar
-          echo "Native module rebuild complete"
 
       - name: Build app (ts + vite)
         run: npm run build

--- a/README.md
+++ b/README.md
@@ -204,16 +204,12 @@ In the chat input, use the provider selector to switch between Codex and Claude 
 ### macOS
 
 ```bash
-# Rebuild native modules for Electron (prevents SIGSEGV)
-npm run rebuild
-
-# Build the DMG
 npm run package:mac
 ```
 
 Outputs: `release/emdash-arm64.dmg` and `release/emdash-arm64.zip`
 
-**Note:** Always run `npm run rebuild` before packaging to ensure native modules (node-pty, sqlite3, keytar) are compiled for Electron's Node.js version.
+**Note:** Native modules (node-pty, sqlite3, keytar) are automatically rebuilt for Electron during `npm install` via the postinstall hook.
 
 ### Linux
 

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "package:mac": "npm run build && electron-builder --mac",
     "package:linux": "npm run build && electron-builder --linux --publish never",
     "package:win": "npm run build && electron-builder --win --publish never",
-    "postinstall": "electron-builder install-app-deps",
+    "postinstall": "electron-rebuild",
     "rebuild": "npx electron-rebuild",
     "clean": "rm -rf node_modules dist",
     "reset": "npm run clean && npm install",


### PR DESCRIPTION
## Fix SIGSEGV crashes from native module ABI mismatch

### Problem
The app was experiencing segmentation faults (SIGSEGV) on startup in both production CI builds and local builds. The crash occurred when loading native modules (`node-pty`, `sqlite3`, `keytar`).

### Root Cause
Native modules contain C++ code that must be compiled against the specific Node.js version used by Electron. When you run `npm install`, these modules are compiled for your **system's Node.js** (v22), but Electron 28 uses its own embedded **Node.js ~v18**. This ABI (Application Binary Interface) mismatch causes immediate crashes when the modules are loaded.

The previous `postinstall` hook (`electron-builder install-app-deps`) was unreliable:
- It's designed to run during packaging, not during install
- It uses heuristics that can fail silently
- It doesn't guarantee modules are rebuilt for Electron's Node version

### Solution
Changed the `postinstall` hook to use `electron-rebuild` directly:
```diff
- "postinstall": "electron-builder install-app-deps"
+ "postinstall": "electron-rebuild"
```

This ensures native modules are automatically rebuilt for Electron's Node.js version **every time** `npm install` runs, both in CI and locally.

### Changes
- **package.json**: Fixed postinstall hook to use `electron-rebuild`
- **.github/workflows/release.yml**: Removed redundant explicit rebuild steps (now automatic)
- **README.md**: Simplified build instructions (no manual rebuild needed)

### Testing
After this change, native modules will be correctly compiled during `npm install`. Verify by:
1. Run `npm install`
2. Build the app: `npm run package:mac` (or platform-specific)
3. Launch the app - should start without SIGSEGV

The next release build should work correctly without crashes.…p startup