### PR TITLE
feat: Add no-cache header to auto-updater requests to ensure the late…

### DIFF
--- a/src/main/services/AutoUpdateService.ts
+++ b/src/main/services/AutoUpdateService.ts
@@ -161,7 +161,7 @@ class AutoUpdateService {
     autoUpdater.autoDownload = false; // We'll manage downloads manually
     autoUpdater.autoInstallOnAppQuit = true;
     autoUpdater.autoRunAppAfterInstall = true;
-    
+
     // Ensure we always get the latest version info, bypassing caches
     autoUpdater.requestHeaders = { 'Cache-Control': 'no-cache' };
 


### PR DESCRIPTION
fix: #770 

@arnestrickmann 

This PR includes changes as:
I modified  setupAutoUpdater to include Cache-Control: no-cache headers in update requests. This forces the auto-updater to bypass any intermediate caches (CDNs, proxies, etc.) and fetch the latest release information directly from the source.