### PR TITLE
fix: show comments also without linked task

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -1082,16 +1082,12 @@ const ChatInterface: React.FC<Props> = ({
                   <Plus className="h-3.5 w-3.5" />
                 </button>
                 <div className="ml-auto flex flex-shrink-0 items-center gap-2">
-                  {(task.metadata?.linearIssue ||
-                    task.metadata?.githubIssue ||
-                    task.metadata?.jiraIssue) && (
-                    <TaskContextBadges
-                      taskId={task.id}
-                      linearIssue={task.metadata?.linearIssue || null}
-                      githubIssue={task.metadata?.githubIssue || null}
-                      jiraIssue={task.metadata?.jiraIssue || null}
-                    />
-                  )}
+                  <TaskContextBadges
+                    taskId={task.id}
+                    linearIssue={task.metadata?.linearIssue || null}
+                    githubIssue={task.metadata?.githubIssue || null}
+                    jiraIssue={task.metadata?.jiraIssue || null}
+                  />
                   {autoApproveEnabled && (
                     <span
                       className="inline-flex h-7 select-none items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 text-xs font-medium text-foreground"

--- a/src/renderer/components/TaskContextBadges.tsx
+++ b/src/renderer/components/TaskContextBadges.tsx
@@ -30,10 +30,16 @@ export const TaskContextBadges: React.FC<Props> = ({
   const resolvedTaskId = taskId ?? scopedTaskId;
   const { unsentCount } = useTaskComments(resolvedTaskId);
   const [selectedCount, setSelectedCount] = React.useState(0);
+  const hasIssueBadge = Boolean(linearIssue || githubIssue || jiraIssue);
+  const hasCommentsBadge = Boolean(resolvedTaskId && unsentCount > 0);
 
   React.useEffect(() => {
     setSelectedCount(0);
   }, [resolvedTaskId]);
+
+  if (!hasIssueBadge && !hasCommentsBadge) {
+    return null;
+  }
 
   const handleIssueClick = (url?: string) => {
     if (!url) return;
@@ -191,7 +197,7 @@ export const TaskContextBadges: React.FC<Props> = ({
         </TooltipProvider>
       )}
 
-      {resolvedTaskId && unsentCount > 0 && (
+      {hasCommentsBadge && (
         <CommentsPopover
           tooltipContent="Selected comments are appended to your next agent message."
           tooltipDelay={300}


### PR DESCRIPTION
## Summary

I was wondering what the comments feature does and couldn't figure it out until I noticed that it only works when you also link a task. To me it seems as if these were two distinct features and comments should be usable without linked tasks.
I only verified locally that the fix works for comments however I haven't set up any task/issue linking so I didn't verify if I broke something there.
Would be cool if you could let me know if these features are supposed to work only together or if my assumption was correct :)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes