### PR TITLE
feat(keyboard): do not intercept reserved CLI shortcuts when terminal is focused

### DIFF
--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -508,6 +508,19 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
           target?.tagName === 'TEXTAREA' ||
           target?.isContentEditable);
 
+      // If the focused terminal belongs to a provider that has reserved this
+      // key (e.g. readline end-of-line, Copilot plan view), let it pass
+      // through to the CLI instead of firing an app shortcut.
+      if (isXtermTextarea) {
+        const hasPlatformMod = isMacPlatform
+          ? event.metaKey && !event.ctrlKey
+          : event.ctrlKey && !event.metaKey;
+        if (hasPlatformMod) {
+          const reservedShortcuts = target.dataset.reservedShortcuts?.split(',') ?? [];
+          if (reservedShortcuts.includes(key)) return;
+        }
+      }
+
       for (const shortcut of shortcuts) {
         const shortcutKey = normalizeShortcutKey(shortcut.config.key);
         const keyMatches = key === shortcutKey;

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -417,14 +417,20 @@ export class TerminalSessionManager {
         }
       }
 
-      // Let registered app shortcuts propagate to the global handler.
+      // Let registered app shortcuts propagate to the global handler,
+      // unless the active provider has reserved the key for its own TUI use
+      // (e.g. readline end-of-line, plan view, etc.).
       const hasPlatformMod = IS_MAC_PLATFORM
         ? event.metaKey && !event.ctrlKey
         : event.ctrlKey && !event.metaKey;
       if (hasPlatformMod) {
         const key = normalizeShortcutKey(event.key);
-        if (!event.shiftKey && APP_CMD_KEYS.has(key)) return false;
-        if (event.shiftKey && APP_CMD_SHIFT_KEYS.has(key)) return false;
+        const provider = this.options.providerId
+          ? getProvider(this.options.providerId as ProviderId)
+          : undefined;
+        const isProviderReserved = provider?.reservedShortcuts?.includes(key) ?? false;
+        if (!event.shiftKey && APP_CMD_KEYS.has(key) && !isProviderReserved) return false;
+        if (event.shiftKey && APP_CMD_SHIFT_KEYS.has(key) && !isProviderReserved) return false;
       }
 
       return true; // Let xterm handle all other keys normally
