### PR TITLE
fix: correct worktree path handling on Windows

### DIFF
--- a/src/main/services/ssh/SshService.ts
+++ b/src/main/services/ssh/SshService.ts
@@ -368,7 +368,9 @@ export class SshService extends EventEmitter {
     // Build the command with optional cwd, wrapped in a login shell so that
     // ~/.ssh/config, ~/.gitconfig, and other user-level configuration files
     // are available (ssh2's client.exec() uses a non-login shell by default).
-    const innerCommand = cwd ? `cd ${quoteShellArg(cwd)} && ${command}` : command;
+    const safeCwd = cwd ? cwd.replace(/\\/g, '/').replace(/"/g, '\\"') : undefined;
+    const innerCommand = safeCwd ? `cd ${quoteShellArg(safeCwd)} && ${command}` : command;
+
     const fullCommand = `bash -l -c ${quoteShellArg(innerCommand)}`;
 
     return new Promise((resolve, reject) => {

--- a/src/main/services/ssh/SshService.ts
+++ b/src/main/services/ssh/SshService.ts
@@ -368,7 +368,7 @@ export class SshService extends EventEmitter {
     // Build the command with optional cwd, wrapped in a login shell so that
     // ~/.ssh/config, ~/.gitconfig, and other user-level configuration files
     // are available (ssh2's client.exec() uses a non-login shell by default).
-    const safeCwd = cwd ? cwd.replace(/\\/g, '/').replace(/"/g, '\\"') : undefined;
+    const safeCwd = cwd ? cwd.replace(/\\/g, '/') : undefined;
     const innerCommand = safeCwd ? `cd ${quoteShellArg(safeCwd)} && ${command}` : command;
 
     const fullCommand = `bash -l -c ${quoteShellArg(innerCommand)}`;

--- a/src/main/services/ssh/SshService.ts
+++ b/src/main/services/ssh/SshService.ts
@@ -448,7 +448,10 @@ export class SshService extends EventEmitter {
     }
 
     const target = row.username ? `${row.username}@${row.host}` : row.host;
-    const innerCommand = cwd ? `cd ${quoteShellArg(cwd)} && ${command}` : command;
+
+    const safeCwd = cwd ? cwd.replace(/\\/g, '/') : undefined;
+    const innerCommand = safeCwd ? `cd ${quoteShellArg(safeCwd)} && ${command}` : command;
+
     const fullCommand = `bash -l -c ${quoteShellArg(innerCommand)}`;
 
     try {


### PR DESCRIPTION
## Summary

Fixes incorrect worktree path handling on Windows environments.

Previously, path normalization was inconsistent, which could lead to invalid or broken paths when executing commands via SSH or local shell. This change ensures paths are properly normalized before execution.

## Fixes

Fixes #1641 

## Snapshot

N/A (backend/service-level fix, no UI changes)

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] Chore
* [ ] New feature
* [ ] Breaking change
* [ ] Refactor
* [ ] This change requires a documentation update

## Mandatory Tasks

* [x] I have self-reviewed the code

## Checklist

* [x] I have read the contributing guide
* [x] I have commented my code where necessary
* [ ] I have checked if my PR needs changes to the documentation
* [ ] I have added tests that prove my fix is effective


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Normalize Windows-style backslashes in working-directory strings before running remote commands (applies to primary and fallback execution paths). This improves compatibility and reduces failures when using complex, quoted, or backslash-containing paths, increasing remote command reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->