### PR TITLE
fix: PR creation spinner persists when switching tasks

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -147,9 +147,10 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
   const [showAllChangesModal, setShowAllChangesModal] = useState(false);
   const [selectedPath, setSelectedPath] = useState<string | undefined>(undefined);
 
-  // Reset selectedPath when task changes
+  // Reset selectedPath and action loading states when task changes
   useEffect(() => {
     setSelectedPath(undefined);
+    setIsMergingToMain(false);
   }, [resolvedTaskPath]);
   const [stagingFiles, setStagingFiles] = useState<Set<string>>(new Set());
   const [unstagingFiles, setUnstagingFiles] = useState<Set<string>>(new Set());
@@ -173,7 +174,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
       return 'create';
     }
   });
-  const { isCreating: isCreatingPR, createPR } = useCreatePR();
+  const { isCreatingForTaskPath, createPR } = useCreatePR();
 
   const selectPrMode = (mode: PrMode) => {
     setPrMode(mode);
@@ -544,7 +545,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
     return null;
   }
 
-  const isActionLoading = isCreatingPR || isMergingToMain;
+  const isActionLoading = isCreatingForTaskPath(safeTaskPath) || isMergingToMain;
 
   return (
     <div className={`flex h-full flex-col bg-card shadow-sm ${className}`}>

--- a/src/renderer/hooks/useCreatePR.tsx
+++ b/src/renderer/hooks/useCreatePR.tsx
@@ -22,7 +22,9 @@ type CreatePROptions = {
 
 export function useCreatePR() {
   const { toast } = useToast();
-  const [isCreating, setIsCreating] = useState(false);
+  const [creatingTaskPath, setCreatingTaskPath] = useState<string | null>(null);
+
+  const isCreatingForTaskPath = (path: string) => creatingTaskPath === path;
 
   const createPR = async (opts: CreatePROptions) => {
     const {
@@ -34,7 +36,7 @@ export function useCreatePR() {
       onSuccess,
     } = opts;
 
-    setIsCreating(true);
+    setCreatingTaskPath(taskPath);
     try {
       // Guard: ensure Electron bridge methods exist (prevents hard crashes in plain web builds)
       const api: any = (window as any).electronAPI;
@@ -267,9 +269,9 @@ export function useCreatePR() {
       });
       return { success: false, error: message } as any;
     } finally {
-      setIsCreating(false);
+      setCreatingTaskPath(null);
     }
   };
 
-  return { isCreating, createPR };
+  return { isCreatingForTaskPath, createPR };
 }


### PR DESCRIPTION
### Problem

- switching tasks while the PR creation spinner is active causes the spinner to appear on the new task’s PR button.

### Solution

- loading state is now scoped to the task that triggered PR creation.

### Changes

- useCreatePR: Track loading by task path instead of a single boolean
- FileChangesPanel: Use isCreatingForTaskPath(safeTaskPath) and reset merge loading on task change

### Testing
- Click "Create PR" on a task
- Switch to another task while the spinner is active
- The new task should show its own PR state (no spinner)

fix : #1140