### PR TITLE
Fix: apply branch prefix to remote worktree creation

### DIFF
--- a/src/main/services/RemoteGitService.ts
+++ b/src/main/services/RemoteGitService.ts
@@ -138,8 +138,12 @@ export class RemoteGitService {
       .replace(/[^a-z0-9-]/g, '-')
       .replace(/-+/g, '-')
       .replace(/^-|-$/g, '');
-    const worktreeName = `${slug || 'task'}-${Date.now()}`;
-    const relWorktreePath = `.emdash/worktrees/${worktreeName}`;
+    const { getAppSettings } = await import('../settings');
+    const settings = getAppSettings();
+    const branchPrefix = settings?.repository?.branchPrefix || 'emdash';
+    const dirName = `${slug || 'task'}-${Date.now()}`;
+    const worktreeName = `${branchPrefix}/${dirName}`;
+    const relWorktreePath = `.emdash/worktrees/${dirName}`;
     const worktreePath = `${normalizedProjectPath}/${relWorktreePath}`.replace(/\/+/g, '/');
 
     // Create worktrees directory (relative so we avoid quoting issues)

--- a/src/main/services/__tests__/RemoteGitService.test.ts
+++ b/src/main/services/__tests__/RemoteGitService.test.ts
@@ -17,6 +17,14 @@ vi.mock('../ssh/SshService', () => ({
   })),
 }));
 
+const mockGetAppSettings = vi.fn().mockReturnValue({
+  repository: { branchPrefix: 'emdash' },
+});
+
+vi.mock('../../settings', () => ({
+  getAppSettings: (...args: any[]) => mockGetAppSettings(...args),
+}));
+
 describe('RemoteGitService', () => {
   let service: RemoteGitService;
   let mockSshService: SshService;
@@ -144,7 +152,7 @@ describe('RemoteGitService', () => {
         expect.stringContaining('git worktree add'),
         '/home/user/project'
       );
-      expect(result.branch).toContain('task-name');
+      expect(result.branch).toMatch(/^emdash\/task-name-/);
       expect(result.isMain).toBe(false);
       expect(result.path).toContain('.emdash/worktrees');
     });
@@ -184,12 +192,30 @@ describe('RemoteGitService', () => {
         'task with spaces & symbols!@#'
       );
 
-      expect(result.branch).toMatch(/^task-with-spaces-/);
+      expect(result.branch).toMatch(/^emdash\/task-with-spaces-/);
       expect(result.branch).not.toContain(' ');
       expect(result.branch).not.toContain('&');
       expect(result.branch).not.toContain('!');
       expect(result.branch).not.toContain('@');
       expect(result.branch).not.toContain('#');
+    });
+
+    it('should use custom branch prefix from settings', async () => {
+      mockGetAppSettings.mockReturnValue({
+        repository: { branchPrefix: 'custom-prefix' },
+      });
+
+      mockExecuteCommand.mockResolvedValue({
+        stdout: '',
+        stderr: '',
+        exitCode: 0,
+      } as ExecResult);
+
+      const result = await service.createWorktree('conn-1', '/home/user/project', 'my-task');
+
+      expect(result.branch).toMatch(/^custom-prefix\/my-task-/);
+      // Directory path should not contain the prefix
+      expect(result.path).toMatch(/\.emdash\/worktrees\/my-task-\d+$/);
     });
 
     it('should throw error when worktree creation fails', async () => {


### PR DESCRIPTION

## Summary

`RemoteGitService.createWorktree()` was generating branch names without the user's configured `branchPrefix` setting. Local worktrees correctly used it, but SSH worktrees were skipped.



## Snapshot




## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code

## Checklist

- [x] I have read the contributing guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Worktree branch naming now supports customizable prefixes through application settings, enabling flexible branch organization based on user preferences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->