### PR TITLE
fix(ui): unify task creation terminology

### DIFF
--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -275,13 +275,13 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                     onCreateTaskForProject?.(typedProject);
                                   }}
                                   disabled={isCreatingTask}
-                                  aria-label={`Add Task to ${typedProject.name}`}
+                                  aria-label={`New Task for ${typedProject.name}`}
                                 >
                                   <Plus
                                     className="h-3 w-3 flex-shrink-0 text-muted-foreground"
                                     aria-hidden
                                   />
-                                  <span className="truncate">Add Task</span>
+                                  <span className="truncate">New Task</span>
                                 </motion.button>
                                 <div className="hidden min-w-0 space-y-0.5 sm:block">
                                   {typedProject.tasks?.map((task) => {

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -569,7 +569,7 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
                       ) : (
                         <>
                           <Plus className="mr-2 size-4" />
-                          Start New Task
+                          New Task
                         </>
                       )}
                     </motion.button>

--- a/src/renderer/components/kanban/KanbanBoard.tsx
+++ b/src/renderer/components/kanban/KanbanBoard.tsx
@@ -282,7 +282,7 @@ const KanbanBoard: React.FC<{
                 size="icon"
                 className="h-8 w-8 rounded-md border border-border/60 bg-muted text-foreground shadow-sm hover:bg-muted/80"
                 onClick={onCreateTask}
-                aria-label="Start New Task"
+                aria-label="New Task"
               >
                 <Plus className="h-4 w-4" aria-hidden="true" />
               </Button>
@@ -301,7 +301,7 @@ const KanbanBoard: React.FC<{
                 <div className="flex flex-1 items-center justify-center">
                   <Button variant="default" size="sm" onClick={onCreateTask}>
                     <Plus className="mr-1.5 h-3.5 w-3.5" />
-                    Start New Task
+                    New Task
                   </Button>
                 </div>
               </div>
@@ -326,7 +326,7 @@ const KanbanBoard: React.FC<{
                   onClick={onCreateTask}
                 >
                   <Plus className="mr-1.5 h-3.5 w-3.5" />
-                  Start New Task
+                  New Task
                 </Button>
               ) : null}
             </>


### PR DESCRIPTION
## Summary

- Standardize task creation buttons/labels to use "New Task" consistently
- Previously used "Add Task" (sidebar), "Start New Task" (project view, kanban)
- Modal title and create button were already correct

## Changes

- `LeftSidebar.tsx`: "Add Task" → "New Task"
- `ProjectMainView.tsx`: "Start New Task" → "New Task"
- `KanbanBoard.tsx`: "Start New Task" → "New Task" (3 occurrences)

Closes #616

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Unifies task creation wording to improve consistency and accessibility.
> 
> - `LeftSidebar.tsx`: "Add Task" → `New Task` (button label and `aria-label`)
> - `ProjectMainView.tsx`: "Start New Task" → `New Task`
> - `KanbanBoard.tsx`: "Start New Task" → `New Task` in button text and `aria-label` (multiple spots)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 06a096ab3542e42ee8d2791f4f1ce80b677f8759. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->