### PR TITLE
Keep provider CLI startup clean and return to shell after exit

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -33,7 +33,8 @@ export function startPty(options: {
   }
   const { id, cwd, shell, env, cols = 80, rows = 24, autoApprove, initialPrompt } = options;
 
-  let useShell = shell || getDefaultShell();
+  const defaultShell = getDefaultShell();
+  let useShell = shell || defaultShell;
   const useCwd = cwd || process.cwd() || os.homedir();
   const useEnv = {
     TERM: 'xterm-256color',
@@ -98,29 +99,54 @@ export function startPty(options: {
     throw new Error(`PTY unavailable: ${e?.message || String(e)}`);
   }
 
-  // Provide sensible defaults for interactive shells so they render prompts
+  // Provide sensible defaults for interactive shells so they render prompts.
+  // For provider CLIs, spawn the user's shell and run the provider command via -c,
+  // then exec back into the shell to allow users to stay in a normal prompt after exiting the agent.
   const args: string[] = [];
   if (process.platform !== 'win32') {
     try {
       const base = String(useShell).split('/').pop() || '';
-
       const baseLower = base.toLowerCase();
       const provider = PROVIDERS.find((p) => p.cli === baseLower);
 
       if (provider) {
-        args.length = 0;
+        // Build the provider command with flags
+        const cliArgs: string[] = [];
         if (provider.defaultArgs?.length) {
-          args.push(...provider.defaultArgs);
+          cliArgs.push(...provider.defaultArgs);
         }
         if (autoApprove && provider.autoApproveFlag) {
-          args.push(provider.autoApproveFlag);
+          cliArgs.push(provider.autoApproveFlag);
         }
         if (provider.initialPromptFlag !== undefined && initialPrompt?.trim()) {
           if (provider.initialPromptFlag) {
-            args.push(provider.initialPromptFlag);
+            cliArgs.push(provider.initialPromptFlag);
           }
-          args.push(initialPrompt.trim());
+          cliArgs.push(initialPrompt.trim());
         }
+
+        const cliCommand = provider.cli || baseLower;
+        const commandString =
+          cliArgs.length > 0
+            ? `${cliCommand} ${cliArgs
+                .map((arg) =>
+                  /[\s'"\\$`\n\r\t]/.test(arg) ? `'${arg.replace(/'/g, "'\\''")}'` : arg
+                )
+                .join(' ')}`
+            : cliCommand;
+
+        // After the provider exits, exec back into the user's shell (login+interactive)
+        const resumeShell = `'${defaultShell.replace(/'/g, "'\\''")}' -il`;
+        const chainCommand = `${commandString}; exec ${resumeShell}`;
+
+        // Always use the default shell for the -c command to avoid re-detecting provider CLI
+        useShell = defaultShell;
+        const shellBase = defaultShell.split('/').pop() || '';
+        if (shellBase === 'zsh') args.push('-lic', chainCommand);
+        else if (shellBase === 'bash') args.push('-lic', chainCommand);
+        else if (shellBase === 'fish') args.push('-ic', chainCommand);
+        else if (shellBase === 'sh') args.push('-lc', chainCommand);
+        else args.push('-c', chainCommand); // Fallback for other shells
       } else {
         // For normal shells, use login + interactive to load user configs
         if (base === 'zsh') args.push('-il');


### PR DESCRIPTION
adding the ability for the user to exit a CLI agent application within a workspace to run shell commands in the worktree and then re-opening CLI agent of choice manually. 