### PR TITLE
feat: display remote project paths and safely disambiguate same-path hosts

### DIFF
--- a/drizzle/0013_remove_projects_path_unique.sql
+++ b/drizzle/0013_remove_projects_path_unique.sql
@@ -1,0 +1,2 @@
+-- Drop the unique index on projects.path to allow remote projects with the same path but different sshConnectionId
+DROP INDEX IF EXISTS idx_projects_path;

--- a/drizzle/meta/0013_snapshot.json
+++ b/drizzle/meta/0013_snapshot.json
@@ -1,0 +1,13 @@
+{
+  "id": "d2c07f6e-5672-45a9-a9f5-fec5931b3ce2",
+  "prevId": "00000000-0000-0000-0000-000000000000",
+  "version": "6",
+  "dialect": "sqlite",
+  "tables": {},
+  "enums": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1776959681864,
       "tag": "0006_bumpy_gamma_corps",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1775625447056,
+      "tag": "0013_remove_projects_path_unique",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -53,7 +53,8 @@ export const projects = sqliteTable(
       .default(sql`CURRENT_TIMESTAMP`),
   },
   (table) => ({
-    pathIdx: uniqueIndex('idx_projects_path').on(table.path),
+    // Note: path uniqueness is enforced at the application layer in DatabaseService.saveProject
+    // to allow remote projects with the same path but different sshConnectionId.
     sshConnectionIdIdx: index('idx_projects_ssh_connection_id').on(table.sshConnectionId),
   })
 );

--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -1,0 +1,2887 @@
+import { BrowserWindow, ipcMain } from 'electron';
+import { log } from '../lib/logger';
+import { exec, execFile } from 'child_process';
+import { randomUUID } from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { promisify } from 'util';
+import {
+  getStatus as gitGetStatus,
+  getFileDiff as gitGetFileDiff,
+  updateIndex as gitUpdateIndex,
+  revertFile as gitRevertFile,
+  commit as gitCommit,
+  push as gitPush,
+  pull as gitPull,
+  getLog as gitGetLog,
+  getLatestCommit as gitGetLatestCommit,
+  getCommitFiles as gitGetCommitFiles,
+  getCommitFileDiff as gitGetCommitFileDiff,
+  softResetLastCommit as gitSoftResetLastCommit,
+} from '../services/GitService';
+import type { GitIndexUpdateArgs } from '../../shared/git/types';
+import { prGenerationService } from '../services/PrGenerationService';
+import { databaseService } from '../services/DatabaseService';
+import { injectIssueFooter } from '../lib/prIssueFooter';
+import { getCreatePrBodyPlan } from '../lib/prCreateBodyPlan';
+import { patchCurrentPrBodyWithIssueFooter } from '../lib/prIssueFooterPatch';
+import { getAppSettings } from '../settings';
+import {
+  resolveRemoteProjectForWorktreePath,
+  resolveRemoteContext,
+} from '../utils/remoteProjectResolver';
+import { RemoteGitService } from '../services/RemoteGitService';
+import { sshService } from '../services/ssh/SshService';
+
+const remoteGitService = new RemoteGitService(sshService);
+
+const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+
+const GIT_STATUS_DEBOUNCE_MS = 500;
+const supportsRecursiveWatch = process.platform === 'darwin' || process.platform === 'win32';
+
+type GitStatusWatchEntry = {
+  watcher: fs.FSWatcher;
+  watchIds: Set<string>;
+  debounceTimer?: NodeJS.Timeout;
+};
+
+const gitStatusWatchers = new Map<string, GitStatusWatchEntry>();
+
+// Remote polling for SSH projects (replaces fs.watch)
+const REMOTE_POLL_INTERVAL_MS = 5000;
+type RemoteStatusPollEntry = {
+  intervalId: NodeJS.Timeout;
+  watchIds: Set<string>;
+  lastStatusHash: string;
+  connectionId: string;
+};
+const remoteStatusPollers = new Map<string, RemoteStatusPollEntry>();
+
+function shouldAutoCloseLinkedIssuesOnPrCreate(): boolean {
+  return getAppSettings().repository.autoCloseLinkedIssuesOnPrCreate !== false;
+}
+
+const ensureRemoteStatusPoller = (
+  taskPath: string,
+  connectionId: string,
+  remotePath?: string
+): { success: true; watchId: string } => {
+  const gitPath = remotePath || taskPath;
+  const watchId = randomUUID();
+  const existing = remoteStatusPollers.get(taskPath);
+  if (existing) {
+    existing.watchIds.add(watchId);
+    return { success: true, watchId };
+  }
+
+  const entry: RemoteStatusPollEntry = {
+    intervalId: setInterval(async () => {
+      try {
+        const changes = await remoteGitService.getStatusDetailed(connectionId, gitPath);
+        // Simple hash: join paths + statuses to detect changes
+        const hash = changes.map((c) => `${c.path}:${c.status}:${c.isStaged}`).join('|');
+        const poller = remoteStatusPollers.get(taskPath);
+        if (!poller) return;
+        if (hash !== poller.lastStatusHash) {
+          poller.lastStatusHash = hash;
+          broadcastGitStatusChange(taskPath);
+        }
+      } catch {
+        // Connection may have dropped — don't crash, just skip this poll
+      }
+    }, REMOTE_POLL_INTERVAL_MS),
+    watchIds: new Set([watchId]),
+    lastStatusHash: '',
+    connectionId,
+  };
+  remoteStatusPollers.set(taskPath, entry);
+  return { success: true, watchId };
+};
+
+const releaseRemoteStatusPoller = (taskPath: string, watchId?: string) => {
+  const entry = remoteStatusPollers.get(taskPath);
+  if (!entry) return { success: true as const };
+  if (watchId) {
+    entry.watchIds.delete(watchId);
+  }
+  if (entry.watchIds.size <= 0) {
+    clearInterval(entry.intervalId);
+    remoteStatusPollers.delete(taskPath);
+  }
+  return { success: true as const };
+};
+
+/**
+ * Validate that a taskPath is an absolute path pointing to a real directory
+ * that is a git repository. Returns an error string if invalid, or null if OK.
+ */
+function validateTaskPath(taskPath: string | undefined): string | null {
+  if (!taskPath) return 'Missing taskPath';
+  if (!path.isAbsolute(taskPath)) return 'taskPath must be absolute';
+  try {
+    const stat = fs.statSync(taskPath);
+    if (!stat.isDirectory()) return 'taskPath is not a directory';
+  } catch {
+    return 'taskPath does not exist';
+  }
+  return null;
+}
+
+const broadcastGitStatusChange = (taskPath: string, error?: string) => {
+  const windows = BrowserWindow.getAllWindows();
+  windows.forEach((window) => {
+    try {
+      window.webContents.send('git:status-changed', { taskPath, error });
+    } catch (err) {
+      log.debug('[git:watch-status] failed to send status change', err);
+    }
+  });
+};
+
+const ensureGitStatusWatcher = (taskPath: string) => {
+  if (!supportsRecursiveWatch) {
+    return { success: false as const, error: 'recursive-watch-unsupported' };
+  }
+  if (!taskPath || !fs.existsSync(taskPath)) {
+    return { success: false as const, error: 'workspace-unavailable' };
+  }
+  const existing = gitStatusWatchers.get(taskPath);
+  const watchId = randomUUID();
+  if (existing) {
+    existing.watchIds.add(watchId);
+    return { success: true as const, watchId };
+  }
+  try {
+    const watcher = fs.watch(taskPath, { recursive: true }, () => {
+      const entry = gitStatusWatchers.get(taskPath);
+      if (!entry) return;
+      if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+      entry.debounceTimer = setTimeout(() => {
+        broadcastGitStatusChange(taskPath);
+      }, GIT_STATUS_DEBOUNCE_MS);
+    });
+    watcher.on('error', (error) => {
+      log.warn('[git:watch-status] watcher error', error);
+      const entry = gitStatusWatchers.get(taskPath);
+      if (entry?.debounceTimer) clearTimeout(entry.debounceTimer);
+      try {
+        entry?.watcher.close();
+      } catch {}
+      gitStatusWatchers.delete(taskPath);
+      broadcastGitStatusChange(taskPath, 'watcher-error');
+    });
+    gitStatusWatchers.set(taskPath, { watcher, watchIds: new Set([watchId]) });
+    return { success: true as const, watchId };
+  } catch (error) {
+    return {
+      success: false as const,
+      error: error instanceof Error ? error.message : 'Failed to watch workspace',
+    };
+  }
+};
+
+const releaseGitStatusWatcher = (taskPath: string, watchId?: string) => {
+  const entry = gitStatusWatchers.get(taskPath);
+  if (!entry) return { success: true as const };
+  if (watchId) {
+    entry.watchIds.delete(watchId);
+  }
+  if (entry.watchIds.size <= 0) {
+    if (entry.debounceTimer) clearTimeout(entry.debounceTimer);
+    entry.watcher.close();
+    gitStatusWatchers.delete(taskPath);
+  }
+  return { success: true as const };
+};
+
+export function registerGitIpc() {
+  function resolveGitBin(): string {
+    // Allow override via env
+    const fromEnv = (process.env.GIT_PATH || '').trim();
+    const candidates = [
+      fromEnv,
+      '/opt/homebrew/bin/git',
+      '/usr/local/bin/git',
+      '/usr/bin/git',
+    ].filter(Boolean) as string[];
+    for (const p of candidates) {
+      try {
+        if (p && fs.existsSync(p)) return p;
+      } catch {}
+    }
+    // Last resort: try /usr/bin/env git
+    return 'git';
+  }
+  const GIT = resolveGitBin();
+
+  // Helper: commit-and-push for remote SSH projects
+  async function commitAndPushRemote(
+    connectionId: string,
+    taskPath: string,
+    opts: { commitMessage: string; createBranchIfOnDefault: boolean; branchPrefix: string }
+  ): Promise<{ success: boolean; branch?: string; output?: string; error?: string }> {
+    const { commitMessage, createBranchIfOnDefault, branchPrefix } = opts;
+
+    // Verify git repo
+    const verifyResult = await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      'rev-parse --is-inside-work-tree'
+    );
+    if (verifyResult.exitCode !== 0) {
+      return { success: false, error: 'Not a git repository' };
+    }
+
+    let activeBranch = await remoteGitService.getCurrentBranch(connectionId, taskPath);
+    const defaultBranch = await remoteGitService.getDefaultBranchName(connectionId, taskPath);
+
+    // Create feature branch if on default
+    if (createBranchIfOnDefault && (!activeBranch || activeBranch === defaultBranch)) {
+      const short = Date.now().toString(36);
+      const name = `${branchPrefix}/${short}`;
+      await remoteGitService.createBranch(connectionId, taskPath, name);
+      activeBranch = name;
+    }
+
+    // Check for changes
+    const statusResult = await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      'status --porcelain --untracked-files=all'
+    );
+    const hasWorkingChanges = Boolean(statusResult.stdout?.trim());
+
+    // Read staged files
+    const readRemoteStagedFiles = async (): Promise<string[]> => {
+      const r = await remoteGitService.execGit(connectionId, taskPath, 'diff --cached --name-only');
+      return (r.stdout || '')
+        .split('\n')
+        .map((f) => f.trim())
+        .filter(Boolean);
+    };
+
+    let stagedFiles = await readRemoteStagedFiles();
+
+    // Auto-stage if nothing staged yet
+    if (hasWorkingChanges && stagedFiles.length === 0) {
+      await remoteGitService.updateIndex(connectionId, taskPath, {
+        action: 'stage',
+        scope: 'all',
+      });
+    }
+
+    // Unstage plan mode artifacts
+    await remoteGitService.execGit(connectionId, taskPath, 'reset -q .emdash 2>/dev/null || true');
+    await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      'reset -q PLANNING.md 2>/dev/null || true'
+    );
+    await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      'reset -q planning.md 2>/dev/null || true'
+    );
+
+    stagedFiles = await readRemoteStagedFiles();
+
+    // Commit
+    if (stagedFiles.length > 0) {
+      const commitResult = await remoteGitService.commit(connectionId, taskPath, commitMessage);
+      if (commitResult.exitCode !== 0 && !/nothing to commit/i.test(commitResult.stderr || '')) {
+        return { success: false, error: commitResult.stderr || 'Commit failed' };
+      }
+    }
+
+    // Push
+    const pushResult = await remoteGitService.push(connectionId, taskPath);
+    if (pushResult.exitCode !== 0) {
+      const retryResult = await remoteGitService.push(connectionId, taskPath, activeBranch, true);
+      if (retryResult.exitCode !== 0) {
+        return { success: false, error: retryResult.stderr || 'Push failed' };
+      }
+    }
+
+    const finalStatus = await remoteGitService.execGit(connectionId, taskPath, 'status -sb');
+    return { success: true, branch: activeBranch, output: (finalStatus.stdout || '').trim() };
+  }
+
+  // Helper: get PR status for remote SSH projects
+  async function getPrStatusRemote(
+    connectionId: string,
+    taskPath: string
+  ): Promise<{ success: boolean; pr?: any; error?: string }> {
+    const queryFields = [
+      'number',
+      'url',
+      'state',
+      'isDraft',
+      'mergeStateStatus',
+      'headRefName',
+      'baseRefName',
+      'title',
+      'author',
+      'additions',
+      'deletions',
+      'changedFiles',
+      'autoMergeRequest',
+    ];
+    const fieldsStr = queryFields.join(',');
+
+    const viewResult = await remoteGitService.execGh(
+      connectionId,
+      taskPath,
+      `pr view --json ${fieldsStr} -q .`
+    );
+    let data =
+      viewResult.exitCode === 0 && viewResult.stdout.trim()
+        ? JSON.parse(viewResult.stdout.trim())
+        : null;
+
+    // Fallback: find by branch name
+    if (!data) {
+      const branch = await remoteGitService.getCurrentBranch(connectionId, taskPath);
+      if (branch) {
+        const listResult = await remoteGitService.execGh(
+          connectionId,
+          taskPath,
+          `pr list --head ${quoteGhArg(branch)} --json ${fieldsStr} --limit 1`
+        );
+        if (listResult.exitCode === 0 && listResult.stdout.trim()) {
+          const listData = JSON.parse(listResult.stdout.trim());
+          if (Array.isArray(listData) && listData.length > 0) data = listData[0];
+        }
+      }
+    }
+
+    if (!data) return { success: true, pr: null };
+
+    // Compute diff stats if missing
+    const asNumber = (v: any): number | null =>
+      typeof v === 'number' && Number.isFinite(v) ? v : null;
+    if (
+      asNumber(data.additions) === null ||
+      asNumber(data.deletions) === null ||
+      asNumber(data.changedFiles) === null
+    ) {
+      const baseRef = typeof data.baseRefName === 'string' ? data.baseRefName.trim() : '';
+      const targetRef = baseRef ? `origin/${baseRef}` : '';
+      const cmd = targetRef
+        ? `diff --shortstat ${quoteGhArg(targetRef)}...HEAD`
+        : 'diff --shortstat HEAD~1..HEAD';
+      const diffResult = await remoteGitService.execGit(connectionId, taskPath, cmd);
+      if (diffResult.exitCode === 0) {
+        const m = (diffResult.stdout || '').match(
+          /(\d+)\s+files? changed(?:,\s+(\d+)\s+insertions?\(\+\))?(?:,\s+(\d+)\s+deletions?\(-\))?/
+        );
+        if (m) {
+          if (asNumber(data.changedFiles) === null && m[1]) data.changedFiles = parseInt(m[1], 10);
+          if (asNumber(data.additions) === null && m[2]) data.additions = parseInt(m[2], 10);
+          if (asNumber(data.deletions) === null && m[3]) data.deletions = parseInt(m[3], 10);
+        }
+      }
+    }
+
+    return { success: true, pr: data };
+  }
+
+  // Helper: create PR for remote SSH projects
+  async function createPrRemote(
+    connectionId: string,
+    taskPath: string,
+    opts: {
+      title?: string;
+      body?: string;
+      base?: string;
+      head?: string;
+      draft?: boolean;
+      web?: boolean;
+      fill?: boolean;
+    }
+  ): Promise<{ success: boolean; url?: string; output?: string; error?: string; code?: string }> {
+    const { title, body, base, head, draft, web, fill } = opts;
+    const outputs: string[] = [];
+
+    const autoCloseLinkedIssuesOnPrCreate = shouldAutoCloseLinkedIssuesOnPrCreate();
+
+    // Enrich body with issue footer
+    let prBody = body;
+    if (autoCloseLinkedIssuesOnPrCreate) {
+      try {
+        const task = await databaseService.getTaskByPath(taskPath);
+        prBody = injectIssueFooter(body, task?.metadata);
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    const {
+      shouldPatchFilledBody,
+      shouldUseBodyFile: _unused,
+      shouldUseFill,
+    } = getCreatePrBodyPlan({
+      fill,
+      title,
+      rawBody: body,
+      enrichedBody: prBody,
+    });
+
+    // Stage and commit pending changes
+    const statusResult = await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      'status --porcelain --untracked-files=all'
+    );
+    if (statusResult.stdout?.trim()) {
+      await remoteGitService.updateIndex(connectionId, taskPath, {
+        action: 'stage',
+        scope: 'all',
+      });
+      const commitResult = await remoteGitService.commit(
+        connectionId,
+        taskPath,
+        'stagehand: prepare pull request'
+      );
+      if (commitResult.exitCode !== 0 && !/nothing to commit/i.test(commitResult.stderr || '')) {
+        outputs.push(commitResult.stderr || '');
+      }
+    }
+
+    // Push branch
+    const pushResult = await remoteGitService.push(connectionId, taskPath);
+    if (pushResult.exitCode !== 0) {
+      const branch = await remoteGitService.getCurrentBranch(connectionId, taskPath);
+      const retryResult = await remoteGitService.push(connectionId, taskPath, branch, true);
+      if (retryResult.exitCode !== 0) {
+        return {
+          success: false,
+          error:
+            'Failed to push branch to origin. Please check your Git remotes and authentication.',
+        };
+      }
+    }
+    outputs.push('git push: success');
+
+    // Resolve branches
+    const currentBranch = await remoteGitService.getCurrentBranch(connectionId, taskPath);
+    const defaultBranch = await remoteGitService.getDefaultBranchName(connectionId, taskPath);
+
+    // Validate commits ahead
+    const baseRef = base || defaultBranch;
+    const aheadResult = await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      `rev-list --count origin/${quoteGhArg(baseRef)}..HEAD`
+    );
+    const aheadCount = parseInt((aheadResult.stdout || '0').trim(), 10) || 0;
+    if (aheadCount <= 0) {
+      return {
+        success: false,
+        error: `No commits to create a PR. Make a commit on current branch '${currentBranch}' ahead of base '${baseRef}'.`,
+      };
+    }
+
+    // Build gh pr create command
+    const flags: string[] = [];
+    if (title) flags.push(`--title ${quoteGhArg(title)}`);
+    // Can't use --body-file on remote, use --body instead
+    if (prBody && !shouldUseFill) flags.push(`--body ${quoteGhArg(prBody)}`);
+    flags.push(`--base ${quoteGhArg(baseRef)}`);
+    if (head) {
+      flags.push(`--head ${quoteGhArg(head)}`);
+    } else if (currentBranch) {
+      flags.push(`--head ${quoteGhArg(currentBranch)}`);
+    }
+    if (draft) flags.push('--draft');
+    if (web) flags.push('--web');
+    if (shouldUseFill) flags.push('--fill');
+
+    const createResult = await remoteGitService.execGh(
+      connectionId,
+      taskPath,
+      `pr create ${flags.join(' ')}`
+    );
+
+    const combined = [createResult.stdout, createResult.stderr].filter(Boolean).join('\n').trim();
+    const urlMatch = combined.match(/https?:\/\/\S+/);
+    const url = urlMatch ? urlMatch[0] : null;
+
+    if (createResult.exitCode !== 0) {
+      const restrictionRe =
+        /Auth App access restrictions|authorized OAuth apps|third-parties is limited/i;
+      const prExistsRe = /already exists|already has.*pull request|pull request for branch/i;
+      let code: string | undefined;
+      if (restrictionRe.test(combined)) code = 'ORG_AUTH_APP_RESTRICTED';
+      else if (prExistsRe.test(combined)) code = 'PR_ALREADY_EXISTS';
+      return { success: false, error: combined, output: combined, code };
+    }
+
+    // Patch body if needed
+    if (autoCloseLinkedIssuesOnPrCreate && shouldPatchFilledBody && url) {
+      try {
+        const task = await databaseService.getTaskByPath(taskPath);
+        if (task?.metadata) {
+          const editBody = injectIssueFooter(undefined, task.metadata);
+          if (editBody) {
+            await remoteGitService.execGh(
+              connectionId,
+              taskPath,
+              `pr edit --body ${quoteGhArg(editBody)}`
+            );
+          }
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    const out = [...outputs, combined].filter(Boolean).join('\n');
+    return { success: true, url: url || undefined, output: out };
+  }
+
+  // Helper: merge-to-main for remote SSH projects
+  async function mergeToMainRemote(
+    connectionId: string,
+    taskPath: string
+  ): Promise<{ success: boolean; prUrl?: string; error?: string }> {
+    const currentBranch = await remoteGitService.getCurrentBranch(connectionId, taskPath);
+    const defaultBranch = await remoteGitService.getDefaultBranchName(connectionId, taskPath);
+
+    if (!currentBranch) {
+      return { success: false, error: 'Not on a branch (detached HEAD state).' };
+    }
+    if (currentBranch === defaultBranch) {
+      return {
+        success: false,
+        error: `Already on ${defaultBranch}. Create a feature branch first.`,
+      };
+    }
+
+    // Stage and commit pending changes
+    const statusResult = await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      'status --porcelain --untracked-files=all'
+    );
+    if (statusResult.stdout?.trim()) {
+      await remoteGitService.updateIndex(connectionId, taskPath, {
+        action: 'stage',
+        scope: 'all',
+      });
+      const commitResult = await remoteGitService.commit(
+        connectionId,
+        taskPath,
+        'chore: prepare for merge to main'
+      );
+      if (commitResult.exitCode !== 0 && !/nothing to commit/i.test(commitResult.stderr || '')) {
+        throw new Error(commitResult.stderr || 'Commit failed');
+      }
+    }
+
+    // Push
+    const pushResult = await remoteGitService.push(connectionId, taskPath);
+    if (pushResult.exitCode !== 0) {
+      const retryResult = await remoteGitService.push(connectionId, taskPath, currentBranch, true);
+      if (retryResult.exitCode !== 0) {
+        throw new Error(retryResult.stderr || 'Push failed');
+      }
+    }
+
+    // Create PR
+    let prUrl = '';
+    const createResult = await remoteGitService.execGh(
+      connectionId,
+      taskPath,
+      `pr create --fill --base ${quoteGhArg(defaultBranch)}`
+    );
+    const urlMatch = (createResult.stdout || '').match(/https?:\/\/\S+/);
+    prUrl = urlMatch ? urlMatch[0] : '';
+
+    if (createResult.exitCode !== 0) {
+      if (!/already exists|already has.*pull request/i.test(createResult.stderr || '')) {
+        return { success: false, error: `Failed to create PR: ${createResult.stderr}` };
+      }
+    }
+
+    if (shouldAutoCloseLinkedIssuesOnPrCreate()) {
+      // Patch PR body with issue footer
+      try {
+        const task = await databaseService.getTaskByPath(taskPath);
+        if (task?.metadata) {
+          const footer = injectIssueFooter(undefined, task.metadata);
+          if (footer) {
+            await remoteGitService.execGh(
+              connectionId,
+              taskPath,
+              `pr edit --body ${quoteGhArg(footer)}`
+            );
+          }
+        }
+      } catch {
+        // Non-fatal
+      }
+    }
+
+    // Merge
+    const mergeResult = await remoteGitService.execGh(connectionId, taskPath, 'pr merge --merge');
+    if (mergeResult.exitCode !== 0) {
+      return {
+        success: false,
+        error: `PR created but merge failed: ${mergeResult.stderr}`,
+        prUrl,
+      };
+    }
+    return { success: true, prUrl };
+  }
+
+  // Helper: escape arguments for gh CLI commands run over SSH
+  function quoteGhArg(arg: string): string {
+    // Use the same POSIX single-quote wrapping as quoteShellArg for consistency
+    return `'${arg.replace(/'/g, "'\\''")}'`;
+  }
+
+  const countStatusBuckets = (
+    changes: Array<{ status?: string; isStaged?: boolean }>
+  ): { staged: number; unstaged: number; untracked: number } => {
+    let staged = 0;
+    let unstaged = 0;
+    let untracked = 0;
+    for (const change of changes) {
+      if (change.status === 'untracked') {
+        untracked += 1;
+      } else if (change.isStaged) {
+        staged += 1;
+      } else {
+        unstaged += 1;
+      }
+    }
+    return { staged, unstaged, untracked };
+  };
+
+  const collectChangedPaths = (changes: Array<{ path?: string }>): string[] => {
+    const seen = new Set<string>();
+    const files: string[] = [];
+    for (const change of changes) {
+      const file = typeof change.path === 'string' ? change.path.trim() : '';
+      if (!file || seen.has(file)) continue;
+      seen.add(file);
+      files.push(file);
+    }
+    return files;
+  };
+
+  const getLocalAheadBehind = async (
+    taskPath: string
+  ): Promise<{ ahead: number; behind: number }> => {
+    try {
+      const { stdout } = await execFileAsync(GIT, ['status', '-sb'], { cwd: taskPath });
+      const firstLine = ((stdout || '').split('\n')[0] || '').trim();
+      const aheadMatch = firstLine.match(/ahead\s+(\d+)/i);
+      const behindMatch = firstLine.match(/behind\s+(\d+)/i);
+      return {
+        ahead: aheadMatch ? parseInt(aheadMatch[1], 10) || 0 : 0,
+        behind: behindMatch ? parseInt(behindMatch[1], 10) || 0 : 0,
+      };
+    } catch {
+      return { ahead: 0, behind: 0 };
+    }
+  };
+
+  const getLocalPrForDeleteRisk = async (
+    taskPath: string
+  ): Promise<{ pr: unknown | null; prKnown: boolean; error?: string }> => {
+    const queryFields = [
+      'number',
+      'url',
+      'state',
+      'isDraft',
+      'title',
+      'headRefName',
+      'baseRefName',
+    ];
+    const cmd = `gh pr view --json ${queryFields.join(',')} -q .`;
+    try {
+      const { stdout } = await execAsync(cmd, { cwd: taskPath });
+      const json = (stdout || '').trim();
+      if (!json) return { pr: null, prKnown: true };
+      return { pr: JSON.parse(json), prKnown: true };
+    } catch (error) {
+      const errObj = error as { stderr?: string; message?: string };
+      const msg = (errObj?.stderr || errObj?.message || String(error || '')).trim();
+      if (/no pull requests? found|not found|could not resolve to a pull request/i.test(msg)) {
+        return { pr: null, prKnown: true };
+      }
+      return { pr: null, prKnown: false, error: msg || 'Failed to query pull request status' };
+    }
+  };
+
+  ipcMain.handle(
+    'git:watch-status',
+    async (_, arg: string | { taskPath: string; taskId?: string }) => {
+      const taskPath = typeof arg === 'string' ? arg : arg.taskPath;
+      const taskId = typeof arg === 'string' ? undefined : arg.taskId;
+      const remote = await resolveRemoteContext(taskPath, taskId);
+      if (remote) {
+        return ensureRemoteStatusPoller(taskPath, remote.connectionId, remote.remotePath);
+      }
+      return ensureGitStatusWatcher(taskPath);
+    }
+  );
+
+  ipcMain.handle(
+    'git:unwatch-status',
+    async (_, arg: string | { taskPath: string; taskId?: string }, watchId?: string) => {
+      const taskPath = typeof arg === 'string' ? arg : arg.taskPath;
+      const taskId = typeof arg === 'string' ? undefined : arg.taskId;
+      const remote = await resolveRemoteContext(taskPath, taskId);
+      if (remote) {
+        return releaseRemoteStatusPoller(taskPath, watchId);
+      }
+      return releaseGitStatusWatcher(taskPath, watchId);
+    }
+  );
+
+  // Git: Status (moved from Codex IPC)
+  ipcMain.handle(
+    'git:get-status',
+    async (_, arg: string | { taskPath: string; taskId?: string }) => {
+      const taskPath = typeof arg === 'string' ? arg : arg.taskPath;
+      const taskId = typeof arg === 'string' ? undefined : arg.taskId;
+      try {
+        const remote = await resolveRemoteContext(taskPath, taskId);
+        if (remote) {
+          const changes = await remoteGitService.getStatusDetailed(
+            remote.connectionId,
+            remote.remotePath
+          );
+          return { success: true, changes };
+        }
+        const changes = await gitGetStatus(taskPath);
+        return { success: true, changes };
+      } catch (error) {
+        log.error('git:get-status error', error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'git:get-delete-risks',
+    async (
+      _,
+      args: {
+        targets: Array<{ id: string; taskPath: string; sshConnectionId?: string }>;
+        includePr?: boolean;
+      }
+    ): Promise<{
+      success: boolean;
+      risks?: Record<
+        string,
+        {
+          staged: number;
+          unstaged: number;
+          untracked: number;
+          files: string[];
+          ahead: number;
+          behind: number;
+          error?: string;
+          pr?: unknown | null;
+          prKnown: boolean;
+        }
+      >;
+      error?: string;
+    }> => {
+      const targets = Array.isArray(args?.targets) ? args.targets : [];
+      const includePr = args?.includePr === true;
+      if (targets.length === 0) {
+        return { success: true, risks: {} };
+      }
+
+      try {
+        const entries = await Promise.all(
+          targets.map(async (target) => {
+            const risk: {
+              staged: number;
+              unstaged: number;
+              untracked: number;
+              files: string[];
+              ahead: number;
+              behind: number;
+              error?: string;
+              pr?: unknown | null;
+              prKnown: boolean;
+            } = {
+              staged: 0,
+              unstaged: 0,
+              untracked: 0,
+              files: [],
+              ahead: 0,
+              behind: 0,
+              pr: null,
+              prKnown: false,
+            };
+
+            try {
+              const remoteProject = await resolveRemoteProjectForWorktreePath(
+                target.taskPath,
+                target.sshConnectionId
+              );
+
+              const [changesRes, aheadBehindRes, prRes] = await Promise.all([
+                (async () => {
+                  if (remoteProject) {
+                    return await remoteGitService.getStatusDetailed(
+                      remoteProject.sshConnectionId,
+                      target.taskPath
+                    );
+                  }
+                  return await gitGetStatus(target.taskPath);
+                })(),
+                (async () => {
+                  if (remoteProject) {
+                    const status = await remoteGitService.getBranchStatus(
+                      remoteProject.sshConnectionId,
+                      target.taskPath
+                    );
+                    return { ahead: status.ahead, behind: status.behind };
+                  }
+                  return await getLocalAheadBehind(target.taskPath);
+                })(),
+                (async () => {
+                  if (!includePr) return { pr: null, prKnown: false as const, error: undefined };
+                  if (remoteProject) {
+                    const result = await getPrStatusRemote(
+                      remoteProject.sshConnectionId,
+                      target.taskPath
+                    );
+                    if (!result.success) {
+                      return {
+                        pr: null,
+                        prKnown: false as const,
+                        error: result.error || 'Failed to query pull request status',
+                      };
+                    }
+                    return { pr: result.pr ?? null, prKnown: true as const, error: undefined };
+                  }
+                  return await getLocalPrForDeleteRisk(target.taskPath);
+                })(),
+              ]);
+
+              const counts = countStatusBuckets(
+                changesRes as Array<{ status?: string; isStaged?: boolean }>
+              );
+              risk.staged = counts.staged;
+              risk.unstaged = counts.unstaged;
+              risk.untracked = counts.untracked;
+              risk.files = collectChangedPaths(changesRes as Array<{ path?: string }>);
+              risk.ahead = aheadBehindRes.ahead || 0;
+              risk.behind = aheadBehindRes.behind || 0;
+              risk.pr = prRes.pr;
+              risk.prKnown = prRes.prKnown;
+              if (prRes.error) {
+                risk.error = prRes.error;
+              }
+            } catch (error) {
+              risk.error = error instanceof Error ? error.message : String(error);
+            }
+
+            return [target.id, risk] as const;
+          })
+        );
+
+        return { success: true, risks: Object.fromEntries(entries) };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Per-file diff (moved from Codex IPC)
+  ipcMain.handle(
+    'git:get-file-diff',
+    async (
+      _,
+      args: {
+        taskPath: string;
+        taskId?: string;
+        filePath: string;
+        baseRef?: string;
+        forceLarge?: boolean;
+      }
+    ) => {
+      try {
+        const remote = await resolveRemoteContext(args.taskPath, args.taskId);
+        if (remote) {
+          const diff = await remoteGitService.getFileDiff(
+            remote.connectionId,
+            remote.remotePath,
+            args.filePath,
+            args.baseRef,
+            args.forceLarge
+          );
+          return { success: true, diff };
+        }
+        const diff = await gitGetFileDiff(
+          args.taskPath,
+          args.filePath,
+          args.baseRef,
+          args.forceLarge
+        );
+        return { success: true, diff };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Update index (stage/unstage all or selected paths)
+  ipcMain.handle(
+    'git:update-index',
+    async (_, args: { taskPath: string; taskId?: string } & GitIndexUpdateArgs) => {
+      try {
+        const operationArgs: GitIndexUpdateArgs = {
+          action: args.action,
+          scope: args.scope,
+          filePaths: args.scope === 'paths' ? (args.filePaths || []).filter(Boolean) : undefined,
+        };
+        if (
+          operationArgs.scope === 'paths' &&
+          (!operationArgs.filePaths || operationArgs.filePaths.length === 0)
+        ) {
+          return { success: true };
+        }
+
+        log.info('Updating git index', {
+          taskPath: args.taskPath,
+          action: operationArgs.action,
+          scope: operationArgs.scope,
+          count: operationArgs.filePaths?.length ?? null,
+        });
+
+        const remote = await resolveRemoteContext(args.taskPath, args.taskId);
+        if (remote) {
+          await remoteGitService.updateIndex(remote.connectionId, remote.remotePath, operationArgs);
+        } else {
+          await gitUpdateIndex(args.taskPath, operationArgs);
+        }
+        return { success: true };
+      } catch (error) {
+        log.error('Failed to update git index', { taskPath: args.taskPath, error });
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Revert file
+  ipcMain.handle(
+    'git:revert-file',
+    async (_, args: { taskPath: string; taskId?: string; filePath: string }) => {
+      try {
+        log.info('Reverting file:', { taskPath: args.taskPath, filePath: args.filePath });
+        const remote = await resolveRemoteContext(args.taskPath, args.taskId);
+        let result: { action: string };
+        if (remote) {
+          result = await remoteGitService.revertFile(
+            remote.connectionId,
+            remote.remotePath,
+            args.filePath
+          );
+        } else {
+          result = await gitRevertFile(args.taskPath, args.filePath);
+        }
+        log.info('File operation completed:', { filePath: args.filePath, action: result.action });
+        return { success: true, action: result.action };
+      } catch (error) {
+        log.error('Failed to revert file:', { filePath: args.filePath, error });
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+  // Git: Generate PR title and description
+  ipcMain.handle(
+    'git:generate-pr-content',
+    async (
+      _,
+      args: {
+        taskPath: string;
+        base?: string;
+        sshConnectionId?: string;
+      }
+    ) => {
+      const {
+        taskPath,
+        base = 'main',
+        sshConnectionId,
+      } = args || ({} as { taskPath: string; base?: string; sshConnectionId?: string });
+      try {
+        // For remote projects, PR content generation still runs locally — it just needs
+        // the diff text. The prGenerationService can get diff data via the now-remote-aware
+        // git:get-status and git:get-file-diff handlers, or we pass the taskPath which the
+        // service uses with local git commands. For remote, we get the diff over SSH and
+        // pass it to the generation service.
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          const connId = remoteProject.sshConnectionId;
+          // Get diff text over SSH
+          const diffResult = await remoteGitService.execGit(
+            connId,
+            taskPath,
+            `diff --stat origin/${quoteGhArg(base)}...HEAD`
+          );
+          const logResult = await remoteGitService.execGit(
+            connId,
+            taskPath,
+            `log --oneline origin/${quoteGhArg(base)}..HEAD`
+          );
+          const diffText = (diffResult.stdout || '').trim();
+          const logText = (logResult.stdout || '').trim();
+          // Use simple title/description generation from diff summary
+          const lines = logText.split('\n').filter((l) => l.trim());
+          const generatedTitle = lines.length === 1 ? lines[0].replace(/^[a-f0-9]+ /, '') : '';
+          return {
+            success: true,
+            title: generatedTitle,
+            description: diffText ? `## Changes\n\n\`\`\`\n${diffText}\n\`\`\`` : '',
+          };
+        }
+
+        // Try to get the task to find which provider was used
+        let providerId: string | null = null;
+        try {
+          const task = await databaseService.getTaskByPath(taskPath);
+          if (task?.agentId) {
+            providerId = task.agentId;
+            log.debug('Found task provider for PR generation', { taskPath, providerId });
+          }
+        } catch (error) {
+          log.debug('Could not lookup task provider', { error });
+          // Non-fatal - continue without provider
+        }
+
+        const result = await prGenerationService.generatePrContent(taskPath, base, providerId);
+        return { success: true, ...result };
+      } catch (error) {
+        log.error('Failed to generate PR content:', error);
+        return {
+          success: false,
+          error: error instanceof Error ? error.message : String(error),
+        };
+      }
+    }
+  );
+
+  // Git: Create Pull Request via GitHub CLI
+  ipcMain.handle(
+    'git:create-pr',
+    async (
+      _,
+      args: {
+        taskPath: string;
+        title?: string;
+        body?: string;
+        base?: string;
+        head?: string;
+        draft?: boolean;
+        web?: boolean;
+        fill?: boolean;
+        skipPrePush?: boolean;
+        sshConnectionId?: string;
+      }
+    ) => {
+      const { taskPath, title, body, base, head, draft, web, fill, skipPrePush, sshConnectionId } =
+        args ||
+        ({} as {
+          taskPath: string;
+          title?: string;
+          body?: string;
+          base?: string;
+          head?: string;
+          draft?: boolean;
+          web?: boolean;
+          fill?: boolean;
+          skipPrePush?: boolean;
+          sshConnectionId?: string;
+        });
+      try {
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          return await createPrRemote(remoteProject.sshConnectionId, taskPath, {
+            title,
+            body,
+            base,
+            head,
+            draft,
+            web,
+            fill,
+          });
+        }
+
+        const outputs: string[] = [];
+        const autoCloseLinkedIssuesOnPrCreate = shouldAutoCloseLinkedIssuesOnPrCreate();
+        let taskMetadata: unknown = undefined;
+        let prBody = body;
+        if (autoCloseLinkedIssuesOnPrCreate) {
+          try {
+            const task = await databaseService.getTaskByPath(taskPath);
+            taskMetadata = task?.metadata;
+            prBody = injectIssueFooter(body, task?.metadata);
+          } catch (error) {
+            log.debug('Unable to enrich PR body with issue footer', { taskPath, error });
+          }
+        }
+        const { shouldPatchFilledBody, shouldUseBodyFile, shouldUseFill } = getCreatePrBodyPlan({
+          fill,
+          title,
+          rawBody: body,
+          enrichedBody: prBody,
+        });
+
+        // Stage, commit, and push — skip when the caller already did this (skipPrePush)
+        if (!skipPrePush) {
+          try {
+            const { stdout: statusOut } = await execAsync(
+              'git status --porcelain --untracked-files=all',
+              {
+                cwd: taskPath,
+              }
+            );
+            if (statusOut && statusOut.trim().length > 0) {
+              const { stdout: addOut, stderr: addErr } = await execAsync('git add -A', {
+                cwd: taskPath,
+              });
+              if (addOut?.trim()) outputs.push(addOut.trim());
+              if (addErr?.trim()) outputs.push(addErr.trim());
+
+              const commitMsg = 'stagehand: prepare pull request';
+              try {
+                const { stdout: commitOut, stderr: commitErr } = await execAsync(
+                  `git commit -m ${JSON.stringify(commitMsg)}`,
+                  { cwd: taskPath }
+                );
+                if (commitOut?.trim()) outputs.push(commitOut.trim());
+                if (commitErr?.trim()) outputs.push(commitErr.trim());
+              } catch (commitErr) {
+                const msg = commitErr instanceof Error ? commitErr.message : String(commitErr);
+                if (msg && /nothing to commit/i.test(msg)) {
+                  outputs.push('git commit: nothing to commit');
+                } else {
+                  throw commitErr;
+                }
+              }
+            }
+          } catch (stageErr) {
+            const stageMsg = stageErr instanceof Error ? stageErr.message : String(stageErr);
+            if (/nothing to commit/i.test(stageMsg)) {
+              outputs.push('git: nothing to commit');
+            } else {
+              log.error('Failed to stage/commit changes before PR:', stageMsg);
+              throw stageErr;
+            }
+          }
+
+          // Ensure branch is pushed to origin so PR includes latest commit
+          try {
+            await execAsync('git push', { cwd: taskPath });
+            outputs.push('git push: success');
+          } catch (pushErr) {
+            try {
+              const { stdout: branchOut } = await execAsync('git rev-parse --abbrev-ref HEAD', {
+                cwd: taskPath,
+              });
+              const branch = branchOut.trim();
+              await execAsync(`git push --set-upstream origin ${JSON.stringify(branch)}`, {
+                cwd: taskPath,
+              });
+              outputs.push(`git push --set-upstream origin ${branch}: success`);
+            } catch (pushErr2) {
+              log.error('Failed to push branch before PR:', pushErr2 as string);
+              return {
+                success: false,
+                error:
+                  'Failed to push branch to origin. Please check your Git remotes and authentication.',
+              };
+            }
+          }
+        }
+
+        // Determine current branch and default base branch (fallback to main)
+        let currentBranch = '';
+        try {
+          const { stdout } = await execAsync('git branch --show-current', { cwd: taskPath });
+          currentBranch = (stdout || '').trim();
+        } catch {}
+        let defaultBranch = 'main';
+        try {
+          const { stdout } = await execAsync(
+            'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
+            { cwd: taskPath }
+          );
+          const db = (stdout || '').trim();
+          if (db) defaultBranch = db;
+        } catch {
+          try {
+            const { stdout } = await execAsync(
+              'git remote show origin | sed -n "/HEAD branch/s/.*: //p"',
+              { cwd: taskPath }
+            );
+            const db2 = (stdout || '').trim();
+            if (db2) defaultBranch = db2;
+          } catch {}
+        }
+
+        // Guard: ensure there is at least one commit ahead of base
+        try {
+          const baseRef = base || defaultBranch;
+          const { stdout: aheadOut } = await execAsync(
+            `git rev-list --count ${JSON.stringify(`origin/${baseRef}`)}..HEAD`,
+            { cwd: taskPath }
+          );
+          const aheadCount = parseInt((aheadOut || '0').trim(), 10) || 0;
+          if (aheadCount <= 0) {
+            return {
+              success: false,
+              error: `No commits to create a PR. Make a commit on 
+current branch '${currentBranch}' ahead of base '${baseRef}'.`,
+            };
+          }
+        } catch {
+          // Non-fatal; continue
+        }
+
+        // Build gh pr create command
+        const flags: string[] = [];
+        if (title) flags.push(`--title ${JSON.stringify(title)}`);
+
+        // Use temp file for body to properly handle newlines and multiline content
+        let bodyFile: string | null = null;
+        if (shouldUseBodyFile && prBody) {
+          try {
+            bodyFile = path.join(
+              os.tmpdir(),
+              `gh-pr-body-${Date.now()}-${Math.random().toString(36).substring(7)}.txt`
+            );
+            // Write body with actual newlines preserved
+            fs.writeFileSync(bodyFile, prBody, 'utf8');
+            flags.push(`--body-file ${JSON.stringify(bodyFile)}`);
+          } catch (writeError) {
+            log.warn('Failed to write body to temp file, falling back to --body flag', {
+              writeError,
+            });
+            // Fallback to direct --body flag if temp file creation fails
+            flags.push(`--body ${JSON.stringify(prBody)}`);
+          }
+        }
+
+        if (base || defaultBranch) flags.push(`--base ${JSON.stringify(base || defaultBranch)}`);
+        if (head) {
+          flags.push(`--head ${JSON.stringify(head)}`);
+        } else if (currentBranch) {
+          flags.push(`--head ${JSON.stringify(currentBranch)}`);
+        }
+        if (draft) flags.push('--draft');
+        if (web) flags.push('--web');
+        if (shouldUseFill) flags.push('--fill');
+
+        const cmd = `gh pr create ${flags.join(' ')}`.trim();
+
+        let stdout: string;
+        let stderr: string;
+        try {
+          const result = await execAsync(cmd, { cwd: taskPath });
+          stdout = result.stdout || '';
+          stderr = result.stderr || '';
+        } finally {
+          // Clean up temp file if it was created
+          if (bodyFile && fs.existsSync(bodyFile)) {
+            try {
+              fs.unlinkSync(bodyFile);
+            } catch (unlinkError) {
+              log.debug('Failed to delete temp body file', { bodyFile, unlinkError });
+            }
+          }
+        }
+        const out = [...outputs, (stdout || '').trim() || (stderr || '').trim()]
+          .filter(Boolean)
+          .join('\n');
+
+        // Try to extract PR URL from output
+        const urlMatch = out.match(/https?:\/\/\S+/);
+        const url = urlMatch ? urlMatch[0] : null;
+
+        if (autoCloseLinkedIssuesOnPrCreate && shouldPatchFilledBody) {
+          try {
+            const didPatchBody = await patchCurrentPrBodyWithIssueFooter({
+              taskPath,
+              metadata: taskMetadata,
+              execFile: execFileAsync,
+              prUrl: url,
+            });
+            if (didPatchBody) {
+              outputs.push('gh pr edit --body-file: success');
+            }
+          } catch (editError) {
+            log.warn('Failed to patch PR body with issue footer after --fill create', {
+              taskPath,
+              editError,
+            });
+          }
+        }
+
+        return { success: true, url, output: out };
+      } catch (error: any) {
+        // Capture rich error info from gh/child_process
+        const errMsg = typeof error?.message === 'string' ? error.message : String(error);
+        const errStdout = typeof error?.stdout === 'string' ? error.stdout : '';
+        const errStderr = typeof error?.stderr === 'string' ? error.stderr : '';
+        const combined = [errMsg, errStdout, errStderr].filter(Boolean).join('\n').trim();
+
+        // Check for various error conditions
+        const restrictionRe =
+          /Auth App access restrictions|authorized OAuth apps|third-parties is limited/i;
+        const prExistsRe = /already exists|already has.*pull request|pull request for branch/i;
+
+        let code: string | undefined;
+        if (restrictionRe.test(combined)) {
+          code = 'ORG_AUTH_APP_RESTRICTED';
+          log.warn('GitHub org restrictions detected during PR creation');
+        } else if (prExistsRe.test(combined)) {
+          code = 'PR_ALREADY_EXISTS';
+          log.info('PR already exists for branch - push was successful');
+        } else {
+          log.error('Failed to create PR:', combined || error);
+        }
+
+        return {
+          success: false,
+          error: combined || errMsg || 'Failed to create PR',
+          output: combined,
+          code,
+        } as any;
+      }
+    }
+  );
+
+  // Git: Get PR status for current branch via GitHub CLI
+  ipcMain.handle(
+    'git:get-pr-status',
+    async (_, args: { taskPath: string; sshConnectionId?: string }) => {
+      const { taskPath, sshConnectionId } =
+        args || ({} as { taskPath: string; sshConnectionId?: string });
+      try {
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          return await getPrStatusRemote(remoteProject.sshConnectionId, taskPath);
+        }
+
+        // Ensure we're in a git repo
+        await execAsync('git rev-parse --is-inside-work-tree', { cwd: taskPath });
+
+        const queryFields = [
+          'number',
+          'url',
+          'state',
+          'isDraft',
+          'mergeStateStatus',
+          'headRefName',
+          'baseRefName',
+          'title',
+          'author',
+          'additions',
+          'deletions',
+          'changedFiles',
+          'autoMergeRequest',
+        ];
+        const cmd = `gh pr view --json ${queryFields.join(',')} -q .`;
+        try {
+          // Attempt 1: gh pr view (works when branch tracking points to a PR)
+          let data: any = null;
+          try {
+            const { stdout } = await execAsync(cmd, { cwd: taskPath });
+            const json = (stdout || '').trim();
+            data = json ? JSON.parse(json) : null;
+          } catch (viewErr) {
+            const viewMsg = String(viewErr);
+            // Re-throw unexpected errors; swallow "no PR found" so fallbacks can run
+            if (!/no pull requests? found/i.test(viewMsg) && !/not found/i.test(viewMsg)) {
+              throw viewErr;
+            }
+          }
+
+          // Fallback: If gh pr view didn't find a PR (e.g. detached head, upstream not set, or fresh branch),
+          // try finding it by branch name via gh pr list.
+          let currentBranch = '';
+          if (!data) {
+            try {
+              const { stdout: branchOut } = await execAsync('git branch --show-current', {
+                cwd: taskPath,
+              });
+              currentBranch = branchOut.trim();
+              if (currentBranch) {
+                const listCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --json ${queryFields.join(',')} --limit 1`;
+                const { stdout: listOut } = await execAsync(listCmd, { cwd: taskPath });
+                const listJson = (listOut || '').trim();
+                const listData = listJson ? JSON.parse(listJson) : [];
+                if (listData.length > 0) {
+                  data = listData[0];
+                }
+              }
+            } catch (fallbackErr) {
+              log.warn('Failed to fallback to gh pr list:', fallbackErr);
+              // Ignore fallback errors and return original null/error
+            }
+          }
+
+          // Fork fallback: if still no PR found, check if this repo is a fork and search
+          // the parent/upstream repo for a PR with head "<fork-owner>:<branch>".
+          if (!data && currentBranch) {
+            try {
+              const { stdout: repoOut } = await execAsync('gh repo view --json owner,parent', {
+                cwd: taskPath,
+              });
+              const repoData = repoOut.trim() ? JSON.parse(repoOut.trim()) : null;
+              const parentOwner = repoData?.parent?.owner?.login;
+              const parentName = repoData?.parent?.name;
+              const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
+              if (parentRepo) {
+                const forkOwnerLogin = repoData?.owner?.login;
+                const forkFields = [...queryFields, 'headRepositoryOwner'];
+                const forkListCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --repo ${JSON.stringify(parentRepo)} --state open --json ${forkFields.join(',')} --limit 10`;
+                const { stdout: forkOut } = await execAsync(forkListCmd, { cwd: taskPath });
+                const forkJson = (forkOut || '').trim();
+                const forkData = forkJson ? JSON.parse(forkJson) : [];
+                const match = forkOwnerLogin
+                  ? forkData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
+                  : forkData[0];
+                if (match) {
+                  data = match;
+                }
+              }
+            } catch (forkFallbackErr) {
+              log.warn('Failed to check fork parent for PR:', forkFallbackErr);
+            }
+          }
+
+          if (!data) return { success: true, pr: null };
+
+          // Fallback: if GH CLI didn't return diff stats, try to compute locally
+          const asNumber = (v: any): number | null =>
+            typeof v === 'number' && Number.isFinite(v)
+              ? v
+              : typeof v === 'string' && Number.isFinite(Number.parseInt(v, 10))
+                ? Number.parseInt(v, 10)
+                : null;
+
+          const hasAdd = asNumber(data?.additions) !== null;
+          const hasDel = asNumber(data?.deletions) !== null;
+          const hasFiles = asNumber(data?.changedFiles) !== null;
+
+          if (!hasAdd || !hasDel || !hasFiles) {
+            const baseRef = typeof data?.baseRefName === 'string' ? data.baseRefName.trim() : '';
+            const targetRef = baseRef ? `origin/${baseRef}` : '';
+            const shortstatCmd = targetRef
+              ? `git diff --shortstat ${JSON.stringify(targetRef)}...HEAD`
+              : 'git diff --shortstat HEAD~1..HEAD';
+            try {
+              const { stdout: diffOut } = await execAsync(shortstatCmd, { cwd: taskPath });
+              const statLine = (diffOut || '').trim();
+              const m =
+                statLine &&
+                statLine.match(
+                  /(\d+)\s+files? changed(?:,\s+(\d+)\s+insertions?\(\+\))?(?:,\s+(\d+)\s+deletions?\(-\))?/
+                );
+              if (m) {
+                const [, filesStr, addStr, delStr] = m;
+                if (!hasFiles && filesStr) data.changedFiles = Number.parseInt(filesStr, 10);
+                if (!hasAdd && addStr) data.additions = Number.parseInt(addStr, 10);
+                if (!hasDel && delStr) data.deletions = Number.parseInt(delStr, 10);
+              }
+            } catch {
+              // best-effort only; ignore failures
+            }
+          }
+
+          return { success: true, pr: data };
+        } catch (err) {
+          const msg = String(err as string);
+          if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
+            return { success: true, pr: null };
+          }
+          return { success: false, error: msg || 'Failed to query PR status' };
+        }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Merge PR via GitHub CLI
+  ipcMain.handle(
+    'git:merge-pr',
+    async (
+      _,
+      args: {
+        taskPath: string;
+        prNumber?: number;
+        strategy?: 'merge' | 'squash' | 'rebase';
+        admin?: boolean;
+        sshConnectionId?: string;
+      }
+    ) => {
+      const {
+        taskPath,
+        prNumber,
+        strategy = 'merge',
+        admin = false,
+        sshConnectionId,
+      } = (args || {}) as {
+        taskPath: string;
+        prNumber?: number;
+        strategy?: 'merge' | 'squash' | 'rebase';
+        admin?: boolean;
+        sshConnectionId?: string;
+      };
+
+      try {
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          const strategyFlag =
+            strategy === 'squash' ? '--squash' : strategy === 'rebase' ? '--rebase' : '--merge';
+          const ghArgs = ['pr', 'merge'];
+          if (typeof prNumber === 'number' && Number.isFinite(prNumber))
+            ghArgs.push(String(prNumber));
+          ghArgs.push(strategyFlag);
+          if (admin) ghArgs.push('--admin');
+          const result = await remoteGitService.execGh(
+            remoteProject.sshConnectionId,
+            taskPath,
+            ghArgs.join(' ')
+          );
+          if (result.exitCode !== 0) {
+            const msg = (result.stderr || '') + (result.stdout || '');
+            if (/not installed|command not found/i.test(msg)) {
+              return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
+            }
+            return { success: false, error: msg || 'Failed to merge PR' };
+          }
+          return {
+            success: true,
+            output: [result.stdout, result.stderr].filter(Boolean).join('\n').trim(),
+          };
+        }
+
+        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+
+        const strategyFlag =
+          strategy === 'squash' ? '--squash' : strategy === 'rebase' ? '--rebase' : '--merge';
+
+        const ghArgs = ['pr', 'merge'];
+        if (typeof prNumber === 'number' && Number.isFinite(prNumber)) {
+          ghArgs.push(String(prNumber));
+        }
+        ghArgs.push(strategyFlag);
+        if (admin) ghArgs.push('--admin');
+
+        try {
+          const { stdout, stderr } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+          const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+          return { success: true, output };
+        } catch (err) {
+          const msg = String(err as string);
+          if (/not installed|command not found/i.test(msg)) {
+            return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
+          }
+          const stderr = (err as any)?.stderr;
+          const stdout = (err as any)?.stdout;
+          const combined = [stderr, stdout, msg].filter(Boolean).join('\n').trim();
+          return { success: false, error: combined || 'Failed to merge PR' };
+        }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Enable auto-merge on a PR via GitHub CLI
+  ipcMain.handle(
+    'git:enable-auto-merge',
+    async (
+      _,
+      args: {
+        taskPath: string;
+        prNumber?: number;
+        strategy?: 'merge' | 'squash' | 'rebase';
+        sshConnectionId?: string;
+      }
+    ) => {
+      const {
+        taskPath,
+        prNumber,
+        strategy = 'merge',
+        sshConnectionId,
+      } = (args || {}) as {
+        taskPath: string;
+        prNumber?: number;
+        strategy?: 'merge' | 'squash' | 'rebase';
+        sshConnectionId?: string;
+      };
+
+      try {
+        const strategyFlag =
+          strategy === 'squash' ? '--squash' : strategy === 'rebase' ? '--rebase' : '--merge';
+        const ghArgs = ['pr', 'merge'];
+        if (typeof prNumber === 'number' && Number.isFinite(prNumber)) {
+          ghArgs.push(String(prNumber));
+        }
+        ghArgs.push('--auto', strategyFlag);
+
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          const result = await remoteGitService.execGh(
+            remoteProject.sshConnectionId,
+            taskPath,
+            ghArgs.join(' ')
+          );
+          if (result.exitCode !== 0) {
+            return { success: false, error: (result.stderr || result.stdout || '').trim() };
+          }
+          return { success: true };
+        }
+
+        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+        const { stdout, stderr } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+        const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+        return { success: true, output };
+      } catch (error) {
+        const stderr = (error as any)?.stderr;
+        const msg = stderr || (error instanceof Error ? error.message : String(error));
+        return { success: false, error: typeof msg === 'string' ? msg.trim() : String(msg) };
+      }
+    }
+  );
+
+  // Git: Disable auto-merge on a PR via GitHub CLI
+  ipcMain.handle(
+    'git:disable-auto-merge',
+    async (
+      _,
+      args: {
+        taskPath: string;
+        prNumber?: number;
+        sshConnectionId?: string;
+      }
+    ) => {
+      const { taskPath, prNumber, sshConnectionId } = (args || {}) as {
+        taskPath: string;
+        prNumber?: number;
+        sshConnectionId?: string;
+      };
+
+      try {
+        const ghArgs = ['pr', 'merge'];
+        if (typeof prNumber === 'number' && Number.isFinite(prNumber)) {
+          ghArgs.push(String(prNumber));
+        }
+        ghArgs.push('--disable-auto');
+
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          const result = await remoteGitService.execGh(
+            remoteProject.sshConnectionId,
+            taskPath,
+            ghArgs.join(' ')
+          );
+          if (result.exitCode !== 0) {
+            return { success: false, error: (result.stderr || result.stdout || '').trim() };
+          }
+          return { success: true };
+        }
+
+        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+        const { stdout, stderr } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+        const output = [stdout, stderr].filter(Boolean).join('\n').trim();
+        return { success: true, output };
+      } catch (error) {
+        const stderr = (error as any)?.stderr;
+        const msg = stderr || (error instanceof Error ? error.message : String(error));
+        return { success: false, error: typeof msg === 'string' ? msg.trim() : String(msg) };
+      }
+    }
+  );
+
+  // Git: Get CI/CD check runs for current branch via GitHub CLI
+  ipcMain.handle(
+    'git:get-check-runs',
+    async (_, args: { taskPath: string; sshConnectionId?: string }) => {
+      const { taskPath, sshConnectionId } =
+        args || ({} as { taskPath: string; sshConnectionId?: string });
+      try {
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          const connId = remoteProject.sshConnectionId;
+          const fields = 'bucket,completedAt,description,event,link,name,startedAt,state,workflow';
+
+          // Detect fork on remote: find PR in parent repo if applicable
+          let prRef: string | null = null;
+          let remoteParentRepo: string | null = null;
+          let remoteChecksApiRepo = 'repos/{owner}/{repo}';
+          let remoteHeadRefOidCmd = "pr view --json headRefOid --jq '.headRefOid'";
+          try {
+            const repoResult = await remoteGitService.execGh(
+              connId,
+              taskPath,
+              'repo view --json owner,parent'
+            );
+            const repoData = repoResult.stdout.trim() ? JSON.parse(repoResult.stdout.trim()) : null;
+            const parentOwner = repoData?.parent?.owner?.login;
+            const parentName = repoData?.parent?.name;
+            const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
+            if (parentRepo) {
+              const branchResult = await remoteGitService.execGit(
+                connId,
+                taskPath,
+                'branch --show-current'
+              );
+              const currentBranch = branchResult.stdout.trim();
+              if (currentBranch) {
+                const listResult = await remoteGitService.execGh(
+                  connId,
+                  taskPath,
+                  `pr list --head ${quoteGhArg(currentBranch)} --repo ${quoteGhArg(parentRepo)} --state open --json number,headRefOid,headRepositoryOwner --limit 10`
+                );
+                const forkOwnerLogin = repoData?.owner?.login;
+                const listData = listResult.stdout.trim()
+                  ? JSON.parse(listResult.stdout.trim())
+                  : [];
+                const matched = forkOwnerLogin
+                  ? listData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
+                  : listData[0];
+                if (matched) {
+                  prRef = String(matched.number);
+                  remoteParentRepo = parentRepo;
+                  remoteChecksApiRepo = `repos/${parentRepo}`;
+                  remoteHeadRefOidCmd = `pr view ${prRef} --repo ${quoteGhArg(parentRepo)} --json headRefOid --jq '.headRefOid'`;
+                }
+              }
+            }
+          } catch {
+            // Not a fork or detection failed — proceed with default behavior
+          }
+
+          const checksCmd =
+            prRef && remoteParentRepo
+              ? `pr checks ${prRef} --repo ${quoteGhArg(remoteParentRepo)} --json ${fields}`
+              : `pr checks --json ${fields}`;
+          const checksResult = await remoteGitService.execGh(connId, taskPath, checksCmd);
+          if (checksResult.exitCode !== 0) {
+            const msg = checksResult.stderr || '';
+            if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
+              return { success: true, checks: null };
+            }
+            if (/not installed|command not found/i.test(msg)) {
+              return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
+            }
+            return { success: false, error: msg || 'Failed to query check runs' };
+          }
+          const checks = checksResult.stdout.trim() ? JSON.parse(checksResult.stdout.trim()) : [];
+
+          // Fetch html_url from API
+          try {
+            const shaResult = await remoteGitService.execGh(connId, taskPath, remoteHeadRefOidCmd);
+            const sha = shaResult.stdout.trim();
+            if (sha) {
+              const apiResult = await remoteGitService.execGh(
+                connId,
+                taskPath,
+                `api ${remoteChecksApiRepo}/commits/${sha}/check-runs --jq '.check_runs | map({name: .name, html_url: .html_url}) | .[]'`
+              );
+              const urlMap = new Map<string, string>();
+              for (const line of apiResult.stdout.trim().split('\n')) {
+                if (!line) continue;
+                try {
+                  const entry = JSON.parse(line);
+                  if (entry.name && entry.html_url) urlMap.set(entry.name, entry.html_url);
+                } catch {}
+              }
+              for (const check of checks) {
+                const htmlUrl = urlMap.get(check.name);
+                if (htmlUrl) check.link = htmlUrl;
+              }
+            }
+          } catch {
+            // Fall back to original link values
+          }
+
+          return { success: true, checks };
+        }
+
+        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+
+        const fields = 'bucket,completedAt,description,event,link,name,startedAt,state,workflow';
+
+        // Resolve the PR number and repo to use for gh commands.
+        // For forks, the PR lives in the parent repo, so we detect that here once.
+        let prRef: string | null = null; // PR number as string, or null to use implicit (current branch)
+        let repoFlag: string[] = []; // ['--repo', 'owner/repo'] or empty
+        let headRefOidArgs: string[] = [
+          'pr',
+          'view',
+          '--json',
+          'headRefOid',
+          '--jq',
+          '.headRefOid',
+        ];
+        let checkRunsApiRepo = 'repos/{owner}/{repo}'; // used in gh api call
+
+        try {
+          // Detect fork: if this repo has a parent, find the PR number there
+          const { stdout: repoOut } = await execFileAsync(
+            'gh',
+            ['repo', 'view', '--json', 'owner,parent'],
+            { cwd: taskPath }
+          );
+          const repoData = repoOut.trim() ? JSON.parse(repoOut.trim()) : null;
+          const parentOwner = repoData?.parent?.owner?.login;
+          const parentName = repoData?.parent?.name;
+          const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
+          if (parentRepo) {
+            const { stdout: branchOut } = await execFileAsync('git', ['branch', '--show-current'], {
+              cwd: taskPath,
+            });
+            const currentBranch = branchOut.trim();
+            if (currentBranch) {
+              const { stdout: listOut } = await execFileAsync(
+                'gh',
+                [
+                  'pr',
+                  'list',
+                  '--head',
+                  currentBranch,
+                  '--repo',
+                  parentRepo,
+                  '--state',
+                  'open',
+                  '--json',
+                  'number,headRefOid,headRepositoryOwner',
+                  '--limit',
+                  '10',
+                ],
+                { cwd: taskPath }
+              );
+              const forkOwnerLogin = repoData?.owner?.login;
+              const listData = listOut.trim() ? JSON.parse(listOut.trim()) : [];
+              const matched = forkOwnerLogin
+                ? listData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
+                : listData[0];
+              if (matched) {
+                prRef = String(matched.number);
+                repoFlag = ['--repo', parentRepo];
+                headRefOidArgs = [
+                  'pr',
+                  'view',
+                  prRef,
+                  '--repo',
+                  parentRepo,
+                  '--json',
+                  'headRefOid',
+                  '--jq',
+                  '.headRefOid',
+                ];
+                checkRunsApiRepo = `repos/${parentRepo}`;
+              }
+            }
+          }
+        } catch {
+          // Not a fork or detection failed — proceed with default (current-branch) behavior
+        }
+
+        try {
+          const checksArgs = prRef
+            ? ['pr', 'checks', prRef, ...repoFlag, '--json', fields]
+            : ['pr', 'checks', '--json', fields];
+          const { stdout } = await execFileAsync('gh', checksArgs, { cwd: taskPath });
+          const json = (stdout || '').trim();
+          const checks = json ? JSON.parse(json) : [];
+
+          // Fetch html_url from the GitHub API instead, which always points to the
+          // actual check run page on GitHub.
+          try {
+            const { stdout: shaOut } = await execFileAsync('gh', headRefOidArgs, { cwd: taskPath });
+            const sha = shaOut.trim();
+            if (sha) {
+              const { stdout: apiOut } = await execFileAsync(
+                'gh',
+                [
+                  'api',
+                  `${checkRunsApiRepo}/commits/${sha}/check-runs`,
+                  '--jq',
+                  '.check_runs | map({name: .name, html_url: .html_url}) | .[]',
+                ],
+                { cwd: taskPath }
+              );
+              const urlMap = new Map<string, string>();
+              for (const line of apiOut.trim().split('\n')) {
+                if (!line) continue;
+                try {
+                  const entry = JSON.parse(line);
+                  if (entry.name && entry.html_url) urlMap.set(entry.name, entry.html_url);
+                } catch {}
+              }
+              for (const check of checks) {
+                const htmlUrl = urlMap.get(check.name);
+                if (htmlUrl) check.link = htmlUrl;
+              }
+            }
+          } catch {
+            // Fall back to original link values if API call fails
+          }
+
+          return { success: true, checks };
+        } catch (err) {
+          const msg = String(err as string);
+          if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
+            return { success: true, checks: null };
+          }
+          if (/not installed|command not found/i.test(msg)) {
+            return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
+          }
+          return { success: false, error: msg || 'Failed to query check runs' };
+        }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Get PR comments and reviews via GitHub CLI
+  ipcMain.handle(
+    'git:get-pr-comments',
+    async (_, args: { taskPath: string; prNumber?: number; sshConnectionId?: string }) => {
+      const { taskPath, prNumber, sshConnectionId } =
+        args || ({} as { taskPath: string; prNumber?: number; sshConnectionId?: string });
+      try {
+        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        if (remoteProject) {
+          const connId = remoteProject.sshConnectionId;
+          const ghViewArgs = prNumber
+            ? `pr view ${prNumber} --json comments,reviews,number`
+            : 'pr view --json comments,reviews,number';
+          const viewResult = await remoteGitService.execGh(connId, taskPath, ghViewArgs);
+          if (viewResult.exitCode !== 0) {
+            const msg = viewResult.stderr || '';
+            if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
+              return { success: true, comments: [], reviews: [] };
+            }
+            if (/not installed|command not found/i.test(msg)) {
+              return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
+            }
+            return { success: false, error: msg || 'Failed to query PR comments' };
+          }
+          const data = viewResult.stdout.trim()
+            ? JSON.parse(viewResult.stdout.trim())
+            : { comments: [], reviews: [], number: 0 };
+          const comments = data.comments || [];
+          const reviews = data.reviews || [];
+
+          // Fetch avatar URLs via REST API
+          if (data.number) {
+            try {
+              const avatarMap = new Map<string, string>();
+              const setAvatar = (login: string, url: string) => {
+                avatarMap.set(login, url);
+                if (login.endsWith('[bot]')) avatarMap.set(login.replace(/\[bot]$/, ''), url);
+              };
+
+              const commentsApi = await remoteGitService.execGh(
+                connId,
+                taskPath,
+                `api repos/{owner}/{repo}/issues/${data.number}/comments --jq '.[] | {login: .user.login, avatar_url: .user.avatar_url}'`
+              );
+              for (const line of commentsApi.stdout.trim().split('\n')) {
+                if (!line) continue;
+                try {
+                  const entry = JSON.parse(line);
+                  if (entry.login && entry.avatar_url) setAvatar(entry.login, entry.avatar_url);
+                } catch {}
+              }
+
+              const reviewsApi = await remoteGitService.execGh(
+                connId,
+                taskPath,
+                `api repos/{owner}/{repo}/pulls/${data.number}/reviews --jq '.[] | {login: .user.login, avatar_url: .user.avatar_url}'`
+              );
+              for (const line of reviewsApi.stdout.trim().split('\n')) {
+                if (!line) continue;
+                try {
+                  const entry = JSON.parse(line);
+                  if (entry.login && entry.avatar_url) setAvatar(entry.login, entry.avatar_url);
+                } catch {}
+              }
+
+              for (const c of [...comments, ...reviews]) {
+                if (c.author?.login) {
+                  const avatarUrl = avatarMap.get(c.author.login);
+                  if (avatarUrl) c.author.avatarUrl = avatarUrl;
+                }
+              }
+            } catch {
+              // Fall back to no avatar URLs
+            }
+          }
+
+          return { success: true, comments, reviews };
+        }
+
+        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+
+        try {
+          const ghArgs = ['pr', 'view'];
+          if (prNumber) ghArgs.push(String(prNumber));
+          ghArgs.push('--json', 'comments,reviews,number');
+
+          const { stdout } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+          const json = (stdout || '').trim();
+          const data = json ? JSON.parse(json) : { comments: [], reviews: [], number: 0 };
+
+          const comments = data.comments || [];
+          const reviews = data.reviews || [];
+
+          // gh pr view doesn't return avatarUrl for authors.
+          // Fetch from the REST API which includes avatar_url (works for GitHub Apps too).
+          if (data.number) {
+            try {
+              const avatarMap = new Map<string, string>();
+
+              const { stdout: commentsApi } = await execFileAsync(
+                'gh',
+                [
+                  'api',
+                  `repos/{owner}/{repo}/issues/${data.number}/comments`,
+                  '--jq',
+                  '.[] | {login: .user.login, avatar_url: .user.avatar_url}',
+                ],
+                { cwd: taskPath }
+              );
+              const setAvatar = (login: string, url: string) => {
+                avatarMap.set(login, url);
+                // REST API returns "app[bot]" while gh CLI returns "app" — store both
+                if (login.endsWith('[bot]')) avatarMap.set(login.replace(/\[bot]$/, ''), url);
+              };
+
+              for (const line of commentsApi.trim().split('\n')) {
+                if (!line) continue;
+                try {
+                  const entry = JSON.parse(line);
+                  if (entry.login && entry.avatar_url) setAvatar(entry.login, entry.avatar_url);
+                } catch {}
+              }
+
+              const { stdout: reviewsApi } = await execFileAsync(
+                'gh',
+                [
+                  'api',
+                  `repos/{owner}/{repo}/pulls/${data.number}/reviews`,
+                  '--jq',
+                  '.[] | {login: .user.login, avatar_url: .user.avatar_url}',
+                ],
+                { cwd: taskPath }
+              );
+              for (const line of reviewsApi.trim().split('\n')) {
+                if (!line) continue;
+                try {
+                  const entry = JSON.parse(line);
+                  if (entry.login && entry.avatar_url) setAvatar(entry.login, entry.avatar_url);
+                } catch {}
+              }
+
+              for (const c of [...comments, ...reviews]) {
+                if (c.author?.login) {
+                  const avatarUrl = avatarMap.get(c.author.login);
+                  if (avatarUrl) c.author.avatarUrl = avatarUrl;
+                }
+              }
+            } catch {
+              // Fall back to no avatar URLs — renderer will use GitHub fallback
+            }
+          }
+
+          return { success: true, comments, reviews };
+        } catch (err) {
+          const msg = String(err as string);
+          if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
+            return { success: true, comments: [], reviews: [] };
+          }
+          if (/not installed|command not found/i.test(msg)) {
+            return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
+          }
+          return { success: false, error: msg || 'Failed to query PR comments' };
+        }
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Commit all changes and push current branch (create feature branch if on default)
+  ipcMain.handle(
+    'git:commit-and-push',
+    async (
+      _,
+      args: {
+        taskPath: string;
+        taskId?: string;
+        commitMessage?: string;
+        createBranchIfOnDefault?: boolean;
+        branchPrefix?: string;
+      }
+    ) => {
+      const {
+        taskPath,
+        taskId,
+        commitMessage = 'chore: apply task changes',
+        createBranchIfOnDefault = true,
+        branchPrefix = 'orch',
+      } = (args ||
+        ({} as {
+          taskPath: string;
+          taskId?: string;
+          commitMessage?: string;
+          createBranchIfOnDefault?: boolean;
+          branchPrefix?: string;
+        })) as {
+        taskPath: string;
+        taskId?: string;
+        commitMessage?: string;
+        createBranchIfOnDefault?: boolean;
+        branchPrefix?: string;
+      };
+
+      try {
+        const remote = await resolveRemoteContext(taskPath, taskId);
+
+        if (remote) {
+          return await commitAndPushRemote(remote.connectionId, remote.remotePath, {
+            commitMessage,
+            createBranchIfOnDefault,
+            branchPrefix,
+          });
+        }
+
+        // Ensure we're in a git repo
+        await execAsync('git rev-parse --is-inside-work-tree', { cwd: taskPath });
+
+        // Determine current branch
+        const { stdout: currentBranchOut } = await execAsync('git branch --show-current', {
+          cwd: taskPath,
+        });
+        const currentBranch = (currentBranchOut || '').trim();
+
+        // Determine default branch via gh, fallback to main/master
+        let defaultBranch = 'main';
+        try {
+          const { stdout } = await execAsync(
+            'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
+            { cwd: taskPath }
+          );
+          const db = (stdout || '').trim();
+          if (db) defaultBranch = db;
+        } catch {
+          try {
+            const { stdout } = await execAsync(
+              'git remote show origin | sed -n "/HEAD branch/s/.*: //p"',
+              { cwd: taskPath }
+            );
+            const db2 = (stdout || '').trim();
+            if (db2) defaultBranch = db2;
+          } catch {}
+        }
+
+        // Optionally create a new branch if on default
+        let activeBranch = currentBranch;
+        if (createBranchIfOnDefault && (!currentBranch || currentBranch === defaultBranch)) {
+          const short = Date.now().toString(36);
+          const name = `${branchPrefix}/${short}`;
+          await execAsync(`git checkout -b ${JSON.stringify(name)}`, { cwd: taskPath });
+          activeBranch = name;
+        }
+
+        // Stage (only if needed) and commit
+        try {
+          const { stdout: st } = await execAsync('git status --porcelain --untracked-files=all', {
+            cwd: taskPath,
+          });
+          const hasWorkingChanges = Boolean(st && st.trim().length > 0);
+
+          const readStagedFiles = async () => {
+            try {
+              const { stdout } = await execAsync('git diff --cached --name-only', {
+                cwd: taskPath,
+              });
+              return (stdout || '')
+                .split('\n')
+                .map((f) => f.trim())
+                .filter(Boolean);
+            } catch {
+              return [];
+            }
+          };
+
+          let stagedFiles = await readStagedFiles();
+
+          // Only auto-stage everything when nothing is staged yet (preserves manual staging choices)
+          if (hasWorkingChanges && stagedFiles.length === 0) {
+            await execAsync('git add -A', { cwd: taskPath });
+          }
+
+          // Never commit plan mode artifacts
+          try {
+            await execAsync('git reset -q .emdash || true', { cwd: taskPath });
+          } catch {}
+          try {
+            await execAsync('git reset -q PLANNING.md || true', { cwd: taskPath });
+          } catch {}
+          try {
+            await execAsync('git reset -q planning.md || true', { cwd: taskPath });
+          } catch {}
+
+          stagedFiles = await readStagedFiles();
+
+          if (stagedFiles.length > 0) {
+            try {
+              await execAsync(`git commit -m ${JSON.stringify(commitMessage)}`, {
+                cwd: taskPath,
+              });
+            } catch (commitErr) {
+              const msg = commitErr instanceof Error ? commitErr.message : String(commitErr);
+              if (!/nothing to commit/i.test(msg)) throw commitErr;
+            }
+          }
+        } catch (e) {
+          log.warn('Stage/commit step issue:', e instanceof Error ? e.message : String(e));
+          throw e;
+        }
+
+        // Push current branch (set upstream if needed)
+        try {
+          await execAsync('git push', { cwd: taskPath });
+        } catch (pushErr) {
+          await execAsync(`git push --set-upstream origin ${JSON.stringify(activeBranch)}`, {
+            cwd: taskPath,
+          });
+        }
+
+        const { stdout: out } = await execAsync('git status -sb', { cwd: taskPath });
+        return { success: true, branch: activeBranch, output: (out || '').trim() };
+      } catch (error) {
+        log.error('Failed to commit and push:', error);
+        const errObj = error as { stderr?: string; message?: string };
+        const errMsg = errObj?.stderr?.trim() || errObj?.message || String(error);
+        return { success: false, error: errMsg };
+      }
+    }
+  );
+
+  // Git: Get branch status (current branch, default branch, ahead/behind counts)
+  ipcMain.handle(
+    'git:get-branch-status',
+    async (_, args: { taskPath: string; taskId?: string }) => {
+      const { taskPath, taskId } = args || ({} as { taskPath: string; taskId?: string });
+
+      if (!taskPath) {
+        return { success: false, error: 'Path does not exist' };
+      }
+
+      const remote = await resolveRemoteContext(taskPath, taskId);
+      if (remote) {
+        try {
+          const status = await remoteGitService.getBranchStatus(
+            remote.connectionId,
+            remote.remotePath
+          );
+          return { success: true, ...status };
+        } catch (error) {
+          log.error(`getBranchStatus (remote): error for ${taskPath}:`, error);
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      }
+
+      // Early exit for missing/invalid local path
+      if (!fs.existsSync(taskPath)) {
+        log.warn(`getBranchStatus: path does not exist: ${taskPath}`);
+        return { success: false, error: 'Path does not exist' };
+      }
+
+      // Check if it's a git repo - expected to fail often for non-git paths
+      try {
+        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+      } catch {
+        log.warn(`getBranchStatus: not a git repository: ${taskPath}`);
+        return { success: false, error: 'Not a git repository' };
+      }
+
+      try {
+        // Current branch
+        const { stdout: currentBranchOut } = await execFileAsync(
+          GIT,
+          ['branch', '--show-current'],
+          {
+            cwd: taskPath,
+          }
+        );
+        const branch = (currentBranchOut || '').trim();
+
+        // Determine default branch
+        let defaultBranch = 'main';
+        try {
+          const { stdout } = await execFileAsync(
+            'gh',
+            ['repo', 'view', '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'],
+            { cwd: taskPath }
+          );
+          const db = (stdout || '').trim();
+          if (db) defaultBranch = db;
+        } catch {
+          try {
+            // Use symbolic-ref to resolve origin/HEAD then take the last path part
+            const { stdout } = await execFileAsync(
+              GIT,
+              ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+              { cwd: taskPath }
+            );
+            const line = (stdout || '').trim();
+            const last = line.split('/').pop();
+            if (last) defaultBranch = last;
+          } catch {}
+        }
+
+        // Ahead/behind relative to upstream tracking branch
+        let ahead = 0;
+        let behind = 0;
+        try {
+          // Best case: compare against the upstream tracking branch (@{upstream})
+          const { stdout } = await execFileAsync(
+            GIT,
+            ['rev-list', '--left-right', '--count', '@{upstream}...HEAD'],
+            { cwd: taskPath }
+          );
+          const parts = (stdout || '').trim().split(/\s+/);
+          if (parts.length >= 2) {
+            behind = parseInt(parts[0] || '0', 10) || 0;
+            ahead = parseInt(parts[1] || '0', 10) || 0;
+          }
+        } catch {
+          try {
+            // Fallback: compare against origin/<current-branch>
+            const { stdout } = await execFileAsync(
+              GIT,
+              ['rev-list', '--left-right', '--count', `origin/${branch}...HEAD`],
+              { cwd: taskPath }
+            );
+            const parts = (stdout || '').trim().split(/\s+/);
+            if (parts.length >= 2) {
+              behind = parseInt(parts[0] || '0', 10) || 0;
+              ahead = parseInt(parts[1] || '0', 10) || 0;
+            }
+          } catch {
+            // No upstream — use git status as last resort
+            try {
+              const { stdout } = await execFileAsync(GIT, ['status', '-sb'], { cwd: taskPath });
+              const line = (stdout || '').split(/\n/)[0] || '';
+              const m = line.match(/ahead\s+(\d+)/i);
+              const n = line.match(/behind\s+(\d+)/i);
+              if (m) ahead = parseInt(m[1] || '0', 10) || 0;
+              if (n) behind = parseInt(n[1] || '0', 10) || 0;
+            } catch {}
+          }
+        }
+
+        // Count commits ahead of origin/<defaultBranch> (for PR visibility)
+        let aheadOfDefault = 0;
+        if (branch !== defaultBranch) {
+          try {
+            const { stdout: countOut } = await execFileAsync(
+              GIT,
+              ['rev-list', '--count', `origin/${defaultBranch}..HEAD`],
+              { cwd: taskPath }
+            );
+            aheadOfDefault = parseInt(countOut.trim(), 10) || 0;
+          } catch {
+            // origin/<defaultBranch> may not exist
+          }
+        }
+
+        return { success: true, branch, defaultBranch, ahead, behind, aheadOfDefault };
+      } catch (error) {
+        log.error(`getBranchStatus: unexpected error for ${taskPath}:`, error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'git:list-remote-branches',
+    async (_, args: { projectPath: string; remote?: string; sshConnectionId?: string }) => {
+      const {
+        projectPath,
+        remote = 'origin',
+        sshConnectionId,
+      } = args || ({} as { projectPath: string; remote?: string; sshConnectionId?: string });
+      if (!projectPath) {
+        return { success: false, error: 'projectPath is required' };
+      }
+
+      const remoteProject = await resolveRemoteProjectForWorktreePath(projectPath, sshConnectionId);
+      if (remoteProject) {
+        try {
+          const branches = await remoteGitService.listBranches(
+            remoteProject.sshConnectionId,
+            projectPath,
+            remote
+          );
+          return { success: true, branches };
+        } catch (error) {
+          log.error('Failed to list branches (remote):', error);
+          return { success: false, error: error instanceof Error ? error.message : String(error) };
+        }
+      }
+
+      try {
+        await execAsync('git rev-parse --is-inside-work-tree', { cwd: projectPath });
+      } catch {
+        return { success: false, error: 'Not a git repository' };
+      }
+
+      try {
+        // Check if remote exists before attempting to fetch
+        let hasRemote = false;
+        try {
+          await execFileAsync('git', ['remote', 'get-url', remote], { cwd: projectPath });
+          hasRemote = true;
+          // Remote exists, try to fetch
+          try {
+            await execFileAsync('git', ['fetch', '--prune', remote], { cwd: projectPath });
+          } catch (fetchError) {
+            log.warn('Failed to fetch remote before listing branches', fetchError);
+          }
+        } catch {
+          // Remote doesn't exist, skip fetch and will use local branches instead
+          log.debug(`Remote '${remote}' not found, will use local branches`);
+        }
+
+        let branches: Array<{ ref: string; remote: string; branch: string; label: string }> = [];
+
+        if (hasRemote) {
+          // List remote branches
+          const { stdout } = await execFileAsync(
+            'git',
+            ['for-each-ref', '--format=%(refname:short)', `refs/remotes/${remote}`],
+            { cwd: projectPath }
+          );
+
+          branches =
+            stdout
+              ?.split('\n')
+              .map((line) => line.trim())
+              .filter((line) => line.length > 0)
+              .filter((line) => !line.endsWith('/HEAD'))
+              .map((ref) => {
+                const [remoteAlias, ...rest] = ref.split('/');
+                const branch = rest.join('/') || ref;
+                return {
+                  ref,
+                  remote: remoteAlias || remote,
+                  branch,
+                  label: `${remoteAlias || remote}/${branch}`,
+                };
+              }) ?? [];
+
+          // Also include local-only branches (not on remote)
+          try {
+            const { stdout: localStdout } = await execAsync(
+              'git for-each-ref --format="%(refname:short)" refs/heads/',
+              { cwd: projectPath }
+            );
+
+            const remoteBranchNames = new Set(branches.map((b) => b.branch));
+
+            const localOnlyBranches =
+              localStdout
+                ?.split('\n')
+                .map((line) => line.trim())
+                .filter((line) => line.length > 0)
+                .filter((branch) => !remoteBranchNames.has(branch))
+                .map((branch) => ({
+                  ref: branch,
+                  remote: '',
+                  branch,
+                  label: branch,
+                })) ?? [];
+
+            branches = [...branches, ...localOnlyBranches];
+          } catch (localBranchError) {
+            log.warn('Failed to list local branches', localBranchError);
+          }
+        } else {
+          // No remote - list local branches instead
+          try {
+            const { stdout } = await execAsync(
+              'git for-each-ref --format="%(refname:short)" refs/heads/',
+              { cwd: projectPath }
+            );
+
+            branches =
+              stdout
+                ?.split('\n')
+                .map((line) => line.trim())
+                .filter((line) => line.length > 0)
+                .map((branch) => ({
+                  ref: branch,
+                  remote: '', // No remote
+                  branch,
+                  label: branch, // Just the branch name, no remote prefix
+                })) ?? [];
+          } catch (localBranchError) {
+            log.warn('Failed to list local branches', localBranchError);
+          }
+        }
+
+        return { success: true, branches };
+      } catch (error) {
+        log.error('Failed to list branches:', error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  // Git: Merge current branch to main via GitHub (create PR + merge immediately)
+  ipcMain.handle('git:merge-to-main', async (_, args: { taskPath: string; taskId?: string }) => {
+    const { taskPath, taskId } = args || ({} as { taskPath: string; taskId?: string });
+
+    try {
+      const remote = await resolveRemoteContext(taskPath, taskId);
+      if (remote) {
+        return await mergeToMainRemote(remote.connectionId, remote.remotePath);
+      }
+
+      // Get current and default branch names
+      const { stdout: currentOut } = await execAsync('git branch --show-current', {
+        cwd: taskPath,
+      });
+      const currentBranch = (currentOut || '').trim();
+
+      let defaultBranch = 'main';
+      try {
+        const { stdout } = await execAsync(
+          'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
+          { cwd: taskPath }
+        );
+        if (stdout?.trim()) defaultBranch = stdout.trim();
+      } catch {
+        // gh not available or not a GitHub repo - fall back to 'main'
+      }
+
+      // Validate: on a valid feature branch
+      if (!currentBranch) {
+        return { success: false, error: 'Not on a branch (detached HEAD state).' };
+      }
+      if (currentBranch === defaultBranch) {
+        return {
+          success: false,
+          error: `Already on ${defaultBranch}. Create a feature branch first.`,
+        };
+      }
+
+      // Stage and commit any pending changes
+      const { stdout: statusOut } = await execAsync(
+        'git status --porcelain --untracked-files=all',
+        { cwd: taskPath }
+      );
+      if (statusOut?.trim()) {
+        await execAsync('git add -A', { cwd: taskPath });
+        try {
+          await execAsync('git commit -m "chore: prepare for merge to main"', { cwd: taskPath });
+        } catch (e) {
+          const msg = String(e);
+          if (!/nothing to commit/i.test(msg)) throw e;
+        }
+      }
+
+      // Push branch (set upstream if needed)
+      try {
+        await execAsync('git push', { cwd: taskPath });
+      } catch {
+        // No upstream set - push with -u
+        await execAsync(`git push --set-upstream origin ${JSON.stringify(currentBranch)}`, {
+          cwd: taskPath,
+        });
+      }
+
+      // Create PR (or use existing)
+      const autoCloseLinkedIssuesOnPrCreate = shouldAutoCloseLinkedIssuesOnPrCreate();
+      let prUrl = '';
+      let prExists = false;
+      let taskMetadata: unknown = undefined;
+      if (autoCloseLinkedIssuesOnPrCreate) {
+        try {
+          const task = await databaseService.getTaskByPath(taskPath);
+          taskMetadata = task?.metadata;
+        } catch (metadataError) {
+          log.debug('Unable to load task metadata for merge-to-main issue footer', {
+            taskPath,
+            metadataError,
+          });
+        }
+      }
+      try {
+        const prCreateArgs = ['pr', 'create', '--fill', '--base', defaultBranch];
+        const { stdout: prOut } = await execFileAsync('gh', prCreateArgs, { cwd: taskPath });
+        const urlMatch = prOut?.match(/https?:\/\/\S+/);
+        prUrl = urlMatch ? urlMatch[0] : '';
+        prExists = true;
+      } catch (e) {
+        const errMsg = (e as { stderr?: string })?.stderr || String(e);
+        if (!/already exists|already has.*pull request/i.test(errMsg)) {
+          return { success: false, error: `Failed to create PR: ${errMsg}` };
+        }
+        // PR already exists - continue to merge
+        prExists = true;
+      }
+
+      if (autoCloseLinkedIssuesOnPrCreate && prExists) {
+        try {
+          await patchCurrentPrBodyWithIssueFooter({
+            taskPath,
+            metadata: taskMetadata,
+            execFile: execFileAsync,
+            prUrl,
+          });
+        } catch (editError) {
+          log.warn('Failed to patch merge-to-main PR body with issue footer', {
+            taskPath,
+            editError,
+          });
+        }
+      }
+
+      // Merge PR (branch cleanup happens when workspace is deleted)
+      try {
+        await execAsync('gh pr merge --merge', { cwd: taskPath });
+        return { success: true, prUrl };
+      } catch (e) {
+        const errMsg = (e as { stderr?: string })?.stderr || String(e);
+        return { success: false, error: `PR created but merge failed: ${errMsg}`, prUrl };
+      }
+    } catch (e) {
+      log.error('Failed to merge to main:', e);
+      return { success: false, error: (e as { message?: string })?.message || String(e) };
+    }
+  });
+
+  // Git: Rename branch (local and optionally remote)
+  ipcMain.handle(
+    'git:rename-branch',
+    async (
+      _,
+      args: {
+        repoPath: string;
+        oldBranch: string;
+        newBranch: string;
+        sshConnectionId?: string;
+      }
+    ) => {
+      const { repoPath, oldBranch, newBranch, sshConnectionId } = args;
+      try {
+        log.info('Renaming branch:', { repoPath, oldBranch, newBranch });
+
+        const remoteProject = await resolveRemoteProjectForWorktreePath(repoPath, sshConnectionId);
+        if (remoteProject) {
+          const result = await remoteGitService.renameBranch(
+            remoteProject.sshConnectionId,
+            repoPath,
+            oldBranch,
+            newBranch
+          );
+          return { success: true, remotePushed: result.remotePushed };
+        }
+
+        // Check remote tracking BEFORE rename (git branch -m renames config section)
+        let remotePushed = false;
+        let remoteName = 'origin';
+        try {
+          const { stdout: remoteOut } = await execFileAsync(
+            GIT,
+            ['config', '--get', `branch.${oldBranch}.remote`],
+            { cwd: repoPath }
+          );
+          if (remoteOut?.trim()) {
+            remoteName = remoteOut.trim();
+            remotePushed = true;
+          }
+        } catch {
+          // Branch wasn't tracking a remote, check if it exists on origin
+          try {
+            const { stdout: lsRemote } = await execFileAsync(
+              GIT,
+              ['ls-remote', '--heads', 'origin', oldBranch],
+              { cwd: repoPath }
+            );
+            if (lsRemote?.trim()) {
+              remotePushed = true;
+            }
+          } catch {
+            // No remote branch
+          }
+        }
+
+        // Rename local branch
+        await execFileAsync(GIT, ['branch', '-m', oldBranch, newBranch], { cwd: repoPath });
+        log.info('Local branch renamed successfully');
+
+        // If pushed to remote, delete old and push new
+        if (remotePushed) {
+          log.info('Branch was pushed to remote, updating remote...');
+          try {
+            // Delete old remote branch
+            await execFileAsync(GIT, ['push', remoteName, '--delete', oldBranch], {
+              cwd: repoPath,
+            });
+            log.info('Deleted old remote branch');
+          } catch (deleteErr) {
+            // Remote branch might not exist or already deleted
+            log.warn('Could not delete old remote branch (may not exist):', deleteErr);
+          }
+
+          // Push new branch and set upstream
+          await execFileAsync(GIT, ['push', '-u', remoteName, newBranch], { cwd: repoPath });
+          log.info('Pushed new branch to remote');
+        }
+
+        return { success: true, remotePushed };
+      } catch (error) {
+        log.error('Failed to rename branch:', error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('git:commit', async (_, args: { taskPath: string; message: string }) => {
+    try {
+      const pathErr = validateTaskPath(args.taskPath);
+      if (pathErr) return { success: false, error: pathErr };
+      const result = await gitCommit(args.taskPath, args.message);
+      broadcastGitStatusChange(args.taskPath);
+      return { success: true, hash: result.hash };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcMain.handle('git:push', async (_, args: { taskPath: string }) => {
+    try {
+      const pathErr = validateTaskPath(args.taskPath);
+      if (pathErr) return { success: false, error: pathErr };
+      const result = await gitPush(args.taskPath);
+      return { success: true, output: result.output };
+    } catch (error) {
+      const errObj = error as { stderr?: string; message?: string };
+      return { success: false, error: errObj?.stderr?.trim() || errObj?.message || String(error) };
+    }
+  });
+
+  ipcMain.handle('git:pull', async (_, args: { taskPath: string }) => {
+    try {
+      const pathErr = validateTaskPath(args.taskPath);
+      if (pathErr) return { success: false, error: pathErr };
+      const result = await gitPull(args.taskPath);
+      return { success: true, output: result.output };
+    } catch (error) {
+      const errObj = error as { stderr?: string; message?: string };
+      return { success: false, error: errObj?.stderr?.trim() || errObj?.message || String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'git:get-log',
+    async (
+      _,
+      args: { taskPath: string; maxCount?: number; skip?: number; aheadCount?: number }
+    ) => {
+      try {
+        const pathErr = validateTaskPath(args.taskPath);
+        if (pathErr) return { success: false, error: pathErr };
+        const result = await gitGetLog(args.taskPath, args.maxCount, args.skip, args.aheadCount);
+        return { success: true, commits: result.commits, aheadCount: result.aheadCount };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('git:get-latest-commit', async (_, args: { taskPath: string }) => {
+    try {
+      const pathErr = validateTaskPath(args.taskPath);
+      if (pathErr) return { success: false, error: pathErr };
+      const commit = await gitGetLatestCommit(args.taskPath);
+      return { success: true, commit };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+
+  ipcMain.handle(
+    'git:get-commit-files',
+    async (_, args: { taskPath: string; commitHash: string }) => {
+      try {
+        const pathErr = validateTaskPath(args.taskPath);
+        if (pathErr) return { success: false, error: pathErr };
+        if (!/^[0-9a-f]{4,40}$/i.test(args.commitHash)) {
+          return { success: false, error: 'Invalid commit hash' };
+        }
+        const files = await gitGetCommitFiles(args.taskPath, args.commitHash);
+        return { success: true, files };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    'git:get-commit-file-diff',
+    async (
+      _,
+      args: { taskPath: string; commitHash: string; filePath: string; forceLarge?: boolean }
+    ) => {
+      try {
+        const pathErr = validateTaskPath(args.taskPath);
+        if (pathErr) return { success: false, error: pathErr };
+        if (!/^[0-9a-f]{4,40}$/i.test(args.commitHash)) {
+          return { success: false, error: 'Invalid commit hash' };
+        }
+        // filePath is validated by path.resolve check in GitService.getCommitFileDiff
+        const diff = await gitGetCommitFileDiff(
+          args.taskPath,
+          args.commitHash,
+          args.filePath,
+          args.forceLarge
+        );
+        return { success: true, diff };
+      } catch (error) {
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
+  );
+
+  ipcMain.handle('git:soft-reset', async (_, args: { taskPath: string }) => {
+    try {
+      const pathErr = validateTaskPath(args.taskPath);
+      if (pathErr) return { success: false, error: pathErr };
+      const result = await gitSoftResetLastCommit(args.taskPath);
+      broadcastGitStatusChange(args.taskPath);
+      return { success: true, subject: result.subject, body: result.body };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  });
+}

--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -1,38 +1,44 @@
-import { BrowserWindow, ipcMain } from 'electron';
-import { log } from '../lib/logger';
 import { exec, execFile } from 'child_process';
 import { randomUUID } from 'node:crypto';
 import fs from 'node:fs';
-import path from 'node:path';
 import os from 'node:os';
+import path from 'node:path';
 import { promisify } from 'util';
-import {
-  getStatus as gitGetStatus,
-  getFileDiff as gitGetFileDiff,
-  updateIndex as gitUpdateIndex,
-  revertFile as gitRevertFile,
-  commit as gitCommit,
-  push as gitPush,
-  pull as gitPull,
-  getLog as gitGetLog,
-  getLatestCommit as gitGetLatestCommit,
-  getCommitFiles as gitGetCommitFiles,
-  getCommitFileDiff as gitGetCommitFileDiff,
-  softResetLastCommit as gitSoftResetLastCommit,
-} from '../services/GitService';
+import { BrowserWindow, ipcMain } from 'electron';
 import type { GitIndexUpdateArgs } from '../../shared/git/types';
-import { prGenerationService } from '../services/PrGenerationService';
-import { databaseService } from '../services/DatabaseService';
-import { injectIssueFooter } from '../lib/prIssueFooter';
+import type {
+  ProjectPathLocator,
+  RepoPathLocator,
+  TaskPathLocator,
+} from '../../shared/ipc/remoteLocator';
+import { mapStatus, parseDiffLines } from '../core/git/impl/git-utils';
+import { log } from '../lib/logger';
 import { getCreatePrBodyPlan } from '../lib/prCreateBodyPlan';
+import { injectIssueFooter } from '../lib/prIssueFooter';
 import { patchCurrentPrBodyWithIssueFooter } from '../lib/prIssueFooterPatch';
-import { getAppSettings } from '../settings';
+import { databaseService } from '../services/DatabaseService';
 import {
-  resolveRemoteProjectForWorktreePath,
-  resolveRemoteContext,
-} from '../utils/remoteProjectResolver';
+  commit as gitCommit,
+  getCommitFileDiff as gitGetCommitFileDiff,
+  getCommitFiles as gitGetCommitFiles,
+  getFileDiff as gitGetFileDiff,
+  getLatestCommit as gitGetLatestCommit,
+  getLog as gitGetLog,
+  getStatus as gitGetStatus,
+  pull as gitPull,
+  push as gitPush,
+  revertFile as gitRevertFile,
+  softResetLastCommit as gitSoftResetLastCommit,
+  updateIndex as gitUpdateIndex,
+} from '../services/GitService';
+import { prGenerationService } from '../services/PrGenerationService';
 import { RemoteGitService } from '../services/RemoteGitService';
 import { sshService } from '../services/ssh/SshService';
+import { getAppSettings } from '../settings';
+import {
+  resolveRemoteContext,
+  resolveRemoteProjectForWorktreePath,
+} from '../utils/remoteProjectResolver';
 
 const remoteGitService = new RemoteGitService(sshService);
 
@@ -59,6 +65,225 @@ type RemoteStatusPollEntry = {
   connectionId: string;
 };
 const remoteStatusPollers = new Map<string, RemoteStatusPollEntry>();
+
+async function resolveRemoteProjectForTaskLocator(locator: TaskPathLocator) {
+  return resolveRemoteProjectForWorktreePath(locator.taskPath, locator.sshConnectionId);
+}
+
+async function resolveRemoteProjectForProjectLocator(locator: ProjectPathLocator) {
+  return resolveRemoteProjectForWorktreePath(locator.projectPath, locator.sshConnectionId);
+}
+
+async function resolveRemoteProjectForRepoLocator(locator: RepoPathLocator) {
+  return resolveRemoteProjectForWorktreePath(locator.repoPath, locator.sshConnectionId);
+}
+
+function normalizeTaskLocator(arg: string | TaskPathLocator): {
+  taskPath: string;
+  taskId?: string;
+  sshConnectionId?: string;
+} {
+  return typeof arg === 'string' ? { taskPath: arg } : arg;
+}
+
+function stripTrailingNewline(value: string): string {
+  return value.endsWith('\n') ? value.slice(0, -1) : value;
+}
+
+async function getRemoteAheadCount(connectionId: string, taskPath: string): Promise<number> {
+  try {
+    const upstream = await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      'rev-list --count @{upstream}..HEAD'
+    );
+    return Number.parseInt((upstream.stdout || '').trim(), 10) || 0;
+  } catch {
+    try {
+      const branchOut = await remoteGitService.execGit(
+        connectionId,
+        taskPath,
+        'rev-parse --abbrev-ref HEAD'
+      );
+      const currentBranch = (branchOut.stdout || '').trim();
+      const remoteOut = await remoteGitService.execGit(
+        connectionId,
+        taskPath,
+        `rev-list --count origin/${quoteGhArg(currentBranch)}..HEAD`
+      );
+      return Number.parseInt((remoteOut.stdout || '').trim(), 10) || 0;
+    } catch {
+      return 0;
+    }
+  }
+}
+
+async function getRemoteLog(
+  connectionId: string,
+  taskPath: string,
+  options?: { maxCount?: number; skip?: number; aheadCount?: number }
+) {
+  const { maxCount = 50, skip = 0, aheadCount: knownAheadCount } = options ?? {};
+  const aheadCount = knownAheadCount ?? (await getRemoteAheadCount(connectionId, taskPath));
+  const FIELD_SEP = '---FIELD_SEP---';
+  const RECORD_SEP = '---RECORD_SEP---';
+  const format = `${RECORD_SEP}%H${FIELD_SEP}%s${FIELD_SEP}%an${FIELD_SEP}%aI${FIELD_SEP}%D${FIELD_SEP}%b`;
+  const result = await remoteGitService.execGit(
+    connectionId,
+    taskPath,
+    `log --max-count=${maxCount} --skip=${skip} --pretty=format:${quoteGhArg(format)} HEAD --`
+  );
+
+  const stdout = result.stdout || '';
+  if (!stdout.trim()) return { commits: [], aheadCount };
+
+  const commits = stdout
+    .split(RECORD_SEP)
+    .filter((entry) => entry.trim())
+    .map((entry, index) => {
+      const parts = entry.trim().split(FIELD_SEP);
+      const refs = parts[4] || '';
+      const tags = refs
+        .split(',')
+        .map((r) => r.trim())
+        .filter((r) => r.startsWith('tag: '))
+        .map((r) => r.slice(5));
+      return {
+        hash: parts[0] || '',
+        subject: parts[1] || '',
+        body: (parts[5] || '').trim(),
+        author: parts[2] || '',
+        authorEmail: '',
+        date: parts[3] || '',
+        isPushed: skip + index >= aheadCount,
+        tags,
+      };
+    });
+
+  return { commits, aheadCount };
+}
+
+async function getRemoteLatestCommit(connectionId: string, taskPath: string) {
+  const { commits } = await getRemoteLog(connectionId, taskPath, { maxCount: 1 });
+  return commits[0] || null;
+}
+
+async function getRemoteCommitFiles(connectionId: string, taskPath: string, commitHash: string) {
+  const [numstatResult, nameStatusResult] = await Promise.all([
+    remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      `diff-tree --root --no-commit-id -r -m --first-parent --numstat ${quoteGhArg(commitHash)}`
+    ),
+    remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      `diff-tree --root --no-commit-id -r -m --first-parent --name-status ${quoteGhArg(commitHash)}`
+    ),
+  ]);
+
+  const statLines = (numstatResult.stdout || '').trim().split('\n').filter(Boolean);
+  const statusLines = (nameStatusResult.stdout || '').trim().split('\n').filter(Boolean);
+
+  const statusMap = new Map<string, string>();
+  for (const line of statusLines) {
+    const [code, ...pathParts] = line.split('\t');
+    const filePath = pathParts[pathParts.length - 1] || '';
+    statusMap.set(filePath, mapStatus(code ?? ''));
+  }
+
+  return statLines.map((line) => {
+    const [addStr, delStr, ...pathParts] = line.split('\t');
+    const filePath = pathParts.join('\t');
+    return {
+      path: filePath,
+      status: statusMap.get(filePath) || 'modified',
+      additions: addStr === '-' ? 0 : Number.parseInt(addStr || '0', 10) || 0,
+      deletions: delStr === '-' ? 0 : Number.parseInt(delStr || '0', 10) || 0,
+    };
+  });
+}
+
+async function getRemoteCommitFileDiff(
+  connectionId: string,
+  taskPath: string,
+  commitHash: string,
+  filePath: string
+) {
+  const getContentAt = async (ref: string): Promise<string | undefined> => {
+    try {
+      const result = await remoteGitService.execGit(
+        connectionId,
+        taskPath,
+        `show ${quoteGhArg(`${ref}:${filePath}`)}`
+      );
+      return stripTrailingNewline(result.stdout || '');
+    } catch {
+      return undefined;
+    }
+  };
+
+  let hasParent = true;
+  try {
+    await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      `rev-parse --verify ${quoteGhArg(`${commitHash}~1`)}`
+    );
+  } catch {
+    hasParent = false;
+  }
+
+  if (!hasParent) {
+    const modifiedContent = await getContentAt(commitHash);
+    if (modifiedContent === undefined) return { lines: [] };
+    if (modifiedContent === '') return { lines: [], modifiedContent };
+    return {
+      lines: modifiedContent.split('\n').map((l) => ({ right: l, type: 'add' as const })),
+      modifiedContent,
+    };
+  }
+
+  let diffStdout: string | undefined;
+  try {
+    const result = await remoteGitService.execGit(
+      connectionId,
+      taskPath,
+      `diff --no-color --unified=2000 ${quoteGhArg(`${commitHash}~1`)} ${quoteGhArg(commitHash)} -- ${quoteGhArg(filePath)}`
+    );
+    diffStdout = result.stdout;
+  } catch {}
+
+  let diffLines: ReturnType<typeof parseDiffLines>['lines'] = [];
+  if (diffStdout !== undefined) {
+    const { lines, isBinary } = parseDiffLines(diffStdout);
+    if (isBinary) return { lines: [], isBinary: true };
+    diffLines = lines;
+  }
+
+  const [originalContent, modifiedContent] = await Promise.all([
+    getContentAt(`${commitHash}~1`),
+    getContentAt(commitHash),
+  ]);
+
+  if (diffLines.length > 0) return { lines: diffLines, originalContent, modifiedContent };
+
+  if (modifiedContent !== undefined && modifiedContent !== '') {
+    return {
+      lines: modifiedContent.split('\n').map((l) => ({ right: l, type: 'add' as const })),
+      originalContent,
+      modifiedContent,
+    };
+  }
+  if (originalContent !== undefined) {
+    return {
+      lines: originalContent.split('\n').map((l) => ({ left: l, type: 'del' as const })),
+      originalContent,
+      modifiedContent,
+    };
+  }
+  return { lines: [], originalContent, modifiedContent };
+}
 
 function shouldAutoCloseLinkedIssuesOnPrCreate(): boolean {
   return getAppSettings().repository.autoCloseLinkedIssuesOnPrCreate !== false;
@@ -718,25 +943,20 @@ export function registerGitIpc() {
     }
   };
 
-  ipcMain.handle(
-    'git:watch-status',
-    async (_, arg: string | { taskPath: string; taskId?: string }) => {
-      const taskPath = typeof arg === 'string' ? arg : arg.taskPath;
-      const taskId = typeof arg === 'string' ? undefined : arg.taskId;
-      const remote = await resolveRemoteContext(taskPath, taskId);
-      if (remote) {
-        return ensureRemoteStatusPoller(taskPath, remote.connectionId, remote.remotePath);
-      }
-      return ensureGitStatusWatcher(taskPath);
+  ipcMain.handle('git:watch-status', async (_, arg: string | TaskPathLocator) => {
+    const { taskPath, taskId, sshConnectionId } = normalizeTaskLocator(arg);
+    const remote = await resolveRemoteContext(taskPath, { taskId, sshConnectionId });
+    if (remote) {
+      return ensureRemoteStatusPoller(taskPath, remote.connectionId, remote.remotePath);
     }
-  );
+    return ensureGitStatusWatcher(taskPath);
+  });
 
   ipcMain.handle(
     'git:unwatch-status',
-    async (_, arg: string | { taskPath: string; taskId?: string }, watchId?: string) => {
-      const taskPath = typeof arg === 'string' ? arg : arg.taskPath;
-      const taskId = typeof arg === 'string' ? undefined : arg.taskId;
-      const remote = await resolveRemoteContext(taskPath, taskId);
+    async (_, arg: string | TaskPathLocator, watchId?: string) => {
+      const { taskPath, taskId, sshConnectionId } = normalizeTaskLocator(arg);
+      const remote = await resolveRemoteContext(taskPath, { taskId, sshConnectionId });
       if (remote) {
         return releaseRemoteStatusPoller(taskPath, watchId);
       }
@@ -745,28 +965,24 @@ export function registerGitIpc() {
   );
 
   // Git: Status (moved from Codex IPC)
-  ipcMain.handle(
-    'git:get-status',
-    async (_, arg: string | { taskPath: string; taskId?: string }) => {
-      const taskPath = typeof arg === 'string' ? arg : arg.taskPath;
-      const taskId = typeof arg === 'string' ? undefined : arg.taskId;
-      try {
-        const remote = await resolveRemoteContext(taskPath, taskId);
-        if (remote) {
-          const changes = await remoteGitService.getStatusDetailed(
-            remote.connectionId,
-            remote.remotePath
-          );
-          return { success: true, changes };
-        }
-        const changes = await gitGetStatus(taskPath);
+  ipcMain.handle('git:get-status', async (_, arg: string | TaskPathLocator) => {
+    const { taskPath, taskId, sshConnectionId } = normalizeTaskLocator(arg);
+    try {
+      const remote = await resolveRemoteContext(taskPath, { taskId, sshConnectionId });
+      if (remote) {
+        const changes = await remoteGitService.getStatusDetailed(
+          remote.connectionId,
+          remote.remotePath
+        );
         return { success: true, changes };
-      } catch (error) {
-        log.error('git:get-status error', error);
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
       }
+      const changes = await gitGetStatus(taskPath);
+      return { success: true, changes };
+    } catch (error) {
+      log.error('git:get-status error', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
-  );
+  });
 
   ipcMain.handle(
     'git:get-delete-risks',
@@ -907,13 +1123,17 @@ export function registerGitIpc() {
       args: {
         taskPath: string;
         taskId?: string;
+        sshConnectionId?: string;
         filePath: string;
         baseRef?: string;
         forceLarge?: boolean;
       }
     ) => {
       try {
-        const remote = await resolveRemoteContext(args.taskPath, args.taskId);
+        const remote = await resolveRemoteContext(args.taskPath, {
+          taskId: args.taskId,
+          sshConnectionId: args.sshConnectionId,
+        });
         if (remote) {
           const diff = await remoteGitService.getFileDiff(
             remote.connectionId,
@@ -940,7 +1160,10 @@ export function registerGitIpc() {
   // Git: Update index (stage/unstage all or selected paths)
   ipcMain.handle(
     'git:update-index',
-    async (_, args: { taskPath: string; taskId?: string } & GitIndexUpdateArgs) => {
+    async (
+      _,
+      args: { taskPath: string; taskId?: string; sshConnectionId?: string } & GitIndexUpdateArgs
+    ) => {
       try {
         const operationArgs: GitIndexUpdateArgs = {
           action: args.action,
@@ -961,7 +1184,10 @@ export function registerGitIpc() {
           count: operationArgs.filePaths?.length ?? null,
         });
 
-        const remote = await resolveRemoteContext(args.taskPath, args.taskId);
+        const remote = await resolveRemoteContext(args.taskPath, {
+          taskId: args.taskId,
+          sshConnectionId: args.sshConnectionId,
+        });
         if (remote) {
           await remoteGitService.updateIndex(remote.connectionId, remote.remotePath, operationArgs);
         } else {
@@ -978,10 +1204,16 @@ export function registerGitIpc() {
   // Git: Revert file
   ipcMain.handle(
     'git:revert-file',
-    async (_, args: { taskPath: string; taskId?: string; filePath: string }) => {
+    async (
+      _,
+      args: { taskPath: string; taskId?: string; sshConnectionId?: string; filePath: string }
+    ) => {
       try {
         log.info('Reverting file:', { taskPath: args.taskPath, filePath: args.filePath });
-        const remote = await resolveRemoteContext(args.taskPath, args.taskId);
+        const remote = await resolveRemoteContext(args.taskPath, {
+          taskId: args.taskId,
+          sshConnectionId: args.sshConnectionId,
+        });
         let result: { action: string };
         if (remote) {
           result = await remoteGitService.revertFile(
@@ -1003,26 +1235,18 @@ export function registerGitIpc() {
   // Git: Generate PR title and description
   ipcMain.handle(
     'git:generate-pr-content',
-    async (
-      _,
-      args: {
-        taskPath: string;
-        base?: string;
-        sshConnectionId?: string;
-      }
-    ) => {
-      const {
-        taskPath,
-        base = 'main',
-        sshConnectionId,
-      } = args || ({} as { taskPath: string; base?: string; sshConnectionId?: string });
+    async (_, args: TaskPathLocator & { base?: string }) => {
+      const { taskPath, base = 'main', sshConnectionId } = args || ({} as typeof args);
       try {
         // For remote projects, PR content generation still runs locally — it just needs
         // the diff text. The prGenerationService can get diff data via the now-remote-aware
         // git:get-status and git:get-file-diff handlers, or we pass the taskPath which the
         // service uses with local git commands. For remote, we get the diff over SSH and
         // pass it to the generation service.
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        const remoteProject = await resolveRemoteProjectForTaskLocator({
+          taskPath,
+          sshConnectionId,
+        });
         if (remoteProject) {
           const connId = remoteProject.sshConnectionId;
           // Get diff text over SSH
@@ -1078,8 +1302,7 @@ export function registerGitIpc() {
     'git:create-pr',
     async (
       _,
-      args: {
-        taskPath: string;
+      args: TaskPathLocator & {
         title?: string;
         body?: string;
         base?: string;
@@ -1088,25 +1311,15 @@ export function registerGitIpc() {
         web?: boolean;
         fill?: boolean;
         skipPrePush?: boolean;
-        sshConnectionId?: string;
       }
     ) => {
       const { taskPath, title, body, base, head, draft, web, fill, skipPrePush, sshConnectionId } =
-        args ||
-        ({} as {
-          taskPath: string;
-          title?: string;
-          body?: string;
-          base?: string;
-          head?: string;
-          draft?: boolean;
-          web?: boolean;
-          fill?: boolean;
-          skipPrePush?: boolean;
-          sshConnectionId?: string;
-        });
+        args || ({} as typeof args);
       try {
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        const remoteProject = await resolveRemoteProjectForTaskLocator({
+          taskPath,
+          sshConnectionId,
+        });
         if (remoteProject) {
           return await createPrRemote(remoteProject.sshConnectionId, taskPath, {
             title,
@@ -1365,169 +1578,163 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
   );
 
   // Git: Get PR status for current branch via GitHub CLI
-  ipcMain.handle(
-    'git:get-pr-status',
-    async (_, args: { taskPath: string; sshConnectionId?: string }) => {
-      const { taskPath, sshConnectionId } =
-        args || ({} as { taskPath: string; sshConnectionId?: string });
-      try {
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
-        if (remoteProject) {
-          return await getPrStatusRemote(remoteProject.sshConnectionId, taskPath);
-        }
-
-        // Ensure we're in a git repo
-        await execAsync('git rev-parse --is-inside-work-tree', { cwd: taskPath });
-
-        const queryFields = [
-          'number',
-          'url',
-          'state',
-          'isDraft',
-          'mergeStateStatus',
-          'headRefName',
-          'baseRefName',
-          'title',
-          'author',
-          'additions',
-          'deletions',
-          'changedFiles',
-          'autoMergeRequest',
-        ];
-        const cmd = `gh pr view --json ${queryFields.join(',')} -q .`;
-        try {
-          // Attempt 1: gh pr view (works when branch tracking points to a PR)
-          let data: any = null;
-          try {
-            const { stdout } = await execAsync(cmd, { cwd: taskPath });
-            const json = (stdout || '').trim();
-            data = json ? JSON.parse(json) : null;
-          } catch (viewErr) {
-            const viewMsg = String(viewErr);
-            // Re-throw unexpected errors; swallow "no PR found" so fallbacks can run
-            if (!/no pull requests? found/i.test(viewMsg) && !/not found/i.test(viewMsg)) {
-              throw viewErr;
-            }
-          }
-
-          // Fallback: If gh pr view didn't find a PR (e.g. detached head, upstream not set, or fresh branch),
-          // try finding it by branch name via gh pr list.
-          let currentBranch = '';
-          if (!data) {
-            try {
-              const { stdout: branchOut } = await execAsync('git branch --show-current', {
-                cwd: taskPath,
-              });
-              currentBranch = branchOut.trim();
-              if (currentBranch) {
-                const listCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --json ${queryFields.join(',')} --limit 1`;
-                const { stdout: listOut } = await execAsync(listCmd, { cwd: taskPath });
-                const listJson = (listOut || '').trim();
-                const listData = listJson ? JSON.parse(listJson) : [];
-                if (listData.length > 0) {
-                  data = listData[0];
-                }
-              }
-            } catch (fallbackErr) {
-              log.warn('Failed to fallback to gh pr list:', fallbackErr);
-              // Ignore fallback errors and return original null/error
-            }
-          }
-
-          // Fork fallback: if still no PR found, check if this repo is a fork and search
-          // the parent/upstream repo for a PR with head "<fork-owner>:<branch>".
-          if (!data && currentBranch) {
-            try {
-              const { stdout: repoOut } = await execAsync('gh repo view --json owner,parent', {
-                cwd: taskPath,
-              });
-              const repoData = repoOut.trim() ? JSON.parse(repoOut.trim()) : null;
-              const parentOwner = repoData?.parent?.owner?.login;
-              const parentName = repoData?.parent?.name;
-              const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
-              if (parentRepo) {
-                const forkOwnerLogin = repoData?.owner?.login;
-                const forkFields = [...queryFields, 'headRepositoryOwner'];
-                const forkListCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --repo ${JSON.stringify(parentRepo)} --state open --json ${forkFields.join(',')} --limit 10`;
-                const { stdout: forkOut } = await execAsync(forkListCmd, { cwd: taskPath });
-                const forkJson = (forkOut || '').trim();
-                const forkData = forkJson ? JSON.parse(forkJson) : [];
-                const match = forkOwnerLogin
-                  ? forkData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
-                  : forkData[0];
-                if (match) {
-                  data = match;
-                }
-              }
-            } catch (forkFallbackErr) {
-              log.warn('Failed to check fork parent for PR:', forkFallbackErr);
-            }
-          }
-
-          if (!data) return { success: true, pr: null };
-
-          // Fallback: if GH CLI didn't return diff stats, try to compute locally
-          const asNumber = (v: any): number | null =>
-            typeof v === 'number' && Number.isFinite(v)
-              ? v
-              : typeof v === 'string' && Number.isFinite(Number.parseInt(v, 10))
-                ? Number.parseInt(v, 10)
-                : null;
-
-          const hasAdd = asNumber(data?.additions) !== null;
-          const hasDel = asNumber(data?.deletions) !== null;
-          const hasFiles = asNumber(data?.changedFiles) !== null;
-
-          if (!hasAdd || !hasDel || !hasFiles) {
-            const baseRef = typeof data?.baseRefName === 'string' ? data.baseRefName.trim() : '';
-            const targetRef = baseRef ? `origin/${baseRef}` : '';
-            const shortstatCmd = targetRef
-              ? `git diff --shortstat ${JSON.stringify(targetRef)}...HEAD`
-              : 'git diff --shortstat HEAD~1..HEAD';
-            try {
-              const { stdout: diffOut } = await execAsync(shortstatCmd, { cwd: taskPath });
-              const statLine = (diffOut || '').trim();
-              const m =
-                statLine &&
-                statLine.match(
-                  /(\d+)\s+files? changed(?:,\s+(\d+)\s+insertions?\(\+\))?(?:,\s+(\d+)\s+deletions?\(-\))?/
-                );
-              if (m) {
-                const [, filesStr, addStr, delStr] = m;
-                if (!hasFiles && filesStr) data.changedFiles = Number.parseInt(filesStr, 10);
-                if (!hasAdd && addStr) data.additions = Number.parseInt(addStr, 10);
-                if (!hasDel && delStr) data.deletions = Number.parseInt(delStr, 10);
-              }
-            } catch {
-              // best-effort only; ignore failures
-            }
-          }
-
-          return { success: true, pr: data };
-        } catch (err) {
-          const msg = String(err as string);
-          if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
-            return { success: true, pr: null };
-          }
-          return { success: false, error: msg || 'Failed to query PR status' };
-        }
-      } catch (error) {
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
+  ipcMain.handle('git:get-pr-status', async (_, args: TaskPathLocator) => {
+    const { taskPath, sshConnectionId } = args || ({} as typeof args);
+    try {
+      const remoteProject = await resolveRemoteProjectForTaskLocator({ taskPath, sshConnectionId });
+      if (remoteProject) {
+        return await getPrStatusRemote(remoteProject.sshConnectionId, taskPath);
       }
+
+      // Ensure we're in a git repo
+      await execAsync('git rev-parse --is-inside-work-tree', { cwd: taskPath });
+
+      const queryFields = [
+        'number',
+        'url',
+        'state',
+        'isDraft',
+        'mergeStateStatus',
+        'headRefName',
+        'baseRefName',
+        'title',
+        'author',
+        'additions',
+        'deletions',
+        'changedFiles',
+        'autoMergeRequest',
+      ];
+      const cmd = `gh pr view --json ${queryFields.join(',')} -q .`;
+      try {
+        // Attempt 1: gh pr view (works when branch tracking points to a PR)
+        let data: any = null;
+        try {
+          const { stdout } = await execAsync(cmd, { cwd: taskPath });
+          const json = (stdout || '').trim();
+          data = json ? JSON.parse(json) : null;
+        } catch (viewErr) {
+          const viewMsg = String(viewErr);
+          // Re-throw unexpected errors; swallow "no PR found" so fallbacks can run
+          if (!/no pull requests? found/i.test(viewMsg) && !/not found/i.test(viewMsg)) {
+            throw viewErr;
+          }
+        }
+
+        // Fallback: If gh pr view didn't find a PR (e.g. detached head, upstream not set, or fresh branch),
+        // try finding it by branch name via gh pr list.
+        let currentBranch = '';
+        if (!data) {
+          try {
+            const { stdout: branchOut } = await execAsync('git branch --show-current', {
+              cwd: taskPath,
+            });
+            currentBranch = branchOut.trim();
+            if (currentBranch) {
+              const listCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --json ${queryFields.join(',')} --limit 1`;
+              const { stdout: listOut } = await execAsync(listCmd, { cwd: taskPath });
+              const listJson = (listOut || '').trim();
+              const listData = listJson ? JSON.parse(listJson) : [];
+              if (listData.length > 0) {
+                data = listData[0];
+              }
+            }
+          } catch (fallbackErr) {
+            log.warn('Failed to fallback to gh pr list:', fallbackErr);
+            // Ignore fallback errors and return original null/error
+          }
+        }
+
+        // Fork fallback: if still no PR found, check if this repo is a fork and search
+        // the parent/upstream repo for a PR with head "<fork-owner>:<branch>".
+        if (!data && currentBranch) {
+          try {
+            const { stdout: repoOut } = await execAsync('gh repo view --json owner,parent', {
+              cwd: taskPath,
+            });
+            const repoData = repoOut.trim() ? JSON.parse(repoOut.trim()) : null;
+            const parentOwner = repoData?.parent?.owner?.login;
+            const parentName = repoData?.parent?.name;
+            const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
+            if (parentRepo) {
+              const forkOwnerLogin = repoData?.owner?.login;
+              const forkFields = [...queryFields, 'headRepositoryOwner'];
+              const forkListCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --repo ${JSON.stringify(parentRepo)} --state open --json ${forkFields.join(',')} --limit 10`;
+              const { stdout: forkOut } = await execAsync(forkListCmd, { cwd: taskPath });
+              const forkJson = (forkOut || '').trim();
+              const forkData = forkJson ? JSON.parse(forkJson) : [];
+              const match = forkOwnerLogin
+                ? forkData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
+                : forkData[0];
+              if (match) {
+                data = match;
+              }
+            }
+          } catch (forkFallbackErr) {
+            log.warn('Failed to check fork parent for PR:', forkFallbackErr);
+          }
+        }
+
+        if (!data) return { success: true, pr: null };
+
+        // Fallback: if GH CLI didn't return diff stats, try to compute locally
+        const asNumber = (v: any): number | null =>
+          typeof v === 'number' && Number.isFinite(v)
+            ? v
+            : typeof v === 'string' && Number.isFinite(Number.parseInt(v, 10))
+              ? Number.parseInt(v, 10)
+              : null;
+
+        const hasAdd = asNumber(data?.additions) !== null;
+        const hasDel = asNumber(data?.deletions) !== null;
+        const hasFiles = asNumber(data?.changedFiles) !== null;
+
+        if (!hasAdd || !hasDel || !hasFiles) {
+          const baseRef = typeof data?.baseRefName === 'string' ? data.baseRefName.trim() : '';
+          const targetRef = baseRef ? `origin/${baseRef}` : '';
+          const shortstatCmd = targetRef
+            ? `git diff --shortstat ${JSON.stringify(targetRef)}...HEAD`
+            : 'git diff --shortstat HEAD~1..HEAD';
+          try {
+            const { stdout: diffOut } = await execAsync(shortstatCmd, { cwd: taskPath });
+            const statLine = (diffOut || '').trim();
+            const m =
+              statLine &&
+              statLine.match(
+                /(\d+)\s+files? changed(?:,\s+(\d+)\s+insertions?\(\+\))?(?:,\s+(\d+)\s+deletions?\(-\))?/
+              );
+            if (m) {
+              const [, filesStr, addStr, delStr] = m;
+              if (!hasFiles && filesStr) data.changedFiles = Number.parseInt(filesStr, 10);
+              if (!hasAdd && addStr) data.additions = Number.parseInt(addStr, 10);
+              if (!hasDel && delStr) data.deletions = Number.parseInt(delStr, 10);
+            }
+          } catch {
+            // best-effort only; ignore failures
+          }
+        }
+
+        return { success: true, pr: data };
+      } catch (err) {
+        const msg = String(err as string);
+        if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
+          return { success: true, pr: null };
+        }
+        return { success: false, error: msg || 'Failed to query PR status' };
+      }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
-  );
+  });
 
   // Git: Merge PR via GitHub CLI
   ipcMain.handle(
     'git:merge-pr',
     async (
       _,
-      args: {
-        taskPath: string;
+      args: TaskPathLocator & {
         prNumber?: number;
         strategy?: 'merge' | 'squash' | 'rebase';
         admin?: boolean;
-        sshConnectionId?: string;
       }
     ) => {
       const {
@@ -1536,16 +1743,13 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         strategy = 'merge',
         admin = false,
         sshConnectionId,
-      } = (args || {}) as {
-        taskPath: string;
-        prNumber?: number;
-        strategy?: 'merge' | 'squash' | 'rebase';
-        admin?: boolean;
-        sshConnectionId?: string;
-      };
+      } = (args || {}) as typeof args;
 
       try {
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        const remoteProject = await resolveRemoteProjectForTaskLocator({
+          taskPath,
+          sshConnectionId,
+        });
         if (remoteProject) {
           const strategyFlag =
             strategy === 'squash' ? '--squash' : strategy === 'rebase' ? '--rebase' : '--merge';
@@ -1609,11 +1813,9 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
     'git:enable-auto-merge',
     async (
       _,
-      args: {
-        taskPath: string;
+      args: TaskPathLocator & {
         prNumber?: number;
         strategy?: 'merge' | 'squash' | 'rebase';
-        sshConnectionId?: string;
       }
     ) => {
       const {
@@ -1621,12 +1823,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         prNumber,
         strategy = 'merge',
         sshConnectionId,
-      } = (args || {}) as {
-        taskPath: string;
-        prNumber?: number;
-        strategy?: 'merge' | 'squash' | 'rebase';
-        sshConnectionId?: string;
-      };
+      } = (args || {}) as typeof args;
 
       try {
         const strategyFlag =
@@ -1637,7 +1834,10 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         }
         ghArgs.push('--auto', strategyFlag);
 
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        const remoteProject = await resolveRemoteProjectForTaskLocator({
+          taskPath,
+          sshConnectionId,
+        });
         if (remoteProject) {
           const result = await remoteGitService.execGh(
             remoteProject.sshConnectionId,
@@ -1665,19 +1865,8 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
   // Git: Disable auto-merge on a PR via GitHub CLI
   ipcMain.handle(
     'git:disable-auto-merge',
-    async (
-      _,
-      args: {
-        taskPath: string;
-        prNumber?: number;
-        sshConnectionId?: string;
-      }
-    ) => {
-      const { taskPath, prNumber, sshConnectionId } = (args || {}) as {
-        taskPath: string;
-        prNumber?: number;
-        sshConnectionId?: string;
-      };
+    async (_, args: TaskPathLocator & { prNumber?: number }) => {
+      const { taskPath, prNumber, sshConnectionId } = (args || {}) as typeof args;
 
       try {
         const ghArgs = ['pr', 'merge'];
@@ -1686,7 +1875,10 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         }
         ghArgs.push('--disable-auto');
 
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        const remoteProject = await resolveRemoteProjectForTaskLocator({
+          taskPath,
+          sshConnectionId,
+        });
         if (remoteProject) {
           const result = await remoteGitService.execGh(
             remoteProject.sshConnectionId,
@@ -1712,235 +1904,66 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
   );
 
   // Git: Get CI/CD check runs for current branch via GitHub CLI
-  ipcMain.handle(
-    'git:get-check-runs',
-    async (_, args: { taskPath: string; sshConnectionId?: string }) => {
-      const { taskPath, sshConnectionId } =
-        args || ({} as { taskPath: string; sshConnectionId?: string });
-      try {
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
-        if (remoteProject) {
-          const connId = remoteProject.sshConnectionId;
-          const fields = 'bucket,completedAt,description,event,link,name,startedAt,state,workflow';
-
-          // Detect fork on remote: find PR in parent repo if applicable
-          let prRef: string | null = null;
-          let remoteParentRepo: string | null = null;
-          let remoteChecksApiRepo = 'repos/{owner}/{repo}';
-          let remoteHeadRefOidCmd = "pr view --json headRefOid --jq '.headRefOid'";
-          try {
-            const repoResult = await remoteGitService.execGh(
-              connId,
-              taskPath,
-              'repo view --json owner,parent'
-            );
-            const repoData = repoResult.stdout.trim() ? JSON.parse(repoResult.stdout.trim()) : null;
-            const parentOwner = repoData?.parent?.owner?.login;
-            const parentName = repoData?.parent?.name;
-            const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
-            if (parentRepo) {
-              const branchResult = await remoteGitService.execGit(
-                connId,
-                taskPath,
-                'branch --show-current'
-              );
-              const currentBranch = branchResult.stdout.trim();
-              if (currentBranch) {
-                const listResult = await remoteGitService.execGh(
-                  connId,
-                  taskPath,
-                  `pr list --head ${quoteGhArg(currentBranch)} --repo ${quoteGhArg(parentRepo)} --state open --json number,headRefOid,headRepositoryOwner --limit 10`
-                );
-                const forkOwnerLogin = repoData?.owner?.login;
-                const listData = listResult.stdout.trim()
-                  ? JSON.parse(listResult.stdout.trim())
-                  : [];
-                const matched = forkOwnerLogin
-                  ? listData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
-                  : listData[0];
-                if (matched) {
-                  prRef = String(matched.number);
-                  remoteParentRepo = parentRepo;
-                  remoteChecksApiRepo = `repos/${parentRepo}`;
-                  remoteHeadRefOidCmd = `pr view ${prRef} --repo ${quoteGhArg(parentRepo)} --json headRefOid --jq '.headRefOid'`;
-                }
-              }
-            }
-          } catch {
-            // Not a fork or detection failed — proceed with default behavior
-          }
-
-          const checksCmd =
-            prRef && remoteParentRepo
-              ? `pr checks ${prRef} --repo ${quoteGhArg(remoteParentRepo)} --json ${fields}`
-              : `pr checks --json ${fields}`;
-          const checksResult = await remoteGitService.execGh(connId, taskPath, checksCmd);
-          if (checksResult.exitCode !== 0) {
-            const msg = checksResult.stderr || '';
-            if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
-              return { success: true, checks: null };
-            }
-            if (/not installed|command not found/i.test(msg)) {
-              return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
-            }
-            return { success: false, error: msg || 'Failed to query check runs' };
-          }
-          const checks = checksResult.stdout.trim() ? JSON.parse(checksResult.stdout.trim()) : [];
-
-          // Fetch html_url from API
-          try {
-            const shaResult = await remoteGitService.execGh(connId, taskPath, remoteHeadRefOidCmd);
-            const sha = shaResult.stdout.trim();
-            if (sha) {
-              const apiResult = await remoteGitService.execGh(
-                connId,
-                taskPath,
-                `api ${remoteChecksApiRepo}/commits/${sha}/check-runs --jq '.check_runs | map({name: .name, html_url: .html_url}) | .[]'`
-              );
-              const urlMap = new Map<string, string>();
-              for (const line of apiResult.stdout.trim().split('\n')) {
-                if (!line) continue;
-                try {
-                  const entry = JSON.parse(line);
-                  if (entry.name && entry.html_url) urlMap.set(entry.name, entry.html_url);
-                } catch {}
-              }
-              for (const check of checks) {
-                const htmlUrl = urlMap.get(check.name);
-                if (htmlUrl) check.link = htmlUrl;
-              }
-            }
-          } catch {
-            // Fall back to original link values
-          }
-
-          return { success: true, checks };
-        }
-
-        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
-
+  ipcMain.handle('git:get-check-runs', async (_, args: TaskPathLocator) => {
+    const { taskPath, sshConnectionId } = args || ({} as typeof args);
+    try {
+      const remoteProject = await resolveRemoteProjectForTaskLocator({ taskPath, sshConnectionId });
+      if (remoteProject) {
+        const connId = remoteProject.sshConnectionId;
         const fields = 'bucket,completedAt,description,event,link,name,startedAt,state,workflow';
 
-        // Resolve the PR number and repo to use for gh commands.
-        // For forks, the PR lives in the parent repo, so we detect that here once.
-        let prRef: string | null = null; // PR number as string, or null to use implicit (current branch)
-        let repoFlag: string[] = []; // ['--repo', 'owner/repo'] or empty
-        let headRefOidArgs: string[] = [
-          'pr',
-          'view',
-          '--json',
-          'headRefOid',
-          '--jq',
-          '.headRefOid',
-        ];
-        let checkRunsApiRepo = 'repos/{owner}/{repo}'; // used in gh api call
-
+        // Detect fork on remote: find PR in parent repo if applicable
+        let prRef: string | null = null;
+        let remoteParentRepo: string | null = null;
+        let remoteChecksApiRepo = 'repos/{owner}/{repo}';
+        let remoteHeadRefOidCmd = "pr view --json headRefOid --jq '.headRefOid'";
         try {
-          // Detect fork: if this repo has a parent, find the PR number there
-          const { stdout: repoOut } = await execFileAsync(
-            'gh',
-            ['repo', 'view', '--json', 'owner,parent'],
-            { cwd: taskPath }
+          const repoResult = await remoteGitService.execGh(
+            connId,
+            taskPath,
+            'repo view --json owner,parent'
           );
-          const repoData = repoOut.trim() ? JSON.parse(repoOut.trim()) : null;
+          const repoData = repoResult.stdout.trim() ? JSON.parse(repoResult.stdout.trim()) : null;
           const parentOwner = repoData?.parent?.owner?.login;
           const parentName = repoData?.parent?.name;
           const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
           if (parentRepo) {
-            const { stdout: branchOut } = await execFileAsync('git', ['branch', '--show-current'], {
-              cwd: taskPath,
-            });
-            const currentBranch = branchOut.trim();
+            const branchResult = await remoteGitService.execGit(
+              connId,
+              taskPath,
+              'branch --show-current'
+            );
+            const currentBranch = branchResult.stdout.trim();
             if (currentBranch) {
-              const { stdout: listOut } = await execFileAsync(
-                'gh',
-                [
-                  'pr',
-                  'list',
-                  '--head',
-                  currentBranch,
-                  '--repo',
-                  parentRepo,
-                  '--state',
-                  'open',
-                  '--json',
-                  'number,headRefOid,headRepositoryOwner',
-                  '--limit',
-                  '10',
-                ],
-                { cwd: taskPath }
+              const listResult = await remoteGitService.execGh(
+                connId,
+                taskPath,
+                `pr list --head ${quoteGhArg(currentBranch)} --repo ${quoteGhArg(parentRepo)} --state open --json number,headRefOid,headRepositoryOwner --limit 10`
               );
               const forkOwnerLogin = repoData?.owner?.login;
-              const listData = listOut.trim() ? JSON.parse(listOut.trim()) : [];
+              const listData = listResult.stdout.trim() ? JSON.parse(listResult.stdout.trim()) : [];
               const matched = forkOwnerLogin
                 ? listData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
                 : listData[0];
               if (matched) {
                 prRef = String(matched.number);
-                repoFlag = ['--repo', parentRepo];
-                headRefOidArgs = [
-                  'pr',
-                  'view',
-                  prRef,
-                  '--repo',
-                  parentRepo,
-                  '--json',
-                  'headRefOid',
-                  '--jq',
-                  '.headRefOid',
-                ];
-                checkRunsApiRepo = `repos/${parentRepo}`;
+                remoteParentRepo = parentRepo;
+                remoteChecksApiRepo = `repos/${parentRepo}`;
+                remoteHeadRefOidCmd = `pr view ${prRef} --repo ${quoteGhArg(parentRepo)} --json headRefOid --jq '.headRefOid'`;
               }
             }
           }
         } catch {
-          // Not a fork or detection failed — proceed with default (current-branch) behavior
+          // Not a fork or detection failed — proceed with default behavior
         }
 
-        try {
-          const checksArgs = prRef
-            ? ['pr', 'checks', prRef, ...repoFlag, '--json', fields]
-            : ['pr', 'checks', '--json', fields];
-          const { stdout } = await execFileAsync('gh', checksArgs, { cwd: taskPath });
-          const json = (stdout || '').trim();
-          const checks = json ? JSON.parse(json) : [];
-
-          // Fetch html_url from the GitHub API instead, which always points to the
-          // actual check run page on GitHub.
-          try {
-            const { stdout: shaOut } = await execFileAsync('gh', headRefOidArgs, { cwd: taskPath });
-            const sha = shaOut.trim();
-            if (sha) {
-              const { stdout: apiOut } = await execFileAsync(
-                'gh',
-                [
-                  'api',
-                  `${checkRunsApiRepo}/commits/${sha}/check-runs`,
-                  '--jq',
-                  '.check_runs | map({name: .name, html_url: .html_url}) | .[]',
-                ],
-                { cwd: taskPath }
-              );
-              const urlMap = new Map<string, string>();
-              for (const line of apiOut.trim().split('\n')) {
-                if (!line) continue;
-                try {
-                  const entry = JSON.parse(line);
-                  if (entry.name && entry.html_url) urlMap.set(entry.name, entry.html_url);
-                } catch {}
-              }
-              for (const check of checks) {
-                const htmlUrl = urlMap.get(check.name);
-                if (htmlUrl) check.link = htmlUrl;
-              }
-            }
-          } catch {
-            // Fall back to original link values if API call fails
-          }
-
-          return { success: true, checks };
-        } catch (err) {
-          const msg = String(err as string);
+        const checksCmd =
+          prRef && remoteParentRepo
+            ? `pr checks ${prRef} --repo ${quoteGhArg(remoteParentRepo)} --json ${fields}`
+            : `pr checks --json ${fields}`;
+        const checksResult = await remoteGitService.execGh(connId, taskPath, checksCmd);
+        if (checksResult.exitCode !== 0) {
+          const msg = checksResult.stderr || '';
           if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
             return { success: true, checks: null };
           }
@@ -1949,20 +1972,178 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
           }
           return { success: false, error: msg || 'Failed to query check runs' };
         }
-      } catch (error) {
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
+        const checks = checksResult.stdout.trim() ? JSON.parse(checksResult.stdout.trim()) : [];
+
+        // Fetch html_url from API
+        try {
+          const shaResult = await remoteGitService.execGh(connId, taskPath, remoteHeadRefOidCmd);
+          const sha = shaResult.stdout.trim();
+          if (sha) {
+            const apiResult = await remoteGitService.execGh(
+              connId,
+              taskPath,
+              `api ${remoteChecksApiRepo}/commits/${sha}/check-runs --jq '.check_runs | map({name: .name, html_url: .html_url}) | .[]'`
+            );
+            const urlMap = new Map<string, string>();
+            for (const line of apiResult.stdout.trim().split('\n')) {
+              if (!line) continue;
+              try {
+                const entry = JSON.parse(line);
+                if (entry.name && entry.html_url) urlMap.set(entry.name, entry.html_url);
+              } catch {}
+            }
+            for (const check of checks) {
+              const htmlUrl = urlMap.get(check.name);
+              if (htmlUrl) check.link = htmlUrl;
+            }
+          }
+        } catch {
+          // Fall back to original link values
+        }
+
+        return { success: true, checks };
       }
+
+      await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+
+      const fields = 'bucket,completedAt,description,event,link,name,startedAt,state,workflow';
+
+      // Resolve the PR number and repo to use for gh commands.
+      // For forks, the PR lives in the parent repo, so we detect that here once.
+      let prRef: string | null = null; // PR number as string, or null to use implicit (current branch)
+      let repoFlag: string[] = []; // ['--repo', 'owner/repo'] or empty
+      let headRefOidArgs: string[] = ['pr', 'view', '--json', 'headRefOid', '--jq', '.headRefOid'];
+      let checkRunsApiRepo = 'repos/{owner}/{repo}'; // used in gh api call
+
+      try {
+        // Detect fork: if this repo has a parent, find the PR number there
+        const { stdout: repoOut } = await execFileAsync(
+          'gh',
+          ['repo', 'view', '--json', 'owner,parent'],
+          { cwd: taskPath }
+        );
+        const repoData = repoOut.trim() ? JSON.parse(repoOut.trim()) : null;
+        const parentOwner = repoData?.parent?.owner?.login;
+        const parentName = repoData?.parent?.name;
+        const parentRepo = parentOwner && parentName ? `${parentOwner}/${parentName}` : null;
+        if (parentRepo) {
+          const { stdout: branchOut } = await execFileAsync('git', ['branch', '--show-current'], {
+            cwd: taskPath,
+          });
+          const currentBranch = branchOut.trim();
+          if (currentBranch) {
+            const { stdout: listOut } = await execFileAsync(
+              'gh',
+              [
+                'pr',
+                'list',
+                '--head',
+                currentBranch,
+                '--repo',
+                parentRepo,
+                '--state',
+                'open',
+                '--json',
+                'number,headRefOid,headRepositoryOwner',
+                '--limit',
+                '10',
+              ],
+              { cwd: taskPath }
+            );
+            const forkOwnerLogin = repoData?.owner?.login;
+            const listData = listOut.trim() ? JSON.parse(listOut.trim()) : [];
+            const matched = forkOwnerLogin
+              ? listData.find((pr: any) => pr?.headRepositoryOwner?.login === forkOwnerLogin)
+              : listData[0];
+            if (matched) {
+              prRef = String(matched.number);
+              repoFlag = ['--repo', parentRepo];
+              headRefOidArgs = [
+                'pr',
+                'view',
+                prRef,
+                '--repo',
+                parentRepo,
+                '--json',
+                'headRefOid',
+                '--jq',
+                '.headRefOid',
+              ];
+              checkRunsApiRepo = `repos/${parentRepo}`;
+            }
+          }
+        }
+      } catch {
+        // Not a fork or detection failed — proceed with default (current-branch) behavior
+      }
+
+      try {
+        const checksArgs = prRef
+          ? ['pr', 'checks', prRef, ...repoFlag, '--json', fields]
+          : ['pr', 'checks', '--json', fields];
+        const { stdout } = await execFileAsync('gh', checksArgs, { cwd: taskPath });
+        const json = (stdout || '').trim();
+        const checks = json ? JSON.parse(json) : [];
+
+        // Fetch html_url from the GitHub API instead, which always points to the
+        // actual check run page on GitHub.
+        try {
+          const { stdout: shaOut } = await execFileAsync('gh', headRefOidArgs, { cwd: taskPath });
+          const sha = shaOut.trim();
+          if (sha) {
+            const { stdout: apiOut } = await execFileAsync(
+              'gh',
+              [
+                'api',
+                `${checkRunsApiRepo}/commits/${sha}/check-runs`,
+                '--jq',
+                '.check_runs | map({name: .name, html_url: .html_url}) | .[]',
+              ],
+              { cwd: taskPath }
+            );
+            const urlMap = new Map<string, string>();
+            for (const line of apiOut.trim().split('\n')) {
+              if (!line) continue;
+              try {
+                const entry = JSON.parse(line);
+                if (entry.name && entry.html_url) urlMap.set(entry.name, entry.html_url);
+              } catch {}
+            }
+            for (const check of checks) {
+              const htmlUrl = urlMap.get(check.name);
+              if (htmlUrl) check.link = htmlUrl;
+            }
+          }
+        } catch {
+          // Fall back to original link values if API call fails
+        }
+
+        return { success: true, checks };
+      } catch (err) {
+        const msg = String(err as string);
+        if (/no pull requests? found/i.test(msg) || /not found/i.test(msg)) {
+          return { success: true, checks: null };
+        }
+        if (/not installed|command not found/i.test(msg)) {
+          return { success: false, error: msg, code: 'GH_CLI_UNAVAILABLE' };
+        }
+        return { success: false, error: msg || 'Failed to query check runs' };
+      }
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
-  );
+  });
 
   // Git: Get PR comments and reviews via GitHub CLI
   ipcMain.handle(
     'git:get-pr-comments',
-    async (_, args: { taskPath: string; prNumber?: number; sshConnectionId?: string }) => {
-      const { taskPath, prNumber, sshConnectionId } =
-        args || ({} as { taskPath: string; prNumber?: number; sshConnectionId?: string });
+    async (_, args: TaskPathLocator & { prNumber?: number }) => {
+      const { taskPath, prNumber, sshConnectionId } = args || ({} as typeof args);
       try {
-        const remoteProject = await resolveRemoteProjectForWorktreePath(taskPath, sshConnectionId);
+        const remoteProject = await resolveRemoteProjectForTaskLocator({
+          taskPath,
+          sshConnectionId,
+        });
         if (remoteProject) {
           const connId = remoteProject.sshConnectionId;
           const ghViewArgs = prNumber
@@ -2129,9 +2310,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
     'git:commit-and-push',
     async (
       _,
-      args: {
-        taskPath: string;
-        taskId?: string;
+      args: TaskPathLocator & {
         commitMessage?: string;
         createBranchIfOnDefault?: boolean;
         branchPrefix?: string;
@@ -2140,26 +2319,14 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
       const {
         taskPath,
         taskId,
+        sshConnectionId,
         commitMessage = 'chore: apply task changes',
         createBranchIfOnDefault = true,
         branchPrefix = 'orch',
-      } = (args ||
-        ({} as {
-          taskPath: string;
-          taskId?: string;
-          commitMessage?: string;
-          createBranchIfOnDefault?: boolean;
-          branchPrefix?: string;
-        })) as {
-        taskPath: string;
-        taskId?: string;
-        commitMessage?: string;
-        createBranchIfOnDefault?: boolean;
-        branchPrefix?: string;
-      };
+      } = (args || ({} as typeof args)) as typeof args;
 
       try {
-        const remote = await resolveRemoteContext(taskPath, taskId);
+        const remote = await resolveRemoteContext(taskPath, { taskId, sshConnectionId });
 
         if (remote) {
           return await commitAndPushRemote(remote.connectionId, remote.remotePath, {
@@ -2284,86 +2451,93 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
   );
 
   // Git: Get branch status (current branch, default branch, ahead/behind counts)
-  ipcMain.handle(
-    'git:get-branch-status',
-    async (_, args: { taskPath: string; taskId?: string }) => {
-      const { taskPath, taskId } = args || ({} as { taskPath: string; taskId?: string });
+  ipcMain.handle('git:get-branch-status', async (_, args: TaskPathLocator) => {
+    const { taskPath, taskId, sshConnectionId } = args || ({} as typeof args);
 
-      if (!taskPath) {
-        return { success: false, error: 'Path does not exist' };
-      }
+    if (!taskPath) {
+      return { success: false, error: 'Path does not exist' };
+    }
 
-      const remote = await resolveRemoteContext(taskPath, taskId);
-      if (remote) {
-        try {
-          const status = await remoteGitService.getBranchStatus(
-            remote.connectionId,
-            remote.remotePath
-          );
-          return { success: true, ...status };
-        } catch (error) {
-          log.error(`getBranchStatus (remote): error for ${taskPath}:`, error);
-          return { success: false, error: error instanceof Error ? error.message : String(error) };
-        }
-      }
-
-      // Early exit for missing/invalid local path
-      if (!fs.existsSync(taskPath)) {
-        log.warn(`getBranchStatus: path does not exist: ${taskPath}`);
-        return { success: false, error: 'Path does not exist' };
-      }
-
-      // Check if it's a git repo - expected to fail often for non-git paths
+    const remote = await resolveRemoteContext(taskPath, { taskId, sshConnectionId });
+    if (remote) {
       try {
-        await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
-      } catch {
-        log.warn(`getBranchStatus: not a git repository: ${taskPath}`);
-        return { success: false, error: 'Not a git repository' };
-      }
-
-      try {
-        // Current branch
-        const { stdout: currentBranchOut } = await execFileAsync(
-          GIT,
-          ['branch', '--show-current'],
-          {
-            cwd: taskPath,
-          }
+        const status = await remoteGitService.getBranchStatus(
+          remote.connectionId,
+          remote.remotePath
         );
-        const branch = (currentBranchOut || '').trim();
+        return { success: true, ...status };
+      } catch (error) {
+        log.error(`getBranchStatus (remote): error for ${taskPath}:`, error);
+        return { success: false, error: error instanceof Error ? error.message : String(error) };
+      }
+    }
 
-        // Determine default branch
-        let defaultBranch = 'main';
-        try {
-          const { stdout } = await execFileAsync(
-            'gh',
-            ['repo', 'view', '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'],
-            { cwd: taskPath }
-          );
-          const db = (stdout || '').trim();
-          if (db) defaultBranch = db;
-        } catch {
-          try {
-            // Use symbolic-ref to resolve origin/HEAD then take the last path part
-            const { stdout } = await execFileAsync(
-              GIT,
-              ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
-              { cwd: taskPath }
-            );
-            const line = (stdout || '').trim();
-            const last = line.split('/').pop();
-            if (last) defaultBranch = last;
-          } catch {}
-        }
+    // Early exit for missing/invalid local path
+    if (!fs.existsSync(taskPath)) {
+      log.warn(`getBranchStatus: path does not exist: ${taskPath}`);
+      return { success: false, error: 'Path does not exist' };
+    }
 
-        // Ahead/behind relative to upstream tracking branch
-        let ahead = 0;
-        let behind = 0;
+    // Check if it's a git repo - expected to fail often for non-git paths
+    try {
+      await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
+    } catch {
+      log.warn(`getBranchStatus: not a git repository: ${taskPath}`);
+      return { success: false, error: 'Not a git repository' };
+    }
+
+    try {
+      // Current branch
+      const { stdout: currentBranchOut } = await execFileAsync(GIT, ['branch', '--show-current'], {
+        cwd: taskPath,
+      });
+      const branch = (currentBranchOut || '').trim();
+
+      // Determine default branch
+      let defaultBranch = 'main';
+      try {
+        const { stdout } = await execFileAsync(
+          'gh',
+          ['repo', 'view', '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'],
+          { cwd: taskPath }
+        );
+        const db = (stdout || '').trim();
+        if (db) defaultBranch = db;
+      } catch {
         try {
-          // Best case: compare against the upstream tracking branch (@{upstream})
+          // Use symbolic-ref to resolve origin/HEAD then take the last path part
           const { stdout } = await execFileAsync(
             GIT,
-            ['rev-list', '--left-right', '--count', '@{upstream}...HEAD'],
+            ['symbolic-ref', '--short', 'refs/remotes/origin/HEAD'],
+            { cwd: taskPath }
+          );
+          const line = (stdout || '').trim();
+          const last = line.split('/').pop();
+          if (last) defaultBranch = last;
+        } catch {}
+      }
+
+      // Ahead/behind relative to upstream tracking branch
+      let ahead = 0;
+      let behind = 0;
+      try {
+        // Best case: compare against the upstream tracking branch (@{upstream})
+        const { stdout } = await execFileAsync(
+          GIT,
+          ['rev-list', '--left-right', '--count', '@{upstream}...HEAD'],
+          { cwd: taskPath }
+        );
+        const parts = (stdout || '').trim().split(/\s+/);
+        if (parts.length >= 2) {
+          behind = parseInt(parts[0] || '0', 10) || 0;
+          ahead = parseInt(parts[1] || '0', 10) || 0;
+        }
+      } catch {
+        try {
+          // Fallback: compare against origin/<current-branch>
+          const { stdout } = await execFileAsync(
+            GIT,
+            ['rev-list', '--left-right', '--count', `origin/${branch}...HEAD`],
             { cwd: taskPath }
           );
           const parts = (stdout || '').trim().split(/\s+/);
@@ -2372,67 +2546,52 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
             ahead = parseInt(parts[1] || '0', 10) || 0;
           }
         } catch {
+          // No upstream — use git status as last resort
           try {
-            // Fallback: compare against origin/<current-branch>
-            const { stdout } = await execFileAsync(
-              GIT,
-              ['rev-list', '--left-right', '--count', `origin/${branch}...HEAD`],
-              { cwd: taskPath }
-            );
-            const parts = (stdout || '').trim().split(/\s+/);
-            if (parts.length >= 2) {
-              behind = parseInt(parts[0] || '0', 10) || 0;
-              ahead = parseInt(parts[1] || '0', 10) || 0;
-            }
-          } catch {
-            // No upstream — use git status as last resort
-            try {
-              const { stdout } = await execFileAsync(GIT, ['status', '-sb'], { cwd: taskPath });
-              const line = (stdout || '').split(/\n/)[0] || '';
-              const m = line.match(/ahead\s+(\d+)/i);
-              const n = line.match(/behind\s+(\d+)/i);
-              if (m) ahead = parseInt(m[1] || '0', 10) || 0;
-              if (n) behind = parseInt(n[1] || '0', 10) || 0;
-            } catch {}
-          }
+            const { stdout } = await execFileAsync(GIT, ['status', '-sb'], { cwd: taskPath });
+            const line = (stdout || '').split(/\n/)[0] || '';
+            const m = line.match(/ahead\s+(\d+)/i);
+            const n = line.match(/behind\s+(\d+)/i);
+            if (m) ahead = parseInt(m[1] || '0', 10) || 0;
+            if (n) behind = parseInt(n[1] || '0', 10) || 0;
+          } catch {}
         }
-
-        // Count commits ahead of origin/<defaultBranch> (for PR visibility)
-        let aheadOfDefault = 0;
-        if (branch !== defaultBranch) {
-          try {
-            const { stdout: countOut } = await execFileAsync(
-              GIT,
-              ['rev-list', '--count', `origin/${defaultBranch}..HEAD`],
-              { cwd: taskPath }
-            );
-            aheadOfDefault = parseInt(countOut.trim(), 10) || 0;
-          } catch {
-            // origin/<defaultBranch> may not exist
-          }
-        }
-
-        return { success: true, branch, defaultBranch, ahead, behind, aheadOfDefault };
-      } catch (error) {
-        log.error(`getBranchStatus: unexpected error for ${taskPath}:`, error);
-        return { success: false, error: error instanceof Error ? error.message : String(error) };
       }
+
+      // Count commits ahead of origin/<defaultBranch> (for PR visibility)
+      let aheadOfDefault = 0;
+      if (branch !== defaultBranch) {
+        try {
+          const { stdout: countOut } = await execFileAsync(
+            GIT,
+            ['rev-list', '--count', `origin/${defaultBranch}..HEAD`],
+            { cwd: taskPath }
+          );
+          aheadOfDefault = parseInt(countOut.trim(), 10) || 0;
+        } catch {
+          // origin/<defaultBranch> may not exist
+        }
+      }
+
+      return { success: true, branch, defaultBranch, ahead, behind, aheadOfDefault };
+    } catch (error) {
+      log.error(`getBranchStatus: unexpected error for ${taskPath}:`, error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
-  );
+  });
 
   ipcMain.handle(
     'git:list-remote-branches',
-    async (_, args: { projectPath: string; remote?: string; sshConnectionId?: string }) => {
-      const {
-        projectPath,
-        remote = 'origin',
-        sshConnectionId,
-      } = args || ({} as { projectPath: string; remote?: string; sshConnectionId?: string });
+    async (_, args: ProjectPathLocator & { remote?: string }) => {
+      const { projectPath, remote = 'origin', sshConnectionId } = args || ({} as typeof args);
       if (!projectPath) {
         return { success: false, error: 'projectPath is required' };
       }
 
-      const remoteProject = await resolveRemoteProjectForWorktreePath(projectPath, sshConnectionId);
+      const remoteProject = await resolveRemoteProjectForProjectLocator({
+        projectPath,
+        sshConnectionId,
+      });
       if (remoteProject) {
         try {
           const branches = await remoteGitService.listBranches(
@@ -2556,11 +2715,11 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
   );
 
   // Git: Merge current branch to main via GitHub (create PR + merge immediately)
-  ipcMain.handle('git:merge-to-main', async (_, args: { taskPath: string; taskId?: string }) => {
-    const { taskPath, taskId } = args || ({} as { taskPath: string; taskId?: string });
+  ipcMain.handle('git:merge-to-main', async (_, args: TaskPathLocator) => {
+    const { taskPath, taskId, sshConnectionId } = args || ({} as typeof args);
 
     try {
-      const remote = await resolveRemoteContext(taskPath, taskId);
+      const remote = await resolveRemoteContext(taskPath, { taskId, sshConnectionId });
       if (remote) {
         return await mergeToMainRemote(remote.connectionId, remote.remotePath);
       }
@@ -2684,18 +2843,19 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
     'git:rename-branch',
     async (
       _,
-      args: {
-        repoPath: string;
+      args: RepoPathLocator & {
         oldBranch: string;
         newBranch: string;
-        sshConnectionId?: string;
       }
     ) => {
       const { repoPath, oldBranch, newBranch, sshConnectionId } = args;
       try {
         log.info('Renaming branch:', { repoPath, oldBranch, newBranch });
 
-        const remoteProject = await resolveRemoteProjectForWorktreePath(repoPath, sshConnectionId);
+        const remoteProject = await resolveRemoteProjectForRepoLocator({
+          repoPath,
+          sshConnectionId,
+        });
         if (remoteProject) {
           const result = await remoteGitService.renameBranch(
             remoteProject.sshConnectionId,
@@ -2806,9 +2966,22 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
     'git:get-log',
     async (
       _,
-      args: { taskPath: string; maxCount?: number; skip?: number; aheadCount?: number }
+      args: TaskPathLocator & { maxCount?: number; skip?: number; aheadCount?: number }
     ) => {
       try {
+        const remote = await resolveRemoteContext(args.taskPath, {
+          taskId: args.taskId,
+          sshConnectionId: args.sshConnectionId,
+        });
+        if (remote) {
+          const result = await getRemoteLog(remote.connectionId, remote.remotePath, {
+            maxCount: args.maxCount,
+            skip: args.skip,
+            aheadCount: args.aheadCount,
+          });
+          return { success: true, commits: result.commits, aheadCount: result.aheadCount };
+        }
+
         const pathErr = validateTaskPath(args.taskPath);
         if (pathErr) return { success: false, error: pathErr };
         const result = await gitGetLog(args.taskPath, args.maxCount, args.skip, args.aheadCount);
@@ -2819,8 +2992,17 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
     }
   );
 
-  ipcMain.handle('git:get-latest-commit', async (_, args: { taskPath: string }) => {
+  ipcMain.handle('git:get-latest-commit', async (_, args: TaskPathLocator) => {
     try {
+      const remote = await resolveRemoteContext(args.taskPath, {
+        taskId: args.taskId,
+        sshConnectionId: args.sshConnectionId,
+      });
+      if (remote) {
+        const commit = await getRemoteLatestCommit(remote.connectionId, remote.remotePath);
+        return { success: true, commit };
+      }
+
       const pathErr = validateTaskPath(args.taskPath);
       if (pathErr) return { success: false, error: pathErr };
       const commit = await gitGetLatestCommit(args.taskPath);
@@ -2832,13 +3014,27 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
 
   ipcMain.handle(
     'git:get-commit-files',
-    async (_, args: { taskPath: string; commitHash: string }) => {
+    async (_, args: TaskPathLocator & { commitHash: string }) => {
       try {
-        const pathErr = validateTaskPath(args.taskPath);
-        if (pathErr) return { success: false, error: pathErr };
         if (!/^[0-9a-f]{4,40}$/i.test(args.commitHash)) {
           return { success: false, error: 'Invalid commit hash' };
         }
+
+        const remote = await resolveRemoteContext(args.taskPath, {
+          taskId: args.taskId,
+          sshConnectionId: args.sshConnectionId,
+        });
+        if (remote) {
+          const files = await getRemoteCommitFiles(
+            remote.connectionId,
+            remote.remotePath,
+            args.commitHash
+          );
+          return { success: true, files };
+        }
+
+        const pathErr = validateTaskPath(args.taskPath);
+        if (pathErr) return { success: false, error: pathErr };
         const files = await gitGetCommitFiles(args.taskPath, args.commitHash);
         return { success: true, files };
       } catch (error) {
@@ -2851,14 +3047,29 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
     'git:get-commit-file-diff',
     async (
       _,
-      args: { taskPath: string; commitHash: string; filePath: string; forceLarge?: boolean }
+      args: TaskPathLocator & { commitHash: string; filePath: string; forceLarge?: boolean }
     ) => {
       try {
-        const pathErr = validateTaskPath(args.taskPath);
-        if (pathErr) return { success: false, error: pathErr };
         if (!/^[0-9a-f]{4,40}$/i.test(args.commitHash)) {
           return { success: false, error: 'Invalid commit hash' };
         }
+
+        const remote = await resolveRemoteContext(args.taskPath, {
+          taskId: args.taskId,
+          sshConnectionId: args.sshConnectionId,
+        });
+        if (remote) {
+          const diff = await getRemoteCommitFileDiff(
+            remote.connectionId,
+            remote.remotePath,
+            args.commitHash,
+            args.filePath
+          );
+          return { success: true, diff };
+        }
+
+        const pathErr = validateTaskPath(args.taskPath);
+        if (pathErr) return { success: false, error: pathErr };
         // filePath is validated by path.resolve check in GitService.getCommitFileDiff
         const diff = await gitGetCommitFileDiff(
           args.taskPath,

--- a/src/main/ipc/sshIpc.ts
+++ b/src/main/ipc/sshIpc.ts
@@ -469,9 +469,13 @@ export function registerSshIpc() {
               host: sshConfigHost.hostname ?? alias,
               port: sshConfigHost.port ?? 22,
               username: sshConfigHost.user ?? userInfo().username,
-              authType: sshConfigHost.identityFile ? 'key' : 'agent',
+              authType: sshConfigHost.identityAgent
+                ? 'agent'
+                : sshConfigHost.identityFile
+                  ? 'key'
+                  : 'agent',
               privateKeyPath: sshConfigHost.identityFile,
-              useAgent: !sshConfigHost.identityFile,
+              useAgent: Boolean(sshConfigHost.identityAgent),
             };
 
             const connectionId = await sshService.connect(config);

--- a/src/main/ipc/sshIpc.ts
+++ b/src/main/ipc/sshIpc.ts
@@ -1,4 +1,5 @@
 import { ipcMain } from 'electron';
+import { userInfo } from 'os';
 import { SSH_IPC_CHANNELS } from '../../shared/ssh/types';
 import { sshService } from '../services/ssh/SshService';
 import { SshCredentialService } from '../services/ssh/SshCredentialService';
@@ -467,7 +468,7 @@ export function registerSshIpc() {
               name: alias,
               host: sshConfigHost.hostname ?? alias,
               port: sshConfigHost.port ?? 22,
-              username: sshConfigHost.user ?? '',
+              username: sshConfigHost.user ?? userInfo().username,
               authType: sshConfigHost.identityFile ? 'key' : 'agent',
               privateKeyPath: sshConfigHost.identityFile,
               useAgent: !sshConfigHost.identityFile,

--- a/src/main/ipc/sshIpc.ts
+++ b/src/main/ipc/sshIpc.ts
@@ -1,0 +1,960 @@
+import { ipcMain } from 'electron';
+import { SSH_IPC_CHANNELS } from '../../shared/ssh/types';
+import { sshService } from '../services/ssh/SshService';
+import { SshCredentialService } from '../services/ssh/SshCredentialService';
+import { SshHostKeyService } from '../services/ssh/SshHostKeyService';
+import { SshConnectionMonitor } from '../services/ssh/SshConnectionMonitor';
+import { getDrizzleClient } from '../db/drizzleClient';
+import { sshConnections as sshConnectionsTable, type SshConnectionInsert } from '../db/schema';
+import { eq, desc } from 'drizzle-orm';
+import { randomUUID } from 'crypto';
+import { quoteShellArg } from '../utils/shellEscape';
+import { getSshExecuteCommandValidationError } from '../utils/sshCommandValidation';
+import {
+  parseSshConfigFile,
+  resolveIdentityAgent,
+  resolveProxyCommand,
+  resolveSshConfigHost,
+} from '../utils/sshConfigParser';
+import type {
+  SshConfig,
+  ConnectionTestResult,
+  FileEntry,
+  ConnectionState,
+  SshConfigHost,
+} from '../../shared/ssh/types';
+
+// Initialize services
+const credentialService = new SshCredentialService();
+// Host key service initialized for future use (host key verification)
+const _hostKeyService = new SshHostKeyService();
+const monitor = new SshConnectionMonitor((id) => sshService.isConnected(id));
+
+// When ssh2 detects a dead connection (via keepalive) and emits `close`,
+// SshService removes it from the pool and emits `disconnected`.
+// The monitor reacts by triggering reconnect with exponential backoff.
+sshService.on('disconnected', (connectionId: string) => {
+  monitor.handleDisconnect(connectionId);
+});
+
+/**
+ * Maps a database row to SshConfig
+ */
+function mapRowToConfig(row: {
+  id: string;
+  name: string;
+  host: string;
+  port: number;
+  username: string;
+  authType: string;
+  privateKeyPath: string | null;
+  useAgent: number;
+}): SshConfig {
+  return {
+    id: row.id,
+    name: row.name,
+    host: row.host,
+    port: row.port,
+    username: row.username,
+    authType: row.authType as 'password' | 'key' | 'agent',
+    privateKeyPath: row.privateKeyPath ?? undefined,
+    useAgent: row.useAgent === 1,
+  };
+}
+
+/**
+ * Validates that a remote path is safe to access.
+ *
+ * Uses a two-layer approach:
+ *   1. Reject any path containing traversal sequences (even after normalization).
+ *   2. Reject paths that resolve into known-sensitive directories.
+ *
+ * The path is resolved against '/' so that relative tricks like
+ * "foo/../../etc/shadow" are caught.
+ */
+function isPathSafe(remotePath: string): boolean {
+  // Must be an absolute path
+  if (!remotePath.startsWith('/')) {
+    return false;
+  }
+
+  // Normalize repeated slashes
+  const normalized = remotePath.replace(/\/+/g, '/');
+
+  // Reject any occurrence of '..' as a path component
+  // This catches ../  /..  and trailing /..
+  const segments = normalized.split('/');
+  if (segments.some((s) => s === '..')) {
+    return false;
+  }
+
+  // Block access to sensitive system directories and hidden dotfiles
+  const restrictedPrefixes = ['/etc/', '/proc/', '/sys/', '/dev/', '/boot/', '/root/'];
+  for (const prefix of restrictedPrefixes) {
+    if (normalized.startsWith(prefix) || normalized === prefix.slice(0, -1)) {
+      return false;
+    }
+  }
+
+  // Block .ssh directories anywhere in the path
+  if (segments.some((s) => s === '.ssh')) {
+    return false;
+  }
+
+  return true;
+}
+
+/**
+ * Classify an SSH error into a safe, non-PII category for telemetry.
+ */
+function classifySshError(err: any): string {
+  const msg = String(err?.message || err || '').toLowerCase();
+  if (msg.includes('authentication') || msg.includes('auth') || msg.includes('password')) {
+    return 'auth_failed';
+  }
+  if (msg.includes('timed out') || msg.includes('timeout')) {
+    return 'timeout';
+  }
+  if (
+    msg.includes('econnrefused') ||
+    msg.includes('enotfound') ||
+    msg.includes('enetunreach') ||
+    msg.includes('network')
+  ) {
+    return 'network';
+  }
+  if (msg.includes('key') || msg.includes('passphrase') || msg.includes('decrypt')) {
+    return 'key_error';
+  }
+  return 'unknown';
+}
+
+/**
+ * Register all SSH IPC handlers
+ */
+export function registerSshIpc() {
+  // Wire up reconnect handler so the monitor's reconnect event actually reconnects (HIGH #9)
+  monitor.on('reconnect', async (connectionId: string, config: SshConfig, attempt: number) => {
+    try {
+      console.log(`[sshIpc] Reconnecting ${connectionId} (attempt ${attempt})...`);
+
+      // Clean up the stale/dead connection before opening a new one
+      if (sshService.isConnected(connectionId)) {
+        await sshService.disconnect(connectionId).catch(() => {});
+      }
+
+      await sshService.connect(config);
+      monitor.updateState(connectionId, 'connected');
+      void import('../telemetry').then(({ capture }) => {
+        void capture('ssh_reconnect_attempted', { success: true });
+      });
+    } catch (err: any) {
+      console.error(
+        `[sshIpc] Reconnect attempt ${attempt} failed for ${connectionId}:`,
+        err.message
+      );
+      monitor.updateState(connectionId, 'error', err.message);
+      void import('../telemetry').then(({ capture }) => {
+        void capture('ssh_reconnect_attempted', { success: false });
+      });
+    }
+  });
+  // Test connection
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.TEST_CONNECTION,
+    async (
+      _,
+      config: SshConfig & { password?: string; passphrase?: string }
+    ): Promise<ConnectionTestResult> => {
+      try {
+        const { Client } = await import('ssh2');
+        const debugLogs: string[] = [];
+        const testClient = new Client();
+
+        return new Promise(async (resolve) => {
+          const startTime = Date.now();
+
+          testClient.on('ready', () => {
+            const latency = Date.now() - startTime;
+            testClient.end();
+            try {
+              proxyProc?.kill();
+            } catch {
+              /* ignore */
+            }
+            resolve({ success: true, latency, debugLogs });
+          });
+
+          testClient.on('error', (err: Error) => {
+            try {
+              proxyProc?.kill();
+            } catch {
+              /* ignore */
+            }
+            resolve({ success: false, error: err.message, debugLogs });
+          });
+
+          testClient.on('keyboard-interactive', () => {
+            // Close the connection if keyboard-interactive auth is required
+            testClient.end();
+            resolve({
+              success: false,
+              error: 'Keyboard-interactive authentication not supported',
+              debugLogs,
+            });
+          });
+
+          const connectConfig: {
+            host: string;
+            port: number;
+            username: string;
+            readyTimeout: number;
+            password?: string;
+            privateKey?: Buffer;
+            passphrase?: string;
+            agent?: string;
+            debug?: (info: string) => void;
+          } = {
+            host: config.host,
+            port: config.port,
+            username: config.username,
+            readyTimeout: 10000,
+            debug: (info: string) => debugLogs.push(info),
+          };
+
+          if (config.authType === 'password') {
+            connectConfig.password = config.password;
+          } else if (config.authType === 'key' && config.privateKeyPath) {
+            const fs = require('fs');
+            const os = require('os');
+            try {
+              // Expand ~ to home directory
+              let keyPath = config.privateKeyPath;
+              if (keyPath.startsWith('~/')) {
+                keyPath = keyPath.replace('~', os.homedir());
+              } else if (keyPath === '~') {
+                keyPath = os.homedir();
+              }
+
+              connectConfig.privateKey = fs.readFileSync(keyPath);
+              if (config.passphrase) {
+                connectConfig.passphrase = config.passphrase;
+              }
+            } catch (err: any) {
+              resolve({
+                success: false,
+                error: `Failed to read private key: ${err.message}`,
+                debugLogs,
+              });
+              return;
+            }
+          } else if (config.authType === 'agent') {
+            const identityAgent = await resolveIdentityAgent(config.host);
+            connectConfig.agent = identityAgent || process.env.SSH_AUTH_SOCK;
+            debugLogs.push(
+              `[emdash] authType=agent, socket=${connectConfig.agent ?? '(not found)'}`
+            );
+          }
+
+          debugLogs.push(
+            `[emdash] authType=${config.authType}, host=${config.host}, port=${config.port}, username=${config.username}`
+          );
+
+          // Check for ProxyCommand in ~/.ssh/config
+          const proxyCommand = await resolveProxyCommand(config.host, config.port);
+          debugLogs.push(`[emdash] ProxyCommand resolve: ${proxyCommand ?? '(none)'}`);
+          let proxyProc: import('child_process').ChildProcess | undefined;
+          if (proxyCommand) {
+            const { Duplex } = await import('stream');
+            const { spawn } = await import('child_process');
+            proxyProc = spawn('sh', ['-c', proxyCommand], {
+              stdio: ['pipe', 'pipe', 'pipe'],
+            });
+            const sock = new Duplex({
+              read() {},
+              write(chunk, encoding, callback) {
+                return proxyProc!.stdin!.write(chunk, encoding, callback);
+              },
+              final(callback) {
+                proxyProc!.stdin!.end(callback);
+              },
+            });
+            proxyProc.stdout!.on('data', (data) => sock.push(data));
+            proxyProc.stdout!.on('close', () => sock.push(null));
+            proxyProc.stderr!.on('data', (data) => {
+              debugLogs.push(`[emdash] proxy stderr: ${data.toString()}`);
+            });
+            proxyProc.on('error', (err) => {
+              debugLogs.push(`[emdash] proxy error: ${err.message}`);
+              sock.destroy(err);
+            });
+            (connectConfig as any).sock = sock;
+          }
+
+          testClient.connect(connectConfig);
+        });
+      } catch (err: any) {
+        console.error('[sshIpc] Test connection error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Save connection
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.SAVE_CONNECTION,
+    async (
+      _,
+      config: SshConfig & { password?: string; passphrase?: string }
+    ): Promise<{ success: boolean; connection?: SshConfig; error?: string }> => {
+      try {
+        const { db } = await getDrizzleClient();
+
+        // Generate ID if not provided
+        const connectionId =
+          config.id ?? `ssh-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+
+        // Save credentials first (secure keychain storage)
+        if (config.password) {
+          await credentialService.storePassword(connectionId, config.password);
+        }
+        if (config.passphrase) {
+          await credentialService.storePassphrase(connectionId, config.passphrase);
+        }
+
+        // Strip sensitive data before saving to DB
+        const { password: _password, passphrase: _passphrase, ...dbConfig } = config;
+
+        const insertData: SshConnectionInsert = {
+          id: connectionId,
+          name: dbConfig.name,
+          host: dbConfig.host,
+          port: dbConfig.port,
+          username: dbConfig.username,
+          authType: dbConfig.authType,
+          privateKeyPath: dbConfig.privateKeyPath,
+          useAgent: dbConfig.useAgent ? 1 : 0,
+        };
+
+        // Insert or update
+        await db
+          .insert(sshConnectionsTable)
+          .values(insertData)
+          .onConflictDoUpdate({
+            target: sshConnectionsTable.id,
+            set: {
+              name: insertData.name,
+              host: insertData.host,
+              port: insertData.port,
+              username: insertData.username,
+              authType: insertData.authType,
+              privateKeyPath: insertData.privateKeyPath,
+              useAgent: insertData.useAgent,
+              updatedAt: new Date().toISOString(),
+            },
+          });
+
+        void import('../telemetry').then(({ capture }) => {
+          void capture('ssh_connection_saved', { type: config.authType });
+        });
+
+        return {
+          success: true,
+          connection: {
+            ...dbConfig,
+            id: connectionId,
+          },
+        };
+      } catch (err: any) {
+        console.error('[sshIpc] Save connection error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Get connections
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.GET_CONNECTIONS,
+    async (): Promise<{ success: boolean; connections?: SshConfig[]; error?: string }> => {
+      try {
+        const { db } = await getDrizzleClient();
+
+        const rows = await db
+          .select({
+            id: sshConnectionsTable.id,
+            name: sshConnectionsTable.name,
+            host: sshConnectionsTable.host,
+            port: sshConnectionsTable.port,
+            username: sshConnectionsTable.username,
+            authType: sshConnectionsTable.authType,
+            privateKeyPath: sshConnectionsTable.privateKeyPath,
+            useAgent: sshConnectionsTable.useAgent,
+          })
+          .from(sshConnectionsTable)
+          .orderBy(desc(sshConnectionsTable.updatedAt));
+
+        return {
+          success: true,
+          connections: rows.map(mapRowToConfig),
+        };
+      } catch (err: any) {
+        console.error('[sshIpc] Get connections error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Delete connection
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.DELETE_CONNECTION,
+    async (_, id: string): Promise<{ success: boolean; error?: string }> => {
+      try {
+        // Stop monitoring BEFORE disconnecting so the monitor's
+        // handleDisconnect listener doesn't trigger a reconnect.
+        monitor.stopMonitoring(id);
+        if (sshService.isConnected(id)) {
+          try {
+            await sshService.disconnect(id);
+          } catch {
+            // Best-effort: continue with deletion even if disconnect fails
+          }
+        }
+
+        const { db } = await getDrizzleClient();
+
+        // Delete credentials
+        await credentialService.deleteAllCredentials(id);
+
+        // Delete from database
+        await db.delete(sshConnectionsTable).where(eq(sshConnectionsTable.id, id));
+
+        void import('../telemetry').then(({ capture }) => {
+          void capture('ssh_connection_deleted');
+        });
+
+        return { success: true };
+      } catch (err: any) {
+        console.error('[sshIpc] Delete connection error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Connect
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.CONNECT,
+    async (
+      _,
+      arg: unknown
+    ): Promise<{ success: boolean; connectionId?: string; error?: string }> => {
+      try {
+        // Accept either a saved connection id (string) or a config object.
+        if (typeof arg === 'string') {
+          const id = arg;
+
+          // Handle SSH config aliases (e.g. "ssh-config:tower02") that were never saved to DB
+          if (id.startsWith('ssh-config:')) {
+            const raw = id.slice('ssh-config:'.length);
+            const alias = /%[0-9A-Fa-f]{2}/.test(raw) ? decodeURIComponent(raw) : raw;
+
+            const sshConfigHost = await resolveSshConfigHost(alias);
+            if (!sshConfigHost) {
+              return { success: false, error: `SSH config host not found: ${alias}` };
+            }
+
+            const config: SshConfig = {
+              id,
+              name: alias,
+              host: sshConfigHost.hostname ?? alias,
+              port: sshConfigHost.port ?? 22,
+              username: sshConfigHost.user ?? '',
+              authType: sshConfigHost.identityFile ? 'key' : 'agent',
+              privateKeyPath: sshConfigHost.identityFile,
+              useAgent: !sshConfigHost.identityFile,
+            };
+
+            const connectionId = await sshService.connect(config);
+            monitor.startMonitoring(connectionId, config);
+            monitor.updateState(connectionId, 'connected');
+            void import('../telemetry').then(({ capture }) => {
+              void capture('ssh_connect_success', { type: config.authType });
+            });
+            return { success: true, connectionId };
+          }
+
+          const { db } = await getDrizzleClient();
+          const rows = await db
+            .select({
+              id: sshConnectionsTable.id,
+              name: sshConnectionsTable.name,
+              host: sshConnectionsTable.host,
+              port: sshConnectionsTable.port,
+              username: sshConnectionsTable.username,
+              authType: sshConnectionsTable.authType,
+              privateKeyPath: sshConnectionsTable.privateKeyPath,
+              useAgent: sshConnectionsTable.useAgent,
+            })
+            .from(sshConnectionsTable)
+            .where(eq(sshConnectionsTable.id, id))
+            .limit(1);
+
+          const row = rows[0];
+          if (!row) {
+            return { success: false, error: `SSH connection not found: ${id}` };
+          }
+
+          const loadedConfig = mapRowToConfig(row);
+          const connectionId = await sshService.connect(loadedConfig);
+          // startMonitoring is a no-op if already tracked; updateState
+          // is a no-op if not tracked. Call both to handle fresh connects
+          // and re-connects after the monitor gave up (state = disconnected).
+          monitor.startMonitoring(connectionId, loadedConfig);
+          monitor.updateState(connectionId, 'connected');
+          void import('../telemetry').then(({ capture }) => {
+            void capture('ssh_connect_success', { type: loadedConfig.authType });
+          });
+          return { success: true, connectionId };
+        }
+
+        if (!arg || typeof arg !== 'object') {
+          return { success: false, error: 'Invalid SSH connect request' };
+        }
+
+        const config = arg as SshConfig & { password?: string; passphrase?: string };
+        const effectiveId = config.id ?? randomUUID();
+
+        // If secrets are provided inline, store them for this id.
+        if (config.authType === 'password' && typeof config.password === 'string') {
+          await credentialService.storePassword(effectiveId, config.password);
+        }
+        if (
+          config.authType === 'key' &&
+          typeof config.passphrase === 'string' &&
+          config.passphrase
+        ) {
+          await credentialService.storePassphrase(effectiveId, config.passphrase);
+        }
+
+        // Load credentials from keychain if needed
+        let password = config.password;
+        let passphrase = config.passphrase;
+
+        if (config.authType === 'password' && !password) {
+          password = (await credentialService.getPassword(effectiveId)) ?? undefined;
+        }
+        if (config.authType === 'key' && !passphrase) {
+          passphrase = (await credentialService.getPassphrase(effectiveId)) ?? undefined;
+        }
+
+        const fullConfig = {
+          ...config,
+          id: effectiveId,
+          password,
+          passphrase,
+        };
+
+        const connectionId = await sshService.connect(fullConfig as any);
+        monitor.startMonitoring(connectionId, fullConfig as any);
+        monitor.updateState(connectionId, 'connected');
+        void import('../telemetry').then(({ capture }) => {
+          void capture('ssh_connect_success', { type: config.authType });
+        });
+        return { success: true, connectionId };
+      } catch (err: any) {
+        console.error('[sshIpc] Connection error:', err);
+        void import('../telemetry').then(({ capture }) => {
+          void capture('ssh_connect_failed', { error_type: classifySshError(err) });
+        });
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Disconnect
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.DISCONNECT,
+    async (_, connectionId: string): Promise<{ success: boolean; error?: string }> => {
+      try {
+        // Stop monitoring BEFORE disconnecting so the monitor's
+        // handleDisconnect listener doesn't trigger a reconnect
+        // for an intentional disconnect.
+        monitor.stopMonitoring(connectionId);
+        await sshService.disconnect(connectionId);
+        void import('../telemetry').then(({ capture }) => {
+          void capture('ssh_disconnected');
+        });
+        return { success: true };
+      } catch (err: any) {
+        console.error('[sshIpc] Disconnect error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.EXECUTE_COMMAND,
+    async (
+      _,
+      connectionId: string,
+      command: string,
+      cwd?: string
+    ): Promise<{
+      success: boolean;
+      stdout?: string;
+      stderr?: string;
+      exitCode?: number;
+      error?: string;
+    }> => {
+      try {
+        const trimmed = command.trimStart();
+        const validationError = getSshExecuteCommandValidationError(command);
+        if (validationError) {
+          console.warn(`[sshIpc] Blocked disallowed command: ${trimmed.slice(0, 80)}`);
+          return { success: false, error: validationError };
+        }
+
+        const result = await sshService.executeCommand(connectionId, command, cwd);
+        return { success: true, ...result };
+      } catch (error: any) {
+        console.error('[sshIpc] Execute command error:', error);
+        return { success: false, error: error.message };
+      }
+    }
+  );
+
+  // List files
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.LIST_FILES,
+    async (
+      _,
+      connectionId: string,
+      path: string
+    ): Promise<{ success: boolean; files?: FileEntry[]; error?: string }> => {
+      try {
+        // Validate path to prevent browsing sensitive directories
+        if (!isPathSafe(path)) {
+          return { success: false, error: 'Access denied: path is restricted' };
+        }
+
+        const sftp = await sshService.getSftp(connectionId);
+
+        return new Promise((resolve) => {
+          sftp.readdir(path, (err, list) => {
+            if (err) {
+              resolve({ success: false, error: `Failed to list files: ${err.message}` });
+              return;
+            }
+
+            const entries: FileEntry[] = list.map((item) => {
+              const isDirectory = item.attrs.isDirectory();
+              const isSymlink = item.attrs.isSymbolicLink();
+
+              let type: 'file' | 'directory' | 'symlink' = 'file';
+              if (isDirectory) type = 'directory';
+              else if (isSymlink) type = 'symlink';
+
+              return {
+                path: `${path}/${item.filename}`.replace(/\/+/g, '/'),
+                name: item.filename,
+                type,
+                size: item.attrs.size,
+                modifiedAt: new Date(item.attrs.mtime * 1000),
+                permissions: item.attrs.mode?.toString(8),
+              };
+            });
+
+            resolve({ success: true, files: entries });
+          });
+        });
+      } catch (error: any) {
+        console.error('[sshIpc] List files error:', error);
+        return { success: false, error: error.message };
+      }
+    }
+  );
+
+  // Read file
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.READ_FILE,
+    async (
+      _,
+      connectionId: string,
+      path: string
+    ): Promise<{ success: boolean; content?: string; error?: string }> => {
+      try {
+        // Validate path to prevent access to sensitive files
+        if (!isPathSafe(path)) {
+          return { success: false, error: 'Access denied: path is restricted' };
+        }
+
+        const sftp = await sshService.getSftp(connectionId);
+
+        return new Promise((resolve) => {
+          sftp.readFile(path, 'utf-8', (err, data) => {
+            if (err) {
+              resolve({ success: false, error: `Failed to read file: ${err.message}` });
+              return;
+            }
+            resolve({ success: true, content: data.toString() });
+          });
+        });
+      } catch (error: any) {
+        console.error('[sshIpc] Read file error:', error);
+        return { success: false, error: error.message };
+      }
+    }
+  );
+
+  // Write file
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.WRITE_FILE,
+    async (
+      _,
+      connectionId: string,
+      path: string,
+      content: string
+    ): Promise<{ success: boolean; error?: string }> => {
+      try {
+        // Validate path to prevent writing to sensitive files
+        if (!isPathSafe(path)) {
+          return { success: false, error: 'Access denied: path is restricted' };
+        }
+
+        const sftp = await sshService.getSftp(connectionId);
+
+        return new Promise((resolve) => {
+          sftp.writeFile(path, content, 'utf-8', (err) => {
+            if (err) {
+              resolve({ success: false, error: `Failed to write file: ${err.message}` });
+              return;
+            }
+            resolve({ success: true });
+          });
+        });
+      } catch (error: any) {
+        console.error('[sshIpc] Write file error:', error);
+        return { success: false, error: error.message };
+      }
+    }
+  );
+
+  // Get state
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.GET_STATE,
+    async (
+      _,
+      connectionId: string
+    ): Promise<{ success: boolean; state?: ConnectionState; error?: string }> => {
+      try {
+        const state = monitor.getState(connectionId);
+        return { success: true, state };
+      } catch (err: any) {
+        console.error('[sshIpc] Get state error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Get SSH config hosts from ~/.ssh/config
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.GET_SSH_CONFIG,
+    async (): Promise<{ success: boolean; hosts?: SshConfigHost[]; error?: string }> => {
+      try {
+        const hosts = await parseSshConfigFile();
+        // Filter out wildcard patterns (Host *, Host ?) — not useful in host dropdowns
+        const concreteHosts = hosts.filter((h) => !h.host.includes('*') && !h.host.includes('?'));
+        return { success: true, hosts: concreteHosts };
+      } catch (err: any) {
+        console.error('[sshIpc] Get SSH config error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Get a specific SSH config host by alias
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.GET_SSH_CONFIG_HOST,
+    async (
+      _,
+      hostAlias: string
+    ): Promise<{ success: boolean; host?: SshConfigHost; error?: string }> => {
+      try {
+        if (!hostAlias || typeof hostAlias !== 'string') {
+          return { success: false, error: 'Host alias is required' };
+        }
+
+        const hosts = await parseSshConfigFile();
+        const host = hosts
+          .filter((h) => !h.host.includes('*') && !h.host.includes('?'))
+          .find((h) => h.host.toLowerCase() === hostAlias.toLowerCase());
+
+        if (!host) {
+          return { success: false, error: `Host alias not found: ${hostAlias}` };
+        }
+
+        return { success: true, host };
+      } catch (err: any) {
+        console.error('[sshIpc] Get SSH config host error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Check if a remote path is a git repository
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.CHECK_IS_GIT_REPO,
+    async (
+      _,
+      connectionId: string,
+      remotePath: string
+    ): Promise<{ success: boolean; isGitRepo?: boolean; error?: string }> => {
+      try {
+        if (!remotePath || !remotePath.startsWith('/')) {
+          return { success: false, error: 'An absolute remote path is required' };
+        }
+        if (!isPathSafe(remotePath)) {
+          return { success: false, error: 'Access denied: path is restricted' };
+        }
+
+        const result = await sshService.executeCommand(
+          connectionId,
+          `git -C ${quoteShellArg(remotePath)} rev-parse --is-inside-work-tree 2>/dev/null`
+        );
+        const isGitRepo = result.exitCode === 0 && result.stdout.trim() === 'true';
+        return { success: true, isGitRepo };
+      } catch (err: any) {
+        console.error('[sshIpc] Check git repo error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Initialize a new git repository on the remote machine
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.INIT_REPO,
+    async (
+      _,
+      connectionId: string,
+      parentPath: string,
+      repoName: string
+    ): Promise<{ success: boolean; path?: string; error?: string }> => {
+      try {
+        if (!parentPath || !parentPath.startsWith('/')) {
+          return { success: false, error: 'An absolute parent path is required' };
+        }
+        if (!isPathSafe(parentPath)) {
+          return { success: false, error: 'Access denied: path is restricted' };
+        }
+        // Validate repo name: alphanumeric, hyphens, underscores, dots
+        if (!repoName || !/^[a-zA-Z0-9][a-zA-Z0-9._-]*$/.test(repoName)) {
+          return {
+            success: false,
+            error:
+              'Invalid repository name. Use letters, numbers, hyphens, underscores, and dots. Must start with a letter or number.',
+          };
+        }
+
+        const repoPath = `${parentPath.replace(/\/+$/, '')}/${repoName}`;
+        if (!isPathSafe(repoPath)) {
+          return { success: false, error: 'Access denied: target path is restricted' };
+        }
+
+        // Check if directory already exists
+        const checkResult = await sshService.executeCommand(
+          connectionId,
+          `test -d ${quoteShellArg(repoPath)} && echo exists || echo absent`
+        );
+        if (checkResult.stdout.trim() === 'exists') {
+          return { success: false, error: `Directory already exists: ${repoPath}` };
+        }
+
+        // Create directory and initialize git repo
+        const initResult = await sshService.executeCommand(
+          connectionId,
+          `mkdir -p ${quoteShellArg(repoPath)} && git -C ${quoteShellArg(repoPath)} init`
+        );
+        if (initResult.exitCode !== 0) {
+          return {
+            success: false,
+            error: `Failed to initialize repository: ${initResult.stderr || initResult.stdout}`,
+          };
+        }
+
+        void import('../telemetry').then(({ capture }) => {
+          void capture('ssh_repo_init');
+        });
+
+        return { success: true, path: repoPath };
+      } catch (err: any) {
+        console.error('[sshIpc] Init repo error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+
+  // Clone a repository on the remote machine
+  ipcMain.handle(
+    SSH_IPC_CHANNELS.CLONE_REPO,
+    async (
+      _,
+      connectionId: string,
+      repoUrl: string,
+      targetPath: string
+    ): Promise<{ success: boolean; path?: string; error?: string }> => {
+      try {
+        if (!repoUrl || typeof repoUrl !== 'string') {
+          return { success: false, error: 'Repository URL is required' };
+        }
+        // Validate URL format
+        const urlPatterns = [/^https?:\/\/.+/i, /^git@.+:.+/i, /^ssh:\/\/.+/i];
+        if (!urlPatterns.some((p) => p.test(repoUrl.trim()))) {
+          return {
+            success: false,
+            error: 'Invalid repository URL. Use https://, git@, or ssh:// format.',
+          };
+        }
+
+        if (!targetPath || !targetPath.startsWith('/')) {
+          return { success: false, error: 'An absolute target path is required' };
+        }
+        if (!isPathSafe(targetPath)) {
+          return { success: false, error: 'Access denied: path is restricted' };
+        }
+
+        // Check if target already exists
+        const checkResult = await sshService.executeCommand(
+          connectionId,
+          `test -e ${quoteShellArg(targetPath)} && echo exists || echo absent`
+        );
+        if (checkResult.stdout.trim() === 'exists') {
+          return { success: false, error: `Target path already exists: ${targetPath}` };
+        }
+
+        // Ensure parent directory exists
+        const parentDir = targetPath.replace(/\/[^/]+\/?$/, '') || '/';
+        await sshService.executeCommand(connectionId, `mkdir -p ${quoteShellArg(parentDir)}`);
+
+        // Clone the repository
+        const cloneResult = await sshService.executeCommand(
+          connectionId,
+          `git clone ${quoteShellArg(repoUrl.trim())} ${quoteShellArg(targetPath)}`
+        );
+        if (cloneResult.exitCode !== 0) {
+          return {
+            success: false,
+            error: `Clone failed: ${cloneResult.stderr || cloneResult.stdout}`,
+          };
+        }
+
+        void import('../telemetry').then(({ capture }) => {
+          void capture('ssh_repo_clone');
+        });
+
+        return { success: true, path: targetPath };
+      } catch (err: any) {
+        console.error('[sshIpc] Clone repo error:', err);
+        return { success: false, error: err.message };
+      }
+    }
+  );
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,0 +1,1466 @@
+import { contextBridge, ipcRenderer } from 'electron';
+import type { TerminalSnapshotPayload } from './types/terminalSnapshot';
+import type { OpenInAppId } from '../shared/openInApps';
+import type { AgentEvent } from '../shared/agentEvents';
+import type { McpServer } from '../shared/mcp/types';
+import type { DiffPayload } from '../shared/diff/types';
+import type { GitIndexUpdateArgs } from '../shared/git/types';
+import type { ResourceMetricsSnapshot } from '../shared/performanceTypes';
+
+// Keep preload self-contained: sandboxed preload cannot reliably require local runtime modules.
+const LIFECYCLE_EVENT_CHANNEL = 'lifecycle:event';
+const GIT_STATUS_CHANGED_CHANNEL = 'git:status-changed';
+
+const gitStatusChangedListeners = new Set<(data: { taskPath: string; error?: string }) => void>();
+let gitStatusBridgeAttached = false;
+
+function attachGitStatusBridgeOnce() {
+  if (gitStatusBridgeAttached) return;
+  gitStatusBridgeAttached = true;
+  ipcRenderer.on(
+    GIT_STATUS_CHANGED_CHANNEL,
+    (_: Electron.IpcRendererEvent, data: { taskPath: string; error?: string }) => {
+      for (const listener of gitStatusChangedListeners) {
+        try {
+          listener(data);
+        } catch {}
+      }
+    }
+  );
+}
+
+// Expose protected methods that allow the renderer process to use
+// the ipcRenderer without exposing the entire object
+contextBridge.exposeInMainWorld('electronAPI', {
+  // Generic invoke for the typed RPC client (createRPCClient)
+  invoke: (channel: string, ...args: unknown[]) => ipcRenderer.invoke(channel, ...args),
+
+  // App info
+  getAppVersion: () => ipcRenderer.invoke('app:getAppVersion'),
+  getElectronVersion: () => ipcRenderer.invoke('app:getElectronVersion'),
+  getPlatform: () => ipcRenderer.invoke('app:getPlatform'),
+  listInstalledFonts: (args?: { refresh?: boolean }) =>
+    ipcRenderer.invoke('app:listInstalledFonts', args),
+  undo: () => ipcRenderer.invoke('app:undo'),
+  redo: () => ipcRenderer.invoke('app:redo'),
+  // Updater
+  checkForUpdates: () => ipcRenderer.invoke('update:check'),
+  downloadUpdate: () => ipcRenderer.invoke('update:download'),
+  quitAndInstallUpdate: () => ipcRenderer.invoke('update:quit-and-install'),
+  openLatestDownload: () => ipcRenderer.invoke('update:open-latest'),
+  // Enhanced update methods
+  getUpdateState: () => ipcRenderer.invoke('update:get-state'),
+  getUpdateSettings: () => ipcRenderer.invoke('update:get-settings'),
+  updateUpdateSettings: (settings: any) => ipcRenderer.invoke('update:update-settings', settings),
+  getReleaseNotes: () => ipcRenderer.invoke('update:get-release-notes'),
+  checkForUpdatesNow: () => ipcRenderer.invoke('update:check-now'),
+  onUpdateEvent: (listener: (data: { type: string; payload?: any }) => void) => {
+    const pairs: Array<[string, string]> = [
+      ['update:checking', 'checking'],
+      ['update:available', 'available'],
+      ['update:not-available', 'not-available'],
+      ['update:error', 'error'],
+      ['update:downloading', 'downloading'],
+      ['update:download-progress', 'download-progress'],
+      ['update:downloaded', 'downloaded'],
+      ['update:installing', 'installing'],
+    ];
+    const handlers: Array<() => void> = [];
+    for (const [channel, type] of pairs) {
+      const wrapped = (_: Electron.IpcRendererEvent, payload: any) => listener({ type, payload });
+      ipcRenderer.on(channel, wrapped);
+      handlers.push(() => ipcRenderer.removeListener(channel, wrapped));
+    }
+    return () => handlers.forEach((off) => off());
+  },
+
+  // Window controls (custom title bar on Windows/Linux)
+  windowMinimize: () => ipcRenderer.invoke('app:windowMinimize'),
+  windowMaximize: () => ipcRenderer.invoke('app:windowMaximize'),
+  windowClose: () => ipcRenderer.invoke('app:windowClose'),
+  windowIsMaximized: () => ipcRenderer.invoke('app:windowIsMaximized') as Promise<boolean>,
+  popupMenu: (args: { label: string; x: number; y: number }) =>
+    ipcRenderer.invoke('app:popupMenu', args),
+  onWindowMaximizeChange: (listener: (isMaximized: boolean) => void) => {
+    const onMaximize = () => listener(true);
+    const onUnmaximize = () => listener(false);
+    ipcRenderer.on('window:maximized', onMaximize);
+    ipcRenderer.on('window:unmaximized', onUnmaximize);
+    return () => {
+      ipcRenderer.removeListener('window:maximized', onMaximize);
+      ipcRenderer.removeListener('window:unmaximized', onUnmaximize);
+    };
+  },
+
+  // Open a path in a specific app
+  openIn: (args: {
+    app: OpenInAppId;
+    path: string;
+    isRemote?: boolean;
+    sshConnectionId?: string | null;
+  }) => ipcRenderer.invoke('app:openIn', args),
+
+  // Check which apps are installed
+  checkInstalledApps: () =>
+    ipcRenderer.invoke('app:checkInstalledApps') as Promise<Record<OpenInAppId, boolean>>,
+
+  // PTY management
+  ptyStart: (opts: {
+    id: string;
+    cwd?: string;
+    remote?: { connectionId: string };
+    shell?: string;
+    env?: Record<string, string>;
+    cols?: number;
+    rows?: number;
+    autoApprove?: boolean;
+    initialPrompt?: string;
+  }) => ipcRenderer.invoke('pty:start', opts),
+  ptyInput: (args: { id: string; data: string }) => ipcRenderer.send('pty:input', args),
+  ptyResize: (args: { id: string; cols: number; rows: number }) =>
+    ipcRenderer.send('pty:resize', args),
+  ptyKill: (id: string) => ipcRenderer.send('pty:kill', { id }),
+  ptyKillTmux: (id: string) =>
+    ipcRenderer.invoke('pty:killTmux', { id }) as Promise<{ ok: boolean; error?: string }>,
+
+  // Direct PTY spawn (no shell wrapper, bypasses shell config loading)
+  ptyStartDirect: (opts: {
+    id: string;
+    providerId: string;
+    cwd: string;
+    remote?: { connectionId: string };
+    cols?: number;
+    rows?: number;
+    autoApprove?: boolean;
+    initialPrompt?: string;
+    clickTime?: number;
+    env?: Record<string, string>;
+    resume?: boolean;
+  }) => ipcRenderer.invoke('pty:startDirect', opts),
+
+  ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) =>
+    ipcRenderer.invoke('pty:scp-to-remote', args),
+
+  onPtyData: (id: string, listener: (data: string) => void) => {
+    const channel = `pty:data:${id}`;
+    const wrapped = (_: Electron.IpcRendererEvent, data: string) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  ptyGetSnapshot: (args: { id: string }) => ipcRenderer.invoke('pty:snapshot:get', args),
+  ptySaveSnapshot: (args: { id: string; payload: TerminalSnapshotPayload }) =>
+    ipcRenderer.invoke('pty:snapshot:save', args),
+  ptyClearSnapshot: (args: { id: string }) => ipcRenderer.invoke('pty:snapshot:clear', args),
+  ptyCleanupSessions: (args: {
+    ids: string[];
+    clearSnapshots?: boolean;
+    waitForSnapshots?: boolean;
+  }) => ipcRenderer.invoke('pty:cleanupSessions', args),
+  onPtyExit: (id: string, listener: (info: { exitCode: number; signal?: number }) => void) => {
+    const channel = `pty:exit:${id}`;
+    const wrapped = (_: Electron.IpcRendererEvent, info: { exitCode: number; signal?: number }) =>
+      listener(info);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onPtyStarted: (listener: (data: { id: string }) => void) => {
+    const channel = 'pty:started';
+    const wrapped = (_: Electron.IpcRendererEvent, data: { id: string }) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onPtyActivity: (listener: (data: { id: string; chunk?: string }) => void) => {
+    const channel = 'pty:activity';
+    const wrapped = (_: Electron.IpcRendererEvent, data: { id: string; chunk?: string }) =>
+      listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onPtyExitGlobal: (listener: (data: { id: string }) => void) => {
+    const channel = 'pty:exit:global';
+    const wrapped = (_: Electron.IpcRendererEvent, data: { id: string }) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onAgentEvent: (listener: (event: AgentEvent, meta: { appFocused: boolean }) => void) => {
+    const channel = 'agent:event';
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: AgentEvent,
+      meta: { appFocused: boolean }
+    ) => listener(data, meta);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onNotificationFocusTask: (listener: (taskId: string) => void) => {
+    const channel = 'notification:focus-task';
+    const wrapped = (_: Electron.IpcRendererEvent, taskId: string) => listener(taskId);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  terminalGetTheme: () => ipcRenderer.invoke('terminal:getTheme'),
+
+  // Menu events (main → renderer)
+  onMenuOpenSettings: (listener: () => void) => {
+    const channel = 'menu:open-settings';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onMenuCheckForUpdates: (listener: () => void) => {
+    const channel = 'menu:check-for-updates';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onMenuUndo: (listener: () => void) => {
+    const channel = 'menu:undo';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onMenuRedo: (listener: () => void) => {
+    const channel = 'menu:redo';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onMenuCloseTab: (listener: () => void) => {
+    const channel = 'menu:close-tab';
+    const wrapped = () => listener();
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+
+  // Worktree management
+  worktreeCreate: (args: {
+    projectPath: string;
+    taskName: string;
+    projectId: string;
+    baseRef?: string;
+  }) => ipcRenderer.invoke('worktree:create', args),
+  worktreeList: (args: { projectPath: string; sshConnectionId?: string }) =>
+    ipcRenderer.invoke('worktree:list', args),
+  worktreeRemove: (args: {
+    projectPath: string;
+    worktreeId: string;
+    worktreePath?: string;
+    branch?: string;
+    taskName?: string;
+    sshConnectionId?: string;
+  }) => ipcRenderer.invoke('worktree:remove', args),
+  worktreeStatus: (args: { worktreePath: string }) => ipcRenderer.invoke('worktree:status', args),
+  worktreeMerge: (args: { projectPath: string; worktreeId: string }) =>
+    ipcRenderer.invoke('worktree:merge', args),
+  worktreeGet: (args: { worktreeId: string }) => ipcRenderer.invoke('worktree:get', args),
+  worktreeGetAll: () => ipcRenderer.invoke('worktree:getAll'),
+
+  // Worktree pool (reserve) management for instant task creation
+  worktreeEnsureReserve: (args: { projectId: string; projectPath: string; baseRef?: string }) =>
+    ipcRenderer.invoke('worktree:ensureReserve', args),
+  worktreePreflightReserve: (args: { projectId: string; projectPath: string }) =>
+    ipcRenderer.invoke('worktree:preflightReserve', args),
+  worktreeHasReserve: (args: { projectId: string }) =>
+    ipcRenderer.invoke('worktree:hasReserve', args),
+  worktreeClaimReserve: (args: {
+    projectId: string;
+    projectPath: string;
+    taskName: string;
+    baseRef?: string;
+  }) => ipcRenderer.invoke('worktree:claimReserve', args),
+  worktreeClaimReserveAndSaveTask: (args: {
+    projectId: string;
+    projectPath: string;
+    taskName: string;
+    baseRef?: string;
+    task: {
+      projectId: string;
+      name: string;
+      status: 'active' | 'idle' | 'running';
+      agentId?: string | null;
+      metadata?: any;
+      useWorktree?: boolean;
+    };
+  }) => ipcRenderer.invoke('worktree:claimReserveAndSaveTask', args),
+  worktreeRemoveReserve: (args: { projectId: string; projectPath?: string; isRemote?: boolean }) =>
+    ipcRenderer.invoke('worktree:removeReserve', args),
+
+  // Lifecycle scripts
+  lifecycleGetScript: (args: { projectPath: string; phase: 'setup' | 'run' | 'teardown' }) =>
+    ipcRenderer.invoke('lifecycle:getScript', args),
+  lifecycleSetup: (args: { taskId: string; taskPath: string; projectPath: string }) =>
+    ipcRenderer.invoke('lifecycle:setup', args),
+  lifecycleRunStart: (args: { taskId: string; taskPath: string; projectPath: string }) =>
+    ipcRenderer.invoke('lifecycle:run:start', args),
+  lifecycleRunStop: (args: {
+    taskId: string;
+    taskPath?: string;
+    projectPath?: string;
+    taskName?: string;
+  }) => ipcRenderer.invoke('lifecycle:run:stop', args),
+  lifecycleTeardown: (args: { taskId: string; taskPath: string; projectPath: string }) =>
+    ipcRenderer.invoke('lifecycle:teardown', args),
+  lifecycleGetState: (args: { taskId: string }) => ipcRenderer.invoke('lifecycle:getState', args),
+  lifecycleGetLogs: (args: { taskId: string }) => ipcRenderer.invoke('lifecycle:getLogs', args),
+  lifecycleClearTask: (args: { taskId: string }) => ipcRenderer.invoke('lifecycle:clearTask', args),
+  onLifecycleEvent: (listener: (data: any) => void) => {
+    const wrapped = (_: Electron.IpcRendererEvent, data: any) => listener(data);
+    ipcRenderer.on(LIFECYCLE_EVENT_CHANNEL, wrapped);
+    return () => ipcRenderer.removeListener(LIFECYCLE_EVENT_CHANNEL, wrapped);
+  },
+
+  // Filesystem helpers
+  fsList: (
+    root: string,
+    opts?: {
+      includeDirs?: boolean;
+      maxEntries?: number;
+      timeBudgetMs?: number;
+      connectionId?: string;
+      remotePath?: string;
+      recursive?: boolean;
+    }
+  ) => ipcRenderer.invoke('fs:list', { root, ...(opts || {}) }),
+  fsRead: (
+    root: string,
+    relPath: string,
+    maxBytes?: number,
+    remote?: { connectionId: string; remotePath: string }
+  ) => ipcRenderer.invoke('fs:read', { root, relPath, maxBytes, ...remote }),
+  fsReadImage: (
+    root: string,
+    relPath: string,
+    remote?: { connectionId: string; remotePath: string }
+  ) => ipcRenderer.invoke('fs:read-image', { root, relPath, ...remote }),
+  fsSearchContent: (
+    root: string,
+    query: string,
+    options?: {
+      caseSensitive?: boolean;
+      maxResults?: number;
+      fileExtensions?: string[];
+    },
+    remote?: { connectionId: string; remotePath: string }
+  ) => ipcRenderer.invoke('fs:searchContent', { root, query, options, ...remote }),
+  fsWriteFile: (
+    root: string,
+    relPath: string,
+    content: string,
+    mkdirs?: boolean,
+    remote?: { connectionId: string; remotePath: string }
+  ) => ipcRenderer.invoke('fs:write', { root, relPath, content, mkdirs, ...remote }),
+  fsRemove: (
+    root: string,
+    relPath: string,
+    remote?: { connectionId: string; remotePath: string }
+  ) => ipcRenderer.invoke('fs:remove', { root, relPath, ...remote }),
+  fsRename: (
+    root: string,
+    oldName: string,
+    newName: string,
+    remote?: { connectionId: string; remotePath: string }
+  ) => ipcRenderer.invoke('fs:rename', { root, oldName, newName, ...remote }),
+  fsMkdir: (root: string, relPath: string, remote?: { connectionId: string; remotePath: string }) =>
+    ipcRenderer.invoke('fs:mkdir', { root, relPath, ...remote }),
+  fsRmdir: (root: string, relPath: string, remote?: { connectionId: string; remotePath: string }) =>
+    ipcRenderer.invoke('fs:rmdir', { root, relPath, ...remote }),
+  getProjectConfig: (projectPath: string) =>
+    ipcRenderer.invoke('fs:getProjectConfig', { projectPath }),
+  saveProjectConfig: (projectPath: string, content: string) =>
+    ipcRenderer.invoke('fs:saveProjectConfig', { projectPath, content }),
+  ensureGitignore: (projectPath: string, patterns: string[]) =>
+    ipcRenderer.invoke('fs:ensureGitignore', { projectPath, patterns }),
+  // Attachments
+  saveAttachment: (args: { taskPath: string; srcPath: string; subdir?: string }) =>
+    ipcRenderer.invoke('fs:save-attachment', args),
+
+  // Project management
+  openProject: () => ipcRenderer.invoke('project:open'),
+  openFile: (args?: { title?: string; message?: string; filters?: Electron.FileFilter[] }) =>
+    ipcRenderer.invoke('project:openFile', args),
+  getProjectSettings: (projectId: string) =>
+    ipcRenderer.invoke('projectSettings:get', { projectId }),
+  updateProjectSettings: (args: { projectId: string; baseRef: string }) =>
+    ipcRenderer.invoke('projectSettings:update', args),
+  fetchProjectBaseRef: (args: { projectId: string; projectPath: string }) =>
+    ipcRenderer.invoke('projectSettings:fetchBaseRef', args),
+  getGitInfo: (projectPath: string) => ipcRenderer.invoke('git:getInfo', projectPath),
+  getGitStatus: (arg: string | { taskPath: string; taskId?: string }) =>
+    ipcRenderer.invoke('git:get-status', arg),
+  getDeleteRisks: (args: {
+    targets: Array<{ id: string; taskPath: string; sshConnectionId?: string }>;
+    includePr?: boolean;
+  }) => ipcRenderer.invoke('git:get-delete-risks', args),
+  watchGitStatus: (arg: string | { taskPath: string; taskId?: string }) =>
+    ipcRenderer.invoke('git:watch-status', arg),
+  unwatchGitStatus: (arg: string | { taskPath: string; taskId?: string }, watchId?: string) =>
+    ipcRenderer.invoke('git:unwatch-status', arg, watchId),
+  onGitStatusChanged: (listener: (data: { taskPath: string; error?: string }) => void) => {
+    attachGitStatusBridgeOnce();
+    gitStatusChangedListeners.add(listener);
+    return () => {
+      gitStatusChangedListeners.delete(listener);
+    };
+  },
+  getFileDiff: (args: {
+    taskPath: string;
+    taskId?: string;
+    filePath: string;
+    baseRef?: string;
+    forceLarge?: boolean;
+  }) => ipcRenderer.invoke('git:get-file-diff', args),
+  updateIndex: (args: { taskPath: string; taskId?: string } & GitIndexUpdateArgs) =>
+    ipcRenderer.invoke('git:update-index', args),
+  revertFile: (args: { taskPath: string; taskId?: string; filePath: string }) =>
+    ipcRenderer.invoke('git:revert-file', args),
+  gitCommit: (args: { taskPath: string; message: string }) =>
+    ipcRenderer.invoke('git:commit', args),
+  gitPush: (args: { taskPath: string }) => ipcRenderer.invoke('git:push', args),
+  gitPull: (args: { taskPath: string }) => ipcRenderer.invoke('git:pull', args),
+  gitGetLog: (args: { taskPath: string; maxCount?: number; skip?: number }) =>
+    ipcRenderer.invoke('git:get-log', args),
+  gitGetLatestCommit: (args: { taskPath: string }) =>
+    ipcRenderer.invoke('git:get-latest-commit', args),
+  gitGetCommitFiles: (args: { taskPath: string; commitHash: string }) =>
+    ipcRenderer.invoke('git:get-commit-files', args),
+  gitGetCommitFileDiff: (args: {
+    taskPath: string;
+    commitHash: string;
+    filePath: string;
+    forceLarge?: boolean;
+  }) => ipcRenderer.invoke('git:get-commit-file-diff', args),
+  gitSoftReset: (args: { taskPath: string }) => ipcRenderer.invoke('git:soft-reset', args),
+  gitCommitAndPush: (args: {
+    taskPath: string;
+    taskId?: string;
+    commitMessage?: string;
+    createBranchIfOnDefault?: boolean;
+    branchPrefix?: string;
+  }) => ipcRenderer.invoke('git:commit-and-push', args),
+  generatePrContent: (args: { taskPath: string; base?: string; sshConnectionId?: string }) =>
+    ipcRenderer.invoke('git:generate-pr-content', args),
+  createPullRequest: (args: {
+    taskPath: string;
+    title?: string;
+    body?: string;
+    base?: string;
+    head?: string;
+    draft?: boolean;
+    web?: boolean;
+    fill?: boolean;
+    skipPrePush?: boolean;
+    sshConnectionId?: string;
+  }) => ipcRenderer.invoke('git:create-pr', args),
+  mergeToMain: (args: { taskPath: string; taskId?: string }) =>
+    ipcRenderer.invoke('git:merge-to-main', args),
+  mergePr: (args: {
+    taskPath: string;
+    prNumber?: number;
+    strategy?: 'merge' | 'squash' | 'rebase';
+    admin?: boolean;
+    sshConnectionId?: string;
+  }) => ipcRenderer.invoke('git:merge-pr', args),
+  getPrStatus: (args: { taskPath: string; sshConnectionId?: string }) =>
+    ipcRenderer.invoke('git:get-pr-status', args),
+  enableAutoMerge: (args: {
+    taskPath: string;
+    prNumber?: number;
+    strategy?: 'merge' | 'squash' | 'rebase';
+    sshConnectionId?: string;
+  }) => ipcRenderer.invoke('git:enable-auto-merge', args),
+  disableAutoMerge: (args: { taskPath: string; prNumber?: number; sshConnectionId?: string }) =>
+    ipcRenderer.invoke('git:disable-auto-merge', args),
+  getCheckRuns: (args: { taskPath: string; sshConnectionId?: string }) =>
+    ipcRenderer.invoke('git:get-check-runs', args),
+  getPrComments: (args: { taskPath: string; prNumber?: number; sshConnectionId?: string }) =>
+    ipcRenderer.invoke('git:get-pr-comments', args),
+  getBranchStatus: (args: { taskPath: string; taskId?: string }) =>
+    ipcRenderer.invoke('git:get-branch-status', args),
+  renameBranch: (args: {
+    repoPath: string;
+    oldBranch: string;
+    newBranch: string;
+    sshConnectionId?: string;
+  }) => ipcRenderer.invoke('git:rename-branch', args),
+  listRemoteBranches: (args: { projectPath: string; remote?: string; sshConnectionId?: string }) =>
+    ipcRenderer.invoke('git:list-remote-branches', args),
+  openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
+  clipboardWriteText: (text: string) => ipcRenderer.invoke('app:clipboard-write-text', text),
+  paste: () => ipcRenderer.invoke('app:paste'),
+  // Telemetry (minimal, anonymous)
+  captureTelemetry: (event: string, properties?: Record<string, any>) =>
+    ipcRenderer.invoke('telemetry:capture', { event, properties }),
+  getTelemetryStatus: () => ipcRenderer.invoke('telemetry:get-status'),
+  setTelemetryEnabled: (enabled: boolean) => ipcRenderer.invoke('telemetry:set-enabled', enabled),
+  setOnboardingSeen: (flag: boolean) => ipcRenderer.invoke('telemetry:set-onboarding-seen', flag),
+  connectToGitHub: (projectPath: string) => ipcRenderer.invoke('github:connect', projectPath),
+
+  // Emdash Account
+  accountGetSession: () => ipcRenderer.invoke('account:getSession'),
+  accountSignIn: () => ipcRenderer.invoke('account:signIn'),
+  accountSignOut: () => ipcRenderer.invoke('account:signOut'),
+  accountCheckServerHealth: () => ipcRenderer.invoke('account:checkServerHealth'),
+  accountValidateSession: () => ipcRenderer.invoke('account:validateSession'),
+
+  // GitHub integration
+  githubAuth: () => ipcRenderer.invoke('github:auth'),
+  githubAuthOAuth: () => ipcRenderer.invoke('github:auth:oauth'),
+  githubCancelAuth: () => ipcRenderer.invoke('github:auth:cancel'),
+
+  // GitHub auth event listeners
+  onGithubAuthDeviceCode: (
+    callback: (data: {
+      userCode: string;
+      verificationUri: string;
+      expiresIn: number;
+      interval: number;
+    }) => void
+  ) => {
+    const listener = (_: any, data: any) => callback(data);
+    ipcRenderer.on('github:auth:device-code', listener);
+    return () => ipcRenderer.removeListener('github:auth:device-code', listener);
+  },
+  onGithubAuthPolling: (callback: (data: { status: string }) => void) => {
+    const listener = (_: any, data: any) => callback(data);
+    ipcRenderer.on('github:auth:polling', listener);
+    return () => ipcRenderer.removeListener('github:auth:polling', listener);
+  },
+  onGithubAuthSlowDown: (callback: (data: { newInterval: number }) => void) => {
+    const listener = (_: any, data: any) => callback(data);
+    ipcRenderer.on('github:auth:slow-down', listener);
+    return () => ipcRenderer.removeListener('github:auth:slow-down', listener);
+  },
+  onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => {
+    const listener = (_: any, data: any) => callback(data);
+    ipcRenderer.on('github:auth:success', listener);
+    return () => ipcRenderer.removeListener('github:auth:success', listener);
+  },
+  onGithubAuthError: (callback: (data: { error: string; message: string }) => void) => {
+    const listener = (_: any, data: any) => callback(data);
+    ipcRenderer.on('github:auth:error', listener);
+    return () => ipcRenderer.removeListener('github:auth:error', listener);
+  },
+  onGithubAuthCancelled: (callback: () => void) => {
+    const listener = () => callback();
+    ipcRenderer.on('github:auth:cancelled', listener);
+    return () => ipcRenderer.removeListener('github:auth:cancelled', listener);
+  },
+  onGithubAuthUserUpdated: (callback: (data: { user: any }) => void) => {
+    const listener = (_: any, data: any) => callback(data);
+    ipcRenderer.on('github:auth:user-updated', listener);
+    return () => ipcRenderer.removeListener('github:auth:user-updated', listener);
+  },
+
+  githubIsAuthenticated: () => ipcRenderer.invoke('github:isAuthenticated'),
+  githubGetStatus: () => ipcRenderer.invoke('github:getStatus'),
+  githubGetUser: () => ipcRenderer.invoke('github:getUser'),
+  githubGetRepositories: () => ipcRenderer.invoke('github:getRepositories'),
+  githubCloneRepository: (repoUrl: string, localPath: string) =>
+    ipcRenderer.invoke('github:cloneRepository', repoUrl, localPath),
+  githubGetOwners: () => ipcRenderer.invoke('github:getOwners'),
+  githubValidateRepoName: (name: string, owner: string) =>
+    ipcRenderer.invoke('github:validateRepoName', name, owner),
+  githubCreateNewProject: (params: {
+    name: string;
+    description?: string;
+    owner: string;
+    isPrivate: boolean;
+    gitignoreTemplate?: string;
+  }) => ipcRenderer.invoke('github:createNewProject', params),
+  githubListPullRequests: (args: { projectPath: string; limit?: number; searchQuery?: string }) =>
+    ipcRenderer.invoke('github:listPullRequests', args),
+  githubCreatePullRequestWorktree: (args: {
+    projectPath: string;
+    projectId: string;
+    prNumber: number;
+    prTitle?: string;
+    taskName?: string;
+    branchName?: string;
+  }) => ipcRenderer.invoke('github:createPullRequestWorktree', args),
+  githubGetPullRequestBaseDiff: (args: { worktreePath: string; prNumber: number }) =>
+    ipcRenderer.invoke('github:getPullRequestBaseDiff', args),
+  githubLogout: () => ipcRenderer.invoke('github:logout'),
+  githubCheckCLIInstalled: () => ipcRenderer.invoke('github:checkCLIInstalled'),
+  githubInstallCLI: () => ipcRenderer.invoke('github:installCLI'),
+  // GitHub issues
+  githubIssuesList: (projectPath: string, limit?: number) =>
+    ipcRenderer.invoke('github:issues:list', projectPath, limit),
+  githubIssuesSearch: (projectPath: string, searchTerm: string, limit?: number) =>
+    ipcRenderer.invoke('github:issues:search', projectPath, searchTerm, limit),
+  githubIssueGet: (projectPath: string, number: number) =>
+    ipcRenderer.invoke('github:issues:get', projectPath, number),
+  // Linear integration
+  linearSaveToken: (token: string) => ipcRenderer.invoke('linear:saveToken', token),
+  linearCheckConnection: () => ipcRenderer.invoke('linear:checkConnection'),
+  linearClearToken: () => ipcRenderer.invoke('linear:clearToken'),
+  linearInitialFetch: (limit?: number) => ipcRenderer.invoke('linear:initialFetch', limit),
+  linearSearchIssues: (searchTerm: string, limit?: number) =>
+    ipcRenderer.invoke('linear:searchIssues', searchTerm, limit),
+  // Jira integration
+  jiraSaveCredentials: (args: { siteUrl: string; email: string; token: string }) =>
+    ipcRenderer.invoke('jira:saveCredentials', args),
+  jiraClearCredentials: () => ipcRenderer.invoke('jira:clearCredentials'),
+  jiraCheckConnection: () => ipcRenderer.invoke('jira:checkConnection'),
+  jiraInitialFetch: (limit?: number) => ipcRenderer.invoke('jira:initialFetch', limit),
+  jiraSearchIssues: (searchTerm: string, limit?: number) =>
+    ipcRenderer.invoke('jira:searchIssues', searchTerm, limit),
+  // GitLab integration
+  gitlabSaveCredentials: (args: { instanceUrl: string; token: string }) =>
+    ipcRenderer.invoke('gitlab:saveCredentials', args),
+  gitlabClearCredentials: () => ipcRenderer.invoke('gitlab:clearCredentials'),
+  gitlabCheckConnection: () => ipcRenderer.invoke('gitlab:checkConnection'),
+  gitlabInitialFetch: (projectPath: string, limit?: number) =>
+    ipcRenderer.invoke('gitlab:initialFetch', { projectPath, limit }),
+  gitlabSearchIssues: (projectPath: string, searchTerm: string, limit?: number) =>
+    ipcRenderer.invoke('gitlab:searchIssues', { projectPath, searchTerm, limit }),
+  // Plain integration
+  plainSaveToken: (token: string) => ipcRenderer.invoke('plain:saveToken', token),
+  plainCheckConnection: () => ipcRenderer.invoke('plain:checkConnection'),
+  plainClearToken: () => ipcRenderer.invoke('plain:clearToken'),
+  plainInitialFetch: (limit?: number, statuses?: string[]) =>
+    ipcRenderer.invoke('plain:initialFetch', limit, statuses),
+  plainSearchThreads: (searchTerm: string, limit?: number) =>
+    ipcRenderer.invoke('plain:searchThreads', searchTerm, limit),
+
+  // Sentry integration
+  sentrySaveToken: (token: string, organizationSlug?: string) =>
+    ipcRenderer.invoke('sentry:saveToken', token, organizationSlug),
+  sentryCheckConnection: () => ipcRenderer.invoke('sentry:checkConnection'),
+  sentryClearToken: () => ipcRenderer.invoke('sentry:clearToken'),
+  sentryInitialFetch: (limit?: number) => ipcRenderer.invoke('sentry:initialFetch', limit),
+  sentrySearchIssues: (searchTerm: string, limit?: number) =>
+    ipcRenderer.invoke('sentry:searchIssues', searchTerm, limit),
+
+  // Forgejo integration
+  forgejoSaveCredentials: (args: { instanceUrl: string; token: string }) =>
+    ipcRenderer.invoke('forgejo:saveCredentials', args),
+  forgejoClearCredentials: () => ipcRenderer.invoke('forgejo:clearCredentials'),
+  forgejoCheckConnection: () => ipcRenderer.invoke('forgejo:checkConnection'),
+  forgejoInitialFetch: (projectPath: string, limit?: number) =>
+    ipcRenderer.invoke('forgejo:initialFetch', { projectPath, limit }),
+  forgejoSearchIssues: (projectPath: string, searchTerm: string, limit?: number) =>
+    ipcRenderer.invoke('forgejo:searchIssues', { projectPath, searchTerm, limit }),
+  getProviderStatuses: (opts?: { refresh?: boolean; providers?: string[]; providerId?: string }) =>
+    ipcRenderer.invoke('providers:getStatuses', opts ?? {}),
+  getProviderCustomConfig: (providerId: string) =>
+    ipcRenderer.invoke('providers:getCustomConfig', providerId),
+  getAllProviderCustomConfigs: () => ipcRenderer.invoke('providers:getAllCustomConfigs'),
+  updateProviderCustomConfig: (providerId: string, config: any) =>
+    ipcRenderer.invoke('providers:updateCustomConfig', providerId, config),
+
+  // Debug helpers
+  debugAppendLog: (filePath: string, content: string, options?: { reset?: boolean }) =>
+    ipcRenderer.invoke('debug:append-log', filePath, content, options ?? {}),
+
+  // PlanMode strict lock
+  planApplyLock: (taskPath: string) => ipcRenderer.invoke('plan:lock', taskPath),
+  planReleaseLock: (taskPath: string) => ipcRenderer.invoke('plan:unlock', taskPath),
+  onPlanEvent: (
+    listener: (data: {
+      type: 'write_blocked' | 'remove_blocked';
+      root: string;
+      relPath: string;
+      code?: string;
+      message?: string;
+    }) => void
+  ) => {
+    const channel = 'plan:event';
+    const wrapped = (_: Electron.IpcRendererEvent, data: any) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+
+  onProviderStatusUpdated: (listener: (data: { providerId: string; status: any }) => void) => {
+    const channel = 'provider:status-updated';
+    const wrapped = (_: Electron.IpcRendererEvent, data: any) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+
+  // Host preview (non-container)
+  hostPreviewStart: (args: {
+    taskId: string;
+    taskPath: string;
+    script?: string;
+    parentProjectPath?: string;
+  }) => ipcRenderer.invoke('preview:host:start', args),
+  hostPreviewSetup: (args: { taskId: string; taskPath: string }) =>
+    ipcRenderer.invoke('preview:host:setup', args),
+  hostPreviewStop: (taskId: string) => ipcRenderer.invoke('preview:host:stop', taskId),
+  hostPreviewStopAll: (exceptId?: string) => ipcRenderer.invoke('preview:host:stopAll', exceptId),
+  onHostPreviewEvent: (listener: (data: any) => void) => {
+    const channel = 'preview:host:event';
+    const wrapped = (_: Electron.IpcRendererEvent, data: any) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+
+  // Main-managed browser (WebContentsView)
+  browserShow: (bounds: { x: number; y: number; width: number; height: number }, url?: string) =>
+    ipcRenderer.invoke('browser:view:show', { ...bounds, url }),
+  browserHide: () => ipcRenderer.invoke('browser:view:hide'),
+  browserSetBounds: (bounds: { x: number; y: number; width: number; height: number }) =>
+    ipcRenderer.invoke('browser:view:setBounds', bounds),
+  browserLoadURL: (url: string, forceReload?: boolean) =>
+    ipcRenderer.invoke('browser:view:loadURL', url, forceReload),
+  browserGoBack: () => ipcRenderer.invoke('browser:view:goBack'),
+  browserGoForward: () => ipcRenderer.invoke('browser:view:goForward'),
+  browserReload: () => ipcRenderer.invoke('browser:view:reload'),
+  browserOpenDevTools: () => ipcRenderer.invoke('browser:view:openDevTools'),
+  browserClear: () => ipcRenderer.invoke('browser:view:clear'),
+  onBrowserViewEvent: (listener: (data: any) => void) => {
+    const channel = 'browser:view:event';
+    const wrapped = (_: Electron.IpcRendererEvent, data: any) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+
+  // Lightweight TCP probe for localhost ports to avoid noisy fetches
+  netProbePorts: (host: string, ports: number[], timeoutMs?: number) =>
+    ipcRenderer.invoke('net:probePorts', host, ports, timeoutMs),
+
+  // SSH operations (unwrap { success, ... } IPC responses)
+  sshTestConnection: (config: any) => ipcRenderer.invoke('ssh:testConnection', config),
+  sshSaveConnection: async (config: any) => {
+    const res = await ipcRenderer.invoke('ssh:saveConnection', config);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'Failed to save SSH connection');
+    }
+    return (res as any).connection;
+  },
+  sshGetConnections: async () => {
+    const res = await ipcRenderer.invoke('ssh:getConnections');
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'Failed to load SSH connections');
+    }
+    return (res as any).connections || [];
+  },
+  sshDeleteConnection: async (id: string) => {
+    const res = await ipcRenderer.invoke('ssh:deleteConnection', id);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'Failed to delete SSH connection');
+    }
+  },
+  sshConnect: async (arg: any) => {
+    const res = await ipcRenderer.invoke('ssh:connect', arg);
+    if (res && typeof res === 'object' && 'success' in res) {
+      if (!res.success) {
+        throw new Error((res as any).error || 'SSH connect failed');
+      }
+      return (res as any).connectionId as string;
+    }
+    return res as string;
+  },
+  sshDisconnect: async (connectionId: string) => {
+    const res = await ipcRenderer.invoke('ssh:disconnect', connectionId);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH disconnect failed');
+    }
+  },
+  sshExecuteCommand: async (connectionId: string, command: string, cwd?: string) => {
+    const res = await ipcRenderer.invoke('ssh:executeCommand', connectionId, command, cwd);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH command failed');
+    }
+    return {
+      stdout: (res as any).stdout || '',
+      stderr: (res as any).stderr || '',
+      exitCode: (res as any).exitCode ?? -1,
+    };
+  },
+  sshListFiles: async (connectionId: string, path: string) => {
+    const res = await ipcRenderer.invoke('ssh:listFiles', connectionId, path);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH list files failed');
+    }
+    return (res as any).files || [];
+  },
+  sshReadFile: async (connectionId: string, path: string) => {
+    const res = await ipcRenderer.invoke('ssh:readFile', connectionId, path);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH read file failed');
+    }
+    return (res as any).content || '';
+  },
+  sshWriteFile: async (connectionId: string, path: string, content: string) => {
+    const res = await ipcRenderer.invoke('ssh:writeFile', connectionId, path, content);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH write file failed');
+    }
+  },
+  sshGetState: async (connectionId: string) => {
+    const res = await ipcRenderer.invoke('ssh:getState', connectionId);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH get state failed');
+    }
+    return (res as any).state;
+  },
+  sshGetConfig: () => ipcRenderer.invoke('ssh:getSshConfig'),
+  sshGetSshConfigHost: (hostAlias: string) => ipcRenderer.invoke('ssh:getSshConfigHost', hostAlias),
+  sshCheckIsGitRepo: async (connectionId: string, remotePath: string) => {
+    const res = await ipcRenderer.invoke('ssh:checkIsGitRepo', connectionId, remotePath);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH check git repo failed');
+    }
+    return (res as any).isGitRepo as boolean;
+  },
+  sshInitRepo: async (connectionId: string, parentPath: string, repoName: string) => {
+    const res = await ipcRenderer.invoke('ssh:initRepo', connectionId, parentPath, repoName);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH init repo failed');
+    }
+    return (res as any).path as string;
+  },
+  sshCloneRepo: async (connectionId: string, repoUrl: string, targetPath: string) => {
+    const res = await ipcRenderer.invoke('ssh:cloneRepo', connectionId, repoUrl, targetPath);
+    if (res && typeof res === 'object' && 'success' in res && !res.success) {
+      throw new Error((res as any).error || 'SSH clone repo failed');
+    }
+    return (res as any).path as string;
+  },
+
+  // Skills management
+  skillsGetCatalog: () => ipcRenderer.invoke('skills:getCatalog'),
+  skillsRefreshCatalog: () => ipcRenderer.invoke('skills:refreshCatalog'),
+  skillsInstall: (args: { skillId: string; source?: { owner: string; repo: string } }) =>
+    ipcRenderer.invoke('skills:install', args),
+  skillsUninstall: (args: { skillId: string }) => ipcRenderer.invoke('skills:uninstall', args),
+  skillsGetDetail: (args: { skillId: string; source?: { owner: string; repo: string } }) =>
+    ipcRenderer.invoke('skills:getDetail', args),
+  skillsGetDetectedAgents: () => ipcRenderer.invoke('skills:getDetectedAgents'),
+  skillsSearch: (args: { query: string }) => ipcRenderer.invoke('skills:search', args),
+  skillsCreate: (args: { name: string; description: string }) =>
+    ipcRenderer.invoke('skills:create', args),
+
+  // Workspace provisioning
+  workspaceProvision: (args: {
+    taskId: string;
+    repoUrl: string;
+    branch: string;
+    baseRef: string;
+    provisionCommand: string;
+    projectPath: string;
+  }) => ipcRenderer.invoke('workspace:provision', args),
+  workspaceCancel: (args: { instanceId: string }) => ipcRenderer.invoke('workspace:cancel', args),
+  workspaceTerminate: (args: {
+    instanceId: string;
+    terminateCommand: string;
+    projectPath: string;
+    env?: Record<string, string>;
+  }) => ipcRenderer.invoke('workspace:terminate', args),
+  workspaceStatus: (args: { taskId: string }) => ipcRenderer.invoke('workspace:status', args),
+  onWorkspaceProvisionProgress: (
+    listener: (data: { instanceId: string; line: string }) => void
+  ) => {
+    const channel = 'workspace:provision-progress';
+    const wrapped = (_: Electron.IpcRendererEvent, data: { instanceId: string; line: string }) =>
+      listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onWorkspaceProvisionTimeoutWarning: (
+    listener: (data: { instanceId: string; timeoutMs: number }) => void
+  ) => {
+    const channel = 'workspace:provision-timeout-warning';
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: { instanceId: string; timeoutMs: number }
+    ) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+  onWorkspaceProvisionComplete: (
+    listener: (data: { instanceId: string; status: string; error?: string }) => void
+  ) => {
+    const channel = 'workspace:provision-complete';
+    const wrapped = (
+      _: Electron.IpcRendererEvent,
+      data: { instanceId: string; status: string; error?: string }
+    ) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+
+  // MCP
+  mcpLoadAll: () => ipcRenderer.invoke('mcp:load-all'),
+  mcpSaveServer: (server: McpServer) => ipcRenderer.invoke('mcp:save-server', server),
+  mcpRemoveServer: (serverName: string) => ipcRenderer.invoke('mcp:remove-server', serverName),
+  mcpGetProviders: () => ipcRenderer.invoke('mcp:get-providers'),
+  mcpRefreshProviders: () => ipcRenderer.invoke('mcp:refresh-providers'),
+
+  // Automations
+  automationsList: () => ipcRenderer.invoke('automations:list'),
+  automationsGet: (args: { id: string }) => ipcRenderer.invoke('automations:get', args),
+  automationsCreate: (args: {
+    name: string;
+    projectId: string;
+    projectName?: string;
+    prompt: string;
+    agentId: string;
+    mode?: string;
+    schedule: {
+      type: string;
+      hour?: number;
+      minute?: number;
+      dayOfWeek?: string;
+      dayOfMonth?: number;
+    };
+    triggerType?: string;
+    triggerConfig?: Record<string, unknown>;
+    useWorktree?: boolean;
+  }) => ipcRenderer.invoke('automations:create', args),
+  automationsUpdate: (args: {
+    id: string;
+    name?: string;
+    projectId?: string;
+    projectName?: string;
+    prompt?: string;
+    agentId?: string;
+    mode?: string;
+    schedule?: {
+      type: string;
+      hour?: number;
+      minute?: number;
+      dayOfWeek?: string;
+      dayOfMonth?: number;
+    };
+    triggerType?: string | null;
+    triggerConfig?: Record<string, unknown> | null;
+    status?: string;
+    useWorktree?: boolean;
+  }) => ipcRenderer.invoke('automations:update', args),
+  automationsDelete: (args: { id: string }) => ipcRenderer.invoke('automations:delete', args),
+  automationsToggle: (args: { id: string }) => ipcRenderer.invoke('automations:toggle', args),
+  automationsRunLogs: (args: { automationId: string; limit?: number }) =>
+    ipcRenderer.invoke('automations:runLogs', args),
+  automationsTriggerNow: (args: { id: string }) =>
+    ipcRenderer.invoke('automations:triggerNow', args),
+  automationsCompleteRun: (args: {
+    runLogId: string;
+    automationId: string;
+    taskId?: string;
+    status: 'success' | 'failure';
+    error?: string;
+  }) => ipcRenderer.invoke('automations:completeRun', args),
+  automationsDrainTriggers: () => ipcRenderer.invoke('automations:drainTriggers'),
+  onAutomationTriggerAvailable: (listener: () => void) => {
+    const wrapped = (_: Electron.IpcRendererEvent) => listener();
+    ipcRenderer.on('automation:trigger-available', wrapped);
+    return () => {
+      ipcRenderer.removeListener('automation:trigger-available', wrapped);
+    };
+  },
+
+  // Integrations
+  integrationsStatusMap: () => ipcRenderer.invoke('integrations:statusMap'),
+
+  // Performance Monitor
+  perfSubscribe: () => ipcRenderer.invoke('perf:subscribe'),
+  perfUnsubscribe: () => ipcRenderer.invoke('perf:unsubscribe'),
+  perfGetSnapshot: (mode?: 'interactive' | 'idle') => ipcRenderer.invoke('perf:getSnapshot', mode),
+  onPerfSnapshot: (listener: (snapshot: ResourceMetricsSnapshot) => void) => {
+    const channel = 'perf:snapshot';
+    const wrapped = (_: Electron.IpcRendererEvent, data: ResourceMetricsSnapshot) => listener(data);
+    ipcRenderer.on(channel, wrapped);
+    return () => ipcRenderer.removeListener(channel, wrapped);
+  },
+});
+
+// Type definitions for the exposed API
+export interface ElectronAPI {
+  // App info
+  getVersion: () => Promise<string>;
+  getPlatform: () => Promise<string>;
+  clipboardWriteText: (text: string) => Promise<{ success: boolean; error?: string }>;
+  paste: () => Promise<{ success: boolean; error?: string }>;
+  listInstalledFonts: (args?: {
+    refresh?: boolean;
+  }) => Promise<{ success: boolean; fonts?: string[]; cached?: boolean; error?: string }>;
+  // Updater
+  checkForUpdates: () => Promise<{ success: boolean; result?: any; error?: string }>;
+  downloadUpdate: () => Promise<{ success: boolean; error?: string }>;
+  quitAndInstallUpdate: () => Promise<{ success: boolean; error?: string }>;
+  openLatestDownload: () => Promise<{ success: boolean; error?: string }>;
+  onUpdateEvent: (listener: (data: { type: string; payload?: any }) => void) => () => void;
+
+  // Telemetry (minimal, anonymous)
+  captureTelemetry: (
+    event: string,
+    properties?: Record<string, any>
+  ) => Promise<{ success: boolean; error?: string; disabled?: boolean }>;
+  getTelemetryStatus: () => Promise<{
+    success: boolean;
+    status?: {
+      enabled: boolean;
+      envDisabled: boolean;
+      userOptOut: boolean;
+      hasKeyAndHost: boolean;
+    };
+    error?: string;
+  }>;
+  setTelemetryEnabled: (
+    enabled: boolean
+  ) => Promise<{ success: boolean; status?: any; error?: string }>;
+
+  // PTY management
+  ptyStart: (opts: {
+    id: string;
+    cwd?: string;
+    shell?: string;
+    env?: Record<string, string>;
+    cols?: number;
+    rows?: number;
+    autoApprove?: boolean;
+    initialPrompt?: string;
+  }) => Promise<{ ok: boolean; error?: string }>;
+  ptyInput: (args: { id: string; data: string }) => void;
+  ptyResize: (args: { id: string; cols: number; rows: number }) => void;
+  ptyKill: (id: string) => void;
+  onPtyData: (id: string, listener: (data: string) => void) => () => void;
+  ptyGetSnapshot: (args: { id: string }) => Promise<{
+    ok: boolean;
+    snapshot?: any;
+    error?: string;
+  }>;
+  ptySaveSnapshot: (args: {
+    id: string;
+    payload: TerminalSnapshotPayload;
+  }) => Promise<{ ok: boolean; error?: string }>;
+  ptyClearSnapshot: (args: { id: string }) => Promise<{ ok: boolean }>;
+  ptyCleanupSessions: (args: {
+    ids: string[];
+    clearSnapshots?: boolean;
+    waitForSnapshots?: boolean;
+  }) => Promise<{
+    ok: boolean;
+    cleaned: number;
+    failedIds: string[];
+    snapshotClearQueued: boolean;
+  }>;
+  onPtyExit: (
+    id: string,
+    listener: (info: { exitCode: number; signal?: number }) => void
+  ) => () => void;
+  // Worktree management
+  worktreeCreate: (args: {
+    projectPath: string;
+    taskName: string;
+    projectId: string;
+    baseRef?: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeList: (args: {
+    projectPath: string;
+  }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+  worktreeRemove: (args: {
+    projectPath: string;
+    worktreeId: string;
+    worktreePath?: string;
+    branch?: string;
+    taskName?: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeStatus: (args: {
+    worktreePath: string;
+  }) => Promise<{ success: boolean; status?: any; error?: string }>;
+  worktreeMerge: (args: {
+    projectPath: string;
+    worktreeId: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeGet: (args: {
+    worktreeId: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeGetAll: () => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+  // Worktree pool (reserve) management for instant task creation
+  worktreeEnsureReserve: (args: {
+    projectId: string;
+    projectPath: string;
+    baseRef?: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreePreflightReserve: (args: {
+    projectId: string;
+    projectPath: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeHasReserve: (args: {
+    projectId: string;
+  }) => Promise<{ success: boolean; hasReserve?: boolean; error?: string }>;
+  worktreeClaimReserve: (args: {
+    projectId: string;
+    projectPath: string;
+    taskName: string;
+    baseRef?: string;
+  }) => Promise<{
+    success: boolean;
+    worktree?: any;
+    needsBaseRefSwitch?: boolean;
+    error?: string;
+  }>;
+  worktreeClaimReserveAndSaveTask: (args: {
+    projectId: string;
+    projectPath: string;
+    taskName: string;
+    baseRef?: string;
+    task: {
+      projectId: string;
+      name: string;
+      status: 'active' | 'idle' | 'running';
+      agentId?: string | null;
+      metadata?: any;
+      useWorktree?: boolean;
+    };
+  }) => Promise<{
+    success: boolean;
+    worktree?: any;
+    task?: any;
+    needsBaseRefSwitch?: boolean;
+    error?: string;
+  }>;
+  worktreeRemoveReserve: (args: {
+    projectId: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+
+  // Lifecycle scripts
+  lifecycleGetScript: (args: {
+    projectPath: string;
+    phase: 'setup' | 'run' | 'teardown';
+  }) => Promise<{ success: boolean; script?: string | null; error?: string }>;
+  lifecycleSetup: (args: {
+    taskId: string;
+    taskPath: string;
+    projectPath: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleRunStart: (args: {
+    taskId: string;
+    taskPath: string;
+    projectPath: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleRunStop: (args: {
+    taskId: string;
+    taskPath?: string;
+    projectPath?: string;
+    taskName?: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleTeardown: (args: {
+    taskId: string;
+    taskPath: string;
+    projectPath: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleGetState: (args: { taskId: string }) => Promise<{
+    success: boolean;
+    state?: {
+      taskId: string;
+      setup: {
+        status: 'idle' | 'running' | 'succeeded' | 'failed';
+        startedAt?: string;
+        finishedAt?: string;
+        exitCode?: number | null;
+        error?: string | null;
+      };
+      run: {
+        status: 'idle' | 'running' | 'succeeded' | 'failed';
+        startedAt?: string;
+        finishedAt?: string;
+        exitCode?: number | null;
+        error?: string | null;
+        pid?: number | null;
+      };
+      teardown: {
+        status: 'idle' | 'running' | 'succeeded' | 'failed';
+        startedAt?: string;
+        finishedAt?: string;
+        exitCode?: number | null;
+        error?: string | null;
+      };
+    };
+    error?: string;
+  }>;
+  lifecycleClearTask: (args: { taskId: string }) => Promise<{ success: boolean; error?: string }>;
+  onLifecycleEvent: (listener: (data: any) => void) => () => void;
+
+  // Project management
+  openProject: () => Promise<{ success: boolean; path?: string; error?: string }>;
+  getGitInfo: (projectPath: string) => Promise<{
+    isGitRepo: boolean;
+    remote?: string;
+    branch?: string;
+    baseRef?: string;
+    upstream?: string;
+    aheadCount?: number;
+    behindCount?: number;
+    path?: string;
+    rootPath?: string;
+    error?: string;
+  }>;
+  getGitStatus: (taskPath: string) => Promise<{
+    success: boolean;
+    changes?: Array<{
+      path: string;
+      status: string;
+      additions: number | null;
+      deletions: number | null;
+      isStaged: boolean;
+      diff?: string;
+    }>;
+    error?: string;
+  }>;
+  getDeleteRisks: (args: {
+    targets: Array<{ id: string; taskPath: string }>;
+    includePr?: boolean;
+  }) => Promise<{
+    success: boolean;
+    risks?: Record<
+      string,
+      {
+        staged: number;
+        unstaged: number;
+        untracked: number;
+        files: string[];
+        ahead: number;
+        behind: number;
+        error?: string;
+        pr?: {
+          number?: number;
+          title?: string;
+          url?: string;
+          state?: string | null;
+          isDraft?: boolean;
+        } | null;
+        prKnown: boolean;
+      }
+    >;
+    error?: string;
+  }>;
+  watchGitStatus: (taskPath: string) => Promise<{
+    success: boolean;
+    watchId?: string;
+    error?: string;
+  }>;
+  unwatchGitStatus: (
+    taskPath: string,
+    watchId?: string
+  ) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  onGitStatusChanged: (
+    listener: (data: { taskPath: string; error?: string }) => void
+  ) => () => void;
+  getFileDiff: (args: {
+    taskPath: string;
+    filePath: string;
+    baseRef?: string;
+    forceLarge?: boolean;
+  }) => Promise<{
+    success: boolean;
+    diff?: DiffPayload;
+    error?: string;
+  }>;
+  updateIndex: (args: { taskPath: string } & GitIndexUpdateArgs) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  revertFile: (args: { taskPath: string; filePath: string }) => Promise<{
+    success: boolean;
+    action?: 'reverted';
+    error?: string;
+  }>;
+  gitCommitAndPush: (args: {
+    taskPath: string;
+    commitMessage?: string;
+    createBranchIfOnDefault?: boolean;
+    branchPrefix?: string;
+  }) => Promise<{ success: boolean; branch?: string; output?: string; error?: string }>;
+  createPullRequest: (args: {
+    taskPath: string;
+    title?: string;
+    body?: string;
+    base?: string;
+    head?: string;
+    draft?: boolean;
+    web?: boolean;
+    fill?: boolean;
+    skipPrePush?: boolean;
+  }) => Promise<{ success: boolean; url?: string; output?: string; error?: string }>;
+  connectToGitHub: (
+    projectPath: string
+  ) => Promise<{ success: boolean; repository?: string; branch?: string; error?: string }>;
+
+  // Filesystem helpers
+  fsList: (
+    root: string,
+    opts?: {
+      includeDirs?: boolean;
+      maxEntries?: number;
+      timeBudgetMs?: number;
+      connectionId?: string;
+      remotePath?: string;
+    }
+  ) => Promise<{
+    success: boolean;
+    items?: Array<{ path: string; type: 'file' | 'dir' }>;
+    error?: string;
+    canceled?: boolean;
+    truncated?: boolean;
+    reason?: string;
+    durationMs?: number;
+  }>;
+  fsRead: (
+    root: string,
+    relPath: string,
+    maxBytes?: number,
+    remote?: { connectionId: string; remotePath: string }
+  ) => Promise<{
+    success: boolean;
+    path?: string;
+    size?: number;
+    truncated?: boolean;
+    content?: string;
+    error?: string;
+  }>;
+
+  // GitHub integration
+  githubAuth: () => Promise<{
+    success: boolean;
+    device_code?: string;
+    user_code?: string;
+    verification_uri?: string;
+    expires_in?: number;
+    interval?: number;
+    error?: string;
+  }>;
+  githubCancelAuth: () => Promise<{ success: boolean; error?: string }>;
+
+  // GitHub auth event listeners (return cleanup function)
+  onGithubAuthDeviceCode: (
+    callback: (data: {
+      userCode: string;
+      verificationUri: string;
+      expiresIn: number;
+      interval: number;
+    }) => void
+  ) => () => void;
+  onGithubAuthPolling: (callback: (data: { status: string }) => void) => () => void;
+  onGithubAuthSlowDown: (callback: (data: { newInterval: number }) => void) => () => void;
+  onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => () => void;
+  onGithubAuthError: (callback: (data: { error: string; message: string }) => void) => () => void;
+  onGithubAuthCancelled: (callback: () => void) => () => void;
+  onGithubAuthUserUpdated: (callback: (data: { user: any }) => void) => () => void;
+
+  githubIsAuthenticated: () => Promise<boolean>;
+  githubGetStatus: () => Promise<{ installed: boolean; authenticated: boolean; user?: any }>;
+  githubGetUser: () => Promise<any>;
+  githubGetRepositories: () => Promise<any[]>;
+  githubCloneRepository: (
+    repoUrl: string,
+    localPath: string
+  ) => Promise<{ success: boolean; error?: string }>;
+  githubListPullRequests: (args: {
+    projectPath: string;
+    limit?: number;
+  }) => Promise<{ success: boolean; prs?: any[]; totalCount?: number; error?: string }>;
+  githubCreatePullRequestWorktree: (args: {
+    projectPath: string;
+    projectId: string;
+    prNumber: number;
+    prTitle?: string;
+    taskName?: string;
+    branchName?: string;
+  }) => Promise<{
+    success: boolean;
+    worktree?: any;
+    branchName?: string;
+    taskName?: string;
+    task?: {
+      id: string;
+      name: string;
+      path: string;
+      branch: string;
+      projectId: string;
+      status: string;
+      agentId: string;
+      metadata?: { prNumber?: number; prTitle?: string | null };
+    };
+    error?: string;
+  }>;
+  githubGetPullRequestBaseDiff: (args: { worktreePath: string; prNumber: number }) => Promise<{
+    success: boolean;
+    diff?: string;
+    baseBranch?: string;
+    headBranch?: string;
+    prUrl?: string;
+    error?: string;
+  }>;
+  githubLogout: () => Promise<void>;
+  githubCheckCLIInstalled: () => Promise<boolean>;
+  githubInstallCLI: () => Promise<{ success: boolean; error?: string }>;
+
+  // Host preview (non-container)
+  hostPreviewStart: (args: {
+    taskId: string;
+    taskPath: string;
+    script?: string;
+    parentProjectPath?: string;
+  }) => Promise<{ ok: boolean; error?: string }>;
+  hostPreviewSetup: (args: {
+    taskId: string;
+    taskPath: string;
+  }) => Promise<{ ok: boolean; error?: string }>;
+  hostPreviewStop: (taskId: string) => Promise<{ ok: boolean }>;
+  onHostPreviewEvent: (
+    listener: (data: { type: 'url'; taskId: string; url: string }) => void
+  ) => () => void;
+
+  // Main-managed browser (WebContentsView)
+  browserShow: (
+    bounds: { x: number; y: number; width: number; height: number },
+    url?: string
+  ) => Promise<{ ok: boolean }>;
+  browserHide: () => Promise<{ ok: boolean }>;
+  browserSetBounds: (bounds: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  }) => Promise<{ ok: boolean }>;
+  browserLoadURL: (url: string) => Promise<{ ok: boolean }>;
+  browserGoBack: () => Promise<{ ok: boolean }>;
+  browserGoForward: () => Promise<{ ok: boolean }>;
+  browserReload: () => Promise<{ ok: boolean }>;
+  browserOpenDevTools: () => Promise<{ ok: boolean }>;
+  onBrowserViewEvent: (listener: (data: any) => void) => () => void;
+
+  // TCP probe (no HTTP requests)
+  netProbePorts: (
+    host: string,
+    ports: number[],
+    timeoutMs?: number
+  ) => Promise<{ reachable: number[] }>;
+
+  // SSH operations
+  sshTestConnection: (
+    config: any
+  ) => Promise<{ success: boolean; latency?: number; error?: string }>;
+  sshSaveConnection: (config: any) => Promise<any>;
+  sshGetConnections: () => Promise<any[]>;
+  sshDeleteConnection: (id: string) => Promise<void>;
+  sshConnect: (arg: any) => Promise<string>;
+  sshDisconnect: (connectionId: string) => Promise<void>;
+  sshExecuteCommand: (
+    connectionId: string,
+    command: string,
+    cwd?: string
+  ) => Promise<{
+    stdout: string;
+    stderr: string;
+    exitCode: number;
+  }>;
+  sshListFiles: (connectionId: string, path: string) => Promise<any[]>;
+  sshReadFile: (connectionId: string, path: string) => Promise<string>;
+  sshWriteFile: (connectionId: string, path: string, content: string) => Promise<void>;
+  sshGetState: (connectionId: string) => Promise<any>;
+  sshGetConfig: () => Promise<{ success: boolean; hosts?: any[]; error?: string }>;
+}
+
+declare global {
+  interface Window {
+    electronAPI: ElectronAPI;
+  }
+}

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -1,11 +1,17 @@
 import { contextBridge, ipcRenderer } from 'electron';
-import type { TerminalSnapshotPayload } from './types/terminalSnapshot';
-import type { OpenInAppId } from '../shared/openInApps';
 import type { AgentEvent } from '../shared/agentEvents';
-import type { McpServer } from '../shared/mcp/types';
 import type { DiffPayload } from '../shared/diff/types';
 import type { GitIndexUpdateArgs } from '../shared/git/types';
+import type {
+  ProjectPathLocator,
+  RepoPathLocator,
+  TaskPathLocator,
+  WorktreePathLocator,
+} from '../shared/ipc/remoteLocator';
+import type { McpServer } from '../shared/mcp/types';
+import type { OpenInAppId } from '../shared/openInApps';
 import type { ResourceMetricsSnapshot } from '../shared/performanceTypes';
+import type { TerminalSnapshotPayload } from './types/terminalSnapshot';
 
 // Keep preload self-contained: sandboxed preload cannot reliably require local runtime modules.
 const LIFECYCLE_EVENT_CHANNEL = 'lifecycle:event';
@@ -239,8 +245,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     projectId: string;
     baseRef?: string;
   }) => ipcRenderer.invoke('worktree:create', args),
-  worktreeList: (args: { projectPath: string; sshConnectionId?: string }) =>
-    ipcRenderer.invoke('worktree:list', args),
+  worktreeList: (args: ProjectPathLocator) => ipcRenderer.invoke('worktree:list', args),
   worktreeRemove: (args: {
     projectPath: string;
     worktreeId: string;
@@ -249,7 +254,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     taskName?: string;
     sshConnectionId?: string;
   }) => ipcRenderer.invoke('worktree:remove', args),
-  worktreeStatus: (args: { worktreePath: string }) => ipcRenderer.invoke('worktree:status', args),
+  worktreeStatus: (args: WorktreePathLocator) => ipcRenderer.invoke('worktree:status', args),
   worktreeMerge: (args: { projectPath: string; worktreeId: string }) =>
     ipcRenderer.invoke('worktree:merge', args),
   worktreeGet: (args: { worktreeId: string }) => ipcRenderer.invoke('worktree:get', args),
@@ -385,15 +390,13 @@ contextBridge.exposeInMainWorld('electronAPI', {
   fetchProjectBaseRef: (args: { projectId: string; projectPath: string }) =>
     ipcRenderer.invoke('projectSettings:fetchBaseRef', args),
   getGitInfo: (projectPath: string) => ipcRenderer.invoke('git:getInfo', projectPath),
-  getGitStatus: (arg: string | { taskPath: string; taskId?: string }) =>
-    ipcRenderer.invoke('git:get-status', arg),
+  getGitStatus: (arg: string | TaskPathLocator) => ipcRenderer.invoke('git:get-status', arg),
   getDeleteRisks: (args: {
     targets: Array<{ id: string; taskPath: string; sshConnectionId?: string }>;
     includePr?: boolean;
   }) => ipcRenderer.invoke('git:get-delete-risks', args),
-  watchGitStatus: (arg: string | { taskPath: string; taskId?: string }) =>
-    ipcRenderer.invoke('git:watch-status', arg),
-  unwatchGitStatus: (arg: string | { taskPath: string; taskId?: string }, watchId?: string) =>
+  watchGitStatus: (arg: string | TaskPathLocator) => ipcRenderer.invoke('git:watch-status', arg),
+  unwatchGitStatus: (arg: string | TaskPathLocator, watchId?: string) =>
     ipcRenderer.invoke('git:unwatch-status', arg, watchId),
   onGitStatusChanged: (listener: (data: { taskPath: string; error?: string }) => void) => {
     attachGitStatusBridgeOnce();
@@ -402,87 +405,83 @@ contextBridge.exposeInMainWorld('electronAPI', {
       gitStatusChangedListeners.delete(listener);
     };
   },
-  getFileDiff: (args: {
-    taskPath: string;
-    taskId?: string;
-    filePath: string;
-    baseRef?: string;
-    forceLarge?: boolean;
-  }) => ipcRenderer.invoke('git:get-file-diff', args),
-  updateIndex: (args: { taskPath: string; taskId?: string } & GitIndexUpdateArgs) =>
+  getFileDiff: (
+    args: TaskPathLocator & {
+      filePath: string;
+      baseRef?: string;
+      forceLarge?: boolean;
+    }
+  ) => ipcRenderer.invoke('git:get-file-diff', args),
+  updateIndex: (args: TaskPathLocator & GitIndexUpdateArgs) =>
     ipcRenderer.invoke('git:update-index', args),
-  revertFile: (args: { taskPath: string; taskId?: string; filePath: string }) =>
+  revertFile: (args: TaskPathLocator & { filePath: string }) =>
     ipcRenderer.invoke('git:revert-file', args),
   gitCommit: (args: { taskPath: string; message: string }) =>
     ipcRenderer.invoke('git:commit', args),
   gitPush: (args: { taskPath: string }) => ipcRenderer.invoke('git:push', args),
   gitPull: (args: { taskPath: string }) => ipcRenderer.invoke('git:pull', args),
-  gitGetLog: (args: { taskPath: string; maxCount?: number; skip?: number }) =>
+  gitGetLog: (args: TaskPathLocator & { maxCount?: number; skip?: number; aheadCount?: number }) =>
     ipcRenderer.invoke('git:get-log', args),
-  gitGetLatestCommit: (args: { taskPath: string }) =>
-    ipcRenderer.invoke('git:get-latest-commit', args),
-  gitGetCommitFiles: (args: { taskPath: string; commitHash: string }) =>
+  gitGetLatestCommit: (args: TaskPathLocator) => ipcRenderer.invoke('git:get-latest-commit', args),
+  gitGetCommitFiles: (args: TaskPathLocator & { commitHash: string }) =>
     ipcRenderer.invoke('git:get-commit-files', args),
-  gitGetCommitFileDiff: (args: {
-    taskPath: string;
-    commitHash: string;
-    filePath: string;
-    forceLarge?: boolean;
-  }) => ipcRenderer.invoke('git:get-commit-file-diff', args),
+  gitGetCommitFileDiff: (
+    args: TaskPathLocator & {
+      commitHash: string;
+      filePath: string;
+      forceLarge?: boolean;
+    }
+  ) => ipcRenderer.invoke('git:get-commit-file-diff', args),
   gitSoftReset: (args: { taskPath: string }) => ipcRenderer.invoke('git:soft-reset', args),
-  gitCommitAndPush: (args: {
-    taskPath: string;
-    taskId?: string;
-    commitMessage?: string;
-    createBranchIfOnDefault?: boolean;
-    branchPrefix?: string;
-  }) => ipcRenderer.invoke('git:commit-and-push', args),
-  generatePrContent: (args: { taskPath: string; base?: string; sshConnectionId?: string }) =>
+  gitCommitAndPush: (
+    args: TaskPathLocator & {
+      commitMessage?: string;
+      createBranchIfOnDefault?: boolean;
+      branchPrefix?: string;
+    }
+  ) => ipcRenderer.invoke('git:commit-and-push', args),
+  generatePrContent: (args: TaskPathLocator & { base?: string }) =>
     ipcRenderer.invoke('git:generate-pr-content', args),
-  createPullRequest: (args: {
-    taskPath: string;
-    title?: string;
-    body?: string;
-    base?: string;
-    head?: string;
-    draft?: boolean;
-    web?: boolean;
-    fill?: boolean;
-    skipPrePush?: boolean;
-    sshConnectionId?: string;
-  }) => ipcRenderer.invoke('git:create-pr', args),
-  mergeToMain: (args: { taskPath: string; taskId?: string }) =>
-    ipcRenderer.invoke('git:merge-to-main', args),
-  mergePr: (args: {
-    taskPath: string;
-    prNumber?: number;
-    strategy?: 'merge' | 'squash' | 'rebase';
-    admin?: boolean;
-    sshConnectionId?: string;
-  }) => ipcRenderer.invoke('git:merge-pr', args),
-  getPrStatus: (args: { taskPath: string; sshConnectionId?: string }) =>
-    ipcRenderer.invoke('git:get-pr-status', args),
-  enableAutoMerge: (args: {
-    taskPath: string;
-    prNumber?: number;
-    strategy?: 'merge' | 'squash' | 'rebase';
-    sshConnectionId?: string;
-  }) => ipcRenderer.invoke('git:enable-auto-merge', args),
-  disableAutoMerge: (args: { taskPath: string; prNumber?: number; sshConnectionId?: string }) =>
+  createPullRequest: (
+    args: TaskPathLocator & {
+      title?: string;
+      body?: string;
+      base?: string;
+      head?: string;
+      draft?: boolean;
+      web?: boolean;
+      fill?: boolean;
+      skipPrePush?: boolean;
+    }
+  ) => ipcRenderer.invoke('git:create-pr', args),
+  mergeToMain: (args: TaskPathLocator) => ipcRenderer.invoke('git:merge-to-main', args),
+  mergePr: (
+    args: TaskPathLocator & {
+      prNumber?: number;
+      strategy?: 'merge' | 'squash' | 'rebase';
+      admin?: boolean;
+    }
+  ) => ipcRenderer.invoke('git:merge-pr', args),
+  getPrStatus: (args: TaskPathLocator) => ipcRenderer.invoke('git:get-pr-status', args),
+  enableAutoMerge: (
+    args: TaskPathLocator & {
+      prNumber?: number;
+      strategy?: 'merge' | 'squash' | 'rebase';
+    }
+  ) => ipcRenderer.invoke('git:enable-auto-merge', args),
+  disableAutoMerge: (args: TaskPathLocator & { prNumber?: number }) =>
     ipcRenderer.invoke('git:disable-auto-merge', args),
-  getCheckRuns: (args: { taskPath: string; sshConnectionId?: string }) =>
-    ipcRenderer.invoke('git:get-check-runs', args),
-  getPrComments: (args: { taskPath: string; prNumber?: number; sshConnectionId?: string }) =>
+  getCheckRuns: (args: TaskPathLocator) => ipcRenderer.invoke('git:get-check-runs', args),
+  getPrComments: (args: TaskPathLocator & { prNumber?: number }) =>
     ipcRenderer.invoke('git:get-pr-comments', args),
-  getBranchStatus: (args: { taskPath: string; taskId?: string }) =>
-    ipcRenderer.invoke('git:get-branch-status', args),
-  renameBranch: (args: {
-    repoPath: string;
-    oldBranch: string;
-    newBranch: string;
-    sshConnectionId?: string;
-  }) => ipcRenderer.invoke('git:rename-branch', args),
-  listRemoteBranches: (args: { projectPath: string; remote?: string; sshConnectionId?: string }) =>
+  getBranchStatus: (args: TaskPathLocator) => ipcRenderer.invoke('git:get-branch-status', args),
+  renameBranch: (
+    args: RepoPathLocator & {
+      oldBranch: string;
+      newBranch: string;
+    }
+  ) => ipcRenderer.invoke('git:rename-branch', args),
+  listRemoteBranches: (args: ProjectPathLocator & { remote?: string }) =>
     ipcRenderer.invoke('git:list-remote-branches', args),
   openExternal: (url: string) => ipcRenderer.invoke('app:openExternal', url),
   clipboardWriteText: (text: string) => ipcRenderer.invoke('app:clipboard-write-text', text),
@@ -1048,19 +1047,24 @@ export interface ElectronAPI {
     projectId: string;
     baseRef?: string;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
-  worktreeList: (args: {
-    projectPath: string;
-  }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+  worktreeList: (args: ProjectPathLocator) => Promise<{
+    success: boolean;
+    worktrees?: any[];
+    error?: string;
+  }>;
   worktreeRemove: (args: {
     projectPath: string;
     worktreeId: string;
     worktreePath?: string;
     branch?: string;
     taskName?: string;
+    sshConnectionId?: string;
   }) => Promise<{ success: boolean; error?: string }>;
-  worktreeStatus: (args: {
-    worktreePath: string;
-  }) => Promise<{ success: boolean; status?: any; error?: string }>;
+  worktreeStatus: (args: WorktreePathLocator) => Promise<{
+    success: boolean;
+    status?: any;
+    error?: string;
+  }>;
   worktreeMerge: (args: {
     projectPath: string;
     worktreeId: string;
@@ -1189,7 +1193,7 @@ export interface ElectronAPI {
     rootPath?: string;
     error?: string;
   }>;
-  getGitStatus: (taskPath: string) => Promise<{
+  getGitStatus: (arg: string | TaskPathLocator) => Promise<{
     success: boolean;
     changes?: Array<{
       path: string;
@@ -1202,7 +1206,7 @@ export interface ElectronAPI {
     error?: string;
   }>;
   getDeleteRisks: (args: {
-    targets: Array<{ id: string; taskPath: string }>;
+    targets: Array<{ id: string; taskPath: string; sshConnectionId?: string }>;
     includePr?: boolean;
   }) => Promise<{
     success: boolean;
@@ -1228,13 +1232,13 @@ export interface ElectronAPI {
     >;
     error?: string;
   }>;
-  watchGitStatus: (taskPath: string) => Promise<{
+  watchGitStatus: (arg: string | TaskPathLocator) => Promise<{
     success: boolean;
     watchId?: string;
     error?: string;
   }>;
   unwatchGitStatus: (
-    taskPath: string,
+    arg: string | TaskPathLocator,
     watchId?: string
   ) => Promise<{
     success: boolean;
@@ -1243,31 +1247,33 @@ export interface ElectronAPI {
   onGitStatusChanged: (
     listener: (data: { taskPath: string; error?: string }) => void
   ) => () => void;
-  getFileDiff: (args: {
-    taskPath: string;
-    filePath: string;
-    baseRef?: string;
-    forceLarge?: boolean;
-  }) => Promise<{
+  getFileDiff: (
+    args: TaskPathLocator & {
+      filePath: string;
+      baseRef?: string;
+      forceLarge?: boolean;
+    }
+  ) => Promise<{
     success: boolean;
     diff?: DiffPayload;
     error?: string;
   }>;
-  updateIndex: (args: { taskPath: string } & GitIndexUpdateArgs) => Promise<{
+  updateIndex: (args: TaskPathLocator & GitIndexUpdateArgs) => Promise<{
     success: boolean;
     error?: string;
   }>;
-  revertFile: (args: { taskPath: string; filePath: string }) => Promise<{
+  revertFile: (args: TaskPathLocator & { filePath: string }) => Promise<{
     success: boolean;
     action?: 'reverted';
     error?: string;
   }>;
-  gitCommitAndPush: (args: {
-    taskPath: string;
-    commitMessage?: string;
-    createBranchIfOnDefault?: boolean;
-    branchPrefix?: string;
-  }) => Promise<{ success: boolean; branch?: string; output?: string; error?: string }>;
+  gitCommitAndPush: (
+    args: TaskPathLocator & {
+      commitMessage?: string;
+      createBranchIfOnDefault?: boolean;
+      branchPrefix?: string;
+    }
+  ) => Promise<{ success: boolean; branch?: string; output?: string; error?: string }>;
   createPullRequest: (args: {
     taskPath: string;
     title?: string;

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -1,0 +1,1240 @@
+import type sqlite3Type from 'sqlite3';
+import { and, asc, desc, eq, isNull, sql } from 'drizzle-orm';
+import { readMigrationFiles } from 'drizzle-orm/migrator';
+import { resolveDatabasePath, resolveMigrationsPath } from '../db/path';
+import { getDrizzleClient } from '../db/drizzleClient';
+import { errorTracking } from '../errorTracking';
+import {
+  projects as projectsTable,
+  tasks as tasksTable,
+  conversations as conversationsTable,
+  messages as messagesTable,
+  sshConnections as sshConnectionsTable,
+  type ProjectRow,
+  type TaskRow,
+  type ConversationRow,
+  type MessageRow,
+  type SshConnectionRow,
+  type SshConnectionInsert,
+} from '../db/schema';
+
+export interface Project {
+  id: string;
+  name: string;
+  path: string;
+  // Remote project fields (optional for backward compatibility)
+  isRemote?: boolean;
+  sshConnectionId?: string | null;
+  remotePath?: string | null;
+  gitInfo: {
+    isGitRepo: boolean;
+    remote?: string;
+    branch?: string;
+    baseRef?: string;
+  };
+  githubInfo?: {
+    repository: string;
+    connected: boolean;
+  };
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Task {
+  id: string;
+  projectId: string;
+  name: string;
+  branch: string;
+  path: string;
+  status: 'active' | 'idle' | 'running';
+  agentId?: string | null;
+  metadata?: any;
+  useWorktree?: boolean;
+  archivedAt?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Conversation {
+  id: string;
+  taskId: string;
+  title: string;
+  provider?: string | null;
+  isActive?: boolean;
+  isMain?: boolean;
+  displayOrder?: number;
+  metadata?: string | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface Message {
+  id: string;
+  conversationId: string;
+  content: string;
+  sender: 'user' | 'agent';
+  timestamp: string;
+  metadata?: string; // JSON string for additional data
+}
+
+export interface MigrationSummary {
+  appliedCount: number;
+  totalMigrations: number;
+  recovered: boolean;
+}
+
+export class DatabaseSchemaMismatchError extends Error {
+  readonly code = 'DB_SCHEMA_MISMATCH';
+  readonly dbPath: string;
+  readonly missingInvariants: string[];
+
+  constructor(dbPath: string, missingInvariants: string[]) {
+    const suffix = missingInvariants.length > 0 ? ` (${missingInvariants.join(', ')})` : '';
+    super(`Database schema mismatch${suffix}`);
+    this.name = 'DatabaseSchemaMismatchError';
+    this.dbPath = dbPath;
+    this.missingInvariants = missingInvariants;
+  }
+}
+
+export class ProjectConflictError extends Error {
+  readonly code = 'PROJECT_CONFLICT';
+  readonly existingProjectId: string;
+  readonly existingProjectName: string;
+  readonly projectPath: string;
+
+  constructor(args: {
+    existingProjectId: string;
+    existingProjectName: string;
+    projectPath: string;
+  }) {
+    super(
+      `A project already exists for "${args.existingProjectName}" at ${args.projectPath}. Emdash kept the existing project and its tasks unchanged.`
+    );
+    this.name = 'ProjectConflictError';
+    this.existingProjectId = args.existingProjectId;
+    this.existingProjectName = args.existingProjectName;
+    this.projectPath = args.projectPath;
+  }
+}
+
+export class DatabaseService {
+  private static migrationsApplied = false;
+  private db: sqlite3Type.Database | null = null;
+  private sqlite3: typeof sqlite3Type | null = null;
+  private dbPath: string;
+  private disabled: boolean = false;
+  private lastMigrationSummary: MigrationSummary | null = null;
+
+  constructor() {
+    if (process.env.EMDASH_DISABLE_NATIVE_DB === '1') {
+      this.disabled = true;
+    }
+    this.dbPath = resolveDatabasePath();
+  }
+
+  async initialize(): Promise<void> {
+    if (this.disabled) return Promise.resolve();
+    if (!this.sqlite3) {
+      try {
+        // Dynamic import to avoid loading native module at startup
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        this.sqlite3 = (await import('sqlite3')) as unknown as typeof sqlite3Type;
+      } catch (e) {
+        // Track critical database initialization error
+        await errorTracking.captureDatabaseError(e, 'initialize_sqlite3_import');
+        return Promise.reject(e);
+      }
+    }
+    return new Promise((resolve, reject) => {
+      this.db = new this.sqlite3!.Database(this.dbPath, async (err) => {
+        if (err) {
+          // Track critical database connection error
+          await errorTracking.captureDatabaseError(err, 'initialize_connection', {
+            db_path: this.dbPath,
+          });
+          reject(err);
+          return;
+        }
+
+        this.ensureMigrations()
+          .then(async () => {
+            await this.validateSchemaContract();
+            resolve();
+          })
+          .catch(async (initError) => {
+            const operation =
+              initError instanceof DatabaseSchemaMismatchError
+                ? 'initialize_schema_contract'
+                : 'initialize_migrations';
+            await errorTracking.captureDatabaseError(initError, operation, {
+              db_path: this.dbPath,
+            });
+            reject(initError);
+          });
+      });
+    });
+  }
+
+  getLastMigrationSummary(): MigrationSummary | null {
+    return this.lastMigrationSummary;
+  }
+
+  async saveProject(project: Omit<Project, 'createdAt' | 'updatedAt'>): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    const gitRemote = project.gitInfo.remote ?? null;
+    const gitBranch = project.gitInfo.branch ?? null;
+    const baseRef = this.computeBaseRef(
+      project.gitInfo.baseRef,
+      project.gitInfo.remote,
+      project.gitInfo.branch
+    );
+    const githubRepository = project.githubInfo?.repository ?? null;
+    const githubConnected = project.githubInfo?.connected ? 1 : 0;
+    const existingByIdRows = await db
+      .select({
+        id: projectsTable.id,
+        path: projectsTable.path,
+      })
+      .from(projectsTable)
+      .where(eq(projectsTable.id, project.id))
+      .limit(1);
+    const existingById = existingByIdRows[0] ?? null;
+
+    const existingByPathRows = await db
+      .select({
+        id: projectsTable.id,
+        name: projectsTable.name,
+        path: projectsTable.path,
+        sshConnectionId: projectsTable.sshConnectionId,
+        isRemote: projectsTable.isRemote,
+      })
+      .from(projectsTable)
+      .where(eq(projectsTable.path, project.path))
+      .limit(1);
+    const existingByPath = existingByPathRows[0] ?? null;
+
+    if (existingByPath && existingByPath.id !== project.id) {
+      // For remote projects, allow the same path if sshConnectionId is different
+      const isNewProjectRemote = project.isRemote && project.sshConnectionId;
+      const isExistingProjectRemote =
+        existingByPath.isRemote === 1 && existingByPath.sshConnectionId;
+      const sameSshConnection =
+        project.sshConnectionId && existingByPath.sshConnectionId === project.sshConnectionId;
+
+      if (!isNewProjectRemote || !isExistingProjectRemote || sameSshConnection) {
+        throw new ProjectConflictError({
+          existingProjectId: existingByPath.id,
+          existingProjectName: existingByPath.name,
+          projectPath: existingByPath.path,
+        });
+      }
+    }
+
+    const values = {
+      id: project.id,
+      name: project.name,
+      path: project.path,
+      gitRemote,
+      gitBranch,
+      baseRef: baseRef ?? null,
+      githubRepository,
+      githubConnected,
+      sshConnectionId: project.sshConnectionId ?? null,
+      isRemote: project.isRemote ? 1 : 0,
+      remotePath: project.remotePath ?? null,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+    } as const;
+
+    if (existingById) {
+      await db.update(projectsTable).set(values).where(eq(projectsTable.id, project.id));
+      return;
+    }
+
+    await db.insert(projectsTable).values(values);
+  }
+
+  async getProjects(): Promise<Project[]> {
+    if (this.disabled) return [];
+    const { db } = await getDrizzleClient();
+    const rows = await db.select().from(projectsTable).orderBy(desc(projectsTable.updatedAt));
+    return rows.map((row) => this.mapDrizzleProjectRow(row));
+  }
+
+  async getProjectById(projectId: string): Promise<Project | null> {
+    if (this.disabled) return null;
+    if (!projectId) {
+      throw new Error('projectId is required');
+    }
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select()
+      .from(projectsTable)
+      .where(eq(projectsTable.id, projectId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      return null;
+    }
+
+    return this.mapDrizzleProjectRow(rows[0]);
+  }
+
+  async updateProjectBaseRef(projectId: string, nextBaseRef: string): Promise<Project | null> {
+    if (this.disabled) return null;
+    if (!projectId) {
+      throw new Error('projectId is required');
+    }
+    const trimmed = typeof nextBaseRef === 'string' ? nextBaseRef.trim() : '';
+    if (!trimmed) {
+      throw new Error('baseRef cannot be empty');
+    }
+
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select({
+        id: projectsTable.id,
+        gitRemote: projectsTable.gitRemote,
+        gitBranch: projectsTable.gitBranch,
+      })
+      .from(projectsTable)
+      .where(eq(projectsTable.id, projectId))
+      .limit(1);
+
+    if (rows.length === 0) {
+      throw new Error(`Project not found: ${projectId}`);
+    }
+
+    const source = rows[0];
+    const normalized = this.computeBaseRef(trimmed, source.gitRemote, source.gitBranch);
+
+    await db
+      .update(projectsTable)
+      .set({
+        baseRef: normalized,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(eq(projectsTable.id, projectId));
+
+    return this.getProjectById(projectId);
+  }
+
+  async saveTask(task: Omit<Task, 'createdAt' | 'updatedAt'>): Promise<void> {
+    if (this.disabled) return;
+    const metadataValue =
+      typeof task.metadata === 'string'
+        ? task.metadata
+        : task.metadata
+          ? JSON.stringify(task.metadata)
+          : null;
+    const { db } = await getDrizzleClient();
+    await db
+      .insert(tasksTable)
+      .values({
+        id: task.id,
+        projectId: task.projectId,
+        name: task.name,
+        branch: task.branch,
+        path: task.path,
+        status: task.status,
+        agentId: task.agentId ?? null,
+        metadata: metadataValue,
+        useWorktree: task.useWorktree !== false ? 1 : 0,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .onConflictDoUpdate({
+        target: tasksTable.id,
+        set: {
+          projectId: task.projectId,
+          name: task.name,
+          branch: task.branch,
+          path: task.path,
+          status: task.status,
+          agentId: task.agentId ?? null,
+          metadata: metadataValue,
+          useWorktree: task.useWorktree !== false ? 1 : 0,
+          updatedAt: sql`CURRENT_TIMESTAMP`,
+        },
+      });
+  }
+
+  async getTasks(projectId?: string): Promise<Task[]> {
+    if (this.disabled) return [];
+    const { db } = await getDrizzleClient();
+
+    // Filter out archived tasks by default
+    const rows: TaskRow[] = projectId
+      ? await db
+          .select()
+          .from(tasksTable)
+          .where(and(eq(tasksTable.projectId, projectId), isNull(tasksTable.archivedAt)))
+          .orderBy(desc(tasksTable.updatedAt))
+      : await db
+          .select()
+          .from(tasksTable)
+          .where(isNull(tasksTable.archivedAt))
+          .orderBy(desc(tasksTable.updatedAt));
+    return rows.map((row) => this.mapDrizzleTaskRow(row));
+  }
+
+  async getArchivedTasks(projectId?: string): Promise<Task[]> {
+    if (this.disabled) return [];
+    const { db } = await getDrizzleClient();
+
+    const rows: TaskRow[] = projectId
+      ? await db
+          .select()
+          .from(tasksTable)
+          .where(
+            and(eq(tasksTable.projectId, projectId), sql`${tasksTable.archivedAt} IS NOT NULL`)
+          )
+          .orderBy(desc(tasksTable.archivedAt))
+      : await db
+          .select()
+          .from(tasksTable)
+          .where(sql`${tasksTable.archivedAt} IS NOT NULL`)
+          .orderBy(desc(tasksTable.archivedAt));
+    return rows.map((row) => this.mapDrizzleTaskRow(row));
+  }
+
+  async archiveTask(taskId: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db
+      .update(tasksTable)
+      .set({
+        archivedAt: new Date().toISOString(),
+        status: 'idle', // Reset status since PTY processes are killed on archive
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(eq(tasksTable.id, taskId));
+  }
+
+  async restoreTask(taskId: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db
+      .update(tasksTable)
+      .set({
+        archivedAt: null,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(eq(tasksTable.id, taskId));
+  }
+
+  async getTaskByPath(taskPath: string): Promise<Task | null> {
+    if (this.disabled) return null;
+    const { db } = await getDrizzleClient();
+
+    const rows = await db.select().from(tasksTable).where(eq(tasksTable.path, taskPath)).limit(1);
+
+    if (rows.length === 0) return null;
+    return this.mapDrizzleTaskRow(rows[0]);
+  }
+
+  async getTaskById(taskId: string): Promise<Task | null> {
+    if (this.disabled) return null;
+    if (!taskId) return null;
+    const { db } = await getDrizzleClient();
+    const rows = await db.select().from(tasksTable).where(eq(tasksTable.id, taskId)).limit(1);
+    if (rows.length === 0) return null;
+    return this.mapDrizzleTaskRow(rows[0]);
+  }
+
+  async deleteProject(projectId: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db.delete(projectsTable).where(eq(projectsTable.id, projectId));
+  }
+
+  async deleteTask(taskId: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db.delete(tasksTable).where(eq(tasksTable.id, taskId));
+  }
+
+  // Conversation management methods
+  async saveConversation(
+    conversation: Omit<Conversation, 'createdAt' | 'updatedAt'>
+  ): Promise<void> {
+    const { db } = await getDrizzleClient();
+    await db
+      .insert(conversationsTable)
+      .values({
+        id: conversation.id,
+        taskId: conversation.taskId,
+        title: conversation.title,
+        provider: conversation.provider ?? null,
+        isActive: conversation.isActive ? 1 : 0,
+        isMain: conversation.isMain ? 1 : 0,
+        displayOrder: conversation.displayOrder ?? 0,
+        metadata: conversation.metadata ?? null,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .onConflictDoUpdate({
+        target: conversationsTable.id,
+        set: {
+          title: conversation.title,
+          provider: conversation.provider ?? null,
+          isActive: conversation.isActive ? 1 : 0,
+          isMain: conversation.isMain ? 1 : 0,
+          displayOrder: conversation.displayOrder ?? 0,
+          metadata: conversation.metadata ?? null,
+          updatedAt: sql`CURRENT_TIMESTAMP`,
+        },
+      });
+  }
+
+  async getConversations(taskId: string): Promise<Conversation[]> {
+    if (this.disabled) return [];
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select()
+      .from(conversationsTable)
+      .where(eq(conversationsTable.taskId, taskId))
+      .orderBy(asc(conversationsTable.displayOrder), desc(conversationsTable.updatedAt));
+    return rows.map((row) => this.mapDrizzleConversationRow(row));
+  }
+
+  async getOrCreateDefaultConversation(taskId: string, provider?: string): Promise<Conversation> {
+    if (this.disabled) {
+      return {
+        id: `conv-${taskId}-default`,
+        taskId,
+        title: 'Default Conversation',
+        provider: provider ?? null,
+        isMain: true,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    }
+    const { db } = await getDrizzleClient();
+
+    const existingRows = await db
+      .select()
+      .from(conversationsTable)
+      .where(eq(conversationsTable.taskId, taskId))
+      .orderBy(asc(conversationsTable.createdAt))
+      .limit(1);
+
+    if (existingRows.length > 0) {
+      const existing = existingRows[0];
+      // Backfill provider if it was previously saved as null
+      if (!existing.provider && provider) {
+        await db
+          .update(conversationsTable)
+          .set({ provider, updatedAt: sql`CURRENT_TIMESTAMP` })
+          .where(eq(conversationsTable.id, existing.id));
+        return this.mapDrizzleConversationRow({ ...existing, provider });
+      }
+      return this.mapDrizzleConversationRow(existing);
+    }
+
+    const conversationId = `conv-${taskId}-${Date.now()}`;
+    await this.saveConversation({
+      id: conversationId,
+      taskId,
+      title: 'Default Conversation',
+      provider: provider ?? null,
+      isMain: true,
+      isActive: true,
+    });
+
+    const [createdRow] = await db
+      .select()
+      .from(conversationsTable)
+      .where(eq(conversationsTable.id, conversationId))
+      .limit(1);
+
+    if (createdRow) {
+      return this.mapDrizzleConversationRow(createdRow);
+    }
+
+    return {
+      id: conversationId,
+      taskId,
+      title: 'Default Conversation',
+      provider: provider ?? null,
+      createdAt: new Date().toISOString(),
+      updatedAt: new Date().toISOString(),
+    };
+  }
+
+  // Message management methods
+  async saveMessage(message: Omit<Message, 'timestamp'>): Promise<void> {
+    if (this.disabled) return;
+    const metadataValue =
+      typeof message.metadata === 'string'
+        ? message.metadata
+        : message.metadata
+          ? JSON.stringify(message.metadata)
+          : null;
+    const { db } = await getDrizzleClient();
+    await db.transaction(async (tx) => {
+      await tx
+        .insert(messagesTable)
+        .values({
+          id: message.id,
+          conversationId: message.conversationId,
+          content: message.content,
+          sender: message.sender,
+          metadata: metadataValue,
+          timestamp: sql`CURRENT_TIMESTAMP`,
+        })
+        .onConflictDoNothing()
+        .run();
+
+      await tx
+        .update(conversationsTable)
+        .set({ updatedAt: sql`CURRENT_TIMESTAMP` })
+        .where(eq(conversationsTable.id, message.conversationId))
+        .run();
+    });
+  }
+
+  async getMessages(conversationId: string): Promise<Message[]> {
+    if (this.disabled) return [];
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select()
+      .from(messagesTable)
+      .where(eq(messagesTable.conversationId, conversationId))
+      .orderBy(asc(messagesTable.timestamp));
+    return rows.map((row) => this.mapDrizzleMessageRow(row));
+  }
+
+  async deleteConversation(conversationId: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db.delete(conversationsTable).where(eq(conversationsTable.id, conversationId));
+  }
+
+  // New multi-chat methods
+  async createConversation(
+    taskId: string,
+    title: string,
+    provider?: string,
+    isMain?: boolean,
+    metadata?: string | null
+  ): Promise<Conversation> {
+    if (this.disabled) {
+      return {
+        id: `conv-${taskId}-${Date.now()}`,
+        taskId,
+        title,
+        provider: provider ?? null,
+        isActive: true,
+        isMain: isMain ?? false,
+        displayOrder: 0,
+        metadata: null,
+        createdAt: new Date().toISOString(),
+        updatedAt: new Date().toISOString(),
+      };
+    }
+
+    const { db } = await getDrizzleClient();
+
+    // Get the next display order
+    const existingConversations = await db
+      .select()
+      .from(conversationsTable)
+      .where(eq(conversationsTable.taskId, taskId));
+
+    const maxOrder = Math.max(...existingConversations.map((c) => c.displayOrder || 0), -1);
+
+    // Check if this should be the main conversation
+    // If explicitly set as main, check if one already exists
+    if (isMain === true) {
+      const hasMain = existingConversations.some((c) => c.isMain === 1);
+      if (hasMain) {
+        isMain = false; // Don't allow multiple main conversations
+      }
+    } else if (isMain === undefined) {
+      // If not specified, make it main only if it's the first conversation
+      isMain = existingConversations.length === 0;
+    }
+
+    // Deactivate other conversations
+    await db
+      .update(conversationsTable)
+      .set({ isActive: 0 })
+      .where(eq(conversationsTable.taskId, taskId));
+
+    // Create the new conversation
+    const conversationId = `conv_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const newConversation = {
+      id: conversationId,
+      taskId,
+      title,
+      provider: provider ?? null,
+      isActive: true,
+      isMain: isMain ?? false,
+      displayOrder: maxOrder + 1,
+      metadata: metadata ?? null,
+    };
+
+    await this.saveConversation(newConversation);
+
+    // Fetch the created conversation
+    const [createdRow] = await db
+      .select()
+      .from(conversationsTable)
+      .where(eq(conversationsTable.id, conversationId))
+      .limit(1);
+
+    return this.mapDrizzleConversationRow(createdRow);
+  }
+
+  async setActiveConversation(taskId: string, conversationId: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+
+    await db.transaction(async (tx) => {
+      // Deactivate all conversations for this task
+      await tx
+        .update(conversationsTable)
+        .set({ isActive: 0 })
+        .where(eq(conversationsTable.taskId, taskId));
+
+      // Activate the selected one
+      await tx
+        .update(conversationsTable)
+        .set({ isActive: 1, updatedAt: sql`CURRENT_TIMESTAMP` })
+        .where(eq(conversationsTable.id, conversationId));
+    });
+  }
+
+  async getActiveConversation(taskId: string): Promise<Conversation | null> {
+    if (this.disabled) return null;
+    const { db } = await getDrizzleClient();
+
+    const results = await db
+      .select()
+      .from(conversationsTable)
+      .where(and(eq(conversationsTable.taskId, taskId), eq(conversationsTable.isActive, 1)))
+      .limit(1);
+
+    return results[0] ? this.mapDrizzleConversationRow(results[0]) : null;
+  }
+
+  async reorderConversations(taskId: string, conversationIds: string[]): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+
+    await db.transaction(async (tx) => {
+      for (let i = 0; i < conversationIds.length; i++) {
+        await tx
+          .update(conversationsTable)
+          .set({ displayOrder: i })
+          .where(eq(conversationsTable.id, conversationIds[i]));
+      }
+    });
+  }
+
+  async updateConversationTitle(conversationId: string, title: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+
+    await db
+      .update(conversationsTable)
+      .set({ title, updatedAt: sql`CURRENT_TIMESTAMP` })
+      .where(eq(conversationsTable.id, conversationId));
+  }
+
+  // SSH connection management methods
+  async saveSshConnection(
+    connection: Omit<SshConnectionInsert, 'id' | 'createdAt' | 'updatedAt'> & { id?: string }
+  ): Promise<SshConnectionRow> {
+    if (this.disabled) {
+      throw new Error('Database is disabled');
+    }
+    const { db } = await getDrizzleClient();
+
+    const id = connection.id ?? `ssh_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`;
+    const now = new Date().toISOString();
+
+    const result = await db
+      .insert(sshConnectionsTable)
+      .values({
+        ...connection,
+        id,
+        createdAt: now,
+        updatedAt: now,
+      })
+      .onConflictDoUpdate({
+        target: sshConnectionsTable.id,
+        set: {
+          name: connection.name,
+          host: connection.host,
+          port: connection.port,
+          username: connection.username,
+          authType: connection.authType,
+          privateKeyPath: connection.privateKeyPath ?? null,
+          useAgent: connection.useAgent,
+          updatedAt: now,
+        },
+      })
+      .returning();
+
+    return result[0];
+  }
+
+  async getSshConnections(): Promise<SshConnectionRow[]> {
+    if (this.disabled) return [];
+    const { db } = await getDrizzleClient();
+    return db.select().from(sshConnectionsTable).orderBy(sshConnectionsTable.name);
+  }
+
+  async getSshConnection(id: string): Promise<SshConnectionRow | null> {
+    if (this.disabled) return null;
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select()
+      .from(sshConnectionsTable)
+      .where(eq(sshConnectionsTable.id, id))
+      .limit(1);
+    return rows.length > 0 ? rows[0] : null;
+  }
+
+  async deleteSshConnection(id: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+
+    // First update any projects using this connection
+    await db
+      .update(projectsTable)
+      .set({ sshConnectionId: null, isRemote: 0 })
+      .where(eq(projectsTable.sshConnectionId, id));
+
+    // Then delete the connection
+    await db.delete(sshConnectionsTable).where(eq(sshConnectionsTable.id, id));
+  }
+
+  private computeBaseRef(
+    preferred?: string | null,
+    remote?: string | null,
+    branch?: string | null
+  ): string {
+    const remoteName = this.getRemoteAlias(remote);
+    const normalize = (value?: string | null): string | undefined => {
+      if (!value) return undefined;
+      const trimmed = value.trim();
+      if (!trimmed || trimmed.includes('://')) return undefined;
+
+      if (trimmed.includes('/')) {
+        const [head, ...rest] = trimmed.split('/');
+        const branchPart = rest.join('/').replace(/^\/+/, '');
+        if (head && branchPart) {
+          return `${head}/${branchPart}`;
+        }
+        if (!head && branchPart) {
+          // Leading slash - prepend remote if available
+          return remoteName ? `${remoteName}/${branchPart}` : branchPart;
+        }
+        return undefined;
+      }
+
+      // Plain branch name - prepend remote only if one exists
+      const suffix = trimmed.replace(/^\/+/, '');
+      return remoteName ? `${remoteName}/${suffix}` : suffix;
+    };
+
+    // Default: use origin/main if remote exists, otherwise just 'main'
+    const defaultBranch = remoteName
+      ? `${remoteName}/${this.defaultBranchName()}`
+      : this.defaultBranchName();
+    return normalize(preferred) ?? normalize(branch) ?? defaultBranch;
+  }
+
+  private defaultRemoteName(): string {
+    return 'origin';
+  }
+
+  private getRemoteAlias(remote?: string | null): string {
+    if (!remote) return this.defaultRemoteName();
+    const trimmed = remote.trim();
+    if (!trimmed) return ''; // Empty string indicates no remote (local-only repo)
+    if (/^[A-Za-z0-9._-]+$/.test(trimmed) && !trimmed.includes('://')) {
+      return trimmed;
+    }
+    return this.defaultRemoteName();
+  }
+
+  private defaultBranchName(): string {
+    return 'main';
+  }
+
+  private mapDrizzleProjectRow(row: ProjectRow): Project {
+    return {
+      id: row.id,
+      name: row.name,
+      path: row.path,
+      isRemote: row.isRemote === 1,
+      sshConnectionId: row.sshConnectionId ?? null,
+      remotePath: row.remotePath ?? null,
+      gitInfo: {
+        isGitRepo: !!(row.gitRemote || row.gitBranch),
+        remote: row.gitRemote ?? undefined,
+        branch: row.gitBranch ?? undefined,
+        baseRef: this.computeBaseRef(row.baseRef, row.gitRemote, row.gitBranch),
+      },
+      githubInfo: row.githubRepository
+        ? {
+            repository: row.githubRepository,
+            connected: !!row.githubConnected,
+          }
+        : undefined,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  private mapDrizzleTaskRow(row: TaskRow): Task {
+    return {
+      id: row.id,
+      projectId: row.projectId,
+      name: row.name,
+      branch: row.branch,
+      path: row.path,
+      status: (row.status as Task['status']) ?? 'idle',
+      agentId: row.agentId ?? null,
+      metadata:
+        typeof row.metadata === 'string' && row.metadata.length > 0
+          ? this.parseTaskMetadata(row.metadata, row.id)
+          : null,
+      useWorktree: row.useWorktree === 1,
+      archivedAt: row.archivedAt ?? null,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  private mapDrizzleConversationRow(row: ConversationRow): Conversation {
+    return {
+      id: row.id,
+      taskId: row.taskId,
+      title: row.title,
+      provider: row.provider ?? null,
+      isActive: row.isActive === 1,
+      // For backward compatibility: treat missing isMain as true (assume first/only conversation is main)
+      isMain: row.isMain !== undefined ? row.isMain === 1 : true,
+      displayOrder: row.displayOrder ?? 0,
+      metadata: row.metadata ?? null,
+      createdAt: row.createdAt,
+      updatedAt: row.updatedAt,
+    };
+  }
+
+  private mapDrizzleMessageRow(row: MessageRow): Message {
+    return {
+      id: row.id,
+      conversationId: row.conversationId,
+      content: row.content,
+      sender: row.sender as Message['sender'],
+      timestamp: row.timestamp,
+      metadata: row.metadata ?? undefined,
+    };
+  }
+
+  private parseTaskMetadata(serialized: string, taskId: string): any {
+    try {
+      return JSON.parse(serialized);
+    } catch (error) {
+      console.warn(`Failed to parse task metadata for ${taskId}`, error);
+      return null;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.disabled || !this.db) return;
+
+    return new Promise((resolve, reject) => {
+      this.db!.close((err) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+
+  private async ensureMigrations(): Promise<void> {
+    if (this.disabled) return;
+    if (!this.db) throw new Error('Database not initialized');
+    if (DatabaseService.migrationsApplied) return;
+
+    const migrationsPath = resolveMigrationsPath();
+    if (!migrationsPath) {
+      // Provide a detailed error message for debugging
+      const errorMsg = [
+        'Failed to locate database migrations folder.',
+        'This can happen when:',
+        '1. The app was installed via Homebrew (try downloading directly from GitHub)',
+        '2. The app is running from Downloads/DMG (move it to Applications)',
+        '3. The installation is incomplete or corrupted',
+        '4. Security software is blocking file access',
+        '',
+        'To fix: Try downloading and installing Emdash directly from:',
+        'https://github.com/generalaction/emdash/releases',
+        '',
+      ].join('\n');
+
+      throw new Error(errorMsg);
+    }
+
+    // We run schema migrations with foreign_keys disabled.
+    // Many dev DBs were created with foreign_keys=OFF, so legacy data can contain orphans.
+    // Enabling FK enforcement mid-migration can cause schema transitions (table rebuilds) to fail.
+    await this.execSql('PRAGMA foreign_keys=OFF;');
+    try {
+      // IMPORTANT:
+      // Drizzle's built-in migrator for sqlite-proxy decides what to run based on the latest
+      // `created_at` timestamp in __drizzle_migrations. If a migration is added later but has an
+      // earlier timestamp than the latest applied migration, Drizzle will skip it forever.
+      //
+      // To make migrations robust for dev DBs (and for any DB that may have extra migrations),
+      // we apply migrations by missing hash instead of timestamp ordering.
+      const migrations = readMigrationFiles({ migrationsFolder: migrationsPath });
+      const tagByWhen = await this.tryLoadMigrationTagByWhen(migrationsPath);
+
+      await this.execSql(`
+        CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
+          id SERIAL PRIMARY KEY,
+          hash text NOT NULL,
+          created_at numeric
+        )
+      `);
+
+      const appliedRows = await this.allSql<{ hash: string }>(
+        `SELECT hash FROM "__drizzle_migrations"`
+      );
+      const applied = new Set(appliedRows.map((r) => r.hash));
+
+      // Recovery: if a previous run partially applied the workspace->task migration, finish it.
+      // Symptom: `tasks` exists, `conversations` still has `workspace_id`, and `__new_conversations` exists.
+      let recovered = false;
+      if (
+        (await this.tableExists('tasks')) &&
+        (await this.tableExists('conversations')) &&
+        (await this.tableExists('__new_conversations')) &&
+        (await this.tableHasColumn('conversations', 'workspace_id')) &&
+        !(await this.tableHasColumn('conversations', 'task_id'))
+      ) {
+        // Populate new conversations table from the old one (FK enforcement is OFF, so orphans won't block)
+        await this.execSql(`
+          INSERT INTO "__new_conversations"("id", "task_id", "title", "created_at", "updated_at")
+          SELECT "id", "workspace_id", "title", "created_at", "updated_at" FROM "conversations"
+        `);
+        await this.execSql(`DROP TABLE "conversations";`);
+        await this.execSql(`ALTER TABLE "__new_conversations" RENAME TO "conversations";`);
+        await this.execSql(
+          `CREATE INDEX IF NOT EXISTS "idx_conversations_task_id" ON "conversations" ("task_id");`
+        );
+
+        // Mark the workspace->task migration as applied (even if it wasn't tracked).
+        // This prevents the hash-based runner from attempting to re-run it against a partially-migrated DB.
+        await this.ensureMigrationMarkedApplied(
+          migrationsPath,
+          applied,
+          '0002_lyrical_impossible_man'
+        );
+        recovered = true;
+      }
+
+      let appliedCount = 0;
+      for (const migration of migrations) {
+        if (applied.has(migration.hash)) continue;
+
+        const tag = tagByWhen?.get(migration.folderMillis);
+        // If the DB already reflects the workspace->task rename (e.g. user manually fixed their DB)
+        // but the migration hash wasn't recorded, mark it as applied and move on.
+        if (
+          tag === '0002_lyrical_impossible_man' &&
+          (await this.tableExists('tasks')) &&
+          !(await this.tableExists('workspaces')) &&
+          (await this.tableExists('conversations')) &&
+          (await this.tableHasColumn('conversations', 'task_id'))
+        ) {
+          await this.execSql(
+            `INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES('${migration.hash}', '${migration.folderMillis}')`
+          );
+          applied.add(migration.hash);
+          continue;
+        }
+
+        // Execute each statement chunk (drizzle-kit uses '--> statement-breakpoint')
+        for (const statement of migration.sql) {
+          // We manage FK enforcement ourselves during migrations.
+          const trimmed = statement.trim().toUpperCase();
+          if (trimmed.startsWith('PRAGMA FOREIGN_KEYS=')) continue;
+          await this.execSql(statement);
+        }
+
+        // Record as applied (same schema as Drizzle uses)
+        await this.execSql(
+          `INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES('${migration.hash}', '${migration.folderMillis}')`
+        );
+
+        applied.add(migration.hash);
+        appliedCount += 1;
+      }
+
+      this.lastMigrationSummary = {
+        appliedCount,
+        totalMigrations: migrations.length,
+        recovered,
+      };
+
+      DatabaseService.migrationsApplied = true;
+    } finally {
+      // Restore FK enforcement for normal operation (and ensure it's re-enabled on failure).
+      await this.execSql('PRAGMA foreign_keys=ON;');
+    }
+  }
+
+  private async validateSchemaContract(): Promise<void> {
+    if (this.disabled) return;
+
+    const missingInvariants: string[] = [];
+
+    if (!(await this.tableHasColumn('projects', 'base_ref'))) {
+      missingInvariants.push('projects.base_ref');
+    }
+    if (!(await this.tableExists('tasks'))) {
+      missingInvariants.push('tasks table');
+    }
+    if (!(await this.tableHasColumn('conversations', 'task_id'))) {
+      missingInvariants.push('conversations.task_id');
+    }
+
+    if (missingInvariants.length > 0) {
+      throw new DatabaseSchemaMismatchError(this.dbPath, missingInvariants);
+    }
+  }
+
+  private async tryLoadMigrationTagByWhen(
+    migrationsFolder: string
+  ): Promise<Map<number, string> | null> {
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const fs = require('node:fs');
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const path = require('node:path');
+      const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
+      if (!fs.existsSync(journalPath)) return null;
+      const parsed: unknown = JSON.parse(fs.readFileSync(journalPath, 'utf8'));
+      if (!parsed || typeof parsed !== 'object') return null;
+      const entries = (parsed as { entries?: unknown }).entries;
+      if (!Array.isArray(entries)) return null;
+
+      const map = new Map<number, string>();
+      for (const e of entries) {
+        if (!e || typeof e !== 'object') continue;
+        const when = (e as { when?: unknown }).when;
+        const tag = (e as { tag?: unknown }).tag;
+        if (typeof when === 'number' && typeof tag === 'string') {
+          map.set(when, tag);
+        }
+      }
+      return map;
+    } catch {
+      return null;
+    }
+  }
+
+  private async ensureMigrationMarkedApplied(
+    migrationsFolder: string,
+    applied: Set<string>,
+    tag: string
+  ): Promise<void> {
+    // Only mark if the SQL file + journal entry exist.
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const fs = require('node:fs');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const path = require('node:path');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const crypto = require('node:crypto');
+
+    const journalPath = path.join(migrationsFolder, 'meta', '_journal.json');
+    if (!fs.existsSync(journalPath)) return;
+    const journalParsed: unknown = JSON.parse(fs.readFileSync(journalPath, 'utf8'));
+    const entries = (journalParsed as { entries?: unknown }).entries;
+    if (!Array.isArray(entries)) return;
+    const entry = entries.find((e) => {
+      if (!e || typeof e !== 'object') return false;
+      return (e as { tag?: unknown }).tag === tag;
+    }) as { when?: unknown } | undefined;
+    if (!entry) return;
+
+    const sqlPath = path.join(migrationsFolder, `${tag}.sql`);
+    if (!fs.existsSync(sqlPath)) return;
+    const contents = fs.readFileSync(sqlPath, 'utf8');
+    const hash = crypto.createHash('sha256').update(contents).digest('hex');
+
+    if (applied.has(hash)) return;
+    const createdAt = typeof entry.when === 'number' ? entry.when : Date.now();
+    await this.execSql(
+      `INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES('${hash}', '${createdAt}')`
+    );
+    applied.add(hash);
+  }
+
+  private async tableExists(name: string): Promise<boolean> {
+    const rows = await this.allSql<{ name: string }>(
+      `SELECT name FROM sqlite_master WHERE type='table' AND name='${name.replace(/'/g, "''")}' LIMIT 1`
+    );
+    return rows.length > 0;
+  }
+
+  private async tableHasColumn(tableName: string, columnName: string): Promise<boolean> {
+    if (!(await this.tableExists(tableName))) return false;
+    const rows = await this.allSql<{ name: string }>(
+      `PRAGMA table_info("${tableName.replace(/"/g, '""')}")`
+    );
+    return rows.some((r) => r.name === columnName);
+  }
+
+  private async allSql<T = any>(query: string): Promise<T[]> {
+    if (!this.db) throw new Error('Database not initialized');
+    const trimmed = query.trim();
+    if (!trimmed) return [];
+
+    return await new Promise<T[]>((resolve, reject) => {
+      this.db!.all(trimmed, (err, rows) => {
+        if (err) {
+          reject(err);
+        } else {
+          resolve((rows ?? []) as T[]);
+        }
+      });
+    });
+  }
+
+  private async execSql(statement: string): Promise<void> {
+    if (!this.db) throw new Error('Database not initialized');
+    const trimmed = statement.trim();
+    if (!trimmed) return;
+
+    await new Promise<void>((resolve, reject) => {
+      this.db!.exec(trimmed, (err) => {
+        if (err) {
+          // Handle idempotent migration cases - skip if schema already matches
+          const msg = err.message ?? '';
+          if (msg.includes('duplicate column name') || msg.includes('already exists')) {
+            // Schema change already applied, continue
+            resolve();
+            return;
+          }
+          reject(err);
+        } else {
+          resolve();
+        }
+      });
+    });
+  }
+}
+
+export const databaseService = new DatabaseService();

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -203,6 +203,17 @@ export class DatabaseService {
       .limit(1);
     const existingById = existingByIdRows[0] ?? null;
 
+    // For remote projects, check for exact duplicate (same path + same sshConnectionId).
+    // This allows same path on different hosts but prevents true duplicates.
+    // For local projects, path uniqueness is preserved.
+    const isNewRemote = project.isRemote && !!project.sshConnectionId;
+    const pathCondition = isNewRemote
+      ? and(
+          eq(projectsTable.path, project.path),
+          eq(projectsTable.sshConnectionId, project.sshConnectionId!)
+        )
+      : eq(projectsTable.path, project.path);
+
     const existingByPathRows = await db
       .select({
         id: projectsTable.id,
@@ -212,25 +223,16 @@ export class DatabaseService {
         isRemote: projectsTable.isRemote,
       })
       .from(projectsTable)
-      .where(eq(projectsTable.path, project.path))
+      .where(pathCondition)
       .limit(1);
     const existingByPath = existingByPathRows[0] ?? null;
 
     if (existingByPath && existingByPath.id !== project.id) {
-      // For remote projects, allow the same path if sshConnectionId is different
-      const isNewProjectRemote = project.isRemote && project.sshConnectionId;
-      const isExistingProjectRemote =
-        existingByPath.isRemote === 1 && existingByPath.sshConnectionId;
-      const sameSshConnection =
-        project.sshConnectionId && existingByPath.sshConnectionId === project.sshConnectionId;
-
-      if (!isNewProjectRemote || !isExistingProjectRemote || sameSshConnection) {
-        throw new ProjectConflictError({
-          existingProjectId: existingByPath.id,
-          existingProjectName: existingByPath.name,
-          projectPath: existingByPath.path,
-        });
-      }
+      throw new ProjectConflictError({
+        existingProjectId: existingByPath.id,
+        existingProjectName: existingByPath.name,
+        projectPath: existingByPath.path,
+      });
     }
 
     const values = {

--- a/src/main/services/worktreeIpc.ts
+++ b/src/main/services/worktreeIpc.ts
@@ -1,0 +1,499 @@
+import { ipcMain } from 'electron';
+import { worktreeService } from './WorktreeService';
+import { worktreePoolService } from './WorktreePoolService';
+import { databaseService, type Project } from './DatabaseService';
+import { getDrizzleClient } from '../db/drizzleClient';
+import { projects as projectsTable } from '../db/schema';
+import { eq } from 'drizzle-orm';
+import crypto from 'crypto';
+import { RemoteGitService } from './RemoteGitService';
+import { sshService } from './ssh/SshService';
+import { log } from '../lib/logger';
+import { quoteShellArg } from '../utils/shellEscape';
+import {
+  isRemoteProject,
+  resolveRemoteProjectForWorktreePath,
+} from '../utils/remoteProjectResolver';
+
+const remoteGitService = new RemoteGitService(sshService);
+
+function stableIdFromRemotePath(worktreePath: string): string {
+  const h = crypto.createHash('sha1').update(worktreePath).digest('hex').slice(0, 12);
+  return `wt-${h}`;
+}
+
+async function resolveProjectByIdOrPath(args: {
+  projectId?: string;
+  projectPath?: string;
+}): Promise<Project | null> {
+  if (args.projectId) {
+    return databaseService.getProjectById(args.projectId);
+  }
+  if (args.projectPath) {
+    const { db } = await getDrizzleClient();
+    const rows = await db
+      .select({ id: projectsTable.id })
+      .from(projectsTable)
+      .where(eq(projectsTable.path, args.projectPath))
+      .limit(1);
+    if (rows.length > 0) {
+      return databaseService.getProjectById(rows[0].id);
+    }
+  }
+  return null;
+}
+
+// isRemoteProject and resolveRemoteProjectForWorktreePath imported from ../utils/remoteProjectResolver
+
+export function registerWorktreeIpc(): void {
+  // Create a new worktree
+  ipcMain.handle(
+    'worktree:create',
+    async (
+      event,
+      args: {
+        projectPath: string;
+        taskName: string;
+        projectId: string;
+        baseRef?: string;
+      }
+    ) => {
+      try {
+        const project = await resolveProjectByIdOrPath({
+          projectId: args.projectId,
+          projectPath: args.projectPath,
+        });
+
+        if (isRemoteProject(project)) {
+          const baseRef = args.baseRef ?? project.gitInfo.baseRef;
+          log.info('worktree:create (remote)', {
+            projectId: project.id,
+            remotePath: project.remotePath,
+          });
+          const remote = await remoteGitService.createWorktree(
+            project.sshConnectionId,
+            project.remotePath,
+            args.taskName,
+            baseRef
+          );
+          const worktree = {
+            id: stableIdFromRemotePath(remote.path),
+            name: args.taskName,
+            branch: remote.branch,
+            path: remote.path,
+            projectId: project.id,
+            status: 'active' as const,
+            createdAt: new Date().toISOString(),
+          };
+          return { success: true, worktree };
+        }
+
+        const worktree = await worktreeService.createWorktree(
+          args.projectPath,
+          args.taskName,
+          args.projectId,
+          args.baseRef
+        );
+        return { success: true, worktree };
+      } catch (error) {
+        console.error('Failed to create worktree:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // List worktrees for a project
+  ipcMain.handle(
+    'worktree:list',
+    async (event, args: { projectPath: string; sshConnectionId?: string }) => {
+      try {
+        let project: Project | null = null;
+        if (args.sshConnectionId) {
+          project = await resolveRemoteProjectForWorktreePath(
+            args.projectPath,
+            args.sshConnectionId
+          );
+        }
+        if (!project) {
+          project = await resolveProjectByIdOrPath({ projectPath: args.projectPath });
+        }
+        if (isRemoteProject(project)) {
+          const remoteWorktrees = await remoteGitService.listWorktrees(
+            project.sshConnectionId,
+            project.remotePath
+          );
+          const worktrees = remoteWorktrees.map((wt) => {
+            const name = wt.path.split('/').filter(Boolean).pop() || wt.path;
+            return {
+              id: stableIdFromRemotePath(wt.path),
+              name,
+              branch: wt.branch,
+              path: wt.path,
+              projectId: project.id,
+              status: 'active' as const,
+              createdAt: new Date().toISOString(),
+            };
+          });
+          return { success: true, worktrees };
+        }
+
+        const worktrees = await worktreeService.listWorktrees(args.projectPath);
+        return { success: true, worktrees };
+      } catch (error) {
+        console.error('Failed to list worktrees:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // Remove a worktree
+  ipcMain.handle(
+    'worktree:remove',
+    async (
+      event,
+      args: {
+        projectPath: string;
+        worktreeId: string;
+        worktreePath?: string;
+        branch?: string;
+        sshConnectionId?: string;
+      }
+    ) => {
+      try {
+        // Prefer sshConnectionId for disambiguation when multiple remotes share the same path
+        let project: Project | null = null;
+        if (args.sshConnectionId) {
+          project = await resolveRemoteProjectForWorktreePath(
+            args.projectPath,
+            args.sshConnectionId
+          );
+        }
+        if (!project) {
+          project = await resolveProjectByIdOrPath({ projectPath: args.projectPath });
+        }
+        if (isRemoteProject(project)) {
+          const pathToRemove = args.worktreePath;
+          if (!pathToRemove) {
+            throw new Error('worktreePath is required for remote worktree removal');
+          }
+          log.info('worktree:remove (remote)', {
+            projectId: project.id,
+            remotePath: project.remotePath,
+            worktreePath: pathToRemove,
+          });
+          await remoteGitService.removeWorktree(
+            project.sshConnectionId,
+            project.remotePath,
+            pathToRemove
+          );
+          // Best-effort prune to clear stale metadata.
+          try {
+            await sshService.executeCommand(
+              project.sshConnectionId,
+              'git worktree prune --verbose',
+              project.remotePath
+            );
+          } catch {}
+          if (args.branch) {
+            try {
+              await sshService.executeCommand(
+                project.sshConnectionId,
+                `git branch -D ${quoteShellArg(args.branch)}`,
+                project.remotePath
+              );
+            } catch {}
+          }
+          return { success: true };
+        }
+
+        await worktreeService.removeWorktree(
+          args.projectPath,
+          args.worktreeId,
+          args.worktreePath,
+          args.branch
+        );
+        return { success: true };
+      } catch (error) {
+        console.error('Failed to remove worktree:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // Get worktree status
+  ipcMain.handle('worktree:status', async (event, args: { worktreePath: string }) => {
+    try {
+      const remoteProject = await resolveRemoteProjectForWorktreePath(args.worktreePath);
+      if (remoteProject) {
+        const status = await remoteGitService.getWorktreeStatus(
+          remoteProject.sshConnectionId,
+          args.worktreePath
+        );
+        return { success: true, status };
+      }
+
+      const status = await worktreeService.getWorktreeStatus(args.worktreePath);
+      return { success: true, status };
+    } catch (error) {
+      console.error('Failed to get worktree status:', error);
+      return { success: false, error: (error as Error).message };
+    }
+  });
+
+  // Merge worktree changes
+  ipcMain.handle(
+    'worktree:merge',
+    async (
+      event,
+      args: {
+        projectPath: string;
+        worktreeId: string;
+      }
+    ) => {
+      try {
+        const project = await resolveProjectByIdOrPath({ projectPath: args.projectPath });
+        if (isRemoteProject(project)) {
+          return { success: false, error: 'Remote worktree merge is not supported yet' };
+        }
+        await worktreeService.mergeWorktreeChanges(args.projectPath, args.worktreeId);
+        return { success: true };
+      } catch (error) {
+        console.error('Failed to merge worktree changes:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // Get worktree by ID
+  ipcMain.handle('worktree:get', async (event, args: { worktreeId: string }) => {
+    try {
+      const worktree = worktreeService.getWorktree(args.worktreeId);
+      return { success: true, worktree };
+    } catch (error) {
+      console.error('Failed to get worktree:', error);
+      return { success: false, error: (error as Error).message };
+    }
+  });
+
+  // Get all worktrees
+  ipcMain.handle('worktree:getAll', async () => {
+    try {
+      const worktrees = worktreeService.getAllWorktrees();
+      return { success: true, worktrees };
+    } catch (error) {
+      console.error('Failed to get all worktrees:', error);
+      return { success: false, error: (error as Error).message };
+    }
+  });
+
+  // Ensure a reserve worktree exists for a project (background operation)
+  ipcMain.handle(
+    'worktree:ensureReserve',
+    async (
+      event,
+      args: {
+        projectId: string;
+        projectPath: string;
+        baseRef?: string;
+      }
+    ) => {
+      try {
+        const project = await resolveProjectByIdOrPath({
+          projectId: args.projectId,
+          projectPath: args.projectPath,
+        });
+        if (isRemoteProject(project)) {
+          // Remote worktree pooling is not supported (avoid local mkdir on remote paths).
+          return { success: true };
+        }
+        // Fire and forget - don't await, just start the process
+        worktreePoolService.ensureReserve(args.projectId, args.projectPath, args.baseRef);
+        return { success: true };
+      } catch (error) {
+        console.error('Failed to ensure reserve:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // Preflight freshness check — called when create-task UI opens so the
+  // ls-remote cost is hidden behind user interaction time.
+  ipcMain.handle(
+    'worktree:preflightReserve',
+    async (
+      event,
+      args: {
+        projectId: string;
+        projectPath: string;
+      }
+    ) => {
+      try {
+        const project = await resolveProjectByIdOrPath({
+          projectId: args.projectId,
+          projectPath: args.projectPath,
+        });
+        if (isRemoteProject(project)) {
+          return { success: true };
+        }
+        await worktreePoolService.preflightCheck(args.projectId, args.projectPath);
+        return { success: true };
+      } catch (error) {
+        console.error('Failed to preflight reserve:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // Check if a reserve is available for a project
+  ipcMain.handle('worktree:hasReserve', async (event, args: { projectId: string }) => {
+    try {
+      const project = await resolveProjectByIdOrPath({ projectId: args.projectId });
+      if (isRemoteProject(project)) {
+        return { success: true, hasReserve: false };
+      }
+      const hasReserve = worktreePoolService.hasReserve(args.projectId);
+      return { success: true, hasReserve };
+    } catch (error) {
+      console.error('Failed to check reserve:', error);
+      return { success: false, error: (error as Error).message };
+    }
+  });
+
+  // Claim a reserve worktree for a new task (instant operation)
+  ipcMain.handle(
+    'worktree:claimReserve',
+    async (
+      event,
+      args: {
+        projectId: string;
+        projectPath: string;
+        taskName: string;
+        baseRef?: string;
+      }
+    ) => {
+      try {
+        const project = await resolveProjectByIdOrPath({
+          projectId: args.projectId,
+          projectPath: args.projectPath,
+        });
+        if (isRemoteProject(project)) {
+          return { success: false, error: 'Remote worktree pooling is not supported yet' };
+        }
+        const result = await worktreePoolService.claimReserve(
+          args.projectId,
+          args.projectPath,
+          args.taskName,
+          args.baseRef
+        );
+        if (result) {
+          return {
+            success: true,
+            worktree: result.worktree,
+            needsBaseRefSwitch: result.needsBaseRefSwitch,
+          };
+        }
+        return { success: false, error: 'No reserve available' };
+      } catch (error) {
+        console.error('Failed to claim reserve:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // Claim a reserve and persist the task in one IPC round-trip.
+  ipcMain.handle(
+    'worktree:claimReserveAndSaveTask',
+    async (
+      event,
+      args: {
+        projectId: string;
+        projectPath: string;
+        taskName: string;
+        baseRef?: string;
+        task: {
+          projectId: string;
+          name: string;
+          status: 'active' | 'idle' | 'running';
+          agentId?: string | null;
+          metadata?: any;
+          useWorktree?: boolean;
+        };
+      }
+    ) => {
+      try {
+        const project = await resolveProjectByIdOrPath({
+          projectId: args.projectId,
+          projectPath: args.projectPath,
+        });
+        if (isRemoteProject(project)) {
+          return { success: false, error: 'Remote worktree pooling is not supported yet' };
+        }
+
+        const claim = await worktreePoolService.claimReserve(
+          args.projectId,
+          args.projectPath,
+          args.taskName,
+          args.baseRef
+        );
+        if (!claim) {
+          return { success: false, error: 'No reserve available' };
+        }
+
+        const persistedTask = {
+          id: claim.worktree.id,
+          projectId: args.projectId,
+          name: args.taskName,
+          branch: claim.worktree.branch,
+          path: claim.worktree.path,
+          status: args.task.status,
+          agentId: args.task.agentId ?? null,
+          metadata: args.task.metadata ?? null,
+          useWorktree: args.task.useWorktree !== false,
+        };
+
+        await databaseService.saveTask(persistedTask);
+
+        return {
+          success: true,
+          worktree: claim.worktree,
+          task: persistedTask,
+          needsBaseRefSwitch: claim.needsBaseRefSwitch,
+        };
+      } catch (error) {
+        console.error('Failed to claim reserve and save task:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+
+  // Remove reserve for a project (cleanup)
+  ipcMain.handle(
+    'worktree:removeReserve',
+    async (event, args: { projectId: string; projectPath?: string; isRemote?: boolean }) => {
+      try {
+        if (args.isRemote) {
+          return { success: true };
+        }
+
+        let projectPath = args.projectPath;
+        if (!projectPath) {
+          const project = await resolveProjectByIdOrPath({ projectId: args.projectId });
+          if (!project) {
+            await worktreePoolService.removeReserve(args.projectId);
+            return { success: true };
+          }
+          if (isRemoteProject(project)) {
+            return { success: true };
+          }
+          projectPath = project.path;
+        }
+
+        await worktreePoolService.removeReserve(args.projectId, projectPath);
+        return { success: true };
+      } catch (error) {
+        console.error('Failed to remove reserve:', error);
+        return { success: false, error: (error as Error).message };
+      }
+    }
+  );
+}

--- a/src/main/services/worktreeIpc.ts
+++ b/src/main/services/worktreeIpc.ts
@@ -1,19 +1,20 @@
+import crypto from 'crypto';
+import { eq } from 'drizzle-orm';
 import { ipcMain } from 'electron';
-import { worktreeService } from './WorktreeService';
-import { worktreePoolService } from './WorktreePoolService';
-import { databaseService, type Project } from './DatabaseService';
+import type { ProjectPathLocator, WorktreePathLocator } from '../../shared/ipc/remoteLocator';
 import { getDrizzleClient } from '../db/drizzleClient';
 import { projects as projectsTable } from '../db/schema';
-import { eq } from 'drizzle-orm';
-import crypto from 'crypto';
-import { RemoteGitService } from './RemoteGitService';
-import { sshService } from './ssh/SshService';
 import { log } from '../lib/logger';
-import { quoteShellArg } from '../utils/shellEscape';
 import {
   isRemoteProject,
   resolveRemoteProjectForWorktreePath,
 } from '../utils/remoteProjectResolver';
+import { quoteShellArg } from '../utils/shellEscape';
+import { databaseService, type Project } from './DatabaseService';
+import { RemoteGitService } from './RemoteGitService';
+import { sshService } from './ssh/SshService';
+import { worktreePoolService } from './WorktreePoolService';
+import { worktreeService } from './WorktreeService';
 
 const remoteGitService = new RemoteGitService(sshService);
 
@@ -41,6 +42,23 @@ async function resolveProjectByIdOrPath(args: {
     }
   }
   return null;
+}
+
+async function resolveProjectForPathLocator(args: ProjectPathLocator): Promise<Project | null> {
+  if (args.sshConnectionId) {
+    const remoteProject = await resolveRemoteProjectForWorktreePath(
+      args.projectPath,
+      args.sshConnectionId
+    );
+    if (remoteProject) {
+      return remoteProject;
+    }
+  }
+
+  return resolveProjectByIdOrPath({
+    projectId: args.projectId,
+    projectPath: args.projectPath,
+  });
 }
 
 // isRemoteProject and resolveRemoteProjectForWorktreePath imported from ../utils/remoteProjectResolver
@@ -103,48 +121,36 @@ export function registerWorktreeIpc(): void {
   );
 
   // List worktrees for a project
-  ipcMain.handle(
-    'worktree:list',
-    async (event, args: { projectPath: string; sshConnectionId?: string }) => {
-      try {
-        let project: Project | null = null;
-        if (args.sshConnectionId) {
-          project = await resolveRemoteProjectForWorktreePath(
-            args.projectPath,
-            args.sshConnectionId
-          );
-        }
-        if (!project) {
-          project = await resolveProjectByIdOrPath({ projectPath: args.projectPath });
-        }
-        if (isRemoteProject(project)) {
-          const remoteWorktrees = await remoteGitService.listWorktrees(
-            project.sshConnectionId,
-            project.remotePath
-          );
-          const worktrees = remoteWorktrees.map((wt) => {
-            const name = wt.path.split('/').filter(Boolean).pop() || wt.path;
-            return {
-              id: stableIdFromRemotePath(wt.path),
-              name,
-              branch: wt.branch,
-              path: wt.path,
-              projectId: project.id,
-              status: 'active' as const,
-              createdAt: new Date().toISOString(),
-            };
-          });
-          return { success: true, worktrees };
-        }
-
-        const worktrees = await worktreeService.listWorktrees(args.projectPath);
+  ipcMain.handle('worktree:list', async (event, args: ProjectPathLocator) => {
+    try {
+      const project = await resolveProjectForPathLocator(args);
+      if (isRemoteProject(project)) {
+        const remoteWorktrees = await remoteGitService.listWorktrees(
+          project.sshConnectionId,
+          project.remotePath
+        );
+        const worktrees = remoteWorktrees.map((wt) => {
+          const name = wt.path.split('/').filter(Boolean).pop() || wt.path;
+          return {
+            id: stableIdFromRemotePath(wt.path),
+            name,
+            branch: wt.branch,
+            path: wt.path,
+            projectId: project.id,
+            status: 'active' as const,
+            createdAt: new Date().toISOString(),
+          };
+        });
         return { success: true, worktrees };
-      } catch (error) {
-        console.error('Failed to list worktrees:', error);
-        return { success: false, error: (error as Error).message };
       }
+
+      const worktrees = await worktreeService.listWorktrees(args.projectPath);
+      return { success: true, worktrees };
+    } catch (error) {
+      console.error('Failed to list worktrees:', error);
+      return { success: false, error: (error as Error).message };
     }
-  );
+  });
 
   // Remove a worktree
   ipcMain.handle(
@@ -157,20 +163,11 @@ export function registerWorktreeIpc(): void {
         worktreePath?: string;
         branch?: string;
         sshConnectionId?: string;
+        projectId?: string;
       }
     ) => {
       try {
-        // Prefer sshConnectionId for disambiguation when multiple remotes share the same path
-        let project: Project | null = null;
-        if (args.sshConnectionId) {
-          project = await resolveRemoteProjectForWorktreePath(
-            args.projectPath,
-            args.sshConnectionId
-          );
-        }
-        if (!project) {
-          project = await resolveProjectByIdOrPath({ projectPath: args.projectPath });
-        }
+        const project = await resolveProjectForPathLocator(args);
         if (isRemoteProject(project)) {
           const pathToRemove = args.worktreePath;
           if (!pathToRemove) {
@@ -221,9 +218,12 @@ export function registerWorktreeIpc(): void {
   );
 
   // Get worktree status
-  ipcMain.handle('worktree:status', async (event, args: { worktreePath: string }) => {
+  ipcMain.handle('worktree:status', async (event, args: WorktreePathLocator) => {
     try {
-      const remoteProject = await resolveRemoteProjectForWorktreePath(args.worktreePath);
+      const remoteProject = await resolveRemoteProjectForWorktreePath(
+        args.worktreePath,
+        args.sshConnectionId
+      );
       if (remoteProject) {
         const status = await remoteGitService.getWorktreeStatus(
           remoteProject.sshConnectionId,

--- a/src/main/utils/remoteProjectResolver.ts
+++ b/src/main/utils/remoteProjectResolver.ts
@@ -1,0 +1,66 @@
+import { databaseService, type Project } from '../services/DatabaseService';
+import { workspaceProviderService } from '../services/WorkspaceProviderService';
+
+export type RemoteProject = Project & { sshConnectionId: string; remotePath: string };
+
+export function isRemoteProject(project: Project | null): project is RemoteProject {
+  return !!(
+    project &&
+    project.isRemote &&
+    typeof project.sshConnectionId === 'string' &&
+    project.sshConnectionId.length > 0 &&
+    typeof project.remotePath === 'string' &&
+    project.remotePath.length > 0
+  );
+}
+
+export interface RemoteContext {
+  connectionId: string;
+  remotePath: string;
+}
+
+export async function resolveRemoteContext(
+  worktreePath: string,
+  taskId?: string
+): Promise<RemoteContext | null> {
+  // Check workspace instances by taskId first
+  if (taskId) {
+    const instance = await workspaceProviderService.getActiveInstance(taskId);
+    if (instance?.connectionId && instance?.worktreePath) {
+      return { connectionId: instance.connectionId, remotePath: instance.worktreePath };
+    }
+  }
+  // Fall back to existing project-based SSH matching
+  const project = await resolveRemoteProjectForWorktreePath(worktreePath);
+  if (project) {
+    return { connectionId: project.sshConnectionId, remotePath: worktreePath };
+  }
+  return null;
+}
+
+export async function resolveRemoteProjectForWorktreePath(
+  worktreePath: string,
+  sshConnectionId?: string
+): Promise<RemoteProject | null> {
+  const all = await databaseService.getProjects();
+  // Pick the longest matching remotePath prefix.
+  const candidates = all
+    .filter((p) => isRemoteProject(p))
+    .filter((p) => worktreePath.startsWith(p.remotePath.replace(/\/+$/g, '') + '/'))
+    .filter((p) => !sshConnectionId || p.sshConnectionId === sshConnectionId)
+    .sort((a, b) => b.remotePath.length - a.remotePath.length);
+
+  if (candidates.length === 0) {
+    return null;
+  }
+
+  if (candidates.length === 1) {
+    return candidates[0]!;
+  }
+
+  // Multiple candidates found but no sshConnectionId provided to disambiguate
+  throw new Error(
+    `Multiple remote projects match path "${worktreePath}" but no sshConnectionId was provided to disambiguate. ` +
+      `Matching projects: ${candidates.map((p) => `${p.remotePath} (${p.sshConnectionId})`).join(', ')}`
+  );
+}

--- a/src/main/utils/remoteProjectResolver.ts
+++ b/src/main/utils/remoteProjectResolver.ts
@@ -1,3 +1,4 @@
+import type { RemoteLocator } from '../../shared/ipc/remoteLocator';
 import { databaseService, type Project } from '../services/DatabaseService';
 import { workspaceProviderService } from '../services/WorkspaceProviderService';
 
@@ -21,17 +22,17 @@ export interface RemoteContext {
 
 export async function resolveRemoteContext(
   worktreePath: string,
-  taskId?: string
+  locator?: Pick<RemoteLocator, 'taskId' | 'sshConnectionId'>
 ): Promise<RemoteContext | null> {
   // Check workspace instances by taskId first
-  if (taskId) {
-    const instance = await workspaceProviderService.getActiveInstance(taskId);
+  if (locator?.taskId) {
+    const instance = await workspaceProviderService.getActiveInstance(locator.taskId);
     if (instance?.connectionId && instance?.worktreePath) {
       return { connectionId: instance.connectionId, remotePath: instance.worktreePath };
     }
   }
   // Fall back to existing project-based SSH matching
-  const project = await resolveRemoteProjectForWorktreePath(worktreePath);
+  const project = await resolveRemoteProjectForWorktreePath(worktreePath, locator?.sshConnectionId);
   if (project) {
     return { connectionId: project.sshConnectionId, remotePath: worktreePath };
   }

--- a/src/renderer/components/sidebar/LeftSidebar.tsx
+++ b/src/renderer/components/sidebar/LeftSidebar.tsx
@@ -1,0 +1,682 @@
+import React, { useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { motion } from 'framer-motion';
+import ReorderList from '../ReorderList';
+import { Button } from '../ui/button';
+import {
+  Sidebar,
+  SidebarContent,
+  SidebarGroup,
+  SidebarGroupContent,
+  SidebarHeader,
+  SidebarMenu,
+  SidebarMenuItem,
+  SidebarMenuButton,
+  useSidebar,
+} from '../ui/sidebar';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
+import {
+  Home,
+  Plus,
+  FolderOpen,
+  FolderClosed,
+  Puzzle,
+  Plug,
+  Timer,
+  Archive,
+  RotateCcw,
+  ChevronRight,
+  ArrowUpDown,
+  Check,
+  Trash2,
+} from 'lucide-react';
+import SidebarEmptyState from '../SidebarEmptyState';
+import { TaskItem } from '../TaskItem';
+import { RemoteProjectIndicator } from '../ssh/RemoteProjectIndicator';
+import { useRemoteProject } from '../../hooks/useRemoteProject';
+import type { Project, Task } from '../../types/app';
+import type { ConnectionState } from '../ssh';
+import { useProjectManagementContext } from '../../contexts/ProjectManagementProvider';
+import { useTaskManagementContext } from '../../contexts/TaskManagementContext';
+import { useAppSettings } from '../../contexts/AppSettingsProvider';
+import { useLocalStorage } from '../../hooks/useLocalStorage';
+import { useFeatureFlag } from '../../hooks/useFeatureFlag';
+import { ProjectsGroupLabel } from './ProjectsGroupLabel';
+import { useChangelogNotification } from '@/hooks/useChangelogNotification';
+import { useModalContext } from '@/contexts/ModalProvider';
+import { ChangelogNotificationCard } from './ChangelogNotificationCard';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+
+const PROJECT_ORDER_KEY = 'sidebarProjectOrder';
+const TASK_ORDER_KEY = 'sidebarTaskOrder';
+const TASK_SORT_MODE_KEY = 'sidebarTaskSortMode';
+const COLLAPSED_PROJECTS_KEY = 'sidebarCollapsedProjects';
+
+type TaskSortMode = 'createdAt' | 'lastActive' | 'alpha';
+
+const SORT_MODE_LABELS: Record<TaskSortMode, string> = {
+  createdAt: 'Creation Date',
+  lastActive: 'Last Active',
+  alpha: 'Alphabetical',
+};
+
+interface LeftSidebarProps {
+  onSidebarContextChange?: (state: {
+    open: boolean;
+    isMobile: boolean;
+    setOpen: (next: boolean) => void;
+  }) => void;
+  onCloseSettingsPage?: () => void;
+  onOpenAccountSettings?: () => void;
+}
+
+const isRemoteProject = (project: Project): boolean => {
+  return Boolean(project.isRemote || project.sshConnectionId);
+};
+
+const getConnectionId = (project: Project): string | null => {
+  return project.sshConnectionId || null;
+};
+
+interface ProjectItemProps {
+  project: Project;
+}
+
+const ProjectItem = React.memo<ProjectItemProps>(({ project }) => {
+  const remote = useRemoteProject(project);
+  const connectionId = getConnectionId(project);
+  const isRemote = isRemoteProject(project);
+
+  const displayName = useMemo(() => {
+    if (isRemote) {
+      const host = remote.host ?? connectionId ?? '';
+      return `${project.name} (${host}:${project.path})`;
+    }
+    return `${project.name} (${project.path})`;
+  }, [project, isRemote, remote.host, connectionId]);
+
+  if (!connectionId && !isRemote) {
+    return <span className="flex-1 truncate">{displayName}</span>;
+  }
+
+  return (
+    <div className="flex min-w-0 items-center gap-2">
+      {connectionId && (
+        <RemoteProjectIndicator
+          host={remote.host || undefined}
+          connectionState={remote.connectionState as ConnectionState}
+          size="md"
+          onReconnect={remote.reconnect}
+          disabled={remote.isLoading}
+        />
+      )}
+      <span className="flex-1 truncate">{displayName}</span>
+    </div>
+  );
+});
+ProjectItem.displayName = 'ProjectItem';
+
+// ---------------------------------------------------------------------------
+// Sort mode picker — shown on project row hover
+// ---------------------------------------------------------------------------
+interface SortModePickerProps {
+  currentMode: TaskSortMode;
+  onSelect: (mode: TaskSortMode) => void;
+}
+
+const SortModePicker = React.memo<SortModePickerProps>(({ currentMode, onSelect }) => {
+  const modes: TaskSortMode[] = ['createdAt', 'lastActive', 'alpha'];
+  return (
+    <Popover>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          title="Sort tasks"
+          className="p-0.5 text-muted-foreground hover:bg-black/5 dark:hover:bg-white/5"
+          onClick={(e) => e.stopPropagation()}
+        >
+          <ArrowUpDown className="h-3.5 w-3.5" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent className="w-44 p-1" align="start" sideOffset={4}>
+        <p className="px-2 pb-1 pt-0.5 text-[10px] font-medium uppercase tracking-wide text-muted-foreground/60">
+          Sort by
+        </p>
+        <div className="space-y-0.5">
+          {modes.map((mode) => (
+            <button
+              key={mode}
+              type="button"
+              className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-foreground hover:bg-muted dark:text-muted-foreground dark:hover:bg-accent"
+              onClick={(e) => {
+                e.stopPropagation();
+                onSelect(mode);
+              }}
+            >
+              <Check
+                className={`h-3 w-3 flex-shrink-0 transition-opacity ${currentMode === mode ? 'opacity-100' : 'opacity-0'}`}
+              />
+              {SORT_MODE_LABELS[mode]}
+            </button>
+          ))}
+        </div>
+      </PopoverContent>
+    </Popover>
+  );
+});
+SortModePicker.displayName = 'SortModePicker';
+
+// ---------------------------------------------------------------------------
+// Sorting helpers
+// ---------------------------------------------------------------------------
+/** Apply a named sort criterion to unpinned tasks. Pinned tasks always float to top. */
+function applySortCriterion(tasks: Task[], mode: TaskSortMode): Task[] {
+  const pinned = tasks.filter((t) => t.metadata?.isPinned);
+  const unpinned = tasks.filter((t) => !t.metadata?.isPinned);
+
+  let sortedUnpinned: Task[];
+  switch (mode) {
+    case 'lastActive':
+      sortedUnpinned = [...unpinned].sort((a, b) => {
+        const at = a.updatedAt ? new Date(a.updatedAt).getTime() : 0;
+        const bt = b.updatedAt ? new Date(b.updatedAt).getTime() : 0;
+        return bt - at;
+      });
+      break;
+    case 'alpha':
+      sortedUnpinned = [...unpinned].sort((a, b) => a.name.localeCompare(b.name));
+      break;
+    case 'createdAt':
+    default:
+      sortedUnpinned = [...unpinned].sort((a, b) => {
+        const at = a.createdAt ? new Date(a.createdAt).getTime() : 0;
+        const bt = b.createdAt ? new Date(b.createdAt).getTime() : 0;
+        return bt - at;
+      });
+      break;
+  }
+
+  return [...pinned, ...sortedUnpinned];
+}
+
+/** Restore a saved manual order, floating any new tasks to the top. */
+function applyManualOrder(tasks: Task[], manualOrder: string[]): Task[] {
+  const pinned = tasks.filter((t) => t.metadata?.isPinned);
+  const unpinned = tasks.filter((t) => !t.metadata?.isPinned);
+  const indexMap = new Map(manualOrder.map((id, i) => [id, i]));
+  const sortedUnpinned = [...unpinned].sort((a, b) => {
+    const ai = indexMap.get(a.id) ?? -1;
+    const bi = indexMap.get(b.id) ?? -1;
+    if (ai === -1 && bi === -1) return 0;
+    if (ai === -1) return -1; // new task floats to top
+    if (bi === -1) return 1;
+    return ai - bi;
+  });
+  return [...pinned, ...sortedUnpinned];
+}
+
+export const LeftSidebar: React.FC<LeftSidebarProps> = ({
+  onSidebarContextChange,
+  onCloseSettingsPage,
+  onOpenAccountSettings,
+}) => {
+  const { open, isMobile, setOpen } = useSidebar();
+  const automationsEnabled = useFeatureFlag('automations');
+  const { showModal } = useModalContext();
+  const {
+    projects,
+    selectedProject,
+    showHomeView: isHomeView,
+    showSkillsView: isSkillsView,
+    showMcpView: isMcpView,
+    showAutomationsView: isAutomationsView,
+    handleSelectProject: onSelectProject,
+    handleGoHome: onGoHome,
+    handleOpenProject: onOpenProject,
+    handleGoToSkills: onGoToSkills,
+    handleGoToMcp: onGoToMcp,
+    handleGoToAutomations: onGoToAutomations,
+  } = useProjectManagementContext();
+
+  const [projectOrder, setProjectOrder] = useLocalStorage<string[]>(PROJECT_ORDER_KEY, []);
+
+  // --- Collapsed project folders state (persisted as array, used as Set) ---
+  const [collapsedProjectsArray, setCollapsedProjectsArray] = useLocalStorage<string[]>(
+    COLLAPSED_PROJECTS_KEY,
+    []
+  );
+  const collapsedProjects = useMemo(
+    () => new Set(collapsedProjectsArray),
+    [collapsedProjectsArray]
+  );
+
+  const sortedProjects = useMemo(() => {
+    if (!projectOrder.length) return projects;
+    return [...projects].sort((a, b) => {
+      const ai = projectOrder.indexOf(a.id);
+      const bi = projectOrder.indexOf(b.id);
+      if (ai === -1 && bi === -1) return 0;
+      if (ai === -1) return -1;
+      if (bi === -1) return 1;
+      return ai - bi;
+    });
+  }, [projects, projectOrder]);
+
+  const handleReorderProjects = useCallback(
+    (newOrder: Project[]) => {
+      setProjectOrder(newOrder.map((p) => p.id));
+    },
+    [setProjectOrder]
+  );
+
+  // --- Task order state (manual drag order, persisted per project) ---
+  const [taskOrderMap, setTaskOrderMap] = useLocalStorage<Record<string, string[]>>(
+    TASK_ORDER_KEY,
+    {}
+  );
+
+  // --- Task sort mode (persisted per project, for checkmark UI) ---
+  const [taskSortModeMap, setTaskSortModeMap] = useLocalStorage<Record<string, TaskSortMode>>(
+    TASK_SORT_MODE_KEY,
+    {}
+  );
+
+  /**
+   * Called when the user drags a task to a new position.
+   * Saves the resulting order as the new manual order for the project.
+   */
+  const handleReorderTasks = useCallback(
+    (projectId: string, newOrder: Task[]) => {
+      setTaskOrderMap((prev) => ({ ...prev, [projectId]: newOrder.map((t) => t.id) }));
+    },
+    [setTaskOrderMap]
+  );
+
+  /**
+   * Called when the user picks a sort criterion from the picker.
+   * Applies the sort to the current task list, saves it as the manual order,
+   * and records which mode is active (for the checkmark).
+   */
+  const handleApplySortCriterion = useCallback(
+    (projectId: string, mode: TaskSortMode, currentTasks: Task[]) => {
+      const sorted = applySortCriterion(currentTasks, mode);
+      setTaskOrderMap((prev) => ({ ...prev, [projectId]: sorted.map((t) => t.id) }));
+      setTaskSortModeMap((prev) => ({ ...prev, [projectId]: mode }));
+    },
+    [setTaskOrderMap, setTaskSortModeMap]
+  );
+
+  const {
+    activeTask,
+    tasksByProjectId,
+    archivedTasksByProjectId,
+    handleSelectTask: onSelectTask,
+    handleStartCreateTaskFromSidebar: onCreateTaskForProject,
+    handleRenameTask: onRenameTask,
+    handleArchiveTask: onArchiveTask,
+    handleRestoreTask: onRestoreTask,
+    handleDeleteTask,
+    handlePinTask,
+  } = useTaskManagementContext();
+
+  const { settings } = useAppSettings();
+  const taskHoverAction = settings?.interface?.taskHoverAction ?? 'delete';
+  const changelogNotification = useChangelogNotification();
+  const changelogEntry = changelogNotification.entry;
+  const changelogCardRef = useRef<HTMLDivElement | null>(null);
+  const [changelogCardHeight, setChangelogCardHeight] = useState(0);
+
+  useEffect(() => {
+    onSidebarContextChange?.({ open, isMobile, setOpen });
+  }, [open, isMobile, setOpen, onSidebarContextChange]);
+
+  const handleNavigationWithCloseSettings = useCallback(
+    (callback: () => void) => {
+      onCloseSettingsPage?.();
+      callback();
+    },
+    [onCloseSettingsPage]
+  );
+
+  useEffect(() => {
+    const card = changelogCardRef.current;
+    if (!card || !changelogNotification.isVisible || !changelogEntry) {
+      setChangelogCardHeight(0);
+      return;
+    }
+
+    const updateHeight = () => {
+      setChangelogCardHeight(card.getBoundingClientRect().height);
+    };
+
+    updateHeight();
+
+    const observer = new ResizeObserver(() => {
+      updateHeight();
+    });
+    observer.observe(card);
+
+    return () => observer.disconnect();
+  }, [changelogNotification.isVisible, changelogEntry]);
+
+  return (
+    <div className="relative h-full">
+      <Sidebar className="!w-full lg:border-r-0">
+        <SidebarHeader className="border-b-0 px-3 py-3">
+          <SidebarMenu>
+            <SidebarMenuItem>
+              <SidebarMenuButton
+                asChild
+                className={`min-w-0 ${isHomeView ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+              >
+                <Button
+                  variant="ghost"
+                  onClick={() => handleNavigationWithCloseSettings(onGoHome)}
+                  aria-label="Home"
+                  className="w-full justify-start"
+                >
+                  <Home className="h-5 w-5 text-muted-foreground sm:h-4 sm:w-4" />
+                  <span className="text-sm font-medium">Home</span>
+                </Button>
+              </SidebarMenuButton>
+            </SidebarMenuItem>
+            {onGoToSkills && (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  className={`min-w-0 ${isSkillsView ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+                >
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleNavigationWithCloseSettings(onGoToSkills)}
+                    aria-label="Skills"
+                    className="w-full justify-start"
+                  >
+                    <Puzzle className="h-5 w-5 text-muted-foreground sm:h-4 sm:w-4" />
+                    <span className="text-sm font-medium">Skills</span>
+                  </Button>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )}
+            {onGoToMcp && (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  className={`min-w-0 ${isMcpView ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+                >
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleNavigationWithCloseSettings(onGoToMcp)}
+                    aria-label="MCP Servers"
+                    className="w-full justify-start"
+                  >
+                    <Plug className="h-5 w-5 text-muted-foreground sm:h-4 sm:w-4" />
+                    <span className="text-sm font-medium">MCP</span>
+                  </Button>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )}
+            {automationsEnabled && onGoToAutomations && (
+              <SidebarMenuItem>
+                <SidebarMenuButton
+                  asChild
+                  className={`min-w-0 ${isAutomationsView ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+                >
+                  <Button
+                    variant="ghost"
+                    onClick={() => handleNavigationWithCloseSettings(onGoToAutomations)}
+                    aria-label="Automations"
+                    className="w-full justify-start"
+                  >
+                    <Timer className="h-5 w-5 text-muted-foreground sm:h-4 sm:w-4" />
+                    <span className="text-sm font-medium">Automations</span>
+                    <span className="rounded bg-zinc-500/15 px-1.5 py-0.5 text-[9px] font-medium uppercase leading-none tracking-wide text-zinc-600 dark:bg-zinc-400/15 dark:text-zinc-400">
+                      Beta
+                    </span>
+                  </Button>
+                </SidebarMenuButton>
+              </SidebarMenuItem>
+            )}
+          </SidebarMenu>
+        </SidebarHeader>
+        <SidebarContent className="relative flex min-h-0 flex-col overflow-hidden">
+          <div
+            className="flex min-h-0 flex-1 flex-col overflow-y-auto"
+            style={{
+              paddingBottom:
+                changelogNotification.isVisible && changelogEntry
+                  ? changelogCardHeight + 28
+                  : undefined,
+            }}
+          >
+            <SidebarGroup>
+              <ProjectsGroupLabel />
+              <SidebarGroupContent>
+                <SidebarMenu>
+                  <ReorderList
+                    as="div"
+                    axis="y"
+                    items={sortedProjects}
+                    onReorder={(newOrder) => handleReorderProjects(newOrder as Project[])}
+                    className="m-0 flex min-w-0 list-none flex-col gap-1 p-0"
+                    itemClassName="relative group cursor-pointer rounded-md list-none min-w-0"
+                    getKey={(p) => (p as Project).id}
+                  >
+                    {(project) => {
+                      const typedProject = project as Project;
+                      const isProjectActive =
+                        selectedProject?.id === typedProject.id && !activeTask;
+                      const rawTasks = tasksByProjectId[typedProject.id] ?? [];
+                      const manualOrder = taskOrderMap[typedProject.id] ?? [];
+                      // If no manual order saved yet, fall back to lastActive sort
+                      const displayTasks =
+                        manualOrder.length > 0
+                          ? applyManualOrder(rawTasks, manualOrder)
+                          : applySortCriterion(rawTasks, 'lastActive');
+                      const activeSortMode: TaskSortMode =
+                        taskSortModeMap[typedProject.id] ?? 'lastActive';
+
+                      return (
+                        <SidebarMenuItem>
+                          <Collapsible
+                            open={!collapsedProjects.has(typedProject.id)}
+                            onOpenChange={(isOpen) => {
+                              const shouldBeCollapsed = !isOpen;
+                              setCollapsedProjectsArray((prev) => {
+                                const prevSet = new Set(prev);
+                                if (shouldBeCollapsed) {
+                                  prevSet.add(typedProject.id);
+                                } else {
+                                  prevSet.delete(typedProject.id);
+                                }
+                                return Array.from(prevSet);
+                              });
+                            }}
+                            className="group/collapsible"
+                          >
+                            <div
+                              className={`group/project relative flex w-full min-w-0 items-center gap-1.5 rounded-md py-1.5 pl-1 pr-1 text-sm font-medium hover:bg-accent ${isProjectActive ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+                            >
+                              <CollapsibleTrigger asChild>
+                                <button
+                                  type="button"
+                                  className="flex-shrink-0 rounded p-0.5 outline-none hover:bg-black/5 dark:hover:bg-white/5"
+                                >
+                                  <FolderOpen className="hidden h-4 w-4 text-foreground/60 group-data-[state=open]/collapsible:block" />
+                                  <FolderClosed className="block h-4 w-4 text-foreground/60 group-data-[state=open]/collapsible:hidden" />
+                                </button>
+                              </CollapsibleTrigger>
+                              <motion.button
+                                type="button"
+                                className="min-w-0 flex-1 truncate bg-transparent text-left text-foreground/60"
+                                whileTap={{ scale: 0.97 }}
+                                onClick={() =>
+                                  handleNavigationWithCloseSettings(() =>
+                                    onSelectProject(typedProject)
+                                  )
+                                }
+                              >
+                                <ProjectItem project={typedProject} />
+                              </motion.button>
+                              {/* Sort picker — visible on hover */}
+                              <span className="flex items-center gap-0.5 opacity-0 transition-opacity group-hover/project:opacity-100">
+                                <SortModePicker
+                                  currentMode={activeSortMode}
+                                  onSelect={(mode) =>
+                                    handleApplySortCriterion(typedProject.id, mode, rawTasks)
+                                  }
+                                />
+                              </span>
+                              {onCreateTaskForProject && (
+                                <button
+                                  type="button"
+                                  className="p-0.5 text-muted-foreground opacity-0 transition-opacity hover:bg-black/5 group-hover/project:opacity-100"
+                                  onClick={() =>
+                                    handleNavigationWithCloseSettings(() =>
+                                      onCreateTaskForProject(typedProject)
+                                    )
+                                  }
+                                >
+                                  <Plus className="h-4 w-4" />
+                                </button>
+                              )}
+                            </div>
+
+                            <CollapsibleContent
+                              forceMount
+                              className="mt-1 min-w-0 data-[state=closed]:hidden"
+                            >
+                              <div className="flex min-w-0 flex-col gap-1">
+                                <ReorderList
+                                  as="div"
+                                  axis="y"
+                                  items={displayTasks}
+                                  onReorder={(newOrder) =>
+                                    handleReorderTasks(typedProject.id, newOrder as Task[])
+                                  }
+                                  className="flex min-w-0 flex-col gap-1"
+                                  itemClassName="min-w-0"
+                                  getKey={(t) => (t as Task).id}
+                                >
+                                  {(task) => {
+                                    const typedTask = task as Task;
+                                    const isActive = activeTask?.id === typedTask.id;
+                                    return (
+                                      <motion.div
+                                        whileTap={{ scale: 0.97 }}
+                                        onClick={() =>
+                                          handleNavigationWithCloseSettings(() =>
+                                            onSelectTask?.(typedTask)
+                                          )
+                                        }
+                                        className={`group/task min-w-0 rounded-md py-1.5 pl-1 pr-2 hover:bg-accent ${isActive ? 'bg-black/[0.06] dark:bg-white/[0.08]' : ''}`}
+                                      >
+                                        <TaskItem
+                                          task={typedTask}
+                                          showDelete={true}
+                                          showDirectBadge={false}
+                                          isPinned={!!typedTask.metadata?.isPinned}
+                                          onPin={() => handlePinTask(typedTask)}
+                                          onRename={(n) =>
+                                            onRenameTask?.(typedProject, typedTask, n)
+                                          }
+                                          onDelete={() => handleDeleteTask(typedProject, typedTask)}
+                                          onArchive={() => onArchiveTask?.(typedProject, typedTask)}
+                                          primaryAction={taskHoverAction}
+                                        />
+                                      </motion.div>
+                                    );
+                                  }}
+                                </ReorderList>
+                                {(archivedTasksByProjectId[typedProject.id]?.length ?? 0) > 0 && (
+                                  <Collapsible className="mt-1">
+                                    <CollapsibleTrigger asChild>
+                                      <button className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-xs text-muted-foreground hover:bg-black/5">
+                                        <Archive className="h-3 w-3 opacity-50" />
+                                        <span>
+                                          Archived (
+                                          {archivedTasksByProjectId[typedProject.id].length})
+                                        </span>
+                                        <ChevronRight className="ml-auto h-3 w-3 transition-transform group-data-[state=open]/archived:rotate-90" />
+                                      </button>
+                                    </CollapsibleTrigger>
+                                    <CollapsibleContent>
+                                      <div className="ml-1.5 space-y-0.5 border-l pl-2">
+                                        {archivedTasksByProjectId[typedProject.id].map(
+                                          (archivedTask) => (
+                                            <div
+                                              key={archivedTask.id}
+                                              className="group flex min-w-0 items-center justify-between gap-2 px-2 py-1.5 text-muted-foreground"
+                                            >
+                                              <span className="truncate text-xs font-medium">
+                                                {archivedTask.name}
+                                              </span>
+                                              <div className="flex items-center gap-0.5 opacity-0 transition-opacity group-focus-within:opacity-100 group-hover:opacity-100">
+                                                <Button
+                                                  variant="ghost"
+                                                  size="icon-sm"
+                                                  onClick={() =>
+                                                    onRestoreTask?.(typedProject, archivedTask)
+                                                  }
+                                                  aria-label={`Unarchive task ${archivedTask.name}`}
+                                                >
+                                                  <RotateCcw className="h-3 w-3" />
+                                                </Button>
+                                                <Button
+                                                  variant="ghost"
+                                                  size="icon-sm"
+                                                  onClick={() =>
+                                                    handleDeleteTask(typedProject, archivedTask)
+                                                  }
+                                                  aria-label={`Delete archived task ${archivedTask.name}`}
+                                                >
+                                                  <Trash2 className="h-3 w-3" />
+                                                </Button>
+                                              </div>
+                                            </div>
+                                          )
+                                        )}
+                                      </div>
+                                    </CollapsibleContent>
+                                  </Collapsible>
+                                )}
+                              </div>
+                            </CollapsibleContent>
+                          </Collapsible>
+                        </SidebarMenuItem>
+                      );
+                    }}
+                  </ReorderList>
+                </SidebarMenu>
+              </SidebarGroupContent>
+            </SidebarGroup>
+            {projects.length === 0 && (
+              <div className="mt-auto">
+                <SidebarEmptyState
+                  title="Put your agents to work"
+                  description="Create a task and run one or more agents on it in parallel."
+                  actionLabel="Open Folder"
+                  onAction={onOpenProject}
+                />
+              </div>
+            )}
+          </div>
+
+          {changelogNotification.isVisible && changelogEntry && (
+            <div ref={changelogCardRef} className="absolute inset-x-3 bottom-4 z-10">
+              <ChangelogNotificationCard
+                entry={changelogEntry}
+                onOpen={() =>
+                  showModal('changelogModal', {
+                    entry: changelogEntry,
+                  })
+                }
+                onCreateAccount={() => onOpenAccountSettings?.()}
+                onDismiss={changelogNotification.dismiss}
+              />
+            </div>
+          )}
+        </SidebarContent>
+      </Sidebar>
+    </div>
+  );
+};

--- a/src/renderer/hooks/useAutomationTrigger.ts
+++ b/src/renderer/hooks/useAutomationTrigger.ts
@@ -1,0 +1,238 @@
+import { useEffect, useCallback, useRef } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
+import { useToast } from './use-toast';
+import { rpc } from '../lib/rpc';
+import { makePtyId } from '@shared/ptyId';
+import {
+  setAutomationRunPhase,
+  clearAutomationRun,
+} from '../components/automations/useRunningAutomations';
+import type { Automation } from '@shared/automations/types';
+import { isValidProviderId } from '@shared/providers/registry';
+
+/**
+ * Global listener for automation trigger events from the main process.
+ * Creates a task and starts the agent fully in the background —
+ * no view switching, no navigation away from the current screen.
+ *
+ * Uses a pull-based model: the main process queues triggers and
+ * sends a hint event. This hook drains the queue when ready, avoiding
+ * lost triggers from startup races or React mount timing.
+ */
+export function useAutomationTrigger(enabled = true): void {
+  const { projects, isInitialLoadComplete } = useProjectManagementContext();
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+
+  // Track PTY exit unsubscribers so we can clean them up on unmount
+  const ptyExitUnsubs = useRef<Map<string, () => void>>(new Map());
+
+  const runAutomationInBackground = useCallback(
+    async (automation: Automation & { _runLogId: string }) => {
+      const runLogId = automation._runLogId;
+      const project = projects.find((p) => p.id === automation.projectId);
+      if (!project) {
+        const errorMsg = `Project not found for "${automation.name}"`;
+        toast({
+          title: 'Automation failed',
+          description: errorMsg,
+          variant: 'destructive',
+        });
+        setAutomationRunPhase(automation.id, automation.name, 'error', {
+          error: 'Project not found',
+        });
+        void window.electronAPI.automationsCompleteRun({
+          runLogId,
+          automationId: automation.id,
+          status: 'failure',
+          error: errorMsg,
+        });
+        return;
+      }
+
+      setAutomationRunPhase(automation.id, automation.name, 'preparing');
+
+      const now = new Date();
+      const timeStr = now.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+      const taskName = `${automation.name} — ${timeStr}`;
+      const useWorktree = automation.useWorktree ?? true;
+
+      let branch = '';
+      let taskPath = '';
+      let taskId = '';
+      let worktreeCreated = false;
+
+      try {
+        // ---------------------------------------------------------------
+        // 1. Create worktree (optional) or use project path directly
+        // ---------------------------------------------------------------
+        if (useWorktree) {
+          setAutomationRunPhase(automation.id, automation.name, 'creating-worktree');
+
+          const worktreeResult = await window.electronAPI.worktreeCreate({
+            projectPath: project.path,
+            taskName,
+            projectId: project.id,
+          });
+          if (!worktreeResult?.success || !worktreeResult.worktree) {
+            throw new Error(worktreeResult?.error || 'Failed to create worktree');
+          }
+          branch = worktreeResult.worktree.branch;
+          taskPath = worktreeResult.worktree.path;
+          taskId = worktreeResult.worktree.id;
+          worktreeCreated = true;
+        } else {
+          branch = project.gitInfo?.branch || 'main';
+          taskPath = project.path;
+          taskId = `auto-${automation.id}-${Date.now()}`;
+        }
+
+        // ---------------------------------------------------------------
+        // 2. Save the task to the database
+        // ---------------------------------------------------------------
+        setAutomationRunPhase(automation.id, automation.name, 'saving-task');
+
+        await rpc.db.saveTask({
+          id: taskId,
+          projectId: project.id,
+          name: taskName,
+          branch,
+          path: taskPath,
+          status: 'idle',
+          agentId: automation.agentId,
+          metadata: {
+            initialPrompt: automation.prompt,
+            autoApprove: true,
+            nameGenerated: true,
+            automationId: automation.id,
+          },
+          useWorktree,
+        });
+
+        void queryClient.invalidateQueries({ queryKey: ['tasks', project.id] });
+
+        // ---------------------------------------------------------------
+        // 3. Start the agent PTY in the background
+        // ---------------------------------------------------------------
+        setAutomationRunPhase(automation.id, automation.name, 'starting-agent');
+
+        if (!isValidProviderId(automation.agentId)) {
+          throw new Error(
+            `Unknown provider "${automation.agentId}" for automation "${automation.name}"`
+          );
+        }
+
+        const ptyId = makePtyId(automation.agentId, 'main', taskId);
+        const ptyResult = await window.electronAPI.ptyStartDirect({
+          id: ptyId,
+          providerId: automation.agentId,
+          cwd: taskPath,
+          autoApprove: true,
+          initialPrompt: automation.prompt,
+          remote:
+            project.isRemote && project.sshConnectionId
+              ? { connectionId: project.sshConnectionId }
+              : undefined,
+        });
+
+        // Check PTY start result — fail explicitly if it didn't start
+        if (ptyResult && !ptyResult.ok) {
+          throw new Error(ptyResult.error || 'PTY failed to start');
+        }
+
+        // Listen for PTY exit to report the real outcome back to main.
+        // Track the unsubscriber so we can clean up on unmount
+        const unsubExit = window.electronAPI.onPtyExit(ptyId, ({ exitCode }) => {
+          ptyExitUnsubs.current.delete(ptyId);
+          unsubExit();
+          void window.electronAPI.automationsCompleteRun({
+            runLogId,
+            automationId: automation.id,
+            taskId,
+            status: exitCode === 0 ? 'success' : 'failure',
+            error: exitCode !== 0 ? `Agent exited with code ${exitCode}` : undefined,
+          });
+        });
+        ptyExitUnsubs.current.set(ptyId, unsubExit);
+
+        clearAutomationRun(automation.id);
+
+        toast({
+          title: 'Automation running',
+          description: `"${automation.name}" started in ${project.name}`,
+        });
+      } catch (err) {
+        const errorMessage = err instanceof Error ? err.message : 'Failed to start automation';
+        setAutomationRunPhase(automation.id, automation.name, 'error', {
+          error: errorMessage,
+        });
+        toast({
+          title: 'Automation failed',
+          description: errorMessage,
+          variant: 'destructive',
+        });
+        void window.electronAPI.automationsCompleteRun({
+          runLogId,
+          automationId: automation.id,
+          status: 'failure',
+          error: errorMessage,
+        });
+
+        // Clean up the worktree if we created one before the error
+        if (worktreeCreated && taskId && taskPath) {
+          try {
+            await window.electronAPI.worktreeRemove({
+              projectPath: project.path,
+              worktreeId: taskId,
+              worktreePath: taskPath,
+              sshConnectionId: project.sshConnectionId ?? undefined,
+            });
+          } catch {
+            // Best-effort cleanup — don't mask the original error
+          }
+        }
+      }
+    },
+    [projects, toast, queryClient]
+  );
+
+  // Drain queued triggers from the main process
+  const drainTriggers = useCallback(async () => {
+    try {
+      const result = await window.electronAPI.automationsDrainTriggers();
+      if (result.success && result.data) {
+        for (const automation of result.data) {
+          void runAutomationInBackground(automation);
+        }
+      }
+    } catch (err) {
+      console.error('[Automations] Failed to drain triggers:', err);
+    }
+  }, [runAutomationInBackground]);
+
+  useEffect(() => {
+    if (!enabled) return;
+    // Don't drain triggers until projects are loaded — otherwise we'll get
+    // "Project not found" errors because the projects array is still empty.
+    // The triggers stay safely queued in the main process until we're ready.
+    if (!isInitialLoadComplete) return;
+
+    // Listen for hint events from main process (new triggers available)
+    const unsub = window.electronAPI.onAutomationTriggerAvailable(() => {
+      void drainTriggers();
+    });
+
+    // Drain on mount — pick up anything queued before we were ready
+    void drainTriggers();
+
+    return () => {
+      unsub();
+      // Clean up any outstanding PTY exit listeners on unmount
+      for (const unsubFn of ptyExitUnsubs.current.values()) {
+        unsubFn();
+      }
+      ptyExitUnsubs.current.clear();
+    };
+  }, [drainTriggers, enabled, isInitialLoadComplete]);
+}

--- a/src/renderer/hooks/useAutomationTrigger.ts
+++ b/src/renderer/hooks/useAutomationTrigger.ts
@@ -1,15 +1,16 @@
-import { useEffect, useCallback, useRef } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
-import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
-import { useToast } from './use-toast';
-import { rpc } from '../lib/rpc';
-import { makePtyId } from '@shared/ptyId';
-import {
-  setAutomationRunPhase,
-  clearAutomationRun,
-} from '../components/automations/useRunningAutomations';
+import { useCallback, useEffect, useRef } from 'react';
 import type { Automation } from '@shared/automations/types';
 import { isValidProviderId } from '@shared/providers/registry';
+import { makePtyId } from '@shared/ptyId';
+import {
+  clearAutomationRun,
+  setAutomationRunPhase,
+} from '../components/automations/useRunningAutomations';
+import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
+import { getProjectRemoteLocator } from '../lib/remoteLocator';
+import { rpc } from '../lib/rpc';
+import { useToast } from './use-toast';
 
 /**
  * Global listener for automation trigger events from the main process.
@@ -186,7 +187,7 @@ export function useAutomationTrigger(enabled = true): void {
               projectPath: project.path,
               worktreeId: taskId,
               worktreePath: taskPath,
-              sshConnectionId: project.sshConnectionId ?? undefined,
+              ...getProjectRemoteLocator(project),
             });
           } catch {
             // Best-effort cleanup — don't mask the original error

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -1,0 +1,1140 @@
+import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
+import { useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
+import { TERMINAL_PROVIDER_IDS } from '../constants/agents';
+import { makePtyId } from '@shared/ptyId';
+import type { ProviderId } from '@shared/providers/registry';
+import { saveActiveIds, getStoredActiveIds } from '../constants/layout';
+import { getAgentForTask } from '../lib/getAgentForTask';
+import { disposeTaskTerminals } from '../lib/taskTerminalsStore';
+import { terminalSessionRegistry } from '../terminal/SessionRegistry';
+import type { Agent } from '../types';
+import type { Project, Task } from '../types/app';
+import type { GitHubIssueLink, AgentRun } from '../types/chat';
+import type { LinearIssueSummary } from '../types/linear';
+import type { GitHubIssueSummary } from '../types/github';
+import type { JiraIssueSummary } from '../types/jira';
+import type { PlainThreadSummary } from '../types/plain';
+import type { GitLabIssueSummary } from '../types/gitlab';
+import type { ForgejoIssueSummary } from '../types/forgejo';
+import { upsertTaskInList } from '../lib/taskListCache';
+import { rpc } from '../lib/rpc';
+import { createTask } from '../lib/taskCreationService';
+import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
+import { useToast } from './use-toast';
+import { useModalContext } from '../contexts/ModalProvider';
+
+const LIFECYCLE_TEARDOWN_TIMEOUT_MS = 15000;
+type LifecycleTarget = { taskId: string; taskPath: string; label: string };
+
+const getLifecycleTaskIds = (task: Task): string[] => {
+  const ids = new Set<string>([task.id]);
+  const variants = task.metadata?.multiAgent?.variants || [];
+  for (const variant of variants) {
+    if (variant?.worktreeId) {
+      ids.add(variant.worktreeId);
+    }
+  }
+  return [...ids];
+};
+
+const getLifecycleTargets = (task: Task): LifecycleTarget[] => {
+  const variants = task.metadata?.multiAgent?.variants || [];
+  if (variants.length > 0) {
+    const validVariantTargets = variants
+      .filter((variant) => variant?.worktreeId && variant?.path)
+      .map((variant) => ({
+        taskId: variant.worktreeId,
+        taskPath: variant.path,
+        label: variant.name || variant.worktreeId,
+      }));
+    if (validVariantTargets.length > 0) {
+      return validVariantTargets;
+    }
+  }
+
+  return [{ taskId: task.id, taskPath: task.path, label: task.name }];
+};
+
+const runSetupForTask = async (task: Task, projectPath: string): Promise<void> => {
+  const targets = getLifecycleTargets(task);
+  await Promise.allSettled(
+    targets.map((target) =>
+      window.electronAPI.lifecycleSetup({
+        taskId: target.taskId,
+        taskPath: target.taskPath,
+        projectPath,
+        taskName: target.label,
+      })
+    )
+  );
+};
+
+const buildLinkedGithubIssueMap = (tasks?: Task[] | null): Map<number, GitHubIssueLink> => {
+  const linked = new Map<number, GitHubIssueLink>();
+  if (!tasks?.length) return linked;
+  for (const task of tasks) {
+    const issueNumber = task.metadata?.githubIssue?.number;
+    if (typeof issueNumber !== 'number' || linked.has(issueNumber)) continue;
+    linked.set(issueNumber, {
+      number: issueNumber,
+      taskId: task.id,
+      taskName: task.name,
+    });
+  }
+  return linked;
+};
+
+/**
+ * If the task has a workspace provider, terminate the remote workspace instance.
+ * Best-effort — logs warnings but does not throw.
+ */
+const terminateWorkspaceIfNeeded = async (
+  project: Project,
+  task: Task,
+  toastFn?: (opts: { title: string; description: string }) => void
+): Promise<void> => {
+  const workspaceConfig = task.metadata?.workspace;
+  if (!workspaceConfig?.terminateCommand) return;
+
+  try {
+    const statusResult = await window.electronAPI.workspaceStatus({ taskId: task.id });
+    if (!statusResult.success || !statusResult.data) return;
+
+    const instance = statusResult.data;
+    if (instance.status === 'terminated') return;
+
+    const terminateResult = await window.electronAPI.workspaceTerminate({
+      instanceId: instance.id,
+      terminateCommand: workspaceConfig.terminateCommand,
+      projectPath: project.path,
+    });
+    if (terminateResult.success) {
+      toastFn?.({
+        title: 'Workspace terminated',
+        description: 'Remote workspace has been shut down.',
+      });
+    } else {
+      toastFn?.({
+        title: 'Workspace teardown failed',
+        description: terminateResult.error || 'Terminate script failed.',
+      });
+    }
+  } catch (err) {
+    const { log } = await import('../lib/logger');
+    log.warn('Workspace termination failed during task cleanup:', err as any);
+  }
+};
+
+const cleanupPtyResources = async (task: Task): Promise<void> => {
+  try {
+    const variants = task.metadata?.multiAgent?.variants || [];
+    const mainSessionIds: string[] = [];
+    if (variants.length > 0) {
+      for (const v of variants) {
+        const id = `${v.worktreeId}-main`;
+        mainSessionIds.push(id);
+      }
+    } else {
+      for (const provider of TERMINAL_PROVIDER_IDS) {
+        const id = makePtyId(provider, 'main', task.id);
+        mainSessionIds.push(id);
+      }
+    }
+
+    const chatSessionIds: string[] = [];
+    try {
+      const conversations = await rpc.db.getConversations(task.id);
+      for (const conv of conversations) {
+        if (!conv.isMain && conv.provider) {
+          const chatId = makePtyId(conv.provider as ProviderId, 'chat', conv.id);
+          chatSessionIds.push(chatId);
+        }
+      }
+    } catch {}
+
+    const sessionIds = [...mainSessionIds, ...chatSessionIds];
+    for (const sessionId of sessionIds) {
+      try {
+        terminalSessionRegistry.dispose(sessionId);
+      } catch {}
+    }
+    if (sessionIds.length > 0) {
+      try {
+        await window.electronAPI.ptyCleanupSessions({
+          ids: sessionIds,
+          clearSnapshots: true,
+          waitForSnapshots: false,
+        });
+      } catch {}
+    }
+
+    const variantPaths = (task.metadata?.multiAgent?.variants || []).map((v) => v.path);
+    const pathsToClean = variantPaths.length > 0 ? variantPaths : [task.path];
+    for (const path of pathsToClean) {
+      disposeTaskTerminals(`${task.id}::${path}`);
+      if (task.useWorktree !== false) {
+        disposeTaskTerminals(`global::${path}`);
+      }
+    }
+    disposeTaskTerminals(task.id);
+  } catch (err) {
+    const { log } = await import('../lib/logger');
+    log.error('Error cleaning up PTY resources:', err as any);
+  }
+};
+
+export function useTaskManagement() {
+  const {
+    projects,
+    selectedProject,
+    setSelectedProject,
+    setShowHomeView,
+    setShowSkillsView,
+    setShowMcpView,
+    setShowAutomationsView,
+    setShowEditorMode,
+    setShowKanban,
+    activateProjectView,
+    resetTaskTrigger,
+    autoOpenTaskModalTrigger,
+  } = useProjectManagementContext();
+
+  const { toast } = useToast();
+  const { showModal } = useModalContext();
+  const queryClient = useQueryClient();
+
+  // ---------------------------------------------------------------------------
+  // Task queries — one per project via useQueries
+  // ---------------------------------------------------------------------------
+  const taskResults = useQueries({
+    queries: projects.map((project) => ({
+      queryKey: ['tasks', project.id],
+      queryFn: () => rpc.db.getTasks(project.id) as Promise<Task[]>,
+      enabled: !!project.id,
+      staleTime: Infinity,
+    })),
+  });
+
+  const tasksByProjectId = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+    projects.forEach((p, i) => {
+      map[p.id] = taskResults[i]?.data ?? [];
+    });
+    return map;
+  }, [projects, taskResults]);
+
+  const archivedTaskResults = useQueries({
+    queries: projects.map((project) => ({
+      queryKey: ['archivedTasks', project.id],
+      queryFn: () => rpc.db.getArchivedTasks(project.id) as Promise<Task[]>,
+      enabled: !!project.id,
+      staleTime: Infinity,
+    })),
+  });
+
+  const archivedTasksByProjectId = useMemo(() => {
+    const map: Record<string, Task[]> = {};
+    projects.forEach((p, i) => {
+      map[p.id] = archivedTaskResults[i]?.data ?? [];
+    });
+    return map;
+  }, [projects, archivedTaskResults]);
+
+  const allTasks = useMemo(
+    () =>
+      projects.flatMap((p) => (tasksByProjectId[p.id] ?? []).map((task) => ({ task, project: p }))),
+    [projects, tasksByProjectId]
+  );
+
+  const linkedGithubIssueMap = useMemo(
+    () => buildLinkedGithubIssueMap(selectedProject ? tasksByProjectId[selectedProject.id] : null),
+    [selectedProject, tasksByProjectId]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Local UI state
+  // ---------------------------------------------------------------------------
+  const [activeTask, setActiveTask] = useState<Task | null>(null);
+  const [activeTaskAgent, setActiveTaskAgent] = useState<Agent | null>(null);
+  const [isCreatingTask, setIsCreatingTask] = useState(false);
+  const deletingTaskIdsRef = useRef<Set<string>>(new Set());
+  const restoringTaskIdsRef = useRef<Set<string>>(new Set());
+  const archivingTaskIdsRef = useRef<Set<string>>(new Set());
+  const openTaskModalImplRef = useRef<(project?: Project) => void>(() => {});
+  const pendingTaskProjectRef = useRef<Project | null>(null);
+  const preflightPromiseRef = useRef<Promise<unknown> | undefined>(undefined);
+  const openTaskModal = useCallback(
+    (project?: Project) => openTaskModalImplRef.current(project),
+    []
+  );
+
+  // Reset active task when project management signals a navigation away
+  useEffect(() => {
+    if (resetTaskTrigger > 0) {
+      setActiveTask(null);
+      setActiveTaskAgent(null);
+    }
+  }, [resetTaskTrigger]);
+
+  // ---------------------------------------------------------------------------
+  // Cache helpers
+  // ---------------------------------------------------------------------------
+  const updateTaskCache = useCallback(
+    (projectId: string, updater: (old: Task[]) => Task[]) => {
+      queryClient.setQueryData<Task[]>(['tasks', projectId], (old = []) => updater(old));
+    },
+    [queryClient]
+  );
+
+  const removeTaskFromCache = useCallback(
+    (projectId: string, taskId: string, wasActive: boolean) => {
+      updateTaskCache(projectId, (old) => old.filter((t) => t.id !== taskId));
+      const stored = getStoredActiveIds();
+      if (stored.taskId === taskId) {
+        saveActiveIds(stored.projectId, null);
+      }
+      if (wasActive) {
+        setActiveTask(null);
+        setActiveTaskAgent(null);
+      }
+    },
+    [updateTaskCache]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Lifecycle helpers
+  // ---------------------------------------------------------------------------
+  const runLifecycleTeardownBestEffort = async (
+    targetProject: Project,
+    task: Task,
+    action: 'archive' | 'delete',
+    options?: { silent?: boolean }
+  ): Promise<void> => {
+    const continueLabel = action === 'archive' ? 'archiving' : 'deletion';
+    const lifecycleTargets = getLifecycleTargets(task);
+    const issues: string[] = [];
+
+    await Promise.allSettled(
+      lifecycleTargets.map((target) =>
+        window.electronAPI.lifecycleRunStop({
+          taskId: target.taskId,
+          taskPath: target.taskPath,
+          projectPath: targetProject.path,
+          taskName: target.label,
+        })
+      )
+    );
+
+    for (const target of lifecycleTargets) {
+      try {
+        const teardownPromise = window.electronAPI.lifecycleTeardown({
+          taskId: target.taskId,
+          taskPath: target.taskPath,
+          projectPath: targetProject.path,
+          taskName: target.label,
+        });
+        const timeoutPromise = new Promise<'timeout'>((resolve) => {
+          window.setTimeout(() => resolve('timeout'), LIFECYCLE_TEARDOWN_TIMEOUT_MS);
+        });
+        const result = await Promise.race([teardownPromise, timeoutPromise]);
+
+        if (result === 'timeout') {
+          issues.push(`${target.label}: timeout`);
+          continue;
+        }
+        if (!result?.success && !result?.skipped) {
+          issues.push(`${target.label}: ${result?.error || 'teardown script failed'}`);
+        }
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        issues.push(`${target.label}: ${message}`);
+      }
+    }
+
+    if (issues.length > 0) {
+      const { log } = await import('../lib/logger');
+      log.warn(
+        `Lifecycle teardown issues for "${task.name}"; continuing ${continueLabel}.`,
+        issues.join(' | ')
+      );
+      if (!options?.silent) {
+        toast({
+          title: 'Teardown issues',
+          description: `Continuing ${continueLabel} (${issues.length} issue${issues.length === 1 ? '' : 's'}).`,
+        });
+      }
+    }
+  };
+
+  // ---------------------------------------------------------------------------
+  // Navigation helpers
+  // ---------------------------------------------------------------------------
+  const handleSelectTask = useCallback(
+    (task: Task) => {
+      const taskProject = projects.find((project) => project.id === task.projectId);
+      const isProjectSwitch = !selectedProject || selectedProject.id !== task.projectId;
+      if (isProjectSwitch) {
+        setShowEditorMode(false);
+      }
+      if (taskProject && selectedProject?.id !== taskProject.id) {
+        setSelectedProject(taskProject);
+      }
+      setShowHomeView(false);
+      setShowSkillsView(false);
+      setShowMcpView(false);
+      setShowAutomationsView(false);
+      setShowKanban(false);
+      setActiveTask(task);
+      setActiveTaskAgent(getAgentForTask(task));
+      saveActiveIds(task.projectId, task.id);
+    },
+    [
+      projects,
+      selectedProject,
+      setSelectedProject,
+      setShowEditorMode,
+      setShowHomeView,
+      setShowSkillsView,
+      setShowMcpView,
+      setShowAutomationsView,
+      setShowKanban,
+    ]
+  );
+
+  const handleOpenExternalTask = useCallback(
+    (task: Task) => {
+      updateTaskCache(task.projectId, (old) => upsertTaskInList(old, task));
+      handleSelectTask(task);
+      void queryClient.invalidateQueries({ queryKey: ['tasks', task.projectId] });
+    },
+    [handleSelectTask, queryClient, updateTaskCache]
+  );
+
+  const handleNextTask = useCallback(() => {
+    if (allTasks.length === 0) return;
+    const currentIndex = activeTask
+      ? allTasks.findIndex((t: { task: Task; project: Project }) => t.task.id === activeTask.id)
+      : -1;
+    const nextIndex = (currentIndex + 1) % allTasks.length;
+    const { task, project } = allTasks[nextIndex];
+    if (!selectedProject || selectedProject.id !== project.id) {
+      setShowEditorMode(false);
+      setShowKanban(false);
+    }
+    setSelectedProject(project);
+    setShowHomeView(false);
+    setShowSkillsView(false);
+    setShowMcpView(false);
+    setShowAutomationsView(false);
+    setActiveTask(task);
+    setActiveTaskAgent(getAgentForTask(task));
+    saveActiveIds(project.id, task.id);
+  }, [allTasks, activeTask, selectedProject]);
+
+  const handlePrevTask = useCallback(() => {
+    if (allTasks.length === 0) return;
+    const currentIndex = activeTask
+      ? allTasks.findIndex((t: { task: Task; project: Project }) => t.task.id === activeTask.id)
+      : -1;
+    const prevIndex = currentIndex <= 0 ? allTasks.length - 1 : currentIndex - 1;
+    const { task, project } = allTasks[prevIndex];
+    if (!selectedProject || selectedProject.id !== project.id) {
+      setShowEditorMode(false);
+      setShowKanban(false);
+    }
+    setSelectedProject(project);
+    setShowHomeView(false);
+    setShowSkillsView(false);
+    setShowMcpView(false);
+    setShowAutomationsView(false);
+    setActiveTask(task);
+    setActiveTaskAgent(getAgentForTask(task));
+    saveActiveIds(project.id, task.id);
+  }, [allTasks, activeTask, selectedProject]);
+
+  const handleNewTask = useCallback(() => {
+    if (selectedProject) {
+      openTaskModal();
+    }
+  }, [selectedProject, openTaskModal]);
+
+  const handleStartCreateTaskFromSidebar = useCallback(
+    (project: Project) => {
+      const targetProject = projects.find((p) => p.id === project.id) || project;
+      if (!selectedProject || selectedProject.id !== targetProject.id) {
+        activateProjectView(targetProject);
+      }
+      openTaskModal(targetProject);
+    },
+    [activateProjectView, projects, selectedProject, openTaskModal]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Delete task mutation
+  // ---------------------------------------------------------------------------
+  const deleteTaskMutation = useMutation({
+    mutationFn: async ({
+      project,
+      task,
+      options,
+    }: {
+      project: Project;
+      task: Task;
+      options?: { silent?: boolean };
+    }) => {
+      await runLifecycleTeardownBestEffort(project, task, 'delete', options);
+
+      // Terminate remote workspace if this task used workspace provisioning
+      await terminateWorkspaceIfNeeded(project, task, toast);
+
+      try {
+        const { initialPromptSentKey } = await import('../lib/keys');
+        try {
+          localStorage.removeItem(initialPromptSentKey(task.id));
+        } catch {}
+        try {
+          for (const p of TERMINAL_PROVIDER_IDS) {
+            localStorage.removeItem(initialPromptSentKey(task.id, p));
+          }
+        } catch {}
+      } catch {}
+
+      const variants = task.metadata?.multiAgent?.variants || [];
+      const mainSessionIds: string[] = [];
+      if (variants.length > 0) {
+        for (const v of variants) {
+          const id = `${v.worktreeId}-main`;
+          mainSessionIds.push(id);
+        }
+      } else {
+        for (const provider of TERMINAL_PROVIDER_IDS) {
+          const id = makePtyId(provider, 'main', task.id);
+          mainSessionIds.push(id);
+        }
+      }
+
+      const chatSessionIds: string[] = [];
+      try {
+        const conversations = await rpc.db.getConversations(task.id);
+        for (const conv of conversations) {
+          if (!conv.isMain && conv.provider) {
+            const chatId = makePtyId(conv.provider as ProviderId, 'chat', conv.id);
+            chatSessionIds.push(chatId);
+          }
+        }
+      } catch {}
+
+      const sessionIds = [...mainSessionIds, ...chatSessionIds];
+      for (const sessionId of sessionIds) {
+        try {
+          terminalSessionRegistry.dispose(sessionId);
+        } catch {}
+      }
+      if (sessionIds.length > 0) {
+        try {
+          await window.electronAPI.ptyCleanupSessions({
+            ids: sessionIds,
+            clearSnapshots: true,
+            waitForSnapshots: false,
+          });
+        } catch {}
+      }
+
+      const variantPaths = (task.metadata?.multiAgent?.variants || []).map((v) => v.path);
+      const pathsToClean = variantPaths.length > 0 ? variantPaths : [task.path];
+      for (const path of pathsToClean) {
+        disposeTaskTerminals(`${task.id}::${path}`);
+        if (task.useWorktree !== false) {
+          disposeTaskTerminals(`global::${path}`);
+        }
+      }
+      disposeTaskTerminals(task.id);
+
+      const shouldRemoveWorktree = task.useWorktree !== false;
+      const promises: Promise<any>[] = [rpc.db.deleteTask(task.id)];
+
+      if (shouldRemoveWorktree) {
+        if (task.path === project.path) {
+          console.warn(
+            `Task "${task.name}" appears to be running on main repo, skipping worktree removal`
+          );
+        } else {
+          promises.unshift(
+            window.electronAPI.worktreeRemove({
+              projectPath: project.path,
+              worktreeId: task.id,
+              worktreePath: task.path,
+              branch: task.branch,
+              taskName: task.name,
+              sshConnectionId: project.sshConnectionId ?? undefined,
+            })
+          );
+        }
+      }
+
+      const results = await Promise.allSettled(promises);
+
+      if (shouldRemoveWorktree) {
+        const removeResult = results[0];
+        if (removeResult.status !== 'fulfilled' || !removeResult.value?.success) {
+          const errorMsg =
+            removeResult.status === 'fulfilled'
+              ? removeResult.value?.error || 'Failed to remove worktree'
+              : removeResult.reason?.message || String(removeResult.reason);
+          throw new Error(errorMsg);
+        }
+      }
+
+      const deleteResult = shouldRemoveWorktree ? results[1] : results[0];
+      if (deleteResult.status !== 'fulfilled') {
+        throw new Error(
+          deleteResult.reason?.message || String(deleteResult.reason) || 'Failed to delete task'
+        );
+      }
+
+      await Promise.allSettled(
+        getLifecycleTaskIds(task).map(async (lifecycleTaskId) => {
+          try {
+            await window.electronAPI.lifecycleClearTask({ taskId: lifecycleTaskId });
+          } catch {}
+        })
+      );
+
+      void import('../lib/telemetryClient').then(({ captureTelemetry }) => {
+        captureTelemetry('task_deleted');
+      });
+    },
+    onMutate: ({ project, task }) => {
+      if (deletingTaskIdsRef.current.has(task.id)) return { blocked: true };
+      deletingTaskIdsRef.current.add(task.id);
+      const wasActive = activeTask?.id === task.id;
+      removeTaskFromCache(project.id, task.id, wasActive);
+      return { task, wasActive, blocked: false };
+    },
+    onError: async (_err, { project, task }, context) => {
+      if (context?.blocked) return;
+      deletingTaskIdsRef.current.delete(task.id);
+      const { log } = await import('../lib/logger');
+      log.error('Failed to delete task:', _err as any);
+      toast({
+        title: 'Error',
+        description:
+          _err instanceof Error
+            ? _err.message
+            : 'Could not delete task. Check the console for details.',
+        variant: 'destructive',
+      });
+      // Rollback: refresh from DB
+      queryClient.invalidateQueries({ queryKey: ['tasks', project.id] });
+      if (context?.wasActive && context.task) handleSelectTask(context.task);
+    },
+    onSuccess: (_, { project, task }, context) => {
+      if (context?.blocked) return;
+      deletingTaskIdsRef.current.delete(task.id);
+      queryClient.invalidateQueries({ queryKey: ['tasks', project.id] });
+      queryClient.invalidateQueries({ queryKey: ['archivedTasks', project.id] });
+    },
+  });
+
+  const handleDeleteTask = useCallback(
+    async (
+      targetProject: Project,
+      task: Task,
+      options?: { silent?: boolean }
+    ): Promise<boolean> => {
+      if (deletingTaskIdsRef.current.has(task.id)) {
+        toast({
+          title: 'Deletion in progress',
+          description: `"${task.name}" is already being removed.`,
+        });
+        return false;
+      }
+      try {
+        await deleteTaskMutation.mutateAsync({ project: targetProject, task, options });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [deleteTaskMutation, toast]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Archive task mutation
+  // ---------------------------------------------------------------------------
+  const archiveTaskMutation = useMutation({
+    mutationFn: async ({
+      project,
+      task,
+      options,
+    }: {
+      project: Project;
+      task: Task;
+      options?: { silent?: boolean };
+    }) => {
+      // PTY cleanup in background — don't block the UI
+      void cleanupPtyResources(task);
+
+      await runLifecycleTeardownBestEffort(project, task, 'archive', options);
+
+      // Terminate remote workspace if this task used workspace provisioning
+      await terminateWorkspaceIfNeeded(project, task, toast);
+
+      await rpc.db.archiveTask(task.id);
+
+      for (const lifecycleTaskId of getLifecycleTaskIds(task)) {
+        try {
+          await window.electronAPI.lifecycleClearTask({ taskId: lifecycleTaskId });
+        } catch {}
+      }
+
+      void import('../lib/telemetryClient').then(({ captureTelemetry }) => {
+        captureTelemetry('task_archived');
+      });
+    },
+    onMutate: ({ project, task }) => {
+      if (archivingTaskIdsRef.current.has(task.id)) return { blocked: true };
+      archivingTaskIdsRef.current.add(task.id);
+      const wasActive = activeTask?.id === task.id;
+      removeTaskFromCache(project.id, task.id, wasActive);
+      return { task, wasActive, blocked: false };
+    },
+    onError: async (_err, { project, task }, context) => {
+      if (context?.blocked) return;
+      archivingTaskIdsRef.current.delete(task.id);
+      const { log } = await import('../lib/logger');
+      log.error('Failed to archive task:', _err as any);
+      // Rollback: refresh from DB
+      queryClient.invalidateQueries({ queryKey: ['tasks', project.id] });
+      if (context?.wasActive && context.task) handleSelectTask(context.task);
+      toast({
+        title: 'Error',
+        description: _err instanceof Error ? _err.message : 'Could not archive task.',
+        variant: 'destructive',
+      });
+    },
+    onSuccess: (_, { project, task, options }, context) => {
+      if (context?.blocked) return;
+      archivingTaskIdsRef.current.delete(task.id);
+      queryClient.invalidateQueries({ queryKey: ['tasks', project.id] });
+      queryClient.invalidateQueries({ queryKey: ['archivedTasks', project.id] });
+      if (!options?.silent) {
+        toast({ title: 'Task archived', description: task.name });
+      }
+    },
+  });
+
+  const handleArchiveTask = useCallback(
+    async (
+      targetProject: Project,
+      task: Task,
+      options?: { silent?: boolean }
+    ): Promise<boolean> => {
+      if (archivingTaskIdsRef.current.has(task.id)) return false;
+      try {
+        await archiveTaskMutation.mutateAsync({ project: targetProject, task, options });
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    [archiveTaskMutation]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Restore task mutation
+  // ---------------------------------------------------------------------------
+  const restoreTaskMutation = useMutation({
+    mutationFn: async ({ project, task }: { project: Project; task: Task }) => {
+      await rpc.db.restoreTask(task.id);
+      const refreshedTasks = (await rpc.db.getTasks(project.id)) as Task[];
+      const restoredTask = refreshedTasks.find((t) => t.id === task.id) ?? {
+        ...task,
+        archivedAt: null,
+      };
+
+      if (restoredTask) {
+        try {
+          await runSetupForTask(restoredTask, project.path);
+        } catch {}
+      }
+
+      void import('../lib/telemetryClient').then(({ captureTelemetry }) => {
+        captureTelemetry('task_restored');
+      });
+
+      return { refreshedTasks, restoredTask };
+    },
+    onMutate: ({ project, task }) => {
+      if (restoringTaskIdsRef.current.has(task.id)) return { blocked: true };
+      restoringTaskIdsRef.current.add(task.id);
+      return { blocked: false };
+    },
+    onError: async (_err, _vars, context) => {
+      if (context?.blocked) return;
+      restoringTaskIdsRef.current.delete(_vars.task.id);
+      const { log } = await import('../lib/logger');
+      log.error('Failed to restore task:', _err as any);
+      toast({
+        title: 'Error',
+        description: _err instanceof Error ? _err.message : 'Could not restore task.',
+        variant: 'destructive',
+      });
+    },
+    onSuccess: ({ refreshedTasks }, { project, task }, context) => {
+      if (context?.blocked) return;
+      restoringTaskIdsRef.current.delete(task.id);
+      queryClient.setQueryData<Task[]>(['tasks', project.id], refreshedTasks);
+      queryClient.invalidateQueries({ queryKey: ['archivedTasks', project.id] });
+      toast({ title: 'Task restored', description: task.name });
+    },
+  });
+
+  const handleRestoreTask = useCallback(
+    async (targetProject: Project, task: Task): Promise<void> => {
+      if (restoringTaskIdsRef.current.has(task.id)) return;
+      try {
+        await restoreTaskMutation.mutateAsync({ project: targetProject, task });
+      } catch {}
+    },
+    [restoreTaskMutation]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Rename task mutation
+  // ---------------------------------------------------------------------------
+  const renameTaskMutation = useMutation({
+    mutationFn: async ({
+      project,
+      task,
+      newName,
+      newBranch,
+    }: {
+      project: Project;
+      task: Task;
+      newName: string;
+      newBranch: string;
+    }) => {
+      const oldBranch = task.branch;
+      let branchRenamed = false;
+
+      if (newBranch !== oldBranch) {
+        const branchResult = await window.electronAPI.renameBranch({
+          repoPath: task.path,
+          oldBranch,
+          newBranch,
+        });
+        if (!branchResult?.success) {
+          throw new Error(branchResult?.error || 'Failed to rename branch');
+        }
+        branchRenamed = true;
+      }
+
+      const updatedMetadata = task.metadata?.nameGenerated
+        ? { ...task.metadata, nameGenerated: null }
+        : task.metadata;
+
+      try {
+        await rpc.db.saveTask({
+          ...task,
+          name: newName,
+          branch: newBranch,
+          metadata: updatedMetadata,
+        });
+      } catch (err) {
+        if (branchRenamed) {
+          try {
+            await window.electronAPI.renameBranch({
+              repoPath: task.path,
+              oldBranch: newBranch,
+              newBranch: oldBranch,
+            });
+          } catch (rollbackErr) {
+            const { log } = await import('../lib/logger');
+            log.error('Failed to rollback branch rename:', rollbackErr as any);
+          }
+        }
+        throw err;
+      }
+    },
+    onMutate: ({ project, task, newName, newBranch }) => {
+      // Optimistic cache update
+      updateTaskCache(project.id, (old) =>
+        old.map((t) => {
+          if (t.id !== task.id) return t;
+          const updated = { ...t, name: newName, branch: newBranch };
+          if (updated.metadata?.nameGenerated) {
+            updated.metadata = { ...updated.metadata, nameGenerated: null };
+          }
+          return updated;
+        })
+      );
+      setActiveTask((prev) => {
+        if (prev?.id !== task.id) return prev;
+        const updated = { ...prev, name: newName, branch: newBranch };
+        if (updated.metadata?.nameGenerated) {
+          updated.metadata = { ...updated.metadata, nameGenerated: null };
+        }
+        return updated;
+      });
+      return { task }; // snapshot for rollback
+    },
+    onError: async (_err, { project, task }, context) => {
+      const { log } = await import('../lib/logger');
+      log.error('Failed to rename task:', _err as any);
+      // Rollback optimistic update
+      queryClient.invalidateQueries({ queryKey: ['tasks', project.id] });
+      setActiveTask((prev) => (prev?.id === task.id ? (context?.task ?? prev) : prev));
+      toast({
+        title: 'Error',
+        description: _err instanceof Error ? _err.message : 'Could not rename task.',
+        variant: 'destructive',
+      });
+    },
+    onSuccess: (_, { project }) => {
+      queryClient.invalidateQueries({ queryKey: ['tasks', project.id] });
+    },
+  });
+
+  const handleRenameTask = useCallback(
+    async (targetProject: Project, task: Task, newName: string) => {
+      const oldBranch = task.branch;
+      let newBranch: string;
+      const branchMatch = oldBranch.match(/^([^/]+)\/(.+)-([a-z0-9]+)$/i);
+      if (branchMatch) {
+        const [, prefix, , hash] = branchMatch;
+        const sluggedName = newName
+          .toLowerCase()
+          .replace(/[^a-z0-9]+/g, '-')
+          .replace(/^-|-$/g, '');
+        newBranch = `${prefix}/${sluggedName}-${hash}`;
+      } else {
+        newBranch = oldBranch;
+      }
+      await renameTaskMutation.mutateAsync({
+        project: targetProject,
+        task,
+        newName,
+        newBranch,
+      });
+    },
+    [renameTaskMutation]
+  );
+
+  // ---------------------------------------------------------------------------
+  // Create task mutation
+  // ---------------------------------------------------------------------------
+  const createTaskMutation = useMutation({
+    mutationFn: (params: Parameters<typeof createTask>[0]) => createTask(params),
+    onMutate: (params) => {
+      const totalRuns = params.agentRuns.reduce((sum, ar) => sum + ar.runs, 0);
+      const isMultiAgent = totalRuns > 1;
+      const primaryAgent = params.agentRuns[0]?.agent || 'claude';
+      const optimisticId = `optimistic-${Date.now()}`;
+
+      const optimisticTask: Task = {
+        id: optimisticId,
+        projectId: params.project.id,
+        name: params.taskName,
+        branch: params.project.gitInfo.branch || 'main',
+        path: params.project.path,
+        status: 'idle',
+        agentId: primaryAgent,
+        metadata: isMultiAgent
+          ? {
+              multiAgent: {
+                enabled: true,
+                maxAgents: 4,
+                agentRuns: params.agentRuns,
+                variants: [],
+                selectedAgent: null,
+              },
+            }
+          : null,
+        useWorktree: params.useWorktree,
+      };
+
+      updateTaskCache(params.project.id, (old) => [optimisticTask, ...old]);
+      setActiveTask(optimisticTask);
+      setActiveTaskAgent(isMultiAgent ? null : getAgentForTask(optimisticTask));
+      saveActiveIds(params.project.id, optimisticId);
+      return { optimisticTask };
+    },
+    onSuccess: ({ task, warning }, params, context) => {
+      const { optimisticTask } = context ?? {};
+      // Replace the optimistic placeholder with the real task
+      updateTaskCache(params.project.id, (old) =>
+        old.map((t) => (t.id === optimisticTask?.id ? task : t))
+      );
+      setActiveTask((current) => (current?.id === optimisticTask?.id ? task : current));
+      setActiveTaskAgent(getAgentForTask(task));
+      saveActiveIds(task.projectId, task.id);
+      queryClient.invalidateQueries({ queryKey: ['tasks', params.project.id] });
+      toast({
+        title: 'Task started',
+        description: task.name,
+      });
+      if (warning) {
+        toast({ title: 'Warning', description: warning });
+      }
+    },
+    onError: (_err, params, context) => {
+      const { optimisticTask } = context ?? {};
+      if (optimisticTask) {
+        updateTaskCache(params.project.id, (old) => old.filter((t) => t.id !== optimisticTask.id));
+        setActiveTask((current) => (current?.id === optimisticTask.id ? null : current));
+      }
+      queryClient.invalidateQueries({ queryKey: ['tasks', params.project.id] });
+      setIsCreatingTask(false);
+      toast({
+        title: 'Error',
+        description:
+          _err instanceof Error ? _err.message : 'Failed to create task. Please check the console.',
+        variant: 'destructive',
+      });
+    },
+  });
+
+  const handleCreateTask = useCallback(
+    async (
+      taskName: string,
+      initialPrompt?: string,
+      agentRuns: AgentRun[] = [{ agent: 'claude', runs: 1 }],
+      linkedLinearIssue: LinearIssueSummary | null = null,
+      linkedGithubIssue: GitHubIssueSummary | null = null,
+      linkedJiraIssue: JiraIssueSummary | null = null,
+      linkedPlainThread: PlainThreadSummary | null = null,
+      linkedGitlabIssue: GitLabIssueSummary | null = null,
+      linkedForgejoIssue: ForgejoIssueSummary | null = null,
+      autoApprove?: boolean,
+      useWorktree: boolean = true,
+      baseRef?: string,
+      nameGenerated?: boolean,
+      useRemoteWorkspace?: boolean,
+      workspaceProvider?: { provisionCommand: string; terminateCommand: string },
+      overrideProject?: Project
+    ) => {
+      const targetProject = overrideProject ?? pendingTaskProjectRef.current ?? selectedProject;
+      pendingTaskProjectRef.current = null;
+      if (!targetProject) return;
+      setIsCreatingTask(true);
+      const preflight = preflightPromiseRef.current;
+      preflightPromiseRef.current = undefined;
+      await createTaskMutation.mutateAsync({
+        project: targetProject,
+        taskName,
+        initialPrompt,
+        agentRuns,
+        linkedLinearIssue,
+        linkedGithubIssue,
+        linkedJiraIssue,
+        linkedPlainThread,
+        linkedGitlabIssue,
+        linkedForgejoIssue,
+        autoApprove,
+        nameGenerated,
+        useWorktree,
+        baseRef,
+        useRemoteWorkspace,
+        workspaceProvider,
+        preflightPromise: preflight,
+      });
+    },
+    [selectedProject, createTaskMutation]
+  );
+
+  const handleTaskInterfaceReady = useCallback(() => {
+    setIsCreatingTask(false);
+  }, []);
+
+  // isCreatingTask safety-net: clear after 30s if task interface never signals ready
+  useEffect(() => {
+    if (!isCreatingTask) return;
+    const timeout = window.setTimeout(() => {
+      setIsCreatingTask(false);
+    }, 30000);
+    return () => {
+      window.clearTimeout(timeout);
+    };
+  }, [isCreatingTask]);
+
+  // Wire up openTaskModal — TaskModalOverlay calls handleCreateTask via context
+  openTaskModalImplRef.current = (project?: Project) => {
+    if (project === undefined) pendingTaskProjectRef.current = null;
+
+    // Fire preflight reserve freshness check while the user fills in the form.
+    const targetProject = project ?? pendingTaskProjectRef.current ?? selectedProject;
+    if (targetProject) {
+      preflightPromiseRef.current = window.electronAPI
+        .worktreePreflightReserve({
+          projectId: targetProject.id,
+          projectPath: targetProject.path,
+        })
+        .catch((err) => {
+          console.warn('[preflight] failed', err);
+        });
+    }
+
+    showModal('taskModal', {
+      initialProject: project,
+      onClose: () => {
+        pendingTaskProjectRef.current = null;
+        preflightPromiseRef.current = undefined;
+      },
+    });
+  };
+
+  // Auto-open task modal when project management requests it
+  useEffect(() => {
+    if (autoOpenTaskModalTrigger > 0) {
+      openTaskModal();
+    }
+  }, [autoOpenTaskModalTrigger, openTaskModal]);
+
+  // ---------------------------------------------------------------------------
+  // Pin / unpin task (persisted in task metadata)
+  // ---------------------------------------------------------------------------
+  const handlePinTask = useCallback(
+    async (task: Task) => {
+      const isPinned = !task.metadata?.isPinned;
+      const updatedMetadata = { ...task.metadata, isPinned: isPinned || null };
+      // Optimistic UI update
+      updateTaskCache(task.projectId, (old) =>
+        old.map((t) => (t.id === task.id ? { ...t, metadata: updatedMetadata } : t))
+      );
+      try {
+        await rpc.db.saveTask({ ...task, metadata: updatedMetadata });
+      } catch {
+        // Rollback on failure
+        queryClient.invalidateQueries({ queryKey: ['tasks', task.projectId] });
+      }
+    },
+    [updateTaskCache, queryClient]
+  );
+
+  return {
+    activeTask,
+    setActiveTask,
+    activeTaskAgent,
+    setActiveTaskAgent,
+    allTasks,
+    tasksByProjectId,
+    archivedTasksByProjectId,
+    linkedGithubIssueMap,
+    isCreatingTask,
+    handleCreateTask,
+    handleTaskInterfaceReady,
+    openTaskModal,
+    handleSelectTask,
+    handleOpenExternalTask,
+    handleNextTask,
+    handlePrevTask,
+    handleNewTask,
+    handleStartCreateTaskFromSidebar,
+    handleDeleteTask,
+    handleRenameTask,
+    handleArchiveTask,
+    handleRestoreTask,
+    handlePinTask,
+  };
+}

--- a/src/renderer/hooks/useTaskManagement.ts
+++ b/src/renderer/hooks/useTaskManagement.ts
@@ -1,27 +1,28 @@
-import { useState, useMemo, useCallback, useRef, useEffect } from 'react';
-import { useQueries, useMutation, useQueryClient } from '@tanstack/react-query';
-import { TERMINAL_PROVIDER_IDS } from '../constants/agents';
-import { makePtyId } from '@shared/ptyId';
+import { useMutation, useQueries, useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { ProviderId } from '@shared/providers/registry';
-import { saveActiveIds, getStoredActiveIds } from '../constants/layout';
+import { makePtyId } from '@shared/ptyId';
+import { TERMINAL_PROVIDER_IDS } from '../constants/agents';
+import { getStoredActiveIds, saveActiveIds } from '../constants/layout';
+import { useModalContext } from '../contexts/ModalProvider';
+import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
 import { getAgentForTask } from '../lib/getAgentForTask';
+import { getProjectRemoteLocator } from '../lib/remoteLocator';
+import { rpc } from '../lib/rpc';
+import { createTask } from '../lib/taskCreationService';
+import { upsertTaskInList } from '../lib/taskListCache';
 import { disposeTaskTerminals } from '../lib/taskTerminalsStore';
 import { terminalSessionRegistry } from '../terminal/SessionRegistry';
 import type { Agent } from '../types';
 import type { Project, Task } from '../types/app';
-import type { GitHubIssueLink, AgentRun } from '../types/chat';
-import type { LinearIssueSummary } from '../types/linear';
-import type { GitHubIssueSummary } from '../types/github';
-import type { JiraIssueSummary } from '../types/jira';
-import type { PlainThreadSummary } from '../types/plain';
-import type { GitLabIssueSummary } from '../types/gitlab';
+import type { AgentRun, GitHubIssueLink } from '../types/chat';
 import type { ForgejoIssueSummary } from '../types/forgejo';
-import { upsertTaskInList } from '../lib/taskListCache';
-import { rpc } from '../lib/rpc';
-import { createTask } from '../lib/taskCreationService';
-import { useProjectManagementContext } from '../contexts/ProjectManagementProvider';
+import type { GitHubIssueSummary } from '../types/github';
+import type { GitLabIssueSummary } from '../types/gitlab';
+import type { JiraIssueSummary } from '../types/jira';
+import type { LinearIssueSummary } from '../types/linear';
+import type { PlainThreadSummary } from '../types/plain';
 import { useToast } from './use-toast';
-import { useModalContext } from '../contexts/ModalProvider';
 
 const LIFECYCLE_TEARDOWN_TIMEOUT_MS = 15000;
 type LifecycleTarget = { taskId: string; taskPath: string; label: string };
@@ -566,7 +567,7 @@ export function useTaskManagement() {
               worktreePath: task.path,
               branch: task.branch,
               taskName: task.name,
-              sshConnectionId: project.sshConnectionId ?? undefined,
+              ...getProjectRemoteLocator(project),
             })
           );
         }

--- a/src/renderer/lib/remoteLocator.ts
+++ b/src/renderer/lib/remoteLocator.ts
@@ -1,0 +1,5 @@
+import type { Project } from '../types/app';
+
+export function getProjectRemoteLocator(project: Project): { sshConnectionId?: string } {
+  return { sshConnectionId: project.sshConnectionId ?? undefined };
+}

--- a/src/renderer/lib/taskCreationService.ts
+++ b/src/renderer/lib/taskCreationService.ts
@@ -1,0 +1,680 @@
+import type { Agent } from '../types';
+import type { Project, Task } from '../types/app';
+import type { AgentRun, TaskMetadata } from '../types/chat';
+import { type GitHubIssueSummary } from '../types/github';
+import { type JiraIssueSummary } from '../types/jira';
+import { type LinearIssueSummary } from '../types/linear';
+import { type PlainThreadSummary } from '../types/plain';
+import { type GitLabIssueSummary } from '../types/gitlab';
+import { type ForgejoIssueSummary } from '../types/forgejo';
+import { rpc } from './rpc';
+
+export interface CreateTaskParams {
+  project: Project;
+  taskName: string;
+  initialPrompt?: string;
+  agentRuns: AgentRun[];
+  linkedLinearIssue: LinearIssueSummary | null;
+  linkedGithubIssue: GitHubIssueSummary | null;
+  linkedJiraIssue: JiraIssueSummary | null;
+  linkedPlainThread: PlainThreadSummary | null;
+  linkedGitlabIssue: GitLabIssueSummary | null;
+  linkedForgejoIssue: ForgejoIssueSummary | null;
+  autoApprove?: boolean;
+  nameGenerated?: boolean;
+  useWorktree: boolean;
+  baseRef?: string;
+  /** When true, provision a remote workspace instead of creating a local worktree. */
+  useRemoteWorkspace?: boolean;
+  /** Workspace provider commands from .emdash.json — required when useRemoteWorkspace is true. */
+  workspaceProvider?: {
+    provisionCommand: string;
+    terminateCommand: string;
+  };
+  preflightPromise?: Promise<unknown>;
+}
+
+export interface CreateTaskResult {
+  task: Task;
+  /** Non-fatal warning to surface in a toast (e.g. base-ref switch failure). */
+  warning?: string;
+}
+
+async function runSetupOnCreate(
+  taskId: string,
+  taskPath: string,
+  projectPath: string,
+  taskName: string
+): Promise<void> {
+  try {
+    const result = await window.electronAPI.lifecycleSetup({
+      taskId,
+      taskPath,
+      projectPath,
+      taskName,
+    });
+    if (!result?.success && !result?.skipped) {
+      const { log } = await import('./logger');
+      log.warn(`Setup script failed for task "${taskName}"`, result?.error);
+    }
+  } catch (error) {
+    const { log } = await import('./logger');
+    log.warn(`Setup script error for task "${taskName}"`, error as any);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Seed conversation with issue context after task creation (fire-and-forget).
+// ---------------------------------------------------------------------------
+function seedIssueContext(
+  taskId: string,
+  taskMetadata: TaskMetadata | null,
+  provider?: string
+): void {
+  void (async () => {
+    const hasIssueContext =
+      taskMetadata?.linearIssue ||
+      taskMetadata?.githubIssue ||
+      taskMetadata?.jiraIssue ||
+      taskMetadata?.plainThread ||
+      taskMetadata?.gitlabIssue ||
+      taskMetadata?.forgejoIssue;
+    if (!hasIssueContext) return;
+
+    let conversationId: string | undefined;
+    try {
+      const conversation = await rpc.db.getOrCreateDefaultConversation({ taskId, provider });
+      if (conversation?.id) conversationId = conversation.id;
+    } catch (error) {
+      const { log } = await import('./logger');
+      log.error('Failed to get or create default conversation:', error as any);
+    }
+    if (!conversationId) return;
+
+    if (taskMetadata?.linearIssue) {
+      try {
+        const issue = taskMetadata.linearIssue;
+        const detailParts: string[] = [];
+        const stateName = issue.state?.name?.trim();
+        const assigneeName = issue.assignee?.displayName?.trim() || issue.assignee?.name?.trim();
+        const teamKey = issue.team?.key?.trim();
+        const projectName = issue.project?.name?.trim();
+        if (stateName) detailParts.push(`State: ${stateName}`);
+        if (assigneeName) detailParts.push(`Assignee: ${assigneeName}`);
+        if (teamKey) detailParts.push(`Team: ${teamKey}`);
+        if (projectName) detailParts.push(`Project: ${projectName}`);
+        const lines = [`Linked Linear issue: ${issue.identifier} — ${issue.title}`];
+        if (detailParts.length) lines.push(`Details: ${detailParts.join(' • ')}`);
+        if (issue.url) lines.push(`URL: ${issue.url}`);
+        if ((issue as any)?.description) {
+          lines.push('');
+          lines.push('Issue Description:');
+          lines.push(String((issue as any).description).trim());
+        }
+        await rpc.db.saveMessage({
+          id: `linear-context-${taskId}`,
+          conversationId,
+          content: lines.join('\n'),
+          sender: 'agent',
+          metadata: JSON.stringify({ isLinearContext: true, linearIssue: issue }),
+        });
+      } catch (seedError) {
+        const { log } = await import('./logger');
+        log.error('Failed to seed task with Linear issue context:', seedError as any);
+      }
+    }
+
+    if (taskMetadata?.githubIssue) {
+      try {
+        const issue = taskMetadata.githubIssue;
+        const detailParts: string[] = [];
+        const stateName = issue.state?.toString()?.trim();
+        const assignees = Array.isArray(issue.assignees)
+          ? issue.assignees
+              .map((a) => a?.name || a?.login)
+              .filter(Boolean)
+              .join(', ')
+          : '';
+        const labels = Array.isArray(issue.labels)
+          ? issue.labels
+              .map((l) => l?.name)
+              .filter(Boolean)
+              .join(', ')
+          : '';
+        if (stateName) detailParts.push(`State: ${stateName}`);
+        if (assignees) detailParts.push(`Assignees: ${assignees}`);
+        if (labels) detailParts.push(`Labels: ${labels}`);
+        const lines = [`Linked GitHub issue: #${issue.number} — ${issue.title}`];
+        if (detailParts.length) lines.push(`Details: ${detailParts.join(' • ')}`);
+        if (issue.url) lines.push(`URL: ${issue.url}`);
+        if ((issue as any)?.body) {
+          lines.push('');
+          lines.push('Issue Description:');
+          lines.push(String((issue as any).body).trim());
+        }
+        await rpc.db.saveMessage({
+          id: `github-context-${taskId}`,
+          conversationId,
+          content: lines.join('\n'),
+          sender: 'agent',
+          metadata: JSON.stringify({ isGitHubContext: true, githubIssue: issue }),
+        });
+      } catch (seedError) {
+        const { log } = await import('./logger');
+        log.error('Failed to seed task with GitHub issue context:', seedError as any);
+      }
+    }
+
+    if (taskMetadata?.jiraIssue) {
+      try {
+        const issue: any = taskMetadata.jiraIssue;
+        const lines: string[] = [];
+        const line1 =
+          `Linked Jira issue: ${issue.key || ''}${issue.summary ? ` — ${issue.summary}` : ''}`.trim();
+        if (line1) lines.push(line1);
+        const details: string[] = [];
+        if (issue.status?.name) details.push(`Status: ${issue.status.name}`);
+        if (issue.assignee?.displayName || issue.assignee?.name)
+          details.push(`Assignee: ${issue.assignee?.displayName || issue.assignee?.name}`);
+        if (issue.project?.key) details.push(`Project: ${issue.project.key}`);
+        if (details.length) lines.push(`Details: ${details.join(' • ')}`);
+        if (issue.url) lines.push(`URL: ${issue.url}`);
+        await rpc.db.saveMessage({
+          id: `jira-context-${taskId}`,
+          conversationId,
+          content: lines.join('\n'),
+          sender: 'agent',
+          metadata: JSON.stringify({ isJiraContext: true, jiraIssue: issue }),
+        });
+      } catch (seedError) {
+        const { log } = await import('./logger');
+        log.error('Failed to seed task with Jira issue context:', seedError as any);
+      }
+    }
+
+    if (taskMetadata?.plainThread) {
+      try {
+        const thread = taskMetadata.plainThread;
+        const detailParts: string[] = [];
+        if (thread.status) detailParts.push(`Status: ${thread.status}`);
+        const customerName = thread.customer?.fullName?.trim();
+        const customerEmail = thread.customer?.email?.trim();
+        if (customerName) detailParts.push(`Customer: ${customerName}`);
+        if (customerEmail) detailParts.push(`Email: ${customerEmail}`);
+        if (thread.priority) detailParts.push(`Priority: ${thread.priority}`);
+        const labelNames = (thread.labels ?? [])
+          .map((l) => l.name)
+          .filter(Boolean)
+          .join(', ');
+        if (labelNames) detailParts.push(`Labels: ${labelNames}`);
+        const lines = [
+          `Linked Plain thread: ${thread.ref ? `${thread.ref} — ` : ''}${thread.title}`,
+        ];
+        if (detailParts.length) lines.push(`Details: ${detailParts.join(' • ')}`);
+        if (thread.url) lines.push(`URL: ${thread.url}`);
+        if (thread.description) {
+          lines.push('');
+          lines.push('Thread Description:');
+          lines.push(String(thread.description).trim());
+        }
+        await rpc.db.saveMessage({
+          id: `plain-context-${taskId}`,
+          conversationId,
+          content: lines.join('\n'),
+          sender: 'agent',
+          metadata: JSON.stringify({ isPlainContext: true, plainThread: thread }),
+        });
+      } catch (seedError) {
+        const { log } = await import('./logger');
+        log.error('Failed to seed task with Plain thread context:', seedError as any);
+      }
+    }
+
+    if (taskMetadata?.gitlabIssue) {
+      try {
+        const issue = taskMetadata.gitlabIssue;
+        const detailParts: string[] = [];
+        if (issue.state) detailParts.push(`State: ${issue.state}`);
+        if (issue.assignee?.name || issue.assignee?.username)
+          detailParts.push(`Assignee: ${issue.assignee.name || issue.assignee.username}`);
+        if (Array.isArray(issue.labels) && issue.labels.length)
+          detailParts.push(`Labels: ${issue.labels.join(', ')}`);
+        const lines = [`Linked GitLab issue: #${issue.iid} — ${issue.title}`];
+        if (detailParts.length) lines.push(`Details: ${detailParts.join(' • ')}`);
+        if (issue.web_url) lines.push(`URL: ${issue.web_url}`);
+        if (issue.description) {
+          lines.push('');
+          lines.push('Issue Description:');
+          lines.push(String(issue.description).trim());
+        }
+        await rpc.db.saveMessage({
+          id: `gitlab-context-${taskId}`,
+          conversationId,
+          content: lines.join('\n'),
+          sender: 'agent',
+          metadata: JSON.stringify({ isGitLabContext: true, gitlabIssue: issue }),
+        });
+      } catch (seedError) {
+        const { log } = await import('./logger');
+        log.error('Failed to seed task with GitLab issue context:', seedError as any);
+      }
+    }
+
+    if (taskMetadata?.forgejoIssue) {
+      try {
+        const issue = taskMetadata.forgejoIssue;
+        const detailParts: string[] = [];
+        if (issue.state) detailParts.push(`State: ${issue.state}`);
+        if (issue.assignee?.name) detailParts.push(`Assignee: ${issue.assignee.name}`);
+        if (Array.isArray(issue.labels) && issue.labels.length)
+          detailParts.push(`Labels: ${issue.labels.join(', ')}`);
+        const lines = [`Linked Forgejo issue: #${issue.number} — ${issue.title}`];
+        if (detailParts.length) lines.push(`Details: ${detailParts.join(' • ')}`);
+        if (issue.html_url) lines.push(`URL: ${issue.html_url}`);
+        if (issue.description) {
+          lines.push('');
+          lines.push('Issue Description:');
+          lines.push(String(issue.description).trim());
+        }
+        await rpc.db.saveMessage({
+          id: `forgejo-context-${taskId}`,
+          conversationId,
+          content: lines.join('\n'),
+          sender: 'agent',
+          metadata: JSON.stringify({ isForgejoContext: true, forgejoIssue: issue }),
+        });
+      } catch (seedError) {
+        const { log } = await import('./logger');
+        log.error('Failed to seed task with Forgejo issue context:', seedError as any);
+      }
+    }
+  })();
+}
+
+// ---------------------------------------------------------------------------
+// Core task creation — pure backend function, no cache/UI knowledge.
+// Throws on unrecoverable errors; returns a warning string for soft failures.
+// ---------------------------------------------------------------------------
+export async function createTask(params: CreateTaskParams): Promise<CreateTaskResult> {
+  const {
+    project,
+    taskName,
+    initialPrompt,
+    agentRuns,
+    linkedLinearIssue,
+    linkedGithubIssue,
+    linkedJiraIssue,
+    linkedPlainThread,
+    linkedGitlabIssue,
+    linkedForgejoIssue,
+    autoApprove,
+    nameGenerated,
+    useWorktree,
+    baseRef,
+    useRemoteWorkspace,
+    workspaceProvider,
+    preflightPromise,
+  } = params;
+
+  // Build prompt prefix from linked issues
+  let preparedPrompt: string | undefined;
+  if (initialPrompt && initialPrompt.trim()) {
+    const parts: string[] = [];
+    if (linkedLinearIssue) {
+      parts.push(`Linear: ${linkedLinearIssue.identifier} — ${linkedLinearIssue.title}`);
+      if (linkedLinearIssue.url) parts.push(`URL: ${linkedLinearIssue.url}`);
+      parts.push('');
+    }
+    if (linkedGithubIssue) {
+      parts.push(`GitHub: #${linkedGithubIssue.number} — ${linkedGithubIssue.title}`);
+      if (linkedGithubIssue.url) parts.push(`URL: ${linkedGithubIssue.url}`);
+      parts.push('');
+    }
+    if (linkedPlainThread) {
+      const t = linkedPlainThread;
+      parts.push(`Plain thread: ${t.ref ? `${t.ref} — ` : ''}${t.title}`);
+      const details: string[] = [];
+      if (t.status) details.push(`Status: ${t.status}`);
+      if (t.customer?.fullName) details.push(`Customer: ${t.customer.fullName}`);
+      if (t.customer?.email) details.push(`Email: ${t.customer.email}`);
+      if (t.priority != null) details.push(`Priority: ${t.priority}`);
+      const labelNames = (t.labels ?? [])
+        .map((l) => l.name)
+        .filter(Boolean)
+        .join(', ');
+      if (labelNames) details.push(`Labels: ${labelNames}`);
+      if (details.length) parts.push(details.join(' • '));
+      if (t.url) parts.push(`URL: ${t.url}`);
+      if (t.description) {
+        parts.push('');
+        parts.push(`Description: ${String(t.description).trim()}`);
+      }
+      parts.push('');
+    }
+    if (linkedGitlabIssue) {
+      parts.push(`GitLab: #${linkedGitlabIssue.iid} — ${linkedGitlabIssue.title}`);
+      if (linkedGitlabIssue.web_url) parts.push(`URL: ${linkedGitlabIssue.web_url}`);
+      parts.push('');
+    }
+    if (linkedForgejoIssue) {
+      parts.push(`Forgejo: #${linkedForgejoIssue.number} — ${linkedForgejoIssue.title}`);
+      if (linkedForgejoIssue.html_url) parts.push(`URL: ${linkedForgejoIssue.html_url}`);
+      parts.push('');
+    }
+    if (initialPrompt && initialPrompt.trim()) {
+      parts.push(initialPrompt.trim());
+    }
+    preparedPrompt = parts.join('\n');
+  }
+
+  const taskMetadata: TaskMetadata | null =
+    linkedLinearIssue ||
+    linkedJiraIssue ||
+    linkedGithubIssue ||
+    linkedPlainThread ||
+    linkedGitlabIssue ||
+    linkedForgejoIssue ||
+    preparedPrompt ||
+    autoApprove ||
+    nameGenerated
+      ? {
+          linearIssue: linkedLinearIssue ?? null,
+          jiraIssue: linkedJiraIssue ?? null,
+          githubIssue: linkedGithubIssue ?? null,
+          plainThread: linkedPlainThread ?? null,
+          gitlabIssue: linkedGitlabIssue ?? null,
+          forgejoIssue: linkedForgejoIssue ?? null,
+          initialPrompt: preparedPrompt ?? null,
+          autoApprove: autoApprove ?? null,
+          nameGenerated: nameGenerated ?? null,
+        }
+      : null;
+
+  const totalRuns = agentRuns.reduce((sum, ar) => sum + ar.runs, 0);
+  const isMultiAgent = totalRuns > 1;
+  const primaryAgent = agentRuns[0]?.agent || 'claude';
+
+  // ---------------------------------------------------------------------------
+  // Multi-agent path
+  // ---------------------------------------------------------------------------
+  if (isMultiAgent) {
+    const groupId = `ws-${taskName}-${Date.now()}`;
+    const variants: Array<{
+      id: string;
+      agent: Agent;
+      name: string;
+      branch: string;
+      path: string;
+      worktreeId: string;
+    }> = [];
+
+    try {
+      for (const { agent, runs } of agentRuns) {
+        for (let instanceIdx = 1; instanceIdx <= runs; instanceIdx++) {
+          const instanceSuffix = runs > 1 ? `-${instanceIdx}` : '';
+          const variantName = `${taskName}-${agent.toLowerCase()}${instanceSuffix}`;
+
+          let branch: string;
+          let path: string;
+          let worktreeId: string;
+
+          if (useWorktree) {
+            const worktreeResult = await window.electronAPI.worktreeCreate({
+              projectPath: project.path,
+              taskName: variantName,
+              projectId: project.id,
+              baseRef,
+            });
+            if (!worktreeResult?.success || !worktreeResult.worktree) {
+              throw new Error(
+                worktreeResult?.error || `Failed to create worktree for ${agent}${instanceSuffix}`
+              );
+            }
+            const worktree = worktreeResult.worktree;
+            branch = worktree.branch;
+            path = worktree.path;
+            worktreeId = worktree.id;
+          } else {
+            branch = project.gitInfo.branch || 'main';
+            path = project.path;
+            worktreeId = `direct-${taskName}-${agent.toLowerCase()}${instanceSuffix}`;
+          }
+
+          variants.push({
+            id: `${taskName}-${agent.toLowerCase()}${instanceSuffix}`,
+            agent,
+            name: variantName,
+            branch,
+            path,
+            worktreeId,
+          });
+        }
+      }
+    } catch (error) {
+      // Clean up any worktrees created before the failure
+      for (const variant of variants) {
+        if (variant.worktreeId && !variant.worktreeId.startsWith('direct-')) {
+          window.electronAPI
+            .worktreeRemove({
+              projectPath: project.path,
+              worktreeId: variant.worktreeId,
+              sshConnectionId: project.sshConnectionId ?? undefined,
+            })
+            .catch(() => {});
+        }
+      }
+      const { log } = await import('./logger');
+      log.error('Failed to create multi-agent worktrees:', error as Error);
+      throw error;
+    }
+
+    const finalMeta: TaskMetadata = {
+      ...(taskMetadata || {}),
+      multiAgent: {
+        enabled: true,
+        maxAgents: 4,
+        agentRuns,
+        variants,
+        selectedAgent: null,
+      },
+    };
+
+    const finalTask: Task = {
+      id: groupId,
+      projectId: project.id,
+      name: taskName,
+      branch: variants[0]?.branch || project.gitInfo.branch || 'main',
+      path: variants[0]?.path || project.path,
+      status: 'idle',
+      agentId: primaryAgent,
+      metadata: finalMeta,
+      useWorktree,
+    };
+
+    try {
+      await rpc.db.saveTask({
+        ...finalTask,
+        agentId: primaryAgent,
+        metadata: finalMeta,
+        useWorktree,
+      });
+    } catch (saveErr) {
+      const { log } = await import('./logger');
+      log.error('Failed to save multi-agent task:', saveErr);
+      for (const variant of variants) {
+        if (variant.worktreeId && !variant.worktreeId.startsWith('direct-')) {
+          window.electronAPI
+            .worktreeRemove({
+              projectPath: project.path,
+              worktreeId: variant.worktreeId,
+              sshConnectionId: project.sshConnectionId ?? undefined,
+            })
+            .catch(() => {});
+        }
+      }
+      throw saveErr;
+    }
+
+    // Background: setup per variant + telemetry
+    for (const variant of variants) {
+      void runSetupOnCreate(variant.worktreeId, variant.path, project.path, variant.name);
+    }
+    void import('./telemetryClient').then(({ captureTelemetry }) => {
+      captureTelemetry('task_created', {
+        provider: 'multi',
+        has_initial_prompt: !!taskMetadata?.initialPrompt,
+      });
+      if (useRemoteWorkspace) captureTelemetry('workspace_provisioning_task_created');
+      if (linkedGithubIssue) captureTelemetry('task_created_with_issue', { source: 'github' });
+      if (linkedLinearIssue) captureTelemetry('task_created_with_issue', { source: 'linear' });
+      if (linkedJiraIssue) captureTelemetry('task_created_with_issue', { source: 'jira' });
+      if (linkedPlainThread) captureTelemetry('task_created_with_issue', { source: 'plain' });
+      if (linkedGitlabIssue) captureTelemetry('task_created_with_issue', { source: 'gitlab' });
+      if (linkedForgejoIssue) captureTelemetry('task_created_with_issue', { source: 'forgejo' });
+    });
+
+    return { task: finalTask };
+  }
+
+  // ---------------------------------------------------------------------------
+  // Single-agent path
+  // ---------------------------------------------------------------------------
+  let branch: string;
+  let path: string;
+  let taskId: string;
+  let taskPersistedInClaim = false;
+  let warning: string | undefined;
+
+  if (useRemoteWorkspace && workspaceProvider) {
+    // Remote workspace — no local worktree, provisioning happens after task save.
+    branch = project.gitInfo.branch || 'main';
+    path = project.path;
+    taskId = `workspace-${taskName}-${Date.now()}`;
+  } else if (useWorktree) {
+    // Wait for the preflight freshness check (started when the modal opened)
+    // so the reserve is up-to-date before we claim it.  Timeout after 10s
+    // to avoid blocking task creation if ls-remote hangs.
+    if (preflightPromise) {
+      await Promise.race([
+        preflightPromise,
+        new Promise<void>((resolve) => setTimeout(resolve, 5_000)),
+      ]);
+    }
+
+    const claimAndSaveResult = await window.electronAPI.worktreeClaimReserveAndSaveTask({
+      projectId: project.id,
+      projectPath: project.path,
+      taskName,
+      baseRef,
+      task: {
+        projectId: project.id,
+        name: taskName,
+        status: 'idle',
+        agentId: primaryAgent,
+        metadata: taskMetadata,
+        useWorktree,
+      },
+    });
+
+    if (claimAndSaveResult.success && claimAndSaveResult.worktree) {
+      const worktree = claimAndSaveResult.worktree;
+      branch = worktree.branch;
+      path = worktree.path;
+      taskId = worktree.id;
+      taskPersistedInClaim = true;
+      if (claimAndSaveResult.needsBaseRefSwitch) {
+        warning = `Could not switch to ${baseRef}. Task created on default branch.`;
+      }
+    } else {
+      const worktreeResult = await window.electronAPI.worktreeCreate({
+        projectPath: project.path,
+        taskName,
+        projectId: project.id,
+        baseRef,
+      });
+      if (!worktreeResult.success) {
+        throw new Error(worktreeResult.error || 'Failed to create worktree');
+      }
+      const worktree = worktreeResult.worktree;
+      branch = worktree.branch;
+      path = worktree.path;
+      taskId = worktree.id;
+    }
+  } else {
+    branch = project.gitInfo.branch || 'main';
+    path = project.path;
+    taskId = `direct-${taskName}-${Date.now()}`;
+  }
+
+  // Attach workspace provider config to metadata so teardown can find the terminate command.
+  const finalTaskMetadata =
+    useRemoteWorkspace && workspaceProvider
+      ? { ...(taskMetadata || {}), workspace: workspaceProvider }
+      : taskMetadata;
+
+  const newTask: Task = {
+    id: taskId,
+    projectId: project.id,
+    name: taskName,
+    branch,
+    path,
+    status: 'idle',
+    agentId: primaryAgent,
+    metadata: finalTaskMetadata,
+    useWorktree: useRemoteWorkspace ? false : useWorktree,
+  };
+
+  if (!taskPersistedInClaim) {
+    try {
+      await rpc.db.saveTask({
+        ...newTask,
+        agentId: primaryAgent,
+        metadata: finalTaskMetadata,
+        useWorktree: newTask.useWorktree,
+      });
+    } catch (saveErr) {
+      const { log } = await import('./logger');
+      log.error('Failed to save task:', saveErr);
+      // Non-fatal: task is created in memory and will work this session
+      warning = 'Task created but may not persist after restart. Try again if it disappears.';
+    }
+  }
+
+  // Background: workspace provisioning (fire-and-forget; progress streamed via events)
+  if (useRemoteWorkspace && workspaceProvider) {
+    void window.electronAPI
+      .workspaceProvision({
+        taskId: newTask.id,
+        repoUrl: project.gitInfo.remote || '',
+        branch: newTask.branch,
+        baseRef: baseRef || project.gitInfo.baseRef || 'main',
+        provisionCommand: workspaceProvider.provisionCommand,
+        projectPath: project.path,
+      })
+      .catch(async (err: unknown) => {
+        const { log } = await import('./logger');
+        log.error(`Workspace provision failed for task "${newTask.name}"`, err as any);
+      });
+  }
+
+  // Background: setup, telemetry, issue seeding
+  if (!useRemoteWorkspace) {
+    void runSetupOnCreate(newTask.id, newTask.path, project.path, newTask.name);
+  }
+  void import('./telemetryClient').then(({ captureTelemetry }) => {
+    captureTelemetry('task_created', {
+      provider: (newTask.agentId as string) || 'codex',
+      has_initial_prompt: !!taskMetadata?.initialPrompt,
+    });
+    if (useRemoteWorkspace) captureTelemetry('workspace_provisioning_task_created');
+    if (linkedGithubIssue) captureTelemetry('task_created_with_issue', { source: 'github' });
+    if (linkedLinearIssue) captureTelemetry('task_created_with_issue', { source: 'linear' });
+    if (linkedJiraIssue) captureTelemetry('task_created_with_issue', { source: 'jira' });
+    if (linkedPlainThread) captureTelemetry('task_created_with_issue', { source: 'plain' });
+    if (linkedGitlabIssue) captureTelemetry('task_created_with_issue', { source: 'gitlab' });
+    if (linkedForgejoIssue) captureTelemetry('task_created_with_issue', { source: 'forgejo' });
+  });
+  seedIssueContext(newTask.id, taskMetadata, newTask.agentId || primaryAgent);
+
+  return { task: newTask, warning };
+}

--- a/src/renderer/lib/taskCreationService.ts
+++ b/src/renderer/lib/taskCreationService.ts
@@ -1,12 +1,13 @@
 import type { Agent } from '../types';
 import type { Project, Task } from '../types/app';
 import type { AgentRun, TaskMetadata } from '../types/chat';
+import { type ForgejoIssueSummary } from '../types/forgejo';
 import { type GitHubIssueSummary } from '../types/github';
+import { type GitLabIssueSummary } from '../types/gitlab';
 import { type JiraIssueSummary } from '../types/jira';
 import { type LinearIssueSummary } from '../types/linear';
 import { type PlainThreadSummary } from '../types/plain';
-import { type GitLabIssueSummary } from '../types/gitlab';
-import { type ForgejoIssueSummary } from '../types/forgejo';
+import { getProjectRemoteLocator } from './remoteLocator';
 import { rpc } from './rpc';
 
 export interface CreateTaskParams {
@@ -458,7 +459,7 @@ export async function createTask(params: CreateTaskParams): Promise<CreateTaskRe
             .worktreeRemove({
               projectPath: project.path,
               worktreeId: variant.worktreeId,
-              sshConnectionId: project.sshConnectionId ?? undefined,
+              ...getProjectRemoteLocator(project),
             })
             .catch(() => {});
         }
@@ -507,7 +508,7 @@ export async function createTask(params: CreateTaskParams): Promise<CreateTaskRe
             .worktreeRemove({
               projectPath: project.path,
               worktreeId: variant.worktreeId,
-              sshConnectionId: project.sshConnectionId ?? undefined,
+              ...getProjectRemoteLocator(project),
             })
             .catch(() => {});
         }

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1,11 +1,19 @@
 // Updated for Codex integration
 
+import type { OpenInAppId } from '#shared/openInApps';
+import type { TerminalSnapshotPayload } from '#types/terminalSnapshot';
 import type { AgentEvent } from '../../shared/agentEvents';
-import type { AutoMergeRequest } from '../lib/prStatus';
 import type { DiffPayload } from '../../shared/diff/types';
 import type { GitIndexUpdateArgs } from '../../shared/git/types';
-import type { ResourceMetricsSnapshot } from '../../shared/performanceTypes';
 import type { SentryIssue } from '../../shared/integrations/sentryTypes';
+import type {
+  ProjectPathLocator,
+  RepoPathLocator,
+  TaskPathLocator,
+  WorktreePathLocator,
+} from '../../shared/ipc/remoteLocator';
+import type { ResourceMetricsSnapshot } from '../../shared/performanceTypes';
+import type { AutoMergeRequest } from '../lib/prStatus';
 
 type ProjectSettingsPayload = {
   projectId: string;
@@ -176,10 +184,11 @@ declare global {
         projectId: string;
         baseRef?: string;
       }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
-      worktreeList: (args: {
-        projectPath: string;
-        sshConnectionId?: string;
-      }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+      worktreeList: (args: ProjectPathLocator) => Promise<{
+        success: boolean;
+        worktrees?: any[];
+        error?: string;
+      }>;
       worktreeRemove: (args: {
         projectPath: string;
         worktreeId: string;
@@ -188,9 +197,11 @@ declare global {
         taskName?: string;
         sshConnectionId?: string;
       }) => Promise<{ success: boolean; error?: string }>;
-      worktreeStatus: (args: {
-        worktreePath: string;
-      }) => Promise<{ success: boolean; status?: any; error?: string }>;
+      worktreeStatus: (args: WorktreePathLocator) => Promise<{
+        success: boolean;
+        status?: any;
+        error?: string;
+      }>;
       worktreeMerge: (args: {
         projectPath: string;
         worktreeId: string;
@@ -359,7 +370,7 @@ declare global {
         rootPath?: string;
         error?: string;
       }>;
-      getGitStatus: (arg: string | { taskPath: string; taskId?: string }) => Promise<{
+      getGitStatus: (arg: string | TaskPathLocator) => Promise<{
         success: boolean;
         changes?: Array<{
           path: string;
@@ -398,13 +409,13 @@ declare global {
         >;
         error?: string;
       }>;
-      watchGitStatus: (arg: string | { taskPath: string; taskId?: string }) => Promise<{
+      watchGitStatus: (arg: string | TaskPathLocator) => Promise<{
         success: boolean;
         watchId?: string;
         error?: string;
       }>;
       unwatchGitStatus: (
-        arg: string | { taskPath: string; taskId?: string },
+        arg: string | TaskPathLocator,
         watchId?: string
       ) => Promise<{
         success: boolean;
@@ -413,22 +424,22 @@ declare global {
       onGitStatusChanged: (
         listener: (data: { taskPath: string; error?: string }) => void
       ) => () => void;
-      getFileDiff: (args: {
-        taskPath: string;
-        taskId?: string;
-        filePath: string;
-        baseRef?: string;
-        forceLarge?: boolean;
-      }) => Promise<{
+      getFileDiff: (
+        args: TaskPathLocator & {
+          filePath: string;
+          baseRef?: string;
+          forceLarge?: boolean;
+        }
+      ) => Promise<{
         success: boolean;
         diff?: DiffPayload;
         error?: string;
       }>;
-      updateIndex: (args: { taskPath: string; taskId?: string } & GitIndexUpdateArgs) => Promise<{
+      updateIndex: (args: TaskPathLocator & GitIndexUpdateArgs) => Promise<{
         success: boolean;
         error?: string;
       }>;
-      revertFile: (args: { taskPath: string; taskId?: string; filePath: string }) => Promise<{
+      revertFile: (args: TaskPathLocator & { filePath: string }) => Promise<{
         success: boolean;
         action?: 'reverted';
         error?: string;
@@ -448,12 +459,13 @@ declare global {
         output?: string;
         error?: string;
       }>;
-      gitGetLog: (args: {
-        taskPath: string;
-        maxCount?: number;
-        skip?: number;
-        aheadCount?: number;
-      }) => Promise<{
+      gitGetLog: (
+        args: TaskPathLocator & {
+          maxCount?: number;
+          skip?: number;
+          aheadCount?: number;
+        }
+      ) => Promise<{
         success: boolean;
         commits?: Array<{
           hash: string;
@@ -468,7 +480,7 @@ declare global {
         aheadCount?: number;
         error?: string;
       }>;
-      gitGetLatestCommit: (args: { taskPath: string }) => Promise<{
+      gitGetLatestCommit: (args: TaskPathLocator) => Promise<{
         success: boolean;
         commit?: {
           hash: string;
@@ -478,7 +490,7 @@ declare global {
         } | null;
         error?: string;
       }>;
-      gitGetCommitFiles: (args: { taskPath: string; commitHash: string }) => Promise<{
+      gitGetCommitFiles: (args: TaskPathLocator & { commitHash: string }) => Promise<{
         success: boolean;
         files?: Array<{
           path: string;
@@ -488,12 +500,13 @@ declare global {
         }>;
         error?: string;
       }>;
-      gitGetCommitFileDiff: (args: {
-        taskPath: string;
-        commitHash: string;
-        filePath: string;
-        forceLarge?: boolean;
-      }) => Promise<{
+      gitGetCommitFileDiff: (
+        args: TaskPathLocator & {
+          commitHash: string;
+          filePath: string;
+          forceLarge?: boolean;
+        }
+      ) => Promise<{
         success: boolean;
         diff?: DiffPayload;
         error?: string;
@@ -504,64 +517,60 @@ declare global {
         body?: string;
         error?: string;
       }>;
-      gitCommitAndPush: (args: {
-        taskPath: string;
-        taskId?: string;
-        commitMessage?: string;
-        createBranchIfOnDefault?: boolean;
-        branchPrefix?: string;
-      }) => Promise<{
+      gitCommitAndPush: (
+        args: TaskPathLocator & {
+          commitMessage?: string;
+          createBranchIfOnDefault?: boolean;
+          branchPrefix?: string;
+        }
+      ) => Promise<{
         success: boolean;
         branch?: string;
         output?: string;
         error?: string;
       }>;
-      generatePrContent: (args: {
-        taskPath: string;
-        base?: string;
-        sshConnectionId?: string;
-      }) => Promise<{
+      generatePrContent: (args: TaskPathLocator & { base?: string }) => Promise<{
         success: boolean;
         title?: string;
         description?: string;
         error?: string;
       }>;
-      createPullRequest: (args: {
-        taskPath: string;
-        title?: string;
-        body?: string;
-        base?: string;
-        head?: string;
-        draft?: boolean;
-        web?: boolean;
-        fill?: boolean;
-        skipPrePush?: boolean;
-        sshConnectionId?: string;
-      }) => Promise<{
+      createPullRequest: (
+        args: TaskPathLocator & {
+          title?: string;
+          body?: string;
+          base?: string;
+          head?: string;
+          draft?: boolean;
+          web?: boolean;
+          fill?: boolean;
+          skipPrePush?: boolean;
+        }
+      ) => Promise<{
         success: boolean;
         url?: string;
         output?: string;
         error?: string;
       }>;
-      mergeToMain: (args: { taskPath: string; taskId?: string }) => Promise<{
+      mergeToMain: (args: TaskPathLocator) => Promise<{
         success: boolean;
         output?: string;
         prUrl?: string;
         error?: string;
       }>;
-      mergePr: (args: {
-        taskPath: string;
-        prNumber?: number;
-        strategy?: 'merge' | 'squash' | 'rebase';
-        admin?: boolean;
-        sshConnectionId?: string;
-      }) => Promise<{
+      mergePr: (
+        args: TaskPathLocator & {
+          prNumber?: number;
+          strategy?: 'merge' | 'squash' | 'rebase';
+          admin?: boolean;
+        }
+      ) => Promise<{
         success: boolean;
         output?: string;
         error?: string;
         code?: string;
       }>;
-      getPrStatus: (args: { taskPath: string; sshConnectionId?: string }) => Promise<{
+      getPrStatus: (args: TaskPathLocator) => Promise<{
         success: boolean;
         pr?: {
           number: number;
@@ -580,26 +589,22 @@ declare global {
         } | null;
         error?: string;
       }>;
-      enableAutoMerge: (args: {
-        taskPath: string;
-        prNumber?: number;
-        strategy?: 'merge' | 'squash' | 'rebase';
-        sshConnectionId?: string;
-      }) => Promise<{
+      enableAutoMerge: (
+        args: TaskPathLocator & {
+          prNumber?: number;
+          strategy?: 'merge' | 'squash' | 'rebase';
+        }
+      ) => Promise<{
         success: boolean;
         output?: string;
         error?: string;
       }>;
-      disableAutoMerge: (args: {
-        taskPath: string;
-        prNumber?: number;
-        sshConnectionId?: string;
-      }) => Promise<{
+      disableAutoMerge: (args: TaskPathLocator & { prNumber?: number }) => Promise<{
         success: boolean;
         output?: string;
         error?: string;
       }>;
-      getCheckRuns: (args: { taskPath: string; sshConnectionId?: string }) => Promise<{
+      getCheckRuns: (args: TaskPathLocator) => Promise<{
         success: boolean;
         checks?: Array<{
           name: string;
@@ -615,11 +620,7 @@ declare global {
         error?: string;
         code?: string;
       }>;
-      getPrComments: (args: {
-        taskPath: string;
-        prNumber?: number;
-        sshConnectionId?: string;
-      }) => Promise<{
+      getPrComments: (args: TaskPathLocator & { prNumber?: number }) => Promise<{
         success: boolean;
         comments?: Array<{
           id: string;
@@ -637,7 +638,7 @@ declare global {
         error?: string;
         code?: string;
       }>;
-      getBranchStatus: (args: { taskPath: string; taskId?: string }) => Promise<{
+      getBranchStatus: (args: TaskPathLocator) => Promise<{
         success: boolean;
         branch?: string;
         defaultBranch?: string;
@@ -646,21 +647,17 @@ declare global {
         aheadOfDefault?: number;
         error?: string;
       }>;
-      renameBranch: (args: {
-        repoPath: string;
-        oldBranch: string;
-        newBranch: string;
-        sshConnectionId?: string;
-      }) => Promise<{
+      renameBranch: (
+        args: RepoPathLocator & {
+          oldBranch: string;
+          newBranch: string;
+        }
+      ) => Promise<{
         success: boolean;
         remotePushed?: boolean;
         error?: string;
       }>;
-      listRemoteBranches: (args: {
-        projectPath: string;
-        remote?: string;
-        sshConnectionId?: string;
-      }) => Promise<{
+      listRemoteBranches: (args: ProjectPathLocator & { remote?: string }) => Promise<{
         success: boolean;
         branches?: Array<{ ref: string; remote: string; branch: string; label: string }>;
         error?: string;
@@ -1585,19 +1582,24 @@ export interface ElectronAPI {
     projectId: string;
     baseRef?: string;
   }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
-  worktreeList: (args: {
-    projectPath: string;
-  }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+  worktreeList: (args: ProjectPathLocator) => Promise<{
+    success: boolean;
+    worktrees?: any[];
+    error?: string;
+  }>;
   worktreeRemove: (args: {
     projectPath: string;
     worktreeId: string;
     worktreePath?: string;
     branch?: string;
     taskName?: string;
+    sshConnectionId?: string;
   }) => Promise<{ success: boolean; error?: string }>;
-  worktreeStatus: (args: {
-    worktreePath: string;
-  }) => Promise<{ success: boolean; status?: any; error?: string }>;
+  worktreeStatus: (args: WorktreePathLocator) => Promise<{
+    success: boolean;
+    status?: any;
+    error?: string;
+  }>;
   worktreeMerge: (args: {
     projectPath: string;
     worktreeId: string;
@@ -1759,32 +1761,29 @@ export interface ElectronAPI {
     path?: string;
     error?: string;
   }>;
-  listRemoteBranches: (args: {
-    projectPath: string;
-    remote?: string;
-    sshConnectionId?: string;
-  }) => Promise<{
+  listRemoteBranches: (args: ProjectPathLocator & { remote?: string }) => Promise<{
     success: boolean;
     branches?: Array<{ ref: string; remote: string; branch: string; label: string }>;
     error?: string;
   }>;
-  createPullRequest: (args: {
-    taskPath: string;
-    title?: string;
-    body?: string;
-    base?: string;
-    head?: string;
-    draft?: boolean;
-    web?: boolean;
-    fill?: boolean;
-    skipPrePush?: boolean;
-  }) => Promise<{
+  createPullRequest: (
+    args: TaskPathLocator & {
+      title?: string;
+      body?: string;
+      base?: string;
+      head?: string;
+      draft?: boolean;
+      web?: boolean;
+      fill?: boolean;
+      skipPrePush?: boolean;
+    }
+  ) => Promise<{
     success: boolean;
     url?: string;
     output?: string;
     error?: string;
   }>;
-  mergeToMain: (args: { taskPath: string; taskId?: string }) => Promise<{
+  mergeToMain: (args: TaskPathLocator) => Promise<{
     success: boolean;
     output?: string;
     prUrl?: string;
@@ -2282,5 +2281,3 @@ export interface ElectronAPI {
   }>;
   onPerfSnapshot: (listener: (snapshot: ResourceMetricsSnapshot) => void) => () => void;
 }
-import type { TerminalSnapshotPayload } from '#types/terminalSnapshot';
-import type { OpenInAppId } from '#shared/openInApps';

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -1,0 +1,2286 @@
+// Updated for Codex integration
+
+import type { AgentEvent } from '../../shared/agentEvents';
+import type { AutoMergeRequest } from '../lib/prStatus';
+import type { DiffPayload } from '../../shared/diff/types';
+import type { GitIndexUpdateArgs } from '../../shared/git/types';
+import type { ResourceMetricsSnapshot } from '../../shared/performanceTypes';
+import type { SentryIssue } from '../../shared/integrations/sentryTypes';
+
+type ProjectSettingsPayload = {
+  projectId: string;
+  name: string;
+  path: string;
+  gitRemote?: string;
+  gitBranch?: string;
+  baseRef?: string;
+};
+
+export type ProviderCustomConfig = {
+  cli?: string;
+  resumeFlag?: string;
+  defaultArgs?: string;
+  autoApproveFlag?: string;
+  initialPromptFlag?: string;
+  extraArgs?: string;
+  env?: Record<string, string>;
+};
+
+export type ProviderCustomConfigs = Record<string, ProviderCustomConfig>;
+
+export {};
+
+declare global {
+  interface Window {
+    electronAPI: {
+      // App info
+      getAppVersion: () => Promise<string>;
+      getElectronVersion: () => Promise<string>;
+      getPlatform: () => Promise<string>;
+      listInstalledFonts: (args?: {
+        refresh?: boolean;
+      }) => Promise<{ success: boolean; fonts?: string[]; cached?: boolean; error?: string }>;
+      undo: () => Promise<{ success: boolean; error?: string }>;
+      redo: () => Promise<{ success: boolean; error?: string }>;
+      // Updater
+      checkForUpdates: () => Promise<{ success: boolean; result?: any; error?: string }>;
+      downloadUpdate: () => Promise<{ success: boolean; error?: string }>;
+      quitAndInstallUpdate: () => Promise<{ success: boolean; error?: string }>;
+      openLatestDownload: () => Promise<{ success: boolean; error?: string }>;
+      onUpdateEvent: (listener: (data: { type: string; payload?: any }) => void) => () => void;
+      // Enhanced update methods
+      getUpdateState: () => Promise<{ success: boolean; data?: any; error?: string }>;
+      getUpdateSettings: () => Promise<{ success: boolean; data?: any; error?: string }>;
+      updateUpdateSettings: (settings: any) => Promise<{ success: boolean; error?: string }>;
+      getReleaseNotes: () => Promise<{ success: boolean; data?: string | null; error?: string }>;
+      checkForUpdatesNow: () => Promise<{ success: boolean; data?: any; error?: string }>;
+
+      // Window controls (custom title bar on Windows/Linux)
+      windowMinimize: () => Promise<void>;
+      windowMaximize: () => Promise<void>;
+      windowClose: () => Promise<void>;
+      windowIsMaximized: () => Promise<boolean>;
+      popupMenu: (args: { label: string; x: number; y: number }) => Promise<void>;
+      onWindowMaximizeChange: (listener: (isMaximized: boolean) => void) => () => void;
+
+      // Menu events (main → renderer)
+      onMenuOpenSettings: (listener: () => void) => () => void;
+      onMenuCheckForUpdates: (listener: () => void) => () => void;
+      onMenuUndo: (listener: () => void) => () => void;
+      onMenuRedo: (listener: () => void) => () => void;
+      onMenuCloseTab: (listener: () => void) => () => void;
+
+      // PTY
+      ptyStart: (opts: {
+        id: string;
+        cwd?: string;
+        remote?: { connectionId: string };
+        shell?: string;
+        env?: Record<string, string>;
+        cols?: number;
+        rows?: number;
+        autoApprove?: boolean;
+        initialPrompt?: string;
+        skipResume?: boolean;
+      }) => Promise<{ ok: boolean; tmux?: boolean; error?: string }>;
+      ptyStartDirect: (opts: {
+        id: string;
+        providerId: string;
+        cwd: string;
+        remote?: { connectionId: string };
+        cols?: number;
+        rows?: number;
+        autoApprove?: boolean;
+        initialPrompt?: string;
+        env?: Record<string, string>;
+        resume?: boolean;
+      }) => Promise<{ ok: boolean; reused?: boolean; tmux?: boolean; error?: string }>;
+      ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) => Promise<{
+        success: boolean;
+        remotePaths?: string[];
+        error?: string;
+      }>;
+      ptyInput: (args: { id: string; data: string }) => void;
+      ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
+      ptyKill: (id: string) => void;
+      ptyKillTmux: (id: string) => Promise<{ ok: boolean; error?: string }>;
+      onPtyData: (id: string, listener: (data: string) => void) => () => void;
+      ptyGetSnapshot: (args: { id: string }) => Promise<{
+        ok: boolean;
+        snapshot?: any;
+        error?: string;
+      }>;
+      ptySaveSnapshot: (args: { id: string; payload: TerminalSnapshotPayload }) => Promise<{
+        ok: boolean;
+        error?: string;
+      }>;
+      ptyClearSnapshot: (args: { id: string }) => Promise<{ ok: boolean }>;
+      ptyCleanupSessions: (args: {
+        ids: string[];
+        clearSnapshots?: boolean;
+        waitForSnapshots?: boolean;
+      }) => Promise<{
+        ok: boolean;
+        cleaned: number;
+        failedIds: string[];
+        snapshotClearQueued: boolean;
+      }>;
+      onPtyExit: (
+        id: string,
+        listener: (info: { exitCode: number; signal?: number }) => void
+      ) => () => void;
+      onPtyStarted: (listener: (data: { id: string }) => void) => () => void;
+      onPtyActivity: (listener: (data: { id: string; chunk?: string }) => void) => () => void;
+      onPtyExitGlobal: (listener: (data: { id: string }) => void) => () => void;
+      onAgentEvent: (
+        listener: (event: AgentEvent, meta: { appFocused: boolean }) => void
+      ) => () => void;
+      onNotificationFocusTask: (listener: (taskId: string) => void) => () => void;
+      terminalGetTheme: () => Promise<{
+        ok: boolean;
+        config?: {
+          terminal: string;
+          theme: {
+            background?: string;
+            foreground?: string;
+            cursor?: string;
+            cursorAccent?: string;
+            selectionBackground?: string;
+            black?: string;
+            red?: string;
+            green?: string;
+            yellow?: string;
+            blue?: string;
+            magenta?: string;
+            cyan?: string;
+            white?: string;
+            brightBlack?: string;
+            brightRed?: string;
+            brightGreen?: string;
+            brightYellow?: string;
+            brightBlue?: string;
+            brightMagenta?: string;
+            brightCyan?: string;
+            brightWhite?: string;
+            fontFamily?: string;
+            fontSize?: number;
+          };
+        };
+        error?: string;
+      }>;
+
+      // Worktree management
+      worktreeCreate: (args: {
+        projectPath: string;
+        taskName: string;
+        projectId: string;
+        baseRef?: string;
+      }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+      worktreeList: (args: {
+        projectPath: string;
+        sshConnectionId?: string;
+      }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+      worktreeRemove: (args: {
+        projectPath: string;
+        worktreeId: string;
+        worktreePath?: string;
+        branch?: string;
+        taskName?: string;
+        sshConnectionId?: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreeStatus: (args: {
+        worktreePath: string;
+      }) => Promise<{ success: boolean; status?: any; error?: string }>;
+      worktreeMerge: (args: {
+        projectPath: string;
+        worktreeId: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreeGet: (args: {
+        worktreeId: string;
+      }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+      worktreeGetAll: () => Promise<{
+        success: boolean;
+        worktrees?: any[];
+        error?: string;
+      }>;
+
+      // Worktree pool (reserve) management for instant task creation
+      worktreeEnsureReserve: (args: {
+        projectId: string;
+        projectPath: string;
+        baseRef?: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreePreflightReserve: (args: {
+        projectId: string;
+        projectPath: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      worktreeHasReserve: (args: {
+        projectId: string;
+      }) => Promise<{ success: boolean; hasReserve?: boolean; error?: string }>;
+      worktreeClaimReserve: (args: {
+        projectId: string;
+        projectPath: string;
+        taskName: string;
+        baseRef?: string;
+      }) => Promise<{
+        success: boolean;
+        worktree?: any;
+        needsBaseRefSwitch?: boolean;
+        error?: string;
+      }>;
+      worktreeClaimReserveAndSaveTask: (args: {
+        projectId: string;
+        projectPath: string;
+        taskName: string;
+        baseRef?: string;
+        task: {
+          projectId: string;
+          name: string;
+          status: 'active' | 'idle' | 'running';
+          agentId?: string | null;
+          metadata?: any;
+          useWorktree?: boolean;
+        };
+      }) => Promise<{
+        success: boolean;
+        worktree?: any;
+        task?: any;
+        needsBaseRefSwitch?: boolean;
+        error?: string;
+      }>;
+      worktreeRemoveReserve: (args: {
+        projectId: string;
+        projectPath?: string;
+        isRemote?: boolean;
+      }) => Promise<{ success: boolean; error?: string }>;
+
+      // Lifecycle scripts
+      lifecycleGetScript: (args: {
+        projectPath: string;
+        phase: 'setup' | 'run' | 'teardown';
+      }) => Promise<{ success: boolean; script?: string | null; error?: string }>;
+      lifecycleSetup: (args: {
+        taskId: string;
+        taskPath: string;
+        projectPath: string;
+        taskName?: string;
+      }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+      lifecycleRunStart: (args: {
+        taskId: string;
+        taskPath: string;
+        projectPath: string;
+        taskName?: string;
+      }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+      lifecycleRunStop: (args: {
+        taskId: string;
+        taskPath?: string;
+        projectPath?: string;
+        taskName?: string;
+      }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+      lifecycleTeardown: (args: {
+        taskId: string;
+        taskPath: string;
+        projectPath: string;
+        taskName?: string;
+      }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+      lifecycleGetState: (args: { taskId: string }) => Promise<{
+        success: boolean;
+        state?: {
+          taskId: string;
+          setup: {
+            status: 'idle' | 'running' | 'succeeded' | 'failed';
+            startedAt?: string;
+            finishedAt?: string;
+            exitCode?: number | null;
+            error?: string | null;
+          };
+          run: {
+            status: 'idle' | 'running' | 'succeeded' | 'failed';
+            startedAt?: string;
+            finishedAt?: string;
+            exitCode?: number | null;
+            error?: string | null;
+            pid?: number | null;
+          };
+          teardown: {
+            status: 'idle' | 'running' | 'succeeded' | 'failed';
+            startedAt?: string;
+            finishedAt?: string;
+            exitCode?: number | null;
+            error?: string | null;
+          };
+        };
+        error?: string;
+      }>;
+      lifecycleGetLogs: (args: { taskId: string }) => Promise<{
+        success: boolean;
+        logs?: { setup: string[]; run: string[]; teardown: string[] };
+        error?: string;
+      }>;
+      lifecycleClearTask: (args: {
+        taskId: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      onLifecycleEvent: (listener: (data: any) => void) => () => void;
+
+      // Project management
+      openProject: () => Promise<{
+        success: boolean;
+        path?: string;
+        error?: string;
+      }>;
+      openFile: (args?: {
+        title?: string;
+        message?: string;
+        filters?: Electron.FileFilter[];
+      }) => Promise<{
+        success: boolean;
+        path?: string;
+        error?: string;
+      }>;
+      getProjectSettings: (projectId: string) => Promise<{
+        success: boolean;
+        settings?: ProjectSettingsPayload;
+        error?: string;
+      }>;
+      updateProjectSettings: (args: { projectId: string; baseRef: string }) => Promise<{
+        success: boolean;
+        settings?: ProjectSettingsPayload;
+        error?: string;
+      }>;
+      getGitInfo: (projectPath: string) => Promise<{
+        isGitRepo: boolean;
+        remote?: string;
+        branch?: string;
+        baseRef?: string;
+        upstream?: string;
+        aheadCount?: number;
+        behindCount?: number;
+        path?: string;
+        rootPath?: string;
+        error?: string;
+      }>;
+      getGitStatus: (arg: string | { taskPath: string; taskId?: string }) => Promise<{
+        success: boolean;
+        changes?: Array<{
+          path: string;
+          status: string;
+          additions: number | null;
+          deletions: number | null;
+          isStaged: boolean;
+          diff?: string;
+        }>;
+        error?: string;
+      }>;
+      getDeleteRisks: (args: {
+        targets: Array<{ id: string; taskPath: string; sshConnectionId?: string }>;
+        includePr?: boolean;
+      }) => Promise<{
+        success: boolean;
+        risks?: Record<
+          string,
+          {
+            staged: number;
+            unstaged: number;
+            untracked: number;
+            files: string[];
+            ahead: number;
+            behind: number;
+            error?: string;
+            pr?: {
+              number?: number;
+              title?: string;
+              url?: string;
+              state?: string | null;
+              isDraft?: boolean;
+            } | null;
+            prKnown: boolean;
+          }
+        >;
+        error?: string;
+      }>;
+      watchGitStatus: (arg: string | { taskPath: string; taskId?: string }) => Promise<{
+        success: boolean;
+        watchId?: string;
+        error?: string;
+      }>;
+      unwatchGitStatus: (
+        arg: string | { taskPath: string; taskId?: string },
+        watchId?: string
+      ) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      onGitStatusChanged: (
+        listener: (data: { taskPath: string; error?: string }) => void
+      ) => () => void;
+      getFileDiff: (args: {
+        taskPath: string;
+        taskId?: string;
+        filePath: string;
+        baseRef?: string;
+        forceLarge?: boolean;
+      }) => Promise<{
+        success: boolean;
+        diff?: DiffPayload;
+        error?: string;
+      }>;
+      updateIndex: (args: { taskPath: string; taskId?: string } & GitIndexUpdateArgs) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      revertFile: (args: { taskPath: string; taskId?: string; filePath: string }) => Promise<{
+        success: boolean;
+        action?: 'reverted';
+        error?: string;
+      }>;
+      gitCommit: (args: { taskPath: string; message: string }) => Promise<{
+        success: boolean;
+        hash?: string;
+        error?: string;
+      }>;
+      gitPush: (args: { taskPath: string }) => Promise<{
+        success: boolean;
+        output?: string;
+        error?: string;
+      }>;
+      gitPull: (args: { taskPath: string }) => Promise<{
+        success: boolean;
+        output?: string;
+        error?: string;
+      }>;
+      gitGetLog: (args: {
+        taskPath: string;
+        maxCount?: number;
+        skip?: number;
+        aheadCount?: number;
+      }) => Promise<{
+        success: boolean;
+        commits?: Array<{
+          hash: string;
+          subject: string;
+          body: string;
+          author: string;
+          authorEmail: string;
+          date: string;
+          isPushed: boolean;
+          tags: string[];
+        }>;
+        aheadCount?: number;
+        error?: string;
+      }>;
+      gitGetLatestCommit: (args: { taskPath: string }) => Promise<{
+        success: boolean;
+        commit?: {
+          hash: string;
+          subject: string;
+          body: string;
+          isPushed: boolean;
+        } | null;
+        error?: string;
+      }>;
+      gitGetCommitFiles: (args: { taskPath: string; commitHash: string }) => Promise<{
+        success: boolean;
+        files?: Array<{
+          path: string;
+          status: string;
+          additions: number;
+          deletions: number;
+        }>;
+        error?: string;
+      }>;
+      gitGetCommitFileDiff: (args: {
+        taskPath: string;
+        commitHash: string;
+        filePath: string;
+        forceLarge?: boolean;
+      }) => Promise<{
+        success: boolean;
+        diff?: DiffPayload;
+        error?: string;
+      }>;
+      gitSoftReset: (args: { taskPath: string }) => Promise<{
+        success: boolean;
+        subject?: string;
+        body?: string;
+        error?: string;
+      }>;
+      gitCommitAndPush: (args: {
+        taskPath: string;
+        taskId?: string;
+        commitMessage?: string;
+        createBranchIfOnDefault?: boolean;
+        branchPrefix?: string;
+      }) => Promise<{
+        success: boolean;
+        branch?: string;
+        output?: string;
+        error?: string;
+      }>;
+      generatePrContent: (args: {
+        taskPath: string;
+        base?: string;
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        title?: string;
+        description?: string;
+        error?: string;
+      }>;
+      createPullRequest: (args: {
+        taskPath: string;
+        title?: string;
+        body?: string;
+        base?: string;
+        head?: string;
+        draft?: boolean;
+        web?: boolean;
+        fill?: boolean;
+        skipPrePush?: boolean;
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        url?: string;
+        output?: string;
+        error?: string;
+      }>;
+      mergeToMain: (args: { taskPath: string; taskId?: string }) => Promise<{
+        success: boolean;
+        output?: string;
+        prUrl?: string;
+        error?: string;
+      }>;
+      mergePr: (args: {
+        taskPath: string;
+        prNumber?: number;
+        strategy?: 'merge' | 'squash' | 'rebase';
+        admin?: boolean;
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        output?: string;
+        error?: string;
+        code?: string;
+      }>;
+      getPrStatus: (args: { taskPath: string; sshConnectionId?: string }) => Promise<{
+        success: boolean;
+        pr?: {
+          number: number;
+          url: string;
+          state: string;
+          isDraft?: boolean;
+          mergeStateStatus?: string;
+          headRefName?: string;
+          baseRefName?: string;
+          title?: string;
+          author?: any;
+          additions?: number;
+          deletions?: number;
+          changedFiles?: number;
+          autoMergeRequest?: AutoMergeRequest | null;
+        } | null;
+        error?: string;
+      }>;
+      enableAutoMerge: (args: {
+        taskPath: string;
+        prNumber?: number;
+        strategy?: 'merge' | 'squash' | 'rebase';
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        output?: string;
+        error?: string;
+      }>;
+      disableAutoMerge: (args: {
+        taskPath: string;
+        prNumber?: number;
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        output?: string;
+        error?: string;
+      }>;
+      getCheckRuns: (args: { taskPath: string; sshConnectionId?: string }) => Promise<{
+        success: boolean;
+        checks?: Array<{
+          name: string;
+          state: string;
+          bucket: 'pass' | 'fail' | 'pending' | 'skipping' | 'cancel';
+          description?: string;
+          link?: string;
+          workflow?: string;
+          event?: string;
+          startedAt?: string;
+          completedAt?: string;
+        }> | null;
+        error?: string;
+        code?: string;
+      }>;
+      getPrComments: (args: {
+        taskPath: string;
+        prNumber?: number;
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        comments?: Array<{
+          id: string;
+          author: { login: string; avatarUrl?: string };
+          body: string;
+          createdAt: string;
+        }>;
+        reviews?: Array<{
+          id: string;
+          author: { login: string; avatarUrl?: string };
+          body: string;
+          submittedAt: string;
+          state: string;
+        }>;
+        error?: string;
+        code?: string;
+      }>;
+      getBranchStatus: (args: { taskPath: string; taskId?: string }) => Promise<{
+        success: boolean;
+        branch?: string;
+        defaultBranch?: string;
+        ahead?: number;
+        behind?: number;
+        aheadOfDefault?: number;
+        error?: string;
+      }>;
+      renameBranch: (args: {
+        repoPath: string;
+        oldBranch: string;
+        newBranch: string;
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        remotePushed?: boolean;
+        error?: string;
+      }>;
+      listRemoteBranches: (args: {
+        projectPath: string;
+        remote?: string;
+        sshConnectionId?: string;
+      }) => Promise<{
+        success: boolean;
+        branches?: Array<{ ref: string; remote: string; branch: string; label: string }>;
+        error?: string;
+      }>;
+      openExternal: (url: string) => Promise<{ success: boolean; error?: string }>;
+      clipboardWriteText: (text: string) => Promise<{ success: boolean; error?: string }>;
+      paste: () => Promise<{ success: boolean; error?: string }>;
+      openIn: (args: {
+        app: OpenInAppId;
+        path: string;
+        isRemote?: boolean;
+        sshConnectionId?: string | null;
+      }) => Promise<{ success: boolean; error?: string }>;
+      checkInstalledApps: () => Promise<Record<OpenInAppId, boolean>>;
+      connectToGitHub: (projectPath: string) => Promise<{
+        success: boolean;
+        repository?: string;
+        branch?: string;
+        error?: string;
+      }>;
+      // Telemetry
+      captureTelemetry: (
+        event: string,
+        properties?: Record<string, any>
+      ) => Promise<{ success: boolean; disabled?: boolean; error?: string }>;
+      getTelemetryStatus: () => Promise<{
+        success: boolean;
+        status?: {
+          enabled: boolean;
+          envDisabled: boolean;
+          userOptOut: boolean;
+          hasKeyAndHost: boolean;
+          onboardingSeen?: boolean;
+          posthogKey?: string;
+          posthogHost?: string;
+        };
+        error?: string;
+      }>;
+      setTelemetryEnabled: (enabled: boolean) => Promise<{
+        success: boolean;
+        status?: {
+          enabled: boolean;
+          envDisabled: boolean;
+          userOptOut: boolean;
+          hasKeyAndHost: boolean;
+          onboardingSeen?: boolean;
+          posthogKey?: string;
+          posthogHost?: string;
+        };
+        error?: string;
+      }>;
+      setOnboardingSeen: (flag: boolean) => Promise<{
+        success: boolean;
+        status?: {
+          enabled: boolean;
+          envDisabled: boolean;
+          userOptOut: boolean;
+          hasKeyAndHost: boolean;
+          onboardingSeen?: boolean;
+        };
+        error?: string;
+      }>;
+
+      // Filesystem helpers
+      fsList: (
+        root: string,
+        opts?: {
+          includeDirs?: boolean;
+          maxEntries?: number;
+          timeBudgetMs?: number;
+          connectionId?: string;
+          remotePath?: string;
+          recursive?: boolean;
+        }
+      ) => Promise<{
+        success: boolean;
+        items?: Array<{ path: string; type: 'file' | 'dir' }>;
+        error?: string;
+        canceled?: boolean;
+        truncated?: boolean;
+        reason?: string;
+        durationMs?: number;
+      }>;
+      fsRead: (
+        root: string,
+        relPath: string,
+        maxBytes?: number,
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{
+        success: boolean;
+        path?: string;
+        size?: number;
+        truncated?: boolean;
+        content?: string;
+        error?: string;
+      }>;
+      fsReadImage: (
+        root: string,
+        relPath: string,
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{
+        success: boolean;
+        dataUrl?: string;
+        mimeType?: string;
+        size?: number;
+        error?: string;
+      }>;
+      fsSearchContent: (
+        root: string,
+        query: string,
+        options?: {
+          caseSensitive?: boolean;
+          maxResults?: number;
+          fileExtensions?: string[];
+        },
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{
+        success: boolean;
+        results?: Array<{
+          file: string;
+          matches: Array<{
+            line: number;
+            column: number;
+            text: string;
+            preview: string;
+          }>;
+        }>;
+        error?: string;
+      }>;
+      fsWriteFile: (
+        root: string,
+        relPath: string,
+        content: string,
+        mkdirs?: boolean,
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{ success: boolean; error?: string }>;
+      fsRemove: (
+        root: string,
+        relPath: string,
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{ success: boolean; error?: string }>;
+
+      fsRename: (
+        root: string,
+        oldName: string,
+        newName: string,
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{ success: boolean; error?: string }>;
+      fsMkdir: (
+        root: string,
+        relPath: string,
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{ success: boolean; error?: string }>;
+      fsRmdir: (
+        root: string,
+        relPath: string,
+        remote?: { connectionId: string; remotePath: string }
+      ) => Promise<{ success: boolean; error?: string }>;
+
+      getProjectConfig: (
+        projectPath: string
+      ) => Promise<{ success: boolean; path?: string; content?: string; error?: string }>;
+      saveProjectConfig: (
+        projectPath: string,
+        content: string
+      ) => Promise<{ success: boolean; path?: string; error?: string }>;
+      ensureGitignore: (
+        projectPath: string,
+        patterns: string[]
+      ) => Promise<{ success: boolean; error?: string }>;
+      // Attachments
+      saveAttachment: (args: { taskPath: string; srcPath: string; subdir?: string }) => Promise<{
+        success: boolean;
+        absPath?: string;
+        relPath?: string;
+        fileName?: string;
+        error?: string;
+      }>;
+
+      // Emdash Account
+      accountGetSession: () => Promise<{
+        success: boolean;
+        data?: {
+          user: { userId: string; username: string; avatarUrl: string; email: string } | null;
+          isSignedIn: boolean;
+          hasAccount: boolean;
+        };
+        error?: string;
+      }>;
+      accountSignIn: () => Promise<{
+        success: boolean;
+        data?: { user: { userId: string; username: string; avatarUrl: string; email: string } };
+        error?: string;
+      }>;
+      accountSignOut: () => Promise<{ success: boolean; error?: string }>;
+      accountCheckServerHealth: () => Promise<{
+        success: boolean;
+        data?: { available: boolean };
+      }>;
+      accountValidateSession: () => Promise<{
+        success: boolean;
+        data?: { valid: boolean };
+        error?: string;
+      }>;
+
+      // GitHub integration
+      githubAuth: () => Promise<{
+        success: boolean;
+        token?: string;
+        user?: any;
+        device_code?: string;
+        user_code?: string;
+        verification_uri?: string;
+        expires_in?: number;
+        interval?: number;
+        error?: string;
+      }>;
+      githubAuthOAuth: () => Promise<{
+        success: boolean;
+        token?: string;
+        user?: any;
+        error?: string;
+      }>;
+      githubCancelAuth: () => Promise<{ success: boolean; error?: string }>;
+      onGithubAuthDeviceCode: (
+        callback: (data: {
+          userCode: string;
+          verificationUri: string;
+          expiresIn: number;
+          interval: number;
+        }) => void
+      ) => () => void;
+      onGithubAuthPolling: (callback: (data: { status: string }) => void) => () => void;
+      onGithubAuthSlowDown: (callback: (data: { newInterval: number }) => void) => () => void;
+      onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => () => void;
+      onGithubAuthError: (
+        callback: (data: { error: string; message: string }) => void
+      ) => () => void;
+      onGithubAuthCancelled: (callback: () => void) => () => void;
+      onGithubAuthUserUpdated: (callback: (data: { user: any }) => void) => () => void;
+      githubIsAuthenticated: () => Promise<boolean>;
+      githubGetStatus: () => Promise<{
+        installed: boolean;
+        authenticated: boolean;
+        user?: any;
+      }>;
+      githubGetUser: () => Promise<any>;
+      githubGetRepositories: () => Promise<any[]>;
+      githubCloneRepository: (
+        repoUrl: string,
+        localPath: string
+      ) => Promise<{ success: boolean; error?: string }>;
+      githubGetOwners: () => Promise<{
+        success: boolean;
+        owners?: Array<{ login: string; type: 'User' | 'Organization' }>;
+        error?: string;
+      }>;
+      githubValidateRepoName: (
+        name: string,
+        owner: string
+      ) => Promise<{
+        success: boolean;
+        valid?: boolean;
+        exists?: boolean;
+        error?: string;
+      }>;
+      githubCreateNewProject: (params: {
+        name: string;
+        description?: string;
+        owner: string;
+        isPrivate: boolean;
+        gitignoreTemplate?: string;
+      }) => Promise<{
+        success: boolean;
+        projectPath?: string;
+        repoUrl?: string;
+        fullName?: string;
+        defaultBranch?: string;
+        githubRepoCreated?: boolean;
+        error?: string;
+      }>;
+      githubCheckCLIInstalled: () => Promise<boolean>;
+      githubInstallCLI: () => Promise<{ success: boolean; error?: string }>;
+      githubListPullRequests: (args: {
+        projectPath: string;
+        limit?: number;
+        searchQuery?: string;
+      }) => Promise<{ success: boolean; prs?: any[]; totalCount?: number; error?: string }>;
+      githubCreatePullRequestWorktree: (args: {
+        projectPath: string;
+        projectId: string;
+        prNumber: number;
+        prTitle?: string;
+        taskName?: string;
+        branchName?: string;
+      }) => Promise<{
+        success: boolean;
+        worktree?: any;
+        branchName?: string;
+        taskName?: string;
+        task?: {
+          id: string;
+          name: string;
+          path: string;
+          branch: string;
+          projectId: string;
+          status: string;
+          agentId: string;
+          metadata?: { prNumber?: number; prTitle?: string | null };
+        };
+        error?: string;
+      }>;
+      githubGetPullRequestBaseDiff: (args: { worktreePath: string; prNumber: number }) => Promise<{
+        success: boolean;
+        diff?: string;
+        baseBranch?: string;
+        headBranch?: string;
+        prUrl?: string;
+        error?: string;
+      }>;
+      githubLogout: () => Promise<void>;
+      // Linear integration
+      linearCheckConnection?: () => Promise<{
+        connected: boolean;
+        taskName?: string;
+        error?: string;
+      }>;
+      linearSaveToken?: (token: string) => Promise<{
+        success: boolean;
+        taskName?: string;
+        error?: string;
+      }>;
+      linearClearToken?: () => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      linearInitialFetch?: (limit?: number) => Promise<{
+        success: boolean;
+        issues?: any[];
+        error?: string;
+      }>;
+      linearSearchIssues?: (
+        searchTerm: string,
+        limit?: number
+      ) => Promise<{
+        success: boolean;
+        issues?: any[];
+        error?: string;
+      }>;
+      // Jira integration
+      jiraSaveCredentials?: (args: {
+        siteUrl: string;
+        email: string;
+        token: string;
+      }) => Promise<{ success: boolean; displayName?: string; error?: string }>;
+      jiraClearCredentials?: () => Promise<{ success: boolean; error?: string }>;
+      jiraCheckConnection?: () => Promise<{
+        connected: boolean;
+        displayName?: string;
+        siteUrl?: string;
+        error?: string;
+      }>;
+      jiraInitialFetch?: (limit?: number) => Promise<{
+        success: boolean;
+        issues?: any[];
+        error?: string;
+      }>;
+      jiraSearchIssues?: (
+        searchTerm: string,
+        limit?: number
+      ) => Promise<{ success: boolean; issues?: any[]; error?: string }>;
+      // GitLab
+      gitlabSaveCredentials?: (args: {
+        instanceUrl: string;
+        token: string;
+      }) => Promise<{ success: boolean; displayName?: string; error?: string }>;
+      gitlabClearCredentials?: () => Promise<{ success: boolean; error?: string }>;
+      gitlabCheckConnection?: () => Promise<{
+        success: boolean;
+        username?: string;
+        instanceUrl?: string;
+        error?: string;
+      }>;
+      gitlabInitialFetch?: (
+        projectPath: string,
+        limit?: number
+      ) => Promise<{ success: boolean; issues?: any[]; error?: string }>;
+      gitlabSearchIssues?: (
+        projectPath: string,
+        searchTerm: string,
+        limit?: number
+      ) => Promise<{ success: boolean; issues?: any[]; error?: string }>;
+      // Plain integration
+      plainSaveToken?: (token: string) => Promise<{
+        success: boolean;
+        workspaceName?: string;
+        error?: string;
+      }>;
+      plainCheckConnection?: () => Promise<{
+        connected: boolean;
+        workspaceName?: string;
+        error?: string;
+      }>;
+      plainClearToken?: () => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      plainInitialFetch?: (
+        limit?: number,
+        statuses?: string[]
+      ) => Promise<{
+        success: boolean;
+        threads?: any[];
+        error?: string;
+      }>;
+      plainSearchThreads?: (
+        searchTerm: string,
+        limit?: number
+      ) => Promise<{
+        success: boolean;
+        threads?: any[];
+        error?: string;
+      }>;
+      // Sentry integration
+      sentrySaveToken?: (
+        token: string,
+        organizationSlug?: string
+      ) => Promise<{
+        success: boolean;
+        organizationName?: string;
+        error?: string;
+      }>;
+      sentryCheckConnection?: () => Promise<{
+        connected: boolean;
+        organizationName?: string;
+        error?: string;
+      }>;
+      sentryClearToken?: () => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      sentryInitialFetch?: (limit?: number) => Promise<{
+        success: boolean;
+        issues?: SentryIssue[];
+        error?: string;
+      }>;
+      sentrySearchIssues?: (
+        searchTerm: string,
+        limit?: number
+      ) => Promise<{
+        success: boolean;
+        issues?: SentryIssue[];
+        error?: string;
+      }>;
+      // Forgejo
+      forgejoSaveCredentials?: (args: {
+        instanceUrl: string;
+        token: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      forgejoClearCredentials?: () => Promise<{ success: boolean; error?: string }>;
+      forgejoCheckConnection?: () => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      forgejoInitialFetch?: (
+        projectPath: string,
+        limit?: number
+      ) => Promise<{ success: boolean; issues?: any[]; error?: string }>;
+      forgejoSearchIssues?: (
+        projectPath: string,
+        searchTerm: string,
+        limit?: number
+      ) => Promise<{ success: boolean; issues?: any[]; error?: string }>;
+      getProviderStatuses?: (opts?: {
+        refresh?: boolean;
+        providers?: string[];
+        providerId?: string;
+      }) => Promise<{
+        success: boolean;
+        statuses?: Record<
+          string,
+          { installed: boolean; path?: string | null; version?: string | null; lastChecked: number }
+        >;
+        error?: string;
+      }>;
+      onProviderStatusUpdated?: (
+        listener: (data: { providerId: string; status: any }) => void
+      ) => () => void;
+      getProviderCustomConfig?: (providerId: string) => Promise<{
+        success: boolean;
+        config?: ProviderCustomConfig;
+        error?: string;
+      }>;
+      getAllProviderCustomConfigs?: () => Promise<{
+        success: boolean;
+        configs?: ProviderCustomConfigs;
+        error?: string;
+      }>;
+      updateProviderCustomConfig?: (
+        providerId: string,
+        config: ProviderCustomConfig | undefined
+      ) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+
+      // Debug helpers
+      debugAppendLog: (
+        filePath: string,
+        content: string,
+        options?: { reset?: boolean }
+      ) => Promise<{ success: boolean; error?: string }>;
+
+      // SSH operations
+      sshTestConnection: (config: {
+        id?: string;
+        name: string;
+        host: string;
+        port: number;
+        username: string;
+        authType: 'password' | 'key' | 'agent';
+        privateKeyPath?: string;
+        useAgent?: boolean;
+        password?: string;
+        passphrase?: string;
+      }) => Promise<{ success: boolean; error?: string; latency?: number; debugLogs?: string[] }>;
+      sshSaveConnection: (config: {
+        id?: string;
+        name: string;
+        host: string;
+        port: number;
+        username: string;
+        authType: 'password' | 'key' | 'agent';
+        privateKeyPath?: string;
+        useAgent?: boolean;
+        password?: string;
+        passphrase?: string;
+      }) => Promise<{
+        id: string;
+        name: string;
+        host: string;
+        port: number;
+        username: string;
+        authType: 'password' | 'key' | 'agent';
+        privateKeyPath?: string;
+        useAgent?: boolean;
+      }>;
+      sshGetConnections: () => Promise<
+        Array<{
+          id: string;
+          name: string;
+          host: string;
+          port: number;
+          username: string;
+          authType: 'password' | 'key' | 'agent';
+          privateKeyPath?: string;
+          useAgent?: boolean;
+        }>
+      >;
+      sshDeleteConnection: (id: string) => Promise<void>;
+      sshConnect: (
+        arg:
+          | string
+          | {
+              id?: string;
+              name: string;
+              host: string;
+              port: number;
+              username: string;
+              authType: 'password' | 'key' | 'agent';
+              privateKeyPath?: string;
+              useAgent?: boolean;
+              password?: string;
+              passphrase?: string;
+            }
+      ) => Promise<string>;
+      sshDisconnect: (connectionId: string) => Promise<void>;
+      sshExecuteCommand: (
+        connectionId: string,
+        command: string,
+        cwd?: string
+      ) => Promise<{
+        stdout: string;
+        stderr: string;
+        exitCode: number;
+      }>;
+      sshListFiles: (
+        connectionId: string,
+        path: string
+      ) => Promise<
+        Array<{
+          path: string;
+          name: string;
+          type: 'file' | 'directory' | 'symlink';
+          size: number;
+          modifiedAt: Date;
+          permissions?: string;
+        }>
+      >;
+      sshReadFile: (connectionId: string, path: string) => Promise<string>;
+      sshWriteFile: (connectionId: string, path: string, content: string) => Promise<void>;
+      sshGetState: (
+        connectionId: string
+      ) => Promise<'connecting' | 'connected' | 'disconnected' | 'error'>;
+      sshGetConfig: () => Promise<{ success: boolean; hosts?: any[]; error?: string }>;
+      sshGetSshConfigHost: (hostAlias: string) => Promise<{
+        success: boolean;
+        host?: {
+          host: string;
+          hostname?: string;
+          user?: string;
+          port?: number;
+          identityFile?: string;
+        };
+        error?: string;
+      }>;
+      sshCheckIsGitRepo: (connectionId: string, remotePath: string) => Promise<boolean>;
+      sshInitRepo: (connectionId: string, parentPath: string, repoName: string) => Promise<string>;
+      sshCloneRepo: (connectionId: string, repoUrl: string, targetPath: string) => Promise<string>;
+
+      // Skills management
+      skillsGetCatalog: () => Promise<{
+        success: boolean;
+        data?: import('@shared/skills/types').CatalogIndex;
+        error?: string;
+      }>;
+      skillsRefreshCatalog: () => Promise<{
+        success: boolean;
+        data?: import('@shared/skills/types').CatalogIndex;
+        error?: string;
+      }>;
+      skillsInstall: (args: {
+        skillId: string;
+        source?: { owner: string; repo: string };
+      }) => Promise<{
+        success: boolean;
+        data?: import('@shared/skills/types').CatalogSkill;
+        error?: string;
+      }>;
+      skillsUninstall: (args: { skillId: string }) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      skillsGetDetail: (args: {
+        skillId: string;
+        source?: { owner: string; repo: string };
+      }) => Promise<{
+        success: boolean;
+        data?: import('@shared/skills/types').CatalogSkill;
+        error?: string;
+      }>;
+      skillsGetDetectedAgents: () => Promise<{
+        success: boolean;
+        data?: import('@shared/skills/types').DetectedAgent[];
+        error?: string;
+      }>;
+      skillsSearch: (args: { query: string }) => Promise<{
+        success: boolean;
+        data?: import('@shared/skills/types').CatalogSkill[];
+        error?: string;
+      }>;
+      skillsCreate: (args: { name: string; description: string; content?: string }) => Promise<{
+        success: boolean;
+        data?: import('@shared/skills/types').CatalogSkill;
+        error?: string;
+      }>;
+
+      // Workspace provisioning
+      workspaceProvision: (args: {
+        taskId: string;
+        repoUrl: string;
+        branch: string;
+        baseRef: string;
+        provisionCommand: string;
+        projectPath: string;
+      }) => Promise<{ success: boolean; data?: { instanceId: string }; error?: string }>;
+      workspaceCancel: (args: {
+        instanceId: string;
+      }) => Promise<{ success: boolean; error?: string }>;
+      workspaceTerminate: (args: {
+        instanceId: string;
+        terminateCommand: string;
+        projectPath: string;
+        env?: Record<string, string>;
+      }) => Promise<{ success: boolean; error?: string }>;
+      workspaceStatus: (args: { taskId: string }) => Promise<{
+        success: boolean;
+        data?: {
+          id: string;
+          taskId: string;
+          externalId: string | null;
+          host: string;
+          port: number;
+          username: string | null;
+          worktreePath: string | null;
+          status: string;
+          connectionId: string | null;
+          createdAt: number;
+          terminatedAt: number | null;
+        } | null;
+        error?: string;
+      }>;
+      onWorkspaceProvisionProgress: (
+        listener: (data: { instanceId: string; line: string }) => void
+      ) => () => void;
+      onWorkspaceProvisionTimeoutWarning: (
+        listener: (data: { instanceId: string; timeoutMs: number }) => void
+      ) => () => void;
+      onWorkspaceProvisionComplete: (
+        listener: (data: { instanceId: string; status: string; error?: string }) => void
+      ) => () => void;
+
+      // MCP
+      mcpLoadAll: () => Promise<{
+        success: boolean;
+        data?: import('../../shared/mcp/types').McpLoadAllResponse;
+        error?: string;
+      }>;
+      mcpSaveServer: (server: import('../../shared/mcp/types').McpServer) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      mcpRemoveServer: (serverName: string) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      mcpGetProviders: () => Promise<{
+        success: boolean;
+        data?: import('../../shared/mcp/types').McpProvidersResponse[];
+        error?: string;
+      }>;
+      mcpRefreshProviders: () => Promise<{
+        success: boolean;
+        data?: import('../../shared/mcp/types').McpProvidersResponse[];
+        error?: string;
+      }>;
+
+      // Automations
+      automationsList: () => Promise<{
+        success: boolean;
+        data?: import('../../shared/automations/types').Automation[];
+        error?: string;
+      }>;
+      automationsGet: (args: { id: string }) => Promise<{
+        success: boolean;
+        data?: import('../../shared/automations/types').Automation | null;
+        error?: string;
+      }>;
+      automationsCreate: (
+        args: import('../../shared/automations/types').CreateAutomationInput
+      ) => Promise<{
+        success: boolean;
+        data?: import('../../shared/automations/types').Automation;
+        error?: string;
+      }>;
+      automationsUpdate: (
+        args: import('../../shared/automations/types').UpdateAutomationInput
+      ) => Promise<{
+        success: boolean;
+        data?: import('../../shared/automations/types').Automation | null;
+        error?: string;
+      }>;
+      automationsDelete: (args: { id: string }) => Promise<{
+        success: boolean;
+        data?: boolean;
+        error?: string;
+      }>;
+      automationsToggle: (args: { id: string }) => Promise<{
+        success: boolean;
+        data?: import('../../shared/automations/types').Automation | null;
+        error?: string;
+      }>;
+      automationsRunLogs: (args: { automationId: string; limit?: number }) => Promise<{
+        success: boolean;
+        data?: import('../../shared/automations/types').AutomationRunLog[];
+        error?: string;
+      }>;
+      automationsTriggerNow: (args: { id: string }) => Promise<{
+        success: boolean;
+        data?: import('../../shared/automations/types').Automation;
+        error?: string;
+      }>;
+      automationsCompleteRun: (args: {
+        runLogId: string;
+        automationId: string;
+        taskId?: string;
+        status: 'success' | 'failure';
+        error?: string;
+      }) => Promise<{
+        success: boolean;
+        error?: string;
+      }>;
+      automationsDrainTriggers: () => Promise<{
+        success: boolean;
+        data?: Array<import('../../shared/automations/types').Automation & { _runLogId: string }>;
+        error?: string;
+      }>;
+      onAutomationTriggerAvailable: (listener: () => void) => () => void;
+
+      // Integrations
+      integrationsStatusMap: () => Promise<{
+        success: boolean;
+        data?: import('../../shared/integrations/types').IntegrationStatusMap;
+        error?: string;
+      }>;
+
+      // Performance Monitor
+      perfSubscribe: () => Promise<{
+        success: boolean;
+        data?: ResourceMetricsSnapshot;
+      }>;
+      perfUnsubscribe: () => Promise<{ success: boolean }>;
+      perfGetSnapshot: (mode?: 'interactive' | 'idle') => Promise<{
+        success: boolean;
+        data?: ResourceMetricsSnapshot;
+        error?: string;
+      }>;
+      onPerfSnapshot: (listener: (snapshot: ResourceMetricsSnapshot) => void) => () => void;
+    };
+  }
+}
+
+// Explicit type export for better TypeScript recognition
+export interface ElectronAPI {
+  // Menu events (main → renderer)
+  onMenuOpenSettings: (listener: () => void) => () => void;
+  onMenuCheckForUpdates: (listener: () => void) => () => void;
+  onMenuUndo: (listener: () => void) => () => void;
+  onMenuRedo: (listener: () => void) => () => void;
+  onMenuCloseTab: (listener: () => void) => () => void;
+
+  // App info
+  getVersion: () => Promise<string>;
+  getPlatform: () => Promise<string>;
+  listInstalledFonts: (args?: {
+    refresh?: boolean;
+  }) => Promise<{ success: boolean; fonts?: string[]; cached?: boolean; error?: string }>;
+  undo: () => Promise<{ success: boolean; error?: string }>;
+  redo: () => Promise<{ success: boolean; error?: string }>;
+  // Updater
+  checkForUpdates: () => Promise<{ success: boolean; result?: any; error?: string }>;
+  downloadUpdate: () => Promise<{ success: boolean; error?: string }>;
+  quitAndInstallUpdate: () => Promise<{ success: boolean; error?: string }>;
+  openLatestDownload: () => Promise<{ success: boolean; error?: string }>;
+  onUpdateEvent: (listener: (data: { type: string; payload?: any }) => void) => () => void;
+  // Enhanced update methods
+  getUpdateState: () => Promise<{ success: boolean; data?: any; error?: string }>;
+  getUpdateSettings: () => Promise<{ success: boolean; data?: any; error?: string }>;
+  updateUpdateSettings: (settings: any) => Promise<{ success: boolean; error?: string }>;
+  getReleaseNotes: () => Promise<{ success: boolean; data?: string | null; error?: string }>;
+  checkForUpdatesNow: () => Promise<{ success: boolean; data?: any; error?: string }>;
+
+  // PTY
+  ptyStart: (opts: {
+    id: string;
+    cwd?: string;
+    shell?: string;
+    env?: Record<string, string>;
+    cols?: number;
+    rows?: number;
+    autoApprove?: boolean;
+    initialPrompt?: string;
+    skipResume?: boolean;
+  }) => Promise<{ ok: boolean; tmux?: boolean; error?: string }>;
+  ptyStartDirect: (opts: {
+    id: string;
+    providerId: string;
+    cwd: string;
+    cols?: number;
+    rows?: number;
+    autoApprove?: boolean;
+    initialPrompt?: string;
+    env?: Record<string, string>;
+    resume?: boolean;
+  }) => Promise<{ ok: boolean; reused?: boolean; tmux?: boolean; error?: string }>;
+  ptyScpToRemote: (args: { connectionId: string; localPaths: string[] }) => Promise<{
+    success: boolean;
+    remotePaths?: string[];
+    error?: string;
+  }>;
+  ptyInput: (args: { id: string; data: string }) => void;
+  ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
+  ptyKill: (id: string) => void;
+  ptyKillTmux: (id: string) => Promise<{ ok: boolean; error?: string }>;
+  onPtyData: (id: string, listener: (data: string) => void) => () => void;
+  ptyGetSnapshot: (args: { id: string }) => Promise<{
+    ok: boolean;
+    snapshot?: any;
+    error?: string;
+  }>;
+  ptySaveSnapshot: (args: { id: string; payload: TerminalSnapshotPayload }) => Promise<{
+    ok: boolean;
+    error?: string;
+  }>;
+  ptyClearSnapshot: (args: { id: string }) => Promise<{ ok: boolean }>;
+  ptyCleanupSessions: (args: {
+    ids: string[];
+    clearSnapshots?: boolean;
+    waitForSnapshots?: boolean;
+  }) => Promise<{
+    ok: boolean;
+    cleaned: number;
+    failedIds: string[];
+    snapshotClearQueued: boolean;
+  }>;
+  onPtyExit: (
+    id: string,
+    listener: (info: { exitCode: number; signal?: number }) => void
+  ) => () => void;
+  onPtyStarted: (listener: (data: { id: string }) => void) => () => void;
+  onPtyActivity: (listener: (data: { id: string; chunk?: string }) => void) => () => void;
+  onPtyExitGlobal: (listener: (data: { id: string }) => void) => () => void;
+  onAgentEvent: (
+    listener: (event: AgentEvent, meta: { appFocused: boolean }) => void
+  ) => () => void;
+  onNotificationFocusTask: (listener: (taskId: string) => void) => () => void;
+
+  // Worktree management
+  worktreeCreate: (args: {
+    projectPath: string;
+    taskName: string;
+    projectId: string;
+    baseRef?: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeList: (args: {
+    projectPath: string;
+  }) => Promise<{ success: boolean; worktrees?: any[]; error?: string }>;
+  worktreeRemove: (args: {
+    projectPath: string;
+    worktreeId: string;
+    worktreePath?: string;
+    branch?: string;
+    taskName?: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeStatus: (args: {
+    worktreePath: string;
+  }) => Promise<{ success: boolean; status?: any; error?: string }>;
+  worktreeMerge: (args: {
+    projectPath: string;
+    worktreeId: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeGet: (args: {
+    worktreeId: string;
+  }) => Promise<{ success: boolean; worktree?: any; error?: string }>;
+  worktreeGetAll: () => Promise<{
+    success: boolean;
+    worktrees?: any[];
+    error?: string;
+  }>;
+
+  // Worktree pool (reserve) management for instant task creation
+  worktreeEnsureReserve: (args: {
+    projectId: string;
+    projectPath: string;
+    baseRef?: string;
+  }) => Promise<{ success: boolean; error?: string }>;
+  worktreeHasReserve: (args: {
+    projectId: string;
+  }) => Promise<{ success: boolean; hasReserve?: boolean; error?: string }>;
+  worktreeClaimReserve: (args: {
+    projectId: string;
+    projectPath: string;
+    taskName: string;
+    baseRef?: string;
+  }) => Promise<{
+    success: boolean;
+    worktree?: any;
+    needsBaseRefSwitch?: boolean;
+    error?: string;
+  }>;
+  worktreeClaimReserveAndSaveTask: (args: {
+    projectId: string;
+    projectPath: string;
+    taskName: string;
+    baseRef?: string;
+    task: {
+      projectId: string;
+      name: string;
+      status: 'active' | 'idle' | 'running';
+      agentId?: string | null;
+      metadata?: any;
+      useWorktree?: boolean;
+    };
+  }) => Promise<{
+    success: boolean;
+    worktree?: any;
+    task?: any;
+    needsBaseRefSwitch?: boolean;
+    error?: string;
+  }>;
+  worktreeRemoveReserve: (args: {
+    projectId: string;
+    projectPath?: string;
+    isRemote?: boolean;
+  }) => Promise<{ success: boolean; error?: string }>;
+
+  // Lifecycle scripts
+  lifecycleGetScript: (args: {
+    projectPath: string;
+    phase: 'setup' | 'run' | 'teardown';
+  }) => Promise<{ success: boolean; script?: string | null; error?: string }>;
+  lifecycleSetup: (args: {
+    taskId: string;
+    taskPath: string;
+    projectPath: string;
+    taskName?: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleRunStart: (args: {
+    taskId: string;
+    taskPath: string;
+    projectPath: string;
+    taskName?: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleRunStop: (args: {
+    taskId: string;
+    taskPath?: string;
+    projectPath?: string;
+    taskName?: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleTeardown: (args: {
+    taskId: string;
+    taskPath: string;
+    projectPath: string;
+    taskName?: string;
+  }) => Promise<{ success: boolean; skipped?: boolean; error?: string }>;
+  lifecycleGetState: (args: { taskId: string }) => Promise<{
+    success: boolean;
+    state?: {
+      taskId: string;
+      setup: {
+        status: 'idle' | 'running' | 'succeeded' | 'failed';
+        startedAt?: string;
+        finishedAt?: string;
+        exitCode?: number | null;
+        error?: string | null;
+      };
+      run: {
+        status: 'idle' | 'running' | 'succeeded' | 'failed';
+        startedAt?: string;
+        finishedAt?: string;
+        exitCode?: number | null;
+        error?: string | null;
+        pid?: number | null;
+      };
+      teardown: {
+        status: 'idle' | 'running' | 'succeeded' | 'failed';
+        startedAt?: string;
+        finishedAt?: string;
+        exitCode?: number | null;
+        error?: string | null;
+      };
+    };
+    error?: string;
+  }>;
+  lifecycleGetLogs: (args: { taskId: string }) => Promise<{
+    success: boolean;
+    logs?: { setup: string[]; run: string[]; teardown: string[] };
+    error?: string;
+  }>;
+  lifecycleClearTask: (args: { taskId: string }) => Promise<{ success: boolean; error?: string }>;
+  onLifecycleEvent: (listener: (data: any) => void) => () => void;
+
+  // Project management
+  openProject: () => Promise<{
+    success: boolean;
+    path?: string;
+    error?: string;
+  }>;
+  openFile: (args?: {
+    title?: string;
+    message?: string;
+    filters?: Electron.FileFilter[];
+  }) => Promise<{
+    success: boolean;
+    path?: string;
+    error?: string;
+  }>;
+  getProjectSettings: (projectId: string) => Promise<{
+    success: boolean;
+    settings?: ProjectSettingsPayload;
+    error?: string;
+  }>;
+  updateProjectSettings: (args: { projectId: string; baseRef: string }) => Promise<{
+    success: boolean;
+    settings?: ProjectSettingsPayload;
+    error?: string;
+  }>;
+  getGitInfo: (projectPath: string) => Promise<{
+    isGitRepo: boolean;
+    remote?: string;
+    branch?: string;
+    baseRef?: string;
+    upstream?: string;
+    aheadCount?: number;
+    behindCount?: number;
+    path?: string;
+    error?: string;
+  }>;
+  listRemoteBranches: (args: {
+    projectPath: string;
+    remote?: string;
+    sshConnectionId?: string;
+  }) => Promise<{
+    success: boolean;
+    branches?: Array<{ ref: string; remote: string; branch: string; label: string }>;
+    error?: string;
+  }>;
+  createPullRequest: (args: {
+    taskPath: string;
+    title?: string;
+    body?: string;
+    base?: string;
+    head?: string;
+    draft?: boolean;
+    web?: boolean;
+    fill?: boolean;
+    skipPrePush?: boolean;
+  }) => Promise<{
+    success: boolean;
+    url?: string;
+    output?: string;
+    error?: string;
+  }>;
+  mergeToMain: (args: { taskPath: string; taskId?: string }) => Promise<{
+    success: boolean;
+    output?: string;
+    prUrl?: string;
+    error?: string;
+  }>;
+  connectToGitHub: (projectPath: string) => Promise<{
+    success: boolean;
+    repository?: string;
+    branch?: string;
+    error?: string;
+  }>;
+  getProviderStatuses?: (opts?: {
+    refresh?: boolean;
+    providers?: string[];
+    providerId?: string;
+  }) => Promise<{
+    success: boolean;
+    statuses?: Record<
+      string,
+      { installed: boolean; path?: string | null; version?: string | null; lastChecked: number }
+    >;
+    error?: string;
+  }>;
+  onProviderStatusUpdated?: (
+    listener: (data: { providerId: string; status: any }) => void
+  ) => () => void;
+  // Telemetry
+  captureTelemetry: (
+    event: string,
+    properties?: Record<string, any>
+  ) => Promise<{ success: boolean; disabled?: boolean; error?: string }>;
+  getTelemetryStatus: () => Promise<{
+    success: boolean;
+    status?: {
+      enabled: boolean;
+      envDisabled: boolean;
+      userOptOut: boolean;
+      hasKeyAndHost: boolean;
+      onboardingSeen?: boolean;
+    };
+    error?: string;
+  }>;
+  setTelemetryEnabled: (enabled: boolean) => Promise<{
+    success: boolean;
+    status?: {
+      enabled: boolean;
+      envDisabled: boolean;
+      userOptOut: boolean;
+      hasKeyAndHost: boolean;
+      onboardingSeen?: boolean;
+    };
+    error?: string;
+  }>;
+
+  // Filesystem
+  fsList: (
+    root: string,
+    opts?: {
+      includeDirs?: boolean;
+      maxEntries?: number;
+      timeBudgetMs?: number;
+      connectionId?: string;
+      remotePath?: string;
+    }
+  ) => Promise<{
+    success: boolean;
+    items?: Array<{ path: string; type: 'file' | 'dir' }>;
+    error?: string;
+    canceled?: boolean;
+    truncated?: boolean;
+    reason?: string;
+    durationMs?: number;
+  }>;
+  fsRead: (
+    root: string,
+    relPath: string,
+    maxBytes?: number,
+    remote?: { connectionId: string; remotePath: string }
+  ) => Promise<{
+    success: boolean;
+    path?: string;
+    size?: number;
+    truncated?: boolean;
+    content?: string;
+    error?: string;
+  }>;
+  fsSearchContent: (
+    root: string,
+    query: string,
+    options?: {
+      caseSensitive?: boolean;
+      maxResults?: number;
+      fileExtensions?: string[];
+    },
+    remote?: { connectionId: string; remotePath: string }
+  ) => Promise<{
+    success: boolean;
+    results?: Array<{
+      file: string;
+      matches: Array<{
+        line: number;
+        column: number;
+        text: string;
+        preview: string;
+      }>;
+    }>;
+    error?: string;
+  }>;
+
+  // GitHub integration
+  githubAuth: () => Promise<{
+    success: boolean;
+    token?: string;
+    user?: any;
+    device_code?: string;
+    user_code?: string;
+    verification_uri?: string;
+    expires_in?: number;
+    interval?: number;
+    error?: string;
+  }>;
+  githubCancelAuth: () => Promise<{ success: boolean; error?: string }>;
+  onGithubAuthDeviceCode: (
+    callback: (data: {
+      userCode: string;
+      verificationUri: string;
+      expiresIn: number;
+      interval: number;
+    }) => void
+  ) => () => void;
+  onGithubAuthPolling: (callback: (data: { status: string }) => void) => () => void;
+  onGithubAuthSlowDown: (callback: (data: { newInterval: number }) => void) => () => void;
+  onGithubAuthSuccess: (callback: (data: { token: string; user: any }) => void) => () => void;
+  onGithubAuthError: (callback: (data: { error: string; message: string }) => void) => () => void;
+  onGithubAuthCancelled: (callback: () => void) => () => void;
+  onGithubAuthUserUpdated: (callback: (data: { user: any }) => void) => () => void;
+  githubIsAuthenticated: () => Promise<boolean>;
+  githubGetUser: () => Promise<any>;
+  githubGetRepositories: () => Promise<any[]>;
+  githubCloneRepository: (
+    repoUrl: string,
+    localPath: string
+  ) => Promise<{ success: boolean; error?: string }>;
+  githubGetStatus?: () => Promise<{
+    installed: boolean;
+    authenticated: boolean;
+    user?: any;
+  }>;
+  githubCheckCLIInstalled?: () => Promise<boolean>;
+  githubInstallCLI?: () => Promise<{ success: boolean; error?: string }>;
+  githubListPullRequests: (args: {
+    projectPath: string;
+    limit?: number;
+    searchQuery?: string;
+  }) => Promise<{ success: boolean; prs?: any[]; totalCount?: number; error?: string }>;
+  githubCreatePullRequestWorktree: (args: {
+    projectPath: string;
+    projectId: string;
+    prNumber: number;
+    prTitle?: string;
+    taskName?: string;
+    branchName?: string;
+  }) => Promise<{
+    success: boolean;
+    worktree?: any;
+    branchName?: string;
+    taskName?: string;
+    task?: {
+      id: string;
+      name: string;
+      path: string;
+      branch: string;
+      projectId: string;
+      status: string;
+      agentId: string;
+      metadata?: { prNumber?: number; prTitle?: string | null };
+    };
+    error?: string;
+  }>;
+  githubGetPullRequestBaseDiff: (args: { worktreePath: string; prNumber: number }) => Promise<{
+    success: boolean;
+    diff?: string;
+    baseBranch?: string;
+    headBranch?: string;
+    prUrl?: string;
+    error?: string;
+  }>;
+  githubLogout: () => Promise<void>;
+  // GitHub issues
+  githubIssuesList?: (
+    projectPath: string,
+    limit?: number
+  ) => Promise<{ success: boolean; issues?: any[]; error?: string }>;
+  githubIssuesSearch?: (
+    projectPath: string,
+    searchTerm: string,
+    limit?: number
+  ) => Promise<{ success: boolean; issues?: any[]; error?: string }>;
+  githubIssueGet?: (
+    projectPath: string,
+    number: number
+  ) => Promise<{ success: boolean; issue?: any; error?: string }>;
+
+  // Linear integration
+  linearCheckConnection?: () => Promise<{
+    connected: boolean;
+    taskName?: string;
+    error?: string;
+  }>;
+  linearSaveToken?: (token: string) => Promise<{
+    success: boolean;
+    taskName?: string;
+    error?: string;
+  }>;
+  linearClearToken?: () => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  linearInitialFetch?: (limit?: number) => Promise<{
+    success: boolean;
+    issues?: any[];
+    error?: string;
+  }>;
+  linearSearchIssues?: (
+    searchTerm: string,
+    limit?: number
+  ) => Promise<{
+    success: boolean;
+    issues?: any[];
+    error?: string;
+  }>;
+
+  // Plain integration
+  plainSaveToken?: (token: string) => Promise<{
+    success: boolean;
+    workspaceName?: string;
+    error?: string;
+  }>;
+  plainCheckConnection?: () => Promise<{
+    connected: boolean;
+    workspaceName?: string;
+    error?: string;
+  }>;
+  plainClearToken?: () => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  plainInitialFetch?: (
+    limit?: number,
+    statuses?: string[]
+  ) => Promise<{
+    success: boolean;
+    threads?: any[];
+    error?: string;
+  }>;
+  plainSearchThreads?: (
+    searchTerm: string,
+    limit?: number
+  ) => Promise<{
+    success: boolean;
+    threads?: any[];
+    error?: string;
+  }>;
+
+  // Sentry integration
+  sentrySaveToken?: (
+    token: string,
+    organizationSlug?: string
+  ) => Promise<{
+    success: boolean;
+    organizationName?: string;
+    error?: string;
+  }>;
+  sentryCheckConnection?: () => Promise<{
+    connected: boolean;
+    organizationName?: string;
+    error?: string;
+  }>;
+  sentryClearToken?: () => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  sentryInitialFetch?: (limit?: number) => Promise<{
+    success: boolean;
+    issues?: SentryIssue[];
+    error?: string;
+  }>;
+  sentrySearchIssues?: (
+    searchTerm: string,
+    limit?: number
+  ) => Promise<{
+    success: boolean;
+    issues?: SentryIssue[];
+    error?: string;
+  }>;
+
+  // Debug helpers
+  debugAppendLog: (
+    filePath: string,
+    content: string,
+    options?: { reset?: boolean }
+  ) => Promise<{ success: boolean; error?: string }>;
+
+  // Skills management
+  skillsGetCatalog: () => Promise<{
+    success: boolean;
+    data?: import('@shared/skills/types').CatalogIndex;
+    error?: string;
+  }>;
+  skillsRefreshCatalog: () => Promise<{
+    success: boolean;
+    data?: import('@shared/skills/types').CatalogIndex;
+    error?: string;
+  }>;
+  skillsInstall: (args: { skillId: string; source?: { owner: string; repo: string } }) => Promise<{
+    success: boolean;
+    data?: import('@shared/skills/types').CatalogSkill;
+    error?: string;
+  }>;
+  skillsUninstall: (args: { skillId: string }) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  skillsGetDetail: (args: {
+    skillId: string;
+    source?: { owner: string; repo: string };
+  }) => Promise<{
+    success: boolean;
+    data?: import('@shared/skills/types').CatalogSkill;
+    error?: string;
+  }>;
+  skillsGetDetectedAgents: () => Promise<{
+    success: boolean;
+    data?: import('@shared/skills/types').DetectedAgent[];
+    error?: string;
+  }>;
+  skillsSearch: (args: { query: string }) => Promise<{
+    success: boolean;
+    data?: import('@shared/skills/types').CatalogSkill[];
+    error?: string;
+  }>;
+  skillsCreate: (args: { name: string; description: string }) => Promise<{
+    success: boolean;
+    data?: import('@shared/skills/types').CatalogSkill;
+    error?: string;
+  }>;
+
+  // Workspace provisioning
+  workspaceProvision: (args: {
+    taskId: string;
+    repoUrl: string;
+    branch: string;
+    baseRef: string;
+    provisionCommand: string;
+    projectPath: string;
+  }) => Promise<{ success: boolean; data?: { instanceId: string }; error?: string }>;
+  workspaceCancel: (args: { instanceId: string }) => Promise<{ success: boolean; error?: string }>;
+  workspaceTerminate: (args: {
+    instanceId: string;
+    terminateCommand: string;
+    projectPath: string;
+    env?: Record<string, string>;
+  }) => Promise<{ success: boolean; error?: string }>;
+  workspaceStatus: (args: { taskId: string }) => Promise<{
+    success: boolean;
+    data?: {
+      id: string;
+      taskId: string;
+      externalId: string | null;
+      host: string;
+      port: number;
+      username: string | null;
+      worktreePath: string | null;
+      status: string;
+      connectionId: string | null;
+      createdAt: number;
+      terminatedAt: number | null;
+    } | null;
+    error?: string;
+  }>;
+  onWorkspaceProvisionProgress: (
+    listener: (data: { instanceId: string; line: string }) => void
+  ) => () => void;
+  onWorkspaceProvisionTimeoutWarning: (
+    listener: (data: { instanceId: string; timeoutMs: number }) => void
+  ) => () => void;
+  onWorkspaceProvisionComplete: (
+    listener: (data: { instanceId: string; status: string; error?: string }) => void
+  ) => () => void;
+
+  // MCP
+  mcpLoadAll: () => Promise<{
+    success: boolean;
+    data?: import('../../shared/mcp/types').McpLoadAllResponse;
+    error?: string;
+  }>;
+  mcpSaveServer: (server: import('../../shared/mcp/types').McpServer) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  mcpRemoveServer: (serverName: string) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  mcpGetProviders: () => Promise<{
+    success: boolean;
+    data?: import('../../shared/mcp/types').McpProvidersResponse[];
+    error?: string;
+  }>;
+  mcpRefreshProviders: () => Promise<{
+    success: boolean;
+    data?: import('../../shared/mcp/types').McpProvidersResponse[];
+    error?: string;
+  }>;
+
+  // Automations
+  automationsList: () => Promise<{
+    success: boolean;
+    data?: import('../../shared/automations/types').Automation[];
+    error?: string;
+  }>;
+  automationsGet: (args: { id: string }) => Promise<{
+    success: boolean;
+    data?: import('../../shared/automations/types').Automation | null;
+    error?: string;
+  }>;
+  automationsCreate: (
+    args: import('../../shared/automations/types').CreateAutomationInput
+  ) => Promise<{
+    success: boolean;
+    data?: import('../../shared/automations/types').Automation;
+    error?: string;
+  }>;
+  automationsUpdate: (
+    args: import('../../shared/automations/types').UpdateAutomationInput
+  ) => Promise<{
+    success: boolean;
+    data?: import('../../shared/automations/types').Automation | null;
+    error?: string;
+  }>;
+  automationsDelete: (args: { id: string }) => Promise<{
+    success: boolean;
+    data?: boolean;
+    error?: string;
+  }>;
+  automationsToggle: (args: { id: string }) => Promise<{
+    success: boolean;
+    data?: import('../../shared/automations/types').Automation | null;
+    error?: string;
+  }>;
+  automationsRunLogs: (args: { automationId: string; limit?: number }) => Promise<{
+    success: boolean;
+    data?: import('../../shared/automations/types').AutomationRunLog[];
+    error?: string;
+  }>;
+  automationsTriggerNow: (args: { id: string }) => Promise<{
+    success: boolean;
+    data?: import('../../shared/automations/types').Automation;
+    error?: string;
+  }>;
+  automationsCompleteRun: (args: {
+    runLogId: string;
+    automationId: string;
+    taskId?: string;
+    status: 'success' | 'failure';
+    error?: string;
+  }) => Promise<{
+    success: boolean;
+    error?: string;
+  }>;
+  automationsDrainTriggers: () => Promise<{
+    success: boolean;
+    data?: Array<import('../../shared/automations/types').Automation & { _runLogId: string }>;
+    error?: string;
+  }>;
+  onAutomationTriggerAvailable: (listener: () => void) => () => void;
+
+  // Integrations
+  integrationsStatusMap: () => Promise<{
+    success: boolean;
+    data?: import('../../shared/integrations/types').IntegrationStatusMap;
+    error?: string;
+  }>;
+
+  // Performance Monitor
+  perfSubscribe: () => Promise<{
+    success: boolean;
+    data?: ResourceMetricsSnapshot;
+  }>;
+  perfUnsubscribe: () => Promise<{ success: boolean }>;
+  perfGetSnapshot: (mode?: 'interactive' | 'idle') => Promise<{
+    success: boolean;
+    data?: ResourceMetricsSnapshot;
+    error?: string;
+  }>;
+  onPerfSnapshot: (listener: (snapshot: ResourceMetricsSnapshot) => void) => () => void;
+}
+import type { TerminalSnapshotPayload } from '#types/terminalSnapshot';
+import type { OpenInAppId } from '#shared/openInApps';

--- a/src/shared/ipc/remoteLocator.ts
+++ b/src/shared/ipc/remoteLocator.ts
@@ -1,0 +1,21 @@
+export type RemoteLocator = {
+  sshConnectionId?: string;
+  taskId?: string;
+  projectId?: string;
+};
+
+export type TaskPathLocator = {
+  taskPath: string;
+} & RemoteLocator;
+
+export type ProjectPathLocator = {
+  projectPath: string;
+} & RemoteLocator;
+
+export type RepoPathLocator = {
+  repoPath: string;
+} & RemoteLocator;
+
+export type WorktreePathLocator = {
+  worktreePath: string;
+} & RemoteLocator;

--- a/src/test/main/DatabaseService.saveProject.test.ts
+++ b/src/test/main/DatabaseService.saveProject.test.ts
@@ -1,0 +1,233 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const selectResults: unknown[][] = [];
+const insertValuesMock = vi.fn();
+const updateValuesMock = vi.fn();
+const updateWhereMock = vi.fn();
+
+const mockDb = {
+  select: vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve((selectResults.shift() as unknown[]) ?? []),
+      }),
+    }),
+  })),
+  insert: vi.fn(() => ({
+    values: (values: unknown) => {
+      insertValuesMock(values);
+      return Promise.resolve();
+    },
+  })),
+  update: vi.fn(() => ({
+    set: (values: unknown) => {
+      updateValuesMock(values);
+      return {
+        where: (...args: unknown[]) => {
+          updateWhereMock(...args);
+          return Promise.resolve();
+        },
+      };
+    },
+  })),
+};
+
+vi.mock('../../main/db/path', () => ({
+  resolveDatabasePath: () => '/tmp/emdash-save-project-test.db',
+  resolveMigrationsPath: () => '/tmp/drizzle',
+}));
+
+vi.mock('../../main/errorTracking', () => ({
+  errorTracking: {
+    captureDatabaseError: vi.fn(),
+  },
+}));
+
+vi.mock('../../main/db/drizzleClient', () => ({
+  getDrizzleClient: () => Promise.resolve({ db: mockDb }),
+}));
+
+import { DatabaseService, type Project } from '../../main/services/DatabaseService';
+
+describe('DatabaseService.saveProject', () => {
+  let service: DatabaseService;
+
+  const baseProject: Omit<Project, 'createdAt' | 'updatedAt'> = {
+    id: 'project-1',
+    name: 'Project One',
+    path: '/tmp/project-one',
+    isRemote: true,
+    sshConnectionId: 'ssh-1',
+    remotePath: '/srv/project-one',
+    gitInfo: {
+      isGitRepo: true,
+      remote: 'origin',
+      branch: 'main',
+      baseRef: 'origin/main',
+    },
+    githubInfo: {
+      repository: 'org/project-one',
+      connected: true,
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectResults.length = 0;
+    service = new DatabaseService();
+  });
+
+  it('throws a typed conflict instead of overwriting an existing project', async () => {
+    selectResults.push([]);
+    selectResults.push([
+      {
+        id: 'project-existing',
+        name: 'Existing Project',
+        path: '/srv/project-one',
+      },
+    ]);
+
+    await expect(service.saveProject(baseProject)).rejects.toEqual(
+      expect.objectContaining({
+        name: 'ProjectConflictError',
+        code: 'PROJECT_CONFLICT',
+        existingProjectId: 'project-existing',
+        existingProjectName: 'Existing Project',
+        projectPath: '/srv/project-one',
+      })
+    );
+
+    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(updateValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('updates an existing project row when the same project id is resaved', async () => {
+    selectResults.push([
+      {
+        id: 'project-1',
+        path: '/tmp/project-one',
+      },
+    ]);
+    selectResults.push([
+      {
+        id: 'project-1',
+        name: 'Project One',
+        path: '/srv/project-one',
+      },
+    ]);
+
+    await expect(service.saveProject(baseProject)).resolves.toBeUndefined();
+
+    expect(updateValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'project-1',
+        name: 'Project One',
+        path: '/tmp/project-one',
+        sshConnectionId: 'ssh-1',
+        remotePath: '/srv/project-one',
+      })
+    );
+    expect(updateWhereMock).toHaveBeenCalledTimes(1);
+    expect(insertValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('inserts a new project without mutating an existing row', async () => {
+    selectResults.push([]);
+    selectResults.push([]);
+
+    await expect(service.saveProject(baseProject)).resolves.toBeUndefined();
+
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'project-1',
+        path: '/tmp/project-one',
+      })
+    );
+    expect(updateValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('allows the same project id to move to a new path when there is no collision', async () => {
+    selectResults.push([
+      {
+        id: 'project-1',
+        path: '/tmp/project-one',
+      },
+    ]);
+    selectResults.push([]);
+
+    const movedProject = {
+      ...baseProject,
+      path: '/tmp/project-one-renamed',
+    };
+
+    await expect(service.saveProject(movedProject)).resolves.toBeUndefined();
+
+    expect(updateValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        path: '/tmp/project-one-renamed',
+      })
+    );
+  });
+
+  it('throws ProjectConflictError when both remote projects share the same sshConnectionId and path', async () => {
+    // Both projects are remote with the same sshConnectionId — conflict
+    selectResults.push([]);
+    selectResults.push([
+      {
+        id: 'project-existing',
+        name: 'Existing Remote',
+        path: '/srv/project-one',
+        isRemote: 1,
+        sshConnectionId: 'ssh-1',
+      },
+    ]);
+
+    await expect(service.saveProject(baseProject)).rejects.toEqual(
+      expect.objectContaining({
+        name: 'ProjectConflictError',
+        code: 'PROJECT_CONFLICT',
+        existingProjectId: 'project-existing',
+        existingProjectName: 'Existing Remote',
+        projectPath: '/srv/project-one',
+      })
+    );
+
+    expect(insertValuesMock).not.toHaveBeenCalled();
+    expect(updateValuesMock).not.toHaveBeenCalled();
+  });
+
+  it('allows two remote projects with the same path but different sshConnectionId', async () => {
+    // Both projects are remote with the same path but DIFFERENT sshConnectionId — allowed
+    selectResults.push([]);
+    selectResults.push([
+      {
+        id: 'project-existing',
+        name: 'Existing Remote on Host B',
+        path: '/srv/project-one',
+        isRemote: 1,
+        sshConnectionId: 'ssh-host-b',
+      },
+    ]);
+
+    // New project on a different host (ssh-host-a) — same path, different connection
+    const remoteProjectOnDifferentHost: Omit<Project, 'createdAt' | 'updatedAt'> = {
+      ...baseProject,
+      id: 'project-2',
+      name: 'Remote Project on Host A',
+      path: '/srv/project-one', // same path as existingByPath
+      sshConnectionId: 'ssh-host-a',
+    };
+
+    await expect(service.saveProject(remoteProjectOnDifferentHost)).resolves.toBeUndefined();
+
+    // Should have inserted a new row, not updated or thrown
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        id: 'project-2',
+        path: '/srv/project-one',
+        sshConnectionId: 'ssh-host-a',
+      })
+    );
+    expect(updateValuesMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/test/main/DatabaseService.saveProject.test.ts
+++ b/src/test/main/DatabaseService.saveProject.test.ts
@@ -197,17 +197,10 @@ describe('DatabaseService.saveProject', () => {
   });
 
   it('allows two remote projects with the same path but different sshConnectionId', async () => {
-    // Both projects are remote with the same path but DIFFERENT sshConnectionId — allowed
-    selectResults.push([]);
-    selectResults.push([
-      {
-        id: 'project-existing',
-        name: 'Existing Remote on Host B',
-        path: '/srv/project-one',
-        isRemote: 1,
-        sshConnectionId: 'ssh-host-b',
-      },
-    ]);
+    // Both projects are remote with the same path but DIFFERENT sshConnectionId — allowed.
+    // For remote projects, conflict check uses exact (path + sshConnectionId) match.
+    selectResults.push([]); // existingById check (no match)
+    selectResults.push([]); // existingByPath check with path+sshCondition (no match)
 
     // New project on a different host (ssh-host-a) — same path, different connection
     const remoteProjectOnDifferentHost: Omit<Project, 'createdAt' | 'updatedAt'> = {

--- a/src/test/main/remoteProjectResolver.test.ts
+++ b/src/test/main/remoteProjectResolver.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const FIXTURE_HOST_A = {
+  id: 'project-host-a',
+  name: 'Project on Host A',
+  path: '/srv/repo',
+  isRemote: true,
+  sshConnectionId: 'ssh-host-a',
+  remotePath: '/srv/repo',
+  gitInfo: { isGitRepo: true, branch: 'main', baseRef: 'main' },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+const FIXTURE_HOST_B = {
+  id: 'project-host-b',
+  name: 'Project on Host B',
+  path: '/srv/repo',
+  isRemote: true,
+  sshConnectionId: 'ssh-host-b',
+  remotePath: '/srv/repo',
+  gitInfo: { isGitRepo: true, branch: 'main', baseRef: 'main' },
+  createdAt: '2024-01-01T00:00:00.000Z',
+  updatedAt: '2024-01-01T00:00:00.000Z',
+};
+
+vi.mock('../../main/services/DatabaseService', () => ({
+  databaseService: {
+    getProjects: vi.fn(),
+  },
+}));
+
+import { databaseService } from '../../main/services/DatabaseService';
+import { resolveRemoteProjectForWorktreePath } from '../../main/utils/remoteProjectResolver';
+
+describe('resolveRemoteProjectForWorktreePath', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // The resolver matches worktreePath against remotePath + '/', so a worktree at
+  // /srv/repo/.worktrees/task-1 matches remotePath /srv/repo
+  const worktreeOfRepo = '/srv/repo/.worktrees/task-1';
+
+  it('returns null when no projects match the path', async () => {
+    vi.mocked(databaseService.getProjects).mockResolvedValue([]);
+    const result = await resolveRemoteProjectForWorktreePath('/some/other/path');
+    expect(result).toBeNull();
+  });
+
+  it('returns the unique match when only one project matches', async () => {
+    vi.mocked(databaseService.getProjects).mockResolvedValue([FIXTURE_HOST_A]);
+    const result = await resolveRemoteProjectForWorktreePath(worktreeOfRepo);
+    expect(result).not.toBeNull();
+    expect(result!.sshConnectionId).toBe('ssh-host-a');
+  });
+
+  it('uses sshConnectionId filter when provided', async () => {
+    vi.mocked(databaseService.getProjects).mockResolvedValue([FIXTURE_HOST_A, FIXTURE_HOST_B]);
+    const result = await resolveRemoteProjectForWorktreePath(worktreeOfRepo, 'ssh-host-b');
+    expect(result).not.toBeNull();
+    expect(result!.sshConnectionId).toBe('ssh-host-b');
+    expect(result!.id).toBe('project-host-b');
+  });
+
+  it('returns null when sshConnectionId is provided but no match', async () => {
+    vi.mocked(databaseService.getProjects).mockResolvedValue([FIXTURE_HOST_A, FIXTURE_HOST_B]);
+    const result = await resolveRemoteProjectForWorktreePath(worktreeOfRepo, 'ssh-nonexistent');
+    expect(result).toBeNull();
+  });
+
+  it('throws when multiple hosts share the same path and no sshConnectionId is provided', async () => {
+    vi.mocked(databaseService.getProjects).mockResolvedValue([FIXTURE_HOST_A, FIXTURE_HOST_B]);
+    await expect(resolveRemoteProjectForWorktreePath(worktreeOfRepo)).rejects.toThrow(
+      /Multiple remote projects match path.*but no sshConnectionId was provided to disambiguate/i
+    );
+  });
+
+  it('does not throw when sshConnectionId is provided even with multiple matching hosts', async () => {
+    vi.mocked(databaseService.getProjects).mockResolvedValue([FIXTURE_HOST_A, FIXTURE_HOST_B]);
+    const result = await resolveRemoteProjectForWorktreePath(worktreeOfRepo, 'ssh-host-a');
+    expect(result).not.toBeNull();
+    expect(result!.sshConnectionId).toBe('ssh-host-a');
+  });
+});


### PR DESCRIPTION
## Summary

- Display project paths in the sidebar, including `host:path` for remote projects
- Allow multiple remote projects with the same filesystem path when they belong to different SSH hosts
- Make remote project resolution fail closed when a path is ambiguous, instead of silently picking the first match
- Push locator-based disambiguation through worktree, Git, PR, and commit-history flows so callers can pass `sshConnectionId` explicitly

## What Changed

### Sidebar and project model
- Show project path alongside the project name in the sidebar
- Remote projects render as `host:path`
- Remove the old global uniqueness assumption on `projects.path`
- Update duplicate detection to use exact `(path, sshConnectionId)` matching for remote projects

### Remote resolution safety
- `resolveRemoteProjectForWorktreePath()` now throws when multiple remote projects match a path and no `sshConnectionId` is provided
- `resolveRemoteContext()` now accepts explicit locator input and uses `sshConnectionId` when available
- The effective policy is now:
  - uniquely identifiable target: execute normally
  - ambiguous target without `sshConnectionId`: return explicit error
  - never silently pick first

### Worktree and Git IPC
- `worktree:list`, `worktree:remove`, and `worktree:status` accept locator-style disambiguation
- Remote-aware Git handlers now consistently support locator input across:
  - status/watch flows
  - file diff / update index / revert file
  - PR creation / status / merge / comments / checks
  - branch rename / branch status / commit-and-push / merge-to-main
  - log / latest commit / commit files / commit file diff
- `preload` and renderer typings were updated to use shared locator types instead of repeating ad hoc `{ taskPath, taskId, sshConnectionId }` shapes

### Renderer cleanup
- Add shared locator helpers for renderer callers
- Replace repeated manual `sshConnectionId` plumbing at existing call sites with shared locator construction

### SSH config fixes
- When connecting through SSH config aliases:
  - default username falls back to `os.userInfo().username` if the SSH config has no `User`
  - `identityAgent` is respected when deciding whether to use the SSH agent

### Tests
- Add/extend tests covering:
  - remote project duplicate detection by `(path + sshConnectionId)`
  - multi-host same-path ambiguity behavior
  - fail-closed resolver behavior

## Notes

This PR is still larger than ideal because these files are effectively introduced relative to `main` on this branch:
- `src/main/ipc/gitIpc.ts`
- `src/main/preload.ts`
- `src/main/services/DatabaseService.ts`
- `src/main/services/worktreeIpc.ts`
- `src/renderer/types/electron-api.d.ts`

The current branch now focuses on correctness and explicit disambiguation. Remaining cleanup and further API consolidation can be split into follow-up PRs.
