### PR TITLE
chore: update README provider banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Emdash lets you develop and test multiple features with multiple agents in paral
 
 # Providers
 
-<img width="4856" height="1000" alt="integration_banner" src="https://github.com/user-attachments/assets/894c3db8-3be5-4730-ae7d-197958b0a044" />
+<img alt="Providers banner" src="https://github.com/user-attachments/assets/6b563230-2263-4603-bcc5-99785b77187d" />
 
 ### Supported CLI Providers
 


### PR DESCRIPTION
Update the provider banner in the README to match the new styling of the title banner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README visual in the **Providers** section.
> 
> - Replaces `integration_banner` image with new `Providers banner` asset in `README.md`
> - Updates `alt` text and removes explicit width/height for more responsive rendering
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ba1db367602a8622fdf041c8e01d8fe692c2117d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->