### PR TITLE
Add v1 beta download links to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,13 @@
     <img src="https://emdash.sh/media/readme/downloadforlinux.png" alt="Download for Linux" height="40">
   </a>
 
+  <p>
+    <strong>Emdash v1 beta is now available.</strong>
+    <a href="https://www.emdash.sh/download">Download the beta</a>
+    ·
+    <a href="https://www.emdash.sh/blog">Read the launch post</a>
+  </p>
+
 </div>
 
 <br />

--- a/README.md
+++ b/README.md
@@ -27,10 +27,11 @@
     <img src="https://emdash.sh/media/readme/downloadforlinux.png" alt="Download for Linux" height="40">
   </a>
 
+  <h3>
+    <a href="https://www.emdash.sh/download">Download the Emdash v1 beta</a>
+  </h3>
   <p>
-    <strong>Emdash v1 beta is now available.</strong>
-    <a href="https://www.emdash.sh/download">Download the beta</a>
-    ·
+    Now available for macOS, Windows, and Linux ·
     <a href="https://www.emdash.sh/blog/public-v1-beta">Read the launch post</a>
   </p>
 

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@
     <strong>Emdash v1 beta is now available.</strong>
     <a href="https://www.emdash.sh/download">Download the beta</a>
     ·
-    <a href="https://www.emdash.sh/blog">Read the launch post</a>
+    <a href="https://www.emdash.sh/blog/public-v1-beta">Read the launch post</a>
   </p>
 
 </div>


### PR DESCRIPTION
## Summary
- point README download buttons at emdash.sh/download
- add v1 beta callout with launch post link
- rename release overview CTA to the v1 beta download

## Tests
- pnpm exec prettier --check README.md
- git diff --check -- README.md

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change that adds external links; no product code or runtime behavior is affected.
> 
> **Overview**
> Updates `README.md` to add a prominent **v1 beta download** call-to-action linking to `emdash.sh/download`, along with a secondary link to the public launch blog post.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fd55df4fb80993fd4f0a34642f402eeddab215d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->