### PR TITLE
fix(ci): harden NuGet provider install on Windows runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -369,6 +369,12 @@ jobs:
         if: ${{ steps.signing.outputs.has_signing == 'true' }}
         shell: pwsh
         run: |
+          # Ensure TLS 1.2 for PSGallery and NuGet
+          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+          # Register NuGet source directly (avoids flaky Install-PackageProvider)
+          if (-not (Get-PackageSource -Name nuget.org -ErrorAction SilentlyContinue)) {
+            Register-PackageSource -Name nuget.org -Location https://api.nuget.org/v3/index.json -ProviderName NuGet -Force
+          }
           Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
           Install-Module -Name TrustedSigning -RequiredVersion 0.5.0 -Force -Repository PSGallery
 


### PR DESCRIPTION
## Summary
- Forces TLS 1.2 and pre-registers the NuGet package source before `Install-PackageProvider` in the Windows release job
- Fixes flaky `Install-PackageProvider -Name NuGet` failures on `windows-2022` GitHub Actions runners where the NuGet provider can't be resolved from the default feed

## Test plan
- [ ] Merge and re-trigger the release workflow
- [ ] Verify the `release-win` job passes the "Install Azure Trusted Signing dependencies" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)