### PR TITLE
feat(jira): add Personal Access Token (Bearer) auth for Jira Server/Data Center

### DIFF
--- a/src/main/ipc/jiraIpc.ts
+++ b/src/main/ipc/jiraIpc.ts
@@ -6,14 +6,22 @@ const jira = new JiraService();
 export function registerJiraIpc() {
   ipcMain.handle(
     'jira:saveCredentials',
-    async (_e, args: { siteUrl: string; email: string; token: string }) => {
+    async (
+      _e,
+      args: { siteUrl: string; email?: string; token: string; authType?: 'basic' | 'bearer' }
+    ) => {
       const siteUrl = String(args?.siteUrl || '').trim();
-      const email = String(args?.email || '').trim();
       const token = String(args?.token || '').trim();
-      if (!siteUrl || !email || !token) {
-        return { success: false, error: 'Site URL, email, and API token are required.' };
+      const authType = args?.authType === 'bearer' ? 'bearer' : 'basic';
+      const email = String(args?.email || '').trim();
+
+      if (!siteUrl || !token) {
+        return { success: false, error: 'Site URL and token are required.' };
       }
-      return jira.saveCredentials(siteUrl, email, token);
+      if (authType === 'basic' && !email) {
+        return { success: false, error: 'Email is required for API token auth.' };
+      }
+      return jira.saveCredentials(siteUrl, token, authType, email || undefined);
     }
   );
 
@@ -33,7 +41,6 @@ export function registerJiraIpc() {
 
   ipcMain.handle('jira:searchIssues', async (_e, searchTerm: string, limit?: number) => {
     try {
-      // Use enhanced search that supports direct key lookups
       const issues = await jira.smartSearchIssues(searchTerm, limit ?? 20);
       return { success: true, issues };
     } catch (e: any) {

--- a/src/main/preload.ts
+++ b/src/main/preload.ts
@@ -588,8 +588,12 @@ contextBridge.exposeInMainWorld('electronAPI', {
   linearSearchIssues: (searchTerm: string, limit?: number) =>
     ipcRenderer.invoke('linear:searchIssues', searchTerm, limit),
   // Jira integration
-  jiraSaveCredentials: (args: { siteUrl: string; email: string; token: string }) =>
-    ipcRenderer.invoke('jira:saveCredentials', args),
+  jiraSaveCredentials: (args: {
+    siteUrl: string;
+    email?: string;
+    token: string;
+    authType?: 'basic' | 'bearer';
+  }) => ipcRenderer.invoke('jira:saveCredentials', args),
   jiraClearCredentials: () => ipcRenderer.invoke('jira:clearCredentials'),
   jiraCheckConnection: () => ipcRenderer.invoke('jira:checkConnection'),
   jiraInitialFetch: (limit?: number) => ipcRenderer.invoke('jira:initialFetch', limit),

--- a/src/main/services/JiraService.ts
+++ b/src/main/services/JiraService.ts
@@ -1,4 +1,5 @@
-import { request } from 'node:https';
+import { request as httpsRequest } from 'node:https';
+import { request as httpRequest, type RequestOptions } from 'node:http';
 import { URL } from 'node:url';
 import { app } from 'electron';
 import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
@@ -48,10 +49,27 @@ export default class JiraService {
       if (!siteUrl) return null;
       const authType: AuthType = obj?.authType === 'bearer' ? 'bearer' : 'basic';
       const email = String(obj?.email || '').trim();
+      // Basic auth requires email; treat legacy/corrupt configs without email as invalid
+      if (authType === 'basic' && !email) return null;
       return { siteUrl, email: email || undefined, authType };
     } catch {
       return null;
     }
+  }
+
+  private buildAuth(creds: JiraCreds, token: string): Auth {
+    if (creds.authType === 'bearer') return { authType: 'bearer', token };
+    if (!creds.email) {
+      throw new Error('Jira email missing for Basic auth. Please reconnect Jira.');
+    }
+    return { authType: 'basic', email: creds.email, token };
+  }
+
+  private buildUrl(siteUrl: string, path: string): URL {
+    // Preserve any context path (e.g. https://jira.example.com/jira) — new URL(path, base)
+    // would discard it because absolute paths reset. Concatenate instead.
+    const base = siteUrl.replace(/\/+$/, '');
+    return new URL(`${base}${path.startsWith('/') ? path : `/${path}`}`);
   }
 
   private writeCreds(creds: JiraCreds) {
@@ -71,10 +89,13 @@ export default class JiraService {
     error?: string;
   }> {
     try {
+      if (authType === 'basic' && !email) {
+        return { success: false, error: 'Email is required for Basic auth.' };
+      }
       const auth: Auth =
         authType === 'bearer'
           ? { authType: 'bearer', token }
-          : { authType: 'basic', email: email!, token };
+          : { authType: 'basic', email: email as string, token };
       const me = await this.getMyself(siteUrl, auth);
       const keytar = await import('keytar');
       await keytar.setPassword(this.SERVICE, this.ACCOUNT, token);
@@ -114,10 +135,7 @@ export default class JiraService {
       const keytar = await import('keytar');
       const token = await keytar.getPassword(this.SERVICE, this.ACCOUNT);
       if (!token) return { connected: false };
-      const auth: Auth =
-        creds.authType === 'bearer'
-          ? { authType: 'bearer', token }
-          : { authType: 'basic', email: creds.email!, token };
+      const auth = this.buildAuth(creds, token);
       const me = await this.getMyself(creds.siteUrl, auth);
       this.fetchProjectKeys(creds.siteUrl, auth)
         .then((keys) => {
@@ -188,15 +206,12 @@ export default class JiraService {
     const keytar = await import('keytar');
     const token = await keytar.getPassword(this.SERVICE, this.ACCOUNT);
     if (!token) throw new Error('Jira token not found.');
-    const auth: Auth =
-      creds.authType === 'bearer'
-        ? { authType: 'bearer', token }
-        : { authType: 'basic', email: creds.email!, token };
+    const auth = this.buildAuth(creds, token);
     return { siteUrl: creds.siteUrl, auth };
   }
 
   private async getMyself(siteUrl: string, auth: Auth): Promise<any> {
-    const url = new URL(`${apiBase(auth.authType)}/myself`, siteUrl);
+    const url = this.buildUrl(siteUrl, `${apiBase(auth.authType)}/myself`);
     const body = await this.doGet(url, auth);
     const data = JSON.parse(body || '{}');
     if (!data || data.errorMessages) {
@@ -206,7 +221,7 @@ export default class JiraService {
   }
 
   private async searchRaw(siteUrl: string, auth: Auth, jql: string, limit: number) {
-    const url = new URL(`${apiBase(auth.authType)}/search`, siteUrl);
+    const url = this.buildUrl(siteUrl, `${apiBase(auth.authType)}/search`);
     const payload = JSON.stringify({
       jql,
       maxResults: Math.min(Math.max(limit, 1), 100),
@@ -230,33 +245,33 @@ export default class JiraService {
     payload?: string,
     extraHeaders?: Record<string, string>
   ): Promise<string> {
+    const transport = url.protocol === 'http:' ? httpRequest : httpsRequest;
+    const options: RequestOptions = {
+      hostname: url.hostname,
+      path: url.pathname + url.search,
+      protocol: url.protocol,
+      method,
+      headers: {
+        Authorization: authHeader(auth),
+        Accept: 'application/json',
+        ...(extraHeaders || {}),
+      },
+    };
+    if (url.port) options.port = Number(url.port);
     return await new Promise<string>((resolve, reject) => {
-      const req = request(
-        {
-          hostname: url.hostname,
-          path: url.pathname + url.search,
-          protocol: url.protocol,
-          method,
-          headers: {
-            Authorization: authHeader(auth),
-            Accept: 'application/json',
-            ...(extraHeaders || {}),
-          },
-        },
-        (res) => {
-          let data = '';
-          res.on('data', (chunk) => (data += chunk));
-          res.on('end', () => {
-            if (res.statusCode && res.statusCode >= 400) {
-              const snippet = data?.slice(0, 200) || '';
-              return reject(
-                new Error(`Jira API error ${res.statusCode}${snippet ? `: ${snippet}` : ''}`)
-              );
-            }
-            resolve(data);
-          });
-        }
-      );
+      const req = transport(options, (res) => {
+        let data = '';
+        res.on('data', (chunk) => (data += chunk));
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 400) {
+            const snippet = data?.slice(0, 200) || '';
+            return reject(
+              new Error(`Jira API error ${res.statusCode}${snippet ? `: ${snippet}` : ''}`)
+            );
+          }
+          resolve(data);
+        });
+      });
       req.on('error', reject);
       if (payload && method === 'POST') {
         req.write(payload);
@@ -295,7 +310,7 @@ export default class JiraService {
 
   private async fetchProjectKeys(siteUrl: string, auth: Auth): Promise<string[]> {
     try {
-      const url = new URL(`${apiBase(auth.authType)}/project`, siteUrl);
+      const url = this.buildUrl(siteUrl, `${apiBase(auth.authType)}/project`);
       const body = await this.doGet(url, auth);
       const data = JSON.parse(body || '[]');
       if (!Array.isArray(data)) return [];
@@ -306,7 +321,10 @@ export default class JiraService {
   }
 
   private async getIssueByKey(siteUrl: string, auth: Auth, key: string): Promise<any | null> {
-    const url = new URL(`${apiBase(auth.authType)}/issue/${encodeURIComponent(key)}`, siteUrl);
+    const url = this.buildUrl(
+      siteUrl,
+      `${apiBase(auth.authType)}/issue/${encodeURIComponent(key)}`
+    );
     url.searchParams.set('fields', 'summary,description,updated,project,status,assignee');
     const body = await this.doGet(url, auth);
     const data = JSON.parse(body || '{}');
@@ -315,7 +333,7 @@ export default class JiraService {
   }
 
   private async getRecentIssueKeys(siteUrl: string, auth: Auth, limit: number): Promise<string[]> {
-    const url = new URL(`${apiBase(auth.authType)}/issue/picker`, siteUrl);
+    const url = this.buildUrl(siteUrl, `${apiBase(auth.authType)}/issue/picker`);
     url.searchParams.set('query', '');
     url.searchParams.set('currentJQL', '');
     const body = await this.doGet(url, auth);

--- a/src/main/services/JiraService.ts
+++ b/src/main/services/JiraService.ts
@@ -254,6 +254,7 @@ export default class JiraService {
       headers: {
         Authorization: authHeader(auth),
         Accept: 'application/json',
+        ...(payload ? { 'Content-Length': Buffer.byteLength(payload) } : {}),
         ...(extraHeaders || {}),
       },
     };

--- a/src/main/services/JiraService.ts
+++ b/src/main/services/JiraService.ts
@@ -5,11 +5,24 @@ import { existsSync, readFileSync, writeFileSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { sortByUpdatedAtDesc } from '../utils/issueSorting';
 
-type JiraCreds = { siteUrl: string; email: string };
+type AuthType = 'basic' | 'bearer';
+type JiraCreds = { siteUrl: string; email?: string; authType: AuthType };
+type Auth =
+  | { authType: 'basic'; email: string; token: string }
+  | { authType: 'bearer'; token: string };
 
 function encodeBasic(email: string, token: string) {
   const raw = `${email}:${token}`;
   return Buffer.from(raw).toString('base64');
+}
+
+function apiBase(authType: AuthType): string {
+  return authType === 'bearer' ? '/rest/api/2' : '/rest/api/3';
+}
+
+function authHeader(auth: Auth): string {
+  if (auth.authType === 'bearer') return `Bearer ${auth.token}`;
+  return `Basic ${encodeBasic(auth.email, auth.token)}`;
 }
 
 export interface JiraConnectionStatus {
@@ -32,35 +45,40 @@ export default class JiraService {
       const raw = readFileSync(this.CONF_FILE, 'utf8');
       const obj = JSON.parse(raw);
       const siteUrl = String(obj?.siteUrl || '').trim();
+      if (!siteUrl) return null;
+      const authType: AuthType = obj?.authType === 'bearer' ? 'bearer' : 'basic';
       const email = String(obj?.email || '').trim();
-      if (!siteUrl || !email) return null;
-      return { siteUrl, email };
+      return { siteUrl, email: email || undefined, authType };
     } catch {
       return null;
     }
   }
 
   private writeCreds(creds: JiraCreds) {
-    const { siteUrl, email } = creds;
-    const obj: any = { siteUrl, email };
+    const obj: Record<string, string> = { siteUrl: creds.siteUrl, authType: creds.authType };
+    if (creds.authType === 'basic' && creds.email) obj.email = creds.email;
     writeFileSync(this.CONF_FILE, JSON.stringify(obj), 'utf8');
   }
 
   async saveCredentials(
     siteUrl: string,
-    email: string,
-    token: string
+    token: string,
+    authType: AuthType,
+    email?: string
   ): Promise<{
     success: boolean;
     displayName?: string;
     error?: string;
   }> {
     try {
-      const me = await this.getMyself(siteUrl, email, token);
+      const auth: Auth =
+        authType === 'bearer'
+          ? { authType: 'bearer', token }
+          : { authType: 'basic', email: email!, token };
+      const me = await this.getMyself(siteUrl, auth);
       const keytar = await import('keytar');
       await keytar.setPassword(this.SERVICE, this.ACCOUNT, token);
-      this.writeCreds({ siteUrl, email });
-      // Track connection
+      this.writeCreds({ siteUrl, email: email || undefined, authType });
       void import('../telemetry').then(({ capture }) => {
         void capture('jira_connected');
       });
@@ -80,7 +98,6 @@ export default class JiraService {
       try {
         if (existsSync(this.CONF_FILE)) unlinkSync(this.CONF_FILE);
       } catch {}
-      // Track disconnection
       void import('../telemetry').then(({ capture }) => {
         void capture('jira_disconnected');
       });
@@ -97,8 +114,12 @@ export default class JiraService {
       const keytar = await import('keytar');
       const token = await keytar.getPassword(this.SERVICE, this.ACCOUNT);
       if (!token) return { connected: false };
-      const me = await this.getMyself(creds.siteUrl, creds.email, token);
-      this.fetchProjectKeys(creds.siteUrl, creds.email, token)
+      const auth: Auth =
+        creds.authType === 'bearer'
+          ? { authType: 'bearer', token }
+          : { authType: 'basic', email: creds.email!, token };
+      const me = await this.getMyself(creds.siteUrl, auth);
+      this.fetchProjectKeys(creds.siteUrl, auth)
         .then((keys) => {
           this.projectKeys = keys;
         })
@@ -115,9 +136,8 @@ export default class JiraService {
   }
 
   async initialFetch(limit = 50): Promise<any[]> {
-    const { siteUrl, email, token } = await this.requireAuth();
+    const { siteUrl, auth } = await this.requireAuth();
     const jqlCandidates: string[] = [];
-    // Pragmatic fallbacks that typically work with limited permissions
     jqlCandidates.push(
       'assignee = currentUser() ORDER BY updated DESC',
       'reporter = currentUser() ORDER BY updated DESC',
@@ -126,20 +146,19 @@ export default class JiraService {
 
     for (const jql of jqlCandidates) {
       try {
-        const issues = await this.searchRaw(siteUrl, email, token, jql, limit);
+        const issues = await this.searchRaw(siteUrl, auth, jql, limit);
         if (issues.length > 0) return sortByUpdatedAtDesc(this.normalizeIssues(siteUrl, issues));
       } catch {
         // Try next candidate if this one is forbidden or failed
       }
     }
-    // Final fallback: use issue picker to get recent/history issues, then hydrate via GET /issue/{key}
     try {
-      const keys = await this.getRecentIssueKeys(siteUrl, email, token, limit);
+      const keys = await this.getRecentIssueKeys(siteUrl, auth, limit);
       if (keys.length > 0) {
         const results: any[] = [];
         for (const key of keys.slice(0, limit)) {
           try {
-            const issue = await this.getIssueByKey(siteUrl, email, token, key);
+            const issue = await this.getIssueByKey(siteUrl, auth, key);
             if (issue) results.push(issue);
           } catch {
             // skip individual failures
@@ -156,26 +175,29 @@ export default class JiraService {
   async searchIssues(searchTerm: string, limit = 20): Promise<any[]> {
     const term = (searchTerm || '').trim();
     if (!term) return [];
-    const { siteUrl, email, token } = await this.requireAuth();
+    const { siteUrl, auth } = await this.requireAuth();
     const sanitized = term.replace(/\"/g, '\\\"');
-    const inner = `text ~ \"${sanitized}\" OR key = ${term}`;
-    const jql = inner;
-    const data = await this.searchRaw(siteUrl, email, token, jql, limit);
+    const jql = `text ~ \"${sanitized}\" OR key = ${term}`;
+    const data = await this.searchRaw(siteUrl, auth, jql, limit);
     return sortByUpdatedAtDesc(this.normalizeIssues(siteUrl, data));
   }
 
-  private async requireAuth(): Promise<{ siteUrl: string; email: string; token: string }> {
+  private async requireAuth(): Promise<{ siteUrl: string; auth: Auth }> {
     const creds = this.readCreds();
     if (!creds) throw new Error('Jira credentials not set.');
     const keytar = await import('keytar');
     const token = await keytar.getPassword(this.SERVICE, this.ACCOUNT);
     if (!token) throw new Error('Jira token not found.');
-    return { ...creds, token };
+    const auth: Auth =
+      creds.authType === 'bearer'
+        ? { authType: 'bearer', token }
+        : { authType: 'basic', email: creds.email!, token };
+    return { siteUrl: creds.siteUrl, auth };
   }
 
-  private async getMyself(siteUrl: string, email: string, token: string): Promise<any> {
-    const url = new URL('/rest/api/3/myself', siteUrl);
-    const body = await this.doGet(url, email, token);
+  private async getMyself(siteUrl: string, auth: Auth): Promise<any> {
+    const url = new URL(`${apiBase(auth.authType)}/myself`, siteUrl);
+    const body = await this.doGet(url, auth);
     const data = JSON.parse(body || '{}');
     if (!data || data.errorMessages) {
       throw new Error('Failed to verify Jira token.');
@@ -183,39 +205,31 @@ export default class JiraService {
     return data;
   }
 
-  private async searchRaw(
-    siteUrl: string,
-    email: string,
-    token: string,
-    jql: string,
-    limit: number
-  ) {
-    const url = new URL('/rest/api/3/search', siteUrl);
+  private async searchRaw(siteUrl: string, auth: Auth, jql: string, limit: number) {
+    const url = new URL(`${apiBase(auth.authType)}/search`, siteUrl);
     const payload = JSON.stringify({
       jql,
       maxResults: Math.min(Math.max(limit, 1), 100),
       fields: ['summary', 'description', 'updated', 'project', 'status', 'assignee'],
     });
-    const body = await this.doRequest(url, email, token, 'POST', payload, {
+    const body = await this.doRequest(url, auth, 'POST', payload, {
       'Content-Type': 'application/json',
     });
     const data = JSON.parse(body || '{}');
     return Array.isArray(data?.issues) ? data.issues : [];
   }
 
-  private async doGet(url: URL, email: string, token: string): Promise<string> {
-    return this.doRequest(url, email, token, 'GET');
+  private async doGet(url: URL, auth: Auth): Promise<string> {
+    return this.doRequest(url, auth, 'GET');
   }
 
   private async doRequest(
     url: URL,
-    email: string,
-    token: string,
+    auth: Auth,
     method: 'GET' | 'POST',
     payload?: string,
     extraHeaders?: Record<string, string>
   ): Promise<string> {
-    const auth = encodeBasic(email, token);
     return await new Promise<string>((resolve, reject) => {
       const req = request(
         {
@@ -224,7 +238,7 @@ export default class JiraService {
           protocol: url.protocol,
           method,
           headers: {
-            Authorization: `Basic ${auth}`,
+            Authorization: authHeader(auth),
             Accept: 'application/json',
             ...(extraHeaders || {}),
           },
@@ -251,24 +265,22 @@ export default class JiraService {
     });
   }
 
-  // Enhanced search that supports direct issue-key lookups and robust quoting
   async smartSearchIssues(searchTerm: string, limit = 20): Promise<any[]> {
     const term = (searchTerm || '').trim();
     if (!term) return [];
-    const { siteUrl, email, token } = await this.requireAuth();
+    const { siteUrl, auth } = await this.requireAuth();
 
     const looksLikeKey = /^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(term);
     if (looksLikeKey) {
       const keyUpper = term.toUpperCase();
       try {
-        const issue = await this.getIssueByKey(siteUrl, email, token, keyUpper);
+        const issue = await this.getIssueByKey(siteUrl, auth, keyUpper);
         if (issue) return sortByUpdatedAtDesc(this.normalizeIssues(siteUrl, [issue]));
       } catch {
         // If direct fetch fails (404/403/etc.), falling back to JQL search below
       }
     }
 
-    // Build JQL safely (escape quotes in term)
     const sanitized = term.replace(/"/g, '\\"');
     const extraKey = looksLikeKey ? ` OR issueKey = ${term.toUpperCase()}` : '';
     const isNumeric = /^\d+$/.test(term);
@@ -277,14 +289,14 @@ export default class JiraService {
         ? ` OR key IN (${this.projectKeys.map((p) => `"${p}-${term}"`).join(',')})`
         : '';
     const jql = `text ~ "${sanitized}"${extraKey}${keyClause}`;
-    const data = await this.searchRaw(siteUrl, email, token, jql, limit);
+    const data = await this.searchRaw(siteUrl, auth, jql, limit);
     return sortByUpdatedAtDesc(this.normalizeIssues(siteUrl, data));
   }
 
-  private async fetchProjectKeys(siteUrl: string, email: string, token: string): Promise<string[]> {
+  private async fetchProjectKeys(siteUrl: string, auth: Auth): Promise<string[]> {
     try {
-      const url = new URL('/rest/api/3/project', siteUrl);
-      const body = await this.doGet(url, email, token);
+      const url = new URL(`${apiBase(auth.authType)}/project`, siteUrl);
+      const body = await this.doGet(url, auth);
       const data = JSON.parse(body || '[]');
       if (!Array.isArray(data)) return [];
       return data.map((p: any) => String(p?.key || '')).filter(Boolean);
@@ -293,31 +305,20 @@ export default class JiraService {
     }
   }
 
-  private async getIssueByKey(
-    siteUrl: string,
-    email: string,
-    token: string,
-    key: string
-  ): Promise<any | null> {
-    const url = new URL(`/rest/api/3/issue/${encodeURIComponent(key)}`, siteUrl);
+  private async getIssueByKey(siteUrl: string, auth: Auth, key: string): Promise<any | null> {
+    const url = new URL(`${apiBase(auth.authType)}/issue/${encodeURIComponent(key)}`, siteUrl);
     url.searchParams.set('fields', 'summary,description,updated,project,status,assignee');
-    const body = await this.doGet(url, email, token);
+    const body = await this.doGet(url, auth);
     const data = JSON.parse(body || '{}');
     if (!data || data.errorMessages) return null;
     return data;
   }
 
-  private async getRecentIssueKeys(
-    siteUrl: string,
-    email: string,
-    token: string,
-    limit: number
-  ): Promise<string[]> {
-    // Jira issue picker provides recent/history issue suggestions
-    const url = new URL('/rest/api/3/issue/picker', siteUrl);
+  private async getRecentIssueKeys(siteUrl: string, auth: Auth, limit: number): Promise<string[]> {
+    const url = new URL(`${apiBase(auth.authType)}/issue/picker`, siteUrl);
     url.searchParams.set('query', '');
     url.searchParams.set('currentJQL', '');
-    const body = await this.doGet(url, email, token);
+    const body = await this.doGet(url, auth);
     const data = JSON.parse(body || '{}');
     const keys: string[] = [];
     const sections = Array.isArray(data?.sections) ? data.sections : [];
@@ -339,7 +340,6 @@ export default class JiraService {
     if (node.type === 'text') return node.text || '';
     if (Array.isArray(node.content)) {
       const parts = node.content.map((c: any) => JiraService.flattenAdf(c));
-      // Add newlines between block-level nodes (paragraphs, headings, etc.)
       if (['doc', 'bulletList', 'orderedList'].includes(node.type)) {
         return parts.join('\n');
       }

--- a/src/renderer/components/IntegrationsCard.tsx
+++ b/src/renderer/components/IntegrationsCard.tsx
@@ -728,7 +728,7 @@ const IntegrationsCard: React.FC = () => {
               <DialogHeader>
                 <DialogTitle>Connect Jira</DialogTitle>
                 <DialogDescription className="text-xs">
-                  Enter your Jira site URL, email, and API token to connect.
+                  Enter your Jira site URL and credentials to connect.
                 </DialogDescription>
               </DialogHeader>
               <Separator />

--- a/src/renderer/components/IntegrationsCard.tsx
+++ b/src/renderer/components/IntegrationsCard.tsx
@@ -72,6 +72,7 @@ const IntegrationsCard: React.FC = () => {
   const [jiraSite, setJiraSite] = useState('');
   const [jiraEmail, setJiraEmail] = useState('');
   const [jiraToken, setJiraToken] = useState('');
+  const [jiraAuthType, setJiraAuthType] = useState<'basic' | 'bearer'>('basic');
   const [jiraLoading, setJiraLoading] = useState(false);
 
   // GitLab state
@@ -267,14 +268,16 @@ const IntegrationsCard: React.FC = () => {
       const api: any = window.electronAPI;
       const res = await api?.jiraSaveCredentials?.({
         siteUrl: jiraSite.trim(),
-        email: jiraEmail.trim(),
+        email: jiraAuthType === 'basic' ? jiraEmail.trim() : undefined,
         token: jiraToken.trim(),
+        authType: jiraAuthType,
       });
       if (res?.success) {
         setJiraConnected(true);
         setJiraSite('');
         setJiraEmail('');
         setJiraToken('');
+        setJiraAuthType('basic');
         setIntegrationSetupModal(null);
       } else {
         setJiraError(res?.error || 'Failed to connect.');
@@ -284,7 +287,7 @@ const IntegrationsCard: React.FC = () => {
     } finally {
       setJiraLoading(false);
     }
-  }, [jiraSite, jiraEmail, jiraToken]);
+  }, [jiraSite, jiraEmail, jiraToken, jiraAuthType]);
 
   const handleJiraDisconnect = useCallback(async () => {
     try {
@@ -734,16 +737,23 @@ const IntegrationsCard: React.FC = () => {
                   site={jiraSite}
                   email={jiraEmail}
                   token={jiraToken}
+                  authType={jiraAuthType}
                   onChange={(u) => {
                     if (typeof u.site === 'string') setJiraSite(u.site);
                     if (typeof u.email === 'string') setJiraEmail(u.email);
                     if (typeof u.token === 'string') setJiraToken(u.token);
+                    if (u.authType === 'basic' || u.authType === 'bearer')
+                      setJiraAuthType(u.authType);
                   }}
                   onClose={() => {
                     setIntegrationSetupModal(null);
                     setJiraError(null);
                   }}
-                  canSubmit={!!(jiraSite.trim() && jiraEmail.trim() && jiraToken.trim())}
+                  canSubmit={
+                    jiraAuthType === 'bearer'
+                      ? !!(jiraSite.trim() && jiraToken.trim())
+                      : !!(jiraSite.trim() && jiraEmail.trim() && jiraToken.trim())
+                  }
                   error={jiraError}
                   onSubmit={handleJiraSubmit}
                   hideHeader
@@ -767,7 +777,9 @@ const IntegrationsCard: React.FC = () => {
                   size="sm"
                   onClick={() => void handleJiraSubmit()}
                   disabled={
-                    !(jiraSite.trim() && jiraEmail.trim() && jiraToken.trim()) || jiraLoading
+                    !(jiraAuthType === 'bearer'
+                      ? jiraSite.trim() && jiraToken.trim()
+                      : jiraSite.trim() && jiraEmail.trim() && jiraToken.trim()) || jiraLoading
                   }
                 >
                   {jiraLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/src/renderer/components/TaskAdvancedSettings.tsx
+++ b/src/renderer/components/TaskAdvancedSettings.tsx
@@ -69,7 +69,12 @@ interface TaskAdvancedSettingsProps {
   selectedJiraIssue: JiraIssueSummary | null;
   onJiraIssueChange: (issue: JiraIssueSummary | null) => void;
   isJiraConnected: boolean | null;
-  onJiraConnect: (credentials: { siteUrl: string; email: string; token: string }) => Promise<void>;
+  onJiraConnect: (credentials: {
+    siteUrl: string;
+    email?: string;
+    token: string;
+    authType: 'basic' | 'bearer';
+  }) => Promise<void>;
 
   // GitLab
   selectedGitlabIssue: GitLabIssueSummary | null;
@@ -147,6 +152,7 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
   const [jiraSite, setJiraSite] = useState('');
   const [jiraEmail, setJiraEmail] = useState('');
   const [jiraToken, setJiraToken] = useState('');
+  const [jiraAuthType, setJiraAuthType] = useState<'basic' | 'bearer'>('basic');
   const [jiraConnectionError, setJiraConnectionError] = useState<string | null>(null);
 
   // GitLab setup state
@@ -187,17 +193,19 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
     try {
       await onJiraConnect({
         siteUrl: jiraSite.trim(),
-        email: jiraEmail.trim(),
+        email: jiraAuthType === 'basic' ? jiraEmail.trim() : undefined,
         token: jiraToken.trim(),
+        authType: jiraAuthType,
       });
       setJiraSetupOpen(false);
       setJiraSite('');
       setJiraEmail('');
       setJiraToken('');
+      setJiraAuthType('basic');
     } catch (error: any) {
       setJiraConnectionError(error?.message || 'Failed to connect.');
     }
-  }, [jiraSite, jiraEmail, jiraToken, onJiraConnect]);
+  }, [jiraSite, jiraEmail, jiraToken, jiraAuthType, onJiraConnect]);
 
   const handleGitlabConnect = useCallback(async () => {
     setGitlabConnectionError(null);
@@ -826,13 +834,20 @@ export const TaskAdvancedSettings: React.FC<TaskAdvancedSettingsProps> = ({
                 site={jiraSite}
                 email={jiraEmail}
                 token={jiraToken}
+                authType={jiraAuthType}
                 onChange={(u) => {
                   if (typeof u.site === 'string') setJiraSite(u.site);
                   if (typeof u.email === 'string') setJiraEmail(u.email);
                   if (typeof u.token === 'string') setJiraToken(u.token);
+                  if (u.authType === 'basic' || u.authType === 'bearer')
+                    setJiraAuthType(u.authType);
                 }}
                 onClose={() => setJiraSetupOpen(false)}
-                canSubmit={!!(jiraSite.trim() && jiraEmail.trim() && jiraToken.trim())}
+                canSubmit={
+                  jiraAuthType === 'bearer'
+                    ? !!(jiraSite.trim() && jiraToken.trim())
+                    : !!(jiraSite.trim() && jiraEmail.trim() && jiraToken.trim())
+                }
                 error={jiraConnectionError}
                 onSubmit={() => void handleJiraConnect()}
               />

--- a/src/renderer/components/hooks/useIntegrationStatus.ts
+++ b/src/renderer/components/hooks/useIntegrationStatus.ts
@@ -16,8 +16,9 @@ interface IntegrationStatus {
   isJiraConnected: boolean | null;
   handleJiraConnect: (credentials: {
     siteUrl: string;
-    email: string;
+    email?: string;
     token: string;
+    authType: 'basic' | 'bearer';
   }) => Promise<void>;
 
   // GitLab
@@ -163,7 +164,12 @@ export function useIntegrationStatus(isOpen: boolean): IntegrationStatus {
   }, [githubConnect]);
 
   const handleJiraConnect = useCallback(
-    async (credentials: { siteUrl: string; email: string; token: string }) => {
+    async (credentials: {
+      siteUrl: string;
+      email?: string;
+      token: string;
+      authType: 'basic' | 'bearer';
+    }) => {
       const api = window.electronAPI as any;
       const res = await api?.jiraSaveCredentials?.(credentials);
       if (res?.success) {

--- a/src/renderer/components/integrations/JiraSetupForm.tsx
+++ b/src/renderer/components/integrations/JiraSetupForm.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
 import { Input } from '../ui/input';
-import { Info } from 'lucide-react';
 import jiraLogo from '../../../assets/images/jira.png';
+
+type AuthType = 'basic' | 'bearer';
 
 interface Props {
   site: string;
   email: string;
   token: string;
-  onChange: (update: Partial<{ site: string; email: string; token: string }>) => void;
+  authType: AuthType;
+  onChange: (
+    update: Partial<{ site: string; email: string; token: string; authType: AuthType }>
+  ) => void;
   onSubmit: () => void | Promise<void>;
   onClose: () => void;
   canSubmit: boolean;
   error?: string | null;
-  /** When true, hides the Jira badge header (useful when rendered inside a Dialog with its own title). */
   hideHeader?: boolean;
-  /** When true, hides the footer buttons (parent e.g. Dialog provides its own DialogFooter). */
   hideFooter?: boolean;
 }
 
@@ -22,6 +24,7 @@ const JiraSetupForm: React.FC<Props> = ({
   site,
   email,
   token,
+  authType,
   onChange,
   onSubmit,
   onClose,
@@ -41,30 +44,67 @@ const JiraSetupForm: React.FC<Props> = ({
         </div>
       )}
       <div className={hideHeader ? 'grid gap-2' : 'mt-2 grid gap-2'}>
+        {/* Auth type toggle */}
+        <div className="flex overflow-hidden rounded-md border border-border/70 text-xs">
+          <button
+            type="button"
+            className={`flex-1 px-3 py-1.5 font-medium transition-colors ${
+              authType === 'basic'
+                ? 'bg-foreground text-background'
+                : 'bg-background text-muted-foreground hover:text-foreground'
+            }`}
+            onClick={() => onChange({ authType: 'basic' })}
+          >
+            API Token (Cloud)
+          </button>
+          <button
+            type="button"
+            className={`flex-1 border-l border-border/70 px-3 py-1.5 font-medium transition-colors ${
+              authType === 'bearer'
+                ? 'bg-foreground text-background'
+                : 'bg-background text-muted-foreground hover:text-foreground'
+            }`}
+            onClick={() => onChange({ authType: 'bearer' })}
+          >
+            PAT (Server/DC)
+          </button>
+        </div>
+
         <Input
           placeholder="https://your-domain.atlassian.net"
           value={site}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange({ site: e.target.value })}
           className="h-9 w-full"
         />
-        <Input
-          placeholder="Email"
-          value={email}
-          onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange({ email: e.target.value })}
-          className="h-9 w-full"
-        />
+        {authType === 'basic' && (
+          <Input
+            placeholder="Email"
+            value={email}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+              onChange({ email: e.target.value })
+            }
+            className="h-9 w-full"
+          />
+        )}
         <Input
           type="password"
-          placeholder="API token"
+          placeholder={authType === 'bearer' ? 'Personal Access Token' : 'API token'}
           value={token}
           onChange={(e: React.ChangeEvent<HTMLInputElement>) => onChange({ token: e.target.value })}
           className="h-9 w-full"
         />
       </div>
-      <p className="mt-2 text-xs text-muted-foreground">
-        Create an API token at{' '}
-        <span className="font-medium">id.atlassian.com/manage-profile/security/api-tokens</span>
-      </p>
+      {authType === 'basic' ? (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Create an API token at{' '}
+          <span className="font-medium">id.atlassian.com/manage-profile/security/api-tokens</span>
+        </p>
+      ) : (
+        <p className="mt-2 text-xs text-muted-foreground">
+          Create a PAT in your Jira profile under{' '}
+          <span className="font-medium">Profile → Personal Access Tokens</span>
+        </p>
+      )}
       {error ? (
         <p className="mt-2 text-xs text-destructive" role="alert">
           {error}

--- a/src/renderer/types/electron-api.d.ts
+++ b/src/renderer/types/electron-api.d.ts
@@ -988,8 +988,9 @@ declare global {
       // Jira integration
       jiraSaveCredentials?: (args: {
         siteUrl: string;
-        email: string;
+        email?: string;
         token: string;
+        authType?: 'basic' | 'bearer';
       }) => Promise<{ success: boolean; displayName?: string; error?: string }>;
       jiraClearCredentials?: () => Promise<{ success: boolean; error?: string }>;
       jiraCheckConnection?: () => Promise<{

--- a/src/test/main/JiraService.test.ts
+++ b/src/test/main/JiraService.test.ts
@@ -1,8 +1,19 @@
 import { beforeEach, describe, expect, it, vi, type MockInstance } from 'vitest';
+import type { ClientRequest, IncomingMessage } from 'node:http';
 
 vi.mock('electron', () => ({
   app: { getPath: () => '/tmp/test-emdash' },
 }));
+
+// Shared mocks for node:http / node:https so we can assert wire-level behavior
+// (URLs, headers) for the doRequest path. vi.hoisted is required because
+// vi.mock factories are hoisted above top-level statements.
+const { httpsRequestMock, httpRequestMock } = vi.hoisted(() => ({
+  httpsRequestMock: vi.fn(),
+  httpRequestMock: vi.fn(),
+}));
+vi.mock('node:https', () => ({ request: httpsRequestMock }));
+vi.mock('node:http', () => ({ request: httpRequestMock }));
 
 import JiraService from '../../main/services/JiraService';
 
@@ -18,6 +29,36 @@ type JiraRawIssue = {
     updated?: string | null;
   };
 };
+
+/**
+ * Fake `https.request` / `http.request` implementation that captures the
+ * options passed and immediately resolves the response callback with the
+ * provided body + status. Returns a minimal ClientRequest-like object.
+ */
+function fakeRequest(body = '{}', statusCode = 200) {
+  const captured: { options: any; body: string }[] = [];
+  const impl = (options: any, cb?: (res: IncomingMessage) => void): ClientRequest => {
+    const entry = { options, body: '' };
+    captured.push(entry);
+    const res: any = {
+      statusCode,
+      on: (event: string, handler: (...args: any[]) => void) => {
+        if (event === 'data') setTimeout(() => handler(Buffer.from(body)), 0);
+        if (event === 'end') setTimeout(() => handler(), 1);
+        return res;
+      },
+    };
+    setTimeout(() => cb?.(res as IncomingMessage), 0);
+    return {
+      on: vi.fn(),
+      write: (chunk: string) => {
+        entry.body += chunk;
+      },
+      end: vi.fn(),
+    } as unknown as ClientRequest;
+  };
+  return { impl, captured };
+}
 
 describe('JiraService sorting', () => {
   let service: JiraService;
@@ -42,23 +83,14 @@ describe('JiraService sorting', () => {
 
   it('sorts initial fetch results by updatedAt descending', async () => {
     const issues: JiraRawIssue[] = [
-      {
-        id: '1',
-        key: 'GEN-11',
-        fields: { summary: 'Older', updated: '2026-03-02T10:00:00.000Z' },
-      },
+      { id: '1', key: 'GEN-11', fields: { summary: 'Older', updated: '2026-03-02T10:00:00.000Z' } },
       {
         id: '2',
         key: 'GEN-12',
         fields: { summary: 'Newest', updated: '2026-03-04T10:00:00.000Z' },
       },
-      {
-        id: '3',
-        key: 'GEN-13',
-        fields: { summary: 'Unknown', updated: null },
-      },
+      { id: '3', key: 'GEN-13', fields: { summary: 'Unknown', updated: null } },
     ];
-
     searchRawSpy.mockResolvedValue(issues);
 
     const result = await service.initialFetch(50);
@@ -79,13 +111,8 @@ describe('JiraService sorting', () => {
         key: 'GEN-22',
         fields: { summary: 'Fresh', updated: '2026-03-05T08:00:00.000Z' },
       },
-      {
-        id: '12',
-        key: 'GEN-23',
-        fields: { summary: 'Bad date', updated: 'not-a-date' },
-      },
+      { id: '12', key: 'GEN-23', fields: { summary: 'Bad date', updated: 'not-a-date' } },
     ];
-
     searchRawSpy.mockResolvedValue(issues);
 
     const result = await service.smartSearchIssues('search term', 20);
@@ -106,13 +133,8 @@ describe('JiraService sorting', () => {
         key: 'GEN-32',
         fields: { summary: 'Newest', updated: '2026-03-06T08:00:00.000Z' },
       },
-      {
-        id: '22',
-        key: 'GEN-33',
-        fields: { summary: 'No date', updated: null },
-      },
+      { id: '22', key: 'GEN-33', fields: { summary: 'No date', updated: null } },
     ];
-
     searchRawSpy.mockResolvedValue(issues);
 
     const result = await service.searchIssues('query', 20);
@@ -122,66 +144,81 @@ describe('JiraService sorting', () => {
   });
 });
 
-describe('JiraService bearer auth', () => {
-  let service: JiraService;
-  let serviceInternals: {
-    requireAuth: () => Promise<{ siteUrl: string; auth: Auth }>;
-    doRequest: (
-      url: URL,
-      auth: Auth,
-      method: 'GET' | 'POST',
-      payload?: string,
-      extraHeaders?: Record<string, string>
-    ) => Promise<string>;
-    searchRaw: (siteUrl: string, auth: Auth, jql: string, limit: number) => Promise<JiraRawIssue[]>;
-  };
-  let requireAuthSpy: MockInstance;
-  let doRequestSpy: MockInstance;
-
-  const bearerAuth: Auth = { authType: 'bearer', token: 'my-pat' };
-
+describe('JiraService wire-level auth behavior', () => {
   beforeEach(() => {
-    service = new JiraService();
-    serviceInternals = service as unknown as typeof serviceInternals;
-    requireAuthSpy = vi.spyOn(serviceInternals, 'requireAuth').mockResolvedValue({
-      siteUrl: 'https://jira.mycompany.com',
-      auth: bearerAuth,
+    httpsRequestMock.mockReset();
+    httpRequestMock.mockReset();
+  });
+
+  it('sends Basic header and /rest/api/3 path for Cloud (basic) auth', async () => {
+    const { impl, captured } = fakeRequest('{"displayName":"Me"}');
+    httpsRequestMock.mockImplementation(impl);
+
+    const service = new JiraService() as unknown as {
+      getMyself: (siteUrl: string, auth: Auth) => Promise<any>;
+    };
+    await service.getMyself('https://acme.atlassian.net', {
+      authType: 'basic',
+      email: 'me@acme.com',
+      token: 'abc',
     });
-    doRequestSpy = vi.spyOn(serviceInternals, 'doRequest');
+
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+    expect(captured[0].options.path).toBe('/rest/api/3/myself');
+    const expected = `Basic ${Buffer.from('me@acme.com:abc').toString('base64')}`;
+    expect(captured[0].options.headers.Authorization).toBe(expected);
   });
 
-  it('uses Bearer header and /rest/api/2 path for bearer auth', async () => {
-    vi.spyOn(serviceInternals, 'searchRaw').mockResolvedValue([]);
+  it('sends Bearer header and /rest/api/2 path for Server/DC (bearer) auth', async () => {
+    const { impl, captured } = fakeRequest('{"displayName":"OnPrem"}');
+    httpsRequestMock.mockImplementation(impl);
 
-    await service.initialFetch(5);
+    const service = new JiraService() as unknown as {
+      getMyself: (siteUrl: string, auth: Auth) => Promise<any>;
+    };
+    await service.getMyself('https://jira.mycorp.com', {
+      authType: 'bearer',
+      token: 'my-pat',
+    });
 
-    expect(requireAuthSpy).toHaveBeenCalled();
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+    expect(captured[0].options.headers.Authorization).toBe('Bearer my-pat');
+    expect(captured[0].options.path).toBe('/rest/api/2/myself');
   });
 
-  it('passes bearer auth object through searchRaw', async () => {
-    const searchRawSpy = vi.spyOn(serviceInternals, 'searchRaw').mockResolvedValue([]);
+  it('preserves context path for Server/DC instances mounted under a subdirectory', async () => {
+    const { impl, captured } = fakeRequest('{"displayName":"CtxPath"}');
+    httpsRequestMock.mockImplementation(impl);
 
-    await service.searchIssues('TEST-1', 5);
+    const service = new JiraService() as unknown as {
+      getMyself: (siteUrl: string, auth: Auth) => Promise<any>;
+    };
+    await service.getMyself('https://intranet.corp.com/jira', {
+      authType: 'bearer',
+      token: 't',
+    });
 
-    expect(searchRawSpy).toHaveBeenCalledWith(
-      'https://jira.mycompany.com',
-      bearerAuth,
-      expect.any(String),
-      5
-    );
+    // The old `new URL('/path', base)` form dropped "/jira" — buildUrl must keep it
+    expect(captured[0].options.path).toBe('/jira/rest/api/2/myself');
+    expect(captured[0].options.hostname).toBe('intranet.corp.com');
   });
 
-  it('resolves /rest/api/2 base for bearer auth type', async () => {
-    // searchRaw is called with the auth object; verify the siteUrl resolves to api/2 endpoints
-    // by checking that searchRaw receives the bearer auth object unchanged
-    const searchRawSpy2 = vi.spyOn(serviceInternals, 'searchRaw').mockResolvedValue([]);
+  it('passes explicit port and selects http transport for http:// URLs', async () => {
+    const { impl, captured } = fakeRequest('{"displayName":"Dev"}');
+    httpRequestMock.mockImplementation(impl);
 
-    await service.searchIssues('foo', 3);
+    const service = new JiraService() as unknown as {
+      getMyself: (siteUrl: string, auth: Auth) => Promise<any>;
+    };
+    await service.getMyself('http://jira.internal:8080/jira', {
+      authType: 'bearer',
+      token: 't',
+    });
 
-    const [calledSiteUrl, calledAuth] = searchRawSpy2.mock.calls[0];
-    expect(calledSiteUrl).toBe('https://jira.mycompany.com');
-    expect(calledAuth).toEqual(bearerAuth);
-    expect((calledAuth as any).authType).toBe('bearer');
-    expect((calledAuth as any).email).toBeUndefined();
+    expect(httpRequestMock).toHaveBeenCalledTimes(1);
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+    expect(captured[0].options.port).toBe(8080);
+    expect(captured[0].options.protocol).toBe('http:');
+    expect(captured[0].options.path).toBe('/jira/rest/api/2/myself');
   });
 });

--- a/src/test/main/JiraService.test.ts
+++ b/src/test/main/JiraService.test.ts
@@ -221,4 +221,29 @@ describe('JiraService wire-level auth behavior', () => {
     expect(captured[0].options.protocol).toBe('http:');
     expect(captured[0].options.path).toBe('/jira/rest/api/2/myself');
   });
+
+  it('sets Content-Length header on POST requests', async () => {
+    const { impl, captured } = fakeRequest('{"issues":[]}');
+    httpsRequestMock.mockImplementation(impl);
+
+    const service = new JiraService() as unknown as {
+      searchRaw: (siteUrl: string, auth: Auth, jql: string, limit: number) => Promise<any[]>;
+    };
+    await service.searchRaw(
+      'https://jira.mycorp.com',
+      { authType: 'bearer', token: 'pat' },
+      'project = FOO',
+      10
+    );
+
+    expect(httpsRequestMock).toHaveBeenCalledTimes(1);
+    expect(captured[0].options.method).toBe('POST');
+    const expectedPayload = JSON.stringify({
+      jql: 'project = FOO',
+      maxResults: 10,
+      fields: ['summary', 'description', 'updated', 'project', 'status', 'assignee'],
+    });
+    expect(captured[0].options.headers['Content-Length']).toBe(Buffer.byteLength(expectedPayload));
+    expect(captured[0].body).toBe(expectedPayload);
+  });
 });

--- a/src/test/main/JiraService.test.ts
+++ b/src/test/main/JiraService.test.ts
@@ -6,6 +6,10 @@ vi.mock('electron', () => ({
 
 import JiraService from '../../main/services/JiraService';
 
+type Auth =
+  | { authType: 'basic'; email: string; token: string }
+  | { authType: 'bearer'; token: string };
+
 type JiraRawIssue = {
   id: string;
   key: string;
@@ -18,25 +22,20 @@ type JiraRawIssue = {
 describe('JiraService sorting', () => {
   let service: JiraService;
   let serviceInternals: {
-    requireAuth: () => Promise<{ siteUrl: string; email: string; token: string }>;
-    searchRaw: (
-      siteUrl: string,
-      email: string,
-      token: string,
-      jql: string,
-      limit: number
-    ) => Promise<JiraRawIssue[]>;
+    requireAuth: () => Promise<{ siteUrl: string; auth: Auth }>;
+    searchRaw: (siteUrl: string, auth: Auth, jql: string, limit: number) => Promise<JiraRawIssue[]>;
   };
   let requireAuthSpy: MockInstance;
   let searchRawSpy: MockInstance;
+
+  const basicAuth: Auth = { authType: 'basic', email: 'user@example.com', token: 'test-token' };
 
   beforeEach(() => {
     service = new JiraService();
     serviceInternals = service as unknown as typeof serviceInternals;
     requireAuthSpy = vi.spyOn(serviceInternals, 'requireAuth').mockResolvedValue({
       siteUrl: 'https://jira.example.com',
-      email: 'user@example.com',
-      token: 'test-token',
+      auth: basicAuth,
     });
     searchRawSpy = vi.spyOn(serviceInternals, 'searchRaw');
   });
@@ -120,5 +119,69 @@ describe('JiraService sorting', () => {
 
     expect(result.map((issue) => issue.key)).toEqual(['GEN-32', 'GEN-31', 'GEN-33']);
     expect(requireAuthSpy).toHaveBeenCalled();
+  });
+});
+
+describe('JiraService bearer auth', () => {
+  let service: JiraService;
+  let serviceInternals: {
+    requireAuth: () => Promise<{ siteUrl: string; auth: Auth }>;
+    doRequest: (
+      url: URL,
+      auth: Auth,
+      method: 'GET' | 'POST',
+      payload?: string,
+      extraHeaders?: Record<string, string>
+    ) => Promise<string>;
+    searchRaw: (siteUrl: string, auth: Auth, jql: string, limit: number) => Promise<JiraRawIssue[]>;
+  };
+  let requireAuthSpy: MockInstance;
+  let doRequestSpy: MockInstance;
+
+  const bearerAuth: Auth = { authType: 'bearer', token: 'my-pat' };
+
+  beforeEach(() => {
+    service = new JiraService();
+    serviceInternals = service as unknown as typeof serviceInternals;
+    requireAuthSpy = vi.spyOn(serviceInternals, 'requireAuth').mockResolvedValue({
+      siteUrl: 'https://jira.mycompany.com',
+      auth: bearerAuth,
+    });
+    doRequestSpy = vi.spyOn(serviceInternals, 'doRequest');
+  });
+
+  it('uses Bearer header and /rest/api/2 path for bearer auth', async () => {
+    vi.spyOn(serviceInternals, 'searchRaw').mockResolvedValue([]);
+
+    await service.initialFetch(5);
+
+    expect(requireAuthSpy).toHaveBeenCalled();
+  });
+
+  it('passes bearer auth object through searchRaw', async () => {
+    const searchRawSpy = vi.spyOn(serviceInternals, 'searchRaw').mockResolvedValue([]);
+
+    await service.searchIssues('TEST-1', 5);
+
+    expect(searchRawSpy).toHaveBeenCalledWith(
+      'https://jira.mycompany.com',
+      bearerAuth,
+      expect.any(String),
+      5
+    );
+  });
+
+  it('resolves /rest/api/2 base for bearer auth type', async () => {
+    // searchRaw is called with the auth object; verify the siteUrl resolves to api/2 endpoints
+    // by checking that searchRaw receives the bearer auth object unchanged
+    const searchRawSpy2 = vi.spyOn(serviceInternals, 'searchRaw').mockResolvedValue([]);
+
+    await service.searchIssues('foo', 3);
+
+    const [calledSiteUrl, calledAuth] = searchRawSpy2.mock.calls[0];
+    expect(calledSiteUrl).toBe('https://jira.mycompany.com');
+    expect(calledAuth).toEqual(bearerAuth);
+    expect((calledAuth as any).authType).toBe('bearer');
+    expect((calledAuth as any).email).toBeUndefined();
   });
 });


### PR DESCRIPTION
## Summary

- Adds a **PAT / Bearer** authentication mode to the Jira integration alongside the existing Atlassian Cloud API token (Basic auth) flow
- Users on **Jira Server or Data Center** can now connect using a Personal Access Token — no email required — sent as `Authorization: Bearer <token>`
- Server/DC instances use `/rest/api/2` endpoints; Cloud keeps `/rest/api/3` — selected automatically based on auth type
- Supports Jira instances mounted under a **context path** (e.g. `https://intranet.corp.com/jira`) — previously broken by `new URL('/path', base)` dropping the base path
- Supports **custom ports and `http://`** on-prem URLs — transport now switches between `node:http` and `node:https` based on protocol, and passes port explicitly
- **Fully backward-compatible**: existing `jira.json` without `authType` defaults to `basic`; basic configs without email are treated as invalid rather than silently producing a wrong credential

## What changed

| File | Change |
|---|---|
| `JiraService.ts` | `Auth` union type, `authHeader()` / `apiBase()` / `buildUrl()` / `buildAuth()` helpers; `doRequest()` uses correct transport + port; `readCreds` validates email for basic; no `!` non-null assertions |
| `jiraIpc.ts` | Accepts optional `email` + `authType`; validates email only for basic auth |
| `preload.ts` + `electron-api.d.ts` | Updated `jiraSaveCredentials` signature |
| `JiraSetupForm.tsx` | Segmented toggle "API Token (Cloud)" / "PAT (Server/DC)"; email field hidden in bearer mode |
| `IntegrationsCard.tsx` + `TaskAdvancedSettings.tsx` + `useIntegrationStatus.ts` | `jiraAuthType` state wired through; `canSubmit` relaxed for bearer |
| `JiraService.test.ts` | Wire-level tests via `vi.hoisted` mocking of `node:https`/`node:http`; asserts actual `Authorization` header, path, context-path preservation, port, and transport selection |

## Screenshot

<img width="1396" height="891" alt="Screenshot 2026-04-20 at 10 03 59 PM" src="https://github.com/user-attachments/assets/784dfdcf-6a71-472c-8f93-e056c69c2546" />


## Test plan

- [ ] **Cloud (regression):** connect with existing email + API token — should work exactly as before
- [ ] **Server/DC (new):** select "PAT (Server/DC)", enter server URL + PAT, no email — `checkConnection` returns connected, issues load
- [ ] Toggle between modes in the form — email field appears/disappears, placeholder and helper text update correctly
- [ ] Context-path instance (e.g. `https://intranet/jira`) — API requests hit `/jira/rest/api/2/…` not `/rest/api/2/…`
- [ ] `http://` + custom-port instance — uses `node:http` transport with explicit port
- [ ] Disconnect + reconnect in both modes — `jira.json` written with correct `authType`
- [ ] `pnpm run type-check && pnpm run lint && pnpm exec vitest run` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)