### PR TITLE
fix(ssh): start remote PTY in worktree dir and auto-start agent

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -649,10 +649,16 @@ export function registerPtyIpc(): void {
           }
 
           const ssh = await resolveSshInvocation(remote.connectionId);
+
+          const remoteInitCommand = cwd
+            ? `cd ${quoteShellArg(cwd)} && exec \${SHELL:-/bin/sh} -il`
+            : undefined;
+
           const proc = startSshPty({
             id,
             target: ssh.target,
             sshArgs: ssh.args,
+            remoteInitCommand,
             cols,
             rows,
             env,
@@ -674,11 +680,13 @@ export function registerPtyIpc(): void {
             listeners.add(id);
           }
 
-          // Resolve tmux config from local project settings
           const remoteTmux = cwd ? await resolveTmuxEnabled(cwd) : false;
           const remoteTmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
 
-          const remoteInit = buildRemoteInitKeystrokes({ cwd, tmux: remoteTmuxOpt });
+          const remoteInit = buildRemoteInitKeystrokes({
+            cwd: undefined,
+            tmux: remoteTmuxOpt,
+          });
           if (remoteInit) {
             waitForSshPromptThenWrite(id, proc, remoteInit, 'ptyIpc:start');
           }
@@ -1171,10 +1179,15 @@ export function registerPtyIpc(): void {
             );
           }
 
+          const remoteInitCommand = cwd
+            ? `cd ${quoteShellArg(cwd)} && exec \${SHELL:-/bin/sh} -il`
+            : undefined;
+
           const proc = startSshPty({
             id,
             target: ssh.target,
             sshArgs: ssh.args,
+            remoteInitCommand,
             cols,
             rows,
             env: mergedEnv,
@@ -1197,12 +1210,11 @@ export function registerPtyIpc(): void {
             listeners.add(id);
           }
 
-          // Resolve tmux config from local project settings
           const remoteTmux = cwd ? await resolveTmuxEnabled(cwd) : false;
           const tmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
 
           const remoteInit = buildRemoteInitKeystrokes({
-            cwd,
+            cwd: undefined,
             provider: remoteProvider,
             tmux: tmuxOpt,
             preProviderCommands: preProviderCommands.length ? preProviderCommands : undefined,

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -375,7 +375,8 @@ describe('ptyIpc notification lifecycle', () => {
 
     expect(startSshPtyMock).toHaveBeenCalledTimes(1);
     expect(lastSshPtyStartOpts?.target).toBe('remote-alias');
-    expect(lastSshPtyStartOpts?.remoteInitCommand).toBeUndefined();
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain("cd '/tmp/task'");
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain('exec');
 
     const proc = ptys.get(id);
     expect(proc).toBeDefined();
@@ -385,7 +386,6 @@ describe('ptyIpc notification lifecycle', () => {
     expect(proc!.write).toHaveBeenCalled();
 
     const written = (proc!.write as any).mock.calls.map((c: any[]) => c[0]).join('');
-    expect(written).toContain("cd '/tmp/task'");
     expect(written).toContain('sh -ilc');
     expect(written).toContain('command -v');
     expect(written).toContain('claude');
@@ -601,7 +601,7 @@ describe('ptyIpc notification lifecycle', () => {
       })
     );
     expect(startSshPtyMock).toHaveBeenCalledTimes(1);
-    expect(lastSshPtyStartOpts?.remoteInitCommand).toBeUndefined();
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain("cd '/tmp/task'");
 
     const proc = ptys.get(id);
     expect(proc).toBeDefined();
@@ -649,7 +649,7 @@ describe('ptyIpc notification lifecycle', () => {
     );
 
     expect(result?.ok).toBe(true);
-    expect(lastSshPtyStartOpts?.remoteInitCommand).toBeUndefined();
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain("cd '/tmp/task'");
 
     const proc = ptys.get(id);
     expect(proc).toBeDefined();


### PR DESCRIPTION
### summary

- SSH terminals now open in the task worktree directory.
- Remote agents auto-start in that worktree like local agents.

### Fixes

fixes : #1370

### Snapshot

- No UI changes (behavioral fix only).

### Type of change

- [x] Bug fix (non-breaking change which fixes an issue)