### PR TITLE
fix(ssh): store host key buffer in addHostKey so verifyHostKey matches

### DIFF
--- a/src/main/services/ssh/SshHostKeyService.ts
+++ b/src/main/services/ssh/SshHostKeyService.ts
@@ -132,21 +132,15 @@ export class SshHostKeyService {
    * @param host - Hostname or IP address
    * @param port - SSH port
    * @param keyType - Type of host key
-   * @param fingerprint - Host key fingerprint
+   * @param key - Raw host key buffer
    */
-  async addHostKey(
-    host: string,
-    port: number,
-    keyType: string,
-    fingerprint: string
-  ): Promise<void> {
+  async addHostKey(host: string, port: number, keyType: string, key: Buffer): Promise<void> {
     await this.initialize();
 
     const hostPort = port === 22 ? host : `[${host}]:${port}`;
-    // Store fingerprint with algorithm so we can persist correctly
-    this.knownHosts.set(hostPort, { algorithm: keyType || 'ssh-ed25519', keyBase64: fingerprint });
+    const keyBase64 = key.toString('base64');
+    this.knownHosts.set(hostPort, { algorithm: keyType || 'ssh-ed25519', keyBase64 });
 
-    // Rewrite entire file to ensure consistency
     await this.persistKnownHosts();
   }
 

--- a/src/main/services/ssh/__tests__/SshHostKeyService.test.ts
+++ b/src/main/services/ssh/__tests__/SshHostKeyService.test.ts
@@ -195,22 +195,26 @@ host3.example.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdH
     it('should add host key with standard port', async () => {
       (access as Mock).mockRejectedValue(new Error('File not found'));
 
-      await service.addHostKey('new.host.com', 22, 'ssh-ed25519', 'SHA256:abc123def456');
+      const keyBuffer = Buffer.from('new-host-key-data');
+      await service.addHostKey('new.host.com', 22, 'ssh-ed25519', keyBuffer);
 
+      const expectedKeyBase64 = keyBuffer.toString('base64');
       expect(writeFile).toHaveBeenCalledWith(
         '/home/testuser/.ssh/known_hosts',
-        'new.host.com ssh-ed25519 SHA256:abc123def456\n'
+        `new.host.com ssh-ed25519 ${expectedKeyBase64}\n`
       );
     });
 
     it('should add host key with non-standard port', async () => {
       (access as Mock).mockRejectedValue(new Error('File not found'));
 
-      await service.addHostKey('new.host.com', 2222, 'ssh-ed25519', 'SHA256:abc123def456');
+      const keyBuffer = Buffer.from('new-host-key-data');
+      await service.addHostKey('new.host.com', 2222, 'ssh-ed25519', keyBuffer);
 
+      const expectedKeyBase64 = keyBuffer.toString('base64');
       expect(writeFile).toHaveBeenCalledWith(
         '/home/testuser/.ssh/known_hosts',
-        '[new.host.com]:2222 ssh-ed25519 SHA256:abc123def456\n'
+        `[new.host.com]:2222 ssh-ed25519 ${expectedKeyBase64}\n`
       );
     });
 
@@ -218,11 +222,13 @@ host3.example.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdH
       (access as Mock).mockResolvedValue(undefined);
       (readFile as Mock).mockResolvedValue('old.host.com ssh-ed25519 oldkey\n');
 
-      await service.addHostKey('old.host.com', 22, 'ssh-ed25519', 'new-fingerprint');
+      const keyBuffer = Buffer.from('updated-key-data');
+      await service.addHostKey('old.host.com', 22, 'ssh-ed25519', keyBuffer);
 
+      const expectedKeyBase64 = keyBuffer.toString('base64');
       expect(writeFile).toHaveBeenCalledWith(
         '/home/testuser/.ssh/known_hosts',
-        'old.host.com ssh-ed25519 new-fingerprint\n'
+        `old.host.com ssh-ed25519 ${expectedKeyBase64}\n`
       );
     });
   });


### PR DESCRIPTION
fix: #1360

### description

- We were saving the host key fingerprint in the key field. Reconnect decoded it as base64 and re-hashed it, so it never matched. Accepted hosts showed as "changed" and TOFU was broken.

### Changes

- addHostKey() now takes a key Buffer and stores its base64; no fingerprint.
- Tests pass a key buffer and assert file has base64 key data.

### Testing
- pnpm exec vitest run src/main/services/ssh/__tests__/SshHostKeyService.test.ts — 29 tests pass.