### PR TITLE
Fix: Preserve terminal scroll position when switching tasks and resiz…

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -474,7 +474,7 @@ export class TerminalSessionManager {
       if (snapshot.cols && snapshot.rows) {
         this.terminal.resize(snapshot.cols, snapshot.rows);
       }
-      
+
       // Note: Viewport position restoration happens in attach() after terminal is opened
       // This ensures the terminal is fully initialized before we try to scroll
     } catch (error) {


### PR DESCRIPTION
# Fix: Preserve Terminal Scroll Position When Switching Tasks and Resizing Sidebars

## Problem

Terminal viewport jumps to top when:
- Switching between tasks/workspaces
- Resizing left/right sidebars

Users lose their scroll position and have to manually scroll back down.

## Solution

- **Capture scroll position** when terminal detaches (task switch) or before resize
- **Restore scroll position** after terminal is fully rendered using `requestAnimationFrame`
- **Store positions** in memory per terminal ID for persistence

## Changes

- Added viewport position capture/restore methods
- Updated `fitPreservingViewport()` to wait for rendering before restoring position
- Integrated into terminal lifecycle (attach/detach)

## Testing

1. Scroll CLI terminal
2. Switch tasks or resize sidebars
3. ✅ Terminal maintains scroll position (no jump to top) also not when sidebars are opened or closed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Preserves terminal scroll position across task switches and container resizes by capturing/restoring viewport and using a fit that avoids jumps.
> 
> - **Renderer/Terminal (`src/renderer/terminal/TerminalSessionManager.ts`)**:
>   - Add in-memory `viewportPositions` map keyed by terminal ID.
>   - Replace direct `fitAddon.fit()` calls with `fitPreservingViewport()` to maintain scroll position using `requestAnimationFrame`.
>   - On `detach()`: capture current viewport offset; on `attach()`: restore viewport after rendering (double `requestAnimationFrame`).
>   - Use preserving fit in `ResizeObserver` to prevent jumps during container/sidebars resize; send size after fitting.
>   - Clean up stored viewport data on `dispose()`.
>   - Note: viewport restoration occurs post-snapshot, after terminal is opened.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 76cd3bc3eba000654011fa1a2024dcca7b21b339. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->