### PR TITLE
fix(ci): use npm install on Linux to resolve rollup native deps

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,14 +54,10 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           echo "python=$(which python3)" >> $GITHUB_ENV
 
-      - name: Install dependencies (allow platform optional deps)
+      - name: Install dependencies (strict lockfile)
         env:
           npm_config_python: ${{ env.python }}
-        run: |
-          # npm ci honors the mac-generated lockfile and may omit linux optional deps (e.g., rollup native)
-          # Use a fresh install on Linux to resolve platform-specific optionalDependencies correctly.
-          rm -f package-lock.json
-          npm install
+        run: npm ci
 
       - name: Build app (ts + vite)
         run: npm run build
@@ -265,10 +261,10 @@ jobs:
           python -m pip install --upgrade pip setuptools wheel
           echo "python=$(which python3)" >> $GITHUB_ENV
 
-      - name: Install dependencies
+      - name: Install dependencies (strict lockfile)
         env:
           npm_config_python: ${{ env.python }}
-        run: npm ci || npm install
+        run: npm ci
 
       - name: Import Apple signing certificate
         uses: apple-actions/import-codesign-certs@v2


### PR DESCRIPTION
- npm ci with a mac‑generated lockfile omitted Linux rollup optional deps,
    causing vite build to fail
- Remove lockfile and run npm install on Linux so platform
    optionalDependencies are installed
- No changes to mac release flow

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Linux removes lockfile and uses npm install to include platform optional deps; macOS enforces strict lockfile via npm ci.
> 
> - **CI/Release workflow (`.github/workflows/release.yml`)**:
>   - **Linux (`release-linux`)**:
>     - Install deps by removing `package-lock.json` then running `npm install` to include Linux-only `optionalDependencies` (e.g., rollup native).
>   - **macOS (`build-mac`, `release-mac`)**:
>     - Enforce strict lockfile with `npm ci` (remove fallback to `npm install`).
>     - Rename install steps to reflect strict/allow-optional behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e133fd9415efcb6f631c4e1c0b3b62a472936ba2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->