### PR TITLE
feat(terminal): add Cmd/Ctrl+F search for terminal panes

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -31,6 +31,8 @@ import { makePtyId } from '@shared/ptyId';
 import { generateTaskName } from '../lib/branchNameGenerator';
 import { ensureUniqueTaskName } from '../lib/taskNames';
 import type { Project } from '../types/app';
+import { useTerminalSearch } from '../hooks/useTerminalSearch';
+import { TerminalSearchOverlay } from './TerminalSearchOverlay';
 
 declare const window: Window & {
   electronAPI: {
@@ -400,6 +402,21 @@ const ChatInterface: React.FC<Props> = ({
 
   // Ref to control terminal focus imperatively if needed
   const terminalRef = useRef<{ focus: () => void }>(null);
+  const terminalPanelRef = useRef<HTMLDivElement | null>(null);
+  const {
+    isSearchOpen,
+    searchQuery,
+    searchStatus,
+    searchInputRef,
+    closeSearch,
+    handleSearchQueryChange,
+    stepSearch,
+  } = useTerminalSearch({
+    terminalId,
+    containerRef: terminalPanelRef,
+    enabled: true,
+    onCloseFocus: () => terminalRef.current?.focus(),
+  });
 
   const handleTerminalActivity = useCallback(() => {
     const storageKey = `agent:locked:${task.id}`;
@@ -1124,7 +1141,8 @@ const ChatInterface: React.FC<Props> = ({
           </div>
           <div className="mt-4 min-h-0 flex-1 px-6">
             <div
-              className={`mx-auto h-full max-w-4xl overflow-hidden rounded-md ${
+              ref={terminalPanelRef}
+              className={`relative mx-auto h-full max-w-4xl overflow-hidden rounded-md ${
                 agent === 'charm'
                   ? effectiveTheme === 'dark-black'
                     ? 'bg-black'
@@ -1140,6 +1158,16 @@ const ChatInterface: React.FC<Props> = ({
                     : ''
               }`}
             >
+              <TerminalSearchOverlay
+                isOpen={isSearchOpen}
+                fullWidth
+                searchQuery={searchQuery}
+                searchStatus={searchStatus}
+                searchInputRef={searchInputRef}
+                onQueryChange={handleSearchQueryChange}
+                onStep={stepSearch}
+                onClose={closeSearch}
+              />
               {/* Wait for conversations to load to ensure stable terminalId */}
               {conversationsLoaded && (
                 <TerminalPane

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -9,6 +9,8 @@ import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/t
 import { Button } from './ui/button';
 import { useToast } from '../hooks/use-toast';
 import { ToastAction } from './ui/toast';
+import { useTerminalSearch } from '../hooks/useTerminalSearch';
+import { TerminalSearchOverlay } from './TerminalSearchOverlay';
 import {
   Select,
   SelectContent,
@@ -78,6 +80,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
 
   const selection = useTerminalSelection({ task, taskTerminals, globalTerminals });
 
+  const panelRef = useRef<HTMLDivElement | null>(null);
   const terminalRefs = useRef<Map<string, { focus: () => void }>>(new Map());
   const setTerminalRef = useCallback((id: string, ref: { focus: () => void } | null) => {
     if (ref) {
@@ -242,6 +245,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   }, [runStatus, selection.onChange]);
 
   const totalTerminals = taskTerminals.terminals.length + globalTerminals.terminals.length;
+  const hasActiveTerminal = !selection.selectedLifecycle && !!selection.activeTerminalId;
 
   const canStartRun =
     !!task &&
@@ -256,6 +260,24 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
     if (selection.parsed?.mode === 'global') return projectPath ? 'PROJECT' : 'GLOBAL';
     return null;
   }, [selection.parsed?.mode, projectPath]);
+  const {
+    isSearchOpen,
+    searchQuery,
+    searchStatus,
+    searchInputRef,
+    closeSearch,
+    handleSearchQueryChange,
+    stepSearch,
+  } = useTerminalSearch({
+    terminalId: selection.selectedLifecycle ? null : selection.activeTerminalId,
+    containerRef: panelRef,
+    enabled: hasActiveTerminal,
+    onCloseFocus: () => {
+      if (selection.activeTerminalId && !selection.selectedLifecycle) {
+        terminalRefs.current.get(selection.activeTerminalId)?.focus();
+      }
+    },
+  });
 
   const handlePlay = useCallback(async () => {
     if (!task || !projectPath) return;
@@ -448,7 +470,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   }, [nativeTheme, defaultTheme]);
 
   return (
-    <div className={cn('flex h-full min-w-0 flex-col bg-card', className)}>
+    <div ref={panelRef} className={cn('flex h-full min-w-0 flex-col bg-card', className)}>
       <div className="flex items-center gap-2 border-b border-border bg-muted px-2 py-1.5 dark:bg-background">
         <Select
           value={selection.value}
@@ -685,6 +707,15 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
               : 'bg-white'
           )}
         >
+          <TerminalSearchOverlay
+            isOpen={isSearchOpen && hasActiveTerminal}
+            searchQuery={searchQuery}
+            searchStatus={searchStatus}
+            searchInputRef={searchInputRef}
+            onQueryChange={handleSearchQueryChange}
+            onStep={stepSearch}
+            onClose={closeSearch}
+          />
           {task &&
             taskTerminals.terminals.map((terminal) => {
               const isActive =

--- a/src/renderer/components/TerminalSearchOverlay.tsx
+++ b/src/renderer/components/TerminalSearchOverlay.tsx
@@ -1,0 +1,102 @@
+import React, { type RefObject } from 'react';
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
+import { cn } from '@/lib/utils';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import type { TerminalSearchStatus } from '../hooks/useTerminalSearch';
+
+interface Props {
+  isOpen: boolean;
+  fullWidth?: boolean;
+  searchQuery: string;
+  searchStatus: TerminalSearchStatus;
+  searchInputRef: RefObject<HTMLInputElement>;
+  onQueryChange: (value: string) => void;
+  onStep: (direction: 'next' | 'prev') => void;
+  onClose: () => void;
+}
+
+export const TerminalSearchOverlay: React.FC<Props> = ({
+  isOpen,
+  fullWidth = false,
+  searchQuery,
+  searchStatus,
+  searchInputRef,
+  onQueryChange,
+  onStep,
+  onClose,
+}) => {
+  if (!isOpen) return null;
+
+  return (
+    <div
+      className={cn(
+        'absolute top-3 z-20 flex items-center gap-1 rounded-md border border-border bg-background/95 p-1.5 shadow-lg backdrop-blur',
+        fullWidth ? 'left-3 right-3 w-auto max-w-none' : 'right-3 w-[min(28rem,calc(100%-1.5rem))]'
+      )}
+    >
+      <div className="relative min-w-0 flex-1">
+        <Search className="pointer-events-none absolute left-2.5 top-1/2 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+        <Input
+          ref={searchInputRef}
+          value={searchQuery}
+          onChange={(event) => onQueryChange(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === 'Enter') {
+              event.preventDefault();
+              onStep(event.shiftKey ? 'prev' : 'next');
+              return;
+            }
+            if (event.key === 'Escape') {
+              event.preventDefault();
+              event.stopPropagation();
+              onClose();
+            }
+          }}
+          placeholder="Find in terminal..."
+          className="h-8 min-w-0 border-0 bg-transparent pl-8 pr-2 text-xs shadow-none focus-visible:ring-0"
+          aria-label="Find in terminal"
+        />
+      </div>
+      <div className="ml-auto flex shrink-0 items-center gap-0.5">
+        <span className="min-w-10 shrink-0 px-1 text-center text-[11px] text-muted-foreground">
+          {searchQuery ? `${searchStatus.currentIndex}/${searchStatus.total}` : '0/0'}
+        </span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onStep('prev')}
+          disabled={!searchQuery || searchStatus.total === 0}
+          className="shrink-0 text-muted-foreground"
+          aria-label="Previous terminal match"
+        >
+          <ChevronUp className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={() => onStep('next')}
+          disabled={!searchQuery || searchStatus.total === 0}
+          className="shrink-0 text-muted-foreground"
+          aria-label="Next terminal match"
+        >
+          <ChevronDown className="h-3.5 w-3.5" />
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-sm"
+          onClick={onClose}
+          className="shrink-0 text-muted-foreground"
+          aria-label="Close terminal search"
+        >
+          <X className="h-3.5 w-3.5" />
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default TerminalSearchOverlay;

--- a/src/renderer/hooks/useTerminalSearch.ts
+++ b/src/renderer/hooks/useTerminalSearch.ts
@@ -1,0 +1,183 @@
+import { useCallback, useEffect, useRef, useState, type RefObject } from 'react';
+import { terminalSessionRegistry } from '../terminal/SessionRegistry';
+
+export type TerminalSearchStatus = {
+  found: boolean;
+  currentIndex: number;
+  total: number;
+};
+
+const EMPTY_SEARCH_STATUS: TerminalSearchStatus = {
+  found: false,
+  currentIndex: 0,
+  total: 0,
+};
+const IS_MAC_PLATFORM =
+  typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+
+interface UseTerminalSearchOptions {
+  terminalId: string | null | undefined;
+  containerRef: RefObject<HTMLElement | null>;
+  enabled: boolean;
+  onCloseFocus?: () => void;
+}
+
+export function useTerminalSearch({
+  terminalId,
+  containerRef,
+  enabled,
+  onCloseFocus,
+}: UseTerminalSearchOptions) {
+  const searchInputRef = useRef<HTMLInputElement>(null);
+  const searchedTerminalIdRef = useRef<string | null>(null);
+  const [isSearchOpen, setIsSearchOpen] = useState(false);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchStatus, setSearchStatus] = useState<TerminalSearchStatus>(EMPTY_SEARCH_STATUS);
+
+  const clearSearchSelection = useCallback((sessionId?: string | null) => {
+    const id = sessionId ?? searchedTerminalIdRef.current;
+    if (!id) return;
+    terminalSessionRegistry.getSession(id)?.clearSearch();
+    if (searchedTerminalIdRef.current === id) {
+      searchedTerminalIdRef.current = null;
+    }
+  }, []);
+
+  const runTerminalSearch = useCallback(
+    (
+      query: string,
+      options: {
+        direction?: 'next' | 'prev';
+        reset?: boolean;
+      } = {}
+    ): TerminalSearchStatus => {
+      if (!enabled || !terminalId) {
+        setSearchStatus(EMPTY_SEARCH_STATUS);
+        return EMPTY_SEARCH_STATUS;
+      }
+
+      if (searchedTerminalIdRef.current && searchedTerminalIdRef.current !== terminalId) {
+        clearSearchSelection(searchedTerminalIdRef.current);
+      }
+
+      const session = terminalSessionRegistry.getSession(terminalId);
+      if (!session) {
+        setSearchStatus(EMPTY_SEARCH_STATUS);
+        return EMPTY_SEARCH_STATUS;
+      }
+
+      const result = session.search(query, options);
+      searchedTerminalIdRef.current = terminalId;
+      setSearchStatus(result);
+      return result;
+    },
+    [clearSearchSelection, enabled, terminalId]
+  );
+
+  const closeSearch = useCallback(() => {
+    clearSearchSelection();
+    setSearchQuery('');
+    setSearchStatus(EMPTY_SEARCH_STATUS);
+    setIsSearchOpen(false);
+    onCloseFocus?.();
+  }, [clearSearchSelection, onCloseFocus]);
+
+  const openSearch = useCallback(() => {
+    if (!enabled) return;
+    setIsSearchOpen(true);
+  }, [enabled]);
+
+  const handleSearchQueryChange = useCallback(
+    (nextQuery: string) => {
+      setSearchQuery(nextQuery);
+      if (!nextQuery) {
+        clearSearchSelection();
+        setSearchStatus(EMPTY_SEARCH_STATUS);
+        return;
+      }
+      runTerminalSearch(nextQuery, { direction: 'next', reset: true });
+    },
+    [clearSearchSelection, runTerminalSearch]
+  );
+
+  const stepSearch = useCallback(
+    (direction: 'next' | 'prev') => {
+      if (!searchQuery) return;
+      runTerminalSearch(searchQuery, { direction, reset: false });
+    },
+    [runTerminalSearch, searchQuery]
+  );
+
+  useEffect(() => {
+    if (!isSearchOpen) return;
+    const focusTimer = requestAnimationFrame(() => {
+      searchInputRef.current?.focus();
+      searchInputRef.current?.select();
+    });
+    return () => cancelAnimationFrame(focusTimer);
+  }, [isSearchOpen]);
+
+  useEffect(() => {
+    if (!enabled && isSearchOpen) {
+      closeSearch();
+    }
+  }, [closeSearch, enabled, isSearchOpen]);
+
+  useEffect(() => {
+    if (searchedTerminalIdRef.current && searchedTerminalIdRef.current !== terminalId) {
+      clearSearchSelection(searchedTerminalIdRef.current);
+      setSearchStatus(EMPTY_SEARCH_STATUS);
+    }
+  }, [clearSearchSelection, terminalId]);
+
+  useEffect(() => {
+    if (!enabled || !isSearchOpen || !searchQuery || !terminalId) {
+      return;
+    }
+    runTerminalSearch(searchQuery, { direction: 'next', reset: true });
+  }, [enabled, isSearchOpen, runTerminalSearch, searchQuery, terminalId]);
+
+  useEffect(() => {
+    if (!enabled) return;
+
+    const handleSearchShortcut = (event: KeyboardEvent) => {
+      const key = event.key.toLowerCase();
+      const hasPlatformModifier = IS_MAC_PLATFORM
+        ? event.metaKey && !event.ctrlKey
+        : event.ctrlKey && !event.metaKey;
+      if (!hasPlatformModifier || event.altKey || event.shiftKey || key !== 'f') {
+        return;
+      }
+
+      const container = containerRef.current;
+      if (!container) return;
+
+      const activeElement = document.activeElement;
+      if (!activeElement || !container.contains(activeElement)) return;
+
+      event.preventDefault();
+      event.stopImmediatePropagation();
+      event.stopPropagation();
+      openSearch();
+    };
+
+    window.addEventListener('keydown', handleSearchShortcut, true);
+    return () => window.removeEventListener('keydown', handleSearchShortcut, true);
+  }, [containerRef, enabled, openSearch]);
+
+  useEffect(() => {
+    return () => {
+      clearSearchSelection();
+    };
+  }, [clearSearchSelection]);
+
+  return {
+    isSearchOpen,
+    searchQuery,
+    searchStatus,
+    searchInputRef,
+    closeSearch,
+    handleSearchQueryChange,
+    stepSearch,
+  };
+}

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -23,6 +23,12 @@ import {
   shouldMapShiftEnterToCtrlJ,
   shouldPasteToTerminal,
 } from './terminalKeybindings';
+import {
+  collectTerminalSearchMatches,
+  getNextTerminalSearchIndex,
+  type TerminalSearchBufferLike,
+  type TerminalSearchMatch,
+} from './terminalSearch';
 import { rpc } from '@/lib/rpc';
 import { APP_SHORTCUTS, normalizeShortcutKey } from '@/hooks/useKeyboardShortcuts';
 
@@ -136,6 +142,8 @@ export class TerminalSessionManager {
   private lastSlowInputLogAt = 0;
   private terminalConfigFontSize: number | null = null;
   private lastTheme: SessionTheme;
+  private activeSearchQuery = '';
+  private activeSearchMatch: TerminalSearchMatch | null = null;
 
   // Timing for startup performance measurement
   private initStartTime: number = 0;
@@ -603,6 +611,73 @@ export class TerminalSessionManager {
     } catch (error) {
       log.warn('Failed to scroll to bottom', { id: this.id, error });
     }
+  }
+
+  search(
+    query: string,
+    options: { direction?: 'next' | 'prev'; reset?: boolean } = {}
+  ): {
+    found: boolean;
+    currentIndex: number;
+    total: number;
+  } {
+    const normalizedQuery = query;
+    if (!normalizedQuery) {
+      this.clearSearch();
+      return { found: false, currentIndex: 0, total: 0 };
+    }
+
+    const buffer = this.terminal.buffer?.active as TerminalSearchBufferLike | undefined;
+    if (!buffer) {
+      this.activeSearchQuery = normalizedQuery;
+      this.activeSearchMatch = null;
+      return { found: false, currentIndex: 0, total: 0 };
+    }
+
+    const matches = collectTerminalSearchMatches(buffer, normalizedQuery);
+    if (matches.length === 0) {
+      this.activeSearchQuery = normalizedQuery;
+      this.activeSearchMatch = null;
+      try {
+        this.terminal.clearSelection();
+      } catch {}
+      return { found: false, currentIndex: 0, total: 0 };
+    }
+
+    const direction = options.direction ?? 'next';
+    const currentMatch =
+      !options.reset && this.activeSearchQuery === normalizedQuery ? this.activeSearchMatch : null;
+    const matchIndex = getNextTerminalSearchIndex(matches, currentMatch, direction);
+    const match = matches[matchIndex];
+
+    this.activeSearchQuery = normalizedQuery;
+    this.activeSearchMatch = match;
+
+    try {
+      this.terminal.select(match.col, match.row, match.length);
+      const contextRows = Math.max(0, Math.floor(this.terminal.rows / 2));
+      this.terminal.scrollToLine(Math.max(0, match.row - contextRows));
+    } catch (error) {
+      log.warn('Failed to apply terminal search match', {
+        id: this.id,
+        query: normalizedQuery,
+        error,
+      });
+    }
+
+    return {
+      found: true,
+      currentIndex: matchIndex + 1,
+      total: matches.length,
+    };
+  }
+
+  clearSearch() {
+    this.activeSearchQuery = '';
+    this.activeSearchMatch = null;
+    try {
+      this.terminal.clearSelection();
+    } catch {}
   }
 
   registerActivityListener(listener: () => void): () => void {

--- a/src/renderer/terminal/terminalSearch.ts
+++ b/src/renderer/terminal/terminalSearch.ts
@@ -1,0 +1,167 @@
+export interface TerminalSearchBufferLineLike {
+  isWrapped?: boolean;
+  translateToString(trimRight?: boolean, startColumn?: number, endColumn?: number): string;
+}
+
+export interface TerminalSearchBufferLike {
+  length: number;
+  getLine(index: number): TerminalSearchBufferLineLike | undefined;
+}
+
+export interface TerminalSearchMatch {
+  row: number;
+  col: number;
+  length: number;
+}
+
+interface PhysicalLineSegment {
+  row: number;
+  startIndex: number;
+}
+
+interface LogicalLine {
+  text: string;
+  segments: PhysicalLineSegment[];
+}
+
+function buildLogicalLines(buffer: TerminalSearchBufferLike): LogicalLine[] {
+  const logicalLines: LogicalLine[] = [];
+  let current: LogicalLine | null = null;
+
+  for (let index = 0; index < buffer.length; index += 1) {
+    const line = buffer.getLine(index);
+    if (!line) continue;
+
+    const text = line.translateToString(false);
+    if (!current || !line.isWrapped) {
+      if (current) {
+        logicalLines.push(current);
+      }
+      current = { text: '', segments: [] };
+    }
+
+    current.segments.push({
+      row: index,
+      startIndex: current.text.length,
+    });
+    current.text += text;
+  }
+
+  if (current) {
+    logicalLines.push(current);
+  }
+
+  return logicalLines;
+}
+
+function resolveMatchStart(
+  segments: PhysicalLineSegment[],
+  startIndex: number
+): TerminalSearchMatch {
+  for (let index = segments.length - 1; index >= 0; index -= 1) {
+    const segment = segments[index];
+    if (startIndex >= segment.startIndex) {
+      return {
+        row: segment.row,
+        col: startIndex - segment.startIndex,
+        length: 0,
+      };
+    }
+  }
+
+  const firstSegment = segments[0];
+  return {
+    row: firstSegment?.row ?? 0,
+    col: 0,
+    length: 0,
+  };
+}
+
+export function collectTerminalSearchMatches(
+  buffer: TerminalSearchBufferLike,
+  query: string
+): TerminalSearchMatch[] {
+  if (!query) return [];
+
+  const normalizedQuery = query.toLocaleLowerCase();
+  if (!normalizedQuery) return [];
+
+  const matches: TerminalSearchMatch[] = [];
+  const logicalLines = buildLogicalLines(buffer);
+
+  for (const logicalLine of logicalLines) {
+    const haystack = logicalLine.text.toLocaleLowerCase();
+    let fromIndex = 0;
+
+    while (fromIndex <= haystack.length - normalizedQuery.length) {
+      const matchIndex = haystack.indexOf(normalizedQuery, fromIndex);
+      if (matchIndex === -1) break;
+
+      const start = resolveMatchStart(logicalLine.segments, matchIndex);
+      matches.push({
+        row: start.row,
+        col: start.col,
+        length: query.length,
+      });
+
+      fromIndex = matchIndex + Math.max(1, normalizedQuery.length);
+    }
+  }
+
+  return matches;
+}
+
+function compareMatchPosition(left: TerminalSearchMatch, right: TerminalSearchMatch): number {
+  if (left.row !== right.row) return left.row - right.row;
+  if (left.col !== right.col) return left.col - right.col;
+  return left.length - right.length;
+}
+
+function findExactCurrentMatchIndex(
+  matches: TerminalSearchMatch[],
+  currentMatch: TerminalSearchMatch | null
+): number {
+  if (!currentMatch) return -1;
+
+  return matches.findIndex(
+    (candidate) =>
+      candidate.row === currentMatch.row &&
+      candidate.col === currentMatch.col &&
+      candidate.length === currentMatch.length
+  );
+}
+
+export function getNextTerminalSearchIndex(
+  matches: TerminalSearchMatch[],
+  currentMatch: TerminalSearchMatch | null,
+  direction: 'next' | 'prev'
+): number {
+  if (matches.length === 0) return -1;
+
+  const currentMatchIndex = findExactCurrentMatchIndex(matches, currentMatch);
+  if (currentMatchIndex === -1 && currentMatch) {
+    if (direction === 'prev') {
+      for (let index = matches.length - 1; index >= 0; index -= 1) {
+        if (compareMatchPosition(matches[index], currentMatch) < 0) {
+          return index;
+        }
+      }
+      return matches.length - 1;
+    }
+
+    const nextIndex = matches.findIndex(
+      (candidate) => compareMatchPosition(candidate, currentMatch) > 0
+    );
+    return nextIndex === -1 ? 0 : nextIndex;
+  }
+
+  if (currentMatchIndex === -1) {
+    return direction === 'prev' ? matches.length - 1 : 0;
+  }
+
+  if (direction === 'prev') {
+    return currentMatchIndex === 0 ? matches.length - 1 : currentMatchIndex - 1;
+  }
+
+  return currentMatchIndex === matches.length - 1 ? 0 : currentMatchIndex + 1;
+}

--- a/src/test/renderer/terminalSearch.test.ts
+++ b/src/test/renderer/terminalSearch.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectTerminalSearchMatches,
+  getNextTerminalSearchIndex,
+  type TerminalSearchBufferLike,
+  type TerminalSearchBufferLineLike,
+  type TerminalSearchMatch,
+} from '../../renderer/terminal/terminalSearch';
+
+class MockBufferLine implements TerminalSearchBufferLineLike {
+  constructor(
+    private readonly text: string,
+    readonly isWrapped: boolean = false
+  ) {}
+
+  translateToString(): string {
+    return this.text;
+  }
+}
+
+function makeBuffer(lines: Array<{ text: string; isWrapped?: boolean }>): TerminalSearchBufferLike {
+  const bufferLines = lines.map((line) => new MockBufferLine(line.text, line.isWrapped ?? false));
+  return {
+    length: bufferLines.length,
+    getLine: (index: number) => bufferLines[index],
+  };
+}
+
+describe('terminalSearch', () => {
+  it('finds case-insensitive matches on buffer rows', () => {
+    const buffer = makeBuffer([{ text: 'Alpha beta' }, { text: 'beta gamma' }]);
+
+    expect(collectTerminalSearchMatches(buffer, 'BETA')).toEqual<TerminalSearchMatch[]>([
+      { row: 0, col: 6, length: 4 },
+      { row: 1, col: 0, length: 4 },
+    ]);
+  });
+
+  it('maps wrapped-line matches back to the physical row and column', () => {
+    const buffer = makeBuffer([
+      { text: 'Hello ', isWrapped: false },
+      { text: 'world', isWrapped: true },
+      { text: 'separate line', isWrapped: false },
+    ]);
+
+    expect(collectTerminalSearchMatches(buffer, 'world')).toEqual<TerminalSearchMatch[]>([
+      { row: 1, col: 0, length: 5 },
+    ]);
+  });
+
+  it('cycles forward and backward through matches', () => {
+    const matches: TerminalSearchMatch[] = [
+      { row: 0, col: 1, length: 3 },
+      { row: 3, col: 2, length: 3 },
+      { row: 7, col: 0, length: 3 },
+    ];
+
+    expect(getNextTerminalSearchIndex(matches, null, 'next')).toBe(0);
+    expect(getNextTerminalSearchIndex(matches, null, 'prev')).toBe(2);
+    expect(getNextTerminalSearchIndex(matches, matches[0], 'next')).toBe(1);
+    expect(getNextTerminalSearchIndex(matches, matches[0], 'prev')).toBe(2);
+    expect(getNextTerminalSearchIndex(matches, matches[2], 'next')).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds in-terminal text search triggered by `Cmd+F` (macOS) / `Ctrl+F` (Linux/Windows)
- Implements a search overlay UI with match counter, prev/next navigation, and keyboard support (Enter/Shift+Enter to step, Escape to close)
- Wires search into both `ChatInterface` (agent terminal) and `TaskTerminalPanel` (worktree/global terminals)

## Details
- **`terminalSearch.ts`** — Pure search logic that scans xterm.js buffer rows (handling wrapped lines) for case-insensitive matches and provides directional cycling
- **`TerminalSessionManager.ts`** — Adds `search()` and `clearSearch()` methods that use `terminal.select()` and `scrollToLine()` to highlight and scroll to matches
- **`useTerminalSearch.ts`** — React hook managing search state, keyboard shortcut binding, and session lifecycle cleanup
- **`TerminalSearchOverlay.tsx`** — Floating search bar component with match count display and nav buttons
- **`terminalSearch.test.ts`** — Unit tests for match collection and directional index cycling

## Test plan
- [x] Unit tests pass: `pnpm exec vitest run src/test/renderer/terminalSearch.test.ts`
- [ ] Open a task with terminal output, press `Cmd+F`/`Ctrl+F` — search overlay appears
- [ ] Type a query — matches are highlighted and count is shown
- [ ] Press Enter/Shift+Enter or arrow buttons to cycle through matches
- [ ] Press Escape — overlay closes, selection is cleared, terminal re-focused
- [ ] Verify search works in both ChatInterface and TaskTerminalPanel views

<!-- emdash-issue-footer:start -->
Fixes #1428
<!-- emdash-issue-footer:end -->