### PR TITLE
fix: prevent terminal from stealing focus from text inputs

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -531,7 +531,7 @@ export class TerminalSessionManager {
         if (!this.disposed) {
           this.restoreViewportPosition();
           if (shouldRestoreFocus) {
-            this.terminal.focus();
+            this.focus();
           }
         }
       });
@@ -619,12 +619,39 @@ export class TerminalSessionManager {
     } catch {}
   }
 
+  /** True when the user is focused on a text input we should not steal from. */
+  private isTextInputFocused(): boolean {
+    const el = document.activeElement;
+    if (!el || el === document.body) return false;
+    // The terminal's own hidden textarea doesn't count
+    if (el === this.terminal.textarea) return false;
+    const tag = (el as HTMLElement).tagName;
+    if (tag === 'TEXTAREA' || (el as HTMLElement).isContentEditable) return true;
+    if (tag === 'INPUT') {
+      const t = (el as HTMLInputElement).type?.toLowerCase();
+      return (
+        !t ||
+        t === 'text' ||
+        t === 'password' ||
+        t === 'email' ||
+        t === 'search' ||
+        t === 'url' ||
+        t === 'tel' ||
+        t === 'number'
+      );
+    }
+    return false;
+  }
+
   focus() {
     // Don't steal focus from open dialogs (e.g. New Task modal).
     // On Linux/Wayland the terminal's hidden textarea can retain focus
     // after a dialog opens, causing keystrokes to go to the PTY instead
     // of dialog inputs.
     if (document.activeElement?.closest('[role="dialog"]')) return;
+
+    // Don't steal focus from text inputs the user is actively typing in (#1467).
+    if (this.isTextInputFocused()) return;
 
     this.terminal.focus();
   }


### PR DESCRIPTION
## Summary

Fixes the terminal stealing focus from text inputs (e.g. search bars, settings fields) when viewport position is restored after a re-render.

## Changes

- Add `isTextInputFocused()` helper that detects when the user is actively typing in a `<textarea>`, `<input>`, or `contentEditable` element (excluding the terminal's own hidden textarea)
- Guard `focus()` to bail out when a text input is focused, preventing the terminal from hijacking keyboard input
- Route the post-restore focus call through `focus()` instead of calling `this.terminal.focus()` directly, so it respects the same guards

Fixes #1467

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal no longer steals focus from active text input fields, ensuring a smoother experience when switching between terminal and other input elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->