### PR TITLE
fix(opencode): preserve explicit config dir overrides

### DIFF
--- a/src/main/services/OpenCodeHookService.ts
+++ b/src/main/services/OpenCodeHookService.ts
@@ -99,21 +99,38 @@ export class OpenCodeHookService {
     ].join('\n');
   }
 
-  static writeLocalPlugin(ptyId: string): string {
-    const configDir = OpenCodeHookService.getLocalConfigDir(ptyId);
+  static writePlugin(configDir: string): boolean {
     const pluginsDir = path.join(configDir, 'plugins');
     const pluginPath = path.join(pluginsDir, OPEN_CODE_PLUGIN_FILE);
 
     try {
       fs.mkdirSync(pluginsDir, { recursive: true });
       fs.writeFileSync(pluginPath, OpenCodeHookService.getPluginSource());
+      return true;
     } catch (err) {
-      log.warn('OpenCodeHookService: failed to write local plugin', {
+      log.warn('OpenCodeHookService: failed to write plugin', {
         path: pluginPath,
         error: String(err),
       });
+      return false;
+    }
+  }
+
+  static writeLocalPlugin(ptyId: string): string {
+    const configDir = OpenCodeHookService.getLocalConfigDir(ptyId);
+    OpenCodeHookService.writePlugin(configDir);
+    return configDir;
+  }
+
+  static applyLocalRuntimeEnv(env: Record<string, string>, ptyId: string): void {
+    const explicitConfigDir =
+      env.OPENCODE_CONFIG_DIR?.trim() || process.env.OPENCODE_CONFIG_DIR?.trim();
+
+    if (explicitConfigDir && OpenCodeHookService.writePlugin(explicitConfigDir)) {
+      env.OPENCODE_CONFIG_DIR = explicitConfigDir;
+      return;
     }
 
-    return configDir;
+    env.OPENCODE_CONFIG_DIR = OpenCodeHookService.writeLocalPlugin(ptyId);
   }
 }

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -361,12 +361,11 @@ async function writeRemoteHookConfig(
   ]);
 }
 
