### PR TITLE
Fix/nix build

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,7 +59,7 @@
               version = "0.3.34";
               src = cleanSrc;
               inherit nodejs;
-              npmDepsHash = "sha256-AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA=";
+              npmDepsHash = "sha256-9NDjQ8L1thkaoSvWm6s9Q9ubT9+oPpWfLDPAnvKsq7A=";
 
               # Don't use npmBuildScript - we'll run electron-builder manually with overrides
               dontNpmBuild = true;


### PR DESCRIPTION
closes #269 

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates `flake.nix` to use `emdash` v0.3.34 and refreshes `npmDepsHash`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4e2af8391ab60255db426d671ee0d1b40f87ec06. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->