### PR TITLE
feat(dashboard): show line change counts on Open PRs

### DIFF
--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -64,7 +64,6 @@ export interface GitHubPullRequest {
   reviewers?: GitHubReviewer[];
   additions?: number;
   deletions?: number;
-  changedFiles?: number;
 }
 
 export interface GitHubPullRequestListResult {
@@ -853,7 +852,6 @@ export class GitHubService {
         'reviewDecision',
         'additions',
         'deletions',
-        'changedFiles',
       ];
       const searchFlag = searchQuery ? ` --search ${quoteShellArg(searchQuery)}` : '';
       const { stdout } = await this.execGH(
@@ -883,7 +881,6 @@ export class GitHubService {
           reviewers: this.buildReviewerList(item?.reviewRequests, item?.latestReviews),
           additions: typeof item?.additions === 'number' ? item.additions : undefined,
           deletions: typeof item?.deletions === 'number' ? item.deletions : undefined,
-          changedFiles: typeof item?.changedFiles === 'number' ? item.changedFiles : undefined,
         }))
       );
 

--- a/src/renderer/components/OpenPrsSection.tsx
+++ b/src/renderer/components/OpenPrsSection.tsx
@@ -436,12 +436,12 @@ const OpenPrsSection: React.FC<OpenPrsSectionProps> = ({ projectPath, projectId 
                               <span className="inline-flex items-center gap-1 font-medium">
                                 {pr.additions != null && (
                                   <span className="text-green-600 dark:text-green-400">
-                                    +{pr.additions}
+                                    +{pr.additions.toLocaleString()}
                                   </span>
                                 )}
                                 {pr.deletions != null && (
                                   <span className="text-red-600 dark:text-red-400">
-                                    -{pr.deletions}
+                                    -{pr.deletions.toLocaleString()}
                                   </span>
                                 )}
                               </span>

--- a/src/renderer/hooks/usePullRequests.ts
+++ b/src/renderer/hooks/usePullRequests.ts
@@ -19,7 +19,6 @@ export interface PullRequestSummary {
   reviewers?: PullRequestReviewer[];
   additions?: number;
   deletions?: number;
-  changedFiles?: number;
 }
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -85,7 +84,6 @@ export function usePullRequests(
               reviewers: Array.isArray(item?.reviewers) ? item.reviewers : [],
               additions: typeof item?.additions === 'number' ? item.additions : undefined,
               deletions: typeof item?.deletions === 'number' ? item.deletions : undefined,
-              changedFiles: typeof item?.changedFiles === 'number' ? item.changedFiles : undefined,
             }))
             .filter((item) => item.number > 0);
           setPrs(mapped);


### PR DESCRIPTION
## Summary

- Fetch `additions` and `deletions` (~~and `changedFiles`~~) from GitHub API when listing PRs
- Display GitHub-style green `+N` / red `-N` line counts inline in each PR row on the project dashboard's Open PRs section
- Large numbers are locale-formatted (e.g. `+15,000`) to match GitHub's display

Fixes #1516

## Test plan

- [x] Open a project with open PRs on the dashboard
- [x] Verify each PR row shows `+additions -deletions` in green/red after the author name
- [ ] Verify large line counts are comma-formatted (e.g. `+1,234`)
- [x] Verify PRs with no diff stats available don't show broken UI
- [x] Run `pnpm run type-check`, `pnpm run lint`, `pnpm exec vitest run` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)