### PR TITLE
feat(workspace): replace hard provision timeout with user-dismissable

### DIFF
--- a/src/main/ipc/workspaceIpc.ts
+++ b/src/main/ipc/workspaceIpc.ts
@@ -8,10 +8,12 @@ import {
 const WORKSPACE_CHANNELS = {
   PROVISION: 'workspace:provision',
   CANCEL: 'workspace:cancel',
+  PROVISION_KEEP_WAITING: 'workspace:provision-keep-waiting',
   TERMINATE: 'workspace:terminate',
   STATUS: 'workspace:status',
   PROVISION_PROGRESS: 'workspace:provision-progress',
   PROVISION_COMPLETE: 'workspace:provision-complete',
+  PROVISION_TIMEOUT_WARNING: 'workspace:provision-timeout-warning',
 } as const;
 
 /**
@@ -41,6 +43,12 @@ export function registerWorkspaceIpc() {
       }
     }
   );
+
+  workspaceProviderService.on('provision-timeout-warning', (data: { instanceId: string }) => {
+    for (const win of BrowserWindow.getAllWindows()) {
+      win.webContents.send(WORKSPACE_CHANNELS.PROVISION_TIMEOUT_WARNING, data);
+    }
+  });
 
   // ── workspace:provision ──────────────────────────────────────────────
   ipcMain.handle(
@@ -87,6 +95,15 @@ export function registerWorkspaceIpc() {
     }
   });
 
+  // ── workspace:provision-keep-waiting ─────────────────────────────────
+  ipcMain.handle(
+    WORKSPACE_CHANNELS.PROVISION_KEEP_WAITING,
+    async (_, args: { instanceId: string }) => {
+      workspaceProviderService.onProvisionTimeoutChoice(args.instanceId, 'keep');
+      return { success: true };
+    }
+  );
+
   // ── workspace:terminate ──────────────────────────────────────────────
   ipcMain.handle(
     WORKSPACE_CHANNELS.TERMINATE,
@@ -119,7 +136,14 @@ export function registerWorkspaceIpc() {
   ipcMain.handle(WORKSPACE_CHANNELS.STATUS, async (_, args: { taskId: string }) => {
     try {
       const instance = await workspaceProviderService.getActiveInstance(args.taskId);
-      return { success: true, data: instance };
+      if (!instance) return { success: true, data: null };
+      const awaitingTimeoutChoice =
+        instance.status === 'provisioning' &&
+        workspaceProviderService.isAwaitingTimeoutChoice(instance.id);
+      return {
+        success: true,
+        data: { ...instance, awaitingTimeoutChoice },
+      };
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       log.error('[workspaceIpc] status failed', { error: message });

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -804,6 +804,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     projectPath: string;
   }) => ipcRenderer.invoke('workspace:provision', args),
   workspaceCancel: (args: { instanceId: string }) => ipcRenderer.invoke('workspace:cancel', args),
+  workspaceProvisionKeepWaiting: (args: { instanceId: string }) =>
+    ipcRenderer.invoke('workspace:provision-keep-waiting', args),
   workspaceTerminate: (args: {
     instanceId: string;
     terminateCommand: string;
@@ -828,6 +830,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
       _: Electron.IpcRendererEvent,
       data: { instanceId: string; status: string; error?: string }
     ) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onWorkspaceProvisionTimeoutWarning: (listener: (data: { instanceId: string }) => void) => {
+    const channel = 'workspace:provision-timeout-warning';
+    const wrapped = (_: Electron.IpcRendererEvent, data: { instanceId: string }) => listener(data);
     ipcRenderer.on(channel, wrapped);
     return () => ipcRenderer.removeListener(channel, wrapped);
   },

--- a/src/main/services/WorkspaceProviderService.ts
+++ b/src/main/services/WorkspaceProviderService.ts
@@ -8,8 +8,11 @@ import { workspaceInstances, sshConnections, type WorkspaceInstanceRow } from '.
 import { eq, and, inArray } from 'drizzle-orm';
 import { sshService } from './ssh/SshService';
 
-/** Default timeout for provision/terminate scripts (5 minutes). */
-const PROVISION_TIMEOUT_MS = 5 * 60 * 1000;
+/** Time after which we show a warning and let the user choose to keep waiting or cancel. */
+const PROVISION_WARNING_MS = 5 * 60 * 1000;
+
+/** Safety cap when user chooses to keep waiting (2 hours). */
+const PROVISION_EXTENDED_TIMEOUT_MS = 2 * 60 * 60 * 1000;
 
 /** Default timeout for terminate scripts (2 minutes). */
 const TERMINATE_TIMEOUT_MS = 2 * 60 * 1000;
@@ -49,10 +52,17 @@ export interface TerminateConfig {
  *
  * - `provision-progress`  { instanceId, line }
  * - `provision-complete`  { instanceId, status, error? }
+ * - `provision-timeout-warning`  { instanceId }  (user may keep waiting or cancel)
  */
 export class WorkspaceProviderService extends EventEmitter {
   /** In-flight provision processes keyed by instanceId. */
   private provisionProcesses = new Map<string, ChildProcess>();
+
+  /** InstanceIds that have hit the warning threshold and are awaiting user choice. */
+  private awaitingTimeoutChoice = new Set<string>();
+
+  /** Resolvers for the user's keep/cancel choice, keyed by instanceId. */
+  private provisionTimeoutResolvers = new Map<string, (choice: 'keep' | 'cancel') => void>();
 
   // ---------------------------------------------------------------------------
   // Provision
@@ -95,12 +105,33 @@ export class WorkspaceProviderService extends EventEmitter {
 
   /** Cancel an in-flight provision by killing the child process. */
   async cancel(instanceId: string): Promise<void> {
+    const resolver = this.provisionTimeoutResolvers.get(instanceId);
+    if (resolver) {
+      resolver('cancel');
+      this.provisionTimeoutResolvers.delete(instanceId);
+      this.awaitingTimeoutChoice.delete(instanceId);
+    }
     const child = this.provisionProcesses.get(instanceId);
     if (child) {
       child.kill('SIGTERM');
       this.provisionProcesses.delete(instanceId);
     }
     await this.updateStatus(instanceId, 'error');
+  }
+
+  /** Called when user chooses to keep waiting after the timeout warning. */
+  onProvisionTimeoutChoice(instanceId: string, choice: 'keep' | 'cancel'): void {
+    const resolver = this.provisionTimeoutResolvers.get(instanceId);
+    if (resolver) {
+      resolver(choice);
+      this.provisionTimeoutResolvers.delete(instanceId);
+      this.awaitingTimeoutChoice.delete(instanceId);
+    }
+  }
+
+  /** Whether the given instance is awaiting user choice after timeout warning. */
+  isAwaitingTimeoutChoice(instanceId: string): boolean {
+    return this.awaitingTimeoutChoice.has(instanceId);
   }
 
   // ---------------------------------------------------------------------------
@@ -255,20 +286,16 @@ export class WorkspaceProviderService extends EventEmitter {
     let stderr = '';
 
     try {
-      const result = await this.runScript({
+      const result = await this.runProvisionScript(instanceId, {
         command: config.provisionCommand,
         cwd: config.projectPath,
         envVars,
-        timeoutMs: PROVISION_TIMEOUT_MS,
         onStderr: (line) => {
           stderr += line;
           this.emit('provision-progress', { instanceId, line });
         },
         onStdout: (data) => {
           stdout += data;
-        },
-        trackProcess: (child) => {
-          this.provisionProcesses.set(instanceId, child);
         },
       });
 
@@ -320,7 +347,93 @@ export class WorkspaceProviderService extends EventEmitter {
   }
 
   // ---------------------------------------------------------------------------
-  // Internal: script runner
+  // Internal: provision script runner (timeout warning instead of hard kill)
+  // ---------------------------------------------------------------------------
+
+  private runProvisionScript(
+    instanceId: string,
+    opts: {
+      command: string;
+      cwd: string;
+      envVars: Record<string, string>;
+      onStderr?: (line: string) => void;
+      onStdout?: (data: string) => void;
+    }
+  ): Promise<{ exitCode: number }> {
+    return new Promise((resolve, reject) => {
+      const env = { ...process.env, ...opts.envVars };
+      const child = spawn('bash', ['-c', opts.command], {
+        cwd: opts.cwd,
+        env,
+        stdio: ['ignore', 'pipe', 'pipe'],
+      });
+
+      this.provisionProcesses.set(instanceId, child);
+
+      let settled = false;
+      let warningTimer: ReturnType<typeof setTimeout> | null = null;
+      let extendedTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const finish = (result: { exitCode: number } | Error) => {
+        if (settled) return;
+        settled = true;
+        this.awaitingTimeoutChoice.delete(instanceId);
+        const resolver = this.provisionTimeoutResolvers.get(instanceId);
+        if (resolver) {
+          resolver('keep');
+          this.provisionTimeoutResolvers.delete(instanceId);
+        }
+        if (warningTimer) clearTimeout(warningTimer);
+        if (extendedTimer) clearTimeout(extendedTimer);
+        if (result instanceof Error) {
+          reject(result);
+        } else {
+          resolve(result);
+        }
+      };
+
+      warningTimer = setTimeout(async () => {
+        if (settled) return;
+        this.emit('provision-timeout-warning', { instanceId });
+        this.awaitingTimeoutChoice.add(instanceId);
+        const choice = await new Promise<'keep' | 'cancel'>((res) => {
+          this.provisionTimeoutResolvers.set(instanceId, res);
+        });
+        if (settled) return;
+        if (choice === 'cancel') {
+          child.kill('SIGTERM');
+          finish(new Error('Provision cancelled by user'));
+        } else {
+          extendedTimer = setTimeout(() => {
+            child.kill('SIGTERM');
+            finish(new Error(`Provision script timed out after extended wait`));
+          }, PROVISION_EXTENDED_TIMEOUT_MS);
+        }
+      }, PROVISION_WARNING_MS);
+
+      child.stdout?.on('data', (buf: Buffer) => {
+        opts.onStdout?.(buf.toString('utf-8'));
+      });
+
+      child.stderr?.on('data', (buf: Buffer) => {
+        const text = buf.toString('utf-8');
+        for (const line of text.split('\n')) {
+          if (line.trim()) opts.onStderr?.(line);
+        }
+      });
+
+      child.on('error', (err) => {
+        finish(new Error(`Failed to spawn script: ${err.message}`));
+      });
+
+      child.on('exit', (code) => {
+        finish({ exitCode: code ?? -1 });
+      });
+    });
+  }
+
+  // ---------------------------------------------------------------------------
+  // Internal: script runner (used for terminate; hard timeout)
   // ---------------------------------------------------------------------------
 
   private runScript(opts: {

--- a/src/renderer/components/WorkspaceProvisioningOverlay.tsx
+++ b/src/renderer/components/WorkspaceProvisioningOverlay.tsx
@@ -23,9 +23,9 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
   const [status, setStatus] = useState<ProvisioningStatus>(null);
   const [lines, setLines] = useState<string[]>(() => getProvisionLogs(task.id));
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showTimeoutWarning, setShowTimeoutWarning] = useState(false);
   const { toast } = useToast();
   const logEndRef = useRef<HTMLDivElement>(null);
-  // Track the instanceId so we can filter events for this task's workspace only
   const instanceIdRef = useRef<string | null>(null);
 
   // Check workspace status on mount / task change
@@ -43,11 +43,14 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
         instanceIdRef.current = instance.id;
         if (instance.status === 'provisioning') {
           setStatus('provisioning');
+          setShowTimeoutWarning(!!instance.awaitingTimeoutChoice);
         } else if (instance.status === 'error') {
           setStatus('error');
+          setShowTimeoutWarning(false);
           setErrorMessage('Workspace provisioning failed.');
         } else if (instance.status === 'ready') {
           setStatus('ready');
+          setShowTimeoutWarning(false);
         } else {
           setStatus(null);
         }
@@ -75,18 +78,28 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
         if (instanceIdRef.current && data.instanceId !== instanceIdRef.current) return;
         if (data.status === 'ready') {
           setStatus('ready');
+          setShowTimeoutWarning(false);
           clearProvisionLogs(task.id);
           toast({ title: 'Workspace connected', description: 'Remote workspace is ready.' });
         } else {
           setStatus('error');
+          setShowTimeoutWarning(false);
           setErrorMessage(data.error || 'Workspace provisioning failed.');
         }
+      }
+    );
+
+    const unsubTimeoutWarning = window.electronAPI.onWorkspaceProvisionTimeoutWarning(
+      (data: { instanceId: string }) => {
+        if (instanceIdRef.current && data.instanceId !== instanceIdRef.current) return;
+        setShowTimeoutWarning(true);
       }
     );
 
     return () => {
       unsubProgress();
       unsubComplete();
+      unsubTimeoutWarning();
     };
   }, []);
 
@@ -101,6 +114,7 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
 
     setStatus('provisioning');
     setLines([]);
+    setShowTimeoutWarning(false);
     clearProvisionLogs(task.id);
     setErrorMessage(null);
 
@@ -135,6 +149,20 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
     }
   }, [task.id]);
 
+  const handleKeepWaiting = useCallback(async () => {
+    try {
+      const result = await window.electronAPI.workspaceStatus({ taskId: task.id });
+      if (result.success && result.data) {
+        await window.electronAPI.workspaceProvisionKeepWaiting({
+          instanceId: result.data.id,
+        });
+        setShowTimeoutWarning(false);
+      }
+    } catch {
+      // Best effort
+    }
+  }, [task.id]);
+
   // Don't render if no workspace or provisioning is complete
   if (!task.metadata?.workspace) return null;
   if (status === 'ready' || status === null) return null;
@@ -150,9 +178,25 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
         <>
           <Spinner size="lg" />
           <p className="text-sm font-medium text-foreground">Provisioning workspace...</p>
-          <p className="text-xs text-muted-foreground">
-            Running provision script. This may take a few minutes.
-          </p>
+          {showTimeoutWarning ? (
+            <div className="flex flex-col items-center gap-3">
+              <p className="text-xs text-amber-600 dark:text-amber-500">
+                Provisioning is taking longer than expected.
+              </p>
+              <div className="flex gap-2">
+                <Button variant="default" size="sm" onClick={handleKeepWaiting}>
+                  Keep waiting
+                </Button>
+                <Button variant="outline" size="sm" onClick={handleCancel}>
+                  Cancel
+                </Button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-xs text-muted-foreground">
+              Running provision script. This may take a few minutes.
+            </p>
+          )}
         </>
       )}
 
