### PR TITLE
feat: enable telemetry for developer builds

### DIFF
--- a/docs/content/docs/security/telemetry.mdx
+++ b/docs/content/docs/security/telemetry.mdx
@@ -137,9 +137,10 @@ All telemetry data passes through a **sanitizer** that:
 
 ### Local Development
 
-- Official builds include PostHog credentials via CI
-- Local development builds **do not send telemetry** unless credentials are explicitly added for testing
-- Development mode is clearly marked in events
+- PostHog credentials are **public and safe to commit** to the repository
+- Both official builds (DMG) and developer builds (cloned repo) send telemetry by default
+- Official builds use credentials injected via CI, while developer builds use credentials from `src/main/appConfig.json`
+- Development mode is clearly marked in events via `is_dev: true` and `install_source: "dev"`
 
 ## For Developers
 
@@ -152,7 +153,10 @@ All telemetry data passes through a **sanitizer** that:
 **For Maintainers:**
 
 - `INSTALL_SOURCE` - Labels distribution channel (e.g., `dmg`, `dev`)
-- PostHog credentials are injected via CI for official builds
+- `POSTHOG_PROJECT_API_KEY` - Override PostHog API key (optional, defaults to public key in `src/main/appConfig.json`)
+- `POSTHOG_HOST` - Override PostHog host (optional, defaults to public host in `src/main/appConfig.json`)
+- PostHog credentials are public and committed to the repo in `src/main/appConfig.json`
+- CI builds can override credentials via GitHub secrets for official releases
 
 ### Renderer Process Events
 

--- a/package.json
+++ b/package.json
@@ -6,10 +6,10 @@
   "scripts": {
     "d": "npm install && npm run dev",
     "dev": "concurrently \"npm run dev:main\" \"npm run dev:renderer\"",
-    "dev:main": "tsc -p tsconfig.main.json && electron dist/main/main/entry.js --dev",
+    "dev:main": "tsc -p tsconfig.main.json && mkdir -p dist/main && cp src/main/appConfig.json dist/main/appConfig.json && electron dist/main/main/entry.js --dev",
     "dev:renderer": "vite",
     "build": "npm run build:main && npm run build:renderer",
-    "build:main": "tsc -p tsconfig.main.json",
+    "build:main": "tsc -p tsconfig.main.json && mkdir -p dist/main && cp src/main/appConfig.json dist/main/appConfig.json",
     "build:renderer": "vite build",
     "package": "npm run build && electron-builder",
     "package:mac": "npm run build && electron-builder --mac",

--- a/src/main/appConfig.json
+++ b/src/main/appConfig.json
@@ -1,4 +1,4 @@
 {
-  "posthogHost": "",
-  "posthogKey": ""
+  "posthogHost": "https://us.i.posthog.com",
+  "posthogKey": "phc_HwVnk5sjxn8S0xnVyTjEl5S2GAP2kxC8tpbR1qyww9"
 }


### PR DESCRIPTION
## Enable Telemetry for Developer Builds

### Problem
Currently, only DMG builds (production releases) send telemetry to PostHog because credentials are only injected during CI builds. Developer builds (cloned repo) don't have access to PostHog credentials, so telemetry silently fails even though users haven't opted out.

This creates an inconsistent experience where:
- DMG users: Telemetry works ✅
- Developer users: Telemetry doesn't work ❌ (even though they're normal users too)

### Solution
Since PostHog credentials are public and safe to commit, we now:
1. **Hardcode public credentials** in `src/main/appConfig.json` so developer builds work out of the box
2. **Add build step** to copy `appConfig.json` to `dist/main/` during compilation
3. **Update documentation** to clarify that credentials are public and both build types now support telemetry

### Changes
- ✅ Added PostHog credentials to `src/main/appConfig.json`
- ✅ Updated `build:main` and `dev:main` scripts to copy `appConfig.json` to `dist/main/`
- ✅ Updated telemetry documentation to reflect the new behavior

### How It Works
- **Developer builds**: Load credentials from `src/main/appConfig.json` → copied to `dist/main/appConfig.json` during build
- **DMG builds**: CI still overwrites `dist/main/appConfig.json` with secrets (same values, but allows flexibility)
- **Users can still opt out**: Via `TELEMETRY_ENABLED=false` env var or in-app settings

### Notes
- PostHog credentials are public and safe to commit (as noted in the plan)
- CI workflow continues to work as before (overwrites `dist/main/appConfig.json`)
- No breaking changes - users can still disable telemetry the same way