### PR TITLE
feat: preload issues when workspace modal opens

### DIFF
--- a/src/renderer/components/WorkspaceModal.tsx
+++ b/src/renderer/components/WorkspaceModal.tsx
@@ -364,7 +364,7 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
                                     setSelectedJiraIssue(null);
                                   }
                                 }}
-                                isOpen={isOpen && showAdvanced}
+                                isOpen={isOpen}
                                 disabled={!!selectedGithubIssue || !!selectedJiraIssue}
                                 className="w-full"
                               />
@@ -385,7 +385,7 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
                                     setSelectedJiraIssue(null);
                                   }
                                 }}
-                                isOpen={isOpen && showAdvanced}
+                                isOpen={isOpen}
                                 disabled={!!selectedJiraIssue || !!selectedLinearIssue}
                                 className="w-full"
                               />
@@ -406,7 +406,7 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
                                       setSelectedGithubIssue(null);
                                     }
                                   }}
-                                  isOpen={isOpen && showAdvanced}
+                                  isOpen={isOpen}
                                   disabled={!!selectedLinearIssue || !!selectedGithubIssue}
                                   className="w-full"
                                 />
@@ -418,7 +418,7 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
                                         <JiraIssueSelector
                                           selectedIssue={null}
                                           onIssueChange={() => {}}
-                                          isOpen={isOpen && showAdvanced}
+                                          isOpen={isOpen}
                                           disabled
                                           className="w-full"
                                         />


### PR DESCRIPTION
Closes #403

Linear, GitHub, and Jira issues now start loading as soon as the workspace modal opens, rather than waiting for the user to expand Advanced Options.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Start loading Linear, GitHub, and Jira issues as soon as the workspace modal opens, not only when Advanced options are expanded.
> 
> - **Frontend**
>   - **Workspace modal (`src/renderer/components/WorkspaceModal.tsx`)**:
>     - Pass `isOpen` (instead of `isOpen && showAdvanced`) to `LinearIssueSelector`, `GitHubIssueSelector`, and `JiraIssueSelector` (including disabled placeholder), so issue lists begin loading immediately when the modal opens.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 22a4b443ce89f98c4787661d5f8c7a230c6809e4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->