### PR TITLE
fix(terminal): enable copy shortcuts in all terminal sessions

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -243,8 +243,6 @@ export class TerminalSessionManager {
 
     this.applyTheme(options.theme);
 
-    const isAgentSession = Boolean(options.providerId);
-
     // Custom key event handler: always attached so the dialog guard
     // runs for every terminal, plus optional copy/Shift+Enter handling.
     this.terminal.attachCustomKeyEventHandler((event: KeyboardEvent) => {
@@ -256,10 +254,7 @@ export class TerminalSessionManager {
         return false;
       }
 
-      if (
-        isAgentSession &&
-        shouldCopySelectionFromTerminal(event, IS_MAC_PLATFORM, this.terminal.hasSelection())
-      ) {
+      if (shouldCopySelectionFromTerminal(event, IS_MAC_PLATFORM, this.terminal.hasSelection())) {
         event.preventDefault();
         event.stopImmediatePropagation();
         event.stopPropagation();


### PR DESCRIPTION
summary:
- ctrl + shift + c and ctrl + c (with selection) now also work in shell terminals, not just agent sessions
- previously gated behind isAgentSession

fixes #1075
fixes #914