### PR TITLE
fix(ui): update merge button label to 'Merge into Main'

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -37,7 +37,7 @@ type PrMode = 'create' | 'draft' | 'merge';
 const PR_MODE_LABELS: Record<PrMode, string> = {
   create: 'Create PR',
   draft: 'Draft PR',
-  merge: 'Merge Main',
+  merge: 'Merge into Main',
 };
 
 interface PrActionButtonProps {


### PR DESCRIPTION
## Summary
- Updated the PR mode label from "Merge Main" to "Merge into Main" in the `FileChangesPanel` component for clearer wording