### PR TITLE
fix(app): set cwd when executing open-in-app commands

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -381,7 +381,7 @@ export function registerAppIpc() {
         }
 
         await new Promise<void>((resolve, reject) => {
-          exec(command, { env: buildExternalToolEnv() }, (err) => {
+          exec(command, { cwd: target, env: buildExternalToolEnv() }, (err) => {
             if (err) return reject(err);
             resolve();
           });


### PR DESCRIPTION
## Summary

- Adds `cwd: target` to the `exec` options when running open-in-app commands, ensuring the command executes in the correct working directory
- Previously the command ran without an explicit working directory, which could cause apps to open in the wrong location

<!-- emdash-issue-footer:start -->
Fixes #595
<!-- emdash-issue-footer:end -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to process spawning options for `exec`; main risk is minor behavior differences for apps that previously relied on inheriting the app’s default working directory.
> 
> **Overview**
> Ensures *command-based* “open in app” actions run from the selected project directory by executing the configured `openCommands` with `cwd: target`.
> 
> This prevents apps that rely on the working directory from opening in an unexpected location while keeping the existing environment setup via `buildExternalToolEnv()`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebecf2af1deeae8f24116a16da6b7b1f8ae2868e. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->