### PR TITLE
fix(pty): prevent crash loop when closing app with running processes

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -194,6 +194,8 @@ export function registerPtyIpc(): void {
           }
           log.debug('pty:ownerDestroyed', { id });
           try {
+            // Ensure telemetry timers are cleared on owner destruction
+            maybeMarkProviderFinish(id, null, undefined);
             killPty(id);
           } catch {}
           owners.delete(id);
@@ -403,6 +405,8 @@ try {
   app.on('before-quit', () => {
     for (const id of Array.from(owners.keys())) {
       try {
+        // Ensure telemetry timers are cleared on app quit
+        maybeMarkProviderFinish(id, null, undefined);
         killPty(id);
       } catch {}
     }


### PR DESCRIPTION
## Summary

- Guard IPC sends to destroyed WebContents with `safeSendToOwner()` helper
- Add WebContents destruction listener to kill PTYs when window closes
- Add `before-quit` handler to clean up all PTYs on app shutdown
- Guard `pty:started` broadcast with per-window `isDestroyed()` check

## Test plan

- [x] Start app with `npm run dev`
- [x] Create a task with a running agent (e.g., Claude)
- [x] Close the app (Cmd+Q) while the agent is active
- [x] Verify clean exit with no crash dialog
- [x] Verify `pty:ownerDestroyed` logs appear in terminal output

Fixes #676

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves PTY lifecycle safety to avoid crashes during window/app shutdown.
> 
> - Adds `safeSendToOwner()` to guard IPC sends when `WebContents` is destroyed
> - Attaches per-PTY `onData`/`onExit` listeners that use safe sending and ignore stale `onExit` events
> - Registers `WebContents` `destroyed` handler to `maybeMarkProviderFinish()`, `killPty()`, and clear PTY ownership/listener state
> - Guards `pty:started` broadcast by checking `webContents.isDestroyed()` per window
> - On app `before-quit`, iterates all PTYs to `maybeMarkProviderFinish()`, `killPty()`, and clears `owners`/`listeners`
> - Minor: import `app` from `electron` to support shutdown handling
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 39e7aed2e625cc5ff1847211d75268ebf94cfcf5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->