### PR TITLE
fix: multi-chat tabs disappearing when adding a new chat     

### DIFF
--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -461,6 +461,7 @@ export class DatabaseService {
       taskId,
       title: 'Default Conversation',
       isMain: true,
+      isActive: true,
     });
 
     const [createdRow] = await db


### PR DESCRIPTION
## Summary

- Move single-agent task DB save from a background fire-and-forget call to a synchronous `await` **before** updating UI state, ensuring the task row exists before `ChatInterface` mounts and tries to create/load conversations (which have FK constraints on the task)
- Set `isActive: true` on default conversations when created, both in `DatabaseService` and when hydrating conversation state in `ChatInterface`
- Fix conversation tab loss when creating a new chat: reconcile React-only conversations with DB state so tabs that existed only in memory are re-persisted before overwriting local state
- Add `conversations` to the `useCallback` dependency array for `handleCreateNewChat` to ensure the reconciliation logic sees current state

## Problem

When a single-agent task was created, the DB save happened asynchronously in the background. If `ChatInterface` mounted and attempted to create or fetch conversations before the task row was committed, the operation would fail due to foreign key constraints. Additionally, switching agents or creating new chats could lose existing conversation tabs that hadn't been persisted to the database.

## Test plan

- Create a new single-agent task and verify it appears immediately with a working chat
- Create multiple conversation tabs within a task, then create a new chat — verify no tabs are lost
- Restart the app and confirm all tasks and conversations persist correctly
- Verify multi-agent task creation still works (unchanged path)