### PR TITLE
fix(pty): pass XDG_DATA_DIRS to PTY sessions for correct default browser

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -101,6 +101,7 @@ const DISPLAY_ENV_VARS = [
   'XDG_RUNTIME_DIR', // Contains Wayland/D-Bus sockets (e.g. /run/user/1000)
   'XDG_CURRENT_DESKTOP', // Used by xdg-open for DE detection (e.g. "GNOME")
   'XDG_SESSION_TYPE', // Used by browsers/toolkits to select X11 vs Wayland
+  'XDG_DATA_DIRS', // .desktop file search paths; includes snap/flatpak dirs set by session
   'DBUS_SESSION_BUS_ADDRESS', // Needed by gio open and desktop portals
 ] as const;
 


### PR DESCRIPTION
summary:
- on linux gh pr view -w (or any xdg-open call) inside the emdash terminal opens the wrong browser 
- the PTY environment is missing XDG_DATA_DIRS
- clicking links in the emdash UI works fine because shell.openExternal runs in the main process which has the full desktop session env

fix:
- added XDG_DATA_DIRS to DISPLAY_ENV_VARS in ptyManager.ts, which is already passed through to all three PTY spawn paths

limits:
- needs verification, could not test 

fixes #1279 