### PR TITLE
feat: show platform-specific labels and icons for Finder/Explorer/Files

### DIFF
--- a/src/assets/images/explorer.svg
+++ b/src/assets/images/explorer.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- Windows File Explorer folder icon -->
+  <path d="M4 10C4 7.79 5.79 6 8 6H18L22 10H40C42.21 10 44 11.79 44 14V38C44 40.21 42.21 42 40 42H8C5.79 42 4 40.21 4 38V10Z" fill="#FFC107"/>
+  <path d="M4 18H44V38C44 40.21 42.21 42 40 42H8C5.79 42 4 40.21 4 38V18Z" fill="#FFD54F"/>
+  <path d="M4 18H44V20H4V18Z" fill="#FFCA28"/>
+</svg>

--- a/src/assets/images/files.svg
+++ b/src/assets/images/files.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 48 48" fill="none">
+  <!-- Generic file manager folder icon for Linux -->
+  <path d="M4 10C4 7.79 5.79 6 8 6H18L22 10H40C42.21 10 44 11.79 44 14V38C44 40.21 42.21 42 40 42H8C5.79 42 4 40.21 4 38V10Z" fill="#5C6BC0"/>
+  <path d="M4 18H44V38C44 40.21 42.21 42 40 42H8C5.79 42 4 40.21 4 38V18Z" fill="#7986CB"/>
+  <path d="M4 18H44V20H4V18Z" fill="#6F7FCC"/>
+</svg>

--- a/src/renderer/components/titlebar/OpenInMenu.tsx
+++ b/src/renderer/components/titlebar/OpenInMenu.tsx
@@ -27,7 +27,7 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const shouldReduceMotion = useReducedMotion();
   const { toast } = useToast();
-  const { icons, installedApps, availability, loading } = useOpenInApps();
+  const { icons, labels, installedApps, availability, loading } = useOpenInApps();
 
   // Fetch default app setting on mount and listen for changes
   React.useEffect(() => {
@@ -79,8 +79,7 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
   }, []);
 
   const callOpen = async (appId: OpenInAppId) => {
-    const appConfig = getAppById(appId);
-    const label = appConfig?.label || appId;
+    const label = labels[appId] || appId;
 
     void import('../../lib/telemetryClient').then(({ captureTelemetry }) => {
       captureTelemetry('toolbar_open_in_selected', { app: appId });
@@ -132,7 +131,7 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
     return menuApps[0]?.id;
   }, [defaultApp, menuApps]);
 
-  const buttonAppLabel = buttonAppId ? (getAppById(buttonAppId)?.label ?? buttonAppId) : null;
+  const buttonAppLabel = buttonAppId ? (labels[buttonAppId] ?? buttonAppId) : null;
 
   return (
     <div ref={containerRef} className="relative">
@@ -152,7 +151,7 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
           {buttonAppId && icons[buttonAppId] && (
             <img
               src={icons[buttonAppId]}
-              alt={getAppById(buttonAppId)?.label}
+              alt={labels[buttonAppId] || buttonAppId}
               className={`h-4 w-4 rounded ${
                 getAppById(buttonAppId)?.invertInDark ? 'dark:invert' : ''
               }`}
@@ -224,11 +223,11 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
                   {icons[app.id] ? (
                     <img
                       src={icons[app.id]}
-                      alt={app.label}
+                      alt={labels[app.id] || app.label}
                       className={`h-4 w-4 rounded ${app.invertInDark ? 'dark:invert' : ''}`}
                     />
                   ) : null}
-                  <span>{app.label}</span>
+                  <span>{labels[app.id] || app.label}</span>
                   {app.id === defaultApp && (
                     <span className="ml-auto text-xs text-muted-foreground">Selected</span>
                   )}

--- a/src/shared/openInApps.ts
+++ b/src/shared/openInApps.ts
@@ -6,6 +6,8 @@ export type PlatformConfig = {
   checkCommands?: string[];
   bundleIds?: string[];
   appNames?: string[];
+  label?: string;
+  iconPath?: string;
 };
 
 type OpenInAppConfigShape = {
@@ -22,6 +24,8 @@ type OpenInAppConfigShape = {
 
 const ICON_PATHS = {
   finder: 'finder.png',
+  explorer: 'explorer.svg',
+  files: 'files.svg',
   cursor: 'cursor.svg',
   vscode: 'vscode.png',
   terminal: 'terminal.png',
@@ -43,8 +47,16 @@ export const OPEN_IN_APPS: OpenInAppConfigShape[] = [
     alwaysAvailable: true,
     platforms: {
       darwin: { openCommands: ['open {{path}}'] },
-      win32: { openCommands: ['explorer {{path}}'] },
-      linux: { openCommands: ['xdg-open {{path}}'] },
+      win32: {
+        openCommands: ['explorer "{{path_raw}}"'],
+        label: 'Explorer',
+        iconPath: ICON_PATHS.explorer,
+      },
+      linux: {
+        openCommands: ['xdg-open {{path}}'],
+        label: 'Files',
+        iconPath: ICON_PATHS.files,
+      },
     },
   },
   {
@@ -282,4 +294,12 @@ export function getAppById(id: string): OpenInAppConfig | undefined {
 
 export function isValidOpenInAppId(value: unknown): value is OpenInAppId {
   return typeof value === 'string' && OPEN_IN_APPS.some((app) => app.id === value);
+}
+
+export function getResolvedLabel(app: OpenInAppConfigShape, platform: PlatformKey): string {
+  return app.platforms[platform]?.label || app.label;
+}
+
+export function getResolvedIconPath(app: OpenInAppConfigShape, platform: PlatformKey): string {
+  return app.platforms[platform]?.iconPath || app.iconPath;
 }


### PR DESCRIPTION
## Summary
- Add per-platform `label` and `iconPath` overrides to `PlatformConfig` so the "Open in" menu shows **Explorer** (with icon) on Windows and **Files** (with icon) on Linux instead of always showing "Finder"
- Add `getResolvedLabel()` and `getResolvedIconPath()` helpers to resolve platform-specific overrides with fallback to the app-level defaults
- Update `useOpenInApps` hook to detect the current platform and resolve labels/icons accordingly
- Update `OpenInMenu` component and `appIpc` handler to use resolved labels in UI text, alt attributes, and error messages
- Fix Windows Explorer open command to use `{{path_raw}}` (unquoted) since `explorer` doesn't accept single-quoted paths

## Assets
- Added `explorer.svg` and `files.svg` icons for Windows and Linux file managers