### PR TITLE
fix: remove toast notification on task deletion

### DIFF
--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -426,12 +426,6 @@ export function useTaskManagement(options: UseTaskManagementOptions) {
         const { captureTelemetry } = await import('../lib/telemetryClient');
         captureTelemetry('task_deleted');
 
-        if (!options?.silent) {
-          toast({
-            title: 'Task deleted',
-            description: task.name,
-          });
-        }
         return true;
       } catch (error) {
         const { log } = await import('../lib/logger');


### PR DESCRIPTION
## Summary

- Removes the "Task deleted" toast notification that appeared after successfully deleting a task
- The toast was stealing focus from the user's workflow after a delete action, which is disruptive since the task visually disappearing from the list is sufficient feedback

## Test plan

- [ ] Delete a task and verify no toast notification appears
- [ ] Verify silent deletion (e.g., bulk operations) still works correctly
- [ ] Verify error toasts still appear when deletion fails