### PR TITLE
Revert DECRQM workaround that breaks TUI app capability detection

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -188,44 +188,6 @@ export class TerminalSessionManager {
     this.terminal.loadAddon(this.serializeAddon);
     this.terminal.loadAddon(this.webLinksAddon);
 
-    // Work around xterm.js 6.0.0 bug: the built-in DECRQM (Request Mode)
-    // handler crashes with "r is not defined" when TUI apps (e.g. Amp) send
-    // mode-query escape sequences (CSI Ps $ p / CSI ? Ps $ p).
-    // Register custom handlers that intercept these sequences before the
-    // buggy built-in handler runs, and send back a proper DECRPM response
-    // reporting each queried mode as "not recognized" (Pm=0).
-    // Response format: CSI [?] Ps ; Pm $ y
-    try {
-      const parser = (this.terminal as any).parser;
-      if (parser?.registerCsiHandler) {
-        const ptyId = this.id;
-        // ANSI mode request: CSI Ps $ p  →  respond CSI Ps ; 0 $ y
-        const ansiDisp = parser.registerCsiHandler(
-          { intermediates: '$', final: 'p' },
-          (params: { params: number[] }) => {
-            const mode = params.params[0] ?? 0;
-            window.electronAPI.ptyInput({ id: ptyId, data: `\x1b[${mode};0$y` });
-            return true;
-          }
-        );
-        // DEC private mode request: CSI ? Ps $ p  →  respond CSI ? Ps ; 0 $ y
-        const decDisp = parser.registerCsiHandler(
-          { prefix: '?', intermediates: '$', final: 'p' },
-          (params: { params: number[] }) => {
-            const mode = params.params[0] ?? 0;
-            window.electronAPI.ptyInput({ id: ptyId, data: `\x1b[?${mode};0$y` });
-            return true;
-          }
-        );
-        this.disposables.push(
-          () => ansiDisp.dispose(),
-          () => decDisp.dispose()
-        );
-      }
-    } catch (err) {
-      log.warn('Failed to register DECRQM workaround handlers', { error: err });
-    }
-
     try {
       this.webglAddon = new WebglAddon();
       this.webglAddon.onContextLoss?.(() => {
@@ -893,8 +855,7 @@ export class TerminalSessionManager {
       try {
         this.terminal.write(chunk);
       } catch (err) {
-        // Guard against xterm.js parser errors (e.g. DECRQM "r is not defined"
-        // in 6.0.0). Log once and continue — the terminal session stays usable.
+        // Guard against unexpected xterm.js parser errors so the session stays usable.
         log.warn('terminalSession:writeError', { id: this.id, error: (err as Error)?.message });
       }
       if (!this.firstFrameRendered) {


### PR DESCRIPTION
## Summary

This reverts the DECRQM workaround introduced in #949 (and patched in #993), which was causing TUI applications like OpenCode to render garbled output in Emdash's terminal panes.

## What was happening

After v0.4.4, users noticed that OpenCode's TUI was displaying garbled content that would only render correctly when scrolling. The regression was traced to the DECRQM workaround in `TerminalSessionManager.ts`.

## Why the workaround was harmful

The workaround intercepted **all** DECRQM mode queries (`CSI ? Ps $ p`) and responded with `Pm=0` ("mode not recognized") for every single mode. This was meant to prevent a supposed xterm.js 6.0.0 crash ("r is not defined" in the `requestMode` handler), but that bug doesn't actually exist — the variable in question is properly defined in xterm.js 6.0.0's source.

By falsely reporting every mode as unsupported, the workaround broke capability detection for TUI frameworks. OpenCode uses [OpenTUI](https://github.com/nickshanks/opentui), which queries the terminal for capabilities at startup via DECRQM. When it received "not recognized" for all modes, it concluded that the terminal lacks support for:

- **Synchronized output** (mode 2026) — used for flicker-free 60fps rendering
- **Focus reporting** (mode 1004) — used for focus/blur events
- **Bracketed paste** (mode 2004) — used for safe paste handling
- …and other standard modes

Without synchronized output in particular, OpenTUI's diff-based rendering produces garbled frames in xterm.js — the exact symptom users were seeing.

## Why this is safe to revert

xterm.js 6.0.0's built-in `requestMode()` correctly handles all standard terminal modes (1, 3, 6, 7, 8, 9, 12, 25, 45, 66, 67, 1000, 1002, 1003, 1004, 1005, 1006, 1015, 1016, 1048, 47, 1047, 1049, 2004, 2026, and more). It does not crash on DECRQM sequences. The claimed "r is not defined" error was never reproduced or reported upstream, and inspection of the minified source confirms the variable is properly scoped.

Removing the workaround lets xterm.js respond accurately to mode queries, which restores correct capability detection for all TUI apps.

## Changes

- Removed the custom CSI handlers that intercepted DECRQM sequences (was ~40 lines)
- Updated a misleading comment on the `terminal.write()` try-catch (the try-catch itself is kept as reasonable defensive code)

## Testing

- `pnpm run lint` — passes
- `pnpm run type-check` — passes
- `pnpm exec vitest run` — passes (pre-existing unrelated failures only)
- Manual testing: OpenCode renders correctly in terminal panes after this change