### PR TITLE
fix: prevent terminal viewport jump during interactive prompts

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -74,6 +74,7 @@ export class TerminalSessionManager {
       convertEol: true,
       fontFamily: 'Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace',
       allowProposedApi: true,
+      scrollOnUserInput: false,
     });
 
     this.fitAddon = new FitAddon();


### PR DESCRIPTION
## Problem

When users navigate through Claude Code's interactive selection prompts (1, 2, 3 options) using arrow keys, the terminal viewport jumps unexpectedly—usually to the top—causing users to lose visual focus on where they are in the selection menu. The selection state updates correctly, but the viewport scroll position is not maintained.

## Root Cause

xterm.js has `scrollOnUserInput: true` by default, which causes the terminal to auto-scroll to the bottom whenever user input is detected. During interactive prompts, arrow key navigation triggers this behavior even though it's not desired.

## Solution

Added `scrollOnUserInput: false` to the Terminal configuration in `TerminalSessionManager.ts`. This prevents auto-scroll on user input while still allowing natural scrolling when new output arrives from the PTY.

## Changes

- Modified `src/renderer/terminal/TerminalSessionManager.ts` to set `scrollOnUserInput: false` in Terminal initialization

## User Impact

- ✨ Better UX when navigating Claude Code selection menus
- ✨ Improved experience with any interactive CLI tool
- ✨ Viewport stays focused on current context during navigation
- ✨ No breaking changes to existing functionality

## References

- xterm.js documentation: https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/#scrollonuserinput