### PR TITLE
Use dark-black theme when system prefers dark mode

### DIFF
--- a/src/renderer/components/ThemeProvider.tsx
+++ b/src/renderer/components/ThemeProvider.tsx
@@ -7,7 +7,7 @@ const STORAGE_KEY = 'emdash-theme';
 
 function getSystemTheme(): EffectiveTheme {
   if (typeof window === 'undefined') return 'light';
-  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light';
+  return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark-black' : 'light';
 }
 
 function getStoredTheme(): Theme {
@@ -56,6 +56,9 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
 
   useEffect(() => {
     applyTheme(theme);
+  }, [theme, systemTheme]);
+
+  useEffect(() => {
     try {
       localStorage.setItem(STORAGE_KEY, theme);
     } catch {

--- a/src/renderer/hooks/useEditorDiffDecorations.ts
+++ b/src/renderer/hooks/useEditorDiffDecorations.ts
@@ -147,7 +147,7 @@ export function useEditorDiffDecorations({
         return;
       }
 
-      const isDark = effectiveTheme === 'dark';
+      const isDark = effectiveTheme === 'dark' || effectiveTheme === 'dark-black';
       const newDecorations: any[] = [];
 
       for (const diff of diffLines) {


### PR DESCRIPTION
## Summary
- Changed system theme detection to use dark-black instead of dark navy when OS is in dark mode
- Updated editor diff decorations to recognize dark-black as a dark theme

## Test plan
- [ ] Toggle system to dark mode and verify app uses dark-black theme
- [ ] Verify diff decorations display correctly in dark-black mode

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches system dark mode to use `dark-black` and updates editor styling accordingly.
> 
> - `ThemeProvider`: `getSystemTheme` now maps system dark to `dark-black`; `applyTheme` effect depends on both `theme` and `systemTheme` to react to OS changes
> - `useEditorDiffDecorations`: treats `dark-black` as a dark theme for diff line and glyph classes
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 421dd4911d9bdcc3a695a1dbc0cea24dcfa45acb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->