### PR TITLE
feat: improve PR status UX with obvious clickable View PR buttons

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -9,7 +9,7 @@ import { useFileChanges } from '../hooks/useFileChanges';
 import { usePrStatus } from '../hooks/usePrStatus';
 import PrStatusSkeleton from './ui/pr-status-skeleton';
 import FileTypeIcon from './ui/file-type-icon';
-import { Plus, Undo2 } from 'lucide-react';
+import { Plus, Undo2, ArrowUpRight } from 'lucide-react';
 
 interface FileChangesPanelProps {
   workspaceId: string;
@@ -304,13 +304,19 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({ workspaceI
               ) : pr ? (
                 <button
                   type="button"
-                  onClick={() => {
-                    window.electronAPI?.openExternal?.(pr.url);
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    if (pr.url) window.electronAPI?.openExternal?.(pr.url);
                   }}
-                  className="cursor-pointer rounded border border-border bg-muted px-2 py-0.5 text-[11px] text-muted-foreground"
-                  title={pr.title || 'Pull Request'}
+                  className="inline-flex items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                  title={`${pr.title || 'Pull Request'} (#${pr.number})`}
                 >
-                  PR {pr.isDraft ? 'draft' : pr.state.toLowerCase()}
+                  {pr.isDraft
+                    ? 'Draft'
+                    : String(pr.state).toUpperCase() === 'OPEN'
+                      ? 'View PR'
+                      : `PR ${String(pr.state).charAt(0).toUpperCase() + String(pr.state).slice(1).toLowerCase()}`}
+                  <ArrowUpRight className="size-3" />
                 </button>
               ) : branchStatusLoading || (branchAhead !== null && branchAhead > 0) ? (
                 <Button

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -304,16 +304,22 @@ function WorkspaceRow({
             </button>
           ) : null}
           {!isLoading && totalAdditions === 0 && totalDeletions === 0 && pr ? (
-            <span
-              className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (pr.url) window.electronAPI.openExternal(pr.url);
+              }}
+              className="inline-flex items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
               title={`${pr.title || 'Pull Request'} (#${pr.number})`}
             >
               {pr.isDraft
-                ? 'draft'
-                : String(pr.state).toLowerCase() === 'open'
-                  ? 'PR open'
-                  : String(pr.state).toLowerCase()}
-            </span>
+                ? 'Draft'
+                : String(pr.state).toUpperCase() === 'OPEN'
+                  ? 'View PR'
+                  : `PR ${String(pr.state).charAt(0).toUpperCase() + String(pr.state).slice(1).toLowerCase()}`}
+              <ArrowUpRight className="size-3" />
+            </button>
           ) : null}
           {/* Agent badge commented out per user request
           {ws.agentId && <Badge variant="outline">agent</Badge>}

--- a/src/renderer/components/WorkspaceItem.tsx
+++ b/src/renderer/components/WorkspaceItem.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { GitBranch } from 'lucide-react';
+import { GitBranch, ArrowUpRight } from 'lucide-react';
 import WorkspaceDeleteButton from './WorkspaceDeleteButton';
 import { useWorkspaceChanges } from '../hooks/useWorkspaceChanges';
 import { ChangesBadge } from './WorkspaceChanges';
@@ -69,12 +69,22 @@ export const WorkspaceItem: React.FC<WorkspaceItemProps> = ({
           {!isLoading && (totalAdditions > 0 || totalDeletions > 0) ? (
             <ChangesBadge additions={totalAdditions} deletions={totalDeletions} />
           ) : pr ? (
-            <span
-              className="rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] text-muted-foreground"
+            <button
+              type="button"
+              onClick={(e) => {
+                e.stopPropagation();
+                if (pr.url) window.electronAPI.openExternal(pr.url);
+              }}
+              className="inline-flex items-center gap-1 rounded border border-border bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
               title={`${pr.title || 'Pull Request'} (#${pr.number})`}
             >
-              {pr.isDraft ? 'draft' : pr.state.toLowerCase()}
-            </span>
+              {pr.isDraft
+                ? 'Draft'
+                : String(pr.state).toUpperCase() === 'OPEN'
+                  ? 'View PR'
+                  : `PR ${String(pr.state).charAt(0).toUpperCase() + String(pr.state).slice(1).toLowerCase()}`}
+              <ArrowUpRight className="size-3" />
+            </button>
           ) : null}
         </div>
       </div>

--- a/src/renderer/hooks/useCreatePR.tsx
+++ b/src/renderer/hooks/useCreatePR.tsx
@@ -71,24 +71,8 @@ export function useCreatePR() {
 
       if (res?.success) {
         toast({
-          title: (
-            <span className="inline-flex items-center gap-2">
-              <img src={githubLogo} alt="GitHub" className="h-5 w-5 rounded-sm object-contain" />
-              Pull Request Created
-            </span>
-          ),
-          description: res.url ? (
-            <a
-              href={res.url}
-              target="_blank"
-              rel="noopener noreferrer"
-              className="cursor-pointer hover:underline"
-            >
-              {res.url}
-            </a>
-          ) : (
-            'PR created successfully.'
-          ),
+          title: 'Pull request created successfully!',
+          description: 'Opening PR page...',
         });
         try {
           await onSuccess?.();


### PR DESCRIPTION
<img width="234" height="356" alt="image" src="https://github.com/user-attachments/assets/5169473f-42a6-4296-9957-13e811aaffc1" />

<img width="396" height="122" alt="image" src="https://github.com/user-attachments/assets/ca8fe8b1-b731-4035-868a-88f6fbc48575" />

Updated and unified all status indicators and buttons

## Changes
- Convert PR status badges to clickable "View PR" buttons in:
  - ProjectMainView (WorkspaceRow)
  - FileChangesPanel
  - WorkspaceItem
- Add ArrowUpRight icon to indicate external link
- Add hover states for better visual affordance
- Simplify PR creation success toast

## UX Improvements
- Clear action label: "View PR" instead of ambiguous "PR open"
- Consistent styling across all PR status displays
- Immediate feedback via simplified toast notification
- Better discoverability with hover effects and icon