### PR TITLE
feat: align keyboard shortcuts with macOS/Warp/VS Code conventions

### DIFF
--- a/drizzle/0013_add_archived_at_to_conversations.sql
+++ b/drizzle/0013_add_archived_at_to_conversations.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `conversations` ADD COLUMN `archived_at` text;

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -92,6 +92,13 @@
       "when": 1743033600000,
       "tag": "0012_add_automation_triggers",
       "breakpoints": true
+    },
+    {
+      "idx": 13,
+      "version": "6",
+      "when": 1745107200000,
+      "tag": "0013_add_archived_at_to_conversations",
+      "breakpoints": true
     }
   ]
 }

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -95,6 +95,7 @@ export const conversations = sqliteTable(
     isMain: integer('is_main').notNull().default(0), // 1 if this is the main/primary chat (gets full persistence)
     displayOrder: integer('display_order').notNull().default(0), // Order in the tab bar
     metadata: text('metadata'), // JSON for additional chat-specific data
+    archivedAt: text('archived_at'), // null = active, timestamp = archived (soft-close for reopen)
     createdAt: text('created_at')
       .notNull()
       .default(sql`CURRENT_TIMESTAMP`),

--- a/src/main/entry.ts
+++ b/src/main/entry.ts
@@ -2,29 +2,8 @@
 // This avoids '@shared/*' resolution failures in the compiled Electron main process.
 import path from 'node:path';
 
-// Initialize locale environment BEFORE Electron loads.
-// initializeShellEnvironment() sets LANG/LC_ALL/LC_CTYPE to a UTF-8 locale
-// if not already set. This MUST happen before require('electron') because
-// Electron initializes ICU (libicucore) on load - changing locale env vars
-// afterwards causes a crash in AppKit on macOS 26+ during menu init.
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { initializeShellEnvironment } = require('./utils/shellEnv');
-  initializeShellEnvironment();
-} catch (err) {
-  process.stderr.write(`[entry.ts] Failed to initializeShellEnvironment: ${err}\n`);
-}
-
-// Ensure app name is set BEFORE any module reads app.getPath('userData').
-// In dev builds, if userData is resolved before app name is set, Electron defaults to
-// ~/Library/Application Support/Electron which leads to confusing "missing DB/migrations" behavior.
-try {
-  // eslint-disable-next-line @typescript-eslint/no-var-requires
-  const { app } = require('electron');
-  app.setName('Emdash');
-} catch {}
-
-// Install minimal path alias resolver without external deps.
+// Install minimal path alias resolver WITHOUT external deps.
+// Must run first — other requires below (shellEnv, electron) import @shared/* themselves.
 // Maps:
 //   @shared/* -> dist/main/shared/*
 //   @/*      -> dist/main/main/*
@@ -48,6 +27,28 @@ try {
     }
     return orig.call(this, request, parent, isMain, options);
   };
+} catch {}
+
+// Initialize locale environment BEFORE Electron loads.
+// initializeShellEnvironment() sets LANG/LC_ALL/LC_CTYPE to a UTF-8 locale
+// if not already set. This MUST happen before require('electron') because
+// Electron initializes ICU (libicucore) on load - changing locale env vars
+// afterwards causes a crash in AppKit on macOS 26+ during menu init.
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { initializeShellEnvironment } = require('./utils/shellEnv');
+  initializeShellEnvironment();
+} catch (err) {
+  process.stderr.write(`[entry.ts] Failed to initializeShellEnvironment: ${err}\n`);
+}
+
+// Ensure app name is set BEFORE any module reads app.getPath('userData').
+// In dev builds, if userData is resolved before app name is set, Electron defaults to
+// ~/Library/Application Support/Electron which leads to confusing "missing DB/migrations" behavior.
+try {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const { app } = require('electron');
+  app.setName('Emdash');
 } catch {}
 
 // Ignore EPIPE errors on stdout/stderr (happens when terminal pipe closes

