### PR TITLE
feat: setting to auto-expand commit details in History tab

### DIFF
--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -70,6 +70,7 @@ export interface InterfaceSettings {
   showResourceMonitor?: boolean;
   theme?: 'light' | 'dark' | 'dark-black' | 'system';
   taskHoverAction?: 'delete' | 'archive';
+  expandCommitDetail?: boolean;
 }
 
 /**
@@ -205,6 +206,7 @@ const DEFAULT_SETTINGS: AppSettings = {
     showResourceMonitor: false,
     theme: 'system',
     taskHoverAction: 'delete',
+    expandCommitDetail: false,
   },
   providerConfigs: {},
   terminal: {
@@ -549,6 +551,9 @@ export function normalizeSettings(input: AppSettings): AppSettings {
       ? iface.theme
       : DEFAULT_SETTINGS.interface!.theme,
     taskHoverAction: iface?.taskHoverAction === 'archive' ? 'archive' : 'delete',
+    expandCommitDetail: Boolean(
+      iface?.expandCommitDetail ?? DEFAULT_SETTINGS.interface!.expandCommitDetail
+    ),
   };
 
   // Provider custom configs

--- a/src/renderer/components/CommitDetailSettingsCard.tsx
+++ b/src/renderer/components/CommitDetailSettingsCard.tsx
@@ -20,7 +20,6 @@ const CommitDetailSettingsCard: React.FC = () => {
       </div>
       <Switch
         checked={expandCommitDetail}
-        defaultChecked={expandCommitDetail}
         disabled={loading}
         onCheckedChange={(checked) =>
           updateSettings({ interface: { expandCommitDetail: checked } })

--- a/src/renderer/components/CommitDetailSettingsCard.tsx
+++ b/src/renderer/components/CommitDetailSettingsCard.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Switch } from './ui/switch';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
+
+const CommitDetailSettingsCard: React.FC = () => {
+  const { settings, updateSettings, isLoading: loading } = useAppSettings();
+
+  const expandCommitDetail = settings?.interface?.expandCommitDetail ?? false;
+
+  return (
+    <div className="flex items-center justify-between gap-4">
+      <div className="flex flex-1 flex-col gap-0.5">
+        <span className="text-sm font-medium text-foreground">
+          Expand commit details by default
+        </span>
+        <span className="text-sm text-muted-foreground">
+          Automatically show the full commit message and author when selecting a commit in the
+          History tab
+        </span>
+      </div>
+      <Switch
+        checked={expandCommitDetail}
+        defaultChecked={expandCommitDetail}
+        disabled={loading}
+        onCheckedChange={(checked) =>
+          updateSettings({ interface: { expandCommitDetail: checked } })
+        }
+      />
+    </div>
+  );
+};
+
+export default CommitDetailSettingsCard;

--- a/src/renderer/components/SettingsPage.tsx
+++ b/src/renderer/components/SettingsPage.tsx
@@ -28,6 +28,7 @@ import TerminalSettingsCard from './TerminalSettingsCard';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
 import ReviewAgentSettingsCard from './ReviewAgentSettingsCard';
 import ResourceMonitorSettingsCard from './ResourceMonitorSettingsCard';
+import CommitDetailSettingsCard from './CommitDetailSettingsCard';
 import { AccountTab } from './settings/AccountTab';
 import { WorkspaceProviderInfoCard } from './WorkspaceProviderInfoCard';
 import { useTaskSettings } from '../hooks/useTaskSettings';
@@ -268,6 +269,7 @@ export const SettingsPage: React.FC<SettingsPageProps> = ({ initialTab, onClose 
               <RightSidebarSettingsCard />
               <BrowserPreviewSettingsCard />
               <TaskHoverActionCard />
+              <CommitDetailSettingsCard />
             </div>
           ),
         },

--- a/src/renderer/components/diff-viewer/HistoryTab.tsx
+++ b/src/renderer/components/diff-viewer/HistoryTab.tsx
@@ -6,6 +6,7 @@ import { CommitFileList } from './CommitFileList';
 import { CommitFileDiffView } from './CommitFileDiffView';
 import { DiffToolbar } from './DiffToolbar';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../ui/resizable';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
 
 interface HistoryTabProps {
   taskPath?: string;
@@ -27,6 +28,8 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
   const [diffStyle, setDiffStyle] = useState<'unified' | 'split'>(
     () => (localStorage.getItem('diffViewer:diffStyle') as 'unified' | 'split') || 'unified'
   );
+  const { settings } = useAppSettings();
+  const expandByDefault = settings?.interface?.expandCommitDetail ?? false;
   const [detailExpanded, setDetailExpanded] = useState(false);
   const [copied, setCopied] = useState(false);
 
@@ -39,7 +42,7 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
     if (commit.hash === selectedCommit?.hash) return;
     setSelectedCommit(commit);
     setSelectedFile(null);
-    setDetailExpanded(false);
+    setDetailExpanded(expandByDefault);
     setCopied(false);
   };
 

--- a/src/renderer/components/diff-viewer/HistoryTab.tsx
+++ b/src/renderer/components/diff-viewer/HistoryTab.tsx
@@ -7,6 +7,7 @@ import { CommitFileDiffView } from './CommitFileDiffView';
 import { DiffToolbar } from './DiffToolbar';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '../ui/resizable';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import { cn } from '@/lib/utils';
 
 interface HistoryTabProps {
   taskPath?: string;
@@ -102,7 +103,12 @@ export const HistoryTab: React.FC<HistoryTabProps> = ({
               {/* Commit message detail */}
               <div className="border-b border-border px-3 py-2">
                 <div className="flex items-center gap-1">
