### PR TITLE
Docs: Fix GitHub links in changelog rendering

### DIFF
--- a/docs/components/Changelog.tsx
+++ b/docs/components/Changelog.tsx
@@ -131,9 +131,9 @@ function ReleaseNotes({ content }: { content: string }) {
       text
         // Handle GitHub URLs, but not if they're followed by punctuation
         .replace(
-          /https:\/\/github\.com\/[^\s\)\]\.,;!?]+/g,
+          /https:\/\/github\.com\/[^\s\)\]]+/g,
           (url) =>
-            `<a href="${url}" target="_blank" rel="noopener noreferrer" class="underline">${url}</a>`
+            `<a href="${url.replace(/[.,;!?]+$/, '')}" target="_blank" rel="noopener noreferrer" class="underline">${url.replace(/[.,;!?]+$/, '')}</a>`
         )
         // Handle @mentions, but avoid matching email addresses
         // Look for @mentions that are preceded by whitespace or start of string
@@ -241,8 +241,9 @@ function ReleaseNotes({ content }: { content: string }) {
     if (line.includes('**')) {
       flushListItems(); // Flush any pending list items
       const formatted = line.replace(/\*\*(.*?)\*\*/g, '<strong>$1</strong>');
+      const withLinks = processLinks(formatted);
       elements.push(
-        <p key={i} className="mt-4 font-semibold" dangerouslySetInnerHTML={{ __html: formatted }} />
+        <p key={i} className="mt-4 font-semibold" dangerouslySetInnerHTML={{ __html: withLinks }} />
       );
       continue;
     }


### PR DESCRIPTION
Fixes GitHub link parsing in the changelog so all links render correctly.

- Full Changelog links are now clickable
- Compare links with ... are correctly detected
- Trailing punctuation no longer breaks URLs
- Links inside bold text are processed

before - 
<img width="886" height="266" alt="Screenshot 2026-03-02 at 7 47 20 AM" src="https://github.com/user-attachments/assets/3034f295-dc61-4ff8-9d1a-c9f78a753101" />

after - 
<img width="886" height="266" alt="Screenshot 2026-03-02 at 7 47 09 AM" src="https://github.com/user-attachments/assets/c1070aeb-d6f9-44d7-8906-b25698a4a636" />
