### PR TITLE
fix(ui): close editor mode when opening settings

### DIFF
--- a/src/renderer/components/FileExplorer/CodeEditor.tsx
+++ b/src/renderer/components/FileExplorer/CodeEditor.tsx
@@ -25,6 +25,7 @@ import { FileTree } from './FileTree';
 import { FileTabs } from './FileTabs';
 import { EditorHeader } from './EditorHeader';
 import { MarkdownPreview } from './MarkdownPreview';
+import { SettingsPage, type SettingsPageTab } from '../SettingsPage';
 import '@/styles/editor-diff.css';
 
 interface CodeEditorProps {
@@ -35,6 +36,9 @@ interface CodeEditorProps {
   onClose: () => void;
   connectionId?: string | null;
   remotePath?: string | null;
+  showSettingsPage?: boolean;
+  settingsPageInitialTab?: SettingsPageTab;
+  onCloseSettingsPage?: () => void;
 }
 
 export default function CodeEditor({
@@ -45,12 +49,37 @@ export default function CodeEditor({
   onClose,
   connectionId,
   remotePath,
+  showSettingsPage,
+  settingsPageInitialTab,
+  onCloseSettingsPage,
 }: CodeEditorProps) {
   const { effectiveTheme } = useTheme();
-  const { toggle: toggleRightSidebar, collapsed: rightSidebarCollapsed } = useRightSidebar();
+  const {
+    toggle: toggleRightSidebar,
+    collapsed: rightSidebarCollapsed,
+    setCollapsed: setRightSidebarCollapsed,
+  } = useRightSidebar();
   const monacoRef = useRef<any>(null);
   const editorRef = useRef<any>(null);
   const editorRegistrationCleanupRef = useRef<(() => void) | null>(null);
+  const rightSidebarWasCollapsedRef = useRef<boolean>(false);
+
+  // Collapse the right sidebar when settings is shown inside the editor,
+  // and restore the previous state when settings is closed.
+  useEffect(() => {
+    if (showSettingsPage) {
+      rightSidebarWasCollapsedRef.current = rightSidebarCollapsed;
+      if (!rightSidebarCollapsed) {
+        setRightSidebarCollapsed(true);
+      }
+    } else {
+      if (!rightSidebarWasCollapsedRef.current && rightSidebarCollapsed) {
+        setRightSidebarCollapsed(false);
+      }
+    }
+    // Only react to showSettingsPage toggling, not rightSidebarCollapsed changes
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [showSettingsPage, setRightSidebarCollapsed]);
 
   // File management with custom hook
   const {
@@ -277,6 +306,7 @@ export default function CodeEditor({
         onSaveAll={saveAllFiles}
         onToggleRightSidebar={toggleRightSidebar}
         onClose={onClose}
+        showSettingsPage={showSettingsPage}
       />
 
       <div className="flex flex-1 overflow-hidden">
@@ -297,24 +327,35 @@ export default function CodeEditor({
         />
 
         <div className="flex flex-1 flex-col overflow-hidden">
-          <FileTabs
-            openFiles={openFiles}
-            activeFilePath={activeFilePath}
-            onTabClick={setActiveFile}
-            onTabClose={handleCloseFile}
-            previewMode={previewMode}
-            onTogglePreview={togglePreview}
-          />
+          {showSettingsPage ? (
+            <div className="flex min-h-0 flex-1 overflow-hidden bg-background">
+              <SettingsPage
+                initialTab={settingsPageInitialTab}
+                onClose={onCloseSettingsPage || (() => {})}
+              />
+            </div>
+          ) : (
+            <>
+              <FileTabs
+                openFiles={openFiles}
+                activeFilePath={activeFilePath}
+                onTabClick={setActiveFile}
+                onTabClose={handleCloseFile}
+                previewMode={previewMode}
+                onTogglePreview={togglePreview}
+              />
 
-          <EditorContent
-            activeFile={activeFile}
-            effectiveTheme={effectiveTheme}
-            onEditorMount={handleEditorMount}
-            onEditorChange={handleEditorChange}
-            isPreviewActive={isPreviewActive}
-            modelRootPath={modelRootPath}
-            taskPath={taskPath}
-          />
+              <EditorContent
+                activeFile={activeFile}
+                effectiveTheme={effectiveTheme}
+                onEditorMount={handleEditorMount}
+                onEditorChange={handleEditorChange}
+                isPreviewActive={isPreviewActive}
+                modelRootPath={modelRootPath}
+                taskPath={taskPath}
+              />
+            </>
+          )}
         </div>
       </div>
     </div>

--- a/src/renderer/components/FileExplorer/EditorHeader.tsx
+++ b/src/renderer/components/FileExplorer/EditorHeader.tsx
@@ -10,6 +10,7 @@ interface EditorHeaderProps {
   onSaveAll: () => void;
   onToggleRightSidebar: () => void;
   onClose: () => void;
+  showSettingsPage?: boolean;
 }
 
 export const EditorHeader: React.FC<EditorHeaderProps> = ({
@@ -20,10 +21,11 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
   onSaveAll,
   onToggleRightSidebar,
   onClose,
+  showSettingsPage,
 }) => {
   return (
     <div className="flex h-9 items-center justify-between border-b border-border bg-muted/30 px-3">
-      <TaskInfo taskName={taskName} hasUnsavedChanges={hasUnsavedChanges} />
+      <TaskInfo taskName={taskName} hasUnsavedChanges={hasUnsavedChanges && !showSettingsPage} />
       <EditorControls
         hasUnsavedChanges={hasUnsavedChanges}
         isSaving={isSaving}
@@ -31,6 +33,7 @@ export const EditorHeader: React.FC<EditorHeaderProps> = ({
         onSaveAll={onSaveAll}
         onToggleRightSidebar={onToggleRightSidebar}
         onClose={onClose}
+        showSettingsPage={showSettingsPage}
       />
     </div>
   );
@@ -54,6 +57,7 @@ const EditorControls: React.FC<{
   onSaveAll: () => void;
   onToggleRightSidebar: () => void;
   onClose: () => void;
+  showSettingsPage?: boolean;
 }> = ({
   hasUnsavedChanges,
   isSaving,
@@ -61,27 +65,32 @@ const EditorControls: React.FC<{
   onSaveAll,
   onToggleRightSidebar,
   onClose,
+  showSettingsPage,
 }) => (
   <div className="flex items-center gap-1">
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-7 w-7"
-      onClick={onSaveAll}
-      disabled={!hasUnsavedChanges || isSaving}
-      title="Save All (⌘⇧S)"
-    >
-      <Save className="h-3.5 w-3.5" />
-    </Button>
-    <Button
-      variant="ghost"
-      size="icon"
-      className="h-7 w-7"
-      onClick={onToggleRightSidebar}
-      title={rightSidebarCollapsed ? 'Show Changes' : 'Hide Changes'}
-    >
-      <PanelRight className="h-3.5 w-3.5" />
-    </Button>
+    {!showSettingsPage && (
+      <>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onSaveAll}
+          disabled={!hasUnsavedChanges || isSaving}
+          title="Save All (⌘⇧S)"
+        >
+          <Save className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="icon"
+          className="h-7 w-7"
+          onClick={onToggleRightSidebar}
+          title={rightSidebarCollapsed ? 'Show Changes' : 'Hide Changes'}
+        >
+          <PanelRight className="h-3.5 w-3.5" />
+        </Button>
+      </>
+    )}
     <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onClose} title="Close Editor">
       <X className="h-3.5 w-3.5" />
     </Button>

--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -184,11 +184,10 @@ export function Workspace() {
   // Listen for native menu "Settings" click (main → renderer)
   useEffect(() => {
     const cleanup = window.electronAPI.onMenuOpenSettings?.(() => {
-      setShowEditorMode(false);
       openSettingsPage();
     });
     return () => cleanup?.();
-  }, [openSettingsPage, setShowEditorMode]);
+  }, [openSettingsPage]);
 
   const handleToggleKanban = useCallback(() => {
     if (!projectMgmt.selectedProject) return;
@@ -260,10 +259,7 @@ export function Workspace() {
   // Show toast on update availability
   useUpdateNotifier({
     checkOnMount: true,
-    onOpenSettings: () => {
-      setShowEditorMode(false);
-      openSettingsPage('general');
-    },
+    onOpenSettings: () => openSettingsPage('general'),
   });
 
   // Listen for native menu "Check for Updates" click (main → renderer)
@@ -342,10 +338,8 @@ export function Workspace() {
       handleCloseSettingsPage();
       return;
     }
-    // Close editor mode so the main content area (where settings renders) is visible
-    setShowEditorMode(false);
     openSettingsPage();
-  }, [showSettingsPage, handleCloseSettingsPage, openSettingsPage, setShowEditorMode]);
+  }, [showSettingsPage, handleCloseSettingsPage, openSettingsPage]);
 
   return (
     <BrowserProvider>
@@ -482,14 +476,8 @@ export function Workspace() {
                   handleCloseSettingsPage();
                   projectMgmt.handleGoHome();
                 }}
-                handleOpenSettings={() => {
-                  setShowEditorMode(false);
-                  openSettingsPage();
-                }}
-                handleOpenKeyboardShortcuts={() => {
-                  setShowEditorMode(false);
-                  openSettingsPage('interface');
-                }}
+                handleOpenSettings={() => openSettingsPage()}
+                handleOpenKeyboardShortcuts={() => openSettingsPage('interface')}
               />
               {showEditorMode && activeTask && selectedProject && (
                 <CodeEditor
@@ -500,6 +488,9 @@ export function Workspace() {
                   onClose={handleCloseEditor}
                   connectionId={derivedRemoteConnectionId}
                   remotePath={derivedRemotePath}
+                  showSettingsPage={showSettingsPage}
+                  settingsPageInitialTab={settingsPageInitialTab}
+                  onCloseSettingsPage={handleCloseSettingsPage}
                 />
               )}
 


### PR DESCRIPTION
## Summary

When the in-app editor (EditorMode) is open, clicking the Settings button had no visible effect — it set `showSettingsPage=true` but the `MainContentArea` where `SettingsPage` renders was hidden via `display: none` behind the editor overlay.

Fix: call `setShowEditorMode(false)` before opening settings in both entry points:
- Titlebar Settings button (`handleToggleSettingsPage`)
- Native OS menu Settings handler (`onMenuOpenSettings`)

## Fixes

Fixes #1367

## Snapshot

https://github.com/user-attachments/assets/b15b534b-33fe-467c-94b2-9860f7eb9db3


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have checked if new and existing unit tests pass locally with my changes