### PR TITLE
fix(navigation): close settings when going home

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -603,7 +603,10 @@ const AppContent: React.FC = () => {
                 projects={projectMgmt.projects}
                 handleSelectProject={projectMgmt.handleSelectProject}
                 handleSelectTask={taskMgmt.handleSelectTask}
-                handleGoHome={projectMgmt.handleGoHome}
+                handleGoHome={() => {
+                  handleCloseSettingsPage();
+                  projectMgmt.handleGoHome();
+                }}
                 handleOpenProject={projectMgmt.handleOpenProject}
                 handleOpenSettings={() => openSettingsPage()}
                 handleOpenKeyboardShortcuts={() => openSettingsPage('interface')}


### PR DESCRIPTION
## Summary
Fixes an issue where triggering "Go Home" from the command palette while on the Settings page did not close the Settings view, preventing proper navigation.

## Before
The Settings page remained open after selecting "Go Home" from the command palette.

https://github.com/user-attachments/assets/a507bb73-8235-45ce-83e5-8e323deb87c8



## After
The Settings page closes correctly and the Home view is displayed.

https://github.com/user-attachments/assets/e00a1f0b-d159-40f4-b1a2-40adfb6f4ed6


