### PR TITLE
fix(ssh): add scroll overflow to saved connections list

### DIFF
--- a/src/renderer/components/ssh/AddRemoteProjectModal.tsx
+++ b/src/renderer/components/ssh/AddRemoteProjectModal.tsx
@@ -828,7 +828,7 @@ export const AddRemoteProjectModal: React.FC<AddRemoteProjectModalProps> = ({
             ) : savedConnections.length > 0 ? (
               <div className="space-y-2">
                 <Label>Saved Connections</Label>
-                <div className="space-y-2">
+                <div className="max-h-[232px] space-y-2 overflow-y-auto">
                   {savedConnections.map((conn) => (
                     <button
                       key={conn.id}


### PR DESCRIPTION
## Summary
- Added `max-h-[232px]` and `overflow-y-auto` to the saved connections container in `AddRemoteProjectModal`
- Prevents the modal from growing unbounded when many SSH connections are saved, keeping the list scrollable within a fixed height