### PR TITLE
fix: make Promise callback async to fix build error

### DIFF
--- a/src/main/ipc/sshIpc.ts
+++ b/src/main/ipc/sshIpc.ts
@@ -164,7 +164,7 @@ export function registerSshIpc() {
         const { Client } = await import('ssh2');
         const testClient = new Client();
 
-        return new Promise((resolve) => {
+        return new Promise(async (resolve) => {
           const startTime = Date.now();
 
           testClient.on('ready', () => {


### PR DESCRIPTION
## Summary
- The `resolveIdentityAgent()` call in `sshIpc.ts` uses `await` inside a non-async Promise callback, causing TypeScript error TS1308 and breaking the build on `main`.
- Marks the Promise callback as `async` to fix the compilation error.

## Test plan
- [x] `pnpm run build` passes successfully
- [ ] SSH agent-auth connection test still works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)