### PR TITLE
feat: configurable task hover action (delete vs archive)

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -47,6 +47,7 @@ export interface KeyboardSettings {
 export interface InterfaceSettings {
   autoRightSidebarBehavior?: boolean;
   theme?: 'light' | 'dark' | 'dark-black' | 'system';
+  taskHoverAction?: 'delete' | 'archive';
 }
 
 /**
@@ -172,6 +173,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   interface: {
     autoRightSidebarBehavior: false,
     theme: 'system',
+    taskHoverAction: 'delete',
   },
   providerConfigs: {},
   terminal: {
@@ -324,7 +326,7 @@ export function persistSettings(settings: AppSettings) {
 /**
  * Coerce and validate settings for robustness and forward-compatibility.
  */
-function normalizeSettings(input: AppSettings): AppSettings {
+export function normalizeSettings(input: AppSettings): AppSettings {
   const out: AppSettings = {
     repository: {
       branchPrefix: DEFAULT_SETTINGS.repository.branchPrefix,
@@ -486,6 +488,7 @@ function normalizeSettings(input: AppSettings): AppSettings {
     theme: ['light', 'dark', 'dark-black', 'system'].includes(iface?.theme)
       ? iface.theme
       : DEFAULT_SETTINGS.interface!.theme,
+    taskHoverAction: iface?.taskHoverAction === 'archive' ? 'archive' : 'delete',
   };
 
   // Provider custom configs

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -23,6 +23,7 @@ import ThemeCard from './ThemeCard';
 import KeyboardSettingsCard from './KeyboardSettingsCard';
 import RightSidebarSettingsCard from './RightSidebarSettingsCard';
 import BrowserPreviewSettingsCard from './BrowserPreviewSettingsCard';
+import TaskHoverActionCard from './TaskHoverActionCard';
 import TerminalSettingsCard from './TerminalSettingsCard';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
 import CliAgentsList from './CliAgentsList';
@@ -245,6 +246,7 @@ const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose }) => {
             <div className="flex flex-col gap-8 rounded-xl border border-muted p-4">
               <RightSidebarSettingsCard />
               <BrowserPreviewSettingsCard />
+              <TaskHoverActionCard />
             </div>
           ),
         },

--- a/src/renderer/components/TaskDeleteButton.tsx
+++ b/src/renderer/components/TaskDeleteButton.tsx
@@ -37,6 +37,12 @@ type Props = {
    * @default true
    */
   useWorktree?: boolean;
+  /** Controlled open state — when provided, overrides the internal state. */
+  externalOpen?: boolean;
+  /** Callback when controlled open state changes. */
+  onExternalOpenChange?: (open: boolean) => void;
+  /** When true, the trigger button is hidden and only the dialog is rendered. */
+  hideTrigger?: boolean;
 };
 
 export const TaskDeleteButton: React.FC<Props> = ({
@@ -48,8 +54,14 @@ export const TaskDeleteButton: React.FC<Props> = ({
   'aria-label': ariaLabel = 'Delete Task',
   isDeleting = false,
   useWorktree = true,
+  externalOpen,
+  onExternalOpenChange,
+  hideTrigger = false,
 }) => {
-  const [open, setOpen] = React.useState(false);
+  const [internalOpen, setInternalOpen] = React.useState(false);
+  const isControlled = externalOpen !== undefined;
+  const open = isControlled ? externalOpen : internalOpen;
+  const setOpen = isControlled ? (v: boolean) => onExternalOpenChange?.(v) : setInternalOpen;
   const [acknowledge, setAcknowledge] = React.useState(false);
   const targets = useMemo(
     () => [{ id: taskId, name: taskName, path: taskPath }],
@@ -90,33 +102,35 @@ export const TaskDeleteButton: React.FC<Props> = ({
 
   return (
     <AlertDialog open={open} onOpenChange={setOpen}>
-      <TooltipProvider delayDuration={200}>
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <AlertDialogTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                className={cn(className, isDeleting && 'opacity-100')}
-                title="Delete Task"
-                aria-label={ariaLabel}
-                aria-busy={isDeleting}
-                disabled={isDeleting}
-                onClick={(e) => e.stopPropagation()}
-              >
-                {isDeleting ? (
-                  <Spinner className="h-4 w-4" size="sm" />
-                ) : (
-                  <Trash className="h-4 w-4" />
-                )}
-              </Button>
-            </AlertDialogTrigger>
-          </TooltipTrigger>
-          <TooltipContent side="top" className="text-xs">
-            Delete Task
-          </TooltipContent>
-        </Tooltip>
-      </TooltipProvider>
+      {!hideTrigger && (
+        <TooltipProvider delayDuration={200}>
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-sm"
+                  className={cn(className, isDeleting && 'opacity-100')}
+                  title="Delete Task"
+                  aria-label={ariaLabel}
+                  aria-busy={isDeleting}
+                  disabled={isDeleting}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {isDeleting ? (
+                    <Spinner className="h-4 w-4" size="sm" />
+                  ) : (
+                    <Trash className="h-4 w-4" />
+                  )}
+                </Button>
+              </AlertDialogTrigger>
+            </TooltipTrigger>
+            <TooltipContent side="top" className="text-xs">
+              Delete Task
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      )}
       <AlertDialogContent onClick={(e) => e.stopPropagation()} className="space-y-4">
         <AlertDialogHeader>
           <AlertDialogTitle>Delete task?</AlertDialogTitle>

--- a/src/renderer/components/TaskHoverActionCard.tsx
+++ b/src/renderer/components/TaskHoverActionCard.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+
+const TaskHoverActionCard: React.FC = () => {
+  const [value, setValue] = useState<'delete' | 'archive'>('delete');
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const result = await window.electronAPI.getSettings();
+        if (result.success && result.settings) {
+          setValue(result.settings.interface?.taskHoverAction ?? 'delete');
+        }
+      } catch (error) {
+        console.error('Failed to load task hover action setting:', error);
+      }
+      setLoading(false);
+    })();
+  }, []);
+
+  const handleChange = async (next: 'delete' | 'archive') => {
+    setValue(next);
+    try {
+      await window.electronAPI.updateSettings({
+        interface: { taskHoverAction: next },
+      });
+      window.dispatchEvent(new CustomEvent('taskHoverActionChanged', { detail: { value: next } }));
+    } catch (error) {
+      console.error('Failed to update task hover action setting:', error);
+    }
+  };
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-1 flex-col gap-0.5">
+        <p className="text-sm font-medium text-foreground">Task hover action</p>
+        <p className="text-sm text-muted-foreground">
+          Primary action when hovering over tasks in the sidebar.
+        </p>
+      </div>
+      <Select value={value} onValueChange={handleChange} disabled={loading}>
+        <SelectTrigger className="w-auto shrink-0 gap-2 [&>span]:line-clamp-none">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="delete">Delete</SelectItem>
+          <SelectItem value="archive">Archive</SelectItem>
+        </SelectContent>
+      </Select>
+    </div>
+  );
+};
+
+export default TaskHoverActionCard;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -149,6 +149,7 @@ declare global {
           interface?: {
             autoRightSidebarBehavior?: boolean;
             theme?: 'light' | 'dark' | 'dark-black' | 'system';
+            taskHoverAction?: 'delete' | 'archive';
           };
           terminal?: {
             fontFamily: string;
@@ -237,6 +238,7 @@ declare global {
           interface?: {
             autoRightSidebarBehavior?: boolean;
             theme?: 'light' | 'dark' | 'dark-black' | 'system';
+            taskHoverAction?: 'delete' | 'archive';
           };
           terminal?: {
             fontFamily?: string;
@@ -324,6 +326,7 @@ declare global {
           interface?: {
             autoRightSidebarBehavior?: boolean;
             theme?: 'light' | 'dark' | 'dark-black' | 'system';
+            taskHoverAction?: 'delete' | 'archive';
           };
           terminal?: {
             fontFamily: string;

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/emdash-test',
+  },
+}));
+
+import { normalizeSettings } from '../../main/settings';
+import type { AppSettings } from '../../main/settings';
+
+/** Minimal valid AppSettings skeleton for normalizeSettings. */
+function makeSettings(overrides?: Partial<AppSettings>): AppSettings {
+  return {
+    repository: { branchPrefix: 'emdash', pushOnCreate: true },
+    projectPrep: { autoInstallOnOpenInEditor: true },
+    ...overrides,
+  } as AppSettings;
+}
+
+describe('normalizeSettings – taskHoverAction', () => {
+  it('preserves "archive"', () => {
+    const result = normalizeSettings(makeSettings({ interface: { taskHoverAction: 'archive' } }));
+    expect(result.interface?.taskHoverAction).toBe('archive');
+  });
+
+  it('preserves "delete"', () => {
+    const result = normalizeSettings(makeSettings({ interface: { taskHoverAction: 'delete' } }));
+    expect(result.interface?.taskHoverAction).toBe('delete');
+  });
+
+  it('coerces invalid value to "delete"', () => {
+    const result = normalizeSettings(
+      makeSettings({ interface: { taskHoverAction: 'invalid' as any } })
+    );
+    expect(result.interface?.taskHoverAction).toBe('delete');
+  });
+
+  it('defaults undefined to "delete"', () => {
+    const result = normalizeSettings(makeSettings({ interface: {} }));
+    expect(result.interface?.taskHoverAction).toBe('delete');
+  });
+
+  it('defaults missing interface to "delete"', () => {
+    const result = normalizeSettings(makeSettings());
+    expect(result.interface?.taskHoverAction).toBe('delete');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds a **Task hover action** setting in Settings > Interface > Workspace letting users choose whether the primary sidebar hover action is "Delete" or "Archive"
- The alternate action appears in the right-click context menu
- Default is "Delete" (preserves current behavior)
- Delete always goes through the confirmation dialog with risk scanning, whether triggered from hover or context menu

## Test plan
- [ ] Settings > Interface > Workspace shows "Task hover action" dropdown with Delete/Archive options
- [ ] Default "Delete": hover shows trash icon with confirmation dialog, right-click shows "Archive"
- [ ] Switch to "Archive": hover shows archive icon (instant), right-click "Delete" opens confirmation dialog
- [ ] Row spacing is identical in both modes
- [ ] Setting persists across app restarts
- [ ] `pnpm run type-check`, `pnpm run lint`, `pnpm exec vitest run` all pass

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes task delete/archive UX in the sidebar, including new controlled dialog behavior for deletions; mistakes here could lead to confusing or unintended destructive actions.
> 
> **Overview**
> Adds a new persisted `interface.taskHoverAction` setting (defaulting to `delete`), including settings normalization and updated Electron API typings.
> 
> Updates the left sidebar task row to use the configured primary hover action (Delete uses the confirmation/risk-scan dialog; Archive is immediate) and moves the alternate action into the right-click context menu. Introduces a new Settings UI card to toggle the behavior and refactors `TaskDeleteButton` to support controlled open state/hidden trigger so Delete can be launched from the context menu consistently; adds unit tests for `normalizeSettings` around the new field.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b70ccdf8938907b72743fd0dac4d6024eddf0ca3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->