### PR TITLE
fix(pty): kill terminal processes on task deletion

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1844,6 +1844,8 @@ const AppContent: React.FC = () => {
         // Clean up task terminal panel terminals (bottom-right shell terminals)
         disposeTaskTerminals(`${task.id}::${task.path}`);
         disposeTaskTerminals(`global::${task.path}`);
+        // Clean up ChatInterface's terminal state (uses task.id as key)
+        disposeTaskTerminals(task.id);
 
         // Only remove worktree if the task was created with one
         // IMPORTANT: Tasks without worktrees have useWorktree === false

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -36,6 +36,7 @@ import { useGithubAuth } from './hooks/useGithubAuth';
 import { useTheme } from './hooks/useTheme';
 import useUpdateNotifier from './hooks/useUpdateNotifier';
 import { loadPanelSizes, savePanelSizes } from './lib/persisted-layout';
+import { disposeTaskTerminals } from './lib/taskTerminalsStore';
 import {
   computeBaseRef,
   getProjectRepoKey,
@@ -1713,6 +1714,10 @@ const AppContent: React.FC = () => {
             } catch {}
           })
         );
+
+        // Clean up task terminal panel terminals (bottom-right shell terminals)
+        disposeTaskTerminals(`${task.id}::${task.path}`);
+        disposeTaskTerminals(`global::${task.path}`);
 
         // Only remove worktree if the task was created with one
         // IMPORTANT: Tasks without worktrees have useWorktree === false

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1693,19 +1693,15 @@ const AppContent: React.FC = () => {
           } catch {}
         } catch {}
         try {
-          window.electronAPI.ptyKill?.(`task-${task.id}`);
-        } catch {}
-        try {
           for (const provider of TERMINAL_PROVIDER_IDS) {
             try {
               window.electronAPI.ptyKill?.(`${provider}-main-${task.id}`);
             } catch {}
           }
         } catch {}
