### PR TITLE
fix(terminal): enable minimum contrast ratio for light-mode terminals

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -1016,6 +1016,7 @@ export class TerminalSessionManager {
     delete (colorTheme as any)?.fontFamily;
     delete (colorTheme as any)?.fontSize;
     this.terminal.options.theme = { ...base, ...colorTheme };
+    this.terminal.options.minimumContrastRatio = theme.base === 'light' ? 4.5 : 1;
 
     this.themeFontFamily = typeof fontFamily === 'string' ? fontFamily.trim() : '';
     this.applyEffectiveFont();


### PR DESCRIPTION
## Summary
Fix unreadable diff highlighting in light-mode terminals by enabling xterm.js minimum contrast ratio enforcement.

Steps to reproduce: 
1. Use light mode
2. Get the agent (Claude in this case) to output a diff

## Fixes 
n/a

## Snapshot
#### Before
<img width="918" height="812" alt="image" src="https://github.com/user-attachments/assets/7c8b1e29-251e-4861-abba-b3a82deac546" />

#### After
<img width="900" height="812" alt="image" src="https://github.com/user-attachments/assets/bc9d817c-84f2-47b2-83f1-2c01832d6339" />


## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [X] I have checked if new and existing unit tests pass locally with my changes