### PR TITLE
fix(locale): strip POSIX encoding suffix from macOS locale vars to prevent ICU crash

### DIFF
--- a/package.json
+++ b/package.json
@@ -180,8 +180,8 @@
       "entitlementsInherit": "build/entitlements.mac.plist",
       "extendInfo": {
         "LSEnvironment": {
-          "LANG": "en_US.UTF-8",
-          "LC_CTYPE": "en_US.UTF-8"
+          "LANG": "en_US",
+          "LC_CTYPE": "en_US"
         }
       },
       "target": [

--- a/src/main/utils/__tests__/shellEnv.test.ts
+++ b/src/main/utils/__tests__/shellEnv.test.ts
@@ -22,11 +22,7 @@ const mockedReaddirSync = vi.mocked(readdirSync);
 describe('shellEnv', () => {
   const originalEnv = process.env;
   const fallbackUtf8Locale =
-    process.platform === 'darwin'
-      ? 'en_US.UTF-8'
-      : process.platform === 'win32'
-        ? undefined
-        : 'C.UTF-8';
+    process.platform === 'darwin' ? 'en_US' : process.platform === 'win32' ? undefined : 'C.UTF-8';
   const shellLookup = (values: Partial<Record<string, string>>) => (command: string) => {
     // Batched locale call: returns values separated by ---
     if (command.includes('echo "---"')) {
@@ -174,9 +170,12 @@ describe('shellEnv', () => {
       initializeShellEnvironment();
 
       expect(process.env.SSH_AUTH_SOCK).toBe('/detected/socket');
-      expect(process.env.LANG).toBe('C.UTF-8');
-      expect(process.env.LC_CTYPE).toBe('C.UTF-8');
-      expect(process.env.LC_ALL).toBe('C.UTF-8');
+      // On macOS, POSIX encoding suffixes are stripped from locale strings to
+      // prevent ICU crashes during AppKit menu init on macOS 26+.
+      const expectedLocale = process.platform === 'darwin' ? 'C' : 'C.UTF-8';
+      expect(process.env.LANG).toBe(expectedLocale);
+      expect(process.env.LC_CTYPE).toBe(expectedLocale);
+      expect(process.env.LC_ALL).toBe(expectedLocale);
     });
 
     it('should fall back to existing SSH_AUTH_SOCK when launchctl fails', () => {
@@ -206,9 +205,12 @@ describe('shellEnv', () => {
 
       initializeShellEnvironment();
 
-      expect(process.env.LANG).toBe('en_US.UTF-8');
-      expect(process.env.LC_CTYPE).toBe('sr_RS.UTF-8');
-      expect(process.env.LC_ALL).toBe('C.UTF-8');
+      // On macOS, encoding suffixes are stripped to prevent ICU crashes.
+      const strip = (v: string) =>
+        process.platform === 'darwin' ? v.replace(/\.[A-Za-z0-9@_-]+$/, '') : v;
+      expect(process.env.LANG).toBe(strip('en_US.UTF-8'));
+      expect(process.env.LC_CTYPE).toBe(strip('sr_RS.UTF-8'));
+      expect(process.env.LC_ALL).toBe(strip('C.UTF-8'));
     });
 
     it('should replace inherited non-UTF-8 locale values with shell UTF-8 values', () => {
@@ -226,9 +228,11 @@ describe('shellEnv', () => {
 
       initializeShellEnvironment();
 
-      expect(process.env.LANG).toBe('en_US.UTF-8');
-      expect(process.env.LC_CTYPE).toBe('en_US.UTF-8');
-      expect(process.env.LC_ALL).toBe('en_US.UTF-8');
+      // On macOS, encoding suffixes are stripped to prevent ICU crashes.
+      const expected = process.platform === 'darwin' ? 'en_US' : 'en_US.UTF-8';
+      expect(process.env.LANG).toBe(expected);
+      expect(process.env.LC_CTYPE).toBe(expected);
+      expect(process.env.LC_ALL).toBe(expected);
     });
 
     it('should fall back to platform UTF-8 locale when shell exposes no locale values', () => {
@@ -286,7 +290,8 @@ describe('shellEnv', () => {
 
       initializeShellEnvironment();
 
-      expect(process.env.LANG).toBe('en_US.UTF-8');
+      // On macOS, encoding suffixes are stripped to prevent ICU crashes.
+      expect(process.env.LANG).toBe(process.platform === 'darwin' ? 'en_US' : 'en_US.UTF-8');
       expect(process.env.LC_CTYPE).toBeUndefined();
       expect(process.env.LC_ALL).toBeUndefined();
     });

--- a/src/main/utils/shellEnv.ts
+++ b/src/main/utils/shellEnv.ts
@@ -12,12 +12,24 @@ import { LOCALE_ENV_VARS, DEFAULT_UTF8_LOCALE, isUtf8Locale } from './locale';
 function getFallbackUtf8Locale(): string | undefined {
   if (process.platform === 'win32') return undefined;
 
-  // `C.UTF-8` is a good generic fallback on Linux, but can crash AppKit on
-  // newer macOS builds when native menus initialize locale-dependent text
-  // direction. Keep macOS on a concrete UTF-8 locale instead.
-  if (process.platform === 'darwin') return 'en_US.UTF-8';
+  // On macOS, all locales use UTF-8 encoding. Use a bare ICU-compatible
+  // locale identifier without a POSIX encoding suffix — suffixes like
+  // `.UTF-8` are not understood by ICU's uloc_getTableStringWithFallback
+  // on macOS 26+ and cause a null-pointer crash during AppKit menu init.
+  if (process.platform === 'darwin') return 'en_US';
 
   return DEFAULT_UTF8_LOCALE;
+}
+
+/**
+ * On macOS, strips POSIX encoding suffixes (e.g. ".UTF-8") from locale strings
+ * so that ICU receives a clean locale identifier it can look up without crashing.
+ * macOS always uses UTF-8, so the suffix carries no information and only causes
+ * problems with newer ICU versions bundled in macOS 26+.
+ */
+function sanitizeLocaleForPlatform(locale: string): string {
+  if (process.platform !== 'darwin') return locale;
+  return locale.replace(/\.[A-Za-z0-9@_-]+$/, '');
 }
 
 /**
@@ -288,4 +300,17 @@ export function initializeShellEnvironment(): void {
   }
 
   initializeLocaleEnvironment();
+
+  // Strip POSIX encoding suffixes (e.g. ".UTF-8") from all locale env vars on
+  // macOS. ICU's uloc_getTableStringWithFallback on macOS 26+ crashes when it
+  // receives locale strings with encoding suffixes — ICU uses its own tag format
+  // (e.g. "en_US") without POSIX encoding markers. macOS always uses UTF-8, so
+  // the suffix carries no useful information and only breaks ICU lookup.
+  if (process.platform === 'darwin') {
+    for (const key of LOCALE_ENV_VARS) {
+      if (process.env[key]) {
+        process.env[key] = sanitizeLocaleForPlatform(process.env[key]!);
+      }
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Strips POSIX encoding suffixes (e.g. `.UTF-8`) from locale env vars after initialization on macOS, catching values from any source (existing env, shell detection, or fallback)
- Changes `getFallbackUtf8Locale()` on darwin to return `en_US` instead of `en_US.UTF-8`
- Updates `LSEnvironment` in `package.json` to use `en_US` so the `Info.plist` value is also ICU-safe before any JS runs
- Updates tests to reflect the suffix-stripped expectations on macOS

## Background

Issue #1633 reports that Emdash crashes on launch on macOS 26+ starting from 0.4.44, and the crash persists through 0.4.45.

The crash stack is:
```
libicucore    uloc_getTableStringWithFallback  ← null pointer dereference
Foundation    Locale.characterDirection(forLanguage:)
UIFoundation  +[NSParagraphStyle _defaultWritingDirection]
AppKit        +[NSApplication _defaultUserInterfaceLayoutDirection]
AppKit        -[NSCocoaMenuImpl initWithMenu:]
```

**Root cause:** ICU's `uloc_getTableStringWithFallback` on macOS 26+ crashes when it receives a locale string with a POSIX encoding suffix like `.UTF-8`. ICU expects bare locale identifiers (`en_US`, not `en_US.UTF-8`). On older macOS, Foundation silently stripped the encoding suffix before passing it to ICU; on macOS 26 this stripping no longer happens.

PR #1632 changed the fallback from `C.UTF-8` to `en_US.UTF-8`, and PR #1640 added `LSEnvironment` with `en_US.UTF-8` — but *any* `.UTF-8` suffix triggers the same crash. macOS always uses UTF-8 regardless of locale, so the suffix is both redundant and harmful.

**Compatibility:** The fix is fully backwards compatible. Stripping `.UTF-8` from `en_US.UTF-8` → `en_US` is semantically a no-op on macOS (all macOS locales are UTF-8). Older macOS versions tolerated the suffix; newer ones do not. The stripped value is what ICU always expected.

## Test plan

- [x] `pnpm exec vitest run src/main/utils/__tests__/shellEnv.test.ts` — all 15 tests pass
- [x] `pnpm exec vitest run` — all 863 tests pass
- [x] `pnpm run build` passes
- [x] `pnpm run type-check` passes
- [x] App launches without crash (`pnpm run dev` — confirmed clean startup with no segfault)

Closes #1633

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced macOS locale and language environment variable handling by normalizing locale identifiers to properly align with macOS system requirements, improving overall system compatibility and ensuring consistent behavior across different language and regional configurations
  * Refined how environment variables for locale-dependent features are configured to provide better support for regional customization and language settings on macOS

<!-- end of auto-generated comment: release notes by coderabbit.ai -->