### PR TITLE
feat: add Cmd/Ctrl shortcuts for agent tabs

### DIFF
--- a/src/main/app/menu.ts
+++ b/src/main/app/menu.ts
@@ -1,4 +1,4 @@
-import { Menu, shell, app, BrowserWindow, nativeImage } from 'electron';
+import { Menu, shell, app, BrowserWindow } from 'electron';
 import { EMDASH_RELEASES_URL, EMDASH_DOCS_URL } from '@shared/urls';
 
 function getFocusedWindow(): BrowserWindow | null {
@@ -65,13 +65,12 @@ export function setupApplicationMenu(): void {
               { type: 'separator' as const },
             ]
           : []),
-        isMac
-          ? {
-              label: 'Close Tab',
-              accelerator: 'CmdOrCtrl+W',
-              click: () => sendToRenderer('menu:close-tab'),
-            }
-          : { role: 'quit' as const },
+        {
+          label: 'Close Tab',
+          accelerator: 'CmdOrCtrl+W',
+          click: () => sendToRenderer('menu:close-tab'),
+        },
+        ...(!isMac ? [{ type: 'separator' as const }, { role: 'quit' as const }] : []),
       ],
     },
     // Edit menu

--- a/src/renderer/components/AppKeyboardShortcuts.tsx
+++ b/src/renderer/components/AppKeyboardShortcuts.tsx
@@ -70,6 +70,8 @@ const AppKeyboardShortcuts: React.FC<AppKeyboardShortcutsProps> = ({
       window.dispatchEvent(
         new CustomEvent('emdash:switch-agent', { detail: { direction: 'prev' } })
       ),
+    onSelectAgentTab: (tabIndex) =>
+      window.dispatchEvent(new CustomEvent('emdash:select-agent-tab', { detail: { tabIndex } })),
     onOpenInEditor: handleOpenInEditor,
     onCloseModal: (
       [

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -788,21 +788,21 @@ const ChatInterface: React.FC<Props> = ({
   useEffect(() => {
     const handleAgentSwitch = (event: Event) => {
       const customEvent = event as CustomEvent<{ direction: 'next' | 'prev' }>;
-      if (conversations.length <= 1) return;
+      if (sortedConversations.length <= 1) return;
       const direction = customEvent.detail?.direction;
       if (!direction) return;
 
-      const currentIndex = conversations.findIndex((c) => c.id === activeConversationId);
+      const currentIndex = sortedConversations.findIndex((c) => c.id === activeConversationId);
       if (currentIndex === -1) return;
 
       let newIndex: number;
       if (direction === 'prev') {
-        newIndex = currentIndex <= 0 ? conversations.length - 1 : currentIndex - 1;
+        newIndex = currentIndex <= 0 ? sortedConversations.length - 1 : currentIndex - 1;
       } else {
-        newIndex = (currentIndex + 1) % conversations.length;
+        newIndex = (currentIndex + 1) % sortedConversations.length;
       }
 
-      const newConversation = conversations[newIndex];
+      const newConversation = sortedConversations[newIndex];
       if (newConversation) {
         handleSwitchChat(newConversation.id);
       }
@@ -812,7 +812,26 @@ const ChatInterface: React.FC<Props> = ({
     return () => {
       window.removeEventListener('emdash:switch-agent', handleAgentSwitch);
     };
-  }, [conversations, activeConversationId, handleSwitchChat]);
+  }, [sortedConversations, activeConversationId, handleSwitchChat]);
+
+  useEffect(() => {
+    const handleAgentTabSelection = (event: Event) => {
+      const customEvent = event as CustomEvent<{ tabIndex: number }>;
+      const tabIndex = customEvent.detail?.tabIndex;
+      if (typeof tabIndex !== 'number') return;
+      if (tabIndex < 0 || tabIndex >= sortedConversations.length) return;
+
+      const selectedConversation = sortedConversations[tabIndex];
+      if (selectedConversation) {
+        handleSwitchChat(selectedConversation.id);
+      }
+    };
+
+    window.addEventListener('emdash:select-agent-tab', handleAgentTabSelection);
+    return () => {
+      window.removeEventListener('emdash:select-agent-tab', handleAgentTabSelection);
+    };
+  }, [sortedConversations, handleSwitchChat]);
 
   // Close active chat tab on Cmd+W
   useEffect(() => {

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -457,6 +457,21 @@ const MultiAgentTask: React.FC<Props> = ({
     };
   }, [variants.length]);
 
+  useEffect(() => {
+    const handleAgentTabSelection = (event: Event) => {
+      const customEvent = event as CustomEvent<{ tabIndex: number }>;
+      const tabIndex = customEvent.detail?.tabIndex;
+      if (typeof tabIndex !== 'number') return;
+      if (tabIndex < 0 || tabIndex >= variants.length) return;
+      setActiveTabIndex(tabIndex);
+    };
+
+    window.addEventListener('emdash:select-agent-tab', handleAgentTabSelection);
+    return () => {
+      window.removeEventListener('emdash:select-agent-tab', handleAgentTabSelection);
+    };
+  }, [variants.length]);
+
   if (!multi?.enabled) {
     return (
       <div className="flex h-full items-center justify-center text-sm text-muted-foreground">

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -280,6 +280,24 @@ export function hasShortcutConflict(shortcut1: ShortcutConfig, shortcut2: Shortc
   );
 }
 
+export function getAgentTabSelectionIndex(
+  event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+  isMac = isMacPlatform
+): number | null {
+  const hasCommandModifier =
+    (isMac ? event.metaKey : event.metaKey || event.ctrlKey) && !event.shiftKey;
+  if (!hasCommandModifier || event.altKey) {
+    return null;
+  }
+
+  const key = normalizeShortcutKey(event.key);
+  if (!/^[1-9]$/.test(key)) {
+    return null;
+  }
+
+  return Number(key) - 1;
+}
+
 function matchesModifier(modifier: ShortcutModifier | undefined, event: KeyboardEvent): boolean {
   if (!modifier) {
     return !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
@@ -538,6 +556,22 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
           return;
         }
       }
+
+      const agentTabIndex = getAgentTabSelectionIndex(event);
+      if (agentTabIndex === null) {
+        return;
+      }
+
+      const isCommandPaletteOpen = Boolean(handlers.isCommandPaletteOpen);
+      if (isCommandPaletteOpen) {
+        event.preventDefault();
+        handlers.onCloseModal?.();
+        setTimeout(() => handlers.onSelectAgentTab?.(agentTabIndex), 100);
+        return;
+      }
+
+      event.preventDefault();
+      handlers.onSelectAgentTab?.(agentTabIndex);
     };
 
     window.addEventListener('keydown', handleKeyDown, true);

--- a/src/renderer/types/shortcuts.ts
+++ b/src/renderer/types/shortcuts.ts
@@ -90,6 +90,7 @@ export interface GlobalShortcutHandlers {
   // Agent switching (within same task)
   onNextAgent?: () => void;
   onPrevAgent?: () => void;
+  onSelectAgentTab?: (tabIndex: number) => void;
 
   // Open in editor
   onOpenInEditor?: () => void;

--- a/src/test/renderer/useKeyboardShortcuts.test.ts
+++ b/src/test/renderer/useKeyboardShortcuts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { getAgentTabSelectionIndex } from '../../renderer/hooks/useKeyboardShortcuts';
+
+describe('getAgentTabSelectionIndex', () => {
+  it('maps Cmd/Ctrl+1 through Cmd/Ctrl+9 to zero-based tab indexes', () => {
+    expect(
+      getAgentTabSelectionIndex({
+        key: '1',
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+      } as KeyboardEvent)
+    ).toBe(0);
+
+    expect(
+      getAgentTabSelectionIndex({
+        key: '9',
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+      } as KeyboardEvent)
+    ).toBe(8);
+  });
+
+  it('accepts Ctrl+number as the Command equivalent on non-mac platforms', () => {
+    expect(
+      getAgentTabSelectionIndex(
+        {
+          key: '4',
+          metaKey: false,
+          ctrlKey: true,
+          altKey: false,
+          shiftKey: false,
+        } as KeyboardEvent,
+        false
+      )
+    ).toBe(3);
+  });
+
+  it('ignores keys outside 1-9 and modified variants', () => {
+    expect(
+      getAgentTabSelectionIndex({
+        key: '0',
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+      } as KeyboardEvent)
+    ).toBeNull();
+
+    expect(
+      getAgentTabSelectionIndex({
+        key: '1',
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: true,
+      } as KeyboardEvent)
+    ).toBeNull();
+
+    expect(
+      getAgentTabSelectionIndex({
+        key: '1',
+        metaKey: true,
+        ctrlKey: false,
+        altKey: true,
+        shiftKey: false,
+      } as KeyboardEvent)
+    ).toBeNull();
+
+    expect(
+      getAgentTabSelectionIndex({
+        key: '1',
+        metaKey: false,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+      } as KeyboardEvent)
+    ).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add Cmd/Ctrl+1 through Cmd/Ctrl+9 to select agent tabs across chat and multi-agent task views
- keep Cmd/Ctrl+W routed through the native menu and align the File menu so Close Tab is available on macOS, Windows, and Linux
- add focused renderer tests for the numeric tab shortcut parsing

## Testing
- pnpm run format
- pnpm run lint
- pnpm run type-check
- pnpm exec vitest run

Closes #1354

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches global keydown handling and tab-switching logic in both chat and multi-agent views, so regressions could impact common navigation shortcuts across platforms. Changes are contained to UI/menu shortcut routing with added unit coverage for the new numeric parsing.
> 
> **Overview**
> Enables **direct agent tab selection** via `Cmd/Ctrl+1`…`Cmd/Ctrl+9`, routing the shortcut through `useKeyboardShortcuts` (with command-palette close-and-retry behavior) and dispatching a new `emdash:select-agent-tab` event.
> 
> Updates `ChatInterface` and `MultiAgentTask` to consume the new event and switch to the requested tab (and makes agent cycling use `sortedConversations` for consistent ordering). Aligns the native `File` menu so **Close Tab (`Cmd/Ctrl+W`)** is available on macOS/Windows/Linux while keeping quit behavior on non-mac, and adds focused Vitest coverage for numeric shortcut parsing (`getAgentTabSelectionIndex`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 82f0636cff4ab26d46278e2df88ba7d737cf82f3. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->