### PR TITLE
fix: equalize padding around homepage tagline text

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1799,8 +1799,8 @@ const AppContent: React.FC = () => {
       return (
         <div className="flex h-full flex-col overflow-y-auto bg-background text-foreground">
           <div className="container mx-auto flex min-h-full max-w-3xl flex-1 flex-col justify-center px-8 py-8">
-            <div className="mb-6 text-center">
-              <div className="mb-2 flex items-center justify-center">
+            <div className="mb-3 text-center">
+              <div className="mb-3 flex items-center justify-center">
                 <div className="logo-shimmer-container">
                   <img
                     key={effectiveTheme}
@@ -1825,7 +1825,7 @@ const AppContent: React.FC = () => {
                 </div>
               </div>
               <p className="whitespace-nowrap text-xs text-muted-foreground">
-                Run multiple Coding Agents in parallel
+                Coding Agent Dashboard
               </p>
             </div>
 


### PR DESCRIPTION
equalize padding above and below the tagline in the main app view

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adjusts home view header spacing and updates the tagline text for consistency.
> 
> - In `App.tsx` home view, change margins from `mb-6`/`mb-2` to `mb-3` to equalize padding
> - Update tagline copy to `Coding Agent Dashboard`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 59b6b61bde1bb757d58dff2b8330cb938e839227. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->