### PR TITLE
fix(build): replace SiCss3 with SiCss for react-icons 5.6.0 compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -130,7 +130,7 @@
     "posthog-js": "^1.297.2",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-icons": "^5.5.0",
+    "react-icons": "^5.6.0",
     "react-markdown": "^10.1.0",
     "react-resizable-panels": "^3.0.6",
     "react-syntax-highlighter": "^15.6.6",

--- a/src/renderer/components/FileExplorer/FileIcons.tsx
+++ b/src/renderer/components/FileExplorer/FileIcons.tsx
@@ -25,7 +25,7 @@ import {
   SiReact,
   SiPython,
   SiHtml5,
-  SiCss3,
+  SiCss,
   SiSass,
   SiNodedotjs,
   SiNpm,
@@ -180,7 +180,7 @@ const EXTENSION_ICONS: Record<string, { icon: React.ElementType; color: string; 
   // Web
   html: { icon: SiHtml5, color: 'text-orange-600', label: 'HTML file' },
   htm: { icon: SiHtml5, color: 'text-orange-600', label: 'HTML file' },
-  css: { icon: SiCss3, color: 'text-blue-600', label: 'CSS file' },
+  css: { icon: SiCss, color: 'text-blue-600', label: 'CSS file' },
   scss: { icon: SiSass, color: 'text-pink-600', label: 'SCSS file' },
   sass: { icon: SiSass, color: 'text-pink-600', label: 'Sass file' },
   less: { icon: VscFileCode, color: 'text-blue-800', label: 'Less file' },


### PR DESCRIPTION
## Summary

- Replaces the removed `SiCss3` export with the new `SiCss` export in `FileIcons.tsx`
- Bumps the minimum `react-icons` version to `^5.6.0` so the dependency and the code are in sync

## Background

`SiCss3` was removed from `react-icons` in 5.6.0. The current `package.json` specifies `^5.5.0`, which allows 5.6.0. The `pnpm-lock.yaml` still pins to 5.5.0, so contributors with the lockfile intact are unaffected today — but anyone whose lockfile resolves to 5.6.0 hits an immediate build failure:

```
src/renderer/components/FileExplorer/FileIcons.tsx: "SiCss3" is not exported by "node_modules/react-icons/si/index.mjs"
```

Bumping to `^5.6.0` makes the lock consistent and prevents the breakage for any contributor who runs `pnpm install` going forward.

## Test plan

- [x] `pnpm run build` passes
- [x] `pnpm run type-check` passes
- [x] CSS files display the correct icon in the file explorer

Closes #1662

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated `react-icons` dependency to the latest version.

* **Style**
  * Updated the icon used for CSS files in the file explorer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->