### PR TITLE
fix(test): flaky ptyIpc test - "binds immediately to an existing exact-cwd Codex thread before polling"

### DIFF
--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { makePtyId } from '../../shared/ptyId';
 
 type ExitPayload = {
@@ -315,6 +315,12 @@ describe('ptyIpc notification lifecycle', () => {
     codexThreadExistsForCwdMock.mockResolvedValue(true);
     codexFindLatestRecentThreadForCwdMock.mockResolvedValue(null);
     codexFindLatestThreadForCwdMock.mockResolvedValue(null);
+    vi.useFakeTimers();
+  });
+
+  afterEach(async () => {
+    await vi.runAllTimersAsync();
+    vi.useRealTimers();
   });
 
   function createSender() {
@@ -522,7 +528,7 @@ describe('ptyIpc notification lifecycle', () => {
     );
 
     expect(result?.ok).toBe(true);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await vi.runAllTimersAsync();
 
     expect(codexFindLatestRecentThreadForCwdMock).toHaveBeenCalled();
     expect(markCodexSessionBoundMock).toHaveBeenCalledWith(id, 'thread-123', '/tmp/task');
@@ -550,7 +556,7 @@ describe('ptyIpc notification lifecycle', () => {
     );
 
     expect(result?.ok).toBe(true);
-    await new Promise((resolve) => setTimeout(resolve, 0));
+    await vi.runAllTimersAsync();
 
     expect(codexFindLatestThreadForCwdMock).toHaveBeenCalledWith('/tmp/task');
     expect(codexFindLatestRecentThreadForCwdMock).not.toHaveBeenCalled();


### PR DESCRIPTION
## Summary

The test `ptyIpc notification lifecycle > binds immediately to an existing
exact-cwd Codex thread before polling` was failing non-deterministically
when running the full test suite, observed at ~55% failure rate (11/20 runs).

Failing assertion:
`expect(codexFindLatestRecentThreadForCwdMock).not.toHaveBeenCalled();`
// AssertionError: expected "spy" not to be called, but called 1 time


## Root Cause
bindCodexThreadForPty() runs a background polling loop:

while (true) {
  const thread = await findLatestRecentThreadForCwd(cwd); // ← the mock
  if (thread) { markCodexSessionBound(...); return; }
  await sleep(250); // ← setTimeout macrotask, outlives the test
  if (Date.now() - startTime > 20_000) return;
}
When the preceding test (prunes stale exact Codex resume targets...)
started a PTY with the mock returning null, the polling loop kept
scheduling sleep(250) macrotasks. These leaked across the test boundary:

Test N completes -> sleep(250) macrotask still pending
Test N+1 beforeEach runs -> vi.clearAllMocks() resets call count to 0
Leaked macrotask fires -> calls findLatestRecentThreadForCwd -> count = 1
Test N+1 asserts not.toHaveBeenCalled() -> FAILS
Race window is CPU-load-dependent, making it worse under full-suite
parallel execution.



##Fix
- Add vi.useFakeTimers() in beforeEach -> puts all setTimeout calls under test control

- Add afterEach that calls vi.runAllTimersAsync() -> exhausts the entire polling loop (advances fake clock to the 20s deadline) before the next test starts, then restores real timers with vi.useRealTimers()

- Replace await new Promise(resolve => setTimeout(resolve, 0)) in the two affected tests with await vi.runAllTimersAsync() -> necessary since real setTimeout no longer auto-fires under fake timers

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes