### PR TITLE
fix: use SVG for Linear logo instead of PNG across components

### DIFF
--- a/src/renderer/components/LinearIssuePreviewTooltip.tsx
+++ b/src/renderer/components/LinearIssuePreviewTooltip.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import { motion } from 'motion/react';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { ExternalLink, User, Tag, Folder } from 'lucide-react';
-import linearLogo from '../../assets/images/linear.png';
+import linearLogoSvg from '../../assets/images/Linear.svg?raw';
 import type { LinearIssueSummary } from '../types/linear';
+import AgentLogo from './AgentLogo';
 
 type Props = {
   issue: LinearIssueSummary | null;
@@ -67,7 +68,11 @@ export const LinearIssuePreviewTooltip: React.FC<Props> = ({ issue, children, si
           >
             <div className="flex items-start justify-between gap-2">
               <div className="flex items-center gap-2 text-xs font-medium text-muted-foreground">
-                <img src={linearLogo} alt="Linear" className="h-4 w-4 dark:invert" />
+                <AgentLogo
+                  logo={linearLogoSvg}
+                  alt="Linear"
+                  className="h-4 w-4 text-muted-foreground"
+                />
                 <span className="tracking-wide">Linear Issue</span>
                 <span className="font-semibold text-muted-foreground/80">{issue.identifier}</span>
               </div>

--- a/src/renderer/components/LinearIssueSelector.tsx
+++ b/src/renderer/components/LinearIssueSelector.tsx
@@ -2,11 +2,12 @@ import React, { useCallback, useEffect, useRef, useState, useMemo } from 'react'
 import { Input } from './ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger } from './ui/select';
 import { Search } from 'lucide-react';
-import linearLogo from '../../assets/images/linear.png';
+import linearLogoSvg from '../../assets/images/Linear.svg?raw';
 import { type LinearIssueSummary } from '../types/linear';
 import { Separator } from './ui/separator';
 import { Spinner } from './ui/spinner';
 import { LinearIssuePreviewTooltip } from './LinearIssuePreviewTooltip';
+import AgentLogo from './AgentLogo';
 
 interface LinearIssueSelectorProps {
   selectedIssue: LinearIssueSummary | null;
@@ -254,7 +255,11 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
                     className="inline-flex items-center gap-1.5 rounded border border-border bg-muted px-1.5 py-0.5 dark:border-border dark:bg-card"
                     onClick={(e) => e.stopPropagation()}
                   >
-                    <img src={linearLogo} alt="Linear" className="h-3.5 w-3.5 dark:invert" />
+                    <AgentLogo
+                      logo={linearLogoSvg}
+                      alt="Linear"
+                      className="h-3.5 w-3.5 text-foreground"
+                    />
                     <span className="text-[11px] font-medium text-foreground">
                       {selectedIssue.identifier}
                     </span>
@@ -269,7 +274,11 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
               </div>
             ) : (
               <>
-                <img src={linearLogo} alt="Linear" className="h-3.5 w-3.5 dark:invert" />
+                <AgentLogo
+                  logo={linearLogoSvg}
+                  alt="Linear"
+                  className="h-3.5 w-3.5 text-foreground"
+                />
                 <span className="truncate text-muted-foreground">{issuePlaceholder}</span>
               </>
             )}
@@ -302,7 +311,11 @@ export const LinearIssueSelector: React.FC<LinearIssueSelectorProps> = ({
                   <SelectItem value={issue.identifier}>
                     <span className="flex min-w-0 items-center gap-2">
                       <span className="inline-flex shrink-0 items-center gap-1.5 rounded border border-border bg-muted px-1.5 py-0.5 dark:border-border dark:bg-card">
-                        <img src={linearLogo} alt="Linear" className="h-3.5 w-3.5 dark:invert" />
+                        <AgentLogo
+                          logo={linearLogoSvg}
+                          alt="Linear"
+                          className="h-3.5 w-3.5 text-foreground"
+                        />
                         <span className="text-[11px] font-medium text-foreground">
                           {issue.identifier}
                         </span>

--- a/src/renderer/components/TaskContextBadges.tsx
+++ b/src/renderer/components/TaskContextBadges.tsx
@@ -8,9 +8,10 @@ import { CommentsPopover } from './CommentsPopover';
 import { Button } from './ui/button';
 import { useTaskComments } from '../hooks/useLineComments';
 import { useTaskScope } from './TaskScopeContext';
-import linearLogo from '../../assets/images/linear.png';
+import linearLogoSvg from '../../assets/images/Linear.svg?raw';
 import githubLogo from '../../assets/images/github.png';
 import jiraLogo from '../../assets/images/jira.png';
+import AgentLogo from './AgentLogo';
 
 type Props = {
   taskId?: string;
@@ -55,7 +56,11 @@ export const TaskContextBadges: React.FC<Props> = ({
                 onClick={() => handleIssueClick(linearIssue.url || undefined)}
                 aria-label={`Linear issue ${linearIssue.identifier}: ${linearIssue.title || 'No title'}`}
               >
-                <img src={linearLogo} alt="Linear" className="h-3.5 w-3.5" />
+                <AgentLogo
+                  logo={linearLogoSvg}
+                  alt="Linear"
+                  className="h-3.5 w-3.5 text-foreground"
+                />
                 <span>{linearIssue.identifier}</span>
               </button>
             </TooltipTrigger>
@@ -63,7 +68,11 @@ export const TaskContextBadges: React.FC<Props> = ({
               <div className="text-xs">
                 <div className="mb-1.5 flex min-w-0 items-center gap-2">
                   <span className="inline-flex shrink-0 items-center gap-1.5 rounded border border-border bg-muted px-1.5 py-0.5 dark:border-border dark:bg-card">
-                    <img src={linearLogo} alt="Linear" className="h-3 w-3" />
+                    <AgentLogo
+                      logo={linearLogoSvg}
+                      alt="Linear"
+                      className="h-3 w-3 text-foreground"
+                    />
                     <span className="text-[11px] font-medium">{linearIssue.identifier}</span>
                   </span>
                   {linearIssue.title && (


### PR DESCRIPTION
## Summary
- Replace Linear PNG logo (`linear.png`) with inline SVG (`Linear.svg?raw`) rendered via `AgentLogo` component in `LinearIssuePreviewTooltip`, `LinearIssueSelector`, and `TaskContextBadges`
- Removes `dark:invert` hack previously needed for the PNG, since the SVG adapts to the current theme via `text-foreground` / `text-muted-foreground` CSS classes
- Aligns Linear logo rendering with the pattern already used for other agent logos in the codebase