### PR TITLE
fix(workspace): gate terminals on remote connection and cache provision logs

### DIFF
--- a/src/renderer/components/RightSidebar.tsx
+++ b/src/renderer/components/RightSidebar.tsx
@@ -51,8 +51,12 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
 
   // For workspace tasks, use the workspace connection instead of project-level
   const { connectionId: wsConnectionId, remotePath: wsRemotePath } = useWorkspaceConnection(task);
+  const isWorkspaceTask = !!task?.metadata?.workspace;
   const effectiveConnectionId = wsConnectionId || projectRemoteConnectionId || null;
   const effectiveRemotePath = wsRemotePath || projectRemotePath || null;
+  // When a workspace task is active but its connection hasn't resolved yet,
+  // terminals should wait instead of starting a local session.
+  const awaitingRemote = isWorkspaceTask && !wsConnectionId;
 
   const toggleVariantCollapsed = (variantKey: string) => {
     setCollapsedVariants((prev) => {
@@ -238,6 +242,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                                     }
                                   : undefined
                               }
+                              awaitingRemote={awaitingRemote}
                               defaultBranch={projectDefaultBranch || undefined}
                               portSeed={v.worktreeId}
                               className="min-h-[200px]"
@@ -276,13 +281,14 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                           agent={v.agent}
                           projectPath={projectPath || task?.path}
                           remote={
-                            projectRemoteConnectionId
+                            effectiveConnectionId
                               ? {
-                                  connectionId: projectRemoteConnectionId,
-                                  projectPath: projectRemotePath || projectPath || undefined,
+                                  connectionId: effectiveConnectionId,
+                                  projectPath: effectiveRemotePath || projectPath || undefined,
                                 }
                               : undefined
                           }
+                          awaitingRemote={awaitingRemote}
                           defaultBranch={projectDefaultBranch || undefined}
                           portSeed={v.worktreeId}
                           className="h-full min-h-0"
@@ -297,6 +303,7 @@ const RightSidebar: React.FC<RightSidebarProps> = ({
                   projectPath={projectPath}
                   effectiveConnectionId={effectiveConnectionId}
                   effectiveRemotePath={effectiveRemotePath}
+                  awaitingRemote={awaitingRemote}
                   projectDefaultBranch={projectDefaultBranch}
                   onOpenChanges={onOpenChanges}
                 />
@@ -354,6 +361,7 @@ const SingleTaskSidebar: React.FC<{
   projectPath?: string | null;
   effectiveConnectionId?: string | null;
   effectiveRemotePath?: string | null;
+  awaitingRemote?: boolean;
   projectDefaultBranch?: string | null;
   onOpenChanges?: (filePath?: string, taskPath?: string) => void;
 }> = ({
@@ -361,6 +369,7 @@ const SingleTaskSidebar: React.FC<{
   projectPath,
   effectiveConnectionId,
   effectiveRemotePath,
+  awaitingRemote,
   projectDefaultBranch,
   onOpenChanges,
 }) => {
@@ -383,6 +392,7 @@ const SingleTaskSidebar: React.FC<{
                 }
               : undefined
           }
+          awaitingRemote={awaitingRemote}
           defaultBranch={projectDefaultBranch || undefined}
           className="h-full min-h-0"
         />

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -48,6 +48,8 @@ interface Props {
     connectionId: string;
     projectPath?: string;
   };
+  /** When true, a workspace connection is expected but not yet resolved. Terminals will show a loading state. */
+  awaitingRemote?: boolean;
   defaultBranch?: string;
   portSeed?: string;
 }
@@ -60,6 +62,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   className,
   projectPath,
   remote,
+  awaitingRemote,
   defaultBranch,
   portSeed,
 }) => {
@@ -762,71 +765,83 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
             onStep={stepSearch}
             onClose={closeSearch}
           />
-          {task &&
-            taskTerminals.terminals.map((terminal) => {
-              const isActive =
-                selection.parsed?.mode === 'task' && terminal.id === selection.activeTerminalId;
-              return (
-                <div
-                  key={`task::${terminal.id}`}
-                  className={cn(
-                    'absolute inset-0 h-full w-full transition-opacity',
-                    isActive ? 'opacity-100' : 'pointer-events-none opacity-0'
-                  )}
-                >
-                  <TerminalPane
-                    key={`${terminal.id}${reattachId === terminal.id ? `::${reattachCounter.current}` : ''}`}
-                    ref={(r) => setTerminalRef(terminal.id, r)}
-                    id={terminal.id}
-                    cwd={terminal.cwd || task.path}
-                    remote={
-                      remote?.connectionId ? { connectionId: remote.connectionId } : undefined
-                    }
-                    env={taskEnv}
-                    variant={
-                      effectiveTheme === 'dark' || effectiveTheme === 'dark-black'
-                        ? 'dark'
-                        : 'light'
-                    }
-                    themeOverride={themeOverride}
-                    className="h-full w-full"
-                    keepAlive
-                  />
-                </div>
-              );
-            })}
-          {globalTerminals.terminals.map((terminal) => {
-            const isActive =
-              selection.parsed?.mode === 'global' && terminal.id === selection.activeTerminalId;
-            return (
-              <div
-                key={`global::${terminal.id}`}
-                className={cn(
-                  'absolute inset-0 h-full w-full transition-opacity',
-                  isActive ? 'opacity-100' : 'pointer-events-none opacity-0'
-                )}
-              >
-                <TerminalPane
-                  key={`${terminal.id}${reattachId === terminal.id ? `::${reattachCounter.current}` : ''}`}
-                  ref={(r) => setTerminalRef(terminal.id, r)}
-                  id={terminal.id}
-                  cwd={terminal.cwd || projectPath}
-                  remote={remote?.connectionId ? { connectionId: remote.connectionId } : undefined}
-                  variant={
-                    effectiveTheme === 'dark' || effectiveTheme === 'dark-black' ? 'dark' : 'light'
-                  }
-                  themeOverride={themeOverride}
-                  className="h-full w-full"
-                  keepAlive
-                />
-              </div>
-            );
-          })}
-          {totalTerminals === 0 ? (
+          {awaitingRemote ? (
             <div className="flex h-full flex-col items-center justify-center text-xs text-muted-foreground">
-              <p>No terminal found.</p>
+              <p>Connecting to workspace...</p>
             </div>
-          ) : null}
+          ) : (
+            <>
+              {task &&
+                taskTerminals.terminals.map((terminal) => {
+                  const isActive =
+                    selection.parsed?.mode === 'task' && terminal.id === selection.activeTerminalId;
+                  return (
+                    <div
+                      key={`task::${terminal.id}`}
+                      className={cn(
+                        'absolute inset-0 h-full w-full transition-opacity',
+                        isActive ? 'opacity-100' : 'pointer-events-none opacity-0'
+                      )}
+                    >
+                      <TerminalPane
+                        key={`${terminal.id}${reattachId === terminal.id ? `::${reattachCounter.current}` : ''}`}
+                        ref={(r) => setTerminalRef(terminal.id, r)}
+                        id={terminal.id}
+                        cwd={remote?.projectPath || terminal.cwd || task.path}
+                        remote={
+                          remote?.connectionId ? { connectionId: remote.connectionId } : undefined
+                        }
+                        env={taskEnv}
+                        variant={
+                          effectiveTheme === 'dark' || effectiveTheme === 'dark-black'
+                            ? 'dark'
+                            : 'light'
+                        }
+                        themeOverride={themeOverride}
+                        className="h-full w-full"
+                        keepAlive
+                      />
+                    </div>
+                  );
+                })}
+              {globalTerminals.terminals.map((terminal) => {
+                const isActive =
+                  selection.parsed?.mode === 'global' && terminal.id === selection.activeTerminalId;
+                return (
+                  <div
+                    key={`global::${terminal.id}`}
+                    className={cn(
+                      'absolute inset-0 h-full w-full transition-opacity',
+                      isActive ? 'opacity-100' : 'pointer-events-none opacity-0'
+                    )}
+                  >
+                    <TerminalPane
+                      key={`${terminal.id}${reattachId === terminal.id ? `::${reattachCounter.current}` : ''}`}
+                      ref={(r) => setTerminalRef(terminal.id, r)}
+                      id={terminal.id}
+                      cwd={terminal.cwd || projectPath}
+                      remote={
+                        remote?.connectionId ? { connectionId: remote.connectionId } : undefined
+                      }
+                      variant={
+                        effectiveTheme === 'dark' || effectiveTheme === 'dark-black'
+                          ? 'dark'
+                          : 'light'
+                      }
+                      themeOverride={themeOverride}
+                      className="h-full w-full"
+                      keepAlive
+                    />
+                  </div>
+                );
+              })}
+              {totalTerminals === 0 ? (
+                <div className="flex h-full flex-col items-center justify-center text-xs text-muted-foreground">
+                  <p>No terminal found.</p>
+                </div>
+              ) : null}
+            </>
+          )}
         </div>
       )}
       {/* Expanded terminal modal */}

