### PR TITLE
Reduce git status polling when inactive

### DIFF
--- a/src/renderer/hooks/useFileChanges.ts
+++ b/src/renderer/hooks/useFileChanges.ts
@@ -1,69 +1,91 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface FileChange {
   path: string;
-  status: 'added' | 'modified' | 'deleted' | 'renamed';
+  status: "added" | "modified" | "deleted" | "renamed";
   additions: number;
   deletions: number;
   diff?: string;
 }
 
-export function useFileChanges(workspacePath: string) {
+interface UseFileChangesOptions {
+  isActive?: boolean;
+  idleIntervalMs?: number;
+}
+
+export function useFileChanges(
+  workspacePath?: string,
+  options: UseFileChangesOptions = {},
+) {
   const [fileChanges, setFileChanges] = useState<FileChange[]>([]);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [isDocumentVisible, setIsDocumentVisible] = useState(() => {
+    if (typeof document === "undefined") return true;
+    return document.visibilityState === "visible";
+  });
+  const [isWindowFocused, setIsWindowFocused] = useState(() => {
+    if (typeof document === "undefined") return true;
+    return document.hasFocus();
+  });
+
+  const { isActive = true, idleIntervalMs = 60000 } = options;
+  const workspacePathRef = useRef(workspacePath);
+  const inFlightRef = useRef(false);
+  const hasLoadedRef = useRef(false);
+  const shouldPollRef = useRef(false);
+  const idleHandleRef = useRef<number | null>(null);
+  const idleHandleModeRef = useRef<"idle" | "timeout" | null>(null);
+  const mountedRef = useRef(true);
 
   useEffect(() => {
-    const fetchFileChanges = async (isInitialLoad = false) => {
-      if (!workspacePath) return;
-      
-      if (isInitialLoad) {
-        setIsLoading(true);
-        setError(null);
-      }
-      
-      try {
-        // Call main process to get git status
-        const result = await window.electronAPI.getGitStatus(workspacePath);
-        
-        if (result?.success && result.changes && result.changes.length > 0) {
-          const changes: FileChange[] = result.changes.map((change: any) => ({
-            path: change.path,
-            status: change.status,
-            additions: change.additions || 0,
-            deletions: change.deletions || 0,
-            diff: change.diff,
-          }));
-          setFileChanges(changes);
-        } else {
-          setFileChanges([]);
-        }
-      } catch (err) {
-        console.error('Failed to fetch file changes:', err);
-        if (isInitialLoad) {
-          setError('Failed to load file changes');
-        }
-        // No changes on error - set empty array
-        setFileChanges([]);
-      } finally {
-        if (isInitialLoad) {
-          setIsLoading(false);
-        }
-      }
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
     };
+  }, []);
 
-    // Initial load with loading state
-    fetchFileChanges(true);
-    
-    const interval = setInterval(() => fetchFileChanges(false), 5000);
-    
-    return () => clearInterval(interval);
+  useEffect(() => {
+    workspacePathRef.current = workspacePath;
+    hasLoadedRef.current = false;
   }, [workspacePath]);
 
-  const refreshChanges = async () => {
-    setIsLoading(true);
+  useEffect(() => {
+    if (typeof document === "undefined" || typeof window === "undefined")
+      return;
+
+    const handleVisibility = () => {
+      setIsDocumentVisible(document.visibilityState === "visible");
+    };
+    const handleFocus = () => setIsWindowFocused(true);
+    const handleBlur = () => setIsWindowFocused(false);
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, []);
+
+  const fetchFileChanges = useCallback(async (isInitialLoad = false) => {
+    const currentPath = workspacePathRef.current;
+    if (!currentPath || inFlightRef.current) return;
+
+    inFlightRef.current = true;
+    if (isInitialLoad && mountedRef.current) {
+      setIsLoading(true);
+      setError(null);
+    }
+
     try {
-      const result = await window.electronAPI.getGitStatus(workspacePath);
+      const result = await window.electronAPI.getGitStatus(currentPath);
+
+      if (!mountedRef.current) return;
+
       if (result?.success && result.changes && result.changes.length > 0) {
         const changes: FileChange[] = result.changes.map((change: any) => ({
           path: change.path,
@@ -77,11 +99,87 @@ export function useFileChanges(workspacePath: string) {
         setFileChanges([]);
       }
     } catch (err) {
-      console.error('Failed to refresh file changes:', err);
+      if (!mountedRef.current) return;
+      console.error("Failed to fetch file changes:", err);
+      if (isInitialLoad) {
+        setError("Failed to load file changes");
+      }
       setFileChanges([]);
     } finally {
-      setIsLoading(false);
+      if (mountedRef.current && isInitialLoad) {
+        setIsLoading(false);
+      }
+      hasLoadedRef.current = true;
+      inFlightRef.current = false;
     }
+  }, []);
+
+  const clearIdleHandle = useCallback(() => {
+    if (idleHandleRef.current === null) return;
+    if (idleHandleModeRef.current === "idle") {
+      const cancelIdle = (window as any).cancelIdleCallback as
+        | ((id: number) => void)
+        | undefined;
+      cancelIdle?.(idleHandleRef.current);
+    } else {
+      clearTimeout(idleHandleRef.current);
+    }
+    idleHandleRef.current = null;
+    idleHandleModeRef.current = null;
+  }, []);
+
+  const scheduleIdleRefresh = useCallback(() => {
+    if (!shouldPollRef.current) return;
+    clearIdleHandle();
+
+    const run = () => {
+      if (!shouldPollRef.current) return;
+      fetchFileChanges(false);
+      scheduleIdleRefresh();
+    };
+
+    const requestIdle = (window as any).requestIdleCallback as
+      | ((cb: () => void, options?: { timeout: number }) => number)
+      | undefined;
+
+    if (requestIdle) {
+      idleHandleModeRef.current = "idle";
+      idleHandleRef.current = requestIdle(run, { timeout: idleIntervalMs });
+    } else {
+      idleHandleModeRef.current = "timeout";
+      idleHandleRef.current = window.setTimeout(run, idleIntervalMs);
+    }
+  }, [clearIdleHandle, fetchFileChanges, idleIntervalMs]);
+
+  const shouldPoll =
+    Boolean(workspacePath) && isActive && isDocumentVisible && isWindowFocused;
+
+  useEffect(() => {
+    shouldPollRef.current = shouldPoll;
+  }, [shouldPoll]);
+
+  useEffect(() => {
+    if (!workspacePath || !shouldPoll) {
+      clearIdleHandle();
+      return;
+    }
+
+    fetchFileChanges(!hasLoadedRef.current);
+    scheduleIdleRefresh();
+
+    return () => {
+      clearIdleHandle();
+    };
+  }, [
+    workspacePath,
+    shouldPoll,
+    fetchFileChanges,
+    scheduleIdleRefresh,
+    clearIdleHandle,
+  ]);
+
+  const refreshChanges = async () => {
+    await fetchFileChanges(true);
   };
 
   return {

--- a/src/renderer/hooks/useWorkspaceChanges.ts
+++ b/src/renderer/hooks/useWorkspaceChanges.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useRef, useState } from "react";
 
 export interface WorkspaceChange {
   path: string;
@@ -17,7 +17,16 @@ export interface WorkspaceChanges {
   error?: string;
 }
 
-export function useWorkspaceChanges(workspacePath: string, workspaceId: string) {
+interface UseWorkspaceChangesOptions {
+  isActive?: boolean;
+  idleIntervalMs?: number;
+}
+
+export function useWorkspaceChanges(
+  workspacePath: string,
+  workspaceId: string,
+  options: UseWorkspaceChangesOptions = {},
+) {
   const [changes, setChanges] = useState<WorkspaceChanges>({
     workspaceId,
     changes: [],
@@ -25,55 +34,184 @@ export function useWorkspaceChanges(workspacePath: string, workspaceId: string) 
     totalDeletions: 0,
     isLoading: true,
   });
+  const [isDocumentVisible, setIsDocumentVisible] = useState(() => {
+    if (typeof document === "undefined") return true;
+    return document.visibilityState === "visible";
+  });
+  const [isWindowFocused, setIsWindowFocused] = useState(() => {
+    if (typeof document === "undefined") return true;
+    return document.hasFocus();
+  });
 
-  const fetchChanges = async (isInitialLoad = false) => {
-    try {
-      if (isInitialLoad) {
-        setChanges(prev => ({ ...prev, isLoading: true, error: undefined }));
-      }
-      
-      const result = await window.electronAPI.getGitStatus(workspacePath);
-      
-      if (result.success && result.changes) {
-        const totalAdditions = result.changes.reduce((sum, change) => sum + change.additions, 0);
-        const totalDeletions = result.changes.reduce((sum, change) => sum + change.deletions, 0);
-        
-        setChanges({
-          workspaceId,
-          changes: result.changes,
-          totalAdditions,
-          totalDeletions,
-          isLoading: false,
-        });
-      } else {
+  const { isActive = true, idleIntervalMs = 60000 } = options;
+  const workspacePathRef = useRef(workspacePath);
+  const inFlightRef = useRef(false);
+  const hasLoadedRef = useRef(false);
+  const shouldPollRef = useRef(false);
+  const idleHandleRef = useRef<number | null>(null);
+  const idleHandleModeRef = useRef<"idle" | "timeout" | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    workspacePathRef.current = workspacePath;
+    hasLoadedRef.current = false;
+  }, [workspacePath]);
+
+  useEffect(() => {
+    if (typeof document === "undefined" || typeof window === "undefined")
+      return;
+
+    const handleVisibility = () => {
+      setIsDocumentVisible(document.visibilityState === "visible");
+    };
+    const handleFocus = () => setIsWindowFocused(true);
+    const handleBlur = () => setIsWindowFocused(false);
+
+    document.addEventListener("visibilitychange", handleVisibility);
+    window.addEventListener("focus", handleFocus);
+    window.addEventListener("blur", handleBlur);
+
+    return () => {
+      document.removeEventListener("visibilitychange", handleVisibility);
+      window.removeEventListener("focus", handleFocus);
+      window.removeEventListener("blur", handleBlur);
+    };
+  }, []);
+
+  const fetchChanges = useCallback(
+    async (isInitialLoad = false) => {
+      const currentPath = workspacePathRef.current;
+      if (!currentPath || inFlightRef.current) return;
+
+      inFlightRef.current = true;
+      try {
+        if (isInitialLoad) {
+          setChanges((prev) => ({
+            ...prev,
+            isLoading: true,
+            error: undefined,
+          }));
+        }
+
+        const result = await window.electronAPI.getGitStatus(currentPath);
+
+        if (!mountedRef.current) return;
+
+        if (result.success && result.changes) {
+          const totalAdditions = result.changes.reduce(
+            (sum, change) => sum + change.additions,
+            0,
+          );
+          const totalDeletions = result.changes.reduce(
+            (sum, change) => sum + change.deletions,
+            0,
+          );
+
+          setChanges({
+            workspaceId,
+            changes: result.changes,
+            totalAdditions,
+            totalDeletions,
+            isLoading: false,
+          });
+        } else {
+          setChanges({
+            workspaceId,
+            changes: [],
+            totalAdditions: 0,
+            totalDeletions: 0,
+            isLoading: false,
+            error: result.error || "Failed to fetch changes",
+          });
+        }
+      } catch (error) {
+        if (!mountedRef.current) return;
         setChanges({
           workspaceId,
           changes: [],
           totalAdditions: 0,
           totalDeletions: 0,
           isLoading: false,
-          error: result.error || 'Failed to fetch changes',
+          error: error instanceof Error ? error.message : "Unknown error",
         });
+      } finally {
+        hasLoadedRef.current = true;
+        inFlightRef.current = false;
       }
-    } catch (error) {
-      setChanges({
-        workspaceId,
-        changes: [],
-        totalAdditions: 0,
-        totalDeletions: 0,
-        isLoading: false,
-        error: error instanceof Error ? error.message : 'Unknown error',
-      });
+    },
+    [workspaceId],
+  );
+
+  const clearIdleHandle = useCallback(() => {
+    if (idleHandleRef.current === null) return;
+    if (idleHandleModeRef.current === "idle") {
+      const cancelIdle = (window as any).cancelIdleCallback as
+        | ((id: number) => void)
+        | undefined;
+      cancelIdle?.(idleHandleRef.current);
+    } else {
+      clearTimeout(idleHandleRef.current);
     }
-  };
+    idleHandleRef.current = null;
+    idleHandleModeRef.current = null;
+  }, []);
+
+  const scheduleIdleRefresh = useCallback(() => {
+    if (!shouldPollRef.current) return;
+    clearIdleHandle();
+
+    const run = () => {
+      if (!shouldPollRef.current) return;
+      fetchChanges(false);
+      scheduleIdleRefresh();
+    };
+
+    const requestIdle = (window as any).requestIdleCallback as
+      | ((cb: () => void, options?: { timeout: number }) => number)
+      | undefined;
+
+    if (requestIdle) {
+      idleHandleModeRef.current = "idle";
+      idleHandleRef.current = requestIdle(run, { timeout: idleIntervalMs });
+    } else {
+      idleHandleModeRef.current = "timeout";
+      idleHandleRef.current = window.setTimeout(run, idleIntervalMs);
+    }
+  }, [clearIdleHandle, fetchChanges, idleIntervalMs]);
+
+  const shouldPoll =
+    Boolean(workspacePath) && isActive && isDocumentVisible && isWindowFocused;
 
   useEffect(() => {
-    fetchChanges(true); 
-    
-    // Poll for changes every 10 seconds without loading state
-    const interval = setInterval(() => fetchChanges(false), 10000);
-    return () => clearInterval(interval);
-  }, [workspacePath, workspaceId]);
+    shouldPollRef.current = shouldPoll;
+  }, [shouldPoll]);
+
+  useEffect(() => {
+    if (!workspacePath || !shouldPoll) {
+      clearIdleHandle();
+      return;
+    }
+
+    fetchChanges(!hasLoadedRef.current);
+    scheduleIdleRefresh();
+
+    return () => {
+      clearIdleHandle();
+    };
+  }, [
+    workspacePath,
+    shouldPoll,
+    fetchChanges,
+    scheduleIdleRefresh,
+    clearIdleHandle,
+  ]);
 
   return {
     ...changes,


### PR DESCRIPTION
- pause git status polling when window is hidden or unfocused\n- switch to idle-driven refresh with long interval\n- keep refresh event-driven on focus/visibility changes