### PR TITLE
Fix AppImage env leakage in Open In launches

### DIFF
--- a/src/main/utils/__tests__/childProcessEnv.test.ts
+++ b/src/main/utils/__tests__/childProcessEnv.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest';
+import { buildExternalToolEnv } from '../childProcessEnv';
+
+describe('buildExternalToolEnv', () => {
+  it('removes AppImage-only keys and strips mount paths from PATH-like vars', () => {
+    const env = buildExternalToolEnv({
+      APPDIR: '/tmp/.mount_emdashAbCd',
+      APPIMAGE: '/home/user/emdash.AppImage',
+      ARGV0: 'AppRun',
+      CHROME_DESKTOP: 'emdash.desktop',
+      GSETTINGS_SCHEMA_DIR: '/tmp/.mount_emdashAbCd/usr/share/glib-2.0/schemas',
+      OWD: '/tmp',
+      PATH: '/usr/local/bin:/tmp/.mount_emdashAbCd/usr/bin:/usr/bin',
+      LD_LIBRARY_PATH: '/tmp/.mount_emdashAbCd/usr/lib:/usr/local/cuda/lib64',
+      XDG_DATA_DIRS: '/tmp/.mount_emdashAbCd/usr/share:/usr/share',
+      HOME: '/home/user',
+      USER: 'user',
+      KEEP_ME: 'yes',
+    });
+
+    expect(env.APPDIR).toBeUndefined();
+    expect(env.APPIMAGE).toBeUndefined();
+    expect(env.ARGV0).toBeUndefined();
+    expect(env.CHROME_DESKTOP).toBeUndefined();
+    expect(env.GSETTINGS_SCHEMA_DIR).toBeUndefined();
+    expect(env.OWD).toBeUndefined();
+
+    expect(env.PATH).toBe('/usr/local/bin:/usr/bin');
+    expect(env.LD_LIBRARY_PATH).toBe('/usr/local/cuda/lib64');
+    expect(env.XDG_DATA_DIRS).toBe('/usr/share');
+
+    expect(env.HOME).toBe('/home/user');
+    expect(env.USER).toBe('user');
+    expect(env.KEEP_ME).toBe('yes');
+  });
+
+  it('removes Python vars only when they point into AppImage mount paths', () => {
+    const stripped = buildExternalToolEnv({
+      APPDIR: '/tmp/.mount_emdashZZ',
+      PYTHONHOME: '/tmp/.mount_emdashZZ/usr',
+      PYTHONPATH: '/tmp/.mount_emdashZZ/usr/lib/python3.11',
+    });
+
+    expect(stripped.PYTHONHOME).toBeUndefined();
+    expect(stripped.PYTHONPATH).toBeUndefined();
+
+    const kept = buildExternalToolEnv({
+      PYTHONHOME: '/opt/python',
+      PYTHONPATH: '/opt/python/lib',
+    });
+
+    expect(kept.PYTHONHOME).toBe('/opt/python');
+    expect(kept.PYTHONPATH).toBe('/opt/python/lib');
+  });
+});

--- a/src/main/utils/childProcessEnv.ts
+++ b/src/main/utils/childProcessEnv.ts
@@ -1,0 +1,51 @@
+const APPIMAGE_ENV_KEYS = [
+  'APPDIR',
+  'APPIMAGE',
+  'ARGV0',
+  'CHROME_DESKTOP',
+  'GSETTINGS_SCHEMA_DIR',
+  'OWD',
+] as const;
+
+const APPIMAGE_PATH_LIKE_ENV_KEYS = ['PATH', 'LD_LIBRARY_PATH', 'XDG_DATA_DIRS'] as const;
+
+function stripPathLikeAppImageEntries(value: string, appDir?: string): string {
+  const separator = process.platform === 'win32' ? ';' : ':';
+  const parts = value.split(separator).filter(Boolean);
+  if (parts.length === 0) return value;
+
+  const filtered = parts.filter((part) => {
+    if (appDir && part.startsWith(appDir)) return false;
+    if (part.includes('/tmp/.mount_')) return false;
+    return true;
+  });
+
+  return filtered.join(separator);
+}
+
+export function buildExternalToolEnv(baseEnv: NodeJS.ProcessEnv = process.env): NodeJS.ProcessEnv {
+  const env: NodeJS.ProcessEnv = { ...baseEnv };
+  const appDir = typeof baseEnv.APPDIR === 'string' ? baseEnv.APPDIR : undefined;
+
+  for (const key of APPIMAGE_ENV_KEYS) {
+    delete env[key];
+  }
+
+  for (const key of APPIMAGE_PATH_LIKE_ENV_KEYS) {
+    const value = env[key];
+    if (typeof value !== 'string' || value.length === 0) continue;
+    const cleaned = stripPathLikeAppImageEntries(value, appDir);
+    if (cleaned.length > 0) env[key] = cleaned;
+    else delete env[key];
+  }
+
+  for (const key of ['PYTHONHOME', 'PYTHONPATH'] as const) {
+    const value = env[key];
+    if (typeof value !== 'string' || value.length === 0) continue;
+    if ((appDir && value.startsWith(appDir)) || value.includes('/tmp/.mount_')) {
+      delete env[key];
+    }
+  }
+
+  return env;
+}


### PR DESCRIPTION
Fixes #596 

## Summary
- add buildExternalToolEnv() to sanitize AppImage/runtime env before launching external tools
- apply sanitized env to all child_process.exec paths in app:openIn and installed-app checks
- add unit tests covering AppImage key removal and path-like env cleanup

## Why
Open-in launched terminals/editors inherited AppImage-only variables (APPDIR, APPIMAGE, mount-derived LD_LIBRARY_PATH, etc.), which polluted external shells and broke tools like cmake.

## Validation
- pnpm run format
- pnpm run type-check
- pnpm exec vitest run src/main/utils/__tests__/childProcessEnv.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches all external process launches by changing the `env` passed to `exec`, which could affect tool discovery or behavior if callers relied on inherited environment variables; scope is limited and covered by unit tests.
> 
> **Overview**
> Prevents AppImage runtime environment variables from leaking into child processes by introducing `buildExternalToolEnv()` to strip AppImage-only keys and remove AppImage mount-path entries from `PATH`/`LD_LIBRARY_PATH`/`XDG_DATA_DIRS` (and conditionally `PYTHONHOME`/`PYTHONPATH`).
> 
> All `child_process.exec` call sites used for **Open In** launches (including macOS AppleScript terminal flows and `ghostty`) and for installed-app detection now pass this sanitized `env`. Adds Vitest coverage for the env sanitization behavior.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70ad62cdfcf68a683cda593a16452ccba14d46fe. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->