### PR TITLE
feat(notifications): include task name in agent notifications

### DIFF
--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -398,6 +398,15 @@ export class DatabaseService {
     return this.mapDrizzleTaskRow(rows[0]);
   }
 
+  async getTaskById(taskId: string): Promise<Task | null> {
+    if (this.disabled) return null;
+    if (!taskId) return null;
+    const { db } = await getDrizzleClient();
+    const rows = await db.select().from(tasksTable).where(eq(tasksTable.id, taskId)).limit(1);
+    if (rows.length === 0) return null;
+    return this.mapDrizzleTaskRow(rows[0]);
+  }
+
   async deleteProject(projectId: string): Promise<void> {
     if (this.disabled) return;
     const { db } = await getDrizzleClient();


### PR DESCRIPTION
fix: #1191

### summary

- notifications for “needs attention” and “task complete” now show the task name so you can tell which task they refer to.

### Changes
 - databaseService: Added getTaskById().
- agentEventService: Looks up task name for main PTYs and uses it in notification title and body.

### Result

- Before: “Claude Code Needs Attention”
- After: “Claude Code — Fix auth bug” + “Your agent is waiting for input”
- Main-task PTYs only; chat PTYs unchanged. Falls back to provider name if task lookup fails.