### PR TITLE
fix: correct Linux .deb download link filename

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Connect to remote machines via SSH/SFTP to work with remote codebases. Emdash su
 
 ### Linux
 - AppImage (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.AppImage
-- Debian package (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.deb
+- Debian package (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-amd64.deb
 
 ### Release Overview
 

--- a/docs/content/docs/installation.mdx
+++ b/docs/content/docs/installation.mdx
@@ -30,7 +30,7 @@ Download the installer or portable version:
 Choose your preferred format:
 
 - [AppImage (x64)](https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.AppImage)
-- [Debian package (x64)](https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.deb)
+- [Debian package (x64)](https://github.com/generalaction/emdash/releases/latest/download/emdash-amd64.deb)
 
 Or run via Nix:
 


### PR DESCRIPTION
## Summary

- Fix the Debian package download URL in both `README.md` and `docs/content/docs/installation.mdx`
- Change filename from `emdash-x64.deb` to `emdash-amd64.deb` to match the actual release asset name

<!-- emdash-issue-footer:start -->
Fixes GEN-447
<!-- emdash-issue-footer:end -->