### PR TITLE
feat(ci): implement auto-trigger agent on CI failure

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -122,6 +122,7 @@ import { worktreePoolService } from './services/WorktreePoolService';
 import { sshService } from './services/ssh/SshService';
 import { taskLifecycleService } from './services/TaskLifecycleService';
 import { agentEventService } from './services/AgentEventService';
+import { ciFailureOrchestratorService } from './services/ci/orchestrator';
 import * as telemetry from './telemetry';
 import { errorTracking } from './errorTracking';
 import { join } from 'path';
@@ -309,6 +310,13 @@ app.whenReady().then(async () => {
   // Register IPC handlers
   registerAllIpc();
 
+  // Start background CI failure monitor/orchestrator for active task branches
+  try {
+    ciFailureOrchestratorService.start();
+  } catch (error) {
+    console.warn('Failed to start CI failure orchestrator:', error);
+  }
+
   // Clean up any orphaned reserve worktrees from previous sessions
   worktreePoolService.cleanupOrphanedReserves(localProjectPathsForReserveCleanup).catch((error) => {
     console.warn('Failed to cleanup orphaned reserves:', error);
@@ -353,6 +361,8 @@ app.on('before-quit', () => {
   agentEventService.stop();
   // Stop any lifecycle run scripts so they do not outlive the app process.
   taskLifecycleService.shutdown();
+  // Stop CI auto-fix monitor loop.
+  ciFailureOrchestratorService.stop();
 
   // Cleanup reserve worktrees (fire and forget - don't block quit)
   worktreePoolService.cleanup().catch(() => {});

--- a/src/main/services/ci/config.ts
+++ b/src/main/services/ci/config.ts
@@ -1,0 +1,121 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { isValidProviderId } from '@shared/providers/registry';
+import { getAppSettings } from '../../settings';
+import type { CiAutoFixConfig, CiAutoFixConfigOverride } from './types';
+
+const DEFAULT_CI_AUTO_FIX_CONFIG: CiAutoFixConfig = {
+  enabled: false,
+  mode: 'review',
+  maxRetries: 2,
+  triggerFilters: {
+    include: ['*test*', '*lint*'],
+    exclude: ['*deploy*', '*build*'],
+  },
+  maxLogChars: 4_000,
+  pollIntervalMs: 120_000,
+};
+
+interface EmdashProjectConfig {
+  ciAutoFix?: CiAutoFixConfigOverride;
+}
+
+function normalizePatternList(value: unknown, fallback: string[]): string[] {
+  if (!Array.isArray(value)) {
+    return [...fallback];
+  }
+
+  const normalized = value
+    .filter((item): item is string => typeof item === 'string')
+    .map((item) => item.trim())
+    .filter(Boolean);
+
+  return normalized.length > 0 ? normalized : [...fallback];
+}
+
+function normalizeCiAutoFixConfig(
+  input: CiAutoFixConfigOverride | undefined,
+  fallback: CiAutoFixConfig
+): CiAutoFixConfig {
+  const normalizedMode =
+    input?.mode === 'auto' || input?.mode === 'review' ? input.mode : fallback.mode;
+
+  const normalizeOptionalNumber = (
+    value: number | undefined,
+    min: number,
+    max: number,
+    fallbackValue: number
+  ): number => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      return fallbackValue;
+    }
+    return Math.max(min, Math.min(max, Math.trunc(value)));
+  };
+
+  const normalizedMaxRetries = normalizeOptionalNumber(
+    input?.maxRetries,
+    0,
+    20,
+    fallback.maxRetries
+  );
+  const normalizedMaxLogChars = normalizeOptionalNumber(
+    input?.maxLogChars,
+    500,
+    40_000,
+    fallback.maxLogChars
+  );
+  const normalizedPollIntervalMs = normalizeOptionalNumber(
+    input?.pollIntervalMs,
+    15_000,
+    30 * 60_000,
+    fallback.pollIntervalMs
+  );
+
+  const providerId = isValidProviderId(input?.providerId) ? input?.providerId : fallback.providerId;
+
+  return {
+    enabled: input?.enabled ?? fallback.enabled,
+    mode: normalizedMode,
+    maxRetries: normalizedMaxRetries,
+    maxLogChars: normalizedMaxLogChars,
+    pollIntervalMs: normalizedPollIntervalMs,
+    providerId,
+    triggerFilters: {
+      include: normalizePatternList(
+        input?.triggerFilters?.include,
+        fallback.triggerFilters.include
+      ),
+      exclude: normalizePatternList(
+        input?.triggerFilters?.exclude,
+        fallback.triggerFilters.exclude
+      ),
+    },
+  };
+}
+
+function readProjectOverride(projectPath: string): CiAutoFixConfigOverride | undefined {
+  try {
+    const configPath = path.join(projectPath, '.emdash.json');
+    if (!fs.existsSync(configPath)) {
+      return undefined;
+    }
+
+    const raw = fs.readFileSync(configPath, 'utf8');
+    const parsed = JSON.parse(raw) as EmdashProjectConfig;
+    return parsed?.ciAutoFix;
+  } catch {
+    return undefined;
+  }
+}
+
+export function getGlobalCiAutoFixConfig(): CiAutoFixConfig {
+  const settings = getAppSettings();
+  const globalOverride = settings.ciAutoFix;
+  return normalizeCiAutoFixConfig(globalOverride, DEFAULT_CI_AUTO_FIX_CONFIG);
+}
+
+export function resolveCiAutoFixConfig(projectPath: string): CiAutoFixConfig {
+  const globalConfig = getGlobalCiAutoFixConfig();
+  const projectOverride = readProjectOverride(projectPath);
+  return normalizeCiAutoFixConfig(projectOverride, globalConfig);
+}

--- a/src/main/services/ci/logParser.ts
+++ b/src/main/services/ci/logParser.ts
@@ -1,0 +1,143 @@
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { stripAnsi } from '@shared/text/stripAnsi';
+import { log } from '../../lib/logger';
+import type { ParsedFailedLog } from './types';
+
+const execFileAsync = promisify(execFile);
+
+interface GitHubRunStep {
+  name?: string;
+  conclusion?: string;
+}
+
+interface GitHubRunJob {
+  name?: string;
+  steps?: GitHubRunStep[];
+}
+
+interface GitHubRunView {
+  workflowName?: string;
+  jobs?: GitHubRunJob[];
+}
+
+function collectFailedStepNames(run: GitHubRunView): string[] {
+  const failedSteps: string[] = [];
+
+  for (const job of run.jobs || []) {
+    for (const step of job.steps || []) {
+      const conclusion = (step.conclusion || '').toLowerCase();
+      if (conclusion === 'failure' || conclusion === 'timed_out' || conclusion === 'cancelled') {
+        if (step.name) {
+          failedSteps.push(step.name);
+        }
+      }
+    }
+  }
+
+  return [...new Set(failedSteps)];
+}
+
+function extractLinesForFailedSteps(rawLog: string, failedStepNames: string[]): string {
+  if (failedStepNames.length === 0) {
+    return rawLog;
+  }
+
+  const failedStepSet = new Set(failedStepNames.map((step) => step.toLowerCase()));
+  const lines = rawLog.split('\n');
+  const selected: string[] = [];
+
+  for (const line of lines) {
+    const parts = line.split('\t');
+    const stepName = parts.length > 1 ? parts[1]?.trim() : '';
+    if (stepName && failedStepSet.has(stepName.toLowerCase())) {
+      selected.push(line);
+    }
+  }
+
+  return selected.length > 0 ? selected.join('\n') : rawLog;
+}
+
+function truncateFromBottom(
+  text: string,
+  maxChars: number
+): { output: string; wasTruncated: boolean } {
+  if (text.length <= maxChars) {
+    return { output: text, wasTruncated: false };
+  }
+
+  const keepTail = text.slice(-maxChars);
+  return {
+    output: `[Output Truncated]\n${keepTail}`,
+    wasTruncated: true,
+  };
+}
+
+export function sanitizeAndTruncateLogOutput(
+  rawLog: string,
+  maxLogChars: number
+): { output: string; wasTruncated: boolean } {
+  const sanitizedLog = stripAnsi(rawLog || '', {
+    stripOscSt: true,
+    stripOtherEscapes: true,
+  }).trim();
+
+  return truncateFromBottom(sanitizedLog, maxLogChars);
+}
+
+export async function fetchAndParseFailedLog(
+  taskPath: string,
+  runId: number,
+  maxLogChars: number
+): Promise<ParsedFailedLog> {
+  let workflowName = 'GitHub Actions';
+  let failedStepNames: string[] = [];
+
+  try {
+    const { stdout: viewStdout } = await execFileAsync(
+      'gh',
+      ['run', 'view', String(runId), '--json', 'workflowName,jobs'],
+      {
+        cwd: taskPath,
+        maxBuffer: 4 * 1024 * 1024,
+      }
+    );
+
+    const runDetails = JSON.parse(viewStdout || '{}') as GitHubRunView;
+    if (runDetails.workflowName) {
+      workflowName = runDetails.workflowName;
+    }
+    failedStepNames = collectFailedStepNames(runDetails);
+  } catch (error) {
+    log.debug('fetchAndParseFailedLog: failed to fetch run details', {
+      runId,
+      taskPath,
+      error: String(error),
+    });
+  }
+
+  let rawFailedLog = '';
+  try {
+    const { stdout } = await execFileAsync('gh', ['run', 'view', String(runId), '--log-failed'], {
+      cwd: taskPath,
+      maxBuffer: 20 * 1024 * 1024,
+    });
+    rawFailedLog = stdout || '';
+  } catch (error) {
+    log.warn('fetchAndParseFailedLog: failed to fetch failed log output', {
+      runId,
+      taskPath,
+      error: String(error),
+    });
+  }
+
+  const stepScopedLog = extractLinesForFailedSteps(rawFailedLog, failedStepNames);
+  const truncated = sanitizeAndTruncateLogOutput(stepScopedLog || rawFailedLog || '', maxLogChars);
+
+  return {
+    workflowName,
+    failedStepNames,
+    output: truncated.output,
+    wasTruncated: truncated.wasTruncated,
+  };
+}

--- a/src/main/services/ci/monitor.ts
+++ b/src/main/services/ci/monitor.ts
@@ -1,0 +1,206 @@
+import fs from 'node:fs';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { minimatch } from 'minimatch';
+import { databaseService } from '../DatabaseService';
+import { log } from '../../lib/logger';
+import { getGlobalCiAutoFixConfig, resolveCiAutoFixConfig } from './config';
+import type { CiAutoFixConfig, CiFailureCandidate, CiFailedRunInfo } from './types';
+
+const execFileAsync = promisify(execFile);
+
+interface GitHubRunListItem {
+  databaseId?: number;
+  status?: string;
+  conclusion?: string;
+  headSha?: string;
+  workflowName?: string;
+  displayTitle?: string;
+  event?: string;
+  url?: string;
+}
+
+function parsePattern(pattern: string): RegExp | null {
+  const trimmed = pattern.trim();
+  if (!trimmed.startsWith('/') || !trimmed.endsWith('/') || trimmed.length < 2) {
+    return null;
+  }
+  const body = trimmed.slice(1, -1);
+  try {
+    return new RegExp(body, 'i');
+  } catch {
+    return null;
+  }
+}
+
+function matchesPattern(value: string, pattern: string): boolean {
+  const regex = parsePattern(pattern);
+  if (regex) {
+    return regex.test(value);
+  }
+
+  return minimatch(value, pattern, { nocase: true, matchBase: true });
+}
+
+function passesTriggerFilters(config: CiAutoFixConfig, checkName: string): boolean {
+  const includeFilters = config.triggerFilters.include;
+  const excludeFilters = config.triggerFilters.exclude;
+
+  const included =
+    includeFilters.length === 0 ||
+    includeFilters.some((pattern) => matchesPattern(checkName, pattern));
+  if (!included) {
+    return false;
+  }
+
+  const excluded = excludeFilters.some((pattern) => matchesPattern(checkName, pattern));
+  return !excluded;
+}
+
+function normalizeRun(item: GitHubRunListItem): CiFailedRunInfo | null {
+  if (!item?.databaseId || !item?.headSha) {
+    return null;
+  }
+
+  return {
+    runId: item.databaseId,
+    headSha: item.headSha,
+    workflowName: item.workflowName || 'GitHub Actions',
+    displayTitle: item.displayTitle || item.workflowName || 'Failed workflow',
+    htmlUrl: item.url,
+    event: item.event,
+  };
+}
+
+async function getLatestFailedRun(
+  taskPath: string,
+  branchName: string
+): Promise<CiFailedRunInfo | null> {
+  const args = [
+    'run',
+    'list',
+    '--branch',
+    branchName,
+    '--limit',
+    '10',
+    '--json',
+    'databaseId,status,conclusion,headSha,workflowName,displayTitle,event,url',
+  ];
+
+  try {
+    const { stdout } = await execFileAsync('gh', args, {
+      cwd: taskPath,
+      maxBuffer: 4 * 1024 * 1024,
+    });
+
+    const parsed = JSON.parse(stdout || '[]') as GitHubRunListItem[];
+    const failed = parsed.find(
+      (item) => item?.status === 'completed' && item?.conclusion === 'failure'
+    );
+    return failed ? normalizeRun(failed) : null;
+  } catch (error) {
+    log.debug('CiFailureMonitorService: failed to list workflow runs', {
+      taskPath,
+      branchName,
+      error: String(error),
+    });
+    return null;
+  }
+}
+
+export class CiFailureMonitorService {
+  private timer: NodeJS.Timeout | null = null;
+  private isPolling = false;
+
+  private async processTask(
+    task: Awaited<ReturnType<typeof databaseService.getTasks>>[number],
+    projectById: Map<string, Awaited<ReturnType<typeof databaseService.getProjects>>[number]>,
+    onFailure: (candidate: CiFailureCandidate, config: CiAutoFixConfig) => Promise<void>
+  ): Promise<void> {
+    if (task.status !== 'active' && task.status !== 'running') {
+      return;
+    }
+
+    const project = projectById.get(task.projectId);
+    if (!project || project.isRemote) {
+      return;
+    }
+
+    const taskPath = task.path;
+    if (!taskPath || !fs.existsSync(taskPath)) {
+      return;
+    }
+
+    const config = resolveCiAutoFixConfig(project.path);
+    if (!config.enabled) {
+      return;
+    }
+
+    const failedRun = await getLatestFailedRun(taskPath, task.branch);
+    if (!failedRun) {
+      return;
+    }
+
+    const checkName = `${failedRun.workflowName} ${failedRun.displayTitle}`.trim();
+    if (!passesTriggerFilters(config, checkName)) {
+      return;
+    }
+
+    await onFailure(
+      {
+        projectId: project.id,
+        projectPath: project.path,
+        taskId: task.id,
+        taskPath,
+        branchName: task.branch,
+        run: failedRun,
+      },
+      config
+    );
+  }
+
+  start(
+    onFailure: (candidate: CiFailureCandidate, config: CiAutoFixConfig) => Promise<void>
+  ): void {
+    if (this.timer) {
+      return;
+    }
+
+    const loop = async () => {
+      if (this.isPolling) {
+        return;
+      }
+      this.isPolling = true;
+
+      try {
+        const tasks = await databaseService.getTasks();
+        const projects = await databaseService.getProjects();
+        const projectById = new Map(projects.map((project) => [project.id, project]));
+
+        for (const task of tasks) {
+          await this.processTask(task, projectById, onFailure);
+        }
+      } catch (error) {
+        log.warn('CiFailureMonitorService: polling cycle failed', { error: String(error) });
+      } finally {
+        this.isPolling = false;
+      }
+    };
+
+    void loop();
+
+    const baseInterval = getGlobalCiAutoFixConfig().pollIntervalMs;
+    this.timer = setInterval(() => {
+      void loop();
+    }, baseInterval);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+  }
+}
+
+export const ciFailureMonitorService = new CiFailureMonitorService();

--- a/src/main/services/ci/orchestrator.ts
+++ b/src/main/services/ci/orchestrator.ts
@@ -1,0 +1,524 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { execFile, spawn } from 'node:child_process';
+import { promisify } from 'node:util';
+import { Notification } from 'electron';
+import { getProvider, isValidProviderId, type ProviderId } from '@shared/providers/registry';
+import { getAppSettings } from '../../settings';
+import { log } from '../../lib/logger';
+import { databaseService } from '../DatabaseService';
+import { ciFailureMonitorService } from './monitor';
+import { fetchAndParseFailedLog } from './logParser';
+import { ciRetryStateTracker, CiRetryStateTracker } from './stateTracker';
+import type { CiAutoFixConfig, CiFailureCandidate } from './types';
+
+const execFileAsync = promisify(execFile);
+
+interface WorktreeLockHandle {
+  lockPath: string;
+  token: string;
+}
+
+type AgentRunResult =
+  | { ok: true }
+  | {
+      ok: false;
+      error: string;
+    };
+
+const LOCK_FILE_NAME = 'ci-agent.lock';
+const STALE_LOCK_MS = 30 * 60_000;
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function safeBranchSegment(branchName: string): string {
+  return branchName.replace(/[^a-zA-Z0-9._/-]/g, '_');
+}
+
+function splitArgs(input: string): string[] {
+  return input
+    .split(' ')
+    .map((segment) => segment.trim())
+    .filter(Boolean);
+}
+
+function buildCiPrompt(
+  candidate: CiFailureCandidate,
+  parsedLog: string,
+  mode: 'auto' | 'review'
+): string {
+  const modeInstruction =
+    mode === 'auto'
+      ? 'Do not commit or push by yourself. Only modify files and explain what you changed.'
+      : 'Do not commit or push. Only modify files in the working tree so a human can review.';
+
+  return [
+    'You are fixing a CI failure in this repository.',
+    '',
+    `Branch: ${candidate.branchName}`,
+    `Workflow: ${candidate.run.workflowName}`,
+    `Run ID: ${candidate.run.runId}`,
+    '',
+    'Primary objective:',
+    '- Make the smallest safe code changes needed to fix the failing CI check.',
+    '- Preserve existing project conventions and avoid unrelated edits.',
+    `- ${modeInstruction}`,
+    '',
+    'Failed CI output context (already filtered and truncated):',
+    parsedLog || '[No failed output was available from GitHub Actions logs.]',
+  ].join('\n');
+}
+
+async function git(taskPath: string, args: string[], maxBuffer = 4 * 1024 * 1024): Promise<string> {
+  const { stdout } = await execFileAsync('git', args, { cwd: taskPath, maxBuffer });
+  return (stdout || '').trim();
+}
+
+async function getLocalHeadSha(taskPath: string): Promise<string> {
+  return git(taskPath, ['rev-parse', 'HEAD']);
+}
+
+async function getRemoteHeadSha(taskPath: string, branchName: string): Promise<string | null> {
+  try {
+    const output = await git(taskPath, ['ls-remote', '--heads', 'origin', branchName]);
+    if (!output) {
+      return null;
+    }
+    const [sha] = output.split(/\s+/);
+    return sha || null;
+  } catch {
+    return null;
+  }
+}
+
+async function getStatusSnapshot(taskPath: string): Promise<string> {
+  return git(taskPath, ['status', '--porcelain', '--untracked-files=all']);
+}
+
+async function acquireWorktreeLock(taskPath: string): Promise<WorktreeLockHandle | null> {
+  const lockDir = path.join(taskPath, '.emdash');
+  const lockPath = path.join(lockDir, LOCK_FILE_NAME);
+  const token = `${process.pid}-${Date.now()}`;
+
+  await fs.promises.mkdir(lockDir, { recursive: true });
+
+  const tryAcquire = async (): Promise<WorktreeLockHandle | null> => {
+    try {
+      const fileHandle = await fs.promises.open(lockPath, 'wx');
+      const payload = {
+        token,
+        pid: process.pid,
+        acquiredAt: nowIso(),
+      };
+      await fileHandle.writeFile(JSON.stringify(payload, null, 2), 'utf8');
+      await fileHandle.close();
+      return { lockPath, token };
+    } catch (error: unknown) {
+      const asNodeError = error as NodeJS.ErrnoException;
+      if (asNodeError.code !== 'EEXIST') {
+        throw error;
+      }
+      return null;
+    }
+  };
+
+  for (let attempt = 0; attempt < 2; attempt += 1) {
+    const acquired = await tryAcquire();
+    if (acquired) {
+      return acquired;
+    }
+
+    try {
+      const raw = await fs.promises.readFile(lockPath, 'utf8');
+      const parsed = JSON.parse(raw) as { acquiredAt?: string };
+      const acquiredMs = parsed?.acquiredAt ? Date.parse(parsed.acquiredAt) : Number.NaN;
+      const stale = Number.isFinite(acquiredMs) && Date.now() - acquiredMs > STALE_LOCK_MS;
+      if (stale) {
+        await fs.promises.unlink(lockPath);
+        continue;
+      }
+    } catch {
+      await fs.promises.unlink(lockPath).catch(() => {});
+      continue;
+    }
+
+    return null;
+  }
+
+  return null;
+}
+
+async function releaseWorktreeLock(handle: WorktreeLockHandle | null): Promise<void> {
+  if (!handle) {
+    return;
+  }
+
+  try {
+    const raw = await fs.promises.readFile(handle.lockPath, 'utf8');
+    const parsed = JSON.parse(raw) as { token?: string };
+    if (parsed?.token !== handle.token) {
+      return;
+    }
+  } catch {
+    return;
+  }
+
+  await fs.promises.unlink(handle.lockPath).catch(() => {});
+}
+
+function maybeNotify(title: string, body: string): void {
+  try {
+    const settings = getAppSettings();
+    if (!settings.notifications?.enabled || !settings.notifications?.osNotifications) {
+      return;
+    }
+    if (!Notification.isSupported()) {
+      return;
+    }
+
+    const notification = new Notification({ title, body, silent: true });
+    notification.show();
+  } catch {
+    // best-effort notifications only
+  }
+}
+
+async function runAgentForCiFix(
+  providerId: ProviderId,
+  taskPath: string,
+  prompt: string,
+  mode: 'auto' | 'review'
+): Promise<AgentRunResult> {
+  const provider = getProvider(providerId);
+  if (!provider?.cli) {
+    return { ok: false, error: `Provider ${providerId} has no CLI command configured` };
+  }
+
+  if (provider.useKeystrokeInjection || provider.initialPromptFlag === undefined) {
+    return {
+      ok: false,
+      error: `Provider ${providerId} cannot receive non-interactive prompts safely for CI auto-fix`,
+    };
+  }
+
+  const args: string[] = [];
+  if (provider.defaultArgs?.length) {
+    args.push(...provider.defaultArgs);
+  }
+  if (mode === 'auto' && provider.autoApproveFlag) {
+    args.push(...splitArgs(provider.autoApproveFlag));
+  }
+  if (provider.initialPromptFlag) {
+    args.push(provider.initialPromptFlag);
+  }
+  args.push(prompt);
+
+  const cli = provider.cli;
+
+  return new Promise<AgentRunResult>((resolve) => {
+    const child = spawn(cli, args, {
+      cwd: taskPath,
+      env: {
+        ...process.env,
+        TERM: 'xterm-256color',
+        COLORTERM: 'truecolor',
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    let stderr = '';
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      try {
+        child.kill('SIGTERM');
+      } catch {
+        // no-op
+      }
+      resolve({ ok: false, error: 'Agent run timed out after 15 minutes' });
+    }, 15 * 60_000);
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      stderr += chunk.toString('utf8');
+    });
+
+    child.on('error', (error) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+      resolve({ ok: false, error: error.message });
+    });
+
+    child.on('exit', (code, signal) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
+
+      if (signal) {
+        resolve({ ok: false, error: `Agent terminated by signal ${signal}` });
+        return;
+      }
+      if (code !== 0) {
+        const trimmedErr = stderr.trim();
+        resolve({
+          ok: false,
+          error: trimmedErr || `Agent exited with status code ${String(code)}`,
+        });
+        return;
+      }
+      resolve({ ok: true });
+    });
+  });
+}
+
+export class CiFailureOrchestratorService {
+  private started = false;
+  private readonly inFlightByBranch = new Set<string>();
+
+  private async ensureAutoModeSafeStartingPoint(
+    candidate: CiFailureCandidate,
+    config: CiAutoFixConfig,
+    localHeadSha: string
+  ): Promise<{ ok: true; remoteHeadAtStart: string | null; statusBefore: string } | { ok: false }> {
+    const remoteHeadAtStart = await getRemoteHeadSha(candidate.taskPath, candidate.branchName);
+    if (remoteHeadAtStart && remoteHeadAtStart !== localHeadSha) {
+      log.info('CiFailureOrchestrator: skipping due to local/remote head mismatch before start', {
+        branch: candidate.branchName,
+        localHeadSha,
+        remoteHeadAtStart,
+      });
+      return { ok: false };
+    }
+
+    const statusBefore = await getStatusSnapshot(candidate.taskPath);
+    if (config.mode === 'auto' && statusBefore.trim().length > 0) {
+      maybeNotify(
+        'CI Auto-Fix needs review',
+        `Skipped auto-commit for ${safeBranchSegment(candidate.branchName)} because worktree was already dirty.`
+      );
+      return { ok: false };
+    }
+
+    return { ok: true, remoteHeadAtStart, statusBefore };
+  }
+
+  private async finalizeAutoMode(
+    candidate: CiFailureCandidate,
+    branchKey: string,
+    localHeadSha: string,
+    remoteHeadAtStart: string | null
+  ): Promise<void> {
+    const remoteHeadBeforePush = await getRemoteHeadSha(candidate.taskPath, candidate.branchName);
+    if (remoteHeadAtStart && remoteHeadBeforePush && remoteHeadBeforePush !== remoteHeadAtStart) {
+      maybeNotify(
+        'CI Auto-Fix aborted',
+        `Remote branch changed while agent was running for ${safeBranchSegment(candidate.branchName)}.`
+      );
+      return;
+    }
+
+    const localHeadBeforeCommit = await getLocalHeadSha(candidate.taskPath);
+    if (localHeadBeforeCommit !== localHeadSha) {
+      maybeNotify(
+        'CI Auto-Fix aborted',
+        `Local HEAD changed during run for ${safeBranchSegment(candidate.branchName)}. Review manually.`
+      );
+      return;
+    }
+
+    await execFileAsync('git', ['add', '-A'], { cwd: candidate.taskPath });
+
+    const commitMessage = `fix(ci): auto-fix workflow failure (run ${candidate.run.runId})`;
+    try {
+      await execFileAsync('git', ['commit', '-m', commitMessage], { cwd: candidate.taskPath });
+    } catch (error) {
+      const message = String(error);
+      if (message.includes('nothing to commit')) {
+        maybeNotify('CI Auto-Fix complete', `No committable changes for ${candidate.branchName}.`);
+        return;
+      }
+      throw error;
+    }
+
+    const agentCommitSha = await getLocalHeadSha(candidate.taskPath);
+    ciRetryStateTracker.markAgentCommit(
+      branchKey,
+      candidate.projectId,
+      candidate.branchName,
+      agentCommitSha
+    );
+
+    await execFileAsync('git', ['push', 'origin', `HEAD:${candidate.branchName}`], {
+      cwd: candidate.taskPath,
+    });
+
+    maybeNotify(
+      'CI Auto-Fix pushed',
+      `Pushed an automated CI fix to ${safeBranchSegment(candidate.branchName)}.`
+    );
+  }
+
+  start(): void {
+    if (this.started) {
+      return;
+    }
+    this.started = true;
+    ciFailureMonitorService.start(async (candidate, config) => {
+      await this.handleFailureCandidate(candidate, config);
+    });
+  }
+
+  stop(): void {
+    this.started = false;
+    ciFailureMonitorService.stop();
+    this.inFlightByBranch.clear();
+  }
+
+  private async resolveProviderId(
+    candidate: CiFailureCandidate,
+    config: CiAutoFixConfig
+  ): Promise<ProviderId> {
+    if (config.providerId && isValidProviderId(config.providerId)) {
+      return config.providerId;
+    }
+
+    const task = await databaseService.getTaskById(candidate.taskId);
+    if (task?.agentId && isValidProviderId(task.agentId)) {
+      return task.agentId;
+    }
+
+    const settings = getAppSettings();
+    if (settings.defaultProvider && isValidProviderId(settings.defaultProvider)) {
+      return settings.defaultProvider;
+    }
+
+    return 'claude';
+  }
+
+  private async handleFailureCandidate(
+    candidate: CiFailureCandidate,
+    config: CiAutoFixConfig
+  ): Promise<void> {
+    const branchKey = CiRetryStateTracker.buildBranchKey(candidate.projectId, candidate.branchName);
+    if (this.inFlightByBranch.has(branchKey)) {
+      return;
+    }
+
+    this.inFlightByBranch.add(branchKey);
+    let lockHandle: WorktreeLockHandle | null = null;
+
+    try {
+      const localHeadSha = await getLocalHeadSha(candidate.taskPath);
+
+      if (candidate.run.headSha && candidate.run.headSha !== localHeadSha) {
+        log.info(
+          'CiFailureOrchestrator: skipping because failed run head differs from local head',
+          {
+            branch: candidate.branchName,
+            localHeadSha,
+            runHeadSha: candidate.run.headSha,
+          }
+        );
+        return;
+      }
+
+      const gate = ciRetryStateTracker.evaluateTrigger({
+        branchKey,
+        projectId: candidate.projectId,
+        branchName: candidate.branchName,
+        currentHeadSha: localHeadSha,
+        runId: candidate.run.runId,
+        maxRetries: config.maxRetries,
+      });
+
+      if (!gate.allowed) {
+        if (gate.reason === 'max-retries-reached') {
+          maybeNotify(
+            'CI Auto-Fix halted',
+            `Reached max retries for ${safeBranchSegment(candidate.branchName)}. Make a manual commit to reset.`
+          );
+        }
+        return;
+      }
+
+      lockHandle = await acquireWorktreeLock(candidate.taskPath);
+      if (!lockHandle) {
+        log.info('CiFailureOrchestrator: worktree is already locked, skipping run', {
+          taskPath: candidate.taskPath,
+          branchName: candidate.branchName,
+        });
+        return;
+      }
+
+      const startingPoint = await this.ensureAutoModeSafeStartingPoint(
+        candidate,
+        config,
+        localHeadSha
+      );
+      if (!startingPoint.ok) {
+        return;
+      }
+      const { remoteHeadAtStart, statusBefore } = startingPoint;
+
+      ciRetryStateTracker.markTriggered({
+        branchKey,
+        projectId: candidate.projectId,
+        branchName: candidate.branchName,
+        currentHeadSha: localHeadSha,
+        runId: candidate.run.runId,
+        maxRetries: config.maxRetries,
+      });
+
+      const parsedLog = await fetchAndParseFailedLog(
+        candidate.taskPath,
+        candidate.run.runId,
+        config.maxLogChars
+      );
+      const prompt = buildCiPrompt(candidate, parsedLog.output, config.mode);
+      const providerId = await this.resolveProviderId(candidate, config);
+      const runResult = await runAgentForCiFix(providerId, candidate.taskPath, prompt, config.mode);
+
+      if (!runResult.ok) {
+        maybeNotify(
+          'CI Auto-Fix failed',
+          `Agent failed on ${safeBranchSegment(candidate.branchName)}: ${runResult.error}`
+        );
+        return;
+      }
+
+      const statusAfter = await getStatusSnapshot(candidate.taskPath);
+      const changed = statusAfter.trim() !== statusBefore.trim();
+      if (!changed) {
+        maybeNotify(
+          'CI Auto-Fix complete',
+          `Agent did not produce file changes for ${candidate.branchName}.`
+        );
+        return;
+      }
+
+      if (config.mode === 'review') {
+        maybeNotify(
+          'CI fix ready for review',
+          `Agent proposed changes in worktree ${safeBranchSegment(candidate.branchName)}. Please review.`
+        );
+        return;
+      }
+
+      await this.finalizeAutoMode(candidate, branchKey, localHeadSha, remoteHeadAtStart);
+    } catch (error) {
+      log.warn('CiFailureOrchestrator: failed to handle candidate', {
+        branch: candidate.branchName,
+        runId: candidate.run.runId,
+        error: String(error),
+      });
+    } finally {
+      await releaseWorktreeLock(lockHandle);
+      this.inFlightByBranch.delete(branchKey);
+    }
+  }
+}
+
+export const ciFailureOrchestratorService = new CiFailureOrchestratorService();

--- a/src/main/services/ci/stateTracker.ts
+++ b/src/main/services/ci/stateTracker.ts
@@ -1,0 +1,197 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { app } from 'electron';
+import { log } from '../../lib/logger';
+import type { CiBranchRetryState, CiRetryStateFile } from './types';
+
+interface TriggerGateInput {
+  branchKey: string;
+  projectId: string;
+  branchName: string;
+  currentHeadSha: string;
+  runId: number;
+  maxRetries: number;
+}
+
+interface TriggerGateResult {
+  allowed: boolean;
+  reason?: string;
+  state: CiBranchRetryState;
+}
+
+const RETRY_STATE_FILE = 'ci_retries.json';
+
+function nowIso(): string {
+  return new Date().toISOString();
+}
+
+function defaultState(projectId: string, branchName: string): CiBranchRetryState {
+  return {
+    projectId,
+    branchName,
+    retryCount: 0,
+    halted: false,
+    lastObservedHeadSha: null,
+    lastAgentCommitSha: null,
+    lastHandledRunId: null,
+    updatedAt: nowIso(),
+  };
+}
+
+export class CiRetryStateTracker {
+  private state: CiRetryStateFile = { version: 1, branches: {} };
+  private loaded = false;
+  private saveQueue: Promise<void> = Promise.resolve();
+
+  private get statePath(): string {
+    return path.join(app.getPath('userData'), RETRY_STATE_FILE);
+  }
+
+  private ensureLoaded(): void {
+    if (this.loaded) return;
+    this.loaded = true;
+
+    try {
+      const filePath = this.statePath;
+      if (!fs.existsSync(filePath)) {
+        return;
+      }
+
+      const raw = fs.readFileSync(filePath, 'utf8');
+      const parsed = JSON.parse(raw) as CiRetryStateFile;
+      if (parsed?.version !== 1 || typeof parsed?.branches !== 'object' || !parsed.branches) {
+        return;
+      }
+
+      this.state = parsed;
+    } catch (error) {
+      log.warn('CiRetryStateTracker: failed to read retry state, using defaults', {
+        error: String(error),
+      });
+    }
+  }
+
+  private persist(): void {
+    this.saveQueue = this.saveQueue
+      .catch(() => {})
+      .then(async () => {
+        const filePath = this.statePath;
+        const directory = path.dirname(filePath);
+        await fs.promises.mkdir(directory, { recursive: true });
+        await fs.promises.writeFile(filePath, JSON.stringify(this.state, null, 2), 'utf8');
+      })
+      .catch((error) => {
+        log.warn('CiRetryStateTracker: failed to persist retry state', {
+          error: String(error),
+        });
+      });
+  }
+
+  private getOrCreate(
+    branchKey: string,
+    projectId: string,
+    branchName: string
+  ): CiBranchRetryState {
+    this.ensureLoaded();
+    const existing = this.state.branches[branchKey];
+    if (existing) {
+      return existing;
+    }
+    const created = defaultState(projectId, branchName);
+    this.state.branches[branchKey] = created;
+    this.persist();
+    return created;
+  }
+
+  private resetForManualCommit(state: CiBranchRetryState, currentHeadSha: string): void {
+    state.retryCount = 0;
+    state.halted = false;
+    state.lastHandledRunId = null;
+    state.lastAgentCommitSha = null;
+    state.lastObservedHeadSha = currentHeadSha;
+    state.updatedAt = nowIso();
+  }
+
+  private syncHead(state: CiBranchRetryState, currentHeadSha: string): void {
+    const previousHead = state.lastObservedHeadSha;
+    if (!previousHead) {
+      state.lastObservedHeadSha = currentHeadSha;
+      state.updatedAt = nowIso();
+      return;
+    }
+
+    if (previousHead === currentHeadSha) {
+      return;
+    }
+
+    const changedByAgent =
+      state.lastAgentCommitSha !== null && currentHeadSha === state.lastAgentCommitSha;
+    if (!changedByAgent) {
+      this.resetForManualCommit(state, currentHeadSha);
+      return;
+    }
+
+    state.lastObservedHeadSha = currentHeadSha;
+    state.updatedAt = nowIso();
+  }
+
+  evaluateTrigger(input: TriggerGateInput): TriggerGateResult {
+    const state = this.getOrCreate(input.branchKey, input.projectId, input.branchName);
+    this.syncHead(state, input.currentHeadSha);
+
+    if (state.lastHandledRunId === input.runId) {
+      return {
+        allowed: false,
+        reason: 'run-already-handled',
+        state,
+      };
+    }
+
+    if (state.halted || state.retryCount >= input.maxRetries) {
+      state.halted = true;
+      state.updatedAt = nowIso();
+      this.persist();
+      return {
+        allowed: false,
+        reason: 'max-retries-reached',
+        state,
+      };
+    }
+
+    return {
+      allowed: true,
+      state,
+    };
+  }
+
+  markTriggered(input: TriggerGateInput): CiBranchRetryState {
+    const state = this.getOrCreate(input.branchKey, input.projectId, input.branchName);
+    this.syncHead(state, input.currentHeadSha);
+    state.retryCount += 1;
+    state.lastHandledRunId = input.runId;
+    state.halted = state.retryCount >= input.maxRetries;
+    state.lastObservedHeadSha = input.currentHeadSha;
+    state.updatedAt = nowIso();
+    this.persist();
+    return state;
+  }
+
+  markAgentCommit(
+    branchKey: string,
+    projectId: string,
+    branchName: string,
+    commitSha: string
+  ): void {
+    const state = this.getOrCreate(branchKey, projectId, branchName);
+    state.lastAgentCommitSha = commitSha;
+    state.lastObservedHeadSha = commitSha;
+    state.updatedAt = nowIso();
+    this.persist();
+  }
+
+  static buildBranchKey(projectId: string, branchName: string): string {
+    return `${projectId}::${branchName}`;
+  }
+}
+
+export const ciRetryStateTracker = new CiRetryStateTracker();

--- a/src/main/services/ci/types.ts
+++ b/src/main/services/ci/types.ts
@@ -1,0 +1,72 @@
+import type { ProviderId } from '@shared/providers/registry';
+
+export type CiAutoFixMode = 'auto' | 'review';
+
+export interface CiTriggerFilters {
+  include: string[];
+  exclude: string[];
+}
+
+export interface CiAutoFixConfig {
+  enabled: boolean;
+  mode: CiAutoFixMode;
+  maxRetries: number;
+  triggerFilters: CiTriggerFilters;
+  maxLogChars: number;
+  pollIntervalMs: number;
+  providerId?: ProviderId;
+}
+
+export interface CiAutoFixConfigOverride {
+  enabled?: boolean;
+  mode?: CiAutoFixMode;
+  maxRetries?: number;
+  triggerFilters?: {
+    include?: string[];
+    exclude?: string[];
+  };
+  maxLogChars?: number;
+  pollIntervalMs?: number;
+  providerId?: ProviderId;
+}
+
+export interface CiBranchRetryState {
+  projectId: string;
+  branchName: string;
+  retryCount: number;
+  halted: boolean;
+  lastObservedHeadSha: string | null;
+  lastAgentCommitSha: string | null;
+  lastHandledRunId: number | null;
+  updatedAt: string;
+}
+
+export interface CiRetryStateFile {
+  version: 1;
+  branches: Record<string, CiBranchRetryState>;
+}
+
+export interface CiFailedRunInfo {
+  runId: number;
+  headSha: string;
+  workflowName: string;
+  displayTitle: string;
+  htmlUrl?: string;
+  event?: string;
+}
+
+export interface CiFailureCandidate {
+  projectId: string;
+  projectPath: string;
+  taskId: string;
+  taskPath: string;
+  branchName: string;
+  run: CiFailedRunInfo;
+}
+
+export interface ParsedFailedLog {
+  workflowName: string;
+  failedStepNames: string[];
+  output: string;
+  wasTruncated: boolean;
+}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -10,6 +10,7 @@ import {
   DEFAULT_REVIEW_PROMPT,
   type ReviewSettings,
 } from '@shared/reviewPreset';
+import type { CiAutoFixConfigOverride } from './services/ci/types';
 
 export type DeepPartial<T> = {
   [K in keyof T]?: NonNullable<T[K]> extends object ? DeepPartial<NonNullable<T[K]>> : T[K];
@@ -118,6 +119,7 @@ export interface AppSettings {
   changelog?: {
     dismissedVersions: string[];
   };
+  ciAutoFix?: CiAutoFixConfigOverride;
 }
 
 function getPlatformTaskSwitchDefaults(): { next: ShortcutBinding; prev: ShortcutBinding } {
@@ -199,6 +201,17 @@ const DEFAULT_SETTINGS: AppSettings = {
   hiddenOpenInApps: [],
   changelog: {
     dismissedVersions: [],
+  },
+  ciAutoFix: {
+    enabled: false,
+    mode: 'review',
+    maxRetries: 2,
+    triggerFilters: {
+      include: ['*test*', '*lint*'],
+      exclude: ['*deploy*', '*build*'],
+    },
+    maxLogChars: 4_000,
+    pollIntervalMs: 120_000,
   },
 };
 
@@ -586,6 +599,44 @@ export function normalizeSettings(input: AppSettings): AppSettings {
           ),
         ]
       : [],
+  };
+
+  const ciAutoFix = (input as any)?.ciAutoFix || {};
+  const mode =
+    ciAutoFix?.mode === 'auto' || ciAutoFix?.mode === 'review' ? ciAutoFix.mode : 'review';
+  const maxRetries = Number.isFinite(ciAutoFix?.maxRetries)
+    ? Math.max(0, Math.min(20, Math.trunc(ciAutoFix.maxRetries)))
+    : 2;
+  const maxLogChars = Number.isFinite(ciAutoFix?.maxLogChars)
+    ? Math.max(500, Math.min(40_000, Math.trunc(ciAutoFix.maxLogChars)))
+    : 4_000;
+  const pollIntervalMs = Number.isFinite(ciAutoFix?.pollIntervalMs)
+    ? Math.max(15_000, Math.min(30 * 60_000, Math.trunc(ciAutoFix.pollIntervalMs)))
+    : 120_000;
+  const includeFilters = Array.isArray(ciAutoFix?.triggerFilters?.include)
+    ? ciAutoFix.triggerFilters.include
+        .filter((pattern: unknown): pattern is string => typeof pattern === 'string')
+        .map((pattern: string) => pattern.trim())
+        .filter(Boolean)
+    : ['*test*', '*lint*'];
+  const excludeFilters = Array.isArray(ciAutoFix?.triggerFilters?.exclude)
+    ? ciAutoFix.triggerFilters.exclude
+        .filter((pattern: unknown): pattern is string => typeof pattern === 'string')
+        .map((pattern: string) => pattern.trim())
+        .filter(Boolean)
+    : ['*deploy*', '*build*'];
+
+  out.ciAutoFix = {
+    enabled: Boolean(ciAutoFix?.enabled ?? false),
+    mode,
+    maxRetries,
+    maxLogChars,
+    pollIntervalMs,
+    triggerFilters: {
+      include: includeFilters.length > 0 ? includeFilters : ['*test*', '*lint*'],
+      exclude: excludeFilters,
+    },
+    ...(isValidProviderId(ciAutoFix?.providerId) ? { providerId: ciAutoFix.providerId } : {}),
   };
 
   return out;

--- a/src/renderer/components/CiAutoFixSettingsCard.tsx
+++ b/src/renderer/components/CiAutoFixSettingsCard.tsx
@@ -1,0 +1,216 @@
+import React, { useMemo } from 'react';
+import { Input } from './ui/input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { Switch } from './ui/switch';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import { isValidProviderId, PROVIDERS, type ProviderId } from '@shared/providers/registry';
+
+const DEFAULT_INCLUDE_FILTERS = '*test*, *lint*';
+const DEFAULT_EXCLUDE_FILTERS = '*deploy*, *build*';
+
+function parseFilterList(raw: string): string[] {
+  return raw
+    .split(',')
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+const CiAutoFixSettingsCard: React.FC = () => {
+  const { settings, updateSettings, isLoading, isSaving } = useAppSettings();
+  const ciAutoFix = settings?.ciAutoFix;
+
+  const includeFiltersValue =
+    ciAutoFix?.triggerFilters?.include?.join(', ') || DEFAULT_INCLUDE_FILTERS;
+  const excludeFiltersValue =
+    ciAutoFix?.triggerFilters?.exclude?.join(', ') || DEFAULT_EXCLUDE_FILTERS;
+
+  const selectedProvider = ciAutoFix?.providerId || 'auto';
+
+  const toProviderOverride = (providerId: string): ProviderId | undefined => {
+    if (providerId === 'auto') return undefined;
+    if (isValidProviderId(providerId)) {
+      return providerId;
+    }
+    return undefined;
+  };
+
+  const providerOptions = useMemo(
+    () => [
+      { id: 'auto', name: 'Task/default provider' },
+      ...PROVIDERS.map((provider) => ({ id: provider.id, name: provider.name })),
+    ],
+    []
+  );
+
+  return (
+    <div className="flex flex-col gap-4 rounded-xl border border-muted p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="flex flex-1 flex-col gap-0.5">
+          <p className="text-sm font-medium text-foreground">CI auto-fix</p>
+          <p className="text-sm text-muted-foreground">
+            Automatically run an agent when GitHub Actions fails on active task branches.
+          </p>
+        </div>
+        <Switch
+          checked={ciAutoFix?.enabled ?? false}
+          disabled={isLoading || isSaving}
+          onCheckedChange={(enabled) => updateSettings({ ciAutoFix: { enabled } })}
+          aria-label="Enable CI auto-fix"
+        />
+      </div>
+
+      <div className="grid gap-3">
+        <div className="grid grid-cols-[minmax(0,1fr)_180px] items-center gap-4">
+          <div className="flex flex-col gap-0.5">
+            <p className="text-sm font-medium text-foreground">Mode</p>
+            <p className="text-sm text-muted-foreground">
+              Auto commits and pushes; review leaves changes for manual approval.
+            </p>
+          </div>
+          <Select
+            value={ciAutoFix?.mode ?? 'review'}
+            onValueChange={(mode) =>
+              updateSettings({ ciAutoFix: { mode: mode as 'auto' | 'review' } })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="review">review</SelectItem>
+              <SelectItem value="auto">auto</SelectItem>
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid grid-cols-[minmax(0,1fr)_180px] items-center gap-4">
+          <div className="flex flex-col gap-0.5">
+            <p className="text-sm font-medium text-foreground">Provider</p>
+            <p className="text-sm text-muted-foreground">
+              Override the agent provider used for CI fixes.
+            </p>
+          </div>
+          <Select
+            value={selectedProvider}
+            onValueChange={(providerId) =>
+              updateSettings({
+                ciAutoFix: {
+                  providerId: toProviderOverride(providerId),
+                },
+              })
+            }
+          >
+            <SelectTrigger className="w-full">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {providerOptions.map((provider) => (
+                <SelectItem key={provider.id} value={provider.id}>
+                  {provider.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <div className="grid grid-cols-[minmax(0,1fr)_180px] items-center gap-4">
+          <div className="flex flex-col gap-0.5">
+            <p className="text-sm font-medium text-foreground">Max retries</p>
+            <p className="text-sm text-muted-foreground">
+              Stops re-triggering after this many auto-fix attempts per branch.
+            </p>
+          </div>
+          <Input
+            type="number"
+            min={0}
+            max={20}
+            value={ciAutoFix?.maxRetries ?? 2}
+            disabled={isLoading || isSaving}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              updateSettings({ ciAutoFix: { maxRetries: Number.isFinite(value) ? value : 2 } });
+            }}
+          />
+        </div>
+
+        <div className="grid grid-cols-[minmax(0,1fr)_180px] items-center gap-4">
+          <div className="flex flex-col gap-0.5">
+            <p className="text-sm font-medium text-foreground">Max log chars</p>
+            <p className="text-sm text-muted-foreground">Tail length passed to the agent prompt.</p>
+          </div>
+          <Input
+            type="number"
+            min={500}
+            max={40000}
+            step={100}
+            value={ciAutoFix?.maxLogChars ?? 4000}
+            disabled={isLoading || isSaving}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              updateSettings({ ciAutoFix: { maxLogChars: Number.isFinite(value) ? value : 4000 } });
+            }}
+          />
+        </div>
+
+        <div className="grid grid-cols-[minmax(0,1fr)_180px] items-center gap-4">
+          <div className="flex flex-col gap-0.5">
+            <p className="text-sm font-medium text-foreground">Poll interval (ms)</p>
+            <p className="text-sm text-muted-foreground">How often CI checks are polled.</p>
+          </div>
+          <Input
+            type="number"
+            min={15000}
+            max={1800000}
+            step={1000}
+            value={ciAutoFix?.pollIntervalMs ?? 120000}
+            disabled={isLoading || isSaving}
+            onChange={(event) => {
+              const value = Number(event.target.value);
+              updateSettings({
+                ciAutoFix: { pollIntervalMs: Number.isFinite(value) ? value : 120000 },
+              });
+            }}
+          />
+        </div>
+
+        <div className="grid gap-2">
+          <p className="text-sm font-medium text-foreground">Trigger filters (include)</p>
+          <Input
+            key={`include-${includeFiltersValue}`}
+            defaultValue={includeFiltersValue}
+            disabled={isLoading || isSaving}
+            onBlur={(event) =>
+              updateSettings({
+                ciAutoFix: { triggerFilters: { include: parseFilterList(event.target.value) } },
+              })
+            }
+            placeholder="*test*, *lint*, /regex/"
+          />
+          <p className="text-xs text-muted-foreground">
+            Comma-separated glob or /regex/ patterns. Only matching checks trigger auto-fix.
+          </p>
+        </div>
+
+        <div className="grid gap-2">
+          <p className="text-sm font-medium text-foreground">Trigger filters (exclude)</p>
+          <Input
+            key={`exclude-${excludeFiltersValue}`}
+            defaultValue={excludeFiltersValue}
+            disabled={isLoading || isSaving}
+            onBlur={(event) =>
+              updateSettings({
+                ciAutoFix: { triggerFilters: { exclude: parseFilterList(event.target.value) } },
+              })
+            }
+            placeholder="*deploy*, *build*, /regex/"
+          />
+          <p className="text-xs text-muted-foreground">
+            Excluded patterns always win over include patterns.
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CiAutoFixSettingsCard;

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
 } from './TaskSettingsRows';
 import IntegrationsCard from './IntegrationsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
+import CiAutoFixSettingsCard from './CiAutoFixSettingsCard';
 import ThemeCard from './ThemeCard';
 import KeyboardSettingsCard from './KeyboardSettingsCard';
 import RightSidebarSettingsCard from './RightSidebarSettingsCard';
@@ -243,7 +244,10 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
     repository: {
       title: 'Repository',
       description: 'Configure repository and branch settings.',
-      sections: [{ title: 'Branch name', component: <RepositorySettingsCard /> }],
+      sections: [
+        { title: 'Branch name', component: <RepositorySettingsCard /> },
+        { title: 'CI auto-fix', component: <CiAutoFixSettingsCard /> },
+      ],
     },
     interface: {
       title: 'Interface',

--- a/src/test/main/ci/logParser.test.ts
+++ b/src/test/main/ci/logParser.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+
+describe('sanitizeAndTruncateLogOutput', () => {
+  it('truncates from top, prefixes warning, and strips ANSI escape codes', async () => {
+    const longSegment = Array.from(
+      { length: 120 },
+      (_, index) => `line-${index.toString().padStart(3, '0')}`
+    ).join('\n');
+    const rawLog = [`\u001b[31mSTART\u001b[0m`, longSegment, 'STACKTRACE-END'].join('\n');
+
+    const { sanitizeAndTruncateLogOutput } = await import('../../../main/services/ci/logParser');
+
+    const parsed = sanitizeAndTruncateLogOutput(rawLog, 200);
+
+    expect(parsed.wasTruncated).toBe(true);
+    expect(parsed.output.startsWith('[Output Truncated]\n')).toBe(true);
+    expect(parsed.output.includes('\u001b[')).toBe(false);
+    expect(parsed.output).toContain('STACKTRACE-END');
+  });
+});

--- a/src/test/main/ci/orchestrator.test.ts
+++ b/src/test/main/ci/orchestrator.test.ts
@@ -1,0 +1,171 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+import type { CiAutoFixConfig, CiFailureCandidate } from '../../../main/services/ci/types';
+
+type ExecFileCallback = (error: Error | null, stdout?: string, stderr?: string) => void;
+
+const execFileMock = vi.fn();
+const spawnMock = vi.fn();
+
+const evaluateTriggerMock = vi.fn();
+const markTriggeredMock = vi.fn();
+const markAgentCommitMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execFile: (...args: unknown[]) => execFileMock(...args),
+  spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+vi.mock('electron', () => ({
+  Notification: class {
+    readonly options: unknown;
+    static isSupported() {
+      return true;
+    }
+    constructor(options: unknown) {
+      this.options = options;
+    }
+    show() {
+      return true;
+    }
+  },
+}));
+
+vi.mock('../../../main/settings', () => ({
+  getAppSettings: vi.fn(() => ({
+    notifications: { enabled: false, osNotifications: false },
+    defaultProvider: 'claude',
+  })),
+}));
+
+vi.mock('../../../main/lib/logger', () => ({
+  log: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('../../../main/services/DatabaseService', () => ({
+  databaseService: {
+    getTaskById: vi.fn(async () => ({ id: 'task-1', agentId: 'claude' })),
+  },
+}));
+
+vi.mock('../../../main/services/ci/logParser', () => ({
+  fetchAndParseFailedLog: vi.fn(async () => ({
+    workflowName: 'CI',
+    failedStepNames: ['Run tests'],
+    output: 'failure output',
+    wasTruncated: false,
+  })),
+}));
+
+vi.mock('../../../main/services/ci/stateTracker', () => ({
+  ciRetryStateTracker: {
+    evaluateTrigger: (...args: unknown[]) => evaluateTriggerMock(...args),
+    markTriggered: (...args: unknown[]) => markTriggeredMock(...args),
+    markAgentCommit: (...args: unknown[]) => markAgentCommitMock(...args),
+  },
+  CiRetryStateTracker: class {
+    static buildBranchKey(projectId: string, branchName: string) {
+      return `${projectId}::${branchName}`;
+    }
+  },
+}));
+
+describe('CiFailureOrchestratorService race condition checks', () => {
+  let taskPath = '';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    taskPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-ci-orchestrator-'));
+    evaluateTriggerMock.mockReturnValue({
+      allowed: true,
+      state: { retryCount: 0, halted: false },
+    });
+
+    execFileMock.mockImplementation(
+      (_command: string, args: string[], _options: unknown, callback: ExecFileCallback) => {
+        if (args[0] === 'rev-parse' && args[1] === 'HEAD') {
+          callback(null, 'local-sha\n', '');
+          return;
+        }
+
+        if (args[0] === 'ls-remote' && args[1] === '--heads') {
+          callback(null, 'remote-sha\trefs/heads/emdash/task-123\n', '');
+          return;
+        }
+
+        if (args[0] === 'status' && args[1] === '--porcelain') {
+          callback(null, '', '');
+          return;
+        }
+
+        callback(null, '', '');
+      }
+    );
+  });
+
+  afterEach(() => {
+    fs.rmSync(taskPath, { recursive: true, force: true });
+  });
+
+  it('aborts before agent execution when local HEAD differs from remote HEAD', async () => {
+    const { CiFailureOrchestratorService } = await import('../../../main/services/ci/orchestrator');
+
+    const service = new CiFailureOrchestratorService();
+
+    const candidate: CiFailureCandidate = {
+      projectId: 'project-1',
+      projectPath: '/tmp/project-1',
+      taskId: 'task-1',
+      taskPath,
+      branchName: 'emdash/task-123',
+      run: {
+        runId: 3001,
+        headSha: 'remote-sha',
+        workflowName: 'CI',
+        displayTitle: 'Run tests',
+      },
+    };
+
+    const config: CiAutoFixConfig = {
+      enabled: true,
+      mode: 'auto',
+      maxRetries: 2,
+      triggerFilters: {
+        include: ['*test*'],
+        exclude: [],
+      },
+      maxLogChars: 4000,
+      pollIntervalMs: 120000,
+      providerId: 'claude',
+    };
+
+    const handleFailureCandidate = (
+      service as unknown as {
+        handleFailureCandidate: (
+          nextCandidate: CiFailureCandidate,
+          nextConfig: CiAutoFixConfig
+        ) => Promise<void>;
+      }
+    ).handleFailureCandidate.bind(service);
+
+    await handleFailureCandidate(candidate, config);
+
+    expect(spawnMock).not.toHaveBeenCalled();
+    expect(markTriggeredMock).not.toHaveBeenCalled();
+
+    const gitCalls = execFileMock.mock.calls
+      .filter((call) => call[0] === 'git')
+      .map((call) => call[1] as string[]);
+
+    expect(gitCalls.some((args) => args[0] === 'add')).toBe(false);
+    expect(gitCalls.some((args) => args[0] === 'commit')).toBe(false);
+    expect(gitCalls.some((args) => args[0] === 'push')).toBe(false);
+  });
+});

--- a/src/test/main/ci/stateTracker.test.ts
+++ b/src/test/main/ci/stateTracker.test.ts
@@ -1,0 +1,113 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+let userDataDir = '';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => userDataDir,
+  },
+}));
+
+vi.mock('../../../main/lib/logger', () => ({
+  log: {
+    info: vi.fn(),
+    debug: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+describe('CiRetryStateTracker', () => {
+  beforeEach(() => {
+    userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-ci-state-'));
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    fs.rmSync(userDataDir, { recursive: true, force: true });
+  });
+
+  it('increments retry count and halts when maxRetries is reached', async () => {
+    const { CiRetryStateTracker } = await import('../../../main/services/ci/stateTracker');
+    const tracker = new CiRetryStateTracker();
+
+    const branchKey = CiRetryStateTracker.buildBranchKey('project-a', 'emdash/task-123');
+
+    const gate1 = tracker.evaluateTrigger({
+      branchKey,
+      projectId: 'project-a',
+      branchName: 'emdash/task-123',
+      currentHeadSha: 'sha-1',
+      runId: 1001,
+      maxRetries: 2,
+    });
+    expect(gate1.allowed).toBe(true);
+
+    const stateAfterFirst = tracker.markTriggered({
+      branchKey,
+      projectId: 'project-a',
+      branchName: 'emdash/task-123',
+      currentHeadSha: 'sha-1',
+      runId: 1001,
+      maxRetries: 2,
+    });
+    expect(stateAfterFirst.retryCount).toBe(1);
+    expect(stateAfterFirst.halted).toBe(false);
+
+    const stateAfterSecond = tracker.markTriggered({
+      branchKey,
+      projectId: 'project-a',
+      branchName: 'emdash/task-123',
+      currentHeadSha: 'sha-1',
+      runId: 1002,
+      maxRetries: 2,
+    });
+    expect(stateAfterSecond.retryCount).toBe(2);
+    expect(stateAfterSecond.halted).toBe(true);
+
+    const gateBlocked = tracker.evaluateTrigger({
+      branchKey,
+      projectId: 'project-a',
+      branchName: 'emdash/task-123',
+      currentHeadSha: 'sha-1',
+      runId: 1003,
+      maxRetries: 2,
+    });
+    expect(gateBlocked.allowed).toBe(false);
+    expect(gateBlocked.reason).toBe('max-retries-reached');
+  });
+
+  it('resets retry state when a manual head change is detected', async () => {
+    const { CiRetryStateTracker } = await import('../../../main/services/ci/stateTracker');
+    const tracker = new CiRetryStateTracker();
+
+    const branchKey = CiRetryStateTracker.buildBranchKey('project-b', 'emdash/task-manual');
+
+    tracker.markTriggered({
+      branchKey,
+      projectId: 'project-b',
+      branchName: 'emdash/task-manual',
+      currentHeadSha: 'agent-sha-1',
+      runId: 2001,
+      maxRetries: 1,
+    });
+    tracker.markAgentCommit(branchKey, 'project-b', 'emdash/task-manual', 'agent-sha-1');
+
+    const gateAfterManualCommit = tracker.evaluateTrigger({
+      branchKey,
+      projectId: 'project-b',
+      branchName: 'emdash/task-manual',
+      currentHeadSha: 'human-sha-2',
+      runId: 2002,
+      maxRetries: 1,
+    });
+
+    expect(gateAfterManualCommit.allowed).toBe(true);
+    expect(gateAfterManualCommit.state.retryCount).toBe(0);
+    expect(gateAfterManualCommit.state.halted).toBe(false);
+    expect(gateAfterManualCommit.state.lastObservedHeadSha).toBe('human-sha-2');
+  });
+});


### PR DESCRIPTION
## Summary

This PR introduces the **Auto-trigger agent on CI failure** feature. It automatically monitors active task branches for GitHub Actions workflow failures. When a failure occurs, Emdash fetches and smartly truncates the error logs, spins up an agent in the task's worktree, and allows the AI to attempt a fix—closing the feedback loop without manual context switching. 

**Key Implementation Details:**
* **Modular Architecture:** Added dedicated CI modules for configuration, monitoring (polling-based), log parsing, and orchestration.
* **Safety Controls:** Implemented a state tracker to prevent infinite retry loops, worktree lock files, and local/remote HEAD checks to prevent race conditions during git operations. 
* **Context Protection:** Built a pure-function log parser that strips ANSI codes and truncates massive logs from the top, ensuring LLM context limits are respected while preserving the actionable tail-end stack traces.
* **In-App Configuration:** Added a `CiAutoFixSettingsCard` to the existing Settings UI so users can easily toggle modes (`auto` vs. `review`), set retry limits, and define trigger filters (e.g., test/lint only) without manually editing `.emdash.json`.

## Fixes 
Fixes #1375

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes