### PR TITLE
fix(ui): increase default right sidebar width for better terminal readability

### DIFF
--- a/src/renderer/constants/layout.ts
+++ b/src/renderer/constants/layout.ts
@@ -1,6 +1,6 @@
 export const TITLEBAR_HEIGHT = '36px';
 export const PANEL_LAYOUT_STORAGE_KEY = 'emdash.layout.left-main-right.v2';
-export const DEFAULT_PANEL_LAYOUT: [number, number, number] = [20, 60, 20];
+export const DEFAULT_PANEL_LAYOUT: [number, number, number] = [18, 57, 25];
 export const LEFT_SIDEBAR_MIN_SIZE = 16;
 export const LEFT_SIDEBAR_MAX_SIZE = 30;
 export const FIRST_LAUNCH_KEY = 'emdash:first-launch:v1';


### PR DESCRIPTION
Fixes #1489

The terminal pane was difficult to use because the right sidebar default
width was only 20%, causing excessive line wrapping for agent output.

This change increases the default sidebar width to improve terminal
readability while keeping the main editor area usable.