### PR TITLE
Fix Linear API key setup navigation copy

### DIFF
--- a/src/renderer/components/integrations/LinearSetupForm.tsx
+++ b/src/renderer/components/integrations/LinearSetupForm.tsx
@@ -47,7 +47,7 @@ const LinearSetupForm: React.FC<Props> = ({
           <div className="text-xs leading-snug text-muted-foreground">
             <p className="font-medium text-foreground">How to get a Linear API key</p>
             <ol className="mt-1 list-decimal pl-4">
-              <li>Open Linear, go to Settings → API Tokens.</li>
+              <li>Open Linear, go to Settings → Security & access → Personal API keys.</li>
               <li>Create a new token and copy the key.</li>
             </ol>
           </div>


### PR DESCRIPTION
## Summary
- update Linear setup instructions to use the correct navigation path
- replace Settings > API Tokens with Settings > Security and access > Personal API keys

Closes #971

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only UI change with no impact to integration logic, data handling, or security-sensitive code paths.
> 
> **Overview**
> Updates the Linear integration setup helper text in `LinearSetupForm` to reflect Linear’s current UI navigation for generating a personal API key (now under *Settings → Security & access → Personal API keys*).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f646e73a3b690ba0962a93033975378ab52dfad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->