### PR TITLE
feat(titlebar): show current project and branch in window title

### DIFF
--- a/src/main/ipc/appIpc.ts
+++ b/src/main/ipc/appIpc.ts
@@ -664,4 +664,16 @@ export function registerAppIpc() {
     const win = BrowserWindow.fromWebContents(event.sender);
     return win?.isMaximized() ?? false;
   });
+  ipcMain.handle('app:setWindowTitle', (event, title: string) => {
+    try {
+      if (typeof title !== 'string') {
+        throw new Error('Invalid window title');
+      }
+      const win = BrowserWindow.fromWebContents(event.sender);
+      win?.setTitle(title);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
 }

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -79,6 +79,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
   windowMaximize: () => ipcRenderer.invoke('app:windowMaximize'),
   windowClose: () => ipcRenderer.invoke('app:windowClose'),
   windowIsMaximized: () => ipcRenderer.invoke('app:windowIsMaximized') as Promise<boolean>,
+  setWindowTitle: (title: string) => ipcRenderer.invoke('app:setWindowTitle', title),
   popupMenu: (args: { label: string; x: number; y: number }) =>
     ipcRenderer.invoke('app:popupMenu', args),
   onWindowMaximizeChange: (listener: (isMaximized: boolean) => void) => {

--- a/src/renderer/components/titlebar/Titlebar.tsx
+++ b/src/renderer/components/titlebar/Titlebar.tsx
@@ -20,6 +20,7 @@ import TitlebarContext from './TitlebarContext';
 import WindowControls from './WindowControls';
 import TitlebarMenu from './TitlebarMenu';
 import PerformanceChip from './PerformanceChip';
+import { buildWindowTitle } from './windowTitle';
 import { useProjectManagementContext } from '../../contexts/ProjectManagementProvider';
 import { useTaskManagementContext } from '../../contexts/TaskManagementContext';
 import { useGithubContext } from '../../contexts/GithubContextProvider';
@@ -205,6 +206,12 @@ const Titlebar: React.FC<TitlebarProps> = ({
       document.documentElement.removeEventListener('mouseleave', handleMouseLeave);
     };
   }, []);
+
+  useEffect(() => {
+    const nextTitle = buildWindowTitle(selectedProject, activeTask);
+    document.title = nextTitle;
+    void window.electronAPI.setWindowTitle(nextTitle);
+  }, [activeTask, selectedProject]);
 
   return (
     <>

--- a/src/renderer/components/titlebar/TitlebarContext.tsx
+++ b/src/renderer/components/titlebar/TitlebarContext.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
 import type { Project, Task } from '../../types/app';
+import { getCurrentBranch } from './windowTitle';
 
 interface TitlebarContextProps {
   projects: Project[];
@@ -23,10 +24,10 @@ const TitlebarContext: React.FC<TitlebarContextProps> = ({
     return <div />;
   }
   const projectValue = selectedProject.id;
-  const noTaskValue = '__no_task_selected__';
-  const taskValue = activeTask?.id ?? noTaskValue;
+  const taskValue = activeTask?.id;
+  const currentBranch = getCurrentBranch(selectedProject, activeTask);
   const projectLabel = selectedProject.name;
-  const taskLabel = activeTask?.name ?? '';
+  const taskLabel = currentBranch;
   const selectContentClassName = 'w-[min(280px,90vw)]';
 
   const handleProjectChange = (value: string) => {
@@ -37,7 +38,6 @@ const TitlebarContext: React.FC<TitlebarContextProps> = ({
   };
 
   const handleTaskChange = (value: string) => {
-    if (value === noTaskValue) return;
     const nextTask = tasks.find((task) => task.id === value);
     if (nextTask) {
       onSelectTask(nextTask);
@@ -76,37 +76,42 @@ const TitlebarContext: React.FC<TitlebarContextProps> = ({
       </div>
       <span className="px-2 text-center text-[11px] text-muted-foreground/60">/</span>
       <div className="flex items-center justify-start">
-        <Select value={taskValue} onValueChange={handleTaskChange} disabled={!selectedProject}>
-          <SelectTrigger
-            className="pointer-events-auto h-7 w-auto min-w-[60px] justify-start gap-1 border-none bg-transparent px-1 py-0.5 text-[13px] font-medium leading-none text-muted-foreground shadow-none [-webkit-app-region:no-drag] hover:bg-background/70 hover:text-foreground data-[state=open]:bg-background/80 data-[placeholder]:text-muted-foreground/70 data-[state=open]:text-foreground [&>span]:block [&>span]:max-w-[218px] [&>span]:truncate [&>svg]:hidden"
-            aria-label="Select task"
+        {activeTask ? (
+          <Select value={taskValue} onValueChange={handleTaskChange} disabled={!selectedProject}>
+            <SelectTrigger
+              className="pointer-events-auto h-7 w-auto min-w-[60px] justify-start gap-1 border-none bg-transparent px-1 py-0.5 text-[13px] font-medium leading-none text-muted-foreground shadow-none [-webkit-app-region:no-drag] hover:bg-background/70 hover:text-foreground data-[state=open]:bg-background/80 data-[placeholder]:text-muted-foreground/70 data-[state=open]:text-foreground [&>span]:block [&>span]:max-w-[218px] [&>span]:truncate [&>svg]:hidden"
+              aria-label="Current branch"
+              title={taskLabel}
+            >
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent side="bottom" align="start" className={selectContentClassName}>
+              {tasks.length > 0 ? (
+                tasks.map((task) => (
+                  <SelectItem
+                    key={task.id}
+                    value={task.id}
+                    className="min-w-0 [&>span:last-child]:block [&>span:last-child]:min-w-0 [&>span:last-child]:truncate"
+                  >
+                    {task.name} • {task.branch}
+                  </SelectItem>
+                ))
+              ) : (
+                <SelectItem value="__empty_tasks__" disabled>
+                  No tasks yet
+                </SelectItem>
+              )}
+            </SelectContent>
+          </Select>
+        ) : (
+          <div
+            className="pointer-events-none h-7 min-w-[60px] max-w-[218px] truncate px-1 py-0.5 text-[13px] font-medium leading-none text-muted-foreground"
+            aria-label="Current branch"
             title={taskLabel}
           >
-            <SelectValue placeholder="" />
-          </SelectTrigger>
-          <SelectContent side="bottom" align="start" className={selectContentClassName}>
-            {!activeTask && (
-              <SelectItem value={noTaskValue} disabled>
-                No active task
-              </SelectItem>
-            )}
-            {tasks.length > 0 ? (
-              tasks.map((task) => (
-                <SelectItem
-                  key={task.id}
-                  value={task.id}
-                  className="min-w-0 [&>span:last-child]:block [&>span:last-child]:min-w-0 [&>span:last-child]:truncate"
-                >
-                  {task.name}
-                </SelectItem>
-              ))
-            ) : (
-              <SelectItem value="__empty_tasks__" disabled>
-                No tasks yet
-              </SelectItem>
-            )}
-          </SelectContent>
-        </Select>
+            {currentBranch}
+          </div>
+        )}
       </div>
     </div>
   );

--- a/src/renderer/components/titlebar/TitlebarContext.tsx
+++ b/src/renderer/components/titlebar/TitlebarContext.tsx
@@ -83,7 +83,7 @@ const TitlebarContext: React.FC<TitlebarContextProps> = ({
             aria-label="Select task"
             title={taskLabel}
           >
-            <SelectValue placeholder={currentBranch} />
+            <SelectValue placeholder={currentBranch || 'Unknown'} />
           </SelectTrigger>
           <SelectContent side="bottom" align="start" className={selectContentClassName}>
             {!activeTask && (

--- a/src/renderer/components/titlebar/TitlebarContext.tsx
+++ b/src/renderer/components/titlebar/TitlebarContext.tsx
@@ -80,7 +80,7 @@ const TitlebarContext: React.FC<TitlebarContextProps> = ({
         <Select value={taskValue} onValueChange={handleTaskChange} disabled={!selectedProject}>
           <SelectTrigger
             className="pointer-events-auto h-7 w-auto min-w-[60px] justify-start gap-1 border-none bg-transparent px-1 py-0.5 text-[13px] font-medium leading-none text-muted-foreground shadow-none [-webkit-app-region:no-drag] hover:bg-background/70 hover:text-foreground data-[state=open]:bg-background/80 data-[placeholder]:text-muted-foreground/70 data-[state=open]:text-foreground [&>span]:block [&>span]:max-w-[218px] [&>span]:truncate [&>svg]:hidden"
-            aria-label="Current branch"
+            aria-label="Select task"
             title={taskLabel}
           >
             <SelectValue placeholder={currentBranch} />

--- a/src/renderer/components/titlebar/TitlebarContext.tsx
+++ b/src/renderer/components/titlebar/TitlebarContext.tsx
@@ -24,7 +24,8 @@ const TitlebarContext: React.FC<TitlebarContextProps> = ({
     return <div />;
   }
   const projectValue = selectedProject.id;
-  const taskValue = activeTask?.id;
+  const noTaskValue = '__no_task_selected__';
+  const taskValue = activeTask?.id ?? noTaskValue;
   const currentBranch = getCurrentBranch(selectedProject, activeTask);
   const projectLabel = selectedProject.name;
   const taskLabel = currentBranch;
@@ -76,42 +77,37 @@ const TitlebarContext: React.FC<TitlebarContextProps> = ({
       </div>
       <span className="px-2 text-center text-[11px] text-muted-foreground/60">/</span>
       <div className="flex items-center justify-start">
-        {activeTask ? (
-          <Select value={taskValue} onValueChange={handleTaskChange} disabled={!selectedProject}>
-            <SelectTrigger
-              className="pointer-events-auto h-7 w-auto min-w-[60px] justify-start gap-1 border-none bg-transparent px-1 py-0.5 text-[13px] font-medium leading-none text-muted-foreground shadow-none [-webkit-app-region:no-drag] hover:bg-background/70 hover:text-foreground data-[state=open]:bg-background/80 data-[placeholder]:text-muted-foreground/70 data-[state=open]:text-foreground [&>span]:block [&>span]:max-w-[218px] [&>span]:truncate [&>svg]:hidden"
-              aria-label="Current branch"
-              title={taskLabel}
-            >
-              <SelectValue />
-            </SelectTrigger>
-            <SelectContent side="bottom" align="start" className={selectContentClassName}>
-              {tasks.length > 0 ? (
-                tasks.map((task) => (
-                  <SelectItem
-                    key={task.id}
-                    value={task.id}
-                    className="min-w-0 [&>span:last-child]:block [&>span:last-child]:min-w-0 [&>span:last-child]:truncate"
-                  >
-                    {task.name} • {task.branch}
-                  </SelectItem>
-                ))
-              ) : (
-                <SelectItem value="__empty_tasks__" disabled>
-                  No tasks yet
-                </SelectItem>
-              )}
-            </SelectContent>
-          </Select>
-        ) : (
-          <div
-            className="pointer-events-none h-7 min-w-[60px] max-w-[218px] truncate px-1 py-0.5 text-[13px] font-medium leading-none text-muted-foreground"
+        <Select value={taskValue} onValueChange={handleTaskChange} disabled={!selectedProject}>
+          <SelectTrigger
+            className="pointer-events-auto h-7 w-auto min-w-[60px] justify-start gap-1 border-none bg-transparent px-1 py-0.5 text-[13px] font-medium leading-none text-muted-foreground shadow-none [-webkit-app-region:no-drag] hover:bg-background/70 hover:text-foreground data-[state=open]:bg-background/80 data-[placeholder]:text-muted-foreground/70 data-[state=open]:text-foreground [&>span]:block [&>span]:max-w-[218px] [&>span]:truncate [&>svg]:hidden"
             aria-label="Current branch"
             title={taskLabel}
           >
-            {currentBranch}
-          </div>
-        )}
+            <SelectValue placeholder={currentBranch} />
+          </SelectTrigger>
+          <SelectContent side="bottom" align="start" className={selectContentClassName}>
+            {!activeTask && (
+              <SelectItem value={noTaskValue} disabled>
+                Current branch: {currentBranch || 'Unknown'}
+              </SelectItem>
+            )}
+            {tasks.length > 0 ? (
+              tasks.map((task) => (
+                <SelectItem
+                  key={task.id}
+                  value={task.id}
+                  className="min-w-0 [&>span:last-child]:block [&>span:last-child]:min-w-0 [&>span:last-child]:truncate"
+                >
+                  {task.name} • {task.branch}
+                </SelectItem>
+              ))
+            ) : (
+              <SelectItem value="__empty_tasks__" disabled>
+                No tasks yet
+              </SelectItem>
+            )}
+          </SelectContent>
+        </Select>
       </div>
     </div>
   );

--- a/src/renderer/components/titlebar/windowTitle.test.ts
+++ b/src/renderer/components/titlebar/windowTitle.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { buildWindowTitle, getCurrentBranch } from './windowTitle';
+
+describe('windowTitle', () => {
+  it('falls back to the app name when no project is selected', () => {
+    expect(buildWindowTitle(null, null)).toBe('Emdash');
+  });
+
+  it('uses the project branch when no task is active', () => {
+    const selectedProject = {
+      id: 'project-1',
+      name: 'emdash',
+      path: '/tmp/emdash',
+      gitInfo: { isGitRepo: true, branch: 'main' },
+    };
+
+    expect(getCurrentBranch(selectedProject, null)).toBe('main');
+    expect(buildWindowTitle(selectedProject, null)).toBe('emdash • main');
+  });
+
+  it('prefers the active task branch over the project branch', () => {
+    const selectedProject = {
+      id: 'project-1',
+      name: 'emdash',
+      path: '/tmp/emdash',
+      gitInfo: { isGitRepo: true, branch: 'main' },
+    };
+    const activeTask = {
+      id: 'task-1',
+      projectId: 'project-1',
+      name: 'Review',
+      branch: 'feature/window-title',
+      path: '/tmp/emdash-review',
+      status: 'active' as const,
+    };
+
+    expect(getCurrentBranch(selectedProject, activeTask)).toBe('feature/window-title');
+    expect(buildWindowTitle(selectedProject, activeTask)).toBe('emdash • feature/window-title');
+  });
+});

--- a/src/renderer/components/titlebar/windowTitle.ts
+++ b/src/renderer/components/titlebar/windowTitle.ts
@@ -1,0 +1,20 @@
+import type { Project, Task } from '../../types/app';
+
+export function getCurrentBranch(selectedProject: Project | null, activeTask: Task | null): string {
+  return activeTask?.branch || selectedProject?.gitInfo.branch || '';
+}
+
+export function buildWindowTitle(selectedProject: Project | null, activeTask: Task | null): string {
+  const projectName = selectedProject?.name?.trim() || '';
+  const branchName = getCurrentBranch(selectedProject, activeTask).trim();
+
+  if (!projectName) {
+    return 'Emdash';
+  }
+
+  if (!branchName) {
+    return projectName;
+  }
+
+  return `${projectName} • ${branchName}`;
+}

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1373,6 +1373,7 @@ export interface ElectronAPI {
   }) => Promise<{ success: boolean; fonts?: string[]; cached?: boolean; error?: string }>;
   undo: () => Promise<{ success: boolean; error?: string }>;
   redo: () => Promise<{ success: boolean; error?: string }>;
+  setWindowTitle: (title: string) => Promise<{ success: boolean; error?: string }>;
   // Updater
   checkForUpdates: () => Promise<{ success: boolean; result?: any; error?: string }>;
   downloadUpdate: () => Promise<{ success: boolean; error?: string }>;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -59,6 +59,7 @@ declare global {
       windowMaximize: () => Promise<void>;
       windowClose: () => Promise<void>;
       windowIsMaximized: () => Promise<boolean>;
+      setWindowTitle: (title: string) => Promise<{ success: boolean; error?: string }>;
       popupMenu: (args: { label: string; x: number; y: number }) => Promise<void>;
       onWindowMaximizeChange: (listener: (isMaximized: boolean) => void) => () => void;
 

--- a/src/test/main/appIpc.windowTitle.test.ts
+++ b/src/test/main/appIpc.windowTitle.test.ts
@@ -1,0 +1,91 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type IpcHandler = (...args: unknown[]) => unknown;
+
+const ipcHandleHandlers = new Map<string, IpcHandler>();
+const setTitleMock = vi.fn<(title: string) => void>();
+const fromWebContentsMock = vi.fn<(webContents: unknown) => { setTitle: typeof setTitleMock }>(
+  () => ({
+    setTitle: setTitleMock,
+  })
+);
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getVersion: vi.fn(() => '0.0.0-test'),
+    getAppPath: vi.fn(() => process.cwd()),
+  },
+  BrowserWindow: {
+    fromWebContents: (webContents: unknown) => fromWebContentsMock(webContents),
+  },
+  clipboard: {
+    writeText: vi.fn(),
+  },
+  ipcMain: {
+    handle: vi.fn((channel: string, cb: IpcHandler) => {
+      ipcHandleHandlers.set(channel, cb);
+    }),
+  },
+  shell: {
+    openExternal: vi.fn(),
+  },
+}));
+
+vi.mock('../../main/services/DatabaseService', () => ({
+  databaseService: {
+    getSshConnection: vi.fn(),
+  },
+}));
+
+vi.mock('../../main/services/ProjectPrep', () => ({
+  ensureProjectPrepared: vi.fn(),
+}));
+
+vi.mock('../../main/settings', () => ({
+  getAppSettings: vi.fn(() => ({
+    projectPrep: {
+      autoInstallOnOpenInEditor: false,
+    },
+  })),
+}));
+
+vi.mock('../../main/utils/childProcessEnv', () => ({
+  buildExternalToolEnv: vi.fn(() => process.env),
+}));
+
+describe('app:setWindowTitle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.resetModules();
+    ipcHandleHandlers.clear();
+  });
+
+  async function getHandler() {
+    const { registerAppIpc } = await import('../../main/ipc/appIpc');
+    registerAppIpc();
+    const handler = ipcHandleHandlers.get('app:setWindowTitle');
+    expect(handler).toBeTypeOf('function');
+    return handler!;
+  }
+
+  it('updates the BrowserWindow title for the sender window', async () => {
+    const handler = await getHandler();
+    const sender = { id: 1 };
+
+    const result = await handler({ sender }, 'repo-name • feature/window-title');
+
+    expect(result).toEqual({ success: true });
+    expect(fromWebContentsMock).toHaveBeenCalledWith(sender);
+    expect(setTitleMock).toHaveBeenCalledWith('repo-name • feature/window-title');
+  });
+
+  it('rejects non-string titles', async () => {
+    const handler = await getHandler();
+
+    const result = await handler({ sender: {} }, 42);
+
+    expect(result).toEqual({ success: false, error: 'Invalid window title' });
+    expect(setTitleMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
## Summary
- show `project • branch` in the titlebar context
- update the native Electron window title and document title from the current project/task state
- add focused renderer and main-process tests for the new title logic

## Testing
- pnpm run format
- pnpm run lint
- pnpm run type-check
- pnpm exec vitest run
- pnpm run build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App window title now updates automatically to reflect the selected project and current branch/task and is synced with the native window via the renderer bridge.

* **Improvements**
  * Titlebar emphasizes branch context (updated trigger/placeholder and option labels).
  * Improved UI text when no active task (shows current branch).
  * Task options include branch info in labels.

* **Tests**
  * Added tests for title composition and the title-update bridge/handler.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->