### PR TITLE
feat: auto-detect open PRs for task worktrees

### DIFF
--- a/src/renderer/features/tasks/stores/pr-store.ts
+++ b/src/renderer/features/tasks/stores/pr-store.ts
@@ -20,6 +20,7 @@ export type MergeResult = { success: true } | { success: false; error: string };
 
 export class PrStore {
   readonly commitHistory: Resource<{ commits: Commit[]; aheadCount: number }>;
+  private readonly _taskPrLookup: Resource<void>;
 
   private _prFiles = new Map<string, Resource<GitChange[]>>();
   private _prCheckRuns = new Map<string, Resource<PrCheckRun[]>>();
@@ -28,6 +29,7 @@ export class PrStore {
   constructor(
     private readonly projectId: string,
     private readonly workspaceId: string,
+    private readonly taskId: string,
     private readonly repositoryStore: RepositoryStore,
     private readonly getPrs: () => PullRequest[]
   ) {
@@ -56,6 +58,39 @@ export class PrStore {
       ]
     );
     this.commitHistory.start();
+
+    // Auto-detect open PRs for this task's branch. The RPC persists results
+    // and emits taskPrUpdatedChannel, which task-manager uses to patch
+    // task.data.prs — there's no local data to hold here.
+    this._taskPrLookup = new Resource<void>(
+      () => this._refreshTaskPrs(),
+      [
+        {
+          kind: 'event',
+          subscribe: (handler) =>
+            events.on(gitWorkspaceChangedChannel, (p) => {
+              if (p.workspaceId === workspaceId && p.kind === 'head') handler();
+            }),
+          onEvent: 'reload',
+          debounceMs: 500,
+        },
+        {
+          kind: 'event',
+          subscribe: (handler) =>
+            events.on(gitRefChangedChannel, (p) => {
+              if (p.projectId === projectId && p.kind === 'remote-refs') handler();
+            }),
+          onEvent: 'reload',
+          debounceMs: 800,
+        },
+        { kind: 'poll', intervalMs: 60_000, pauseWhenHidden: true },
+      ]
+    );
+    this._taskPrLookup.start();
+  }
+
+  refreshPullRequestsForTask(): void {
+    this._taskPrLookup.invalidate();
   }
 
   get pullRequests(): PullRequest[] {
@@ -194,9 +229,14 @@ export class PrStore {
 
   dispose(): void {
     this.commitHistory.dispose();
+    this._taskPrLookup.dispose();
     for (const r of this._prFiles.values()) r.dispose();
     for (const r of this._prCheckRuns.values()) r.dispose();
     for (const r of this._prComments.values()) r.dispose();
+  }
+
+  private async _refreshTaskPrs(): Promise<void> {
+    await rpc.pullRequests.getPullRequestsForTask(this.projectId, this.taskId, true);
   }
 
   private async _fetchPrFiles(

--- a/src/renderer/features/tasks/stores/task.ts
+++ b/src/renderer/features/tasks/stores/task.ts
@@ -66,6 +66,7 @@ export class ProvisionedTask {
     this.workspace = workspaceRegistry.acquire(
       taskData.projectId,
       this.workspaceId,
+      taskData.id,
       repositoryStore,
       () => (this._taskData as Task).prs ?? []
     );

--- a/src/renderer/features/tasks/stores/workspace-registry.ts
+++ b/src/renderer/features/tasks/stores/workspace-registry.ts
@@ -18,6 +18,7 @@ export class WorkspaceRegistryStore {
   acquire(
     projectId: string,
     workspaceId: string,
+    taskId: string,
     repositoryStore: RepositoryStore,
     getPrs: () => PullRequest[]
   ): WorkspaceStore {
@@ -28,7 +29,7 @@ export class WorkspaceRegistryStore {
       return existing.store;
     }
 
-    const store = new WorkspaceStore(projectId, workspaceId, repositoryStore, getPrs);
+    const store = new WorkspaceStore(projectId, workspaceId, taskId, repositoryStore, getPrs);
     this.entries.set(key, { store, refCount: 1, activated: false });
     return store;
   }

--- a/src/renderer/features/tasks/stores/workspace.ts
+++ b/src/renderer/features/tasks/stores/workspace.ts
@@ -17,13 +17,14 @@ export class WorkspaceStore {
   constructor(
     projectId: string,
     workspaceId: string,
+    taskId: string,
     repositoryStore: RepositoryStore,
     getPrs: () => PullRequest[]
   ) {
     this.git = new GitStore(projectId, workspaceId, repositoryStore);
     this.files = new FilesStore(projectId, workspaceId);
     this.lifecycleScripts = new LifecycleScriptsStore(projectId, workspaceId);
-    this.pr = new PrStore(projectId, workspaceId, repositoryStore, getPrs);
+    this.pr = new PrStore(projectId, workspaceId, taskId, repositoryStore, getPrs);
     this.nameWithOwner = new Resource<string | null>(async () => {
       const result = await rpc.pullRequests.getNameWithOwner(projectId);
       return result.status === 'ready' ? result.nameWithOwner : null;

--- a/src/renderer/features/tasks/task-titlebar.tsx
+++ b/src/renderer/features/tasks/task-titlebar.tsx
@@ -26,6 +26,7 @@ import {
 } from '@renderer/features/tasks/stores/task-selectors';
 import { useProvisionedTask, useTaskViewContext } from '@renderer/features/tasks/task-view-context';
 import { RightPanelView } from '@renderer/features/tasks/types';
+import { PrBadge } from '@renderer/lib/components/pr-badge';
 import { OpenInMenu } from '@renderer/lib/components/titlebar/open-in-menu';
 import { Titlebar } from '@renderer/lib/components/titlebar/Titlebar';
 import { useDelayedBoolean } from '@renderer/lib/hooks/use-delay-boolean';
@@ -259,6 +260,9 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
               />
             </PopoverContent>
           </Popover>
+          {provisionedTask.workspace.pr.currentPr && (
+            <PrBadge pr={provisionedTask.workspace.pr.currentPr} className="ml-1" />
+          )}
           <button
             className={cn(
               'text-foreground-muted ml-1',


### PR DESCRIPTION
Tasks now auto-detect open GitHub PRs against their worktree branch and surface them in the titlebar, without the user having to open the repo-level PR list first.

- Added a `Resource<void>` in `PrStore` that calls `rpc.pullRequests.getPullRequestsForTask(..., invalidate=true)` so the existing service actually runs on its own.
- Triggers: task mount, `gitWorkspaceChangedChannel` (HEAD), `gitRefChangedChannel` (remote-refs, i.e. first push), and a 60s poll that pauses when the window is hidden.
- Threaded `taskId` through `workspaceRegistry.acquire` → `WorkspaceStore` → `PrStore` so the RPC can resolve the branch.
- Added a `<PrBadge>` chip in `ActiveTaskTitlebar` bound to `workspace.pr.currentPr`; renders only when a PR exists.
- Data propagation is unchanged: the RPC upserts and `onPrUpserted` emits `taskPrUpdatedChannel`, which `task-manager` already patches into `task.data.prs`.

## Example usage

1. Open a task whose branch already has an open PR on GitHub — the titlebar chip appears within a second of mount.
2. Push a task branch (`Push` / `Publish` in the titlebar popover), then `gh pr create --head <branch>` — the chip appears within ~1s without any UI refresh.
3. Open a PR for the branch externally via the GitHub web UI — the chip appears within ≤60s via the poll.