### PR TITLE
fix(ui): decouple OpenPrsSection from parent via context

### DIFF
--- a/src/renderer/components/OpenPrsSection.tsx
+++ b/src/renderer/components/OpenPrsSection.tsx
@@ -15,6 +15,7 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { useToast } from '../hooks/use-toast';
+import { useTaskManagementContext } from '../contexts/TaskManagementContext';
 import {
   ArrowUpRight,
   ChevronDown,
@@ -29,7 +30,6 @@ import type { Task } from '../types/app';
 interface OpenPrsSectionProps {
   projectPath: string;
   projectId: string;
-  onReviewPr: (task: Task) => void;
 }
 
 const DEFAULT_VISIBLE = 10;
@@ -183,8 +183,9 @@ const ReviewersList: React.FC<{ reviewers: PullRequestReviewer[] }> = ({ reviewe
   );
 };
 
-const OpenPrsSection: React.FC<OpenPrsSectionProps> = ({ projectPath, projectId, onReviewPr }) => {
+const OpenPrsSection: React.FC<OpenPrsSectionProps> = ({ projectPath, projectId }) => {
   const { toast } = useToast();
+  const { handleOpenExternalTask } = useTaskManagementContext();
   const [collapsed, setCollapsed] = useState(false);
   const [creatingForPr, setCreatingForPr] = useState<number | null>(null);
   const [appliedQuery, setAppliedQuery] = useState('');
@@ -239,7 +240,7 @@ const OpenPrsSection: React.FC<OpenPrsSectionProps> = ({ projectPath, projectId,
           useWorktree: true,
           metadata: result.task.metadata,
         };
-        onReviewPr(task);
+        handleOpenExternalTask(task);
       } else if (result.success && result.worktree) {
         const task: Task = {
           id: result.worktree.id || crypto.randomUUID(),
@@ -251,7 +252,7 @@ const OpenPrsSection: React.FC<OpenPrsSectionProps> = ({ projectPath, projectId,
           useWorktree: true,
           metadata: { prNumber: pr.number, prTitle: pr.title },
         };
-        onReviewPr(task);
+        handleOpenExternalTask(task);
       } else {
         toast({
           title: 'Failed to create review task',

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -1067,11 +1067,7 @@ const ProjectMainView: React.FC<ProjectMainViewProps> = ({
 
             {/* Open PRs Section */}
             {project.githubInfo?.connected && !project.isRemote && (
-              <OpenPrsSection
-                projectPath={project.path}
-                projectId={project.id}
-                onReviewPr={onSelectTask}
-              />
+              <OpenPrsSection projectPath={project.path} projectId={project.id} />
             )}
           </div>
         </div>

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -16,6 +16,7 @@ import type { JiraIssueSummary } from '../types/jira';
 import type { PlainThreadSummary } from '../types/plain';
 import type { GitLabIssueSummary } from '../types/gitlab';
 import type { ForgejoIssueSummary } from '../types/forgejo';
+import { upsertTaskInList } from '../lib/taskListCache';
 import { rpc } from '../lib/rpc';
 import { createTask } from '../lib/taskCreationService';
 import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
@@ -321,23 +322,44 @@ export function useTaskManagement() {
   // ---------------------------------------------------------------------------
   // Navigation helpers
   // ---------------------------------------------------------------------------
-  const handleSelectTask = (task: Task) => {
-    const taskProject = projects.find((project) => project.id === task.projectId);
-    const isProjectSwitch = !selectedProject || selectedProject.id !== task.projectId;
-    if (isProjectSwitch) {
-      setShowEditorMode(false);
-    }
-    if (taskProject && selectedProject?.id !== taskProject.id) {
-      setSelectedProject(taskProject);
-    }
-    setShowHomeView(false);
-    setShowSkillsView(false);
-    setShowMcpView(false);
-    setShowKanban(false);
-    setActiveTask(task);
-    setActiveTaskAgent(getAgentForTask(task));
-    saveActiveIds(task.projectId, task.id);
-  };
+  const handleSelectTask = useCallback(
+    (task: Task) => {
+      const taskProject = projects.find((project) => project.id === task.projectId);
+      const isProjectSwitch = !selectedProject || selectedProject.id !== task.projectId;
+      if (isProjectSwitch) {
+        setShowEditorMode(false);
+      }
+      if (taskProject && selectedProject?.id !== taskProject.id) {
+        setSelectedProject(taskProject);
+      }
+      setShowHomeView(false);
+      setShowSkillsView(false);
+      setShowMcpView(false);
+      setShowKanban(false);
+      setActiveTask(task);
+      setActiveTaskAgent(getAgentForTask(task));
+      saveActiveIds(task.projectId, task.id);
+    },
+    [
+      projects,
+      selectedProject,
+      setSelectedProject,
+      setShowEditorMode,
+      setShowHomeView,
+      setShowSkillsView,
+      setShowMcpView,
+      setShowKanban,
+    ]
+  );
+
+  const handleOpenExternalTask = useCallback(
+    (task: Task) => {
+      updateTaskCache(task.projectId, (old) => upsertTaskInList(old, task));
+      handleSelectTask(task);
+      void queryClient.invalidateQueries({ queryKey: ['tasks', task.projectId] });
+    },
+    [handleSelectTask, queryClient, updateTaskCache]
+  );
 
   const handleNextTask = useCallback(() => {
     if (allTasks.length === 0) return;
@@ -1035,6 +1057,7 @@ export function useTaskManagement() {
     handleTaskInterfaceReady,
     openTaskModal,
     handleSelectTask,
+    handleOpenExternalTask,
     handleNextTask,
     handlePrevTask,
     handleNewTask,

--- a/src/renderer/lib/taskListCache.ts
+++ b/src/renderer/lib/taskListCache.ts
@@ -1,0 +1,23 @@
+import type { Task } from '../types/app';
+
+export function upsertTaskInList(tasks: Task[], task: Task): Task[] {
+  const existingIndex = tasks.findIndex(
+    (existingTask) => existingTask.id === task.id || existingTask.path === task.path
+  );
+
+  if (existingIndex === -1) {
+    return [task, ...tasks];
+  }
+
+  const existingTask = tasks[existingIndex];
+  const taskOverrides = Object.fromEntries(
+    Object.entries(task).filter(([, value]) => value !== undefined)
+  ) as Partial<Task>;
+  const nextTask: Task = {
+    ...existingTask,
+    ...taskOverrides,
+    metadata: task.metadata ?? existingTask.metadata,
+  };
+
+  return tasks.map((existing, index) => (index === existingIndex ? nextTask : existing));
+}

--- a/src/test/renderer/taskListCache.test.ts
+++ b/src/test/renderer/taskListCache.test.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest';
+import { upsertTaskInList } from '../../renderer/lib/taskListCache';
+import type { Task } from '../../renderer/types/app';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: overrides.id ?? 'task-1',
+    projectId: overrides.projectId ?? 'project-1',
+    name: overrides.name ?? 'Task',
+    branch: overrides.branch ?? 'main',
+    path: overrides.path ?? '/tmp/task-1',
+    status: overrides.status ?? 'active',
+    useWorktree: overrides.useWorktree ?? true,
+    metadata: overrides.metadata ?? null,
+    agentId: overrides.agentId,
+    archivedAt: overrides.archivedAt,
+    createdAt: overrides.createdAt,
+    updatedAt: overrides.updatedAt,
+  };
+}
+
+describe('upsertTaskInList', () => {
+  it('prepends a new task when it is not already cached', () => {
+    const existingTask = makeTask({ id: 'task-1', path: '/tmp/task-1', name: 'Existing task' });
+    const reviewTask = makeTask({ id: 'task-2', path: '/tmp/task-2', name: 'pr-42-fix-cache' });
+
+    const result = upsertTaskInList([existingTask], reviewTask);
+
+    expect(result).toEqual([reviewTask, existingTask]);
+  });
+
+  it('updates an existing task by id without changing its position', () => {
+    const existingTask = makeTask({
+      id: 'task-1',
+      path: '/tmp/task-1',
+      name: 'Old name',
+      createdAt: '2026-03-14T10:00:00.000Z',
+    });
+    const otherTask = makeTask({ id: 'task-2', path: '/tmp/task-2', name: 'Other task' });
+
+    const result = upsertTaskInList(
+      [existingTask, otherTask],
+      makeTask({
+        id: 'task-1',
+        path: '/tmp/task-1',
+        name: 'pr-42-refresh-sidebar',
+        metadata: { prNumber: 42, prTitle: 'Refresh sidebar' },
+      })
+    );
+
+    expect(result).toEqual([
+      {
+        ...existingTask,
+        name: 'pr-42-refresh-sidebar',
+        metadata: { prNumber: 42, prTitle: 'Refresh sidebar' },
+      },
+      otherTask,
+    ]);
+  });
+
+  it('updates by path when the task id changes to avoid duplicates', () => {
+    const existingTask = makeTask({
+      id: 'optimistic-review-task',
+      path: '/tmp/review-task',
+      name: 'PR #42',
+      metadata: null,
+    });
+
+    const result = upsertTaskInList(
+      [existingTask],
+      makeTask({
+        id: 'db-review-task',
+        path: '/tmp/review-task',
+        name: 'pr-42-refresh-sidebar',
+        metadata: { prNumber: 42 },
+      })
+    );
+
+    expect(result).toEqual([
+      {
+        ...existingTask,
+        id: 'db-review-task',
+        name: 'pr-42-refresh-sidebar',
+        metadata: { prNumber: 42 },
+      },
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Removes the `onReviewPr` prop from `OpenPrsSection`, replacing it with `handleOpenExternalTask` from `TaskManagementContext`
- Adds `handleOpenExternalTask` to `useTaskManagement` hook which upserts the task into the cache before selecting it, preventing stale/missing task list entries
- Wraps `handleSelectTask` in `useCallback` for stable reference
- Introduces `upsertTaskInList` utility to safely insert or update a task in the cached task list (with matching by id or path)

## Test plan
- [x] Unit tests for `upsertTaskInList` cover insert, update-by-id, and update-by-path scenarios
- [ ] Open a project with GitHub connected, click "Review" on a PR, and verify the task appears in the sidebar and opens correctly
- [ ] Verify existing task selection still works normally