### PR TITLE
feat(ui): show changed file names in delete confirmation dialogs

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -645,6 +645,18 @@ export function registerGitIpc() {
     return { staged, unstaged, untracked };
   };
 
+  const collectChangedPaths = (changes: Array<{ path?: string }>): string[] => {
+    const seen = new Set<string>();
+    const files: string[] = [];
+    for (const change of changes) {
+      const file = typeof change.path === 'string' ? change.path.trim() : '';
+      if (!file || seen.has(file)) continue;
+      seen.add(file);
+      files.push(file);
+    }
+    return files;
+  };
+
   const getLocalAheadBehind = async (
     taskPath: string
   ): Promise<{ ahead: number; behind: number }> => {
@@ -737,6 +749,7 @@ export function registerGitIpc() {
           staged: number;
           unstaged: number;
           untracked: number;
+          files: string[];
           ahead: number;
           behind: number;
           error?: string;
@@ -759,6 +772,7 @@ export function registerGitIpc() {
               staged: number;
               unstaged: number;
               untracked: number;
+              files: string[];
               ahead: number;
               behind: number;
               error?: string;
@@ -768,6 +782,7 @@ export function registerGitIpc() {
               staged: 0,
               unstaged: 0,
               untracked: 0,
+              files: [],
               ahead: 0,
               behind: 0,
               pr: null,
@@ -823,6 +838,7 @@ export function registerGitIpc() {
               risk.staged = counts.staged;
               risk.unstaged = counts.unstaged;
               risk.untracked = counts.untracked;
+              risk.files = collectChangedPaths(changesRes as Array<{ path?: string }>);
               risk.ahead = aheadBehindRes.ahead || 0;
               risk.behind = aheadBehindRes.behind || 0;
               risk.pr = prRes.pr;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1032,6 +1032,7 @@ export interface ElectronAPI {
         staged: number;
         unstaged: number;
         untracked: number;
+        files: string[];
         ahead: number;
         behind: number;
         error?: string;

--- a/src/renderer/components/DeleteRiskFileList.tsx
+++ b/src/renderer/components/DeleteRiskFileList.tsx
@@ -1,0 +1,34 @@
+import { cn } from '@/lib/utils';
+
+type Props = {
+  files: string[];
+  limit?: number;
+  className?: string;
+};
+
+export default function DeleteRiskFileList({ files, limit = 4, className }: Props) {
+  const uniqueFiles = Array.from(new Set(files.filter((file) => file.trim().length > 0)));
+  if (uniqueFiles.length === 0) return null;
+
+  const shouldScroll = uniqueFiles.length > limit;
+
+  return (
+    <div
+      className={cn(
+        'ml-6 mt-1 flex flex-wrap gap-1',
+        shouldScroll && 'max-h-16 overflow-y-auto pr-1',
+        className
+      )}
+    >
+      {uniqueFiles.map((file) => (
+        <span
+          key={file}
+          title={file}
+          className="max-w-[220px] truncate rounded-sm border border-amber-300/70 bg-white/70 px-1.5 py-0.5 font-mono text-[11px] text-amber-900 dark:border-amber-400/30 dark:bg-black/10 dark:text-amber-50"
+        >
+          {file}
+        </span>
+      ))}
+    </div>
+  );
+}

--- a/src/renderer/components/ProjectDeleteButton.tsx
+++ b/src/renderer/components/ProjectDeleteButton.tsx
@@ -19,6 +19,7 @@ import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
 import { useDeleteRisks } from '../hooks/useDeleteRisks';
 import DeletePrNotice from './DeletePrNotice';
+import DeleteRiskFileList from './DeleteRiskFileList';
 import { isActivePr } from '../lib/prStatus';
 import type { Task } from '../types/chat';
 
@@ -172,12 +173,16 @@ export const ProjectDeleteButton: React.FC<Props> = ({
                     return (
                       <li
                         key={ws.id}
-                        className="flex items-center gap-2 rounded-md bg-amber-50/80 px-2 py-1 text-amber-900 dark:bg-amber-500/10 dark:text-amber-50"
+                        className="rounded-md bg-amber-50/80 px-2 py-1 text-amber-900 dark:bg-amber-500/10 dark:text-amber-50"
                       >
-                        <Folder className="h-4 w-4 fill-amber-700 text-amber-700" />
-                        <span className="font-medium">{ws.name}</span>
-                        <span className="text-muted-foreground">—</span>
-                        <span className="text-sm">{summary}</span>
+                        <div className="flex items-start gap-2">
+                          <Folder className="mt-0.5 h-4 w-4 flex-shrink-0 fill-amber-700 text-amber-700" />
+                          <div className="min-w-0">
+                            <div className="font-medium">{ws.name}</div>
+                            <div className="text-sm">{summary}</div>
+                          </div>
+                        </div>
+                        <DeleteRiskFileList files={status.files} />
                       </li>
                     );
                   })}

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -41,6 +41,7 @@ import { pickDefaultBranch, type BranchOption } from './BranchSelect';
 import { ConfigEditorModal } from './ConfigEditorModal';
 import { useToast } from '../hooks/use-toast';
 import DeletePrNotice from './DeletePrNotice';
+import DeleteRiskFileList from './DeleteRiskFileList';
 import PrPreviewTooltip from './PrPreviewTooltip';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
@@ -1112,12 +1113,16 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
                         return (
                           <li
                             key={ws.id}
-                            className="flex items-center gap-2 rounded-md bg-amber-50/80 px-2 py-1 text-sm text-amber-900 dark:bg-amber-500/10 dark:text-amber-50"
+                            className="rounded-md bg-amber-50/80 px-2 py-1 text-sm text-amber-900 dark:bg-amber-500/10 dark:text-amber-50"
                           >
-                            <Folder className="h-4 w-4 fill-amber-700 text-amber-700" />
-                            <span className="font-medium">{ws.name}</span>
-                            <span className="text-muted-foreground">—</span>
-                            <span>{summary || status?.error || 'Status unavailable'}</span>
+                            <div className="flex items-start gap-2">
+                              <Folder className="mt-0.5 h-4 w-4 flex-shrink-0 fill-amber-700 text-amber-700" />
+                              <div className="min-w-0">
+                                <div className="font-medium">{ws.name}</div>
+                                <div>{summary || status?.error || 'Status unavailable'}</div>
+                              </div>
+                            </div>
+                            <DeleteRiskFileList files={status?.files || []} />
                           </li>
                         );
                       })}

--- a/src/renderer/components/TaskDeleteButton.tsx
+++ b/src/renderer/components/TaskDeleteButton.tsx
@@ -20,6 +20,7 @@ import { cn } from '@/lib/utils';
 import { DELETE_RISK_SCAN_FRESH_MS, useDeleteRisks } from '../hooks/useDeleteRisks';
 import { useToast } from '../hooks/use-toast';
 import DeletePrNotice from './DeletePrNotice';
+import DeleteRiskFileList from './DeleteRiskFileList';
 import { isActivePr } from '../lib/prStatus';
 
 type Props = {
@@ -83,6 +84,7 @@ export const TaskDeleteButton: React.FC<Props> = ({
     staged: 0,
     unstaged: 0,
     untracked: 0,
+    files: [],
     ahead: 0,
     behind: 0,
     error: undefined,
@@ -176,33 +178,37 @@ export const TaskDeleteButton: React.FC<Props> = ({
                 className="space-y-2 rounded-md border border-amber-300/60 bg-amber-50 px-3 py-2 text-amber-900 dark:border-amber-500/40 dark:bg-amber-500/10 dark:text-amber-50"
               >
                 <p className="font-medium">Unmerged or unpushed work detected</p>
-                <div className="flex items-center gap-2 rounded-md bg-amber-50/80 px-2 py-1 text-amber-900 dark:bg-amber-500/10 dark:text-amber-50">
-                  <Folder className="h-4 w-4 fill-amber-700 text-amber-700" />
-                  <span className="font-medium">{taskName}</span>
-                  <span className="text-muted-foreground">—</span>
-                  <span>
-                    {[
-                      status.staged > 0
-                        ? `${status.staged} ${status.staged === 1 ? 'file' : 'files'} staged`
-                        : null,
-                      status.unstaged > 0
-                        ? `${status.unstaged} ${status.unstaged === 1 ? 'file' : 'files'} unstaged`
-                        : null,
-                      status.untracked > 0
-                        ? `${status.untracked} ${status.untracked === 1 ? 'file' : 'files'} untracked`
-                        : null,
-                      status.ahead > 0
-                        ? `ahead by ${status.ahead} ${status.ahead === 1 ? 'commit' : 'commits'}`
-                        : null,
-                      status.behind > 0
-                        ? `behind by ${status.behind} ${status.behind === 1 ? 'commit' : 'commits'}`
-                        : null,
-                    ]
-                      .filter(Boolean)
-                      .join(', ') ||
-                      status.error ||
-                      'Status unavailable'}
-                  </span>
+                <div className="rounded-md bg-amber-50/80 px-2 py-1 text-amber-900 dark:bg-amber-500/10 dark:text-amber-50">
+                  <div className="flex items-start gap-2">
+                    <Folder className="mt-0.5 h-4 w-4 flex-shrink-0 fill-amber-700 text-amber-700" />
+                    <div className="min-w-0">
+                      <div className="font-medium">{taskName}</div>
+                      <div className="text-sm">
+                        {[
+                          status.staged > 0
+                            ? `${status.staged} ${status.staged === 1 ? 'file' : 'files'} staged`
+                            : null,
+                          status.unstaged > 0
+                            ? `${status.unstaged} ${status.unstaged === 1 ? 'file' : 'files'} unstaged:`
+                            : null,
+                          status.untracked > 0
+                            ? `${status.untracked} ${status.untracked === 1 ? 'file' : 'files'} untracked:`
+                            : null,
+                          status.ahead > 0
+                            ? `ahead by ${status.ahead} ${status.ahead === 1 ? 'commit' : 'commits'}`
+                            : null,
+                          status.behind > 0
+                            ? `behind by ${status.behind} ${status.behind === 1 ? 'commit' : 'commits'}`
+                            : null,
+                        ]
+                          .filter(Boolean)
+                          .join(', ') ||
+                          status.error ||
+                          'Status unavailable'}
+                      </div>
+                    </div>
+                  </div>
+                  <DeleteRiskFileList files={status.files} limit={6} />
                 </div>
                 {status.pr && isActivePr(status.pr) ? (
                   <DeletePrNotice tasks={[{ name: taskName, pr: status.pr }]} />

--- a/src/renderer/hooks/useDeleteRisks.ts
+++ b/src/renderer/hooks/useDeleteRisks.ts
@@ -5,19 +5,19 @@ import { getCachedGitStatus } from '../lib/gitStatusCache';
 
 type TaskRef = { id: string; name: string; path: string };
 
-type RiskState = Record<
-  string,
-  {
-    staged: number;
-    unstaged: number;
-    untracked: number;
-    ahead: number;
-    behind: number;
-    error?: string;
-    pr?: PrInfo | null;
-    prKnown: boolean;
-  }
->;
+export type DeleteRiskStatus = {
+  staged: number;
+  unstaged: number;
+  untracked: number;
+  files: string[];
+  ahead: number;
+  behind: number;
+  error?: string;
+  pr?: PrInfo | null;
+  prKnown: boolean;
+};
+
+type RiskState = Record<string, DeleteRiskStatus>;
 
 export const DELETE_RISK_SCAN_FRESH_MS = 10_000;
 
@@ -58,6 +58,18 @@ export function useDeleteRisks(
   const inFlightCountRef = useRef(0);
   const eagerPrRefresh = options?.eagerPrRefresh ?? true;
 
+  const collectRiskFiles = useCallback((files: unknown): string[] => {
+    if (!Array.isArray(files)) return [];
+    return Array.from(
+      new Set(
+        files
+          .filter((file): file is string => typeof file === 'string')
+          .map((file) => file.trim())
+          .filter(Boolean)
+      )
+    );
+  }, []);
+
   const scanRisks = useCallback(
     async (options?: { force?: boolean }): Promise<RiskState> => {
       if (!enabled || tasks.length === 0) {
@@ -92,6 +104,7 @@ export function useDeleteRisks(
                   staged: typeof item.staged === 'number' ? item.staged : 0,
                   unstaged: typeof item.unstaged === 'number' ? item.unstaged : 0,
                   untracked: typeof item.untracked === 'number' ? item.untracked : 0,
+                  files: collectRiskFiles(item.files),
                   ahead: typeof item.ahead === 'number' ? item.ahead : 0,
                   behind: typeof item.behind === 'number' ? item.behind : 0,
                   error: typeof item.error === 'string' ? item.error : undefined,
@@ -131,11 +144,13 @@ export function useDeleteRisks(
               let staged = 0;
               let unstaged = 0;
               let untracked = 0;
+              let files: string[] = [];
               if (
                 statusRes.status === 'fulfilled' &&
                 statusRes.value?.success &&
                 statusRes.value.changes
               ) {
+                files = collectRiskFiles(statusRes.value.changes.map((change) => change.path));
                 for (const change of statusRes.value.changes) {
                   if (change.status === 'untracked') {
                     untracked += 1;
@@ -165,6 +180,7 @@ export function useDeleteRisks(
                   staged,
                   unstaged,
                   untracked,
+                  files,
                   ahead,
                   behind,
                   error:
@@ -182,6 +198,7 @@ export function useDeleteRisks(
                   staged: 0,
                   unstaged: 0,
                   untracked: 0,
+                  files: [],
                   ahead: 0,
                   behind: 0,
                   error: error?.message || String(error),
@@ -209,7 +226,7 @@ export function useDeleteRisks(
         setLoading(inFlightCountRef.current > 0);
       }
     },
-    [eagerPrRefresh, enabled, tasks]
+    [collectRiskFiles, eagerPrRefresh, enabled, tasks]
   );
 
   useEffect(() => {
@@ -242,7 +259,7 @@ export function useDeleteRisks(
             ? `${status.staged} ${status.staged === 1 ? 'file' : 'files'} staged`
             : null,
           status.unstaged > 0
-            ? `${status.unstaged} ${status.unstaged === 1 ? 'file' : 'files'} unstaged`
+            ? `${status.unstaged} ${status.unstaged === 1 ? 'file' : 'files'} unstaged:`
             : null,
           status.untracked > 0
             ? `${status.untracked} ${status.untracked === 1 ? 'file' : 'files'} untracked`

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -375,6 +375,7 @@ declare global {
             staged: number;
             unstaged: number;
             untracked: number;
+            files: string[];
             ahead: number;
             behind: number;
             error?: string;

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -270,6 +270,7 @@ declare global {
             staged: number;
             unstaged: number;
             untracked: number;
+            files: string[];
             ahead: number;
             behind: number;
             error?: string;


### PR DESCRIPTION
## Summary

Enhances the delete confirmation dialogs for tasks and projects by listing the actual file paths that have uncommitted changes, giving users concrete visibility into what work would be lost.

## Changes

- Added `DeleteRiskFileList` component that renders changed file names as compact mono-spaced badges with scrollable overflow
- Extended the `git:taskDeleteRisks` IPC response to include a `files: string[]` field alongside the existing counts
- Added `collectChangedPaths` helper in `gitIpc.ts` to deduplicate and extract file paths from git status results
- Updated `useDeleteRisks` hook to propagate file paths through the risk state, with a `collectRiskFiles` sanitizer
- Refactored risk item layout in `TaskDeleteButton`, `ProjectDeleteButton`, and `ProjectMainView` from inline flex to a stacked layout to accommodate the file list
- Exported `DeleteRiskStatus` type from `useDeleteRisks` for reuse

## Test plan

- [ ] Create a task, make file changes (staged, unstaged, untracked), then open the delete dialog — changed file names should appear as badges
- [ ] Delete a project with multiple tasks that have changes — each task should list its changed files
- [ ] Verify scrollable overflow when many files are changed (> limit)
- [ ] Confirm dark mode styling renders correctly
- [ ] Run `pnpm run type-check` and `pnpm run lint`