### PR TITLE
fix(shellEnv): scrub AppImage env from shell probe

### DIFF
--- a/src/main/utils/__tests__/shellEnv.test.ts
+++ b/src/main/utils/__tests__/shellEnv.test.ts
@@ -363,10 +363,18 @@ describe('shellEnv', () => {
 
       initializeShellEnvironment();
 
-      // Every execSync invocation in this module should have been handed a
-      // scrubbed env — no AppImage keys, no mount paths in PATH-like vars.
-      expect(mockedExecSync).toHaveBeenCalled();
-      for (const call of mockedExecSync.mock.calls) {
+      // Every probe invocation should have been handed a scrubbed env — no
+      // AppImage keys, no mount paths in PATH-like vars. Filter to the shell
+      // probe calls specifically: on macOS, detectSshAuthSock() also calls
+      // `launchctl getenv SSH_AUTH_SOCK` with no `env` option, and we don't
+      // want that call to trip the `env` assertion below. The probe call
+      // sites in getShellEnvVar / getShellLocaleVars both use `-ilc`, which
+      // is a clean discriminator.
+      const probeCalls = mockedExecSync.mock.calls.filter(
+        (call) => typeof call[0] === 'string' && call[0].includes('-ilc')
+      );
+      expect(probeCalls.length).toBeGreaterThan(0);
+      for (const call of probeCalls) {
         const options = call[1] as { env?: NodeJS.ProcessEnv } | undefined;
         const env = options?.env;
         expect(env).toBeDefined();

--- a/src/main/utils/__tests__/shellEnv.test.ts
+++ b/src/main/utils/__tests__/shellEnv.test.ts
@@ -330,6 +330,60 @@ describe('shellEnv', () => {
       expect(process.env.LC_ALL).toBeUndefined();
     });
 
+    it('should strip AppImage env leakage from the probed shell', () => {
+      // Regression test: shellEnv.ts used to hand `...process.env` wholesale
+      // to the login shell it spawns for env probing. On Linux AppImage
+      // installs this meant the child shell saw APPIMAGE, APPDIR, and the
+      // `/tmp/.mount_*` entries on PATH. If any shell-init plugin (starship,
+      // mise, oh-my-zsh plugins) exec'd a binary by name through PATH, the
+      // exec could resolve back into the AppImage mount and re-enter Emdash's
+      // main process, which would run this probe again — a fork bomb.
+      //
+      // The fix routes the probe's env through buildExternalToolEnv() from
+      // ./childProcessEnv. These assertions lock the behavior in.
+      const appDir = '/tmp/.mount_emdashAbCd';
+      process.env.APPIMAGE = '/home/user/emdash.AppImage';
+      process.env.APPDIR = appDir;
+      process.env.ARGV0 = 'AppRun';
+      process.env.OWD = '/tmp';
+      process.env.PATH = `/usr/local/bin:${appDir}/usr/bin:/usr/bin`;
+      process.env.LD_LIBRARY_PATH = `${appDir}/usr/lib:/usr/local/cuda/lib64`;
+      delete process.env.LANG;
+      delete process.env.LC_CTYPE;
+      delete process.env.LC_ALL;
+
+      mockedExecSync.mockImplementation(
+        shellLookup({
+          SSH_AUTH_SOCK: '/detected/socket',
+          LANG: 'C.UTF-8',
+          LC_CTYPE: 'C.UTF-8',
+          LC_ALL: 'C.UTF-8',
+        })
+      );
+
+      initializeShellEnvironment();
+
+      // Every execSync invocation in this module should have been handed a
+      // scrubbed env — no AppImage keys, no mount paths in PATH-like vars.
+      expect(mockedExecSync).toHaveBeenCalled();
+      for (const call of mockedExecSync.mock.calls) {
+        const options = call[1] as { env?: NodeJS.ProcessEnv } | undefined;
+        const env = options?.env;
+        expect(env).toBeDefined();
+        if (!env) continue;
+        expect(env.APPIMAGE).toBeUndefined();
+        expect(env.APPDIR).toBeUndefined();
+        expect(env.ARGV0).toBeUndefined();
+        expect(env.OWD).toBeUndefined();
+        expect(env.PATH).toBeDefined();
+        expect(env.PATH).not.toContain(appDir);
+        expect(env.PATH).not.toContain('/tmp/.mount_');
+        expect(env.LD_LIBRARY_PATH).toBeDefined();
+        expect(env.LD_LIBRARY_PATH).not.toContain(appDir);
+        expect(env.LD_LIBRARY_PATH).not.toContain('/tmp/.mount_');
+      }
+    });
+
     it('should drop non-UTF-8 overrides when LANG is already UTF-8', () => {
       process.env.LANG = 'en_US.UTF-8';
       process.env.LC_CTYPE = 'C';

--- a/src/main/utils/shellEnv.ts
+++ b/src/main/utils/shellEnv.ts
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as os from 'os';
 import { stripAnsi } from '@shared/text/stripAnsi';
+import { buildExternalToolEnv } from './childProcessEnv';
 import { LOCALE_ENV_VARS, DEFAULT_UTF8_LOCALE, isUtf8Locale } from './locale';
 
 const SHELL_VALUE_START = '__EMDASH_SHELL_VALUE_START__';
@@ -40,13 +41,28 @@ export function getShellEnvVar(varName: string): string | undefined {
     const shell = process.env.SHELL || (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
 
     // -i = interactive, -l = login shell (sources .zshrc/.bash_profile)
+    //
+    // Env: route through buildExternalToolEnv() to strip AppImage-only keys
+    // (APPIMAGE, APPDIR, ARGV0, ...) and AppImage mount entries from PATH /
+    // LD_LIBRARY_PATH / XDG_DATA_DIRS before handing them to the child shell.
+    //
+    // WHY: Without this, a Linux AppImage install leaks APPIMAGE and the
+    // `/tmp/.mount_*` PATH entries into the probed login shell. If the user's
+    // .zshrc / .bash_profile exec's any binary by name through PATH (starship
+    // version modules, mise activation hooks, oh-my-zsh completion plugins all
+    // do some flavor of this), the exec can resolve back into the AppImage
+    // mount, which re-enters Emdash's main process, which runs this probe
+    // again, which spawns another shell — a fork bomb that OOMs the machine.
+    // See the matching rationale and helper at
+    // src/main/utils/childProcessEnv.ts and the ptyManager.ts:1404 comment
+    // introduced by issue #485 / PR #872.
     const result = execSync(
       `${shell} -ilc 'printf "${SHELL_VALUE_START}\\n"; printenv ${varName}; printf "${SHELL_VALUE_END}\\n"; exit 0'`,
       {
         encoding: 'utf8',
         timeout: 5000,
         env: {
-          ...process.env,
+          ...buildExternalToolEnv(process.env),
           // Prevent oh-my-zsh plugins from breaking output
           DISABLE_AUTO_UPDATE: 'true',
           ZSH_TMUX_AUTOSTART: 'false',
@@ -234,11 +250,12 @@ function getShellLocaleVars(): Partial<Record<string, string>> {
     const printCommands = LOCALE_ENV_VARS.map((v) => `printenv ${v} || echo`).join(
       '; echo "---"; '
     );
+    // See getShellEnvVar for the rationale behind buildExternalToolEnv.
     const result = execSync(`${shell} -ilc '${printCommands}; exit 0'`, {
       encoding: 'utf8',
       timeout: 5000,
       env: {
-        ...process.env,
+        ...buildExternalToolEnv(process.env),
         DISABLE_AUTO_UPDATE: 'true',
         ZSH_TMUX_AUTOSTART: 'false',
         ZSH_TMUX_AUTOSTARTED: 'true',


### PR DESCRIPTION
## Summary
- `src/main/utils/shellEnv.ts` spawned `$SHELL -ilc '<probe>'` with `process.env` passed wholesale, leaking `APPIMAGE` / `APPDIR` / `/tmp/.mount_*` `PATH` entries into the child shell on Linux AppImage installs. Any shell-init code that exec's a binary by name through `PATH` (starship version modules, mise activation hooks, oh-my-zsh completion plugins) could then re-enter the AppImage binary and fork-bomb Emdash. See #1679 for the failure mode.
- Route the probe env through `buildExternalToolEnv()` from `src/main/utils/childProcessEnv.ts` — the same helper already used by `ptyManager.ts` (introduced by #485) and `appIpc.ts` (#872). `shellEnv.ts` was the remaining `process.env`-wholesale call site.
- Adds a regression test that mocks `execSync` and asserts the spawned env has `APPIMAGE` / `APPDIR` / `ARGV0` / `OWD` stripped and no `/tmp/.mount_*` entries left in `PATH` / `LD_LIBRARY_PATH`.

## Fixes
Fixes #1679

## Test plan
- [x] `pnpm run format` — clean
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run type-check` — clean
- [x] `pnpm exec vitest run` — 878 passing, 1 skipped, 82 files
- [x] Regression test verified by stash-and-rerun: fails without the fix (`expected '/home/user/emdash.AppImage' to be undefined`), passes with it
- [ ] Manual end-to-end verification against a real AppImage build was not performed; a standalone sandboxed reproducer of the mechanism (`systemd-run --scope` + `zsh -ilc` + PATH-based version probe) confirmed the upstream cause and is available on request

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented AppImage-related environment variables and mount paths from leaking into probed shell environments during initialization.

* **Tests**
  * Added a regression test that verifies AppImage env keys and mount entries are stripped when detecting the shell environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->