### PR TITLE
refactor(workspace): replace hard timeout with warning for provisioning

### DIFF
--- a/src/main/ipc/workspaceIpc.ts
+++ b/src/main/ipc/workspaceIpc.ts
@@ -11,6 +11,7 @@ const WORKSPACE_CHANNELS = {
   TERMINATE: 'workspace:terminate',
   STATUS: 'workspace:status',
   PROVISION_PROGRESS: 'workspace:provision-progress',
+  PROVISION_TIMEOUT_WARNING: 'workspace:provision-timeout-warning',
   PROVISION_COMPLETE: 'workspace:provision-complete',
 } as const;
 
@@ -29,6 +30,15 @@ export function registerWorkspaceIpc() {
     (data: { instanceId: string; line: string }) => {
       for (const win of BrowserWindow.getAllWindows()) {
         win.webContents.send(WORKSPACE_CHANNELS.PROVISION_PROGRESS, data);
+      }
+    }
+  );
+
+  workspaceProviderService.on(
+    'provision-timeout-warning',
+    (data: { instanceId: string; timeoutMs: number }) => {
+      for (const win of BrowserWindow.getAllWindows()) {
+        win.webContents.send(WORKSPACE_CHANNELS.PROVISION_TIMEOUT_WARNING, data);
       }
     }
   );

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -820,6 +820,17 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on(channel, wrapped);
     return () => ipcRenderer.removeListener(channel, wrapped);
   },
