### PR TITLE
feat(settings): add toggle to disable auto-close linked issues on PR creation

### DIFF
--- a/docs/content/docs/issues.mdx
+++ b/docs/content/docs/issues.mdx
@@ -63,4 +63,6 @@ GitHub Issues requires the GitHub CLI (`gh`). Emdash auto-installs it if missing
 
 ## Auto-Closing Issues
 
-When you create a PR from a task that has a linked issue, Emdash automatically closes the associated GitHub or Linear issue. This only applies to issues that were passed to the task at creation time.
+When you create a PR from a task that has a linked issue, Emdash automatically closes the associated GitHub or Linear issue by default. This only applies to issues that were passed to the task at creation time.
+
+If your workflow closes issues later, after environment testing, deployment, or customer approval, you can disable this in **Settings → Repository → Auto-close linked issues on PR creation**.

--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -26,6 +26,7 @@ import { databaseService } from '../services/DatabaseService';
 import { injectIssueFooter } from '../lib/prIssueFooter';
 import { getCreatePrBodyPlan } from '../lib/prCreateBodyPlan';
 import { patchCurrentPrBodyWithIssueFooter } from '../lib/prIssueFooterPatch';
+import { getAppSettings } from '../settings';
 import {
   resolveRemoteProjectForWorktreePath,
   resolveRemoteContext,
@@ -58,6 +59,10 @@ type RemoteStatusPollEntry = {
   connectionId: string;
 };
 const remoteStatusPollers = new Map<string, RemoteStatusPollEntry>();
+
+function shouldAutoCloseLinkedIssuesOnPrCreate(): boolean {
+  return getAppSettings().repository.autoCloseLinkedIssuesOnPrCreate !== false;
+}
 
 const ensureRemoteStatusPoller = (
   taskPath: string,
@@ -400,13 +405,17 @@ export function registerGitIpc() {
     const { title, body, base, head, draft, web, fill } = opts;
     const outputs: string[] = [];
 
+    const autoCloseLinkedIssuesOnPrCreate = shouldAutoCloseLinkedIssuesOnPrCreate();
+
     // Enrich body with issue footer
     let prBody = body;
-    try {
-      const task = await databaseService.getTaskByPath(taskPath);
-      prBody = injectIssueFooter(body, task?.metadata);
-    } catch {
-      // Non-fatal
+    if (autoCloseLinkedIssuesOnPrCreate) {
+      try {
+        const task = await databaseService.getTaskByPath(taskPath);
+        prBody = injectIssueFooter(body, task?.metadata);
+      } catch {
+        // Non-fatal
+      }
     }
 
     const {
@@ -511,7 +520,7 @@ export function registerGitIpc() {
     }
 
     // Patch body if needed
-    if (shouldPatchFilledBody && url) {
+    if (autoCloseLinkedIssuesOnPrCreate && shouldPatchFilledBody && url) {
       try {
         const task = await databaseService.getTaskByPath(taskPath);
         if (task?.metadata) {
@@ -597,21 +606,23 @@ export function registerGitIpc() {
       }
     }
 
-    // Patch PR body with issue footer
-    try {
-      const task = await databaseService.getTaskByPath(taskPath);
-      if (task?.metadata) {
-        const footer = injectIssueFooter(undefined, task.metadata);
-        if (footer) {
-          await remoteGitService.execGh(
-            connectionId,
-            taskPath,
-            `pr edit --body ${quoteGhArg(footer)}`
-          );
+    if (shouldAutoCloseLinkedIssuesOnPrCreate()) {
+      // Patch PR body with issue footer
+      try {
+        const task = await databaseService.getTaskByPath(taskPath);
+        if (task?.metadata) {
+          const footer = injectIssueFooter(undefined, task.metadata);
+          if (footer) {
+            await remoteGitService.execGh(
+              connectionId,
+              taskPath,
+              `pr edit --body ${quoteGhArg(footer)}`
+            );
+          }
         }
+      } catch {
+        // Non-fatal
       }
-    } catch {
-      // Non-fatal
     }
 
     // Merge
@@ -1094,14 +1105,17 @@ export function registerGitIpc() {
         }
 
         const outputs: string[] = [];
+        const autoCloseLinkedIssuesOnPrCreate = shouldAutoCloseLinkedIssuesOnPrCreate();
         let taskMetadata: unknown = undefined;
         let prBody = body;
-        try {
-          const task = await databaseService.getTaskByPath(taskPath);
-          taskMetadata = task?.metadata;
-          prBody = injectIssueFooter(body, task?.metadata);
-        } catch (error) {
-          log.debug('Unable to enrich PR body with issue footer', { taskPath, error });
+        if (autoCloseLinkedIssuesOnPrCreate) {
+          try {
+            const task = await databaseService.getTaskByPath(taskPath);
+            taskMetadata = task?.metadata;
+            prBody = injectIssueFooter(body, task?.metadata);
+          } catch (error) {
+            log.debug('Unable to enrich PR body with issue footer', { taskPath, error });
+          }
         }
         const { shouldPatchFilledBody, shouldUseBodyFile, shouldUseFill } = getCreatePrBodyPlan({
           fill,
@@ -1275,7 +1289,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         const urlMatch = out.match(/https?:\/\/\S+/);
         const url = urlMatch ? urlMatch[0] : null;
 
-        if (shouldPatchFilledBody) {
+        if (autoCloseLinkedIssuesOnPrCreate && shouldPatchFilledBody) {
           try {
             const didPatchBody = await patchCurrentPrBodyWithIssueFooter({
               taskPath,
@@ -2403,17 +2417,20 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
       }
 
       // Create PR (or use existing)
+      const autoCloseLinkedIssuesOnPrCreate = shouldAutoCloseLinkedIssuesOnPrCreate();
       let prUrl = '';
       let prExists = false;
       let taskMetadata: unknown = undefined;
-      try {
-        const task = await databaseService.getTaskByPath(taskPath);
-        taskMetadata = task?.metadata;
-      } catch (metadataError) {
-        log.debug('Unable to load task metadata for merge-to-main issue footer', {
-          taskPath,
-          metadataError,
-        });
+      if (autoCloseLinkedIssuesOnPrCreate) {
+        try {
+          const task = await databaseService.getTaskByPath(taskPath);
+          taskMetadata = task?.metadata;
+        } catch (metadataError) {
+          log.debug('Unable to load task metadata for merge-to-main issue footer', {
+            taskPath,
+            metadataError,
+          });
+        }
       }
       try {
         const prCreateArgs = ['pr', 'create', '--fill', '--base', defaultBranch];
@@ -2430,7 +2447,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         prExists = true;
       }
 
-      if (prExists) {
+      if (autoCloseLinkedIssuesOnPrCreate && prExists) {
         try {
           await patchCurrentPrBodyWithIssueFooter({
             taskPath,

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -25,6 +25,7 @@ const IS_MAC = process.platform === 'darwin';
 export interface RepositorySettings {
   branchPrefix: string; // e.g., 'emdash'
   pushOnCreate: boolean;
+  autoCloseLinkedIssuesOnPrCreate: boolean;
 }
 
 export type ShortcutModifier =
@@ -145,6 +146,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   repository: {
     branchPrefix: 'emdash',
     pushOnCreate: true,
+    autoCloseLinkedIssuesOnPrCreate: true,
   },
   projectPrep: {
     autoInstallOnOpenInEditor: true,
@@ -360,6 +362,7 @@ export function normalizeSettings(input: AppSettings): AppSettings {
     repository: {
       branchPrefix: DEFAULT_SETTINGS.repository.branchPrefix,
       pushOnCreate: DEFAULT_SETTINGS.repository.pushOnCreate,
+      autoCloseLinkedIssuesOnPrCreate: DEFAULT_SETTINGS.repository.autoCloseLinkedIssuesOnPrCreate,
     },
     projectPrep: {
       autoInstallOnOpenInEditor: DEFAULT_SETTINGS.projectPrep.autoInstallOnOpenInEditor,
@@ -383,9 +386,14 @@ export function normalizeSettings(input: AppSettings): AppSettings {
   if (!prefix) prefix = DEFAULT_SETTINGS.repository.branchPrefix;
   if (prefix.length > 50) prefix = prefix.slice(0, 50);
   const push = Boolean(repo?.pushOnCreate ?? DEFAULT_SETTINGS.repository.pushOnCreate);
+  const autoCloseLinkedIssuesOnPrCreate = Boolean(
+    repo?.autoCloseLinkedIssuesOnPrCreate ??
+      DEFAULT_SETTINGS.repository.autoCloseLinkedIssuesOnPrCreate
+  );
 
   out.repository.branchPrefix = prefix;
   out.repository.pushOnCreate = push;
+  out.repository.autoCloseLinkedIssuesOnPrCreate = autoCloseLinkedIssuesOnPrCreate;
   // Project prep
   const prep = (input as any)?.projectPrep || {};
   out.projectPrep.autoInstallOnOpenInEditor = Boolean(

--- a/src/renderer/components/RepositorySettingsCard.tsx
+++ b/src/renderer/components/RepositorySettingsCard.tsx
@@ -6,11 +6,13 @@ import { useAppSettings } from '@/contexts/AppSettingsProvider';
 type RepoSettings = {
   branchPrefix: string;
   pushOnCreate: boolean;
+  autoCloseLinkedIssuesOnPrCreate: boolean;
 };
 
 const DEFAULTS: RepoSettings = {
   branchPrefix: 'emdash',
   pushOnCreate: true,
+  autoCloseLinkedIssuesOnPrCreate: true,
 };
 
 const RepositorySettingsCard: React.FC = () => {
@@ -45,10 +47,32 @@ const RepositorySettingsCard: React.FC = () => {
           </div>
         </div>
         <Switch
-          defaultChecked={repository?.pushOnCreate ?? DEFAULTS.pushOnCreate}
+          checked={repository?.pushOnCreate ?? DEFAULTS.pushOnCreate}
           onCheckedChange={(checked) => updateSettings({ repository: { pushOnCreate: checked } })}
           disabled={loading || saving}
           aria-label="Enable automatic push on create"
+        />
+      </div>
+      <div className="flex items-center justify-between gap-4">
+        <div className="space-y-1 text-xs text-muted-foreground">
+          <div className="text-sm font-medium text-foreground">
+            Auto-close linked issues on PR creation
+          </div>
+          <div className="text-sm">
+            Add Emdash-managed closing keywords to new PRs so linked GitHub and Linear issues are
+            closed automatically. Disable this if your team closes issues only after testing,
+            deployment, or external approval.
+          </div>
+        </div>
+        <Switch
+          checked={
+            repository?.autoCloseLinkedIssuesOnPrCreate ?? DEFAULTS.autoCloseLinkedIssuesOnPrCreate
+          }
+          onCheckedChange={(checked) =>
+            updateSettings({ repository: { autoCloseLinkedIssuesOnPrCreate: checked } })
+          }
+          disabled={loading || saving}
+          aria-label="Enable automatic closing of linked issues on pull request creation"
         />
       </div>
     </div>

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -13,11 +13,44 @@ import { DEFAULT_REVIEW_AGENT, DEFAULT_REVIEW_PROMPT } from '../../shared/review
 /** Minimal valid AppSettings skeleton for normalizeSettings. */
 function makeSettings(overrides?: Partial<AppSettings>): AppSettings {
   return {
-    repository: { branchPrefix: 'emdash', pushOnCreate: true },
+    repository: {
+      branchPrefix: 'emdash',
+      pushOnCreate: true,
+      autoCloseLinkedIssuesOnPrCreate: true,
+    },
     projectPrep: { autoInstallOnOpenInEditor: true },
     ...overrides,
   } as AppSettings;
 }
+
+describe('normalizeSettings - repository settings', () => {
+  it('defaults autoCloseLinkedIssuesOnPrCreate to true', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        repository: {
+          branchPrefix: 'emdash',
+          pushOnCreate: true,
+        } as any,
+      })
+    );
+
+    expect(result.repository.autoCloseLinkedIssuesOnPrCreate).toBe(true);
+  });
+
+  it('preserves autoCloseLinkedIssuesOnPrCreate when explicitly disabled', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        repository: {
+          branchPrefix: 'emdash',
+          pushOnCreate: true,
+          autoCloseLinkedIssuesOnPrCreate: false,
+        },
+      })
+    );
+
+    expect(result.repository.autoCloseLinkedIssuesOnPrCreate).toBe(false);
+  });
+});
 
 describe('normalizeSettings – taskHoverAction', () => {
   it('preserves "archive"', () => {


### PR DESCRIPTION
## Summary

- Adds a new `autoCloseLinkedIssuesOnPrCreate` repository setting (defaults to `true`) that controls whether Emdash injects closing keywords into PR bodies for linked GitHub/Linear issues
- Adds a toggle in **Settings → Repository** so users can disable auto-closing when their workflow requires manual issue closure after testing, deployment, or approval
- Guards all issue-footer injection paths (`gh pr create`, `gh pr edit`, merge-to-main) behind the new setting
- Updates docs to document the opt-out behavior
- Adds tests for the new setting normalization

## Changes

- `src/main/settings.ts` — new `autoCloseLinkedIssuesOnPrCreate` field on `RepositorySettings` with normalization
- `src/main/ipc/gitIpc.ts` — conditionally skip `injectIssueFooter` and `patchCurrentPrBodyWithIssueFooter` calls when disabled
- `src/renderer/components/RepositorySettingsCard.tsx` — new Switch toggle with descriptive label
- `src/test/main/settings.test.ts` — tests for default and explicit-false normalization
- `docs/content/docs/issues.mdx` — documents opt-out in Auto-Closing Issues section

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a repository setting to control whether linked issues are automatically closed when creating pull requests. Auto-closing is enabled by default.

* **Documentation**
  * Updated documentation explaining the auto-close linked issues feature and instructions to disable it via settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->