### PR TITLE
feat(jira): support numeric issue search by expanding to project keys

### DIFF
--- a/src/main/services/JiraService.ts
+++ b/src/main/services/JiraService.ts
@@ -72,6 +72,7 @@ export default class JiraService {
   async clearCredentials(): Promise<{ success: boolean; error?: string }> {
     try {
       const keytar = await import('keytar');
+      this.projectKeys = [];
       try {
         await keytar.deletePassword(this.SERVICE, this.ACCOUNT);
       } catch {}


### PR DESCRIPTION
## Summary
- Add `fetchProjectKeys()` to retrieve all project keys from the Jira API on connection check
- Cache project keys in memory for use during search
- When a user searches for a plain number (e.g. `123`), expand it into a `key IN ("PROJ-123", ...)` JQL clause using cached project keys, so users can find issues without typing the full project prefix
- Clean up redundant variable in `smartSearchIssues` JQL construction

<!-- emdash-issue-footer:start -->
Fixes GEN-223
<!-- emdash-issue-footer:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a new Jira API call during `checkConnection` and changes JQL generation, which could affect performance and search results if project listing is slow/forbidden or the key expansion is large.
> 
> **Overview**
> Improves Jira issue search so entering a plain number (e.g. `123`) can resolve to matching issues by expanding the query to all known project-prefixed keys.
> 
> On connection check, the service now fetches `/rest/api/3/project` to cache project keys in memory, clears that cache on disconnect, and updates `smartSearchIssues` JQL construction to append a `key IN ("PROJ-123", ...)` clause when the search term is numeric.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 98479cca2362d06b1b705b0fe42e17fcbe5e35c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->