--- a/src/renderer/components/WorkspaceProvisioningOverlay.tsx
+++ b/src/renderer/components/WorkspaceProvisioningOverlay.tsx
@@ -5,6 +5,7 @@ import { cn } from '@/lib/utils';
 import type { Task } from '../types/app';
 import type { Project } from '../types/app';
 import { useToast } from '../hooks/use-toast';
+import { getProvisionLogs, appendProvisionLog, clearProvisionLogs } from '../lib/provisionLogCache';
 
 type ProvisioningStatus = 'provisioning' | 'error' | 'ready' | null;
 
@@ -20,7 +21,7 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
   className,
 }) => {
   const [status, setStatus] = useState<ProvisioningStatus>(null);
-  const [lines, setLines] = useState<string[]>([]);
+  const [lines, setLines] = useState<string[]>(() => getProvisionLogs(task.id));
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
   const { toast } = useToast();
   const logEndRef = useRef<HTMLDivElement>(null);
@@ -65,7 +66,7 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
       (data: { instanceId: string; line: string }) => {
         // Only handle events for our task's workspace instance
         if (instanceIdRef.current && data.instanceId !== instanceIdRef.current) return;
-        setLines((prev) => [...prev, data.line]);
+        setLines(() => appendProvisionLog(task.id, data.line));
       }
     );
 
