### PR TITLE
feat: restore active task on app reload

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1780,7 +1780,7 @@ const AppContent: React.FC = () => {
   const handleSelectTask = (task: Task) => {
     setActiveTask(task);
     setActiveTaskAgent(getAgentForTask(task));
-    saveActiveIds(selectedProject?.id ?? null, task.id);
+    saveActiveIds(task.projectId, task.id);
   };
 
   const handleStartCreateTaskFromSidebar = useCallback(
@@ -2183,6 +2183,7 @@ const AppContent: React.FC = () => {
         setSelectedProject(null);
         setActiveTask(null);
         setShowHomeView(true);
+        saveActiveIds(null, null);
       }
       toast({ title: 'Project deleted', description: `"${project.name}" was removed.` });
     } catch (err) {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1316,6 +1316,7 @@ const AppContent: React.FC = () => {
         );
         setActiveTask(newTask);
         setActiveTaskAgent(null);
+        saveActiveIds(newTask.projectId, newTask.id);
 
         // Create worktrees in background, then update task with real variants
         (async () => {
@@ -1561,11 +1562,8 @@ const AppContent: React.FC = () => {
 
         // Set the active task and its agent immediately
         setActiveTask(newTask);
-        if ((newTask.metadata as any)?.multiAgent?.enabled) {
-          setActiveTaskAgent(null);
-        } else {
-          setActiveTaskAgent((newTask.agentId as Agent) || primaryAgent || 'codex');
-        }
+        setActiveTaskAgent(getAgentForTask(newTask) ?? primaryAgent ?? 'codex');
+        saveActiveIds(newTask.projectId, newTask.id);
 
         // Background: save to database (non-blocking)
         window.electronAPI

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -164,23 +164,6 @@
     background-color: hsl(var(--muted-foreground) / 0.4);
   }
 
-  .sidebar-panel {
-    transition: flex-grow 300ms ease;
-  }
-
-  [data-panel-group]:has([data-resize-handle-state='drag']) .sidebar-panel {
-    transition-duration: 0ms;
-  }
-
-  [data-panel-group].no-transition .sidebar-panel {
-    transition-duration: 0ms;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .sidebar-panel {
-      transition-duration: 0ms;
-    }
-  }
 }
 
 @layer components {

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -163,7 +163,6 @@
   .dark-black *::-webkit-scrollbar-thumb:hover {
     background-color: hsl(var(--muted-foreground) / 0.4);
   }
-
 }
 
 @layer components {


### PR DESCRIPTION
## Summary
Restores the active task view when reloading the app, instead of always landing on the home page.

## Changes
- Persist active project and task IDs to localStorage
- Read stored IDs synchronously on init to prevent UI flash
- Restore view state after projects load, with validation
- Handle edge cases: deleted project/task gracefully falls back
- Remove unused sidebar panel CSS transitions (were always overridden)
- Extract `getAgentForTask` helper to reduce code duplication

## Testing
- Reload app while on a task → returns to same task
- Reload while on project view → returns to project
- Delete a task, reload → falls back to project view
- Delete a project, reload → falls back to home

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Restores the previously active project/task on app reload and simplifies right sidebar behavior to avoid UI flash.
> 
> - Persist/restore `activeProjectId` and `activeTaskId` via `localStorage`; initialize `showHomeView` based on stored IDs and validate on load (clears if project/task missing)
> - Add `getAgentForTask` helper and replace duplicated agent-selection logic across navigation and task creation
> - Update selection flows (`next/prev` task, select project/task, go home, delete task/project) to save/clear active IDs consistently
> - Defer auto right-sidebar collapse/expand until initial load completes; remove no-transition hack and delete unused sidebar transition CSS in `index.css`
> - Minor: introduce `isInitialLoadComplete`, guard sidebar behavior, and prevent first-load flash
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b6b925abd18d298fe8a772298df522a062c384fb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->