### PR TITLE
refactor: switch dialog, button, popover impl to baseui

### DIFF
--- a/components.json
+++ b/components.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://ui.shadcn.com/schema.json",
-  "style": "new-york",
+  "style": "base-vega",
   "rsc": false,
   "tsx": true,
   "tailwind": {

--- a/src/renderer/components/CloneFromUrlModal.tsx
+++ b/src/renderer/components/CloneFromUrlModal.tsx
@@ -6,6 +6,7 @@ import { Label } from './ui/label';
 import { Spinner } from './ui/spinner';
 import { Separator } from './ui/separator';
 import { rpc } from '@/lib/rpc';
+import { useModalCloseGuard } from '@/contexts/ModalProvider';
 
 interface CloneFromUrlModalProps {
   onClose: () => void;
@@ -19,6 +20,8 @@ export const CloneFromUrlModal: React.FC<CloneFromUrlModalProps> = ({ onClose, o
   const [error, setError] = useState<string | null>(null);
   const [progress, setProgress] = useState<string>('');
   const [touched, setTouched] = useState(false);
+
+  useModalCloseGuard(isCloning);
 
   // Clean URL by removing hash, query params, and trailing slashes
   const cleanUrl = useCallback((url: string): string => {
@@ -162,15 +165,7 @@ export const CloneFromUrlModal: React.FC<CloneFromUrlModalProps> = ({ onClose, o
   );
 
   return (
-    <DialogContent
-      className="max-w-md"
-      onInteractOutside={(e) => {
-        if (isCloning) e.preventDefault();
-      }}
-      onEscapeKeyDown={(e) => {
-        if (isCloning) e.preventDefault();
-      }}
-    >
+    <DialogContent className="max-w-md">
       <DialogHeader>
         <DialogTitle>Clone from URL</DialogTitle>
       </DialogHeader>

--- a/src/renderer/components/CommentsPopover.tsx
+++ b/src/renderer/components/CommentsPopover.tsx
@@ -150,7 +150,7 @@ export function CommentsPopover({
         <TooltipProvider delayDuration={tooltipDelay}>
           <Tooltip>
             <TooltipTrigger asChild>
-              <PopoverTrigger asChild>{children}</PopoverTrigger>
+              <PopoverTrigger>{children}</PopoverTrigger>
             </TooltipTrigger>
             <TooltipContent side="bottom" className="text-xs">
               {tooltipContent}
@@ -158,7 +158,7 @@ export function CommentsPopover({
           </Tooltip>
         </TooltipProvider>
       ) : (
-        <PopoverTrigger asChild>{children}</PopoverTrigger>
+        <PopoverTrigger>{children}</PopoverTrigger>
       )}
       <PopoverContent className="w-[min(460px,92vw)] p-0" align="start">
         <div className="flex items-center justify-between border-b px-4 py-3">

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -65,7 +65,7 @@ function PrActionButton({ mode, onModeChange, onExecute, isLoading }: PrActionBu
         {isLoading ? <Spinner size="sm" /> : PR_MODE_LABELS[mode]}
       </Button>
       <Popover>
-        <PopoverTrigger asChild>
+        <PopoverTrigger>
           <Button
             variant="outline"
             size="sm"

--- a/src/renderer/components/GithubDeviceFlowModal.tsx
+++ b/src/renderer/components/GithubDeviceFlowModal.tsx
@@ -207,12 +207,6 @@ export function GithubDeviceFlowModal({ onClose, onSuccess, onError }: GithubDev
     }
   };
 
-  const handleClose = () => {
-    // Cancel auth flow in main process (polling continues in background)
-    window.electronAPI.githubCancelAuth();
-    onClose();
-  };
-
   const formatTime = (seconds: number) => {
     const mins = Math.floor(seconds / 60);
     const secs = seconds % 60;
@@ -237,14 +231,16 @@ export function GithubDeviceFlowModal({ onClose, onSuccess, onError }: GithubDev
     return () => window.removeEventListener('keydown', handleKeyDown);
   }, [userCode]);
 
+  useEffect(() => {
+    return () => {
+      window.electronAPI.githubCancelAuth();
+    };
+  }, []);
+
   return (
-    <DialogContent
-      className="max-w-[480px] p-0"
-      onInteractOutside={() => handleClose()}
-      onEscapeKeyDown={() => handleClose()}
-    >
+    <DialogContent className="max-w-[480px] p-0">
       <button
-        onClick={handleClose}
+        onClick={onClose}
         className="absolute right-4 top-4 z-10 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground"
       >
         <X className="h-4 w-4" />
@@ -286,7 +282,7 @@ export function GithubDeviceFlowModal({ onClose, onSuccess, onError }: GithubDev
               <h2 className="text-xl font-semibold">Authentication Failed</h2>
               <p className="text-sm text-muted-foreground">{error}</p>
             </div>
-            <Button onClick={handleClose} variant="outline" className="w-full">
+            <Button onClick={onClose} variant="outline" className="w-full">
               Close
             </Button>
           </div>

--- a/src/renderer/components/LeftSidebar.tsx
+++ b/src/renderer/components/LeftSidebar.tsx
@@ -16,7 +16,6 @@ import {
 } from './ui/sidebar';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from './ui/collapsible';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import {
   Home,
   Plus,
@@ -279,7 +278,7 @@ const LeftSidebar: React.FC<LeftSidebarProps> = ({
               </span>
               {onOpenProject && (
                 <Popover>
-                  <PopoverTrigger asChild>
+                  <PopoverTrigger>
                     <Button variant="ghost" size="icon-sm" className="text-foreground/30">
                       <FolderPlus className="h-3.5 w-3.5" />
                     </Button>

--- a/src/renderer/components/MergePrSection.tsx
+++ b/src/renderer/components/MergePrSection.tsx
@@ -316,7 +316,7 @@ export function MergePrSection({
               </Button>
             )}
             <Popover>
-              <PopoverTrigger asChild>
+              <PopoverTrigger>
                 <Button
                   variant="default"
                   size="sm"

--- a/src/renderer/components/NewProjectModal.tsx
+++ b/src/renderer/components/NewProjectModal.tsx
@@ -7,6 +7,7 @@ import { Label } from './ui/label';
 import { RadioGroup, RadioGroupItem } from './ui/radio-group';
 import { Spinner } from './ui/spinner';
 import { Separator } from './ui/separator';
+import { useModalCloseGuard } from '@/contexts/ModalProvider';
 
 interface NewProjectModalProps {
   onClose: () => void;
@@ -31,6 +32,8 @@ export const NewProjectModal: React.FC<NewProjectModalProps> = ({ onClose, onSuc
   const [progress, setProgress] = useState<string>('');
   const [touched, setTouched] = useState(false);
   const validationTimeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+  useModalCloseGuard(isCreating);
 
   // Load owners on mount
   useEffect(() => {
@@ -163,15 +166,7 @@ export const NewProjectModal: React.FC<NewProjectModalProps> = ({ onClose, onSuc
   );
 
   return (
-    <DialogContent
-      className="max-w-md"
-      onInteractOutside={(e) => {
-        if (isCreating) e.preventDefault();
-      }}
-      onEscapeKeyDown={(e) => {
-        if (isCreating) e.preventDefault();
-      }}
-    >
+    <DialogContent className="max-w-md">
       <DialogHeader>
         <DialogTitle>New Project</DialogTitle>
       </DialogHeader>

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -872,7 +872,7 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
                           </button>
                         )}
                         <Popover>
-                          <PopoverTrigger asChild>
+                          <PopoverTrigger>
                             <Button
                               variant="ghost"
                               size="icon-sm"

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -354,15 +354,10 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
     }
   };
 
-  const handleOpenAutoFocus = useCallback((event: Event) => {
-    event.preventDefault();
-    taskNameInputRef.current?.focus({ preventScroll: true });
-  }, []);
-
   return (
     <DialogContent
       className="max-h-[calc(100vh-48px)] max-w-md overflow-visible"
-      onOpenAutoFocus={handleOpenAutoFocus}
+      initialFocus={taskNameInputRef}
     >
       <DialogHeader>
         <DialogTitle>New Task</DialogTitle>

--- a/src/renderer/components/TerminalSettingsCard.tsx
+++ b/src/renderer/components/TerminalSettingsCard.tsx
@@ -158,7 +158,7 @@ const TerminalSettingsCard: React.FC = () => {
         </div>
         <div className="w-[183px] flex-shrink-0">
           <Popover open={pickerOpen} onOpenChange={setPickerOpen}>
-            <PopoverTrigger asChild>
+            <PopoverTrigger>
               <Button
                 type="button"
                 variant="outline"

--- a/src/renderer/components/ssh/AddRemoteProjectModal.tsx
+++ b/src/renderer/components/ssh/AddRemoteProjectModal.tsx
@@ -38,6 +38,7 @@ import {
   Download,
   Copy,
 } from 'lucide-react';
+import { useModalCloseGuard } from '@/contexts/ModalProvider';
 
 type WizardStep = 'connection' | 'auth' | 'path' | 'confirm';
 type AuthType = 'password' | 'key' | 'agent';
@@ -134,6 +135,8 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
   const [isLoadingSavedConnections, setIsLoadingSavedConnections] = useState(false);
   const [selectedSavedConnection, setSelectedSavedConnection] = useState<string | null>(null);
   const [useExistingConnection, setUseExistingConnection] = useState(false);
+
+  useModalCloseGuard(isSubmitting);
 
   // Form data
   const [formData, setFormData] = useState<FormData>({
@@ -1508,17 +1511,7 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
   };
 
   return (
-    <DialogContent
-      className="max-w-lg md:max-w-2xl"
-      onInteractOutside={(e) => {
-        if (isSubmitting) e.preventDefault();
-        else handleClose();
-      }}
-      onEscapeKeyDown={(e) => {
-        if (isSubmitting) e.preventDefault();
-        else handleClose();
-      }}
-    >
+    <DialogContent className="max-w-lg md:max-w-2xl">
       <DialogHeader>
         <DialogTitle>Add Remote Project</DialogTitle>
         <DialogDescription>

--- a/src/renderer/components/ui/button.tsx
+++ b/src/renderer/components/ui/button.tsx
@@ -1,27 +1,36 @@
-import * as React from 'react';
-import { Slot } from '@radix-ui/react-slot';
+import { Button as ButtonPrimitive } from '@base-ui/react/button';
 import { cva, type VariantProps } from 'class-variance-authority';
 
 import { cn } from '@/lib/utils';
 
 const buttonVariants = cva(
-  'inline-flex items-center justify-center whitespace-nowrap rounded-md text-sm font-medium ring-offset-background transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+  "group/button inline-flex shrink-0 items-center justify-center rounded-md border border-transparent bg-clip-padding text-sm font-medium whitespace-nowrap transition-all outline-none select-none focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 disabled:pointer-events-none disabled:opacity-50 aria-invalid:border-destructive aria-invalid:ring-3 aria-invalid:ring-destructive/20 dark:aria-invalid:border-destructive/50 dark:aria-invalid:ring-destructive/40 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
   {
     variants: {
       variant: {
-        default: 'bg-primary text-primary-foreground hover:bg-primary/90',
-        destructive: 'bg-destructive text-destructive-foreground hover:bg-destructive/90',
-        outline: 'border border-input bg-background hover:bg-accent hover:text-accent-foreground',
-        secondary: 'bg-secondary text-secondary-foreground hover:bg-secondary/80',
-        ghost: 'hover:bg-accent hover:text-accent-foreground',
+        default: 'bg-primary text-primary-foreground hover:bg-primary/80',
+        outline:
+          'border-border bg-background shadow-xs hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:border-input dark:bg-input/30 dark:hover:bg-input/50',
+        secondary:
+          'bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground',
+        ghost:
+          'hover:bg-muted hover:text-foreground aria-expanded:bg-muted aria-expanded:text-foreground dark:hover:bg-muted/50',
+        destructive:
+          'bg-destructive/10 text-destructive hover:bg-destructive/20 focus-visible:border-destructive/40 focus-visible:ring-destructive/20 dark:bg-destructive/20 dark:hover:bg-destructive/30 dark:focus-visible:ring-destructive/40',
         link: 'text-primary underline-offset-4 hover:underline',
       },
       size: {
-        default: 'h-10 px-4 py-2',
-        sm: 'h-9 rounded-md px-3',
-        lg: 'h-11 rounded-md px-8',
-        icon: 'h-10 w-10',
-        'icon-sm': 'h-7 w-7',
+        default:
+          'h-9 gap-1.5 px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2',
+        xs: "h-6 gap-1 rounded-[min(var(--radius-md),8px)] px-2 text-xs in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+        sm: 'h-8 gap-1 rounded-[min(var(--radius-md),10px)] px-2.5 in-data-[slot=button-group]:rounded-md has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5',
+        lg: 'h-10 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-3 has-data-[icon=inline-start]:pl-3',
+        icon: 'size-9',
+        'icon-xs':
+          "size-6 rounded-[min(var(--radius-md),8px)] in-data-[slot=button-group]:rounded-md [&_svg:not([class*='size-'])]:size-3",
+        'icon-sm':
+          'size-8 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-md',
+        'icon-lg': 'size-10',
       },
     },
     defaultVariants: {
@@ -31,20 +40,19 @@ const buttonVariants = cva(
   }
 );
 
-export interface ButtonProps
-  extends React.ButtonHTMLAttributes<HTMLButtonElement>,
-    VariantProps<typeof buttonVariants> {
-  asChild?: boolean;
+function Button({
+  className,
+  variant = 'default',
+  size = 'default',
+  ...props
+}: ButtonPrimitive.Props & VariantProps<typeof buttonVariants>) {
+  return (
+    <ButtonPrimitive
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  );
 }
-
-const Button = React.forwardRef<HTMLButtonElement, ButtonProps>(
-  ({ className, variant, size, asChild = false, ...props }, ref) => {
-    const Comp = asChild ? Slot : 'button';
-    return (
-      <Comp className={cn(buttonVariants({ variant, size, className }))} ref={ref} {...props} />
-    );
-  }
-);
-Button.displayName = 'Button';
 
 export { Button, buttonVariants };

--- a/src/renderer/components/ui/dialog.tsx
+++ b/src/renderer/components/ui/dialog.tsx
@@ -1,102 +1,135 @@
+'use client';
+
 import * as React from 'react';
-import * as DialogPrimitive from '@radix-ui/react-dialog';
-import { X } from 'lucide-react';
+import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 
 import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { XIcon } from 'lucide-react';
 
-const Dialog = DialogPrimitive.Root;
+function Dialog({ ...props }: DialogPrimitive.Root.Props) {
+  return <DialogPrimitive.Root data-slot="dialog" {...props} />;
+}
 
-const DialogTrigger = DialogPrimitive.Trigger;
+function DialogTrigger({ ...props }: DialogPrimitive.Trigger.Props) {
+  return <DialogPrimitive.Trigger data-slot="dialog-trigger" {...props} />;
+}
 
-const DialogPortal = DialogPrimitive.Portal;
+function DialogPortal({ ...props }: DialogPrimitive.Portal.Props) {
+  return <DialogPrimitive.Portal data-slot="dialog-portal" {...props} />;
+}
 
-const DialogClose = DialogPrimitive.Close;
+function DialogClose({ ...props }: DialogPrimitive.Close.Props) {
+  return <DialogPrimitive.Close data-slot="dialog-close" {...props} />;
+}
 
-const DialogOverlay = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Overlay>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Overlay
-    ref={ref}
-    className={cn(
-      'fixed inset-0 z-[998] bg-black/50 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
-      className
-    )}
-    {...props}
-  />
-));
-DialogOverlay.displayName = DialogPrimitive.Overlay.displayName;
-
-const DialogContent = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
->(({ className, children, ...props }, ref) => (
-  <DialogPortal>
-    <DialogOverlay />
-    <DialogPrimitive.Content
-      ref={ref}
+function DialogOverlay({ className, ...props }: DialogPrimitive.Backdrop.Props) {
+  return (
+    <DialogPrimitive.Backdrop
+      data-slot="dialog-overlay"
       className={cn(
-        'fixed left-[50%] top-[50%] z-[999] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 overflow-hidden border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
+        'supports-backdrop-filter:backdrop-blur-xs data-open:animate-in data-open:fade-in-0 data-closed:animate-out data-closed:fade-out-0 fixed inset-0 isolate z-50 bg-black/10 duration-100',
         className
       )}
       {...props}
+    />
+  );
+}
+
+function DialogContent({
+  className,
+  children,
+  showCloseButton = true,
+  ...props
+}: DialogPrimitive.Popup.Props & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <DialogPortal>
+      <DialogOverlay />
+      <DialogPrimitive.Popup
+        data-slot="dialog-content"
+        className={cn(
+          'data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 fixed left-1/2 top-1/2 z-50 grid w-full max-w-[calc(100%-2rem)] -translate-x-1/2 -translate-y-1/2 gap-6 rounded-xl bg-background p-6 text-sm outline-none ring-1 ring-foreground/10 duration-100 sm:max-w-md',
+          className
+        )}
+        {...props}
+      >
+        {children}
+        {showCloseButton && (
+          <DialogPrimitive.Close
+            data-slot="dialog-close"
+            render={<Button variant="ghost" className="absolute right-4 top-4" size="icon-sm" />}
+          >
+            <XIcon />
+            <span className="sr-only">Close</span>
+          </DialogPrimitive.Close>
+        )}
+      </DialogPrimitive.Popup>
+    </DialogPortal>
+  );
+}
+
+function DialogHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div data-slot="dialog-header" className={cn('flex flex-col gap-2', className)} {...props} />
+  );
+}
+
+function DialogFooter({
+  className,
+  showCloseButton = false,
+  children,
+  ...props
+}: React.ComponentProps<'div'> & {
+  showCloseButton?: boolean;
+}) {
+  return (
+    <div
+      data-slot="dialog-footer"
+      className={cn('flex flex-col-reverse gap-2 sm:flex-row sm:justify-end', className)}
+      {...props}
     >
       {children}
-      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
-        <X className="h-4 w-4" />
-        <span className="sr-only">Close</span>
-      </DialogPrimitive.Close>
-    </DialogPrimitive.Content>
-  </DialogPortal>
-));
-DialogContent.displayName = DialogPrimitive.Content.displayName;
+      {showCloseButton && (
+        <DialogPrimitive.Close render={<Button variant="outline" />}>Close</DialogPrimitive.Close>
+      )}
+    </div>
+  );
+}
 
-const DialogHeader = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div className={cn('flex flex-col space-y-1.5 text-center sm:text-left', className)} {...props} />
-);
-DialogHeader.displayName = 'DialogHeader';
+function DialogTitle({ className, ...props }: DialogPrimitive.Title.Props) {
+  return (
+    <DialogPrimitive.Title
+      data-slot="dialog-title"
+      className={cn('font-medium leading-none', className)}
+      {...props}
+    />
+  );
+}
 
-const DialogFooter = ({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) => (
-  <div
-    className={cn('flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2', className)}
-    {...props}
-  />
-);
-DialogFooter.displayName = 'DialogFooter';
-
-const DialogTitle = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Title>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Title
-    ref={ref}
-    className={cn('text-lg font-semibold leading-none tracking-tight', className)}
-    {...props}
-  />
-));
-DialogTitle.displayName = DialogPrimitive.Title.displayName;
-
-const DialogDescription = React.forwardRef<
-  React.ElementRef<typeof DialogPrimitive.Description>,
-  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
->(({ className, ...props }, ref) => (
-  <DialogPrimitive.Description
-    ref={ref}
-    className={cn('text-sm text-muted-foreground', className)}
-    {...props}
-  />
-));
-DialogDescription.displayName = DialogPrimitive.Description.displayName;
+function DialogDescription({ className, ...props }: DialogPrimitive.Description.Props) {
+  return (
+    <DialogPrimitive.Description
+      data-slot="dialog-description"
+      className={cn(
+        '*:[a]:underline *:[a]:underline-offset-3 *:[a]:hover:text-foreground text-sm text-muted-foreground',
+        className
+      )}
+      {...props}
+    />
+  );
+}
 
 export {
   Dialog,
-  DialogPortal,
-  DialogOverlay,
-  DialogTrigger,
   DialogClose,
   DialogContent,
-  DialogHeader,
-  DialogFooter,
-  DialogTitle,
   DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogOverlay,
+  DialogPortal,
+  DialogTitle,
+  DialogTrigger,
 };

--- a/src/renderer/components/ui/popover.tsx
+++ b/src/renderer/components/ui/popover.tsx
@@ -1,32 +1,75 @@
 import * as React from 'react';
-import * as PopoverPrimitive from '@radix-ui/react-popover';
+import { Popover as PopoverPrimitive } from '@base-ui/react/popover';
 
 import { cn } from '@/lib/utils';
 
-const Popover = PopoverPrimitive.Root;
+function Popover({ ...props }: PopoverPrimitive.Root.Props) {
+  return <PopoverPrimitive.Root data-slot="popover" {...props} />;
+}
 
-const PopoverTrigger = PopoverPrimitive.Trigger;
+function PopoverTrigger({ ...props }: PopoverPrimitive.Trigger.Props) {
+  return <PopoverPrimitive.Trigger data-slot="popover-trigger" {...props} />;
+}
 
-const PopoverAnchor = PopoverPrimitive.Anchor;
+function PopoverContent({
+  className,
+  align = 'center',
+  alignOffset = 0,
+  side = 'bottom',
+  sideOffset = 4,
+  ...props
+}: PopoverPrimitive.Popup.Props &
+  Pick<PopoverPrimitive.Positioner.Props, 'align' | 'alignOffset' | 'side' | 'sideOffset'>) {
+  return (
+    <PopoverPrimitive.Portal>
+      <PopoverPrimitive.Positioner
+        align={align}
+        alignOffset={alignOffset}
+        side={side}
+        sideOffset={sideOffset}
+        className="isolate z-50"
+      >
+        <PopoverPrimitive.Popup
+          data-slot="popover-content"
+          className={cn(
+            'origin-(--transform-origin) outline-hidden data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 z-50 flex w-72 flex-col gap-4 rounded-md bg-popover p-4 text-sm text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
+            className
+          )}
+          {...props}
+        />
+      </PopoverPrimitive.Positioner>
+    </PopoverPrimitive.Portal>
+  );
+}
 
-const PopoverContent = React.forwardRef<
-  React.ElementRef<typeof PopoverPrimitive.Content>,
-  React.ComponentPropsWithoutRef<typeof PopoverPrimitive.Content>
->(({ className, align = 'center', sideOffset = 4, ...props }, ref) => (
-  <PopoverPrimitive.Portal>
-    <PopoverPrimitive.Content
-      ref={ref}
-      align={align}
-      sideOffset={sideOffset}
-      className={cn(
-        'relative z-[9999] w-72 origin-[--radix-popover-content-transform-origin] overflow-hidden rounded-md border bg-popover text-popover-foreground shadow-md outline-none data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2',
-        className
-      )}
-      style={{ zIndex: 9999 }}
+function PopoverHeader({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="popover-header"
+      className={cn('flex flex-col gap-1 text-sm', className)}
       {...props}
     />
-  </PopoverPrimitive.Portal>
-));
-PopoverContent.displayName = PopoverPrimitive.Content.displayName;
+  );
+}
 
-export { Popover, PopoverTrigger, PopoverContent, PopoverAnchor };
+function PopoverTitle({ className, ...props }: PopoverPrimitive.Title.Props) {
+  return (
+    <PopoverPrimitive.Title
+      data-slot="popover-title"
+      className={cn('font-medium', className)}
+      {...props}
+    />
+  );
+}
+
+function PopoverDescription({ className, ...props }: PopoverPrimitive.Description.Props) {
+  return (
+    <PopoverPrimitive.Description
+      data-slot="popover-description"
+      className={cn('text-muted-foreground', className)}
+      {...props}
+    />
+  );
+}
+
+export { Popover, PopoverContent, PopoverDescription, PopoverHeader, PopoverTitle, PopoverTrigger };

--- a/src/renderer/contexts/ModalProvider.tsx
+++ b/src/renderer/contexts/ModalProvider.tsx
@@ -1,4 +1,12 @@
-import { createContext, ReactNode, useCallback, useContext, useRef, useState } from 'react';
+import {
+  createContext,
+  ReactNode,
+  useCallback,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
 import { CloneFromUrlModal } from '@/components/CloneFromUrlModal';
 import { NewProjectModal } from '@/components/NewProjectModal';
 import { UpdateModalOverlay } from '@/components/UpdateModal';
@@ -42,13 +50,18 @@ type ModalContext = {
   renderModal: () => ReactNode;
   closeModal: () => void;
   showModal: <TId extends ModalId>(modal: TId, args: UserArgs<TId>) => void;
+  canClose: boolean;
+  setCloseBlocked: (blocked: boolean) => void;
 };
 
 const ModalContext = createContext<ModalContext | undefined>(undefined);
 
 export function ModalProvider({ children }: { children: ReactNode }) {
   const [activeModalId, setActiveModalId] = useState<ModalId | null>(null);
+  const [canClose, setCanClose] = useState<boolean>(true);
   const activeModalArgs = useRef<ModalArgs<ModalId> | null>(null);
+
+  const setCloseBlocked = (blocked: boolean) => setCanClose(!blocked);
 
   const renderModal = useCallback((): ReactNode => {
     if (!activeModalId || !activeModalArgs.current) return null;
@@ -97,6 +110,8 @@ export function ModalProvider({ children }: { children: ReactNode }) {
         renderModal: renderModal,
         closeModal: closeModal,
         showModal: showModal,
+        setCloseBlocked: setCloseBlocked,
+        canClose: canClose,
       }}
     >
       {children}
@@ -115,4 +130,12 @@ export function useModalContext() {
 export function useShowModal<MId extends ModalId>(id: MId) {
   const { showModal } = useModalContext();
   return (args: UserArgs<MId>) => showModal(id, args);
+}
+
+export function useModalCloseGuard(shouldBlock: boolean) {
+  const { setCloseBlocked } = useModalContext();
+  useEffect(() => {
+    setCloseBlocked(shouldBlock);
+    return () => setCloseBlocked(false);
+  }, [shouldBlock, setCloseBlocked]);
 }


### PR DESCRIPTION
Some of the newer shadCN components depend on BaseUI (combobox for instance) when using some BaseUI components together with some radix components some compatibility issues can arise