### PR TITLE
fix(ci): remove redundant TrustedSigning install from Windows release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -365,19 +365,6 @@ jobs:
             echo "::warning::Azure Trusted Signing secrets not configured. Windows build will be unsigned."
           fi
 
-      - name: Install Azure Trusted Signing dependencies
-        if: ${{ steps.signing.outputs.has_signing == 'true' }}
-        shell: pwsh
-        run: |
-          # Ensure TLS 1.2 for PSGallery and NuGet
-          [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
-          # Register NuGet source directly (avoids flaky Install-PackageProvider)
-          if (-not (Get-PackageSource -Name nuget.org -ErrorAction SilentlyContinue)) {
-            Register-PackageSource -Name nuget.org -Location https://api.nuget.org/v3/index.json -ProviderName NuGet -Force
-          }
-          Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-          Install-Module -Name TrustedSigning -RequiredVersion 0.5.0 -Force -Repository PSGallery
-
       - name: Rebuild native modules (x64)
         shell: bash
         run: |


### PR DESCRIPTION
## Summary
- Removes the manual `Install-PackageProvider -Name NuGet` / `Install-Module -Name TrustedSigning` step from the Windows release job
- electron-builder 26.x already handles this internally in `windowsSignAzureManager.js` — it installs NuGet (catching errors gracefully) and TrustedSigning automatically when `azureSignOptions` is configured
- The manual step was failing hard on GitHub Actions `windows-2022` runners, killing the job before electron-builder could try its own approach

## Test plan
- [ ] Merge, re-tag `v0.4.23`, verify `release-win` passes the build step

🤖 Generated with [Claude Code](https://claude.com/claude-code)