### PR TITLE
fix: show Create PR button for variant tasks with no file changes

### DIFF
--- a/src/renderer/components/RightSidebar.tsx
+++ b/src/renderer/components/RightSidebar.tsx
@@ -1,7 +1,6 @@
 import React, { useState } from 'react';
 import { cn } from '@/lib/utils';
 import FileChangesPanel from './FileChangesPanel';
-import { useFileChanges } from '@/hooks/useFileChanges';
 import TaskTerminalPanel from './TaskTerminalPanel';
 import { useRightSidebar } from './ui/right-sidebar';
 import { agentAssets } from '@/providers/assets';
@@ -374,9 +373,7 @@ const VariantChangesIfAny: React.FC<{ path: string; taskId: string; className?: 
   taskId,
   className,
 }) => {
-  const { fileChanges } = useFileChanges(path);
   const { projectPath } = useTaskScope();
-  if (!fileChanges || fileChanges.length === 0) return null;
   return (
     <TaskScopeProvider value={{ taskId, taskPath: path, projectPath }}>
       <FileChangesPanel className={className || 'min-h-0'} />


### PR DESCRIPTION
## Summary
- The `VariantChangesIfAny` component in `RightSidebar` was returning `null` when there were no file changes, which hid the Create PR button even when commits were ahead of `main`
- `FileChangesPanel` already handles the "no changes" state internally (showing Create PR when `branchAhead > 0`), so the early return was unnecessary

Closes #1073

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI change that only removes an early-return guard in the sidebar; behavior now relies on `FileChangesPanel`’s existing empty-state logic.
> 
> **Overview**
> Fixes variant task sidebars incorrectly hiding PR actions when there are *no file changes*.
> 
> `VariantChangesIfAny` in `RightSidebar` no longer calls `useFileChanges` or returns `null` for empty change sets, ensuring `FileChangesPanel` always renders and can show the **Create PR** button when the branch is ahead.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e33b0f810db1041af99a81c7e6dd27b4f6302eb8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->