### PR TITLE
Collapse right sidebar on home screen by default

### DIFF
--- a/src/renderer/hooks/usePanelLayout.ts
+++ b/src/renderer/hooks/usePanelLayout.ts
@@ -247,15 +247,23 @@ export function usePanelLayout(opts: UsePanelLayoutOptions) {
     };
   }, []);
 
-  // Auto-collapse/expand right sidebar based on current view
+  // Always collapse right sidebar on home screen
+  useEffect(() => {
+    if (!isInitialLoadComplete) return;
+
+    if (showHomeView) {
+      rightSidebarSetCollapsedRef.current?.(true);
+    }
+  }, [isInitialLoadComplete, showHomeView]);
+
+  // Auto-collapse/expand right sidebar based on current view (when setting enabled)
   useEffect(() => {
     // Defer sidebar behavior until initial load completes to prevent flash
     if (!autoRightSidebarBehavior || !isInitialLoadComplete) return;
 
-    const isHomePage = showHomeView;
     const isRepoHomePage = selectedProject !== null && activeTask === null;
     const isNonTaskView = showSettingsPage || showSkillsView || showMcpView;
-    const shouldCollapse = isHomePage || isRepoHomePage || isNonTaskView;
+    const shouldCollapse = isRepoHomePage || isNonTaskView;
 
     if (shouldCollapse) {
       rightSidebarSetCollapsedRef.current?.(true);
@@ -265,7 +273,6 @@ export function usePanelLayout(opts: UsePanelLayoutOptions) {
   }, [
     autoRightSidebarBehavior,
     isInitialLoadComplete,
-    showHomeView,
     showSettingsPage,
     showSkillsView,
     showMcpView,


### PR DESCRIPTION
## Summary
- The right terminal panel now always collapses when the user is on the home screen, without requiring the auto-collapse setting to be enabled
- Previously this behavior was gated behind the `autoRightSidebarBehavior` setting (default off), so the sidebar stayed open on home — even on first app launch
- The opt-in setting still controls auto-collapse for repo home page, settings, skills, and MCP views

## Test plan
- [ ] Open the app fresh — right sidebar should be collapsed on the home screen
- [ ] Navigate to a project and open a task — right sidebar should behave normally (expand if auto-collapse setting is on)
- [ ] Navigate back to home — right sidebar collapses again
- [ ] Verify the `autoRightSidebarBehavior` setting still works for repo home/settings/skills/MCP views

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/layout change limited to right sidebar collapse behavior and gated until initial load completes; main risk is unexpected sidebar state when navigating to/from home.
> 
> **Overview**
> **Updates right sidebar auto-collapse behavior.** The home screen now *always* forces the right sidebar to collapse after initial load, independent of the `autoRightSidebarBehavior` setting.
> 
> When `autoRightSidebarBehavior` is enabled, auto-collapse/expand continues to apply only to repo home and other non-task views (settings/skills/MCP), with home removed from that setting-gated logic.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 7f2060ea526bad2c780f1ef4bc0e99bd1158e0e5. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->