### PR TITLE
Fix docs search by adding Fumadocs API route

### DIFF
--- a/docs/app/api/search/route.ts
+++ b/docs/app/api/search/route.ts
@@ -1,0 +1,6 @@
+import { source } from '@/lib/source';
+import { createFromSource } from 'fumadocs-core/search/server';
+
+export const { GET } = createFromSource(source, {
+  language: 'english',
+});


### PR DESCRIPTION
## Summary
- add missing docs/app/api/search/route.ts for Fumadocs search
- wire route via createFromSource(source) so docs search has a backend endpoint

## Validation
- ran docs app and confirmed search requests return HTTP 200
- verified requests like /api/search?query=issue and /api/search?query=config succeed

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive change limited to the docs app by introducing a single API route; minimal impact beyond search behavior.
> 
> **Overview**
> Restores docs search by adding a Next.js route handler at `docs/app/api/search/route.ts` that exposes a `GET` endpoint generated via `createFromSource(source)`.
> 
> The route is configured for English language search, enabling `/api/search?query=...` requests to resolve successfully.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70b68be66f09caa86093d4306eaf2a180aa8bbd7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->