### PR TITLE
fix: allow terminal switching while lifecycle run script is active

### DIFF
--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -235,12 +235,15 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
     };
   }, [task?.id, refreshLifecycleState]);
 
-  // Auto-switch dropdown to Run when the run phase starts.
+  // Auto-switch dropdown to Run when the run phase first starts.
+  const prevRunStatusRef = useRef(runStatus);
   useEffect(() => {
-    if (runStatus === 'running' && selection.selectedLifecycle !== 'run') {
+    const wasRunning = prevRunStatusRef.current === 'running';
+    prevRunStatusRef.current = runStatus;
+    if (runStatus === 'running' && !wasRunning) {
       selection.onChange('lifecycle::run');
     }
-  }, [runStatus, selection.selectedLifecycle, selection.onChange]);
+  }, [runStatus, selection.onChange]);
 
   const totalTerminals = taskTerminals.terminals.length + globalTerminals.terminals.length;
 


### PR DESCRIPTION
summary:
- terminal dropdown won't switch away from "Run" while a lifecycle run script is active
- auto-switch effect keeps firing and snapping the selection back

fix:
- only auto-switch to the run terminal once, when the run first starts, instead of continuously while it's running

fixes #1246 