### PR TITLE
fix: focus agent cli after task creation

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -284,6 +284,7 @@ const ChatInterface: React.FC<Props> = ({
 
   // Auto-focus terminal when switching to this task
   useEffect(() => {
+    if (!conversationsLoaded) return;
     // Small delay to ensure terminal is mounted and attached
     const timer = setTimeout(() => {
       const session = terminalSessionRegistry.getSession(terminalId);
@@ -292,7 +293,7 @@ const ChatInterface: React.FC<Props> = ({
       }
     }, 100);
     return () => clearTimeout(timer);
-  }, [task.id, terminalId]);
+  }, [task.id, terminalId, conversationsLoaded]);
 
   // Focus terminal when this task becomes active (for already-mounted terminals)
   useEffect(() => {


### PR DESCRIPTION
summary:
- after creating a new task, the agent cli terminal was not focused
- the auto-focus useEffect in ChatInterface fired before conversationsLoaded was true

fix:
- added conversationsLoaded to the dependency array of terminal focus useEffect
- added early return guard so the effect skips when conversations haven't loaded yet

fixes #1221 