### PR TITLE
feat: Hide the RightSidebar while a task is being created or is an op…

### DIFF
--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -439,7 +439,7 @@ export function Workspace() {
                     order={3}
                   >
                     <RightSidebar
-                      task={isCreatingTask ? null : effectiveTask}
+                      task={effectiveTask}
                       projectPath={selectedProject?.path || activeTaskProjectPath}
                       projectRemoteConnectionId={derivedRemoteConnectionId}
                       projectRemotePath={derivedRemotePath}


### PR DESCRIPTION
## Summary

Briefly describe what this PR does and why 
The problem: ChatInterface mounts immediately with the placeholder, calling handleTaskInterfaceReady before onSuccess delivers the real worktree task.
Fix applied: effectiveTask now masks the task when either isCreatingTask is true or activeTask.id.startsWith('optimistic-'). This way the sidebar stays hidden for the entire window between onMutate → onSuccess, regardless of when handleTaskInterfaceReady fires.

## Fixes 
 If this PR fixes an issue, mention it like: Fixes #1342  

## Snapshot
 Add screenshots, GIFs, or videos demonstrating the changes (if applicable) 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [ ] I have read the contributing guide
- [ ] My code follows the style guidelines of this project (`pnpm run format`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked if my PR needs changes to the documentation
- [ ] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes