### PR TITLE
feat: add configurable worktrees directory path

### DIFF
--- a/src/main/ipc/githubIpc.ts
+++ b/src/main/ipc/githubIpc.ts
@@ -8,6 +8,7 @@ import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
 import { homedir } from 'os';
+import { getAppSettings, getWorktreesBaseDir } from '../settings';
 import { quoteShellArg } from '../utils/shellEscape';
 
 const execAsync = promisify(exec);
@@ -291,7 +292,11 @@ export function registerGithubIpc() {
 
         await githubService.ensurePullRequestBranch(projectPath, prNumber, branchName);
 
-        const worktreesDir = path.resolve(projectPath, '..', 'worktrees');
+        const settings = getAppSettings();
+        const worktreesDir = getWorktreesBaseDir(
+          projectPath,
+          settings?.repository?.worktreesDirectory
+        );
         const slug = slugify(taskName) || `pr-${prNumber}`;
         let worktreePath = path.join(worktreesDir, slug);
 

--- a/src/main/ipc/settingsIpc.ts
+++ b/src/main/ipc/settingsIpc.ts
@@ -1,7 +1,13 @@
-import { AppSettingsUpdate, getAppSettings, updateAppSettings } from '../settings';
+import {
+  AppSettingsUpdate,
+  getAppSettings,
+  updateAppSettings,
+  validateWorktreesPath,
+} from '../settings';
 import { createRPCController } from '../../shared/ipc/rpc';
 
 export const appSettingsController = createRPCController({
   get: async () => getAppSettings(),
   update: (partial: AppSettingsUpdate) => updateAppSettings(partial || {}),
+  validateWorktreesPath: (path: string) => validateWorktreesPath(path),
 });

--- a/src/main/services/WorktreePoolService.ts
+++ b/src/main/services/WorktreePoolService.ts
@@ -4,6 +4,7 @@ import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
 import { log } from '../lib/logger';
+import { getAppSettings, getWorktreesBaseDir } from '../settings';
 import { worktreeService, type WorktreeInfo } from './WorktreeService';
 
 const execFileAsync = promisify(execFile);
@@ -49,7 +50,12 @@ export class WorktreePoolService {
 
   /** Get the reserve worktree path for a project */
   private getReservePath(projectPath: string, hash: string): string {
-    return path.join(projectPath, '..', `worktrees/${this.RESERVE_PREFIX}-${hash}`);
+    const settings = getAppSettings();
+    const worktreesBase = getWorktreesBaseDir(
+      projectPath,
+      settings?.repository?.worktreesDirectory
+    );
+    return path.join(worktreesBase, `${this.RESERVE_PREFIX}-${hash}`);
   }
 
   /** Get the reserve branch name */
@@ -291,12 +297,16 @@ export class WorktreePoolService {
     const { getAppSettings } = await import('../settings');
     const settings = getAppSettings();
     const prefix = settings?.repository?.branchPrefix || 'emdash';
+    const worktreesBase = getWorktreesBaseDir(
+      reserve.projectPath,
+      settings?.repository?.worktreesDirectory
+    );
 
     // Generate new names
     const sluggedName = this.slugify(taskName);
     const hash = this.generateShortHash();
     const newBranch = `${prefix}/${sluggedName}-${hash}`;
-    const newPath = path.join(reserve.projectPath, '..', `worktrees/${sluggedName}-${hash}`);
+    const newPath = path.join(worktreesBase, `${sluggedName}-${hash}`);
     const newId = this.stableIdFromPath(newPath);
 
     // Move the worktree (instant operation)
@@ -456,7 +466,8 @@ export class WorktreePoolService {
     projectPath: string,
     reserveBranches: Set<string>
   ): Array<{ path: string; branch: string | null }> {
-    const worktreesDir = path.join(projectPath, '..', 'worktrees');
+    const settings = getAppSettings();
+    const worktreesDir = getWorktreesBaseDir(projectPath, settings?.repository?.worktreesDirectory);
     if (!fs.existsSync(worktreesDir)) {
       return [];
     }
@@ -573,9 +584,9 @@ export class WorktreePoolService {
     await new Promise((resolve) => setTimeout(resolve, 2000));
 
     // Find all worktree directories that might contain reserves
-    const homedir = require('os').homedir();
+    const settings = getAppSettings();
     const projectWorktreeDirs = projectPaths.map((projectPath) =>
-      path.join(projectPath, '..', 'worktrees')
+      getWorktreesBaseDir(projectPath, settings?.repository?.worktreesDirectory)
     );
     const possibleWorktreeDirs = [
       ...projectWorktreeDirs,

--- a/src/main/services/WorktreeService.ts
+++ b/src/main/services/WorktreeService.ts
@@ -4,6 +4,7 @@ import { promisify } from 'util';
 import path from 'path';
 import fs from 'fs';
 import crypto from 'crypto';
+import { getWorktreesBaseDir } from '../settings';
 import { projectSettingsService } from './ProjectSettingsService';
 import { minimatch } from 'minimatch';
 import { errorTracking } from '../errorTracking';
@@ -74,7 +75,17 @@ export class WorktreeService {
       return;
     }
 
+    const { getAppSettings } = await import('../settings');
+    const settings = getAppSettings();
+    const worktreesBase = getWorktreesBaseDir(
+      projectPath,
+      settings?.repository?.worktreesDirectory
+    );
+    const isUnderWorktreesBase =
+      normalizedPathToRemove.startsWith(path.resolve(worktreesBase) + path.sep) ||
+      normalizedPathToRemove === path.resolve(worktreesBase);
     const isLikelyWorktree =
+      isUnderWorktreesBase ||
       pathToRemove.includes('/worktrees/') ||
       pathToRemove.includes('\\worktrees\\') ||
       pathToRemove.includes('/.conductor/') ||
@@ -193,7 +204,11 @@ export class WorktreeService {
       const settings = getAppSettings();
       const prefix = settings?.repository?.branchPrefix || 'emdash';
       branchName = this.sanitizeBranchName(`${prefix}/${sluggedName}-${hash}`);
-      worktreePath = path.join(projectPath, '..', `worktrees/${sluggedName}-${hash}`);
+      const worktreesBase = getWorktreesBaseDir(
+        projectPath,
+        settings?.repository?.worktreesDirectory
+      );
+      worktreePath = path.join(worktreesBase, `${sluggedName}-${hash}`);
       const worktreeId = this.stableIdFromPath(worktreePath);
 
       log.info(`Creating worktree: ${branchName} -> ${worktreePath}`);
@@ -1192,9 +1207,14 @@ export class WorktreeService {
   ): Promise<WorktreeInfo> {
     const normalizedName = taskName || branchName.replace(/\//g, '-');
     const sluggedName = this.slugify(normalizedName) || 'task';
+    const { getAppSettings } = await import('../settings');
+    const settings = getAppSettings();
+    const worktreesBase = getWorktreesBaseDir(
+      projectPath,
+      settings?.repository?.worktreesDirectory
+    );
     const targetPath =
-      options?.worktreePath ||
-      path.join(projectPath, '..', `worktrees/${sluggedName}-${Date.now()}`);
+      options?.worktreePath || path.join(worktreesBase, `${sluggedName}-${Date.now()}`);
     const worktreePath = path.resolve(targetPath);
 
     if (fs.existsSync(worktreePath)) {

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -1,6 +1,6 @@
 import { app } from 'electron';
-import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
-import { dirname, join } from 'node:path';
+import { accessSync, constants, existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
+import { dirname, isAbsolute, join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import type { ProviderId } from '@shared/providers/registry';
 import { isValidProviderId } from '@shared/providers/registry';
@@ -18,6 +18,7 @@ const IS_MAC = process.platform === 'darwin';
 export interface RepositorySettings {
   branchPrefix: string; // e.g., 'emdash'
   pushOnCreate: boolean;
+  worktreesDirectory?: string;
 }
 
 export type ShortcutModifier =
@@ -134,6 +135,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   repository: {
     branchPrefix: 'emdash',
     pushOnCreate: true,
+    worktreesDirectory: undefined,
   },
   projectPrep: {
     autoInstallOnOpenInEditor: true,
@@ -317,6 +319,11 @@ export function updateAppSettings(partial: AppSettingsUpdate): AppSettings {
   if (partial.keyboard) {
     assertNoKeyboardShortcutConflicts(next.keyboard);
   }
+  const worktreesDir = next.repository?.worktreesDirectory;
+  if (worktreesDir) {
+    const err = validateWorktreesPath(worktreesDir);
+    if (err) throw new Error(err);
+  }
   persistSettings(next);
   cached = next;
   return next;
@@ -339,6 +346,7 @@ export function normalizeSettings(input: AppSettings): AppSettings {
     repository: {
       branchPrefix: DEFAULT_SETTINGS.repository.branchPrefix,
       pushOnCreate: DEFAULT_SETTINGS.repository.pushOnCreate,
+      worktreesDirectory: undefined,
     },
     projectPrep: {
       autoInstallOnOpenInEditor: DEFAULT_SETTINGS.projectPrep.autoInstallOnOpenInEditor,
@@ -368,9 +376,12 @@ export function normalizeSettings(input: AppSettings): AppSettings {
   if (!prefix) prefix = DEFAULT_SETTINGS.repository.branchPrefix;
   if (prefix.length > 50) prefix = prefix.slice(0, 50);
   const push = Boolean(repo?.pushOnCreate ?? DEFAULT_SETTINGS.repository.pushOnCreate);
+  const worktreesDir =
+    typeof repo?.worktreesDirectory === 'string' ? repo.worktreesDirectory.trim() : undefined;
 
   out.repository.branchPrefix = prefix;
   out.repository.pushOnCreate = push;
+  out.repository.worktreesDirectory = worktreesDir || undefined;
   // Project prep
   const prep = (input as any)?.projectPrep || {};
   out.projectPrep.autoInstallOnOpenInEditor = Boolean(
@@ -578,6 +589,46 @@ export function getAllProviderCustomConfigs(): ProviderCustomConfigs {
   const configs = settings.providerConfigs ?? {};
   // Return deep copy to prevent cache corruption
   return Object.fromEntries(Object.entries(configs).map(([key, value]) => [key, { ...value }]));
+}
+
+export function validateWorktreesPath(dirPath: string): string | null {
+  const trimmed = typeof dirPath === 'string' ? dirPath.trim() : '';
+  if (!trimmed) return null;
+  let expanded = trimmed;
+  if (expanded.startsWith('~')) {
+    expanded = join(homedir(), expanded.slice(1));
+  }
+  const resolved = resolve(expanded);
+  if (existsSync(resolved)) {
+    try {
+      accessSync(resolved, constants.W_OK);
+      return null;
+    } catch {
+      return `Directory exists but is not writable: ${resolved}`;
+    }
+  }
+  const parent = dirname(resolved);
+  if (!existsSync(parent)) {
+    return `Parent directory does not exist: ${parent}`;
+  }
+  try {
+    accessSync(parent, constants.W_OK);
+    return null;
+  } catch {
+    return `Parent directory is not writable: ${parent}`;
+  }
+}
+
+export function getWorktreesBaseDir(projectPath: string, worktreesDirectory?: string): string {
+  const trimmed = typeof worktreesDirectory === 'string' ? worktreesDirectory.trim() : '';
+  if (!trimmed) {
+    return join(projectPath, '..', 'worktrees');
+  }
+  let expanded = trimmed;
+  if (expanded.startsWith('~')) {
+    expanded = join(homedir(), expanded.slice(1));
+  }
+  return isAbsolute(expanded) ? resolve(expanded) : resolve(projectPath, expanded);
 }
 
 /**

--- a/src/renderer/components/RepositorySettingsCard.tsx
+++ b/src/renderer/components/RepositorySettingsCard.tsx
@@ -1,11 +1,14 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useState } from 'react';
 import { Input } from './ui/input';
 import { Switch } from './ui/switch';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import { rpc } from '@/lib/rpc';
+import { useToast } from '@/hooks/use-toast';
 
 type RepoSettings = {
   branchPrefix: string;
   pushOnCreate: boolean;
+  worktreesDirectory?: string;
 };
 
 const DEFAULTS: RepoSettings = {
@@ -15,6 +18,8 @@ const DEFAULTS: RepoSettings = {
 
 const RepositorySettingsCard: React.FC = () => {
   const { settings, updateSettings, isLoading: loading, isSaving: saving } = useAppSettings();
+  const { toast } = useToast();
+  const [worktreesError, setWorktreesError] = useState<string | null>(null);
 
   const { repository } = settings ?? {};
 
@@ -22,6 +27,29 @@ const RepositorySettingsCard: React.FC = () => {
     const prefix = repository?.branchPrefix || DEFAULTS.branchPrefix;
     return `${prefix}/my-feature-a3f`;
   }, [repository?.branchPrefix]);
+
+  const handleWorktreesBlur = async (e: React.FocusEvent<HTMLInputElement>) => {
+    const value = e.target.value.trim();
+    setWorktreesError(null);
+    if (!value) {
+      updateSettings({ repository: { worktreesDirectory: '' } });
+      return;
+    }
+    const err = await rpc.appSettings.validateWorktreesPath(value);
+    if (err) {
+      setWorktreesError(err);
+      return;
+    }
+    try {
+      updateSettings({ repository: { worktreesDirectory: value } });
+    } catch (e) {
+      toast({
+        title: 'Failed to save',
+        description: e instanceof Error ? e.message : 'Invalid worktrees path',
+        variant: 'destructive',
+      });
+    }
+  };
 
   return (
     <div className="grid gap-8">
@@ -36,6 +64,21 @@ const RepositorySettingsCard: React.FC = () => {
         <div className="text-[11px] text-muted-foreground">
           Example: <code className="rounded bg-muted/60 px-1">{example}</code>
         </div>
+      </div>
+      <div className="grid gap-2">
+        <Input
+          key={repository?.worktreesDirectory ?? 'default'}
+          defaultValue={repository?.worktreesDirectory ?? ''}
+          onBlur={handleWorktreesBlur}
+          placeholder="../worktrees (default)"
+          aria-label="Worktrees directory"
+          disabled={loading}
+        />
+        <div className="text-[11px] text-muted-foreground">
+          Base path for worktree directories. Leave empty for default (sibling of project). Supports
+          ~ for home.
+        </div>
+        {worktreesError && <div className="text-[11px] text-destructive">{worktreesError}</div>}
       </div>
       <div className="flex items-center justify-between gap-4">
         <div className="space-y-1 text-xs text-muted-foreground">

--- a/src/test/main/WorktreePoolService.test.ts
+++ b/src/test/main/WorktreePoolService.test.ts
@@ -38,14 +38,20 @@ vi.mock('../../main/lib/logger', () => ({
   },
 }));
 
-vi.mock('../../main/settings', () => ({
-  getAppSettings: vi.fn().mockReturnValue({
-    repository: {
-      branchPrefix: 'emdash',
-      pushOnCreate: false,
-    },
-  }),
-}));
+vi.mock('../../main/settings', () => {
+  const path = require('path');
+  return {
+    getAppSettings: vi.fn().mockReturnValue({
+      repository: {
+        branchPrefix: 'emdash',
+        pushOnCreate: false,
+        worktreesDirectory: undefined,
+      },
+    }),
+    getWorktreesBaseDir: (projectPath: string, _worktreesDirectory?: string) =>
+      path.join(projectPath, '..', 'worktrees'),
+  };
+});
 
 describe('WorktreePoolService', () => {
   let tempDir: string;


### PR DESCRIPTION
### summary
- adds a global setting to choose where worktrees are created. When empty, behavior stays the same (../worktrees). 
- supports absolute paths and ~ for home. Validates that the path exists and is writable.

### Fixes

fix : #1313 

### Snapshot

- settings → Repository → new “Worktrees directory” input.

### Type of change

- [x] New feature (non-breaking change which adds functionality)

### Mandatory Tasks

[ ] I have self-reviewed the code
[ ] A decent size PR without self-review might be rejected
Checklist
[ ] I have read the contributing guide
[ ] My code follows the style guidelines of this project (pnpm run format)
[ ] I have commented my code, particularly in hard-to-understand areas
[ ] I have checked if my PR needs changes to the documentation
[ ] I have checked if my changes generate no new warnings (pnpm run lint)
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] I haven't checked if new and existing unit tests pass locally with my changes


Ctrl+K to generate command
