### PR TITLE
feat: allow empty branch prefix and allo custom prefix for every task

### DIFF
--- a/src/main/services/worktreeIpc.ts
+++ b/src/main/services/worktreeIpc.ts
@@ -75,6 +75,7 @@ export function registerWorktreeIpc(): void {
         taskName: string;
         projectId: string;
         baseRef?: string;
+        branchPrefix?: string;
       }
     ) => {
       try {
@@ -89,6 +90,7 @@ export function registerWorktreeIpc(): void {
             projectId: project.id,
             remotePath: project.remotePath,
           });
+          // Remote worktrees don't support prefix customization yet
           const remote = await remoteGitService.createWorktree(
             project.sshConnectionId,
             project.remotePath,
@@ -111,7 +113,8 @@ export function registerWorktreeIpc(): void {
           args.projectPath,
           args.taskName,
           args.projectId,
-          args.baseRef
+          args.baseRef,
+          args.branchPrefix
         );
         return { success: true, worktree };
       } catch (error) {
@@ -337,6 +340,7 @@ export function registerWorktreeIpc(): void {
         projectPath: string;
         taskName: string;
         baseRef?: string;
+        branchPrefix?: string;
       }
     ) => {
       try {
@@ -351,7 +355,8 @@ export function registerWorktreeIpc(): void {
           args.projectId,
           args.projectPath,
           args.taskName,
-          args.baseRef
+          args.baseRef,
+          args.branchPrefix
         );
         if (result) {
           return {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -240,7 +240,7 @@ function normalizeSettings(input: AppSettings): AppSettings {
   const repo = input?.repository ?? DEFAULT_SETTINGS.repository;
   let prefix = String(repo?.branchPrefix ?? DEFAULT_SETTINGS.repository.branchPrefix);
   prefix = prefix.trim().replace(/\/+$/, ''); // remove trailing slashes
-  if (!prefix) prefix = DEFAULT_SETTINGS.repository.branchPrefix;
+  // Allow empty string - no forced fallback to default
   if (prefix.length > 50) prefix = prefix.slice(0, 50);
   const push = Boolean(repo?.pushOnCreate ?? DEFAULT_SETTINGS.repository.pushOnCreate);
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -266,7 +266,8 @@ const AppContent: React.FC = () => {
       linkedJiraIssue: JiraIssueSummary | null = null,
       autoApprove?: boolean,
       useWorktree: boolean = true,
-      baseRef?: string
+      baseRef?: string,
+      branchPrefix?: string
     ) => {
       if (!projectMgmt.selectedProject) return;
       await createTask(
@@ -280,6 +281,7 @@ const AppContent: React.FC = () => {
           autoApprove,
           useWorktree,
           baseRef,
+          branchPrefix,
         },
         {
           selectedProject: projectMgmt.selectedProject,

--- a/src/renderer/components/RepositorySettingsCard.tsx
+++ b/src/renderer/components/RepositorySettingsCard.tsx
@@ -59,7 +59,10 @@ const RepositorySettingsCard: React.FC = () => {
   );
 
   const example = useMemo(() => {
-    const prefix = settings.branchPrefix || DEFAULTS.branchPrefix;
+    const prefix = settings.branchPrefix.trim();
+    if (!prefix) {
+      return 'my-feature-a3f';
+    }
     return `${prefix}/my-feature-a3f`;
   }, [settings.branchPrefix]);
 
@@ -70,12 +73,16 @@ const RepositorySettingsCard: React.FC = () => {
           value={settings.branchPrefix}
           onChange={(e) => setSettings((s) => ({ ...s, branchPrefix: e.target.value }))}
           onBlur={() => savePartial({ branchPrefix: settings.branchPrefix.trim() })}
-          placeholder="Branch prefix"
-          aria-label="Branch prefix"
+          placeholder="Branch prefix (optional)"
+          aria-label="Branch prefix (optional)"
           disabled={loading}
         />
         <div className="text-[11px] text-muted-foreground">
           Example: <code className="rounded bg-muted/60 px-1">{example}</code>
+          <br />
+          <span className="text-[10px]">
+            Leave empty for no prefix. You can also override this per task during creation.
+          </span>
         </div>
       </div>
 

--- a/src/renderer/components/integrations/LinearSetupForm.tsx
+++ b/src/renderer/components/integrations/LinearSetupForm.tsx
@@ -47,8 +47,8 @@ const LinearSetupForm: React.FC<Props> = ({
           <div className="text-xs leading-snug text-muted-foreground">
             <p className="font-medium text-foreground">How to get a Linear API key</p>
             <ol className="mt-1 list-decimal pl-4">
-              <li>Open Linear, go to Settings → API Tokens.</li>
-              <li>Create a new token and copy the key.</li>
+              <li>Open Linear, go to Settings → Security & access.</li>
+              <li>Create a new personal API key and copy the key.</li>
             </ol>
           </div>
         </div>

--- a/src/renderer/components/ssh/AddRemoteProjectModal.tsx
+++ b/src/renderer/components/ssh/AddRemoteProjectModal.tsx
@@ -222,7 +222,7 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
       setConnectionId(stableId);
 
       // Determine auth type and key path - default to key auth (more reliable)
-      let authType: AuthType = 'key';
+      const authType: AuthType = 'key';
       let privateKeyPath = '';
 
       if (host.identityFile) {

--- a/src/renderer/lib/taskCreationService.ts
+++ b/src/renderer/lib/taskCreationService.ts
@@ -17,6 +17,7 @@ export interface CreateTaskParams {
   autoApprove?: boolean;
   useWorktree: boolean;
   baseRef?: string;
+  branchPrefix?: string;
 }
 
 export interface CreateTaskCallbacks {
@@ -61,6 +62,7 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
     autoApprove,
     useWorktree,
     baseRef,
+    branchPrefix,
   } = params;
   const {
     selectedProject,
@@ -193,6 +195,7 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
                   taskName: variantName,
                   projectId: selectedProject.id,
                   baseRef,
+                  branchPrefix,
                 });
                 if (!worktreeResult?.success || !worktreeResult.worktree) {
                   throw new Error(
@@ -345,6 +348,7 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
           projectPath: selectedProject.path,
           taskName,
           baseRef,
+          branchPrefix,
         });
 
         if (claimResult.success && claimResult.worktree) {
@@ -367,6 +371,7 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
             taskName,
             projectId: selectedProject.id,
             baseRef,
+            branchPrefix,
           });
 
           if (!worktreeResult.success) {

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -388,6 +388,7 @@ declare global {
         taskName: string;
         projectId: string;
         baseRef?: string;
+        branchPrefix?: string;
       }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
       worktreeList: (args: {
         projectPath: string;
@@ -429,6 +430,7 @@ declare global {
         projectPath: string;
         taskName: string;
         baseRef?: string;
+        branchPrefix?: string;
       }) => Promise<{
         success: boolean;
         worktree?: any;
@@ -1322,6 +1324,7 @@ export interface ElectronAPI {
     taskName: string;
     projectId: string;
     baseRef?: string;
+    branchPrefix?: string;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
   worktreeList: (args: {
     projectPath: string;
@@ -1363,6 +1366,7 @@ export interface ElectronAPI {
     projectPath: string;
     taskName: string;
     baseRef?: string;
+    branchPrefix?: string;
   }) => Promise<{
     success: boolean;
     worktree?: any;


### PR DESCRIPTION
This PR adds the option to leave the prefix empty and allows a custom branch prefix for every task. 
 
This is more of an idea; feel free to expand on it or move the option for a custom prefix somewhere else.