### PR TITLE
feat(terminal): add shell selector with auto-detection

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -1,5 +1,6 @@
 import { app, clipboard, ipcMain, shell } from 'electron';
 import { exec, execFile } from 'child_process';
+import { existsSync } from 'fs';
 import { readFile } from 'fs/promises';
 import { join } from 'path';
 import { ensureProjectPrepared } from '../services/ProjectPrep';
@@ -627,4 +628,105 @@ export function registerAppIpc() {
   ipcMain.handle('app:getAppVersion', () => getCachedAppVersion());
   ipcMain.handle('app:getElectronVersion', () => process.versions.electron);
   ipcMain.handle('app:getPlatform', () => process.platform);
+
+  // Detect available shells on the system
+  ipcMain.handle('app:detectShells', async () => {
+    type ShellInfo = { name: string; path: string };
+    const shells: ShellInfo[] = [];
+
+    if (process.platform === 'win32') {
+      const candidates: Array<{ name: string; paths: string[]; cmd?: string }> = [
+        {
+          name: 'Command Prompt',
+          paths: [
+            process.env.ComSpec || 'C:\\Windows\\System32\\cmd.exe',
+            'C:\\Windows\\System32\\cmd.exe',
+          ],
+        },
+        {
+          name: 'PowerShell 7',
+          paths: [],
+          cmd: 'pwsh',
+        },
+        {
+          name: 'Windows PowerShell',
+          paths: ['C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe'],
+        },
+        {
+          name: 'Git Bash',
+          paths: [
+            'C:\\Program Files\\Git\\bin\\bash.exe',
+            'C:\\Program Files (x86)\\Git\\bin\\bash.exe',
+          ],
+        },
+      ];
+
+      for (const candidate of candidates) {
+        for (const p of candidate.paths) {
+          if (existsSync(p)) {
+            shells.push({ name: candidate.name, path: p });
+            break;
+          }
+        }
+
+        if (!shells.some((s) => s.name === candidate.name) && candidate.cmd) {
+          try {
+            const resolved = await new Promise<string>((resolve, reject) => {
+              exec(`where ${candidate.cmd}`, { timeout: 5000 }, (err, stdout) => {
+                if (err) return reject(err);
+                const first = stdout.trim().split('\n')[0].replace(/\r/g, '').trim();
+                if (first) resolve(first);
+                else reject(new Error('not found'));
+              });
+            });
+            shells.push({ name: candidate.name, path: resolved });
+          } catch {
+            // Not installed
+          }
+        }
+      }
+
+      try {
+        const wslOutput = await new Promise<string>((resolve, reject) => {
+          exec('wsl --list --quiet', { timeout: 5000 }, (err, stdout) => {
+            if (err) return reject(err);
+            resolve(stdout);
+          });
+        });
+        const distros = wslOutput
+          .replace(/\0/g, '')
+          .split('\n')
+          .map((l) => l.trim())
+          .filter(Boolean);
+        for (const distro of distros) {
+          shells.push({ name: `WSL: ${distro}`, path: `wsl -d ${distro}` });
+        }
+      } catch {
+        // WSL not installed
+      }
+    } else {
+      try {
+        const content = await readFile('/etc/shells', 'utf8');
+        const shellPaths = content
+          .split('\n')
+          .map((l) => l.trim())
+          .filter((l) => l && !l.startsWith('#'));
+        for (const p of shellPaths) {
+          if (existsSync(p)) {
+            const name = p.split('/').pop() || p;
+            shells.push({ name, path: p });
+          }
+        }
+      } catch {
+        const fallbacks = ['/bin/bash', '/bin/zsh', '/bin/fish', '/bin/sh'];
+        for (const p of fallbacks) {
+          if (existsSync(p)) {
+            shells.push({ name: p.split('/').pop() || p, path: p });
+          }
+        }
+      }
+    }
+
+    return { success: true, data: shells };
+  });
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -73,6 +73,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
     return () => handlers.forEach((off) => off());
   },
 
+  // Shell detection
+  detectShells: () =>
+    ipcRenderer.invoke('app:detectShells') as Promise<{
+      success: boolean;
+      data?: Array<{ name: string; path: string }>;
+    }>,
+
   // Open a path in a specific app
   openIn: (args: { app: OpenInAppId; path: string }) => ipcRenderer.invoke('app:openIn', args),
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -8,7 +8,7 @@ import { PROVIDERS, type ProviderDefinition } from '@shared/providers/registry';
 import { parsePtyId } from '@shared/ptyId';
 import { providerStatusCache } from './providerStatusCache';
 import { errorTracking } from '../errorTracking';
