### PR TITLE
fix: sync GitHub owner/repo from git remote on project select (#1402)

### DIFF
--- a/src/renderer/components/UpdateCard.tsx
+++ b/src/renderer/components/UpdateCard.tsx
@@ -170,8 +170,8 @@ export function UpdateCard(): JSX.Element {
             variant="outline"
             className="border-border/60 bg-transparent text-muted-foreground"
           >
-            <AlertCircle className="h-3 w-3" />
-            A new release is being prepared right now. Check again in a few minutes.
+            <AlertCircle className="h-3 w-3" />A new release is being prepared right now. Check
+            again in a few minutes.
           </Badge>
         );
 

--- a/src/renderer/hooks/useProjectManagement.tsx
+++ b/src/renderer/hooks/useProjectManagement.tsx
@@ -7,7 +7,7 @@ import {
   computeBaseRef,
   getProjectRepoKey,
   normalizePathForComparison,
-  resolveOwnerRepo,
+  parseGithubOwnerRepo,
   resolveProjectGithubInfo,
   withRepoKey,
 } from '../lib/projectUtils';
@@ -582,21 +582,32 @@ export const useProjectManagement = () => {
   useEffect(() => {
     if (!selectedProject || selectedProject.isRemote || !isAuthenticated) return;
 
+    const originProjectId = selectedProject.id;
+
     void (async () => {
       try {
         const gitInfo = await window.electronAPI.getGitInfo(selectedProject.path);
-        const ownerRepo = await resolveOwnerRepo(
-          gitInfo.remote || '',
-          selectedProject.path,
-          window.electronAPI.connectToGitHub
-        );
+        let ownerRepo = parseGithubOwnerRepo(gitInfo.remote || '');
+        let verifiedConnected = false;
+        if (!ownerRepo) {
+          const result = await window.electronAPI.connectToGitHub(selectedProject.path);
+          if (result.success && result.repository) {
+            ownerRepo = result.repository;
+            verifiedConnected = true;
+          }
+        }
+        if (activeProjectIdRef.current !== originProjectId) return;
         if (!ownerRepo || ownerRepo === selectedProject.githubInfo?.repository) return;
 
         const updatedProject: Project = {
           ...selectedProject,
-          githubInfo: { repository: ownerRepo, connected: true },
+          githubInfo: {
+            repository: ownerRepo,
+            connected: selectedProject.githubInfo?.connected ?? verifiedConnected,
+          },
         };
         await rpc.db.saveProject(updatedProject);
+        if (activeProjectIdRef.current !== originProjectId) return;
         setSelectedProject(updatedProject);
         queryClient.invalidateQueries({ queryKey: ['projects'] });
       } catch {

--- a/src/renderer/hooks/useProjectManagement.tsx
+++ b/src/renderer/hooks/useProjectManagement.tsx
@@ -7,6 +7,7 @@ import {
   computeBaseRef,
   getProjectRepoKey,
   normalizePathForComparison,
+  resolveOwnerRepo,
   resolveProjectGithubInfo,
   withRepoKey,
 } from '../lib/projectUtils';
@@ -576,6 +577,34 @@ export const useProjectManagement = () => {
       }
     }
   }, [selectedProject]);
+
+  // Re-sync GitHub owner/repo from the current git remote on project select (#1402).
+  useEffect(() => {
+    if (!selectedProject || selectedProject.isRemote || !isAuthenticated) return;
+
+    void (async () => {
+      try {
+        const gitInfo = await window.electronAPI.getGitInfo(selectedProject.path);
+        const ownerRepo = await resolveOwnerRepo(
+          gitInfo.remote || '',
+          selectedProject.path,
+          window.electronAPI.connectToGitHub
+        );
+        if (!ownerRepo || ownerRepo === selectedProject.githubInfo?.repository) return;
+
+        const updatedProject: Project = {
+          ...selectedProject,
+          githubInfo: { repository: ownerRepo, connected: true },
+        };
+        await rpc.db.saveProject(updatedProject);
+        setSelectedProject(updatedProject);
+        queryClient.invalidateQueries({ queryKey: ['projects'] });
+      } catch {
+        // best effort
+      }
+    })();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedProject?.id, isAuthenticated]);
 
   // Initial load when project changes
   useEffect(() => {

--- a/src/renderer/lib/projectUtils.ts
+++ b/src/renderer/lib/projectUtils.ts
@@ -96,6 +96,37 @@ export function withRepoKey(project: Project, platform?: string): Project {
 }
 
 /**
+ * Parses the GitHub owner/repo slug from a git remote URL.
+ * Handles both HTTPS and SSH formats:
+ *   https://github.com/owner/repo.git  →  "owner/repo"
+ *   git@github.com:owner/repo.git      →  "owner/repo"
+ * Returns null if the URL is not a GitHub remote.
+ */
+export function parseGithubOwnerRepo(remoteUrl: string): string | null {
+  if (!remoteUrl) return null;
+  const match = remoteUrl.match(/github\.com[/:]([^/]+\/[^/.]+?)(?:\.git)?(?:[/?#].*)?$/i);
+  return match ? match[1] : null;
+}
+
+/**
+ * Resolves the GitHub owner/repo for a project.
+ * Primary: parses directly from the git remote URL.
+ * Fallback: calls connectToGitHub (gh repo view) when URL parsing fails,
+ * which resolves the official GitHub repo (e.g. non-standard remote format).
+ */
+export async function resolveOwnerRepo(
+  remoteUrl: string,
+  projectPath: string,
+  connectToGitHub: (path: string) => Promise<{ success: boolean; repository?: string }>
+): Promise<string | null> {
+  const ownerRepo = parseGithubOwnerRepo(remoteUrl);
+  if (ownerRepo) return ownerRepo;
+
+  const result = await connectToGitHub(projectPath);
+  return result.success && result.repository ? result.repository : null;
+}
+
+/**
  * Determines the GitHub connection info for a project being added.
  * Returns connected: true only when the user is authenticated, the remote
  * is a GitHub URL, and connectToGitHub succeeds. Otherwise falls through

--- a/src/renderer/lib/projectUtils.ts
+++ b/src/renderer/lib/projectUtils.ts
@@ -109,24 +109,6 @@ export function parseGithubOwnerRepo(remoteUrl: string): string | null {
 }
 
 /**
- * Resolves the GitHub owner/repo for a project.
- * Primary: parses directly from the git remote URL.
- * Fallback: calls connectToGitHub (gh repo view) when URL parsing fails,
- * which resolves the official GitHub repo (e.g. non-standard remote format).
- */
-export async function resolveOwnerRepo(
-  remoteUrl: string,
-  projectPath: string,
-  connectToGitHub: (path: string) => Promise<{ success: boolean; repository?: string }>
-): Promise<string | null> {
-  const ownerRepo = parseGithubOwnerRepo(remoteUrl);
-  if (ownerRepo) return ownerRepo;
-
-  const result = await connectToGitHub(projectPath);
-  return result.success && result.repository ? result.repository : null;
-}
-
-/**
  * Determines the GitHub connection info for a project being added.
  * Returns connected: true only when the user is authenticated, the remote
  * is a GitHub URL, and connectToGitHub succeeds. Otherwise falls through

--- a/src/test/renderer/useProjectManagement.test.ts
+++ b/src/test/renderer/useProjectManagement.test.ts
@@ -1,5 +1,69 @@
 import { describe, expect, it, vi } from 'vitest';
-import { resolveProjectGithubInfo } from '../../renderer/lib/projectUtils';
+import {
+  parseGithubOwnerRepo,
+  resolveOwnerRepo,
+  resolveProjectGithubInfo,
+} from '../../renderer/lib/projectUtils';
+
+describe('parseGithubOwnerRepo', () => {
+  it('parses HTTPS remote', () => {
+    expect(parseGithubOwnerRepo('https://github.com/myuser/myrepo.git')).toBe('myuser/myrepo');
+  });
+
+  it('parses SSH remote', () => {
+    expect(parseGithubOwnerRepo('git@github.com:myuser/myrepo.git')).toBe('myuser/myrepo');
+  });
+
+  it('parses remote without .git suffix', () => {
+    expect(parseGithubOwnerRepo('https://github.com/owner/repo')).toBe('owner/repo');
+  });
+
+  it('returns null for non-GitHub remotes', () => {
+    expect(parseGithubOwnerRepo('https://gitlab.com/owner/repo.git')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(parseGithubOwnerRepo('')).toBeNull();
+  });
+});
+
+describe('resolveOwnerRepo', () => {
+  const projectPath = '/path/to/project';
+
+  it('returns parsed owner/repo when remote is a valid GitHub URL', async () => {
+    const connectToGitHub = vi.fn();
+    const result = await resolveOwnerRepo(
+      'https://github.com/owner/repo.git',
+      projectPath,
+      connectToGitHub
+    );
+    expect(result).toBe('owner/repo');
+    expect(connectToGitHub).not.toHaveBeenCalled();
+  });
+
+  it('falls back to connectToGitHub when URL parsing fails', async () => {
+    const connectToGitHub = vi
+      .fn()
+      .mockResolvedValue({ success: true, repository: 'generalaction/emdash' });
+    const result = await resolveOwnerRepo(
+      'https://gitlab.com/owner/repo.git',
+      projectPath,
+      connectToGitHub
+    );
+    expect(connectToGitHub).toHaveBeenCalledWith(projectPath);
+    expect(result).toBe('generalaction/emdash');
+  });
+
+  it('returns null when both URL parsing and connectToGitHub fail', async () => {
+    const connectToGitHub = vi.fn().mockResolvedValue({ success: false });
+    const result = await resolveOwnerRepo(
+      'https://gitlab.com/owner/repo.git',
+      projectPath,
+      connectToGitHub
+    );
+    expect(result).toBeNull();
+  });
+});
 
 describe('resolveProjectGithubInfo', () => {
   const projectPath = '/path/to/project';

--- a/src/test/renderer/useProjectManagement.test.ts
+++ b/src/test/renderer/useProjectManagement.test.ts
@@ -1,9 +1,119 @@
 import { describe, expect, it, vi } from 'vitest';
-import {
-  parseGithubOwnerRepo,
-  resolveOwnerRepo,
-  resolveProjectGithubInfo,
-} from '../../renderer/lib/projectUtils';
+import { parseGithubOwnerRepo, resolveProjectGithubInfo } from '../../renderer/lib/projectUtils';
+
+// ---------------------------------------------------------------------------
+// Staleness guard simulation
+// Mirrors the logic in the useEffect in useProjectManagement that re-syncs
+// githubInfo.repository on project selection.
+// ---------------------------------------------------------------------------
+async function syncGithubOwnerRepo({
+  activeProjectIdRef,
+  originProjectId,
+  getGitInfo,
+  connectToGitHub,
+  currentRepository,
+  saveProject,
+  setSelectedProject,
+}: {
+  activeProjectIdRef: { current: string | null };
+  originProjectId: string;
+  getGitInfo: () => Promise<{ remote: string }>;
+  connectToGitHub: () => Promise<{ success: boolean; repository?: string }>;
+  currentRepository: string | undefined;
+  saveProject: (repo: string) => Promise<void>;
+  setSelectedProject: (repo: string) => void;
+}) {
+  const gitInfo = await getGitInfo();
+  let ownerRepo = parseGithubOwnerRepo(gitInfo.remote || '');
+  if (!ownerRepo) {
+    const result = await connectToGitHub();
+    if (result.success && result.repository) ownerRepo = result.repository;
+  }
+  if (activeProjectIdRef.current !== originProjectId) return;
+  if (!ownerRepo || ownerRepo === currentRepository) return;
+  await saveProject(ownerRepo);
+  if (activeProjectIdRef.current !== originProjectId) return;
+  setSelectedProject(ownerRepo);
+}
+
+describe('syncGithubOwnerRepo staleness guard', () => {
+  it('updates project when owner/repo changes and project is still active', async () => {
+    const activeProjectIdRef = { current: 'project-a' };
+    const saveProject = vi.fn().mockResolvedValue(undefined);
+    const setSelectedProject = vi.fn();
+
+    await syncGithubOwnerRepo({
+      activeProjectIdRef,
+      originProjectId: 'project-a',
+      getGitInfo: vi.fn().mockResolvedValue({ remote: 'https://github.com/owner/new-repo.git' }),
+      connectToGitHub: vi.fn(),
+      currentRepository: 'owner/old-repo',
+      saveProject,
+      setSelectedProject,
+    });
+
+    expect(saveProject).toHaveBeenCalledWith('owner/new-repo');
+    expect(setSelectedProject).toHaveBeenCalledWith('owner/new-repo');
+  });
+
+  it('does not update state when project switches before getGitInfo resolves', async () => {
+    const activeProjectIdRef = { current: 'project-a' };
+    const saveProject = vi.fn();
+    const setSelectedProject = vi.fn();
+
+    await syncGithubOwnerRepo({
+      activeProjectIdRef,
+      originProjectId: 'project-b', // stale — user already switched away from B
+      getGitInfo: vi.fn().mockResolvedValue({ remote: 'https://github.com/owner/repo.git' }),
+      connectToGitHub: vi.fn(),
+      currentRepository: undefined,
+      saveProject,
+      setSelectedProject,
+    });
+
+    expect(saveProject).not.toHaveBeenCalled();
+    expect(setSelectedProject).not.toHaveBeenCalled();
+  });
+
+  it('does not call setSelectedProject when project switches between saveProject and state update', async () => {
+    const activeProjectIdRef = { current: 'project-a' };
+    const setSelectedProject = vi.fn();
+
+    await syncGithubOwnerRepo({
+      activeProjectIdRef,
+      originProjectId: 'project-a',
+      getGitInfo: vi.fn().mockResolvedValue({ remote: 'https://github.com/owner/repo.git' }),
+      connectToGitHub: vi.fn(),
+      currentRepository: 'owner/old-repo',
+      saveProject: vi.fn().mockImplementation(async () => {
+        // Simulate project switch happening during DB save
+        activeProjectIdRef.current = 'project-b';
+      }),
+      setSelectedProject,
+    });
+
+    expect(setSelectedProject).not.toHaveBeenCalled();
+  });
+
+  it('skips update when resolved owner/repo matches stored value', async () => {
+    const activeProjectIdRef = { current: 'project-a' };
+    const saveProject = vi.fn();
+    const setSelectedProject = vi.fn();
+
+    await syncGithubOwnerRepo({
+      activeProjectIdRef,
+      originProjectId: 'project-a',
+      getGitInfo: vi.fn().mockResolvedValue({ remote: 'https://github.com/owner/repo.git' }),
+      connectToGitHub: vi.fn(),
+      currentRepository: 'owner/repo', // already up to date
+      saveProject,
+      setSelectedProject,
+    });
+
+    expect(saveProject).not.toHaveBeenCalled();
+    expect(setSelectedProject).not.toHaveBeenCalled();
+  });
+});
 
 describe('parseGithubOwnerRepo', () => {
   it('parses HTTPS remote', () => {
@@ -24,44 +134,6 @@ describe('parseGithubOwnerRepo', () => {
 
   it('returns null for empty string', () => {
     expect(parseGithubOwnerRepo('')).toBeNull();
-  });
-});
-
-describe('resolveOwnerRepo', () => {
-  const projectPath = '/path/to/project';
-
-  it('returns parsed owner/repo when remote is a valid GitHub URL', async () => {
-    const connectToGitHub = vi.fn();
-    const result = await resolveOwnerRepo(
-      'https://github.com/owner/repo.git',
-      projectPath,
-      connectToGitHub
-    );
-    expect(result).toBe('owner/repo');
-    expect(connectToGitHub).not.toHaveBeenCalled();
-  });
-
-  it('falls back to connectToGitHub when URL parsing fails', async () => {
-    const connectToGitHub = vi
-      .fn()
-      .mockResolvedValue({ success: true, repository: 'generalaction/emdash' });
-    const result = await resolveOwnerRepo(
-      'https://gitlab.com/owner/repo.git',
-      projectPath,
-      connectToGitHub
-    );
-    expect(connectToGitHub).toHaveBeenCalledWith(projectPath);
-    expect(result).toBe('generalaction/emdash');
-  });
-
-  it('returns null when both URL parsing and connectToGitHub fail', async () => {
-    const connectToGitHub = vi.fn().mockResolvedValue({ success: false });
-    const result = await resolveOwnerRepo(
-      'https://gitlab.com/owner/repo.git',
-      projectPath,
-      connectToGitHub
-    );
-    expect(result).toBeNull();
   });
 });
 


### PR DESCRIPTION
## Summary

When a GitHub repository is transferred to a new owner, or the git remote
URL is changed manually, Emdash continued using the originally stored
`owner/repo` value from the database. This silently broke below feature:

- View on GitHub -> opened the old/wrong repository URL

Closes:  #1402 

## Root Cause
The root cause was that `githubInfo.repository` was only set once when the
project was first added, and never re-synced against the actual git remote.

## Fixes 
On every project selection, re-read `git remote get-url origin` and derive
the correct `owner/repo` directly from the URL. If the parsed value differs
from what is stored, update it.

Primary: parse `owner/repo` from the `origin` remote URL via regex,
reliable for forks since it reads the local git config directly, unaffected
by `gh repo view` resolving to the upstream.

Fallback: if the remote URL is not a recognizable GitHub URL, fall back
to `connectToGitHub` (`gh repo view`) which resolves the official GitHub repo.


## Snapshot
 Attached video
 [Screencast from 2026-03-14 16-13-19.webm](https://github.com/user-attachments/assets/e5fbaefb-977f-48f9-9aa9-2139e3881a43)

## Test plan

- [x] Open a project connected to GitHub -> View on GitHub opens the correct URL
- [x] Fork with `origin` pointing to your fork -> View on GitHub opens your
  fork, not the upstream
- [x] All 14 tests in `useProjectManagement.test.ts` pass

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes