### PR TITLE
fix: always sync systemTheme with OS for instant theme switching

### DIFF
--- a/src/renderer/components/ThemeProvider.tsx
+++ b/src/renderer/components/ThemeProvider.tsx
@@ -44,16 +44,14 @@ export function ThemeProvider({ children }: { children: ReactNode }) {
     applyTheme(theme, systemTheme);
   }, [theme, systemTheme]);
 
-  // Listen for OS theme changes when preference is 'system'
+  // Always keep systemTheme in sync with OS so switching to 'system' is instant
   useEffect(() => {
-    if (theme !== 'system') return undefined;
-
     const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)');
     const handler = () => setSystemTheme(getSystemTheme());
 
     mediaQuery.addEventListener('change', handler);
     return () => mediaQuery.removeEventListener('change', handler);
-  }, [theme]);
+  }, []);
 
   const setTheme = (newTheme: Theme) => {
     updateSettings({ interface: { theme: newTheme } });


### PR DESCRIPTION
## Summary
system theme listneer only ran when theme was set to "system" so switching from light or dark mode to system could show a stale theme until the next os change

## Snapshot
this was before:
https://github.com/user-attachments/assets/4d9d777f-5f8b-47bf-ae6c-38578d983dd1

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed system theme switching to immediately apply the current OS theme preference and properly respond to OS theme changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->