### PR TITLE
fix: improve tab bar layout with scrollable tabs, pinned context badges, and overflow

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -74,6 +74,8 @@ const ChatInterface: React.FC<Props> = ({
   const [showDeleteChatModal, setShowDeleteChatModal] = useState(false);
   const [chatToDelete, setChatToDelete] = useState<string | null>(null);
   const [busyByConversationId, setBusyByConversationId] = useState<Record<string, boolean>>({});
+  const tabsContainerRef = useRef<HTMLDivElement>(null);
+  const [tabsOverflow, setTabsOverflow] = useState(false);
 
   const mainConversationId = useMemo(
     () => conversations.find((c) => c.isMain)?.id ?? null,
@@ -141,6 +143,16 @@ const ChatInterface: React.FC<Props> = ({
   useAutoScrollOnTaskSwitch(true, task.id);
 
   const readySignaledTaskIdRef = useRef<string | null>(null);
+  useEffect(() => {
+    const el = tabsContainerRef.current;
+    if (!el) return;
+    const check = () => setTabsOverflow(el.scrollWidth > el.clientWidth);
+    check();
+    const ro = new ResizeObserver(check);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, [conversations.length]);
+
   useEffect(() => {
     if (!onTaskInterfaceReady) return;
     if (readySignaledTaskIdRef.current === task.id) return;
@@ -887,96 +899,99 @@ const ChatInterface: React.FC<Props> = ({
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="px-6 pt-4">
             <div className="mx-auto max-w-4xl space-y-2">
-              <div className="flex items-center justify-between">
-                <div className="flex min-w-0 flex-1 items-start gap-2">
-                  <div className="flex min-w-0 items-center gap-2 overflow-x-auto">
-                    {sortedConversations.map((conv, index) => {
-                      const isActive = conv.id === activeConversationId;
-                      const convAgent = conv.provider || agent;
-                      const config = agentConfig[convAgent as Agent];
-                      const agentName = config?.name || convAgent;
-                      const isBusy = busyByConversationId[conv.id] === true;
+              <div className="flex items-center gap-2">
+                <div
+                  ref={tabsContainerRef}
+                  className={cn(
+                    'flex min-w-0 items-center gap-2 overflow-x-auto [scrollbar-width:none] [&::-webkit-scrollbar]:hidden',
+                    tabsOverflow &&
+                      '[mask-image:linear-gradient(to_right,black_calc(100%_-_16px),transparent)]'
+                  )}
+                >
+                  {sortedConversations.map((conv, index) => {
+                    const isActive = conv.id === activeConversationId;
+                    const convAgent = conv.provider || agent;
+                    const config = agentConfig[convAgent as Agent];
+                    const agentName = config?.name || convAgent;
+                    const isBusy = busyByConversationId[conv.id] === true;
 
-                      // Count how many chats use the same agent up to this point
-                      const sameAgentCount = sortedConversations
-                        .slice(0, index + 1)
-                        .filter((c) => (c.provider || agent) === convAgent).length;
-                      const showNumber =
-                        sortedConversations.filter((c) => (c.provider || agent) === convAgent)
-                          .length > 1;
+                    // Count how many chats use the same agent up to this point
+                    const sameAgentCount = sortedConversations
+                      .slice(0, index + 1)
+                      .filter((c) => (c.provider || agent) === convAgent).length;
+                    const showNumber =
+                      sortedConversations.filter((c) => (c.provider || agent) === convAgent)
+                        .length > 1;
 
-                      return (
-                        <button
-                          key={conv.id}
-                          onClick={() => handleSwitchChat(conv.id)}
-                          aria-current={isActive ? 'page' : undefined}
-                          className={cn(
-                            'inline-flex h-7 flex-shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs font-medium transition-colors',
-                            'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
-                            isActive
-                              ? 'bg-background text-foreground shadow-sm'
-                              : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
-                          )}
-                          title={`${agentName}${showNumber ? ` (${sameAgentCount})` : ''}`}
-                        >
-                          {config?.logo && (
-                            <AgentLogo
-                              logo={config.logo}
-                              alt={config.alt}
-                              isSvg={config.isSvg}
-                              invertInDark={config.invertInDark}
-                              className="h-3.5 w-3.5 flex-shrink-0"
-                            />
-                          )}
-                          <span className="max-w-[10rem] truncate">
-                            {agentName}
-                            {showNumber && (
-                              <span className="ml-1 opacity-60">{sameAgentCount}</span>
+                    return (
+                      <button
+                        key={conv.id}
+                        onClick={() => handleSwitchChat(conv.id)}
+                        aria-current={isActive ? 'page' : undefined}
+                        className={cn(
+                          'inline-flex h-7 flex-shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs font-medium transition-colors',
+                          'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+                          isActive
+                            ? 'bg-background text-foreground shadow-sm'
+                            : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
+                        )}
+                        title={`${agentName}${showNumber ? ` (${sameAgentCount})` : ''}`}
+                      >
+                        {config?.logo && (
+                          <AgentLogo
+                            logo={config.logo}
+                            alt={config.alt}
+                            isSvg={config.isSvg}
+                            invertInDark={config.invertInDark}
+                            className="h-3.5 w-3.5 flex-shrink-0"
+                          />
+                        )}
+                        <span className="max-w-[10rem] truncate">
+                          {agentName}
+                          {showNumber && <span className="ml-1 opacity-60">{sameAgentCount}</span>}
+                        </span>
+                        {isBusy && conversations.length > 1 ? (
+                          <Spinner
+                            size="sm"
+                            className={cn(
+                              'h-3 w-3 flex-shrink-0',
+                              isActive ? 'text-foreground' : 'text-muted-foreground'
                             )}
-                          </span>
-                          {isBusy && conversations.length > 1 ? (
-                            <Spinner
-                              size="sm"
-                              className={cn(
-                                'h-3 w-3 flex-shrink-0',
-                                isActive ? 'text-foreground' : 'text-muted-foreground'
-                              )}
-                            />
-                          ) : null}
-                          {conversations.length > 1 && (
-                            <span
-                              role="button"
-                              tabIndex={0}
-                              onClick={(e) => {
+                          />
+                        ) : null}
+                        {conversations.length > 1 && (
+                          <span
+                            role="button"
+                            tabIndex={0}
+                            onClick={(e) => {
+                              e.stopPropagation();
+                              handleCloseChat(conv.id);
+                            }}
+                            onKeyDown={(e) => {
+                              if (e.key === 'Enter' || e.key === ' ') {
+                                e.preventDefault();
                                 e.stopPropagation();
                                 handleCloseChat(conv.id);
-                              }}
-                              onKeyDown={(e) => {
-                                if (e.key === 'Enter' || e.key === ' ') {
-                                  e.preventDefault();
-                                  e.stopPropagation();
-                                  handleCloseChat(conv.id);
-                                }
-                              }}
-                              className="ml-1 rounded hover:bg-background/20"
-                              title="Close chat"
-                            >
-                              <X className="h-3 w-3" />
-                            </span>
-                          )}
-                        </button>
-                      );
-                    })}
-                  </div>
-
-                  <button
-                    onClick={handleCreateNewChat}
-                    className="inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border bg-muted transition-colors hover:bg-muted/80"
-                    title="New Chat"
-                  >
-                    <Plus className="h-3.5 w-3.5" />
-                  </button>
-
+                              }
+                            }}
+                            className="ml-1 rounded hover:bg-background/20"
+                            title="Close chat"
+                          >
+                            <X className="h-3 w-3" />
+                          </span>
+                        )}
+                      </button>
+                    );
+                  })}
+                </div>
+                <button
+                  onClick={handleCreateNewChat}
+                  className="inline-flex h-7 w-7 flex-shrink-0 items-center justify-center rounded-md border border-border bg-muted transition-colors hover:bg-muted/80"
+                  title="New Chat"
+                >
+                  <Plus className="h-3.5 w-3.5" />
+                </button>
+                <div className="ml-auto flex flex-shrink-0 items-center gap-2">
                   {(task.metadata?.linearIssue ||
                     task.metadata?.githubIssue ||
                     task.metadata?.jiraIssue) && (
@@ -987,16 +1002,16 @@ const ChatInterface: React.FC<Props> = ({
                       jiraIssue={task.metadata?.jiraIssue || null}
                     />
                   )}
+                  {autoApproveEnabled && (
+                    <span
+                      className="inline-flex h-7 select-none items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 text-xs font-medium text-foreground"
+                      title="Auto-approve enabled"
+                    >
+                      <span className="h-1.5 w-1.5 rounded-full bg-orange-500" />
+                      Auto-approve
+                    </span>
+                  )}
                 </div>
-                {autoApproveEnabled && (
-                  <span
-                    className="inline-flex h-7 select-none items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 text-xs font-medium text-foreground"
-                    title="Auto-approve enabled"
-                  >
-                    <span className="h-1.5 w-1.5 rounded-full bg-orange-500" />
-                    Auto-approve
-                  </span>
-                )}
               </div>
               {(() => {
                 if (isAgentInstalled === false) {


### PR DESCRIPTION
Restructured the chat bar
* Context badges (Linear tickets, auto-approve) will always be visible, aligned on the right side
* chat tabs will expand, and if space isn't sufficient, fade out (horizontal scroll)
* Plus icon to add a new chat is always close to the latest chat

<img width="698" height="62" alt="Screenshot 2026-02-25 at 12 40 27" src="https://github.com/user-attachments/assets/d7ca04ed-899c-4bb2-86bc-7809b657d13e" />

<img width="698" height="69" alt="Screenshot 2026-02-25 at 12 40 51" src="https://github.com/user-attachments/assets/4151569f-4522-4a74-b143-c55304a16fbc" />
