### PR TITLE
docs: capitalize Tmux in tmux-sessions page title

### DIFF
--- a/docs/content/docs/tmux-sessions.mdx
+++ b/docs/content/docs/tmux-sessions.mdx
@@ -1,5 +1,5 @@
 ---
-title: tmux Sessions
+title: Tmux Sessions
 description: Persistent agent sessions with tmux
 ---
 


### PR DESCRIPTION
## Summary

- Capitalize the title of the tmux sessions documentation page from "tmux Sessions" to "Tmux Sessions" for consistent title casing across docs