### PR TITLE
Fix theme shortcut modifier handling

### DIFF
--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -108,7 +108,8 @@ export function hasShortcutConflict(shortcut1: ShortcutConfig, shortcut2: Shortc
   );
 }
 
-const isMacPlatform = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+const isMacPlatform =
+  typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
 function matchesModifier(modifier: ShortcutModifier | undefined, event: KeyboardEvent): boolean {
   if (!modifier) {


### PR DESCRIPTION
Why: Ctrl+T is needed in the Claude CLI; it shouldn’t toggle app theme on macOS. Command + T still triggers theme-change as intended.

What: Make shortcut modifier matching platform-aware so Cmd+T requires Command on macOS; Ctrl remains Cmd-equivalent on non-macOS.

Impact: Prevents accidental theme toggles; no other shortcuts changed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Make keyboard shortcut modifier matching platform-aware, requiring Command on macOS and allowing Ctrl as Command-equivalent elsewhere to avoid unintended triggers.
> 
> - **Shortcuts (renderer/hooks/useKeyboardShortcuts.ts)**:
>   - Add platform-aware modifier detection (`isMacPlatform`, `matchesModifier`) and use it in keydown handling to precisely validate modifiers.
>   - Distinguish `Cmd` vs `Ctrl` on macOS (require Command), while allowing `Ctrl` as Command-equivalent on non-macOS.
>   - Prevent unintended triggers (e.g., theme toggle) when only `Ctrl` is pressed on macOS.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 738edf339e6d2abb4dbf0c1b7df56778ae84d9a3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->