### PR TITLE
feat: add VS Code Insiders as a separate Open In app

### DIFF
--- a/src/shared/openInApps.ts
+++ b/src/shared/openInApps.ts
@@ -118,7 +118,6 @@ export const OPEN_IN_APPS: OpenInAppConfigShape[] = [
     label: 'VS Code Insiders',
     iconPath: ICON_PATHS.vscode,
     autoInstall: true,
-    supportsRemote: true,
     hideIfUnavailable: true,
     platforms: {
       darwin: {


### PR DESCRIPTION
## Summary
- Adds VS Code Insiders as its own entry in the "Open In" app list, reusing the existing VS Code icon
- Removes Insiders-specific references (`code-insiders` CLI, `com.microsoft.VSCodeInsiders` bundle ID) from the regular VS Code entry so they don't conflict
- Uses `hideIfUnavailable: true` so it only appears when VS Code Insiders is installed
- Supports all three platforms (macOS, Windows, Linux) with appropriate CLI commands and bundle IDs

## Test plan
- [ ] Verify VS Code Insiders appears in "Open In" list when installed
- [ ] Verify it does not appear when VS Code Insiders is not installed
- [ ] Verify regular VS Code entry still works independently
- [ ] Verify opening a worktree in VS Code Insiders works on macOS/Windows/Linux

🤖 Generated with [Claude Code](https://claude.com/claude-code)