### PR TITLE
fix: logo shimmer animation visible as box in dark mode

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -222,9 +222,15 @@
   }
 
   @keyframes logo-fade-in {
-    0% { opacity: 0.5; }
-    90% { opacity: 0.5; }
-    100% { opacity: 1; }
+    0% {
+      opacity: 0.5;
+    }
+    90% {
+      opacity: 0.5;
+    }
+    100% {
+      opacity: 1;
+    }
   }
 
   @keyframes logo-shimmer-move {


### PR DESCRIPTION
## Summary
  - Fix logo shimmer animation showing a visible box in dark mode
  - Remove `mix-blend-mode: screen` and add opacity-based approach for dark theme visibility


https://github.com/user-attachments/assets/cb802875-3fd6-45b2-bf30-57a4de6143f9