-async function writeRemoteOpenCodePlugin(
+async function writeRemoteOpenCodePluginToDir(
   sshArgs: string[],
   sshTarget: string,
-  ptyId: string
-): Promise<string> {
-  const configDir = OpenCodeHookService.getRemoteConfigDir(ptyId);
+  configDir: string
+): Promise<void> {
   const pluginsDir = `${configDir}/plugins`;
   const pluginPath = `${pluginsDir}/${OPEN_CODE_PLUGIN_FILE}`;
   const pluginSource = OpenCodeHookService.getPluginSource();
@@ -376,8 +375,6 @@ async function writeRemoteOpenCodePlugin(
     sshTarget,
     `mkdir -p "${pluginsDir}" && printf '%s\\n' ${quoteShellArg(pluginSource)} > "${pluginPath}"`,
   ]);
-
-  return configDir;
 }
 
 /**
@@ -1211,14 +1208,35 @@ export function registerPtyIpc(): void {
 
           const preProviderCommands: string[] = [];
           if (providerId === 'opencode') {
+            const explicitConfigDir = mergedEnv?.OPENCODE_CONFIG_DIR?.trim();
             try {
-              const remoteConfigDir = await writeRemoteOpenCodePlugin(ssh.args, ssh.target, id);
-              preProviderCommands.push(`export OPENCODE_CONFIG_DIR="${remoteConfigDir}"`);
-            } catch (err: any) {
-              log.warn('ptyIpc:startDirect failed to write remote OpenCode plugin', {
-                id,
-                error: err?.message || String(err),
-              });
+              if (explicitConfigDir) {
+                await writeRemoteOpenCodePluginToDir(ssh.args, ssh.target, explicitConfigDir);
+                preProviderCommands.push(`export OPENCODE_CONFIG_DIR="${explicitConfigDir}"`);
+              } else {
+                const remoteConfigDir = OpenCodeHookService.getRemoteConfigDir(id);
+                await writeRemoteOpenCodePluginToDir(ssh.args, ssh.target, remoteConfigDir);
+                preProviderCommands.push(`export OPENCODE_CONFIG_DIR="${remoteConfigDir}"`);
+              }
+            } catch (installErr: any) {
+              if (explicitConfigDir) {
+                try {
+                  const remoteConfigDir = OpenCodeHookService.getRemoteConfigDir(id);
+                  await writeRemoteOpenCodePluginToDir(ssh.args, ssh.target, remoteConfigDir);
+                  preProviderCommands.push(`export OPENCODE_CONFIG_DIR="${remoteConfigDir}"`);
+                } catch (fallbackErr: any) {
+                  log.warn('ptyIpc:startDirect failed to write remote OpenCode plugin', {
+                    id,
+                    error: fallbackErr?.message || String(fallbackErr),
+                    installError: installErr?.message || String(installErr),
+                  });
+                }
+              } else {
+                log.warn('ptyIpc:startDirect failed to write remote OpenCode plugin', {
+                  id,
+                  error: installErr?.message || String(installErr),
+                });
+              }
             }
           }
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -113,16 +113,6 @@ function applyAgentEventHookEnv(env: Record<string, string>, ptyId: string): voi
   env['EMDASH_HOOK_TOKEN'] = agentEventService.getToken();
 }
 
-function applyOpenCodeRuntimeEnv(
-  env: Record<string, string>,
-  ptyId: string,
-  providerId?: string
-): void {
-  if (providerId !== 'opencode') return;
-
-  env['OPENCODE_CONFIG_DIR'] = OpenCodeHookService.writeLocalPlugin(ptyId);
-}
-
 function applyProviderSpecificRuntimeEnv(
   env: Record<string, string>,
   options: {
@@ -130,7 +120,9 @@ function applyProviderSpecificRuntimeEnv(
     providerId?: string;
   }
 ): void {
-  applyOpenCodeRuntimeEnv(env, options.ptyId, options.providerId);
+  if (options.providerId === 'opencode') {
+    OpenCodeHookService.applyLocalRuntimeEnv(env, options.ptyId);
+  }
 }
 
 export function applyProviderRuntimeEnv(
@@ -1408,6 +1400,15 @@ export async function startPty(options: {
       if (provider) {
         const resolvedConfig = resolveProviderCommandConfig(provider.id);
         const resolvedCli = resolvedConfig?.cli || provider.cli || baseLower;
+
+        if (resolvedConfig?.env) {
+          for (const [k, v] of Object.entries(resolvedConfig.env)) {
+            if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(k) && typeof v === 'string') {
+              useEnv[k] = v;
+            }
+          }
+        }
+
         applyProviderSpecificRuntimeEnv(useEnv, { ptyId: id, providerId: provider.id });
 
         // Build the provider command with flags
@@ -1438,14 +1439,6 @@ export async function startPty(options: {
             useKeystrokeInjection: provider.useKeystrokeInjection,
           })
         );
-
-        if (resolvedConfig?.env) {
-          for (const [k, v] of Object.entries(resolvedConfig.env)) {
-            if (/^[A-Za-z_][A-Za-z0-9_]*$/.test(k) && typeof v === 'string') {
-              useEnv[k] = v;
-            }
-          }
-        }
 
         const cliCommand = resolvedCli;
         const commandString =

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -764,7 +764,7 @@ describe('ptyIpc notification lifecycle', () => {
     expect(written).not.toContain('mock-codex-notify');
   });
 
-  it('writes OpenCode plugin on remote and exports OPENCODE_CONFIG_DIR', async () => {
+  it('writes OpenCode plugin on remote into the Emdash per-pty config dir and exports OPENCODE_CONFIG_DIR', async () => {
     agentEventGetPortMock.mockReturnValue(12345);
 
     const { registerPtyIpc } = await import('../../main/services/ptyIpc');
@@ -787,14 +787,15 @@ describe('ptyIpc notification lifecycle', () => {
     );
 
     expect(result?.ok).toBe(true);
-    expect(openCodeGetRemoteConfigDirMock).toHaveBeenCalledWith(id);
     expect(openCodeGetPluginSourceMock).toHaveBeenCalled();
 
     const pluginWriteCall = execFileMock.mock.calls.find(
       (c: any[]) =>
         c[0] === 'ssh' &&
         typeof c[1]?.[c[1].length - 1] === 'string' &&
-        c[1][c[1].length - 1].includes('emdash-notify.js')
+        c[1][c[1].length - 1].includes(
+          `$HOME/.config/emdash/agent-hooks/opencode/${id}/plugins/emdash-notify.js`
+        )
     );
     expect(pluginWriteCall).toBeDefined();
 
@@ -804,8 +805,108 @@ describe('ptyIpc notification lifecycle', () => {
     proc!.emitData('user@host:~$ ');
 
     const written = (proc!.write as any).mock.calls.map((c: any[]) => c[0]).join('');
-    expect(written).toContain('export OPENCODE_CONFIG_DIR=');
-    expect(written).toContain(`$HOME/.config/emdash/agent-hooks/opencode/${id}`);
+    expect(written).toContain(
+      `export OPENCODE_CONFIG_DIR="$HOME/.config/emdash/agent-hooks/opencode/${id}"`
+    );
+  });
+
+  it('preserves an explicit remote OPENCODE_CONFIG_DIR when provided', async () => {
+    agentEventGetPortMock.mockReturnValue(12345);
+
+    const { registerPtyIpc } = await import('../../main/services/ptyIpc');
+    registerPtyIpc();
+
+    const startDirect = ipcHandleHandlers.get('pty:startDirect');
+    expect(startDirect).toBeTypeOf('function');
+
+    const id = makePtyId('opencode', 'main', 'task-remote-opencode-explicit');
+    const result = await startDirect!(
+      { sender: createSender() },
+      {
+        id,
+        providerId: 'opencode',
+        cwd: '/tmp/task',
+        remote: { connectionId: 'ssh-config:remote-alias' },
+        env: { OPENCODE_CONFIG_DIR: '/remote/custom-opencode' },
+        cols: 120,
+        rows: 32,
+      }
+    );
+
+    expect(result?.ok).toBe(true);
+
+    const pluginWriteCall = execFileMock.mock.calls.find(
+      (c: any[]) =>
+        c[0] === 'ssh' &&
+        typeof c[1]?.[c[1].length - 1] === 'string' &&
+        c[1][c[1].length - 1].includes('/remote/custom-opencode/plugins/emdash-notify.js')
+    );
+    expect(pluginWriteCall).toBeDefined();
+
+    const proc = ptys.get(id);
+    expect(proc).toBeDefined();
+
+    proc!.emitData('user@host:~$ ');
+
+    const written = (proc!.write as any).mock.calls.map((c: any[]) => c[0]).join('');
+    expect(written).toContain('export OPENCODE_CONFIG_DIR="/remote/custom-opencode"');
+  });
+
+  it('falls back to the Emdash per-pty config dir on remote when an explicit OPENCODE_CONFIG_DIR write fails', async () => {
+    agentEventGetPortMock.mockReturnValue(12345);
+    execFileMock.mockImplementationOnce(
+      (
+        _cmd: string,
+        _args: string[],
+        _opts: any,
+        cb: (err: any, stdout: string, stderr: string) => void
+      ) => {
+        cb(new Error('EACCES'), '', 'EACCES');
+      }
+    );
+
+    const { registerPtyIpc } = await import('../../main/services/ptyIpc');
+    registerPtyIpc();
+
+    const startDirect = ipcHandleHandlers.get('pty:startDirect');
+    expect(startDirect).toBeTypeOf('function');
+
+    const id = makePtyId('opencode', 'main', 'task-remote-opencode-fallback');
+    const result = await startDirect!(
+      { sender: createSender() },
+      {
+        id,
+        providerId: 'opencode',
+        cwd: '/tmp/task',
+        remote: { connectionId: 'ssh-config:remote-alias' },
+        env: { OPENCODE_CONFIG_DIR: '/remote/custom-opencode' },
+        cols: 120,
+        rows: 32,
+      }
+    );
+
+    expect(result?.ok).toBe(true);
+    expect(openCodeGetRemoteConfigDirMock).toHaveBeenCalledWith(id);
+
+    const fallbackWriteCall = execFileMock.mock.calls.find(
+      (c: any[]) =>
+        c[0] === 'ssh' &&
+        typeof c[1]?.[c[1].length - 1] === 'string' &&
+        c[1][c[1].length - 1].includes(
+          `$HOME/.config/emdash/agent-hooks/opencode/${id}/plugins/emdash-notify.js`
+        )
+    );
+    expect(fallbackWriteCall).toBeDefined();
+
+    const proc = ptys.get(id);
+    expect(proc).toBeDefined();
+
+    proc!.emitData('user@host:~$ ');
+
+    const written = (proc!.write as any).mock.calls.map((c: any[]) => c[0]).join('');
+    expect(written).toContain(
+      `export OPENCODE_CONFIG_DIR="$HOME/.config/emdash/agent-hooks/opencode/${id}"`
+    );
   });
 
   it('writes Claude hook config on remote via ssh exec for claude provider', async () => {

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -74,6 +74,7 @@ describe('ptyManager provider command resolution', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    delete process.env.OPENCODE_CONFIG_DIR;
     providerStatusGetMock.mockReturnValue({
       installed: true,
       path: '/usr/local/bin/codex',
@@ -308,8 +309,57 @@ describe('ptyManager provider command resolution', () => {
     ]);
   });
 
-  it('injects OPENCODE_CONFIG_DIR for local OpenCode PTYs', async () => {
+  it('defaults local OpenCode PTYs to the Emdash per-pty config dir', async () => {
     const { applyProviderRuntimeEnv } = await import('../../main/services/ptyManager');
+
+    const env: Record<string, string> = {};
+    applyProviderRuntimeEnv(env, {
+      ptyId: 'opencode-main-task-123',
+      providerId: 'opencode',
+    });
+
+    expect(env.OPENCODE_CONFIG_DIR).toBe(
+      '/tmp/emdash-test/agent-hooks/opencode/opencode-main-task-123'
+    );
+    expect(fsMkdirSyncMock).toHaveBeenCalledWith(
+      '/tmp/emdash-test/agent-hooks/opencode/opencode-main-task-123/plugins',
+      { recursive: true }
+    );
+    expect(fsWriteFileSyncMock).toHaveBeenCalledWith(
+      '/tmp/emdash-test/agent-hooks/opencode/opencode-main-task-123/plugins/emdash-notify.js',
+      expect.stringContaining('session.idle')
+    );
+  });
+
+  it('preserves an explicit OPENCODE_CONFIG_DIR for local OpenCode PTYs', async () => {
+    const { applyProviderRuntimeEnv } = await import('../../main/services/ptyManager');
+    process.env.OPENCODE_CONFIG_DIR = '/tmp/user-opencode-config';
+
+    const env: Record<string, string> = {};
+    applyProviderRuntimeEnv(env, {
+      ptyId: 'opencode-main-task-123',
+      providerId: 'opencode',
+    });
+
+    expect(env.OPENCODE_CONFIG_DIR).toBe('/tmp/user-opencode-config');
+    expect(fsMkdirSyncMock).toHaveBeenCalledWith('/tmp/user-opencode-config/plugins', {
+      recursive: true,
+    });
+    expect(fsWriteFileSyncMock).toHaveBeenCalledWith(
+      '/tmp/user-opencode-config/plugins/emdash-notify.js',
+      expect.stringContaining('session.idle')
+    );
+  });
+
+  it('falls back to an Emdash-owned OPENCODE_CONFIG_DIR when plugin install fails', async () => {
+    const { applyProviderRuntimeEnv } = await import('../../main/services/ptyManager');
+    process.env.OPENCODE_CONFIG_DIR = '/tmp/user-opencode-config';
+    fsMkdirSyncMock.mockImplementation((target: string) => {
+      if (target === '/tmp/user-opencode-config/plugins') {
+        throw new Error('EACCES');
+      }
+      return undefined;
+    });
 
     const env: Record<string, string> = {};
     applyProviderRuntimeEnv(env, {


### PR DESCRIPTION
## Summary

Emdash was overwriting an existing `OPENCODE_CONFIG_DIR` with its own per-PTY OpenCode config dir.

In my case, `OPENCODE_CONFIG_DIR` already points at a company-managed config repo, so that override caused OpenCode to ignore the shared config.

This change preserves an explicit `OPENCODE_CONFIG_DIR` if one is already set. If it cannot write the notify plugin there, it falls back to Emdash's per-PTY config dir. If no override is set, the existing per-PTY behavior stays the same.

## Testing

- `pnpm exec vitest run src/test/main/ptyManager.test.ts src/test/main/ptyIpc.test.ts`
- `pnpm exec prettier --check src/main/services/OpenCodeHookService.ts src/main/services/ptyManager.ts`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OpenCode plugin install with clearer fallback behavior and additional error logging when an explicit config directory write fails.

* **Refactor**
  * Separated plugin-writing and runtime-env application to support explicit OPENCODE_CONFIG_DIR while retaining per-PTY defaults.

* **Tests**
  * Added and expanded tests covering explicit-config installs, fallback to per-PTY paths, and test isolation of OPENCODE_CONFIG_DIR.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->