### PR TITLE
Unify provider command config across local and remote PTY execution

### DIFF
--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const providerStatusGetMock = vi.fn();
+const getProviderCustomConfigMock = vi.fn();
+const execFileSyncMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  execFileSync: execFileSyncMock,
+}));
+
+vi.mock('../../main/services/providerStatusCache', () => ({
+  providerStatusCache: {
+    get: providerStatusGetMock,
+  },
+}));
+
+vi.mock('../../main/settings', () => ({
+  getProviderCustomConfig: getProviderCustomConfigMock,
+}));
+
+vi.mock('../../main/lib/logger', () => ({
+  log: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('../../main/errorTracking', () => ({
+  errorTracking: {
+    captureAgentSpawnError: vi.fn(),
+    captureCriticalError: vi.fn(),
+  },
+}));
+
+describe('ptyManager provider command resolution', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    providerStatusGetMock.mockReturnValue({
+      installed: true,
+      path: '/usr/local/bin/codex',
+    });
+    getProviderCustomConfigMock.mockReturnValue(undefined);
+  });
+
+  it('resolves provider command config from custom settings', async () => {
+    getProviderCustomConfigMock.mockReturnValue({
+      cli: 'codex-custom',
+      resumeFlag: 'resume --last',
+      defaultArgs: '--model gpt-5',
+      autoApproveFlag: '--dangerously-bypass-approvals-and-sandbox',
+      initialPromptFlag: '',
+    });
+
+    const { resolveProviderCommandConfig } = await import('../../main/services/ptyManager');
+    const config = resolveProviderCommandConfig('codex');
+
+    expect(config?.cli).toBe('codex-custom');
+    expect(config?.resumeFlag).toBe('resume --last');
+    expect(config?.defaultArgs).toEqual(['--model', 'gpt-5']);
+    expect(config?.autoApproveFlag).toBe('--dangerously-bypass-approvals-and-sandbox');
+    expect(config?.initialPromptFlag).toBe('');
+  });
+
+  it('builds provider CLI args consistently from resolved flags', async () => {
+    const { buildProviderCliArgs } = await import('../../main/services/ptyManager');
+
+    const args = buildProviderCliArgs({
+      resume: true,
+      resumeFlag: 'resume --last',
+      defaultArgs: ['--model', 'gpt-5'],
+      autoApprove: true,
+      autoApproveFlag: '--dangerously-bypass-approvals-and-sandbox',
+      initialPrompt: 'hello world',
+      initialPromptFlag: '',
+      useKeystrokeInjection: false,
+    });
+
+    expect(args).toEqual([
+      'resume',
+      '--last',
+      '--model',
+      'gpt-5',
+      '--dangerously-bypass-approvals-and-sandbox',
+      'hello world',
+    ]);
+  });
+
+  it('falls back when custom CLI needs shell parsing', async () => {
+    getProviderCustomConfigMock.mockReturnValue({
+      cli: 'codex --dangerously-bypass-approvals-and-sandbox',
+    });
+
+    const { startDirectPty } = await import('../../main/services/ptyManager');
+    const proc = startDirectPty({
+      id: 'codex-main-shell-fallback',
+      providerId: 'codex',
+      cwd: '/tmp/task',
+    });
+
+    expect(proc).toBeNull();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- centralize provider command resolution in `ptyManager` with shared helpers for CLI, flags, and argument parsing
- apply the same resolved provider config to local direct spawn, local shell-based provider launch, and remote provider invocation
- keep direct spawn fast-path and only fall back to shell mode when custom CLI needs shell semantics (alias/compound command)
- add targeted tests for provider command resolution and remote invocation config propagation

## Validation
- `pnpm run format`
- `pnpm run lint` (existing repo warnings only)
- `pnpm run type-check`
- `pnpm exec vitest run src/test/main/ptyManager.test.ts src/test/main/ptyIpc.test.ts`
- `pnpm exec vitest run` *(fails on existing unrelated tests: `src/test/main/GitHubService.test.ts`, `src/test/main/TaskLifecycleService.test.ts`)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core PTY spawn paths (direct, shell, and remote) and changes how configured CLI commands are resolved/executed, which could affect agent startup behavior across platforms despite added tests.
> 
> **Overview**
> Provider CLI resolution is centralized in `ptyManager` via new helpers (`resolveProviderCommandConfig`, `buildProviderCliArgs`, exported `parseShellArgs`) so custom per-provider CLI/flags are applied consistently for direct-spawn PTYs, shell-based launches, and remote SSH invocations.
> 
> Direct-spawn now attempts to execute a custom `cli` override by resolving it to an executable (`which`/`where`) and **falls back to shell mode** when the configured command requires shell parsing/semantics; remote invocation now checks `command -v` against the parsed base command while still executing the full configured command string. Tests were updated/added to cover config resolution, arg building, direct-spawn fallback, and remote flag propagation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 53550174bae2e3bd6b3f170bcb04aee7d7524284. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->