### PR TITLE
fix: shared input bar now submits follow-up prompts to all agent panes

### DIFF
--- a/src/renderer/lib/activityConstants.ts
+++ b/src/renderer/lib/activityConstants.ts
@@ -6,3 +6,4 @@ export const CLEAR_BUSY_MS = 6_000;
 export const INJECT_ON_DATA_DELAY_MS = 150;
 export const INJECT_ON_STARTED_DELAY_MS = 250;
 export const INJECT_FALLBACK_MS = 2_000;
+export const INJECT_ENTER_DELAY_MS = 50;


### PR DESCRIPTION
summary:
- when entering a message into the shared input bar and hitting enter, the message was mirrored into the agents cli, but not submitted
- TUI frameworks detect multi byte input as paste and strip trailing newlines

fix:
- split PTY write into two parts: text + line ending first, then a bare \r after a 50ms delay
- sending "Enter" separately fixes the issue

limits:
- could only verify with Claude Code and Gemini CLI

fixes #1103