### PR TITLE
fix(feedback): update Discord webhook URL

### DIFF
--- a/src/renderer/components/FeedbackModal.tsx
+++ b/src/renderer/components/FeedbackModal.tsx
@@ -9,7 +9,7 @@ import { Textarea } from './ui/textarea';
 import { useToast } from '../hooks/use-toast';
 
 const DISCORD_WEBHOOK_URL =
-  'https://discord.com/api/webhooks/1430482776045391912/7r3aZtu7y0safAJfFF0mywzw2uoY_2UhadMf7uv1oJSitIC2eUirWzGHdjiEm7zgdPDt';
+  'https://discord.com/api/webhooks/1473390363388416230/eRIo1UhylapH94KpqUUp5PDzkLhjBvcnjjyE_JezfHiAyfN3QEbRyEIJaSl8QQUz7Mak';
 
 interface FeedbackModalProps {
   isOpen: boolean;


### PR DESCRIPTION
## Summary
- replace the stale Discord feedback webhook URL used by the feedback modal
- restore feedback submission flow that was failing with HTTP 404 (Unknown Webhook)

## Testing
- manually submitted feedback from the in-app feedback modal
- confirmed submission succeeds with the new webhook

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates a hardcoded Discord webhook endpoint used for feedback submission, with no logic or data handling changes.
> 
> **Overview**
> Restores in-app feedback submissions by replacing the stale `DISCORD_WEBHOOK_URL` in `FeedbackModal.tsx` with a new Discord webhook endpoint (fixing failures from an invalid/removed webhook).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9e1aa31ffa3656b62b0abbe12c5e80cfe719b28d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->