### PR TITLE
fix: auto-compute npmDepsHash in nix build workflow

### DIFF
--- a/.github/workflows/nix-build.yml
+++ b/.github/workflows/nix-build.yml
@@ -25,6 +25,24 @@ jobs:
           name: emdash
           authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
 
+      - name: Compute npmDepsHash from package-lock.json
+        id: npm-hash
+        run: |
+          set -euo pipefail
+          # Use prefetch-npm-deps to compute the correct hash for current package-lock.json
+          HASH=$(nix run nixpkgs#prefetch-npm-deps -- package-lock.json 2>/dev/null)
+          echo "Computed npmDepsHash: $HASH"
+          echo "hash=$HASH" >> "$GITHUB_OUTPUT"
+
+      - name: Update flake.nix with computed hash
+        run: |
+          set -euo pipefail
+          HASH="${{ steps.npm-hash.outputs.hash }}"
+          echo "Updating flake.nix npmDepsHash to: $HASH"
+          sed -i "s|npmDepsHash = \"sha256-[^\"]*\"|npmDepsHash = \"$HASH\"|" flake.nix
+          echo "Updated flake.nix:"
+          grep npmDepsHash flake.nix
+
       - name: Build x86_64-linux package
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary

- Automatically computes the correct `npmDepsHash` from `package-lock.json` before building
- Uses `prefetch-npm-deps` to calculate the hash at build time
- Updates `flake.nix` in-place during CI so the build uses the correct hash

This fixes the issue where nix builds fail after a release because the hardcoded `npmDepsHash` in `flake.nix` doesn't match the updated `package-lock.json`.

## How it works

1. Runs `nix run nixpkgs#prefetch-npm-deps -- package-lock.json` to compute the hash
2. Uses `sed` to replace the `npmDepsHash` value in `flake.nix`
3. Proceeds with the normal nix build

## Test plan

- [x] Triggered the nix-build workflow manually and verified it computes and uses the correct hash

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Computes npmDepsHash from package-lock.json in CI and updates flake.nix before running the Nix build.
> 
> - **CI (GitHub Actions)** in `.github/workflows/nix-build.yml`:
>   - Compute `npmDepsHash` via `nix run nixpkgs#prefetch-npm-deps -- package-lock.json` and export via `$GITHUB_OUTPUT`.
>   - Update `flake.nix` in-place with the computed `npmDepsHash` using `sed` before building.
>   - Proceed with existing x86_64-linux build and optional artifact upload.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a3615d8502b5e1c8464a9ba6102ce9d5b4d02dc2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->