### PR TITLE
feat(worktree): add per-task DB target env

### DIFF
--- a/drizzle/0010_add_db_target_to_tasks.sql
+++ b/drizzle/0010_add_db_target_to_tasks.sql
@@ -1,0 +1,2 @@
+ALTER TABLE `tasks` ADD COLUMN `db_target` text;
+--> statement-breakpoint

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -69,6 +69,7 @@ export const tasks = sqliteTable(
     agentId: text('agent_id'),
     metadata: text('metadata'),
     useWorktree: integer('use_worktree').notNull().default(1),
+    dbTarget: text('db_target'), // JSON string: { url?: string, name?: string, profile?: string }
     archivedAt: text('archived_at'), // null = active, timestamp = archived
     createdAt: text('created_at')
       .notNull()

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -165,6 +165,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     taskName: string;
     projectId: string;
     baseRef?: string;
+    dbTarget?: string | null;
   }) => ipcRenderer.invoke('worktree:create', args),
   worktreeList: (args: { projectPath: string }) => ipcRenderer.invoke('worktree:list', args),
   worktreeRemove: (args: {
@@ -714,6 +715,7 @@ export interface ElectronAPI {
     taskName: string;
     projectId: string;
     baseRef?: string;
+    dbTarget?: string | null;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
   worktreeList: (args: {
     projectPath: string;

--- a/src/main/services/TaskLifecycleService.ts
+++ b/src/main/services/TaskLifecycleService.ts
@@ -12,6 +12,7 @@ import {
 import { getTaskEnvVars } from '@shared/task/envVars';
 import { log } from '../lib/logger';
 import { execFile } from 'node:child_process';
+import { databaseService } from './DatabaseService';
 
 const execFileAsync = promisify(execFile);
 
@@ -107,6 +108,7 @@ class TaskLifecycleService extends EventEmitter {
   ): Promise<NodeJS.ProcessEnv> {
     const defaultBranch = await this.resolveDefaultBranch(projectPath);
     const taskName = path.basename(taskPath) || taskId;
+    const task = await databaseService.getTaskById(taskId);
     const taskEnv = getTaskEnvVars({
       taskId,
       taskName,
@@ -114,6 +116,7 @@ class TaskLifecycleService extends EventEmitter {
       projectPath,
       defaultBranch,
       portSeed: taskPath || taskId,
+      dbTarget: task?.dbTarget ?? null,
     });
     return { ...process.env, ...taskEnv };
   }

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -49,6 +49,19 @@ const AGENT_ENV_VARS = [
   'OPENAI_BASE_URL',
 ];
 
+const TASK_DB_ENV_VARS = new Set([
+  'DATABASE_URL',
+  'DB_URL',
+  'DB_NAME',
+  'DATABASE_NAME',
+  'DB_PROFILE',
+  'DATABASE_PROFILE',
+]);
+
+function shouldForwardTaskEnvVar(key: string): boolean {
+  return key.startsWith('EMDASH_') || TASK_DB_ENV_VARS.has(key);
+}
+
 type PtyRecord = {
   id: string;
   proc: IPty;
@@ -387,7 +400,7 @@ export function startSshPty(options: {
 
   if (env) {
     for (const [key, value] of Object.entries(env)) {
-      if (!key.startsWith('EMDASH_')) continue;
+      if (!shouldForwardTaskEnvVar(key)) continue;
       if (typeof value === 'string') {
         useEnv[key] = value;
       }
@@ -514,7 +527,7 @@ export function startDirectPty(options: {
 
   if (env) {
     for (const [key, value] of Object.entries(env)) {
-      if (!key.startsWith('EMDASH_')) continue;
+      if (!shouldForwardTaskEnvVar(key)) continue;
       if (typeof value === 'string') {
         useEnv[key] = value;
       }

--- a/src/main/services/worktreeIpc.ts
+++ b/src/main/services/worktreeIpc.ts
@@ -75,6 +75,7 @@ export function registerWorktreeIpc(): void {
         taskName: string;
         projectId: string;
         baseRef?: string;
+        dbTarget?: string | null;
       }
     ) => {
       try {
@@ -103,6 +104,7 @@ export function registerWorktreeIpc(): void {
             projectId: project.id,
             status: 'active' as const,
             createdAt: new Date().toISOString(),
+            dbTarget: args.dbTarget ?? null,
           };
           return { success: true, worktree };
         }
@@ -113,7 +115,7 @@ export function registerWorktreeIpc(): void {
           args.projectId,
           args.baseRef
         );
-        return { success: true, worktree };
+        return { success: true, worktree: { ...worktree, dbTarget: args.dbTarget ?? null } };
       } catch (error) {
         console.error('Failed to create worktree:', error);
         return { success: false, error: (error as Error).message };

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -274,7 +274,8 @@ const AppContent: React.FC = () => {
       linkedJiraIssue: JiraIssueSummary | null = null,
       autoApprove?: boolean,
       useWorktree: boolean = true,
-      baseRef?: string
+      baseRef?: string,
+      dbTarget?: string | null
     ) => {
       if (!projectMgmt.selectedProject) return;
       await createTask(
@@ -288,6 +289,7 @@ const AppContent: React.FC = () => {
           autoApprove,
           useWorktree,
           baseRef,
+          dbTarget: dbTarget ?? null,
         },
         {
           selectedProject: projectMgmt.selectedProject,

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -99,8 +99,23 @@ const ChatInterface: React.FC<Props> = ({
       taskPath: task.path,
       projectPath,
       defaultBranch: defaultBranch || undefined,
+      dbTarget: task.dbTarget,
     });
-  }, [task.id, task.name, task.path, projectPath, defaultBranch]);
+  }, [task.id, task.name, task.path, projectPath, defaultBranch, task.dbTarget]);
+
+  const dbTargetLabel = useMemo(() => {
+    const raw = (task.dbTarget ?? '').trim();
+    if (!raw) return null;
+    try {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') {
+        const profile = typeof parsed.profile === 'string' ? parsed.profile.trim() : '';
+        const name = typeof parsed.name === 'string' ? parsed.name.trim() : '';
+        return profile || name || 'custom';
+      }
+    } catch {}
+    return 'custom';
+  }, [task.dbTarget]);
 
   const installedAgents = useMemo(
     () =>
@@ -879,6 +894,11 @@ const ChatInterface: React.FC<Props> = ({
                   <Badge variant="outline">
                     <span className="h-1.5 w-1.5 rounded-full bg-orange-500" />
                     Auto-approve
+                  </Badge>
+                )}
+                {dbTargetLabel && (
+                  <Badge variant="outline" title="Active DB target for this task">
+                    DB: {dbTargetLabel}
                   </Badge>
                 )}
               </div>

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -65,11 +65,12 @@ const MultiAgentTask: React.FC<Props> = ({
           projectPath,
           defaultBranch: defaultBranch || undefined,
           portSeed: key,
+          dbTarget: task.dbTarget,
         })
       );
     }
     return envMap;
-  }, [variants, task.id, task.name, projectPath, defaultBranch]);
+  }, [variants, task.id, task.name, projectPath, defaultBranch, task.dbTarget]);
 
   // Auto-scroll to bottom when this task becomes active
   const { scrollToBottom } = useAutoScrollOnTaskSwitch(true, task.id);

--- a/src/renderer/components/TaskAdvancedSettings.tsx
+++ b/src/renderer/components/TaskAdvancedSettings.tsx
@@ -25,6 +25,10 @@ interface TaskAdvancedSettingsProps {
   useWorktree: boolean;
   onUseWorktreeChange: (value: boolean) => void;
 
+  // DB target (app/project DB, not Emdash DB)
+  dbTarget: string;
+  onDbTargetChange: (value: string) => void;
+
   // Auto-approve
   autoApprove: boolean;
   onAutoApproveChange: (value: boolean) => void;
@@ -62,6 +66,8 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
   projectPath,
   useWorktree,
   onUseWorktreeChange,
+  dbTarget,
+  onDbTargetChange,
   autoApprove,
   onAutoApproveChange,
   hasAutoApproveSupport,
@@ -246,6 +252,25 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
                       )}
                     </div>
                   </label>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-[128px_1fr] items-start gap-4">
+                <Label htmlFor="db-target" className="pt-2">
+                  DB target
+                </Label>
+                <div className="min-w-0 flex-1">
+                  <Textarea
+                    id="db-target"
+                    value={dbTarget}
+                    onChange={(e) => onDbTargetChange(e.target.value)}
+                    placeholder="DATABASE_URL or JSON {\"url\":\"...\",\"name\":\"...\",\"profile\":\"...\"}"
+                    className="resize-none font-mono text-xs"
+                    rows={2}
+                  />
+                  <div className="mt-1 text-[11px] text-muted-foreground">
+                    Passed to terminals/agents as DATABASE_URL/DB_URL and optional name/profile.
+                  </div>
                 </div>
               </div>
 

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -37,7 +37,8 @@ interface TaskModalProps {
     linkedJiraIssue?: JiraIssueSummary | null,
     autoApprove?: boolean,
     useWorktree?: boolean,
-    baseRef?: string
+    baseRef?: string,
+    dbTarget?: string | null
   ) => void;
   projectName: string;
   defaultBranch: string;
@@ -74,6 +75,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
   const [selectedJiraIssue, setSelectedJiraIssue] = useState<JiraIssueSummary | null>(null);
   const [autoApprove, setAutoApprove] = useState(false);
   const [useWorktree, setUseWorktree] = useState(true);
+  const [dbTarget, setDbTarget] = useState('');
 
   // Branch selection state - sync with defaultBranch unless user manually changed it
   const [selectedBranch, setSelectedBranch] = useState(defaultBranch);
@@ -156,6 +158,7 @@ const TaskModal: React.FC<TaskModalProps> = ({
     setSelectedJiraIssue(null);
     setAutoApprove(false);
     setUseWorktree(true);
+    setDbTarget('');
     userHasTypedRef.current = false;
     autoNameInitializedRef.current = false;
     customNameTrackedRef.current = false;
@@ -242,7 +245,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
         selectedJiraIssue,
         hasAutoApproveSupport ? autoApprove : false,
         useWorktree,
-        selectedBranch
+        selectedBranch,
+        dbTarget.trim() ? dbTarget.trim() : null
       );
     } catch (error) {
       console.error('Failed to create task:', error);
@@ -317,6 +321,8 @@ const TaskModal: React.FC<TaskModalProps> = ({
             projectPath={projectPath}
             useWorktree={useWorktree}
             onUseWorktreeChange={setUseWorktree}
+            dbTarget={dbTarget}
+            onDbTargetChange={setDbTarget}
             autoApprove={autoApprove}
             onAutoApproveChange={setAutoApprove}
             hasAutoApproveSupport={hasAutoApproveSupport}

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -102,8 +102,9 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
       projectPath,
       defaultBranch,
       portSeed,
+      dbTarget: task.dbTarget,
     });
-  }, [task?.id, task?.name, task?.path, projectPath, defaultBranch, portSeed]);
+  }, [task?.id, task?.name, task?.path, projectPath, defaultBranch, portSeed, task?.dbTarget]);
 
   useEffect(() => {
     activeTaskIdRef.current = task?.id ?? null;

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -53,6 +53,7 @@ export interface Task {
   status: 'active' | 'idle' | 'running';
   metadata?: TaskMetadata | null;
   useWorktree?: boolean;
+  dbTarget?: string | null;
   createdAt?: string;
   updatedAt?: string;
   agentId?: string;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -392,6 +392,7 @@ declare global {
         taskName: string;
         projectId: string;
         baseRef?: string;
+        dbTarget?: string | null;
       }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
       worktreeList: (args: {
         projectPath: string;
@@ -1330,6 +1331,7 @@ export interface ElectronAPI {
     taskName: string;
     projectId: string;
     baseRef?: string;
+    dbTarget?: string | null;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
   worktreeList: (args: {
     projectPath: string;

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -64,6 +64,7 @@ declare global {
         taskName: string;
         projectId: string;
         baseRef?: string;
+        dbTarget?: string | null;
       }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
       worktreeList: (args: {
         projectPath: string;


### PR DESCRIPTION
### add per-worktree database target configuration

- Enables configuring a database target per worktree/task for isolated testing.

### Problem

- Multiple worktrees share the same DATABASE_URL, causing cross-worktree data interference during parallel testing.

### Solution

- Added db_target column to tasks table
- Added "DB target" field in task creation (Advanced options)
- Injects DATABASE_URL, DB_NAME, DB_PROFILE into terminals/agents
- Shows active DB target badge in task header
- Fixed DB env vars not being passed to direct-spawn agents

### Usage

- Create task → Advanced options → Enter DB target → Injected automatically

### Backward compatibility
- Existing tasks work without changes
- dbTarget is optional
- No breaking changes


fix : #935
