### PR TITLE
fix: remove localStorage persistence for PR merge admin override

### DIFF
--- a/src/renderer/components/MergePrSection.tsx
+++ b/src/renderer/components/MergePrSection.tsx
@@ -172,12 +172,7 @@ export function MergePrSection({
     } catch {}
     return 'merge';
   });
-  const [adminOverride, setAdminOverride] = useState<boolean>(() => {
-    try {
-      return localStorage.getItem('emdash:prMergeAdminOverride') === 'true';
-    } catch {}
-    return false;
-  });
+  const [adminOverride, setAdminOverride] = useState(false);
 
   const activePr = pr && typeof pr.number === 'number' && Number.isFinite(pr.number) ? pr : null;
   const mergeUiState = activePr ? computeMergeUiState(activePr, adminOverride) : null;
@@ -204,9 +199,6 @@ export function MergePrSection({
 
   const setAndPersistAdminOverride = (next: boolean) => {
     setAdminOverride(next);
-    try {
-      localStorage.setItem('emdash:prMergeAdminOverride', String(next));
-    } catch {}
   };
 
   const setAndPersistStrategy = (next: MergeStrategy) => {


### PR DESCRIPTION
## Summary

- Remove localStorage persistence for the admin override toggle in `MergePrSection`
- The admin override state now defaults to `false` on each session instead of being remembered

This prevents the admin override from silently persisting across sessions, which could lead to unintended force-merges of PRs that haven't passed required checks.