### PR TITLE
fix(terminal): add padding to expanded terminal modal content

### DIFF
--- a/src/renderer/components/ExpandedTerminalModal.tsx
+++ b/src/renderer/components/ExpandedTerminalModal.tsx
@@ -109,15 +109,19 @@ const ExpandedTerminalModal: React.FC<Props> = ({ terminalId, title, onClose, va
           </Button>
         </div>
 
-        {/* Terminal container — click to focus */}
+        {/* Match the embedded terminal inset so expanded mode does not render flush to the modal edge. */}
         <div
-          ref={containerRef}
-          className="flex-1 overflow-hidden"
+          className={cn(
+            'flex-1 overflow-hidden p-2 pt-1',
+            isDark ? 'bg-zinc-900' : 'bg-background'
+          )}
           onClick={() => {
             const session = terminalSessionRegistry.getSession(terminalId);
             session?.focus();
           }}
-        />
+        >
+          <div ref={containerRef} className="h-full w-full overflow-hidden" />
+        </div>
       </div>
     </div>,
     document.body


### PR DESCRIPTION
## Summary

Adds inner padding to the expanded terminal modal so the terminal content doesn't render flush against the modal edge.

## Changes

- Wrapped the terminal container `ref` in a padding wrapper with `p-2 pt-1` to match the embedded terminal inset
- Applied theme-aware background color (`bg-zinc-900` for dark, `bg-background` for light) to the padding wrapper
- Moved the click-to-focus handler to the outer wrapper so clicking the padding area also focuses the terminal

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the expanded terminal modal's visual presentation with improved padding and background styling to ensure better visual consistency and alignment within the modal container.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->