### PR TITLE
feat(changelog): add hero image support and GitHub Releases fallback

### DIFF
--- a/src/main/services/ChangelogService.ts
+++ b/src/main/services/ChangelogService.ts
@@ -7,6 +7,8 @@ import {
 } from '@shared/changelog';
 import { log } from '../lib/logger';
 
+const GITHUB_RELEASES_API_URL = 'https://api.github.com/repos/generalaction/emdash/releases';
+
 type ChangelogCandidate = {
   version?: string | null;
   title?: string | null;
@@ -21,6 +23,9 @@ type ChangelogCandidate = {
   date?: string | null;
   url?: string | null;
   href?: string | null;
+  image?: string | null;
+  image_url?: string | null;
+  screenshot?: string | null;
 };
 
 function firstString(...values: Array<unknown>): string | undefined {
@@ -142,7 +147,16 @@ function htmlToMarkdown(html: string): string {
     .replace(/<\/(ul|ol)>/gi, '\n')
     .replace(/<(ul|ol)\b[^>]*>/gi, '\n');
 
-  const withParagraphs = withLists
+  const withImages = withLists.replace(
+    /<img\b[^>]*\bsrc=(["'])(.*?)\1[^>]*>/gi,
+    (_match, _quote, src: string) => {
+      const altMatch = _match.match(/\balt=(["'])(.*?)\1/i);
+      const alt = altMatch ? altMatch[2] : '';
+      return `![${alt}](${src.trim()})`;
+    }
+  );
+
+  const withParagraphs = withImages
     .replace(/<br\s*\/?>/gi, '\n')
     .replace(/<\/p>/gi, '\n\n')
     .replace(/<p\b[^>]*>/gi, '')
@@ -154,6 +168,42 @@ function htmlToMarkdown(html: string): string {
     .replace(/\n{3,}/g, '\n\n')
     .replace(/ {2,}/g, ' ')
     .trim();
+}
+
+function extractFirstImageUrl(content: string): string | undefined {
+  const match = content.match(/!\[[^\]]*\]\((\s*https?:\/\/[^)]+)\)/);
+  return match?.[1]?.trim();
+}
+
+function extractFirstImageUrlFromHtml(html: string): string | undefined {
+  const match = html.match(/<img\b[^>]*\bsrc=(["'])(https?:\/\/[^"']+)\1/i);
+  return match?.[2]?.trim();
+}
+
+function stripImageFromContent(content: string, imageUrl: string): string {
+  const escaped = escapeRegex(imageUrl);
+  const stripped = content
+    .replace(new RegExp(`!\\[[^\\]]*\\]\\(\\s*${escaped}\\s*\\)\\s*\\n?`), '')
+    .trim();
+  return stripped || content;
+}
+
+function stripHtmlImageFromContent(content: string, imageUrl: string): string {
+  const escaped = escapeRegex(imageUrl);
+  const stripped = content
+    .replace(new RegExp(`<img\\b[^>]*\\bsrc=["']${escaped}["'][^>]*/?>\\s*\\n?`, 'i'), '')
+    .trim();
+  return stripped || content;
+}
+
+function mapGitHubRelease(release: Record<string, unknown>): ChangelogCandidate {
+  return {
+    version: typeof release.tag_name === 'string' ? release.tag_name : null,
+    title: typeof release.name === 'string' ? release.name : null,
+    body: typeof release.body === 'string' ? release.body : null,
+    published_at: typeof release.published_at === 'string' ? release.published_at : null,
+    url: typeof release.html_url === 'string' ? release.html_url : null,
+  };
 }
 
 function extractSummaryFromContent(content: string): string {
@@ -213,7 +263,22 @@ function normalizeEntry(
     extractSummaryFromContent(dedupedContent) ??
     `See what changed in Emdash v${version}.`;
 
-  const content = dedupedContent || summary || `See what changed in Emdash v${version}.`;
+  const explicitImage = firstString(candidate.image, candidate.image_url, candidate.screenshot);
+  const contentImageUrl = !explicitImage
+    ? (extractFirstImageUrl(contentSource) ?? extractFirstImageUrlFromHtml(contentSource))
+    : undefined;
+  const htmlImageUrl =
+    !explicitImage && !contentImageUrl
+      ? firstString(candidate.contentHtml, candidate.html)
+        ? extractFirstImageUrlFromHtml(firstString(candidate.contentHtml, candidate.html)!)
+        : undefined
+      : undefined;
+  const image = explicitImage ?? contentImageUrl ?? htmlImageUrl;
+
+  const rawContent = dedupedContent || summary || `See what changed in Emdash v${version}.`;
+  const content = contentImageUrl
+    ? stripHtmlImageFromContent(stripImageFromContent(rawContent, contentImageUrl), contentImageUrl)
+    : rawContent;
 
   return {
     version,
@@ -222,6 +287,7 @@ function normalizeEntry(
     content,
     publishedAt: firstString(candidate.publishedAt, candidate.published_at, candidate.date),
     url: firstString(candidate.url, candidate.href),
+    image,
   };
 }
 
@@ -401,6 +467,35 @@ class ChangelogService {
     }
   }
 
+  private async getGitHubReleaseEntry(requestedVersion?: string): Promise<ChangelogEntry | null> {
+    try {
+      const version = normalizeChangelogVersion(requestedVersion);
+      const url = version
+        ? `${GITHUB_RELEASES_API_URL}/tags/v${version}`
+        : `${GITHUB_RELEASES_API_URL}/latest`;
+
+      const payload = await fetchJson(url);
+      if (!payload || typeof payload !== 'object') return null;
+
+      return normalizeEntry(
+        mapGitHubRelease(payload as Record<string, unknown>),
+        version ?? undefined
+      );
+    } catch (error) {
+      log.debug('GitHub releases fetch failed', { error });
+      return null;
+    }
+  }
+
+  private async supplementWithGitHubImage(entry: ChangelogEntry): Promise<ChangelogEntry> {
+    if (entry.image) return entry;
+
+    const ghEntry = await this.getGitHubReleaseEntry(entry.version);
+    if (ghEntry?.image) return { ...entry, image: ghEntry.image };
+
+    return entry;
+  }
+
   async getLatestEntry(requestedVersion?: string): Promise<ChangelogEntry | null> {
     const version = normalizeChangelogVersion(requestedVersion);
     const apiUrls = [
@@ -422,23 +517,28 @@ class ChangelogService {
           .filter((candidate): candidate is ChangelogEntry => candidate !== null);
         const match = pickBestCandidate(entries, version ?? undefined);
         if (match) {
-          if (match.publishedAt) return match;
-
-          const htmlEntry = await this.getHtmlEntry(match.version);
-          if (!htmlEntry) return match;
-
-          return {
-            ...match,
-            publishedAt: htmlEntry.publishedAt ?? match.publishedAt,
-            url: match.url ?? htmlEntry.url,
-          };
+          let result = match;
+          if (!match.publishedAt) {
+            const htmlEntry = await this.getHtmlEntry(match.version);
+            if (htmlEntry) {
+              result = {
+                ...match,
+                publishedAt: htmlEntry.publishedAt ?? match.publishedAt,
+                url: match.url ?? htmlEntry.url,
+              };
+            }
+          }
+          return this.supplementWithGitHubImage(result);
         }
       } catch (error) {
         log.debug('Changelog JSON fetch failed', { url, error });
       }
     }
 
-    return this.getHtmlEntry(version ?? undefined);
+    const htmlEntry = await this.getHtmlEntry(version ?? undefined);
+    if (htmlEntry) return this.supplementWithGitHubImage(htmlEntry);
+
+    return this.getGitHubReleaseEntry(version ?? undefined);
   }
 }
 

--- a/src/renderer/components/ChangelogModal.tsx
+++ b/src/renderer/components/ChangelogModal.tsx
@@ -55,9 +55,26 @@ function stripLeadingReleaseHeadings(content: string, entry: ChangelogEntry): st
   return lines.join('\n').trim();
 }
 
+const FOOTER_PATTERN =
+  /^(?:#{1,6}\s*new\s+contributors|[\s*-]*@\S+\s+made\s+their\s+first\s+contribution|\*{0,2}full\s+changelog\*{0,2}\s*:)/im;
+
+function splitContentFooter(content: string): { main: string; footer: string } {
+  const lines = content.split('\n');
+  for (let i = 0; i < lines.length; i++) {
+    if (FOOTER_PATTERN.test(lines[i])) {
+      return {
+        main: lines.slice(0, i).join('\n').trim(),
+        footer: lines.slice(i).join('\n').trim(),
+      };
+    }
+  }
+  return { main: content, footer: '' };
+}
+
 function ChangelogModal({ entry }: ChangelogModalProps): JSX.Element {
   const publishedAt = formatChangelogPublishedAt(entry.publishedAt);
   const content = stripLeadingReleaseHeadings(entry.content, entry);
+  const { main, footer } = splitContentFooter(content);
 
   return (
     <DialogContent className="max-w-2xl gap-0 overflow-hidden p-0 focus:outline-none">
@@ -71,22 +88,41 @@ function ChangelogModal({ entry }: ChangelogModalProps): JSX.Element {
         </button>
       </div>
 
-      <div className="max-h-[min(75vh,44rem)] overflow-y-auto px-6 py-5">
-        {publishedAt && (
-          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
-            <Badge variant="outline" className="h-5 px-2 text-[11px] font-medium">
-              {publishedAt}
-            </Badge>
+      <div className="max-h-[min(75vh,44rem)] overflow-y-auto">
+        <div className="px-6 py-5">
+          {publishedAt && (
+            <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+              <Badge variant="outline" className="h-5 px-2 text-[11px] font-medium">
+                {publishedAt}
+              </Badge>
+            </div>
+          )}
+          <h2 className="mt-3 text-2xl font-semibold tracking-tight text-foreground">
+            {entry.title}
+          </h2>
+          {entry.image && (
+            <div className="mt-4 overflow-hidden rounded-lg">
+              <img
+                src={entry.image}
+                alt={`${entry.title} screenshot`}
+                className="h-auto w-full object-cover"
+                loading="lazy"
+              />
+            </div>
+          )}
+          {entry.summary && (
+            <p className="mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">
+              {entry.summary}
+            </p>
+          )}
+          <div className="mt-6">
+            <MarkdownRenderer content={main} />
           </div>
-        )}
-        <h2 className="mt-3 text-2xl font-semibold tracking-tight text-foreground">
-          {entry.title}
-        </h2>
-        {entry.summary && (
-          <p className="mt-4 max-w-2xl text-sm leading-6 text-muted-foreground">{entry.summary}</p>
-        )}
-        <div className="mt-6">
-          <MarkdownRenderer content={content} />
+          {footer && (
+            <div className="mt-6 border-t border-border pt-5">
+              <MarkdownRenderer content={footer} />
+            </div>
+          )}
         </div>
       </div>
     </DialogContent>

--- a/src/renderer/hooks/useChangelogNotification.ts
+++ b/src/renderer/hooks/useChangelogNotification.ts
@@ -80,10 +80,10 @@ export function useChangelogNotification() {
       rpc.changelog.getLatestEntry({ version: notificationVersion ?? undefined }),
   });
 
-  const entry = useMemo(
-    () => (notificationVersion ? (data ?? createFallbackEntry(notificationVersion)) : null),
-    [data, notificationVersion]
-  );
+  const entry = useMemo(() => {
+    if (!notificationVersion) return null;
+    return data ?? createFallbackEntry(notificationVersion);
+  }, [data, notificationVersion]);
 
   const dismiss = useCallback(() => {
     if (!notificationVersion) return;

--- a/src/shared/changelog.ts
+++ b/src/shared/changelog.ts
@@ -8,6 +8,8 @@ export interface ChangelogEntry {
   content: string;
   publishedAt?: string;
   url?: string;
+  /** Hero/banner image URL shown at the top of the changelog modal */
+  image?: string;
 }
 
 export function normalizeChangelogVersion(version: string | null | undefined): string | null {

--- a/src/test/main/ChangelogService.test.ts
+++ b/src/test/main/ChangelogService.test.ts
@@ -79,6 +79,27 @@ describe('parseChangelogHtml', () => {
     expect(entry?.publishedAt).toBe('March 13, 2026');
   });
 
+  it('extracts a hero image from an img tag inside the article and strips it from content', () => {
+    const htmlWithImage = `
+      <main>
+        <article data-version="0.5.0">
+          <time datetime="2026-03-20">Mar 20, 2026</time>
+          <h2>Screenshot release</h2>
+          <p>A release with a screenshot.</p>
+          <img src="https://github.com/user-attachments/assets/abc123.png" alt="hero" />
+        </article>
+      </main>
+    `;
+
+    const entry = parseChangelogHtml(htmlWithImage, '0.5.0');
+
+    expect(entry?.version).toBe('0.5.0');
+    expect(entry?.image).toBe('https://github.com/user-attachments/assets/abc123.png');
+    expect(entry?.content).not.toContain(
+      '![hero](https://github.com/user-attachments/assets/abc123.png)'
+    );
+  });
+
   it('does not assign another release date when the requested version has no matching date text', () => {
     const htmlWithOtherDate = `
       <main>


### PR DESCRIPTION
## Summary

- Add `image` field to `ChangelogEntry` for hero/banner images displayed at the top of the changelog modal
- Extract images from changelog content (markdown `![]()` and HTML `<img>` tags), explicit candidate fields, or GitHub Releases API as a fallback
- Strip extracted hero images from body content to avoid duplication
- Add GitHub Releases API (`/repos/.../releases`) as a tertiary changelog source when JSON and HTML endpoints fail
- Separate contributor/"full changelog" footers into a visually distinct section in the modal

## Changes

- **`ChangelogService.ts`** — `htmlToMarkdown` now converts `<img>` tags; new helpers to extract, strip, and deduplicate images; `mapGitHubRelease` + `getGitHubReleaseEntry` for GitHub API fallback; `supplementWithGitHubImage` enriches entries missing an image
- **`ChangelogModal.tsx`** — Renders hero image below the title; splits content from contributor/footer sections via `splitContentFooter`
- **`useChangelogNotification.ts`** — Minor readability refactor of the `entry` memo
- **`shared/changelog.ts`** — Add optional `image` field to `ChangelogEntry`
- **`ChangelogService.test.ts`** — Test for image extraction and content stripping from HTML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Changelog entries now display hero and banner images for richer visual presentation.
  * Changelog content intelligently separates footer sections (contributors, full changelog links) for improved readability.
  * Enhanced changelog data retrieval with GitHub releases as a fallback source when other sources are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->