### PR TITLE
fix(sidebar): prevent empty state from squishing during resize

### DIFF
--- a/src/renderer/components/SidebarEmptyState.tsx
+++ b/src/renderer/components/SidebarEmptyState.tsx
@@ -21,7 +21,7 @@ const SidebarEmptyState: React.FC<Props> = ({
   onSecondaryAction,
 }) => {
   return (
-    <div>
+    <div className="min-w-0 overflow-hidden">
       <Card className="bg-muted/20">
         <CardHeader className="py-3 sm:py-4">
           <CardTitle className="text-base leading-tight">{title}</CardTitle>


### PR DESCRIPTION
Add `min-w-0` and `overflow-hidden` to SidebarEmptyState wrapper to match the behavior of the project list. This ensures the empty state clips cleanly during sidebar resize instead of squishing text awkwardly.

**Root cause:** The project list uses `min-w-0` throughout, which allows flex children to shrink and truncate cleanly. The empty state Card had no such constraint, causing it to squish/reflow during resize.

**Fix:** Add the same `min-w-0 overflow-hidden` pattern to the empty state wrapper.

Alternative approach to #675 (thanks for flagging @noumanamalik) 🙏 


https://github.com/user-attachments/assets/fb7468ed-0144-43e8-94ef-c15769655db3



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Aligns empty-state layout with the project list to avoid text squishing during sidebar resize.
> 
> - Adds `min-w-0 overflow-hidden` to the `SidebarEmptyState` wrapper
> - Results in clean clipping/truncation instead of reflow when the sidebar is resized
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 6aac1609a57b4478e826e4484a8c5083fb92119c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->