### PR TITLE
fix(ssh): use file selector for SSH private key path

### DIFF
--- a/src/main/ipc/projectIpc.ts
+++ b/src/main/ipc/projectIpc.ts
@@ -82,6 +82,29 @@ export function registerProjectIpc() {
     }
   });
 
+  ipcMain.handle(
+    'project:openFile',
+    async (_, args?: { title?: string; message?: string; filters?: Electron.FileFilter[] }) => {
+      try {
+        const result = await dialog.showOpenDialog(getMainWindow()!, {
+          title: args?.title || 'Select File',
+          properties: ['openFile'],
+          message: args?.message || 'Select a file',
+          filters: args?.filters,
+        });
+
+        if (result.canceled || result.filePaths.length === 0) {
+          return { success: false, error: 'No file selected' };
+        }
+
+        return { success: true, path: result.filePaths[0] };
+      } catch (error) {
+        console.error('Failed to open file dialog:', error);
+        return { success: false, error: 'Failed to open file selector' };
+      }
+    }
+  );
+
   ipcMain.handle('git:getInfo', async (_, projectPath: string) => {
     try {
       const resolveRealPath = async (target: string) => {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -309,6 +309,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Project management
   openProject: () => ipcRenderer.invoke('project:open'),
+  openFile: (args?: { title?: string; message?: string; filters?: Electron.FileFilter[] }) =>
+    ipcRenderer.invoke('project:openFile', args),
   getProjectSettings: (projectId: string) =>
     ipcRenderer.invoke('projectSettings:get', { projectId }),
   updateProjectSettings: (args: { projectId: string; baseRef: string }) =>

--- a/src/renderer/components/ssh/AddRemoteProjectModal.tsx
+++ b/src/renderer/components/ssh/AddRemoteProjectModal.tsx
@@ -1111,7 +1111,10 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
                       variant="outline"
                       onClick={async () => {
                         try {
-                          const result = await window.electronAPI.openProject();
+                          const result = await window.electronAPI.openFile({
+                            title: 'Select SSH Private Key',
+                            message: 'Select your SSH private key file',
+                          });
                           if (result.success && result.path) {
                             updateField('privateKeyPath', result.path);
                           }

--- a/src/renderer/components/ssh/SshConnectionForm.tsx
+++ b/src/renderer/components/ssh/SshConnectionForm.tsx
@@ -206,7 +206,10 @@ export const SshConnectionForm: React.FC<Props> = ({
 
   const handleSelectKeyFile = useCallback(async () => {
     try {
-      const result = await window.electronAPI.openProject();
+      const result = await window.electronAPI.openFile({
+        title: 'Select SSH Private Key',
+        message: 'Select your SSH private key file',
+      });
       if (result.success && result.path) {
         handleChange('privateKeyPath', result.path);
       }

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -301,6 +301,15 @@ declare global {
         path?: string;
         error?: string;
       }>;
+      openFile: (args?: {
+        title?: string;
+        message?: string;
+        filters?: Electron.FileFilter[];
+      }) => Promise<{
+        success: boolean;
+        path?: string;
+        error?: string;
+      }>;
       getProjectSettings: (projectId: string) => Promise<{
         success: boolean;
         settings?: ProjectSettingsPayload;
@@ -1312,6 +1321,15 @@ export interface ElectronAPI {
 
   // Project management
   openProject: () => Promise<{
+    success: boolean;
+    path?: string;
+    error?: string;
+  }>;
+  openFile: (args?: {
+    title?: string;
+    message?: string;
+    filters?: Electron.FileFilter[];
+  }) => Promise<{
     success: boolean;
     path?: string;
     error?: string;


### PR DESCRIPTION
## Summary

The Browse button for selecting SSH private key was incorrectly using `openProject()` which opens a directory selector. Added a new `openFile()` IPC method that properly opens a file selector dialog.

## Changes

- Added `project:openFile` IPC handler in `projectIpc.ts` with `properties: ['openFile']`
- Exposed `openFile` method in `preload.ts`
- Added type declarations in `electron-api.d.ts`
- Updated `AddRemoteProjectModal.tsx` and `SshConnectionForm.tsx` to use `openFile()` instead of `openProject()`

## Testing

1. Click Create New Project button
2. Select Remote Project
3. Fill in SSH config and continue
4. In authentication form, select SSH Key method
5. Click Browse button
6. ✅ File selector opens (not directory selector)

Fixes #1267