### PR TITLE
Fix fs list worker response type

### DIFF
--- a/src/main/services/fsIpc.ts
+++ b/src/main/services/fsIpc.ts
@@ -97,7 +97,7 @@ export function registerFsIpc(): void {
         worker.once('message', (message) => {
           cleanup();
           worker.terminate().catch(() => {});
-          resolve(message as ListWorkerResponse);
+          resolve(message as FsListWorkerResponse);
         });
         worker.once('error', (error) => {
           cleanup();


### PR DESCRIPTION
Fixes a typo in fs:list worker response casting that breaks "npm run d" on main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Type-only correction to a worker message cast with no behavioral changes expected beyond fixing compilation/type errors.
> 
> **Overview**
> Fixes a typo in `fsIpc.ts` where the `fs:list` worker `message` payload was cast to the wrong response type, and now correctly resolves it as `FsListWorkerResponse` to restore type-checking/build compatibility.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 28cb28236b8e369ab525feee0596c89fc5f6d1d9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->