### PR TITLE
fix(terminal): align font size between agent pane and terminal pane

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -24,6 +24,7 @@ import { rpc } from '@/lib/rpc';
 const SNAPSHOT_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
 const MAX_DATA_WINDOW_BYTES = 128 * 1024 * 1024; // 128 MB soft guardrail
 const FALLBACK_FONTS = 'Menlo, Monaco, Courier New, monospace';
+const DEFAULT_FONT_SIZE = 13;
 const MIN_RENDERABLE_TERMINAL_WIDTH_PX = 24;
 const MIN_RENDERABLE_TERMINAL_HEIGHT_PX = 24;
 const PTY_RESIZE_DEBOUNCE_MS = 60;
@@ -103,6 +104,8 @@ export class TerminalSessionManager {
   private inputBuffer: TerminalInputBuffer | null = null;
   private autoCopyOnSelection = false;
   private selectionChangeDebounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private terminalConfigFontSize: number | null = null;
+  private lastTheme: SessionTheme;
 
   // Timing for startup performance measurement
   private initStartTime: number = 0;
@@ -112,6 +115,7 @@ export class TerminalSessionManager {
   constructor(private readonly options: TerminalSessionOptions) {
     this.initStartTime = performance.now();
     this.id = options.taskId;
+    this.lastTheme = options.theme;
 
     this.container = document.createElement('div');
     this.container.className = 'terminal-session-root';
@@ -137,7 +141,7 @@ export class TerminalSessionManager {
       rows: options.initialSize.rows,
       scrollback: options.scrollbackLines,
       convertEol: true,
-      fontSize: 13,
+      fontSize: DEFAULT_FONT_SIZE,
       lineHeight: 1.2,
       letterSpacing: 0,
       allowProposedApi: true,
@@ -155,6 +159,16 @@ export class TerminalSessionManager {
     rpc.appSettings.get().then((settings) => {
       updateCustomFont(settings?.terminal?.fontFamily);
       this.autoCopyOnSelection = settings?.terminal?.autoCopyOnSelection ?? false;
+    });
+
+    window.electronAPI.terminalGetTheme().then((result) => {
+      if (this.disposed) return;
+      const size = result?.ok && result.config?.theme?.fontSize;
+      if (typeof size === 'number' && size > 0) {
+        this.terminalConfigFontSize = size;
+        this.applyTheme(this.lastTheme);
+        this.fitPreservingViewport();
+      }
     });
 
     const handleFontChange = (e: Event) => {
@@ -458,6 +472,7 @@ export class TerminalSessionManager {
   }
 
   setTheme(theme: SessionTheme) {
+    this.lastTheme = theme;
     this.applyTheme(theme);
   }
 
@@ -708,22 +723,21 @@ export class TerminalSessionManager {
             ...selection,
           };
 
-    // Extract font settings before applying theme (they're not part of ITheme)
     const fontFamily = (theme.override as any)?.fontFamily;
-    const fontSize = (theme.override as any)?.fontSize;
+    const overrideFontSize = (theme.override as any)?.fontSize;
+    const effectiveFontSize =
+      typeof overrideFontSize === 'number' && overrideFontSize > 0
+        ? overrideFontSize
+        : (this.terminalConfigFontSize ?? DEFAULT_FONT_SIZE);
 
-    // Apply color theme (excluding font properties)
     const colorTheme = { ...theme.override };
     delete (colorTheme as any)?.fontFamily;
     delete (colorTheme as any)?.fontSize;
     this.terminal.options.theme = { ...base, ...colorTheme };
 
-    // Apply font settings separately
     this.themeFontFamily = typeof fontFamily === 'string' ? fontFamily.trim() : '';
     this.applyEffectiveFont();
-    if (fontSize) {
-      this.terminal.options.fontSize = fontSize;
-    }
+    this.terminal.options.fontSize = effectiveFontSize;
   }
 
   private applyEffectiveFont() {


### PR DESCRIPTION
### summary

- Use one shared font size for both the agent pane and the terminal pane. The agent pane now falls back to the terminal config font size (from terminalGetTheme()) when its theme override has no fontSize, so both panes match.

### Fixes
- Fixes font size mismatch between agent pane and terminal pane.

### Snapshot

- No screenshots added.

### Type of change
[x] Bug fix (non-breaking change which fixes an issue)

### Mandatory Tasks
[ ] I have self-reviewed the code
[ ] A decent size PR without self-review might be rejected
Checklist
[ ] I have read the contributing guide
[ ] My code follows the style guidelines of this project (pnpm run format)
[ ] I have commented my code, particularly in hard-to-understand areas
[ ] I have checked if my PR needs changes to the documentation
[ ] I have checked if my changes generate no new warnings (pnpm run lint)
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] I haven't checked if new and existing unit tests pass locally with my changes

fix : #1311