### PR TITLE
fix(git): propagate commit-and-push errors with proper messages

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -882,6 +882,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
           }
         } catch (e) {
           log.warn('Stage/commit step issue:', e as string);
+          throw e;
         }
 
         // Push current branch (set upstream if needed)
@@ -897,7 +898,9 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         return { success: true, branch: activeBranch, output: (out || '').trim() };
       } catch (error) {
         log.error('Failed to commit and push:', error);
-        return { success: false, error: error as string };
+        const errObj = error as { stderr?: string; message?: string };
+        const errMsg = errObj?.stderr?.trim() || errObj?.message || String(error);
+        return { success: false, error: errMsg };
       }
     }
   );


### PR DESCRIPTION
fixes https://github.com/generalaction/emdash/pull/903

## Summary
- Re-throw stage/commit errors in `git:commit-and-push` so failures are not silently swallowed
- Extract meaningful error message from `stderr` or `message` property instead of returning the raw error object as a string

## Problem
When the stage/commit step failed during `git:commit-and-push`, the error was caught and logged but not re-thrown, causing the handler to proceed to the push step and eventually return a misleading success or unhelpful error. The error response also cast the entire error object to `string`, producing `[object Object]` instead of a useful message.

## Changes
- Added `throw e` in the stage/commit catch block so failures propagate to the outer error handler
- Extracted `stderr` or `message` from the error object for a human-readable error response