### PR TITLE
docs: remove Windows download links from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Emdash lets you develop and test multiple features with multiple agents in paral
 
 # Installation
 
-**[Latest Release (macOS • Windows • Linux)](https://github.com/generalaction/emdash/releases/latest)**
+**[Latest Release (macOS • Linux)](https://github.com/generalaction/emdash/releases/latest)**
 
 <details><summary>Direct links</summary>
 
@@ -46,10 +46,6 @@ Emdash lets you develop and test multiple features with multiple agents in paral
 
 [![Homebrew](https://img.shields.io/badge/-Homebrew-000000?style=for-the-badge&logo=homebrew&logoColor=FBB040)](https://formulae.brew.sh/cask/emdash)
 > macOS users can also: `brew install --cask emdash`
-
-### Windows
-- Installer (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x64-installer.exe  
-- Portable (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.exe
 
 ### Linux
 - AppImage (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.AppImage  
@@ -123,7 +119,6 @@ Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md) to get star
 >
 > ```
 > macOS:  ~/Library/Application Support/emdash/emdash.db
-> Windows: %APPDATA%/emdash/emdash.db
 > Linux:  ~/.config/emdash/emdash.db
 > ```
 >


### PR DESCRIPTION
## Summary

Removes Windows-related content from the README.md file, including:
- Windows download links in the installation section
- Windows database path in the FAQ

## Changes

- Removed Windows installer and portable executable download links
- Updated installation header from "macOS • Windows • Linux" to "macOS • Linux"
- Removed Windows app data path reference from the "Where is my data stored?" FAQ entry

This update reflects the current platform support for the application.