### PR TITLE
feat(telemetry): add GitHub username tracking to PostHog events

### DIFF
--- a/docs/content/docs/telemetry.mdx
+++ b/docs/content/docs/telemetry.mdx
@@ -26,17 +26,23 @@ TELEMETRY_ENABLED=false
 
 ## What We Collect
 
-Anonymous, aggregated usage data only.
+Anonymous, aggregated usage data only. If you have authenticated with GitHub, your GitHub username may be included with telemetry events to help us understand user engagement patterns.
 
 ### App Lifecycle
 
 **`app_started`** / **`app_closed`**
 
 - `app_version`, `electron_version`, `platform`, `arch`, `is_dev`, `install_source`
+- `github_username` (if authenticated with GitHub)
 
 **`app_session`** (on quit)
 
 - `session_duration_ms`
+
+**`daily_active_user`** (once per calendar day)
+
+- `date`, `timezone`
+- `github_username` (if authenticated with GitHub)
 
 ### Feature Usage
 
@@ -103,7 +109,7 @@ All events include only: event name, anonymized properties (e.g., `provider: "cl
 - File paths or repository names
 - Prompts or messages sent to agents
 - Environment variables
-- Personally identifiable information (PII)
+- Personally identifiable information (PII) except GitHub username if authenticated
 - User text input or command contents
 - IP-derived location data
 - Session recordings or screen captures

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -146,8 +146,8 @@ app.whenReady().then(async () => {
     console.error('Failed to initialize database:', error);
   }
 
-  // Initialize telemetry (privacy-first, anonymous)
-  telemetry.init({ installSource: app.isPackaged ? 'dmg' : 'dev' });
+  // Initialize telemetry (privacy-first, with optional GitHub username)
+  await telemetry.init({ installSource: app.isPackaged ? 'dmg' : 'dev' });
   try {
     const summary = databaseService.getLastMigrationSummary();
     const toBucket = (n: number) => (n === 0 ? '0' : n === 1 ? '1' : n <= 3 ? '2-3' : '>3');


### PR DESCRIPTION
## Summary

This PR adds GitHub username tracking to our PostHog telemetry when users are authenticated with GitHub. This will
help us understand user engagement patterns and identify our most active users.

## Changes

- **Telemetry Enhancement**: Added `github_username` property to telemetry events
  - Tracks GitHub username in `app_started` event
  - Tracks GitHub username in `daily_active_user` event
  - Uses PostHog's `identify()` to create user profiles linking anonymous instanceId with GitHub username

- **Privacy-First Implementation**:
  - Only tracks GitHub username if user is already authenticated with GitHub CLI
  - Users can still disable all telemetry via Settings
  - Updated documentation with clear disclosure about GitHub username tracking

## Technical Details

- Added `github_username` to the SAFE_PROPERTIES allowlist in telemetry sanitization
- Created `getGithubUsername()` function that fetches username from existing GitHubService
- Made `telemetry.init()` async to fetch GitHub username on app startup
- Updated `checkDailyActiveUser()` to include GitHub username in DAU tracking