### PR TITLE
fix: native module architecture mismatch in x64 builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -115,6 +115,7 @@ jobs:
           set -euo pipefail
           # Verify that each build has native modules matching its Electron binary architecture.
           # This catches issues like #706 where x64 builds had arm64 native modules.
+          VERIFIED_COUNT=0
           for APP_DIR in release/mac-*/emdash.app; do
             [ -d "$APP_DIR" ] || continue
             ARCH_DIR=$(basename "$(dirname "$APP_DIR")")
@@ -144,8 +145,13 @@ jobs:
             else
               echo "::warning::sqlite3 native module not found at $SQLITE_NODE"
             fi
+            VERIFIED_COUNT=$((VERIFIED_COUNT + 1))
           done
-          echo "All architecture checks passed"
+          if [ "$VERIFIED_COUNT" -eq 0 ]; then
+            echo "::error::No app bundles found to verify"
+            exit 1
+          fi
+          echo "Verified $VERIFIED_COUNT app bundle(s)"
 
       - name: Smoke test sqlite3 in packaged app (arm64)
         if: ${{ github.event.inputs.arch == '' || github.event.inputs.arch == 'arm64' || github.event.inputs.arch == 'both' }}
@@ -382,6 +388,7 @@ jobs:
           set -euo pipefail
           # Verify that each build has native modules matching its Electron binary architecture.
           # This catches issues like #706 where x64 builds had arm64 native modules.
+          VERIFIED_COUNT=0
           for APP_DIR in release/mac-*/emdash.app; do
             [ -d "$APP_DIR" ] || continue
             ARCH_DIR=$(basename "$(dirname "$APP_DIR")")
@@ -411,8 +418,13 @@ jobs:
             else
               echo "::warning::sqlite3 native module not found at $SQLITE_NODE"
             fi
+            VERIFIED_COUNT=$((VERIFIED_COUNT + 1))
           done
-          echo "All architecture checks passed"
+          if [ "$VERIFIED_COUNT" -eq 0 ]; then
+            echo "::error::No app bundles found to verify"
+            exit 1
+          fi
+          echo "Verified $VERIFIED_COUNT app bundle(s)"
 
       - name: Smoke test sqlite3 in packaged app (arm64, signed)
         if: ${{ github.event.inputs.arch == '' || github.event.inputs.arch == 'arm64' || github.event.inputs.arch == 'both' }}


### PR DESCRIPTION
Fixes #706

The x64 mac build was getting arm64 native modules because we rebuilt all architectures first, then ran electron-builder with `--x64 --arm64`. The last rebuild (arm64) overwrote the x64 modules, so both builds used arm64 natives.

Now we build each architecture separately - rebuild native modules, then package, then move to the next arch.

Also added a CI step that verifies native module architectures match the Electron binary, so this can't regress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk because it changes the macOS release workflow build order and adds new CI checks; misconfiguration could break or slow releases, but it’s isolated to CI packaging.
> 
> **Overview**
> Fixes macOS x64/arm64 native module mismatches by **building each architecture separately**: for each selected arch, the workflow now runs `@electron/rebuild` for `sqlite3`, `node-pty`, and `keytar`, then packages via `electron-builder` (both unsigned and signed jobs).
> 
> Adds a **post-build verification step** that inspects each generated `.app` bundle and fails CI if the Electron binary or `sqlite3` native module architecture doesn’t match the expected arch, preventing regressions like #706.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5ed47fa11fc7ad13feca4b7e116830419344e299. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->