### PR TITLE
fix(terminal): recalculate layout on theme and font changes

### DIFF
--- a/src/renderer/terminal/TerminalSessionManager.ts
+++ b/src/renderer/terminal/TerminalSessionManager.ts
@@ -203,6 +203,7 @@ export class TerminalSessionManager {
     const updateCustomFont = (customFont?: string) => {
       this.customFontFamily = customFont?.trim() ?? '';
       this.applyEffectiveFont();
+      this.scheduleFit();
     };
 
     const updateCustomFontSize = (size: number) => {
@@ -552,6 +553,7 @@ export class TerminalSessionManager {
       this.captureViewportPosition();
       this.cancelScheduledFit();
       this.clearQueuedResize();
+      this.lastSentResize = null;
       this.resizeObserver?.disconnect();
       this.resizeObserver = null;
       ensureTerminalHost().appendChild(this.container);
@@ -567,6 +569,7 @@ export class TerminalSessionManager {
   setTheme(theme: SessionTheme) {
     this.lastTheme = theme;
     this.applyTheme(theme);
+    this.scheduleFit();
   }
 
   dispose() {


### PR DESCRIPTION
## Summary

- **`setTheme()`** now calls `scheduleFit()` after applying the theme — when the native terminal theme arrives asynchronously (with a different fontFamily/fontSize), the terminal recalculates its columns to match the new font metrics
- **`updateCustomFont()`** now calls `scheduleFit()` — aligned with the live `handleFontChange` event handler which already triggered a fit after font changes
- **`detach()`** now resets `lastSentResize = null` — ensures the PTY resize is not skipped by deduplication when re-attaching after a task switch

## Context

The Claude Code TUI output was sometimes truncated on the right side (status bar, tool use output cut off). Resizing the panel by a few pixels would fix it.

**Root cause:** font/size changes via `applyTheme()` or `updateCustomFont()` didn't trigger a terminal refit. The PTY and xterm.js kept stale column counts calculated with old font metrics, so the process formatted output for more columns than the terminal could display.

This was a race condition between the async native terminal theme detection (iTerm2, Terminal.app, Ghostty, etc.) and the initial terminal fit — depending on timing, the fit could run before or after the font change.

## Test plan

- [ ] Open a task with Claude Code running — verify the terminal output is not truncated on the right
- [ ] Switch between tasks — verify layout stays correct without needing manual resize
- [ ] Resize the terminal panel — verify it still works as before
- [ ] Expand/collapse the terminal modal — verify layout is correct after collapse

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal layout adjustment when custom fonts are applied.
  * Enhanced terminal display refresh when theme changes are made.
  * Better session cleanup during terminal disconnection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->