### PR TITLE
docs: add Emdash Cloud section to remote projects page

### DIFF
--- a/docs/content/docs/remote-projects.mdx
+++ b/docs/content/docs/remote-projects.mdx
@@ -141,3 +141,7 @@ Some features that work locally are not yet available for remote projects:
 - GitHub PR creation, status checks, and merge from the UI
 
 Agents can still perform these operations via shell commands in the terminal.
+
+## Emdash Cloud for Teams
+
+For business and team setups — including managed remote environments, centralized configuration, and admin controls — visit [emdash.sh/cloud](https://emdash.sh/cloud) to learn more.


### PR DESCRIPTION
## Summary
- Adds an "Emdash Cloud for Teams" section at the end of the Remote Projects docs page
- Links to emdash.sh/cloud for business and team setups (managed remote environments, centralized config, admin controls)

## Test plan
- [ ] Verify the docs site builds: `cd docs && pnpm dev`
- [ ] Check the Remote Projects page renders the new section with a working link

🤖 Generated with [Claude Code](https://claude.com/claude-code)