### PR TITLE
feat(ui): add loading feedback during project deletion

### DIFF
--- a/src/renderer/components/ProjectDeleteButton.tsx
+++ b/src/renderer/components/ProjectDeleteButton.tsx
@@ -124,10 +124,8 @@ export const ProjectDeleteButton: React.FC<Props> = ({
                 className="flex items-start gap-3 rounded-md border border-border/70 bg-muted/30 px-4 py-4"
               >
                 <Spinner className="mt-0.5 h-5 w-5 flex-shrink-0 text-muted-foreground" size="sm" />
-                <div className="flex flex-col gap-1 min-w-0">
-                  <span className="text-sm font-semibold text-foreground">
-                    Please wait...
-                  </span>
+                <div className="flex min-w-0 flex-col gap-1">
+                  <span className="text-sm font-semibold text-foreground">Please wait...</span>
                   <span className="text-xs text-muted-foreground">
                     Scanning workspaces for uncommitted changes and open pull requests
                   </span>


### PR DESCRIPTION

<img width="434" height="362" alt="image" src="https://github.com/user-attachments/assets/ecb4026f-ca70-40b0-b81f-b8ab69253175" />


## Summary
- Show a clear loading indicator while scanning workspaces for uncommitted changes and open PRs
- explaining why Delete button is at the moment disabled

## What Changed
Added loading state UI to the project delete dialog with:
- Prominent "Please wait..." message during workspace scanning
- Context-aware tooltips on the Delete button
- Proper state management to prevent warnings from flickering