### PR TITLE
Add NSMicrophoneUsageDescription to fix claude code voice input

### DIFF
--- a/build/entitlements.mac.plist
+++ b/build/entitlements.mac.plist
@@ -7,6 +7,7 @@
   <key>com.apple.security.cs.allow-unsigned-executable-memory</key><true/>
   <key>com.apple.security.cs.allow-jit</key><true/>
   <key>com.apple.security.get-task-allow</key><false/>
+  <key>com.apple.security.device.audio-input</key><true/>
 </dict>
 </plist>
 

--- a/package.json
+++ b/package.json
@@ -193,7 +193,10 @@
         }
       ],
       "icon": "src/assets/images/emdash/emdash.icns",
-      "notarize": false
+      "notarize": false,
+      "extendInfo": {
+        "NSMicrophoneUsageDescription": "Emdash needs microphone access to support voice input for coding agents like Claude Code."
+      }
     },
     "dmg": {
       "icon": "src/assets/images/emdash/emdash.icns"


### PR DESCRIPTION
## Summary
Allows one to use claude codes new voice input.

Haven't tested it yet, a real test would need to be done on a notarized release build, to see if the permissions work.

## Fixes 
- fixes #1611 
- related #1426 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code

## Checklist

- [ ] I have read the contributing guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have checked if my PR needs changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled microphone and audio input permissions for macOS. Added system entitlements and user-facing permission request messaging to allow the app to access device audio input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->