### PR TITLE
Cache app version in IPC

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -64,11 +64,10 @@ const getCachedAppVersion = (): Promise<string> => {
   }
 
   if (!cachedAppVersionPromise) {
-    cachedAppVersionPromise = resolveAppVersion()
-      .then((version) => {
-        cachedAppVersion = version;
-        return version;
-      });
+    cachedAppVersionPromise = resolveAppVersion().then((version) => {
+      cachedAppVersion = version;
+      return version;
+    });
   }
 
   return cachedAppVersionPromise;


### PR DESCRIPTION
## Summary
- cache app version lookups to avoid repeated disk reads
- switch package.json reads to async while preserving existing fallbacks

## Context
Clean extraction of the appIpc change from #736. Thanks @cschubiner.

## Testing
- not run (IPC change only)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized IPC metadata change; primary risk is returning `unknown`/different version strings in edge dev/packaged path scenarios.
> 
> **Overview**
> `app:getAppVersion` now resolves the app version asynchronously by scanning likely `package.json` locations and **caches the result** (including in-flight requests) to avoid repeated disk reads.
> 
> Replaces synchronous `readFileSync` usage and hardcoded fallback versions with an `UNKNOWN_VERSION` fallback, and pre-warms the cache during `registerAppIpc` startup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3538ffa35b3f049b8403ba142a8c333697b1859a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>3538ffa</u></sup><!-- /BUGBOT_STATUS -->