### PR TITLE
fix(search): truncate overflowing text in search results panel

### DIFF
--- a/src/renderer/components/FileExplorer/ContentSearchResults.tsx
+++ b/src/renderer/components/FileExplorer/ContentSearchResults.tsx
@@ -67,9 +67,13 @@ const SearchResultItem: React.FC<{
 };
 
 const FileHeader: React.FC<{ fileName: string; filePath: string }> = ({ fileName, filePath }) => (
-  <div className="flex items-center gap-1">
-    <FileIcon filename={fileName} isDirectory={false} />
-    <span className="text-sm font-medium">{filePath}</span>
+  <div className="flex items-center gap-1 overflow-hidden">
+    <span className="shrink-0">
+      <FileIcon filename={fileName} isDirectory={false} />
+    </span>
+    <span className="truncate text-sm font-medium" title={filePath}>
+      {filePath}
+    </span>
   </div>
 );
 
@@ -82,9 +86,9 @@ const MatchList: React.FC<{ matches: any[] }> = ({ matches }) => (
 );
 
 const MatchPreview: React.FC<{ match: any }> = ({ match }) => (
-  <div className="text-xs text-muted-foreground">
-    <span className="font-mono">Line {match.line}:</span>{' '}
-    <span className="text-foreground">{match.preview}</span>
+  <div className="flex gap-1 overflow-hidden text-xs text-muted-foreground">
+    <span className="shrink-0 font-mono">Line {match.line}:</span>
+    <span className="truncate text-foreground">{match.preview}</span>
   </div>
 );
 


### PR DESCRIPTION
 When searching for content in files, long file paths would overflow outside the search panel container, making the UI look broken. This PR added proper text truncation with ellipsis to:
- File paths in search results
- Match preview text

Before:

https://github.com/user-attachments/assets/114f7b4e-3685-4dca-8439-d89f8eb42f8e



After:

https://github.com/user-attachments/assets/b940f7e2-c8d3-4213-a031-3cdedea55576


