### PR TITLE
fix(nix): update pnpmDeps hash for nbranch

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -94,13 +94,13 @@
                     inherit pname version src;
                     inherit pnpm;
                     fetcherVersion = 1;
-                    hash = "sha256-JvJBHY0r1lNrLHrsAQjf0HMseZVaev93sOFfWoyN34s=";
+                    hash = "";
                   }
                 else
                   pnpm.fetchDeps {
                     inherit pname version src;
                     fetcherVersion = 1;
-                    hash = "sha256-JvJBHY0r1lNrLHrsAQjf0HMseZVaev93sOFfWoyN34s=";
+                    hash = "";
                   };
               nativeBuildInputs =
                 sharedEnv


### PR DESCRIPTION
## Summary
- The Nix build (`nix-build` CI job) fails because `nbranch@0.1.0` was added as a dependency but the `pnpmDeps.hash` in `flake.nix` was never updated to include it in the offline store.
- This PR resets the hash to `""` so the next CI run will compute and report the correct `sha256-...` value in the build logs.
- **Follow-up needed**: Once CI runs and logs the correct hash, update `flake.nix` with that hash in a second commit.

## How this happened
`nbranch` was added to `package.json`/`pnpm-lock.yaml` but `flake.nix`'s `pnpmDeps.hash` (a fixed-output derivation hash covering all offline pnpm tarballs) was not regenerated.

## Test plan
- [ ] Push with empty hash → CI fails with `hash mismatch` and prints the correct `got: sha256-...`
- [ ] Update `flake.nix` with the correct hash → CI `nix-build` job passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)