### PR TITLE
refactor(GitService): make getStatus faster

### DIFF
--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -119,6 +119,18 @@ export async function getStatus(taskPath: string): Promise<GitChange[]> {
   // Batch: run ONE staged numstat and ONE unstaged numstat for ALL files at once and parse the file
   // into a map of file paths to their additions and deletions
   // Map { filePath: { add: number, del: number } }
+  // Resolve git's rename notation to the new (destination) file path.
+  // Formats: "old.ts => new.ts" or "src/{Old => New}.tsx"
+  const resolveRenamePath = (file: string): string => {
+    if (!file.includes(' => ')) return file;
+    // In-place rename with braces: "src/{Old => New}.tsx"
+    if (file.includes('{')) {
+      return file.replace(/\{[^}]+ => ([^}]+)\}/g, '$1').replace(/\/\//g, '/');
+    }
+    // Full rename: "old.ts => new.ts"
+    return file.split(' => ').pop()!.trim();
+  };
+
   const parseNumstatMap = (stdout: string): Map<string, { add: number; del: number }> => {
     const map = new Map<string, { add: number; del: number }>();
     if (!stdout || !stdout.trim()) return map;
@@ -128,7 +140,7 @@ export async function getStatus(taskPath: string): Promise<GitChange[]> {
       if (parts.length >= 3) {
         const add = parts[0] === '-' ? 0 : parseInt(parts[0], 10) || 0;
         const del = parts[1] === '-' ? 0 : parseInt(parts[1], 10) || 0;
-        const file = parts.slice(2).join('\t');
+        const file = resolveRenamePath(parts.slice(2).join('\t'));
         const existing = map.get(file);
         if (existing) {
           existing.add += add;


### PR DESCRIPTION
## Problem

  `getStatus()` spawns 2 `git diff --numstat` processes per file in a sequential loop. 100 files = 200 process
  spawns, blocking the main thread.

  ## Fix
 #1264 
  Run 2 total `git diff --numstat` calls (staged + unstaged) for all files at once via `Promise.all()`, parse output
   into a Map, then look up per file in O(1).

  ## Benchmark

  | Changed files | Before | After | Speedup |
  |--------------|--------|-------|---------|
  | 10           | 306ms  | 41ms  | 7.5x   |
  | 25           | 660ms  | 41ms  | 16x    |
  | 50           | 1,319ms| 41ms  | 32x    |
  | 100          | 2,771ms| 41ms  | 67x    |

  O(n) → O(1). All 391 tests pass.
  
  
Old - 

https://github.com/user-attachments/assets/e267d03e-2f83-4efb-8147-62c69bbb84a0



New - 

https://github.com/user-attachments/assets/2b764e17-bef4-4ce0-8839-fca3203365d0

