### PR TITLE
feat(open-in): filter unsupported apps for remote SSH workspaces

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -7,6 +7,7 @@ import { getAppSettings } from '../settings';
 import {
   getAppById,
   getResolvedLabel,
+  isOpenInAppSupportedForWorkspace,
   OPEN_IN_APPS,
   type OpenInAppId,
   type PlatformKey,
@@ -298,8 +299,22 @@ export function registerAppIpc() {
           return { success: false, error: `${label} is not available on this platform.` };
         }
 
+        if (!isOpenInAppSupportedForWorkspace(appConfig, isRemote)) {
+          return {
+            success: false,
+            error: `${label} is not available for remote SSH workspaces.`,
+          };
+        }
+
         // Handle remote SSH connections for supported editors and terminals
-        if (isRemote && sshConnectionId) {
+        if (isRemote) {
+          if (!sshConnectionId) {
+            return {
+              success: false,
+              error: `Missing SSH connection for remote ${label} launch.`,
+            };
+          }
+
           try {
             const connection = await databaseService.getSshConnection(sshConnectionId);
             if (!connection) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -93,7 +93,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   },
 
   // Open a path in a specific app
-  openIn: (args: { app: OpenInAppId; path: string }) => ipcRenderer.invoke('app:openIn', args),
+  openIn: (args: {
+    app: OpenInAppId;
+    path: string;
+    isRemote?: boolean;
+    sshConnectionId?: string | null;
+  }) => ipcRenderer.invoke('app:openIn', args),
 
   // Check which apps are installed
   checkInstalledApps: () =>

--- a/src/renderer/components/titlebar/OpenInMenu.tsx
+++ b/src/renderer/components/titlebar/OpenInMenu.tsx
@@ -30,7 +30,7 @@ const OpenInMenu: React.FC<OpenInMenuProps> = ({
   const containerRef = React.useRef<HTMLDivElement | null>(null);
   const shouldReduceMotion = useReducedMotion();
   const { toast } = useToast();
-  const { icons, labels, installedApps, availability, loading } = useOpenInApps();
+  const { icons, labels, installedApps, availability, loading } = useOpenInApps({ isRemote });
   const { settings, updateSettings } = useAppSettings();
 
   const defaultApp: OpenInAppId | null =

--- a/src/renderer/hooks/useOpenInApps.ts
+++ b/src/renderer/hooks/useOpenInApps.ts
@@ -3,6 +3,7 @@ import {
   OPEN_IN_APPS,
   getResolvedIconPath,
   getResolvedLabel,
+  isOpenInAppSupportedForWorkspace,
   type OpenInAppId,
   type PlatformKey,
 } from '@shared/openInApps';
@@ -16,7 +17,9 @@ export interface UseOpenInAppsResult {
   loading: boolean;
 }
 
-export function useOpenInApps(): UseOpenInAppsResult {
+export function useOpenInApps({
+  isRemote = false,
+}: { isRemote?: boolean } = {}): UseOpenInAppsResult {
   const { settings, isLoading: settingsLoading } = useAppSettings();
   const [icons, setIcons] = useState<Partial<Record<OpenInAppId, string>>>({});
   const [labels, setLabels] = useState<Partial<Record<OpenInAppId, string>>>({});
@@ -68,9 +71,14 @@ export function useOpenInApps(): UseOpenInAppsResult {
   // Filter to only installed and visible apps (return all while loading)
   const installedApps = useMemo(() => {
     const hiddenApps: OpenInAppId[] = settings?.hiddenOpenInApps ?? [];
-    if (loading) return OPEN_IN_APPS;
-    return OPEN_IN_APPS.filter((app) => availability[app.id] && !hiddenApps.includes(app.id));
-  }, [availability, loading, settings?.hiddenOpenInApps]);
+    const workspaceApps = OPEN_IN_APPS.filter((app) =>
+      isOpenInAppSupportedForWorkspace(app, isRemote)
+    );
+
+    if (loading) return workspaceApps;
+
+    return workspaceApps.filter((app) => availability[app.id] && !hiddenApps.includes(app.id));
+  }, [availability, isRemote, loading, settings?.hiddenOpenInApps]);
 
   return { icons, labels, availability, installedApps, loading };
 }

--- a/src/shared/openInApps.ts
+++ b/src/shared/openInApps.ts
@@ -409,6 +409,13 @@ export function isValidOpenInAppId(value: unknown): value is OpenInAppId {
   return typeof value === 'string' && OPEN_IN_APPS.some((app) => app.id === value);
 }
 
+export function isOpenInAppSupportedForWorkspace(
+  app: Pick<OpenInAppConfigShape, 'supportsRemote'>,
+  isRemote: boolean
+): boolean {
+  return !isRemote || app.supportsRemote === true;
+}
+
 export function getResolvedLabel(app: OpenInAppConfigShape, platform: PlatformKey): string {
   return app.platforms[platform]?.label || app.label;
 }

--- a/src/test/main/appIpc.openIn.test.ts
+++ b/src/test/main/appIpc.openIn.test.ts
@@ -1,0 +1,133 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type IpcHandler = (...args: unknown[]) => unknown;
+
+const ipcHandleHandlers = new Map<string, IpcHandler>();
+const shellOpenExternalMock = vi.fn<(url: string) => Promise<void>>();
+const getSshConnectionMock =
+  vi.fn<(id: string) => Promise<{ host: string; username: string; port: number } | null>>();
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getVersion: vi.fn(() => '0.0.0-test'),
+    getAppPath: vi.fn(() => process.cwd()),
+  },
+  BrowserWindow: vi.fn(),
+  clipboard: {
+    writeText: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, cb: IpcHandler) => {
+      ipcHandleHandlers.set(channel, cb);
+    }),
+  },
+  shell: {
+    openExternal: (url: string) => shellOpenExternalMock(url),
+  },
+}));
+
+vi.mock('../../main/services/DatabaseService', () => ({
+  databaseService: {
+    getSshConnection: (id: string) => getSshConnectionMock(id),
+  },
+}));
+
+vi.mock('../../main/services/ProjectPrep', () => ({
+  ensureProjectPrepared: vi.fn(),
+}));
+
+vi.mock('../../main/settings', () => ({
+  getAppSettings: vi.fn(() => ({
+    projectPrep: {
+      autoInstallOnOpenInEditor: false,
+    },
+  })),
+}));
+
+vi.mock('../../main/utils/childProcessEnv', () => ({
+  buildExternalToolEnv: vi.fn(() => process.env),
+}));
+
+describe('app:openIn remote workspace handling', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    ipcHandleHandlers.clear();
+  });
+
+  async function getHandler() {
+    const { registerAppIpc } = await import('../../main/ipc/appIpc');
+    registerAppIpc();
+    const handler = ipcHandleHandlers.get('app:openIn');
+    expect(handler).toBeTypeOf('function');
+    return handler!;
+  }
+
+  it('rejects unsupported remote apps before attempting SSH launch', async () => {
+    const handler = await getHandler();
+
+    const result = await handler(
+      {},
+      {
+        app: 'zed',
+        path: '/srv/repo',
+        isRemote: true,
+        sshConnectionId: 'ssh-1',
+      }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Zed is not available for remote SSH workspaces.',
+    });
+    expect(getSshConnectionMock).not.toHaveBeenCalled();
+    expect(shellOpenExternalMock).not.toHaveBeenCalled();
+  });
+
+  it('returns a clear error when a supported remote app is missing the SSH connection id', async () => {
+    const handler = await getHandler();
+
+    const result = await handler(
+      {},
+      {
+        app: 'vscode',
+        path: '/srv/repo',
+        isRemote: true,
+      }
+    );
+
+    expect(result).toEqual({
+      success: false,
+      error: 'Missing SSH connection for remote VS Code launch.',
+    });
+    expect(getSshConnectionMock).not.toHaveBeenCalled();
+  });
+
+  it('keeps supported remote editor launches working', async () => {
+    const handler = await getHandler();
+
+    getSshConnectionMock.mockResolvedValue({
+      host: 'example.internal',
+      username: 'azureuser',
+      port: 22,
+    });
+    shellOpenExternalMock.mockResolvedValue(undefined);
+
+    const result = await handler(
+      {},
+      {
+        app: 'vscode',
+        path: '/srv/repo',
+        isRemote: true,
+        sshConnectionId: 'ssh-1',
+      }
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(getSshConnectionMock).toHaveBeenCalledWith('ssh-1');
+    expect(shellOpenExternalMock).toHaveBeenCalledWith(
+      'vscode://vscode-remote/ssh-remote+azureuser%40example.internal/srv/repo'
+    );
+  });
+});

