### PR TITLE
refactor: terminal selection hook

### DIFF
--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -74,10 +74,12 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
     }
   }, []);
 
+  // Small delay to ensure the terminal pane has rendered after visibility change
   useEffect(() => {
-    if (!selection.activeTerminalId) return;
+    const id = selection.activeTerminalId;
+    if (!id) return;
     const timer = setTimeout(() => {
-      terminalRefs.current.get(selection.activeTerminalId!)?.focus();
+      terminalRefs.current.get(id)?.focus();
     }, 50);
     return () => clearTimeout(timer);
   }, [selection.activeTerminalId]);

--- a/src/renderer/hooks/useTerminalSelection.ts
+++ b/src/renderer/hooks/useTerminalSelection.ts
@@ -121,7 +121,8 @@ export function useTerminalSelection(options: UseTerminalSelectionOptions): Term
 
   const prevTaskIdRef = useRef<string | null>(task?.id ?? null);
 
-  // Unified validity effect
+  // Unified validity effect — deps list individual properties to avoid re-runs
+  // from unstable object references (useTaskTerminals returns new objects each render).
   useEffect(() => {
     const prevTaskId = prevTaskIdRef.current;
     const newValue = resolveSelection({
@@ -138,6 +139,7 @@ export function useTerminalSelection(options: UseTerminalSelectionOptions): Term
     if (newValue !== null && newValue !== selectedValue) {
       setSelectedValue(newValue);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     task?.id,
     selectedValue,
@@ -149,6 +151,7 @@ export function useTerminalSelection(options: UseTerminalSelectionOptions): Term
 
   const parsed = selectedValue ? parseTerminalValue(selectedValue) : null;
 
+  // Intentionally deps on stable setActiveTerminal methods, not full store objects.
   const onChange = useCallback(
     (value: string) => {
       setSelectedValue(value);
@@ -160,9 +163,11 @@ export function useTerminalSelection(options: UseTerminalSelectionOptions): Term
         globalTerminals.setActiveTerminal(p.id);
       }
     },
-    [taskTerminals, globalTerminals]
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [taskTerminals.setActiveTerminal, globalTerminals.setActiveTerminal]
   );
 
+  // Assumes the store's activeId was already set by createTerminal() before this is called.
   const onCreateTerminal = useCallback((mode: 'task' | 'global', id: string) => {
     setSelectedValue(`${mode}::${id}`);
     setIsOpen(false);

--- a/src/renderer/lib/taskTerminalsStore.ts
+++ b/src/renderer/lib/taskTerminalsStore.ts
@@ -245,17 +245,15 @@ function createTerminal(
   taskPath?: string,
   options?: { title?: string; cwd?: string }
 ): string {
-  let newId = '';
+  const newId = makeTerminalId(taskId);
   updateTaskState(taskId, taskPath, (draft) => {
     const nextIndex = draft.counter + 1;
-    const id = makeTerminalId(taskId);
-    newId = id;
     draft.counter = nextIndex;
-    draft.activeId = id;
+    draft.activeId = newId;
     draft.terminals = [
       ...draft.terminals,
       {
-        id,
+        id: newId,
         title: options?.title || `Terminal ${nextIndex}`,
         cwd: options?.cwd || taskPath,
         createdAt: Date.now(),

--- a/src/test/renderer/useTerminalSelection.test.ts
+++ b/src/test/renderer/useTerminalSelection.test.ts
@@ -70,6 +70,17 @@ describe('resolveSelection', () => {
       });
       expect(result).toBe('');
     });
+
+    it('resets from lifecycle mode on task switch', () => {
+      const result = resolveSelection({
+        currentValue: 'lifecycle::setup',
+        taskId: 'task-2',
+        prevTaskId: 'task-1',
+        taskTerminals: makeTerminals(['t1']),
+        globalTerminals: makeTerminals(['g1']),
+      });
+      expect(result).toBe('task::t1');
+    });
   });
 
   describe('no selection', () => {


### PR DESCRIPTION
summary:
- terminal selector dropdown had 3 competing useEffect hooks that caused bugs on create, delete and task switch
- extracted into a single useTerminalSelection hook

changes:
- createTerminal now returns the new ID so callers can select it immediately
- new useTerminalSelection hook replacing 3 competing useEffects
- unit tests for the pure selection logic


- when adding a new worktree/global terminal, the new terminal is now automatically focused
- relates to #1136