### PR TITLE
chore: remove unused untracked constant

### DIFF
--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -87,8 +87,6 @@ export async function getStatus(taskPath: string): Promise<GitChange[]> {
     .map((l) => l.replace(/\r$/, ''))
     .filter((l) => l.length > 0);
 
-  const nullPath = process.platform === 'win32' ? 'NUL' : '/dev/null';
-
   for (const line of statusLines) {
     const statusCode = line.substring(0, 2);
     let filePath = line.substring(3);


### PR DESCRIPTION
## Summary
- remove an unused `nullPath` constant in `GitService.getStatus`
- keep the best-effort untracked-counts note aligned with current async count behavior

## Context
Upstream `main` replaced the earlier `git diff --no-index` path with capped async reads for untracked files, so the original behavior change is already present. This PR now only contains cleanup/documentation aligned with that implementation.

## Testing
- `npm run format`
- `npm run lint` (warnings only, existing baseline)
- `npm run type-check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure cleanup in status parsing with no behavioral changes to git operations or data handling.
> 
> **Overview**
> Cleans up `GitService.getStatus` by removing an unused `nullPath` constant related to untracked-file handling, leaving the current best-effort async counting behavior unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c6c69a228f86cb10bb5fde80eef971106f1c0cf0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

