### PR TITLE
fix: enhance prompt detection by improving escape sequence stripping …

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -65,7 +65,8 @@ function waitForSshPromptThenWrite(
     write: (data: string) => void;
   },
   data: string,
-  label: string
+  label: string,
+  earlyChunks?: string[]
 ): void {
   const handles = promptHandles.get(id) ?? [];
   promptHandles.set(id, handles);
@@ -73,6 +74,12 @@ function waitForSshPromptThenWrite(
   const handle = waitForShellPrompt({
     subscribe: (cb) => {
       const disposable = proc.onData(cb);
+      // Replay data that arrived before the prompt detector subscribed
+      // (e.g. during an async resolveRemoteTmuxEnabled call).
+      // Replayed after subscribing so finish() can dispose the real listener.
+      if (earlyChunks) {
+        for (const chunk of earlyChunks) cb(chunk);
+      }
       return () => disposable.dispose();
     },
     write: (d) => {
@@ -725,9 +732,15 @@ export function registerPtyIpc(): void {
             env,
           });
 
+          // Capture early PTY data so the prompt detector can replay it
+          // even if the prompt arrives during the async tmux resolution below.
+          const earlyChunks: string[] = [];
+          let capturingEarly = true;
+
           if (!listeners.has(id)) {
             proc.onData((data) => {
               bufferedSendPtyData(id, data);
+              if (capturingEarly) earlyChunks.push(data);
             });
             proc.onExit(({ exitCode, signal }) => {
               cancelPromptHandles(id);
@@ -753,8 +766,10 @@ export function registerPtyIpc(): void {
             cwd,
             tmux: remoteTmuxOpt,
           });
+          capturingEarly = false;
+
           if (remoteInit) {
-            waitForSshPromptThenWrite(id, proc, remoteInit, 'ptyIpc:start');
+            waitForSshPromptThenWrite(id, proc, remoteInit, 'ptyIpc:start', earlyChunks);
           }
 
           try {
@@ -1266,9 +1281,15 @@ export function registerPtyIpc(): void {
             env: mergedEnv,
           });
 
+          // Capture early PTY data so the prompt detector can replay it
+          // even if the prompt arrives during the async tmux resolution below.
+          const earlyChunks: string[] = [];
+          let capturingEarly = true;
+
           if (!listeners.has(id)) {
             proc.onData((data) => {
               bufferedSendPtyData(id, data);
+              if (capturingEarly) earlyChunks.push(data);
             });
             proc.onExit(({ exitCode, signal }) => {
               cancelPromptHandles(id);
@@ -1297,8 +1318,10 @@ export function registerPtyIpc(): void {
             tmux: tmuxOpt,
             preProviderCommands: preProviderCommands.length ? preProviderCommands : undefined,
           });
+          capturingEarly = false;
+
           if (remoteInit) {
-            waitForSshPromptThenWrite(id, proc, remoteInit, 'ptyIpc:startDirect');
+            waitForSshPromptThenWrite(id, proc, remoteInit, 'ptyIpc:startDirect', earlyChunks);
           }
 
           maybeMarkProviderStart(id);

--- a/src/main/utils/__tests__/waitForShellPrompt.test.ts
+++ b/src/main/utils/__tests__/waitForShellPrompt.test.ts
@@ -112,6 +112,32 @@ describe('waitForShellPrompt', () => {
     expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
   });
 
+  it('detects prompt followed by charset designation escape \\x1b(B', () => {
+    const pty = createMockPty();
+    waitForShellPrompt({
+      subscribe: pty.subscribe,
+      write: pty.write,
+      data: 'cd /foo\n',
+    });
+
+    // fish's set_color normal emits \x1b(B after the prompt
+    pty.emit('\x1b[32muser@host\x1b[0m \x1b[34m~\x1b[0m\x1b(B> \x1b[?2004h');
+    expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
+  });
+
+  it('detects prompt with trailing unstripped escape sequences', () => {
+    const pty = createMockPty();
+    waitForShellPrompt({
+      subscribe: pty.subscribe,
+      write: pty.write,
+      data: 'cd /foo\n',
+    });
+
+    // Prompt followed by charset reset + bracketed paste that survive escape stripping
+    pty.emit('user@host ~> \x1b(B');
+    expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
+  });
+
   it('does not match a bare prompt character with no preceding context', () => {
     const pty = createMockPty();
     waitForShellPrompt({
@@ -292,6 +318,71 @@ describe('waitForShellPrompt', () => {
 
     pty.emit('Total: 5$');
     expect(pty.write).not.toHaveBeenCalled();
+  });
+
+  it('detects fish prompt with DCS and mixed OSC terminators', () => {
+    const pty = createMockPty();
+    waitForShellPrompt({
+      subscribe: pty.subscribe,
+      write: pty.write,
+      data: 'cd /foo\n',
+    });
+
+    // Real fish output: DCS queries (\x1bP...\x1b\\), ST-terminated OSC (\x1b]...\x1b\\),
+    // and BEL-terminated OSC (\x1b]...\x07) interleaved with visible prompt text.
+    // The ST-terminated OSC must be stripped before the BEL-terminated OSC regex runs,
+    // otherwise the greedy BEL regex matches from an ST-terminated \x1b] across visible
+    // text to a distant \x07, consuming the entire prompt.
+    pty.emit(
+      '\x1b[?u\x1b[>0q\x1b]11;?\x1b\\\x1b[?1049h' +
+        '\x1bP+q696e646e\x1b\\\x1bP+q71756572792d6f732d6e616d65\x1b\\' +
+        '\x1b[?1049l\x1b[0c\r' +
+        'Welcome to fish, the friendly interactive shell\r\n' +
+        'Type \x1b[32mhelp\x1b[m for instructions on how to use fish\r\n' +
+        '\x1b]7;file://host/home/user/project\x07' +
+        '\x1b]0;[host] ~/project\x07' +
+        '\x1b[m\x1b]11;?\x1b\\\x1b[6n\x1b[0c' +
+        '\x1b[?2004h\x1b[?2031h\x1b[>4;1m\x1b=' +
+        '\x1b]133;A;click_events=1\x1b\\' +
+        '\x1b[92muser\x1b[m@\x1b[33mhost\x1b[m \x1b[32m~/project\x1b[m (master)\x1b[m> ' +
+        '\x1b]133;B\x07\x1b[K\r\x1b[45C'
+    );
+    expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
+  });
+
+  it('detects prompt split across TCP segments', () => {
+    const pty = createMockPty();
+    waitForShellPrompt({
+      subscribe: pty.subscribe,
+      write: pty.write,
+      data: 'cd /foo\n',
+    });
+
+    // Prompt character arrives in a separate chunk from the rest
+    pty.emit('user@host /path');
+    expect(pty.write).not.toHaveBeenCalled();
+
+    pty.emit('> ');
+    expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
+  });
+
+  it('detects fish prompt split across TCP segments', () => {
+    const pty = createMockPty();
+    waitForShellPrompt({
+      subscribe: pty.subscribe,
+      write: pty.write,
+      data: 'cd /foo\n',
+    });
+
+    pty.emit('Welcome to fish, the friendly interactive shell\r\n');
+    pty.emit('Type `help` for instructions on how to use fish\r\n');
+    expect(pty.write).not.toHaveBeenCalled();
+
+    pty.emit('\x1b[32muser@host\x1b[0m \x1b[34m~');
+    expect(pty.write).not.toHaveBeenCalled();
+
+    pty.emit('\x1b[0m> ');
+    expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
   });
 
   it('detects prompt after multiple MOTD chunks', () => {

--- a/src/main/utils/waitForShellPrompt.ts
+++ b/src/main/utils/waitForShellPrompt.ts
@@ -1,8 +1,8 @@
-import { stripAnsi } from '@shared/text/stripAnsi';
+import { stripForPromptDetection } from '@shared/text/stripAnsi';
 
 /**
  * Matches common shell prompt endings: $, #, %, >, ❯ preceded by a non-digit, non-space character.
- * Each chunk is matched independently — prompts split across TCP segments rely on the timeout fallback.
+ * Chunks are accumulated so prompts split across TCP segments are still detected.
  */
 const SHELL_PROMPT_RE = /\S.*(?<!\d)[#$%>❯]\s*$/;
 
@@ -44,10 +44,19 @@ export function waitForShellPrompt(options: PromptWaitOptions): PromptWaitHandle
     unsubscribe();
   };
 
-  const unsubscribe = subscribe((chunk: string) => {
+  let buffer = '';
+  // Use `let` so unsubscribe is available if subscribe's callback fires
+  // synchronously (e.g. earlyChunks replay) before subscribe() returns.
+  let unsubscribe: () => void = () => {};
+  unsubscribe = subscribe((chunk: string) => {
     if (done) return;
-    const clean = stripAnsi(chunk, { includePrivateCsiParams: true });
-    if (SHELL_PROMPT_RE.test(clean)) {
+    buffer += chunk;
+    // Keep only the tail to bound memory on large MOTD output.
+    // The regex uses $ (end-of-string) so only the tail matters.
+    if (buffer.length > 2048) {
+      buffer = buffer.slice(-1024);
+    }
+    if (SHELL_PROMPT_RE.test(stripForPromptDetection(buffer))) {
       finish();
     }
   });

--- a/src/shared/text/stripAnsi.ts
+++ b/src/shared/text/stripAnsi.ts
@@ -50,3 +50,27 @@ export function stripAnsi(input: string, options: StripAnsiOptions = {}): string
 
   return output;
 }
+
+/**
+ * Aggressively strip all escape sequences for prompt detection.
+ *
+ * DCS (\x1bP...\x1b\\) and ST-terminated OSC (\x1b]...\x1b\\) sequences are
+ * removed BEFORE BEL-terminated OSC (\x1b]...\x07). Otherwise the greedy BEL
+ * regex matches from an ST-terminated \x1b] all the way to a distant \x07,
+ * consuming visible text in between (e.g. the entire fish shell prompt).
+ */
+export function stripForPromptDetection(input: string): string {
+  return (
+    input
+      // 1. DCS sequences: \x1bP ... \x1b\\
+      .replace(/\x1bP[^\x1b]*\x1b\\/g, '')
+      // 2. ST-terminated OSC: \x1b] ... \x1b\\  (must precede BEL-terminated OSC)
+      .replace(/\x1b\][^\x1b]*\x1b\\/g, '')
+      // 3. Now safe to strip CSI, BEL-terminated OSC, and remaining sequences
+      .replace(CSI_PRIVATE_RE, '') // CSI (including private params)
+      .replace(/\x1b\][^\x07]*\x07/g, '') // OSC-BEL
+      .replace(/\x1b[()#][A-Za-z0-9]/g, '') // charset designation (\x1b(B etc.)
+      .replace(/\x1b[A-Za-z=><]/g, '') // simple ESC sequences (\x1bM, \x1b=, etc.)
+      .replace(/\r/g, '') // carriage returns
+  );
+}

--- a/src/test/renderer/stripAnsi.test.ts
+++ b/src/test/renderer/stripAnsi.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { stripAnsi } from '../../shared/text/stripAnsi';
+import { stripAnsi, stripForPromptDetection } from '../../shared/text/stripAnsi';
 
 describe('shared stripAnsi', () => {
   it('strips CSI sequences', () => {
@@ -43,5 +43,56 @@ describe('shared stripAnsi', () => {
   it('does not strip non-escape text when stripOtherEscapes is enabled', () => {
     expect(stripAnsi('hello world', { stripOtherEscapes: true })).toBe('hello world');
     expect(stripAnsi('\x1b[32mhello\x1b[0m', { stripOtherEscapes: true })).toBe('hello');
+  });
+});
+
+describe('stripForPromptDetection', () => {
+  it('strips CSI sequences including private params', () => {
+    expect(stripForPromptDetection('\x1b[32mhello\x1b[0m')).toBe('hello');
+    expect(stripForPromptDetection('\x1b[?2004h\x1b[?25htext')).toBe('text');
+  });
+
+  it('strips BEL-terminated OSC sequences', () => {
+    expect(stripForPromptDetection('\x1b]0;title\x07prompt$ ')).toBe('prompt$ ');
+  });
+
+  it('strips ST-terminated OSC sequences', () => {
+    expect(stripForPromptDetection('\x1b]11;?\x1b\\prompt$ ')).toBe('prompt$ ');
+  });
+
+  it('strips DCS sequences', () => {
+    expect(stripForPromptDetection('\x1bP+q696e646e\x1b\\prompt$ ')).toBe('prompt$ ');
+  });
+
+  it('strips charset designation sequences', () => {
+    expect(stripForPromptDetection('\x1b(Btext')).toBe('text');
+    expect(stripForPromptDetection('\x1b)0text')).toBe('text');
+  });
+
+  it('strips simple ESC sequences', () => {
+    expect(stripForPromptDetection('\x1b=\x1b>text\x1bM')).toBe('text');
+  });
+
+  it('strips carriage returns', () => {
+    expect(stripForPromptDetection('hello\rworld')).toBe('helloworld');
+  });
+
+  it('preserves visible text when DCS and mixed OSC terminators are interleaved', () => {
+    // This is the core bug: ST-terminated OSC (\x1b]11;?\x1b\\) must be stripped
+    // BEFORE BEL-terminated OSC, otherwise the greedy BEL regex matches from the
+    // ST-terminated \x1b] across visible text to a distant \x07.
+    const fishOutput =
+      '\x1b]11;?\x1b\\' + // OSC-ST (background query)
+      '\x1bP+q696e646e\x1b\\' + // DCS (capability query)
+      'Welcome to fish\r\n' +
+      '\x1b]7;file://host/path\x07' + // OSC-BEL (cwd)
+      '\x1b]11;?\x1b\\' + // OSC-ST again
+      '\x1b]133;A\x1b\\' + // OSC-ST (shell integration)
+      '\x1b[92muser\x1b[m@host ~> ' +
+      '\x1b]133;B\x07'; // OSC-BEL (shell integration)
+
+    const result = stripForPromptDetection(fishOutput);
+    expect(result).toContain('Welcome to fish');
+    expect(result).toContain('user@host ~>');
   });
 });


### PR DESCRIPTION
…and handling incomplete TCP segments

## Summary

Fix 15-second SSH timeout on fish shell: fish outputs mixed DCS/OSC escape sequences with different terminators (ST vs BEL), causing the ANSI stripping regex to greedily consume the entire prompt text. Added `stripForPromptDetection` that strips sequences in the correct order, and early PTY data capture to handle the race between prompt emission and detector subscription.

## Fixes 
Fixes #1597 

## Snapshot
<img width="614" height="160" alt="image" src="https://github.com/user-attachments/assets/c4b2454a-6b7a-42c2-8d9d-802ab08e8dc7" />

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced shell prompt detection to reliably handle complex terminal escape sequences and prompts split across network segments.

* **Bug Fixes**
  * Improved reliability of PTY output capture during SSH connection initialization to ensure prompts are detected correctly even during asynchronous operations.

* **Tests**
  * Added comprehensive test coverage for shell prompt detection with complex escape sequences and segmented network packet delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->