### PR TITLE
fix: remote file tree shows root contents when expanding subdirectories

### DIFF
--- a/src/renderer/components/FileExplorer/FileTree.tsx
+++ b/src/renderer/components/FileExplorer/FileTree.tsx
@@ -703,7 +703,7 @@ export const FileTree: React.FC<FileTreeProps> = ({
         };
         if (connectionId && remotePath) {
           opts.connectionId = connectionId;
-          opts.remotePath = remotePath;
+          opts.remotePath = constructSubRoot(remotePath, node.path);
         }
 
         const result = await window.electronAPI.fsList(subRoot, opts);


### PR DESCRIPTION
## Summary
- Fix `loadChildren` in `FileTree.tsx` to pass the subdirectory path instead of the repo root when expanding remote directories
- Uses the existing `constructSubRoot` helper, matching how local paths are already handled

## Fixes 
Fixes #1710

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [x] I have self-reviewed the code

## Checklist

- [x] I have read the contributing guide
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have checked if my PR needs changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works - N/A


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed remote path scoping when expanding directories in the file explorer. The application now correctly constructs the remote path for nested directory expansions, ensuring the proper file scope is accessed when loading contents of subdirectories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->