### PR TITLE
fix: make single-task sidebar panels resizable

### DIFF
--- a/src/renderer/components/RightSidebar.tsx
+++ b/src/renderer/components/RightSidebar.tsx
@@ -373,27 +373,29 @@ const SingleTaskSidebar: React.FC<{
   onOpenChanges,
 }) => {
   return (
-    <>
-      <FileChangesPanel
-        className="min-h-0 flex-1 border-b border-border"
-        onOpenChanges={onOpenChanges}
-      />
-      <TaskTerminalPanel
-        task={task}
-        agent={task.agentId as Agent}
-        projectPath={projectPath || task?.path}
-        remote={
-          projectRemoteConnectionId
-            ? {
-                connectionId: projectRemoteConnectionId,
-                projectPath: projectRemotePath || projectPath || undefined,
-              }
-            : undefined
-        }
-        defaultBranch={projectDefaultBranch || undefined}
-        className="min-h-0 flex-1"
-      />
-    </>
+    <ResizablePanelGroup direction="vertical" autoSaveId={RIGHT_SIDEBAR_VERTICAL_STORAGE_KEY}>
+      <ResizablePanel defaultSize={50} minSize={20}>
+        <FileChangesPanel className="h-full min-h-0" onOpenChanges={onOpenChanges} />
+      </ResizablePanel>
+      <ResizableHandle />
+      <ResizablePanel defaultSize={50} minSize={20}>
+        <TaskTerminalPanel
+          task={task}
+          agent={task.agentId as Agent}
+          projectPath={projectPath || task?.path}
+          remote={
+            projectRemoteConnectionId
+              ? {
+                  connectionId: projectRemoteConnectionId,
+                  projectPath: projectRemotePath || projectPath || undefined,
+                }
+              : undefined
+          }
+          defaultBranch={projectDefaultBranch || undefined}
+          className="h-full min-h-0"
+        />
+      </ResizablePanel>
+    </ResizablePanelGroup>
   );
 };
 


### PR DESCRIPTION
## Summary

- Replace the fixed flex layout in `SingleTaskSidebar` with `ResizablePanelGroup` so the file changes and terminal panels can be resized by dragging, matching the behavior already used in other sidebar branches (multi-agent variants, no-task state).

## Changes

- Wrapped `FileChangesPanel` and `TaskTerminalPanel` in `ResizablePanel` components with a `ResizableHandle` between them
- Applied consistent `h-full min-h-0` styling and 50/50 default split with 20% minimum panel size
- Persists panel sizes via `RIGHT_SIDEBAR_VERTICAL_STORAGE_KEY`

<!-- emdash-issue-footer:start -->
Fixes GEN-446
<!-- emdash-issue-footer:end -->