### PR TITLE
fix(preview): use shared isReachable + reset actionBusy on install/start

### DIFF
--- a/src/renderer/components/BrowserPane.tsx
+++ b/src/renderer/components/BrowserPane.tsx
@@ -120,6 +120,11 @@ const BrowserPane: React.FC<{
           // so we keep the spinner until a URL is reachable.
           if (data.status === 'error') {
             hideSpinner();
+            setActionBusy(null);
+          }
+          if (data.status === 'done') {
+            // Install finished successfully: re-enable action buttons, but keep spinner until URL is reachable
+            setActionBusy(null);
           }
         }
         if (data.type === 'url' && data.url) {
@@ -202,6 +207,8 @@ const BrowserPane: React.FC<{
     showSpinner();
     try {
       await (window as any).electronAPI?.hostPreviewSetup?.({ workspaceId: id, workspacePath: wp });
+      // Success: unlock actions; spinner remains until URL reachable or user retries
+      setActionBusy(null);
     } catch {
       setActionBusy(null);
       hideSpinner();
@@ -216,6 +223,8 @@ const BrowserPane: React.FC<{
     showSpinner();
     try {
       await (window as any).electronAPI?.hostPreviewStart?.({ workspaceId: id, workspacePath: wp });
+      // Success: unlock actions; spinner remains until URL reachable or user retries
+      setActionBusy(null);
     } catch {
       setActionBusy(null);
       hideSpinner();

--- a/src/renderer/components/titlebar/BrowserToggleButton.tsx
+++ b/src/renderer/components/titlebar/BrowserToggleButton.tsx
@@ -84,20 +84,6 @@ const BrowserToggleButton: React.FC<Props> = ({
     };
   }, [browser, workspaceId]);
 
-  const isReachable = async (u?: string | null, timeoutMs = 900): Promise<boolean> => {
-    const url = (u || '').trim();
-    if (!url) return false;
-    try {
-      const c = new AbortController();
-      const t = setTimeout(() => c.abort(), timeoutMs);
-      await fetch(url, { method: 'GET', mode: 'no-cors', signal: c.signal });
-      clearTimeout(t);
-      return true;
-    } catch {
-      return false;
-    }
-  };
-
   const handleClick = React.useCallback(async () => {
     const id = (workspaceId || '').trim();
     const wp = (workspacePath || '').trim();


### PR DESCRIPTION
- Remove shadowed isReachable in BrowserToggleButton; use previewNetwork constant
- Reset actionBusy on successful install/start and on setup:done/error
- Spinner behavior unchanged: hides when URL reachable or timed out
- Type‑check passes; no behavioral regressions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Resets action button busy state after install/start completion and setup events, and removes the shadowed isReachable in favor of the shared previewNetwork utility.
> 
> - **Renderer**:
>   - `src/renderer/components/BrowserPane.tsx`
>     - Clear `actionBusy` on `setup:error` and `setup:done` events.
>     - Clear `actionBusy` after successful `hostPreviewSetup` and `hostPreviewStart` calls; spinner behavior unchanged.
> - **Titlebar**:
>   - `src/renderer/components/titlebar/BrowserToggleButton.tsx`
>     - Remove local `isReachable` helper; use shared `previewNetwork.isReachable`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f2671b8a53c5fb86b16687c3d2df80e60116f514. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->