### PR TITLE
fix: remove broken demo images from README

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,6 +69,7 @@ npm run docs:build   # Build documentation
 - **ALWAYS** run `npm run type-check` and `npm run lint` before committing
 - **ALWAYS** test changes in both main and renderer processes
 - **ALWAYS** use feature branches (never commit directly to `main`)
+- **ALWAYS** put temporary notes, reference files, or scratch content in `.notes/` (gitignored)
 
 ## Code Organization
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Emdash lets you develop and test multiple features with multiple agents in paral
 
 <div align="center" style="margin:24px 0;">
 
-[Installation](#installation) • [Integrations](#integrations) • [Demo](#demo) • [Contributing](#contributing) • [FAQ](#faq)
+[Installation](#installation) • [Integrations](#integrations) • [Contributing](#contributing) • [FAQ](#faq)
 
 </div>
 
@@ -91,19 +91,6 @@ Emdash allows you to pass tickets straight from Linear, GitHub, or Jira to your 
 | [Linear](https://linear.app) | ✅ Supported | Connect with a Linear API key. |
 | [Jira](https://www.atlassian.com/software/jira) | ✅ Supported | Provide your site URL, email, and Atlassian API token. |
 | [GitHub Issues](https://docs.github.com/en/issues) | ✅ Supported | Authenticate via GitHub CLI (`gh auth login`). |
-
-# Demo
-
-#### Add an agents.md file
-![Agents.md](https://www.emdash.sh/addagentsfilescreenshot.png)
-#### Run multiple agents in parallel
-
-![Parallel agents](https://www.emdash.sh/parallel_loop.gif)
-
-#### Pass a Linear ticket
-
-![Passing Linear](https://www.emdash.sh/addlinearscreenshot.png)
-
 
 # Contributing
 

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -17,6 +17,5 @@ node_modules
 .tanstack
 
 src/routeTree.gen.ts
-.writing-guide.md
 .source/
 next-env.d.ts

--- a/docs/.writing-guide.md
+++ b/docs/.writing-guide.md
@@ -1,9 +1,0 @@
-# Docs Writing Guide
-
-- No filler words
-- Every sentence information dense
-- Get to the point
-- Short words, fewer words
-- One example max
-- No "it's important to note" or similar
-- No unnecessary transitions


### PR DESCRIPTION
Removes broken demo image references that were returning 404.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Removes broken demo content and tightens contributor guidance.
> 
> - Remove README "Demo" section and broken image references; fix center nav links
> - Add CLAUDE.md critical rule to place temporary notes in gitignored `.notes/`
> - Update `docs/.gitignore` (stop ignoring `docs/.writing-guide.md`) and delete that file
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1f42c2b100a6a3938eef7414025683220a65b7dc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->