### PR TITLE
fix(pr-generation): compare against remote branch to prevent incorrect PR   descriptions

### DIFF
--- a/src/main/services/PrGenerationService.ts
+++ b/src/main/services/PrGenerationService.ts
@@ -136,13 +136,10 @@ export class PrGenerationService {
       if (baseBranchExists) {
         // Get diff between base branch and current HEAD (committed changes)
         try {
-          const { stdout: diffOut } = await execAsync(
-            `git diff ${baseBranchRef}...HEAD --stat`,
-            {
-              cwd: taskPath,
-              maxBuffer: 10 * 1024 * 1024,
-            }
-          );
+          const { stdout: diffOut } = await execAsync(`git diff ${baseBranchRef}...HEAD --stat`, {
+            cwd: taskPath,
+            maxBuffer: 10 * 1024 * 1024,
+          });
           diff = diffOut || '';
 
           // Get list of changed files from commits


### PR DESCRIPTION
When generating PR titles and descriptions, the system was comparing against the user's local `main` branch. If that local branch was stale (behind `origin/main`), the diff would incorrectly include commits from other developers' merged PRs.

Solution
- Fetch `origin` before generating PR content to ensure latest refs
- Prioritize `origin/main` over local `main` when comparing branches
- Use the remote ref in all git diff/log commands