### PR TITLE
feat(ssh): support file drag-and-drop onto SSH terminals via SCP

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -104,6 +104,9 @@ contextBridge.exposeInMainWorld('electronAPI', {
     resume?: boolean;
   }) => ipcRenderer.invoke('pty:startDirect', opts),
 
+  ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) =>
+    ipcRenderer.invoke('pty:scp-to-remote', args),
+
   onPtyData: (id: string, listener: (data: string) => void) => {
     const channel = `pty:data:${id}`;
     const wrapped = (_: Electron.IpcRendererEvent, data: string) => listener(data);

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -334,6 +334,11 @@ declare global {
         env?: Record<string, string>;
         resume?: boolean;
       }) => Promise<{ ok: boolean; reused?: boolean; error?: string }>;
+      ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) => Promise<{
+        success: boolean;
+        remotePaths?: string[];
+        error?: string;
+      }>;
       ptyInput: (args: { id: string; data: string }) => void;
       ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
       ptyKill: (id: string) => void;
@@ -1304,6 +1309,11 @@ export interface ElectronAPI {
     env?: Record<string, string>;
     resume?: boolean;
   }) => Promise<{ ok: boolean; reused?: boolean; error?: string }>;
+  ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) => Promise<{
+    success: boolean;
+    remotePaths?: string[];
+    error?: string;
+  }>;
   ptyInput: (args: { id: string; data: string }) => void;
   ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
   ptyKill: (id: string) => void;


### PR DESCRIPTION
## Summary
- Add SCP-based file transfer when dropping files onto SSH terminal panes, transferring local files to `/tmp/emdash-images/` on the remote host with UUID-prefixed names to avoid collisions
- Add `pty:scp-to-remote` IPC handler in the main process that resolves SSH connection details, converts SSH args to SCP-compatible args, and transfers files sequentially
- Update `TerminalPane` drop handler to detect SSH sessions and route through SCP before pasting remote paths into the terminal

## Test plan
- [ ] Drop a file onto a local terminal and verify the local path is pasted as before
- [ ] Drop a file onto an SSH terminal and verify the file is transferred via SCP and the remote path is pasted
- [ ] Drop multiple files onto an SSH terminal and verify all are transferred with unique names
- [ ] Test with SSH connections that use non-default ports and custom identity files
- [ ] Verify SCP failure is handled gracefully (warning logged, no crash)