### PR TITLE
feat: infer task names from providers

### DIFF
--- a/src/main/ipc/index.ts
+++ b/src/main/ipc/index.ts
@@ -31,6 +31,7 @@ import { registerForgejoIpc } from './forgejoIpc';
 import { registerAccountIpc } from './accountIpc';
 import { changelogController } from './changelogIpc';
 import { registerPerformanceIpc } from './performanceIpc';
+import { registerTaskNamingIpc } from './taskNamingIpc';
 
 export const rpcRouter = createRPCRouter({
   db: databaseController,
@@ -76,4 +77,5 @@ export function registerAllIpc() {
   registerPlainIpc();
   registerForgejoIpc();
   registerPerformanceIpc();
+  registerTaskNamingIpc();
 }

--- a/src/main/ipc/taskNamingIpc.ts
+++ b/src/main/ipc/taskNamingIpc.ts
@@ -1,0 +1,39 @@
+import { ipcMain, BrowserWindow } from 'electron';
+import { inferTaskNameFromProvider } from '../services/TaskNamingService';
+import { log } from '../lib/logger';
+
+export function registerTaskNamingIpc(): void {
+  /**
+   * Fire-and-forget task name inference via provider CLI.
+   * Returns immediately; pushes 'task:nameInferred' to the renderer when done.
+   */
+  ipcMain.handle(
+    'task:inferName',
+    async (
+      event,
+      args: {
+        taskId: string;
+        providerId: string;
+        initialPrompt: string;
+        projectPath: string;
+      }
+    ) => {
+      const { taskId, providerId, initialPrompt, projectPath } = args;
+
+      void inferTaskNameFromProvider(providerId, initialPrompt, projectPath)
+        .then((name) => {
+          const win = BrowserWindow.fromWebContents(event.sender);
+          if (!win || win.isDestroyed()) return;
+          win.webContents.send('task:nameInferred', { taskId, name });
+        })
+        .catch((err: unknown) => {
+          log.warn(`[TaskNaming] unexpected error for task ${taskId}: ${String(err)}`);
+          const win = BrowserWindow.fromWebContents(event.sender);
+          if (!win || win.isDestroyed()) return;
+          win.webContents.send('task:nameInferred', { taskId, name: null });
+        });
+
+      return { accepted: true };
+    }
+  );
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -198,6 +198,19 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.on(channel, wrapped);
     return () => ipcRenderer.removeListener(channel, wrapped);
   },
+  taskInferName: (args: {
+    taskId: string;
+    providerId: string;
+    initialPrompt: string;
+    projectPath: string;
+  }) => ipcRenderer.invoke('task:inferName', args),
+  onTaskNameInferred: (listener: (data: { taskId: string; name: string | null }) => void) => {
+    const channel = 'task:nameInferred';
+    const wrapped = (_: Electron.IpcRendererEvent, data: { taskId: string; name: string | null }) =>
+      listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
   terminalGetTheme: () => ipcRenderer.invoke('terminal:getTheme'),
 
   // Menu events (main → renderer)

--- a/src/main/services/TaskNamingService.ts
+++ b/src/main/services/TaskNamingService.ts
@@ -1,0 +1,91 @@
+import { spawn } from 'child_process';
+import { resolveProviderCommandConfig } from './ptyManager';
+import { log } from '../lib/logger';
+
+const NAMING_PROMPT =
+  'Output only a short git branch name slug for the following task description. ' +
+  'Rules: lowercase letters, numbers, and hyphens only; no spaces; max 40 characters; ' +
+  'no leading or trailing hyphens; be concise and descriptive. ' +
+  'Output the slug and nothing else.\n\nTask: ';
+
+const TIMEOUT_MS = 15_000;
+const MAX_STDOUT_BYTES = 4096;
+
+function normalizeSlug(raw: string): string | null {
+  const slug = raw
+    .trim()
+    .toLowerCase()
+    .split('\n')[0] // take first line only
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 40);
+
+  return slug.length >= 3 ? slug : null;
+}
+
+export async function inferTaskNameFromProvider(
+  providerId: string,
+  initialPrompt: string,
+  cwd: string
+): Promise<string | null> {
+  const resolved = resolveProviderCommandConfig(providerId);
+  if (!resolved) return null;
+
+  const { provider, cli } = resolved;
+  if (!provider.utilityCliArgs) return null;
+
+  const args = [...provider.utilityCliArgs, `${NAMING_PROMPT}${initialPrompt}`];
+
+  return new Promise((resolve) => {
+    let stdout = '';
+    let settled = false;
+
+    const timer = setTimeout(() => {
+      if (!settled) {
+        settled = true;
+        log.warn(`[TaskNaming] timed out for provider: ${providerId}`);
+        child.kill();
+        resolve(null);
+      }
+    }, TIMEOUT_MS);
+
+    const child = spawn(cli, args, {
+      cwd,
+      env: process.env as Record<string, string>,
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      if (stdout.length < MAX_STDOUT_BYTES) {
+        stdout += chunk.toString();
+      }
+    });
+
+    child.stderr?.on('data', (chunk: Buffer) => {
+      log.debug(`[TaskNaming] stderr from ${providerId}: ${chunk.toString().trim()}`);
+    });
+
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+
+      if (code !== 0) {
+        log.warn(`[TaskNaming] CLI exited with code ${code} for provider: ${providerId}`);
+        resolve(null);
+        return;
+      }
+
+      resolve(normalizeSlug(stdout));
+    });
+
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      if (settled) return;
+      settled = true;
+      log.warn(`[TaskNaming] spawn error for ${providerId}: ${err.message}`);
+      resolve(null);
+    });
+  });
+}

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -20,7 +20,11 @@ import { Task } from '../types/chat';
 import { useTaskTerminals } from '@/lib/taskTerminalsStore';
 import { activityStore } from '@/lib/activityStore';
 import { rpc } from '@/lib/rpc';
