### PR TITLE
Fix workspace deletion with uncommitted changes and ENOTEMPTY errors

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -91,6 +91,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     branch?: string;
   }) => ipcRenderer.invoke('worktree:remove', args),
   worktreeStatus: (args: { worktreePath: string }) => ipcRenderer.invoke('worktree:status', args),
+  worktreeHasUncommittedChanges: (args: { worktreePath: string; branch?: string }) =>
+    ipcRenderer.invoke('worktree:hasUncommittedChanges', args),
   worktreeMerge: (args: { projectPath: string; worktreeId: string }) =>
     ipcRenderer.invoke('worktree:merge', args),
   worktreeGet: (args: { worktreeId: string }) => ipcRenderer.invoke('worktree:get', args),

--- a/src/main/services/worktreeIpc.ts
+++ b/src/main/services/worktreeIpc.ts
@@ -76,6 +76,20 @@ export function registerWorktreeIpc(): void {
     }
   });
 
+  // Check if worktree has uncommitted changes
+  ipcMain.handle(
+    'worktree:hasUncommittedChanges',
+    async (event, args: { worktreePath: string; branch?: string }) => {
+      try {
+        const result = await worktreeService.hasUncommittedChanges(args.worktreePath, args.branch);
+        return { success: true, result };
+      } catch (error) {
+        console.error('Failed to check uncommitted changes:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
   // Merge worktree changes
   ipcMain.handle(
     'worktree:merge',

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -126,6 +126,8 @@ function WorkspaceRow({
 
         <WorkspaceDeleteButton
           workspaceName={ws.name}
+          workspacePath={ws.path}
+          workspaceBranch={ws.branch}
           onConfirm={async () => {
             try {
               setIsDeleting(true);

--- a/src/renderer/components/WorkspaceDeleteButton.tsx
+++ b/src/renderer/components/WorkspaceDeleteButton.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { Trash } from 'lucide-react';
+import React, { useState } from 'react';
+import { Trash, AlertTriangle } from 'lucide-react';
 import { Spinner } from './ui/spinner';
 import {
   AlertDialog,
@@ -16,6 +16,8 @@ import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/t
 
 type Props = {
   workspaceName: string;
+  workspacePath?: string;
+  workspaceBranch?: string;
   onConfirm: () => void | Promise<void>;
   className?: string;
   'aria-label'?: string;
@@ -24,36 +26,76 @@ type Props = {
 
 export const WorkspaceDeleteButton: React.FC<Props> = ({
   workspaceName,
+  workspacePath,
+  workspaceBranch,
   onConfirm,
   className,
   'aria-label': ariaLabel = 'Delete workspace',
   isDeleting = false,
 }) => {
+  const [isCheckingStatus, setIsCheckingStatus] = useState(false);
+  const [hasUncommittedChanges, setHasUncommittedChanges] = useState(false);
+  const [hasUnpushedCommits, setHasUnpushedCommits] = useState(false);
+  const [showDialog, setShowDialog] = useState(false);
+
+  const handleDeleteClick = async () => {
+    if (workspacePath) {
+      setIsCheckingStatus(true);
+      try {
+        const result = await window.electronAPI.worktreeHasUncommittedChanges({
+          worktreePath: workspacePath,
+          branch: workspaceBranch,
+        });
+        if (result.success && result.result) {
+          setHasUncommittedChanges(result.result.hasChanges);
+          setHasUnpushedCommits(result.result.hasUnpushedCommits);
+        }
+      } catch (error) {
+        console.error('Failed to check workspace status:', error);
+      } finally {
+        setIsCheckingStatus(false);
+      }
+    }
+    setShowDialog(true);
+  };
+
+  const getWarningMessage = () => {
+    if (hasUncommittedChanges && hasUnpushedCommits) {
+      return `This workspace has uncommitted changes and unpushed commits. Deleting "${workspaceName}" will permanently lose all changes.`;
+    } else if (hasUncommittedChanges) {
+      return `This workspace has uncommitted changes. Deleting "${workspaceName}" will permanently lose these changes.`;
+    } else if (hasUnpushedCommits) {
+      return `This workspace has unpushed commits. Deleting "${workspaceName}" will remove the worktree and delete its branch.`;
+    }
+    return `This will remove the worktree for "${workspaceName}" and delete its branch.`;
+  };
+
   return (
-    <AlertDialog>
+    <AlertDialog open={showDialog} onOpenChange={setShowDialog}>
       <TooltipProvider delayDuration={200}>
         <Tooltip>
           <TooltipTrigger asChild>
-            <AlertDialogTrigger asChild>
-              <button
-                type="button"
-                className={
-                  className ||
-                  'inline-flex items-center justify-center rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-red-600 dark:hover:bg-gray-800'
-                }
-                title="Delete workspace"
-                aria-label={ariaLabel}
-                aria-busy={isDeleting}
-                disabled={isDeleting}
-                onClick={(e) => e.stopPropagation()}
-              >
-                {isDeleting ? (
-                  <Spinner className="h-3.5 w-3.5" size="sm" />
-                ) : (
-                  <Trash className="h-3.5 w-3.5" />
-                )}
-              </button>
-            </AlertDialogTrigger>
+            <button
+              type="button"
+              className={
+                className ||
+                'inline-flex items-center justify-center rounded p-1 text-gray-500 hover:bg-gray-100 hover:text-red-600 dark:hover:bg-gray-800'
+              }
+              title="Delete workspace"
+              aria-label={ariaLabel}
+              aria-busy={isDeleting || isCheckingStatus}
+              disabled={isDeleting || isCheckingStatus}
+              onClick={(e) => {
+                e.stopPropagation();
+                handleDeleteClick();
+              }}
+            >
+              {isDeleting || isCheckingStatus ? (
+                <Spinner className="h-3.5 w-3.5" size="sm" />
+              ) : (
+                <Trash className="h-3.5 w-3.5" />
+              )}
+            </button>
           </TooltipTrigger>
           <TooltipContent side="top" className="text-xs">
             Delete workspace
@@ -62,9 +104,14 @@ export const WorkspaceDeleteButton: React.FC<Props> = ({
       </TooltipProvider>
       <AlertDialogContent onClick={(e) => e.stopPropagation()} className="space-y-4">
         <AlertDialogHeader>
-          <AlertDialogTitle>Delete workspace?</AlertDialogTitle>
+          <AlertDialogTitle className="flex items-center gap-2">
+            {(hasUncommittedChanges || hasUnpushedCommits) && (
+              <AlertTriangle className="h-5 w-5 text-orange-500" />
+            )}
+            Delete workspace?
+          </AlertDialogTitle>
           <AlertDialogDescription>
-            {`This will remove the worktree for "${workspaceName}" and delete its branch.`}
+            {getWarningMessage()}
           </AlertDialogDescription>
         </AlertDialogHeader>
         <AlertDialogFooter>
@@ -75,6 +122,7 @@ export const WorkspaceDeleteButton: React.FC<Props> = ({
               e.stopPropagation();
               try {
                 await onConfirm();
+                setShowDialog(false);
               } catch {}
             }}
           >

--- a/src/renderer/components/WorkspaceItem.tsx
+++ b/src/renderer/components/WorkspaceItem.tsx
@@ -58,6 +58,8 @@ export const WorkspaceItem: React.FC<WorkspaceItemProps> = ({ workspace, onDelet
         {showDelete && onDelete ? (
           <WorkspaceDeleteButton
             workspaceName={workspace.name}
+            workspacePath={workspace.path}
+            workspaceBranch={workspace.branch}
             onConfirm={async () => {
               try {
                 setIsDeleting(true);

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -71,6 +71,10 @@ declare global {
       worktreeStatus: (args: {
         worktreePath: string;
       }) => Promise<{ success: boolean; status?: any; error?: string }>;
+      worktreeHasUncommittedChanges: (args: {
+        worktreePath: string;
+        branch?: string;
+      }) => Promise<{ success: boolean; result?: any; error?: string }>;
       worktreeMerge: (args: {
         projectPath: string;
         worktreeId: string;
@@ -481,6 +485,10 @@ export interface ElectronAPI {
   worktreeStatus: (args: {
     worktreePath: string;
   }) => Promise<{ success: boolean; status?: any; error?: string }>;
+  worktreeHasUncommittedChanges: (args: {
+    worktreePath: string;
+    branch?: string;
+  }) => Promise<{ success: boolean; result?: any; error?: string }>;
   worktreeMerge: (args: {
     projectPath: string;
     worktreeId: string;

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -39,6 +39,10 @@ declare global {
       worktreeStatus: (args: {
         worktreePath: string;
       }) => Promise<{ success: boolean; status?: any; error?: string }>;
+      worktreeHasUncommittedChanges: (args: {
+        worktreePath: string;
+        branch?: string;
+      }) => Promise<{ success: boolean; result?: any; error?: string }>;
       worktreeMerge: (args: {
         projectPath: string;
         worktreeId: string;


### PR DESCRIPTION
## Summary
- **Fixed ENOTEMPTY errors** when deleting workspaces by implementing robust retry logic and fallback removal strategies
- **Added uncommitted changes detection** to warn users before they lose work
- **Enhanced delete confirmation UI** with specific warnings about what will be lost
- **Improved error handling** to ensure workspace deletion works reliably even with file locks

## Details
This fix addresses the issue where workspace deletion would fail with "ENOTEMPTY: directory not empty" errors, particularly when workspaces contained node_modules or other locked files. The solution includes:

1. **Robust file removal**: Multiple retry attempts with delays and fallback strategies
2. **User warnings**: Clear notifications about uncommitted changes and unpushed commits
3. **Better UX**: Warning icons and descriptive messages in delete confirmation dialogs

## Testing
- Workspace deletion now works even with uncommitted changes (after user confirmation)
- File system errors are handled gracefully with retry logic
- Users are properly warned about data loss before deletion proceeds