### PR TITLE
fix(sidebar): left sidebar empty state doesn't stretch vertically when toggled

### DIFF
--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -109,6 +109,25 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
 }) => {
   const { open, isMobile, setOpen } = useSidebar();
   const [deletingProjectId, setDeletingProjectId] = React.useState<string | null>(null);
+  const emptyStateRef = React.useRef<HTMLDivElement>(null);
+  const [emptyStateWidth, setEmptyStateWidth] = React.useState<number | null>(null);
+  const prevOpenRef = React.useRef<boolean>(open);
+
+  React.useEffect(() => {
+    const wasOpen = prevOpenRef.current;
+    prevOpenRef.current = open;
+
+    if (wasOpen && !open && emptyStateRef.current) {
+      // Transitioning from open to closed - capture and lock width
+      setEmptyStateWidth(emptyStateRef.current.offsetWidth);
+    } else if (!wasOpen && open) {
+      // Transitioning from closed to open - clear width after animation completes
+      const timer = setTimeout(() => {
+        setEmptyStateWidth(null);
+      }, 300); // Match sidebar transition duration
+      return () => clearTimeout(timer);
+    }
+  }, [open]);
 
   const handleDeleteProject = React.useCallback(
     async (project: Project) => {
@@ -152,16 +171,22 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
             </SidebarMenuItem>
           </SidebarMenu>
         </SidebarHeader>
-        <SidebarContent>
+        <SidebarContent className={projects.length === 0 ? 'overflow-x-hidden' : undefined}>
           {projects.length === 0 && (
-            <SidebarEmptyState
-              title="No projects yet"
-              description="Open a project to start creating worktrees and running coding agents."
-              actionLabel={onOpenProject ? 'Open Project' : undefined}
-              onAction={onOpenProject}
-              secondaryActionLabel={onNewProject ? 'New Project' : undefined}
-              onSecondaryAction={onNewProject}
-            />
+            <div
+              ref={emptyStateRef}
+              className="overflow-hidden"
+              style={{ minWidth: emptyStateWidth ?? undefined }}
+            >
+              <SidebarEmptyState
+                title="No projects yet"
+                description="Open a project to start creating worktrees and running coding agents."
+                actionLabel={onOpenProject ? 'Open Project' : undefined}
+                onAction={onOpenProject}
+                secondaryActionLabel={onNewProject ? 'New Project' : undefined}
+                onSecondaryAction={onNewProject}
+              />
+            </div>
           )}
 
           <SidebarGroup>

--- a/src/renderer/components/ui/sidebar.tsx
+++ b/src/renderer/components/ui/sidebar.tsx
@@ -109,7 +109,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
 
     const baseClasses =
       variant === 'default'
-        ? 'group/sidebar relative z-50 flex h-full flex-col border-r border-border bg-muted/10 text-sm text-foreground transition-all duration-200 ease-linear overflow-hidden flex-shrink-0 data-[state=collapsed]:border-r-0 data-[state=collapsed]:pointer-events-none'
+        ? 'group group/sidebar relative z-50 flex h-full flex-col border-r border-border bg-muted/10 text-sm text-foreground transition-all duration-200 ease-linear overflow-hidden flex-shrink-0 data-[state=collapsed]:border-r-0 data-[state=collapsed]:pointer-events-none'
         : '';
     const responsiveClasses =
       variant === 'default'


### PR DESCRIPTION
When the sidebar is empty, and you toggle the left sidebar the "No Project Yet" empty state would adjust the width as the sidebar is collapsing, making the animation janky.

The fix was to set a fixed width on the element, based on what the sidebar is, so during animations, the card just overflows, and doesn't stretch.

Before:
<img width="1408" height="909" alt="before" src="https://github.com/user-attachments/assets/d66afbc0-22d1-44ce-bd42-2fdbe573b570" />

After:
<img width="1409" height="916" alt="after" src="https://github.com/user-attachments/assets/00b0c0d4-f9bc-4336-bb6b-2b5532864d5d" />
