### PR TITLE
chore: delay app quit after manual download link

### DIFF
--- a/src/main/services/updateIpc.ts
+++ b/src/main/services/updateIpc.ts
@@ -144,6 +144,12 @@ export function registerUpdateIpc() {
     try {
       const { shell } = require('electron');
       await shell.openExternal(getLatestDownloadUrl());
+      // Gracefully quit after opening the external download link so the user can install
+      setTimeout(() => {
+        try {
+          app.quit();
+        } catch {}
+      }, 500);
       return { success: true };
     } catch (error) {
       return { success: false, error: error instanceof Error ? error.message : String(error) };


### PR DESCRIPTION
- quit app after clicking on download update button
- introduce a delay between click of the download button and start of the download