### PR TITLE
fix(pty): resolve tmux config from remote filesystem for SSH sessions

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -418,6 +418,12 @@ function buildRemoteInitKeystrokes(args: {
       )}; fi`;
       lines.push(`sh -ilc ${quoteShellArg(shScript)}`);
     }
+  } else if (args.tmux) {
+    // tmux-only (no provider): wrap the shell in a named tmux session for persistence.
+    // Falls back gracefully if tmux isn't installed on the remote.
+    const tmuxName = quoteShellArg(args.tmux.sessionName);
+    const shScript = `if command -v tmux >/dev/null 2>&1; then exec tmux new-session -As ${tmuxName}; else printf '%s\\n' 'emdash: tmux not found on remote, running without session persistence'; fi`;
+    lines.push(`sh -ilc ${quoteShellArg(shScript)}`);
   }
 
   return lines.length ? `${lines.join('\n')}\n` : '';
@@ -567,6 +573,41 @@ async function resolveTmuxEnabled(cwd: string): Promise<boolean> {
   return false;
 }
 
+async function resolveRemoteTmuxEnabled(
+  ssh: { target: string; args: string[] },
+  cwd: string
+): Promise<boolean> {
+  try {
+    // Build list of paths to check: cwd first, then project root if cwd is a worktree
+    const paths = [cwd];
+    const marker = '/.emdash/worktrees/';
+    const markerIdx = cwd.indexOf(marker);
+    if (markerIdx > 0) {
+      paths.push(cwd.slice(0, markerIdx));
+    }
+
+    // Read all .emdash.json files in a single SSH exec to avoid multiple round trips
+    const catParts = paths.map(
+      (p) => `cat ${quoteShellArg(`${p}/.emdash.json`)} 2>/dev/null || echo '{}'`
+    );
+    const { stdout } = await execFileAsync('ssh', [
+      ...ssh.args,
+      ssh.target,
+      catParts.join('; echo "---EMDASH_SEP---"; '),
+    ]);
+
+    const parts = stdout.split('---EMDASH_SEP---');
+    for (const part of parts) {
+      try {
+        if (JSON.parse(part.trim())?.tmux === true) return true;
+      } catch {}
+    }
+    return false;
+  } catch {
+    return false;
+  }
+}
+
 export function registerPtyIpc(): void {
   // When a direct-spawned CLI exits, spawn a shell so user can continue working
   setOnDirectCliExit(async (id: string, cwd: string) => {
@@ -693,10 +734,11 @@ export function registerPtyIpc(): void {
             listeners.add(id);
           }
 
-          // Resolve tmux config from local project settings.
+          // Resolve tmux config from remote .emdash.json.
           // Workspace-provisioned connections always use tmux for session persistence.
           const isWorkspaceConnection = remote.connectionId.startsWith('workspace-');
-          const remoteTmux = isWorkspaceConnection || (cwd ? await resolveTmuxEnabled(cwd) : false);
+          const remoteTmux =
+            isWorkspaceConnection || (cwd ? await resolveRemoteTmuxEnabled(ssh, cwd) : false);
           const remoteTmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
 
           const remoteInit = buildRemoteInitKeystrokes({
@@ -1228,10 +1270,11 @@ export function registerPtyIpc(): void {
             listeners.add(id);
           }
 
-          // Resolve tmux config from local project settings.
+          // Resolve tmux config from remote .emdash.json.
           // Workspace-provisioned connections always use tmux for session persistence.
           const isWorkspaceConn = remote.connectionId.startsWith('workspace-');
-          const remoteTmux = isWorkspaceConn || (cwd ? await resolveTmuxEnabled(cwd) : false);
+          const remoteTmux =
+            isWorkspaceConn || (cwd ? await resolveRemoteTmuxEnabled(ssh, cwd) : false);
           const tmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
 
           const remoteInit = buildRemoteInitKeystrokes({


### PR DESCRIPTION
Two bugs prevented tmux from activating in remote SSH sessions:

1. resolveTmuxEnabled used local fs calls (fs.existsSync/readFileSync) to check .emdash.json, which always returned false for remote paths like /home/user/projects/foo that don't exist locally.

2. buildRemoteInitKeystrokes only wrapped commands in tmux inside the provider block, so pty:start (no provider) silently dropped tmux.

Add resolveRemoteTmuxEnabled that reads .emdash.json via a single SSH exec (checking both cwd and project root for worktrees), and add an else-if branch in buildRemoteInitKeystrokes for tmux-only sessions.

## Summary

Fix two bugs that prevented tmux session persistence from ever activating in remote SSH sessions. `resolveTmuxEnabled` was reading the local filesystem for remote paths (always returning false), and `buildRemoteInitKeystrokes` silently dropped tmux when no provider was specified. The fix adds `resolveRemoteTmuxEnabled` which reads `.emdash.json` from the remote via SSH exec, and a new `else if (args.tmux)` branch for tmux-only (no provider) sessions.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [ ] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes