### PR TITLE
feat: enable auto-approve, initial prompt, and issue linking for Amp agent

### DIFF
--- a/src/renderer/lib/agentConfig.ts
+++ b/src/renderer/lib/agentConfig.ts
@@ -45,8 +45,8 @@ export const agentConfig: Record<Agent, AgentInfo> = {
   cline: { name: 'Cline', logo: clineLogo, alt: 'Cline CLI' },
   continue: { name: 'Continue', logo: continueLogo, alt: 'Continue CLI' },
   codebuff: { name: 'Codebuff', logo: codebuffLogo, alt: 'Codebuff CLI' },
-  // Without initial prompt support
   amp: { name: 'Amp', logo: ampLogo, alt: 'Amp Code' },
+  // Without initial prompt support
   copilot: { name: 'Copilot', logo: copilotLogo, alt: 'GitHub Copilot CLI', invertInDark: true },
   charm: { name: 'Charm', logo: charmLogo, alt: 'Charm Crush', invertInDark: true },
   rovo: { name: 'Rovo Dev', logo: atlassianLogo, alt: 'Rovo Dev' },

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -134,6 +134,8 @@ export const PROVIDERS: ProviderDefinition[] = [
     commands: ['amp'],
     versionArgs: ['--version'],
     cli: 'amp',
+    autoApproveFlag: '--dangerously-allow-all',
+    initialPromptFlag: '',
     icon: 'ampcode.png',
     terminalOnly: true,
   },


### PR DESCRIPTION
The Amp provider definition was missing `autoApproveFlag` and `initialPromptFlag`, which meant all the advanced task options (auto-approve, initial prompt, Linear/GitHub/Jira issue linking) were disabled when Amp was selected.

## Changes
- Add `autoApproveFlag: '--dangerously-allow-all'` to the Amp provider entry in `registry.ts`
- Add `initialPromptFlag: ''` (empty string = positional argument, same convention as Codex/Claude)
- Move Amp above the "without initial prompt support" comment in `agentConfig.ts`

All downstream UI and PTY logic is already provider-agnostic, so no additional code was needed.