### PR TITLE
fix(github): ensure local branch exists for fork PR checkout

### DIFF
--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -897,7 +897,7 @@ export class GitHubService {
         { cwd: projectPath }
       );
     } catch (fetchError) {
-      // Fallback: try gh pr checkout with detach to avoid working tree conflicts
+      // Fallback: use gh pr checkout to create/sync the local PR branch.
       console.warn(
         'Fetch-based PR branch creation failed, falling back to gh pr checkout:',
         fetchError
@@ -931,7 +931,7 @@ export class GitHubService {
           });
         }
       } catch (error) {
-        console.error('Failed to checkout pull request branch via gh:', error);
+        console.error('Failed during PR branch checkout or local-ref creation:', error);
         throw error;
       } finally {
         if (previousRef && previousRef !== safeBranch) {


### PR DESCRIPTION
summary:
- fix PR review worktree setup for forked PRs when direct fallback is needed
- remove --detach from fallback gh pr checkout
- after checkout explicitly verify refs/heads/<branch> exists
- If missing create the local branch ref from HEAD

this ensures downstream worktree creation can reliably use the expected local branch for fork PR review flows.