### PR TITLE
docs(readme): escape install commands using <code> tags and HTML entities for pipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ Emdash currently supports twenty-one CLI providers and we are adding new provide
 
 | CLI Provider | Status | Install |
 | ----------- | ------ | ----------- |
-| https://ampcode.com/manual | ✅ Supported | <code>npm install -g @sourcegraph/amp@latest</code> |
+| [Amp](https://ampcode.com/manual) | ✅ Supported | <code>npm install -g @sourcegraph/amp@latest</code> |
 | [Auggie](https://docs.augmentcode.com/cli/overview) | ✅ Supported | <code>npm install -g @augmentcode/auggie</code> |
 | [Charm](https://github.com/charmbracelet/crush) | ✅ Supported | <code>npm install -g @charmland/crush</code> |
 | [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) | ✅ Supported | <code>curl -fsSL https://claude.ai/install.sh &#124; bash</code> |
@@ -87,7 +87,7 @@ Emdash currently supports twenty-one CLI providers and we are adding new provide
 | [Codex](https://developers.openai.com/codex/cli/) | ✅ Supported | <code>npm install -g @openai/codex</code> |
 | [Continue](https://docs.continue.dev/guides/cli) | ✅ Supported | <code>npm i -g @continuedev/cli</code> |
 | [Cursor](https://cursor.com/cli) | ✅ Supported | <code>curl https://cursor.com/install -fsS &#124; bash</code> |
-| https://docs.factory.ai/cli/getting-started/quickstart | ✅ Supported | <code>curl -fsSL https://app.factory.ai/cli &#124; sh</code> |
+| [Droid](https://docs.factory.ai/cli/getting-started/quickstart) | ✅ Supported | <code>curl -fsSL https://app.factory.ai/cli &#124; sh</code> |
 | [Gemini](https://github.com/google-gemini/gemini-cli) | ✅ Supported | <code>npm install -g @google/gemini-cli</code> |
 | [GitHub Copilot](https://docs.github.com/en/copilot/how-tos/set-up/installing-github-copilot-in-the-cli) | ✅ Supported | <code>npm install -g @github/copilot</code> |
 | [Goose](https://github.com/block/goose) | ✅ Supported | <code>curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh &#124; bash</code> |


### PR DESCRIPTION
The install commands in the README table were not being rendered correctly because Markdown interpreted the pipe characters (`|`) inside the commands as column separators. As a result, parts of several commands were treated as separate table cells, causing missing code segments and incorrect text rendering.

This update escapes all pipe characters using `&#124;` and wraps each install command in `<code>` tags. The README now displays the full commands as intended without breaking the table layout.