-import { getInstallCommandForProvider } from '@shared/providers/registry';
+import {
+  getInstallCommandForProvider,
+  getProvider,
+  isValidProviderId,
+} from '@shared/providers/registry';
 import { useAutoScrollOnTaskSwitch } from '@/hooks/useAutoScrollOnTaskSwitch';
 import { useTerminalViewportWheelForwarding } from '@/hooks/useTerminalViewportWheelForwarding';
 import { TaskScopeProvider } from './TaskScopeContext';
@@ -1099,12 +1103,31 @@ const ChatInterface: React.FC<Props> = ({
       // Skip multi-agent tasks
       if (task.metadata?.multiAgent?.enabled) return;
 
-      const generated = generateTaskName(message);
-      if (!generated) return;
-
       const existingNames = (project.tasks || []).map((t) => t.name);
-      const uniqueName = ensureUniqueTaskName(generated, existingNames);
-      void onRenameTask(project, task, uniqueName);
+
+      const applySlugName = () => {
+        const generated = generateTaskName(message);
+        if (!generated) return;
+        void onRenameTask(project, task, ensureUniqueTaskName(generated, existingNames));
+      };
+
+      // Try utility model naming first; result arrives via onTaskNameInferred.
+      // Fall back to slug generator if the provider doesn't support utility mode or errors.
+      const providerId = task.agentId;
+      if (providerId && isValidProviderId(providerId) && getProvider(providerId)?.utilityCliArgs) {
+        firstMessageRef.current = message;
+        void window.electronAPI
+          .taskInferName({
+            taskId: task.id,
+            providerId,
+            initialPrompt: message,
+            projectPath: project.path,
+          })
+          .catch(applySlugName);
+        return;
+      }
+
+      applySlugName();
     },
     [project, task, onRenameTask, autoInferTaskNames]
   );
