### PR TITLE
fix: env vars not deleted when saving agent config

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -646,10 +646,14 @@ export function updateProviderCustomConfig(
     const cleaned: ProviderCustomConfig = {};
     for (const [k, v] of Object.entries(config)) {
       if (v !== undefined) {
-        (cleaned as any)[k] = v;
+        cleaned[k as keyof ProviderCustomConfig] = v;
       }
     }
-    currentConfigs[providerId] = cleaned;
+    if (Object.keys(cleaned).length > 0) {
+      currentConfigs[providerId] = cleaned;
+    } else {
+      delete currentConfigs[providerId];
+    }
   }
 
   // Write the full providerConfigs map directly to avoid deepMerge


### PR DESCRIPTION
## Summary
- **Bug:** Deleting env vars in the agent config modal appeared to work in the UI, but the vars reappeared after reopening because `deepMerge` in `updateAppSettings` skips `undefined` values, preserving the old `env` record.
- **Fix:** `updateProviderCustomConfig` now bypasses `deepMerge` by writing the full `providerConfigs` map directly via `normalizeSettings` + `persistSettings`. It also strips `undefined` values from the config before saving.

## Test plan
- [ ] Open agent config modal for a provider with env vars set
- [ ] Delete one or more env vars and save
- [ ] Reopen the modal — deleted env vars should no longer appear
- [ ] Verify adding new env vars still works correctly
- [ ] Verify resetting to defaults still removes the provider config entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)