### PR TITLE
feat: support configurable dev server port

### DIFF
--- a/src/main/app/window.ts
+++ b/src/main/app/window.ts
@@ -43,7 +43,7 @@ export function createMainWindow(): BrowserWindow {
   });
 
   if (isDev) {
-    mainWindow.loadURL('http://localhost:3000');
+    mainWindow.loadURL(`http://localhost:${process.env.EMDASH_DEV_PORT || 3000}`);
   } else {
     // Serve renderer over an HTTP origin in production so embeds work.
     const rendererRoot = join(app.getAppPath(), 'dist', 'renderer');

--- a/src/main/utils/externalLinks.ts
+++ b/src/main/utils/externalLinks.ts
@@ -9,7 +9,7 @@ export function registerExternalLinkHandlers(win: BrowserWindow, isDev: boolean)
   const wc = win.webContents;
 
   const isInternalAppUrl = (url: string) => {
-    if (isDev) return url.startsWith('http://localhost:3000');
+    if (isDev) return url.startsWith(`http://localhost:${process.env.EMDASH_DEV_PORT || 3000}`);
     return url.startsWith('file://') || /^http:\/\/(127\.0\.0\.1|localhost):\d+(?:\/|$)/i.test(url);
   };
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -24,6 +24,6 @@ export default defineConfig(({ command }) => ({
     },
   },
   server: {
-    port: 3000,
+    port: Number(process.env.EMDASH_DEV_PORT) || 3000,
   },
 }));


### PR DESCRIPTION
## Summary

Adds `EMDASH_DEV_PORT` env var support so the Vite dev server, Electron main window, and external link handler all respect a custom port. 

This unlocks developing emdash in multiple worktrees simultaneously all with their individual run scripts without port collisions:

```bash
EMDASH_DEV_PORT=$EMDASH_PORT pnpm dev
```

Not loving the `EMDASH_DEV_PORT` env name, so feel free to suggest changes

## Fixes 
N/A

## Snapshot
N/A

## Type of change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks
- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Development server port configuration is now flexible through environment variables instead of being fixed, with a sensible default fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->