### PR TITLE
feat: add 'From PR' mode to TaskModal for PR checkout

### DIFF
--- a/src/main/ipc/githubIpc.ts
+++ b/src/main/ipc/githubIpc.ts
@@ -382,6 +382,35 @@ export function registerGithubIpc() {
   );
 
   ipcMain.handle(
+    'github:getPullRequestDetails',
+    async (
+      _,
+      args: {
+        projectPath: string;
+        prNumber: number;
+      }
+    ) => {
+      const { projectPath, prNumber } = args || ({} as typeof args);
+
+      if (!projectPath || !prNumber) {
+        return { success: false, error: 'Missing required parameters' };
+      }
+
+      try {
+        const pr = await githubService.getPullRequestDetails(projectPath, prNumber);
+        if (!pr) {
+          return { success: false, error: `PR #${prNumber} not found` };
+        }
+        return { success: true, pr };
+      } catch (error) {
+        log.error('Failed to get PR details:', error);
+        const message = error instanceof Error ? error.message : 'Unable to fetch PR details';
+        return { success: false, error: message };
+      }
+    }
+  );
+
+  ipcMain.handle(
     'github:getPullRequestBaseDiff',
     async (
       _,

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -567,6 +567,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   }) => ipcRenderer.invoke('github:createPullRequestWorktree', args),
   githubGetPullRequestBaseDiff: (args: { worktreePath: string; prNumber: number }) =>
     ipcRenderer.invoke('github:getPullRequestBaseDiff', args),
+  githubGetPullRequestDetails: (args: { projectPath: string; prNumber: number }) =>
+    ipcRenderer.invoke('github:getPullRequestDetails', args),
   githubLogout: () => ipcRenderer.invoke('github:logout'),
   githubCheckCLIInstalled: () => ipcRenderer.invoke('github:checkCLIInstalled'),
   githubInstallCLI: () => ipcRenderer.invoke('github:installCLI'),
@@ -1297,6 +1299,17 @@ export interface ElectronAPI {
     baseBranch?: string;
     headBranch?: string;
     prUrl?: string;
+    error?: string;
+  }>;
+  githubGetPullRequestDetails: (args: { projectPath: string; prNumber: number }) => Promise<{
+    success: boolean;
+    pr?: {
+      baseRefName: string;
+      headRefName: string;
+      title: string;
+      number: number;
+      url: string;
+    };
     error?: string;
   }>;
   githubLogout: () => Promise<void>;

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -31,9 +31,11 @@ import {
 } from '../lib/taskNames';
 import BranchSelect, { pickDefaultBranch } from './BranchSelect';
 import { generateTaskNameFromContext } from '../lib/branchNameGenerator';
-import type { Project } from '../types/app';
+import type { Project, Task } from '../types/app';
 import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
 import { useTaskManagementContext } from '../contexts/TaskManagementContext';
+import { parsePrInput } from '../lib/parsePrInput';
+import { useToast } from '../hooks/use-toast';
 import { rpc } from '@/lib/rpc';
 import { useFeatureFlag } from '../hooks/useFeatureFlag';
 
@@ -143,7 +145,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
     isLoadingBranches,
     refreshBranches,
   } = useProjectManagementContext();
-  const { linkedGithubIssueMap } = useTaskManagementContext();
+  const { linkedGithubIssueMap, handleOpenExternalTask } = useTaskManagementContext();
 
   const workspaceProviderEnabled = useFeatureFlag('workspace-provider');
   const project = initialProject ?? selectedProject;
@@ -157,6 +159,24 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
   const [touched, setTouched] = useState(false);
   const [isFocused, setIsFocused] = useState(false);
   const [isCreating, setIsCreating] = useState(false);
+
+  // PR mode state
+  type TaskMode = 'branch' | 'pr';
+  const [mode, setMode] = useState<TaskMode>('branch');
+  const [prInput, setPrInput] = useState('');
+  const [prDetails, setPrDetails] = useState<{
+    baseRefName: string;
+    headRefName: string;
+    title: string;
+    number: number;
+    url: string;
+  } | null>(null);
+  const [prLoading, setPrLoading] = useState(false);
+  const [prError, setPrError] = useState<string | null>(null);
+  const { toast } = useToast();
+
+  // Determine if PR mode is available (GitHub must be connected)
+  const isGithubConnected = project?.githubInfo?.connected === true;
 
   // Advanced settings state
   const [initialPrompt, setInitialPrompt] = useState('');
@@ -200,6 +220,47 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
       }
     })();
   }, [projectPath, workspaceProviderEnabled]);
