### PR TITLE
feat(docs): add llms.txt and llms-full.txt for AI discoverability

### DIFF
--- a/docs/app/llms-full.txt/route.ts
+++ b/docs/app/llms-full.txt/route.ts
@@ -1,0 +1,14 @@
+import { source } from '@/lib/source';
+import { getLLMText } from '@/lib/get-llm-text';
+
+export const revalidate = false;
+
+export async function GET() {
+  const pages = source.getPages();
+  const scanned = await Promise.all(pages.map(getLLMText));
+  return new Response(scanned.join('\n\n'), {
+    headers: {
+      'Content-Type': 'text/markdown',
+    },
+  });
+}

--- a/docs/app/llms.txt/route.ts
+++ b/docs/app/llms.txt/route.ts
@@ -1,0 +1,27 @@
+import { source } from '@/lib/source';
+
+export const revalidate = false;
+
+export function GET() {
+  const pages = source.getPages();
+  const lines: string[] = [];
+
+  for (const page of pages) {
+    const url = page.url;
+    const data = page.data as { title?: string; description?: string };
+    const title = data.title ?? 'Page';
+    const description = data.description ?? '';
+    lines.push(`## ${title}`);
+    if (description) {
+      lines.push(`> ${description}`);
+    }
+    lines.push(`- Source: ${url}\n`);
+  }
+
+  const result = lines.join('\n');
+  return new Response(result || '# No pages found', {
+    headers: {
+      'Content-Type': 'text/markdown',
+    },
+  });
+}

--- a/docs/lib/get-llm-text.ts
+++ b/docs/lib/get-llm-text.ts
@@ -1,0 +1,9 @@
+import { source } from '@/lib/source';
+import type { InferPageType } from 'fumadocs-core/source';
+
+type Page = InferPageType<typeof source>;
+
+export async function getLLMText(page: Page): Promise<string> {
+  const processed = await page.data.getText?.('processed');
+  return processed ?? '';
+}

--- a/docs/source.config.ts
+++ b/docs/source.config.ts
@@ -3,6 +3,11 @@ import lastModified from 'fumadocs-mdx/plugins/last-modified';
 
 export const docs = defineDocs({
   dir: 'content/docs',
+  docs: {
+    postprocess: {
+      includeProcessedMarkdown: true,
+    },
+  },
 });
 
 export default defineConfig({


### PR DESCRIPTION
## Summary

Add llms.txt and llms-full.txt endpoints to the emdash documentation to improve AI agent discoverability and context retrieval. This follows the industry standard for making documentation accessible to LLMs and AI coding agents.

## Fixes 
Fixes #1412 

## Snapshot
 <img width="1840" height="1062" alt="image" src="https://github.com/user-attachments/assets/bd17583f-d93a-441e-a9cd-7b16a32a2ef8" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have checked if new and existing unit tests pass locally with my changes