### PR TITLE
fix(tasks): add bulk unarchive functionality to task selection

### DIFF
--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -589,6 +589,8 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
         title: restoredNames.length === 1 ? 'Task restored' : 'Tasks restored',
         description: remaining > 0 ? `${displayNames} and ${remaining} more` : displayNames,
       });
+    } else {
+      toast({ title: 'Failed to restore tasks', variant: 'destructive' });
     }
   };
 


### PR DESCRIPTION
Fixes missing bulk unarchive functionality when selecting archived tasks.

## Problem
When selecting archived tasks via checkbox, the bulk action toolbar showed:
- Archive button (wrong - can't archive already-archived tasks)
- Delete button
- No Unarchive button (missing!)

Users had no way to bulk unarchive tasks through the selection interface.

before:

https://github.com/user-attachments/assets/d21bf53e-3d49-471d-b505-ad5dec0e357c



after:

https://github.com/user-attachments/assets/0adf7336-3e9f-4de1-abcb-2929571f40a2