-                  <div className="min-w-0 flex-1 truncate text-sm font-medium leading-snug">
+                  <div
+                    className={cn(
+                      'min-w-0 flex-1 text-sm font-medium leading-snug',
+                      !detailExpanded && 'truncate'
+                    )}
+                  >
                     {selectedCommit.subject}
                   </div>
                   {hasExpandableContent && (

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -299,4 +299,9 @@ describe('normalizeSettings – expandCommitDetail', () => {
     const result = normalizeSettings(makeSettings({ interface: { expandCommitDetail: false } }));
     expect(result.interface?.expandCommitDetail).toBe(false);
   });
+
+  it('coerces missing value inside interface to false', () => {
+    const result = normalizeSettings(makeSettings({ interface: {} }));
+    expect(result.interface?.expandCommitDetail).toBe(false);
+  });
 });

--- a/src/test/main/settings.test.ts
+++ b/src/test/main/settings.test.ts
@@ -283,3 +283,20 @@ describe('normalizeSettings – terminal settings', () => {
     expect(result.terminal?.macOptionIsMeta).toBe(true);
   });
 });
+
+describe('normalizeSettings – expandCommitDetail', () => {
+  it('defaults expandCommitDetail to false when not set', () => {
+    const result = normalizeSettings(makeSettings());
+    expect(result.interface?.expandCommitDetail).toBe(false);
+  });
+
+  it('preserves expandCommitDetail: true', () => {
+    const result = normalizeSettings(makeSettings({ interface: { expandCommitDetail: true } }));
+    expect(result.interface?.expandCommitDetail).toBe(true);
+  });
+
+  it('preserves expandCommitDetail: false', () => {
+    const result = normalizeSettings(makeSettings({ interface: { expandCommitDetail: false } }));
+    expect(result.interface?.expandCommitDetail).toBe(false);
+  });
+});

