### PR TITLE
fix: detect remote project for exact worktree path

### DIFF
--- a/src/main/utils/remoteProjectResolver.ts
+++ b/src/main/utils/remoteProjectResolver.ts
@@ -17,10 +17,13 @@ export async function resolveRemoteProjectForWorktreePath(
   worktreePath: string
 ): Promise<RemoteProject | null> {
   const all = await databaseService.getProjects();
-  // Pick the longest matching remotePath prefix.
+  const normalizedInput = worktreePath.replace(/\/+$/g, '');
   const candidates = all
     .filter((p) => isRemoteProject(p))
-    .filter((p) => worktreePath.startsWith(p.remotePath.replace(/\/+$/g, '') + '/'))
+    .filter((p) => {
+      const base = p.remotePath.replace(/\/+$/g, '');
+      return normalizedInput === base || normalizedInput.startsWith(base + '/');
+    })
     .sort((a, b) => b.remotePath.length - a.remotePath.length);
   return candidates[0] ?? null;
 }


### PR DESCRIPTION
### summary

- Fix remote worktree path matching so git status/diff uses SSH for remote projects.

### Fixes

Fixes #1540

### Snapshot

N/A

### Type of change
[x] Bug fix

### Mandatory Tasks
[x] Self-reviewed

### Checklist
[x] Format/lint/type-check/tests run




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved remote project path resolution by normalizing input paths and supporting both exact matches and subtree paths, making path matching more robust and flexible.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->