### PR TITLE
fix: remove max-w-4xl and drop Ctrl+Z to let terminal fill available width

### DIFF
--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1534,14 +1534,13 @@ export async function startPty(options: {
 
         const shellBase = (defaultShell.split('/').pop() || '').toLowerCase();
 
-        // After the provider exits, exec back into the user's shell (login+interactive)
         const resumeShell =
           shellBase === 'fish'
             ? `'${defaultShell.replace(/'/g, "'\\''")}' -i -l`
             : `'${defaultShell.replace(/'/g, "'\\''")}' -il`;
         const chainCommand = shellSetup
-          ? `${shellSetup} && ${commandString}; exec ${resumeShell}`
-          : `${commandString}; exec ${resumeShell}`;
+          ? `${shellSetup} && ${commandString}; ${resumeShell}`
+          : `${commandString}; ${resumeShell}`;
 
         // Always use the default shell for the -c command to avoid re-detecting provider CLI
         useShell = defaultShell;
@@ -1557,11 +1556,15 @@ export async function startPty(options: {
             baseLower === 'fish'
               ? `'${useShell.replace(/'/g, "'\\''")}' -i -l`
               : `'${useShell.replace(/'/g, "'\\''")}' -il`;
+          // Use foreground shell (no exec) so job control works properly.
+          // With 'exec', the shell chain can deadlock when Ctrl+Z is pressed
+          // because the parent shell stops before reaching exec, leaving no
+          // foreground process to handle fg/bg.
           if (baseLower === 'fish') {
-            args.push('-l', '-i', '-c', `${shellSetup}; exec ${resumeShell}`);
+            args.push('-l', '-i', '-c', `${shellSetup}; ${resumeShell}`);
           } else {
             const cFlag = baseLower === 'sh' ? '-lc' : '-lic';
-            args.push(cFlag, `${shellSetup}; exec ${resumeShell}`);
+            args.push(cFlag, `${shellSetup}; ${resumeShell}`);
           }
         } else {
           if (baseLower === 'fish') {
@@ -1646,6 +1649,14 @@ export async function startPty(options: {
 export function writePty(id: string, data: string): void {
   const rec = ptys.get(id);
   if (!rec) {
+    return;
+  }
+  // Drop SIGTSTP (Ctrl+Z, \x1a) to prevent job control deadlocks.
+  // In emdash's terminal, suspending an agent is meaningless and causes the
+  // shell chain to deadlock. Dropping \x1a at the PTY write level ensures
+  // SIGTSTP is never generated. Ctrl+C (\x03) is NOT dropped so users can
+  // still interrupt agent actions within Claude.
+  if (data === '\x1a') {
     return;
   }
   rec.proc.write(data);

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -1249,7 +1249,7 @@ const ChatInterface: React.FC<Props> = ({
           >
             <div
               ref={terminalPanelRef}
-              className={`relative mx-auto h-full max-w-4xl overflow-hidden rounded-md ${
+              className={`relative mx-auto h-full w-full overflow-hidden rounded-md ${
                 agent === 'charm'
                   ? effectiveTheme === 'dark-black'
                     ? 'bg-black'

--- a/src/renderer/components/MultiAgentTask.tsx
+++ b/src/renderer/components/MultiAgentTask.tsx
@@ -637,7 +637,7 @@ const MultiAgentTask: React.FC<Props> = ({
                   onWheelCapture={handleTerminalViewportWheelForwarding}
                 >
                   <div
-                    className={`mx-auto h-full max-w-4xl overflow-hidden rounded-md ${
+                    className={`mx-auto h-full w-full overflow-hidden rounded-md ${
                       v.agent === 'mistral'
                         ? isDark
                           ? 'bg-[#202938]'


### PR DESCRIPTION
## Summary

Two fixes for terminal UX issues:

1. **Terminal width**: Removes `max-w-4xl` from `ChatInterface.tsx` and `MultiAgentTask.tsx` terminal containers. The terminal was capped at 896px regardless of window width, wasting horizontal space on wide monitors.

2. **Ctrl+Z deadlock**: Drops `\x1a` (SIGTSTP) at the PTY write level in `writePty()`. When Ctrl+Z is pressed in emdash's terminal running an agent, the shell chain (`bash -ilc "claude; exec bash -il"`) would deadlock — the agent stops but `exec bash -il` never runs, leaving no foreground process to handle `fg`. Also removes `exec` from the shell chain so the resume shell runs as a proper foreground child. Ctrl+C (`\x03`) is preserved so users can still interrupt agent actions.

Fixes generalaction/emdash#1650

## Test plan

- [ ] Terminal fills available width on wide monitors
- [ ] Ctrl+Z does not hang the terminal or cause deadlocks
- [ ] Ctrl+C still interrupts agent actions within Claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed PTY input handling to prevent unwanted signal generation when pressing Ctrl+Z in the terminal.

* **UI Improvements**
  * Terminal containers now expand to full available width for optimal screen space utilization.

* **Improvements**
  * Enhanced shell command execution flow for better process management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->