### PR TITLE
fix: update broken link in docs home page

### DIFF
--- a/docs/content/docs/index.mdx
+++ b/docs/content/docs/index.mdx
@@ -7,7 +7,7 @@ Emdash is an open source desktop app for running multiple coding agents in paral
 
 ## Capabilities
 
-- **[Parallel agents](/parallel-agents):** Run multiple agents simultaneously, each in its own worktree
+- **[Parallel agents](/tasks):** Run multiple agents simultaneously, each in its own worktree
 - **[Provider support](/providers):** Use any of 18+ CLI-based agents: Claude Code, Codex, Gemini, OpenCode, and more
 - **[Best-of-N](/best-of-n):** Run multiple agents on the same task and pick the best result
 - **[Diff view](/diff-view):** Review changes across agents side-by-side


### PR DESCRIPTION
## Summary

- Fix incorrect link for "Parallel agents" on the docs home page
- Changed `/parallel-agents` to `/tasks` to point to the correct route