### PR TITLE
feat(titlebar): show first app icon in Open In menu button

### DIFF
--- a/src/renderer/components/titlebar/OpenInMenu.tsx
+++ b/src/renderer/components/titlebar/OpenInMenu.tsx
@@ -126,6 +126,13 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({ path, align = 'right' }) => {
         aria-haspopup
       >
         <span>Open in</span>
+        {icons[OPEN_IN_APPS[0]?.id] && (
+          <img
+            src={icons[OPEN_IN_APPS[0].id]}
+            alt={OPEN_IN_APPS[0].label}
+            className="h-4 w-4 rounded"
+          />
+        )}
         <ChevronDown
           className={`h-3 w-3 opacity-50 transition-transform duration-200 ${
             open ? 'rotate-180' : ''


### PR DESCRIPTION
## Summary

- Display the icon of the first available app in the "Open in" toolbar button, providing a visual indicator alongside the text label
- The icon is conditionally rendered only when successfully loaded