### PR TITLE
fix: change default notification sound profile from gilfoyle to default

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -167,7 +167,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     sound: true,
     osNotifications: true,
     soundFocusMode: 'always',
-    soundProfile: 'gilfoyle',
+    soundProfile: 'default',
   },
   defaultProvider: DEFAULT_PROVIDER_ID,
   review: {

--- a/src/renderer/components/NotificationSettingsCard.tsx
+++ b/src/renderer/components/NotificationSettingsCard.tsx
@@ -106,7 +106,7 @@ const NotificationSettingsCard: React.FC = () => {
             </p>
           </div>
           <Select
-            value={notifications?.soundProfile ?? 'gilfoyle'}
+            value={notifications?.soundProfile ?? 'default'}
             onValueChange={handleSoundProfileChange}
           >
             <SelectTrigger className="w-auto shrink-0 gap-2 [&>span]:line-clamp-none">

--- a/src/renderer/lib/soundPlayer.ts
+++ b/src/renderer/lib/soundPlayer.ts
@@ -5,7 +5,7 @@ import gilfoyleBitcoinAlertUrl from '../assets/sounds/gilfoyle-bitcoin-alert.mp3
 let audioCtx: AudioContext | null = null;
 let enabled = true;
 let focusMode: 'always' | 'unfocused' = 'always';
-let profile: NotificationSoundProfile = 'gilfoyle';
+let profile: NotificationSoundProfile = 'default';
 let previewAudio: HTMLAudioElement | null = null;
 
 function getContext(): AudioContext {

--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -94,7 +94,7 @@ export function Workspace() {
     const soundOn = Boolean(notif?.sound ?? true);
     soundPlayer.setEnabled(masterEnabled && soundOn);
     soundPlayer.setFocusMode(notif?.soundFocusMode ?? 'always');
-    soundPlayer.setProfile(notif?.soundProfile ?? 'gilfoyle');
+    soundPlayer.setProfile(notif?.soundProfile ?? 'default');
   }, [settings?.notifications]);
 
   // --- View-mode / UI visibility state (inlined from former useModalState) ---

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -157,7 +157,7 @@ describe('normalizeSettings - changelog dismissed versions', () => {
 describe('normalizeSettings - notification sound profile', () => {
   it('defaults to the current sound profile when missing', () => {
     const result = normalizeSettings(makeSettings());
-    expect(result.notifications?.soundProfile).toBe('gilfoyle');
+    expect(result.notifications?.soundProfile).toBe('default');
   });
 
   it('preserves the gilfoyle sound profile when selected', () => {
@@ -189,7 +189,7 @@ describe('normalizeSettings - notification sound profile', () => {
       })
     );
 
-    expect(result.notifications?.soundProfile).toBe('gilfoyle');
+    expect(result.notifications?.soundProfile).toBe('default');
   });
 });
 

--- a/src/test/renderer/soundPlayer.test.ts
+++ b/src/test/renderer/soundPlayer.test.ts
@@ -122,14 +122,15 @@ describe('soundPlayer', () => {
     vi.unstubAllGlobals();
   });
 
-  it('uses the gilfoyle clip by default', async () => {
+  it('uses the classic Emdash profile by default', async () => {
     const { soundPlayer } = await loadSoundPlayer();
 
     soundPlayer.play('needs_attention');
 
-    expect(FakeAudio.instances).toHaveLength(1);
-    expect(FakeAudio.instances[0].src).toBe('gilfoyle-bitcoin-alert.mp3');
-    expect(FakeAudio.instances[0].played).toBe(true);
+    const ctx = FakeAudioContext.instances[0];
+    expect(FakeAudio.instances).toHaveLength(0);
+    expect(ctx.oscillators).toHaveLength(2);
+    expect(ctx.oscillators.map((osc) => osc.type)).toEqual(['triangle', 'triangle']);
   });
 
   it('switches to the gilfoyle profile for notification alerts', async () => {


### PR DESCRIPTION
## Summary

Changes the default notification sound profile from `gilfoyle` (Bitcoin alert clip) to `default` (classic Emdash triangle-wave oscillator).

## Changes

- Updated `DEFAULT_SETTINGS` in `src/main/settings.ts` to use `'default'` sound profile
- Updated fallback values in `NotificationSettingsCard`, `soundPlayer`, and `Workspace` from `'gilfoyle'` to `'default'`
- Updated tests to reflect the new default profile behavior

Existing users who explicitly selected the `gilfoyle` profile will keep their setting; only the default for new users (or unset configs) changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the default notification sound profile from 'gilfoyle' to 'default', affecting the fallback sound played when no explicit sound profile preference is configured.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->