### PR TITLE
Persistent session backends

### DIFF
--- a/agents/risky-areas/pty.md
+++ b/agents/risky-areas/pty.md
@@ -14,7 +14,7 @@
 - PTY cleanup and exit handling
 - resize behavior
 - shell quoting and Windows command wrapping
-- tmux lifecycle
+- persistent session backend lifecycle (`tmux`, `zellij`)
 - provider-specific resume/session behavior
 - env passthrough safety
 

--- a/agents/workflows/worktrees.md
+++ b/agents/workflows/worktrees.md
@@ -23,6 +23,7 @@ Current supported keys:
 - `scripts.run`
 - `scripts.teardown`
 - `shellSetup`
+- `sessionBackend`
 - `tmux`
 
 ## Rules
@@ -30,4 +31,4 @@ Current supported keys:
 - do not hardcode worktree paths; use service helpers
 - use lifecycle config for repo-specific bootstrap and teardown behavior
 - `shellSetup` runs inside each PTY before the interactive shell starts
-- tmux wrapping is project-configurable and affects PTY lifecycle behavior
+- persistent session backends are project-configurable and affect PTY lifecycle behavior

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -114,6 +114,11 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ptyResize: (args: { id: string; cols: number; rows: number }) =>
     ipcRenderer.send('pty:resize', args),
   ptyKill: (id: string) => ipcRenderer.send('pty:kill', { id }),
+  ptyKillPersistentSession: (id: string) =>
+    ipcRenderer.invoke('pty:killPersistentSession', { id }) as Promise<{
+      ok: boolean;
+      error?: string;
+    }>,
   ptyKillTmux: (id: string) =>
     ipcRenderer.invoke('pty:killTmux', { id }) as Promise<{ ok: boolean; error?: string }>,
 

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -1,5 +1,5 @@
 import type sqlite3Type from 'sqlite3';
-import { and, asc, desc, eq, isNull, ne, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, getTableColumns, isNull, ne, or, sql } from 'drizzle-orm';
 import { readMigrationFiles } from 'drizzle-orm/migrator';
 import { resolveDatabasePath, resolveMigrationsPath } from '../db/path';
 import { getDrizzleClient } from '../db/drizzleClient';
@@ -51,6 +51,7 @@ export interface Task {
   metadata?: any;
   useWorktree?: boolean;
   archivedAt?: string | null;
+  lastActivityAt?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -325,18 +326,28 @@ export class DatabaseService {
     if (this.disabled) return [];
     const { db } = await getDrizzleClient();
 
-    // Filter out archived tasks by default
-    const rows: TaskRow[] = projectId
+    const lastActivityAt = sql<string>`coalesce(max(${conversationsTable.updatedAt}), ${tasksTable.updatedAt}, ${tasksTable.createdAt})`;
+    const taskSelection = {
+      ...getTableColumns(tasksTable),
+      lastActivityAt: lastActivityAt.as('lastActivityAt'),
+    };
+
+    const rows = projectId
       ? await db
-          .select()
+          .select(taskSelection)
           .from(tasksTable)
+          .leftJoin(conversationsTable, eq(conversationsTable.taskId, tasksTable.id))
           .where(and(eq(tasksTable.projectId, projectId), isNull(tasksTable.archivedAt)))
-          .orderBy(desc(tasksTable.updatedAt))
+          .groupBy(tasksTable.id)
+          .orderBy(desc(lastActivityAt), desc(tasksTable.createdAt))
       : await db
-          .select()
+          .select(taskSelection)
           .from(tasksTable)
+          .leftJoin(conversationsTable, eq(conversationsTable.taskId, tasksTable.id))
           .where(isNull(tasksTable.archivedAt))
-          .orderBy(desc(tasksTable.updatedAt));
+          .groupBy(tasksTable.id)
+          .orderBy(desc(lastActivityAt), desc(tasksTable.createdAt));
+
     return rows.map((row) => this.mapDrizzleTaskRow(row));
   }
 
@@ -344,19 +355,30 @@ export class DatabaseService {
     if (this.disabled) return [];
     const { db } = await getDrizzleClient();
 
-    const rows: TaskRow[] = projectId
+    const lastActivityAt = sql<string>`coalesce(max(${conversationsTable.updatedAt}), ${tasksTable.updatedAt}, ${tasksTable.createdAt})`;
+    const taskSelection = {
+      ...getTableColumns(tasksTable),
+      lastActivityAt: lastActivityAt.as('lastActivityAt'),
+    };
+
+    const rows = projectId
       ? await db
-          .select()
+          .select(taskSelection)
           .from(tasksTable)
+          .leftJoin(conversationsTable, eq(conversationsTable.taskId, tasksTable.id))
           .where(
             and(eq(tasksTable.projectId, projectId), sql`${tasksTable.archivedAt} IS NOT NULL`)
           )
+          .groupBy(tasksTable.id)
           .orderBy(desc(tasksTable.archivedAt))
       : await db
-          .select()
+          .select(taskSelection)
           .from(tasksTable)
+          .leftJoin(conversationsTable, eq(conversationsTable.taskId, tasksTable.id))
           .where(sql`${tasksTable.archivedAt} IS NOT NULL`)
+          .groupBy(tasksTable.id)
           .orderBy(desc(tasksTable.archivedAt));
+
     return rows.map((row) => this.mapDrizzleTaskRow(row));
   }
 
@@ -852,7 +874,7 @@ export class DatabaseService {
     };
   }
 
