### PR TITLE
improve: git commit error messages and add skip-hooks option

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -2252,9 +2252,15 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
         return { success: true, branch: activeBranch, output: (out || '').trim() };
       } catch (error) {
         log.error('Failed to commit and push:', error);
-        const errObj = error as { stderr?: string; message?: string };
-        const errMsg = errObj?.stderr?.trim() || errObj?.message || String(error);
-        return { success: false, error: errMsg };
+        const errObj = error as { stderr?: string; stdout?: string; message?: string };
+        // Hooks (husky/lint-staged etc.) often write failure details to stdout, not stderr.
+        const stderr = errObj?.stderr?.trim() ?? '';
+        const stdout = errObj?.stdout?.trim() ?? '';
+        const combined = [stdout, stderr].filter(Boolean).join('\n').trim();
+        return {
+          success: false,
+          error: combined || errObj?.message || String(error),
+        };
       }
     }
   );
@@ -2737,17 +2743,29 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
     }
   );
 
-  ipcMain.handle('git:commit', async (_, args: { taskPath: string; message: string }) => {
-    try {
-      const pathErr = validateTaskPath(args.taskPath);
-      if (pathErr) return { success: false, error: pathErr };
-      const result = await gitCommit(args.taskPath, args.message);
-      broadcastGitStatusChange(args.taskPath);
-      return { success: true, hash: result.hash };
-    } catch (error) {
-      return { success: false, error: error instanceof Error ? error.message : String(error) };
+  ipcMain.handle(
+    'git:commit',
+    async (_, args: { taskPath: string; message: string; noVerify?: boolean }) => {
+      try {
+        const pathErr = validateTaskPath(args.taskPath);
+        if (pathErr) return { success: false, error: pathErr };
+        const result = await gitCommit(args.taskPath, args.message, { noVerify: args.noVerify });
+        broadcastGitStatusChange(args.taskPath);
+        return { success: true, hash: result.hash };
+      } catch (error) {
+        const errObj = error as { stderr?: string; stdout?: string; message?: string };
+        // Hooks (husky/lint-staged etc.) often write failure details to stdout, not just stderr.
+        // Combine both so the renderer can show the full output.
+        const stderr = errObj?.stderr?.trim() ?? '';
+        const stdout = errObj?.stdout?.trim() ?? '';
+        const combined = [stdout, stderr].filter(Boolean).join('\n').trim();
+        return {
+          success: false,
+          error: combined || errObj?.message || String(error),
+        };
+      }
     }
-  });
+  );
 
   ipcMain.handle('git:push', async (_, args: { taskPath: string }) => {
     try {
@@ -2756,8 +2774,12 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
       const result = await gitPush(args.taskPath);
       return { success: true, output: result.output };
     } catch (error) {
-      const errObj = error as { stderr?: string; message?: string };
-      return { success: false, error: errObj?.stderr?.trim() || errObj?.message || String(error) };
+      const errObj = error as { stderr?: string; stdout?: string; message?: string };
+      // Hooks (husky/lint-staged etc.) often write failure details to stdout, not just stderr.
+      const stderr = errObj?.stderr?.trim() ?? '';
+      const stdout = errObj?.stdout?.trim() ?? '';
+      const combined = [stdout, stderr].filter(Boolean).join('\n').trim();
+      return { success: false, error: combined || errObj?.message || String(error) };
     }
   });
 
@@ -2768,8 +2790,12 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
       const result = await gitPull(args.taskPath);
       return { success: true, output: result.output };
     } catch (error) {
-      const errObj = error as { stderr?: string; message?: string };
-      return { success: false, error: errObj?.stderr?.trim() || errObj?.message || String(error) };
+      const errObj = error as { stderr?: string; stdout?: string; message?: string };
+      // Hooks (husky/lint-staged etc.) often write failure details to stdout, not just stderr.
+      const stderr = errObj?.stderr?.trim() ?? '';
+      const stdout = errObj?.stdout?.trim() ?? '';
+      const combined = [stdout, stderr].filter(Boolean).join('\n').trim();
+      return { success: false, error: combined || errObj?.message || String(error) };
     }
   });
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -411,7 +411,7 @@ contextBridge.exposeInMainWorld('electronAPI', {
     ipcRenderer.invoke('git:update-index', args),
   revertFile: (args: { taskPath: string; taskId?: string; filePath: string }) =>
     ipcRenderer.invoke('git:revert-file', args),
-  gitCommit: (args: { taskPath: string; message: string }) =>
+  gitCommit: (args: { taskPath: string; message: string; noVerify?: boolean }) =>
     ipcRenderer.invoke('git:commit', args),
   gitPush: (args: { taskPath: string }) => ipcRenderer.invoke('git:push', args),
   gitPull: (args: { taskPath: string }) => ipcRenderer.invoke('git:pull', args),

--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -683,7 +683,13 @@ export class GitHubService {
         throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
       }
 
-      const userData = await response.json();
+      const userData = (await response.json()) as {
+        id: number;
+        login: string;
+        name: string | null;
+        email: string | null;
+        avatar_url: string;
+      };
 
       return {
         id: userData.id,

--- a/src/main/services/GitService.ts
+++ b/src/main/services/GitService.ts
@@ -429,11 +429,19 @@ export async function getFileDiff(
 }
 
 /** Commit staged files (no push). Returns the commit hash. */
-export async function commit(taskPath: string, message: string): Promise<{ hash: string }> {
+export async function commit(
+  taskPath: string,
+  message: string,
+  options: { noVerify?: boolean } = {}
+): Promise<{ hash: string }> {
   if (!message || !message.trim()) {
     throw new Error('Commit message cannot be empty');
   }
-  await execFileAsync('git', ['commit', '-m', message], { cwd: taskPath });
+  const args = ['commit', '-m', message];
+  if (options.noVerify) {
+    args.push('--no-verify');
+  }
+  await execFileAsync('git', args, { cwd: taskPath });
   const { stdout } = await execFileAsync('git', ['rev-parse', 'HEAD'], { cwd: taskPath });
   return { hash: stdout.trim() };
 }

--- a/src/renderer/components/FileChangesPanel.tsx
+++ b/src/renderer/components/FileChangesPanel.tsx
@@ -5,6 +5,8 @@ import { Button } from './ui/button';
 import { Input } from './ui/input';
 import { Spinner } from './ui/spinner';
 import { useToast } from '../hooks/use-toast';
+import { useErrorDetails } from '../hooks/useErrorDetails';
+import { friendlyGitError } from '../lib/friendlyGitError';
 import { useCreatePR } from '../hooks/useCreatePR';
 import { useFileChanges, type FileChange } from '../hooks/useFileChanges';
 import { dispatchFileChangeEvent } from '../lib/fileChangeEvents';
@@ -228,6 +230,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
     taskId: resolvedTaskId,
   });
   const { toast } = useToast();
+  const { showError, errorDialog } = useErrorDetails();
   const hasChanges = fileChanges.length > 0;
   const stagedCount = fileChanges.filter((change) => change.isStaged).length;
   const hasStagedChanges = stagedCount > 0;
@@ -447,18 +450,15 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
           if (taskPathRef.current === taskPathAtCommit) setBranchStatusLoading(false);
         }
       } else {
-        toast({
-          title: 'Commit Failed',
-          description:
-            typeof result.error === 'string' ? result.error : 'Failed to commit and push changes.',
-          variant: 'destructive',
-        });
+        showError(
+          'Commit Failed',
+          typeof result.error === 'string' ? result.error : 'Failed to commit and push changes.',
+          { summarize: friendlyGitError }
+        );
       }
