### PR TITLE
feat: add Kiro IDE to open-in-apps registry

### DIFF
--- a/src/shared/openInApps.ts
+++ b/src/shared/openInApps.ts
@@ -37,6 +37,7 @@ const ICON_PATHS = {
   webstorm: 'webstorm.svg',
   pycharm: 'pycharm.svg',
   rustrover: 'rustrover.svg',
+  kiro: 'kiro.png',
 } as const;
 
 export const OPEN_IN_APPS: OpenInAppConfigShape[] = [
@@ -192,6 +193,31 @@ export const OPEN_IN_APPS: OpenInAppConfigShape[] = [
       linux: {
         openCommands: ['zed {{path}}', 'xdg-open {{path}}'],
         checkCommands: ['zed'],
+      },
+    },
+  },
+  {
+    id: 'kiro',
+    label: 'Kiro',
+    iconPath: ICON_PATHS.kiro,
+    autoInstall: true,
+    platforms: {
+      darwin: {
+        openCommands: [
+          'command -v kiro >/dev/null 2>&1 && kiro {{path}}',
+          'open -a "Kiro" {{path}}',
+        ],
+        checkCommands: ['kiro'],
+        bundleIds: ['dev.kiro.desktop'],
+        appNames: ['Kiro'],
+      },
+      win32: {
+        openCommands: ['start "" kiro {{path}}'],
+        checkCommands: ['kiro'],
+      },
+      linux: {
+        openCommands: ['kiro {{path}}'],
+        checkCommands: ['kiro'],
       },
     },
   },


### PR DESCRIPTION
## Summary

- Add Kiro IDE as a new "Open In" app option with cross-platform support (macOS, Windows, Linux)
- Includes CLI detection via `kiro` command, macOS bundle ID (`dev.kiro.desktop`), and app name detection
- Configured with `autoInstall: true` for automatic CLI installation prompts

## Changes

- Added `kiro` icon path to `ICON_PATHS`
- Added full `Kiro` entry to `OPEN_IN_APPS` array with platform configs:
  - **macOS**: CLI fallback + `open -a` command, bundle ID and app name detection
  - **Windows**: `start` command with CLI
  - **Linux**: Direct CLI invocation

<!-- emdash-issue-footer:start -->
Fixes GEN-482
<!-- emdash-issue-footer:end -->