### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/src/main/services/SkillsService.ts
+++ b/src/main/services/SkillsService.ts
@@ -129,6 +129,22 @@ export class SkillsService {
       if (anthropicSkills.status === 'fulfilled') {
         allSkills.push(...anthropicSkills.value);
       }
+      allSkills.push({
+        id: 'mmx-cli',
+        displayName: 'MiniMax CLI',
+        description: 'Generate text, images, video, speech, and music via MiniMax AI platform',
+        source: 'skills-sh',
+        iconUrl: 'https://github.com/MiniMax-AI.png?size=80',
+        brandColor: '#171717',
+        defaultPrompt: 'Use MiniMax to generate content (text, image, video, speech, or music).',
+        frontmatter: {
+          name: 'mmx-cli',
+          description: 'Generate text, images, video, speech, and music via MiniMax AI platform',
+        },
+        installed: false,
+        owner: 'MiniMax-AI',
+        repo: 'cli',
+      });
 
       const skills = deduplicateById(allSkills);
 

--- a/src/main/services/skills/bundled-catalog.json
+++ b/src/main/services/skills/bundled-catalog.json
@@ -626,6 +626,21 @@
         "name": "internal-comms",
         "description": "Draft internal communications and announcements"
       }
+    },
+    {
+      "id": "mmx-cli",
+      "displayName": "MiniMax CLI",
+      "description": "Generate text, images, video, speech, and music via MiniMax AI platform",
+      "source": "skills-sh",
+      "iconUrl": "https://github.com/MiniMax-AI.png?size=80",
+      "brandColor": "#171717",
+      "defaultPrompt": "Use MiniMax to generate content (text, image, video, speech, or music).",
+      "frontmatter": {
+        "name": "mmx-cli",
+        "description": "Generate text, images, video, speech, and music via MiniMax AI platform"
+      },
+      "owner": "MiniMax-AI",
+      "repo": "cli"
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to the bundled catalog (`bundled-catalog.json`) and `refreshCatalog()` in `SkillsService.ts` so the mmx-cli skill is discoverable out of the box
- Users can install via the Skills panel in Emdash — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) using the existing GitHub Trees API fallback
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**2 files changed, 31 insertions.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard.

## Test plan

- Open the Skills panel in Emdash — mmx-cli appears in the catalog before any refresh
- Click "Refresh catalog" — mmx-cli remains visible (added to `refreshCatalog()`)
- Click "Install" on mmx-cli — SKILL.md is fetched from `MiniMax-AI/cli` via the GitHub Trees API and synced to all detected agents

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MiniMax CLI as a new available skill, enabling text, image, video, speech, and music generation through the MiniMax AI platform.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->