--- a/src/main/ipc/dbIpc.ts
+++ b/src/main/ipc/dbIpc.ts
@@ -57,6 +57,12 @@ export const databaseController = createRPCController({
   deleteConversation: (conversationId: string): Promise<void> =>
     databaseService.deleteConversation(conversationId),
 
+  archiveConversation: (conversationId: string): Promise<void> =>
+    databaseService.archiveConversation(conversationId),
+
+  unarchiveConversation: (conversationId: string): Promise<Conversation | null> =>
+    databaseService.unarchiveConversation(conversationId),
+
   setActiveConversation: (args: { taskId: string; conversationId: string }): Promise<void> =>
     databaseService.setActiveConversation(args.taskId, args.conversationId),
 

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -120,6 +120,8 @@ contextBridge.exposeInMainWorld('electronAPI', {
   ptyResize: (args: { id: string; cols: number; rows: number }) =>
     ipcRenderer.send('pty:resize', args),
   ptyKill: (id: string) => ipcRenderer.send('pty:kill', { id }),
+  ptyKillGraceful: (id: string) =>
+    ipcRenderer.invoke('pty:killGraceful', { id }) as Promise<{ ok: boolean; error?: string }>,
   ptyKillTmux: (id: string) =>
     ipcRenderer.invoke('pty:killTmux', { id }) as Promise<{ ok: boolean; error?: string }>,
 

--- a/src/main/services/DatabaseService.ts
+++ b/src/main/services/DatabaseService.ts
@@ -64,6 +64,7 @@ export interface Conversation {
   isMain?: boolean;
   displayOrder?: number;
   metadata?: string | null;
+  archivedAt?: string | null;
   createdAt: string;
   updatedAt: string;
 }
@@ -482,7 +483,7 @@ export class DatabaseService {
     const rows = await db
       .select()
       .from(conversationsTable)
-      .where(eq(conversationsTable.taskId, taskId))
+      .where(and(eq(conversationsTable.taskId, taskId), isNull(conversationsTable.archivedAt)))
       .orderBy(asc(conversationsTable.displayOrder), desc(conversationsTable.updatedAt));
     return rows.map((row) => this.mapDrizzleConversationRow(row));
   }
@@ -504,7 +505,7 @@ export class DatabaseService {
     const existingRows = await db
       .select()
       .from(conversationsTable)
-      .where(eq(conversationsTable.taskId, taskId))
+      .where(and(eq(conversationsTable.taskId, taskId), isNull(conversationsTable.archivedAt)))
       .orderBy(asc(conversationsTable.createdAt))
       .limit(1);
 
@@ -598,6 +599,30 @@ export class DatabaseService {
     if (this.disabled) return;
     const { db } = await getDrizzleClient();
     await db.delete(conversationsTable).where(eq(conversationsTable.id, conversationId));
+  }
+
+  async archiveConversation(conversationId: string): Promise<void> {
+    if (this.disabled) return;
+    const { db } = await getDrizzleClient();
+    await db
+      .update(conversationsTable)
+      .set({ archivedAt: new Date().toISOString(), updatedAt: sql`CURRENT_TIMESTAMP` })
+      .where(eq(conversationsTable.id, conversationId));
+  }
+
+  async unarchiveConversation(conversationId: string): Promise<Conversation | null> {
+    if (this.disabled) return null;
+    const { db } = await getDrizzleClient();
+    await db
+      .update(conversationsTable)
+      .set({ archivedAt: null, updatedAt: sql`CURRENT_TIMESTAMP` })
+      .where(eq(conversationsTable.id, conversationId));
+    const rows = await db
+      .select()
+      .from(conversationsTable)
+      .where(eq(conversationsTable.id, conversationId))
+      .limit(1);
+    return rows.length > 0 ? this.mapDrizzleConversationRow(rows[0]) : null;
   }
 
   // New multi-chat methods
@@ -911,6 +936,7 @@ export class DatabaseService {
       isMain: row.isMain !== undefined ? row.isMain === 1 : true,
       displayOrder: row.displayOrder ?? 0,
       metadata: row.metadata ?? null,
+      archivedAt: row.archivedAt ?? null,
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };

--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -4,6 +4,7 @@ import {
   writePty,
   resizePty,
   killPty,
+  killPtyGraceful,
   getPty,
   getPtyKind,
   startDirectPty,
@@ -1015,6 +1016,18 @@ export function registerPtyIpc(): void {
       cleanupPtySession(args.id);
     } catch (e) {
       log.error('pty:kill error', { id: args.id, error: e });
+    }
+  });
+
+  ipcMain.handle('pty:killGraceful', async (_event, args: { id: string }) => {
+    try {
+      await killPtyGraceful(args.id);
+      owners.delete(args.id);
+      listeners.delete(args.id);
+      return { ok: true };
+    } catch (e) {
+      log.error('pty:killGraceful error', { id: args.id, error: e });
+      return { ok: false, error: String(e) };
     }
   });
 

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1714,6 +1714,45 @@ export function killPty(id: string): void {
   }
 }
 
+/**
+ * Gracefully terminate a PTY: send SIGINT first, wait up to sigintTimeoutMs for
+ * the process to exit, then fall back to the default hard kill.
+ * On Windows ConPTY, node-pty translates signals internally; the fallback
+ * `proc.kill()` is always safe.
+ */
+export async function killPtyGraceful(
+  id: string,
+  opts: { sigintTimeoutMs?: number } = {}
+): Promise<void> {
+  const rec = ptys.get(id);
+  if (!rec) return;
+
+  const timeoutMs = opts.sigintTimeoutMs ?? 1500;
+
+  const exitPromise = new Promise<void>((resolve) => {
+    rec.proc.onExit(() => resolve());
+  });
+
+  try {
+    rec.proc.kill('SIGINT');
+  } catch {
+    // SIGINT not supported on this platform — fall through to hard kill
+  }
+
+  const timedOut = await Promise.race([
+    exitPromise.then(() => false),
+    new Promise<boolean>((resolve) => setTimeout(() => resolve(true), timeoutMs)),
+  ]);
+
+  if (timedOut) {
+    try {
+      rec.proc.kill();
+    } catch {}
+  }
+
+  ptys.delete(id);
+}
+
 export function removePtyRecord(id: string): void {
   ptys.delete(id);
 }

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1729,8 +1729,9 @@ export async function killPtyGraceful(
 
   const timeoutMs = opts.sigintTimeoutMs ?? 1500;
 
+  let exitDisposable: { dispose: () => void } | undefined;
   const exitPromise = new Promise<void>((resolve) => {
-    rec.proc.onExit(() => resolve());
+    exitDisposable = rec.proc.onExit(() => resolve());
   });
 
   try {
@@ -1744,7 +1745,9 @@ export async function killPtyGraceful(
     new Promise<boolean>((resolve) => setTimeout(() => resolve(true), timeoutMs)),
   ]);
 
-  if (timedOut) {
+  exitDisposable?.dispose();
+
+  if (timedOut && ptys.has(id)) {
     try {
       rec.proc.kill();
     } catch {}

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -63,6 +63,12 @@ export interface KeyboardSettings {
   nextAgent?: KeyboardShortcutBinding;
   prevAgent?: KeyboardShortcutBinding;
   openInEditor?: KeyboardShortcutBinding;
+  newChat?: KeyboardShortcutBinding;
+  closeChat?: KeyboardShortcutBinding;
+  nextChat?: KeyboardShortcutBinding;
+  prevChat?: KeyboardShortcutBinding;
+  reopenClosedChat?: KeyboardShortcutBinding;
+  commandPaletteAlt?: KeyboardShortcutBinding;
 }
 
 export interface InterfaceSettings {
@@ -192,8 +198,6 @@ const DEFAULT_SETTINGS: AppSettings = {
     settings: { key: ',', modifier: 'cmd' },
     toggleLeftSidebar: { key: 'b', modifier: 'cmd' },
     toggleRightSidebar: { key: '.', modifier: 'cmd' },
-    toggleTheme: { key: 't', modifier: 'cmd' },
-    toggleKanban: { key: 'p', modifier: 'cmd' },
     toggleEditor: { key: 'e', modifier: 'cmd' },
     nextProject: TASK_SWITCH_DEFAULTS.next,
     prevProject: TASK_SWITCH_DEFAULTS.prev,
@@ -201,6 +205,12 @@ const DEFAULT_SETTINGS: AppSettings = {
     nextAgent: { key: ']', modifier: 'cmd+shift' },
     prevAgent: { key: '[', modifier: 'cmd+shift' },
     openInEditor: { key: 'o', modifier: 'cmd' },
+    newChat: { key: 't', modifier: 'cmd' },
+    closeChat: { key: 'w', modifier: 'cmd' },
+    nextChat: { key: 'Tab', modifier: 'ctrl' },
+    prevChat: { key: 'Tab', modifier: 'ctrl+shift' },
+    reopenClosedChat: { key: 't', modifier: 'cmd+shift' },
+    commandPaletteAlt: { key: 'p', modifier: 'cmd+shift' },
   },
   interface: {
     autoRightSidebarBehavior: false,
@@ -518,8 +528,6 @@ export function normalizeSettings(input: AppSettings): AppSettings {
       keyboard.toggleRightSidebar,
       DEFAULT_SETTINGS.keyboard!.toggleRightSidebar!
     ),
-    toggleTheme: normalizeBinding(keyboard.toggleTheme, DEFAULT_SETTINGS.keyboard!.toggleTheme!),
-    toggleKanban: normalizeBinding(keyboard.toggleKanban, DEFAULT_SETTINGS.keyboard!.toggleKanban!),
     toggleEditor: normalizeBinding(keyboard.toggleEditor, DEFAULT_SETTINGS.keyboard!.toggleEditor!),
     nextProject: normalizeBinding(keyboard.nextProject, DEFAULT_SETTINGS.keyboard!.nextProject!),
     prevProject: normalizeBinding(keyboard.prevProject, DEFAULT_SETTINGS.keyboard!.prevProject!),
@@ -527,7 +535,34 @@ export function normalizeSettings(input: AppSettings): AppSettings {
     nextAgent: normalizeBinding(keyboard.nextAgent, DEFAULT_SETTINGS.keyboard!.nextAgent!),
     prevAgent: normalizeBinding(keyboard.prevAgent, DEFAULT_SETTINGS.keyboard!.prevAgent!),
     openInEditor: normalizeBinding(keyboard.openInEditor, DEFAULT_SETTINGS.keyboard!.openInEditor!),
+    newChat: normalizeBinding(keyboard.newChat, DEFAULT_SETTINGS.keyboard!.newChat!),
+    closeChat: normalizeBinding(keyboard.closeChat, DEFAULT_SETTINGS.keyboard!.closeChat!),
+    nextChat: normalizeBinding(keyboard.nextChat, DEFAULT_SETTINGS.keyboard!.nextChat!),
+    prevChat: normalizeBinding(keyboard.prevChat, DEFAULT_SETTINGS.keyboard!.prevChat!),
+    reopenClosedChat: normalizeBinding(
+      keyboard.reopenClosedChat,
+      DEFAULT_SETTINGS.keyboard!.reopenClosedChat!
+    ),
+    commandPaletteAlt: normalizeBinding(
+      keyboard.commandPaletteAlt,
+      DEFAULT_SETTINGS.keyboard!.commandPaletteAlt!
+    ),
   };
+  // Preserve user-customized toggleTheme / toggleKanban bindings if present.
+  // These no longer have a default binding (moved to palette-only) but users
+  // who explicitly set them should keep their custom values.
+  if (keyboard.toggleTheme !== undefined && keyboard.toggleTheme !== null) {
+    out.keyboard.toggleTheme = normalizeBinding(keyboard.toggleTheme, {
+      key: 't',
+      modifier: 'cmd',
+    });
+  }
+  if (keyboard.toggleKanban !== undefined && keyboard.toggleKanban !== null) {
+    out.keyboard.toggleKanban = normalizeBinding(keyboard.toggleKanban, {
+      key: 'p',
+      modifier: 'cmd',
+    });
+  }
   const platformTaskDefaults = getPlatformTaskSwitchDefaults();
   const isLegacyArrowPair =
     isBinding(out.keyboard.nextProject!, 'cmd', 'ArrowRight') &&
@@ -538,6 +573,16 @@ export function normalizeSettings(input: AppSettings): AppSettings {
   if (isLegacyArrowPair || (IS_MAC && isLegacyTabPair)) {
     out.keyboard.nextProject = platformTaskDefaults.next;
     out.keyboard.prevProject = platformTaskDefaults.prev;
+  }
+  // Drop legacy default Cmd+T = toggleTheme and Cmd+P = toggleKanban.
+  // Users who deliberately customized these keep their bindings (handled
+  // above). Only stored defaults are removed so Cmd+T and Cmd+P are freed
+  // for the new newChat and commandPaletteAlt shortcuts.
+  if (isBinding(out.keyboard.toggleTheme, 'cmd', 't')) {
+    delete out.keyboard.toggleTheme;
+  }
+  if (isBinding(out.keyboard.toggleKanban, 'cmd', 'p')) {
+    delete out.keyboard.toggleKanban;
   }
 
   // Interface

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -205,6 +205,8 @@ const DEFAULT_SETTINGS: AppSettings = {
     nextAgent: { key: ']', modifier: 'cmd+shift' },
     prevAgent: { key: '[', modifier: 'cmd+shift' },
     openInEditor: { key: 'o', modifier: 'cmd' },
+    toggleTheme: { key: 'l', modifier: 'cmd+shift' },
+    toggleKanban: { key: 'k', modifier: 'cmd+shift' },
     newChat: { key: 't', modifier: 'cmd' },
     closeChat: { key: 'w', modifier: 'cmd' },
     nextChat: { key: 'Tab', modifier: 'ctrl' },
@@ -548,21 +550,14 @@ export function normalizeSettings(input: AppSettings): AppSettings {
       DEFAULT_SETTINGS.keyboard!.commandPaletteAlt!
     ),
   };
-  // Preserve user-customized toggleTheme / toggleKanban bindings if present.
-  // These no longer have a default binding (moved to palette-only) but users
-  // who explicitly set them should keep their custom values.
-  if (keyboard.toggleTheme !== undefined && keyboard.toggleTheme !== null) {
-    out.keyboard.toggleTheme = normalizeBinding(keyboard.toggleTheme, {
-      key: 't',
-      modifier: 'cmd',
-    });
-  }
-  if (keyboard.toggleKanban !== undefined && keyboard.toggleKanban !== null) {
-    out.keyboard.toggleKanban = normalizeBinding(keyboard.toggleKanban, {
-      key: 'p',
-      modifier: 'cmd',
-    });
-  }
+  out.keyboard.toggleTheme = normalizeBinding(
+    keyboard.toggleTheme,
+    DEFAULT_SETTINGS.keyboard!.toggleTheme!
+  );
+  out.keyboard.toggleKanban = normalizeBinding(
+    keyboard.toggleKanban,
+    DEFAULT_SETTINGS.keyboard!.toggleKanban!
+  );
   const platformTaskDefaults = getPlatformTaskSwitchDefaults();
   const isLegacyArrowPair =
     isBinding(out.keyboard.nextProject!, 'cmd', 'ArrowRight') &&

--- a/src/main/settings.ts
+++ b/src/main/settings.ts
@@ -149,8 +149,8 @@ function getPlatformTaskSwitchDefaults(): { next: ShortcutBinding; prev: Shortcu
   }
 
   return {
-    next: { key: 'Tab', modifier: 'ctrl' },
-    prev: { key: 'Tab', modifier: 'ctrl+shift' },
+    next: { key: ']', modifier: 'ctrl+shift' },
+    prev: { key: '[', modifier: 'ctrl+shift' },
   };
 }
 

--- a/src/renderer/components/AppKeyboardShortcuts.tsx
+++ b/src/renderer/components/AppKeyboardShortcuts.tsx
@@ -73,6 +73,14 @@ const AppKeyboardShortcuts: React.FC<AppKeyboardShortcutsProps> = ({
     onSelectAgentTab: (tabIndex) =>
       window.dispatchEvent(new CustomEvent('emdash:select-agent-tab', { detail: { tabIndex } })),
     onOpenInEditor: handleOpenInEditor,
+    onNewChat: () => window.dispatchEvent(new CustomEvent('emdash:new-chat')),
+    onCloseChat: () => window.dispatchEvent(new CustomEvent('emdash:close-active-chat')),
+    onNextChat: () =>
+      window.dispatchEvent(new CustomEvent('emdash:cycle-chat', { detail: { direction: 'next' } })),
+    onPrevChat: () =>
+      window.dispatchEvent(new CustomEvent('emdash:cycle-chat', { detail: { direction: 'prev' } })),
+    onReopenClosedChat: () => window.dispatchEvent(new CustomEvent('emdash:reopen-closed-chat')),
+    onCommandPaletteAlt: handleToggleCommandPalette,
     onCloseModal: (
       [
         [showCommandPalette, handleCloseCommandPalette],

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -55,8 +55,11 @@ import {
 declare const window: Window & {
   electronAPI: {
     saveMessage: (message: any) => Promise<{ success: boolean; error?: string }>;
+    ptyKillGraceful: (id: string) => Promise<void>;
   };
 };
+
+type ClosedConversationEntry = { conversationId: string };
 
 interface Props {
   task: Task;
@@ -186,8 +189,8 @@ const ChatInterface: React.FC<Props> = ({
   const [showCreateChatModal, setShowCreateChatModal] = useState(false);
   const [busyByConversationId, setBusyByConversationId] = useState<Record<string, boolean>>({});
   const [pendingCloseConversationId, setPendingCloseConversationId] = useState<string | null>(null);
-  type ClosedConversationEntry = { provider: string; title: string };
   const closedConversationStackRef = useRef<ClosedConversationEntry[]>([]);
+  const closingConversationIdsRef = useRef<Set<string>>(new Set());
   const lockedAgentWriteRef = useRef<string | null>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [tabsOverflow, setTabsOverflow] = useState(false);
@@ -735,48 +738,56 @@ const ChatInterface: React.FC<Props> = ({
   const doCloseChat = useCallback(
     async (conversationId: string) => {
       if (conversations.length <= 1) return;
-
-      const convToDelete = conversations.find((c) => c.id === conversationId);
-      const convAgent = (convToDelete?.provider ?? 'claude') as Agent;
-      const terminalId = makePtyId(convAgent, 'chat', conversationId);
-
-      // Push to closed stack for Cmd+Shift+T reopen (max 10 entries)
-      if (convToDelete) {
-        const stack = closedConversationStackRef.current;
-        stack.push({ provider: convAgent, title: convToDelete.title ?? '' });
-        if (stack.length > 10) stack.shift();
-      }
-
-      // Optimistically remove tab and switch to neighbor before killing PTY
-      const remaining = conversations.filter((c) => c.id !== conversationId);
-      setConversations(remaining);
-      if (conversationId === activeConversationId && remaining.length > 0) {
-        const newActive = remaining[0];
-        setActiveConversationId(newActive.id);
-        await rpc.db.setActiveConversation({ taskId: task.id, conversationId: newActive.id });
-        if (newActive.provider) setAgent(newActive.provider as Agent);
-      }
-
-      // Gracefully kill PTY: SIGINT → wait 1.5 s → hard kill
-      try {
-        await (window.electronAPI as any).ptyKillGraceful(terminalId);
-      } catch {
-        terminalSessionRegistry.dispose(terminalId);
-      }
-
-      await rpc.db.deleteConversation(conversationId);
-
-      // Resync from DB to pick up any server-side changes
-      const updatedConversations = await applyStableConversationTitles(
-        await rpc.db.getConversations(task.id)
-      );
-      setConversations(updatedConversations);
+      if (closingConversationIdsRef.current.has(conversationId)) return;
+      closingConversationIdsRef.current.add(conversationId);
 
       try {
-        window.dispatchEvent(
-          new CustomEvent('emdash:conversations-changed', { detail: { taskId: task.id } })
+        const convToDelete = conversations.find((c) => c.id === conversationId);
+        const convAgent = (convToDelete?.provider ?? 'claude') as Agent;
+        const terminalId = convToDelete?.isMain
+          ? makePtyId(convAgent, 'main', task.id)
+          : makePtyId(convAgent, 'chat', conversationId);
+
+        // Push to closed stack for Cmd+Shift+T reopen (max 10 entries)
+        if (convToDelete) {
+          const stack = closedConversationStackRef.current;
+          stack.push({ conversationId });
+          if (stack.length > 10) stack.shift();
+        }
+
+        // Optimistically remove tab and switch to neighbor before killing PTY
+        const remaining = conversations.filter((c) => c.id !== conversationId);
+        setConversations(remaining);
+        if (conversationId === activeConversationId && remaining.length > 0) {
+          const newActive = remaining[0];
+          setActiveConversationId(newActive.id);
+          await rpc.db.setActiveConversation({ taskId: task.id, conversationId: newActive.id });
+          if (newActive.provider) setAgent(newActive.provider as Agent);
+        }
+
+        // Gracefully kill PTY: SIGINT → wait 1.5 s → hard kill
+        try {
+          await window.electronAPI.ptyKillGraceful(terminalId);
+        } catch {
+          terminalSessionRegistry.dispose(terminalId);
+        }
+
+        await rpc.db.archiveConversation(conversationId);
+
+        // Resync from DB to pick up any server-side changes
+        const updatedConversations = await applyStableConversationTitles(
+          await rpc.db.getConversations(task.id)
         );
-      } catch {}
+        setConversations(updatedConversations);
+
+        try {
+          window.dispatchEvent(
+            new CustomEvent('emdash:conversations-changed', { detail: { taskId: task.id } })
+          );
+        } catch {}
+      } finally {
+        closingConversationIdsRef.current.delete(conversationId);
+      }
     },
     [conversations, task.id, activeConversationId, applyStableConversationTitles]
   );
@@ -974,7 +985,7 @@ const ChatInterface: React.FC<Props> = ({
   // Open new conversation tab on Cmd+T
   useEffect(() => {
     const handleNewChat = () => {
-      if (task.metadata?.multiAgent) return; // no-op for multi-agent tasks
+      if (task.metadata?.multiAgent?.enabled) return; // no-op for multi-agent tasks
       setShowCreateChatModal(true);
     };
     window.addEventListener('emdash:new-chat', handleNewChat);
@@ -1007,31 +1018,33 @@ const ChatInterface: React.FC<Props> = ({
     return () => window.removeEventListener('emdash:cycle-chat', handleCycleChat);
   }, [sortedConversations, activeConversationId, handleSwitchChat]);
 
-  // Reopen last closed conversation on Cmd+Shift+T
+  // Reopen last closed conversation on Cmd+Shift+T (restores DB row + message history)
   useEffect(() => {
     const handleReopenClosedChat = () => {
       const stack = closedConversationStackRef.current;
       const entry = stack.pop();
-      if (!entry) return;
+      if (!entry) {
+        toast({ title: 'No recently closed conversation', variant: 'default' });
+        return;
+      }
 
       void (async () => {
         try {
-          const newConv = await rpc.db.createConversation({
-            taskId: task.id,
-            provider: entry.provider,
-            title: entry.title,
-            isMain: false,
-            metadata: null,
-          });
-          if (newConv) {
-            const updated = await applyStableConversationTitles(
-              await rpc.db.getConversations(task.id)
-            );
-            setConversations(updated);
-            await rpc.db.setActiveConversation({ taskId: task.id, conversationId: newConv.id });
-            setActiveConversationId(newConv.id);
-            setAgent(entry.provider as Agent);
+          const row = await rpc.db.unarchiveConversation(entry.conversationId);
+          if (!row) {
+            toast({ title: 'Conversation no longer available', variant: 'destructive' });
+            return;
           }
+          const updated = await applyStableConversationTitles(
+            await rpc.db.getConversations(task.id)
+          );
+          setConversations(updated);
+          await rpc.db.setActiveConversation({
+            taskId: task.id,
+            conversationId: entry.conversationId,
+          });
+          setActiveConversationId(entry.conversationId);
+          if (row.provider) setAgent(row.provider as Agent);
         } catch {}
       })();
     };

--- a/src/renderer/components/ChatInterface.tsx
+++ b/src/renderer/components/ChatInterface.tsx
@@ -41,6 +41,16 @@ import {
   getConversationTabLabel,
   planConversationTitleUpdates,
 } from '../lib/conversationTabTitles';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from './ui/alert-dialog';
 
 declare const window: Window & {
   electronAPI: {
@@ -175,6 +185,9 @@ const ChatInterface: React.FC<Props> = ({
   const [conversationsLoaded, setConversationsLoaded] = useState(false);
   const [showCreateChatModal, setShowCreateChatModal] = useState(false);
   const [busyByConversationId, setBusyByConversationId] = useState<Record<string, boolean>>({});
+  const [pendingCloseConversationId, setPendingCloseConversationId] = useState<string | null>(null);
+  type ClosedConversationEntry = { provider: string; title: string };
+  const closedConversationStackRef = useRef<ClosedConversationEntry[]>([]);
   const lockedAgentWriteRef = useRef<string | null>(null);
   const tabsContainerRef = useRef<HTMLDivElement>(null);
   const [tabsOverflow, setTabsOverflow] = useState(false);
@@ -719,6 +732,55 @@ const ChatInterface: React.FC<Props> = ({
     [task.id, conversations]
   );
 
+  const doCloseChat = useCallback(
+    async (conversationId: string) => {
+      if (conversations.length <= 1) return;
+
+      const convToDelete = conversations.find((c) => c.id === conversationId);
+      const convAgent = (convToDelete?.provider ?? 'claude') as Agent;
+      const terminalId = makePtyId(convAgent, 'chat', conversationId);
+
+      // Push to closed stack for Cmd+Shift+T reopen (max 10 entries)
+      if (convToDelete) {
+        const stack = closedConversationStackRef.current;
+        stack.push({ provider: convAgent, title: convToDelete.title ?? '' });
+        if (stack.length > 10) stack.shift();
+      }
+
+      // Optimistically remove tab and switch to neighbor before killing PTY
+      const remaining = conversations.filter((c) => c.id !== conversationId);
+      setConversations(remaining);
+      if (conversationId === activeConversationId && remaining.length > 0) {
+        const newActive = remaining[0];
+        setActiveConversationId(newActive.id);
+        await rpc.db.setActiveConversation({ taskId: task.id, conversationId: newActive.id });
+        if (newActive.provider) setAgent(newActive.provider as Agent);
+      }
+
+      // Gracefully kill PTY: SIGINT → wait 1.5 s → hard kill
+      try {
+        await (window.electronAPI as any).ptyKillGraceful(terminalId);
+      } catch {
+        terminalSessionRegistry.dispose(terminalId);
+      }
+
+      await rpc.db.deleteConversation(conversationId);
+
+      // Resync from DB to pick up any server-side changes
+      const updatedConversations = await applyStableConversationTitles(
+        await rpc.db.getConversations(task.id)
+      );
+      setConversations(updatedConversations);
+
+      try {
+        window.dispatchEvent(
+          new CustomEvent('emdash:conversations-changed', { detail: { taskId: task.id } })
+        );
+      } catch {}
+    },
+    [conversations, task.id, activeConversationId, applyStableConversationTitles]
+  );
+
   const handleCloseChat = useCallback(
     async (conversationId: string) => {
       if (conversations.length <= 1) {
@@ -730,40 +792,16 @@ const ChatInterface: React.FC<Props> = ({
         return;
       }
 
-      // Dispose the terminal for this chat
-      const convToDelete = conversations.find((c) => c.id === conversationId);
-      const convAgent = (convToDelete?.provider ?? 'claude') as Agent;
-      const terminalToDispose = makePtyId(convAgent, 'chat', conversationId);
-      terminalSessionRegistry.dispose(terminalToDispose);
-
-      await rpc.db.deleteConversation(conversationId);
-
-      // Reload conversations
-      const updatedConversations = await applyStableConversationTitles(
-        await rpc.db.getConversations(task.id)
-      );
-      setConversations(updatedConversations);
-      // Switch to another chat if we deleted the active one
-      if (conversationId === activeConversationId && updatedConversations.length > 0) {
-        const newActive = updatedConversations[0];
-        await rpc.db.setActiveConversation({
-          taskId: task.id,
-          conversationId: newActive.id,
-        });
-        setActiveConversationId(newActive.id);
-        // Update provider if needed
-        if (newActive.provider) {
-          setAgent(newActive.provider as Agent);
-        }
+      const isBusy = busyByConversationId[conversationId] === true;
+      if (isBusy) {
+        // Show confirmation dialog — actual close proceeds via dialog confirm handler
+        setPendingCloseConversationId(conversationId);
+        return;
       }
 
-      try {
-        window.dispatchEvent(
-          new CustomEvent('emdash:conversations-changed', { detail: { taskId: task.id } })
-        );
-      } catch {}
+      await doCloseChat(conversationId);
     },
-    [conversations, task.id, activeConversationId, toast, applyStableConversationTitles]
+    [conversations.length, busyByConversationId, doCloseChat, toast]
   );
 
   // Persist last-selected agent per task (including Droid)
@@ -905,9 +943,12 @@ const ChatInterface: React.FC<Props> = ({
       const customEvent = event as CustomEvent<{ tabIndex: number }>;
       const tabIndex = customEvent.detail?.tabIndex;
       if (typeof tabIndex !== 'number') return;
-      if (tabIndex < 0 || tabIndex >= sortedConversations.length) return;
 
-      const selectedConversation = sortedConversations[tabIndex];
+      // -1 is the sentinel for "last tab" (Cmd+9 convention)
+      const resolvedIndex = tabIndex === -1 ? sortedConversations.length - 1 : tabIndex;
+      if (resolvedIndex < 0 || resolvedIndex >= sortedConversations.length) return;
+
+      const selectedConversation = sortedConversations[resolvedIndex];
       if (selectedConversation) {
         handleSwitchChat(selectedConversation.id);
       }
@@ -929,6 +970,75 @@ const ChatInterface: React.FC<Props> = ({
     window.addEventListener('emdash:close-active-chat', handleCloseActiveChat);
     return () => window.removeEventListener('emdash:close-active-chat', handleCloseActiveChat);
   }, [activeConversationId, handleCloseChat]);
+
+  // Open new conversation tab on Cmd+T
+  useEffect(() => {
+    const handleNewChat = () => {
+      if (task.metadata?.multiAgent) return; // no-op for multi-agent tasks
+      setShowCreateChatModal(true);
+    };
+    window.addEventListener('emdash:new-chat', handleNewChat);
+    return () => window.removeEventListener('emdash:new-chat', handleNewChat);
+  }, [task.metadata?.multiAgent]);
+
+  // Cycle conversations on Ctrl+Tab / Ctrl+Shift+Tab
+  useEffect(() => {
+    const handleCycleChat = (event: Event) => {
+      const customEvent = event as CustomEvent<{ direction: 'next' | 'prev' }>;
+      if (sortedConversations.length <= 1) return;
+      const direction = customEvent.detail?.direction;
+      if (!direction) return;
+
+      const currentIndex = sortedConversations.findIndex((c) => c.id === activeConversationId);
+      if (currentIndex === -1) return;
+
+      let newIndex: number;
+      if (direction === 'prev') {
+        newIndex = currentIndex <= 0 ? sortedConversations.length - 1 : currentIndex - 1;
+      } else {
+        newIndex = (currentIndex + 1) % sortedConversations.length;
+      }
+
+      const newConversation = sortedConversations[newIndex];
+      if (newConversation) handleSwitchChat(newConversation.id);
+    };
+
+    window.addEventListener('emdash:cycle-chat', handleCycleChat);
+    return () => window.removeEventListener('emdash:cycle-chat', handleCycleChat);
+  }, [sortedConversations, activeConversationId, handleSwitchChat]);
+
+  // Reopen last closed conversation on Cmd+Shift+T
+  useEffect(() => {
+    const handleReopenClosedChat = () => {
+      const stack = closedConversationStackRef.current;
+      const entry = stack.pop();
+      if (!entry) return;
+
+      void (async () => {
+        try {
+          const newConv = await rpc.db.createConversation({
+            taskId: task.id,
+            provider: entry.provider,
+            title: entry.title,
+            isMain: false,
+            metadata: null,
+          });
+          if (newConv) {
+            const updated = await applyStableConversationTitles(
+              await rpc.db.getConversations(task.id)
+            );
+            setConversations(updated);
+            await rpc.db.setActiveConversation({ taskId: task.id, conversationId: newConv.id });
+            setActiveConversationId(newConv.id);
+            setAgent(entry.provider as Agent);
+          }
+        } catch {}
+      })();
+    };
+
+    window.addEventListener('emdash:reopen-closed-chat', handleReopenClosedChat);
+    return () => window.removeEventListener('emdash:reopen-closed-chat', handleReopenClosedChat);
+  }, [task.id, applyStableConversationTitles]);
 
   const isTerminal = agentMeta[agent]?.terminalOnly === true;
 
@@ -1158,6 +1268,35 @@ const ChatInterface: React.FC<Props> = ({
           onCreateChat={handleCreateChat}
           installedAgents={installedAgents}
         />
+
+        <AlertDialog
+          open={pendingCloseConversationId !== null}
+          onOpenChange={(open) => {
+            if (!open) setPendingCloseConversationId(null);
+          }}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Close conversation?</AlertDialogTitle>
+              <AlertDialogDescription>
+                An agent is currently running. Closing this conversation will send an interrupt
+                signal and stop the agent.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                onClick={() => {
+                  const id = pendingCloseConversationId;
+                  setPendingCloseConversationId(null);
+                  if (id) void doCloseChat(id);
+                }}
+              >
+                Close
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         <div className="flex min-h-0 flex-1 flex-col">
           <div className="px-6 pt-4">

--- a/src/renderer/components/CommandPalette.tsx
+++ b/src/renderer/components/CommandPalette.tsx
@@ -18,6 +18,7 @@ import {
   Command as CommandIcon,
   Option,
   Palette,
+  Kanban,
 } from 'lucide-react';
 import {
   APP_SHORTCUTS,
@@ -47,6 +48,7 @@ interface CommandPaletteProps {
   onToggleLeftSidebar?: () => void;
   onToggleRightSidebar?: () => void;
   onToggleTheme?: () => void;
+  onToggleKanban?: () => void;
   onGoHome?: () => void;
   onOpenProject?: () => void;
 }
@@ -76,6 +78,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
   onToggleLeftSidebar,
   onToggleRightSidebar,
   onToggleTheme,
+  onToggleKanban,
   onGoHome,
   onOpenProject,
 }) => {
@@ -227,6 +230,19 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
       });
     }
 
+    if (onToggleKanban) {
+      items.push({
+        id: 'toggle-kanban',
+        label: 'Toggle Kanban',
+        description: APP_SHORTCUTS.TOGGLE_KANBAN.description,
+        icon: <Kanban className="h-4 w-4" />,
+        group: 'Toggles',
+        keywords: ['kanban', 'board', 'project', 'toggle'],
+        shortcut: getEffectiveShortcut('toggleKanban', APP_SHORTCUTS.TOGGLE_KANBAN),
+        onSelect: () => runCommand(onToggleKanban),
+      });
+    }
+
     // Project commands
     projects.forEach((project) => {
       if (onSelectProject) {
@@ -275,6 +291,7 @@ const CommandPalette: React.FC<CommandPaletteProps> = ({
     onToggleLeftSidebar,
     onToggleRightSidebar,
     onToggleTheme,
+    onToggleKanban,
     runCommand,
   ]);
 

--- a/src/renderer/components/CommandPaletteWrapper.tsx
+++ b/src/renderer/components/CommandPaletteWrapper.tsx
@@ -13,6 +13,7 @@ export interface CommandPaletteWrapperProps {
   handleGoHome: () => void;
   handleOpenSettings: () => void;
   handleOpenKeyboardShortcuts: () => void;
+  handleToggleKanban?: () => void;
 }
 
 const CommandPaletteWrapper: React.FC<CommandPaletteWrapperProps> = ({
@@ -21,6 +22,7 @@ const CommandPaletteWrapper: React.FC<CommandPaletteWrapperProps> = ({
   handleGoHome,
   handleOpenSettings,
   handleOpenKeyboardShortcuts,
+  handleToggleKanban,
 }) => {
   const { toggle: toggleLeftSidebar } = useSidebar();
   const { toggle: toggleRightSidebar } = useRightSidebar();
@@ -50,6 +52,7 @@ const CommandPaletteWrapper: React.FC<CommandPaletteWrapperProps> = ({
       onToggleLeftSidebar={toggleLeftSidebar}
       onToggleRightSidebar={toggleRightSidebar}
       onToggleTheme={toggleTheme}
+      onToggleKanban={handleToggleKanban}
       onGoHome={handleGoHome}
       onOpenProject={handleOpenProject}
     />

--- a/src/renderer/contexts/KeyboardSettingsContext.tsx
+++ b/src/renderer/contexts/KeyboardSettingsContext.tsx
@@ -36,7 +36,7 @@ export const KeyboardSettingsProvider: React.FC<{ children: React.ReactNode }> =
       const defaultShortcut = Object.values(APP_SHORTCUTS).find(
         (s) => s.settingsKey === settingsKey
       );
-      if (defaultShortcut && !defaultShortcut.defaultDisabled) {
+      if (defaultShortcut) {
         return { key: defaultShortcut.key, modifier: defaultShortcut.modifier };
       }
       return null;
@@ -60,7 +60,7 @@ export const useKeyboardSettings = (): KeyboardSettingsContextValue => {
         const defaultShortcut = Object.values(APP_SHORTCUTS).find(
           (s) => s.settingsKey === settingsKey
         );
-        if (defaultShortcut && !defaultShortcut.defaultDisabled) {
+        if (defaultShortcut) {
           return { key: defaultShortcut.key, modifier: defaultShortcut.modifier };
         }
         return null;

--- a/src/renderer/contexts/KeyboardSettingsContext.tsx
+++ b/src/renderer/contexts/KeyboardSettingsContext.tsx
@@ -36,7 +36,7 @@ export const KeyboardSettingsProvider: React.FC<{ children: React.ReactNode }> =
       const defaultShortcut = Object.values(APP_SHORTCUTS).find(
         (s) => s.settingsKey === settingsKey
       );
-      if (defaultShortcut) {
+      if (defaultShortcut && !defaultShortcut.defaultDisabled) {
         return { key: defaultShortcut.key, modifier: defaultShortcut.modifier };
       }
       return null;
@@ -60,7 +60,7 @@ export const useKeyboardSettings = (): KeyboardSettingsContextValue => {
         const defaultShortcut = Object.values(APP_SHORTCUTS).find(
           (s) => s.settingsKey === settingsKey
         );
-        if (defaultShortcut) {
+        if (defaultShortcut && !defaultShortcut.defaultDisabled) {
           return { key: defaultShortcut.key, modifier: defaultShortcut.modifier };
         }
         return null;

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -38,8 +38,6 @@ export interface AppShortcut {
   category: string;
   settingsKey: ShortcutSettingsKey;
   hideFromSettings?: boolean;
-  /** When true, the shortcut has no default binding. Users must explicitly assign one. */
-  defaultDisabled?: boolean;
 }
 
 const isMacPlatform =
@@ -69,15 +67,15 @@ function getPlatformTaskSwitchDefaults(): { next: AppShortcut; prev: AppShortcut
 
   return {
     next: {
-      key: 'Tab',
-      modifier: 'ctrl',
+      key: ']',
+      modifier: 'ctrl+shift',
       label: 'Next Task',
       description: 'Switch to the next task',
       category: 'Navigation',
       settingsKey: 'nextProject',
     },
     prev: {
-      key: 'Tab',
+      key: '[',
       modifier: 'ctrl+shift',
       label: 'Previous Task',
       description: 'Switch to the previous task',
@@ -424,11 +422,6 @@ function getEffectiveConfig(
       description: shortcut.description,
       category: shortcut.category,
     };
-  }
-  // Shortcuts marked defaultDisabled have no active binding unless the user
-  // explicitly assigns one via settings.
-  if (shortcut.defaultDisabled) {
-    return null;
   }
   return {
     key: shortcut.key,

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -558,12 +558,14 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
         handler: () => handlers.onNewChat?.(),
         priority: 'global',
         requiresClosed: true,
+        allowInInput: true,
       },
       effectiveShortcuts.closeChat && {
         config: effectiveShortcuts.closeChat,
         handler: () => handlers.onCloseChat?.(),
         priority: 'global',
         requiresClosed: true,
+        allowInInput: true,
       },
       effectiveShortcuts.nextChat && {
         config: effectiveShortcuts.nextChat,
@@ -584,6 +586,7 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
         handler: () => handlers.onReopenClosedChat?.(),
         priority: 'global',
         requiresClosed: true,
+        allowInInput: true,
       },
       effectiveShortcuts.commandPaletteAlt && {
         config: effectiveShortcuts.commandPaletteAlt,

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -22,7 +22,13 @@ export type ShortcutSettingsKey =
   | 'newTask'
   | 'nextAgent'
   | 'prevAgent'
-  | 'openInEditor';
+  | 'openInEditor'
+  | 'newChat'
+  | 'closeChat'
+  | 'nextChat'
+  | 'prevChat'
+  | 'reopenClosedChat'
+  | 'commandPaletteAlt';
 
 export interface AppShortcut {
   key: string;
@@ -32,6 +38,8 @@ export interface AppShortcut {
   category: string;
   settingsKey: ShortcutSettingsKey;
   hideFromSettings?: boolean;
+  /** When true, the shortcut has no default binding. Users must explicitly assign one. */
+  defaultDisabled?: boolean;
 }
 
 const isMacPlatform =
@@ -141,6 +149,7 @@ export const APP_SHORTCUTS: Record<string, AppShortcut> = {
     description: 'Cycle through light, dark navy, and dark black themes',
     category: 'View',
     settingsKey: 'toggleTheme',
+    defaultDisabled: true,
   },
 
   TOGGLE_KANBAN: {
@@ -150,6 +159,7 @@ export const APP_SHORTCUTS: Record<string, AppShortcut> = {
     description: 'Show or hide the Kanban board',
     category: 'Navigation',
     settingsKey: 'toggleKanban',
+    defaultDisabled: true,
   },
 
   TOGGLE_EDITOR: {
@@ -209,6 +219,60 @@ export const APP_SHORTCUTS: Record<string, AppShortcut> = {
     description: 'Open the project in the default editor',
     category: 'Navigation',
     settingsKey: 'openInEditor',
+  },
+
+  NEW_CHAT: {
+    key: 't',
+    modifier: 'cmd',
+    label: 'New Conversation',
+    description: 'Open a new conversation tab in the current task',
+    category: 'Navigation',
+    settingsKey: 'newChat',
+  },
+
+  CLOSE_CHAT: {
+    key: 'w',
+    modifier: 'cmd',
+    label: 'Close Conversation',
+    description: 'Close the active conversation tab',
+    category: 'Navigation',
+    settingsKey: 'closeChat',
+  },
+
+  NEXT_CHAT: {
+    key: 'Tab',
+    modifier: 'ctrl',
+    label: 'Next Conversation',
+    description: 'Switch to the next conversation tab',
+    category: 'Navigation',
+    settingsKey: 'nextChat',
+  },
+
+  PREV_CHAT: {
+    key: 'Tab',
+    modifier: 'ctrl+shift',
+    label: 'Previous Conversation',
+    description: 'Switch to the previous conversation tab',
+    category: 'Navigation',
+    settingsKey: 'prevChat',
+  },
+
+  REOPEN_CLOSED_CHAT: {
+    key: 't',
+    modifier: 'cmd+shift',
+    label: 'Reopen Closed Conversation',
+    description: 'Reopen the last closed conversation tab',
+    category: 'Navigation',
+    settingsKey: 'reopenClosedChat',
+  },
+
+  COMMAND_PALETTE_ALT: {
+    key: 'p',
+    modifier: 'cmd+shift',
+    label: 'Command Palette',
+    description: 'Open the command palette (VS Code / Warp alias)',
+    category: 'Navigation',
+    settingsKey: 'commandPaletteAlt',
   },
 };
 
@@ -295,6 +359,10 @@ export function getAgentTabSelectionIndex(
     return null;
   }
 
+  // Cmd+9 means "last tab" (not ninth), matching Chrome / Warp convention.
+  // Return -1 as a sentinel; callers must interpret -1 as the last index.
+  if (key === '9') return -1;
+
   return Number(key) - 1;
 }
 
@@ -359,6 +427,11 @@ function getEffectiveConfig(
       category: shortcut.category,
     };
   }
+  // Shortcuts marked defaultDisabled have no active binding unless the user
+  // explicitly assigns one via settings.
+  if (shortcut.defaultDisabled) {
+    return null;
+  }
   return {
     key: shortcut.key,
     modifier: shortcut.modifier,
@@ -390,6 +463,12 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
       nextAgent: getEffectiveConfig(APP_SHORTCUTS.NEXT_AGENT, custom),
       prevAgent: getEffectiveConfig(APP_SHORTCUTS.PREV_AGENT, custom),
       openInEditor: getEffectiveConfig(APP_SHORTCUTS.OPEN_IN_EDITOR, custom),
+      newChat: getEffectiveConfig(APP_SHORTCUTS.NEW_CHAT, custom),
+      closeChat: getEffectiveConfig(APP_SHORTCUTS.CLOSE_CHAT, custom),
+      nextChat: getEffectiveConfig(APP_SHORTCUTS.NEXT_CHAT, custom),
+      prevChat: getEffectiveConfig(APP_SHORTCUTS.PREV_CHAT, custom),
+      reopenClosedChat: getEffectiveConfig(APP_SHORTCUTS.REOPEN_CLOSED_CHAT, custom),
+      commandPaletteAlt: getEffectiveConfig(APP_SHORTCUTS.COMMAND_PALETTE_ALT, custom),
     };
   }, [handlers.customKeyboardSettings]);
 
@@ -482,6 +561,44 @@ export function useKeyboardShortcuts(handlers: GlobalShortcutHandlers) {
         handler: () => handlers.onOpenInEditor?.(),
         priority: 'global',
         requiresClosed: true,
+      },
+      effectiveShortcuts.newChat && {
+        config: effectiveShortcuts.newChat,
+        handler: () => handlers.onNewChat?.(),
+        priority: 'global',
+        requiresClosed: true,
+      },
+      effectiveShortcuts.closeChat && {
+        config: effectiveShortcuts.closeChat,
+        handler: () => handlers.onCloseChat?.(),
+        priority: 'global',
+        requiresClosed: true,
+      },
+      effectiveShortcuts.nextChat && {
+        config: effectiveShortcuts.nextChat,
+        handler: () => handlers.onNextChat?.(),
+        priority: 'global',
+        requiresClosed: true,
+        allowInInput: true,
+      },
+      effectiveShortcuts.prevChat && {
+        config: effectiveShortcuts.prevChat,
+        handler: () => handlers.onPrevChat?.(),
+        priority: 'global',
+        requiresClosed: true,
+        allowInInput: true,
+      },
+      effectiveShortcuts.reopenClosedChat && {
+        config: effectiveShortcuts.reopenClosedChat,
+        handler: () => handlers.onReopenClosedChat?.(),
+        priority: 'global',
+        requiresClosed: true,
+      },
+      effectiveShortcuts.commandPaletteAlt && {
+        config: effectiveShortcuts.commandPaletteAlt,
+        handler: () => handlers.onCommandPaletteAlt?.(),
+        priority: 'global',
+        isCommandPalette: true,
       },
     ];
     const shortcuts: ShortcutMapping[] = maybeShortcuts.filter(

--- a/src/renderer/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/hooks/useKeyboardShortcuts.ts
@@ -143,23 +143,21 @@ export const APP_SHORTCUTS: Record<string, AppShortcut> = {
   },
 
   TOGGLE_THEME: {
-    key: 't',
-    modifier: 'cmd',
+    key: 'l',
+    modifier: 'cmd+shift',
     label: 'Toggle Theme',
     description: 'Cycle through light, dark navy, and dark black themes',
     category: 'View',
     settingsKey: 'toggleTheme',
-    defaultDisabled: true,
   },
 
   TOGGLE_KANBAN: {
-    key: 'p',
-    modifier: 'cmd',
+    key: 'k',
+    modifier: 'cmd+shift',
     label: 'Toggle Kanban',
     description: 'Show or hide the Kanban board',
     category: 'Navigation',
     settingsKey: 'toggleKanban',
-    defaultDisabled: true,
   },
 
   TOGGLE_EDITOR: {

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -103,6 +103,7 @@ declare global {
       ptyInput: (args: { id: string; data: string }) => void;
       ptyResize: (args: { id: string; cols: number; rows?: number }) => void;
       ptyKill: (id: string) => void;
+      ptyKillGraceful: (id: string) => Promise<{ ok: boolean; error?: string }>;
       ptyKillTmux: (id: string) => Promise<{ ok: boolean; error?: string }>;
       onPtyData: (id: string, listener: (data: string) => void) => () => void;
       ptyGetSnapshot: (args: { id: string }) => Promise<{

--- a/src/renderer/types/shortcuts.ts
+++ b/src/renderer/types/shortcuts.ts
@@ -29,6 +29,12 @@ export interface KeyboardSettings {
   nextAgent?: KeyboardShortcutBinding;
   prevAgent?: KeyboardShortcutBinding;
   openInEditor?: KeyboardShortcutBinding;
+  newChat?: KeyboardShortcutBinding;
+  closeChat?: KeyboardShortcutBinding;
+  nextChat?: KeyboardShortcutBinding;
+  prevChat?: KeyboardShortcutBinding;
+  reopenClosedChat?: KeyboardShortcutBinding;
+  commandPaletteAlt?: KeyboardShortcutBinding;
 }
 
 export interface ShortcutConfig {
@@ -96,6 +102,14 @@ export interface GlobalShortcutHandlers {
 
   // Open in editor
   onOpenInEditor?: () => void;
+
+  // Chat (conversation tab) management
+  onNewChat?: () => void;
+  onCloseChat?: () => void;
+  onNextChat?: () => void;
+  onPrevChat?: () => void;
+  onReopenClosedChat?: () => void;
+  onCommandPaletteAlt?: () => void;
 
   // State checks
   isCommandPaletteOpen?: boolean;

--- a/src/renderer/views/Workspace.tsx
+++ b/src/renderer/views/Workspace.tsx
@@ -491,6 +491,7 @@ export function Workspace() {
                 }}
                 handleOpenSettings={() => openSettingsPage()}
                 handleOpenKeyboardShortcuts={() => openSettingsPage('interface')}
+                handleToggleKanban={handleToggleKanban}
               />
               {showEditorMode && activeTask && selectedProject && (
                 <CodeEditor

--- a/src/test/main/DatabaseService.archiveConversation.test.ts
+++ b/src/test/main/DatabaseService.archiveConversation.test.ts
@@ -1,0 +1,124 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Minimal DB mock: tracks the latest update call so we can assert on it.
+let lastUpdateSet: Record<string, unknown> = {};
+let lastUpdateWhere: unknown = null;
+const selectResults: unknown[][] = [];
+
+const mockDb = {
+  select: vi.fn(() => ({
+    from: () => ({
+      where: () => ({
+        limit: () => Promise.resolve((selectResults.shift() as unknown[]) ?? []),
+      }),
+    }),
+  })),
+  insert: vi.fn(() => ({
+    values: () => Promise.resolve(),
+  })),
+  update: vi.fn(() => ({
+    set: (values: Record<string, unknown>) => {
+      lastUpdateSet = values;
+      return {
+        where: (whereClause: unknown) => {
+          lastUpdateWhere = whereClause;
+          return Promise.resolve();
+        },
+      };
+    },
+  })),
+};
+
+vi.mock('../../main/db/path', () => ({
+  resolveDatabasePath: () => '/tmp/emdash-archive-conv-test.db',
+  resolveMigrationsPath: () => '/tmp/drizzle',
+}));
+
+vi.mock('../../main/errorTracking', () => ({
+  errorTracking: {
+    captureDatabaseError: vi.fn(),
+  },
+}));
+
+vi.mock('../../main/db/drizzleClient', () => ({
+  getDrizzleClient: () => Promise.resolve({ db: mockDb }),
+}));
+
+import { DatabaseService } from '../../main/services/DatabaseService';
+
+describe('DatabaseService.archiveConversation', () => {
+  let service: DatabaseService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectResults.length = 0;
+    lastUpdateSet = {};
+    lastUpdateWhere = null;
+    service = new DatabaseService();
+  });
+
+  it('sets archivedAt to a non-null ISO timestamp', async () => {
+    await service.archiveConversation('conv-1');
+
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(lastUpdateSet).toMatchObject({
+      archivedAt: expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/),
+    });
+  });
+
+  it('does not touch the messages table on archive', async () => {
+    await service.archiveConversation('conv-1');
+
+    // Only one update call — the conversations table.
+    // If messages were touched we'd see a second update or insert.
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(mockDb.insert).not.toHaveBeenCalled();
+  });
+});
+
+describe('DatabaseService.unarchiveConversation', () => {
+  let service: DatabaseService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    selectResults.length = 0;
+    lastUpdateSet = {};
+    lastUpdateWhere = null;
+    service = new DatabaseService();
+  });
+
+  it('sets archivedAt to null', async () => {
+    // The select after update returns the unarchived row
+    selectResults.push([
+      {
+        id: 'conv-1',
+        taskId: 'task-1',
+        title: 'Test Chat',
+        provider: 'claude',
+        isActive: 0,
+        isMain: 0,
+        displayOrder: 0,
+        metadata: null,
+        archivedAt: null,
+        createdAt: '2024-01-01T00:00:00.000Z',
+        updatedAt: '2024-01-01T00:00:00.000Z',
+      },
+    ]);
+
+    const result = await service.unarchiveConversation('conv-1');
+
+    expect(mockDb.update).toHaveBeenCalledTimes(1);
+    expect(lastUpdateSet).toMatchObject({ archivedAt: null });
+    expect(result).not.toBeNull();
+    expect(result?.id).toBe('conv-1');
+    expect(result?.archivedAt).toBeNull();
+  });
+
+  it('returns null when the row is not found after unarchive', async () => {
+    selectResults.push([]); // empty result set
+
+    const result = await service.unarchiveConversation('conv-missing');
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/test/main/ptyManager.test.ts
+++ b/src/test/main/ptyManager.test.ts
@@ -687,3 +687,71 @@ describe('stale Claude session detection', () => {
     expect(fsWriteFileSyncMock).toHaveBeenCalledWith(SESSION_MAP_PATH, JSON.stringify({}));
   });
 });
+
+describe('killPtyGraceful', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    fsMkdirSyncMock.mockImplementation(() => undefined);
+    fsWriteFileSyncMock.mockImplementation(() => undefined);
+    fsReadFileSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    fsExistsSyncMock.mockReturnValue(false);
+    fsStatSyncMock.mockImplementation(() => {
+      throw new Error('ENOENT');
+    });
+    fsAccessSyncMock.mockImplementation(() => undefined);
+    delete process.env.EMDASH_DISABLE_PTY;
+  });
+
+  it('resolves immediately when PTY is not registered (no 1.5s wait)', async () => {
+    const { killPtyGraceful } = await import('../../main/services/ptyManager');
+
+    const start = performance.now();
+    await killPtyGraceful('nonexistent-id', { sigintTimeoutMs: 1500 });
+    expect(performance.now() - start).toBeLessThan(100);
+  });
+
+  it('calls dispose() on the onExit subscription when process exits before timeout', async () => {
+    const disposeSpy = vi.fn();
+    let killGracefulExitCb: (() => void) | undefined;
+
+    const fakeProc = {
+      pid: 99999,
+      cols: 80,
+      rows: 24,
+      process: 'zsh',
+      handleFlowControl: false,
+      kill: vi.fn(),
+      write: vi.fn(),
+      resize: vi.fn(),
+      pause: vi.fn(),
+      resume: vi.fn(),
+      onData: vi.fn().mockReturnValue({ dispose: vi.fn() }),
+      // startPty does NOT call onExit internally, so the only caller is killPtyGraceful
+      onExit: vi.fn().mockImplementation((cb: () => void) => {
+        killGracefulExitCb = cb;
+        return { dispose: disposeSpy };
+      }),
+    };
+
+    nodePtySpawnMock.mockReturnValue(fakeProc);
+
+    // startPty uses `await import('node-pty')` (ESM), which vitest properly mocks.
+    // startDirectPty uses `require('node-pty')` (CJS) — not intercepted by vi.mock.
+    const { startPty, killPtyGraceful } = await import('../../main/services/ptyManager');
+
+    await startPty({ id: 'zsh-main-test-dispose', cwd: '/tmp/task', shell: '/bin/zsh' });
+
+    // killPtyGraceful calls fakeProc.onExit once — killGracefulExitCb is now the resolve fn
+    const killPromise = killPtyGraceful('zsh-main-test-dispose', { sigintTimeoutMs: 5000 });
+
+    // Simulate the process exiting before the timeout fires
+    killGracefulExitCb?.();
+
+    await killPromise;
+
+    expect(disposeSpy).toHaveBeenCalled();
+  });
+});

--- a/src/test/renderer/useKeyboardShortcuts.test.ts
+++ b/src/test/renderer/useKeyboardShortcuts.test.ts
@@ -1,6 +1,53 @@
 import { describe, expect, it } from 'vitest';
 import { getAgentTabSelectionIndex } from '../../renderer/hooks/useKeyboardShortcuts';
 
+// Non-mac default keyboard shortcuts — derived from DEFAULT_SETTINGS with ctrl+shift
+// project cycling (A2 fix: moved off Ctrl+Tab to avoid collision with chat cycling).
+const NON_MAC_DEFAULTS: Record<string, { key: string; modifier: string }> = {
+  commandPalette: { key: 'k', modifier: 'cmd' },
+  settings: { key: ',', modifier: 'cmd' },
+  toggleLeftSidebar: { key: 'b', modifier: 'cmd' },
+  toggleRightSidebar: { key: '.', modifier: 'cmd' },
+  toggleEditor: { key: 'e', modifier: 'cmd' },
+  nextProject: { key: ']', modifier: 'ctrl+shift' },
+  prevProject: { key: '[', modifier: 'ctrl+shift' },
+  newTask: { key: 'n', modifier: 'cmd' },
+  nextAgent: { key: ']', modifier: 'cmd+shift' },
+  prevAgent: { key: '[', modifier: 'cmd+shift' },
+  openInEditor: { key: 'o', modifier: 'cmd' },
+  toggleTheme: { key: 'l', modifier: 'cmd+shift' },
+  toggleKanban: { key: 'k', modifier: 'cmd+shift' },
+  newChat: { key: 't', modifier: 'cmd' },
+  closeChat: { key: 'w', modifier: 'cmd' },
+  nextChat: { key: 'Tab', modifier: 'ctrl' },
+  prevChat: { key: 'Tab', modifier: 'ctrl+shift' },
+  reopenClosedChat: { key: 't', modifier: 'cmd+shift' },
+  commandPaletteAlt: { key: 'p', modifier: 'cmd+shift' },
+};
+
+describe('non-mac default keyboard shortcuts', () => {
+  it('has no duplicate modifier+key bindings (assertNoKeyboardShortcutConflicts equivalent)', () => {
+    const seen = new Map<string, string>();
+    for (const [name, binding] of Object.entries(NON_MAC_DEFAULTS)) {
+      const sig = `${binding.modifier}:${binding.key.toLowerCase()}`;
+      expect(seen.has(sig), `"${name}" conflicts with "${seen.get(sig)}" on binding ${sig}`).toBe(
+        false
+      );
+      seen.set(sig, name);
+    }
+  });
+
+  it('uses Ctrl+Shift+]/[ for project cycling, not Ctrl+Tab', () => {
+    expect(NON_MAC_DEFAULTS.nextProject).toEqual({ key: ']', modifier: 'ctrl+shift' });
+    expect(NON_MAC_DEFAULTS.prevProject).toEqual({ key: '[', modifier: 'ctrl+shift' });
+  });
+
+  it('keeps Ctrl+Tab/Ctrl+Shift+Tab for chat cycling on non-mac', () => {
+    expect(NON_MAC_DEFAULTS.nextChat).toEqual({ key: 'Tab', modifier: 'ctrl' });
+    expect(NON_MAC_DEFAULTS.prevChat).toEqual({ key: 'Tab', modifier: 'ctrl+shift' });
+  });
+});
+
 describe('getAgentTabSelectionIndex', () => {
   it('maps Cmd/Ctrl+1 through Cmd/Ctrl+8 to zero-based tab indexes', () => {
     expect(

--- a/src/test/renderer/useKeyboardShortcuts.test.ts
+++ b/src/test/renderer/useKeyboardShortcuts.test.ts
@@ -1,5 +1,10 @@
-import { describe, expect, it } from 'vitest';
-import { getAgentTabSelectionIndex } from '../../renderer/hooks/useKeyboardShortcuts';
+// @vitest-environment jsdom
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  getAgentTabSelectionIndex,
+  useKeyboardShortcuts,
+} from '../../renderer/hooks/useKeyboardShortcuts';
 
 // Non-mac default keyboard shortcuts — derived from DEFAULT_SETTINGS with ctrl+shift
 // project cycling (A2 fix: moved off Ctrl+Tab to avoid collision with chat cycling).
@@ -138,5 +143,49 @@ describe('getAgentTabSelectionIndex', () => {
         shiftKey: false,
       } as KeyboardEvent)
     ).toBeNull();
+  });
+});
+
+// Regression: conversation tab shortcuts must fire even when a textarea is focused.
+// Previously newChat / closeChat / reopenClosedChat lacked allowInInput:true, so
+// they were silently skipped whenever the chat input held focus.
+describe('chat shortcuts fire from inside a textarea', () => {
+  function fireKeyInTextarea(key: string, modifiers: Partial<KeyboardEventInit> = {}) {
+    const textarea = document.createElement('textarea');
+    document.body.appendChild(textarea);
+    textarea.focus();
+
+    const event = new KeyboardEvent('keydown', {
+      key,
+      bubbles: true,
+      cancelable: true,
+      ...modifiers,
+    });
+    // Override target to the textarea so isEditableTarget fires.
+    Object.defineProperty(event, 'target', { value: textarea, configurable: true });
+    window.dispatchEvent(event);
+
+    document.body.removeChild(textarea);
+  }
+
+  it('Cmd+T (newChat) fires from inside a textarea', () => {
+    const onNewChat = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onNewChat }));
+    fireKeyInTextarea('t', { metaKey: true });
+    expect(onNewChat).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd+W (closeChat) fires from inside a textarea', () => {
+    const onCloseChat = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onCloseChat }));
+    fireKeyInTextarea('w', { metaKey: true });
+    expect(onCloseChat).toHaveBeenCalledTimes(1);
+  });
+
+  it('Cmd+Shift+T (reopenClosedChat) fires from inside a textarea', () => {
+    const onReopenClosedChat = vi.fn();
+    renderHook(() => useKeyboardShortcuts({ onReopenClosedChat }));
+    fireKeyInTextarea('t', { metaKey: true, shiftKey: true });
+    expect(onReopenClosedChat).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/test/renderer/useKeyboardShortcuts.test.ts
+++ b/src/test/renderer/useKeyboardShortcuts.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from 'vitest';
 import { getAgentTabSelectionIndex } from '../../renderer/hooks/useKeyboardShortcuts';
 
 describe('getAgentTabSelectionIndex', () => {
-  it('maps Cmd/Ctrl+1 through Cmd/Ctrl+9 to zero-based tab indexes', () => {
+  it('maps Cmd/Ctrl+1 through Cmd/Ctrl+8 to zero-based tab indexes', () => {
     expect(
       getAgentTabSelectionIndex({
         key: '1',
@@ -15,13 +15,25 @@ describe('getAgentTabSelectionIndex', () => {
 
     expect(
       getAgentTabSelectionIndex({
+        key: '8',
+        metaKey: true,
+        ctrlKey: false,
+        altKey: false,
+        shiftKey: false,
+      } as KeyboardEvent)
+    ).toBe(7);
+  });
+
+  it('maps Cmd/Ctrl+9 to -1 (last-tab sentinel)', () => {
+    expect(
+      getAgentTabSelectionIndex({
         key: '9',
         metaKey: true,
         ctrlKey: false,
         altKey: false,
         shiftKey: false,
       } as KeyboardEvent)
-    ).toBe(8);
+    ).toBe(-1);
   });
 
   it('accepts Ctrl+number as the Command equivalent on non-mac platforms', () => {


### PR DESCRIPTION
Closes #1008

## Summary

Fixes three convention violations and adds the tab-management shortcuts that Chrome, Warp, and VS Code users expect.

**Reclaimed keys (old behavior moved to palette or new binding):**
- `Cmd+T` → **New Conversation** (was: toggle theme → now `Cmd+Shift+L`)
- `Cmd+W` → **Close active Conversation** with PTY-busy confirmation dialog (was: no-op in shortcut registry)
- `Cmd+P` → **Unbound** (was: toggle kanban → now `Cmd+Shift+K`)

**New shortcuts:**
- `Cmd+1`–`Cmd+8` → jump to Conversation N (was partially implemented; `Cmd+9` now jumps to last)
- `Ctrl+Tab` / `Ctrl+Shift+Tab` → cycle Conversations forward/back with wrap
- `Cmd+Shift+T` → reopen last closed Conversation (restores agent + title; max 10 stack)
- `Cmd+Shift+P` → Command Palette alias (VS Code muscle memory; primary `Cmd+K` unchanged)
- `Cmd+Shift+K` → Toggle Kanban (new home for displaced `Cmd+P` action)
- `Cmd+Shift+L` → Toggle Theme (new home for displaced `Cmd+T` action)

**Other changes:**
- PTY graceful shutdown: `SIGINT` → 1500ms → hard kill via new `pty:killGraceful` IPC
- "Toggle Kanban" entry added to `Cmd+K` palette (Kanban was previously only in titlebar)
- Settings migration drops legacy `Cmd+T=theme` and `Cmd+P=kanban` stored defaults on upgrade; user-customized bindings are preserved

## Test Plan

- [ ] `Cmd+T` opens Create Conversation modal; `Cmd+Shift+L` toggles theme
- [ ] `Cmd+W` on idle conversation closes immediately; on busy PTY shows confirmation dialog; on single conversation does nothing
- [ ] `Cmd+1`–`Cmd+8` jump to Conversation N; `Cmd+9` jumps to last
- [ ] `Ctrl+Tab` / `Ctrl+Shift+Tab` cycle and wrap
- [ ] `Cmd+Shift+T` reopens last closed Conversation (same agent)
- [ ] `Cmd+Shift+P` opens Command Palette
- [ ] `Cmd+Shift+K` toggles Kanban; `Cmd+P` does nothing
- [ ] `Cmd+K` → "kanban" entry appears and works
- [ ] Settings with old `toggleTheme: {key:'t', modifier:'cmd'}` → binding removed on launch

🤖 Generated with [Claude Code](https://claude.ai/claude-code)