### PR TITLE
feat: add inline connection buttons for Linear, GitHub, and Jira in w…

### DIFF
--- a/src/renderer/components/GitHubIssueSelector.tsx
+++ b/src/renderer/components/GitHubIssueSelector.tsx
@@ -16,6 +16,7 @@ interface GitHubIssueSelectorProps {
   isOpen?: boolean;
   className?: string;
   disabled?: boolean;
+  placeholder?: string;
 }
 
 export const GitHubIssueSelector: React.FC<GitHubIssueSelectorProps> = ({
@@ -25,6 +26,7 @@ export const GitHubIssueSelector: React.FC<GitHubIssueSelectorProps> = ({
   isOpen = false,
   className = '',
   disabled = false,
+  placeholder: customPlaceholder,
 }) => {
   const [availableIssues, setAvailableIssues] = useState<GitHubIssueSummary[]>([]);
   const [isLoadingIssues, setIsLoadingIssues] = useState(false);
@@ -151,11 +153,13 @@ export const GitHubIssueSelector: React.FC<GitHubIssueSelectorProps> = ({
     onIssueChange(issue);
   };
 
-  const issuePlaceholder = isLoadingIssues
-    ? 'Loading…'
-    : issueListError
-      ? 'Connect your GitHub'
-      : 'Select a GitHub issue';
+  const issuePlaceholder =
+    customPlaceholder ??
+    (isLoadingIssues
+      ? 'Loading…'
+      : issueListError
+        ? 'Connect your GitHub'
+        : 'Select a GitHub issue');
 
   if (!canListGithub) {
     return (

--- a/src/renderer/components/JiraIssueSelector.tsx
+++ b/src/renderer/components/JiraIssueSelector.tsx
@@ -14,6 +14,7 @@ interface Props {
   isOpen?: boolean;
   className?: string;
   disabled?: boolean;
+  placeholder?: string;
 }
 
 const JiraIssueSelector: React.FC<Props> = ({
@@ -22,6 +23,7 @@ const JiraIssueSelector: React.FC<Props> = ({
   isOpen = false,
   className = '',
   disabled = false,
+  placeholder: customPlaceholder,
 }) => {
   const [availableIssues, setAvailableIssues] = useState<JiraIssueSummary[]>([]);
   const [isLoadingIssues, setIsLoadingIssues] = useState(false);
@@ -180,11 +182,13 @@ const JiraIssueSelector: React.FC<Props> = ({
     );
   }
 
-  const issuePlaceholder = isLoadingIssues
-    ? 'Loading…'
-    : issueListError
-      ? 'Connect your Jira'
-      : 'Select a Jira issue';
+  const issuePlaceholder =
+    customPlaceholder ??
+    (isLoadingIssues
+      ? 'Loading…'
+      : issueListError
+        ? 'Connect your Jira'
+        : 'Select a Jira issue');
 
   return (
     <div className={className}>

--- a/src/renderer/components/LinearIssueSelector.tsx
+++ b/src/renderer/components/LinearIssueSelector.tsx
@@ -13,6 +13,9 @@ interface LinearIssueSelectorProps {
   isOpen?: boolean;
   className?: string;
   disabled?: boolean;
+  autoOpen?: boolean;
+  onAutoOpenHandled?: () => void;
+  placeholder?: string;
 }
 
 export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
@@ -21,6 +24,9 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
   isOpen = false,
   className = '',
   disabled = false,
+  autoOpen = false,
+  onAutoOpenHandled,
+  placeholder: customPlaceholder,
 }) => {
   const [availableIssues, setAvailableIssues] = useState<LinearIssueSummary[]>([]);
   const [isLoadingIssues, setIsLoadingIssues] = useState(false);
@@ -31,6 +37,7 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
   const [isSearching, setIsSearching] = useState(false);
   const isMountedRef = useRef(true);
   const [visibleCount, setVisibleCount] = useState(10);
+  const [dropdownOpen, setDropdownOpen] = useState(false);
 
   const canListLinear = typeof window !== 'undefined' && !!window.electronAPI?.linearInitialFetch;
   const issuesLoaded = availableIssues.length > 0;
@@ -55,6 +62,19 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
       setVisibleCount(10);
     }
   }, [isOpen, onIssueChange]);
+
+  useEffect(() => {
+    if (!isOpen) {
+      setDropdownOpen(false);
+    }
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (autoOpen) {
+      setDropdownOpen(true);
+      onAutoOpenHandled?.();
+    }
+  }, [autoOpen, onAutoOpenHandled]);
 
   const loadLinearIssues = useCallback(async () => {
     if (!canListLinear) {
@@ -187,11 +207,13 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
     return null;
   })();
 
-  const issuePlaceholder = isLoadingIssues
-    ? 'Loading…'
-    : issueListError
-      ? 'Connect your Linear'
-      : 'Select a Linear issue';
+  const issuePlaceholder =
+    customPlaceholder ??
+    (isLoadingIssues
+      ? 'Loading…'
+      : issueListError
+        ? 'Connect your Linear'
+        : 'Select a Linear issue');
 
   if (!canListLinear) {
     return (
@@ -210,6 +232,8 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
         value={selectedIssue?.identifier || undefined}
         onValueChange={handleIssueSelect}
         disabled={isDisabled}
+        open={dropdownOpen}
+        onOpenChange={(open) => setDropdownOpen(open)}
       >
         <SelectTrigger className="h-9 w-full border-none bg-gray-100 dark:bg-gray-700">
           <div className="flex min-w-0 flex-1 items-center gap-2 overflow-hidden text-left text-foreground">

--- a/src/renderer/components/WorkspaceModal.tsx
+++ b/src/renderer/components/WorkspaceModal.tsx
@@ -25,12 +25,15 @@ import {
 
 const DEFAULT_PROVIDER: Provider = 'claude';
 
+import LinearSetupForm from './integrations/LinearSetupForm';
+import JiraSetupForm from './integrations/JiraSetupForm';
 import { LinearIssueSelector } from './LinearIssueSelector';
 import { GitHubIssueSelector } from './GitHubIssueSelector';
 import JiraIssueSelector from './JiraIssueSelector';
 import { type JiraIssueSummary } from '../types/jira';
 import { Badge } from './ui/badge';
 import jiraLogo from '../../assets/images/jira.png';
+import { useGithubAuth } from '../hooks/useGithubAuth';
 
 interface WorkspaceModalProps {
   isOpen: boolean;
@@ -75,7 +78,21 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
 
   const [selectedJiraIssue, setSelectedJiraIssue] = useState<JiraIssueSummary | null>(null);
   const [isJiraConnected, setIsJiraConnected] = useState<boolean | null>(null);
+  const [isLinearConnected, setIsLinearConnected] = useState<boolean | null>(null);
+  const [linearSetupOpen, setLinearSetupOpen] = useState(false);
+  const [linearApiKey, setLinearApiKey] = useState('');
+  const [linearConnectionError, setLinearConnectionError] = useState<string | null>(null);
+  const [autoOpenLinearSelector, setAutoOpenLinearSelector] = useState(false);
+  const [jiraSetupOpen, setJiraSetupOpen] = useState(false);
+  const [jiraSite, setJiraSite] = useState('');
+  const [jiraEmail, setJiraEmail] = useState('');
+  const [jiraToken, setJiraToken] = useState('');
+  const [jiraConnectionError, setJiraConnectionError] = useState<string | null>(null);
   const [autoApprove, setAutoApprove] = useState(false);
+
+  // GitHub connection state
+  const { installed: githubInstalled, authenticated: githubAuthenticated, login: githubLogin, isLoading: githubLoading } = useGithubAuth();
+  const isGithubConnected = githubInstalled && githubAuthenticated;
 
   // Computed values
   const activeProviders = useMemo(() => providerRuns.map((pr) => pr.provider), [providerRuns]);
@@ -152,6 +169,49 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
   useEffect(() => {
     let cancel = false;
     (async () => {
+      if (!isOpen) {
+        setLinearSetupOpen(false);
+        setLinearApiKey('');
+        setLinearConnectionError(null);
+        setIsLinearConnected(null);
+        setAutoOpenLinearSelector(false);
+        setJiraSetupOpen(false);
+        setJiraSite('');
+        setJiraEmail('');
+        setJiraToken('');
+        setJiraConnectionError(null);
+        return;
+      }
+      try {
+        const api: any = (window as any).electronAPI;
+        if (!api?.linearCheckConnection) {
+          if (!cancel) {
+            setIsLinearConnected(false);
+            setLinearConnectionError('Linear integration unavailable.');
+          }
+          return;
+        }
+        const res = await api.linearCheckConnection();
+        if (!cancel) {
+          setIsLinearConnected(!!res?.connected);
+          setLinearConnectionError(res?.connected ? null : res?.error ?? null);
+        }
+      } catch {
+        if (!cancel) {
+          setIsLinearConnected(false);
+          setLinearConnectionError('Unable to verify Linear connection.');
+        }
+      }
+    })();
+    return () => {
+      cancel = true;
+    };
+  }, [isOpen]);
+
+  // Check Jira connection to decide whether to render the Jira selector
+  useEffect(() => {
+    let cancel = false;
+    (async () => {
       try {
         const api: any = (window as any).electronAPI;
         const res = await api?.jiraCheckConnection?.();
@@ -164,6 +224,73 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
       cancel = true;
     };
   }, []);
+
+  const handleLinearConnect = useCallback(async () => {
+    const trimmedKey = linearApiKey.trim();
+    if (!trimmedKey || !window?.electronAPI?.linearSaveToken) {
+      return;
+    }
+
+    setLinearConnectionError(null);
+    try {
+      const result = await window.electronAPI.linearSaveToken(trimmedKey);
+      if (result?.success) {
+        setIsLinearConnected(true);
+        setLinearSetupOpen(false);
+        setLinearApiKey('');
+        setLinearConnectionError(null);
+        setAutoOpenLinearSelector(true);
+      } else {
+        setLinearConnectionError(result?.error || 'Could not connect Linear. Try again.');
+      }
+    } catch (error) {
+      console.error('Linear connect failed:', error);
+      setLinearConnectionError('Could not connect Linear. Try again.');
+    }
+  }, [linearApiKey]);
+
+  const handleGithubConnect = useCallback(async () => {
+    if (!githubInstalled) {
+      try {
+        await window.electronAPI.openExternal('https://cli.github.com/manual/installation');
+      } catch (error) {
+        console.error('Failed to open GitHub CLI install docs:', error);
+      }
+      return;
+    }
+    try {
+      const result = await githubLogin();
+      if (result?.success) {
+        // Connection status will update via useGithubAuth hook
+      }
+    } catch (error) {
+      console.error('GitHub connect failed:', error);
+    }
+  }, [githubInstalled, githubLogin]);
+
+  const handleJiraConnect = useCallback(async () => {
+    try {
+      setJiraConnectionError(null);
+      const api: any = (window as any).electronAPI;
+      const res = await api?.jiraSaveCredentials?.({
+        siteUrl: jiraSite.trim(),
+        email: jiraEmail.trim(),
+        token: jiraToken.trim(),
+      });
+      if (res?.success) {
+        setIsJiraConnected(true);
+        setJiraSite('');
+        setJiraEmail('');
+        setJiraToken('');
+        setJiraSetupOpen(false);
+        setJiraConnectionError(null);
+      } else {
+        setJiraConnectionError(res?.error || 'Failed to connect.');
+      }
+    } catch (e: any) {
+      setJiraConnectionError(e?.message || 'Failed to connect.');
+    }
+  }, [jiraSite, jiraEmail, jiraToken]);
 
   useEffect(() => {
     if (!hasAutoApproveSupport && autoApprove) {
@@ -354,7 +481,7 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
                             <Label htmlFor="linear-issue" className="w-32 shrink-0 pt-2">
                               Linear issue
                             </Label>
-                            <div className="min-w-0 flex-1">
+                            <div className="flex min-w-0 flex-1 items-center gap-2">
                               <LinearIssueSelector
                                 selectedIssue={selectedLinearIssue}
                                 onIssueChange={(issue) => {
@@ -365,16 +492,66 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
                                   }
                                 }}
                                 isOpen={isOpen}
-                                disabled={!!selectedGithubIssue || !!selectedJiraIssue}
+                                disabled={
+                                  !isLinearConnected ||
+                                  !!selectedGithubIssue ||
+                                  !!selectedJiraIssue
+                                }
                                 className="w-full"
+                                autoOpen={autoOpenLinearSelector}
+                                onAutoOpenHandled={() => setAutoOpenLinearSelector(false)}
+                                placeholder={
+                                  isLinearConnected ? 'Select a Linear issue' : 'Select issue'
+                                }
                               />
+                              {!isLinearConnected && (
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-9 shrink-0 whitespace-nowrap border-border/50 bg-transparent text-muted-foreground hover:border-border hover:bg-muted/50 hover:text-foreground"
+                                  onClick={() => setLinearSetupOpen(true)}
+                                >
+                                  Connect
+                                </Button>
+                              )}
                             </div>
+                            <AnimatePresence>
+                              {linearSetupOpen ? (
+                                <motion.div
+                                  className="fixed inset-0 z-[130] flex items-center justify-center px-3"
+                                  initial={{ opacity: 0 }}
+                                  animate={{ opacity: 1 }}
+                                  exit={{ opacity: 0 }}
+                                  onClick={() => setLinearSetupOpen(false)}
+                                >
+                                  <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+                                  <motion.div
+                                    className="relative z-10 w-full max-w-md rounded-xl border border-border/70 bg-background/95 p-4 shadow-2xl backdrop-blur-sm"
+                                    initial={{ opacity: 0, scale: 0.95 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    exit={{ opacity: 0, scale: 0.95 }}
+                                    transition={{ duration: shouldReduceMotion ? 0 : 0.15 }}
+                                    onClick={(event) => event.stopPropagation()}
+                                  >
+                                    <LinearSetupForm
+                                      apiKey={linearApiKey}
+                                      onChange={(value) => setLinearApiKey(value)}
+                                      onSubmit={() => void handleLinearConnect()}
+                                      onClose={() => setLinearSetupOpen(false)}
+                                      canSubmit={!!linearApiKey.trim()}
+                                      error={linearConnectionError}
+                                    />
+                                  </motion.div>
+                                </motion.div>
+                              ) : null}
+                            </AnimatePresence>
                           </div>
                           <div className="flex items-start gap-4">
                             <Label htmlFor="github-issue" className="w-32 shrink-0 pt-2">
                               GitHub issue
                             </Label>
-                            <div className="min-w-0 flex-1">
+                            <div className="flex min-w-0 flex-1 items-center gap-2">
                               <GitHubIssueSelector
                                 projectPath={projectPath || ''}
                                 selectedIssue={selectedGithubIssue}
@@ -386,64 +563,112 @@ const WorkspaceModal: React.FC<WorkspaceModalProps> = ({
                                   }
                                 }}
                                 isOpen={isOpen}
-                                disabled={!!selectedJiraIssue || !!selectedLinearIssue}
+                                disabled={
+                                  !isGithubConnected ||
+                                  !!selectedJiraIssue ||
+                                  !!selectedLinearIssue
+                                }
                                 className="w-full"
+                                placeholder={
+                                  isGithubConnected ? 'Select a GitHub issue' : 'Select issue'
+                                }
                               />
+                              {!isGithubConnected && (
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-9 shrink-0 whitespace-nowrap border-border/50 bg-transparent text-muted-foreground hover:border-border hover:bg-muted/50 hover:text-foreground"
+                                  onClick={() => void handleGithubConnect()}
+                                  disabled={githubLoading}
+                                >
+                                  {githubLoading ? (
+                                    <>
+                                      <Spinner size="sm" className="mr-1" />
+                                      Connecting...
+                                    </>
+                                  ) : !githubInstalled ? (
+                                    'Install CLI'
+                                  ) : (
+                                    'Connect'
+                                  )}
+                                </Button>
+                              )}
                             </div>
                           </div>
                           <div className="flex items-start gap-4">
                             <Label htmlFor="jira-issue" className="w-32 shrink-0 pt-2">
                               Jira issue
                             </Label>
-                            <div className="min-w-0 flex-1">
-                              {isJiraConnected ? (
-                                <JiraIssueSelector
-                                  selectedIssue={selectedJiraIssue}
-                                  onIssueChange={(issue) => {
-                                    setSelectedJiraIssue(issue);
-                                    if (issue) {
-                                      setSelectedLinearIssue(null);
-                                      setSelectedGithubIssue(null);
-                                    }
-                                  }}
-                                  isOpen={isOpen}
-                                  disabled={!!selectedLinearIssue || !!selectedGithubIssue}
-                                  className="w-full"
-                                />
-                              ) : (
-                                <TooltipProvider delayDuration={150}>
-                                  <Tooltip>
-                                    <TooltipTrigger asChild>
-                                      <div className="w-full">
-                                        <JiraIssueSelector
-                                          selectedIssue={null}
-                                          onIssueChange={() => {}}
-                                          isOpen={isOpen}
-                                          disabled
-                                          className="w-full"
-                                        />
-                                      </div>
-                                    </TooltipTrigger>
-                                    <TooltipContent
-                                      side="top"
-                                      align="start"
-                                      className="max-w-xs text-left"
-                                    >
-                                      <div className="flex items-center gap-2 pb-1">
-                                        <Badge className="inline-flex items-center gap-1.5">
-                                          <img src={jiraLogo} alt="Jira" className="h-3.5 w-3.5" />
-                                          <span>Connect Jira</span>
-                                        </Badge>
-                                      </div>
-                                      <p className="text-xs text-muted-foreground">
-                                        Add your Jira site, email, and API token in Settings →
-                                        Integrations to browse and attach issues here.
-                                      </p>
-                                    </TooltipContent>
-                                  </Tooltip>
-                                </TooltipProvider>
+                            <div className="flex min-w-0 flex-1 items-center gap-2">
+                              <JiraIssueSelector
+                                selectedIssue={selectedJiraIssue}
+                                onIssueChange={(issue) => {
+                                  setSelectedJiraIssue(issue);
+                                  if (issue) {
+                                    setSelectedLinearIssue(null);
+                                    setSelectedGithubIssue(null);
+                                  }
+                                }}
+                                isOpen={isOpen}
+                                disabled={
+                                  !isJiraConnected ||
+                                  !!selectedLinearIssue ||
+                                  !!selectedGithubIssue
+                                }
+                                className="w-full"
+                                placeholder={
+                                  isJiraConnected ? 'Select a Jira issue' : 'Select issue'
+                                }
+                              />
+                              {!isJiraConnected && (
+                                <Button
+                                  type="button"
+                                  size="sm"
+                                  variant="outline"
+                                  className="h-9 shrink-0 whitespace-nowrap border-border/50 bg-transparent text-muted-foreground hover:border-border hover:bg-muted/50 hover:text-foreground"
+                                  onClick={() => setJiraSetupOpen(true)}
+                                >
+                                  Connect
+                                </Button>
                               )}
                             </div>
+                            <AnimatePresence>
+                              {jiraSetupOpen ? (
+                                <motion.div
+                                  className="fixed inset-0 z-[130] flex items-center justify-center px-3"
+                                  initial={{ opacity: 0 }}
+                                  animate={{ opacity: 1 }}
+                                  exit={{ opacity: 0 }}
+                                  onClick={() => setJiraSetupOpen(false)}
+                                >
+                                  <div className="absolute inset-0 bg-black/60 backdrop-blur-sm" />
+                                  <motion.div
+                                    className="relative z-10 w-full max-w-md rounded-xl border border-border/70 bg-background/95 p-4 shadow-2xl backdrop-blur-sm"
+                                    initial={{ opacity: 0, scale: 0.95 }}
+                                    animate={{ opacity: 1, scale: 1 }}
+                                    exit={{ opacity: 0, scale: 0.95 }}
+                                    transition={{ duration: shouldReduceMotion ? 0 : 0.15 }}
+                                    onClick={(event) => event.stopPropagation()}
+                                  >
+                                    <JiraSetupForm
+                                      site={jiraSite}
+                                      email={jiraEmail}
+                                      token={jiraToken}
+                                      onChange={(u) => {
+                                        if (typeof u.site === 'string') setJiraSite(u.site);
+                                        if (typeof u.email === 'string') setJiraEmail(u.email);
+                                        if (typeof u.token === 'string') setJiraToken(u.token);
+                                      }}
+                                      onClose={() => setJiraSetupOpen(false)}
+                                      canSubmit={!!(jiraSite.trim() && jiraEmail.trim() && jiraToken.trim())}
+                                      error={jiraConnectionError}
+                                      onSubmit={() => void handleJiraConnect()}
+                                    />
+                                  </motion.div>
+                                </motion.div>
+                              ) : null}
+                            </AnimatePresence>
                           </div>
                         </div>
                         <div className="flex items-start gap-4 p-2">

--- a/src/renderer/components/integrations/LinearSetupForm.tsx
+++ b/src/renderer/components/integrations/LinearSetupForm.tsx
@@ -1,0 +1,83 @@
+import React from 'react';
+import { Input } from '../ui/input';
+import { Info } from 'lucide-react';
+import linearLogo from '../../../assets/images/linear-icon.png';
+
+interface Props {
+  apiKey: string;
+  onChange: (value: string) => void;
+  onSubmit: () => void | Promise<void>;
+  onClose: () => void;
+  canSubmit: boolean;
+  error?: string | null;
+}
+
+const LinearSetupForm: React.FC<Props> = ({
+  apiKey,
+  onChange,
+  onSubmit,
+  onClose,
+  canSubmit,
+  error,
+}) => {
+  return (
+    <div className="w-full">
+      <div className="flex items-center gap-2">
+        <span className="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-muted/40 px-2 py-0.5 text-xs font-medium">
+          <img src={linearLogo} alt="Linear" className="h-3.5 w-3.5" />
+          Linear setup
+        </span>
+        <span className="text-xs text-muted-foreground">
+          Connect to Linear by entering an API key.
+        </span>
+      </div>
+      <div className="mt-2 grid gap-2">
+        <Input
+          type="password"
+          placeholder="Linear API key"
+          value={apiKey}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange(e.target.value)}
+          className="h-8 w-full"
+          aria-label="Linear API key"
+        />
+      </div>
+      <div className="mt-2 rounded-md border border-dashed border-border/70 bg-muted/40 p-2">
+        <div className="flex items-start gap-2">
+          <Info className="mt-0.5 h-4 w-4 text-muted-foreground" aria-hidden="true" />
+          <div className="text-xs leading-snug text-muted-foreground">
+            <p className="font-medium text-foreground">How to get a Linear API key</p>
+            <ol className="mt-1 list-decimal pl-4">
+              <li>Open Linear, go to Settings → API Tokens.</li>
+              <li>Create a new token and copy the key.</li>
+            </ol>
+          </div>
+        </div>
+      </div>
+      {error ? (
+        <p className="mt-2 text-xs text-red-600" role="alert">
+          {error}
+        </p>
+      ) : null}
+      <div className="mt-3 flex justify-end gap-2">
+        <button
+          type="button"
+          className="inline-flex h-8 items-center justify-center rounded-md border border-border/70 bg-background px-2.5 text-xs font-medium"
+          onClick={onClose}
+        >
+          Close
+        </button>
+        <button
+          type="button"
+          className="inline-flex h-8 items-center justify-center rounded-md border border-border/70 bg-background px-2.5 text-xs font-medium disabled:opacity-60"
+          onClick={() => void onSubmit()}
+          disabled={!canSubmit}
+        >
+          Connect
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default LinearSetupForm;
+


### PR DESCRIPTION
## Add inline connection buttons for integrations in workspace modal (While creating New Task)

Allows users to connect Linear, GitHub, and Jira directly from the workspace creation modal without navigating to Settings.

**Before:**

<img width="547" height="806" alt="image" src="https://github.com/user-attachments/assets/05c54c30-e3ed-447e-9d6f-ba4dbd5f77ad" />


**After:**

<img width="549" height="781" alt="image" src="https://github.com/user-attachments/assets/b58809a5-c909-43bb-97b6-ab553112e80f" />
--
<img width="530" height="305" alt="image" src="https://github.com/user-attachments/assets/526df734-4988-4375-94a5-554b2a00b2e6" />


**Changes:**
- Added "Connect" buttons next to issue selectors when integrations are disconnected
- Created `LinearSetupForm` component for inline Linear connection
- Added `placeholder` prop to all issue selectors
- Implemented connection handlers for all three integrations
- Added Jira setup popup matching Linear pattern
- Auto-opens Linear selector after successful connection

**UI/UX:**
- Connection actions are always visible (no hover required)
- Consistent pattern across all three integrations
- Placeholder text: "Select issue" (disconnected) → "Select a [Service] issue" (connected)
- Subtle button styling that doesn't clutter the interface

**Testing:**
- ✅ Linear, GitHub, and Jira connection flows work
- ✅ Placeholder text updates correctly
- ✅ Connect buttons appear/disappear based on status
- ✅ Auto-open Linear selector works after connection