### PR TITLE
fix: ensure POSIX compatibility for remote shell commands

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -380,6 +380,15 @@ async function writeRemoteOpenCodePlugin(
   return configDir;
 }
 
+/**
+ * Builds a remote init command wrapped in `/bin/sh -c` so it works regardless
+ * of the remote login shell (fish, csh, etc. can't parse POSIX `${VAR:-…}`).
+ */
+function buildRemoteInitShellCommand(cwd: string): string {
+  const posixPayload = `cd ${quoteShellArg(cwd)} && exec "\${SHELL:-/bin/sh}" -il`;
+  return `/bin/sh -c ${quoteShellArg(posixPayload)}`;
+}
+
 function buildRemoteInitKeystrokes(args: {
   cwd?: string;
   provider?: { cli: string; cmd: string; installCommand?: string };
@@ -704,9 +713,7 @@ export function registerPtyIpc(): void {
 
           const ssh = await resolveSshInvocation(remote.connectionId);
 
-          const remoteInitCommand = cwd
-            ? `cd ${quoteShellArg(cwd)} && exec \${SHELL:-/bin/sh} -il`
-            : undefined;
+          const remoteInitCommand = cwd ? buildRemoteInitShellCommand(cwd) : undefined;
 
           const proc = startSshPty({
             id,
@@ -1247,9 +1254,7 @@ export function registerPtyIpc(): void {
             );
           }
 
-          const remoteInitCommand = cwd
-            ? `cd ${quoteShellArg(cwd)} && exec \${SHELL:-/bin/sh} -il`
-            : undefined;
+          const remoteInitCommand = cwd ? buildRemoteInitShellCommand(cwd) : undefined;
 
           const proc = startSshPty({
             id,

--- a/src/main/utils/__tests__/remoteOpenIn.test.ts
+++ b/src/main/utils/__tests__/remoteOpenIn.test.ts
@@ -36,10 +36,13 @@ describe('buildRemoteEditorUrl', () => {
 });
 
 describe('buildGhosttyRemoteExecArgs', () => {
-  const expectedRemoteShellCommand =
-    `cd '/home/azureuser/pro/smv/.emdash/worktrees/task one' && ` +
+  const posixPayload =
+    "cd '/home/azureuser/pro/smv/.emdash/worktrees/task one' && " +
     '(if command -v infocmp >/dev/null 2>&1 && [ -n "${TERM:-}" ] && infocmp "${TERM}" >/dev/null 2>&1; then :; else export TERM=xterm-256color; fi) && ' +
     '(exec "${SHELL:-/bin/bash}" || exec /bin/bash || exec /bin/sh)';
+
+  // quoteShellArg wraps in single quotes and escapes embedded single quotes with '\''
+  const expectedRemoteShellCommand = "/bin/sh -c '" + posixPayload.replace(/'/g, "'\\''") + "'";
 
   it('builds shared remote shell bootstrap command', () => {
     expect(
@@ -87,7 +90,7 @@ describe('buildGhosttyRemoteExecArgs', () => {
       '-p',
       '2202',
       '-t',
-      `cd '/tmp/x' && (if command -v infocmp >/dev/null 2>&1 && [ -n "\${TERM:-}" ] && infocmp "\${TERM}" >/dev/null 2>&1; then :; else export TERM=xterm-256color; fi) && (exec "\${SHELL:-/bin/bash}" || exec /bin/bash || exec /bin/sh)`,
+      buildRemoteTerminalShellCommand('/tmp/x'),
     ]);
   });
 

--- a/src/main/utils/remoteOpenIn.ts
+++ b/src/main/utils/remoteOpenIn.ts
@@ -43,7 +43,9 @@ type GhosttyRemoteExecInput = {
  * - keep session alive even when SHELL is unset/invalid by chaining shell fallbacks
  */
 export function buildRemoteTerminalShellCommand(targetPath: string): string {
-  return `cd ${quoteShellArg(targetPath)} && (if command -v infocmp >/dev/null 2>&1 && [ -n "\${TERM:-}" ] && infocmp "\${TERM}" >/dev/null 2>&1; then :; else export TERM=xterm-256color; fi) && (exec "\${SHELL:-/bin/bash}" || exec /bin/bash || exec /bin/sh)`;
+  // Wrap the POSIX payload in /bin/sh -c so non-POSIX login shells (fish, csh) can execute it.
+  const posixPayload = `cd ${quoteShellArg(targetPath)} && (if command -v infocmp >/dev/null 2>&1 && [ -n "\${TERM:-}" ] && infocmp "\${TERM}" >/dev/null 2>&1; then :; else export TERM=xterm-256color; fi) && (exec "\${SHELL:-/bin/bash}" || exec /bin/bash || exec /bin/sh)`;
+  return `/bin/sh -c ${quoteShellArg(posixPayload)}`;
 }
 
 /**

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -388,7 +388,8 @@ describe('ptyIpc notification lifecycle', () => {
 
     expect(startSshPtyMock).toHaveBeenCalledTimes(1);
     expect(lastSshPtyStartOpts?.target).toBe('remote-alias');
-    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain("cd '/tmp/task'");
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain('/bin/sh -c');
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toMatch(/cd\b.*\/tmp\/task/);
     expect(lastSshPtyStartOpts?.remoteInitCommand).toContain('exec');
 
     const proc = ptys.get(id);
@@ -614,7 +615,8 @@ describe('ptyIpc notification lifecycle', () => {
       })
     );
     expect(startSshPtyMock).toHaveBeenCalledTimes(1);
-    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain("cd '/tmp/task'");
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain('/bin/sh -c');
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toMatch(/cd\b.*\/tmp\/task/);
 
     const proc = ptys.get(id);
     expect(proc).toBeDefined();
@@ -662,7 +664,8 @@ describe('ptyIpc notification lifecycle', () => {
     );
 
     expect(result?.ok).toBe(true);
-    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain("cd '/tmp/task'");
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toContain('/bin/sh -c');
+    expect(lastSshPtyStartOpts?.remoteInitCommand).toMatch(/cd\b.*\/tmp\/task/);
 
     const proc = ptys.get(id);
     expect(proc).toBeDefined();


### PR DESCRIPTION
## Summary

 Briefly describe what this PR does and why 

## Fixes 
 Fixes #1573 

## Snapshot
not applicable

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Remote SSH terminal initialization now works correctly and reliably with all shell types, including various non-POSIX shells such as fish and csh.
  * Working directory setup and initialization during remote PTY session establishment is now significantly more reliable and consistent when working across all different remote shell environments and system configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->