### PR TITLE
feat: move Add Task button to top of sidebar dropdown

### DIFF
--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -222,7 +222,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                   className="flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
                   aria-label={githubProfileUrl ? 'Open GitHub profile' : 'Connect GitHub'}
                 >
-                  {githubAuthenticated ? (
+                  {githubProfileUrl ? (
                     <img
                       src={githubLogo}
                       alt="GitHub"


### PR DESCRIPTION
**Why**: Users had to scroll to the bottom of each project's task dropdown to access the "+ Add Task" button, which was inconvenient when projects had many tasks.

**What**: Moved the "+ Add Task" button to the top of the project dropdown in the left sidebar. The button now appears in a sticky container above the task list, making it always visible and easily accessible without scrolling.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a collapsible rail-style left sidebar with project badges and GitHub control, and moves "+ Add Task" to a sticky header at the top of each project's dropdown.
> 
> - **UI — Left Sidebar**:
>   - **Collapsible behavior**: Adds open/close controls and a compact rail view with project initial badges, workspace counts, and tooltips.
>   - **Projects dropdown**: Moves `+ Add Task` to a sticky header at the top of each project's list for quick access.
>   - **GitHub control**: Adds a rail-bottom GitHub button (opens profile or triggers connect) and uses logo/icon accordingly.
>   - **Cleanup/Icons**: Removes obsolete toggle component and adds tooltip components and new icons.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 46f1e5822f9870b9411c30d5c0182bab5e883b21. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->