### PR TITLE
feat(open-in): add Foot terminal emulator support

### DIFF
--- a/src/shared/openInApps.ts
+++ b/src/shared/openInApps.ts
@@ -248,6 +248,21 @@ export const OPEN_IN_APPS: OpenInAppConfigShape[] = [
     },
   },
   {
+    id: 'foot',
+    label: 'Foot',
+    iconPath: ICON_PATHS.terminal,
+    supportsRemote: true,
+    platforms: {
+      linux: {
+        openCommands: [
+          'footclient --working-directory={{path}}',
+          'foot --working-directory={{path}}',
+        ],
+        checkCommands: ['footclient', 'foot'],
+      },
+    },
+  },
+  {
     id: 'zed',
     label: 'Zed',
     iconPath: ICON_PATHS.zed,


### PR DESCRIPTION
## Summary
- Add Foot terminal as a dedicated entry in the Open In tools dropdown for Linux
- Uses `footclient` (preferred, connects to foot server) with fallback to `foot` standalone
- Opens in the worktree directory via `--working-directory` flag

## Test plan
- [ ] Verify Foot appears in the Open In dropdown on Linux when `foot` or `footclient` is installed
- [ ] Verify clicking Foot opens a terminal in the correct worktree directory
- [ ] Verify Foot does not appear when neither `foot` nor `footclient` is available
- [ ] Verify existing terminal entries are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Foot terminal application to open files and directories. Available on Linux systems with remote functionality enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->