### PR TITLE
refactor: centralize provider config and use ProviderId type

### DIFF
--- a/src/renderer/components/MultiProviderMenu.tsx
+++ b/src/renderer/components/MultiProviderMenu.tsx
@@ -5,45 +5,7 @@ import { type Provider } from '../types';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import { ProviderInfoCard } from './ProviderInfoCard';
 import type { UiProvider } from '@/providers/meta';
-import openaiLogo from '../../assets/images/openai.png';
-import kiroLogo from '../../assets/images/kiro.png';
-import claudeLogo from '../../assets/images/claude.png';
-import factoryLogo from '../../assets/images/factorydroid.png';
-import geminiLogo from '../../assets/images/gemini.png';
-import cursorLogo from '../../assets/images/cursorlogo.png';
-import copilotLogo from '../../assets/images/ghcopilot.png';
-import ampLogo from '../../assets/images/ampcode.png';
-import opencodeLogo from '../../assets/images/opencode.png';
-import charmLogo from '../../assets/images/charm.png';
-import qwenLogo from '../../assets/images/qwen.png';
-import augmentLogo from '../../assets/images/augmentcode.png';
-import gooseLogo from '../../assets/images/goose.png';
-import kimiLogo from '../../assets/images/kimi.png';
-import atlassianLogo from '../../assets/images/atlassian.png';
-import clineLogo from '../../assets/images/cline.png';
-import codebuffLogo from '../../assets/images/codebuff.png';
-
-type ProviderInfo = { name: string; logo: string; alt: string; invertInDark?: boolean };
-
-const providerConfig: Record<Provider, ProviderInfo> = {
-  codex: { name: 'Codex', logo: openaiLogo, alt: 'Codex', invertInDark: true },
-  qwen: { name: 'Qwen Code', logo: qwenLogo, alt: 'Qwen Code' },
-  claude: { name: 'Claude Code', logo: claudeLogo, alt: 'Claude Code' },
-  droid: { name: 'Droid', logo: factoryLogo, alt: 'Factory Droid', invertInDark: true },
-  gemini: { name: 'Gemini', logo: geminiLogo, alt: 'Gemini CLI' },
-  cursor: { name: 'Cursor', logo: cursorLogo, alt: 'Cursor CLI', invertInDark: true },
-  copilot: { name: 'Copilot', logo: copilotLogo, alt: 'GitHub Copilot CLI', invertInDark: true },
-  amp: { name: 'Amp', logo: ampLogo, alt: 'Amp Code' },
-  opencode: { name: 'OpenCode', logo: opencodeLogo, alt: 'OpenCode', invertInDark: true },
-  charm: { name: 'Charm', logo: charmLogo, alt: 'Charm' },
-  auggie: { name: 'Auggie', logo: augmentLogo, alt: 'Auggie CLI', invertInDark: true },
-  goose: { name: 'Goose', logo: gooseLogo, alt: 'Goose CLI' },
-  kimi: { name: 'Kimi', logo: kimiLogo, alt: 'Kimi CLI' },
-  kiro: { name: 'Kiro', logo: kiroLogo, alt: 'Kiro CLI' },
-  rovo: { name: 'Rovo Dev', logo: atlassianLogo, alt: 'Rovo Dev CLI' },
-  cline: { name: 'Cline', logo: clineLogo, alt: 'Cline CLI' },
-  codebuff: { name: 'Codebuff', logo: codebuffLogo, alt: 'Codebuff CLI' },
-};
+import { providerConfig } from '../lib/providerConfig';
 
 interface Props {
   value: Provider[];

--- a/src/renderer/components/MultiProviderSelector.tsx
+++ b/src/renderer/components/MultiProviderSelector.tsx
@@ -1,44 +1,6 @@
 import React from 'react';
 import { type Provider } from '../types';
-import openaiLogo from '../../assets/images/openai.png';
-import claudeLogo from '../../assets/images/claude.png';
-import factoryLogo from '../../assets/images/factorydroid.png';
-import geminiLogo from '../../assets/images/gemini.png';
-import cursorLogo from '../../assets/images/cursorlogo.png';
-import copilotLogo from '../../assets/images/ghcopilot.png';
-import ampLogo from '../../assets/images/ampcode.png';
-import opencodeLogo from '../../assets/images/opencode.png';
-import charmLogo from '../../assets/images/charm.png';
-import qwenLogo from '../../assets/images/qwen.png';
-import augmentLogo from '../../assets/images/augmentcode.png';
-import gooseLogo from '../../assets/images/goose.png';
-import kimiLogo from '../../assets/images/kimi.png';
-import kiroLogo from '../../assets/images/kiro.png';
-import atlassianLogo from '../../assets/images/atlassian.png';
-import clineLogo from '../../assets/images/cline.png';
-import codebuffLogo from '../../assets/images/codebuff.png';
-
-type ProviderInfo = { name: string; logo: string; alt: string; invertInDark?: boolean };
-
-const providerConfig: Record<Provider, ProviderInfo> = {
-  codex: { name: 'Codex', logo: openaiLogo, alt: 'Codex', invertInDark: true },
-  qwen: { name: 'Qwen Code', logo: qwenLogo, alt: 'Qwen Code' },
-  claude: { name: 'Claude Code', logo: claudeLogo, alt: 'Claude Code' },
-  droid: { name: 'Droid', logo: factoryLogo, alt: 'Factory Droid', invertInDark: true },
-  gemini: { name: 'Gemini', logo: geminiLogo, alt: 'Gemini CLI' },
-  cursor: { name: 'Cursor', logo: cursorLogo, alt: 'Cursor CLI', invertInDark: true },
-  copilot: { name: 'Copilot', logo: copilotLogo, alt: 'GitHub Copilot CLI', invertInDark: true },
-  amp: { name: 'Amp', logo: ampLogo, alt: 'Amp Code' },
-  opencode: { name: 'OpenCode', logo: opencodeLogo, alt: 'OpenCode', invertInDark: true },
-  charm: { name: 'Charm', logo: charmLogo, alt: 'Charm' },
-  auggie: { name: 'Auggie', logo: augmentLogo, alt: 'Auggie CLI' },
-  goose: { name: 'Goose', logo: gooseLogo, alt: 'Goose CLI' },
-  kimi: { name: 'Kimi', logo: kimiLogo, alt: 'Kimi CLI' },
-  kiro: { name: 'Kiro', logo: kiroLogo, alt: 'Kiro CLI' },
-  rovo: { name: 'Rovo Dev', logo: atlassianLogo, alt: 'Rovo Dev CLI' },
-  cline: { name: 'Cline', logo: clineLogo, alt: 'Cline CLI' },
-  codebuff: { name: 'Codebuff', logo: codebuffLogo, alt: 'Codebuff CLI' },
-};
+import { providerConfig } from '../lib/providerConfig';
 
 interface MultiProviderSelectorProps {
   value: Provider[];

--- a/src/renderer/components/ProviderSelector.tsx
+++ b/src/renderer/components/ProviderSelector.tsx
@@ -7,23 +7,7 @@ import { Workflow } from 'lucide-react';
 import { Badge } from './ui/badge';
 import type { UiProvider } from '@/providers/meta';
 import { type Provider } from '../types';
-import openaiLogo from '../../assets/images/openai.png';
-import kiroLogo from '../../assets/images/kiro.png';
-import claudeLogo from '../../assets/images/claude.png';
-import factoryLogo from '../../assets/images/factorydroid.png';
-import geminiLogo from '../../assets/images/gemini.png';
-import cursorLogo from '../../assets/images/cursorlogo.png';
-import copilotLogo from '../../assets/images/ghcopilot.png';
-import ampLogo from '../../assets/images/ampcode.png';
-import opencodeLogo from '../../assets/images/opencode.png';
-import charmLogo from '../../assets/images/charm.png';
-import qwenLogo from '../../assets/images/qwen.png';
-import augmentLogo from '../../assets/images/augmentcode.png';
-import gooseLogo from '../../assets/images/goose.png';
-import kimiLogo from '../../assets/images/kimi.png';
-import atlassianLogo from '../../assets/images/atlassian.png';
-import clineLogo from '../../assets/images/cline.png';
-import codebuffLogo from '../../assets/images/codebuff.png';
+import { providerConfig } from '../lib/providerConfig';
 
 interface ProviderSelectorProps {
   value: Provider;
@@ -31,111 +15,6 @@ interface ProviderSelectorProps {
   disabled?: boolean;
   className?: string;
 }
-
-const providerConfig = {
-  codex: {
-    name: 'Codex',
-    logo: openaiLogo,
-    alt: 'Codex',
-    invertInDark: true,
-  },
-  qwen: {
-    name: 'Qwen Code',
-    logo: qwenLogo,
-    alt: 'Qwen Code CLI',
-    invertInDark: false,
-  },
-  claude: {
-    name: 'Claude Code',
-    logo: claudeLogo,
-    alt: 'Claude Code',
-    invertInDark: false,
-  },
-  droid: {
-    name: 'Droid',
-    logo: factoryLogo,
-    alt: 'Factory Droid',
-    invertInDark: true,
-  },
-  gemini: {
-    name: 'Gemini',
-    logo: geminiLogo,
-    alt: 'Gemini CLI',
-    invertInDark: false,
-  },
-  cursor: {
-    name: 'Cursor',
-    logo: cursorLogo,
-    alt: 'Cursor CLI',
-    invertInDark: true,
-  },
-  copilot: {
-    name: 'Copilot',
-    logo: copilotLogo,
-    alt: 'GitHub Copilot CLI',
-    invertInDark: true,
-  },
-  amp: {
-    name: 'Amp',
-    logo: ampLogo,
-    alt: 'Amp Code',
-    invertInDark: false,
-  },
-  opencode: {
-    name: 'OpenCode',
-    logo: opencodeLogo,
-    alt: 'OpenCode',
-    invertInDark: true,
-  },
-  charm: {
-    name: 'Charm',
-    logo: charmLogo,
-    alt: 'Charm',
-    invertInDark: false,
-  },
-  auggie: {
-    name: 'Auggie',
-    logo: augmentLogo,
-    alt: 'Auggie CLI',
-    invertInDark: true,
-  },
-  goose: {
-    name: 'Goose',
-    logo: gooseLogo,
-    alt: 'Goose CLI',
-    invertInDark: false,
-  },
-  kimi: {
-    name: 'Kimi',
-    logo: kimiLogo,
-    alt: 'Kimi CLI',
-    invertInDark: false,
-  },
-  kiro: {
-    name: 'Kiro',
-    logo: kiroLogo,
-    alt: 'Kiro CLI',
-    invertInDark: false,
-  },
-  rovo: {
-    name: 'Rovo Dev',
-    logo: atlassianLogo,
-    alt: 'Rovo Dev CLI',
-    invertInDark: false,
-  },
-  cline: {
-    name: 'Cline',
-    logo: clineLogo,
-    alt: 'Cline CLI',
-    invertInDark: false,
-  },
-  codebuff: {
-    name: 'Codebuff',
-    logo: codebuffLogo,
-    alt: 'Codebuff CLI',
-    invertInDark: false,
-  },
-} as const;
 
 export const ProviderSelector: React.FC<ProviderSelectorProps> = ({
   value,

--- a/src/renderer/lib/providerConfig.ts
+++ b/src/renderer/lib/providerConfig.ts
@@ -1,0 +1,45 @@
+import type { Provider } from '../types';
+import openaiLogo from '../../assets/images/openai.png';
+import kiroLogo from '../../assets/images/kiro.png';
+import claudeLogo from '../../assets/images/claude.png';
+import factoryLogo from '../../assets/images/factorydroid.png';
+import geminiLogo from '../../assets/images/gemini.png';
+import cursorLogo from '../../assets/images/cursorlogo.png';
+import copilotLogo from '../../assets/images/ghcopilot.png';
+import ampLogo from '../../assets/images/ampcode.png';
+import opencodeLogo from '../../assets/images/opencode.png';
+import charmLogo from '../../assets/images/charm.png';
+import qwenLogo from '../../assets/images/qwen.png';
+import augmentLogo from '../../assets/images/augmentcode.png';
+import gooseLogo from '../../assets/images/goose.png';
+import kimiLogo from '../../assets/images/kimi.png';
+import atlassianLogo from '../../assets/images/atlassian.png';
+import clineLogo from '../../assets/images/cline.png';
+import codebuffLogo from '../../assets/images/codebuff.png';
+
+export type ProviderInfo = {
+  name: string;
+  logo: string;
+  alt: string;
+  invertInDark?: boolean;
+};
+
+export const providerConfig: Record<Provider, ProviderInfo> = {
+  codex: { name: 'Codex', logo: openaiLogo, alt: 'Codex', invertInDark: true },
+  qwen: { name: 'Qwen Code', logo: qwenLogo, alt: 'Qwen Code' },
+  claude: { name: 'Claude Code', logo: claudeLogo, alt: 'Claude Code' },
+  droid: { name: 'Droid', logo: factoryLogo, alt: 'Factory Droid', invertInDark: true },
+  gemini: { name: 'Gemini', logo: geminiLogo, alt: 'Gemini CLI' },
+  cursor: { name: 'Cursor', logo: cursorLogo, alt: 'Cursor CLI', invertInDark: true },
+  copilot: { name: 'Copilot', logo: copilotLogo, alt: 'GitHub Copilot CLI', invertInDark: true },
+  amp: { name: 'Amp', logo: ampLogo, alt: 'Amp Code' },
+  opencode: { name: 'OpenCode', logo: opencodeLogo, alt: 'OpenCode', invertInDark: true },
+  charm: { name: 'Charm', logo: charmLogo, alt: 'Charm' },
+  auggie: { name: 'Auggie', logo: augmentLogo, alt: 'Auggie CLI', invertInDark: true },
+  goose: { name: 'Goose', logo: gooseLogo, alt: 'Goose CLI' },
+  kimi: { name: 'Kimi', logo: kimiLogo, alt: 'Kimi CLI' },
+  kiro: { name: 'Kiro', logo: kiroLogo, alt: 'Kiro CLI' },
+  rovo: { name: 'Rovo Dev', logo: atlassianLogo, alt: 'Rovo Dev CLI' },
+  cline: { name: 'Cline', logo: clineLogo, alt: 'Cline CLI' },
+  codebuff: { name: 'Codebuff', logo: codebuffLogo, alt: 'Codebuff CLI' },
+};

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -1,3 +1,4 @@
+import type { ProviderId } from '@shared/providers/registry';
 import { type LinearIssueSummary } from './linear';
 import { type GitHubIssueSummary } from './github';
 import { type JiraIssueSummary } from './jira';
@@ -14,69 +15,16 @@ export interface WorkspaceMetadata {
     // Max panes allowed when the workspace was created (UI hint)
     maxProviders?: number;
     // Selected providers to run in parallel (ids match Provider type)
-    providers: Array<
-      | 'codex'
-      | 'claude'
-      | 'qwen'
-      | 'droid'
-      | 'gemini'
-      | 'cursor'
-      | 'copilot'
-      | 'amp'
-      | 'opencode'
-      | 'charm'
-      | 'auggie'
-      | 'goose'
-      | 'kimi'
-      | 'kiro'
-      | 'rovo'
-      | 'cline'
-      | 'codebuff'
-    >;
+    providers: ProviderId[];
     variants: Array<{
       id: string;
-      provider:
-        | 'codex'
-        | 'claude'
-        | 'qwen'
-        | 'droid'
-        | 'gemini'
-        | 'cursor'
-        | 'copilot'
-        | 'amp'
-        | 'opencode'
-        | 'charm'
-        | 'auggie'
-        | 'goose'
-        | 'kimi'
-        | 'kiro'
-        | 'rovo'
-        | 'cline'
-        | 'codebuff';
+      provider: ProviderId;
       name: string; // worktree display name, e.g. workspaceName-providerSlug
       branch: string;
       path: string; // filesystem path of the worktree
       worktreeId: string; // WorktreeService id (stable hash of path)
     }>;
-    selectedProvider?:
-      | 'codex'
-      | 'claude'
-      | 'qwen'
-      | 'droid'
-      | 'gemini'
-      | 'cursor'
-      | 'copilot'
-      | 'amp'
-      | 'opencode'
-      | 'charm'
-      | 'auggie'
-      | 'goose'
-      | 'kimi'
-      | 'kiro'
-      | 'rovo'
-      | 'cline'
-      | 'codebuff'
-      | null;
+    selectedProvider?: ProviderId | null;
   } | null;
 }
 


### PR DESCRIPTION
cleanup I wanted to do before i start w https://github.com/generalaction/emdash/issues/353