### PR TITLE
fix(pty): fix tmux absolute-path test to pass in CI

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1349,10 +1349,9 @@ export async function startPty(options: {
   }
 
   // Lazy load native module at call time to prevent startup crashes
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
   let pty: typeof import('node-pty');
   try {
-    pty = require('node-pty');
+    pty = await import('node-pty');
   } catch (e: any) {
     throw new Error(`PTY unavailable: ${e?.message || String(e)}`);
   }

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -330,6 +330,9 @@ describe('ptyManager provider command resolution', () => {
   });
 
   it('spawns tmux using its absolute path when tmux wrapping is enabled', async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = `/opt/homebrew/bin${origPath ? ':' + origPath : ''}`;
+
     fsStatSyncMock.mockImplementation((candidate: string) => {
       if (candidate === '/opt/homebrew/bin/tmux') {
         return { isFile: () => true };
@@ -352,6 +355,8 @@ describe('ptyManager provider command resolution', () => {
       shell: '/bin/zsh',
       tmux: true,
     });
+
+    process.env.PATH = origPath;
 
     expect(nodePtySpawnMock).toHaveBeenCalledWith(
       '/opt/homebrew/bin/tmux',


### PR DESCRIPTION
## Summary
- Adds `process.env.PATH` setup in the tmux spawn test so `resolveCommandPath('tmux')` finds the mocked `/opt/homebrew/bin/tmux` binary
- Changes `require('node-pty')` to `await import('node-pty')` in `startPty` so vitest can intercept the mock (vitest does not intercept CJS `require()` calls)
- Preserves all tmux resolution logic from #1470 — only fixes the test that was silently broken

## Test plan
- [x] `pnpm exec vitest run` — all 655 tests pass (including the previously failing tmux test)
- [x] `pnpm run type-check` — clean
- [x] `pnpm run lint` — no new warnings
- [x] `pnpm run format` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)