-    } catch (_error) {
-      toast({
-        title: 'Commit Failed',
-        description: 'An unexpected error occurred.',
-        variant: 'destructive',
+    } catch (error) {
+      showError('Commit Failed', error instanceof Error ? error.message : String(error), {
+        summarize: friendlyGitError,
       });
     } finally {
       setIsCommitting(false);
@@ -1070,6 +1070,7 @@ const FileChangesPanelComponent: React.FC<FileChangesPanelProps> = ({
           </AlertDialogFooter>
         </AlertDialogContent>
       </AlertDialog>
+      {errorDialog}
     </div>
   );
 };

--- a/src/renderer/components/diff-viewer/CommitArea.tsx
+++ b/src/renderer/components/diff-viewer/CommitArea.tsx
@@ -1,8 +1,11 @@
 import React, { useCallback, useEffect, useState } from 'react';
 import { ArrowUp, ArrowDown, Undo2, Loader2 } from 'lucide-react';
 import { useToast } from '../../hooks/use-toast';
+import { useErrorDetails } from '../../hooks/useErrorDetails';
+import { friendlyGitError } from '../../lib/friendlyGitError';
 import type { FileChange } from '../../hooks/useFileChanges';
 import { subscribeToFileChanges } from '../../lib/fileChangeEvents';
+import { Checkbox } from '../ui/checkbox';
 
 interface CommitAreaProps {
   taskPath?: string;
@@ -17,30 +20,13 @@ interface LatestCommit {
   isPushed: boolean;
 }
 
-function friendlyGitError(raw: string): string {
-  const s = raw.toLowerCase();
-  if (s.includes('non-fast-forward') || s.includes('tip of your current branch is behind'))
-    return 'Remote has new commits. Pull before pushing.';
-  if (s.includes('merge conflict') || s.includes('fix conflicts'))
-    return 'Merge conflicts detected. Resolve them in your editor.';
-  if (s.includes('permission denied') || s.includes('authentication'))
-    return 'Authentication failed. Check your credentials.';
-  if (s.includes('could not resolve host') || s.includes('unable to access'))
-    return 'Cannot reach remote. Check your network connection.';
-  if (s.includes('no such remote')) return 'No remote configured for this repository.';
-  if (s.includes('cannot undo the initial commit')) return 'Cannot undo the initial commit.';
-  if (s.includes('nothing to commit')) return 'Nothing to commit.';
-  // Return first meaningful line, capped
-  const firstLine = raw.split('\n').find((l) => l.trim().length > 0) || raw;
-  return firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine;
-}
-
 export const CommitArea: React.FC<CommitAreaProps> = ({
   taskPath,
   fileChanges,
   onRefreshChanges,
 }) => {
   const { toast } = useToast();
+  const { showError, errorDialog } = useErrorDetails();
   const [commitMessage, setCommitMessage] = useState('');
   const [description, setDescription] = useState('');
   const [branch, setBranch] = useState<string | null>(null);
@@ -51,6 +37,14 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
   const [isUndoing, setIsUndoing] = useState(false);
   const [aheadCount, setAheadCount] = useState(0);
   const [behindCount, setBehindCount] = useState(0);
+  const [skipHooks, setSkipHooks] = useState(false);
+
+  const showGitError = useCallback(
+    (title: string, rawError: string) => {
+      showError(title, rawError, { summarize: friendlyGitError });
+    },
+    [showError]
+  );
 
   const hasStagedFiles = fileChanges.some((f) => f.isStaged);
   const canCommit = hasStagedFiles && commitMessage.trim().length > 0 && !isCommitting;
@@ -96,7 +90,11 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
       const message = description.trim()
         ? `${commitMessage.trim()}\n\n${description.trim()}`
         : commitMessage.trim();
-      const result = await window.electronAPI.gitCommit({ taskPath, message });
+      const result = await window.electronAPI.gitCommit({
+        taskPath,
+        message,
+        noVerify: skipHooks,
+      });
       if (result.success) {
         setCommitMessage('');
         setDescription('');
@@ -104,18 +102,10 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
         await fetchLatestCommit();
         await fetchBranch();
       } else {
-        toast({
-          title: 'Commit failed',
-          description: friendlyGitError(result?.error || 'Unknown error'),
-          variant: 'destructive',
-        });
+        showGitError('Commit failed', result?.error || 'Unknown error');
       }
     } catch (err) {
-      toast({
-        title: 'Commit failed',
-        description: friendlyGitError(err instanceof Error ? err.message : String(err)),
-        variant: 'destructive',
-      });
+      showGitError('Commit failed', err instanceof Error ? err.message : String(err));
     } finally {
       setIsCommitting(false);
     }
@@ -131,20 +121,12 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
       if (result?.success) {
         toast({ title: 'Pushed successfully' });
       } else {
-        toast({
-          title: 'Push failed',
-          description: friendlyGitError(result?.error || 'Unknown error'),
-          variant: 'destructive',
-        });
+        showGitError('Push failed', result?.error || 'Unknown error');
       }
       await fetchBranch();
       await fetchLatestCommit();
     } catch (err) {
-      toast({
-        title: 'Push failed',
-        description: friendlyGitError(err instanceof Error ? err.message : String(err)),
-        variant: 'destructive',
-      });
+      showGitError('Push failed', err instanceof Error ? err.message : String(err));
     } finally {
       setIsPushing(false);
     }
@@ -156,21 +138,13 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
     try {
       const result = await window.electronAPI.gitPull({ taskPath });
       if (!result?.success) {
-        toast({
-          title: 'Pull failed',
-          description: friendlyGitError(result?.error || 'Unknown error'),
-          variant: 'destructive',
-        });
+        showGitError('Pull failed', result?.error || 'Unknown error');
       }
       await fetchBranch();
       await fetchLatestCommit();
       await onRefreshChanges?.();
     } catch (err) {
-      toast({
-        title: 'Pull failed',
-        description: friendlyGitError(err instanceof Error ? err.message : String(err)),
-        variant: 'destructive',
-      });
+      showGitError('Pull failed', err instanceof Error ? err.message : String(err));
     } finally {
       setIsPulling(false);
     }
@@ -188,18 +162,10 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
         await fetchLatestCommit();
         await fetchBranch();
       } else {
-        toast({
-          title: 'Undo failed',
-          description: friendlyGitError(result?.error || 'Unknown error'),
-          variant: 'destructive',
-        });
+        showGitError('Undo failed', result?.error || 'Unknown error');
       }
     } catch (err) {
-      toast({
-        title: 'Undo failed',
-        description: friendlyGitError(err instanceof Error ? err.message : String(err)),
-        variant: 'destructive',
-      });
+      showGitError('Undo failed', err instanceof Error ? err.message : String(err));
     } finally {
       setIsUndoing(false);
     }
@@ -236,6 +202,20 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
         rows={3}
         className="w-full resize-none rounded-md border border-border bg-background px-2.5 py-1.5 text-xs text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-1 focus:ring-ring"
       />
+
+      {/* Skip git hooks toggle */}
+      <label
+        className="flex cursor-pointer select-none items-center gap-2 text-xs text-muted-foreground transition-colors hover:text-foreground"
+        title="Pass --no-verify when committing. Bypasses pre-commit and commit-msg hooks."
+      >
+        <Checkbox
+          checked={skipHooks}
+          onCheckedChange={(checked) => setSkipHooks(checked === true)}
+          className="h-3.5 w-3.5"
+        />
+        Skip git hooks
+        <span className="font-mono text-[10px] opacity-60">--no-verify</span>
+      </label>
 
       {/* Commit & Push & Pull buttons */}
       <div className="flex gap-2">
@@ -308,6 +288,8 @@ export const CommitArea: React.FC<CommitAreaProps> = ({
           )}
         </div>
       )}
