### PR TITLE
Preserve selected project path for terminal cwd

### DIFF
--- a/src/renderer/hooks/useProjectManagement.tsx
+++ b/src/renderer/hooks/useProjectManagement.tsx
@@ -103,8 +103,9 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
       if (result.success && result.path) {
         try {
           const gitInfo = await window.electronAPI.getGitInfo(result.path);
-          const canonicalPath = gitInfo.rootPath || gitInfo.path || result.path;
-          const repoKey = normalizePathForComparison(canonicalPath, platform);
+          const selectedPath = gitInfo.path || result.path;
+          const repoCanonicalPath = gitInfo.rootPath || selectedPath;
+          const repoKey = normalizePathForComparison(repoCanonicalPath, platform);
           const existingProject = projects.find(
             (project) => getProjectRepoKey(project, platform) === repoKey
           );
@@ -130,12 +131,12 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
           const remoteUrl = gitInfo.remote || '';
           const isGithubRemote = /github\.com[:/]/i.test(remoteUrl);
           const projectName =
-            canonicalPath.split(/[/\\]/).filter(Boolean).pop() || 'Unknown Project';
+            selectedPath.split(/[/\\]/).filter(Boolean).pop() || 'Unknown Project';
 
           const baseProject: Project = {
             id: Date.now().toString(),
             name: projectName,
-            path: canonicalPath,
+            path: selectedPath,
             repoKey,
             gitInfo: {
               isGitRepo: true,
@@ -147,7 +148,7 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
           };
 
           if (isAuthenticated && isGithubRemote) {
-            const githubInfo = await window.electronAPI.connectToGitHub(canonicalPath);
+            const githubInfo = await window.electronAPI.connectToGitHub(selectedPath);
             if (githubInfo.success) {
               const projectWithGithub = withRepoKey(
                 {
@@ -292,8 +293,9 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
       captureTelemetry('project_cloned');
       try {
         const gitInfo = await window.electronAPI.getGitInfo(projectPath);
-        const canonicalPath = gitInfo.rootPath || gitInfo.path || projectPath;
-        const repoKey = normalizePathForComparison(canonicalPath, platform);
+        const selectedPath = gitInfo.path || projectPath;
+        const repoCanonicalPath = gitInfo.rootPath || selectedPath;
+        const repoKey = normalizePathForComparison(repoCanonicalPath, platform);
         const existingProject = projects.find(
           (project) => getProjectRepoKey(project, platform) === repoKey
         );
@@ -305,12 +307,12 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
 
         const remoteUrl = gitInfo.remote || '';
         const isGithubRemote = /github\.com[:/]/i.test(remoteUrl);
-        const projectName = canonicalPath.split(/[/\\]/).filter(Boolean).pop() || 'Unknown Project';
+        const projectName = selectedPath.split(/[/\\]/).filter(Boolean).pop() || 'Unknown Project';
 
         const baseProject: Project = {
           id: Date.now().toString(),
           name: projectName,
-          path: canonicalPath,
+          path: selectedPath,
           repoKey,
           gitInfo: {
             isGitRepo: true,
@@ -322,7 +324,7 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
         };
 
         if (isAuthenticated && isGithubRemote) {
-          const githubInfo = await window.electronAPI.connectToGitHub(canonicalPath);
+          const githubInfo = await window.electronAPI.connectToGitHub(selectedPath);
           if (githubInfo.success) {
             const projectWithGithub = withRepoKey(
               {
@@ -409,8 +411,9 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
       captureTelemetry('new_project_created');
       try {
         const gitInfo = await window.electronAPI.getGitInfo(projectPath);
-        const canonicalPath = gitInfo.rootPath || gitInfo.path || projectPath;
-        const repoKey = normalizePathForComparison(canonicalPath, platform);
+        const selectedPath = gitInfo.path || projectPath;
+        const repoCanonicalPath = gitInfo.rootPath || selectedPath;
+        const repoKey = normalizePathForComparison(repoCanonicalPath, platform);
         const existingProject = projects.find(
           (project) => getProjectRepoKey(project, platform) === repoKey
         );
@@ -422,12 +425,12 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
 
         const remoteUrl = gitInfo.remote || '';
         const isGithubRemote = /github\.com[:/]/i.test(remoteUrl);
-        const projectName = canonicalPath.split(/[/\\]/).filter(Boolean).pop() || 'Unknown Project';
+        const projectName = selectedPath.split(/[/\\]/).filter(Boolean).pop() || 'Unknown Project';
 
         const baseProject: Project = {
           id: Date.now().toString(),
           name: projectName,
-          path: canonicalPath,
+          path: selectedPath,
           repoKey,
           gitInfo: {
             isGitRepo: true,
@@ -439,7 +442,7 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
         };
 
         if (isAuthenticated && isGithubRemote) {
-          const githubInfo = await window.electronAPI.connectToGitHub(canonicalPath);
+          const githubInfo = await window.electronAPI.connectToGitHub(selectedPath);
           if (githubInfo.success) {
             const projectWithGithub = withRepoKey(
               {


### PR DESCRIPTION
## Summary
- keep selected folder as runtime project path
- use git root only for repo dedupe key
- update open/clone/new project flows consistently

## Why
Opening a subfolder inside a larger repo was canonicalized to repo root, causing agent sessions to start in the parent directory instead of the selected folder.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized path-handling change in project creation flows; main risk is subtle regressions in repo deduping or GitHub connection when paths differ between selected folder and repo root.
> 
> **Overview**
> Ensures projects opened from a subfolder keep that *selected folder* as `project.path` (used for runtime operations like working directory), instead of canonicalizing to the Git root.
> 
> Across `handleOpenProject`, `handleCloneSuccess`, and `handleNewProjectSuccess`, the Git root (`gitInfo.rootPath`) is now only used to compute the normalized `repoKey` for deduping, while GitHub connection and project naming/saving use the preserved selected path.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd812e97962bda24d7d19aee1a21e713b634a835. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->