### PR TITLE
Remove redundant direct branch mode banner

### DIFF
--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -1,6 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from './ui/button';
-import { GitBranch, Plus, Loader2, ArrowUpRight, Folder, AlertCircle, Archive } from 'lucide-react';
+import { GitBranch, Plus, Loader2, ArrowUpRight, Folder, Archive } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
 import { Separator } from './ui/separator';
 import { Alert, AlertDescription, AlertTitle } from './ui/alert';
@@ -598,40 +598,6 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
               </header>
               <Separator className="my-2" />
             </div>
-
-            {(() => {
-              // Find tasks running directly on the main branch (without worktrees)
-              // Check both useWorktree === false and tasks where path equals project path
-              const directTasks = tasksInProject.filter(
-                (task) => task.useWorktree === false || task.path === project.path
-              );
-              if (directTasks.length === 0) return null;
-
-              return (
-                <Alert className="border-border bg-muted/50">
-                  <AlertCircle className="h-3.5 w-3.5 text-muted-foreground" />
-                  <AlertTitle className="text-sm font-medium text-foreground">
-                    Direct branch mode
-                  </AlertTitle>
-                  <AlertDescription className="text-xs text-muted-foreground">
-                    {directTasks.length === 1 ? (
-                      <>
-                        <span className="font-medium text-foreground">{directTasks[0].name}</span>{' '}
-                        is running directly on your current branch.
-                      </>
-                    ) : (
-                      <>
-                        <span className="font-medium text-foreground">
-                          {directTasks.map((t) => t.name).join(', ')}
-                        </span>{' '}
-                        are running directly on your current branch.
-                      </>
-                    )}{' '}
-                    Changes will affect your working directory.
-                  </AlertDescription>
-                </Alert>
-              );
-            })()}
 
             <div className="space-y-3">
               <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">


### PR DESCRIPTION
## Summary
- Remove the persistent "Direct branch mode" alert from the project view
- The user already sees a warning when unchecking "Run in worktree" in the task creation modal — no need to repeat it as a permanent banner

## Test plan
- [ ] Create a task with "Run in worktree" unchecked
- [ ] Verify no banner appears on the project view
- [ ] Verify the warning in task advanced settings still shows

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only removal of a redundant warning; no changes to task/worktree behavior or data handling.
> 
> **Overview**
> Removes the persistent *"Direct branch mode"* warning banner from `ProjectMainView` that listed tasks running without worktrees.
> 
> Cleans up the related `AlertCircle` icon import now that the banner UI is gone.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e680ae4647b3179fb53fa64e7f5aaad6465c1997. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->