### PR TITLE
test(github): align isAuthenticated gh-cli expectations

### DIFF
--- a/src/test/main/GitHubService.test.ts
+++ b/src/test/main/GitHubService.test.ts
@@ -87,6 +87,7 @@ describe('GitHubService.isAuthenticated', () => {
 
     expect(result).toBe(true);
     expect(execCalls.find((cmd) => cmd.startsWith('gh auth status'))).toBeDefined();
-    expect(setPasswordMock).toHaveBeenCalledWith('emdash-github', 'github-token', 'gho_mocktoken');
+    expect(execCalls.find((cmd) => cmd.startsWith('gh auth token'))).toBeUndefined();
+    expect(setPasswordMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
this test was failing after we updated gh auth

## Summary
- update  test to match current behavior when github.com

## Validation
- pnpm exec vitest run src/test/main/GitHubService.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only change that tightens expectations around side effects (no token fetch/storage) without modifying production authentication code.
> 
> **Overview**
> Adjusts the `GitHubService.isAuthenticated` unit test to match current behavior when GitHub CLI is already authenticated.
> 
> The test now asserts that the `gh auth token` command is *not* invoked and that `keytar.setPassword` is not called in this path, instead of expecting the token to be fetched and stored.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c7df24267d7107a4f692910b92a8b89e01bdbe52. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->