### PR TITLE
fix(pty): restore workspace cwd for SSH terminal sessions

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -742,7 +742,7 @@ export function registerPtyIpc(): void {
           const remoteTmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
 
           const remoteInit = buildRemoteInitKeystrokes({
-            cwd: undefined,
+            cwd,
             tmux: remoteTmuxOpt,
           });
           if (remoteInit) {
@@ -1278,7 +1278,7 @@ export function registerPtyIpc(): void {
           const tmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
 
           const remoteInit = buildRemoteInitKeystrokes({
-            cwd: undefined,
+            cwd,
             provider: remoteProvider,
             tmux: tmuxOpt,
             preProviderCommands: preProviderCommands.length ? preProviderCommands : undefined,


### PR DESCRIPTION
## Summary

- Fixes the working directory for all workspace provider SSH sessions
- Commit `1b52cf4d` (Mar 10) accidentally changed `cwd` to `cwd: undefined` in both `pty:start` and `pty:startDirect` when calling `buildRemoteInitKeystrokes`
- This caused tmux to start a fresh shell in `~` instead of `cd`-ing to the workspace path (e.g. `/dd/dd-source`)
- Every workspace provider task has been broken since — this is what Simon and dbd reported

## Test plan

- [ ] Kill all tmux sessions (`tmux kill-server`)
- [ ] Create a workspace provider task
- [ ] After provisioning, verify `pwd` shows the workspace path (not `~`)
- [ ] Verify regular SSH projects still work

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remote terminal sessions not respecting the specified working directory on startup. Remote PTY connections now correctly initialize in the intended directory when provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->