### PR TITLE
feat(settings): add right sidebar auto-collapse toggle

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -32,6 +32,10 @@ export interface KeyboardSettings {
   newTask?: ShortcutBinding;
 }
 
+export interface InterfaceSettings {
+  autoRightSidebarBehavior?: boolean;
+}
+
 export interface AppSettings {
   repository: RepositorySettings;
   projectPrep: {
@@ -60,6 +64,7 @@ export interface AppSettings {
     defaultDirectory: string;
   };
   keyboard?: KeyboardSettings;
+  interface?: InterfaceSettings;
 }
 
 const DEFAULT_SETTINGS: AppSettings = {
@@ -102,6 +107,9 @@ const DEFAULT_SETTINGS: AppSettings = {
     nextProject: { key: 'ArrowRight', modifier: 'cmd' },
     prevProject: { key: 'ArrowLeft', modifier: 'cmd' },
     newTask: { key: 'n', modifier: 'cmd' },
+  },
+  interface: {
+    autoRightSidebarBehavior: false,
   },
 };
 
@@ -191,6 +199,9 @@ function normalizeSettings(input: AppSettings): AppSettings {
         enabled: DEFAULT_SETTINGS.mcp!.context7!.enabled,
         installHintsDismissed: {},
       },
+    },
+    interface: {
+      autoRightSidebarBehavior: DEFAULT_SETTINGS.interface!.autoRightSidebarBehavior,
     },
   };
 
@@ -300,6 +311,14 @@ function normalizeSettings(input: AppSettings): AppSettings {
     nextProject: normalizeBinding(keyboard.nextProject, DEFAULT_SETTINGS.keyboard!.nextProject!),
     prevProject: normalizeBinding(keyboard.prevProject, DEFAULT_SETTINGS.keyboard!.prevProject!),
     newTask: normalizeBinding(keyboard.newTask, DEFAULT_SETTINGS.keyboard!.newTask!),
+  };
+
+  // Interface
+  const iface = (input as any)?.interface || {};
+  out.interface = {
+    autoRightSidebarBehavior: Boolean(
+      iface?.autoRightSidebarBehavior ?? DEFAULT_SETTINGS.interface!.autoRightSidebarBehavior
+    ),
   };
 
   return out;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -168,6 +168,7 @@ const AppContent: React.FC = () => {
   const leftSidebarOpenRef = useRef<boolean>(true);
   const rightSidebarSetCollapsedRef = useRef<((next: boolean) => void) | null>(null);
   const [rightSidebarCollapsed, setRightSidebarCollapsed] = useState<boolean>(false);
+  const [autoRightSidebarBehavior, setAutoRightSidebarBehavior] = useState<boolean>(false);
 
   const handlePanelLayout = useCallback((sizes: number[]) => {
     if (!Array.isArray(sizes) || sizes.length < 3) {
@@ -373,6 +374,61 @@ const AppContent: React.FC = () => {
     };
     void check();
   }, []);
+
+  // Load autoRightSidebarBehavior setting on mount and listen for changes
+  useEffect(() => {
+    (async () => {
+      try {
+        const result = await window.electronAPI.getSettings();
+        if (result.success && result.settings) {
+          setAutoRightSidebarBehavior(
+            Boolean(result.settings.interface?.autoRightSidebarBehavior ?? false)
+          );
+        }
+      } catch (error) {
+        console.error('Failed to load right sidebar settings:', error);
+      }
+    })();
+
+    // Listen for setting changes from RightSidebarSettingsCard
+    const handleSettingChange = (event: Event) => {
+      const customEvent = event as CustomEvent<{ enabled: boolean }>;
+      setAutoRightSidebarBehavior(customEvent.detail.enabled);
+    };
+    window.addEventListener('autoRightSidebarBehaviorChanged', handleSettingChange);
+    return () => {
+      window.removeEventListener('autoRightSidebarBehaviorChanged', handleSettingChange);
+    };
+  }, []);
+
+  // Auto-collapse/expand right sidebar based on current view (no animation)
+  useEffect(() => {
+    if (!autoRightSidebarBehavior) return;
+
+    // On home page or repo home page (no active task), collapse the sidebar
+    const isHomePage = showHomeView;
+    const isRepoHomePage = selectedProject !== null && activeTask === null;
+
+    const shouldCollapse = isHomePage || isRepoHomePage;
+    const shouldExpand = activeTask !== null;
+
+    if (shouldCollapse || shouldExpand) {
+      // Add no-transition class to skip animation
+      const panelGroup = document.querySelector('[data-panel-group]');
+      panelGroup?.classList.add('no-transition');
+
+      if (shouldCollapse) {
+        rightSidebarSetCollapsedRef.current?.(true);
+      } else if (shouldExpand) {
+        rightSidebarSetCollapsedRef.current?.(false);
+      }
+
+      // Remove the class after a frame to allow future animations
+      requestAnimationFrame(() => {
+        panelGroup?.classList.remove('no-transition');
+      });
+    }
+  }, [autoRightSidebarBehavior, showHomeView, selectedProject, activeTask]);
 
   useEffect(() => {
     const rightPanel = rightSidebarPanelRef.current;

--- a/src/renderer/components/RightSidebarSettingsCard.tsx
+++ b/src/renderer/components/RightSidebarSettingsCard.tsx
@@ -1,0 +1,63 @@
+import React, { useEffect, useState } from 'react';
+import { Switch } from './ui/switch';
+
+const RightSidebarSettingsCard: React.FC = () => {
+  const [autoRightSidebarBehavior, setAutoRightSidebarBehavior] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const result = await window.electronAPI.getSettings();
+        if (result.success && result.settings) {
+          setAutoRightSidebarBehavior(
+            Boolean(result.settings.interface?.autoRightSidebarBehavior ?? false)
+          );
+        }
+      } catch (error) {
+        console.error('Failed to load right sidebar settings:', error);
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  const updateAutoRightSidebarBehavior = async (next: boolean) => {
+    setAutoRightSidebarBehavior(next);
+    try {
+      await window.electronAPI.updateSettings({
+        interface: { autoRightSidebarBehavior: next },
+      });
+      // Dispatch custom event to notify App.tsx of the setting change
+      window.dispatchEvent(
+        new CustomEvent('autoRightSidebarBehaviorChanged', { detail: { enabled: next } })
+      );
+    } catch (error) {
+      console.error('Failed to update right sidebar setting:', error);
+    }
+  };
+
+  return (
+    <div className="rounded-xl border border-border/60 bg-muted/10 p-4">
+      <div className="mb-4 text-sm text-muted-foreground">
+        Automatically manage the right sidebar based on the current view.
+      </div>
+      <div className="space-y-3">
+        <label className="flex items-center justify-between gap-2">
+          <div className="flex flex-col gap-0.5">
+            <span className="text-sm">Auto-collapse on home pages</span>
+            <span className="text-xs text-muted-foreground">
+              Collapse sidebar on home/repo pages, expand on tasks
+            </span>
+          </div>
+          <Switch
+            checked={autoRightSidebarBehavior}
+            disabled={loading}
+            onCheckedChange={updateAutoRightSidebarBehavior}
+          />
+        </label>
+      </div>
+    </div>
+  );
+};
+
+export default RightSidebarSettingsCard;

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -11,6 +11,7 @@ import TelemetryCard from './TelemetryCard';
 import ThemeCard from './ThemeCard';
 import BrowserPreviewSettingsCard from './BrowserPreviewSettingsCard';
 import NotificationSettingsCard from './NotificationSettingsCard';
+import RightSidebarSettingsCard from './RightSidebarSettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
 import ProjectPrepSettingsCard from './ProjectPrepSettingsCard';
 import Context7SettingsCard from './Context7SettingsCard';
@@ -221,6 +222,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
           { title: 'Theme', render: () => <ThemeCard /> },
           { title: 'Keyboard shortcuts', render: () => <KeyboardSettingsCard /> },
           { title: 'Notifications', render: () => <NotificationSettingsCard /> },
+          { title: 'Right sidebar', render: () => <RightSidebarSettingsCard /> },
           { title: 'In‑app Browser Preview', render: () => <BrowserPreviewSettingsCard /> },
         ],
       },
@@ -366,7 +368,7 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
                 </nav>
               </aside>
 
-              <div className="flex flex-1 flex-col">
+              <div className="flex min-h-0 flex-1 flex-col">
                 <header className="flex items-center justify-between border-b border-border/60 px-6 py-4">
                   <div>
                     <h2 className="text-lg font-semibold">{activeTabDetails.title}</h2>
@@ -383,7 +385,9 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose }) => {
                   </Button>
                 </header>
 
-                <div className="flex-1 overflow-y-auto px-6 py-6">{renderContent()}</div>
+                <div className="flex min-h-0 flex-1 overflow-y-auto px-6 py-6">
+                  {renderContent()}
+                </div>
               </div>
             </div>
           </motion.div>

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -135,6 +135,10 @@
     transition-duration: 0ms;
   }
 
