### PR TITLE
chore: update README banners with public URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="Emdash banner" src="https://github.com/user-attachments/assets/85836268-a4a4-4cc6-8969-462dee683817" />
+<img alt="Emdash banner" src="https://github.com/user-attachments/assets/a2ecaf3c-9d84-40ca-9a8e-d4f612cc1c6f" />
 
 <div align="center" style="margin:24px 0;">
   
@@ -54,7 +54,7 @@ Emdash lets you develop and test multiple features with multiple agents in paral
 
 # Providers
 
-<img width="4856" height="1000" alt="integration_banner" src="https://github.com/user-attachments/assets/894c3db8-3be5-4730-ae7d-197958b0a044" />
+<img alt="Providers banner" src="https://github.com/user-attachments/assets/c7b32a3e-452c-4209-91ef-71bcd895e2df" />
 
 ### Supported CLI Providers
 


### PR DESCRIPTION
Updates both the title banner and providers banner to use URLs from issue #670, which are publicly accessible.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Docs:** Update README banners to public assets
> 
> - Replace top `img` banner `src` with a new public `user-attachments` URL
> - Replace `Providers` section banner image with a new public `user-attachments` URL
> - Change confined to `README.md` only
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b28eb9d95cb1c29b75a2aa35f2cc89d26c1277d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->