### PR TITLE
feat(ssh): surface debug logs from SSH connection tests

### DIFF
--- a/src/renderer/components/ssh/AddRemoteProjectModal.tsx
+++ b/src/renderer/components/ssh/AddRemoteProjectModal.tsx
@@ -9,6 +9,7 @@ import { Alert, AlertDescription } from '../ui/alert';
 import { Badge } from '../ui/badge';
 import { RadioGroup, RadioGroupItem } from '../ui/radio-group';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
 import { cn } from '@/lib/utils';
 import type { SshConfig, ConnectionTestResult, FileEntry, SshConfigHost } from '@shared/ssh/types';
 import {
@@ -28,12 +29,14 @@ import {
   XCircle,
   Folder,
   ChevronUp,
+  ChevronDown,
   Loader2,
   Shield,
   Trash,
   Plus,
   GitBranch,
   Download,
+  Copy,
 } from 'lucide-react';
 
 type WizardStep = 'connection' | 'auth' | 'path' | 'confirm';
@@ -91,6 +94,9 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [testStatus, setTestStatus] = useState<TestStatus>('idle');
   const [testResult, setTestResult] = useState<ConnectionTestResult | null>(null);
+  const [debugLogs, setDebugLogs] = useState<string[]>([]);
+  const [debugLogsOpen, setDebugLogsOpen] = useState(false);
+  const [debugLogsCopied, setDebugLogsCopied] = useState(false);
   const [errors, setErrors] = useState<FormErrors>({});
   const [touched, setTouched] = useState<Record<string, boolean>>({});
 
@@ -163,6 +169,9 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
       setTouched({});
       setTestStatus('idle');
       setTestResult(null);
+      setDebugLogs([]);
+      setDebugLogsOpen(false);
+      setDebugLogsCopied(false);
       setFileEntries([]);
       setBrowseError(null);
       setConnectionId(null);
@@ -398,6 +407,7 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
 
       const result = await window.electronAPI.sshTestConnection(testConfig);
       setTestResult(result);
+      setDebugLogs(result.debugLogs || []);
 
       import('../../lib/telemetryClient').then(({ captureTelemetry }) => {
         captureTelemetry('remote_project_connection_tested', { success: result.success });
@@ -1197,6 +1207,43 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
                   {testStatus === 'error' && (testResult?.error || 'Connection failed')}
                 </span>
               </Badge>
+            )}
+
+            {debugLogs.length > 0 && (
+              <Collapsible open={debugLogsOpen} onOpenChange={setDebugLogsOpen}>
+                <CollapsibleTrigger className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground [&[data-state=open]>svg:first-child]:rotate-180">
+                  <ChevronDown className="h-3 w-3 transition-transform duration-200" />
+                  Show connection debug log ({debugLogs.length})
+                </CollapsibleTrigger>
+                <CollapsibleContent>
+                  <div className="mt-1 flex items-center justify-end">
+                    <button
+                      type="button"
+                      onClick={async () => {
+                        try {
+                          await navigator.clipboard.writeText(debugLogs.join('\n'));
+                          setDebugLogsCopied(true);
+                          setTimeout(() => setDebugLogsCopied(false), 2000);
+                        } catch {
+                          // Clipboard access may be denied
+                        }
+                      }}
+                      className="flex items-center gap-1 text-[10px] text-muted-foreground hover:text-foreground"
+                      aria-label="Copy debug log"
+                    >
+                      {debugLogsCopied ? (
+                        <Check className="h-3 w-3" />
+                      ) : (
+                        <Copy className="h-3 w-3" />
+                      )}
+                      {debugLogsCopied ? 'Copied' : 'Copy'}
+                    </button>
+                  </div>
+                  <pre className="max-h-[200px] overflow-y-auto overflow-x-hidden whitespace-pre-wrap break-words rounded border bg-muted/50 p-2 font-mono text-[10px] leading-relaxed text-muted-foreground">
+                    {debugLogs.join('\n')}
+                  </pre>
+                </CollapsibleContent>
+              </Collapsible>
             )}
           </div>
         );

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1170,7 +1170,7 @@ declare global {
         useAgent?: boolean;
         password?: string;
         passphrase?: string;
-      }) => Promise<{ success: boolean; error?: string; latency?: number }>;
+      }) => Promise<{ success: boolean; error?: string; latency?: number; debugLogs?: string[] }>;
       sshSaveConnection: (config: {
         id?: string;
         name: string;

--- a/src/shared/ssh/types.ts
+++ b/src/shared/ssh/types.ts
@@ -62,6 +62,7 @@ export interface ConnectionTestResult {
   error?: string;
   latency?: number;
   serverVersion?: string;
+  debugLogs?: string[];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Capture ssh2 debug output during connection tests by passing a `debug` callback to the ssh2 client
- Return `debugLogs` array in `ConnectionTestResult` from the IPC handler
- Add collapsible debug log viewer with copy-to-clipboard to both `SshConnectionTestButton` and `AddRemoteProjectModal` auth step
- Keep test result after success timeout so debug logs remain accessible

## Test plan
- [ ] Open Add Remote Project modal, configure an SSH connection, and test it — verify debug log collapsible appears after test completes
- [ ] Click "Show debug log" to expand and verify ssh2 protocol messages are displayed
- [ ] Click "Copy" and verify logs are copied to clipboard
- [ ] Test with a failing connection and verify debug logs are shown alongside the error
- [ ] Verify `SshConnectionTestButton` (used standalone) also shows debug logs
- [ ] Run `pnpm run type-check` and `pnpm run lint` to confirm no regressions

<!-- emdash-issue-footer:start -->
Fixes GEN-443
<!-- emdash-issue-footer:end -->

fixes https://github.com/generalaction/emdash/issues/1159