### PR TITLE
fix: eliminate terminal scroll delay on workspace switch

### DIFF
--- a/src/renderer/hooks/useAutoScrollOnWorkspaceSwitch.ts
+++ b/src/renderer/hooks/useAutoScrollOnWorkspaceSwitch.ts
@@ -43,7 +43,7 @@ export function useAutoScrollOnWorkspaceSwitch(isActive: boolean, workspaceId: s
       container.scrollTo({
         top: container.scrollHeight,
         left: 0,
-        behavior: 'smooth',
+        behavior: 'instant',
       });
       scrolledAny = true;
     });
@@ -69,7 +69,7 @@ export function useAutoScrollOnWorkspaceSwitch(isActive: boolean, workspaceId: s
 
       // Delay scroll to allow content to render
       scrollTimeoutRef.current = setTimeout(() => {
-        scrollToBottom({ onlyIfNearTop: true });
+        scrollToBottom({ onlyIfNearTop: false });
       }, 200);
     }
 

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -39,6 +39,10 @@ class SessionRegistry {
     this.sessions.delete(workspaceId);
   }
 
+  getSession(workspaceId: string): TerminalSessionManager | undefined {
+    return this.sessions.get(workspaceId);
+  }
+
   disposeAll() {
     for (const id of Array.from(this.sessions.keys())) {
       this.dispose(id);

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -230,6 +230,14 @@ export class TerminalSessionManager {
     this.terminal.focus();
   }
 
+  scrollToBottom() {
+    try {
+      this.terminal.scrollToBottom();
+    } catch (error) {
+      log.warn('Failed to scroll to bottom', { id: this.id, error });
+    }
+  }
+
   registerActivityListener(listener: () => void): () => void {
     this.activityListeners.add(listener);
     return () => {
@@ -444,6 +452,11 @@ export class TerminalSessionManager {
           this.terminal.refresh(0, this.terminal.rows - 1);
         } catch {}
       }
+      // Auto-scroll to bottom when new data arrives
+      // This ensures users always see the latest output, especially when the agent is waiting for input
+      try {
+        this.terminal.scrollToBottom();
+      } catch {}
     });
 
     const offExit = window.electronAPI.onPtyExit(id, (info) => {


### PR DESCRIPTION
- Change scroll behavior from 'smooth' to 'instant' (removes 10-20s animation for long claude code threads)
- Remove onlyIfNearTop restriction to always scroll to bottom
- Auto-scroll to bottom on new PTY data to keep view at latest output