### PR TITLE
fix(ui): increase toast z-index to prevent overlapping

### DIFF
--- a/src/renderer/components/ui/toast.tsx
+++ b/src/renderer/components/ui/toast.tsx
@@ -16,7 +16,7 @@ const ToastViewport = React.forwardRef<
   <ToastPrimitives.Viewport
     ref={ref}
     className={cn(
-      'fixed top-0 z-[200] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
+      'fixed top-0 z-[10000] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]',
       className
     )}
     {...props}


### PR DESCRIPTION
## Summary

- Increased the `ToastViewport` z-index from `200` to `10000` to ensure toast notifications render above all other UI layers (modals, dropdowns, command palette, etc.)