### PR TITLE
end-docker-1763778320396

### DIFF
--- a/src/main/ipc/dbIpc.ts
+++ b/src/main/ipc/dbIpc.ts
@@ -115,11 +115,10 @@ export function registerDatabaseIpc() {
   ipcMain.handle('db:deleteWorkspace', async (_, workspaceId: string) => {
     try {
       // Stop any running Docker container for this workspace before deletion
-      try {
-        await containerRunnerService.stopRun(workspaceId);
-      } catch (containerError) {
+      const stopResult = await containerRunnerService.stopRun(workspaceId);
+      if (!stopResult.ok) {
         // Log but don't fail workspace deletion if container stop fails
-        log.warn('Failed to stop container during workspace deletion:', containerError);
+        log.warn('Failed to stop container during workspace deletion:', stopResult.error);
       }
 
       await databaseService.deleteWorkspace(workspaceId);


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Stop workspace Docker container during `db:deleteWorkspace` before deleting the workspace, logging but not failing on stop errors.
> 
> - **Backend IPC (`src/main/ipc/dbIpc.ts`)**:
>   - **Workspace deletion flow**: Before `databaseService.deleteWorkspace`, invoke `containerRunnerService.stopRun(workspaceId)` to stop any running Docker container.
>     - Logs a warning on stop failure but proceeds with deletion.
>   - Added import for `containerRunnerService`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2b98e9cb96a5637abde5654487212f0b77c871d5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->