### PR TITLE
fix: reduce minimum window size and show resize handles at smaller breakpoints

### DIFF
--- a/src/main/app/window.ts
+++ b/src/main/app/window.ts
@@ -16,8 +16,8 @@ export function createMainWindow(): BrowserWindow {
   mainWindow = new BrowserWindow({
     width: 1400,
     height: 900,
-    minWidth: 1200,
-    minHeight: 800,
+    minWidth: 700,
+    minHeight: 500,
     title: 'Emdash',
     ...(iconPath && { icon: iconPath }),
     webPreferences: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -629,7 +629,7 @@ const AppContent: React.FC = () => {
                   <ResizableHandle
                     withHandle
                     onDragging={(dragging) => handlePanelResizeDragging('left', dragging)}
-                    className="hidden cursor-col-resize items-center justify-center transition-colors hover:bg-border/80 lg:flex"
+                    className="hidden cursor-col-resize items-center justify-center transition-colors hover:bg-border/80 sm:flex"
                   />
                   <ResizablePanel
                     className="sidebar-panel sidebar-panel--main"
@@ -673,7 +673,7 @@ const AppContent: React.FC = () => {
                   <ResizableHandle
                     withHandle
                     onDragging={(dragging) => handlePanelResizeDragging('right', dragging)}
-                    className="hidden cursor-col-resize items-center justify-center transition-colors hover:bg-border/80 lg:flex"
+                    className="hidden cursor-col-resize items-center justify-center transition-colors hover:bg-border/80 sm:flex"
                   />
                   <ResizablePanel
                     ref={rightSidebarPanelRef}


### PR DESCRIPTION
## Summary
- Lower minimum window dimensions from 1200x800 to 700x500 so the app can be used on half-screen and smaller displays
- Change resizable panel handles from `lg:flex` to `sm:flex` so they appear at smaller viewport widths

## Test plan
- [ ] Launch the app and resize the window below 1200x800 — it should allow shrinking down to 700x500
- [ ] At narrow widths (between `sm` and `lg` breakpoints), verify the left and right sidebar resize handles are visible and functional