-  private mapDrizzleTaskRow(row: TaskRow): Task {
+  private mapDrizzleTaskRow(row: TaskRow & { lastActivityAt?: string | null }): Task {
     return {
       id: row.id,
       projectId: row.projectId,
@@ -867,6 +889,7 @@ export class DatabaseService {
           : null,
       useWorktree: row.useWorktree === 1,
       archivedAt: row.archivedAt ?? null,
+      lastActivityAt: row.lastActivityAt ?? row.updatedAt ?? row.createdAt,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };

--- a/src/main/services/LifecycleScriptsService.ts
+++ b/src/main/services/LifecycleScriptsService.ts
@@ -2,6 +2,11 @@ import fs from 'fs';
 import path from 'path';
 import { log } from '../lib/logger';
 import type { LifecyclePhase, LifecycleScriptConfig } from '@shared/lifecycle';
+import {
+  normalizeSessionBackend,
+  resolveConfiguredSessionBackend,
+  type SessionBackend,
+} from '@shared/sessionBackend';
 
 export interface WorkspaceProviderConfig {
   type: 'script';
@@ -13,6 +18,7 @@ export interface EmdashConfig {
   preservePatterns?: string[];
   scripts?: LifecycleScriptConfig;
   shellSetup?: string;
+  sessionBackend?: SessionBackend;
   tmux?: boolean;
   workspaceProvider?: WorkspaceProviderConfig;
 }
@@ -67,8 +73,17 @@ class LifecycleScriptsService {
    * for persistence and resumability.
    */
   getTmuxEnabled(projectPath: string): boolean {
+    return this.getSessionBackend(projectPath) === 'tmux';
+  }
+
+  getConfiguredSessionBackend(projectPath: string): SessionBackend | null {
     const config = this.readConfig(projectPath);
-    return config?.tmux === true;
+    return resolveConfiguredSessionBackend(config);
+  }
+
+  getSessionBackend(projectPath: string): SessionBackend {
+    const config = this.readConfig(projectPath);
+    return normalizeSessionBackend(config);
   }
 }
 

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -14,9 +14,8 @@ import {
   buildProviderCliArgs,
   getProviderRuntimeCliArgs,
   resolveProviderCommandConfig,
-  killTmuxSession,
-  getTmuxSessionName,
-  getPtyTmuxSessionName,
+  killPersistentSession,
+  getPtySessionBackend,
   clearStoredSession,
   getStoredResumeTarget,
   markCodexSessionBound,
@@ -44,6 +43,12 @@ import { quoteShellArg } from '../utils/shellEscape';
 import { agentEventService } from './AgentEventService';
 import { codexSessionService } from './CodexSessionService';
 import { waitForShellPrompt, type PromptWaitHandle } from '../utils/waitForShellPrompt';
+import {
+  getPersistentSessionName,
+  isPersistentSessionBackend,
+  type PersistentSessionBackend,
+  type SessionBackend,
+} from '@shared/sessionBackend';
 
 const owners = new Map<string, WebContents>();
 const listeners = new Set<string>();
@@ -288,9 +293,10 @@ function cleanupPtySession(id: string): void {
   // Ensure telemetry timers are cleared even on manual kill
   maybeMarkProviderFinish(id, null, undefined, 'manual_kill');
   sendPtyExitGlobal(id);
-  // Kill associated tmux session if this PTY was tmux-wrapped
-  if (getPtyTmuxSessionName(id)) {
-    killTmuxSession(id);
+  // Kill associated persistent session if this PTY was wrapped in one.
+  const sessionBackend = getPtySessionBackend(id);
+  if (sessionBackend) {
+    killPersistentSession(id, sessionBackend);
   }
   killPty(id);
   owners.delete(id);
@@ -382,7 +388,7 @@ async function writeRemoteOpenCodePlugin(
 function buildRemoteInitKeystrokes(args: {
   cwd?: string;
   provider?: { cli: string; cmd: string; installCommand?: string };
-  tmux?: { sessionName: string };
+  persistentSession?: { backend: PersistentSessionBackend; sessionName: string };
   preProviderCommands?: string[];
 }): string {
   const lines: string[] = [];
@@ -403,12 +409,15 @@ function buildRemoteInitKeystrokes(args: {
     const msg = `emdash: ${cli} not found on remote.${install}`;
     const providerCmd = args.provider.cmd;
 
-    if (args.tmux) {
-      // When tmux is enabled, wrap the provider command in a named tmux session.
-      // tmux new-session -As creates-or-attaches in one command.
-      // Falls back to running without tmux if tmux isn't installed on the remote.
-      const tmuxName = quoteShellArg(args.tmux.sessionName);
+    if (args.persistentSession?.backend === 'tmux') {
+      const tmuxName = quoteShellArg(args.persistentSession.sessionName);
       const shScript = `if command -v ${quoteShellArg(cli)} >/dev/null 2>&1; then if command -v tmux >/dev/null 2>&1; then exec tmux new-session -As ${tmuxName} -- sh -c ${quoteShellArg(providerCmd)}; else printf '%s\\n' 'emdash: tmux not found on remote, running without session persistence'; exec ${providerCmd}; fi; else printf '%s\\n' ${quoteShellArg(
+        msg
+      )}; fi`;
+      lines.push(`sh -ilc ${quoteShellArg(shScript)}`);
+    } else if (args.persistentSession?.backend === 'zellij') {
+      const zellijConfigPath = buildRemoteZellijConfigPath(args.persistentSession.sessionName);
+      const shScript = `if command -v ${quoteShellArg(cli)} >/dev/null 2>&1; then if command -v zellij >/dev/null 2>&1; then exec zellij --config "${zellijConfigPath}"; else printf '%s\\n' 'emdash: zellij not found on remote, running without session persistence'; exec ${providerCmd}; fi; else printf '%s\\n' ${quoteShellArg(
         msg
       )}; fi`;
       lines.push(`sh -ilc ${quoteShellArg(shScript)}`);
@@ -544,6 +553,52 @@ function execFileAsync(cmd: string, args: string[]): Promise<{ stdout: string; s
   });
 }
 
+function buildRemoteZellijConfigPath(sessionName: string): string {
+  return `$HOME/.config/emdash/session-backends/zellij/${sessionName}/config.kdl`;
+}
+
+async function ensureRemoteZellijLauncher(args: {
+  sshArgs: string[];
+  sshTarget: string;
+  sessionName: string;
+  cwd: string;
+  providerCommand: string;
+  preProviderCommands?: string[];
+}): Promise<void> {
+  const { sshArgs, sshTarget, sessionName, cwd, providerCommand, preProviderCommands = [] } = args;
+  const wrapperCommand = [...preProviderCommands, providerCommand].join(' && ');
+  const wrapperScript = [
+    '#!/bin/sh',
+    `cd ${quoteShellArg(cwd)} || exit 1`,
+    `exec /bin/sh -ilc ${quoteShellArg(`${wrapperCommand}; exec /bin/sh -il`)}`,
+    '',
+  ].join('\n');
+
+  const script = [
+    'set -eu',
+    `base_dir="$HOME/.config/emdash/session-backends/zellij/${sessionName}"`,
+    'wrapper_path="$base_dir/launcher.sh"',
+    'config_path="$base_dir/config.kdl"',
+    'mkdir -p "$base_dir"',
+    `cat > "$wrapper_path" <<'EMDASH_ZELLIJ_WRAPPER'\n${wrapperScript}EMDASH_ZELLIJ_WRAPPER`,
+    'chmod 700 "$wrapper_path"',
+    'cat > "$config_path" <<EMDASH_ZELLIJ_CONFIG',
+    `session_name "${sessionName}"`,
+    'attach_to_session true',
+    'on_force_close "detach"',
+    'session_serialization true',
+    'pane_viewport_serialization true',
+    'scrollback_lines_to_serialize 0',
+    'serialization_interval 60',
+    'support_kitty_keyboard_protocol true',
+    `default_cwd "${cwd.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`,
+    'default_shell "$wrapper_path"',
+    'EMDASH_ZELLIJ_CONFIG',
+  ].join('\n');
+
+  await execFileAsync('ssh', [...sshArgs, sshTarget, `sh -ilc ${quoteShellArg(script)}`]);
+}
+
 async function resolveShellSetup(cwd: string): Promise<string | undefined> {
   // Committed .emdash.json lives in the worktree itself
   const fromCwd = lifecycleScriptsService.getShellSetup(cwd);
@@ -557,14 +612,29 @@ async function resolveShellSetup(cwd: string): Promise<string | undefined> {
   return undefined;
 }
 
-async function resolveTmuxEnabled(cwd: string): Promise<boolean> {
-  if (lifecycleScriptsService.getTmuxEnabled(cwd)) return true;
+async function resolveSessionBackend(
+  cwd: string,
+  options?: { defaultPersistentBackend?: PersistentSessionBackend }
+): Promise<SessionBackend> {
+  const configuredFromCwd = lifecycleScriptsService.getConfiguredSessionBackend(cwd);
+  if (configuredFromCwd) {
+    return configuredFromCwd;
+  }
+
   try {
     const task = await databaseService.getTaskByPath(cwd);
     const project = task ? await databaseService.getProjectById(task.projectId) : null;
-    if (project?.path) return lifecycleScriptsService.getTmuxEnabled(project.path);
+    if (project?.path) {
+      const configuredFromProject = lifecycleScriptsService.getConfiguredSessionBackend(
+        project.path
+      );
+      if (configuredFromProject) {
+        return configuredFromProject;
+      }
+    }
   } catch {}
-  return false;
+
+  return options?.defaultPersistentBackend ?? 'none';
 }
 
 export function registerPtyIpc(): void {
@@ -693,26 +763,12 @@ export function registerPtyIpc(): void {
             listeners.add(id);
           }
 
-          // Resolve tmux config from local project settings.
-          // Workspace-provisioned connections always use tmux for session persistence.
-          const isWorkspaceConnection = remote.connectionId.startsWith('workspace-');
-          const remoteTmux = isWorkspaceConnection || (cwd ? await resolveTmuxEnabled(cwd) : false);
-          const remoteTmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
-
-          const remoteInit = buildRemoteInitKeystrokes({
-            cwd: undefined,
-            tmux: remoteTmuxOpt,
-          });
-          if (remoteInit) {
-            waitForSshPromptThenWrite(id, proc, remoteInit, 'ptyIpc:start');
-          }
-
           try {
             const windows = BrowserWindow.getAllWindows();
             windows.forEach((w: any) => w.webContents.send('pty:started', { id }));
           } catch {}
 
-          return { ok: true, tmux: remoteTmux };
+          return { ok: true };
         }
 
         // Determine if we should skip resume
@@ -805,7 +861,10 @@ export function registerPtyIpc(): void {
         if (parsedPty) maybeAutoTrustForClaude(parsedPty.providerId, cwd);
 
         const shellSetup = cwd ? await resolveShellSetup(cwd) : undefined;
-        const tmux = cwd ? await resolveTmuxEnabled(cwd) : false;
+        const sessionBackend = cwd ? await resolveSessionBackend(cwd) : 'none';
+        const persistentSessionBackend = isPersistentSessionBackend(sessionBackend)
+          ? sessionBackend
+          : undefined;
 
         const proc =
           existing ??
@@ -820,7 +879,7 @@ export function registerPtyIpc(): void {
             initialPrompt,
             skipResume: shouldSkipResume,
             shellSetup,
-            tmux,
+            sessionBackend: persistentSessionBackend,
           }));
         const wc = event.sender;
         owners.set(id, wc);
@@ -895,7 +954,7 @@ export function registerPtyIpc(): void {
           });
         } catch {}
 
-        return { ok: true, tmux };
+        return { ok: true, sessionBackend: persistentSessionBackend };
       } catch (err: any) {
         log.error('pty:start FAIL', {
           id: args.id,
@@ -1010,10 +1069,21 @@ export function registerPtyIpc(): void {
     }
   );
 
-  // Kill a tmux session by PTY ID (used during task deletion cleanup)
+  // Kill a persistent session backend by PTY ID (used during task deletion cleanup).
+  ipcMain.handle('pty:killPersistentSession', async (_event, args: { id: string }) => {
+    try {
+      killPersistentSession(args.id);
+      return { ok: true };
+    } catch (e) {
+      log.error('pty:killPersistentSession error', { id: args.id, error: e });
+      return { ok: false, error: String(e) };
+    }
+  });
+
+  // Backward-compatible tmux-specific alias.
   ipcMain.handle('pty:killTmux', async (_event, args: { id: string }) => {
     try {
-      killTmuxSession(args.id);
+      killPersistentSession(args.id, 'tmux');
       return { ok: true };
     } catch (e) {
       log.error('pty:killTmux error', { id: args.id, error: e });
@@ -1196,6 +1266,30 @@ export function registerPtyIpc(): void {
             );
           }
 
+          const isWorkspaceConn = remote.connectionId.startsWith('workspace-');
+          let remoteSessionBackend: SessionBackend = await resolveSessionBackend(cwd, {
+            defaultPersistentBackend: isWorkspaceConn ? 'tmux' : undefined,
+          });
+
+          if (remoteSessionBackend === 'zellij') {
+            try {
+              await ensureRemoteZellijLauncher({
+                sshArgs: ssh.args,
+                sshTarget: ssh.target,
+                sessionName: getPersistentSessionName(id),
+                cwd,
+                providerCommand: remoteProvider.cmd,
+                preProviderCommands,
+              });
+            } catch (err: any) {
+              log.warn('ptyIpc:startDirect failed to prepare remote zellij launcher', {
+                id,
+                error: err?.message || String(err),
+              });
+              remoteSessionBackend = 'none';
+            }
+          }
+
           const remoteInitCommand = cwd
             ? `cd ${quoteShellArg(cwd)} && exec \${SHELL:-/bin/sh} -il`
             : undefined;
@@ -1228,16 +1322,17 @@ export function registerPtyIpc(): void {
             listeners.add(id);
           }
 
-          // Resolve tmux config from local project settings.
-          // Workspace-provisioned connections always use tmux for session persistence.
-          const isWorkspaceConn = remote.connectionId.startsWith('workspace-');
-          const remoteTmux = isWorkspaceConn || (cwd ? await resolveTmuxEnabled(cwd) : false);
-          const tmuxOpt = remoteTmux ? { sessionName: getTmuxSessionName(id) } : undefined;
+          const persistentRemoteSession = isPersistentSessionBackend(remoteSessionBackend)
+            ? {
+                backend: remoteSessionBackend,
+                sessionName: getPersistentSessionName(id),
+              }
+            : undefined;
 
           const remoteInit = buildRemoteInitKeystrokes({
             cwd: undefined,
             provider: remoteProvider,
-            tmux: tmuxOpt,
+            persistentSession: persistentRemoteSession,
             preProviderCommands: preProviderCommands.length ? preProviderCommands : undefined,
           });
           if (remoteInit) {
@@ -1250,7 +1345,7 @@ export function registerPtyIpc(): void {
             windows.forEach((w: any) => w.webContents.send('pty:started', { id }));
           } catch {}
 
-          return { ok: true, tmux: remoteTmux };
+          return { ok: true, sessionBackend: persistentRemoteSession?.backend };
         }
 
         if (existing) {
@@ -1278,7 +1373,10 @@ export function registerPtyIpc(): void {
         maybeAutoTrustForClaude(providerId, cwd);
 
         const shellSetup = await resolveShellSetup(cwd);
-        const tmux = await resolveTmuxEnabled(cwd);
+        const sessionBackend = await resolveSessionBackend(cwd);
+        const persistentSessionBackend = isPersistentSessionBackend(sessionBackend)
+          ? sessionBackend
+          : undefined;
         const codexBindingStartedAt = providerId === 'codex' ? Date.now() : 0;
 
         // Write Claude Code hook config so it calls back to Emdash on events
@@ -1292,9 +1390,10 @@ export function registerPtyIpc(): void {
           }
         }
 
-        // Try direct spawn first; skip if shellSetup or tmux requires a shell wrapper
+        // Try direct spawn first; skip if shell setup or a persistent session backend requires
+        // a shell wrapper.
         const directProc =
-          shellSetup || tmux
+          shellSetup || persistentSessionBackend
             ? null
             : startDirectPty({
                 id,
@@ -1306,10 +1405,10 @@ export function registerPtyIpc(): void {
                 initialPrompt,
                 env,
                 resume: effectiveResume,
-                tmux,
+                sessionBackend: persistentSessionBackend,
               });
 
-        // Fall back to shell-based spawn when direct spawn is unavailable or shellSetup/tmux is set
+        // Fall back to shell-based spawn when direct spawn is unavailable or a wrapper is required.
         let usedFallback = false;
         let proc: import('node-pty').IPty;
         if (directProc) {
@@ -1319,7 +1418,7 @@ export function registerPtyIpc(): void {
           if (!provider?.cli) {
             return { ok: false, error: `CLI path not found for provider: ${providerId}` };
           }
-          if (!shellSetup && !tmux)
+          if (!shellSetup && !persistentSessionBackend)
             log.info('pty:startDirect - falling back to shell spawn', { id, providerId });
           proc = await startPty({
             id,
@@ -1332,7 +1431,7 @@ export function registerPtyIpc(): void {
             env,
             skipResume: !resume,
             shellSetup,
-            tmux,
+            sessionBackend: persistentSessionBackend,
           });
           usedFallback = true;
         }
@@ -1408,7 +1507,7 @@ export function registerPtyIpc(): void {
           windows.forEach((w: any) => w.webContents.send('pty:started', { id }));
         } catch {}
 
-        return { ok: true, tmux };
+        return { ok: true, sessionBackend: persistentSessionBackend };
       } catch (err: any) {
         log.error('pty:startDirect FAIL', { id: args.id, error: err?.message || err });
         return { ok: false, error: String(err?.message || err) };

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -1330,7 +1330,7 @@ export function registerPtyIpc(): void {
             : undefined;
 
           const remoteInit = buildRemoteInitKeystrokes({
-            cwd: undefined,
+            cwd: remoteSessionBackend === 'zellij' ? undefined : cwd,
             provider: remoteProvider,
             persistentSession: persistentRemoteSession,
             preProviderCommands: preProviderCommands.length ? preProviderCommands : undefined,

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1626,6 +1626,13 @@ export async function startPty(options: {
       cwd: useCwd,
       env: useEnv,
     });
+
+    if (process.platform === 'win32') {
+      (proc as IPty & { on?: (event: string, listener: (error: Error) => void) => void }).on?.(
+        'error',
+        () => {}
+      );
+    }
   } catch (err: any) {
     // Track initial spawn error
     const provider = args.find((arg) => PROVIDERS.some((p) => p.cli === arg));

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -6,6 +6,7 @@ import type { IPty } from 'node-pty';
 import { log } from '../lib/logger';
 import { PROVIDERS, type ProviderDefinition } from '@shared/providers/registry';
 import { parsePtyId } from '@shared/ptyId';
+import { getPersistentSessionName, type PersistentSessionBackend } from '@shared/sessionBackend';
 import { providerStatusCache } from './providerStatusCache';
 import { errorTracking } from '../errorTracking';
 import { getProviderCustomConfig } from '../settings';
@@ -77,7 +78,8 @@ type PtyRecord = {
   kind?: 'local' | 'ssh';
   cols?: number;
   rows?: number;
-  tmuxSessionName?: string; // Set when session is wrapped in tmux
+  sessionBackend?: PersistentSessionBackend;
+  persistentSessionName?: string;
 };
 
 const ptys = new Map<string, PtyRecord>();
@@ -173,21 +175,75 @@ function getDisplayEnv(): Record<string, string> {
   return env;
 }
 
-// --- Tmux session helpers ---
+// --- Persistent session backend helpers ---
 
 /**
- * Derive a deterministic tmux session name from a PTY ID.
- * Sanitizes to characters allowed by tmux (alphanumeric, `-`, `_`, `.`).
+ * @deprecated Use getPersistentSessionName() instead.
  */
 export function getTmuxSessionName(ptyId: string): string {
-  // PTY ID format: {providerId}-main-{taskId} or {providerId}-chat-{conversationId}
-  // Prefix with "emdash-" and sanitize
-  const sanitized = ptyId.replace(/[^a-zA-Z0-9._-]/g, '-');
-  return `emdash-${sanitized}`;
+  return getPersistentSessionName(ptyId);
 }
 
 function resolveTmuxPath(): string | null {
   return resolveCommandPathCached('tmux');
+}
+
+function resolveZellijPath(): string | null {
+  return resolveCommandPathCached('zellij');
+}
+
+function getPersistentSessionStateDir(backend: PersistentSessionBackend): string {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { app } = require('electron');
+  return path.join(app.getPath('userData'), 'session-backends', backend);
+}
+
+function escapeKdlString(value: string): string {
+  return `"${value.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
+}
+
+function buildExecScript(command: string, args: string[]): string {
+  return `exec ${[command, ...args].map(escapeShSingleQuoted).join(' ')}`;
+}
+
+function ensureLocalZellijLaunchConfig(options: {
+  id: string;
+  cwd: string;
+  command: string;
+  args: string[];
+}): { configPath: string; sessionName: string } {
+  const sessionName = getPersistentSessionName(options.id);
+  const baseDir = path.join(getPersistentSessionStateDir('zellij'), sessionName);
+  const wrapperPath = path.join(baseDir, 'launcher.sh');
+  const configPath = path.join(baseDir, 'config.kdl');
+
+  const wrapperScript = [
+    '#!/bin/sh',
+    `cd ${escapeShSingleQuoted(options.cwd)} || exit 1`,
+    buildExecScript(options.command, options.args),
+    '',
+  ].join('\n');
+
+  const configContent = [
+    `session_name ${escapeKdlString(sessionName)}`,
+    'attach_to_session true',
+    'on_force_close "detach"',
+    'session_serialization true',
+    'pane_viewport_serialization true',
+    'scrollback_lines_to_serialize 0',
+    'serialization_interval 60',
+    'support_kitty_keyboard_protocol true',
+    `default_cwd ${escapeKdlString(options.cwd)}`,
+    `default_shell ${escapeKdlString(wrapperPath)}`,
+    '',
+  ].join('\n');
+
+  fs.mkdirSync(baseDir, { recursive: true });
+  fs.writeFileSync(wrapperPath, wrapperScript, 'utf8');
+  fs.chmodSync(wrapperPath, 0o700);
+  fs.writeFileSync(configPath, configContent, 'utf8');
+
+  return { configPath, sessionName };
 }
 
 /**
@@ -195,28 +251,48 @@ function resolveTmuxPath(): string | null {
  * for non-existent sessions (e.g., tmux not installed or session already dead).
  */
 export function killTmuxSession(ptyId: string): void {
-  const sessionName = getTmuxSessionName(ptyId);
-  const tmuxPath = resolveTmuxPath();
-  if (!tmuxPath) {
+  killPersistentSession(ptyId, 'tmux');
+}
+
+export function killPersistentSession(ptyId: string, backend?: PersistentSessionBackend): void {
+  const sessionBackend = backend ?? ptys.get(ptyId)?.sessionBackend;
+  if (!sessionBackend) {
+    killPersistentSession(ptyId, 'tmux');
+    killPersistentSession(ptyId, 'zellij');
     return;
   }
+
+  const sessionName = getPersistentSessionName(ptyId);
+  const commandPath = sessionBackend === 'tmux' ? resolveTmuxPath() : resolveZellijPath();
+  if (!commandPath) {
+    return;
+  }
+
+  const commandArgs =
+    sessionBackend === 'tmux'
+      ? ['kill-session', '-t', sessionName]
+      : ['kill-sessions', sessionName];
+
   try {
     const { execFile } = require('child_process');
-    execFile(tmuxPath, ['kill-session', '-t', sessionName], { timeout: 5000 }, (err: any) => {
+    execFile(commandPath, commandArgs, { timeout: 5000 }, (err: any) => {
       if (!err) {
-        log.info('ptyManager:tmux - killed session', { sessionName });
+        log.info('ptyManager:sessionBackend - killed session', {
+          backend: sessionBackend,
+          sessionName,
+        });
       }
-      // Ignore errors — session may not exist or tmux not installed
+      // Ignore errors — session may not exist or the backend may not be installed
     });
   } catch {
     // Ignore
   }
 }
 
-// TODO: Remote tmux cleanup will be handled by the workspace provider teardown script.
+// TODO: Remote persistent session cleanup will be handled by the workspace provider teardown script.
 // The PTY record doesn't currently store SSH target/args, so we can't shell out
-// `ssh <target> tmux kill-session` from here. When workspace providers land, the
-// teardown script is the right place for this.
+// `ssh <target> <backend-specific kill command>` from here. When workspace providers land,
+// the teardown script is the right place for this.
 
 function resolveWindowsPtySpawn(
   command: string,
@@ -1074,16 +1150,20 @@ export function startDirectPty(options: {
   initialPrompt?: string;
   env?: Record<string, string>;
   resume?: boolean;
+  sessionBackend?: PersistentSessionBackend;
   tmux?: boolean;
 }): IPty | null {
   if (process.env.EMDASH_DISABLE_PTY === '1') {
     throw new Error('PTY disabled via EMDASH_DISABLE_PTY=1');
   }
 
-  // Tmux wrapping requires a shell — fall back to startPty() which handles tmux.
-  if (options.tmux) {
-    log.info('ptyManager:directSpawn - tmux enabled, falling back to shell spawn', {
+  const persistentSessionBackend = options.sessionBackend ?? (options.tmux ? 'tmux' : undefined);
+
+  // Persistent session backends require a shell wrapper.
+  if (persistentSessionBackend) {
+    log.info('ptyManager:directSpawn - persistent session backend enabled, falling back', {
       id: options.id,
+      backend: persistentSessionBackend,
     });
     return null;
   }
@@ -1264,6 +1344,7 @@ export async function startPty(options: {
   initialPrompt?: string;
   skipResume?: boolean;
   shellSetup?: string;
+  sessionBackend?: PersistentSessionBackend;
   tmux?: boolean;
 }): Promise<IPty> {
   if (process.env.EMDASH_DISABLE_PTY === '1') {
@@ -1280,8 +1361,10 @@ export async function startPty(options: {
     initialPrompt,
     skipResume,
     shellSetup,
+    sessionBackend,
     tmux,
   } = options;
+  const persistentSessionBackend = sessionBackend ?? (tmux ? 'tmux' : undefined);
 
   const defaultShell = getDefaultShell();
   let useShell = shell || defaultShell;
@@ -1479,23 +1562,57 @@ export async function startPty(options: {
     } catch {}
   }
 
-  // When tmux is enabled, wrap the spawn in a tmux session.
-  // tmux new-session -As <name> creates or attaches to a named session.
-  // The inner shell command (with the agent CLI) runs inside tmux.
-  let tmuxSessionName: string | undefined;
+  // When a persistent session backend is enabled, wrap the spawn in it so the
+  // terminal session can outlive the Electron PTY client connection.
+  let activeSessionBackend: PersistentSessionBackend | undefined;
+  let persistentSessionName: string | undefined;
   let spawnCommand = useShell;
   let spawnArgs = args;
 
-  if (tmux && process.platform !== 'win32') {
-    const tmuxPath = resolveTmuxPath();
-    if (!tmuxPath) {
-      log.warn('ptyManager:tmux - tmux not found, falling back to unwrapped spawn', { id });
-    } else {
-      tmuxSessionName = getTmuxSessionName(id);
-      // Build: tmux new-session -As <name> -- <shell> <args...>
-      spawnCommand = tmuxPath;
-      spawnArgs = ['new-session', '-As', tmuxSessionName, '--', useShell, ...args];
-      log.info('ptyManager:tmux - wrapping in tmux session', { id, tmuxSessionName, tmuxPath });
+  if (persistentSessionBackend && process.platform !== 'win32') {
+    if (persistentSessionBackend === 'tmux') {
+      const tmuxPath = resolveTmuxPath();
+      if (!tmuxPath) {
+        log.warn('ptyManager:tmux - tmux not found, falling back to unwrapped spawn', { id });
+      } else {
+        persistentSessionName = getPersistentSessionName(id);
+        activeSessionBackend = 'tmux';
+        spawnCommand = tmuxPath;
+        spawnArgs = ['new-session', '-As', persistentSessionName, '--', useShell, ...args];
+        log.info('ptyManager:tmux - wrapping in tmux session', {
+          id,
+          sessionName: persistentSessionName,
+          tmuxPath,
+        });
+      }
+    } else if (persistentSessionBackend === 'zellij') {
+      const zellijPath = resolveZellijPath();
+      if (!zellijPath) {
+        log.warn('ptyManager:zellij - zellij not found, falling back to unwrapped spawn', { id });
+      } else {
+        try {
+          const launchConfig = ensureLocalZellijLaunchConfig({
+            id,
+            cwd: useCwd,
+            command: useShell,
+            args,
+          });
+          persistentSessionName = launchConfig.sessionName;
+          activeSessionBackend = 'zellij';
+          spawnCommand = zellijPath;
+          spawnArgs = ['--config', launchConfig.configPath];
+          log.info('ptyManager:zellij - attaching to persistent zellij session', {
+            id,
+            sessionName: persistentSessionName,
+            configPath: launchConfig.configPath,
+          });
+        } catch (error) {
+          log.warn('ptyManager:zellij - failed to prepare launcher, falling back', {
+            id,
+            error: String(error),
+          });
+        }
+      }
     }
   }
 
@@ -1540,7 +1657,15 @@ export async function startPty(options: {
     }
   }
 
-  ptys.set(id, { id, proc, kind: 'local', cols, rows, tmuxSessionName });
+  ptys.set(id, {
+    id,
+    proc,
+    kind: 'local',
+    cols,
+    rows,
+    sessionBackend: activeSessionBackend,
+    persistentSessionName,
+  });
   return proc;
 }
 
@@ -1615,8 +1740,8 @@ export function getPtyKind(id: string): 'local' | 'ssh' | undefined {
   return ptys.get(id)?.kind;
 }
 
-export function getPtyTmuxSessionName(id: string): string | undefined {
-  return ptys.get(id)?.tmuxSessionName;
+export function getPtySessionBackend(id: string): PersistentSessionBackend | undefined {
+  return ptys.get(id)?.sessionBackend;
 }
 
 export interface LifecyclePtyHandle {

--- a/src/renderer/components/ConfigEditorModal.tsx
+++ b/src/renderer/components/ConfigEditorModal.tsx
@@ -4,9 +4,10 @@ import { Dialog, DialogContent, DialogHeader, DialogTitle } from './ui/dialog';
 import { Input } from './ui/input';
 import { Label } from './ui/label';
 import { Spinner } from './ui/spinner';
-import { Switch } from './ui/switch';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Textarea } from './ui/textarea';
 import { useFeatureFlag } from '../hooks/useFeatureFlag';
+import { normalizeSessionBackend, type SessionBackend } from '@shared/sessionBackend';
 
 type LifecycleScripts = {
   setup: string;
@@ -24,6 +25,7 @@ type ConfigShape = Record<string, unknown> & {
   preservePatterns?: string[];
   scripts?: Partial<LifecycleScripts>;
   shellSetup?: string;
+  sessionBackend?: SessionBackend;
   tmux?: boolean;
   workspaceProvider?: WorkspaceProviderConfig;
 };
@@ -109,10 +111,10 @@ function applyShellSetup(config: ConfigShape, shellSetup: string): ConfigShape {
   return { ...rest, shellSetup: trimmed };
 }
 
-function applyTmux(config: ConfigShape, tmux: boolean): ConfigShape {
-  const { tmux: _tmux, ...rest } = config;
-  if (!tmux) return rest;
-  return { ...rest, tmux: true };
+function applySessionBackend(config: ConfigShape, sessionBackend: SessionBackend): ConfigShape {
+  const { tmux: _tmux, sessionBackend: _sessionBackend, ...rest } = config;
+  if (sessionBackend === 'none') return rest;
+  return { ...rest, sessionBackend };
 }
 
 function applyWorkspaceProvider(
@@ -149,8 +151,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
   const [originalPreservePatternsInput, setOriginalPreservePatternsInput] = useState('');
   const [shellSetup, setShellSetup] = useState('');
   const [originalShellSetup, setOriginalShellSetup] = useState('');
-  const [tmux, setTmux] = useState(false);
-  const [originalTmux, setOriginalTmux] = useState(false);
+  const [sessionBackend, setSessionBackend] = useState<SessionBackend>('none');
+  const [originalSessionBackend, setOriginalSessionBackend] = useState<SessionBackend>('none');
   const [wpProvisionCommand, setWpProvisionCommand] = useState('');
   const [originalWpProvisionCommand, setOriginalWpProvisionCommand] = useState('');
   const [wpTerminateCommand, setWpTerminateCommand] = useState('');
@@ -173,11 +175,23 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
   const normalizedConfigContent = useMemo(() => {
     const withPatterns = applyPreservePatterns(config, preservePatterns);
     const withShellSetup = applyShellSetup(withPatterns, shellSetup);
-    const withTmux = applyTmux(withShellSetup, tmux);
-    const withWp = applyWorkspaceProvider(withTmux, wpProvisionCommand, wpTerminateCommand);
+    const withSessionBackend = applySessionBackend(withShellSetup, sessionBackend);
+    const withWp = applyWorkspaceProvider(
+      withSessionBackend,
+      wpProvisionCommand,
+      wpTerminateCommand
+    );
     const withScripts = applyScripts(withWp, scripts);
     return `${JSON.stringify(withScripts, null, 2)}\n`;
-  }, [config, preservePatterns, shellSetup, tmux, wpProvisionCommand, wpTerminateCommand, scripts]);
+  }, [
+    config,
+    preservePatterns,
+    shellSetup,
+    sessionBackend,
+    wpProvisionCommand,
+    wpTerminateCommand,
+    scripts,
+  ]);
 
   const scriptsDirty = useMemo(
     () =>
@@ -186,7 +200,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       scripts.teardown !== originalScripts.teardown ||
       preservePatternsInput !== originalPreservePatternsInput ||
       shellSetup !== originalShellSetup ||
-      tmux !== originalTmux ||
+      sessionBackend !== originalSessionBackend ||
       wpProvisionCommand !== originalWpProvisionCommand ||
       wpTerminateCommand !== originalWpTerminateCommand,
     [
@@ -195,7 +209,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       originalScripts.run,
       originalScripts.setup,
       originalScripts.teardown,
-      originalTmux,
+      originalSessionBackend,
       originalWpProvisionCommand,
       originalWpTerminateCommand,
       shellSetup,
@@ -203,7 +217,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       scripts.run,
       scripts.setup,
       scripts.teardown,
-      tmux,
+      sessionBackend,
       wpProvisionCommand,
       wpTerminateCommand,
     ]
@@ -238,7 +252,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       const nextScripts = scriptsFromConfig(parsed);
       const nextPreservePatterns = preservePatternsFromConfig(parsed);
       const nextShellSetup = typeof parsed.shellSetup === 'string' ? parsed.shellSetup : '';
-      const nextTmux = parsed.tmux === true;
+      const nextSessionBackend = normalizeSessionBackend(parsed);
       const wp = parsed.workspaceProvider;
       const nextWpProvision =
         wp && typeof wp === 'object' && typeof wp.provisionCommand === 'string'
@@ -255,8 +269,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       setOriginalPreservePatternsInput(nextPreservePatterns.join('\n'));
       setShellSetup(nextShellSetup);
       setOriginalShellSetup(nextShellSetup);
-      setTmux(nextTmux);
-      setOriginalTmux(nextTmux);
+      setSessionBackend(nextSessionBackend);
+      setOriginalSessionBackend(nextSessionBackend);
       setWpProvisionCommand(nextWpProvision);
       setOriginalWpProvisionCommand(nextWpProvision);
       setWpTerminateCommand(nextWpTerminate);
@@ -269,8 +283,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       setOriginalPreservePatternsInput('');
       setShellSetup('');
       setOriginalShellSetup('');
-      setTmux(false);
-      setOriginalTmux(false);
+      setSessionBackend('none');
+      setOriginalSessionBackend('none');
       setWpProvisionCommand('');
       setOriginalWpProvisionCommand('');
       setWpTerminateCommand('');
@@ -328,9 +342,9 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
 
       const nextConfig = applyScripts(
         applyWorkspaceProvider(
-          applyTmux(
+          applySessionBackend(
             applyShellSetup(applyPreservePatterns(config, preservePatterns), shellSetup),
-            tmux
+            sessionBackend
           ),
           wpProvisionCommand,
           wpTerminateCommand
@@ -341,7 +355,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       setOriginalScripts(scripts);
       setOriginalPreservePatternsInput(preservePatternsInput);
       setOriginalShellSetup(shellSetup);
-      setOriginalTmux(tmux);
+      setOriginalSessionBackend(sessionBackend);
       setOriginalWpProvisionCommand(wpProvisionCommand);
       setOriginalWpTerminateCommand(wpTerminateCommand);
 
@@ -371,7 +385,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
     preservePatterns,
     projectPath,
     scripts,
-    tmux,
+    sessionBackend,
     wpProvisionCommand,
     wpTerminateCommand,
   ]);
@@ -436,22 +450,29 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
                 </p>
               </div>
 
-              <div className="flex items-center justify-between">
-                <div className="space-y-0.5">
-                  <Label htmlFor="config-tmux">tmux session persistence</Label>
-                  <p className="text-xs text-muted-foreground">
-                    Wrap agent sessions in tmux so they survive disconnects and restarts.
-                  </p>
-                </div>
-                <Switch
-                  id="config-tmux"
-                  checked={tmux}
-                  onCheckedChange={(checked) => {
-                    setTmux(checked);
+              <div className="space-y-2">
+                <Label htmlFor="config-session-backend">Persistent session backend</Label>
+                <Select
+                  value={sessionBackend}
+                  onValueChange={(value) => {
+                    setSessionBackend(value as SessionBackend);
                     setError(null);
                   }}
                   disabled={isSaving}
-                />
+                >
+                  <SelectTrigger id="config-session-backend" className="font-mono text-xs">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="none">none</SelectItem>
+                    <SelectItem value="tmux">tmux</SelectItem>
+                    <SelectItem value="zellij">zellij</SelectItem>
+                  </SelectContent>
+                </Select>
+                <p className="text-xs text-muted-foreground">
+                  Keep agent sessions alive across reconnects and restarts. `zellij` adds built-in
+                  resurrection; `tmux` matches the existing workflow.
+                </p>
               </div>
 
               {workspaceProviderEnabled && (

--- a/src/renderer/components/ReorderList.tsx
+++ b/src/renderer/components/ReorderList.tsx
@@ -12,6 +12,10 @@ interface ReorderListProps<T> {
   layoutScroll?: boolean;
   as?: keyof JSX.IntrinsicElements | React.ComponentType<any>;
   getKey?: (item: T, index: number) => string | number;
+  getItemProps?: (
+    item: T,
+    index: number
+  ) => Omit<React.HTMLAttributes<HTMLElement>, 'children' | 'className'>;
   children: (item: T, index: number) => React.ReactNode;
 }
 
@@ -24,6 +28,7 @@ export function ReorderList<T>({
   layoutScroll = true,
   as = 'div',
   getKey,
+  getItemProps,
   children,
 }: ReorderListProps<T>) {
   return (
@@ -41,6 +46,7 @@ export function ReorderList<T>({
           value={item as any}
           className={itemClassName}
           transition={{ layout: { duration: 0 } }}
+          {...getItemProps?.(item, index)}
         >
           {children(item, index)}
         </Reorder.Item>

--- a/src/renderer/components/TaskItem.tsx
+++ b/src/renderer/components/TaskItem.tsx
@@ -48,6 +48,7 @@ interface Task {
   status: 'active' | 'idle' | 'running';
   agentId?: string;
   useWorktree?: boolean;
+  lastActivityAt?: string | null;
   updatedAt?: string;
 }
 
@@ -154,7 +155,7 @@ export const TaskItem: React.FC<TaskItemProps> = ({
   }, [isEditing]);
 
   const hasChanges = !isLoading && (totalAdditions > 0 || totalDeletions > 0);
-  const compact = formatCompactDate(task.updatedAt);
+  const compact = formatCompactDate(task.lastActivityAt ?? task.updatedAt);
 
   // Right side: PR badge only, OR changes + date, OR just date
   const rightBadge = pr ? (

--- a/src/renderer/components/sidebar/LeftSidebar.tsx
+++ b/src/renderer/components/sidebar/LeftSidebar.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react'
 import { motion } from 'framer-motion';
 import ReorderList from '../ReorderList';
 import { Button } from '../ui/button';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import {
   Sidebar,
   SidebarContent,
@@ -30,7 +31,7 @@ import { TaskItem } from '../TaskItem';
 import { TaskDeleteButton } from '../TaskDeleteButton';
 import { RemoteProjectIndicator } from '../ssh/RemoteProjectIndicator';
 import { useRemoteProject } from '../../hooks/useRemoteProject';
-import type { Project } from '../../types/app';
+import type { Project, Task } from '../../types/app';
 import type { ConnectionState } from '../ssh';
 import { useProjectManagementContext } from '../../contexts/ProjectManagementProvider';
 import { useTaskManagementContext } from '../../contexts/TaskManagementContext';
@@ -39,9 +40,16 @@ import { useLocalStorage } from '../../hooks/useLocalStorage';
 import { ProjectsGroupLabel } from './ProjectsGroupLabel';
 import { useChangelogNotification } from '@/hooks/useChangelogNotification';
 import { useModalContext } from '@/contexts/ModalProvider';
+import { DEFAULT_TASK_SORT_MODE, type TaskSortMode } from '@/lib/taskOrdering';
 import { ChangelogNotificationCard } from './ChangelogNotificationCard';
 
 const PROJECT_ORDER_KEY = 'sidebarProjectOrder';
+const TASK_SORT_LABELS: Record<TaskSortMode, string> = {
+  'last-active': 'Last active',
+  created: 'Creation date',
+  alphabetical: 'Alphabetical',
+  manual: 'Manual order',
+};
 
 interface LeftSidebarProps {
   onSidebarContextChange?: (state: {
@@ -135,6 +143,7 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
   const {
     activeTask,
     tasksByProjectId,
+    taskSortModeByProjectId,
     archivedTasksByProjectId,
     handleSelectTask: onSelectTask,
     handleStartCreateTaskFromSidebar: onCreateTaskForProject,
@@ -143,6 +152,8 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
     handleRestoreTask: onRestoreTask,
     handleDeleteTask,
     handlePinTask,
+    handleTaskSortModeChange,
+    handleReorderTasks,
   } = useTaskManagementContext();
 
   const { settings } = useAppSettings();
@@ -286,6 +297,38 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                       const typedProject = project as Project;
                       const isProjectActive =
                         selectedProject?.id === typedProject.id && !activeTask;
+                      const projectTasks = tasksByProjectId[typedProject.id] ?? [];
+                      const taskSortMode =
+                        taskSortModeByProjectId[typedProject.id] ?? DEFAULT_TASK_SORT_MODE;
+                      const shouldShowTaskSortControl =
+                        projectTasks.length > 1 || taskSortMode !== DEFAULT_TASK_SORT_MODE;
+
+                      const renderTaskRow = (task: Task) => {
+                        const isActive = activeTask?.id === task.id;
+                        return (
+                          <motion.div
+                            key={task.id}
+                            whileTap={{ scale: 0.97 }}
+                            onClick={() =>
+                              handleNavigationWithCloseSettings(() => onSelectTask?.(task))
+                            }
+                            className={`group/task min-w-0 rounded-md py-1.5 pl-1 pr-2 hover:bg-accent ${taskSortMode === 'manual' ? 'cursor-grab active:cursor-grabbing' : ''} ${isActive ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+                          >
+                            <TaskItem
+                              task={task}
+                              showDelete={true}
+                              showDirectBadge={false}
+                              isPinned={!!task.metadata?.isPinned}
+                              onPin={() => handlePinTask(task)}
+                              onRename={(n) => onRenameTask?.(typedProject, task, n)}
+                              onDelete={() => handleDeleteTask(typedProject, task)}
+                              onArchive={() => onArchiveTask?.(typedProject, task)}
+                              primaryAction={taskHoverAction}
+                            />
+                          </motion.div>
+                        );
+                      };
+
                       return (
                         <SidebarMenuItem>
                           <Collapsible
@@ -346,40 +389,60 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                               className="mt-1 min-w-0 data-[state=closed]:hidden"
                             >
                               <div className="flex min-w-0 flex-col gap-1">
-                                {(tasksByProjectId[typedProject.id] ?? [])
-                                  .slice()
-                                  .sort(
-                                    (a, b) =>
-                                      (b.metadata?.isPinned ? 1 : 0) -
-                                      (a.metadata?.isPinned ? 1 : 0)
-                                  )
-                                  .map((task) => {
-                                    const isActive = activeTask?.id === task.id;
-                                    return (
-                                      <motion.div
-                                        key={task.id}
-                                        whileTap={{ scale: 0.97 }}
-                                        onClick={() =>
-                                          handleNavigationWithCloseSettings(() =>
-                                            onSelectTask?.(task)
-                                          )
-                                        }
-                                        className={`group/task min-w-0 rounded-md py-1.5 pl-1 pr-2 hover:bg-accent ${isActive ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+                                {shouldShowTaskSortControl && (
+                                  <div className="flex items-center justify-end px-1 pb-1">
+                                    <Select
+                                      value={taskSortMode}
+                                      onValueChange={(value) =>
+                                        handleTaskSortModeChange(
+                                          typedProject.id,
+                                          value as TaskSortMode
+                                        )
+                                      }
+                                    >
+                                      <SelectTrigger
+                                        aria-label={`Sort tasks in ${typedProject.name}`}
+                                        className="h-6 w-[132px] border-none bg-transparent px-2 text-[11px] font-medium text-muted-foreground shadow-none hover:bg-accent hover:text-foreground data-[state=open]:bg-accent data-[state=open]:text-foreground"
                                       >
-                                        <TaskItem
-                                          task={task}
-                                          showDelete={true}
-                                          showDirectBadge={false}
-                                          isPinned={!!task.metadata?.isPinned}
-                                          onPin={() => handlePinTask(task)}
-                                          onRename={(n) => onRenameTask?.(typedProject, task, n)}
-                                          onDelete={() => handleDeleteTask(typedProject, task)}
-                                          onArchive={() => onArchiveTask?.(typedProject, task)}
-                                          primaryAction={taskHoverAction}
-                                        />
-                                      </motion.div>
-                                    );
-                                  })}
+                                        <SelectValue placeholder="Sort tasks" />
+                                      </SelectTrigger>
+                                      <SelectContent align="end" side="bottom">
+                                        {(
+                                          [
+                                            'last-active',
+                                            'created',
+                                            'alphabetical',
+                                            'manual',
+                                          ] as TaskSortMode[]
+                                        ).map((mode) => (
+                                          <SelectItem key={mode} value={mode}>
+                                            {TASK_SORT_LABELS[mode]}
+                                          </SelectItem>
+                                        ))}
+                                      </SelectContent>
+                                    </Select>
+                                  </div>
+                                )}
+                                {taskSortMode === 'manual' && projectTasks.length > 1 ? (
+                                  <ReorderList
+                                    as="div"
+                                    axis="y"
+                                    items={projectTasks}
+                                    onReorder={(newOrder) =>
+                                      handleReorderTasks(typedProject.id, newOrder as Task[])
+                                    }
+                                    className="m-0 flex min-w-0 list-none flex-col gap-1 p-0"
+                                    itemClassName="relative min-w-0 list-none"
+                                    getKey={(task) => (task as Task).id}
+                                    getItemProps={() => ({
+                                      onPointerDown: (event) => event.stopPropagation(),
+                                    })}
+                                  >
+                                    {(task) => renderTaskRow(task as Task)}
+                                  </ReorderList>
+                                ) : (
+                                  projectTasks.map((task) => renderTaskRow(task))
+                                )}
                                 {(archivedTasksByProjectId[typedProject.id]?.length ?? 0) > 0 && (
                                   <Collapsible className="mt-1">
                                     <CollapsibleTrigger asChild>

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -17,13 +17,23 @@ import type { PlainThreadSummary } from '../types/plain';
 import type { GitLabIssueSummary } from '../types/gitlab';
 import type { ForgejoIssueSummary } from '../types/forgejo';
 import { upsertTaskInList } from '../lib/taskListCache';
+import {
+  DEFAULT_TASK_SORT_MODE,
+  mergeManualTaskOrder,
+  sortTasks,
+  type TaskSortMode,
+} from '../lib/taskOrdering';
 import { rpc } from '../lib/rpc';
 import { createTask } from '../lib/taskCreationService';
 import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
 import { useToast } from './use-toast';
 import { useModalContext } from '../contexts/ModalProvider';
+import { useLocalStorage } from './useLocalStorage';
 
 const LIFECYCLE_TEARDOWN_TIMEOUT_MS = 15000;
+const TASK_SORT_MODE_STORAGE_KEY = 'emdash.sidebar.taskSortModeByProject';
+const TASK_MANUAL_ORDER_STORAGE_KEY = 'emdash.sidebar.taskManualOrderByProject';
+
 type LifecycleTarget = { taskId: string; taskPath: string; label: string };
 
 const getLifecycleTaskIds = (task: Task): string[] => {
@@ -201,6 +211,12 @@ export function useTaskManagement() {
   const { toast } = useToast();
   const { showModal } = useModalContext();
   const queryClient = useQueryClient();
+  const [taskSortModeByProjectId, setTaskSortModeByProjectId] = useLocalStorage<
+    Record<string, TaskSortMode>
+  >(TASK_SORT_MODE_STORAGE_KEY, {});
+  const [manualTaskOrderByProjectId, setManualTaskOrderByProjectId] = useLocalStorage<
+    Record<string, string[]>
+  >(TASK_MANUAL_ORDER_STORAGE_KEY, {});
 
   // ---------------------------------------------------------------------------
   // Task queries — one per project via useQueries
@@ -214,13 +230,26 @@ export function useTaskManagement() {
     })),
   });
 
-  const tasksByProjectId = useMemo(() => {
+  const queriedTasksByProjectId = useMemo(() => {
     const map: Record<string, Task[]> = {};
     projects.forEach((p, i) => {
       map[p.id] = taskResults[i]?.data ?? [];
     });
     return map;
   }, [projects, taskResults]);
+
+  const tasksByProjectId = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+    projects.forEach((project) => {
+      const mode = taskSortModeByProjectId[project.id] ?? DEFAULT_TASK_SORT_MODE;
+      map[project.id] = sortTasks(
+        queriedTasksByProjectId[project.id] ?? [],
+        mode,
+        manualTaskOrderByProjectId[project.id] ?? []
+      );
+    });
+    return map;
+  }, [manualTaskOrderByProjectId, projects, queriedTasksByProjectId, taskSortModeByProjectId]);
 
   const archivedTaskResults = useQueries({
     queries: projects.map((project) => ({
@@ -267,6 +296,33 @@ export function useTaskManagement() {
     []
   );
 
+  useEffect(() => {
+    setManualTaskOrderByProjectId((previous) => {
+      let changed = false;
+      const next: Record<string, string[]> = { ...previous };
+
+      for (const project of projects) {
+        const storedOrder = previous[project.id];
+        if (!storedOrder) continue;
+
+        const mergedOrder = mergeManualTaskOrder(
+          (queriedTasksByProjectId[project.id] ?? []).map((task) => task.id),
+          storedOrder
+        );
+
+        if (
+          mergedOrder.length !== storedOrder.length ||
+          mergedOrder.some((taskId, index) => taskId !== storedOrder[index])
+        ) {
+          next[project.id] = mergedOrder;
+          changed = true;
+        }
+      }
+
+      return changed ? next : previous;
+    });
+  }, [projects, queriedTasksByProjectId, setManualTaskOrderByProjectId]);
+
   // Reset active task when project management signals a navigation away
   useEffect(() => {
     if (resetTaskTrigger > 0) {
@@ -283,6 +339,42 @@ export function useTaskManagement() {
       queryClient.setQueryData<Task[]>(['tasks', projectId], (old = []) => updater(old));
     },
     [queryClient]
+  );
+
+  const handleTaskSortModeChange = useCallback(
+    (projectId: string, mode: TaskSortMode) => {
+      setTaskSortModeByProjectId((previous) => {
+        if ((previous[projectId] ?? DEFAULT_TASK_SORT_MODE) === mode) {
+          return previous;
+        }
+        return { ...previous, [projectId]: mode };
+      });
+
+      if (mode !== 'manual') return;
+
+      const currentVisibleTaskIds = (tasksByProjectId[projectId] ?? []).map((task) => task.id);
+      setManualTaskOrderByProjectId((previous) => ({
+        ...previous,
+        [projectId]: mergeManualTaskOrder(currentVisibleTaskIds, previous[projectId] ?? []),
+      }));
+    },
+    [setManualTaskOrderByProjectId, setTaskSortModeByProjectId, tasksByProjectId]
+  );
+
+  const handleReorderTasks = useCallback(
+    (projectId: string, orderedTasks: Task[]) => {
+      setTaskSortModeByProjectId((previous) => {
+        if ((previous[projectId] ?? DEFAULT_TASK_SORT_MODE) === 'manual') {
+          return previous;
+        }
+        return { ...previous, [projectId]: 'manual' };
+      });
+      setManualTaskOrderByProjectId((previous) => ({
+        ...previous,
+        [projectId]: orderedTasks.map((task) => task.id),
+      }));
+    },
+    [setManualTaskOrderByProjectId, setTaskSortModeByProjectId]
   );
 
   const removeTaskFromCache = useCallback(
@@ -1102,6 +1194,7 @@ export function useTaskManagement() {
     setActiveTaskAgent,
     allTasks,
     tasksByProjectId,
+    taskSortModeByProjectId,
     archivedTasksByProjectId,
     linkedGithubIssueMap,
     isCreatingTask,
@@ -1119,5 +1212,7 @@ export function useTaskManagement() {
     handleArchiveTask,
     handleRestoreTask,
     handlePinTask,
+    handleTaskSortModeChange,
+    handleReorderTasks,
   };
 }

--- a/src/renderer/lib/taskOrdering.ts
+++ b/src/renderer/lib/taskOrdering.ts
@@ -1,0 +1,87 @@
+import { normalizeSqliteTimestamp } from './utils';
+import type { Task } from '../types/app';
+
+export type TaskSortMode = 'last-active' | 'created' | 'alphabetical' | 'manual';
+
+export const DEFAULT_TASK_SORT_MODE: TaskSortMode = 'created';
+
+const taskNameCollator = new Intl.Collator(undefined, {
+  numeric: true,
+  sensitivity: 'base',
+});
+
+function getTimestamp(value?: string | null): number {
+  if (!value) return 0;
+
+  const normalized = normalizeSqliteTimestamp(value);
+  const parsed = Date.parse(normalized);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function compareCreatedDesc(left: Task, right: Task): number {
+  const diff = getTimestamp(right.createdAt) - getTimestamp(left.createdAt);
+  if (diff !== 0) return diff;
+  return taskNameCollator.compare(left.name, right.name);
+}
+
+function comparePinned(left: Task, right: Task): number {
+  return Number(Boolean(right.metadata?.isPinned)) - Number(Boolean(left.metadata?.isPinned));
+}
+
+export function mergeManualTaskOrder(taskIds: string[], storedOrder: string[]): string[] {
+  const validTaskIds = new Set(taskIds);
+  const seen = new Set<string>();
+
+  const retained = storedOrder.filter((taskId) => {
+    if (!validTaskIds.has(taskId) || seen.has(taskId)) return false;
+    seen.add(taskId);
+    return true;
+  });
+
+  const missing = taskIds.filter((taskId) => !seen.has(taskId));
+  return [...missing, ...retained];
+}
+
+export function sortTasks(tasks: Task[], mode: TaskSortMode, manualOrder: string[] = []): Task[] {
+  const ordered = [...tasks];
+
+  if (mode === 'manual') {
+    const normalizedManualOrder = mergeManualTaskOrder(
+      ordered.map((task) => task.id),
+      manualOrder
+    );
+    const orderIndex = new Map(normalizedManualOrder.map((taskId, index) => [taskId, index]));
+
+    ordered.sort((left, right) => {
+      const leftIndex = orderIndex.get(left.id) ?? Number.MAX_SAFE_INTEGER;
+      const rightIndex = orderIndex.get(right.id) ?? Number.MAX_SAFE_INTEGER;
+      if (leftIndex !== rightIndex) return leftIndex - rightIndex;
+      return compareCreatedDesc(left, right);
+    });
+
+    return ordered;
+  }
+
+  ordered.sort((left, right) => {
+    const pinDiff = comparePinned(left, right);
+    if (pinDiff !== 0) return pinDiff;
+
+    if (mode === 'alphabetical') {
+      const nameDiff = taskNameCollator.compare(left.name, right.name);
+      if (nameDiff !== 0) return nameDiff;
+      return compareCreatedDesc(left, right);
+    }
+
+    if (mode === 'last-active') {
+      const activityDiff =
+        getTimestamp(right.lastActivityAt ?? right.updatedAt ?? right.createdAt) -
+        getTimestamp(left.lastActivityAt ?? left.updatedAt ?? left.createdAt);
+      if (activityDiff !== 0) return activityDiff;
+      return compareCreatedDesc(left, right);
+    }
+
+    return compareCreatedDesc(left, right);
+  });
+
+  return ordered;
+}

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -12,6 +12,7 @@ import { log } from '../lib/logger';
 import { TERMINAL_SNAPSHOT_VERSION, type TerminalSnapshotPayload } from '#types/terminalSnapshot';
 import { pendingInjectionManager } from '../lib/PendingInjectionManager';
 import { getProvider, type ProviderId } from '@shared/providers/registry';
+import type { PersistentSessionBackend } from '@shared/sessionBackend';
 import { consumeSubmittedInputChunk } from './submitCapture';
 import { isSlashCommandInput } from '../lib/slashCommand';
 import { buildCommentInjectionPayload } from '../lib/terminalInjection';
@@ -121,7 +122,7 @@ export class TerminalSessionManager {
   private ptyConnectPromise: Promise<{
     ok: boolean;
     reused?: boolean;
-    tmux?: boolean;
+    sessionBackend?: PersistentSessionBackend;
     error?: string;
   }> | null = null;
   private restartPromise: Promise<boolean> | null = null;
@@ -1166,16 +1167,16 @@ export class TerminalSessionManager {
     // Connect to PTY - pass resume flag if we have a previous session
     const result = await this.connectPty(hasSnapshot);
 
-    // When tmux is active, disable snapshots — tmux preserves terminal state natively.
-    if (result?.tmux) {
+    // Persistent session backends restore terminal state on their own.
+    if (result?.sessionBackend) {
       this.options.disableSnapshots = true;
       this.stopSnapshotTimer();
     }
 
     // Decide whether to restore snapshot based on PTY result
     try {
-      if (result?.tmux) {
-        // Tmux session: skip snapshot — tmux restores its own scrollback on reattach
+      if (result?.sessionBackend) {
+        // Persistent session backend: skip snapshot and let the backend restore state.
       } else if (result?.reused) {
         // Hot reload - PTY still running, restore snapshot for visual continuity
         if (snapshot) {
@@ -1226,9 +1227,12 @@ export class TerminalSessionManager {
     }
   }
 
-  private async connectPty(
-    hasExistingSession: boolean = false
-  ): Promise<{ ok: boolean; reused?: boolean; tmux?: boolean; error?: string }> {
+  private async connectPty(hasExistingSession: boolean = false): Promise<{
+    ok: boolean;
+    reused?: boolean;
+    sessionBackend?: PersistentSessionBackend;
+    error?: string;
+  }> {
     if (this.ptyConnectPromise) {
       return this.ptyConnectPromise;
     }

--- a/src/renderer/types/chat.ts
+++ b/src/renderer/types/chat.ts
@@ -73,6 +73,7 @@ export interface Task {
   metadata?: TaskMetadata | null;
   useWorktree?: boolean;
   archivedAt?: string | null;
+  lastActivityAt?: string | null;
   createdAt?: string;
   updatedAt?: string;
   agentId?: string;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -4,6 +4,7 @@ import type { AgentEvent } from '../../shared/agentEvents';
 import type { AutoMergeRequest } from '../lib/prStatus';
 import type { DiffPayload } from '../../shared/diff/types';
 import type { GitIndexUpdateArgs } from '../../shared/git/types';
+import type { PersistentSessionBackend, SessionBackend } from '../../shared/sessionBackend';
 
 type ProjectSettingsPayload = {
   projectId: string;
@@ -23,6 +24,8 @@ export type ProviderCustomConfig = {
   extraArgs?: string;
   env?: Record<string, string>;
 };
+
+export type ProjectSessionBackend = SessionBackend;
 
 export type ProviderCustomConfigs = Record<string, ProviderCustomConfig>;
 
@@ -80,7 +83,7 @@ declare global {
         autoApprove?: boolean;
         initialPrompt?: string;
         skipResume?: boolean;
-      }) => Promise<{ ok: boolean; tmux?: boolean; error?: string }>;
+      }) => Promise<{ ok: boolean; sessionBackend?: PersistentSessionBackend; error?: string }>;
       ptyStartDirect: (opts: {
         id: string;
         providerId: string;
@@ -92,7 +95,12 @@ declare global {
         initialPrompt?: string;
         env?: Record<string, string>;
         resume?: boolean;
-      }) => Promise<{ ok: boolean; reused?: boolean; tmux?: boolean; error?: string }>;
+      }) => Promise<{
+        ok: boolean;
+        reused?: boolean;
+        sessionBackend?: PersistentSessionBackend;
+        error?: string;
+      }>;
       ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) => Promise<{
         success: boolean;
         remotePaths?: string[];
@@ -101,6 +109,7 @@ declare global {
       ptyInput: (args: { id: string; data: string }) => void;
       ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
       ptyKill: (id: string) => void;
+      ptyKillPersistentSession: (id: string) => Promise<{ ok: boolean; error?: string }>;
       ptyKillTmux: (id: string) => Promise<{ ok: boolean; error?: string }>;
       onPtyData: (id: string, listener: (data: string) => void) => () => void;
       ptyGetSnapshot: (args: { id: string }) => Promise<{
@@ -1363,7 +1372,7 @@ export interface ElectronAPI {
     autoApprove?: boolean;
     initialPrompt?: string;
     skipResume?: boolean;
-  }) => Promise<{ ok: boolean; tmux?: boolean; error?: string }>;
+  }) => Promise<{ ok: boolean; sessionBackend?: PersistentSessionBackend; error?: string }>;
   ptyStartDirect: (opts: {
     id: string;
     providerId: string;
@@ -1374,7 +1383,12 @@ export interface ElectronAPI {
     initialPrompt?: string;
     env?: Record<string, string>;
     resume?: boolean;
-  }) => Promise<{ ok: boolean; reused?: boolean; tmux?: boolean; error?: string }>;
+  }) => Promise<{
+    ok: boolean;
+    reused?: boolean;
+    sessionBackend?: PersistentSessionBackend;
+    error?: string;
+  }>;
   ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) => Promise<{
     success: boolean;
     remotePaths?: string[];
@@ -1383,6 +1397,7 @@ export interface ElectronAPI {
   ptyInput: (args: { id: string; data: string }) => void;
   ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
   ptyKill: (id: string) => void;
+  ptyKillPersistentSession: (id: string) => Promise<{ ok: boolean; error?: string }>;
   ptyKillTmux: (id: string) => Promise<{ ok: boolean; error?: string }>;
   onPtyData: (id: string, listener: (data: string) => void) => () => void;
   ptyGetSnapshot: (args: { id: string }) => Promise<{

--- a/src/shared/sessionBackend.ts
+++ b/src/shared/sessionBackend.ts
@@ -1,0 +1,44 @@
+export const SESSION_BACKENDS = ['none', 'tmux', 'zellij'] as const;
+
+export type SessionBackend = (typeof SESSION_BACKENDS)[number];
+export type PersistentSessionBackend = Exclude<SessionBackend, 'none'>;
+
+export function parseSessionBackend(value: unknown): SessionBackend | null {
+  return value === 'none' || value === 'tmux' || value === 'zellij' ? value : null;
+}
+
+export function resolveConfiguredSessionBackend(
+  config: { sessionBackend?: unknown; tmux?: unknown } | null | undefined
+): SessionBackend | null {
+  if (!config || typeof config !== 'object') {
+    return null;
+  }
+
+  const explicit = parseSessionBackend(config.sessionBackend);
+  if (explicit) {
+    return explicit;
+  }
+
+  if (config.tmux === true) {
+    return 'tmux';
+  }
+
+  return null;
+}
+
+export function normalizeSessionBackend(
+  config: { sessionBackend?: unknown; tmux?: unknown } | null | undefined
+): SessionBackend {
+  return resolveConfiguredSessionBackend(config) ?? 'none';
+}
+
+export function isPersistentSessionBackend(
+  value: SessionBackend | PersistentSessionBackend | null | undefined
+): value is PersistentSessionBackend {
+  return value === 'tmux' || value === 'zellij';
+}
+
+export function getPersistentSessionName(ptyId: string): string {
+  const sanitized = ptyId.replace(/[^a-zA-Z0-9._-]/g, '-');
+  return `emdash-${sanitized}`;
+}

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -32,6 +32,8 @@ const openCodeGetPluginSourceMock = vi.fn(
 const clearStoredSessionMock = vi.fn();
 const getStoredResumeTargetMock = vi.fn(() => null);
 const markCodexSessionBoundMock = vi.fn();
+const lifecycleGetShellSetupMock = vi.fn(() => undefined);
+const lifecycleGetConfiguredSessionBackendMock = vi.fn(() => null);
 const codexThreadExistsForCwdMock = vi.fn(async () => true);
 const codexFindLatestRecentThreadForCwdMock = vi.fn(async () => null);
 const codexFindLatestThreadForCwdMock = vi.fn(async () => null);
@@ -191,9 +193,8 @@ vi.mock('../../main/services/ptyManager', () => ({
   buildProviderCliArgs: buildProviderCliArgsMock,
   getProviderRuntimeCliArgs: getProviderRuntimeCliArgsMock,
   resolveProviderCommandConfig: resolveProviderCommandConfigMock,
-  killTmuxSession: vi.fn(),
-  getTmuxSessionName: vi.fn(() => ''),
-  getPtyTmuxSessionName: vi.fn(() => ''),
+  killPersistentSession: vi.fn(),
+  getPtySessionBackend: vi.fn(() => undefined),
   clearStoredSession: clearStoredSessionMock,
   getStoredResumeTarget: getStoredResumeTargetMock,
   markCodexSessionBound: markCodexSessionBoundMock,
@@ -290,8 +291,8 @@ vi.mock('../../main/services/OpenCodeHookService', () => ({
 
 vi.mock('../../main/services/LifecycleScriptsService', () => ({
   lifecycleScriptsService: {
-    getShellSetup: vi.fn(() => undefined),
-    getTmuxEnabled: vi.fn(() => false),
+    getShellSetup: lifecycleGetShellSetupMock,
+    getConfiguredSessionBackend: lifecycleGetConfiguredSessionBackendMock,
   },
 }));
 
@@ -310,6 +311,8 @@ describe('ptyIpc notification lifecycle', () => {
     onDirectCliExitCallback = null;
     lastSshPtyStartOpts = null;
     resolveProviderCommandConfigMock.mockReturnValue(null);
+    lifecycleGetShellSetupMock.mockReturnValue(undefined);
+    lifecycleGetConfiguredSessionBackendMock.mockReturnValue(null);
     getProviderRuntimeCliArgsMock.mockClear();
     getStoredResumeTargetMock.mockReturnValue(null);
     codexThreadExistsForCwdMock.mockResolvedValue(true);
@@ -395,6 +398,51 @@ describe('ptyIpc notification lifecycle', () => {
     expect(written).toContain('sh -ilc');
     expect(written).toContain('command -v');
     expect(written).toContain('claude');
+  });
+
+  it('uses zellij as the remote persistent session backend when configured', async () => {
+    lifecycleGetConfiguredSessionBackendMock.mockReturnValue('zellij');
+
+    const { registerPtyIpc } = await import('../../main/services/ptyIpc');
+    registerPtyIpc();
+
+    const startDirect = ipcHandleHandlers.get('pty:startDirect');
+    expect(startDirect).toBeTypeOf('function');
+
+    const id = makePtyId('codex', 'main', 'task-remote-zellij');
+    const result = await startDirect!(
+      { sender: createSender() },
+      {
+        id,
+        providerId: 'codex',
+        cwd: '/tmp/task',
+        remote: { connectionId: 'ssh-config:devbox' },
+        cols: 120,
+        rows: 32,
+      }
+    );
+
+    expect(result?.ok).toBe(true);
+    expect(result?.sessionBackend).toBe('zellij');
+
+    const remoteSetupCall = execFileMock.mock.calls.find(
+      (call: any[]) =>
+        call[0] === 'ssh' &&
+        Array.isArray(call[1]) &&
+        typeof call[1][call[1].length - 1] === 'string' &&
+        call[1][call[1].length - 1].includes('session-backends/zellij')
+    );
+    expect(remoteSetupCall).toBeDefined();
+
+    const proc = ptys.get(id);
+    expect(proc).toBeDefined();
+    proc!.emitData('user@host:~$ ');
+
+    const written = (proc!.write as any).mock.calls.map((c: any[]) => c[0]).join('');
+    expect(written).toContain(
+      'exec zellij --config "$HOME/.config/emdash/session-backends/zellij/'
+    );
+    expect(written).toContain('config.kdl');
   });
 
   it('does not show completion notification on process exit (moved to AgentEventService)', async () => {

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -6,6 +6,7 @@ const fsReadFileSyncMock = vi.fn();
 const fsExistsSyncMock = vi.fn();
 const fsWriteFileSyncMock = vi.fn();
 const fsMkdirSyncMock = vi.fn();
+const fsChmodSyncMock = vi.fn();
 const fsStatSyncMock = vi.fn();
 const fsAccessSyncMock = vi.fn();
 const fsReaddirSyncMock = vi.fn();
@@ -45,6 +46,7 @@ vi.mock('fs', () => {
     existsSync: (...args: any[]) => fsExistsSyncMock(...args),
     writeFileSync: (...args: any[]) => fsWriteFileSyncMock(...args),
     mkdirSync: (...args: any[]) => fsMkdirSyncMock(...args),
+    chmodSync: (...args: any[]) => fsChmodSyncMock(...args),
     statSync: (...args: any[]) => fsStatSyncMock(...args),
     accessSync: (...args: any[]) => fsAccessSyncMock(...args),
     readdirSync: (...args: any[]) => fsReaddirSyncMock(...args),
@@ -83,6 +85,7 @@ describe('ptyManager provider command resolution', () => {
     agentEventGetTokenMock.mockReturnValue('');
     fsMkdirSyncMock.mockImplementation(() => undefined);
     fsWriteFileSyncMock.mockImplementation(() => undefined);
+    fsChmodSyncMock.mockImplementation(() => undefined);
     fsStatSyncMock.mockImplementation(() => {
       throw new Error('ENOENT');
     });
@@ -381,6 +384,60 @@ describe('ptyManager provider command resolution', () => {
           PATH: expect.anything(),
         }),
       })
+    );
+  });
+
+  it('spawns zellij with a generated config when zellij backend is enabled', async () => {
+    const origPath = process.env.PATH;
+    process.env.PATH = `/opt/homebrew/bin${origPath ? ':' + origPath : ''}`;
+
+    fsStatSyncMock.mockImplementation((candidate: string) => {
+      if (candidate === '/opt/homebrew/bin/zellij') {
+        return { isFile: () => true };
+      }
+      throw new Error('ENOENT');
+    });
+
+    const mockProc = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+    };
+    nodePtySpawnMock.mockReturnValue(mockProc);
+
+    const { startPty } = await import('../../main/services/ptyManager');
+    await startPty({
+      id: 'codex-main-task-zellij',
+      cwd: '/tmp/task',
+      shell: '/bin/zsh',
+      sessionBackend: 'zellij',
+    });
+
+    process.env.PATH = origPath;
+
+    expect(nodePtySpawnMock).toHaveBeenCalledWith(
+      '/opt/homebrew/bin/zellij',
+      ['/opt/homebrew/bin/zellij', '--config', expect.any(String)].slice(1),
+      expect.objectContaining({
+        cwd: '/tmp/task',
+      })
+    );
+
+    expect(fsWriteFileSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('/session-backends/zellij/emdash-codex-main-task-zellij/launcher.sh'),
+      expect.stringContaining("exec '/bin/zsh' '-il'"),
+      'utf8'
+    );
+    expect(fsWriteFileSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('/session-backends/zellij/emdash-codex-main-task-zellij/config.kdl'),
+      expect.stringContaining('session_name "emdash-codex-main-task-zellij"'),
+      'utf8'
+    );
+    expect(fsChmodSyncMock).toHaveBeenCalledWith(
+      expect.stringContaining('/session-backends/zellij/emdash-codex-main-task-zellij/launcher.sh'),
+      0o700
     );
   });
 });

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -440,6 +440,63 @@ describe('ptyManager provider command resolution', () => {
       0o700
     );
   });
+
+  it('attaches PTY pipe error suppression on Windows only', async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    const onWin32 = vi.fn();
+    const onDarwin = vi.fn();
+
+    try {
+      Object.defineProperty(process, 'platform', {
+        value: 'win32',
+        configurable: true,
+      });
+
+      nodePtySpawnMock.mockReturnValueOnce({
+        on: onWin32,
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        onData: vi.fn(),
+        onExit: vi.fn(),
+      });
+
+      const { startPty } = await import('../../main/services/ptyManager');
+      await startPty({
+        id: 'codex-main-task-win32',
+        cwd: '/tmp/task',
+        shell: '/bin/zsh',
+      });
+
+      expect(onWin32).toHaveBeenCalledWith('error', expect.any(Function));
+
+      Object.defineProperty(process, 'platform', {
+        value: 'darwin',
+        configurable: true,
+      });
+
+      nodePtySpawnMock.mockReturnValueOnce({
+        on: onDarwin,
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(),
+        onData: vi.fn(),
+        onExit: vi.fn(),
+      });
+
+      await startPty({
+        id: 'codex-main-task-darwin',
+        cwd: '/tmp/task',
+        shell: '/bin/zsh',
+      });
+
+      expect(onDarwin).not.toHaveBeenCalledWith('error', expect.any(Function));
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+      }
+    }
+  });
 });
 
 describe('stale Claude session detection', () => {

--- a/src/test/renderer/taskOrdering.test.ts
+++ b/src/test/renderer/taskOrdering.test.ts
@@ -1,0 +1,119 @@
+import { describe, expect, it } from 'vitest';
+import { sortTasks, mergeManualTaskOrder } from '../../renderer/lib/taskOrdering';
+import type { Task } from '../../renderer/types/app';
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: overrides.id ?? 'task-1',
+    projectId: overrides.projectId ?? 'project-1',
+    name: overrides.name ?? 'Task',
+    branch: overrides.branch ?? 'main',
+    path: overrides.path ?? `/tmp/${overrides.id ?? 'task-1'}`,
+    status: overrides.status ?? 'idle',
+    metadata: overrides.metadata ?? null,
+    useWorktree: overrides.useWorktree ?? true,
+    archivedAt: overrides.archivedAt ?? null,
+    lastActivityAt: overrides.lastActivityAt ?? null,
+    createdAt: overrides.createdAt ?? '2026-03-15 10:00:00',
+    updatedAt: overrides.updatedAt ?? '2026-03-15 10:00:00',
+    agentId: overrides.agentId,
+  };
+}
+
+describe('taskOrdering', () => {
+  it('sorts last-active tasks by recent activity while keeping pinned tasks first', () => {
+    const result = sortTasks(
+      [
+        makeTask({
+          id: 'older',
+          name: 'Older',
+          createdAt: '2026-03-15 08:00:00',
+          lastActivityAt: '2026-03-15 09:00:00',
+        }),
+        makeTask({
+          id: 'newer',
+          name: 'Newer',
+          createdAt: '2026-03-15 09:30:00',
+          lastActivityAt: '2026-03-15 11:00:00',
+        }),
+        makeTask({
+          id: 'pinned',
+          name: 'Pinned',
+          createdAt: '2026-03-15 07:00:00',
+          lastActivityAt: '2026-03-15 08:30:00',
+          metadata: { isPinned: true },
+        }),
+      ],
+      'last-active'
+    );
+
+    expect(result.map((task) => task.id)).toEqual(['pinned', 'newer', 'older']);
+  });
+
+  it('sorts by creation date descending', () => {
+    const result = sortTasks(
+      [
+        makeTask({ id: 'oldest', createdAt: '2026-03-14 08:00:00' }),
+        makeTask({ id: 'newest', createdAt: '2026-03-16 08:00:00' }),
+        makeTask({ id: 'middle', createdAt: '2026-03-15 08:00:00' }),
+      ],
+      'created'
+    );
+
+    expect(result.map((task) => task.id)).toEqual(['newest', 'middle', 'oldest']);
+  });
+
+  it('sorts alphabetically without case sensitivity', () => {
+    const result = sortTasks(
+      [
+        makeTask({ id: 'zeta', name: 'zeta' }),
+        makeTask({ id: 'alpha', name: 'Alpha' }),
+        makeTask({ id: 'beta', name: 'beta' }),
+      ],
+      'alphabetical'
+    );
+
+    expect(result.map((task) => task.id)).toEqual(['alpha', 'beta', 'zeta']);
+  });
+
+  it('falls back to updatedAt when lastActivityAt is not available yet', () => {
+    const result = sortTasks(
+      [
+        makeTask({
+          id: 'older',
+          lastActivityAt: null,
+          updatedAt: '2026-03-15 09:00:00',
+        }),
+        makeTask({
+          id: 'newer',
+          lastActivityAt: null,
+          updatedAt: '2026-03-15 11:00:00',
+        }),
+      ],
+      'last-active'
+    );
+
+    expect(result.map((task) => task.id)).toEqual(['newer', 'older']);
+  });
+
+  it('merges new tasks ahead of the saved manual order', () => {
+    expect(mergeManualTaskOrder(['task-c', 'task-b', 'task-a'], ['task-b', 'task-a'])).toEqual([
+      'task-c',
+      'task-b',
+      'task-a',
+    ]);
+  });
+
+  it('uses the saved manual order exactly when all tasks are already known', () => {
+    const result = sortTasks(
+      [
+        makeTask({ id: 'task-a', name: 'Alpha', metadata: { isPinned: true } }),
+        makeTask({ id: 'task-b', name: 'Beta' }),
+      ],
+      'manual',
+      ['task-b', 'task-a']
+    );
+
+    expect(result.map((task) => task.id)).toEqual(['task-b', 'task-a']);
+  });
+});


### PR DESCRIPTION
## Summary

Closes #1215  
Refs #1518

This PR turns persistent PTY handling into a configurable session-backend abstraction instead of treating it as a tmux-only feature.

Both issues are really about the same underlying problem: Emdash currently owns PTY lifetime directly, which makes long-running agent sessions fragile across disconnects, app restarts, and multi-device workflows. This change moves session lifetime behind a backend layer so Emdash can work with persistent terminal multiplexers instead of managing persistence itself.

As a result, `tmux` and `zellij` are now supported as first-class session backends for agent PTYs.

## What This Solves

- Makes persistent/resumable PTY sessions a real product concept instead of a tmux-specific special case
- Preserves the existing optional `tmux` workflow from #1215
- Adds `zellij` as a supported backend to address the main architectural need from #1518
- Allows local and remote agent sessions to reconnect to an existing persistent session instead of always starting from scratch
- Improves the path toward safer app restarts and reconnects for long-running agents

## What Changed

- Added a shared `sessionBackend` abstraction with supported values:
  - `none`
  - `tmux`
  - `zellij`
- Added shared parsing/normalization helpers for session backend config
- Updated lifecycle/config resolution so projects can opt into a backend through config
- Preserved backward compatibility with legacy `tmux: true` config
- Reworked PTY startup and cleanup logic to operate on a generic persistent backend instead of only tmux
- Added local `zellij` session support
- Added remote `zellij` session support for provider-backed PTYs
- Updated preload, IPC, and renderer typings so the renderer knows whether a PTY is backed by a persistent session backend
- Updated terminal snapshot behavior so renderer-side snapshotting is disabled for any persistent backend, not just tmux
- Replaced the old tmux toggle in project settings with a backend selector
- Added tests covering local and remote zellij flows

## Behavior After This PR

- `none` keeps the current non-persistent PTY behavior
- `tmux` keeps the existing persistent-session model, but now through the shared backend abstraction
- `zellij` becomes a first-class backend option for persistent/resumable agent sessions

This means Emdash now has a clean architectural path for persistent PTY sessions regardless of which multiplexer is used.

## Why This Is The Right Abstraction

Issue #1215 asks for optional persistent tmux-backed sessions. Issue #1518 asks for zellij as a first-class backend with better persistence ergonomics.

Those are not two unrelated features; they are two versions of the same requirement: PTY session lifetime should be delegated to a resumable backend rather than being tied directly to the app connection. This PR addresses that shared boundary and makes the implementation extensible instead of hardcoding more tmux-specific logic.

## Compatibility

- Existing tmux-based configuration continues to work
- Legacy `tmux: true` config is still recognized
- New config can use `sessionBackend: "none" | "tmux" | "zellij"`

## Non-Goals In This PR

- This PR does not make `zellij` the default backend
- This PR does not auto-install `zellij` on remote hosts
- This PR does not claim full “safe by default on cmd+q” behavior for all users out of the box

Those are product/defaulting decisions that can build on top of this backend abstraction in follow-up work.

## Testing

- Added PTY manager coverage for local zellij startup
- Added PTY IPC coverage for remote zellij startup and wiring
- Updated tests to cover the new session-backend behavior instead of tmux-only branching

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for configurable persistent session backends (tmux and zellij alternatives)
  * Tasks now track and display last activity time
  * Added multiple task sorting modes: by last activity, creation date, alphabetically, or manual reordering
  * Users can manually reorder tasks in the project sidebar

<!-- end of auto-generated comment: release notes by coderabbit.ai -->