@@ -74,6 +75,7 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
         if (instanceIdRef.current && data.instanceId !== instanceIdRef.current) return;
         if (data.status === 'ready') {
           setStatus('ready');
+          clearProvisionLogs(task.id);
           toast({ title: 'Workspace connected', description: 'Remote workspace is ready.' });
         } else {
           setStatus('error');
@@ -99,6 +101,7 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
 
     setStatus('provisioning');
     setLines([]);
+    clearProvisionLogs(task.id);
     setErrorMessage(null);
 
     void window.electronAPI

--- a/src/renderer/lib/provisionLogCache.ts
+++ b/src/renderer/lib/provisionLogCache.ts
@@ -1,0 +1,29 @@
+/**
+ * Module-level cache for workspace provisioning logs.
+ *
+ * Provisioning logs are stored in React state inside WorkspaceProvisioningOverlay,
+ * which means they are lost when the component unmounts (e.g. switching tabs).
+ * This cache persists logs by task ID so they can be restored on remount.
+ */
+
+const cache = new Map<string, string[]>();
+
+export function getProvisionLogs(taskId: string): string[] {
+  return cache.get(taskId) ?? [];
+}
+
+export function appendProvisionLog(taskId: string, line: string): string[] {
+  const existing = cache.get(taskId) ?? [];
+  const next = [...existing, line];
+  cache.set(taskId, next);
+  return next;
+}
+
+export function clearProvisionLogs(taskId: string): void {
+  cache.delete(taskId);
+}
+
+/** For testing only — clears the entire cache. */
+export function _resetCache(): void {
+  cache.clear();
+}

--- a/src/test/renderer/provisionLogCache.test.ts
+++ b/src/test/renderer/provisionLogCache.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  getProvisionLogs,
+  appendProvisionLog,
+  clearProvisionLogs,
+  _resetCache,
+} from '../../renderer/lib/provisionLogCache';
+
+describe('provisionLogCache', () => {
+  beforeEach(() => {
+    _resetCache();
+  });
+
+  it('returns empty array for unknown task', () => {
+    expect(getProvisionLogs('task-1')).toEqual([]);
+  });
+
+  it('appends log lines and returns accumulated result', () => {
+    const after1 = appendProvisionLog('task-1', 'line-1');
+    expect(after1).toEqual(['line-1']);
+
+    const after2 = appendProvisionLog('task-1', 'line-2');
+    expect(after2).toEqual(['line-1', 'line-2']);
+  });
+
+  it('persists logs across getProvisionLogs calls (simulates unmount/remount)', () => {
+    appendProvisionLog('task-1', 'line-a');
+    appendProvisionLog('task-1', 'line-b');
+
+    // Simulate component remount — reading from cache
+    const restored = getProvisionLogs('task-1');
+    expect(restored).toEqual(['line-a', 'line-b']);
+  });
+
+  it('isolates logs between different task IDs', () => {
+    appendProvisionLog('task-1', 'task1-line');
+    appendProvisionLog('task-2', 'task2-line');
+
+    expect(getProvisionLogs('task-1')).toEqual(['task1-line']);
+    expect(getProvisionLogs('task-2')).toEqual(['task2-line']);
+  });
+
+  it('clearProvisionLogs removes logs for the given task', () => {
+    appendProvisionLog('task-1', 'line-1');
+    appendProvisionLog('task-1', 'line-2');
+
+    clearProvisionLogs('task-1');
+    expect(getProvisionLogs('task-1')).toEqual([]);
+  });
+
+  it('clearProvisionLogs does not affect other tasks', () => {
+    appendProvisionLog('task-1', 'line-a');
+    appendProvisionLog('task-2', 'line-b');
+
+    clearProvisionLogs('task-1');
+    expect(getProvisionLogs('task-2')).toEqual(['line-b']);
+  });
+
+  it('can append after clearing (simulates retry)', () => {
+    appendProvisionLog('task-1', 'attempt-1');
+    clearProvisionLogs('task-1');
+
+    const result = appendProvisionLog('task-1', 'attempt-2');
+    expect(result).toEqual(['attempt-2']);
+    expect(getProvisionLogs('task-1')).toEqual(['attempt-2']);
+  });
+});

