### PR TITLE
feat(changelog): extract and display published date for changelog entries

### DIFF
--- a/src/main/services/ChangelogService.ts
+++ b/src/main/services/ChangelogService.ts
@@ -32,6 +32,58 @@ function firstString(...values: Array<unknown>): string | undefined {
   return undefined;
 }
 
+const MONTH_NAME_PATTERN =
+  '(?:Jan(?:uary)?|Feb(?:ruary)?|Mar(?:ch)?|Apr(?:il)?|May|Jun(?:e)?|Jul(?:y)?|Aug(?:ust)?|Sep(?:t(?:ember)?)?|Oct(?:ober)?|Nov(?:ember)?|Dec(?:ember)?)';
+const HUMAN_DATE_REGEX = new RegExp(`\\b(${MONTH_NAME_PATTERN}\\s+\\d{1,2},\\s+\\d{4})\\b`, 'i');
+const ISO_DATE_REGEX = /\b(\d{4}-\d{2}-\d{2}(?:[tT][0-9:.+-Z]*)?)\b/;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function extractPublishedAtFromText(value: string): string | undefined {
+  const normalized = stripTags(value).replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+
+  const humanDate = normalized.match(HUMAN_DATE_REGEX)?.[1];
+  if (humanDate) return humanDate;
+
+  const isoDate = normalized.match(ISO_DATE_REGEX)?.[1];
+  if (isoDate) return isoDate;
+
+  return undefined;
+}
+
+function extractPublishedAtForVersion(value: string, version?: string): string | undefined {
+  if (!version) return extractPublishedAtFromText(value);
+
+  const normalized = stripTags(value).replace(/\s+/g, ' ').trim();
+  if (!normalized) return undefined;
+
+  const escapedVersion = escapeRegex(version);
+  const leadingDate = normalized.match(
+    new RegExp(`(${MONTH_NAME_PATTERN}\\s+\\d{1,2},\\s+\\d{4})\\s+v?${escapedVersion}\\b`, 'i')
+  )?.[1];
+  if (leadingDate) return leadingDate;
+
+  const trailingDate = normalized.match(
+    new RegExp(`v?${escapedVersion}\\b\\s+(${MONTH_NAME_PATTERN}\\s+\\d{1,2},\\s+\\d{4})`, 'i')
+  )?.[1];
+  if (trailingDate) return trailingDate;
+
+  const leadingIsoDate = normalized.match(
+    new RegExp(`(\\d{4}-\\d{2}-\\d{2}(?:[tT][0-9:.+-Z]*)?)\\s+v?${escapedVersion}\\b`, 'i')
+  )?.[1];
+  if (leadingIsoDate) return leadingIsoDate;
+
+  const trailingIsoDate = normalized.match(
+    new RegExp(`v?${escapedVersion}\\b\\s+(\\d{4}-\\d{2}-\\d{2}(?:[tT][0-9:.+-Z]*)?)`, 'i')
+  )?.[1];
+  if (trailingIsoDate) return trailingIsoDate;
+
+  return undefined;
+}
+
 function decodeHtmlEntities(input: string): string {
   return input
     .replace(/&nbsp;/gi, ' ')
@@ -237,6 +289,15 @@ async function fetchJson(url: string): Promise<unknown | null> {
   return response.json();
 }
 
+async function fetchHtml(url: string): Promise<string | null> {
+  const response = await fetch(url, {
+    headers: { Accept: 'text/html,application/xhtml+xml', 'Cache-Control': 'no-cache' },
+  });
+
+  if (!response.ok) return null;
+  return response.text();
+}
+
 function extractTime(block: string): string | undefined {
   const datetime = block.match(/<time\b[^>]*datetime=(["'])(.*?)\1/i)?.[2];
   if (datetime?.trim()) return datetime.trim();
@@ -258,6 +319,18 @@ function extractSummary(block: string): string | undefined {
   return summary || undefined;
 }
 
+function withResolvedHtmlPublishedAt(
+  entry: ChangelogEntry | null,
+  html: string,
+  requestedVersion?: string
+): ChangelogEntry | null {
+  if (!entry) return null;
+  if (entry.publishedAt) return entry;
+
+  const publishedAt = extractPublishedAtForVersion(html, requestedVersion ?? entry.version);
+  return publishedAt ? { ...entry, publishedAt } : entry;
+}
+
 export function parseChangelogHtml(html: string, requestedVersion?: string): ChangelogEntry | null {
   const blocks = html.match(/<(article|section)\b[\s\S]*?<\/\1>/gi) ?? [];
   const candidates: ChangelogEntry[] = [];
@@ -277,7 +350,7 @@ export function parseChangelogHtml(html: string, requestedVersion?: string): Cha
         title: extractTitle(block),
         summary: extractSummary(block),
         contentHtml: block,
-        publishedAt: extractTime(block),
+        publishedAt: extractTime(block) ?? extractPublishedAtForVersion(block, versionFromBlock),
       },
       requestedVersion
     );
@@ -288,24 +361,46 @@ export function parseChangelogHtml(html: string, requestedVersion?: string): Cha
   }
 
   if (candidates.length > 0) {
-    return pickBestCandidate(candidates, requestedVersion);
+    return withResolvedHtmlPublishedAt(
+      pickBestCandidate(candidates, requestedVersion),
+      html,
+      requestedVersion
+    );
   }
 
-  const fallback = normalizeEntry(
-    {
-      version: normalizeChangelogVersion(requestedVersion) ?? undefined,
-      title: extractTitle(html),
-      summary: extractSummary(html),
-      contentHtml: html,
-      publishedAt: extractTime(html),
-    },
+  return withResolvedHtmlPublishedAt(
+    normalizeEntry(
+      {
+        version: normalizeChangelogVersion(requestedVersion) ?? undefined,
+        title: extractTitle(html),
+        summary: extractSummary(html),
+        contentHtml: html,
+        publishedAt:
+          extractTime(html) ??
+          extractPublishedAtForVersion(
+            html,
+            normalizeChangelogVersion(requestedVersion) ?? undefined
+          ),
+      },
+      requestedVersion
+    ),
+    html,
     requestedVersion
   );
-
-  return fallback;
 }
 
 class ChangelogService {
+  private async getHtmlEntry(requestedVersion?: string): Promise<ChangelogEntry | null> {
+    try {
+      const html = await fetchHtml(EMDASH_CHANGELOG_URL);
+      if (!html) return null;
+      return parseChangelogHtml(html, requestedVersion);
+    } catch (error) {
+      log.error('Failed to fetch changelog HTML', error);
+      return null;
+    }
+  }
+
   async getLatestEntry(requestedVersion?: string): Promise<ChangelogEntry | null> {
     const version = normalizeChangelogVersion(requestedVersion);
     const apiUrls = [
@@ -326,23 +421,24 @@ class ChangelogService {
           .map((candidate) => normalizeEntry(candidate, version ?? undefined))
           .filter((candidate): candidate is ChangelogEntry => candidate !== null);
         const match = pickBestCandidate(entries, version ?? undefined);
-        if (match) return match;
+        if (match) {
+          if (match.publishedAt) return match;
+
+          const htmlEntry = await this.getHtmlEntry(match.version);
+          if (!htmlEntry) return match;
+
+          return {
+            ...match,
+            publishedAt: htmlEntry.publishedAt ?? match.publishedAt,
+            url: match.url ?? htmlEntry.url,
+          };
+        }
       } catch (error) {
         log.debug('Changelog JSON fetch failed', { url, error });
       }
     }
 
-    try {
-      const response = await fetch(EMDASH_CHANGELOG_URL, {
-        headers: { Accept: 'text/html,application/xhtml+xml', 'Cache-Control': 'no-cache' },
-      });
-      if (!response.ok) return null;
-      const html = await response.text();
-      return parseChangelogHtml(html, version ?? undefined);
-    } catch (error) {
-      log.error('Failed to fetch changelog HTML', error);
-      return null;
-    }
+    return this.getHtmlEntry(version ?? undefined);
   }
 }
 

--- a/src/renderer/components/ChangelogModal.tsx
+++ b/src/renderer/components/ChangelogModal.tsx
@@ -1,6 +1,8 @@
+import { Badge } from '@/components/ui/badge';
 import { BaseModalProps } from '@/contexts/ModalProvider';
 import { MarkdownRenderer } from '@/components/ui/markdown-renderer';
 import { DialogContent } from '@/components/ui/dialog';
+import { formatChangelogPublishedAt } from '@/lib/changelogDate';
 import { EMDASH_CHANGELOG_URL, type ChangelogEntry } from '@shared/changelog';
 import { ExternalLink } from 'lucide-react';
 
@@ -10,18 +12,6 @@ interface ChangelogModalProps {
 
 export function ChangelogModalOverlay({ entry }: BaseModalProps<void> & ChangelogModalProps) {
   return <ChangelogModal entry={entry} />;
-}
-
-function formatPublishedAt(value?: string): string | null {
-  if (!value) return null;
-  const parsed = new Date(value);
-  if (Number.isNaN(parsed.getTime())) return value;
-
-  return new Intl.DateTimeFormat('en-US', {
-    month: 'short',
-    day: '2-digit',
-    year: 'numeric',
-  }).format(parsed);
 }
 
 function normalizeLeadLine(value: string): string {
@@ -66,7 +56,7 @@ function stripLeadingReleaseHeadings(content: string, entry: ChangelogEntry): st
 }
 
 function ChangelogModal({ entry }: ChangelogModalProps): JSX.Element {
-  const publishedAt = formatPublishedAt(entry.publishedAt);
+  const publishedAt = formatChangelogPublishedAt(entry.publishedAt);
   const content = stripLeadingReleaseHeadings(entry.content, entry);
 
   return (
@@ -83,9 +73,11 @@ function ChangelogModal({ entry }: ChangelogModalProps): JSX.Element {
 
       <div className="max-h-[min(75vh,44rem)] overflow-y-auto px-6 py-5">
         {publishedAt && (
-          <p className="text-xs font-medium uppercase tracking-[0.18em] text-muted-foreground">
-            {publishedAt}
-          </p>
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            <Badge variant="outline" className="h-5 px-2 text-[11px] font-medium">
+              {publishedAt}
+            </Badge>
+          </div>
         )}
         <h2 className="mt-3 text-2xl font-semibold tracking-tight text-foreground">
           {entry.title}

--- a/src/renderer/components/sidebar/ChangelogNotificationCard.tsx
+++ b/src/renderer/components/sidebar/ChangelogNotificationCard.tsx
@@ -1,3 +1,5 @@
+import { Badge } from '@/components/ui/badge';
+import { formatChangelogPublishedAt } from '@/lib/changelogDate';
 import { cn } from '@/lib/utils';
 import { motion } from 'framer-motion';
 import type { ChangelogEntry } from '@shared/changelog';
@@ -16,6 +18,8 @@ export function ChangelogNotificationCard({
   onDismiss,
   className,
 }: ChangelogNotificationCardProps) {
+  const publishedAt = formatChangelogPublishedAt(entry.publishedAt);
+
   return (
     <motion.div
       whileTap={{ scale: 0.97 }}
@@ -30,6 +34,11 @@ export function ChangelogNotificationCard({
         className="flex w-full flex-col gap-3 rounded-xl px-3 py-3 text-left transition-colors hover:bg-accent/30"
       >
         <div className="pr-8">
+          {publishedAt && (
+            <Badge variant="outline" className="mb-2 h-5 px-2 text-[11px] font-medium">
+              {publishedAt}
+            </Badge>
+          )}
           <h3 className="line-clamp-2 text-sm font-semibold leading-5 text-foreground">
             {entry.title}
           </h3>

--- a/src/renderer/lib/changelogDate.ts
+++ b/src/renderer/lib/changelogDate.ts
@@ -1,0 +1,12 @@
+export function formatChangelogPublishedAt(value?: string): string | null {
+  if (!value) return null;
+
+  const parsed = new Date(value);
+  if (Number.isNaN(parsed.getTime())) return value;
+
+  return new Intl.DateTimeFormat('en-US', {
+    month: 'short',
+    day: '2-digit',
+    year: 'numeric',
+  }).format(parsed);
+}

--- a/src/test/main/ChangelogService.test.ts
+++ b/src/test/main/ChangelogService.test.ts
@@ -62,4 +62,40 @@ describe('parseChangelogHtml', () => {
     expect(entry?.content).toContain('## Sidebar card');
     expect(entry?.content).toContain('- Dismiss per version');
   });
+
+  it('infers the published date from rendered content when no time tag exists', () => {
+    const htmlWithoutTime = `
+      <main>
+        <article data-version="0.4.32">
+          <h2>March 13, 2026 v0.4.32</h2>
+          <p>Added a changelog card in the sidebar.</p>
+        </article>
+      </main>
+    `;
+
+    const entry = parseChangelogHtml(htmlWithoutTime, '0.4.32');
+
+    expect(entry?.version).toBe('0.4.32');
+    expect(entry?.publishedAt).toBe('March 13, 2026');
+  });
+
+  it('does not assign another release date when the requested version has no matching date text', () => {
+    const htmlWithOtherDate = `
+      <main>
+        <article data-version="0.4.31">
+          <h2>March 12, 2026 v0.4.31</h2>
+          <p>Previous release.</p>
+        </article>
+        <article data-version="0.4.32">
+          <h2>What&apos;s new in Emdash v0.4.32</h2>
+          <p>Current release.</p>
+        </article>
+      </main>
+    `;
+
+    const entry = parseChangelogHtml(htmlWithOtherDate, '0.4.32');
+
+    expect(entry?.version).toBe('0.4.32');
+    expect(entry?.publishedAt).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

- Extract published dates from changelog HTML when no `<time>` tag is present, supporting both human-readable (e.g. "March 13, 2026") and ISO date formats adjacent to version strings
- When JSON API responses lack `publishedAt`, fall back to HTML scraping to resolve the date
- Display the published date as a `Badge` in both the changelog modal and sidebar notification card
- Extract shared `formatChangelogPublishedAt` helper into `src/renderer/lib/changelogDate.ts` for reuse

## Changes

- **`ChangelogService.ts`** — Added regex-based date extraction (`extractPublishedAtForVersion`, `extractPublishedAtFromText`), `fetchHtml` helper, and `withResolvedHtmlPublishedAt` fallback. JSON-sourced entries now attempt HTML enrichment when `publishedAt` is missing.
- **`ChangelogModal.tsx`** — Replaced inline `formatPublishedAt` with shared helper; renders date in a `Badge` component
- **`ChangelogNotificationCard.tsx`** — Added published date display as a `Badge` above the title
- **`changelogDate.ts`** — New shared date formatting utility extracted from the modal
- **`ChangelogService.test.ts`** — Added tests for date inference from rendered content and for avoiding incorrect cross-version date assignment

## Test plan

- [ ] Verify `pnpm exec vitest run` passes, including the two new `parseChangelogHtml` tests
- [ ] Confirm the changelog modal shows a date badge for releases with and without `<time>` tags
- [ ] Confirm the sidebar notification card shows the published date badge
- [ ] Verify releases without any discoverable date do not show a badge