@@ -1117,6 +1140,36 @@ const ChatInterface: React.FC<Props> = ({
     project &&
     onRenameTask
   );
+
+  // Apply utility-model-inferred name when the main process completes background naming.
+  // Deps use stable IDs rather than object refs to avoid re-registering on every render.
+  const projectRef = useRef(project);
+  projectRef.current = project;
+  const taskRef = useRef(task);
+  taskRef.current = task;
+  const onRenameTaskRef = useRef(onRenameTask);
+  onRenameTaskRef.current = onRenameTask;
+  const firstMessageRef = useRef<string | null>(null);
+  useEffect(() => {
+    if (!shouldCaptureFirstMessage) return;
+    const off = window.electronAPI.onTaskNameInferred(({ taskId, name }) => {
+      const t = taskRef.current;
+      const p = projectRef.current;
+      const rename = onRenameTaskRef.current;
+      if (taskId !== t.id) return;
+      if (!t.metadata?.nameGenerated) return;
+      if (!p || !rename) return;
+
+      // Fall back to slug generator if inference returned null
+      const resolvedName =
+        name ?? (firstMessageRef.current ? generateTaskName(firstMessageRef.current) : null);
+      if (!resolvedName) return;
+
+      const existingNames = (p.tasks || []).map((u) => u.name);
+      void rename(p, t, ensureUniqueTaskName(resolvedName, existingNames));
+    });
+    return off;
+  }, [task.id, shouldCaptureFirstMessage]);
 
   const markActiveReviewPromptSent = useCallback(() => {
     if (!activeConversation || activeConversation.isMain || !activeReviewMetadata) return;

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -135,6 +135,15 @@ declare global {
         listener: (event: AgentEvent, meta: { appFocused: boolean }) => void
       ) => () => void;
       onNotificationFocusTask: (listener: (taskId: string) => void) => () => void;
+      taskInferName: (args: {
+        taskId: string;
+        providerId: string;
+        initialPrompt: string;
+        projectPath: string;
+      }) => Promise<{ accepted: boolean }>;
+      onTaskNameInferred: (
+        listener: (data: { taskId: string; name: string | null }) => void
+      ) => () => void;
       terminalGetTheme: () => Promise<{
         ok: boolean;
         config?: {
@@ -1449,6 +1458,15 @@ export interface ElectronAPI {
     listener: (event: AgentEvent, meta: { appFocused: boolean }) => void
   ) => () => void;
   onNotificationFocusTask: (listener: (taskId: string) => void) => () => void;
+  taskInferName: (args: {
+    taskId: string;
+    providerId: string;
+    initialPrompt: string;
+    projectPath: string;
+  }) => Promise<{ accepted: boolean }>;
+  onTaskNameInferred: (
+    listener: (data: { taskId: string; name: string | null }) => void
+  ) => () => void;
 
   // Worktree management
   worktreeCreate: (args: {

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -57,6 +57,13 @@ export type ProviderDefinition = {
   autoStartCommand?: string;
   icon?: string;
   terminalOnly?: boolean;
+  /**
+   * CLI args to invoke this provider in non-interactive mode for background
+   * utility tasks (e.g. task naming). When present, the provider will be
+   * spawned with these args for lightweight work instead of a full session.
+   * e.g. ['-p', '--model', 'haiku', '--tools', '']
+   */
+  utilityCliArgs?: string[];
 };
 
 export const PROVIDERS: ProviderDefinition[] = [
@@ -89,6 +96,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     planActivateCommand: '/plan',
     icon: 'claude.png',
     terminalOnly: true,
+    utilityCliArgs: ['-p', '--model', 'haiku', '--tools', '', '--no-session-persistence'],
   },
   {
     id: 'cursor',
@@ -116,6 +124,7 @@ export const PROVIDERS: ProviderDefinition[] = [
     resumeFlag: '--resume',
     icon: 'gemini.png',
     terminalOnly: true,
+    utilityCliArgs: ['--model', 'gemini-2.5-flash', '--prompt'],
   },
   {
     id: 'qwen',

--- a/src/test/main/TaskNamingService.test.ts
+++ b/src/test/main/TaskNamingService.test.ts
@@ -1,0 +1,156 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { EventEmitter } from 'events';
+import { inferTaskNameFromProvider } from '../../main/services/TaskNamingService';
+
+const { resolveProviderCommandConfigMock, spawnMock } = vi.hoisted(() => ({
+  resolveProviderCommandConfigMock: vi.fn(),
+  spawnMock: vi.fn(),
+}));
+
+vi.mock('../../main/services/ptyManager', () => ({
+  resolveProviderCommandConfig: resolveProviderCommandConfigMock,
+}));
+
+vi.mock('../../main/settings', () => ({
+  getProviderCustomConfig: vi.fn(() => null),
+  getAppSettings: vi.fn(() => ({})),
+}));
+
+vi.mock('../../main/lib/logger', () => ({
+  log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+vi.mock('electron', () => ({
+  app: { getPath: () => '/tmp/emdash-test' },
+}));
+
+vi.mock('child_process', () => ({ spawn: spawnMock }));
+
+function makeChild(stdout: string, exitCode: number = 0) {
+  const child = new EventEmitter() as any;
+  child.stdout = new EventEmitter();
+  child.kill = vi.fn();
+
+  // Emit stdout data and close asynchronously
+  setTimeout(() => {
+    child.stdout.emit('data', Buffer.from(stdout));
+    child.emit('close', exitCode);
+  }, 0);
+
+  return child;
+}
+
+const RESOLVED_WITH_UTILITY = {
+  provider: {
+    id: 'test-provider',
+    utilityCliArgs: ['-p', '--tools', ''],
+  },
+  cli: 'test-cli',
+};
+
+describe('inferTaskNameFromProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('returns null when provider has no resolved config', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(null);
+    const result = await inferTaskNameFromProvider('unknown', 'fix the login bug', '/tmp');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when provider has no utilityCliArgs', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue({
+      provider: { id: 'test-provider' },
+      cli: 'test-cli',
+    });
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
+    expect(result).toBeNull();
+    expect(spawnMock).not.toHaveBeenCalled();
+  });
+
+  it('spawns the CLI with utility args and the prompt', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(makeChild('fix-login-bug'));
+
+    await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp/project');
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'test-cli',
+      expect.arrayContaining(['-p', '--tools', '']),
+      expect.objectContaining({ cwd: '/tmp/project' })
+    );
+  });
+
+  it('returns a normalized slug from CLI output', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(makeChild('fix-login-bug\n'));
+
+    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    expect(result).toBe('fix-login-bug');
+  });
+
+  it('takes only the first line of CLI output', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(makeChild('fix-login-bug\nsome explanation text'));
+
+    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    expect(result).toBe('fix-login-bug');
+  });
+
+  it('normalizes uppercase and spaces in CLI output', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(makeChild('Fix Login Bug'));
+
+    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    expect(result).toBe('fix-login-bug');
+  });
+
+  it('strips leading and trailing hyphens', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(makeChild('---fix-login---'));
+
+    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    expect(result).toBe('fix-login');
+  });
+
+  it('truncates output to 40 characters', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(
+      makeChild('a-very-long-branch-name-that-exceeds-the-maximum-allowed-length')
+    );
+
+    const result = await inferTaskNameFromProvider('claude', 'do something', '/tmp');
+    expect(result).not.toBeNull();
+    expect(result!.length).toBeLessThanOrEqual(40);
+  });
+
+  it('returns null when output is too short after normalization', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(makeChild('ab'));
+
+    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    expect(result).toBeNull();
+  });
+
+  it('returns null when CLI exits with non-zero code', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+    spawnMock.mockReturnValue(makeChild('fix-login-bug', 1));
+
+    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on spawn error', async () => {
+    resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
+
+    const child = new EventEmitter() as any;
+    child.stdout = new EventEmitter();
+    child.kill = vi.fn();
+    setTimeout(() => child.emit('error', new Error('ENOENT')), 0);
+    spawnMock.mockReturnValue(child);
+
+    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    expect(result).toBeNull();
+  });
+});