--- a/src/test/shared/openInApps.test.ts
+++ b/src/test/shared/openInApps.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  OPEN_IN_APPS,
+  getAppById,
+  isOpenInAppSupportedForWorkspace,
+} from '../../shared/openInApps';
+
+describe('isOpenInAppSupportedForWorkspace', () => {
+  it('keeps all apps available for local workspaces', () => {
+    const localAppIds = OPEN_IN_APPS.filter((app) =>
+      isOpenInAppSupportedForWorkspace(app, false)
+    ).map((app) => app.id);
+
+    expect(localAppIds).toEqual(OPEN_IN_APPS.map((app) => app.id));
+    expect(localAppIds).toContain('zed');
+  });
+
+  it('filters out apps without remote support for SSH workspaces', () => {
+    const remoteAppIds = OPEN_IN_APPS.filter((app) =>
+      isOpenInAppSupportedForWorkspace(app, true)
+    ).map((app) => app.id);
+
+    expect(remoteAppIds).not.toContain('zed');
+    expect(remoteAppIds).toEqual(
+      expect.arrayContaining(['cursor', 'vscode', 'terminal', 'warp', 'iterm2', 'ghostty'])
+    );
+    expect(remoteAppIds).not.toContain('vscodium');
+  });
+
+  it('treats Zed as local-only until remote support exists', () => {
+    const zed = getAppById('zed');
+
+    expect(zed).toBeDefined();
+    expect(isOpenInAppSupportedForWorkspace(zed!, true)).toBe(false);
+    expect(isOpenInAppSupportedForWorkspace(zed!, false)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- Add `isOpenInAppSupportedForWorkspace` helper to filter apps by remote/local context based on each app's `supportsRemote` flag
- Pass `isRemote` and `sshConnectionId` through the full stack: preload IPC args, `useOpenInApps` hook, and `OpenInMenu` component
- Add early validation in `app:openIn` IPC handler to reject unsupported apps for remote workspaces and require a valid SSH connection ID

## Details
Previously the "Open In" menu showed all installed apps regardless of whether the workspace was remote. Apps without `supportsRemote: true` (e.g., Finder, Xcode, Zed) would silently fail when used on SSH workspaces. Now:
- The renderer filters the app list to only show remote-compatible apps when `isRemote` is true
- The main process validates both workspace compatibility and SSH connection presence before attempting to launch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for "Open In" functionality with remote SSH workspaces, with application-specific availability based on remote compatibility.
  * Certain applications (e.g., Zed) are restricted to local workspaces, while supported remote-capable applications (e.g., VS Code, Cursor, Terminal) can be used with SSH connections.

* **Tests**
  * Added comprehensive test coverage for remote workspace scenarios and app support validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->