### PR TITLE
Sanitize auto-updater errors to prevent noisy terminal output

### DIFF
--- a/src/main/lib/updaterError.ts
+++ b/src/main/lib/updaterError.ts
@@ -1,0 +1,29 @@
+// Utilities to keep updater errors/logs concise and scrub HTML bodies.
+export function stripMarkupAndTruncate(raw: string): string {
+  if (!raw) return 'Unknown update error';
+
+  const withoutData = raw.includes('Data:') ? raw.slice(0, raw.indexOf('Data:')) : raw;
+  const noHtml = withoutData.replace(/<!DOCTYPE html.*$/is, '').replace(/<html.*$/is, '');
+  const collapsed = noHtml.replace(/\s+/g, ' ').trim();
+  if (!collapsed) return 'Unknown update error';
+  return collapsed.length > 240 ? `${collapsed.slice(0, 240)}…` : collapsed;
+}
+
+export function formatUpdaterError(error: any): string {
+  const status = error?.statusCode || error?.code || error?.status;
+  const statusText = error?.statusMessage || error?.description;
+  if (status) {
+    const base = `Update request failed with HTTP ${status}`;
+    return statusText ? `${base}: ${stripMarkupAndTruncate(String(statusText))}` : base;
+  }
+  const message = error instanceof Error ? error.message : String(error ?? 'Unknown update error');
+  return stripMarkupAndTruncate(message);
+}
+
+export function sanitizeUpdaterLogArgs(args: any[]) {
+  return args.map((arg) => {
+    if (arg instanceof Error) return formatUpdaterError(arg);
+    if (typeof arg === 'string') return stripMarkupAndTruncate(arg);
+    return arg;
+  });
+}


### PR DESCRIPTION
- Problem: auto-updater printed full HTML bodies (e.g., GitHub 503 Unicorn page) to the terminal and UI when updates failed.
- Fix: add shared updater error sanitizers and wire autoUpdater logger/error handling to use them; IPC responses now return concise messages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds utilities to strip/truncate HTML-heavy updater errors and wires autoUpdater logging and IPC error responses to use them.
> 
> - **Updater error handling**:
>   - **New utilities** (`src/main/lib/updaterError.ts`): `stripMarkupAndTruncate`, `formatUpdaterError`, `sanitizeUpdaterLogArgs` to scrub HTML and truncate messages.
>   - **Logging**: Routes `autoUpdater.logger` through app `log` with sanitized args to reduce noisy console output.
>   - **IPC/error responses** (`src/main/services/updateIpc.ts`): Uses `formatUpdaterError` for `autoUpdater` error event and IPC handlers (`update:check`, `update:download`, `update:quit-and-install`) to return concise messages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 47f633118a248a498f073cfb3525eea32beffaea. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->