### PR TITLE
fix: stop creating .claude/settings.json for non-Claude providers

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -116,7 +116,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     projectPath: string;
     taskName: string;
     projectId: string;
-    autoApprove?: boolean;
+    baseRef?: string;
   }) => ipcRenderer.invoke('worktree:create', args),
   worktreeList: (args: { projectPath: string }) => ipcRenderer.invoke('worktree:list', args),
   worktreeRemove: (args: {
@@ -142,7 +142,6 @@ contextBridge.exposeInMainWorld('electronAPI', {
     projectPath: string;
     taskName: string;
     baseRef?: string;
-    autoApprove?: boolean;
   }) => ipcRenderer.invoke('worktree:claimReserve', args),
   worktreeRemoveReserve: (args: { projectId: string }) =>
     ipcRenderer.invoke('worktree:removeReserve', args),
@@ -512,7 +511,7 @@ export interface ElectronAPI {
     projectPath: string;
     taskName: string;
     projectId: string;
-    autoApprove?: boolean;
+    baseRef?: string;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
   worktreeList: (args: {
     projectPath: string;

--- a/src/main/services/WorktreeService.ts
+++ b/src/main/services/WorktreeService.ts
@@ -117,7 +117,6 @@ export class WorktreeService {
     projectPath: string,
     taskName: string,
     projectId: string,
-    autoApprove?: boolean,
     baseRef?: string
   ): Promise<WorktreeInfo> {
     // Declare variables outside try block for access in catch block
@@ -190,11 +189,6 @@ export class WorktreeService {
         await this.preserveFilesToWorktree(projectPath, worktreePath, patterns);
       } catch (preserveErr) {
         log.warn('Failed to preserve files to worktree (continuing):', preserveErr);
-      }
-
-      // Setup Claude Code settings if auto-approve is enabled
-      if (autoApprove) {
-        this.ensureClaudeAutoApprove(worktreePath);
       }
 
       await this.logWorktreeSyncStatus(projectPath, worktreePath, fetchedBaseRef);
@@ -1110,38 +1104,6 @@ export class WorktreeService {
     }
 
     return result;
-  }
-
-  private ensureClaudeAutoApprove(worktreePath: string) {
-    try {
-      const claudeDir = path.join(worktreePath, '.claude');
-      const settingsPath = path.join(claudeDir, 'settings.json');
-
-      // Create .claude directory if it doesn't exist
-      if (!fs.existsSync(claudeDir)) {
-        fs.mkdirSync(claudeDir, { recursive: true });
-      }
-
-      // Read existing settings or create new
-      let settings: any = {};
-      if (fs.existsSync(settingsPath)) {
-        try {
-          const content = fs.readFileSync(settingsPath, 'utf8');
-          settings = JSON.parse(content);
-        } catch (err) {
-          log.warn('Failed to parse existing .claude/settings.json, will overwrite', err);
-        }
-      }
-
-      // Set defaultMode to bypassPermissions
-      settings.defaultMode = 'bypassPermissions';
-
-      // Write settings file
-      fs.writeFileSync(settingsPath, JSON.stringify(settings, null, 2) + '\n', 'utf8');
-      log.info(`Created .claude/settings.json with auto-approve enabled in ${worktreePath}`);
-    } catch (err) {
-      log.error('Failed to create .claude/settings.json', err);
-    }
   }
 
   private async logWorktreeSyncStatus(

--- a/src/main/services/worktreeIpc.ts
+++ b/src/main/services/worktreeIpc.ts
@@ -12,7 +12,6 @@ export function registerWorktreeIpc(): void {
         projectPath: string;
         taskName: string;
         projectId: string;
-        autoApprove?: boolean;
         baseRef?: string;
       }
     ) => {
@@ -21,7 +20,6 @@ export function registerWorktreeIpc(): void {
           args.projectPath,
           args.taskName,
           args.projectId,
-          args.autoApprove,
           args.baseRef
         );
         return { success: true, worktree };
@@ -166,7 +164,6 @@ export function registerWorktreeIpc(): void {
         projectPath: string;
         taskName: string;
         baseRef?: string;
-        autoApprove?: boolean;
       }
     ) => {
       try {
@@ -174,8 +171,7 @@ export function registerWorktreeIpc(): void {
           args.projectId,
           args.projectPath,
           args.taskName,
-          args.baseRef,
-          args.autoApprove
+          args.baseRef
         );
         if (result) {
           return {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1357,7 +1357,6 @@ const AppContent: React.FC = () => {
                     projectPath: selectedProject.path,
                     taskName: variantName,
                     projectId: selectedProject.id,
-                    autoApprove,
                     baseRef,
                   });
                   if (!worktreeResult?.success || !worktreeResult.worktree) {
@@ -1498,7 +1497,6 @@ const AppContent: React.FC = () => {
             projectPath: selectedProject.path,
             taskName,
             baseRef,
-            autoApprove,
           });
 
           if (claimResult.success && claimResult.worktree) {
@@ -1520,7 +1518,6 @@ const AppContent: React.FC = () => {
               projectPath: selectedProject.path,
               taskName,
               projectId: selectedProject.id,
-              autoApprove,
               baseRef,
             });
 

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -352,7 +352,6 @@ declare global {
         projectPath: string;
         taskName: string;
         projectId: string;
-        autoApprove?: boolean;
         baseRef?: string;
       }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
       worktreeList: (args: {
@@ -395,7 +394,6 @@ declare global {
         projectPath: string;
         taskName: string;
         baseRef?: string;
-        autoApprove?: boolean;
       }) => Promise<{
         success: boolean;
         worktree?: any;
@@ -994,7 +992,6 @@ export interface ElectronAPI {
     projectPath: string;
     taskName: string;
     projectId: string;
-    autoApprove?: boolean;
     baseRef?: string;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
   worktreeList: (args: {
@@ -1037,7 +1034,6 @@ export interface ElectronAPI {
     projectPath: string;
     taskName: string;
     baseRef?: string;
-    autoApprove?: boolean;
   }) => Promise<{
     success: boolean;
     worktree?: any;

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -50,7 +50,7 @@ declare global {
         projectPath: string;
         taskName: string;
         projectId: string;
-        autoApprove?: boolean;
+        baseRef?: string;
       }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
       worktreeList: (args: {
         projectPath: string;
@@ -87,7 +87,6 @@ declare global {
         projectPath: string;
         taskName: string;
         baseRef?: string;
-        autoApprove?: boolean;
       }) => Promise<{
         success: boolean;
         worktree?: any;


### PR DESCRIPTION
## Summary
- Removes `ensureClaudeAutoApprove` from WorktreeService and WorktreePoolService
- Auto-approve is already handled via CLI flags (`--full-auto`, `--dangerously-skip-permissions`, etc.) when launching agents

Fixes #708

## Test plan
- [ ] Create a task with Codex and auto-approve enabled
- [ ] Verify no `.claude/settings.json` is created in the worktree
- [ ] Verify auto-approve still works (CLI flag should be passed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: removes a side-effect during worktree creation/claiming and updates the IPC/renderer API surface accordingly; main risk is any downstream dependency on the removed `autoApprove` worktree parameter.
> 
> **Overview**
> Stops worktree creation/claiming from creating or mutating `.claude/settings.json` by removing the `ensureClaudeAutoApprove` logic from both `WorktreeService` and `WorktreePoolService`.
> 
> Removes the `autoApprove` argument from the worktree IPC and renderer APIs (`worktreeCreate`/`worktreeClaimReserve`) and updates the UI call sites and type definitions to match, leaving auto-approve to be handled via agent CLI flags.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit fc587b67a091c71a8d11061b3eb186f691272d84. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->