### PR TITLE
fix(terminal): prevent terminal from stealing focus on re-attach

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -147,7 +147,6 @@ export class TerminalSessionManager {
     }
 
     this.fitAddon.fit();
-    this.terminal.focus();
     this.sendSizeIfStarted();
 
     this.resizeObserver = new ResizeObserver(() => {


### PR DESCRIPTION
## Summary
- Removed `this.terminal.focus()` call from `attach()` method in TerminalSessionManager
- Terminal was stealing focus from message input in multi-agent mode whenever React re-renders triggered terminal re-attachment

Closes #398

## Test plan
- [ ] Open a multi-agent workspace
- [ ] Click on the message input field
- [ ] Type multiple characters
- [ ] Verify focus remains in the input field (not stolen by terminal)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Remove `this.terminal.focus()` in `attach()` so the terminal no longer grabs focus when re-attached.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 71178c8c35fad102d87112324e9e391c8dcd2585. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->