### PR TITLE
feat: show CI check status icon on project dashboard PR list

### DIFF
--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -64,6 +64,7 @@ export interface GitHubPullRequest {
   reviewers?: GitHubReviewer[];
   additions?: number;
   deletions?: number;
+  checksStatus?: 'pass' | 'fail' | 'pending' | 'none';
 }
 
 export interface GitHubPullRequestListResult {
@@ -852,6 +853,7 @@ export class GitHubService {
         'reviewDecision',
         'additions',
         'deletions',
+        'statusCheckRollup',
       ];
       const searchFlag = searchQuery ? ` --search ${quoteShellArg(searchQuery)}` : '';
       const { stdout } = await this.execGH(
@@ -881,6 +883,7 @@ export class GitHubService {
           reviewers: this.buildReviewerList(item?.reviewRequests, item?.latestReviews),
           additions: typeof item?.additions === 'number' ? item.additions : undefined,
           deletions: typeof item?.deletions === 'number' ? item.deletions : undefined,
+          checksStatus: this.deriveChecksStatus(item?.statusCheckRollup),
         }))
       );
 
@@ -892,6 +895,46 @@ export class GitHubService {
       console.error('Failed to list pull requests:', error);
       throw error;
     }
+  }
+
+  private deriveChecksStatus(rollup: any[]): 'pass' | 'fail' | 'pending' | 'none' {
+    if (!Array.isArray(rollup) || rollup.length === 0) return 'none';
+
+    let hasFail = false;
+    let hasPending = false;
+    let hasPass = false;
+
+    for (const item of rollup) {
+      if (item?.__typename === 'CheckRun') {
+        if (item.status !== 'COMPLETED') {
+          hasPending = true;
+        } else {
+          const c = item.conclusion;
+          if (['FAILURE', 'ACTION_REQUIRED', 'TIMED_OUT', 'STARTUP_FAILURE'].includes(c)) {
+            hasFail = true;
+          } else if (['SUCCESS', 'NEUTRAL', 'SKIPPED', 'CANCELLED'].includes(c)) {
+            hasPass = true;
+          } else {
+            hasPending = true;
+          }
+        }
+      } else {
+        // StatusContext
+        const s = item?.state;
+        if (['FAILURE', 'ERROR'].includes(s)) {
+          hasFail = true;
+        } else if (s === 'SUCCESS') {
+          hasPass = true;
+        } else {
+          hasPending = true;
+        }
+      }
+    }
+
+    if (hasFail) return 'fail';
+    if (hasPending) return 'pending';
+    if (hasPass) return 'pass';
+    return 'none';
   }
 
   private buildReviewerList(reviewRequests?: any[], latestReviews?: any[]): GitHubReviewer[] {

--- a/src/renderer/components/OpenPrsSection.tsx
+++ b/src/renderer/components/OpenPrsSection.tsx
@@ -18,12 +18,15 @@ import { useToast } from '../hooks/use-toast';
 import { useTaskManagementContext } from '../contexts/TaskManagementContext';
 import {
   ArrowUpRight,
+  CheckCircle2,
   ChevronDown,
   ChevronRight,
+  Clock,
   Github,
   Loader2,
   MessageSquare,
   Search,
+  XCircle,
 } from 'lucide-react';
 import type { Task } from '../types/app';
 
@@ -120,6 +123,50 @@ function getReviewStateMeta(state?: PullRequestReviewer['state']): {
         dotClassName: 'bg-slate-300 dark:bg-slate-600',
       };
   }
+}
+
+function CheckStatusIcon({
+  status,
+}: {
+  status: 'pass' | 'fail' | 'pending' | 'none' | null | undefined;
+}) {
+  if (!status || status === 'none') return null;
+
+  if (status === 'pass') {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="shrink-0">
+            <CheckCircle2 className="h-4 w-4 text-emerald-500" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">All checks passed</TooltipContent>
+      </Tooltip>
+    );
+  }
+  if (status === 'fail') {
+    return (
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <span className="shrink-0">
+            <XCircle className="h-4 w-4 text-red-500" />
+          </span>
+        </TooltipTrigger>
+        <TooltipContent side="top">Some checks failed</TooltipContent>
+      </Tooltip>
+    );
+  }
+  // pending
+  return (
+    <Tooltip>
+      <TooltipTrigger asChild>
+        <span className="shrink-0">
+          <Clock className="h-4 w-4 text-amber-500" />
+        </span>
+      </TooltipTrigger>
+      <TooltipContent side="top">Checks in progress</TooltipContent>
+    </Tooltip>
+  );
 }
 
 const ReviewerBadge: React.FC<{ reviewer: PullRequestReviewer }> = ({ reviewer }) => {
@@ -387,6 +434,7 @@ const OpenPrsSection: React.FC<OpenPrsSectionProps> = ({ projectPath, projectId 
                       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
                         <div className="flex items-center gap-2">
                           <span className={`${prBadgeClass} shrink-0`}>#{pr.number}</span>
+                          <CheckStatusIcon status={pr.checksStatus} />
                           <span className="truncate text-sm font-medium">{pr.title}</span>
                           {pr.isDraft ? (
                             <span className={`${prBadgeClass} shrink-0`}>Draft</span>

--- a/src/renderer/hooks/usePullRequests.ts
+++ b/src/renderer/hooks/usePullRequests.ts
@@ -19,6 +19,7 @@ export interface PullRequestSummary {
   reviewers?: PullRequestReviewer[];
   additions?: number;
   deletions?: number;
+  checksStatus?: 'pass' | 'fail' | 'pending' | 'none' | null;
 }
 
 const DEFAULT_PAGE_SIZE = 10;
@@ -84,6 +85,7 @@ export function usePullRequests(
               reviewers: Array.isArray(item?.reviewers) ? item.reviewers : [],
               additions: typeof item?.additions === 'number' ? item.additions : undefined,
               deletions: typeof item?.deletions === 'number' ? item.deletions : undefined,
+              checksStatus: item?.checksStatus ?? null,
             }))
             .filter((item) => item.number > 0);
           setPrs(mapped);


### PR DESCRIPTION
Closes #1539

## Summary

- Fetches `statusCheckRollup` from the GitHub CLI alongside existing PR list fields in `GitHubService.getPullRequests`
- Derives an overall rollup state (pass / fail / pending / none) via a new `deriveChecksStatus` helper, correctly handling both `CheckRun` and `StatusContext` union types the GitHub CLI can return
- Propagates `checksStatus` through `GitHubPullRequest` → `PullRequestSummary` to the renderer
- Renders a `CheckStatusIcon` in `OpenPrsSection` between the PR number badge and title — emerald `CheckCircle2` (all passed), red `XCircle` (failures), amber `Clock` (in progress) — each with a tooltip, matching GitHub's own check status iconography

## Test plan

- [x] Open the project dashboard for a repo with open PRs that have CI configured
- [x] Verify a green ✓ appears next to PRs where all checks passed
- [x] Verify a red ✗ appears next to PRs with at least one failed check
- [x] Verify an amber clock appears next to PRs with checks still running
- [ ] Verify no icon appears for PRs with no checks configured
- [x] Hover each icon to confirm the tooltip text is correct