### PR TITLE
feat(notifications): add system notifications for agent task completion

### DIFF
--- a/.github/workflows/code-consistency-check.yml
+++ b/.github/workflows/code-consistency-check.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: '24'
+          node-version: '22'
           cache: 'npm'
 
       - name: Install dependencies

--- a/src/main/ipc/settingsIpc.ts
+++ b/src/main/ipc/settingsIpc.ts
@@ -11,21 +11,12 @@ export function registerSettingsIpc() {
     }
   });
 
-  ipcMain.handle(
-    'settings:update',
-    async (
-      _event,
-      partial: Partial<{
-        repository: { branchTemplate?: string; pushOnCreate?: boolean };
-        projectPrep: { autoInstallOnOpenInEditor?: boolean };
-      }>
-    ) => {
-      try {
-        const settings = updateAppSettings((partial as Partial<AppSettings>) || {});
-        return { success: true, settings };
-      } catch (error) {
-        return { success: false, error: (error as Error).message };
-      }
+  ipcMain.handle('settings:update', async (_, partial: Partial<AppSettings>) => {
+    try {
+      const settings = updateAppSettings(partial || {});
+      return { success: true, settings };
+    } catch (error) {
+      return { success: false, error: (error as Error).message };
     }
-  );
+  });
 }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -16,6 +16,10 @@ export interface AppSettings {
     enabled: boolean;
     engine: 'chromium';
   };
+  notifications?: {
+    enabled: boolean;
+    sound: boolean;
+  };
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -29,6 +33,10 @@ const DEFAULT_SETTINGS: AppSettings = {
   browserPreview: {
     enabled: true,
     engine: 'chromium',
+  },
+  notifications: {
+    enabled: true,
+    sound: true,
   },
 };
 
@@ -111,6 +119,10 @@ function normalizeSettings(input: AppSettings): AppSettings {
       enabled: DEFAULT_SETTINGS.browserPreview!.enabled,
       engine: DEFAULT_SETTINGS.browserPreview!.engine,
     },
+    notifications: {
+      enabled: DEFAULT_SETTINGS.notifications!.enabled,
+      sound: DEFAULT_SETTINGS.notifications!.sound,
+    },
   };
 
   // Repository
@@ -134,6 +146,12 @@ function normalizeSettings(input: AppSettings): AppSettings {
   out.browserPreview = {
     enabled: Boolean(bp?.enabled ?? DEFAULT_SETTINGS.browserPreview!.enabled),
     engine: 'chromium',
+  };
+
+  const notif = (input as any)?.notifications || {};
+  out.notifications = {
+    enabled: Boolean(notif?.enabled ?? DEFAULT_SETTINGS.notifications!.enabled),
+    sound: Boolean(notif?.sound ?? DEFAULT_SETTINGS.notifications!.sound),
   };
   return out;
 }

