### PR TITLE
fix(ssh): resolve Windows ssh executable path for PTY

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -570,7 +570,7 @@ function resolveCommandPath(command: string): string | null {
     return resolveFromCandidates([expandWindowsEnvVars(trimmed)], true);
   }
 
-  const pathEnv = process.env.PATH;
+  const pathEnv = process.env.PATH || process.env.Path;
   if (!pathEnv) return null;
 
   const pathDirs = pathEnv

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -199,6 +199,7 @@ describe('ptyManager SSH spawn resolution', () => {
       const resolved = resolveSshCommand();
       expect(resolved).toBe(fakeSshPath);
     } finally {
+      process.env = { ...originalEnv };
       rmSync(tempDir, { recursive: true, force: true });
       if (originalPlatformDescriptor) {
         Object.defineProperty(process, 'platform', originalPlatformDescriptor);


### PR DESCRIPTION
## Summary
- resolve `ssh` executable path robustly on Windows before PTY spawn
- expand `%VAR%` entries while resolving command paths on Windows (`PATH` / `Path`)
- use resolved SSH command via `resolveWindowsPtySpawn()` in `startSshPty()`
- add a targeted test for fallback to `%SystemRoot%\\System32\\OpenSSH\\ssh.exe`
- restore `process.env` in the new test to avoid cross-test contamination

## Validation
- `pnpm exec prettier --check src/main/services/ptyManager.ts src/test/main/ptyManager.test.ts`
- `pnpm run lint` (passes with existing repo warnings)
- `pnpm run type-check`
- `pnpm run build`
- `pnpm exec vitest run src/test/main/ptyManager.test.ts`
- `pnpm exec vitest run` (fails on existing Windows cross-platform test expectations unrelated to this change)
