### PR TITLE
feat: main panel terminal pinning

### DIFF
--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -340,7 +340,6 @@ const ChatInterface: React.FC<Props> = ({
       }),
     [conversations]
   );
-
   const { activeTerminalId } = useTaskTerminals(task.id, task.path);
   const sidebarTaskKey = `${task.id}::${task.path}`;
   const sidebarTaskTerminals = useTaskTerminals(sidebarTaskKey, task.path);
@@ -374,6 +373,19 @@ const ChatInterface: React.FC<Props> = ({
   const activePinnedTerminal = useMemo(
     () => pinnedTerminals.find((terminal) => terminal.key === activePinnedTerminalKey) ?? null,
     [pinnedTerminals, activePinnedTerminalKey]
+  );
+  const numberedTabs = useMemo(
+    () => [
+      ...sortedConversations.map((conversation) => ({
+        type: 'conversation' as const,
+        conversationId: conversation.id,
+      })),
+      ...pinnedTerminals.map((terminal) => ({
+        type: 'pinned' as const,
+        terminalKey: terminal.key,
+      })),
+    ],
+    [sortedConversations, pinnedTerminals]
   );
   const effectiveRemoteProjectPath = useMemo(
     () => workspaceRemotePath || projectRemotePath || undefined,
@@ -1061,19 +1073,24 @@ const ChatInterface: React.FC<Props> = ({
       const customEvent = event as CustomEvent<{ tabIndex: number }>;
       const tabIndex = customEvent.detail?.tabIndex;
       if (typeof tabIndex !== 'number') return;
-      if (tabIndex < 0 || tabIndex >= sortedConversations.length) return;
+      if (tabIndex < 0 || tabIndex >= numberedTabs.length) return;
 
-      const selectedConversation = sortedConversations[tabIndex];
-      if (selectedConversation) {
-        handleSwitchChat(selectedConversation.id);
+      const selectedTab = numberedTabs[tabIndex];
+      if (!selectedTab) return;
+
+      if (selectedTab.type === 'conversation') {
+        handleSwitchChat(selectedTab.conversationId);
+        return;
       }
+
+      handleSelectPinnedTerminal(selectedTab.terminalKey);
     };
 
     window.addEventListener('emdash:select-agent-tab', handleAgentTabSelection);
     return () => {
       window.removeEventListener('emdash:select-agent-tab', handleAgentTabSelection);
     };
-  }, [sortedConversations, handleSwitchChat]);
+  }, [numberedTabs, handleSwitchChat, handleSelectPinnedTerminal]);
 
   // Close active chat tab on Cmd+W
   useEffect(() => {

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState, useMemo, useCallback, useRef } from 'react';
-import { Plus, X } from 'lucide-react';
+import { PinOff, Plus, X } from 'lucide-react';
 import { useToast } from '../hooks/use-toast';
 import { useTheme } from '../hooks/useTheme';
 import { TerminalPane, type TerminalPaneHandle } from './TerminalPane';
@@ -61,6 +61,9 @@ interface Props {
   onTaskInterfaceReady?: () => void;
   onRenameTask?: (project: Project, task: Task, newName: string) => Promise<void>;
 }
+
+// Cross-panel signal emitted from TaskTerminalPanel when a pinned terminal is selected.
+const FOCUS_PINNED_TERMINAL_EVENT = 'emdash:focus-pinned-terminal';
 
 function ConversationTabButton({
   conversation,
@@ -142,13 +145,64 @@ function ConversationTabButton({
   );
 }
 
+function PinnedTerminalTabButton({
+  label,
+  isActive,
+  onClick,
+  onUnpin,
+}: {
+  label: string;
+  isActive: boolean;
+  onClick: () => void;
+  onUnpin: () => void;
+}) {
+  return (
+    <button
+      onClick={onClick}
+      aria-current={isActive ? 'page' : undefined}
+      className={cn(
+        'inline-flex h-7 flex-shrink-0 items-center gap-1.5 rounded-md border border-border px-2.5 text-xs font-medium transition-colors',
+        'ring-offset-background focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+        isActive
+          ? 'bg-background text-foreground shadow-sm'
+          : 'bg-muted text-muted-foreground hover:bg-muted/80 hover:text-foreground'
+      )}
+      title={label}
+    >
+      <span className="inline-flex w-3.5 flex-shrink-0 justify-center text-[10px] leading-none text-muted-foreground/90">
+        {'>_'}
+      </span>
+      <span className="max-w-[10rem] truncate">{label}</span>
+      <span
+        role="button"
+        tabIndex={0}
+        onClick={(e) => {
+          e.stopPropagation();
+          onUnpin();
+        }}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            e.stopPropagation();
+            onUnpin();
+          }
+        }}
+        className="ml-1 rounded hover:bg-background/20"
+        title="Unpin terminal"
+      >
+        <PinOff className="h-3 w-3" />
+      </span>
+    </button>
+  );
+}
+
 const ChatInterface: React.FC<Props> = ({
   task,
   project,
   projectName: _projectName,
   projectPath,
   projectRemoteConnectionId,
-  projectRemotePath: _projectRemotePath,
+  projectRemotePath,
   defaultBranch,
   className,
   initialAgent,
@@ -175,6 +229,7 @@ const ChatInterface: React.FC<Props> = ({
   const [conversationsLoaded, setConversationsLoaded] = useState(false);
   const [showCreateChatModal, setShowCreateChatModal] = useState(false);
   const [busyByConversationId, setBusyByConversationId] = useState<Record<string, boolean>>({});
+  const [activePinnedTerminalKey, setActivePinnedTerminalKey] = useState<string | null>(null);
   const lockedAgentWriteRef = useRef<string | null>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [tabsOverflow, setTabsOverflow] = useState(false);
@@ -287,6 +342,51 @@ const ChatInterface: React.FC<Props> = ({
   );
 
   const { activeTerminalId } = useTaskTerminals(task.id, task.path);
+  const sidebarTaskKey = `${task.id}::${task.path}`;
+  const sidebarTaskTerminals = useTaskTerminals(sidebarTaskKey, task.path);
+  const sidebarGlobalKey = task.path
+    ? `global::${task.path}`
+    : projectPath
+      ? `global::${projectPath}`
+      : 'global::home';
+  const sidebarGlobalTerminals = useTaskTerminals(sidebarGlobalKey, projectPath || undefined);
+  const pinnedTerminals = useMemo(() => {
+    const taskPins = sidebarTaskTerminals.terminals
+      .filter((terminal) => terminal.pinned)
+      .map((terminal) => ({
+        key: `task::${terminal.id}`,
+        terminalId: terminal.id,
+        tabLabel: `${terminal.title} (worktree)`,
+        cwd: terminal.cwd,
+        scope: 'task' as const,
+      }));
+    const globalPins = sidebarGlobalTerminals.terminals
+      .filter((terminal) => terminal.pinned)
+      .map((terminal) => ({
+        key: `global::${terminal.id}`,
+        terminalId: terminal.id,
+        tabLabel: `${terminal.title} (project)`,
+        cwd: terminal.cwd,
+        scope: 'global' as const,
+      }));
+    return [...taskPins, ...globalPins];
+  }, [sidebarTaskTerminals.terminals, sidebarGlobalTerminals.terminals]);
+  const activePinnedTerminal = useMemo(
+    () => pinnedTerminals.find((terminal) => terminal.key === activePinnedTerminalKey) ?? null,
+    [pinnedTerminals, activePinnedTerminalKey]
+  );
+  const effectiveRemoteProjectPath = useMemo(
+    () => workspaceRemotePath || projectRemotePath || undefined,
+    [workspaceRemotePath, projectRemotePath]
+  );
+  const activeTerminalPaneId = activePinnedTerminal?.terminalId ?? terminalId;
+  const activeTerminalPaneCwd = useMemo(() => {
+    if (!activePinnedTerminal) return effectiveCwd;
+    if (activePinnedTerminal.scope === 'task') {
+      return effectiveRemoteProjectPath || activePinnedTerminal.cwd || task.path;
+    }
+    return activePinnedTerminal.cwd || projectPath || task.path;
+  }, [activePinnedTerminal, effectiveCwd, effectiveRemoteProjectPath, task.path, projectPath]);
 
   // Wire comment injection to pendingInjectionManager
   useCommentInjection(task.id, task.path);
@@ -311,6 +411,12 @@ const ChatInterface: React.FC<Props> = ({
     readySignaledTaskIdRef.current = task.id;
     onTaskInterfaceReady();
   }, [task.id, onTaskInterfaceReady]);
+
+  useEffect(() => {
+    if (!activePinnedTerminalKey) return;
+    if (pinnedTerminals.some((terminal) => terminal.key === activePinnedTerminalKey)) return;
+    setActivePinnedTerminalKey(null);
+  }, [activePinnedTerminalKey, pinnedTerminals]);
 
   const syncConversations = useCallback(async () => {
     setConversationsLoaded(false);
@@ -472,7 +578,7 @@ const ChatInterface: React.FC<Props> = ({
     handleSearchQueryChange,
     stepSearch,
   } = useTerminalSearch({
-    terminalId,
+    terminalId: activeTerminalPaneId,
     containerRef: terminalPanelRef,
     enabled: true,
     onCloseFocus: () => terminalRef.current?.focus(),
@@ -495,13 +601,13 @@ const ChatInterface: React.FC<Props> = ({
     if (!conversationsLoaded) return;
     // Small delay to ensure terminal is mounted and attached
     const timer = setTimeout(() => {
-      const session = terminalSessionRegistry.getSession(terminalId);
+      const session = terminalSessionRegistry.getSession(activeTerminalPaneId);
       if (session) {
         session.focus();
       }
     }, 100);
     return () => clearTimeout(timer);
-  }, [task.id, terminalId, conversationsLoaded]);
+  }, [task.id, activeTerminalPaneId, conversationsLoaded]);
 
   // Focus terminal when this task becomes active (for already-mounted terminals)
   useEffect(() => {
@@ -519,7 +625,7 @@ const ChatInterface: React.FC<Props> = ({
       timer = setTimeout(() => {
         timer = null;
         if (!mounted) return;
-        const session = terminalSessionRegistry.getSession(terminalId);
+        const session = terminalSessionRegistry.getSession(activeTerminalPaneId);
         if (session) session.focus();
       }, 0);
     };
@@ -529,9 +635,10 @@ const ChatInterface: React.FC<Props> = ({
       if (timer !== null) clearTimeout(timer);
       window.removeEventListener('focus', handleWindowFocus);
     };
-  }, [terminalId]);
+  }, [activeTerminalPaneId]);
 
   useEffect(() => {
+    if (activePinnedTerminal) return;
     const meta = agentMeta[agent];
     if (!meta?.terminalOnly || !meta.autoStartCommand) return;
 
@@ -568,7 +675,7 @@ const ChatInterface: React.FC<Props> = ({
       } catch {}
       clearTimeout(t);
     };
-  }, [agent, terminalId]);
+  }, [agent, terminalId, activePinnedTerminal]);
 
   useEffect(() => {
     setCliStartError(null);
@@ -709,6 +816,7 @@ const ChatInterface: React.FC<Props> = ({
         conversationId,
       });
       setActiveConversationId(conversationId);
+      setActivePinnedTerminalKey(null);
 
       // Update provider based on conversation
       const conv = conversations.find((c) => c.id === conversationId);
@@ -718,6 +826,54 @@ const ChatInterface: React.FC<Props> = ({
     },
     [task.id, conversations]
   );
+
+  const handleSelectPinnedTerminal = useCallback(
+    (terminalKey: string) => {
+      const current = pinnedTerminals.find((terminal) => terminal.key === terminalKey);
+      if (!current) return;
+      if (activePinnedTerminalKey === terminalKey) {
+        terminalSessionRegistry.getSession(current.terminalId)?.focus();
+        return;
+      }
+      setActivePinnedTerminalKey(terminalKey);
+    },
+    [activePinnedTerminalKey, pinnedTerminals]
+  );
+
+  const handleUnpinPinnedTerminal = useCallback(
+    (terminalKey: string) => {
+      const terminal = pinnedTerminals.find((item) => item.key === terminalKey);
+      if (!terminal) return;
+      if (terminal.scope === 'task') {
+        sidebarTaskTerminals.setPinned(terminal.terminalId, false);
+      } else {
+        sidebarGlobalTerminals.setPinned(terminal.terminalId, false);
+      }
+      if (activePinnedTerminalKey === terminalKey) {
+        setActivePinnedTerminalKey(null);
+      }
+    },
+    [pinnedTerminals, sidebarTaskTerminals, sidebarGlobalTerminals, activePinnedTerminalKey]
+  );
+
+  useEffect(() => {
+    const onFocusPinned = (event: Event) => {
+      const detail = (
+        event as CustomEvent<{
+          taskId?: string | null;
+          scope?: 'task' | 'global';
+          terminalId?: string;
+        }>
+      ).detail;
+      if (!detail?.terminalId || !detail.scope) return;
+      if (detail.taskId !== task.id) return;
+      handleSelectPinnedTerminal(`${detail.scope}::${detail.terminalId}`);
+    };
+
+    window.addEventListener(FOCUS_PINNED_TERMINAL_EVENT, onFocusPinned as EventListener);
+    return () =>
+      window.removeEventListener(FOCUS_PINNED_TERMINAL_EVENT, onFocusPinned as EventListener);
+  }, [task.id, handleSelectPinnedTerminal]);
 
   const handleCloseChat = useCallback(
     async (conversationId: string) => {
@@ -1178,7 +1334,7 @@ const ChatInterface: React.FC<Props> = ({
                       <ConversationTabButton
                         key={conv.id}
                         conversation={conv}
-                        activeConversationId={activeConversationId}
+                        activeConversationId={activePinnedTerminal ? null : activeConversationId}
                         onSwitchChat={handleSwitchChat}
                         onCloseChat={handleCloseChat}
                         totalConversationCount={conversations.length}
@@ -1187,6 +1343,15 @@ const ChatInterface: React.FC<Props> = ({
                       />
                     );
                   })}
+                  {pinnedTerminals.map((terminal) => (
+                    <PinnedTerminalTabButton
+                      key={terminal.key}
+                      label={terminal.tabLabel}
+                      isActive={activePinnedTerminal?.key === terminal.key}
+                      onClick={() => handleSelectPinnedTerminal(terminal.key)}
+                      onUnpin={() => handleUnpinPinnedTerminal(terminal.key)}
+                    />
+                  ))}
                 </div>
                 <button
                   onClick={handleCreateNewChat}
@@ -1213,34 +1378,35 @@ const ChatInterface: React.FC<Props> = ({
                   )}
                 </div>
               </div>
-              {(() => {
-                if (isAgentInstalled === false) {
-                  return (
-                    <InstallBanner
-                      agent={agent as any}
-                      terminalId={terminalId}
-                      installCommand={getInstallCommandForProvider(agent as any)}
-                      onRunInstall={runInstallCommand}
-                      onOpenExternal={(url) => window.electronAPI.openExternal(url)}
-                      mode="missing"
-                    />
-                  );
-                }
-                if (cliStartError) {
-                  return (
-                    <InstallBanner
-                      agent={agent as any}
-                      terminalId={terminalId}
-                      installCommand={null}
-                      onRunInstall={runInstallCommand}
-                      onOpenExternal={(url) => window.electronAPI.openExternal(url)}
-                      mode="start_failed"
-                      details={cliStartError}
-                    />
-                  );
-                }
-                return null;
-              })()}
+              {!activePinnedTerminal &&
+                (() => {
+                  if (isAgentInstalled === false) {
+                    return (
+                      <InstallBanner
+                        agent={agent as any}
+                        terminalId={terminalId}
+                        installCommand={getInstallCommandForProvider(agent as any)}
+                        onRunInstall={runInstallCommand}
+                        onOpenExternal={(url) => window.electronAPI.openExternal(url)}
+                        mode="missing"
+                      />
+                    );
+                  }
+                  if (cliStartError) {
+                    return (
+                      <InstallBanner
+                        agent={agent as any}
+                        terminalId={terminalId}
+                        installCommand={null}
+                        onRunInstall={runInstallCommand}
+                        onOpenExternal={(url) => window.electronAPI.openExternal(url)}
+                        mode="start_failed"
+                        details={cliStartError}
+                      />
+                    );
+                  }
+                  return null;
+                })()}
             </div>
           </div>
           <div
@@ -1281,20 +1447,25 @@ const ChatInterface: React.FC<Props> = ({
               {conversationsLoaded && (!isWorkspaceTask || workspaceConnectionId) && (
                 <TerminalPane
                   ref={terminalRef}
-                  id={terminalId}
-                  cwd={effectiveCwd}
+                  id={activeTerminalPaneId}
+                  cwd={activeTerminalPaneCwd}
                   remote={effectiveRemote}
-                  providerId={agent}
-                  autoApprove={autoApproveEnabled}
-                  env={taskEnv}
+                  providerId={activePinnedTerminal ? undefined : agent}
+                  autoApprove={activePinnedTerminal ? undefined : autoApproveEnabled}
+                  env={activePinnedTerminal ? undefined : taskEnv}
                   keepAlive={true}
                   mapShiftEnterToCtrlJ
                   disableSnapshots={false}
-                  onActivity={handleTerminalActivity}
-                  onStartError={(message) => {
-                    setCliStartError(message);
-                  }}
+                  onActivity={activePinnedTerminal ? undefined : handleTerminalActivity}
+                  onStartError={
+                    activePinnedTerminal
+                      ? undefined
+                      : (message) => {
+                          setCliStartError(message);
+                        }
+                  }
                   onStartSuccess={() => {
+                    if (activePinnedTerminal) return;
                     setCliStartError(null);
                     if (
                       isMainConversation &&
@@ -1355,6 +1526,7 @@ const ChatInterface: React.FC<Props> = ({
                       : undefined
                   }
                   initialPrompt={
+                    !activePinnedTerminal &&
                     agentMeta[agent]?.initialPromptFlag !== undefined &&
                     !agentMeta[agent]?.useKeystrokeInjection &&
                     ((isMainConversation && !task.metadata?.initialInjectionSent) ||
@@ -1364,7 +1536,13 @@ const ChatInterface: React.FC<Props> = ({
                         : (reviewPrompt ?? undefined)
                       : undefined
                   }
-                  onFirstMessage={shouldCaptureFirstMessage ? handleFirstMessage : undefined}
+                  onFirstMessage={
+                    activePinnedTerminal
+                      ? undefined
+                      : shouldCaptureFirstMessage
+                        ? handleFirstMessage
+                        : undefined
+                  }
                   className="h-full w-full"
                 />
               )}

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -278,13 +278,14 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   }, [runStatus, selection.onChange]);
 
   const totalTerminals = visibleTaskTerminals.length + visibleGlobalTerminals.length;
-  // Ignore the immediate Select onValueChange emitted from the same pointer interaction
-  // used to click the inline pin button inside an item.
-  const suppressSelectionUntilRef = useRef(0);
+  // Ignore the next Select onValueChange emitted from the same interaction
+  // used to click a row-level pin button.
+  const pinButtonClickedRef = useRef(false);
 
   const handleSelectionChange = useCallback(
     (value: string) => {
-      if (Date.now() < suppressSelectionUntilRef.current) {
+      if (pinButtonClickedRef.current) {
+        pinButtonClickedRef.current = false;
         return;
       }
       const parsed = parseTerminalValue(value);
@@ -639,7 +640,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                         onPointerDown={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          suppressSelectionUntilRef.current = Date.now() + 250;
+                          pinButtonClickedRef.current = true;
                           handleTogglePinned('task', terminal.id);
                         }}
                         onClick={(e) => {
@@ -704,7 +705,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                         onPointerDown={(e) => {
                           e.preventDefault();
                           e.stopPropagation();
-                          suppressSelectionUntilRef.current = Date.now() + 250;
+                          pinButtonClickedRef.current = true;
                           handleTogglePinned('global', terminal.id);
                         }}
                         onClick={(e) => {

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -632,32 +632,34 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                     key={`task::${terminal.id}`}
                     value={`task::${terminal.id}`}
                     className="text-xs"
+                    action={
+                      <button
+                        type="button"
+                        className="flex h-3.5 w-3.5 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                        onPointerDown={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          suppressSelectionUntilRef.current = Date.now() + 250;
+                          handleTogglePinned('task', terminal.id);
+                        }}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                        title={
+                          terminal.pinned
+                            ? 'Unpin terminal from main panel'
+                            : 'Pin terminal to main panel'
+                        }
+                      >
+                        {terminal.pinned ? (
+                          <PinOff className="h-3 w-3" />
+                        ) : (
+                          <Pin className="h-3 w-3" />
+                        )}
+                      </button>
+                    }
                   >
-                    <button
-                      type="button"
-                      className="absolute right-7 flex h-3.5 w-3.5 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        suppressSelectionUntilRef.current = Date.now() + 250;
-                        handleTogglePinned('task', terminal.id);
-                      }}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      title={
-                        terminal.pinned
-                          ? 'Unpin terminal from main panel'
-                          : 'Pin terminal to main panel'
-                      }
-                    >
-                      {terminal.pinned ? (
-                        <PinOff className="h-3 w-3" />
-                      ) : (
-                        <Pin className="h-3 w-3" />
-                      )}
-                    </button>
                     {terminal.title}
                   </SelectItem>
                 ))}
@@ -695,32 +697,34 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                     key={`global::${terminal.id}`}
                     value={`global::${terminal.id}`}
                     className="text-xs"
+                    action={
+                      <button
+                        type="button"
+                        className="flex h-3.5 w-3.5 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                        onPointerDown={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                          suppressSelectionUntilRef.current = Date.now() + 250;
+                          handleTogglePinned('global', terminal.id);
+                        }}
+                        onClick={(e) => {
+                          e.preventDefault();
+                          e.stopPropagation();
+                        }}
+                        title={
+                          terminal.pinned
+                            ? 'Unpin terminal from main panel'
+                            : 'Pin terminal to main panel'
+                        }
+                      >
+                        {terminal.pinned ? (
+                          <PinOff className="h-3 w-3" />
+                        ) : (
+                          <Pin className="h-3 w-3" />
+                        )}
+                      </button>
+                    }
                   >
-                    <button
-                      type="button"
-                      className="absolute right-7 flex h-3.5 w-3.5 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
-                      onPointerDown={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                        suppressSelectionUntilRef.current = Date.now() + 250;
-                        handleTogglePinned('global', terminal.id);
-                      }}
-                      onClick={(e) => {
-                        e.preventDefault();
-                        e.stopPropagation();
-                      }}
-                      title={
-                        terminal.pinned
-                          ? 'Unpin terminal from main panel'
-                          : 'Pin terminal to main panel'
-                      }
-                    >
-                      {terminal.pinned ? (
-                        <PinOff className="h-3 w-3" />
-                      ) : (
-                        <Pin className="h-3 w-3" />
-                      )}
-                    </button>
                     {terminal.title}
                   </SelectItem>
                 ))}

--- a/src/renderer/components/TaskTerminalPanel.tsx
+++ b/src/renderer/components/TaskTerminalPanel.tsx
@@ -1,10 +1,10 @@
 import React, { useMemo, useState, useEffect, useCallback, useRef } from 'react';
 import { TerminalPane } from './TerminalPane';
 import { LifecycleTerminalView } from './LifecycleTerminalView';
-import { Plus, Play, RotateCw, Square, X, Maximize2 } from 'lucide-react';
+import { Plus, Play, RotateCw, Square, X, Maximize2, Pin, PinOff } from 'lucide-react';
 import { useTheme } from '../hooks/useTheme';
 import { useTaskTerminals } from '@/lib/taskTerminalsStore';
-import { useTerminalSelection } from '../hooks/useTerminalSelection';
+import { parseTerminalValue, useTerminalSelection } from '../hooks/useTerminalSelection';
 import { cn } from '@/lib/utils';
 import { TooltipProvider, Tooltip, TooltipTrigger, TooltipContent } from './ui/tooltip';
 import { Button } from './ui/button';
@@ -55,6 +55,8 @@ interface Props {
 }
 
 type LifecyclePhaseStatus = 'idle' | 'running' | 'succeeded' | 'failed';
+// Cross-panel signal used to activate a pinned terminal tab in ChatInterface.
+const FOCUS_PINNED_TERMINAL_EVENT = 'emdash:focus-pinned-terminal';
 
 const TaskTerminalPanelComponent: React.FC<Props> = ({
   task,
@@ -84,6 +86,22 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   const globalTerminals = useTaskTerminals(globalKey, effectiveCwd);
 
   const selection = useTerminalSelection({ task, taskTerminals, globalTerminals });
+  const pinnedTaskTerminalIds = useMemo(
+    () => new Set(taskTerminals.terminals.filter((terminal) => terminal.pinned).map((t) => t.id)),
+    [taskTerminals.terminals]
+  );
+  const pinnedGlobalTerminalIds = useMemo(
+    () => new Set(globalTerminals.terminals.filter((terminal) => terminal.pinned).map((t) => t.id)),
+    [globalTerminals.terminals]
+  );
+  const visibleTaskTerminals = useMemo(
+    () => taskTerminals.terminals.filter((terminal) => !terminal.pinned),
+    [taskTerminals.terminals]
+  );
+  const visibleGlobalTerminals = useMemo(
+    () => globalTerminals.terminals.filter((terminal) => !terminal.pinned),
+    [globalTerminals.terminals]
+  );
 
   const [expandedTerminalId, setExpandedTerminalId] = useState<string | null>(null);
   // Tracks which terminal needs a key bump to force re-attach after modal close
@@ -259,7 +277,73 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
     }
   }, [runStatus, selection.onChange]);
 
-  const totalTerminals = taskTerminals.terminals.length + globalTerminals.terminals.length;
+  const totalTerminals = visibleTaskTerminals.length + visibleGlobalTerminals.length;
+  // Ignore the immediate Select onValueChange emitted from the same pointer interaction
+  // used to click the inline pin button inside an item.
+  const suppressSelectionUntilRef = useRef(0);
+
+  const handleSelectionChange = useCallback(
+    (value: string) => {
+      if (Date.now() < suppressSelectionUntilRef.current) {
+        return;
+      }
+      const parsed = parseTerminalValue(value);
+      if (!parsed) return;
+      if (parsed.mode === 'task' && pinnedTaskTerminalIds.has(parsed.id)) {
+        window.dispatchEvent(
+          new CustomEvent(FOCUS_PINNED_TERMINAL_EVENT, {
+            detail: {
+              taskId: task?.id ?? null,
+              scope: 'task',
+              terminalId: parsed.id,
+            },
+          })
+        );
+        selection.setIsOpen(false);
+        return;
+      }
+      if (parsed.mode === 'global' && pinnedGlobalTerminalIds.has(parsed.id)) {
+        window.dispatchEvent(
+          new CustomEvent(FOCUS_PINNED_TERMINAL_EVENT, {
+            detail: {
+              taskId: task?.id ?? null,
+              scope: 'global',
+              terminalId: parsed.id,
+            },
+          })
+        );
+        selection.setIsOpen(false);
+        return;
+      }
+      selection.onChange(value);
+    },
+    [selection, pinnedTaskTerminalIds, pinnedGlobalTerminalIds, task?.id]
+  );
+
+  const handleTogglePinned = useCallback(
+    (mode: 'task' | 'global', terminalId: string) => {
+      const store = mode === 'task' ? taskTerminals : globalTerminals;
+      store.togglePinned(terminalId);
+
+      const selected = selection.parsed;
+      if (selected?.mode === mode && selected.id === terminalId) {
+        const fallback =
+          mode === 'task'
+            ? visibleTaskTerminals.find((terminal) => terminal.id !== terminalId)
+            : visibleGlobalTerminals.find((terminal) => terminal.id !== terminalId);
+        if (fallback) {
+          selection.onChange(`${mode}::${fallback.id}`);
+          return;
+        }
+        if (mode === 'task' && visibleGlobalTerminals.length > 0) {
+          selection.onChange(`global::${visibleGlobalTerminals[0].id}`);
+        } else if (mode === 'global' && visibleTaskTerminals.length > 0) {
+          selection.onChange(`task::${visibleTaskTerminals[0].id}`);
+        }
+      }
+    },
+    [taskTerminals, globalTerminals, selection, visibleTaskTerminals, visibleGlobalTerminals]
+  );
 
   const lifecycleLogContent = useMemo(() => {
     if (!selection.selectedLifecycle) return '';
@@ -268,6 +352,13 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
   }, [lifecycleLogs, selection.selectedLifecycle]);
 
   const hasActiveTerminal = !selection.selectedLifecycle && !!selection.activeTerminalId;
+  const selectedPinnedTerminal = useMemo(() => {
+    const selected = selection.parsed;
+    if (!selected) return false;
+    if (selected.mode === 'task') return pinnedTaskTerminalIds.has(selected.id);
+    if (selected.mode === 'global') return pinnedGlobalTerminalIds.has(selected.id);
+    return false;
+  }, [selection.parsed, pinnedTaskTerminalIds, pinnedGlobalTerminalIds]);
 
   const canStartRun =
     !!task &&
@@ -501,7 +592,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
       <div className="flex items-center gap-2 border-b border-border bg-muted px-2 py-1.5 dark:bg-background">
         <Select
           value={selection.value}
-          onValueChange={selection.onChange}
+          onValueChange={handleSelectionChange}
           open={selection.isOpen}
           onOpenChange={selection.setIsOpen}
         >
@@ -542,6 +633,31 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                     value={`task::${terminal.id}`}
                     className="text-xs"
                   >
+                    <button
+                      type="button"
+                      className="absolute right-7 flex h-3.5 w-3.5 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        suppressSelectionUntilRef.current = Date.now() + 250;
+                        handleTogglePinned('task', terminal.id);
+                      }}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      title={
+                        terminal.pinned
+                          ? 'Unpin terminal from main panel'
+                          : 'Pin terminal to main panel'
+                      }
+                    >
+                      {terminal.pinned ? (
+                        <PinOff className="h-3 w-3" />
+                      ) : (
+                        <Pin className="h-3 w-3" />
+                      )}
+                    </button>
                     {terminal.title}
                   </SelectItem>
                 ))}
@@ -580,6 +696,31 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                     value={`global::${terminal.id}`}
                     className="text-xs"
                   >
+                    <button
+                      type="button"
+                      className="absolute right-7 flex h-3.5 w-3.5 items-center justify-center rounded-sm text-muted-foreground hover:bg-accent hover:text-accent-foreground"
+                      onPointerDown={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        suppressSelectionUntilRef.current = Date.now() + 250;
+                        handleTogglePinned('global', terminal.id);
+                      }}
+                      onClick={(e) => {
+                        e.preventDefault();
+                        e.stopPropagation();
+                      }}
+                      title={
+                        terminal.pinned
+                          ? 'Unpin terminal from main panel'
+                          : 'Pin terminal to main panel'
+                      }
+                    >
+                      {terminal.pinned ? (
+                        <PinOff className="h-3 w-3" />
+                      ) : (
+                        <Pin className="h-3 w-3" />
+                      )}
+                    </button>
                     {terminal.title}
                   </SelectItem>
                 ))}
@@ -688,9 +829,9 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
         {(() => {
           const canDelete =
             selection.parsed?.mode === 'task'
-              ? taskTerminals.terminals.length > 1
+              ? visibleTaskTerminals.length > 1
               : selection.parsed?.mode === 'global'
-                ? globalTerminals.terminals.length > 1
+                ? visibleGlobalTerminals.length > 1
                 : false;
           return (
             <TooltipProvider delayDuration={200}>
@@ -777,7 +918,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
           ) : (
             <>
               {task &&
-                taskTerminals.terminals.map((terminal) => {
+                visibleTaskTerminals.map((terminal) => {
                   const isActive =
                     selection.parsed?.mode === 'task' && terminal.id === selection.activeTerminalId;
                   return (
@@ -809,7 +950,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
                     </div>
                   );
                 })}
-              {globalTerminals.terminals.map((terminal) => {
+              {visibleGlobalTerminals.map((terminal) => {
                 const isActive =
                   selection.parsed?.mode === 'global' && terminal.id === selection.activeTerminalId;
                 return (
@@ -842,7 +983,7 @@ const TaskTerminalPanelComponent: React.FC<Props> = ({
               })}
               {totalTerminals === 0 ? (
                 <div className="flex h-full flex-col items-center justify-center text-xs text-muted-foreground">
-                  <p>No terminal found.</p>
+                  <p>{selectedPinnedTerminal ? 'Terminal pinned.' : 'No terminal found.'}</p>
                 </div>
               ) : null}
             </>

--- a/src/renderer/components/ui/select.tsx
+++ b/src/renderer/components/ui/select.tsx
@@ -102,26 +102,30 @@ const SelectLabel = React.forwardRef<
 ));
 SelectLabel.displayName = SelectPrimitive.Label.displayName;
 
-const SelectItem = React.forwardRef<
-  React.ElementRef<typeof SelectPrimitive.Item>,
-  React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item>
->(({ className, children, ...props }, ref) => (
-  <SelectPrimitive.Item
-    ref={ref}
-    className={cn(
-      'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
-      className
-    )}
-    {...props}
-  >
-    <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
-      <SelectPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
-      </SelectPrimitive.ItemIndicator>
-    </span>
-    <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
-  </SelectPrimitive.Item>
-));
+type SelectItemProps = React.ComponentPropsWithoutRef<typeof SelectPrimitive.Item> & {
+  action?: React.ReactNode;
+};
+
+const SelectItem = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Item>, SelectItemProps>(
+  ({ className, children, action, ...props }, ref) => (
+    <SelectPrimitive.Item
+      ref={ref}
+      className={cn(
+        'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        className
+      )}
+      {...props}
+    >
+      {action ? <span className="absolute right-7 flex items-center">{action}</span> : null}
+      <span className="absolute right-2 flex h-3.5 w-3.5 items-center justify-center">
+        <SelectPrimitive.ItemIndicator>
+          <Check className="h-4 w-4" />
+        </SelectPrimitive.ItemIndicator>
+      </span>
+      <SelectPrimitive.ItemText>{children}</SelectPrimitive.ItemText>
+    </SelectPrimitive.Item>
+  )
+);
 SelectItem.displayName = SelectPrimitive.Item.displayName;
 
 const SelectSeparator = React.forwardRef<

--- a/src/renderer/components/ui/select.tsx
+++ b/src/renderer/components/ui/select.tsx
@@ -111,7 +111,8 @@ const SelectItem = React.forwardRef<React.ElementRef<typeof SelectPrimitive.Item
     <SelectPrimitive.Item
       ref={ref}
       className={cn(
-        'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 pr-8 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        'relative flex w-full cursor-pointer select-none items-center rounded-sm py-1.5 pl-2 text-sm outline-none focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50',
+        action ? 'pr-12' : 'pr-8',
         className
       )}
       {...props}

--- a/src/renderer/lib/taskTerminalsStore.ts
+++ b/src/renderer/lib/taskTerminalsStore.ts
@@ -6,6 +6,7 @@ type TaskTerminal = {
   title: string;
   cwd?: string;
   shell?: string;
+  pinned?: boolean;
   createdAt: number;
 };
 
@@ -75,6 +76,7 @@ function loadFromStorage(taskId: string): TaskTerminalsState | null {
               title,
               cwd: typeof item.cwd === 'string' && item.cwd ? item.cwd : undefined,
               shell: typeof item.shell === 'string' && item.shell ? item.shell : undefined,
+              pinned: item.pinned === true,
               createdAt:
                 typeof item.createdAt === 'number' && Number.isFinite(item.createdAt)
                   ? item.createdAt
@@ -296,6 +298,22 @@ function closeTerminal(taskId: string, terminalId: string, taskPath?: string) {
   }
 }
 
+function setPinned(taskId: string, terminalId: string, pinned: boolean, taskPath?: string) {
+  updateTaskState(taskId, taskPath, (draft) => {
+    draft.terminals = draft.terminals.map((terminal) =>
+      terminal.id === terminalId ? { ...terminal, pinned } : terminal
+    );
+  });
+}
+
+function togglePinned(taskId: string, terminalId: string, taskPath?: string) {
+  updateTaskState(taskId, taskPath, (draft) => {
+    draft.terminals = draft.terminals.map((terminal) =>
+      terminal.id === terminalId ? { ...terminal, pinned: !terminal.pinned } : terminal
+    );
+  });
+}
+
 export function disposeTaskTerminals(taskKey: string): void {
   const state = taskStates.get(taskKey) ?? loadFromStorage(taskKey);
   if (state) {
@@ -350,6 +368,9 @@ export function useTaskTerminals(
         createTerminal(resolvedId, options?.cwd || resolvedPath, options),
       setActiveTerminal: (terminalId: string) => setActive(resolvedId, terminalId, resolvedPath),
       closeTerminal: (terminalId: string) => closeTerminal(resolvedId, terminalId, resolvedPath),
+      setPinned: (terminalId: string, pinned: boolean) =>
+        setPinned(resolvedId, terminalId, pinned, resolvedPath),
+      togglePinned: (terminalId: string) => togglePinned(resolvedId, terminalId, resolvedPath),
     };
   }, [resolvedId, resolvedPath]);
 


### PR DESCRIPTION
Hello 👋🏻
## Summary
Adds support for pinning terminals (worktree/project) into the main panel as first-class tabs, so users can quickly switch between agent chats and pinned terminals in one place and with the existing CMD+<NUM> keyboard shortcuts.

## This PR introduces:
- Pin/unpin controls for sidebar terminal entries.
- Pinned terminal tabs in the main chat tab row (with terminal-style icon and scoped labels like Terminal 1 (worktree) / Terminal 1 (project) to avoid ambiguity).
- Ability to unpin directly from the main pinned tab.
- A few small sidebar behaviour updates for pinned terminals:
  - Pinned terminals are excluded from inline sidebar terminal (so the terminal is only mounted in the appropriate location)
  - If a pinned terminal is selected in the dropdown, the main panel focuses that pinned terminal tab.
  - Empty-state message changed to "Terminal pinned." when appropriate
  - Keyboard shortcut enhancement:
      - Cmd+<num> tab selection now includes pinned terminal tabs in the same visual order as the tab strip, not only agent
        chat tabs.
  - UI cleanup:
      - Removes an unintended pin icon that appeared in the terminal header near expand/close controls.

## Snapshot
Add screenshots, GIFs, or videos demonstrating the changes (if applicable) 

### Demo
<img width="2560" height="1440" alt="terminal-pin-demo" src="https://github.com/user-attachments/assets/5de7a0f0-5857-4165-a108-f82ed3eef07b" />
<img width="2524" height="1204" alt="terminal-pin-demo-2" src="https://github.com/user-attachments/assets/15e2e555-45c6-4e40-be5e-f39feb72f181" />

### Screenshot

<img width="2523" height="858" alt="terminal-pin-screen" src="https://github.com/user-attachments/assets/aaa03089-4e83-43fd-843e-53549c0da267" />


## Type of change

- [X] New feature (non-breaking change which adds functionality)
 
## Mandatory Tasks

- [X] I have self-reviewed the code

## Checklist

- [X] I have read the contributing guide
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have checked if my PR needs changes to the documentation
- [ ] I have added tests that prove my fix is effective or that my feature works