### PR TITLE
Add GitHub multi-account management

### DIFF
--- a/drizzle/0002_add_github_accounts.sql
+++ b/drizzle/0002_add_github_accounts.sql
@@ -1,0 +1,17 @@
+-- Migration for github_accounts table
+CREATE TABLE IF NOT EXISTS "github_accounts" (
+	"id" text PRIMARY KEY NOT NULL,
+	"login" text NOT NULL,
+	"name" text NOT NULL,
+	"email" text DEFAULT '',
+	"avatar_url" text NOT NULL,
+	"is_default" integer DEFAULT false NOT NULL,
+	"is_active" integer DEFAULT false NOT NULL,
+	"created_at" text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" text DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+-- Create indexes
+CREATE UNIQUE INDEX IF NOT EXISTS "idx_github_accounts_login" ON "github_accounts" ("login");
+CREATE INDEX IF NOT EXISTS "idx_github_accounts_default" ON "github_accounts" ("is_default");
+CREATE INDEX IF NOT EXISTS "idx_github_accounts_active" ON "github_accounts" ("is_active");

--- a/src/main/db/path.ts
+++ b/src/main/db/path.ts
@@ -10,7 +10,9 @@ export interface ResolveDatabasePathOptions {
 }
 
 export function resolveDatabasePath(options: ResolveDatabasePathOptions = {}): string {
-  const userDataPath = options.userDataPath ?? app.getPath('userData');
+  const userDataPath =
+    options.userDataPath ??
+    (typeof app?.getPath === 'function' ? app.getPath('userData') : process.cwd());
 
   const currentPath = join(userDataPath, CURRENT_DB_FILENAME);
   if (existsSync(currentPath)) {
@@ -38,7 +40,7 @@ export const databaseFilenames = {
 };
 
 export function resolveMigrationsPath(): string | null {
-  const appPath = app.getAppPath();
+  const appPath = typeof app?.getAppPath === 'function' ? app.getAppPath() : process.cwd();
   const resourcesPath = process.resourcesPath ?? appPath;
   const candidates = [
     join(appPath, 'drizzle'),

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -89,6 +89,30 @@ export const messages = sqliteTable(
   })
 );
 
+export const githubAccounts = sqliteTable(
+  'github_accounts',
+  {
+    id: text('id').primaryKey(),
+    login: text('login').notNull(),
+    name: text('name').notNull(),
+    email: text('email').notNull().default(''),
+    avatar_url: text('avatar_url').notNull(),
+    isDefault: integer('is_default', { mode: 'boolean' }).notNull().default(false),
+    isActive: integer('is_active', { mode: 'boolean' }).notNull().default(false),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    loginIdx: uniqueIndex('idx_github_accounts_login').on(table.login),
+    defaultIdx: index('idx_github_accounts_default').on(table.isDefault),
+    activeIdx: index('idx_github_accounts_active').on(table.isActive),
+  })
+);
+
 export const projectsRelations = relations(projects, ({ many }) => ({
   workspaces: many(workspaces),
 }));
@@ -120,3 +144,4 @@ export type ProjectRow = typeof projects.$inferSelect;
 export type WorkspaceRow = typeof workspaces.$inferSelect;
 export type ConversationRow = typeof conversations.$inferSelect;
 export type MessageRow = typeof messages.$inferSelect;
+export type GithubAccountRow = typeof githubAccounts.$inferSelect;

--- a/src/main/ipc/githubIpc.ts
+++ b/src/main/ipc/githubIpc.ts
@@ -333,4 +333,61 @@ export function registerGithubIpc() {
       };
     }
   });
