### PR TITLE
chore: extract shared AgentTooltipRow and add missing info tooltips to AgentDropdown

### DIFF
--- a/src/renderer/components/AgentDropdown.tsx
+++ b/src/renderer/components/AgentDropdown.tsx
@@ -1,8 +1,11 @@
 import React from 'react';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './ui/select';
+import { TooltipProvider } from './ui/tooltip';
 import { type Agent } from '../types';
 import { agentConfig } from '../lib/agentConfig';
 import AgentLogo from './AgentLogo';
+import AgentTooltipRow from './AgentTooltipRow';
+import type { UiAgent } from '@/providers/meta';
 
 interface AgentDropdownProps {
   value: Agent;
@@ -21,17 +24,17 @@ export const AgentDropdown: React.FC<AgentDropdownProps> = ({
 }) => {
   const installedSet = new Set(installedAgents);
   return (
-    <Select value={value} onValueChange={(v) => onChange(v as Agent)}>
-      <SelectTrigger className={`h-9 w-full border-none bg-muted ${className}`}>
-        <SelectValue placeholder="Select agent" />
-      </SelectTrigger>
-      <SelectContent side="top" className="z-[120]">
-        {Object.entries(agentConfig)
-          .filter(([key]) => installedSet.has(key))
-          .map(([key, config]) => {
-            const isDisabled = disabledAgents.includes(key);
-            return (
-              <SelectItem key={key} value={key} disabled={isDisabled}>
+    <TooltipProvider delayDuration={150}>
+      <Select value={value} onValueChange={(v) => onChange(v as Agent)}>
+        <SelectTrigger className={`h-9 w-full border-none bg-muted ${className}`}>
+          <SelectValue placeholder="Select agent" />
+        </SelectTrigger>
+        <SelectContent side="top" className="z-[120]">
+          {Object.entries(agentConfig)
+            .filter(([key]) => installedSet.has(key))
+            .map(([key, config]) => {
+              const isDisabled = disabledAgents.includes(key);
+              const content = (
                 <div className="flex items-center gap-2">
                   <AgentLogo
                     logo={config.logo}
@@ -46,11 +49,23 @@ export const AgentDropdown: React.FC<AgentDropdownProps> = ({
                     {isDisabled && <span className="ml-1 text-xs">(in use)</span>}
                   </span>
                 </div>
-              </SelectItem>
-            );
-          })}
-      </SelectContent>
-    </Select>
+              );
+
+              return isDisabled ? (
+                <AgentTooltipRow key={key} id={key as UiAgent}>
+                  <div className="relative flex w-full cursor-not-allowed select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm opacity-50">
+                    {content}
+                  </div>
+                </AgentTooltipRow>
+              ) : (
+                <AgentTooltipRow key={key} id={key as UiAgent}>
+                  <SelectItem value={key}>{content}</SelectItem>
+                </AgentTooltipRow>
+              );
+            })}
+        </SelectContent>
+      </Select>
+    </TooltipProvider>
   );
 };
 

--- a/src/renderer/components/AgentSelector.tsx
+++ b/src/renderer/components/AgentSelector.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { Select, SelectTrigger, SelectValue, SelectContent, SelectItem } from './ui/select';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
-import { AgentInfoCard } from './AgentInfoCard';
+import AgentTooltipRow from './AgentTooltipRow';
 import RoutingInfoCard from './RoutingInfoCard';
 import { Workflow } from 'lucide-react';
 import { Badge } from './ui/badge';
@@ -58,7 +58,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({
         <SelectContent side="top" className="z-[120]">
           <TooltipProvider delayDuration={150}>
             {Object.entries(agentConfig).map(([key, config]) => (
-              <TooltipRow key={key} id={key as UiAgent}>
+              <AgentTooltipRow key={key} id={key as UiAgent}>
                 <SelectItem value={key}>
                   <div className="flex items-center gap-2">
                     <AgentLogo
@@ -71,7 +71,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({
                     <span>{config.name}</span>
                   </div>
                 </SelectItem>
-              </TooltipRow>
+              </AgentTooltipRow>
             ))}
             {false && (
               <RoutingTooltipRow>
@@ -97,33 +97,6 @@ export const AgentSelector: React.FC<AgentSelectorProps> = ({
         </SelectContent>
       </Select>
     </div>
-  );
-};
-
-const TooltipRow: React.FC<{ id: UiAgent; children: React.ReactElement }> = ({ id, children }) => {
-  const [open, setOpen] = useState(false);
-  return (
-    <Tooltip open={open}>
-      <TooltipTrigger asChild>
-        {React.cloneElement(children, {
-          onMouseEnter: () => setOpen(true),
-          onMouseLeave: () => setOpen(false),
-          onPointerEnter: () => setOpen(true),
-          onPointerLeave: () => setOpen(false),
-        })}
-      </TooltipTrigger>
-      <TooltipContent
-        side="right"
-        align="start"
-        className="border-foreground/20 bg-background p-0 text-foreground"
-        onMouseEnter={() => setOpen(true)}
-        onMouseLeave={() => setOpen(false)}
-        onPointerEnter={() => setOpen(true)}
-        onPointerLeave={() => setOpen(false)}
-      >
-        <AgentInfoCard id={id} />
-      </TooltipContent>
-    </Tooltip>
   );
 };
 

--- a/src/renderer/components/AgentTooltipRow.tsx
+++ b/src/renderer/components/AgentTooltipRow.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+import { AgentInfoCard } from './AgentInfoCard';
+import { Tooltip, TooltipContent, TooltipTrigger } from './ui/tooltip';
+import type { UiAgent } from '@/providers/meta';
+
+type TooltipSide = React.ComponentPropsWithoutRef<typeof TooltipContent>['side'];
+type TooltipAlign = React.ComponentPropsWithoutRef<typeof TooltipContent>['align'];
+
+interface AgentTooltipRowProps {
+  id: UiAgent;
+  children: React.ReactElement;
+  open?: boolean;
+  onOpenChange?: (open: boolean) => void;
+  side?: TooltipSide;
+  align?: TooltipAlign;
+  contentClassName?: string;
+}
+
+export const AgentTooltipRow: React.FC<AgentTooltipRowProps> = ({
+  id,
+  children,
+  open,
+  onOpenChange,
+  side = 'right',
+  align = 'start',
+  contentClassName = 'border-foreground/20 bg-background p-0 text-foreground',
+}) => {
+  const [internalOpen, setInternalOpen] = useState(false);
+  const resolvedOpen = open ?? internalOpen;
+
+  const setOpen = (nextOpen: boolean) => {
+    if (open === undefined) {
+      setInternalOpen(nextOpen);
+    }
+    onOpenChange?.(nextOpen);
+  };
+
+  return (
+    <Tooltip open={resolvedOpen}>
+      <TooltipTrigger asChild>
+        {React.cloneElement(children, {
+          onMouseEnter: (event: React.MouseEvent<HTMLElement>) => {
+            children.props.onMouseEnter?.(event);
+            setOpen(true);
+          },
+          onMouseLeave: (event: React.MouseEvent<HTMLElement>) => {
+            children.props.onMouseLeave?.(event);
+            setOpen(false);
+          },
+          onPointerEnter: (event: React.PointerEvent<HTMLElement>) => {
+            children.props.onPointerEnter?.(event);
+            setOpen(true);
+          },
+          onPointerLeave: (event: React.PointerEvent<HTMLElement>) => {
+            children.props.onPointerLeave?.(event);
+            setOpen(false);
+          },
+        })}
+      </TooltipTrigger>
+      <TooltipContent
+        side={side}
+        align={align}
+        className={contentClassName}
+        onMouseEnter={() => setOpen(true)}
+        onMouseLeave={() => setOpen(false)}
+        onPointerEnter={() => setOpen(true)}
+        onPointerLeave={() => setOpen(false)}
+      >
+        <AgentInfoCard id={id} />
+      </TooltipContent>
+    </Tooltip>
+  );
+};
+
+export default AgentTooltipRow;

--- a/src/renderer/components/MultiAgentDropdown.tsx
+++ b/src/renderer/components/MultiAgentDropdown.tsx
@@ -5,9 +5,9 @@ import { Info, ExternalLink } from 'lucide-react';
 import { type Agent } from '../types';
 import { type AgentRun } from '../types/chat';
 import { agentConfig } from '../lib/agentConfig';
-import { AgentInfoCard } from './AgentInfoCard';
 import AgentLogo from './AgentLogo';
 import type { UiAgent } from '@/providers/meta';
+import AgentTooltipRow from './AgentTooltipRow';
 
 const MAX_RUNS = 4;
 
@@ -121,13 +121,16 @@ export const MultiAgentDropdown: React.FC<MultiAgentDropdownProps> = ({
                 <AgentTooltipRow
                   key={key}
                   id={agent as UiAgent}
-                  isHovered={hoveredAgent === agent || runsSelectOpenFor === agent}
-                  onHover={() => setHoveredAgent(agent)}
-                  onLeave={() => {
-                    if (runsSelectOpenFor !== agent) {
+                  open={hoveredAgent === agent || runsSelectOpenFor === agent}
+                  onOpenChange={(nextOpen) => {
+                    if (nextOpen) {
+                      setHoveredAgent(agent);
+                    } else if (runsSelectOpenFor !== agent) {
                       setHoveredAgent(null);
                     }
                   }}
+                  side="left"
+                  contentClassName="z-[1000] border-foreground/20 bg-background p-0 text-foreground"
                 >
                   <div
                     className="flex h-8 cursor-pointer items-center justify-between rounded-sm px-2 hover:bg-accent"
@@ -243,38 +246,6 @@ export const MultiAgentDropdown: React.FC<MultiAgentDropdownProps> = ({
         </SelectContent>
       </Select>
     </TooltipProvider>
-  );
-};
-
-const AgentTooltipRow: React.FC<{
-  id: UiAgent;
-  children: React.ReactElement;
-  isHovered: boolean;
-  onHover: () => void;
-  onLeave: () => void;
-}> = ({ id, children, isHovered, onHover, onLeave }) => {
-  return (
-    <Tooltip open={isHovered}>
-      <TooltipTrigger asChild>
-        {React.cloneElement(children, {
-          onMouseEnter: onHover,
-          onMouseLeave: onLeave,
-          onPointerEnter: onHover,
-          onPointerLeave: onLeave,
-        })}
-      </TooltipTrigger>
-      <TooltipContent
-        side="left"
-        align="start"
-        className="z-[1000] border-foreground/20 bg-background p-0 text-foreground"
-        onMouseEnter={onHover}
-        onMouseLeave={onLeave}
-        onPointerEnter={onHover}
-        onPointerLeave={onLeave}
-      >
-        <AgentInfoCard id={id} />
-      </TooltipContent>
-    </Tooltip>
   );
 };
 

--- a/src/renderer/components/ui/tooltip.tsx
+++ b/src/renderer/components/ui/tooltip.tsx
@@ -16,7 +16,7 @@ export const TooltipContent = React.forwardRef<
       sideOffset={sideOffset}
       className={cn(
         // High z-index to appear above sidebars, selects, modals
-        'z-[240] overflow-hidden rounded-md border border-border px-3 py-1.5 text-xs shadow-md',
+        'z-[10000] overflow-hidden rounded-md border border-border px-3 py-1.5 text-xs shadow-md',
         // Default to app background + foreground (white in light)
         'bg-background text-foreground',
         'animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95',


### PR DESCRIPTION
## Summary
- Extract the duplicated agent tooltip row logic from `AgentSelector` and `MultiAgentDropdown` into a shared `AgentTooltipRow` component
- Add `AgentInfoCard` tooltips to `AgentDropdown` (which previously had none), wrapping both enabled and disabled agent rows
- Update `MultiAgentDropdown` to use the shared component's `open`/`onOpenChange`/`side`/`contentClassName` API instead of custom `isHovered`/`onHover`/`onLeave` props
- Bump tooltip base `z-index` from `240` to `10000` in `tooltip.tsx` so tooltips reliably render above selects and modals

## Changes
- **`AgentTooltipRow.tsx`** (new) — Reusable tooltip wrapper that shows an `AgentInfoCard` on hover with configurable positioning and controlled/uncontrolled open state
- **`AgentDropdown.tsx`** — Wrap each agent row in `AgentTooltipRow`; disabled agents render as non-interactive styled divs instead of `disabled` `SelectItem`s
- **`AgentSelector.tsx`** — Replace inline `TooltipRow` with the shared `AgentTooltipRow`; remove ~30 lines of duplicated tooltip logic
- **`MultiAgentDropdown.tsx`** — Replace local `AgentTooltipRow` with the shared component; remove ~30 lines of duplicated tooltip logic
- **`tooltip.tsx`** — Increase default `z-index` from `240` to `10000`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved agent information tooltips in dropdown menus with enhanced visibility and positioning control.

* **Bug Fixes**
  * Fixed tooltip z-index layering to prevent overlapping UI elements.

* **Refactor**
  * Reorganized tooltip components for better code reusability across agent selection interfaces.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->