### PR TITLE
feat(telemetry): add SSH connection lifecycle events

### DIFF
--- a/docs/content/docs/telemetry.mdx
+++ b/docs/content/docs/telemetry.mdx
@@ -91,7 +91,7 @@ All events include only: event name, anonymized properties (e.g., `provider: "cl
 
 **Skills:** `skills_view_opened`, `skill_installed`, `skill_uninstalled`, `skill_created`, `skill_detail_viewed`
 
-**Remote Server / SSH:** `remote_project_modal_opened`, `remote_project_connection_tested`, `remote_project_created`
+**Remote Server / SSH:** `remote_project_modal_opened`, `remote_project_connection_tested`, `remote_project_created`, `ssh_connection_saved`, `ssh_connection_deleted`, `ssh_connect_success`, `ssh_connect_failed`, `ssh_disconnected`, `ssh_reconnect_attempted`, `ssh_settings_opened`
 
 **Browser Preview:** `browser_preview_opened`, `browser_preview_closed`, `browser_preview_url_navigated`
 

--- a/src/main/ipc/telemetryIpc.ts
+++ b/src/main/ipc/telemetryIpc.ts
@@ -79,6 +79,7 @@ const RENDERER_ALLOWED_EVENTS = new Set([
   'remote_project_modal_opened',
   'remote_project_connection_tested',
   'remote_project_created',
+  'ssh_settings_opened',
   // GitHub issues
   'github_issues_searched',
   'github_issue_selected',

--- a/src/main/telemetry.ts
+++ b/src/main/telemetry.ts
@@ -104,6 +104,13 @@ type TelemetryEvent =
   | 'remote_project_modal_opened'
   | 'remote_project_connection_tested'
   | 'remote_project_created'
+  | 'ssh_connection_saved'
+  | 'ssh_connection_deleted'
+  | 'ssh_connect_success'
+  | 'ssh_connect_failed'
+  | 'ssh_disconnected'
+  | 'ssh_reconnect_attempted'
+  | 'ssh_settings_opened'
   // GitHub issues
   | 'github_issues_searched'
   | 'github_issue_selected'

--- a/src/renderer/components/ssh/SshSettingsCard.tsx
+++ b/src/renderer/components/ssh/SshSettingsCard.tsx
@@ -33,6 +33,9 @@ export const SshSettingsCard: React.FC<Props> = ({ onAddConnection, onManageKeys
     setEditingConnection(null);
     setViewState('create');
     onAddConnection?.();
+    void import('../../lib/telemetryClient').then(({ captureTelemetry }) => {
+      captureTelemetry('ssh_settings_opened');
+    });
   }, [onAddConnection]);
 
   const handleEdit = useCallback((connection: SshConnection) => {


### PR DESCRIPTION
## Summary

- Add telemetry tracking for SSH connection lifecycle events (connect, disconnect, errors)
- Register new SSH IPC handlers in `sshIpc.ts` for capturing connection events
- Expose new telemetry event type in `telemetry.ts`
- Update telemetry documentation to reflect new SSH events
- Trigger telemetry capture from `SshSettingsCard` on connection actions