### PR TITLE
fix(github): support GitHub Enterprise for PR creation

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -445,13 +445,7 @@ export function registerGitIpc() {
     }
     outputs.push('git push: success');
 
-    // Resolve repo + branches
-    const repoResult = await remoteGitService.execGh(
-      connectionId,
-      taskPath,
-      'repo view --json nameWithOwner -q .nameWithOwner'
-    );
-    const repoNameWithOwner = (repoResult.stdout || '').trim();
+    // Resolve branches
     const currentBranch = await remoteGitService.getCurrentBranch(connectionId, taskPath);
     const defaultBranch = await remoteGitService.getDefaultBranchName(connectionId, taskPath);
 
@@ -472,7 +466,6 @@ export function registerGitIpc() {
 
     // Build gh pr create command
     const flags: string[] = [];
-    if (repoNameWithOwner) flags.push(`--repo ${quoteGhArg(repoNameWithOwner)}`);
     if (title) flags.push(`--title ${quoteGhArg(title)}`);
     // Can't use --body-file on remote, use --body instead
     if (prBody && !shouldUseFill) flags.push(`--body ${quoteGhArg(prBody)}`);
@@ -480,10 +473,7 @@ export function registerGitIpc() {
     if (head) {
       flags.push(`--head ${quoteGhArg(head)}`);
     } else if (currentBranch) {
-      const headRef = repoNameWithOwner
-        ? `${repoNameWithOwner.split('/')[0]}:${currentBranch}`
-        : currentBranch;
-      flags.push(`--head ${quoteGhArg(headRef)}`);
+      flags.push(`--head ${quoteGhArg(currentBranch)}`);
     }
     if (draft) flags.push('--draft');
     if (web) flags.push('--web');
@@ -953,32 +943,6 @@ export function registerGitIpc() {
           }
         }
 
-        // Resolve repo owner/name (prefer gh, fallback to parsing origin url)
-        let repoNameWithOwner = '';
-        try {
-          const { stdout: repoOut } = await execAsync(
-            'gh repo view --json nameWithOwner -q .nameWithOwner',
-            { cwd: taskPath }
-          );
-          repoNameWithOwner = (repoOut || '').trim();
-        } catch {
-          try {
-            const { stdout: urlOut } = await execAsync('git remote get-url origin', {
-              cwd: taskPath,
-            });
-            const url = (urlOut || '').trim();
-            // Handle both SSH and HTTPS forms
-            const m =
-              url.match(/github\.com[/:]([^/]+)\/([^/.]+)(?:\.git)?$/i) ||
-              url.match(/([^/:]+)[:/]([^/]+)\/([^/.]+)(?:\.git)?$/i);
-            if (m) {
-              const owner = m[1].includes('github.com') ? m[1].split('github.com').pop() : m[1];
-              const repo = m[2] || m[3];
-              repoNameWithOwner = `${owner}/${repo}`.replace(/^\/*/, '');
-            }
-          } catch {}
-        }
-
         // Determine current branch and default base branch (fallback to main)
         let currentBranch = '';
         try {
@@ -1023,9 +987,8 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
           // Non-fatal; continue
         }
 
-        // Build gh pr create command with explicit repo/base/head for reliability
+        // Build gh pr create command
         const flags: string[] = [];
-        if (repoNameWithOwner) flags.push(`--repo ${JSON.stringify(repoNameWithOwner)}`);
         if (title) flags.push(`--title ${JSON.stringify(title)}`);
 
         // Use temp file for body to properly handle newlines and multiline content
@@ -1052,11 +1015,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         if (head) {
           flags.push(`--head ${JSON.stringify(head)}`);
         } else if (currentBranch) {
-          // Prefer owner:branch form when repo is known; otherwise branch name
-          const headRef = repoNameWithOwner
-            ? `${repoNameWithOwner.split('/')[0]}:${currentBranch}`
-            : currentBranch;
-          flags.push(`--head ${JSON.stringify(headRef)}`);
+          flags.push(`--head ${JSON.stringify(currentBranch)}`);
         }
         if (draft) flags.push('--draft');
         if (web) flags.push('--web');

--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -506,12 +506,6 @@ export class GitHubService {
   > {
     const safeLimit = Math.min(Math.max(Number(limit) || 50, 1), 200);
     try {
-      // Check if repo has GitHub remote before attempting to list issues
-      const hasGitHubRemote = await this.hasGitHubRemote(projectPath);
-      if (!hasGitHubRemote) {
-        return []; // No GitHub remote, return empty array
-      }
-
       const fields = ['number', 'title', 'url', 'state', 'updatedAt', 'assignees', 'labels'];
       const { stdout } = await this.execGH(
         `gh issue list --state open --limit ${safeLimit} --json ${fields.join(',')}`,
@@ -545,12 +539,6 @@ export class GitHubService {
     const safeLimit = Math.min(Math.max(Number(limit) || 20, 1), 200);
     const term = String(searchTerm || '').trim();
     if (!term) return [];
-
-    // Check if repo has GitHub remote before attempting to search issues
-    const hasGitHubRemote = await this.hasGitHubRemote(projectPath);
-    if (!hasGitHubRemote) {
-      return []; // No GitHub remote, return empty array
-    }
 
     try {
       const fields = ['number', 'title', 'url', 'state', 'updatedAt', 'assignees', 'labels'];
@@ -673,20 +661,6 @@ export class GitHubService {
       return true;
     } catch (error) {
       // Not authenticated or gh CLI not installed
-      return false;
-    }
-  }
-
-  /**
-   * Check if repository has a GitHub remote
-   */
-  private async hasGitHubRemote(projectPath: string): Promise<boolean> {
-    try {
-      const { stdout } = await execAsync('git remote -v', { cwd: projectPath });
-      // Check if any remote URL contains github.com
-      return stdout.includes('github.com');
-    } catch (error) {
-      // Not a git repo or no remotes
       return false;
     }
   }


### PR DESCRIPTION
## Summary

PR creation was previously broken on GitHub Enterprise (GHE) instances because the codebase assumed all GitHub remotes were hosted on `github.com`. Specifically:

* `gh repo view --json nameWithOwner` fails on GHE hosts if they are not the default, causing the `--repo` and `--head owner:branch` flags to be malformed or missing.
* `hasGitHubRemote()` explicitly searched for the `github.com` string in remote URLs, which caused GHE repositories to be incorrectly identified as non-GitHub.

This PR removes these assumptions and allows the GitHub CLI (`gh`) to handle host resolution natively based on the local git configuration.

## Changes

### src/main/ipc/gitIpc.ts — PR creation (local and remote)

* **Removed --repo flag:** Both local and remote PR creation paths previously attempted to resolve `nameWithOwner` via `gh repo view` to pass an explicit `--repo owner/repo` flag. This is unnecessary as `gh pr create` automatically infers the repository from the working directory's git remote. The explicit flag caused failures on GHE when the host was not `github.com`.
* **Simplified --head flag:** Changed from `owner:branch` to using the branch name directly. The `owner:` prefix is only necessary for cross-fork PRs, which are not currently a use case for Emdash. This avoids a failure cascade when repository resolution fails.
* **Removed repo URL parsing fallback:** Deleted the regex-based SSH/HTTPS remote URL parsing logic. This logic was fragile, did not support GHE URL patterns, and was only used to support the now-removed `--repo` flag.

### src/main/services/GitHubService.ts — Issue listing

* **Removed hasGitHubRemote() method:** This guard previously checked for `github.com` in the output of `git remote -v` before executing issue commands. On GHE repositories, this check always failed, silently disabling issue integration features.
* **Streamlined host validation:** Removed the manual check in favor of the existing error handling in `listIssues()` and `searchIssues()`. On non-GitHub repositories, the `gh` CLI fails quickly; the code now catches these failures and returns an empty list as intended.

## Test Plan

* [x] **Type Check:** Verified that `pnpm run type-check` passes.
* [x] **Unit Tests:** Verified that `pnpm exec vitest run` passes (noting that 3 pre-existing failures in `TaskLifecycleService.test.ts` are unrelated to these changes).
* [ ] **Manual (github.com):** Confirmed PR creation still functions correctly for public GitHub repositories.
* [x] **Manual (GHE):** Confirmed PR creation now succeeds on GitHub Enterprise instances.
* [x] **Manual (Non-GitHub):** Confirmed that opening the issue selector on a non-GitHub repository returns an empty list without throwing UI errors.