### PR TITLE
fix(connections): avoid caching shell path as provider cli

### DIFF
--- a/src/main/services/ConnectionsService.ts
+++ b/src/main/services/ConnectionsService.ts
@@ -258,7 +258,11 @@ class ConnectionsService {
       };
     }
 
-    return { ...result, command };
+    // Never cache the shell binary path as the provider path.
+    // If provider resolution still fails here, keep `resolvedPath` null so
+    // PTY startup falls back to shell-based spawn instead of direct-spawning the shell.
+    const providerResolvedPath = this.resolveCommandPath(command);
+    return { ...result, command, resolvedPath: providerResolvedPath };
   }
 
   private async runCommand(

--- a/src/test/main/ConnectionsService.test.ts
+++ b/src/test/main/ConnectionsService.test.ts
@@ -177,9 +177,36 @@ describe('ConnectionsService – resolveStatus', () => {
     const secondCall = spawnMock.mock.calls[1];
     expect(secondCall).toBeDefined();
     // Should invoke a shell (e.g. /bin/zsh or /bin/bash) with login+interactive flags
-    const shellCmd = secondCall[0] as string;
+    const _shellCmd = secondCall[0] as string;
     const shellArgs = secondCall[1] as string[];
     expect(shellArgs.some((a: string) => a.includes('claude'))).toBe(true);
     expect(shellArgs.some((a: string) => a.includes('-l'))).toBe(true);
+  });
+
+  it('does not cache shell path as provider path after shell fallback success', async () => {
+    const previousShell = process.env.SHELL;
+    process.env.SHELL = '/opt/homebrew/bin/fish';
+
+    execFileSyncMock.mockImplementation((resolver: string, args: string[]) => {
+      if (resolver !== 'which') throw new Error('unexpected resolver');
+      const command = args[0];
+      if (command === '/opt/homebrew/bin/fish') return '/opt/homebrew/bin/fish\n';
+      if (command === 'claude') throw new Error('not found');
+      throw new Error(`unexpected command: ${command}`);
+    });
+
+    const err = new Error('spawn claude ENOENT') as NodeJS.ErrnoException;
+    err.code = 'ENOENT';
+    spawnEmits({ error: err }, { stdout: '2.1.56 (Claude Code)\n', closeCode: 0 });
+
+    try {
+      const { connectionsService } = await import('../../main/services/ConnectionsService');
+      await connectionsService.checkProvider('claude', 'manual');
+    } finally {
+      process.env.SHELL = previousShell;
+    }
+
+    expect(statusMap.claude?.installed).toBe(true);
+    expect(statusMap.claude?.path).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- fix provider detection fallback so we never cache the login shell binary (for example `fish`) as the provider CLI path
- preserve fallback behavior while resolving the real provider command path before caching
- add regression coverage in `ConnectionsService.test.ts` for the fish fallback scenario

## Why
In some fallback detections, the cached path could incorrectly become the shell executable. Later direct PTY startup would run that shell with Claude flags (including `--session-id`), producing `fish: --session-id: unknown option`.

Fixes #1143

## Validation
- `pnpm run format`
- `pnpm run lint` (warnings only)
- `pnpm run type-check`
- `pnpm exec vitest run src/test/main/ConnectionsService.test.ts`
- `pnpm exec vitest run` *(fails in this environment on existing `AgentEventService.test.ts` with `listen EPERM 127.0.0.1`)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches provider detection and caching used to launch CLIs, so mistakes could break provider startup on some environments. Change is small and covered by a new regression test for the shell-fallback scenario.
> 
> **Overview**
> Fixes `ConnectionsService.runCommandViaShell` so a successful shell-fallback detection **does not cache the login shell executable** (e.g. `fish`) as the provider `resolvedPath`; it now re-resolves the actual provider command path (or leaves it `null` to force later shell-based spawning).
> 
> Adds a regression test ensuring that when `SHELL` points to `fish` and the provider is only found via shell fallback, the cached provider `path` remains `null`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit af5123aee7afb520170a18750d804543857902f4. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->