### PR TITLE
fix: terminal steals focus in multi-agent mode

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -147,7 +147,6 @@ export class TerminalSessionManager {
     }
 
     this.fitAddon.fit();
-    this.terminal.focus();
     this.sendSizeIfStarted();
 
     this.resizeObserver = new ResizeObserver(() => {
@@ -211,7 +210,7 @@ export class TerminalSessionManager {
   }
 
   focus() {
-    this.container.focus();
+    this.terminal.focus();
   }
 
   registerActivityListener(listener: () => void): () => void {


### PR DESCRIPTION
Closes #398

Removes unconditional `terminal.focus()` from `attach()` that caused focus to jump from input fields to terminal during React re-renders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes automatic terminal focus during `attach()` and updates `focus()` to target the xterm terminal, preventing unintended focus stealing.
> 
> - **Terminal focus behavior**:
>   - Remove unconditional `this.terminal.focus()` from `attach()` to avoid auto-focus.
>   - Change `focus()` to call `this.terminal.focus()` instead of focusing the container.
> - **Files**:
>   - `src/renderer/terminal/TerminalSessionManager.ts`: focus logic adjusted; no other functional changes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 769aa3e01bdb101ac9c678367d35eab68b490b14. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->