### PR TITLE
fix: adapt auth flow to new server response type

### DIFF
--- a/src/main/ipc/accountIpc.ts
+++ b/src/main/ipc/accountIpc.ts
@@ -16,7 +16,9 @@ export function registerAccountIpc() {
   ipcMain.handle('account:signIn', async () => {
     try {
       const result = await emdashAccountService.signIn();
-      await githubService.storeTokenFromOAuth(result.githubToken);
+      if (result.providerId === 'github') {
+        await githubService.storeTokenFromOAuth(result.accessToken);
+      }
 
       const windows = BrowserWindow.getAllWindows();
       if (windows.length > 0) {

--- a/src/main/services/EmdashAccountService.ts
+++ b/src/main/services/EmdashAccountService.ts
@@ -10,7 +10,8 @@ import type { AccountUser, ExchangeResult } from './OAuthFlowService';
 export type { AccountUser, ExchangeResult };
 
 interface SignInResult {
-  githubToken: string;
+  accessToken: string;
+  providerId: string;
   user: AccountUser;
 }
 
@@ -132,7 +133,7 @@ export class EmdashAccountService {
     this.cachedProfile = profile;
     accountProfileCache.write(profile);
 
-    return { githubToken: result.githubToken, user: result.user };
+    return { accessToken: result.accessToken, providerId: result.providerId, user: result.user };
   }
 
   /**

--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -127,10 +127,12 @@ export class GitHubService {
     try {
       const result = await emdashAccountService.signIn();
 
-      await this.storeToken(result.githubToken);
-      await this.authenticateGHCLI(result.githubToken);
+      if (result.providerId === 'github') {
+        await this.storeToken(result.accessToken);
+        await this.authenticateGHCLI(result.accessToken);
+      }
 
-      const user = await this.getUserInfo(result.githubToken);
+      const user = await this.getUserInfo(result.accessToken);
 
       if (user?.login) {
         await errorTracking.updateGithubUsername(user.login);
@@ -139,12 +141,12 @@ export class GitHubService {
       const mainWindow = getMainWindow();
       if (mainWindow) {
         mainWindow.webContents.send('github:auth:success', {
-          token: result.githubToken,
+          token: result.accessToken,
           user,
         });
       }
 
-      return { success: true, token: result.githubToken, user: user || undefined };
+      return { success: true, token: result.accessToken, user: user || undefined };
     } catch (error) {
       return {
         success: false,

--- a/src/main/services/OAuthFlowService.ts
+++ b/src/main/services/OAuthFlowService.ts
@@ -44,7 +44,8 @@ export interface AccountUser {
 
 export interface ExchangeResult {
   sessionToken: string;
-  githubToken: string;
+  accessToken: string;
+  providerId: string;
   user: AccountUser;
 }
 
@@ -127,7 +128,7 @@ export class OAuthFlowService {
         const port = (server.address() as any).port;
         const { baseUrl } = GITHUB_CONFIG.oauthServer;
         const redirectUri = `http://127.0.0.1:${port}/callback`;
-        const signInUrl = `${baseUrl}/sign-in?provider=github&state=${encodeURIComponent(state)}&redirect_uri=${encodeURIComponent(redirectUri)}&code_challenge=${encodeURIComponent(codeChallenge)}&code_challenge_method=S256`;
+        const signInUrl = `${baseUrl}/sign-in?provider_id=github&state=${encodeURIComponent(state)}&redirect_uri=${encodeURIComponent(redirectUri)}&code_challenge=${encodeURIComponent(codeChallenge)}&code_challenge_method=S256`;
 
         shell.openExternal(signInUrl).catch((err) => {
           clearTimeout(timeout);
@@ -160,7 +161,7 @@ export class OAuthFlowService {
     }
 
     const data = (await response.json()) as ExchangeResult;
-    if (!data.sessionToken || !data.githubToken || !data.user) {
+    if (!data.sessionToken || !data.accessToken || !data.providerId || !data.user) {
       throw new Error('Invalid exchange response');
     }
 


### PR DESCRIPTION
summary:
- adapt the oauth flow to work with the new server response type
- server now returns accessToken and providerId instead of githubToken