### PR TITLE
docs(skills): add skills.sh as a skill source

### DIFF
--- a/docs/content/docs/skills.mdx
+++ b/docs/content/docs/skills.mdx
@@ -24,8 +24,9 @@ Open the Skills view by clicking **Skills** (puzzle icon) in the left sidebar. Y
 
 - [OpenAI skill library](https://github.com/openai/skills/)
 - [Anthropic skill library](https://github.com/anthropics/skills/)
+- [skills.sh](https://skills.sh/) — a community skill registry
 
-Use the search box to filter by name or description. Click **Refresh** to fetch the latest skills from GitHub.
+Click **Refresh** to fetch the latest skills from the OpenAI and Anthropic catalogs. Use the search box to filter by name or description. When you search, Emdash also queries the skills.sh API to surface community-contributed skills beyond the built-in catalogs.
 
 If you want to use skills from another library, feel free to let us know through the feedback modal in the app.
 


### PR DESCRIPTION
## Summary

  Add skills.sh as a documented skill source in the skills documentation page. The app already integrates with the
  skills.sh API for search, but the docs only listed OpenAI and Anthropic catalogs.

  ## Fixes

  N/A

  ## Snapshot

  N/A

  ## Type of change

  - [ ] Bug fix (non-breaking change which fixes an issue)
  - [ ] Chore (refactoring code, technical debt, workflow improvements)
  - [ ] New feature (non-breaking change which adds functionality)
  - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
  - [x] This change requires a documentation update

  ## Mandatory Tasks

  - [x] I have self-reviewed the code
  - [ ] A decent size PR without self-review might be rejected

  ## Checklist

  - [x] I have read the contributing guide
  - [x] My code follows the style guidelines of this project (`pnpm run format`)
  - [x] I have commented my code, particularly in hard-to-understand areas
  - [x] I have checked if my PR needs changes to the documentation
  - [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
  - [ ] I have added tests that prove my fix is effective or that my feature works
  - [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Skills catalog now references skills.sh as a community skill registry source
  * Updated refresh behavior documentation: sources from OpenAI and Anthropic catalogs
  * Search now includes community-contributed skills via skills.sh API integration

<!-- end of auto-generated comment: release notes by coderabbit.ai -->