### PR TITLE
feat(ssh): enable hook notifications for remote sessions

### DIFF
--- a/src/main/services/ClaudeHookService.ts
+++ b/src/main/services/ClaudeHookService.ts
@@ -23,31 +23,14 @@ export class ClaudeHookService {
     );
   }
 
-  static writeHookConfig(worktreePath: string): void {
-    const claudeDir = path.join(worktreePath, '.claude');
-    const settingsPath = path.join(claudeDir, 'settings.local.json');
-
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    let existing: Record<string, any> = {};
-    try {
-      const content = fs.readFileSync(settingsPath, 'utf-8');
-      existing = JSON.parse(content);
-    } catch {
-      // File doesn't exist or isn't valid JSON — start fresh
-    }
-
-    // Ensure .claude directory exists
-    try {
-      fs.mkdirSync(claudeDir, { recursive: true });
-    } catch {
-      // May already exist
-    }
-
-    // Merge our hook entries alongside any user-defined hooks.
-    // Claude Code hook format: [{ matcher?, hooks: [{ type, command }] }]
-    // We identify our own entries by the EMDASH_HOOK_PORT marker in the
-    // command string, strip them out, then append a fresh one. This is
-    // idempotent across restarts and preserves user hooks.
+  /**
+   * Merge emdash hook entries into an existing settings object.
+   * Strips old emdash entries (identified by the EMDASH_HOOK_PORT marker),
+   * preserves user-defined hooks, and appends fresh Notification + Stop entries.
+   * Returns the mutated object.
+   */
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  static mergeHookEntries(existing: Record<string, any>): Record<string, any> {
     const hooks = existing.hooks || {};
 
     for (const eventType of ['Notification', 'Stop'] as const) {
@@ -64,6 +47,29 @@ export class ClaudeHookService {
     }
 
     existing.hooks = hooks;
+    return existing;
+  }
+
+  static writeHookConfig(worktreePath: string): void {
+    const claudeDir = path.join(worktreePath, '.claude');
+    const settingsPath = path.join(claudeDir, 'settings.local.json');
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    let existing: Record<string, any> = {};
+    try {
+      const content = fs.readFileSync(settingsPath, 'utf-8');
+      existing = JSON.parse(content);
+    } catch {
+      // File doesn't exist or isn't valid JSON — start fresh
+    }
+
+    try {
+      fs.mkdirSync(claudeDir, { recursive: true });
+    } catch {
+      // May already exist
+    }
+
+    ClaudeHookService.mergeHookEntries(existing);
 
     try {
       fs.writeFileSync(settingsPath, JSON.stringify(existing, null, 2) + '\n');

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -143,23 +143,7 @@ async function writeRemoteHookConfig(
     // File doesn't exist, isn't valid JSON, or ssh failed — start fresh
   }
 
-  // Merge hook entries: strip old emdash entries (identified by
-  // EMDASH_HOOK_PORT marker), then append fresh ones.  Preserves
-  // user-defined hooks and all other settings.
-  const hooks = existing.hooks || {};
-  for (const eventType of ['Notification', 'Stop'] as const) {
-    const prev: unknown[] = Array.isArray(hooks[eventType]) ? hooks[eventType] : [];
-    const userEntries = prev.filter(
-      (entry: any) => !JSON.stringify(entry).includes('EMDASH_HOOK_PORT')
-    );
-    userEntries.push({
-      hooks: [
-        { type: 'command', command: ClaudeHookService.makeHookCommand(eventType.toLowerCase()) },
-      ],
-    });
-    hooks[eventType] = userEntries;
-  }
-  existing.hooks = hooks;
+  ClaudeHookService.mergeHookEntries(existing);
 
   const json = JSON.stringify(existing, null, 2);
   await execFileAsync('ssh', [

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -225,6 +225,13 @@ vi.mock('../../main/services/ClaudeHookService', () => ({
   ClaudeHookService: {
     writeHookConfig: vi.fn(),
     makeHookCommand: vi.fn((type: string) => `mock-hook-command-${type}`),
+    mergeHookEntries: vi.fn((existing: Record<string, any>) => {
+      existing.hooks = {
+        Notification: [{ hooks: [{ type: 'command', command: 'mock-hook-command-notification' }] }],
+        Stop: [{ hooks: [{ type: 'command', command: 'mock-hook-command-stop' }] }],
+      };
+      return existing;
+    }),
   },
 }));
 


### PR DESCRIPTION
## Summary
- Adds reverse SSH tunnel (`-R` flag) so remote agent sessions can send Notification and Stop hook events back to the local AgentEventService
- Exports `EMDASH_HOOK_PORT`/`EMDASH_HOOK_TOKEN`/`EMDASH_PTY_ID` env vars in the remote shell for hook commands to reference
- Writes Claude's `.claude/settings.local.json` hook config on the remote via SSH exec channel (avoids terminal line-buffer corruption from keystroke injection)
- Makes `ClaudeHookService.makeHookCommand()` public static so it can be reused for remote config generation

## Test plan
- [x] Unit tests for reverse tunnel injection, env var exports, Claude hook config via ssh exec, and non-Claude provider skip
- [x] All 392 tests pass, type-check clean, lint clean
- [x] Manual E2E test: SSH to localhost, created remote Claude task, confirmed notification and completion sounds fire

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds reverse SSH tunneling and remote hook configuration writes, which affects remote session startup and exposes a local hook token/port to the remote environment; failures could break remote agent launch or event delivery.
> 
> **Overview**
> Remote `pty:startDirect` now optionally provisions **hook event callbacks** by adding an `ssh -R` reverse tunnel to the local `AgentEventService` and exporting `EMDASH_HOOK_PORT`/`EMDASH_HOOK_TOKEN`/`EMDASH_PTY_ID` in the remote init keystrokes.
> 
> For Claude remote sessions, the PR writes/merges `.claude/settings.local.json` on the remote via `ssh` exec (read + write) to avoid PTY keystroke corruption, reusing new `ClaudeHookService.mergeHookEntries()` and `ClaudeHookService.makeHookCommand()` extracted from the previous inline logic.
> 
> Unit tests extend `ptyIpc` coverage for reverse-tunnel injection, hook env exports, Claude remote hook config writing, and the no-hook/no-Claude paths.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 024aa3f80fb12d0287889a1978bab2d84526a9f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->