--- a/src/renderer/components/NotificationSettingsCard.tsx
+++ b/src/renderer/components/NotificationSettingsCard.tsx
@@ -1,0 +1,67 @@
+import React, { useEffect, useState } from 'react';
+import { Switch } from './ui/switch';
+
+const NotificationSettingsCard: React.FC = () => {
+  const [enabled, setEnabled] = useState(true);
+  const [sound, setSound] = useState(true);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const result = await window.electronAPI.getSettings();
+        if (result.success && result.settings) {
+          const en = Boolean(result.settings.notifications?.enabled ?? true);
+          const snd = Boolean(result.settings.notifications?.sound ?? true);
+          setEnabled(en);
+          setSound(snd);
+        }
+      } catch (error) {
+        console.error('Failed to load notification settings:', error);
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  const updateEnabled = async (next: boolean) => {
+    setEnabled(next);
+    try {
+      await window.electronAPI.updateSettings({
+        notifications: { enabled: next, sound },
+      });
+    } catch (error) {
+      console.error('Failed to update notification enabled setting:', error);
+    }
+  };
+
+  const updateSound = async (next: boolean) => {
+    setSound(next);
+    try {
+      await window.electronAPI.updateSettings({
+        notifications: { enabled, sound: next },
+      });
+    } catch (error) {
+      console.error('Failed to update notification sound setting:', error);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-muted/10 p-4">
+      <div className="mb-4 text-sm text-muted-foreground">
+        Get notified when agents complete tasks.
+      </div>
+      <div className="space-y-3">
+        <label className="flex items-center justify-between gap-2">
+          <span className="text-sm">Enable notifications</span>
+          <Switch checked={enabled} disabled={loading} onCheckedChange={updateEnabled} />
+        </label>
+        <label className="flex items-center justify-between gap-2">
+          <span className="text-sm">Enable sound</span>
+          <Switch checked={sound} disabled={loading || !enabled} onCheckedChange={updateSound} />
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default NotificationSettingsCard;

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -10,6 +10,7 @@ import CliProvidersList, { BASE_CLI_PROVIDERS } from './CliProvidersList';
 import TelemetryCard from './TelemetryCard';
 import ThemeCard from './ThemeCard';
 import BrowserPreviewSettingsCard from './BrowserPreviewSettingsCard';
+import NotificationSettingsCard from './NotificationSettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
 import ProjectPrepSettingsCard from './ProjectPrepSettingsCard';
 import { CliProviderStatus } from '../types/connections';
@@ -109,6 +110,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
         description: '',
         sections: [
           { title: 'Privacy & Telemetry', render: () => <TelemetryCard /> },
+          { title: 'Notifications', render: () => <NotificationSettingsCard /> },
           { title: 'In‑app Browser Preview', render: () => <BrowserPreviewSettingsCard /> },
           { title: 'Project prep', render: () => <ProjectPrepSettingsCard /> },
           { title: 'Theme', render: () => <ThemeCard /> },

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -23,6 +23,8 @@ declare global {
         settings?: {
           repository: { branchTemplate: string; pushOnCreate: boolean };
           projectPrep?: { autoInstallOnOpenInEditor: boolean };
+          browserPreview?: { enabled: boolean; engine: 'chromium' };
+          notifications?: { enabled: boolean; sound: boolean };
         };
         error?: string;
       }>;
@@ -30,12 +32,16 @@ declare global {
         settings: Partial<{
           repository: { branchTemplate?: string; pushOnCreate?: boolean };
           projectPrep: { autoInstallOnOpenInEditor?: boolean };
+          browserPreview: { enabled?: boolean; engine?: 'chromium' };
+          notifications: { enabled?: boolean; sound?: boolean };
         }>
       ) => Promise<{
         success: boolean;
         settings?: {
           repository: { branchTemplate: string; pushOnCreate: boolean };
           projectPrep?: { autoInstallOnOpenInEditor: boolean };
+          browserPreview?: { enabled: boolean; engine: 'chromium' };
+          notifications?: { enabled: boolean; sound: boolean };
         };
         error?: string;
       }>;


### PR DESCRIPTION
Implements native system notifications when agents (Codex/Claude) complete tasks, with full UI controls for user preferences.

## Features
- 🔔 User preference toggle in settings (default: enabled)
- 🔊 Sound control preference (default: enabled)  
- 🎯 Smart focus detection (only notifies when app is in background)
- ✅ Platform support check using Electron Notification API
- 🛡️ Graceful fallback if notifications unsupported

## Implementation

### Backend (from commit 815d2aa)
- Added notifications settings to AppSettings interface
- Created showCompletionNotification() helper in agentIpc.ts
- Integrated with existing agent:complete and codex:complete event handlers

### UI (this PR)
- **NotificationSettingsCard** component with Switch toggles
- Positioned in Settings → General tab after Privacy & Telemetry
- Sound toggle disabled when notifications are off
- Proper error logging for debugging
- Type-safe IPC communication

### Code Quality Improvements
- Fixed settingsIpc.ts to accept `Partial<AppSettings>` (was limiting fields)
- Added console.error logging in catch blocks
- Removed unsafe `(window as any)` type casts
- Follows existing code patterns from BrowserPreviewSettingsCard

## Testing

To test:
1. Open Settings → General → Notifications
2. Toggle notifications on/off
3. Toggle sound on/off (disabled when notifications off)
4. Trigger agent completion (send task to Codex/Claude)
5. Verify notification appears (only when app in background)
6. Settings persist across app restarts

## Screenshots
_TODO: Add screenshots of settings UI_

Closes #213