### PR TITLE
Gate workspace provider behind PostHog feature flag

### DIFF
--- a/src/renderer/components/ConfigEditorModal.tsx
+++ b/src/renderer/components/ConfigEditorModal.tsx
@@ -459,7 +459,15 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
                   <Label>Workspace provider</Label>
                   <p className="text-xs text-muted-foreground">
                     Shell commands to provision and tear down remote workspaces. When configured,
-                    tasks can choose between a local worktree and a remote workspace.
+                    tasks can choose between a local worktree and a remote workspace.{' '}
+                    <a
+                      href="https://docs.emdash.dev/docs/bring-your-own-infrastructure"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="underline hover:text-foreground"
+                    >
+                      View docs
+                    </a>
                   </p>
                   <div className="space-y-2 rounded-md border p-3">
                     <div className="space-y-1">
@@ -477,6 +485,11 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
                         className="font-mono text-xs"
                         disabled={isSaving}
                       />
+                      <p className="text-[11px] text-muted-foreground">
+                        Script that creates a workspace and outputs SSH connection details as JSON
+                        to stdout. Receives EMDASH_TASK_ID, EMDASH_REPO_URL, EMDASH_BRANCH,
+                        EMDASH_BASE_REF as env vars.
+                      </p>
                     </div>
                     <div className="space-y-1">
                       <Label htmlFor="config-wp-terminate" className="text-xs">
@@ -493,6 +506,10 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
                         className="font-mono text-xs"
                         disabled={isSaving}
                       />
+                      <p className="text-[11px] text-muted-foreground">
+                        Script that destroys the workspace when the task is deleted. Receives
+                        EMDASH_INSTANCE_ID and EMDASH_TASK_ID as env vars.
+                      </p>
                     </div>
                   </div>
                 </div>


### PR DESCRIPTION
## Summary
- Add `PostHogFeatureFlagProvider` that initializes posthog-js for feature flag evaluation only (no event capture), respects telemetry opt-out, and identifies users via Emdash account (GitHub OAuth)
- Add `useFeatureFlag` hook wrapping `posthog.isFeatureEnabled`
- Gate workspace provider UI behind `workspace-provider` flag in TaskAdvancedSettings, ConfigEditorModal, MainContentArea, and TaskModal
- Add helper text and docs link to workspace provider config fields in ConfigEditorModal
- Add Docker logo and early access contact banner to BYOI docs page

## How it works
Users must sign in via GitHub OAuth. PostHog evaluates the `workspace-provider` flag against their email/username. Only whitelisted users (configured in PostHog dashboard) see the workspace UI. Non-flagged users see no trace of the feature.

## Test plan
- [ ] Verify workspace UI is hidden when not signed in
- [ ] Verify workspace UI is hidden for non-flagged signed-in user
- [ ] Create `workspace-provider` flag in PostHog targeting test email, verify UI appears
- [ ] Verify telemetry opt-out disables PostHog initialization (flags default to hidden)

🤖 Generated with [Claude Code](https://claude.com/claude-code)