+
+  // Fetch PR details on debounced valid input
+  useEffect(() => {
+    if (mode !== 'pr') return;
+
+    const prNumber = parsePrInput(prInput);
+    if (!prNumber) {
+      setPrDetails(null);
+      setPrError(null);
+      return;
+    }
+
+    setPrLoading(true);
+    setPrError(null);
+
+    const timer = setTimeout(async () => {
+      try {
+        const result = await window.electronAPI.githubGetPullRequestDetails({
+          projectPath: projectPath!,
+          prNumber,
+        });
+        if (result.success && result.pr) {
+          setPrDetails(result.pr);
+          setPrError(null);
+        } else {
+          setPrDetails(null);
+          setPrError(result.error || `PR #${prNumber} not found`);
+        }
+      } catch (err) {
+        setPrDetails(null);
+        setPrError(err instanceof Error ? err.message : 'Failed to fetch PR details');
+      } finally {
+        setPrLoading(false);
+      }
+    }, 500);
+
+    return () => {
+      clearTimeout(timer);
+      setPrLoading(false);
+    };
+  }, [mode, prInput, projectPath]);
 
   // Branch selection state - sync with defaultBranch unless user manually changed it
   const [selectedBranch, setSelectedBranch] = useState(defaultBranch);
@@ -465,10 +526,76 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
     }
   };
 
