### PR TITLE
fix(sidebar): show activity indicator for multi-agent workspaces

### DIFF
--- a/src/renderer/components/MultiAgentWorkspace.tsx
+++ b/src/renderer/components/MultiAgentWorkspace.tsx
@@ -9,6 +9,7 @@ import { providerMeta } from '@/providers/meta';
 import { providerAssets } from '@/providers/assets';
 import { useTheme } from '@/hooks/useTheme';
 import { classifyActivity } from '@/lib/activityClassifier';
+import { activityStore } from '@/lib/activityStore';
 import { Spinner } from './ui/spinner';
 import { BUSY_HOLD_MS, CLEAR_BUSY_MS } from '@/lib/activityConstants';
 import { CornerDownLeft } from 'lucide-react';
@@ -336,6 +337,12 @@ const MultiAgentWorkspace: React.FC<Props> = ({ workspace }) => {
     prefillOnceRef.current = true;
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [initialInjection]);
+
+  // Sync variant busy state to activityStore for sidebar indicator
+  useEffect(() => {
+    const anyBusy = Object.values(variantBusy).some(Boolean);
+    activityStore.setWorkspaceBusy(workspace.id, anyBusy);
+  }, [variantBusy, workspace.id]);
 
   if (!multi?.enabled || variants.length === 0) {
     return (

--- a/src/renderer/lib/activityStore.ts
+++ b/src/renderer/lib/activityStore.ts
@@ -102,6 +102,10 @@ class ActivityStore {
     }
   }
 
+  setWorkspaceBusy(wsId: string, busy: boolean) {
+    this.setBusy(wsId, busy, false);
+  }
+
   subscribe(wsId: string, fn: Listener) {
     this.ensureSubscribed();
     this.subscribedIds.add(wsId);


### PR DESCRIPTION
## Summary

- Multi-agent workspaces now show a spinner in the sidebar when any agent is running
- Added `setWorkspaceBusy` method to `activityStore`
- `MultiAgentWorkspace` syncs its `variantBusy` state to the store

## Test plan

- [ ] Create a Best of N task with 2+ providers
- [ ] Send a prompt to the agents
- [ ] Verify the sidebar shows a spinner for the workspace while agents are working

Fixes #376

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Propagates multi-agent busy state to the global activity store so the sidebar spinner reflects when any agent is running.
> 
> - **UI (MultiAgentWorkspace)**
>   - Syncs per-variant `busy` state to `activityStore` via a new effect, computing `anyBusy` and updating `activityStore.setWorkspaceBusy(workspace.id, anyBusy)`.
> - **State/Activity Store**
>   - Adds `setWorkspaceBusy(wsId, busy)` API to set workspace busy state without an event.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c710013c9c792db4313da8d205eb28d7ff7e5aaa. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->