+
+      {errorDialog}
     </div>
   );
 };

--- a/src/renderer/hooks/useErrorDetails.tsx
+++ b/src/renderer/hooks/useErrorDetails.tsx
@@ -43,7 +43,7 @@ export function useErrorDetails(): UseErrorDetailsResult {
   const [details, setDetails] = useState<{ title: string; message: string } | null>(null);
   const [open, setOpen] = useState(false);
   const [copied, setCopied] = useState(false);
-  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>();
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
   useEffect(() => {
     return () => {
@@ -53,7 +53,7 @@ export function useErrorDetails(): UseErrorDetailsResult {
 
   const showError = useCallback(
     (title: string, rawError: string, options?: ShowErrorOptions) => {
-      const fullMessage = rawError || 'Unknown error';
+      const fullMessage = rawError?.trim() ? rawError : 'Unknown error';
       const summarize = options?.summarize ?? defaultSummarize;
       toast({
         title,

--- a/src/renderer/hooks/useErrorDetails.tsx
+++ b/src/renderer/hooks/useErrorDetails.tsx
@@ -1,0 +1,122 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { Copy, Check } from 'lucide-react';
+import { useToast } from './use-toast';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '../components/ui/dialog';
+import { ToastAction } from '../components/ui/toast';
+
+interface ShowErrorOptions {
+  /**
+   * Optional summarizer that turns the raw error into a one-line toast description.
+   * If omitted, the first non-empty line of the raw error is used (capped at 120 chars).
+   */
+  summarize?: (raw: string) => string;
+}
+
+interface UseErrorDetailsResult {
+  /** Show a destructive toast with a "View details" action that opens a dialog with the full output. */
+  showError: (title: string, rawError: string, options?: ShowErrorOptions) => void;
+  /** JSX to render somewhere inside the consuming component. */
+  errorDialog: React.ReactNode;
+}
+
+function defaultSummarize(raw: string): string {
+  const firstLine = raw.split('\n').find((l) => l.trim().length > 0) || raw;
+  return firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine;
+}
+
+/**
+ * Provides a `showError` helper that pairs a friendly destructive toast with a
+ * "View details" action button. Clicking the action opens a dialog containing
+ * the full multi-line error output, with a copy-to-clipboard button.
+ *
+ * Use this whenever you want to surface stderr/stdout from an external process
+ * (git, hooks, package managers) without losing information to truncation.
+ */
+export function useErrorDetails(): UseErrorDetailsResult {
+  const { toast } = useToast();
+  const [details, setDetails] = useState<{ title: string; message: string } | null>(null);
+  const [open, setOpen] = useState(false);
+  const [copied, setCopied] = useState(false);
+  const copyTimerRef = useRef<ReturnType<typeof setTimeout>>();
+
+  useEffect(() => {
+    return () => {
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+    };
+  }, []);
+
+  const showError = useCallback(
+    (title: string, rawError: string, options?: ShowErrorOptions) => {
+      const fullMessage = rawError || 'Unknown error';
+      const summarize = options?.summarize ?? defaultSummarize;
+      toast({
+        title,
+        description: summarize(fullMessage),
+        variant: 'destructive',
+        action: (
+          <ToastAction
+            altText="View full error details"
+            onClick={() => {
+              setDetails({ title, message: fullMessage });
+              setOpen(true);
+            }}
+          >
+            View details
+          </ToastAction>
+        ),
+      });
+    },
+    [toast]
+  );
+
+  const handleCopy = async () => {
+    if (!details?.message) return;
+    try {
+      await navigator.clipboard.writeText(details.message);
+      setCopied(true);
+      if (copyTimerRef.current) clearTimeout(copyTimerRef.current);
+      copyTimerRef.current = setTimeout(() => setCopied(false), 1500);
+    } catch {
+      // Clipboard may be unavailable; ignore.
+    }
+  };
+
+  const errorDialog = (
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        setOpen(next);
+        if (!next) setCopied(false);
+      }}
+    >
+      <DialogContent className="max-w-2xl gap-3">
+        <DialogHeader>
+          <DialogTitle>{details?.title ?? 'Error'}</DialogTitle>
+          <DialogDescription>Full output, including any hook errors.</DialogDescription>
+        </DialogHeader>
+        <div className="relative">
+          <pre className="max-h-[60vh] overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/50 p-3 pr-10 font-mono text-xs leading-relaxed text-foreground">
+            {details?.message ?? ''}
+          </pre>
+          <button
+            type="button"
+            onClick={() => void handleCopy()}
+            className="absolute right-2 top-2 flex h-7 w-7 items-center justify-center rounded-md border border-border bg-background text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            title={copied ? 'Copied' : 'Copy to clipboard'}
+            aria-label={copied ? 'Copied' : 'Copy to clipboard'}
+          >
+            {copied ? <Check className="h-3.5 w-3.5" /> : <Copy className="h-3.5 w-3.5" />}
+          </button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+
+  return { showError, errorDialog };
+}

--- a/src/renderer/lib/friendlyGitError.ts
+++ b/src/renderer/lib/friendlyGitError.ts
@@ -1,0 +1,26 @@
+/**
+ * Reduce a (potentially long, multi-line) raw git/hook error string to a single
+ * concise sentence suitable for a toast description.
+ *
+ * The full text should still be preserved separately so users can view it in a
+ * details dialog — see `useErrorDetails`.
+ */
+export function friendlyGitError(raw: string): string {
+  const s = raw.toLowerCase();
+  if (s.includes('non-fast-forward') || s.includes('tip of your current branch is behind'))
+    return 'Remote has new commits. Pull before pushing.';
+  if (s.includes('merge conflict') || s.includes('fix conflicts'))
+    return 'Merge conflicts detected. Resolve them in your editor.';
+  if (s.includes('permission denied') || s.includes('authentication'))
+    return 'Authentication failed. Check your credentials.';
+  if (s.includes('could not resolve host') || s.includes('unable to access'))
+    return 'Cannot reach remote. Check your network connection.';
+  if (s.includes('no such remote')) return 'No remote configured for this repository.';
+  if (s.includes('cannot undo the initial commit')) return 'Cannot undo the initial commit.';
+  if (s.includes('nothing to commit')) return 'Nothing to commit.';
+  if (s.includes('pre-commit') || s.includes('commit-msg') || s.includes('husky'))
+    return 'A git hook rejected the commit. View details for the full output.';
+  // Return first meaningful line, capped
+  const firstLine = raw.split('\n').find((l) => l.trim().length > 0) || raw;
+  return firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine;
+}

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -431,7 +431,7 @@ declare global {
         action?: 'reverted';
         error?: string;
       }>;
-      gitCommit: (args: { taskPath: string; message: string }) => Promise<{
+      gitCommit: (args: { taskPath: string; message: string; noVerify?: boolean }) => Promise<{
         success: boolean;
         hash?: string;
         error?: string;


### PR DESCRIPTION
## Summary
this should make the error message on commit way more debugable and easier to work with :D 

would be open to tweak this further :D 

## Fixes 
#1708 

## Snapshot
https://github.com/user-attachments/assets/4cf6063c-0931-4ade-be06-b1e843f10067

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code

## Checklist

- [X] I have read the contributing guide
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Toggle to skip git hooks when committing.
  * Enhanced error UI: compact friendly summaries in notifications plus a “View details” dialog with full error text and copy-to-clipboard.
  * Improved in-place error handling across commit/push/pull flows for clearer feedback.

* **Bug Fixes**
  * Git error reporting now combines all command output streams so failure messages are more complete.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->