### PR TITLE
fix(sidebar): clear task spinner when PTY has no activity for 15s

### DIFF
--- a/src/renderer/lib/activityClassifier.ts
+++ b/src/renderer/lib/activityClassifier.ts
@@ -81,6 +81,7 @@ export function classifyActivity(
     if (/Ready|Awaiting input|Press Enter/i.test(text)) return 'idle';
     if (/\b\/(status|approvals|model)\b/i.test(text)) return 'idle';
     if (/send\s+\S*\s*newline|transcript|quit/i.test(text)) return 'idle';
+    if (/What would you like|Type your message|Enter your message/i.test(text)) return 'idle';
   }
 
   if (p === 'copilot') {

--- a/src/renderer/lib/activityConstants.ts
+++ b/src/renderer/lib/activityConstants.ts
@@ -3,6 +3,7 @@ export const USER_WINDOW_MS = 30_000;
 export const BUSY_HOLD_MS = 2_000;
 // How long we wait on neutral output before clearing busy if no further busy arrives
 export const CLEAR_BUSY_MS = 6_000;
+export const INACTIVITY_CLEAR_MS = 15_000;
 export const INJECT_ON_DATA_DELAY_MS = 150;
 export const INJECT_ON_STARTED_DELAY_MS = 250;
 export const INJECT_FALLBACK_MS = 2_000;

--- a/src/renderer/lib/activityStore.ts
+++ b/src/renderer/lib/activityStore.ts
@@ -1,5 +1,5 @@
 import { classifyActivity, sampleActivityChunk } from './activityClassifier';
-import { CLEAR_BUSY_MS, BUSY_HOLD_MS } from './activityConstants';
+import { CLEAR_BUSY_MS, BUSY_HOLD_MS, INACTIVITY_CLEAR_MS } from './activityConstants';
 import { type PtyIdKind, parsePtyId, makePtyId } from '@shared/ptyId';
 import { PROVIDER_IDS } from '@shared/providers/registry';
 import type { AgentEvent } from '@shared/agentEvents';
@@ -15,6 +15,7 @@ class ActivityStore {
   private listeners = new Map<string, Set<Listener>>();
   private states = new Map<string, boolean>();
   private timers = new Map<string, ReturnType<typeof setTimeout>>();
+  private inactivityTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private busySince = new Map<string, number>();
   private subscribed = false;
   private subscribedIds = new Set<string>();
@@ -53,9 +54,18 @@ class ActivityStore {
     } else if (signal === 'idle') {
       this.setBusy(wsId, false, true);
     } else if (this.states.get(wsId)) {
-      // neutral: keep current but set soft clear timer
       this.armTimer(wsId);
     }
+    if (this.states.get(wsId)) {
+      this.armInactivityTimer(wsId);
+    }
+  }
+
+  private armInactivityTimer(wsId: string) {
+    const prev = this.inactivityTimers.get(wsId);
+    if (prev) clearTimeout(prev);
+    const t = setTimeout(() => this.setBusy(wsId, false, true), INACTIVITY_CLEAR_MS);
+    this.inactivityTimers.set(wsId, t);
   }
 
   private ensureSubscribed() {
@@ -104,11 +114,13 @@ class ActivityStore {
 
   private setBusy(wsId: string, busy: boolean, _fromEvent = false) {
     const current = this.states.get(wsId) || false;
-    // If setting busy: clear timers and record start
     if (busy) {
       const prev = this.timers.get(wsId);
       if (prev) clearTimeout(prev);
       this.timers.delete(wsId);
+      const prevInact = this.inactivityTimers.get(wsId);
+      if (prevInact) clearTimeout(prevInact);
+      this.inactivityTimers.delete(wsId);
       this.busySince.set(wsId, Date.now());
       if (!current) {
         this.states.set(wsId, true);
@@ -126,6 +138,9 @@ class ActivityStore {
       const prev = this.timers.get(wsId);
       if (prev) clearTimeout(prev);
       this.timers.delete(wsId);
+      const prevInact = this.inactivityTimers.get(wsId);
+      if (prevInact) clearTimeout(prevInact);
+      this.inactivityTimers.delete(wsId);
       this.busySince.delete(wsId);
       if (this.states.get(wsId) !== false) {
         this.states.set(wsId, false);
@@ -254,6 +269,9 @@ class ActivityStore {
           const pendingTimer = this.timers.get(wsId);
           if (pendingTimer) clearTimeout(pendingTimer);
           this.timers.delete(wsId);
+          const pendingInact = this.inactivityTimers.get(wsId);
+          if (pendingInact) clearTimeout(pendingInact);
+          this.inactivityTimers.delete(wsId);
           this.busySince.delete(wsId);
           this.states.delete(wsId);
         }


### PR DESCRIPTION
### summary

- Fixes the sidebar task spinner staying active after Codex (or other agents) stops. Adds an inactivity timeout so that if no PTY data is received for 15 seconds while busy, the busy state is cleared. Also adds Codex idle patterns to better detect when the agent is done.

### Fixes

Fixes #1401

### Snapshot

- N/A – UI behavior change: spinner now stops when the agent is idle.

### Type of change
[x] Bug fix (non-breaking change which fixes an issue)

### Mandatory Tasks
[ ] I have self-reviewed the code
[ ] A decent size PR without self-review might be rejected

### Checklist
[ ] I have read the contributing guide
[ ] My code follows the style guidelines of this project (pnpm run format)
[ ] I have commented my code, particularly in hard-to-understand areas
[ ] I have checked if my PR needs changes to the documentation
[ ] I have checked if my changes generate no new warnings (pnpm run lint)
[ ] I have added tests that prove my fix is effective or that my feature works
[ ] I haven't checked if new and existing unit tests pass locally with my changes