--- a/src/test/renderer/workspaceTerminalGating.test.ts
+++ b/src/test/renderer/workspaceTerminalGating.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect } from 'vitest';
+
+/**
+ * Tests the workspace terminal gating logic used in RightSidebar.
+ *
+ * Bug: TaskTerminalPanel rendered TerminalPane immediately, even when the
+ * workspace connection hadn't resolved yet. This caused the terminal to
+ * start a local session instead of connecting to the remote workspace.
+ *
+ * Fix: Compute `awaitingRemote = isWorkspaceTask && !wsConnectionId` and
+ * pass it to TaskTerminalPanel, which shows a loading state instead of
+ * rendering terminals.
+ */
+
+/** Mirrors the computation in RightSidebar.tsx */
+function computeAwaitingRemote(
+  taskMetadata: { workspace?: unknown } | null | undefined,
+  wsConnectionId: string | null
+): boolean {
+  const isWorkspaceTask = !!taskMetadata?.workspace;
+  return isWorkspaceTask && !wsConnectionId;
+}
+
+/** Mirrors the effectiveConnectionId computation in RightSidebar.tsx */
+function computeEffectiveConnectionId(
+  wsConnectionId: string | null,
+  projectRemoteConnectionId: string | null
+): string | null {
+  return wsConnectionId || projectRemoteConnectionId || null;
+}
+
+describe('workspace terminal gating', () => {
+  describe('awaitingRemote computation', () => {
+    it('returns false for non-workspace tasks (no metadata)', () => {
+      expect(computeAwaitingRemote(null, null)).toBe(false);
+    });
+
+    it('returns false for non-workspace tasks (no workspace key)', () => {
+      expect(computeAwaitingRemote({}, null)).toBe(false);
+    });
+
+    it('returns true when task has workspace but connection not yet resolved', () => {
+      expect(
+        computeAwaitingRemote({ workspace: { provisionCommand: './provision.sh' } }, null)
+      ).toBe(true);
+    });
+
+    it('returns false when workspace connection is resolved', () => {
+      expect(
+        computeAwaitingRemote(
+          { workspace: { provisionCommand: './provision.sh' } },
+          'workspace-conn-123'
+        )
+      ).toBe(false);
+    });
+  });
+
+  describe('effectiveConnectionId computation', () => {
+    it('prefers workspace connection over project connection', () => {
+      expect(computeEffectiveConnectionId('ws-conn-1', 'proj-conn-1')).toBe('ws-conn-1');
+    });
+
+    it('falls back to project connection when workspace is null', () => {
+      expect(computeEffectiveConnectionId(null, 'proj-conn-1')).toBe('proj-conn-1');
+    });
+
+    it('returns null when neither connection is available', () => {
+      expect(computeEffectiveConnectionId(null, null)).toBe(null);
+    });
+  });
+
+  describe('terminal rendering decision', () => {
+    /** Mirrors the logic in TaskTerminalPanel: when awaitingRemote, don't render terminals */
+    function shouldRenderTerminals(awaitingRemote: boolean): boolean {
+      return !awaitingRemote;
+    }
+
+    it('renders terminals for non-workspace tasks', () => {
+      const awaiting = computeAwaitingRemote(null, null);
+      expect(shouldRenderTerminals(awaiting)).toBe(true);
+    });
+
+    it('does NOT render terminals while workspace connection is pending', () => {
+      const awaiting = computeAwaitingRemote({ workspace: { provisionCommand: './p.sh' } }, null);
+      expect(shouldRenderTerminals(awaiting)).toBe(false);
+    });
+
+    it('renders terminals once workspace connection resolves', () => {
+      const awaiting = computeAwaitingRemote(
+        { workspace: { provisionCommand: './p.sh' } },
+        'workspace-conn-abc'
+      );
+      expect(shouldRenderTerminals(awaiting)).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Fix a bug where `TaskTerminalPanel` rendered terminals immediately for workspace tasks, starting a local session before the workspace connection resolved
- Add `awaitingRemote` prop that shows a "Connecting to workspace..." loading state until the workspace connection is available
- Use `remote.projectPath` as the preferred `cwd` for task terminals so they open in the correct remote directory
- Use `effectiveConnectionId` (workspace-aware) for non-variant terminal panels instead of only `projectRemoteConnectionId`
- Add `provisionLogCache` module to persist provisioning logs across component unmount/remount cycles (e.g. tab switching)

## Test plan

- [ ] Verify workspace tasks show "Connecting to workspace..." until the remote connection resolves
- [ ] Verify terminals open in the correct remote path once connected
- [ ] Verify provisioning logs survive tab switching and are cleared on success or retry
- [ ] Run `pnpm exec vitest run src/test/renderer/provisionLogCache.test.ts src/test/renderer/workspaceTerminalGating.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved workspace task handling with intelligent fallback to project-level connections when workspace connections are unavailable.
  * Added "Connecting to workspace..." loading state while establishing workspace connections.
  * Persistent caching of provisioning logs across component lifecycle.

* **Tests**
  * Added comprehensive test coverage for provisioning log caching and workspace terminal connection logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->