### PR TITLE
fix(ci): resolve pnpm packaging issues for electron-builder

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+node-linker=hoisted

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "@isaacs/brace-expansion": "^5.0.1",
     "@monaco-editor/react": "^4.7.0",
     "@radix-ui/react-accordion": "^1.2.12",
     "@radix-ui/react-alert-dialog": "^1.1.15",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@isaacs/brace-expansion':
+        specifier: ^5.0.1
+        version: 5.0.1
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)


### PR DESCRIPTION
Summary                                        

  - Add node-linker=hoisted to .npmrc so pnpm uses a flat node_modules/ layout compatible
  with electron-builder's asar packaging
  - Fix pnpm exec @electron/rebuild → pnpm exec electron-rebuild (correct binary name)
  - Add @isaacs/brace-expansion as direct dependency for safety

  Context

  The npm-to-pnpm migration (#789) left node_modules/ in a hybrid state with stale npm
  directories and pnpm symlinks. pnpm's default symlink-based store caused transitive
  dependencies (like @isaacs/brace-expansion) to be missing from the packaged asar,
  crashing the app at launch.

  Test plan

  - pnpm exec electron-rebuild succeeds locally
  - pnpm run package:mac builds successfully
  - Packaged app launches without "Cannot find module" errors
  - Verified @isaacs/brace-expansion and all scoped packages present in asar