### PR TITLE
fix(pty): ensure runtime args precede positional prompt in CLI arg order

### DIFF
--- a/docs/content/docs/mcp.mdx
+++ b/docs/content/docs/mcp.mdx
@@ -42,17 +42,17 @@ Click an installed server card to edit its config — change credentials, update
 
 When you add or edit a server, Emdash translates the config into each agent's native format and writes it to the correct location:
 
-| Agent          | Config file                            |
-| -------------- | -------------------------------------- |
-| Claude Code    | `~/.claude.json`                       |
-| Cursor         | `~/.cursor/mcp.json`                   |
-| Codex          | `~/.codex/config.toml`                 |
-| Amp            | `~/.config/amp/settings.json`          |
-| Gemini         | `~/.gemini/settings.json`              |
-| Qwen           | `~/.qwen/settings.json`               |
-| OpenCode       | `~/.config/opencode/opencode.json`     |
-| GitHub Copilot | `~/.copilot/mcp-config.json`           |
-| Droid          | `~/.droid/settings.json`               |
+| Agent          | Config file                        |
+| -------------- | ---------------------------------- |
+| Claude Code    | `~/.claude.json`                   |
+| Cursor         | `~/.cursor/mcp.json`               |
+| Codex          | `~/.codex/config.toml`             |
+| Amp            | `~/.config/amp/settings.json`      |
+| Gemini         | `~/.gemini/settings.json`          |
+| Qwen           | `~/.qwen/settings.json`            |
+| OpenCode       | `~/.config/opencode/opencode.json` |
+| GitHub Copilot | `~/.copilot/mcp-config.json`       |
+| Droid          | `~/.droid/settings.json`           |
 
 This means MCP servers configured through Emdash also work when you run these agents outside of Emdash.
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -557,6 +557,7 @@ type ProviderCliArgsOptions = {
   resumeFlag?: string;
   defaultArgs?: string[];
   extraArgs?: string[];
+  runtimeArgs?: string[];
   autoApprove?: boolean;
   autoApproveFlag?: string;
   initialPrompt?: string;
@@ -634,6 +635,14 @@ export function buildProviderCliArgs(options: ProviderCliArgsOptions): string[] 
     args.push(...parseShellArgs(options.autoApproveFlag));
   }
 
+  if (options.extraArgs?.length) {
+    args.push(...options.extraArgs);
+  }
+
+  if (options.runtimeArgs?.length) {
+    args.push(...options.runtimeArgs);
+  }
+
   if (
     options.initialPromptFlag !== undefined &&
     !options.useKeystrokeInjection &&
@@ -643,10 +652,6 @@ export function buildProviderCliArgs(options: ProviderCliArgsOptions): string[] 
       args.push(...parseShellArgs(options.initialPromptFlag));
     }
     args.push(options.initialPrompt.trim());
-  }
-
-  if (options.extraArgs?.length) {
-    args.push(...options.extraArgs);
   }
 
   return args;
@@ -1019,6 +1024,7 @@ export function startDirectPty(options: {
         resumeFlag: resolvedConfig.resumeFlag,
         defaultArgs: resolvedConfig.defaultArgs,
         extraArgs: resolvedConfig.extraArgs,
+        runtimeArgs: getProviderRuntimeCliArgs({ providerId }),
         autoApprove,
         autoApproveFlag: resolvedConfig.autoApproveFlag,
         initialPrompt,
@@ -1026,7 +1032,6 @@ export function startDirectPty(options: {
         useKeystrokeInjection: provider.useKeystrokeInjection,
       })
     );
-    cliArgs.push(...getProviderRuntimeCliArgs({ providerId }));
   }
 
   // Build minimal environment - just what the CLI needs