+  onWorkspaceProvisionTimeoutWarning: (
+    listener: (data: { instanceId: string; timeoutMs: number }) => void
+  ) => {
+    const channel = 'workspace:provision-timeout-warning';
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: { instanceId: string; timeoutMs: number }
+    ) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
   onWorkspaceProvisionComplete: (
     listener: (data: { instanceId: string; status: string; error?: string }) => void
   ) => {

--- a/src/main/services/WorkspaceProviderService.ts
+++ b/src/main/services/WorkspaceProviderService.ts
@@ -8,8 +8,8 @@ import { workspaceInstances, sshConnections, type WorkspaceInstanceRow } from '.
 import { eq, and, inArray } from 'drizzle-orm';
 import { sshService } from './ssh/SshService';
 
-/** Default timeout for provision/terminate scripts (5 minutes). */
-const PROVISION_TIMEOUT_MS = 5 * 60 * 1000;
+/** Show a warning if provisioning exceeds 5 minutes. */
+const PROVISION_WARNING_TIMEOUT_MS = 5 * 60 * 1000;
 
 /** Default timeout for terminate scripts (2 minutes). */
 const TERMINATE_TIMEOUT_MS = 2 * 60 * 1000;
@@ -48,11 +48,14 @@ export interface TerminateConfig {
  * shell scripts.  Emits events so the renderer can stream progress:
  *
  * - `provision-progress`  { instanceId, line }
+ * - `provision-timeout-warning`  { instanceId, timeoutMs }
  * - `provision-complete`  { instanceId, status, error? }
  */
 export class WorkspaceProviderService extends EventEmitter {
   /** In-flight provision processes keyed by instanceId. */
   private provisionProcesses = new Map<string, ChildProcess>();
+  /** Provision attempts the user has explicitly cancelled. */
+  private cancelledProvisionIds = new Set<string>();
 
   // ---------------------------------------------------------------------------
   // Provision
@@ -95,6 +98,7 @@ export class WorkspaceProviderService extends EventEmitter {
 
   /** Cancel an in-flight provision by killing the child process. */
   async cancel(instanceId: string): Promise<void> {
+    this.cancelledProvisionIds.add(instanceId);
     const child = this.provisionProcesses.get(instanceId);
     if (child) {
       child.kill('SIGTERM');
@@ -132,7 +136,7 @@ export class WorkspaceProviderService extends EventEmitter {
         command: config.terminateCommand,
         cwd: config.projectPath,
         envVars,
-        timeoutMs: TERMINATE_TIMEOUT_MS,
+        hardTimeoutMs: TERMINATE_TIMEOUT_MS,
         onStderr: (line) => stderrLines.push(line),
       });
 
@@ -259,7 +263,13 @@ export class WorkspaceProviderService extends EventEmitter {
         command: config.provisionCommand,
         cwd: config.projectPath,
         envVars,
-        timeoutMs: PROVISION_TIMEOUT_MS,
+        warningTimeoutMs: PROVISION_WARNING_TIMEOUT_MS,
+        onTimeoutWarning: () => {
+          this.emit('provision-timeout-warning', {
+            instanceId,
+            timeoutMs: PROVISION_WARNING_TIMEOUT_MS,
+          });
+        },
         onStderr: (line) => {
           stderr += line;
           this.emit('provision-progress', { instanceId, line });
@@ -269,6 +279,9 @@ export class WorkspaceProviderService extends EventEmitter {
         },
         trackProcess: (child) => {
           this.provisionProcesses.set(instanceId, child);
+          if (this.cancelledProvisionIds.has(instanceId)) {
+            child.kill('SIGTERM');
+          }
         },
       });
 
@@ -276,10 +289,15 @@ export class WorkspaceProviderService extends EventEmitter {
       this.provisionProcesses.delete(instanceId);
 
       if (result.exitCode !== 0) {
+        if (this.cancelledProvisionIds.has(instanceId)) {
+          throw new Error('Workspace provisioning was cancelled.');
+        }
         throw new Error(
           `Provision script exited with code ${result.exitCode}.\n${stderr.slice(-500)}`
         );
       }
+
+      this.cancelledProvisionIds.delete(instanceId);
 
       // Parse the JSON output from stdout.
       const output = this.parseProvisionOutput(stdout);
@@ -311,10 +329,23 @@ export class WorkspaceProviderService extends EventEmitter {
       this.emit('provision-complete', { instanceId, status: 'ready' });
     } catch (err) {
       this.provisionProcesses.delete(instanceId);
-      const message = err instanceof Error ? err.message : String(err);
-      log.error('[WorkspaceProvider] Provision failed', { instanceId, error: message });
+      const wasCancelled = this.cancelledProvisionIds.delete(instanceId);
+      const message = wasCancelled
+        ? 'Workspace provisioning was cancelled.'
+        : err instanceof Error
+          ? err.message
+          : String(err);
+
+      if (wasCancelled) {
+        log.info('[WorkspaceProvider] Provision cancelled', { instanceId });
+      } else {
+        log.error('[WorkspaceProvider] Provision failed', { instanceId, error: message });
+      }
+
       await this.updateStatus(instanceId, 'error');
-      capture('workspace_provisioning_failed', { error_type: 'provision' });
+      if (!wasCancelled) {
+        capture('workspace_provisioning_failed', { error_type: 'provision' });
+      }
       this.emit('provision-complete', { instanceId, status: 'error', error: message });
     }
   }
@@ -327,7 +358,9 @@ export class WorkspaceProviderService extends EventEmitter {
     command: string;
     cwd: string;
     envVars: Record<string, string>;
-    timeoutMs: number;
+    hardTimeoutMs?: number;
+    warningTimeoutMs?: number;
+    onTimeoutWarning?: () => void;
     onStderr?: (line: string) => void;
     onStdout?: (data: string) => void;
     trackProcess?: (child: ChildProcess) => void;
@@ -347,7 +380,8 @@ export class WorkspaceProviderService extends EventEmitter {
       const finish = (result: { exitCode: number } | Error) => {
         if (settled) return;
         settled = true;
-        clearTimeout(timer);
+        clearTimeout(hardTimeoutTimer);
+        clearTimeout(warningTimer);
         if (result instanceof Error) {
           reject(result);
         } else {
@@ -355,10 +389,21 @@ export class WorkspaceProviderService extends EventEmitter {
         }
       };
 
-      const timer = setTimeout(() => {
-        child.kill('SIGTERM');
-        finish(new Error(`Script timed out after ${opts.timeoutMs / 1000}s`));
-      }, opts.timeoutMs);
+      const hardTimeoutMs = opts.hardTimeoutMs;
+      const hardTimeoutTimer =
+        hardTimeoutMs == null
+          ? undefined
+          : setTimeout(() => {
+              child.kill('SIGTERM');
+              finish(new Error(`Script timed out after ${hardTimeoutMs / 1000}s`));
+            }, hardTimeoutMs);
+
+      const warningTimer =
+        opts.warningTimeoutMs == null
+          ? undefined
+          : setTimeout(() => {
+              opts.onTimeoutWarning?.();
+            }, opts.warningTimeoutMs);
 
       child.stdout?.on('data', (buf: Buffer) => {
         opts.onStdout?.(buf.toString('utf-8'));

--- a/src/renderer/components/WorkspaceProvisioningOverlay.tsx
+++ b/src/renderer/components/WorkspaceProvisioningOverlay.tsx
@@ -1,5 +1,4 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
-import { Spinner } from './ui/spinner';
 import { Button } from './ui/button';
 import { cn } from '@/lib/utils';
 import type { Task } from '../types/app';
@@ -23,6 +22,8 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
   const [status, setStatus] = useState<ProvisioningStatus>(null);
   const [lines, setLines] = useState<string[]>(() => getProvisionLogs(task.id));
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [showTimeoutWarning, setShowTimeoutWarning] = useState(false);
+  const [dotCount, setDotCount] = useState(1);
   const { toast } = useToast();
   const logEndRef = useRef<HTMLDivElement>(null);
   // Track the instanceId so we can filter events for this task's workspace only
@@ -31,6 +32,11 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
   // Check workspace status on mount / task change
   useEffect(() => {
     let cancelled = false;
+    instanceIdRef.current = null;
+    setLines(getProvisionLogs(task.id));
+    setErrorMessage(null);
+    setShowTimeoutWarning(false);
+
     void (async () => {
       try {
         const result = await window.electronAPI.workspaceStatus({ taskId: task.id });
@@ -70,9 +76,17 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
       }
     );
 
+    const unsubTimeoutWarning = window.electronAPI.onWorkspaceProvisionTimeoutWarning(
+      (data: { instanceId: string; timeoutMs: number }) => {
+        if (instanceIdRef.current && data.instanceId !== instanceIdRef.current) return;
+        setShowTimeoutWarning(true);
+      }
+    );
+
     const unsubComplete = window.electronAPI.onWorkspaceProvisionComplete(
       (data: { instanceId: string; status: string; error?: string }) => {
         if (instanceIdRef.current && data.instanceId !== instanceIdRef.current) return;
+        setShowTimeoutWarning(false);
         if (data.status === 'ready') {
           setStatus('ready');
           clearProvisionLogs(task.id);
@@ -86,14 +100,28 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
 
     return () => {
       unsubProgress();
+      unsubTimeoutWarning();
       unsubComplete();
     };
-  }, []);
+  }, [task.id, toast]);
 
   // Auto-scroll log to bottom
   useEffect(() => {
     logEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [lines]);
+
+  useEffect(() => {
+    if (status !== 'provisioning') {
+      setDotCount(1);
+      return;
+    }
+
+    const interval = window.setInterval(() => {
+      setDotCount((count) => (count === 3 ? 1 : count + 1));
+    }, 500);
+
+    return () => window.clearInterval(interval);
+  }, [status]);
 
   const handleRetry = useCallback(() => {
     const workspaceConfig = task.metadata?.workspace;
@@ -103,6 +131,7 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
     setLines([]);
     clearProvisionLogs(task.id);
     setErrorMessage(null);
+    setShowTimeoutWarning(false);
 
     void window.electronAPI
       .workspaceProvision({
@@ -124,6 +153,10 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
       });
   }, [task, project]);
 
+  const handleKeepWaiting = useCallback(() => {
+    setShowTimeoutWarning(false);
+  }, []);
+
   const handleCancel = useCallback(async () => {
     try {
       const result = await window.electronAPI.workspaceStatus({ taskId: task.id });
@@ -142,51 +175,75 @@ const WorkspaceProvisioningOverlay: React.FC<WorkspaceProvisioningOverlayProps> 
   return (
     <div
       className={cn(
-        'absolute inset-0 z-10 flex flex-col items-center justify-center gap-4 bg-background p-6',
+        'absolute inset-0 z-10 flex items-center justify-center bg-background p-6',
         className
       )}
     >
-      {status === 'provisioning' && (
-        <>
-          <Spinner size="lg" />
-          <p className="text-sm font-medium text-foreground">Provisioning workspace...</p>
-          <p className="text-xs text-muted-foreground">
-            Running provision script. This may take a few minutes.
-          </p>
-        </>
-      )}
-
-      {status === 'error' && (
-        <>
-          <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
-            {errorMessage || 'Workspace provisioning failed.'}
-          </div>
-          <div className="flex gap-2">
-            <Button variant="outline" size="sm" onClick={handleRetry}>
-              Retry
-            </Button>
-          </div>
-        </>
-      )}
-
-      {lines.length > 0 && (
-        <div className="w-full max-w-xl">
-          <div className="max-h-48 overflow-y-auto rounded-md border bg-muted/50 p-3 font-mono text-xs text-muted-foreground">
-            {lines.map((line, i) => (
-              <div key={i} className="whitespace-pre-wrap">
-                {line}
+      <div className="flex w-full max-w-xl flex-col items-start gap-4 text-left">
+        {status === 'provisioning' && (
+          <>
+            <div className="flex flex-col items-start gap-3">
+              <div className="space-y-1">
+                <p className="text-sm font-medium text-foreground">
+                  Provisioning workspace{'.'.repeat(dotCount)}
+                </p>
+                <p className="text-xs text-muted-foreground">
+                  Running provision script. This may take a few minutes.
+                </p>
               </div>
-            ))}
-            <div ref={logEndRef} />
-          </div>
-        </div>
-      )}
+            </div>
+            {showTimeoutWarning && (
+              <div className="w-full rounded-xl border border-border/70 bg-background/95 px-4 py-3 text-sm text-foreground shadow-sm">
+                <p className="font-medium">Provisioning is taking longer than expected.</p>
+                <p className="mt-1 text-xs text-muted-foreground">
+                  The provision script is still running. Large repositories can take longer than
+                  five minutes to prepare.
+                </p>
+                <div className="mt-3 flex gap-2">
+                  <Button size="sm" variant="outline" onClick={handleKeepWaiting}>
+                    Keep waiting
+                  </Button>
+                  <Button size="sm" variant="outline" onClick={handleCancel}>
+                    Cancel
+                  </Button>
+                </div>
+              </div>
+            )}
+          </>
+        )}
 
-      {status === 'provisioning' && (
-        <Button variant="ghost" size="sm" className="text-xs" onClick={handleCancel}>
-          Cancel
-        </Button>
-      )}
+        {status === 'error' && (
+          <div className="flex flex-wrap items-center gap-3">
+            <div className="rounded-md bg-destructive/10 p-3 text-sm text-destructive">
+              {errorMessage || 'Workspace provisioning failed.'}
+            </div>
+            <div className="flex gap-2">
+              <Button variant="outline" size="sm" onClick={handleRetry}>
+                Retry
+              </Button>
+            </div>
+          </div>
+        )}
+
+        {lines.length > 0 && (
+          <div className="w-full">
+            <div className="max-h-48 overflow-y-auto rounded-md border bg-muted/50 p-3 font-mono text-xs text-muted-foreground">
+              {lines.map((line, i) => (
+                <div key={i} className="whitespace-pre-wrap">
+                  {line}
+                </div>
+              ))}
+              <div ref={logEndRef} />
+            </div>
+          </div>
+        )}
+
+        {status === 'provisioning' && !showTimeoutWarning && (
+          <Button variant="ghost" size="sm" className="text-xs" onClick={handleCancel}>
+            Cancel
+          </Button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1301,6 +1301,9 @@ declare global {
       onWorkspaceProvisionProgress: (
         listener: (data: { instanceId: string; line: string }) => void
       ) => () => void;
+      onWorkspaceProvisionTimeoutWarning: (
+        listener: (data: { instanceId: string; timeoutMs: number }) => void
+      ) => () => void;
       onWorkspaceProvisionComplete: (
         listener: (data: { instanceId: string; status: string; error?: string }) => void
       ) => () => void;
@@ -1977,6 +1980,9 @@ export interface ElectronAPI {
   }>;
   onWorkspaceProvisionProgress: (
     listener: (data: { instanceId: string; line: string }) => void
+  ) => () => void;
+  onWorkspaceProvisionTimeoutWarning: (
+    listener: (data: { instanceId: string; timeoutMs: number }) => void
   ) => () => void;
   onWorkspaceProvisionComplete: (
     listener: (data: { instanceId: string; status: string; error?: string }) => void

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -487,6 +487,9 @@ declare global {
       onWorkspaceProvisionProgress: (
         listener: (data: { instanceId: string; line: string }) => void
       ) => () => void;
+      onWorkspaceProvisionTimeoutWarning: (
+        listener: (data: { instanceId: string; timeoutMs: number }) => void
+      ) => () => void;
       onWorkspaceProvisionComplete: (
         listener: (data: { instanceId: string; status: string; error?: string }) => void
       ) => () => void;

--- a/src/test/main/WorkspaceProviderService.test.ts
+++ b/src/test/main/WorkspaceProviderService.test.ts
@@ -259,6 +259,55 @@ describe('WorkspaceProviderService', () => {
       expect(events[0].error).toContain('exited with code 1');
     });
 
+    it('emits a timeout warning without killing the provision process', async () => {
+      vi.useFakeTimers();
+      try {
+        vi.resetModules();
+        const child = createChild();
+        spawnMock.mockReturnValue(child);
+
+        const { workspaceProviderService } = await import(
+          '../../main/services/WorkspaceProviderService'
+        );
+
+        const warnings: any[] = [];
+        const events: any[] = [];
+        workspaceProviderService.on('provision-timeout-warning', (evt: any) => warnings.push(evt));
+        workspaceProviderService.on('provision-complete', (evt: any) => events.push(evt));
+
+        await workspaceProviderService.provision({
+          taskId: 'task-timeout-warning',
+          repoUrl: 'git@github.com:org/repo.git',
+          branch: 'emdash/long-provision',
+          baseRef: 'main',
+          provisionCommand: './provision.sh',
+          projectPath: '/project',
+        });
+
+        await vi.advanceTimersByTimeAsync(5 * 60 * 1000);
+
+        expect(warnings).toHaveLength(1);
+        expect(warnings[0]).toEqual(
+          expect.objectContaining({
+            instanceId: expect.any(String),
+            timeoutMs: expect.any(Number),
+          })
+        );
+        expect(warnings[0].timeoutMs).toBeGreaterThan(0);
+        expect(child.killed).toBe(false);
+
+        child.stdout.emit('data', Buffer.from('{"host": "workspace-test-timeout"}'));
+        child.emit('exit', 0);
+
+        await vi.advanceTimersByTimeAsync(0);
+
+        expect(events).toHaveLength(1);
+        expect(events[0].status).toBe('ready');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('streams stderr lines as provision-progress events', async () => {
       vi.resetModules();
       const child = createChild();
@@ -384,6 +433,43 @@ describe('WorkspaceProviderService', () => {
 
       expect(child.killed).toBe(true);
       expect(updateMock).toHaveBeenCalledWith(expect.objectContaining({ status: 'error' }));
+    });
+
+    it('emits a cancelled message instead of a generic exit code error', async () => {
+      vi.resetModules();
+      const child = createChild();
+      spawnMock.mockReturnValue(child);
+
+      const { workspaceProviderService } = await import(
+        '../../main/services/WorkspaceProviderService'
+      );
+
+      const events: any[] = [];
+      workspaceProviderService.on('provision-complete', (evt: any) => events.push(evt));
+
+      const instanceId = await workspaceProviderService.provision({
+        taskId: 'task-cancel-message',
+        repoUrl: 'git@github.com:org/repo.git',
+        branch: 'emdash/cancel-message-test',
+        baseRef: 'main',
+        provisionCommand: './provision.sh',
+        projectPath: '/project',
+      });
+
+      await new Promise((r) => setTimeout(r, 50));
+
+      await workspaceProviderService.cancel(instanceId);
+      child.emit('exit', -1);
+
+      await new Promise((r) => setTimeout(r, 100));
+
+      expect(events).toContainEqual(
+        expect.objectContaining({
+          instanceId,
+          status: 'error',
+          error: 'Workspace provisioning was cancelled.',
+        })
+      );
     });
   });
 


### PR DESCRIPTION
## Summary

- Replace the hard 5-minute provisioning timeout with a soft warning that lets the process keep running
- Add a `provision-timeout-warning` IPC event so the renderer can show a non-blocking notification
- Show an inline timeout warning in `WorkspaceProvisioningOverlay` with "Keep waiting" and "Cancel" options instead of killing the process
- Track cancelled provisions explicitly so the error message says "cancelled" instead of a generic exit code error
- Retain a hard timeout only for terminate scripts (2 minutes)

## Changes

- `WorkspaceProviderService`: split `timeoutMs` into `hardTimeoutMs` (terminate only) and `warningTimeoutMs` + `onTimeoutWarning` callback (provision); track `cancelledProvisionIds` for clean cancellation messaging
- `workspaceIpc.ts` / `preload.ts` / type declarations: wire up new `workspace:provision-timeout-warning` IPC channel
- `WorkspaceProvisioningOverlay`: show animated provisioning dots, display a timeout warning card with keep-waiting/cancel actions, reset state properly on task change
- Added tests for the timeout warning emission and cancelled-provision error message

## Test plan

- `pnpm exec vitest run src/test/main/WorkspaceProviderService.test.ts` passes new and existing tests
- Verify provisioning overlay shows the warning after 5 minutes and allows dismissing or cancelling
- Verify cancelling a provision shows "cancelled" rather than a script exit code error

<!-- emdash-issue-footer:start -->
Fixes GEN-642
<!-- emdash-issue-footer:end -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a timeout warning during workspace provisioning, allowing users to continue waiting or cancel the operation.
  * Introduced animated visual feedback during the provisioning process.

* **Improvements**
  * Enhanced cancellation handling with clearer user-facing error messages for cancelled provisioning attempts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->