### PR TITLE
Refine task settings hierarchy and auto-approve labeling

### DIFF
--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -11,6 +11,7 @@ import TelemetryCard from './TelemetryCard';
 import NotificationSettingsCard from './NotificationSettingsCard';
 import { UpdateCard } from './UpdateCard';
 import DefaultAgentSettingsCard from './DefaultAgentSettingsCard';
+import TaskSettingsCard from './TaskSettingsCard';
 import IntegrationsCard from './IntegrationsCard';
 import Context7SettingsCard from './Context7SettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
@@ -178,6 +179,12 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose }) => {
       sections: [
         {
           component: <TelemetryCard />,
+        },
+        {
+          component: <TaskSettingsCard variant="auto-generate" />,
+        },
+        {
+          component: <TaskSettingsCard variant="auto-approve" />,
         },
         {
           component: <NotificationSettingsCard />,

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -260,7 +260,7 @@ export const PROVIDERS: ProviderDefinition[] = [
   },
   {
     id: 'rovo',
-    name: 'Rovo Dev (Atlassian)',
+    name: 'Rovo Dev',
     docUrl: 'https://support.atlassian.com/rovo/docs/install-and-run-rovo-dev-cli-on-your-device/',
     installCommand: 'acli rovodev auth login',
     commands: ['rovodev', 'acli'],


### PR DESCRIPTION
## Summary\n- restore task settings visibility in the active Settings page\n- flatten task toggles to top-level General rows for consistent hierarchy\n- make task setting copy/title+subtitle styling consistent\n- add an info tooltip on auto-approve listing providers that support auto-approve flags\n- rename provider label from `Rovo Dev (Atlassian)` to `Rovo Dev` and use provider labels directly in tooltip\n\n## Validation\n- pnpm run format\n- pnpm run type-check\n

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only settings presentation changes plus a provider label rename; no changes to the underlying settings persistence logic beyond how it’s displayed.
> 
> **Overview**
> Task settings are now **visible directly in the `SettingsPage` General tab** as two separate rows by rendering `TaskSettingsCard` twice (variants for *auto-generate name* and *auto-approve*), aligning their hierarchy with other General settings.
> 
> `TaskSettingsCard` is refactored to support variants, updates copy/styling, and replaces the external “learn more” link with an **info tooltip** that dynamically lists agents supporting auto-approve (derived from `agentMeta`/`autoApproveFlag`). Provider display naming is also tweaked by renaming `rovo` from `Rovo Dev (Atlassian)` to `Rovo Dev`, which flows through to the tooltip labels.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 35d44fdf9e3cf59a0bd9fccf8e760a4bb12ce4d0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->