### PR TITLE
feat(config): add support for browser url

### DIFF
--- a/agents/workflows/worktrees.md
+++ b/agents/workflows/worktrees.md
@@ -24,6 +24,7 @@ Current supported keys:
 - `scripts.teardown`
 - `shellSetup`
 - `tmux`
+- `openBrowserUrl`
 
 ## Rules
 

--- a/docs/content/docs/project-config.mdx
+++ b/docs/content/docs/project-config.mdx
@@ -130,6 +130,18 @@ Python project with virtual environment:
 python -m venv .venv && source .venv/bin/activate && pip install -r requirements.txt
 ```
 
+## Open Browser URL
+
+The **Open Browser URL** field (`openBrowserUrl` in `.emdash.json`) lets you pin a specific URL for the browser toggle button instead of relying on auto-detection from terminal output.
+
+Supports env var expansion — any `$VAR` or `${VAR}` reference is expanded using the task's environment variables as well as system vars like `$USER`.
+
+```text
+http://localhost:$EMDASH_PORT
+```
+
+Leave it blank to fall back to auto-detection.
+
 ## Editing the config
 
 On the project page, click **Edit config**, fill the fields, then click **Save**. Emdash stores these settings in `.emdash.json`.

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -356,6 +356,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('fs:getProjectConfig', { projectPath }),
   saveProjectConfig: (projectPath: string, content: string) =>
     ipcRenderer.invoke('fs:saveProjectConfig', { projectPath, content }),
+  resolvePreviewUrl: (projectPath: string, taskEnvVars?: Record<string, string>) =>
+    ipcRenderer.invoke('fs:resolvePreviewUrl', { projectPath, taskEnvVars }),
   ensureGitignore: (projectPath: string, patterns: string[]) =>
     ipcRenderer.invoke('fs:ensureGitignore', { projectPath, patterns }),
   // Attachments

--- a/src/main/services/LifecycleScriptsService.ts
+++ b/src/main/services/LifecycleScriptsService.ts
@@ -15,7 +15,7 @@ export interface EmdashConfig {
   shellSetup?: string;
   tmux?: boolean;
   workspaceProvider?: WorkspaceProviderConfig;
-  previewUrl?: string;
+  openBrowserUrl?: string;
 }
 
 /**

--- a/src/main/services/LifecycleScriptsService.ts
+++ b/src/main/services/LifecycleScriptsService.ts
@@ -15,6 +15,7 @@ export interface EmdashConfig {
   shellSetup?: string;
   tmux?: boolean;
   workspaceProvider?: WorkspaceProviderConfig;
+  previewUrl?: string;
 }
 
 /**

--- a/src/main/services/fsIpc.ts
+++ b/src/main/services/fsIpc.ts
@@ -880,6 +880,42 @@ export function registerFsIpc(): void {
     }
   );
 
+  // Resolve the previewUrl from .emdash.json, expanding $VAR references using
+  // process.env merged with EMDASH task-specific vars supplied by the caller.
+  ipcMain.handle(
+    'fs:resolvePreviewUrl',
+    async (_event, args: { projectPath: string; taskEnvVars?: Record<string, string> }) => {
+      try {
+        const { projectPath, taskEnvVars } = args;
+        if (!projectPath) return { success: false, error: 'Missing projectPath' };
+        const configPath = path.join(projectPath, '.emdash.json');
+        if (!fs.existsSync(configPath)) return { success: true, url: null };
+        const raw = fs.readFileSync(configPath, 'utf8');
+        const config = JSON.parse(raw);
+        const template: string | undefined = config?.previewUrl;
+        if (!template || typeof template !== 'string' || !template.trim()) {
+          return { success: true, url: null };
+        }
+        // Expand $VAR and ${VAR} references: EMDASH vars take priority, then process.env
+        const env: Record<string, string> = {
+          ...(process.env as Record<string, string>),
+          ...(taskEnvVars || {}),
+        };
+        const resolved = template.replace(
+          /\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
+          (_m, braced, bare) => {
+            const key = braced || bare;
+            return Object.prototype.hasOwnProperty.call(env, key) ? env[key] : _m;
+          }
+        );
+        return { success: true, url: resolved.trim() };
+      } catch (error) {
+        console.error('fs:resolvePreviewUrl failed:', error);
+        return { success: false, error: 'Failed to resolve preview URL' };
+      }
+    }
+  );
+
   // Ensure entries exist in .gitignore (idempotent)
   ipcMain.handle(
     'fs:ensureGitignore',

--- a/src/main/services/fsIpc.ts
+++ b/src/main/services/fsIpc.ts
@@ -72,6 +72,8 @@ const ALLOWED_IMAGE_EXTENSIONS = new Set<string>([
 ]);
 const DEFAULT_ATTACHMENTS_SUBDIR = 'attachments' as const;
 
+const ALLOWED_HOST_VARS = ['USER'];
+
 export function registerFsIpc(): void {
   function emitPlanEvent(payload: any) {
     try {
@@ -881,7 +883,7 @@ export function registerFsIpc(): void {
   );
 
   // Resolve the openBrowserUrl from .emdash.json, expanding $VAR references using
-  // process.env merged with EMDASH task-specific vars supplied by the caller.
+  // taskEnvVars and a small allowlist of benign host vars supplied by the caller.
   ipcMain.handle(
     'fs:resolvePreviewUrl',
     async (_event, args: { projectPath: string; taskEnvVars?: Record<string, string> }) => {
@@ -896,11 +898,15 @@ export function registerFsIpc(): void {
         if (!template || typeof template !== 'string' || !template.trim()) {
           return { success: true, url: null };
         }
-        // Expand $VAR and ${VAR} references: EMDASH vars take priority, then process.env
-        const env: Record<string, string> = {
-          ...(process.env as Record<string, string>),
-          ...(taskEnvVars || {}),
-        };
+
+        // Expand $VAR and ${VAR} references from taskEnvVars plus an allowlist
+        // of benign host vars to avoid leaking secrets from process.env.
+        const hostVars: Record<string, string> = {};
+        for (const key of ALLOWED_HOST_VARS) {
+          if (typeof process.env[key] === 'string') hostVars[key] = process.env[key]!;
+        }
+
+        const env: Record<string, string> = { ...hostVars, ...(taskEnvVars || {}) };
         const resolved = template.replace(
           /\$\{([^}]+)\}|\$([A-Za-z_][A-Za-z0-9_]*)/g,
           (_m, braced, bare) => {

--- a/src/main/services/fsIpc.ts
+++ b/src/main/services/fsIpc.ts
@@ -880,7 +880,7 @@ export function registerFsIpc(): void {
     }
   );
 
-  // Resolve the previewUrl from .emdash.json, expanding $VAR references using
+  // Resolve the openBrowserUrl from .emdash.json, expanding $VAR references using
   // process.env merged with EMDASH task-specific vars supplied by the caller.
   ipcMain.handle(
     'fs:resolvePreviewUrl',
@@ -892,7 +892,7 @@ export function registerFsIpc(): void {
         if (!fs.existsSync(configPath)) return { success: true, url: null };
         const raw = fs.readFileSync(configPath, 'utf8');
         const config = JSON.parse(raw);
-        const template: string | undefined = config?.previewUrl;
+        const template: string | undefined = config?.openBrowserUrl;
         if (!template || typeof template !== 'string' || !template.trim()) {
           return { success: true, url: null };
         }

--- a/src/renderer/components/ConfigEditorModal.tsx
+++ b/src/renderer/components/ConfigEditorModal.tsx
@@ -26,6 +26,7 @@ type ConfigShape = Record<string, unknown> & {
   shellSetup?: string;
   tmux?: boolean;
   workspaceProvider?: WorkspaceProviderConfig;
+  previewUrl?: string;
 };
 
 interface ConfigEditorModalProps {
@@ -134,6 +135,13 @@ function applyWorkspaceProvider(
   };
 }
 
+function applyPreviewUrl(config: ConfigShape, previewUrl: string): ConfigShape {
+  const { previewUrl: _previewUrl, ...rest } = config;
+  const trimmed = previewUrl.trim();
+  if (!trimmed) return rest;
+  return { ...rest, previewUrl: trimmed };
+}
+
 export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
   isOpen,
   onClose,
@@ -155,6 +163,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
   const [originalWpProvisionCommand, setOriginalWpProvisionCommand] = useState('');
   const [wpTerminateCommand, setWpTerminateCommand] = useState('');
   const [originalWpTerminateCommand, setOriginalWpTerminateCommand] = useState('');
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [originalPreviewUrl, setOriginalPreviewUrl] = useState('');
 
   const [isLoading, setIsLoading] = useState(false);
   const [isSaving, setIsSaving] = useState(false);
@@ -175,9 +185,19 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
     const withShellSetup = applyShellSetup(withPatterns, shellSetup);
     const withTmux = applyTmux(withShellSetup, tmux);
     const withWp = applyWorkspaceProvider(withTmux, wpProvisionCommand, wpTerminateCommand);
-    const withScripts = applyScripts(withWp, scripts);
+    const withPreviewUrl = applyPreviewUrl(withWp, previewUrl);
+    const withScripts = applyScripts(withPreviewUrl, scripts);
     return `${JSON.stringify(withScripts, null, 2)}\n`;
-  }, [config, preservePatterns, shellSetup, tmux, wpProvisionCommand, wpTerminateCommand, scripts]);
+  }, [
+    config,
+    preservePatterns,
+    shellSetup,
+    tmux,
+    wpProvisionCommand,
+    wpTerminateCommand,
+    previewUrl,
+    scripts,
+  ]);
 
   const scriptsDirty = useMemo(
     () =>
@@ -188,7 +208,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       shellSetup !== originalShellSetup ||
       tmux !== originalTmux ||
       wpProvisionCommand !== originalWpProvisionCommand ||
-      wpTerminateCommand !== originalWpTerminateCommand,
+      wpTerminateCommand !== originalWpTerminateCommand ||
+      previewUrl !== originalPreviewUrl,
     [
       originalShellSetup,
       originalPreservePatternsInput,
@@ -198,6 +219,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       originalTmux,
       originalWpProvisionCommand,
       originalWpTerminateCommand,
+      originalPreviewUrl,
       shellSetup,
       preservePatternsInput,
       scripts.run,
@@ -206,6 +228,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       tmux,
       wpProvisionCommand,
       wpTerminateCommand,
+      previewUrl,
     ]
   );
 
@@ -248,6 +271,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
         wp && typeof wp === 'object' && typeof wp.terminateCommand === 'string'
           ? wp.terminateCommand
           : '';
+      const nextPreviewUrl = typeof parsed.previewUrl === 'string' ? parsed.previewUrl : '';
       setConfig(parsed);
       setScripts(nextScripts);
       setOriginalScripts(nextScripts);
@@ -261,6 +285,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       setOriginalWpProvisionCommand(nextWpProvision);
       setWpTerminateCommand(nextWpTerminate);
       setOriginalWpTerminateCommand(nextWpTerminate);
+      setPreviewUrl(nextPreviewUrl);
+      setOriginalPreviewUrl(nextPreviewUrl);
     } catch (err) {
       setConfig({});
       setScripts({ ...EMPTY_SCRIPTS });
@@ -275,6 +301,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       setOriginalWpProvisionCommand('');
       setWpTerminateCommand('');
       setOriginalWpTerminateCommand('');
+      setPreviewUrl('');
+      setOriginalPreviewUrl('');
       setError(err instanceof Error ? err.message : 'Failed to load config');
       setLoadFailed(true);
     } finally {
@@ -327,13 +355,16 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       }
 
       const nextConfig = applyScripts(
-        applyWorkspaceProvider(
-          applyTmux(
-            applyShellSetup(applyPreservePatterns(config, preservePatterns), shellSetup),
-            tmux
+        applyPreviewUrl(
+          applyWorkspaceProvider(
+            applyTmux(
+              applyShellSetup(applyPreservePatterns(config, preservePatterns), shellSetup),
+              tmux
+            ),
+            wpProvisionCommand,
+            wpTerminateCommand
           ),
-          wpProvisionCommand,
-          wpTerminateCommand
+          previewUrl
         ),
         scripts
       );
@@ -344,6 +375,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
       setOriginalTmux(tmux);
       setOriginalWpProvisionCommand(wpProvisionCommand);
       setOriginalWpTerminateCommand(wpTerminateCommand);
+      setOriginalPreviewUrl(previewUrl);
 
       if (
         wpProvisionCommand !== originalWpProvisionCommand ||
@@ -374,6 +406,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
     tmux,
     wpProvisionCommand,
     wpTerminateCommand,
+    previewUrl,
   ]);
 
   return (
@@ -433,6 +466,25 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
                 />
                 <p className="text-xs text-muted-foreground">
                   Runs in every terminal before the shell starts.
+                </p>
+              </div>
+
+              <div className="space-y-2">
+                <Label htmlFor="config-preview-url">Open Browser URL</Label>
+                <Input
+                  id="config-preview-url"
+                  value={previewUrl}
+                  onChange={(event) => {
+                    setPreviewUrl(event.target.value);
+                    setError(null);
+                  }}
+                  placeholder="http://localhost:$EMDASH_PORT"
+                  className="font-mono text-xs"
+                  disabled={isSaving}
+                />
+                <p className="text-xs text-muted-foreground">
+                  Overrides the browser toggle URL. Supports env var expansion. Leave blank to
+                  auto-detect from output.
                 </p>
               </div>
 

--- a/src/renderer/components/ConfigEditorModal.tsx
+++ b/src/renderer/components/ConfigEditorModal.tsx
@@ -483,8 +483,8 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
                   disabled={isSaving}
                 />
                 <p className="text-xs text-muted-foreground">
-                  Overrides the browser toggle URL. Supports env var expansion. Leave blank to
-                  auto-detect from output.
+                  Overrides the browser toggle URL. Supports EMDASH vars. Leave blank to auto-detect
+                  from output.
                 </p>
               </div>
 

--- a/src/renderer/components/ConfigEditorModal.tsx
+++ b/src/renderer/components/ConfigEditorModal.tsx
@@ -26,7 +26,7 @@ type ConfigShape = Record<string, unknown> & {
   shellSetup?: string;
   tmux?: boolean;
   workspaceProvider?: WorkspaceProviderConfig;
-  previewUrl?: string;
+  openBrowserUrl?: string;
 };
 
 interface ConfigEditorModalProps {
@@ -136,10 +136,10 @@ function applyWorkspaceProvider(
 }
 
 function applyPreviewUrl(config: ConfigShape, previewUrl: string): ConfigShape {
-  const { previewUrl: _previewUrl, ...rest } = config;
+  const { openBrowserUrl: _openBrowserUrl, ...rest } = config;
   const trimmed = previewUrl.trim();
   if (!trimmed) return rest;
-  return { ...rest, previewUrl: trimmed };
+  return { ...rest, openBrowserUrl: trimmed };
 }
 
 export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
@@ -271,7 +271,7 @@ export const ConfigEditorModal: React.FC<ConfigEditorModalProps> = ({
         wp && typeof wp === 'object' && typeof wp.terminateCommand === 'string'
           ? wp.terminateCommand
           : '';
-      const nextPreviewUrl = typeof parsed.previewUrl === 'string' ? parsed.previewUrl : '';
+      const nextPreviewUrl = typeof parsed.openBrowserUrl === 'string' ? parsed.openBrowserUrl : '';
       setConfig(parsed);
       setScripts(nextScripts);
       setOriginalScripts(nextScripts);

--- a/src/renderer/components/titlebar/BrowserToggleButton.tsx
+++ b/src/renderer/components/titlebar/BrowserToggleButton.tsx
@@ -12,15 +12,24 @@ import {
   setInstalled,
 } from '@/lib/previewStorage';
 import { isReachable, isAppPort, FALLBACK_DELAY_MS, SPINNER_MAX_MS } from '@/lib/previewNetwork';
+import { getBasePort } from '@shared/task/envVars';
 
 interface Props {
   defaultUrl?: string;
   taskId?: string | null;
+  taskName?: string | null;
   taskPath?: string | null;
+  taskBranch?: string | null;
   parentProjectPath?: string | null;
 }
 
-const BrowserToggleButton: React.FC<Props> = ({ taskId, taskPath, parentProjectPath }) => {
+const BrowserToggleButton: React.FC<Props> = ({
+  taskId,
+  taskName,
+  taskPath,
+  taskBranch,
+  parentProjectPath,
+}) => {
   const browser = useBrowser();
   async function needsInstall(path?: string | null): Promise<boolean> {
     const p = (path || '').trim();
@@ -96,10 +105,14 @@ const BrowserToggleButton: React.FC<Props> = ({ taskId, taskPath, parentProjectP
     // If openBrowserUrl is configured in .emdash.json, use it directly
     if (pp) {
       try {
+        const portSeed = wp || id;
         const taskEnvVars: Record<string, string> = {};
         if (id) taskEnvVars['EMDASH_TASK_ID'] = id;
+        if (taskName) taskEnvVars['EMDASH_TASK_NAME'] = taskName;
         if (wp) taskEnvVars['EMDASH_TASK_PATH'] = wp;
         if (pp) taskEnvVars['EMDASH_ROOT_PATH'] = pp;
+        taskEnvVars['EMDASH_DEFAULT_BRANCH'] = taskBranch || 'main';
+        if (portSeed) taskEnvVars['EMDASH_PORT'] = String(getBasePort(portSeed));
         const result = await (window as any).electronAPI?.resolvePreviewUrl?.(pp, taskEnvVars);
         if (result?.success && result?.url) {
           const configuredUrl = String(result.url);
@@ -179,7 +192,7 @@ const BrowserToggleButton: React.FC<Props> = ({ taskId, taskPath, parentProjectP
     }
     // Fallback: clear spinner after a grace period if nothing arrives
     setTimeout(() => browser.hideSpinner(), SPINNER_MAX_MS);
-  }, [browser, taskId, taskPath, parentProjectPath]);
+  }, [browser, taskId, taskName, taskPath, taskBranch, parentProjectPath]);
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/src/renderer/components/titlebar/BrowserToggleButton.tsx
+++ b/src/renderer/components/titlebar/BrowserToggleButton.tsx
@@ -12,7 +12,7 @@ import {
   setInstalled,
 } from '@/lib/previewStorage';
 import { isReachable, isAppPort, FALLBACK_DELAY_MS, SPINNER_MAX_MS } from '@/lib/previewNetwork';
-import { getBasePort } from '@shared/task/envVars';
+import { getTaskEnvVars } from '@shared/task/envVars';
 
 interface Props {
   defaultUrl?: string;
@@ -21,6 +21,7 @@ interface Props {
   taskPath?: string | null;
   taskBranch?: string | null;
   parentProjectPath?: string | null;
+  defaultBranch?: string;
 }
 
 const BrowserToggleButton: React.FC<Props> = ({
@@ -29,6 +30,7 @@ const BrowserToggleButton: React.FC<Props> = ({
   taskPath,
   taskBranch,
   parentProjectPath,
+  defaultBranch,
 }) => {
   const browser = useBrowser();
   async function needsInstall(path?: string | null): Promise<boolean> {
@@ -105,14 +107,14 @@ const BrowserToggleButton: React.FC<Props> = ({
     // If openBrowserUrl is configured in .emdash.json, use it directly
     if (pp) {
       try {
-        const portSeed = wp || id;
-        const taskEnvVars: Record<string, string> = {};
-        if (id) taskEnvVars['EMDASH_TASK_ID'] = id;
-        if (taskName) taskEnvVars['EMDASH_TASK_NAME'] = taskName;
-        if (wp) taskEnvVars['EMDASH_TASK_PATH'] = wp;
-        if (pp) taskEnvVars['EMDASH_ROOT_PATH'] = pp;
-        taskEnvVars['EMDASH_DEFAULT_BRANCH'] = taskBranch || 'main';
-        if (portSeed) taskEnvVars['EMDASH_PORT'] = String(getBasePort(portSeed));
+        const taskEnvVars = getTaskEnvVars({
+          taskId: id,
+          taskName: taskName || '',
+          taskPath: wp,
+          projectPath: pp,
+          defaultBranch,
+          portSeed: wp || id,
+        });
         const result = await (window as any).electronAPI?.resolvePreviewUrl?.(pp, taskEnvVars);
         if (result?.success && result?.url) {
           const configuredUrl = String(result.url);
@@ -192,7 +194,7 @@ const BrowserToggleButton: React.FC<Props> = ({
     }
     // Fallback: clear spinner after a grace period if nothing arrives
     setTimeout(() => browser.hideSpinner(), SPINNER_MAX_MS);
-  }, [browser, taskId, taskName, taskPath, taskBranch, parentProjectPath]);
+  }, [browser, taskId, taskName, taskPath, defaultBranch, parentProjectPath]);
 
   return (
     <TooltipProvider delayDuration={200}>

--- a/src/renderer/components/titlebar/BrowserToggleButton.tsx
+++ b/src/renderer/components/titlebar/BrowserToggleButton.tsx
@@ -93,7 +93,7 @@ const BrowserToggleButton: React.FC<Props> = ({ taskId, taskPath, parentProjectP
     browser.showSpinner();
     browser.toggle(undefined);
 
-    // If a previewUrl is configured in .emdash.json, use it directly
+    // If openBrowserUrl is configured in .emdash.json, use it directly
     if (pp) {
       try {
         const taskEnvVars: Record<string, string> = {};

--- a/src/renderer/components/titlebar/BrowserToggleButton.tsx
+++ b/src/renderer/components/titlebar/BrowserToggleButton.tsx
@@ -87,10 +87,35 @@ const BrowserToggleButton: React.FC<Props> = ({ taskId, taskPath, parentProjectP
     }
     const id = (taskId || '').trim();
     const wp = (taskPath || '').trim();
+    const pp = (parentProjectPath || '').trim();
     const appPort = Number(window.location.port || 0);
     // Open pane immediately with no URL; we will navigate when ready
     browser.showSpinner();
     browser.toggle(undefined);
+
+    // If a previewUrl is configured in .emdash.json, use it directly
+    if (pp) {
+      try {
+        const taskEnvVars: Record<string, string> = {};
+        if (id) taskEnvVars['EMDASH_TASK_ID'] = id;
+        if (wp) taskEnvVars['EMDASH_TASK_PATH'] = wp;
+        if (pp) taskEnvVars['EMDASH_ROOT_PATH'] = pp;
+        const result = await (window as any).electronAPI?.resolvePreviewUrl?.(pp, taskEnvVars);
+        if (result?.success && result?.url) {
+          const configuredUrl = String(result.url);
+          if (!isAppPort(configuredUrl, appPort)) {
+            browser.open(configuredUrl);
+            try {
+              if (id) {
+                setLastUrl(id, configuredUrl);
+              }
+            } catch {}
+            browser.hideSpinner();
+            return;
+          }
+        }
+      } catch {}
+    }
 
     if (id) {
       try {
@@ -131,7 +156,7 @@ const BrowserToggleButton: React.FC<Props> = ({ taskId, taskPath, parentProjectP
           await (window as any).electronAPI?.hostPreviewStart?.({
             taskId: id,
             taskPath: wp,
-            parentProjectPath: (parentProjectPath || '').trim(),
+            parentProjectPath: pp,
           });
         }
         // Fallback: if no URL event yet after a short delay, try default dev port once.

--- a/src/renderer/components/titlebar/BrowserToggleButton.tsx
+++ b/src/renderer/components/titlebar/BrowserToggleButton.tsx
@@ -104,7 +104,7 @@ const BrowserToggleButton: React.FC<Props> = ({
     browser.showSpinner();
     browser.toggle(undefined);
 
-    // If openBrowserUrl is configured in .emdash.json, use it directly
+    let configuredUrl: string | null = null;
     if (pp) {
       try {
         const taskEnvVars = getTaskEnvVars({
@@ -117,16 +117,9 @@ const BrowserToggleButton: React.FC<Props> = ({
         });
         const result = await (window as any).electronAPI?.resolvePreviewUrl?.(pp, taskEnvVars);
         if (result?.success && result?.url) {
-          const configuredUrl = String(result.url);
-          if (!isAppPort(configuredUrl, appPort)) {
-            browser.open(configuredUrl);
-            try {
-              if (id) {
-                setLastUrl(id, configuredUrl);
-              }
-            } catch {}
-            browser.hideSpinner();
-            return;
+          const resolvedUrl = String(result.url);
+          if (!isAppPort(resolvedUrl, appPort)) {
+            configuredUrl = resolvedUrl;
           }
         }
       } catch {}
@@ -174,11 +167,9 @@ const BrowserToggleButton: React.FC<Props> = ({
             parentProjectPath: pp,
           });
         }
-        // Fallback: if no URL event yet after a short delay, try default dev port once.
         setTimeout(async () => {
           try {
-            const candidate = 'http://localhost:5173';
-            // Avoid the app's own port
+            const candidate = configuredUrl || 'http://localhost:5173';
             if (isAppPort(candidate, appPort)) return;
             if (await isReachable(candidate)) {
               browser.open(candidate);

--- a/src/renderer/components/titlebar/Titlebar.tsx
+++ b/src/renderer/components/titlebar/Titlebar.tsx
@@ -303,7 +303,9 @@ const Titlebar: React.FC<TitlebarProps> = ({
           {taskId && !isTaskMultiAgent ? (
             <BrowserToggleButton
               taskId={taskId}
+              taskName={activeTask?.name ?? null}
               taskPath={taskPath}
+              taskBranch={activeTask?.branch ?? null}
               parentProjectPath={projectPath}
             />
           ) : null}

--- a/src/renderer/components/titlebar/Titlebar.tsx
+++ b/src/renderer/components/titlebar/Titlebar.tsx
@@ -103,6 +103,7 @@ const Titlebar: React.FC<TitlebarProps> = ({
   const {
     projects,
     selectedProject,
+    projectDefaultBranch,
     handleSelectProject: onSelectProject,
     showKanban: isKanbanOpen,
     showEditorMode: isEditorOpen,
@@ -307,6 +308,7 @@ const Titlebar: React.FC<TitlebarProps> = ({
               taskPath={taskPath}
               taskBranch={activeTask?.branch ?? null}
               parentProjectPath={projectPath}
+              defaultBranch={projectDefaultBranch}
             />
           ) : null}
           <TooltipProvider delayDuration={200}>

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -796,6 +796,10 @@ declare global {
         projectPath: string,
         content: string
       ) => Promise<{ success: boolean; path?: string; error?: string }>;
+      resolvePreviewUrl: (
+        projectPath: string,
+        taskEnvVars?: Record<string, string>
+      ) => Promise<{ success: boolean; url?: string | null; error?: string }>;
       ensureGitignore: (
         projectPath: string,
         patterns: string[]

--- a/src/shared/task/envVars.ts
+++ b/src/shared/task/envVars.ts
@@ -28,7 +28,7 @@ function slugify(value: string): string {
     .replace(/^-|-$/g, '');
 }
 
-function getBasePort(seed: string): number {
+export function getBasePort(seed: string): number {
   let hash = 0;
   for (let i = 0; i < seed.length; i += 1) {
     hash = (hash << 5) - hash + seed.charCodeAt(i);

--- a/src/test/main/fsIpc.resolvePreviewUrl.test.ts
+++ b/src/test/main/fsIpc.resolvePreviewUrl.test.ts
@@ -42,6 +42,7 @@ describe('fs:resolvePreviewUrl', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.resetModules();
+    vi.unstubAllEnvs();
     ipcHandleHandlers.clear();
   });
 
@@ -116,8 +117,7 @@ describe('fs:resolvePreviewUrl', () => {
       JSON.stringify({ openBrowserUrl: 'http://localhost:$EMDASH_PORT' })
     );
     // Simulate process.env having a different value
-    const origEnv = process.env.EMDASH_PORT;
-    process.env.EMDASH_PORT = '9999';
+    vi.stubEnv('EMDASH_PORT', '9999');
     const handler = await getHandler();
     const result = await handler(
       {},
@@ -126,7 +126,6 @@ describe('fs:resolvePreviewUrl', () => {
         taskEnvVars: { EMDASH_PORT: '3000' },
       }
     );
-    process.env.EMDASH_PORT = origEnv;
     expect(result).toEqual({ success: true, url: 'http://localhost:3000' });
   });
 

--- a/src/test/main/fsIpc.resolvePreviewUrl.test.ts
+++ b/src/test/main/fsIpc.resolvePreviewUrl.test.ts
@@ -1,0 +1,148 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const ipcHandleHandlers = new Map<string, (...args: any[]) => any>();
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn((channel: string, cb: (...args: any[]) => any) => {
+      ipcHandleHandlers.set(channel, cb);
+    }),
+  },
+  shell: { openExternal: vi.fn() },
+}));
+
+// Mock heavy deps that fsIpc pulls in but are irrelevant to resolvePreviewUrl
+vi.mock('worker_threads', () => ({ Worker: vi.fn() }));
+vi.mock('../../main/services/ssh/SshService', () => ({ sshService: {} }));
+vi.mock('../../main/services/fs/RemoteFileSystem', () => ({ RemoteFileSystem: vi.fn() }));
+vi.mock('../../main/utils/fsIgnores', () => ({ DEFAULT_IGNORES: [] }));
+vi.mock('../../main/utils/safeStat', () => ({ safeStat: vi.fn() }));
+vi.mock('../../main/utils/gitIgnore', () => ({ GitIgnoreParser: vi.fn() }));
+
+const fsMock = {
+  existsSync: vi.fn(),
+  readFileSync: vi.fn(),
+  writeFileSync: vi.fn(),
+  mkdirSync: vi.fn(),
+  readdirSync: vi.fn(),
+  statSync: vi.fn(),
+};
+
+vi.mock('fs', () => fsMock);
+
+async function getHandler() {
+  const { registerFsIpc } = await import('../../main/services/fsIpc');
+  registerFsIpc();
+  const handler = ipcHandleHandlers.get('fs:resolvePreviewUrl');
+  expect(handler).toBeTypeOf('function');
+  return handler!;
+}
+
+describe('fs:resolvePreviewUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    ipcHandleHandlers.clear();
+  });
+
+  it('returns null when .emdash.json does not exist', async () => {
+    fsMock.existsSync.mockReturnValue(false);
+    const handler = await getHandler();
+    const result = await handler({}, { projectPath: '/tmp/repo' });
+    expect(result).toEqual({ success: true, url: null });
+  });
+
+  it('returns null when previewUrl is not set in config', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(JSON.stringify({ scripts: { run: 'npm start' } }));
+    const handler = await getHandler();
+    const result = await handler({}, { projectPath: '/tmp/repo' });
+    expect(result).toEqual({ success: true, url: null });
+  });
+
+  it('returns null when previewUrl is blank', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(JSON.stringify({ previewUrl: '   ' }));
+    const handler = await getHandler();
+    const result = await handler({}, { projectPath: '/tmp/repo' });
+    expect(result).toEqual({ success: true, url: null });
+  });
+
+  it('returns a static URL unchanged', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(JSON.stringify({ previewUrl: 'http://localhost:3000' }));
+    const handler = await getHandler();
+    const result = await handler({}, { projectPath: '/tmp/repo' });
+    expect(result).toEqual({ success: true, url: 'http://localhost:3000' });
+  });
+
+  it('expands $VAR from taskEnvVars', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(
+      JSON.stringify({ previewUrl: 'http://localhost:$EMDASH_PORT' })
+    );
+    const handler = await getHandler();
+    const result = await handler(
+      {},
+      {
+        projectPath: '/tmp/repo',
+        taskEnvVars: { EMDASH_PORT: '8080' },
+      }
+    );
+    expect(result).toEqual({ success: true, url: 'http://localhost:8080' });
+  });
+
+  it('expands ${VAR} syntax', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(
+      JSON.stringify({ previewUrl: 'http://${EMDASH_TASK_NAME}.localhost' })
+    );
+    const handler = await getHandler();
+    const result = await handler(
+      {},
+      {
+        projectPath: '/tmp/repo',
+        taskEnvVars: { EMDASH_TASK_NAME: 'my-feature' },
+      }
+    );
+    expect(result).toEqual({ success: true, url: 'http://my-feature.localhost' });
+  });
+
+  it('taskEnvVars take priority over process.env', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(
+      JSON.stringify({ previewUrl: 'http://localhost:$EMDASH_PORT' })
+    );
+    // Simulate process.env having a different value
+    const origEnv = process.env.EMDASH_PORT;
+    process.env.EMDASH_PORT = '9999';
+    const handler = await getHandler();
+    const result = await handler(
+      {},
+      {
+        projectPath: '/tmp/repo',
+        taskEnvVars: { EMDASH_PORT: '3000' },
+      }
+    );
+    process.env.EMDASH_PORT = origEnv;
+    expect(result).toEqual({ success: true, url: 'http://localhost:3000' });
+  });
+
+  it('leaves unresolvable vars unexpanded', async () => {
+    fsMock.existsSync.mockReturnValue(true);
+    fsMock.readFileSync.mockReturnValue(
+      JSON.stringify({ previewUrl: 'http://localhost:$UNKNOWN_VAR' })
+    );
+    // Make sure UNKNOWN_VAR is not in process.env
+    delete process.env.UNKNOWN_VAR;
+    const handler = await getHandler();
+    const result = await handler({}, { projectPath: '/tmp/repo' });
+    expect(result).toEqual({ success: true, url: 'http://localhost:$UNKNOWN_VAR' });
+  });
+
+  it('returns error when projectPath is missing', async () => {
+    const handler = await getHandler();
+    const result = await handler({}, { projectPath: '' });
+    expect(result).toMatchObject({ success: false });
+  });
+});

--- a/src/test/main/fsIpc.resolvePreviewUrl.test.ts
+++ b/src/test/main/fsIpc.resolvePreviewUrl.test.ts
@@ -52,7 +52,7 @@ describe('fs:resolvePreviewUrl', () => {
     expect(result).toEqual({ success: true, url: null });
   });
 
-  it('returns null when previewUrl is not set in config', async () => {
+  it('returns null when openBrowserUrl is not set in config', async () => {
     fsMock.existsSync.mockReturnValue(true);
     fsMock.readFileSync.mockReturnValue(JSON.stringify({ scripts: { run: 'npm start' } }));
     const handler = await getHandler();
@@ -60,9 +60,9 @@ describe('fs:resolvePreviewUrl', () => {
     expect(result).toEqual({ success: true, url: null });
   });
 
-  it('returns null when previewUrl is blank', async () => {
+  it('returns null when openBrowserUrl is blank', async () => {
     fsMock.existsSync.mockReturnValue(true);
-    fsMock.readFileSync.mockReturnValue(JSON.stringify({ previewUrl: '   ' }));
+    fsMock.readFileSync.mockReturnValue(JSON.stringify({ openBrowserUrl: '   ' }));
     const handler = await getHandler();
     const result = await handler({}, { projectPath: '/tmp/repo' });
     expect(result).toEqual({ success: true, url: null });
@@ -70,7 +70,9 @@ describe('fs:resolvePreviewUrl', () => {
 
   it('returns a static URL unchanged', async () => {
     fsMock.existsSync.mockReturnValue(true);
-    fsMock.readFileSync.mockReturnValue(JSON.stringify({ previewUrl: 'http://localhost:3000' }));
+    fsMock.readFileSync.mockReturnValue(
+      JSON.stringify({ openBrowserUrl: 'http://localhost:3000' })
+    );
     const handler = await getHandler();
     const result = await handler({}, { projectPath: '/tmp/repo' });
     expect(result).toEqual({ success: true, url: 'http://localhost:3000' });
@@ -79,7 +81,7 @@ describe('fs:resolvePreviewUrl', () => {
   it('expands $VAR from taskEnvVars', async () => {
     fsMock.existsSync.mockReturnValue(true);
     fsMock.readFileSync.mockReturnValue(
-      JSON.stringify({ previewUrl: 'http://localhost:$EMDASH_PORT' })
+      JSON.stringify({ openBrowserUrl: 'http://localhost:$EMDASH_PORT' })
     );
     const handler = await getHandler();
     const result = await handler(
@@ -95,7 +97,7 @@ describe('fs:resolvePreviewUrl', () => {
   it('expands ${VAR} syntax', async () => {
     fsMock.existsSync.mockReturnValue(true);
     fsMock.readFileSync.mockReturnValue(
-      JSON.stringify({ previewUrl: 'http://${EMDASH_TASK_NAME}.localhost' })
+      JSON.stringify({ openBrowserUrl: 'http://${EMDASH_TASK_NAME}.localhost' })
     );
     const handler = await getHandler();
     const result = await handler(
@@ -111,7 +113,7 @@ describe('fs:resolvePreviewUrl', () => {
   it('taskEnvVars take priority over process.env', async () => {
     fsMock.existsSync.mockReturnValue(true);
     fsMock.readFileSync.mockReturnValue(
-      JSON.stringify({ previewUrl: 'http://localhost:$EMDASH_PORT' })
+      JSON.stringify({ openBrowserUrl: 'http://localhost:$EMDASH_PORT' })
     );
     // Simulate process.env having a different value
     const origEnv = process.env.EMDASH_PORT;
@@ -131,7 +133,7 @@ describe('fs:resolvePreviewUrl', () => {
   it('leaves unresolvable vars unexpanded', async () => {
     fsMock.existsSync.mockReturnValue(true);
     fsMock.readFileSync.mockReturnValue(
-      JSON.stringify({ previewUrl: 'http://localhost:$UNKNOWN_VAR' })
+      JSON.stringify({ openBrowserUrl: 'http://localhost:$UNKNOWN_VAR' })
     );
     // Make sure UNKNOWN_VAR is not in process.env
     delete process.env.UNKNOWN_VAR;

--- a/src/test/main/fsIpc.resolvePreviewUrl.test.ts
+++ b/src/test/main/fsIpc.resolvePreviewUrl.test.ts
@@ -111,22 +111,15 @@ describe('fs:resolvePreviewUrl', () => {
     expect(result).toEqual({ success: true, url: 'http://my-feature.localhost' });
   });
 
-  it('taskEnvVars take priority over process.env', async () => {
+  it('expands allowlisted host vars', async () => {
     fsMock.existsSync.mockReturnValue(true);
     fsMock.readFileSync.mockReturnValue(
-      JSON.stringify({ openBrowserUrl: 'http://localhost:$EMDASH_PORT' })
+      JSON.stringify({ openBrowserUrl: 'http://$USER.internal' })
     );
-    // Simulate process.env having a different value
-    vi.stubEnv('EMDASH_PORT', '9999');
+    vi.stubEnv('USER', 'alice');
     const handler = await getHandler();
-    const result = await handler(
-      {},
-      {
-        projectPath: '/tmp/repo',
-        taskEnvVars: { EMDASH_PORT: '3000' },
-      }
-    );
-    expect(result).toEqual({ success: true, url: 'http://localhost:3000' });
+    const result = await handler({}, { projectPath: '/tmp/repo' });
+    expect(result).toEqual({ success: true, url: 'http://alice.internal' });
   });
 
   it('leaves unresolvable vars unexpanded', async () => {


### PR DESCRIPTION
## Summary
Add the ability to optionally define what URL the in-app browser opens, this removes a lot of the guess work about what to use because it'll be user provided. The Emdash env vars are exposed so you can do things like:

```
https://localhost:$EMDASH_PORT
```

### Use case
For this particular use case, we sync our development code to Kubernetes which would available at a specific url like:

```
https://${USER}-${EMDASH_TASK_NAME}.internal.dev
```

Exposing this configuration allows the user to define how they want to open the URL per worktree

## Fixes 
N/A

## Snapshot
<img width="759" height="180" alt="image" src="https://github.com/user-attachments/assets/665f83da-6270-4aa5-a32c-bf343f3f4903" />

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an "Open Browser URL" project setting and editor field (supports env-variable expansion and task-specific interpolation); browser toggle now consults this configured URL (per-task) before falling back to auto-detection.
* **Documentation**
  * Project config docs updated with Open Browser URL usage, examples, and blank-to-auto-detect behavior.
* **Tests**
  * Added tests for preview-URL resolution, interpolation, and error cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->