### PR TITLE
feat: support worktree creation from local-only branches

### DIFF
--- a/src/renderer/components/BaseBranchControls.tsx
+++ b/src/renderer/components/BaseBranchControls.tsx
@@ -22,7 +22,7 @@ const BaseBranchControls: React.FC<BaseBranchControlsProps> = ({
   const placeholder = isLoadingBranches
     ? 'Loading...'
     : branchOptions.length === 0
-      ? 'No remote branches found'
+      ? 'No branches found'
       : 'Select a base branch';
 
   return (

--- a/src/renderer/hooks/useProjectManagement.tsx
+++ b/src/renderer/hooks/useProjectManagement.tsx
@@ -650,7 +650,10 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
         });
         if (cancelled) return;
         if (res.success && res.branches) {
-          const options = res.branches.map((b) => ({ value: b.label, label: b.label }));
+          const options = res.branches.map((b) => ({
+            value: b.ref,
+            label: b.remote ? b.label : `${b.branch} (local)`,
+          }));
           setProjectBranchOptions(options);
           const defaultBranch = pickDefaultBranch(options, currentRef);
           setProjectDefaultBranch(defaultBranch ?? currentRef ?? 'main');


### PR DESCRIPTION
## Added Features

- Local-only branches (not yet pushed to remote) now appear in the branch selection dropdown even when a remote exists
- Local branches are visually distinguished with a `(local)` suffix
- Users can select a local branch as the base for worktree creation

## Why This Implementation

The existing `git:list-remote-branches` IPC handler only queried `refs/remotes/origin` when a remote existed, making local-only branches invisible in the UI. Since the backend (`WorktreeService`) already fully supports local branches via `parseBaseRef()` and `fetchBaseRefWithFallback()`, only the IPC handler and renderer mapping needed changes — a minimal modification.

- After listing remote branches, also query `refs/heads/` for local branches
- Deduplicate using a `remoteBranchNames` Set (branches already on remote are excluded)
- Changed `value` to use `b.ref` so a valid git ref is stored as `baseRef`

## Modified Files

| File | Change |
|------|--------|
| `src/main/ipc/gitIpc.ts` | Added local-only branch listing and merging within `hasRemote` block |
| `src/renderer/hooks/useProjectManagement.tsx` | Changed `value` to `b.ref`, added `(local)` suffix for local branches |
| `src/renderer/components/BaseBranchControls.tsx` | Updated placeholder text to `No branches found` |

## Test Plan

- [x] Verify local branches appear with `(local)` suffix in branch dropdown for projects with a remote
- [x] Verify worktree creation works correctly when a local branch is selected
- [x] Verify branches existing on both local and remote are not duplicated
- [x] Verify projects without a remote still work as before
- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` has no new errors

## Related Issues

- Relates to #451 (Emdash requires Git remote for local-only projects)