### PR TITLE
make gh auth command legible in dark mode

### DIFF
--- a/src/renderer/components/GithubStatus.tsx
+++ b/src/renderer/components/GithubStatus.tsx
@@ -52,8 +52,11 @@ export function GithubStatus({
               <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0" />
               <div>
                 <p className="font-medium">GitHub not authenticated</p>
-                <p className="text-[11px] text-gray-700/80 dark:text-gray-200/80">
-                  Run <code className="rounded bg-gray-100 px-1">gh auth login</code>
+                <p className="text-[11px] text-gray-800 dark:text-gray-100">
+                  Run{' '}
+                  <code className="rounded border border-gray-200 bg-gray-100 px-1 py-0.5 text-gray-900 dark:border-white/20 dark:bg-white/10 dark:text-white">
+                    gh auth login
+                  </code>
                 </p>
               </div>
             </div>


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Refines dark-mode styling of the unauthenticated GitHub status, making the `gh auth login` code snippet and text readable.
> 
> - **UI (renderer)**:
>   - `src/renderer/components/GithubStatus.tsx`
>     - Adjust unauthenticated state styles for dark mode:
>       - Update text colors.
>       - Restyle `gh auth login` code snippet with border, background, padding, and dark-mode colors for better readability.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e329a380a075f5bae374af00537cc251ab1ac09b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->