### PR TITLE
Add worktree path tracking and GitHub branch support

### DIFF
--- a/src/main/ipc/gitIpc.ts
+++ b/src/main/ipc/gitIpc.ts
@@ -1234,7 +1234,7 @@ export function registerGitIpc() {
               { cwd: taskPath }
             );
             const db2 = (stdout || '').trim();
-            if (db2) defaultBranch = db2;
+            if (db2 && db2 !== '(unknown)') defaultBranch = db2;
           } catch {}
         }
 
@@ -2170,7 +2170,7 @@ current branch '${currentBranch}' ahead of base '${baseRef}'.`,
               { cwd: taskPath }
             );
             const db2 = (stdout || '').trim();
-            if (db2) defaultBranch = db2;
+            if (db2 && db2 !== '(unknown)') defaultBranch = db2;
           } catch {}
         }
 

--- a/src/main/ipc/projectIpc.ts
+++ b/src/main/ipc/projectIpc.ts
@@ -51,7 +51,10 @@ const detectDefaultBranch = async (projectPath: string, remote?: string | null) 
       cwd: projectPath,
     });
     const match = stdout.match(/HEAD branch:\s*(\S+)/);
-    return match ? match[1] : null;
+    if (match && match[1] !== '(unknown)') {
+      return match[1];
+    }
+    return null;
   } catch {
     return null;
   }

--- a/src/main/services/GitHubService.ts
+++ b/src/main/services/GitHubService.ts
@@ -683,7 +683,13 @@ export class GitHubService {
         throw new Error(`GitHub API error: ${response.status} ${response.statusText}`);
       }
 
-      const userData = await response.json();
+      const userData = (await response.json()) as {
+        id: number;
+        login: string;
+        name: string | null;
+        email: string | null;
+        avatar_url: string;
+      };
 
       return {
         id: userData.id,

--- a/src/main/services/RemoteGitService.ts
+++ b/src/main/services/RemoteGitService.ts
@@ -704,7 +704,11 @@ export class RemoteGitService {
       'git remote show origin 2>/dev/null | sed -n "/HEAD branch/s/.*: //p"',
       cwd
     );
-    if (remoteResult.exitCode === 0 && remoteResult.stdout.trim()) {
+    if (
+      remoteResult.exitCode === 0 &&
+      remoteResult.stdout.trim() &&
+      remoteResult.stdout.trim() !== '(unknown)'
+    ) {
       return remoteResult.stdout.trim();
     }
 

--- a/src/main/services/WorktreePoolService.ts
+++ b/src/main/services/WorktreePoolService.ts
@@ -248,6 +248,14 @@ export class WorktreePoolService {
       fs.mkdirSync(worktreesDir, { recursive: true });
     }
 
+    // Skip reserve creation for empty repos (no commits).
+    // The first createWorktree() call will initialize the repo,
+    // and the pool will replenish on the next task creation.
+    if (!(await worktreeService.hasCommits(projectPath))) {
+      log.info('WorktreePool: Skipping reserve creation for empty repository', { projectId });
+      return;
+    }
+
     // Keep reserve refs fresh in the background so claim remains instant.
     await this.refreshRefsForReserveCreation(projectPath, projectId);
 

--- a/src/main/services/WorktreeService.ts
+++ b/src/main/services/WorktreeService.ts
@@ -225,6 +225,15 @@ export class WorktreeService {
       } else {
         baseRefInfo = await this.resolveProjectBaseRef(projectPath, projectId);
       }
+
+      // Initialize empty repos on the same branch we intend to use as the worktree base.
+      if (!(await this.hasCommits(projectPath))) {
+        const initBranch = await this.initializeEmptyRepo(projectPath, baseRefInfo.branch);
+        log.info(
+          `Empty repo initialized with branch '${initBranch}', proceeding with worktree creation`
+        );
+      }
+
       const fetchedBaseRef = await this.fetchBaseRefWithFallback(
         projectPath,
         projectId,
@@ -646,7 +655,10 @@ export class WorktreeService {
         cwd: projectPath,
       });
       const match = stdout.match(/HEAD branch:\s*(\S+)/);
-      return match ? match[1] : 'main';
+      if (match && match[1] !== '(unknown)') {
+        return match[1];
+      }
+      return 'main';
     } catch {
       return 'main';
     }
@@ -847,6 +859,17 @@ export class WorktreeService {
         throw new Error(`Failed to fetch ${target.fullRef}: ${message}`);
       }
 
+      // Remote ref is missing — check if the branch exists locally (e.g. after initializing an empty repo).
+      try {
+        await execFileAsync('git', ['rev-parse', '--verify', `refs/heads/${target.branch}`], {
+          cwd: projectPath,
+        });
+        log.info(`Remote ref ${target.fullRef} is missing, using local branch '${target.branch}'`);
+        return { remote: '', branch: target.branch, fullRef: target.branch };
+      } catch {
+        // Local branch doesn't exist either; continue to fallback logic.
+      }
+
       // Attempt fallback to default branch
       const fallback = await this.buildDefaultBaseRef(projectPath);
       if (fallback.fullRef === target.fullRef) {
@@ -903,6 +926,33 @@ export class WorktreeService {
       }
       return false;
     }
+  }
+
+  async hasCommits(projectPath: string): Promise<boolean> {
+    try {
+      await execFileAsync('git', ['rev-parse', '--verify', 'HEAD'], {
+        cwd: projectPath,
+      });
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async initializeEmptyRepo(projectPath: string, branchName: string): Promise<string> {
+    const targetBranch = this.sanitizeBranchName(branchName.trim() || 'main');
+
+    log.info(`Initializing empty repository with initial commit on branch '${targetBranch}'`);
+
+    await execFileAsync('git', ['symbolic-ref', 'HEAD', `refs/heads/${targetBranch}`], {
+      cwd: projectPath,
+    });
+
+    await execFileAsync('git', ['commit', '--allow-empty', '-m', 'Initial commit'], {
+      cwd: projectPath,
+    });
+
+    return targetBranch;
   }
 
   /**

--- a/src/test/main/WorktreeService.test.ts
+++ b/src/test/main/WorktreeService.test.ts
@@ -396,5 +396,59 @@ describe('WorktreeService', () => {
 
       expect(upstream).toBe(`origin/${branchName}`);
     });
+
+    it('initializes empty repos on the resolved base branch without pushing to origin', async () => {
+      const emptyRepo = path.join(tempDir, 'empty-repo');
+      const emptyOrigin = path.join(tempDir, 'empty-origin.git');
+      fs.mkdirSync(emptyRepo);
+      fs.mkdirSync(emptyOrigin);
+
+      execSync('git init', { cwd: emptyRepo, stdio: 'pipe' });
+      execSync('git config user.email "test@test.com"', { cwd: emptyRepo, stdio: 'pipe' });
+      execSync('git config user.name "Test"', { cwd: emptyRepo, stdio: 'pipe' });
+      execSync('git init --bare', { cwd: emptyOrigin, stdio: 'pipe' });
+      execFileSync('git', ['remote', 'add', 'origin', emptyOrigin], {
+        cwd: emptyRepo,
+        stdio: 'pipe',
+      });
+
+      const { projectSettingsService } = await import('../../main/services/ProjectSettingsService');
+      vi.mocked(projectSettingsService.getProjectSettings).mockResolvedValue({
+        projectId: 'proj-1',
+        name: 'empty-repo',
+        path: emptyRepo,
+        baseRef: 'origin/main',
+        gitBranch: 'main',
+      });
+
+      const { worktreeService } = await import('../../main/services/WorktreeService');
+      const worktree = await worktreeService.createWorktree(emptyRepo, 'Empty Repo Task', 'proj-1');
+
+      expect(worktree.branch).toMatch(/^emdash\/empty-repo-task-/);
+      expect(fs.existsSync(worktree.path)).toBe(true);
+
+      const currentBranch = execFileSync('git', ['branch', '--show-current'], {
+        cwd: emptyRepo,
+        encoding: 'utf8',
+      }).trim();
+      expect(currentBranch).toBe('main');
+
+      expect(() =>
+        execFileSync('git', ['rev-parse', '--verify', 'refs/heads/main'], {
+          cwd: emptyRepo,
+          stdio: 'pipe',
+        })
+      ).not.toThrow();
+
+      const remoteHeads = execFileSync(
+        'git',
+        ['for-each-ref', '--format=%(refname)', 'refs/heads'],
+        {
+          cwd: emptyOrigin,
+          encoding: 'utf8',
+        }
+      ).trim();
+      expect(remoteHeads).toBe('');
+    });
   });
 });


### PR DESCRIPTION
## Summary
before when you had an empty github repo and tried to create a new task inside of a worktree it would give you a weird error
this should fix that :D 

## Fixes 
#1712 

## Snapshot
https://streamable.com/74vkz5

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] Chore (refactoring code, technical debt, workflow improvements)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (does not change functionality, e.g. code style improvements, linting)
- [ ] This change requires a documentation update
 
## Mandatory Tasks

- [X] I have self-reviewed the code

## Checklist

- [X] I have read the contributing guide
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [X] I have added tests that prove my fix is effective or that my feature works


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented invalid "(unknown)" values from being treated as the default branch.
  * Improved handling of repositories with no commits (creates initial commit and avoids creating reserves prematurely).
  * Use local branch when remote ref is missing to allow successful worktree operations.

* **Tests**
  * Added test coverage for worktree creation in empty-repo scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->