### PR TITLE
fix: enable automatic Wayland/X11 detection on Linux

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -73,6 +73,13 @@ if (process.platform === 'linux') {
   } catch {}
 }
 
+// Enable automatic Wayland/X11 detection on Linux.
+// Uses native Wayland when available, falls back to X11 (XWayland) otherwise.
+// Must be called before app.whenReady().
+if (process.platform === 'linux') {
+  app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
+}
+
 if (process.platform === 'win32') {
   // Ensure npm global binaries are in PATH for Windows
   const npmPath = require('path').join(process.env.APPDATA || '', 'npm');


### PR DESCRIPTION
## Summary

- Adds `ozone-platform-hint=auto` Chromium flag on Linux to auto-detect display backend (Wayland vs X11)
- Fixes Emdash failing to display a window on Wayland compositors (Hyprland, Sway, GNOME Wayland, KDE Plasma)
- Fixes GPU process crash loop (`eglCreateImage failed with EGL_BAD_ALLOC`) on some drivers

## Details

A single `app.commandLine.appendSwitch('ozone-platform-hint', 'auto')` call is added in `src/main/main.ts` for Linux, before `app.whenReady()`. This follows the existing per-platform `process.platform` block pattern already used for PATH setup.

`auto` is the industry standard — Chromium auto-detects via `$XDG_SESSION_TYPE` and `$WAYLAND_DISPLAY`. VSCode, Chrome, and all maintained Electron apps use this approach.

### Why only `ozone-platform-hint=auto`

- `--disable-gpu` is too aggressive — degrades performance for everyone
- `--ozone-platform=wayland` would break X11-only setups
- `--ozone-platform=x11` defeats native Wayland support
- `auto` lets Chromium pick the right backend per session

## Test plan

- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes (only pre-existing warnings)
- [x] `pnpm run format` — all files unchanged
- [ ] Build with `pnpm run build`
- [ ] Test on Wayland compositor — window appears
- [ ] Test on X11 — no regression (auto falls back to X11)