### PR TITLE
feat(pr-comments): allow comments to be injected into chat

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -291,7 +291,7 @@ const ChatInterface: React.FC<Props> = ({
 
   // Wire comment injection to pendingInjectionManager
   useCommentInjection(task.id, task.path);
-  usePrCommentInjection();
+  usePrCommentInjection(task.id);
 
   // Auto-scroll to bottom when this task becomes active
   useAutoScrollOnTaskSwitch(true, task.id);

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -15,6 +15,7 @@ import { useConversationStatus } from '../hooks/useConversationStatus';
 import { useStatusUnread } from '../hooks/useStatusUnread';
 import { useInitialPromptInjection } from '../hooks/useInitialPromptInjection';
 import { useCommentInjection } from '../hooks/useCommentInjection';
+import { usePrCommentInjection } from '../hooks/usePrCommentInjection';
 import { type Agent } from '../types';
 import { Task } from '../types/chat';
 import { useTaskTerminals } from '@/lib/taskTerminalsStore';
@@ -290,6 +291,7 @@ const ChatInterface: React.FC<Props> = ({
 
   // Wire comment injection to pendingInjectionManager
   useCommentInjection(task.id, task.path);
+  usePrCommentInjection();
 
   // Auto-scroll to bottom when this task becomes active
   useAutoScrollOnTaskSwitch(true, task.id);

--- a/src/renderer/components/CommentsPopover.tsx
+++ b/src/renderer/components/CommentsPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useSyncExternalStore } from 'react';
+import React, { useMemo } from 'react';
 import { Trash2 } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from './ui/popover';
 import { Button } from './ui/button';
@@ -6,11 +6,9 @@ import { ScrollArea } from './ui/scroll-area';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/tooltip';
 import { useTaskScope } from './TaskScopeContext';
 import { useTaskComments } from '../hooks/useLineComments';
+import { useSelectedPrComments } from '../hooks/usePrCommentInjection';
 import type { DraftComment } from '../lib/DraftCommentsStore';
 import { selectedPrCommentsStore } from '../lib/selectedPrCommentsStore';
-
-const subscribePrComments = (listener: () => void) => selectedPrCommentsStore.subscribe(listener);
-const getPrCommentsSnapshot = () => selectedPrCommentsStore.getSnapshot();
 
 interface CommentsPopoverProps {
   taskId?: string;
@@ -30,7 +28,7 @@ export function CommentsPopover({
   const { taskId: scopedTaskId, taskPath: scopedTaskPath } = useTaskScope();
   const resolvedTaskId = taskId ?? scopedTaskId ?? '';
   const { comments, remove } = useTaskComments(resolvedTaskId, scopedTaskPath);
-  const prComments = useSyncExternalStore(subscribePrComments, getPrCommentsSnapshot);
+  const prComments = useSelectedPrComments(resolvedTaskId);
   const totalCount = comments.length + prComments.length;
 
   const groupedComments = useMemo(() => {
@@ -92,7 +90,7 @@ export function CommentsPopover({
                         variant="ghost"
                         size="icon"
                         className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
-                        onClick={() => selectedPrCommentsStore.remove(comment.id)}
+                        onClick={() => selectedPrCommentsStore.remove(resolvedTaskId, comment.id)}
                       >
                         <Trash2 className="h-3.5 w-3.5" />
                       </Button>

--- a/src/renderer/components/CommentsPopover.tsx
+++ b/src/renderer/components/CommentsPopover.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React, { useMemo, useSyncExternalStore } from 'react';
 import { Trash2 } from 'lucide-react';
 import { Popover, PopoverTrigger, PopoverContent } from './ui/popover';
 import { Button } from './ui/button';
@@ -7,6 +7,10 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from './ui/t
 import { useTaskScope } from './TaskScopeContext';
 import { useTaskComments } from '../hooks/useLineComments';
 import type { DraftComment } from '../lib/DraftCommentsStore';
+import { selectedPrCommentsStore } from '../lib/selectedPrCommentsStore';
+
+const subscribePrComments = (listener: () => void) => selectedPrCommentsStore.subscribe(listener);
+const getPrCommentsSnapshot = () => selectedPrCommentsStore.getSnapshot();
 
 interface CommentsPopoverProps {
   taskId?: string;
@@ -26,6 +30,8 @@ export function CommentsPopover({
   const { taskId: scopedTaskId, taskPath: scopedTaskPath } = useTaskScope();
   const resolvedTaskId = taskId ?? scopedTaskId ?? '';
   const { comments, remove } = useTaskComments(resolvedTaskId, scopedTaskPath);
+  const prComments = useSyncExternalStore(subscribePrComments, getPrCommentsSnapshot);
+  const totalCount = comments.length + prComments.length;
 
   const groupedComments = useMemo(() => {
     const groups = new Map<string, DraftComment[]>();
@@ -53,19 +59,48 @@ export function CommentsPopover({
       ) : (
         <PopoverTrigger asChild>{children}</PopoverTrigger>
       )}
-      <PopoverContent className="w-[min(460px,92vw)] p-0" align="start">
+      <PopoverContent className="w-[min(460px,92vw)] overflow-hidden p-0" align="start">
         <div className="flex items-center justify-between border-b px-4 py-3">
           <div className="flex flex-col">
             <span className="text-sm font-semibold">Review comments</span>
             <span className="text-xs text-muted-foreground">
-              {comments.length} comment{comments.length !== 1 ? 's' : ''} will be sent with your
-              next message
+              {totalCount} comment{totalCount !== 1 ? 's' : ''} will be sent with your next message
             </span>
           </div>
         </div>
 
         <ScrollArea className="max-h-[360px]">
-          <div className="divide-y">
+          <div className="divide-y overflow-hidden">
+            {prComments.length > 0 && (
+              <div className="py-2">
+                <div className="truncate px-4 pb-1 text-xs font-medium text-muted-foreground">
+                  PR comments
+                </div>
+                <div className="space-y-1">
+                  {prComments.map((comment) => (
+                    <div
+                      key={comment.id}
+                      className="flex min-w-0 items-start gap-2 px-4 py-2 transition-colors hover:bg-muted/40"
+                    >
+                      <div className="min-w-0 flex-1">
+                        <div className="text-xs text-muted-foreground">{comment.author.login}</div>
+                        <div className="line-clamp-2 break-all text-sm leading-snug">
+                          {comment.body}
+                        </div>
+                      </div>
+                      <Button
+                        variant="ghost"
+                        size="icon"
+                        className="h-6 w-6 shrink-0 text-muted-foreground hover:text-destructive"
+                        onClick={() => selectedPrCommentsStore.remove(comment.id)}
+                      >
+                        <Trash2 className="h-3.5 w-3.5" />
+                      </Button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            )}
             {Array.from(groupedComments.entries()).map(([filePath, fileComments]) => (
               <div key={filePath} className="py-2">
                 <div
@@ -101,7 +136,7 @@ export function CommentsPopover({
                 </div>
               </div>
             ))}
-            {comments.length === 0 && (
+            {totalCount === 0 && (
               <div className="px-4 py-6 text-center text-sm text-muted-foreground">
                 No comments. Click the + icon in the diff gutter to add one.
               </div>

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -876,6 +876,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
             />
             {pr && (
               <PrCommentsList
+                taskId={resolvedTaskId ?? ''}
                 status={prCommentsStatus}
                 isLoading={prCommentsLoading}
                 hasPr={!!pr}

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -22,6 +22,7 @@ import { getTaskEnvVars } from '@shared/task/envVars';
 import { rpc } from '@/lib/rpc';
 import { useWorkspaceConnection } from '../hooks/useWorkspaceConnection';
 import { useCommentInjection } from '@/hooks/useCommentInjection';
+import { usePrCommentInjection } from '@/hooks/usePrCommentInjection';
 import { isSlashCommandInput } from '@/lib/slashCommand';
 import { buildCommentScopeKey, draftCommentsStore } from '@/lib/DraftCommentsStore';
 import { formatCommentsForAgent } from '@/lib/formatCommentsForAgent';
@@ -69,6 +70,7 @@ const MultiAgentTask: React.FC<Props> = ({
 
   const activeVariantPath = variants[activeTabIndex]?.path ?? task.path;
   useCommentInjection(task.id, activeVariantPath);
+  usePrCommentInjection();
 
   const variantEnvs = useMemo(() => {
     if (!projectPath) return new Map<string, Record<string, string>>();

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -70,7 +70,7 @@ const MultiAgentTask: React.FC<Props> = ({
 
   const activeVariantPath = variants[activeTabIndex]?.path ?? task.path;
   useCommentInjection(task.id, activeVariantPath);
-  usePrCommentInjection();
+  usePrCommentInjection(task.id);
 
   const variantEnvs = useMemo(() => {
     if (!projectPath) return new Map<string, Record<string, string>>();

--- a/src/renderer/components/PrCommentsList.tsx
+++ b/src/renderer/components/PrCommentsList.tsx
@@ -6,7 +6,7 @@ import {
   MessageSquarePlus,
   XCircle,
 } from 'lucide-react';
-import { useMemo, useState, useSyncExternalStore } from 'react';
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'react';
 import type { PrCommentsStatus, PrComment } from '../lib/prCommentsStatus';
 import { formatRelativeTime } from '../lib/prCommentsStatus';
 import { selectedPrCommentsStore } from '../lib/selectedPrCommentsStore';
@@ -46,17 +46,26 @@ function stripMarkdown(text: string): string {
     .trim();
 }
 
-const subscribe = (listener: () => void) => selectedPrCommentsStore.subscribe(listener);
-
-function CommentItem({ comment, prUrl }: { comment: PrComment; prUrl?: string }) {
+function CommentItem({
+  taskId,
+  comment,
+  prUrl,
+}: {
+  taskId: string;
+  comment: PrComment;
+  prUrl?: string;
+}) {
   const preview = useMemo(() => (comment.body ? stripMarkdown(comment.body) : ''), [comment.body]);
   const hasBody = !!comment.body;
   const [expanded, setExpanded] = useState(false);
-  const isSelected = useSyncExternalStore(subscribe, () => selectedPrCommentsStore.has(comment.id));
+  const isSelected = useSyncExternalStore(
+    useCallback((listener) => selectedPrCommentsStore.subscribe(taskId, listener), [taskId]),
+    useCallback(() => selectedPrCommentsStore.has(taskId, comment.id), [taskId, comment.id])
+  );
 
   const handleToggle = (e: React.MouseEvent) => {
     e.stopPropagation();
-    selectedPrCommentsStore.toggle(comment);
+    selectedPrCommentsStore.toggle(taskId, comment);
   };
 
   return (
@@ -123,13 +132,14 @@ function CommentItem({ comment, prUrl }: { comment: PrComment; prUrl?: string })
 }
 
 interface PrCommentsListProps {
+  taskId: string;
   status: PrCommentsStatus | null;
   isLoading: boolean;
   hasPr: boolean;
   prUrl?: string;
 }
 
-export function PrCommentsList({ status, isLoading, hasPr, prUrl }: PrCommentsListProps) {
+export function PrCommentsList({ taskId, status, isLoading, hasPr, prUrl }: PrCommentsListProps) {
   if (!hasPr) return null;
 
   if (isLoading && !status) return null;
@@ -142,7 +152,12 @@ export function PrCommentsList({ status, isLoading, hasPr, prUrl }: PrCommentsLi
         <span className="text-sm font-medium text-foreground">Comments</span>
       </div>
       {status.comments.map((comment) => (
-        <CommentItem key={`${comment.type}-${comment.id}`} comment={comment} prUrl={prUrl} />
+        <CommentItem
+          key={`${comment.type}-${comment.id}`}
+          taskId={taskId}
+          comment={comment}
+          prUrl={prUrl}
+        />
       ))}
     </div>
   );

--- a/src/renderer/components/PrCommentsList.tsx
+++ b/src/renderer/components/PrCommentsList.tsx
@@ -1,6 +1,15 @@
-import { CheckCircle2, XCircle } from 'lucide-react';
+import {
+  CheckCircle2,
+  ChevronDown,
+  ChevronRight,
+  ExternalLink,
+  MessageSquarePlus,
+  XCircle,
+} from 'lucide-react';
+import { useMemo, useState, useSyncExternalStore } from 'react';
 import type { PrCommentsStatus, PrComment } from '../lib/prCommentsStatus';
 import { formatRelativeTime } from '../lib/prCommentsStatus';
+import { selectedPrCommentsStore } from '../lib/selectedPrCommentsStore';
 
 function ReviewBadge({ state }: { state?: PrComment['reviewState'] }) {
   switch (state) {
@@ -37,29 +46,78 @@ function stripMarkdown(text: string): string {
     .trim();
 }
 
+const subscribe = (listener: () => void) => selectedPrCommentsStore.subscribe(listener);
+
 function CommentItem({ comment, prUrl }: { comment: PrComment; prUrl?: string }) {
-  const preview = comment.body ? stripMarkdown(comment.body) : '';
+  const preview = useMemo(() => (comment.body ? stripMarkdown(comment.body) : ''), [comment.body]);
+  const hasBody = !!comment.body;
+  const [expanded, setExpanded] = useState(false);
+  const isSelected = useSyncExternalStore(subscribe, () => selectedPrCommentsStore.has(comment.id));
+
+  const handleToggle = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    selectedPrCommentsStore.toggle(comment);
+  };
 
   return (
     <div
-      className="min-w-0 cursor-pointer px-4 py-2.5 transition-colors hover:bg-muted/50"
-      onClick={() => prUrl && window.electronAPI?.openExternal?.(prUrl)}
+      className={`group min-w-0 px-4 py-2.5 transition-colors hover:bg-muted/50 ${
+        isSelected ? 'bg-primary/10' : ''
+      } ${hasBody ? 'cursor-pointer' : ''}`}
+      onClick={hasBody ? () => setExpanded((prev) => !prev) : undefined}
     >
       <div className="flex items-center gap-2">
+        {hasBody ? (
+          expanded ? (
+            <ChevronDown className="h-3 w-3 shrink-0 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0 text-muted-foreground" />
+          )
+        ) : (
+          <span className="h-3 w-3 shrink-0" />
+        )}
         <img
           src={comment.author.avatarUrl || `https://github.com/${comment.author.login}.png?size=40`}
           alt=""
           className="h-5 w-5 shrink-0 rounded-sm"
         />
         <span className="shrink-0 text-sm font-medium text-foreground">{comment.author.login}</span>
-        {preview && (
+        {!expanded && preview && (
           <span className="min-w-0 truncate text-xs text-muted-foreground">{preview}</span>
         )}
         <span className="ml-auto shrink-0 text-xs text-muted-foreground">
           {formatRelativeTime(comment.createdAt)}
         </span>
         {comment.type === 'review' && <ReviewBadge state={comment.reviewState} />}
+        {hasBody && (
+          <button
+            className={`shrink-0 rounded p-0.5 transition-colors hover:bg-muted ${
+              isSelected ? 'text-primary' : 'text-muted-foreground'
+            }`}
+            onClick={handleToggle}
+            title={isSelected ? 'Remove from chat' : 'Send to chat'}
+          >
+            <MessageSquarePlus className="h-3.5 w-3.5" />
+          </button>
+        )}
+        {prUrl && (
+          <button
+            className="shrink-0 rounded p-0.5 text-muted-foreground transition-colors hover:bg-muted hover:text-foreground"
+            onClick={(e) => {
+              e.stopPropagation();
+              window.electronAPI?.openExternal?.(prUrl);
+            }}
+            title="Open in GitHub"
+          >
+            <ExternalLink className="h-3 w-3" />
+          </button>
+        )}
       </div>
+      {expanded && comment.body && (
+        <div className="mt-2 whitespace-pre-wrap break-words pl-5 text-xs text-foreground">
+          {comment.body}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/renderer/components/TaskContextBadges.tsx
+++ b/src/renderer/components/TaskContextBadges.tsx
@@ -30,7 +30,7 @@ export const TaskContextBadges: React.FC<Props> = ({
   const { taskId: scopedTaskId, taskPath: scopedTaskPath } = useTaskScope();
   const resolvedTaskId = taskId ?? scopedTaskId;
   const { count: unsentCount } = useTaskComments(resolvedTaskId, scopedTaskPath);
-  const prCommentCount = useSelectedPrCommentCount();
+  const prCommentCount = useSelectedPrCommentCount(resolvedTaskId ?? '');
   const totalUnsentCount = unsentCount + prCommentCount;
 
   const hasAnything = !!linearIssue || !!githubIssue || !!jiraIssue || totalUnsentCount > 0;

--- a/src/renderer/components/TaskContextBadges.tsx
+++ b/src/renderer/components/TaskContextBadges.tsx
@@ -7,6 +7,7 @@ import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/t
 import { CommentsPopover } from './CommentsPopover';
 import { Button } from './ui/button';
 import { useTaskComments } from '../hooks/useLineComments';
+import { useSelectedPrCommentCount } from '../hooks/usePrCommentInjection';
 import { useTaskScope } from './TaskScopeContext';
 import linearLogoSvg from '../../assets/images/Linear.svg?raw';
 import githubLogo from '../../assets/images/github.png';
@@ -29,8 +30,10 @@ export const TaskContextBadges: React.FC<Props> = ({
   const { taskId: scopedTaskId, taskPath: scopedTaskPath } = useTaskScope();
   const resolvedTaskId = taskId ?? scopedTaskId;
   const { count: unsentCount } = useTaskComments(resolvedTaskId, scopedTaskPath);
+  const prCommentCount = useSelectedPrCommentCount();
+  const totalUnsentCount = unsentCount + prCommentCount;
 
-  const hasAnything = !!linearIssue || !!githubIssue || !!jiraIssue || unsentCount > 0;
+  const hasAnything = !!linearIssue || !!githubIssue || !!jiraIssue || totalUnsentCount > 0;
   if (!hasAnything) return null;
 
   const handleIssueClick = (url?: string) => {
@@ -189,7 +192,7 @@ export const TaskContextBadges: React.FC<Props> = ({
         </TooltipProvider>
       )}
 
-      {resolvedTaskId && unsentCount > 0 && (
+      {resolvedTaskId && totalUnsentCount > 0 && (
         <CommentsPopover
           tooltipContent="These comments will be appended to your next agent message."
           tooltipDelay={300}
@@ -199,12 +202,12 @@ export const TaskContextBadges: React.FC<Props> = ({
             variant="outline"
             size="sm"
             className="relative h-7 gap-1.5 border-border bg-muted px-2 text-xs hover:bg-muted/80 dark:border-border dark:bg-muted"
-            title={`${unsentCount} comment${unsentCount === 1 ? '' : 's'} will be sent`}
+            title={`${totalUnsentCount} comment${totalUnsentCount === 1 ? '' : 's'} will be sent`}
           >
             <MessageSquare className="h-3.5 w-3.5 flex-shrink-0" />
             <span className="font-medium">Comments</span>
             <span className="absolute -right-1.5 -top-1.5 flex h-4 min-w-4 items-center justify-center rounded-full bg-blue-500 px-1 text-[10px] font-semibold text-white">
-              {unsentCount}
+              {totalUnsentCount}
             </span>
           </Button>
         </CommentsPopover>

--- a/src/renderer/hooks/useCommentInjection.ts
+++ b/src/renderer/hooks/useCommentInjection.ts
@@ -1,59 +1,15 @@
-import { useEffect, useLayoutEffect, useRef } from 'react';
 import { useTaskComments } from './useLineComments';
-import { pendingInjectionManager } from '../lib/PendingInjectionManager';
 import { formatCommentsForAgent } from '../lib/formatCommentsForAgent';
+import { useInjectionSource } from './useInjectionSource';
 
 const INJECTION_SOURCE = 'diff-comments';
+
+const formatter = (comments: { filePath: string; lineNumber: number; content: string }[]) =>
+  formatCommentsForAgent(comments, { includeIntro: false, leadingNewline: true });
 
 export function useCommentInjection(taskId?: string, taskPath?: string | null) {
   const resolvedTaskId = taskId ?? '';
   const { comments, consumeAll } = useTaskComments(resolvedTaskId, taskPath);
-  const consumeAllRef = useRef(consumeAll);
-  const hasPendingRef = useRef(false);
-  useLayoutEffect(() => {
-    consumeAllRef.current = consumeAll;
-  });
 
-  useEffect(() => {
-    if (!resolvedTaskId || comments.length === 0) {
-      if (hasPendingRef.current) {
-        pendingInjectionManager.clear(INJECTION_SOURCE);
-        hasPendingRef.current = false;
-      }
-      return () => {
-        if (hasPendingRef.current) {
-          pendingInjectionManager.clear(INJECTION_SOURCE);
-          hasPendingRef.current = false;
-        }
-      };
-    }
-
-    const formatted = formatCommentsForAgent(comments, {
-      includeIntro: false,
-      leadingNewline: true,
-    });
-
-    if (formatted) {
-      pendingInjectionManager.setPending(formatted, INJECTION_SOURCE);
-      hasPendingRef.current = true;
-    } else if (hasPendingRef.current) {
-      pendingInjectionManager.clear(INJECTION_SOURCE);
-      hasPendingRef.current = false;
-    }
-
-    return () => {
-      if (hasPendingRef.current) {
-        pendingInjectionManager.clear(INJECTION_SOURCE);
-        hasPendingRef.current = false;
-      }
-    };
-  }, [comments, resolvedTaskId]);
-
-  useEffect(() => {
-    if (!resolvedTaskId) return;
-    return pendingInjectionManager.onInjectionUsed(() => {
-      consumeAllRef.current();
-      hasPendingRef.current = false;
-    });
-  }, [resolvedTaskId]);
+  useInjectionSource(INJECTION_SOURCE, comments, formatter, consumeAll, !!resolvedTaskId);
 }

--- a/src/renderer/hooks/useCommentInjection.ts
+++ b/src/renderer/hooks/useCommentInjection.ts
@@ -3,6 +3,8 @@ import { useTaskComments } from './useLineComments';
 import { pendingInjectionManager } from '../lib/PendingInjectionManager';
 import { formatCommentsForAgent } from '../lib/formatCommentsForAgent';
 
+const INJECTION_SOURCE = 'diff-comments';
+
 export function useCommentInjection(taskId?: string, taskPath?: string | null) {
   const resolvedTaskId = taskId ?? '';
   const { comments, consumeAll } = useTaskComments(resolvedTaskId, taskPath);
@@ -15,12 +17,12 @@ export function useCommentInjection(taskId?: string, taskPath?: string | null) {
   useEffect(() => {
     if (!resolvedTaskId || comments.length === 0) {
       if (hasPendingRef.current) {
-        pendingInjectionManager.clear();
+        pendingInjectionManager.clear(INJECTION_SOURCE);
         hasPendingRef.current = false;
       }
       return () => {
         if (hasPendingRef.current) {
-          pendingInjectionManager.clear();
+          pendingInjectionManager.clear(INJECTION_SOURCE);
           hasPendingRef.current = false;
         }
       };
@@ -32,16 +34,16 @@ export function useCommentInjection(taskId?: string, taskPath?: string | null) {
     });
 
     if (formatted) {
-      pendingInjectionManager.setPending(formatted);
+      pendingInjectionManager.setPending(formatted, INJECTION_SOURCE);
       hasPendingRef.current = true;
     } else if (hasPendingRef.current) {
-      pendingInjectionManager.clear();
+      pendingInjectionManager.clear(INJECTION_SOURCE);
       hasPendingRef.current = false;
     }
 
     return () => {
       if (hasPendingRef.current) {
-        pendingInjectionManager.clear();
+        pendingInjectionManager.clear(INJECTION_SOURCE);
         hasPendingRef.current = false;
       }
     };

--- a/src/renderer/hooks/useInjectionSource.ts
+++ b/src/renderer/hooks/useInjectionSource.ts
@@ -1,0 +1,60 @@
+import { useEffect, useLayoutEffect, useRef } from 'react';
+import { pendingInjectionManager } from '../lib/PendingInjectionManager';
+
+/**
+ * Generic hook that syncs an array of items to a named PendingInjectionManager source.
+ * Items are formatted and set as pending; when the injection is consumed, onConsumed fires.
+ *
+ * @param source   Named key in PendingInjectionManager (e.g. 'diff-comments', 'pr-comments')
+ * @param items    Reactive array of items to inject (empty = nothing pending)
+ * @param formatter Converts items to a string for injection (return '' to skip)
+ * @param onConsumed Called after the injection is used — clear the source store here
+ * @param enabled  When false, the source is cleared and no injection is set (default: true)
+ */
+export function useInjectionSource<T>(
+  source: string,
+  items: T[],
+  formatter: (items: T[]) => string,
+  onConsumed: () => void,
+  enabled = true
+): void {
+  const hasPendingRef = useRef(false);
+  const onConsumedRef = useRef(onConsumed);
+  useLayoutEffect(() => {
+    onConsumedRef.current = onConsumed;
+  });
+
+  useEffect(() => {
+    if (!enabled || items.length === 0) {
+      if (hasPendingRef.current) {
+        pendingInjectionManager.clear(source);
+        hasPendingRef.current = false;
+      }
+      return;
+    }
+
+    const formatted = formatter(items);
+    if (formatted) {
+      pendingInjectionManager.setPending(formatted, source);
+      hasPendingRef.current = true;
+    } else if (hasPendingRef.current) {
+      pendingInjectionManager.clear(source);
+      hasPendingRef.current = false;
+    }
+
+    return () => {
+      if (hasPendingRef.current) {
+        pendingInjectionManager.clear(source);
+        hasPendingRef.current = false;
+      }
+    };
+  }, [items, source, enabled, formatter]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    return pendingInjectionManager.onInjectionUsed(() => {
+      onConsumedRef.current();
+      hasPendingRef.current = false;
+    });
+  }, [enabled]);
+}

--- a/src/renderer/hooks/usePrCommentInjection.ts
+++ b/src/renderer/hooks/usePrCommentInjection.ts
@@ -1,7 +1,7 @@
-import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { useCallback, useSyncExternalStore } from 'react';
 import { selectedPrCommentsStore } from '../lib/selectedPrCommentsStore';
-import { pendingInjectionManager } from '../lib/PendingInjectionManager';
 import { formatPrCommentsForAgent } from '../lib/formatPrCommentsForAgent';
+import { useInjectionSource } from './useInjectionSource';
 
 const INJECTION_SOURCE = 'pr-comments';
 
@@ -14,42 +14,12 @@ const getSnapshot = () => selectedPrCommentsStore.getSnapshot();
  */
 export function usePrCommentInjection() {
   const selected = useSyncExternalStore(subscribe, getSnapshot);
-  const hasPendingRef = useRef(false);
 
-  useEffect(() => {
-    if (selected.length === 0) {
-      if (hasPendingRef.current) {
-        pendingInjectionManager.clear(INJECTION_SOURCE);
-        hasPendingRef.current = false;
-      }
-      return () => {
-        if (hasPendingRef.current) {
-          pendingInjectionManager.clear(INJECTION_SOURCE);
-          hasPendingRef.current = false;
-        }
-      };
-    }
-
-    const formatted = formatPrCommentsForAgent(selected);
-    if (formatted) {
-      pendingInjectionManager.setPending(formatted, INJECTION_SOURCE);
-      hasPendingRef.current = true;
-    }
-
-    return () => {
-      if (hasPendingRef.current) {
-        pendingInjectionManager.clear(INJECTION_SOURCE);
-        hasPendingRef.current = false;
-      }
-    };
-  }, [selected]);
-
-  useEffect(() => {
-    return pendingInjectionManager.onInjectionUsed(() => {
-      selectedPrCommentsStore.clear();
-      hasPendingRef.current = false;
-    });
+  const onConsumed = useCallback(() => {
+    selectedPrCommentsStore.clear();
   }, []);
+
+  useInjectionSource(INJECTION_SOURCE, selected, formatPrCommentsForAgent, onConsumed);
 }
 
 /**

--- a/src/renderer/hooks/usePrCommentInjection.ts
+++ b/src/renderer/hooks/usePrCommentInjection.ts
@@ -1,0 +1,62 @@
+import { useEffect, useRef, useSyncExternalStore } from 'react';
+import { selectedPrCommentsStore } from '../lib/selectedPrCommentsStore';
+import { pendingInjectionManager } from '../lib/PendingInjectionManager';
+import { formatPrCommentsForAgent } from '../lib/formatPrCommentsForAgent';
+
+const INJECTION_SOURCE = 'pr-comments';
+
+const subscribe = (listener: () => void) => selectedPrCommentsStore.subscribe(listener);
+const getSnapshot = () => selectedPrCommentsStore.getSnapshot();
+
+/**
+ * Drives the PR comment → PendingInjectionManager side-effect.
+ * Call once, high in the component tree (ChatInterface / MultiAgentTask).
+ */
+export function usePrCommentInjection() {
+  const selected = useSyncExternalStore(subscribe, getSnapshot);
+  const hasPendingRef = useRef(false);
+
+  useEffect(() => {
+    if (selected.length === 0) {
+      if (hasPendingRef.current) {
+        pendingInjectionManager.clear(INJECTION_SOURCE);
+        hasPendingRef.current = false;
+      }
+      return () => {
+        if (hasPendingRef.current) {
+          pendingInjectionManager.clear(INJECTION_SOURCE);
+          hasPendingRef.current = false;
+        }
+      };
+    }
+
+    const formatted = formatPrCommentsForAgent(selected);
+    if (formatted) {
+      pendingInjectionManager.setPending(formatted, INJECTION_SOURCE);
+      hasPendingRef.current = true;
+    }
+
+    return () => {
+      if (hasPendingRef.current) {
+        pendingInjectionManager.clear(INJECTION_SOURCE);
+        hasPendingRef.current = false;
+      }
+    };
+  }, [selected]);
+
+  useEffect(() => {
+    return pendingInjectionManager.onInjectionUsed(() => {
+      selectedPrCommentsStore.clear();
+      hasPendingRef.current = false;
+    });
+  }, []);
+}
+
+/**
+ * Lightweight reader for selected PR comment count.
+ * Safe to call from any component without duplicating side-effects.
+ */
+export function useSelectedPrCommentCount(): number {
+  const selected = useSyncExternalStore(subscribe, getSnapshot);
+  return selected.length;
+}

--- a/src/renderer/hooks/usePrCommentInjection.ts
+++ b/src/renderer/hooks/usePrCommentInjection.ts
@@ -1,23 +1,29 @@
 import { useCallback, useSyncExternalStore } from 'react';
 import { selectedPrCommentsStore } from '../lib/selectedPrCommentsStore';
+import type { PrComment } from '../lib/prCommentsStatus';
 import { formatPrCommentsForAgent } from '../lib/formatPrCommentsForAgent';
 import { useInjectionSource } from './useInjectionSource';
 
 const INJECTION_SOURCE = 'pr-comments';
 
-const subscribe = (listener: () => void) => selectedPrCommentsStore.subscribe(listener);
-const getSnapshot = () => selectedPrCommentsStore.getSnapshot();
+/** Subscribe to the selected PR comments for a task. */
+export function useSelectedPrComments(taskId: string): PrComment[] {
+  return useSyncExternalStore(
+    useCallback((listener) => selectedPrCommentsStore.subscribe(taskId, listener), [taskId]),
+    useCallback(() => selectedPrCommentsStore.getSnapshot(taskId), [taskId])
+  );
+}
 
 /**
  * Drives the PR comment → PendingInjectionManager side-effect.
  * Call once, high in the component tree (ChatInterface / MultiAgentTask).
  */
-export function usePrCommentInjection() {
-  const selected = useSyncExternalStore(subscribe, getSnapshot);
+export function usePrCommentInjection(taskId: string) {
+  const selected = useSelectedPrComments(taskId);
 
   const onConsumed = useCallback(() => {
-    selectedPrCommentsStore.clear();
-  }, []);
+    selectedPrCommentsStore.clear(taskId);
+  }, [taskId]);
 
   useInjectionSource(INJECTION_SOURCE, selected, formatPrCommentsForAgent, onConsumed);
 }
@@ -26,7 +32,6 @@ export function usePrCommentInjection() {
  * Lightweight reader for selected PR comment count.
  * Safe to call from any component without duplicating side-effects.
  */
-export function useSelectedPrCommentCount(): number {
-  const selected = useSyncExternalStore(subscribe, getSnapshot);
-  return selected.length;
+export function useSelectedPrCommentCount(taskId: string): number {
+  return useSelectedPrComments(taskId).length;
 }

--- a/src/renderer/lib/PendingInjectionManager.ts
+++ b/src/renderer/lib/PendingInjectionManager.ts
@@ -4,51 +4,61 @@
  * This is implemented as a singleton rather than React context because:
  * 1. TerminalSessionManager is a class-based component that can't access React context
  * 2. We need synchronous access to pending text during terminal input handling
+ *
+ * Supports multiple named sources (e.g. diff comments, PR comments) that are
+ * concatenated when retrieved and all cleared when the injection is consumed.
  */
 
 type InjectionUsedCallback = () => void;
 
+const DEFAULT_SOURCE = 'default';
+
 class PendingInjectionManagerSingleton {
-  private pendingText: string | null = null;
+  private sources = new Map<string, string>();
   private listeners: Set<() => void> = new Set();
   private onInjectionUsedCallbacks: Set<InjectionUsedCallback> = new Set();
 
   /**
-   * Set pending text to be prepended to the next user message
+   * Set pending text for a named source. Multiple sources are concatenated on retrieval.
    */
-  setPending(text: string): void {
-    this.pendingText = text;
+  setPending(text: string, source: string = DEFAULT_SOURCE): void {
+    this.sources.set(source, text);
     this.notifyListeners();
   }
 
   /**
-   * Get the current pending text (if any)
+   * Get concatenated pending text from all sources (if any)
    */
   getPending(): string | null {
-    return this.pendingText;
+    if (this.sources.size === 0) return null;
+    return Array.from(this.sources.values()).join('');
   }
 
   /**
-   * Clear the pending text
+   * Clear pending text. If source is given, clears only that source; otherwise clears all.
    */
-  clear(): void {
-    this.pendingText = null;
+  clear(source?: string): void {
+    if (source !== undefined) {
+      this.sources.delete(source);
+    } else {
+      this.sources.clear();
+    }
     this.notifyListeners();
   }
 
   /**
-   * Check if there is pending text
+   * Check if there is any pending text
    */
   hasPending(): boolean {
-    return this.pendingText !== null;
+    return this.sources.size > 0;
   }
 
   /**
    * Called when the pending injection has been used (prepended to user input)
-   * This clears the pending text and notifies callbacks
+   * This clears all sources and notifies callbacks
    */
   markUsed(): void {
-    this.pendingText = null;
+    this.sources.clear();
     this.notifyListeners();
     // Notify callbacks that injection was used
     for (const callback of this.onInjectionUsedCallbacks) {

--- a/src/renderer/lib/formatPrCommentsForAgent.ts
+++ b/src/renderer/lib/formatPrCommentsForAgent.ts
@@ -1,0 +1,33 @@
+import type { PrComment } from './prCommentsStatus';
+
+function escapeXml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+function formatReviewState(state?: PrComment['reviewState']): string {
+  switch (state) {
+    case 'APPROVED':
+      return ' state="approved"';
+    case 'CHANGES_REQUESTED':
+      return ' state="changes_requested"';
+    default:
+      return '';
+  }
+}
+
+export function formatPrCommentsForAgent(comments: PrComment[]): string {
+  if (!comments.length) return '';
+
+  const entries = comments
+    .map((c) => {
+      const stateAttr = c.type === 'review' ? formatReviewState(c.reviewState) : '';
+      return `  <comment author="${escapeXml(c.author.login)}"${stateAttr}>${escapeXml(c.body)}</comment>`;
+    })
+    .join('\n');
+
+  return `\n<pr_comments>\n${entries}\n</pr_comments>`;
+}

--- a/src/renderer/lib/selectedPrCommentsStore.ts
+++ b/src/renderer/lib/selectedPrCommentsStore.ts
@@ -2,61 +2,88 @@ import type { PrComment } from './prCommentsStatus';
 
 const EMPTY: PrComment[] = [];
 
-class SelectedPrCommentsStoreSingleton {
-  private selected = new Map<string, PrComment>();
-  private listeners = new Set<() => void>();
-  private cachedSnapshot: PrComment[] = EMPTY;
+class SelectedPrCommentsStore {
+  private selected = new Map<string, Map<string, PrComment>>();
+  private listeners = new Map<string, Set<() => void>>();
+  private snapshots = new Map<string, PrComment[]>();
 
-  private updateSnapshot(): void {
-    this.cachedSnapshot = this.selected.size === 0 ? EMPTY : Array.from(this.selected.values());
+  add(scopeKey: string, comment: PrComment): void {
+    const scope = this.getOrCreateScope(scopeKey);
+    scope.set(comment.id, comment);
+    this.invalidateSnapshot(scopeKey);
+    this.emit(scopeKey);
   }
 
-  add(comment: PrComment): void {
-    this.selected.set(comment.id, comment);
-    this.updateSnapshot();
-    this.notify();
+  remove(scopeKey: string, commentId: string): void {
+    const scope = this.selected.get(scopeKey);
+    if (!scope?.delete(commentId)) return;
+    if (scope.size === 0) this.selected.delete(scopeKey);
+    this.invalidateSnapshot(scopeKey);
+    this.emit(scopeKey);
   }
 
-  remove(commentId: string): void {
-    if (!this.selected.delete(commentId)) return;
-    this.updateSnapshot();
-    this.notify();
-  }
-
-  toggle(comment: PrComment): void {
-    if (this.selected.has(comment.id)) {
-      this.selected.delete(comment.id);
+  toggle(scopeKey: string, comment: PrComment): void {
+    const scope = this.getOrCreateScope(scopeKey);
+    if (scope.has(comment.id)) {
+      scope.delete(comment.id);
+      if (scope.size === 0) this.selected.delete(scopeKey);
     } else {
-      this.selected.set(comment.id, comment);
+      scope.set(comment.id, comment);
     }
-    this.updateSnapshot();
-    this.notify();
+    this.invalidateSnapshot(scopeKey);
+    this.emit(scopeKey);
   }
 
-  has(commentId: string): boolean {
-    return this.selected.has(commentId);
+  has(scopeKey: string, commentId: string): boolean {
+    return this.selected.get(scopeKey)?.has(commentId) ?? false;
   }
 
-  clear(): void {
-    if (this.selected.size === 0) return;
-    this.selected.clear();
-    this.updateSnapshot();
-    this.notify();
+  clear(scopeKey: string): void {
+    const scope = this.selected.get(scopeKey);
+    if (!scope || scope.size === 0) return;
+    this.selected.delete(scopeKey);
+    this.invalidateSnapshot(scopeKey);
+    this.emit(scopeKey);
   }
 
-  subscribe(listener: () => void): () => void {
-    this.listeners.add(listener);
+  subscribe(scopeKey: string, listener: () => void): () => void {
+    const set = this.listeners.get(scopeKey) ?? new Set();
+    set.add(listener);
+    this.listeners.set(scopeKey, set);
     return () => {
-      this.listeners.delete(listener);
+      set.delete(listener);
+      if (set.size === 0) this.listeners.delete(scopeKey);
     };
   }
 
-  getSnapshot(): PrComment[] {
-    return this.cachedSnapshot;
+  getSnapshot(scopeKey: string): PrComment[] {
+    const scope = this.selected.get(scopeKey);
+    if (!scope || scope.size === 0) return EMPTY;
+    let snapshot = this.snapshots.get(scopeKey);
+    if (!snapshot) {
+      snapshot = Array.from(scope.values());
+      this.snapshots.set(scopeKey, snapshot);
+    }
+    return snapshot;
   }
 
-  private notify(): void {
-    for (const fn of this.listeners) {
+  private getOrCreateScope(scopeKey: string): Map<string, PrComment> {
+    let scope = this.selected.get(scopeKey);
+    if (!scope) {
+      scope = new Map();
+      this.selected.set(scopeKey, scope);
+    }
+    return scope;
+  }
+
+  private invalidateSnapshot(scopeKey: string): void {
+    this.snapshots.delete(scopeKey);
+  }
+
+  private emit(scopeKey: string): void {
+    const set = this.listeners.get(scopeKey);
+    if (!set) return;
+    for (const fn of set) {
       try {
         fn();
       } catch (err) {
@@ -66,4 +93,4 @@ class SelectedPrCommentsStoreSingleton {
   }
 }
 
-export const selectedPrCommentsStore = new SelectedPrCommentsStoreSingleton();
+export const selectedPrCommentsStore = new SelectedPrCommentsStore();

--- a/src/renderer/lib/selectedPrCommentsStore.ts
+++ b/src/renderer/lib/selectedPrCommentsStore.ts
@@ -1,0 +1,69 @@
+import type { PrComment } from './prCommentsStatus';
+
+const EMPTY: PrComment[] = [];
+
+class SelectedPrCommentsStoreSingleton {
+  private selected = new Map<string, PrComment>();
+  private listeners = new Set<() => void>();
+  private cachedSnapshot: PrComment[] = EMPTY;
+
+  private updateSnapshot(): void {
+    this.cachedSnapshot = this.selected.size === 0 ? EMPTY : Array.from(this.selected.values());
+  }
+
+  add(comment: PrComment): void {
+    this.selected.set(comment.id, comment);
+    this.updateSnapshot();
+    this.notify();
+  }
+
+  remove(commentId: string): void {
+    if (!this.selected.delete(commentId)) return;
+    this.updateSnapshot();
+    this.notify();
+  }
+
+  toggle(comment: PrComment): void {
+    if (this.selected.has(comment.id)) {
+      this.selected.delete(comment.id);
+    } else {
+      this.selected.set(comment.id, comment);
+    }
+    this.updateSnapshot();
+    this.notify();
+  }
+
+  has(commentId: string): boolean {
+    return this.selected.has(commentId);
+  }
+
+  clear(): void {
+    if (this.selected.size === 0) return;
+    this.selected.clear();
+    this.updateSnapshot();
+    this.notify();
+  }
+
+  subscribe(listener: () => void): () => void {
+    this.listeners.add(listener);
+    return () => {
+      this.listeners.delete(listener);
+    };
+  }
+
+  getSnapshot(): PrComment[] {
+    return this.cachedSnapshot;
+  }
+
+  private notify(): void {
+    for (const fn of this.listeners) {
+      try {
+        fn();
+      } catch (err) {
+        console.error('SelectedPrCommentsStore listener error:', err);
+      }
+    }
+  }
+}
+
+export const selectedPrCommentsStore = new SelectedPrCommentsStoreSingleton();

--- a/src/test/renderer/formatPrCommentsForAgent.test.ts
+++ b/src/test/renderer/formatPrCommentsForAgent.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { formatPrCommentsForAgent } from '../../renderer/lib/formatPrCommentsForAgent';
+import type { PrComment } from '../../renderer/lib/prCommentsStatus';
+
+function makeComment(overrides: Partial<PrComment> = {}): PrComment {
+  return {
+    id: '1',
+    author: { login: 'alice' },
+    body: 'Please fix this',
+    createdAt: '2026-01-01T00:00:00Z',
+    type: 'comment',
+    ...overrides,
+  };
+}
+
+describe('formatPrCommentsForAgent', () => {
+  it('returns empty string for no comments', () => {
+    expect(formatPrCommentsForAgent([])).toBe('');
+  });
+
+  it('formats a single comment', () => {
+    const result = formatPrCommentsForAgent([makeComment()]);
+    expect(result).toBe(
+      '\n<pr_comments>\n  <comment author="alice">Please fix this</comment>\n</pr_comments>'
+    );
+  });
+
+  it('formats multiple comments', () => {
+    const result = formatPrCommentsForAgent([
+      makeComment({ id: '1', author: { login: 'alice' }, body: 'Fix A' }),
+      makeComment({ id: '2', author: { login: 'bob' }, body: 'Fix B' }),
+    ]);
+    expect(result).toContain('<comment author="alice">Fix A</comment>');
+    expect(result).toContain('<comment author="bob">Fix B</comment>');
+    expect(result).toMatch(/^\n<pr_comments>\n/);
+  });
+
+  it('includes review state for reviews', () => {
+    const result = formatPrCommentsForAgent([
+      makeComment({ type: 'review', reviewState: 'APPROVED', body: 'LGTM' }),
+    ]);
+    expect(result).toContain('state="approved"');
+  });
+
+  it('includes changes_requested state', () => {
+    const result = formatPrCommentsForAgent([
+      makeComment({ type: 'review', reviewState: 'CHANGES_REQUESTED', body: 'Needs work' }),
+    ]);
+    expect(result).toContain('state="changes_requested"');
+  });
+
+  it('omits state attribute for plain comments even with reviewState', () => {
+    const result = formatPrCommentsForAgent([
+      makeComment({ type: 'comment', reviewState: 'APPROVED', body: 'Nice' }),
+    ]);
+    expect(result).not.toContain('state=');
+  });
+
+  it('omits state attribute for reviews without a recognized state', () => {
+    const result = formatPrCommentsForAgent([
+      makeComment({ type: 'review', reviewState: 'COMMENTED', body: 'FYI' }),
+    ]);
+    expect(result).not.toContain('state=');
+  });
+
+  it('escapes XML-sensitive characters in body and author', () => {
+    const result = formatPrCommentsForAgent([
+      makeComment({
+        author: { login: 'user"name' },
+        body: 'Use </comment> & <script>alert("xss")</script>',
+      }),
+    ]);
+    expect(result).toContain('author="user&quot;name"');
+    expect(result).toContain('&lt;/comment&gt;');
+    expect(result).toContain('&amp;');
+    expect(result).toContain('&lt;script&gt;');
+    expect(result).not.toContain('<script>');
+  });
+});

--- a/src/test/renderer/pendingInjectionMultiSource.test.ts
+++ b/src/test/renderer/pendingInjectionMultiSource.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { pendingInjectionManager } from '../../renderer/lib/PendingInjectionManager';
+
+describe('PendingInjectionManager multi-source', () => {
+  beforeEach(() => {
+    pendingInjectionManager.clear();
+  });
+
+  it('returns null when empty', () => {
+    expect(pendingInjectionManager.getPending()).toBeNull();
+    expect(pendingInjectionManager.hasPending()).toBe(false);
+  });
+
+  it('setPending with default source', () => {
+    pendingInjectionManager.setPending('hello');
+    expect(pendingInjectionManager.getPending()).toBe('hello');
+    expect(pendingInjectionManager.hasPending()).toBe(true);
+  });
+
+  it('concatenates multiple sources', () => {
+    pendingInjectionManager.setPending('A', 'source-a');
+    pendingInjectionManager.setPending('B', 'source-b');
+    expect(pendingInjectionManager.getPending()).toBe('AB');
+  });
+
+  it('overwriting a source replaces its text', () => {
+    pendingInjectionManager.setPending('A', 'source-a');
+    pendingInjectionManager.setPending('B', 'source-b');
+    pendingInjectionManager.setPending('A2', 'source-a');
+    expect(pendingInjectionManager.getPending()).toBe('A2B');
+  });
+
+  it('clear with source only removes that source', () => {
+    pendingInjectionManager.setPending('A', 'source-a');
+    pendingInjectionManager.setPending('B', 'source-b');
+    pendingInjectionManager.clear('source-a');
+    expect(pendingInjectionManager.getPending()).toBe('B');
+    expect(pendingInjectionManager.hasPending()).toBe(true);
+  });
+
+  it('clear without source removes all', () => {
+    pendingInjectionManager.setPending('A', 'source-a');
+    pendingInjectionManager.setPending('B', 'source-b');
+    pendingInjectionManager.clear();
+    expect(pendingInjectionManager.getPending()).toBeNull();
+    expect(pendingInjectionManager.hasPending()).toBe(false);
+  });
+
+  it('markUsed clears all sources and fires callbacks', () => {
+    pendingInjectionManager.setPending('A', 'source-a');
+    pendingInjectionManager.setPending('B', 'source-b');
+
+    let fired = false;
+    const unsub = pendingInjectionManager.onInjectionUsed(() => {
+      fired = true;
+    });
+
+    pendingInjectionManager.markUsed();
+    expect(pendingInjectionManager.hasPending()).toBe(false);
+    expect(pendingInjectionManager.getPending()).toBeNull();
+    expect(fired).toBe(true);
+
+    unsub();
+  });
+
+  it('listeners are notified on setPending and clear', () => {
+    const listener = vi.fn();
+    const unsub = pendingInjectionManager.subscribe(listener);
+
+    pendingInjectionManager.setPending('A', 'src');
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    pendingInjectionManager.clear('src');
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsub();
+    pendingInjectionManager.setPending('B', 'src');
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/test/renderer/selectedPrCommentsStore.test.ts
+++ b/src/test/renderer/selectedPrCommentsStore.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import type { PrComment } from '../../renderer/lib/prCommentsStatus';
+
+// Import the class indirectly — we need fresh instances per test,
+// so we reconstruct via the module's exported singleton pattern.
+// Instead, we'll test the singleton and reset it between tests via clear().
+import { selectedPrCommentsStore } from '../../renderer/lib/selectedPrCommentsStore';
+
+function makeComment(id: string, login = 'alice'): PrComment {
+  return {
+    id,
+    author: { login },
+    body: `Comment ${id}`,
+    createdAt: '2026-01-01T00:00:00Z',
+    type: 'comment',
+  };
+}
+
+describe('selectedPrCommentsStore', () => {
+  beforeEach(() => {
+    selectedPrCommentsStore.clear();
+  });
+
+  it('starts empty', () => {
+    expect(selectedPrCommentsStore.getSnapshot()).toEqual([]);
+    expect(selectedPrCommentsStore.getSnapshot().length).toBe(0);
+  });
+
+  it('add and has', () => {
+    const c = makeComment('1');
+    selectedPrCommentsStore.add(c);
+    expect(selectedPrCommentsStore.has('1')).toBe(true);
+    expect(selectedPrCommentsStore.getSnapshot().length).toBe(1);
+    expect(selectedPrCommentsStore.getSnapshot()).toEqual([c]);
+  });
+
+  it('remove', () => {
+    selectedPrCommentsStore.add(makeComment('1'));
+    selectedPrCommentsStore.remove('1');
+    expect(selectedPrCommentsStore.has('1')).toBe(false);
+    expect(selectedPrCommentsStore.getSnapshot().length).toBe(0);
+  });
+
+  it('remove non-existent id is a no-op', () => {
+    const listener = vi.fn();
+    selectedPrCommentsStore.subscribe(listener);
+    selectedPrCommentsStore.remove('nonexistent');
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('toggle adds then removes', () => {
+    const c = makeComment('1');
+    selectedPrCommentsStore.toggle(c);
+    expect(selectedPrCommentsStore.has('1')).toBe(true);
+    selectedPrCommentsStore.toggle(c);
+    expect(selectedPrCommentsStore.has('1')).toBe(false);
+  });
+
+  it('clear removes all', () => {
+    selectedPrCommentsStore.add(makeComment('1'));
+    selectedPrCommentsStore.add(makeComment('2'));
+    selectedPrCommentsStore.clear();
+    expect(selectedPrCommentsStore.getSnapshot().length).toBe(0);
+    expect(selectedPrCommentsStore.getSnapshot()).toEqual([]);
+  });
+
+  it('clear on empty store does not notify', () => {
+    const listener = vi.fn();
+    selectedPrCommentsStore.subscribe(listener);
+    selectedPrCommentsStore.clear();
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('getSnapshot returns stable reference until mutation', () => {
+    const snap1 = selectedPrCommentsStore.getSnapshot();
+    const snap2 = selectedPrCommentsStore.getSnapshot();
+    expect(snap1).toBe(snap2);
+
+    selectedPrCommentsStore.add(makeComment('1'));
+    const snap3 = selectedPrCommentsStore.getSnapshot();
+    expect(snap3).not.toBe(snap1);
+    expect(snap3).toHaveLength(1);
+
+    // Same reference on repeated reads
+    const snap4 = selectedPrCommentsStore.getSnapshot();
+    expect(snap4).toBe(snap3);
+  });
+
+  it('getSnapshot returns EMPTY sentinel when cleared', () => {
+    selectedPrCommentsStore.add(makeComment('1'));
+    selectedPrCommentsStore.clear();
+    const snap = selectedPrCommentsStore.getSnapshot();
+    expect(snap).toEqual([]);
+    // Stable empty reference
+    expect(snap).toBe(selectedPrCommentsStore.getSnapshot());
+  });
+
+  it('subscribe and unsubscribe', () => {
+    const listener = vi.fn();
+    const unsub = selectedPrCommentsStore.subscribe(listener);
+    selectedPrCommentsStore.add(makeComment('1'));
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    unsub();
+    selectedPrCommentsStore.add(makeComment('2'));
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/test/renderer/selectedPrCommentsStore.test.ts
+++ b/src/test/renderer/selectedPrCommentsStore.test.ts
@@ -1,10 +1,9 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import type { PrComment } from '../../renderer/lib/prCommentsStatus';
 
-// Import the class indirectly — we need fresh instances per test,
-// so we reconstruct via the module's exported singleton pattern.
-// Instead, we'll test the singleton and reset it between tests via clear().
 import { selectedPrCommentsStore } from '../../renderer/lib/selectedPrCommentsStore';
+
+const TASK = 'task-1';
 
 function makeComment(id: string, login = 'alice'): PrComment {
   return {
@@ -18,91 +17,107 @@ function makeComment(id: string, login = 'alice'): PrComment {
 
 describe('selectedPrCommentsStore', () => {
   beforeEach(() => {
-    selectedPrCommentsStore.clear();
+    selectedPrCommentsStore.clear(TASK);
   });
 
   it('starts empty', () => {
-    expect(selectedPrCommentsStore.getSnapshot()).toEqual([]);
-    expect(selectedPrCommentsStore.getSnapshot().length).toBe(0);
+    expect(selectedPrCommentsStore.getSnapshot(TASK)).toEqual([]);
+    expect(selectedPrCommentsStore.getSnapshot(TASK).length).toBe(0);
   });
 
   it('add and has', () => {
     const c = makeComment('1');
-    selectedPrCommentsStore.add(c);
-    expect(selectedPrCommentsStore.has('1')).toBe(true);
-    expect(selectedPrCommentsStore.getSnapshot().length).toBe(1);
-    expect(selectedPrCommentsStore.getSnapshot()).toEqual([c]);
+    selectedPrCommentsStore.add(TASK, c);
+    expect(selectedPrCommentsStore.has(TASK, '1')).toBe(true);
+    expect(selectedPrCommentsStore.getSnapshot(TASK).length).toBe(1);
+    expect(selectedPrCommentsStore.getSnapshot(TASK)).toEqual([c]);
   });
 
   it('remove', () => {
-    selectedPrCommentsStore.add(makeComment('1'));
-    selectedPrCommentsStore.remove('1');
-    expect(selectedPrCommentsStore.has('1')).toBe(false);
-    expect(selectedPrCommentsStore.getSnapshot().length).toBe(0);
+    selectedPrCommentsStore.add(TASK, makeComment('1'));
+    selectedPrCommentsStore.remove(TASK, '1');
+    expect(selectedPrCommentsStore.has(TASK, '1')).toBe(false);
+    expect(selectedPrCommentsStore.getSnapshot(TASK).length).toBe(0);
   });
 
   it('remove non-existent id is a no-op', () => {
     const listener = vi.fn();
-    selectedPrCommentsStore.subscribe(listener);
-    selectedPrCommentsStore.remove('nonexistent');
+    selectedPrCommentsStore.subscribe(TASK, listener);
+    selectedPrCommentsStore.remove(TASK, 'nonexistent');
     expect(listener).not.toHaveBeenCalled();
   });
 
   it('toggle adds then removes', () => {
     const c = makeComment('1');
-    selectedPrCommentsStore.toggle(c);
-    expect(selectedPrCommentsStore.has('1')).toBe(true);
-    selectedPrCommentsStore.toggle(c);
-    expect(selectedPrCommentsStore.has('1')).toBe(false);
+    selectedPrCommentsStore.toggle(TASK, c);
+    expect(selectedPrCommentsStore.has(TASK, '1')).toBe(true);
+    selectedPrCommentsStore.toggle(TASK, c);
+    expect(selectedPrCommentsStore.has(TASK, '1')).toBe(false);
   });
 
   it('clear removes all', () => {
-    selectedPrCommentsStore.add(makeComment('1'));
-    selectedPrCommentsStore.add(makeComment('2'));
-    selectedPrCommentsStore.clear();
-    expect(selectedPrCommentsStore.getSnapshot().length).toBe(0);
-    expect(selectedPrCommentsStore.getSnapshot()).toEqual([]);
+    selectedPrCommentsStore.add(TASK, makeComment('1'));
+    selectedPrCommentsStore.add(TASK, makeComment('2'));
+    selectedPrCommentsStore.clear(TASK);
+    expect(selectedPrCommentsStore.getSnapshot(TASK).length).toBe(0);
+    expect(selectedPrCommentsStore.getSnapshot(TASK)).toEqual([]);
   });
 
   it('clear on empty store does not notify', () => {
     const listener = vi.fn();
-    selectedPrCommentsStore.subscribe(listener);
-    selectedPrCommentsStore.clear();
+    selectedPrCommentsStore.subscribe(TASK, listener);
+    selectedPrCommentsStore.clear(TASK);
     expect(listener).not.toHaveBeenCalled();
   });
 
   it('getSnapshot returns stable reference until mutation', () => {
-    const snap1 = selectedPrCommentsStore.getSnapshot();
-    const snap2 = selectedPrCommentsStore.getSnapshot();
+    const snap1 = selectedPrCommentsStore.getSnapshot(TASK);
+    const snap2 = selectedPrCommentsStore.getSnapshot(TASK);
     expect(snap1).toBe(snap2);
 
-    selectedPrCommentsStore.add(makeComment('1'));
-    const snap3 = selectedPrCommentsStore.getSnapshot();
+    selectedPrCommentsStore.add(TASK, makeComment('1'));
+    const snap3 = selectedPrCommentsStore.getSnapshot(TASK);
     expect(snap3).not.toBe(snap1);
     expect(snap3).toHaveLength(1);
 
     // Same reference on repeated reads
-    const snap4 = selectedPrCommentsStore.getSnapshot();
+    const snap4 = selectedPrCommentsStore.getSnapshot(TASK);
     expect(snap4).toBe(snap3);
   });
 
   it('getSnapshot returns EMPTY sentinel when cleared', () => {
-    selectedPrCommentsStore.add(makeComment('1'));
-    selectedPrCommentsStore.clear();
-    const snap = selectedPrCommentsStore.getSnapshot();
+    selectedPrCommentsStore.add(TASK, makeComment('1'));
+    selectedPrCommentsStore.clear(TASK);
+    const snap = selectedPrCommentsStore.getSnapshot(TASK);
     expect(snap).toEqual([]);
     // Stable empty reference
-    expect(snap).toBe(selectedPrCommentsStore.getSnapshot());
+    expect(snap).toBe(selectedPrCommentsStore.getSnapshot(TASK));
   });
 
   it('subscribe and unsubscribe', () => {
     const listener = vi.fn();
-    const unsub = selectedPrCommentsStore.subscribe(listener);
-    selectedPrCommentsStore.add(makeComment('1'));
+    const unsub = selectedPrCommentsStore.subscribe(TASK, listener);
+    selectedPrCommentsStore.add(TASK, makeComment('1'));
     expect(listener).toHaveBeenCalledTimes(1);
 
     unsub();
-    selectedPrCommentsStore.add(makeComment('2'));
+    selectedPrCommentsStore.add(TASK, makeComment('2'));
     expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('scopes are isolated', () => {
+    const other = 'task-2';
+    selectedPrCommentsStore.add(TASK, makeComment('1'));
+    selectedPrCommentsStore.add(other, makeComment('2'));
+    expect(selectedPrCommentsStore.getSnapshot(TASK)).toHaveLength(1);
+    expect(selectedPrCommentsStore.getSnapshot(other)).toHaveLength(1);
+    expect(selectedPrCommentsStore.has(TASK, '2')).toBe(false);
+    expect(selectedPrCommentsStore.has(other, '1')).toBe(false);
+
+    selectedPrCommentsStore.clear(TASK);
+    expect(selectedPrCommentsStore.getSnapshot(TASK)).toHaveLength(0);
+    expect(selectedPrCommentsStore.getSnapshot(other)).toHaveLength(1);
+
+    selectedPrCommentsStore.clear(other);
   });
 });


### PR DESCRIPTION
## Summary
After a PR has been opened, the app starts to populate the sidebar with comments from Github. The only thing you can do with the comments is click it and it brings to you to the PR

This PR adds the ability to view these comments inline and add these comments to the chat (just like how comments work in the diff viewer)

## Fixes 
N/A

## Snapshot
#### Expanded comments
<img width="1064" height="481" alt="image" src="https://github.com/user-attachments/assets/9d0b4747-dd15-48f1-9e4e-af40f5435d3d" />

#### Ability to add to chat and link to Github
<img width="367" height="132" alt="image" src="https://github.com/user-attachments/assets/e4b074ba-559d-4e77-92e1-027a0c149ea4" />

#### Queued up comments
<img width="480" height="217" alt="image" src="https://github.com/user-attachments/assets/79d89962-d4d0-4917-8c39-3d96416bd012" />


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * PR-level review comments are now shown in the comments popover alongside line comments, with a dedicated section when present.
  * Comments can be selected/toggled for sending to chat or removed from the selection; PR comment rows support expand/collapse and external PR links.
  * Comment counts and badges now combine line and PR-level comment totals.

* **Tests**
  * Added tests covering PR comment formatting, multi-source pending injection behavior, and PR comment selection store.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->