### PR TITLE
fix(ui): simplify config modal and improve edit button

### DIFF
--- a/src/renderer/components/BaseBranchControls.tsx
+++ b/src/renderer/components/BaseBranchControls.tsx
@@ -27,19 +27,16 @@ const BaseBranchControls: React.FC<BaseBranchControlsProps> = ({
 
   return (
     <div className="space-y-2">
-      <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
-        <p className="text-sm font-medium text-foreground">Config</p>
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="h-8 px-3 text-xs sm:w-auto"
-          onClick={onOpenConfig}
-          disabled={!onOpenConfig}
-        >
-          Open
-        </Button>
-      </div>
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        className="h-8 px-3 text-xs"
+        onClick={onOpenConfig}
+        disabled={!onOpenConfig}
+      >
+        Edit config
+      </Button>
       <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:gap-3">
         <p className="text-sm font-medium text-foreground">Base branch</p>
         <BranchSelect


### PR DESCRIPTION
## Summary

Improves the config editing experience per GEN-284.

## Changes

- **Remove JSON page**: Removed the JSON editor mode and toggle, keeping only the scripts view
- **Clearer modal heading**: Changed from 'Config' to 'Project config'
- **Simplified button**: Replaced 'Config' label + 'Open' button with a single 'Edit config' button
- **Better placeholders**: Updated script input placeholders from example commands to 'No X script configured'

## Testing

- `pnpm run type-check` passes
- `pnpm run lint` passes
- `pnpm exec vitest run` passes

Closes GEN-284

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only changes with straightforward state simplification and the same underlying config load/save APIs; main risk is minor regression in config editing/saving behavior due to removal of JSON mode.
> 
> **Overview**
> Simplifies the config editing experience by removing the JSON/Monaco editor mode and related theme/validation logic, leaving a single scripts + preserved-patterns form that always saves via normalized JSON.
> 
> Updates UI copy and layout: `BaseBranchControls` replaces the “Config” label + “Open” button with a single **Edit config** button, and `ConfigEditorModal` renames the title to **Project config**, uses clearer “No … configured” placeholders, and separates *load failure* (blocking) from other save/edit errors (inline).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5879937cdfc773afef78b42810c15531abcc46d3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->