### PR TITLE
fix(jira): include issue description in linked Jira context

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -695,6 +695,12 @@ const ChatInterface: React.FC<Props> = ({
       if (j.project?.key) details.push(`Project: ${j.project.key}`);
       if (details.length) lines.push(`Details: ${details.join(' • ')}`);
       if (j.url) lines.push(`URL: ${j.url}`);
+      const desc = typeof j.description === 'string' ? j.description.trim() : '';
+      if (desc) {
+        const max = 1500;
+        const clipped = desc.length > max ? desc.slice(0, max) + '\n…' : desc;
+        lines.push('', 'Issue Description:', clipped);
+      }
       const jiraContent = lines.join('\n');
       // Prepend comments if any
       if (commentsContext) {


### PR DESCRIPTION
## Summary
- The Jira integration was not fetching or including the issue description when linking a Jira ticket to a workspace. This means the `description` is not included in the agents prompt ([the docs says description are included](https://docs.emdash.sh/issues))
- Adds `description` to the Jira API field requests (`searchRaw` and `getIssueByKey`)
- Converts Jira's Atlassian Document Format (ADF) to plain text via a `flattenAdf` helper
- Includes the description (truncated to 1500 chars) in the initial prompt injected into the chat, matching the existing Linear and GitHub issue behavior

## Test plan
- [x] `pnpm run type-check` passes
- [x] `pnpm run build` succeeds
- [x] Tested locally with `pnpm run dev` — linked Jira issue description now appears in chat context