### PR TITLE
chore: update README banners with public URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="Emdash banner" src="https://github.com/user-attachments/assets/85836268-a4a4-4cc6-8969-462dee683817" />
+<img alt="Emdash banner" src="https://github.com/user-attachments/assets/a2ecaf3c-9d84-40ca-9a8e-d4f612cc1c6f" />
 
 <div align="center" style="margin:24px 0;">
   
@@ -54,7 +54,7 @@ Emdash lets you develop and test multiple features with multiple agents in paral
 
 # Providers
 
-<img width="4856" height="1000" alt="integration_banner" src="https://github.com/user-attachments/assets/894c3db8-3be5-4730-ae7d-197958b0a044" />
+<img alt="Providers banner" src="https://github.com/user-attachments/assets/c7b32a3e-452c-4209-91ef-71bcd895e2df" />
 
 ### Supported CLI Providers
 


### PR DESCRIPTION
Updates both banners to use URLs from issue #670, which are publicly accessible from the emdash repo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Updates README visuals to use public, accessible assets.
> 
> - Replace top banner image `src` with new GitHub `user-attachments` URL
> - Update Providers section banner: new `src` and refined `alt` text in `README.md`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7bf3b0cdc766c71f77afd3ee84d980f64850b105. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->