### PR TITLE
fix: make newWorkspaceModal scrollable on overflow

### DIFF
--- a/src/renderer/components/WorkspaceModal.tsx
+++ b/src/renderer/components/WorkspaceModal.tsx
@@ -206,7 +206,7 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
             }
             className="mx-4 w-full max-w-md transform-gpu will-change-transform"
           >
-            <Card className="relative w-full">
+            <Card className="relative max-h-[calc(100vh-48px)] w-full overflow-y-auto">
               <Button
                 variant="ghost"
                 size="sm"


### PR DESCRIPTION
Closes #359 

![newworkspacescroll](https://github.com/user-attachments/assets/8be1a5eb-dd4f-46a7-8a49-991408446d6c)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds max height and vertical scrolling to `WorkspaceModal`'s `Card` to prevent overflow on smaller viewports.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 23ebf9660c0769ea9bbacf0a64b5fb18585164cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->