### PR TITLE
Reduce git status polling when inactive

### DIFF
--- a/src/renderer/hooks/useFileChanges.ts
+++ b/src/renderer/hooks/useFileChanges.ts
@@ -129,9 +129,7 @@ export function useFileChanges(taskPath?: string, options: UseFileChangesOptions
   const clearIdleHandle = useCallback(() => {
     if (idleHandleRef.current === null) return;
     if (idleHandleModeRef.current === 'idle') {
-      const cancelIdle = (window as any).cancelIdleCallback as
-        | ((id: number) => void)
-        | undefined;
+      const cancelIdle = (window as any).cancelIdleCallback as ((id: number) => void) | undefined;
       cancelIdle?.(idleHandleRef.current);
     } else {
       clearTimeout(idleHandleRef.current);

--- a/src/renderer/hooks/useTaskChanges.ts
+++ b/src/renderer/hooks/useTaskChanges.ts
@@ -144,9 +144,7 @@ export function useTaskChanges(
   const clearIdleHandle = useCallback(() => {
     if (idleHandleRef.current === null) return;
     if (idleHandleModeRef.current === 'idle') {
-      const cancelIdle = (window as any).cancelIdleCallback as
-        | ((id: number) => void)
-        | undefined;
+      const cancelIdle = (window as any).cancelIdleCallback as ((id: number) => void) | undefined;
       cancelIdle?.(idleHandleRef.current);
     } else {
       clearTimeout(idleHandleRef.current);

--- a/src/renderer/hooks/useTaskChanges.ts
+++ b/src/renderer/hooks/useTaskChanges.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 export interface TaskChange {
   path: string;
@@ -17,7 +17,16 @@ export interface TaskChanges {
   error?: string;
 }
 
-export function useTaskChanges(taskPath: string, taskId: string) {
+interface UseTaskChangesOptions {
+  isActive?: boolean;
+  idleIntervalMs?: number;
+}
+
+export function useTaskChanges(
+  taskPath: string,
+  taskId: string,
+  options: UseTaskChangesOptions = {}
+) {
   const [changes, setChanges] = useState<TaskChanges>({
     taskId,
     changes: [],
@@ -25,15 +34,70 @@ export function useTaskChanges(taskPath: string, taskId: string) {
     totalDeletions: 0,
     isLoading: true,
   });
+  const [isDocumentVisible, setIsDocumentVisible] = useState(() => {
+    if (typeof document === 'undefined') return true;
+    return document.visibilityState === 'visible';
+  });
+  const [isWindowFocused, setIsWindowFocused] = useState(() => {
+    if (typeof document === 'undefined') return true;
+    return document.hasFocus();
+  });
+
+  const { isActive = true, idleIntervalMs = 60000 } = options;
+  const taskPathRef = useRef(taskPath);
+  const inFlightRef = useRef(false);
+  const hasLoadedRef = useRef(false);
+  const shouldPollRef = useRef(false);
+  const idleHandleRef = useRef<number | null>(null);
+  const idleHandleModeRef = useRef<'idle' | 'timeout' | null>(null);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    mountedRef.current = true;
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
+
+  useEffect(() => {
+    taskPathRef.current = taskPath;
+    hasLoadedRef.current = false;
+  }, [taskPath]);
+
+  useEffect(() => {
+    if (typeof document === 'undefined' || typeof window === 'undefined') return;
+
+    const handleVisibility = () => {
+      setIsDocumentVisible(document.visibilityState === 'visible');
+    };
+    const handleFocus = () => setIsWindowFocused(true);
+    const handleBlur = () => setIsWindowFocused(false);
+
+    document.addEventListener('visibilitychange', handleVisibility);
+    window.addEventListener('focus', handleFocus);
+    window.addEventListener('blur', handleBlur);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility);
+      window.removeEventListener('focus', handleFocus);
+      window.removeEventListener('blur', handleBlur);
+    };
+  }, []);
 
   const fetchChanges = useCallback(
     async (isInitialLoad = false) => {
+      const currentPath = taskPathRef.current;
+      if (!currentPath || inFlightRef.current) return;
+
+      inFlightRef.current = true;
       try {
         if (isInitialLoad) {
           setChanges((prev) => ({ ...prev, isLoading: true, error: undefined }));
         }
 
-        const result = await window.electronAPI.getGitStatus(taskPath);
+        const result = await window.electronAPI.getGitStatus(currentPath);
+
+        if (!mountedRef.current) return;
 
         if (result.success && result.changes) {
           const filtered = result.changes.filter(
@@ -60,6 +124,7 @@ export function useTaskChanges(taskPath: string, taskId: string) {
           });
         }
       } catch (error) {
+        if (!mountedRef.current) return;
         setChanges({
           taskId,
           changes: [],
@@ -68,21 +133,70 @@ export function useTaskChanges(taskPath: string, taskId: string) {
           isLoading: false,
           error: error instanceof Error ? error.message : 'Unknown error',
         });
+      } finally {
+        hasLoadedRef.current = true;
+        inFlightRef.current = false;
       }
     },
-    [taskPath, taskId]
+    [taskId]
   );
 
-  // eslint-disable-next-line react-hooks/set-state-in-effect
-  useEffect(() => {
-    void fetchChanges(true);
+  const clearIdleHandle = useCallback(() => {
+    if (idleHandleRef.current === null) return;
+    if (idleHandleModeRef.current === 'idle') {
+      const cancelIdle = (window as any).cancelIdleCallback as
+        | ((id: number) => void)
+        | undefined;
+      cancelIdle?.(idleHandleRef.current);
+    } else {
+      clearTimeout(idleHandleRef.current);
+    }
+    idleHandleRef.current = null;
+    idleHandleModeRef.current = null;
+  }, []);
 
-    // Poll for changes every 10 seconds without loading state
-    const interval = setInterval(() => {
+  const scheduleIdleRefresh = useCallback(() => {
+    if (!shouldPollRef.current) return;
+    clearIdleHandle();
+
+    const run = () => {
+      if (!shouldPollRef.current) return;
       void fetchChanges(false);
-    }, 10000);
-    return () => clearInterval(interval);
-  }, [fetchChanges]);
+      scheduleIdleRefresh();
+    };
+
+    const requestIdle = (window as any).requestIdleCallback as
+      | ((cb: () => void, options?: { timeout: number }) => number)
+      | undefined;
+
+    if (requestIdle) {
+      idleHandleModeRef.current = 'idle';
+      idleHandleRef.current = requestIdle(run, { timeout: idleIntervalMs });
+    } else {
+      idleHandleModeRef.current = 'timeout';
+      idleHandleRef.current = window.setTimeout(run, idleIntervalMs);
+    }
+  }, [clearIdleHandle, fetchChanges, idleIntervalMs]);
+
+  const shouldPoll = Boolean(taskPath) && isActive && isDocumentVisible && isWindowFocused;
+
+  useEffect(() => {
+    shouldPollRef.current = shouldPoll;
+  }, [shouldPoll]);
+
+  useEffect(() => {
+    if (!taskPath || !shouldPoll) {
+      clearIdleHandle();
+      return;
+    }
+
+    void fetchChanges(!hasLoadedRef.current);
+    scheduleIdleRefresh();
+
+    return () => {
+      clearIdleHandle();
+    };
+  }, [taskPath, shouldPoll, fetchChanges, scheduleIdleRefresh, clearIdleHandle]);
 
   return {
     ...changes,

--- a/src/renderer/hooks/useTaskChanges.ts
+++ b/src/renderer/hooks/useTaskChanges.ts
@@ -124,7 +124,7 @@ export function useTaskChanges(
           return;
         }
 
-        if (result.success && result.changes) {
+        if (result?.success && result.changes) {
           const filtered = result.changes.filter(
             (c: { path: string }) => !c.path.startsWith('.emdash/') && c.path !== 'PLANNING.md'
           );
@@ -145,7 +145,7 @@ export function useTaskChanges(
             totalAdditions: 0,
             totalDeletions: 0,
             isLoading: false,
-            error: result.error || 'Failed to fetch changes',
+            error: result?.error || 'Failed to fetch changes',
           });
         }
       } catch (error) {


### PR DESCRIPTION
Clean extraction of #743.\n\n- pause polling when the window is hidden or unfocused\n- refresh on focus/visibility changes\n- schedule background refreshes via idle/timeout with a longer interval\n\nRefs #743 (cschubiner).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core polling/state management for git status in the renderer; main risk is missed/late refreshes or stuck loading state due to new scheduling and concurrency guards.
> 
> **Overview**
> Reduces renderer-side `getGitStatus` polling by pausing refresh when the window is hidden/unfocused (or the hook is marked inactive) and resuming with an immediate refresh when active again.
> 
> Replaces fixed-interval polling in `useFileChanges`/`useTaskChanges` with an idle/timeout scheduler (default 60s), and hardens the fetch logic against overlapping requests, unmounts, and `taskPath` changes by queuing forced refreshes and guarding state updates.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 42051bae435b17f228d032e3dda7d463b3446819. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->