### PR TITLE
Fix preserve patterns for untracked files in worktree copy

### DIFF
--- a/src/test/main/WorktreeService.test.ts
+++ b/src/test/main/WorktreeService.test.ts
@@ -207,6 +207,18 @@ describe('WorktreeService', () => {
       expect(fs.existsSync(path.join(destDir, 'local.config.json'))).toBe(true);
     });
 
+    it('should copy untracked files that match preserve patterns', async () => {
+      fs.writeFileSync(path.join(sourceDir, 'AGENTS.md'), '# local agent notes\n');
+
+      const result = await service.preserveFilesToWorktree(sourceDir, destDir, ['AGENTS.md'], []);
+
+      expect(result.copied).toContain('AGENTS.md');
+      expect(fs.existsSync(path.join(destDir, 'AGENTS.md'))).toBe(true);
+      expect(fs.readFileSync(path.join(destDir, 'AGENTS.md'), 'utf8')).toBe(
+        '# local agent notes\n'
+      );
+    });
+
     it('should copy nested files for basename-only custom patterns', async () => {
       const nestedDir = path.join(sourceDir, 'secrets');
       fs.mkdirSync(nestedDir, { recursive: true });


### PR DESCRIPTION
## Summary
- include both ignored and untracked files when collecting preserve candidates
- keep preserve pattern and exclusion filtering unchanged
- add regression test covering untracked AGENTS.md copy behavior

## Testing
- pnpm exec vitest run src/test/main/WorktreeService.test.ts src/test/main/WorktreePoolService.test.ts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, well-scoped change to the worktree file copy candidate selection plus a targeted test; minimal impact beyond which local files get preserved.
> 
> **Overview**
> Worktree file preservation now considers both *ignored* and *non-ignored untracked* files when collecting preserve candidates, so preserve patterns (e.g. `AGENTS.md`) are copied even if they are not gitignored.
> 
> This replaces the ignored-only `git ls-files --ignored` scan with a combined ignored + untracked scan (deduped) while keeping existing preserve-pattern matching and exclusion filtering behavior unchanged, and adds a regression test covering untracked file copying.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 37add9e98182105c1ccffa618bfe41738c7b36ff. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->