### PR TITLE
fix(terminal): prevent terminal from stealing focus from text inputs

### DIFF
--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -93,6 +93,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   }, [expandedTerminalId]);
 
   const panelRef = useRef<HTMLDivElement | null>(null);
+
   const terminalRefs = useRef<Map<string, { focus: () => void }>>(new Map());
   const setTerminalRef = useCallback((id: string, ref: { focus: () => void } | null) => {
     if (ref) {

--- a/src/renderer/lib/terminalFocusPolicy.ts
+++ b/src/renderer/lib/terminalFocusPolicy.ts
@@ -21,10 +21,14 @@ export function shouldAllowTerminalAutoFocus(): boolean {
   const active = document.activeElement as HTMLElement | null;
   if (!active || active === document.body) return true;
 
+  // Terminal elements (including xterm's hidden .xterm-helper-textarea) must
+  // be checked first — they are technically editable elements but should
+  // still allow terminal-to-terminal auto-focus on task/tab switches.
+  if (active.closest(TERMINAL_FOCUS_SELECTORS)) return true;
+
   if (active.closest('[role="dialog"]')) return false;
   if (isEditableElement(active)) return false;
 
-  // If focus is currently on any non-terminal control (buttons, tabs, etc.),
-  // preserve that focus instead of stealing it back to the terminal.
-  return Boolean(active.closest(TERMINAL_FOCUS_SELECTORS));
+  // Focus is on a non-terminal control (button, tab, link, etc.) — preserve it.
+  return false;
 }

--- a/src/renderer/lib/terminalFocusPolicy.ts
+++ b/src/renderer/lib/terminalFocusPolicy.ts
@@ -1,0 +1,30 @@
+const TERMINAL_FOCUS_SELECTORS = [
+  '[data-terminal-container]',
+  '.xterm',
+  '.xterm-helper-textarea',
+  '[data-expanded-terminal="true"]',
+].join(',');
+
+function isEditableElement(element: HTMLElement): boolean {
+  const tagName = element.tagName;
+  return (
+    tagName === 'INPUT' ||
+    tagName === 'TEXTAREA' ||
+    tagName === 'SELECT' ||
+    element.isContentEditable
+  );
+}
+
+export function shouldAllowTerminalAutoFocus(): boolean {
+  if (typeof document === 'undefined') return false;
+
+  const active = document.activeElement as HTMLElement | null;
+  if (!active || active === document.body) return true;
+
+  if (active.closest('[role="dialog"]')) return false;
+  if (isEditableElement(active)) return false;
+
+  // If focus is currently on any non-terminal control (buttons, tabs, etc.),
+  // preserve that focus instead of stealing it back to the terminal.
+  return Boolean(active.closest(TERMINAL_FOCUS_SELECTORS));
+}

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -31,6 +31,7 @@ import {
 } from './terminalSearch';
 import { rpc } from '@/lib/rpc';
 import { APP_SHORTCUTS, normalizeShortcutKey } from '@/hooks/useKeyboardShortcuts';
+import { shouldAllowTerminalAutoFocus } from '@/lib/terminalFocusPolicy';
 
 const SNAPSHOT_INTERVAL_MS = 2 * 60 * 1000; // 2 minutes
 const MAX_DATA_WINDOW_BYTES = 128 * 1024 * 1024; // 128 MB soft guardrail
@@ -605,12 +606,7 @@ export class TerminalSessionManager {
   }
 
   focus() {
-    // Don't steal focus from open dialogs (e.g. New Task modal).
-    // On Linux/Wayland the terminal's hidden textarea can retain focus
-    // after a dialog opens, causing keystrokes to go to the PTY instead
-    // of dialog inputs.
-    if (document.activeElement?.closest('[role="dialog"]')) return;
-
+    if (!shouldAllowTerminalAutoFocus()) return;
     this.terminal.focus();
   }
 

--- a/src/test/renderer/terminalFocusPolicy.test.ts
+++ b/src/test/renderer/terminalFocusPolicy.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect, vi, afterEach } from 'vitest';
+import { shouldAllowTerminalAutoFocus } from '../../renderer/lib/terminalFocusPolicy';
+
+/**
+ * Mock document.activeElement by temporarily injecting a global `document`
+ * object. The policy function only reads `document.activeElement` and calls
+ * `.closest()` / `.tagName` / `.isContentEditable` on the element, so we
+ * can stub that with plain objects.
+ */
+
+function makeElement(opts: {
+  tagName?: string;
+  isContentEditable?: boolean;
+  closestResults?: Record<string, boolean>;
+}): HTMLElement {
+  const el = {
+    tagName: opts.tagName ?? 'DIV',
+    isContentEditable: opts.isContentEditable ?? false,
+    closest: (selector: string) => {
+      if (opts.closestResults?.[selector]) return el;
+      return null;
+    },
+  } as unknown as HTMLElement;
+  return el;
+}
+
+function setActiveElement(el: HTMLElement | null) {
+  (globalThis as any).document = {
+    activeElement: el,
+    body: { tagName: 'BODY' } as unknown as HTMLElement,
+  };
+}
+
+afterEach(() => {
+  delete (globalThis as any).document;
+});
+
+describe('shouldAllowTerminalAutoFocus', () => {
+  it('returns false when document is undefined (SSR)', () => {
+    // document is not defined by default in node env
+    delete (globalThis as any).document;
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns true when activeElement is null', () => {
+    setActiveElement(null);
+    expect(shouldAllowTerminalAutoFocus()).toBe(true);
+  });
+
+  it('returns true when activeElement is body', () => {
+    // Simulate body being the activeElement
+    (globalThis as any).document = {
+      activeElement: { tagName: 'BODY' },
+      body: { tagName: 'BODY' },
+    };
+    // activeElement === document.body check uses object identity
+    (globalThis as any).document.activeElement = (globalThis as any).document.body;
+    expect(shouldAllowTerminalAutoFocus()).toBe(true);
+  });
+
+  it('returns false when an <input> is focused', () => {
+    setActiveElement(makeElement({ tagName: 'INPUT' }));
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns false when a <textarea> is focused', () => {
+    setActiveElement(makeElement({ tagName: 'TEXTAREA' }));
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns false when a <select> is focused', () => {
+    setActiveElement(makeElement({ tagName: 'SELECT' }));
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns false when a contentEditable element is focused', () => {
+    setActiveElement(makeElement({ isContentEditable: true }));
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns false when focus is inside a dialog', () => {
+    setActiveElement(
+      makeElement({
+        tagName: 'BUTTON',
+        closestResults: { '[role="dialog"]': true },
+      })
+    );
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns false when an input inside a dialog is focused', () => {
+    setActiveElement(
+      makeElement({
+        tagName: 'INPUT',
+        closestResults: { '[role="dialog"]': true },
+      })
+    );
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns true when focus is on an xterm element', () => {
+    // Matches '.xterm' selector
+    setActiveElement(
+      makeElement({
+        tagName: 'TEXTAREA',
+        closestResults: {
+          // The joined selector string
+          '[data-terminal-container],.xterm,.xterm-helper-textarea,[data-expanded-terminal="true"]': true,
+        },
+        // Even though tagName is TEXTAREA, the `.closest()` for terminal
+        // selectors matches — but isEditableElement returns true first.
+        // Let's use a DIV inside xterm instead.
+      })
+    );
+    // A TEXTAREA triggers isEditableElement → false. Use a non-editable element.
+    setActiveElement(
+      makeElement({
+        tagName: 'DIV',
+        closestResults: {
+          '[data-terminal-container],.xterm,.xterm-helper-textarea,[data-expanded-terminal="true"]': true,
+        },
+      })
+    );
+    expect(shouldAllowTerminalAutoFocus()).toBe(true);
+  });
+
+  it('returns true when focus is on a terminal container', () => {
+    setActiveElement(
+      makeElement({
+        tagName: 'DIV',
+        closestResults: {
+          '[data-terminal-container],.xterm,.xterm-helper-textarea,[data-expanded-terminal="true"]': true,
+        },
+      })
+    );
+    expect(shouldAllowTerminalAutoFocus()).toBe(true);
+  });
+
+  it('returns false when focus is on a generic button (non-terminal UI)', () => {
+    setActiveElement(makeElement({ tagName: 'BUTTON' }));
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+
+  it('returns false when focus is on a sidebar link', () => {
+    setActiveElement(makeElement({ tagName: 'A' }));
+    expect(shouldAllowTerminalAutoFocus()).toBe(false);
+  });
+});

--- a/src/test/renderer/terminalFocusPolicy.test.ts
+++ b/src/test/renderer/terminalFocusPolicy.test.ts
@@ -98,24 +98,13 @@ describe('shouldAllowTerminalAutoFocus', () => {
     expect(shouldAllowTerminalAutoFocus()).toBe(false);
   });
 
-  it('returns true when focus is on an xterm element', () => {
-    // Matches '.xterm' selector
+  it('returns true when focus is on xterm helper textarea (real-world terminal focus)', () => {
+    // In production, when a terminal has focus, document.activeElement IS
+    // the .xterm-helper-textarea — a <textarea>. The terminal-selector check
+    // must run before isEditableElement so this returns true.
     setActiveElement(
       makeElement({
         tagName: 'TEXTAREA',
-        closestResults: {
-          // The joined selector string
-          '[data-terminal-container],.xterm,.xterm-helper-textarea,[data-expanded-terminal="true"]': true,
-        },
-        // Even though tagName is TEXTAREA, the `.closest()` for terminal
-        // selectors matches — but isEditableElement returns true first.
-        // Let's use a DIV inside xterm instead.
-      })
-    );
-    // A TEXTAREA triggers isEditableElement → false. Use a non-editable element.
-    setActiveElement(
-      makeElement({
-        tagName: 'DIV',
         closestResults: {
           '[data-terminal-container],.xterm,.xterm-helper-textarea,[data-expanded-terminal="true"]': true,
         },


### PR DESCRIPTION
## Summary

Terminal auto-focus was stealing keyboard input from text fields (commit message box, modals, search inputs). Multiple `useEffect` hooks and the window focus handler were calling `session.focus()` aggressively — even when the user was typing somewhere else.

Moved the focus guard into `TerminalSessionManager.focus()` as a single enforcement point. This covers all callers (ChatInterface, TaskTerminalPanel, MultiAgentTask, ExpandedTerminalModal) without per-component guards.

The policy blocks auto-focus when:
- An input/textarea/select/contentEditable element is focused
- A dialog is open
- Any non-terminal UI element (button, tab, link) has focus

Terminal-to-terminal auto-focus (task/tab switches) still works because the terminal-selector check runs before the editable-element check — xterm's hidden `.xterm-helper-textarea` is recognized as a terminal element.

User-initiated focus (clicking the terminal, closing search overlay, drag-and-drop) still works because the policy only gates *auto*-focus.

## Fixes

Fixes #1467

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- Tested with single-agent and multi-agent tasks — terminal no longer steals focus from commit message field, search inputs, or modal dialogs
- Verified terminal still auto-focuses correctly on task switch when no other input is active
- Verified terminal-to-terminal focus works on tab switches (xterm-helper-textarea is correctly recognized)
- Added 13 unit tests covering all policy branches (editable elements, dialogs, terminal selectors, xterm textarea, generic UI)
- `pnpm run format` ✅
- `pnpm run lint` ✅ (0 errors)
- `pnpm run type-check` ✅
- `pnpm exec vitest run` ✅ (668/668 pass)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes