### PR TITLE
fix: claude code starting in "do not ask" mode instead of the dangerously bypass permissions mode 

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -931,8 +931,16 @@ const ChatInterface: React.FC<Props> = ({
   }, [activeConversationId, handleCloseChat]);
 
   const isTerminal = agentMeta[agent]?.terminalOnly === true;
+
+  // Auto-approve is enabled if:
+  // 1. The task was explicitly created with autoApprove, OR
+  // 2. The global "auto-approve by default" setting is on
+  // In both cases the provider must actually support an auto-approve flag.
+  const { settings: autoApproveSettings } = useAppSettings();
   const autoApproveEnabled =
-    Boolean(task.metadata?.autoApprove) && Boolean(agentMeta[agent]?.autoApproveFlag);
+    (Boolean(task.metadata?.autoApprove) ||
+      Boolean(autoApproveSettings?.tasks?.autoApproveByDefault)) &&
+    Boolean(agentMeta[agent]?.autoApproveFlag);
 
   const isMainConversation = activeConversationId === mainConversationId;
 

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -13,6 +13,7 @@ import { classifyActivity, sampleActivityChunk } from '@/lib/activityClassifier'
 import { activityStore } from '@/lib/activityStore';
 import { Spinner } from './ui/spinner';
 import { BUSY_HOLD_MS, CLEAR_BUSY_MS } from '@/lib/activityConstants';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
 import { CornerDownLeft } from 'lucide-react';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import { useAutoScrollOnTaskSwitch } from '@/hooks/useAutoScrollOnTaskSwitch';
@@ -57,6 +58,7 @@ const MultiAgentTask: React.FC<Props> = ({
   onTaskInterfaceReady,
 }) => {
   const { effectiveTheme } = useTheme();
+  const { settings: multiAgentSettings } = useAppSettings();
   const [prompt, setPrompt] = useState('');
   const [activeTabIndex, setActiveTabIndex] = useState(0);
   const [variantBusy, setVariantBusy] = useState<Record<string, boolean>>({});
@@ -655,7 +657,8 @@ const MultiAgentTask: React.FC<Props> = ({
                       providerId={v.agent}
                       env={variantEnvs.get(v.worktreeId || v.path)}
                       autoApprove={
-                        Boolean(task.metadata?.autoApprove) &&
+                        (Boolean(task.metadata?.autoApprove) ||
+                          Boolean(multiAgentSettings?.tasks?.autoApproveByDefault)) &&
                         Boolean(agentMeta[v.agent]?.autoApproveFlag)
                       }
                       initialPrompt={


### PR DESCRIPTION
## Summary
previously i had the issue that, seemingly random, claude code was starting in the "do not ask" mode where then the AI agent also wasnt allowed to perform any file changes. this should fix this

## Snapshot
https://github.com/user-attachments/assets/3d41d75c-25d5-4854-a7d9-ff40911eb07e

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Auto-approve behavior can now be configured at the application level in addition to per-task settings, providing more flexible automation control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->