### PR TITLE
feat(nav): add back/forward navigation buttons

### DIFF
--- a/src/main/app/window.ts
+++ b/src/main/app/window.ts
@@ -89,6 +89,32 @@ export function createMainWindow(): BrowserWindow {
     });
   }
 
+  // macOS trackpad two-finger swipe navigation (respects setting)
+  if (process.platform === 'darwin') {
+    mainWindow.on('swipe', (_event, direction) => {
+      void import('../settings').then(({ getAppSettings }) => {
+        const settings = getAppSettings();
+        if (!settings.navigation?.trackpadSwipe) return;
+        if (direction === 'left') {
+          mainWindow?.webContents.send('navigate:back');
+        } else if (direction === 'right') {
+          mainWindow?.webContents.send('navigate:forward');
+        }
+      });
+    });
+  }
+
+  // Windows/Linux mouse back/forward buttons via app-command
+  if (process.platform !== 'darwin') {
+    mainWindow.on('app-command', (_event, command) => {
+      if (command === 'browser-backward') {
+        mainWindow?.webContents.send('navigate:back');
+      } else if (command === 'browser-forward') {
+        mainWindow?.webContents.send('navigate:forward');
+      }
+    });
+  }
+
   // Cleanup reference on close
   mainWindow.on('closed', () => {
     mainWindow = null;

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -227,6 +227,20 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => ipcRenderer.removeListener(channel, wrapped);
   },
 
+  // Navigation events (main → renderer) — trackpad swipe / mouse back-forward
+  onNavigateBack: (listener: () => void) => {
+    const channel = 'navigate:back';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onNavigateForward: (listener: () => void) => {
+    const channel = 'navigate:forward';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+
   // Worktree management
   worktreeCreate: (args: {
     projectPath: string;

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -113,6 +113,9 @@ export interface AppSettings {
     defaultDirectory: string;
   };
   keyboard?: KeyboardSettings;
+  navigation?: {
+    trackpadSwipe: boolean;
+  };
   interface?: InterfaceSettings;
   providerConfigs?: ProviderCustomConfigs;
   terminal?: {
@@ -177,6 +180,9 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   projects: {
     defaultDirectory: join(homedir(), 'emdash-projects'),
+  },
+  navigation: {
+    trackpadSwipe: true,
   },
   keyboard: {
     commandPalette: { key: 'k', modifier: 'cmd' },
@@ -574,6 +580,12 @@ export function normalizeSettings(input: AppSettings): AppSettings {
       }
     }
   }
+
+  // Navigation
+  const nav = (input as any)?.navigation || {};
+  out.navigation = {
+    trackpadSwipe: Boolean(nav?.trackpadSwipe ?? DEFAULT_SETTINGS.navigation!.trackpadSwipe),
+  };
 
   // Terminal
   const term = (input as any)?.terminal || {};

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -12,6 +12,7 @@ import { EmdashAccountProvider } from './contexts/EmdashAccountProvider';
 import { PostHogFeatureFlagProvider } from './contexts/PostHogFeatureFlagProvider';
 import { ProjectManagementProvider } from './contexts/ProjectManagementProvider';
 import { TaskManagementProvider } from './contexts/TaskManagementContext';
+import { NavigationHistoryProvider } from './contexts/NavigationHistoryProvider';
 import { ModalProvider } from './contexts/ModalProvider';
 
 const queryClient = new QueryClient();
@@ -41,11 +42,13 @@ export function App() {
               <GithubContextProvider>
                 <ProjectManagementProvider>
                   <TaskManagementProvider>
-                    <AppSettingsProvider>
-                      <ThemeProvider>
-                        <ErrorBoundary>{renderContent()}</ErrorBoundary>
-                      </ThemeProvider>
-                    </AppSettingsProvider>
+                    <NavigationHistoryProvider>
+                      <AppSettingsProvider>
+                        <ThemeProvider>
+                          <ErrorBoundary>{renderContent()}</ErrorBoundary>
+                        </ThemeProvider>
+                      </AppSettingsProvider>
+                    </NavigationHistoryProvider>
                   </TaskManagementProvider>
                 </ProjectManagementProvider>
               </GithubContextProvider>

--- a/src/renderer/components/AppKeyboardShortcuts.tsx
+++ b/src/renderer/components/AppKeyboardShortcuts.tsx
@@ -24,6 +24,8 @@ export interface AppKeyboardShortcutsProps {
   handleToggleKanban: () => void;
   handleToggleEditor: () => void;
   handleOpenInEditor: () => void;
+  handleNavigateBack: () => void;
+  handleNavigateForward: () => void;
 }
 
 const AppKeyboardShortcuts: React.FC<AppKeyboardShortcutsProps> = ({
@@ -44,6 +46,8 @@ const AppKeyboardShortcuts: React.FC<AppKeyboardShortcutsProps> = ({
   handleToggleKanban,
   handleToggleEditor,
   handleOpenInEditor,
+  handleNavigateBack,
+  handleNavigateForward,
 }) => {
   const { toggle: toggleLeftSidebar } = useSidebar();
   const { toggle: toggleRightSidebar } = useRightSidebar();
@@ -73,6 +77,8 @@ const AppKeyboardShortcuts: React.FC<AppKeyboardShortcutsProps> = ({
     onSelectAgentTab: (tabIndex) =>
       window.dispatchEvent(new CustomEvent('emdash:select-agent-tab', { detail: { tabIndex } })),
     onOpenInEditor: handleOpenInEditor,
+    onNavigateBack: handleNavigateBack,
+    onNavigateForward: handleNavigateForward,
     onCloseModal: (
       [
         [showCommandPalette, handleCloseCommandPalette],

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -23,6 +23,7 @@ import ThemeCard from './ThemeCard';
 import KeyboardSettingsCard from './KeyboardSettingsCard';
 import RightSidebarSettingsCard from './RightSidebarSettingsCard';
 import BrowserPreviewSettingsCard from './BrowserPreviewSettingsCard';
+import TrackpadNavigationSettingsCard from './TrackpadNavigationSettingsCard';
 import TaskHoverActionCard from './TaskHoverActionCard';
 import TerminalSettingsCard from './TerminalSettingsCard';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
@@ -267,6 +268,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
               <ResourceMonitorSettingsCard />
               <RightSidebarSettingsCard />
               <BrowserPreviewSettingsCard />
+              <TrackpadNavigationSettingsCard />
               <TaskHoverActionCard />
             </div>
           ),

--- a/src/renderer/components/TrackpadNavigationSettingsCard.tsx
+++ b/src/renderer/components/TrackpadNavigationSettingsCard.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { Switch } from './ui/switch';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
+
+export default function TrackpadNavigationSettingsCard() {
+  const { settings, updateSettings, isLoading, isSaving } = useAppSettings();
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-1 flex-col gap-0.5">
+        <span className="text-sm font-medium text-foreground">Trackpad swipe navigation</span>
+        <span className="text-sm text-muted-foreground">
+          Navigate back and forward between views using trackpad swipe gestures.
+        </span>
+      </div>
+      <Switch
+        checked={settings?.navigation?.trackpadSwipe ?? true}
+        disabled={isLoading || isSaving}
+        onCheckedChange={(next) => updateSettings({ navigation: { trackpadSwipe: next } })}
+      />
+    </div>
+  );
+}

--- a/src/renderer/components/TrackpadNavigationSettingsCard.tsx
+++ b/src/renderer/components/TrackpadNavigationSettingsCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { Switch } from './ui/switch';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
 
+/** Settings toggle for enabling/disabling trackpad swipe navigation gestures. */
 export default function TrackpadNavigationSettingsCard() {
   const { settings, updateSettings, isLoading, isSaving } = useAppSettings();
 

--- a/src/renderer/components/titlebar/Titlebar.tsx
+++ b/src/renderer/components/titlebar/Titlebar.tsx
@@ -2,12 +2,15 @@ import React, { useCallback, useEffect, useRef, useState } from 'react';
 import type { LucideIcon } from 'lucide-react';
 import {
   ArrowLeft,
+  ChevronLeft,
+  ChevronRight,
   Command,
   MessageSquare,
   Settings as SettingsIcon,
   KanbanSquare,
   Code2,
 } from 'lucide-react';
+import { useNavigationHistoryContext } from '../../contexts/NavigationHistoryProvider';
 import { ShortcutHint } from '../ui/shortcut-hint';
 import SidebarLeftToggleButton from './SidebarLeftToggleButton';
 import SidebarRightToggleButton from './SidebarRightToggleButton';
@@ -115,6 +118,7 @@ const Titlebar: React.FC<TitlebarProps> = ({
   const { user: githubUser } = useGithubContext();
   const { settings } = useAppSettings();
   const showResourceMonitor = settings?.interface?.showResourceMonitor ?? false;
+  const { canGoBack, canGoForward, goBack, goForward } = useNavigationHistoryContext();
 
   const isTaskMultiAgent = Boolean(activeTask?.metadata?.multiAgent?.enabled);
   const currentPath = isTaskMultiAgent
@@ -218,12 +222,59 @@ const Titlebar: React.FC<TitlebarProps> = ({
             <TitlebarMenu />
           </div>
         )}
+        {/* Left: navigation + performance chip */}
         <div
           className="pointer-events-auto flex flex-shrink-0 items-center [-webkit-app-region:no-drag]"
           style={{
             paddingLeft: isMacOS ? 'env(titlebar-area-x, 80px)' : '0.5rem',
           }}
         >
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Navigate back"
+                  disabled={!canGoBack}
+                  onClick={goBack}
+                  className="h-7 w-7 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+                >
+                  <ChevronLeft className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs font-medium">
+                <div className="flex flex-col gap-1">
+                  <span>Back</span>
+                  <ShortcutHint settingsKey="navigateBack" />
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider delayDuration={200}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="icon"
+                  aria-label="Navigate forward"
+                  disabled={!canGoForward}
+                  onClick={goForward}
+                  className="h-7 w-7 text-muted-foreground transition-colors hover:bg-transparent hover:text-foreground disabled:pointer-events-none disabled:opacity-30"
+                >
+                  <ChevronRight className="h-4 w-4" />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" className="text-xs font-medium">
+                <div className="flex flex-col gap-1">
+                  <span>Forward</span>
+                  <ShortcutHint settingsKey="navigateForward" />
+                </div>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           {showResourceMonitor ? <PerformanceChip /> : null}
         </div>
         {/* Center: project/task context (grows to fill) */}

--- a/src/renderer/contexts/NavigationHistoryProvider.tsx
+++ b/src/renderer/contexts/NavigationHistoryProvider.tsx
@@ -6,6 +6,7 @@ type NavigationHistoryContextValue = ReturnType<typeof useNavigationHistory>;
 
 const NavigationHistoryContext = createContext<NavigationHistoryContextValue | null>(null);
 
+/** Access the navigation history context (goBack, goForward, canGoBack, canGoForward). */
 export function useNavigationHistoryContext(): NavigationHistoryContextValue {
   const ctx = useContext(NavigationHistoryContext);
   if (!ctx) {
@@ -14,6 +15,7 @@ export function useNavigationHistoryContext(): NavigationHistoryContextValue {
   return ctx;
 }
 
+/** Provides navigation history to the component tree, wiring up task lookup from TaskManagementContext. */
 export function NavigationHistoryProvider({ children }: { children: React.ReactNode }) {
   const { allTasks } = useTaskManagementContext();
 

--- a/src/renderer/contexts/NavigationHistoryProvider.tsx
+++ b/src/renderer/contexts/NavigationHistoryProvider.tsx
@@ -1,0 +1,32 @@
+import React, { createContext, useCallback, useContext } from 'react';
+import { useNavigationHistory } from '../hooks/useNavigationHistory';
+import { useTaskManagementContext } from './TaskManagementContext';
+
+type NavigationHistoryContextValue = ReturnType<typeof useNavigationHistory>;
+
+const NavigationHistoryContext = createContext<NavigationHistoryContextValue | null>(null);
+
+export function useNavigationHistoryContext(): NavigationHistoryContextValue {
+  const ctx = useContext(NavigationHistoryContext);
+  if (!ctx) {
+    throw new Error('useNavigationHistoryContext must be used within a NavigationHistoryProvider');
+  }
+  return ctx;
+}
+
+export function NavigationHistoryProvider({ children }: { children: React.ReactNode }) {
+  const { allTasks } = useTaskManagementContext();
+
+  const taskLookup = useCallback(
+    (taskId: string) => allTasks.find((t) => t.task.id === taskId)?.task,
+    [allTasks]
+  );
+
+  const navHistory = useNavigationHistory(taskLookup);
+
+  return (
+    <NavigationHistoryContext.Provider value={navHistory}>
+      {children}
+    </NavigationHistoryContext.Provider>
+  );
+}

--- a/src/renderer/contexts/NavigationHistoryProvider.tsx
+++ b/src/renderer/contexts/NavigationHistoryProvider.tsx
@@ -19,6 +19,7 @@ export function useNavigationHistoryContext(): NavigationHistoryContextValue {
 export function NavigationHistoryProvider({ children }: { children: React.ReactNode }) {
   const { allTasks } = useTaskManagementContext();
 
+  /** Find a Task object by ID across all projects for history restoration. */
   const taskLookup = useCallback(
     (taskId: string) => allTasks.find((t) => t.task.id === taskId)?.task,
     [allTasks]

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -22,7 +22,9 @@ export type ShortcutSettingsKey =
   | 'newTask'
   | 'nextAgent'
   | 'prevAgent'
-  | 'openInEditor';
+  | 'openInEditor'
+  | 'navigateBack'
+  | 'navigateForward';
 
 export interface AppShortcut {
   key: string;
@@ -210,6 +212,24 @@ export const APP_SHORTCUTS: Record<string, AppShortcut> = {
     category: 'Navigation',
     settingsKey: 'openInEditor',
   },
+
+  NAVIGATE_BACK: {
+    key: 'ArrowLeft',
+    modifier: 'option',
+    label: 'Back',
+    description: 'Navigate back to the previous view',
+    category: 'Navigation',
+    settingsKey: 'navigateBack',
+  },
+
+  NAVIGATE_FORWARD: {
+    key: 'ArrowRight',
+    modifier: 'option',
+    label: 'Forward',
+    description: 'Navigate forward to the next view',
+    category: 'Navigation',
+    settingsKey: 'navigateForward',
+  },
 };
 
 /**
@@ -390,6 +410,8 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
       nextAgent: getEffectiveConfig(APP_SHORTCUTS.NEXT_AGENT, custom),
       prevAgent: getEffectiveConfig(APP_SHORTCUTS.PREV_AGENT, custom),
       openInEditor: getEffectiveConfig(APP_SHORTCUTS.OPEN_IN_EDITOR, custom),
+      navigateBack: getEffectiveConfig(APP_SHORTCUTS.NAVIGATE_BACK, custom),
+      navigateForward: getEffectiveConfig(APP_SHORTCUTS.NAVIGATE_FORWARD, custom),
     };
   }, [handlers.customKeyboardSettings]);
 
@@ -480,6 +502,18 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
       effectiveShortcuts.openInEditor && {
         config: effectiveShortcuts.openInEditor,
         handler: () => handlers.onOpenInEditor?.(),
+        priority: 'global',
+        requiresClosed: true,
+      },
+      effectiveShortcuts.navigateBack && {
+        config: effectiveShortcuts.navigateBack,
+        handler: () => handlers.onNavigateBack?.(),
+        priority: 'global',
+        requiresClosed: true,
+      },
+      effectiveShortcuts.navigateForward && {
+        config: effectiveShortcuts.navigateForward,
+        handler: () => handlers.onNavigateForward?.(),
         priority: 'global',
         requiresClosed: true,
       },

--- a/src/renderer/hooks/useNavigationHistory.ts
+++ b/src/renderer/hooks/useNavigationHistory.ts
@@ -13,6 +13,7 @@ interface NavigationState {
 
 const MAX_HISTORY = 50;
 
+/** Compare two navigation states for equality by projectId, taskId, and view kind. */
 function statesEqual(a: NavigationState, b: NavigationState): boolean {
   return a.projectId === b.projectId && a.taskId === b.taskId && a.view === b.view;
 }

--- a/src/renderer/hooks/useNavigationHistory.ts
+++ b/src/renderer/hooks/useNavigationHistory.ts
@@ -1,0 +1,200 @@
+import { useState, useCallback, useRef, useEffect } from 'react';
+import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
+import { useTaskManagementContext } from '../contexts/TaskManagementContext';
+import type { Task } from '../types/app';
+
+type ViewKind = 'home' | 'project' | 'task' | 'skills' | 'mcp';
+
+interface NavigationState {
+  projectId: string | null;
+  taskId: string | null;
+  view: ViewKind;
+}
+
+const MAX_HISTORY = 50;
+
+function statesEqual(a: NavigationState, b: NavigationState): boolean {
+  return a.projectId === b.projectId && a.taskId === b.taskId && a.view === b.view;
+}
+
+export function useNavigationHistory(taskLookup?: (taskId: string) => Task | undefined) {
+  const {
+    selectedProject,
+    showHomeView,
+    showSkillsView,
+    showMcpView,
+    activateProjectView,
+    handleGoHome,
+    handleGoToSkills,
+    handleGoToMcp,
+    projects,
+  } = useProjectManagementContext();
+
+  const { activeTask, handleSelectTask } = useTaskManagementContext();
+
+  // Use refs for history data to avoid batching issues with nested setState
+  const historyRef = useRef<NavigationState[]>([]);
+  const indexRef = useRef(-1);
+
+  // Derived state for canGoBack/canGoForward (updated via tick)
+  const [canGoBack, setCanGoBack] = useState(false);
+  const [canGoForward, setCanGoForward] = useState(false);
+
+  const syncCanFlags = useCallback(() => {
+    setCanGoBack(indexRef.current > 0);
+    setCanGoForward(indexRef.current < historyRef.current.length - 1);
+  }, []);
+
+  // Flag to suppress recording when we're navigating via back/forward
+  const isRestoringRef = useRef(false);
+
+  // Keep task lookup in a ref so callbacks always see the latest version
+  const taskLookupRef = useRef(taskLookup);
+  useEffect(() => {
+    taskLookupRef.current = taskLookup;
+  }, [taskLookup]);
+
+  // Derive the current navigation state from app state
+  const deriveState = useCallback((): NavigationState => {
+    if (showHomeView) return { projectId: null, taskId: null, view: 'home' };
+    if (showSkillsView) return { projectId: null, taskId: null, view: 'skills' };
+    if (showMcpView) return { projectId: null, taskId: null, view: 'mcp' };
+    if (activeTask) {
+      return {
+        projectId: activeTask.projectId ?? selectedProject?.id ?? null,
+        taskId: activeTask.id,
+        view: 'task',
+      };
+    }
+    if (selectedProject) {
+      return { projectId: selectedProject.id, taskId: null, view: 'project' };
+    }
+    return { projectId: null, taskId: null, view: 'home' };
+  }, [showHomeView, showSkillsView, showMcpView, activeTask, selectedProject]);
+
+  // Record state changes into history
+  useEffect(() => {
+    if (isRestoringRef.current) {
+      isRestoringRef.current = false;
+      return;
+    }
+
+    const state = deriveState();
+    const history = historyRef.current;
+    const idx = indexRef.current;
+
+    // If identical to current entry, skip
+    if (idx >= 0 && idx < history.length && statesEqual(history[idx], state)) {
+      return;
+    }
+
+    // Truncate forward history and append
+    const truncated = history.slice(0, idx + 1);
+    truncated.push(state);
+
+    // Trim to max length
+    if (truncated.length > MAX_HISTORY) {
+      const overflow = truncated.length - MAX_HISTORY;
+      truncated.splice(0, overflow);
+    }
+
+    historyRef.current = truncated;
+    indexRef.current = truncated.length - 1;
+    syncCanFlags();
+  }, [deriveState, syncCanFlags]);
+
+  const restoreState = useCallback(
+    (state: NavigationState) => {
+      isRestoringRef.current = true;
+
+      switch (state.view) {
+        case 'home':
+          handleGoHome();
+          break;
+        case 'skills':
+          handleGoToSkills();
+          break;
+        case 'mcp':
+          handleGoToMcp();
+          break;
+        case 'project': {
+          const project = projects.find((p) => p.id === state.projectId);
+          if (project) {
+            activateProjectView(project);
+          } else {
+            handleGoHome();
+          }
+          break;
+        }
+        case 'task': {
+          const project = projects.find((p) => p.id === state.projectId);
+          if (project) {
+            if (state.taskId && taskLookupRef.current) {
+              const task = taskLookupRef.current(state.taskId);
+              if (task) {
+                handleSelectTask(task);
+              } else {
+                // Task no longer exists, navigate to project instead
+                activateProjectView(project);
+              }
+            } else {
+              activateProjectView(project);
+            }
+          } else {
+            handleGoHome();
+          }
+          break;
+        }
+      }
+    },
+    [handleGoHome, handleGoToSkills, handleGoToMcp, activateProjectView, projects, handleSelectTask]
+  );
+
+  const goBack = useCallback(() => {
+    if (indexRef.current <= 0) return;
+    const newIndex = indexRef.current - 1;
+    indexRef.current = newIndex;
+    syncCanFlags();
+    restoreState(historyRef.current[newIndex]);
+  }, [restoreState, syncCanFlags]);
+
+  const goForward = useCallback(() => {
+    if (indexRef.current >= historyRef.current.length - 1) return;
+    const newIndex = indexRef.current + 1;
+    indexRef.current = newIndex;
+    syncCanFlags();
+    restoreState(historyRef.current[newIndex]);
+  }, [restoreState, syncCanFlags]);
+
+  // Mouse back/forward buttons (buttons 3 and 4 on mice with extra buttons)
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      if (e.button === 3) {
+        e.preventDefault();
+        goBack();
+      } else if (e.button === 4) {
+        e.preventDefault();
+        goForward();
+      }
+    };
+    window.addEventListener('mousedown', handleMouseDown);
+    return () => window.removeEventListener('mousedown', handleMouseDown);
+  }, [goBack, goForward]);
+
+  // macOS trackpad swipe and Windows/Linux app-command (forwarded from main process)
+  useEffect(() => {
+    const cleanupBack = window.electronAPI.onNavigateBack(() => goBack());
+    const cleanupForward = window.electronAPI.onNavigateForward(() => goForward());
+    return () => {
+      cleanupBack();
+      cleanupForward();
+    };
+  }, [goBack, goForward]);
+
+  return {
+    canGoBack,
+    canGoForward,
+    goBack,
+    goForward,
+  };
+}

--- a/src/renderer/hooks/useNavigationHistory.ts
+++ b/src/renderer/hooks/useNavigationHistory.ts
@@ -46,6 +46,7 @@ export function useNavigationHistory(taskLookup?: (taskId: string) => Task | und
   const [canGoBack, setCanGoBack] = useState(false);
   const [canGoForward, setCanGoForward] = useState(false);
 
+  /** Sync the canGoBack/canGoForward state flags from the current ref values. */
   const syncCanFlags = useCallback(() => {
     setCanGoBack(indexRef.current > 0);
     setCanGoForward(indexRef.current < historyRef.current.length - 1);
@@ -60,7 +61,7 @@ export function useNavigationHistory(taskLookup?: (taskId: string) => Task | und
     taskLookupRef.current = taskLookup;
   }, [taskLookup]);
 
-  // Derive the current navigation state from app state
+  /** Derive the current navigation state from the active project/task/view flags. */
   const deriveState = useCallback((): NavigationState => {
     if (showHomeView) return { projectId: null, taskId: null, view: 'home' };
     if (showSkillsView) return { projectId: null, taskId: null, view: 'skills' };
@@ -109,6 +110,7 @@ export function useNavigationHistory(taskLookup?: (taskId: string) => Task | und
     syncCanFlags();
   }, [deriveState, syncCanFlags]);
 
+  /** Restore the app to a given navigation state (navigate to the correct view/project/task). */
   const restoreState = useCallback(
     (state: NavigationState) => {
       isRestoringRef.current = true;
@@ -156,6 +158,7 @@ export function useNavigationHistory(taskLookup?: (taskId: string) => Task | und
     [handleGoHome, handleGoToSkills, handleGoToMcp, activateProjectView, projects, handleSelectTask]
   );
 
+  /** Navigate to the previous entry in the history stack. */
   const goBack = useCallback(() => {
     if (indexRef.current <= 0) return;
     const newIndex = indexRef.current - 1;
@@ -164,6 +167,7 @@ export function useNavigationHistory(taskLookup?: (taskId: string) => Task | und
     restoreState(historyRef.current[newIndex]);
   }, [restoreState, syncCanFlags]);
 
+  /** Navigate to the next entry in the history stack. */
   const goForward = useCallback(() => {
     if (indexRef.current >= historyRef.current.length - 1) return;
     const newIndex = indexRef.current + 1;

--- a/src/renderer/hooks/useNavigationHistory.ts
+++ b/src/renderer/hooks/useNavigationHistory.ts
@@ -165,6 +165,13 @@ export function useNavigationHistory(taskLookup?: (taskId: string) => Task | und
     indexRef.current = newIndex;
     syncCanFlags();
     restoreState(historyRef.current[newIndex]);
+    // Safety net: if restoreState resolved to the current view (no state change),
+    // the recording effect won't fire to clear isRestoringRef. Clear it here so
+    // future navigations are still recorded. The statesEqual guard in the effect
+    // prevents duplicate entries if the effect does fire.
+    queueMicrotask(() => {
+      isRestoringRef.current = false;
+    });
   }, [restoreState, syncCanFlags]);
 
   /** Navigate to the next entry in the history stack. */
@@ -174,6 +181,9 @@ export function useNavigationHistory(taskLookup?: (taskId: string) => Task | und
     indexRef.current = newIndex;
     syncCanFlags();
     restoreState(historyRef.current[newIndex]);
+    queueMicrotask(() => {
+      isRestoringRef.current = false;
+    });
   }, [restoreState, syncCanFlags]);
 
   // Mouse back/forward buttons (buttons 3 and 4 on mice with extra buttons)

--- a/src/renderer/hooks/useNavigationHistory.ts
+++ b/src/renderer/hooks/useNavigationHistory.ts
@@ -17,6 +17,11 @@ function statesEqual(a: NavigationState, b: NavigationState): boolean {
   return a.projectId === b.projectId && a.taskId === b.taskId && a.view === b.view;
 }
 
+/**
+ * Tracks a browser-style navigation history stack across views (home, project, task,
+ * skills, MCP). Provides goBack/goForward and listens for mouse buttons, keyboard
+ * shortcuts, and IPC events from the main process (trackpad swipe, app-command).
+ */
 export function useNavigationHistory(taskLookup?: (taskId: string) => Task | undefined) {
   const {
     selectedProject,

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -69,6 +69,10 @@ declare global {
       onMenuRedo: (listener: () => void) => () => void;
       onMenuCloseTab: (listener: () => void) => () => void;
 
+      // Navigation events (trackpad swipe / mouse back-forward)
+      onNavigateBack: (listener: () => void) => () => void;
+      onNavigateForward: (listener: () => void) => () => void;
+
       // PTY
       ptyStart: (opts: {
         id: string;
@@ -1360,6 +1364,10 @@ export interface ElectronAPI {
   onMenuUndo: (listener: () => void) => () => void;
   onMenuRedo: (listener: () => void) => () => void;
   onMenuCloseTab: (listener: () => void) => () => void;
+
+  // Navigation events (trackpad swipe / mouse back-forward)
+  onNavigateBack: (listener: () => void) => () => void;
+  onNavigateForward: (listener: () => void) => () => void;
 
   // App info
   getVersion: () => Promise<string>;

--- a/src/renderer/types/shortcuts.ts
+++ b/src/renderer/types/shortcuts.ts
@@ -29,6 +29,8 @@ export interface KeyboardSettings {
   nextAgent?: KeyboardShortcutBinding;
   prevAgent?: KeyboardShortcutBinding;
   openInEditor?: KeyboardShortcutBinding;
+  navigateBack?: KeyboardShortcutBinding;
+  navigateForward?: KeyboardShortcutBinding;
 }
 
 export interface ShortcutConfig {
@@ -96,6 +98,10 @@ export interface GlobalShortcutHandlers {
 
   // Open in editor
   onOpenInEditor?: () => void;
+
+  // Navigation history
+  onNavigateBack?: () => void;
+  onNavigateForward?: () => void;
 
   // State checks
   isCommandPaletteOpen?: boolean;

--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -23,6 +23,7 @@ import {
   RIGHT_SIDEBAR_MAX_SIZE,
 } from '@/constants/layout';
 import { KeyboardSettingsProvider } from '@/contexts/KeyboardSettingsContext';
+import { useNavigationHistoryContext } from '@/contexts/NavigationHistoryProvider';
 import { useTaskManagementContext } from '@/contexts/TaskManagementContext';
 import { useAgentEvents } from '@/hooks/useAgentEvents';
 import { useAutoPrRefresh } from '@/hooks/useAutoPrRefresh';
@@ -176,6 +177,10 @@ export function Workspace() {
     });
     return () => cleanup?.();
   }, []);
+
+  // --- Navigation history ---
+  const { goBack: handleNavigateBack, goForward: handleNavigateForward } =
+    useNavigationHistoryContext();
 
   // --- Project management (provided by ProjectManagementProvider in App.tsx) ---
   const projectMgmt = useProjectManagementContext();
@@ -366,6 +371,8 @@ export function Workspace() {
                 handleToggleKanban={handleToggleKanban}
                 handleToggleEditor={handleToggleEditor}
                 handleOpenInEditor={handleOpenInEditor}
+                handleNavigateBack={handleNavigateBack}
+                handleNavigateForward={handleNavigateForward}
               />
               <RightSidebarBridge
                 onCollapsedChange={handleRightSidebarCollapsedChange}


### PR DESCRIPTION
## Summary
- Adds browser-style back/forward navigation to move between previously viewed screens (home, project, task, skills, MCP)
- Supports titlebar chevron buttons, keyboard shortcuts (Option+Arrow keys), mouse back/forward buttons, macOS trackpad swipe gestures, and Windows/Linux app-commands
- Adds a toggleable "Trackpad swipe navigation" setting under Settings > Interface > Workspace (enabled by default)

## Test plan
- [ ] Navigate between different views (home, projects, tasks, skills, MCP) and verify the back/forward buttons enable/disable correctly
- [ ] Test Option+Left / Option+Right keyboard shortcuts
- [ ] Test mouse back/forward buttons (if available)
- [ ] Test macOS trackpad swipe gestures
- [ ] Toggle the trackpad swipe setting off in Settings > Interface > Workspace and verify swipe gestures no longer navigate
- [ ] Verify history is capped at 50 entries and forward history is truncated on new navigation

Closes #1483

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Back/Forward buttons added to the titlebar with shortcut hints
  * In-app navigation history that preserves and restores viewing context
  * Trackpad swipe navigation on macOS with a toggle in Preferences (default enabled)
  * Mouse back/forward buttons and global keyboard shortcuts wired to navigation
  * System navigation events forwarded to the app so UI, gestures, and shortcuts trigger navigation actions
<!-- end of auto-generated comment: release notes by coderabbit.ai -->