### PR TITLE
feat: prevent MergePrSection from rendering for closed pull requests

### DIFF
--- a/src/renderer/components/MergePrSection.tsx
+++ b/src/renderer/components/MergePrSection.tsx
@@ -190,6 +190,8 @@ export function MergePrSection({
     (mergeState === 'BLOCKED' || mergeState === 'HAS_HOOKS' || mergeState === 'UNSTABLE');
 
   if (!activePr || !mergeUiState) return null;
+  const prStateNormalized = typeof pr?.state === 'string' ? pr.state.toUpperCase() : '';
+  if (prStateNormalized === 'CLOSED') return null;
 
   const formatMergeError = (error: unknown): string => {
     if (typeof error !== 'string') return 'Failed to merge PR.';


### PR DESCRIPTION
fix: #1052 

This PR includes changes as: 
1. Added handling when PR is closed 


Check
1. Format
2. build 
3. Manual Verification