### PR TITLE
fix(ui): prevent TaskModal content overflow on small viewports

### DIFF
--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -11,7 +11,6 @@ import {
 import type { BaseModalProps } from '@/contexts/ModalProvider';
 import { SlugInput } from './ui/slug-input';
 import { Label } from './ui/label';
-import { Separator } from './ui/separator';
 import { MultiAgentDropdown } from './MultiAgentDropdown';
 import { TaskAdvancedSettings } from './TaskAdvancedSettings';
 import { useIntegrationStatus } from './hooks/useIntegrationStatus';
@@ -389,7 +388,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
 
   return (
     <DialogContent
-      className="max-h-[calc(100vh-48px)] max-w-md overflow-visible"
+      className="flex max-h-[calc(100vh-48px)] max-w-md flex-col overflow-hidden p-0"
       onOpenAutoFocus={handleOpenAutoFocus}
       onInteractOutside={(e) => {
         if (isCreating) e.preventDefault();
@@ -398,7 +397,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
         if (isCreating) e.preventDefault();
       }}
     >
-      <DialogHeader>
+      <DialogHeader className="shrink-0 px-6 pr-12 pt-6">
         <DialogTitle>New Task</DialogTitle>
         <DialogDescription className="text-xs">
           Create a task and open the agent workspace.
@@ -424,72 +423,72 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, onCreateTask }) => {
         </div>
       </DialogHeader>
 
-      <Separator />
+      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+        <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
+          <div>
+            <Label htmlFor="task-name" className="mb-2 block">
+              Task name (optional)
+            </Label>
+            <SlugInput
+              ref={taskNameInputRef}
+              id="task-name"
+              value={taskName}
+              onChange={handleNameChange}
+              onFocus={() => setIsFocused(true)}
+              onBlur={() => {
+                setTouched(true);
+                setIsFocused(false);
+              }}
+              placeholder="refactor-api-routes"
+              maxLength={MAX_TASK_NAME_LENGTH}
+              className={`w-full ${touched && error && !isFocused ? 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive' : ''}`}
+              aria-invalid={touched && !!error && !isFocused}
+            />
+          </div>
 
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <div>
-          <Label htmlFor="task-name" className="mb-2 block">
-            Task name (optional)
-          </Label>
-          <SlugInput
-            ref={taskNameInputRef}
-            id="task-name"
-            value={taskName}
-            onChange={handleNameChange}
-            onFocus={() => setIsFocused(true)}
-            onBlur={() => {
-              setTouched(true);
-              setIsFocused(false);
-            }}
-            placeholder="refactor-api-routes"
-            maxLength={MAX_TASK_NAME_LENGTH}
-            className={`w-full ${touched && error && !isFocused ? 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive' : ''}`}
-            aria-invalid={touched && !!error && !isFocused}
+          <div className="flex items-center gap-4">
+            <Label className="shrink-0">Agent</Label>
+            <MultiAgentDropdown agentRuns={agentRuns} onChange={setAgentRuns} />
+          </div>
+
+          <TaskAdvancedSettings
+            isOpen={true}
+            projectPath={projectPath}
+            useWorktree={useWorktree}
+            onUseWorktreeChange={setUseWorktree}
+            autoApprove={autoApprove}
+            onAutoApproveChange={setAutoApprove}
+            hasAutoApproveSupport={hasAutoApproveSupport}
+            initialPrompt={initialPrompt}
+            onInitialPromptChange={setInitialPrompt}
+            hasInitialPromptSupport={hasInitialPromptSupport}
+            selectedLinearIssue={selectedLinearIssue}
+            onLinearIssueChange={setSelectedLinearIssue}
+            isLinearConnected={integrations.isLinearConnected}
+            onLinearConnect={integrations.handleLinearConnect}
+            selectedGithubIssue={selectedGithubIssue}
+            onGithubIssueChange={setSelectedGithubIssue}
+            linkedGithubIssueMap={linkedGithubIssueMap}
+            isGithubConnected={integrations.isGithubConnected}
+            onGithubConnect={integrations.handleGithubConnect}
+            githubLoading={integrations.githubLoading}
+            githubInstalled={integrations.githubInstalled}
+            selectedJiraIssue={selectedJiraIssue}
+            onJiraIssueChange={setSelectedJiraIssue}
+            isJiraConnected={integrations.isJiraConnected}
+            onJiraConnect={integrations.handleJiraConnect}
+            selectedGitlabIssue={selectedGitlabIssue}
+            onGitlabIssueChange={setSelectedGitlabIssue}
+            isGitlabConnected={integrations.isGitlabConnected}
+            onGitlabConnect={integrations.handleGitlabConnect}
+            selectedPlainThread={selectedPlainThread}
+            onPlainThreadChange={setSelectedPlainThread}
+            isPlainConnected={integrations.isPlainConnected}
+            onPlainConnect={integrations.handlePlainConnect}
           />
         </div>
 
-        <div className="flex items-center gap-4">
-          <Label className="shrink-0">Agent</Label>
-          <MultiAgentDropdown agentRuns={agentRuns} onChange={setAgentRuns} />
-        </div>
-
-        <TaskAdvancedSettings
-          isOpen={true}
-          projectPath={projectPath}
-          useWorktree={useWorktree}
-          onUseWorktreeChange={setUseWorktree}
-          autoApprove={autoApprove}
-          onAutoApproveChange={setAutoApprove}
-          hasAutoApproveSupport={hasAutoApproveSupport}
-          initialPrompt={initialPrompt}
-          onInitialPromptChange={setInitialPrompt}
-          hasInitialPromptSupport={hasInitialPromptSupport}
-          selectedLinearIssue={selectedLinearIssue}
-          onLinearIssueChange={setSelectedLinearIssue}
-          isLinearConnected={integrations.isLinearConnected}
-          onLinearConnect={integrations.handleLinearConnect}
-          selectedGithubIssue={selectedGithubIssue}
-          onGithubIssueChange={setSelectedGithubIssue}
-          linkedGithubIssueMap={linkedGithubIssueMap}
-          isGithubConnected={integrations.isGithubConnected}
-          onGithubConnect={integrations.handleGithubConnect}
-          githubLoading={integrations.githubLoading}
-          githubInstalled={integrations.githubInstalled}
-          selectedJiraIssue={selectedJiraIssue}
-          onJiraIssueChange={setSelectedJiraIssue}
-          isJiraConnected={integrations.isJiraConnected}
-          onJiraConnect={integrations.handleJiraConnect}
-          selectedGitlabIssue={selectedGitlabIssue}
-          onGitlabIssueChange={setSelectedGitlabIssue}
-          isGitlabConnected={integrations.isGitlabConnected}
-          onGitlabConnect={integrations.handleGitlabConnect}
-          selectedPlainThread={selectedPlainThread}
-          onPlainThreadChange={setSelectedPlainThread}
-          isPlainConnected={integrations.isPlainConnected}
-          onPlainConnect={integrations.handlePlainConnect}
-        />
-
-        <DialogFooter>
+        <DialogFooter className="shrink-0 px-6 py-4">
           <Button type="submit" disabled={!!error || isCreating} aria-busy={isCreating}>
             {isCreating ? (
               <>


### PR DESCRIPTION
## Summary

- Restructure `TaskModal` layout to use flexbox with a scrollable content area, preventing the dialog from overflowing the viewport when advanced settings expand the form
- Change `DialogContent` from `overflow-visible` to `overflow-hidden` with flex column layout
- Move padding from `DialogContent` to individual sections (`DialogHeader`, form body, `DialogFooter`) so the header and footer stay pinned while the form body scrolls
- Remove unused `Separator` import

## Test plan

- [x] Open the New Task modal on a small viewport (e.g. < 600px height)
- [x] Expand advanced settings (initial prompt, issue linking) and verify the form scrolls instead of overflowing
- [x] Verify the header and Create button remain visible and fixed at top/bottom
- [x] Confirm normal task creation flow still works end-to-end