-import { getProviderCustomConfig } from '../settings';
+import { getAppSettings, getProviderCustomConfig } from '../settings';
 import { agentEventService } from './AgentEventService';
 import { OpenCodeHookService } from './OpenCodeHookService';
 
@@ -1246,6 +1246,12 @@ export function startDirectPty(options: {
 }
 
 function getDefaultShell(): string {
+  // Check user setting first
+  const shellSetting = getAppSettings()?.terminal?.shell;
+  if (shellSetting) {
+    return shellSetting;
+  }
+
   if (process.platform === 'win32') {
     // Prefer ComSpec (usually cmd.exe) or fallback to PowerShell
     return process.env.ComSpec || 'C:\\Windows\\System32\\WindowsPowerShell\\v1.0\\powershell.exe';

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -112,6 +112,7 @@ export interface AppSettings {
     fontFamily: string;
     fontSize: number;
     autoCopyOnSelection: boolean;
+    shell: string;
   };
   defaultOpenInApp?: OpenInAppId;
   hiddenOpenInApps?: OpenInAppId[];
@@ -194,6 +195,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     fontFamily: '',
     fontSize: 0,
     autoCopyOnSelection: false,
+    shell: '',
   },
   defaultOpenInApp: 'terminal',
   hiddenOpenInApps: [],
@@ -557,7 +559,8 @@ export function normalizeSettings(input: AppSettings): AppSettings {
     const clamped = Math.round(rawFontSize);
     fontSize = clamped >= 8 && clamped <= 24 ? clamped : 0;
   }
-  out.terminal = { fontFamily, fontSize, autoCopyOnSelection };
+  const shell = typeof term?.shell === 'string' ? term.shell.trim() : '';
+  out.terminal = { fontFamily, fontSize, autoCopyOnSelection, shell };
 
   // Default Open In App
   const defaultOpenInApp = (input as any)?.defaultOpenInApp;

--- a/src/renderer/components/TerminalSettingsCard.tsx
+++ b/src/renderer/components/TerminalSettingsCard.tsx
@@ -13,6 +13,11 @@ type FontOption = {
   fontValue: string;
 };
 
+type ShellInfo = {
+  name: string;
+  path: string;
+};
+
 const POPULAR_FONTS = [
   'Menlo',
   'SF Mono',
@@ -41,10 +46,33 @@ const TerminalSettingsCard: React.FC = () => {
   const [search, setSearch] = useState<string>('');
   const [installedFonts, setInstalledFonts] = useState<string[] | null>(null);
   const [loadingFonts, setLoadingFonts] = useState<boolean>(false);
+  const [availableShells, setAvailableShells] = useState<ShellInfo[]>([]);
+  const [loadingShells, setLoadingShells] = useState(false);
 
   const fontFamily = settings?.terminal?.fontFamily ?? '';
   const fontSize = settings?.terminal?.fontSize ?? 0;
   const autoCopyOnSelection = settings?.terminal?.autoCopyOnSelection ?? false;
+  const shellPath = settings?.terminal?.shell ?? '';
+
+  // Detect available shells on mount
+  useEffect(() => {
+    let cancelled = false;
+    setLoadingShells(true);
+    window.electronAPI
+      .detectShells()
+      .then((result) => {
+        if (!cancelled && result?.success && result.data) {
+          setAvailableShells(result.data);
+        }
+      })
+      .catch(() => {})
+      .finally(() => {
+        if (!cancelled) setLoadingShells(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   const popularOptions = useMemo<FontOption[]>(() => {
     return [
@@ -142,6 +170,13 @@ const TerminalSettingsCard: React.FC = () => {
     [updateSettings]
   );
 
+  const applyShell = useCallback(
+    (next: string) => {
+      updateSettings({ terminal: { shell: next } });
+    },
+    [updateSettings]
+  );
+
   const selectedPreset = findPreset(fontFamily);
   const pickerLabel = fontFamily.trim()
     ? (selectedPreset?.label ?? `Custom: ${fontFamily.trim()}`)
@@ -161,8 +196,45 @@ const TerminalSettingsCard: React.FC = () => {
 
   const hasAnyResults = filteredPopularOptions.length > 0 || filteredInstalledOptions.length > 0;
 
+  const shellLabel = useMemo(() => {
+    if (!shellPath) return 'Auto-detect';
+    const match = availableShells.find((s) => s.path === shellPath);
+    return match?.name ?? shellPath;
+  }, [shellPath, availableShells]);
+
   return (
     <div className="flex flex-col gap-4">
+      {/* Shell selector */}
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-1 flex-col gap-0.5">
+          <p className="text-sm font-medium text-foreground">Default shell</p>
+          <p className="text-sm text-muted-foreground">
+            Shell used for terminals. New terminals will use the selected shell.
+          </p>
+        </div>
+        <div className="w-[183px] flex-shrink-0">
+          <Select
+            value={shellPath || '__auto__'}
+            onValueChange={(v) => applyShell(v === '__auto__' ? '' : v)}
+            disabled={loading || saving || loadingShells}
+          >
+            <SelectTrigger className="h-9 bg-background hover:bg-accent hover:text-accent-foreground">
+              <SelectValue placeholder={loadingShells ? 'Detecting...' : 'Auto-detect'}>
+                {shellLabel}
+              </SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="__auto__">Auto-detect</SelectItem>
+              {availableShells.map((shell) => (
+                <SelectItem key={shell.path} value={shell.path}>
+                  {shell.name}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      {/* Font family */}
       <div className="flex items-center justify-between gap-4">
         <div className="flex flex-1 flex-col gap-0.5">
           <p className="text-sm font-medium text-foreground">Terminal font</p>
@@ -268,6 +340,7 @@ const TerminalSettingsCard: React.FC = () => {
           </Popover>
         </div>
       </div>
+      {/* Font size */}
       <div className="flex items-center justify-between gap-4">
         <div className="flex flex-1 flex-col gap-0.5">
           <p className="text-sm font-medium text-foreground">Terminal font size</p>
@@ -298,6 +371,7 @@ const TerminalSettingsCard: React.FC = () => {
           </Select>
         </div>
       </div>
+      {/* Auto-copy */}
       <div className="flex items-center justify-between gap-4">
         <div className="flex flex-1 flex-col gap-0.5">
           <p className="text-sm font-medium text-foreground">Auto-copy selected text</p>

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -53,6 +53,12 @@ declare global {
       getReleaseNotes: () => Promise<{ success: boolean; data?: string | null; error?: string }>;
       checkForUpdatesNow: () => Promise<{ success: boolean; data?: any; error?: string }>;
 
+      // Shell detection
+      detectShells: () => Promise<{
+        success: boolean;
+        data?: Array<{ name: string; path: string }>;
+      }>;
+
       // Menu events (main → renderer)
       onMenuOpenSettings: (listener: () => void) => () => void;
       onMenuCheckForUpdates: (listener: () => void) => () => void;


### PR DESCRIPTION
## Summary
- Adds a shell selector dropdown to Terminal Settings, allowing users to choose their preferred shell (bash, zsh, PowerShell, cmd, WSL distros, etc.)
- Auto-detects available shells on the system (reads `/etc/shells` on Unix, probes known paths + WSL on Windows)
- Persists the selected shell in app settings (`terminal.shellPath`)
- Wires the setting through to PTY spawning via `ptyManager.ts`

## Changed Files
- `src/main/ipc/appIpc.ts` — New `app:detectShells` IPC handler
- `src/main/preload.ts` — Expose `detectShells` to renderer
- `src/main/services/ptyManager.ts` — Use configured shell path when spawning PTYs
- `src/main/settings.ts` — Add `terminal.shellPath` to settings schema
- `src/renderer/components/TerminalSettingsCard.tsx` — Shell selector UI component
- `src/renderer/types/electron-api.d.ts` — Type declaration for `detectShells`

## Test plan
- [ ] Verify shell detection works on macOS/Linux (reads `/etc/shells`)
- [ ] Verify shell detection works on Windows (cmd, PowerShell, Git Bash, WSL)
- [ ] Select a non-default shell and confirm new PTY sessions use it
- [ ] Confirm the setting persists across app restarts
- [ ] Confirm "Default" option uses the system default shell