-  const handleOpenAutoFocus = useCallback((event: Event) => {
-    event.preventDefault();
-    taskNameInputRef.current?.focus({ preventScroll: true });
-  }, []);
+  const handlePrSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+
+    if (!prDetails || !project) return;
+
+    setIsCreating(true);
+    try {
+      const result = await window.electronAPI.githubCreatePullRequestWorktree({
+        projectPath: project.path,
+        projectId: project.id,
+        prNumber: prDetails.number,
+        prTitle: prDetails.title,
+      });
+
+      if (result.success && result.task) {
+        const task: Task = {
+          id: result.task.id,
+          projectId: result.task.projectId,
+          name: result.task.name,
+          branch: result.task.branch,
+          path: result.task.path,
+          status: result.task.status as Task['status'],
+          agentId: result.task.agentId,
+          useWorktree: true,
+          metadata: result.task.metadata,
+        };
+        handleOpenExternalTask(task);
+        onClose();
+      } else if (result.success && result.worktree) {
+        const task: Task = {
+          id: result.worktree.id || crypto.randomUUID(),
+          projectId: project.id,
+          name: result.taskName || `PR #${prDetails.number}`,
+          branch: result.branchName || '',
+          path: result.worktree.path || '',
+          status: 'active',
+          useWorktree: true,
+          metadata: { prNumber: prDetails.number, prTitle: prDetails.title },
+        };
+        handleOpenExternalTask(task);
+        onClose();
+      } else {
+        toast({
+          title: 'Failed to create review task',
+          description: result.error || 'Unknown error',
+          variant: 'destructive',
+        });
+      }
+    } catch (err) {
+      toast({
+        title: 'Failed to create review task',
+        description: err instanceof Error ? err.message : String(err),
+        variant: 'destructive',
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  const handleOpenAutoFocus = useCallback(
+    (event: Event) => {
+      event.preventDefault();
+      // In PR mode, the autoFocus on the PR input handles focus.
+      // In branch mode, focus the task name input.
+      if (mode !== 'pr') {
+        taskNameInputRef.current?.focus({ preventScroll: true });
+      }
+    },
+    [mode]
+  );
 
   return (
     <DialogContent
@@ -488,103 +615,175 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
         </DialogDescription>
         <div className="space-y-1 pt-1">
           <p className="text-sm font-medium text-foreground">{projectName}</p>
-          <div className="flex items-center gap-1.5">
-            <span className="text-xs text-muted-foreground">from</span>
-            {branchOptions.length > 0 ? (
-              <BranchSelect
-                value={selectedBranch}
-                onValueChange={handleBranchChange}
-                options={branchOptions}
-                isLoading={isLoadingBranches}
-                variant="ghost"
-              />
-            ) : (
-              <span className="text-xs text-muted-foreground">
-                {isLoadingBranches ? 'Loading...' : selectedBranch || defaultBranch}
-              </span>
-            )}
-          </div>
+
+          {/* Mode toggle — only show "From PR" when GitHub is connected */}
+          {isGithubConnected && (
+            <div className="flex gap-1 rounded-md bg-muted p-0.5">
+              <button
+                type="button"
+                className={`flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors ${
+                  mode === 'branch'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setMode('branch')}
+              >
+                New branch
+              </button>
+              <button
+                type="button"
+                className={`flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors ${
+                  mode === 'pr'
+                    ? 'bg-background text-foreground shadow-sm'
+                    : 'text-muted-foreground hover:text-foreground'
+                }`}
+                onClick={() => setMode('pr')}
+              >
+                From PR
+              </button>
+            </div>
+          )}
+
+          {mode === 'branch' && (
+            <div className="flex items-center gap-1.5">
+              <span className="text-xs text-muted-foreground">from</span>
+              {branchOptions.length > 0 ? (
+                <BranchSelect
+                  value={selectedBranch}
+                  onValueChange={handleBranchChange}
+                  options={branchOptions}
+                  isLoading={isLoadingBranches}
+                  variant="ghost"
+                />
+              ) : (
+                <span className="text-xs text-muted-foreground">
+                  {isLoadingBranches ? 'Loading...' : selectedBranch || defaultBranch}
+                </span>
+              )}
+            </div>
+          )}
         </div>
       </DialogHeader>
 
-      <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+      <form
+        onSubmit={mode === 'pr' ? handlePrSubmit : handleSubmit}
+        className="flex min-h-0 flex-1 flex-col"
+      >
         <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-4">
-          <div>
-            <Label htmlFor="task-name" className="mb-2 block">
-              Task name (optional)
-            </Label>
-            <SlugInput
-              ref={taskNameInputRef}
-              id="task-name"
-              value={taskName}
-              onChange={handleNameChange}
-              onFocus={() => setIsFocused(true)}
-              onBlur={() => {
-                setTouched(true);
-                setIsFocused(false);
-              }}
-              placeholder="refactor-api-routes"
-              maxLength={MAX_TASK_NAME_LENGTH}
-              className={`w-full ${touched && error && !isFocused ? 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive' : ''}`}
-              aria-invalid={touched && !!error && !isFocused}
-            />
-          </div>
+          {mode === 'pr' ? (
+            /* -- PR mode input -- */
+            <div>
+              <Label htmlFor="pr-input" className="mb-2 block">
+                Pull request number or URL
+              </Label>
+              <input
+                id="pr-input"
+                type="text"
+                value={prInput}
+                onChange={(e) => setPrInput(e.target.value)}
+                placeholder="1603 or https://github.com/org/repo/pull/1603"
+                className="flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                autoFocus
+              />
+              {prLoading && (
+                <p className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                  <Spinner size="sm" />
+                  Looking up PR...
+                </p>
+              )}
+              {prError && <p className="mt-2 text-xs text-destructive">{prError}</p>}
+              {prDetails && !prLoading && (
+                <p className="mt-2 text-xs text-muted-foreground">
+                  <span className="font-medium text-foreground">PR #{prDetails.number}:</span>{' '}
+                  {prDetails.title}
+                </p>
+              )}
+            </div>
+          ) : (
+            /* -- Normal branch mode input -- */
+            <div>
+              <Label htmlFor="task-name" className="mb-2 block">
+                Task name (optional)
+              </Label>
+              <SlugInput
+                ref={taskNameInputRef}
+                id="task-name"
+                value={taskName}
+                onChange={handleNameChange}
+                onFocus={() => setIsFocused(true)}
+                onBlur={() => {
+                  setTouched(true);
+                  setIsFocused(false);
+                }}
+                placeholder="refactor-api-routes"
+                maxLength={MAX_TASK_NAME_LENGTH}
+                className={`w-full ${touched && error && !isFocused ? 'border-destructive focus-visible:border-destructive focus-visible:ring-destructive' : ''}`}
+                aria-invalid={touched && !!error && !isFocused}
+              />
+            </div>
+          )}
 
           <div className="flex items-center gap-4">
             <Label className="shrink-0">Agent</Label>
             <MultiAgentDropdown agentRuns={agentRuns} onChange={setAgentRuns} />
           </div>
 
-          <TaskAdvancedSettings
-            isOpen={true}
-            projectPath={projectPath}
-            useWorktree={useWorktree}
-            onUseWorktreeChange={setUseWorktree}
-            useRemoteWorkspace={useRemoteWorkspace}
-            onUseRemoteWorkspaceChange={setUseRemoteWorkspace}
-            hasWorkspaceProvider={!!workspaceProviderConfig}
-            autoApprove={autoApprove}
-            onAutoApproveChange={setAutoApprove}
-            hasAutoApproveSupport={hasAutoApproveSupport}
-            initialPrompt={initialPrompt}
-            onInitialPromptChange={setInitialPrompt}
-            hasInitialPromptSupport={hasInitialPromptSupport}
-            selectedLinearIssue={selectedLinearIssue}
-            onLinearIssueChange={setSelectedLinearIssue}
-            isLinearConnected={integrations.isLinearConnected}
-            onLinearConnect={integrations.handleLinearConnect}
-            selectedGithubIssue={selectedGithubIssue}
-            onGithubIssueChange={setSelectedGithubIssue}
-            linkedGithubIssueMap={linkedGithubIssueMap}
-            isGithubConnected={integrations.isGithubConnected}
-            onGithubConnect={integrations.handleGithubConnect}
-            githubLoading={integrations.githubLoading}
-            githubInstalled={integrations.githubInstalled}
-            selectedJiraIssue={selectedJiraIssue}
-            onJiraIssueChange={setSelectedJiraIssue}
-            isJiraConnected={integrations.isJiraConnected}
-            onJiraConnect={integrations.handleJiraConnect}
-            selectedGitlabIssue={selectedGitlabIssue}
-            onGitlabIssueChange={setSelectedGitlabIssue}
-            isGitlabConnected={integrations.isGitlabConnected}
-            onGitlabConnect={integrations.handleGitlabConnect}
-            selectedPlainThread={selectedPlainThread}
-            onPlainThreadChange={setSelectedPlainThread}
-            isPlainConnected={integrations.isPlainConnected}
-            onPlainConnect={integrations.handlePlainConnect}
-            selectedForgejoIssue={selectedForgejoIssue}
-            onForgejoIssueChange={setSelectedForgejoIssue}
-            isForgejoConnected={integrations.isForgejoConnected}
-            onForgejoConnect={integrations.handleForgejoConnect}
-          />
+          {mode === 'branch' && (
+            <TaskAdvancedSettings
+              isOpen={true}
+              projectPath={projectPath}
+              useWorktree={useWorktree}
+              onUseWorktreeChange={setUseWorktree}
+              useRemoteWorkspace={useRemoteWorkspace}
+              onUseRemoteWorkspaceChange={setUseRemoteWorkspace}
+              hasWorkspaceProvider={!!workspaceProviderConfig}
+              autoApprove={autoApprove}
+              onAutoApproveChange={setAutoApprove}
+              hasAutoApproveSupport={hasAutoApproveSupport}
+              initialPrompt={initialPrompt}
+              onInitialPromptChange={setInitialPrompt}
+              hasInitialPromptSupport={hasInitialPromptSupport}
+              selectedLinearIssue={selectedLinearIssue}
+              onLinearIssueChange={setSelectedLinearIssue}
+              isLinearConnected={integrations.isLinearConnected}
+              onLinearConnect={integrations.handleLinearConnect}
+              selectedGithubIssue={selectedGithubIssue}
+              onGithubIssueChange={setSelectedGithubIssue}
+              linkedGithubIssueMap={linkedGithubIssueMap}
+              isGithubConnected={integrations.isGithubConnected}
+              onGithubConnect={integrations.handleGithubConnect}
+              githubLoading={integrations.githubLoading}
+              githubInstalled={integrations.githubInstalled}
+              selectedJiraIssue={selectedJiraIssue}
+              onJiraIssueChange={setSelectedJiraIssue}
+              isJiraConnected={integrations.isJiraConnected}
+              onJiraConnect={integrations.handleJiraConnect}
+              selectedGitlabIssue={selectedGitlabIssue}
+              onGitlabIssueChange={setSelectedGitlabIssue}
+              isGitlabConnected={integrations.isGitlabConnected}
+              onGitlabConnect={integrations.handleGitlabConnect}
+              selectedPlainThread={selectedPlainThread}
+              onPlainThreadChange={setSelectedPlainThread}
+              isPlainConnected={integrations.isPlainConnected}
+              onPlainConnect={integrations.handlePlainConnect}
+              selectedForgejoIssue={selectedForgejoIssue}
+              onForgejoIssueChange={setSelectedForgejoIssue}
+              isForgejoConnected={integrations.isForgejoConnected}
+              onForgejoConnect={integrations.handleForgejoConnect}
+            />
+          )}
         </div>
 
         <DialogFooter className="shrink-0 px-6 py-4">
-          <Button type="submit" disabled={!!error || isCreating} aria-busy={isCreating}>
+          <Button
+            type="submit"
+            disabled={mode === 'pr' ? !prDetails || prLoading || isCreating : !!error || isCreating}
+            aria-busy={isCreating}
+          >
             {isCreating ? (
               <>
                 <Spinner size="sm" className="mr-2" />
-                Creating…
+                Creating...
               </>
             ) : (
               'Create'

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -161,8 +161,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
   const [isCreating, setIsCreating] = useState(false);
 
   // PR mode state
-  type TaskMode = 'branch' | 'pr';
-  const [mode, setMode] = useState<TaskMode>('branch');
+  const [mode, setMode] = useState<'branch' | 'pr'>('branch');
   const [prInput, setPrInput] = useState('');
   const [prDetails, setPrDetails] = useState<{
     baseRefName: string;
@@ -223,7 +222,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
 
   // Fetch PR details on debounced valid input
   useEffect(() => {
-    if (mode !== 'pr') return;
+    if (mode !== 'pr' || !projectPath) return;
 
     const prNumber = parsePrInput(prInput);
     if (!prNumber) {
@@ -238,7 +237,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
       setPrLoading(true);
       try {
         const result = await window.electronAPI.githubGetPullRequestDetails({
-          projectPath: projectPath!,
+          projectPath,
           prNumber,
         });
         if (result.success && result.pr) {
@@ -621,6 +620,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
             <div className="flex gap-1 rounded-md bg-muted p-0.5">
               <button
                 type="button"
+                aria-pressed={mode === 'branch'}
                 className={`flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors ${
                   mode === 'branch'
                     ? 'bg-background text-foreground shadow-sm'
@@ -632,6 +632,7 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
               </button>
               <button
                 type="button"
+                aria-pressed={mode === 'pr'}
                 className={`flex-1 rounded-sm px-3 py-1 text-xs font-medium transition-colors ${
                   mode === 'pr'
                     ? 'bg-background text-foreground shadow-sm'

--- a/src/renderer/components/TaskModal.tsx
+++ b/src/renderer/components/TaskModal.tsx
@@ -232,10 +232,10 @@ const TaskModal: React.FC<TaskModalProps> = ({ onClose, initialProject, onCreate
       return;
     }
 
-    setPrLoading(true);
     setPrError(null);
 
     const timer = setTimeout(async () => {
+      setPrLoading(true);
       try {
         const result = await window.electronAPI.githubGetPullRequestDetails({
           projectPath: projectPath!,

--- a/src/renderer/lib/parsePrInput.ts
+++ b/src/renderer/lib/parsePrInput.ts
@@ -1,0 +1,26 @@
+/**
+ * Extract a PR number from user input.
+ * Accepts a plain number (e.g. "1603", "#1603") or a GitHub PR URL
+ * (e.g. "https://github.com/org/repo/pull/1603").
+ * Returns the PR number or null if the input is not valid.
+ */
+export function parsePrInput(input: string): number | null {
+  const trimmed = input.trim();
+  if (!trimmed) return null;
+
+  // Try plain number (with optional leading #)
+  const numMatch = trimmed.match(/^#?(\d+)$/);
+  if (numMatch) {
+    const n = Number.parseInt(numMatch[1], 10);
+    return n > 0 ? n : null;
+  }
+
+  // Try GitHub PR URL: https://<host>/<owner>/<repo>/pull/<number>[/...]
+  const urlMatch = trimmed.match(/^https?:\/\/[^/]+\/[^/]+\/[^/]+\/pull\/(\d+)/);
+  if (urlMatch) {
+    const n = Number.parseInt(urlMatch[1], 10);
+    return n > 0 ? n : null;
+  }
+
+  return null;
+}

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -953,6 +953,17 @@ declare global {
         prUrl?: string;
         error?: string;
       }>;
+      githubGetPullRequestDetails: (args: { projectPath: string; prNumber: number }) => Promise<{
+        success: boolean;
+        pr?: {
+          baseRefName: string;
+          headRefName: string;
+          title: string;
+          number: number;
+          url: string;
+        };
+        error?: string;
+      }>;
       githubLogout: () => Promise<void>;
       // Linear integration
       linearCheckConnection?: () => Promise<{

--- a/src/renderer/types/global.d.ts
+++ b/src/renderer/types/global.d.ts
@@ -424,6 +424,17 @@ declare global {
         };
         error?: string;
       }>;
+      githubGetPullRequestDetails: (args: { projectPath: string; prNumber: number }) => Promise<{
+        success: boolean;
+        pr?: {
+          baseRefName: string;
+          headRefName: string;
+          title: string;
+          number: number;
+          url: string;
+        };
+        error?: string;
+      }>;
       githubLogout: () => Promise<void>;
       linearCheckConnection?: () => Promise<{
         connected: boolean;

--- a/src/test/renderer/parsePrInput.test.ts
+++ b/src/test/renderer/parsePrInput.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { parsePrInput } from '../../renderer/lib/parsePrInput';
+
+describe('parsePrInput', () => {
+  it('parses a plain number string', () => {
+    expect(parsePrInput('1603')).toBe(1603);
+  });
+
+  it('parses a number with whitespace', () => {
+    expect(parsePrInput('  1603  ')).toBe(1603);
+  });
+
+  it('parses a number with leading hash', () => {
+    expect(parsePrInput('#1603')).toBe(1603);
+  });
+
+  it('parses a GitHub PR URL', () => {
+    expect(parsePrInput('https://github.com/org/repo/pull/1603')).toBe(1603);
+  });
+
+  it('parses a GitHub PR URL with trailing slash', () => {
+    expect(parsePrInput('https://github.com/org/repo/pull/1603/')).toBe(1603);
+  });
+
+  it('parses a GitHub PR URL with extra path segments (files, commits)', () => {
+    expect(parsePrInput('https://github.com/org/repo/pull/1603/files')).toBe(1603);
+    expect(parsePrInput('https://github.com/org/repo/pull/1603/commits')).toBe(1603);
+  });
+
+  it('parses a GitHub Enterprise URL', () => {
+    expect(parsePrInput('https://ghe.spotify.net/org/repo/pull/42')).toBe(42);
+  });
+
+  it('returns null for empty string', () => {
+    expect(parsePrInput('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only', () => {
+    expect(parsePrInput('   ')).toBeNull();
+  });
+
+  it('returns null for non-numeric non-URL input', () => {
+    expect(parsePrInput('fix-login-bug')).toBeNull();
+  });
+
+  it('returns null for zero', () => {
+    expect(parsePrInput('0')).toBeNull();
+  });
+
+  it('returns null for negative numbers', () => {
+    expect(parsePrInput('-5')).toBeNull();
+  });
+
+  it('returns null for a URL that is not a PR', () => {
+    expect(parsePrInput('https://github.com/org/repo/issues/1603')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary

Adds a "From PR" mode to the TaskModal, allowing users to enter a PR number or GitHub URL and check out its branch in a new worktree — primarily for code review.

When a project has GitHub connected, the task creation modal shows a segmented toggle: **"New branch"** (existing flow, unchanged) and **"From PR"** (new). The PR path fetches details for preview, then uses the existing `github:createPullRequestWorktree` IPC handler to create the worktree and task in one step.

## What Changed

**New utility** (`src/renderer/lib/parsePrInput.ts`)
- Extracts a PR number from raw input (`1603`, `#1603`) or a full GitHub PR URL
- Handles github.com and GitHub Enterprise URLs
- 13 unit tests

**New IPC handler** (`src/main/ipc/githubIpc.ts`)
- `github:getPullRequestDetails` — thin wrapper exposing existing `GitHubService.getPullRequestDetails()` to the renderer for live PR preview
- Preload binding and type declarations added

**TaskModal changes** (`src/renderer/components/TaskModal.tsx`)
- Mode toggle (segmented control) in DialogHeader, only visible when GitHub is connected
- PR input with debounced (500ms) fetch of PR details and inline preview
- Alternate submit path via existing `githubCreatePullRequestWorktree` IPC
- `aria-pressed` on toggle buttons for accessibility
- Existing "New branch" flow completely preserved

## Behavioral Impact
- Breaking changes: No
- Migrations: No
- New IPC channels: `github:getPullRequestDetails`

## Testing
- [x] 790/790 tests passing (`pnpm exec vitest run`)
- [x] New `parsePrInput` tests: 13/13 passing
- [x] Type-check clean (only pre-existing `SiCss3` error in FileIcons.tsx)
- [x] Lint clean (0 errors)

## Review Guidance
Start here: `src/renderer/components/TaskModal.tsx` — the mode toggle and PR input UI
Then: `src/main/ipc/githubIpc.ts` — the new IPC handler (~25 lines)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Create tasks directly from GitHub pull requests by entering a PR number or URL; the app automatically fetches PR details.
  * PR mode toggle in task creation modal (visible when GitHub is connected).

* **Tests**
  * Added comprehensive test coverage for PR input parsing and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->