### PR TITLE
Focus task name input when opening New Task modal

### DIFF
--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -78,6 +78,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
   // Branch selection state - sync with defaultBranch unless user manually changed it
   const [selectedBranch, setSelectedBranch] = useState(defaultBranch);
   const userChangedBranchRef = useRef(false);
+  const taskNameInputRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (isOpen && !userChangedBranchRef.current) {
@@ -248,9 +249,17 @@ const TaskModal: React.FC<TaskModalProps> = ({
     }
   };
 
+  const handleOpenAutoFocus = useCallback((event: Event) => {
+    event.preventDefault();
+    taskNameInputRef.current?.focus({ preventScroll: true });
+  }, []);
+
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && onClose()}>
-      <DialogContent className="max-h-[calc(100vh-48px)] max-w-md overflow-visible">
+      <DialogContent
+        className="max-h-[calc(100vh-48px)] max-w-md overflow-visible"
+        onOpenAutoFocus={handleOpenAutoFocus}
+      >
         <DialogHeader>
           <DialogTitle>New Task</DialogTitle>
           <div className="space-y-1 pt-1">
@@ -282,6 +291,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
               Task name
             </Label>
             <SlugInput
+              ref={taskNameInputRef}
               id="task-name"
               value={taskName}
               onChange={handleNameChange}
@@ -294,7 +304,6 @@ const TaskModal: React.FC<TaskModalProps> = ({
               maxLength={MAX_TASK_NAME_LENGTH}
               className={`w-full ${touched && error && !isFocused ? 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive' : ''}`}
               aria-invalid={touched && !!error && !isFocused}
-              autoFocus
             />
           </div>
 


### PR DESCRIPTION
## Summary
- ensure New Task modal always focuses the task name field when opened
- handle focus via Radix dialog open autofocus hook to avoid focus landing on other controls
- wire SlugInput ref and remove redundant autofocus prop

## Testing
- npm run format

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only focus change scoped to the task creation modal; low risk aside from potential edge-case focus behavior changes in the dialog.
> 
> **Overview**
> Ensures the **New Task** modal always focuses the task name field when opened by intercepting Radix `DialogContent`'s `onOpenAutoFocus` and manually focusing the `SlugInput` via a forwarded ref.
> 
> Removes the input-level `autoFocus` prop to avoid focus landing on other dialog controls and to make focus behavior consistent.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 25250e6889a84ab4e17cf9c4e82264bf4ae5c715. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->