### PR TITLE
feat: show 'create pr' if commits are ahead of main

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -224,7 +224,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
-      if (!safeTaskPath || hasChanges) {
+      if (!safeTaskPath) {
         setBranchAhead(null);
         return;
       }


### PR DESCRIPTION
Problem:
The 'Create PR' button was only visible when the working directory had uncommitted changes. If a user committed locally but hadn't yet opened a PR, the button would disappear.

Solution:
Updated FileChangesPanel.tsx to ensure branchAhead status is tracked even when hasChanges is true. This allows the "Create PR" button to persist as long as the local branch is ahead of main.

Verification:
Verified via code analysis that the branchAhead state is no longer reset by uncommitted file presence.