### PR TITLE
Async worktree cleanup

### DIFF
--- a/src/main/services/WorktreeService.ts
+++ b/src/main/services/WorktreeService.ts
@@ -70,9 +70,7 @@ export class WorktreeService {
     const normalizedProjectPath = path.resolve(projectPath);
 
     if (normalizedPathToRemove === normalizedProjectPath) {
-      log.error(
-        `CRITICAL: Prevented filesystem removal of main repository! Path: ${pathToRemove}`
-      );
+      log.error(`CRITICAL: Prevented filesystem removal of main repository! Path: ${pathToRemove}`);
       return;
     }
 


### PR DESCRIPTION
## Summary
- move worktree directory cleanup to a background best-effort helper

## Context
Clean extraction of the worktree cleanup change from #739. Thanks @cschubiner.

## Testing
- not run

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes deletion/error-handling behavior for worktree directories; failures are now non-fatal and may leave stale directories behind, but adds safety guards to avoid deleting the main repo.
> 
> **Overview**
> Makes worktree filesystem deletion *asynchronous and best-effort* by extracting the directory removal logic into a new `cleanupWorktreeDirectory()` helper and calling it via `void` from `removeWorktree` after `git worktree remove/prune`.
> 
> The cleanup now logs and returns on safety checks/failures (rather than throwing), and retains permission-fix retries (Windows `attrib` / POSIX `chmod`) while treating all errors as non-fatal background cleanup.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3f69dc073eb648b5bae5ae92cdacf8b309881066. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>3f69dc0</u></sup><!-- /BUGBOT_STATUS -->