### PR TITLE
fix(windows): resolve Codex CLI PTY spawn issues on Windows

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -31,6 +31,30 @@ if (process.platform === 'darwin') {
     }
   } catch {}
 }
+
+if (process.platform === 'win32') {
+  // Ensure npm global binaries are in PATH for Windows
+  const npmPath = require('path').join(process.env.APPDATA || '', 'npm');
+  const cur = process.env.PATH || '';
+  const parts = cur.split(';').filter(Boolean);
+  console.log('[PATH DEBUG] npmPath:', npmPath);
+  console.log('[PATH DEBUG] Already in PATH?', parts.includes(npmPath));
+  if (npmPath && !parts.includes(npmPath)) {
+    parts.unshift(npmPath);
+    process.env.PATH = parts.join(';');
+    console.log('[PATH DEBUG] Added npm path to PATH');
+  }
+  console.log('[PATH DEBUG] Final PATH includes npm?', process.env.PATH?.includes(npmPath));
+
+  // Test if codex is accessible
+  try {
+    const { execSync } = require('child_process');
+    const codexPath = execSync('where codex', { encoding: 'utf8' }).trim();
+    console.log('[PATH DEBUG] Codex found at:', codexPath);
+  } catch (e: any) {
+    console.error('[PATH DEBUG] Codex not found:', e.message);
+  }
+}
 import { createMainWindow } from './app/window';
 import { registerAppLifecycle } from './app/lifecycle';
 import { registerAllIpc } from './ipc';


### PR DESCRIPTION
## Summary
Fixes the "File not found" and "Cannot create process" errors when spawning Codex CLI in PTY processes on Windows.


## Changes

### 1. PATH Configuration (main.ts)
- Add npm global binaries directory to Electron's PATH on Windows
- Ensures `%APPDATA%\npm` is included for CLI tools like codex
- Mirrors the existing macOS PATH handling approach
- Includes debug logging for troubleshooting

### 2. Shell Command Resolution (ptyManager.ts)
- Resolve shell commands to full paths before spawning PTY on Windows
- Prioritize `.cmd` extension (npm globals are .cmd files)
- Strip carriage returns from Windows command output
- Validate executable extensions (`.exe`, `.cmd`, `.bat`)
- Fallback to `.cmd` appending if needed

## Root Cause
The issue occurred because:
- Electron's PATH didn't include npm global binaries on Windows
- node-pty requires full paths or proper extensions on Windows
- The `where` command returns paths with `\r\n` line endings
- npm global commands like `codex` are actually `codex.cmd`

## Errors Fixed
- ✅ `"File not found:"` (missing PATH)
- ✅ `"File not found: path\r"` (carriage return issue)  
- ✅ `"Cannot create process, error code: 193"` (wrong file extension)

## Testing
Tested on Windows 11 with:
- Node.js 22.21.0
- Electron 30.5.1
- Codex CLI 0.47.0

After applying these fixes, Codex CLI PTY processes spawn successfully on Windows.

## Misc

Vibed with claude but i tested it myself on my machine and it appears to work properly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
