### PR TITLE
fix: remove npm fallbacks from non-npm package manager install commands

### DIFF
--- a/src/main/services/ProjectPrep.ts
+++ b/src/main/services/ProjectPrep.ts
@@ -5,20 +5,14 @@ import { spawn } from 'child_process';
 function pickNodeInstallCmd(target: string): string[] {
   // Prefer package manager based on lockfile presence
   if (existsSync(join(target, 'pnpm-lock.yaml'))) {
-    return ['pnpm install --frozen-lockfile', 'pnpm install', 'npm ci', 'npm install'];
+    return ['pnpm install --frozen-lockfile', 'pnpm install'];
   }
   if (existsSync(join(target, 'yarn.lock'))) {
     // Support modern Yarn (Berry) and classic Yarn
-    return [
-      'yarn install --immutable',
-      'yarn install --frozen-lockfile',
-      'yarn install',
-      'npm ci',
-      'npm install',
-    ];
+    return ['yarn install --immutable', 'yarn install --frozen-lockfile', 'yarn install'];
   }
   if (existsSync(join(target, 'bun.lockb'))) {
-    return ['bun install', 'npm ci', 'npm install'];
+    return ['bun install'];
   }
   if (existsSync(join(target, 'package-lock.json'))) {
     return ['npm ci', 'npm install'];


### PR DESCRIPTION
## Summary

- Remove `npm ci` and `npm install` fallback commands from `pnpm`, `yarn`, and `bun` install strategies in `ProjectPrep.ts`
- When a project uses a specific package manager (detected by lockfile), falling back to npm can generate an invalid `package-lock.json` that pollutes the worktree
- Each package manager now only attempts its own install commands

<!-- emdash-issue-footer:start -->
Fixes GEN-382
<!-- emdash-issue-footer:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to background dependency install command selection; main risk is reduced resiliency if pnpm/yarn/bun aren’t available, causing prep to skip rather than fall back to npm.
> 
> **Overview**
> When a Node project is detected via lockfiles, `ProjectPrep.pickNodeInstallCmd` no longer falls back to `npm ci`/`npm install` for `pnpm`, `yarn`, or `bun` workflows.
> 
> Dependency prep now only tries install commands for the detected package manager, avoiding unintended `package-lock.json` generation and worktree pollution for non-npm projects.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1d512a5dde3ddb78ae5b4d6fa45312663f33d95. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->