### PR TITLE
chore: Capitalize Emdash branding in the app

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to emdash
+# Contributing to Emdash
 
 Thanks for your interest in contributing! We favor small, focused PRs and clear intent over big bangs. This guide explains how to get set up, the workflow we use, and a few project‑specific conventions.
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,4 +1,4 @@
-# emdash
+# Emdash
 
 This is a Tanstack Start application generated with
 [Create Fumadocs](https://github.com/fuma-nama/fumadocs).

--- a/src/main/app/window.ts
+++ b/src/main/app/window.ts
@@ -18,7 +18,7 @@ export function createMainWindow(): BrowserWindow {
     height: 900,
     minWidth: 1200,
     minHeight: 800,
-    title: 'emdash',
+    title: 'Emdash',
     ...(iconPath && { icon: iconPath }),
     webPreferences: {
       nodeIntegration: false,

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -111,7 +111,7 @@ import * as telemetry from './telemetry';
 import { join } from 'path';
 
 // Set app name for macOS dock and menu bar (especially important in dev mode)
-app.setName('emdash');
+app.setName('Emdash');
 
 // Set dock icon on macOS in development mode
 if (process.platform === 'darwin' && !app.isPackaged) {

--- a/src/main/services/WorktreeService.ts
+++ b/src/main/services/WorktreeService.ts
@@ -511,7 +511,7 @@ export class WorktreeService {
     const settings = await projectSettingsService.getProjectSettings(projectId);
     if (!settings) {
       throw new Error(
-        'Project settings not found. Please re-open the project in emdash and try again.'
+        'Project settings not found. Please re-open the project in Emdash and try again.'
       );
     }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -576,10 +576,10 @@ const AppContent: React.FC = () => {
             } else {
               const updateHint =
                 platform === 'darwin'
-                  ? 'Tip: Update GitHub CLI with: brew upgrade gh — then restart emdash.'
+                  ? 'Tip: Update GitHub CLI with: brew upgrade gh — then restart Emdash.'
                   : platform === 'win32'
-                    ? 'Tip: Update GitHub CLI with: winget upgrade GitHub.cli — then restart emdash.'
-                    : 'Tip: Update GitHub CLI via your package manager (e.g., apt/dnf) and restart emdash.';
+                    ? 'Tip: Update GitHub CLI with: winget upgrade GitHub.cli — then restart Emdash.'
+                    : 'Tip: Update GitHub CLI via your package manager (e.g., apt/dnf) and restart Emdash.';
               toast({
                 title: 'GitHub Connection Failed',
                 description: `Git repository detected but couldn't connect to GitHub: ${githubInfo.error}\n\n${updateHint}`,
@@ -1507,7 +1507,7 @@ const AppContent: React.FC = () => {
                   <img
                     key={effectiveTheme}
                     src={effectiveTheme === 'dark' ? emdashLogoWhite : emdashLogo}
-                    alt="emdash"
+                    alt="Emdash"
                     className="logo-shimmer-image"
                   />
                   <span
@@ -1599,7 +1599,7 @@ const AppContent: React.FC = () => {
               <img
                 key={effectiveTheme}
                 src={effectiveTheme === 'dark' ? emdashLogoWhite : emdashLogo}
-                alt="emdash"
+                alt="Emdash"
                 className="h-16"
               />
             </div>

--- a/src/renderer/components/GithubDeviceFlowModal.tsx
+++ b/src/renderer/components/GithubDeviceFlowModal.tsx
@@ -237,7 +237,6 @@ export function GithubDeviceFlowModal({
       <Dialog.Portal>
         <Dialog.Overlay className="fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0" />
         <Dialog.Content className="fixed left-[50%] top-[50%] z-50 grid w-full max-w-[480px] translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden border bg-background p-0 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg">
-          {/* Close button */}
           <button
             onClick={handleClose}
             className="absolute right-4 top-4 z-10 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
@@ -247,8 +246,7 @@ export function GithubDeviceFlowModal({
           </button>
 
           <div className="flex flex-col items-center px-8 py-12">
-            {/* Logo */}
-            <img src={emdashLogo} alt="emdash" className="mb-8 h-8 opacity-90" />
+            <img src={emdashLogo} alt="Emdash" className="mb-8 h-8 opacity-90" />
 
             {success ? (
               // Success State
@@ -296,11 +294,10 @@ export function GithubDeviceFlowModal({
                 <div className="space-y-2 text-center">
                   <h2 className="text-2xl font-semibold">Connect to GitHub</h2>
                   <p className="text-sm text-muted-foreground">
-                    Follow these steps to authorize emdash
+                    Follow these steps to authorize Emdash
                   </p>
                 </div>
 
-                {/* Device Code Display */}
                 {userCode && (
                   <>
                     <div className="w-full space-y-3 rounded-lg bg-muted/30 p-6">
@@ -312,7 +309,6 @@ export function GithubDeviceFlowModal({
                       </p>
                     </div>
 
-                    {/* Copy Button */}
                     <Button
                       onClick={() => copyToClipboard(userCode)}
                       variant="outline"
@@ -334,7 +330,6 @@ export function GithubDeviceFlowModal({
                   </>
                 )}
 
-                {/* Instructions */}
                 <div className="w-full space-y-3 text-sm">
                   <div className="flex items-start gap-3">
                     <div className="flex h-6 w-6 flex-shrink-0 items-center justify-center rounded-full bg-primary/10 text-xs font-semibold">
@@ -353,7 +348,6 @@ export function GithubDeviceFlowModal({
                   </div>
                 </div>
 
-                {/* Browser Opening Countdown */}
                 {browserOpening && (
                   <div className="w-full rounded-lg border border-blue-500/20 bg-blue-500/10 p-4">
                     <p className="text-center text-sm text-blue-600 dark:text-blue-400">
@@ -362,7 +356,6 @@ export function GithubDeviceFlowModal({
                   </div>
                 )}
 
-                {/* Status */}
                 <div className="flex flex-col items-center gap-2 text-center">
                   <Spinner className="h-5 w-5 text-muted-foreground" />
                   <p className="text-sm text-muted-foreground">Waiting for authorization...</p>
@@ -373,7 +366,6 @@ export function GithubDeviceFlowModal({
                   )}
                 </div>
 
-                {/* Open GitHub Button */}
                 {verificationUri && !browserOpening && (
                   <Button onClick={openGitHub} className="w-full" size="lg">
                     <ExternalLink className="mr-2 h-4 w-4" />
@@ -381,12 +373,10 @@ export function GithubDeviceFlowModal({
                   </Button>
                 )}
 
-                {/* Help Text */}
                 <div className="w-full border-t pt-4">
                   <p className="text-center text-xs text-muted-foreground">Having trouble?</p>
                 </div>
 
-                {/* Keyboard Shortcuts */}
                 <div className="space-x-3 text-center text-xs text-muted-foreground">
                   <span>⌘C to copy</span>
                   <span>•</span>

--- a/src/renderer/components/MainContent.tsx
+++ b/src/renderer/components/MainContent.tsx
@@ -39,7 +39,7 @@ const MainContent: React.FC<MainContentProps> = ({
                 textShadow: '2px 2px 0px #000',
               }}
             >
-              emdash
+              Emdash
             </h1>
             <h2 className="text-2xl text-gray-400">Codex</h2>
           </div>

--- a/src/renderer/components/VersionCard.tsx
+++ b/src/renderer/components/VersionCard.tsx
@@ -47,7 +47,7 @@ const VersionCard: React.FC = () => {
       <div className="flex items-start gap-3">
         <div className="flex-1 space-y-1">
           <div className="flex items-baseline gap-2">
-            <span className="text-sm font-medium text-foreground">emdash</span>
+            <span className="text-sm font-medium text-foreground">Emdash</span>
             <code className="font-mono text-sm text-muted-foreground">{emdashVersion}</code>
           </div>
         </div>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>emdash</title>
+    <title>Emdash</title>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
- Ensure desktop window title and app name use “Emdash”.
- Capitalize renderer-facing branding text and alt attributes.
- Align docs and user-facing error message with the capitalized brand.