### PR TITLE
fix(github): gracefully handle repos without remotes and detect system gh auth

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -674,10 +674,18 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
       }
 
       try {
+        // Check if remote exists before attempting to fetch
         try {
-          await execAsync(`git fetch --prune ${remote}`, { cwd: projectPath });
-        } catch (fetchError) {
-          log.warn('Failed to fetch remote before listing branches', fetchError);
+          await execAsync(`git remote get-url ${remote}`, { cwd: projectPath });
+          // Remote exists, try to fetch
+          try {
+            await execAsync(`git fetch --prune ${remote}`, { cwd: projectPath });
+          } catch (fetchError) {
+            log.warn('Failed to fetch remote before listing branches', fetchError);
+          }
+        } catch {
+          // Remote doesn't exist, skip fetch and continue to list local branches
+          log.debug(`Remote '${remote}' not found, skipping fetch`);
         }
 
         const { stdout } = await execAsync(


### PR DESCRIPTION
  - Detect system-wide gh CLI authentication (gh auth status)
  - Check for remote existence before git fetch --prune
  - Check for GitHub remote before gh CLI commands
  - Return empty arrays instead of throwing errors
  - Prevents error stack traces for non-GitHub/non-remote repos

  Fixes: "GitHub CLI not authenticated" false positives
  Fixes: "fatal: 'origin' does not appear to be a git repository" errors
  Fixes: "no git remotes found" errors on non-GitHub repos