@@ -1265,6 +1270,7 @@ export async function startPty(options: {
             resumeFlag: resolvedConfig?.resumeFlag,
             defaultArgs: resolvedConfig?.defaultArgs,
             extraArgs: resolvedConfig?.extraArgs,
+            runtimeArgs: getProviderRuntimeCliArgs({ providerId: provider.id }),
             autoApprove,
             autoApproveFlag: resolvedConfig?.autoApproveFlag,
             initialPrompt,
@@ -1272,7 +1278,6 @@ export async function startPty(options: {
             useKeystrokeInjection: provider.useKeystrokeInjection,
           })
         );
-        cliArgs.push(...getProviderRuntimeCliArgs({ providerId: provider.id }));
 
         if (resolvedConfig?.env) {
           for (const [k, v] of Object.entries(resolvedConfig.env)) {

--- a/src/renderer/terminal/stripAnsi.ts
+++ b/src/renderer/terminal/stripAnsi.ts
@@ -1,3 +1,15 @@
 export function stripAnsi(data: string): string {
-  return data.replace(/\x1b\[[0-9;]*[A-Za-z]/g, '').replace(/\x1b\][^\x07]*\x07/g, '');
+  return (
+    data
+      // CSI sequences: \x1b[ ... <letter>
+      .replace(/\x1b\[[0-9;]*[A-Za-z]/g, '')
+      // OSC sequences terminated by BEL (\x07)
+      .replace(/\x1b\][^\x07\x1b]*\x07/g, '')
+      // OSC sequences terminated by ST (\x1b\\)
+      .replace(/\x1b\][^\x07\x1b]*\x1b\\/g, '')
+      // DCS sequences (\x1bP ... ST)
+      .replace(/\x1bP[^\x1b]*\x1b\\/g, '')
+      // Remaining lone ESC + single char (SS2, SS3, etc.)
+      .replace(/\x1b[^[\]P]/g, '')
+  );
 }

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -108,6 +108,8 @@ describe('ptyManager provider command resolution', () => {
       defaultArgs: ['--model', 'gpt-5'],
       autoApprove: true,
       autoApproveFlag: '--dangerously-bypass-approvals-and-sandbox',
+      extraArgs: ['--extra-flag'],
+      runtimeArgs: ['-c', 'notify=test'],
       initialPrompt: 'hello world',
       initialPromptFlag: '',
       useKeystrokeInjection: false,
@@ -119,7 +121,30 @@ describe('ptyManager provider command resolution', () => {
       '--model',
       'gpt-5',
       '--dangerously-bypass-approvals-and-sandbox',
+      '--extra-flag',
+      '-c',
+      'notify=test',
       'hello world',
+    ]);
+  });
+
+  it('places positional prompt after --full-auto and runtime args for Codex', async () => {
+    const { buildProviderCliArgs } = await import('../../main/services/ptyManager');
+
+    const args = buildProviderCliArgs({
+      autoApprove: true,
+      autoApproveFlag: '--full-auto',
+      runtimeArgs: ['-c', 'notify=["sh","-lc","curl ...","sh"]'],
+      initialPrompt: 'fix the login bug',
+      initialPromptFlag: '',
+      useKeystrokeInjection: false,
+    });
+
+    expect(args).toEqual([
+      '--full-auto',
+      '-c',
+      'notify=["sh","-lc","curl ...","sh"]',
+      'fix the login bug',
     ]);
   });
 

--- a/src/test/renderer/terminalInputBuffer.test.ts
+++ b/src/test/renderer/terminalInputBuffer.test.ts
@@ -111,6 +111,31 @@ describe('TerminalInputBuffer', () => {
     expect(onCapture).not.toHaveBeenCalled();
   });
 
+  it('strips OSC color query responses terminated with ST', () => {
+    const onCapture = vi.fn();
+    const buffer = new TerminalInputBuffer(onCapture);
+
+    // Simulate OSC 10/11 color responses (ST-terminated) that Codex's TUI triggers
+    buffer.feed('\x1b]10;rgb:1f1f/2929/3333\x1b\\');
+    buffer.feed('\x1b]11;rgb:0000/0000/0000\x1b\\');
+    buffer.feed('Fix the broken login flow\r');
+    buffer.confirmSubmit();
+
+    expect(onCapture).toHaveBeenCalledWith('Fix the broken login flow');
+  });
+
+  it('does not capture OSC color data as a task name', () => {
+    const onCapture = vi.fn();
+    const buffer = new TerminalInputBuffer(onCapture);
+
+    // Feed only OSC responses (no real user input) then Enter
+    buffer.feed('\x1b]10;rgb:1f1f/2929/3333\x1b\\\r');
+    buffer.confirmSubmit();
+
+    // Should not capture — the stripped content is empty
+    expect(onCapture).not.toHaveBeenCalled();
+  });
+
   it('ignores feed after completion', () => {
     const onCapture = vi.fn();
     const buffer = new TerminalInputBuffer(onCapture);


### PR DESCRIPTION
## Summary

- Fix CLI argument ordering in `buildProviderCliArgs` so that `extraArgs` and `runtimeArgs` (e.g. Codex `-c notify=...`) are placed **before** the positional initial prompt, preventing agents like Codex from misinterpreting flags as part of the prompt text
- Enhance `stripAnsi` to handle additional ANSI escape sequences: ST-terminated OSC (`\x1b\\`), DCS sequences, and lone ESC codes (SS2/SS3) — fixes issues where terminal color query responses from agent TUIs leaked into captured input
- Add tests covering the new arg ordering and ANSI stripping behavior
- Minor whitespace cleanup in MCP docs table

## Test plan

- [x] New test: positional prompt placed after `--full-auto` and runtime args for Codex
- [x] New test: `extraArgs` and `runtimeArgs` included before prompt in arg output
- [x] New test: OSC color query responses (ST-terminated) stripped from terminal input buffer
- [x] New test: empty input after stripping OSC data does not trigger capture
- [x] Existing tests continue to pass

<!-- emdash-issue-footer:start -->
Fixes GEN-508
<!-- emdash-issue-footer:end -->