### PR TITLE
fix(terminal): allow scrolling while agent is running

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -462,9 +462,7 @@ export class TerminalSessionManager {
       // Check if at bottom BEFORE writing - if yes, we'll scroll to stay at bottom
       // If user has scrolled up, they stay where they are
       const buffer = this.terminal.buffer?.active;
-      const isAtBottom = buffer
-        ? buffer.baseY - buffer.viewportY <= 2
-        : true;
+      const isAtBottom = buffer ? buffer.baseY - buffer.viewportY <= 2 : true;
 
       this.terminal.write(chunk);
       if (!this.firstFrameRendered) {


### PR DESCRIPTION
## Summary
- Allow users to scroll up to read previous output while an agent is actively running
- Auto-scroll only if user is already at bottom (stay-at-bottom behavior)
- If user scrolls up, they stay where they are until they scroll back down

## Problem
Users couldn't scroll up to read previous terminal output while an agent was running - the terminal kept snapping back to the bottom with each new chunk of output.

## Solution
Simple check before each write: if viewport is at bottom, auto-scroll after write to stay at bottom. If user has scrolled up, don't auto-scroll.

No state tracking or scroll event listeners needed - just check position before write.

## Test plan
- [ ] Start an agent task that produces output
- [ ] While running, scroll up - should stay scrolled up
- [ ] Scroll back to bottom - should resume auto-scrolling
- [ ] Reopen a task - should scroll to bottom (handled by existing hook)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements stay-at-bottom behavior for terminal output to allow reading prior logs while processes run.
> 
> - In `TerminalSessionManager.ts`, compute `isAtBottom` (via `buffer.baseY - buffer.viewportY <= 2`) before writing and call `scrollToBottom()` only when true
> - Preserves initial frame refresh and existing memory guard; removes unconditional auto-scroll after each chunk
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3bf18f9b15c039724f21811157ef18df703ff394. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->