### PR TITLE
fix: jira connection form clipping in settings

### DIFF
--- a/src/renderer/components/IntegrationsCard.tsx
+++ b/src/renderer/components/IntegrationsCard.tsx
@@ -484,8 +484,8 @@ const IntegrationsCard: React.FC = () => {
                   <motion.div
                     role="dialog"
                     aria-label="Jira setup"
-                    className="absolute right-0 top-full z-50 mt-2 w-[420px] max-w-[calc(100vw-3rem)] rounded-xl border border-border/60 bg-background/95 p-3 shadow-2xl ring-1 ring-border/60 backdrop-blur supports-[backdrop-filter]:bg-background/80 md:w-[480px]"
-                    style={{ transformOrigin: 'top right' }}
+                    className="absolute left-0 top-full z-50 mt-2 w-[360px] max-w-[calc(100vw-3rem)] rounded-xl border border-border/60 bg-background/95 p-3 shadow-2xl ring-1 ring-border/60 backdrop-blur supports-[backdrop-filter]:bg-background/80"
+                    style={{ transformOrigin: 'top left' }}
                     {...(menuMotion(!!reduceMotion) as any)}
                   >
                     <JiraSetupForm

--- a/src/renderer/components/integrations/JiraSetupForm.tsx
+++ b/src/renderer/components/integrations/JiraSetupForm.tsx
@@ -29,10 +29,7 @@ const JiraSetupForm: React.FC<Props> = ({
       <div className="flex items-center gap-2">
         <span className="inline-flex items-center gap-1.5 rounded-md border border-border/70 bg-muted/40 px-2 py-0.5 text-xs font-medium">
           <img src={jiraLogo} alt="Jira" className="h-3.5 w-3.5" />
-          Jira setup
-        </span>
-        <span className="text-xs text-muted-foreground">
-          Connect your Jira site using email + API token.
+          Jira
         </span>
       </div>
       <div className="mt-2 grid gap-2">
@@ -43,7 +40,7 @@ const JiraSetupForm: React.FC<Props> = ({
           className="h-8 w-full"
         />
         <Input
-          placeholder="email@example.com"
+          placeholder="Email"
           value={email}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange({ email: e.target.value })}
           className="h-8 w-full"
@@ -56,25 +53,11 @@ const JiraSetupForm: React.FC<Props> = ({
           className="h-8 w-full"
         />
       </div>
-      <div className="mt-2 rounded-md border border-dashed border-border/70 bg-muted/40 p-2">
-        <div className="flex items-start gap-2">
-          <Info className="mt-0.5 h-4 w-4 text-muted-foreground" aria-hidden="true" />
-          <div className="text-xs leading-snug text-muted-foreground">
-            <p className="font-medium text-foreground">How to get your Jira credentials</p>
-            <ol className="mt-1 list-decimal pl-4">
-              <li>
-                Site URL: open Jira in the browser and copy the base URL (e.g.
-                https://your-domain.atlassian.net).
-              </li>
-              <li>Use your Atlassian account email address.</li>
-              <li>
-                Create an API token: id.atlassian.com/manage-profile/security/api-tokens → Create
-                API token → Copy the token here.
-              </li>
-            </ol>
-          </div>
-        </div>
-      </div>
+      <p className="mt-2 text-xs text-muted-foreground">
+        <Info className="mr-1 inline h-3 w-3" aria-hidden="true" />
+        Create an API token at{' '}
+        <span className="font-medium">id.atlassian.com/manage-profile/security/api-tokens</span>
+      </p>
       {error ? (
         <p className="mt-2 text-xs text-red-600" role="alert">
           {error}


### PR DESCRIPTION
Fixes #696

The jira setup form was getting clipped on the left side because it was anchored to the right edge and wider than the available space.

- anchor from left instead of right  
- reduced width to 360px
- cleaned up the form copy while I was in there

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only adjustments to the Jira setup popover positioning/sizing and form copy; no changes to connection logic or credential handling.
> 
> **Overview**
> Fixes Jira setup popover clipping by anchoring the menu to the left (`left-0`, `top left` transform origin) and reducing its width to `360px`.
> 
> Simplifies the Jira setup form header/labels and replaces the long credential instructions block with a short inline hint linking to the Atlassian API token page.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ad92f16e94f6b1f60d969ab9d57e533d66c6bcf1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->