### PR TITLE
fix(update): improve update error state wording and styling

### DIFF
--- a/src/renderer/components/UpdateCard.tsx
+++ b/src/renderer/components/UpdateCard.tsx
@@ -168,10 +168,10 @@ export function UpdateCard(): JSX.Element {
         return (
           <Badge
             variant="outline"
-            className="border-amber-200 bg-amber-50 text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400"
+            className="border-border/60 bg-transparent text-muted-foreground"
           >
             <AlertCircle className="h-3 w-3" />
-            Update temporarily unavailable — please try again later
+            A new release is being prepared right now. Check again in a few minutes.
           </Badge>
         );
 


### PR DESCRIPTION
## Summary

- Updated the update error state message from "Update temporarily unavailable — please try again later" to "A new release is being prepared right now. Check again in a few minutes." for a friendlier, more informative tone
- Changed the error badge styling from amber/warning colors to neutral muted colors (`border-border/60 bg-transparent text-muted-foreground`) to reduce alarm since this is a transient state