### PR TITLE
Fix task terminal resize prompt duplication on drag

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -56,9 +56,13 @@ type PtyRecord = {
   cwd?: string; // Working directory (for respawning shell after CLI exit)
   isDirectSpawn?: boolean; // Whether this was a direct CLI spawn
   kind?: 'local' | 'ssh';
+  cols?: number;
+  rows?: number;
 };
 
 const ptys = new Map<string, PtyRecord>();
+const MIN_PTY_COLS = 2;
+const MIN_PTY_ROWS = 1;
 
 /**
  * Generate a deterministic UUID from an arbitrary string.
@@ -518,7 +522,7 @@ export function startSshPty(options: {
     env: useEnv,
   });
 
-  ptys.set(id, { id, proc, kind: 'ssh' });
+  ptys.set(id, { id, proc, kind: 'ssh', cols, rows });
   return proc;
 }
 
@@ -669,7 +673,7 @@ export function startDirectPty(options: {
   });
 
   // Store record with cwd for shell respawn after CLI exits
-  ptys.set(id, { id, proc, cwd, isDirectSpawn: true, kind: 'local' });
+  ptys.set(id, { id, proc, cwd, isDirectSpawn: true, kind: 'local', cols, rows });
 
   // When CLI exits, spawn a shell so user can continue working
   proc.onExit(() => {
@@ -914,7 +918,7 @@ export async function startPty(options: {
     }
   }
 
-  ptys.set(id, { id, proc, kind: 'local' });
+  ptys.set(id, { id, proc, kind: 'local', cols, rows });
   return proc;
 }
 
@@ -929,11 +933,16 @@ export function writePty(id: string, data: string): void {
 export function resizePty(id: string, cols: number, rows: number): void {
   const rec = ptys.get(id);
   if (!rec) {
-    // PTY not ready yet - this is normal during startup, ignore silently
     return;
   }
+  const normalizedCols = Number.isFinite(cols) ? Math.max(MIN_PTY_COLS, Math.floor(cols)) : 0;
+  const normalizedRows = Number.isFinite(rows) ? Math.max(MIN_PTY_ROWS, Math.floor(rows)) : 0;
+  if (normalizedCols <= 0 || normalizedRows <= 0) return;
+  if (rec.cols === normalizedCols && rec.rows === normalizedRows) return;
   try {
-    rec.proc.resize(cols, rows);
+    rec.proc.resize(normalizedCols, normalizedRows);
+    rec.cols = normalizedCols;
+    rec.rows = normalizedRows;
   } catch (error: any) {
     if (
       error &&
@@ -947,7 +956,12 @@ export function resizePty(id: string, cols: number, rows: number): void {
       // Expected during shutdown - PTY already exited
       return;
     }
-    log.error('ptyManager:resizeFailed', { id, cols, rows, error: String(error) });
+    log.error('ptyManager:resizeFailed', {
+      id,
+      cols: normalizedCols,
+      rows: normalizedRows,
+      error: String(error),
+    });
   }
 }
 

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -452,7 +452,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   }
 
   return (
-    <div className={cn('flex h-full flex-col bg-card', className)}>
+    <div className={cn('flex h-full min-w-0 flex-col bg-card', className)}>
       <div className="flex items-center gap-2 border-b border-border bg-muted px-2 py-1.5 dark:bg-background">
         <Select value={selectedValue} onValueChange={handleSelectChange}>
           <SelectTrigger className="h-7 min-w-0 flex-1 justify-between border-none bg-transparent px-2 text-left text-xs shadow-none">

--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -250,7 +250,9 @@ const TerminalPaneComponent = forwardRef<{ focus: () => void }, Props>(
     return (
       <>
         <div
-          className={['terminal-pane flex h-full w-full', className].filter(Boolean).join(' ')}
+          className={['terminal-pane flex h-full w-full min-w-0', className]
+            .filter(Boolean)
+            .join(' ')}
           style={{
             width: '100%',
             height: '100%',


### PR DESCRIPTION
Summary:\n- prevent repeated PTY resize while dragging panel handles\n- flush final PTY size on drag end\n- remove temporary resize debug logs\n- keep small-screen terminal min width safeguards\n\nValidation:\n- pnpm run format\n- pnpm run type-check\n\nNote:\n- wrap and unwrap in the shell are finalized on handle release to avoid prompt duplication.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches renderer↔main PTY sizing behavior and introduces debounced/queued resize logic, which could cause missed or delayed resizes if edge cases (detach/exit/very small containers) aren’t handled correctly.
> 
> **Overview**
> Fixes terminal prompt duplication during sidebar drag-resizes by **debouncing and coalescing PTY resize events** in the renderer and only flushing the final size when the user releases a panel resize handle.
> 
> Adds a global `emdash:panel-resize-dragging` signal from `App.tsx`, tracks last-sent sizes and minimum dimensions, and cancels pending fits/resizes on detach/dispose/PTY exit; the main process `ptyManager.resizePty` now normalizes sizes, skips no-op resizes, and stores last known `cols/rows` per PTY. Minor layout tweaks add `min-w-0` to terminal containers to avoid flex overflow during narrow resizes.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 97a3050f0cbfea16898d348d3ffb38c36dcb0fef. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->