### PR TITLE
fix(pty): resolve tmux to absolute path before spawning

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -169,15 +169,23 @@ export function getTmuxSessionName(ptyId: string): string {
   return `emdash-${sanitized}`;
 }
 
+function resolveTmuxPath(): string | null {
+  return resolveCommandPathCached('tmux');
+}
+
 /**
  * Kill a tmux session by PTY ID. Fire-and-forget — ignores errors
  * for non-existent sessions (e.g., tmux not installed or session already dead).
  */
 export function killTmuxSession(ptyId: string): void {
   const sessionName = getTmuxSessionName(ptyId);
+  const tmuxPath = resolveTmuxPath();
+  if (!tmuxPath) {
+    return;
+  }
   try {
     const { execFile } = require('child_process');
-    execFile('tmux', ['kill-session', '-t', sessionName], { timeout: 5000 }, (err: any) => {
+    execFile(tmuxPath, ['kill-session', '-t', sessionName], { timeout: 5000 }, (err: any) => {
       if (!err) {
         log.info('ptyManager:tmux - killed session', { sessionName });
       }
@@ -1463,21 +1471,15 @@ export async function startPty(options: {
   let spawnArgs = args;
 
   if (tmux && process.platform !== 'win32') {
-    let tmuxAvailable = false;
-    try {
-      const { execFileSync } = require('child_process');
-      execFileSync('tmux', ['-V'], { timeout: 3000, stdio: 'ignore' });
-      tmuxAvailable = true;
-    } catch {
+    const tmuxPath = resolveTmuxPath();
+    if (!tmuxPath) {
       log.warn('ptyManager:tmux - tmux not found, falling back to unwrapped spawn', { id });
-    }
-
-    if (tmuxAvailable) {
+    } else {
       tmuxSessionName = getTmuxSessionName(id);
       // Build: tmux new-session -As <name> -- <shell> <args...>
-      spawnCommand = 'tmux';
+      spawnCommand = tmuxPath;
       spawnArgs = ['new-session', '-As', tmuxSessionName, '--', useShell, ...args];
-      log.info('ptyManager:tmux - wrapping in tmux session', { id, tmuxSessionName });
+      log.info('ptyManager:tmux - wrapping in tmux session', { id, tmuxSessionName, tmuxPath });
     }
   }
 

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -11,6 +11,7 @@ const fsAccessSyncMock = vi.fn();
 const fsReaddirSyncMock = vi.fn();
 const agentEventGetPortMock = vi.fn(() => 0);
 const agentEventGetTokenMock = vi.fn(() => '');
+const nodePtySpawnMock = vi.fn();
 
 vi.mock('../../main/services/providerStatusCache', () => ({
   providerStatusCache: {
@@ -58,6 +59,10 @@ vi.mock('electron', () => ({
   },
 }));
 
+vi.mock('node-pty', () => ({
+  spawn: (...args: any[]) => nodePtySpawnMock(...args),
+}));
+
 vi.mock('../../main/services/AgentEventService', () => ({
   agentEventService: {
     getPort: () => agentEventGetPortMock(),
@@ -78,6 +83,10 @@ describe('ptyManager provider command resolution', () => {
     agentEventGetTokenMock.mockReturnValue('');
     fsMkdirSyncMock.mockImplementation(() => undefined);
     fsWriteFileSyncMock.mockImplementation(() => undefined);
+    fsStatSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    fsAccessSyncMock.mockImplementation(() => undefined);
   });
 
   it('resolves provider command config from custom settings', async () => {
@@ -318,6 +327,42 @@ describe('ptyManager provider command resolution', () => {
 
     expect(env.OPENCODE_CONFIG_DIR).toBeUndefined();
     expect(fsWriteFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('spawns tmux using its absolute path when tmux wrapping is enabled', async () => {
+    fsStatSyncMock.mockImplementation((candidate: string) => {
+      if (candidate === '/opt/homebrew/bin/tmux') {
+        return { isFile: () => true };
+      }
+      throw new Error('ENOENT');
+    });
+    const mockProc = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+    };
+    nodePtySpawnMock.mockReturnValue(mockProc);
+
+    const { startPty, getTmuxSessionName } = await import('../../main/services/ptyManager');
+    await startPty({
+      id: 'claude-main-task-tmux',
+      cwd: '/tmp/task',
+      shell: '/bin/zsh',
+      tmux: true,
+    });
+
+    expect(nodePtySpawnMock).toHaveBeenCalledWith(
+      '/opt/homebrew/bin/tmux',
+      ['new-session', '-As', getTmuxSessionName('claude-main-task-tmux'), '--', '/bin/zsh', '-il'],
+      expect.objectContaining({
+        cwd: '/tmp/task',
+        env: expect.not.objectContaining({
+          PATH: expect.anything(),
+        }),
+      })
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- Replaces `execFileSync('tmux', ['-V'])` version check with cached `resolveCommandPathCached('tmux')` lookup, reusing the existing PATH resolution infrastructure
- Uses the resolved absolute path when spawning tmux sessions (`startPty`) and killing them (`killTmuxSession`), avoiding issues where `tmux` isn't found on PATH in packaged Electron environments
- Extracts `resolveTmuxPath()` helper for consistent reuse across both call sites

## Test plan
- Added test verifying tmux is spawned using its resolved absolute path (`/opt/homebrew/bin/tmux`) when tmux wrapping is enabled
- Added `node-pty` mock and `fsStatSync`/`fsAccessSync` stubs to support the new test
- Existing tmux and PTY tests continue to pass