### PR TITLE
feat(open-in): support user-configurable custom tools via settings

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -1,17 +1,11 @@
 import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import { exec, execFile } from 'child_process';
-import { readFile } from 'fs/promises';
-import { join } from 'path';
+import { readFile, stat } from 'fs/promises';
+import { extname, isAbsolute, join } from 'path';
 import { ensureProjectPrepared } from '../services/ProjectPrep';
 import { getAppSettings } from '../settings';
-import {
-  getAppById,
-  getResolvedLabel,
-  isOpenInAppSupportedForWorkspace,
-  OPEN_IN_APPS,
-  type OpenInAppId,
-  type PlatformKey,
-} from '@shared/openInApps';
+import { type PlatformKey } from '@shared/openInApps';
+import { getMergedApps, getResolvedAppById } from '../services/openInRegistry';
 import { databaseService } from '../services/DatabaseService';
 import { buildExternalToolEnv } from '../utils/childProcessEnv';
 import {
@@ -272,7 +266,7 @@ export function registerAppIpc() {
     async (
       _event,
       args: {
-        app: OpenInAppId;
+        app: string;
         path: string;
         isRemote?: boolean;
         sshConnectionId?: string | null;
@@ -288,18 +282,21 @@ export function registerAppIpc() {
       }
       try {
         const platform = process.platform as PlatformKey;
-        const appConfig = getAppById(appId);
-        if (!appConfig) {
+        const resolvedApp = getResolvedAppById(appId, platform);
+        if (!resolvedApp) {
           return { success: false, error: 'Invalid app ID' };
         }
 
-        const platformConfig = appConfig.platforms?.[platform];
-        const label = getResolvedLabel(appConfig, platform);
-        if (!platformConfig && !appConfig.alwaysAvailable) {
+        const label = resolvedApp.label;
+        if (
+          resolvedApp.openCommands.length === 0 &&
+          resolvedApp.openUrls.length === 0 &&
+          !resolvedApp.alwaysAvailable
+        ) {
           return { success: false, error: `${label} is not available on this platform.` };
         }
 
-        if (!isOpenInAppSupportedForWorkspace(appConfig, isRemote)) {
+        if (isRemote && !resolvedApp.supportsRemote) {
           return {
             success: false,
             error: `${label} is not available for remote SSH workspaces.`,
@@ -438,7 +435,7 @@ export function registerAppIpc() {
 
               if (lastError instanceof Error) throw lastError;
               throw new Error('Unable to launch Ghostty');
-            } else if (appConfig.supportsRemote) {
+            } else if (resolvedApp.supportsRemote) {
               // App claims to support remote but we don't have a handler
               return {
                 success: false,
@@ -456,8 +453,8 @@ export function registerAppIpc() {
         const quoted = (p: string) => `'${p.replace(/'/g, "'\\''")}'`;
 
         // Handle URL-based apps (like Warp)
-        if (platformConfig?.openUrls) {
-          for (const urlTemplate of platformConfig.openUrls) {
+        if (resolvedApp.openUrls.length > 0) {
+          for (const urlTemplate of resolvedApp.openUrls) {
             const url = urlTemplate
               .replace('{{path_url}}', encodeURIComponent(target))
               .replace('{{path}}', target);
@@ -475,7 +472,7 @@ export function registerAppIpc() {
         }
 
         // Handle command-based apps
-        const commands = platformConfig?.openCommands || [];
+        const commands = resolvedApp.openCommands;
         let command = '';
 
         if (commands.length > 0) {
@@ -491,7 +488,7 @@ export function registerAppIpc() {
           return { success: false, error: 'Unsupported platform or app' };
         }
 
-        if (appConfig.autoInstall) {
+        if (resolvedApp.autoInstall) {
           try {
             const settings = getAppSettings();
             if (settings?.projectPrep?.autoInstallOnOpenInEditor) {
@@ -508,11 +505,7 @@ export function registerAppIpc() {
         });
         return { success: true };
       } catch (error) {
-        const appConfig = getAppById(appId);
-        const catchLabel = appConfig
-          ? getResolvedLabel(appConfig, process.platform as PlatformKey)
-          : appId;
-        return { success: false, error: `Unable to open in ${catchLabel}` };
+        return { success: false, error: `Unable to open in ${appId}` };
       }
     }
   );
@@ -556,17 +549,22 @@ export function registerAppIpc() {
       });
     };
 
-    for (const app of OPEN_IN_APPS) {
-      // Skip apps that don't have platform-specific config
-      const platformConfig = app.platforms[platform];
-      if (!platformConfig && !app.alwaysAvailable) {
-        availability[app.id] = false;
+    const allApps = getMergedApps(platform);
+
+    for (const resolvedApp of allApps) {
+      // Always available apps are set to true by default
+      if (resolvedApp.alwaysAvailable) {
+        availability[resolvedApp.id] = true;
         continue;
       }
 
-      // Always available apps are set to true by default
-      if (app.alwaysAvailable) {
-        availability[app.id] = true;
+      // Apps with no detection methods and not always available
+      if (
+        resolvedApp.checkCommands.length === 0 &&
+        resolvedApp.bundleIds.length === 0 &&
+        resolvedApp.appNames.length === 0
+      ) {
+        availability[resolvedApp.id] = false;
         continue;
       }
 
@@ -574,18 +572,16 @@ export function registerAppIpc() {
         let isAvailable = false;
 
         // Check via bundle IDs (macOS)
-        if (platformConfig?.bundleIds) {
-          for (const bundleId of platformConfig.bundleIds) {
-            if (await checkMacApp(bundleId)) {
-              isAvailable = true;
-              break;
-            }
+        for (const bundleId of resolvedApp.bundleIds) {
+          if (await checkMacApp(bundleId)) {
+            isAvailable = true;
+            break;
           }
         }
 
         // Check via app names (macOS)
-        if (!isAvailable && platformConfig?.appNames) {
-          for (const appName of platformConfig.appNames) {
+        if (!isAvailable) {
+          for (const appName of resolvedApp.appNames) {
             if (await checkMacAppByName(appName)) {
               isAvailable = true;
               break;
@@ -594,8 +590,8 @@ export function registerAppIpc() {
         }
 
         // Check via CLI commands (all platforms)
-        if (!isAvailable && platformConfig?.checkCommands) {
-          for (const cmd of platformConfig.checkCommands) {
+        if (!isAvailable) {
+          for (const cmd of resolvedApp.checkCommands) {
             if (await checkCommand(cmd)) {
               isAvailable = true;
               break;
@@ -603,14 +599,60 @@ export function registerAppIpc() {
           }
         }
 
-        availability[app.id] = isAvailable;
+        availability[resolvedApp.id] = isAvailable;
       } catch (error) {
-        console.error(`Error checking installed app ${app.id}:`, error);
-        availability[app.id] = false;
+        console.error(`Error checking installed app ${resolvedApp.id}:`, error);
+        availability[resolvedApp.id] = false;
       }
     }
 
     return availability;
+  });
+
+  ipcMain.handle('app:getResolvedOpenInApps', async () => {
+    const platform = process.platform as PlatformKey;
+    return getMergedApps(platform);
+  });
+
+  const ALLOWED_ICON_EXTENSIONS = new Set([
+    '.png',
+    '.jpg',
+    '.jpeg',
+    '.svg',
+    '.webp',
+    '.gif',
+    '.ico',
+  ]);
+  const MAX_ICON_SIZE_BYTES = 2 * 1024 * 1024; // 2 MB
+
+  ipcMain.handle('app:getCustomToolIcon', async (_event, iconPath: string) => {
+    try {
+      if (typeof iconPath !== 'string' || !isAbsolute(iconPath)) return '';
+      // Only allow paths that are actually configured in customOpenInApps
+      const settings = getAppSettings();
+      const allowedPaths = new Set(
+        (settings.customOpenInApps ?? []).map((c) => c.iconPath).filter(Boolean)
+      );
+      if (!allowedPaths.has(iconPath)) return '';
+      const ext = extname(iconPath).toLowerCase();
+      if (!ALLOWED_ICON_EXTENSIONS.has(ext)) return '';
+      const info = await stat(iconPath);
+      if (!info.isFile() || info.size > MAX_ICON_SIZE_BYTES) return '';
+      const data = await readFile(iconPath);
+      const mimeMap: Record<string, string> = {
+        '.png': 'image/png',
+        '.jpg': 'image/jpeg',
+        '.jpeg': 'image/jpeg',
+        '.svg': 'image/svg+xml',
+        '.webp': 'image/webp',
+        '.gif': 'image/gif',
+        '.ico': 'image/x-icon',
+      };
+      const mime = mimeMap[ext] || 'application/octet-stream';
+      return `data:${mime};base64,${data.toString('base64')}`;
+    } catch {
+      return '';
+    }
   });
 
   ipcMain.handle('app:listInstalledFonts', async (_event, args?: { refresh?: boolean }) => {

--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -1,7 +1,7 @@
 import { app, BrowserWindow, clipboard, ipcMain, shell } from 'electron';
 import { exec, execFile } from 'child_process';
 import { readFile, stat } from 'fs/promises';
-import { extname, isAbsolute, join } from 'path';
+import { extname, isAbsolute, join, normalize } from 'path';
 import { ensureProjectPrepared } from '../services/ProjectPrep';
 import { getAppSettings } from '../settings';
 import { type PlatformKey } from '@shared/openInApps';
@@ -628,17 +628,21 @@ export function registerAppIpc() {
   ipcMain.handle('app:getCustomToolIcon', async (_event, iconPath: string) => {
     try {
       if (typeof iconPath !== 'string' || !isAbsolute(iconPath)) return '';
+      const normalizedInput = normalize(iconPath);
       // Only allow paths that are actually configured in customOpenInApps
       const settings = getAppSettings();
       const allowedPaths = new Set(
-        (settings.customOpenInApps ?? []).map((c) => c.iconPath).filter(Boolean)
+        (settings.customOpenInApps ?? [])
+          .map((c) => c.iconPath)
+          .filter(Boolean)
+          .map((p) => normalize(p!))
       );
-      if (!allowedPaths.has(iconPath)) return '';
-      const ext = extname(iconPath).toLowerCase();
+      if (!allowedPaths.has(normalizedInput)) return '';
+      const ext = extname(normalizedInput).toLowerCase();
       if (!ALLOWED_ICON_EXTENSIONS.has(ext)) return '';
-      const info = await stat(iconPath);
+      const info = await stat(normalizedInput);
       if (!info.isFile() || info.size > MAX_ICON_SIZE_BYTES) return '';
-      const data = await readFile(iconPath);
+      const data = await readFile(normalizedInput);
       const mimeMap: Record<string, string> = {
         '.png': 'image/png',
         '.jpg': 'image/jpeg',

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,6 +1,5 @@
 import { contextBridge, ipcRenderer } from 'electron';
 import type { TerminalSnapshotPayload } from './types/terminalSnapshot';
-import type { OpenInAppId } from '../shared/openInApps';
 import type { AgentEvent } from '../shared/agentEvents';
 import type { McpServer } from '../shared/mcp/types';
 import type { DiffPayload } from '../shared/diff/types';
@@ -94,7 +93,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Open a path in a specific app
   openIn: (args: {
-    app: OpenInAppId;
+    app: string;
     path: string;
     isRemote?: boolean;
     sshConnectionId?: string | null;
@@ -102,7 +101,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
 
   // Check which apps are installed
   checkInstalledApps: () =>
-    ipcRenderer.invoke('app:checkInstalledApps') as Promise<Record<OpenInAppId, boolean>>,
+    ipcRenderer.invoke('app:checkInstalledApps') as Promise<Record<string, boolean>>,
+
+  // Get the merged list of built-in + custom open-in apps (resolved for current platform)
+  getResolvedOpenInApps: () => ipcRenderer.invoke('app:getResolvedOpenInApps'),
+
+  // Read a custom tool icon from disk and return a data: URI (or '' on failure)
+  getCustomToolIcon: (iconPath: string) => ipcRenderer.invoke('app:getCustomToolIcon', iconPath),
 
   // PTY management
   ptyStart: (opts: {

--- a/src/main/services/__tests__/openInRegistry.test.ts
+++ b/src/main/services/__tests__/openInRegistry.test.ts
@@ -42,6 +42,23 @@ describe('mergeApps', () => {
     expect(result.filter((a) => a.id === 'terminal')).toHaveLength(1);
   });
 
+  it('preserves built-in metadata when overriding', () => {
+    const customs: CustomOpenInApp[] = [
+      { id: 'vscode', label: 'My VS Code', openCommand: 'my-code {{path}}' },
+    ];
+    const result = mergeApps(customs, 'darwin');
+    const vscode = result.find((a) => a.id === 'vscode');
+    expect(vscode!.isCustom).toBe(true);
+    expect(vscode!.label).toBe('My VS Code');
+    expect(vscode!.openCommands).toEqual(['my-code {{path}}']);
+    // Built-in metadata should be preserved
+    expect(vscode!.supportsRemote).toBe(true);
+    expect(vscode!.autoInstall).toBe(true);
+    // Built-in icon should be preserved when no custom iconPath
+    expect(vscode!.iconPath).toBe('vscode.png');
+    expect(vscode!.iconIsCustomPath).toBe(false);
+  });
+
   it('marks custom tools without checkCommand as alwaysAvailable', () => {
     const customs: CustomOpenInApp[] = [
       { id: 'no-check', label: 'No Check', openCommand: 'cmd {{path}}' },

--- a/src/main/services/__tests__/openInRegistry.test.ts
+++ b/src/main/services/__tests__/openInRegistry.test.ts
@@ -1,0 +1,90 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/emdash-test',
+  },
+}));
+
+import { mergeApps } from '../openInRegistry';
+import type { CustomOpenInApp } from '@shared/openInApps';
+
+describe('mergeApps', () => {
+  it('returns built-in apps when no customs provided', () => {
+    const result = mergeApps([], 'linux');
+    expect(result.length).toBeGreaterThan(0);
+    expect(result.every((app) => !app.isCustom)).toBe(true);
+  });
+
+  it('appends custom tools after built-ins', () => {
+    const customs: CustomOpenInApp[] = [
+      { id: 'my-tool', label: 'My Tool', openCommand: 'my-tool {{path}}' },
+    ];
+    const result = mergeApps(customs, 'linux');
+    const last = result[result.length - 1];
+    expect(last.id).toBe('my-tool');
+    expect(last.isCustom).toBe(true);
+    expect(last.label).toBe('My Tool');
+    expect(last.openCommands).toEqual(['my-tool {{path}}']);
+  });
+
+  it('overrides a built-in when custom has the same id', () => {
+    const customs: CustomOpenInApp[] = [
+      { id: 'terminal', label: 'My Terminal', openCommand: 'my-term {{path}}' },
+    ];
+    const result = mergeApps(customs, 'linux');
+    const terminal = result.find((a) => a.id === 'terminal');
+    expect(terminal).toBeDefined();
+    expect(terminal!.isCustom).toBe(true);
+    expect(terminal!.label).toBe('My Terminal');
+    expect(terminal!.openCommands).toEqual(['my-term {{path}}']);
+    // Should be at the same position as the original, not appended
+    expect(result.filter((a) => a.id === 'terminal')).toHaveLength(1);
+  });
+
+  it('marks custom tools without checkCommand as alwaysAvailable', () => {
+    const customs: CustomOpenInApp[] = [
+      { id: 'no-check', label: 'No Check', openCommand: 'cmd {{path}}' },
+    ];
+    const result = mergeApps(customs, 'linux');
+    const app = result.find((a) => a.id === 'no-check');
+    expect(app!.alwaysAvailable).toBe(true);
+  });
+
+  it('does not mark custom tools with checkCommand as alwaysAvailable', () => {
+    const customs: CustomOpenInApp[] = [
+      { id: 'has-check', label: 'Has Check', openCommand: 'cmd {{path}}', checkCommand: 'cmd' },
+    ];
+    const result = mergeApps(customs, 'linux');
+    const app = result.find((a) => a.id === 'has-check');
+    expect(app!.alwaysAvailable).toBe(false);
+    expect(app!.checkCommands).toEqual(['cmd']);
+  });
+
+  it('sets iconIsCustomPath for custom tools', () => {
+    const customs: CustomOpenInApp[] = [
+      {
+        id: 'with-icon',
+        label: 'With Icon',
+        openCommand: 'cmd {{path}}',
+        iconPath: '/usr/share/icons/tool.png',
+      },
+    ];
+    const result = mergeApps(customs, 'linux');
+    const app = result.find((a) => a.id === 'with-icon');
+    expect(app!.iconIsCustomPath).toBe(true);
+    expect(app!.iconPath).toBe('/usr/share/icons/tool.png');
+  });
+
+  it('resolves built-in apps for the given platform', () => {
+    const result = mergeApps([], 'darwin');
+    const finder = result.find((a) => a.id === 'finder');
+    expect(finder).toBeDefined();
+    expect(finder!.label).toBe('Finder');
+    expect(finder!.openCommands).toContain('open {{path}}');
+
+    const linuxResult = mergeApps([], 'linux');
+    const files = linuxResult.find((a) => a.id === 'finder');
+    expect(files!.label).toBe('Files');
+  });
+});

--- a/src/main/services/openInRegistry.ts
+++ b/src/main/services/openInRegistry.ts
@@ -25,7 +25,7 @@ export function mergeApps(customs: CustomOpenInApp[], platform: PlatformKey): Re
     const override = customById.get(builtIn.id);
     if (override) {
       customById.delete(builtIn.id);
-      return customToResolved(override);
+      return customToResolved(override, resolveAppForPlatform(builtIn, platform));
     }
     return resolveAppForPlatform(builtIn, platform);
   });
@@ -37,22 +37,22 @@ export function mergeApps(customs: CustomOpenInApp[], platform: PlatformKey): Re
   return result;
 }
 
-function customToResolved(c: CustomOpenInApp): ResolvedOpenInApp {
+function customToResolved(c: CustomOpenInApp, base?: ResolvedOpenInApp): ResolvedOpenInApp {
   return {
     id: c.id,
     label: c.label,
-    iconPath: c.iconPath ?? '',
-    iconIsCustomPath: true,
+    iconPath: c.iconPath ?? base?.iconPath ?? '',
+    iconIsCustomPath: Boolean(c.iconPath),
     openCommands: [c.openCommand],
     openUrls: [],
     checkCommands: c.checkCommand ? [c.checkCommand] : [],
     bundleIds: [],
     appNames: [],
     alwaysAvailable: !c.checkCommand,
-    hideIfUnavailable: false,
-    autoInstall: false,
-    supportsRemote: false,
-    invertInDark: false,
+    hideIfUnavailable: base?.hideIfUnavailable ?? false,
+    autoInstall: base?.autoInstall ?? false,
+    supportsRemote: base?.supportsRemote ?? false,
+    invertInDark: c.iconPath ? false : (base?.invertInDark ?? false),
     isCustom: true,
   };
 }

--- a/src/main/services/openInRegistry.ts
+++ b/src/main/services/openInRegistry.ts
@@ -1,0 +1,65 @@
+import {
+  OPEN_IN_APPS,
+  resolveAppForPlatform,
+  type CustomOpenInApp,
+  type PlatformKey,
+  type ResolvedOpenInApp,
+} from '@shared/openInApps';
+import { getAppSettings } from '../settings';
+
+/**
+ * Build the merged app list: built-ins (resolved for platform) + custom tools.
+ * Custom entries with an id matching a built-in replace that built-in at its position.
+ * Remaining custom entries are appended.
+ */
+export function getMergedApps(platform: PlatformKey): ResolvedOpenInApp[] {
+  const settings = getAppSettings();
+  const customs = settings.customOpenInApps ?? [];
+  return mergeApps(customs, platform);
+}
+
+export function mergeApps(customs: CustomOpenInApp[], platform: PlatformKey): ResolvedOpenInApp[] {
+  const customById = new Map(customs.map((c) => [c.id, c]));
+
+  const result: ResolvedOpenInApp[] = OPEN_IN_APPS.map((builtIn) => {
+    const override = customById.get(builtIn.id);
+    if (override) {
+      customById.delete(builtIn.id);
+      return customToResolved(override);
+    }
+    return resolveAppForPlatform(builtIn, platform);
+  });
+
+  for (const custom of customById.values()) {
+    result.push(customToResolved(custom));
+  }
+
+  return result;
+}
+
+function customToResolved(c: CustomOpenInApp): ResolvedOpenInApp {
+  return {
+    id: c.id,
+    label: c.label,
+    iconPath: c.iconPath ?? '',
+    iconIsCustomPath: true,
+    openCommands: [c.openCommand],
+    openUrls: [],
+    checkCommands: c.checkCommand ? [c.checkCommand] : [],
+    bundleIds: [],
+    appNames: [],
+    alwaysAvailable: !c.checkCommand,
+    hideIfUnavailable: false,
+    autoInstall: false,
+    supportsRemote: false,
+    invertInDark: false,
+    isCustom: true,
+  };
+}
+
+export function getResolvedAppById(
+  id: string,
+  platform: PlatformKey
+): ResolvedOpenInApp | undefined {
+  return getMergedApps(platform).find((app) => app.id === id);
+}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
 import type { ProviderId } from '@shared/providers/registry';
 import { isValidProviderId } from '@shared/providers/registry';
-import { isValidOpenInAppId, type OpenInAppId } from '@shared/openInApps';
+import { isValidOpenInAppId, type CustomOpenInApp } from '@shared/openInApps';
 import {
   isNotificationSoundProfile,
   type NotificationSoundProfile,
@@ -126,8 +126,9 @@ export interface AppSettings {
     autoCopyOnSelection: boolean;
     macOptionIsMeta: boolean;
   };
-  defaultOpenInApp?: OpenInAppId;
-  hiddenOpenInApps?: OpenInAppId[];
+  defaultOpenInApp?: string;
+  hiddenOpenInApps?: string[];
+  customOpenInApps?: CustomOpenInApp[];
   changelog?: {
     dismissedVersions: string[];
   };
@@ -215,6 +216,7 @@ const DEFAULT_SETTINGS: AppSettings = {
   },
   defaultOpenInApp: 'terminal',
   hiddenOpenInApps: [],
+  customOpenInApps: [],
   changelog: {
     dismissedVersions: [],
   },
@@ -600,16 +602,60 @@ export function normalizeSettings(input: AppSettings): AppSettings {
   }
   out.terminal = { fontFamily, fontSize, autoCopyOnSelection, macOptionIsMeta };
 
-  // Default Open In App
-  const defaultOpenInApp = (input as any)?.defaultOpenInApp;
-  out.defaultOpenInApp = isValidOpenInAppId(defaultOpenInApp)
-    ? defaultOpenInApp
-    : DEFAULT_SETTINGS.defaultOpenInApp!;
+  // Custom Open In Apps
+  const rawCustom = (input as any)?.customOpenInApps;
+  if (Array.isArray(rawCustom)) {
+    out.customOpenInApps = rawCustom
+      .filter(
+        (c: unknown): c is CustomOpenInApp =>
+          c !== null &&
+          typeof c === 'object' &&
+          typeof (c as any).id === 'string' &&
+          (c as any).id.trim() !== '' &&
+          typeof (c as any).label === 'string' &&
+          (c as any).label.trim() !== '' &&
+          typeof (c as any).openCommand === 'string' &&
+          (c as any).openCommand.trim() !== ''
+      )
+      .map((c) => {
+        const entry: CustomOpenInApp = {
+          id: c.id.trim(),
+          label: c.label.trim(),
+          openCommand: c.openCommand.trim(),
+        };
+        // checkCommand is interpolated into `command -v ${cmd}`, so restrict to safe basenames
+        if (typeof c.checkCommand === 'string') {
+          const cmd = c.checkCommand.trim();
+          if (cmd && /^[a-zA-Z0-9_\-./]+$/.test(cmd)) {
+            entry.checkCommand = cmd;
+          }
+        }
+        if (typeof c.iconPath === 'string' && c.iconPath.trim()) {
+          entry.iconPath = c.iconPath.trim();
+        }
+        return entry;
+      });
+  } else {
+    out.customOpenInApps = [];
+  }
+  const customIds = new Set((out.customOpenInApps ?? []).map((c) => c.id));
 
-  // Hidden Open In Apps
+  // Default Open In App (accept both built-in and custom IDs)
+  const defaultOpenInApp = (input as any)?.defaultOpenInApp;
+  out.defaultOpenInApp =
+    typeof defaultOpenInApp === 'string' &&
+    defaultOpenInApp.trim() &&
+    (isValidOpenInAppId(defaultOpenInApp) || customIds.has(defaultOpenInApp))
+      ? defaultOpenInApp
+      : DEFAULT_SETTINGS.defaultOpenInApp!;
+
+  // Hidden Open In Apps (accept both built-in and custom IDs)
   const rawHidden = (input as any)?.hiddenOpenInApps;
   if (Array.isArray(rawHidden)) {
-    const validated = rawHidden.filter(isValidOpenInAppId);
+    const validated = rawHidden.filter(
+      (v: unknown): v is string =>
+        typeof v === 'string' && v.trim() !== '' && (isValidOpenInAppId(v) || customIds.has(v))
+    );
     out.hiddenOpenInApps = [...new Set(validated)];
   } else {
     out.hiddenOpenInApps = [];

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -626,7 +626,7 @@ export function normalizeSettings(input: AppSettings): AppSettings {
         // checkCommand is interpolated into `command -v ${cmd}`, so restrict to safe basenames
         if (typeof c.checkCommand === 'string') {
           const cmd = c.checkCommand.trim();
-          if (cmd && /^[a-zA-Z0-9_\-./]+$/.test(cmd)) {
+          if (cmd && /^[a-zA-Z0-9_\-]+$/.test(cmd)) {
             entry.checkCommand = cmd;
           }
         }

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -602,9 +602,10 @@ export function normalizeSettings(input: AppSettings): AppSettings {
   }
   out.terminal = { fontFamily, fontSize, autoCopyOnSelection, macOptionIsMeta };
 
-  // Custom Open In Apps
+  // Custom Open In Apps (deduplicate by id, first occurrence wins)
   const rawCustom = (input as any)?.customOpenInApps;
   if (Array.isArray(rawCustom)) {
+    const seenIds = new Set<string>();
     out.customOpenInApps = rawCustom
       .filter(
         (c: unknown): c is CustomOpenInApp =>
@@ -634,6 +635,11 @@ export function normalizeSettings(input: AppSettings): AppSettings {
           entry.iconPath = c.iconPath.trim();
         }
         return entry;
+      })
+      .filter((c) => {
+        if (seenIds.has(c.id)) return false;
+        seenIds.add(c.id);
+        return true;
       });
   } else {
     out.customOpenInApps = [];
@@ -641,21 +647,23 @@ export function normalizeSettings(input: AppSettings): AppSettings {
   const customIds = new Set((out.customOpenInApps ?? []).map((c) => c.id));
 
   // Default Open In App (accept both built-in and custom IDs)
-  const defaultOpenInApp = (input as any)?.defaultOpenInApp;
+  const rawDefaultOpenInApp =
+    typeof (input as any)?.defaultOpenInApp === 'string'
+      ? ((input as any).defaultOpenInApp as string).trim()
+      : '';
   out.defaultOpenInApp =
-    typeof defaultOpenInApp === 'string' &&
-    defaultOpenInApp.trim() &&
-    (isValidOpenInAppId(defaultOpenInApp) || customIds.has(defaultOpenInApp))
-      ? defaultOpenInApp
+    rawDefaultOpenInApp &&
+    (isValidOpenInAppId(rawDefaultOpenInApp) || customIds.has(rawDefaultOpenInApp))
+      ? rawDefaultOpenInApp
       : DEFAULT_SETTINGS.defaultOpenInApp!;
 
   // Hidden Open In Apps (accept both built-in and custom IDs)
   const rawHidden = (input as any)?.hiddenOpenInApps;
   if (Array.isArray(rawHidden)) {
-    const validated = rawHidden.filter(
-      (v: unknown): v is string =>
-        typeof v === 'string' && v.trim() !== '' && (isValidOpenInAppId(v) || customIds.has(v))
-    );
+    const validated = rawHidden
+      .filter((v: unknown): v is string => typeof v === 'string')
+      .map((v) => v.trim())
+      .filter((v) => v !== '' && (isValidOpenInAppId(v) || customIds.has(v)));
     out.hiddenOpenInApps = [...new Set(validated)];
   } else {
     out.hiddenOpenInApps = [];

--- a/src/renderer/components/CustomToolModal.tsx
+++ b/src/renderer/components/CustomToolModal.tsx
@@ -1,0 +1,193 @@
+import React, { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Button } from './ui/button';
+import { Input } from './ui/input';
+import { Label } from './ui/label';
+import type { CustomOpenInApp } from '@shared/openInApps';
+
+interface CustomToolModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSave: (tool: CustomOpenInApp) => void;
+  onDelete?: () => void;
+  initial?: CustomOpenInApp;
+}
+
+export default function CustomToolModal({
+  open,
+  onOpenChange,
+  onSave,
+  onDelete,
+  initial,
+}: CustomToolModalProps) {
+  const [label, setLabel] = useState('');
+  const [openCommand, setOpenCommand] = useState('');
+  const [checkCommand, setCheckCommand] = useState('');
+  const [iconPath, setIconPath] = useState('');
+
+  const isEdit = Boolean(initial);
+
+  useEffect(() => {
+    if (open && initial) {
+      setLabel(initial.label);
+      setOpenCommand(initial.openCommand);
+      setCheckCommand(initial.checkCommand ?? '');
+      setIconPath(initial.iconPath ?? '');
+    }
+  }, [open, initial]);
+
+  const id = isEdit
+    ? initial!.id
+    : label
+        .trim()
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-|-$/g, '');
+
+  const checkCommandError =
+    checkCommand.trim() && !/^[a-zA-Z0-9_\-]+$/.test(checkCommand.trim())
+      ? 'Must be a plain binary name (no spaces, flags, or paths)'
+      : '';
+
+  const isValid =
+    label.trim() !== '' && openCommand.trim() !== '' && id !== '' && !checkCommandError;
+
+  const handleSave = () => {
+    if (!isValid) return;
+    onSave({
+      id,
+      label: label.trim(),
+      openCommand: openCommand.trim(),
+      ...(checkCommand.trim() ? { checkCommand: checkCommand.trim() } : {}),
+      ...(iconPath.trim() ? { iconPath: iconPath.trim() } : {}),
+    });
+    reset();
+    onOpenChange(false);
+  };
+
+  const reset = () => {
+    setLabel('');
+    setOpenCommand('');
+    setCheckCommand('');
+    setIconPath('');
+  };
+
+  const handleOpenChange = (next: boolean) => {
+    if (!next) reset();
+    onOpenChange(next);
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{isEdit ? 'Edit Custom Tool' : 'Add Custom Tool'}</DialogTitle>
+          <DialogDescription>
+            {isEdit
+              ? 'Update the configuration for this custom tool.'
+              : 'Define a custom tool that will appear in the Open In dropdown.'}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="flex flex-col gap-4 py-2">
+          <div className="space-y-2">
+            <Label htmlFor="custom-tool-label">Name</Label>
+            <Input
+              id="custom-tool-label"
+              value={label}
+              onChange={(e) => setLabel(e.target.value)}
+              placeholder="e.g. Foot Terminal"
+            />
+            {!isEdit && id && (
+              <p className="text-xs text-muted-foreground">
+                ID: <code className="rounded bg-muted px-1">{id}</code>
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="custom-tool-command">Open Command</Label>
+            <Input
+              id="custom-tool-command"
+              value={openCommand}
+              onChange={(e) => setOpenCommand(e.target.value)}
+              placeholder="e.g. foot --working-directory={{path}}"
+              className="font-mono text-sm"
+            />
+            <p className="text-xs text-muted-foreground">
+              Use <code className="rounded bg-muted px-1">{'{{path}}'}</code> as a placeholder for
+              the directory.
+            </p>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="custom-tool-check">
+              Check Command <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="custom-tool-check"
+              value={checkCommand}
+              onChange={(e) => setCheckCommand(e.target.value)}
+              placeholder="e.g. foot"
+              className={`font-mono text-sm ${checkCommandError ? 'border-destructive' : ''}`}
+            />
+            {checkCommandError ? (
+              <p className="text-xs text-destructive">{checkCommandError}</p>
+            ) : (
+              <p className="text-xs text-muted-foreground">
+                Binary name used to detect if the tool is installed (e.g.{' '}
+                <code className="rounded bg-muted px-1">foot</code>, not a full command). If empty,
+                the tool is always shown.
+              </p>
+            )}
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="custom-tool-icon">
+              Icon Path <span className="text-muted-foreground">(optional)</span>
+            </Label>
+            <Input
+              id="custom-tool-icon"
+              value={iconPath}
+              onChange={(e) => setIconPath(e.target.value)}
+              placeholder="e.g. /usr/share/icons/tool.png"
+              className="font-mono text-sm"
+            />
+          </div>
+        </div>
+
+        <DialogFooter className="sm:justify-between">
+          <div>
+            {isEdit && onDelete && (
+              <Button
+                variant="destructive"
+                onClick={() => {
+                  onDelete();
+                  reset();
+                  onOpenChange(false);
+                }}
+              >
+                Delete
+              </Button>
+            )}
+          </div>
+          <div className="flex gap-2">
+            <Button variant="outline" onClick={() => handleOpenChange(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={!isValid}>
+              Save
+            </Button>
+          </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/renderer/components/HiddenToolsSettingsCard.tsx
+++ b/src/renderer/components/HiddenToolsSettingsCard.tsx
@@ -1,16 +1,23 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import type { ResolvedOpenInApp } from '@shared/openInApps';
+import { Pencil } from 'lucide-react';
+import type { CustomOpenInApp, ResolvedOpenInApp } from '@shared/openInApps';
 import IntegrationRow from './IntegrationRow';
 import { Switch } from './ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import CustomToolModal from './CustomToolModal';
 
-export default function HiddenToolsSettingsCard() {
+interface HiddenToolsSettingsCardProps {
+  refreshKey?: number;
+}
+
+export default function HiddenToolsSettingsCard({ refreshKey }: HiddenToolsSettingsCardProps) {
   const { settings, updateSettings, isLoading, isSaving } = useAppSettings();
   const [allApps, setAllApps] = useState<ResolvedOpenInApp[]>([]);
   const [icons, setIcons] = useState<Record<string, string>>({});
   const [labels, setLabels] = useState<Record<string, string>>({});
   const [availability, setAvailability] = useState<Record<string, boolean>>({});
+  const [editTarget, setEditTarget] = useState<CustomOpenInApp | null>(null);
 
   const hiddenApps: string[] = settings?.hiddenOpenInApps ?? [];
 
@@ -49,12 +56,27 @@ export default function HiddenToolsSettingsCard() {
       } catch {}
     };
     void init();
-  }, []);
+  }, [refreshKey]);
 
   const toggle = (appId: string, visible: boolean) => {
     const next = visible ? hiddenApps.filter((id) => id !== appId) : [...hiddenApps, appId];
     updateSettings({ hiddenOpenInApps: next });
     window.dispatchEvent(new Event('hiddenOpenInAppsChanged'));
+  };
+
+  const getCustomById = (id: string): CustomOpenInApp | undefined =>
+    (settings?.customOpenInApps ?? []).find((c) => c.id === id);
+
+  const handleEditSave = (tool: CustomOpenInApp) => {
+    const customs = settings?.customOpenInApps ?? [];
+    const next = customs.map((c) => (c.id === tool.id ? tool : c));
+    updateSettings({ customOpenInApps: next });
+  };
+
+  const handleDelete = (id: string) => {
+    const customs = settings?.customOpenInApps ?? [];
+    updateSettings({ customOpenInApps: customs.filter((c) => c.id !== id) });
+    setAllApps((prev) => prev.filter((a) => a.id !== id));
   };
 
   // Sort: detected first, then alphabetically by label
@@ -69,52 +91,95 @@ export default function HiddenToolsSettingsCard() {
   }, [allApps, availability, labels]);
 
   return (
-    <div className="rounded-xl border border-border/60 bg-muted/10 p-2">
-      <div className="space-y-2">
-        {sortedApps.map((app) => {
-          const isDetected = availability[app.id] ?? app.alwaysAvailable ?? false;
-          const isVisible = !hiddenApps.includes(app.id);
-          const label = labels[app.id] ?? app.label;
-          const icon = icons[app.id];
-          const indicatorClass = isDetected ? 'bg-emerald-500' : 'bg-muted-foreground/50';
-          const statusLabel = isDetected ? 'Detected' : 'Not detected';
+    <>
+      <div className="rounded-xl border border-border/60 bg-muted/10 p-2">
+        <div className="space-y-2">
+          {sortedApps.map((app) => {
+            const isDetected = availability[app.id] ?? app.alwaysAvailable ?? false;
+            const isVisible = !hiddenApps.includes(app.id);
+            const label = labels[app.id] ?? app.label;
+            const icon = icons[app.id];
+            const indicatorClass = isDetected ? 'bg-emerald-500' : 'bg-muted-foreground/50';
+            const statusLabel = isDetected ? 'Detected' : 'Not detected';
 
-          return (
-            <IntegrationRow
-              key={app.id}
-              logoSrc={icon}
-              name={label}
-              status={isDetected ? 'connected' : 'missing'}
-              showStatusPill={false}
-              middle={
-                <span className="flex items-center gap-2 text-sm text-muted-foreground">
-                  <span className={`h-1.5 w-1.5 rounded-full ${indicatorClass}`} />
-                  {statusLabel}
-                </span>
-              }
-              rightExtra={
-                <TooltipProvider delayDuration={150}>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span>
-                        <Switch
-                          checked={isVisible}
-                          disabled={isLoading || isSaving}
-                          onCheckedChange={(checked) => toggle(app.id, checked)}
-                          aria-label={`${isVisible ? 'Hide' : 'Show'} ${label} in open menu`}
-                        />
+            return (
+              <IntegrationRow
+                key={app.id}
+                logoSrc={icon}
+                name={label}
+                status={isDetected ? 'connected' : 'missing'}
+                showStatusPill={false}
+                middle={
+                  <span className="flex items-center gap-2 text-sm text-muted-foreground">
+                    <span className={`h-1.5 w-1.5 rounded-full ${indicatorClass}`} />
+                    {statusLabel}
+                    {app.isCustom && (
+                      <span className="rounded bg-muted px-1.5 py-0.5 text-[10px] font-medium text-muted-foreground">
+                        Custom
                       </span>
-                    </TooltipTrigger>
-                    <TooltipContent side="top" className="text-xs">
-                      {isVisible ? 'Hide from menu' : 'Show in menu'}
-                    </TooltipContent>
-                  </Tooltip>
-                </TooltipProvider>
-              }
-            />
-          );
-        })}
+                    )}
+                  </span>
+                }
+                rightExtra={
+                  <div className="flex items-center gap-1">
+                    {app.isCustom && (
+                      <TooltipProvider delayDuration={150}>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <button
+                              type="button"
+                              className="rounded-md p-1.5 text-muted-foreground transition hover:bg-muted/60 hover:text-foreground"
+                              onClick={() => {
+                                const custom = getCustomById(app.id);
+                                if (custom) setEditTarget(custom);
+                              }}
+                              aria-label={`Edit ${label}`}
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                          </TooltipTrigger>
+                          <TooltipContent side="top" className="text-xs">
+                            Edit custom tool
+                          </TooltipContent>
+                        </Tooltip>
+                      </TooltipProvider>
+                    )}
+                    <TooltipProvider delayDuration={150}>
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <span>
+                            <Switch
+                              checked={isVisible}
+                              disabled={isLoading || isSaving}
+                              onCheckedChange={(checked) => toggle(app.id, checked)}
+                              aria-label={`${isVisible ? 'Hide' : 'Show'} ${label} in open menu`}
+                            />
+                          </span>
+                        </TooltipTrigger>
+                        <TooltipContent side="top" className="text-xs">
+                          {isVisible ? 'Hide from menu' : 'Show in menu'}
+                        </TooltipContent>
+                      </Tooltip>
+                    </TooltipProvider>
+                  </div>
+                }
+              />
+            );
+          })}
+        </div>
       </div>
-    </div>
+
+      <CustomToolModal
+        open={editTarget !== null}
+        onOpenChange={(open) => {
+          if (!open) setEditTarget(null);
+        }}
+        initial={editTarget ?? undefined}
+        onSave={handleEditSave}
+        onDelete={() => {
+          if (editTarget) handleDelete(editTarget.id);
+        }}
+      />
+    </>
   );
 }

--- a/src/renderer/components/HiddenToolsSettingsCard.tsx
+++ b/src/renderer/components/HiddenToolsSettingsCard.tsx
@@ -1,11 +1,5 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import {
-  OPEN_IN_APPS,
-  getResolvedIconPath,
-  getResolvedLabel,
-  type OpenInAppId,
-  type PlatformKey,
-} from '@shared/openInApps';
+import type { ResolvedOpenInApp } from '@shared/openInApps';
 import IntegrationRow from './IntegrationRow';
 import { Switch } from './ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
@@ -13,28 +7,39 @@ import { useAppSettings } from '@/contexts/AppSettingsProvider';
 
 export default function HiddenToolsSettingsCard() {
   const { settings, updateSettings, isLoading, isSaving } = useAppSettings();
-  const [icons, setIcons] = useState<Partial<Record<OpenInAppId, string>>>({});
-  const [labels, setLabels] = useState<Partial<Record<OpenInAppId, string>>>({});
+  const [allApps, setAllApps] = useState<ResolvedOpenInApp[]>([]);
+  const [icons, setIcons] = useState<Record<string, string>>({});
+  const [labels, setLabels] = useState<Record<string, string>>({});
   const [availability, setAvailability] = useState<Record<string, boolean>>({});
 
-  const hiddenApps: OpenInAppId[] = settings?.hiddenOpenInApps ?? [];
+  const hiddenApps: string[] = settings?.hiddenOpenInApps ?? [];
 
   useEffect(() => {
     const init = async () => {
-      let platform: PlatformKey = 'darwin';
-      try {
-        platform = ((await window.electronAPI?.getPlatform?.()) as PlatformKey) || 'darwin';
-      } catch {}
+      const apps: ResolvedOpenInApp[] = (await window.electronAPI?.getResolvedOpenInApps?.()) ?? [];
+      setAllApps(apps);
 
-      const loadedIcons: Partial<Record<OpenInAppId, string>> = {};
-      const loadedLabels: Partial<Record<OpenInAppId, string>> = {};
-      for (const app of OPEN_IN_APPS) {
-        const iconPath = getResolvedIconPath(app, platform);
-        loadedLabels[app.id] = getResolvedLabel(app, platform);
-        try {
-          loadedIcons[app.id] = new URL(`../../assets/images/${iconPath}`, import.meta.url).href;
-        } catch {}
+      const loadedIcons: Record<string, string> = {};
+      const loadedLabels: Record<string, string> = {};
+
+      for (const app of apps) {
+        loadedLabels[app.id] = app.label;
+
+        if (app.iconIsCustomPath && app.iconPath) {
+          try {
+            const dataUri = await window.electronAPI?.getCustomToolIcon?.(app.iconPath);
+            if (dataUri) loadedIcons[app.id] = dataUri;
+          } catch {}
+        } else if (app.iconPath) {
+          try {
+            loadedIcons[app.id] = new URL(
+              `../../assets/images/${app.iconPath}`,
+              import.meta.url
+            ).href;
+          } catch {}
+        }
       }
+
       setIcons(loadedIcons);
       setLabels(loadedLabels);
 
@@ -46,7 +51,7 @@ export default function HiddenToolsSettingsCard() {
     void init();
   }, []);
 
-  const toggle = (appId: OpenInAppId, visible: boolean) => {
+  const toggle = (appId: string, visible: boolean) => {
     const next = visible ? hiddenApps.filter((id) => id !== appId) : [...hiddenApps, appId];
     updateSettings({ hiddenOpenInApps: next });
     window.dispatchEvent(new Event('hiddenOpenInAppsChanged'));
@@ -54,14 +59,14 @@ export default function HiddenToolsSettingsCard() {
 
   // Sort: detected first, then alphabetically by label
   const sortedApps = useMemo(() => {
-    return [...OPEN_IN_APPS].sort((a, b) => {
+    return [...allApps].sort((a, b) => {
       const aDetected = availability[a.id] ?? a.alwaysAvailable ?? false;
       const bDetected = availability[b.id] ?? b.alwaysAvailable ?? false;
       if (aDetected && !bDetected) return -1;
       if (!aDetected && bDetected) return 1;
       return (labels[a.id] ?? a.label).localeCompare(labels[b.id] ?? b.label);
     });
-  }, [availability, labels]);
+  }, [allApps, availability, labels]);
 
   return (
     <div className="rounded-xl border border-border/60 bg-muted/10 p-2">

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useState } from 'react';
-import { ExternalLink, X } from 'lucide-react';
+import { ExternalLink, Plus, X } from 'lucide-react';
 import { Separator } from './ui/separator';
 import type { CliAgentStatus } from '../types/connections';
 import { BASE_CLI_AGENTS, CliAgentsList } from './CliAgentsList';
@@ -26,11 +26,13 @@ import BrowserPreviewSettingsCard from './BrowserPreviewSettingsCard';
 import TaskHoverActionCard from './TaskHoverActionCard';
 import TerminalSettingsCard from './TerminalSettingsCard';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
+import CustomToolModal from './CustomToolModal';
 import ReviewAgentSettingsCard from './ReviewAgentSettingsCard';
 import ResourceMonitorSettingsCard from './ResourceMonitorSettingsCard';
 import { AccountTab } from './settings/AccountTab';
 import { WorkspaceProviderInfoCard } from './WorkspaceProviderInfoCard';
 import { useTaskSettings } from '../hooks/useTaskSettings';
+import { useAppSettings } from '../contexts/AppSettingsProvider';
 
 export type SettingsPageTab =
   | 'general'
@@ -105,6 +107,9 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
   const [activeTab, setActiveTab] = useState<SettingsPageTab>(initialTab || 'general');
   const [cliAgents, setCliAgents] = useState<CliAgentStatus[]>(() => createDefaultCliAgents());
   const taskSettings = useTaskSettings();
+  const { settings, updateSettings } = useAppSettings();
+  const [addToolOpen, setAddToolOpen] = useState(false);
+  const [toolsRefreshKey, setToolsRefreshKey] = useState(0);
 
   useEffect(() => {
     setActiveTab(initialTab || 'general');
@@ -273,7 +278,17 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
         },
         {
           title: 'Tools',
-          component: <HiddenToolsSettingsCard />,
+          action: (
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              onClick={() => setAddToolOpen(true)}
+              aria-label="Add custom tool"
+            >
+              <Plus className="h-4 w-4" />
+            </Button>
+          ),
+          component: <HiddenToolsSettingsCard refreshKey={toolsRefreshKey} />,
         },
       ],
     },
@@ -375,6 +390,16 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
           )}
         </div>
       </div>
+
+      <CustomToolModal
+        open={addToolOpen}
+        onOpenChange={setAddToolOpen}
+        onSave={(tool) => {
+          const existing = settings?.customOpenInApps ?? [];
+          updateSettings({ customOpenInApps: [...existing, tool] });
+          setToolsRefreshKey((k) => k + 1);
+        }}
+      />
     </div>
   );
 };

--- a/src/renderer/components/titlebar/OpenInMenu.tsx
+++ b/src/renderer/components/titlebar/OpenInMenu.tsx
@@ -4,7 +4,6 @@ import { ChevronDown } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
 import { useToast } from '@/hooks/use-toast';
-import { getAppById, isValidOpenInAppId, type OpenInAppId } from '@shared/openInApps';
 import { useOpenInApps } from '../../hooks/useOpenInApps';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
 
@@ -33,8 +32,8 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
   const { icons, labels, installedApps, availability, loading } = useOpenInApps({ isRemote });
   const { settings, updateSettings } = useAppSettings();
 
-  const defaultApp: OpenInAppId | null =
-    settings?.defaultOpenInApp && isValidOpenInAppId(settings.defaultOpenInApp)
+  const defaultApp: string | null =
+    settings?.defaultOpenInApp && typeof settings.defaultOpenInApp === 'string'
       ? settings.defaultOpenInApp
       : null;
 
@@ -48,7 +47,7 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
   }, [open]);
 
   const persistPreferredApp = React.useCallback(
-    (appId: OpenInAppId) => {
+    (appId: string) => {
       updateSettings({ defaultOpenInApp: appId });
       window.dispatchEvent(new CustomEvent('defaultOpenInAppChanged', { detail: appId }));
     },
@@ -56,7 +55,7 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
   );
 
   const callOpen = React.useCallback(
-    async (appId: OpenInAppId) => {
+    async (appId: string) => {
       const label = labels[appId] || appId;
 
       void import('../../lib/telemetryClient').then(({ captureTelemetry }) => {
@@ -147,7 +146,9 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
                     src={icons[buttonAppId]}
                     alt={labels[buttonAppId] || buttonAppId}
                     className={`h-4 w-4 rounded ${
-                      getAppById(buttonAppId)?.invertInDark ? 'dark:invert' : ''
+                      installedApps.find((a) => a.id === buttonAppId)?.invertInDark
+                        ? 'dark:invert'
+                        : ''
                     }`}
                   />
                 )}

--- a/src/renderer/hooks/useOpenInApps.ts
+++ b/src/renderer/hooks/useOpenInApps.ts
@@ -1,19 +1,12 @@
 import { useEffect, useMemo, useState } from 'react';
-import {
-  OPEN_IN_APPS,
-  getResolvedIconPath,
-  getResolvedLabel,
-  isOpenInAppSupportedForWorkspace,
-  type OpenInAppId,
-  type PlatformKey,
-} from '@shared/openInApps';
+import type { ResolvedOpenInApp } from '@shared/openInApps';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
 
 export interface UseOpenInAppsResult {
-  icons: Partial<Record<OpenInAppId, string>>;
-  labels: Partial<Record<OpenInAppId, string>>;
+  icons: Record<string, string>;
+  labels: Record<string, string>;
   availability: Record<string, boolean>;
-  installedApps: typeof OPEN_IN_APPS;
+  installedApps: ResolvedOpenInApp[];
   loading: boolean;
 }
 
@@ -21,34 +14,51 @@ export function useOpenInApps({
   isRemote = false,
 }: { isRemote?: boolean } = {}): UseOpenInAppsResult {
   const { settings, isLoading: settingsLoading } = useAppSettings();
-  const [icons, setIcons] = useState<Partial<Record<OpenInAppId, string>>>({});
-  const [labels, setLabels] = useState<Partial<Record<OpenInAppId, string>>>({});
+  const [allApps, setAllApps] = useState<ResolvedOpenInApp[]>([]);
+  const [icons, setIcons] = useState<Record<string, string>>({});
+  const [labels, setLabels] = useState<Record<string, string>>({});
   const [availability, setAvailability] = useState<Record<string, boolean>>({});
+  const [appsListLoading, setAppsListLoading] = useState(true);
   const [availabilityLoading, setAvailabilityLoading] = useState(true);
 
-  const loading = settingsLoading || availabilityLoading;
+  const loading = settingsLoading || appsListLoading || availabilityLoading;
 
-  // Load platform-resolved icons and labels
+  // Load resolved apps, icons, and labels
   useEffect(() => {
     const load = async () => {
-      let platform: PlatformKey = 'darwin';
       try {
-        platform = ((await window.electronAPI?.getPlatform?.()) as PlatformKey) || 'darwin';
-      } catch {}
+        const apps: ResolvedOpenInApp[] =
+          (await window.electronAPI?.getResolvedOpenInApps?.()) ?? [];
+        setAllApps(apps);
 
-      const loadedIcons: Partial<Record<OpenInAppId, string>> = {};
-      const loadedLabels: Partial<Record<OpenInAppId, string>> = {};
-      for (const app of OPEN_IN_APPS) {
-        const iconPath = getResolvedIconPath(app, platform);
-        loadedLabels[app.id] = getResolvedLabel(app, platform);
-        try {
-          loadedIcons[app.id] = new URL(`../../assets/images/${iconPath}`, import.meta.url).href;
-        } catch (e) {
-          console.error(`Failed to load icon for ${app.id}:`, e);
+        const loadedIcons: Record<string, string> = {};
+        const loadedLabels: Record<string, string> = {};
+
+        for (const app of apps) {
+          loadedLabels[app.id] = app.label;
+
+          if (app.iconIsCustomPath && app.iconPath) {
+            try {
+              const dataUri = await window.electronAPI?.getCustomToolIcon?.(app.iconPath);
+              if (dataUri) loadedIcons[app.id] = dataUri;
+            } catch {}
+          } else if (app.iconPath) {
+            try {
+              loadedIcons[app.id] = new URL(
+                `../../assets/images/${app.iconPath}`,
+                import.meta.url
+              ).href;
+            } catch {}
+          }
         }
+
+        setIcons(loadedIcons);
+        setLabels(loadedLabels);
+      } catch (e) {
+        console.error('Failed to load resolved open-in apps:', e);
+      } finally {
+        setAppsListLoading(false);
       }
-      setIcons(loadedIcons);
-      setLabels(loadedLabels);
     };
     void load();
   }, []);
@@ -70,15 +80,11 @@ export function useOpenInApps({
 
   // Filter to only installed and visible apps (return all while loading)
   const installedApps = useMemo(() => {
-    const hiddenApps: OpenInAppId[] = settings?.hiddenOpenInApps ?? [];
-    const workspaceApps = OPEN_IN_APPS.filter((app) =>
-      isOpenInAppSupportedForWorkspace(app, isRemote)
-    );
-
+    const hiddenApps: string[] = settings?.hiddenOpenInApps ?? [];
+    const workspaceApps = allApps.filter((app) => !isRemote || app.supportsRemote);
     if (loading) return workspaceApps;
-
     return workspaceApps.filter((app) => availability[app.id] && !hiddenApps.includes(app.id));
-  }, [availability, isRemote, loading, settings?.hiddenOpenInApps]);
+  }, [allApps, availability, isRemote, loading, settings?.hiddenOpenInApps]);
 
   return { icons, labels, availability, installedApps, loading };
 }

--- a/src/renderer/hooks/useOpenInApps.ts
+++ b/src/renderer/hooks/useOpenInApps.ts
@@ -23,7 +23,10 @@ export function useOpenInApps({
 
   const loading = settingsLoading || appsListLoading || availabilityLoading;
 
-  // Load resolved apps, icons, and labels
+  // Stable key to detect when customOpenInApps changes
+  const customAppsKey = JSON.stringify((settings?.customOpenInApps ?? []).map((c) => c.id).sort());
+
+  // Load resolved apps, icons, and labels — refetch when custom tools change
   useEffect(() => {
     const load = async () => {
       try {
@@ -61,7 +64,7 @@ export function useOpenInApps({
       }
     };
     void load();
-  }, []);
+  }, [customAppsKey]);
 
   // Fetch app availability
   useEffect(() => {
@@ -76,7 +79,7 @@ export function useOpenInApps({
       }
     };
     void fetchAvailability();
-  }, []);
+  }, [customAppsKey]);
 
   // Filter to only installed and visible apps (return all while loading)
   const installedApps = useMemo(() => {

--- a/src/renderer/hooks/useOpenInApps.ts
+++ b/src/renderer/hooks/useOpenInApps.ts
@@ -83,7 +83,9 @@ export function useOpenInApps({
     const hiddenApps: string[] = settings?.hiddenOpenInApps ?? [];
     const workspaceApps = allApps.filter((app) => !isRemote || app.supportsRemote);
     if (loading) return workspaceApps;
-    return workspaceApps.filter((app) => availability[app.id] && !hiddenApps.includes(app.id));
+    return workspaceApps.filter(
+      (app) => (availability[app.id] || app.alwaysAvailable) && !hiddenApps.includes(app.id)
+    );
   }, [allApps, availability, isRemote, loading, settings?.hiddenOpenInApps]);
 
   return { icons, labels, availability, installedApps, loading };

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1459,8 +1459,12 @@ declare global {
   }
 }
 
-// Explicit type export for better TypeScript recognition
-export interface ElectronAPI {
+// Re-export the Window.electronAPI shape so consumers can import the type directly.
+// Previously a hand-maintained duplicate that drifted out of sync.
+export type ElectronAPI = Window['electronAPI'];
+
+/* eslint-disable @typescript-eslint/no-unused-vars -- kept for reference, replaced by the alias above */
+interface _DeprecatedElectronAPI {
   // Menu events (main → renderer)
   onMenuOpenSettings: (listener: () => void) => () => void;
   onMenuCheckForUpdates: (listener: () => void) => () => void;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -643,12 +643,14 @@ declare global {
       clipboardWriteText: (text: string) => Promise<{ success: boolean; error?: string }>;
       paste: () => Promise<{ success: boolean; error?: string }>;
       openIn: (args: {
-        app: OpenInAppId;
+        app: string;
         path: string;
         isRemote?: boolean;
         sshConnectionId?: string | null;
       }) => Promise<{ success: boolean; error?: string }>;
-      checkInstalledApps: () => Promise<Record<OpenInAppId, boolean>>;
+      checkInstalledApps: () => Promise<Record<string, boolean>>;
+      getResolvedOpenInApps: () => Promise<ResolvedOpenInApp[]>;
+      getCustomToolIcon: (iconPath: string) => Promise<string>;
       connectToGitHub: (projectPath: string) => Promise<{
         success: boolean;
         repository?: string;
@@ -2253,4 +2255,4 @@ export interface ElectronAPI {
   onPerfSnapshot: (listener: (snapshot: ResourceMetricsSnapshot) => void) => () => void;
 }
 import type { TerminalSnapshotPayload } from '#types/terminalSnapshot';
-import type { OpenInAppId } from '#shared/openInApps';
+import type { OpenInAppId, ResolvedOpenInApp } from '#shared/openInApps';

--- a/src/shared/openInApps.ts
+++ b/src/shared/openInApps.ts
@@ -10,7 +10,7 @@ export type PlatformConfig = {
   iconPath?: string;
 };
 
-type OpenInAppConfigShape = {
+export type OpenInAppConfigShape = {
   id: string;
   label: string;
   iconPath: (typeof ICON_PATHS)[keyof typeof ICON_PATHS];
@@ -488,4 +488,57 @@ export function getResolvedLabel(app: OpenInAppConfigShape, platform: PlatformKe
 
 export function getResolvedIconPath(app: OpenInAppConfigShape, platform: PlatformKey): string {
   return app.platforms[platform]?.iconPath || app.iconPath;
+}
+
+/** Shape of a user-defined tool entry in settings.json. */
+export interface CustomOpenInApp {
+  id: string;
+  label: string;
+  openCommand: string;
+  checkCommand?: string;
+  iconPath?: string;
+}
+
+/** Flattened, single-platform representation used as wire format between main and renderer. */
+export type ResolvedOpenInApp = {
+  id: string;
+  label: string;
+  iconPath: string;
+  iconIsCustomPath: boolean;
+  openCommands: string[];
+  openUrls: string[];
+  checkCommands: string[];
+  bundleIds: string[];
+  appNames: string[];
+  alwaysAvailable: boolean;
+  hideIfUnavailable: boolean;
+  autoInstall: boolean;
+  supportsRemote: boolean;
+  invertInDark: boolean;
+  isCustom: boolean;
+};
+
+/** Resolve a built-in app config to the flattened single-platform shape. */
+export function resolveAppForPlatform(
+  app: OpenInAppConfigShape,
+  platform: PlatformKey
+): ResolvedOpenInApp {
+  const pc = app.platforms[platform];
+  return {
+    id: app.id,
+    label: pc?.label || app.label,
+    iconPath: pc?.iconPath || app.iconPath,
+    iconIsCustomPath: false,
+    openCommands: pc?.openCommands ?? [],
+    openUrls: pc?.openUrls ?? [],
+    checkCommands: pc?.checkCommands ?? [],
+    bundleIds: pc?.bundleIds ?? [],
+    appNames: pc?.appNames ?? [],
+    alwaysAvailable: app.alwaysAvailable ?? false,
+    hideIfUnavailable: app.hideIfUnavailable ?? false,
+    autoInstall: app.autoInstall ?? false,
+    supportsRemote: app.supportsRemote ?? false,
+    invertInDark: app.invertInDark ?? false,
+    isCustom: false,
+  };
 }

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -418,4 +418,41 @@ describe('normalizeSettings - customOpenInApps', () => {
     expect(result.customOpenInApps![0].checkCommand).toBe('safe-cmd');
     expect(result.customOpenInApps![1].checkCommand).toBeUndefined();
   });
+
+  it('deduplicates custom tools by id, keeping the first occurrence', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [
+          { id: 'dup', label: 'First', openCommand: 'first {{path}}' },
+          { id: 'dup', label: 'Second', openCommand: 'second {{path}}' },
+          { id: 'unique', label: 'Unique', openCommand: 'unique {{path}}' },
+        ],
+      })
+    );
+
+    expect(result.customOpenInApps).toHaveLength(2);
+    expect(result.customOpenInApps![0].label).toBe('First');
+    expect(result.customOpenInApps![1].id).toBe('unique');
+  });
+
+  it('trims defaultOpenInApp before validating', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        defaultOpenInApp: '  terminal  ',
+      })
+    );
+
+    expect(result.defaultOpenInApp).toBe('terminal');
+  });
+
+  it('trims hiddenOpenInApps entries before validating', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        hiddenOpenInApps: ['  terminal  ', '  vscode  '],
+      })
+    );
+
+    expect(result.hiddenOpenInApps).toContain('terminal');
+    expect(result.hiddenOpenInApps).toContain('vscode');
+  });
 });

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -283,3 +283,139 @@ describe('normalizeSettings – terminal settings', () => {
     expect(result.terminal?.macOptionIsMeta).toBe(true);
   });
 });
+
+describe('normalizeSettings - customOpenInApps', () => {
+  it('accepts valid custom tool entries', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [
+          { id: 'my-term', label: 'My Term', openCommand: 'my-term {{path}}' },
+          {
+            id: 'my-editor',
+            label: 'My Editor',
+            openCommand: 'my-editor {{path}}',
+            checkCommand: 'my-editor',
+            iconPath: '/usr/share/icons/my-editor.png',
+          },
+        ],
+      })
+    );
+
+    expect(result.customOpenInApps).toHaveLength(2);
+    expect(result.customOpenInApps![0]).toEqual({
+      id: 'my-term',
+      label: 'My Term',
+      openCommand: 'my-term {{path}}',
+    });
+    expect(result.customOpenInApps![1]).toEqual({
+      id: 'my-editor',
+      label: 'My Editor',
+      openCommand: 'my-editor {{path}}',
+      checkCommand: 'my-editor',
+      iconPath: '/usr/share/icons/my-editor.png',
+    });
+  });
+
+  it('strips entries with missing required fields', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [
+          { id: '', label: 'No ID', openCommand: 'cmd' } as any,
+          { id: 'x', label: '', openCommand: 'cmd' } as any,
+          { id: 'y', label: 'Y', openCommand: '' } as any,
+          { id: 'z', label: 'Z' } as any, // missing openCommand entirely
+          null as any,
+          42 as any,
+        ],
+      })
+    );
+
+    expect(result.customOpenInApps).toEqual([]);
+  });
+
+  it('trims whitespace from all fields', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [
+          {
+            id: '  my-term  ',
+            label: '  My Term  ',
+            openCommand: '  my-term {{path}}  ',
+            checkCommand: '  my-term  ',
+            iconPath: '  /icon.png  ',
+          },
+        ],
+      })
+    );
+
+    const app = result.customOpenInApps![0];
+    expect(app.id).toBe('my-term');
+    expect(app.label).toBe('My Term');
+    expect(app.openCommand).toBe('my-term {{path}}');
+    expect(app.checkCommand).toBe('my-term');
+    expect(app.iconPath).toBe('/icon.png');
+  });
+
+  it('defaults to empty array when not provided', () => {
+    const result = normalizeSettings(makeSettings());
+    expect(result.customOpenInApps).toEqual([]);
+  });
+
+  it('allows custom tool ID as defaultOpenInApp', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [{ id: 'my-tool', label: 'Tool', openCommand: 'tool {{path}}' }],
+        defaultOpenInApp: 'my-tool',
+      })
+    );
+
+    expect(result.defaultOpenInApp).toBe('my-tool');
+  });
+
+  it('rejects unknown defaultOpenInApp that is not a custom ID', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [],
+        defaultOpenInApp: 'nonexistent' as any,
+      })
+    );
+
+    expect(result.defaultOpenInApp).toBe('terminal');
+  });
+
+  it('allows custom tool ID in hiddenOpenInApps', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [{ id: 'my-tool', label: 'Tool', openCommand: 'tool {{path}}' }],
+        hiddenOpenInApps: ['my-tool', 'terminal'],
+      })
+    );
+
+    expect(result.hiddenOpenInApps).toContain('my-tool');
+    expect(result.hiddenOpenInApps).toContain('terminal');
+  });
+
+  it('strips checkCommand with shell metacharacters', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        customOpenInApps: [
+          {
+            id: 'safe',
+            label: 'Safe',
+            openCommand: 'safe {{path}}',
+            checkCommand: 'safe-cmd',
+          },
+          {
+            id: 'unsafe',
+            label: 'Unsafe',
+            openCommand: 'unsafe {{path}}',
+            checkCommand: 'foo; rm -rf ~',
+          },
+        ],
+      })
+    );
+
+    expect(result.customOpenInApps![0].checkCommand).toBe('safe-cmd');
+    expect(result.customOpenInApps![1].checkCommand).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Add user-configurable custom tools to the Open In dropdown via a new Settings UI
- Custom entries can override built-in tools by matching their `id` (e.g., override `terminal` with your preferred emulator)
- New `openInRegistry` service + `ResolvedOpenInApp` wire type for clean main↔renderer separation
- Custom tool icons served securely via `data:` URIs through IPC
- `checkCommand` sanitized against shell injection; icon paths restricted to configured values

### Settings UI

A (+) button next to the "Tools" header opens a modal to add custom tools. Custom tools show a "Custom" badge and a pencil icon to edit. The edit modal includes a Delete button.

<img width="1735" height="1016" alt="Screenshot from 2026-04-01 13-55-33" src="https://github.com/user-attachments/assets/50436d46-db5c-4372-9eb1-bbc373f32759" />

### Example `settings.json` config
```json
{
  "customOpenInApps": [
    {
      "id": "my-terminal",
      "label": "My Terminal",
      "openCommand": "my-terminal --working-directory={{path}}",
      "checkCommand": "my-terminal",
      "iconPath": "/usr/share/icons/my-terminal.png"
    }
  ]
}
```

## Test plan
- [x] Add a custom tool via the Settings UI, verify it appears in the Open In dropdown
- [x] Edit a custom tool, verify changes are reflected
- [x] Delete a custom tool via the edit modal
- [x] Set a custom tool as `defaultOpenInApp`, verify it shows as the primary Open button
- [x] Override a built-in (e.g., `"id": "zed"`) and verify the custom command is used
- [x] Verify custom tools appear in the Settings > Tools show/hide panel with "Custom" badge
- [x] Verify tools without `checkCommand` are always shown (assumed available)
- [x] Verify tools with `checkCommand` are only shown when the command is found
- [x] Verify invalid entries (empty id/label/command) are silently dropped
- [x] Verify check command field validates against shell metacharacters with inline error
- [x] Run `pnpm exec vitest run` — 47 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)