### PR TITLE
fix: close in-app editor when opening diff from changes panel

### DIFF
--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -450,6 +450,7 @@ export function Workspace() {
                       className="lg:border-l-0"
                       forceBorder={showEditorMode}
                       onOpenChanges={(filePath?: string, taskPath?: string) => {
+                        setShowEditorMode(false);
                         setDiffViewerInitialFile(filePath ?? null);
                         setDiffViewerTaskPath(taskPath ?? null);
                         setShowDiffViewer(true);


### PR DESCRIPTION
### summary

- Close the in‑app editor when a changed file is clicked so the diff viewer becomes visible.

### Fixes

Fixes #1368

### Snapshot
- No visual changes; behavior-only fix.