### PR TITLE
feat(sidebar): add Remote Project option to new project menu

### DIFF
--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -316,6 +316,12 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
                         ariaLabel="Clone"
                         onClick={() => onCloneProject?.()}
                       />
+                      <MenuItemButton
+                        icon={Server}
+                        label="Remote Project"
+                        ariaLabel="Remote Project"
+                        onClick={() => onAddRemoteProject?.()}
+                      />
                     </div>
                   </PopoverContent>
                 </Popover>


### PR DESCRIPTION
## Summary
- Adds a "Remote Project" menu item to the project creation popover in the left sidebar
- Uses the `Server` icon and wires up the existing `onAddRemoteProject` callback
- Gives users a discoverable way to add remote SSH projects directly from the sidebar menu

## Test plan
- [ ] Open the sidebar and click the folder-plus button next to "Projects"
- [ ] Verify "Remote Project" appears as the fourth option with a server icon
- [ ] Click "Remote Project" and confirm it triggers the remote project flow