### PR TITLE
feat(menu): add reload and force reload to View menu

### DIFF
--- a/src/main/app/menu.ts
+++ b/src/main/app/menu.ts
@@ -101,6 +101,8 @@ export function setupApplicationMenu(): void {
     {
       label: 'View',
       submenu: [
+        { role: 'reload' as const },
+        { role: 'forceReload' as const },
         { role: 'toggleDevTools' as const },
         { type: 'separator' as const },
         { role: 'resetZoom' as const },


### PR DESCRIPTION
## Summary

Adds `Reload` and `Force Reload` menu items to the View menu, restoring standard Electron menu entries that allow users to refresh the renderer process.

## Changes

- Added `reload` and `forceReload` role entries to the View submenu in `src/main/app/menu.ts`

## Test plan

- Launch the app and verify the View menu shows "Reload" and "Force Reload" entries above "Toggle Developer Tools"
- Confirm the keyboard shortcuts (Cmd+R / Cmd+Shift+R on macOS, Ctrl+R / Ctrl+Shift+R on other platforms) work as expected