### PR TITLE
fix(remote-open): preserve SSH authority and harden terminal launches

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -1,5 +1,5 @@
 import { app, clipboard, ipcMain, shell } from 'electron';
-import { exec } from 'child_process';
+import { exec, execFile } from 'child_process';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { ensureProjectPrepared } from '../services/ProjectPrep';
@@ -13,7 +13,11 @@ import {
 } from '@shared/openInApps';
 import { databaseService } from '../services/DatabaseService';
 import { buildExternalToolEnv } from '../utils/childProcessEnv';
-import { quoteShellArg } from '../utils/shellEscape';
+import {
+  buildGhosttyRemoteExecArgs,
+  buildRemoteEditorUrl,
+  buildRemoteSshCommand,
+} from '../utils/remoteOpenIn';
 
 const UNKNOWN_VERSION = 'unknown';
 
@@ -41,6 +45,30 @@ const execCommand = (
     );
   });
 };
+
+const execFileCommand = (
+  file: string,
+  args: string[],
+  opts?: { timeout?: number }
+): Promise<void> => {
+  return new Promise((resolve, reject) => {
+    execFile(
+      file,
+      args,
+      {
+        timeout: opts?.timeout ?? 30000,
+        env: buildExternalToolEnv(),
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+};
+
+const escapeAppleScriptString = (value: string): string =>
+  value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 
 const dedupeAndSortFonts = (fonts: string[]): string[] => {
   const unique = Array.from(new Set(fonts.map((font) => font.trim()).filter(Boolean)));
@@ -280,70 +308,121 @@ export function registerAppIpc() {
 
             // Construct remote SSH URL or command based on the app
             // Security: Escape all user-controlled values to prevent command injection
-            const safeHost = encodeURIComponent(connection.host);
-            const safeTarget = encodeURIComponent(target);
-
             if (appId === 'vscode') {
-              // VS Code Remote SSH URL format: vscode://vscode-remote/ssh-remote+hostname/path
-              const remoteUrl = `vscode://vscode-remote/ssh-remote+${safeHost}${target}`;
+              // VS Code Remote SSH URL format:
+              // vscode://vscode-remote/ssh-remote+user%40hostname/path
+              const remoteUrl = buildRemoteEditorUrl(
+                'vscode',
+                connection.host,
+                connection.username,
+                target
+              );
               await shell.openExternal(remoteUrl);
               return { success: true };
             } else if (appId === 'cursor') {
               // Cursor uses its own URL scheme for remote SSH
-              const remoteUrl = `cursor://vscode-remote/ssh-remote+${safeHost}${target}`;
+              const remoteUrl = buildRemoteEditorUrl(
+                'cursor',
+                connection.host,
+                connection.username,
+                target
+              );
               await shell.openExternal(remoteUrl);
               return { success: true };
             } else if (appId === 'terminal' && platform === 'darwin') {
               // macOS Terminal.app - execute SSH command
-              // Security: Use quoteShellArg to prevent command injection
-              const sshCommand = `ssh ${quoteShellArg(connection.username)}@${quoteShellArg(connection.host)} -p ${quoteShellArg(String(connection.port))} -t "cd ${quoteShellArg(target)} && exec \\$SHELL"`;
-              // Properly escape for AppleScript
-              const escapedCommand = sshCommand.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-              const terminalCommand = `osascript -e 'tell application "Terminal" to do script "${escapedCommand}"' -e 'tell application "Terminal" to activate'`;
-
-              await new Promise<void>((resolve, reject) => {
-                exec(terminalCommand, { env: buildExternalToolEnv() }, (err) => {
-                  if (err) return reject(err);
-                  resolve();
-                });
+              const sshCommand = buildRemoteSshCommand({
+                host: connection.host,
+                username: connection.username,
+                port: connection.port,
+                targetPath: target,
               });
+              const escapedCommand = escapeAppleScriptString(sshCommand);
+
+              await execFileCommand('osascript', [
+                '-e',
+                `tell application "Terminal" to do script "${escapedCommand}"`,
+                '-e',
+                'tell application "Terminal" to activate',
+              ]);
               return { success: true };
             } else if (appId === 'iterm2' && platform === 'darwin') {
               // iTerm2 - execute SSH command
-              // Security: Use quoteShellArg to prevent command injection
-              const sshCommand = `ssh ${quoteShellArg(connection.username)}@${quoteShellArg(connection.host)} -p ${quoteShellArg(String(connection.port))} -t "cd ${quoteShellArg(target)} && exec \\$SHELL"`;
-              const escapedCommand = sshCommand.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
-              const terminalCommand = `osascript -e 'tell application "iTerm" to create window with default profile command "${escapedCommand}"'`;
-
-              await new Promise<void>((resolve, reject) => {
-                exec(terminalCommand, { env: buildExternalToolEnv() }, (err) => {
-                  if (err) return reject(err);
-                  resolve();
-                });
+              const sshCommand = buildRemoteSshCommand({
+                host: connection.host,
+                username: connection.username,
+                port: connection.port,
+                targetPath: target,
               });
+              const escapedCommand = escapeAppleScriptString(sshCommand);
+
+              await execFileCommand('osascript', [
+                '-e',
+                `tell application "iTerm" to create window with default profile command "${escapedCommand}"`,
+                '-e',
+                'tell application "iTerm" to activate',
+              ]);
               return { success: true };
             } else if (appId === 'warp' && platform === 'darwin') {
               // Warp - use URL scheme with SSH command
-              // Security: Use quoteShellArg to prevent command injection
-              const sshCommand = `ssh ${quoteShellArg(connection.username)}@${quoteShellArg(connection.host)} -p ${quoteShellArg(String(connection.port))} -t "cd ${quoteShellArg(target)} && exec \\$SHELL"`;
+              const sshCommand = buildRemoteSshCommand({
+                host: connection.host,
+                username: connection.username,
+                port: connection.port,
+                targetPath: target,
+              });
               await shell.openExternal(
                 `warp://action/new_window?cmd=${encodeURIComponent(sshCommand)}`
               );
               return { success: true };
             } else if (appId === 'ghostty') {
-              // Ghostty - execute SSH command directly
-              // Security: Use quoteShellArg to prevent command injection
-              const sshCommand = `ssh ${quoteShellArg(connection.username)}@${quoteShellArg(connection.host)} -p ${quoteShellArg(String(connection.port))} -t "cd ${quoteShellArg(target)} && exec \\$SHELL"`;
-              const quoted = (p: string) => `'${p.replace(/'/g, "'\\''")}'`;
-              const terminalCommand = `ghostty -e ${quoted(sshCommand)}`;
-
-              await new Promise<void>((resolve, reject) => {
-                exec(terminalCommand, { env: buildExternalToolEnv() }, (err) => {
-                  if (err) return reject(err);
-                  resolve();
-                });
+              // Ghostty - execute SSH command directly.
+              // Prefer remote login shell behavior for normal prompt/init scripts while
+              // keeping deterministic fallbacks when SHELL is missing or invalid.
+              // Compatibility note: many remote hosts don't ship xterm-ghostty terminfo.
+              // The argv builder falls back to TERM=xterm-256color only when current TERM
+              // isn't supported, keeping TUIs (e.g. ranger) working without always downgrading.
+              const ghosttyExecArgs = buildGhosttyRemoteExecArgs({
+                host: connection.host,
+                username: connection.username,
+                port: connection.port,
+                targetPath: target,
               });
-              return { success: true };
+
+              const attempts =
+                platform === 'darwin'
+                  ? [
+                      {
+                        file: 'open',
+                        args: [
+                          '-n',
+                          '-b',
+                          'com.mitchellh.ghostty',
+                          '--args',
+                          '-e',
+                          ...ghosttyExecArgs,
+                        ],
+                      },
+                      {
+                        file: 'open',
+                        args: ['-na', 'Ghostty', '--args', '-e', ...ghosttyExecArgs],
+                      },
+                      { file: 'ghostty', args: ['-e', ...ghosttyExecArgs] },
+                    ]
+                  : [{ file: 'ghostty', args: ['-e', ...ghosttyExecArgs] }];
+
+              let lastError: unknown = null;
+              for (const attempt of attempts) {
+                try {
+                  await execFileCommand(attempt.file, attempt.args);
+                  return { success: true };
+                } catch (error) {
+                  lastError = error;
+                }
+              }
+
+              if (lastError instanceof Error) throw lastError;
+              throw new Error('Unable to launch Ghostty');
             } else if (appConfig.supportsRemote) {
               // App claims to support remote but we don't have a handler
               return {

--- a/src/main/utils/__tests__/remoteOpenIn.test.ts
+++ b/src/main/utils/__tests__/remoteOpenIn.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGhosttyRemoteExecArgs,
+  buildRemoteEditorUrl,
+  buildRemoteSshCommand,
+  buildRemoteSshAuthority,
+  buildRemoteTerminalShellCommand,
+} from '../remoteOpenIn';
+
+describe('buildRemoteSshAuthority', () => {
+  it('prepends username when host has no user component', () => {
+    expect(buildRemoteSshAuthority('example.internal', 'azureuser')).toBe(
+      'azureuser@example.internal'
+    );
+  });
+
+  it('preserves host when username is already embedded', () => {
+    expect(buildRemoteSshAuthority('existing@example.internal', 'azureuser')).toBe(
+      'existing@example.internal'
+    );
+  });
+});
+
+describe('buildRemoteEditorUrl', () => {
+  it('builds cursor remote URL with encoded user@host authority', () => {
+    expect(
+      buildRemoteEditorUrl('cursor', 'example.internal', 'azureuser', '/home/azureuser/src')
+    ).toBe('cursor://vscode-remote/ssh-remote+azureuser%40example.internal/home/azureuser/src');
+  });
+
+  it('normalizes relative target paths with a leading slash', () => {
+    expect(buildRemoteEditorUrl('vscode', 'example.internal', 'azureuser', 'workspace')).toBe(
+      'vscode://vscode-remote/ssh-remote+azureuser%40example.internal/workspace'
+    );
+  });
+});
+
+describe('buildGhosttyRemoteExecArgs', () => {
+  const expectedRemoteShellCommand =
+    `cd '/home/azureuser/pro/smv/.emdash/worktrees/task one' && ` +
+    '(if command -v infocmp >/dev/null 2>&1 && [ -n "${TERM:-}" ] && infocmp "${TERM}" >/dev/null 2>&1; then :; else export TERM=xterm-256color; fi) && ' +
+    '(exec "${SHELL:-/bin/bash}" || exec /bin/bash || exec /bin/sh)';
+
+  it('builds shared remote shell bootstrap command', () => {
+    expect(
+      buildRemoteTerminalShellCommand('/home/azureuser/pro/smv/.emdash/worktrees/task one')
+    ).toBe(expectedRemoteShellCommand);
+  });
+
+  it('builds ssh argv tokens for Ghostty -e', () => {
+    expect(
+      buildGhosttyRemoteExecArgs({
+        host: 'example.internal',
+        username: 'azureuser',
+        port: 22,
+        targetPath: '/home/azureuser/pro/smv/.emdash/worktrees/task one',
+      })
+    ).toEqual([
+      'ssh',
+      'azureuser@example.internal',
+      '-o',
+      'ControlMaster=no',
+      '-o',
+      'ControlPath=none',
+      '-p',
+      '22',
+      '-t',
+      expectedRemoteShellCommand,
+    ]);
+  });
+
+  it('preserves existing user@host authority', () => {
+    expect(
+      buildGhosttyRemoteExecArgs({
+        host: 'ops@example.internal',
+        username: 'ignored-user',
+        port: '2202',
+        targetPath: '/tmp/x',
+      })
+    ).toEqual([
+      'ssh',
+      'ops@example.internal',
+      '-o',
+      'ControlMaster=no',
+      '-o',
+      'ControlPath=none',
+      '-p',
+      '2202',
+      '-t',
+      `cd '/tmp/x' && (if command -v infocmp >/dev/null 2>&1 && [ -n "\${TERM:-}" ] && infocmp "\${TERM}" >/dev/null 2>&1; then :; else export TERM=xterm-256color; fi) && (exec "\${SHELL:-/bin/bash}" || exec /bin/bash || exec /bin/sh)`,
+    ]);
+  });
+
+  it('builds quoted ssh command string for shell-based launchers', () => {
+    expect(
+      buildRemoteSshCommand({
+        host: 'example.internal',
+        username: 'azureuser',
+        port: 22,
+        targetPath: '/home/azureuser/pro/smv/.emdash/worktrees/task one',
+      })
+    ).toBe(
+      `ssh 'azureuser@example.internal' -o 'ControlMaster=no' -o 'ControlPath=none' -p '22' -t '${expectedRemoteShellCommand.replace(/'/g, `'\\''`)}'`
+    );
+  });
+
+  it('preserves existing user@host authority in shell command string', () => {
+    expect(
+      buildRemoteSshCommand({
+        host: 'ops@example.internal',
+        username: 'ignored-user',
+        port: 22,
+        targetPath: '/tmp/x',
+      })
+    ).toContain(`ssh 'ops@example.internal'`);
+  });
+});

--- a/src/main/utils/remoteOpenIn.ts
+++ b/src/main/utils/remoteOpenIn.ts
@@ -1,0 +1,83 @@
+import { quoteShellArg } from './shellEscape';
+
+type RemoteEditorScheme = 'vscode' | 'cursor';
+
+export function buildRemoteSshAuthority(host: string, username: string): string {
+  const normalizedHost = host.trim();
+  if (!normalizedHost) return normalizedHost;
+
+  // Keep host as-is when caller already included user info (for SSH aliases like user@host).
+  if (normalizedHost.includes('@')) return normalizedHost;
+
+  const normalizedUsername = username.trim();
+  if (!normalizedUsername) return normalizedHost;
+
+  return `${normalizedUsername}@${normalizedHost}`;
+}
+
+export function buildRemoteEditorUrl(
+  scheme: RemoteEditorScheme,
+  host: string,
+  username: string,
+  targetPath: string
+): string {
+  const authority = buildRemoteSshAuthority(host, username);
+  const encodedAuthority = encodeURIComponent(authority);
+  const normalizedTargetPath = targetPath.startsWith('/') ? targetPath : `/${targetPath}`;
+  return `${scheme}://vscode-remote/ssh-remote+${encodedAuthority}${normalizedTargetPath}`;
+}
+
+type GhosttyRemoteExecInput = {
+  host: string;
+  username: string;
+  port: number | string;
+  targetPath: string;
+};
+
+/**
+ * Shell payload executed on the remote host after SSH connects.
+ *
+ * Goals:
+ * - always start in the requested directory
+ * - preserve current TERM only when host supports it (fallback for missing terminfo)
+ * - keep session alive even when SHELL is unset/invalid by chaining shell fallbacks
+ */
+export function buildRemoteTerminalShellCommand(targetPath: string): string {
+  return `cd ${quoteShellArg(targetPath)} && (if command -v infocmp >/dev/null 2>&1 && [ -n "\${TERM:-}" ] && infocmp "\${TERM}" >/dev/null 2>&1; then :; else export TERM=xterm-256color; fi) && (exec "\${SHELL:-/bin/bash}" || exec /bin/bash || exec /bin/sh)`;
+}
+
+/**
+ * Builds a single SSH command string for terminals that accept shell command text
+ * (Terminal.app, iTerm2 via AppleScript, Warp URL cmd parameter).
+ *
+ * Command text is shell-escaped because these launchers execute through a shell.
+ */
+export function buildRemoteSshCommand(input: GhosttyRemoteExecInput): string {
+  const sshAuthority = buildRemoteSshAuthority(input.host, input.username);
+  const remoteCommand = buildRemoteTerminalShellCommand(input.targetPath);
+  return `ssh ${quoteShellArg(sshAuthority)} -o ${quoteShellArg('ControlMaster=no')} -o ${quoteShellArg('ControlPath=none')} -p ${quoteShellArg(String(input.port))} -t ${quoteShellArg(remoteCommand)}`;
+}
+
+/**
+ * Builds argv tokens for Ghostty `-e` remote SSH execution.
+ *
+ * We pass these tokens directly via child_process execFile/spawn (shell disabled),
+ * so host/port are not shell-quoted here. The remote command itself is still
+ * shell-escaped because it is parsed by the remote shell over SSH.
+ */
+export function buildGhosttyRemoteExecArgs(input: GhosttyRemoteExecInput): string[] {
+  const sshAuthority = buildRemoteSshAuthority(input.host, input.username);
+  const remoteCommand = buildRemoteTerminalShellCommand(input.targetPath);
+  return [
+    'ssh',
+    sshAuthority,
+    '-o',
+    'ControlMaster=no',
+    '-o',
+    'ControlPath=none',
+    '-p',
+    String(input.port),
+    '-t',
+    remoteCommand,
+  ];
+}


### PR DESCRIPTION
## Summary
- preserve SSH authority for remote editor URLs by including `username@host` semantics when appropriate
- centralize remote SSH command construction for terminal-based remote open flows
- harden remote terminal launches for Ghostty, Terminal.app, iTerm2, and Warp on macOS
- improve compatibility on hosts lacking `xterm-ghostty` terminfo by using conditional TERM fallback

## Root Cause
Issue #1200 had two primary causes:
1. Remote editor URL authority could omit the intended SSH username when opening Cursor/VS Code remote targets.
2. Some terminal launch flows depended on a single shell path (`$SHELL`) and could terminate immediately when that shell was invalid in the remote session context.

## What Changed
- Added shared remote-open utilities:
  - `buildRemoteSshAuthority`
  - `buildRemoteEditorUrl`
  - `buildRemoteTerminalShellCommand`
  - `buildRemoteSshCommand`
  - `buildGhosttyRemoteExecArgs`
- Updated `app:openIn` remote handlers to use shared command builders.
- Switched macOS terminal AppleScript invocations to `execFile('osascript', ...)` for safer process execution.
- Added focused unit tests for authority/url/command construction and Ghostty argv generation.

## Behavior Notes
- Ghostty remote open now launches via structured argv attempts on macOS (`open -b`, `open -a`, then direct `ghostty -e`) with shared SSH bootstrap behavior.
- Remote shell bootstrap now:
  - enters the requested remote path
  - keeps current `TERM` when supported by host terminfo
  - falls back to `TERM=xterm-256color` when unsupported
  - falls back across shells (`${SHELL:-/bin/bash}` -> `/bin/bash` -> `/bin/sh`) to avoid immediate session termination

## Testing
Local validation on Node 22:
- `pnpm run format`
- `pnpm run lint`
- `pnpm run type-check`
- `pnpm exec vitest run`

Results:
- all commands passed
- vitest: `34` files passed, `338` tests passed

## Privacy / Redaction
This PR description intentionally avoids machine-specific identifiers and uses generalized terminology only.

Closes #1200
