### PR TITLE
feat(terminal): detect and open URLs from terminal output

### DIFF
--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -1,6 +1,6 @@
 import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import { TerminalPane } from './TerminalPane';
-import { Plus, Play, RotateCw, Square, X } from 'lucide-react';
+import { Plus, Play, RotateCw, Square, X, ExternalLink, Globe } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { useTaskTerminals } from '@/lib/taskTerminalsStore';
 import { useTerminalSelection } from '../hooks/useTerminalSelection';
@@ -28,6 +28,7 @@ import {
   formatLifecycleLogLine,
 } from '@shared/lifecycle';
 import { shouldDisablePlay } from '../lib/lifecycleUi';
+import { normalizeUrl } from '@shared/urls';
 
 interface Task {
   id: string;
@@ -64,6 +65,9 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   const { effectiveTheme } = useTheme();
   const { toast } = useToast();
 
+  const [detectedUrls, setDetectedUrls] = useState<string[]>([]);
+  const [selectedUrl, setSelectedUrl] = useState<string | null>(null);
+
   // Use path in the key to differentiate multi-agent variants that share the same task.id
   const taskKey = task ? `${task.id}::${task.path}` : 'task-placeholder';
   const taskTerminals = useTaskTerminals(taskKey, task?.path);
@@ -99,6 +103,40 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
     }, 50);
     return () => clearTimeout(timer);
   }, [selection.activeTerminalId]);
+
+  useEffect(() => {
+    // Reset URLs when task changes
+    setDetectedUrls([]);
+    setSelectedUrl(null);
+
+    if (!task?.id) return;
+
+    const off = window.electronAPI?.onLifecycleEvent?.((data: any) => {
+      if (data?.taskId !== task.id) return;
+
+      // Extract URL from run line output
+      if (data?.phase === 'run' && data?.status === 'line' && data?.line) {
+        const url = normalizeUrl(data.line);
+        if (url) {
+          setDetectedUrls((prev) => {
+            if (prev.includes(url)) return prev;
+            setSelectedUrl((current) => current || url);
+            return [...prev, url];
+          });
+        }
+      }
+
+      // Reset URLs when run exits
+      if (data?.phase === 'run' && (data?.status === 'done' || data?.status === 'error')) {
+        setDetectedUrls([]);
+        setSelectedUrl(null);
+      }
+    });
+
+    return () => {
+      off?.();
+    };
+  }, [task?.id]);
 
   const [runStatus, setRunStatus] = useState<LifecyclePhaseStatus>('idle');
   const [setupStatus, setSetupStatus] = useState<LifecyclePhaseStatus>('idle');
@@ -631,6 +669,52 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                           : setupStatus === 'failed'
                             ? 'Retry setup and start run script'
                             : 'Start run script'}
