### PR TITLE
Reduce diff polling and cache git status

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,218 +1,550 @@
-import { contextBridge, ipcRenderer } from 'electron'
+import { contextBridge, ipcRenderer } from "electron";
 
 // Expose protected methods that allow the renderer process to use
 // the ipcRenderer without exposing the entire object
-contextBridge.exposeInMainWorld('electronAPI', {
+contextBridge.exposeInMainWorld("electronAPI", {
   // App info
-  getVersion: () => ipcRenderer.invoke('app:getVersion'),
-  getPlatform: () => ipcRenderer.invoke('app:getPlatform'),
-  
+  getVersion: () => ipcRenderer.invoke("app:getVersion"),
+  getPlatform: () => ipcRenderer.invoke("app:getPlatform"),
+
   // PTY management
-  ptyStart: (opts: { id: string; cwd?: string; shell?: string; env?: Record<string, string>; cols?: number; rows?: number; }) =>
-    ipcRenderer.invoke('pty:start', opts),
+  ptyStart: (opts: {
+    id: string;
+    cwd?: string;
+    shell?: string;
+    env?: Record<string, string>;
+    cols?: number;
+    rows?: number;
+  }) => ipcRenderer.invoke("pty:start", opts),
   ptyInput: (args: { id: string; data: string }) =>
-    ipcRenderer.send('pty:input', args),
+    ipcRenderer.send("pty:input", args),
   ptyResize: (args: { id: string; cols: number; rows: number }) =>
-    ipcRenderer.send('pty:resize', args),
-  ptyKill: (id: string) => ipcRenderer.send('pty:kill', { id }),
-  
+    ipcRenderer.send("pty:resize", args),
+  ptyKill: (id: string) => ipcRenderer.send("pty:kill", { id }),
+
   onPtyData: (id: string, listener: (data: string) => void) => {
-    const channel = `pty:data:${id}`
-    const wrapped = (_: Electron.IpcRendererEvent, data: string) => listener(data)
-    ipcRenderer.on(channel, wrapped)
-    return () => ipcRenderer.removeListener(channel, wrapped)
+    const channel = `pty:data:${id}`;
+    const wrapped = (_: Electron.IpcRendererEvent, data: string) =>
+      listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
   },
-  onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => {
-    const channel = `pty:exit:${id}`
-    const wrapped = (_: Electron.IpcRendererEvent, info: { exitCode: number; signal?: number }) => listener(info)
-    ipcRenderer.on(channel, wrapped)
-    return () => ipcRenderer.removeListener(channel, wrapped)
+  onPtyExit: (
+    id: string,
+    listener: (info: { exitCode: number; signal?: number }) => void,
+  ) => {
+    const channel = `pty:exit:${id}`;
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      info: { exitCode: number; signal?: number },
+    ) => listener(info);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
   },
 
   // Worktree management
-  worktreeCreate: (args: { projectPath: string; workspaceName: string; projectId: string }) =>
-    ipcRenderer.invoke('worktree:create', args),
+  worktreeCreate: (args: {
+    projectPath: string;
+    workspaceName: string;
+    projectId: string;
+  }) => ipcRenderer.invoke("worktree:create", args),
   worktreeList: (args: { projectPath: string }) =>
-    ipcRenderer.invoke('worktree:list', args),
-  worktreeRemove: (args: { projectPath: string; worktreeId: string; worktreePath?: string; branch?: string }) =>
-    ipcRenderer.invoke('worktree:remove', args),
+    ipcRenderer.invoke("worktree:list", args),
+  worktreeRemove: (args: {
+    projectPath: string;
+    worktreeId: string;
+    worktreePath?: string;
+    branch?: string;
+  }) => ipcRenderer.invoke("worktree:remove", args),
   worktreeStatus: (args: { worktreePath: string }) =>
-    ipcRenderer.invoke('worktree:status', args),
+    ipcRenderer.invoke("worktree:status", args),
   worktreeMerge: (args: { projectPath: string; worktreeId: string }) =>
-    ipcRenderer.invoke('worktree:merge', args),
+    ipcRenderer.invoke("worktree:merge", args),
   worktreeGet: (args: { worktreeId: string }) =>
-    ipcRenderer.invoke('worktree:get', args),
-  worktreeGetAll: () =>
-    ipcRenderer.invoke('worktree:getAll'),
+    ipcRenderer.invoke("worktree:get", args),
+  worktreeGetAll: () => ipcRenderer.invoke("worktree:getAll"),
 
   // Filesystem helpers
-  fsList: (root: string, opts?: { includeDirs?: boolean; maxEntries?: number }) =>
-    ipcRenderer.invoke('fs:list', { root, ...(opts || {}) }),
+  fsList: (
+    root: string,
+    opts?: { includeDirs?: boolean; maxEntries?: number },
+  ) => ipcRenderer.invoke("fs:list", { root, ...(opts || {}) }),
   fsRead: (root: string, relPath: string, maxBytes?: number) =>
-    ipcRenderer.invoke('fs:read', { root, relPath, maxBytes }),
+    ipcRenderer.invoke("fs:read", { root, relPath, maxBytes }),
 
   // Project management
-  openProject: () => ipcRenderer.invoke('project:open'),
-  getGitInfo: (projectPath: string) => ipcRenderer.invoke('git:getInfo', projectPath),
-  getGitStatus: (workspacePath: string) => ipcRenderer.invoke('git:get-status', workspacePath),
+  openProject: () => ipcRenderer.invoke("project:open"),
+  getGitInfo: (projectPath: string) =>
+    ipcRenderer.invoke("git:getInfo", projectPath),
+  getGitStatus: (workspacePath: string) =>
+    ipcRenderer.invoke("git:get-status", workspacePath),
+  watchGitStatus: (workspacePath: string) =>
+    ipcRenderer.invoke("git:watch-status", workspacePath),
+  unwatchGitStatus: (workspacePath: string) =>
+    ipcRenderer.invoke("git:unwatch-status", workspacePath),
+  onGitStatusChanged: (listener: (data: { workspacePath: string }) => void) => {
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: { workspacePath: string },
+    ) => listener(data);
+    ipcRenderer.on("git:status-changed", wrapped);
+    return () => ipcRenderer.removeListener("git:status-changed", wrapped);
+  },
   getFileDiff: (args: { workspacePath: string; filePath: string }) =>
-    ipcRenderer.invoke('git:get-file-diff', args),
-  gitCommitAndPush: (args: { workspacePath: string; commitMessage?: string; createBranchIfOnDefault?: boolean; branchPrefix?: string }) =>
-    ipcRenderer.invoke('git:commit-and-push', args),
-  createPullRequest: (args: { workspacePath: string; title?: string; body?: string; base?: string; head?: string; draft?: boolean; web?: boolean; fill?: boolean }) =>
-    ipcRenderer.invoke('git:create-pr', args),
+    ipcRenderer.invoke("git:get-file-diff", args),
+  gitCommitAndPush: (args: {
+    workspacePath: string;
+    commitMessage?: string;
+    createBranchIfOnDefault?: boolean;
+    branchPrefix?: string;
+  }) => ipcRenderer.invoke("git:commit-and-push", args),
+  createPullRequest: (args: {
+    workspacePath: string;
+    title?: string;
+    body?: string;
+    base?: string;
+    head?: string;
+    draft?: boolean;
+    web?: boolean;
+    fill?: boolean;
+  }) => ipcRenderer.invoke("git:create-pr", args),
   getPrStatus: (args: { workspacePath: string }) =>
-    ipcRenderer.invoke('git:get-pr-status', args),
-  openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
-  connectToGitHub: (projectPath: string) => ipcRenderer.invoke('github:connect', projectPath),
+    ipcRenderer.invoke("git:get-pr-status", args),
+  openExternal: (url: string) => ipcRenderer.invoke("app:openExternal", url),
+  connectToGitHub: (projectPath: string) =>
+    ipcRenderer.invoke("github:connect", projectPath),
   onRunEvent: (callback: (event: any) => void) => {
-    ipcRenderer.on('run:event', (_, event) => callback(event))
+    ipcRenderer.on("run:event", (_, event) => callback(event));
   },
   removeRunEventListeners: () => {
-    ipcRenderer.removeAllListeners('run:event')
+    ipcRenderer.removeAllListeners("run:event");
   },
-  
+
   // GitHub integration
-  githubAuth: () => ipcRenderer.invoke('github:auth'),
-  githubIsAuthenticated: () => ipcRenderer.invoke('github:isAuthenticated'),
-  githubGetStatus: () => ipcRenderer.invoke('github:getStatus'),
-  githubGetUser: () => ipcRenderer.invoke('github:getUser'),
-  githubGetRepositories: () => ipcRenderer.invoke('github:getRepositories'),
-  githubCloneRepository: (repoUrl: string, localPath: string) => ipcRenderer.invoke('github:cloneRepository', repoUrl, localPath),
-  githubLogout: () => ipcRenderer.invoke('github:logout'),
+  githubAuth: () => ipcRenderer.invoke("github:auth"),
+  githubIsAuthenticated: () => ipcRenderer.invoke("github:isAuthenticated"),
+  githubGetStatus: () => ipcRenderer.invoke("github:getStatus"),
+  githubGetUser: () => ipcRenderer.invoke("github:getUser"),
+  githubGetRepositories: () => ipcRenderer.invoke("github:getRepositories"),
+  githubCloneRepository: (repoUrl: string, localPath: string) =>
+    ipcRenderer.invoke("github:cloneRepository", repoUrl, localPath),
+  githubLogout: () => ipcRenderer.invoke("github:logout"),
   // Database methods
-  getProjects: () => ipcRenderer.invoke('db:getProjects'),
-  saveProject: (project: any) => ipcRenderer.invoke('db:saveProject', project),
-  getWorkspaces: (projectId?: string) => ipcRenderer.invoke('db:getWorkspaces', projectId),
-  saveWorkspace: (workspace: any) => ipcRenderer.invoke('db:saveWorkspace', workspace),
-  deleteProject: (projectId: string) => ipcRenderer.invoke('db:deleteProject', projectId),
-  deleteWorkspace: (workspaceId: string) => ipcRenderer.invoke('db:deleteWorkspace', workspaceId),
+  getProjects: () => ipcRenderer.invoke("db:getProjects"),
+  saveProject: (project: any) => ipcRenderer.invoke("db:saveProject", project),
+  getWorkspaces: (projectId?: string) =>
+    ipcRenderer.invoke("db:getWorkspaces", projectId),
+  saveWorkspace: (workspace: any) =>
+    ipcRenderer.invoke("db:saveWorkspace", workspace),
+  deleteProject: (projectId: string) =>
+    ipcRenderer.invoke("db:deleteProject", projectId),
+  deleteWorkspace: (workspaceId: string) =>
+    ipcRenderer.invoke("db:deleteWorkspace", workspaceId),
 
   // Conversation management
-  saveConversation: (conversation: any) => ipcRenderer.invoke('db:saveConversation', conversation),
-  getConversations: (workspaceId: string) => ipcRenderer.invoke('db:getConversations', workspaceId),
-  getOrCreateDefaultConversation: (workspaceId: string) => ipcRenderer.invoke('db:getOrCreateDefaultConversation', workspaceId),
-  saveMessage: (message: any) => ipcRenderer.invoke('db:saveMessage', message),
-  getMessages: (conversationId: string) => ipcRenderer.invoke('db:getMessages', conversationId),
-  deleteConversation: (conversationId: string) => ipcRenderer.invoke('db:deleteConversation', conversationId),
+  saveConversation: (conversation: any) =>
+    ipcRenderer.invoke("db:saveConversation", conversation),
+  getConversations: (workspaceId: string) =>
+    ipcRenderer.invoke("db:getConversations", workspaceId),
+  getOrCreateDefaultConversation: (workspaceId: string) =>
+    ipcRenderer.invoke("db:getOrCreateDefaultConversation", workspaceId),
+  saveMessage: (message: any) => ipcRenderer.invoke("db:saveMessage", message),
+  getMessages: (conversationId: string) =>
+    ipcRenderer.invoke("db:getMessages", conversationId),
+  deleteConversation: (conversationId: string) =>
+    ipcRenderer.invoke("db:deleteConversation", conversationId),
 
   // Debug helpers
-  debugAppendLog: (filePath: string, content: string, options?: { reset?: boolean }) =>
-    ipcRenderer.invoke('debug:append-log', filePath, content, options ?? {}),
+  debugAppendLog: (
+    filePath: string,
+    content: string,
+    options?: { reset?: boolean },
+  ) => ipcRenderer.invoke("debug:append-log", filePath, content, options ?? {}),
 
   // Codex integration
-  codexCheckInstallation: () => ipcRenderer.invoke('codex:check-installation'),
-  codexCreateAgent: (workspaceId: string, worktreePath: string) => ipcRenderer.invoke('codex:create-agent', workspaceId, worktreePath),
-  codexSendMessage: (workspaceId: string, message: string) => ipcRenderer.invoke('codex:send-message', workspaceId, message),
-  codexSendMessageStream: (workspaceId: string, message: string, conversationId?: string) => ipcRenderer.invoke('codex:send-message-stream', workspaceId, message, conversationId),
-  codexStopStream: (workspaceId: string) => ipcRenderer.invoke('codex:stop-stream', workspaceId),
-  codexGetStreamTail: (workspaceId: string) => ipcRenderer.invoke('codex:get-stream-tail', workspaceId),
-  codexGetAgentStatus: (workspaceId: string) => ipcRenderer.invoke('codex:get-agent-status', workspaceId),
-  codexGetAllAgents: () => ipcRenderer.invoke('codex:get-all-agents'),
-  codexRemoveAgent: (workspaceId: string) => ipcRenderer.invoke('codex:remove-agent', workspaceId),
-  codexGetInstallationInstructions: () => ipcRenderer.invoke('codex:get-installation-instructions'),
-  
+  codexCheckInstallation: () => ipcRenderer.invoke("codex:check-installation"),
+  codexCreateAgent: (workspaceId: string, worktreePath: string) =>
+    ipcRenderer.invoke("codex:create-agent", workspaceId, worktreePath),
+  codexSendMessage: (workspaceId: string, message: string) =>
+    ipcRenderer.invoke("codex:send-message", workspaceId, message),
+  codexSendMessageStream: (
+    workspaceId: string,
+    message: string,
+    conversationId?: string,
+  ) =>
+    ipcRenderer.invoke(
+      "codex:send-message-stream",
+      workspaceId,
+      message,
+      conversationId,
+    ),
+  codexStopStream: (workspaceId: string) =>
+    ipcRenderer.invoke("codex:stop-stream", workspaceId),
+  codexGetStreamTail: (workspaceId: string) =>
+    ipcRenderer.invoke("codex:get-stream-tail", workspaceId),
+  codexGetAgentStatus: (workspaceId: string) =>
+    ipcRenderer.invoke("codex:get-agent-status", workspaceId),
+  codexGetAllAgents: () => ipcRenderer.invoke("codex:get-all-agents"),
+  codexRemoveAgent: (workspaceId: string) =>
+    ipcRenderer.invoke("codex:remove-agent", workspaceId),
+  codexGetInstallationInstructions: () =>
+    ipcRenderer.invoke("codex:get-installation-instructions"),
+
   // Streaming event listeners
-  onCodexStreamOutput: (listener: (data: { workspaceId: string; output: string; agentId: string; conversationId?: string }) => void) => {
-    const wrapped = (_: Electron.IpcRendererEvent, data: { workspaceId: string; output: string; agentId: string; conversationId?: string }) => listener(data)
-    ipcRenderer.on('codex:stream-output', wrapped)
-    return () => ipcRenderer.removeListener('codex:stream-output', wrapped)
+  onCodexStreamOutput: (
+    listener: (data: {
+      workspaceId: string;
+      output: string;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => {
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: {
+        workspaceId: string;
+        output: string;
+        agentId: string;
+        conversationId?: string;
+      },
+    ) => listener(data);
+    ipcRenderer.on("codex:stream-output", wrapped);
+    return () => ipcRenderer.removeListener("codex:stream-output", wrapped);
   },
-  onCodexStreamError: (listener: (data: { workspaceId: string; error: string; agentId: string; conversationId?: string }) => void) => {
-    const wrapped = (_: Electron.IpcRendererEvent, data: { workspaceId: string; error: string; agentId: string; conversationId?: string }) => listener(data)
-    ipcRenderer.on('codex:stream-error', wrapped)
-    return () => ipcRenderer.removeListener('codex:stream-error', wrapped)
+  onCodexStreamError: (
+    listener: (data: {
+      workspaceId: string;
+      error: string;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => {
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: {
+        workspaceId: string;
+        error: string;
+        agentId: string;
+        conversationId?: string;
+      },
+    ) => listener(data);
+    ipcRenderer.on("codex:stream-error", wrapped);
+    return () => ipcRenderer.removeListener("codex:stream-error", wrapped);
   },
-  onCodexStreamComplete: (listener: (data: { workspaceId: string; exitCode: number; agentId: string; conversationId?: string }) => void) => {
-    const wrapped = (_: Electron.IpcRendererEvent, data: { workspaceId: string; exitCode: number; agentId: string; conversationId?: string }) => listener(data)
-    ipcRenderer.on('codex:stream-complete', wrapped)
-    return () => ipcRenderer.removeListener('codex:stream-complete', wrapped)
+  onCodexStreamComplete: (
+    listener: (data: {
+      workspaceId: string;
+      exitCode: number;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => {
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: {
+        workspaceId: string;
+        exitCode: number;
+        agentId: string;
+        conversationId?: string;
+      },
+    ) => listener(data);
+    ipcRenderer.on("codex:stream-complete", wrapped);
+    return () => ipcRenderer.removeListener("codex:stream-complete", wrapped);
   },
-})
+});
 
 // Type definitions for the exposed API
 export interface ElectronAPI {
   // App info
-  getVersion: () => Promise<string>
-  getPlatform: () => Promise<string>
-  
+  getVersion: () => Promise<string>;
+  getPlatform: () => Promise<string>;
+
   // PTY management
-  ptyStart: (opts: { id: string; cwd?: string; shell?: string; env?: Record<string, string>; cols?: number; rows?: number; }) => Promise<{ ok: boolean }>
-  ptyInput: (args: { id: string; data: string }) => void
-  ptyResize: (args: { id: string; cols: number; rows: number }) => void
-  ptyKill: (id: string) => void
-  onPtyData: (id: string, listener: (data: string) => void) => () => void
-  onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => () => void
+  ptyStart: (opts: {
+    id: string;
+    cwd?: string;
+    shell?: string;
+    env?: Record<string, string>;
+    cols?: number;
+    rows?: number;
+  }) => Promise<{ ok: boolean }>;
+  ptyInput: (args: { id: string; data: string }) => void;
+  ptyResize: (args: { id: string; cols: number; rows: number }) => void;
+  ptyKill: (id: string) => void;
+  onPtyData: (id: string, listener: (data: string) => void) => () => void;
+  onPtyExit: (
+    id: string,
+    listener: (info: { exitCode: number; signal?: number }) => void,
+  ) => () => void;
   // Worktree management
-  worktreeCreate: (args: { projectPath: string; workspaceName: string; projectId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-  worktreeList: (args: { projectPath: string }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
-  worktreeRemove: (args: { projectPath: string; worktreeId: string }) => Promise<{ success: boolean; error?: string }>
-  worktreeStatus: (args: { worktreePath: string }) => Promise<{ success: boolean; status?: any; error?: string }>
-  worktreeMerge: (args: { projectPath: string; worktreeId: string }) => Promise<{ success: boolean; error?: string }>
-  worktreeGet: (args: { worktreeId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-  worktreeGetAll: () => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
+  worktreeCreate: (args: {
+    projectPath: string;
+    workspaceName: string;
+    projectId: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeList: (args: {
+    projectPath: string;
+  }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+  worktreeRemove: (args: {
+    projectPath: string;
+    worktreeId: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeStatus: (args: {
+    worktreePath: string;
+  }) => Promise<{ success: boolean; status?: any; error?: string }>;
+  worktreeMerge: (args: {
+    projectPath: string;
+    worktreeId: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeGet: (args: {
+    worktreeId: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeGetAll: () => Promise<{
+    success: boolean;
+    worktrees?: any[];
+    error?: string;
+  }>;
 
   // Project management
-  openProject: () => Promise<{ success: boolean; path?: string; error?: string }>
-  getGitInfo: (projectPath: string) => Promise<{ isGitRepo: boolean; remote?: string; branch?: string; path?: string; error?: string }>
-  getGitStatus: (workspacePath: string) => Promise<{ success: boolean; changes?: Array<{ path: string; status: string; additions: number; deletions: number; diff?: string }>; error?: string }>
-  getFileDiff: (args: { workspacePath: string; filePath: string }) => Promise<{ success: boolean; diff?: { lines: Array<{ left?: string; right?: string; type: 'context' | 'add' | 'del' }> }; error?: string }>
-  gitCommitAndPush: (args: { workspacePath: string; commitMessage?: string; createBranchIfOnDefault?: boolean; branchPrefix?: string }) => Promise<{ success: boolean; branch?: string; output?: string; error?: string }>
-  createPullRequest: (args: { workspacePath: string; title?: string; body?: string; base?: string; head?: string; draft?: boolean; web?: boolean; fill?: boolean }) => Promise<{ success: boolean; url?: string; output?: string; error?: string }>
-  connectToGitHub: (projectPath: string) => Promise<{ success: boolean; repository?: string; branch?: string; error?: string }>
+  openProject: () => Promise<{
+    success: boolean;
+    path?: string;
+    error?: string;
+  }>;
+  getGitInfo: (
+    projectPath: string,
+  ) => Promise<{
+    isGitRepo: boolean;
+    remote?: string;
+    branch?: string;
+    path?: string;
+    error?: string;
+  }>;
+  getGitStatus: (
+    workspacePath: string,
+  ) => Promise<{
+    success: boolean;
+    changes?: Array<{
+      path: string;
+      status: string;
+      additions: number;
+      deletions: number;
+      diff?: string;
+    }>;
+    error?: string;
+  }>;
+  watchGitStatus: (
+    workspacePath: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  unwatchGitStatus: (
+    workspacePath: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  onGitStatusChanged: (
+    listener: (data: { workspacePath: string }) => void,
+  ) => () => void;
+  getFileDiff: (args: {
+    workspacePath: string;
+    filePath: string;
+  }) => Promise<{
+    success: boolean;
+    diff?: {
+      lines: Array<{
+        left?: string;
+        right?: string;
+        type: "context" | "add" | "del";
+      }>;
+    };
+    error?: string;
+  }>;
+  gitCommitAndPush: (args: {
+    workspacePath: string;
+    commitMessage?: string;
+    createBranchIfOnDefault?: boolean;
+    branchPrefix?: string;
+  }) => Promise<{
+    success: boolean;
+    branch?: string;
+    output?: string;
+    error?: string;
+  }>;
+  createPullRequest: (args: {
+    workspacePath: string;
+    title?: string;
+    body?: string;
+    base?: string;
+    head?: string;
+    draft?: boolean;
+    web?: boolean;
+    fill?: boolean;
+  }) => Promise<{
+    success: boolean;
+    url?: string;
+    output?: string;
+    error?: string;
+  }>;
+  connectToGitHub: (
+    projectPath: string,
+  ) => Promise<{
+    success: boolean;
+    repository?: string;
+    branch?: string;
+    error?: string;
+  }>;
 
   // Filesystem helpers
-  fsList: (root: string, opts?: { includeDirs?: boolean; maxEntries?: number }) => Promise<{ success: boolean; items?: Array<{ path: string; type: 'file' | 'dir' }>; error?: string }>
-  fsRead: (root: string, relPath: string, maxBytes?: number) => Promise<{ success: boolean; path?: string; size?: number; truncated?: boolean; content?: string; error?: string }>
-  
-  onRunEvent: (callback: (event: any) => void) => void
-  removeRunEventListeners: () => void
-  
+  fsList: (
+    root: string,
+    opts?: { includeDirs?: boolean; maxEntries?: number },
+  ) => Promise<{
+    success: boolean;
+    items?: Array<{ path: string; type: "file" | "dir" }>;
+    error?: string;
+  }>;
+  fsRead: (
+    root: string,
+    relPath: string,
+    maxBytes?: number,
+  ) => Promise<{
+    success: boolean;
+    path?: string;
+    size?: number;
+    truncated?: boolean;
+    content?: string;
+    error?: string;
+  }>;
+
+  onRunEvent: (callback: (event: any) => void) => void;
+  removeRunEventListeners: () => void;
+
   // GitHub integration
-  githubAuth: () => Promise<{ success: boolean; token?: string; user?: any; error?: string }>
-  githubIsAuthenticated: () => Promise<boolean>
-  githubGetStatus: () => Promise<{ installed: boolean; authenticated: boolean; user?: any }>
-  githubGetUser: () => Promise<any>
-  githubGetRepositories: () => Promise<any[]>
-  githubCloneRepository: (repoUrl: string, localPath: string) => Promise<{ success: boolean; error?: string }>
-  githubLogout: () => Promise<void>
-  
+  githubAuth: () => Promise<{
+    success: boolean;
+    token?: string;
+    user?: any;
+    error?: string;
+  }>;
+  githubIsAuthenticated: () => Promise<boolean>;
+  githubGetStatus: () => Promise<{
+    installed: boolean;
+    authenticated: boolean;
+    user?: any;
+  }>;
+  githubGetUser: () => Promise<any>;
+  githubGetRepositories: () => Promise<any[]>;
+  githubCloneRepository: (
+    repoUrl: string,
+    localPath: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  githubLogout: () => Promise<void>;
+
   // Database methods
-  getProjects: () => Promise<any[]>
-  saveProject: (project: any) => Promise<{ success: boolean; error?: string }>
-  getWorkspaces: (projectId?: string) => Promise<any[]>
-  saveWorkspace: (workspace: any) => Promise<{ success: boolean; error?: string }>
-  deleteProject: (projectId: string) => Promise<{ success: boolean; error?: string }>
-  deleteWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>
+  getProjects: () => Promise<any[]>;
+  saveProject: (project: any) => Promise<{ success: boolean; error?: string }>;
+  getWorkspaces: (projectId?: string) => Promise<any[]>;
+  saveWorkspace: (
+    workspace: any,
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteProject: (
+    projectId: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteWorkspace: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; error?: string }>;
 
   // Conversation management
-  saveConversation: (conversation: any) => Promise<{ success: boolean; error?: string }>
-  getConversations: (workspaceId: string) => Promise<{ success: boolean; conversations?: any[]; error?: string }>
-  getOrCreateDefaultConversation: (workspaceId: string) => Promise<{ success: boolean; conversation?: any; error?: string }>
-  saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>
-  getMessages: (conversationId: string) => Promise<{ success: boolean; messages?: any[]; error?: string }>
-  deleteConversation: (conversationId: string) => Promise<{ success: boolean; error?: string }>
+  saveConversation: (
+    conversation: any,
+  ) => Promise<{ success: boolean; error?: string }>;
+  getConversations: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; conversations?: any[]; error?: string }>;
+  getOrCreateDefaultConversation: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
+  saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>;
+  getMessages: (
+    conversationId: string,
+  ) => Promise<{ success: boolean; messages?: any[]; error?: string }>;
+  deleteConversation: (
+    conversationId: string,
+  ) => Promise<{ success: boolean; error?: string }>;
 
   // Codex integration
-  codexCheckInstallation: () => Promise<{ success: boolean; isInstalled?: boolean; error?: string }>
-  codexCreateAgent: (workspaceId: string, worktreePath: string) => Promise<{ success: boolean; agent?: any; error?: string }>
-  codexSendMessage: (workspaceId: string, message: string) => Promise<{ success: boolean; response?: any; error?: string }>
-  codexSendMessageStream: (workspaceId: string, message: string, conversationId?: string) => Promise<{ success: boolean; error?: string }>
-  codexStopStream: (workspaceId: string) => Promise<{ success: boolean; stopped?: boolean; error?: string }>
-  codexGetStreamTail: (workspaceId: string) => Promise<{ success: boolean; tail?: string; startedAt?: string; error?: string }>
-  codexGetAgentStatus: (workspaceId: string) => Promise<{ success: boolean; agent?: any; error?: string }>
-  codexGetAllAgents: () => Promise<{ success: boolean; agents?: any[]; error?: string }>
-  codexRemoveAgent: (workspaceId: string) => Promise<{ success: boolean; removed?: boolean; error?: string }>
-  codexGetInstallationInstructions: () => Promise<{ success: boolean; instructions?: string; error?: string }>
-  
+  codexCheckInstallation: () => Promise<{
+    success: boolean;
+    isInstalled?: boolean;
+    error?: string;
+  }>;
+  codexCreateAgent: (
+    workspaceId: string,
+    worktreePath: string,
+  ) => Promise<{ success: boolean; agent?: any; error?: string }>;
+  codexSendMessage: (
+    workspaceId: string,
+    message: string,
+  ) => Promise<{ success: boolean; response?: any; error?: string }>;
+  codexSendMessageStream: (
+    workspaceId: string,
+    message: string,
+    conversationId?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  codexStopStream: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; stopped?: boolean; error?: string }>;
+  codexGetStreamTail: (
+    workspaceId: string,
+  ) => Promise<{
+    success: boolean;
+    tail?: string;
+    startedAt?: string;
+    error?: string;
+  }>;
+  codexGetAgentStatus: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; agent?: any; error?: string }>;
+  codexGetAllAgents: () => Promise<{
+    success: boolean;
+    agents?: any[];
+    error?: string;
+  }>;
+  codexRemoveAgent: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; removed?: boolean; error?: string }>;
+  codexGetInstallationInstructions: () => Promise<{
+    success: boolean;
+    instructions?: string;
+    error?: string;
+  }>;
+
   // Streaming event listeners
-  onCodexStreamOutput: (listener: (data: { workspaceId: string; output: string; agentId: string; conversationId?: string }) => void) => () => void
-  onCodexStreamError: (listener: (data: { workspaceId: string; error: string; agentId: string; conversationId?: string }) => void) => () => void
-  onCodexStreamComplete: (listener: (data: { workspaceId: string; exitCode: number; agentId: string; conversationId?: string }) => void) => () => void
+  onCodexStreamOutput: (
+    listener: (data: {
+      workspaceId: string;
+      output: string;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => () => void;
+  onCodexStreamError: (
+    listener: (data: {
+      workspaceId: string;
+      error: string;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => () => void;
+  onCodexStreamComplete: (
+    listener: (data: {
+      workspaceId: string;
+      exitCode: number;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => () => void;
 }
 
 declare global {
   interface Window {
-    electronAPI: ElectronAPI
+    electronAPI: ElectronAPI;
   }
 }

--- a/src/renderer/components/ChangesDiffModal.tsx
+++ b/src/renderer/components/ChangesDiffModal.tsx
@@ -20,8 +20,8 @@ const Line: React.FC<{ text?: string; type: DiffLine["type"] }> = ({
     type === "add"
       ? "bg-emerald-50 dark:bg-emerald-900/30 text-emerald-800 dark:text-emerald-200"
       : type === "del"
-      ? "bg-rose-50 dark:bg-rose-900/30 text-rose-800 dark:text-rose-200"
-      : "bg-transparent text-gray-700 dark:text-gray-300";
+        ? "bg-rose-50 dark:bg-rose-900/30 text-rose-800 dark:text-rose-200"
+        : "bg-transparent text-gray-700 dark:text-gray-300";
   return (
     <div
       className={`px-3 py-0.5 whitespace-pre-wrap break-words font-mono text-[12px] leading-5 ${cls}`}
@@ -39,9 +39,11 @@ export const ChangesDiffModal: React.FC<ChangesDiffModalProps> = ({
   initialFile,
 }) => {
   const [selected, setSelected] = useState<string | undefined>(
-    initialFile || files[0]?.path
+    initialFile || files[0]?.path,
   );
-  const { lines, loading } = useFileDiff(workspacePath, selected);
+  const { lines, loading } = useFileDiff(workspacePath, selected, {
+    enabled: open,
+  });
   const shouldReduceMotion = useReducedMotion();
 
   const grouped = useMemo(() => {

--- a/src/renderer/hooks/useDocumentVisibility.ts
+++ b/src/renderer/hooks/useDocumentVisibility.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from "react";
+
+export function useDocumentVisibility(): boolean {
+  const [visible, setVisible] = useState(() => {
+    if (typeof document === "undefined") return true;
+    return document.visibilityState !== "hidden";
+  });
+
+  useEffect(() => {
+    if (typeof document === "undefined") return;
+    const onChange = () => setVisible(document.visibilityState !== "hidden");
+    document.addEventListener("visibilitychange", onChange);
+    return () => document.removeEventListener("visibilitychange", onChange);
+  }, []);
+
+  return visible;
+}

--- a/src/renderer/hooks/useFileDiff.ts
+++ b/src/renderer/hooks/useFileDiff.ts
@@ -1,36 +1,117 @@
-import { useEffect, useState } from 'react'
+import { useCallback, useEffect, useReducer, useRef, useState } from "react";
+import { useDocumentVisibility } from "./useDocumentVisibility";
 
-export type DiffLine = { left?: string; right?: string; type: 'context' | 'add' | 'del' }
+export type DiffLine = {
+  left?: string;
+  right?: string;
+  type: "context" | "add" | "del";
+};
 
-export function useFileDiff(workspacePath: string | undefined, filePath: string | undefined) {
-  const [lines, setLines] = useState<DiffLine[]>([])
-  const [loading, setLoading] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+type DiffCacheEntry = {
+  lines: DiffLine[];
+  error: string | null;
+  timestamp: number;
+};
+
+const CACHE_TTL_MS = 30000;
+
+const diffCache = new Map<string, DiffCacheEntry>();
+const inFlight = new Map<string, Promise<DiffCacheEntry>>();
+
+const buildKey = (workspacePath: string, filePath: string) =>
+  `${workspacePath}::${filePath}`;
+
+const fetchDiff = async (
+  workspacePath: string,
+  filePath: string,
+): Promise<DiffCacheEntry> => {
+  try {
+    const res = await window.electronAPI.getFileDiff({
+      workspacePath,
+      filePath,
+    });
+    if (res?.success && res.diff) {
+      return { lines: res.diff.lines, error: null, timestamp: Date.now() };
+    }
+    return {
+      lines: [],
+      error: res?.error || "Failed to load diff",
+      timestamp: Date.now(),
+    };
+  } catch (e: any) {
+    return {
+      lines: [],
+      error: e?.message || "Failed to load diff",
+      timestamp: Date.now(),
+    };
+  }
+};
+
+export function useFileDiff(
+  workspacePath: string | undefined,
+  filePath: string | undefined,
+  options?: { enabled?: boolean },
+) {
+  const enabled = options?.enabled ?? true;
+  const isVisible = useDocumentVisibility();
+  const [lines, setLines] = useState<DiffLine[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [refreshSeq, bumpRefresh] = useReducer((n) => n + 1, 0);
+  const refreshSeqRef = useRef(0);
+
+  const refresh = useCallback(() => bumpRefresh(), []);
 
   useEffect(() => {
-    let cancelled = false
-    const run = async () => {
-      if (!workspacePath || !filePath) return
-      setLoading(true)
-      setError(null)
-      try {
-        const res = await window.electronAPI.getFileDiff({ workspacePath, filePath })
-        if (!cancelled) {
-          if (res?.success && res.diff) setLines(res.diff.lines)
-          else setError(res?.error || 'Failed to load diff')
-        }
-      } catch (e: any) {
-        if (!cancelled) setError(e?.message || 'Failed to load diff')
-      } finally {
-        if (!cancelled) setLoading(false)
-      }
+    let cancelled = false;
+    if (!workspacePath || !filePath) return;
+    if (!enabled || !isVisible) return;
+
+    const key = buildKey(workspacePath, filePath);
+    const now = Date.now();
+    const force = refreshSeqRef.current !== refreshSeq;
+    refreshSeqRef.current = refreshSeq;
+
+    const cached = diffCache.get(key);
+    if (!force && cached && now - cached.timestamp < CACHE_TTL_MS) {
+      setLines(cached.lines);
+      setError(cached.error);
+      setLoading(false);
+      return;
     }
-    run()
+
+    let pending = inFlight.get(key);
+    const isOwner = !pending;
+    if (!pending) {
+      pending = (async () => {
+        const result = await fetchDiff(workspacePath, filePath);
+        diffCache.set(key, result);
+        return result;
+      })();
+      inFlight.set(key, pending);
+    }
+
+    setLoading(true);
+    setError(null);
+
+    pending
+      .then((result) => {
+        if (cancelled) return;
+        setLines(result.lines);
+        setError(result.error);
+      })
+      .catch((e: any) => {
+        if (!cancelled) setError(e?.message || "Failed to load diff");
+      })
+      .finally(() => {
+        if (isOwner) inFlight.delete(key);
+        if (!cancelled) setLoading(false);
+      });
+
     return () => {
-      cancelled = true
-    }
-  }, [workspacePath, filePath])
+      cancelled = true;
+    };
+  }, [workspacePath, filePath, enabled, isVisible, refreshSeq]);
 
-  return { lines, loading, error }
+  return { lines, loading, error, refresh };
 }
-

--- a/src/renderer/lib/gitStatusCache.ts
+++ b/src/renderer/lib/gitStatusCache.ts
@@ -1,0 +1,60 @@
+export type GitStatusChange = {
+  path: string;
+  status: string;
+  additions: number;
+  deletions: number;
+  diff?: string;
+};
+
+export type GitStatusResult = {
+  success: boolean;
+  changes?: GitStatusChange[];
+  error?: string;
+};
+
+const CACHE_TTL_MS = 30000;
+
+const cache = new Map<string, { timestamp: number; result: GitStatusResult }>();
+const inFlight = new Map<string, Promise<GitStatusResult>>();
+
+export async function getCachedGitStatus(
+  workspacePath: string,
+  options?: { force?: boolean },
+): Promise<GitStatusResult> {
+  if (!workspacePath) return { success: false, error: "workspace-unavailable" };
+  const force = options?.force ?? false;
+  const now = Date.now();
+
+  if (!force) {
+    const cached = cache.get(workspacePath);
+    if (cached && now - cached.timestamp < CACHE_TTL_MS) return cached.result;
+  }
+
+  const existing = inFlight.get(workspacePath);
+  if (existing) return existing;
+
+  const promise = (async () => {
+    try {
+      const res = await window.electronAPI.getGitStatus(workspacePath);
+      const result = res ?? {
+        success: false,
+        error: "Failed to load git status",
+      };
+      cache.set(workspacePath, { timestamp: Date.now(), result });
+      return result;
+    } catch (error) {
+      const result = {
+        success: false,
+        error:
+          error instanceof Error ? error.message : "Failed to load git status",
+      };
+      cache.set(workspacePath, { timestamp: Date.now(), result });
+      return result;
+    } finally {
+      inFlight.delete(workspacePath);
+    }
+  })();
+
+  inFlight.set(workspacePath, promise);
+  return promise;
+}

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1,166 +1,577 @@
 // Updated for Codex integration
-export {}
+export {};
 
 declare global {
   interface Window {
     electronAPI: {
       // App info
-      getVersion: () => Promise<string>
-      getPlatform: () => Promise<string>
+      getVersion: () => Promise<string>;
+      getPlatform: () => Promise<string>;
 
       // PTY
-      ptyStart: (opts: { id: string; cwd?: string; shell?: string; env?: Record<string, string>; cols?: number; rows?: number }) => Promise<{ ok: boolean }>
-      ptyInput: (args: { id: string; data: string }) => void
-      ptyResize: (args: { id: string; cols: number; rows?: number }) => void
-      ptyKill: (id: string) => void
-      onPtyData: (id: string, listener: (data: string) => void) => () => void
-      onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => () => void
+      ptyStart: (opts: {
+        id: string;
+        cwd?: string;
+        shell?: string;
+        env?: Record<string, string>;
+        cols?: number;
+        rows?: number;
+      }) => Promise<{ ok: boolean }>;
+      ptyInput: (args: { id: string; data: string }) => void;
+      ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
+      ptyKill: (id: string) => void;
+      onPtyData: (id: string, listener: (data: string) => void) => () => void;
+      onPtyExit: (
+        id: string,
+        listener: (info: { exitCode: number; signal?: number }) => void,
+      ) => () => void;
 
       // Worktree management
-      worktreeCreate: (args: { projectPath: string; workspaceName: string; projectId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-      worktreeList: (args: { projectPath: string }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
-      worktreeRemove: (args: { projectPath: string; worktreeId: string; worktreePath?: string; branch?: string }) => Promise<{ success: boolean; error?: string }>
-      worktreeStatus: (args: { worktreePath: string }) => Promise<{ success: boolean; status?: any; error?: string }>
-      worktreeMerge: (args: { projectPath: string; worktreeId: string }) => Promise<{ success: boolean; error?: string }>
-      worktreeGet: (args: { worktreeId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-      worktreeGetAll: () => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
+      worktreeCreate: (args: {
+        projectPath: string;
+        workspaceName: string;
+        projectId: string;
+      }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+      worktreeList: (args: {
+        projectPath: string;
+      }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+      worktreeRemove: (args: {
+        projectPath: string;
+        worktreeId: string;
+        worktreePath?: string;
+        branch?: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreeStatus: (args: {
+        worktreePath: string;
+      }) => Promise<{ success: boolean; status?: any; error?: string }>;
+      worktreeMerge: (args: {
+        projectPath: string;
+        worktreeId: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreeGet: (args: {
+        worktreeId: string;
+      }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+      worktreeGetAll: () => Promise<{
+        success: boolean;
+        worktrees?: any[];
+        error?: string;
+      }>;
 
       // Project management
-      openProject: () => Promise<{ success: boolean; path?: string; error?: string }>
-      getGitInfo: (projectPath: string) => Promise<{ isGitRepo: boolean; remote?: string; branch?: string; path?: string; error?: string }>
-      getGitStatus: (workspacePath: string) => Promise<{ success: boolean; changes?: Array<{ path: string; status: string; additions: number; deletions: number; diff?: string }>; error?: string }>
-      getFileDiff: (args: { workspacePath: string; filePath: string }) => Promise<{ success: boolean; diff?: { lines: Array<{ left?: string; right?: string; type: 'context' | 'add' | 'del' }> }; error?: string }>
-  gitCommitAndPush: (args: { workspacePath: string; commitMessage?: string; createBranchIfOnDefault?: boolean; branchPrefix?: string }) => Promise<{ success: boolean; branch?: string; output?: string; error?: string }>
-  createPullRequest: (args: { workspacePath: string; title?: string; body?: string; base?: string; head?: string; draft?: boolean; web?: boolean; fill?: boolean }) => Promise<{ success: boolean; url?: string; output?: string; error?: string }>
-  getPrStatus: (args: { workspacePath: string }) => Promise<{ success: boolean; pr?: { number: number; url: string; state: string; isDraft?: boolean; mergeStateStatus?: string; headRefName?: string; baseRefName?: string; title?: string; author?: any } | null; error?: string }>
-  openExternal: (url: string) => Promise<{ success: boolean; error?: string }>
-  connectToGitHub: (projectPath: string) => Promise<{ success: boolean; repository?: string; branch?: string; error?: string }>
+      openProject: () => Promise<{
+        success: boolean;
+        path?: string;
+        error?: string;
+      }>;
+      getGitInfo: (
+        projectPath: string,
+      ) => Promise<{
+        isGitRepo: boolean;
+        remote?: string;
+        branch?: string;
+        path?: string;
+        error?: string;
+      }>;
+      getGitStatus: (
+        workspacePath: string,
+      ) => Promise<{
+        success: boolean;
+        changes?: Array<{
+          path: string;
+          status: string;
+          additions: number;
+          deletions: number;
+          diff?: string;
+        }>;
+        error?: string;
+      }>;
+      watchGitStatus: (
+        workspacePath: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      unwatchGitStatus: (
+        workspacePath: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      onGitStatusChanged: (
+        listener: (data: { workspacePath: string }) => void,
+      ) => () => void;
+      getFileDiff: (args: {
+        workspacePath: string;
+        filePath: string;
+      }) => Promise<{
+        success: boolean;
+        diff?: {
+          lines: Array<{
+            left?: string;
+            right?: string;
+            type: "context" | "add" | "del";
+          }>;
+        };
+        error?: string;
+      }>;
+      gitCommitAndPush: (args: {
+        workspacePath: string;
+        commitMessage?: string;
+        createBranchIfOnDefault?: boolean;
+        branchPrefix?: string;
+      }) => Promise<{
+        success: boolean;
+        branch?: string;
+        output?: string;
+        error?: string;
+      }>;
+      createPullRequest: (args: {
+        workspacePath: string;
+        title?: string;
+        body?: string;
+        base?: string;
+        head?: string;
+        draft?: boolean;
+        web?: boolean;
+        fill?: boolean;
+      }) => Promise<{
+        success: boolean;
+        url?: string;
+        output?: string;
+        error?: string;
+      }>;
+      getPrStatus: (args: {
+        workspacePath: string;
+      }) => Promise<{
+        success: boolean;
+        pr?: {
+          number: number;
+          url: string;
+          state: string;
+          isDraft?: boolean;
+          mergeStateStatus?: string;
+          headRefName?: string;
+          baseRefName?: string;
+          title?: string;
+          author?: any;
+        } | null;
+        error?: string;
+      }>;
+      openExternal: (
+        url: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      connectToGitHub: (
+        projectPath: string,
+      ) => Promise<{
+        success: boolean;
+        repository?: string;
+        branch?: string;
+        error?: string;
+      }>;
 
       // Filesystem helpers
-      fsList: (root: string, opts?: { includeDirs?: boolean; maxEntries?: number }) => Promise<{ success: boolean; items?: Array<{ path: string; type: 'file' | 'dir' }>; error?: string }>
-      fsRead: (root: string, relPath: string, maxBytes?: number) => Promise<{ success: boolean; path?: string; size?: number; truncated?: boolean; content?: string; error?: string }>
+      fsList: (
+        root: string,
+        opts?: { includeDirs?: boolean; maxEntries?: number },
+      ) => Promise<{
+        success: boolean;
+        items?: Array<{ path: string; type: "file" | "dir" }>;
+        error?: string;
+      }>;
+      fsRead: (
+        root: string,
+        relPath: string,
+        maxBytes?: number,
+      ) => Promise<{
+        success: boolean;
+        path?: string;
+        size?: number;
+        truncated?: boolean;
+        content?: string;
+        error?: string;
+      }>;
 
       // Run events
-      onRunEvent: (callback: (event: any) => void) => void
-      removeRunEventListeners: () => void
+      onRunEvent: (callback: (event: any) => void) => void;
+      removeRunEventListeners: () => void;
 
       // GitHub integration
-      githubAuth: () => Promise<{ success: boolean; token?: string; user?: any; error?: string }>
-      githubIsAuthenticated: () => Promise<boolean>
-      githubGetStatus: () => Promise<{ installed: boolean; authenticated: boolean; user?: any }>
-      githubGetUser: () => Promise<any>
-      githubGetRepositories: () => Promise<any[]>
-      githubLogout: () => Promise<void>
+      githubAuth: () => Promise<{
+        success: boolean;
+        token?: string;
+        user?: any;
+        error?: string;
+      }>;
+      githubIsAuthenticated: () => Promise<boolean>;
+      githubGetStatus: () => Promise<{
+        installed: boolean;
+        authenticated: boolean;
+        user?: any;
+      }>;
+      githubGetUser: () => Promise<any>;
+      githubGetRepositories: () => Promise<any[]>;
+      githubLogout: () => Promise<void>;
 
       // Database operations
-      getProjects: () => Promise<any[]>
-      saveProject: (project: any) => Promise<{ success: boolean; error?: string }>
-      getWorkspaces: (projectId?: string) => Promise<any[]>
-      saveWorkspace: (workspace: any) => Promise<{ success: boolean; error?: string }>
-      deleteProject: (projectId: string) => Promise<{ success: boolean; error?: string }>
-      deleteWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>
-      
+      getProjects: () => Promise<any[]>;
+      saveProject: (
+        project: any,
+      ) => Promise<{ success: boolean; error?: string }>;
+      getWorkspaces: (projectId?: string) => Promise<any[]>;
+      saveWorkspace: (
+        workspace: any,
+      ) => Promise<{ success: boolean; error?: string }>;
+      deleteProject: (
+        projectId: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      deleteWorkspace: (
+        workspaceId: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+
       // Message operations
-      saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>
-      getMessages: (conversationId: string) => Promise<{ success: boolean; messages?: any[]; error?: string }>
-      getOrCreateDefaultConversation: (workspaceId: string) => Promise<{ success: boolean; conversation?: any; error?: string }>
+      saveMessage: (
+        message: any,
+      ) => Promise<{ success: boolean; error?: string }>;
+      getMessages: (
+        conversationId: string,
+      ) => Promise<{ success: boolean; messages?: any[]; error?: string }>;
+      getOrCreateDefaultConversation: (
+        workspaceId: string,
+      ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
 
       // Debug helpers
-      debugAppendLog: (filePath: string, content: string, options?: { reset?: boolean }) => Promise<{ success: boolean; error?: string }>
+      debugAppendLog: (
+        filePath: string,
+        content: string,
+        options?: { reset?: boolean },
+      ) => Promise<{ success: boolean; error?: string }>;
 
       // Codex
-      codexCheckInstallation: () => Promise<{ success: boolean; isInstalled?: boolean; error?: string }>
-      codexCreateAgent: (workspaceId: string, worktreePath: string) => Promise<{ success: boolean; agent?: any; error?: string }>
-      codexSendMessage: (workspaceId: string, message: string) => Promise<{ success: boolean; response?: any; error?: string }>
-      codexSendMessageStream: (workspaceId: string, message: string) => Promise<{ success: boolean; error?: string }>
-      codexStopStream: (workspaceId: string) => Promise<{ success: boolean; stopped?: boolean; error?: string }>
-      codexGetAgentStatus: (workspaceId: string) => Promise<{ success: boolean; agent?: any; error?: string }>
-      codexGetAllAgents: () => Promise<{ success: boolean; agents?: any[]; error?: string }>
-      codexRemoveAgent: (workspaceId: string) => Promise<{ success: boolean; removed?: boolean; error?: string }>
-      codexGetInstallationInstructions: () => Promise<{ success: boolean; instructions?: string; error?: string }>
-      
+      codexCheckInstallation: () => Promise<{
+        success: boolean;
+        isInstalled?: boolean;
+        error?: string;
+      }>;
+      codexCreateAgent: (
+        workspaceId: string,
+        worktreePath: string,
+      ) => Promise<{ success: boolean; agent?: any; error?: string }>;
+      codexSendMessage: (
+        workspaceId: string,
+        message: string,
+      ) => Promise<{ success: boolean; response?: any; error?: string }>;
+      codexSendMessageStream: (
+        workspaceId: string,
+        message: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      codexStopStream: (
+        workspaceId: string,
+      ) => Promise<{ success: boolean; stopped?: boolean; error?: string }>;
+      codexGetAgentStatus: (
+        workspaceId: string,
+      ) => Promise<{ success: boolean; agent?: any; error?: string }>;
+      codexGetAllAgents: () => Promise<{
+        success: boolean;
+        agents?: any[];
+        error?: string;
+      }>;
+      codexRemoveAgent: (
+        workspaceId: string,
+      ) => Promise<{ success: boolean; removed?: boolean; error?: string }>;
+      codexGetInstallationInstructions: () => Promise<{
+        success: boolean;
+        instructions?: string;
+        error?: string;
+      }>;
+
       // Streaming event listeners
-      onCodexStreamOutput: (listener: (data: { workspaceId: string; output: string; agentId: string }) => void) => () => void
-      onCodexStreamError: (listener: (data: { workspaceId: string; error: string; agentId: string }) => void) => () => void
-      onCodexStreamComplete: (listener: (data: { workspaceId: string; exitCode: number; agentId: string }) => void) => () => void
-    }
+      onCodexStreamOutput: (
+        listener: (data: {
+          workspaceId: string;
+          output: string;
+          agentId: string;
+        }) => void,
+      ) => () => void;
+      onCodexStreamError: (
+        listener: (data: {
+          workspaceId: string;
+          error: string;
+          agentId: string;
+        }) => void,
+      ) => () => void;
+      onCodexStreamComplete: (
+        listener: (data: {
+          workspaceId: string;
+          exitCode: number;
+          agentId: string;
+        }) => void,
+      ) => () => void;
+    };
   }
 }
 
 // Explicit type export for better TypeScript recognition
 export interface ElectronAPI {
   // App info
-  getVersion: () => Promise<string>
-  getPlatform: () => Promise<string>
+  getVersion: () => Promise<string>;
+  getPlatform: () => Promise<string>;
 
   // PTY
-  ptyStart: (opts: { id: string; cwd?: string; shell?: string; env?: Record<string, string>; cols?: number; rows?: number }) => Promise<{ ok: boolean }>
-  ptyInput: (args: { id: string; data: string }) => void
-  ptyResize: (args: { id: string; cols: number; rows?: number }) => void
-  ptyKill: (id: string) => void
-  onPtyData: (id: string, listener: (data: string) => void) => () => void
-  onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => () => void
+  ptyStart: (opts: {
+    id: string;
+    cwd?: string;
+    shell?: string;
+    env?: Record<string, string>;
+    cols?: number;
+    rows?: number;
+  }) => Promise<{ ok: boolean }>;
+  ptyInput: (args: { id: string; data: string }) => void;
+  ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
+  ptyKill: (id: string) => void;
+  onPtyData: (id: string, listener: (data: string) => void) => () => void;
+  onPtyExit: (
+    id: string,
+    listener: (info: { exitCode: number; signal?: number }) => void,
+  ) => () => void;
 
   // Worktree management
-  worktreeCreate: (args: { projectPath: string; workspaceName: string; projectId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-  worktreeList: (args: { projectPath: string }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
-  worktreeRemove: (args: { projectPath: string; worktreeId: string; worktreePath?: string; branch?: string }) => Promise<{ success: boolean; error?: string }>
-  worktreeStatus: (args: { worktreePath: string }) => Promise<{ success: boolean; status?: any; error?: string }>
-  worktreeMerge: (args: { projectPath: string; worktreeId: string }) => Promise<{ success: boolean; error?: string }>
-  worktreeGet: (args: { worktreeId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-  worktreeGetAll: () => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
+  worktreeCreate: (args: {
+    projectPath: string;
+    workspaceName: string;
+    projectId: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeList: (args: {
+    projectPath: string;
+  }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+  worktreeRemove: (args: {
+    projectPath: string;
+    worktreeId: string;
+    worktreePath?: string;
+    branch?: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeStatus: (args: {
+    worktreePath: string;
+  }) => Promise<{ success: boolean; status?: any; error?: string }>;
+  worktreeMerge: (args: {
+    projectPath: string;
+    worktreeId: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeGet: (args: {
+    worktreeId: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeGetAll: () => Promise<{
+    success: boolean;
+    worktrees?: any[];
+    error?: string;
+  }>;
 
   // Project management
-  openProject: () => Promise<{ success: boolean; path?: string; error?: string }>
-  getGitInfo: (projectPath: string) => Promise<{ isGitRepo: boolean; remote?: string; branch?: string; path?: string; error?: string }>
-  createPullRequest: (args: { workspacePath: string; title?: string; body?: string; base?: string; head?: string; draft?: boolean; web?: boolean; fill?: boolean }) => Promise<{ success: boolean; url?: string; output?: string; error?: string }>
-  connectToGitHub: (projectPath: string) => Promise<{ success: boolean; repository?: string; branch?: string; error?: string }>
+  openProject: () => Promise<{
+    success: boolean;
+    path?: string;
+    error?: string;
+  }>;
+  getGitInfo: (
+    projectPath: string,
+  ) => Promise<{
+    isGitRepo: boolean;
+    remote?: string;
+    branch?: string;
+    path?: string;
+    error?: string;
+  }>;
+  getGitStatus: (
+    workspacePath: string,
+  ) => Promise<{
+    success: boolean;
+    changes?: Array<{
+      path: string;
+      status: string;
+      additions: number;
+      deletions: number;
+      diff?: string;
+    }>;
+    error?: string;
+  }>;
+  watchGitStatus: (
+    workspacePath: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  unwatchGitStatus: (
+    workspacePath: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  onGitStatusChanged: (
+    listener: (data: { workspacePath: string }) => void,
+  ) => () => void;
+  getFileDiff: (args: {
+    workspacePath: string;
+    filePath: string;
+  }) => Promise<{
+    success: boolean;
+    diff?: {
+      lines: Array<{
+        left?: string;
+        right?: string;
+        type: "context" | "add" | "del";
+      }>;
+    };
+    error?: string;
+  }>;
+  createPullRequest: (args: {
+    workspacePath: string;
+    title?: string;
+    body?: string;
+    base?: string;
+    head?: string;
+    draft?: boolean;
+    web?: boolean;
+    fill?: boolean;
+  }) => Promise<{
+    success: boolean;
+    url?: string;
+    output?: string;
+    error?: string;
+  }>;
+  connectToGitHub: (
+    projectPath: string,
+  ) => Promise<{
+    success: boolean;
+    repository?: string;
+    branch?: string;
+    error?: string;
+  }>;
 
   // Filesystem
-  fsList: (root: string, opts?: { includeDirs?: boolean; maxEntries?: number }) => Promise<{ success: boolean; items?: Array<{ path: string; type: 'file' | 'dir' }>; error?: string }>
-  fsRead: (root: string, relPath: string, maxBytes?: number) => Promise<{ success: boolean; path?: string; size?: number; truncated?: boolean; content?: string; error?: string }>
+  fsList: (
+    root: string,
+    opts?: { includeDirs?: boolean; maxEntries?: number },
+  ) => Promise<{
+    success: boolean;
+    items?: Array<{ path: string; type: "file" | "dir" }>;
+    error?: string;
+  }>;
+  fsRead: (
+    root: string,
+    relPath: string,
+    maxBytes?: number,
+  ) => Promise<{
+    success: boolean;
+    path?: string;
+    size?: number;
+    truncated?: boolean;
+    content?: string;
+    error?: string;
+  }>;
 
   // Run events
-  onRunEvent: (callback: (event: any) => void) => void
-  removeRunEventListeners: () => void
+  onRunEvent: (callback: (event: any) => void) => void;
+  removeRunEventListeners: () => void;
 
   // GitHub integration
-  githubAuth: () => Promise<{ success: boolean; token?: string; user?: any; error?: string }>
-  githubIsAuthenticated: () => Promise<boolean>
-  githubGetUser: () => Promise<any>
-  githubGetRepositories: () => Promise<any[]>
-  githubLogout: () => Promise<void>
+  githubAuth: () => Promise<{
+    success: boolean;
+    token?: string;
+    user?: any;
+    error?: string;
+  }>;
+  githubIsAuthenticated: () => Promise<boolean>;
+  githubGetUser: () => Promise<any>;
+  githubGetRepositories: () => Promise<any[]>;
+  githubLogout: () => Promise<void>;
 
   // Database operations
-  getProjects: () => Promise<any[]>
-  saveProject: (project: any) => Promise<{ success: boolean; error?: string }>
-  getWorkspaces: (projectId?: string) => Promise<any[]>
-  saveWorkspace: (workspace: any) => Promise<{ success: boolean; error?: string }>
-  deleteProject: (projectId: string) => Promise<{ success: boolean; error?: string }>
-  deleteWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>
-  
+  getProjects: () => Promise<any[]>;
+  saveProject: (project: any) => Promise<{ success: boolean; error?: string }>;
+  getWorkspaces: (projectId?: string) => Promise<any[]>;
+  saveWorkspace: (
+    workspace: any,
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteProject: (
+    projectId: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  deleteWorkspace: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+
   // Message operations
-  saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>
-  getMessages: (conversationId: string) => Promise<{ success: boolean; messages?: any[]; error?: string }>
-  getOrCreateDefaultConversation: (workspaceId: string) => Promise<{ success: boolean; conversation?: any; error?: string }>
+  saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>;
+  getMessages: (
+    conversationId: string,
+  ) => Promise<{ success: boolean; messages?: any[]; error?: string }>;
+  getOrCreateDefaultConversation: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; conversation?: any; error?: string }>;
 
   // Debug helpers
-  debugAppendLog: (filePath: string, content: string, options?: { reset?: boolean }) => Promise<{ success: boolean; error?: string }>
+  debugAppendLog: (
+    filePath: string,
+    content: string,
+    options?: { reset?: boolean },
+  ) => Promise<{ success: boolean; error?: string }>;
 
   // Codex
-  codexCheckInstallation: () => Promise<{ success: boolean; isInstalled?: boolean; error?: string }>
-  codexCreateAgent: (workspaceId: string, worktreePath: string) => Promise<{ success: boolean; agent?: any; error?: string }>
-  codexSendMessage: (workspaceId: string, message: string) => Promise<{ success: boolean; response?: any; error?: string }>
-  codexSendMessageStream: (workspaceId: string, message: string, conversationId?: string) => Promise<{ success: boolean; error?: string }>
-  codexStopStream: (workspaceId: string) => Promise<{ success: boolean; stopped?: boolean; error?: string }>
-  codexGetStreamTail: (workspaceId: string) => Promise<{ success: boolean; tail?: string; startedAt?: string; error?: string }>
-  codexGetAgentStatus: (workspaceId: string) => Promise<{ success: boolean; agent?: any; error?: string }>
-  codexGetAllAgents: () => Promise<{ success: boolean; agents?: any[]; error?: string }>
-  codexRemoveAgent: (workspaceId: string) => Promise<{ success: boolean; removed?: boolean; error?: string }>
-  codexGetInstallationInstructions: () => Promise<{ success: boolean; instructions?: string; error?: string }>
-  
+  codexCheckInstallation: () => Promise<{
+    success: boolean;
+    isInstalled?: boolean;
+    error?: string;
+  }>;
+  codexCreateAgent: (
+    workspaceId: string,
+    worktreePath: string,
+  ) => Promise<{ success: boolean; agent?: any; error?: string }>;
+  codexSendMessage: (
+    workspaceId: string,
+    message: string,
+  ) => Promise<{ success: boolean; response?: any; error?: string }>;
+  codexSendMessageStream: (
+    workspaceId: string,
+    message: string,
+    conversationId?: string,
+  ) => Promise<{ success: boolean; error?: string }>;
+  codexStopStream: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; stopped?: boolean; error?: string }>;
+  codexGetStreamTail: (
+    workspaceId: string,
+  ) => Promise<{
+    success: boolean;
+    tail?: string;
+    startedAt?: string;
+    error?: string;
+  }>;
+  codexGetAgentStatus: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; agent?: any; error?: string }>;
+  codexGetAllAgents: () => Promise<{
+    success: boolean;
+    agents?: any[];
+    error?: string;
+  }>;
+  codexRemoveAgent: (
+    workspaceId: string,
+  ) => Promise<{ success: boolean; removed?: boolean; error?: string }>;
+  codexGetInstallationInstructions: () => Promise<{
+    success: boolean;
+    instructions?: string;
+    error?: string;
+  }>;
+
   // Streaming event listeners
-  onCodexStreamOutput: (listener: (data: { workspaceId: string; output: string; agentId: string; conversationId?: string }) => void) => () => void
-  onCodexStreamError: (listener: (data: { workspaceId: string; error: string; agentId: string; conversationId?: string }) => void) => () => void
-  onCodexStreamComplete: (listener: (data: { workspaceId: string; exitCode: number; agentId: string; conversationId?: string }) => void) => () => void
+  onCodexStreamOutput: (
+    listener: (data: {
+      workspaceId: string;
+      output: string;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => () => void;
+  onCodexStreamError: (
+    listener: (data: {
+      workspaceId: string;
+      error: string;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => () => void;
+  onCodexStreamComplete: (
+    listener: (data: {
+      workspaceId: string;
+      exitCode: number;
+      agentId: string;
+      conversationId?: string;
+    }) => void,
+  ) => () => void;
 }

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -2,54 +2,160 @@
 declare global {
   interface Window {
     electronAPI: {
-      getVersion: () => Promise<string>
-      getPlatform: () => Promise<string>
+      getVersion: () => Promise<string>;
+      getPlatform: () => Promise<string>;
       // PTY management
-      ptyStart: (opts: { id: string; cwd?: string; shell?: string; env?: Record<string, string>; cols?: number; rows?: number; }) => Promise<{ ok: boolean }>
-      ptyInput: (args: { id: string; data: string }) => void
-      ptyResize: (args: { id: string; cols: number; rows: number }) => void
-      ptyKill: (id: string) => void
-      onPtyData: (id: string, listener: (data: string) => void) => () => void
-      onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => () => void
+      ptyStart: (opts: {
+        id: string;
+        cwd?: string;
+        shell?: string;
+        env?: Record<string, string>;
+        cols?: number;
+        rows?: number;
+      }) => Promise<{ ok: boolean }>;
+      ptyInput: (args: { id: string; data: string }) => void;
+      ptyResize: (args: { id: string; cols: number; rows: number }) => void;
+      ptyKill: (id: string) => void;
+      onPtyData: (id: string, listener: (data: string) => void) => () => void;
+      onPtyExit: (
+        id: string,
+        listener: (info: { exitCode: number; signal?: number }) => void,
+      ) => () => void;
       // Worktree management
-      worktreeCreate: (args: { projectPath: string; workspaceName: string; projectId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-      worktreeList: (args: { projectPath: string }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
-      worktreeRemove: (args: { projectPath: string; worktreeId: string; worktreePath?: string; branch?: string }) => Promise<{ success: boolean; error?: string }>
-      worktreeStatus: (args: { worktreePath: string }) => Promise<{ success: boolean; status?: any; error?: string }>
-      worktreeMerge: (args: { projectPath: string; worktreeId: string }) => Promise<{ success: boolean; error?: string }>
-      worktreeGet: (args: { worktreeId: string }) => Promise<{ success: boolean; worktree?: any; error?: string }>
-      worktreeGetAll: () => Promise<{ success: boolean; worktrees?: any[]; error?: string }>
-      openProject: () => Promise<{ success: boolean; path?: string; error?: string }>
-      getGitInfo: (projectPath: string) => Promise<{ isGitRepo: boolean; remote?: string; branch?: string; path?: string; error?: string }>
-      getGitStatus: (workspacePath: string) => Promise<{ success: boolean; changes?: Array<{ path: string; status: string; additions: number; deletions: number; diff?: string }>; error?: string }>
-      connectToGitHub: (projectPath: string) => Promise<{ success: boolean; repository?: string; branch?: string; error?: string }>
-      scanRepos: () => Promise<any[]>
-      addRepo: (path: string) => Promise<any>
+      worktreeCreate: (args: {
+        projectPath: string;
+        workspaceName: string;
+        projectId: string;
+      }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+      worktreeList: (args: {
+        projectPath: string;
+      }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+      worktreeRemove: (args: {
+        projectPath: string;
+        worktreeId: string;
+        worktreePath?: string;
+        branch?: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreeStatus: (args: {
+        worktreePath: string;
+      }) => Promise<{ success: boolean; status?: any; error?: string }>;
+      worktreeMerge: (args: {
+        projectPath: string;
+        worktreeId: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreeGet: (args: {
+        worktreeId: string;
+      }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+      worktreeGetAll: () => Promise<{
+        success: boolean;
+        worktrees?: any[];
+        error?: string;
+      }>;
+      openProject: () => Promise<{
+        success: boolean;
+        path?: string;
+        error?: string;
+      }>;
+      getGitInfo: (
+        projectPath: string,
+      ) => Promise<{
+        isGitRepo: boolean;
+        remote?: string;
+        branch?: string;
+        path?: string;
+        error?: string;
+      }>;
+      getGitStatus: (
+        workspacePath: string,
+      ) => Promise<{
+        success: boolean;
+        changes?: Array<{
+          path: string;
+          status: string;
+          additions: number;
+          deletions: number;
+          diff?: string;
+        }>;
+        error?: string;
+      }>;
+      watchGitStatus: (
+        workspacePath: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      unwatchGitStatus: (
+        workspacePath: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      onGitStatusChanged: (
+        listener: (data: { workspacePath: string }) => void,
+      ) => () => void;
+      connectToGitHub: (
+        projectPath: string,
+      ) => Promise<{
+        success: boolean;
+        repository?: string;
+        branch?: string;
+        error?: string;
+      }>;
+      scanRepos: () => Promise<any[]>;
+      addRepo: (path: string) => Promise<any>;
       // Filesystem
-      fsList: (root: string, opts?: { includeDirs?: boolean; maxEntries?: number }) => Promise<{ success: boolean; items?: Array<{ path: string; type: 'file' | 'dir' }>; error?: string }>
-      fsRead: (root: string, relPath: string, maxBytes?: number) => Promise<{ success: boolean; path?: string; size?: number; truncated?: boolean; content?: string; error?: string }>
-      createRun: (config: any) => Promise<string>
-      cancelRun: (runId: string) => Promise<void>
-      getRunDiff: (runId: string) => Promise<any>
-      onRunEvent: (callback: (event: any) => void) => void
-      removeRunEventListeners: () => void
-      githubAuth: () => Promise<{ success: boolean; token?: string; user?: any; error?: string }>
-      githubIsAuthenticated: () => Promise<boolean>
-      githubGetUser: () => Promise<any>
-      githubGetRepositories: () => Promise<any[]>
-      githubCloneRepository: (repoUrl: string, localPath: string) => Promise<{ success: boolean; error?: string }>
-      githubLogout: () => Promise<void>
-      getSettings: () => Promise<any>
-      updateSettings: (settings: any) => Promise<void>
+      fsList: (
+        root: string,
+        opts?: { includeDirs?: boolean; maxEntries?: number },
+      ) => Promise<{
+        success: boolean;
+        items?: Array<{ path: string; type: "file" | "dir" }>;
+        error?: string;
+      }>;
+      fsRead: (
+        root: string,
+        relPath: string,
+        maxBytes?: number,
+      ) => Promise<{
+        success: boolean;
+        path?: string;
+        size?: number;
+        truncated?: boolean;
+        content?: string;
+        error?: string;
+      }>;
+      createRun: (config: any) => Promise<string>;
+      cancelRun: (runId: string) => Promise<void>;
+      getRunDiff: (runId: string) => Promise<any>;
+      onRunEvent: (callback: (event: any) => void) => void;
+      removeRunEventListeners: () => void;
+      githubAuth: () => Promise<{
+        success: boolean;
+        token?: string;
+        user?: any;
+        error?: string;
+      }>;
+      githubIsAuthenticated: () => Promise<boolean>;
+      githubGetUser: () => Promise<any>;
+      githubGetRepositories: () => Promise<any[]>;
+      githubCloneRepository: (
+        repoUrl: string,
+        localPath: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      githubLogout: () => Promise<void>;
+      getSettings: () => Promise<any>;
+      updateSettings: (settings: any) => Promise<void>;
       // Database methods
-      getProjects: () => Promise<any[]>
-      saveProject: (project: any) => Promise<{ success: boolean; error?: string }>
-      getWorkspaces: (projectId?: string) => Promise<any[]>
-      saveWorkspace: (workspace: any) => Promise<{ success: boolean; error?: string }>
-      deleteProject: (projectId: string) => Promise<{ success: boolean; error?: string }>
-      deleteWorkspace: (workspaceId: string) => Promise<{ success: boolean; error?: string }>
-    }
+      getProjects: () => Promise<any[]>;
+      saveProject: (
+        project: any,
+      ) => Promise<{ success: boolean; error?: string }>;
+      getWorkspaces: (projectId?: string) => Promise<any[]>;
+      saveWorkspace: (
+        workspace: any,
+      ) => Promise<{ success: boolean; error?: string }>;
+      deleteProject: (
+        projectId: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+      deleteWorkspace: (
+        workspaceId: string,
+      ) => Promise<{ success: boolean; error?: string }>;
+    };
   }
 }
 
-export {}
+export {};


### PR DESCRIPTION
## Summary
- replace polling with git status watchers and visibility-aware refresh
- add shared git status cache + diff cache with in-flight guards
- skip diff work when hidden or inactive

## Testing
- npm run lint (fails: eslint not installed in environment)