### PR TITLE
fix(ui): improve installing update status message clarity

### DIFF
--- a/src/renderer/components/UpdateCard.tsx
+++ b/src/renderer/components/UpdateCard.tsx
@@ -159,7 +159,8 @@ export function UpdateCard(): JSX.Element {
         return (
           <p className="flex items-center gap-1 text-sm text-muted-foreground">
             <Loader2 className="h-3 w-3 animate-spin" />
-            Installing update. Emdash will close when ready.
+            Installing update. Emdash will close and restart automatically — this may take a few
+            seconds.
           </p>
         );
 


### PR DESCRIPTION
## Summary

- Updates the auto-update "installing" status message in `UpdateCard` to better describe what happens during installation
- Old: "Emdash will close when ready."
- New: "Emdash will close and restart automatically — this may take a few seconds."

This gives users clearer expectations that the app will both close **and** restart, and that there may be a brief delay.