### PR TITLE
fix: reduce freezes when opening a project

### DIFF
--- a/src/main/ipc/dbIpc.ts
+++ b/src/main/ipc/dbIpc.ts
@@ -1,7 +1,13 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { databaseService } from '../services/DatabaseService';
-import type { Conversation, Message, Project, Task } from '../services/DatabaseService';
+import type {
+  Conversation,
+  Message,
+  Project,
+  Task,
+  TaskConversationSummaryRow,
+} from '../services/DatabaseService';
 import { createRPCController } from '../../shared/ipc/rpc';
 import { log } from '../lib/logger';
 
@@ -32,6 +38,9 @@ export const databaseController = createRPCController({
 
   getConversations: (taskId: string): Promise<Conversation[]> =>
     databaseService.getConversations(taskId),
+
+  getConversationSummaries: (taskIds: string[]): Promise<TaskConversationSummaryRow[]> =>
+    databaseService.getConversationSummaries(taskIds),
 
   getOrCreateDefaultConversation: (args: {
     taskId: string;

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -71,6 +71,13 @@ export interface Conversation {
   updatedAt: string;
 }
 
+export interface TaskConversationSummaryRow {
+  id: string;
+  taskId: string;
+  provider?: string | null;
+  isMain: boolean;
+}
+
 export interface Message {
   id: string;
   conversationId: string;
@@ -460,6 +467,32 @@ export class DatabaseService {
       .where(eq(conversationsTable.taskId, taskId))
       .orderBy(asc(conversationsTable.displayOrder), desc(conversationsTable.updatedAt));
     return rows.map((row) => this.mapDrizzleConversationRow(row));
+  }
+
+  async getConversationSummaries(taskIds: string[]): Promise<TaskConversationSummaryRow[]> {
+    if (this.disabled || taskIds.length === 0) return [];
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select({
+        id: conversationsTable.id,
+        taskId: conversationsTable.taskId,
+        provider: conversationsTable.provider,
+        isMain: conversationsTable.isMain,
+      })
+      .from(conversationsTable)
+      .where(inArray(conversationsTable.taskId, taskIds))
+      .orderBy(
+        asc(conversationsTable.taskId),
+        asc(conversationsTable.displayOrder),
+        desc(conversationsTable.updatedAt)
+      );
+
+    return rows.map((row) => ({
+      id: row.id,
+      taskId: row.taskId,
+      provider: row.provider ?? null,
+      isMain: Boolean(row.isMain),
+    }));
   }
 
   async getOrCreateDefaultConversation(taskId: string, provider?: string): Promise<Conversation> {

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { Button } from './ui/button';
 import { Input } from './ui/input';
 import {
@@ -46,7 +47,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/t
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { isActivePr, type PrInfo } from '../lib/prStatus';
 import { rpc } from '../lib/rpc';
-import { useTaskAgentNames } from '../hooks/useTaskAgentNames';
 import { useTaskBusy } from '../hooks/useTaskBusy';
 import { useTaskStatus } from '../hooks/useTaskStatus';
 import { useTaskUnread } from '../hooks/useTaskUnread';
@@ -57,6 +57,28 @@ import type { ProviderId } from '@shared/providers/registry';
 import type { Project, Task } from '../types/app';
 import { useTaskManagementContext } from '../contexts/TaskManagementContext';
 import { TaskStatusIndicator } from './TaskStatusIndicator';
+
+const CONVERSATIONS_CHANGED_EVENT = 'emdash:conversations-changed';
+const TASK_ROW_VISIBILITY_ROOT_MARGIN = '240px 0px';
+
+interface ConversationSummaryRow {
+  id: string;
+  taskId: string;
+  provider?: string | null;
+  isMain: boolean;
+}
+
+interface TaskConversationSummary {
+  chatIds: string[];
+  providerIds: string[];
+  totalChatCount: number;
+}
+
+const EMPTY_TASK_CONVERSATION_SUMMARY: TaskConversationSummary = {
+  chatIds: [],
+  providerIds: [],
+  totalChatCount: 0,
+};
 
 const normalizeBaseRef = (ref?: string | null): string | undefined => {
   if (!ref) return undefined;
@@ -84,6 +106,47 @@ const hasDeleteRisk = (status?: {
   );
 };
 
+const buildTaskConversationSummaryMap = (
+  rows: ConversationSummaryRow[]
+): Record<string, TaskConversationSummary> => {
+  const summaryByTaskId: Record<string, TaskConversationSummary> = {};
+
+  for (const row of rows) {
+    const current = summaryByTaskId[row.taskId] ?? {
+      chatIds: [],
+      providerIds: [],
+      totalChatCount: 0,
+    };
+
+    if (!row.isMain) {
+      current.chatIds.push(row.id);
+    }
+    if (row.provider) {
+      current.totalChatCount += 1;
+      if (!current.providerIds.includes(row.provider)) {
+        current.providerIds.push(row.provider);
+      }
+    }
+
+    summaryByTaskId[row.taskId] = current;
+  }
+
+  return summaryByTaskId;
+};
+
+const getTaskAgentInfo = (
+  summary: TaskConversationSummary,
+  fallbackAgentId?: string
+): { providerIds: string[]; additionalCount: number } => {
+  const providerIds =
+    summary.providerIds.length > 0 ? summary.providerIds : fallbackAgentId ? [fallbackAgentId] : [];
+  const totalChats = summary.totalChatCount > 0 ? summary.totalChatCount : providerIds.length;
+  return {
+    providerIds,
+    additionalCount: Math.max(0, totalChats - 1),
+  };
+};
+
 function TaskRow({
   ws,
   active,
@@ -95,6 +158,7 @@ function TaskRow({
   isSelected,
   onToggleSelect,
   enablePrStatus = true,
+  conversationSummary = EMPTY_TASK_CONVERSATION_SUMMARY,
 }: {
   ws: Task;
   active: boolean;
@@ -106,16 +170,53 @@ function TaskRow({
   isSelected?: boolean;
   onToggleSelect?: () => void;
   enablePrStatus?: boolean;
+  conversationSummary?: TaskConversationSummary;
 }) {
   const isArchived = Boolean(ws.archivedAt);
-  const isBusy = useTaskBusy(ws.id);
-  const taskStatus = useTaskStatus(ws.id);
-  const taskUnread = useTaskUnread(ws.id);
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const [detailsEnabled, setDetailsEnabled] = useState(active);
+  const effectiveDetailsEnabled = detailsEnabled || active;
+  const isBusy = useTaskBusy(ws.id, conversationSummary.chatIds, effectiveDetailsEnabled);
+  const taskStatus = useTaskStatus(ws.id, conversationSummary.chatIds, effectiveDetailsEnabled);
+  const taskUnread = useTaskUnread(ws.id, conversationSummary.chatIds, effectiveDetailsEnabled);
   const displayStatus = taskStatus === 'unknown' && isBusy ? 'working' : taskStatus;
   const [isDeleting, setIsDeleting] = useState(false);
-  const { pr } = usePrStatus(ws.path, enablePrStatus);
-  const { totalAdditions, totalDeletions, isLoading } = useTaskChanges(ws.path, ws.id);
-  const agentInfo = useTaskAgentNames(ws.id, ws.agentId);
+  const { pr } = usePrStatus(ws.path, enablePrStatus && effectiveDetailsEnabled);
+  const { totalAdditions, totalDeletions, isLoading } = useTaskChanges(ws.path, ws.id, {
+    isActive: effectiveDetailsEnabled,
+  });
+  const agentInfo = useMemo(
+    () => getTaskAgentInfo(conversationSummary, ws.agentId ?? undefined),
+    [conversationSummary, ws.agentId]
+  );
+
+  useEffect(() => {
+    if (active) {
+      setDetailsEnabled(true);
+    }
+  }, [active]);
+
+  useEffect(() => {
+    if (detailsEnabled) return;
+    const node = rowRef.current;
+    if (!node) return;
+    if (typeof IntersectionObserver === 'undefined') {
+      setDetailsEnabled(true);
+      return;
+    }
+
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (!entries.some((entry) => entry.isIntersecting)) return;
+        setDetailsEnabled(true);
+        observer.disconnect();
+      },
+      { rootMargin: TASK_ROW_VISIBILITY_ROOT_MARGIN }
+    );
+
+    observer.observe(node);
+    return () => observer.disconnect();
+  }, [detailsEnabled]);
 
   const handleRowClick = () => {
     if (isSelectMode) {
@@ -178,6 +279,7 @@ function TaskRow({
 
   return (
     <div
+      ref={rowRef}
       className="task-row group relative flex items-center gap-3"
       data-active={active || undefined}
       data-selected={isSelected || undefined}
@@ -368,7 +470,6 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
   const [archivedTasks, setArchivedTasks] = useState<Task[]>([]);
 
   const activeTasks = tasksByProjectId[project.id] ?? [];
-  const activeTasksLength = activeTasks.length;
 
   const refetchArchivedTasks = useCallback(() => {
     const timeoutId = setTimeout(async () => {
@@ -390,6 +491,23 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
     () => (showFilter === 'all' ? [...activeTasks, ...archivedTasks] : activeTasks),
     [activeTasks, archivedTasks, showFilter]
   );
+  const taskIdsForConversationSummary = useMemo(
+    () => tasksInProject.map((task) => task.id),
+    [tasksInProject]
+  );
+  const { data: conversationSummaryByTaskId = {}, refetch: refetchConversationSummaries } =
+    useQuery({
+      queryKey: ['taskConversationSummaries', taskIdsForConversationSummary],
+      queryFn: async () => {
+        if (taskIdsForConversationSummary.length === 0) {
+          return {} as Record<string, TaskConversationSummary>;
+        }
+        const rows = await rpc.db.getConversationSummaries(taskIdsForConversationSummary);
+        return buildTaskConversationSummaryMap(rows as ConversationSummaryRow[]);
+      },
+      enabled: taskIdsForConversationSummary.length > 0,
+      staleTime: 30000,
+    });
   const hasAnyTasks = activeTasks.length > 0 || archivedTasks.length > 0;
   const filteredTasks = useMemo(
     () =>
@@ -430,6 +548,21 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
         .map((ws) => ({ id: ws.id, name: ws.name, path: ws.path })),
     [selectedTasks]
   );
+
+  useEffect(() => {
+    if (taskIdsForConversationSummary.length === 0) return;
+    const taskIdSet = new Set(taskIdsForConversationSummary);
+    const handleConversationsChanged = (event: Event) => {
+      const taskId = (event as CustomEvent<{ taskId?: string }>).detail?.taskId;
+      if (!taskId || !taskIdSet.has(taskId)) return;
+      void refetchConversationSummaries();
+    };
+
+    window.addEventListener(CONVERSATIONS_CHANGED_EVENT, handleConversationsChanged);
+    return () => {
+      window.removeEventListener(CONVERSATIONS_CHANGED_EVENT, handleConversationsChanged);
+    };
+  }, [refetchConversationSummaries, taskIdsForConversationSummary]);
   const {
     risks: deleteStatus,
     scannedAtById: deleteRiskScannedAt,
@@ -1028,6 +1161,9 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
                         <TaskRow
                           key={ws.id}
                           ws={ws}
+                          conversationSummary={
+                            conversationSummaryByTaskId[ws.id] ?? EMPTY_TASK_CONVERSATION_SUMMARY
+                          }
                           isSelectMode={isSelectMode}
                           isSelected={selectedIds.has(ws.id)}
                           onToggleSelect={() => toggleSelect(ws.id)}

--- a/src/renderer/hooks/useProjectManagement.tsx
+++ b/src/renderer/hooks/useProjectManagement.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState, useRef } from 'react';
+import { startTransition, useCallback, useEffect, useState, useRef } from 'react';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { ToastAction } from '@radix-ui/react-toast';
 import { pickDefaultBranch } from '../components/BranchSelect';
@@ -206,13 +206,15 @@ export const useProjectManagement = () => {
       void import('../lib/telemetryClient').then(({ captureTelemetry }) => {
         captureTelemetry('project_view_opened');
       });
-      setSelectedProject(project);
-      setShowHomeView(false);
-      setShowSkillsView(false);
-      setShowMcpView(false);
-      setResetTaskTrigger((t) => t + 1);
-      setShowEditorMode(false);
-      setShowKanban(false);
+      startTransition(() => {
+        setSelectedProject(project);
+        setShowHomeView(false);
+        setShowSkillsView(false);
+        setShowMcpView(false);
+        setResetTaskTrigger((t) => t + 1);
+        setShowEditorMode(false);
+        setShowKanban(false);
+      });
       saveActiveIds(project.id, null);
       prewarmReserveForBaseRef(
         project.id,

--- a/src/renderer/hooks/useTaskBusy.ts
+++ b/src/renderer/hooks/useTaskBusy.ts
@@ -4,12 +4,16 @@ import { rpc } from '../lib/rpc';
 
 const CONVERSATIONS_CHANGED_EVENT = 'emdash:conversations-changed';
 
-export function useTaskBusy(taskId: string) {
+export function useTaskBusy(taskId: string, chatIds?: string[], enabled = true) {
   const [mainBusy, setMainBusy] = useState(false);
   const [chatBusyById, setChatBusyById] = useState<Record<string, boolean>>({});
   const chatBusy = useMemo(() => Object.values(chatBusyById).some(Boolean), [chatBusyById]);
+  const hasProvidedChatIds = Array.isArray(chatIds);
 
   const reloadChats = useCallback(async () => {
+    if (hasProvidedChatIds) {
+      return chatIds;
+    }
     try {
       const conversations = await rpc.db.getConversations(taskId);
       return conversations
@@ -18,11 +22,22 @@ export function useTaskBusy(taskId: string) {
     } catch {
       return [];
     }
-  }, [taskId]);
-
-  useEffect(() => activityStore.subscribe(taskId, setMainBusy, { kinds: ['main'] }), [taskId]);
+  }, [chatIds, hasProvidedChatIds, taskId]);
 
   useEffect(() => {
+    if (!enabled) {
+      setMainBusy(false);
+      return;
+    }
+    return activityStore.subscribe(taskId, setMainBusy, { kinds: ['main'] });
+  }, [enabled, taskId]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setChatBusyById({});
+      return;
+    }
+
     let cancelled = false;
     const chatUnsubsById = new Map<string, () => void>();
     let loadSeq = 0;
@@ -71,6 +86,15 @@ export function useTaskBusy(taskId: string) {
 
     void load();
 
+    if (hasProvidedChatIds) {
+      return () => {
+        cancelled = true;
+        try {
+          for (const off of chatUnsubsById.values()) off?.();
+        } catch {}
+      };
+    }
+
     const onChanged = (event: Event) => {
       const custom = event as CustomEvent<{ taskId?: string }>;
       if (custom.detail?.taskId !== taskId) return;
@@ -85,7 +109,7 @@ export function useTaskBusy(taskId: string) {
         for (const off of chatUnsubsById.values()) off?.();
       } catch {}
     };
-  }, [taskId, reloadChats]);
+  }, [enabled, hasProvidedChatIds, reloadChats, taskId]);
 
-  return mainBusy || chatBusy;
+  return enabled ? mainBusy || chatBusy : false;
 }

--- a/src/renderer/hooks/useTaskChanges.ts
+++ b/src/renderer/hooks/useTaskChanges.ts
@@ -28,12 +28,13 @@ export function useTaskChanges(
   taskId: string,
   options: UseTaskChangesOptions = {}
 ) {
+  const { isActive = true, idleIntervalMs = 60000 } = options;
   const [changes, setChanges] = useState<TaskChanges>({
     taskId,
     changes: [],
     totalAdditions: 0,
     totalDeletions: 0,
-    isLoading: true,
+    isLoading: Boolean(isActive),
   });
   const [isDocumentVisible, setIsDocumentVisible] = useState(() => {
     if (typeof document === 'undefined') return true;
@@ -44,7 +45,6 @@ export function useTaskChanges(
     return document.hasFocus();
   });
 
-  const { isActive = true, idleIntervalMs = 60000 } = options;
   const taskPathRef = useRef(taskPath);
   const inFlightRef = useRef(false);
   const hasLoadedRef = useRef(false);
@@ -68,6 +68,7 @@ export function useTaskChanges(
   }, [taskPath]);
 
   useEffect(() => {
+    if (!isActive) return;
     if (typeof document === 'undefined' || typeof window === 'undefined') return;
 
     const handleVisibility = () => {
@@ -85,7 +86,7 @@ export function useTaskChanges(
       window.removeEventListener('focus', handleFocus);
       window.removeEventListener('blur', handleBlur);
     };
-  }, []);
+  }, [isActive]);
 
   const queueRefresh = useCallback((shouldSetLoading: boolean) => {
     pendingRefreshRef.current = true;
@@ -225,6 +226,9 @@ export function useTaskChanges(
   useEffect(() => {
     if (!taskPath || !shouldPoll) {
       clearIdleHandle();
+      if (!isActive) {
+        setChanges((prev) => (prev.isLoading ? { ...prev, isLoading: false } : prev));
+      }
       return;
     }
 
@@ -237,7 +241,7 @@ export function useTaskChanges(
   }, [taskPath, shouldPoll, fetchChanges, scheduleIdleRefresh, clearIdleHandle]);
 
   useEffect(() => {
-    if (!taskPath) return;
+    if (!taskPath || !isActive) return;
     const api = window.electronAPI;
     let off: (() => void) | undefined;
     let watchId: string | undefined;
@@ -280,7 +284,7 @@ export function useTaskChanges(
         api.unwatchGitStatus(taskPath, watchId).catch(() => {});
       }
     };
-  }, [taskPath, fetchChanges]);
+  }, [taskPath, fetchChanges, isActive]);
 
   return {
     ...changes,

--- a/src/renderer/hooks/useTaskStatus.ts
+++ b/src/renderer/hooks/useTaskStatus.ts
@@ -9,11 +9,15 @@ import { rpc } from '../lib/rpc';
 const EMPTY_STATUS = 'unknown' as AgentStatusKind;
 const CONVERSATIONS_CHANGED_EVENT = 'emdash:conversations-changed';
 
-export function useTaskStatus(taskId: string): AgentStatusKind {
+export function useTaskStatus(taskId: string, chatIds?: string[], enabled = true): AgentStatusKind {
   const [mainStatus, setMainStatus] = useState<AgentStatusKind>(EMPTY_STATUS);
   const [chatStatuses, setChatStatuses] = useState<Record<string, AgentStatusKind>>({});
+  const hasProvidedChatIds = Array.isArray(chatIds);
 
   const reloadChats = useCallback(async () => {
+    if (hasProvidedChatIds) {
+      return chatIds;
+    }
     try {
       const conversations = await rpc.db.getConversations(taskId);
       return conversations
@@ -22,14 +26,22 @@ export function useTaskStatus(taskId: string): AgentStatusKind {
     } catch {
       return [];
     }
-  }, [taskId]);
-
-  useEffect(
-    () => agentStatusStore.subscribe(taskId, (snapshot) => setMainStatus(snapshot.kind)),
-    [taskId]
-  );
+  }, [chatIds, hasProvidedChatIds, taskId]);
 
   useEffect(() => {
+    if (!enabled) {
+      setMainStatus(EMPTY_STATUS);
+      return;
+    }
+    return agentStatusStore.subscribe(taskId, (snapshot) => setMainStatus(snapshot.kind));
+  }, [enabled, taskId]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setChatStatuses({});
+      return;
+    }
+
     let cancelled = false;
     const chatUnsubs = new Map<string, () => void>();
     const exitUnsubs = new Map<string, () => void>();
@@ -92,6 +104,22 @@ export function useTaskStatus(taskId: string): AgentStatusKind {
 
     void load();
 
+    if (hasProvidedChatIds) {
+      const mainExitUnsubs = PROVIDER_IDS.map((providerId) => {
+        const ptyId = makePtyId(providerId, 'main', taskId);
+        return window.electronAPI.onPtyExit(ptyId, () => {
+          agentStatusStore.handlePtyExit({ ptyId });
+        });
+      });
+
+      return () => {
+        cancelled = true;
+        for (const off of chatUnsubs.values()) off?.();
+        for (const off of exitUnsubs.values()) off?.();
+        for (const off of mainExitUnsubs) off?.();
+      };
+    }
+
     const onChanged = (event: Event) => {
       const custom = event as CustomEvent<{ taskId?: string }>;
       if (custom.detail?.taskId !== taskId) return;
@@ -113,7 +141,7 @@ export function useTaskStatus(taskId: string): AgentStatusKind {
       for (const off of exitUnsubs.values()) off?.();
       for (const off of mainExitUnsubs) off?.();
     };
-  }, [taskId, reloadChats]);
+  }, [enabled, hasProvidedChatIds, reloadChats, taskId]);
 
   return useMemo(
     () => deriveTaskStatus([mainStatus, ...Object.values(chatStatuses)]),

--- a/src/renderer/hooks/useTaskUnread.ts
+++ b/src/renderer/hooks/useTaskUnread.ts
@@ -4,11 +4,15 @@ import { rpc } from '../lib/rpc';
 
 const CONVERSATIONS_CHANGED_EVENT = 'emdash:conversations-changed';
 
-export function useTaskUnread(taskId: string): boolean {
+export function useTaskUnread(taskId: string, chatIds?: string[], enabled = true): boolean {
   const [mainUnread, setMainUnread] = useState(false);
   const [chatUnreadById, setChatUnreadById] = useState<Record<string, boolean>>({});
+  const hasProvidedChatIds = Array.isArray(chatIds);
 
   const reloadChats = useCallback(async () => {
+    if (hasProvidedChatIds) {
+      return chatIds;
+    }
     try {
       const conversations = await rpc.db.getConversations(taskId);
       return conversations
@@ -17,11 +21,22 @@ export function useTaskUnread(taskId: string): boolean {
     } catch {
       return [];
     }
-  }, [taskId]);
-
-  useEffect(() => agentStatusStore.subscribeUnread(taskId, setMainUnread), [taskId]);
+  }, [chatIds, hasProvidedChatIds, taskId]);
 
   useEffect(() => {
+    if (!enabled) {
+      setMainUnread(false);
+      return;
+    }
+    return agentStatusStore.subscribeUnread(taskId, setMainUnread);
+  }, [enabled, taskId]);
+
+  useEffect(() => {
+    if (!enabled) {
+      setChatUnreadById({});
+      return;
+    }
+
     let cancelled = false;
     const chatUnsubs = new Map<string, () => void>();
     let loadSeq = 0;
@@ -66,6 +81,13 @@ export function useTaskUnread(taskId: string): boolean {
 
     void load();
 
+    if (hasProvidedChatIds) {
+      return () => {
+        cancelled = true;
+        for (const off of chatUnsubs.values()) off?.();
+      };
+    }
+
     const onChanged = (event: Event) => {
       const custom = event as CustomEvent<{ taskId?: string }>;
       if (custom.detail?.taskId !== taskId) return;
@@ -78,7 +100,7 @@ export function useTaskUnread(taskId: string): boolean {
       window.removeEventListener(CONVERSATIONS_CHANGED_EVENT, onChanged);
       for (const off of chatUnsubs.values()) off?.();
     };
-  }, [taskId, reloadChats]);
+  }, [enabled, hasProvidedChatIds, reloadChats, taskId]);
 
   return useMemo(
     () => mainUnread || Object.values(chatUnreadById).some(Boolean),


### PR DESCRIPTION
## Summary
- batch conversation summary loading for project task lists instead of fetching conversations per row
- defer expensive row-level status, git, and PR work until a task row becomes visible
- mark project-view activation as a transition so selection does not block the renderer

## Testing
- pnpm run type-check
- pnpm exec vitest run