### PR TITLE
fix(terminal): correct CSI handler params for DECRQM workaround

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -202,8 +202,8 @@ export class TerminalSessionManager {
         // ANSI mode request: CSI Ps $ p  →  respond CSI Ps ; 0 $ y
         const ansiDisp = parser.registerCsiHandler(
           { intermediates: '$', final: 'p' },
-          (params: { params: number[] }) => {
-            const mode = params.params[0] ?? 0;
+          (params: (number | number[])[]) => {
+            const mode = (params[0] as number) ?? 0;
             window.electronAPI.ptyInput({ id: ptyId, data: `\x1b[${mode};0$y` });
             return true;
           }
@@ -211,8 +211,8 @@ export class TerminalSessionManager {
         // DEC private mode request: CSI ? Ps $ p  →  respond CSI ? Ps ; 0 $ y
         const decDisp = parser.registerCsiHandler(
           { prefix: '?', intermediates: '$', final: 'p' },
-          (params: { params: number[] }) => {
-            const mode = params.params[0] ?? 0;
+          (params: (number | number[])[]) => {
+            const mode = (params[0] as number) ?? 0;
             window.electronAPI.ptyInput({ id: ptyId, data: `\x1b[?${mode};0$y` });
             return true;
           }


### PR DESCRIPTION
## Summary
- Fixes crash when spawning OpenCode CLI: `Cannot read properties of undefined (reading '0')` at `TerminalSessionManager.ts:215`
- The `registerCsiHandler` callback receives `params` as `(number | number[])[]` directly, not as an object with a `.params` property — the code was accessing `params.params[0]` which is `undefined`
- The bug existed since the DECRQM workaround was added but was never triggered until OpenCode sent mode-query escape sequences

## Test plan
- [ ] Spawn OpenCode CLI agent — should no longer crash
- [ ] Spawn Amp agent — DECRQM workaround still functions correctly
- [ ] Other CLI agents (Claude Code, Codex, etc.) unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)