### PR TITLE
Fix/windows provider cli resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -272,7 +272,6 @@
     },
     "onlyBuiltDependencies": [
       "sqlite3",
-      "node-pty",
       "keytar",
       "electron"
     ],
@@ -281,6 +280,7 @@
       "core-js",
       "cpu-features",
       "esbuild",
+      "node-pty",
       "protobufjs",
       "ssh2"
     ],

--- a/src/main/services/ConnectionsService.ts
+++ b/src/main/services/ConnectionsService.ts
@@ -390,6 +390,12 @@ class ConnectionsService {
         .split(/\r?\n/)
         .map((l) => l.trim())
         .filter(Boolean);
+      if (process.platform === 'win32') {
+        const executable = lines.find((line) => /\.(com|exe|bat|cmd|ps1)$/i.test(line));
+        if (executable) {
+          return executable;
+        }
+      }
       return lines[0] ?? null;
     } catch {
       return null;

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -981,7 +981,8 @@ function resolveCommandPath(command: string): string | null {
       .split(';')
       .map((ext) => ext.trim())
       .filter(Boolean);
-    return [base, ...exts.map((ext) => `${base}${ext.toLowerCase()}`)];
+    const expanded = exts.map((ext) => `${base}${ext.toLowerCase()}`);
+    return [...expanded, base];
   };
 
   const resolveFromCandidates = (bases: string[], makeAbsolute: boolean): string | null => {

--- a/src/test/main/ConnectionsService.test.ts
+++ b/src/test/main/ConnectionsService.test.ts
@@ -209,4 +209,32 @@ describe('ConnectionsService – resolveStatus', () => {
     expect(statusMap.claude?.installed).toBe(true);
     expect(statusMap.claude?.path).toBeNull();
   });
+
+  it('prefers executable where results on Windows over extensionless shims', async () => {
+    const originalPlatformDescriptor = Object.getOwnPropertyDescriptor(process, 'platform');
+    Object.defineProperty(process, 'platform', {
+      value: 'win32',
+      configurable: true,
+    });
+
+    execFileSyncMock.mockReturnValue(
+      'C:\\Users\\test\\AppData\\Roaming\\npm\\codex\r\nC:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd\r\n'
+    );
+    spawnEmits({ stdout: '0.27.0\n', closeCode: 0 });
+
+    try {
+      const { connectionsService } = await import('../../main/services/ConnectionsService');
+      await connectionsService.checkProvider('codex', 'manual');
+    } finally {
+      if (originalPlatformDescriptor) {
+        Object.defineProperty(process, 'platform', originalPlatformDescriptor);
+      }
+    }
+
+    expect(statusMap.codex?.installed).toBe(true);
+    expect(statusMap.codex?.path).toBe('C:\\Users\\test\\AppData\\Roaming\\npm\\codex.cmd');
+    const firstSpawnCall = spawnMock.mock.calls[0];
+    expect(firstSpawnCall?.[0]).toMatch(/cmd\.exe$/i);
+    expect(firstSpawnCall?.[1]).toEqual(expect.arrayContaining(['/d', '/s', '/c']));
+  });
 });


### PR DESCRIPTION
## Summary

On Windows, provider discovery can return multiple lines from `where`-style resolution (e.g. an extensionless npm shim plus `codex.cmd`). This PR prefers a line that looks like a real executable on `win32`, and updates `resolveCommandPath` so `PATHEXT`-qualified candidates are tried before the bare name—so spawned CLIs resolve to an actual executable.

A second commit adjusts pnpm’s native build allowlist so `node-pty`’s **install-time** `node-gyp` step is skipped. Native `node-pty` is still built in **`postinstall` via `electron-rebuild`** for Electron, which is what the app loads; this avoids redundant/broken Node-targeted builds on some Windows toolchain setups.

## Fixes

Fixes #1667

## Snapshot

N/A — behavior fix (CLI path resolution / install reliability on Windows); no UI change.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update

## Mandatory Tasks

- [x] I have self-reviewed the code

## Checklist

- [x] I have read the contributing guide
- [ ] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows executable resolution to prioritize files with recognized extensions (.com, .exe, .bat, .cmd, .ps1).

* **Tests**
  * Added test coverage for Windows command path resolution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->