### PR TITLE
fix(pty): remove dead PTY records on exit to prevent memory leak

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -249,6 +249,7 @@ export function registerPtyIpc(): void {
           safeSendToOwner(id, `pty:exit:${id}`, { exitCode, signal });
           owners.delete(id);
           listeners.delete(id);
+          removePtyRecord(id);
         });
         listeners.add(id);
       }
@@ -457,6 +458,7 @@ export function registerPtyIpc(): void {
             );
             owners.delete(id);
             listeners.delete(id);
+            removePtyRecord(id);
           });
 
           listeners.add(id);
@@ -769,6 +771,7 @@ export function registerPtyIpc(): void {
               owners.delete(id);
             }
             listeners.delete(id);
+            removePtyRecord(id);
           });
           listeners.add(id);
         }


### PR DESCRIPTION
## Summary
- Local PTY `onExit` handlers cleaned up `owners` and `listeners` but never called `removePtyRecord()`, leaving dead `PtyRecord` objects (holding `IPty` native references) in the `ptys` Map indefinitely
- Added `removePtyRecord(id)` to the 3 local PTY `onExit` handlers that were missing it — matching the existing behavior in SSH `onExit` handlers and `killPty()`
- Prevents unbounded memory growth in the main process during long sessions with many agent runs

## Test plan
- [ ] Start emdash, run an agent, let it finish naturally — verify PTY cleans up (no stale entries in ptys Map)
- [ ] Run multiple agents sequentially in the same task — verify shell respawn still works correctly
- [ ] Kill an agent manually via UI — verify cleanup still works (this path uses `killPty` which was already correct)
- [ ] `pnpm run type-check` passes
- [ ] `pnpm run lint` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)