### PR TITLE
fix(terminal): use buffered write drain scheduler with visibility fallback

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -29,6 +29,7 @@ import {
   type TerminalSearchBufferLike,
   type TerminalSearchMatch,
 } from './terminalSearch';
+import { scheduleTerminalWriteDrain } from './writeDrainScheduler';
 import { rpc } from '@/lib/rpc';
 import { APP_SHORTCUTS, normalizeShortcutKey } from '@/hooks/useKeyboardShortcuts';
 
@@ -145,6 +146,7 @@ export class TerminalSessionManager {
   private readonly pendingWriteQueue: string[] = [];
   private queuedWriteChars = 0;
   private writeDrainScheduled = false;
+  private cancelPendingWriteDrain: CleanupFn | null = null;
   private writeInFlight = false;
   private shouldScrollToBottomAfterWrites = false;
   private lastSlowInputLogAt = 0;
@@ -562,6 +564,8 @@ export class TerminalSessionManager {
     this.pendingWriteQueue.length = 0;
     this.queuedWriteChars = 0;
     this.writeDrainScheduled = false;
+    this.cancelPendingWriteDrain?.();
+    this.cancelPendingWriteDrain = null;
     this.writeInFlight = false;
     this.shouldScrollToBottomAfterWrites = false;
     this.detach();
@@ -1373,8 +1377,9 @@ export class TerminalSessionManager {
   private scheduleWriteDrain() {
     if (this.writeDrainScheduled || this.disposed) return;
     this.writeDrainScheduled = true;
-    requestAnimationFrame(() => {
+    this.cancelPendingWriteDrain = scheduleTerminalWriteDrain(() => {
       this.writeDrainScheduled = false;
+      this.cancelPendingWriteDrain = null;
       this.drainQueuedWrites();
     });
   }

--- a/src/renderer/terminal/writeDrainScheduler.ts
+++ b/src/renderer/terminal/writeDrainScheduler.ts
@@ -1,0 +1,54 @@
+const VISIBLE_DRAIN_FALLBACK_MS = 48;
+
+function getVisibilityState(): DocumentVisibilityState {
+  if (typeof document === 'undefined') return 'visible';
+  return document.visibilityState;
+}
+
+export function scheduleTerminalWriteDrain(run: () => void): () => void {
+  let finished = false;
+  let frameId: number | null = null;
+  let timeoutId: ReturnType<typeof setTimeout> | null = null;
+
+  const cancelPending = () => {
+    if (frameId !== null && typeof cancelAnimationFrame === 'function') {
+      cancelAnimationFrame(frameId);
+      frameId = null;
+    }
+    if (timeoutId !== null) {
+      clearTimeout(timeoutId);
+      timeoutId = null;
+    }
+  };
+
+  const finish = () => {
+    if (finished) return;
+    finished = true;
+    cancelPending();
+    run();
+  };
+
+  const canUseAnimationFrame =
+    getVisibilityState() === 'visible' &&
+    typeof requestAnimationFrame === 'function' &&
+    typeof cancelAnimationFrame === 'function';
+
+  if (canUseAnimationFrame) {
+    frameId = requestAnimationFrame(() => {
+      finish();
+    });
+    timeoutId = setTimeout(() => {
+      finish();
+    }, VISIBLE_DRAIN_FALLBACK_MS);
+  } else {
+    timeoutId = setTimeout(() => {
+      finish();
+    }, 0);
+  }
+
+  return () => {
+    if (finished) return;
+    finished = true;
+    cancelPending();
+  };
+}

--- a/src/test/renderer/writeDrainScheduler.test.ts
+++ b/src/test/renderer/writeDrainScheduler.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { scheduleTerminalWriteDrain } from '../../renderer/terminal/writeDrainScheduler';
+
+describe('scheduleTerminalWriteDrain', () => {
+  const originalDocument = globalThis.document;
+  const originalRequestAnimationFrame = globalThis.requestAnimationFrame;
+  const originalCancelAnimationFrame = globalThis.cancelAnimationFrame;
+  const globals = globalThis as typeof globalThis & {
+    document?: Document;
+    requestAnimationFrame?: (callback: (time: number) => void) => number;
+    cancelAnimationFrame?: (handle: number) => void;
+  };
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+
+    if (originalDocument === undefined) {
+      Reflect.deleteProperty(globals, 'document');
+    } else {
+      globals.document = originalDocument;
+    }
+
+    if (originalRequestAnimationFrame === undefined) {
+      Reflect.deleteProperty(globals, 'requestAnimationFrame');
+    } else {
+      globals.requestAnimationFrame = originalRequestAnimationFrame;
+    }
+
+    if (originalCancelAnimationFrame === undefined) {
+      Reflect.deleteProperty(globals, 'cancelAnimationFrame');
+    } else {
+      globals.cancelAnimationFrame = originalCancelAnimationFrame;
+    }
+  });
+
+  it('prefers requestAnimationFrame while visible', () => {
+    let frameCallback: ((time: number) => void) | null = null;
+    const run = vi.fn();
+
+    globals.document = { visibilityState: 'visible' } as Document;
+    globals.requestAnimationFrame = vi.fn((callback: (time: number) => void) => {
+      frameCallback = callback;
+      return 1;
+    });
+    globals.cancelAnimationFrame = vi.fn();
+
+    scheduleTerminalWriteDrain(run);
+
+    expect(globals.requestAnimationFrame).toHaveBeenCalledTimes(1);
+    expect(run).not.toHaveBeenCalled();
+
+    expect(frameCallback).not.toBeNull();
+    const callback = frameCallback!;
+    callback(16);
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back to a timeout when the document is hidden', () => {
+    const run = vi.fn();
+
+    globals.document = { visibilityState: 'hidden' } as Document;
+    globals.requestAnimationFrame = vi.fn();
+    globals.cancelAnimationFrame = vi.fn();
+
+    scheduleTerminalWriteDrain(run);
+
+    expect(globals.requestAnimationFrame).not.toHaveBeenCalled();
+
+    vi.runAllTimers();
+
+    expect(run).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses the timeout fallback if requestAnimationFrame never fires', () => {
+    const run = vi.fn();
+
+    globals.document = { visibilityState: 'visible' } as Document;
+    globals.requestAnimationFrame = vi.fn(() => 7);
+    globals.cancelAnimationFrame = vi.fn();
+
+    scheduleTerminalWriteDrain(run);
+
+    vi.runAllTimers();
+
+    expect(run).toHaveBeenCalledTimes(1);
+    expect(globals.cancelAnimationFrame).toHaveBeenCalledWith(7);
+  });
+});


### PR DESCRIPTION
## Summary

Replaces the raw `requestAnimationFrame` call in `TerminalSessionManager.scheduleWriteDrain()` with a new `scheduleTerminalWriteDrain` utility that handles background-tab scenarios.

## Problem

When the app tab is hidden, `requestAnimationFrame` callbacks are throttled or paused by the browser, causing terminal write drains to stall indefinitely.

## Changes

- Add `writeDrainScheduler.ts` — schedules drains via `requestAnimationFrame` when visible, with a `setTimeout` fallback (48ms) to guarantee delivery even when throttled. Falls back to `setTimeout(0)` when the document is hidden.
- Update `TerminalSessionManager` to use the new scheduler and track a `cancelPendingWriteDrain` handle, ensuring pending drains are properly cancelled on dispose/reset.

<!-- emdash-issue-footer:start -->
Fixes #1510
<!-- emdash-issue-footer:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved terminal write operation scheduling to enhance responsiveness when the window is visible, with optimized timing strategies and refined fallback behavior for edge cases.

* **Tests**
  * Added comprehensive test suite for terminal write scheduling with visibility state detection and timer fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->