### PR TITLE
fix: close modals before titlebar view toggles

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -434,6 +434,41 @@ const AppContent: React.FC = () => {
     return selectedProject.isRemote ? selectedProject.path : null;
   }, [selectedProject, derivedRemoteConnectionId]);
 
+  // Close modals before titlebar view toggles
+  const handleTitlebarKanbanToggle = useCallback(() => {
+    const isModalOpen = showCommandPalette || showSettingsPage;
+    if (isModalOpen) {
+      if (showCommandPalette) handleCloseCommandPalette();
+      if (showSettingsPage) handleCloseSettingsPage();
+      setTimeout(() => handleToggleKanban(), 100);
+    } else {
+      handleToggleKanban();
+    }
+  }, [
+    showCommandPalette,
+    showSettingsPage,
+    handleCloseCommandPalette,
+    handleCloseSettingsPage,
+    handleToggleKanban,
+  ]);
+
+  const handleTitlebarEditorToggle = useCallback(() => {
+    const isModalOpen = showCommandPalette || showSettingsPage;
+    if (isModalOpen) {
+      if (showCommandPalette) handleCloseCommandPalette();
+      if (showSettingsPage) handleCloseSettingsPage();
+      setTimeout(() => handleToggleEditor(), 100);
+    } else {
+      handleToggleEditor();
+    }
+  }, [
+    showCommandPalette,
+    showSettingsPage,
+    handleCloseCommandPalette,
+    handleCloseSettingsPage,
+    handleToggleEditor,
+  ]);
+
   return (
     <BrowserProvider>
       <div
@@ -479,10 +514,10 @@ const AppContent: React.FC = () => {
                   projectPath={selectedProject?.path || null}
                   isTaskMultiAgent={Boolean(activeTask?.metadata?.multiAgent?.enabled)}
                   githubUser={github.user}
-                  onToggleKanban={handleToggleKanban}
+                  onToggleKanban={handleTitlebarKanbanToggle}
                   isKanbanOpen={Boolean(showKanban)}
                   kanbanAvailable={Boolean(selectedProject)}
-                  onToggleEditor={handleToggleEditor}
+                  onToggleEditor={handleTitlebarEditorToggle}
                   showEditorButton={Boolean(activeTask)}
                   isEditorOpen={showEditorMode}
                   projects={projectMgmt.projects}


### PR DESCRIPTION
Fixes #933 
  
Added wrapper functions for titlebar kanban and editor buttons to close open modals before toggling views, matching keyboard shortcut behavior.