### PR TITLE
Change add project to dropdown

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -636,6 +636,46 @@ const AppContent: React.FC = () => {
     }
   };
 
+  const handleNewProjectClick = async () => {
+    const { captureTelemetry } = await import('./lib/telemetryClient');
+    captureTelemetry('project_create_clicked');
+
+    if (!isAuthenticated || !ghInstalled) {
+      toast({
+        title: 'GitHub authentication required',
+        variant: 'destructive',
+        action: (
+          <ToastAction altText="Connect GitHub" onClick={handleGithubConnect}>
+            Connect GitHub
+          </ToastAction>
+        ),
+      });
+      return;
+    }
+
+    setShowNewProjectModal(true);
+  };
+
+  const handleCloneProjectClick = async () => {
+    const { captureTelemetry } = await import('./lib/telemetryClient');
+    captureTelemetry('project_clone_clicked');
+
+    if (!isAuthenticated || !ghInstalled) {
+      toast({
+        title: 'GitHub authentication required',
+        variant: 'destructive',
+        action: (
+          <ToastAction altText="Connect GitHub" onClick={handleGithubConnect}>
+            Connect GitHub
+          </ToastAction>
+        ),
+      });
+      return;
+    }
+
+    setShowCloneModal(true);
+  };
+
   const handleCloneSuccess = useCallback(
     async (projectPath: string) => {
       const { captureTelemetry } = await import('./lib/telemetryClient');
@@ -1792,25 +1832,7 @@ const AppContent: React.FC = () => {
               <motion.button
                 whileTap={{ scale: 0.97 }}
                 transition={{ duration: 0.1, ease: 'easeInOut' }}
-                onClick={() => {
-                  void (async () => {
-                    const { captureTelemetry } = await import('./lib/telemetryClient');
-                    captureTelemetry('project_create_clicked');
-                  })();
-                  if (!isAuthenticated || !ghInstalled) {
-                    toast({
-                      title: 'GitHub authentication required',
-                      variant: 'destructive',
-                      action: (
-                        <ToastAction altText="Connect GitHub" onClick={handleGithubConnect}>
-                          Connect GitHub
-                        </ToastAction>
-                      ),
-                    });
-                    return;
-                  }
-                  setShowNewProjectModal(true);
-                }}
+                onClick={handleNewProjectClick}
                 className="group flex flex-col items-start justify-between rounded-lg border border-border bg-muted/20 p-4 text-card-foreground shadow-sm transition-all hover:bg-muted/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
                 <Plus className="mb-5 h-5 w-5 text-foreground opacity-70" />
@@ -1822,25 +1844,7 @@ const AppContent: React.FC = () => {
               <motion.button
                 whileTap={{ scale: 0.97 }}
                 transition={{ duration: 0.1, ease: 'easeInOut' }}
-                onClick={() => {
-                  void (async () => {
-                    const { captureTelemetry } = await import('./lib/telemetryClient');
-                    captureTelemetry('project_clone_clicked');
-                  })();
-                  if (!isAuthenticated || !ghInstalled) {
-                    toast({
-                      title: 'GitHub authentication required',
-                      variant: 'destructive',
-                      action: (
-                        <ToastAction altText="Connect GitHub" onClick={handleGithubConnect}>
-                          Connect GitHub
-                        </ToastAction>
-                      ),
-                    });
-                    return;
-                  }
-                  setShowCloneModal(true);
-                }}
+                onClick={handleCloneProjectClick}
                 className="group flex flex-col items-start justify-between rounded-lg border border-border bg-muted/20 p-4 text-card-foreground shadow-sm transition-all hover:bg-muted/40 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2"
               >
                 <Github className="mb-5 h-5 w-5 text-foreground opacity-70" />
@@ -1957,8 +1961,8 @@ const AppContent: React.FC = () => {
                     onSelectProject={handleSelectProject}
                     onGoHome={handleGoHome}
                     onOpenProject={handleOpenProject}
-                    onNewProject={() => setShowNewProjectModal(true)}
-                    onCloneProject={() => setShowCloneModal(true)}
+                    onNewProject={handleNewProjectClick}
+                    onCloneProject={handleCloneProjectClick}
                     onSelectTask={handleSelectTask}
                     activeTask={activeTask || undefined}
                     onReorderProjects={handleReorderProjects}

--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -158,63 +158,6 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
     onSidebarContextChange?.({ open, isMobile, setOpen });
   }, [open, isMobile, setOpen, onSidebarContextChange]);
 
-  const checkGithubAuth = React.useCallback((): boolean => {
-    if (!githubAuthenticated || !githubInstalled) {
-      void (async () => {
-        const { toast } = await import('../hooks/use-toast');
-        toast({
-          title: 'GitHub authentication required',
-          variant: 'destructive',
-          action: (
-            <Button
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                onGithubConnect?.();
-              }}
-            >
-              Connect GitHub
-            </Button>
-          ),
-        });
-      })();
-      return false;
-    }
-    return true;
-  }, [githubAuthenticated, githubInstalled, onGithubConnect]);
-
-  const handleOpenFolder = React.useCallback(() => {
-    if (onOpenProject) {
-      void (async () => {
-        const { captureTelemetry } = await import('../lib/telemetryClient');
-        captureTelemetry('project_open_clicked');
-      })();
-      onOpenProject();
-    }
-  }, [onOpenProject]);
-
-  const handleCreateNew = React.useCallback(() => {
-    if (!checkGithubAuth()) {
-      return;
-    }
-    void (async () => {
-      const { captureTelemetry } = await import('../lib/telemetryClient');
-      captureTelemetry('project_create_clicked');
-    })();
-    onNewProject?.();
-  }, [checkGithubAuth, onNewProject]);
-
-  const handleCloneFromGithub = React.useCallback(() => {
-    if (!checkGithubAuth()) {
-      return;
-    }
-    void (async () => {
-      const { captureTelemetry } = await import('../lib/telemetryClient');
-      captureTelemetry('project_clone_clicked');
-    })();
-    onCloneProject?.();
-  }, [checkGithubAuth, onCloneProject]);
-
   const renderGithubStatus = () => (
     <GithubStatus
       installed={githubInstalled}
@@ -446,19 +389,19 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                             icon={FolderOpen}
                             label="Open Folder"
                             ariaLabel="Open Folder"
-                            onClick={handleOpenFolder}
+                            onClick={() => onOpenProject?.()}
                           />
                           <MenuItemButton
                             icon={Plus}
                             label="Create New"
                             ariaLabel="Create New Project"
-                            onClick={handleCreateNew}
+                            onClick={() => onNewProject?.()}
                           />
                           <MenuItemButton
                             icon={Github}
                             label="Clone from GitHub"
                             ariaLabel="Clone from GitHub"
-                            onClick={handleCloneFromGithub}
+                            onClick={() => onCloneProject?.()}
                           />
                         </div>
                       </PopoverContent>


### PR DESCRIPTION
Change add project button in left sidebar to a dropdown with: open project, create new, clone from github

<img width="648" height="330" alt="image" src="https://github.com/user-attachments/assets/deba7b04-d72b-4ae5-83fa-efde5981b708" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a dropdown for adding projects and centralizes action handling.
> 
> - Replaces sidebar `Add Project` button with a `Popover` dropdown offering `Open Folder`, `Create New`, and `Clone from GitHub` (`LeftSidebar.tsx`)
> - Adds `onCloneProject` prop and new accessible `MenuItemButton` for keyboard/ARIA-friendly menu actions
> - Extracts `handleNewProjectClick` and `handleCloneProjectClick` in `App.tsx` with telemetry events and GitHub auth/installation checks; wires them into home cards and `LeftSidebar`
> - Minor imports/props updates (e.g., `Popover`, `Github` icon) to support the new UI
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6d8812f49e4452a097ee45060c10ab542bcdfe95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->