### PR TITLE
docs: add MCP page to docs navigation

### DIFF
--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -1,0 +1,84 @@
+---
+title: MCP Servers
+description: Connect your agents to external tools and data sources via MCP
+---
+
+MCP (Model Context Protocol) lets your coding agents connect to external tools and data sources — databases, APIs, browsers, and more. Emdash manages MCP server configs across all your installed agents from a single place, so you configure once and every agent picks it up.
+
+## Getting Started
+
+Open the MCP view by clicking **MCP** in the left sidebar. You'll see two sections:
+
+- **Added** — servers you've already configured
+- **Recommended** — a curated catalog of popular MCP servers ready to add
+
+Use the search box to filter by name or description.
+
+## Adding a Server from the Catalog
+
+1. Find a server in the **Recommended** section (e.g. Playwright, Supabase, Sentry)
+2. Click **Add** on the card
+3. The modal opens pre-filled with the server's default config
+4. Fill in any required credentials (marked with an asterisk)
+5. Select which agents to sync to under **Sync to agents**
+6. Click **Add**
+
+Emdash writes the config into each selected agent's native config file. The server is available in your next agent session.
+
+## Adding a Custom Server
+
+1. Click **Custom MCP** in the toolbar
+2. Enter a name and choose the transport type:
+   - **stdio** — runs a local process (provide a command and optional arguments)
+   - **http** — connects to a remote URL (provide the endpoint and optional headers)
+3. Add any environment variables the server needs
+4. Select target agents and click **Add**
+
+## Editing and Removing
+
+Click an installed server card to edit its config — change credentials, update the URL, or adjust which agents it syncs to. Click **Remove** to delete the server from all agents.
+
+## Agent Sync
+
+When you add or edit a server, Emdash translates the config into each agent's native format and writes it to the correct location:
+
+| Agent          | Config file                            |
+| -------------- | -------------------------------------- |
+| Claude Code    | `~/.claude.json`                       |
+| Cursor         | `~/.cursor/mcp.json`                   |
+| Codex          | `~/.codex/config.toml`                 |
+| Amp            | `~/.config/amp/settings.json`          |
+| Gemini         | `~/.gemini/settings.json`              |
+| Qwen           | `~/.qwen/settings.json`               |
+| OpenCode       | `~/.config/opencode/opencode.json`     |
+| GitHub Copilot | `~/.copilot/mcp-config.json`           |
+| Droid          | `~/.droid/settings.json`               |
+
+This means MCP servers configured through Emdash also work when you run these agents outside of Emdash.
+
+## Transport Compatibility
+
+MCP servers use one of two transports: **stdio** (local process) or **http** (remote URL). Most agents support both, but Codex currently only supports stdio servers. When adding an HTTP server, incompatible agents are automatically disabled in the agent selector.
+
+## Catalog Servers
+
+The built-in catalog includes 40+ servers for common services:
+
+- **Browser & DevTools**: Playwright, Chrome DevTools
+- **Databases & Data**: Supabase, PlanetScale, MotherDuck, BigQuery
+- **Hosting & Infrastructure**: Vercel, Netlify, Cloudflare, AWS Marketplace
+- **Monitoring & Analytics**: Sentry, PostHog, Honeycomb, Amplitude
+- **Project Management**: Linear, Asana, ClickUp, Notion, Jira (Atlassian)
+- **Design & Content**: Figma, Canva, Miro, Webflow, Sanity, Cloudinary, WordPress
+- **Communication**: Slack, Intercom
+- **Payments & Auth**: Stripe, Clerk
+- **AI & Search**: Hugging Face, Exa, Context7
+- **Automation**: Make
+
+Each catalog entry includes a link to the server's documentation for setup details.
+
+## Tips
+
+- You can sync a single MCP server to multiple agents at once — no need to configure each one separately.
+- Environment variables with credential keys are highlighted in the modal so you know what to fill in.
+- Click **Refresh** to re-detect installed agents if you've installed a new CLI since opening Emdash.

--- a/docs/content/docs/meta.json
+++ b/docs/content/docs/meta.json
@@ -14,6 +14,7 @@
     "file-editor",
     "kanban-view",
     "skills",
+    "mcp",
     "ci-checks",
     "remote-projects",
     "tmux-sessions",


### PR DESCRIPTION
## Summary

Adds the `mcp` entry to `docs/content/docs/meta.json` so the MCP documentation page appears in the docs sidebar navigation under the Capabilities section.