### PR TITLE
fix(db): prevent saveProject from silently deleting unrelated projects

### DIFF
--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -1,5 +1,5 @@
 import type sqlite3Type from 'sqlite3';
-import { and, asc, desc, eq, isNull, ne, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import { resolveDatabasePath, resolveMigrationsPath } from '../db/path';
 import { getDrizzleClient } from '../db/drizzleClient';
@@ -97,6 +97,27 @@ export class DatabaseSchemaMismatchError extends Error {
   }
 }
 
+export class ProjectConflictError extends Error {
+  readonly code = 'PROJECT_CONFLICT';
+  readonly existingProjectId: string;
+  readonly existingProjectName: string;
+  readonly projectPath: string;
+
+  constructor(args: {
+    existingProjectId: string;
+    existingProjectName: string;
+    projectPath: string;
+  }) {
+    super(
+      `A project already exists for "${args.existingProjectName}" at ${args.projectPath}. Emdash kept the existing project and its tasks unchanged.`
+    );
+    this.name = 'ProjectConflictError';
+    this.existingProjectId = args.existingProjectId;
+    this.existingProjectName = args.existingProjectName;
+    this.projectPath = args.projectPath;
+  }
+}
+
 export class DatabaseService {
   private static migrationsApplied = false;
   private db: sqlite3Type.Database | null = null;
@@ -172,49 +193,56 @@ export class DatabaseService {
     );
     const githubRepository = project.githubInfo?.repository ?? null;
     const githubConnected = project.githubInfo?.connected ? 1 : 0;
-
-    // Clean up stale rows that would conflict on id or path but not both.
-    // This prevents unique constraint errors when re-adding a deleted project.
-    await db
-      .delete(projectsTable)
-      .where(
-        or(
-          and(eq(projectsTable.id, project.id), ne(projectsTable.path, project.path)),
-          and(eq(projectsTable.path, project.path), ne(projectsTable.id, project.id))
-        )
-      );
-
-    await db
-      .insert(projectsTable)
-      .values({
-        id: project.id,
-        name: project.name,
-        path: project.path,
-        gitRemote,
-        gitBranch,
-        baseRef: baseRef ?? null,
-        githubRepository,
-        githubConnected,
-        sshConnectionId: project.sshConnectionId ?? null,
-        isRemote: project.isRemote ? 1 : 0,
-        remotePath: project.remotePath ?? null,
-        updatedAt: sql`CURRENT_TIMESTAMP`,
+    const existingByIdRows = await db
+      .select({
+        id: projectsTable.id,
+        path: projectsTable.path,
       })
-      .onConflictDoUpdate({
-        target: projectsTable.path,
-        set: {
-          name: project.name,
-          gitRemote,
-          gitBranch,
-          baseRef: baseRef ?? null,
-          githubRepository,
-          githubConnected,
-          sshConnectionId: project.sshConnectionId ?? null,
-          isRemote: project.isRemote ? 1 : 0,
-          remotePath: project.remotePath ?? null,
-          updatedAt: sql`CURRENT_TIMESTAMP`,
-        },
+      .from(projectsTable)
+      .where(eq(projectsTable.id, project.id))
+      .limit(1);
+    const existingById = existingByIdRows[0] ?? null;
+
+    const existingByPathRows = await db
+      .select({
+        id: projectsTable.id,
+        name: projectsTable.name,
+        path: projectsTable.path,
+      })
+      .from(projectsTable)
+      .where(eq(projectsTable.path, project.path))
+      .limit(1);
+    const existingByPath = existingByPathRows[0] ?? null;
+
+    if (existingByPath && existingByPath.id !== project.id) {
+      throw new ProjectConflictError({
+        existingProjectId: existingByPath.id,
+        existingProjectName: existingByPath.name,
+        projectPath: existingByPath.path,
       });
+    }
+
+    const values = {
+      id: project.id,
+      name: project.name,
+      path: project.path,
+      gitRemote,
+      gitBranch,
+      baseRef: baseRef ?? null,
+      githubRepository,
+      githubConnected,
+      sshConnectionId: project.sshConnectionId ?? null,
+      isRemote: project.isRemote ? 1 : 0,
+      remotePath: project.remotePath ?? null,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    } as const;
+
+    if (existingById) {
+      await db.update(projectsTable).set(values).where(eq(projectsTable.id, project.id));
+      return;
+    }
+
+    await db.insert(projectsTable).values(values);
   }
 
   async getProjects(): Promise<Project[]> {

--- a/src/renderer/hooks/useProjectManagement.tsx
+++ b/src/renderer/hooks/useProjectManagement.tsx
@@ -314,8 +314,11 @@ export const useProjectManagement = () => {
           const { log } = await import('../lib/logger');
           log.error('Git detection error:', error as any);
           toast({
-            title: 'Project Opened',
-            description: `Could not detect Git information. Path: ${result.path}`,
+            title: 'Failed to Open Project',
+            description:
+              error instanceof Error
+                ? error.message
+                : `Could not detect Git information. Path: ${result.path}`,
             variant: 'destructive',
           });
         }
@@ -391,8 +394,11 @@ export const useProjectManagement = () => {
         const { log } = await import('../lib/logger');
         log.error('Failed to load cloned project:', error);
         toast({
-          title: 'Project Cloned',
-          description: 'Repository cloned but failed to load. Please try opening it manually.',
+          title: 'Failed to add cloned project',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Repository cloned but failed to load. Please try opening it manually.',
           variant: 'destructive',
         });
       }
@@ -436,8 +442,11 @@ export const useProjectManagement = () => {
         const { log } = await import('../lib/logger');
         log.error('Failed to load new project:', error);
         toast({
-          title: 'Project Created',
-          description: 'Repository created but failed to load. Please try opening it manually.',
+          title: 'Failed to add new project',
+          description:
+            error instanceof Error
+              ? error.message
+              : 'Repository created but failed to load. Please try opening it manually.',
           variant: 'destructive',
         });
       }
@@ -502,7 +511,8 @@ export const useProjectManagement = () => {
         log.error('Failed to save remote project:', error);
         toast({
           title: 'Failed to add remote project',
-          description: 'An error occurred while saving the project.',
+          description:
+            error instanceof Error ? error.message : 'An error occurred while saving the project.',
           variant: 'destructive',
         });
       }

--- a/src/test/main/DatabaseService.saveProject.test.ts
+++ b/src/test/main/DatabaseService.saveProject.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const selectResults: unknown[][] = [];
+const insertValuesMock = vi.fn();
+const updateValuesMock = vi.fn();
+const updateWhereMock = vi.fn();
+
+const mockDb = {
+  select: vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve((selectResults.shift() as unknown[]) ?? []),
+      }),
+    }),
+  })),
+  insert: vi.fn(() => ({
+    values: (values: unknown) => {
+      insertValuesMock(values);
+      return Promise.resolve();
+    },
+  })),
+  update: vi.fn(() => ({
+    set: (values: unknown) => {
+      updateValuesMock(values);
+      return {
+        where: (...args: unknown[]) => {
+          updateWhereMock(...args);
+          return Promise.resolve();
+        },
+      };
+    },
+  })),
+};
+
+vi.mock('../../main/db/path', () => ({
+  resolveDatabasePath: () => '/tmp/emdash-save-project-test.db',
+  resolveMigrationsPath: () => '/tmp/drizzle',
+}));
+
+vi.mock('../../main/errorTracking', () => ({
+  errorTracking: {
+    captureDatabaseError: vi.fn(),
+  },
+}));
+
+vi.mock('../../main/db/drizzleClient', () => ({
+  getDrizzleClient: () => Promise.resolve({ db: mockDb }),
+}));
+
+import { DatabaseService, type Project } from '../../main/services/DatabaseService';
+
+describe('DatabaseService.saveProject', () => {
+  let service: DatabaseService;
+
+  const baseProject: Omit<Project, 'createdAt' | 'updatedAt'> = {
+    id: 'project-1',
+    name: 'Project One',
+    path: '/tmp/project-one',
+    isRemote: true,
+    sshConnectionId: 'ssh-1',
+    remotePath: '/srv/project-one',
+    gitInfo: {
+      isGitRepo: true,
+      remote: 'origin',
+      branch: 'main',
+      baseRef: 'origin/main',
+    },
+    githubInfo: {
+      repository: 'org/project-one',
+      connected: true,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectResults.length = 0;
+    service = new DatabaseService();
+  });
+
+  it('throws a typed conflict instead of overwriting an existing project', async () => {
+    selectResults.push([]);
+    selectResults.push([
+      {
+        id: 'project-existing',
+        name: 'Existing Project',
+        path: '/srv/project-one',
+      },
+    ]);
+
+    await expect(service.saveProject(baseProject)).rejects.toEqual(
+      expect.objectContaining({
+        name: 'ProjectConflictError',
+        code: 'PROJECT_CONFLICT',
+        existingProjectId: 'project-existing',
+        existingProjectName: 'Existing Project',
+        projectPath: '/srv/project-one',
+      })
+    );
+
+    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(updateValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('updates an existing project row when the same project id is resaved', async () => {
+    selectResults.push([
+      {
+        id: 'project-1',
+        path: '/tmp/project-one',
+      },
+    ]);
+    selectResults.push([
+      {
+        id: 'project-1',
+        name: 'Project One',
+        path: '/srv/project-one',
+      },
+    ]);
+
+    await expect(service.saveProject(baseProject)).resolves.toBeUndefined();
+
+    expect(updateValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'project-1',
+        name: 'Project One',
+        path: '/tmp/project-one',
+        sshConnectionId: 'ssh-1',
+        remotePath: '/srv/project-one',
+      })
+    );
+    expect(updateWhereMock).toHaveBeenCalledTimes(1);
+    expect(insertValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('inserts a new project without mutating an existing row', async () => {
+    selectResults.push([]);
+    selectResults.push([]);
+
+    await expect(service.saveProject(baseProject)).resolves.toBeUndefined();
+
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'project-1',
+        path: '/tmp/project-one',
+      })
+    );
+    expect(updateValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('allows the same project id to move to a new path when there is no collision', async () => {
+    selectResults.push([
+      {
+        id: 'project-1',
+        path: '/tmp/project-one',
+      },
+    ]);
+    selectResults.push([]);
+
+    const movedProject = {
+      ...baseProject,
+      path: '/tmp/project-one-renamed',
+    };
+
+    await expect(service.saveProject(movedProject)).resolves.toBeUndefined();
+
+    expect(updateValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/tmp/project-one-renamed',
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary

- Replace the destructive `DELETE + INSERT ... ON CONFLICT` pattern in `DatabaseService.saveProject` with explicit lookup-then-update/insert logic
- Add `ProjectConflictError` that is thrown when a different project already occupies the same path, instead of silently overwriting it
- Surface actual error messages in project-related toast notifications in `useProjectManagement` instead of showing generic failure text

## Motivation

The previous `saveProject` implementation deleted any row whose `id` or `path` partially matched, which could silently destroy an unrelated project and its associated tasks. The new approach checks for conflicts explicitly and throws a typed error, letting the UI inform the user rather than losing data.

## Test plan

- [ ] Verify opening an existing project by path reuses the existing row (update path)
- [ ] Verify adding a project with a path that belongs to a different project ID shows a conflict error toast
- [ ] Verify new projects are inserted correctly when no conflict exists
- [ ] Run `pnpm exec vitest run src/test/main/DatabaseService.saveProject.test.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Projects with conflicting file paths now fail with descriptive error messages instead of being silently overwritten.

* **Improved Error Messaging**
  * Error notifications for project operations (open, clone, create, and save) now display detailed, actionable error information instead of generic messages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->