### PR TITLE
Refine settings layout and toggle behavior

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -462,6 +462,14 @@ const AppContent: React.FC = () => {
     handleToggleEditor,
   ]);
 
+  const handleToggleSettingsPage = useCallback(() => {
+    if (showSettingsPage) {
+      handleCloseSettingsPage();
+      return;
+    }
+    openSettingsPage();
+  }, [showSettingsPage, handleCloseSettingsPage, openSettingsPage]);
+
   return (
     <BrowserProvider>
       <div
@@ -475,7 +483,7 @@ const AppContent: React.FC = () => {
                 showCommandPalette={showCommandPalette}
                 showSettings={showSettingsPage}
                 handleToggleCommandPalette={handleToggleCommandPalette}
-                handleOpenSettings={() => openSettingsPage()}
+                handleOpenSettings={handleToggleSettingsPage}
                 handleCloseCommandPalette={handleCloseCommandPalette}
                 handleCloseSettings={handleCloseSettingsPage}
                 handleToggleKanban={handleToggleKanban}
@@ -490,7 +498,7 @@ const AppContent: React.FC = () => {
               />
               {!showWelcomeScreen && (
                 <Titlebar
-                  onToggleSettings={() => openSettingsPage()}
+                  onToggleSettings={handleToggleSettingsPage}
                   isSettingsOpen={showSettingsPage}
                   currentPath={
                     activeTask?.metadata?.multiAgent?.enabled

--- a/src/renderer/components/SettingsModal.tsx
+++ b/src/renderer/components/SettingsModal.tsx
@@ -342,10 +342,10 @@ const SettingsModal: React.FC<SettingsModalProps> = ({ isOpen, onClose, initialT
             transition={
               shouldReduceMotion ? { duration: 0 } : { duration: 0.18, ease: [0.22, 1, 0.36, 1] }
             }
-            className="mx-4 w-full max-w-3xl overflow-hidden rounded-2xl border border-border/50 bg-background shadow-2xl"
+            className="mx-4 my-4 w-full max-w-4xl overflow-hidden rounded-2xl border border-border/50 bg-background shadow-2xl"
           >
-            <div className="flex h-[520px]">
-              <aside className="w-60 border-r border-border/60 bg-muted/20 p-4">
+            <div className="flex h-[min(560px,calc(100vh-2rem))] min-h-0">
+              <aside className="w-52 shrink-0 overflow-y-auto border-r border-border/60 bg-muted/20 p-4 lg:w-60">
                 <nav className="space-y-1">
                   {ORDERED_TABS.map((tab) => {
                     const { icon: Icon, label } = tabDetails[tab];

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -245,89 +245,93 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose }) => {
   const currentContent = tabContent[activeTab as keyof typeof tabContent];
 
   return (
-    <div className="flex h-full min-w-[720px] flex-col gap-6 overflow-hidden px-6 pb-0 pt-8">
-      {/* Header */}
-      <div className="flex flex-col gap-6 px-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="flex flex-col gap-1.5">
-            <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
-            <p className="text-sm text-muted-foreground">
-              Manage your account settings and set preferences.
-            </p>
-          </div>
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            onClick={onClose}
-            className="h-8 w-8"
-            aria-label="Close settings"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-        <Separator />
-      </div>
-
-      {/* Contents: Navigation + Content */}
-      <div className="flex min-h-0 flex-1 gap-8 overflow-hidden pr-32">
-        {/* Navigation menu */}
-        <nav className="flex w-[215px] flex-col gap-2">
-          {tabs.map((tab) => {
-            const isActive = activeTab === tab.id && !tab.isExternal;
-
-            return (
-              <button
-                key={tab.id}
-                type="button"
-                onClick={() => {
-                  if (tab.isExternal) {
-                    handleDocsClick();
-                  } else {
-                    setActiveTab(tab.id as SettingsPageTab);
-                  }
-                }}
-                className={`flex w-full items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
-                  isActive
-                    ? 'bg-muted text-foreground'
-                    : tab.isExternal
-                      ? 'text-muted-foreground hover:bg-muted/60'
-                      : 'text-foreground hover:bg-muted/60'
-                }`}
-              >
-                <span className="text-left">{tab.label}</span>
-                {tab.isExternal && <ExternalLink className="h-4 w-4" />}
-              </button>
-            );
-          })}
-        </nav>
-
-        {/* Content container */}
-        {currentContent && (
-          <div className="flex min-h-0 flex-1 flex-col gap-8 overflow-y-auto pb-8">
-            {/* Page title */}
-            <div className="flex flex-col gap-6">
-              <div className="flex flex-col gap-1">
-                <h2 className="text-base font-medium">{currentContent.title}</h2>
-                <p className="text-sm text-muted-foreground">{currentContent.description}</p>
-              </div>
-              <Separator />
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden px-6 pb-0 pt-8">
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-[1060px] flex-col gap-6">
+        {/* Header */}
+        <div className="flex flex-col gap-6">
+          <div className="flex items-start justify-between gap-4">
+            <div className="flex flex-col gap-1.5">
+              <h1 className="text-2xl font-semibold tracking-tight">Settings</h1>
+              <p className="text-sm text-muted-foreground">
+                Manage your account settings and set preferences.
+              </p>
             </div>
-
-            {/* Sections */}
-            {currentContent.sections.map((section, index) => (
-              <div key={index} className="flex flex-col gap-3">
-                {section.title && (
-                  <div className="flex items-center justify-between">
-                    <h3 className="text-sm font-medium text-foreground">{section.title}</h3>
-                    {section.action && <div>{section.action}</div>}
-                  </div>
-                )}
-                {section.component}
-              </div>
-            ))}
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              onClick={onClose}
+              className="h-8 w-8"
+              aria-label="Close settings"
+            >
+              <X className="h-4 w-4" />
+            </Button>
           </div>
-        )}
+          <Separator />
+        </div>
+
+        {/* Contents: Navigation + Content */}
+        <div className="grid min-h-0 flex-1 grid-cols-[13rem_minmax(0,1fr)] gap-8 overflow-hidden">
+          {/* Navigation menu */}
+          <nav className="flex min-h-0 w-52 flex-col gap-2 overflow-y-auto">
+            {tabs.map((tab) => {
+              const isActive = activeTab === tab.id && !tab.isExternal;
+
+              return (
+                <button
+                  key={tab.id}
+                  type="button"
+                  onClick={() => {
+                    if (tab.isExternal) {
+                      handleDocsClick();
+                    } else {
+                      setActiveTab(tab.id as SettingsPageTab);
+                    }
+                  }}
+                  className={`flex w-full items-center gap-2 rounded-md px-4 py-2 text-sm font-medium transition-colors ${
+                    isActive
+                      ? 'bg-muted text-foreground'
+                      : tab.isExternal
+                        ? 'text-muted-foreground hover:bg-muted/60'
+                        : 'text-foreground hover:bg-muted/60'
+                  }`}
+                >
+                  <span className="text-left">{tab.label}</span>
+                  {tab.isExternal && <ExternalLink className="h-4 w-4" />}
+                </button>
+              );
+            })}
+          </nav>
+
+          {/* Content container */}
+          {currentContent && (
+            <div className="flex min-h-0 min-w-0 flex-1 justify-center overflow-y-auto pb-8">
+              <div className="mx-auto w-full max-w-4xl space-y-8">
+                {/* Page title */}
+                <div className="flex flex-col gap-6">
+                  <div className="flex flex-col gap-1">
+                    <h2 className="text-base font-medium">{currentContent.title}</h2>
+                    <p className="text-sm text-muted-foreground">{currentContent.description}</p>
+                  </div>
+                  <Separator />
+                </div>
+
+                {/* Sections */}
+                {currentContent.sections.map((section, index) => (
+                  <div key={index} className="flex flex-col gap-3">
+                    {section.title && (
+                      <div className="flex items-center justify-between">
+                        <h3 className="text-sm font-medium text-foreground">{section.title}</h3>
+                        {section.action && <div>{section.action}</div>}
+                      </div>
+                    )}
+                    {section.component}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+        </div>
       </div>
     </div>
   );

--- a/src/renderer/components/ThemeCard.tsx
+++ b/src/renderer/components/ThemeCard.tsx
@@ -18,7 +18,7 @@ const ThemeCard: React.FC = () => {
         <div className="text-sm font-medium text-foreground">Color mode</div>
         <div className="text-sm text-muted-foreground">Choose how Emdash looks.</div>
       </div>
-      <div className="grid grid-cols-4 gap-2">
+      <div className="grid grid-cols-[repeat(auto-fit,minmax(6.5rem,1fr))] gap-2">
         {options.map(({ value, label, icon: Icon }) => (
           <button
             key={value}
@@ -31,7 +31,7 @@ const ThemeCard: React.FC = () => {
               }
               setTheme(value);
             }}
-            className={`flex flex-col items-center justify-center gap-2 rounded-lg border px-3 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background ${
+            className={`flex min-h-24 flex-col items-center justify-center gap-2 rounded-lg border px-2 py-2.5 text-sm font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background sm:px-3 ${
               theme === value
                 ? 'border-primary bg-primary/10 text-foreground'
                 : 'border-border/60 bg-background text-muted-foreground hover:border-border hover:bg-muted/40'
@@ -40,7 +40,7 @@ const ThemeCard: React.FC = () => {
             aria-label={`Set theme to ${label}`}
           >
             <Icon className="h-4 w-4 shrink-0" aria-hidden="true" />
-            <span className="truncate">{label}</span>
+            <span className="text-center leading-tight">{label}</span>
           </button>
         ))}
       </div>

--- a/src/renderer/components/ui/sidebar.tsx
+++ b/src/renderer/components/ui/sidebar.tsx
@@ -44,7 +44,7 @@ export function SidebarProvider({ defaultOpen = true, children }: SidebarProvide
   const isMobile = useMediaQuery('(max-width: 1024px)');
   const storageKey = 'emdash.sidebarOpen';
 
-  const [open, setOpenState] = React.useState<boolean>(() => {
+  const [desktopOpen, setDesktopOpen] = React.useState<boolean>(() => {
     if (typeof window === 'undefined') return defaultOpen;
     try {
       const stored = window.localStorage.getItem(storageKey);
@@ -54,29 +54,43 @@ export function SidebarProvider({ defaultOpen = true, children }: SidebarProvide
       return defaultOpen;
     }
   });
+  const [mobileOpen, setMobileOpen] = React.useState(false);
 
   React.useEffect(() => {
     if (isMobile) {
-      setOpenState(false);
+      setMobileOpen(false);
     }
   }, [isMobile]);
 
   React.useEffect(() => {
     if (typeof window === 'undefined') return;
     try {
-      window.localStorage.setItem(storageKey, open ? 'true' : 'false');
+      window.localStorage.setItem(storageKey, desktopOpen ? 'true' : 'false');
     } catch {
       // ignore persistence errors
     }
-  }, [open, storageKey]);
+  }, [desktopOpen, storageKey]);
 
-  const setOpen = React.useCallback((next: boolean) => {
-    setOpenState(next);
-  }, []);
+  const setOpen = React.useCallback(
+    (next: boolean) => {
+      if (isMobile) {
+        setMobileOpen(next);
+        return;
+      }
+      setDesktopOpen(next);
+    },
+    [isMobile]
+  );
 
   const toggle = React.useCallback(() => {
-    setOpenState((prev) => !prev);
-  }, []);
+    if (isMobile) {
+      setMobileOpen((prev) => !prev);
+      return;
+    }
+    setDesktopOpen((prev) => !prev);
+  }, [isMobile]);
+
+  const open = isMobile ? mobileOpen : desktopOpen;
 
   const value = React.useMemo(
     () => ({


### PR DESCRIPTION
## Summary
- improve settings theme option cards so they reflow cleanly under zoom/larger text
- make settings modal sizing more viewport-aware to reduce cramping at higher zoom
- align SettingsPage layout with main panel behavior (stable vertical nav + centered content rail)
- make settings open/close behavior consistent across Cmd+, and toolbar settings button
- keep settings open when toggling sidebars/other global view shortcuts
- fix left sidebar state persistence so crossing mobile-width breakpoints does not permanently collapse desktop sidebar

## Validation
- pnpm run format
- pnpm run type-check
- pnpm exec eslint src/renderer/App.tsx src/renderer/components/SettingsModal.tsx src/renderer/components/SettingsPage.tsx src/renderer/components/ThemeCard.tsx src/renderer/components/ui/sidebar.tsx src/renderer/hooks/useKeyboardShortcuts.ts

## Notes
- eslint output includes pre-existing warnings in touched files (no new errors).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Mostly UI/layout and shortcut-state changes, but it modifies global keyboard shortcut gating and sidebar open-state persistence, which can cause regressions in navigation/toggling behavior across breakpoints.
> 
> **Overview**
> Refines Settings UI layout for responsiveness: `SettingsModal` becomes more viewport-aware (taller max height, scrollable nav, wider max width) and `SettingsPage` is restructured to a centered content rail with a stable, scrollable left nav.
> 
> Makes settings open/close behavior consistent by introducing a single `handleToggleSettingsPage` used by both keyboard shortcuts and the titlebar settings button.
> 
> Adjusts global shortcut dispatch in `useKeyboardShortcuts` so only the command palette is treated as blocking; settings no longer force-closes when using other global view shortcuts.
> 
> Fixes left sidebar state persistence by separating `desktopOpen` (persisted) from `mobileOpen` (ephemeral), preventing breakpoint transitions from permanently collapsing the desktop sidebar, and updates `ThemeCard` option buttons to reflow cleanly under zoom/larger text.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 125c1befd35495ee0ed7ea3c75a2f3407f77a4b6. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->