### PR TITLE
fix(pty): fish shell --session-id parsing error

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1092,14 +1092,13 @@ export async function startPty(options: {
             args.push(cFlag, `${shellSetup}; exec ${resumeShell}`);
           }
         } else {
-          args.push(
-            baseLower === 'zsh' ||
-              baseLower === 'bash' ||
-              baseLower === 'fish' ||
-              baseLower === 'sh'
-              ? '-il'
-              : '-i'
-          );
+          if (baseLower === 'fish') {
+            args.push('-i', '-l');
+          } else {
+            args.push(
+              baseLower === 'zsh' || baseLower === 'bash' || baseLower === 'sh' ? '-il' : '-i'
+            );
+          }
         }
       }
     } catch {}


### PR DESCRIPTION
## Summary
- Split combined `-ic` flag into separate `-l`, `-i`, `-c` argv elements when spawning fish as the shell wrapper for agent CLIs
- Adds the previously-missing `-l` (login) flag for fish, matching bash/zsh behavior, so user PATH config is loaded and agent CLIs can be found
- Also fixes the resume shell (`exec fish -il` → `exec fish -i -l`) to avoid the same combined-flag ambiguity

## Context
When `startDirectPty` fails (e.g. CLI path not cached in packaged builds), the fallback spawns the user's default shell with a `-c` command string. For fish users, the combined `-ic` flag could be misparsed, causing `--session-id` to be interpreted as a fish option rather than part of the command string passed to `-c`.

Fixes #1143

## Test plan
- [x] `pnpm run type-check` passes
- [x] `pnpm exec vitest run` — all 329 tests pass
- [x] `pnpm run lint` passes
- [x] `pnpm run format` clean

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to how PTYs are spawned for `fish`, adjusting argv flags and resume `exec` behavior; main risk is regression in shell startup/arg parsing for fish users.
> 
> **Overview**
> Fixes PTY spawning for `fish` by **splitting combined `-ic`/`-il` flags into separate argv elements** and ensuring `fish` is started in *login + interactive* mode.
> 
> This prevents `fish` from mis-parsing provider CLI arguments (e.g., treating `--session-id` as a shell option) when running provider commands via `-c`, and keeps the post-provider `exec` back into the user’s shell consistent with the updated flag handling.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit daa4958e99a4c4d1542ca49745beb1d4a373575a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->