### PR TITLE
Fix revert button to actually discard changes on staged files

### DIFF
--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -166,23 +166,6 @@ export async function revertFile(
   taskPath: string,
   filePath: string
 ): Promise<{ action: 'unstaged' | 'reverted' }> {
-  // Check if file is staged
-  try {
-    const { stdout: stagedStatus } = await execFileAsync(
-      'git',
-      ['diff', '--cached', '--name-only', '--', filePath],
-      {
-        cwd: taskPath,
-      }
-    );
-
-    if (stagedStatus.trim()) {
-      // File is staged, unstage it (but keep working directory changes)
-      await execFileAsync('git', ['reset', 'HEAD', '--', filePath], { cwd: taskPath });
-      return { action: 'unstaged' };
-    }
-  } catch {}
-
   // Check if file is tracked in git (exists in HEAD)
   let fileExistsInHead = false;
   try {


### PR DESCRIPTION
The "Revert file changes" button wasn't working correctly for staged files. It would only unstage them instead of actually discarding the changes, making it functionally identical to the unstage button.

fixes #1022 