### PR TITLE
feat: add tooltip to enable auto-merge button

### DIFF
--- a/src/renderer/components/MergePrSection.tsx
+++ b/src/renderer/components/MergePrSection.tsx
@@ -450,22 +450,31 @@ export function MergePrSection({
               </Popover>
             </div>
             {showAutoMerge && (
-              <Button
-                variant="outline"
-                size="sm"
-                className="h-8 w-full justify-center px-2 text-xs"
-                disabled={isTogglingAutoMerge}
-                onClick={toggleAutoMerge}
-              >
-                {isTogglingAutoMerge ? (
-                  <Spinner size="sm" />
-                ) : (
-                  <span className="inline-flex items-center gap-1.5">
-                    <Timer className="h-3.5 w-3.5" />
-                    Enable auto-merge
-                  </span>
-                )}
-              </Button>
+              <TooltipProvider delayDuration={120}>
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant="outline"
+                      size="sm"
+                      className="h-8 w-full justify-center px-2 text-xs"
+                      disabled={isTogglingAutoMerge}
+                      onClick={toggleAutoMerge}
+                    >
+                      {isTogglingAutoMerge ? (
+                        <Spinner size="sm" />
+                      ) : (
+                        <span className="inline-flex items-center gap-1.5">
+                          <Timer className="h-3.5 w-3.5" />
+                          Enable auto-merge
+                        </span>
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                  <TooltipContent side="top">
+                    Automatically merge when all checks pass
+                  </TooltipContent>
+                </Tooltip>
+              </TooltipProvider>
             )}
           </>
         )}


### PR DESCRIPTION
## Summary

- Wraps the "Enable auto-merge" button in a `TooltipProvider` / `Tooltip` to show an explanatory tooltip ("Automatically merge when all checks pass") on hover
- Helps users understand what the auto-merge toggle does before clicking it

## Test plan

- [ ] Open a PR that is blocked by checks (status: `BLOCKED`, `HAS_HOOKS`, or `UNSTABLE`)
- [ ] Verify the "Enable auto-merge" button shows a tooltip on hover
- [ ] Verify the tooltip reads "Automatically merge when all checks pass"
- [ ] Verify the button still functions correctly (enables auto-merge on click)

🤖 Generated with [Claude Code](https://claude.com/claude-code)