### PR TITLE
Add on-device voice dictation (RunAnywhere STT)

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,8 @@
     "@radix-ui/react-toast": "^1.2.15",
     "@radix-ui/react-tooltip": "^1.2.8",
     "@radix-ui/react-use-controllable-state": "^1.2.2",
+    "@runanywhere/web": "0.1.0-beta.10",
+    "@runanywhere/web-onnx": "0.1.0-beta.10",
     "@tanstack/react-query": "^5.90.21",
     "@types/react-window": "^1.8.8",
     "@types/sqlite3": "^3.1.11",
@@ -170,6 +172,9 @@
     "mac": {
       "category": "public.app-category.developer-tools",
       "hardenedRuntime": true,
+      "extendInfo": {
+        "NSMicrophoneUsageDescription": "Emdash uses the microphone for on-device voice dictation into agent prompts."
+      },
       "entitlements": "build/entitlements.mac.plist",
       "entitlementsInherit": "build/entitlements.mac.plist",
       "target": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -83,6 +83,12 @@ importers:
       '@radix-ui/react-use-controllable-state':
         specifier: ^1.2.2
         version: 1.2.2(@types/react@18.3.28)(react@18.3.1)
+      '@runanywhere/web':
+        specifier: 0.1.0-beta.10
+        version: 0.1.0-beta.10
+      '@runanywhere/web-onnx':
+        specifier: 0.1.0-beta.10
+        version: 0.1.0-beta.10(@runanywhere/web@0.1.0-beta.10)
       '@tanstack/react-query':
         specifier: ^5.90.21
         version: 5.90.21(react@18.3.1)
@@ -1808,6 +1814,16 @@ packages:
 
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
+
+  '@runanywhere/web-onnx@0.1.0-beta.10':
+    resolution: {integrity: sha512-PYMvoE5ij0fK3sHoEYzwvp0FgZYQpX2Jdygfrs63+YYH+CtJ5vQVoukQfnHl/Knl8psL0WPY+Ukj5NvDp3yD9Q==}
+    engines: {node: '>=18.0.0'}
+    peerDependencies:
+      '@runanywhere/web': '>=0.1.0-beta.0'
+
+  '@runanywhere/web@0.1.0-beta.10':
+    resolution: {integrity: sha512-GSnymtlu7Vx1+ufV3V8o6zgpiKGxFqHlfmq7ynyLGAZOkR+Hj96geryS1NMTTEZN34MHOZ0TjSM49NsMpfRCPg==}
+    engines: {node: '>=18.0.0'}
 
   '@shikijs/core@3.22.0':
     resolution: {integrity: sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA==}
@@ -7542,6 +7558,12 @@ snapshots:
     optional: true
 
   '@rtsao/scc@1.1.0': {}
+
+  '@runanywhere/web-onnx@0.1.0-beta.10(@runanywhere/web@0.1.0-beta.10)':
+    dependencies:
+      '@runanywhere/web': 0.1.0-beta.10
+
+  '@runanywhere/web@0.1.0-beta.10': {}
 
   '@shikijs/core@3.22.0':
     dependencies:

--- a/src/main/app/staticServer.ts
+++ b/src/main/app/staticServer.ts
@@ -24,6 +24,14 @@ const MIME_MAP: Record<string, string> = {
   '.webp': 'image/webp',
   '.ico': 'image/x-icon',
   '.woff2': 'font/woff2',
+  '.wasm': 'application/wasm',
+};
+
+// Required for SharedArrayBuffer access — the ONNX WASM runtime needs these
+// headers on every response served to the renderer.
+const CROSS_ORIGIN_HEADERS = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'credentialless',
 };
 
 function getMime(filePath: string) {
@@ -49,21 +57,18 @@ async function listenWithFallback(server: ReturnType<typeof createServer>): Prom
   for (const port of candidates) {
     try {
       const addr = await new Promise<AddressInfo>((resolve, reject) => {
-        let onError: (error: unknown) => void;
-        let onListening: () => void;
+        const onError = (error: unknown) => {
+          cleanup();
+          reject(error);
+        };
+        const onListening = () => {
+          cleanup();
+          resolve(server.address() as AddressInfo);
+        };
 
         const cleanup = () => {
           server.removeListener('error', onError);
           server.removeListener('listening', onListening);
-        };
-
-        onError = (error: unknown) => {
-          cleanup();
-          reject(error);
-        };
-        onListening = () => {
-          cleanup();
-          resolve(server.address() as AddressInfo);
         };
 
         server.once('error', onError);
@@ -76,7 +81,10 @@ async function listenWithFallback(server: ReturnType<typeof createServer>): Prom
       }
       return addr;
     } catch (error) {
-      const code = (error as any)?.code;
+      const code =
+        typeof error === 'object' && error !== null && 'code' in error
+          ? String((error as { code?: unknown }).code)
+          : undefined;
       if (code === 'EADDRINUSE') {
         if (server.listening) {
           await new Promise<void>((resolve) => server.close(() => resolve()));
@@ -139,6 +147,7 @@ export async function ensureRendererServer(root: string): Promise<string> {
       res.writeHead(200, {
         'Content-Type': getMime(filePath),
         'Cache-Control': 'no-cache, no-store, must-revalidate',
+        ...CROSS_ORIGIN_HEADERS,
       });
       if (!isHead) res.write(data);
       res.end();

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -10,6 +10,12 @@ import {
   DEFAULT_REVIEW_PROMPT,
   type ReviewSettings,
 } from '@shared/reviewPreset';
+import {
+  DEFAULT_VOICE_INPUT_SETTINGS,
+  isVoiceInputModelId,
+  isVoiceInputProvider,
+  type VoiceInputSettings,
+} from '@shared/voiceInput';
 
 export type DeepPartial<T> = {
   [K in keyof T]?: NonNullable<T[K]> extends object
@@ -123,6 +129,7 @@ export interface AppSettings {
   changelog?: {
     dismissedVersions: string[];
   };
+  voiceInput?: VoiceInputSettings;
 }
 
 function getPlatformTaskSwitchDefaults(): { next: ShortcutBinding; prev: ShortcutBinding } {
@@ -206,6 +213,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   changelog: {
     dismissedVersions: [],
   },
+  voiceInput: DEFAULT_VOICE_INPUT_SETTINGS,
 };
 
 function getSettingsPath(): string {
@@ -601,6 +609,16 @@ export function normalizeSettings(input: AppSettings): AppSettings {
           ),
         ]
       : [],
+  };
+
+  const rawVoiceInput = (input as any)?.voiceInput || {};
+  out.voiceInput = {
+    provider: isVoiceInputProvider(rawVoiceInput?.provider)
+      ? rawVoiceInput.provider
+      : DEFAULT_VOICE_INPUT_SETTINGS.provider,
+    modelId: isVoiceInputModelId(rawVoiceInput?.modelId)
+      ? rawVoiceInput.modelId
+      : DEFAULT_VOICE_INPUT_SETTINGS.modelId,
   };
 
   return out;

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -40,6 +40,12 @@ import {
   getConversationTabLabel,
   planConversationTitleUpdates,
 } from '../lib/conversationTabTitles';
+import { TaskPromptBar } from './TaskPromptBar';
+import {
+  consumePromptComments,
+  injectPromptViaPty,
+  preparePromptSubmission,
+} from '@/lib/promptSubmission';
 
 declare const window: Window & {
   electronAPI: {
@@ -163,6 +169,7 @@ const ChatInterface: React.FC<Props> = ({
   const [agent, setAgent] = useState<Agent>(initialAgent || 'claude');
   const currentAgentStatus = agentStatuses[agent];
   const [cliStartError, setCliStartError] = useState<string | null>(null);
+  const [prompt, setPrompt] = useState('');
 
   // Workspace-provisioned remote connection overrides
   const { connectionId: workspaceConnectionId, remotePath: workspaceRemotePath } =
@@ -571,6 +578,10 @@ const ChatInterface: React.FC<Props> = ({
   useEffect(() => {
     setCliStartError(null);
   }, [task.id]);
+
+  useEffect(() => {
+    setPrompt('');
+  }, [task.id, activeConversationId]);
 
   const runInstallCommand = useCallback(
     (cmd: string) => {
@@ -1133,6 +1144,25 @@ const ChatInterface: React.FC<Props> = ({
     });
   }, [activeConversation, activeReviewMetadata]);
 
+  const handlePromptSubmit = useCallback(async () => {
+    const prepared = preparePromptSubmission({
+      prompt,
+      taskId: task.id,
+      taskPath: task.path,
+    });
+    if (!prepared.text) return;
+
+    const injected = await injectPromptViaPty({
+      ptyId: terminalId,
+      agent,
+      text: prepared.text,
+    });
+    consumePromptComments(prepared.commentScopeKey, injected);
+    if (injected) {
+      setPrompt('');
+    }
+  }, [agent, prompt, task.id, task.path, terminalId]);
+
   if (!isTerminal) {
     return null;
   }
@@ -1356,6 +1386,15 @@ const ChatInterface: React.FC<Props> = ({
                 />
               )}
             </div>
+          </div>
+          <div className="px-6 pb-6 pt-4">
+            <TaskPromptBar
+              value={prompt}
+              onChange={setPrompt}
+              onSubmit={handlePromptSubmit}
+              disabled={!conversationsLoaded || isAgentInstalled === false || !!cliStartError}
+              placeholder={`Tell ${agentMeta[agent]?.label ?? 'the agent'} what to do...`}
+            />
           </div>
         </div>
       </div>

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -233,10 +233,14 @@ const MultiAgentTask: React.FC<Props> = ({
       }
     );
     const results = await Promise.all(tasks);
+    let anyInjected = false;
     for (const result of results) {
       consumePromptComments(result.scopeKey, result.injected);
+      if (result.injected) anyInjected = true;
     }
-    setPrompt('');
+    if (anyInjected) {
+      setPrompt('');
+    }
   };
 
   // Track per-variant activity so we can render a spinner on the tabs

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -1,8 +1,6 @@
 import React, { useEffect, useMemo, useRef, useState } from 'react';
 import { type Task } from '../types/chat';
 import { type Agent } from '../types';
-import { Button } from './ui/button';
-import { Input } from './ui/input';
 import OpenInMenu from './titlebar/OpenInMenu';
 import { TerminalPane } from './TerminalPane';
 import { agentMeta } from '@/providers/meta';
@@ -13,19 +11,20 @@ import { classifyActivity, sampleActivityChunk } from '@/lib/activityClassifier'
 import { activityStore } from '@/lib/activityStore';
 import { Spinner } from './ui/spinner';
 import { BUSY_HOLD_MS, CLEAR_BUSY_MS } from '@/lib/activityConstants';
-import { CornerDownLeft } from 'lucide-react';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import { useAutoScrollOnTaskSwitch } from '@/hooks/useAutoScrollOnTaskSwitch';
 import { getTaskEnvVars } from '@shared/task/envVars';
 import { rpc } from '@/lib/rpc';
 import { useWorkspaceConnection } from '../hooks/useWorkspaceConnection';
 import { useCommentInjection } from '@/hooks/useCommentInjection';
-import { isSlashCommandInput } from '@/lib/slashCommand';
-import { buildCommentScopeKey, draftCommentsStore } from '@/lib/DraftCommentsStore';
-import { formatCommentsForAgent } from '@/lib/formatCommentsForAgent';
-import { buildPromptInjectionPayload } from '@/lib/terminalInjection';
 import { TaskScopeProvider } from './TaskScopeContext';
 import TaskContextBadges from './TaskContextBadges';
+import { TaskPromptBar } from './TaskPromptBar';
+import {
+  consumePromptComments,
+  injectPromptViaPty,
+  preparePromptSubmission,
+} from '@/lib/promptSubmission';
 
 interface Props {
   task: Task;
@@ -213,129 +212,29 @@ const MultiAgentTask: React.FC<Props> = ({
     return null;
   }, [task.metadata]);
 
-  const injectPrompt = async (ptyId: string, agent: Agent, text: string): Promise<boolean> => {
-    const trimmed = (text || '').trim();
-    if (!trimmed) return false;
-
-    return await new Promise<boolean>((resolve) => {
-      let sent = false;
-      let finished = false;
-      let silenceTimer: ReturnType<typeof setTimeout> | null = null;
-      let eagerTimer: ReturnType<typeof setTimeout> | null = null;
-      let hardTimer: ReturnType<typeof setTimeout> | null = null;
-      let offData: (() => void) | undefined;
-      let offStarted: (() => void) | undefined;
-
-      const cleanup = () => {
-        if (silenceTimer) {
-          clearTimeout(silenceTimer);
-          silenceTimer = null;
-        }
-        if (eagerTimer) {
-          clearTimeout(eagerTimer);
-          eagerTimer = null;
-        }
-        if (hardTimer) {
-          clearTimeout(hardTimer);
-          hardTimer = null;
-        }
-        offData?.();
-        offStarted?.();
-      };
-
-      const finish = (didInject: boolean) => {
-        if (finished) return;
-        finished = true;
-        cleanup();
-        resolve(didInject);
-      };
-
-      const send = () => {
-        if (sent) return;
-        sent = true;
-        try {
-          const pty = (window as any).electronAPI?.ptyInput;
-          if (!pty) {
-            finish(false);
-            return;
-          }
-          const { payload, submitDelayMs } = buildPromptInjectionPayload({ agent, text: trimmed });
-          pty({ id: ptyId, data: payload });
-          setTimeout(() => {
-            try {
-              pty({ id: ptyId, data: '\r' });
-            } catch {}
-          }, submitDelayMs);
-          finish(true);
-        } catch {
-          finish(false);
-        }
-      };
-
-      offData = (window as any).electronAPI?.onPtyData?.(ptyId, (chunk: string) => {
-        if (silenceTimer) clearTimeout(silenceTimer);
-        silenceTimer = setTimeout(() => {
-          if (!sent) send();
-        }, 1000);
-        try {
-          const signal = classifyActivity(agent, chunk);
-          if (signal === 'idle' && !sent) {
-            setTimeout(send, 200);
-          }
-        } catch {}
-      });
-
-      offStarted = (window as any).electronAPI?.onPtyStarted?.((info: { id: string }) => {
-        if (info?.id === ptyId) {
-          if (silenceTimer) clearTimeout(silenceTimer);
-          silenceTimer = setTimeout(() => {
-            if (!sent) send();
-          }, 1500);
-        }
-      });
-
-      eagerTimer = setTimeout(() => {
-        if (!sent) send();
-      }, 300);
-
-      hardTimer = setTimeout(() => {
-        if (!sent) send();
-      }, 5000);
-    });
-  };
-
   const handleRunAll = async () => {
     const msg = prompt.trim();
     if (!msg) return;
-    const isSlashCommand = isSlashCommandInput(msg);
-    // Send concurrently via PTY injection for all agents (Codex/Claude included)
+
     const tasks: Promise<{ scopeKey: string | null; injected: boolean }>[] = variants.map(
       async (v) => {
         const termId = `${v.worktreeId}-main`;
-        let messageWithComments = msg;
-        let scopeKey: string | null = null;
-        if (!isSlashCommand) {
-          scopeKey = buildCommentScopeKey(task.id, v.path);
-          const comments = draftCommentsStore.getAll(scopeKey);
-          const pendingText = formatCommentsForAgent(comments, {
-            includeIntro: false,
-            leadingNewline: true,
-          });
-          if (pendingText) {
-            messageWithComments = `${msg}${pendingText}`;
-          } else {
-            scopeKey = null;
-          }
-        }
-        const injected = await injectPrompt(termId, v.agent, messageWithComments);
-        return { scopeKey, injected };
+        const prepared = preparePromptSubmission({
+          prompt: msg,
+          taskId: task.id,
+          taskPath: v.path,
+        });
+        const injected = await injectPromptViaPty({
+          ptyId: termId,
+          agent: v.agent,
+          text: prepared.text,
+        });
+        return { scopeKey: prepared.commentScopeKey, injected };
       }
     );
     const results = await Promise.all(tasks);
     for (const result of results) {
-      if (result.scopeKey && result.injected) {
-        draftCommentsStore.consumeAll(result.scopeKey);
-      }
+      consumePromptComments(result.scopeKey, result.injected);
     }
     setPrompt('');
   };
@@ -690,7 +589,11 @@ const MultiAgentTask: React.FC<Props> = ({
                           (agentMeta[v.agent]?.initialPromptFlag === undefined ||
                             agentMeta[v.agent]?.useKeystrokeInjection)
                         ) {
-                          void injectPrompt(`${v.worktreeId}-main`, v.agent, initialInjection);
+                          void injectPromptViaPty({
+                            ptyId: `${v.worktreeId}-main`,
+                            agent: v.agent,
+                            text: initialInjection,
+                          });
                         }
                         if (initialInjection && !task.metadata?.initialInjectionSent) {
                           void rpc.db.saveTask({
@@ -711,37 +614,12 @@ const MultiAgentTask: React.FC<Props> = ({
         })}
 
         <div className="px-6 pb-6 pt-4">
-          <div className="mx-auto max-w-4xl">
-            <div className="relative rounded-md border border-border bg-white shadow-lg dark:border-border dark:bg-card">
-              <div className="flex items-center gap-2 rounded-md px-4 py-3">
-                <Input
-                  className="h-9 flex-1 border-border bg-muted dark:border-border dark:bg-muted"
-                  placeholder="Tell the agents what to do..."
-                  value={prompt}
-                  onChange={(e) => setPrompt(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && !e.shiftKey) {
-                      e.preventDefault();
-                      if (prompt.trim()) {
-                        void handleRunAll();
-                      }
-                    }
-                  }}
-                />
-                <Button
-                  variant="outline"
-                  size="sm"
-                  className="h-9 border border-border bg-muted px-3 text-xs font-medium hover:bg-muted dark:border-border dark:bg-muted dark:hover:bg-muted"
-                  onClick={handleRunAll}
-                  disabled={!prompt.trim()}
-                  title="Run in all panes (Enter)"
-                  aria-label="Run in all panes"
-                >
-                  <CornerDownLeft className="h-4 w-4" />
-                </Button>
-              </div>
-            </div>
-          </div>
+          <TaskPromptBar
+            value={prompt}
+            onChange={setPrompt}
+            onSubmit={handleRunAll}
+            placeholder="Tell the agents what to do..."
+          />
         </div>
       </div>
     </TaskScopeProvider>

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -29,6 +29,7 @@ import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
 import ReviewAgentSettingsCard from './ReviewAgentSettingsCard';
 import { AccountTab } from './settings/AccountTab';
 import { useTaskSettings } from '../hooks/useTaskSettings';
+import { VoiceInputSettingsCard } from './VoiceInputSettingsCard';
 
 export type SettingsPageTab =
   | 'general'
@@ -254,6 +255,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
       sections: [
         { component: <ThemeCard /> },
         { component: <TerminalSettingsCard /> },
+        { component: <VoiceInputSettingsCard /> },
         { title: 'Keyboard shortcuts', component: <KeyboardSettingsCard /> },
         {
           title: 'Workspace',
@@ -281,7 +283,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
   const currentContent = tabContent[activeTab as keyof typeof tabContent];
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden px-6 pb-0 pt-8">
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden px-6 pb-8 pt-8">
       <div className="mx-auto flex h-full min-h-0 w-full max-w-[1060px] flex-col gap-6">
         {/* Header */}
         <div className="flex flex-col gap-6">
@@ -309,7 +311,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
         {/* Contents: Navigation + Content */}
         <div className="grid min-h-0 flex-1 grid-cols-[13rem_minmax(0,1fr)] gap-8 overflow-hidden">
           {/* Navigation menu */}
-          <nav className="flex min-h-0 w-52 flex-col gap-2 overflow-y-auto">
+          <nav className="flex min-h-0 w-52 flex-col gap-2 overflow-y-auto pb-8 pr-2">
             {tabs.map((tab) => {
               const isActive = activeTab === tab.id && !tab.isExternal;
 
@@ -341,29 +343,31 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
 
           {/* Content container */}
           {currentContent && (
-            <div className="flex min-h-0 min-w-0 flex-1 justify-center overflow-y-auto pb-8">
-              <div className="mx-auto w-full max-w-4xl space-y-8">
-                {/* Page title */}
-                <div className="flex flex-col gap-6">
-                  <div className="flex flex-col gap-1">
-                    <h2 className="text-base font-medium">{currentContent.title}</h2>
-                    <p className="text-sm text-muted-foreground">{currentContent.description}</p>
+            <div className="min-h-0 min-w-0 flex-1 overflow-hidden">
+              <div className="h-full overflow-y-auto pr-2">
+                <div className="mx-auto w-full max-w-4xl space-y-8 pb-8">
+                  {/* Page title */}
+                  <div className="flex flex-col gap-6">
+                    <div className="flex flex-col gap-1">
+                      <h2 className="text-base font-medium">{currentContent.title}</h2>
+                      <p className="text-sm text-muted-foreground">{currentContent.description}</p>
+                    </div>
+                    <Separator />
                   </div>
-                  <Separator />
-                </div>
 
-                {/* Sections */}
-                {currentContent.sections.map((section, index) => (
-                  <div key={index} className="flex flex-col gap-3">
-                    {section.title && (
-                      <div className="flex items-center justify-between">
-                        <h3 className="text-sm font-medium text-foreground">{section.title}</h3>
-                        {section.action && <div>{section.action}</div>}
-                      </div>
-                    )}
-                    {section.component}
-                  </div>
-                ))}
+                  {/* Sections */}
+                  {currentContent.sections.map((section, index) => (
+                    <div key={index} className="flex flex-col gap-3">
+                      {section.title && (
+                        <div className="flex items-center justify-between">
+                          <h3 className="text-sm font-medium text-foreground">{section.title}</h3>
+                          {section.action && <div>{section.action}</div>}
+                        </div>
+                      )}
+                      {section.component}
+                    </div>
+                  ))}
+                </div>
               </div>
             </div>
           )}

--- a/src/renderer/components/TaskPromptBar.tsx
+++ b/src/renderer/components/TaskPromptBar.tsx
@@ -176,7 +176,7 @@ export function TaskPromptBar({
               type="button"
               variant="ghost"
               size="icon"
-              className="h-12 w-12 shrink-0 rounded-full bg-foreground text-background shadow-sm hover:bg-foreground/90"
+              className="h-12 w-12 shrink-0 rounded-full bg-foreground text-background shadow-sm hover:opacity-80 hover:shadow-md"
               disabled={voiceInput.phase === 'preparing' || voiceInput.phase === 'transcribing'}
               onClick={() => {
                 void handleVoiceToggle();

--- a/src/renderer/components/TaskPromptBar.tsx
+++ b/src/renderer/components/TaskPromptBar.tsx
@@ -1,0 +1,283 @@
+import React, { useEffect, useRef } from 'react';
+import { ArrowUp, CornerDownLeft, LoaderCircle, Mic, X } from 'lucide-react';
+import { Button } from './ui/button';
+import { Textarea } from './ui/textarea';
+import { ToastAction } from './ui/toast';
+import { cn } from '@/lib/utils';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import { useToast } from '@/hooks/use-toast';
+import { dispatchOpenSettingsPage } from '@/lib/settingsPageEvents';
+import { DEFAULT_VOICE_INPUT_SETTINGS, getVoiceInputModelOption } from '@shared/voiceInput';
+import { useRunAnywhereVoiceInput } from '@/hooks/useRunAnywhereVoiceInput';
+
+interface TaskPromptBarProps {
+  value: string;
+  onChange: (value: string) => void;
+  onSubmit: () => Promise<void> | void;
+  disabled?: boolean;
+  placeholder?: string;
+  className?: string;
+}
+
+const MAX_PROMPT_HEIGHT = 160;
+
+function syncPromptHeight(textarea: HTMLTextAreaElement | null) {
+  if (!textarea) return;
+
+  textarea.style.height = '0px';
+  const nextHeight = Math.min(textarea.scrollHeight, MAX_PROMPT_HEIGHT);
+  textarea.style.height = `${Math.max(nextHeight, 40)}px`;
+  textarea.style.overflowY = textarea.scrollHeight > MAX_PROMPT_HEIGHT ? 'auto' : 'hidden';
+}
+
+function VoiceRecordingWave({
+  phase,
+  audioLevel,
+}: {
+  phase: 'idle' | 'preparing' | 'listening' | 'transcribing';
+  audioLevel: number;
+}) {
+  const normalizedLevel = Math.min(Math.max(audioLevel, 0), 1);
+  const bars = Array.from({ length: 19 }, (_, index) => {
+    const distanceFromCenter = Math.abs(index - 9);
+    const centerWeight = Math.max(0.2, 1 - distanceFromCenter / 10);
+    const activity =
+      phase === 'listening' ? 0.3 + normalizedLevel * 0.9 : phase === 'transcribing' ? 0.5 : 0.25;
+    const pulse = 0.75 + ((index % 3) + 1) * 0.08;
+    return 8 + centerWeight * activity * pulse * 28;
+  });
+
+  return (
+    <div className="flex flex-1 items-center justify-center px-2" aria-hidden="true">
+      <div className="flex h-11 w-full max-w-[420px] items-end justify-center gap-1.5">
+        {bars.map((height, index) => (
+          <span
+            key={index}
+            className={cn(
+              'w-1.5 rounded-full bg-foreground/75 transition-[height,opacity,background-color] duration-150 ease-out',
+              phase === 'listening' ? 'opacity-100' : 'bg-muted-foreground/50 opacity-75'
+            )}
+            style={{ height }}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function appendTranscription(existing: string, incoming: string) {
+  const current = existing.trim();
+  const next = incoming.trim();
+  if (!next) return existing;
+  if (!current) return next;
+  return `${current} ${next}`;
+}
+
+export function TaskPromptBar({
+  value,
+  onChange,
+  onSubmit,
+  disabled = false,
+  placeholder = 'Tell the agent what to do...',
+  className,
+}: TaskPromptBarProps) {
+  const inputRef = useRef<HTMLTextAreaElement | null>(null);
+  const latestValueRef = useRef(value);
+  const lastTranscriptIdRef = useRef(0);
+  const { settings } = useAppSettings();
+  const { toast } = useToast();
+  const voiceSettings = settings?.voiceInput ?? DEFAULT_VOICE_INPUT_SETTINGS;
+  const selectedModel = getVoiceInputModelOption(voiceSettings.modelId);
+  const voiceInput = useRunAnywhereVoiceInput({
+    modelId: voiceSettings.modelId,
+  });
+  const voiceModeActive =
+    voiceInput.phase === 'preparing' ||
+    voiceInput.phase === 'listening' ||
+    voiceInput.phase === 'transcribing';
+  const liveMicScale = voiceInput.isSessionActive
+    ? 1 + Math.min(Math.max(voiceInput.audioLevel, 0), 1) * 0.25
+    : 1;
+
+  useEffect(() => {
+    if (!voiceInput.statusText) return;
+    inputRef.current?.focus();
+    syncPromptHeight(inputRef.current);
+  }, [voiceInput.statusText]);
+
+  useEffect(() => {
+    latestValueRef.current = value;
+  }, [value]);
+
+  useEffect(() => {
+    syncPromptHeight(inputRef.current);
+  }, [value]);
+
+  useEffect(() => {
+    if (voiceInput.transcriptId === 0 || voiceInput.transcriptId === lastTranscriptIdRef.current) {
+      return;
+    }
+
+    lastTranscriptIdRef.current = voiceInput.transcriptId;
+
+    if (!voiceInput.transcript) return;
+    onChange(appendTranscription(latestValueRef.current, voiceInput.transcript));
+  }, [onChange, voiceInput.transcript, voiceInput.transcriptId]);
+
+  const submitDisabled =
+    disabled || !value.trim() || voiceInput.isSessionActive || voiceInput.phase === 'transcribing';
+
+  const handleVoiceToggle = async () => {
+    const result = await voiceInput.toggleRecording();
+
+    if (result === 'download-required' || result === 'download-in-progress') {
+      const modelLabel = selectedModel?.label ?? 'The selected dictation model';
+      toast({
+        title:
+          result === 'download-required'
+            ? 'Download voice model first'
+            : 'Voice model is still downloading',
+        description:
+          result === 'download-required'
+            ? `${modelLabel} is not downloaded on this device yet. Open Settings > Interface > Voice input to download it.`
+            : `${modelLabel} is still downloading. Open Settings > Interface > Voice input to finish preparing it.`,
+        action: (
+          <ToastAction
+            altText="Open settings"
+            onClick={() => dispatchOpenSettingsPage({ tab: 'interface' })}
+          >
+            Open settings
+          </ToastAction>
+        ),
+      });
+    }
+  };
+
+  if (voiceModeActive) {
+    return (
+      <div className={cn('mx-auto max-w-4xl', className)}>
+        <div className="rounded-[30px] border border-border/70 bg-background/95 shadow-lg">
+          <div className="flex items-center gap-3 px-3 py-2.5">
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-12 w-12 shrink-0 rounded-full border border-border/70 bg-muted/30 text-foreground/80 hover:bg-muted/60 hover:text-foreground"
+              onClick={() => {
+                voiceInput.cancelListening();
+              }}
+              title="Cancel dictation"
+              aria-label="Cancel dictation"
+            >
+              <X className="h-5 w-5" />
+            </Button>
+            <VoiceRecordingWave phase={voiceInput.phase} audioLevel={voiceInput.audioLevel} />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-12 w-12 shrink-0 rounded-full bg-foreground text-background shadow-sm hover:bg-foreground/90"
+              disabled={voiceInput.phase === 'preparing' || voiceInput.phase === 'transcribing'}
+              onClick={() => {
+                void handleVoiceToggle();
+              }}
+              title="Finish dictation"
+              aria-label="Finish dictation"
+            >
+              {voiceInput.phase === 'preparing' || voiceInput.phase === 'transcribing' ? (
+                <LoaderCircle className="h-5 w-5 animate-spin" />
+              ) : (
+                <ArrowUp className="h-5 w-5" />
+              )}
+            </Button>
+          </div>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('mx-auto max-w-4xl', className)}>
+      <div className="rounded-md border border-border bg-background shadow-lg">
+        <div className="flex items-end gap-2 rounded-md px-4 py-3">
+          <Textarea
+            ref={inputRef}
+            rows={1}
+            className="max-h-40 min-h-[40px] flex-1 resize-none border-border bg-muted py-2"
+            placeholder={placeholder}
+            value={value}
+            disabled={disabled}
+            onChange={(event) => {
+              onChange(event.target.value);
+              syncPromptHeight(event.target);
+            }}
+            onKeyDown={(event) => {
+              if (event.key !== 'Enter' || event.shiftKey || submitDisabled) return;
+              event.preventDefault();
+              void onSubmit();
+            }}
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className={cn(
+              'h-9 border border-border bg-muted px-3 text-xs font-medium hover:bg-muted',
+              voiceInput.isSessionActive ? 'border-red-500/50 text-red-600' : undefined
+            )}
+            disabled={disabled || !voiceInput.isSupported}
+            title={
+              !voiceInput.isSupported
+                ? 'Voice input is unavailable in this environment.'
+                : voiceInput.isSessionActive
+                  ? 'Finish dictation'
+                  : 'Dictate into the prompt field'
+            }
+            aria-label={voiceInput.isSessionActive ? 'Finish dictation' : 'Start voice input'}
+            onClick={() => {
+              void handleVoiceToggle();
+            }}
+          >
+            {voiceInput.phase === 'preparing' || voiceInput.phase === 'transcribing' ? (
+              <LoaderCircle className="h-4 w-4 animate-spin" />
+            ) : (
+              <span
+                className={cn(
+                  'inline-flex items-center justify-center transition-transform duration-150',
+                  voiceInput.isSessionActive ? 'text-red-600' : undefined
+                )}
+                style={{ transform: `scale(${liveMicScale})` }}
+              >
+                <Mic
+                  className={cn(
+                    'h-4 w-4',
+                    voiceInput.isSessionActive ? 'animate-pulse' : undefined
+                  )}
+                />
+              </span>
+            )}
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            className="h-9 border border-border bg-muted px-3 text-xs font-medium hover:bg-muted"
+            onClick={() => {
+              void onSubmit();
+            }}
+            disabled={submitDisabled}
+            title="Send prompt (Enter)"
+            aria-label="Send prompt"
+          >
+            <CornerDownLeft className="h-4 w-4" />
+          </Button>
+        </div>
+        {voiceInput.error && voiceInput.statusText ? (
+          <div className="flex items-center justify-between gap-3 border-t border-border/60 px-4 py-2 text-[11px] text-muted-foreground">
+            <span>{voiceInput.statusText}</span>
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/TaskPromptBar.tsx
+++ b/src/renderer/components/TaskPromptBar.tsx
@@ -272,7 +272,7 @@ export function TaskPromptBar({
             <CornerDownLeft className="h-4 w-4" />
           </Button>
         </div>
-        {voiceInput.error && voiceInput.statusText ? (
+        {voiceInput.statusText ? (
           <div className="flex items-center justify-between gap-3 border-t border-border/60 px-4 py-2 text-[11px] text-muted-foreground">
             <span>{voiceInput.statusText}</span>
           </div>

--- a/src/renderer/components/VoiceInputSettingsCard.tsx
+++ b/src/renderer/components/VoiceInputSettingsCard.tsx
@@ -1,0 +1,181 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { LoaderCircle } from 'lucide-react';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
+import { Button } from './ui/button';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import { ModelManager, ModelStatus } from '@runanywhere/web';
+import {
+  DEFAULT_VOICE_INPUT_SETTINGS,
+  getVoiceInputModelOption,
+  VOICE_INPUT_MODEL_OPTIONS,
+  type VoiceInputModelId,
+} from '@shared/voiceInput';
+import {
+  ensureRunAnywhereReady,
+  ensureVoiceModelLoaded,
+  formatVoiceInputError,
+  getManagedVoiceModel,
+} from '@/lib/voiceInputRuntime';
+
+export function VoiceInputSettingsCard() {
+  const { settings, updateSettings, isLoading, isSaving } = useAppSettings();
+  const voiceSettings = settings?.voiceInput ?? DEFAULT_VOICE_INPUT_SETTINGS;
+  const selectedModel = getVoiceInputModelOption(voiceSettings.modelId);
+  const [modelStatus, setModelStatus] = useState<ModelStatus | null>(null);
+  const [statusError, setStatusError] = useState<string | null>(null);
+  const [isPreparingModel, setIsPreparingModel] = useState(false);
+
+  useEffect(() => {
+    let isActive = true;
+
+    const updateModelStatus = () => {
+      const model = getManagedVoiceModel(voiceSettings.modelId);
+      setModelStatus(model?.status ?? null);
+      setStatusError(model?.error ?? null);
+    };
+
+    void ensureRunAnywhereReady()
+      .then(() => {
+        if (!isActive) return;
+        updateModelStatus();
+      })
+      .catch((error) => {
+        if (!isActive) return;
+        setStatusError(formatVoiceInputError(error));
+      });
+
+    const unsubscribe = ModelManager.onChange(() => {
+      if (!isActive) return;
+      updateModelStatus();
+    });
+
+    return () => {
+      isActive = false;
+      unsubscribe();
+    };
+  }, [voiceSettings.modelId]);
+
+  const modelStatusLabel = useMemo(() => {
+    if (statusError || modelStatus === ModelStatus.Error) {
+      return statusError || 'The selected model is unavailable right now.';
+    }
+
+    switch (modelStatus) {
+      case ModelStatus.Downloading:
+        return 'Downloading on this device...';
+      case ModelStatus.Downloaded:
+        return 'Downloaded and ready to load.';
+      case ModelStatus.Loading:
+        return 'Loading on this device...';
+      case ModelStatus.Loaded:
+        return 'Ready on this device.';
+      case ModelStatus.Registered:
+        return 'Not downloaded on this device yet. Download it here before using the mic.';
+      default:
+        return 'Choose a model for dictation.';
+    }
+  }, [modelStatus, statusError]);
+
+  const prepareButtonLabel = useMemo(() => {
+    if (isPreparingModel || modelStatus === ModelStatus.Downloading) return 'Downloading...';
+    if (modelStatus === ModelStatus.Loading) return 'Loading...';
+    if (modelStatus === ModelStatus.Loaded) return 'Ready';
+    if (modelStatus === ModelStatus.Downloaded) return 'Load model';
+    if (modelStatus === ModelStatus.Error) return 'Retry';
+    return 'Download model';
+  }, [isPreparingModel, modelStatus]);
+
+  const prepareModel = async () => {
+    setStatusError(null);
+    setIsPreparingModel(true);
+
+    try {
+      await ensureVoiceModelLoaded(voiceSettings.modelId);
+    } catch (error) {
+      setStatusError(formatVoiceInputError(error));
+    } finally {
+      setIsPreparingModel(false);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3 rounded-xl border border-muted p-4">
+      <div className="flex flex-col gap-0.5">
+        <p className="text-sm font-medium text-foreground">Voice input</p>
+        <p className="text-sm text-muted-foreground">
+          Choose which on-device model the app uses for dictation. Download the selected model here
+          before first use. The selection applies anywhere the mic button appears.
+        </p>
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <div className="flex flex-1 flex-col gap-0.5">
+          <p className="text-sm font-medium text-foreground">Dictation model</p>
+          <p className="text-sm text-muted-foreground">
+            {selectedModel?.description ??
+              'Select the on-device Whisper model to use for dictation.'}
+          </p>
+        </div>
+        <div className="w-[220px] flex-shrink-0">
+          <Select
+            value={voiceSettings.modelId}
+            disabled={isLoading || isSaving}
+            onValueChange={(value) =>
+              updateSettings({
+                voiceInput: {
+                  provider: 'runanywhere',
+                  modelId: value as VoiceInputModelId,
+                },
+              })
+            }
+          >
+            <SelectTrigger className="h-9">
+              <SelectValue placeholder="Choose a model" />
+            </SelectTrigger>
+            <SelectContent>
+              {VOICE_INPUT_MODEL_OPTIONS.map((model) => (
+                <SelectItem key={model.id} value={model.id}>
+                  {model.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      </div>
+      <div className="flex items-center justify-between gap-4 rounded-lg border border-border/60 bg-muted/20 px-3 py-2">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-foreground">Model availability</p>
+          <p className="text-sm text-muted-foreground">{modelStatusLabel}</p>
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          className="shrink-0"
+          disabled={
+            isPreparingModel ||
+            modelStatus === ModelStatus.Downloading ||
+            modelStatus === ModelStatus.Loading ||
+            modelStatus === ModelStatus.Loaded
+          }
+          onClick={() => {
+            void prepareModel();
+          }}
+        >
+          {isPreparingModel || modelStatus === ModelStatus.Downloading ? (
+            <>
+              <LoaderCircle className="mr-2 h-4 w-4 animate-spin" />
+              {prepareButtonLabel}
+            </>
+          ) : (
+            prepareButtonLabel
+          )}
+        </Button>
+      </div>
+      {selectedModel && (
+        <p className="text-xs text-muted-foreground">
+          Download profile: {selectedModel.downloadHint}. Larger models improve accuracy but take
+          longer to download and load.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/hooks/useRunAnywhereVoiceInput.ts
+++ b/src/renderer/hooks/useRunAnywhereVoiceInput.ts
@@ -1,0 +1,223 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { AudioCapture, ModelManager, ModelStatus } from '@runanywhere/web';
+import { ONNX, STT } from '@runanywhere/web-onnx';
+import type { VoiceInputModelId } from '@shared/voiceInput';
+import {
+  ensureRunAnywhereReady,
+  ensureVoiceModelLoaded,
+  formatVoiceInputError,
+  getManagedVoiceModel,
+} from '@/lib/voiceInputRuntime';
+
+type VoiceInputPhase = 'idle' | 'preparing' | 'listening' | 'transcribing';
+export type VoiceInputToggleResult =
+  | 'started'
+  | 'stopped'
+  | 'download-required'
+  | 'download-in-progress'
+  | 'error'
+  | 'noop';
+
+// At 16 kHz sample rate this is ~100ms of audio — anything shorter is probably
+// accidental and not worth sending to the model.
+const MIN_CAPTURED_SAMPLES = 1600;
+
+export function useRunAnywhereVoiceInput(args: { modelId: VoiceInputModelId }) {
+  const captureRef = useRef<AudioCapture | null>(null);
+  const activeSessionRef = useRef(0);
+  const [phase, setPhase] = useState<VoiceInputPhase>('idle');
+  const [audioLevel, setAudioLevel] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+  const [isSessionActive, setIsSessionActive] = useState(false);
+  const [transcript, setTranscript] = useState('');
+  const [transcriptId, setTranscriptId] = useState(0);
+  const [modelStatus, setModelStatus] = useState<ModelStatus | null>(null);
+
+  useEffect(() => {
+    setModelStatus(getManagedVoiceModel(args.modelId)?.status ?? null);
+    return ModelManager.onChange(() => {
+      setModelStatus(getManagedVoiceModel(args.modelId)?.status ?? null);
+    });
+  }, [args.modelId]);
+
+  useEffect(() => {
+    return () => {
+      captureRef.current?.stop();
+      captureRef.current = null;
+    };
+  }, []);
+
+  const startListening = useCallback(async (): Promise<VoiceInputToggleResult> => {
+    setError(null);
+    setPhase('preparing');
+    setIsSessionActive(true);
+    setTranscript('');
+
+    const sessionId = activeSessionRef.current + 1;
+    activeSessionRef.current = sessionId;
+
+    try {
+      await ensureRunAnywhereReady();
+      if (activeSessionRef.current !== sessionId) return 'noop';
+
+      const model = getManagedVoiceModel(args.modelId);
+      if (!model) {
+        throw new Error(`Voice input model is not registered: ${args.modelId}`);
+      }
+
+      if (model.status === ModelStatus.Registered) {
+        setError(
+          'Download the selected dictation model in Settings > Interface > Voice input before using the mic.'
+        );
+        setAudioLevel(0);
+        setIsSessionActive(false);
+        setPhase('idle');
+        return 'download-required';
+      }
+
+      if (model.status === ModelStatus.Downloading) {
+        setError(
+          'The selected dictation model is still downloading. Finish it in Settings > Interface > Voice input.'
+        );
+        setAudioLevel(0);
+        setIsSessionActive(false);
+        setPhase('idle');
+        return 'download-in-progress';
+      }
+
+      if (model.status === ModelStatus.Error) {
+        setError(
+          model.error ||
+            'The selected dictation model needs attention in Settings > Interface > Voice input.'
+        );
+        setAudioLevel(0);
+        setIsSessionActive(false);
+        setPhase('idle');
+        return 'error';
+      }
+
+      await ensureVoiceModelLoaded(args.modelId);
+      if (activeSessionRef.current !== sessionId) return 'noop';
+
+      setAudioLevel(0);
+
+      const capture = new AudioCapture({
+        sampleRate: 16000,
+        channels: 1,
+      });
+      captureRef.current = capture;
+
+      await capture.start(undefined, (level) => {
+        if (activeSessionRef.current !== sessionId) return;
+        setAudioLevel(level);
+      });
+
+      if (activeSessionRef.current !== sessionId) {
+        capture.stop();
+        if (captureRef.current === capture) {
+          captureRef.current = null;
+        }
+        return 'noop';
+      }
+
+      setPhase('listening');
+      return 'started';
+    } catch (voiceError) {
+      captureRef.current?.stop();
+      captureRef.current = null;
+      setAudioLevel(0);
+      setError(formatVoiceInputError(voiceError));
+      setIsSessionActive(false);
+      setPhase('idle');
+      return 'error';
+    }
+  }, [args.modelId]);
+
+  const stopListening = useCallback(async (): Promise<VoiceInputToggleResult> => {
+    const sessionId = activeSessionRef.current;
+    const capture = captureRef.current;
+    capture?.stop();
+    captureRef.current = null;
+    setAudioLevel(0);
+
+    const finalSamples = capture?.getAudioBuffer() ?? new Float32Array(0);
+
+    if (finalSamples.length >= MIN_CAPTURED_SAMPLES) {
+      setPhase('transcribing');
+      setError(null);
+
+      try {
+        const result = await STT.transcribe(finalSamples);
+        if (activeSessionRef.current !== sessionId) return 'noop';
+        setTranscript(result.text.trim());
+        setTranscriptId((current) => current + 1);
+      } catch (voiceError) {
+        if (activeSessionRef.current !== sessionId) return 'noop';
+        setError(formatVoiceInputError(voiceError));
+      }
+    }
+
+    if (activeSessionRef.current === sessionId) {
+      activeSessionRef.current += 1;
+    }
+
+    setIsSessionActive(false);
+    setPhase('idle');
+    return 'stopped';
+  }, []);
+
+  const cancelListening = useCallback(() => {
+    const sessionId = activeSessionRef.current;
+    captureRef.current?.stop();
+    captureRef.current = null;
+    setAudioLevel(0);
+    setError(null);
+    setIsSessionActive(false);
+    setPhase('idle');
+    setTranscript('');
+
+    if (activeSessionRef.current === sessionId) {
+      activeSessionRef.current += 1;
+    }
+  }, []);
+
+  const toggleRecording = useCallback(async (): Promise<VoiceInputToggleResult> => {
+    if (isSessionActive) {
+      return stopListening();
+    }
+    if (phase === 'idle') {
+      return startListening();
+    }
+    return 'noop';
+  }, [isSessionActive, phase, startListening, stopListening]);
+
+  const statusText = useMemo(() => {
+    if (error) return error;
+    if (phase === 'listening') return 'Listening... tap the mic again when you are done.';
+    if (phase === 'transcribing') return 'Transcribing your recording...';
+    if (phase === 'preparing') {
+      if (modelStatus === ModelStatus.Downloading) return 'Downloading voice model...';
+      if (modelStatus === ModelStatus.Loading) return 'Loading voice model...';
+      return 'Preparing dictation...';
+    }
+    return null;
+  }, [error, modelStatus, phase]);
+
+  return {
+    phase,
+    audioLevel,
+    error,
+    isSessionActive,
+    transcript,
+    transcriptId,
+    statusText,
+    isSupported:
+      typeof navigator !== 'undefined' &&
+      !!navigator.mediaDevices?.getUserMedia &&
+      typeof window !== 'undefined' &&
+      window.isSecureContext,
+    cancelListening,
+    toggleRecording,
+    stopListening,
+  };
+}

--- a/src/renderer/hooks/useRunAnywhereVoiceInput.ts
+++ b/src/renderer/hooks/useRunAnywhereVoiceInput.ts
@@ -18,6 +18,13 @@ export type VoiceInputToggleResult =
   | 'error'
   | 'noop';
 
+/** Computed once — the browser environment never changes during the app lifecycle. */
+const VOICE_INPUT_SUPPORTED =
+  typeof navigator !== 'undefined' &&
+  !!navigator.mediaDevices?.getUserMedia &&
+  typeof window !== 'undefined' &&
+  window.isSecureContext;
+
 // At 16 kHz sample rate this is ~100ms of audio — anything shorter is probably
 // accidental and not worth sending to the model.
 const MIN_CAPTURED_SAMPLES = 1600;
@@ -34,6 +41,7 @@ export function useRunAnywhereVoiceInput(args: { modelId: VoiceInputModelId }) {
   const [modelStatus, setModelStatus] = useState<ModelStatus | null>(null);
 
   useEffect(() => {
+    if (!VOICE_INPUT_SUPPORTED) return;
     setModelStatus(getManagedVoiceModel(args.modelId)?.status ?? null);
     return ModelManager.onChange(() => {
       setModelStatus(getManagedVoiceModel(args.modelId)?.status ?? null);
@@ -211,11 +219,7 @@ export function useRunAnywhereVoiceInput(args: { modelId: VoiceInputModelId }) {
     transcript,
     transcriptId,
     statusText,
-    isSupported:
-      typeof navigator !== 'undefined' &&
-      !!navigator.mediaDevices?.getUserMedia &&
-      typeof window !== 'undefined' &&
-      window.isSecureContext,
+    isSupported: VOICE_INPUT_SUPPORTED,
     cancelListening,
     toggleRecording,
     stopListening,

--- a/src/renderer/lib/promptSubmission.ts
+++ b/src/renderer/lib/promptSubmission.ts
@@ -1,0 +1,154 @@
+import { buildCommentScopeKey, draftCommentsStore } from './DraftCommentsStore';
+import { formatCommentsForAgent } from './formatCommentsForAgent';
+import { buildPromptInjectionPayload } from './terminalInjection';
+import { isSlashCommandInput } from './slashCommand';
+import { classifyActivity } from './activityClassifier';
+import type { Agent } from '../types';
+
+export interface PreparedPromptSubmission {
+  text: string;
+  isSlashCommand: boolean;
+  commentScopeKey: string | null;
+}
+
+export function preparePromptSubmission(args: {
+  prompt: string;
+  taskId: string;
+  taskPath?: string | null;
+}): PreparedPromptSubmission {
+  const prompt = args.prompt.trim();
+  if (!prompt) {
+    return {
+      text: '',
+      isSlashCommand: false,
+      commentScopeKey: null,
+    };
+  }
+
+  const isSlashCommand = isSlashCommandInput(prompt);
+  if (isSlashCommand) {
+    return {
+      text: prompt,
+      isSlashCommand: true,
+      commentScopeKey: null,
+    };
+  }
+
+  const scopeKey = buildCommentScopeKey(args.taskId, args.taskPath);
+  const comments = draftCommentsStore.getAll(scopeKey);
+  const pendingText = formatCommentsForAgent(comments, {
+    includeIntro: false,
+    leadingNewline: true,
+  });
+
+  return {
+    text: pendingText ? `${prompt}${pendingText}` : prompt,
+    isSlashCommand: false,
+    commentScopeKey: pendingText ? scopeKey : null,
+  };
+}
+
+export function consumePromptComments(commentScopeKey: string | null, injected: boolean) {
+  if (!injected || !commentScopeKey) return;
+  draftCommentsStore.consumeAll(commentScopeKey);
+}
+
+export async function injectPromptViaPty(args: {
+  ptyId: string;
+  agent: Agent;
+  text: string;
+}): Promise<boolean> {
+  const trimmed = args.text.trim();
+  if (!trimmed) return false;
+
+  return await new Promise<boolean>((resolve) => {
+    let sent = false;
+    let finished = false;
+    let silenceTimer: ReturnType<typeof setTimeout> | null = null;
+    let eagerTimer: ReturnType<typeof setTimeout> | null = null;
+    let hardTimer: ReturnType<typeof setTimeout> | null = null;
+    let offData: (() => void) | undefined;
+    let offStarted: (() => void) | undefined;
+
+    const cleanup = () => {
+      if (silenceTimer) {
+        clearTimeout(silenceTimer);
+        silenceTimer = null;
+      }
+      if (eagerTimer) {
+        clearTimeout(eagerTimer);
+        eagerTimer = null;
+      }
+      if (hardTimer) {
+        clearTimeout(hardTimer);
+        hardTimer = null;
+      }
+      offData?.();
+      offStarted?.();
+    };
+
+    const finish = (didInject: boolean) => {
+      if (finished) return;
+      finished = true;
+      cleanup();
+      resolve(didInject);
+    };
+
+    const send = () => {
+      if (sent) return;
+      sent = true;
+
+      try {
+        const pty = window.electronAPI?.ptyInput;
+        if (!pty) {
+          finish(false);
+          return;
+        }
+
+        const { payload, submitDelayMs } = buildPromptInjectionPayload({
+          agent: args.agent,
+          text: trimmed,
+        });
+        pty({ id: args.ptyId, data: payload });
+        setTimeout(() => {
+          try {
+            pty({ id: args.ptyId, data: '\r' });
+          } catch {}
+        }, submitDelayMs);
+        finish(true);
+      } catch {
+        finish(false);
+      }
+    };
+
+    offData = window.electronAPI?.onPtyData?.(args.ptyId, (chunk: string) => {
+      if (silenceTimer) clearTimeout(silenceTimer);
+      silenceTimer = setTimeout(() => {
+        if (!sent) send();
+      }, 1000);
+
+      try {
+        const signal = classifyActivity(args.agent, chunk);
+        if (signal === 'idle' && !sent) {
+          setTimeout(send, 200);
+        }
+      } catch {}
+    });
+
+    offStarted = window.electronAPI?.onPtyStarted?.((info: { id: string }) => {
+      if (info?.id !== args.ptyId) return;
+      if (silenceTimer) clearTimeout(silenceTimer);
+      silenceTimer = setTimeout(() => {
+        if (!sent) send();
+      }, 1500);
+    });
+
+    eagerTimer = setTimeout(() => {
+      if (!sent) send();
+    }, 300);
+
+    hardTimer = setTimeout(() => {
+      if (!sent) send();
+    }, 5000);
+  });
+}

--- a/src/renderer/lib/settingsPageEvents.ts
+++ b/src/renderer/lib/settingsPageEvents.ts
@@ -1,0 +1,19 @@
+import type { SettingsPageTab } from '@/components/SettingsPage';
+
+export const OPEN_SETTINGS_PAGE_EVENT = 'emdash:open-settings-page';
+
+export interface OpenSettingsPageDetail {
+  tab?: SettingsPageTab;
+}
+
+export function dispatchOpenSettingsPage(detail: OpenSettingsPageDetail = {}): void {
+  if (typeof window === 'undefined' || typeof window.dispatchEvent !== 'function') {
+    return;
+  }
+
+  window.dispatchEvent(
+    new CustomEvent<OpenSettingsPageDetail>(OPEN_SETTINGS_PAGE_EVENT, {
+      detail,
+    })
+  );
+}

--- a/src/renderer/lib/voiceInputRuntime.ts
+++ b/src/renderer/lib/voiceInputRuntime.ts
@@ -23,6 +23,10 @@ const RUNANYWHERE_HELPER_BASE_URL = '/assets/sherpa/';
 let initPromise: Promise<void> | null = null;
 let registeredCatalog = false;
 
+/** Tracks consecutive init failures to avoid unbounded retries on deterministic errors. */
+let consecutiveInitFailures = 0;
+const MAX_INIT_RETRIES = 3;
+
 function isDevelopmentRenderer() {
   if (typeof window === 'undefined') return false;
   return window.location.hostname === 'localhost' || window.location.port === '3000';
@@ -51,6 +55,10 @@ export async function ensureRunAnywhereReady() {
     return initPromise;
   }
 
+  if (consecutiveInitFailures >= MAX_INIT_RETRIES) {
+    throw new Error('Voice input initialization failed repeatedly. Restart the app to try again.');
+  }
+
   initPromise = (async () => {
     if (!RunAnywhere.isInitialized) {
       await RunAnywhere.initialize({
@@ -74,8 +82,12 @@ export async function ensureRunAnywhereReady() {
       );
       registeredCatalog = true;
     }
+
+    // Reset failure counter on success.
+    consecutiveInitFailures = 0;
   })().catch((error) => {
     initPromise = null;
+    consecutiveInitFailures += 1;
     throw error;
   });
 

--- a/src/renderer/lib/voiceInputRuntime.ts
+++ b/src/renderer/lib/voiceInputRuntime.ts
@@ -1,0 +1,117 @@
+import {
+  ModelCategory,
+  ModelManager,
+  ModelStatus,
+  RunAnywhere,
+  SDKEnvironment,
+  type CompactModelDef,
+  type ManagedModel,
+} from '@runanywhere/web';
+import { LLMFramework } from '@runanywhere/web';
+import { ONNX } from '@runanywhere/web-onnx';
+import {
+  getVoiceInputModelOption,
+  VOICE_INPUT_MODEL_OPTIONS,
+  type VoiceInputModelId,
+} from '@shared/voiceInput';
+
+// The ONNX backend expects the glue JS module URL, not the .wasm directly.
+// It derives the .wasm path from this URL internally.
+const RUNANYWHERE_GLUE_URL = '/assets/sherpa/sherpa-onnx-glue.js';
+const RUNANYWHERE_HELPER_BASE_URL = '/assets/sherpa/';
+
+let initPromise: Promise<void> | null = null;
+let registeredCatalog = false;
+
+function isDevelopmentRenderer() {
+  if (typeof window === 'undefined') return false;
+  return window.location.hostname === 'localhost' || window.location.port === '3000';
+}
+
+function toCompactModelDef(modelId: VoiceInputModelId): CompactModelDef {
+  const option = getVoiceInputModelOption(modelId);
+  if (!option) {
+    throw new Error(`Unknown voice input model: ${modelId}`);
+  }
+
+  return {
+    id: option.id,
+    name: option.label,
+    ...(option.repo ? { repo: option.repo } : {}),
+    ...(option.url ? { url: option.url } : {}),
+    ...(option.files ? { files: option.files } : {}),
+    ...(option.artifactType ? { artifactType: option.artifactType } : {}),
+    framework: LLMFramework.ONNX,
+    modality: ModelCategory.SpeechRecognition,
+  };
+}
+
+export async function ensureRunAnywhereReady() {
+  if (initPromise) {
+    return initPromise;
+  }
+
+  initPromise = (async () => {
+    if (!RunAnywhere.isInitialized) {
+      await RunAnywhere.initialize({
+        environment: isDevelopmentRenderer()
+          ? SDKEnvironment.Development
+          : SDKEnvironment.Production,
+        debug: isDevelopmentRenderer(),
+      });
+    }
+
+    if (!ONNX.isRegistered) {
+      await ONNX.register({
+        wasmUrl: RUNANYWHERE_GLUE_URL,
+        helperBaseUrl: RUNANYWHERE_HELPER_BASE_URL,
+      });
+    }
+
+    if (!registeredCatalog) {
+      RunAnywhere.registerModels(
+        VOICE_INPUT_MODEL_OPTIONS.map((option) => toCompactModelDef(option.id))
+      );
+      registeredCatalog = true;
+    }
+  })().catch((error) => {
+    initPromise = null;
+    throw error;
+  });
+
+  return initPromise;
+}
+
+export function getManagedVoiceModel(modelId: VoiceInputModelId): ManagedModel | null {
+  return ModelManager.getModels().find((model) => model.id === modelId) ?? null;
+}
+
+export async function ensureVoiceModelLoaded(modelId: VoiceInputModelId) {
+  await ensureRunAnywhereReady();
+
+  const currentlyLoaded = ModelManager.getLoadedModel(ModelCategory.SpeechRecognition);
+  if (currentlyLoaded?.id === modelId) return;
+
+  const model = getManagedVoiceModel(modelId);
+  if (!model) {
+    throw new Error(`Voice input model is not registered: ${modelId}`);
+  }
+
+  if (model.status === ModelStatus.Registered) {
+    await ModelManager.downloadModel(modelId);
+  }
+
+  const loaded = await ModelManager.loadModel(modelId);
+  if (loaded) return;
+
+  const nextModel = getManagedVoiceModel(modelId);
+  throw new Error(nextModel?.error || `Failed to load voice input model: ${modelId}`);
+}
+
+export function formatVoiceInputError(error: unknown) {
+  const message = error instanceof Error ? error.message : String(error);
+  if (/permission/i.test(message) || /notallowed/i.test(message)) {
+    return 'Microphone access was denied.';
+  }
+  return message;
+}

--- a/src/renderer/lib/voiceInputRuntime.ts
+++ b/src/renderer/lib/voiceInputRuntime.ts
@@ -109,7 +109,10 @@ export async function ensureVoiceModelLoaded(modelId: VoiceInputModelId) {
     throw new Error(`Voice input model is not registered: ${modelId}`);
   }
 
-  if (model.status === ModelStatus.Registered) {
+  // Also re-download when a previous attempt left the model in Error state —
+  // the SDK does not auto-reset to Registered, so we must trigger the download
+  // again to give the user a working retry path.
+  if (model.status === ModelStatus.Registered || model.status === ModelStatus.Error) {
     await ModelManager.downloadModel(modelId);
   }
 

--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -35,6 +35,7 @@ import { activityStore } from '@/lib/activityStore';
 import { agentStatusStore } from '@/lib/agentStatusStore';
 import { handleMenuUndo, handleMenuRedo } from '@/lib/menuUndoRedo';
 import { rpc } from '@/lib/rpc';
+import { OPEN_SETTINGS_PAGE_EVENT, type OpenSettingsPageDetail } from '@/lib/settingsPageEvents';
 import { soundPlayer } from '@/lib/soundPlayer';
 import BrowserProvider, { useBrowser } from '@/providers/BrowserProvider';
 import { useState, useCallback, useEffect, useRef, useMemo } from 'react';
@@ -187,6 +188,16 @@ export function Workspace() {
       openSettingsPage();
     });
     return () => cleanup?.();
+  }, [openSettingsPage]);
+
+  useEffect(() => {
+    const handleOpenSettingsPage = (event: Event) => {
+      const detail = (event as CustomEvent<OpenSettingsPageDetail>).detail;
+      openSettingsPage(detail?.tab ?? 'general');
+    };
+
+    window.addEventListener(OPEN_SETTINGS_PAGE_EVENT, handleOpenSettingsPage);
+    return () => window.removeEventListener(OPEN_SETTINGS_PAGE_EVENT, handleOpenSettingsPage);
   }, [openSettingsPage]);
 
   const handleToggleKanban = useCallback(() => {

--- a/src/shared/voiceInput.ts
+++ b/src/shared/voiceInput.ts
@@ -1,0 +1,83 @@
+export const VOICE_INPUT_PROVIDERS = ['runanywhere'] as const;
+
+export type VoiceInputProvider = (typeof VOICE_INPUT_PROVIDERS)[number];
+
+export const VOICE_INPUT_MODEL_IDS = [
+  'whisper-tiny-en',
+  'whisper-base-en-int8',
+  'whisper-small-en-int8',
+  'whisper-medium-en-int8',
+] as const;
+
+export type VoiceInputModelId = (typeof VOICE_INPUT_MODEL_IDS)[number];
+
+export interface VoiceInputSettings {
+  provider: VoiceInputProvider;
+  modelId: VoiceInputModelId;
+}
+
+export interface VoiceInputModelOption {
+  id: VoiceInputModelId;
+  label: string;
+  description: string;
+  downloadHint: string;
+  repo?: string;
+  url?: string;
+  files?: string[];
+  artifactType?: 'archive';
+}
+
+export const DEFAULT_VOICE_INPUT_SETTINGS: VoiceInputSettings = {
+  provider: 'runanywhere',
+  modelId: 'whisper-tiny-en',
+};
+
+export const VOICE_INPUT_MODEL_OPTIONS: VoiceInputModelOption[] = [
+  {
+    id: 'whisper-tiny-en',
+    label: 'Whisper Tiny',
+    description: 'Fastest startup and best default for prompt dictation. English only.',
+    downloadHint: '~105 MB',
+    url: 'https://huggingface.co/runanywhere/sherpa-onnx-whisper-tiny.en/resolve/main/sherpa-onnx-whisper-tiny.en.tar.gz',
+    artifactType: 'archive',
+  },
+  {
+    id: 'whisper-base-en-int8',
+    label: 'Whisper Base',
+    description: 'Better accuracy with a moderate download. English only.',
+    downloadHint: 'Moderate download',
+    repo: 'csukuangfj/sherpa-onnx-whisper-base.en',
+    files: ['base.en-encoder.int8.onnx', 'base.en-decoder.int8.onnx', 'base.en-tokens.txt'],
+  },
+  {
+    id: 'whisper-small-en-int8',
+    label: 'Whisper Small',
+    description: 'Higher accuracy with noticeably more disk and RAM usage. English only.',
+    downloadHint: 'Large download',
+    repo: 'csukuangfj/sherpa-onnx-whisper-small.en',
+    files: ['small.en-encoder.int8.onnx', 'small.en-decoder.int8.onnx', 'small.en-tokens.txt'],
+  },
+  {
+    id: 'whisper-medium-en-int8',
+    label: 'Whisper Medium',
+    description: 'Highest accuracy, but the heaviest option. Expect slower loads. English only.',
+    downloadHint: 'Very large download',
+    repo: 'csukuangfj/sherpa-onnx-whisper-medium.en',
+    files: ['medium.en-encoder.int8.onnx', 'medium.en-decoder.int8.onnx', 'medium.en-tokens.txt'],
+  },
+];
+
+export function isVoiceInputProvider(value: unknown): value is VoiceInputProvider {
+  return typeof value === 'string' && VOICE_INPUT_PROVIDERS.includes(value as VoiceInputProvider);
+}
+
+export function isVoiceInputModelId(value: unknown): value is VoiceInputModelId {
+  return typeof value === 'string' && VOICE_INPUT_MODEL_IDS.includes(value as VoiceInputModelId);
+}
+
+export function getVoiceInputModelOption(
+  modelId: VoiceInputModelId | null | undefined
+): VoiceInputModelOption | null {
+  if (!modelId) return null;
+  return VOICE_INPUT_MODEL_OPTIONS.find((option) => option.id === modelId) ?? null;
+}

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -173,3 +173,45 @@ describe('normalizeSettings - review preset', () => {
     });
   });
 });
+
+describe('normalizeSettings - voiceInput', () => {
+  it('defaults to RunAnywhere tiny when missing', () => {
+    const result = normalizeSettings(makeSettings());
+    expect(result.voiceInput).toEqual({
+      provider: 'runanywhere',
+      modelId: 'whisper-tiny-en',
+    });
+  });
+
+  it('preserves a valid configured model', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        voiceInput: {
+          provider: 'runanywhere',
+          modelId: 'whisper-small-en-int8',
+        },
+      })
+    );
+
+    expect(result.voiceInput).toEqual({
+      provider: 'runanywhere',
+      modelId: 'whisper-small-en-int8',
+    });
+  });
+
+  it('falls back when the provider or model is invalid', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        voiceInput: {
+          provider: 'invalid' as any,
+          modelId: 'invalid-model' as any,
+        },
+      })
+    );
+
+    expect(result.voiceInput).toEqual({
+      provider: 'runanywhere',
+      modelId: 'whisper-tiny-en',
+    });
+  });
+});

--- a/src/test/renderer/promptSubmission.test.ts
+++ b/src/test/renderer/promptSubmission.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildCommentScopeKey, draftCommentsStore } from '../../renderer/lib/DraftCommentsStore';
+import {
+  consumePromptComments,
+  preparePromptSubmission,
+} from '../../renderer/lib/promptSubmission';
+
+describe('promptSubmission helpers', () => {
+  const taskId = 'task-1';
+  const taskPath = '/tmp/worktree';
+  const scopeKey = buildCommentScopeKey(taskId, taskPath);
+
+  beforeEach(() => {
+    draftCommentsStore.consumeAll(scopeKey);
+  });
+
+  it('passes slash commands through without comment injection', () => {
+    draftCommentsStore.add(scopeKey, {
+      filePath: 'src/app.ts',
+      lineNumber: 10,
+      lineContent: 'const value = 1;',
+      content: 'Check this edge case.',
+    });
+
+    const result = preparePromptSubmission({
+      prompt: '/model',
+      taskId,
+      taskPath,
+    });
+
+    expect(result.text).toBe('/model');
+    expect(result.isSlashCommand).toBe(true);
+    expect(result.commentScopeKey).toBeNull();
+  });
+
+  it('appends queued review comments to normal prompts', () => {
+    draftCommentsStore.add(scopeKey, {
+      filePath: 'src/app.ts',
+      lineNumber: 10,
+      lineContent: 'const value = 1;',
+      content: 'Check this edge case.',
+    });
+
+    const result = preparePromptSubmission({
+      prompt: 'Please fix this',
+      taskId,
+      taskPath,
+    });
+
+    expect(result.text).toContain('Please fix this');
+    expect(result.text).toContain('<user_comments>');
+    expect(result.commentScopeKey).toBe(scopeKey);
+  });
+
+  it('consumes pending comments only after a successful injection', () => {
+    draftCommentsStore.add(scopeKey, {
+      filePath: 'src/app.ts',
+      lineNumber: 10,
+      lineContent: 'const value = 1;',
+      content: 'Check this edge case.',
+    });
+
+    consumePromptComments(scopeKey, false);
+    expect(draftCommentsStore.getCount(scopeKey)).toBe(1);
+
+    consumePromptComments(scopeKey, true);
+    expect(draftCommentsStore.getCount(scopeKey)).toBe(0);
+  });
+});

--- a/src/test/renderer/voiceInputCatalog.test.ts
+++ b/src/test/renderer/voiceInputCatalog.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getVoiceInputModelOption,
+  isVoiceInputModelId,
+  VOICE_INPUT_MODEL_OPTIONS,
+} from '../../shared/voiceInput';
+
+describe('voice input model catalog', () => {
+  it('includes the shipped Whisper presets', () => {
+    expect(VOICE_INPUT_MODEL_OPTIONS.map((option) => option.id)).toEqual([
+      'whisper-tiny-en',
+      'whisper-base-en-int8',
+      'whisper-small-en-int8',
+      'whisper-medium-en-int8',
+    ]);
+  });
+
+  it('resolves catalog entries for known model ids', () => {
+    const option = getVoiceInputModelOption('whisper-small-en-int8');
+    expect(option?.label).toBe('Whisper Small');
+    expect(option?.files).toEqual([
+      'small.en-encoder.int8.onnx',
+      'small.en-decoder.int8.onnx',
+      'small.en-tokens.txt',
+    ]);
+  });
+
+  it('validates model ids defensively', () => {
+    expect(isVoiceInputModelId('whisper-medium-en-int8')).toBe(true);
+    expect(isVoiceInputModelId('not-a-model')).toBe(false);
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,11 +1,84 @@
-import { defineConfig } from 'vite';
+import { copyFileSync, createReadStream, existsSync, mkdirSync, readdirSync, statSync } from 'fs';
+import { join, resolve, sep } from 'path';
 import react from '@vitejs/plugin-react';
-import { resolve } from 'path';
+import { defineConfig, type Plugin } from 'vite';
+
+const RUNANYWHERE_SHERPA_SOURCE_DIR = resolve(
+  __dirname,
+  './node_modules/@runanywhere/web-onnx/wasm/sherpa'
+);
+const RUNANYWHERE_SHERPA_ROUTE = '/assets/sherpa/';
+
+const CROSS_ORIGIN_HEADERS = {
+  'Cross-Origin-Opener-Policy': 'same-origin',
+  'Cross-Origin-Embedder-Policy': 'credentialless',
+};
+
+function getContentType(filePath: string) {
+  if (filePath.endsWith('.wasm')) return 'application/wasm';
+  if (filePath.endsWith('.js')) return 'application/javascript; charset=utf-8';
+  return 'application/octet-stream';
+}
+
+function isPathInside(parent: string, child: string) {
+  const parentPath = `${resolve(parent)}${sep}`;
+  return resolve(child).startsWith(parentPath);
+}
+
+function copyDirectory(source: string, destination: string) {
+  mkdirSync(destination, { recursive: true });
+
+  for (const entry of readdirSync(source)) {
+    const sourcePath = join(source, entry);
+    const destinationPath = join(destination, entry);
+    const stats = statSync(sourcePath);
+    if (stats.isDirectory()) {
+      copyDirectory(sourcePath, destinationPath);
+      continue;
+    }
+    copyFileSync(sourcePath, destinationPath);
+  }
+}
+
+function runAnywhereOnnxAssetsPlugin(): Plugin {
+  return {
+    name: 'runanywhere-onnx-assets',
+    configureServer(server) {
+      server.middlewares.use((req, res, next) => {
+        const requestPath = req.url?.split('?')[0] ?? '';
+        if (!requestPath.startsWith(RUNANYWHERE_SHERPA_ROUTE)) {
+          next();
+          return;
+        }
+
+        const relativePath = requestPath.slice(RUNANYWHERE_SHERPA_ROUTE.length);
+        const filePath = resolve(RUNANYWHERE_SHERPA_SOURCE_DIR, relativePath);
+        if (!isPathInside(RUNANYWHERE_SHERPA_SOURCE_DIR, filePath) || !existsSync(filePath)) {
+          next();
+          return;
+        }
+
+        res.statusCode = 200;
+        for (const [header, value] of Object.entries(CROSS_ORIGIN_HEADERS)) {
+          res.setHeader(header, value);
+        }
+        res.setHeader('Content-Type', getContentType(filePath));
+        createReadStream(filePath).pipe(res);
+      });
+    },
+    writeBundle(options) {
+      const outputDir =
+        typeof options.dir === 'string' ? options.dir : resolve(__dirname, './dist/renderer');
+      const destinationDir = join(outputDir, 'assets', 'sherpa');
+      copyDirectory(RUNANYWHERE_SHERPA_SOURCE_DIR, destinationDir);
+    },
+  };
+}
 
 export default defineConfig(({ command }) => ({
   // Use relative asset paths in production so file:// loads work from DMG/app bundle
   base: command === 'build' ? './' : '/',
-  plugins: [react()],
+  plugins: [react(), runAnywhereOnnxAssetsPlugin()],
   root: './src/renderer',
   test: {
     dir: '.',
@@ -24,6 +97,14 @@ export default defineConfig(({ command }) => ({
     },
   },
   server: {
+    headers: CROSS_ORIGIN_HEADERS,
     port: 3000,
   },
+  worker: {
+    format: 'es',
+  },
+  optimizeDeps: {
+    exclude: ['@runanywhere/web', '@runanywhere/web-onnx'],
+  },
+  assetsInclude: ['**/*.wasm'],
 }));

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -63,7 +63,15 @@ function runAnywhereOnnxAssetsPlugin(): Plugin {
           res.setHeader(header, value);
         }
         res.setHeader('Content-Type', getContentType(filePath));
-        createReadStream(filePath).pipe(res);
+        const stream = createReadStream(filePath);
+        stream.on('error', (err) => {
+          if (!res.headersSent) {
+            res.statusCode = 500;
+            res.end();
+          }
+          console.error('[runanywhere-onnx-assets] stream error:', err);
+        });
+        stream.pipe(res);
       });
     },
     writeBundle(options) {


### PR DESCRIPTION
## Summary

- Adds app-side voice dictation so every agent (single or multi-agent) gets mic input through a shared prompt bar — no per-provider terminal hacks needed
- Uses the RunAnywhere Web SDK to run Whisper on-device via ONNX/WASM, so audio never leaves the machine
- Includes a model picker in Settings > Interface > Voice input where users can choose between Tiny, Base, Small, and Medium whisper models and download them before first use
- Extracts prompt submission logic into a shared module so ChatInterface and MultiAgentTask both use the same injection path (was duplicated before)
- Fixes settings page scroll not reaching the bottom on longer tabs
- First mic click when no model is downloaded shows a toast with a direct link to Settings instead of a blank loading state

## Fixes

Closes #1426

## Snapshot


https://github.com/user-attachments/assets/7395496b-fcc1-4a07-9e13-caeef261626d


## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes (`pnpm exec vitest run`)