### PR TITLE
fix: show PR info and CI checks for fork branches

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -1694,11 +1694,57 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
       if (remoteProject) {
         const connId = remoteProject.sshConnectionId;
         const fields = 'bucket,completedAt,description,event,link,name,startedAt,state,workflow';
-        const checksResult = await remoteGitService.execGh(
-          connId,
-          taskPath,
-          `pr checks --json ${fields}`
-        );
+
+        // Detect fork on remote: find PR in parent repo if applicable
+        let prRef: string | null = null;
+        let remoteParentRepo: string | null = null;
+        let remoteChecksApiRepo = 'repos/{owner}/{repo}';
+        let remoteHeadRefOidCmd = "pr view --json headRefOid --jq '.headRefOid'";
+        try {
+          const repoResult = await remoteGitService.execGh(
+            connId,
+            taskPath,
+            'repo view --json owner,parent'
+          );
+          const repoData = repoResult.stdout.trim() ? JSON.parse(repoResult.stdout.trim()) : null;
+          const parentOwner = repoData?.parent?.owner?.login;
+          const parentName = repoData?.parent?.name;
+          const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
+          if (parentRepo) {
+            const branchResult = await remoteGitService.execGit(
+              connId,
+              taskPath,
+              'branch --show-current'
+            );
+            const currentBranch = branchResult.stdout.trim();
+            if (currentBranch) {
+              const listResult = await remoteGitService.execGh(
+                connId,
+                taskPath,
+                `pr list --head ${quoteGhArg(currentBranch)} --repo ${quoteGhArg(parentRepo)} --state open --json number,headRefOid,headRepositoryOwner --limit 10`
+              );
+              const forkOwnerLogin = repoData?.owner?.login;
+              const listData = listResult.stdout.trim() ? JSON.parse(listResult.stdout.trim()) : [];
+              const matched = forkOwnerLogin
+                ? listData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
+                : listData[0];
+              if (matched) {
+                prRef = String(matched.number);
+                remoteParentRepo = parentRepo;
+                remoteChecksApiRepo = `repos/${parentRepo}`;
+                remoteHeadRefOidCmd = `pr view ${prRef} --repo ${quoteGhArg(parentRepo)} --json headRefOid --jq '.headRefOid'`;
+              }
+            }
+          }
+        } catch {
+          // Not a fork or detection failed — proceed with default behavior
+        }
+
+        const checksCmd =
+          prRef && remoteParentRepo
+            ? `pr checks ${prRef} --repo ${quoteGhArg(remoteParentRepo)} --json ${fields}`
+            : `pr checks --json ${fields}`;
+        const checksResult = await remoteGitService.execGh(connId, taskPath, checksCmd);
         if (checksResult.exitCode !== 0) {
           const msg = checksResult.stderr || '';
           if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
@@ -1713,17 +1759,13 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
 
         // Fetch html_url from API
         try {
-          const shaResult = await remoteGitService.execGh(
-            connId,
-            taskPath,
-            "pr view --json headRefOid --jq '.headRefOid'"
-          );
+          const shaResult = await remoteGitService.execGh(connId, taskPath, remoteHeadRefOidCmd);
           const sha = shaResult.stdout.trim();
           if (sha) {
             const apiResult = await remoteGitService.execGh(
               connId,
               taskPath,
-              `api repos/{owner}/{repo}/commits/${sha}/check-runs --jq '.check_runs | map({name: .name, html_url: .html_url}) | .[]'`
+              `api ${remoteChecksApiRepo}/commits/${sha}/check-runs --jq '.check_runs | map({name: .name, html_url: .html_url}) | .[]'`
             );
             const urlMap = new Map<string, string>();
             for (const line of apiResult.stdout.trim().split('\n')) {


### PR DESCRIPTION
## Summary

When working in a fork, `gh pr view` exits non-zero because the PR lives in the upstream repo, not the fork. The thrown error was caught by an outer try/catch that immediately returned null — bypassing the branch-name and fork-detection fallbacks. Additionally, the fork detection logic read a non-existent `parent.nameWithOwner` field instead of constructing the repo string from `parent.owner.login` + `parent.name`.

This PR fixes both `git:get-pr-status` and `git:get-check-runs` so they correctly resolve PR info and CI checks when the project is a fork.

## Fixes

Fixes #1643

## Snapshot

N/A — sidebar now shows PR title, status, and CI checks for fork branches where previously it showed "No PR for this task" / "No CI checks found for this repository".

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] I have self-reviewed the code

## Checklist

- [x] I have read the contributing guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved PR detection with additional fallback checks for more reliable discovery when primary lookup fails.
  * Added support for forked repositories so PR status and check runs are resolved against parent repositories when appropriate.
  * Refined error handling: unresolved PRs now return success with no PR data instead of an error.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->