### PR TITLE
Update README to simplify coding agents description

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 <br />
 
-**Run multiple coding agents in parallel—provider-agnostic, worktree-isolated, and local-first.**
+**Run multiple coding agents in parallel**
 
 Emdash lets you develop and test multiple features with multiple agents in parallel. It’s provider-agnostic (we support 15+ CLIs, such as Claude Code, Qwen Code, Amp, and Codex) and runs each agent in its own Git worktree to keep changes clean; Hand off Linear, GitHub, or Jira tickets to an agent and review diffs side-by-side.
 


### PR DESCRIPTION
Update README to simplify coding agents description

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Shortens the README tagline to just “Run multiple coding agents in parallel.”
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11f64ef45b547039dc5e4f95992fbd4e63fab372. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->