### PR TITLE
feat: add Cmd+W shortcut to close active chat tab on macOS

### DIFF
--- a/src/main/app/menu.ts
+++ b/src/main/app/menu.ts
@@ -65,7 +65,13 @@ export function setupApplicationMenu(): void {
               { type: 'separator' as const },
             ]
           : []),
-        isMac ? { role: 'close' as const } : { role: 'quit' as const },
+        isMac
+          ? {
+              label: 'Close Tab',
+              accelerator: 'CmdOrCtrl+W',
+              click: () => sendToRenderer('menu:close-tab'),
+            }
+          : { role: 'quit' as const },
       ],
     },
     // Edit menu

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -176,6 +176,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on(channel, wrapped);
     return () => ipcRenderer.removeListener(channel, wrapped);
   },
+  onMenuCloseTab: (listener: () => void) => {
+    const channel = 'menu:close-tab';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
 
   // Worktree management
   worktreeCreate: (args: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -205,6 +205,14 @@ const AppContent: React.FC = () => {
     };
   }, []);
 
+  // Listen for native menu "Close Tab" (Cmd+W) — dispatches to active ChatInterface
+  useEffect(() => {
+    const cleanup = window.electronAPI.onMenuCloseTab?.(() => {
+      window.dispatchEvent(new CustomEvent('emdash:close-active-chat'));
+    });
+    return () => cleanup?.();
+  }, []);
+
   // --- App initialization (version, platform, loadAppData) ---
   // The callbacks here execute inside a useEffect (after render), so all hooks
   // are already initialized by the time they run — no temporal dead zone issue.

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -708,6 +708,17 @@ const ChatInterface: React.FC<Props> = ({
     };
   }, [conversations, activeConversationId, handleSwitchChat]);
 
+  // Close active chat tab on Cmd+W
+  useEffect(() => {
+    const handleCloseActiveChat = () => {
+      if (activeConversationId) {
+        handleCloseChat(activeConversationId);
+      }
+    };
+    window.addEventListener('emdash:close-active-chat', handleCloseActiveChat);
+    return () => window.removeEventListener('emdash:close-active-chat', handleCloseActiveChat);
+  }, [activeConversationId, handleCloseChat]);
+
   const isTerminal = agentMeta[agent]?.terminalOnly === true;
   const autoApproveEnabled =
     Boolean(task.metadata?.autoApprove) && Boolean(agentMeta[agent]?.autoApproveFlag);

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -67,6 +67,7 @@ declare global {
       onMenuCheckForUpdates: (listener: () => void) => () => void;
       onMenuUndo: (listener: () => void) => () => void;
       onMenuRedo: (listener: () => void) => () => void;
+      onMenuCloseTab: (listener: () => void) => () => void;
 
       // App settings
       getSettings: () => Promise<{
@@ -1282,6 +1283,7 @@ export interface ElectronAPI {
   onMenuCheckForUpdates: (listener: () => void) => () => void;
   onMenuUndo: (listener: () => void) => () => void;
   onMenuRedo: (listener: () => void) => () => void;
+  onMenuCloseTab: (listener: () => void) => () => void;
 
   // App info
   getVersion: () => Promise<string>;


### PR DESCRIPTION
## Summary
- Overrides macOS `Cmd+W` to close the active chat conversation tab instead of closing the Electron window
- Adds `menu:close-tab` IPC channel from main menu through preload to renderer
- App.tsx dispatches a custom `emdash:close-active-chat` DOM event, which ChatInterface listens for and triggers the existing close-chat flow (with delete confirmation if multiple tabs exist)

## Changes
- `menu.ts`: Replace `role: 'close'` with custom "Close Tab" menu item bound to `CmdOrCtrl+W`
- `preload.ts`: Expose `onMenuCloseTab` bridge method
- `electron-api.d.ts`: Add `onMenuCloseTab` type declaration
- `App.tsx`: Listen for menu event, dispatch DOM custom event
- `ChatInterface.tsx`: Listen for `emdash:close-active-chat` and close the active conversation