--- a/src/test/renderer/CommitDetailSettingsCard.component.test.tsx
+++ b/src/test/renderer/CommitDetailSettingsCard.component.test.tsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { useAppSettings } from '@/contexts/AppSettingsProvider';
+import CommitDetailSettingsCard from '../../renderer/components/CommitDetailSettingsCard';
+import type { AppSettings } from '../../main/settings';
+
+vi.mock('@/contexts/AppSettingsProvider', () => ({
+  useAppSettings: vi.fn(),
+}));
+
+function setup(expandCommitDetail = false) {
+  const updateSettings = vi.fn();
+  vi.mocked(useAppSettings).mockReturnValue({
+    settings: {
+      interface: { expandCommitDetail },
+    } as unknown as ReturnType<typeof useAppSettings>['settings'],
+    isLoading: false,
+    isSaving: false,
+    updateSettings,
+  });
+  render(<CommitDetailSettingsCard />);
+  return { updateSettings };
+}
+
+describe('CommitDetailSettingsCard', () => {
+  it('renders the toggle label', () => {
+    setup();
+    expect(screen.getByText('Expand commit details by default')).toBeInTheDocument();
+  });
+
+  it('is unchecked when expandCommitDetail is false', () => {
+    setup(false);
+    expect(screen.getByRole('switch')).toHaveAttribute('data-state', 'unchecked');
+  });
+
+  it('is checked when expandCommitDetail is true', () => {
+    setup(true);
+    expect(screen.getByRole('switch')).toHaveAttribute('data-state', 'checked');
+  });
+
+  it('calls updateSettings with true when toggled on', () => {
+    const { updateSettings } = setup(false);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(updateSettings).toHaveBeenCalledWith({ interface: { expandCommitDetail: true } });
+  });
+
+  it('calls updateSettings with false when toggled off', () => {
+    const { updateSettings } = setup(true);
+    fireEvent.click(screen.getByRole('switch'));
+    expect(updateSettings).toHaveBeenCalledWith({ interface: { expandCommitDetail: false } });
+  });
+});

--- a/src/test/renderer/CommitDetailSettingsCard.component.test.tsx
+++ b/src/test/renderer/CommitDetailSettingsCard.component.test.tsx
@@ -2,7 +2,6 @@ import { render, screen, fireEvent } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 import { useAppSettings } from '@/contexts/AppSettingsProvider';
 import CommitDetailSettingsCard from '../../renderer/components/CommitDetailSettingsCard';
-import type { AppSettings } from '../../main/settings';
 
 vi.mock('@/contexts/AppSettingsProvider', () => ({
   useAppSettings: vi.fn(),


### PR DESCRIPTION
## Summary

- Adds an **"Expand commit details by default"** toggle in Settings → Interface → Workspace
- When enabled, selecting a commit in the History tab immediately shows the full message, author, and hash — no click required
- It obviously still is possible to manually expand or collapse at any point
- Fixes commit subject being truncated with an ellipsis even when the detail section is expanded

## Fixes

Fixes #1693
Fixes #1694

## Snapshot

<img width="2270" height="2300" alt="CleanShot 2026-04-11 at 19 02 20@2x" src="https://github.com/user-attachments/assets/aaa7ef2c-0d5f-4c02-a632-928bf010fb3e" />

This setting results in the following when entering the history and selecting a commit:
| Enabled | Disabled |
|--------|--------|
| <img width="3002" height="638" alt="CleanShot 2026-04-11 at 19 01 41@2x" src="https://github.com/user-attachments/assets/8e9bc8ca-0672-4004-8549-4388db7ab4f7" /> | <img width="3002" height="638" alt="CleanShot 2026-04-11 at 19 01 45@2x" src="https://github.com/user-attachments/assets/342ff4da-eb2d-415e-b9b7-bb3bd28d18ec" /> | 

__

## Type of change

- [x] New feature (non-breaking change which adds functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Mandatory Tasks

- [x] I have self-reviewed the code

## Checklist

- [x] I have read the contributing guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added "Expand commit details by default" toggle in Interface settings (off by default). Toggle is disabled while settings are loading.
  * History view now respects that setting: commit details open by default and subject truncation is lifted when enabled.

* **Tests**
  * Added tests for settings normalization and for the new settings control behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->