### PR TITLE
feat: make right sidebar open by default

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -225,7 +225,7 @@ const AppContent: React.FC = () => {
   const leftSidebarIsMobileRef = useRef<boolean>(false);
   const leftSidebarOpenRef = useRef<boolean>(true);
   const rightSidebarSetCollapsedRef = useRef<((next: boolean) => void) | null>(null);
-  const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState<boolean>(true);
+  const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState<boolean>(false);
 
   const handlePanelLayout = useCallback((sizes: number[]) => {
     if (!Array.isArray(sizes) || sizes.length < 3) {
@@ -1476,7 +1476,7 @@ const AppContent: React.FC = () => {
           return null;
         })()}
         <SidebarProvider>
-          <RightSidebarProvider defaultCollapsed>
+          <RightSidebarProvider>
             <AppKeyboardShortcuts
               showCommandPalette={showCommandPalette}
               showSettings={showSettings}

--- a/src/renderer/components/ui/right-sidebar.tsx
+++ b/src/renderer/components/ui/right-sidebar.tsx
@@ -15,7 +15,7 @@ export interface RightSidebarProviderProps {
 
 export function RightSidebarProvider({
   children,
-  defaultCollapsed = true,
+  defaultCollapsed = false,
 }: RightSidebarProviderProps) {
   const [collapsed, setCollapsedState] = React.useState<boolean>(defaultCollapsed);
 


### PR DESCRIPTION
## Make right sidebar open by default

### Summary
Changes the right sidebar (containing the Changes and Terminal panels) to be open by default instead of collapsed.

### Motivation
Previously, users had to discover and manually open the right sidebar to access the Changes and Terminal panels. This created a discovery barrier for important features.

With this change, users have immediate access to:
- **Changes panel**: See file modifications right after their first prompt completes
- **Terminal panel**: Access the workspace terminal without extra steps

This is especially valuable after the first prompt finishes and changes are made—users can see the changes immediately without needing to find the sidebar toggle first.

### Changes
- Updated `RightSidebarProvider` default from `collapsed=true` to `collapsed=false`
- Updated initial state in `App.tsx` to match the new default
- Removed explicit `defaultCollapsed` prop to use the provider's default
