### PR TITLE
fix: persist sidebar folder collapse state

### DIFF
--- a/src/renderer/components/sidebar/LeftSidebar.tsx
+++ b/src/renderer/components/sidebar/LeftSidebar.tsx
@@ -316,21 +316,6 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
   const changelogCardRef = useRef<HTMLDivElement | null>(null);
   const [changelogCardHeight, setChangelogCardHeight] = useState(0);
 
-  const [forceOpenIds, setForceOpenIds] = useState<Set<string>>(new Set());
-  const prevTaskCountsRef = useRef<Map<string, number>>(new Map());
-
-  useEffect(() => {
-    const prev = prevTaskCountsRef.current;
-    for (const project of projects) {
-      const taskCount = tasksByProjectId[project.id]?.length ?? 0;
-      const prevCount = prev.get(project.id) ?? 0;
-      if (prevCount === 0 && taskCount > 0) {
-        setForceOpenIds((s) => new Set(s).add(project.id));
-      }
-      prev.set(project.id, taskCount);
-    }
-  }, [projects, tasksByProjectId]);
-
   useEffect(() => {
     onSidebarContextChange?.({ open, isMobile, setOpen });
   }, [open, isMobile, setOpen, onSidebarContextChange]);
@@ -481,21 +466,8 @@ export const LeftSidebar: React.FC<LeftSidebarProps> = ({
                       return (
                         <SidebarMenuItem>
                           <Collapsible
-                            open={
-                              forceOpenIds.has(typedProject.id)
-                                ? true
-                                : !collapsedProjects.has(typedProject.id)
-                            }
+                            open={!collapsedProjects.has(typedProject.id)}
                             onOpenChange={(isOpen) => {
-                              // When force-open is active, clear it first
-                              if (forceOpenIds.has(typedProject.id)) {
-                                setForceOpenIds((s) => {
-                                  const n = new Set(s);
-                                  n.delete(typedProject.id);
-                                  return n;
-                                });
-                              }
-                              // Sync with persisted state
                               const shouldBeCollapsed = !isOpen;
                               setCollapsedProjectsArray((prev) => {
                                 const prevSet = new Set(prev);


### PR DESCRIPTION
## Summary
before we had the issue that you had to press on a folder twice to make it collapse which ofc gave away the feeling that collapsing does work but this fixes it :D 

and i also wanted to have that folders that are collapsed stay collapsed even across restarts but this could be removed if this is not wanted :) would be open to change anything

## Fixes 
Fixes #1670 

## Snapshot
https://streamable.com/nrs4lr

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code

## Checklist

- [X] I have read the contributing guide
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed sidebar projects to properly persist their collapsed/expanded state across sessions.
  * Removed automatic project expansion when new tasks are added, allowing users to maintain their preferred sidebar layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->