### PR TITLE
Add task creation CTAs to kanban

### DIFF
--- a/src/renderer/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/components/kanban/KanbanBoard.tsx
@@ -280,6 +280,19 @@ const KanbanBoard: React.FC<{
           title={titles[s]}
           count={byStatus[s].length}
           onDropCard={(id) => handleDrop(s, id)}
+          action={
+            s === 'todo' && onCreateWorkspace ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 rounded-md border border-border/60 bg-muted text-foreground shadow-sm hover:bg-muted/80"
+                onClick={onCreateWorkspace}
+                aria-label="Start New Task"
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            ) : undefined
+          }
         >
           {byStatus[s].length === 0 ? (
             s === 'todo' && !hasAny && onCreateWorkspace ? (
@@ -291,9 +304,9 @@ const KanbanBoard: React.FC<{
                   <span className="ml-2">No items</span>
                 </div>
                 <div className="flex flex-1 items-center justify-center">
-                  <Button variant="secondary" size="sm" onClick={onCreateWorkspace}>
+                  <Button variant="default" size="sm" onClick={onCreateWorkspace}>
                     <Plus className="mr-1.5 h-3.5 w-3.5" />
-                    Create Task
+                    Start New Task
                   </Button>
                 </div>
               </div>
@@ -306,7 +319,22 @@ const KanbanBoard: React.FC<{
               </div>
             )
           ) : (
-            byStatus[s].map((ws) => <KanbanCard key={ws.id} ws={ws} onOpen={onOpenWorkspace} />)
+            <>
+              {byStatus[s].map((ws) => (
+                <KanbanCard key={ws.id} ws={ws} onOpen={onOpenWorkspace} />
+              ))}
+              {s === 'todo' && onCreateWorkspace ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-1 w-full justify-center text-xs font-medium"
+                  onClick={onCreateWorkspace}
+                >
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  Start New Task
+                </Button>
+              ) : null}
+            </>
           )}
         </KanbanColumn>
       ))}

--- a/src/renderer/components/kanban/KanbanColumn.tsx
+++ b/src/renderer/components/kanban/KanbanColumn.tsx
@@ -5,14 +5,18 @@ const KanbanColumn: React.FC<{
   count: number;
   onDropCard: (workspaceId: string) => void;
   children: React.ReactNode;
-}> = ({ title, count, onDropCard, children }) => {
+  action?: React.ReactNode;
+}> = ({ title, count, onDropCard, children, action }) => {
   return (
     <div className="flex min-h-0 flex-col rounded-xl border border-border bg-background shadow-sm">
       <div className="flex items-center justify-between border-b border-border px-3 py-2 text-sm font-medium">
-        <span>{title}</span>
-        <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted/50 px-1.5 text-[11px]">
-          {count}
-        </span>
+        <div className="flex items-center gap-2">
+          <span>{title}</span>
+          <span className="inline-flex h-5 min-w-5 items-center justify-center rounded-full bg-muted/50 px-1.5 text-[11px]">
+            {count}
+          </span>
+        </div>
+        {action ? <div className="shrink-0">{action}</div> : null}
       </div>
       <div
         className="min-h-0 flex-1 space-y-2 overflow-auto p-2"


### PR DESCRIPTION
Summary:
- Add a compact add-task button to the To-do column header for quick entry.
- Add a footer “Start New Task” CTA within the To-do column to support add-while-scanning.
- Refresh the empty-state CTA in To-do to use the primary label/style for consistency.

**After**
<img width="781" height="297" alt="image" src="https://github.com/user-attachments/assets/995dd8f2-ade8-4f5c-8a30-2ce119181c7e" />