+                </p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+        )}
+
+        {task && detectedUrls.length > 0 && (
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                {detectedUrls.length > 1 ? (
+                  <Select
+                    value={selectedUrl || ''}
+                    onValueChange={(value) => {
+                      setSelectedUrl(value);
+                      window.electronAPI.openExternal(value);
+                    }}
+                  >
+                    <SelectTrigger className="h-7 w-auto min-w-[40px] gap-2 border-none bg-transparent px-2 text-xs shadow-none hover:bg-accent">
+                      <Globe className="h-3.5 w-3.5" />
+                      <SelectValue placeholder="Open URL" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectGroup>
+                        {detectedUrls.map((url) => (
+                          <SelectItem key={url} value={url} className="text-xs">
+                            {url.replace('http://localhost:', 'port: ')}
+                          </SelectItem>
+                        ))}
+                      </SelectGroup>
+                    </SelectContent>
+                  </Select>
+                ) : (
+                  <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    onClick={() => selectedUrl && window.electronAPI.openExternal(selectedUrl)}
+                    className="text-muted-foreground hover:text-foreground"
+                  >
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  </Button>
+                )}
+              </TooltipTrigger>
+              <TooltipContent side="bottom">
+                <p className="text-xs">
+                  {selectedUrl ? `Open ${selectedUrl} in browser` : 'No URL detected yet'}
                 </p>
               </TooltipContent>
             </Tooltip>

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -120,9 +120,11 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
         if (url) {
           setDetectedUrls((prev) => {
             if (prev.includes(url)) return prev;
-            setSelectedUrl((current) => current || url);
             return [...prev, url];
           });
+          if (!selectedUrl) {
+            setSelectedUrl(url);
+          }
         }
       }
 
@@ -679,38 +681,40 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
           <TooltipProvider delayDuration={200}>
             <Tooltip>
               <TooltipTrigger asChild>
-                {detectedUrls.length > 1 ? (
-                  <Select
-                    value={selectedUrl || ''}
-                    onValueChange={(value) => {
-                      setSelectedUrl(value);
-                      window.electronAPI.openExternal(value);
-                    }}
-                  >
-                    <SelectTrigger className="h-7 w-auto min-w-[40px] gap-2 border-none bg-transparent px-2 text-xs shadow-none hover:bg-accent">
-                      <Globe className="h-3.5 w-3.5" />
-                      <SelectValue placeholder="Open URL" />
-                    </SelectTrigger>
-                    <SelectContent>
-                      <SelectGroup>
-                        {detectedUrls.map((url) => (
-                          <SelectItem key={url} value={url} className="text-xs">
-                            {url.replace('http://localhost:', 'port: ')}
-                          </SelectItem>
-                        ))}
-                      </SelectGroup>
-                    </SelectContent>
-                  </Select>
-                ) : (
-                  <Button
-                    variant="ghost"
-                    size="icon-sm"
-                    onClick={() => selectedUrl && window.electronAPI.openExternal(selectedUrl)}
-                    className="text-muted-foreground hover:text-foreground"
-                  >
-                    <ExternalLink className="h-3.5 w-3.5" />
-                  </Button>
-                )}
+                <span className="inline-flex items-center">
+                  {detectedUrls.length > 1 ? (
+                    <Select
+                      value={selectedUrl || ''}
+                      onValueChange={(value) => {
+                        setSelectedUrl(value);
+                        window.electronAPI.openExternal(value);
+                      }}
+                    >
+                      <SelectTrigger className="h-7 w-auto min-w-[40px] gap-2 border-none bg-transparent px-2 text-xs shadow-none hover:bg-accent">
+                        <Globe className="h-3.5 w-3.5" />
+                        <SelectValue placeholder="Open URL" />
+                      </SelectTrigger>
+                      <SelectContent>
+                        <SelectGroup>
+                          {detectedUrls.map((url) => (
+                            <SelectItem key={url} value={url} className="text-xs">
+                              {url.replace(/^https?:\/\/localhost:/, 'port: ')}
+                            </SelectItem>
+                          ))}
+                        </SelectGroup>
+                      </SelectContent>
+                    </Select>
+                  ) : (
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => selectedUrl && window.electronAPI.openExternal(selectedUrl)}
+                      className="text-muted-foreground hover:text-foreground"
+                    >
+                      <ExternalLink className="h-3.5 w-3.5" />
+                    </Button>
+                  )}
+                </span>
               </TooltipTrigger>
               <TooltipContent side="bottom">
                 <p className="text-xs">

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -622,6 +622,14 @@ declare global {
         branches?: Array<{ ref: string; remote: string; branch: string; label: string }>;
         error?: string;
       }>;
+      onHostPreviewEvent: (
+        listener: (data: {
+          type: 'url' | 'setup' | 'exit';
+          taskId: string;
+          url?: string;
+          status?: string;
+        }) => void
+      ) => () => void;
       openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
       clipboardWriteText: (text: string) => Promise<{ success: boolean; error?: string }>;
       paste: () => Promise<{ success: boolean; error?: string }>;

--- a/src/shared/urls.ts
+++ b/src/shared/urls.ts
@@ -1,2 +1,14 @@
 export const EMDASH_RELEASES_URL = 'https://github.com/generalaction/emdash/releases';
 export const EMDASH_DOCS_URL = 'https://docs.emdash.sh';
+export function normalizeUrl(u: string): string {
+  try {
+    const re = /(https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0|\[::1\]):\d{2,5}(?:\/\S*)?)/i;
+    const m = u.match(re);
+    if (!m) return '';
+    const url = new URL(m[1]);
+    url.hostname = 'localhost';
+    return url.toString();
+  } catch {
+    return '';
+  }
+}


### PR DESCRIPTION
- Added functionality to extract URLs from terminal output during the 'run' phase.
- Implemented a dropdown to select and open detected URLs in the browser.
- Introduced a  function to standardize URL formats.
- Updated electron API types to include  for URL handling.

## Summary

This PR adds a feature that allows users to quickly open detected localhost URLs (from running dev servers) directly in their system browser from the run terminal toolbar.

## Fixes 
 Fixes #1369  

## Snapshot
 
https://github.com/user-attachments/assets/618b883b-6add-418a-b102-2b1b31719354


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes