### PR TITLE
(ui): small changes

### DIFF
--- a/src/renderer/components/ContainerStatusBadge.tsx
+++ b/src/renderer/components/ContainerStatusBadge.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Loader2 } from 'lucide-react';
+import { Loader2, Square } from 'lucide-react';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import dockerLogo from '../../assets/images/docker.png';
 
@@ -133,10 +133,7 @@ export const ContainerStatusBadge: React.FC<Props> = ({
                   {stoppingAction ? (
                     <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
                   ) : (
-                    <span
-                      className="inline-block h-3.5 w-3.5 rounded-[2px] bg-muted-foreground"
-                      aria-hidden="true"
-                    />
+                    <Square className="h-3.5 w-3.5" aria-hidden="true" />
                   )}
                 </button>
               </TooltipTrigger>

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -253,6 +253,10 @@ function WorkspaceRow({
         </div>
 
         <div className="flex shrink-0 items-center gap-2">
+          {!isLoading && (totalAdditions > 0 || totalDeletions > 0) ? (
+            <ChangesBadge additions={totalAdditions} deletions={totalDeletions} />
+          ) : null}
+
           {hasComposeFile ? (
             <TooltipProvider delayDuration={200}>
               <Tooltip>
@@ -304,9 +308,7 @@ function WorkspaceRow({
               Ports
             </button>
           ) : null}
-          {!isLoading && (totalAdditions > 0 || totalDeletions > 0) ? (
-            <ChangesBadge additions={totalAdditions} deletions={totalDeletions} />
-          ) : pr ? (
+          {!isLoading && totalAdditions === 0 && totalDeletions === 0 && pr ? (
             <span
               className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
               title={`${pr.title || 'Pull Request'} (#${pr.number})`}


### PR DESCRIPTION
edit square icons for stopping docker containers - consistency

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces the stop control with a `lucide-react` Square icon and adjusts workspace badges to show changes first and PR status only when there are no local changes.
> 
> - **UI/Containers**:
>   - Replace custom styled square with `lucide-react` `Square` icon for the stop button in `ContainerStatusBadge.tsx`.
> - **UI/Workspaces** (`ProjectMainView.tsx`):
>   - Show `ChangesBadge` (additions/deletions) earlier in the toolbar when present.
>   - Display PR status badge only when `totalAdditions` and `totalDeletions` are zero and `pr` exists.
>   - Minor layout/visibility tweaks around the Ports button and badges.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2ecccb67f3bba6a24ada7097d8badbb4811055ea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->