### PR TITLE
feat(copilot): preserve terminal shortcut focus

### DIFF
--- a/src/renderer/components/TerminalPane.tsx
+++ b/src/renderer/components/TerminalPane.tsx
@@ -309,6 +309,7 @@ const TerminalPaneComponent = forwardRef<TerminalPaneHandle, Props>(
         <div
           ref={containerRef}
           data-terminal-container
+          data-terminal-provider-id={providerId}
           style={{
             width: '100%',
             height: '100%',

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -1,4 +1,10 @@
 import { useEffect, useMemo } from 'react';
+import {
+  getProvider,
+  isValidProviderId,
+  type ProviderId,
+  type ProviderReservedShortcut,
+} from '@shared/providers/registry';
 import type {
   ShortcutConfig,
   GlobalShortcutHandlers,
@@ -96,6 +102,27 @@ export function normalizeShortcutKey(value: string): string {
   if (trimmed.length === 1) return trimmed.toLowerCase();
   return trimmed;
 }
+
+type KeyboardShortcutEvent = Pick<
+  KeyboardEvent,
+  'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'
+>;
+
+type ShortcutTarget = {
+  getAttribute?: (name: string) => string | null | undefined;
+  closest?: (selector: string) => ShortcutTarget | null;
+  querySelector?: (selector: string) => ShortcutTarget | null;
+  classList?: {
+    contains?: (value: string) => boolean;
+  };
+  tagName?: string;
+  isContentEditable?: boolean;
+};
+
+const TERMINAL_PROVIDER_ID_ATTRIBUTE = 'data-terminal-provider-id';
+const TERMINAL_PROVIDER_SELECTOR = `[${TERMINAL_PROVIDER_ID_ATTRIBUTE}]`;
+const TERMINAL_HOST_ATTRIBUTE = 'data-terminal-host';
+const XTERM_HELPER_TEXTAREA_SELECTOR = '.xterm-helper-textarea';
 
 export const APP_SHORTCUTS: Record<string, AppShortcut> = {
   COMMAND_PALETTE: {
@@ -281,7 +308,7 @@ export function hasShortcutConflict(shortcut1: ShortcutConfig, shortcut2: Shortc
 }
 
 export function getAgentTabSelectionIndex(
-  event: Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+  event: KeyboardShortcutEvent,
   isMac = isMacPlatform
 ): number | null {
   const hasCommandModifier =
@@ -298,7 +325,11 @@ export function getAgentTabSelectionIndex(
   return Number(key) - 1;
 }
 
-function matchesModifier(modifier: ShortcutModifier | undefined, event: KeyboardEvent): boolean {
+function matchesModifier(
+  modifier: ShortcutModifier | ProviderReservedShortcut['modifier'] | undefined,
+  event: Pick<KeyboardEvent, 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'>,
+  isMac = isMacPlatform
+): boolean {
   if (!modifier) {
     return !event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey;
   }
@@ -308,9 +339,7 @@ function matchesModifier(modifier: ShortcutModifier | undefined, event: Keyboard
       // On macOS require the Command key; on other platforms allow Ctrl as the Command equivalent
       // Also ensure shift is NOT pressed (to distinguish from cmd+shift)
       return (
-        (isMacPlatform ? event.metaKey : event.metaKey || event.ctrlKey) &&
-        !event.shiftKey &&
-        !event.altKey
+        (isMac ? event.metaKey : event.metaKey || event.ctrlKey) && !event.shiftKey && !event.altKey
       );
     case 'ctrl':
       // Require the Control key without treating Command as equivalent
@@ -323,15 +352,97 @@ function matchesModifier(modifier: ShortcutModifier | undefined, event: Keyboard
     case 'cmd+shift':
       // Compound modifier: Command + Shift
       return (
-        (isMacPlatform ? event.metaKey : event.metaKey || event.ctrlKey) &&
-        event.shiftKey &&
-        !event.altKey
+        (isMac ? event.metaKey : event.metaKey || event.ctrlKey) && event.shiftKey && !event.altKey
       );
     case 'ctrl+shift':
       return event.ctrlKey && event.shiftKey && !event.metaKey && !event.altKey;
     default:
       return false;
   }
+}
+
+function getTargetAttribute(
+  target: ShortcutTarget | null | undefined,
+  name: string
+): string | null {
+  return target?.getAttribute?.(name) ?? null;
+}
+
+function readProviderIdFromTarget(target: ShortcutTarget | null | undefined): ProviderId | null {
+  const ownProviderId = getTargetAttribute(target, TERMINAL_PROVIDER_ID_ATTRIBUTE);
+  if (ownProviderId && isValidProviderId(ownProviderId)) {
+    return ownProviderId;
+  }
+
+  const providerTarget = target?.closest?.(TERMINAL_PROVIDER_SELECTOR) ?? null;
+  const closestProviderId = getTargetAttribute(providerTarget, TERMINAL_PROVIDER_ID_ATTRIBUTE);
+  return closestProviderId && isValidProviderId(closestProviderId) ? closestProviderId : null;
+}
+
+function getDefaultActiveElement(): ShortcutTarget | null {
+  return typeof document !== 'undefined'
+    ? ((document.activeElement as ShortcutTarget | null) ?? null)
+    : null;
+}
+
+function isTerminalHostTarget(target: ShortcutTarget | null | undefined): boolean {
+  return getTargetAttribute(target, TERMINAL_HOST_ATTRIBUTE) === 'true';
+}
+
+function matchesReservedShortcut(
+  reservedShortcut: ProviderReservedShortcut,
+  event: KeyboardShortcutEvent,
+  isMac = isMacPlatform
+): boolean {
+  if (reservedShortcut.platform === 'mac' && !isMac) return false;
+  if (reservedShortcut.platform === 'nonMac' && isMac) return false;
+  if (normalizeShortcutKey(event.key) !== normalizeShortcutKey(reservedShortcut.key)) return false;
+  return matchesModifier(reservedShortcut.modifier, event, isMac);
+}
+
+export function getFocusedTerminalProviderId(
+  target: EventTarget | ShortcutTarget | null,
+  activeElement: ShortcutTarget | null = getDefaultActiveElement()
+): ProviderId | null {
+  const targetNode = target as ShortcutTarget | null;
+  const focusedProviderId = readProviderIdFromTarget(targetNode);
+  if (focusedProviderId) {
+    return focusedProviderId;
+  }
+
+  if (!isTerminalHostTarget(targetNode)) {
+    return null;
+  }
+
+  const activeProviderId = readProviderIdFromTarget(activeElement);
+  if (activeProviderId) {
+    return activeProviderId;
+  }
+
+  return readProviderIdFromTarget(
+    targetNode?.querySelector?.(XTERM_HELPER_TEXTAREA_SELECTOR) ?? null
+  );
+}
+
+export function focusedTerminalProviderReservesShortcut(
+  target: EventTarget | ShortcutTarget | null,
+  event: KeyboardShortcutEvent,
+  activeElement: ShortcutTarget | null = getDefaultActiveElement(),
+  isMac = isMacPlatform
+): boolean {
+  const providerId = getFocusedTerminalProviderId(target, activeElement);
+  if (!providerId) {
+    return false;
+  }
+
+  const reservedShortcuts = getProvider(providerId)?.terminalReservedShortcuts;
+  if (!reservedShortcuts?.length) {
+    return false;
+  }
+
+  return reservedShortcuts.some((reservedShortcut) =>
+    matchesReservedShortcut(reservedShortcut, event, isMac)
+  );
 }
 
 /**
@@ -498,15 +609,16 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
       // method reports an unexpected modifier state during normal typing.
       // The command palette toggle is exempt so it remains reachable from
       // any context.
-      const target = event.target as HTMLElement;
+      const target = event.target as ShortcutTarget | null;
       // Exclude xterm's hidden textarea from the editable-target check —
       // it captures keyboard input but is not a user-editable field.
-      const isXtermTextarea = target?.classList?.contains('xterm-helper-textarea');
+      const isXtermTextarea = target?.classList?.contains?.('xterm-helper-textarea');
       const isEditableTarget =
         !isXtermTextarea &&
         (target?.tagName === 'INPUT' ||
           target?.tagName === 'TEXTAREA' ||
           target?.isContentEditable);
+      const shouldBypassTerminalShortcut = focusedTerminalProviderReservesShortcut(target, event);
 
       for (const shortcut of shortcuts) {
         const shortcutKey = normalizeShortcutKey(shortcut.config.key);
@@ -516,6 +628,8 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
 
         // Check modifier requirements precisely (e.g., Cmd ≠ Ctrl on macOS)
         if (!matchesModifier(shortcut.config.modifier, event)) continue;
+
+        if (shouldBypassTerminalShortcut) continue;
 
         // Skip non-command-palette shortcuts when typing in an input
         if (isEditableTarget && !shortcut.isCommandPalette && !shortcut.allowInInput) continue;

--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -46,6 +46,7 @@ const PANEL_RESIZE_DRAGGING_EVENT = 'emdash:panel-resize-dragging';
 const MAX_TERMINAL_WRITE_CHARS_PER_SLICE = 16_384;
 const SLOW_INPUT_HANDLER_MS = 16;
 const SLOW_INPUT_LOG_THROTTLE_MS = 2_000;
+const TERMINAL_PROVIDER_ID_ATTRIBUTE = 'data-terminal-provider-id';
 const IS_MAC_PLATFORM =
   typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
 
@@ -168,6 +169,9 @@ export class TerminalSessionManager {
 
     this.container = document.createElement('div');
     this.container.className = 'terminal-session-root';
+    if (options.providerId) {
+      this.container.setAttribute(TERMINAL_PROVIDER_ID_ATTRIBUTE, options.providerId);
+    }
     Object.assign(this.container.style, {
       width: '100%',
       height: '100%',

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -26,6 +26,21 @@ export const PROVIDER_IDS = [
 
 export type ProviderId = (typeof PROVIDER_IDS)[number];
 
+export type ProviderShortcutModifier =
+  | 'cmd'
+  | 'ctrl'
+  | 'shift'
+  | 'alt'
+  | 'option'
+  | 'cmd+shift'
+  | 'ctrl+shift';
+
+export type ProviderReservedShortcut = {
+  key: string;
+  modifier: ProviderShortcutModifier;
+  platform?: 'mac' | 'nonMac';
+};
+
 export type ProviderDefinition = {
   id: ProviderId;
   name: string;
@@ -56,6 +71,7 @@ export type ProviderDefinition = {
   planActivateCommand?: string;
   autoStartCommand?: string;
   icon?: string;
+  terminalReservedShortcuts?: ProviderReservedShortcut[];
   terminalOnly?: boolean;
 };
 
@@ -197,6 +213,10 @@ export const PROVIDERS: ProviderDefinition[] = [
     autoApproveFlag: '--allow-all-tools',
     initialPromptFlag: '-i',
     icon: 'gh-copilot.svg',
+    terminalReservedShortcuts: [
+      { key: 'e', modifier: 'cmd', platform: 'mac' },
+      { key: 'e', modifier: 'ctrl', platform: 'nonMac' },
+    ],
     terminalOnly: true,
   },
   {

--- a/src/test/renderer/useKeyboardShortcuts.test.ts
+++ b/src/test/renderer/useKeyboardShortcuts.test.ts
@@ -1,5 +1,67 @@
-import { describe, expect, it } from 'vitest';
-import { getAgentTabSelectionIndex } from '../../renderer/hooks/useKeyboardShortcuts';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import {
+  focusedTerminalProviderReservesShortcut,
+  getAgentTabSelectionIndex,
+  getFocusedTerminalProviderId,
+} from '../../renderer/hooks/useKeyboardShortcuts';
+
+type MockNode = {
+  getAttribute: (name: string) => string | null;
+  closest: (selector: string) => MockNode | null;
+  querySelector: (selector: string) => MockNode | null;
+  classList: {
+    contains: (value: string) => boolean;
+  };
+};
+
+function createNode({
+  attrs = {},
+  classes = [],
+  closestMap = {},
+  querySelectorMap = {},
+}: {
+  attrs?: Record<string, string>;
+  classes?: string[];
+  closestMap?: Record<string, MockNode | null>;
+  querySelectorMap?: Record<string, MockNode | null>;
+} = {}): MockNode {
+  return {
+    getAttribute: (name: string) => attrs[name] ?? null,
+    closest: (selector: string) => closestMap[selector] ?? null,
+    querySelector: (selector: string) => querySelectorMap[selector] ?? null,
+    classList: {
+      contains: (value: string) => classes.includes(value),
+    },
+  };
+}
+
+function createKeyEvent({
+  key,
+  metaKey = false,
+  ctrlKey = false,
+  altKey = false,
+  shiftKey = false,
+}: {
+  key: string;
+  metaKey?: boolean;
+  ctrlKey?: boolean;
+  altKey?: boolean;
+  shiftKey?: boolean;
+}): Pick<KeyboardEvent, 'key' | 'metaKey' | 'ctrlKey' | 'altKey' | 'shiftKey'> {
+  return {
+    key,
+    metaKey,
+    ctrlKey,
+    altKey,
+    shiftKey,
+  };
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+  vi.resetModules();
+  vi.doUnmock('react');
+});
 
 describe('getAgentTabSelectionIndex', () => {
   it('maps Cmd/Ctrl+1 through Cmd/Ctrl+9 to zero-based tab indexes', () => {
@@ -79,5 +141,224 @@ describe('getAgentTabSelectionIndex', () => {
         shiftKey: false,
       } as KeyboardEvent)
     ).toBeNull();
+  });
+});
+
+describe('getFocusedTerminalProviderId', () => {
+  it('recovers the provider from the focused xterm helper textarea', () => {
+    const providerRoot = createNode({ attrs: { 'data-terminal-provider-id': 'copilot' } });
+    const helperTextarea = createNode({
+      classes: ['xterm-helper-textarea'],
+      closestMap: { '[data-terminal-provider-id]': providerRoot },
+    });
+
+    expect(getFocusedTerminalProviderId(helperTextarea as unknown as EventTarget, null)).toBe(
+      'copilot'
+    );
+  });
+
+  it('falls back to the terminal host when the host is the event target', () => {
+    const providerRoot = createNode({ attrs: { 'data-terminal-provider-id': 'copilot' } });
+    const helperTextarea = createNode({
+      classes: ['xterm-helper-textarea'],
+      closestMap: { '[data-terminal-provider-id]': providerRoot },
+    });
+    const terminalHost = createNode({
+      attrs: { 'data-terminal-host': 'true' },
+      querySelectorMap: { '.xterm-helper-textarea': helperTextarea },
+    });
+
+    expect(
+      getFocusedTerminalProviderId(
+        terminalHost as unknown as EventTarget,
+        helperTextarea as unknown as MockNode
+      )
+    ).toBe('copilot');
+  });
+});
+
+describe('focusedTerminalProviderReservesShortcut', () => {
+  it('bypasses Cmd+E for GitHub Copilot on macOS', () => {
+    const providerRoot = createNode({ attrs: { 'data-terminal-provider-id': 'copilot' } });
+    const helperTextarea = createNode({
+      classes: ['xterm-helper-textarea'],
+      closestMap: { '[data-terminal-provider-id]': providerRoot },
+    });
+
+    expect(
+      focusedTerminalProviderReservesShortcut(
+        helperTextarea as unknown as EventTarget,
+        createKeyEvent({ key: 'e', metaKey: true }),
+        null,
+        true
+      )
+    ).toBe(true);
+  });
+
+  it('bypasses Ctrl+E for GitHub Copilot on non-mac platforms', () => {
+    const providerRoot = createNode({ attrs: { 'data-terminal-provider-id': 'copilot' } });
+    const helperTextarea = createNode({
+      classes: ['xterm-helper-textarea'],
+      closestMap: { '[data-terminal-provider-id]': providerRoot },
+    });
+    const terminalHost = createNode({
+      attrs: { 'data-terminal-host': 'true' },
+      querySelectorMap: { '.xterm-helper-textarea': helperTextarea },
+    });
+
+    expect(
+      focusedTerminalProviderReservesShortcut(
+        terminalHost as unknown as EventTarget,
+        createKeyEvent({ key: 'e', ctrlKey: true }),
+        helperTextarea as unknown as MockNode,
+        false
+      )
+    ).toBe(true);
+  });
+
+  it('keeps intercepting matching shortcuts for other terminal providers', () => {
+    const providerRoot = createNode({ attrs: { 'data-terminal-provider-id': 'claude' } });
+    const helperTextarea = createNode({
+      classes: ['xterm-helper-textarea'],
+      closestMap: { '[data-terminal-provider-id]': providerRoot },
+    });
+
+    expect(
+      focusedTerminalProviderReservesShortcut(
+        helperTextarea as unknown as EventTarget,
+        createKeyEvent({ key: 'e', metaKey: true }),
+        null,
+        true
+      )
+    ).toBe(false);
+  });
+
+  it('keeps intercepting matching shortcuts outside terminal focus', () => {
+    const plainInput = createNode();
+
+    expect(
+      focusedTerminalProviderReservesShortcut(
+        plainInput as unknown as EventTarget,
+        createKeyEvent({ key: 'e', metaKey: true }),
+        null,
+        true
+      )
+    ).toBe(false);
+  });
+});
+
+describe('useKeyboardShortcuts integration', () => {
+  it('does not intercept the editor shortcut while Copilot terminal focus is active', async () => {
+    const originalWindow = globalThis.window;
+    const originalDocument = globalThis.document;
+    const originalNavigator = globalThis.navigator;
+
+    let cleanup: (() => void) | undefined;
+    let keydownListener: ((event: KeyboardEvent) => void) | null = null;
+    const addEventListener = vi.fn((type: string, listener: EventListenerOrEventListenerObject) => {
+      if (type === 'keydown' && typeof listener === 'function') {
+        keydownListener = listener as (event: KeyboardEvent) => void;
+      }
+    });
+    const removeEventListener = vi.fn();
+
+    const providerRoot = createNode({ attrs: { 'data-terminal-provider-id': 'copilot' } });
+    const helperTextarea = {
+      ...createNode({
+        classes: ['xterm-helper-textarea'],
+        closestMap: { '[data-terminal-provider-id]': providerRoot },
+      }),
+      tagName: 'TEXTAREA',
+      isContentEditable: false,
+    };
+
+    Object.defineProperty(globalThis, 'navigator', {
+      value: { platform: 'Linux x86_64' },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'window', {
+      value: {
+        addEventListener,
+        removeEventListener,
+      },
+      configurable: true,
+    });
+    Object.defineProperty(globalThis, 'document', {
+      value: {
+        activeElement: helperTextarea,
+        querySelector: vi.fn(() => null),
+      },
+      configurable: true,
+    });
+
+    vi.resetModules();
+    vi.doMock('react', () => ({
+      useEffect: (effect: () => void | (() => void)) => {
+        cleanup = effect() ?? undefined;
+      },
+      useMemo: <T>(factory: () => T) => factory(),
+    }));
+
+    try {
+      const { useKeyboardShortcuts } = await import('../../renderer/hooks/useKeyboardShortcuts');
+      const onToggleEditor = vi.fn();
+
+      useKeyboardShortcuts({ onToggleEditor });
+
+      expect(addEventListener).toHaveBeenCalledWith('keydown', expect.any(Function), true);
+      expect(keydownListener).not.toBeNull();
+
+      const event = {
+        key: 'e',
+        metaKey: false,
+        ctrlKey: true,
+        altKey: false,
+        shiftKey: false,
+        target: helperTextarea,
+        defaultPrevented: false,
+        preventDefault: vi.fn(),
+      } as unknown as KeyboardEvent & {
+        defaultPrevented: boolean;
+        preventDefault: () => void;
+      };
+      event.preventDefault = () => {
+        event.defaultPrevented = true;
+      };
+
+      keydownListener!(event);
+
+      expect(event.defaultPrevented).toBe(false);
+      expect(onToggleEditor).not.toHaveBeenCalled();
+
+      cleanup?.();
+      expect(removeEventListener).toHaveBeenCalledWith('keydown', keydownListener, true);
+    } finally {
+      if (originalNavigator === undefined) {
+        delete (globalThis as { navigator?: Navigator }).navigator;
+      } else {
+        Object.defineProperty(globalThis, 'navigator', {
+          value: originalNavigator,
+          configurable: true,
+        });
+      }
+
+      if (originalWindow === undefined) {
+        delete (globalThis as { window?: Window & typeof globalThis }).window;
+      } else {
+        Object.defineProperty(globalThis, 'window', {
+          value: originalWindow,
+          configurable: true,
+        });
+      }
+
+      if (originalDocument === undefined) {
+        delete (globalThis as { document?: Document }).document;
+      } else {
+        Object.defineProperty(globalThis, 'document', {
+          value: originalDocument,
+          configurable: true,
+        });
+      }
+    }
   });
 });


### PR DESCRIPTION
## Summary
- add provider-level terminal-reserved shortcut metadata
- let GitHub Copilot keep `Cmd+E` on macOS and `Ctrl+E` on non-mac when its terminal is focused
- cover the bypass logic with helper tests plus a real keydown-path regression test

Fixes #1509

## Test Plan
- [x] `pnpm exec vitest run src/test/renderer/useKeyboardShortcuts.test.ts`
- [x] `pnpm run type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Terminal providers can now reserve keyboard shortcuts that are bypassed when focus is within their terminal context.
  * The Copilot provider now reserves Cmd+E (Mac) and Ctrl+E (non-Mac) to prevent unintended editor toggles during terminal use.

* **Tests**
  * Added comprehensive test coverage for provider-aware keyboard shortcut handling and terminal context detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->