### PR TITLE
Toggle settings shortcut

### DIFF
--- a/src/main/app/menu.ts
+++ b/src/main/app/menu.ts
@@ -2,8 +2,8 @@ import { app, Menu, shell } from 'electron';
 import {
   menuCheckForUpdatesChannel,
   menuCloseTabChannel,
-  menuOpenSettingsChannel,
   menuRedoChannel,
+  menuToggleSettingsChannel,
   menuUndoChannel,
 } from '@shared/events/appEvents';
 import { EMDASH_DOCS_URL, EMDASH_RELEASES_URL } from '@shared/urls';
@@ -27,7 +27,7 @@ export function setupApplicationMenu(): void {
               {
                 label: 'Settings\u2026',
                 accelerator: 'CmdOrCtrl+,',
-                click: () => events.emit(menuOpenSettingsChannel, undefined),
+                click: () => events.emit(menuToggleSettingsChannel, undefined),
               },
               {
                 label: 'Check for Updates\u2026',
@@ -59,7 +59,7 @@ export function setupApplicationMenu(): void {
               {
                 label: 'Settings\u2026',
                 accelerator: 'CmdOrCtrl+,',
-                click: () => events.emit(menuOpenSettingsChannel, undefined),
+                click: () => events.emit(menuToggleSettingsChannel, undefined),
               },
               { type: 'separator' as const },
             ]

--- a/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -1,16 +1,23 @@
 import { useHotkey } from '@tanstack/react-hotkeys';
+import { useCallback, useEffect, useRef } from 'react';
+import { menuOpenSettingsChannel } from '@shared/events/appEvents';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import {
   getEffectiveHotkey,
   getHotkeyRegistration,
 } from '@renderer/lib/hooks/useKeyboardShortcuts';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
+import { events } from '@renderer/lib/ipc';
 import { useWorkspaceLayoutContext } from '@renderer/lib/layout/layout-provider';
 import {
   useNavigate,
   useParams,
   useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
+import {
+  getSettingsToggleDestination,
+  type NonSettingsViewId,
+} from '@renderer/lib/layout/settings-shortcut';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 
 /**
@@ -38,6 +45,7 @@ export function AppKeyboardShortcuts() {
   const { currentView } = useWorkspaceSlots();
   const { params: taskParams } = useParams('task');
   const { params: projectParams } = useParams('project');
+  const lastNonSettingsViewRef = useRef<NonSettingsViewId | null>(null);
   const currentProjectId =
     currentView === 'task'
       ? taskParams.projectId
@@ -45,11 +53,24 @@ export function AppKeyboardShortcuts() {
         ? projectParams.projectId
         : undefined;
 
+  useEffect(() => {
+    if (currentView !== 'settings') {
+      lastNonSettingsViewRef.current = currentView;
+    }
+  }, [currentView]);
+
+  const toggleSettings = useCallback(() => {
+    const targetView = getSettingsToggleDestination(currentView, lastNonSettingsViewRef.current);
+    navigate(targetView);
+  }, [currentView, navigate]);
+
+  useEffect(() => events.on(menuOpenSettingsChannel, toggleSettings), [toggleSettings]);
+
   useHotkey(getHotkeyRegistration('commandPalette', keyboard), () => showCmdPalette({}), {
     enabled: commandPaletteHotkey !== null,
   });
 
-  useHotkey(getHotkeyRegistration('settings', keyboard), () => navigate('settings'), {
+  useHotkey(getHotkeyRegistration('settings', keyboard), toggleSettings, {
     enabled: settingsHotkey !== null,
   });
 

--- a/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -1,6 +1,6 @@
 import { useHotkey } from '@tanstack/react-hotkeys';
 import { useCallback, useEffect, useRef } from 'react';
-import { menuOpenSettingsChannel } from '@shared/events/appEvents';
+import { menuToggleSettingsChannel } from '@shared/events/appEvents';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import {
   getEffectiveHotkey,
@@ -64,7 +64,7 @@ export function AppKeyboardShortcuts() {
     navigate(targetView);
   }, [currentView, navigate]);
 
-  useEffect(() => events.on(menuOpenSettingsChannel, toggleSettings), [toggleSettings]);
+  useEffect(() => events.on(menuToggleSettingsChannel, toggleSettings), [toggleSettings]);
 
   useHotkey(getHotkeyRegistration('commandPalette', keyboard), () => showCmdPalette({}), {
     enabled: commandPaletteHotkey !== null,

--- a/src/renderer/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/lib/hooks/useKeyboardShortcuts.ts
@@ -40,7 +40,7 @@ export const APP_SHORTCUTS = defineShortcuts({
   settings: {
     defaultHotkey: 'Mod+,',
     label: 'Settings',
-    description: 'Open application settings',
+    description: 'Open or close application settings',
     category: 'Navigation',
   },
   toggleLeftSidebar: {

--- a/src/renderer/lib/layout/settings-shortcut.ts
+++ b/src/renderer/lib/layout/settings-shortcut.ts
@@ -1,0 +1,14 @@
+import type { ViewId } from '@renderer/app/view-registry';
+
+export type NonSettingsViewId = Exclude<ViewId, 'settings'>;
+
+export function getSettingsToggleDestination(
+  currentView: ViewId,
+  lastNonSettingsView: NonSettingsViewId | null
+): ViewId {
+  if (currentView !== 'settings') {
+    return 'settings';
+  }
+
+  return lastNonSettingsView ?? 'home';
+}

--- a/src/renderer/tests/settings-shortcut.test.ts
+++ b/src/renderer/tests/settings-shortcut.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest';
+import { getSettingsToggleDestination } from '@renderer/lib/layout/settings-shortcut';
+
+describe('getSettingsToggleDestination', () => {
+  it('opens settings from any non-settings view', () => {
+    expect(getSettingsToggleDestination('home', null)).toBe('settings');
+    expect(getSettingsToggleDestination('task', 'task')).toBe('settings');
+    expect(getSettingsToggleDestination('project', 'project')).toBe('settings');
+  });
+
+  it('returns to the last non-settings view when settings is already open', () => {
+    expect(getSettingsToggleDestination('settings', 'task')).toBe('task');
+    expect(getSettingsToggleDestination('settings', 'mcp')).toBe('mcp');
+  });
+
+  it('falls back to home when settings is open without a remembered source view', () => {
+    expect(getSettingsToggleDestination('settings', null)).toBe('home');
+  });
+});

--- a/src/shared/events/appEvents.ts
+++ b/src/shared/events/appEvents.ts
@@ -6,7 +6,7 @@ export const appRedoChannel = defineEvent<void>('app:redo');
 export const appPasteChannel = defineEvent<void>('app:paste');
 
 // Menu events (main → renderer, no payload)
-export const menuOpenSettingsChannel = defineEvent<void>('menu:open-settings');
+export const menuToggleSettingsChannel = defineEvent<void>('menu:toggle-settings');
 export const menuCheckForUpdatesChannel = defineEvent<void>('menu:check-for-updates');
 export const menuUndoChannel = defineEvent<void>('menu:undo');
 export const menuRedoChannel = defineEvent<void>('menu:redo');


### PR DESCRIPTION
## Summary
- toggle the Settings shortcut so Cmd+, returns to the previous view when Settings is already open
- route the native Settings menu action through the same toggle behavior
- rename the menu event to match its semantics

## Testing
- pnpm run format
- pnpm run lint
- pnpm exec eslint src/renderer/lib/components/app-keyboard-shortcuts.tsx
- pnpm exec prettier --write src/renderer/lib/components/app-keyboard-shortcuts.tsx

## Notes
- pnpm run typecheck currently fails on the existing tsconfig baseUrl deprecation under TypeScript 6
- vitest hits a sandbox listen EPERM after test execution in this environment

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to settings navigation/shortcuts and a menu IPC event rename, with potential for minor regressions in view toggling or event wiring.
> 
> **Overview**
> **Settings navigation is now a true toggle.** Pressing the Settings hotkey (`Mod+,`) will open Settings from any view, and if already in Settings it will navigate back to the last non-settings view (falling back to `home`).
> 
> The native app menu “Settings…” action is routed through the same toggle logic via a renamed IPC event (`menu:open-settings` → `menu:toggle-settings`), and shortcut metadata copy is updated accordingly. A small helper (`getSettingsToggleDestination`) plus unit tests were added to lock in the toggle behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4544188d21dc8f884fc9773c99e935e3a91b9528. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->