@@ -471,6 +477,19 @@ export class TerminalSessionManager {
     if (!this.opened) {
       this.terminal.open(this.container);
       this.opened = true;
+
+      // Stamp provider reserved shortcuts onto the xterm textarea so the
+      // window-level shortcut handler (useKeyboardShortcuts) can skip them
+      // before the app shortcut fires.
+      if (this.options.providerId) {
+        const provider = getProvider(this.options.providerId as ProviderId);
+        const reserved = provider?.reservedShortcuts;
+        if (reserved?.length) {
+          const textarea = this.container.querySelector<HTMLElement>('.xterm-helper-textarea');
+          if (textarea) textarea.dataset.reservedShortcuts = reserved.join(',');
+        }
+      }
+
       const element = (this.terminal as any).element as HTMLElement | null;
       if (element) {
         element.style.width = '100%';

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -57,7 +57,31 @@ export type ProviderDefinition = {
   autoStartCommand?: string;
   icon?: string;
   terminalOnly?: boolean;
+  /**
+   * Normalized key characters (e.g. 'e', 'k') that this provider's TUI
+   * handles internally via the platform modifier key (Ctrl on Linux/Windows,
+   * Cmd on macOS). When the agent's terminal is focused, these keys will NOT
+   * be intercepted as app-level shortcuts and will instead pass through to
+   * the CLI process.
+   */
+  reservedShortcuts?: string[];
 };
+
+/**
+ * Common readline keybindings that conflict with emdash app shortcuts on
+ * Linux/Windows (where the platform modifier is Ctrl).
+ *
+ * These are standard readline editing commands used by virtually all
+ * terminal-based agent CLIs:
+ *   e → end-of-line        (conflicts with Toggle Editor)
+ *   k → kill-to-end        (conflicts with Command Palette)
+ *   n → next-history       (conflicts with New Task)
+ *   p → prev-history       (conflicts with Toggle Kanban)
+ *   b → backward-char      (conflicts with Toggle Left Sidebar)
+ *   o → operate-and-get-next (conflicts with Open in Editor)
+ *   t → transpose-chars    (conflicts with Toggle Theme)
+ */
+export const READLINE_SHORTCUTS: string[] = ['e', 'k', 'n', 'p', 'b', 'o', 't'];
 
 export const PROVIDERS: ProviderDefinition[] = [
   {
@@ -73,6 +97,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: 'resume --last',
     icon: 'openai.svg',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'claude',
@@ -89,6 +114,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     planActivateCommand: '/plan',
     icon: 'claude.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'cursor',
@@ -102,6 +128,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '',
     icon: 'cursor.svg',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'gemini',
@@ -116,6 +143,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '--resume',
     icon: 'gemini.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'qwen',
@@ -130,6 +158,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '--continue',
     icon: 'qwen.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'droid',
@@ -143,6 +172,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '-r',
     icon: 'droid.svg',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'amp',
@@ -157,6 +187,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     useKeystrokeInjection: true,
     icon: 'ampcode.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'opencode',
@@ -170,6 +201,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     useKeystrokeInjection: true,
     icon: 'opencode.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'hermes',
@@ -185,6 +217,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '--continue',
     icon: 'hermesagent.jpg',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'copilot',
@@ -198,6 +231,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '-i',
     icon: 'gh-copilot.svg',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'charm',
@@ -210,6 +244,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     autoApproveFlag: '--yolo',
     icon: 'charm.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'auggie',
@@ -224,6 +259,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     defaultArgs: ['--allow-indexing'],
     icon: 'Auggie.svg',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'goose',
@@ -238,6 +274,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '-t',
     icon: 'goose.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'kimi',
@@ -251,6 +288,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '-c',
     icon: 'kimi.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'kilocode',
@@ -265,6 +303,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '--continue',
     icon: 'kilocode.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'kiro',
@@ -278,6 +317,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '',
     icon: 'kiro.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'rovo',
@@ -290,6 +330,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     autoStartCommand: 'acli rovodev run',
     icon: 'atlassian.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'cline',
@@ -303,6 +344,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '',
     icon: 'cline.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'continue',
@@ -316,6 +358,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '--resume',
     icon: 'continue.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'codebuff',
@@ -328,6 +371,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '',
     icon: 'codebuff.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'mistral',
@@ -341,6 +385,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '--prompt',
     icon: 'mistral.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'pi',
@@ -354,6 +399,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '-c',
     icon: 'pi.png',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
   {
     id: 'autohand',
@@ -367,6 +413,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     initialPromptFlag: '-p',
     icon: 'autohand.svg',
     terminalOnly: true,
+    reservedShortcuts: READLINE_SHORTCUTS,
   },
 ];
 

--- a/src/test/renderer/useKeyboardShortcuts.test.ts
+++ b/src/test/renderer/useKeyboardShortcuts.test.ts
@@ -1,5 +1,116 @@
 import { describe, expect, it } from 'vitest';
-import { getAgentTabSelectionIndex } from '../../renderer/hooks/useKeyboardShortcuts';
+import {
+  getAgentTabSelectionIndex,
+  normalizeShortcutKey,
+  hasShortcutConflict,
+  APP_SHORTCUTS,
+} from '../../renderer/hooks/useKeyboardShortcuts';
+import { READLINE_SHORTCUTS, PROVIDERS, getProvider } from '../../shared/providers/registry';
+
+describe('normalizeShortcutKey', () => {
+  it('normalizes { to [ (Ctrl+Shift+[ produces { on some keyboards)', () => {
+    expect(normalizeShortcutKey('{')).toBe('[');
+  });
+
+  it('normalizes } to ] (Ctrl+Shift+] produces } on some keyboards)', () => {
+    expect(normalizeShortcutKey('}')).toBe(']');
+  });
+
+  it('normalizes single characters to lowercase', () => {
+    expect(normalizeShortcutKey('E')).toBe('e');
+    expect(normalizeShortcutKey('K')).toBe('k');
+  });
+
+  it('normalizes special key aliases', () => {
+    expect(normalizeShortcutKey('Esc')).toBe('Escape');
+    expect(normalizeShortcutKey('esc')).toBe('Escape');
+    expect(normalizeShortcutKey('left')).toBe('ArrowLeft');
+    expect(normalizeShortcutKey('right')).toBe('ArrowRight');
+  });
+});
+
+describe('READLINE_SHORTCUTS — conflicts with Emdash app shortcuts on Linux/Windows', () => {
+  it('contains exactly the 7 expected readline keys', () => {
+    expect(READLINE_SHORTCUTS).toHaveLength(7);
+    expect(READLINE_SHORTCUTS).toEqual(expect.arrayContaining(['e', 'k', 'n', 'p', 'b', 'o', 't']));
+  });
+
+  it('every readline key conflicts with a cmd-modifier app shortcut', () => {
+    // On Linux/Windows cmd=Ctrl, so Ctrl+E etc. would fire app shortcuts
+    // without the reserved-shortcuts fix
+    const cmdShortcutKeys = Object.values(APP_SHORTCUTS)
+      .filter((s) => s.modifier === 'cmd')
+      .map((s) => normalizeShortcutKey(s.key));
+
+    for (const key of READLINE_SHORTCUTS) {
+      expect(cmdShortcutKeys).toContain(key);
+    }
+  });
+
+  it('the ] and [ keys (Next/Prev Task & Agent) are NOT in READLINE_SHORTCUTS', () => {
+    // These should always fire as Emdash shortcuts even when CLI is focused
+    expect(READLINE_SHORTCUTS).not.toContain(']');
+    expect(READLINE_SHORTCUTS).not.toContain('[');
+  });
+});
+
+describe('Provider reservedShortcuts', () => {
+  it('every provider has reservedShortcuts defined', () => {
+    for (const provider of PROVIDERS) {
+      expect(
+        provider.reservedShortcuts,
+        `${provider.name} is missing reservedShortcuts`
+      ).toBeDefined();
+    }
+  });
+
+  it('every provider reserves all READLINE_SHORTCUTS', () => {
+    for (const provider of PROVIDERS) {
+      for (const key of READLINE_SHORTCUTS) {
+        expect(
+          provider.reservedShortcuts,
+          `${provider.name} is missing reserved key '${key}'`
+        ).toContain(key);
+      }
+    }
+  });
+
+  it('GitHub Copilot reserves all READLINE_SHORTCUTS', () => {
+    const copilot = getProvider('copilot');
+    expect(copilot).toBeDefined();
+    expect(copilot?.reservedShortcuts).toEqual(expect.arrayContaining(READLINE_SHORTCUTS));
+  });
+});
+
+describe('hasShortcutConflict', () => {
+  const sc = (key: string, modifier: 'cmd' | 'ctrl' | 'cmd+shift' = 'cmd') => ({
+    key,
+    modifier,
+    description: '',
+  });
+
+  it('detects conflict when key and modifier both match', () => {
+    expect(hasShortcutConflict(sc('e'), sc('e'))).toBe(true);
+  });
+
+  it('no conflict when modifier differs', () => {
+    expect(hasShortcutConflict(sc('e', 'cmd'), sc('e', 'ctrl'))).toBe(false);
+  });
+
+  it('no conflict when key differs', () => {
+    expect(hasShortcutConflict(sc('e'), sc('k'))).toBe(false);
+  });
+
+  it('normalizes keys before comparing (e vs E)', () => {
+    expect(hasShortcutConflict(sc('E'), sc('e'))).toBe(true);
+  });
+
+  it('normalizes { and } before comparing', () => {
+    // } normalizes to ] — used for Next/Prev Agent on keyboards that produce curly braces
+    expect(hasShortcutConflict(sc('}', 'cmd+shift'), sc(']', 'cmd+shift'))).toBe(true);
+    expect(hasShortcutConflict(sc('{', 'cmd+shift'), sc('[', 'cmd+shift'))).toBe(true);
+  });
+});
 
 describe('getAgentTabSelectionIndex', () => {
   it('maps Cmd/Ctrl+1 through Cmd/Ctrl+9 to zero-based tab indexes', () => {


### PR DESCRIPTION
## Summary

Emdash was intercepting `Ctrl+E` (and other `Ctrl+<key>` app shortcuts) even when a CLI agent terminal was focused, preventing readline commands from reaching the CLI process.

Closes: #1509 

### Root cause

On Linux/Windows, Emdash uses `Ctrl` as the platform modifier for app shortcuts (`Ctrl+E` = Toggle Editor, `Ctrl+K` = Command Palette, etc.). Standard readline , used by virtually all terminal-based CLI agents , also uses `Ctrl` for editing commands (`Ctrl+E` = end-of-line, `Ctrl+K` = kill-to-end, etc.). When a CLI terminal had focus, xterm's key handler was passing these keys up to the app shortcut handler unconditionally.

### Fix

[Screencast from 2026-03-20 19-10-12.webm](https://github.com/user-attachments/assets/2d9b7604-f7f4-47f9-99ff-95ee3b3c394c)

Two-layer guard: when a CLI terminal is focused and the platform modifier is held, check whether the provider has reserved the key before firing any app shortcut.

*Layer 1 -> `TerminalSessionManager.ts` (xterm key handler):*
- Looks up the active provider via `providerId` and checks `provider.reservedShortcuts`
- If the key is reserved, xterm returns `true` (keeps it for the CLI) instead of `false` (passes to app)
- On `attach()`, stamps `data-reserved-shortcuts` onto the xterm hidden textarea element

*Layer 2 -> `useKeyboardShortcuts.ts` (global `keydown` handler):*
- When the focused element is the xterm textarea, reads `target.dataset.reservedShortcuts`
- If the platform modifier is held and the key is reserved -> early `return`, skipping all app shortcuts

*`registry.ts`:*
- Adds `reservedShortcuts?: string[]` field to `ProviderDefinition` type
- Exports `READLINE_SHORTCUTS = ['e', 'k', 'n', 'p', 'b', 'o', 't']` , the 7 readline keys that conflict with Emdash app shortcuts on Linux/Windows
- Assigns `READLINE_SHORTCUTS` to all 23 CLI providers

### Conflicting keys resolved

| Key | Emdash shortcut | readline command |
|-----|----------------|-----------------|
| `e` | Toggle Editor | end-of-line |
| `k` | Command Palette | kill-to-end |
| `n` | New Task | next-history |
| `p` | Toggle Kanban | prev-history |
| `b` | Toggle Left Sidebar | backward-char |
| `o` | Open in Editor | operate-and-get-next |
| `t` | Toggle Theme | transpose-chars |

> Conflicts only occur on Linux/Windows. On macOS, Emdash uses `⌘` while readline uses `Ctrl`  -> no collision.

## Test plan

- [x] `Ctrl+E` with Copilot CLI focused -> cursor moves to end of line in terminal; Toggle Editor does not fire
- [x] `Ctrl+K` with Copilot CLI focused -> kills text to end of line; Command Palette does not open
- [x] `Ctrl+N` with Copilot CLI focused -> advances history; New Task does not fire
- [x] `Ctrl+P` with Copilot CLI focused -> goes back in history; Toggle Kanban does not fire
- [x] `Ctrl+B` with Copilot CLI focused -> cursor moves one character left; Toggle Left Sidebar does not fire
- [x] `Ctrl+O` with Copilot CLI focused -> executes history entry and advances; Open in Editor does not fire
- [x] `Ctrl+T` with Copilot CLI focused -> transposes characters; Toggle Theme does not fire
- [x] `Ctrl+E` with plain shell terminal focused (no provider) -> Toggle Editor fires normally
- [x] `Ctrl+E` with no terminal focused -> Toggle Editor fires normally
- [x] `Ctrl+Tab` / `Ctrl+Shift+Tab` (Next/Prev Task) still fire regardless of CLI focus
- [x] `Ctrl+Shift+]` / `Ctrl+Shift+[` (Next/Prev Agent) still fire regardless of CLI focus
- [x] All 23 CLI providers pass automated reserved shortcuts coverage tests

## Tests added

- `normalizeShortcutKey` __ `{`/`}` normalisation for keyboards that produce curly braces for `[`/`]`
- `READLINE_SHORTCUTS` __ contains exactly 7 keys; every key conflicts with a `cmd`-modifier app shortcut; `]` and `[` are excluded
- `Provider reservedShortcuts` __ every provider has `reservedShortcuts` defined; every provider reserves all 7 readline keys; GitHub Copilot specifically verified
- `hasShortcutConflict` __ key/modifier matching, case normalisation, curly brace normalisation

##Type of change

   New feature (non-breaking change which adds functionality)

##Mandatory Tasks

  - I have self-reviewed the code
  - A decent size PR without self-review might be rejected

##Checklist

  - I have read the contributing guide
  -  My code follows the style guidelines of this project (pnpm run format)
  -  I have commented my code, particularly in hard-to-understand areas
  -  I have checked if my PR needs changes to the documentation
  -  I have checked if my changes generate no new warnings (pnpm run lint)
  -  I have added tests that prove my fix is effective or that my feature works

