### PR TITLE
fix: prepend new workspaces to top of list for consistent ordering

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1020,7 +1020,7 @@ const AppContent: React.FC = () => {
             project.id === selectedProject.id
               ? {
                   ...project,
-                  workspaces: [...(project.workspaces || []), newWorkspace],
+                  workspaces: [newWorkspace, ...(project.workspaces || [])],
                 }
               : project
           )
@@ -1030,7 +1030,7 @@ const AppContent: React.FC = () => {
           prev
             ? {
                 ...prev,
-                workspaces: [...(prev.workspaces || []), newWorkspace],
+                workspaces: [newWorkspace, ...(prev.workspaces || [])],
               }
             : null
         );
@@ -1253,7 +1253,7 @@ const AppContent: React.FC = () => {
               const alreadyPresent = existing.some((w) => w.id === workspaceSnapshot.id);
               return alreadyPresent
                 ? project
-                : { ...project, workspaces: [...existing, workspaceSnapshot] };
+                : { ...project, workspaces: [workspaceSnapshot, ...existing] };
             })
           );
           setSelectedProject((prev) => {
@@ -1262,7 +1262,7 @@ const AppContent: React.FC = () => {
             const alreadyPresent = existing.some((w) => w.id === workspaceSnapshot.id);
             return alreadyPresent
               ? prev
-              : { ...prev, workspaces: [...existing, workspaceSnapshot] };
+              : { ...prev, workspaces: [workspaceSnapshot, ...existing] };
           });
 
           if (wasActive) {


### PR DESCRIPTION
## Fix: New Tasks Now Appear at Top of List

### Problem

When users created a new task (workspace), it would appear at the bottom of the task list in the left sidebar. However, the database already orders tasks by recency (`updatedAt DESC`), meaning the most recent tasks are returned first. This created an inconsistency:

- **During session**: New tasks appeared at the bottom
- **After app reload**: Those same tasks would appear at the top (per database order)

This caused a jarring experience where users would see tasks that were previously at the bottom suddenly jump to the top when reopening the app, creating confusion about task ordering.

### Solution

Updated the workspace state management to prepend newly created workspaces to the beginning of the array instead of appending them to the end. This ensures:

1. **Immediate consistency**: New tasks appear at the top right after creation
2. **Persistent consistency**: Task order remains the same when the app is reopened
3. **Matches database ordering**: UI now reflects the `updatedAt DESC` ordering from the database

### Changes

- Modified `handleCreateWorkspace` in `App.tsx` to prepend `newWorkspace` to the workspaces array
- Updated error recovery path in `handleDeleteWorkspace` to also prepend for consistency