### PR TITLE
fix: move onboarding state from localStorage to app settings

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -112,6 +112,7 @@ export interface AppSettings {
   };
   defaultOpenInApp?: OpenInAppId;
   hiddenOpenInApps?: OpenInAppId[];
+  onboardingSeen?: boolean;
 }
 
 function getPlatformTaskSwitchDefaults(): { next: ShortcutBinding; prev: ShortcutBinding } {
@@ -554,6 +555,11 @@ export function normalizeSettings(input: AppSettings): AppSettings {
     out.hiddenOpenInApps = [...new Set(validated)];
   } else {
     out.hiddenOpenInApps = [];
+  }
+
+  // Onboarding
+  if ((input as any)?.onboardingSeen === true) {
+    out.onboardingSeen = true;
   }
 
   return out;

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -2,34 +2,31 @@ import { ThemeProvider } from './components/ThemeProvider';
 import ErrorBoundary from './components/ErrorBoundary';
 import { WelcomeScreen } from './views/Welcome';
 import { Workspace } from './views/Workspace';
-import { useLocalStorage } from './hooks/useLocalStorage';
-import { FIRST_LAUNCH_KEY } from './constants/layout';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { AppSettingsProvider } from './contexts/AppSettingsProvider';
+import { AppSettingsProvider, useAppSettings } from './contexts/AppSettingsProvider';
 
 const queryClient = new QueryClient();
 
+function AppContent() {
+  const { settings, isLoading, updateSettings } = useAppSettings();
+
+  if (isLoading || !settings) return null;
+
+  if (!settings.onboardingSeen) {
+    return <WelcomeScreen onGetStarted={() => updateSettings({ onboardingSeen: true })} />;
+  }
+
+  return <Workspace />;
+}
+
 export function App() {
-  const [isFirstLaunch, setIsFirstLaunch] = useLocalStorage<boolean | number>(
-    FIRST_LAUNCH_KEY,
-    true
-  );
-
-  const renderContent = () => {
-    // Handle legacy string value '1' from old implementation
-    const isFirstLaunchBool = isFirstLaunch === true || isFirstLaunch === 1;
-
-    if (isFirstLaunchBool) {
-      return <WelcomeScreen onGetStarted={() => setIsFirstLaunch(false)} />;
-    }
-    return <Workspace />;
-  };
-
   return (
     <QueryClientProvider client={queryClient}>
       <AppSettingsProvider>
         <ThemeProvider>
-          <ErrorBoundary>{renderContent()}</ErrorBoundary>
+          <ErrorBoundary>
+            <AppContent />
+          </ErrorBoundary>
         </ThemeProvider>
       </AppSettingsProvider>
     </QueryClientProvider>


### PR DESCRIPTION
## Summary

- Replaces the `localStorage`-based first launch check (`useLocalStorage` + `FIRST_LAUNCH_KEY`) with a persistent `onboardingSeen` flag in `AppSettings`
- Adds `onboardingSeen?: boolean` to the settings schema and normalization logic in `settings.ts`
- Extracts `AppContent` component in `App.tsx` that reads settings via `useAppSettings()` to gate the welcome screen

## Motivation

Storing onboarding state in `localStorage` was unreliable — it could be cleared independently of app settings, causing the welcome screen to reappear unexpectedly. Moving it to the persisted settings file ensures consistency across sessions.

## Test plan

- [ ] Fresh install shows the welcome screen
- [ ] Clicking "Get Started" persists `onboardingSeen: true` in settings and transitions to the workspace
- [ ] Subsequent launches skip the welcome screen
- [ ] Existing users with `onboardingSeen` unset in settings see the welcome screen once (migration path)