### PR TITLE
Add spinner and message while setup script is running

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -316,10 +316,15 @@ const ChatInterface: React.FC<Props> = ({
       setSetupRunning(event.status === 'running');
     });
 
-    window.electronAPI.lifecycleGetState({ taskId: task.id }).then((res) => {
-      if (cancelled) return;
-      setSetupRunning(res?.state?.setup?.status === 'running');
-    });
+    window.electronAPI
+      .lifecycleGetState({ taskId: task.id })
+      .then((res) => {
+        if (cancelled) return;
+        setSetupRunning(res?.state?.setup?.status === 'running');
+      })
+      .catch((err) => {
+        console.error('Failed to get lifecycle state:', err);
+      });
 
     return () => {
       cancelled = true;

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -1277,21 +1277,25 @@ const ChatInterface: React.FC<Props> = ({
             )}
             <div
               ref={terminalPanelRef}
-              className={`relative mx-auto h-full max-w-4xl overflow-hidden rounded-md ${setupRunning ? 'hidden' : ''} ${
-                agent === 'charm'
-                  ? effectiveTheme === 'dark-black'
-                    ? 'bg-black'
-                    : effectiveTheme === 'dark'
-                      ? 'bg-card'
-                      : 'bg-white'
-                  : agent === 'mistral'
-                    ? effectiveTheme === 'dark' || effectiveTheme === 'dark-black'
-                      ? effectiveTheme === 'dark-black'
-                        ? 'bg-[#141820]'
-                        : 'bg-[#202938]'
-                      : 'bg-white'
-                    : ''
-              }`}
+              className={cn(
+                'relative mx-auto h-full max-w-4xl overflow-hidden rounded-md',
+                setupRunning && 'hidden',
+                `${
+                  agent === 'charm'
+                    ? effectiveTheme === 'dark-black'
+                      ? 'bg-black'
+                      : effectiveTheme === 'dark'
+                        ? 'bg-card'
+                        : 'bg-white'
+                    : agent === 'mistral'
+                      ? effectiveTheme === 'dark' || effectiveTheme === 'dark-black'
+                        ? effectiveTheme === 'dark-black'
+                          ? 'bg-[#141820]'
+                          : 'bg-[#202938]'
+                        : 'bg-white'
+                      : ''
+                }`
+              )}
             >
               <TerminalSearchOverlay
                 isOpen={isSearchOpen}

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -311,11 +311,13 @@ const ChatInterface: React.FC<Props> = ({
   useEffect(() => {
     let cancelled = false;
 
+    // Add event listener to track setup status changes
     const off = window.electronAPI.onLifecycleEvent((event) => {
       if (event.taskId !== task.id || event.phase !== 'setup') return;
       setSetupRunning(event.status === 'running');
     });
 
+    // Additionally, in case the event is missed during mount, also fetch the state immediately
     window.electronAPI
       .lifecycleGetState({ taskId: task.id })
       .then((res) => {

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -41,12 +41,7 @@ import {
   getConversationTabLabel,
   planConversationTitleUpdates,
 } from '../lib/conversationTabTitles';
-
-declare const window: Window & {
-  electronAPI: {
-    saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>;
-  };
-};
+import { Spinner } from './ui/spinner';
 
 interface Props {
   task: Task;
@@ -178,6 +173,7 @@ const ChatInterface: React.FC<Props> = ({
   const lockedAgentWriteRef = useRef<string | null>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [tabsOverflow, setTabsOverflow] = useState(false);
+  const [setupRunning, setSetupRunning] = useState(false);
   const fallbackAgentRef = useRef<Agent>(initialAgent || 'claude');
   fallbackAgentRef.current = agent;
 
@@ -311,6 +307,25 @@ const ChatInterface: React.FC<Props> = ({
     readySignaledTaskIdRef.current = task.id;
     onTaskInterfaceReady();
   }, [task.id, onTaskInterfaceReady]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    const off = window.electronAPI.onLifecycleEvent((event) => {
+      if (event.taskId !== task.id || event.phase !== 'setup') return;
+      setSetupRunning(event.status === 'running');
+    });
+
+    window.electronAPI.lifecycleGetState({ taskId: task.id }).then((res) => {
+      if (cancelled) return;
+      setSetupRunning(res?.state?.setup?.status === 'running');
+    });
+
+    return () => {
+      cancelled = true;
+      off();
+    };
+  }, [task.id]);
 
   const syncConversations = useCallback(async () => {
     setConversationsLoaded(false);
@@ -1247,9 +1262,15 @@ const ChatInterface: React.FC<Props> = ({
             className="mt-4 min-h-0 flex-1 px-6"
             onWheelCapture={handleTerminalViewportWheelForwarding}
           >
+            {setupRunning && (
+              <div className="flex h-full items-center justify-center gap-2 text-muted-foreground">
+                <Spinner />
+                <span>Running setup script...</span>
+              </div>
+            )}
             <div
               ref={terminalPanelRef}
-              className={`relative mx-auto h-full max-w-4xl overflow-hidden rounded-md ${
+              className={`relative mx-auto h-full max-w-4xl overflow-hidden rounded-md ${setupRunning ? 'hidden' : ''} ${
                 agent === 'charm'
                   ? effectiveTheme === 'dark-black'
                     ? 'bg-black'

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -311,6 +311,8 @@ const ChatInterface: React.FC<Props> = ({
   useEffect(() => {
     let cancelled = false;
 
+    setSetupRunning(false);
+
     // Add event listener to track setup status changes
     const off = window.electronAPI.onLifecycleEvent((event) => {
       if (event.taskId !== task.id || event.phase !== 'setup') return;
@@ -326,6 +328,7 @@ const ChatInterface: React.FC<Props> = ({
       })
       .catch((err) => {
         console.error('Failed to get lifecycle state:', err);
+        if (!cancelled) setSetupRunning(false);
       });
 
     return () => {


### PR DESCRIPTION
## Summary

When a task has a setup script, the chat interface shows a blank terminal while the script is running — which makes it unclear that anything is happening.

This replaces that blank state with a spinner and "Running setup script..." message, making it clearer the agent isn't shown because of the setup script.


## Snapshot

### Before

https://github.com/user-attachments/assets/8cdb3cd3-6d32-4b48-8a10-7cc8210cc44d


### After

https://github.com/user-attachments/assets/74af3c51-3a3f-41e3-9bab-a8e8bb3c9427


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal area now displays a centered spinner and the message "Running setup script..." while setup is running, and hides the terminal to avoid interference.
  * Setup status updates are more reliable across task changes and component lifecycle events, preventing stale or incorrect progress indicators.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->