### PR TITLE
fix: prevent Create PR button overflow in narrow sidebar

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -620,7 +620,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
                   </span>
                 )}
               </div>
-              <div className="flex items-center gap-2">
+              <div className="flex min-w-0 flex-wrap items-center gap-2">
                 {onOpenChanges && (
                   <Button
                     variant="outline"
@@ -695,7 +695,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
               <span className="text-muted-foreground">&middot;</span>
               <span className="font-medium text-red-600 dark:text-red-400">&mdash;</span>
             </div>
-            <div className="flex shrink-0 items-center gap-2">
+            <div className="flex min-w-0 flex-wrap items-center gap-2">
               {onOpenChanges && (
                 <Button
                   variant="outline"


### PR DESCRIPTION
fix : #1417

### summary

- Ensure the right sidebar "Create PR" button and header actions wrap instead of overflowing when the sidebar is narrow.

### Fixes

- Fixes: Create PR button clipping in narrow right sidebar.

### Snapshot

- Before: "Create PR" button clipped when sidebar width is reduced.
- After: Header buttons wrap to a new line and remain fully visible.

### Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

### Mandatory Tasks
- [x] I have self-reviewed the code

Checklist
[x] I have read the contributing guide
[x] My code follows the style guidelines of this project (pnpm run format)
[x] I have checked if my changes generate no new warnings (pnpm run lint)