### PR TITLE
fix(chat): hide spinner for single-agent conversations

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -905,7 +905,7 @@ const ChatInterface: React.FC<Props> = ({
                           {agentName}
                           {showNumber && <span className="ml-1 opacity-60">{sameAgentCount}</span>}
                         </span>
-                        {isBusy ? (
+                        {isBusy && conversations.length > 1 ? (
                           <Spinner
                             size="sm"
                             className={cn(


### PR DESCRIPTION
## Summary

- Hide the busy spinner on the agent tab when there is only one conversation/agent in the chat
- The spinner is only useful in multi-agent views to indicate which agent is actively working
- When there's a single agent, the spinner adds visual noise without providing meaningful information