-        const sessionIds = [
-          `task-${task.id}`,
-          ...TERMINAL_PROVIDER_IDS.map((provider) => `${provider}-main-${task.id}`),
-        ];
+        const sessionIds = TERMINAL_PROVIDER_IDS.map(
+          (provider) => `${provider}-main-${task.id}`
+        );
 
         await Promise.allSettled(
           sessionIds.map(async (sessionId) => {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1843,8 +1843,11 @@ const AppContent: React.FC = () => {
 
         // Clean up task terminal panel terminals (bottom-right shell terminals)
         disposeTaskTerminals(`${task.id}::${task.path}`);
-        disposeTaskTerminals(`global::${task.path}`);
-        // Clean up ChatInterface's terminal state (uses task.id as key)
+        // Global terminals are shared by non-worktree tasks on the same path
+        if (task.useWorktree !== false) {
+          disposeTaskTerminals(`global::${task.path}`);
+        }
+        // ChatInterface uses task.id as key
         disposeTaskTerminals(task.id);
 
         // Only remove worktree if the task was created with one

--- a/src/renderer/components/GitHubIssueSelector.tsx
+++ b/src/renderer/components/GitHubIssueSelector.tsx
@@ -262,10 +262,10 @@ export const GitHubIssueSelector: React.FC<GitHubIssueSelectorProps> = ({
                       {linkedIssueMode === 'disable' && isLinked ? (
                         <Badge
                           variant="outline"
-                          className="ml-auto shrink-0 text-[10px]"
-                          title={`Linked to task "${linkedIssue?.taskName ?? 'another task'}"`}
+                          className="ml-auto shrink-0 text-[10px] opacity-75"
+                          title={`Already linked to task: ${linkedIssue?.taskName ?? 'another task'}`}
                         >
-                          In use
+                          Linked to: {linkedIssue?.taskName ? linkedIssue.taskName.slice(0, 20) + (linkedIssue.taskName.length > 20 ? '...' : '') : 'task'}
                         </Badge>
                       ) : null}
                     </span>

--- a/src/renderer/components/GitHubIssueSelector.tsx
+++ b/src/renderer/components/GitHubIssueSelector.tsx
@@ -265,7 +265,11 @@ export const GitHubIssueSelector: React.FC<GitHubIssueSelectorProps> = ({
                           className="ml-auto shrink-0 text-[10px] opacity-75"
                           title={`Already linked to task: ${linkedIssue?.taskName ?? 'another task'}`}
                         >
-                          Linked to: {linkedIssue?.taskName ? linkedIssue.taskName.slice(0, 20) + (linkedIssue.taskName.length > 20 ? '...' : '') : 'task'}
+                          Linked to:{' '}
+                          {linkedIssue?.taskName
+                            ? linkedIssue.taskName.slice(0, 20) +
+                              (linkedIssue.taskName.length > 20 ? '...' : '')
+                            : 'task'}
                         </Badge>
                       ) : null}
                     </span>

--- a/src/renderer/components/TaskAdvancedSettings.tsx
+++ b/src/renderer/components/TaskAdvancedSettings.tsx
@@ -14,6 +14,7 @@ import LinearSetupForm from './integrations/LinearSetupForm';
 import JiraSetupForm from './integrations/JiraSetupForm';
 import { type LinearIssueSummary } from '../types/linear';
 import { type GitHubIssueSummary } from '../types/github';
+import { type GitHubIssueLink } from '../types/chat';
 import { type JiraIssueSummary } from '../types/jira';
 
 interface TaskAdvancedSettingsProps {
@@ -43,6 +44,7 @@ interface TaskAdvancedSettingsProps {
   // GitHub
   selectedGithubIssue: GitHubIssueSummary | null;
   onGithubIssueChange: (issue: GitHubIssueSummary | null) => void;
+  linkedGithubIssueMap?: ReadonlyMap<number, GitHubIssueLink>;
   isGithubConnected: boolean;
   onGithubConnect: () => Promise<void>;
   githubLoading: boolean;
@@ -72,6 +74,7 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
   onLinearConnect,
   selectedGithubIssue,
   onGithubIssueChange,
+  linkedGithubIssueMap,
   isGithubConnected,
   onGithubConnect,
   githubLoading,
@@ -324,6 +327,7 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
                       projectPath={projectPath || ''}
                       selectedIssue={selectedGithubIssue}
                       onIssueChange={handleGithubIssueChange}
+                      linkedIssueMap={linkedGithubIssueMap}
                       isOpen={isOpen}
                       disabled={
                         !hasInitialPromptSupport ||

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -14,6 +14,7 @@ import { providerMeta } from '../providers/meta';
 import { isValidProviderId } from '@shared/providers/registry';
 import { type LinearIssueSummary } from '../types/linear';
 import { type GitHubIssueSummary } from '../types/github';
+import { type GitHubIssueLink } from '../types/chat';
 import { type JiraIssueSummary } from '../types/jira';
 import {
   generateFriendlyTaskName,
@@ -41,6 +42,7 @@ interface TaskModalProps {
   projectName: string;
   defaultBranch: string;
   existingNames?: string[];
+  linkedGithubIssueMap?: ReadonlyMap<number, GitHubIssueLink>;
   projectPath?: string;
   branchOptions?: BranchOption[];
   isLoadingBranches?: boolean;
@@ -53,6 +55,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
   projectName,
   defaultBranch,
   existingNames = [],
+  linkedGithubIssueMap,
   projectPath,
   branchOptions = [],
   isLoadingBranches = false,
@@ -326,6 +329,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
             onLinearConnect={integrations.handleLinearConnect}
             selectedGithubIssue={selectedGithubIssue}
             onGithubIssueChange={setSelectedGithubIssue}
+            linkedGithubIssueMap={linkedGithubIssueMap}
             isGithubConnected={integrations.isGithubConnected}
             onGithubConnect={integrations.handleGithubConnect}
             githubLoading={integrations.githubLoading}

--- a/src/renderer/lib/taskTerminalsStore.ts
+++ b/src/renderer/lib/taskTerminalsStore.ts
@@ -1,4 +1,5 @@
 import { useMemo, useSyncExternalStore } from 'react';
+import { terminalSessionRegistry } from '../terminal/SessionRegistry';
 
 type TaskTerminal = {
   id: string;
@@ -302,6 +303,18 @@ export function disposeTaskTerminals(taskKey: string): void {
         (window as any).electronAPI?.ptyKill?.(terminal.id);
       } catch {
         // ignore kill errors
+      }
+      try {
+        // Dispose xterm.js session from registry
+        terminalSessionRegistry.dispose(terminal.id);
+      } catch {
+        // ignore dispose errors
+      }
+      try {
+        // Clear PTY snapshot from main process
+        (window as any).electronAPI?.ptyClearSnapshot?.({ id: terminal.id });
+      } catch {
+        // ignore snapshot clear errors
       }
     }
   }

--- a/src/renderer/lib/taskTerminalsStore.ts
+++ b/src/renderer/lib/taskTerminalsStore.ts
@@ -294,6 +294,31 @@ function closeTerminal(taskId: string, terminalId: string, taskPath?: string) {
   }
 }
 
+export function disposeTaskTerminals(taskKey: string): void {
+  const state = taskStates.get(taskKey) ?? loadFromStorage(taskKey);
+  if (state) {
+    for (const terminal of state.terminals) {
+      try {
+        (window as any).electronAPI?.ptyKill?.(terminal.id);
+      } catch {
+        // ignore kill errors
+      }
+    }
+  }
+
+  taskStates.delete(taskKey);
+  taskSnapshots.delete(taskKey);
+  taskListeners.delete(taskKey);
+
+  if (storageAvailable) {
+    try {
+      window.localStorage.removeItem(storageKey(taskKey));
+    } catch {
+      // ignore storage errors
+    }
+  }
+}
+
 export function useTaskTerminals(
   taskId: string | null,
   taskPath?: string,

--- a/src/renderer/lib/taskTerminalsStore.ts
+++ b/src/renderer/lib/taskTerminalsStore.ts
@@ -305,16 +305,14 @@ export function disposeTaskTerminals(taskKey: string): void {
         // ignore kill errors
       }
       try {
-        // Dispose xterm.js session from registry
         terminalSessionRegistry.dispose(terminal.id);
       } catch {
         // ignore dispose errors
       }
       try {
-        // Clear PTY snapshot from main process
         (window as any).electronAPI?.ptyClearSnapshot?.({ id: terminal.id });
       } catch {
-        // ignore snapshot clear errors
+        // ignore snapshot errors
       }
     }
   }

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -9,6 +9,12 @@ export interface ProviderRun {
   runs: number;
 }
 
+export interface GitHubIssueLink {
+  number: number;
+  taskId: string;
+  taskName: string;
+}
+
 export interface TaskMetadata {
   linearIssue?: LinearIssueSummary | null;
   githubIssue?: GitHubIssueSummary | null;


### PR DESCRIPTION
## Summary
- Remove legacy `task-${taskId}` terminal cleanup code (no longer used)
- Kill task terminal panel processes (bottom-right shell terminals) when deleting a task
- Kill chat agent terminals (agents added via "+") when deleting a task

Previously, when deleting a task:
- Dev servers running in the bottom-right terminal panel were orphaned
- Non-main agent terminals (e.g., Codex added to a Claude task) were orphaned

## Test plan
- [ ] Create a task, run `npm run dev` in the bottom-right terminal panel
- [ ] Delete the task
- [ ] Verify with `lsof -i :3000` that the process is killed
- [ ] Create a task with Claude, add Codex via "+"
- [ ] Exit Codex CLI, run a process (e.g., `npx serve -p 3001`)
- [ ] Delete the task
- [ ] Verify with `lsof -i :3001` that the process is killed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves task deletion cleanup and adds GitHub issue linking safeguards in the task creation flow.
> 
> - On task delete, kills all related PTY sessions (main agent sessions incl. multi‑agent variants, chat agent terminals), disposes `terminalSessionRegistry`, clears PTY snapshots, and disposes bottom‑right panel terminals via `disposeTaskTerminals`
> - Adds `disposeTaskTerminals` utility and integrates it into deletion flow
> - Adds `GitHubIssueLink` type and builds a map of already‑linked GitHub issues to prevent re‑linking
> - Updates `GitHubIssueSelector` to disable/hide issues already linked (with badge and tooltip) and wires through via `TaskAdvancedSettings`/`TaskModal`
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c9d9b89e71388ecd7de4b70a7572a7c7adfb2da5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->