### PR TITLE
fix(opencode): change initialPromptFlag from -p to --prompt

### DIFF
--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -143,7 +143,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     commands: ['opencode'],
     versionArgs: ['--version'],
     cli: 'opencode',
-    initialPromptFlag: '-p',
+    initialPromptFlag: '--prompt',
     icon: 'opencode.png',
     terminalOnly: true,
   },


### PR DESCRIPTION
## Summary

- Fix OpenCode CLI argument issue where `-p` flag was incorrectly used instead of `--prompt` for TUI mode
- OpenCode TUI only supports `--prompt` flag for initial prompt injection (not `-p`)

## Why this implementation

Per the [OpenCode CLI documentation](https://opencode.ai/docs/cli/), the TUI mode accepts `--prompt` as the flag for passing initial prompts. The previous `-p` flag was invalid, causing "incorrect command" errors when spawning OpenCode with an initial prompt.

## Modified files

- `src/shared/providers/registry.ts` - Changed `initialPromptFlag` from `-p` to `--prompt` for opencode provider

## Test checklist

- [x] Verify OpenCode spawns correctly with `--prompt` flag
- [x] Verify initial prompt is passed to OpenCode TUI

## Official documentation

- https://opencode.ai/docs/cli/