### PR TITLE
fix(ssh): prevent duplicate connections and race conditions

### DIFF
--- a/src/main/ipc/sshIpc.ts
+++ b/src/main/ipc/sshIpc.ts
@@ -100,6 +100,12 @@ export function registerSshIpc() {
   monitor.on('reconnect', async (connectionId: string, config: SshConfig, attempt: number) => {
     try {
       console.log(`[sshIpc] Reconnecting ${connectionId} (attempt ${attempt})...`);
+
+      // Clean up the stale/dead connection before opening a new one
+      if (sshService.isConnected(connectionId)) {
+        await sshService.disconnect(connectionId).catch(() => {});
+      }
+
       await sshService.connect(config);
       monitor.updateState(connectionId, 'connected');
     } catch (err: any) {


### PR DESCRIPTION
## Summary

- Add connection deduplication in `SshService.connect()` — coalesces in-flight connection attempts for the same ID and reuses existing connections instead of opening duplicate TCP sockets
- Enforce a connection pool limit (max 10) with a warning threshold at 80% to prevent resource exhaustion
- Fix stale `close` event handler that could remove a newer connection from the pool when an old client disconnects
- Clean up stale connections in the reconnect handler before opening new ones
- Add renderer-side deduplication via `connectingIds` set to prevent multiple React re-renders from firing parallel connects
- Use `reconnectRef` to stabilize the health-check interval and avoid unnecessary teardown/recreation loops

## Changes

- `src/main/services/ssh/SshService.ts` — Connection deduplication, pool limits, guarded `close` handler
- `src/main/ipc/sshIpc.ts` — Disconnect stale connection before reconnect attempt
- `src/renderer/hooks/useRemoteProject.ts` — Client-side connect deduplication, stable reconnect ref, guard against reconnecting while already connecting