### PR TITLE
fix(ui): make (Having trouble?) link clickable

### DIFF
--- a/src/renderer/components/GithubDeviceFlowModal.tsx
+++ b/src/renderer/components/GithubDeviceFlowModal.tsx
@@ -374,7 +374,20 @@ export function GithubDeviceFlowModal({
                 )}
 
                 <div className="w-full border-t pt-4">
-                  <p className="text-center text-xs text-muted-foreground">Having trouble?</p>
+                  <p className="text-center text-xs text-muted-foreground">
+                    Having{' '}
+                    <button
+                      onClick={() =>
+                        window.electronAPI.openExternal(
+                          'https://github.com/generalaction/emdash/issues'
+                        )
+                      }
+                      className="text-primary hover:underline focus:underline focus:outline-none"
+                    >
+                      trouble
+                    </button>
+                    ?
+                  </p>
                 </div>
 
                 <div className="space-x-3 text-center text-xs text-muted-foreground">


### PR DESCRIPTION
Makes the “Having trouble?” text in the GitHub device flow modal clickable, linking directly to the project's issues page.