### PR TITLE
docs: fix Linear API key setup instructions path in docs

### DIFF
--- a/docs/content/docs/issues.mdx
+++ b/docs/content/docs/issues.mdx
@@ -43,7 +43,7 @@ Go to **Settings → Connections** to connect.
 
 ### Linear
 
-1. Go to [Linear Settings → API → Personal API Keys](https://linear.app/settings/api)
+1. Go to [Linear Settings → Security & access → Personal API keys](https://linear.app/settings/api)
 2. Create a new API key
 3. Paste the key in Emdash and click Connect
 


### PR DESCRIPTION
## Summary

- Fix the navigation path in the Linear setup instructions to match the current Linear UI
- Changed from "Settings → API → Personal API Keys" to "Settings → Security & access → Personal API keys"