### PR TITLE
fix(ssh): support IdentityAgent from ~/.ssh/config for agent auth

### DIFF
--- a/src/main/utils/shellEnv.ts
+++ b/src/main/utils/shellEnv.ts
@@ -49,6 +49,11 @@ export function getShellEnvVar(varName: string): string | undefined {
 const COMMON_SSH_AGENT_LOCATIONS: ReadonlyArray<{ path: string; description: string }> = [
   // macOS launchd
   { path: '/private/tmp/com.apple.launchd.*/Listeners', description: 'macOS launchd' },
+  // 1Password SSH agent (macOS)
+  {
+    path: path.join(os.homedir(), 'Library/Group Containers/2BUA8C4S2C.com.1password/t/agent.sock'),
+    description: '1Password SSH agent',
+  },
   // Generic temp directory patterns
   { path: path.join(os.tmpdir(), 'ssh-??????????', 'agent.*'), description: 'OpenSSH temp' },
   // User's .ssh directory

--- a/src/main/utils/sshConfigParser.ts
+++ b/src/main/utils/sshConfigParser.ts
@@ -1,0 +1,133 @@
+import { readFile } from 'fs/promises';
+import { homedir } from 'os';
+import { join } from 'path';
+import type { SshConfigHost } from '../../shared/ssh/types';
+
+/**
+ * Strips surrounding quotes (single or double) from a value string.
+ */
+function stripQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
+ * Expands a leading `~` or `~/` to the user's home directory.
+ */
+function expandTilde(filePath: string): string {
+  if (filePath === '~') {
+    return homedir();
+  }
+  if (filePath.startsWith('~/')) {
+    return join(homedir(), filePath.slice(2));
+  }
+  return filePath;
+}
+
+/**
+ * Parses ~/.ssh/config and returns an array of host entries.
+ * Skips wildcard host patterns (containing * or ?).
+ */
+export async function parseSshConfigFile(): Promise<SshConfigHost[]> {
+  const configPath = join(homedir(), '.ssh', 'config');
+  const content = await readFile(configPath, 'utf-8').catch(() => '');
+
+  const hosts: SshConfigHost[] = [];
+  const lines = content.split('\n');
+  let currentHost: SshConfigHost | null = null;
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip empty lines and comments
+    if (!trimmed || trimmed.startsWith('#')) continue;
+
+    // Match Host directive
+    const hostMatch = trimmed.match(/^Host\s+(.+)$/i);
+    if (hostMatch) {
+      // Save previous host if exists
+      if (currentHost && currentHost.host) {
+        hosts.push(currentHost);
+      }
+      // Start new host entry
+      const hostPattern = hostMatch[1].trim();
+      // Skip wildcard patterns
+      if (!hostPattern.includes('*') && !hostPattern.includes('?')) {
+        currentHost = { host: hostPattern };
+      } else {
+        currentHost = null;
+      }
+      continue;
+    }
+
+    // Match HostName
+    const hostnameMatch = trimmed.match(/^HostName\s+(.+)$/i);
+    if (hostnameMatch && currentHost) {
+      currentHost.hostname = hostnameMatch[1].trim();
+      continue;
+    }
+
+    // Match User
+    const userMatch = trimmed.match(/^User\s+(.+)$/i);
+    if (userMatch && currentHost) {
+      currentHost.user = userMatch[1].trim();
+      continue;
+    }
+
+    // Match Port
+    const portMatch = trimmed.match(/^Port\s+(\d+)$/i);
+    if (portMatch && currentHost) {
+      currentHost.port = parseInt(portMatch[1], 10);
+      continue;
+    }
+
+    // Match IdentityFile
+    const identityMatch = trimmed.match(/^IdentityFile\s+(.+)$/i);
+    if (identityMatch && currentHost) {
+      const identityFile = expandTilde(stripQuotes(identityMatch[1].trim()));
+      currentHost.identityFile = identityFile;
+      continue;
+    }
+
+    // Match IdentityAgent
+    const identityAgentMatch = trimmed.match(/^IdentityAgent\s+(.+)$/i);
+    if (identityAgentMatch && currentHost) {
+      const identityAgent = expandTilde(stripQuotes(identityAgentMatch[1].trim()));
+      currentHost.identityAgent = identityAgent;
+      continue;
+    }
+  }
+
+  // Don't forget the last host
+  if (currentHost && currentHost.host) {
+    hosts.push(currentHost);
+  }
+
+  return hosts;
+}
+
+/**
+ * Resolves the IdentityAgent socket path for a given hostname.
+ *
+ * Parses ~/.ssh/config and finds a matching host entry by checking
+ * both the Host alias and the HostName value. Returns the expanded
+ * IdentityAgent path if found, or undefined.
+ */
+export async function resolveIdentityAgent(hostname: string): Promise<string | undefined> {
+  try {
+    const hosts = await parseSshConfigFile();
+    const match = hosts.find(
+      (h) =>
+        h.host.toLowerCase() === hostname.toLowerCase() ||
+        h.hostname?.toLowerCase() === hostname.toLowerCase()
+    );
+    return match?.identityAgent;
+  } catch {
+    return undefined;
+  }
+}

--- a/src/renderer/components/ssh/AddRemoteProjectModal.tsx
+++ b/src/renderer/components/ssh/AddRemoteProjectModal.tsx
@@ -241,15 +241,20 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
       const stableId = `ssh-config:${encodeURIComponent(host.host)}`;
       setConnectionId(stableId);
 
-      // Determine auth type and key path - default to key auth (more reliable)
-      const authType: AuthType = 'key';
+      // Determine auth type and key path
+      let authType: AuthType;
       let privateKeyPath = '';
 
-      if (host.identityFile) {
+      if (host.identityAgent) {
+        // IdentityAgent signals the user wants agent-based auth (e.g. 1Password)
+        authType = 'agent';
+      } else if (host.identityFile) {
         // SSH config specifies a key - use it
+        authType = 'key';
         privateKeyPath = host.identityFile;
       } else {
-        // No key specified - use default ed25519 key (most common modern key)
+        // No key specified - default to key auth with ed25519 (most common modern key)
+        authType = 'key';
         privateKeyPath = '~/.ssh/id_ed25519';
       }
 

--- a/src/renderer/components/ssh/SshConnectionForm.tsx
+++ b/src/renderer/components/ssh/SshConnectionForm.tsx
@@ -72,6 +72,7 @@ export const SshConnectionForm: React.FC<Props> = ({
             user?: string;
             port?: number;
             identityFile?: string;
+            identityAgent?: string;
           }>;
           error?: string;
         };
@@ -120,7 +121,10 @@ export const SshConnectionForm: React.FC<Props> = ({
       let authType: 'password' | 'key' | 'agent' = 'agent';
       let privateKeyPath = '';
 
-      if (host.identityFile) {
+      if (host.identityAgent) {
+        // IdentityAgent signals the user wants agent-based auth (e.g. 1Password)
+        authType = 'agent';
+      } else if (host.identityFile) {
         authType = 'key';
         privateKeyPath = host.identityFile;
       }

--- a/src/shared/ssh/types.ts
+++ b/src/shared/ssh/types.ts
@@ -115,4 +115,5 @@ export interface SshConfigHost {
   user?: string;
   port?: number;
   identityFile?: string;
+  identityAgent?: string;
 }


### PR DESCRIPTION
## Summary

- Parse `IdentityAgent` directive from `~/.ssh/config` and use it as the SSH agent socket when connecting, enabling support for tools like 1Password SSH agent
- Extract SSH config parsing into a dedicated `sshConfigParser.ts` utility module with a new `resolveIdentityAgent()` helper
- Auto-select agent auth type when `IdentityAgent` is present in a host's SSH config entry
- Add 1Password agent socket to the common SSH agent fallback locations

## Changes

- **`src/main/utils/sshConfigParser.ts`** (new): Extracted and enhanced SSH config parser from `sshIpc.ts`; adds `IdentityAgent` parsing and `resolveIdentityAgent()` lookup
- **`src/main/ipc/sshIpc.ts`**: Removed inline SSH config parser, imports from new module; resolves `IdentityAgent` before falling back to `SSH_AUTH_SOCK` during connection test
- **`src/main/services/ssh/SshService.ts`**: Resolves `IdentityAgent` for the target host before falling back to `SSH_AUTH_SOCK`; improved error message mentioning `IdentityAgent` workaround
- **`src/main/utils/shellEnv.ts`**: Added 1Password agent socket path to common SSH agent locations
- **`src/renderer/components/ssh/AddRemoteProjectModal.tsx`** & **`SshConnectionForm.tsx`**: When an SSH config host has `IdentityAgent`, auto-select agent auth type instead of key auth
- **`src/shared/ssh/types.ts`**: Added `identityAgent` field to `SshConfigHost` interface

<!-- emdash-issue-footer:start -->
Fixes GEN-409
<!-- emdash-issue-footer:end -->