### PR TITLE
fix(diff): improve sidebar deleted-file presentation

### DIFF
--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -515,19 +515,27 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
     return (
       <span className="flex min-w-0" title={p}>
         <span
-          className={`shrink-0 font-medium ${
-            isDeleted ? 'text-foreground line-through' : 'text-foreground'
-          }`}
+          className={['shrink-0 font-medium text-foreground', isDeleted ? 'line-through' : '']
+            .filter(Boolean)
+            .join(' ')}
         >
           {base}
         </span>
-        {dir && <span className="ml-1 truncate text-muted-foreground">{dir}</span>}
+        {dir && (
+          <span
+            className={['ml-1 truncate text-muted-foreground', isDeleted ? 'line-through' : '']
+              .filter(Boolean)
+              .join(' ')}
+          >
+            {dir}
+          </span>
+        )}
       </span>
     );
   };
 
   const shouldShowDiffPill = (value: number | null | undefined) =>
-    typeof value !== 'number' || value !== 0;
+    typeof value === 'number' && value !== 0;
 
   // Use PR diff changes when in PR review mode, otherwise use local file changes
   const displayChanges = isPrReview ? prDiffChanges : fileChanges;


### PR DESCRIPTION
summary:
- this PR updates the right sidebar file list in the diff panel to better distinguish deleted files from modified files.

changes:
- seleted files are displayed with a crossed-out filename
- deleted files no longer show +N/-N pills
- for non-deleted files, diff pills are only shown when the value is non-zero

This improves scanability and avoids noisy/ambiguous counters in the sidebar.


<img width="1160" height="222" alt="image" src="https://github.com/user-attachments/assets/6b19cdcd-f7ec-40cf-b02d-2aa8844bfe33" />

fixes #1444