### PR TITLE
chore: rename CI workflow to 'CI Check'

### DIFF
--- a/.github/workflows/code-consistency-check.yml
+++ b/.github/workflows/code-consistency-check.yml
@@ -1,4 +1,4 @@
-name: Code Consistency Check
+name: CI Check
 
 on:
   pull_request:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -302,7 +302,7 @@ All optional:
 
 ## CI/CD
 
-- **`code-consistency-check.yml`** (every PR): format check, type check, vitest
+- **`code-consistency-check.yml`** (every PR): format check, type check, vitest (workflow name: "CI Check")
 - **`release.yml`** (on `v*` tags): per-platform builds. Mac builds each arch separately to prevent native module architecture mismatches. Mac release includes signing + notarization.
 
 ## Common Pitfalls


### PR DESCRIPTION
## Summary
- Renames the GitHub Actions workflow from "Code Consistency Check" to "CI Check"
- Checks will now display as **CI Check / format-check** and **CI Check / vitest** instead of the verbose "Code Consistency Check / ..." names
- Updates AGENTS.md to reflect the new workflow name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow rename and doc update only; no behavior, build, or test logic changes.
> 
> **Overview**
> Renames the GitHub Actions workflow in `code-consistency-check.yml` from **"Code Consistency Check"** to **"CI Check"**, changing how PR checks are labeled without altering the jobs/steps.
> 
> Updates `AGENTS.md` CI/CD documentation to reflect the new workflow name.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit c1d683d2918927f0a026d6afcb167a4a8cbef555. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->