### PR TITLE
fix(terminal): auto-switch to Run tab and remove horizontal scroll in lifecycle logs

### DIFF
--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -233,6 +233,13 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
     };
   }, [task?.id, refreshLifecycleState]);
 
+  // Auto-switch dropdown to Run when the run phase starts.
+  useEffect(() => {
+    if (runStatus === 'running' && selectedLifecycle !== 'run') {
+      setSelectedValue('lifecycle::run');
+    }
+  }, [runStatus, selectedLifecycle]);
+
   // Sync selection when store active terminal changes; don't override lifecycle selection.
   useEffect(() => {
     if (!taskTerminals.activeTerminalId) return;
@@ -657,7 +664,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                 ? `Teardown status: ${teardownStatus}`
                 : `Run status: ${runStatus}`}
           </div>
-          <pre className="h-full overflow-auto p-3 text-xs leading-relaxed text-foreground">
+          <pre className="h-full overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words p-3 text-xs leading-relaxed text-foreground">
             {lifecycleLogs[selectedLifecycle].join('') || 'No lifecycle output yet.'}
           </pre>
         </div>


### PR DESCRIPTION
## Summary
- Auto-switch dropdown to the **Run** lifecycle tab when a run script starts, so users see logs immediately without manual switching
- Remove horizontal scrolling from lifecycle log output by wrapping long lines (`whitespace-pre-wrap break-words`), matching the terminal view's behavior

## Details

**Auto-switch to Run tab**: Added a `useEffect` that watches `runStatus`. When it transitions to `'running'` (via lifecycle event), the dropdown automatically switches to `lifecycle::run`. This is reactive rather than imperative — it responds to the actual state change instead of setting state inside the click handler (which was interfering with the API call).

**Horizontal scroll fix**: Changed the `<pre>` element from `overflow-auto` to `overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words`. The terminal view (xterm.js) wraps text internally, but the lifecycle logs used a raw `<pre>` that preserved all whitespace without wrapping, causing unwanted horizontal scroll.

## Test plan
- [ ] Configure a lifecycle `run` script in `.emdash.json`
- [ ] Click the Play button from any terminal tab — verify dropdown auto-switches to "Run" and logs appear
- [ ] Verify long lines in lifecycle logs wrap instead of causing horizontal scroll
- [ ] Verify terminal tabs still work normally (no horizontal scroll regression)
- [ ] Verify setup/teardown lifecycle phases still work when selected manually

🤖 Generated with [Claude Code](https://claude.com/claude-code)