### PR TITLE
Improve styling for left sidebar on small screens (when overlayed)

### DIFF
--- a/src/renderer/components/ui/sidebar.tsx
+++ b/src/renderer/components/ui/sidebar.tsx
@@ -150,7 +150,7 @@ const Sidebar = React.forwardRef<HTMLDivElement, SidebarProps>(
           <button
             type="button"
             aria-label="Close sidebar overlay"
-            className="fixed inset-0 z-40 bg-black/20 backdrop-blur-sm lg:hidden"
+            className="fixed inset-0 z-[48] bg-black/50 backdrop-blur-sm lg:hidden"
             onClick={() => setOpen(false)}
           />
         ) : null}


### PR DESCRIPTION
## Summary

This improves the styling for the left side bar when the window side is small, and the sidebar starts overlaying the content

## Snapshot

### Before

https://github.com/user-attachments/assets/36c9fe83-5cdf-434c-b4f8-e8ad275d15ec

### After

https://github.com/user-attachments/assets/847e414f-4410-4ef1-a61a-b8cbdf6bffb6


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved mobile sidebar overlay appearance with enhanced opacity and visual layering for better visibility when interacting with the sidebar.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->