### PR TITLE
fix: always land on home view after app restart

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -185,10 +185,7 @@ const AppContent: React.FC = () => {
   const appInit = useAppInitialization({
     checkGithubStatus: () => github.checkStatus(),
     onProjectsLoaded: (projects) => projectMgmt.setProjects(projects),
-    onProjectSelected: (project) => projectMgmt.setSelectedProject(project),
     onShowHomeView: (show) => projectMgmt.setShowHomeView(show),
-    onTaskSelected: (task) => taskMgmt.setActiveTask(task),
-    onTaskAgentSelected: (agent) => taskMgmt.setActiveTaskAgent(agent),
     onInitialLoadComplete: () => {},
   });
 
@@ -214,7 +211,6 @@ const AppContent: React.FC = () => {
     setActiveTask: (task) => taskMgmt.setActiveTask(task),
     saveProjectOrder: appInit.saveProjectOrder,
     ToastAction,
-    storedActiveIds: appInit.storedActiveIds,
   });
 
   // Keep the selectedProject ref in sync for useModalState's kanban toggle guard

--- a/src/renderer/hooks/useProjectManagement.tsx
+++ b/src/renderer/hooks/useProjectManagement.tsx
@@ -23,7 +23,6 @@ interface UseProjectManagementOptions {
   setActiveTask: React.Dispatch<React.SetStateAction<Task | null>>;
   saveProjectOrder: (list: Project[]) => void;
   ToastAction: React.ComponentType<any>;
-  storedActiveIds: { projectId: string | null; taskId: string | null };
 }
 
 export const useProjectManagement = (options: UseProjectManagementOptions) => {
@@ -41,14 +40,12 @@ export const useProjectManagement = (options: UseProjectManagementOptions) => {
     setActiveTask,
     saveProjectOrder,
     ToastAction,
-    storedActiveIds,
   } = options;
 
   const [projects, setProjects] = useState<Project[]>([]);
   const [selectedProject, setSelectedProject] = useState<Project | null>(null);
-  const hasPendingRestore = storedActiveIds.projectId !== null;
-  // Start with showHomeView=false if we have a pending restore to prevent flash
-  const [showHomeView, setShowHomeView] = useState<boolean>(!hasPendingRestore);
+  // Always start on home view (e.g. after app restart)
+  const [showHomeView, setShowHomeView] = useState<boolean>(true);
   const [showSkillsView, setShowSkillsView] = useState(false);
   const [projectBranchOptions, setProjectBranchOptions] = useState<
     Array<{ value: string; label: string }>


### PR DESCRIPTION
## Summary

- Remove stored active project/task restoration on app startup, always showing the home view instead
- Simplify `useAppInitialization` by removing `storedActiveIds`, `onProjectSelected`, `onTaskSelected`, and `onTaskAgentSelected` callbacks
- Remove `storedActiveIds` prop threading through `useProjectManagement`
- Initialize `showHomeView` state to `true` unconditionally, eliminating the flash-prevention logic

## Motivation

Previously, the app would attempt to restore the last active project and task from `localStorage` on startup. This could lead to issues after restarts or updates where the restored state was stale or unexpected. Now the app always starts fresh on the home view, giving users a clean starting point.

<!-- emdash-issue-footer:start -->
Fixes GEN-412
<!-- emdash-issue-footer:end -->