### PR TITLE
 fix: terminal focus not working when switching tasks (#639)

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -262,7 +262,30 @@ export class TerminalSessionManager {
   }
 
   focus() {
+    // Ensure container is focusable and focus it first
+    if (this.attachedContainer) {
+      // Find and focus the terminal container div
+      const terminalContainer = this.attachedContainer.querySelector(
+        '[data-terminal-container]'
+      ) as HTMLElement;
+      if (terminalContainer) {
+        if (terminalContainer.tabIndex < 0) {
+          terminalContainer.tabIndex = -1;
+        }
+        terminalContainer.focus();
+      }
+    }
+
+    // Focus the xterm terminal
     this.terminal.focus();
+
+    // Also focus the terminal's textarea element directly for reliability
+    const textarea = this.container.querySelector(
+      'textarea.xterm-helper-textarea'
+    ) as HTMLTextAreaElement;
+    if (textarea) {
+      textarea.focus();
+    }
   }
 
   scrollToBottom() {


### PR DESCRIPTION
## Summary
  Fixes the issue where users need to click into the terminal before being able to type after
  switching tasks.

  ## Changes
  - **ChatInterface**: Added retry logic with exponential backoff for terminal focus
  - **MultiAgentTask**: Added terminal auto-focus support when switching tasks or tabs
  - **TerminalPane**: Added `tabIndex` attribute and focus on terminal ready
  - **TerminalSessionManager**: Enhanced focus method to handle container, xterm, and textarea
  elements

  ## Fixes
  Closes #639

  ## Implementation Details
  - Focus attempts with retry logic (150ms initial delay, then exponential backoff)
  - Multiple focus targets to ensure reliability across different scenarios
  - RequestAnimationFrame to ensure focus survives React re-renders
  - Focus triggered at multiple lifecycle points (attach, ready, task switch)

  ## Testing
  - Switching between tasks with Cmd+Arrow keys
  - Switching between multi-agent provider tabs
  - Opening tasks for the first time
  - All scenarios now properly focus the terminal without requiring a click