### PR TITLE
fix(ssh): detect fish prompts without timeout fallback

### DIFF
--- a/src/main/utils/__tests__/waitForShellPrompt.test.ts
+++ b/src/main/utils/__tests__/waitForShellPrompt.test.ts
@@ -112,6 +112,38 @@ describe('waitForShellPrompt', () => {
     expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
   });
 
+  it('detects a prompt split across chunks', () => {
+    const pty = createMockPty();
+    waitForShellPrompt({
+      subscribe: pty.subscribe,
+      write: pty.write,
+      data: 'cd /foo\n',
+    });
+
+    pty.emit('user@host:~');
+    expect(pty.write).not.toHaveBeenCalled();
+
+    pty.emit('$ ');
+    expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
+  });
+
+  it('detects a fish prompt after greeting output arrives in earlier chunks', () => {
+    const pty = createMockPty();
+    waitForShellPrompt({
+      subscribe: pty.subscribe,
+      write: pty.write,
+      data: 'cd /foo\n',
+    });
+
+    pty.emit('Welcome to fish, the friendly interactive shell\r\n');
+    pty.emit('Type help for instructions on how to use fish\r\n');
+    pty.emit('user@remote ~/worktrees/1597-fish-prompt');
+    expect(pty.write).not.toHaveBeenCalled();
+
+    pty.emit('> ');
+    expect(pty.write).toHaveBeenCalledWith('cd /foo\n');
+  });
+
   it('does not match a bare prompt character with no preceding context', () => {
     const pty = createMockPty();
     waitForShellPrompt({

--- a/src/main/utils/waitForShellPrompt.ts
+++ b/src/main/utils/waitForShellPrompt.ts
@@ -2,9 +2,12 @@ import { stripAnsi } from '@shared/text/stripAnsi';
 
 /**
  * Matches common shell prompt endings: $, #, %, >, ❯ preceded by a non-digit, non-space character.
- * Each chunk is matched independently — prompts split across TCP segments rely on the timeout fallback.
+ * Tests against a rolling sanitized buffer so prompts split across PTY chunks still match.
  */
 const SHELL_PROMPT_RE = /\S.*(?<!\d)[#$%>❯]\s*$/;
+const PROMPT_END_CHARS = new Set(['#', '$', '%', '>', '❯']);
+// Keep enough recent output to match delayed prompts without retaining unbounded PTY history.
+const PROMPT_BUFFER_MAX = 1024;
 
 export interface PromptWaitOptions {
   subscribe: (callback: (chunk: string) => void) => () => void;
@@ -28,6 +31,7 @@ export function waitForShellPrompt(options: PromptWaitOptions): PromptWaitHandle
   if (!data) return noop;
 
   let done = false;
+  let promptBuffer = '';
 
   const finish = () => {
     if (done) return;
@@ -46,8 +50,31 @@ export function waitForShellPrompt(options: PromptWaitOptions): PromptWaitHandle
 
   const unsubscribe = subscribe((chunk: string) => {
     if (done) return;
+
     const clean = stripAnsi(chunk, { includePrivateCsiParams: true });
-    if (SHELL_PROMPT_RE.test(clean)) {
+    if (!clean) return;
+
+    promptBuffer += clean;
+
+    const lastLineBreak = Math.max(promptBuffer.lastIndexOf('\n'), promptBuffer.lastIndexOf('\r'));
+    if (lastLineBreak >= 0) {
+      promptBuffer = promptBuffer.slice(lastLineBreak + 1);
+    }
+
+    if (promptBuffer.length > PROMPT_BUFFER_MAX) {
+      promptBuffer = promptBuffer.slice(-PROMPT_BUFFER_MAX);
+    }
+
+    let lastMeaningfulIndex = promptBuffer.length - 1;
+    while (lastMeaningfulIndex >= 0 && /\s/.test(promptBuffer[lastMeaningfulIndex] ?? '')) {
+      lastMeaningfulIndex -= 1;
+    }
+    if (lastMeaningfulIndex < 0) return;
+    if (!PROMPT_END_CHARS.has(promptBuffer[lastMeaningfulIndex] ?? '')) {
+      return;
+    }
+
+    if (SHELL_PROMPT_RE.test(promptBuffer)) {
       finish();
     }
   });

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -405,6 +405,48 @@ describe('ptyIpc notification lifecycle', () => {
     expect(written).toContain('claude');
   });
 
+  it('writes remote init keystrokes before timeout when a fish prompt is split across chunks', async () => {
+    const { registerPtyIpc } = await import('../../main/services/ptyIpc');
+    registerPtyIpc();
+
+    const startDirect = ipcHandleHandlers.get('pty:startDirect');
+    expect(startDirect).toBeTypeOf('function');
+
+    const id = makePtyId('claude', 'main', 'task-remote-fish');
+    await startDirect!(
+      { sender: createSender() },
+      {
+        id,
+        providerId: 'claude',
+        cwd: '/tmp/task',
+        remote: { connectionId: 'ssh-config:remote-alias' },
+        cols: 120,
+        rows: 32,
+      }
+    );
+
+    const proc = ptys.get(id);
+    expect(proc).toBeDefined();
+
+    proc!.emitData('Welcome to fish, the friendly interactive shell\r\n');
+    proc!.emitData('Type help for instructions on how to use fish\r\n');
+    proc!.emitData('user@host /tmp/task');
+    expect(proc!.write).not.toHaveBeenCalled();
+
+    proc!.emitData('> ');
+
+    expect(proc!.write).toHaveBeenCalled();
+    expect(proc!.write).toHaveBeenCalledTimes(1);
+
+    const written = (proc!.write as any).mock.calls.map((c: any[]) => c[0]).join('');
+    expect(written).toContain('cd');
+    expect(written).toContain('/tmp/task');
+    expect(written).toContain('sh -ilc');
+
+    vi.advanceTimersByTime(14999);
+    expect(proc!.write).toHaveBeenCalledTimes(1);
+  });
+
   it('does not show completion notification on process exit (moved to AgentEventService)', async () => {
     const { registerPtyIpc } = await import('../../main/services/ptyIpc');
     registerPtyIpc();


### PR DESCRIPTION
## Summary
- buffer sanitized prompt output so fish prompts split across PTY chunks are detected immediately
- keep the existing timeout fallback as a safety net
- add regression coverage for split prompts, fish greeting output, and the remote `ptyIpc` init path

Fixes #1597

## Test Plan
- [x] `pnpm exec vitest run src/main/utils/__tests__/waitForShellPrompt.test.ts src/test/main/ptyIpc.test.ts`
- [x] `pnpm run type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved shell prompt detection to reliably identify and respond to prompts that arrive in fragmented data chunks, ensuring terminal initialization commands execute immediately upon complete prompt recognition rather than waiting for unnecessary timeout delays.

* **Tests**
  * Added comprehensive test coverage for various fragmented prompt detection scenarios across different shell environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->