### PR TITLE
feat(editor): render local images in markdown preview

### DIFF
--- a/src/renderer/components/FileExplorer/CodeEditor.tsx
+++ b/src/renderer/components/FileExplorer/CodeEditor.tsx
@@ -310,6 +310,7 @@ export default function CodeEditor({
             onEditorChange={handleEditorChange}
             isPreviewActive={isPreviewActive}
             modelRootPath={modelRootPath}
+            taskPath={taskPath}
           />
         </div>
       </div>
@@ -402,6 +403,7 @@ interface EditorContentProps {
   onEditorChange: (value: string | undefined) => void;
   isPreviewActive: boolean;
   modelRootPath: string;
+  taskPath: string;
 }
 
 const EditorContent: React.FC<EditorContentProps> = ({
@@ -411,6 +413,7 @@ const EditorContent: React.FC<EditorContentProps> = ({
   onEditorChange,
   isPreviewActive,
   modelRootPath,
+  taskPath,
 }) => {
   if (!activeFile) {
     return <NoFileOpen />;
@@ -425,7 +428,10 @@ const EditorContent: React.FC<EditorContentProps> = ({
   }
 
   if (isPreviewActive) {
-    return <MarkdownPreview content={activeFile.content} />;
+    const fileDir = activeFile.path.includes('/')
+      ? activeFile.path.substring(0, activeFile.path.lastIndexOf('/'))
+      : '';
+    return <MarkdownPreview content={activeFile.content} rootPath={taskPath} fileDir={fileDir} />;
   }
 
   return (

--- a/src/renderer/components/FileExplorer/MarkdownPreview.tsx
+++ b/src/renderer/components/FileExplorer/MarkdownPreview.tsx
@@ -3,12 +3,22 @@ import { MarkdownRenderer } from '../ui/markdown-renderer';
 
 interface MarkdownPreviewProps {
   content: string;
+  /** Root path for resolving relative image paths (e.g. taskPath / worktree root) */
+  rootPath?: string;
+  /** Directory of the markdown file, relative to rootPath */
+  fileDir?: string;
 }
 
-export const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content }) => {
+export const MarkdownPreview: React.FC<MarkdownPreviewProps> = ({ content, rootPath, fileDir }) => {
   return (
     <div className="flex flex-1 overflow-auto bg-background">
-      <MarkdownRenderer content={content} variant="full" className="w-full max-w-3xl px-8 py-8" />
+      <MarkdownRenderer
+        content={content}
+        variant="full"
+        className="w-full max-w-3xl px-8 py-8"
+        rootPath={rootPath}
+        fileDir={fileDir}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- Add support for rendering relative image paths in the markdown preview by resolving them via `fsReadImage` and displaying as base64 data URIs
- Local (non-HTTP) image references in markdown files are resolved relative to the file's directory and the worktree root path
- External (HTTP/HTTPS) images continue to render normally
- Update `rehype-sanitize` schema to allow `data:` URIs on image `src` attributes

## Changes
- **`markdown-renderer.tsx`**: Add `ResolvedImage` component that loads local images via `electronAPI.fsReadImage`, add `rootPath`/`fileDir` props, update sanitize schema for data URIs
- **`MarkdownPreview.tsx`**: Pass through `rootPath` and `fileDir` props to `MarkdownRenderer`
- **`CodeEditor.tsx`**: Compute `fileDir` from the active file path and pass `taskPath`/`fileDir` to `MarkdownPreview`