### PR TITLE
Prevent setup reruns on additional terminals in same worktree

### DIFF
--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -100,41 +100,44 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   const firstTaskTerminalId = taskTerminals.terminals[0]?.id;
 
   // Run setup script when a task terminal becomes ready (only once per task/worktree)
-  const handleTerminalReady = useCallback((terminalId: string) => {
-    const currentTask = taskRef.current;
-    const currentProjectPath = projectPathRef.current;
-    if (!currentTask || !currentProjectPath) return;
+  const handleTerminalReady = useCallback(
+    (terminalId: string) => {
+      const currentTask = taskRef.current;
+      const currentProjectPath = projectPathRef.current;
+      if (!currentTask || !currentProjectPath) return;
 
-    // Only the primary task terminal is allowed to trigger automatic setup.
-    // Additional terminals in the same worktree should open immediately.
-    if (terminalId !== firstTaskTerminalId) return;
+      // Only the primary task terminal is allowed to trigger automatic setup.
+      // Additional terminals in the same worktree should open immediately.
+      if (terminalId !== firstTaskTerminalId) return;
 
-    const key = `${currentTask.id}::${currentTask.path}`;
-    if (setupScriptRan.has(key)) return;
+      const key = `${currentTask.id}::${currentTask.path}`;
+      if (setupScriptRan.has(key)) return;
 
-    // Mark as attempted immediately to prevent race conditions
-    setupScriptRan.add(key);
+      // Mark as attempted immediately to prevent race conditions
+      setupScriptRan.add(key);
 
-    (async () => {
-      try {
-        // Check if there's a setup script configured
-        const result = await window.electronAPI.lifecycleGetSetupScript({
-          projectPath: currentProjectPath,
-        });
-        if (!result.success || !result.script) {
-          return;
+      (async () => {
+        try {
+          // Check if there's a setup script configured
+          const result = await window.electronAPI.lifecycleGetSetupScript({
+            projectPath: currentProjectPath,
+          });
+          if (!result.success || !result.script) {
+            return;
+          }
+
+          // Send the setup command to the terminal (clear first to avoid timing artifacts)
+          window.electronAPI.ptyInput({
+            id: terminalId,
+            data: 'clear && ' + result.script + '\n',
+          });
+        } catch (error) {
+          console.error('Failed to run setup script:', error);
         }
-
-        // Send the setup command to the terminal (clear first to avoid timing artifacts)
-        window.electronAPI.ptyInput({
-          id: terminalId,
-          data: 'clear && ' + result.script + '\n',
-        });
-      } catch (error) {
-        console.error('Failed to run setup script:', error);
-      }
-    })();
-  }, [firstTaskTerminalId]);
+      })();
+    },
+    [firstTaskTerminalId]
+  );
 
   // Memoize callbacks per terminal to avoid recreating on every render
   const terminalReadyCallbacks = useMemo(() => {


### PR DESCRIPTION
## Summary\n- run task setup only from the primary worktree terminal\n- de-duplicate setup execution at task/worktree scope instead of per terminal\n- keep additional terminals opening immediately without rerunning setup\n\nCloses #765

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to terminal initialization behavior; primary risk is missed or delayed setup execution if primary terminal selection changes unexpectedly.
> 
> **Overview**
> Prevents task terminal setup scripts from re-running when users open additional terminals for the same task/worktree.
> 
> `TaskTerminalPanel` now only triggers the automatic setup script from the *primary* task terminal, and de-duplicates execution using a task/worktree key (`task.id::task.path`) instead of per-terminal IDs; the existing task-level cleanup (`clearSetupScriptState`) continues to reset this state on task deletion.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 038c3496fc49530e33c87d52629405461984d19c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->