### PR TITLE
fix: show Create PR button when branch is ahead of main

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -226,7 +226,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
   useEffect(() => {
     let cancelled = false;
     const load = async () => {
-      if (!safeTaskPath || hasChanges) {
+      if (!safeTaskPath) {
         setBranchAhead(null);
         return;
       }
@@ -264,7 +264,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
       cancelled = true;
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [safeTaskPath, hasChanges]);
+  }, [safeTaskPath]);
 
   const handleStageFile = async (filePath: string, event: React.MouseEvent) => {
     event.stopPropagation();


### PR DESCRIPTION
## Summary
Fix issue #1073: Show Create PR button when commits are ahead of main, even when there are no uncommitted file changes.

## Changes
- Removed the `hasChanges` check from branch status useEffect
- Now branch status is always checked (except for remote SSH paths)
- Create PR button will show when local branch is ahead of main, regardless of whether there are uncommitted changes