### PR TITLE
Add toast element when feedback has been sent successfully

### DIFF
--- a/src/renderer/components/FeedbackModal.tsx
+++ b/src/renderer/components/FeedbackModal.tsx
@@ -130,12 +130,10 @@ const FeedbackModal: React.FC<FeedbackModalProps> = ({ isOpen, onClose, githubUs
       setContactEmail('');
       setAttachments([]);
       onClose();
-      // Toast: success
       toast({ title: 'Feedback sent', description: 'Thanks for your feedback!' });
     } catch (error) {
       console.error('Failed to submit feedback:', error);
       setErrorMessage('Unable to send feedback. Please try again.');
-      // Toast: error
       toast({
         title: 'Failed to send feedback',
         description: 'Please try again.',


### PR DESCRIPTION
Adds a bottom‑right toast after feedback is submitted successfully (and an error toast on failure) in FeedbackModal.