### PR TITLE
Derive flake pnpm from package.json packageManager

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -21,16 +21,15 @@
             throw "package.json must define packageManager as pnpm@<version> (optionally with +suffix)";
         requiredPnpmMajor = builtins.elemAt (builtins.match "([0-9]+)\\..*" requiredPnpmVersion) 0;
         requiredPnpmAttr = "pnpm_" + requiredPnpmMajor;
+        majorPnpm =
+          if builtins.hasAttr requiredPnpmAttr pkgs then
+            builtins.getAttr requiredPnpmAttr pkgs
+          else
+            null;
         nodejs = pkgs.nodejs_22;
         pnpm =
-          if builtins.hasAttr requiredPnpmAttr pkgs then
-            let
-              candidate = builtins.getAttr requiredPnpmAttr pkgs;
-            in
-            if lib.versionAtLeast candidate.version requiredPnpmVersion then
-              candidate
-            else
-              throw "Nixpkgs ${requiredPnpmAttr} is too old for this repo. Required >= ${requiredPnpmVersion}, but found ${candidate.version}."
+          if majorPnpm != null && lib.versionAtLeast majorPnpm.version requiredPnpmVersion then
+            majorPnpm
           else if pkgs ? pnpm && lib.versionAtLeast pkgs.pnpm.version requiredPnpmVersion then
             pkgs.pnpm
           else


### PR DESCRIPTION
## Summary
- derive the required pnpm version in `flake.nix` from `package.json` `packageManager`
- select an exact `pnpm_<version>` attr when present, otherwise fall back to compatible `pnpm`/`pnpm_10`
- fail early with a clear error if pinned nixpkgs cannot satisfy the required pnpm version

## Why
The Nix build was using an older static pnpm package and failed against `engines.pnpm >=10.28.2`. This keeps `package.json` as the single source of truth and prevents silent drift.

## Validation
- `nix-instantiate --parse flake.nix`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/dev-shell tooling-only change that mainly affects Nix environment resolution and adds earlier failures when `pnpm` requirements aren’t met.
> 
> **Overview**
> `flake.nix` now derives the required `pnpm` version from `package.json`’s `packageManager` field, extracting the pinned semver (and major) to choose a matching `pnpm_<major>` when available.
> 
> The flake falls back to `pkgs.pnpm` only when it meets the required minimum version, and otherwise throws a clear error to prevent builds using an incompatible/too-old `pnpm`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9f7762003d32d07e65ba5ff7413dd5bd7a30a316. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->