+  [data-panel-group].no-transition .sidebar-panel {
+    transition-duration: 0ms;
+  }
+
   @media (prefers-reduced-motion: reduce) {
     .sidebar-panel {
       transition-duration: 0ms;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -100,6 +100,9 @@ declare global {
               modifier: 'cmd' | 'ctrl' | 'shift' | 'alt' | 'option';
             };
           };
+          interface?: {
+            autoRightSidebarBehavior?: boolean;
+          };
         };
         error?: string;
       }>;
@@ -157,6 +160,9 @@ declare global {
               modifier: 'cmd' | 'ctrl' | 'shift' | 'alt' | 'option';
             };
           };
+          interface?: {
+            autoRightSidebarBehavior?: boolean;
+          };
         }>
       ) => Promise<{
         success: boolean;
@@ -212,6 +218,9 @@ declare global {
               key: string;
               modifier: 'cmd' | 'ctrl' | 'shift' | 'alt' | 'option';
             };
+          };
+          interface?: {
+            autoRightSidebarBehavior?: boolean;
           };
         };
         error?: string;


### PR DESCRIPTION
What changed
- Added a setting in the Interface tab to auto-collapse the right sidebar on home screens and reopen it on tasks.
- Saved this preference so it persists between app launches.

Why
- Provides a simple way to keep the sidebar out of the way when it’s not needed.

<img width="780" height="535" alt="Screenshot 2026-01-06 at 4 17 36 PM" src="https://github.com/user-attachments/assets/74aa4622-d255-4eba-b643-b1e83cc2efca" />