### PR TITLE
fix: suppress EPIPE during PTY shutdown on Windows

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -19,6 +19,8 @@ import { errorTracking } from '../errorTracking';
  * swallow the error instead of throwing.
  */
 function suppressPtyPipeErrors(proc: IPty): void {
+  if (process.platform !== 'win32') return;
+
   // IPty doesn't expose .on() in its type, but the underlying Terminal
   // class extends EventEmitter and proxies to the socket.
   (proc as any).on?.('error', (err: NodeJS.ErrnoException) => {

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -383,6 +383,63 @@ describe('ptyManager provider command resolution', () => {
       })
     );
   });
+
+  it('attaches PTY pipe error suppression on Windows only', async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    const onWin32 = vi.fn();
+    const onDarwin = vi.fn();
+
+    try {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+
+      nodePtySpawnMock.mockReturnValueOnce({
+        on: onWin32,
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        onData: vi.fn(),
+        onExit: vi.fn(),
+      });
+
+      const { startPty } = await import('../../main/services/ptyManager');
+      await startPty({
+        id: 'codex-main-task-win32',
+        cwd: '/tmp/task',
+        shell: '/bin/zsh',
+      });
+
+      expect(onWin32).toHaveBeenCalledWith('error', expect.any(Function));
+
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+
+      nodePtySpawnMock.mockReturnValueOnce({
+        on: onDarwin,
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        onData: vi.fn(),
+        onExit: vi.fn(),
+      });
+
+      await startPty({
+        id: 'codex-main-task-darwin',
+        cwd: '/tmp/task',
+        shell: '/bin/zsh',
+      });
+
+      expect(onDarwin).not.toHaveBeenCalledWith('error', expect.any(Function));
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+      }
+    }
+  });
 });
 
 describe('stale Claude session detection', () => {


### PR DESCRIPTION
Fixes #1192

On Windows with ConPTY, killing a PTY process tree breaks the output pipe with EPIPE. node-pty only suppresses EIO (the Unix equivalent), so the EPIPE bubbles up as an uncaught exception and shows an error dialog.

The fix registers an error listener on every spawned PTY proc. For EPIPE/EIO it silently returns, for anything else it logs a warning. This also bumps the node-pty socket listener count past the throw threshold.

Greetings, saschabuehrle

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience of terminal/PTY error handling on Windows to reduce unexpected error surfacing during terminal sessions and lifecycle operations.

* **Tests**
  * Added a unit test verifying platform-specific attachment of PTY error handling to ensure behavior differs between Windows and non-Windows platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->