### PR TITLE
fix(build): pin app-builder-lib minimatch to restore mac releases

### DIFF
--- a/package.json
+++ b/package.json
@@ -251,6 +251,7 @@
   },
   "pnpm": {
     "overrides": {
+      "app-builder-lib>minimatch": "10.1.2",
       "minimatch@3": "3.1.4",
       "minimatch@5": "5.1.8",
       "minimatch@9": "9.0.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5,6 +5,7 @@ settings:
   excludeLinksFromLockfile: false
 
 overrides:
+  app-builder-lib>minimatch: 10.1.2
   minimatch@3: 3.1.4
   minimatch@5: 5.1.8
   minimatch@9: 9.0.7
@@ -4465,6 +4466,10 @@ packages:
     resolution: {integrity: sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==}
     engines: {node: '>=10'}
 
+  minimatch@10.1.2:
+    resolution: {integrity: sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==}
+    engines: {node: 20 || >=22}
+
   minimatch@10.2.3:
     resolution: {integrity: sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==}
     engines: {node: 18 || 20 || >=22}
@@ -7998,7 +8003,7 @@ snapshots:
       isbinaryfile: 5.0.7
       js-yaml: 4.1.1
       lazy-val: 1.0.5
-      minimatch: 5.1.8
+      minimatch: 10.1.2
       read-config-file: 6.3.2
       sanitize-filename: 1.6.3
       semver: 7.7.4
@@ -8038,7 +8043,7 @@ snapshots:
       js-yaml: 4.1.1
       json5: 2.2.3
       lazy-val: 1.0.5
-      minimatch: 10.2.3
+      minimatch: 10.1.2
       plist: 3.1.0
       proper-lockfile: 4.1.2
       resedit: 1.7.2
@@ -10883,6 +10888,10 @@ snapshots:
   mimic-response@1.0.1: {}
 
   mimic-response@3.1.0: {}
+
+  minimatch@10.1.2:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.1
 
   minimatch@10.2.3:
     dependencies:


### PR DESCRIPTION
## Summary

Pin `app-builder-lib` to `minimatch@10.1.2` via pnpm overrides.

This fixes the mac release packaging regression introduced after the broader minimatch security override update, where `electron-builder` produced an `app.asar` without the `dist/` output and then failed with:

`Application entry file "dist/main/main/entry.js" ... was not found in this archive`

## Root cause

The `v0.4.28` dependency update forced newer `minimatch` versions across the tree. With a fresh install, `app-builder-lib` resolved a newer minimatch version and stopped packaging `dist/**/*` into `app.asar` during mac builds.

## Changes

- Add a targeted pnpm override for `app-builder-lib>minimatch` to `10.1.2`
- Update `pnpm-lock.yaml` accordingly

## Verification

Reproduced the failure locally, then verified the fix by rerunning:

```bash
pnpm exec electron-builder --mac dmg --x64 --publish never --config.npmRebuild=false
```

Result:
- Packaging completed successfully
- `dist/main/main/entry.js` was present inside the packaged `app.asar`

## Notes

This keeps the broader minimatch security overrides in place and only pins the Electron Builder path back to the last known working version.
