### PR TITLE
fix(ssh): resolve saved connection by ID when testing with ID-only config

### DIFF
--- a/src/main/ipc/sshIpc.ts
+++ b/src/main/ipc/sshIpc.ts
@@ -161,6 +161,49 @@ export function registerSshIpc() {
       config: SshConfig & { password?: string; passphrase?: string }
     ): Promise<ConnectionTestResult> => {
       try {
+        // When renderer sends only connection id (e.g. SshConnectionTestButton), resolve from DB and keytar
+        const isIdOnly =
+          config.id &&
+          (typeof config.host !== 'string' || !config.host.trim()) &&
+          (typeof config.username !== 'string' || !config.username.trim());
+
+        let resolvedConfig: SshConfig & { password?: string; passphrase?: string } = config;
+        if (isIdOnly && config.id) {
+          const { db } = await getDrizzleClient();
+          const rows = await db
+            .select({
+              id: sshConnectionsTable.id,
+              name: sshConnectionsTable.name,
+              host: sshConnectionsTable.host,
+              port: sshConnectionsTable.port,
+              username: sshConnectionsTable.username,
+              authType: sshConnectionsTable.authType,
+              privateKeyPath: sshConnectionsTable.privateKeyPath,
+              useAgent: sshConnectionsTable.useAgent,
+            })
+            .from(sshConnectionsTable)
+            .where(eq(sshConnectionsTable.id, config.id))
+            .limit(1);
+
+          const row = rows[0];
+          if (!row) {
+            return { success: false, error: `Connection not found: ${config.id}` };
+          }
+
+          resolvedConfig = mapRowToConfig(row) as SshConfig & {
+            password?: string;
+            passphrase?: string;
+          };
+          if (resolvedConfig.authType === 'password') {
+            resolvedConfig.password =
+              (await credentialService.getPassword(resolvedConfig.id)) ?? undefined;
+          }
+          if (resolvedConfig.authType === 'key') {
+            resolvedConfig.passphrase =
+              (await credentialService.getPassphrase(resolvedConfig.id)) ?? undefined;
+          }
+        }
+
         const { Client } = await import('ssh2');
         const debugLogs: string[] = [];
         const testClient = new Client();
@@ -199,21 +242,21 @@ export function registerSshIpc() {
             agent?: string;
             debug?: (info: string) => void;
           } = {
-            host: config.host,
-            port: config.port,
-            username: config.username,
+            host: resolvedConfig.host,
+            port: resolvedConfig.port,
+            username: resolvedConfig.username,
             readyTimeout: 10000,
             debug: (info: string) => debugLogs.push(info),
           };
 
-          if (config.authType === 'password') {
-            connectConfig.password = config.password;
-          } else if (config.authType === 'key' && config.privateKeyPath) {
+          if (resolvedConfig.authType === 'password') {
+            connectConfig.password = resolvedConfig.password;
+          } else if (resolvedConfig.authType === 'key' && resolvedConfig.privateKeyPath) {
             const fs = require('fs');
             const os = require('os');
             try {
               // Expand ~ to home directory
-              let keyPath = config.privateKeyPath;
+              let keyPath = resolvedConfig.privateKeyPath;
               if (keyPath.startsWith('~/')) {
                 keyPath = keyPath.replace('~', os.homedir());
               } else if (keyPath === '~') {
@@ -221,8 +264,8 @@ export function registerSshIpc() {
               }
 
               connectConfig.privateKey = fs.readFileSync(keyPath);
-              if (config.passphrase) {
-                connectConfig.passphrase = config.passphrase;
+              if (resolvedConfig.passphrase) {
+                connectConfig.passphrase = resolvedConfig.passphrase;
               }
             } catch (err: any) {
               resolve({
@@ -232,8 +275,8 @@ export function registerSshIpc() {
               });
               return;
             }
-          } else if (config.authType === 'agent') {
-            const identityAgent = await resolveIdentityAgent(config.host);
+          } else if (resolvedConfig.authType === 'agent') {
+            const identityAgent = await resolveIdentityAgent(resolvedConfig.host);
             connectConfig.agent = identityAgent || process.env.SSH_AUTH_SOCK;
           }
 

--- a/src/renderer/components/ssh/SshConnectionTestButton.tsx
+++ b/src/renderer/components/ssh/SshConnectionTestButton.tsx
@@ -35,9 +35,7 @@ export const SshConnectionTestButton: React.FC<Props> = ({
     setCopied(false);
 
     try {
-      // For testing, we need the full config - this would need to be fetched or passed in
-      // For now, we'll call the test with just the ID and let the main process handle it
-      // TODO: Fetch connection details or update IPC to accept just ID
+      // Main process accepts ID-only: it loads the saved connection from DB and hydrates credentials from keytar.
       const testResult = await window.electronAPI.sshTestConnection({
         id: connectionId,
         name: '',


### PR DESCRIPTION
## Description

When the renderer calls `sshTestConnection` with only a connection ID and empty host/username (e.g. from `SshConnectionTestButton`), the main process previously used those empty values and the test could not succeed. This change detects that "ID-only" call shape, loads the saved connection from the DB, hydrates credentials from keytar, and runs the test against the resolved config.

## Rationale

`SshConnectionTestButton` only has access to `connectionId` and was intentionally calling the IPC with ID + empty fields and a TODO for the main process to handle it. The main process did not handle that case; this fix adds the same resolve-by-ID pattern already used by the `CONNECT` handler.

## Changes

- **Main process (`src/main/ipc/sshIpc.ts`)**: In the `TEST_CONNECTION` handler, detect ID-only calls (config has `id` but `host` or `username` empty). For those, load the saved connection from the DB, hydrate password/passphrase from keytar, and run the test using the resolved config.
- **Renderer (`src/renderer/components/ssh/SshConnectionTestButton.tsx`)**: Comment updated to state that the main process accepts ID-only and resolves from DB/keytar.

## Testing

- No new tests; behavior aligns with the existing `CONNECT` handler (resolve by ID from DB + keytar).
- Manual: use "Test" on a saved SSH connection from the UI that uses `SshConnectionTestButton`.

## Pre-PR Checklist

- [ ] Dev server runs: `pnpm run d` (or `pnpm run dev`) starts cleanly.
- [ ] Code is formatted: `pnpm run format`.
- [ ] Lint passes: `pnpm run lint`.
- [ ] Types check: `pnpm run type-check`.
- [ ] Tests pass: `pnpm exec vitest run`.
- [ ] No stray build artifacts or secrets committed.
- [ ] Documented any schema or config changes impacting users. (N/A — no schema/config changes.)