### PR TITLE
fix: remove unnecessary toast notifications from diff modals

### DIFF
--- a/src/renderer/components/AllChangesDiffModal.tsx
+++ b/src/renderer/components/AllChangesDiffModal.tsx
@@ -140,7 +140,6 @@ export const AllChangesDiffModal: React.FC<AllChangesDiffModalProps> = ({
         saving: false,
         saveError: null,
       }));
-      toast({ title: 'Saved', description: filePath });
       // Dispatch file change event to update editor
       dispatchFileChangeEvent(resolvedTaskPath, filePath);
       if (onRefreshChanges) {
@@ -596,10 +595,6 @@ export const AllChangesDiffModal: React.FC<AllChangesDiffModalProps> = ({
     try {
       await navigator.clipboard.writeText(filePath);
       setCopiedFile(filePath);
-      toast({
-        title: 'Copied',
-        description: `File path copied to clipboard`,
-      });
       // Reset copied state after 2 seconds
       setTimeout(() => {
         setCopiedFile(null);

--- a/src/renderer/components/ChangesDiffModal.tsx
+++ b/src/renderer/components/ChangesDiffModal.tsx
@@ -604,10 +604,6 @@ export const ChangesDiffModal: React.FC<ChangesDiffModalProps> = ({
             }
           : prev
       );
-      toast({
-        title: 'Saved',
-        description: selected,
-      });
       // Dispatch file change event to update editor
       dispatchFileChangeEvent(safeTaskPath, selected);
       if (onRefreshChanges) {
@@ -714,10 +710,6 @@ export const ChangesDiffModal: React.FC<ChangesDiffModalProps> = ({
                         try {
                           await navigator.clipboard.writeText(selected);
                           setCopiedFile(selected);
-                          toast({
-                            title: 'Copied',
-                            description: `File path copied to clipboard`,
-                          });
                           setTimeout(() => {
                             setCopiedFile(null);
                           }, 2000);


### PR DESCRIPTION
## Summary
- Remove redundant "Saved" toast notifications after successful file saves in `AllChangesDiffModal` and `ChangesDiffModal` — the UI already reflects save state inline
- Remove redundant "Copied" toast notifications after copying file paths — the checkmark icon already provides visual feedback

## Changed Files
- `src/renderer/components/AllChangesDiffModal.tsx` — removed save success and copy path toasts
- `src/renderer/components/ChangesDiffModal.tsx` — removed save success and copy path toasts