### PR TITLE
feat(ui): always show changes button in file changes panel top bar

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -329,7 +329,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
   return (
     <div className={`flex h-full flex-col bg-card shadow-sm ${className}`}>
       <div className="bg-muted px-3 py-2">
-        <div className="flex w-full items-center justify-between gap-2">
+        <div className="flex w-full flex-wrap items-center justify-between gap-2">
           <div className="flex shrink-0 items-center gap-1 text-xs">
             {hasChanges ? (
               <>


### PR DESCRIPTION
summary:
- the Changes button (opens diff viewer) only rendered when there were file changes
- since the diff viewer now also provides access to history, it should always be accessible

changes:
- unified the two separate top-bar layouts in FileChangesPanel.tsx into one consistent layout
- changes button renders unconditionally, no longer gated behind hasChanges
- empty state shows emdashes in green/red (— · —) instead of a static "Changes" text label
- all PR logic (create, draft, view, merge) unchanged