### PR TITLE
fix: improve active file highlighting in diff modal sidebar

### DIFF
--- a/src/renderer/components/ChangesDiffModal.tsx
+++ b/src/renderer/components/ChangesDiffModal.tsx
@@ -669,10 +669,10 @@ export const ChangesDiffModal: React.FC<ChangesDiffModalProps> = ({
               {files.map((f) => (
                 <button
                   key={f.path}
-                  className={`w-full border-b border-border px-3 py-2 text-left text-sm hover:bg-muted dark:border-border dark:hover:bg-accent ${
+                  className={`w-full border-b border-border px-3 py-2 text-left text-sm dark:border-border ${
                     selected === f.path
-                      ? 'bg-muted text-foreground dark:bg-muted dark:text-foreground'
-                      : 'text-foreground'
+                      ? 'bg-accent text-accent-foreground'
+                      : 'text-foreground hover:bg-accent/50'
                   }`}
                   onClick={() => setSelected(f.path)}
                 >


### PR DESCRIPTION
## Summary

- Use `bg-accent` / `text-accent-foreground` for the selected file in the changes diff modal sidebar, replacing the previous `bg-muted` styling that was hard to distinguish from the hover state
- Add `hover:bg-accent/50` to unselected files for a subtler hover effect
- Remove redundant dark mode hover classes from the base button styles

<!-- emdash-issue-footer:start -->
Fixes GEN-444
<!-- emdash-issue-footer:end -->