### PR TITLE
docs: update README and settings links

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Emdash currently supports twenty-one CLI providers and we are adding new provide
 | [Charm](https://github.com/charmbracelet/crush) | ✅ Supported | `npm install -g @charmland/crush` |
 | [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) | ✅ Supported | `curl -fsSL https://claude.ai/install.sh \| bash` |
 | [Cline](https://docs.cline.bot/cline-cli/overview) | ✅ Supported | `npm install -g cline` |
-| [Codebuff](https://www.codebuff.com/docs/help/getting-started) | ✅ Supported | `npm install -g codebuff` |
+| [Codebuff](https://www.codebuff.com/docs/help/quick-start) | ✅ Supported | `npm install -g codebuff` |
 | [Codex](https://developers.openai.com/codex/cli/) | ✅ Supported | `npm install -g @openai/codex` |
 | [Continue](https://docs.continue.dev/guides/cli) | ✅ Supported | `npm i -g @continuedev/cli` |
 | [Cursor](https://cursor.com/cli) | ✅ Supported | `curl https://cursor.com/install -fsS | bash` |
@@ -81,7 +81,7 @@ Emdash currently supports twenty-one CLI providers and we are adding new provide
 | [GitHub Copilot](https://docs.github.com/en/copilot/how-tos/set-up/installing-github-copilot-in-the-cli) | ✅ Supported | `npm install -g @github/copilot` |
 | [Goose](https://github.com/block/goose) | ✅ Supported | `curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh | bash` |
 | [Kilocode](https://kilo.ai/docs/cli) | ✅ Supported | `npm install -g @kilocode/cli` |
-| [Kimi](https://www.kimi.com/coding/docs/en/kimi-cli.html) | ✅ Supported | `uv tool install --python 3.13 kimi-cli` |
+| [Kimi](https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html) | ✅ Supported | `uv tool install --python 3.13 kimi-cli` |
 | [Kiro](https://kiro.dev/docs/cli/) | ✅ Supported | `curl -fsSL https://cli.kiro.dev/install | bash` |
 | [Mistral Vibe](https://github.com/mistralai/mistral-vibe) | ✅ Supported | `curl -LsSf https://mistral.ai/vibe/install.sh \| bash` |
 | [OpenCode](https://opencode.ai/docs/) | ✅ Supported | `npm install -g opencode-ai` |

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -224,7 +224,7 @@ export const PROVIDERS: ProviderDefinition[] = [
   {
     id: 'kimi',
     name: 'Kimi',
-    docUrl: 'https://www.kimi.com/coding/docs/en/kimi-cli.html',
+    docUrl: 'https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html',
     installCommand: 'uv tool install kimi-cli',
     commands: ['kimi'],
     versionArgs: ['--version'],
@@ -302,7 +302,7 @@ export const PROVIDERS: ProviderDefinition[] = [
   {
     id: 'codebuff',
     name: 'Codebuff',
-    docUrl: 'https://www.codebuff.com/docs/help/getting-started',
+    docUrl: 'https://www.codebuff.com/docs/help/quick-start',
     installCommand: 'npm install -g codebuff',
     commands: ['codebuff'],
     versionArgs: ['--version'],


### PR DESCRIPTION
Updated two documentation links in the README and settings page.

## Changes
- Replaced outdated links with:
  - Kimi CLI getting started guide
  - Codebuff quick start guide

## Impact
Documentation-only change. No functional impact.