### PR TITLE
chore: update README banners with public URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img alt="Emdash banner" src="https://github.com/user-attachments/assets/85836268-a4a4-4cc6-8969-462dee683817" />
+<img alt="Emdash banner" src="https://github.com/user-attachments/assets/a2ecaf3c-9d84-40ca-9a8e-d4f612cc1c6f" />
 
 <div align="center" style="margin:24px 0;">
   
@@ -54,7 +54,7 @@ Emdash lets you develop and test multiple features with multiple agents in paral
 
 # Providers
 
-<img width="4856" height="1000" alt="integration_banner" src="https://github.com/user-attachments/assets/894c3db8-3be5-4730-ae7d-197958b0a044" />
+<img alt="Providers banner" src="https://github.com/user-attachments/assets/c7b32a3e-452c-4209-91ef-71bcd895e2df" />
 
 ### Supported CLI Providers
 


### PR DESCRIPTION
Updates both title and providers banners to use public URLs from issue #670.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refreshes README visuals to use public, stable assets.
> 
> - Replaces top banner image `src` in `README.md` with a new GitHub user-attachments URL
> - Updates Providers section banner to a new asset and clarifies `alt` text
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ed55f20baea06f1d0c3101abd3bd45c648a55873. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->