### PR TITLE
Add task env vars and port isolation

### DIFF
--- a/docs/content/docs/project-config.mdx
+++ b/docs/content/docs/project-config.mdx
@@ -81,6 +81,26 @@ When a task terminal starts, Emdash injects convenience environment variables yo
 }
 ```
 
+### Example: docker-compose override with task ports
+
+```yaml
+services:
+  db:
+    ports:
+      - "${EMDASH_PORT:-5432}:5432"
+  app:
+    environment:
+      - DATABASE_PORT=${EMDASH_PORT:-5432}
+```
+
+### Example: Port offsets (app + db + redis)
+
+```
+APP_PORT=$EMDASH_PORT
+DB_PORT=$((EMDASH_PORT + 1))
+REDIS_PORT=$((EMDASH_PORT + 2))
+```
+
 ### Examples
 
 Install dependencies:

--- a/docs/content/docs/project-config.mdx
+++ b/docs/content/docs/project-config.mdx
@@ -58,6 +58,29 @@ You can run a command automatically when a new task is created. This is useful f
 
 The setup script runs in the task's terminal as soon as the worktree is ready. It runs in parallel with the agent starting, so the agent can begin working while your dev server spins up.
 
+## Task env vars
+
+When a task terminal starts, Emdash injects convenience environment variables you can use inside setup scripts and other terminal commands.
+
+| Variable | Purpose |
+| --- | --- |
+| `EMDASH_TASK_ID` | Stable unique task id |
+| `EMDASH_TASK_NAME` | Shell-safe task name slug |
+| `EMDASH_TASK_PATH` | Absolute task (worktree) path |
+| `EMDASH_ROOT_PATH` | Absolute project root path |
+| `EMDASH_DEFAULT_BRANCH` | Default branch name (e.g., main) |
+| `EMDASH_PORT` | Base port for a 10-port range |
+
+### Example: Port-aware setup script
+
+```json
+{
+  "scripts": {
+    "setup": "export PORT=$EMDASH_PORT && export DB_PORT=$((EMDASH_PORT + 1)) && export COMPOSE_PROJECT_NAME=$EMDASH_TASK_NAME && docker-compose up -d && npm run dev"
+  }
+}
+```
+
 ### Examples
 
 Install dependencies:

--- a/docs/content/docs/project-config.mdx
+++ b/docs/content/docs/project-config.mdx
@@ -62,14 +62,14 @@ The setup script runs in the task's terminal as soon as the worktree is ready. I
 
 When a task terminal starts, Emdash injects convenience environment variables you can use inside setup scripts and other terminal commands.
 
-| Variable | Purpose |
-| --- | --- |
-| `EMDASH_TASK_ID` | Stable unique task id |
-| `EMDASH_TASK_NAME` | Shell-safe task name slug |
-| `EMDASH_TASK_PATH` | Absolute task (worktree) path |
-| `EMDASH_ROOT_PATH` | Absolute project root path |
+| Variable                | Purpose                          |
+| ----------------------- | -------------------------------- |
+| `EMDASH_TASK_ID`        | Stable unique task id            |
+| `EMDASH_TASK_NAME`      | Shell-safe task name slug        |
+| `EMDASH_TASK_PATH`      | Absolute task (worktree) path    |
+| `EMDASH_ROOT_PATH`      | Absolute project root path       |
 | `EMDASH_DEFAULT_BRANCH` | Default branch name (e.g., main) |
-| `EMDASH_PORT` | Base port for a 10-port range |
+| `EMDASH_PORT`           | Base port for a 10-port range    |
 
 ### Example: Port-aware setup script
 
@@ -87,7 +87,7 @@ When a task terminal starts, Emdash injects convenience environment variables yo
 services:
   db:
     ports:
-      - "${EMDASH_PORT:-5432}:5432"
+      - '${EMDASH_PORT:-5432}:5432'
   app:
     environment:
       - DATABASE_PORT=${EMDASH_PORT:-5432}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -79,6 +79,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     autoApprove?: boolean;
     initialPrompt?: string;
     clickTime?: number;
+    env?: Record<string, string>;
     resume?: boolean;
   }) => ipcRenderer.invoke('pty:startDirect', opts),
 

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -363,18 +363,18 @@ export function registerPtyIpc(): void {
     'pty:startDirect',
     async (
       event,
-        args: {
-          id: string;
-          providerId: string;
-          cwd: string;
-          cols?: number;
-          rows?: number;
-          autoApprove?: boolean;
-          initialPrompt?: string;
-          env?: Record<string, string>;
-          resume?: boolean;
-        }
-      ) => {
+      args: {
+        id: string;
+        providerId: string;
+        cwd: string;
+        cols?: number;
+        rows?: number;
+        autoApprove?: boolean;
+        initialPrompt?: string;
+        env?: Record<string, string>;
+        resume?: boolean;
+      }
+    ) => {
       if (process.env.EMDASH_DISABLE_PTY === '1') {
         return { ok: false, error: 'PTY disabled via EMDASH_DISABLE_PTY=1' };
       }

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -418,6 +418,7 @@ export function registerPtyIpc(): void {
             rows,
             autoApprove,
             initialPrompt,
+            env,
             skipResume: !resume,
           });
           usedFallback = true;

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -363,23 +363,24 @@ export function registerPtyIpc(): void {
     'pty:startDirect',
     async (
       event,
-      args: {
-        id: string;
-        providerId: string;
-        cwd: string;
-        cols?: number;
-        rows?: number;
-        autoApprove?: boolean;
-        initialPrompt?: string;
-        resume?: boolean;
-      }
-    ) => {
+        args: {
+          id: string;
+          providerId: string;
+          cwd: string;
+          cols?: number;
+          rows?: number;
+          autoApprove?: boolean;
+          initialPrompt?: string;
+          env?: Record<string, string>;
+          resume?: boolean;
+        }
+      ) => {
       if (process.env.EMDASH_DISABLE_PTY === '1') {
         return { ok: false, error: 'PTY disabled via EMDASH_DISABLE_PTY=1' };
       }
 
       try {
-        const { id, providerId, cwd, cols, rows, autoApprove, initialPrompt, resume } = args;
+        const { id, providerId, cwd, cols, rows, autoApprove, initialPrompt, env, resume } = args;
         const existing = getPty(id);
 
         if (existing) {
@@ -396,6 +397,7 @@ export function registerPtyIpc(): void {
           rows,
           autoApprove,
           initialPrompt,
+          env,
           resume,
         });
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -75,6 +75,7 @@ export function startDirectPty(options: {
   rows?: number;
   autoApprove?: boolean;
   initialPrompt?: string;
+  env?: Record<string, string>;
   resume?: boolean;
 }): IPty | null {
   if (process.env.EMDASH_DISABLE_PTY === '1') {
@@ -89,6 +90,7 @@ export function startDirectPty(options: {
     rows = 32,
     autoApprove,
     initialPrompt,
+    env,
     resume,
   } = options;
 
@@ -148,6 +150,15 @@ export function startDirectPty(options: {
   for (const key of AGENT_ENV_VARS) {
     if (process.env[key]) {
       useEnv[key] = process.env[key];
+    }
+  }
+
+  if (env) {
+    for (const [key, value] of Object.entries(env)) {
+      if (!key.startsWith('EMDASH_')) continue;
+      if (typeof value === 'string') {
+        useEnv[key] = value;
+      }
     }
   }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2645,11 +2645,15 @@ const AppContent: React.FC = () => {
                 task={activeTask}
                 projectName={selectedProject.name}
                 projectId={selectedProject.id}
+                projectPath={selectedProject.path}
+                defaultBranch={projectDefaultBranch}
               />
             ) : (
               <ChatInterface
                 task={activeTask}
                 projectName={selectedProject.name}
+                projectPath={selectedProject.path}
+                defaultBranch={projectDefaultBranch}
                 className="min-h-0 flex-1"
                 initialAgent={activeTaskAgent || undefined}
               />

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2808,6 +2808,7 @@ const AppContent: React.FC = () => {
                     <RightSidebar
                       task={activeTask}
                       projectPath={selectedProject?.path || null}
+                      projectDefaultBranch={projectDefaultBranch}
                       className="lg:border-l-0"
                       forceBorder={showEditorMode}
                     />

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -918,14 +918,14 @@ const ChatInterface: React.FC<Props> = ({
             >
               {/* Wait for conversations to load to ensure stable terminalId */}
               {conversationsLoaded && (
-                  <TerminalPane
-                    ref={terminalRef}
-                    id={terminalId}
-                    cwd={terminalCwd}
-                    providerId={agent}
-                    autoApprove={autoApproveEnabled}
-                    env={taskEnv}
-                    keepAlive={true}
+                <TerminalPane
+                  ref={terminalRef}
+                  id={terminalId}
+                  cwd={terminalCwd}
+                  providerId={agent}
+                  autoApprove={autoApproveEnabled}
+                  env={taskEnv}
+                  keepAlive={true}
                   disableSnapshots={false}
                   onActivity={() => {
                     try {

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -19,6 +19,7 @@ import { CreateChatModal } from './CreateChatModal';
 import { DeleteChatModal } from './DeleteChatModal';
 import { type Conversation } from '../../main/services/DatabaseService';
 import { terminalSessionRegistry } from '../terminal/SessionRegistry';
+import { getTaskEnvVars } from '@shared/task/envVars';
 
 declare const window: Window & {
   electronAPI: {
@@ -29,6 +30,8 @@ declare const window: Window & {
 interface Props {
   task: Task;
   projectName: string;
+  projectPath?: string | null;
+  defaultBranch?: string | null;
   className?: string;
   initialAgent?: Agent;
 }
@@ -36,6 +39,8 @@ interface Props {
 const ChatInterface: React.FC<Props> = ({
   task,
   projectName: _projectName,
+  projectPath,
+  defaultBranch,
   className,
   initialAgent,
 }) => {
@@ -79,6 +84,17 @@ const ChatInterface: React.FC<Props> = ({
   const terminalCwd = useMemo(() => {
     return task.path;
   }, [task.path]);
+
+  const taskEnv = useMemo(() => {
+    if (!projectPath) return undefined;
+    return getTaskEnvVars({
+      taskId: task.id,
+      taskName: task.name,
+      taskPath: task.path,
+      projectPath,
+      defaultBranch: defaultBranch || undefined,
+    });
+  }, [task.id, task.name, task.path, projectPath, defaultBranch]);
 
   const installedAgents = useMemo(
     () =>
@@ -902,14 +918,14 @@ const ChatInterface: React.FC<Props> = ({
             >
               {/* Wait for conversations to load to ensure stable terminalId */}
               {conversationsLoaded && (
-                <TerminalPane
-                  ref={terminalRef}
-                  id={terminalId}
-                  cwd={terminalCwd}
-                  providerId={agent}
-                  autoApprove={autoApproveEnabled}
-                  env={undefined}
-                  keepAlive={true}
+                  <TerminalPane
+                    ref={terminalRef}
+                    id={terminalId}
+                    cwd={terminalCwd}
+                    providerId={agent}
+                    autoApprove={autoApproveEnabled}
+                    env={taskEnv}
+                    keepAlive={true}
                   disableSnapshots={false}
                   onActivity={() => {
                     try {

--- a/src/renderer/components/RightSidebar.tsx
+++ b/src/renderer/components/RightSidebar.tsx
@@ -62,16 +62,22 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
   }, []);
 
   // Detect multi-agent variants in task metadata
-  const variants: Array<{ agent: Agent; name: string; path: string }> = (() => {
-    try {
-      const v = task?.metadata?.multiAgent?.variants || [];
-      if (Array.isArray(v))
-        return v
-          .map((x: any) => ({ agent: x?.agent as Agent, name: x?.name, path: x?.path }))
+  const variants: Array<{ agent: Agent; name: string; path: string; worktreeId?: string }> =
+    (() => {
+      try {
+        const v = task?.metadata?.multiAgent?.variants || [];
+        if (Array.isArray(v))
+          return v
+          .map((x: any) => ({
+            agent: x?.agent as Agent,
+            name: x?.name,
+            path: x?.path,
+            worktreeId: x?.worktreeId,
+          }))
           .filter((x) => x?.path);
-    } catch {}
-    return [];
-  })();
+      } catch {}
+      return [];
+    })();
 
   // Helper to generate display label with instance number if needed
   const getVariantDisplayLabel = (variant: { agent: Agent; name: string }): string => {
@@ -196,6 +202,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                               agent={v.agent}
                               projectPath={projectPath || task?.path}
                               defaultBranch={projectDefaultBranch || undefined}
+                              portSeed={v.worktreeId}
                               className="min-h-[200px]"
                             />
                           </TaskScopeProvider>
@@ -224,6 +231,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                         agent={v.agent}
                         projectPath={projectPath || task?.path}
                         defaultBranch={projectDefaultBranch || undefined}
+                        portSeed={v.worktreeId}
                         className="min-h-0 flex-1"
                       />
                     </>

--- a/src/renderer/components/RightSidebar.tsx
+++ b/src/renderer/components/RightSidebar.tsx
@@ -23,12 +23,14 @@ export interface RightSidebarTask {
 interface RightSidebarProps extends React.HTMLAttributes<HTMLElement> {
   task: RightSidebarTask | null;
   projectPath?: string | null;
+  projectDefaultBranch?: string | null;
   forceBorder?: boolean;
 }
 
 const RightSidebar: React.FC<RightSidebarProps> = ({
   task,
   projectPath,
+  projectDefaultBranch,
   className,
   forceBorder = false,
   ...rest
@@ -193,6 +195,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                               }}
                               agent={v.agent}
                               projectPath={projectPath || task?.path}
+                              defaultBranch={projectDefaultBranch || undefined}
                               className="min-h-[200px]"
                             />
                           </TaskScopeProvider>
@@ -220,6 +223,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                         task={derived}
                         agent={v.agent}
                         projectPath={projectPath || task?.path}
+                        defaultBranch={projectDefaultBranch || undefined}
                         className="min-h-0 flex-1"
                       />
                     </>
@@ -232,6 +236,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                     task={task}
                     agent={task.agentId as Agent}
                     projectPath={projectPath || task?.path}
+                    defaultBranch={projectDefaultBranch || undefined}
                     className="min-h-0 flex-1"
                   />
                 </>
@@ -251,6 +256,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                     task={null}
                     agent={undefined}
                     projectPath={projectPath || undefined}
+                    defaultBranch={projectDefaultBranch || undefined}
                     className="h-1/2 min-h-0"
                   />
                 </>

--- a/src/renderer/components/RightSidebar.tsx
+++ b/src/renderer/components/RightSidebar.tsx
@@ -68,13 +68,13 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
         const v = task?.metadata?.multiAgent?.variants || [];
         if (Array.isArray(v))
           return v
-          .map((x: any) => ({
-            agent: x?.agent as Agent,
-            name: x?.name,
-            path: x?.path,
-            worktreeId: x?.worktreeId,
-          }))
-          .filter((x) => x?.path);
+            .map((x: any) => ({
+              agent: x?.agent as Agent,
+              name: x?.name,
+              path: x?.path,
+              worktreeId: x?.worktreeId,
+            }))
+            .filter((x) => x?.path);
       } catch {}
       return [];
     })();

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -95,7 +95,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
       defaultBranch,
       portSeed,
     });
-  }, [task, projectPath, defaultBranch, portSeed]);
+  }, [task?.id, task?.name, task?.path, projectPath, defaultBranch, portSeed]);
 
   // Run setup script when a task terminal becomes ready (only once per terminal)
   const handleTerminalReady = useCallback((terminalId: string) => {

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -476,15 +476,15 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                 isActive ? 'opacity-100' : 'pointer-events-none opacity-0'
               )}
             >
-                <TerminalPane
-                  id={terminal.id}
-                  cwd={terminal.cwd || task?.path}
-                  env={taskEnv}
-                  variant={
-                    effectiveTheme === 'dark' || effectiveTheme === 'dark-black' ? 'dark' : 'light'
-                  }
-                  themeOverride={themeOverride}
-                  className="h-full w-full"
+              <TerminalPane
+                id={terminal.id}
+                cwd={terminal.cwd || task?.path}
+                env={taskEnv}
+                variant={
+                  effectiveTheme === 'dark' || effectiveTheme === 'dark-black' ? 'dark' : 'light'
+                }
+                themeOverride={themeOverride}
+                className="h-full w-full"
                 keepAlive
                 onStartSuccess={terminalReadyCallbacks.get(terminal.id)}
               />

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -43,6 +43,7 @@ interface Props {
   className?: string;
   projectPath?: string;
   defaultBranch?: string;
+  portSeed?: string;
 }
 
 const TaskTerminalPanelComponent: React.FC<Props> = ({
@@ -51,6 +52,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   className,
   projectPath,
   defaultBranch,
+  portSeed,
 }) => {
   const { effectiveTheme } = useTheme();
   // Use path in the key to differentiate multi-agent variants that share the same task.id
@@ -91,8 +93,9 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
       taskPath: task.path,
       projectPath,
       defaultBranch,
+      portSeed,
     });
-  }, [task, projectPath, defaultBranch]);
+  }, [task, projectPath, defaultBranch, portSeed]);
 
   // Run setup script when a task terminal becomes ready (only once per terminal)
   const handleTerminalReady = useCallback((terminalId: string) => {

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -542,6 +542,7 @@ export class TerminalSessionManager {
             rows: initialSize.rows,
             autoApprove,
             initialPrompt,
+            env,
             resume: hasExistingSession,
           })
         : window.electronAPI.ptyStart({

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -293,6 +293,7 @@ declare global {
         rows?: number;
         autoApprove?: boolean;
         initialPrompt?: string;
+        env?: Record<string, string>;
         resume?: boolean;
       }) => Promise<{ ok: boolean; reused?: boolean; error?: string }>;
       ptyInput: (args: { id: string; data: string }) => void;
@@ -968,6 +969,7 @@ export interface ElectronAPI {
     rows?: number;
     autoApprove?: boolean;
     initialPrompt?: string;
+    env?: Record<string, string>;
     resume?: boolean;
   }) => Promise<{ ok: boolean; reused?: boolean; error?: string }>;
   ptyInput: (args: { id: string; data: string }) => void;

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -27,6 +27,17 @@ declare global {
         initialPrompt?: string;
         skipResume?: boolean;
       }) => Promise<{ ok: boolean; error?: string }>;
+      ptyStartDirect: (opts: {
+        id: string;
+        providerId: string;
+        cwd: string;
+        cols?: number;
+        rows?: number;
+        autoApprove?: boolean;
+        initialPrompt?: string;
+        env?: Record<string, string>;
+        resume?: boolean;
+      }) => Promise<{ ok: boolean; reused?: boolean; error?: string }>;
       ptyInput: (args: { id: string; data: string }) => void;
       ptyResize: (args: { id: string; cols: number; rows: number }) => void;
       ptyKill: (id: string) => void;

--- a/src/shared/task/envVars.ts
+++ b/src/shared/task/envVars.ts
@@ -1,0 +1,36 @@
+export interface TaskEnvContext {
+  taskId: string;
+  taskName: string;
+  taskPath: string;
+  projectPath: string;
+  defaultBranch?: string;
+}
+
+export function getTaskEnvVars(ctx: TaskEnvContext): Record<string, string> {
+  const taskName = slugify(ctx.taskName) || 'task';
+  return {
+    EMDASH_TASK_ID: ctx.taskId,
+    EMDASH_TASK_NAME: taskName,
+    EMDASH_TASK_PATH: ctx.taskPath,
+    EMDASH_ROOT_PATH: ctx.projectPath,
+    EMDASH_DEFAULT_BRANCH: ctx.defaultBranch || 'main',
+    EMDASH_PORT: String(getBasePort(ctx.taskId)),
+  };
+}
+
+function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}
+
+function getBasePort(taskId: string): number {
+  let hash = 0;
+  for (let i = 0; i < taskId.length; i += 1) {
+    hash = (hash << 5) - hash + taskId.charCodeAt(i);
+    hash |= 0;
+  }
+  return 50000 + (Math.abs(hash) % 1000) * 10;
+}

--- a/src/shared/task/envVars.ts
+++ b/src/shared/task/envVars.ts
@@ -4,17 +4,19 @@ export interface TaskEnvContext {
   taskPath: string;
   projectPath: string;
   defaultBranch?: string;
+  portSeed?: string;
 }
 
 export function getTaskEnvVars(ctx: TaskEnvContext): Record<string, string> {
   const taskName = slugify(ctx.taskName) || 'task';
+  const portSeed = ctx.portSeed || ctx.taskPath || ctx.taskId;
   return {
     EMDASH_TASK_ID: ctx.taskId,
     EMDASH_TASK_NAME: taskName,
     EMDASH_TASK_PATH: ctx.taskPath,
     EMDASH_ROOT_PATH: ctx.projectPath,
     EMDASH_DEFAULT_BRANCH: ctx.defaultBranch || 'main',
-    EMDASH_PORT: String(getBasePort(ctx.taskId)),
+    EMDASH_PORT: String(getBasePort(portSeed)),
   };
 }
 
@@ -26,10 +28,10 @@ function slugify(value: string): string {
     .replace(/^-|-$/g, '');
 }
 
-function getBasePort(taskId: string): number {
+function getBasePort(seed: string): number {
   let hash = 0;
-  for (let i = 0; i < taskId.length; i += 1) {
-    hash = (hash << 5) - hash + taskId.charCodeAt(i);
+  for (let i = 0; i < seed.length; i += 1) {
+    hash = (hash << 5) - hash + seed.charCodeAt(i);
     hash |= 0;
   }
   return 50000 + (Math.abs(hash) % 1000) * 10;


### PR DESCRIPTION
## Summary
- add task env helper and inject EMDASH_* vars into task terminals and direct-spawn agents
- seed EMDASH_PORT by worktree identity to avoid collisions
- document task env vars with usage examples

## Testing
- npm run lint
- npm run type-check
- npx vitest run
- create a task and run  in the task terminal
- create a multi-agent task, run  in each variant terminal and confirm same task id, different ports
- open an agent terminal (direct spawn), exit the CLI to shell, run  to confirm env vars

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches terminal/PTTY spawning paths and IPC boundaries; while env injection is gated to `EMDASH_*`, regressions could affect agent/terminal startup behavior across single- and multi-agent tasks.
> 
> **Overview**
> Adds a shared `getTaskEnvVars` helper that generates `EMDASH_*` task context variables (including a deterministic `EMDASH_PORT` range) and wires it into task terminals across the UI, including multi-agent variants via a `portSeed` to reduce port collisions.
> 
> Extends the direct PTY spawn IPC/API to accept an `env` payload and updates the main-process direct-spawn path to merge only `EMDASH_*` keys into the minimal CLI environment. Updates docs to describe the new task env vars and provide port-aware setup and `docker-compose` examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 8b375f1846853a3f7a43b72a99e0acdf960d90a6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->