### PR TITLE
feat: distinguish Claude approval prompts with differentiated icon states

### DIFF
--- a/docs/content/docs/kanban-view.mdx
+++ b/docs/content/docs/kanban-view.mdx
@@ -40,7 +40,10 @@ Each card shows:
 - Task name
 - Branch name
 - Provider/agent running the task
-- Activity spinner when the agent is busy
+- Status icon:
+  - **Amber alert** (pulsing): Agent needs your approval or input
+  - **Green checkmark**: Agent action is complete or ready for input
+  - **Spinner**: Agent is waiting on something
 
 Hover over a card to see more details: provider list, and a summary of file changes (files changed, lines added/removed).
 

--- a/src/main/services/AgentEventService.ts
+++ b/src/main/services/AgentEventService.ts
@@ -201,9 +201,13 @@ class AgentEventService {
           nt === 'elicitation_dialog' ||
           nt === 'auth_success'
         ) {
+          let fallbackMessage = 'Your agent is waiting for input';
+          if (nt === 'auth_success') {
+            fallbackMessage = 'Your agent has authenticated successfully';
+          }
           const notification = new Notification({
             title: `${providerName}${titleSuffix}`,
-            body: event.payload.message?.trim() || 'Your agent is waiting for input',
+            body: event.payload.message?.trim() || fallbackMessage,
             silent: true,
           });
           addClickHandler(notification);

--- a/src/main/services/AgentEventService.ts
+++ b/src/main/services/AgentEventService.ts
@@ -195,7 +195,12 @@ class AgentEventService {
         notification.show();
       } else if (event.type === 'notification') {
         const nt = event.payload.notificationType;
-        if (nt === 'permission_prompt' || nt === 'idle_prompt' || nt === 'elicitation_dialog') {
+        if (
+          nt === 'permission_prompt' ||
+          nt === 'idle_prompt' ||
+          nt === 'elicitation_dialog' ||
+          nt === 'auth_success'
+        ) {
           const notification = new Notification({
             title: `${providerName}${titleSuffix}`,
             body: event.payload.message?.trim() || 'Your agent is waiting for input',

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -13,6 +13,7 @@ import { TaskStatusIndicator } from './TaskStatusIndicator';
 import TaskContextBadges from './TaskContextBadges';
 import { useConversationStatus } from '../hooks/useConversationStatus';
 import { useStatusUnread } from '../hooks/useStatusUnread';
+import { useTaskNotificationType } from '../hooks/useTaskNotificationType';
 import { useInitialPromptInjection } from '../hooks/useInitialPromptInjection';
 import { useCommentInjection } from '../hooks/useCommentInjection';
 import { type Agent } from '../types';
@@ -88,6 +89,8 @@ function ConversationTabButton({
     ptyKind: conversation.isMain ? 'main' : 'chat',
   });
   const unread = useStatusUnread(conversation.isMain ? taskId : conversation.id);
+  const taskNotificationTypeAll = useTaskNotificationType(taskId);
+  const notificationType = conversation.isMain ? taskNotificationTypeAll : undefined;
   const displayStatus = semanticStatus === 'unknown' && fallbackBusy ? 'working' : semanticStatus;
 
   return (
@@ -114,7 +117,11 @@ function ConversationTabButton({
       )}
       <span className="max-w-[10rem] truncate">{tabLabel}</span>
       {totalConversationCount > 1 ? (
-        <TaskStatusIndicator status={displayStatus} unread={unread && !isActive} />
+        <TaskStatusIndicator
+          status={displayStatus}
+          unread={unread && !isActive}
+          notificationType={notificationType}
+        />
       ) : null}
       {totalConversationCount > 1 && (
         <span

--- a/src/renderer/components/ProjectMainView.tsx
+++ b/src/renderer/components/ProjectMainView.tsx
@@ -50,6 +50,7 @@ import { rpc } from '../lib/rpc';
 import { useTaskAgentNames } from '../hooks/useTaskAgentNames';
 import { useTaskBusy } from '../hooks/useTaskBusy';
 import { useTaskStatus } from '../hooks/useTaskStatus';
+import { useTaskNotificationType } from '../hooks/useTaskNotificationType';
 import { useTaskUnread } from '../hooks/useTaskUnread';
 import AgentLogo from './AgentLogo';
 import { agentAssets } from '../providers/assets';
@@ -112,6 +113,7 @@ function TaskRow({
   const isArchived = Boolean(ws.archivedAt);
   const isBusy = useTaskBusy(ws.id);
   const taskStatus = useTaskStatus(ws.id);
+  const taskNotificationType = useTaskNotificationType(ws.id);
   const taskUnread = useTaskUnread(ws.id);
   const displayStatus = taskStatus === 'unknown' && isBusy ? 'working' : taskStatus;
   const [isDeleting, setIsDeleting] = useState(false);
@@ -197,7 +199,11 @@ function TaskRow({
       <div onClick={handleRowClick} role="button" tabIndex={0} className={contentClasses}>
         <div className="flex min-w-0 flex-1 items-center gap-2">
           <div className="flex w-5 flex-shrink-0 items-center justify-center">
-            <TaskStatusIndicator status={displayStatus} unread={taskUnread} />
+            <TaskStatusIndicator
+              status={displayStatus}
+              unread={taskUnread}
+              notificationType={taskNotificationType}
+            />
           </div>
           <span className={`text-sm font-medium ${isArchived ? 'text-muted-foreground' : ''}`}>
             {ws.name}

--- a/src/renderer/components/TaskItem.tsx
+++ b/src/renderer/components/TaskItem.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useRef, useEffect, useCallback } from 'react';
-import { ArrowUpRight, AlertCircle, Archive, Pencil, Pin, PinOff, Trash2 } from 'lucide-react';
+import { AlertCircle, Archive, Pencil, Pin, PinOff, Trash2 } from 'lucide-react';
 import { useTaskChanges } from '../hooks/useTaskChanges';
 import { ChangesBadge } from './TaskChanges';
 import { usePrStatus } from '../hooks/usePrStatus';
@@ -8,6 +8,7 @@ import PrPreviewTooltip from './PrPreviewTooltip';
 import { TaskStatusIndicator } from './TaskStatusIndicator';
 import TaskDeleteButton from './TaskDeleteButton';
 import { useTaskStatus } from '../hooks/useTaskStatus';
+import { useTaskNotificationType } from '../hooks/useTaskNotificationType';
 import { useTaskUnread } from '../hooks/useTaskUnread';
 import { normalizeTaskName, MAX_TASK_NAME_LENGTH } from '../lib/taskNames';
 import { normalizeSqliteTimestamp } from '../lib/utils';
@@ -78,6 +79,7 @@ export const TaskItem: React.FC<TaskItemProps> = ({
   const { pr } = usePrStatus(task.path);
   const isBusy = useTaskBusy(task.id);
   const taskStatus = useTaskStatus(task.id);
+  const taskNotificationType = useTaskNotificationType(task.id);
   const taskUnread = useTaskUnread(task.id);
   const displayStatus = taskStatus === 'unknown' && isBusy ? 'working' : taskStatus;
 
@@ -191,7 +193,11 @@ export const TaskItem: React.FC<TaskItemProps> = ({
         <div
           className={`absolute inset-0 flex items-center justify-center transition-opacity ${showDelete && (onDelete || onArchive) && !isDeleting ? 'group-hover/task:opacity-0' : ''}`}
         >
-          <TaskStatusIndicator status={displayStatus} unread={taskUnread} />
+          <TaskStatusIndicator
+            status={displayStatus}
+            unread={taskUnread}
+            notificationType={taskNotificationType}
+          />
         </div>
         {showDelete && onDelete && primaryAction === 'delete' ? (
           <div className="absolute inset-0 flex items-center justify-center">

--- a/src/renderer/components/TaskStatusIndicator.tsx
+++ b/src/renderer/components/TaskStatusIndicator.tsx
@@ -1,23 +1,74 @@
 import React from 'react';
-import type { AgentStatusKind } from '@shared/agentStatus';
+import type { AgentStatusKind, NotificationType } from '@shared/agentStatus';
 import { Spinner } from './ui/spinner';
+import { AlertTriangle, CheckCircle2 } from 'lucide-react';
 
 export function TaskStatusIndicator({
   status,
   unread = false,
+  notificationType,
 }: {
   status: AgentStatusKind;
   unread?: boolean;
+  notificationType?: NotificationType;
 }) {
   if (status === 'working') {
     return (
-      <span className="flex h-3 w-3 flex-shrink-0 items-center justify-center">
-        <Spinner size="sm" className="h-3 w-3 text-muted-foreground" />
+      <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center">
+        <Spinner size="sm" className="h-4 w-4 text-muted-foreground" />
       </span>
     );
   }
 
-  if (unread && (status === 'waiting' || status === 'complete' || status === 'error')) {
+  // Handle waiting status with notification type differentiation
+  if (status === 'waiting') {
+    // User action required: permission_prompt OR elicitation_dialog
+    // Both mean "needs your attention NOW" → amber alert icon with pulse
+    if (notificationType === 'permission_prompt' || notificationType === 'elicitation_dialog') {
+      return (
+        <span className="flex h-4 w-4 flex-shrink-0 animate-pulse items-center justify-center text-amber-500">
+          <AlertTriangle className="h-4 w-4" />
+        </span>
+      );
+    }
+
+    // Ready/complete states: auth_success OR idle_prompt
+    // Both mean "ready for next action" → green checkmark, static
+    if (notificationType === 'auth_success' || notificationType === 'idle_prompt') {
+      return (
+        <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-green-500">
+          <CheckCircle2 className="h-4 w-4" />
+        </span>
+      );
+    }
+
+    // Generic waiting without specific notification type (fallback spinner)
+    if (!notificationType) {
+      return (
+        <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-muted-foreground">
+          <Spinner size="sm" className="h-4 w-4" />
+        </span>
+      );
+    }
+  }
+
+  if (status === 'complete') {
+    return (
+      <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-green-500">
+        <CheckCircle2 className="h-4 w-4" />
+      </span>
+    );
+  }
+
+  if (status === 'error') {
+    return (
+      <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-red-500">
+        <AlertTriangle className="h-4 w-4" />
+      </span>
+    );
+  }
+
+  if (unread && status === 'idle') {
     return (
       <span className="flex h-3 w-3 flex-shrink-0 items-center justify-center">
         <span className="h-2 w-2 rounded-full bg-blue-500" />

--- a/src/renderer/components/TaskStatusIndicator.tsx
+++ b/src/renderer/components/TaskStatusIndicator.tsx
@@ -52,7 +52,7 @@ export function TaskStatusIndicator({
     }
   }
 
-  if (status === 'complete') {
+  if (unread && status === 'complete') {
     return (
       <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-green-500">
         <CheckCircle2 className="h-4 w-4" />
@@ -60,7 +60,7 @@ export function TaskStatusIndicator({
     );
   }
 
-  if (status === 'error') {
+  if (unread && status === 'error') {
     return (
       <span className="flex h-4 w-4 flex-shrink-0 items-center justify-center text-red-500">
         <AlertTriangle className="h-4 w-4" />

--- a/src/renderer/hooks/useTaskNotificationType.ts
+++ b/src/renderer/hooks/useTaskNotificationType.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from 'react';
+import type { NotificationType } from '@shared/agentStatus';
+import { agentStatusStore } from '../lib/agentStatusStore';
+
+export function useTaskNotificationType(taskId: string): NotificationType | undefined {
+  const [notificationType, setNotificationType] = useState<NotificationType | undefined>();
+
+  useEffect(() => {
+    const unsubscribe = agentStatusStore.subscribe(taskId, (snapshot) => {
+      setNotificationType(snapshot.notificationType);
+    });
+    return unsubscribe;
+  }, [taskId]);
+
+  return notificationType;
+}

--- a/src/renderer/lib/agentStatusStore.ts
+++ b/src/renderer/lib/agentStatusStore.ts
@@ -151,7 +151,8 @@ export class AgentStatusStore {
       current.kind === next.kind &&
       current.ptyId === next.ptyId &&
       current.providerId === next.providerId &&
-      current.message === next.message
+      current.message === next.message &&
+      current.notificationType === next.notificationType
     ) {
       return;
     }

--- a/src/renderer/lib/agentStatusStore.ts
+++ b/src/renderer/lib/agentStatusStore.ts
@@ -12,6 +12,7 @@ const UNKNOWN_STATUS: AgentStatusSnapshot = {
   providerId: '',
   kind: 'unknown',
   updatedAt: 0,
+  notificationType: undefined,
 };
 
 export class AgentStatusStore {
@@ -84,6 +85,7 @@ export class AgentStatusStore {
       providerId: event.providerId,
       kind: nextKind,
       message: event.payload.message?.trim() || undefined,
+      notificationType: event.type === 'notification' ? event.payload.notificationType : undefined,
     });
   }
 
@@ -131,6 +133,7 @@ export class AgentStatusStore {
     providerId: string;
     kind: AgentStatusKind;
     message?: string;
+    notificationType?: import('@shared/agentStatus').NotificationType;
   }): void {
     const current = this.statusById.get(args.id);
     const next: AgentStatusSnapshot = {
@@ -140,6 +143,7 @@ export class AgentStatusStore {
       kind: args.kind,
       updatedAt: Date.now(),
       message: args.message,
+      notificationType: args.notificationType,
     };
 
     if (

--- a/src/renderer/lib/providerStatusAdapters.ts
+++ b/src/renderer/lib/providerStatusAdapters.ts
@@ -18,7 +18,8 @@ export function mapAgentEventToStatus(event: AgentEvent): AgentStatusKind | null
   if (
     notificationType === 'permission_prompt' ||
     notificationType === 'elicitation_dialog' ||
-    notificationType === 'idle_prompt'
+    notificationType === 'idle_prompt' ||
+    notificationType === 'auth_success'
   ) {
     return 'waiting';
   }

--- a/src/shared/agentStatus.ts
+++ b/src/shared/agentStatus.ts
@@ -1,5 +1,11 @@
 export type AgentStatusKind = 'unknown' | 'working' | 'waiting' | 'complete' | 'error' | 'idle';
 
+export type NotificationType =
+  | 'permission_prompt'
+  | 'idle_prompt'
+  | 'auth_success'
+  | 'elicitation_dialog';
+
 export interface AgentStatusSnapshot {
   id: string;
   ptyId: string;
@@ -7,6 +13,7 @@ export interface AgentStatusSnapshot {
   kind: AgentStatusKind;
   updatedAt: number;
   message?: string;
+  notificationType?: NotificationType; // ← Preserved for UI differentiation
 }
 
 export interface TaskStatusSnapshot {


### PR DESCRIPTION
## Summary

Replace the spinning wheel indicator with differentiated icons when Claude needs approval or input. Instead of a generic "waiting" spinner for all agent states, the sidebar now displays:
- **Amber alert icon (pulsing)** when Claude needs approval or user input (`permission_prompt` or `elicitation_dialog`)
- **Green checkmark (static)** when action is complete or ready for next input (`auth_success` or `idle_prompt`)

This provides users with immediate visual feedback about what type of action Claude is waiting for, implementing the UX pattern requested in Issue #531 

## Related Issue
- Part of #531 
- Only fixes the issue for claude code, a more general solution is still needed to handle all the other agents

## Snapshot
![permission_prompt](https://github.com/user-attachments/assets/f5ab09fe-5aa1-4244-b7b8-da7c7cad434f)
![auth_success](https://github.com/user-attachments/assets/0c937b3e-76b4-40a7-bcd7-1d279fad09cb)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [x] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes