### PR TITLE
Move fs list to worker thread

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -144,7 +144,10 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('lifecycle:getSetupScript', args),
 
   // Filesystem helpers
-  fsList: (root: string, opts?: { includeDirs?: boolean; maxEntries?: number }) =>
+  fsList: (
+    root: string,
+    opts?: { includeDirs?: boolean; maxEntries?: number; timeBudgetMs?: number }
+  ) =>
     ipcRenderer.invoke('fs:list', { root, ...(opts || {}) }),
   fsRead: (root: string, relPath: string, maxBytes?: number) =>
     ipcRenderer.invoke('fs:read', { root, relPath, maxBytes }),
@@ -590,11 +593,15 @@ export interface ElectronAPI {
   // Filesystem helpers
   fsList: (
     root: string,
-    opts?: { includeDirs?: boolean; maxEntries?: number }
+    opts?: { includeDirs?: boolean; maxEntries?: number; timeBudgetMs?: number }
   ) => Promise<{
     success: boolean;
     items?: Array<{ path: string; type: 'file' | 'dir' }>;
     error?: string;
+    canceled?: boolean;
+    truncated?: boolean;
+    reason?: string;
+    durationMs?: number;
   }>;
   fsRead: (
     root: string,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -147,8 +147,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   fsList: (
     root: string,
     opts?: { includeDirs?: boolean; maxEntries?: number; timeBudgetMs?: number }
-  ) =>
-    ipcRenderer.invoke('fs:list', { root, ...(opts || {}) }),
+  ) => ipcRenderer.invoke('fs:list', { root, ...(opts || {}) }),
   fsRead: (root: string, relPath: string, maxBytes?: number) =>
     ipcRenderer.invoke('fs:read', { root, relPath, maxBytes }),
   fsReadImage: (root: string, relPath: string) =>

--- a/src/main/services/fsIpc.ts
+++ b/src/main/services/fsIpc.ts
@@ -257,7 +257,7 @@ export function registerFsIpc(): void {
   const SEARCH_PREVIEW_CONTEXT_LENGTH = 30;
   const DEFAULT_MAX_SEARCH_RESULTS = 100; // Increased back for better coverage
   const MAX_FILE_SIZE = 2 * 1024 * 1024; // 2MB max file size
-  const MAX_FILES_TO_SEARCH = 5000; // Increased to search more files
+  const MAX_SEARCH_FILES = 5000; // Increased to search more files
   const BINARY_CHECK_BYTES = 512; // Check first 512 bytes for binary content (faster)
 
   // Extended ignore patterns for performance
@@ -420,7 +420,7 @@ export function registerFsIpc(): void {
 
         // Optimized async file search
         const searchInFile = async (filePath: string): Promise<void> => {
-          if (totalMatches >= maxResults || filesSearched >= MAX_FILES_TO_SEARCH) return;
+          if (totalMatches >= maxResults || filesSearched >= MAX_SEARCH_FILES) return;
 
           try {
             filesSearched++;
@@ -485,13 +485,13 @@ export function registerFsIpc(): void {
 
         // Collect files first, then search in parallel
         const collectFiles = async (dirPath: string, files: string[] = []): Promise<string[]> => {
-          if (files.length >= MAX_FILES_TO_SEARCH) return files;
+          if (files.length >= MAX_SEARCH_FILES) return files;
 
           try {
             const entries = await fs.promises.readdir(dirPath, { withFileTypes: true });
 
             for (const entry of entries) {
-              if (files.length >= MAX_FILES_TO_SEARCH) break;
+              if (files.length >= MAX_SEARCH_FILES) break;
 
               const fullPath = path.join(dirPath, entry.name);
 

--- a/src/main/services/fsIpc.ts
+++ b/src/main/services/fsIpc.ts
@@ -3,6 +3,8 @@ import * as fs from 'fs';
 import * as path from 'path';
 import { Worker } from 'worker_threads';
 import { FsListWorkerResponse } from '../types/fsListWorker';
+import { DEFAULT_IGNORES } from '../utils/fsIgnores';
+import { safeStat } from '../utils/safeStat';
 
 const DEFAULT_EMDASH_CONFIG = `{
   "preservePatterns": [
@@ -47,14 +49,6 @@ const ALLOWED_IMAGE_EXTENSIONS = new Set<string>([
   '.svg',
 ]);
 const DEFAULT_ATTACHMENTS_SUBDIR = 'attachments' as const;
-
-function safeStat(p: string): fs.Stats | null {
-  try {
-    return fs.statSync(p);
-  } catch {
-    return null;
-  }
-}
 
 export function registerFsIpc(): void {
   function emitPlanEvent(payload: any) {

--- a/src/main/types/fsListWorker.ts
+++ b/src/main/types/fsListWorker.ts
@@ -1,0 +1,19 @@
+export type FsListItem = {
+  path: string;
+  type: 'file' | 'dir';
+};
+
+export type FsListWorkerResponse =
+  | {
+      taskId: number;
+      ok: true;
+      items: FsListItem[];
+      truncated: boolean;
+      reason?: 'maxEntries' | 'timeBudget';
+      durationMs: number;
+    }
+  | {
+      taskId: number;
+      ok: false;
+      error: string;
+    };

--- a/src/main/utils/fsIgnores.ts
+++ b/src/main/utils/fsIgnores.ts
@@ -1,0 +1,12 @@
+export const DEFAULT_IGNORES = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  '.next',
+  '.nuxt',
+  '.cache',
+  'coverage',
+  '.DS_Store',
+]);

--- a/src/main/utils/safeStat.ts
+++ b/src/main/utils/safeStat.ts
@@ -1,0 +1,9 @@
+import * as fs from 'fs';
+
+export function safeStat(pathname: string): fs.Stats | null {
+  try {
+    return fs.statSync(pathname);
+  } catch {
+    return null;
+  }
+}

--- a/src/main/workers/fsListWorker.ts
+++ b/src/main/workers/fsListWorker.ts
@@ -1,0 +1,151 @@
+import { parentPort } from 'worker_threads';
+import * as fs from 'fs';
+import * as path from 'path';
+
+type Item = {
+  path: string;
+  type: 'file' | 'dir';
+};
+
+type ListWorkerRequest = {
+  taskId: number;
+  root: string;
+  includeDirs: boolean;
+  maxEntries: number;
+  timeBudgetMs: number;
+  batchSize: number;
+};
+
+type ListWorkerResponse =
+  | {
+      taskId: number;
+      ok: true;
+      items: Item[];
+      truncated: boolean;
+      reason?: 'maxEntries' | 'timeBudget';
+      durationMs: number;
+    }
+  | {
+      taskId: number;
+      ok: false;
+      error: string;
+    };
+
+const DEFAULT_IGNORES = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'out',
+  '.next',
+  '.nuxt',
+  '.cache',
+  'coverage',
+  '.DS_Store',
+]);
+
+function safeStat(p: string): fs.Stats | null {
+  try {
+    return fs.statSync(p);
+  } catch {
+    return null;
+  }
+}
+
+const yieldImmediate = () => new Promise<void>((resolve) => setImmediate(resolve));
+
+async function listFiles(request: ListWorkerRequest): Promise<ListWorkerResponse> {
+  const items: Item[] = [];
+  const stack: string[] = ['.'];
+  const start = Date.now();
+  const deadline = start + request.timeBudgetMs;
+  let truncated = false;
+  let reason: 'maxEntries' | 'timeBudget' | undefined;
+  let visited = 0;
+
+  while (stack.length > 0) {
+    if (items.length >= request.maxEntries) {
+      truncated = true;
+      reason = 'maxEntries';
+      break;
+    }
+    if (Date.now() >= deadline) {
+      truncated = true;
+      reason = 'timeBudget';
+      break;
+    }
+
+    const rel = stack.pop() as string;
+    const abs = path.join(request.root, rel);
+
+    const stat = safeStat(abs);
+    if (!stat) continue;
+
+    if (stat.isDirectory()) {
+      const name = path.basename(abs);
+      if (rel !== '.' && DEFAULT_IGNORES.has(name)) continue;
+
+      if (rel !== '.' && request.includeDirs) {
+        items.push({ path: rel, type: 'dir' });
+        if (items.length >= request.maxEntries) {
+          truncated = true;
+          reason = 'maxEntries';
+          break;
+        }
+      }
+
+      let entries: string[] = [];
+      try {
+        entries = fs.readdirSync(abs);
+      } catch {
+        continue;
+      }
+
+      for (let i = entries.length - 1; i >= 0; i--) {
+        const entry = entries[i];
+        if (DEFAULT_IGNORES.has(entry)) continue;
+        const nextRel = rel === '.' ? entry : path.join(rel, entry);
+        stack.push(nextRel);
+      }
+    } else if (stat.isFile()) {
+      items.push({ path: rel, type: 'file' });
+      if (items.length >= request.maxEntries) {
+        truncated = true;
+        reason = 'maxEntries';
+        break;
+      }
+    }
+
+    visited += 1;
+    if (visited % request.batchSize === 0) {
+      await yieldImmediate();
+    }
+  }
+
+  return {
+    taskId: request.taskId,
+    ok: true,
+    items,
+    truncated,
+    reason,
+    durationMs: Date.now() - start,
+  };
+}
+
+if (!parentPort) {
+  throw new Error('fsListWorker must be run as a worker thread');
+}
+
+parentPort.on('message', async (request: ListWorkerRequest) => {
+  try {
+    const result = await listFiles(request);
+    parentPort?.postMessage(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    parentPort?.postMessage({
+      taskId: request.taskId,
+      ok: false,
+      error: message,
+    });
+  }
+});

--- a/src/main/workers/fsListWorker.ts
+++ b/src/main/workers/fsListWorker.ts
@@ -1,11 +1,7 @@
 import { parentPort } from 'worker_threads';
 import * as fs from 'fs';
 import * as path from 'path';
-
-type Item = {
-  path: string;
-  type: 'file' | 'dir';
-};
+import { FsListItem, FsListWorkerResponse } from '../types/fsListWorker';
 
 type ListWorkerRequest = {
   taskId: number;
@@ -15,21 +11,6 @@ type ListWorkerRequest = {
   timeBudgetMs: number;
   batchSize: number;
 };
-
-type ListWorkerResponse =
-  | {
-      taskId: number;
-      ok: true;
-      items: Item[];
-      truncated: boolean;
-      reason?: 'maxEntries' | 'timeBudget';
-      durationMs: number;
-    }
-  | {
-      taskId: number;
-      ok: false;
-      error: string;
-    };
 
 const DEFAULT_IGNORES = new Set([
   '.git',
@@ -54,8 +35,8 @@ function safeStat(p: string): fs.Stats | null {
 
 const yieldImmediate = () => new Promise<void>((resolve) => setImmediate(resolve));
 
-async function listFiles(request: ListWorkerRequest): Promise<ListWorkerResponse> {
-  const items: Item[] = [];
+async function listFiles(request: ListWorkerRequest): Promise<FsListWorkerResponse> {
+  const items: FsListItem[] = [];
   const stack: string[] = ['.'];
   const start = Date.now();
   const deadline = start + request.timeBudgetMs;

--- a/src/main/workers/fsListWorker.ts
+++ b/src/main/workers/fsListWorker.ts
@@ -2,6 +2,8 @@ import { parentPort } from 'worker_threads';
 import * as fs from 'fs';
 import * as path from 'path';
 import { FsListItem, FsListWorkerResponse } from '../types/fsListWorker';
+import { DEFAULT_IGNORES } from '../utils/fsIgnores';
+import { safeStat } from '../utils/safeStat';
 
 type ListWorkerRequest = {
   taskId: number;
@@ -11,27 +13,6 @@ type ListWorkerRequest = {
   timeBudgetMs: number;
   batchSize: number;
 };
-
-const DEFAULT_IGNORES = new Set([
-  '.git',
-  'node_modules',
-  'dist',
-  'build',
-  'out',
-  '.next',
-  '.nuxt',
-  '.cache',
-  'coverage',
-  '.DS_Store',
-]);
-
-function safeStat(p: string): fs.Stats | null {
-  try {
-    return fs.statSync(p);
-  } catch {
-    return null;
-  }
-}
 
 const yieldImmediate = () => new Promise<void>((resolve) => setImmediate(resolve));
 

--- a/src/renderer/components/FileExplorer/FileTree.tsx
+++ b/src/renderer/components/FileExplorer/FileTree.tsx
@@ -326,6 +326,10 @@ export const FileTree: React.FC<FileTreeProps> = ({
       try {
         const result = await window.electronAPI.fsList(rootPath, { includeDirs: true });
 
+        if (result.canceled) {
+          return;
+        }
+
         if (!result.success || !result.items) {
           throw new Error(result.error || 'Failed to load files');
         }

--- a/src/renderer/hooks/useFileIndex.ts
+++ b/src/renderer/hooks/useFileIndex.ts
@@ -7,13 +7,13 @@ export function useFileIndex(rootPath: string | undefined) {
   const [loadedFor, setLoadedFor] = useState<string | undefined>(undefined);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const loadRequestedRef = useRef(false);
+  const loadRequestedRef = useRef<string | null>(null);
 
   useEffect(() => {
     if (!rootPath) return;
     // Only load once per rootPath (lazy); can be reloaded manually
-    if (loadedFor === rootPath || loadRequestedRef.current) return;
-    loadRequestedRef.current = true;
+    if (loadedFor === rootPath || loadRequestedRef.current === rootPath) return;
+    loadRequestedRef.current = rootPath;
     setLoading(true);
     setError(null);
     (async () => {
@@ -23,6 +23,9 @@ export function useFileIndex(rootPath: string | undefined) {
           maxEntries: 5000,
         });
         if (res.canceled) {
+          if (loadRequestedRef.current === rootPath) {
+            loadRequestedRef.current = null;
+          }
           return;
         }
         if (res.success && res.items) {

--- a/src/renderer/hooks/useFileIndex.ts
+++ b/src/renderer/hooks/useFileIndex.ts
@@ -22,6 +22,9 @@ export function useFileIndex(rootPath: string | undefined) {
           includeDirs: true,
           maxEntries: 5000,
         });
+        if (res.canceled) {
+          return;
+        }
         if (res.success && res.items) {
           setItems(res.items);
           setLoadedFor(rootPath);
@@ -45,6 +48,9 @@ export function useFileIndex(rootPath: string | undefined) {
         includeDirs: true,
         maxEntries: 5000,
       });
+      if (res.canceled) {
+        return;
+      }
       if (res.success && res.items) {
         setItems(res.items);
         setLoadedFor(rootPath);

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -601,11 +601,15 @@ declare global {
       // Filesystem helpers
       fsList: (
         root: string,
-        opts?: { includeDirs?: boolean; maxEntries?: number }
+        opts?: { includeDirs?: boolean; maxEntries?: number; timeBudgetMs?: number }
       ) => Promise<{
         success: boolean;
         items?: Array<{ path: string; type: 'file' | 'dir' }>;
         error?: string;
+        canceled?: boolean;
+        truncated?: boolean;
+        reason?: string;
+        durationMs?: number;
       }>;
       fsRead: (
         root: string,
@@ -1158,11 +1162,15 @@ export interface ElectronAPI {
   // Filesystem
   fsList: (
     root: string,
-    opts?: { includeDirs?: boolean; maxEntries?: number }
+    opts?: { includeDirs?: boolean; maxEntries?: number; timeBudgetMs?: number }
   ) => Promise<{
     success: boolean;
     items?: Array<{ path: string; type: 'file' | 'dir' }>;
     error?: string;
+    canceled?: boolean;
+    truncated?: boolean;
+    reason?: string;
+    durationMs?: number;
   }>;
   fsRead: (
     root: string,

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -156,11 +156,15 @@ declare global {
       // Filesystem
       fsList: (
         root: string,
-        opts?: { includeDirs?: boolean; maxEntries?: number }
+        opts?: { includeDirs?: boolean; maxEntries?: number; timeBudgetMs?: number }
       ) => Promise<{
         success: boolean;
         items?: Array<{ path: string; type: 'file' | 'dir' }>;
         error?: string;
+        canceled?: boolean;
+        truncated?: boolean;
+        reason?: string;
+        durationMs?: number;
       }>;
       fsRead: (
         root: string,


### PR DESCRIPTION
## Summary
- run fs:list in a worker thread with time budgets and cancellation
- return truncated/canceled metadata to the renderer

## Context
Clean extraction of the fs:list worker change from #737. Thanks @cschubiner.

## Testing
- not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the `fs:list` IPC implementation and response contract, introducing worker-thread execution and cancellation semantics that could affect file browsing behavior and edge cases under load.
> 
> **Overview**
> Moves `fs:list` off the Electron main thread by running directory traversal in a dedicated worker with a configurable `timeBudgetMs`, plus per-sender cancellation of in-flight requests.
> 
> Extends the `fsList` API to report `canceled`, `truncated`, `reason`, and `durationMs`, and updates renderer callers/types (notably `FileTree` and `useFileIndex`) to ignore canceled/stale responses. Also factors shared helpers into new `DEFAULT_IGNORES` and `safeStat` utilities and renames the search file-limit constant to avoid collision.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ab750fe95dca0cf76eb7d7e8d2ced08a7ac7f3d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->