### PR TITLE
fix(agent): stabilize conversation tab titles with persistent numbering

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -34,6 +34,10 @@ import { useAppSettings } from '@/contexts/AppSettingsProvider';
 import type { Project } from '../types/app';
 import { useTerminalSearch } from '../hooks/useTerminalSearch';
 import { TerminalSearchOverlay } from './TerminalSearchOverlay';
+import {
+  getConversationTabLabel,
+  planConversationTitleUpdates,
+} from '../lib/conversationTabTitles';
 
 declare const window: Window & {
   electronAPI: {
@@ -61,8 +65,6 @@ function ConversationTabButton({
   onSwitchChat,
   onCloseChat,
   totalConversationCount,
-  sameAgentCount,
-  showNumber,
   fallbackBusy,
   taskId,
 }: {
@@ -71,15 +73,13 @@ function ConversationTabButton({
   onSwitchChat: (conversationId: string) => void;
   onCloseChat: (conversationId: string) => void;
   totalConversationCount: number;
-  sameAgentCount: number;
-  showNumber: boolean;
   fallbackBusy: boolean;
   taskId: string;
 }) {
   const isActive = conversation.id === activeConversationId;
   const convAgent = conversation.provider ?? 'claude';
   const config = agentConfig[convAgent as Agent];
-  const agentName = config?.name || convAgent;
+  const tabLabel = getConversationTabLabel(conversation);
   const semanticStatus = useConversationStatus({
     statusId: conversation.isMain ? taskId : conversation.id,
     ptySuffix: conversation.isMain ? taskId : conversation.id,
@@ -99,7 +99,7 @@ function ConversationTabButton({
           ? 'bg-background text-foreground shadow-sm'
           : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
       )}
-      title={`${agentName}${showNumber ? ` (${sameAgentCount})` : ''}`}
+      title={tabLabel}
     >
       {config?.logo && (
         <AgentLogo
@@ -110,10 +110,7 @@ function ConversationTabButton({
           className="h-3.5 w-3.5 flex-shrink-0"
         />
       )}
-      <span className="max-w-[10rem] truncate">
-        {agentName}
-        {showNumber && <span className="ml-1 opacity-60">{sameAgentCount}</span>}
-      </span>
+      <span className="max-w-[10rem] truncate">{tabLabel}</span>
       {totalConversationCount > 1 ? (
         <TaskStatusIndicator status={displayStatus} unread={unread && !isActive} />
       ) : null}
@@ -174,6 +171,27 @@ const ChatInterface: React.FC<Props> = ({
   const lockedAgentWriteRef = useRef<string | null>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [tabsOverflow, setTabsOverflow] = useState(false);
+
+  const applyStableConversationTitles = useCallback(async (loadedConversations: Conversation[]) => {
+    const updates = planConversationTitleUpdates(loadedConversations);
+    if (updates.length === 0) return loadedConversations;
+
+    await Promise.all(
+      updates.map((update) =>
+        rpc.db.updateConversationTitle({
+          conversationId: update.id,
+          title: update.title,
+        })
+      )
+    );
+
+    const titleById = new Map(updates.map((update) => [update.id, update.title]));
+    return loadedConversations.map((conversation) =>
+      titleById.has(conversation.id)
+        ? { ...conversation, title: titleById.get(conversation.id)! }
+        : conversation
+    );
+  }, []);
 
   const mainConversationId = useMemo(
     () => conversations.find((c) => c.isMain)?.id ?? null,
@@ -265,13 +283,14 @@ const ChatInterface: React.FC<Props> = ({
     const loadConversations = async () => {
       setConversationsLoaded(false);
       const loadedConversations = await rpc.db.getConversations(task.id);
+      const normalizedConversations = await applyStableConversationTitles(loadedConversations);
       if (cancelled) return;
 
-      if (loadedConversations.length > 0) {
-        setConversations(loadedConversations);
+      if (normalizedConversations.length > 0) {
+        setConversations(normalizedConversations);
 
         // Set active conversation
-        const active = loadedConversations.find((c: Conversation) => c.isActive);
+        const active = normalizedConversations.find((c: Conversation) => c.isActive);
         if (active) {
           setActiveConversationId(active.id);
           // Update agent to match the active conversation
@@ -280,7 +299,7 @@ const ChatInterface: React.FC<Props> = ({
           }
         } else {
           // Fallback to first conversation
-          const firstConv = loadedConversations[0];
+          const firstConv = normalizedConversations[0];
           setActiveConversationId(firstConv.id);
           // Update agent to match the first conversation
           if (firstConv.provider) {
@@ -303,14 +322,16 @@ const ChatInterface: React.FC<Props> = ({
         });
         if (cancelled) return;
         if (defaultConversation) {
-          // Provider is guaranteed by getOrCreateDefaultConversation (saves atomically)
-          setConversations([
+          const normalizedConversations = await applyStableConversationTitles([
             {
               ...defaultConversation,
               isMain: true,
               isActive: true,
             },
           ]);
+          if (cancelled) return;
+          // Provider is guaranteed by getOrCreateDefaultConversation (saves atomically)
+          setConversations(normalizedConversations);
           setActiveConversationId(defaultConversation.id);
           setAgent((defaultConversation.provider || taskAgent) as Agent);
           if (!cancelled) setConversationsLoaded(true);
@@ -322,7 +343,7 @@ const ChatInterface: React.FC<Props> = ({
     return () => {
       cancelled = true;
     };
-  }, [task.id, task.agentId]); // agent is intentionally not included as a dependency
+  }, [task.id, task.agentId, applyStableConversationTitles]); // agent is intentionally not included as a dependency
 
   // Activity indicators per conversation tab (main PTY uses `task.id`, chat PTYs use `conversation.id`).
   useEffect(() => {
@@ -620,9 +641,9 @@ const ChatInterface: React.FC<Props> = ({
             await rpc.db.saveConversation({ ...missing, isActive: false });
           }
           const retryConversations = await rpc.db.getConversations(task.id);
-          setConversations(retryConversations);
+          setConversations(await applyStableConversationTitles(retryConversations));
         } else {
-          setConversations(dbConversations);
+          setConversations(await applyStableConversationTitles(dbConversations));
         }
         setActiveConversationId(newConversation.id);
         setAgent(newAgent as Agent);
@@ -640,7 +661,7 @@ const ChatInterface: React.FC<Props> = ({
         });
       }
     },
-    [task.id, toast, conversations]
+    [task.id, toast, conversations, applyStableConversationTitles]
   );
 
   const handleCreateNewChat = useCallback(() => {
@@ -687,7 +708,9 @@ const ChatInterface: React.FC<Props> = ({
       await rpc.db.deleteConversation(conversationId);
 
       // Reload conversations
-      const updatedConversations = await rpc.db.getConversations(task.id);
+      const updatedConversations = await applyStableConversationTitles(
+        await rpc.db.getConversations(task.id)
+      );
       setConversations(updatedConversations);
       // Switch to another chat if we deleted the active one
       if (conversationId === activeConversationId && updatedConversations.length > 0) {
@@ -709,7 +732,7 @@ const ChatInterface: React.FC<Props> = ({
         );
       } catch {}
     },
-    [conversations, agent, task.id, activeConversationId, toast]
+    [conversations, task.id, activeConversationId, toast, applyStableConversationTitles]
   );
 
   // Persist last-selected agent per task (including Droid)
@@ -1065,17 +1088,8 @@ const ChatInterface: React.FC<Props> = ({
                       '[mask-image:linear-gradient(to_right,black_calc(100%_-_16px),transparent)]'
                   )}
                 >
-                  {sortedConversations.map((conv, index) => {
-                    const convAgent = conv.provider ?? 'claude';
+                  {sortedConversations.map((conv) => {
                     const isBusy = busyByConversationId[conv.id] === true;
-
-                    // Count how many chats use the same agent up to this point
-                    const sameAgentCount = sortedConversations
-                      .slice(0, index + 1)
-                      .filter((c) => (c.provider ?? 'claude') === convAgent).length;
-                    const showNumber =
-                      sortedConversations.filter((c) => (c.provider ?? 'claude') === convAgent)
-                        .length > 1;
 
                     return (
                       <ConversationTabButton
@@ -1085,8 +1099,6 @@ const ChatInterface: React.FC<Props> = ({
                         onSwitchChat={handleSwitchChat}
                         onCloseChat={handleCloseChat}
                         totalConversationCount={conversations.length}
-                        sameAgentCount={sameAgentCount}
-                        showNumber={showNumber}
                         fallbackBusy={isBusy}
                         taskId={task.id}
                       />

--- a/src/renderer/lib/conversationTabTitles.ts
+++ b/src/renderer/lib/conversationTabTitles.ts
@@ -1,0 +1,135 @@
+import { agentConfig } from './agentConfig';
+
+export interface ConversationTabTitleInput {
+  id: string;
+  title: string;
+  provider?: string | null;
+  createdAt: string;
+  displayOrder?: number;
+}
+
+export interface ConversationTitleUpdate {
+  id: string;
+  title: string;
+}
+
+const LEGACY_TITLES = new Set(['Default Conversation']);
+const LEGACY_CHAT_TITLE = /^Chat \d+$/;
+
+function escapeRegex(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function getManagedTitleMatch(title: string, agentName: string): RegExpMatchArray | null {
+  return title.match(new RegExp(`^${escapeRegex(agentName)}(?: (\\d+))?$`));
+}
+
+function isLegacyTitle(title: string): boolean {
+  return LEGACY_TITLES.has(title) || LEGACY_CHAT_TITLE.test(title);
+}
+
+function sortByCreationOrder(
+  a: Pick<ConversationTabTitleInput, 'createdAt' | 'displayOrder' | 'id'>,
+  b: Pick<ConversationTabTitleInput, 'createdAt' | 'displayOrder' | 'id'>
+): number {
+  const createdDiff = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  if (createdDiff !== 0) return createdDiff;
+
+  const orderA = a.displayOrder ?? Number.MAX_SAFE_INTEGER;
+  const orderB = b.displayOrder ?? Number.MAX_SAFE_INTEGER;
+  if (orderA !== orderB) return orderA - orderB;
+
+  return a.id.localeCompare(b.id);
+}
+
+function getNextOrdinal(assigned: Set<number>, startAt: number): number {
+  let next = startAt;
+  while (assigned.has(next)) next += 1;
+  return next;
+}
+
+export function getConversationAgentName(provider?: string | null): string {
+  const providerId = (provider ?? 'claude') as keyof typeof agentConfig;
+  return agentConfig[providerId]?.name ?? provider ?? 'Claude Code';
+}
+
+export function getConversationTabLabel(conversation: {
+  title: string;
+  provider?: string | null;
+}): string {
+  const fallback = getConversationAgentName(conversation.provider);
+  const title = conversation.title?.trim();
+  if (!title || isLegacyTitle(title)) return fallback;
+  return title;
+}
+
+export function planConversationTitleUpdates(
+  conversations: ConversationTabTitleInput[]
+): ConversationTitleUpdate[] {
+  const grouped = new Map<string, ConversationTabTitleInput[]>();
+
+  for (const conversation of conversations) {
+    const providerKey = conversation.provider ?? 'claude';
+    const existing = grouped.get(providerKey);
+    if (existing) {
+      existing.push(conversation);
+    } else {
+      grouped.set(providerKey, [conversation]);
+    }
+  }
+
+  const updates: ConversationTitleUpdate[] = [];
+
+  for (const [providerKey, group] of grouped) {
+    const agentName = getConversationAgentName(providerKey);
+    const ordered = [...group].sort(sortByCreationOrder);
+    const assignedOrdinals = new Set<number>();
+
+    for (const conversation of ordered) {
+      const match = getManagedTitleMatch(conversation.title, agentName);
+      const ordinal = match?.[1] ? Number(match[1]) : null;
+      if (ordinal && Number.isFinite(ordinal)) {
+        assignedOrdinals.add(ordinal);
+      }
+    }
+
+    let nextOrdinal = assignedOrdinals.size > 0 ? Math.max(...assignedOrdinals) + 1 : 1;
+    const multipleForProvider = ordered.length > 1;
+
+    for (const conversation of ordered) {
+      const title = conversation.title?.trim() ?? '';
+      const match = getManagedTitleMatch(title, agentName);
+      const explicitOrdinal = match?.[1] ? Number(match[1]) : null;
+      const isManagedUnnumbered = Boolean(match && !match[1]);
+      const legacy = isLegacyTitle(title);
+
+      let desiredTitle = title;
+
+      if (multipleForProvider) {
+        if (explicitOrdinal && Number.isFinite(explicitOrdinal)) {
+          desiredTitle = `${agentName} ${explicitOrdinal}`;
+        } else if (isManagedUnnumbered) {
+          const ordinal = assignedOrdinals.has(1)
+            ? getNextOrdinal(assignedOrdinals, nextOrdinal)
+            : 1;
+          assignedOrdinals.add(ordinal);
+          if (ordinal >= nextOrdinal) nextOrdinal = ordinal + 1;
+          desiredTitle = `${agentName} ${ordinal}`;
+        } else if (legacy) {
+          const ordinal = getNextOrdinal(assignedOrdinals, nextOrdinal);
+          assignedOrdinals.add(ordinal);
+          nextOrdinal = ordinal + 1;
+          desiredTitle = `${agentName} ${ordinal}`;
+        }
+      } else if (legacy) {
+        desiredTitle = agentName;
+      }
+
+      if (desiredTitle !== title) {
+        updates.push({ id: conversation.id, title: desiredTitle });
+      }
+    }
+  }
+
+  return updates;
+}

--- a/src/test/renderer/conversationTabTitles.test.ts
+++ b/src/test/renderer/conversationTabTitles.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getConversationTabLabel,
+  planConversationTitleUpdates,
+} from '../../renderer/lib/conversationTabTitles';
+
+describe('conversationTabTitles', () => {
+  it('converts legacy duplicate titles into stable numbered labels', () => {
+    const updates = planConversationTitleUpdates([
+      {
+        id: 'one',
+        provider: 'claude',
+        title: 'Default Conversation',
+        createdAt: '2026-03-14T10:00:00.000Z',
+      },
+      {
+        id: 'two',
+        provider: 'claude',
+        title: 'Chat 1741946400000',
+        createdAt: '2026-03-14T10:01:00.000Z',
+      },
+    ]);
+
+    expect(updates).toEqual([
+      { id: 'one', title: 'Claude Code 1' },
+      { id: 'two', title: 'Claude Code 2' },
+    ]);
+  });
+
+  it('keeps an existing numbered label stable after earlier tabs are gone', () => {
+    const updates = planConversationTitleUpdates([
+      {
+        id: 'two',
+        provider: 'claude',
+        title: 'Claude Code 2',
+        createdAt: '2026-03-14T10:01:00.000Z',
+      },
+    ]);
+
+    expect(updates).toEqual([]);
+    expect(
+      getConversationTabLabel({
+        provider: 'claude',
+        title: 'Claude Code 2',
+      })
+    ).toBe('Claude Code 2');
+  });
+
+  it('continues numbering from the highest existing label instead of filling gaps', () => {
+    const updates = planConversationTitleUpdates([
+      {
+        id: 'two',
+        provider: 'claude',
+        title: 'Claude Code 2',
+        createdAt: '2026-03-14T10:01:00.000Z',
+      },
+      {
+        id: 'three',
+        provider: 'claude',
+        title: 'Chat 1741946460000',
+        createdAt: '2026-03-14T10:02:00.000Z',
+      },
+    ]);
+
+    expect(updates).toEqual([{ id: 'three', title: 'Claude Code 3' }]);
+  });
+
+  it('promotes an existing single auto-managed title to index 1 when a duplicate is added', () => {
+    const updates = planConversationTitleUpdates([
+      {
+        id: 'one',
+        provider: 'codex',
+        title: 'Codex',
+        createdAt: '2026-03-14T10:00:00.000Z',
+      },
+      {
+        id: 'two',
+        provider: 'codex',
+        title: 'Chat 1741946400000',
+        createdAt: '2026-03-14T10:01:00.000Z',
+      },
+    ]);
+
+    expect(updates).toEqual([
+      { id: 'one', title: 'Codex 1' },
+      { id: 'two', title: 'Codex 2' },
+    ]);
+  });
+
+  it('uses the agent name for a single legacy tab', () => {
+    const updates = planConversationTitleUpdates([
+      {
+        id: 'main',
+        provider: 'qwen',
+        title: 'Default Conversation',
+        createdAt: '2026-03-14T10:00:00.000Z',
+      },
+    ]);
+
+    expect(updates).toEqual([{ id: 'main', title: 'Qwen Code' }]);
+    expect(
+      getConversationTabLabel({
+        provider: 'qwen',
+        title: 'Default Conversation',
+      })
+    ).toBe('Qwen Code');
+  });
+});


### PR DESCRIPTION
## Summary

- Extract conversation tab title logic into a dedicated `conversationTabTitles.ts` module with `getConversationTabLabel()` and `planConversationTitleUpdates()` functions
- Replace the ephemeral per-render numbering scheme (which recounted same-agent tabs on every render, causing labels to shift when tabs were reordered or removed) with stable, persisted titles written to the database
- Normalize legacy titles (`Default Conversation`, `Chat {timestamp}`) into agent-named labels (e.g. `Claude Code 1`, `Codex 2`) on conversation load, create, and delete
- Preserve existing numbered titles across tab deletions — closing `Claude Code 1` does not renumber `Claude Code 2`

## Test plan

- [x] Unit tests in `src/test/renderer/conversationTabTitles.test.ts` covering legacy conversion, stable numbering after deletion, ordinal continuation, and single-tab fallback
- [ ] Open a task with multiple agent tabs of the same provider and verify numbered labels persist after closing/reopening the app
- [ ] Delete a middle tab and confirm remaining tabs keep their original numbers
- [ ] Create a new tab for the same provider and verify it gets the next sequential number

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- emdash-issue-footer:start -->
Fixes #1480
<!-- emdash-issue-footer:end -->