### PR TITLE
fix(pty): resolve race condition between direct-spawn exit handlers

### DIFF
--- a/src/main/services/ptyIpc.ts
+++ b/src/main/services/ptyIpc.ts
@@ -622,7 +622,12 @@ export function registerPtyIpc(): void {
   // When a direct-spawned CLI exits, spawn a shell so user can continue working
   setOnDirectCliExit(async (id: string, cwd: string) => {
     const wc = owners.get(id);
-    if (!wc) return;
+    if (!wc) {
+      // No owner — clean up since the ptyIpc onExit handler skipped
+      // cleanup for direct spawns.
+      removePtyRecord(id);
+      return;
+    }
 
     try {
       // Spawn a shell in the same terminal
@@ -636,6 +641,11 @@ export function registerPtyIpc(): void {
       if (!proc) {
         log.warn('ptyIpc: Failed to spawn shell after CLI exit', { id });
         killPty(id); // Clean up dead PTY record
+        safeSendToOwner(id, `pty:exit:${id}`, { exitCode: 1, signal: undefined });
+        sendPtyExitGlobal(id);
+        owners.delete(id);
+        listeners.delete(id);
+        removePtyRecord(id);
         return;
       }
 
@@ -665,6 +675,11 @@ export function registerPtyIpc(): void {
     } catch (err) {
       log.error('ptyIpc: Error spawning shell after CLI exit', { id, error: err });
       killPty(id); // Clean up dead PTY record
+      safeSendToOwner(id, `pty:exit:${id}`, { exitCode: 1, signal: undefined });
+      sendPtyExitGlobal(id);
+      owners.delete(id);
+      listeners.delete(id);
+      removePtyRecord(id);
     }
   });
 
@@ -1420,6 +1435,21 @@ export function registerPtyIpc(): void {
               signal,
               isAppQuitting ? 'app_quit' : 'process_exit'
             );
+            // Direct-spawn CLIs are replaced by a fallback shell via the
+            // onDirectCliExit callback (registered in ptyManager).  That
+            // callback is async — it calls startPty() which creates a new
+            // PTY record and re-attaches listeners.  If we run cleanup
+            // here synchronously we race with the async respawn: we'd
+            // delete the PTY record and send pty:exit before the new shell
+            // is ready, leaving the renderer with a dead terminal.
+            //
+            // So for direct spawns we only clean up listeners (the respawn
+            // callback re-adds them) and leave the PTY record + owner
+            // intact for the respawn to reuse.
+            if (!usedFallback) {
+              listeners.delete(id);
+              return;
+            }
             // Direct-spawn CLIs can be replaced immediately by a fallback shell after exit.
             // If this PTY has already been replaced, skip cleanup so we don't delete the new PTY record.
             const current = getPty(id);
@@ -1428,11 +1458,7 @@ export function registerPtyIpc(): void {
             }
             safeSendToOwner(id, `pty:exit:${id}`, { exitCode, signal });
             sendPtyExitGlobal(id);
-            // For direct spawn: keep owner (shell respawn reuses it), delete listeners (shell respawn re-adds)
-            // For fallback: clean up owner since no shell respawn happens
-            if (usedFallback) {
-              owners.delete(id);
-            }
+            owners.delete(id);
             listeners.delete(id);
             removePtyRecord(id);
           });

--- a/src/main/services/ptyManager.ts
+++ b/src/main/services/ptyManager.ts
@@ -1331,12 +1331,16 @@ export function startDirectPty(options: {
   // Store record with cwd for shell respawn after CLI exits
   ptys.set(id, { id, proc, cwd, isDirectSpawn: true, kind: 'local', cols, rows });
 
-  // When CLI exits, spawn a shell so user can continue working
+  // When CLI exits, spawn a shell so user can continue working.
+  // If no callback is registered, clean up the PTY record so it
+  // doesn't leak (the ptyIpc onExit handler skips cleanup for
+  // direct spawns, relying on the callback to handle it).
   proc.onExit(() => {
     const rec = ptys.get(id);
     if (rec?.isDirectSpawn && rec.cwd && onDirectCliExitCallback) {
-      // Spawn shell immediately after CLI exits
       onDirectCliExitCallback(id, rec.cwd);
+    } else if (rec?.isDirectSpawn && !onDirectCliExitCallback) {
+      removePtyRecord(id);
     }
   });
 

--- a/src/test/main/ptyIpc.test.ts
+++ b/src/test/main/ptyIpc.test.ts
@@ -85,9 +85,14 @@ const startPtyMock = vi.fn(async ({ id }: { id: string }) => {
 const startDirectPtyMock = vi.fn(({ id, cwd }: { id: string; cwd: string }) => {
   const proc = createMockProc();
   ptys.set(id, proc);
-  // Mimic ptyManager wiring: direct CLI exit triggers shell respawn callback first.
+  // Mimic ptyManager wiring: direct CLI exit triggers shell respawn callback,
+  // or cleans up the PTY record if no callback is registered.
   proc.onExit(() => {
-    onDirectCliExitCallback?.(id, cwd);
+    if (onDirectCliExitCallback) {
+      onDirectCliExitCallback(id, cwd);
+    } else {
+      removePtyRecordMock(id);
+    }
   });
   return proc;
 });


### PR DESCRIPTION
## Summary

Fixes a bug where keyboard input stops working in the terminal after a direct-spawned agent (e.g. Codex) exits.

## Root cause

Two `onExit` handlers fire when the agent exits:

1. `ptyManager` starts an async shell respawn via `startPty`
2. `ptyIpc` runs synchronously right after — calls `removePtyRecord(id)` and emits `pty:exit` to the renderer

Because the async respawn hasn't completed yet, the renderer receives `pty:exit` first and tears down its listeners. By the time the new shell is ready, nothing is listening anymore — so keyboard input has no effect.

## Fix

- Skip cleanup in the `ptyIpc` `onExit` handler when the exiting PTY belongs to a direct spawn, so it doesn't race with the respawn
- Let the respawn callback own the full lifecycle (including cleanup if respawn fails)

Fixes #1519