### PR TITLE
fix(terminal): auto-focus terminal when switching back

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -275,6 +275,25 @@ const ChatInterface: React.FC<Props> = ({
   }, [task.id]);
 
   useEffect(() => {
+    let mounted = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const handleWindowFocus = () => {
+      timer = setTimeout(() => {
+        timer = null;
+        if (!mounted) return;
+        const session = terminalSessionRegistry.getSession(terminalId);
+        if (session) session.focus();
+      }, 0);
+    };
+    window.addEventListener('focus', handleWindowFocus);
+    return () => {
+      mounted = false;
+      if (timer !== null) clearTimeout(timer);
+      window.removeEventListener('focus', handleWindowFocus);
+    };
+  }, [terminalId]);
+
+  useEffect(() => {
     const meta = agentMeta[agent];
     if (!meta?.terminalOnly || !meta.autoStartCommand) return;
 

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -396,6 +396,24 @@ const MultiAgentTask: React.FC<Props> = ({
     }
   }, [task.id, activeTabIndex, variants.length, scrollToBottom]);
 
+  useEffect(() => {
+    let mounted = true;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const handleWindowFocus = () => {
+      timer = setTimeout(() => {
+        timer = null;
+        if (!mounted) return;
+        activeTerminalRef.current?.focus();
+      }, 0);
+    };
+    window.addEventListener('focus', handleWindowFocus);
+    return () => {
+      mounted = false;
+      if (timer !== null) clearTimeout(timer);
+      window.removeEventListener('focus', handleWindowFocus);
+    };
+  }, []);
+
   // Switch active agent tab via global shortcuts (Cmd+Shift+J/K)
   useEffect(() => {
     const handleAgentSwitch = (event: Event) => {


### PR DESCRIPTION
fix : #973

### What
- When you switch back to Emdash from another app (e.g. Alt+Tab), the agent terminal now automatically receives keyboard focus.

### Why
- Previously, the terminal did not regain focus when returning to the window, so an extra click inside the terminal was needed before typing or using arrow keys. This was awkward when moving between the browser/editor and Emdash to respond to agents.

### How
- Single-agent tasks: `ChatInterface` listens for `window` focus and focuses the current terminal session.
- Multi-agent tasks: `MultiAgentTask` listens for `window` focus and focuses the active tab’s terminal.
- Existing dialog check in `TerminalSessionManager.focus()` still prevents stealing focus from open modals.