### PR TITLE
refactor(github): decouple from gh CLI authentication

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -33,11 +33,30 @@ import {
 } from '../utils/remoteProjectResolver';
 import { RemoteGitService } from '../services/RemoteGitService';
 import { sshService } from '../services/ssh/SshService';
+import { githubService } from '../services/GitHubService';
 
 const remoteGitService = new RemoteGitService(sshService);
 
 const execAsync = promisify(exec);
 const execFileAsync = promisify(execFile);
+
+async function execGhAsync(command: string, options?: any) {
+  const env = await githubService.getCliEnvironment(options?.env);
+  const result = await execAsync(command, { encoding: 'utf8', ...options, env });
+  return {
+    stdout: String(result.stdout),
+    stderr: String(result.stderr),
+  };
+}
+
+async function execGhFileAsync(args: string[], options?: any) {
+  const env = await githubService.getCliEnvironment(options?.env);
+  const result = await execFileAsync('gh', args, { encoding: 'utf8', ...options, env });
+  return {
+    stdout: String(result.stdout),
+    stderr: String(result.stderr),
+  };
+}
 
 const GIT_STATUS_DEBOUNCE_MS = 500;
 const supportsRecursiveWatch = process.platform === 'darwin' || process.platform === 'win32';
@@ -704,7 +723,7 @@ export function registerGitIpc() {
     ];
     const cmd = `gh pr view --json ${queryFields.join(',')} -q .`;
     try {
-      const { stdout } = await execAsync(cmd, { cwd: taskPath });
+      const { stdout } = await execGhAsync(cmd, { cwd: taskPath });
       const json = (stdout || '').trim();
       if (!json) return { pr: null, prKnown: true };
       return { pr: JSON.parse(json), prKnown: true };
@@ -1202,7 +1221,7 @@ export function registerGitIpc() {
         } catch {}
         let defaultBranch = 'main';
         try {
-          const { stdout } = await execAsync(
+          const { stdout } = await execGhAsync(
             'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
             { cwd: taskPath }
           );
@@ -1277,7 +1296,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         let stdout: string;
         let stderr: string;
         try {
-          const result = await execAsync(cmd, { cwd: taskPath });
+          const result = await execGhAsync(cmd, { cwd: taskPath });
           stdout = result.stdout || '';
           stderr = result.stderr || '';
         } finally {
@@ -1303,7 +1322,8 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
             const didPatchBody = await patchCurrentPrBodyWithIssueFooter({
               taskPath,
               metadata: taskMetadata,
-              execFile: execFileAsync,
+              execFile: (file, args, options) =>
+                file === 'gh' ? execGhFileAsync(args, options) : execFileAsync(file, args, options),
               prUrl: url,
             });
             if (didPatchBody) {
@@ -1383,7 +1403,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         // Attempt 1: gh pr view (works when branch tracking points to a PR)
         let data: any = null;
         try {
-          const { stdout } = await execAsync(cmd, { cwd: taskPath });
+          const { stdout } = await execGhAsync(cmd, { cwd: taskPath });
           const json = (stdout || '').trim();
           data = json ? JSON.parse(json) : null;
         } catch (viewErr) {
@@ -1405,7 +1425,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
             currentBranch = branchOut.trim();
             if (currentBranch) {
               const listCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --json ${queryFields.join(',')} --limit 1`;
-              const { stdout: listOut } = await execAsync(listCmd, { cwd: taskPath });
+              const { stdout: listOut } = await execGhAsync(listCmd, { cwd: taskPath });
               const listJson = (listOut || '').trim();
               const listData = listJson ? JSON.parse(listJson) : [];
               if (listData.length > 0) {
@@ -1422,7 +1442,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         // the parent/upstream repo for a PR with head "<fork-owner>:<branch>".
         if (!data && currentBranch) {
           try {
-            const { stdout: repoOut } = await execAsync('gh repo view --json owner,parent', {
+            const { stdout: repoOut } = await execGhAsync('gh repo view --json owner,parent', {
               cwd: taskPath,
             });
             const repoData = repoOut.trim() ? JSON.parse(repoOut.trim()) : null;
@@ -1433,7 +1453,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
               const forkOwnerLogin = repoData?.owner?.login;
               const forkFields = [...queryFields, 'headRepositoryOwner'];
               const forkListCmd = `gh pr list --head ${JSON.stringify(currentBranch)} --repo ${JSON.stringify(parentRepo)} --state open --json ${forkFields.join(',')} --limit 10`;
-              const { stdout: forkOut } = await execAsync(forkListCmd, { cwd: taskPath });
+              const { stdout: forkOut } = await execGhAsync(forkListCmd, { cwd: taskPath });
               const forkJson = (forkOut || '').trim();
               const forkData = forkJson ? JSON.parse(forkJson) : [];
               const match = forkOwnerLogin
@@ -1565,7 +1585,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         if (admin) ghArgs.push('--admin');
 
         try {
-          const { stdout, stderr } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+          const { stdout, stderr } = await execGhFileAsync(ghArgs, { cwd: taskPath });
           const output = [stdout, stderr].filter(Boolean).join('\n').trim();
           return { success: true, output };
         } catch (err) {
@@ -1628,7 +1648,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         }
 
         await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
-        const { stdout, stderr } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+        const { stdout, stderr } = await execGhFileAsync(ghArgs, { cwd: taskPath });
         const output = [stdout, stderr].filter(Boolean).join('\n').trim();
         return { success: true, output };
       } catch (error) {
@@ -1675,7 +1695,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         }
 
         await execFileAsync(GIT, ['rev-parse', '--is-inside-work-tree'], { cwd: taskPath });
-        const { stdout, stderr } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+        const { stdout, stderr } = await execGhFileAsync(ghArgs, { cwd: taskPath });
         const output = [stdout, stderr].filter(Boolean).join('\n').trim();
         return { success: true, output };
       } catch (error) {
@@ -1800,8 +1820,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
 
       try {
         // Detect fork: if this repo has a parent, find the PR number there
-        const { stdout: repoOut } = await execFileAsync(
-          'gh',
+        const { stdout: repoOut } = await execGhFileAsync(
           ['repo', 'view', '--json', 'owner,parent'],
           { cwd: taskPath }
         );
@@ -1815,8 +1834,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
           });
           const currentBranch = branchOut.trim();
           if (currentBranch) {
-            const { stdout: listOut } = await execFileAsync(
-              'gh',
+            const { stdout: listOut } = await execGhFileAsync(
               [
                 'pr',
                 'list',
@@ -1864,18 +1882,17 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         const checksArgs = prRef
           ? ['pr', 'checks', prRef, ...repoFlag, '--json', fields]
           : ['pr', 'checks', '--json', fields];
-        const { stdout } = await execFileAsync('gh', checksArgs, { cwd: taskPath });
+        const { stdout } = await execGhFileAsync(checksArgs, { cwd: taskPath });
         const json = (stdout || '').trim();
         const checks = json ? JSON.parse(json) : [];
 
         // Fetch html_url from the GitHub API instead, which always points to the
         // actual check run page on GitHub.
         try {
-          const { stdout: shaOut } = await execFileAsync('gh', headRefOidArgs, { cwd: taskPath });
+          const { stdout: shaOut } = await execGhFileAsync(headRefOidArgs, { cwd: taskPath });
           const sha = shaOut.trim();
           if (sha) {
-            const { stdout: apiOut } = await execFileAsync(
-              'gh',
+            const { stdout: apiOut } = await execGhFileAsync(
               [
                 'api',
                 `${checkRunsApiRepo}/commits/${sha}/check-runs`,
@@ -2002,7 +2019,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
           if (prNumber) ghArgs.push(String(prNumber));
           ghArgs.push('--json', 'comments,reviews,number');
 
-          const { stdout } = await execFileAsync('gh', ghArgs, { cwd: taskPath });
+          const { stdout } = await execGhFileAsync(ghArgs, { cwd: taskPath });
           const json = (stdout || '').trim();
           const data = json ? JSON.parse(json) : { comments: [], reviews: [], number: 0 };
 
@@ -2015,8 +2032,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
             try {
               const avatarMap = new Map<string, string>();
 
-              const { stdout: commentsApi } = await execFileAsync(
-                'gh',
+              const { stdout: commentsApi } = await execGhFileAsync(
                 [
                   'api',
                   `repos/{owner}/{repo}/issues/${data.number}/comments`,
@@ -2039,8 +2055,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
                 } catch {}
               }
 
-              const { stdout: reviewsApi } = await execFileAsync(
-                'gh',
+              const { stdout: reviewsApi } = await execGhFileAsync(
                 [
                   'api',
                   `repos/{owner}/{repo}/pulls/${data.number}/reviews`,
@@ -2142,7 +2157,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         // Determine default branch via gh, fallback to main/master
         let defaultBranch = 'main';
         try {
-          const { stdout } = await execAsync(
+          const { stdout } = await execGhAsync(
             'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
             { cwd: taskPath }
           );
@@ -2530,7 +2545,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
 
       let defaultBranch = 'main';
       try {
-        const { stdout } = await execAsync(
+        const { stdout } = await execGhAsync(
           'gh repo view --json defaultBranchRef -q .defaultBranchRef.name',
           { cwd: taskPath }
         );
@@ -2593,7 +2608,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
       }
       try {
         const prCreateArgs = ['pr', 'create', '--fill', '--base', defaultBranch];
-        const { stdout: prOut } = await execFileAsync('gh', prCreateArgs, { cwd: taskPath });
+        const { stdout: prOut } = await execGhFileAsync(prCreateArgs, { cwd: taskPath });
         const urlMatch = prOut?.match(/https?:\/\/\S+/);
         prUrl = urlMatch ? urlMatch[0] : '';
         prExists = true;
@@ -2611,7 +2626,8 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
           await patchCurrentPrBodyWithIssueFooter({
             taskPath,
             metadata: taskMetadata,
-            execFile: execFileAsync,
+            execFile: (file, args, options) =>
+              file === 'gh' ? execGhFileAsync(args, options) : execFileAsync(file, args, options),
             prUrl,
           });
         } catch (editError) {
@@ -2624,7 +2640,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
 
       // Merge PR (branch cleanup happens when workspace is deleted)
       try {
-        await execAsync('gh pr merge --merge', { cwd: taskPath });
+        await execGhAsync('gh pr merge --merge', { cwd: taskPath });
         return { success: true, prUrl };
       } catch (e) {
         const errMsg = (e as { stderr?: string })?.stderr || String(e);

--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -2311,8 +2311,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         // Determine default branch
         let defaultBranch = 'main';
         try {
-          const { stdout } = await execFileAsync(
-            'gh',
+          const { stdout } = await execGhFileAsync(
             ['repo', 'view', '--json', 'defaultBranchRef', '-q', '.defaultBranchRef.name'],
             { cwd: taskPath }
           );

--- a/src/main/ipc/githubIpc.ts
+++ b/src/main/ipc/githubIpc.ts
@@ -23,32 +23,66 @@ const slugify = (name: string) =>
     .replace(/-+/g, '-')
     .replace(/^-|-$/g, '');
 
+function parseGitHubRepository(remoteUrl: string): string | null {
+  const trimmed = remoteUrl.trim();
+  if (!trimmed) return null;
+
+  const match = trimmed.match(
+    /(?:git@github\.com:|https?:\/\/github\.com\/)([^/\s]+)\/([^/\s]+?)(?:\.git)?$/
+  );
+  if (!match) return null;
+
+  return `${match[1]}/${match[2]}`;
+}
+
+async function getDefaultBranchForRepo(projectPath: string): Promise<string> {
+  try {
+    const { stdout } = await execAsync(
+      'git symbolic-ref --quiet --short refs/remotes/origin/HEAD',
+      {
+        cwd: projectPath,
+      }
+    );
+    const ref = stdout.trim();
+    if (ref.startsWith('origin/')) {
+      return ref.slice('origin/'.length) || 'main';
+    }
+  } catch {
+    // Fall back to main when origin/HEAD is unavailable.
+  }
+
+  return 'main';
+}
+
 export function registerGithubIpc() {
   ipcMain.handle('github:connect', async (_, projectPath: string) => {
     try {
-      // Check if GitHub CLI is authenticated
       const isAuth = await githubService.isAuthenticated();
       if (!isAuth) {
-        return { success: false, error: 'GitHub CLI not authenticated' };
+        return { success: false, error: 'GitHub is not connected' };
       }
 
-      // Get repository info from GitHub CLI
       try {
-        const { stdout } = await execAsync(
-          'gh repo view --json name,nameWithOwner,defaultBranchRef',
-          { cwd: projectPath }
-        );
-        const repoInfo = JSON.parse(stdout);
+        const { stdout } = await execAsync('git config --get remote.origin.url', {
+          cwd: projectPath,
+        });
+        const repository = parseGitHubRepository(stdout);
+        if (!repository) {
+          return {
+            success: false,
+            error: 'Repository is not using a GitHub origin remote',
+          };
+        }
 
         return {
           success: true,
-          repository: repoInfo.nameWithOwner,
-          branch: repoInfo.defaultBranchRef?.name || 'main',
+          repository,
+          branch: await getDefaultBranchForRepo(projectPath),
         };
       } catch (error) {
         return {
           success: false,
-          error: 'Repository not found on GitHub or not connected to GitHub CLI',
+          error: 'Could not resolve the GitHub repository for this project',
         };
       }
     } catch (error) {
@@ -97,27 +131,22 @@ export function registerGithubIpc() {
     }
   });
 
-  // GitHub status: installed + authenticated + user
+  // GitHub status: optional gh install + Emdash auth + user
   ipcMain.handle('github:getStatus', async () => {
     try {
-      let installed = true;
-      try {
-        await execAsync('gh --version');
-      } catch {
-        installed = false;
-      }
+      const installed = await githubCLIInstaller.isInstalled();
 
       let authenticated = false;
       let user: any = null;
-      if (installed) {
-        try {
-          const { stdout } = await execAsync('gh api user');
-          user = JSON.parse(stdout);
-          authenticated = true;
-        } catch {
-          authenticated = false;
-          user = null;
+      try {
+        const token = await githubService.getStoredToken();
+        if (token) {
+          user = await githubService.getUserInfo(token);
+          authenticated = !!user;
         }
+      } catch {
+        authenticated = false;
+        user = null;
       }
 
       return { installed, authenticated, user };
@@ -129,7 +158,7 @@ export function registerGithubIpc() {
 
   ipcMain.handle('github:getUser', async () => {
     try {
-      const token = await (githubService as any)['getStoredToken']();
+      const token = await githubService.getStoredToken();
       if (!token) return null;
       return await githubService.getUserInfo(token);
     } catch (error) {
@@ -140,7 +169,7 @@ export function registerGithubIpc() {
 
   ipcMain.handle('github:getRepositories', async () => {
     try {
-      const token = await (githubService as any)['getStoredToken']();
+      const token = await githubService.getStoredToken();
       if (!token) throw new Error('Not authenticated');
       return await githubService.getRepositories(token);
     } catch (error) {
@@ -613,8 +642,10 @@ export function registerGithubIpc() {
           try {
             // Security: Use quoteShellArg to prevent command injection
             const repoRef = `${quoteShellArg(owner)}/${quoteShellArg(name)}`;
+            const env = await githubService.getCliEnvironment();
             await execAsync(`gh repo delete ${repoRef} --yes`, {
               timeout: 10000,
+              env,
             });
           } catch (cleanupError) {
             log.warn('Failed to cleanup GitHub repo after clone failure:', cleanupError);

--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -1262,6 +1262,7 @@ export class GitHubService {
       await keytar.deletePassword(this.SERVICE_NAME, this.ACCOUNT_NAME);
     } catch (error) {
       console.error('Failed to clear keychain token:', error);
+      throw new Error('Failed to clear keychain token');
     }
   }
 

--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -680,7 +680,7 @@ export class GitHubService {
       });
 
       if (!response.ok) {
-        throw new Error(`GitHub API error: ${response.statusText}`);
+        throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
       }
 
       const userData = await response.json();

--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -1,4 +1,4 @@
-import { exec, spawn } from 'child_process';
+import { exec } from 'child_process';
 import { promisify } from 'util';
 import * as path from 'path';
 import * as fs from 'fs';
@@ -114,11 +114,9 @@ export class GitHubService {
 
   /**
    * Store a GitHub token obtained via OAuth (Emdash Accounts flow).
-   * Also authenticates the gh CLI with the token.
    */
   async storeTokenFromOAuth(token: string): Promise<void> {
     await this.storeToken(token);
-    await this.authenticateGHCLI(token);
   }
 
   /**
@@ -132,7 +130,6 @@ export class GitHubService {
 
       if (result.providerId === 'github') {
         await this.storeToken(result.accessToken);
-        await this.authenticateGHCLI(result.accessToken);
       }
 
       const user = await this.getUserInfo(result.accessToken);
@@ -432,26 +429,14 @@ export class GitHubService {
       };
 
       if (data.access_token) {
-        // We get the token, now fetch user info immediately before returning success
-        // This ensures the UI has the correct username without a race condition
+        // We get the token, now fetch user info immediately before returning success.
         const token = data.access_token;
         const user = await this.getUserInfo(token);
 
-        // Store token and authenticate gh CLI BEFORE returning success.
-        // This must complete synchronously (awaited) so that when the renderer
-        // receives the success event and checks `gh api user`, the CLI is
-        // already authenticated. Previously these were deferred via setImmediate,
-        // causing a race where the status check ran before gh CLI auth finished.
         try {
           await this.storeToken(token);
         } catch (error) {
           console.warn('Failed to store token:', error);
-        }
-
-        try {
-          await this.authenticateGHCLI(token);
-        } catch {
-          // Silent fail - gh CLI might not be installed
         }
 
         const mainWindow = getMainWindow();
@@ -488,71 +473,38 @@ export class GitHubService {
   }
 
   /**
-   * Authenticate gh CLI with the OAuth token
+   * Environment for gh invocations. Always scope auth to Emdash's stored token
+   * so we do not read or mutate the user's global gh login state.
    */
-  private async authenticateGHCLI(token: string): Promise<void> {
-    try {
-      // Check if gh CLI is installed first
-      await execAsync('gh --version');
-
-      // Security: Authenticate gh CLI with token via stdin (not shell interpolation)
-      // This prevents command injection if token contains shell metacharacters
-      await new Promise<void>((resolve, reject) => {
-        const child = spawn('gh', ['auth', 'login', '--with-token'], {
-          stdio: ['pipe', 'pipe', 'pipe'],
-        });
-
-        child.on('close', (code) => {
-          if (code === 0) {
-            resolve();
-          } else {
-            reject(new Error(`gh auth login failed with code ${code}`));
-          }
-        });
-
-        child.on('error', reject);
-
-        // Write token to stdin and close it
-        child.stdin.write(token);
-        child.stdin.end();
-      });
-    } catch (error) {
-      console.warn('Could not authenticate gh CLI (may not be installed):', error);
-      // Don't throw - OAuth still succeeded even if gh CLI isn't available
+  async getCliEnvironment(
+    extraEnv?: NodeJS.ProcessEnv
+  ): Promise<NodeJS.ProcessEnv & { GH_TOKEN: string; GITHUB_TOKEN: string }> {
+    const token = await this.getStoredToken();
+    if (!token) {
+      throw new Error('GitHub is not connected in Emdash');
     }
+
+    return {
+      ...process.env,
+      ...extraEnv,
+      GH_TOKEN: token,
+      GITHUB_TOKEN: token,
+    };
   }
 
   /**
-   * Execute gh command with automatic re-auth on failure
+   * Execute gh using Emdash's stored token.
    */
   private async execGH(
     command: string,
     options?: any
   ): Promise<{ stdout: string; stderr: string }> {
-    try {
-      const result = await execAsync(command, { encoding: 'utf8', ...options });
-      return {
-        stdout: String(result.stdout),
-        stderr: String(result.stderr),
-      };
-    } catch (error: any) {
-      // Check if it's an auth error
-      if (error.message && error.message.includes('not authenticated')) {
-        // Try to re-authenticate gh CLI with stored token
-        const token = await this.getStoredToken();
-        if (token) {
-          await this.authenticateGHCLI(token);
-
-          // Retry the command
-          const result = await execAsync(command, { encoding: 'utf8', ...options });
-          return {
-            stdout: String(result.stdout),
-            stderr: String(result.stderr),
-          };
-        }
-      }
-      throw error;
-    }
+    const env = await this.getCliEnvironment(options?.env);
+    const result = await execAsync(command, { encoding: 'utf8', ...options, env });
+    return {
+      stdout: String(result.stdout),
+      stderr: String(result.stderr),
+    };
   }
 
   /**
@@ -696,21 +648,12 @@ export class GitHubService {
    */
   async isAuthenticated(): Promise<boolean> {
     try {
-      // First check if gh CLI is authenticated system-wide
-      const isGHAuth = await this.isGHCLIAuthenticated();
-      if (isGHAuth) {
-        return true;
-      }
-
-      // Fall back to checking stored token
       const token = await this.getStoredToken();
 
       if (!token) {
-        // No stored token, user needs to authenticate
         return false;
       }
 
-      // Test the token by making a simple API call
       const user = await this.getUserInfo(token);
       return !!user;
     } catch (error) {
@@ -720,44 +663,27 @@ export class GitHubService {
   }
 
   /**
-   * Check if gh CLI is authenticated system-wide
-   */
-  private async isGHCLIAuthenticated(): Promise<boolean> {
-    try {
-      // gh auth status exits with 0 if authenticated, non-zero otherwise
-      await execAsync('gh auth status');
-      return true;
-    } catch (error) {
-      // Not authenticated or gh CLI not installed
-      return false;
-    }
-  }
-
-  /**
-   * Get user information using GitHub API or CLI
+   * Get user information using the GitHub API.
    */
   async getUserInfo(token: string): Promise<GitHubUser | null> {
     try {
-      let userData;
-      if (token) {
-        const response = await fetch('https://api.github.com/user', {
-          headers: {
-            Authorization: `Bearer ${token}`,
-            Accept: 'application/vnd.github.v3+json',
-            'X-GitHub-Api-Version': '2022-11-28',
-          },
-        });
-
-        if (!response.ok) {
-          throw new Error(`GitHub API error: ${response.statusText}`);
-        }
-
-        userData = await response.json();
-      } else {
-        // Use gh CLI to get user info as fallback
-        const { stdout } = await this.execGH('gh api user');
-        userData = JSON.parse(stdout);
+      if (!token) {
+        return null;
       }
+
+      const response = await fetch('https://api.github.com/user', {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github.v3+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`GitHub API error: ${response.statusText}`);
+      }
+
+      const userData = await response.json();
 
       return {
         id: userData.id,
@@ -778,15 +704,8 @@ export class GitHubService {
    */
   async getCurrentUser(): Promise<GitHubUser | null> {
     try {
-      // Check if authenticated first
-      const isAuth = await this.isAuthenticated();
-      if (!isAuth) {
-        return null;
-      }
-
-      // Get user info using the existing method
-      // Note: The token parameter is ignored in getUserInfo since it uses gh CLI
-      return await this.getUserInfo('');
+      const token = await this.getStoredToken();
+      return token ? await this.getUserInfo(token) : null;
     } catch (error) {
       console.error('Failed to get current user:', error);
       return null;
@@ -1337,22 +1256,13 @@ export class GitHubService {
    * Logout and clear stored token
    */
   async logout(): Promise<void> {
-    // Run both operations in parallel since they're independent
-    await Promise.allSettled([
-      // Logout from gh CLI
-      execAsync('echo Y | gh auth logout --hostname github.com').catch((error) => {
-        console.warn('Failed to logout from gh CLI (may not be installed or logged in):', error);
-      }),
-      // Clear keychain token
-      (async () => {
-        try {
-          const keytar = await import('keytar');
-          await keytar.deletePassword(this.SERVICE_NAME, this.ACCOUNT_NAME);
-        } catch (error) {
-          console.error('Failed to clear keychain token:', error);
-        }
-      })(),
-    ]);
+    this.stopPolling();
+    try {
+      const keytar = await import('keytar');
+      await keytar.deletePassword(this.SERVICE_NAME, this.ACCOUNT_NAME);
+    } catch (error) {
+      console.error('Failed to clear keychain token:', error);
+    }
   }
 
   /**
@@ -1371,7 +1281,7 @@ export class GitHubService {
   /**
    * Retrieve stored authentication token
    */
-  private async getStoredToken(): Promise<string | null> {
+  async getStoredToken(): Promise<string | null> {
     try {
       const keytar = await import('keytar');
       return await keytar.getPassword(this.SERVICE_NAME, this.ACCOUNT_NAME);

--- a/src/renderer/components/GitHubIssueSelector.tsx
+++ b/src/renderer/components/GitHubIssueSelector.tsx
@@ -188,7 +188,7 @@ export const GitHubIssueSelector: React.FC<GitHubIssueSelectorProps> = ({
       <div className={className}>
         <Input value="" placeholder="GitHub integration unavailable" disabled />
         <p className="mt-2 text-xs text-muted-foreground">
-          Connect GitHub CLI in Settings to browse issues.
+          Connect GitHub in Settings to browse issues.
         </p>
       </div>
     );
@@ -336,7 +336,7 @@ export const GitHubIssueSelector: React.FC<GitHubIssueSelectorProps> = ({
             </Badge>
           </div>
           <p className="mt-1 text-xs text-muted-foreground">
-            Sign in with GitHub CLI in Settings to browse and attach issues here.
+            Sign in with GitHub in Settings to browse and attach issues here.
           </p>
         </div>
       ) : null}

--- a/src/renderer/components/GithubConnectionCard.tsx
+++ b/src/renderer/components/GithubConnectionCard.tsx
@@ -191,7 +191,7 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
             <Button type="button" variant="outline" onClick={handleRefresh} disabled={isLoading}>
               <RefreshCcw className="mr-2 h-4 w-4" /> Check status
             </Button>
-            {!cliInstalled ? (
+            {!cliInstalled && !installed ? (
               <Button type="button" variant="outline" onClick={handleInstall} disabled={isLoading}>
                 <ExternalLink className="mr-2 h-4 w-4" /> Install GitHub CLI
               </Button>

--- a/src/renderer/components/GithubConnectionCard.tsx
+++ b/src/renderer/components/GithubConnectionCard.tsx
@@ -17,15 +17,13 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
     useGithubContext();
   const [message, setMessage] = useState<string | null>(null);
   const [isError, setIsError] = useState<boolean>(false);
-  const [isInstalling, setIsInstalling] = useState(false);
   const [cliInstalled, setCLIInstalled] = useState(true);
 
   const status: GithubConnectionStatus = useMemo(() => {
-    if (!installed) {
-      return 'missing';
-    }
-    return authenticated ? 'connected' : 'disconnected';
-  }, [installed, authenticated]);
+    if (authenticated) return 'connected';
+    if (!installed) return 'missing';
+    return 'disconnected';
+  }, [authenticated, installed]);
 
   useEffect(() => {
     onStatusChange?.(status);
@@ -50,27 +48,6 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
   const handleConnect = useCallback(async () => {
     setMessage(null);
     setIsError(false);
-
-    // Check if gh CLI is installed
-    const cliPresent = await window.electronAPI.githubCheckCLIInstalled();
-
-    if (!cliPresent) {
-      // Offer to install
-      setMessage('GitHub CLI not found. Installing...');
-      setIsInstalling(true);
-
-      const installResult = await window.electronAPI.githubInstallCLI();
-      setIsInstalling(false);
-
-      if (!installResult.success) {
-        setMessage(`Could not auto-install gh CLI: ${installResult.error || 'Unknown error'}`);
-        setIsError(true);
-        return;
-      }
-
-      setMessage('GitHub CLI installed successfully!');
-      setCLIInstalled(true);
-    }
 
     // Proceed with OAuth authentication
     try {
@@ -127,12 +104,24 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
         <div className="space-y-3">
           <div className="rounded-lg border border-dashed border-border bg-white p-3 dark:border-border dark:bg-background">
             <p className="text-sm text-muted-foreground">
-              Install GitHub CLI (gh) to enable repo access.
+              GitHub CLI is optional. Install it only if you want CLI-backed PR actions.
             </p>
           </div>
-          <Button type="button" variant="outline" size="sm" onClick={handleInstall}>
-            <ExternalLink className="mr-2 h-4 w-4" /> Install GitHub CLI
-          </Button>
+          <div className="flex flex-wrap gap-3">
+            <Button type="button" size="sm" onClick={handleConnect} disabled={isLoading}>
+              {isLoading ? (
+                <>
+                  <Spinner size="sm" className="mr-2" />
+                  Connecting…
+                </>
+              ) : (
+                'Sign in with GitHub'
+              )}
+            </Button>
+            <Button type="button" variant="outline" size="sm" onClick={handleInstall}>
+              <ExternalLink className="mr-2 h-4 w-4" /> Install GitHub CLI
+            </Button>
+          </div>
         </div>
       ) : status === 'connected' ? (
         <div className="space-y-3">
@@ -174,13 +163,14 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
             </div>
           </div>
           <p className="text-xs text-muted-foreground">
-            gh stays signed in to keep PR actions working.
+            Disconnecting here only removes Emdash's GitHub token. Your local `gh` login is left
+            alone.
           </p>
         </div>
       ) : (
         <div className="space-y-3">
           <p className="text-sm text-muted-foreground">
-            Sign in to gh to enable cloning and PR actions.
+            Sign in to connect GitHub in Emdash. GitHub CLI remains optional.
           </p>
           <div className="flex flex-wrap gap-3">
             <Button
@@ -189,10 +179,10 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
               disabled={isLoading}
               aria-busy={isLoading}
             >
-              {isLoading || isInstalling ? (
+              {isLoading ? (
                 <>
                   <Spinner size="sm" className="mr-2" />
-                  {isInstalling ? 'Installing CLI...' : 'Connecting…'}
+                  Connecting…
                 </>
               ) : (
                 'Sign in with GitHub'
@@ -201,6 +191,11 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
             <Button type="button" variant="outline" onClick={handleRefresh} disabled={isLoading}>
               <RefreshCcw className="mr-2 h-4 w-4" /> Check status
             </Button>
+            {!cliInstalled ? (
+              <Button type="button" variant="outline" onClick={handleInstall} disabled={isLoading}>
+                <ExternalLink className="mr-2 h-4 w-4" /> Install GitHub CLI
+              </Button>
+            ) : null}
           </div>
         </div>
       )}

--- a/src/renderer/components/GithubConnectionCard.tsx
+++ b/src/renderer/components/GithubConnectionCard.tsx
@@ -17,7 +17,7 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
     useGithubContext();
   const [message, setMessage] = useState<string | null>(null);
   const [isError, setIsError] = useState<boolean>(false);
-  const [cliInstalled, setCLIInstalled] = useState(true);
+  const [cliInstalled, setCLIInstalled] = useState(installed);
 
   const status: GithubConnectionStatus = useMemo(() => {
     if (authenticated) return 'connected';
@@ -28,6 +28,10 @@ const GithubConnectionCard: React.FC<GithubConnectionCardProps> = ({ onStatusCha
   useEffect(() => {
     onStatusChange?.(status);
   }, [status, onStatusChange]);
+
+  useEffect(() => {
+    setCLIInstalled(installed);
+  }, [installed]);
 
   useEffect(() => {
     // Check if CLI is installed on mount

--- a/src/renderer/components/GithubStatus.tsx
+++ b/src/renderer/components/GithubStatus.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Download, Github } from 'lucide-react';
+import { Github } from 'lucide-react';
 import githubLogo from '../../assets/images/github.png';
 import { Button } from './ui/button';
 import { Spinner } from './ui/spinner';
@@ -30,7 +30,7 @@ export function GithubStatus({
     return null;
   }
 
-  // Not installed - show install button
+  // CLI missing but app auth is still available
   if (!installed) {
     return (
       <Button
@@ -44,18 +44,18 @@ export function GithubStatus({
           <>
             <Spinner size="sm" className="flex-shrink-0" />
             <span className="min-w-0 truncate text-xs font-medium">
-              {statusMessage || 'Installing GitHub CLI...'}
+              {statusMessage || 'Connecting to GitHub...'}
             </span>
           </>
         ) : (
           <>
-            <Download className="h-4 w-4 flex-shrink-0" />
+            <Github className="h-4 w-4 flex-shrink-0" />
             <div className="flex min-w-0 flex-1 flex-col items-start gap-0.5">
               <span className="w-full truncate text-xs font-medium leading-tight">
                 Connect GitHub
               </span>
               <span className="w-full truncate text-[10px] leading-tight opacity-80">
-                Install & sign in
+                Sign in with GitHub
               </span>
             </div>
           </>

--- a/src/renderer/components/IntegrationsCard.tsx
+++ b/src/renderer/components/IntegrationsCard.tsx
@@ -48,7 +48,7 @@ const SvgLogo = ({ raw }: { raw: string }) => {
 };
 
 const IntegrationsCard: React.FC = () => {
-  const { installed, authenticated, isLoading, login, logout, checkStatus } = useGithubContext();
+  const { authenticated, isLoading, login, logout, checkStatus } = useGithubContext();
   const { hasAccount, checkServerHealth, refreshSession } = useEmdashAccount();
   const { showModal, closeModal } = useModalContext();
 
@@ -170,18 +170,6 @@ const IntegrationsCard: React.FC = () => {
   const handleGithubConnect = useCallback(async () => {
     setGithubError(null);
     try {
-      if (!installed) {
-        // Auto-install gh CLI
-        const installResult = await window.electronAPI.githubInstallCLI();
-        if (!installResult.success) {
-          setGithubError(
-            `Could not auto-install gh CLI: ${installResult.error || 'Unknown error'}`
-          );
-          return;
-        }
-        await checkStatus();
-      }
-
       if (hasAccount && (await checkServerHealth())) {
         try {
           const result = await window.electronAPI.githubAuthOAuth();
@@ -221,16 +209,7 @@ const IntegrationsCard: React.FC = () => {
       setGithubError('Could not connect.');
       closeModal();
     }
-  }, [
-    hasAccount,
-    checkServerHealth,
-    refreshSession,
-    checkStatus,
-    login,
-    installed,
-    showModal,
-    closeModal,
-  ]);
+  }, [hasAccount, checkServerHealth, refreshSession, checkStatus, login, showModal, closeModal]);
 
   const handleGithubDisconnect = useCallback(async () => {
     setGithubError(null);

--- a/src/renderer/components/TaskAdvancedSettings.tsx
+++ b/src/renderer/components/TaskAdvancedSettings.tsx
@@ -114,7 +114,7 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
   isGithubConnected,
   onGithubConnect,
   githubLoading,
-  githubInstalled,
+  githubInstalled: _githubInstalled,
   selectedJiraIssue,
   onJiraIssueChange,
   isJiraConnected,
@@ -594,8 +594,6 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
                           <Spinner size="sm" className="mr-1" />
                           Connecting...
                         </>
-                      ) : !githubInstalled ? (
-                        'Install CLI'
                       ) : (
                         'Connect'
                       )}

--- a/src/renderer/components/hooks/useIntegrationStatus.ts
+++ b/src/renderer/components/hooks/useIntegrationStatus.ts
@@ -51,7 +51,7 @@ export function useIntegrationStatus(isOpen: boolean): IntegrationStatus {
     isLoading: githubLoading,
   } = useGithubContext();
 
-  const isGithubConnected = githubInstalled && githubAuthenticated;
+  const isGithubConnected = githubAuthenticated;
 
   // Check Linear connection
   useEffect(() => {
@@ -154,21 +154,13 @@ export function useIntegrationStatus(isOpen: boolean): IntegrationStatus {
   }, []);
 
   const handleGithubConnect = useCallback(async () => {
-    if (!githubInstalled) {
-      try {
-        await window.electronAPI.openExternal('https://cli.github.com/manual/installation');
-      } catch (error) {
-        console.error('Failed to open GitHub CLI install docs:', error);
-      }
-      return;
-    }
     try {
       await githubLogin();
     } catch (error) {
       console.error('Failed to connect GitHub:', error);
       throw error;
     }
-  }, [githubInstalled, githubLogin]);
+  }, [githubLogin]);
 
   const handleJiraConnect = useCallback(
     async (credentials: { siteUrl: string; email: string; token: string }) => {

--- a/src/renderer/components/hooks/useIntegrationStatus.ts
+++ b/src/renderer/components/hooks/useIntegrationStatus.ts
@@ -47,7 +47,7 @@ export function useIntegrationStatus(isOpen: boolean): IntegrationStatus {
   const {
     installed: githubInstalled,
     authenticated: githubAuthenticated,
-    login: githubLogin,
+    handleGithubConnect: githubConnect,
     isLoading: githubLoading,
   } = useGithubContext();
 
@@ -155,12 +155,12 @@ export function useIntegrationStatus(isOpen: boolean): IntegrationStatus {
 
   const handleGithubConnect = useCallback(async () => {
     try {
-      await githubLogin();
+      await githubConnect();
     } catch (error) {
       console.error('Failed to connect GitHub:', error);
       throw error;
     }
-  }, [githubLogin]);
+  }, [githubConnect]);
 
   const handleJiraConnect = useCallback(
     async (credentials: { siteUrl: string; email: string; token: string }) => {

--- a/src/renderer/contexts/GithubContextProvider.tsx
+++ b/src/renderer/contexts/GithubContextProvider.tsx
@@ -2,7 +2,6 @@ import React, { createContext, useContext, useState, useCallback, useEffect } fr
 import { useQuery, useQueryClient, useMutation } from '@tanstack/react-query';
 import { useToast } from '../hooks/use-toast';
 import { useModalContext } from './ModalProvider';
-import { useAppContext } from './AppContextProvider';
 import { useEmdashAccount } from './EmdashAccountProvider';
 
 type GithubUser = any;
@@ -15,13 +14,13 @@ type GithubContextValue = {
   isLoading: boolean;
   isInitialized: boolean;
 
-  /** True during the handleGithubConnect flow (CLI install + auth start) */
+  /** True during the handleGithubConnect flow */
   githubLoading: boolean;
   githubStatusMessage: string | undefined;
   needsGhInstall: boolean;
   needsGhAuth: boolean;
 
-  /** Full connect flow: installs CLI if needed, starts device flow, shows modal */
+  /** Full connect flow: authenticates via account or device flow and shows the modal */
   handleGithubConnect: () => Promise<void>;
   /** Raw login — starts the device flow and returns the IPC result */
   login: () => Promise<any>;
@@ -38,7 +37,6 @@ const GithubContext = createContext<GithubContextValue | null>(null);
 export function GithubContextProvider({ children }: { children: React.ReactNode }) {
   const { showModal } = useModalContext();
   const { toast } = useToast();
-  const { platform } = useAppContext();
   const { hasAccount, checkServerHealth, refreshSession } = useEmdashAccount();
   const queryClient = useQueryClient();
 
@@ -136,41 +134,6 @@ export function GithubContextProvider({ children }: { children: React.ReactNode 
     setGithubStatusMessage(undefined);
 
     try {
-      setGithubStatusMessage('Checking for GitHub CLI...');
-      const cliInstalled = await window.electronAPI.githubCheckCLIInstalled();
-
-      if (!cliInstalled) {
-        let installMessage = 'Installing GitHub CLI...';
-        if (platform === 'darwin') {
-          installMessage = 'Installing GitHub CLI via Homebrew...';
-        } else if (platform === 'linux') {
-          installMessage = 'Installing GitHub CLI via apt...';
-        } else if (platform === 'win32') {
-          installMessage = 'Installing GitHub CLI via winget...';
-        }
-
-        setGithubStatusMessage(installMessage);
-        const installResult = await window.electronAPI.githubInstallCLI();
-
-        if (!installResult.success) {
-          setGithubLoading(false);
-          setGithubStatusMessage(undefined);
-          toast({
-            title: 'Installation Failed',
-            description: `Could not auto-install gh CLI: ${installResult.error || 'Unknown error'}`,
-            variant: 'destructive',
-          });
-          return;
-        }
-
-        setGithubStatusMessage('GitHub CLI installed! Setting up connection...');
-        toast({
-          title: 'GitHub CLI Installed',
-          description: 'Now authenticating with GitHub...',
-        });
-        void checkStatus();
-      }
-
       if (hasAccount && (await checkServerHealth())) {
         setGithubStatusMessage('Authenticating via Emdash account...');
         try {
@@ -220,7 +183,6 @@ export function GithubContextProvider({ children }: { children: React.ReactNode 
     hasAccount,
     checkServerHealth,
     refreshSession,
-    platform,
     toast,
     checkStatus,
     login,

--- a/src/test/main/GitHubService.test.ts
+++ b/src/test/main/GitHubService.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { promisify } from 'util';
 
 const execCalls: string[] = [];
@@ -115,6 +115,10 @@ describe('GitHubService.isAuthenticated', () => {
       }),
     });
     vi.stubGlobal('fetch', fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
   });
 
   it('does not treat a global gh login as authenticated without an Emdash token', async () => {

--- a/src/test/main/GitHubService.test.ts
+++ b/src/test/main/GitHubService.test.ts
@@ -73,6 +73,7 @@ vi.mock('child_process', () => {
 const setPasswordMock = vi.fn().mockResolvedValue(undefined);
 const getPasswordMock = vi.fn().mockResolvedValue(null);
 const deletePasswordMock = vi.fn().mockResolvedValue(undefined);
+const fetchMock = vi.fn();
 
 vi.mock('keytar', () => {
   const module = {
@@ -99,21 +100,62 @@ describe('GitHubService.isAuthenticated', () => {
     prCountStdout = '0';
     setPasswordMock.mockClear();
     getPasswordMock.mockClear();
+    deletePasswordMock.mockClear();
     getPasswordMock.mockResolvedValue(null);
+    fetchMock.mockReset();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      statusText: 'OK',
+      json: async () => ({
+        id: 1,
+        login: 'tester',
+        name: 'Tester',
+        email: '',
+        avatar_url: '',
+      }),
+    });
+    vi.stubGlobal('fetch', fetchMock);
   });
 
-  it('treats GitHub CLI login as authenticated even without stored token', async () => {
+  it('does not treat a global gh login as authenticated without an Emdash token', async () => {
+    const service = new GitHubService();
+
+    const result = await service.isAuthenticated();
+
+    expect(result).toBe(false);
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(execCalls.find((cmd) => cmd.startsWith('gh auth status'))).toBeUndefined();
+    expect(setPasswordMock).not.toHaveBeenCalled();
+  });
+
+  it('treats a stored Emdash token as authenticated', async () => {
+    getPasswordMock.mockResolvedValue('gho_mocktoken');
+
     const service = new GitHubService();
 
     const result = await service.isAuthenticated();
 
     expect(result).toBe(true);
-    expect(execCalls.find((cmd) => cmd.startsWith('gh auth status'))).toBeDefined();
-    expect(execCalls.find((cmd) => cmd.startsWith('gh auth token'))).toBeUndefined();
-    expect(setPasswordMock).not.toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalledWith('https://api.github.com/user', {
+      headers: {
+        Authorization: 'Bearer gho_mocktoken',
+        Accept: 'application/vnd.github.v3+json',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+    });
+  });
+
+  it('logout only clears Emdash token storage', async () => {
+    const service = new GitHubService();
+
+    await service.logout();
+
+    expect(deletePasswordMock).toHaveBeenCalledWith('emdash-github', 'github-token');
+    expect(execCalls).toEqual([]);
   });
 
   it('sorts listed issues by updatedAt descending', async () => {
+    getPasswordMock.mockResolvedValue('gho_mocktoken');
     issueListStdout = JSON.stringify([
       { number: 11, title: 'Older', updatedAt: '2026-03-01T10:00:00.000Z' },
       { number: 12, title: 'Newest', updatedAt: '2026-03-03T12:00:00.000Z' },
@@ -127,6 +169,7 @@ describe('GitHubService.isAuthenticated', () => {
   });
 
   it('sorts searched issues by updatedAt descending', async () => {
+    getPasswordMock.mockResolvedValue('gho_mocktoken');
     issueSearchStdout = JSON.stringify([
       { number: 101, title: 'Stale', updatedAt: '2026-03-02T08:00:00.000Z' },
       { number: 102, title: 'Fresh', updatedAt: '2026-03-04T08:00:00.000Z' },
@@ -140,6 +183,7 @@ describe('GitHubService.isAuthenticated', () => {
   });
 
   it('limits pull requests and returns the total open PR count', async () => {
+    getPasswordMock.mockResolvedValue('gho_mocktoken');
     prListStdout = JSON.stringify([
       { number: 8, title: 'Older', updatedAt: '2026-03-01T10:00:00.000Z' },
       { number: 9, title: 'Newest', updatedAt: '2026-03-03T10:00:00.000Z' },
@@ -158,6 +202,7 @@ describe('GitHubService.isAuthenticated', () => {
   });
 
   it('passes search queries through to gh pr list and the filtered count lookup', async () => {
+    getPasswordMock.mockResolvedValue('gho_mocktoken');
     prListStdout = JSON.stringify([
       { number: 17, title: 'Needs review', updatedAt: '2026-03-04T10:00:00.000Z' },
     ]);


### PR DESCRIPTION
## Summary
this fix makes it so that emdash no longer uses your gh cli login behind the scenes. github is now considered connected when emdash iteslf has a valid token and disconnecting no longer signes you out of the gh cli 

we also now pass the emdash token für pr's and stuff 

## Fixes 
#1704 

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code

## Checklist

- [X] I have read the contributing guide
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * GitHub integration no longer requires or auto-installs the GitHub CLI; disconnect now only clears the app token.

* **Improvements**
  * Simplified sign-in flow—connect directly via GitHub (account/device) without CLI pre-checks.
  * Status text, buttons, and messaging clarified to show GitHub as optional and reflect connection states.
  * More reliable repository/branch and authentication checks using stored tokens and API lookups.

* **Tests**
  * Added tests covering token-based auth and logout behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->