### PR TITLE
Fix UI freeze on workspace deletion by offloading cleanup

### DIFF
--- a/docs/next-env.d.ts
+++ b/docs/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import "./.next/dev/types/routes.d.ts";
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1075,21 +1075,22 @@ const AppContent: React.FC = () => {
     [activateProjectView, projects]
   );
 
-  const removeWorkspaceFromState = (
-    projectId: string,
-    workspaceId: string,
-    wasActive: boolean
-  ) => {
-    const filterWorkspaces = (list?: Workspace[]) => (list || []).filter((w) => w.id !== workspaceId);
+  const removeWorkspaceFromState = (projectId: string, workspaceId: string, wasActive: boolean) => {
+    const filterWorkspaces = (list?: Workspace[]) =>
+      (list || []).filter((w) => w.id !== workspaceId);
 
     setProjects((prev) =>
       prev.map((project) =>
-        project.id === projectId ? { ...project, workspaces: filterWorkspaces(project.workspaces) } : project
+        project.id === projectId
+          ? { ...project, workspaces: filterWorkspaces(project.workspaces) }
+          : project
       )
     );
 
     setSelectedProject((prev) =>
-      prev && prev.id === projectId ? { ...prev, workspaces: filterWorkspaces(prev.workspaces) } : prev
+      prev && prev.id === projectId
+        ? { ...prev, workspaces: filterWorkspaces(prev.workspaces) }
+        : prev
     );
 
     if (wasActive) {
@@ -1202,11 +1203,15 @@ const AppContent: React.FC = () => {
           const refreshedWorkspaces = await window.electronAPI.getWorkspaces(targetProject.id);
           setProjects((prev) =>
             prev.map((project) =>
-              project.id === targetProject.id ? { ...project, workspaces: refreshedWorkspaces } : project
+              project.id === targetProject.id
+                ? { ...project, workspaces: refreshedWorkspaces }
+                : project
             )
           );
           setSelectedProject((prev) =>
-            prev && prev.id === targetProject.id ? { ...prev, workspaces: refreshedWorkspaces } : prev
+            prev && prev.id === targetProject.id
+              ? { ...prev, workspaces: refreshedWorkspaces }
+              : prev
           );
 
           if (wasActive) {
@@ -1360,7 +1365,6 @@ const AppContent: React.FC = () => {
                 Open Project
               </Button>
             </div>
-
           </div>
         </div>
       );
@@ -1428,7 +1432,6 @@ const AppContent: React.FC = () => {
               Open Project
             </Button>
           </div>
-
         </div>
       </div>
     );


### PR DESCRIPTION
- Deletion now returns immediately, optimistically removes the workspace, and guards double-clicks while cleanup runs in the background
- Worktree/DB deletion and PTY teardown happen concurrently; on failure we refresh, and if refresh fails we reinsert the stashed workspace and restore the active session.
- Removed the interim “Deleting workspace…” toast; only success/error toasts remain to reduce noise.