### PR TITLE
feat: add pin/unpin tasks in sidebar

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -217,6 +217,20 @@ const AppContent: React.FC = () => {
     });
   }, []);
 
+  const handleDeleteTaskAndUnpin: typeof taskMgmt.handleDeleteTask = useCallback(
+    async (project, task, options) => {
+      setPinnedTaskIds((prev) => {
+        if (!prev.has(task.id)) return prev;
+        const next = new Set(prev);
+        next.delete(task.id);
+        localStorage.setItem(PINNED_TASKS_KEY, JSON.stringify([...next]));
+        return next;
+      });
+      return taskMgmt.handleDeleteTask(project, task, options);
+    },
+    [taskMgmt.handleDeleteTask]
+  );
+
   // --- Task creation wrapper ---
   const handleCreateTask = useCallback(
     async (
@@ -354,7 +368,7 @@ const AppContent: React.FC = () => {
                       onReorderProjectsFull={projectMgmt.handleReorderProjectsFull}
                       onSidebarContextChange={handleSidebarContextChange}
                       onCreateTaskForProject={taskMgmt.handleStartCreateTaskFromSidebar}
-                      onDeleteTask={taskMgmt.handleDeleteTask}
+                      onDeleteTask={handleDeleteTaskAndUnpin}
                       onRenameTask={taskMgmt.handleRenameTask}
                       onArchiveTask={taskMgmt.handleArchiveTask}
                       onRestoreTask={taskMgmt.handleRestoreTask}

--- a/src/renderer/components/TaskItem.tsx
+++ b/src/renderer/components/TaskItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { GitBranch, ArrowUpRight, AlertCircle, Pencil } from 'lucide-react';
+import { GitBranch, ArrowUpRight, AlertCircle, Pencil, Pin, PinOff } from 'lucide-react';
 import TaskDeleteButton from './TaskDeleteButton';
 import { useTaskChanges } from '../hooks/useTaskChanges';
 import { ChangesBadge } from './TaskChanges';
@@ -35,6 +35,8 @@ interface TaskItemProps {
   onDelete?: () => void | Promise<void | boolean>;
   onRename?: (newName: string) => void | Promise<void>;
   onArchive?: () => void | Promise<void | boolean>;
+  onPin?: () => void | Promise<void>;
+  isPinned?: boolean;
   showDelete?: boolean;
   showDirectBadge?: boolean;
 }
@@ -44,6 +46,8 @@ export const TaskItem: React.FC<TaskItemProps> = ({
   onDelete,
   onRename,
   onArchive,
+  onPin,
+  isPinned,
   showDelete,
   showDirectBadge = true,
 }) => {
@@ -131,7 +135,10 @@ export const TaskItem: React.FC<TaskItemProps> = ({
             onClick={stopPropagation}
           />
         ) : (
-          <span className="block truncate text-xs font-medium text-foreground">{task.name}</span>
+          <>
+            {isPinned && <Pin className="h-3 w-3 flex-shrink-0 text-muted-foreground" />}
+            <span className="block truncate text-xs font-medium text-foreground">{task.name}</span>
+          </>
         )}
         {showDirectBadge && task.useWorktree === false && (
           <span
@@ -193,12 +200,32 @@ export const TaskItem: React.FC<TaskItemProps> = ({
     </div>
   );
 
-  // Wrap with context menu if rename or archive is available
-  if (onRename || onArchive) {
+  // Wrap with context menu if rename, archive, or pin is available
+  if (onRename || onArchive || onPin) {
     return (
       <ContextMenu>
         <ContextMenuTrigger asChild>{taskContent}</ContextMenuTrigger>
         <ContextMenuContent>
+          {onPin && (
+            <ContextMenuItem
+              onClick={(e) => {
+                e.stopPropagation();
+                onPin();
+              }}
+            >
+              {isPinned ? (
+                <>
+                  <PinOff className="mr-2 h-3.5 w-3.5" />
+                  Unpin
+                </>
+              ) : (
+                <>
+                  <Pin className="mr-2 h-3.5 w-3.5" />
+                  Pin
+                </>
+              )}
+            </ContextMenuItem>
+          )}
           {onRename && (
             <ContextMenuItem
               onClick={(e) => {


### PR DESCRIPTION
## Summary
- Add ability to pin tasks in the left sidebar via right-click context menu
- Pinned tasks are sorted to the top of each project's task list
- Pin state is persisted in localStorage across sessions
- Pinned tasks display a pin icon indicator next to the task name

## Changes
- **App.tsx**: Add `pinnedTaskIds` state backed by localStorage, pass pin props to `LeftSidebar`
- **LeftSidebar.tsx**: Accept `pinnedTaskIds` and `onPinTask` props, sort tasks so pinned ones appear first
- **TaskItem.tsx**: Add pin/unpin option to context menu, show `Pin` icon for pinned tasks

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI behavior change with small, localized state persisted to `localStorage`; main risk is minor ordering/state edge cases (e.g., stale pinned IDs or storage parse failures).
> 
> **Overview**
> Adds a *pin/unpin* affordance for tasks in the left sidebar via `TaskItem`’s context menu, plus a visual pin indicator next to pinned task names.
> 
> Introduces `pinnedTaskIds` state in `App.tsx` persisted under `emdash-pinned-tasks` in `localStorage`, passes it into `LeftSidebar`, and ensures deleting a task also removes it from the pinned set.
> 
> Updates `LeftSidebar` to accept pin props and sort each project’s task list so pinned tasks appear first, while wiring pin callbacks through to `TaskItem`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a1d425cb74cc3d7df5abee754681f0fb76775964. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->