### PR TITLE
feat(history): show author avatar in commit list

### DIFF
--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -407,6 +407,7 @@ export async function getLog(
     subject: string;
     body: string;
     author: string;
+    authorEmail: string;
     date: string;
     isPushed: boolean;
     tags: string[];
@@ -469,7 +470,7 @@ export async function getLog(
 
   const FIELD_SEP = '---FIELD_SEP---';
   const RECORD_SEP = '---RECORD_SEP---';
-  const format = `${RECORD_SEP}%H${FIELD_SEP}%s${FIELD_SEP}%an${FIELD_SEP}%aI${FIELD_SEP}%D${FIELD_SEP}%b`;
+  const format = `${RECORD_SEP}%H${FIELD_SEP}%s${FIELD_SEP}%an${FIELD_SEP}%aI${FIELD_SEP}%D${FIELD_SEP}%ae${FIELD_SEP}%b`;
   const { stdout } = await execFileAsync(
     'git',
     ['log', `--max-count=${maxCount}`, `--skip=${skip}`, `--pretty=format:${format}`, '--'],
@@ -493,8 +494,9 @@ export async function getLog(
       return {
         hash: parts[0] || '',
         subject: parts[1] || '',
-        body: (parts[5] || '').trim(),
+        body: (parts[6] || '').trim(),
         author: parts[2] || '',
+        authorEmail: parts[5] || '',
         date: parts[3] || '',
         isPushed: skip + index >= aheadCount,
         tags,

--- a/src/renderer/components/diff-viewer/CommitList.tsx
+++ b/src/renderer/components/diff-viewer/CommitList.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback, useEffect, useRef, useState } from 'react';
+import React, { useCallback, useEffect, useRef, useState, type SyntheticEvent } from 'react';
 import { ArrowUp, Tag } from 'lucide-react';
 
 interface Commit {
@@ -6,6 +6,7 @@ interface Commit {
   subject: string;
   body: string;
   author: string;
+  authorEmail: string;
   date: string;
   isPushed: boolean;
   tags: string[];
@@ -44,6 +45,45 @@ function formatRelativeDate(dateStr: string): string {
   if (diffMonths < 12) return `${diffMonths} month${diffMonths === 1 ? '' : 's'} ago`;
   const diffYears = Math.floor(diffDays / 365);
   return `${diffYears} year${diffYears === 1 ? '' : 's'} ago`;
+}
+
+/** Try to extract a GitHub username from an email address. */
+function githubLoginFromEmail(email: string): string | null {
+  if (!email) return null;
+  // GitHub noreply: 12345+username@users.noreply.github.com
+  const noreply = email.match(/^\d+\+([^@]+)@users\.noreply\.github\.com$/i);
+  if (noreply) return noreply[1];
+  // Older noreply: username@users.noreply.github.com
+  const oldNoreply = email.match(/^([^@]+)@users\.noreply\.github\.com$/i);
+  if (oldNoreply) return oldNoreply[1];
+  return null;
+}
+
+function getAvatarUrl(author: string, authorEmail: string): string {
+  const login = githubLoginFromEmail(authorEmail);
+  if (login) return `https://github.com/${login}.png?size=40`;
+  // Fall back to trying the author name as a GitHub username
+  return `https://github.com/${author}.png?size=40`;
+}
+
+function AuthorAvatar({ author, authorEmail }: { author: string; authorEmail: string }) {
+  const [failed, setFailed] = useState(false);
+
+  const url = getAvatarUrl(author, authorEmail);
+
+  if (failed) return null;
+
+  return (
+    <img
+      src={url}
+      alt=""
+      className="h-4 w-4 shrink-0 rounded-sm"
+      onError={(e: SyntheticEvent<HTMLImageElement>) => {
+        e.currentTarget.style.display = 'none';
+        setFailed(true);
+      }}
+    />
+  );
 }
 
 export const CommitList: React.FC<CommitListProps> = ({
@@ -164,8 +204,11 @@ export const CommitList: React.FC<CommitListProps> = ({
           <div className="flex items-center gap-2">
             <div className="min-w-0 flex-1">
               {commit.subject ? <div className="truncate text-sm">{commit.subject}</div> : null}
-              <div className="text-xs text-muted-foreground">
-                {commit.author} &middot; {formatRelativeDate(commit.date)}
+              <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                <AuthorAvatar author={commit.author} authorEmail={commit.authorEmail} />
+                <span className="truncate">
+                  {commit.author} &middot; {formatRelativeDate(commit.date)}
+                </span>
               </div>
             </div>
             {commit.tags.length > 0 &&

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -459,6 +459,7 @@ declare global {
           subject: string;
           body: string;
           author: string;
+          authorEmail: string;
           date: string;
           isPushed: boolean;
           tags: string[];


### PR DESCRIPTION
## Summary
- Add GitHub avatar thumbnails next to commit author names in the commit history list
- Extract `authorEmail` from git log output (`%ae` format) and pass it through the IPC layer
- Resolve GitHub usernames from noreply email addresses to load correct avatars
- Gracefully hide the avatar if the image fails to load

## Changes
- **`GitService.ts`**: Add `authorEmail` field to `getLog()` return type and include `%ae` in the git log format string
- **`CommitList.tsx`**: Add `AuthorAvatar` component that loads GitHub profile images, with `githubLoginFromEmail()` helper to extract usernames from GitHub noreply addresses
- **`electron-api.d.ts`**: Add `authorEmail` to the `gitGetLog` response type