### PR TITLE
fix(release): use --only flag in electron-rebuild to skip cpu-features

### DIFF
--- a/.emdash.json
+++ b/.emdash.json
@@ -1,0 +1,15 @@
+{
+  "preservePatterns": [
+    ".env",
+    ".env.keys",
+    ".env.local",
+    ".env.*.local",
+    ".envrc",
+    "docker-compose.override.yml"
+  ],
+  "scripts": {
+    "setup": "",
+    "run": "",
+    "teardown": ""
+  }
+}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -110,7 +110,7 @@ jobs:
           for A in "${ARCHS[@]}"; do
             echo "=== Building for $A ==="
             echo "Rebuilding native modules for $A (Electron $ELECTRON_VERSION)"
-            npm_config_build_from_source=true pnpm exec electron-rebuild -f -a "$A" -v "$ELECTRON_VERSION" -w sqlite3,node-pty,keytar
+            npm_config_build_from_source=true pnpm exec electron-rebuild -f -a "$A" -v "$ELECTRON_VERSION" -o sqlite3,node-pty,keytar
             echo "Packaging $A DMG"
             pnpm exec electron-builder --mac dmg --$A --publish never --config.npmRebuild=false
           done
@@ -392,7 +392,7 @@ jobs:
           for A in "${ARCHS[@]}"; do
             echo "=== Building for $A ==="
             echo "Rebuilding native modules for $A (Electron $ELECTRON_VERSION)"
-            npm_config_build_from_source=true pnpm exec electron-rebuild -f -a "$A" -v "$ELECTRON_VERSION" -w sqlite3,node-pty,keytar
+            npm_config_build_from_source=true pnpm exec electron-rebuild -f -a "$A" -v "$ELECTRON_VERSION" -o sqlite3,node-pty,keytar
             echo "Packaging $A DMG and ZIP"
             pnpm exec electron-builder --mac dmg zip --$A --publish never --config.npmRebuild=false
           done


### PR DESCRIPTION
## Summary                                                      
  - Switch `-w` (which-module) to `-o` (only) for electron-rebuild in the release workflow
                                                 
  The SSH feature (PR #815) added `ssh2`, which pulls in `cpu-features` as an optional
  native dependency. `cpu-features` ships with a missing `buildcheck.gypi`, causing
  node-gyp to crash during rebuild. The `-w` flag still walks the full dependency tree and
  hits this, while `-o` skips everything except the three modules we actually need
  (`sqlite3`, `node-pty`, `keytar`). This already works in our local build scripts
  (`package.json` postinstall/rebuild) — the release workflow was the only place that was
  missed.
