### PR TITLE
fix: persist pinned tasks in database across restarts

### DIFF
--- a/drizzle/0010_add_is_pinned_to_tasks.sql
+++ b/drizzle/0010_add_is_pinned_to_tasks.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD COLUMN `is_pinned` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1738857600000,
       "tag": "0009_add_ssh_support",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1738886400000,
+      "tag": "0010_add_is_pinned_to_tasks",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -70,6 +70,7 @@ export const tasks = sqliteTable(
     metadata: text('metadata'),
     useWorktree: integer('use_worktree').notNull().default(1),
     archivedAt: text('archived_at'), // null = active, timestamp = archived
+    isPinned: integer('is_pinned').notNull().default(0),
     createdAt: text('created_at')
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),

--- a/src/main/ipc/dbIpc.ts
+++ b/src/main/ipc/dbIpc.ts
@@ -24,6 +24,9 @@ export const databaseController = createRPCController({
 
   restoreTask: (taskId: string): Promise<void> => databaseService.restoreTask(taskId),
 
+  setTaskPinned: (args: { taskId: string; isPinned: boolean }): Promise<void> =>
+    databaseService.setTaskPinned(args.taskId, args.isPinned),
+
   getArchivedTasks: (projectId?: string): Promise<Task[]> =>
     databaseService.getArchivedTasks(projectId),
 

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -54,6 +54,7 @@ export interface Task {
   metadata?: any;
   useWorktree?: boolean;
   archivedAt?: string | null;
+  isPinned?: boolean;
   createdAt: string;
   updatedAt: string;
 }
@@ -294,6 +295,7 @@ export class DatabaseService {
           ? JSON.stringify(task.metadata)
           : null;
     const { db } = await getDrizzleClient();
+    const isPinned = task.isPinned === true ? 1 : 0;
     await db
       .insert(tasksTable)
       .values({
@@ -306,6 +308,7 @@ export class DatabaseService {
         agentId: task.agentId ?? null,
         metadata: metadataValue,
         useWorktree: task.useWorktree !== false ? 1 : 0,
+        isPinned,
         updatedAt: sql`CURRENT_TIMESTAMP`,
       })
       .onConflictDoUpdate({
@@ -319,6 +322,7 @@ export class DatabaseService {
           agentId: task.agentId ?? null,
           metadata: metadataValue,
           useWorktree: task.useWorktree !== false ? 1 : 0,
+          isPinned,
           updatedAt: sql`CURRENT_TIMESTAMP`,
         },
       });
@@ -383,6 +387,18 @@ export class DatabaseService {
       .update(tasksTable)
       .set({
         archivedAt: null,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(eq(tasksTable.id, taskId));
+  }
+
+  async setTaskPinned(taskId: string, isPinned: boolean): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db
+      .update(tasksTable)
+      .set({
+        isPinned: isPinned ? 1 : 0,
         updatedAt: sql`CURRENT_TIMESTAMP`,
       })
       .where(eq(tasksTable.id, taskId));
@@ -937,6 +953,7 @@ export class DatabaseService {
           : null,
       useWorktree: row.useWorktree === 1,
       archivedAt: row.archivedAt ?? null,
+      isPinned: row.isPinned === 1,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };

--- a/src/renderer/components/sidebar/LeftSidebar.tsx
+++ b/src/renderer/components/sidebar/LeftSidebar.tsx
@@ -38,7 +38,6 @@ import { useAppSettings } from '../../contexts/AppSettingsProvider';
 import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { ProjectsGroupLabel } from './ProjectsGroupLabel';
 
-const PINNED_TASKS_KEY = 'emdash-pinned-tasks';
 const PROJECT_ORDER_KEY = 'sidebarProjectOrder';
 
 interface LeftSidebarProps {
@@ -135,39 +134,11 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
     handleArchiveTask: onArchiveTask,
     handleRestoreTask: onRestoreTask,
     handleDeleteTask,
+    handlePinTask,
   } = useTaskManagementContext();
 
   const { settings } = useAppSettings();
   const taskHoverAction = settings?.interface?.taskHoverAction ?? 'delete';
-
-  const [pinnedTaskIdsArray, setPinnedTaskIdsArray] = useLocalStorage<string[]>(
-    PINNED_TASKS_KEY,
-    []
-  );
-  const pinnedTaskIds = useMemo(() => new Set(pinnedTaskIdsArray), [pinnedTaskIdsArray]);
-
-  const handlePinTask = useCallback(
-    (task: Task) => {
-      setPinnedTaskIdsArray((prev) =>
-        prev.includes(task.id) ? prev.filter((id) => id !== task.id) : [...prev, task.id]
-      );
-    },
-    [setPinnedTaskIdsArray]
-  );
-
-  // Remove pinned IDs for tasks that no longer exist (deleted or archived)
-  useEffect(() => {
-    if (!pinnedTaskIdsArray.length) return;
-    const allActiveIds = new Set(
-      Object.values(tasksByProjectId)
-        .flat()
-        .map((t) => t.id)
-    );
-    const cleaned = pinnedTaskIdsArray.filter((id) => allActiveIds.has(id));
-    if (cleaned.length !== pinnedTaskIdsArray.length) {
-      setPinnedTaskIdsArray(cleaned);
-    }
-  }, [tasksByProjectId, pinnedTaskIdsArray, setPinnedTaskIdsArray]);
 
   const [forceOpenIds, setForceOpenIds] = useState<Set<string>>(new Set());
   const prevTaskCountsRef = useRef<Map<string, number>>(new Map());
@@ -316,11 +287,7 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                             <div className="flex min-w-0 flex-col gap-1">
                               {(tasksByProjectId[typedProject.id] ?? [])
                                 .slice()
-                                .sort(
-                                  (a, b) =>
-                                    (pinnedTaskIds.has(b.id) ? 1 : 0) -
-                                    (pinnedTaskIds.has(a.id) ? 1 : 0)
-                                )
+                                .sort((a, b) => (b.isPinned ? 1 : 0) - (a.isPinned ? 1 : 0))
                                 .map((task) => {
                                   const isActive = activeTask?.id === task.id;
                                   return (
@@ -338,7 +305,7 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                                         task={task}
                                         showDelete={true}
                                         showDirectBadge={false}
-                                        isPinned={pinnedTaskIds.has(task.id)}
+                                        isPinned={!!task.isPinned}
                                         onPin={() => handlePinTask(task)}
                                         onRename={(n) => onRenameTask?.(typedProject, task, n)}
                                         onDelete={() => handleDeleteTask(typedProject, task)}

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -705,6 +705,21 @@ export function useTaskManagement() {
     [restoreTaskMutation]
   );
 
+  const handlePinTask = useCallback(
+    async (task: Task): Promise<void> => {
+      const nextPinned = !task.isPinned;
+      try {
+        await rpc.db.setTaskPinned({ taskId: task.id, isPinned: nextPinned });
+        updateTaskCache(task.projectId, (old) =>
+          old.map((t) => (t.id === task.id ? { ...t, isPinned: nextPinned } : t))
+        );
+      } catch {
+        // ignore
+      }
+    },
+    [updateTaskCache]
+  );
+
   // ---------------------------------------------------------------------------
   // Rename task mutation
   // ---------------------------------------------------------------------------
@@ -977,5 +992,6 @@ export function useTaskManagement() {
     handleRenameTask,
     handleArchiveTask,
     handleRestoreTask,
+    handlePinTask,
   };
 }

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -56,6 +56,7 @@ export interface Task {
   metadata?: TaskMetadata | null;
   useWorktree?: boolean;
   archivedAt?: string | null;
+  isPinned?: boolean;
   createdAt?: string;
   updatedAt?: string;
   agentId?: string;


### PR DESCRIPTION
### Summary

- Pinned tasks were only in localStorage and disappeared after restart/update. Pinned state is now stored in the DB (tasks.is_pinned) and survives restarts and updates.

### Fixes

Fixes : #1314

### Snapshot

- Optional: screenshot or short clip of pinning a task, restarting, and it still pinned.

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

### Mandatory Tasks
- [ ] I have self-reviewed the code

### Checklist
[ ] Read contributing guide
[ ] Code formatted (pnpm run format)
[ ] Comments where needed
[ ] Docs checked
[ ] No new warnings (pnpm run lint)
[ ] Tests added/updated as needed
[ ] Tests pass locally
