### PR TITLE
fix(terminal): enable autoscroll when typing after scrolling up

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -148,7 +148,7 @@ export class TerminalSessionManager {
       lineHeight: 1.2,
       letterSpacing: 0,
       allowProposedApi: true,
-      scrollOnUserInput: false,
+      scrollOnUserInput: true,
       linkHandler: {
         activate: (_event, text) => openLink(text),
       },


### PR DESCRIPTION
### summary

- Terminal now scrolls to the bottom when you type after scrolling up.

### Fixes

Fixes #1384

### Snapshot
Add video: scroll up → type → view scrolls to show input.

### Type of change
[x] Bug fix (non-breaking change which fixes an issue)

### Mandatory Tasks
[ ] I have self-reviewed the code
[ ] A decent size PR without self-review might be rejected
Checklist
[ ] I have read the contributing guide
[ ] My code follows the style guidelines of this project (pnpm run format)
[ ] I have commented my code, particularly in hard-to-understand areas
[ ] I have checked if my PR needs changes to the documentation
[ ] I have checked if my changes generate no new warnings (pnpm run lint)
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] I haven't checked if new and existing unit tests pass locally with my changes