--- a/src/test/main/TaskNamingService.test.ts
+++ b/src/test/main/TaskNamingService.test.ts
@@ -73,7 +73,7 @@ describe('inferTaskNameFromProvider', () => {
     resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
     spawnMock.mockReturnValue(makeChild('fix-login-bug'));
 
-    await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp/project');
+    await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp/project');
 
     expect(spawnMock).toHaveBeenCalledWith(
       'test-cli',
@@ -86,7 +86,7 @@ describe('inferTaskNameFromProvider', () => {
     resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
     spawnMock.mockReturnValue(makeChild('fix-login-bug\n'));
 
-    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
     expect(result).toBe('fix-login-bug');
   });
 
@@ -94,7 +94,7 @@ describe('inferTaskNameFromProvider', () => {
     resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
     spawnMock.mockReturnValue(makeChild('fix-login-bug\nsome explanation text'));
 
-    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
     expect(result).toBe('fix-login-bug');
   });
 
@@ -102,7 +102,7 @@ describe('inferTaskNameFromProvider', () => {
     resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
     spawnMock.mockReturnValue(makeChild('Fix Login Bug'));
 
-    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
     expect(result).toBe('fix-login-bug');
   });
 
@@ -110,7 +110,7 @@ describe('inferTaskNameFromProvider', () => {
     resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
     spawnMock.mockReturnValue(makeChild('---fix-login---'));
 
-    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
     expect(result).toBe('fix-login');
   });
 
@@ -120,7 +120,7 @@ describe('inferTaskNameFromProvider', () => {
       makeChild('a-very-long-branch-name-that-exceeds-the-maximum-allowed-length')
     );
 
-    const result = await inferTaskNameFromProvider('claude', 'do something', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'do something', '/tmp');
     expect(result).not.toBeNull();
     expect(result!.length).toBeLessThanOrEqual(40);
   });
@@ -129,7 +129,7 @@ describe('inferTaskNameFromProvider', () => {
     resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
     spawnMock.mockReturnValue(makeChild('ab'));
 
-    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
     expect(result).toBeNull();
   });
 
@@ -137,7 +137,7 @@ describe('inferTaskNameFromProvider', () => {
     resolveProviderCommandConfigMock.mockReturnValue(RESOLVED_WITH_UTILITY);
     spawnMock.mockReturnValue(makeChild('fix-login-bug', 1));
 
-    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
     expect(result).toBeNull();
   });
 
@@ -150,7 +150,7 @@ describe('inferTaskNameFromProvider', () => {
     setTimeout(() => child.emit('error', new Error('ENOENT')), 0);
     spawnMock.mockReturnValue(child);
 
-    const result = await inferTaskNameFromProvider('claude', 'fix the login bug', '/tmp');
+    const result = await inferTaskNameFromProvider('test-provider', 'fix the login bug', '/tmp');
     expect(result).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
I'm finding it hard to find which task I'm working on because the branch / task name generation sometimes either doesn't work or isn't descriptive enough.

Adds model task naming: when a user sends their first message in a new task, the provider's CLI is invoked in a lightweight non-interactive mode to generate a descriptive slug for the task name and git branch. This replaces the random adjective-noun fallback (e.g. `clever-moose-burn`) with something more meaningful (e.g. `fix-login-oauth-flow`).
                                                                                                                                                                                                                                                                                                                                                                                                                                            
I've only tested the utility args with two providers I have access to, Claude and Gemini. But research shows that all of the providers Emdash supports supports CLI flags for headless prompting except Codebuff

## Fixes 
n/a

## Snapshot
I pasted in this prompt as the first message: "does drag and drop work in this repo?"

Before: `feat-does-drag-drop`
After: `drag-drop-investigation`

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code
- [X] A decent size PR without self-review might be rejected

## Checklist

- [X] I have read the contributing guide
- [X] My code follows the style guidelines of this project (`pnpm run format`)
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have checked if my changes generate no new warnings (`pnpm run lint`)
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] I haven't checked if new and existing unit tests pass locally with my changes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automatic task naming: Tasks now receive intelligently suggested names based on your initial message. Names are inferred in the background using integrated AI providers and applied automatically when creating tasks.

* **Tests**
  * Added comprehensive test coverage for the task naming feature.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->