### PR TITLE
fix(ui): add padding to terminal pane container

### DIFF
--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -261,6 +261,7 @@ const TerminalPaneComponent = forwardRef<{ focus: () => void }, Props>(
           width: '100%',
           height: '100%',
           minHeight: 0,
+          padding: '4px 8px 8px 8px',
           backgroundColor: variant === 'light' ? '#ffffff' : themeOverride?.background || '#1f2937',
           boxSizing: 'border-box',
         }}


### PR DESCRIPTION
## Summary

Adds `padding: 4px 8px 8px 8px` to the terminal pane's outer container to prevent terminal content from being clipped against the bottom and right edges.

## Changes

- Added padding (`4px` top, `8px` right, `8px` bottom, `8px` left) to the terminal pane wrapper `div` in `TerminalPane.tsx`

## Test plan

- [ ] Verify terminal content has visible spacing from the bottom and right edges
- [ ] Confirm no text clipping or overflow issues in the terminal
- [ ] Check terminal resize behavior still works correctly with the added padding

<!-- emdash-issue-footer:start -->
Fixes #1286
<!-- emdash-issue-footer:end -->