### PR TITLE
fix: truncate file paths from the start in diff viewer components

### DIFF
--- a/src/renderer/components/AllChangesDiffModal.tsx
+++ b/src/renderer/components/AllChangesDiffModal.tsx
@@ -832,7 +832,10 @@ export const AllChangesDiffModal: React.FC<AllChangesDiffModalProps> = ({
                                   <ChevronRight className="h-3.5 w-3.5 text-muted-foreground transition-colors group-hover:text-muted-foreground dark:text-muted-foreground dark:group-hover:text-muted-foreground" />
                                 )}
                               </div>
-                              <span className="truncate font-mono text-sm font-medium text-foreground">
+                              <span
+                                className="truncate text-left font-mono text-sm font-medium text-foreground [direction:rtl]"
+                                title={file.path}
+                              >
                                 {file.path}
                               </span>
                               {isDirty && (

--- a/src/renderer/components/ChangesDiffModal.tsx
+++ b/src/renderer/components/ChangesDiffModal.tsx
@@ -677,7 +677,9 @@ export const ChangesDiffModal: React.FC<ChangesDiffModalProps> = ({
                   onClick={() => setSelected(f.path)}
                 >
                   <div className="flex min-w-0 items-center gap-1">
-                    <div className="truncate font-medium">{f.path}</div>
+                    <div className="truncate text-left font-medium [direction:rtl]" title={f.path}>
+                      {f.path}
+                    </div>
                     {selected === f.path && isDirty && (
                       <div className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
                     )}
@@ -700,7 +702,12 @@ export const ChangesDiffModal: React.FC<ChangesDiffModalProps> = ({
               <div className="flex items-center justify-between border-b border-border bg-white/80 px-4 py-2.5 dark:border-border dark:bg-muted/50">
                 <div className="flex min-w-0 flex-1 items-center gap-2">
                   <div className="flex min-w-0 items-center gap-1">
-                    <span className="truncate font-mono text-sm text-foreground">{selected}</span>
+                    <span
+                      className="truncate text-left font-mono text-sm text-foreground [direction:rtl]"
+                      title={selected ?? undefined}
+                    >
+                      {selected}
+                    </span>
                     {isDirty && (
                       <div className="h-1.5 w-1.5 flex-shrink-0 rounded-full bg-blue-500" />
                     )}

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -549,9 +549,11 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
     const dir = last >= 0 ? p.slice(0, last + 1) : '';
     const base = last >= 0 ? p.slice(last + 1) : p;
     return (
-      <span className="truncate">
-        {dir && <span className="text-muted-foreground">{dir}</span>}
-        <span className="font-medium text-foreground">{base}</span>
+      <span className="flex min-w-0" title={p}>
+        {dir && (
+          <span className="truncate text-left text-muted-foreground [direction:rtl]">{dir}</span>
+        )}
+        <span className="shrink-0 font-medium text-foreground">{base}</span>
       </span>
     );
   };
@@ -789,7 +791,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
                     <FileIcon filename={change.path} isDirectory={false} size={16} />
                   </span>
                   <div className="min-w-0 flex-1">
-                    <div className="truncate text-sm">{renderPath(change.path)}</div>
+                    <div className="min-w-0 text-sm">{renderPath(change.path)}</div>
                   </div>
                 </div>
                 <div className="ml-3 flex items-center gap-2">


### PR DESCRIPTION
## Summary

- Use RTL direction trick (`[direction:rtl]` + `text-left`) to truncate long file paths from the beginning rather than the end, so the filename is always visible
- Add `title` attributes to file path elements for full-path tooltips on hover
- Fix `FileChangesPanel` `renderPath` to use flexbox with `shrink-0` on the filename so the directory portion truncates while the base filename stays visible

## Affected Components

- `AllChangesDiffModal.tsx` — file path in stacked diff header
- `ChangesDiffModal.tsx` — sidebar file list and top header bar
- `FileChangesPanel.tsx` — file list items and path rendering

## Test plan

- Open the Changes panel with files that have deeply nested paths
- Verify paths truncate from the left (start), keeping the filename visible
- Hover over truncated paths and confirm the full path tooltip appears
- Open both the single-file diff modal and stacked (all changes) modal to verify consistent behavior

<!-- emdash-issue-footer:start -->
Fixes GEN-445
<!-- emdash-issue-footer:end -->