### PR TITLE
feat(terminal): add Option as Meta key setting for macOS

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -119,6 +119,7 @@ export interface AppSettings {
     fontFamily: string;
     fontSize: number;
     autoCopyOnSelection: boolean;
+    macOptionIsMeta: boolean;
   };
   defaultOpenInApp?: OpenInAppId;
   hiddenOpenInApps?: OpenInAppId[];
@@ -204,6 +205,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     fontFamily: '',
     fontSize: 0,
     autoCopyOnSelection: false,
+    macOptionIsMeta: false,
   },
   defaultOpenInApp: 'terminal',
   hiddenOpenInApps: [],
@@ -579,13 +581,14 @@ export function normalizeSettings(input: AppSettings): AppSettings {
   const term = (input as any)?.terminal || {};
   const fontFamily = String(term?.fontFamily ?? '').trim();
   const autoCopyOnSelection = Boolean(term?.autoCopyOnSelection ?? false);
+  const macOptionIsMeta = Boolean(term?.macOptionIsMeta ?? false);
   const rawFontSize = term?.fontSize;
   let fontSize = 0;
   if (typeof rawFontSize === 'number' && Number.isFinite(rawFontSize)) {
     const clamped = Math.round(rawFontSize);
     fontSize = clamped >= 8 && clamped <= 24 ? clamped : 0;
   }
-  out.terminal = { fontFamily, fontSize, autoCopyOnSelection };
+  out.terminal = { fontFamily, fontSize, autoCopyOnSelection, macOptionIsMeta };
 
   // Default Open In App
   const defaultOpenInApp = (input as any)?.defaultOpenInApp;

--- a/src/renderer/components/TerminalSettingsCard.tsx
+++ b/src/renderer/components/TerminalSettingsCard.tsx
@@ -6,6 +6,7 @@ import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from './ui/select';
 import { Switch } from './ui/switch';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import { useAppContext } from '@/contexts/AppContextProvider';
 
 type FontOption = {
   id: string;
@@ -37,6 +38,7 @@ const dedupeAndSort = (fonts: string[]) =>
 
 const TerminalSettingsCard: React.FC = () => {
   const { settings, updateSettings, isLoading: loading, isSaving: saving } = useAppSettings();
+  const { platform } = useAppContext();
   const [pickerOpen, setPickerOpen] = useState<boolean>(false);
   const [search, setSearch] = useState<string>('');
   const [installedFonts, setInstalledFonts] = useState<string[] | null>(null);
@@ -45,6 +47,7 @@ const TerminalSettingsCard: React.FC = () => {
   const fontFamily = settings?.terminal?.fontFamily ?? '';
   const fontSize = settings?.terminal?.fontSize ?? 0;
   const autoCopyOnSelection = settings?.terminal?.autoCopyOnSelection ?? false;
+  const macOptionIsMeta = settings?.terminal?.macOptionIsMeta ?? false;
 
   const popularOptions = useMemo<FontOption[]>(() => {
     return [
@@ -137,6 +140,18 @@ const TerminalSettingsCard: React.FC = () => {
       updateSettings({ terminal: { autoCopyOnSelection: next } });
       window.dispatchEvent(
         new CustomEvent('terminal-auto-copy-changed', { detail: { autoCopyOnSelection: next } })
+      );
+    },
+    [updateSettings]
+  );
+
+  const toggleMacOptionIsMeta = useCallback(
+    (next: boolean) => {
+      updateSettings({ terminal: { macOptionIsMeta: next } });
+      window.dispatchEvent(
+        new CustomEvent('terminal-mac-option-is-meta-changed', {
+          detail: { macOptionIsMeta: next },
+        })
       );
     },
     [updateSettings]
@@ -311,6 +326,21 @@ const TerminalSettingsCard: React.FC = () => {
           onCheckedChange={toggleAutoCopy}
         />
       </div>
+      {platform === 'darwin' ? (
+        <div className="flex items-center justify-between gap-4">
+          <div className="flex flex-1 flex-col gap-0.5">
+            <p className="text-sm font-medium text-foreground">Use Option as Meta key</p>
+            <p className="text-sm text-muted-foreground">
+              Treat the Option key as the Meta key in the terminal.
+            </p>
+          </div>
+          <Switch
+            checked={macOptionIsMeta}
+            disabled={loading || saving}
+            onCheckedChange={toggleMacOptionIsMeta}
+          />
+        </div>
+      ) : null}
     </div>
   );
 };

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -218,6 +218,7 @@ export class TerminalSessionManager {
         updateCustomFontSize(size);
       }
       this.autoCopyOnSelection = settings?.terminal?.autoCopyOnSelection ?? false;
+      this.terminal.options.macOptionIsMeta = settings?.terminal?.macOptionIsMeta ?? false;
     });
 
     window.electronAPI.terminalGetTheme().then((result) => {
@@ -261,6 +262,15 @@ export class TerminalSessionManager {
     window.addEventListener('terminal-auto-copy-changed', handleAutoCopyChange);
     this.disposables.push(() =>
       window.removeEventListener('terminal-auto-copy-changed', handleAutoCopyChange)
+    );
+
+    const handleMacOptionIsMetaChange = (e: Event) => {
+      const detail = (e as CustomEvent<{ macOptionIsMeta?: boolean }>).detail;
+      this.terminal.options.macOptionIsMeta = detail?.macOptionIsMeta ?? false;
+    };
+    window.addEventListener('terminal-mac-option-is-meta-changed', handleMacOptionIsMetaChange);
+    this.disposables.push(() =>
+      window.removeEventListener('terminal-mac-option-is-meta-changed', handleMacOptionIsMetaChange)
     );
 
     const handlePanelResizeDragging = (e: Event) => {

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -228,3 +228,19 @@ describe('normalizeSettings - review preset', () => {
     });
   });
 });
+
+describe('normalizeSettings – terminal settings', () => {
+  it('preserves macOptionIsMeta: true', () => {
+    const result = normalizeSettings(
+      makeSettings({
+        terminal: {
+          fontFamily: '',
+          fontSize: 0,
+          autoCopyOnSelection: false,
+          macOptionIsMeta: true,
+        },
+      })
+    );
+    expect(result.terminal?.macOptionIsMeta).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
In macOS, the Option key can be used as a Meta key in terminals. Similar applications like VSCode and Terminal expose this as an option (default off)

#### VSCode
<img width="613" height="69" alt="image" src="https://github.com/user-attachments/assets/4d8dc375-9ef5-4a1d-89c2-73b53852a180" />

#### Terminal
<img width="177" height="56" alt="image" src="https://github.com/user-attachments/assets/31bca93b-2e50-408b-ade0-67a0f1dfee52" />

## Fixes 
This pull request exposes this option to Emdash and passes this to `xterm.js` (see [documentation](https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/#optional-macoptionismeta))

## Snapshot
<img width="692" height="139" alt="image" src="https://github.com/user-attachments/assets/46c00bb0-c577-45e6-9968-4b882989f43a" />

Pressing `Meta-f` / `Meta-b` (`Option + f` / `Option + b`):

#### Before
![Kapture 2026-03-25 at 21 58 51](https://github.com/user-attachments/assets/fa1b0be9-f7eb-479a-b744-9f078162f104)

#### After
![Kapture 2026-03-25 at 21 55 55](https://github.com/user-attachments/assets/f9aeb399-4291-4022-b944-e65b6b8ba9c0)


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked if new and existing unit tests pass locally with my changes