### PR TITLE
fix(menu): remove reload and force reload from View menu

### DIFF
--- a/src/main/app/menu.ts
+++ b/src/main/app/menu.ts
@@ -95,8 +95,6 @@ export function setupApplicationMenu(): void {
     {
       label: 'View',
       submenu: [
-        { role: 'reload' as const },
-        { role: 'forceReload' as const },
         { role: 'toggleDevTools' as const },
         { type: 'separator' as const },
         { role: 'resetZoom' as const },


### PR DESCRIPTION
## Summary

- Remove `reload` and `forceReload` menu items from the View menu to prevent accidental renderer reloads that can disrupt active agent sessions and PTY connections.