### PR TITLE
fix(settings): improve padding for smaller screens

### DIFF
--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -287,7 +287,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
   const currentContent = tabContent[activeTab as keyof typeof tabContent];
 
   return (
-    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden px-6 pb-0 pt-8">
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden px-6 pb-6 pt-8">
       <div className="mx-auto flex h-full min-h-0 w-full max-w-[1060px] flex-col gap-6">
         {/* Header */}
         <div className="flex flex-col gap-6">
@@ -315,7 +315,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
         {/* Contents: Navigation + Content */}
         <div className="grid min-h-0 flex-1 grid-cols-[13rem_minmax(0,1fr)] gap-8 overflow-hidden">
           {/* Navigation menu */}
-          <nav className="flex min-h-0 w-52 flex-col gap-2 overflow-y-auto">
+          <nav className="flex min-h-0 w-52 flex-col gap-2 overflow-y-auto pb-8 pr-2">
             {tabs.map((tab) => {
               const isActive = activeTab === tab.id && !tab.isExternal;
 
@@ -347,8 +347,8 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
 
           {/* Content container */}
           {currentContent && (
-            <div className="flex min-h-0 min-w-0 flex-1 justify-center overflow-y-auto pb-8">
-              <div className="mx-auto w-full max-w-4xl space-y-8">
+            <div className="flex min-h-0 min-w-0 flex-1 justify-center overflow-y-auto pr-2">
+              <div className="mx-auto w-full max-w-4xl space-y-8 pb-10">
                 {/* Page title */}
                 <div className="flex flex-col gap-6">
                   <div className="flex flex-col gap-1">


### PR DESCRIPTION
## Summary

- Add bottom padding (`pb-6`) to the settings page outer container to prevent content from touching the window edge
- Add bottom padding (`pb-8`) and right padding (`pr-2`) to the navigation sidebar for better scroll behavior
- Move bottom padding from the scroll container to the inner content wrapper (`pb-10`) so content doesn't get clipped
- Add right padding (`pr-2`) to the content scroll area for scrollbar spacing

These changes improve the settings page layout on smaller screens by ensuring consistent spacing around all edges and proper padding for scrollable areas.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined spacing and padding in the Settings Page for improved visual consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->