+
+  // Multi-account support handlers
+
+  // Get all stored GitHub accounts
+  ipcMain.handle('github:getAccounts', async () => {
+    try {
+      const accounts = await githubService.getGithubAccounts();
+      return { success: true, accounts };
+    } catch (error) {
+      log.error('Failed to get GitHub accounts:', error);
+      return { success: false, error: 'Failed to get accounts' };
+    }
+  });
+
+  // Get the currently active GitHub account
+  ipcMain.handle('github:getActiveAccount', async () => {
+    try {
+      const account = await githubService.getActiveGithubAccount();
+      return { success: true, account };
+    } catch (error) {
+      log.error('Failed to get active GitHub account:', error);
+      return { success: false, error: 'Failed to get active account' };
+    }
+  });
+
+  // Switch to a different GitHub account
+  ipcMain.handle('github:switchAccount', async (_, accountId: string) => {
+    try {
+      const result = await githubService.switchToGithubAccount(accountId);
+      return result;
+    } catch (error) {
+      log.error('Failed to switch GitHub account:', error);
+      return { success: false, error: 'Failed to switch account' };
+    }
+  });
+
+  // Remove a GitHub account
+  ipcMain.handle('github:removeAccount', async (_, accountId: string) => {
+    try {
+      const result = await githubService.removeGithubAccount(accountId);
+      return result;
+    } catch (error) {
+      log.error('Failed to remove GitHub account:', error);
+      return { success: false, error: 'Failed to remove account' };
+    }
+  });
+
+  // Set default GitHub account
+  ipcMain.handle('github:setDefaultAccount', async (_, accountId: string) => {
+    try {
+      const result = await githubService.setDefaultGithubAccount(accountId);
+      return result;
+    } catch (error) {
+      log.error('Failed to set default GitHub account:', error);
+      return { success: false, error: 'Failed to set default account' };
+    }
+  });
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -207,7 +207,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on('github:auth:slow-down', listener);
     return () => ipcRenderer.removeListener('github:auth:slow-down', listener);
   },
