### PR TITLE
Start terminal snapshot timer on attach

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -172,10 +172,6 @@ export class TerminalSessionManager {
     );
 
     void this.initializeTerminal();
-    // Only start snapshot timer if snapshots are enabled (main chats only)
-    if (!this.options.disableSnapshots) {
-      this.startSnapshotTimer();
-    }
   }
 
   attach(container: HTMLElement) {
@@ -218,6 +214,11 @@ export class TerminalSessionManager {
         }
       });
     });
+
+    // Only start snapshot timer if snapshots are enabled (main chats only)
+    if (!this.options.disableSnapshots) {
+      this.startSnapshotTimer();
+    }
   }
 
   detach() {
@@ -228,6 +229,7 @@ export class TerminalSessionManager {
       this.resizeObserver = null;
       ensureTerminalHost().appendChild(this.container);
       this.attachedContainer = null;
+      this.stopSnapshotTimer();
       // Only capture snapshot on detach if snapshots are enabled
       if (!this.options.disableSnapshots) {
         void this.captureSnapshot('detach');


### PR DESCRIPTION
Clean extraction of #742.\n\n- start snapshot timer when terminal is attached\n- stop snapshot timer on detach to avoid background intervals\n\nRefs #742 (cschubiner).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small lifecycle change limited to snapshot timer start/stop behavior; primary risk is missed or extra snapshots if attach/detach sequencing differs from expectations.
> 
> **Overview**
> Moves terminal snapshot interval management from construction time to UI lifecycle: the snapshot timer now starts when a `TerminalSessionManager` is `attach`ed (when snapshots are enabled) and is stopped on `detach` (and still on `dispose`).
> 
> This prevents snapshot intervals from running while a terminal is not mounted, while still capturing a snapshot on detach when enabled.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 2e34a931e8ba34d6ceb450b491fdca97fad25ce8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- BUGBOT_STATUS --><sup><a href="https://cursor.com/dashboard?tab=bugbot">Cursor Bugbot</a> reviewed your changes and found no issues for commit <u>2e34a93</u></sup><!-- /BUGBOT_STATUS -->