### PR TITLE
perf(git): optimize git status for large monorepos

### DIFF
--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -167,7 +167,7 @@ export async function getStatus(taskPath: string): Promise<GitChange[]> {
             '--porcelain=v2',
             '-z',
             '--no-ahead-behind',
-            '--untracked-files=normal',
+            '--untracked-files=all',
           ],
           {
             cwd: taskPath,
@@ -179,7 +179,7 @@ export async function getStatus(taskPath: string): Promise<GitChange[]> {
         // Fallback for older git versions that do not support porcelain v2.
         const { stdout } = await execFileAsync(
           'git',
-          ['--no-optional-locks', 'status', '--porcelain', '--untracked-files=normal'],
+          ['--no-optional-locks', 'status', '--porcelain', '--untracked-files=all'],
           {
             cwd: taskPath,
             maxBuffer: MAX_DIFF_OUTPUT_BYTES,


### PR DESCRIPTION
## Summary

Optimizes `GitService.getStatus()` for large monorepos by running git commands in parallel and adding flags to reduce unnecessary work:
- **Parallel execution**: `git status` and both `git diff --numstat` commands now run concurrently via `Promise.all` instead of sequentially
- **`--no-optional-locks`**: Prevents `git status` from blocking when a concurrent `git fetch` holds the index lock
- **`--no-ahead-behind`**: Skips commit-graph traversal for branch tracking info we don't use
- **`--untracked-files=normal`**: Shows untracked directories as single entries instead of recursively enumerating every file within them

## Fixes
N/A

## Snapshot

Testing steps in the video:
1. Use a super large monorepo
2. Refresh the Electron App (`cmd + r`)
3. Click on a task
4. Open the sidebar to see the changes

This test uses the exact same repo with the exact same changes, one running the latest Emdash dist and one running this PR. This is running on an Apple M4 Max 64GB

#### Before

https://github.com/user-attachments/assets/7a367352-b01b-4016-b0db-5509c747778c

#### After

https://github.com/user-attachments/assets/f4b631f9-328a-43dc-9394-295ad37cc814


## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] I have self-reviewed the code
- [x] A decent size PR without self-review might be rejected

## Checklist

- [x] I have read the contributing guide
- [x] My code follows the style guidelines of this project (`pnpm run format`)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I haven't checked if new and existing unit tests pass locally with my changes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Status and file-change detection now run concurrently for faster, more responsive results.

* **Compatibility**
  * Improved fallback handling for older Git versions to ensure status reporting works across environments.

* **Reliability**
  * More consistent status information, safer Git options to reduce interference, and non-blocking handling of auxiliary diff checks to avoid disrupting results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->