@@ -182,7 +226,7 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
         </div>
       )}
 
-      {status === 'provisioning' && (
+      {status === 'provisioning' && !showTimeoutWarning && (
         <Button variant="ghost" size="sm" className="text-xs" onClick={handleCancel}>
           Cancel
         </Button>

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1952,6 +1952,9 @@ export interface ElectronAPI {
     projectPath: string;
   }) => Promise<{ success: boolean; data?: { instanceId: string }; error?: string }>;
   workspaceCancel: (args: { instanceId: string }) => Promise<{ success: boolean; error?: string }>;
+  workspaceProvisionKeepWaiting: (args: {
+    instanceId: string;
+  }) => Promise<{ success: boolean; error?: string }>;
   workspaceTerminate: (args: {
     instanceId: string;
     terminateCommand: string;
@@ -1980,6 +1983,9 @@ export interface ElectronAPI {
   ) => () => void;
   onWorkspaceProvisionComplete: (
     listener: (data: { instanceId: string; status: string; error?: string }) => void
+  ) => () => void;
+  onWorkspaceProvisionTimeoutWarning: (
+    listener: (data: { instanceId: string }) => void
   ) => () => void;
 
   // MCP

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -461,6 +461,9 @@ declare global {
       workspaceCancel: (args: {
         instanceId: string;
       }) => Promise<{ success: boolean; error?: string }>;
+      workspaceProvisionKeepWaiting: (args: {
+        instanceId: string;
+      }) => Promise<{ success: boolean; error?: string }>;
       workspaceTerminate: (args: {
         instanceId: string;
         terminateCommand: string;
@@ -481,6 +484,7 @@ declare global {
           connectionId: string | null;
           createdAt: number;
           terminatedAt: number | null;
+          awaitingTimeoutChoice?: boolean;
         } | null;
         error?: string;
       }>;
@@ -489,6 +493,9 @@ declare global {
       ) => () => void;
       onWorkspaceProvisionComplete: (
         listener: (data: { instanceId: string; status: string; error?: string }) => void
+      ) => () => void;
+      onWorkspaceProvisionTimeoutWarning: (
+        listener: (data: { instanceId: string }) => void
       ) => () => void;
     };
   }


### PR DESCRIPTION
### summary

- Replace the hard 5-minute workspace provisioning kill with a warning + user choice (keep waiting or cancel), so large repos can finish provisioning.

### Fixes

Fixes #1553

### Snapshot
N/A

### Type of change
[x] Bug fix

### Mandatory Tasks
[x] Self-reviewed

### Checklist
[x] pnpm run format
[x] pnpm run lint
[x] Tests added/updated and passing

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Extended workspace provisioning timeout handling: When workspace provisioning takes longer than expected, a timeout warning appears with "Keep waiting" and "Cancel" options, giving users control over long-running operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->