### PR TITLE
chore: remove legacy codex-stream.log references

### DIFF
--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -55,8 +55,6 @@ export async function getStatus(taskPath: string): Promise<GitChange[]> {
     // Check if file is staged (first character of status code indicates staged changes)
     const isStaged = statusCode[0] !== ' ' && statusCode[0] !== '?';
 
-    if (filePath.endsWith('codex-stream.log')) continue;
-
     let additions = 0;
     let deletions = 0;
 

--- a/src/main/services/WorktreeService.ts
+++ b/src/main/services/WorktreeService.ts
@@ -164,9 +164,6 @@ export class WorktreeService {
         throw new Error(`Worktree directory was not created: ${worktreePath}`);
       }
 
-      // Ensure codex logs are ignored in this worktree
-      this.ensureCodexLogIgnored(worktreePath);
-
       // Preserve .env and other gitignored config files from source to worktree
       try {
         const patterns = this.getPreservePatterns(projectPath);
@@ -1027,37 +1024,6 @@ export class WorktreeService {
     return result;
   }
 
-  private ensureCodexLogIgnored(worktreePath: string) {
-    try {
-      const gitMeta = path.join(worktreePath, '.git');
-      let gitDir = gitMeta;
-      if (fs.existsSync(gitMeta) && fs.statSync(gitMeta).isFile()) {
-        try {
-          const content = fs.readFileSync(gitMeta, 'utf8');
-          const m = content.match(/gitdir:\s*(.*)\s*$/i);
-          if (m && m[1]) {
-            gitDir = path.resolve(worktreePath, m[1].trim());
-          }
-        } catch {}
-      }
-      const excludePath = path.join(gitDir, 'info', 'exclude');
-      try {
-        const dir = path.dirname(excludePath);
-        if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
-        let current = '';
-        try {
-          current = fs.readFileSync(excludePath, 'utf8');
-        } catch {}
-        if (!current.includes('codex-stream.log')) {
-          fs.appendFileSync(
-            excludePath,
-            (current.endsWith('\n') || current === '' ? '' : '\n') + 'codex-stream.log\n'
-          );
-        }
-      } catch {}
-    } catch {}
-  }
-
   private ensureClaudeAutoApprove(worktreePath: string) {
     try {
       const claudeDir = path.join(worktreePath, '.claude');
@@ -1152,8 +1118,6 @@ export class WorktreeService {
     if (!fs.existsSync(worktreePath)) {
       throw new Error(`Worktree directory was not created: ${worktreePath}`);
     }
-
-    this.ensureCodexLogIgnored(worktreePath);
 
     // Preserve .env and other gitignored config files from source to worktree
     try {


### PR DESCRIPTION
## Summary

Remove unused code that handled `codex-stream.log` files:

- Remove `ensureCodexLogIgnored` method from WorktreeService
- Remove calls to `ensureCodexLogIgnored` in worktree creation
- Remove `codex-stream.log` skip in GitService status parsing

This file is no longer written since agents now run via PTY/xterm.js terminal emulation.

## Test plan

- [x] `npm run type-check` passes
- [ ] Create a new workspace and verify worktree creation still works

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes legacy logic related to `codex-stream.log`, simplifying Git status and worktree setup.
> 
> - Delete `ensureCodexLogIgnored` from `WorktreeService` and remove its invocations during worktree creation
> - Drop special-case skip of `codex-stream.log` in `GitService.getStatus` parsing
> - No changes to worktree preservation or other functionality
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5cec3511109ad04afac06f6dc004f5f210bc0842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->