### PR TITLE
fix(nix): resolve deprecation warnings and document flake usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,39 @@ Connect to remote machines via SSH/SFTP to work with remote codebases. Emdash su
 - AppImage (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x86_64.AppImage
 - Debian package (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-amd64.deb
 
+### NixOS / Nix Flake
+
+This repository exposes a Nix flake with `packages.<system>.emdash`. You can run it directly:
+
+```bash
+nix run github:generalaction/emdash
+```
+
+To install it as part of a NixOS or home-manager configuration, add the flake input and use the package:
+
+```nix
+# flake.nix
+{
+  inputs.emdash.url = "github:generalaction/emdash";
+
+  # ... in your outputs:
+  # packages = [ inputs.emdash.packages.${system}.default ];
+}
+```
+
+> **Note:** The `pnpmDeps` hash is pinned against the flake's own nixpkgs. If you
+> override `emdash.inputs.nixpkgs.follows` to a different nixpkgs, the pnpm version
+> may differ and produce a hash mismatch. In that case, run `nix build` once — Nix
+> will print the correct hash in the error — then apply it:
+>
+> ```nix
+> inputs.emdash.packages.${pkgs.system}.default.overrideAttrs (old: {
+>   pnpmDeps = old.pnpmDeps.overrideAttrs {
+>     outputHash = "<hash from error>";
+>   };
+> });
+> ```
+
 ### Release Overview
 
 **[Latest Releases (macOS • Windows • Linux)](https://github.com/generalaction/emdash/releases/latest)**

--- a/flake.nix
+++ b/flake.nix
@@ -9,7 +9,7 @@
   outputs = { self, nixpkgs, flake-utils, ... }:
     flake-utils.lib.eachDefaultSystem (system:
       let
-        pkgs = import nixpkgs { inherit system; };
+        pkgs = import nixpkgs { localSystem = system; };
         lib = pkgs.lib;
         packageJson = builtins.fromJSON (builtins.readFile ./package.json);
         pnpmPackageManager = packageJson.packageManager or "";
@@ -84,10 +84,10 @@
             pkgs.automake
             pkgs.coreutils
           ]
-          ++ lib.optionals pkgs.stdenv.isDarwin [
+          ++ lib.optionals pkgs.stdenv.hostPlatform.isDarwin [
             pkgs.libiconv
           ]
-          ++ lib.optionals pkgs.stdenv.isLinux [
+          ++ lib.optionals pkgs.stdenv.hostPlatform.isLinux [
             pkgs.libsecret
             pkgs.sqlite
             pkgs.zlib
@@ -96,7 +96,7 @@
           ];
         cleanSrc = lib.cleanSource ./.;
         emdashPackage =
-          if pkgs.stdenv.isLinux then
+          if pkgs.stdenv.hostPlatform.isLinux then
             pkgs.stdenv.mkDerivation rec {
               pname = "emdash";
               version = packageJson.version;
@@ -144,16 +144,15 @@
                 pkgs.libdrm
                 pkgs.pango
                 pkgs.cairo
-                pkgs.xorg.libX11
-                pkgs.xorg.libXcomposite
-                pkgs.xorg.libXdamage
-                pkgs.xorg.libXext
-                pkgs.xorg.libXfixes
-                pkgs.xorg.libXrandr
-                pkgs.xorg.libxcb
+                pkgs.libx11
+                pkgs.libxcomposite
+                pkgs.libxdamage
+                pkgs.libxext
+                pkgs.libxfixes
+                pkgs.libxrandr
+                pkgs.libxcb
                 pkgs.libxkbcommon
                 pkgs.expat
-                pkgs.mesa.drivers
               ];
               env = {
                 HOME = "$TMPDIR/emdash-home";


### PR DESCRIPTION
## Summary

Follow-up to #1602. Fixes all nixpkgs deprecation warnings emitted during `nix build` and adds installation docs for Nix flake consumers.

- **`system` deprecation**: Replace `import nixpkgs { inherit system; }` with `localSystem = system`
- **`stdenv.isDarwin/isLinux`**: Use `stdenv.hostPlatform.isDarwin/isLinux`
- **`xorg.*` deprecation**: Replace `xorg.libX11` etc. with top-level `libx11` etc.
- **`mesa.drivers`**: Remove (already covered by `mesa`)
- **Reset pnpmDeps hash to empty**: Consumers on a different nixpkgs channel (e.g. stable) need to override the hash anyway since pnpm version differences produce different hashes. Keeping it empty avoids hash drift on every `pnpm-lock.yaml` update and matches CI behavior.
- **README**: Added a NixOS/Nix flake installation section with instructions on how to use the flake as an input and how to override the pnpmDeps hash when needed.

## Test plan

- [x] `nix flake check` passes with no deprecation warnings
- [x] Flake evaluates cleanly (only the expected empty-hash warning for `pnpmDeps`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added NixOS / Nix Flake installation guidance: how to run the project via the flake, how to add it as a flake input, and a note about the pinned pnpmDeps outputHash with an override snippet for updates.

* **Chores**
  * Adjusted flake configuration for improved cross-platform behavior and compatibility with different nixpkgs and system targets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->