### PR TITLE
fix: always close expanded terminal on Escape even when xterm focused

### DIFF
--- a/src/renderer/components/ExpandedTerminalModal.tsx
+++ b/src/renderer/components/ExpandedTerminalModal.tsx
@@ -5,6 +5,7 @@ import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
 import { TITLEBAR_HEIGHT } from '../constants/layout';
 import { terminalSessionRegistry } from '../terminal/SessionRegistry';
+import { shouldCloseExpandedTerminal } from '../lib/expandedTerminal';
 
 interface Props {
   terminalId: string;
@@ -43,19 +44,13 @@ const ExpandedTerminalModal: React.FC<Props> = ({ terminalId, title, onClose, va
     };
   }, [terminalId]);
 
-  // Handle Escape key to close
+  // Capture Escape at window level so the modal closes even when xterm has focus.
   const handleKeyDown = useCallback(
     (e: KeyboardEvent) => {
-      // Only close on Escape when not inside the terminal textarea
-      // (xterm captures Escape for its own use only when not at a prompt)
-      if (
-        e.key === 'Escape' &&
-        !(e.target as HTMLElement)?.classList?.contains('xterm-helper-textarea')
-      ) {
-        e.preventDefault();
-        e.stopPropagation();
-        onClose();
-      }
+      if (!shouldCloseExpandedTerminal(e)) return;
+      e.preventDefault();
+      e.stopImmediatePropagation();
+      onClose();
     },
     [onClose]
   );

--- a/src/renderer/lib/expandedTerminal.ts
+++ b/src/renderer/lib/expandedTerminal.ts
@@ -1,0 +1,8 @@
+export interface ExpandedTerminalKeydownEventLike {
+  key: string;
+  target?: EventTarget | null;
+}
+
+export function shouldCloseExpandedTerminal(event: ExpandedTerminalKeydownEventLike): boolean {
+  return event.key === 'Escape';
+}

--- a/src/test/renderer/expandedTerminal.test.ts
+++ b/src/test/renderer/expandedTerminal.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { shouldCloseExpandedTerminal } from '../../renderer/lib/expandedTerminal';
+
+describe('shouldCloseExpandedTerminal', () => {
+  it('closes on Escape for regular targets', () => {
+    expect(shouldCloseExpandedTerminal({ key: 'Escape', target: {} as EventTarget })).toBe(true);
+  });
+
+  it('closes on Escape when xterm helper textarea is focused', () => {
+    const target = {
+      classList: {
+        contains: (value: string) => value === 'xterm-helper-textarea',
+      },
+    } as unknown as EventTarget;
+
+    expect(shouldCloseExpandedTerminal({ key: 'Escape', target })).toBe(true);
+  });
+
+  it('ignores other keys', () => {
+    expect(shouldCloseExpandedTerminal({ key: 'Enter', target: {} as EventTarget })).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

- Extract `shouldCloseExpandedTerminal` into a dedicated utility (`src/renderer/lib/expandedTerminal.ts`) so the close-on-Escape logic is testable independently
- Remove the previous guard that skipped Escape when the xterm helper textarea was focused — the modal should always close on Escape regardless of focus target
- Use `stopImmediatePropagation` instead of `stopPropagation` to ensure no other keydown listeners intercept the event

## Test plan

- Unit tests in `src/test/renderer/expandedTerminal.test.ts` verify the helper returns `true` for Escape (including when xterm textarea is focused) and `false` for other keys