### PR TITLE
feat(content): add agent-orchestrated content workspace

### DIFF
--- a/drizzle/0010_add_content_workspace.sql
+++ b/drizzle/0010_add_content_workspace.sql
@@ -1,0 +1,82 @@
+-- Content Workspace Tables Migration
+
+-- Content Workspaces (top-level container)
+CREATE TABLE `content_workspaces` (
+	`id` text PRIMARY KEY NOT NULL,
+	`project_id` text NOT NULL,
+	`name` text NOT NULL,
+	`kanban_columns` text NOT NULL,
+	`default_agents` text,
+	`metadata` text,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`project_id`) REFERENCES `projects`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_content_workspaces_project_id` ON `content_workspaces` (`project_id`);
+
+--> statement-breakpoint
+-- Brand Guidelines (workspace-level)
+CREATE TABLE `brand_guidelines` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL,
+	`name` text NOT NULL,
+	`content` text NOT NULL,
+	`is_active` integer DEFAULT 1 NOT NULL,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`workspace_id`) REFERENCES `content_workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_brand_guidelines_workspace_id` ON `brand_guidelines` (`workspace_id`);
+
+--> statement-breakpoint
+-- Collections (groups of knowledge documents)
+CREATE TABLE `collections` (
+	`id` text PRIMARY KEY NOT NULL,
+	`workspace_id` text NOT NULL,
+	`name` text NOT NULL,
+	`description` text,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`workspace_id`) REFERENCES `content_workspaces`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_collections_workspace_id` ON `collections` (`workspace_id`);
+
+--> statement-breakpoint
+-- Knowledge Documents (markdown files in collections)
+CREATE TABLE `knowledge_documents` (
+	`id` text PRIMARY KEY NOT NULL,
+	`collection_id` text NOT NULL,
+	`name` text NOT NULL,
+	`content` text NOT NULL,
+	`metadata` text,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	`updated_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`collection_id`) REFERENCES `collections`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_knowledge_documents_collection_id` ON `knowledge_documents` (`collection_id`);
+
+--> statement-breakpoint
+-- Content Outputs (generated content per task)
+CREATE TABLE `content_outputs` (
+	`id` text PRIMARY KEY NOT NULL,
+	`task_id` text NOT NULL,
+	`agent_id` text NOT NULL,
+	`content` text NOT NULL,
+	`version` integer DEFAULT 1 NOT NULL,
+	`selected` integer DEFAULT 0 NOT NULL,
+	`metadata` text,
+	`created_at` text DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	FOREIGN KEY (`task_id`) REFERENCES `tasks`(`id`) ON UPDATE no action ON DELETE cascade
+);
+--> statement-breakpoint
+CREATE INDEX `idx_content_outputs_task_id` ON `content_outputs` (`task_id`);
+
+--> statement-breakpoint
+-- Add collection_id to tasks table
+ALTER TABLE `tasks` ADD `collection_id` text;
+--> statement-breakpoint
+CREATE INDEX `idx_tasks_collection_id` ON `tasks` (`collection_id`);

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -71,6 +71,13 @@
       "when": 1738857600000,
       "tag": "0009_add_ssh_support",
       "breakpoints": true
+    },
+    {
+      "idx": 10,
+      "version": "6",
+      "when": 1741622400000,
+      "tag": "0010_add_content_workspace",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -70,6 +70,7 @@ export const tasks = sqliteTable(
     metadata: text('metadata'),
     useWorktree: integer('use_worktree').notNull().default(1),
     archivedAt: text('archived_at'), // null = active, timestamp = archived
+    collectionId: text('collection_id'), // FK to collections for content tasks (nullable for non-content tasks)
     createdAt: text('created_at')
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),
@@ -79,6 +80,7 @@ export const tasks = sqliteTable(
   },
   (table) => ({
     projectIdIdx: index('idx_tasks_project_id').on(table.projectId),
+    collectionIdIdx: index('idx_tasks_collection_id').on(table.collectionId),
   })
 );
 
