### PR TITLE
Fix Cursor auto-approve flag mapping

### DIFF
--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -96,7 +96,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     commands: ['cursor-agent', 'cursor'],
     versionArgs: ['--version'],
     cli: 'cursor-agent',
-    autoApproveFlag: '-p',
+    autoApproveFlag: '-f',
     initialPromptFlag: '',
     icon: 'cursor.svg',
     terminalOnly: true,


### PR DESCRIPTION
## Summary
- change Cursor provider auto-approve flag from -p to -f
- prevent launching cursor-agent in print mode when Auto-approve is enabled

## Why
-p maps to Cursor print mode (--print), which caused the runtime error about missing prompt in print mode.

## Validation
- pnpm run type-check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-string configuration change affecting only the Cursor provider’s CLI argument mapping; low blast radius but could impact Cursor users if the flag is still incorrect.
> 
> **Overview**
> Updates the Cursor provider definition to use `-f` (instead of `-p`) for `autoApproveFlag`, aligning Emdash’s auto-approve option with Cursor’s intended behavior and avoiding accidental `--print` mode invocation when starting `cursor-agent`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit da5b3716421c74d2150dae3dc4cc9abd1893faa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->