### PR TITLE
fix(sidebar): auto collapse right sidebar on settings and skills views

### DIFF
--- a/src/renderer/hooks/usePanelLayout.ts
+++ b/src/renderer/hooks/usePanelLayout.ts
@@ -14,6 +14,8 @@ export interface UsePanelLayoutOptions {
   showDiffViewer: boolean;
   isInitialLoadComplete: boolean;
   showHomeView: boolean;
+  showSettingsPage: boolean;
+  showSkillsView: boolean;
   selectedProject: { id: string } | null;
   activeTask: { id: string } | null;
 }
@@ -24,6 +26,8 @@ export function usePanelLayout(opts: UsePanelLayoutOptions) {
     showDiffViewer,
     isInitialLoadComplete,
     showHomeView,
+    showSettingsPage,
+    showSkillsView,
     selectedProject,
     activeTask,
   } = opts;
@@ -248,14 +252,23 @@ export function usePanelLayout(opts: UsePanelLayoutOptions) {
 
     const isHomePage = showHomeView;
     const isRepoHomePage = selectedProject !== null && activeTask === null;
-    const shouldCollapse = isHomePage || isRepoHomePage;
+    const isNonTaskView = showSettingsPage || showSkillsView;
+    const shouldCollapse = isHomePage || isRepoHomePage || isNonTaskView;
 
     if (shouldCollapse) {
       rightSidebarSetCollapsedRef.current?.(true);
     } else if (activeTask !== null) {
       rightSidebarSetCollapsedRef.current?.(false);
     }
-  }, [autoRightSidebarBehavior, isInitialLoadComplete, showHomeView, selectedProject, activeTask]);
+  }, [
+    autoRightSidebarBehavior,
+    isInitialLoadComplete,
+    showHomeView,
+    showSettingsPage,
+    showSkillsView,
+    selectedProject,
+    activeTask,
+  ]);
 
   // Sync right sidebar panel with collapsed state
   useEffect(() => {

--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -246,6 +246,8 @@ export function Workspace() {
     showDiffViewer,
     isInitialLoadComplete: projectMgmt.isInitialLoadComplete,
     showHomeView: projectMgmt.showHomeView,
+    showSettingsPage,
+    showSkillsView: projectMgmt.showSkillsView,
     selectedProject: projectMgmt.selectedProject,
     activeTask: taskMgmt.activeTask,
   });


### PR DESCRIPTION
summary:
- right sidebar auto-collapse only checked for home view and repo home page
- navigating from a task to Settings or Skills left the sidebar open because those views weren't considered non-task views

fix:
- added showSettingsPage and showSkillsView to usePanelLayout options
- shouldCollapse now includes an isNonTaskView check so the sidebar collapses on all non-task views consistently

fixes #1297