### PR TITLE
  feat: allow multiple chats of the same provider on one worktree

### DIFF
--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -50,6 +50,11 @@ export type ProviderDefinition = {
    * e.g. '--session-id' for Claude Code.
    */
   sessionIdFlag?: string;
+  /**
+   * CLI flag to resume a specific isolated session by id.
+   * e.g. '--resume' for Claude Code.
+   */
+  sessionResumeFlag?: string;
   defaultArgs?: string[];
   planActivateCommand?: string;
   autoStartCommand?: string;
@@ -84,6 +89,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '',
     resumeFlag: '-c -r',
     sessionIdFlag: '--session-id',
+    sessionResumeFlag: '--resume',
     planActivateCommand: '/plan',
     icon: 'claude.png',
     terminalOnly: true,


### PR DESCRIPTION
  Closes #837

  Summary
  Allow multiple chat instances of the same provider within a single task/worktree.

   What changed
  - Removed UI uniqueness restriction that blocked selecting an already-used provider in New Chat.
  - Kept and enabled duplicate-instance tab labeling (e.g. provider instance numbering).
  - Added provider capability `sessionIdFlag` and configured Claude with `--session-id`.
  - Implemented PTY session isolation/resume logic so same-provider chats keep separate histories.
  - Updated PTY IPC resume behavior:
    - additional chats resume only when provider supports per-session isolation
    - otherwise additional chats start fresh to avoid shared provider session state.

  Why
  Previously, users had to choose different providers to run parallel chats in the same worktree, even when they wanted    
multiple instances of the same provider.

  Testing
  - `pnpm run type-check` ✅
  - `pnpm exec vitest run src/test/main/ptyIpc.test.ts` ✅
  - Manual: in one task/worktree, created multiple chats with same provider ✅
  
  
![Image 18-02-26 at 11 03 AM](https://github.com/user-attachments/assets/e0a4cab9-5c16-4529-a910-dfdb3c75082a)
