### PR TITLE
feat(tasks): add loading state to task creation button

### DIFF
--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Button } from './ui/button';
+import { Spinner } from './ui/spinner';
 import {
   DialogContent,
   DialogDescription,
@@ -61,16 +62,18 @@ interface TaskModalProps {
     useWorktree?: boolean,
     baseRef?: string,
     nameGenerated?: boolean
-  ) => void;
+  ) => Promise<void>;
 }
 
 export type TaskModalOverlayProps = BaseModalProps<CreateTaskResult>;
 
-export function TaskModalOverlay({ onSuccess, onClose }: TaskModalOverlayProps) {
+export function TaskModalOverlay({ onClose }: TaskModalOverlayProps) {
+  const { handleCreateTask } = useTaskManagementContext();
+
   return (
     <TaskModal
       onClose={onClose}
-      onCreateTask={(
+      onCreateTask={async (
         name,
         initialPrompt,
         agentRuns,
@@ -81,20 +84,20 @@ export function TaskModalOverlay({ onSuccess, onClose }: TaskModalOverlayProps) 
         useWorktree,
         baseRef,
         nameGenerated
-      ) =>
-        onSuccess({
+      ) => {
+        await handleCreateTask(
           name,
           initialPrompt,
           agentRuns,
-          linkedLinearIssue,
-          linkedGithubIssue,
-          linkedJiraIssue,
+          linkedLinearIssue ?? null,
+          linkedGithubIssue ?? null,
+          linkedJiraIssue ?? null,
           autoApprove,
           useWorktree,
           baseRef,
-          nameGenerated,
-        })
-      }
+          nameGenerated
+        );
+      }}
     />
   );
 }
@@ -118,6 +121,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
   const [error, setError] = useState<string | null>(null);
   const [touched, setTouched] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
 
   // Advanced settings state
   const [initialPrompt, setInitialPrompt] = useState('');
@@ -337,13 +341,10 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
     // When the name was auto-generated from context (prompt/issue),
     // it's already descriptive — don't mark it for post-creation rename.
 
-    // Close modal immediately - task creation happens in background
-    // The task will appear in sidebar via optimistic UI update
-    onClose();
+    setIsCreating(true);
 
-    // Fire and forget - don't await
     try {
-      onCreateTask(
+      await onCreateTask(
         finalName,
         hasInitialPromptSupport && initialPrompt.trim() ? initialPrompt.trim() : undefined,
         agentRuns,
@@ -355,8 +356,10 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
         selectedBranch,
         isNameGenerated
       );
+      onClose();
     } catch (error) {
       console.error('Failed to create task:', error);
+      setIsCreating(false);
     }
   };
 
@@ -369,6 +372,12 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
     <DialogContent
       className="max-h-[calc(100vh-48px)] max-w-md overflow-visible"
       onOpenAutoFocus={handleOpenAutoFocus}
+      onInteractOutside={(e) => {
+        if (isCreating) e.preventDefault();
+      }}
+      onEscapeKeyDown={(e) => {
+        if (isCreating) e.preventDefault();
+      }}
     >
       <DialogHeader>
         <DialogTitle>New Task</DialogTitle>
@@ -458,8 +467,15 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
         />
 
         <DialogFooter>
-          <Button type="submit" disabled={!!error}>
-            Create
+          <Button type="submit" disabled={!!error || isCreating} aria-busy={isCreating}>
+            {isCreating ? (
+              <>
+                <Spinner size="sm" className="mr-2" />
+                Creating…
+              </>
+            ) : (
+              'Create'
+            )}
           </Button>
         </DialogFooter>
       </form>

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -897,7 +897,7 @@ export function useTaskManagement() {
   });
 
   const handleCreateTask = useCallback(
-    (
+    async (
       taskName: string,
       initialPrompt?: string,
       agentRuns: AgentRun[] = [{ agent: 'claude', runs: 1 }],
@@ -911,7 +911,7 @@ export function useTaskManagement() {
     ) => {
       if (!selectedProject) return;
       setIsCreatingTask(true);
-      createTaskMutation.mutate({
+      await createTaskMutation.mutateAsync({
         project: selectedProject,
         taskName,
         initialPrompt,
@@ -943,23 +943,9 @@ export function useTaskManagement() {
     };
   }, [isCreatingTask]);
 
-  // Wire up openTaskModal with the latest handleCreateTask
+  // Wire up openTaskModal — TaskModalOverlay calls handleCreateTask via context
   openTaskModalImplRef.current = () => {
-    showModal('taskModal', {
-      onSuccess: (result) =>
-        handleCreateTask(
-          result.name,
-          result.initialPrompt,
-          result.agentRuns,
-          result.linkedLinearIssue ?? null,
-          result.linkedGithubIssue ?? null,
-          result.linkedJiraIssue ?? null,
-          result.autoApprove,
-          result.useWorktree,
-          result.baseRef,
-          result.nameGenerated
-        ),
-    });
+    showModal('taskModal', {});
   };
 
   // Auto-open task modal when project management requests it


### PR DESCRIPTION
## Summary

- Replace fire-and-forget task creation with an awaited flow so the modal stays open until the task is fully created
- Add a spinner and "Creating..." loading state to the submit button while the task is being created
- Prevent dismissing the modal (via outside click or Escape) during creation
- Simplify the modal-to-hook wiring by calling `handleCreateTask` directly via context instead of routing through `onSuccess` callback

## Motivation

Previously the modal closed immediately on submit with task creation happening in the background. This gave no feedback if creation was slow or failed. Now the user sees a clear loading indicator and the modal only closes on success, improving perceived reliability.

## Changes

- `TaskModal.tsx`: Added `isCreating` state, `Spinner` import, awaited `onCreateTask`, disabled button and modal dismissal during creation
- `useTaskManagement.ts`: Changed `handleCreateTask` to `async` with `mutateAsync` so callers can `await` it; removed `onSuccess` indirection from `showModal` call

<!-- emdash-issue-footer:start -->
Fixes GEN-507
<!-- emdash-issue-footer:end -->