### PR TITLE
feat: add debate mode for parallel agent comparison

### DIFF
--- a/src/main/ipc/debateIpc.ts
+++ b/src/main/ipc/debateIpc.ts
@@ -1,0 +1,298 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { log } from '../lib/logger';
+import {
+  HeadlessAgentRunner,
+  HeadlessAgentProgress,
+  getWorktreeDiff,
+  runJudge,
+} from '../services/HeadlessAgentService';
+
+export interface DebateConfig {
+  worktreeA: {
+    id: string;
+    path: string;
+  };
+  worktreeB: {
+    id: string;
+    path: string;
+  };
+  prompt: string;
+  baseBranch?: string;
+}
+
+export interface DebateProgress {
+  phase: 'running' | 'judging' | 'complete' | 'error';
+  agentA: {
+    status: 'running' | 'complete' | 'error';
+    currentTool?: string;
+    elapsedMs: number;
+    error?: string;
+  };
+  agentB: {
+    status: 'running' | 'complete' | 'error';
+    currentTool?: string;
+    elapsedMs: number;
+    error?: string;
+  };
+  judge?: {
+    status: 'running' | 'complete' | 'error';
+    elapsedMs: number;
+  };
+}
+
+export interface DebateResult {
+  success: boolean;
+  winner?: 'A' | 'B';
+  reasoning?: string;
+  diffA?: string;
+  diffB?: string;
+  winnerWorktreePath?: string;
+  loserWorktreePath?: string;
+  error?: string;
+}
+
+// Track active debates for cancellation
+const activeDebates = new Map<
+  string,
+  { runnerA: HeadlessAgentRunner; runnerB: HeadlessAgentRunner }
+>();
+
+function broadcastProgress(debateId: string, progress: DebateProgress) {
+  BrowserWindow.getAllWindows().forEach((win) => {
+    try {
+      win.webContents.send('debate:progress', { debateId, progress });
+    } catch {}
+  });
+}
+
+function broadcastResult(debateId: string, result: DebateResult) {
+  BrowserWindow.getAllWindows().forEach((win) => {
+    try {
+      win.webContents.send('debate:result', { debateId, result });
+    } catch {}
+  });
+}
+
+export function registerDebateIpc() {
+  // Start a debate between two agents
+  ipcMain.handle(
+    'debate:start',
+    async (
+      _,
+      args: { debateId: string; config: DebateConfig }
+    ): Promise<{ success: boolean; error?: string }> => {
+      const { debateId, config } = args;
+
+      log.info('debate:start', {
+        debateId,
+        worktreeA: config.worktreeA.path,
+        worktreeB: config.worktreeB.path,
+      });
+
+      const progress: DebateProgress = {
+        phase: 'running',
+        agentA: { status: 'running', elapsedMs: 0 },
+        agentB: { status: 'running', elapsedMs: 0 },
+      };
+
+      try {
+        const runnerA = new HeadlessAgentRunner(config.worktreeA.path, config.prompt);
+        const runnerB = new HeadlessAgentRunner(config.worktreeB.path, config.prompt);
+
+        activeDebates.set(debateId, { runnerA, runnerB });
+
+        // Set up progress listeners
+        runnerA.on('progress', (p: HeadlessAgentProgress) => {
+          progress.agentA.elapsedMs = p.elapsedMs;
+          if (p.type === 'tool_use') {
+            progress.agentA.currentTool = p.toolName;
+          } else if (p.type === 'complete') {
+            progress.agentA.status = 'complete';
+            progress.agentA.currentTool = undefined;
+          } else if (p.type === 'error') {
+            progress.agentA.status = 'error';
+            progress.agentA.error = p.text;
+          }
+          broadcastProgress(debateId, progress);
+        });
+
+        runnerB.on('progress', (p: HeadlessAgentProgress) => {
+          progress.agentB.elapsedMs = p.elapsedMs;
+          if (p.type === 'tool_use') {
+            progress.agentB.currentTool = p.toolName;
+          } else if (p.type === 'complete') {
+            progress.agentB.status = 'complete';
+            progress.agentB.currentTool = undefined;
+          } else if (p.type === 'error') {
+            progress.agentB.status = 'error';
+            progress.agentB.error = p.text;
+          }
+          broadcastProgress(debateId, progress);
+        });
+
+        // Broadcast initial state
+        broadcastProgress(debateId, progress);
+
+        // Run agents in background - don't await, return immediately so modal closes
+        runDebateInBackground(debateId, config, progress, runnerA, runnerB);
+
+        return { success: true };
+      } catch (err: any) {
+        log.error('debate:start:error', { debateId, error: err.message });
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Cancel an ongoing debate
+  ipcMain.handle('debate:cancel', async (_, args: { debateId: string }) => {
+    const { debateId } = args;
+    const debate = activeDebates.get(debateId);
+
+    if (debate) {
+      log.info('debate:cancel', { debateId });
+      debate.runnerA.kill();
+      debate.runnerB.kill();
+      activeDebates.delete(debateId);
+      return { success: true };
+    }
+
+    return { success: false, error: 'No active debate found' };
+  });
+}
+
+// Run the debate flow in the background
+async function runDebateInBackground(
+  debateId: string,
+  config: DebateConfig,
+  progress: DebateProgress,
+  runnerA: HeadlessAgentRunner,
+  runnerB: HeadlessAgentRunner
+) {
+  try {
+    // Run both agents in parallel
+    const [resultA, resultB] = await Promise.all([runnerA.start(), runnerB.start()]);
+
+    // Update progress with final results
+    progress.agentA.status = resultA.success ? 'complete' : 'error';
+    progress.agentA.elapsedMs = resultA.elapsedMs;
+    if (!resultA.success) progress.agentA.error = resultA.error;
+
+    progress.agentB.status = resultB.success ? 'complete' : 'error';
+    progress.agentB.elapsedMs = resultB.elapsedMs;
+    if (!resultB.success) progress.agentB.error = resultB.error;
+
+    broadcastProgress(debateId, progress);
+
+    // Handle cases where one or both agents failed
+    if (!resultA.success && !resultB.success) {
+      const result: DebateResult = {
+        success: false,
+        error: 'Both agents failed to complete',
+      };
+      broadcastResult(debateId, result);
+      activeDebates.delete(debateId);
+      return;
+    }
+
+    // Get diffs from both worktrees
+    const baseBranch = config.baseBranch || 'main';
+    let diffA = '';
+    let diffB = '';
+
+    try {
+      diffA = resultA.success ? await getWorktreeDiff(config.worktreeA.path, baseBranch) : '';
+    } catch (err) {
+      log.warn('debate:getDiffA:error', { error: err });
+    }
+
+    try {
+      diffB = resultB.success ? await getWorktreeDiff(config.worktreeB.path, baseBranch) : '';
+    } catch (err) {
+      log.warn('debate:getDiffB:error', { error: err });
+    }
+
+    // If only one agent succeeded, that's the winner
+    if (!resultA.success || !diffA) {
+      const result: DebateResult = {
+        success: true,
+        winner: 'B',
+        reasoning: 'Agent A failed or produced no changes, defaulting to Agent B',
+        diffA,
+        diffB,
+        winnerWorktreePath: config.worktreeB.path,
+        loserWorktreePath: config.worktreeA.path,
+      };
+      broadcastResult(debateId, result);
+      activeDebates.delete(debateId);
+      return;
+    }
+
+    if (!resultB.success || !diffB) {
+      const result: DebateResult = {
+        success: true,
+        winner: 'A',
+        reasoning: 'Agent B failed or produced no changes, defaulting to Agent A',
+        diffA,
+        diffB,
+        winnerWorktreePath: config.worktreeA.path,
+        loserWorktreePath: config.worktreeB.path,
+      };
+      broadcastResult(debateId, result);
+      activeDebates.delete(debateId);
+      return;
+    }
+
+    // Both succeeded - run the judge
+    progress.phase = 'judging';
+    progress.judge = { status: 'running', elapsedMs: 0 };
+    broadcastProgress(debateId, progress);
+
+    const judgeResult = await runJudge(config.prompt, diffA, diffB, (p) => {
+      if (progress.judge) {
+        progress.judge.elapsedMs = p.elapsedMs;
+        if (p.type === 'complete') {
+          progress.judge.status = 'complete';
+        }
+        broadcastProgress(debateId, progress);
+      }
+    });
+
+    progress.phase = 'complete';
+    if (progress.judge) progress.judge.status = 'complete';
+    broadcastProgress(debateId, progress);
+
+    const result: DebateResult = {
+      success: judgeResult.success,
+      winner: judgeResult.winner,
+      reasoning: judgeResult.reasoning,
+      diffA,
+      diffB,
+      winnerWorktreePath:
+        judgeResult.winner === 'A' ? config.worktreeA.path : config.worktreeB.path,
+      loserWorktreePath: judgeResult.winner === 'A' ? config.worktreeB.path : config.worktreeA.path,
+      error: judgeResult.error,
+    };
+
+    broadcastResult(debateId, result);
+    activeDebates.delete(debateId);
+
+    log.info('debate:complete', {
+      debateId,
+      winner: result.winner,
+      reasoning: result.reasoning?.slice(0, 100),
+    });
+  } catch (err: any) {
+    log.error('debate:error', { debateId, error: err.message });
+
+    progress.phase = 'error';
+    broadcastProgress(debateId, progress);
+
+    const result: DebateResult = {
+      success: false,
+      error: err.message || 'Unknown error during debate',
+    };
+    broadcastResult(debateId, result);
+    activeDebates.delete(debateId);
+  }
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -21,6 +21,7 @@ import { registerHostPreviewIpc } from './hostPreviewIpc';
 import { registerBrowserIpc } from './browserIpc';
 import { registerNetIpc } from './netIpc';
 import { registerLineCommentsIpc } from './lineCommentsIpc';
+import { registerDebateIpc } from './debateIpc';
 
 export function registerAllIpc() {
   // Core app/utility IPC
@@ -50,4 +51,5 @@ export function registerAllIpc() {
   registerConnectionsIpc();
   registerJiraIpc();
   registerPlanLockIpc();
+  registerDebateIpc();
 }

--- a/src/main/services/HeadlessAgentService.ts
+++ b/src/main/services/HeadlessAgentService.ts
@@ -1,0 +1,435 @@
+import { spawn, ChildProcess } from 'child_process';
+import { EventEmitter } from 'events';
+import { log } from '../lib/logger';
+
+export interface HeadlessAgentProgress {
+  type: 'tool_use' | 'text' | 'complete' | 'error';
+  toolName?: string;
+  text?: string;
+  elapsedMs: number;
+}
+
+export interface HeadlessAgentResult {
+  success: boolean;
+  output: string;
+  elapsedMs: number;
+  error?: string;
+}
+
+interface StreamMessage {
+  type: 'assistant' | 'user' | 'system' | 'result';
+  subtype?: 'init';
+  message?: {
+    content?: Array<{
+      type: 'text' | 'tool_use' | 'tool_result';
+      text?: string;
+      name?: string;
+      input?: Record<string, unknown>;
+    }>;
+  };
+  status?: 'success' | 'error';
+  duration_ms?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+
+export class HeadlessAgentRunner extends EventEmitter {
+  private proc: ChildProcess | null = null;
+  private output = '';
+  private lineBuffer = ''; // Buffer for incomplete lines from stdout
+  private startTime = 0;
+  private worktreePath: string;
+  private prompt: string;
+  private timeoutMs: number;
+  private timeoutId: NodeJS.Timeout | null = null;
+
+  constructor(worktreePath: string, prompt: string, timeoutMs = DEFAULT_TIMEOUT_MS) {
+    super();
+    this.worktreePath = worktreePath;
+    this.prompt = prompt;
+    this.timeoutMs = timeoutMs;
+  }
+
+  start(): Promise<HeadlessAgentResult> {
+    return new Promise((resolve, reject) => {
+      this.startTime = Date.now();
+
+      try {
+        this.proc = spawn(
+          'claude',
+          ['-p', this.prompt, '--output-format', 'stream-json', '--dangerously-skip-permissions'],
+          {
+            cwd: this.worktreePath,
+            env: { ...process.env },
+            shell: true,
+          }
+        );
+
+        log.info('HeadlessAgentService:started', {
+          worktreePath: this.worktreePath,
+          pid: this.proc.pid,
+        });
+
+        // Set timeout
+        this.timeoutId = setTimeout(() => {
+          log.warn('HeadlessAgentService:timeout', { worktreePath: this.worktreePath });
+          this.kill();
+          resolve({
+            success: false,
+            output: this.output,
+            elapsedMs: Date.now() - this.startTime,
+            error: 'Agent timed out',
+          });
+        }, this.timeoutMs);
+
+        this.proc.stdout?.on('data', (data: Buffer) => {
+          const chunk = data.toString();
+          log.info('HeadlessAgentService:stdout', {
+            worktreePath: this.worktreePath,
+            length: chunk.length,
+            preview: chunk.slice(0, 300),
+          });
+          this.output += chunk;
+          this.parseStreamChunk(chunk);
+        });
+
+        this.proc.stderr?.on('data', (data: Buffer) => {
+          log.warn('HeadlessAgentService:stderr', {
+            worktreePath: this.worktreePath,
+            data: data.toString().slice(0, 500),
+          });
+        });
+
+        this.proc.on('error', (err) => {
+          log.error('HeadlessAgentService:error', { error: err.message });
+          this.clearTimeout();
+          reject(err);
+        });
+
+        this.proc.on('exit', (code) => {
+          this.clearTimeout();
+          const elapsedMs = Date.now() - this.startTime;
+          log.info('HeadlessAgentService:exit', {
+            code,
+            elapsedMs,
+            worktreePath: this.worktreePath,
+          });
+
+          this.emit('progress', {
+            type: 'complete',
+            elapsedMs,
+          } as HeadlessAgentProgress);
+
+          resolve({
+            success: code === 0,
+            output: this.output,
+            elapsedMs,
+            error: code !== 0 ? `Process exited with code ${code}` : undefined,
+          });
+        });
+      } catch (err: any) {
+        log.error('HeadlessAgentService:spawnError', { error: err.message });
+        reject(err);
+      }
+    });
+  }
+
+  private parseStreamChunk(chunk: string): void {
+    // Append chunk to buffer
+    this.lineBuffer += chunk;
+
+    // Process complete lines (those ending with \n)
+    const lines = this.lineBuffer.split('\n');
+
+    // Keep the last element in buffer (it's either empty or an incomplete line)
+    this.lineBuffer = lines.pop() || '';
+
+    for (const line of lines) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+
+      try {
+        const msg: StreamMessage = JSON.parse(trimmed);
+        this.handleStreamMessage(msg);
+      } catch {
+        // Not valid JSON, skip
+      }
+    }
+  }
+
+  private handleStreamMessage(msg: StreamMessage): void {
+    const elapsedMs = Date.now() - this.startTime;
+
+    if (msg.type === 'assistant' && msg.message?.content) {
+      for (const content of msg.message.content) {
+        if (content.type === 'tool_use' && content.name) {
+          this.emit('progress', {
+            type: 'tool_use',
+            toolName: content.name,
+            elapsedMs,
+          } as HeadlessAgentProgress);
+        } else if (content.type === 'text' && content.text) {
+          this.emit('progress', {
+            type: 'text',
+            text: content.text.slice(0, 100), // Truncate for progress display
+            elapsedMs,
+          } as HeadlessAgentProgress);
+        }
+      }
+    }
+
+    if (msg.type === 'result') {
+      this.emit('progress', {
+        type: 'complete',
+        elapsedMs,
+      } as HeadlessAgentProgress);
+    }
+  }
+
+  private clearTimeout(): void {
+    if (this.timeoutId) {
+      clearTimeout(this.timeoutId);
+      this.timeoutId = null;
+    }
+  }
+
+  kill(): void {
+    this.clearTimeout();
+    if (this.proc && !this.proc.killed) {
+      this.proc.kill('SIGTERM');
+      log.info('HeadlessAgentService:killed', { worktreePath: this.worktreePath });
+    }
+  }
+}
+
+/**
+ * Run multiple headless agents in parallel and return when all complete
+ */
+export async function runHeadlessAgents(
+  configs: Array<{ worktreePath: string; prompt: string; id: string }>,
+  onProgress?: (id: string, progress: HeadlessAgentProgress) => void
+): Promise<Map<string, HeadlessAgentResult>> {
+  const runners = configs.map((config) => {
+    const runner = new HeadlessAgentRunner(config.worktreePath, config.prompt);
+
+    if (onProgress) {
+      runner.on('progress', (progress: HeadlessAgentProgress) => {
+        onProgress(config.id, progress);
+      });
+    }
+
+    return {
+      id: config.id,
+      runner,
+      promise: runner.start(),
+    };
+  });
+
+  const results = new Map<string, HeadlessAgentResult>();
+
+  // Wait for all to complete (or fail)
+  const settled = await Promise.allSettled(runners.map((r) => r.promise));
+
+  for (let i = 0; i < runners.length; i++) {
+    const { id } = runners[i];
+    const result = settled[i];
+
+    if (result.status === 'fulfilled') {
+      results.set(id, result.value);
+    } else {
+      results.set(id, {
+        success: false,
+        output: '',
+        elapsedMs: 0,
+        error: result.reason?.message || 'Unknown error',
+      });
+    }
+  }
+
+  return results;
+}
+
+/**
+ * Get git diff for a worktree compared to its base branch
+ */
+export async function getWorktreeDiff(worktreePath: string, baseBranch = 'main'): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const proc = spawn('git', ['diff', `${baseBranch}...HEAD`], {
+      cwd: worktreePath,
+    });
+
+    let output = '';
+    let stderr = '';
+
+    proc.stdout?.on('data', (data: Buffer) => {
+      output += data.toString();
+    });
+
+    proc.stderr?.on('data', (data: Buffer) => {
+      stderr += data.toString();
+    });
+
+    proc.on('exit', (code) => {
+      if (code === 0) {
+        // TODO: Handle edge case for massive diffs - log size for now
+        const diffSizeKb = Math.round(output.length / 1024);
+        if (diffSizeKb > 50) {
+          log.warn('HeadlessAgentService:largeDiff', {
+            worktreePath,
+            sizeKb: diffSizeKb,
+          });
+        }
+        resolve(output);
+      } else {
+        reject(new Error(`git diff failed: ${stderr}`));
+      }
+    });
+
+    proc.on('error', reject);
+  });
+}
+
+export interface JudgeResult {
+  winner: 'A' | 'B';
+  reasoning: string;
+  success: boolean;
+  error?: string;
+}
+
+/**
+ * Run the judge to compare two solutions and pick the best one
+ */
+export async function runJudge(
+  originalPrompt: string,
+  diffA: string,
+  diffB: string,
+  onProgress?: (progress: HeadlessAgentProgress) => void
+): Promise<JudgeResult> {
+  const judgePrompt = `You are a code review judge. Compare these two solutions for the following task and pick the better one.
+
+TASK: ${originalPrompt}
+
+SOLUTION A:
+\`\`\`diff
+${diffA.slice(0, 50000)}
+\`\`\`
+
+SOLUTION B:
+\`\`\`diff
+${diffB.slice(0, 50000)}
+\`\`\`
+
+Analyze both solutions and reply with ONLY valid JSON in this exact format:
+{"winner": "A" or "B", "reasoning": "Brief explanation of why this solution is better"}`;
+
+  return new Promise((resolve) => {
+    const startTime = Date.now();
+    const proc = spawn(
+      'claude',
+      ['-p', judgePrompt, '--output-format', 'stream-json', '--dangerously-skip-permissions'],
+      { shell: true }
+    );
+
+    let output = '';
+
+    proc.stdout?.on('data', (data: Buffer) => {
+      const chunk = data.toString();
+      output += chunk;
+
+      // Emit progress for tool usage
+      const lines = chunk.split('\n').filter((line) => line.trim());
+      for (const line of lines) {
+        try {
+          const msg = JSON.parse(line);
+          if (msg.type === 'assistant' && msg.message?.content) {
+            for (const content of msg.message.content) {
+              if (content.type === 'tool_use' && content.name) {
+                onProgress?.({
+                  type: 'tool_use',
+                  toolName: content.name,
+                  elapsedMs: Date.now() - startTime,
+                });
+              }
+            }
+          }
+        } catch {
+          // Not valid JSON
+        }
+      }
+    });
+
+    proc.on('exit', (code) => {
+      const elapsedMs = Date.now() - startTime;
+      onProgress?.({ type: 'complete', elapsedMs });
+
+      if (code !== 0) {
+        resolve({
+          winner: 'A',
+          reasoning: 'Judge failed to run, defaulting to solution A',
+          success: false,
+          error: `Judge exited with code ${code}`,
+        });
+        return;
+      }
+
+      // Parse the output to find the JSON result
+      // Look for JSON in assistant messages
+      try {
+        const lines = output.split('\n').filter((line) => line.trim());
+        for (const line of lines) {
+          try {
+            const msg = JSON.parse(line);
+            if (msg.type === 'assistant' && msg.message?.content) {
+              for (const content of msg.message.content) {
+                if (content.type === 'text' && content.text) {
+                  // Try to extract JSON from the text
+                  const jsonMatch = content.text.match(
+                    /\{[\s\S]*"winner"[\s\S]*"reasoning"[\s\S]*\}/
+                  );
+                  if (jsonMatch) {
+                    const result = JSON.parse(jsonMatch[0]);
+                    if (result.winner === 'A' || result.winner === 'B') {
+                      resolve({
+                        winner: result.winner,
+                        reasoning: result.reasoning || 'No reasoning provided',
+                        success: true,
+                      });
+                      return;
+                    }
+                  }
+                }
+              }
+            }
+          } catch {
+            // Continue parsing
+          }
+        }
+
+        // Fallback if no valid JSON found
+        log.warn('HeadlessAgentService:judgeParseError', { output: output.slice(0, 500) });
+        resolve({
+          winner: 'A',
+          reasoning: 'Could not parse judge response, defaulting to solution A',
+          success: false,
+          error: 'Failed to parse judge response',
+        });
+      } catch (err: any) {
+        resolve({
+          winner: 'A',
+          reasoning: 'Judge error, defaulting to solution A',
+          success: false,
+          error: err.message,
+        });
+      }
+    });
+
+    proc.on('error', (err) => {
+      resolve({
+        winner: 'A',
+        reasoning: 'Judge failed to start',
+        success: false,
+        error: err.message,
+      });
+    });
+  });
+}

--- a/src/renderer/components/DebateProgressCard.tsx
+++ b/src/renderer/components/DebateProgressCard.tsx
@@ -1,0 +1,190 @@
+import React from 'react';
+import { motion } from 'motion/react';
+import { Bot, CheckCircle2, XCircle, Clock, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from './ui/button';
+
+export interface AgentProgress {
+  id: string;
+  status: 'running' | 'complete' | 'error';
+  currentTool?: string;
+  elapsedMs: number;
+  error?: string;
+}
+
+interface DebateProgressCardProps {
+  taskName: string;
+  prompt: string;
+  agents: AgentProgress[];
+  judgeStatus?: 'running' | 'complete' | 'error';
+  judgeElapsedMs?: number;
+  onCancel?: () => void;
+}
+
+function formatElapsed(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  if (minutes > 0) {
+    return `${minutes}m ${remainingSeconds}s`;
+  }
+  return `${seconds}s`;
+}
+
+const ShimmerText: React.FC<{ children: React.ReactNode; className?: string }> = ({
+  children,
+  className,
+}) => (
+  <motion.span
+    className={cn('inline-block', className)}
+    animate={{
+      opacity: [0.5, 1, 0.5],
+    }}
+    transition={{
+      duration: 1.5,
+      repeat: Infinity,
+      ease: 'easeInOut',
+    }}
+  >
+    {children}
+  </motion.span>
+);
+
+const AgentStatusRow: React.FC<{ agent: AgentProgress }> = ({ agent }) => {
+  const isRunning = agent.status === 'running';
+  const isComplete = agent.status === 'complete';
+  const isError = agent.status === 'error';
+
+  return (
+    <div
+      className={cn(
+        'flex items-center gap-3 rounded-md border px-3 py-2',
+        isRunning && 'border-blue-500/30 bg-blue-500/5',
+        isComplete && 'border-green-500/30 bg-green-500/5',
+        isError && 'border-red-500/30 bg-red-500/5'
+      )}
+    >
+      <div
+        className={cn(
+          'flex h-8 w-8 items-center justify-center rounded-full',
+          isRunning && 'bg-blue-500/20',
+          isComplete && 'bg-green-500/20',
+          isError && 'bg-red-500/20'
+        )}
+      >
+        {isRunning && <Bot className="h-4 w-4 text-blue-500" />}
+        {isComplete && <CheckCircle2 className="h-4 w-4 text-green-500" />}
+        {isError && <XCircle className="h-4 w-4 text-red-500" />}
+      </div>
+
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <span className="text-sm font-medium">Agent {agent.id}</span>
+          {isRunning && (
+            <span className="rounded bg-blue-500/20 px-1.5 py-0.5 text-[10px] font-medium text-blue-600 dark:text-blue-400">
+              running
+            </span>
+          )}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {isRunning && agent.currentTool ? (
+            <ShimmerText>{agent.currentTool}...</ShimmerText>
+          ) : isRunning ? (
+            <ShimmerText>Thinking...</ShimmerText>
+          ) : isComplete ? (
+            'Completed'
+          ) : (
+            agent.error || 'Failed'
+          )}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-1 text-xs text-muted-foreground">
+        <Clock className="h-3 w-3" />
+        {formatElapsed(agent.elapsedMs)}
+      </div>
+    </div>
+  );
+};
+
+export const DebateProgressCard: React.FC<DebateProgressCardProps> = ({
+  taskName,
+  prompt,
+  agents,
+  judgeStatus,
+  judgeElapsedMs,
+  onCancel,
+}) => {
+  const allAgentsComplete = agents.every((a) => a.status === 'complete' || a.status === 'error');
+  const isJudging = judgeStatus === 'running';
+
+  return (
+    <div className="space-y-4 rounded-lg border bg-card p-4">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-lg font-semibold">Debate Mode</h3>
+          <p className="mt-1 text-sm text-muted-foreground">{taskName}</p>
+        </div>
+        {onCancel && (
+          <Button variant="ghost" size="sm" onClick={onCancel} className="shrink-0">
+            <X className="mr-1.5 h-3.5 w-3.5" />
+            Cancel
+          </Button>
+        )}
+      </div>
+
+      {/* Prompt preview */}
+      <div className="rounded-md border bg-muted/30 p-3">
+        <p className="text-xs text-muted-foreground">Prompt</p>
+        <p className="mt-1 line-clamp-3 text-sm">{prompt}</p>
+      </div>
+
+      {/* Status header */}
+      <div className="flex items-center gap-2">
+        <h4 className="text-sm font-medium">
+          {!allAgentsComplete && 'Agents working...'}
+          {allAgentsComplete && isJudging && 'Judging solutions...'}
+          {allAgentsComplete && !isJudging && judgeStatus === 'complete' && 'Debate complete'}
+        </h4>
+        {(!allAgentsComplete || isJudging) && (
+          <motion.div
+            className={cn('h-2 w-2 rounded-full', isJudging ? 'bg-amber-500' : 'bg-blue-500')}
+            animate={{ scale: [1, 1.2, 1] }}
+            transition={{ duration: 1, repeat: Infinity }}
+          />
+        )}
+      </div>
+
+      {/* Agent statuses */}
+      <div className="space-y-2">
+        {agents.map((agent) => (
+          <AgentStatusRow key={agent.id} agent={agent} />
+        ))}
+      </div>
+
+      {/* Judge status */}
+      {isJudging && (
+        <div className="flex items-center gap-3 rounded-md border border-amber-500/30 bg-amber-500/5 px-3 py-2">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-500/20">
+            <Bot className="h-4 w-4 text-amber-500" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-medium">Judge</div>
+            <ShimmerText className="text-xs text-muted-foreground">
+              Comparing solutions...
+            </ShimmerText>
+          </div>
+          {judgeElapsedMs !== undefined && (
+            <div className="flex items-center gap-1 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              {formatElapsed(judgeElapsedMs)}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DebateProgressCard;

--- a/src/renderer/components/DebateResultsView.tsx
+++ b/src/renderer/components/DebateResultsView.tsx
@@ -1,0 +1,150 @@
+import React from 'react';
+import { Trophy, GitCompare, ArrowRight, ChevronDown, ChevronUp } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from './ui/button';
+
+interface DebateResult {
+  winner: 'A' | 'B';
+  reasoning: string;
+  diffA: string;
+  diffB: string;
+  winnerWorktreePath: string;
+  loserWorktreePath: string;
+}
+
+interface DebateResultsViewProps {
+  result: DebateResult;
+  onFollowUp?: () => void;
+  onDiscard?: () => void;
+  onViewDiff?: (diff: string, label: string) => void;
+}
+
+export const DebateResultsView: React.FC<DebateResultsViewProps> = ({
+  result,
+  onFollowUp,
+  onDiscard,
+  onViewDiff,
+}) => {
+  const [showDiffs, setShowDiffs] = React.useState(false);
+  const [selectedDiff, setSelectedDiff] = React.useState<'A' | 'B'>(result.winner);
+
+  const winnerLabel = `Agent ${result.winner}`;
+  const loserLabel = result.winner === 'A' ? 'Agent B' : 'Agent A';
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Header */}
+      <div className="border-b px-6 py-4">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-amber-500/20">
+            <Trophy className="h-5 w-5 text-amber-500" />
+          </div>
+          <div>
+            <h2 className="text-lg font-semibold">Debate Complete</h2>
+            <p className="text-sm text-muted-foreground">{winnerLabel} won the debate</p>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="flex-1 overflow-auto p-6">
+        <div className="mx-auto max-w-3xl space-y-6">
+          {/* Winner announcement */}
+          <div className="rounded-lg border border-green-500/30 bg-green-500/5 p-4">
+            <div className="flex items-center gap-2 text-green-600 dark:text-green-400">
+              <Trophy className="h-4 w-4" />
+              <span className="font-medium">Winner: {winnerLabel}</span>
+            </div>
+          </div>
+
+          {/* Judge reasoning */}
+          <div className="space-y-2">
+            <h3 className="text-sm font-medium">Judge's Reasoning</h3>
+            <div className="rounded-md border bg-muted/30 p-4">
+              <p className="whitespace-pre-wrap text-sm">{result.reasoning}</p>
+            </div>
+          </div>
+
+          {/* Diff viewer toggle */}
+          <div className="space-y-3">
+            <button
+              onClick={() => setShowDiffs(!showDiffs)}
+              className="flex w-full items-center justify-between rounded-md border bg-muted/30 px-4 py-3 text-left transition-colors hover:bg-muted/50"
+            >
+              <div className="flex items-center gap-2">
+                <GitCompare className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium">View Solution Diffs</span>
+              </div>
+              {showDiffs ? (
+                <ChevronUp className="h-4 w-4 text-muted-foreground" />
+              ) : (
+                <ChevronDown className="h-4 w-4 text-muted-foreground" />
+              )}
+            </button>
+
+            {showDiffs && (
+              <div className="space-y-3">
+                {/* Diff tabs */}
+                <div className="flex gap-2">
+                  <button
+                    onClick={() => setSelectedDiff('A')}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                      selectedDiff === 'A'
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted hover:bg-muted/80'
+                    )}
+                  >
+                    Agent A{result.winner === 'A' && <Trophy className="h-3 w-3 text-amber-400" />}
+                  </button>
+                  <button
+                    onClick={() => setSelectedDiff('B')}
+                    className={cn(
+                      'flex items-center gap-2 rounded-md px-3 py-1.5 text-sm font-medium transition-colors',
+                      selectedDiff === 'B'
+                        ? 'bg-primary text-primary-foreground'
+                        : 'bg-muted hover:bg-muted/80'
+                    )}
+                  >
+                    Agent B{result.winner === 'B' && <Trophy className="h-3 w-3 text-amber-400" />}
+                  </button>
+                </div>
+
+                {/* Diff content */}
+                <div className="max-h-[400px] overflow-auto rounded-md border bg-background">
+                  <pre className="p-4 text-xs">
+                    <code>{selectedDiff === 'A' ? result.diffA : result.diffB}</code>
+                  </pre>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+
+      {/* Footer actions */}
+      <div className="border-t px-6 py-4">
+        <div className="flex items-center justify-between">
+          <p className="text-sm text-muted-foreground">
+            Continue working with the winning solution?
+          </p>
+          <div className="flex gap-3">
+            {onDiscard && (
+              <Button variant="outline" onClick={onDiscard}>
+                Discard Both
+              </Button>
+            )}
+            {onFollowUp && (
+              <Button onClick={onFollowUp}>
+                Open {winnerLabel}'s Solution
+                <ArrowRight className="ml-2 h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DebateResultsView;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -772,6 +772,57 @@ declare global {
         comments?: LineComment[];
         error?: string;
       }>;
+
+      // Debate mode
+      debateStart: (args: {
+        debateId: string;
+        config: {
+          worktreeA: { id: string; path: string };
+          worktreeB: { id: string; path: string };
+          prompt: string;
+          baseBranch?: string;
+        };
+      }) => Promise<{ success: boolean; error?: string }>;
+      debateCancel: (args: { debateId: string }) => Promise<{ success: boolean; error?: string }>;
+      onDebateProgress: (
+        callback: (data: {
+          debateId: string;
+          progress: {
+            phase: 'running' | 'judging' | 'complete' | 'error';
+            agentA: {
+              status: 'running' | 'complete' | 'error';
+              currentTool?: string;
+              elapsedMs: number;
+              error?: string;
+            };
+            agentB: {
+              status: 'running' | 'complete' | 'error';
+              currentTool?: string;
+              elapsedMs: number;
+              error?: string;
+            };
+            judge?: {
+              status: 'running' | 'complete' | 'error';
+              elapsedMs: number;
+            };
+          };
+        }) => void
+      ) => () => void;
+      onDebateResult: (
+        callback: (data: {
+          debateId: string;
+          result: {
+            success: boolean;
+            winner?: 'A' | 'B';
+            reasoning?: string;
+            diffA?: string;
+            diffB?: string;
+            winnerWorktreePath?: string;
+            loserWorktreePath?: string;
+            error?: string;
+          };
+        }) => void
+      ) => () => void;
     };
   }
 }


### PR DESCRIPTION
## Summary

Add experimental "debate mode" feature that runs 2 Claude agents in parallel on the same task, then uses a judge agent to compare solutions and pick the best.

- Add HeadlessAgentService for spawning headless Claude CLI agents
- Add debateIpc handlers for starting/canceling debates and progress events
- Add DebateProgressCard component showing agent status during execution
- Add DebateResultsView component for viewing judge's decision and diffs
- Update TaskModal with debate mode toggle (Claude-only, experimental)
- Wire up App.tsx with debate state management and event listeners

## Status

**WIP** - stdout parsing from the headless agent process needs debugging. The agents spawn but output isn't being captured correctly.

## Test plan

- [ ] Enable debate mode in new task modal (only shows for Claude provider)
- [ ] Enter a prompt and start a debate
- [ ] Verify two worktrees are created (agent-a and agent-b)
- [ ] Verify progress updates show in the UI
- [ ] After agents complete, verify judge comparison runs
- [ ] Verify results view shows winner and reasoning