### PR TITLE
fix(ui): hide check-for-updates button when update is downloaded

### DIFF
--- a/src/renderer/components/UpdateCard.tsx
+++ b/src/renderer/components/UpdateCard.tsx
@@ -84,19 +84,21 @@ export function UpdateCard(): JSX.Element {
           {renderStatusMessage()}
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            type="button"
-            variant="outline"
-            size="icon"
-            className="h-8 w-8"
-            onClick={handleCheckNow}
-            disabled={updater.state.status === 'checking'}
-            aria-label="Check for updates"
-          >
-            <RefreshCw
-              className={`h-3 w-3 ${updater.state.status === 'checking' ? 'animate-spin' : ''}`}
-            />
-          </Button>
+          {updater.state.status !== 'downloaded' && (
+            <Button
+              type="button"
+              variant="outline"
+              size="icon"
+              className="h-8 w-8"
+              onClick={handleCheckNow}
+              disabled={updater.state.status === 'checking'}
+              aria-label="Check for updates"
+            >
+              <RefreshCw
+                className={`h-3 w-3 ${updater.state.status === 'checking' ? 'animate-spin' : ''}`}
+              />
+            </Button>
+          )}
           {renderAction()}
         </div>
       </div>


### PR DESCRIPTION
## Summary

- Hide the "Check for updates" refresh button in the UpdateCard when an update has already been downloaded and is ready to install
- Prevents confusing UX where users could re-check for updates while a downloaded update is already pending restart

## Changes

- Wrapped the check-for-updates button in a conditional that hides it when `updater.state.status === 'downloaded'`, so only the "Restart" action button is shown in that state