### PR TITLE
fix(diff): remove phantom newline in diff view

### DIFF
--- a/src/renderer/components/ChangesDiffModal.tsx
+++ b/src/renderer/components/ChangesDiffModal.tsx
@@ -191,7 +191,8 @@ export const ChangesDiffModal: React.FC<ChangesDiffModalProps> = ({
               2 * 1024 * 1024
             );
             if (readRes?.success && readRes.content) {
-              modifiedContent = readRes.content;
+              // Strip one trailing newline to prevent phantom newline in diff view
+              modifiedContent = readRes.content.replace(/\n$/, '');
             }
           } catch {
             // Fallback to diff-based content


### PR DESCRIPTION
The diff view always showed a phantom "added" empty line at the end of modified files.

Before:
<img width="1296" height="739" alt="Screenshot 2026-02-20 at 8 14 54 PM" src="https://github.com/user-attachments/assets/ecc6dcc3-35d5-4d6f-ae03-b2370dc0eb22" />

After:
<img width="1293" height="736" alt="Screenshot 2026-02-20 at 8 15 11 PM" src="https://github.com/user-attachments/assets/ca427137-fe6c-4823-8554-7e4bcb4f480c" />
