### PR TITLE
Fix packaged app startup: runtime path aliases + renderer path

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "tsconfig-paths": "^3.15.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",
     "@radix-ui/react-collapsible": "^1.1.12",

--- a/src/main/app/window.ts
+++ b/src/main/app/window.ts
@@ -26,7 +26,8 @@ export function createMainWindow(): BrowserWindow {
     mainWindow.loadURL('http://localhost:3000');
   } else {
     // renderer build outputs to dist/renderer
-    mainWindow.loadFile(join(__dirname, '..', '..', 'renderer', 'index.html'));
+    // __dirname resolves to dist/main/main/app at runtime; go up to dist and into renderer
+    mainWindow.loadFile(join(__dirname, '..', '..', '..', 'renderer', 'index.html'));
   }
 
   // Route external links to the user’s default browser

--- a/src/renderer/hooks/usePlanMode.ts
+++ b/src/renderer/hooks/usePlanMode.ts
@@ -40,13 +40,17 @@ export function usePlanMode(workspaceId: string, workspacePath: string) {
       let wroteRootHelper = false;
       try {
         const gitRef = await (window as any).electronAPI.fsRead(workspacePath, '.git', 1024);
-        const isWorktree = !!(gitRef?.success && typeof gitRef.content === 'string' && /^gitdir:\s*/i.test(gitRef.content.trim()));
+        const isWorktree = !!(
+          gitRef?.success &&
+          typeof gitRef.content === 'string' &&
+          /^gitdir:\s*/i.test(gitRef.content.trim())
+        );
         if (!isWorktree) {
           const rootRel = 'PLANNING.md';
           let exists = false;
           try {
             const readTry = await (window as any).electronAPI.fsRead?.(workspacePath, rootRel, 1);
-            exists = !!(readTry?.success);
+            exists = !!readTry?.success;
           } catch {}
           if (!exists) {
             log.info('[plan] writing policy (root helper)', { workspacePath, rootRel });
@@ -128,7 +132,10 @@ export function usePlanMode(workspaceId: string, workspacePath: string) {
       try {
         const metaRel = '.emdash/planning.meta.json';
         const metaRead = await (window as any).electronAPI.fsRead?.(workspacePath, metaRel, 4096);
-        const meta = metaRead?.success && typeof metaRead.content === 'string' ? JSON.parse(metaRead.content) : {};
+        const meta =
+          metaRead?.success && typeof metaRead.content === 'string'
+            ? JSON.parse(metaRead.content)
+            : {};
         if (meta?.wroteRootHelper) {
           const rootRel = 'PLANNING.md';
           await (window as any).electronAPI.fsRemove(workspacePath, rootRel);


### PR DESCRIPTION
 - Summary: Fix startup failures in packaged app caused by missing runtime
  alias resolution and an incorrect renderer file path.
  - Root cause: TypeScript paths aren’t applied at runtime; __dirname depth
  mismatch led to loading dist/main/renderer instead of dist/renderer.
  - Changes:
      - Add tsconfig-paths to dependencies and register in entry.ts.
      - Update BrowserWindow.loadFile to use ../../../renderer/index.html.
  - Verification:
      - npm ci && npm run package
      - Launch: ELECTRON_ENABLE_LOGGING=1 … emdash --debug-logs
      - Renderer loads, DevTools opens; no alias or file-not-found errors.
  - Risk: Low; affects only packaged startup paths and alias resolution.

