### PR TITLE
fix(ci): add electron-rebuild step to Linux release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -238,6 +238,12 @@ jobs:
           sed -i "s#__PH_KEY__#${PH_KEY}#g" dist/main/appConfig.json
           echo "Wrote dist/main/appConfig.json"
 
+      - name: Rebuild native modules for Electron (x64)
+        run: |
+          set -euo pipefail
+          ELECTRON_VERSION=$(node -p "require('electron/package.json').version")
+          npm_config_build_from_source=true pnpm exec electron-rebuild -f -a x64 -v "$ELECTRON_VERSION" -o sqlite3,node-pty,keytar
+
       - name: Build Linux packages (AppImage and .deb)
         run: pnpm run package:linux
 


### PR DESCRIPTION
summary:
- fixes PTY unavailable error on Linux since 0.4.16 (NODE_MODULE_VERSION 127 vs. 123

cause:
- native modules (node-pty, sqlite3, keytar) are compiled for CI runners node 22 (ABI 127)
- those modules need to be recompiled for electrons node version (ABI 123)
- in 0.4.15, postinstall script handled this rebuild, but was changed to be skipped in CI in 0.4.16 (mac build needs to be per architecture, postinstall could not handle that)
- each platform is now expected to run "electron-rebuild" explicitly in the workflow
- mac and windows already had that step, linux was still missing it

fix:
- added electron-rebuild step for linux

fixes #1068