### PR TITLE
feat: add Cmd+E keyboard shortcut to toggle editor

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2099,6 +2099,7 @@ const AppContent: React.FC = () => {
                 handleCloseCommandPalette={handleCloseCommandPalette}
                 handleCloseSettings={handleCloseSettings}
                 handleToggleKanban={handleToggleKanban}
+                handleToggleEditor={() => setShowEditorMode((prev) => !prev)}
                 handleNextTask={handleNextTask}
                 handlePrevTask={handlePrevTask}
                 handleNewTask={handleNewTask}

--- a/src/renderer/components/AppKeyboardShortcuts.tsx
+++ b/src/renderer/components/AppKeyboardShortcuts.tsx
@@ -13,6 +13,7 @@ export interface AppKeyboardShortcutsProps {
   handleCloseCommandPalette: () => void;
   handleCloseSettings: () => void;
   handleToggleKanban: () => void;
+  handleToggleEditor: () => void;
   handleNextTask: () => void;
   handlePrevTask: () => void;
   handleNewTask: () => void;
@@ -26,6 +27,7 @@ const AppKeyboardShortcuts: React.FC<AppKeyboardShortcutsProps> = ({
   handleCloseCommandPalette,
   handleCloseSettings,
   handleToggleKanban,
+  handleToggleEditor,
   handleNextTask,
   handlePrevTask,
   handleNewTask,
@@ -42,6 +44,7 @@ const AppKeyboardShortcuts: React.FC<AppKeyboardShortcutsProps> = ({
     onToggleRightSidebar: toggleRightSidebar,
     onToggleTheme: toggleTheme,
     onToggleKanban: handleToggleKanban,
+    onToggleEditor: handleToggleEditor,
     onNextProject: handleNextTask,
     onPrevProject: handlePrevTask,
     onNewTask: handleNewTask,

--- a/src/renderer/components/titlebar/Titlebar.tsx
+++ b/src/renderer/components/titlebar/Titlebar.tsx
@@ -140,7 +140,10 @@ const Titlebar: React.FC<TitlebarProps> = ({
                   </Button>
                 </TooltipTrigger>
                 <TooltipContent side="bottom" className="text-xs font-medium">
-                  <span>{isEditorOpen ? 'Close Editor' : 'Open Editor'}</span>
+                  <div className="flex flex-col gap-1">
+                    <span>{isEditorOpen ? 'Close Editor' : 'Open Editor'}</span>
+                    <ShortcutHint settingsKey="toggleEditor" />
+                  </div>
                 </TooltipContent>
               </Tooltip>
             </TooltipProvider>

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -15,6 +15,7 @@ export type ShortcutSettingsKey =
   | 'toggleRightSidebar'
   | 'toggleTheme'
   | 'toggleKanban'
+  | 'toggleEditor'
   | 'closeModal'
   | 'nextProject'
   | 'prevProject'
@@ -83,6 +84,15 @@ export const APP_SHORTCUTS: Record<string, AppShortcut> = {
     description: 'Show or hide the Kanban board',
     category: 'Navigation',
     settingsKey: 'toggleKanban',
+  },
+
+  TOGGLE_EDITOR: {
+    key: 'e',
+    modifier: 'cmd',
+    label: 'Toggle Editor',
+    description: 'Show or hide the code editor',
+    category: 'View',
+    settingsKey: 'toggleEditor',
   },
 
   CLOSE_MODAL: {
@@ -245,6 +255,7 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
       toggleRightSidebar: getEffectiveConfig(APP_SHORTCUTS.TOGGLE_RIGHT_SIDEBAR, custom),
       toggleTheme: getEffectiveConfig(APP_SHORTCUTS.TOGGLE_THEME, custom),
       toggleKanban: getEffectiveConfig(APP_SHORTCUTS.TOGGLE_KANBAN, custom),
+      toggleEditor: getEffectiveConfig(APP_SHORTCUTS.TOGGLE_EDITOR, custom),
       closeModal: getEffectiveConfig(APP_SHORTCUTS.CLOSE_MODAL, custom),
       nextProject: getEffectiveConfig(APP_SHORTCUTS.NEXT_TASK, custom),
       prevProject: getEffectiveConfig(APP_SHORTCUTS.PREV_TASK, custom),
@@ -288,6 +299,12 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
       {
         config: effectiveShortcuts.toggleKanban,
         handler: () => handlers.onToggleKanban?.(),
+        priority: 'global',
+        requiresClosed: true,
+      },
+      {
+        config: effectiveShortcuts.toggleEditor,
+        handler: () => handlers.onToggleEditor?.(),
         priority: 'global',
         requiresClosed: true,
       },

--- a/src/renderer/types/shortcuts.ts
+++ b/src/renderer/types/shortcuts.ts
@@ -12,6 +12,7 @@ export interface KeyboardSettings {
   toggleRightSidebar?: ShortcutBinding;
   toggleTheme?: ShortcutBinding;
   toggleKanban?: ShortcutBinding;
+  toggleEditor?: ShortcutBinding;
   closeModal?: ShortcutBinding;
   nextProject?: ShortcutBinding;
   prevProject?: ShortcutBinding;
@@ -64,6 +65,9 @@ export interface GlobalShortcutHandlers {
 
   // Kanban
   onToggleKanban?: () => void;
+
+  // Editor
+  onToggleEditor?: () => void;
 
   // Project navigation
   onNextProject?: () => void;


### PR DESCRIPTION
Adds a keyboard shortcut (Cmd+E / Ctrl+E) to toggle the code editor, consistent with other toolbar shortcuts.

Changes:
- Added `toggleEditor` shortcut to the keyboard shortcuts system
- Shows shortcut hint in the editor button tooltip
- Shortcut is customizable in Settings like other shortcuts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Integrates editor toggling into the global keyboard shortcuts system and UI.
> 
> - Adds `toggleEditor` shortcut (default `Cmd/Ctrl+E`) in `useKeyboardShortcuts` with settings support
> - Wires `onToggleEditor` through `App.tsx` → `AppKeyboardShortcuts` → `useKeyboardShortcuts`
> - Updates types (`ShortcutSettingsKey`, `KeyboardSettings`, `GlobalShortcutHandlers`) to include `toggleEditor`
> - Shows `ShortcutHint` for `toggleEditor` in the titlebar editor button tooltip
> - Toggles editor mode via `setShowEditorMode` and hides left sidebar appropriately
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 08b54ece41974f09685734895bf1b67606403c11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->