-  onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => {
+  onGithubAuthSuccess: (callback: (data: { token: string; user: any; account?: any }) => void) => {
     const listener = (_: any, data: any) => callback(data);
     ipcRenderer.on('github:auth:success', listener);
     return () => ipcRenderer.removeListener('github:auth:success', listener);
@@ -247,6 +247,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   githubLogout: () => ipcRenderer.invoke('github:logout'),
   githubCheckCLIInstalled: () => ipcRenderer.invoke('github:checkCLIInstalled'),
   githubInstallCLI: () => ipcRenderer.invoke('github:installCLI'),
+
+  // Multi-account GitHub support
+  githubGetAccounts: () => ipcRenderer.invoke('github:getAccounts'),
+  githubGetActiveAccount: () => ipcRenderer.invoke('github:getActiveAccount'),
+  githubSwitchAccount: (accountId: string) => ipcRenderer.invoke('github:switchAccount', accountId),
+  githubRemoveAccount: (accountId: string) => ipcRenderer.invoke('github:removeAccount', accountId),
+  githubSetDefaultAccount: (accountId: string) => ipcRenderer.invoke('github:setDefaultAccount', accountId),
   // GitHub issues
   githubIssuesList: (projectPath: string, limit?: number) =>
     ipcRenderer.invoke('github:issues:list', projectPath, limit),
@@ -587,7 +594,9 @@ export interface ElectronAPI {
   ) => () => void;
   onGithubAuthPolling: (callback: (data: { status: string }) => void) => () => void;
   onGithubAuthSlowDown: (callback: (data: { newInterval: number }) => void) => () => void;
-  onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => () => void;
+  onGithubAuthSuccess: (
+    callback: (data: { token: string; user: any; account?: any }) => void
+  ) => () => void;
   onGithubAuthError: (callback: (data: { error: string; message: string }) => void) => () => void;
   onGithubAuthCancelled: (callback: () => void) => () => void;
   onGithubAuthUserUpdated: (callback: (data: { user: any }) => void) => () => void;

--- a/src/renderer/components/AccountManagerPopup.tsx
+++ b/src/renderer/components/AccountManagerPopup.tsx
@@ -1,0 +1,330 @@
+import React, { useState } from 'react';
+import { Plus, Settings, ExternalLink, Trash2, Star, User, Users } from 'lucide-react';
+import { Button } from './ui/button';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
+import { useToast } from '@/hooks/use-toast';
+
+interface GithubAccount {
+  id: string;
+  login: string;
+  name: string;
+  email: string;
+  avatar_url: string;
+  isDefault: boolean;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+interface AccountManagerPopupProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onAddAccount: () => void;
+  onSwitchAccount: (accountId: string) => Promise<unknown>;
+  onRemoveAccount: (accountId: string) => Promise<unknown>;
+  onSetDefaultAccount: (accountId: string) => Promise<unknown>;
+  onOpenSettings: () => void;
+  accounts: GithubAccount[];
+  activeAccount: GithubAccount | null;
+  isLoading?: boolean;
+}
+
+function AccountManagerPopup({
+  isOpen,
+  onClose,
+  onAddAccount,
+  onSwitchAccount,
+  onRemoveAccount,
+  onSetDefaultAccount,
+  onOpenSettings,
+  accounts,
+  activeAccount,
+  isLoading = false,
+}: AccountManagerPopupProps) {
+  const { toast } = useToast();
+  const [accountToRemove, setAccountToRemove] = useState<string | null>(null);
+
+  const handleSwitchAccount = async (accountId: string) => {
+    if (accountId === activeAccount?.id) return;
+
+    try {
+      await onSwitchAccount(accountId);
+      toast({
+        title: "Account switched",
+        description: `Switched to ${accounts.find(a => a.id === accountId)?.login}`,
+      });
+      onClose();
+    } catch (error) {
+      toast({
+        title: "Failed to switch account",
+        description: "Could not switch to the selected account. Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleRemoveAccount = async (accountId: string) => {
+    const account = accounts.find(a => a.id === accountId);
+    if (!account) return;
+
+    if (accounts.length <= 1) {
+      toast({
+        title: "Cannot remove account",
+        description: "You must have at least one GitHub account connected.",
+        variant: "destructive",
+      });
+      return;
+    }
+
+    setAccountToRemove(accountId);
+  };
+
+  const confirmRemoveAccount = async () => {
+    if (!accountToRemove) return;
+
+    const account = accounts.find(a => a.id === accountToRemove);
+    if (!account) return;
+
+    try {
+      await onRemoveAccount(accountToRemove);
+      toast({
+        title: "Account removed",
+        description: `${account.login} has been removed from your accounts.`,
+      });
+
+      // If we removed the active account, we need to close and let the parent handle the state update
+      if (accountToRemove === activeAccount?.id) {
+        onClose();
+      }
+    } catch (error) {
+      toast({
+        title: "Failed to remove account",
+        description: "Could not remove the account. Please try again.",
+        variant: "destructive",
+      });
+    } finally {
+      setAccountToRemove(null);
+    }
+  };
+
+  const handleSetDefaultAccount = async (accountId: string) => {
+    try {
+      await onSetDefaultAccount(accountId);
+      toast({
+        title: "Default account updated",
+        description: `${accounts.find(a => a.id === accountId)?.login} is now your default account.`,
+      });
+    } catch (error) {
+      toast({
+        title: "Failed to update default",
+        description: "Could not set the default account. Please try again.",
+        variant: "destructive",
+      });
+    }
+  };
+
+  const handleViewProfile = (login: string) => {
+    window.open(`https://github.com/${login}`, '_blank');
+  };
+
+  const renderAccount = (account: GithubAccount, isActive: boolean = false) => (
+    <div
+      key={account.id}
+      className={`p-3 rounded-lg border ${
+        isActive ? 'bg-muted border-primary border-2' : 'hover:bg-muted/50'
+      } transition-colors`}
+    >
+      <div className="flex items-center justify-between mb-2">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">
+            {isActive ? 'Active Account' : account.name}
+          </span>
+          {isActive && (
+            <div className="h-2 w-2 bg-green-500 rounded-full" />
+          )}
+          {account.isDefault && (
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Star className="h-3 w-3 fill-current" />
+              Default
+            </div>
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="h-8 w-8 bg-muted rounded-full flex items-center justify-center">
+            <span className="text-xs font-medium">
+              {account.login.slice(0, 2).toUpperCase()}
+            </span>
+          </div>
+          <div>
+            <div className="flex items-center gap-2">
+              <span className="font-medium text-sm">{account.name}</span>
+            </div>
+            <div className="text-xs text-muted-foreground">@{account.login}</div>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-1">
+          {!isActive && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleSwitchAccount(account.id)}
+              className="h-8 px-2"
+            >
+              Switch
+            </Button>
+          )}
+
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={() => handleViewProfile(account.login)}
+            className="h-8 w-8 p-0"
+            title="View Profile"
+          >
+            <ExternalLink className="h-4 w-4" />
+          </Button>
+
+          {isActive && !account.isDefault && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleSetDefaultAccount(account.id)}
+              className="h-8 w-8 p-0"
+              title="Set as Default"
+            >
+              <Star className="h-4 w-4" />
+            </Button>
+          )}
+
+          {!isActive && accounts.length > 1 && (
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => handleRemoveAccount(account.id)}
+              className="h-8 w-8 p-0 text-destructive hover:text-destructive"
+              title="Remove Account"
+            >
+              <Trash2 className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+
+  return (
+    <>
+      <AlertDialog open={isOpen} onOpenChange={onClose}>
+        <AlertDialogContent className="sm:max-w-md max-h-[80vh] overflow-y-auto">
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <Users className="h-5 w-5" />
+              GitHub Accounts
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              Manage your connected GitHub accounts and switch between them.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          <div className="space-y-4">
+            {/* Active Account */}
+            {activeAccount && renderAccount(activeAccount, true)}
+
+            {/* Other Accounts */}
+            {accounts.length > 1 && (
+              <div className="space-y-2">
+                <h4 className="text-sm font-medium text-muted-foreground">
+                  Other Accounts ({accounts.length - 1})
+                </h4>
+                <div className="space-y-2">
+                  {accounts
+                    .filter(account => account.id !== activeAccount?.id)
+                    .map(account => renderAccount(account, false))}
+                </div>
+              </div>
+            )}
+
+            {/* No Accounts State */}
+            {accounts.length === 0 && !isLoading && (
+              <div className="text-center py-8">
+                <User className="h-12 w-12 mx-auto text-muted-foreground mb-4" />
+                <h3 className="font-medium mb-2">No GitHub Accounts</h3>
+                <p className="text-sm text-muted-foreground mb-4">
+                  Connect your GitHub account to get started with GitHub integration.
+                </p>
+              </div>
+            )}
+
+            {/* Loading State */}
+            {isLoading && (
+              <div className="text-center py-8">
+                <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-primary mx-auto mb-4" />
+                <p className="text-sm text-muted-foreground">Loading accounts...</p>
+              </div>
+            )}
+
+            {/* Actions */}
+            {!isLoading && (
+              <div className="flex gap-2 pt-4 border-t">
+                <Button
+                  variant="outline"
+                  onClick={onAddAccount}
+                  className="flex-1"
+                >
+                  <Plus className="h-4 w-4 mr-2" />
+                  Add Account
+                </Button>
+                <Button
+                  variant="outline"
+                  onClick={onOpenSettings}
+                  className="flex-1"
+                >
+                  <Settings className="h-4 w-4 mr-2" />
+                  Settings
+                </Button>
+              </div>
+            )}
+          </div>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      {/* Remove Account Confirmation */}
+      <AlertDialog open={!!accountToRemove} onOpenChange={() => setAccountToRemove(null)}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Remove GitHub Account?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Are you sure you want to remove {accounts.find(a => a.id === accountToRemove)?.login}?
+              {accounts.find(a => a.id === accountToRemove)?.isDefault && (
+                <span className="block mt-2 text-orange-600">
+                  ⚠️ This is your default account. You'll need to set another account as default.
+                </span>
+              )}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <Button variant="outline" onClick={() => setAccountToRemove(null)}>
+              Cancel
+            </Button>
+            <Button variant="destructive" onClick={confirmRemoveAccount}>
+              Remove Account
+            </Button>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}
+
+export default AccountManagerPopup;

--- a/src/renderer/hooks/useGithubAuth.ts
+++ b/src/renderer/hooks/useGithubAuth.ts
@@ -2,10 +2,24 @@ import { useCallback, useEffect, useState } from 'react';
 
 type GithubUser = any;
 
+type GithubAccount = {
+  id: string;
+  login: string;
+  name: string;
+  email: string;
+  avatar_url: string;
+  isDefault: boolean;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
 type GithubCache = {
   installed: boolean;
   authenticated: boolean;
   user: GithubUser | null;
+  activeAccount: GithubAccount | null;
+  accounts: GithubAccount[];
 } | null;
 
 let cachedGithubStatus: GithubCache = null;
@@ -16,14 +30,28 @@ export function useGithubAuth() {
     () => cachedGithubStatus?.authenticated ?? false
   );
   const [user, setUser] = useState<GithubUser | null>(() => cachedGithubStatus?.user ?? null);
+  const [activeAccount, setActiveAccount] = useState<GithubAccount | null>(
+    () => cachedGithubStatus?.activeAccount ?? null
+  );
+  const [accounts, setAccounts] = useState<GithubAccount[]>(
+    () => cachedGithubStatus?.accounts ?? []
+  );
   const [isLoading, setIsLoading] = useState<boolean>(false);
 
   const syncCache = useCallback(
-    (next: { installed: boolean; authenticated: boolean; user: GithubUser | null }) => {
+    (next: {
+      installed: boolean;
+      authenticated: boolean;
+      user: GithubUser | null;
+      activeAccount: GithubAccount | null;
+      accounts: GithubAccount[];
+    }) => {
       cachedGithubStatus = next;
       setInstalled(next.installed);
       setAuthenticated(next.authenticated);
       setUser(next.user);
+      setActiveAccount(next.activeAccount);
+      setAccounts(next.accounts);
     },
     []
   );
@@ -31,15 +59,33 @@ export function useGithubAuth() {
   const checkStatus = useCallback(async () => {
     try {
       const status = await window.electronAPI.githubGetStatus();
+      const accountsResult = window.electronAPI.githubGetAccounts
+        ? await window.electronAPI.githubGetAccounts()
+        : { success: false };
+      const activeAccountResult = window.electronAPI.githubGetActiveAccount
+        ? await window.electronAPI.githubGetActiveAccount()
+        : { success: false };
+
       const normalized = {
         installed: !!status?.installed,
         authenticated: !!status?.authenticated,
         user: status?.user || null,
+        activeAccount:
+          activeAccountResult?.success && activeAccountResult.account
+            ? activeAccountResult.account
+            : null,
+        accounts: accountsResult?.success ? accountsResult.accounts || [] : [],
       };
       syncCache(normalized);
-      return status;
+      return normalized;
     } catch (e) {
-      const fallback = { installed: false, authenticated: false, user: null };
+      const fallback = {
+        installed: false,
+        authenticated: false,
+        user: null,
+        activeAccount: null,
+        accounts: [],
+      };
       syncCache(fallback);
       return fallback;
     }
@@ -65,22 +111,160 @@ export function useGithubAuth() {
         installed: cachedGithubStatus?.installed ?? true,
         authenticated: false,
         user: null,
+        activeAccount: null,
+        accounts: [],
       });
     }
   }, [syncCache]);
+
+  // Multi-account methods
+  const getAccounts = useCallback(async () => {
+    try {
+      // Check if method is available (for backward compatibility)
+      if (!window.electronAPI.githubGetAccounts) {
+        console.warn('githubGetAccounts method not available, using fallback');
+        return [];
+      }
+
+      const result = await window.electronAPI.githubGetAccounts();
+      if (result.success && result.accounts) {
+        setAccounts(result.accounts);
+        return result.accounts;
+      }
+      return [];
+    } catch (error) {
+      console.error('Failed to get GitHub accounts:', error);
+      return [];
+    }
+  }, []);
+
+  const getActiveAccount = useCallback(async () => {
+    try {
+      // Check if method is available (for backward compatibility)
+      if (!window.electronAPI.githubGetActiveAccount) {
+        console.warn('githubGetActiveAccount method not available, using fallback');
+        return null;
+      }
+
+      const result = await window.electronAPI.githubGetActiveAccount();
+      if (result.success && result.account) {
+        const parsedId = Number.parseInt(result.account.id, 10);
+        const normalizedId = Number.isNaN(parsedId) ? result.account.id : parsedId;
+
+        setActiveAccount(result.account);
+        setUser({
+          id: normalizedId,
+          login: result.account.login,
+          name: result.account.name,
+          email: result.account.email,
+          avatar_url: result.account.avatar_url,
+        });
+        return result.account;
+      }
+      return null;
+    } catch (error) {
+      console.error('Failed to get active GitHub account:', error);
+      return null;
+    }
+  }, []);
+
+  const switchAccount = useCallback(async (accountId: string) => {
+    setIsLoading(true);
+    try {
+      const result = await window.electronAPI.githubSwitchAccount(accountId);
+      if (result.success) {
+        // Update the active account and user
+        await getActiveAccount();
+        await getAccounts();
+        return result;
+      }
+      throw new Error(result.error || 'Failed to switch account');
+    } catch (error) {
+      console.error('Failed to switch GitHub account:', error);
+      throw error;
+    } finally {
+      setIsLoading(false);
+    }
+  }, [getActiveAccount, getAccounts]);
+
+  const removeAccount = useCallback(async (accountId: string) => {
+    try {
+      const result = await window.electronAPI.githubRemoveAccount(accountId);
+      if (result.success) {
+        // Refresh accounts list
+        await getAccounts();
+
+        // If we removed the active account, get the new active one
+        if (activeAccount?.id === accountId) {
+          await getActiveAccount();
+        }
+
+        return result;
+      }
+      throw new Error(result.error || 'Failed to remove account');
+    } catch (error) {
+      console.error('Failed to remove GitHub account:', error);
+      throw error;
+    }
+  }, [activeAccount?.id, getAccounts, getActiveAccount]);
+
+  const setDefaultAccount = useCallback(async (accountId: string) => {
+    try {
+      const result = await window.electronAPI.githubSetDefaultAccount(accountId);
+      if (result.success) {
+        // Refresh accounts list to update default flags
+        await getAccounts();
+        return result;
+      }
+      throw new Error(result.error || 'Failed to set default account');
+    } catch (error) {
+      console.error('Failed to set default GitHub account:', error);
+      throw error;
+    }
+  }, [getAccounts]);
+
+  const refreshAccounts = useCallback(async () => {
+    await Promise.all([
+      getAccounts(),
+      getActiveAccount(),
+    ]);
+  }, [getAccounts, getActiveAccount]);
 
   useEffect(() => {
     if (cachedGithubStatus) return;
     checkStatus();
   }, [checkStatus]);
 
+  // Listen for authentication success events to refresh accounts
+  useEffect(() => {
+    const handleAuthSuccess = () => {
+      refreshAccounts();
+    };
+
+    const unsubscribe = window.electronAPI.onGithubAuthSuccess?.(handleAuthSuccess);
+
+    return () => {
+      unsubscribe?.();
+    };
+  }, [refreshAccounts]);
+
   return {
     installed,
     authenticated,
     user,
+    activeAccount,
+    accounts,
+    hasMultipleAccounts: accounts.length > 1,
     isLoading,
     checkStatus,
     login,
     logout,
+    // Multi-account methods
+    getAccounts,
+    getActiveAccount,
+    switchAccount,
+    removeAccount,
+    setDefaultAccount,
+    refreshAccounts,
   };
 }

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -453,7 +453,9 @@ declare global {
       ) => () => void;
       onGithubAuthPolling: (callback: (data: { status: string }) => void) => () => void;
       onGithubAuthSlowDown: (callback: (data: { newInterval: number }) => void) => () => void;
-      onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => () => void;
+      onGithubAuthSuccess: (
+        callback: (data: { token: string; user: any; account?: any }) => void
+      ) => () => void;
       onGithubAuthError: (
         callback: (data: { error: string; message: string }) => void
       ) => () => void;
@@ -491,6 +493,53 @@ declare global {
         error?: string;
       }>;
       githubLogout: () => Promise<void>;
+
+      // Multi-account GitHub support
+      githubGetAccounts: () => Promise<{
+        success: boolean;
+        accounts?: Array<{
+          id: string;
+          login: string;
+          name: string;
+          email: string;
+          avatar_url: string;
+          isDefault: boolean;
+          isActive: boolean;
+          createdAt: string;
+          updatedAt: string;
+        }>;
+        error?: string;
+      }>;
+      githubGetActiveAccount: () => Promise<{
+        success: boolean;
+        account?: {
+          id: string;
+          login: string;
+          name: string;
+          email: string;
+          avatar_url: string;
+          isDefault: boolean;
+          isActive: boolean;
+          createdAt: string;
+          updatedAt: string;
+        };
+        error?: string;
+      }>;
+      githubSwitchAccount: (accountId: string) => Promise<{
+        success: boolean;
+        token?: string;
+        user?: any;
+        error?: string;
+      }>;
+      githubRemoveAccount: (accountId: string) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      githubSetDefaultAccount: (accountId: string) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+
       // Linear integration
       linearCheckConnection?: () => Promise<{
         connected: boolean;
@@ -804,7 +853,9 @@ export interface ElectronAPI {
   ) => () => void;
   onGithubAuthPolling: (callback: (data: { status: string }) => void) => () => void;
   onGithubAuthSlowDown: (callback: (data: { newInterval: number }) => void) => () => void;
-  onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => () => void;
+  onGithubAuthSuccess: (
+    callback: (data: { token: string; user: any; account?: any }) => void
+  ) => () => void;
   onGithubAuthError: (callback: (data: { error: string; message: string }) => void) => () => void;
   onGithubAuthCancelled: (callback: () => void) => () => void;
   onGithubAuthUserUpdated: (callback: (data: { user: any }) => void) => () => void;


### PR DESCRIPTION
 - add GitHub accounts schema/migration and ensure the accounts table is created automatically
 - store tokens per GitHub login, migrate legacy/gh CLI sessions, and expose IPC/preload handlers for listing/switching/removing accounts
 - add a sidebar account manager UI and multi-account-aware auth hook