### PR TITLE
fix(pty): add keystroke injection mode for Amp and OpenCode agents

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -281,8 +281,12 @@ export function startDirectPty(options: {
       cliArgs.push(provider.autoApproveFlag);
     }
 
-    // Add initial prompt
-    if (provider.initialPromptFlag !== undefined && initialPrompt?.trim()) {
+    // Add initial prompt (skip if agent uses keystroke injection instead)
+    if (
+      provider.initialPromptFlag !== undefined &&
+      !provider.useKeystrokeInjection &&
+      initialPrompt?.trim()
+    ) {
       if (provider.initialPromptFlag) {
         cliArgs.push(provider.initialPromptFlag);
       }
@@ -526,7 +530,12 @@ export async function startPty(options: {
         }
 
         // Finally initial prompt (parse shell-style in case of multiple flags or quoted values)
-        if (resolvedInitialPromptFlag !== undefined && initialPrompt?.trim()) {
+        // Skip if agent uses keystroke injection instead of CLI arg
+        if (
+          resolvedInitialPromptFlag !== undefined &&
+          !provider.useKeystrokeInjection &&
+          initialPrompt?.trim()
+        ) {
           if (resolvedInitialPromptFlag) {
             const promptFlagParts = parseShellArgs(resolvedInitialPromptFlag);
             cliArgs.push(...promptFlagParts);

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -729,13 +729,17 @@ const ChatInterface: React.FC<Props> = ({
     return null;
   }, [isTerminal, task.metadata, commentsContext]);
 
-  // Only use keystroke injection for agents WITHOUT CLI flag support
-  // Agents with initialPromptFlag use CLI arg injection via TerminalPane instead
+  // Only use keystroke injection for agents WITHOUT CLI flag support,
+  // or agents that explicitly opt into it (useKeystrokeInjection: true).
+  // Agents with initialPromptFlag use CLI arg injection via TerminalPane instead.
   useInitialPromptInjection({
     taskId: task.id,
     providerId: agent,
     prompt: initialInjection,
-    enabled: isTerminal && agentMeta[agent]?.initialPromptFlag === undefined,
+    enabled:
+      isTerminal &&
+      (agentMeta[agent]?.initialPromptFlag === undefined ||
+        agentMeta[agent]?.useKeystrokeInjection === true),
   });
 
   // Ensure an agent is stored for this task so fallbacks can subscribe immediately
@@ -991,6 +995,7 @@ const ChatInterface: React.FC<Props> = ({
                   }
                   initialPrompt={
                     agentMeta[agent]?.initialPromptFlag !== undefined &&
+                    !agentMeta[agent]?.useKeystrokeInjection &&
                     !task.metadata?.initialInjectionSent
                       ? (initialInjection ?? undefined)
                       : undefined

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -532,6 +532,7 @@ const MultiAgentTask: React.FC<Props> = ({
                     }
                     initialPrompt={
                       agentMeta[v.agent]?.initialPromptFlag !== undefined &&
+                      !agentMeta[v.agent]?.useKeystrokeInjection &&
                       !task.metadata?.initialInjectionSent
                         ? (initialInjection ?? undefined)
                         : undefined
@@ -561,11 +562,12 @@ const MultiAgentTask: React.FC<Props> = ({
                     }
                     className="h-full w-full"
                     onStartSuccess={() => {
-                      // For agents WITHOUT CLI flag support, use keystroke injection
+                      // For agents WITHOUT CLI flag support or with keystroke injection, type prompt in
                       if (
                         initialInjection &&
                         !task.metadata?.initialInjectionSent &&
-                        agentMeta[v.agent]?.initialPromptFlag === undefined
+                        (agentMeta[v.agent]?.initialPromptFlag === undefined ||
+                          agentMeta[v.agent]?.useKeystrokeInjection)
                       ) {
                         void injectPrompt(`${v.worktreeId}-main`, v.agent, initialInjection);
                       }

--- a/src/renderer/providers/meta.ts
+++ b/src/renderer/providers/meta.ts
@@ -57,6 +57,7 @@ export type AgentMeta = {
   autoStartCommand?: string;
   autoApproveFlag?: string;
   initialPromptFlag?: string;
+  useKeystrokeInjection?: boolean;
 };
 
 export const agentMeta: Record<UiAgent, AgentMeta> = Object.fromEntries(
@@ -71,6 +72,7 @@ export const agentMeta: Record<UiAgent, AgentMeta> = Object.fromEntries(
       autoStartCommand: p.autoStartCommand,
       autoApproveFlag: p.autoApproveFlag,
       initialPromptFlag: p.initialPromptFlag,
+      useKeystrokeInjection: p.useKeystrokeInjection,
     },
   ])
 ) as Record<UiAgent, AgentMeta>;

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -35,6 +35,12 @@ export type ProviderDefinition = {
   cli?: string;
   autoApproveFlag?: string;
   initialPromptFlag?: string;
+  /**
+   * When true, the initial prompt is delivered via keystroke injection
+   * (typing into the TUI after startup) instead of as a CLI argument.
+   * Use for agents whose CLI has no flag for interactive-mode prompt delivery.
+   */
+  useKeystrokeInjection?: boolean;
   resumeFlag?: string;
   defaultArgs?: string[];
   planActivateCommand?: string;
@@ -137,6 +143,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     cli: 'amp',
     autoApproveFlag: '--dangerously-allow-all',
     initialPromptFlag: '',
+    useKeystrokeInjection: true,
     icon: 'ampcode.png',
     terminalOnly: true,
   },
@@ -148,7 +155,8 @@ export const PROVIDERS: ProviderDefinition[] = [
     commands: ['opencode'],
     versionArgs: ['--version'],
     cli: 'opencode',
-    initialPromptFlag: '--prompt',
+    initialPromptFlag: '',
+    useKeystrokeInjection: true,
     icon: 'opencode.png',
     terminalOnly: true,
   },


### PR DESCRIPTION
## Summary

- Adds a `useKeystrokeInjection` flag to the provider definition to support agents that need their initial prompt typed into the TUI after startup rather than passed as a CLI argument
- Enables this flag for **Amp** and **OpenCode**, fixing prompt delivery for agents whose CLI doesn't support passing prompts as arguments in interactive mode
- Updates `ptyManager.ts` to skip CLI arg injection when `useKeystrokeInjection` is true
- Updates `ChatInterface.tsx` and `MultiAgentTask.tsx` to route initial prompts through keystroke injection for opted-in agents

## Context

Some agents (like Amp) define an `initialPromptFlag` (empty string = positional arg) but their CLI doesn't actually accept prompts that way in interactive/TUI mode. This caused prompts to be silently dropped. The new `useKeystrokeInjection` flag allows an agent to declare that it has CLI support but still needs the prompt typed in after the TUI loads.

Closes #326