### PR TITLE
Add Copilot auto-approve support and comprehensive auto-approve flag coverage test

### DIFF
--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -177,6 +177,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     commands: ['copilot'],
     versionArgs: ['--version'],
     cli: 'copilot',
+    autoApproveFlag: '--allow-all-tools',
     icon: 'gh-copilot.svg',
     terminalOnly: true,
   },


### PR DESCRIPTION
## Summary
- add GitHub Copilot auto-approve support via --allow-all-tools
- intentionally keep Copilot without an initial prompt flag to avoid non-interactive startup behavior
- replace provider-specific assertion with a comprehensive matrix test that validates all configured autoApproveFlag providers and fails on drift

## Testing
- npm run format
- pnpm exec vitest run src/test/main/ptyManager.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, isolated change to provider metadata plus a stronger unit test; runtime impact is limited to Copilot’s optional auto-approve argument.
> 
> **Overview**
> Adds an `autoApproveFlag` (`--allow-all-tools`) to the GitHub Copilot provider definition so auto-approve can be enabled when building Copilot CLI args.
> 
> Replaces/extends testing with a comprehensive matrix that asserts every provider configured with `autoApproveFlag` is covered and that `resolveProviderCommandConfig` + `buildProviderCliArgs` emit the expected parsed flag, failing if provider registry flags drift.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 86f06c8110c70753a094ff04795af5326b395644. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->