### PR TITLE
fix(ui): allow unpinning tasks by clicking the pin icon

### DIFF
--- a/src/renderer/components/TaskItem.tsx
+++ b/src/renderer/components/TaskItem.tsx
@@ -231,7 +231,15 @@ export const TaskItem: React.FC<TaskItemProps> = ({
           />
         ) : (
           <>
-            {isPinned && <Pin className="h-3 w-3 flex-shrink-0 text-muted-foreground" />}
+            {isPinned && (
+              <Pin
+                className="h-3 w-3 flex-shrink-0 cursor-pointer text-muted-foreground hover:text-foreground"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onPin?.();
+                }}
+              />
+            )}
             <span className="block truncate text-sm font-medium text-foreground">{task.name}</span>
           </>
         )}


### PR DESCRIPTION
## Summary
- Makes the pin icon on pinned tasks clickable to unpin them, instead of requiring a right-click context menu
- Adds hover effect and pointer cursor for discoverability

## Test plan
- [ ] Pin a task via the right-click context menu
- [ ] Click the pin icon on the pinned task — it should unpin
- [ ] Verify clicking the pin icon does not also select/navigate to the task

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that alters click handling for the pinned icon; main risk is unintended event propagation or duplicate pin toggles.
> 
> **Overview**
> Pinned tasks now render the `Pin` icon as an interactive control: it shows a pointer/hover style and clicking it calls `onPin` while stopping event propagation so it doesn’t also select/navigate the task.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 69522ec0b133fd1d42ca463f57d3af2b155f6842. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->