### PR TITLE
feat: add 'Reveal in Finder' and 'Open in Terminal' to folder context

### DIFF
--- a/src/renderer/components/FileExplorer/FileTree.tsx
+++ b/src/renderer/components/FileExplorer/FileTree.tsx
@@ -245,17 +245,13 @@ const TreeNode: React.FC<{
         <ContextMenuItem onSelect={() => onContextMenuCopyRelPath?.(node)}>
           Copy Relative Path
         </ContextMenuItem>
-        {node.type === 'file' && (
-          <>
-            <ContextMenuSeparator />
-            <ContextMenuItem onSelect={() => onContextMenuOpenTerminal?.(node)}>
-              Open in Terminal
-            </ContextMenuItem>
-            <ContextMenuItem onSelect={() => onContextMenuReveal?.(node)}>
-              Reveal in Finder
-            </ContextMenuItem>
-          </>
-        )}
+        <ContextMenuSeparator />
+        <ContextMenuItem onSelect={() => onContextMenuOpenTerminal?.(node)}>
+          Open in Terminal
+        </ContextMenuItem>
+        <ContextMenuItem onSelect={() => onContextMenuReveal?.(node)}>
+          Reveal in Finder
+        </ContextMenuItem>
       </ContextMenuContent>
     </ContextMenu>
   );


### PR DESCRIPTION
## Summary
before when in the code editor and you right clicked on a folder there were no options to reveal in finder and open in terminal those were exclusive to files. this now adds it for files and folder

open to update anything :D 

## Fixes 
#1669 

## Snapshot
https://github.com/user-attachments/assets/d58d08b1-4c7d-4a1f-9fb5-1986ae0d4422

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code

## Checklist

- [X] I have read the contributing guide
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * "Open in Terminal" and "Reveal in Finder" actions are now available for directories in addition to files in the context menu.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->