### PR TITLE
feat(agent): add per-task CLI presets

### DIFF
--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -462,6 +462,19 @@ export class DatabaseService {
     return rows.map((row) => this.mapDrizzleConversationRow(row));
   }
 
+  async getConversationById(conversationId: string): Promise<Conversation | null> {
+    if (this.disabled) return null;
+    if (!conversationId) return null;
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select()
+      .from(conversationsTable)
+      .where(eq(conversationsTable.id, conversationId))
+      .limit(1);
+    if (rows.length === 0) return null;
+    return this.mapDrizzleConversationRow(rows[0]);
+  }
+
   async getOrCreateDefaultConversation(taskId: string, provider?: string): Promise<Conversation> {
     if (this.disabled) {
       return {

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -26,6 +26,7 @@ import { terminalSnapshotService } from './TerminalSnapshotService';
 import { errorTracking } from '../errorTracking';
 import type { TerminalSnapshotPayload } from '../types/terminalSnapshot';
 import * as telemetry from '../telemetry';
+import type { ProviderCustomConfig } from '../../shared/providers/customConfig';
 import { PROVIDER_IDS, getProvider, type ProviderId } from '../../shared/providers/registry';
 import { parsePtyId, isChatPty } from '../../shared/ptyId';
 import { detectAndLoadTerminalConfig } from './TerminalConfigParser';
@@ -479,10 +480,11 @@ function buildRemoteProviderInvocation(args: {
   autoApprove?: boolean;
   initialPrompt?: string;
   resume?: boolean;
+  providerConfigOverride?: ProviderCustomConfig;
 }): { cli: string; cmd: string; installCommand?: string } {
-  const { providerId, autoApprove, initialPrompt, resume } = args;
+  const { providerId, autoApprove, initialPrompt, resume, providerConfigOverride } = args;
   const fallbackProvider = getProvider(providerId as ProviderId);
-  const resolvedConfig = resolveProviderCommandConfig(providerId);
+  const resolvedConfig = resolveProviderCommandConfig(providerId, providerConfigOverride);
   const provider = resolvedConfig?.provider ?? fallbackProvider;
 
   const cliCommand = (
@@ -511,6 +513,26 @@ function buildRemoteProviderInvocation(args: {
   const cmd = cmdParts.map(quoteShellArg).join(' ');
 
   return { cli: cliCheckCommand, cmd, installCommand: provider?.installCommand };
+}
+
+async function getTaskPresetForPty(
+  ptyId: string,
+  providerId: string
+): Promise<ProviderCustomConfig | undefined> {
+  const parsed = parsePtyId(ptyId);
+  if (!parsed || parsed.providerId !== providerId) return undefined;
+
+  const taskId =
+    parsed.kind === 'main'
+      ? parsed.suffix
+      : (await databaseService.getConversationById(parsed.suffix))?.taskId;
+
+  if (!taskId) return undefined;
+
+  const task = await databaseService.getTaskById(taskId);
+  const preset = task?.metadata?.agentPresets?.[providerId];
+  if (!preset || typeof preset !== 'object') return undefined;
+  return preset as ProviderCustomConfig;
 }
 
 /** Convert SSH args to SCP-compatible args (e.g. `-p` port → `-P` port). */
@@ -1120,6 +1142,7 @@ export function registerPtyIpc(): void {
       try {
         const { id, providerId, cwd, remote, cols, rows, autoApprove, initialPrompt, env, resume } =
           args;
+        const providerConfigOverride = await getTaskPresetForPty(id, providerId);
         const existing = getPty(id);
 
         if (remote?.connectionId) {
@@ -1143,9 +1166,10 @@ export function registerPtyIpc(): void {
             autoApprove,
             initialPrompt,
             resume,
+            providerConfigOverride,
           });
 
-          const resolvedConfig = resolveProviderCommandConfig(providerId);
+          const resolvedConfig = resolveProviderCommandConfig(providerId, providerConfigOverride);
           const mergedEnv = resolvedConfig?.env ? { ...resolvedConfig.env, ...env } : env;
 
           const preProviderCommands: string[] = [];
@@ -1301,6 +1325,7 @@ export function registerPtyIpc(): void {
                 env,
                 resume: effectiveResume,
                 tmux,
+                providerConfigOverride,
               });
 
         // Fall back to shell-based spawn when direct spawn is unavailable or shellSetup/tmux is set
@@ -1327,6 +1352,7 @@ export function registerPtyIpc(): void {
             skipResume: !resume,
             shellSetup,
             tmux,
+            providerConfigOverride,
           });
           usedFallback = true;
         }

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -6,6 +6,7 @@ import type { IPty } from 'node-pty';
 import { log } from '../lib/logger';
 import { PROVIDERS, type ProviderDefinition } from '@shared/providers/registry';
 import { parsePtyId } from '@shared/ptyId';
+import type { ProviderCustomConfig } from '@shared/providers/customConfig';
 import { providerStatusCache } from './providerStatusCache';
 import { errorTracking } from '../errorTracking';
 import { getProviderCustomConfig } from '../settings';
@@ -681,13 +682,36 @@ type ProviderRuntimeCliArgsOptions = {
   platform?: NodeJS.Platform;
 };
 
+function mergeProviderCustomConfig(
+  base: ProviderCustomConfig | undefined,
+  override: ProviderCustomConfig | undefined
+): ProviderCustomConfig | undefined {
+  if (!base && !override) return undefined;
+  const mergedEnv =
+    base?.env || override?.env
+      ? {
+          ...(base?.env ?? {}),
+          ...(override?.env ?? {}),
+        }
+      : undefined;
+  return {
+    ...base,
+    ...override,
+    env: mergedEnv,
+  };
+}
+
 export function resolveProviderCommandConfig(
-  providerId: string
+  providerId: string,
+  overrideConfig?: ProviderCustomConfig
 ): ResolvedProviderCommandConfig | null {
   const provider = PROVIDERS.find((p) => p.id === providerId);
   if (!provider) return null;
 
-  const customConfig = getProviderCustomConfig(provider.id);
+  const customConfig = mergeProviderCustomConfig(
+    getProviderCustomConfig(provider.id),
+    overrideConfig
+  );
 
   const extraArgs =
     customConfig?.extraArgs !== undefined && customConfig.extraArgs.trim() !== ''
@@ -1050,6 +1074,7 @@ export function startDirectPty(options: {
   env?: Record<string, string>;
   resume?: boolean;
   tmux?: boolean;
+  providerConfigOverride?: ProviderCustomConfig;
 }): IPty | null {
   if (process.env.EMDASH_DISABLE_PTY === '1') {
     throw new Error('PTY disabled via EMDASH_DISABLE_PTY=1');
@@ -1073,9 +1098,10 @@ export function startDirectPty(options: {
     initialPrompt,
     env,
     resume,
+    providerConfigOverride,
   } = options;
 
-  const resolvedConfig = resolveProviderCommandConfig(providerId);
+  const resolvedConfig = resolveProviderCommandConfig(providerId, providerConfigOverride);
   const provider = resolvedConfig?.provider;
 
   // Get the CLI path from cache
@@ -1240,6 +1266,7 @@ export async function startPty(options: {
   skipResume?: boolean;
   shellSetup?: string;
   tmux?: boolean;
+  providerConfigOverride?: ProviderCustomConfig;
 }): Promise<IPty> {
   if (process.env.EMDASH_DISABLE_PTY === '1') {
     throw new Error('PTY disabled via EMDASH_DISABLE_PTY=1');
@@ -1256,6 +1283,7 @@ export async function startPty(options: {
     skipResume,
     shellSetup,
     tmux,
+    providerConfigOverride,
   } = options;
 
   const defaultShell = getDefaultShell();
@@ -1360,7 +1388,7 @@ export async function startPty(options: {
       const provider = PROVIDERS.find((p) => p.cli === baseLower);
 
       if (provider) {
-        const resolvedConfig = resolveProviderCommandConfig(provider.id);
+        const resolvedConfig = resolveProviderCommandConfig(provider.id, providerConfigOverride);
         const resolvedCli = resolvedConfig?.cli || provider.cli || baseLower;
         applyProviderSpecificRuntimeEnv(useEnv, { ptyId: id, providerId: provider.id });
 

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -3,8 +3,11 @@ import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ProviderId } from '@shared/providers/registry';
+import type { ProviderCustomConfig, ProviderCustomConfigs } from '@shared/providers/customConfig';
 import { isValidProviderId } from '@shared/providers/registry';
 import { isValidOpenInAppId, type OpenInAppId } from '@shared/openInApps';
+
+export type { ProviderCustomConfig, ProviderCustomConfigs };
 
 export type DeepPartial<T> = {
   [K in keyof T]?: NonNullable<T[K]> extends object ? DeepPartial<NonNullable<T[K]>> : T[K];
@@ -55,23 +58,6 @@ export interface InterfaceSettings {
   theme?: 'light' | 'dark' | 'dark-black' | 'system';
   taskHoverAction?: 'delete' | 'archive';
 }
-
-/**
- * Custom configuration for a CLI provider.
- * All fields are optional - if undefined, the default from registry.ts is used.
- * If set to empty string, the flag is disabled.
- */
-export interface ProviderCustomConfig {
-  cli?: string;
-  resumeFlag?: string;
-  defaultArgs?: string;
-  autoApproveFlag?: string;
-  initialPromptFlag?: string;
-  extraArgs?: string;
-  env?: Record<string, string>;
-}
-
-export type ProviderCustomConfigs = Record<string, ProviderCustomConfig>;
 
 export interface AppSettings {
   repository: RepositorySettings;

--- a/src/renderer/components/CustomCommandModal.tsx
+++ b/src/renderer/components/CustomCommandModal.tsx
@@ -7,7 +7,7 @@ import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { PROVIDERS, type ProviderDefinition } from '@shared/providers/registry';
-import type { ProviderCustomConfig } from '../types/electron-api';
+import type { ProviderCustomConfig } from '@shared/providers/customConfig';
 
 interface CustomCommandModalProps {
   isOpen: boolean;

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -17,6 +17,7 @@ import { CornerDownLeft } from 'lucide-react';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import { useAutoScrollOnTaskSwitch } from '@/hooks/useAutoScrollOnTaskSwitch';
 import { getTaskEnvVars } from '@shared/task/envVars';
+import { makePtyId } from '@shared/ptyId';
 import { rpc } from '@/lib/rpc';
 
 interface Props {
@@ -38,6 +39,9 @@ type Variant = {
   path: string;
   worktreeId: string;
 };
+
+const getVariantMainPtyId = (variant: Variant): string =>
+  makePtyId(variant.agent, 'main', variant.worktreeId);
 
 const MultiAgentTask: React.FC<Props> = ({
   task,
@@ -265,7 +269,7 @@ const MultiAgentTask: React.FC<Props> = ({
     // Send concurrently via PTY injection for all agents (Codex/Claude included)
     const tasks: Promise<any>[] = [];
     variants.forEach((v) => {
-      const termId = `${v.worktreeId}-main`;
+      const termId = getVariantMainPtyId(v);
       tasks.push(injectPrompt(termId, v.agent, msg));
     });
     await Promise.all(tasks);
@@ -346,7 +350,7 @@ const MultiAgentTask: React.FC<Props> = ({
 
     variants.forEach((variant) => {
       const variantId = variant.worktreeId;
-      const ptyId = `${variant.worktreeId}-main`;
+      const ptyId = getVariantMainPtyId(variant);
       busyState.set(variantId, variantBusy[variantId] ?? false);
 
       const offData = (window as any).electronAPI?.onPtyData?.(ptyId, (chunk: string) => {
@@ -566,7 +570,7 @@ const MultiAgentTask: React.FC<Props> = ({
                 >
                   <TerminalPane
                     ref={isActive ? activeTerminalRef : undefined}
-                    id={`${v.worktreeId}-main`}
+                    id={getVariantMainPtyId(v)}
                     cwd={v.path}
                     remote={
                       projectRemoteConnectionId
@@ -618,7 +622,7 @@ const MultiAgentTask: React.FC<Props> = ({
                         (agentMeta[v.agent]?.initialPromptFlag === undefined ||
                           agentMeta[v.agent]?.useKeystrokeInjection)
                       ) {
-                        void injectPrompt(`${v.worktreeId}-main`, v.agent, initialInjection);
+                        void injectPrompt(getVariantMainPtyId(v), v.agent, initialInjection);
                       }
                       // Mark initial injection as sent so it won't re-run on restart
                       if (initialInjection && !task.metadata?.initialInjectionSent) {

--- a/src/renderer/components/TaskAdvancedSettings.tsx
+++ b/src/renderer/components/TaskAdvancedSettings.tsx
@@ -1,6 +1,7 @@
 import React, { useCallback, useState } from 'react';
 import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
 import { ExternalLink, Settings } from 'lucide-react';
+import type { ProviderId } from '@shared/providers/registry';
 import { Button } from './ui/button';
 import { Checkbox } from './ui/checkbox';
 import { Label } from './ui/label';
@@ -43,6 +44,9 @@ interface TaskAdvancedSettingsProps {
   initialPrompt: string;
   onInitialPromptChange: (value: string) => void;
   hasInitialPromptSupport: boolean;
+  activeAgents: ProviderId[];
+  configuredAgentPresetCount: number;
+  onConfigureAgentPresets: () => void;
 
   // Linear
   selectedLinearIssue: LinearIssueSummary | null;
@@ -95,6 +99,9 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
   initialPrompt,
   onInitialPromptChange,
   hasInitialPromptSupport,
+  activeAgents,
+  configuredAgentPresetCount,
+  onConfigureAgentPresets,
   selectedLinearIssue,
   onLinearIssueChange,
   isLinearConnected,
@@ -481,6 +488,30 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
                   </div>
                 </div>
               ) : null}
+
+              <div className="flex items-center gap-4">
+                <Label className="w-32 shrink-0">Agent presets</Label>
+                <div className="flex min-w-0 flex-1 items-center justify-between gap-3 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
+                  <div className="min-w-0">
+                    <p className="text-sm text-muted-foreground">
+                      Override model and CLI flags for this task only.
+                    </p>
+                    <p className="text-xs text-muted-foreground">
+                      {configuredAgentPresetCount > 0
+                        ? `${configuredAgentPresetCount} custom preset${configuredAgentPresetCount === 1 ? '' : 's'} across ${activeAgents.length} agent${activeAgents.length === 1 ? '' : 's'}`
+                        : `Using inherited defaults for ${activeAgents.length} agent${activeAgents.length === 1 ? '' : 's'}`}
+                    </p>
+                  </div>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={onConfigureAgentPresets}
+                  >
+                    Configure
+                  </Button>
+                </div>
+              </div>
 
               <div className="grid grid-cols-[128px_1fr] items-start gap-4">
                 <Label htmlFor="linear-issue" className="pt-2">

--- a/src/renderer/components/TaskAgentPresetsModal.tsx
+++ b/src/renderer/components/TaskAgentPresetsModal.tsx
@@ -1,0 +1,587 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { createPortal } from 'react-dom';
+import { AnimatePresence, motion, useReducedMotion } from 'motion/react';
+import { Info, Plus, RotateCcw, Trash2, X } from 'lucide-react';
+import { PROVIDERS, type ProviderDefinition, type ProviderId } from '@shared/providers/registry';
+import type { ProviderCustomConfig } from '@shared/providers/customConfig';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
+
+type EnvEntry = { key: string; value: string };
+
+type FormState = {
+  cli: string;
+  resumeFlag: string;
+  defaultArgs: string;
+  extraArgs: string;
+  autoApproveFlag: string;
+  initialPromptFlag: string;
+  envEntries: EnvEntry[];
+};
+
+type ProviderPresetMap = Partial<Record<ProviderId, ProviderCustomConfig>>;
+type ProviderFormMap = Partial<Record<ProviderId, FormState>>;
+
+interface TaskAgentPresetsModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  agentIds: ProviderId[];
+  value: ProviderPresetMap;
+  onSave: (nextValue: ProviderPresetMap) => void;
+}
+
+const getProviderById = (providerId: ProviderId): ProviderDefinition | undefined =>
+  PROVIDERS.find((provider) => provider.id === providerId);
+
+const getDefaultForm = (
+  provider: ProviderDefinition | undefined,
+  globalConfig?: ProviderCustomConfig
+): FormState => ({
+  cli: globalConfig?.cli ?? provider?.cli ?? '',
+  resumeFlag: globalConfig?.resumeFlag ?? provider?.resumeFlag ?? '',
+  defaultArgs: globalConfig?.defaultArgs ?? provider?.defaultArgs?.join(' ') ?? '',
+  extraArgs: globalConfig?.extraArgs ?? '',
+  autoApproveFlag: globalConfig?.autoApproveFlag ?? provider?.autoApproveFlag ?? '',
+  initialPromptFlag: globalConfig?.initialPromptFlag ?? provider?.initialPromptFlag ?? '',
+  envEntries:
+    globalConfig?.env && typeof globalConfig.env === 'object'
+      ? Object.entries(globalConfig.env).map(([key, value]) => ({ key, value: String(value) }))
+      : [],
+});
+
+const formFromConfig = (
+  config: ProviderCustomConfig | undefined,
+  defaults: FormState
+): FormState => ({
+  cli: config?.cli ?? defaults.cli,
+  resumeFlag: config?.resumeFlag ?? defaults.resumeFlag,
+  defaultArgs: config?.defaultArgs ?? defaults.defaultArgs,
+  extraArgs: config?.extraArgs ?? defaults.extraArgs,
+  autoApproveFlag: config?.autoApproveFlag ?? defaults.autoApproveFlag,
+  initialPromptFlag: config?.initialPromptFlag ?? defaults.initialPromptFlag,
+  envEntries:
+    config?.env && typeof config.env === 'object'
+      ? Object.entries(config.env).map(([key, value]) => ({ key, value: String(value) }))
+      : defaults.envEntries,
+});
+
+const sanitizeEnvEntries = (entries: EnvEntry[]): EnvEntry[] =>
+  entries.filter((entry) => entry.key.trim() || entry.value.trim());
+
+const formsEqual = (left: FormState, right: FormState): boolean =>
+  left.cli === right.cli &&
+  left.resumeFlag === right.resumeFlag &&
+  left.defaultArgs === right.defaultArgs &&
+  left.extraArgs === right.extraArgs &&
+  left.autoApproveFlag === right.autoApproveFlag &&
+  left.initialPromptFlag === right.initialPromptFlag &&
+  JSON.stringify(sanitizeEnvEntries(left.envEntries)) ===
+    JSON.stringify(sanitizeEnvEntries(right.envEntries));
+
+const buildConfigFromForm = (
+  form: FormState,
+  defaults: FormState
+): ProviderCustomConfig | undefined => {
+  if (formsEqual(form, defaults)) return undefined;
+
+  const envRecord: Record<string, string> = {};
+  for (const { key, value } of form.envEntries) {
+    const trimmedKey = key.trim();
+    if (trimmedKey && /^[A-Za-z_][A-Za-z0-9_]*$/.test(trimmedKey)) {
+      envRecord[trimmedKey] = value;
+    }
+  }
+
+  return {
+    cli: form.cli,
+    resumeFlag: form.resumeFlag,
+    defaultArgs: form.defaultArgs,
+    extraArgs: form.extraArgs.trim() || undefined,
+    autoApproveFlag: form.autoApproveFlag,
+    initialPromptFlag: form.initialPromptFlag,
+    env: Object.keys(envRecord).length > 0 ? envRecord : undefined,
+  };
+};
+
+export default function TaskAgentPresetsModal({
+  isOpen,
+  onClose,
+  agentIds,
+  value,
+  onSave,
+}: TaskAgentPresetsModalProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const normalizedAgentIds = useMemo(
+    () => [...new Set(agentIds)].filter((id): id is ProviderId => Boolean(getProviderById(id))),
+    [agentIds]
+  );
+  const [selectedAgentId, setSelectedAgentId] = useState<ProviderId | null>(
+    normalizedAgentIds[0] ?? null
+  );
+  const [defaultsByAgent, setDefaultsByAgent] = useState<ProviderFormMap>({});
+  const [formsByAgent, setFormsByAgent] = useState<ProviderFormMap>({});
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    setSelectedAgentId((current) =>
+      current && normalizedAgentIds.includes(current) ? current : (normalizedAgentIds[0] ?? null)
+    );
+  }, [isOpen, normalizedAgentIds]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    let cancelled = false;
+    setLoading(true);
+
+    void (async () => {
+      const nextDefaults: ProviderFormMap = {};
+      const nextForms: ProviderFormMap = {};
+
+      for (const agentId of normalizedAgentIds) {
+        const provider = getProviderById(agentId);
+        let globalConfig: ProviderCustomConfig | undefined;
+        try {
+          const result = await window.electronAPI.getProviderCustomConfig?.(agentId);
+          if (result?.success) globalConfig = result.config;
+        } catch {}
+
+        const defaults = getDefaultForm(provider, globalConfig);
+        nextDefaults[agentId] = defaults;
+        nextForms[agentId] = formFromConfig(value[agentId], defaults);
+      }
+
+      if (cancelled) return;
+      setDefaultsByAgent(nextDefaults);
+      setFormsByAgent(nextForms);
+      setLoading(false);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [isOpen, normalizedAgentIds, value]);
+
+  const selectedAgent = selectedAgentId ? getProviderById(selectedAgentId) : undefined;
+  const selectedForm =
+    (selectedAgentId ? formsByAgent[selectedAgentId] : undefined) ??
+    (selectedAgent ? getDefaultForm(selectedAgent) : null);
+  const selectedDefaults =
+    (selectedAgentId ? defaultsByAgent[selectedAgentId] : undefined) ??
+    (selectedAgent ? getDefaultForm(selectedAgent) : null);
+
+  const updateSelectedForm = useCallback(
+    (updater: (current: FormState) => FormState) => {
+      if (!selectedAgentId || !selectedForm) return;
+      setFormsByAgent((prev) => ({
+        ...prev,
+        [selectedAgentId]: updater(prev[selectedAgentId] ?? selectedForm),
+      }));
+    },
+    [selectedAgentId, selectedForm]
+  );
+
+  const handleChange = useCallback(
+    (field: keyof FormState, nextValue: string) => {
+      updateSelectedForm((current) => ({ ...current, [field]: nextValue }));
+    },
+    [updateSelectedForm]
+  );
+
+  const setEnvEntry = useCallback(
+    (index: number, update: Partial<EnvEntry>) => {
+      updateSelectedForm((current) => {
+        const nextEntries = [...current.envEntries];
+        nextEntries[index] = { ...nextEntries[index], ...update };
+        return { ...current, envEntries: nextEntries };
+      });
+    },
+    [updateSelectedForm]
+  );
+
+  const addEnvEntry = useCallback(() => {
+    updateSelectedForm((current) => ({
+      ...current,
+      envEntries: [...current.envEntries, { key: '', value: '' }],
+    }));
+  }, [updateSelectedForm]);
+
+  const removeEnvEntry = useCallback(
+    (index: number) => {
+      updateSelectedForm((current) => ({
+        ...current,
+        envEntries: current.envEntries.filter((_, currentIndex) => currentIndex !== index),
+      }));
+    },
+    [updateSelectedForm]
+  );
+
+  const handleReset = useCallback(() => {
+    if (!selectedAgentId || !selectedDefaults) return;
+    setFormsByAgent((prev) => ({ ...prev, [selectedAgentId]: selectedDefaults }));
+  }, [selectedAgentId, selectedDefaults]);
+
+  const hasChanges = useMemo(
+    () =>
+      normalizedAgentIds.some((agentId) => {
+        const defaults = defaultsByAgent[agentId];
+        const form = formsByAgent[agentId];
+        return !!defaults && !!form && !formsEqual(form, defaults);
+      }),
+    [defaultsByAgent, formsByAgent, normalizedAgentIds]
+  );
+
+  const configuredCount = useMemo(
+    () =>
+      normalizedAgentIds.filter((agentId) => {
+        const defaults = defaultsByAgent[agentId];
+        const form = formsByAgent[agentId];
+        return !!defaults && !!form && !formsEqual(form, defaults);
+      }).length,
+    [defaultsByAgent, formsByAgent, normalizedAgentIds]
+  );
+
+  const handleSave = useCallback(() => {
+    const nextValue: ProviderPresetMap = {};
+    for (const agentId of normalizedAgentIds) {
+      const defaults = defaultsByAgent[agentId];
+      const form = formsByAgent[agentId];
+      if (!defaults || !form) continue;
+      const config = buildConfigFromForm(form, defaults);
+      if (config) nextValue[agentId] = config;
+    }
+    onSave(nextValue);
+    onClose();
+  }, [defaultsByAgent, formsByAgent, normalizedAgentIds, onClose, onSave]);
+
+  const previewCommand = useMemo(() => {
+    if (!selectedForm) return '';
+    const parts: string[] = [];
+    if (selectedForm.cli) parts.push(selectedForm.cli);
+    if (selectedForm.resumeFlag) parts.push(selectedForm.resumeFlag);
+    if (selectedForm.defaultArgs) parts.push(selectedForm.defaultArgs);
+    if (selectedForm.extraArgs) parts.push(selectedForm.extraArgs);
+    if (selectedForm.autoApproveFlag) parts.push(selectedForm.autoApproveFlag);
+    if (selectedForm.initialPromptFlag) parts.push(selectedForm.initialPromptFlag);
+    parts.push('{prompt}');
+    return parts.join(' ');
+  }, [selectedForm]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  if (!isOpen) return null;
+
+  return createPortal(
+    <AnimatePresence>
+      <motion.div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="task-agent-presets-title"
+        className="fixed inset-0 z-[130] flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
+        initial={shouldReduceMotion ? false : { opacity: 0 }}
+        animate={{ opacity: 1 }}
+        exit={shouldReduceMotion ? { opacity: 1 } : { opacity: 0 }}
+        transition={shouldReduceMotion ? { duration: 0 } : { duration: 0.12, ease: 'easeOut' }}
+        onClick={onClose}
+      >
+        <motion.div
+          onClick={(event) => event.stopPropagation()}
+          initial={shouldReduceMotion ? false : { opacity: 0, y: 8, scale: 0.995 }}
+          animate={{ opacity: 1, y: 0, scale: 1 }}
+          exit={
+            shouldReduceMotion ? { opacity: 1, y: 0, scale: 1 } : { opacity: 0, y: 6, scale: 0.995 }
+          }
+          transition={
+            shouldReduceMotion ? { duration: 0 } : { duration: 0.18, ease: [0.22, 1, 0.36, 1] }
+          }
+          className="flex max-h-[85vh] w-full max-w-4xl overflow-hidden rounded-2xl border border-border/50 bg-background shadow-2xl"
+        >
+          <aside className="w-52 shrink-0 border-r border-border/60 bg-muted/20 p-4">
+            <div className="mb-3 flex items-start justify-between gap-3">
+              <div>
+                <h2 id="task-agent-presets-title" className="text-lg font-semibold">
+                  Agent presets
+                </h2>
+                <p className="mt-1 text-sm text-muted-foreground">
+                  Override CLI args for this task only.
+                </p>
+              </div>
+              <Button
+                type="button"
+                variant="ghost"
+                size="icon"
+                onClick={onClose}
+                className="h-8 w-8 shrink-0"
+                aria-label="Close"
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+
+            <div className="space-y-2">
+              {normalizedAgentIds.map((agentId) => {
+                const provider = getProviderById(agentId);
+                const defaults = defaultsByAgent[agentId];
+                const form = formsByAgent[agentId];
+                const configured = !!defaults && !!form && !formsEqual(form, defaults);
+                return (
+                  <button
+                    key={agentId}
+                    type="button"
+                    onClick={() => setSelectedAgentId(agentId)}
+                    className={`flex w-full items-center justify-between rounded-lg px-3 py-2 text-left text-sm transition ${
+                      selectedAgentId === agentId
+                        ? 'bg-foreground text-background'
+                        : 'bg-transparent text-foreground hover:bg-accent'
+                    }`}
+                  >
+                    <span>{provider?.name ?? agentId}</span>
+                    {configured ? (
+                      <span className="rounded-full bg-emerald-500/15 px-2 py-0.5 text-[11px] text-emerald-600">
+                        Custom
+                      </span>
+                    ) : null}
+                  </button>
+                );
+              })}
+            </div>
+          </aside>
+
+          <div className="flex min-w-0 flex-1 flex-col">
+            <div className="border-b border-border/60 px-6 py-4">
+              <div className="flex items-center justify-between gap-4">
+                <div>
+                  <p className="text-sm font-medium text-foreground">
+                    {selectedAgent?.name ?? 'Agent configuration'}
+                  </p>
+                  <p className="text-sm text-muted-foreground">
+                    Inherits from global agent settings until overridden here.
+                  </p>
+                </div>
+                <div className="text-xs text-muted-foreground">
+                  {configuredCount} of {normalizedAgentIds.length} customized
+                </div>
+              </div>
+            </div>
+
+            <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+              {loading || !selectedForm || !selectedDefaults ? (
+                <div className="flex items-center justify-center py-10 text-sm text-muted-foreground">
+                  Loading presets…
+                </div>
+              ) : (
+                <div className="space-y-4">
+                  <Field
+                    label="CLI Command"
+                    tooltip="The CLI command to execute (for example: codex)"
+                  >
+                    <Input
+                      value={selectedForm.cli}
+                      onChange={(event) => handleChange('cli', event.target.value)}
+                      placeholder={selectedDefaults.cli || 'CLI command'}
+                      className="font-mono text-sm"
+                    />
+                  </Field>
+
+                  <Field
+                    label="Resume Flag"
+                    tooltip="Flag used when resuming a session (for example: -c -r)"
+                  >
+                    <Input
+                      value={selectedForm.resumeFlag}
+                      onChange={(event) => handleChange('resumeFlag', event.target.value)}
+                      placeholder={selectedDefaults.resumeFlag || '(none)'}
+                      className="font-mono text-sm"
+                    />
+                  </Field>
+
+                  <Field
+                    label="Default Args"
+                    tooltip="Default arguments such as model selection flags"
+                  >
+                    <Input
+                      value={selectedForm.defaultArgs}
+                      onChange={(event) => handleChange('defaultArgs', event.target.value)}
+                      placeholder={selectedDefaults.defaultArgs || '(none)'}
+                      className="font-mono text-sm"
+                    />
+                  </Field>
+
+                  <Field
+                    label="Additional Parameters"
+                    tooltip="Extra flags appended to the command for this task only"
+                  >
+                    <Input
+                      value={selectedForm.extraArgs}
+                      onChange={(event) => handleChange('extraArgs', event.target.value)}
+                      placeholder="e.g. --model gpt-5 --enable-feature"
+                      className="font-mono text-sm"
+                    />
+                  </Field>
+
+                  <div className="space-y-2">
+                    <div className="flex items-center gap-2">
+                      <Label className="text-sm font-medium">Environment variables</Label>
+                      <FieldTooltip content="Environment variables set when running this agent for the task" />
+                    </div>
+                    <div className="space-y-2">
+                      {selectedForm.envEntries.map((entry, index) => (
+                        <div key={index} className="flex items-center gap-2">
+                          <Input
+                            value={entry.key}
+                            onChange={(event) => setEnvEntry(index, { key: event.target.value })}
+                            placeholder="KEY"
+                            className="min-w-0 flex-1 font-mono text-sm"
+                          />
+                          <Input
+                            value={entry.value}
+                            onChange={(event) => setEnvEntry(index, { value: event.target.value })}
+                            placeholder="value"
+                            className="min-w-0 flex-1 font-mono text-sm"
+                          />
+                          <Button
+                            type="button"
+                            variant="ghost"
+                            size="icon"
+                            onClick={() => removeEnvEntry(index)}
+                            className="h-8 w-8 shrink-0"
+                            aria-label="Remove"
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        </div>
+                      ))}
+                      <Button
+                        type="button"
+                        variant="outline"
+                        size="sm"
+                        onClick={addEnvEntry}
+                        className="gap-1.5"
+                      >
+                        <Plus className="h-3.5 w-3.5" />
+                        Add variable
+                      </Button>
+                    </div>
+                  </div>
+
+                  <Field
+                    label="Auto-approve Flag"
+                    tooltip="Flag used when task auto-approve is enabled"
+                  >
+                    <Input
+                      value={selectedForm.autoApproveFlag}
+                      onChange={(event) => handleChange('autoApproveFlag', event.target.value)}
+                      placeholder={selectedDefaults.autoApproveFlag || '(none)'}
+                      className="font-mono text-sm"
+                    />
+                  </Field>
+
+                  <Field
+                    label="Initial Prompt Flag"
+                    tooltip="Flag for passing the initial prompt; leave empty to pass the prompt directly"
+                  >
+                    <Input
+                      value={selectedForm.initialPromptFlag}
+                      onChange={(event) => handleChange('initialPromptFlag', event.target.value)}
+                      placeholder={selectedDefaults.initialPromptFlag || '(pass directly)'}
+                      className="font-mono text-sm"
+                    />
+                  </Field>
+
+                  <div className="rounded-lg border border-border/60 bg-muted/30 p-4">
+                    <div className="mb-2 text-xs font-medium text-muted-foreground">
+                      Command preview
+                    </div>
+                    <code className="block break-all font-mono text-sm text-foreground">
+                      {previewCommand}
+                    </code>
+                  </div>
+                </div>
+              )}
+            </div>
+
+            <footer className="flex items-center justify-between border-t border-border/60 px-6 py-4">
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                onClick={handleReset}
+                disabled={loading || !selectedForm || !selectedDefaults}
+                className="gap-1.5"
+              >
+                <RotateCcw className="h-3.5 w-3.5" />
+                Reset agent
+              </Button>
+              <div className="flex gap-2">
+                <Button type="button" variant="outline" size="sm" onClick={onClose}>
+                  Cancel
+                </Button>
+                <Button
+                  type="button"
+                  size="sm"
+                  onClick={handleSave}
+                  disabled={loading || !hasChanges}
+                >
+                  Save presets
+                </Button>
+              </div>
+            </footer>
+          </div>
+        </motion.div>
+      </motion.div>
+    </AnimatePresence>,
+    document.body
+  );
+}
+
+function Field({
+  label,
+  tooltip,
+  children,
+}: {
+  label: string;
+  tooltip: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="space-y-2">
+      <div className="flex items-center gap-2">
+        <Label className="text-sm font-medium">{label}</Label>
+        <FieldTooltip content={tooltip} />
+      </div>
+      {children}
+    </div>
+  );
+}
+
+const FieldTooltip: React.FC<{ content: string }> = ({ content }) => (
+  <TooltipProvider>
+    <Tooltip delayDuration={200}>
+      <TooltipTrigger asChild>
+        <button
+          type="button"
+          className="text-muted-foreground hover:text-foreground"
+          aria-label="More information"
+        >
+          <Info className="h-3.5 w-3.5" aria-hidden="true" />
+        </button>
+      </TooltipTrigger>
+      <TooltipContent side="top" className="max-w-[220px] text-xs">
+        {content}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -13,11 +13,13 @@ import { SlugInput } from './ui/slug-input';
 import { Label } from './ui/label';
 import { MultiAgentDropdown } from './MultiAgentDropdown';
 import { TaskAdvancedSettings } from './TaskAdvancedSettings';
+import TaskAgentPresetsModal from './TaskAgentPresetsModal';
 import { useIntegrationStatus } from './hooks/useIntegrationStatus';
 import { type Agent } from '../types';
 import { type AgentRun } from '../types/chat';
 import { agentMeta } from '../providers/meta';
-import { isValidProviderId } from '@shared/providers/registry';
+import type { ProviderCustomConfig } from '@shared/providers/customConfig';
+import { isValidProviderId, type ProviderId } from '@shared/providers/registry';
 import { type LinearIssueSummary } from '../types/linear';
 import { type GitHubIssueSummary } from '../types/github';
 import { type JiraIssueSummary } from '../types/jira';
@@ -52,6 +54,7 @@ export interface CreateTaskResult {
   useWorktree?: boolean;
   baseRef?: string;
   nameGenerated?: boolean;
+  agentPresets?: Partial<Record<ProviderId, ProviderCustomConfig>>;
 }
 
 interface TaskModalProps {
@@ -70,7 +73,8 @@ interface TaskModalProps {
     autoApprove?: boolean,
     useWorktree?: boolean,
     baseRef?: string,
-    nameGenerated?: boolean
+    nameGenerated?: boolean,
+    agentPresets?: Partial<Record<ProviderId, ProviderCustomConfig>>
   ) => Promise<void>;
 }
 
@@ -98,7 +102,8 @@ export function TaskModalOverlay({ onClose, initialProject }: TaskModalOverlayPr
         autoApprove,
         useWorktree,
         baseRef,
-        nameGenerated
+        nameGenerated,
+        agentPresets
       ) => {
         await handleCreateTask(
           name,
@@ -114,6 +119,7 @@ export function TaskModalOverlay({ onClose, initialProject }: TaskModalOverlayPr
           useWorktree,
           baseRef,
           nameGenerated,
+          agentPresets,
           initialProject ?? undefined
         );
       }}
@@ -155,6 +161,10 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
   );
   const [autoApprove, setAutoApprove] = useState(false);
   const [useWorktree, setUseWorktree] = useState(true);
+  const [agentPresets, setAgentPresets] = useState<
+    Partial<Record<ProviderId, ProviderCustomConfig>>
+  >({});
+  const [agentPresetModalOpen, setAgentPresetModalOpen] = useState(false);
 
   // Branch selection state - sync with defaultBranch unless user manually changed it
   const [selectedBranch, setSelectedBranch] = useState(defaultBranch);
@@ -186,6 +196,14 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
 
   // Computed values
   const activeAgents = useMemo(() => agentRuns.map((ar) => ar.agent), [agentRuns]);
+  const presetAgents = useMemo(() => [...new Set(activeAgents)] as ProviderId[], [activeAgents]);
+  const activeAgentSet = useMemo(() => new Set(presetAgents), [presetAgents]);
+  const configuredAgentPresetCount = useMemo(
+    () =>
+      Object.keys(agentPresets).filter((agentId) => activeAgentSet.has(agentId as ProviderId))
+        .length,
+    [activeAgentSet, agentPresets]
+  );
   const hasAutoApproveSupport = activeAgents.every((id) => !!agentMeta[id]?.autoApproveFlag);
   const hasInitialPromptSupport = activeAgents.every(
     (id) => agentMeta[id]?.initialPromptFlag !== undefined
@@ -227,6 +245,16 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
     if (!hasAutoApproveSupport && autoApprove) setAutoApprove(false);
   }, [hasAutoApproveSupport, autoApprove]);
 
+  useEffect(() => {
+    setAgentPresets((current) => {
+      const nextEntries = Object.entries(current).filter(([providerId]) =>
+        activeAgentSet.has(providerId as ProviderId)
+      );
+      if (nextEntries.length === Object.keys(current).length) return current;
+      return Object.fromEntries(nextEntries) as Partial<Record<ProviderId, ProviderCustomConfig>>;
+    });
+  }, [activeAgentSet]);
+
   // Reset form and load settings on mount
   useEffect(() => {
     void refreshBranches();
@@ -245,6 +273,8 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
     setSelectedForgejoIssue(null);
     setAutoApprove(false);
     setUseWorktree(true);
+    setAgentPresets({});
+    setAgentPresetModalOpen(false);
     userHasTypedRef.current = false;
     autoNameInitializedRef.current = false;
     customNameTrackedRef.current = false;
@@ -401,7 +431,8 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
         hasAutoApproveSupport ? autoApprove : false,
         useWorktree,
         selectedBranch,
-        isNameGenerated
+        isNameGenerated,
+        agentPresets
       );
       onClose();
     } catch (error) {
@@ -491,6 +522,9 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
             initialPrompt={initialPrompt}
             onInitialPromptChange={setInitialPrompt}
             hasInitialPromptSupport={hasInitialPromptSupport}
+            activeAgents={presetAgents}
+            configuredAgentPresetCount={configuredAgentPresetCount}
+            onConfigureAgentPresets={() => setAgentPresetModalOpen(true)}
             selectedLinearIssue={selectedLinearIssue}
             onLinearIssueChange={setSelectedLinearIssue}
             isLinearConnected={integrations.isLinearConnected}
@@ -534,6 +568,14 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
           </Button>
         </DialogFooter>
       </form>
+
+      <TaskAgentPresetsModal
+        isOpen={agentPresetModalOpen}
+        onClose={() => setAgentPresetModalOpen(false)}
+        agentIds={presetAgents}
+        value={agentPresets}
+        onSave={setAgentPresets}
+      />
     </DialogContent>
   );
 };

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -2,7 +2,6 @@ import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
 import { useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
 import { TERMINAL_PROVIDER_IDS } from '../constants/agents';
 import { makePtyId } from '@shared/ptyId';
-import type { ProviderId } from '@shared/providers/registry';
 import { saveActiveIds, getStoredActiveIds } from '../constants/layout';
 import { getAgentForTask } from '../lib/getAgentForTask';
 import { disposeTaskTerminals } from '../lib/taskTerminalsStore';
@@ -10,6 +9,8 @@ import { terminalSessionRegistry } from '../terminal/SessionRegistry';
 import type { Agent } from '../types';
 import type { Project, Task } from '../types/app';
 import type { GitHubIssueLink, AgentRun } from '../types/chat';
+import type { ProviderCustomConfig } from '@shared/providers/customConfig';
+import type { ProviderId } from '@shared/providers/registry';
 import type { LinearIssueSummary } from '../types/linear';
 import type { GitHubIssueSummary } from '../types/github';
 import type { JiraIssueSummary } from '../types/jira';
@@ -83,13 +84,16 @@ const buildLinkedGithubIssueMap = (tasks?: Task[] | null): Map<number, GitHubIss
   return linked;
 };
 
+const getVariantMainSessionId = (providerId: ProviderId, worktreeId: string): string =>
+  makePtyId(providerId, 'main', worktreeId);
+
 const cleanupPtyResources = async (task: Task): Promise<void> => {
   try {
     const variants = task.metadata?.multiAgent?.variants || [];
     const mainSessionIds: string[] = [];
     if (variants.length > 0) {
       for (const v of variants) {
-        const id = `${v.worktreeId}-main`;
+        const id = getVariantMainSessionId(v.agent as ProviderId, v.worktreeId);
         mainSessionIds.push(id);
       }
     } else {
@@ -425,7 +429,7 @@ export function useTaskManagement() {
       const mainSessionIds: string[] = [];
       if (variants.length > 0) {
         for (const v of variants) {
-          const id = `${v.worktreeId}-main`;
+          const id = getVariantMainSessionId(v.agent as ProviderId, v.worktreeId);
           mainSessionIds.push(id);
         }
       } else {
@@ -859,6 +863,9 @@ export function useTaskManagement() {
         agentId: primaryAgent,
         metadata: isMultiAgent
           ? {
+              ...(params.agentPresets && Object.keys(params.agentPresets).length > 0
+                ? { agentPresets: params.agentPresets }
+                : {}),
               multiAgent: {
                 enabled: true,
                 maxAgents: 4,
@@ -867,7 +874,9 @@ export function useTaskManagement() {
                 selectedAgent: null,
               },
             }
-          : null,
+          : params.agentPresets && Object.keys(params.agentPresets).length > 0
+            ? { agentPresets: params.agentPresets }
+            : null,
         useWorktree: params.useWorktree,
       };
 
@@ -923,6 +932,7 @@ export function useTaskManagement() {
       useWorktree: boolean = true,
       baseRef?: string,
       nameGenerated?: boolean,
+      agentPresets?: Partial<Record<ProviderId, ProviderCustomConfig>>,
       overrideProject?: Project
     ) => {
       const targetProject = overrideProject ?? pendingTaskProjectRef.current ?? selectedProject;
@@ -946,6 +956,7 @@ export function useTaskManagement() {
         nameGenerated,
         useWorktree,
         baseRef,
+        agentPresets,
         preflightPromise: preflight,
       });
     },

--- a/src/renderer/lib/taskCreationService.ts
+++ b/src/renderer/lib/taskCreationService.ts
@@ -1,6 +1,8 @@
 import type { Agent } from '../types';
 import type { Project, Task } from '../types/app';
 import type { AgentRun, TaskMetadata } from '../types/chat';
+import type { ProviderCustomConfig } from '@shared/providers/customConfig';
+import type { ProviderId } from '@shared/providers/registry';
 import { type GitHubIssueSummary } from '../types/github';
 import { type JiraIssueSummary } from '../types/jira';
 import { type LinearIssueSummary } from '../types/linear';
@@ -24,6 +26,7 @@ export interface CreateTaskParams {
   nameGenerated?: boolean;
   useWorktree: boolean;
   baseRef?: string;
+  agentPresets?: Partial<Record<ProviderId, ProviderCustomConfig>>;
   preflightPromise?: Promise<unknown>;
 }
 
@@ -304,6 +307,7 @@ export async function createTask(params: CreateTaskParams): Promise<CreateTaskRe
     nameGenerated,
     useWorktree,
     baseRef,
+    agentPresets,
     preflightPromise,
   } = params;
 
@@ -367,7 +371,8 @@ export async function createTask(params: CreateTaskParams): Promise<CreateTaskRe
     linkedForgejoIssue ||
     preparedPrompt ||
     autoApprove ||
-    nameGenerated
+    nameGenerated ||
+    (agentPresets && Object.keys(agentPresets).length > 0)
       ? {
           linearIssue: linkedLinearIssue ?? null,
           jiraIssue: linkedJiraIssue ?? null,
@@ -378,6 +383,7 @@ export async function createTask(params: CreateTaskParams): Promise<CreateTaskRe
           initialPrompt: preparedPrompt ?? null,
           autoApprove: autoApprove ?? null,
           nameGenerated: nameGenerated ?? null,
+          agentPresets: agentPresets && Object.keys(agentPresets).length > 0 ? agentPresets : null,
         }
       : null;
 

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -1,4 +1,5 @@
 import type { ProviderId } from '@shared/providers/registry';
+import type { ProviderCustomConfig } from '@shared/providers/customConfig';
 import { type LinearIssueSummary } from './linear';
 import { type GitHubIssueSummary } from './github';
 import { type JiraIssueSummary } from './jira';
@@ -37,6 +38,8 @@ export interface TaskMetadata {
   prNumber?: number | null;
   /** PR title when this task is a PR review task */
   prTitle?: string | null;
+  /** Per-task CLI overrides keyed by provider id. */
+  agentPresets?: Partial<Record<ProviderId, ProviderCustomConfig>> | null;
   // When present, this task is a multi-agent task orchestrating multiple worktrees
   multiAgent?: {
     enabled: boolean;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1,6 +1,10 @@
 // Updated for Codex integration
 
 import type { AgentEvent } from '../../shared/agentEvents';
+import type {
+  ProviderCustomConfig,
+  ProviderCustomConfigs,
+} from '../../shared/providers/customConfig';
 import type { AutoMergeRequest } from '../lib/prStatus';
 
 type ProjectSettingsPayload = {
@@ -24,17 +28,7 @@ export type LineComment = {
   sentAt?: string | null;
 };
 
-export type ProviderCustomConfig = {
-  cli?: string;
-  resumeFlag?: string;
-  defaultArgs?: string;
-  autoApproveFlag?: string;
-  initialPromptFlag?: string;
-  extraArgs?: string;
-  env?: Record<string, string>;
-};
-
-export type ProviderCustomConfigs = Record<string, ProviderCustomConfig>;
+export type { ProviderCustomConfig, ProviderCustomConfigs };
 
 export {};
 

--- a/src/shared/providers/customConfig.ts
+++ b/src/shared/providers/customConfig.ts
@@ -1,0 +1,11 @@
+export interface ProviderCustomConfig {
+  cli?: string;
+  resumeFlag?: string;
+  defaultArgs?: string;
+  autoApproveFlag?: string;
+  initialPromptFlag?: string;
+  extraArgs?: string;
+  env?: Record<string, string>;
+}
+
+export type ProviderCustomConfigs = Record<string, ProviderCustomConfig>;

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -121,6 +121,8 @@ const getProviderRuntimeCliArgsMock = vi.fn((opts: any) => {
   return ['-c', 'notify=["sh","-lc","mock-codex-notify","sh"]'];
 });
 const resolveProviderCommandConfigMock = vi.fn();
+const getTaskByIdMock = vi.fn<(taskId: string) => Promise<any>>(async () => null);
+const getConversationByIdMock = vi.fn<(conversationId: string) => Promise<any>>(async () => null);
 const getPtyMock = vi.fn((id: string) => ptys.get(id));
 const writePtyMock = vi.fn((id: string, data: string) => {
   ptys.get(id)?.write(data);
@@ -244,7 +246,10 @@ vi.mock('../../main/services/TerminalConfigParser', () => ({
 }));
 
 vi.mock('../../main/services/DatabaseService', () => ({
-  databaseService: {},
+  databaseService: {
+    getTaskById: getTaskByIdMock,
+    getConversationById: getConversationByIdMock,
+  },
 }));
 
 vi.mock('../../main/services/ClaudeConfigService', () => ({
@@ -315,6 +320,8 @@ describe('ptyIpc notification lifecycle', () => {
     codexThreadExistsForCwdMock.mockResolvedValue(true);
     codexFindLatestRecentThreadForCwdMock.mockResolvedValue(null);
     codexFindLatestThreadForCwdMock.mockResolvedValue(null);
+    getTaskByIdMock.mockResolvedValue(null);
+    getConversationByIdMock.mockResolvedValue(null);
   });
 
   function createSender() {
@@ -618,6 +625,90 @@ describe('ptyIpc notification lifecycle', () => {
     expect(written).toContain('gpt-5');
     expect(written).toContain('--dangerously-bypass-approvals-and-sandbox');
     expect(written).toContain('hello world');
+  });
+
+  it('passes task-scoped agent preset overrides into provider resolution', async () => {
+    getTaskByIdMock.mockResolvedValue({
+      id: 'task-preset',
+      metadata: {
+        agentPresets: {
+          codex: {
+            defaultArgs: '--model gpt-5-mini',
+            extraArgs: '--sandbox workspace-write',
+          },
+        },
+      },
+    });
+    resolveProviderCommandConfigMock.mockReturnValue({
+      provider: {
+        id: 'codex',
+        name: 'Codex',
+        useKeystrokeInjection: false,
+      },
+      cli: 'codex',
+      defaultArgs: ['--model', 'gpt-5-mini'],
+      extraArgs: ['--sandbox', 'workspace-write'],
+      autoApproveFlag: '--full-auto',
+      initialPromptFlag: '',
+    });
+
+    const { registerPtyIpc } = await import('../../main/services/ptyIpc');
+    registerPtyIpc();
+
+    const startDirect = ipcHandleHandlers.get('pty:startDirect');
+    expect(startDirect).toBeTypeOf('function');
+
+    const id = makePtyId('codex', 'main', 'task-preset');
+    const result = await startDirect!(
+      { sender: createSender() },
+      { id, providerId: 'codex', cwd: '/tmp/task', cols: 120, rows: 32 }
+    );
+
+    expect(result?.ok).toBe(true);
+    expect(getTaskByIdMock).toHaveBeenCalledWith('task-preset');
+    expect(startDirectPtyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerConfigOverride: {
+          defaultArgs: '--model gpt-5-mini',
+          extraArgs: '--sandbox workspace-write',
+        },
+      })
+    );
+  });
+
+  it('applies task-scoped presets for multi-agent variant PTY ids', async () => {
+    getTaskByIdMock.mockResolvedValue({
+      id: 'variant-worktree',
+      metadata: {
+        agentPresets: {
+          codex: {
+            defaultArgs: '--model gpt-5-mini',
+          },
+        },
+      },
+    });
+
+    const { registerPtyIpc } = await import('../../main/services/ptyIpc');
+    registerPtyIpc();
+
+    const startDirect = ipcHandleHandlers.get('pty:startDirect');
+    expect(startDirect).toBeTypeOf('function');
+
+    const id = makePtyId('codex', 'main', 'variant-worktree');
+    const result = await startDirect!(
+      { sender: createSender() },
+      { id, providerId: 'codex', cwd: '/tmp/task-variant', cols: 120, rows: 32 }
+    );
+
+    expect(result?.ok).toBe(true);
+    expect(getTaskByIdMock).toHaveBeenCalledWith('variant-worktree');
+    expect(startDirectPtyMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerConfigOverride: {
+          defaultArgs: '--model gpt-5-mini',
+        },
+      })
+    );
   });
 
   it('quotes remote custom CLI tokens to prevent shell metachar expansion', async () => {

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -99,6 +99,47 @@ describe('ptyManager provider command resolution', () => {
     expect(config?.initialPromptFlag).toBe('');
   });
 
+  it('prefers task-scoped provider overrides over global settings', async () => {
+    getProviderCustomConfigMock.mockReturnValue({
+      cli: 'codex-global',
+      defaultArgs: '--model gpt-5',
+      extraArgs: '--approval-mode full',
+    });
+
+    const { resolveProviderCommandConfig } = await import('../../main/services/ptyManager');
+    const config = resolveProviderCommandConfig('codex', {
+      defaultArgs: '--model gpt-5-mini',
+      extraArgs: '--sandbox workspace-write',
+    });
+
+    expect(config?.cli).toBe('codex-global');
+    expect(config?.defaultArgs).toEqual(['--model', 'gpt-5-mini']);
+    expect(config?.extraArgs).toEqual(['--sandbox', 'workspace-write']);
+  });
+
+  it('merges task-scoped env overrides with global provider env', async () => {
+    getProviderCustomConfigMock.mockReturnValue({
+      env: {
+        OPENAI_API_KEY: 'global-key',
+        SHARED_FLAG: 'global',
+      },
+    });
+
+    const { resolveProviderCommandConfig } = await import('../../main/services/ptyManager');
+    const config = resolveProviderCommandConfig('codex', {
+      env: {
+        SHARED_FLAG: 'task',
+        TASK_ONLY_FLAG: 'enabled',
+      },
+    });
+
+    expect(config?.env).toEqual({
+      OPENAI_API_KEY: 'global-key',
+      SHARED_FLAG: 'task',
+      TASK_ONLY_FLAG: 'enabled',
+    });
+  });
+
   it('builds provider CLI args consistently from resolved flags', async () => {
     const { buildProviderCliArgs } = await import('../../main/services/ptyManager');
 


### PR DESCRIPTION
## Summary

Add task-scoped agent presets so each task can override provider CLI settings such as model, args, and env without changing the global provider configuration. The implementation persists presets in task metadata, applies them during local and remote PTY startup, and adds task-creation UI for editing per-provider presets.

This also fixes two follow-up correctness gaps found during review:
- multi-agent panes now use standard PTY ids so task presets resolve for variant terminals
- task-level env overrides merge over global provider env instead of replacing it

## Fixes

Fixes #1472

## Snapshot

UI change only affects the task creation flow. No screenshots attached.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes
