### PR TITLE
fix(ci): fix Linux releaseflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,7 +205,7 @@ jobs:
       - name: Install system build dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential
+          sudo apt-get install -y build-essential pkg-config libsecret-1-dev
 
       - name: Install dependencies (allow platform optional deps)
         env:


### PR DESCRIPTION
## Summary
  - PR #1069 added electron-rebuild to the Linux release workflow but keytar's
    native build fails because libsecret-1-dev is missing on the Ubuntu runner
  - Adds libsecret-1-dev and pkg-config to the apt-get install step

  ## Test plan
  - [ ] Trigger a Linux release build and verify electron-rebuild completes