@@ -171,6 +173,11 @@ export const tasksRelations = relations(tasks, ({ one, many }) => ({
   }),
   conversations: many(conversations),
   lineComments: many(lineComments),
+  contentOutputs: many(contentOutputs),
+  collection: one(collections, {
+    fields: [tasks.collectionId],
+    references: [collections.id],
+  }),
 }));
 
 export const conversationsRelations = relations(conversations, ({ one, many }) => ({
@@ -195,6 +202,158 @@ export const lineCommentsRelations = relations(lineComments, ({ one }) => ({
   }),
 }));
 
+// ============================================================================
+// Content Workspace Tables
+// ============================================================================
+
+export const contentWorkspaces = sqliteTable(
+  'content_workspaces',
+  {
+    id: text('id').primaryKey(),
+    projectId: text('project_id')
+      .notNull()
+      .references(() => projects.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    kanbanColumns: text('kanban_columns').notNull(), // JSON array of column definitions
+    defaultAgents: text('default_agents'), // JSON array of agent IDs
+    metadata: text('metadata'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    projectIdIdx: index('idx_content_workspaces_project_id').on(table.projectId),
+  })
+);
+
+export const brandGuidelines = sqliteTable(
+  'brand_guidelines',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => contentWorkspaces.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    content: text('content').notNull(), // Markdown content
+    isActive: integer('is_active').notNull().default(1), // 1 = current brand guide
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    workspaceIdIdx: index('idx_brand_guidelines_workspace_id').on(table.workspaceId),
+  })
+);
+
+export const collections = sqliteTable(
+  'collections',
+  {
+    id: text('id').primaryKey(),
+    workspaceId: text('workspace_id')
+      .notNull()
+      .references(() => contentWorkspaces.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    description: text('description'),
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    workspaceIdIdx: index('idx_collections_workspace_id').on(table.workspaceId),
+  })
+);
+
+export const knowledgeDocuments = sqliteTable(
+  'knowledge_documents',
+  {
+    id: text('id').primaryKey(),
+    collectionId: text('collection_id')
+      .notNull()
+      .references(() => collections.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(), // Filename
+    content: text('content').notNull(), // Markdown content
+    metadata: text('metadata'), // JSON for additional fields
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+    updatedAt: text('updated_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    collectionIdIdx: index('idx_knowledge_documents_collection_id').on(table.collectionId),
+  })
+);
+
+export const contentOutputs = sqliteTable(
+  'content_outputs',
+  {
+    id: text('id').primaryKey(),
+    taskId: text('task_id')
+      .notNull()
+      .references(() => tasks.id, { onDelete: 'cascade' }),
+    agentId: text('agent_id').notNull(), // Which agent generated this
+    content: text('content').notNull(), // Markdown content
+    version: integer('version').notNull().default(1),
+    selected: integer('selected').notNull().default(0), // 1 = user's preferred version
+    metadata: text('metadata'), // JSON (word count, etc.)
+    createdAt: text('created_at')
+      .notNull()
+      .default(sql`CURRENT_TIMESTAMP`),
+  },
+  (table) => ({
+    taskIdIdx: index('idx_content_outputs_task_id').on(table.taskId),
+  })
+);
+
+// Content Workspace Relations
+export const contentWorkspacesRelations = relations(contentWorkspaces, ({ one, many }) => ({
+  project: one(projects, {
+    fields: [contentWorkspaces.projectId],
+    references: [projects.id],
+  }),
+  brandGuidelines: many(brandGuidelines),
+  collections: many(collections),
+}));
+
+export const brandGuidelinesRelations = relations(brandGuidelines, ({ one }) => ({
+  workspace: one(contentWorkspaces, {
+    fields: [brandGuidelines.workspaceId],
+    references: [contentWorkspaces.id],
+  }),
+}));
+
+export const collectionsRelations = relations(collections, ({ one, many }) => ({
+  workspace: one(contentWorkspaces, {
+    fields: [collections.workspaceId],
+    references: [contentWorkspaces.id],
+  }),
+  documents: many(knowledgeDocuments),
+}));
+
+export const knowledgeDocumentsRelations = relations(knowledgeDocuments, ({ one }) => ({
+  collection: one(collections, {
+    fields: [knowledgeDocuments.collectionId],
+    references: [collections.id],
+  }),
+}));
+
+export const contentOutputsRelations = relations(contentOutputs, ({ one }) => ({
+  task: one(tasks, {
+    fields: [contentOutputs.taskId],
+    references: [tasks.id],
+  }),
+}));
+
 export type SshConnectionRow = typeof sshConnections.$inferSelect;
 export type SshConnectionInsert = typeof sshConnections.$inferInsert;
 export type ProjectRow = typeof projects.$inferSelect;
@@ -203,3 +362,15 @@ export type ConversationRow = typeof conversations.$inferSelect;
 export type MessageRow = typeof messages.$inferSelect;
 export type LineCommentRow = typeof lineComments.$inferSelect;
 export type LineCommentInsert = typeof lineComments.$inferInsert;
+
+// Content Workspace Types
+export type ContentWorkspaceRow = typeof contentWorkspaces.$inferSelect;
+export type ContentWorkspaceInsert = typeof contentWorkspaces.$inferInsert;
+export type BrandGuidelineRow = typeof brandGuidelines.$inferSelect;
+export type BrandGuidelineInsert = typeof brandGuidelines.$inferInsert;
+export type CollectionRow = typeof collections.$inferSelect;
+export type CollectionInsert = typeof collections.$inferInsert;
+export type KnowledgeDocumentRow = typeof knowledgeDocuments.$inferSelect;
+export type KnowledgeDocumentInsert = typeof knowledgeDocuments.$inferInsert;
+export type ContentOutputRow = typeof contentOutputs.$inferSelect;
+export type ContentOutputInsert = typeof contentOutputs.$inferInsert;

--- a/src/main/ipc/contentIpc.ts
+++ b/src/main/ipc/contentIpc.ts
@@ -1,0 +1,665 @@
+import { ipcMain } from 'electron';
+import {
+  contentWorkspaceService,
+  brandService,
+  collectionService,
+  knowledgeService,
+  contentOutputService,
+  contentContextService,
+  contentExportService,
+  type KanbanColumn,
+  type ExportOptions,
+} from '../services/content';
+import { log } from '../lib/logger';
+
+export function registerContentIpc() {
+  // ============================================================================
+  // Content Workspace Handlers
+  // ============================================================================
+
+  ipcMain.handle(
+    'content:workspace:create',
+    async (
+      _,
+      args: {
+        projectId: string;
+        name: string;
+        kanbanColumns?: KanbanColumn[];
+        defaultAgents?: string[];
+        metadata?: Record<string, unknown>;
+      }
+    ) => {
+      try {
+        const workspace = await contentWorkspaceService.create(args.projectId, args.name, {
+          kanbanColumns: args.kanbanColumns,
+          defaultAgents: args.defaultAgents,
+          metadata: args.metadata,
+        });
+        return { success: true, data: workspace };
+      } catch (error) {
+        log.error('Failed to create content workspace:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:workspace:get', async (_, id: string) => {
+    try {
+      const workspace = await contentWorkspaceService.getById(id);
+      return { success: true, data: workspace };
+    } catch (error) {
+      log.error('Failed to get content workspace:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:workspace:getByProject', async (_, projectId: string) => {
+    try {
+      const workspaces = await contentWorkspaceService.getByProjectId(projectId);
+      return { success: true, data: workspaces };
+    } catch (error) {
+      log.error('Failed to get content workspaces:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'content:workspace:update',
+    async (
+      _,
+      args: {
+        id: string;
+        name?: string;
+        kanbanColumns?: KanbanColumn[];
+        defaultAgents?: string[];
+        metadata?: Record<string, unknown>;
+      }
+    ) => {
+      try {
+        const workspace = await contentWorkspaceService.update(args.id, {
+          name: args.name,
+          kanbanColumns: args.kanbanColumns,
+          defaultAgents: args.defaultAgents,
+          metadata: args.metadata,
+        });
+        return { success: true, data: workspace };
+      } catch (error) {
+        log.error('Failed to update content workspace:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:workspace:delete', async (_, id: string) => {
+    try {
+      await contentWorkspaceService.delete(id);
+      return { success: true };
+    } catch (error) {
+      log.error('Failed to delete content workspace:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  // ============================================================================
+  // Brand Guidelines Handlers
+  // ============================================================================
+
+  ipcMain.handle(
+    'content:brand:create',
+    async (
+      _,
+      args: {
+        workspaceId: string;
+        name: string;
+        content: string;
+        isActive?: boolean;
+      }
+    ) => {
+      try {
+        const brand = await brandService.create(
+          args.workspaceId,
+          args.name,
+          args.content,
+          args.isActive
+        );
+        return { success: true, data: brand };
+      } catch (error) {
+        log.error('Failed to create brand guideline:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:brand:get', async (_, id: string) => {
+    try {
+      const brand = await brandService.getById(id);
+      return { success: true, data: brand };
+    } catch (error) {
+      log.error('Failed to get brand guideline:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:brand:getByWorkspace', async (_, workspaceId: string) => {
+    try {
+      const brands = await brandService.getByWorkspaceId(workspaceId);
+      return { success: true, data: brands };
+    } catch (error) {
+      log.error('Failed to get brand guidelines:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:brand:getActive', async (_, workspaceId: string) => {
+    try {
+      const brand = await brandService.getActive(workspaceId);
+      return { success: true, data: brand };
+    } catch (error) {
+      log.error('Failed to get active brand guideline:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'content:brand:update',
+    async (
+      _,
+      args: {
+        id: string;
+        name?: string;
+        content?: string;
+        isActive?: boolean;
+      }
+    ) => {
+      try {
+        const brand = await brandService.update(args.id, {
+          name: args.name,
+          content: args.content,
+          isActive: args.isActive,
+        });
+        return { success: true, data: brand };
+      } catch (error) {
+        log.error('Failed to update brand guideline:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:brand:delete', async (_, id: string) => {
+    try {
+      await brandService.delete(id);
+      return { success: true };
+    } catch (error) {
+      log.error('Failed to delete brand guideline:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  // ============================================================================
+  // Collection Handlers
+  // ============================================================================
+
+  ipcMain.handle(
+    'content:collection:create',
+    async (
+      _,
+      args: {
+        workspaceId: string;
+        name: string;
+        description?: string;
+      }
+    ) => {
+      try {
+        const collection = await collectionService.create(
+          args.workspaceId,
+          args.name,
+          args.description
+        );
+        return { success: true, data: collection };
+      } catch (error) {
+        log.error('Failed to create collection:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:collection:get', async (_, id: string) => {
+    try {
+      const collection = await collectionService.getById(id);
+      return { success: true, data: collection };
+    } catch (error) {
+      log.error('Failed to get collection:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:collection:getByWorkspace', async (_, workspaceId: string) => {
+    try {
+      const collections = await collectionService.getByWorkspaceId(workspaceId);
+      return { success: true, data: collections };
+    } catch (error) {
+      log.error('Failed to get collections:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'content:collection:update',
+    async (
+      _,
+      args: {
+        id: string;
+        name?: string;
+        description?: string;
+      }
+    ) => {
+      try {
+        const collection = await collectionService.update(args.id, {
+          name: args.name,
+          description: args.description,
+        });
+        return { success: true, data: collection };
+      } catch (error) {
+        log.error('Failed to update collection:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:collection:delete', async (_, id: string) => {
+    try {
+      await collectionService.delete(id);
+      return { success: true };
+    } catch (error) {
+      log.error('Failed to delete collection:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  // ============================================================================
+  // Knowledge Document Handlers
+  // ============================================================================
+
+  ipcMain.handle(
+    'content:knowledge:create',
+    async (
+      _,
+      args: {
+        collectionId: string;
+        name: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }
+    ) => {
+      try {
+        const document = await knowledgeService.create(
+          args.collectionId,
+          args.name,
+          args.content,
+          args.metadata
+        );
+        return { success: true, data: document };
+      } catch (error) {
+        log.error('Failed to create knowledge document:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'content:knowledge:upload',
+    async (
+      _,
+      args: {
+        collectionId: string;
+        documents: Array<{
+          name: string;
+          content: string;
+          metadata?: Record<string, unknown>;
+        }>;
+      }
+    ) => {
+      try {
+        const documents = await knowledgeService.uploadDocuments(args.collectionId, args.documents);
+        return { success: true, data: documents };
+      } catch (error) {
+        log.error('Failed to upload knowledge documents:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:knowledge:get', async (_, id: string) => {
+    try {
+      const document = await knowledgeService.getById(id);
+      return { success: true, data: document };
+    } catch (error) {
+      log.error('Failed to get knowledge document:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:knowledge:getByCollection', async (_, collectionId: string) => {
+    try {
+      const documents = await knowledgeService.getByCollectionId(collectionId);
+      return { success: true, data: documents };
+    } catch (error) {
+      log.error('Failed to get knowledge documents:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'content:knowledge:update',
+    async (
+      _,
+      args: {
+        id: string;
+        name?: string;
+        content?: string;
+        metadata?: Record<string, unknown>;
+      }
+    ) => {
+      try {
+        const document = await knowledgeService.update(args.id, {
+          name: args.name,
+          content: args.content,
+          metadata: args.metadata,
+        });
+        return { success: true, data: document };
+      } catch (error) {
+        log.error('Failed to update knowledge document:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:knowledge:delete', async (_, id: string) => {
+    try {
+      await knowledgeService.delete(id);
+      return { success: true };
+    } catch (error) {
+      log.error('Failed to delete knowledge document:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:knowledge:getContextForAgent', async (_, collectionId: string) => {
+    try {
+      const context = await knowledgeService.getCollectionContextForAgent(collectionId);
+      return { success: true, data: context };
+    } catch (error) {
+      log.error('Failed to get knowledge context for agent:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  // ============================================================================
+  // Content Output Handlers
+  // ============================================================================
+
+  ipcMain.handle(
+    'content:output:create',
+    async (
+      _,
+      args: {
+        taskId: string;
+        agentId: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }
+    ) => {
+      try {
+        const output = await contentOutputService.create(
+          args.taskId,
+          args.agentId,
+          args.content,
+          args.metadata
+        );
+        return { success: true, data: output };
+      } catch (error) {
+        log.error('Failed to create content output:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:output:get', async (_, id: string) => {
+    try {
+      const output = await contentOutputService.getById(id);
+      return { success: true, data: output };
+    } catch (error) {
+      log.error('Failed to get content output:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:output:getByTask', async (_, taskId: string) => {
+    try {
+      const outputs = await contentOutputService.getByTaskId(taskId);
+      return { success: true, data: outputs };
+    } catch (error) {
+      log.error('Failed to get content outputs:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'content:output:getByTaskAndAgent',
+    async (_, args: { taskId: string; agentId: string }) => {
+      try {
+        const outputs = await contentOutputService.getByTaskAndAgent(args.taskId, args.agentId);
+        return { success: true, data: outputs };
+      } catch (error) {
+        log.error('Failed to get content outputs:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:output:getSelected', async (_, taskId: string) => {
+    try {
+      const output = await contentOutputService.getSelectedForTask(taskId);
+      return { success: true, data: output };
+    } catch (error) {
+      log.error('Failed to get selected content output:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:output:select', async (_, id: string) => {
+    try {
+      const output = await contentOutputService.selectVersion(id);
+      return { success: true, data: output };
+    } catch (error) {
+      log.error('Failed to select content output:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'content:output:update',
+    async (
+      _,
+      args: {
+        id: string;
+        content?: string;
+        metadata?: Record<string, unknown>;
+      }
+    ) => {
+      try {
+        const output = await contentOutputService.update(args.id, {
+          content: args.content,
+          metadata: args.metadata,
+        });
+        return { success: true, data: output };
+      } catch (error) {
+        log.error('Failed to update content output:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:output:delete', async (_, id: string) => {
+    try {
+      await contentOutputService.delete(id);
+      return { success: true };
+    } catch (error) {
+      log.error('Failed to delete content output:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle('content:output:deleteByTask', async (_, taskId: string) => {
+    try {
+      await contentOutputService.deleteByTaskId(taskId);
+      return { success: true };
+    } catch (error) {
+      log.error('Failed to delete content outputs:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  // ============================================================================
+  // Content Context Handlers
+  // ============================================================================
+
+  ipcMain.handle(
+    'content:context:getForTask',
+    async (
+      _,
+      args: {
+        collectionId: string | null;
+        includeBrief?: boolean;
+        brief?: {
+          topic?: string;
+          audience?: string;
+          keywords?: string;
+          tone?: string;
+          notes?: string;
+        };
+        template?: string;
+      }
+    ) => {
+      try {
+        const context = await contentContextService.getContextForTask(args.collectionId, {
+          includeBrief: args.includeBrief,
+          brief: args.brief,
+          template: args.template,
+        });
+        return { success: true, data: context };
+      } catch (error) {
+        log.error('Failed to get content context for task:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('content:context:getForWorkspace', async (_, workspaceId: string) => {
+    try {
+      const context = await contentContextService.getWorkspaceContext(workspaceId);
+      return { success: true, data: context };
+    } catch (error) {
+      log.error('Failed to get content context for workspace:', error);
+      return { success: false, error: String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'content:context:composePrompt',
+    async (
+      _,
+      args: {
+        collectionId: string | null;
+        userPrompt?: string;
+        role?: string;
+        includeBrief?: boolean;
+        brief?: {
+          topic?: string;
+          audience?: string;
+          keywords?: string;
+          tone?: string;
+          notes?: string;
+        };
+      }
+    ) => {
+      try {
+        const context = await contentContextService.getContextForTask(args.collectionId, {
+          includeBrief: args.includeBrief,
+          brief: args.brief,
+        });
+        const fullPrompt = contentContextService.composeFullPrompt({
+          context,
+          userPrompt: args.userPrompt,
+          role: args.role,
+        });
+        return {
+          success: true,
+          data: {
+            prompt: fullPrompt,
+            context,
+          },
+        };
+      } catch (error) {
+        log.error('Failed to compose content prompt:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  // ============================================================================
+  // Content Export Handlers
+  // ============================================================================
+
+  ipcMain.handle(
+    'content:export:clipboard',
+    async (_, args: { outputId: string; options?: ExportOptions }) => {
+      try {
+        const result = await contentExportService.copyToClipboard(args.outputId, args.options);
+        return result;
+      } catch (error) {
+        log.error('Failed to copy content to clipboard:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'content:export:file',
+    async (_, args: { outputId: string; options?: ExportOptions }) => {
+      try {
+        const result = await contentExportService.exportToFile(args.outputId, args.options);
+        return result;
+      } catch (error) {
+        log.error('Failed to export content to file:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'content:export:folder',
+    async (_, args: { taskId: string; options?: ExportOptions }) => {
+      try {
+        const result = await contentExportService.exportToFolder(args.taskId, args.options);
+        return result;
+      } catch (error) {
+        log.error('Failed to export content to folder:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'content:export:selectedToFile',
+    async (_, args: { taskId: string; options?: ExportOptions }) => {
+      try {
+        const result = await contentExportService.exportSelectedToFile(args.taskId, args.options);
+        return result;
+      } catch (error) {
+        log.error('Failed to export selected content to file:', error);
+        return { success: false, error: String(error) };
+      }
+    }
+  );
+}

--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -27,6 +27,7 @@ import { createRPCRouter, registerRPCRouter } from '../../shared/ipc/rpc';
 import { ipcMain } from 'electron';
 import { registerGitlabIpc } from './gitlabIpc';
 import { registerPlainIpc } from './plainIpc';
+import { registerContentIpc } from './contentIpc';
 
 export const rpcRouter = createRPCRouter({
   db: databaseController,
@@ -69,4 +70,7 @@ export function registerAllIpc() {
   registerMcpIpc();
   registerGitlabIpc();
   registerPlainIpc();
+
+  // Content Workspace IPC
+  registerContentIpc();
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -739,6 +739,143 @@ contextBridge.exposeInMainWorld('electronAPI', {
   mcpRemoveServer: (serverName: string) => ipcRenderer.invoke('mcp:remove-server', serverName),
   mcpGetProviders: () => ipcRenderer.invoke('mcp:get-providers'),
   mcpRefreshProviders: () => ipcRenderer.invoke('mcp:refresh-providers'),
+
+  // Content Workspace
+  contentWorkspaceCreate: (args: {
+    projectId: string;
+    name: string;
+    kanbanColumns?: Array<{ id: string; name: string; status: string }>;
+    defaultAgents?: string[];
+    metadata?: Record<string, unknown>;
+  }) => ipcRenderer.invoke('content:workspace:create', args),
+  contentWorkspaceGet: (id: string) => ipcRenderer.invoke('content:workspace:get', id),
+  contentWorkspaceGetByProject: (projectId: string) =>
+    ipcRenderer.invoke('content:workspace:getByProject', projectId),
+  contentWorkspaceUpdate: (args: {
+    id: string;
+    name?: string;
+    kanbanColumns?: Array<{ id: string; name: string; status: string }>;
+    defaultAgents?: string[];
+    metadata?: Record<string, unknown>;
+  }) => ipcRenderer.invoke('content:workspace:update', args),
+  contentWorkspaceDelete: (id: string) => ipcRenderer.invoke('content:workspace:delete', id),
+
+  // Brand Guidelines
+  contentBrandCreate: (args: {
+    workspaceId: string;
+    name: string;
+    content: string;
+    isActive?: boolean;
+  }) => ipcRenderer.invoke('content:brand:create', args),
+  contentBrandGet: (id: string) => ipcRenderer.invoke('content:brand:get', id),
+  contentBrandGetByWorkspace: (workspaceId: string) =>
+    ipcRenderer.invoke('content:brand:getByWorkspace', workspaceId),
+  contentBrandGetActive: (workspaceId: string) =>
+    ipcRenderer.invoke('content:brand:getActive', workspaceId),
+  contentBrandUpdate: (args: { id: string; name?: string; content?: string; isActive?: boolean }) =>
+    ipcRenderer.invoke('content:brand:update', args),
+  contentBrandDelete: (id: string) => ipcRenderer.invoke('content:brand:delete', id),
+
+  // Collections
+  contentCollectionCreate: (args: { workspaceId: string; name: string; description?: string }) =>
+    ipcRenderer.invoke('content:collection:create', args),
+  contentCollectionGet: (id: string) => ipcRenderer.invoke('content:collection:get', id),
+  contentCollectionGetByWorkspace: (workspaceId: string) =>
+    ipcRenderer.invoke('content:collection:getByWorkspace', workspaceId),
+  contentCollectionUpdate: (args: { id: string; name?: string; description?: string }) =>
+    ipcRenderer.invoke('content:collection:update', args),
+  contentCollectionDelete: (id: string) => ipcRenderer.invoke('content:collection:delete', id),
+
+  // Knowledge Documents
+  contentKnowledgeCreate: (args: {
+    collectionId: string;
+    name: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+  }) => ipcRenderer.invoke('content:knowledge:create', args),
+  contentKnowledgeUpload: (args: {
+    collectionId: string;
+    documents: Array<{
+      name: string;
+      content: string;
+      metadata?: Record<string, unknown>;
+    }>;
+  }) => ipcRenderer.invoke('content:knowledge:upload', args),
+  contentKnowledgeGet: (id: string) => ipcRenderer.invoke('content:knowledge:get', id),
+  contentKnowledgeGetByCollection: (collectionId: string) =>
+    ipcRenderer.invoke('content:knowledge:getByCollection', collectionId),
+  contentKnowledgeUpdate: (args: {
+    id: string;
+    name?: string;
+    content?: string;
+    metadata?: Record<string, unknown>;
+  }) => ipcRenderer.invoke('content:knowledge:update', args),
+  contentKnowledgeDelete: (id: string) => ipcRenderer.invoke('content:knowledge:delete', id),
+  contentKnowledgeGetContextForAgent: (collectionId: string) =>
+    ipcRenderer.invoke('content:knowledge:getContextForAgent', collectionId),
+
+  // Content Outputs
+  contentOutputCreate: (args: {
+    taskId: string;
+    agentId: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+  }) => ipcRenderer.invoke('content:output:create', args),
+  contentOutputGet: (id: string) => ipcRenderer.invoke('content:output:get', id),
+  contentOutputGetByTask: (taskId: string) =>
+    ipcRenderer.invoke('content:output:getByTask', taskId),
+  contentOutputGetByTaskAndAgent: (args: { taskId: string; agentId: string }) =>
+    ipcRenderer.invoke('content:output:getByTaskAndAgent', args),
+  contentOutputGetSelected: (taskId: string) =>
+    ipcRenderer.invoke('content:output:getSelected', taskId),
+  contentOutputSelect: (id: string) => ipcRenderer.invoke('content:output:select', id),
+  contentOutputUpdate: (args: {
+    id: string;
+    content?: string;
+    metadata?: Record<string, unknown>;
+  }) => ipcRenderer.invoke('content:output:update', args),
+  contentOutputDelete: (id: string) => ipcRenderer.invoke('content:output:delete', id),
+  contentOutputDeleteByTask: (taskId: string) =>
+    ipcRenderer.invoke('content:output:deleteByTask', taskId),
+
+  // Content Context
+  contentContextGetForTask: (args: {
+    collectionId: string | null;
+    includeBrief?: boolean;
+    brief?: {
+      topic?: string;
+      audience?: string;
+      keywords?: string;
+      tone?: string;
+      notes?: string;
+    };
+    template?: string;
+  }) => ipcRenderer.invoke('content:context:getForTask', args),
+  contentContextGetForWorkspace: (workspaceId: string) =>
+    ipcRenderer.invoke('content:context:getForWorkspace', workspaceId),
+  contentContextComposePrompt: (args: {
+    collectionId: string | null;
+    userPrompt?: string;
+    role?: string;
+    includeBrief?: boolean;
+    brief?: {
+      topic?: string;
+      audience?: string;
+      keywords?: string;
+      tone?: string;
+      notes?: string;
+    };
+  }) => ipcRenderer.invoke('content:context:composePrompt', args),
+
+  // Content Export
+  contentExportClipboard: (args: { outputId: string; options?: Record<string, unknown> }) =>
+    ipcRenderer.invoke('content:export:clipboard', args),
+  contentExportFile: (args: { outputId: string; options?: Record<string, unknown> }) =>
+    ipcRenderer.invoke('content:export:file', args),
+  contentExportFolder: (args: { taskId: string; options?: Record<string, unknown> }) =>
+    ipcRenderer.invoke('content:export:folder', args),
+  contentExportSelectedToFile: (args: { taskId: string; options?: Record<string, unknown> }) =>
+    ipcRenderer.invoke('content:export:selectedToFile', args),
 });
 
 // Type definitions for the exposed API

--- a/src/main/services/content/BrandService.ts
+++ b/src/main/services/content/BrandService.ts
@@ -1,0 +1,168 @@
+import { and, eq } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { getDrizzleClient } from '../../db/drizzleClient';
+import {
+  brandGuidelines,
+  type BrandGuidelineRow,
+  type BrandGuidelineInsert,
+} from '../../db/schema';
+import { log } from '../../lib/logger';
+
+export interface BrandGuideline {
+  id: string;
+  workspaceId: string;
+  name: string;
+  content: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rowToBrand(row: BrandGuidelineRow): BrandGuideline {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    name: row.name,
+    content: row.content,
+    isActive: row.isActive === 1,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class BrandService {
+  async create(
+    workspaceId: string,
+    name: string,
+    content: string,
+    isActive: boolean = true
+  ): Promise<BrandGuideline> {
+    const client = await getDrizzleClient();
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    // If this brand is active, deactivate others in the same workspace
+    if (isActive) {
+      await client.db
+        .update(brandGuidelines)
+        .set({ isActive: 0, updatedAt: now })
+        .where(eq(brandGuidelines.workspaceId, workspaceId));
+    }
+
+    const insert: BrandGuidelineInsert = {
+      id,
+      workspaceId,
+      name,
+      content,
+      isActive: isActive ? 1 : 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await client.db.insert(brandGuidelines).values(insert);
+    log.info(`Created brand guideline: ${id} for workspace: ${workspaceId}`);
+
+    return {
+      id,
+      workspaceId,
+      name,
+      content,
+      isActive,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async getById(id: string): Promise<BrandGuideline | null> {
+    const client = await getDrizzleClient();
+    const rows = await client.db.select().from(brandGuidelines).where(eq(brandGuidelines.id, id));
+
+    if (rows.length === 0) return null;
+    return rowToBrand(rows[0]);
+  }
+
+  async getByWorkspaceId(workspaceId: string): Promise<BrandGuideline[]> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(brandGuidelines)
+      .where(eq(brandGuidelines.workspaceId, workspaceId));
+
+    return rows.map(rowToBrand);
+  }
+
+  async getActive(workspaceId: string): Promise<BrandGuideline | null> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(brandGuidelines)
+      .where(and(eq(brandGuidelines.workspaceId, workspaceId), eq(brandGuidelines.isActive, 1)));
+
+    if (rows.length === 0) return null;
+    return rowToBrand(rows[0]);
+  }
+
+  async update(
+    id: string,
+    updates: Partial<{
+      name: string;
+      content: string;
+      isActive: boolean;
+    }>
+  ): Promise<BrandGuideline | null> {
+    const client = await getDrizzleClient();
+    const now = new Date().toISOString();
+
+    // Get the current brand to know its workspace
+    const current = await this.getById(id);
+    if (!current) return null;
+
+    // If activating this brand, deactivate others in the same workspace
+    if (updates.isActive === true) {
+      await client.db
+        .update(brandGuidelines)
+        .set({ isActive: 0, updatedAt: now })
+        .where(eq(brandGuidelines.workspaceId, current.workspaceId));
+    }
+
+    const updateData: Partial<BrandGuidelineInsert> = {
+      updatedAt: now,
+    };
+
+    if (updates.name !== undefined) {
+      updateData.name = updates.name;
+    }
+    if (updates.content !== undefined) {
+      updateData.content = updates.content;
+    }
+    if (updates.isActive !== undefined) {
+      updateData.isActive = updates.isActive ? 1 : 0;
+    }
+
+    await client.db.update(brandGuidelines).set(updateData).where(eq(brandGuidelines.id, id));
+
+    return this.getById(id);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const client = await getDrizzleClient();
+    await client.db.delete(brandGuidelines).where(eq(brandGuidelines.id, id));
+
+    log.info(`Deleted brand guideline: ${id}`);
+    return true;
+  }
+
+  /**
+   * Format brand guidelines for agent context injection
+   */
+  formatForAgent(brand: BrandGuideline): string {
+    return `<brand_guidelines>
+<name>${brand.name}</name>
+<content>
+${brand.content}
+</content>
+</brand_guidelines>`;
+  }
+}
+
+export const brandService = new BrandService();

--- a/src/main/services/content/CollectionService.ts
+++ b/src/main/services/content/CollectionService.ts
@@ -1,0 +1,130 @@
+import { eq } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { getDrizzleClient } from '../../db/drizzleClient';
+import {
+  collections,
+  knowledgeDocuments,
+  type CollectionRow,
+  type CollectionInsert,
+} from '../../db/schema';
+import { log } from '../../lib/logger';
+
+export interface Collection {
+  id: string;
+  workspaceId: string;
+  name: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+  documentCount?: number;
+}
+
+function rowToCollection(row: CollectionRow): Collection {
+  return {
+    id: row.id,
+    workspaceId: row.workspaceId,
+    name: row.name,
+    description: row.description ?? undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class CollectionService {
+  async create(workspaceId: string, name: string, description?: string): Promise<Collection> {
+    const client = await getDrizzleClient();
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    const insert: CollectionInsert = {
+      id,
+      workspaceId,
+      name,
+      description: description ?? null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await client.db.insert(collections).values(insert);
+    log.info(`Created collection: ${id} for workspace: ${workspaceId}`);
+
+    return {
+      id,
+      workspaceId,
+      name,
+      description,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async getById(id: string): Promise<Collection | null> {
+    const client = await getDrizzleClient();
+    const rows = await client.db.select().from(collections).where(eq(collections.id, id));
+
+    if (rows.length === 0) return null;
+    return rowToCollection(rows[0]);
+  }
+
+  async getByWorkspaceId(workspaceId: string): Promise<Collection[]> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(collections)
+      .where(eq(collections.workspaceId, workspaceId));
+
+    // Get document counts for each collection
+    const collectionsWithCounts = await Promise.all(
+      rows.map(async (row) => {
+        const docRows = await client.db
+          .select()
+          .from(knowledgeDocuments)
+          .where(eq(knowledgeDocuments.collectionId, row.id));
+
+        return {
+          ...rowToCollection(row),
+          documentCount: docRows.length,
+        };
+      })
+    );
+
+    return collectionsWithCounts;
+  }
+
+  async update(
+    id: string,
+    updates: Partial<{
+      name: string;
+      description: string;
+    }>
+  ): Promise<Collection | null> {
+    const client = await getDrizzleClient();
+    const now = new Date().toISOString();
+
+    const updateData: Partial<CollectionInsert> = {
+      updatedAt: now,
+    };
+
+    if (updates.name !== undefined) {
+      updateData.name = updates.name;
+    }
+    if (updates.description !== undefined) {
+      updateData.description = updates.description;
+    }
+
+    await client.db.update(collections).set(updateData).where(eq(collections.id, id));
+
+    return this.getById(id);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const client = await getDrizzleClient();
+    // Documents will be cascade deleted due to FK constraint
+    await client.db.delete(collections).where(eq(collections.id, id));
+
+    log.info(`Deleted collection: ${id}`);
+    return true;
+  }
+}
+
+export const collectionService = new CollectionService();

--- a/src/main/services/content/ContentContextService.ts
+++ b/src/main/services/content/ContentContextService.ts
@@ -1,0 +1,247 @@
+import { brandService } from './BrandService';
+import { knowledgeService } from './KnowledgeService';
+import { collectionService } from './CollectionService';
+import { contentWorkspaceService } from './ContentWorkspaceService';
+import { log } from '../../lib/logger';
+
+export interface ContentContext {
+  /** Formatted context ready for agent injection */
+  context: string;
+  /** Estimated character count */
+  characterCount: number;
+  /** Whether brand guidelines were included */
+  hasBrand: boolean;
+  /** Whether knowledge documents were included */
+  hasKnowledge: boolean;
+  /** Number of knowledge documents included */
+  documentCount: number;
+}
+
+export interface ContentContextOptions {
+  /** Include content brief in context */
+  includeBrief?: boolean;
+  /** Content brief data */
+  brief?: {
+    topic?: string;
+    audience?: string;
+    keywords?: string;
+    tone?: string;
+    notes?: string;
+  };
+  /** Optional prompt template to wrap the context */
+  template?: string;
+}
+
+/**
+ * Service for composing content context from brand guidelines and knowledge documents.
+ * This context is injected into agent prompts for content-aware generation.
+ */
+export class ContentContextService {
+  /**
+   * Get full content context for a task based on its collection.
+   * Loads workspace brand guidelines and collection knowledge documents.
+   */
+  async getContextForTask(
+    collectionId: string | null | undefined,
+    options: ContentContextOptions = {}
+  ): Promise<ContentContext> {
+    let brandContext = '';
+    let knowledgeContext = '';
+    let hasBrand = false;
+    let hasKnowledge = false;
+    let documentCount = 0;
+
+    if (collectionId) {
+      // Get the collection to find the workspace
+      const collection = await collectionService.getById(collectionId);
+
+      if (collection) {
+        // Get workspace brand guidelines
+        const workspace = await contentWorkspaceService.getById(collection.workspaceId);
+        if (workspace) {
+          const activeBrand = await brandService.getActive(workspace.id);
+          if (activeBrand) {
+            brandContext = brandService.formatForAgent(activeBrand);
+            hasBrand = true;
+          }
+        }
+
+        // Get knowledge documents from collection
+        const documents = await knowledgeService.getByCollectionId(collectionId);
+        if (documents.length > 0) {
+          knowledgeContext = knowledgeService.formatCollectionForAgent(documents);
+          hasKnowledge = true;
+          documentCount = documents.length;
+        }
+      }
+    }
+
+    // Build the context sections
+    const sections: string[] = [];
+
+    // Add brand guidelines
+    if (brandContext) {
+      sections.push(brandContext);
+    }
+
+    // Add content brief if provided
+    if (options.includeBrief && options.brief) {
+      const briefContext = this.formatBriefForAgent(options.brief);
+      if (briefContext) {
+        sections.push(briefContext);
+      }
+    }
+
+    // Add knowledge documents
+    if (knowledgeContext) {
+      sections.push(knowledgeContext);
+    }
+
+    // Combine sections
+    let context = sections.join('\n\n');
+
+    // Wrap with template if provided
+    if (options.template && context) {
+      context = options.template.replace('{{content_context}}', context);
+    }
+
+    return {
+      context,
+      characterCount: context.length,
+      hasBrand,
+      hasKnowledge,
+      documentCount,
+    };
+  }
+
+  /**
+   * Get context for a workspace (brand only, no collection-specific knowledge).
+   */
+  async getWorkspaceContext(workspaceId: string): Promise<ContentContext> {
+    let brandContext = '';
+    let hasBrand = false;
+
+    const activeBrand = await brandService.getActive(workspaceId);
+    if (activeBrand) {
+      brandContext = brandService.formatForAgent(activeBrand);
+      hasBrand = true;
+    }
+
+    return {
+      context: brandContext,
+      characterCount: brandContext.length,
+      hasBrand,
+      hasKnowledge: false,
+      documentCount: 0,
+    };
+  }
+
+  /**
+   * Format content brief for agent context injection.
+   */
+  formatBriefForAgent(brief: ContentContextOptions['brief']): string {
+    if (!brief) return '';
+
+    const lines: string[] = ['<content_brief>'];
+
+    if (brief.topic) {
+      lines.push(`<topic>${brief.topic}</topic>`);
+    }
+    if (brief.audience) {
+      lines.push(`<target_audience>${brief.audience}</target_audience>`);
+    }
+    if (brief.keywords) {
+      lines.push(`<keywords>${brief.keywords}</keywords>`);
+    }
+    if (brief.tone) {
+      lines.push(`<tone_style>${brief.tone}</tone_style>`);
+    }
+    if (brief.notes) {
+      lines.push(`<additional_notes>${brief.notes}</additional_notes>`);
+    }
+
+    lines.push('</content_brief>');
+
+    // Only return if we have at least one field
+    if (lines.length <= 2) return '';
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Estimate token count (rough approximation: ~4 chars per token).
+   */
+  estimateTokenCount(context: string): number {
+    return Math.ceil(context.length / 4);
+  }
+
+  /**
+   * Create a system prompt preamble for content creation.
+   */
+  createContentPreamble(options: {
+    hasBrand: boolean;
+    hasKnowledge: boolean;
+    role?: string;
+  }): string {
+    const lines: string[] = ['You are assisting with content creation.', ''];
+
+    if (options.role) {
+      lines[0] = `You are a ${options.role} assisting with content creation.`;
+    }
+
+    if (options.hasBrand) {
+      lines.push(
+        'The following brand guidelines define the voice, tone, and style to use.',
+        'Ensure all content adheres to these guidelines.',
+        ''
+      );
+    }
+
+    if (options.hasKnowledge) {
+      lines.push(
+        'Knowledge documents are provided as reference material.',
+        'Use these documents to inform your content with accurate, relevant information.',
+        ''
+      );
+    }
+
+    return lines.join('\n');
+  }
+
+  /**
+   * Compose full prompt with preamble, context, and user instructions.
+   */
+  composeFullPrompt(options: {
+    context: ContentContext;
+    userPrompt?: string;
+    role?: string;
+  }): string {
+    const { context, userPrompt, role } = options;
+
+    const parts: string[] = [];
+
+    // Add preamble
+    const preamble = this.createContentPreamble({
+      hasBrand: context.hasBrand,
+      hasKnowledge: context.hasKnowledge,
+      role,
+    });
+    if (preamble) {
+      parts.push(preamble);
+    }
+
+    // Add context
+    if (context.context) {
+      parts.push(context.context);
+    }
+
+    // Add user prompt
+    if (userPrompt?.trim()) {
+      parts.push('---', '', userPrompt.trim());
+    }
+
+    return parts.join('\n');
+  }
+}
+
+export const contentContextService = new ContentContextService();

--- a/src/main/services/content/ContentExportService.ts
+++ b/src/main/services/content/ContentExportService.ts
@@ -1,0 +1,247 @@
+import { clipboard, dialog } from 'electron';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { getMainWindow } from '../../app/window';
+import { log } from '../../lib/logger';
+import { contentOutputService, type ContentOutput } from './ContentOutputService';
+
+export interface ExportOptions {
+  includeMetadata?: boolean;
+  filenameFormat?: 'simple' | 'detailed';
+}
+
+/**
+ * Service for exporting content outputs to various formats.
+ * Currently supports Markdown export to clipboard, file, and folder.
+ */
+export class ContentExportService {
+  /**
+   * Format output content with optional metadata header.
+   */
+  private formatOutputContent(output: ContentOutput, options: ExportOptions = {}): string {
+    if (!options.includeMetadata) {
+      return output.content;
+    }
+
+    const metadataLines = [
+      '---',
+      `agent: ${output.agentId}`,
+      `version: ${output.version}`,
+      `created: ${new Date(output.createdAt).toISOString()}`,
+      output.selected ? 'selected: true' : null,
+      '---',
+      '',
+    ].filter(Boolean);
+
+    return metadataLines.join('\n') + output.content;
+  }
+
+  /**
+   * Generate filename for an output.
+   */
+  private generateFilename(output: ContentOutput, options: ExportOptions = {}): string {
+    const sanitizedAgent = output.agentId.replace(/[^a-zA-Z0-9-_]/g, '_');
+
+    if (options.filenameFormat === 'detailed') {
+      const date = new Date(output.createdAt).toISOString().split('T')[0];
+      return `${sanitizedAgent}_v${output.version}_${date}.md`;
+    }
+
+    return `${sanitizedAgent}_v${output.version}.md`;
+  }
+
+  /**
+   * Copy output content to clipboard.
+   */
+  async copyToClipboard(
+    outputId: string,
+    options: ExportOptions = {}
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const output = await contentOutputService.getById(outputId);
+      if (!output) {
+        return { success: false, error: 'Output not found' };
+      }
+
+      const content = this.formatOutputContent(output, options);
+      clipboard.writeText(content);
+
+      log.info(`Copied content output ${outputId} to clipboard`);
+      return { success: true };
+    } catch (error) {
+      log.error('Failed to copy to clipboard:', error);
+      return { success: false, error: 'Failed to copy to clipboard' };
+    }
+  }
+
+  /**
+   * Export output to a single .md file with save dialog.
+   */
+  async exportToFile(
+    outputId: string,
+    options: ExportOptions = {}
+  ): Promise<{ success: boolean; filePath?: string; error?: string }> {
+    try {
+      const output = await contentOutputService.getById(outputId);
+      if (!output) {
+        return { success: false, error: 'Output not found' };
+      }
+
+      const defaultFilename = this.generateFilename(output, options);
+
+      const mainWindow = getMainWindow();
+      if (!mainWindow) {
+        return { success: false, error: 'No main window available' };
+      }
+
+      const result = await dialog.showSaveDialog(mainWindow, {
+        title: 'Export Content',
+        defaultPath: defaultFilename,
+        filters: [
+          { name: 'Markdown', extensions: ['md'] },
+          { name: 'All Files', extensions: ['*'] },
+        ],
+      });
+
+      if (result.canceled || !result.filePath) {
+        return { success: false, error: 'Export cancelled' };
+      }
+
+      const content = this.formatOutputContent(output, options);
+      await fs.writeFile(result.filePath, content, 'utf-8');
+
+      log.info(`Exported content output ${outputId} to ${result.filePath}`);
+      return { success: true, filePath: result.filePath };
+    } catch (error) {
+      log.error('Failed to export to file:', error);
+      return { success: false, error: 'Failed to export to file' };
+    }
+  }
+
+  /**
+   * Export all outputs for a task to a folder.
+   */
+  async exportToFolder(
+    taskId: string,
+    options: ExportOptions = {}
+  ): Promise<{ success: boolean; folderPath?: string; fileCount?: number; error?: string }> {
+    try {
+      const outputs = await contentOutputService.getByTaskId(taskId);
+      if (outputs.length === 0) {
+        return { success: false, error: 'No outputs found for task' };
+      }
+
+      const mainWindow = getMainWindow();
+      if (!mainWindow) {
+        return { success: false, error: 'No main window available' };
+      }
+
+      const result = await dialog.showOpenDialog(mainWindow, {
+        title: 'Select Export Folder',
+        properties: ['openDirectory', 'createDirectory'],
+        message: 'Choose a folder to export content outputs',
+      });
+
+      if (result.canceled || result.filePaths.length === 0) {
+        return { success: false, error: 'Export cancelled' };
+      }
+
+      const folderPath = result.filePaths[0];
+      let fileCount = 0;
+
+      // Group outputs by agent for organized export
+      const outputsByAgent = new Map<string, ContentOutput[]>();
+      for (const output of outputs) {
+        const existing = outputsByAgent.get(output.agentId) || [];
+        existing.push(output);
+        outputsByAgent.set(output.agentId, existing);
+      }
+
+      // Export each output
+      for (const output of outputs) {
+        const filename = this.generateFilename(output, { ...options, filenameFormat: 'detailed' });
+        const filePath = path.join(folderPath, filename);
+        const content = this.formatOutputContent(output, options);
+
+        await fs.writeFile(filePath, content, 'utf-8');
+        fileCount++;
+      }
+
+      // Create an index file if multiple outputs
+      if (outputs.length > 1) {
+        const indexContent = this.generateIndexFile(outputs, taskId);
+        await fs.writeFile(path.join(folderPath, '_index.md'), indexContent, 'utf-8');
+      }
+
+      log.info(`Exported ${fileCount} content outputs for task ${taskId} to ${folderPath}`);
+      return { success: true, folderPath, fileCount };
+    } catch (error) {
+      log.error('Failed to export to folder:', error);
+      return { success: false, error: 'Failed to export to folder' };
+    }
+  }
+
+  /**
+   * Export selected output for a task to file.
+   */
+  async exportSelectedToFile(
+    taskId: string,
+    options: ExportOptions = {}
+  ): Promise<{ success: boolean; filePath?: string; error?: string }> {
+    try {
+      const output = await contentOutputService.getSelectedForTask(taskId);
+      if (!output) {
+        return { success: false, error: 'No selected output for task' };
+      }
+
+      return this.exportToFile(output.id, options);
+    } catch (error) {
+      log.error('Failed to export selected output:', error);
+      return { success: false, error: 'Failed to export selected output' };
+    }
+  }
+
+  /**
+   * Generate an index file listing all exported outputs.
+   */
+  private generateIndexFile(outputs: ContentOutput[], taskId: string): string {
+    const lines = [
+      '# Content Outputs Index',
+      '',
+      `Task ID: ${taskId}`,
+      `Exported: ${new Date().toISOString()}`,
+      `Total outputs: ${outputs.length}`,
+      '',
+      '## Outputs',
+      '',
+    ];
+
+    // Group by agent
+    const outputsByAgent = new Map<string, ContentOutput[]>();
+    for (const output of outputs) {
+      const existing = outputsByAgent.get(output.agentId) || [];
+      existing.push(output);
+      outputsByAgent.set(output.agentId, existing);
+    }
+
+    for (const [agentId, agentOutputs] of outputsByAgent) {
+      lines.push(`### ${agentId}`);
+      lines.push('');
+
+      // Sort by version descending
+      const sorted = [...agentOutputs].sort((a, b) => b.version - a.version);
+
+      for (const output of sorted) {
+        const date = new Date(output.createdAt).toISOString().split('T')[0];
+        const filename = this.generateFilename(output, { filenameFormat: 'detailed' });
+        const selected = output.selected ? ' ⭐ (selected)' : '';
+        lines.push(`- [v${output.version}](${filename}) - ${date}${selected}`);
+      }
+      lines.push('');
+    }
+
+    return lines.join('\n');
+  }
+}
+
+export const contentExportService = new ContentExportService();

--- a/src/main/services/content/ContentOutputService.ts
+++ b/src/main/services/content/ContentOutputService.ts
@@ -1,0 +1,182 @@
+import { and, desc, eq } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { getDrizzleClient } from '../../db/drizzleClient';
+import { contentOutputs, type ContentOutputRow, type ContentOutputInsert } from '../../db/schema';
+import { log } from '../../lib/logger';
+
+export interface ContentOutput {
+  id: string;
+  taskId: string;
+  agentId: string;
+  content: string;
+  version: number;
+  selected: boolean;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+}
+
+function rowToOutput(row: ContentOutputRow): ContentOutput {
+  return {
+    id: row.id,
+    taskId: row.taskId,
+    agentId: row.agentId,
+    content: row.content,
+    version: row.version,
+    selected: row.selected === 1,
+    metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+    createdAt: row.createdAt,
+  };
+}
+
+export class ContentOutputService {
+  async create(
+    taskId: string,
+    agentId: string,
+    content: string,
+    metadata?: Record<string, unknown>
+  ): Promise<ContentOutput> {
+    const client = await getDrizzleClient();
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    // Get the next version number for this task/agent combination
+    const existingRows = await client.db
+      .select()
+      .from(contentOutputs)
+      .where(and(eq(contentOutputs.taskId, taskId), eq(contentOutputs.agentId, agentId)))
+      .orderBy(desc(contentOutputs.version));
+
+    const nextVersion = existingRows.length > 0 ? existingRows[0].version + 1 : 1;
+
+    const insert: ContentOutputInsert = {
+      id,
+      taskId,
+      agentId,
+      content,
+      version: nextVersion,
+      selected: 0,
+      metadata: metadata ? JSON.stringify(metadata) : null,
+      createdAt: now,
+    };
+
+    await client.db.insert(contentOutputs).values(insert);
+    log.info(
+      `Created content output: ${id} for task: ${taskId}, agent: ${agentId}, version: ${nextVersion}`
+    );
+
+    return {
+      id,
+      taskId,
+      agentId,
+      content,
+      version: nextVersion,
+      selected: false,
+      metadata,
+      createdAt: now,
+    };
+  }
+
+  async getById(id: string): Promise<ContentOutput | null> {
+    const client = await getDrizzleClient();
+    const rows = await client.db.select().from(contentOutputs).where(eq(contentOutputs.id, id));
+
+    if (rows.length === 0) return null;
+    return rowToOutput(rows[0]);
+  }
+
+  async getByTaskId(taskId: string): Promise<ContentOutput[]> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(contentOutputs)
+      .where(eq(contentOutputs.taskId, taskId))
+      .orderBy(desc(contentOutputs.createdAt));
+
+    return rows.map(rowToOutput);
+  }
+
+  async getByTaskAndAgent(taskId: string, agentId: string): Promise<ContentOutput[]> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(contentOutputs)
+      .where(and(eq(contentOutputs.taskId, taskId), eq(contentOutputs.agentId, agentId)))
+      .orderBy(desc(contentOutputs.version));
+
+    return rows.map(rowToOutput);
+  }
+
+  async getSelectedForTask(taskId: string): Promise<ContentOutput | null> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(contentOutputs)
+      .where(and(eq(contentOutputs.taskId, taskId), eq(contentOutputs.selected, 1)));
+
+    if (rows.length === 0) return null;
+    return rowToOutput(rows[0]);
+  }
+
+  async selectVersion(id: string): Promise<ContentOutput | null> {
+    const client = await getDrizzleClient();
+
+    // Get the output to find its task
+    const output = await this.getById(id);
+    if (!output) return null;
+
+    // Deselect all outputs for this task
+    await client.db
+      .update(contentOutputs)
+      .set({ selected: 0 })
+      .where(eq(contentOutputs.taskId, output.taskId));
+
+    // Select the specified output
+    await client.db.update(contentOutputs).set({ selected: 1 }).where(eq(contentOutputs.id, id));
+
+    log.info(`Selected content output: ${id} for task: ${output.taskId}`);
+    return this.getById(id);
+  }
+
+  async update(
+    id: string,
+    updates: Partial<{
+      content: string;
+      metadata: Record<string, unknown>;
+    }>
+  ): Promise<ContentOutput | null> {
+    const client = await getDrizzleClient();
+
+    const updateData: Partial<ContentOutputInsert> = {};
+
+    if (updates.content !== undefined) {
+      updateData.content = updates.content;
+    }
+    if (updates.metadata !== undefined) {
+      updateData.metadata = JSON.stringify(updates.metadata);
+    }
+
+    if (Object.keys(updateData).length > 0) {
+      await client.db.update(contentOutputs).set(updateData).where(eq(contentOutputs.id, id));
+    }
+
+    return this.getById(id);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const client = await getDrizzleClient();
+    await client.db.delete(contentOutputs).where(eq(contentOutputs.id, id));
+
+    log.info(`Deleted content output: ${id}`);
+    return true;
+  }
+
+  async deleteByTaskId(taskId: string): Promise<boolean> {
+    const client = await getDrizzleClient();
+    await client.db.delete(contentOutputs).where(eq(contentOutputs.taskId, taskId));
+
+    log.info(`Deleted all content outputs for task: ${taskId}`);
+    return true;
+  }
+}
+
+export const contentOutputService = new ContentOutputService();

--- a/src/main/services/content/ContentWorkspaceService.ts
+++ b/src/main/services/content/ContentWorkspaceService.ts
@@ -1,0 +1,153 @@
+import { eq } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { getDrizzleClient } from '../../db/drizzleClient';
+import {
+  contentWorkspaces,
+  type ContentWorkspaceRow,
+  type ContentWorkspaceInsert,
+} from '../../db/schema';
+import { log } from '../../lib/logger';
+
+export interface ContentWorkspace {
+  id: string;
+  projectId: string;
+  name: string;
+  kanbanColumns: KanbanColumn[];
+  defaultAgents: string[];
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface KanbanColumn {
+  id: string;
+  name: string;
+  status: string;
+}
+
+const DEFAULT_KANBAN_COLUMNS: KanbanColumn[] = [
+  { id: 'backlog', name: 'Backlog', status: 'backlog' },
+  { id: 'research', name: 'Research', status: 'research' },
+  { id: 'writing', name: 'Writing', status: 'writing' },
+  { id: 'review', name: 'Review', status: 'review' },
+  { id: 'ready', name: 'Ready', status: 'ready' },
+];
+
+function rowToWorkspace(row: ContentWorkspaceRow): ContentWorkspace {
+  return {
+    id: row.id,
+    projectId: row.projectId,
+    name: row.name,
+    kanbanColumns: JSON.parse(row.kanbanColumns) as KanbanColumn[],
+    defaultAgents: row.defaultAgents ? JSON.parse(row.defaultAgents) : [],
+    metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class ContentWorkspaceService {
+  async create(
+    projectId: string,
+    name: string,
+    options?: {
+      kanbanColumns?: KanbanColumn[];
+      defaultAgents?: string[];
+      metadata?: Record<string, unknown>;
+    }
+  ): Promise<ContentWorkspace> {
+    const client = await getDrizzleClient();
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    const insert: ContentWorkspaceInsert = {
+      id,
+      projectId,
+      name,
+      kanbanColumns: JSON.stringify(options?.kanbanColumns ?? DEFAULT_KANBAN_COLUMNS),
+      defaultAgents: options?.defaultAgents ? JSON.stringify(options.defaultAgents) : null,
+      metadata: options?.metadata ? JSON.stringify(options.metadata) : null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await client.db.insert(contentWorkspaces).values(insert);
+    log.info(`Created content workspace: ${id} for project: ${projectId}`);
+
+    return {
+      id,
+      projectId,
+      name,
+      kanbanColumns: options?.kanbanColumns ?? DEFAULT_KANBAN_COLUMNS,
+      defaultAgents: options?.defaultAgents ?? [],
+      metadata: options?.metadata,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  async getById(id: string): Promise<ContentWorkspace | null> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(contentWorkspaces)
+      .where(eq(contentWorkspaces.id, id));
+
+    if (rows.length === 0) return null;
+    return rowToWorkspace(rows[0]);
+  }
+
+  async getByProjectId(projectId: string): Promise<ContentWorkspace[]> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(contentWorkspaces)
+      .where(eq(contentWorkspaces.projectId, projectId));
+
+    return rows.map(rowToWorkspace);
+  }
+
+  async update(
+    id: string,
+    updates: Partial<{
+      name: string;
+      kanbanColumns: KanbanColumn[];
+      defaultAgents: string[];
+      metadata: Record<string, unknown>;
+    }>
+  ): Promise<ContentWorkspace | null> {
+    const client = await getDrizzleClient();
+    const now = new Date().toISOString();
+
+    const updateData: Partial<ContentWorkspaceInsert> = {
+      updatedAt: now,
+    };
+
+    if (updates.name !== undefined) {
+      updateData.name = updates.name;
+    }
+    if (updates.kanbanColumns !== undefined) {
+      updateData.kanbanColumns = JSON.stringify(updates.kanbanColumns);
+    }
+    if (updates.defaultAgents !== undefined) {
+      updateData.defaultAgents = JSON.stringify(updates.defaultAgents);
+    }
+    if (updates.metadata !== undefined) {
+      updateData.metadata = JSON.stringify(updates.metadata);
+    }
+
+    await client.db.update(contentWorkspaces).set(updateData).where(eq(contentWorkspaces.id, id));
+
+    return this.getById(id);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const client = await getDrizzleClient();
+    const result = await client.db.delete(contentWorkspaces).where(eq(contentWorkspaces.id, id));
+
+    log.info(`Deleted content workspace: ${id}`);
+    return true;
+  }
+}
+
+export const contentWorkspaceService = new ContentWorkspaceService();

--- a/src/main/services/content/KnowledgeService.ts
+++ b/src/main/services/content/KnowledgeService.ts
@@ -1,0 +1,175 @@
+import { eq } from 'drizzle-orm';
+import { v4 as uuidv4 } from 'uuid';
+import { getDrizzleClient } from '../../db/drizzleClient';
+import {
+  knowledgeDocuments,
+  type KnowledgeDocumentRow,
+  type KnowledgeDocumentInsert,
+} from '../../db/schema';
+import { log } from '../../lib/logger';
+
+export interface KnowledgeDocument {
+  id: string;
+  collectionId: string;
+  name: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+}
+
+function rowToDocument(row: KnowledgeDocumentRow): KnowledgeDocument {
+  return {
+    id: row.id,
+    collectionId: row.collectionId,
+    name: row.name,
+    content: row.content,
+    metadata: row.metadata ? JSON.parse(row.metadata) : undefined,
+    createdAt: row.createdAt,
+    updatedAt: row.updatedAt,
+  };
+}
+
+export class KnowledgeService {
+  async create(
+    collectionId: string,
+    name: string,
+    content: string,
+    metadata?: Record<string, unknown>
+  ): Promise<KnowledgeDocument> {
+    const client = await getDrizzleClient();
+    const id = uuidv4();
+    const now = new Date().toISOString();
+
+    const insert: KnowledgeDocumentInsert = {
+      id,
+      collectionId,
+      name,
+      content,
+      metadata: metadata ? JSON.stringify(metadata) : null,
+      createdAt: now,
+      updatedAt: now,
+    };
+
+    await client.db.insert(knowledgeDocuments).values(insert);
+    log.info(`Created knowledge document: ${id} in collection: ${collectionId}`);
+
+    return {
+      id,
+      collectionId,
+      name,
+      content,
+      metadata,
+      createdAt: now,
+      updatedAt: now,
+    };
+  }
+
+  /**
+   * Upload multiple markdown documents to a collection
+   */
+  async uploadDocuments(
+    collectionId: string,
+    documents: Array<{ name: string; content: string; metadata?: Record<string, unknown> }>
+  ): Promise<KnowledgeDocument[]> {
+    const results: KnowledgeDocument[] = [];
+
+    for (const doc of documents) {
+      const created = await this.create(collectionId, doc.name, doc.content, doc.metadata);
+      results.push(created);
+    }
+
+    log.info(`Uploaded ${results.length} documents to collection: ${collectionId}`);
+    return results;
+  }
+
+  async getById(id: string): Promise<KnowledgeDocument | null> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(knowledgeDocuments)
+      .where(eq(knowledgeDocuments.id, id));
+
+    if (rows.length === 0) return null;
+    return rowToDocument(rows[0]);
+  }
+
+  async getByCollectionId(collectionId: string): Promise<KnowledgeDocument[]> {
+    const client = await getDrizzleClient();
+    const rows = await client.db
+      .select()
+      .from(knowledgeDocuments)
+      .where(eq(knowledgeDocuments.collectionId, collectionId));
+
+    return rows.map(rowToDocument);
+  }
+
+  async update(
+    id: string,
+    updates: Partial<{
+      name: string;
+      content: string;
+      metadata: Record<string, unknown>;
+    }>
+  ): Promise<KnowledgeDocument | null> {
+    const client = await getDrizzleClient();
+    const now = new Date().toISOString();
+
+    const updateData: Partial<KnowledgeDocumentInsert> = {
+      updatedAt: now,
+    };
+
+    if (updates.name !== undefined) {
+      updateData.name = updates.name;
+    }
+    if (updates.content !== undefined) {
+      updateData.content = updates.content;
+    }
+    if (updates.metadata !== undefined) {
+      updateData.metadata = JSON.stringify(updates.metadata);
+    }
+
+    await client.db.update(knowledgeDocuments).set(updateData).where(eq(knowledgeDocuments.id, id));
+
+    return this.getById(id);
+  }
+
+  async delete(id: string): Promise<boolean> {
+    const client = await getDrizzleClient();
+    await client.db.delete(knowledgeDocuments).where(eq(knowledgeDocuments.id, id));
+
+    log.info(`Deleted knowledge document: ${id}`);
+    return true;
+  }
+
+  /**
+   * Format all documents in a collection for agent context injection
+   */
+  formatCollectionForAgent(documents: KnowledgeDocument[]): string {
+    if (documents.length === 0) {
+      return '';
+    }
+
+    const formattedDocs = documents
+      .map(
+        (doc) => `<document name="${doc.name}">
+${doc.content}
+</document>`
+      )
+      .join('\n\n');
+
+    return `<knowledge_documents>
+${formattedDocs}
+</knowledge_documents>`;
+  }
+
+  /**
+   * Get all documents in a collection and format them for agent context
+   */
+  async getCollectionContextForAgent(collectionId: string): Promise<string> {
+    const documents = await this.getByCollectionId(collectionId);
+    return this.formatCollectionForAgent(documents);
+  }
+}
+
+export const knowledgeService = new KnowledgeService();

--- a/src/main/services/content/index.ts
+++ b/src/main/services/content/index.ts
@@ -1,0 +1,20 @@
+export { ContentWorkspaceService, contentWorkspaceService } from './ContentWorkspaceService';
+export type { ContentWorkspace, KanbanColumn } from './ContentWorkspaceService';
+
+export { BrandService, brandService } from './BrandService';
+export type { BrandGuideline } from './BrandService';
+
+export { CollectionService, collectionService } from './CollectionService';
+export type { Collection } from './CollectionService';
+
+export { KnowledgeService, knowledgeService } from './KnowledgeService';
+export type { KnowledgeDocument } from './KnowledgeService';
+
+export { ContentOutputService, contentOutputService } from './ContentOutputService';
+export type { ContentOutput } from './ContentOutputService';
+
+export { ContentContextService, contentContextService } from './ContentContextService';
+export type { ContentContext, ContentContextOptions } from './ContentContextService';
+
+export { ContentExportService, contentExportService } from './ContentExportService';
+export type { ExportOptions } from './ContentExportService';

--- a/src/renderer/components/content/BrandEditor.tsx
+++ b/src/renderer/components/content/BrandEditor.tsx
@@ -1,0 +1,195 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Pencil, Trash2, Plus, Check, X } from 'lucide-react';
+import type { BrandGuideline } from '@/types/electron-api';
+
+interface BrandEditorProps {
+  brands: BrandGuideline[];
+  activeBrand: BrandGuideline | null;
+  onCreateBrand: (
+    name: string,
+    content: string,
+    isActive?: boolean
+  ) => Promise<BrandGuideline | null>;
+  onUpdateBrand: (
+    id: string,
+    updates: Partial<{ name: string; content: string; isActive: boolean }>
+  ) => Promise<BrandGuideline | null>;
+  onDeleteBrand: (id: string) => Promise<boolean>;
+  onSetActive: (id: string) => Promise<BrandGuideline | null>;
+}
+
+export function BrandEditor({
+  brands,
+  activeBrand,
+  onCreateBrand,
+  onUpdateBrand,
+  onDeleteBrand,
+  onSetActive,
+}: BrandEditorProps) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [newName, setNewName] = useState('');
+  const [newContent, setNewContent] = useState('');
+  const [editName, setEditName] = useState('');
+  const [editContent, setEditContent] = useState('');
+
+  const handleCreate = useCallback(async () => {
+    if (!newName.trim()) return;
+
+    const result = await onCreateBrand(newName.trim(), newContent, true);
+    if (result) {
+      setIsCreating(false);
+      setNewName('');
+      setNewContent('');
+    }
+  }, [newName, newContent, onCreateBrand]);
+
+  const handleStartEdit = useCallback((brand: BrandGuideline) => {
+    setEditingId(brand.id);
+    setEditName(brand.name);
+    setEditContent(brand.content);
+  }, []);
+
+  const handleSaveEdit = useCallback(async () => {
+    if (!editingId || !editName.trim()) return;
+
+    await onUpdateBrand(editingId, {
+      name: editName.trim(),
+      content: editContent,
+    });
+    setEditingId(null);
+  }, [editingId, editName, editContent, onUpdateBrand]);
+
+  const handleCancelEdit = useCallback(() => {
+    setEditingId(null);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Brand Guidelines</h3>
+        {!isCreating && (
+          <Button size="sm" variant="outline" onClick={() => setIsCreating(true)}>
+            <Plus className="mr-1 h-4 w-4" />
+            New Brand
+          </Button>
+        )}
+      </div>
+
+      {isCreating && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Create Brand Guideline</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Input
+              placeholder="Brand name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <Textarea
+              placeholder="Enter your brand guidelines in markdown..."
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+              rows={8}
+              className="font-mono text-sm"
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleCreate}>
+                <Check className="mr-1 h-4 w-4" />
+                Create
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsCreating(false);
+                  setNewName('');
+                  setNewContent('');
+                }}
+              >
+                <X className="mr-1 h-4 w-4" />
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {brands.length === 0 && !isCreating && (
+        <div className="py-8 text-center text-muted-foreground">
+          <p>No brand guidelines yet.</p>
+          <p className="text-sm">Create one to define your writing tone and style.</p>
+        </div>
+      )}
+
+      <div className="space-y-3">
+        {brands.map((brand) => (
+          <Card key={brand.id} className={brand.isActive ? 'border-primary' : ''}>
+            <CardHeader className="pb-2">
+              <div className="flex items-center justify-between">
+                {editingId === brand.id ? (
+                  <Input
+                    value={editName}
+                    onChange={(e) => setEditName(e.target.value)}
+                    className="max-w-xs"
+                  />
+                ) : (
+                  <div className="flex items-center gap-2">
+                    <CardTitle className="text-base">{brand.name}</CardTitle>
+                    {brand.isActive && <Badge variant="default">Active</Badge>}
+                  </div>
+                )}
+                <div className="flex items-center gap-1">
+                  {editingId === brand.id ? (
+                    <>
+                      <Button size="icon" variant="ghost" onClick={handleSaveEdit}>
+                        <Check className="h-4 w-4" />
+                      </Button>
+                      <Button size="icon" variant="ghost" onClick={handleCancelEdit}>
+                        <X className="h-4 w-4" />
+                      </Button>
+                    </>
+                  ) : (
+                    <>
+                      {!brand.isActive && (
+                        <Button size="sm" variant="outline" onClick={() => onSetActive(brand.id)}>
+                          Set Active
+                        </Button>
+                      )}
+                      <Button size="icon" variant="ghost" onClick={() => handleStartEdit(brand)}>
+                        <Pencil className="h-4 w-4" />
+                      </Button>
+                      <Button size="icon" variant="ghost" onClick={() => onDeleteBrand(brand.id)}>
+                        <Trash2 className="h-4 w-4" />
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              {editingId === brand.id ? (
+                <Textarea
+                  value={editContent}
+                  onChange={(e) => setEditContent(e.target.value)}
+                  rows={8}
+                  className="font-mono text-sm"
+                />
+              ) : (
+                <pre className="max-h-48 overflow-auto whitespace-pre-wrap rounded bg-muted/50 p-3 text-sm text-muted-foreground">
+                  {brand.content || '(No content)'}
+                </pre>
+              )}
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/content/CollectionList.tsx
+++ b/src/renderer/components/content/CollectionList.tsx
@@ -1,0 +1,145 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { FolderOpen, Plus, Trash2, FileText, Check, X } from 'lucide-react';
+import type { ContentCollection } from '@/types/electron-api';
+
+interface CollectionListProps {
+  collections: ContentCollection[];
+  selectedCollection: ContentCollection | null;
+  onSelectCollection: (collection: ContentCollection | null) => void;
+  onCreateCollection: (name: string, description?: string) => Promise<ContentCollection | null>;
+  onDeleteCollection: (id: string) => Promise<boolean>;
+}
+
+export function CollectionList({
+  collections,
+  selectedCollection,
+  onSelectCollection,
+  onCreateCollection,
+  onDeleteCollection,
+}: CollectionListProps) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+
+  const handleCreate = useCallback(async () => {
+    if (!newName.trim()) return;
+
+    const result = await onCreateCollection(newName.trim(), newDescription.trim() || undefined);
+    if (result) {
+      setIsCreating(false);
+      setNewName('');
+      setNewDescription('');
+      onSelectCollection(result);
+    }
+  }, [newName, newDescription, onCreateCollection, onSelectCollection]);
+
+  const handleDelete = useCallback(
+    async (e: React.MouseEvent, id: string) => {
+      e.stopPropagation();
+      await onDeleteCollection(id);
+    },
+    [onDeleteCollection]
+  );
+
+  return (
+    <div className="space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Collections</h3>
+        {!isCreating && (
+          <Button size="sm" variant="outline" onClick={() => setIsCreating(true)}>
+            <Plus className="mr-1 h-4 w-4" />
+            New Collection
+          </Button>
+        )}
+      </div>
+
+      {isCreating && (
+        <Card>
+          <CardContent className="space-y-3 pt-4">
+            <Input
+              placeholder="Collection name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+              autoFocus
+            />
+            <Input
+              placeholder="Description (optional)"
+              value={newDescription}
+              onChange={(e) => setNewDescription(e.target.value)}
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleCreate}>
+                <Check className="mr-1 h-4 w-4" />
+                Create
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsCreating(false);
+                  setNewName('');
+                  setNewDescription('');
+                }}
+              >
+                <X className="mr-1 h-4 w-4" />
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {collections.length === 0 && !isCreating && (
+        <div className="py-8 text-center text-muted-foreground">
+          <FolderOpen className="mx-auto mb-2 h-12 w-12 opacity-50" />
+          <p>No collections yet.</p>
+          <p className="text-sm">Create a collection to organize your knowledge documents.</p>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {collections.map((collection) => (
+          <Card
+            key={collection.id}
+            className={`cursor-pointer transition-colors hover:bg-muted/50 ${
+              selectedCollection?.id === collection.id ? 'border-primary bg-muted/30' : ''
+            }`}
+            onClick={() => onSelectCollection(collection)}
+          >
+            <CardContent className="px-4 py-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <FolderOpen className="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <div className="font-medium">{collection.name}</div>
+                    {collection.description && (
+                      <div className="text-sm text-muted-foreground">{collection.description}</div>
+                    )}
+                  </div>
+                </div>
+                <div className="flex items-center gap-2">
+                  <Badge variant="secondary" className="gap-1">
+                    <FileText className="h-3 w-3" />
+                    {collection.documentCount || 0}
+                  </Badge>
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8"
+                    onClick={(e) => handleDelete(e, collection.id)}
+                  >
+                    <Trash2 className="h-4 w-4" />
+                  </Button>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/content/CollectionSelector.tsx
+++ b/src/renderer/components/content/CollectionSelector.tsx
@@ -1,0 +1,282 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { FolderOpen, Plus, Upload, Check, ChevronDown, X } from 'lucide-react';
+import type { ContentCollection } from '@/types/electron-api';
+import { cn } from '@/lib/utils';
+
+interface CollectionSelectorProps {
+  workspaceId: string | null;
+  collections: ContentCollection[];
+  selectedCollectionId: string | null;
+  onSelect: (collectionId: string | null) => void;
+  onCreateCollection: (name: string, description?: string) => Promise<ContentCollection | null>;
+  onUploadDocuments?: (
+    collectionId: string,
+    files: Array<{ name: string; content: string }>
+  ) => Promise<unknown>;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function CollectionSelector({
+  workspaceId,
+  collections,
+  selectedCollectionId,
+  onSelect,
+  onCreateCollection,
+  onUploadDocuments,
+  disabled = false,
+  className,
+}: CollectionSelectorProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [isCreating, setIsCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newDescription, setNewDescription] = useState('');
+  const [pendingFiles, setPendingFiles] = useState<Array<{ name: string; content: string }>>([]);
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const selectedCollection = collections.find((c) => c.id === selectedCollectionId);
+
+  // Reset create form when popover closes
+  useEffect(() => {
+    if (!isOpen) {
+      setIsCreating(false);
+      setNewName('');
+      setNewDescription('');
+      setPendingFiles([]);
+    }
+  }, [isOpen]);
+
+  const handleSelectExisting = (collectionId: string) => {
+    onSelect(collectionId);
+    setIsOpen(false);
+  };
+
+  const handleFileSelect = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = e.target.files;
+    if (!files || files.length === 0) return;
+
+    const fileData: Array<{ name: string; content: string }> = [];
+
+    for (let i = 0; i < files.length; i++) {
+      const file = files[i];
+      if (
+        file.name.endsWith('.md') ||
+        file.name.endsWith('.txt') ||
+        file.name.endsWith('.markdown')
+      ) {
+        const content = await file.text();
+        fileData.push({ name: file.name, content });
+      }
+    }
+
+    if (fileData.length > 0) {
+      setPendingFiles((prev) => [...prev, ...fileData]);
+    }
+
+    if (fileInputRef.current) {
+      fileInputRef.current.value = '';
+    }
+  }, []);
+
+  const handleRemoveFile = (index: number) => {
+    setPendingFiles((prev) => prev.filter((_, i) => i !== index));
+  };
+
+  const handleCreateAndSelect = async () => {
+    if (!newName.trim()) return;
+
+    setIsUploading(true);
+    try {
+      const collection = await onCreateCollection(
+        newName.trim(),
+        newDescription.trim() || undefined
+      );
+      if (collection) {
+        // Upload pending files if any
+        if (pendingFiles.length > 0 && onUploadDocuments) {
+          await onUploadDocuments(collection.id, pendingFiles);
+        }
+        onSelect(collection.id);
+        setIsOpen(false);
+      }
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  if (!workspaceId) {
+    return (
+      <div className={cn('text-sm text-muted-foreground', className)}>
+        Select a content workspace first
+      </div>
+    );
+  }
+
+  return (
+    <div className={className}>
+      <Popover open={isOpen} onOpenChange={setIsOpen}>
+        <PopoverTrigger asChild>
+          <Button
+            variant="outline"
+            role="combobox"
+            aria-expanded={isOpen}
+            disabled={disabled}
+            className="w-full justify-between"
+          >
+            <div className="flex items-center gap-2 truncate">
+              <FolderOpen className="h-4 w-4 shrink-0" />
+              <span className="truncate">
+                {selectedCollection ? selectedCollection.name : 'Select collection...'}
+              </span>
+            </div>
+            <ChevronDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent className="w-80 p-0" align="start">
+          {!isCreating ? (
+            <div className="flex flex-col">
+              {/* Existing collections list */}
+              <div className="max-h-60 overflow-auto p-1">
+                {collections.length === 0 ? (
+                  <div className="px-3 py-6 text-center text-sm text-muted-foreground">
+                    No collections yet
+                  </div>
+                ) : (
+                  collections.map((collection) => (
+                    <button
+                      key={collection.id}
+                      onClick={() => handleSelectExisting(collection.id)}
+                      className={cn(
+                        'flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted',
+                        selectedCollectionId === collection.id && 'bg-muted'
+                      )}
+                    >
+                      <FolderOpen className="h-4 w-4 shrink-0 text-muted-foreground" />
+                      <div className="flex-1 truncate">
+                        <div className="font-medium">{collection.name}</div>
+                        {collection.description && (
+                          <div className="truncate text-xs text-muted-foreground">
+                            {collection.description}
+                          </div>
+                        )}
+                      </div>
+                      {selectedCollectionId === collection.id && (
+                        <Check className="h-4 w-4 shrink-0" />
+                      )}
+                    </button>
+                  ))
+                )}
+              </div>
+
+              {/* Create new button */}
+              <div className="border-t p-1">
+                <button
+                  onClick={() => setIsCreating(true)}
+                  className="flex w-full items-center gap-2 rounded-sm px-3 py-2 text-left text-sm hover:bg-muted"
+                >
+                  <Plus className="h-4 w-4" />
+                  Create new collection
+                </button>
+              </div>
+            </div>
+          ) : (
+            <div className="space-y-3 p-3">
+              <div className="text-sm font-medium">Create New Collection</div>
+
+              <div className="space-y-2">
+                <Label htmlFor="collection-name">Name</Label>
+                <Input
+                  id="collection-name"
+                  placeholder="Collection name"
+                  value={newName}
+                  onChange={(e) => setNewName(e.target.value)}
+                  autoFocus
+                />
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="collection-desc">Description (optional)</Label>
+                <Input
+                  id="collection-desc"
+                  placeholder="Brief description"
+                  value={newDescription}
+                  onChange={(e) => setNewDescription(e.target.value)}
+                />
+              </div>
+
+              {/* File upload */}
+              <div className="space-y-2">
+                <Label>Knowledge Documents (optional)</Label>
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept=".md,.txt,.markdown"
+                  multiple
+                  className="hidden"
+                  onChange={handleFileSelect}
+                />
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="w-full"
+                  onClick={() => fileInputRef.current?.click()}
+                >
+                  <Upload className="mr-2 h-4 w-4" />
+                  Upload Markdown Files
+                </Button>
+
+                {/* Pending files list */}
+                {pendingFiles.length > 0 && (
+                  <div className="space-y-1">
+                    {pendingFiles.map((file, index) => (
+                      <div
+                        key={index}
+                        className="flex items-center justify-between rounded bg-muted px-2 py-1 text-xs"
+                      >
+                        <span className="truncate">{file.name}</span>
+                        <button
+                          type="button"
+                          onClick={() => handleRemoveFile(index)}
+                          className="ml-2 text-muted-foreground hover:text-foreground"
+                        >
+                          <X className="h-3 w-3" />
+                        </button>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+
+              {/* Actions */}
+              <div className="flex gap-2">
+                <Button
+                  size="sm"
+                  onClick={handleCreateAndSelect}
+                  disabled={!newName.trim() || isUploading}
+                >
+                  {isUploading ? 'Creating...' : 'Create & Select'}
+                </Button>
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={() => setIsCreating(false)}
+                  disabled={isUploading}
+                >
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          )}
+        </PopoverContent>
+      </Popover>
+    </div>
+  );
+}
+
+export default CollectionSelector;

--- a/src/renderer/components/content/ContentArchivePanel.tsx
+++ b/src/renderer/components/content/ContentArchivePanel.tsx
@@ -1,0 +1,340 @@
+import { useState, useMemo } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Archive,
+  Clock,
+  FileText,
+  Check,
+  Copy,
+  Download,
+  FolderOpen,
+  ChevronDown,
+  ChevronRight,
+  RotateCcw,
+} from 'lucide-react';
+import type { ContentOutput } from '@/types/electron-api';
+import { cn } from '@/lib/utils';
+
+interface ContentArchivePanelProps {
+  outputs: ContentOutput[];
+  onSelectVersion?: (id: string) => Promise<boolean>;
+  onCopy?: (output: ContentOutput) => void;
+  onExportFile?: (outputId: string) => void;
+  onExportFolder?: () => void;
+  onClose?: () => void;
+  className?: string;
+}
+
+interface GroupedOutputs {
+  date: string;
+  outputs: ContentOutput[];
+}
+
+/**
+ * Archive panel showing full history of content outputs.
+ * Outputs are grouped by date and agent for easy navigation.
+ */
+export function ContentArchivePanel({
+  outputs,
+  onSelectVersion,
+  onCopy,
+  onExportFile,
+  onExportFolder,
+  onClose,
+  className,
+}: ContentArchivePanelProps) {
+  const [expandedDates, setExpandedDates] = useState<Set<string>>(new Set());
+  const [expandedAgents, setExpandedAgents] = useState<Set<string>>(new Set());
+  const [copiedId, setCopiedId] = useState<string | null>(null);
+
+  // Group outputs by date
+  const groupedByDate = useMemo(() => {
+    const groups = new Map<string, ContentOutput[]>();
+
+    for (const output of outputs) {
+      const date = new Date(output.createdAt).toLocaleDateString();
+      const existing = groups.get(date) || [];
+      existing.push(output);
+      groups.set(date, existing);
+    }
+
+    // Sort dates descending (newest first)
+    const sortedEntries = Array.from(groups.entries()).sort((a, b) => {
+      const dateA = new Date(a[1][0].createdAt);
+      const dateB = new Date(b[1][0].createdAt);
+      return dateB.getTime() - dateA.getTime();
+    });
+
+    return sortedEntries.map(([date, outputs]) => ({
+      date,
+      outputs: outputs.sort(
+        (a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
+      ),
+    }));
+  }, [outputs]);
+
+  // Group outputs by agent within each date
+  const getOutputsByAgent = (dateOutputs: ContentOutput[]) => {
+    const groups = new Map<string, ContentOutput[]>();
+
+    for (const output of dateOutputs) {
+      const existing = groups.get(output.agentId) || [];
+      existing.push(output);
+      groups.set(output.agentId, existing);
+    }
+
+    return Array.from(groups.entries());
+  };
+
+  const toggleDate = (date: string) => {
+    const newExpanded = new Set(expandedDates);
+    if (newExpanded.has(date)) {
+      newExpanded.delete(date);
+    } else {
+      newExpanded.add(date);
+    }
+    setExpandedDates(newExpanded);
+  };
+
+  const toggleAgent = (key: string) => {
+    const newExpanded = new Set(expandedAgents);
+    if (newExpanded.has(key)) {
+      newExpanded.delete(key);
+    } else {
+      newExpanded.add(key);
+    }
+    setExpandedAgents(newExpanded);
+  };
+
+  const handleCopy = async (output: ContentOutput) => {
+    if (onCopy) {
+      onCopy(output);
+    } else {
+      await navigator.clipboard.writeText(output.content);
+    }
+    setCopiedId(output.id);
+    setTimeout(() => setCopiedId(null), 1000);
+  };
+
+  const handleRestore = async (output: ContentOutput) => {
+    if (onSelectVersion) {
+      await onSelectVersion(output.id);
+    }
+  };
+
+  if (outputs.length === 0) {
+    return (
+      <div className={cn('flex h-full flex-col', className)}>
+        <div className="flex items-center justify-between border-b px-4 py-3">
+          <h3 className="flex items-center gap-2 text-sm font-medium">
+            <Archive className="h-4 w-4" />
+            Content Archive
+          </h3>
+          {onClose && (
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              Close
+            </Button>
+          )}
+        </div>
+        <div className="flex flex-1 items-center justify-center text-muted-foreground">
+          <div className="text-center">
+            <Archive className="mx-auto mb-2 h-12 w-12 opacity-50" />
+            <p>No archived content</p>
+            <p className="text-xs">Generated outputs will appear here</p>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  const selectedOutput = outputs.find((o) => o.selected);
+  const totalVersions = outputs.length;
+  const uniqueAgents = new Set(outputs.map((o) => o.agentId)).size;
+
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="flex items-center gap-2 text-sm font-medium">
+          <Archive className="h-4 w-4" />
+          Content Archive
+          <Badge variant="secondary">{totalVersions} versions</Badge>
+        </h3>
+        <div className="flex items-center gap-2">
+          {onExportFolder && (
+            <Button variant="outline" size="sm" onClick={onExportFolder}>
+              <FolderOpen className="mr-1 h-3 w-3" />
+              Export All
+            </Button>
+          )}
+          {onClose && (
+            <Button variant="ghost" size="sm" onClick={onClose}>
+              Close
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Summary */}
+      <div className="border-b bg-muted/50 px-4 py-2">
+        <div className="flex items-center gap-4 text-xs text-muted-foreground">
+          <span className="flex items-center gap-1">
+            <FileText className="h-3 w-3" />
+            {totalVersions} total outputs
+          </span>
+          <span className="flex items-center gap-1">
+            <Clock className="h-3 w-3" />
+            {groupedByDate.length} dates
+          </span>
+          <span>{uniqueAgents} agents</span>
+          {selectedOutput && (
+            <span className="flex items-center gap-1 text-primary">
+              <Check className="h-3 w-3" />
+              Selected: {selectedOutput.agentId} v{selectedOutput.version}
+            </span>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        <div className="space-y-3">
+          {groupedByDate.map(({ date, outputs: dateOutputs }) => {
+            const isDateExpanded = expandedDates.has(date);
+            const outputsByAgent = getOutputsByAgent(dateOutputs);
+
+            return (
+              <Card key={date}>
+                <CardHeader className="cursor-pointer py-2" onClick={() => toggleDate(date)}>
+                  <CardTitle className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2">
+                      {isDateExpanded ? (
+                        <ChevronDown className="h-4 w-4" />
+                      ) : (
+                        <ChevronRight className="h-4 w-4" />
+                      )}
+                      <Clock className="h-4 w-4 text-muted-foreground" />
+                      {date}
+                    </span>
+                    <Badge variant="outline">{dateOutputs.length} outputs</Badge>
+                  </CardTitle>
+                </CardHeader>
+
+                {isDateExpanded && (
+                  <CardContent className="space-y-3 pt-0">
+                    {outputsByAgent.map(([agentId, agentOutputs]) => {
+                      const agentKey = `${date}-${agentId}`;
+                      const isAgentExpanded = expandedAgents.has(agentKey);
+
+                      return (
+                        <div key={agentKey} className="rounded-md border">
+                          <div
+                            className="flex cursor-pointer items-center justify-between p-2 hover:bg-muted/50"
+                            onClick={() => toggleAgent(agentKey)}
+                          >
+                            <span className="flex items-center gap-2 text-sm">
+                              {isAgentExpanded ? (
+                                <ChevronDown className="h-3 w-3" />
+                              ) : (
+                                <ChevronRight className="h-3 w-3" />
+                              )}
+                              <Badge variant="outline">{agentId}</Badge>
+                            </span>
+                            <span className="text-xs text-muted-foreground">
+                              {agentOutputs.length} version{agentOutputs.length !== 1 ? 's' : ''}
+                            </span>
+                          </div>
+
+                          {isAgentExpanded && (
+                            <div className="space-y-2 border-t p-2">
+                              {agentOutputs
+                                .sort((a, b) => b.version - a.version)
+                                .map((output) => (
+                                  <div
+                                    key={output.id}
+                                    className={cn(
+                                      'rounded-md border p-2',
+                                      output.selected && 'border-primary bg-primary/5'
+                                    )}
+                                  >
+                                    <div className="flex items-center justify-between">
+                                      <div className="flex items-center gap-2">
+                                        <Badge variant="secondary">v{output.version}</Badge>
+                                        {output.selected && (
+                                          <Badge variant="default">Selected</Badge>
+                                        )}
+                                        <span className="text-xs text-muted-foreground">
+                                          {new Date(output.createdAt).toLocaleTimeString()}
+                                        </span>
+                                      </div>
+                                      <div className="flex gap-1">
+                                        <Button
+                                          variant="ghost"
+                                          size="icon"
+                                          className="h-6 w-6"
+                                          onClick={(e) => {
+                                            e.stopPropagation();
+                                            handleCopy(output);
+                                          }}
+                                          title="Copy to clipboard"
+                                        >
+                                          <Copy className="h-3 w-3" />
+                                        </Button>
+                                        {onExportFile && (
+                                          <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-6 w-6"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              onExportFile(output.id);
+                                            }}
+                                            title="Export to file"
+                                          >
+                                            <Download className="h-3 w-3" />
+                                          </Button>
+                                        )}
+                                        {!output.selected && onSelectVersion && (
+                                          <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            className="h-6 w-6"
+                                            onClick={(e) => {
+                                              e.stopPropagation();
+                                              handleRestore(output);
+                                            }}
+                                            title="Restore this version"
+                                          >
+                                            <RotateCcw className="h-3 w-3" />
+                                          </Button>
+                                        )}
+                                      </div>
+                                    </div>
+                                    <pre className="mt-2 max-h-20 overflow-hidden whitespace-pre-wrap text-xs text-muted-foreground">
+                                      {output.content.slice(0, 200)}
+                                      {output.content.length > 200 && '...'}
+                                    </pre>
+                                    {copiedId === output.id && (
+                                      <span className="text-xs text-primary">Copied!</span>
+                                    )}
+                                  </div>
+                                ))}
+                            </div>
+                          )}
+                        </div>
+                      );
+                    })}
+                  </CardContent>
+                )}
+              </Card>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default ContentArchivePanel;

--- a/src/renderer/components/content/ContentBriefBadge.tsx
+++ b/src/renderer/components/content/ContentBriefBadge.tsx
@@ -1,0 +1,61 @@
+import { FileText } from 'lucide-react';
+import { type ContentBrief, hasContentBrief, formatBriefSummary } from './ContentBriefFields';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+
+interface ContentBriefBadgeProps {
+  brief: ContentBrief | undefined | null;
+  className?: string;
+}
+
+/**
+ * Small badge that shows content brief info on Kanban cards.
+ * Shows a tooltip with full brief on hover.
+ */
+export function ContentBriefBadge({ brief, className }: ContentBriefBadgeProps) {
+  if (!hasContentBrief(brief)) {
+    return null;
+  }
+
+  const summary = formatBriefSummary(brief);
+
+  return (
+    <TooltipProvider>
+      <Tooltip delayDuration={200}>
+        <TooltipTrigger asChild>
+          <div
+            className={`inline-flex items-center gap-1 rounded bg-muted/60 px-1.5 py-0.5 text-[10px] text-muted-foreground ${className || ''}`}
+          >
+            <FileText className="h-3 w-3" />
+            <span className="max-w-24 truncate">{summary || 'Content Brief'}</span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          <div className="space-y-1 text-xs">
+            {brief?.topic && (
+              <div>
+                <span className="font-medium">Topic:</span> {brief.topic}
+              </div>
+            )}
+            {brief?.audience && (
+              <div>
+                <span className="font-medium">Audience:</span> {brief.audience}
+              </div>
+            )}
+            {brief?.keywords && (
+              <div>
+                <span className="font-medium">Keywords:</span> {brief.keywords}
+              </div>
+            )}
+            {brief?.tone && (
+              <div>
+                <span className="font-medium">Tone:</span> {brief.tone}
+              </div>
+            )}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+export default ContentBriefBadge;

--- a/src/renderer/components/content/ContentBriefFields.tsx
+++ b/src/renderer/components/content/ContentBriefFields.tsx
@@ -1,0 +1,146 @@
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+
+export interface ContentBrief {
+  topic?: string;
+  audience?: string;
+  keywords?: string;
+  tone?: string;
+  notes?: string;
+}
+
+interface ContentBriefFieldsProps {
+  value: ContentBrief;
+  onChange: (brief: ContentBrief) => void;
+  disabled?: boolean;
+}
+
+export function ContentBriefFields({ value, onChange, disabled = false }: ContentBriefFieldsProps) {
+  const handleChange = (field: keyof ContentBrief, fieldValue: string) => {
+    onChange({ ...value, [field]: fieldValue });
+  };
+
+  return (
+    <div className="space-y-3">
+      <div className="space-y-1.5">
+        <Label htmlFor="content-topic" className="text-xs">
+          Topic / Product
+        </Label>
+        <Input
+          id="content-topic"
+          placeholder="What is this content about?"
+          value={value.topic || ''}
+          onChange={(e) => handleChange('topic', e.target.value)}
+          disabled={disabled}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="content-audience" className="text-xs">
+          Target Audience
+        </Label>
+        <Input
+          id="content-audience"
+          placeholder="Who is this content for?"
+          value={value.audience || ''}
+          onChange={(e) => handleChange('audience', e.target.value)}
+          disabled={disabled}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="content-keywords" className="text-xs">
+          Keywords
+        </Label>
+        <Input
+          id="content-keywords"
+          placeholder="SEO keywords (comma-separated)"
+          value={value.keywords || ''}
+          onChange={(e) => handleChange('keywords', e.target.value)}
+          disabled={disabled}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="content-tone" className="text-xs">
+          Tone / Style
+        </Label>
+        <Input
+          id="content-tone"
+          placeholder="e.g., Professional, Casual, Friendly"
+          value={value.tone || ''}
+          onChange={(e) => handleChange('tone', e.target.value)}
+          disabled={disabled}
+          className="h-8 text-sm"
+        />
+      </div>
+
+      <div className="space-y-1.5">
+        <Label htmlFor="content-notes" className="text-xs">
+          Additional Notes
+        </Label>
+        <Textarea
+          id="content-notes"
+          placeholder="Any other requirements or context..."
+          value={value.notes || ''}
+          onChange={(e) => handleChange('notes', e.target.value)}
+          disabled={disabled}
+          rows={2}
+          className="text-sm"
+        />
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Check if a content brief has any meaningful data.
+ */
+export function hasContentBrief(brief: ContentBrief | undefined | null): boolean {
+  if (!brief) return false;
+  return !!(brief.topic || brief.audience || brief.keywords || brief.tone || brief.notes);
+}
+
+/**
+ * Format content brief for display (short summary).
+ */
+export function formatBriefSummary(brief: ContentBrief | undefined | null): string {
+  if (!brief) return '';
+  const parts: string[] = [];
+  if (brief.topic) parts.push(brief.topic);
+  if (brief.audience) parts.push(`for ${brief.audience}`);
+  return parts.join(' ') || '';
+}
+
+/**
+ * Format content brief for agent context injection.
+ */
+export function formatBriefForAgent(brief: ContentBrief | undefined | null): string {
+  if (!brief) return '';
+
+  const lines: string[] = ['## Content Brief', ''];
+
+  if (brief.topic) {
+    lines.push(`**Topic/Product:** ${brief.topic}`);
+  }
+  if (brief.audience) {
+    lines.push(`**Target Audience:** ${brief.audience}`);
+  }
+  if (brief.keywords) {
+    lines.push(`**Keywords:** ${brief.keywords}`);
+  }
+  if (brief.tone) {
+    lines.push(`**Tone/Style:** ${brief.tone}`);
+  }
+  if (brief.notes) {
+    lines.push('', '**Additional Notes:**', brief.notes);
+  }
+
+  return lines.join('\n');
+}
+
+export default ContentBriefFields;

--- a/src/renderer/components/content/ContentKanbanBoard.tsx
+++ b/src/renderer/components/content/ContentKanbanBoard.tsx
@@ -1,0 +1,136 @@
+import React, { useCallback, useEffect, useState } from 'react';
+import type { Task } from '../../types/app';
+import KanbanColumn from '../kanban/KanbanColumn';
+import KanbanCard from '../kanban/KanbanCard';
+import { Button } from '../ui/button';
+import { Inbox, Plus } from 'lucide-react';
+import {
+  getAllContentStatuses,
+  setContentStatus,
+  parseKanbanColumns,
+  type ContentColumn,
+} from '../../lib/contentKanbanStore';
+
+interface ContentKanbanBoardProps {
+  tasks: Task[];
+  /** JSON string of column definitions from workspace, or null for defaults */
+  columnsJson?: string | null;
+  onOpenTask?: (task: Task) => void;
+  onCreateTask?: () => void;
+}
+
+export function ContentKanbanBoard({
+  tasks,
+  columnsJson,
+  onOpenTask,
+  onCreateTask,
+}: ContentKanbanBoardProps) {
+  const columns = parseKanbanColumns(columnsJson);
+  const firstColumnId = columns[0]?.id || 'backlog';
+
+  const [statusMap, setStatusMap] = useState<Record<string, string>>({});
+
+  // Initialize status map on mount
+  useEffect(() => {
+    setStatusMap(getAllContentStatuses());
+  }, []);
+
+  // Handle dropping a card into a column
+  const handleDrop = useCallback((targetColumn: string, taskId: string) => {
+    setContentStatus(taskId, targetColumn);
+    setStatusMap((prev) => ({ ...prev, [taskId]: targetColumn }));
+  }, []);
+
+  // Group tasks by column
+  const tasksByColumn: Record<string, Task[]> = {};
+  for (const col of columns) {
+    tasksByColumn[col.id] = [];
+  }
+  for (const task of tasks) {
+    const status = statusMap[task.id] || firstColumnId;
+    if (tasksByColumn[status]) {
+      tasksByColumn[status].push(task);
+    } else {
+      // If status doesn't match any column, put in first column
+      tasksByColumn[firstColumnId]?.push(task);
+    }
+  }
+
+  const hasAny = tasks.length > 0;
+
+  return (
+    <div
+      className="grid h-full w-full gap-4 p-3"
+      style={{
+        gridTemplateColumns: `repeat(${columns.length}, minmax(0, 1fr))`,
+      }}
+    >
+      {columns.map((col, index) => (
+        <KanbanColumn
+          key={col.id}
+          title={col.title}
+          count={tasksByColumn[col.id]?.length || 0}
+          onDropCard={(id) => handleDrop(col.id, id)}
+          action={
+            index === 0 && onCreateTask ? (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-8 w-8 rounded-md border border-border/60 bg-muted text-foreground shadow-sm hover:bg-muted/80"
+                onClick={onCreateTask}
+                aria-label="New Task"
+              >
+                <Plus className="h-4 w-4" aria-hidden="true" />
+              </Button>
+            ) : undefined
+          }
+        >
+          {(tasksByColumn[col.id]?.length || 0) === 0 ? (
+            index === 0 && !hasAny && onCreateTask ? (
+              <div className="flex h-full flex-col">
+                <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 p-4 text-center text-sm text-muted-foreground">
+                  <div className="mx-auto mb-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-dashed border-border/60 bg-background/60">
+                    <Inbox className="h-3.5 w-3.5" aria-hidden="true" />
+                  </div>
+                  <span className="ml-2">No items</span>
+                </div>
+                <div className="flex flex-1 items-center justify-center">
+                  <Button variant="default" size="sm" onClick={onCreateTask}>
+                    <Plus className="mr-1.5 h-3.5 w-3.5" />
+                    New Task
+                  </Button>
+                </div>
+              </div>
+            ) : (
+              <div className="rounded-lg border border-dashed border-border/70 bg-muted/20 p-4 text-center text-sm text-muted-foreground">
+                <div className="mx-auto mb-2 inline-flex h-7 w-7 items-center justify-center rounded-full border border-dashed border-border/60 bg-background/60">
+                  <Inbox className="h-3.5 w-3.5" aria-hidden="true" />
+                </div>
+                <span className="ml-2">No items</span>
+              </div>
+            )
+          ) : (
+            <>
+              {tasksByColumn[col.id]?.map((task) => (
+                <KanbanCard key={task.id} ws={task} onOpen={onOpenTask} />
+              ))}
+              {index === 0 && onCreateTask ? (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-1 w-full justify-center text-xs font-medium"
+                  onClick={onCreateTask}
+                >
+                  <Plus className="mr-1.5 h-3.5 w-3.5" />
+                  New Task
+                </Button>
+              ) : null}
+            </>
+          )}
+        </KanbanColumn>
+      ))}
+    </div>
+  );
+}
+
+export default ContentKanbanBoard;

--- a/src/renderer/components/content/ContentOutputEditor.tsx
+++ b/src/renderer/components/content/ContentOutputEditor.tsx
@@ -1,0 +1,215 @@
+import { useState, useCallback, useEffect } from 'react';
+import Editor from '@monaco-editor/react';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Save, Undo2, Check, History, X } from 'lucide-react';
+import type { ContentOutput } from '@/types/electron-api';
+import { useTheme } from '@/hooks/useTheme';
+import { cn } from '@/lib/utils';
+
+interface ContentOutputEditorProps {
+  output: ContentOutput;
+  onSave: (content: string) => Promise<ContentOutput | null>;
+  onSelect?: () => Promise<boolean>;
+  onClose?: () => void;
+  className?: string;
+}
+
+/**
+ * Editor for content outputs with version tracking.
+ * Allows editing and saving as a new version.
+ */
+export function ContentOutputEditor({
+  output,
+  onSave,
+  onSelect,
+  onClose,
+  className,
+}: ContentOutputEditorProps) {
+  const { effectiveTheme } = useTheme();
+  const isDark = effectiveTheme === 'dark' || effectiveTheme === 'dark-black';
+
+  const [content, setContent] = useState(output.content);
+  const [isSaving, setIsSaving] = useState(false);
+  const [hasChanges, setHasChanges] = useState(false);
+
+  // Reset content when output changes
+  useEffect(() => {
+    setContent(output.content);
+    setHasChanges(false);
+  }, [output.id, output.content]);
+
+  const handleEditorChange = useCallback(
+    (value: string | undefined) => {
+      const newContent = value || '';
+      setContent(newContent);
+      setHasChanges(newContent !== output.content);
+    },
+    [output.content]
+  );
+
+  const handleSave = useCallback(async () => {
+    if (!hasChanges) return;
+
+    setIsSaving(true);
+    try {
+      const result = await onSave(content);
+      if (result) {
+        setHasChanges(false);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  }, [content, hasChanges, onSave]);
+
+  const handleReset = useCallback(() => {
+    setContent(output.content);
+    setHasChanges(false);
+  }, [output.content]);
+
+  const handleSelect = useCallback(async () => {
+    if (onSelect) {
+      await onSelect();
+    }
+  }, [onSelect]);
+
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <div className="flex items-center gap-3">
+          <h3 className="text-sm font-medium">Edit Output</h3>
+          <Badge variant="outline">{output.agentId}</Badge>
+          <Badge variant="secondary">v{output.version}</Badge>
+          {output.selected && <Badge variant="default">Selected</Badge>}
+          {hasChanges && (
+            <Badge
+              variant="outline"
+              className="border-orange-500/50 bg-orange-500/10 text-xs text-orange-600 dark:text-orange-400"
+            >
+              Unsaved
+            </Badge>
+          )}
+        </div>
+        <div className="flex items-center gap-2">
+          {onClose && (
+            <Button variant="ghost" size="icon" onClick={onClose}>
+              <X className="h-4 w-4" />
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Editor */}
+      <div className="min-h-0 flex-1">
+        <Editor
+          value={content}
+          language="markdown"
+          theme={isDark ? 'vs-dark' : 'light'}
+          onChange={handleEditorChange}
+          options={{
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            wordWrap: 'on',
+            fontSize: 13,
+            lineNumbers: 'on',
+            folding: true,
+            renderLineHighlight: 'line',
+            scrollbar: {
+              vertical: 'auto',
+              horizontal: 'auto',
+            },
+            padding: { top: 8, bottom: 8 },
+          }}
+        />
+      </div>
+
+      {/* Footer actions */}
+      <div className="flex items-center justify-between border-t px-4 py-3">
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <History className="h-3 w-3" />
+          <span>
+            Created {new Date(output.createdAt).toLocaleDateString()} at{' '}
+            {new Date(output.createdAt).toLocaleTimeString()}
+          </span>
+        </div>
+        <div className="flex gap-2">
+          {hasChanges && (
+            <Button variant="ghost" size="sm" onClick={handleReset}>
+              <Undo2 className="mr-1 h-3 w-3" />
+              Discard
+            </Button>
+          )}
+          {onSelect && !output.selected && (
+            <Button variant="outline" size="sm" onClick={handleSelect}>
+              <Check className="mr-1 h-3 w-3" />
+              Select as Preferred
+            </Button>
+          )}
+          <Button
+            variant="default"
+            size="sm"
+            onClick={handleSave}
+            disabled={!hasChanges || isSaving}
+          >
+            <Save className="mr-1 h-3 w-3" />
+            {isSaving ? 'Saving...' : 'Save Changes'}
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Compact version history list for an output.
+ */
+interface VersionHistoryProps {
+  outputs: ContentOutput[];
+  currentOutputId: string;
+  onSelectVersion: (output: ContentOutput) => void;
+  className?: string;
+}
+
+export function VersionHistory({
+  outputs,
+  currentOutputId,
+  onSelectVersion,
+  className,
+}: VersionHistoryProps) {
+  // Sort by version descending
+  const sortedOutputs = [...outputs].sort((a, b) => b.version - a.version);
+
+  return (
+    <div className={cn('space-y-1', className)}>
+      <div className="text-xs font-medium text-muted-foreground">Version History</div>
+      <div className="space-y-1">
+        {sortedOutputs.map((output) => (
+          <button
+            key={output.id}
+            onClick={() => onSelectVersion(output)}
+            className={cn(
+              'flex w-full items-center justify-between rounded px-2 py-1 text-xs hover:bg-muted',
+              currentOutputId === output.id && 'bg-muted'
+            )}
+          >
+            <span className="flex items-center gap-2">
+              <span className="font-medium">v{output.version}</span>
+              {output.selected && (
+                <Badge variant="default" className="h-4 px-1 text-[10px]">
+                  Selected
+                </Badge>
+              )}
+            </span>
+            <span className="text-muted-foreground">
+              {new Date(output.createdAt).toLocaleDateString()}
+            </span>
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+export default ContentOutputEditor;

--- a/src/renderer/components/content/ContentOutputsPanel.tsx
+++ b/src/renderer/components/content/ContentOutputsPanel.tsx
@@ -1,0 +1,375 @@
+import { useState, useCallback } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  FileText,
+  GitCompare,
+  Edit3,
+  Check,
+  Trash2,
+  Copy,
+  Download,
+  FolderOpen,
+  Archive,
+} from 'lucide-react';
+import type { ContentOutput } from '@/types/electron-api';
+import { useContentOutputs, groupOutputsByAgent } from '@/hooks/useContentOutputs';
+import { OutputComparisonPanel } from './OutputComparisonPanel';
+import { ContentOutputEditor } from './ContentOutputEditor';
+import { ContentArchivePanel } from './ContentArchivePanel';
+import { cn } from '@/lib/utils';
+
+interface ContentOutputsPanelProps {
+  taskId: string;
+  className?: string;
+}
+
+type ViewMode = 'list' | 'compare' | 'edit' | 'archive';
+
+/**
+ * Panel displaying all content outputs for a task.
+ * Supports viewing, comparing, editing, exporting, and selecting outputs.
+ */
+export function ContentOutputsPanel({ taskId, className }: ContentOutputsPanelProps) {
+  const { outputs, selectedOutput, isLoading, error, selectOutput, updateOutput, deleteOutput } =
+    useContentOutputs(taskId);
+
+  const [viewMode, setViewMode] = useState<ViewMode>('list');
+  const [editingOutput, setEditingOutput] = useState<ContentOutput | null>(null);
+  const [isCopying, setIsCopying] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+
+  const groupedOutputs = groupOutputsByAgent(outputs);
+
+  const handleCopy = useCallback(async (output: ContentOutput) => {
+    setIsCopying(output.id);
+    try {
+      await navigator.clipboard.writeText(output.content);
+    } finally {
+      setTimeout(() => setIsCopying(null), 1000);
+    }
+  }, []);
+
+  const handleEdit = useCallback((output: ContentOutput) => {
+    setEditingOutput(output);
+    setViewMode('edit');
+  }, []);
+
+  const handleSaveEdit = useCallback(
+    async (content: string) => {
+      if (!editingOutput) return null;
+      const result = await updateOutput(editingOutput.id, content);
+      if (result) {
+        setEditingOutput(result);
+      }
+      return result;
+    },
+    [editingOutput, updateOutput]
+  );
+
+  const handleSelectFromEdit = useCallback(async () => {
+    if (!editingOutput) return false;
+    return selectOutput(editingOutput.id);
+  }, [editingOutput, selectOutput]);
+
+  const handleCloseEdit = useCallback(() => {
+    setEditingOutput(null);
+    setViewMode('list');
+  }, []);
+
+  const handleDelete = useCallback(
+    async (output: ContentOutput) => {
+      if (confirm(`Delete this output from ${output.agentId} (v${output.version})?`)) {
+        await deleteOutput(output.id);
+      }
+    },
+    [deleteOutput]
+  );
+
+  // Export handlers
+  const handleExportToFile = useCallback(async (outputId: string) => {
+    setIsExporting(true);
+    try {
+      await window.electronAPI.contentExportFile({
+        outputId,
+        options: { includeMetadata: true },
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  }, []);
+
+  const handleExportSelectedToFile = useCallback(async () => {
+    if (!selectedOutput) return;
+    await handleExportToFile(selectedOutput.id);
+  }, [selectedOutput, handleExportToFile]);
+
+  const handleExportToFolder = useCallback(async () => {
+    setIsExporting(true);
+    try {
+      await window.electronAPI.contentExportFolder({
+        taskId,
+        options: { includeMetadata: true, filenameFormat: 'detailed' },
+      });
+    } finally {
+      setIsExporting(false);
+    }
+  }, [taskId]);
+
+  // Compare mode
+  if (viewMode === 'compare') {
+    return (
+      <div className={cn('flex h-full flex-col', className)}>
+        <OutputComparisonPanel
+          outputs={outputs}
+          onSelectOutput={selectOutput}
+          onClose={() => setViewMode('list')}
+        />
+      </div>
+    );
+  }
+
+  // Edit mode
+  if (viewMode === 'edit' && editingOutput) {
+    return (
+      <div className={cn('flex h-full flex-col', className)}>
+        <ContentOutputEditor
+          output={editingOutput}
+          onSave={handleSaveEdit}
+          onSelect={handleSelectFromEdit}
+          onClose={handleCloseEdit}
+        />
+      </div>
+    );
+  }
+
+  // Archive mode
+  if (viewMode === 'archive') {
+    return (
+      <div className={cn('flex h-full flex-col', className)}>
+        <ContentArchivePanel
+          outputs={outputs}
+          onSelectVersion={selectOutput}
+          onCopy={handleCopy}
+          onExportFile={handleExportToFile}
+          onExportFolder={handleExportToFolder}
+          onClose={() => setViewMode('list')}
+        />
+      </div>
+    );
+  }
+
+  // List mode
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-3">
+        <h3 className="flex items-center gap-2 text-sm font-medium">
+          <FileText className="h-4 w-4" />
+          Content Outputs
+          {outputs.length > 0 && <Badge variant="secondary">{outputs.length}</Badge>}
+        </h3>
+        <div className="flex gap-2">
+          {outputs.length > 0 && (
+            <>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setViewMode('archive')}
+                title="View archive"
+              >
+                <Archive className="h-4 w-4" />
+              </Button>
+              {outputs.length >= 2 && (
+                <Button variant="outline" size="sm" onClick={() => setViewMode('compare')}>
+                  <GitCompare className="mr-1 h-3 w-3" />
+                  Compare
+                </Button>
+              )}
+            </>
+          )}
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="min-h-0 flex-1 overflow-auto p-4">
+        {isLoading ? (
+          <div className="flex h-32 items-center justify-center text-muted-foreground">
+            Loading outputs...
+          </div>
+        ) : error ? (
+          <div className="flex h-32 items-center justify-center text-destructive">{error}</div>
+        ) : outputs.length === 0 ? (
+          <div className="flex h-32 flex-col items-center justify-center text-muted-foreground">
+            <FileText className="mb-2 h-12 w-12 opacity-50" />
+            <p>No outputs yet</p>
+            <p className="text-xs">Outputs will appear here when agents generate content</p>
+          </div>
+        ) : (
+          <div className="space-y-4">
+            {/* Selected output highlight */}
+            {selectedOutput && (
+              <Card className="border-primary bg-primary/5">
+                <CardHeader className="pb-2">
+                  <CardTitle className="flex items-center justify-between text-sm">
+                    <span className="flex items-center gap-2">
+                      <Check className="h-4 w-4 text-primary" />
+                      Selected Output
+                    </span>
+                    <div className="flex items-center gap-2">
+                      <Badge variant="outline">{selectedOutput.agentId}</Badge>
+                      <Badge variant="secondary">v{selectedOutput.version}</Badge>
+                    </div>
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <pre className="max-h-32 overflow-auto whitespace-pre-wrap rounded bg-muted/50 p-3 font-mono text-xs">
+                    {selectedOutput.content.slice(0, 500)}
+                    {selectedOutput.content.length > 500 && '...'}
+                  </pre>
+                  <div className="mt-2 flex flex-wrap gap-2">
+                    <Button variant="ghost" size="sm" onClick={() => handleCopy(selectedOutput)}>
+                      <Copy className="mr-1 h-3 w-3" />
+                      {isCopying === selectedOutput.id ? 'Copied!' : 'Copy'}
+                    </Button>
+                    <Button variant="ghost" size="sm" onClick={() => handleEdit(selectedOutput)}>
+                      <Edit3 className="mr-1 h-3 w-3" />
+                      Edit
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleExportSelectedToFile}
+                      disabled={isExporting}
+                    >
+                      <Download className="mr-1 h-3 w-3" />
+                      Export
+                    </Button>
+                    <Button
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleExportToFolder}
+                      disabled={isExporting}
+                    >
+                      <FolderOpen className="mr-1 h-3 w-3" />
+                      Export All
+                    </Button>
+                  </div>
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Outputs by agent */}
+            {Array.from(groupedOutputs.entries()).map(([agentId, agentOutputs]) => (
+              <div key={agentId} className="space-y-2">
+                <div className="flex items-center gap-2 text-sm font-medium">
+                  <span>{agentId}</span>
+                  <Badge variant="secondary">
+                    {agentOutputs.length} version{agentOutputs.length !== 1 ? 's' : ''}
+                  </Badge>
+                </div>
+                <div className="space-y-2">
+                  {agentOutputs.map((output) => (
+                    <Card
+                      key={output.id}
+                      className={cn(
+                        'cursor-pointer transition-colors hover:bg-muted/50',
+                        output.selected && 'border-primary'
+                      )}
+                    >
+                      <CardContent className="py-3">
+                        <div className="flex items-start justify-between gap-4">
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center gap-2">
+                              <Badge variant="outline">v{output.version}</Badge>
+                              {output.selected && <Badge variant="default">Selected</Badge>}
+                              <span className="text-xs text-muted-foreground">
+                                {new Date(output.createdAt).toLocaleString()}
+                              </span>
+                            </div>
+                            <pre className="mt-2 max-h-20 overflow-hidden whitespace-pre-wrap text-xs text-muted-foreground">
+                              {output.content.slice(0, 200)}
+                              {output.content.length > 200 && '...'}
+                            </pre>
+                          </div>
+                          <div className="flex shrink-0 gap-1">
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleCopy(output);
+                              }}
+                              title="Copy to clipboard"
+                            >
+                              <Copy className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleExportToFile(output.id);
+                              }}
+                              title="Export to file"
+                              disabled={isExporting}
+                            >
+                              <Download className="h-3 w-3" />
+                            </Button>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleEdit(output);
+                              }}
+                              title="Edit"
+                            >
+                              <Edit3 className="h-3 w-3" />
+                            </Button>
+                            {!output.selected && (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8"
+                                onClick={(e) => {
+                                  e.stopPropagation();
+                                  selectOutput(output.id);
+                                }}
+                                title="Select as preferred"
+                              >
+                                <Check className="h-3 w-3" />
+                              </Button>
+                            )}
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="h-8 w-8 text-muted-foreground hover:text-destructive"
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleDelete(output);
+                              }}
+                              title="Delete"
+                            >
+                              <Trash2 className="h-3 w-3" />
+                            </Button>
+                          </div>
+                        </div>
+                      </CardContent>
+                    </Card>
+                  ))}
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default ContentOutputsPanel;

--- a/src/renderer/components/content/ContentRoleSelector.tsx
+++ b/src/renderer/components/content/ContentRoleSelector.tsx
@@ -1,0 +1,65 @@
+import { Label } from '@/components/ui/label';
+import { CONTENT_ROLES, PROMPT_TEMPLATES, type ContentRole } from '@shared/content/promptTemplates';
+import { cn } from '@/lib/utils';
+import { Search, Target, PenTool, MessageSquare, Edit3 } from 'lucide-react';
+
+interface ContentRoleSelectorProps {
+  selectedRole: ContentRole | null;
+  onRoleChange: (role: ContentRole | null) => void;
+  disabled?: boolean;
+  className?: string;
+}
+
+const ROLE_ICONS: Record<ContentRole, React.ReactNode> = {
+  researcher: <Search className="h-4 w-4" />,
+  'seo-specialist': <Target className="h-4 w-4" />,
+  copywriter: <PenTool className="h-4 w-4" />,
+  'brand-voice': <MessageSquare className="h-4 w-4" />,
+  editor: <Edit3 className="h-4 w-4" />,
+};
+
+export function ContentRoleSelector({
+  selectedRole,
+  onRoleChange,
+  disabled = false,
+  className,
+}: ContentRoleSelectorProps) {
+  return (
+    <div className={cn('space-y-2', className)}>
+      <Label className="text-xs">Content Role (optional)</Label>
+      <div className="flex flex-wrap gap-2">
+        {CONTENT_ROLES.map((roleId) => {
+          const template = PROMPT_TEMPLATES[roleId];
+          const isSelected = selectedRole === roleId;
+
+          return (
+            <button
+              key={roleId}
+              type="button"
+              disabled={disabled}
+              onClick={() => onRoleChange(isSelected ? null : roleId)}
+              className={cn(
+                'inline-flex items-center gap-1.5 rounded-md border px-2.5 py-1.5 text-xs font-medium transition-colors',
+                isSelected
+                  ? 'border-primary bg-primary/10 text-primary'
+                  : 'border-border bg-background text-muted-foreground hover:bg-muted hover:text-foreground',
+                disabled && 'cursor-not-allowed opacity-50'
+              )}
+              title={template.description}
+            >
+              {ROLE_ICONS[roleId]}
+              {template.name}
+            </button>
+          );
+        })}
+      </div>
+      {selectedRole && (
+        <p className="text-xs text-muted-foreground">
+          {PROMPT_TEMPLATES[selectedRole].description}
+        </p>
+      )}
+    </div>
+  );
+}
+
+export default ContentRoleSelector;

--- a/src/renderer/components/content/ContentWorkspacePanel.tsx
+++ b/src/renderer/components/content/ContentWorkspacePanel.tsx
@@ -1,0 +1,283 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/dialog';
+import { BrandEditor } from './BrandEditor';
+import { CollectionList } from './CollectionList';
+import { DocumentUploader } from './DocumentUploader';
+import { useContentWorkspace } from '@/hooks/useContentWorkspace';
+import { useBrand } from '@/hooks/useBrand';
+import { useCollections } from '@/hooks/useCollections';
+import { useKnowledgeDocs } from '@/hooks/useKnowledgeDocs';
+import { Plus, Layers, FileText, Palette, FolderOpen } from 'lucide-react';
+import { cn } from '@/lib/utils';
+
+type TabValue = 'brand' | 'knowledge';
+
+interface ContentWorkspacePanelProps {
+  projectId: string;
+}
+
+export function ContentWorkspacePanel({ projectId }: ContentWorkspacePanelProps) {
+  const [isCreateDialogOpen, setIsCreateDialogOpen] = useState(false);
+  const [newWorkspaceName, setNewWorkspaceName] = useState('');
+  const [activeTab, setActiveTab] = useState<TabValue>('brand');
+
+  const {
+    workspaces,
+    activeWorkspace,
+    isLoading: isLoadingWorkspaces,
+    createWorkspace,
+    selectWorkspace,
+  } = useContentWorkspace(projectId);
+
+  const { brands, activeBrand, createBrand, updateBrand, deleteBrand, setActiveById } = useBrand(
+    activeWorkspace?.id
+  );
+
+  const {
+    collections,
+    selectedCollection,
+    createCollection,
+    deleteCollection,
+    selectCollection,
+    incrementDocumentCount,
+  } = useCollections(activeWorkspace?.id);
+
+  const {
+    documents,
+    selectedDocument,
+    createDocument,
+    uploadDocuments,
+    deleteDocument,
+    selectDocument,
+  } = useKnowledgeDocs(selectedCollection?.id);
+
+  const handleCreateWorkspace = async () => {
+    if (!newWorkspaceName.trim()) return;
+
+    const result = await createWorkspace(newWorkspaceName.trim());
+    if (result) {
+      setIsCreateDialogOpen(false);
+      setNewWorkspaceName('');
+    }
+  };
+
+  const handleCreateDocument = async (
+    name: string,
+    content: string,
+    metadata?: Record<string, unknown>
+  ) => {
+    const result = await createDocument(name, content, metadata);
+    if (result && selectedCollection) {
+      incrementDocumentCount(selectedCollection.id, 1);
+    }
+    return result;
+  };
+
+  const handleUploadDocuments = async (files: Array<{ name: string; content: string }>) => {
+    const result = await uploadDocuments(files);
+    if (result && selectedCollection) {
+      incrementDocumentCount(selectedCollection.id, result.length);
+    }
+    return result;
+  };
+
+  const handleDeleteDocument = async (id: string) => {
+    const result = await deleteDocument(id);
+    if (result && selectedCollection) {
+      incrementDocumentCount(selectedCollection.id, -1);
+    }
+    return result;
+  };
+
+  if (isLoadingWorkspaces) {
+    return (
+      <div className="flex h-64 items-center justify-center">
+        <div className="text-muted-foreground">Loading...</div>
+      </div>
+    );
+  }
+
+  // No workspaces yet - show create prompt
+  if (workspaces.length === 0) {
+    return (
+      <div className="flex h-64 flex-col items-center justify-center gap-4">
+        <Layers className="h-16 w-16 text-muted-foreground/50" />
+        <div className="text-center">
+          <h3 className="text-lg font-semibold">No Content Workspaces</h3>
+          <p className="text-sm text-muted-foreground">
+            Create a workspace to start managing your content.
+          </p>
+        </div>
+        <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+          <DialogTrigger asChild>
+            <Button>
+              <Plus className="mr-2 h-4 w-4" />
+              Create Workspace
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create Content Workspace</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 pt-4">
+              <Input
+                placeholder="Workspace name"
+                value={newWorkspaceName}
+                onChange={(e) => setNewWorkspaceName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreateWorkspace();
+                }}
+              />
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" onClick={() => setIsCreateDialogOpen(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={handleCreateWorkspace}>Create</Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full flex-col">
+      {/* Workspace selector */}
+      <div className="flex items-center gap-2 border-b p-4">
+        <Layers className="h-5 w-5 text-muted-foreground" />
+        <select
+          value={activeWorkspace?.id || ''}
+          onChange={(e) => {
+            const workspace = workspaces.find((w) => w.id === e.target.value);
+            selectWorkspace(workspace || null);
+          }}
+          className="flex-1 rounded border bg-transparent px-2 py-1"
+        >
+          {workspaces.map((w) => (
+            <option key={w.id} value={w.id}>
+              {w.name}
+            </option>
+          ))}
+        </select>
+        <Dialog open={isCreateDialogOpen} onOpenChange={setIsCreateDialogOpen}>
+          <DialogTrigger asChild>
+            <Button size="sm" variant="outline">
+              <Plus className="h-4 w-4" />
+            </Button>
+          </DialogTrigger>
+          <DialogContent>
+            <DialogHeader>
+              <DialogTitle>Create Content Workspace</DialogTitle>
+            </DialogHeader>
+            <div className="space-y-4 pt-4">
+              <Input
+                placeholder="Workspace name"
+                value={newWorkspaceName}
+                onChange={(e) => setNewWorkspaceName(e.target.value)}
+                onKeyDown={(e) => {
+                  if (e.key === 'Enter') handleCreateWorkspace();
+                }}
+              />
+              <div className="flex justify-end gap-2">
+                <Button variant="ghost" onClick={() => setIsCreateDialogOpen(false)}>
+                  Cancel
+                </Button>
+                <Button onClick={handleCreateWorkspace}>Create</Button>
+              </div>
+            </div>
+          </DialogContent>
+        </Dialog>
+      </div>
+
+      {/* Workspace content */}
+      {activeWorkspace && (
+        <div className="flex flex-1 flex-col">
+          {/* Tab buttons */}
+          <div className="mx-4 mt-4 inline-flex h-10 w-fit items-center justify-center rounded-md bg-muted p-1 text-muted-foreground">
+            <button
+              onClick={() => setActiveTab('brand')}
+              className={cn(
+                'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+                activeTab === 'brand'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'hover:bg-background/50'
+              )}
+            >
+              <Palette className="h-4 w-4" />
+              Brand
+            </button>
+            <button
+              onClick={() => setActiveTab('knowledge')}
+              className={cn(
+                'inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-sm px-3 py-1.5 text-sm font-medium ring-offset-background transition-all focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 disabled:pointer-events-none disabled:opacity-50',
+                activeTab === 'knowledge'
+                  ? 'bg-background text-foreground shadow-sm'
+                  : 'hover:bg-background/50'
+              )}
+            >
+              <FolderOpen className="h-4 w-4" />
+              Knowledge
+            </button>
+          </div>
+
+          {/* Tab content */}
+          {activeTab === 'brand' && (
+            <div className="flex-1 overflow-auto p-4">
+              <BrandEditor
+                brands={brands}
+                activeBrand={activeBrand}
+                onCreateBrand={createBrand}
+                onUpdateBrand={updateBrand}
+                onDeleteBrand={deleteBrand}
+                onSetActive={setActiveById}
+              />
+            </div>
+          )}
+
+          {activeTab === 'knowledge' && (
+            <div className="flex-1 overflow-auto p-4">
+              <div className="grid h-full grid-cols-2 gap-6">
+                <div>
+                  <CollectionList
+                    collections={collections}
+                    selectedCollection={selectedCollection}
+                    onSelectCollection={selectCollection}
+                    onCreateCollection={createCollection}
+                    onDeleteCollection={deleteCollection}
+                  />
+                </div>
+                <div>
+                  {selectedCollection ? (
+                    <DocumentUploader
+                      collectionId={selectedCollection.id}
+                      documents={documents}
+                      onCreateDocument={handleCreateDocument}
+                      onUploadDocuments={handleUploadDocuments}
+                      onDeleteDocument={handleDeleteDocument}
+                      onSelectDocument={selectDocument}
+                      selectedDocument={selectedDocument}
+                    />
+                  ) : (
+                    <div className="flex h-64 flex-col items-center justify-center text-muted-foreground">
+                      <FileText className="mb-2 h-12 w-12 opacity-50" />
+                      <p>Select a collection to view documents</p>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/content/DocumentUploader.tsx
+++ b/src/renderer/components/content/DocumentUploader.tsx
@@ -1,0 +1,226 @@
+import { useState, useCallback, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Upload, FileText, Plus, Check, X, Trash2 } from 'lucide-react';
+import type { KnowledgeDocument } from '@/types/electron-api';
+
+interface DocumentUploaderProps {
+  collectionId: string;
+  documents: KnowledgeDocument[];
+  onCreateDocument: (
+    name: string,
+    content: string,
+    metadata?: Record<string, unknown>
+  ) => Promise<KnowledgeDocument | null>;
+  onUploadDocuments: (
+    files: Array<{ name: string; content: string }>
+  ) => Promise<KnowledgeDocument[] | null>;
+  onDeleteDocument: (id: string) => Promise<boolean>;
+  onSelectDocument: (document: KnowledgeDocument | null) => void;
+  selectedDocument: KnowledgeDocument | null;
+}
+
+export function DocumentUploader({
+  collectionId,
+  documents,
+  onCreateDocument,
+  onUploadDocuments,
+  onDeleteDocument,
+  onSelectDocument,
+  selectedDocument,
+}: DocumentUploaderProps) {
+  const [isCreating, setIsCreating] = useState(false);
+  const [newName, setNewName] = useState('');
+  const [newContent, setNewContent] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const handleCreate = useCallback(async () => {
+    if (!newName.trim()) return;
+
+    const result = await onCreateDocument(newName.trim(), newContent);
+    if (result) {
+      setIsCreating(false);
+      setNewName('');
+      setNewContent('');
+    }
+  }, [newName, newContent, onCreateDocument]);
+
+  const handleFileSelect = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const files = e.target.files;
+      if (!files || files.length === 0) return;
+
+      setIsUploading(true);
+
+      try {
+        const fileData: Array<{ name: string; content: string }> = [];
+
+        for (let i = 0; i < files.length; i++) {
+          const file = files[i];
+          if (
+            file.name.endsWith('.md') ||
+            file.name.endsWith('.txt') ||
+            file.name.endsWith('.markdown')
+          ) {
+            const content = await file.text();
+            fileData.push({
+              name: file.name,
+              content,
+            });
+          }
+        }
+
+        if (fileData.length > 0) {
+          await onUploadDocuments(fileData);
+        }
+      } catch (err) {
+        console.error('Failed to upload files:', err);
+      } finally {
+        setIsUploading(false);
+        if (fileInputRef.current) {
+          fileInputRef.current.value = '';
+        }
+      }
+    },
+    [onUploadDocuments]
+  );
+
+  const handleDelete = useCallback(
+    async (e: React.MouseEvent, id: string) => {
+      e.stopPropagation();
+      await onDeleteDocument(id);
+    },
+    [onDeleteDocument]
+  );
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Documents</h3>
+        <div className="flex gap-2">
+          <input
+            ref={fileInputRef}
+            type="file"
+            accept=".md,.txt,.markdown"
+            multiple
+            className="hidden"
+            onChange={handleFileSelect}
+          />
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={() => fileInputRef.current?.click()}
+            disabled={isUploading}
+          >
+            <Upload className="mr-1 h-4 w-4" />
+            {isUploading ? 'Uploading...' : 'Upload Files'}
+          </Button>
+          {!isCreating && (
+            <Button size="sm" variant="outline" onClick={() => setIsCreating(true)}>
+              <Plus className="mr-1 h-4 w-4" />
+              New Document
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {isCreating && (
+        <Card>
+          <CardHeader className="pb-3">
+            <CardTitle className="text-base">Create Document</CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Input
+              placeholder="Document name"
+              value={newName}
+              onChange={(e) => setNewName(e.target.value)}
+            />
+            <Textarea
+              placeholder="Enter document content in markdown..."
+              value={newContent}
+              onChange={(e) => setNewContent(e.target.value)}
+              rows={10}
+              className="font-mono text-sm"
+            />
+            <div className="flex gap-2">
+              <Button size="sm" onClick={handleCreate}>
+                <Check className="mr-1 h-4 w-4" />
+                Create
+              </Button>
+              <Button
+                size="sm"
+                variant="ghost"
+                onClick={() => {
+                  setIsCreating(false);
+                  setNewName('');
+                  setNewContent('');
+                }}
+              >
+                <X className="mr-1 h-4 w-4" />
+                Cancel
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {documents.length === 0 && !isCreating && (
+        <div className="rounded-lg border-2 border-dashed py-8 text-center text-muted-foreground">
+          <FileText className="mx-auto mb-2 h-12 w-12 opacity-50" />
+          <p>No documents in this collection.</p>
+          <p className="text-sm">Upload markdown files or create a new document.</p>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        {documents.map((doc) => (
+          <Card
+            key={doc.id}
+            className={`cursor-pointer transition-colors hover:bg-muted/50 ${
+              selectedDocument?.id === doc.id ? 'border-primary bg-muted/30' : ''
+            }`}
+            onClick={() => onSelectDocument(doc)}
+          >
+            <CardContent className="px-4 py-3">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-3">
+                  <FileText className="h-5 w-5 text-muted-foreground" />
+                  <div>
+                    <div className="font-medium">{doc.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {doc.content.length} characters
+                    </div>
+                  </div>
+                </div>
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8"
+                  onClick={(e) => handleDelete(e, doc.id)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {selectedDocument && (
+        <Card className="mt-4">
+          <CardHeader className="pb-2">
+            <CardTitle className="text-base">{selectedDocument.name}</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <pre className="max-h-64 overflow-auto whitespace-pre-wrap rounded bg-muted/50 p-3 font-mono text-sm">
+              {selectedDocument.content}
+            </pre>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/content/OutputComparisonPanel.tsx
+++ b/src/renderer/components/content/OutputComparisonPanel.tsx
@@ -1,0 +1,235 @@
+import { useState, useCallback } from 'react';
+import { DiffEditor } from '@monaco-editor/react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Check, ChevronLeft, ChevronRight, Copy, GitCompare } from 'lucide-react';
+import type { ContentOutput } from '@/types/electron-api';
+import { useTheme } from '@/hooks/useTheme';
+import { cn } from '@/lib/utils';
+
+interface OutputComparisonPanelProps {
+  outputs: ContentOutput[];
+  onSelectOutput?: (id: string) => Promise<boolean | void>;
+  onClose?: () => void;
+  className?: string;
+}
+
+/**
+ * Side-by-side comparison panel for content outputs.
+ * Allows comparing two outputs and selecting the preferred version.
+ */
+export function OutputComparisonPanel({
+  outputs,
+  onSelectOutput,
+  onClose,
+  className,
+}: OutputComparisonPanelProps) {
+  const { effectiveTheme } = useTheme();
+  const isDark = effectiveTheme === 'dark' || effectiveTheme === 'dark-black';
+
+  const [leftIndex, setLeftIndex] = useState(0);
+  const [rightIndex, setRightIndex] = useState(Math.min(1, outputs.length - 1));
+  const [isCopying, setIsCopying] = useState<'left' | 'right' | null>(null);
+
+  const leftOutput = outputs[leftIndex];
+  const rightOutput = outputs[rightIndex];
+
+  const handlePrevLeft = useCallback(() => {
+    setLeftIndex((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const handleNextLeft = useCallback(() => {
+    setLeftIndex((prev) => Math.min(outputs.length - 1, prev + 1));
+  }, [outputs.length]);
+
+  const handlePrevRight = useCallback(() => {
+    setRightIndex((prev) => Math.max(0, prev - 1));
+  }, []);
+
+  const handleNextRight = useCallback(() => {
+    setRightIndex((prev) => Math.min(outputs.length - 1, prev + 1));
+  }, [outputs.length]);
+
+  const handleCopy = useCallback(
+    async (side: 'left' | 'right') => {
+      const content = side === 'left' ? leftOutput?.content : rightOutput?.content;
+      if (!content) return;
+
+      setIsCopying(side);
+      try {
+        await navigator.clipboard.writeText(content);
+      } finally {
+        setTimeout(() => setIsCopying(null), 1000);
+      }
+    },
+    [leftOutput, rightOutput]
+  );
+
+  const handleSelect = useCallback(
+    async (side: 'left' | 'right') => {
+      const output = side === 'left' ? leftOutput : rightOutput;
+      if (output && onSelectOutput) {
+        await onSelectOutput(output.id);
+      }
+    },
+    [leftOutput, rightOutput, onSelectOutput]
+  );
+
+  if (outputs.length < 2) {
+    return (
+      <Card className={className}>
+        <CardContent className="flex h-64 items-center justify-center text-muted-foreground">
+          <div className="text-center">
+            <GitCompare className="mx-auto mb-2 h-12 w-12 opacity-50" />
+            <p>Need at least 2 outputs to compare</p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className={cn('flex h-full flex-col', className)}>
+      {/* Header */}
+      <div className="flex items-center justify-between border-b px-4 py-2">
+        <h3 className="flex items-center gap-2 text-sm font-medium">
+          <GitCompare className="h-4 w-4" />
+          Compare Outputs
+        </h3>
+        {onClose && (
+          <Button variant="ghost" size="sm" onClick={onClose}>
+            Close
+          </Button>
+        )}
+      </div>
+
+      {/* Comparison controls */}
+      <div className="grid grid-cols-2 gap-4 border-b p-4">
+        {/* Left output selector */}
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" size="icon" onClick={handlePrevLeft} disabled={leftIndex === 0}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <div className="text-center">
+            <div className="text-sm font-medium">{leftOutput?.agentId}</div>
+            <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+              <Badge variant="outline" className="text-xs">
+                v{leftOutput?.version}
+              </Badge>
+              {leftOutput?.selected && (
+                <Badge variant="default" className="text-xs">
+                  Selected
+                </Badge>
+              )}
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleNextLeft}
+            disabled={leftIndex === outputs.length - 1}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {/* Right output selector */}
+        <div className="flex items-center justify-between">
+          <Button variant="ghost" size="icon" onClick={handlePrevRight} disabled={rightIndex === 0}>
+            <ChevronLeft className="h-4 w-4" />
+          </Button>
+          <div className="text-center">
+            <div className="text-sm font-medium">{rightOutput?.agentId}</div>
+            <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+              <Badge variant="outline" className="text-xs">
+                v{rightOutput?.version}
+              </Badge>
+              {rightOutput?.selected && (
+                <Badge variant="default" className="text-xs">
+                  Selected
+                </Badge>
+              )}
+            </div>
+          </div>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={handleNextRight}
+            disabled={rightIndex === outputs.length - 1}
+          >
+            <ChevronRight className="h-4 w-4" />
+          </Button>
+        </div>
+      </div>
+
+      {/* Diff viewer */}
+      <div className="min-h-0 flex-1">
+        <DiffEditor
+          original={leftOutput?.content || ''}
+          modified={rightOutput?.content || ''}
+          language="markdown"
+          theme={isDark ? 'vs-dark' : 'light'}
+          options={{
+            readOnly: true,
+            renderSideBySide: true,
+            minimap: { enabled: false },
+            scrollBeyondLastLine: false,
+            wordWrap: 'on',
+            fontSize: 13,
+            lineNumbers: 'off',
+            folding: false,
+            renderLineHighlight: 'none',
+            overviewRulerLanes: 0,
+            hideCursorInOverviewRuler: true,
+            overviewRulerBorder: false,
+            scrollbar: {
+              vertical: 'auto',
+              horizontal: 'auto',
+            },
+          }}
+        />
+      </div>
+
+      {/* Actions */}
+      <div className="grid grid-cols-2 gap-4 border-t p-4">
+        <div className="flex gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleCopy('left')}
+            disabled={isCopying !== null}
+          >
+            <Copy className="mr-1 h-3 w-3" />
+            {isCopying === 'left' ? 'Copied!' : 'Copy'}
+          </Button>
+          {onSelectOutput && !leftOutput?.selected && (
+            <Button variant="default" size="sm" onClick={() => handleSelect('left')}>
+              <Check className="mr-1 h-3 w-3" />
+              Select This
+            </Button>
+          )}
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => handleCopy('right')}
+            disabled={isCopying !== null}
+          >
+            <Copy className="mr-1 h-3 w-3" />
+            {isCopying === 'right' ? 'Copied!' : 'Copy'}
+          </Button>
+          {onSelectOutput && !rightOutput?.selected && (
+            <Button variant="default" size="sm" onClick={() => handleSelect('right')}>
+              <Check className="mr-1 h-3 w-3" />
+              Select This
+            </Button>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default OutputComparisonPanel;

--- a/src/renderer/components/content/index.ts
+++ b/src/renderer/components/content/index.ts
@@ -1,0 +1,21 @@
+export { ContentWorkspacePanel } from './ContentWorkspacePanel';
+export { BrandEditor } from './BrandEditor';
+export { CollectionList } from './CollectionList';
+export { DocumentUploader } from './DocumentUploader';
+export { ContentKanbanBoard } from './ContentKanbanBoard';
+export { CollectionSelector } from './CollectionSelector';
+export {
+  ContentBriefFields,
+  hasContentBrief,
+  formatBriefSummary,
+  formatBriefForAgent,
+  type ContentBrief,
+} from './ContentBriefFields';
+export { ContentBriefBadge } from './ContentBriefBadge';
+export { ContentRoleSelector } from './ContentRoleSelector';
+// Epic 4: Multi-Agent Output Management
+export { OutputComparisonPanel } from './OutputComparisonPanel';
+export { ContentOutputEditor, VersionHistory } from './ContentOutputEditor';
+export { ContentOutputsPanel } from './ContentOutputsPanel';
+// Epic 5: Export & Archive
+export { ContentArchivePanel } from './ContentArchivePanel';

--- a/src/renderer/hooks/useBrand.ts
+++ b/src/renderer/hooks/useBrand.ts
@@ -1,0 +1,157 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { BrandGuideline } from '@/types/electron-api';
+
+export function useBrand(workspaceId: string | undefined) {
+  const [brands, setBrands] = useState<BrandGuideline[]>([]);
+  const [activeBrand, setActiveBrand] = useState<BrandGuideline | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadBrands = useCallback(async () => {
+    if (!workspaceId) {
+      setBrands([]);
+      setActiveBrand(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const [brandsResult, activeResult] = await Promise.all([
+        window.electronAPI.contentBrandGetByWorkspace(workspaceId),
+        window.electronAPI.contentBrandGetActive(workspaceId),
+      ]);
+
+      if (brandsResult.success && brandsResult.data) {
+        setBrands(brandsResult.data);
+      }
+
+      if (activeResult.success) {
+        setActiveBrand(activeResult.data || null);
+      }
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    loadBrands();
+  }, [workspaceId]);
+
+  const createBrand = useCallback(
+    async (name: string, content: string, isActive: boolean = true) => {
+      if (!workspaceId) return null;
+
+      try {
+        const result = await window.electronAPI.contentBrandCreate({
+          workspaceId,
+          name,
+          content,
+          isActive,
+        });
+
+        if (result.success && result.data) {
+          setBrands((prev) => [...prev, result.data!]);
+          if (result.data.isActive) {
+            setActiveBrand(result.data);
+            // Update other brands to not be active
+            setBrands((prev) =>
+              prev.map((b) => (b.id === result.data!.id ? b : { ...b, isActive: false }))
+            );
+          }
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to create brand');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [workspaceId]
+  );
+
+  const updateBrand = useCallback(
+    async (
+      id: string,
+      updates: Partial<{
+        name: string;
+        content: string;
+        isActive: boolean;
+      }>
+    ) => {
+      try {
+        const result = await window.electronAPI.contentBrandUpdate({
+          id,
+          ...updates,
+        });
+
+        if (result.success && result.data) {
+          setBrands((prev) => prev.map((b) => (b.id === id ? result.data! : b)));
+          if (result.data.isActive) {
+            setActiveBrand(result.data);
+            // Update other brands to not be active
+            setBrands((prev) =>
+              prev.map((b) => (b.id === result.data!.id ? b : { ...b, isActive: false }))
+            );
+          } else if (activeBrand?.id === id) {
+            setActiveBrand(null);
+          }
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to update brand');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [activeBrand]
+  );
+
+  const deleteBrand = useCallback(
+    async (id: string) => {
+      try {
+        const result = await window.electronAPI.contentBrandDelete(id);
+        if (result.success) {
+          setBrands((prev) => prev.filter((b) => b.id !== id));
+          if (activeBrand?.id === id) {
+            setActiveBrand(null);
+          }
+          return true;
+        } else {
+          setError(result.error || 'Failed to delete brand');
+          return false;
+        }
+      } catch (err) {
+        setError(String(err));
+        return false;
+      }
+    },
+    [activeBrand]
+  );
+
+  const setActiveById = useCallback(
+    async (id: string) => {
+      return updateBrand(id, { isActive: true });
+    },
+    [updateBrand]
+  );
+
+  return {
+    brands,
+    activeBrand,
+    isLoading,
+    error,
+    createBrand,
+    updateBrand,
+    deleteBrand,
+    setActiveById,
+    refresh: loadBrands,
+  };
+}

--- a/src/renderer/hooks/useCollectionSelector.ts
+++ b/src/renderer/hooks/useCollectionSelector.ts
@@ -1,0 +1,116 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { ContentCollection, KnowledgeDocument } from '@/types/electron-api';
+
+/**
+ * Hook for collection selection in task creation flow.
+ * Fetches collections for a workspace and provides CRUD operations.
+ */
+export function useCollectionSelector(workspaceId: string | null | undefined) {
+  const [collections, setCollections] = useState<ContentCollection[]>([]);
+  const [selectedCollectionId, setSelectedCollectionId] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  // Fetch collections when workspace changes
+  useEffect(() => {
+    if (!workspaceId) {
+      setCollections([]);
+      setSelectedCollectionId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchCollections = async () => {
+      setIsLoading(true);
+      try {
+        const result = await window.electronAPI.contentCollectionGetByWorkspace(workspaceId);
+        if (!cancelled && result.success && result.data) {
+          setCollections(result.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch collections:', err);
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchCollections();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [workspaceId]);
+
+  // Create a new collection
+  const createCollection = useCallback(
+    async (name: string, description?: string): Promise<ContentCollection | null> => {
+      if (!workspaceId) return null;
+
+      try {
+        const result = await window.electronAPI.contentCollectionCreate({
+          workspaceId,
+          name,
+          description,
+        });
+        if (result.success && result.data) {
+          setCollections((prev) => [...prev, result.data!]);
+          return result.data;
+        }
+      } catch (err) {
+        console.error('Failed to create collection:', err);
+      }
+      return null;
+    },
+    [workspaceId]
+  );
+
+  // Upload documents to a collection
+  const uploadDocuments = useCallback(
+    async (
+      collectionId: string,
+      files: Array<{ name: string; content: string }>
+    ): Promise<KnowledgeDocument[] | null> => {
+      try {
+        const result = await window.electronAPI.contentKnowledgeUpload({
+          collectionId,
+          documents: files,
+        });
+        if (result.success && result.data) {
+          // Update collection document count
+          setCollections((prev) =>
+            prev.map((c) =>
+              c.id === collectionId
+                ? { ...c, documentCount: (c.documentCount || 0) + result.data!.length }
+                : c
+            )
+          );
+          return result.data;
+        }
+      } catch (err) {
+        console.error('Failed to upload documents:', err);
+      }
+      return null;
+    },
+    []
+  );
+
+  // Select a collection
+  const selectCollection = useCallback((collectionId: string | null) => {
+    setSelectedCollectionId(collectionId);
+  }, []);
+
+  // Get selected collection object
+  const selectedCollection = collections.find((c) => c.id === selectedCollectionId) || null;
+
+  return {
+    collections,
+    selectedCollectionId,
+    selectedCollection,
+    isLoading,
+    selectCollection,
+    createCollection,
+    uploadDocuments,
+  };
+}

--- a/src/renderer/hooks/useCollections.ts
+++ b/src/renderer/hooks/useCollections.ts
@@ -1,0 +1,148 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ContentCollection } from '@/types/electron-api';
+
+export function useCollections(workspaceId: string | undefined) {
+  const [collections, setCollections] = useState<ContentCollection[]>([]);
+  const [selectedCollection, setSelectedCollection] = useState<ContentCollection | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadCollections = useCallback(async () => {
+    if (!workspaceId) {
+      setCollections([]);
+      setSelectedCollection(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await window.electronAPI.contentCollectionGetByWorkspace(workspaceId);
+      if (result.success && result.data) {
+        setCollections(result.data);
+      } else {
+        setError(result.error || 'Failed to load collections');
+      }
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [workspaceId]);
+
+  useEffect(() => {
+    loadCollections();
+  }, [workspaceId]);
+
+  const createCollection = useCallback(
+    async (name: string, description?: string) => {
+      if (!workspaceId) return null;
+
+      try {
+        const result = await window.electronAPI.contentCollectionCreate({
+          workspaceId,
+          name,
+          description,
+        });
+
+        if (result.success && result.data) {
+          const newCollection = { ...result.data, documentCount: 0 };
+          setCollections((prev) => [...prev, newCollection]);
+          return newCollection;
+        } else {
+          setError(result.error || 'Failed to create collection');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [workspaceId]
+  );
+
+  const updateCollection = useCallback(
+    async (
+      id: string,
+      updates: Partial<{
+        name: string;
+        description: string;
+      }>
+    ) => {
+      try {
+        const result = await window.electronAPI.contentCollectionUpdate({
+          id,
+          ...updates,
+        });
+
+        if (result.success && result.data) {
+          setCollections((prev) =>
+            prev.map((c) => (c.id === id ? { ...result.data!, documentCount: c.documentCount } : c))
+          );
+          if (selectedCollection?.id === id) {
+            setSelectedCollection({
+              ...result.data,
+              documentCount: selectedCollection.documentCount,
+            });
+          }
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to update collection');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [selectedCollection]
+  );
+
+  const deleteCollection = useCallback(
+    async (id: string) => {
+      try {
+        const result = await window.electronAPI.contentCollectionDelete(id);
+        if (result.success) {
+          setCollections((prev) => prev.filter((c) => c.id !== id));
+          if (selectedCollection?.id === id) {
+            setSelectedCollection(null);
+          }
+          return true;
+        } else {
+          setError(result.error || 'Failed to delete collection');
+          return false;
+        }
+      } catch (err) {
+        setError(String(err));
+        return false;
+      }
+    },
+    [selectedCollection]
+  );
+
+  const selectCollection = useCallback((collection: ContentCollection | null) => {
+    setSelectedCollection(collection);
+  }, []);
+
+  const incrementDocumentCount = useCallback((collectionId: string, delta: number = 1) => {
+    setCollections((prev) =>
+      prev.map((c) =>
+        c.id === collectionId ? { ...c, documentCount: (c.documentCount || 0) + delta } : c
+      )
+    );
+  }, []);
+
+  return {
+    collections,
+    selectedCollection,
+    isLoading,
+    error,
+    createCollection,
+    updateCollection,
+    deleteCollection,
+    selectCollection,
+    incrementDocumentCount,
+    refresh: loadCollections,
+  };
+}

--- a/src/renderer/hooks/useContentAwarePromptInjection.ts
+++ b/src/renderer/hooks/useContentAwarePromptInjection.ts
@@ -1,0 +1,126 @@
+import { useEffect, useState } from 'react';
+import { initialPromptSentKey } from '../lib/keys';
+import { classifyActivity } from '../lib/activityClassifier';
+import { agentStatusStore } from '../lib/agentStatusStore';
+import { makePtyId } from '@shared/ptyId';
+import type { ProviderId } from '@shared/providers/registry';
+import { hasContentWorkflow, enhancePromptFromTaskMetadata } from '../lib/contentPromptEnhancer';
+
+/**
+ * Enhanced prompt injection hook that adds content context when available.
+ *
+ * Similar to useInitialPromptInjection but:
+ * 1. Checks if task has content workflow metadata (collectionId, brief)
+ * 2. If so, enhances the prompt with brand guidelines and knowledge documents
+ * 3. Injects the enhanced prompt into the terminal
+ */
+export function useContentAwarePromptInjection(opts: {
+  taskId: string;
+  providerId: string;
+  prompt?: string | null;
+  taskMetadata?: Record<string, unknown> | null;
+  enabled?: boolean;
+}) {
+  const { taskId, providerId, prompt, taskMetadata, enabled = true } = opts;
+  const [isEnhancing, setIsEnhancing] = useState(false);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const trimmed = (prompt || '').trim();
+    if (!trimmed) return;
+
+    const sentKey = initialPromptSentKey(taskId, providerId);
+    if (localStorage.getItem(sentKey) === '1') return;
+
+    const ptyId = makePtyId(providerId as ProviderId, 'main', taskId);
+    let sent = false;
+    let silenceTimer: ReturnType<typeof setTimeout> | null = null;
+    let enhancedPrompt: string = trimmed;
+
+    // Enhance prompt with content context if applicable
+    const preparePrompt = async () => {
+      if (hasContentWorkflow(taskMetadata)) {
+        setIsEnhancing(true);
+        try {
+          const result = await enhancePromptFromTaskMetadata(trimmed, taskMetadata);
+          enhancedPrompt = result.prompt;
+        } catch (err) {
+          console.error('Failed to enhance prompt with content context:', err);
+          // Fall back to original prompt
+        } finally {
+          setIsEnhancing(false);
+        }
+      }
+    };
+
+    const send = () => {
+      try {
+        if (sent) return;
+        agentStatusStore.markUserInputSubmitted({ ptyId });
+        (
+          window as unknown as {
+            electronAPI: { ptyInput: (args: { id: string; data: string }) => void };
+          }
+        ).electronAPI?.ptyInput?.({ id: ptyId, data: enhancedPrompt + '\n' });
+        localStorage.setItem(sentKey, '1');
+        sent = true;
+      } catch {
+        // Ignore errors
+      }
+    };
+
+    // Start preparing the enhanced prompt
+    void preparePrompt();
+
+    const offData = (
+      window as unknown as {
+        electronAPI: { onPtyData: (ptyId: string, cb: (chunk: string) => void) => () => void };
+      }
+    ).electronAPI?.onPtyData?.(ptyId, (chunk: string) => {
+      // Debounce-based idle: send after a short period of silence
+      if (silenceTimer) clearTimeout(silenceTimer);
+      silenceTimer = setTimeout(() => {
+        if (!sent) send();
+      }, 1200);
+
+      // Heuristic: if classifier says idle, trigger a quicker send
+      try {
+        const signal = classifyActivity(providerId, chunk);
+        if (signal === 'idle' && !sent) {
+          setTimeout(send, 250);
+        }
+      } catch {
+        // ignore classifier errors; rely on silence debounce
+      }
+    });
+
+    const offStarted = (
+      window as unknown as {
+        electronAPI: { onPtyStarted: (cb: (info: { id: string }) => void) => () => void };
+      }
+    ).electronAPI?.onPtyStarted?.((info: { id: string }) => {
+      if (info?.id === ptyId) {
+        // Start a silence timer in case no output arrives (rare but possible)
+        if (silenceTimer) clearTimeout(silenceTimer);
+        silenceTimer = setTimeout(() => {
+          if (!sent) send();
+        }, 2000);
+      }
+    });
+
+    // Global last-resort fallback if neither event fires
+    const t = setTimeout(() => {
+      if (!sent) send();
+    }, 10000);
+
+    return () => {
+      clearTimeout(t);
+      if (silenceTimer) clearTimeout(silenceTimer);
+      offStarted?.();
+      offData?.();
+    };
+  }, [enabled, taskId, providerId, prompt, taskMetadata]);
+
+  return { isEnhancing };
+}

--- a/src/renderer/hooks/useContentContext.ts
+++ b/src/renderer/hooks/useContentContext.ts
@@ -1,0 +1,192 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { ContentContext } from '@/types/electron-api';
+import type { ContentBrief } from '@/components/content/ContentBriefFields';
+import { parseContentWorkflow } from '@/lib/contentWorkflowStatus';
+
+export interface ContentContextResult {
+  context: ContentContext | null;
+  isLoading: boolean;
+  error: string | null;
+}
+
+/**
+ * Hook to fetch content context for a task based on its collection.
+ * Automatically loads brand and knowledge context when collectionId changes.
+ */
+export function useContentContext(collectionId: string | null | undefined): ContentContextResult {
+  const [context, setContext] = useState<ContentContext | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!collectionId) {
+      setContext(null);
+      setError(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchContext = async () => {
+      setIsLoading(true);
+      setError(null);
+
+      try {
+        const result = await window.electronAPI.contentContextGetForTask({
+          collectionId,
+        });
+
+        if (!cancelled) {
+          if (result.success && result.data) {
+            setContext(result.data);
+          } else {
+            setError(result.error || 'Failed to load content context');
+          }
+        }
+      } catch (err) {
+        if (!cancelled) {
+          setError(String(err));
+        }
+      } finally {
+        if (!cancelled) {
+          setIsLoading(false);
+        }
+      }
+    };
+
+    fetchContext();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [collectionId]);
+
+  return { context, isLoading, error };
+}
+
+/**
+ * Get content context from task metadata.
+ */
+export function getCollectionIdFromTaskMetadata(
+  metadata: Record<string, unknown> | null | undefined
+): string | null {
+  const workflow = parseContentWorkflow(metadata);
+  return workflow?.collectionId || null;
+}
+
+/**
+ * Get content brief from task metadata.
+ */
+export function getBriefFromTaskMetadata(
+  metadata: Record<string, unknown> | null | undefined
+): ContentBrief | null {
+  const workflow = parseContentWorkflow(metadata);
+  return workflow?.brief || null;
+}
+
+/**
+ * Compose a full prompt with content context for agent injection.
+ * This is the main function to call when starting an agent with content context.
+ */
+export async function composeContentPrompt(options: {
+  collectionId: string | null;
+  userPrompt?: string;
+  role?: string;
+  brief?: ContentBrief;
+}): Promise<{
+  prompt: string;
+  context: ContentContext | null;
+  error: string | null;
+}> {
+  const { collectionId, userPrompt, role, brief } = options;
+
+  if (!collectionId) {
+    // No content context, just return the user prompt
+    return {
+      prompt: userPrompt || '',
+      context: null,
+      error: null,
+    };
+  }
+
+  try {
+    const result = await window.electronAPI.contentContextComposePrompt({
+      collectionId,
+      userPrompt,
+      role,
+      includeBrief: !!brief,
+      brief,
+    });
+
+    if (result.success && result.data) {
+      return {
+        prompt: result.data.prompt,
+        context: result.data.context,
+        error: null,
+      };
+    } else {
+      return {
+        prompt: userPrompt || '',
+        context: null,
+        error: result.error || 'Failed to compose prompt',
+      };
+    }
+  } catch (err) {
+    return {
+      prompt: userPrompt || '',
+      context: null,
+      error: String(err),
+    };
+  }
+}
+
+/**
+ * Hook for composing content-aware prompts.
+ * Use this when you need to manually compose a prompt with content context.
+ */
+export function useContentPromptComposer() {
+  const [isComposing, setIsComposing] = useState(false);
+
+  const compose = useCallback(
+    async (options: {
+      collectionId: string | null;
+      userPrompt?: string;
+      role?: string;
+      brief?: ContentBrief;
+    }) => {
+      setIsComposing(true);
+      try {
+        return await composeContentPrompt(options);
+      } finally {
+        setIsComposing(false);
+      }
+    },
+    []
+  );
+
+  return { compose, isComposing };
+}
+
+/**
+ * Prepend content context to an existing prompt.
+ * Use this to enhance an existing prompt with content context.
+ */
+export async function enhancePromptWithContext(options: {
+  collectionId: string | null;
+  originalPrompt: string;
+  brief?: ContentBrief;
+}): Promise<string> {
+  const { collectionId, originalPrompt, brief } = options;
+
+  if (!collectionId) {
+    return originalPrompt;
+  }
+
+  const result = await composeContentPrompt({
+    collectionId,
+    userPrompt: originalPrompt,
+    brief,
+  });
+
+  return result.prompt;
+}

--- a/src/renderer/hooks/useContentOutputs.ts
+++ b/src/renderer/hooks/useContentOutputs.ts
@@ -1,0 +1,237 @@
+import { useState, useEffect, useCallback } from 'react';
+import type { ContentOutput } from '@/types/electron-api';
+
+export interface UseContentOutputsResult {
+  outputs: ContentOutput[];
+  selectedOutput: ContentOutput | null;
+  isLoading: boolean;
+  error: string | null;
+
+  // Actions
+  saveOutput: (
+    agentId: string,
+    content: string,
+    metadata?: Record<string, unknown>
+  ) => Promise<ContentOutput | null>;
+  selectOutput: (id: string) => Promise<boolean>;
+  updateOutput: (
+    id: string,
+    content: string,
+    metadata?: Record<string, unknown>
+  ) => Promise<ContentOutput | null>;
+  deleteOutput: (id: string) => Promise<boolean>;
+  refresh: () => Promise<void>;
+}
+
+/**
+ * Hook for managing content outputs for a task.
+ * Provides CRUD operations and tracks selected/preferred output.
+ */
+export function useContentOutputs(taskId: string | null | undefined): UseContentOutputsResult {
+  const [outputs, setOutputs] = useState<ContentOutput[]>([]);
+  const [selectedOutput, setSelectedOutput] = useState<ContentOutput | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  // Fetch outputs when taskId changes
+  const fetchOutputs = useCallback(async () => {
+    if (!taskId) {
+      setOutputs([]);
+      setSelectedOutput(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      // Fetch all outputs for the task
+      const outputsResult = await window.electronAPI.contentOutputGetByTask(taskId);
+      if (outputsResult.success && outputsResult.data) {
+        setOutputs(outputsResult.data);
+
+        // Find selected output
+        const selected = outputsResult.data.find((o) => o.selected);
+        setSelectedOutput(selected || null);
+      } else {
+        setError(outputsResult.error || 'Failed to fetch outputs');
+      }
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [taskId]);
+
+  useEffect(() => {
+    fetchOutputs();
+  }, [fetchOutputs]);
+
+  // Save a new output
+  const saveOutput = useCallback(
+    async (
+      agentId: string,
+      content: string,
+      metadata?: Record<string, unknown>
+    ): Promise<ContentOutput | null> => {
+      if (!taskId) return null;
+
+      try {
+        const result = await window.electronAPI.contentOutputCreate({
+          taskId,
+          agentId,
+          content,
+          metadata,
+        });
+
+        if (result.success && result.data) {
+          setOutputs((prev) => [...prev, result.data!]);
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to save output');
+        }
+      } catch (err) {
+        setError(String(err));
+      }
+
+      return null;
+    },
+    [taskId]
+  );
+
+  // Select an output as preferred
+  const selectOutput = useCallback(async (id: string): Promise<boolean> => {
+    try {
+      const result = await window.electronAPI.contentOutputSelect(id);
+
+      if (result.success && result.data) {
+        // Update local state to reflect selection
+        setOutputs((prev) =>
+          prev.map((o) => ({
+            ...o,
+            selected: o.id === id,
+          }))
+        );
+        setSelectedOutput(result.data);
+        return true;
+      } else {
+        setError(result.error || 'Failed to select output');
+      }
+    } catch (err) {
+      setError(String(err));
+    }
+
+    return false;
+  }, []);
+
+  // Update an output's content
+  const updateOutput = useCallback(
+    async (
+      id: string,
+      content: string,
+      metadata?: Record<string, unknown>
+    ): Promise<ContentOutput | null> => {
+      try {
+        const result = await window.electronAPI.contentOutputUpdate({
+          id,
+          content,
+          metadata,
+        });
+
+        if (result.success && result.data) {
+          setOutputs((prev) => prev.map((o) => (o.id === id ? result.data! : o)));
+
+          // Update selected if this was the selected one
+          if (selectedOutput?.id === id) {
+            setSelectedOutput(result.data);
+          }
+
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to update output');
+        }
+      } catch (err) {
+        setError(String(err));
+      }
+
+      return null;
+    },
+    [selectedOutput]
+  );
+
+  // Delete an output
+  const deleteOutput = useCallback(
+    async (id: string): Promise<boolean> => {
+      try {
+        const result = await window.electronAPI.contentOutputDelete(id);
+
+        if (result.success) {
+          setOutputs((prev) => prev.filter((o) => o.id !== id));
+
+          // Clear selected if deleted
+          if (selectedOutput?.id === id) {
+            setSelectedOutput(null);
+          }
+
+          return true;
+        } else {
+          setError(result.error || 'Failed to delete output');
+        }
+      } catch (err) {
+        setError(String(err));
+      }
+
+      return false;
+    },
+    [selectedOutput]
+  );
+
+  return {
+    outputs,
+    selectedOutput,
+    isLoading,
+    error,
+    saveOutput,
+    selectOutput,
+    updateOutput,
+    deleteOutput,
+    refresh: fetchOutputs,
+  };
+}
+
+/**
+ * Get outputs grouped by agent.
+ */
+export function groupOutputsByAgent(outputs: ContentOutput[]): Map<string, ContentOutput[]> {
+  const grouped = new Map<string, ContentOutput[]>();
+
+  for (const output of outputs) {
+    const existing = grouped.get(output.agentId) || [];
+    existing.push(output);
+    grouped.set(output.agentId, existing);
+  }
+
+  // Sort each group by version descending
+  for (const [agentId, agentOutputs] of grouped) {
+    agentOutputs.sort((a, b) => b.version - a.version);
+    grouped.set(agentId, agentOutputs);
+  }
+
+  return grouped;
+}
+
+/**
+ * Get the latest output for each agent.
+ */
+export function getLatestOutputPerAgent(outputs: ContentOutput[]): ContentOutput[] {
+  const grouped = groupOutputsByAgent(outputs);
+  const latest: ContentOutput[] = [];
+
+  for (const agentOutputs of grouped.values()) {
+    if (agentOutputs.length > 0) {
+      latest.push(agentOutputs[0]); // First is latest due to version sort
+    }
+  }
+
+  return latest;
+}

--- a/src/renderer/hooks/useContentTaskCreation.ts
+++ b/src/renderer/hooks/useContentTaskCreation.ts
@@ -1,0 +1,229 @@
+import { useState, useCallback, useEffect } from 'react';
+import type { ContentWorkspace, ContentCollection } from '@/types/electron-api';
+import type { ContentBrief } from '@/components/content/ContentBriefFields';
+import { createContentWorkflowMetadata } from '@/lib/contentWorkflowStatus';
+
+export interface ContentTaskData {
+  workspaceId: string | null;
+  collectionId: string | null;
+  brief: ContentBrief;
+}
+
+/**
+ * Hook for managing content-specific task creation data.
+ * Combines workspace selection, collection selection, and content brief.
+ */
+export function useContentTaskCreation(projectId: string | null | undefined) {
+  // Workspaces
+  const [workspaces, setWorkspaces] = useState<ContentWorkspace[]>([]);
+  const [selectedWorkspaceId, setSelectedWorkspaceId] = useState<string | null>(null);
+  const [isLoadingWorkspaces, setIsLoadingWorkspaces] = useState(false);
+
+  // Collections (filtered by selected workspace)
+  const [collections, setCollections] = useState<ContentCollection[]>([]);
+  const [selectedCollectionId, setSelectedCollectionId] = useState<string | null>(null);
+  const [isLoadingCollections, setIsLoadingCollections] = useState(false);
+
+  // Content brief
+  const [brief, setBrief] = useState<ContentBrief>({});
+
+  // Fetch workspaces when project changes
+  useEffect(() => {
+    if (!projectId) {
+      setWorkspaces([]);
+      setSelectedWorkspaceId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchWorkspaces = async () => {
+      setIsLoadingWorkspaces(true);
+      try {
+        const result = await window.electronAPI.contentWorkspaceGetByProject(projectId);
+        if (!cancelled && result.success && result.data) {
+          setWorkspaces(result.data);
+          // Auto-select first workspace if available
+          if (result.data.length > 0 && !selectedWorkspaceId) {
+            setSelectedWorkspaceId(result.data[0].id);
+          }
+        }
+      } catch (err) {
+        console.error('Failed to fetch workspaces:', err);
+      } finally {
+        if (!cancelled) {
+          setIsLoadingWorkspaces(false);
+        }
+      }
+    };
+
+    fetchWorkspaces();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  // Fetch collections when workspace changes
+  useEffect(() => {
+    if (!selectedWorkspaceId) {
+      setCollections([]);
+      setSelectedCollectionId(null);
+      return;
+    }
+
+    let cancelled = false;
+
+    const fetchCollections = async () => {
+      setIsLoadingCollections(true);
+      try {
+        const result =
+          await window.electronAPI.contentCollectionGetByWorkspace(selectedWorkspaceId);
+        if (!cancelled && result.success && result.data) {
+          setCollections(result.data);
+        }
+      } catch (err) {
+        console.error('Failed to fetch collections:', err);
+      } finally {
+        if (!cancelled) {
+          setIsLoadingCollections(false);
+        }
+      }
+    };
+
+    fetchCollections();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedWorkspaceId]);
+
+  // Create workspace
+  const createWorkspace = useCallback(
+    async (name: string): Promise<ContentWorkspace | null> => {
+      if (!projectId) return null;
+      try {
+        const result = await window.electronAPI.contentWorkspaceCreate({
+          projectId,
+          name,
+        });
+        if (result.success && result.data) {
+          setWorkspaces((prev) => [...prev, result.data!]);
+          return result.data;
+        }
+      } catch (err) {
+        console.error('Failed to create workspace:', err);
+      }
+      return null;
+    },
+    [projectId]
+  );
+
+  // Create collection
+  const createCollection = useCallback(
+    async (name: string, description?: string): Promise<ContentCollection | null> => {
+      if (!selectedWorkspaceId) return null;
+      try {
+        const result = await window.electronAPI.contentCollectionCreate({
+          workspaceId: selectedWorkspaceId,
+          name,
+          description,
+        });
+        if (result.success && result.data) {
+          setCollections((prev) => [...prev, result.data!]);
+          return result.data;
+        }
+      } catch (err) {
+        console.error('Failed to create collection:', err);
+      }
+      return null;
+    },
+    [selectedWorkspaceId]
+  );
+
+  // Upload documents to collection
+  const uploadDocuments = useCallback(
+    async (
+      collectionId: string,
+      files: Array<{ name: string; content: string }>
+    ): Promise<boolean> => {
+      try {
+        const result = await window.electronAPI.contentKnowledgeUpload({
+          collectionId,
+          documents: files,
+        });
+        if (result.success) {
+          // Update collection document count
+          setCollections((prev) =>
+            prev.map((c) =>
+              c.id === collectionId
+                ? { ...c, documentCount: (c.documentCount || 0) + (result.data?.length || 0) }
+                : c
+            )
+          );
+          return true;
+        }
+      } catch (err) {
+        console.error('Failed to upload documents:', err);
+      }
+      return false;
+    },
+    []
+  );
+
+  // Get metadata object to attach to task
+  const getTaskMetadata = useCallback((): Record<string, unknown> => {
+    const metadata: Record<string, unknown> = {};
+
+    if (selectedWorkspaceId || selectedCollectionId || Object.keys(brief).length > 0) {
+      metadata.contentWorkflow = createContentWorkflowMetadata(
+        'backlog', // Start in backlog
+        selectedCollectionId || undefined,
+        Object.keys(brief).length > 0 ? brief : undefined
+      );
+    }
+
+    return metadata;
+  }, [selectedWorkspaceId, selectedCollectionId, brief]);
+
+  // Check if content mode is active
+  const isContentMode = selectedWorkspaceId !== null;
+
+  // Selected objects
+  const selectedWorkspace = workspaces.find((w) => w.id === selectedWorkspaceId) || null;
+  const selectedCollection = collections.find((c) => c.id === selectedCollectionId) || null;
+
+  // Reset all content data
+  const reset = useCallback(() => {
+    setSelectedCollectionId(null);
+    setBrief({});
+  }, []);
+
+  return {
+    // Workspaces
+    workspaces,
+    selectedWorkspaceId,
+    selectedWorkspace,
+    isLoadingWorkspaces,
+    setSelectedWorkspaceId,
+    createWorkspace,
+
+    // Collections
+    collections,
+    selectedCollectionId,
+    selectedCollection,
+    isLoadingCollections,
+    setSelectedCollectionId,
+    createCollection,
+    uploadDocuments,
+
+    // Brief
+    brief,
+    setBrief,
+
+    // Utilities
+    isContentMode,
+    getTaskMetadata,
+    reset,
+  };
+}

--- a/src/renderer/hooks/useContentWorkspace.ts
+++ b/src/renderer/hooks/useContentWorkspace.ts
@@ -1,0 +1,146 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { ContentWorkspace, ContentKanbanColumn } from '@/types/electron-api';
+
+export function useContentWorkspace(projectId: string | undefined) {
+  const [workspaces, setWorkspaces] = useState<ContentWorkspace[]>([]);
+  const [activeWorkspace, setActiveWorkspace] = useState<ContentWorkspace | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadWorkspaces = useCallback(async () => {
+    if (!projectId) {
+      setWorkspaces([]);
+      setActiveWorkspace(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await window.electronAPI.contentWorkspaceGetByProject(projectId);
+      if (result.success && result.data) {
+        setWorkspaces(result.data);
+        // Auto-select first workspace if none selected
+        if (result.data.length > 0 && !activeWorkspace) {
+          setActiveWorkspace(result.data[0]);
+        }
+      } else {
+        setError(result.error || 'Failed to load workspaces');
+      }
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [projectId, activeWorkspace]);
+
+  useEffect(() => {
+    loadWorkspaces();
+  }, [projectId]);
+
+  const createWorkspace = useCallback(
+    async (
+      name: string,
+      options?: {
+        kanbanColumns?: ContentKanbanColumn[];
+        defaultAgents?: string[];
+      }
+    ) => {
+      if (!projectId) return null;
+
+      try {
+        const result = await window.electronAPI.contentWorkspaceCreate({
+          projectId,
+          name,
+          kanbanColumns: options?.kanbanColumns,
+          defaultAgents: options?.defaultAgents,
+        });
+
+        if (result.success && result.data) {
+          setWorkspaces((prev) => [...prev, result.data!]);
+          setActiveWorkspace(result.data);
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to create workspace');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [projectId]
+  );
+
+  const updateWorkspace = useCallback(
+    async (
+      id: string,
+      updates: Partial<{
+        name: string;
+        kanbanColumns: ContentKanbanColumn[];
+        defaultAgents: string[];
+      }>
+    ) => {
+      try {
+        const result = await window.electronAPI.contentWorkspaceUpdate({
+          id,
+          ...updates,
+        });
+
+        if (result.success && result.data) {
+          setWorkspaces((prev) => prev.map((w) => (w.id === id ? result.data! : w)));
+          if (activeWorkspace?.id === id) {
+            setActiveWorkspace(result.data);
+          }
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to update workspace');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [activeWorkspace]
+  );
+
+  const deleteWorkspace = useCallback(
+    async (id: string) => {
+      try {
+        const result = await window.electronAPI.contentWorkspaceDelete(id);
+        if (result.success) {
+          setWorkspaces((prev) => prev.filter((w) => w.id !== id));
+          if (activeWorkspace?.id === id) {
+            setActiveWorkspace(null);
+          }
+          return true;
+        } else {
+          setError(result.error || 'Failed to delete workspace');
+          return false;
+        }
+      } catch (err) {
+        setError(String(err));
+        return false;
+      }
+    },
+    [activeWorkspace]
+  );
+
+  const selectWorkspace = useCallback((workspace: ContentWorkspace | null) => {
+    setActiveWorkspace(workspace);
+  }, []);
+
+  return {
+    workspaces,
+    activeWorkspace,
+    isLoading,
+    error,
+    createWorkspace,
+    updateWorkspace,
+    deleteWorkspace,
+    selectWorkspace,
+    refresh: loadWorkspaces,
+  };
+}

--- a/src/renderer/hooks/useKnowledgeDocs.ts
+++ b/src/renderer/hooks/useKnowledgeDocs.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState } from 'react';
+import type { KnowledgeDocument } from '@/types/electron-api';
+
+export function useKnowledgeDocs(collectionId: string | undefined) {
+  const [documents, setDocuments] = useState<KnowledgeDocument[]>([]);
+  const [selectedDocument, setSelectedDocument] = useState<KnowledgeDocument | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const loadDocuments = useCallback(async () => {
+    if (!collectionId) {
+      setDocuments([]);
+      setSelectedDocument(null);
+      return;
+    }
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await window.electronAPI.contentKnowledgeGetByCollection(collectionId);
+      if (result.success && result.data) {
+        setDocuments(result.data);
+      } else {
+        setError(result.error || 'Failed to load documents');
+      }
+    } catch (err) {
+      setError(String(err));
+    } finally {
+      setIsLoading(false);
+    }
+  }, [collectionId]);
+
+  useEffect(() => {
+    loadDocuments();
+  }, [collectionId]);
+
+  const createDocument = useCallback(
+    async (name: string, content: string, metadata?: Record<string, unknown>) => {
+      if (!collectionId) return null;
+
+      try {
+        const result = await window.electronAPI.contentKnowledgeCreate({
+          collectionId,
+          name,
+          content,
+          metadata,
+        });
+
+        if (result.success && result.data) {
+          setDocuments((prev) => [...prev, result.data!]);
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to create document');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [collectionId]
+  );
+
+  const uploadDocuments = useCallback(
+    async (
+      files: Array<{
+        name: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }>
+    ) => {
+      if (!collectionId) return null;
+
+      try {
+        const result = await window.electronAPI.contentKnowledgeUpload({
+          collectionId,
+          documents: files,
+        });
+
+        if (result.success && result.data) {
+          setDocuments((prev) => [...prev, ...result.data!]);
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to upload documents');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [collectionId]
+  );
+
+  const updateDocument = useCallback(
+    async (
+      id: string,
+      updates: Partial<{
+        name: string;
+        content: string;
+        metadata: Record<string, unknown>;
+      }>
+    ) => {
+      try {
+        const result = await window.electronAPI.contentKnowledgeUpdate({
+          id,
+          ...updates,
+        });
+
+        if (result.success && result.data) {
+          setDocuments((prev) => prev.map((d) => (d.id === id ? result.data! : d)));
+          if (selectedDocument?.id === id) {
+            setSelectedDocument(result.data);
+          }
+          return result.data;
+        } else {
+          setError(result.error || 'Failed to update document');
+          return null;
+        }
+      } catch (err) {
+        setError(String(err));
+        return null;
+      }
+    },
+    [selectedDocument]
+  );
+
+  const deleteDocument = useCallback(
+    async (id: string) => {
+      try {
+        const result = await window.electronAPI.contentKnowledgeDelete(id);
+        if (result.success) {
+          setDocuments((prev) => prev.filter((d) => d.id !== id));
+          if (selectedDocument?.id === id) {
+            setSelectedDocument(null);
+          }
+          return true;
+        } else {
+          setError(result.error || 'Failed to delete document');
+          return false;
+        }
+      } catch (err) {
+        setError(String(err));
+        return false;
+      }
+    },
+    [selectedDocument]
+  );
+
+  const selectDocument = useCallback((document: KnowledgeDocument | null) => {
+    setSelectedDocument(document);
+  }, []);
+
+  const getContextForAgent = useCallback(async () => {
+    if (!collectionId) return '';
+
+    try {
+      const result = await window.electronAPI.contentKnowledgeGetContextForAgent(collectionId);
+      if (result.success && result.data) {
+        return result.data;
+      }
+      return '';
+    } catch {
+      return '';
+    }
+  }, [collectionId]);
+
+  return {
+    documents,
+    selectedDocument,
+    isLoading,
+    error,
+    createDocument,
+    uploadDocuments,
+    updateDocument,
+    deleteDocument,
+    selectDocument,
+    getContextForAgent,
+    refresh: loadDocuments,
+  };
+}

--- a/src/renderer/lib/contentKanbanStore.ts
+++ b/src/renderer/lib/contentKanbanStore.ts
@@ -1,0 +1,109 @@
+/**
+ * Content Kanban Store
+ * Supports dynamic column statuses for content workspaces.
+ * Unlike the original kanbanStore which uses hardcoded statuses,
+ * this store allows any string-based status values.
+ */
+
+// Default content workflow columns
+export const DEFAULT_CONTENT_COLUMNS = [
+  { id: 'backlog', title: 'Backlog' },
+  { id: 'research', title: 'Research' },
+  { id: 'writing', title: 'Writing' },
+  { id: 'review', title: 'Review' },
+  { id: 'ready', title: 'Ready' },
+] as const;
+
+export type ContentColumnId = (typeof DEFAULT_CONTENT_COLUMNS)[number]['id'];
+
+export interface ContentColumn {
+  id: string;
+  title: string;
+}
+
+const STORAGE_KEY = 'emdash:content-kanban:statusByTask';
+
+type MapShape = Record<string, string>;
+
+let cache: MapShape | null = null;
+
+function read(): MapShape {
+  if (cache) return cache;
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (raw) {
+      const parsed = JSON.parse(raw);
+      if (parsed && typeof parsed === 'object') {
+        cache = parsed as MapShape;
+        return cache;
+      }
+    }
+  } catch {
+    // ignore parse errors
+  }
+  cache = {};
+  return cache;
+}
+
+function write(next: MapShape) {
+  cache = next;
+  try {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(next));
+  } catch {
+    // ignore storage errors
+  }
+}
+
+/**
+ * Get the content kanban status for a task.
+ * Returns the first column ID if not set.
+ */
+export function getContentStatus(taskId: string, defaultStatus = 'backlog'): string {
+  const map = read();
+  return map[taskId] || defaultStatus;
+}
+
+/**
+ * Set the content kanban status for a task.
+ */
+export function setContentStatus(taskId: string, status: string): void {
+  const map = { ...read(), [taskId]: status };
+  write(map);
+}
+
+/**
+ * Get all task statuses.
+ */
+export function getAllContentStatuses(): MapShape {
+  return { ...read() };
+}
+
+/**
+ * Clear all content kanban statuses.
+ */
+export function clearAllContentStatuses(): void {
+  write({});
+}
+
+/**
+ * Parse kanban columns from JSON string (stored in workspace).
+ */
+export function parseKanbanColumns(json: string | null | undefined): ContentColumn[] {
+  if (!json) return [...DEFAULT_CONTENT_COLUMNS];
+  try {
+    const parsed = JSON.parse(json);
+    if (Array.isArray(parsed) && parsed.every((c) => c.id && c.title)) {
+      return parsed;
+    }
+  } catch {
+    // ignore parse errors
+  }
+  return [...DEFAULT_CONTENT_COLUMNS];
+}
+
+/**
+ * Serialize kanban columns to JSON string for storage.
+ */
+export function serializeKanbanColumns(columns: ContentColumn[]): string {
+  return JSON.stringify(columns);
+}

--- a/src/renderer/lib/contentPromptEnhancer.ts
+++ b/src/renderer/lib/contentPromptEnhancer.ts
@@ -1,0 +1,159 @@
+/**
+ * Content Prompt Enhancer
+ *
+ * Utilities for enhancing prompts with content context (brand guidelines,
+ * knowledge documents, and content briefs) before injecting them into agents.
+ */
+
+import type { ContentContext } from '@/types/electron-api';
+
+export interface ContentBrief {
+  topic?: string;
+  audience?: string;
+  keywords?: string;
+  tone?: string;
+  notes?: string;
+}
+
+export interface ContentWorkflowMetadata {
+  stage: string;
+  collectionId?: string;
+  brief?: ContentBrief;
+}
+
+/**
+ * Check if task metadata has content workflow data.
+ */
+export function hasContentWorkflow(metadata: Record<string, unknown> | null | undefined): boolean {
+  if (!metadata?.contentWorkflow) return false;
+  const cw = metadata.contentWorkflow as ContentWorkflowMetadata;
+  return !!(cw.collectionId || cw.brief);
+}
+
+/**
+ * Extract content workflow metadata from task metadata.
+ */
+export function getContentWorkflowFromMetadata(
+  metadata: Record<string, unknown> | null | undefined
+): ContentWorkflowMetadata | null {
+  if (!metadata?.contentWorkflow) return null;
+  return metadata.contentWorkflow as ContentWorkflowMetadata;
+}
+
+/**
+ * Enhance a prompt with content context.
+ * Fetches brand guidelines and knowledge documents from the collection
+ * and prepends them to the original prompt.
+ *
+ * @param originalPrompt - The original user prompt
+ * @param collectionId - The collection ID to fetch context from
+ * @param brief - Optional content brief to include
+ * @param role - Optional role (e.g., "SEO Specialist", "Copywriter")
+ * @returns Enhanced prompt with content context prepended
+ */
+export async function enhancePromptWithContentContext(
+  originalPrompt: string,
+  collectionId: string | null | undefined,
+  brief?: ContentBrief,
+  role?: string
+): Promise<{ prompt: string; context: ContentContext | null }> {
+  if (!collectionId) {
+    return { prompt: originalPrompt, context: null };
+  }
+
+  try {
+    const result = await window.electronAPI.contentContextComposePrompt({
+      collectionId,
+      userPrompt: originalPrompt,
+      role,
+      includeBrief: !!brief,
+      brief,
+    });
+
+    if (result.success && result.data) {
+      return {
+        prompt: result.data.prompt,
+        context: result.data.context,
+      };
+    }
+  } catch (error) {
+    console.error('Failed to enhance prompt with content context:', error);
+  }
+
+  // Fallback to original prompt if enhancement fails
+  return { prompt: originalPrompt, context: null };
+}
+
+/**
+ * Enhance a prompt based on task metadata.
+ * Automatically extracts collection ID and brief from metadata.
+ *
+ * @param originalPrompt - The original user prompt
+ * @param metadata - Task metadata containing contentWorkflow
+ * @param role - Optional role for the agent
+ * @returns Enhanced prompt with content context
+ */
+export async function enhancePromptFromTaskMetadata(
+  originalPrompt: string,
+  metadata: Record<string, unknown> | null | undefined,
+  role?: string
+): Promise<{ prompt: string; context: ContentContext | null }> {
+  const workflow = getContentWorkflowFromMetadata(metadata);
+
+  if (!workflow || !workflow.collectionId) {
+    return { prompt: originalPrompt, context: null };
+  }
+
+  return enhancePromptWithContentContext(
+    originalPrompt,
+    workflow.collectionId,
+    workflow.brief,
+    role
+  );
+}
+
+/**
+ * Get just the content context without composing a prompt.
+ * Useful when you need the context for display or other purposes.
+ */
+export async function getContentContextForTask(
+  collectionId: string | null | undefined,
+  brief?: ContentBrief
+): Promise<ContentContext | null> {
+  if (!collectionId) {
+    return null;
+  }
+
+  try {
+    const result = await window.electronAPI.contentContextGetForTask({
+      collectionId,
+      includeBrief: !!brief,
+      brief,
+    });
+
+    if (result.success && result.data) {
+      return result.data;
+    }
+  } catch (error) {
+    console.error('Failed to get content context:', error);
+  }
+
+  return null;
+}
+
+/**
+ * Format content context info for display (e.g., in UI badges).
+ */
+export function formatContentContextSummary(context: ContentContext | null): string {
+  if (!context) return '';
+
+  const parts: string[] = [];
+  if (context.hasBrand) {
+    parts.push('Brand');
+  }
+  if (context.hasKnowledge) {
+    parts.push(`${context.documentCount} doc${context.documentCount !== 1 ? 's' : ''}`);
+  }
+
+  return parts.join(' + ') || '';
+}

--- a/src/renderer/lib/contentWorkflowStatus.ts
+++ b/src/renderer/lib/contentWorkflowStatus.ts
@@ -1,0 +1,132 @@
+/**
+ * Content Workflow Status Management
+ *
+ * Maps content Kanban columns to task metadata and provides
+ * utilities for workflow status transitions.
+ */
+
+import { DEFAULT_CONTENT_COLUMNS, type ContentColumn } from './contentKanbanStore';
+
+/**
+ * Content workflow stage metadata stored in task.metadata.contentWorkflow
+ */
+export interface ContentWorkflowMetadata {
+  /** Current content workflow stage */
+  stage: string;
+  /** Collection ID assigned to this task */
+  collectionId?: string;
+  /** Content brief data */
+  brief?: {
+    topic?: string;
+    audience?: string;
+    keywords?: string;
+    tone?: string;
+    notes?: string;
+  };
+  /** Timestamp when stage last changed */
+  stageChangedAt?: string;
+}
+
+/**
+ * Get the next stage in the workflow.
+ */
+export function getNextStage(
+  currentStage: string,
+  columns: ContentColumn[] = [...DEFAULT_CONTENT_COLUMNS]
+): string | null {
+  const currentIndex = columns.findIndex((c) => c.id === currentStage);
+  if (currentIndex === -1 || currentIndex >= columns.length - 1) {
+    return null;
+  }
+  return columns[currentIndex + 1].id;
+}
+
+/**
+ * Get the previous stage in the workflow.
+ */
+export function getPreviousStage(
+  currentStage: string,
+  columns: ContentColumn[] = [...DEFAULT_CONTENT_COLUMNS]
+): string | null {
+  const currentIndex = columns.findIndex((c) => c.id === currentStage);
+  if (currentIndex <= 0) {
+    return null;
+  }
+  return columns[currentIndex - 1].id;
+}
+
+/**
+ * Check if task is in a "working" stage (not backlog or final ready stage).
+ */
+export function isWorkingStage(
+  stage: string,
+  columns: ContentColumn[] = [...DEFAULT_CONTENT_COLUMNS]
+): boolean {
+  const index = columns.findIndex((c) => c.id === stage);
+  // Not first (backlog) and not last (ready)
+  return index > 0 && index < columns.length - 1;
+}
+
+/**
+ * Check if task is in the final "ready" stage.
+ */
+export function isReadyStage(
+  stage: string,
+  columns: ContentColumn[] = [...DEFAULT_CONTENT_COLUMNS]
+): boolean {
+  const lastColumn = columns[columns.length - 1];
+  return lastColumn?.id === stage;
+}
+
+/**
+ * Get display label for a stage.
+ */
+export function getStageLabel(
+  stage: string,
+  columns: ContentColumn[] = [...DEFAULT_CONTENT_COLUMNS]
+): string {
+  const column = columns.find((c) => c.id === stage);
+  return column?.title || stage;
+}
+
+/**
+ * Parse content workflow metadata from task metadata.
+ */
+export function parseContentWorkflow(
+  metadata: Record<string, unknown> | null | undefined
+): ContentWorkflowMetadata | null {
+  if (!metadata?.contentWorkflow) return null;
+  const cw = metadata.contentWorkflow as ContentWorkflowMetadata;
+  if (typeof cw.stage !== 'string') return null;
+  return cw;
+}
+
+/**
+ * Create content workflow metadata object.
+ */
+export function createContentWorkflowMetadata(
+  stage: string,
+  collectionId?: string,
+  brief?: ContentWorkflowMetadata['brief']
+): ContentWorkflowMetadata {
+  return {
+    stage,
+    collectionId,
+    brief,
+    stageChangedAt: new Date().toISOString(),
+  };
+}
+
+/**
+ * Update stage in content workflow metadata.
+ */
+export function updateContentWorkflowStage(
+  existing: ContentWorkflowMetadata | null,
+  newStage: string
+): ContentWorkflowMetadata {
+  return {
+    ...(existing || { stage: newStage }),
+    stage: newStage,
+    stageChangedAt: new Date().toISOString(),
+  };
+}

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1230,9 +1230,249 @@ declare global {
         data?: import('../../shared/mcp/types').McpProvidersResponse[];
         error?: string;
       }>;
+
+      // Content Workspace API
+      contentWorkspaceCreate: (args: {
+        projectId: string;
+        name: string;
+        kanbanColumns?: Array<{ id: string; name: string; status: string }>;
+        defaultAgents?: string[];
+        metadata?: Record<string, unknown>;
+      }) => Promise<{ success: boolean; data?: ContentWorkspace; error?: string }>;
+      contentWorkspaceGet: (
+        id: string
+      ) => Promise<{ success: boolean; data?: ContentWorkspace | null; error?: string }>;
+      contentWorkspaceGetByProject: (
+        projectId: string
+      ) => Promise<{ success: boolean; data?: ContentWorkspace[]; error?: string }>;
+      contentWorkspaceUpdate: (args: {
+        id: string;
+        name?: string;
+        kanbanColumns?: Array<{ id: string; name: string; status: string }>;
+        defaultAgents?: string[];
+        metadata?: Record<string, unknown>;
+      }) => Promise<{ success: boolean; data?: ContentWorkspace | null; error?: string }>;
+      contentWorkspaceDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
+
+      // Brand Guidelines
+      contentBrandCreate: (args: {
+        workspaceId: string;
+        name: string;
+        content: string;
+        isActive?: boolean;
+      }) => Promise<{ success: boolean; data?: BrandGuideline; error?: string }>;
+      contentBrandGet: (
+        id: string
+      ) => Promise<{ success: boolean; data?: BrandGuideline | null; error?: string }>;
+      contentBrandGetByWorkspace: (
+        workspaceId: string
+      ) => Promise<{ success: boolean; data?: BrandGuideline[]; error?: string }>;
+      contentBrandGetActive: (
+        workspaceId: string
+      ) => Promise<{ success: boolean; data?: BrandGuideline | null; error?: string }>;
+      contentBrandUpdate: (args: {
+        id: string;
+        name?: string;
+        content?: string;
+        isActive?: boolean;
+      }) => Promise<{ success: boolean; data?: BrandGuideline | null; error?: string }>;
+      contentBrandDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
+
+      // Collections
+      contentCollectionCreate: (args: {
+        workspaceId: string;
+        name: string;
+        description?: string;
+      }) => Promise<{ success: boolean; data?: ContentCollection; error?: string }>;
+      contentCollectionGet: (
+        id: string
+      ) => Promise<{ success: boolean; data?: ContentCollection | null; error?: string }>;
+      contentCollectionGetByWorkspace: (
+        workspaceId: string
+      ) => Promise<{ success: boolean; data?: ContentCollection[]; error?: string }>;
+      contentCollectionUpdate: (args: {
+        id: string;
+        name?: string;
+        description?: string;
+      }) => Promise<{ success: boolean; data?: ContentCollection | null; error?: string }>;
+      contentCollectionDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
+
+      // Knowledge Documents
+      contentKnowledgeCreate: (args: {
+        collectionId: string;
+        name: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }) => Promise<{ success: boolean; data?: KnowledgeDocument; error?: string }>;
+      contentKnowledgeUpload: (args: {
+        collectionId: string;
+        documents: Array<{ name: string; content: string; metadata?: Record<string, unknown> }>;
+      }) => Promise<{ success: boolean; data?: KnowledgeDocument[]; error?: string }>;
+      contentKnowledgeGet: (
+        id: string
+      ) => Promise<{ success: boolean; data?: KnowledgeDocument | null; error?: string }>;
+      contentKnowledgeGetByCollection: (
+        collectionId: string
+      ) => Promise<{ success: boolean; data?: KnowledgeDocument[]; error?: string }>;
+      contentKnowledgeUpdate: (args: {
+        id: string;
+        name?: string;
+        content?: string;
+        metadata?: Record<string, unknown>;
+      }) => Promise<{ success: boolean; data?: KnowledgeDocument | null; error?: string }>;
+      contentKnowledgeDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
+      contentKnowledgeGetContextForAgent: (
+        collectionId: string
+      ) => Promise<{ success: boolean; data?: string; error?: string }>;
+
+      // Content Outputs
+      contentOutputCreate: (args: {
+        taskId: string;
+        agentId: string;
+        content: string;
+        metadata?: Record<string, unknown>;
+      }) => Promise<{ success: boolean; data?: ContentOutput; error?: string }>;
+      contentOutputGet: (
+        id: string
+      ) => Promise<{ success: boolean; data?: ContentOutput | null; error?: string }>;
+      contentOutputGetByTask: (
+        taskId: string
+      ) => Promise<{ success: boolean; data?: ContentOutput[]; error?: string }>;
+      contentOutputGetByTaskAndAgent: (args: {
+        taskId: string;
+        agentId: string;
+      }) => Promise<{ success: boolean; data?: ContentOutput[]; error?: string }>;
+      contentOutputGetSelected: (
+        taskId: string
+      ) => Promise<{ success: boolean; data?: ContentOutput | null; error?: string }>;
+      contentOutputSelect: (
+        id: string
+      ) => Promise<{ success: boolean; data?: ContentOutput | null; error?: string }>;
+      contentOutputUpdate: (args: {
+        id: string;
+        content?: string;
+        metadata?: Record<string, unknown>;
+      }) => Promise<{ success: boolean; data?: ContentOutput | null; error?: string }>;
+      contentOutputDelete: (id: string) => Promise<{ success: boolean; error?: string }>;
+      contentOutputDeleteByTask: (taskId: string) => Promise<{ success: boolean; error?: string }>;
+
+      // Content Context
+      contentContextGetForTask: (args: {
+        collectionId: string | null;
+        includeBrief?: boolean;
+        brief?: {
+          topic?: string;
+          audience?: string;
+          keywords?: string;
+          tone?: string;
+          notes?: string;
+        };
+        template?: string;
+      }) => Promise<{ success: boolean; data?: ContentContext; error?: string }>;
+      contentContextGetForWorkspace: (
+        workspaceId: string
+      ) => Promise<{ success: boolean; data?: ContentContext; error?: string }>;
+      contentContextComposePrompt: (args: {
+        collectionId: string | null;
+        userPrompt?: string;
+        role?: string;
+        includeBrief?: boolean;
+        brief?: {
+          topic?: string;
+          audience?: string;
+          keywords?: string;
+          tone?: string;
+          notes?: string;
+        };
+      }) => Promise<{
+        success: boolean;
+        data?: { prompt: string; context: ContentContext };
+        error?: string;
+      }>;
+
+      // Content Export
+      contentExportClipboard: (args: {
+        outputId: string;
+        options?: ExportOptions;
+      }) => Promise<{ success: boolean; error?: string }>;
+      contentExportFile: (args: {
+        outputId: string;
+        options?: ExportOptions;
+      }) => Promise<{ success: boolean; filePath?: string; error?: string }>;
+      contentExportFolder: (args: {
+        taskId: string;
+        options?: ExportOptions;
+      }) => Promise<{ success: boolean; folderPath?: string; fileCount?: number; error?: string }>;
+      contentExportSelectedToFile: (args: {
+        taskId: string;
+        options?: ExportOptions;
+      }) => Promise<{ success: boolean; filePath?: string; error?: string }>;
     };
   }
 }
+
+// Content Workspace Types (used by both global and exported interface)
+export type ContentKanbanColumn = { id: string; name: string; status: string };
+export type ContentWorkspace = {
+  id: string;
+  projectId: string;
+  name: string;
+  kanbanColumns: ContentKanbanColumn[];
+  defaultAgents: string[];
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+export type BrandGuideline = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  content: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+export type ContentCollection = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  description?: string;
+  documentCount?: number;
+  createdAt: string;
+  updatedAt: string;
+};
+export type KnowledgeDocument = {
+  id: string;
+  collectionId: string;
+  name: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+export type ContentOutput = {
+  id: string;
+  taskId: string;
+  agentId: string;
+  content: string;
+  version: number;
+  selected: boolean;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type ContentContext = {
+  context: string;
+  characterCount: number;
+  hasBrand: boolean;
+  hasKnowledge: boolean;
+  documentCount: number;
+};
+
+export type ExportOptions = {
+  includeMetadata?: boolean;
+  filenameFormat?: 'simple' | 'detailed';
+};
 
 // Explicit type export for better TypeScript recognition
 export interface ElectronAPI {
@@ -1877,6 +2117,348 @@ export interface ElectronAPI {
     data?: import('../../shared/mcp/types').McpProvidersResponse[];
     error?: string;
   }>;
+
+  // ============================================================================
+  // Content Workspace API
+  // ============================================================================
+
+  // Content Workspace
+  contentWorkspaceCreate: (args: {
+    projectId: string;
+    name: string;
+    kanbanColumns?: ContentKanbanColumn[];
+    defaultAgents?: string[];
+    metadata?: Record<string, unknown>;
+  }) => Promise<{ success: boolean; data?: ContentWorkspace; error?: string }>;
+
+  contentWorkspaceGet: (id: string) => Promise<{
+    success: boolean;
+    data?: ContentWorkspace | null;
+    error?: string;
+  }>;
+
+  contentWorkspaceGetByProject: (projectId: string) => Promise<{
+    success: boolean;
+    data?: ContentWorkspace[];
+    error?: string;
+  }>;
+
+  contentWorkspaceUpdate: (args: {
+    id: string;
+    name?: string;
+    kanbanColumns?: ContentKanbanColumn[];
+    defaultAgents?: string[];
+    metadata?: Record<string, unknown>;
+  }) => Promise<{ success: boolean; data?: ContentWorkspace | null; error?: string }>;
+
+  contentWorkspaceDelete: (id: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+
+  // Brand Guidelines
+  contentBrandCreate: (args: {
+    workspaceId: string;
+    name: string;
+    content: string;
+    isActive?: boolean;
+  }) => Promise<{ success: boolean; data?: BrandGuideline; error?: string }>;
+
+  contentBrandGet: (id: string) => Promise<{
+    success: boolean;
+    data?: BrandGuideline | null;
+    error?: string;
+  }>;
+
+  contentBrandGetByWorkspace: (workspaceId: string) => Promise<{
+    success: boolean;
+    data?: BrandGuideline[];
+    error?: string;
+  }>;
+
+  contentBrandGetActive: (workspaceId: string) => Promise<{
+    success: boolean;
+    data?: BrandGuideline | null;
+    error?: string;
+  }>;
+
+  contentBrandUpdate: (args: {
+    id: string;
+    name?: string;
+    content?: string;
+    isActive?: boolean;
+  }) => Promise<{ success: boolean; data?: BrandGuideline | null; error?: string }>;
+
+  contentBrandDelete: (id: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+
+  // Collections
+  contentCollectionCreate: (args: {
+    workspaceId: string;
+    name: string;
+    description?: string;
+  }) => Promise<{ success: boolean; data?: ContentCollection; error?: string }>;
+
+  contentCollectionGet: (id: string) => Promise<{
+    success: boolean;
+    data?: ContentCollection | null;
+    error?: string;
+  }>;
+
+  contentCollectionGetByWorkspace: (workspaceId: string) => Promise<{
+    success: boolean;
+    data?: ContentCollection[];
+    error?: string;
+  }>;
+
+  contentCollectionUpdate: (args: {
+    id: string;
+    name?: string;
+    description?: string;
+  }) => Promise<{ success: boolean; data?: ContentCollection | null; error?: string }>;
+
+  contentCollectionDelete: (id: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+
+  // Knowledge Documents
+  contentKnowledgeCreate: (args: {
+    collectionId: string;
+    name: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+  }) => Promise<{ success: boolean; data?: KnowledgeDocument; error?: string }>;
+
+  contentKnowledgeUpload: (args: {
+    collectionId: string;
+    documents: Array<{
+      name: string;
+      content: string;
+      metadata?: Record<string, unknown>;
+    }>;
+  }) => Promise<{ success: boolean; data?: KnowledgeDocument[]; error?: string }>;
+
+  contentKnowledgeGet: (id: string) => Promise<{
+    success: boolean;
+    data?: KnowledgeDocument | null;
+    error?: string;
+  }>;
+
+  contentKnowledgeGetByCollection: (collectionId: string) => Promise<{
+    success: boolean;
+    data?: KnowledgeDocument[];
+    error?: string;
+  }>;
+
+  contentKnowledgeUpdate: (args: {
+    id: string;
+    name?: string;
+    content?: string;
+    metadata?: Record<string, unknown>;
+  }) => Promise<{ success: boolean; data?: KnowledgeDocument | null; error?: string }>;
+
+  contentKnowledgeDelete: (id: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+
+  contentKnowledgeGetContextForAgent: (collectionId: string) => Promise<{
+    success: boolean;
+    data?: string;
+    error?: string;
+  }>;
+
+  // Content Outputs
+  contentOutputCreate: (args: {
+    taskId: string;
+    agentId: string;
+    content: string;
+    metadata?: Record<string, unknown>;
+  }) => Promise<{ success: boolean; data?: ContentOutput; error?: string }>;
+
+  contentOutputGet: (id: string) => Promise<{
+    success: boolean;
+    data?: ContentOutput | null;
+    error?: string;
+  }>;
+
+  contentOutputGetByTask: (taskId: string) => Promise<{
+    success: boolean;
+    data?: ContentOutput[];
+    error?: string;
+  }>;
+
+  contentOutputGetByTaskAndAgent: (args: {
+    taskId: string;
+    agentId: string;
+  }) => Promise<{ success: boolean; data?: ContentOutput[]; error?: string }>;
+
+  contentOutputGetSelected: (taskId: string) => Promise<{
+    success: boolean;
+    data?: ContentOutput | null;
+    error?: string;
+  }>;
+
+  contentOutputSelect: (id: string) => Promise<{
+    success: boolean;
+    data?: ContentOutput | null;
+    error?: string;
+  }>;
+
+  contentOutputUpdate: (args: {
+    id: string;
+    content?: string;
+    metadata?: Record<string, unknown>;
+  }) => Promise<{ success: boolean; data?: ContentOutput | null; error?: string }>;
+
+  contentOutputDelete: (id: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+
+  contentOutputDeleteByTask: (taskId: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+
+  // Content Context
+  contentContextGetForTask: (args: {
+    collectionId: string | null;
+    includeBrief?: boolean;
+    brief?: {
+      topic?: string;
+      audience?: string;
+      keywords?: string;
+      tone?: string;
+      notes?: string;
+    };
+    template?: string;
+  }) => Promise<{
+    success: boolean;
+    data?: ContentContext;
+    error?: string;
+  }>;
+
+  contentContextGetForWorkspace: (workspaceId: string) => Promise<{
+    success: boolean;
+    data?: ContentContext;
+    error?: string;
+  }>;
+
+  contentContextComposePrompt: (args: {
+    collectionId: string | null;
+    userPrompt?: string;
+    role?: string;
+    includeBrief?: boolean;
+    brief?: {
+      topic?: string;
+      audience?: string;
+      keywords?: string;
+      tone?: string;
+      notes?: string;
+    };
+  }) => Promise<{
+    success: boolean;
+    data?: {
+      prompt: string;
+      context: ContentContext;
+    };
+    error?: string;
+  }>;
+
+  // Content Export
+  contentExportClipboard: (args: {
+    outputId: string;
+    options?: ExportOptions;
+  }) => Promise<{ success: boolean; error?: string }>;
+
+  contentExportFile: (args: {
+    outputId: string;
+    options?: ExportOptions;
+  }) => Promise<{ success: boolean; filePath?: string; error?: string }>;
+
+  contentExportFolder: (args: { taskId: string; options?: ExportOptions }) => Promise<{
+    success: boolean;
+    folderPath?: string;
+    fileCount?: number;
+    error?: string;
+  }>;
+
+  contentExportSelectedToFile: (args: {
+    taskId: string;
+    options?: ExportOptions;
+  }) => Promise<{ success: boolean; filePath?: string; error?: string }>;
 }
+
+// Content Workspace Types
+export type ContentKanbanColumn = {
+  id: string;
+  name: string;
+  status: string;
+};
+
+export type ContentWorkspace = {
+  id: string;
+  projectId: string;
+  name: string;
+  kanbanColumns: ContentKanbanColumn[];
+  defaultAgents: string[];
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type BrandGuideline = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  content: string;
+  isActive: boolean;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ContentCollection = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  description?: string;
+  documentCount?: number;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type KnowledgeDocument = {
+  id: string;
+  collectionId: string;
+  name: string;
+  content: string;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type ContentOutput = {
+  id: string;
+  taskId: string;
+  agentId: string;
+  content: string;
+  version: number;
+  selected: boolean;
+  metadata?: Record<string, unknown>;
+  createdAt: string;
+};
+
+export type ContentContext = {
+  context: string;
+  characterCount: number;
+  hasBrand: boolean;
+  hasKnowledge: boolean;
+  documentCount: number;
+};
+
 import type { TerminalSnapshotPayload } from '#types/terminalSnapshot';
 import type { OpenInAppId } from '#shared/openInApps';

--- a/src/shared/content/promptTemplates.ts
+++ b/src/shared/content/promptTemplates.ts
@@ -1,0 +1,204 @@
+/**
+ * Content Prompt Templates
+ *
+ * Role-specific prompt templates for content creation agents.
+ * Each template wraps the content context (brand guidelines, knowledge documents)
+ * with role-appropriate instructions.
+ */
+
+export interface ContentPromptTemplate {
+  id: string;
+  name: string;
+  description: string;
+  role: string;
+  systemPrompt: string;
+  /** Placeholder where content context will be inserted */
+  contextPlaceholder: string;
+}
+
+/**
+ * Available content creation roles.
+ */
+export const CONTENT_ROLES = [
+  'researcher',
+  'seo-specialist',
+  'copywriter',
+  'brand-voice',
+  'editor',
+] as const;
+
+export type ContentRole = (typeof CONTENT_ROLES)[number];
+
+/**
+ * Prompt templates for each content creation role.
+ */
+export const PROMPT_TEMPLATES: Record<ContentRole, ContentPromptTemplate> = {
+  researcher: {
+    id: 'researcher',
+    name: 'Research Agent',
+    description: 'Gathers and synthesizes information from knowledge documents',
+    role: 'Research Specialist',
+    systemPrompt: `You are a Research Specialist helping with content creation.
+
+Your role is to:
+- Analyze the provided knowledge documents thoroughly
+- Extract relevant facts, statistics, and insights
+- Identify key themes and talking points
+- Organize information in a clear, structured format
+- Cite sources from the knowledge documents when referencing specific information
+- Highlight any gaps in the available information
+
+Follow the brand guidelines for tone and style in your research summaries.
+
+{{content_context}}
+
+---
+
+Based on the knowledge documents and brand guidelines above, provide your research findings.`,
+    contextPlaceholder: '{{content_context}}',
+  },
+
+  'seo-specialist': {
+    id: 'seo-specialist',
+    name: 'SEO Specialist',
+    description: 'Optimizes content for search engines while maintaining quality',
+    role: 'SEO Specialist',
+    systemPrompt: `You are an SEO Specialist helping with content creation.
+
+Your role is to:
+- Analyze target keywords and their search intent
+- Suggest optimal keyword placement and density
+- Recommend heading structure (H1, H2, H3) for SEO
+- Identify opportunities for internal and external links
+- Optimize meta descriptions and title tags
+- Ensure content is scannable and well-structured
+- Balance SEO best practices with readability and brand voice
+
+Follow the brand guidelines to maintain consistent voice while optimizing for search.
+
+{{content_context}}
+
+---
+
+Provide SEO-optimized recommendations for the content.`,
+    contextPlaceholder: '{{content_context}}',
+  },
+
+  copywriter: {
+    id: 'copywriter',
+    name: 'Copywriter',
+    description: 'Creates compelling, conversion-focused content',
+    role: 'Professional Copywriter',
+    systemPrompt: `You are a Professional Copywriter helping with content creation.
+
+Your role is to:
+- Write compelling, engaging copy that resonates with the target audience
+- Use persuasive techniques appropriate for the content type
+- Create attention-grabbing headlines and hooks
+- Structure content for maximum impact and readability
+- Include clear calls-to-action where appropriate
+- Balance creativity with brand consistency
+- Draw on knowledge documents to ensure accuracy
+
+Strictly adhere to the brand guidelines for voice, tone, and style.
+
+{{content_context}}
+
+---
+
+Create compelling copy based on the brief and available knowledge.`,
+    contextPlaceholder: '{{content_context}}',
+  },
+
+  'brand-voice': {
+    id: 'brand-voice',
+    name: 'Brand Voice Expert',
+    description: 'Ensures content aligns with brand identity and voice',
+    role: 'Brand Voice Expert',
+    systemPrompt: `You are a Brand Voice Expert helping with content creation.
+
+Your role is to:
+- Ensure all content strictly adheres to brand guidelines
+- Review and refine copy to match the brand's unique voice
+- Maintain consistency in tone, style, and messaging
+- Suggest alternatives that better align with brand identity
+- Flag any content that may conflict with brand values
+- Help establish and reinforce brand personality
+- Balance brand consistency with audience appropriateness
+
+The brand guidelines are your primary reference. Every piece of content must reflect the brand's identity.
+
+{{content_context}}
+
+---
+
+Review and refine the content to perfectly align with the brand voice.`,
+    contextPlaceholder: '{{content_context}}',
+  },
+
+  editor: {
+    id: 'editor',
+    name: 'Editor',
+    description: 'Reviews and polishes content for clarity and quality',
+    role: 'Professional Editor',
+    systemPrompt: `You are a Professional Editor helping with content creation.
+
+Your role is to:
+- Review content for grammar, spelling, and punctuation
+- Improve clarity and readability
+- Ensure logical flow and structure
+- Check facts against the knowledge documents
+- Verify brand voice consistency
+- Suggest improvements without changing the core message
+- Polish the final draft for publication
+- Flag any inconsistencies or errors
+
+Apply editing standards while respecting the brand guidelines and original intent.
+
+{{content_context}}
+
+---
+
+Edit and polish the content for publication-ready quality.`,
+    contextPlaceholder: '{{content_context}}',
+  },
+};
+
+/**
+ * Get a prompt template by role ID.
+ */
+export function getPromptTemplate(role: ContentRole): ContentPromptTemplate {
+  return PROMPT_TEMPLATES[role];
+}
+
+/**
+ * Get all available prompt templates.
+ */
+export function getAllPromptTemplates(): ContentPromptTemplate[] {
+  return Object.values(PROMPT_TEMPLATES);
+}
+
+/**
+ * Apply content context to a template.
+ * Replaces the placeholder with the actual context.
+ */
+export function applyContextToTemplate(
+  template: ContentPromptTemplate,
+  contentContext: string
+): string {
+  return template.systemPrompt.replace(template.contextPlaceholder, contentContext);
+}
+
+/**
+ * Get role display name.
+ */
+export function getRoleDisplayName(role: ContentRole): string {
+  return PROMPT_TEMPLATES[role]?.name || role;
+}
+
+/**
+ * Check if a string is a valid content role.
+ */
+export function isContentRole(value: string): value is ContentRole {
+  return CONTENT_ROLES.includes(value as ContentRole);
+}


### PR DESCRIPTION
## Summary

- Implements complete content creation workflow with multi-agent orchestration support
- Adds database schema for content workspaces, brand guidelines, knowledge collections, and outputs
- Creates content-specific Kanban board with customizable workflow stages
- Enables automatic context injection (brand + knowledge) into agent prompts
- Provides multi-agent output comparison, editing, and version management
- Supports export to clipboard, file, and folder with full archive history

## Features by Epic

### Epic 1: Foundation
- Database migrations for 5 new tables + 1 column extension
- Core services: Brand, Collection, Knowledge, ContentOutput, ContentWorkspace
- Full IPC handler coverage for all CRUD operations

### Epic 2: Kanban & Workflow  
- ContentKanbanBoard with drag-and-drop (Backlog → Research → Writing → Review → Ready)
- Content brief system with topic, audience, keywords, tone fields
- Collection selector for task creation

### Epic 3: Agent Context Injection
- ContentContextService composes brand guidelines + knowledge documents
- Role-specific prompt templates (researcher, SEO specialist, copywriter, brand-voice expert, editor)
- Content-aware prompt injection via useContentAwarePromptInjection hook

### Epic 4: Multi-Agent Output Management
- OutputComparisonPanel with Monaco DiffEditor for side-by-side comparison
- ContentOutputEditor with version tracking and save/discard
- Version selection and history viewing

### Epic 5: Export & Archive
- ContentExportService for clipboard, file, and folder export
- ContentArchivePanel with date/agent grouping and expand/collapse
- Version restoration functionality

## Test plan

- [ ] Create a content workspace and verify brand guidelines can be saved
- [ ] Create collections and upload knowledge documents
- [ ] Create content tasks with briefs and verify Kanban placement
- [ ] Run agents and verify context injection includes brand + knowledge
- [ ] Compare multiple agent outputs side-by-side
- [ ] Export outputs to file and folder
- [ ] Restore previous versions from archive

🤖 Generated with [Claude Code](https://claude.com/claude-code)