### PR TITLE
fix(opencode): show spinner while tasks are running

### DIFF
--- a/src/renderer/lib/activityClassifier.ts
+++ b/src/renderer/lib/activityClassifier.ts
@@ -114,6 +114,7 @@ export function classifyActivity(
     if (/Thinking\.{0,3}/i.test(text)) return 'busy';
     if (/waiting\s+for\s+response/i.test(text)) return 'busy';
     if (/esc\s*to\s*cancel/i.test(text)) return 'busy';
+    if (/[⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏]/.test(text)) return 'busy';
     if (/Ready|Awaiting|Press Enter|Next command|Type your message/i.test(text)) return 'idle';
   }
 

--- a/src/test/renderer/activityClassifier.test.ts
+++ b/src/test/renderer/activityClassifier.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { classifyActivity } from '../../renderer/lib/activityClassifier';
+
+describe('classifyActivity', () => {
+  describe('opencode', () => {
+    it('treats braille spinner frames as busy activity', () => {
+      expect(classifyActivity('opencode', '⠋')).toBe('busy');
+    });
+
+    it('treats spinner text with the default Working prompt as busy activity', () => {
+      expect(classifyActivity('opencode', '⠙ Working...')).toBe('busy');
+    });
+
+    it('keeps ready prompts classified as idle', () => {
+      expect(classifyActivity('opencode', 'Type your message')).toBe('idle');
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- add a focused renderer regression test for OpenCode activity classification
- treat OpenCode braille spinner frames as `busy` so the status-driven spinner stays visible while tasks run

## Fixes
Fixes #1488

## Verification
- `pnpm exec vitest run src/test/renderer/activityClassifier.test.ts`
- `pnpm run type-check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced busy state detection for the opencode provider, improving activity status recognition accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->