### PR TITLE
fix: propagate auto-approve flag to provider CLI sessions

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -352,6 +352,8 @@ const ChatInterface: React.FC<Props> = ({
   }, [provider, workspace.id]);
 
   const isTerminal = providerMeta[provider]?.terminalOnly === true;
+  const autoApproveEnabled =
+    Boolean(workspace.metadata?.autoApprove) && Boolean(providerMeta[provider]?.autoApproveFlag);
 
   const initialInjection = useMemo(() => {
     if (!isTerminal) return null;
@@ -702,6 +704,7 @@ const ChatInterface: React.FC<Props> = ({
               id={terminalId}
               cwd={workspace.path}
               shell={providerMeta[provider].cli}
+              autoApprove={autoApproveEnabled}
               env={
                 planEnabled
                   ? {
@@ -763,6 +766,7 @@ const ChatInterface: React.FC<Props> = ({
         linearIssue={workspace.metadata?.linearIssue || null}
         githubIssue={workspace.metadata?.githubIssue || null}
         jiraIssue={workspace.metadata?.jiraIssue || null}
+        autoApprove={autoApproveEnabled}
         planModeEnabled={planEnabled}
         onPlanModeChange={setPlanEnabled}
         onApprovePlan={async () => {

--- a/src/renderer/components/MultiAgentWorkspace.tsx
+++ b/src/renderer/components/MultiAgentWorkspace.tsx
@@ -443,7 +443,10 @@ const MultiAgentWorkspace: React.FC<Props> = ({ workspace }) => {
                     id={`${v.worktreeId}-main`}
                     cwd={v.path}
                     shell={providerMeta[v.provider].cli}
-                    autoApprove={workspace.metadata?.autoApprove ?? false}
+                    autoApprove={
+                      Boolean(workspace.metadata?.autoApprove) &&
+                      Boolean(providerMeta[v.provider]?.autoApproveFlag)
+                    }
                     initialPrompt={
                       providerMeta[v.provider]?.initialPromptFlag !== undefined &&
                       !workspace.metadata?.initialInjectionSent


### PR DESCRIPTION
## Fix: Auto-approve flag not propagating to provider CLI sessions

Fixing: https://github.com/generalaction/emdash/issues/360

### Problem

When users checked the **"Auto-approve"** checkbox during Task creation, the setting was stored in workspace metadata but **never actually reached the provider CLI**. This caused:

- **Claude Code** to repeatedly prompt for file operation permissions despite "skip permissions" being enabled
- Other providers with auto-approve support (Codex, Gemini, Qwen, Cursor, Mistral, Rovo) to also ignore the setting
- The "Auto-approve" badge in `ProviderBar` to not display in single-agent mode, making the UI state inconsistent

**Root cause:** In `ChatInterface.tsx` (single-agent view), the `TerminalPane` component was never passed the `autoApprove` prop, so `ptyManager.ts` couldn't append the provider's `autoApproveFlag` (e.g., Claude's `--dangerously-skip-permissions`) when spawning the CLI process.

### Solution

- Added a derived `autoApproveEnabled` flag that combines:
  - Workspace metadata setting (`workspace.metadata.autoApprove`)
  - Provider support check (`providerMeta[provider]?.autoApproveFlag`)
- Wired this flag into both:
  - `<TerminalPane autoApprove={autoApproveEnabled} />` → reaches PTY spawn layer
  - `<ProviderBar autoApprove={autoApproveEnabled} />` → shows indicator badge
- Applied the same logic to `MultiAgentWorkspace.tsx` for consistency

### What's fixed

✅ **Provider CLIs now receive their auto-approve flags** (e.g., `claude --dangerously-skip-permissions`)  
✅ **ProviderBar badge displays correctly** in single-agent mode  
✅ **Works for all providers** with `autoApproveFlag` support  
✅ **Gracefully handles providers without support** (doesn't enable/show for unsupported providers)

### What's NOT changed

⚠️ **Claude's "Do you trust the files in this folder?" prompt** will still appear for new worktrees—this is a separate per-directory trust mechanism in Claude Code that can't be bypassed right now via CLI flags.

### Testing checklist

- [x] Create a new Task with "Auto-approve" checked
- [x] Verify Claude Code launches with `--dangerously-skip-permissions` in the terminal command
- [x] Confirm file operation prompts are skipped (except workspace trust on first run)
- [x] Check that the "Auto-approve" badge appears in ProviderBar
- [x] Test with another supported provider (e.g., Gemini, Codex) to ensure their flags work too

### Files changed

- `src/renderer/components/ChatInterface.tsx`
- `src/renderer/components/MultiAgentWorkspace.tsx`