### PR TITLE
revert: Revert PR #875 (allow empty branch prefix and custom prefix)

### DIFF
--- a/src/main/services/WorktreePoolService.ts
+++ b/src/main/services/WorktreePoolService.ts
@@ -167,8 +167,7 @@ export class WorktreePoolService {
     projectId: string,
     projectPath: string,
     taskName: string,
-    requestedBaseRef?: string,
-    requestedBranchPrefix?: string
+    requestedBaseRef?: string
   ): Promise<ClaimResult | null> {
     const reserve = this.reserves.get(projectId);
     if (!reserve) {
@@ -189,12 +188,7 @@ export class WorktreePoolService {
     this.reserves.delete(projectId);
 
     try {
-      const result = await this.transformReserve(
-        reserve,
-        taskName,
-        requestedBaseRef,
-        requestedBranchPrefix
-      );
+      const result = await this.transformReserve(reserve, taskName, requestedBaseRef);
 
       // Start background replenishment
       this.replenishReserve(projectId, projectPath, requestedBaseRef);
@@ -214,28 +208,16 @@ export class WorktreePoolService {
   private async transformReserve(
     reserve: ReserveWorktree,
     taskName: string,
-    requestedBaseRef?: string,
-    requestedBranchPrefix?: string
+    requestedBaseRef?: string
   ): Promise<ClaimResult> {
-    // Load settings for prefix resolution and pushOnCreate check
     const { getAppSettings } = await import('../settings');
     const settings = getAppSettings();
-
-    // Resolve effective prefix: explicit override > settings default
-    let effectivePrefix: string;
-    if (requestedBranchPrefix !== undefined) {
-      // Explicit value (empty string means no prefix)
-      effectivePrefix = requestedBranchPrefix.trim().replace(/\/+$/, '');
-    } else {
-      // Use repository default from settings
-      effectivePrefix = settings?.repository?.branchPrefix?.trim() || '';
-    }
+    const prefix = settings?.repository?.branchPrefix || 'emdash';
 
     // Generate new names
     const sluggedName = this.slugify(taskName);
     const hash = this.generateShortHash();
-    const taskSegment = `${sluggedName}-${hash}`;
-    const newBranch = effectivePrefix ? `${effectivePrefix}/${taskSegment}` : taskSegment;
+    const newBranch = `${prefix}/${sluggedName}-${hash}`;
     const newPath = path.join(reserve.projectPath, '..', `worktrees/${sluggedName}-${hash}`);
     const newId = this.stableIdFromPath(newPath);
 

--- a/src/main/services/WorktreeService.ts
+++ b/src/main/services/WorktreeService.ts
@@ -180,8 +180,7 @@ export class WorktreeService {
     projectPath: string,
     taskName: string,
     projectId: string,
-    baseRef?: string,
-    branchPrefix?: string
+    baseRef?: string
   ): Promise<WorktreeInfo> {
     // Declare variables outside try block for access in catch block
     let branchName: string | undefined;
@@ -190,24 +189,10 @@ export class WorktreeService {
     const hash = this.generateShortHash();
 
     try {
-      // Load settings for prefix resolution and pushOnCreate check
       const { getAppSettings } = await import('../settings');
       const settings = getAppSettings();
-
-      // Resolve effective prefix: explicit override > settings default
-      let effectivePrefix: string;
-      if (branchPrefix !== undefined) {
-        // Explicit value (empty string means no prefix)
-        effectivePrefix = branchPrefix.trim().replace(/\/+$/, '');
-      } else {
-        // Use repository default from settings
-        effectivePrefix = settings?.repository?.branchPrefix?.trim() || '';
-      }
-
-      // Build branch name conditionally
-      const taskSegment = `${sluggedName}-${hash}`;
-      const branchNameRaw = effectivePrefix ? `${effectivePrefix}/${taskSegment}` : taskSegment;
-      branchName = this.sanitizeBranchName(branchNameRaw);
+      const prefix = settings?.repository?.branchPrefix || 'emdash';
+      branchName = this.sanitizeBranchName(`${prefix}/${sluggedName}-${hash}`);
       worktreePath = path.join(projectPath, '..', `worktrees/${sluggedName}-${hash}`);
       const worktreeId = this.stableIdFromPath(worktreePath);
 

--- a/src/main/services/worktreeIpc.ts
+++ b/src/main/services/worktreeIpc.ts
@@ -75,7 +75,6 @@ export function registerWorktreeIpc(): void {
         taskName: string;
         projectId: string;
         baseRef?: string;
-        branchPrefix?: string;
       }
     ) => {
       try {
@@ -90,7 +89,6 @@ export function registerWorktreeIpc(): void {
             projectId: project.id,
             remotePath: project.remotePath,
           });
-          // Remote worktrees don't support prefix customization yet
           const remote = await remoteGitService.createWorktree(
             project.sshConnectionId,
             project.remotePath,
@@ -113,8 +111,7 @@ export function registerWorktreeIpc(): void {
           args.projectPath,
           args.taskName,
           args.projectId,
-          args.baseRef,
-          args.branchPrefix
+          args.baseRef
         );
         return { success: true, worktree };
       } catch (error) {
@@ -340,7 +337,6 @@ export function registerWorktreeIpc(): void {
         projectPath: string;
         taskName: string;
         baseRef?: string;
-        branchPrefix?: string;
       }
     ) => {
       try {
@@ -355,8 +351,7 @@ export function registerWorktreeIpc(): void {
           args.projectId,
           args.projectPath,
           args.taskName,
-          args.baseRef,
-          args.branchPrefix
+          args.baseRef
         );
         if (result) {
           return {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -240,7 +240,7 @@ function normalizeSettings(input: AppSettings): AppSettings {
   const repo = input?.repository ?? DEFAULT_SETTINGS.repository;
   let prefix = String(repo?.branchPrefix ?? DEFAULT_SETTINGS.repository.branchPrefix);
   prefix = prefix.trim().replace(/\/+$/, ''); // remove trailing slashes
-  // Allow empty string - no forced fallback to default
+  if (!prefix) prefix = DEFAULT_SETTINGS.repository.branchPrefix;
   if (prefix.length > 50) prefix = prefix.slice(0, 50);
   const push = Boolean(repo?.pushOnCreate ?? DEFAULT_SETTINGS.repository.pushOnCreate);
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -266,8 +266,7 @@ const AppContent: React.FC = () => {
       linkedJiraIssue: JiraIssueSummary | null = null,
       autoApprove?: boolean,
       useWorktree: boolean = true,
-      baseRef?: string,
-      branchPrefix?: string
+      baseRef?: string
     ) => {
       if (!projectMgmt.selectedProject) return;
       await createTask(
@@ -281,7 +280,6 @@ const AppContent: React.FC = () => {
           autoApprove,
           useWorktree,
           baseRef,
-          branchPrefix,
         },
         {
           selectedProject: projectMgmt.selectedProject,

--- a/src/renderer/components/RepositorySettingsCard.tsx
+++ b/src/renderer/components/RepositorySettingsCard.tsx
@@ -59,10 +59,7 @@ const RepositorySettingsCard: React.FC = () => {
   );
 
   const example = useMemo(() => {
-    const prefix = settings.branchPrefix.trim();
-    if (!prefix) {
-      return 'my-feature-a3f';
-    }
+    const prefix = settings.branchPrefix || DEFAULTS.branchPrefix;
     return `${prefix}/my-feature-a3f`;
   }, [settings.branchPrefix]);
 
@@ -73,16 +70,12 @@ const RepositorySettingsCard: React.FC = () => {
           value={settings.branchPrefix}
           onChange={(e) => setSettings((s) => ({ ...s, branchPrefix: e.target.value }))}
           onBlur={() => savePartial({ branchPrefix: settings.branchPrefix.trim() })}
-          placeholder="Branch prefix (optional)"
-          aria-label="Branch prefix (optional)"
+          placeholder="Branch prefix"
+          aria-label="Branch prefix"
           disabled={loading}
         />
         <div className="text-[11px] text-muted-foreground">
           Example: <code className="rounded bg-muted/60 px-1">{example}</code>
-          <br />
-          <span className="text-[10px]">
-            Leave empty for no prefix. You can also override this per task during creation.
-          </span>
         </div>
       </div>
 

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -22,8 +22,6 @@ import {
   MAX_TASK_NAME_LENGTH,
 } from '../lib/taskNames';
 import BranchSelect, { type BranchOption } from './BranchSelect';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
-import { Input } from './ui/input';
 
 const DEFAULT_AGENT: Agent = 'claude';
 
@@ -39,8 +37,7 @@ interface TaskModalProps {
     linkedJiraIssue?: JiraIssueSummary | null,
     autoApprove?: boolean,
     useWorktree?: boolean,
-    baseRef?: string,
-    branchPrefix?: string
+    baseRef?: string
   ) => void;
   projectName: string;
   defaultBranch: string;
@@ -82,11 +79,6 @@ const TaskModal: React.FC<TaskModalProps> = ({
   const [selectedBranch, setSelectedBranch] = useState(defaultBranch);
   const userChangedBranchRef = useRef(false);
   const taskNameInputRef = useRef<HTMLInputElement>(null);
-
-  // Prefix selection state
-  const [prefixMode, setPrefixMode] = useState<'default' | 'none' | 'custom'>('default');
-  const [customPrefix, setCustomPrefix] = useState('');
-  const [repoDefaultPrefix, setRepoDefaultPrefix] = useState<string>('');
 
   useEffect(() => {
     if (isOpen && !userChangedBranchRef.current) {
@@ -169,8 +161,6 @@ const TaskModal: React.FC<TaskModalProps> = ({
     customNameTrackedRef.current = false;
     userChangedBranchRef.current = false;
     setSelectedBranch(defaultBranch);
-    setPrefixMode('default');
-    setCustomPrefix('');
 
     // Generate initial name
     const suggested = generateFriendlyTaskName(normalizedExisting);
@@ -193,10 +183,6 @@ const TaskModal: React.FC<TaskModalProps> = ({
 
       const autoApproveByDefault = settings?.tasks?.autoApproveByDefault ?? false;
       setAutoApprove(autoApproveByDefault && !!agentMeta[agent]?.autoApproveFlag);
-
-      // Load repository default prefix
-      const defaultPrefix = settings?.repository?.branchPrefix?.trim() || '';
-      setRepoDefaultPrefix(defaultPrefix);
 
       // Handle auto-generate setting
       if (settings?.tasks?.autoGenerateName === false && !userHasTypedRef.current) {
@@ -241,19 +227,6 @@ const TaskModal: React.FC<TaskModalProps> = ({
       return;
     }
 
-    // Resolve branch prefix based on selection mode
-    let resolvedBranchPrefix: string | undefined;
-    if (prefixMode === 'default') {
-      // Use repository default (undefined means use default in service layer)
-      resolvedBranchPrefix = undefined;
-    } else if (prefixMode === 'none') {
-      // Explicitly no prefix
-      resolvedBranchPrefix = '';
-    } else {
-      // Custom prefix
-      resolvedBranchPrefix = customPrefix.trim();
-    }
-
     // Close modal immediately - task creation happens in background
     // The task will appear in sidebar via optimistic UI update
     onClose();
@@ -269,8 +242,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
         selectedJiraIssue,
         hasAutoApproveSupport ? autoApprove : false,
         useWorktree,
-        selectedBranch,
-        resolvedBranchPrefix
+        selectedBranch
       );
     } catch (error) {
       console.error('Failed to create task:', error);
@@ -339,39 +311,6 @@ const TaskModal: React.FC<TaskModalProps> = ({
             <Label className="shrink-0">Agent</Label>
             <MultiAgentDropdown agentRuns={agentRuns} onChange={setAgentRuns} />
           </div>
-
-          {useWorktree && (
-            <div className="space-y-2">
-              <Label htmlFor="branch-prefix">Branch prefix</Label>
-              <div className="flex gap-2">
-                <Select
-                  value={prefixMode}
-                  onValueChange={(v) => setPrefixMode(v as typeof prefixMode)}
-                >
-                  <SelectTrigger className="w-[180px]">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    <SelectItem value="default">
-                      Use repository default
-                      {repoDefaultPrefix ? ` (${repoDefaultPrefix})` : ' (none)'}
-                    </SelectItem>
-                    <SelectItem value="none">No prefix</SelectItem>
-                    <SelectItem value="custom">Custom</SelectItem>
-                  </SelectContent>
-                </Select>
-                {prefixMode === 'custom' && (
-                  <Input
-                    id="branch-prefix"
-                    value={customPrefix}
-                    onChange={(e) => setCustomPrefix(e.target.value)}
-                    placeholder="e.g., feature"
-                    className="flex-1"
-                  />
-                )}
-              </div>
-            </div>
-          )}
 
           <TaskAdvancedSettings
             isOpen={isOpen}

--- a/src/renderer/components/integrations/LinearSetupForm.tsx
+++ b/src/renderer/components/integrations/LinearSetupForm.tsx
@@ -47,8 +47,8 @@ const LinearSetupForm: React.FC<Props> = ({
           <div className="text-xs leading-snug text-muted-foreground">
             <p className="font-medium text-foreground">How to get a Linear API key</p>
             <ol className="mt-1 list-decimal pl-4">
-              <li>Open Linear, go to Settings → Security & access.</li>
-              <li>Create a new personal API key and copy the key.</li>
+              <li>Open Linear, go to Settings → API Tokens.</li>
+              <li>Create a new token and copy the key.</li>
             </ol>
           </div>
         </div>

--- a/src/renderer/lib/taskCreationService.ts
+++ b/src/renderer/lib/taskCreationService.ts
@@ -17,7 +17,6 @@ export interface CreateTaskParams {
   autoApprove?: boolean;
   useWorktree: boolean;
   baseRef?: string;
-  branchPrefix?: string;
 }
 
 export interface CreateTaskCallbacks {
@@ -62,7 +61,6 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
     autoApprove,
     useWorktree,
     baseRef,
-    branchPrefix,
   } = params;
   const {
     selectedProject,
@@ -195,7 +193,6 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
                   taskName: variantName,
                   projectId: selectedProject.id,
                   baseRef,
-                  branchPrefix,
                 });
                 if (!worktreeResult?.success || !worktreeResult.worktree) {
                   throw new Error(
@@ -348,7 +345,6 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
           projectPath: selectedProject.path,
           taskName,
           baseRef,
-          branchPrefix,
         });
 
         if (claimResult.success && claimResult.worktree) {
@@ -371,7 +367,6 @@ export async function createTask(params: CreateTaskParams, callbacks: CreateTask
             taskName,
             projectId: selectedProject.id,
             baseRef,
-            branchPrefix,
           });
 
           if (!worktreeResult.success) {

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -388,7 +388,6 @@ declare global {
         taskName: string;
         projectId: string;
         baseRef?: string;
-        branchPrefix?: string;
       }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
       worktreeList: (args: {
         projectPath: string;
@@ -430,7 +429,6 @@ declare global {
         projectPath: string;
         taskName: string;
         baseRef?: string;
-        branchPrefix?: string;
       }) => Promise<{
         success: boolean;
         worktree?: any;
@@ -1324,7 +1322,6 @@ export interface ElectronAPI {
     taskName: string;
     projectId: string;
     baseRef?: string;
-    branchPrefix?: string;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
   worktreeList: (args: {
     projectPath: string;
@@ -1366,7 +1363,6 @@ export interface ElectronAPI {
     projectPath: string;
     taskName: string;
     baseRef?: string;
-    branchPrefix?: string;
   }) => Promise<{
     success: boolean;
     worktree?: any;


### PR DESCRIPTION
## Summary
- Reverts #875 which was accidentally merged
- Removes the empty branch prefix option and custom per-task branch prefix feature

## Test plan
- [ ] Verify `pnpm run dev` starts cleanly
- [ ] Verify task creation works with default branch prefix behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)