### PR TITLE
fix: terminal focus using React refs (fixes #639)

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState, useMemo, useCallback } from 'react';
+import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
 import { useReducedMotion } from 'motion/react';
-import { useToast } from '../hooks/use-toast';
 import { useTheme } from '../hooks/useTheme';
 import { TerminalPane } from './TerminalPane';
 import InstallBanner from './InstallBanner';
@@ -14,7 +13,6 @@ import { useBrowser } from '@/providers/BrowserProvider';
 import { useTaskTerminals } from '@/lib/taskTerminalsStore';
 import { getInstallCommandForProvider } from '@shared/providers/registry';
 import { useAutoScrollOnTaskSwitch } from '@/hooks/useAutoScrollOnTaskSwitch';
-import { terminalSessionRegistry } from '../terminal/SessionRegistry';
 import { TaskScopeProvider } from './TaskScopeContext';
 
 declare const window: Window & {
@@ -36,7 +34,6 @@ const ChatInterface: React.FC<Props> = ({
   className,
   initialProvider,
 }) => {
-  const { toast } = useToast();
   const { effectiveTheme } = useTheme();
   const [isProviderInstalled, setIsProviderInstalled] = useState<boolean | null>(null);
   const [providerStatuses, setProviderStatuses] = useState<
@@ -56,28 +53,17 @@ const ChatInterface: React.FC<Props> = ({
   // Auto-scroll to bottom when this task becomes active
   useAutoScrollOnTaskSwitch(true, task.id);
 
-  // Auto-focus terminal when switching to this task
+  // Ref to control terminal focus imperatively if needed
+  const terminalRef = useRef<{ focus: () => void }>(null);
+
+  // Focus terminal when this task becomes active (for already-mounted terminals)
   useEffect(() => {
-    // Focus terminal with retry logic to handle async mounting
-    const focusWithRetry = (attempts = 0) => {
-      const session = terminalSessionRegistry.getSession(terminalId);
-      if (session) {
-        session.focus();
-        // Double-check focus after a frame to ensure it sticks
-        requestAnimationFrame(() => {
-          session.focus();
-        });
-      } else if (attempts < 3) {
-        // Retry with exponential backoff: 100ms, 200ms, 400ms
-        setTimeout(() => focusWithRetry(attempts + 1), 100 * Math.pow(2, attempts));
-      }
-    };
-
-    // Initial delay to allow terminal mounting
-    const timer = setTimeout(() => focusWithRetry(0), 150);
-
+    // Small delay to ensure terminal is visible after tab switch
+    const timer = setTimeout(() => {
+      terminalRef.current?.focus();
+    }, 50);
     return () => clearTimeout(timer);
-  }, [task.id, terminalId]);
+  }, [task.id]);
 
   useEffect(() => {
     const meta = providerMeta[provider];
@@ -541,6 +527,7 @@ const ChatInterface: React.FC<Props> = ({
               }`}
             >
               <TerminalPane
+                ref={terminalRef}
                 id={terminalId}
                 cwd={task.path}
                 shell={providerMeta[provider].cli}

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -262,30 +262,8 @@ export class TerminalSessionManager {
   }
 
   focus() {
-    // Ensure container is focusable and focus it first
-    if (this.attachedContainer) {
-      // Find and focus the terminal container div
-      const terminalContainer = this.attachedContainer.querySelector(
-        '[data-terminal-container]'
-      ) as HTMLElement;
-      if (terminalContainer) {
-        if (terminalContainer.tabIndex < 0) {
-          terminalContainer.tabIndex = -1;
-        }
-        terminalContainer.focus();
-      }
-    }
-
-    // Focus the xterm terminal
+    // Simply focus the xterm terminal - let React handle DOM management
     this.terminal.focus();
-
-    // Also focus the terminal's textarea element directly for reliability
-    const textarea = this.container.querySelector(
-      'textarea.xterm-helper-textarea'
-    ) as HTMLTextAreaElement;
-    if (textarea) {
-      textarea.focus();
-    }
   }
 
   scrollToBottom() {


### PR DESCRIPTION
## Summary
Fixes terminal focus when switching tasks using proper React patterns.

## Changes
- Use `forwardRef` + `useImperativeHandle` for terminal refs
- Focus via effects when switching tasks/tabs
- Remove all DOM manipulation, retries, and polling
- Clean up redundant autoFocus prop

## Solution
Terminal exposes `focus()` via ref, parent components focus on task/tab switch via effects. Simple 50ms delay ensures DOM is ready.

Fixes #639