### PR TITLE
refactor(pty): centralize PTY ID construction and parsing  

### DIFF
--- a/src/renderer/hooks/useInitialPromptInjection.ts
+++ b/src/renderer/hooks/useInitialPromptInjection.ts
@@ -1,6 +1,8 @@
 import { useEffect } from 'react';
 import { initialPromptSentKey } from '../lib/keys';
 import { classifyActivity } from '../lib/activityClassifier';
+import { makePtyId } from '@shared/ptyId';
+import type { ProviderId } from '@shared/providers/registry';
 
 /**
  * Injects an initial prompt into the provider's terminal once the PTY is ready.
@@ -21,7 +23,7 @@ export function useInitialPromptInjection(opts: {
     const sentKey = initialPromptSentKey(taskId, providerId);
     if (localStorage.getItem(sentKey) === '1') return;
 
-    const ptyId = `${providerId}-main-${taskId}`;
+    const ptyId = makePtyId(providerId as ProviderId, 'main', taskId);
     let sent = false;
     let idleSeen = false;
     let silenceTimer: any = null;

--- a/src/shared/ptyId.ts
+++ b/src/shared/ptyId.ts
@@ -1,0 +1,40 @@
+import { PROVIDER_IDS, type ProviderId } from './providers/registry';
+
+// Delimiter chosen to be unambiguous — providers are validated against PROVIDER_IDS
+const MAIN_SEP = '-main-';
+const CHAT_SEP = '-chat-';
+
+export type PtyIdKind = 'main' | 'chat';
+
+export function makePtyId(provider: ProviderId, kind: PtyIdKind, suffix: string): string {
+  const sep = kind === 'main' ? MAIN_SEP : CHAT_SEP;
+  return `${provider}${sep}${suffix}`;
+}
+
+export function parsePtyId(id: string): {
+  providerId: ProviderId;
+  kind: PtyIdKind;
+  suffix: string; // taskId for 'main', conversationId for 'chat'
+} | null {
+  // Try each known provider prefix to avoid ambiguity from greedy matching.
+  // Longest-first so e.g. "continue" is tried before a hypothetical "co".
+  const sorted = [...PROVIDER_IDS].sort((a, b) => b.length - a.length);
+  for (const pid of sorted) {
+    if (id.startsWith(pid + MAIN_SEP)) {
+      return { providerId: pid, kind: 'main', suffix: id.slice(pid.length + MAIN_SEP.length) };
+    }
+    if (id.startsWith(pid + CHAT_SEP)) {
+      return { providerId: pid, kind: 'chat', suffix: id.slice(pid.length + CHAT_SEP.length) };
+    }
+  }
+  return null;
+}
+
+/** Quick check without full parse */
+export function isMainPty(id: string): boolean {
+  return id.includes(MAIN_SEP);
+}
+
+export function isChatPty(id: string): boolean {
+  return id.includes(CHAT_SEP) && !id.includes(MAIN_SEP);
+}

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePtyId } from '../../shared/ptyId';
 
 type ExitPayload = {
   exitCode: number | null | undefined;
@@ -167,7 +168,7 @@ describe('ptyIpc notification lifecycle', () => {
     const start = ipcHandleHandlers.get('pty:start');
     expect(start).toBeTypeOf('function');
 
-    const id = 'codex-main-task-quit';
+    const id = makePtyId('codex', 'main', 'task-quit');
     await start!(
       { sender: createSender() },
       { id, cwd: '/tmp/task', shell: 'codex', cols: 120, rows: 32 }
@@ -194,7 +195,7 @@ describe('ptyIpc notification lifecycle', () => {
     const start = ipcHandleHandlers.get('pty:start');
     expect(start).toBeTypeOf('function');
 
-    const id = 'codex-main-task-success';
+    const id = makePtyId('codex', 'main', 'task-success');
     await start!(
       { sender: createSender() },
       { id, cwd: '/tmp/task', shell: 'codex', cols: 120, rows: 32 }


### PR DESCRIPTION
## Summary
  - Add `src/shared/ptyId.ts` with typed constructors (`makePtyId`) and an unambiguous parser (`parsePtyId`) for
   PTY IDs
  - Replace ~10 inline template literals and regex/split parsing across 6 files with calls to the shared module
  - Fix: old regex could mismatch if a task ID contained `-main-`; new parser matches known provider prefixes
  longest-first

  ## Test plan
  - [x] `pnpm run type-check` passes
  - [x] `pnpm run lint` passes (1 pre-existing error unchanged)
  - [x] `pnpm exec vitest run` passes (1 pre-existing failure in GitHubService.test.ts unchanged)
  - [x] No behavioral changes — `makePtyId` produces identical strings to the old template literals