### PR TITLE
fix(updater): harden install flow for Linux and simplify UpdateModal

### DIFF
--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -55,6 +55,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
       ['update:downloading', 'downloading'],
       ['update:download-progress', 'download-progress'],
       ['update:downloaded', 'downloaded'],
+      ['update:installing', 'installing'],
     ];
     const handlers: Array<() => void> = [];
     for (const [channel, type] of pairs) {

--- a/src/renderer/components/UpdateCard.tsx
+++ b/src/renderer/components/UpdateCard.tsx
@@ -84,7 +84,7 @@ export function UpdateCard(): JSX.Element {
           {renderStatusMessage()}
         </div>
         <div className="flex items-center gap-2">
-          {updater.state.status !== 'downloaded' && (
+          {updater.state.status !== 'downloaded' && updater.state.status !== 'installing' && (
             <Button
               type="button"
               variant="outline"
@@ -155,6 +155,14 @@ export function UpdateCard(): JSX.Element {
           </p>
         );
 
+      case 'installing':
+        return (
+          <p className="flex items-center gap-1 text-sm text-muted-foreground">
+            <Loader2 className="h-3 w-3 animate-spin" />
+            Installing update. Emdash will close when ready.
+          </p>
+        );
+
       case 'error':
         return (
           <Badge
@@ -206,6 +214,14 @@ export function UpdateCard(): JSX.Element {
           <Button size="sm" variant="default" onClick={handleInstall} className="h-7 text-xs">
             <RefreshCw className="mr-1.5 h-3 w-3" />
             Restart
+          </Button>
+        );
+
+      case 'installing':
+        return (
+          <Button size="sm" variant="outline" disabled className="h-7 text-xs">
+            <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+            Installing
           </Button>
         );
 


### PR DESCRIPTION
## Summary
- Cherry-picks the Linux crash fix from #965: adds `installing` state with single-shot `quitAndInstall` guard and 2-minute timeout rollback, so Linux users don't get stuck when the dpkg auth dialog blocks the app
- Simplifies `UpdateModal` to use the exact same `useUpdater()` pattern as `UpdateCard` in Settings — removes the complex state machine (dev simulation, `useLayoutEffect`, backend state sync, auto-download) that caused race conditions and stale closures
- Zero changes to the check/download flow — only the install path (`quitAndInstall`) is hardened

## Changes
- **AutoUpdateService.ts**: Single-shot `installRequested` guard, `installing` status broadcast, 2-min timeout rollback if app doesn't quit, error guard during install, try/catch around `quitAndInstall`
- **UpdateModal.tsx**: Rewritten to match UpdateCard pattern — simple `useUpdater()` hook, manual user actions, auto-check on open
- **useUpdater.ts**: Added `installing` state to type union, event handler, `applyBackendState`, and optimistic state in `install()`
- **UpdateCard.tsx**: Added `installing` state rendering (spinner + disabled button)
- **preload.ts**: Added `update:installing` event channel

## Test plan
- [x] `pnpm run type-check` passes
- [x] `pnpm run lint` passes (0 errors)
- [x] Built local production package at v0.4.14, auto-update to v0.4.16 worked correctly on macOS
- [ ] Settings UpdateCard check/download/restart flow works unchanged
- [ ] Menu bar "Check for Updates" modal works with simplified flow
- [ ] Linux: install no longer hangs on dpkg auth dialog

Closes #966

🤖 Generated with [Claude Code](https://claude.com/claude-code)