### PR TITLE
feat(terminal): map Cmd+Backspace to kill-line on macOS

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -13,7 +13,9 @@ import { pendingInjectionManager } from '../lib/PendingInjectionManager';
 import { getProvider, type ProviderId } from '@shared/providers/registry';
 import {
   CTRL_J_ASCII,
+  CTRL_U_ASCII,
   shouldCopySelectionFromTerminal,
+  shouldKillLineFromTerminal,
   shouldMapShiftEnterToCtrlJ,
   shouldPasteToTerminal,
 } from './terminalKeybindings';
@@ -300,6 +302,14 @@ export class TerminalSessionManager {
         // Pass true to skip injection handling - this is a newline insert, not a submit
         this.handleTerminalInput(CTRL_J_ASCII, true);
         return false; // Prevent xterm from processing the Shift+Enter
+      }
+
+      if (shouldKillLineFromTerminal(event, IS_MAC_PLATFORM)) {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        event.stopPropagation();
+        this.handleTerminalInput(CTRL_U_ASCII, true);
+        return false;
       }
 
       // Map Cmd+Left/Right to Ctrl+A/E on macOS (line navigation)

--- a/src/renderer/terminal/terminalKeybindings.ts
+++ b/src/renderer/terminal/terminalKeybindings.ts
@@ -10,6 +10,9 @@ export type KeyEventLike = {
 // Ctrl+J sends line feed (LF) to the PTY, which CLI agents interpret as a newline
 export const CTRL_J_ASCII = '\x0A';
 
+// Ctrl+U (unix-line-discard) kills from cursor to beginning of line
+export const CTRL_U_ASCII = '\x15';
+
 export function shouldMapShiftEnterToCtrlJ(event: KeyEventLike): boolean {
   return (
     event.type === 'keydown' &&
@@ -44,6 +47,22 @@ export function shouldCopySelectionFromTerminal(
   }
 
   return ctrl && !meta && !shift && !alt;
+}
+
+/**
+ * Detect Cmd+Backspace on macOS for "kill to beginning of line".
+ * We send Ctrl+U (\x15) to the PTY, which readline-compatible shells
+ * and most CLI agents interpret as unix-line-discard.
+ *
+ * Only intercepted on macOS — on Linux/Windows, Ctrl+U already reaches
+ * the PTY natively for the same effect.
+ */
+export function shouldKillLineFromTerminal(event: KeyEventLike, isMacPlatform: boolean): boolean {
+  if (!isMacPlatform) return false;
+  if (event.type !== 'keydown') return false;
+  if (event.key !== 'Backspace') return false;
+
+  return event.metaKey === true && !event.ctrlKey && !event.shiftKey && !event.altKey;
 }
 
 /**

--- a/src/test/renderer/terminalKeybindings.test.ts
+++ b/src/test/renderer/terminalKeybindings.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from 'vitest';
 import {
   CTRL_J_ASCII,
+  CTRL_U_ASCII,
   shouldCopySelectionFromTerminal,
+  shouldKillLineFromTerminal,
   shouldMapShiftEnterToCtrlJ,
   shouldPasteToTerminal,
   type KeyEventLike,
@@ -136,6 +138,60 @@ describe('TerminalSessionManager - Shift+Enter to Ctrl+J mapping', () => {
       shouldPasteToTerminal(
         makeEvent({ type: 'keyup', key: 'v', ctrlKey: true, shiftKey: true }),
         isNotMac
+      )
+    ).toBe(false);
+  });
+
+  it('uses Ctrl+U for kill-line', () => {
+    expect(CTRL_U_ASCII).toBe('\x15');
+  });
+
+  it('detects Cmd+Backspace on macOS only', () => {
+    const isMac = true;
+    const isNotMac = false;
+
+    // Cmd+Backspace on macOS should trigger
+    expect(shouldKillLineFromTerminal(makeEvent({ key: 'Backspace', metaKey: true }), isMac)).toBe(
+      true
+    );
+
+    // Cmd+Backspace on Linux/Windows should NOT trigger
+    expect(
+      shouldKillLineFromTerminal(makeEvent({ key: 'Backspace', metaKey: true }), isNotMac)
+    ).toBe(false);
+
+    // Ctrl+Backspace should NOT trigger on any platform
+    expect(shouldKillLineFromTerminal(makeEvent({ key: 'Backspace', ctrlKey: true }), isMac)).toBe(
+      false
+    );
+    expect(
+      shouldKillLineFromTerminal(makeEvent({ key: 'Backspace', ctrlKey: true }), isNotMac)
+    ).toBe(false);
+
+    // Additional modifiers should NOT trigger
+    expect(
+      shouldKillLineFromTerminal(
+        makeEvent({ key: 'Backspace', metaKey: true, shiftKey: true }),
+        isMac
+      )
+    ).toBe(false);
+    expect(
+      shouldKillLineFromTerminal(
+        makeEvent({ key: 'Backspace', metaKey: true, altKey: true }),
+        isMac
+      )
+    ).toBe(false);
+
+    // Wrong key should NOT trigger
+    expect(shouldKillLineFromTerminal(makeEvent({ key: 'Delete', metaKey: true }), isMac)).toBe(
+      false
+    );
+
+    // keyup should NOT trigger
+    expect(
+      shouldKillLineFromTerminal(
+        makeEvent({ type: 'keyup', key: 'Backspace', metaKey: true }),
+        isMac
       )
     ).toBe(false);
   });


### PR DESCRIPTION
summary:
- cmd + backspace is no recognized by xterm.js

changes:
- intercept cmd+ backspace in the terminal and send \x15 (Ctrl+U / unix-line-discard) to the PTY
- macos only, on linux/windows Ctrl+U already reaches the PTY natively