### PR TITLE
fix(pty): prevent session ID collision for non-worktree tasks

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -525,7 +525,7 @@ export function applySessionIsolation(
     return true;
   }
 
-  if (hasOtherSameProviderSessions(id, parsed.providerId, cwd)) {
+  if (isResume && hasOtherSameProviderSessions(id, parsed.providerId, cwd)) {
     // Main chat transitioning to multi-chat mode. Try to discover its
     // existing session from Claude's local storage and adopt it.
     const otherUuids = getOtherSessionUuids(id, parsed.providerId, cwd);


### PR DESCRIPTION
## Summary

Fixes "Session ID ... is already in use" error when creating a new task without a worktree.

New non-worktree tasks were entering the multi-chat session discovery branch, which scans `~/.claude/projects/` for existing `.jsonl` session files. If any of those files belonged to an active Claude process, the discovered UUID was passed via `--session-id` and Claude rejected it as already in use.

The fix gates that discovery branch on `isResume` so new tasks always get a fresh session UUID instead of trying to adopt one from disk.

## Screenshot

<img width="623" height="117" alt="Screenshot 2026-03-12 at 11 01 23" src="https://github.com/user-attachments/assets/c20fc2d1-ed1c-4b97-bfa9-02534d9f360f" />

## Type of change
- [x] Bug fix

## Checklist
- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run type-check`
- [x] `pnpm exec vitest run` (638 tests passing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)