### PR TITLE
fix(nix): fix Nix flake package build for NixOS

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -59,6 +59,19 @@
           cp ${electronLinuxZip} $out/electron-v${electronVersion}-linux-x64.zip
         '';
 
+        # Pre-fetch Electron headers for native module compilation (node-gyp)
+        electronHeaders = pkgs.fetchurl {
+          url = "https://www.electronjs.org/headers/v${electronVersion}/node-v${electronVersion}-headers.tar.gz";
+          sha256 = "sha256-Q+c8G4nIRoJL/0uAYVYY2hrnFgvmkKB6RC3nxJtFYzU=";
+        };
+
+        # Create a node-gyp cache directory with the Electron headers
+        electronHeadersDir = pkgs.runCommand "electron-headers" {} ''
+          mkdir -p $out/${electronVersion}
+          tar -xzf ${electronHeaders} -C $out/${electronVersion} --strip-components=1
+          echo "9" > $out/${electronVersion}/installVersion
+        '';
+
         sharedEnv =
           [
             nodejs
@@ -94,13 +107,13 @@
                     inherit pname version src;
                     inherit pnpm;
                     fetcherVersion = 1;
-                    hash = "";
+                    hash = "sha256-utuVjD/5w9AihDqvwFOzTqWvQqdHcKj3PybdOE2Cef8=";
                   }
                 else
                   pnpm.fetchDeps {
                     inherit pname version src;
                     fetcherVersion = 1;
-                    hash = "";
+                    hash = "sha256-utuVjD/5w9AihDqvwFOzTqWvQqdHcKj3PybdOE2Cef8=";
                   };
               nativeBuildInputs =
                 sharedEnv
@@ -109,12 +122,38 @@
                   (pkgs.pnpmConfigHook or pnpm.configHook)
                   pkgs.dpkg
                   pkgs.rpm
+                  pkgs.autoPatchelfHook
+                  pkgs.makeWrapper
                 ];
               buildInputs = [
                 pkgs.libsecret
                 pkgs.sqlite
                 pkgs.zlib
                 pkgs.libutempter
+                # Electron runtime dependencies
+                pkgs.libglvnd
+                pkgs.mesa
+                pkgs.alsa-lib
+                pkgs.nss
+                pkgs.nspr
+                pkgs.systemdLibs
+                pkgs.gtk3
+                pkgs.at-spi2-atk
+                pkgs.at-spi2-core
+                pkgs.cups
+                pkgs.libdrm
+                pkgs.pango
+                pkgs.cairo
+                pkgs.xorg.libX11
+                pkgs.xorg.libXcomposite
+                pkgs.xorg.libXdamage
+                pkgs.xorg.libXext
+                pkgs.xorg.libXfixes
+                pkgs.xorg.libXrandr
+                pkgs.xorg.libxcb
+                pkgs.libxkbcommon
+                pkgs.expat
+                pkgs.mesa.drivers
               ];
               env = {
                 HOME = "$TMPDIR/emdash-home";
@@ -132,6 +171,11 @@
 
                 # Build the app (renderer + main)
                 pnpm run build
+
+                # Rebuild native modules (keytar, sqlite3, node-pty) for Electron
+                # Point node-gyp at pre-fetched headers to avoid network access
+                export npm_config_nodedir="${electronHeadersDir}/${electronVersion}"
+                pnpm exec electron-rebuild -f -v ${electronVersion} --only=sqlite3,node-pty,keytar
 
                 # Run electron-builder with electronDist override to avoid download
                 # Use --dir to only produce unpacked output (no AppImage/deb which require network)
@@ -164,14 +208,16 @@
                 fi
 
                 install -d $out/bin
-                cat <<EOF > $out/bin/emdash
-#!${pkgs.bash}/bin/bash
-set -euo pipefail
-
-APP_ROOT="$out/share/emdash/linux-unpacked"
-exec "\$APP_ROOT/emdash" "\$@"
-EOF
-                chmod +x $out/bin/emdash
+                makeWrapper $out/share/emdash/linux-unpacked/emdash $out/bin/emdash \
+                  --prefix LD_LIBRARY_PATH : "${lib.makeLibraryPath [
+                    pkgs.libglvnd
+                    pkgs.mesa
+                    pkgs.alsa-lib
+                    pkgs.nss
+                    pkgs.nspr
+                    pkgs.systemdLibs
+                    pkgs.libsecret
+                  ]}"
 
                 runHook postInstall
               '';


### PR DESCRIPTION
## Summary

The Nix flake package (`nix build .#emdash`) was not functional on NixOS. This PR fixes three issues:

- **Empty pnpm dependency hash**: The `fetchPnpmDeps`/`pnpm.fetchDeps` hash was set to `""`, causing the build to fail on the first attempt. Set the correct hash.
- **Native modules not compiled for Electron**: `keytar.node`, `sqlite3`, and `node-pty` were never rebuilt for the Electron runtime. Added `electron-rebuild` step with pre-fetched Electron headers so it works in the Nix sandbox (no network access).
- **Missing runtime shared libraries**: The Electron binary couldn't find `libGL.so.1`, GTK, X11, and other libraries at runtime. Added `autoPatchelfHook` to automatically patch ELF binaries and `makeWrapper` to set `LD_LIBRARY_PATH`.

## Question for maintainers

Was the empty `hash = ""` in `pnpmDeps` intentional — e.g. is the package output considered WIP, with the `devShell` being the primary supported output?

An empty hash in a Nix fixed-output derivation will always fail on first build (Nix then prints the correct hash in the error). There's no "unpinned" mode for FODs — Nix requires an exact hash for reproducibility. The tradeoff of pinning it is that it needs updating whenever `pnpm-lock.yaml` changes, but that's the standard pattern in nixpkgs. A CI check on PRs touching `pnpm-lock.yaml` or `flake.nix` could catch hash drift automatically.

Happy to adjust the approach based on your intent here.

## Test plan

- [x] `nix build .#emdash` completes successfully
- [x] `result/bin/emdash` launches without errors on NixOS
- [x] Native modules (keytar for credential storage, sqlite3, node-pty) work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)