### PR TITLE
feat(claude): allow enabling skip-permissions toggle on running tasks

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -1202,14 +1202,40 @@ const ChatInterface: React.FC<Props> = ({
                     githubIssue={task.metadata?.githubIssue || null}
                     jiraIssue={task.metadata?.jiraIssue || null}
                   />
-                  {autoApproveEnabled && (
-                    <span
-                      className="inline-flex h-7 select-none items-center gap-1.5 rounded-md border border-border bg-muted px-2.5 text-xs font-medium text-foreground"
-                      title="Auto-approve enabled"
+                  {Boolean(agentMeta[agent]?.autoApproveFlag) && (
+                    <button
+                      type="button"
+                      onClick={() => {
+                        const next = !autoApproveEnabled;
+                        void rpc.db.saveTask({
+                          ...task,
+                          metadata: {
+                            ...task.metadata,
+                            autoApprove: next,
+                          },
+                        });
+                        if (next) {
+                          // Kill the running PTY so the session manager restarts it
+                          // with autoApprove: true on next spawn.
+                          window.electronAPI.ptyKill(terminalId);
+                        }
+                      }}
+                      className={`inline-flex h-7 select-none items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors ${
+                        autoApproveEnabled
+                          ? 'border-orange-500/40 bg-orange-500/10 text-orange-600 hover:bg-orange-500/20 dark:text-orange-400'
+                          : 'border-border bg-muted text-muted-foreground hover:bg-accent hover:text-foreground'
+                      }`}
+                      title={
+                        autoApproveEnabled
+                          ? 'Auto-approve enabled — click to disable'
+                          : 'Enable auto-approve (skip permissions)'
+                      }
                     >
-                      <span className="h-1.5 w-1.5 rounded-full bg-orange-500" />
+                      <span
+                        className={`h-1.5 w-1.5 rounded-full ${autoApproveEnabled ? 'bg-orange-500' : 'bg-muted-foreground'}`}
+                      />
                       Auto-approve
-                    </span>
+                    </button>
                   )}
                 </div>
               </div>

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -937,9 +937,15 @@ const ChatInterface: React.FC<Props> = ({
   // 2. The global "auto-approve by default" setting is on
   // In both cases the provider must actually support an auto-approve flag.
   const { settings: autoApproveSettings } = useAppSettings();
+  const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
+  useEffect(() => {
+    setAutoApproveOverride(null);
+  }, [task.id]);
   const autoApproveEnabled =
-    (Boolean(task.metadata?.autoApprove) ||
-      Boolean(autoApproveSettings?.tasks?.autoApproveByDefault)) &&
+    (autoApproveOverride !== null
+      ? autoApproveOverride
+      : Boolean(task.metadata?.autoApprove) ||
+        Boolean(autoApproveSettings?.tasks?.autoApproveByDefault)) &&
     Boolean(agentMeta[agent]?.autoApproveFlag);
 
   const isMainConversation = activeConversationId === mainConversationId;
@@ -1206,20 +1212,33 @@ const ChatInterface: React.FC<Props> = ({
                     <button
                       type="button"
                       onClick={() => {
-                        const next = !autoApproveEnabled;
-                        void rpc.db.saveTask({
-                          ...task,
-                          metadata: {
-                            ...task.metadata,
-                            autoApprove: next,
-                          },
-                        });
-                        if (next) {
-                          // Kill the running PTY so the session manager restarts it
-                          // with autoApprove: true on next spawn.
-                          window.electronAPI.ptyKill(terminalId);
-                        }
-                      }}
+                  void (async () => {
+                    const next = !autoApproveEnabled;
+                    setAutoApproveOverride(next);
+                    try {
+                      await rpc.db.saveTask({
+                        ...task,
+                        metadata: {
+                          ...task.metadata,
+                          autoApprove: next,
+                        },
+                      });
+                      if (next) {
+                        // Kill the running PTY so the session manager restarts it
+                        // with autoApprove: true on next spawn.
+                        window.electronAPI.ptyKill(terminalId);
+                      }
+                      } catch (error) {
+                      console.error('Failed to update auto-approve setting:', error);
+                      setAutoApproveOverride(null);
+                      toast({
+                        title: 'Error',
+                        description: 'Failed to update auto-approve setting.',
+                        variant: 'destructive',
+                      });
+                    }
+                  })();
+                }}
                       className={`inline-flex h-7 select-none items-center gap-1.5 rounded-md border px-2.5 text-xs font-medium transition-colors ${
                         autoApproveEnabled
                           ? 'border-orange-500/40 bg-orange-500/10 text-orange-600 hover:bg-orange-500/20 dark:text-orange-400'


### PR DESCRIPTION
## What
Converts the read-only "Auto-approve" badge in the task tab bar into a 
clickable toggle. Users can now enable or disable skip-permissions 
for file operations on an already-running task — no restart required.

Closes #1671

## Why
Previously, if a user forgot to enable "Skip permissions for file 
operations" at task creation time, they had no way to enable it 
mid-session. The only option was to stop the task and lose context.

## How
- The badge is now a `<button>` that toggles `task.metadata.autoApprove`
- On **enable**: persists to DB and kills the PTY — the session manager 
  restarts it with `--dangerously-skip-permissions` and Claude's resume 
  flag, preserving session context
- On **disable**: persists to DB only — the current session continues 
  uninterrupted; the flag is removed on next spawn
- Button is only shown for providers that have `autoApproveFlag` defined 
  (Claude, Codex, Gemini, etc.)
- Visual state: orange when active, muted when inactive

## Testing
- Create a Claude task without skip-permissions → grey button visible → 
  click → PTY restarts with flag → button turns orange
- Create with skip-permissions → orange → click → grey, session continues
- Non-Claude providers (no `autoApproveFlag`): button not shown
- `pnpm run type-check` and `pnpm run lint` pass

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code

## Checklist

- [x] I have read the contributing guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Auto-approve is now an interactive toggle shown only for agents that support it.
  * Toggle respects a temporary override (resets when switching tasks) and otherwise falls back to task/global settings.
  * Enabling auto-approve triggers an immediate terminal restart; failures clear the override and show a destructive error toast.

* **Style**
  * Visual indicator, tooltip text, and dot color update dynamically to reflect enabled/disabled state.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->