### PR TITLE
add droid session resume

### DIFF
--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -53,7 +53,6 @@ export const PROVIDERS: ProviderDefinition[] = [
     cli: 'codex',
     autoApproveFlag: '--full-auto',
     initialPromptFlag: '',
-    resumeFlag: 'resume --last',
     icon: 'openai.png',
     terminalOnly: true,
   },


### PR DESCRIPTION
adds resume flags for droid (`-r`) and codex (`resume --last`) so sessions persist per worktree, same as claude code and the others

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds session resume support for Droid.
> 
> - Set `resumeFlag: '-r'` on `droid` in `src/shared/providers/registry.ts`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a072239d9744683961a368b6f330bff6d7e4e110. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->