### PR TITLE
fix: use stable port for renderer static server with fallback

### DIFF
--- a/src/main/app/staticServer.ts
+++ b/src/main/app/staticServer.ts
@@ -78,7 +78,9 @@ async function listenWithFallback(server: ReturnType<typeof createServer>): Prom
     } catch (error) {
       const code = (error as any)?.code;
       if (code === 'EADDRINUSE') {
-        await new Promise<void>((resolve) => server.close(() => resolve()));
+        if (server.listening) {
+          await new Promise<void>((resolve) => server.close(() => resolve()));
+        }
         continue;
       }
       throw error;


### PR DESCRIPTION
## Summary

- Replace ephemeral port (`0`) with a deterministic default port (`12112`) for the renderer static server
- Try up to 100 consecutive ports starting from the default, falling back to ephemeral only as a last resort
- Support `EMDASH_RENDERER_PORT` env var to override the default starting port

## Motivation

Using a random ephemeral port made the renderer URL unpredictable across restarts, which can cause issues with sidebar persistence and any features that rely on a stable origin. A fixed port range ensures the renderer server binds to a consistent address when possible.

## Changes

- Added `getRendererPortCandidates()` to generate a list of candidate ports from a configurable starting point
- Added `listenWithFallback()` to iterate through candidates, skipping `EADDRINUSE` errors, with proper listener cleanup
- Refactored `ensureRendererServer()` to use the new port selection logic