### PR TITLE
draft: feat: Add multi-conversation support (multi chats in worktree)

### DIFF
--- a/src/main/ipc/dbIpc.ts
+++ b/src/main/ipc/dbIpc.ts
@@ -102,6 +102,19 @@ export function registerDatabaseIpc() {
     }
   });
 
+  ipcMain.handle(
+    'db:updateConversation',
+    async (_, conversationId: string, updates: Partial<{ title: string }>) => {
+      try {
+        await databaseService.updateConversation(conversationId, updates);
+        return { success: true };
+      } catch (error) {
+        log.error('Failed to update conversation:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
   ipcMain.handle('db:deleteConversation', async (_, conversationId: string) => {
     try {
       await databaseService.deleteConversation(conversationId);

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -47,6 +47,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     rows?: number;
     autoApprove?: boolean;
     initialPrompt?: string;
+    skipResume?: boolean;
   }) => ipcRenderer.invoke('pty:start', opts),
   ptyInput: (args: { id: string; data: string }) => ipcRenderer.send('pty:input', args),
   ptyResize: (args: { id: string; cols: number; rows: number }) =>
@@ -286,10 +287,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   getConversations: (workspaceId: string) => ipcRenderer.invoke('db:getConversations', workspaceId),
   getOrCreateDefaultConversation: (workspaceId: string) =>
     ipcRenderer.invoke('db:getOrCreateDefaultConversation', workspaceId),
-  saveMessage: (message: any) => ipcRenderer.invoke('db:saveMessage', message),
-  getMessages: (conversationId: string) => ipcRenderer.invoke('db:getMessages', conversationId),
+  updateConversation: (conversationId: string, updates: Partial<{ title: string }>) =>
+    ipcRenderer.invoke('db:updateConversation', conversationId, updates),
   deleteConversation: (conversationId: string) =>
     ipcRenderer.invoke('db:deleteConversation', conversationId),
+  saveMessage: (message: any) => ipcRenderer.invoke('db:saveMessage', message),
+  getMessages: (conversationId: string) => ipcRenderer.invoke('db:getMessages', conversationId),
 
   // Debug helpers
   debugAppendLog: (filePath: string, content: string, options?: { reset?: boolean }) =>
@@ -639,11 +642,15 @@ export interface ElectronAPI {
   getOrCreateDefaultConversation: (
     workspaceId: string
   ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
+  updateConversation: (
+    conversationId: string,
+    updates: Partial<{ title: string }>
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteConversation: (conversationId: string) => Promise<{ success: boolean; error?: string }>;
   saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>;
   getMessages: (
     conversationId: string
   ) => Promise<{ success: boolean; messages?: any[]; error?: string }>;
-  deleteConversation: (conversationId: string) => Promise<{ success: boolean; error?: string }>;
 
   // Host preview (non-container)
   hostPreviewStart: (args: {

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -313,7 +313,7 @@ export class DatabaseService {
       .select()
       .from(conversationsTable)
       .where(eq(conversationsTable.workspaceId, workspaceId))
-      .orderBy(desc(conversationsTable.updatedAt));
+      .orderBy(asc(conversationsTable.createdAt));
     return rows.map((row) => this.mapDrizzleConversationRow(row));
   }
 
@@ -322,7 +322,7 @@ export class DatabaseService {
       return {
         id: `conv-${workspaceId}-default`,
         workspaceId,
-        title: 'Default Conversation',
+        title: 'Main Chat',
         createdAt: new Date().toISOString(),
         updatedAt: new Date().toISOString(),
       };
@@ -344,7 +344,7 @@ export class DatabaseService {
     await this.saveConversation({
       id: conversationId,
       workspaceId,
-      title: 'Default Conversation',
+      title: 'Main Chat',
     });
 
     const [createdRow] = await db
@@ -360,7 +360,7 @@ export class DatabaseService {
     return {
       id: conversationId,
       workspaceId,
-      title: 'Default Conversation',
+      title: 'Main Chat',
       createdAt: new Date().toISOString(),
       updatedAt: new Date().toISOString(),
     };
@@ -407,6 +407,21 @@ export class DatabaseService {
       .where(eq(messagesTable.conversationId, conversationId))
       .orderBy(asc(messagesTable.timestamp));
     return rows.map((row) => this.mapDrizzleMessageRow(row));
+  }
+
+  async updateConversation(
+    conversationId: string,
+    updates: Partial<Pick<Conversation, 'title'>>
+  ): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db
+      .update(conversationsTable)
+      .set({
+        ...updates,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(eq(conversationsTable.id, conversationId));
   }
 
   async deleteConversation(conversationId: string): Promise<void> {

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -26,16 +26,17 @@ export function registerPtyIpc(): void {
         rows?: number;
         autoApprove?: boolean;
         initialPrompt?: string;
+        skipResume?: boolean;
       }
     ) => {
       if (process.env.EMDASH_DISABLE_PTY === '1') {
         return { ok: false, error: 'PTY disabled via EMDASH_DISABLE_PTY=1' };
       }
       try {
-        const { id, cwd, shell, env, cols, rows, autoApprove, initialPrompt } = args;
+        const { id, cwd, shell, env, cols, rows, autoApprove, initialPrompt, skipResume } = args;
         const existing = getPty(id);
         const proc =
-          existing ?? startPty({ id, cwd, shell, env, cols, rows, autoApprove, initialPrompt });
+          existing ?? startPty({ id, cwd, shell, env, cols, rows, autoApprove, initialPrompt, skipResume });
         const envKeys = env ? Object.keys(env) : [];
         const planEnv = env && (env.EMDASH_PLAN_MODE || env.EMDASH_PLAN_FILE) ? true : false;
         log.debug('pty:start OK', {

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -27,11 +27,12 @@ export function startPty(options: {
   rows?: number;
   autoApprove?: boolean;
   initialPrompt?: string;
+  skipResume?: boolean;
 }): IPty {
   if (process.env.EMDASH_DISABLE_PTY === '1') {
     throw new Error('PTY disabled via EMDASH_DISABLE_PTY=1');
   }
-  const { id, cwd, shell, env, cols = 80, rows = 24, autoApprove, initialPrompt } = options;
+  const { id, cwd, shell, env, cols = 80, rows = 24, autoApprove, initialPrompt, skipResume = false } = options;
 
   const defaultShell = getDefaultShell();
   let useShell = shell || defaultShell;
@@ -113,8 +114,8 @@ export function startPty(options: {
         // Build the provider command with flags
         const cliArgs: string[] = [];
 
-        // Add resume flag FIRST if available
-        if (provider.resumeFlag) {
+        // Add resume flag FIRST if available (skip for new conversations)
+        if (provider.resumeFlag && !skipResume) {
           const resumeParts = provider.resumeFlag.split(' ');
           cliArgs.push(...resumeParts);
         }

--- a/src/renderer/components/ConversationTabs.tsx
+++ b/src/renderer/components/ConversationTabs.tsx
@@ -1,0 +1,152 @@
+import React, { useState } from 'react';
+import { X, Terminal } from 'lucide-react';
+import type { Conversation } from '../types/chat';
+import { cn } from '../lib/utils';
+import { Tooltip, TooltipContent, TooltipTrigger, TooltipProvider } from './ui/tooltip';
+import { NewConversationButton } from './NewConversationButton';
+import type { ProviderId } from '@shared/providers/registry';
+
+interface ConversationTabsProps {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  onSelectConversation: (id: string) => void;
+  workspaceId: string;
+  onCreateConversationWithProvider: (provider: ProviderId | null) => void;
+  onRenameConversation: (id: string, newTitle: string) => void;
+  onDeleteConversation: (id: string) => void;
+  isBusy?: boolean;
+  providerIcon?: string;
+  providerLabel?: string;
+}
+
+export const ConversationTabs: React.FC<ConversationTabsProps> = ({
+  conversations,
+  activeConversationId,
+  onSelectConversation,
+  workspaceId,
+  onCreateConversationWithProvider,
+  onRenameConversation,
+  onDeleteConversation,
+  isBusy = false,
+  providerIcon,
+  providerLabel,
+}) => {
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editingTitle, setEditingTitle] = useState('');
+  const [hoveredId, setHoveredId] = useState<string | null>(null);
+
+  const handleDoubleClick = (conversation: Conversation) => {
+    setEditingId(conversation.id);
+    setEditingTitle(conversation.title);
+  };
+
+  const handleRenameSubmit = (id: string) => {
+    if (editingTitle.trim() && editingTitle !== conversations.find(c => c.id === id)?.title) {
+      onRenameConversation(id, editingTitle.trim());
+    }
+    setEditingId(null);
+    setEditingTitle('');
+  };
+
+  const handleRenameKeyDown = (e: React.KeyboardEvent, id: string) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleRenameSubmit(id);
+    } else if (e.key === 'Escape') {
+      setEditingId(null);
+      setEditingTitle('');
+    }
+  };
+
+  return (
+    <TooltipProvider>
+      <div className="flex items-center border-b border-border bg-background px-5 py-1.5">
+        <div className="flex items-center gap-0.5 flex-1 overflow-x-auto scrollbar-hide">
+        {conversations.map(conversation => {
+          const isActive = conversation.id === activeConversationId;
+          const isEditing = editingId === conversation.id;
+          const isHovered = hoveredId === conversation.id;
+
+          return (
+            <div
+              key={conversation.id}
+              className={cn(
+                'group relative inline-flex items-center px-4 py-2 text-sm font-medium transition-colors',
+                isActive
+                  ? 'text-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              )}
+              onMouseEnter={() => setHoveredId(conversation.id)}
+              onMouseLeave={() => setHoveredId(null)}
+            >
+              {/* Active indicator (bottom border) */}
+              {isActive && (
+                <div className="absolute bottom-0 left-0 right-0 h-0.5 bg-primary" />
+              )}
+
+              {/* Title or edit input */}
+              {isEditing ? (
+                <input
+                  type="text"
+                  value={editingTitle}
+                  onChange={e => setEditingTitle(e.target.value)}
+                  onBlur={() => handleRenameSubmit(conversation.id)}
+                  onKeyDown={e => handleRenameKeyDown(e, conversation.id)}
+                  className="h-6 w-32 rounded border border-border bg-background px-2 text-sm focus:outline-none focus:ring-1 focus:ring-primary"
+                  autoFocus
+                  onFocus={e => e.target.select()}
+                />
+              ) : (
+                <div className="relative flex items-center justify-center min-w-0 flex-1">
+                  <button
+                    type="button"
+                    onClick={() => onSelectConversation(conversation.id)}
+                    onDoubleClick={() => handleDoubleClick(conversation)}
+                    className="truncate text-left"
+                  >
+                    {conversation.title}
+                  </button>
+                </div>
+              )}
+
+              {/* Gradient fade on hover */}
+              {!isEditing && isHovered && conversations.length > 1 && (
+                <div className="absolute right-0 top-0 bottom-0 w-8 bg-gradient-to-l from-background to-transparent pointer-events-none" />
+              )}
+
+              {/* Close button (show only on hover) - positioned absolutely relative to tab */}
+              {!isEditing && isHovered && conversations.length > 1 && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <button
+                      type="button"
+                      onClick={e => {
+                        e.stopPropagation();
+                        onDeleteConversation(conversation.id);
+                      }}
+                      className="absolute right-2 inline-flex h-5 w-5 items-center justify-center rounded bg-muted/80 transition-colors hover:bg-muted hover:text-foreground"
+                      aria-label="Delete conversation"
+                    >
+                      <X className="h-3.5 w-3.5" />
+                    </button>
+                  </TooltipTrigger>
+                  <TooltipContent side="bottom" sideOffset={2}>
+                    Delete conversation
+                  </TooltipContent>
+                </Tooltip>
+              )}
+            </div>
+          );
+        })}
+
+        {/* New conversation button with provider selector */}
+        <NewConversationButton
+          workspaceId={workspaceId}
+          onProviderSelect={onCreateConversationWithProvider}
+          isBusy={isBusy}
+        />
+      </div>
+      </div>
+    </TooltipProvider>
+  );
+};

--- a/src/renderer/components/NewConversationButton.tsx
+++ b/src/renderer/components/NewConversationButton.tsx
@@ -1,0 +1,61 @@
+import React, { useState, useEffect } from 'react';
+import { Plus } from 'lucide-react';
+import { PROVIDER_IDS, type ProviderId } from '@shared/providers/registry';
+import { cn } from '../lib/utils';
+
+interface NewConversationButtonProps {
+  workspaceId: string;
+  onProviderSelect: (provider: ProviderId | null) => void;
+  isBusy?: boolean;
+  className?: string;
+}
+
+export const NewConversationButton: React.FC<NewConversationButtonProps> = ({
+  workspaceId,
+  onProviderSelect,
+  isBusy = false,
+  className,
+}) => {
+  const [defaultProvider, setDefaultProvider] = useState<ProviderId>('claude');
+
+  // Load default provider from localStorage
+  useEffect(() => {
+    try {
+      const lastKey = `provider:last:${workspaceId}`;
+      const last = window.localStorage.getItem(lastKey) as ProviderId | null;
+
+      if (last && PROVIDER_IDS.includes(last as any)) {
+        setDefaultProvider(last);
+      } else {
+        setDefaultProvider('claude');
+        window.localStorage.setItem(lastKey, 'claude');
+      }
+    } catch (error) {
+      console.error('Failed to load last provider:', error);
+      setDefaultProvider('claude');
+    }
+  }, [workspaceId]);
+
+  const handleClick = () => {
+    if (isBusy) return;
+    onProviderSelect(defaultProvider);
+  };
+
+  return (
+    <button
+      type="button"
+      disabled={isBusy}
+      onClick={handleClick}
+      className={cn(
+        'inline-flex h-8 w-8 items-center justify-center rounded-md',
+        'text-muted-foreground hover:text-foreground hover:bg-accent',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        'transition-colors',
+        className
+      )}
+      aria-label="New conversation"
+    >
+      <Plus className="h-3.5 w-3.5" />
+    </button>
+  );
+};

--- a/src/renderer/hooks/useConversations.ts
+++ b/src/renderer/hooks/useConversations.ts
@@ -1,0 +1,179 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { Conversation } from '../types/chat';
+
+interface UseConversationsResult {
+  conversations: Conversation[];
+  activeConversationId: string | null;
+  activeConversation: Conversation | null;
+  isLoading: boolean;
+  createConversation: (title?: string) => Promise<Conversation | null>;
+  selectConversation: (id: string) => void;
+  renameConversation: (id: string, title: string) => Promise<void>;
+  deleteConversation: (id: string) => Promise<void>;
+}
+
+export function useConversations(workspaceId: string): UseConversationsResult {
+  const [conversations, setConversations] = useState<Conversation[]>([]);
+  const [activeConversationId, setActiveConversationId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Load conversations for this workspace
+  useEffect(() => {
+    let cancelled = false;
+
+    const loadConversations = async () => {
+      try {
+        setIsLoading(true);
+        const result = await window.electronAPI.getConversations(workspaceId);
+
+        if (cancelled) return;
+
+        if (result.success && result.conversations && result.conversations.length > 0) {
+          setConversations(result.conversations);
+
+          // Try to restore last active from localStorage
+          const lastActiveKey = `activeConversation:${workspaceId}`;
+          const lastActive = localStorage.getItem(lastActiveKey);
+
+          if (lastActive && result.conversations.some((c: Conversation) => c.id === lastActive)) {
+            setActiveConversationId(lastActive);
+          } else {
+            // Select most recent
+            setActiveConversationId(result.conversations[0].id);
+          }
+        } else {
+          // No conversations exist, create a default one
+          const defaultResult = await window.electronAPI.getOrCreateDefaultConversation(workspaceId);
+          if (!cancelled && defaultResult.success && defaultResult.conversation) {
+            setConversations([defaultResult.conversation]);
+            setActiveConversationId(defaultResult.conversation.id);
+          }
+        }
+      } catch (error) {
+        console.error('Failed to load conversations:', error);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    loadConversations();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]); // Only reload when workspace changes
+
+  // Persist active conversation ID to localStorage
+  useEffect(() => {
+    if (activeConversationId) {
+      const key = `activeConversation:${workspaceId}`;
+      localStorage.setItem(key, activeConversationId);
+    }
+  }, [activeConversationId, workspaceId]);
+
+  const createConversation = useCallback(
+    async (title?: string): Promise<Conversation | null> => {
+      // Calculate the next chat number (Chat 2, Chat 3, etc.)
+      const chatNumbers = conversations
+        .map(c => {
+          const match = c.title.match(/^Chat (\d+)$/);
+          return match ? parseInt(match[1], 10) : 0;
+        })
+        .filter(n => n > 0);
+
+      const nextNumber = chatNumbers.length > 0 ? Math.max(...chatNumbers) + 1 : 2;
+      const newTitle = title || `Chat ${nextNumber}`;
+      const conversationId = `conv-${workspaceId}-${Date.now()}`;
+
+      try {
+        const result = await window.electronAPI.saveConversation({
+          id: conversationId,
+          workspaceId,
+          title: newTitle,
+        });
+
+        if (result.success) {
+          const newConversation: Conversation = {
+            id: conversationId,
+            workspaceId,
+            title: newTitle,
+            createdAt: new Date().toISOString(),
+            updatedAt: new Date().toISOString(),
+          };
+
+          // Add new conversation to the right (end of array)
+          setConversations(prev => [...prev, newConversation]);
+          setActiveConversationId(conversationId);
+          return newConversation;
+        }
+      } catch (error) {
+        console.error('Failed to create conversation:', error);
+      }
+
+      return null;
+    },
+    [workspaceId, conversations]
+  );
+
+  const selectConversation = useCallback((id: string) => {
+    setActiveConversationId(id);
+  }, []);
+
+  const renameConversation = useCallback(async (id: string, title: string) => {
+    try {
+      const result = await window.electronAPI.updateConversation(id, { title });
+
+      if (result.success) {
+        setConversations(prev =>
+          prev.map(c => (c.id === id ? { ...c, title, updatedAt: new Date().toISOString() } : c))
+        );
+      }
+    } catch (error) {
+      console.error('Failed to rename conversation:', error);
+    }
+  }, []);
+
+  const deleteConversation = useCallback(
+    async (id: string) => {
+      // Prevent deleting the last conversation
+      if (conversations.length <= 1) {
+        console.warn('Cannot delete the last conversation');
+        return;
+      }
+
+      try {
+        const result = await window.electronAPI.deleteConversation(id);
+
+        if (result.success) {
+          setConversations(prev => prev.filter(c => c.id !== id));
+
+          // If we deleted the active conversation, switch to the most recent remaining one
+          if (activeConversationId === id) {
+            const remaining = conversations.filter(c => c.id !== id);
+            if (remaining.length > 0) {
+              setActiveConversationId(remaining[0].id);
+            }
+          }
+        }
+      } catch (error) {
+        console.error('Failed to delete conversation:', error);
+      }
+    },
+    [conversations, activeConversationId]
+  );
+
+  const activeConversation = conversations.find(c => c.id === activeConversationId) || null;
+
+  return {
+    conversations,
+    activeConversationId,
+    activeConversation,
+    isLoading,
+    createConversation,
+    selectConversation,
+    renameConversation,
+    deleteConversation,
+  };
+}

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -64,7 +64,8 @@ class SessionRegistry {
       telemetry: null,
       autoApprove: options.autoApprove,
       initialPrompt: options.initialPrompt,
-      skipResume: true, // Always skip resume for new sessions (new conversations/tabs)
+      // Let ptyIpc decide whether to skip resume based on snapshot existence
+      // Don't force skipResume here - the IPC layer handles this intelligently
     };
 
     const session = new TerminalSessionManager(sessionOptions);

--- a/src/renderer/terminal/SessionRegistry.ts
+++ b/src/renderer/terminal/SessionRegistry.ts
@@ -64,6 +64,7 @@ class SessionRegistry {
       telemetry: null,
       autoApprove: options.autoApprove,
       initialPrompt: options.initialPrompt,
+      skipResume: true, // Always skip resume for new sessions (new conversations/tabs)
     };
 
     const session = new TerminalSessionManager(sessionOptions);

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -30,6 +30,7 @@ export interface TerminalSessionOptions {
   telemetry?: { track: (event: string, payload?: Record<string, unknown>) => void } | null;
   autoApprove?: boolean;
   initialPrompt?: string;
+  skipResume?: boolean;
 }
 
 type CleanupFn = () => void;
@@ -401,7 +402,7 @@ export class TerminalSessionManager {
   }
 
   private connectPty() {
-    const { workspaceId, cwd, shell, env, initialSize, autoApprove, initialPrompt } = this.options;
+    const { workspaceId, cwd, shell, env, initialSize, autoApprove, initialPrompt, skipResume } = this.options;
     const id = workspaceId;
     void window.electronAPI
       .ptyStart({
@@ -413,6 +414,7 @@ export class TerminalSessionManager {
         rows: initialSize.rows,
         autoApprove,
         initialPrompt,
+        skipResume,
       })
       .then((result) => {
         if (result?.ok) {

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -48,6 +48,14 @@ export interface Workspace {
   metadata?: WorkspaceMetadata | null;
 }
 
+export interface Conversation {
+  id: string;
+  workspaceId: string;
+  title: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
 export interface Message {
   id: string;
   content: string;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -98,6 +98,7 @@ declare global {
         rows?: number;
         autoApprove?: boolean;
         initialPrompt?: string;
+        skipResume?: boolean;
       }) => Promise<{ ok: boolean; error?: string }>;
       ptyInput: (args: { id: string; data: string }) => void;
       ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
@@ -586,14 +587,25 @@ declare global {
       deleteProject: (projectId: string) => Promise<{ success: boolean; error?: string }>;
       deleteWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>;
 
+      // Conversation operations
+      saveConversation: (conversation: any) => Promise<{ success: boolean; error?: string }>;
+      getConversations: (
+        workspaceId: string
+      ) => Promise<{ success: boolean; conversations?: any[]; error?: string }>;
+      getOrCreateDefaultConversation: (
+        workspaceId: string
+      ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
+      updateConversation: (
+        conversationId: string,
+        updates: Partial<{ title: string }>
+      ) => Promise<{ success: boolean; error?: string }>;
+      deleteConversation: (conversationId: string) => Promise<{ success: boolean; error?: string }>;
+
       // Message operations
       saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>;
       getMessages: (
         conversationId: string
       ) => Promise<{ success: boolean; messages?: any[]; error?: string }>;
-      getOrCreateDefaultConversation: (
-        workspaceId: string
-      ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
 
       // Debug helpers
       debugAppendLog: (
@@ -913,14 +925,25 @@ export interface ElectronAPI {
   deleteProject: (projectId: string) => Promise<{ success: boolean; error?: string }>;
   deleteWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>;
 
+  // Conversation operations
+  saveConversation: (conversation: any) => Promise<{ success: boolean; error?: string }>;
+  getConversations: (
+    workspaceId: string
+  ) => Promise<{ success: boolean; conversations?: any[]; error?: string }>;
+  getOrCreateDefaultConversation: (
+    workspaceId: string
+  ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
+  updateConversation: (
+    conversationId: string,
+    updates: Partial<{ title: string }>
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteConversation: (conversationId: string) => Promise<{ success: boolean; error?: string }>;
+
   // Message operations
   saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>;
   getMessages: (
     conversationId: string
   ) => Promise<{ success: boolean; messages?: any[]; error?: string }>;
-  getOrCreateDefaultConversation: (
-    workspaceId: string
-  ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
 
   // Debug helpers
   debugAppendLog: (


### PR DESCRIPTION
## Summary
- Adds multi-conversation (multi-chat) support per workspace/worktree

## Key Features
- **Multiple conversations per workspace**: Users can now have multiple independent chat sessions within a single workspace
- **Conversation tabs**: Clean tab interface for switching between conversations
- **Proper history isolation**: New conversations start fresh without resume flags

## Technical Changes

### UI Components
- `ConversationTabs`: New component for tab-based conversation navigation with:
  - Centered tab titles with proper padding
  - Close button (X) on hover with gradient fade effect
  - Active tab indicator (bottom border)

### State Management
- `useConversations`: New hook for conversation CRUD operations
- Conversations persist via SQLite database
- Active conversation ID stored in localStorage per workspace

### Database Schema
- Added conversations table with proper foreign key relationships
- IPC handlers for conversation CRUD operations
- Automatic default conversation creation