### PR TITLE
fix: non solid bg on navy and dark mode sidebar when small windo

### DIFF
--- a/src/renderer/components/ui/sidebar.tsx
+++ b/src/renderer/components/ui/sidebar.tsx
@@ -123,13 +123,13 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
 
     const baseClasses =
       variant === 'default'
-        ? 'group/sidebar relative z-50 flex h-full flex-col border-r border-border bg-gray-50 dark:bg-muted/10 text-sm text-foreground transition-all duration-200 ease-linear overflow-hidden flex-shrink-0 data-[state=collapsed]:border-r-0 data-[state=collapsed]:pointer-events-none'
+        ? 'group/sidebar relative z-50 flex h-full flex-col border-r border-border bg-gray-50 md:dark:bg-muted/10 text-sm text-foreground transition-all duration-200 ease-linear overflow-hidden flex-shrink-0 data-[state=collapsed]:border-r-0 data-[state=collapsed]:pointer-events-none'
         : '';
     const responsiveClasses =
       variant === 'default'
         ? isMobile
           ? cn(
-              'fixed inset-y-0 left-0 w-[var(--sidebar-width-mobile,18rem)] !bg-background shadow-lg pt-[var(--tb)]',
+              'fixed inset-y-0 left-0 w-[var(--sidebar-width-mobile,18rem)] bg-background shadow-lg pt-[var(--tb)]',
               open ? 'translate-x-0' : '-translate-x-full'
             )
           : cn(open ? 'w-full' : 'w-0')


### PR DESCRIPTION
## Summary
the sidebar was translucent when the window was small when using the navy/dark mode but NOT the light mode. this fixes it so that its always solid :D

## Fixes 
https://github.com/user-attachments/assets/240dccca-c863-4b5d-a677-3b3c9ef5983a

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Adjusted dark-mode sidebar background so the muted background appears only on medium-and-larger screens, improving contrast and appearance on small/mobile viewports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->