### PR TITLE
feat: add Merge Main option to PR dropdown

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -857,9 +857,9 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         // PR already exists - continue to merge
       }
 
-      // Merge and delete branch
+      // Merge PR (branch cleanup happens when workspace is deleted)
       try {
-        await execAsync('gh pr merge --merge --delete-branch', { cwd: taskPath });
+        await execAsync('gh pr merge --merge', { cwd: taskPath });
         return { success: true, prUrl };
       } catch (e) {
         const errMsg = (e as { stderr?: string })?.stderr || String(e);

--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -804,7 +804,10 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         // gh not available or not a GitHub repo - fall back to 'main'
       }
 
-      // Validate: not on default branch
+      // Validate: on a valid feature branch
+      if (!currentBranch) {
+        return { success: false, error: 'Not on a branch (detached HEAD state).' };
+      }
       if (currentBranch === defaultBranch) {
         return {
           success: false,

--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -783,159 +783,90 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
   );
 
   // Git: Merge current branch to main via GitHub (create PR + merge immediately)
-  ipcMain.handle(
-    'git:merge-to-main',
-    async (
-      _,
-      args: {
-        taskPath: string;
-      }
-    ) => {
-      const { taskPath } = args || ({} as { taskPath: string });
+  ipcMain.handle('git:merge-to-main', async (_, args: { taskPath: string }) => {
+    const { taskPath } = args || ({} as { taskPath: string });
+
+    try {
+      // Get current and default branch names
+      const { stdout: currentOut } = await execAsync('git branch --show-current', {
+        cwd: taskPath,
+      });
+      const currentBranch = (currentOut || '').trim();
+
+      let defaultBranch = 'main';
       try {
-        const outputs: string[] = [];
+        const { stdout } = await execAsync(
+          'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
+          { cwd: taskPath }
+        );
+        if (stdout?.trim()) defaultBranch = stdout.trim();
+      } catch {
+        // gh not available or not a GitHub repo - fall back to 'main'
+      }
 
-        // Stage and commit any pending changes
-        try {
-          const { stdout: statusOut } = await execAsync(
-            'git status --porcelain --untracked-files=all',
-            { cwd: taskPath }
-          );
-          if (statusOut && statusOut.trim().length > 0) {
-            await execAsync('git add -A', { cwd: taskPath });
-            const commitMsg = 'chore: prepare for merge to main';
-            try {
-              await execAsync(`git commit -m ${JSON.stringify(commitMsg)}`, { cwd: taskPath });
-              outputs.push('Committed pending changes');
-            } catch (commitErr) {
-              const msg = commitErr as string;
-              if (!/nothing to commit/i.test(msg)) throw commitErr;
-            }
-          }
-        } catch (stageErr) {
-          log.warn('Failed to stage/commit changes before merge:', stageErr as string);
-        }
-
-        // Push the branch
-        try {
-          await execAsync('git push', { cwd: taskPath });
-          outputs.push('Pushed branch');
-        } catch (pushErr) {
-          try {
-            const { stdout: branchOut } = await execAsync('git rev-parse --abbrev-ref HEAD', {
-              cwd: taskPath,
-            });
-            const branch = branchOut.trim();
-            await execAsync(`git push --set-upstream origin ${JSON.stringify(branch)}`, {
-              cwd: taskPath,
-            });
-            outputs.push(`Pushed branch with upstream`);
-          } catch (pushErr2) {
-            log.error('Failed to push branch:', pushErr2 as string);
-            return {
-              success: false,
-              error: 'Failed to push branch. Please check your Git remotes and authentication.',
-            };
-          }
-        }
-
-        // Determine default branch
-        let defaultBranch = 'main';
-        try {
-          const { stdout } = await execAsync(
-            'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
-            { cwd: taskPath }
-          );
-          const db = (stdout || '').trim();
-          if (db) defaultBranch = db;
-        } catch {}
-
-        // Get current branch
-        let currentBranch = '';
-        try {
-          const { stdout } = await execAsync('git branch --show-current', { cwd: taskPath });
-          currentBranch = (stdout || '').trim();
-        } catch {}
-
-        // Check if already on default branch
-        if (currentBranch === defaultBranch) {
-          return {
-            success: false,
-            error: `Already on ${defaultBranch}. Create a feature branch first.`,
-          };
-        }
-
-        // Check if there are commits ahead of main
-        try {
-          const { stdout: aheadOut } = await execAsync(
-            `git rev-list --count origin/${JSON.stringify(defaultBranch)}..HEAD`,
-            { cwd: taskPath }
-          );
-          const aheadCount = parseInt((aheadOut || '0').trim(), 10) || 0;
-          if (aheadCount <= 0) {
-            return {
-              success: false,
-              error: `No commits ahead of ${defaultBranch}. Nothing to merge.`,
-            };
-          }
-        } catch {}
-
-        // Create PR with --fill to auto-fill title/body from commits
-        let prUrl = '';
-        try {
-          const { stdout: prOut } = await execAsync(
-            `gh pr create --fill --base ${JSON.stringify(defaultBranch)}`,
-            { cwd: taskPath }
-          );
-          const urlMatch = (prOut || '').match(/https?:\/\/\S+/);
-          prUrl = urlMatch ? urlMatch[0] : '';
-          outputs.push(`Created PR: ${prUrl}`);
-        } catch (prErr) {
-          const err = prErr as { stderr?: string; message?: string };
-          const errMsg = err?.stderr || err?.message || String(prErr);
-          // Check if PR already exists
-          if (/already exists|already has.*pull request/i.test(errMsg)) {
-            outputs.push('PR already exists, proceeding to merge');
-          } else {
-            log.error('Failed to create PR:', errMsg);
-            return {
-              success: false,
-              error: `Failed to create PR: ${errMsg}`,
-            };
-          }
-        }
-
-        // Merge the PR immediately
-        try {
-          const { stdout: mergeOut, stderr: mergeErr } = await execAsync(
-            'gh pr merge --merge --delete-branch',
-            { cwd: taskPath }
-          );
-          outputs.push('Merged to main and deleted branch');
-          const out = [...outputs, (mergeOut || '').trim(), (mergeErr || '').trim()]
-            .filter(Boolean)
-            .join('\n');
-          return { success: true, output: out, prUrl };
-        } catch (mergeErr) {
-          const err = mergeErr as { stderr?: string; message?: string };
-          const errMsg = err?.stderr || err?.message || String(mergeErr);
-          log.error('Failed to merge PR:', errMsg);
-          return {
-            success: false,
-            error: `PR created but merge failed: ${errMsg}`,
-            prUrl,
-          };
-        }
-      } catch (error) {
-        const err = error as { message?: string };
-        log.error('Failed to merge to main:', error);
+      // Validate: not on default branch
+      if (currentBranch === defaultBranch) {
         return {
           success: false,
-          error: err?.message || String(error),
+          error: `Already on ${defaultBranch}. Create a feature branch first.`,
         };
       }
+
+      // Stage and commit any pending changes
+      const { stdout: statusOut } = await execAsync(
+        'git status --porcelain --untracked-files=all',
+        { cwd: taskPath }
+      );
+      if (statusOut?.trim()) {
+        await execAsync('git add -A', { cwd: taskPath });
+        try {
+          await execAsync('git commit -m "chore: prepare for merge to main"', { cwd: taskPath });
+        } catch (e) {
+          const msg = String(e);
+          if (!/nothing to commit/i.test(msg)) throw e;
+        }
+      }
+
+      // Push branch (set upstream if needed)
+      try {
+        await execAsync('git push', { cwd: taskPath });
+      } catch {
+        // No upstream set - push with -u
+        await execAsync(`git push --set-upstream origin ${JSON.stringify(currentBranch)}`, {
+          cwd: taskPath,
+        });
+      }
+
+      // Create PR (or use existing)
+      let prUrl = '';
+      try {
+        const { stdout: prOut } = await execAsync(
+          `gh pr create --fill --base ${JSON.stringify(defaultBranch)}`,
+          { cwd: taskPath }
+        );
+        const urlMatch = prOut?.match(/https?:\/\/\S+/);
+        prUrl = urlMatch ? urlMatch[0] : '';
+      } catch (e) {
+        const errMsg = (e as { stderr?: string })?.stderr || String(e);
+        if (!/already exists|already has.*pull request/i.test(errMsg)) {
+          return { success: false, error: `Failed to create PR: ${errMsg}` };
+        }
+        // PR already exists - continue to merge
+      }
+
+      // Merge and delete branch
+      try {
+        await execAsync('gh pr merge --merge --delete-branch', { cwd: taskPath });
+        return { success: true, prUrl };
+      } catch (e) {
+        const errMsg = (e as { stderr?: string })?.stderr || String(e);
+        return { success: false, error: `PR created but merge failed: ${errMsg}`, prUrl };
+      }
+    } catch (e) {
+      log.error('Failed to merge to main:', e);
+      return { success: false, error: (e as { message?: string })?.message || String(e) };
     }
-  );
+  });
 
   // Git: Rename branch (local and optionally remote)
   ipcMain.handle(

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -206,6 +206,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     web?: boolean;
     fill?: boolean;
   }) => ipcRenderer.invoke('git:create-pr', args),
+  mergeToMain: (args: { taskPath: string }) => ipcRenderer.invoke('git:merge-to-main', args),
   getPrStatus: (args: { taskPath: string }) => ipcRenderer.invoke('git:get-pr-status', args),
   getBranchStatus: (args: { taskPath: string }) =>
     ipcRenderer.invoke('git:get-branch-status', args),

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -27,18 +27,9 @@ interface PrActionButtonProps {
   onModeChange: (mode: PrMode) => void;
   onExecute: () => Promise<void>;
   isLoading: boolean;
-  dropdownOpen: boolean;
-  onDropdownChange: (open: boolean) => void;
 }
 
-function PrActionButton({
-  mode,
-  onModeChange,
-  onExecute,
-  isLoading,
-  dropdownOpen,
-  onDropdownChange,
-}: PrActionButtonProps) {
+function PrActionButton({ mode, onModeChange, onExecute, isLoading }: PrActionButtonProps) {
   return (
     <div className="flex min-w-0">
       <Button
@@ -50,7 +41,7 @@ function PrActionButton({
       >
         {isLoading ? <Spinner size="sm" /> : PR_MODE_LABELS[mode]}
       </Button>
-      <Popover open={dropdownOpen} onOpenChange={onDropdownChange}>
+      <Popover>
         <PopoverTrigger asChild>
           <Button
             variant="outline"
@@ -105,7 +96,6 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
   const [commitMessage, setCommitMessage] = useState('');
   const [isCommitting, setIsCommitting] = useState(false);
   const [isMergingToMain, setIsMergingToMain] = useState(false);
-  const [prDropdownOpen, setPrDropdownOpen] = useState(false);
   const [prMode, setPrMode] = useState<PrMode>(() => {
     try {
       const stored = localStorage.getItem('emdash:prMode');
@@ -122,7 +112,6 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
 
   const selectPrMode = (mode: PrMode) => {
     setPrMode(mode);
-    setPrDropdownOpen(false);
     try {
       localStorage.setItem('emdash:prMode', mode);
     } catch {
@@ -345,7 +334,6 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
 
   const handleMergeToMain = async () => {
     setIsMergingToMain(true);
-    setPrDropdownOpen(false);
     try {
       const result = await window.electronAPI.mergeToMain({ taskPath: safeTaskPath });
       if (result.success) {
@@ -464,8 +452,6 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
                   onModeChange={selectPrMode}
                   onExecute={handlePrAction}
                   isLoading={isActionLoading}
-                  dropdownOpen={prDropdownOpen}
-                  onDropdownChange={setPrDropdownOpen}
                 />
               </div>
             </div>
@@ -526,8 +512,6 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
                   onModeChange={selectPrMode}
                   onExecute={handlePrAction}
                   isLoading={isActionLoading || branchStatusLoading}
-                  dropdownOpen={prDropdownOpen}
-                  onDropdownChange={setPrDropdownOpen}
                 />
               ) : (
                 <span className="text-xs text-muted-foreground">No PR for this branch</span>

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -99,7 +99,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
   const [prMode, setPrMode] = useState<PrMode>(() => {
     try {
       const stored = localStorage.getItem('emdash:prMode');
-      if (stored === 'draft' || stored === 'merge') return stored;
+      if (stored === 'create' || stored === 'draft' || stored === 'merge') return stored;
       // Migrate from old boolean key
       if (localStorage.getItem('emdash:createPrAsDraft') === 'true') return 'draft';
       return 'create';

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -341,7 +341,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
       if (result.success) {
         toast({
           title: 'Merged to Main',
-          description: 'Changes have been merged to main and branch deleted.',
+          description: 'Changes have been merged to main.',
         });
         await refreshChanges();
         try {

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -11,6 +11,7 @@ import { usePrStatus } from '../hooks/usePrStatus';
 import { FileIcon } from './FileExplorer/FileIcons';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
+import { Close as PopoverClose } from '@radix-ui/react-popover';
 import { Plus, Minus, Undo2, ArrowUpRight, FileDiff, ChevronDown } from 'lucide-react';
 import { useTaskScope } from './TaskScopeContext';
 
@@ -56,13 +57,14 @@ function PrActionButton({ mode, onModeChange, onExecute, isLoading }: PrActionBu
           {(['create', 'draft', 'merge'] as PrMode[])
             .filter((m) => m !== mode)
             .map((m) => (
-              <button
-                key={m}
-                className="w-full whitespace-nowrap rounded px-2 py-1 text-left text-xs hover:bg-accent"
-                onClick={() => onModeChange(m)}
-              >
-                {PR_MODE_LABELS[m]}
-              </button>
+              <PopoverClose key={m} asChild>
+                <button
+                  className="w-full whitespace-nowrap rounded px-2 py-1 text-left text-xs hover:bg-accent"
+                  onClick={() => onModeChange(m)}
+                >
+                  {PR_MODE_LABELS[m]}
+                </button>
+              </PopoverClose>
             ))}
         </PopoverContent>
       </Popover>

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -505,6 +505,12 @@ declare global {
         output?: string;
         error?: string;
       }>;
+      mergeToMain: (args: { taskPath: string }) => Promise<{
+        success: boolean;
+        output?: string;
+        prUrl?: string;
+        error?: string;
+      }>;
       getPrStatus: (args: { taskPath: string }) => Promise<{
         success: boolean;
         pr?: {
@@ -1092,6 +1098,12 @@ export interface ElectronAPI {
     success: boolean;
     url?: string;
     output?: string;
+    error?: string;
+  }>;
+  mergeToMain: (args: { taskPath: string }) => Promise<{
+    success: boolean;
+    output?: string;
+    prUrl?: string;
     error?: string;
   }>;
   connectToGitHub: (projectPath: string) => Promise<{


### PR DESCRIPTION
## Summary
- Adds "Merge Main" as a third option in the PR button dropdown (alongside Create PR / Draft PR)
- Creates a PR via `gh pr create --fill` and immediately merges it via `gh pr merge --merge`
- Branch is not deleted on merge (cleanup happens when workspace is deleted)
- Useful for quickly landing changes without going through PR review

## Changes
- Add `git:merge-to-main` IPC handler
- Refactor PR button from boolean (draft/create) to 3-way mode selector
- Extract `PrActionButton` component to eliminate UI duplication
- Mode persists in localStorage (`emdash:prMode`)

## Test plan
- [ ] Select "Merge Main" from dropdown, verify it persists on reload
- [ ] On a feature branch with commits, click Merge Main → should create PR and merge
- [ ] On main branch → should show error "Already on main"
- [ ] With no commits ahead → should fail gracefully