### PR TITLE
fix: strip AppImage env vars from TaskLifecycleService PTYs

### DIFF
--- a/src/main/services/TaskLifecycleService.ts
+++ b/src/main/services/TaskLifecycleService.ts
@@ -13,6 +13,7 @@ import {
 } from '@shared/lifecycle';
 import { getTaskEnvVars } from '@shared/task/envVars';
 import { log } from '../lib/logger';
+import { buildExternalToolEnv } from '../utils/childProcessEnv';
 import { execFile } from 'node:child_process';
 import { startLifecyclePty, type LifecyclePtyHandle } from './ptyManager';
 
@@ -141,7 +142,7 @@ class TaskLifecycleService extends EventEmitter {
       defaultBranch,
       portSeed: taskPath || taskId,
     });
-    return { ...process.env, ...taskEnv };
+    return { ...buildExternalToolEnv(process.env), ...taskEnv };
   }
 
   private createPhaseState(): LifecyclePhaseState {

--- a/src/main/services/TaskLifecycleService.ts
+++ b/src/main/services/TaskLifecycleService.ts
@@ -12,9 +12,9 @@ import {
   formatLifecycleLogLine,
 } from '@shared/lifecycle';
 import { getTaskEnvVars } from '@shared/task/envVars';
+import { execFile } from 'node:child_process';
 import { log } from '../lib/logger';
 import { buildExternalToolEnv } from '../utils/childProcessEnv';
-import { execFile } from 'node:child_process';
 import { startLifecyclePty, type LifecyclePtyHandle } from './ptyManager';
 
 const execFileAsync = promisify(execFile);

--- a/src/test/main/TaskLifecycleService.test.ts
+++ b/src/test/main/TaskLifecycleService.test.ts
@@ -1,4 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Real buildExternalToolEnv is used so the stripped env is asserted for real.
 
 type MockLifecyclePtyHandle = {
   pid: number | null;
@@ -509,5 +511,107 @@ describe('TaskLifecycleService', () => {
     taskLifecycleService.clearTask(taskId);
     expect(setupHandle.killed).toBe(true);
     expect(serviceAny.finitePtys.has(taskId)).toBe(false);
+  });
+
+  describe('lifecycle env sanitization (AppImage)', () => {
+    const SAVED_ENV_KEYS = [
+      'APPIMAGE',
+      'APPDIR',
+      'ARGV0',
+      'CHROME_DESKTOP',
+      'GSETTINGS_SCHEMA_DIR',
+      'OWD',
+      'PATH',
+      'LD_LIBRARY_PATH',
+      'XDG_DATA_DIRS',
+      'PYTHONHOME',
+    ] as const;
+    const originalEnv: Record<string, string | undefined> = {};
+
+    beforeEach(() => {
+      for (const key of SAVED_ENV_KEYS) originalEnv[key] = process.env[key];
+
+      process.env.APPIMAGE = '/home/user/emdash.AppImage';
+      process.env.APPDIR = '/tmp/.mount_emdashXYZ';
+      process.env.ARGV0 = 'AppRun';
+      process.env.CHROME_DESKTOP = 'emdash.desktop';
+      process.env.GSETTINGS_SCHEMA_DIR = '/tmp/.mount_emdashXYZ/usr/share/glib-2.0/schemas';
+      process.env.OWD = '/tmp';
+      process.env.PATH = '/usr/local/bin:/tmp/.mount_emdashXYZ/usr/bin:/usr/bin';
+      process.env.LD_LIBRARY_PATH = '/tmp/.mount_emdashXYZ/usr/lib:/usr/local/cuda/lib64';
+      process.env.XDG_DATA_DIRS = '/tmp/.mount_emdashXYZ/usr/share:/usr/share';
+      process.env.PYTHONHOME = '/tmp/.mount_emdashXYZ/usr';
+    });
+
+    afterEach(() => {
+      for (const key of SAVED_ENV_KEYS) {
+        if (originalEnv[key] === undefined) delete process.env[key];
+        else process.env[key] = originalEnv[key];
+      }
+    });
+
+    it('strips AppImage env vars from lifecycle setup PTY env', async () => {
+      vi.resetModules();
+
+      const handle = createLifecyclePty(4001);
+      startLifecyclePtyMock.mockReturnValue(handle);
+      getScriptMock.mockImplementation((_: string, phase: string) => {
+        if (phase === 'setup') return 'pnpm install';
+        return null;
+      });
+
+      const { taskLifecycleService } = await import('../../main/services/TaskLifecycleService');
+
+      const setupPromise = taskLifecycleService.runSetup(
+        'wt-appimage-1',
+        '/tmp/wt-appimage-1',
+        '/tmp/project'
+      );
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      handle.emitExit(0);
+      await setupPromise;
+
+      expect(startLifecyclePtyMock).toHaveBeenCalledTimes(1);
+      const passedEnv = startLifecyclePtyMock.mock.calls[0][0].env as NodeJS.ProcessEnv;
+
+      expect(passedEnv.APPIMAGE).toBeUndefined();
+      expect(passedEnv.APPDIR).toBeUndefined();
+      expect(passedEnv.ARGV0).toBeUndefined();
+      expect(passedEnv.CHROME_DESKTOP).toBeUndefined();
+      expect(passedEnv.GSETTINGS_SCHEMA_DIR).toBeUndefined();
+      expect(passedEnv.OWD).toBeUndefined();
+      expect(passedEnv.PYTHONHOME).toBeUndefined();
+
+      expect(passedEnv.PATH).toBe('/usr/local/bin:/usr/bin');
+      expect(passedEnv.LD_LIBRARY_PATH).toBe('/usr/local/cuda/lib64');
+      expect(passedEnv.XDG_DATA_DIRS).toBe('/usr/share');
+    });
+
+    it('still injects task env vars over the sanitized base env', async () => {
+      vi.resetModules();
+
+      const handle = createLifecyclePty(4002);
+      startLifecyclePtyMock.mockReturnValue(handle);
+      getScriptMock.mockImplementation((_: string, phase: string) =>
+        phase === 'setup' ? 'pnpm install' : null
+      );
+
+      const { taskLifecycleService } = await import('../../main/services/TaskLifecycleService');
+
+      const setupPromise = taskLifecycleService.runSetup(
+        'wt-appimage-2',
+        '/tmp/wt-appimage-2',
+        '/tmp/project',
+        'appimage-task'
+      );
+      await new Promise((resolve) => setTimeout(resolve, 25));
+      handle.emitExit(0);
+      await setupPromise;
+
+      const passedEnv = startLifecyclePtyMock.mock.calls[0][0].env as NodeJS.ProcessEnv;
+
+      expect(passedEnv.EMDASH_TASK_ID).toBe('wt-appimage-2');
+      expect(passedEnv.APPIMAGE).toBeUndefined();
+    });
   });
 });


### PR DESCRIPTION
## Summary

- `buildLifecycleEnv` in `TaskLifecycleService` passed raw `process.env` into lifecycle PTYs, carrying AppImage-only vars (`APPIMAGE`, `APPDIR`, `/tmp/.mount_...` entries in `PATH`/`LD_LIBRARY_PATH`/`XDG_DATA_DIRS`, `PYTHONHOME`, etc.)
- On Linux AppImage + mise, `.zshrc` runs `mise activate`, which walks `PATH`, tries to treat the AppImage binary as a shim, and aborts the shell — the configured setup command never executes
- Fix: use existing `buildExternalToolEnv` (already used in `appIpc.ts`) to sanitize the base env before merging task vars

## Test plan

- [x] New tests in `TaskLifecycleService.test.ts` verify AppImage vars are stripped and path-like vars are cleaned
- [x] Test verifies task env vars (`EMDASH_TASK_ID`) still merge over the sanitized base
- [x] Existing `childProcessEnv.test.ts` still passes
- [x] `type-check`, `lint`, `format` all pass

Closes #1750