### PR TITLE
fix: scoped PR loading state to task path to prevent spinner leak

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -171,7 +171,9 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
       return 'create';
     }
   });
-  const { isCreating: isCreatingPR, createPR } = useCreatePR();
+  // NEW CODE: Rename the hook result and call it with the current path
+  const { isCreating: getIsCreatingPR, createPR } = useCreatePR();
+  const isCreatingPR = getIsCreatingPR(safeTaskPath);
 
   const selectPrMode = (mode: PrMode) => {
     setPrMode(mode);
@@ -616,7 +618,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
                   mode={prMode}
                   onModeChange={selectPrMode}
                   onExecute={handlePrAction}
-                  isLoading={isActionLoading}
+                  isLoading={isActionLoading || isCreatingPR}
                 />
               </div>
             </div>


### PR DESCRIPTION
Problem:
The PR creation loading spinner was using a global boolean state within the useCreatePR hook. This caused the spinner to "leak" across different tasks; if a user started creating a PR for one task and then switched to another, the new task would erroneously show a loading spinner.

Solution:

- Modified useCreatePR.tsx to use a keyed state object (Record<string, boolean>) that tracks the loading status for each specific taskPath independently.
 
- Updated the hook to return a function, isCreating(path), which allows components to query the loading status of a specific task.
 
- Updated FileChangesPanel.tsx to consume this new keyed state, ensuring that the "Create PR" button only shows a spinner if that specific task is currently in the process of creating a PR.

Verification:

- Verified that the TypeScript compilation errors in FileChangesPanel.tsx were resolved by correctly calling the new isCreating function with the safeTaskPath.
 
- Verified via code logic that switching tasks now correctly resets the UI spinner because the loading state is now unique to each task's file path.