### PR TITLE
fix(worktree): resolve local refs to remote tracking refs for reserve creation

### DIFF
--- a/src/main/services/WorktreePoolService.ts
+++ b/src/main/services/WorktreePoolService.ts
@@ -90,8 +90,8 @@ export class WorktreePoolService {
    * potentially stale local branch.
    */
   private async resolveToRemoteRef(projectPath: string, baseRef: string): Promise<string> {
-    // Already a remote ref (e.g. origin/main) — use as-is
-    if (baseRef.includes('/')) return baseRef;
+    // Already a remote tracking ref — use as-is
+    if (baseRef.startsWith('origin/')) return baseRef;
 
     try {
       const branchName =


### PR DESCRIPTION
## Summary
- Reserve worktrees were being created from potentially stale local branch refs instead of freshly-fetched remote refs
- Added `resolveToRemoteRef()` that translates `HEAD` or bare branch names (e.g. `main`) to their remote tracking counterpart (e.g. `origin/main`) after `git fetch --all`
- Falls back gracefully to the original ref if the remote tracking branch doesn't exist

## Problem
After `refreshRefsForReserveCreation` fetches all remote refs, the reserve worktree was still being created from the local branch ref, which could be behind the remote. This meant claimed reserves could start from outdated code.

## Test plan
- [ ] Create a task when local branch is behind remote — verify the worktree starts from the remote HEAD
- [ ] Create a task with a baseRef that has no remote tracking branch — verify fallback works
- [ ] Create a task with an already-qualified remote ref (e.g. `origin/main`) — verify it passes through unchanged
- [ ] Run `pnpm run type-check` and `pnpm exec vitest run`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to reserve worktree creation that only adjusts which git ref is used; failures fall back to prior behavior.
> 
> **Overview**
> Reserve worktree creation now resolves `HEAD`/bare branch names (e.g. `main`) to their corresponding remote-tracking ref (e.g. `origin/main`) after `git fetch --all`, so reserves start from up-to-date remote code.
> 
> Adds `resolveToRemoteRef()` to translate and verify the `origin/*` ref (with graceful fallback), and uses the resolved ref in `git worktree add` during `createReserve()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4afc68aea0a763b1b0626bb5bd7cea4b6ee2c970. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->