### PR TITLE
fix(sidebar): prevent pinned tasks from clearing before data loads

### DIFF
--- a/src/renderer/components/sidebar/LeftSidebar.tsx
+++ b/src/renderer/components/sidebar/LeftSidebar.tsx
@@ -30,7 +30,6 @@ import { TaskDeleteButton } from '../TaskDeleteButton';
 import { RemoteProjectIndicator } from '../ssh/RemoteProjectIndicator';
 import { useRemoteProject } from '../../hooks/useRemoteProject';
 import type { Project } from '../../types/app';
-import type { Task } from '../../types/chat';
 import type { ConnectionState } from '../ssh';
 import { useProjectManagementContext } from '../../contexts/ProjectManagementProvider';
 import { useTaskManagementContext } from '../../contexts/TaskManagementContext';
@@ -38,7 +37,6 @@ import { useAppSettings } from '../../contexts/AppSettingsProvider';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { ProjectsGroupLabel } from './ProjectsGroupLabel';
 
-const PINNED_TASKS_KEY = 'emdash-pinned-tasks';
 const PROJECT_ORDER_KEY = 'sidebarProjectOrder';
 
 interface LeftSidebarProps {
@@ -135,43 +133,11 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
     handleArchiveTask: onArchiveTask,
     handleRestoreTask: onRestoreTask,
     handleDeleteTask,
-    isTasksLoaded,
+    handlePinTask,
   } = useTaskManagementContext();
 
   const { settings } = useAppSettings();
   const taskHoverAction = settings?.interface?.taskHoverAction ?? 'delete';
-
-  const [pinnedTaskIdsArray, setPinnedTaskIdsArray] = useLocalStorage<string[]>(
-    PINNED_TASKS_KEY,
-    []
-  );
-  const pinnedTaskIds = useMemo(() => new Set(pinnedTaskIdsArray), [pinnedTaskIdsArray]);
-
-  const handlePinTask = useCallback(
-    (task: Task) => {
-      setPinnedTaskIdsArray((prev) =>
-        prev.includes(task.id) ? prev.filter((id) => id !== task.id) : [...prev, task.id]
-      );
-    },
-    [setPinnedTaskIdsArray]
-  );
-
-  // Remove pinned IDs for tasks that no longer exist (deleted or archived).
-  // Guard: skip until task queries have completed their initial load to avoid
-  // wiping pinned IDs before data arrives from the database.
-  useEffect(() => {
-    if (!isTasksLoaded) return;
-    if (!pinnedTaskIdsArray.length) return;
-    const allActiveIds = new Set(
-      Object.values(tasksByProjectId)
-        .flat()
-        .map((t) => t.id)
-    );
-    const cleaned = pinnedTaskIdsArray.filter((id) => allActiveIds.has(id));
-    if (cleaned.length !== pinnedTaskIdsArray.length) {
-      setPinnedTaskIdsArray(cleaned);
-    }
-  }, [isTasksLoaded, tasksByProjectId, pinnedTaskIdsArray, setPinnedTaskIdsArray]);
 
   const [forceOpenIds, setForceOpenIds] = useState<Set<string>>(new Set());
   const prevTaskCountsRef = useRef<Map<string, number>>(new Map());
@@ -322,8 +288,7 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                 .slice()
                                 .sort(
                                   (a, b) =>
-                                    (pinnedTaskIds.has(b.id) ? 1 : 0) -
-                                    (pinnedTaskIds.has(a.id) ? 1 : 0)
+                                    (b.metadata?.isPinned ? 1 : 0) - (a.metadata?.isPinned ? 1 : 0)
                                 )
                                 .map((task) => {
                                   const isActive = activeTask?.id === task.id;
@@ -342,7 +307,7 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                         task={task}
                                         showDelete={true}
                                         showDirectBadge={false}
-                                        isPinned={pinnedTaskIds.has(task.id)}
+                                        isPinned={!!task.metadata?.isPinned}
                                         onPin={() => handlePinTask(task)}
                                         onRename={(n) => onRenameTask?.(typedProject, task, n)}
                                         onDelete={() => handleDeleteTask(typedProject, task)}

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -168,8 +168,6 @@ export function useTaskManagement() {
     })),
   });
 
-  const isTasksLoaded = taskResults.length === 0 || taskResults.every((r) => !r.isPending);
-
   const tasksByProjectId = useMemo(() => {
     const map: Record<string, Task[]> = {};
     projects.forEach((p, i) => {
@@ -971,6 +969,27 @@ export function useTaskManagement() {
     }
   }, [autoOpenTaskModalTrigger, openTaskModal]);
 
+  // ---------------------------------------------------------------------------
+  // Pin / unpin task (persisted in task metadata)
+  // ---------------------------------------------------------------------------
+  const handlePinTask = useCallback(
+    async (task: Task) => {
+      const isPinned = !task.metadata?.isPinned;
+      const updatedMetadata = { ...task.metadata, isPinned: isPinned || null };
+      // Optimistic UI update
+      updateTaskCache(task.projectId, (old) =>
+        old.map((t) => (t.id === task.id ? { ...t, metadata: updatedMetadata } : t))
+      );
+      try {
+        await rpc.db.saveTask({ ...task, metadata: updatedMetadata });
+      } catch {
+        // Rollback on failure
+        queryClient.invalidateQueries({ queryKey: ['tasks', task.projectId] });
+      }
+    },
+    [updateTaskCache, queryClient]
+  );
+
   return {
     activeTask,
     setActiveTask,
@@ -978,7 +997,6 @@ export function useTaskManagement() {
     setActiveTaskAgent,
     allTasks,
     tasksByProjectId,
-    isTasksLoaded,
     archivedTasksByProjectId,
     linkedGithubIssueMap,
     isCreatingTask,
@@ -994,5 +1012,6 @@ export function useTaskManagement() {
     handleRenameTask,
     handleArchiveTask,
     handleRestoreTask,
+    handlePinTask,
   };
 }

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -25,6 +25,8 @@ export interface TaskMetadata {
   nameGenerated?: boolean | null;
   /** Set to true after the initial injection (prompt/issue) has been sent to the agent */
   initialInjectionSent?: boolean | null;
+  /** Whether this task is pinned to the top of the sidebar */
+  isPinned?: boolean | null;
   // When present, this task is a multi-agent task orchestrating multiple worktrees
   multiAgent?: {
     enabled: boolean;


### PR DESCRIPTION
## Summary

- Add `isTasksLoaded` flag to `useTaskManagement` that tracks whether all task queries have completed their initial load
- Guard the pinned-task cleanup effect in `LeftSidebar` with `isTasksLoaded` to prevent wiping pinned task IDs when `tasksByProjectId` is still empty during initial data fetch

## Problem

On app startup, the pinned-task cleanup effect would run before task data arrived from the database, seeing an empty task map and removing all pinned task IDs from localStorage.

<!-- emdash-issue-footer:start -->
Fixes GEN-506
<!-- emdash-issue-footer:end -->