### PR TITLE
docs: add Emdash X follow badge to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,5 +224,6 @@ Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md) to get star
 > See [docs/ssh-setup.md](./docs/ssh-setup.md) for detailed setup instructions and [docs/ssh-architecture.md](./docs/ssh-architecture.md) for technical details.
 </details>
 
+[![Follow @emdashsh](https://img.shields.io/twitter/follow/emdashsh?style=social&label=Follow%20%40emdashsh)](https://x.com/emdashsh)
 [![Follow @rabanspiegel](https://img.shields.io/twitter/follow/rabanspiegel?style=social&label=Follow%20%40rabanspiegel)](https://x.com/rabanspiegel)
 [![Follow @arnestrickmann](https://img.shields.io/twitter/follow/arnestrickmann?style=social&label=Follow%20%40arnestrickmann)](https://x.com/arnestrickmann)


### PR DESCRIPTION
## Summary
- Adds a `Follow @emdashsh` X/Twitter badge to the README footer, alongside the existing personal follow badges for @rabanspiegel and @arnestrickmann