### PR TITLE
Reduce git status polling intervals

### DIFF
--- a/src/renderer/hooks/useFileChanges.ts
+++ b/src/renderer/hooks/useFileChanges.ts
@@ -55,7 +55,7 @@ export function useFileChanges(workspacePath: string) {
     // Initial load with loading state
     fetchFileChanges(true);
     
-    const interval = setInterval(() => fetchFileChanges(false), 5000);
+    const interval = setInterval(() => fetchFileChanges(false), 15000);
     
     return () => clearInterval(interval);
   }, [workspacePath]);

--- a/src/renderer/hooks/useWorkspaceChanges.ts
+++ b/src/renderer/hooks/useWorkspaceChanges.ts
@@ -70,8 +70,8 @@ export function useWorkspaceChanges(workspacePath: string, workspaceId: string) 
   useEffect(() => {
     fetchChanges(true); 
     
-    // Poll for changes every 10 seconds without loading state
-    const interval = setInterval(() => fetchChanges(false), 10000);
+    // Poll for changes every 15 seconds without loading state
+    const interval = setInterval(() => fetchChanges(false), 15000);
     return () => clearInterval(interval);
   }, [workspacePath, workspaceId]);
 


### PR DESCRIPTION
## Summary
- increase polling interval in useFileChanges to 15s
- increase polling interval in useWorkspaceChanges to 15s

## Testing
- npm run lint (fails: ESLint config could not find @typescript-eslint/recommended)