### PR TITLE
fix: enable terminal auto-scroll on keypress

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -194,7 +194,7 @@ export class TerminalSessionManager {
       lineHeight: 1.2,
       letterSpacing: 0,
       allowProposedApi: true,
-      scrollOnUserInput: false,
+      scrollOnUserInput: true,
       linkHandler: {
         activate: (_event, text) => openLink(text),
       },


### PR DESCRIPTION
## Summary
Fixes terminal not auto-scrolling to bottom when user starts typing while scrolled up.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes
Changed `scrollOnUserInput` from `false` to `true` in `TerminalSessionManager.ts` to match standard terminal emulator behavior (VS Code, iTerm, Kitty, etc.).

**Before:** When scrolled back in terminal history, typing a command didn't automatically scroll viewport to show what you're typing.

**After:** Typing immediately scrolls viewport to bottom, showing the cursor and user input.

## Technical Details
- **File:** `src/renderer/terminal/TerminalSessionManager.ts`
- **Line:** 197
- **Change:** `scrollOnUserInput: false` → `scrollOnUserInput: true`
- This is a built-in xterm.js `Terminal` option, not custom logic

## Steps to Verify
1. Start any task in Emdash
2. Fill terminal scrollback (run multiple commands or let agent output scroll)
3. Scroll up using mouse/keyboard to view earlier output
4. Start typing any command
5. Terminal viewport should auto-scroll to bottom, showing the cursor

## Mandatory Tasks
- [x] I have self-reviewed the code

## Checklist
- [x] I have read the contributing guide
- [x] This change does not require documentation updates (restores standard terminal behavior)
- [x] Tests not required (built-in xterm.js feature, UX behavior)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Terminal viewport now scrolls automatically when users type input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->