### PR TITLE
docs: add auto-closing issues section to issues documentation

### DIFF
--- a/docs/content/docs/issues.mdx
+++ b/docs/content/docs/issues.mdx
@@ -60,3 +60,7 @@ GitHub Issues requires the GitHub CLI (`gh`). Emdash auto-installs it if missing
 1. Click **Sign in with GitHub**
 2. Copy the device code shown
 3. Authorize on GitHub when prompted
+
+## Auto-Closing Issues
+
+When you create a PR from a task that has a linked issue, Emdash automatically closes the associated GitHub or Linear issue. This only applies to issues that were passed to the task at creation time.


### PR DESCRIPTION
## Summary

- Adds a new "Auto-Closing Issues" section to the issues documentation page
- Documents the behavior where Emdash automatically closes linked GitHub or Linear issues when a PR is created from a task

<!-- emdash-issue-footer:start -->
Fixes GEN-373
<!-- emdash-issue-footer:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only change that clarifies existing behavior; no code paths, data handling, or auth are modified.
> 
> **Overview**
> Adds an **Auto-Closing Issues** section to `docs/content/docs/issues.mdx`, documenting that creating a PR from a task will automatically close the linked GitHub or Linear issue (only for issues attached at task creation).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 299e487042c168cbc3642a7c44e5f0e133407ae8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->