### PR TITLE
Add SSH ProxyCommand support for #1121

### DIFF
--- a/src/main/core/ssh/build-connect-config.ts
+++ b/src/main/core/ssh/build-connect-config.ts
@@ -4,6 +4,7 @@ import type { ConnectConfig } from 'ssh2';
 import { sshCredentialService } from '@main/core/ssh/ssh-credential-service';
 import { resolveIdentityAgent } from '@main/core/ssh/sshConfigParser';
 import type { SshConnectionRow } from '@main/db/schema';
+import { log } from '@main/lib/logger';
 import { parseSshConnectionMetadata } from './connection-metadata';
 import { createProxyCommandTransport, type ProxyCommandTransport } from './proxy-command';
 
@@ -33,6 +34,13 @@ export async function buildConnectConfigFromRow(
       host: row.host,
       port: row.port,
       username: row.username,
+      onDebug: (line) => {
+        log.debug('buildConnectConfigFromRow: ProxyCommand stderr', {
+          connectionId: row.id,
+          host: row.host,
+          line,
+        });
+      },
     });
     base.sock = proxyTransport.sock;
     base.cleanupTransport = proxyTransport.cleanup;

--- a/src/main/core/ssh/build-connect-config.ts
+++ b/src/main/core/ssh/build-connect-config.ts
@@ -4,14 +4,23 @@ import type { ConnectConfig } from 'ssh2';
 import { sshCredentialService } from '@main/core/ssh/ssh-credential-service';
 import { resolveIdentityAgent } from '@main/core/ssh/sshConfigParser';
 import type { SshConnectionRow } from '@main/db/schema';
+import { parseSshConnectionMetadata } from './connection-metadata';
+import { createProxyCommandTransport, type ProxyCommandTransport } from './proxy-command';
+
+export interface ManagedConnectConfig extends ConnectConfig {
+  cleanupTransport?: () => void;
+}
 
 /**
  * Build an ssh2 `ConnectConfig` from a stored `SshConnectionRow`.
  */
 export async function buildConnectConfigFromRow(
   row: SshConnectionRow
-): Promise<ConnectConfig | undefined> {
-  const base: ConnectConfig = {
+): Promise<ManagedConnectConfig | undefined> {
+  const metadata = parseSshConnectionMetadata(row.metadata);
+  let proxyTransport: ProxyCommandTransport | undefined;
+
+  const base: ManagedConnectConfig = {
     host: row.host,
     port: row.port,
     username: row.username,
@@ -19,45 +28,59 @@ export async function buildConnectConfigFromRow(
     keepaliveInterval: 60_000,
     keepaliveCountMax: 3,
   };
+  if (metadata.proxyCommand) {
+    proxyTransport = createProxyCommandTransport(metadata.proxyCommand, {
+      host: row.host,
+      port: row.port,
+      username: row.username,
+    });
+    base.sock = proxyTransport.sock;
+    base.cleanupTransport = proxyTransport.cleanup;
+  }
 
-  switch (row.authType) {
-    case 'password': {
-      const password = await sshCredentialService.getPassword(row.id);
-      if (!password) {
-        throw new Error(`No password found for SSH connection '${row.name}' (id: ${row.id})`);
+  try {
+    switch (row.authType) {
+      case 'password': {
+        const password = await sshCredentialService.getPassword(row.id);
+        if (!password) {
+          throw new Error(`No password found for SSH connection '${row.name}' (id: ${row.id})`);
+        }
+        return { ...base, password };
       }
-      return { ...base, password };
-    }
 
-    case 'key': {
-      if (!row.privateKeyPath) {
-        throw new Error(`Private key path is required for SSH connection '${row.name}'`);
+      case 'key': {
+        if (!row.privateKeyPath) {
+          throw new Error(`Private key path is required for SSH connection '${row.name}'`);
+        }
+        let keyPath = row.privateKeyPath;
+        if (keyPath.startsWith('~/')) {
+          keyPath = keyPath.replace('~', homedir());
+        } else if (keyPath === '~') {
+          keyPath = homedir();
+        }
+        const privateKey = await readFile(keyPath, 'utf-8');
+        const passphrase = await sshCredentialService.getPassphrase(row.id);
+        return { ...base, privateKey, ...(passphrase ? { passphrase } : {}) };
       }
-      let keyPath = row.privateKeyPath;
-      if (keyPath.startsWith('~/')) {
-        keyPath = keyPath.replace('~', homedir());
-      } else if (keyPath === '~') {
-        keyPath = homedir();
-      }
-      const privateKey = await readFile(keyPath, 'utf-8');
-      const passphrase = await sshCredentialService.getPassphrase(row.id);
-      return { ...base, privateKey, ...(passphrase ? { passphrase } : {}) };
-    }
 
-    case 'agent': {
-      const identityAgent = await resolveIdentityAgent(row.host);
-      const agent = identityAgent || process.env.SSH_AUTH_SOCK;
-      if (!agent) {
-        throw new Error(
-          `SSH agent socket not found for connection '${row.name}'. ` +
-            'Ensure the SSH agent is running or use key/password auth.'
-        );
+      case 'agent': {
+        const identityAgent = await resolveIdentityAgent(row.host);
+        const agent = identityAgent || process.env.SSH_AUTH_SOCK;
+        if (!agent) {
+          throw new Error(
+            `SSH agent socket not found for connection '${row.name}'. ` +
+              'Ensure the SSH agent is running or use key/password auth.'
+          );
+        }
+        return { ...base, agent };
       }
-      return { ...base, agent };
-    }
 
-    default: {
-      throw new Error(`Unsupported SSH auth type: ${(row as { authType: string }).authType}`);
+      default: {
+        throw new Error(`Unsupported SSH auth type: ${(row as { authType: string }).authType}`);
+      }
     }
+  } catch (error) {
+    proxyTransport?.cleanup();
+    throw error;
   }
 }

--- a/src/main/core/ssh/connection-metadata.ts
+++ b/src/main/core/ssh/connection-metadata.ts
@@ -1,0 +1,35 @@
+import { normalizeProxyCommand } from './proxy-command';
+
+export interface SshConnectionMetadata {
+  worktreesDir?: string;
+  proxyCommand?: string;
+}
+
+export function parseSshConnectionMetadata(metadata: string | null): SshConnectionMetadata {
+  if (!metadata) {
+    return {};
+  }
+
+  try {
+    const parsed = JSON.parse(metadata) as Record<string, unknown>;
+    return {
+      worktreesDir:
+        typeof parsed.worktreesDir === 'string' && parsed.worktreesDir.trim()
+          ? parsed.worktreesDir
+          : undefined,
+      proxyCommand:
+        typeof parsed.proxyCommand === 'string'
+          ? normalizeProxyCommand(parsed.proxyCommand)
+          : undefined,
+    };
+  } catch {
+    return {};
+  }
+}
+
+export function serializeSshConnectionMetadata(metadata: SshConnectionMetadata): string {
+  return JSON.stringify({
+    worktreesDir: metadata.worktreesDir,
+    proxyCommand: normalizeProxyCommand(metadata.proxyCommand),
+  });
+}

--- a/src/main/core/ssh/controller.ts
+++ b/src/main/core/ssh/controller.ts
@@ -9,6 +9,8 @@ import { db } from '@main/db/client';
 import { sshConnections as sshConnectionsTable, type SshConnectionInsert } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import { capture } from '@main/lib/telemetry';
+import { parseSshConnectionMetadata, serializeSshConnectionMetadata } from './connection-metadata';
+import { createProxyCommandTransport } from './proxy-command';
 import { sshConnectionManager } from './ssh-connection-manager';
 import { sshCredentialService } from './ssh-credential-service';
 import { resolveIdentityAgent } from './utils';
@@ -17,17 +19,21 @@ export const sshController = createRPCController({
   /** List all saved SSH connections (no secrets). */
   getConnections: async (): Promise<SshConfig[]> => {
     const rows = await db.select().from(sshConnectionsTable);
-    return rows.map((row) => ({
-      id: row.id,
-      name: row.name,
-      host: row.host,
-      port: row.port,
-      worktreesDir: row.metadata ? JSON.parse(row.metadata).worktreesDir : undefined,
-      username: row.username,
-      authType: row.authType as 'password' | 'key' | 'agent',
-      privateKeyPath: row.privateKeyPath ?? undefined,
-      useAgent: row.useAgent === 1,
-    }));
+    return rows.map((row) => {
+      const metadata = parseSshConnectionMetadata(row.metadata);
+      return {
+        id: row.id,
+        name: row.name,
+        host: row.host,
+        port: row.port,
+        username: row.username,
+        proxyCommand: metadata.proxyCommand,
+        worktreesDir: metadata.worktreesDir,
+        authType: row.authType as 'password' | 'key' | 'agent',
+        privateKeyPath: row.privateKeyPath ?? undefined,
+        useAgent: row.useAgent === 1,
+      };
+    });
   },
 
   /** Create or update an SSH connection, storing secrets in local secure storage. */
@@ -48,16 +54,15 @@ export const sshController = createRPCController({
 
     const { password: _p, passphrase: _pp, ...dbConfig } = config;
 
-    const metadata: Record<string, unknown> = {
-      worktreesDir: config.worktreesDir,
-    };
-
     const insertData: SshConnectionInsert = {
       id: connectionId,
       name: dbConfig.name,
       host: dbConfig.host,
       port: dbConfig.port,
-      metadata: JSON.stringify(metadata),
+      metadata: serializeSshConnectionMetadata({
+        worktreesDir: config.worktreesDir,
+        proxyCommand: config.proxyCommand,
+      }),
       username: dbConfig.username,
       authType: dbConfig.authType,
       privateKeyPath: dbConfig.privateKeyPath ?? null,
@@ -82,7 +87,12 @@ export const sshController = createRPCController({
         },
       });
 
-    return { ...dbConfig, id: connectionId, worktreesDir: config.worktreesDir };
+    return {
+      ...dbConfig,
+      id: connectionId,
+      proxyCommand: config.proxyCommand,
+      worktreesDir: config.worktreesDir,
+    };
   },
 
   /** Delete a saved SSH connection and its stored credentials. */
@@ -112,6 +122,11 @@ export const sshController = createRPCController({
       const client = new Client();
       const debugLogs: string[] = [];
       const startTime = Date.now();
+      let cleanupTransport: (() => void) | undefined;
+
+      client.on('close', () => {
+        cleanupTransport?.();
+      });
 
       client.on('ready', () => {
         const latency = Date.now() - startTime;
@@ -133,6 +148,16 @@ export const sshController = createRPCController({
           readyTimeout: 10_000,
           debug: (info: string) => debugLogs.push(info),
         };
+        if (config.proxyCommand) {
+          const proxyTransport = createProxyCommandTransport(config.proxyCommand, {
+            host: config.host,
+            port: config.port,
+            username: config.username,
+            onDebug: (line) => debugLogs.push(line),
+          });
+          connectConfig.sock = proxyTransport.sock;
+          cleanupTransport = proxyTransport.cleanup;
+        }
 
         if (config.authType === 'password') {
           connectConfig.password = config.password;
@@ -147,6 +172,7 @@ export const sshController = createRPCController({
 
         client.connect(connectConfig);
       } catch (e) {
+        cleanupTransport?.();
         capture('ssh_connection_attempted', { success: false });
         resolve({ success: false, error: (e as Error).message, debugLogs });
       }

--- a/src/main/core/ssh/proxy-command.test.ts
+++ b/src/main/core/ssh/proxy-command.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseSshConnectionMetadata,
+  serializeSshConnectionMetadata,
+} from '@main/core/ssh/connection-metadata';
+import {
+  createProxyCommandTransport,
+  interpolateProxyCommand,
+  normalizeProxyCommand,
+} from '@main/core/ssh/proxy-command';
+
+describe('normalizeProxyCommand', () => {
+  it('returns undefined for blank values and none', () => {
+    expect(normalizeProxyCommand(undefined)).toBeUndefined();
+    expect(normalizeProxyCommand('   ')).toBeUndefined();
+    expect(normalizeProxyCommand('none')).toBeUndefined();
+    expect(normalizeProxyCommand(' NoNe ')).toBeUndefined();
+  });
+
+  it('returns a trimmed command', () => {
+    expect(normalizeProxyCommand('  cloudflared access ssh --hostname %h  ')).toBe(
+      'cloudflared access ssh --hostname %h'
+    );
+  });
+});
+
+describe('interpolateProxyCommand', () => {
+  it('expands OpenSSH-style placeholders', () => {
+    expect(
+      interpolateProxyCommand('ssh jumphost -W %h:%p -l %r %%', {
+        host: 'example.com',
+        port: 2222,
+        username: 'ubuntu',
+      })
+    ).toBe('ssh jumphost -W example.com:2222 -l ubuntu %');
+  });
+
+  it('preserves literal shell metacharacters as plain text during interpolation', () => {
+    expect(
+      interpolateProxyCommand('cloudflared --hostname=%h $(echo nope)', {
+        host: 'example.com',
+        port: 2222,
+        username: 'ubuntu',
+      })
+    ).toBe('cloudflared --hostname=example.com $(echo nope)');
+  });
+});
+
+describe('createProxyCommandTransport', () => {
+  it('supports quoted arguments without invoking a shell', async () => {
+    const transport = createProxyCommandTransport(
+      'python3 -c "import sys; sys.stdout.write(\'ok\\n\'); sys.stdout.flush(); sys.stdin.read(1)"',
+      {
+        host: 'example.com',
+        port: 2222,
+        username: 'ubuntu',
+      }
+    );
+
+    const output = await new Promise<string>((resolve, reject) => {
+      const chunks: Buffer[] = [];
+
+      transport.sock.on('data', (chunk: Buffer) => {
+        chunks.push(chunk);
+        transport.cleanup();
+        resolve(Buffer.concat(chunks).toString('utf8'));
+      });
+      transport.sock.on('error', reject);
+    });
+
+    expect(output).toContain('ok');
+  });
+
+  it('rejects unmatched quotes', () => {
+    expect(() =>
+      createProxyCommandTransport('python3 -c "print(1)', {
+        host: 'example.com',
+        port: 2222,
+        username: 'ubuntu',
+      })
+    ).toThrow('unmatched');
+  });
+});
+
+describe('ssh connection metadata', () => {
+  it('serializes and parses proxyCommand and worktreesDir', () => {
+    const metadata = serializeSshConnectionMetadata({
+      proxyCommand: 'cloudflared access ssh --hostname %h',
+      worktreesDir: '/tmp/worktrees',
+    });
+
+    expect(parseSshConnectionMetadata(metadata)).toEqual({
+      proxyCommand: 'cloudflared access ssh --hostname %h',
+      worktreesDir: '/tmp/worktrees',
+    });
+  });
+
+  it('drops blank proxyCommand values', () => {
+    expect(
+      parseSshConnectionMetadata(serializeSshConnectionMetadata({ proxyCommand: '   ' }))
+    ).toEqual({
+      proxyCommand: undefined,
+      worktreesDir: undefined,
+    });
+  });
+});

--- a/src/main/core/ssh/proxy-command.ts
+++ b/src/main/core/ssh/proxy-command.ts
@@ -1,0 +1,169 @@
+import { spawn } from 'node:child_process';
+import { Duplex } from 'node:stream';
+
+export function normalizeProxyCommand(proxyCommand?: string | null): string | undefined {
+  const value = proxyCommand?.trim();
+  if (!value || value.toLowerCase() === 'none') {
+    return undefined;
+  }
+  return value;
+}
+
+export function interpolateProxyCommand(
+  value: string,
+  options: {
+    host: string;
+    port: number;
+    username: string;
+  }
+): string {
+  return value.replace(/%%|%h|%p|%r/g, (token) => {
+    switch (token) {
+      case '%%':
+        return '%';
+      case '%h':
+        return options.host;
+      case '%p':
+        return String(options.port);
+      case '%r':
+        return options.username;
+      default:
+        return token;
+    }
+  });
+}
+
+function parseProxyCommandArgs(proxyCommand: string): string[] {
+  const args: string[] = [];
+  let current = '';
+  let quote: "'" | '"' | null = null;
+  let escaping = false;
+
+  for (let index = 0; index < proxyCommand.length; index += 1) {
+    const char = proxyCommand[index];
+
+    if (escaping) {
+      current += char;
+      escaping = false;
+      continue;
+    }
+
+    if (char === '\\') {
+      escaping = true;
+      continue;
+    }
+
+    if (quote) {
+      if (char === quote) {
+        quote = null;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (/\s/.test(char)) {
+      if (current) {
+        args.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaping) {
+    current += '\\';
+  }
+
+  if (quote) {
+    throw new Error(`ProxyCommand contains an unmatched ${quote} quote`);
+  }
+
+  if (current) {
+    args.push(current);
+  }
+
+  if (args.length === 0) {
+    throw new Error('ProxyCommand is empty');
+  }
+
+  return args;
+}
+
+export interface ProxyCommandTransport {
+  sock: Duplex;
+  cleanup(): void;
+}
+
+export function createProxyCommandTransport(
+  proxyCommand: string,
+  options: {
+    host: string;
+    port: number;
+    username: string;
+    onDebug?: (line: string) => void;
+  }
+): ProxyCommandTransport {
+  const [command, ...args] = parseProxyCommandArgs(proxyCommand).map((arg) =>
+    interpolateProxyCommand(arg, options)
+  );
+  const child = spawn(command, args, {
+    shell: false,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  });
+
+  const sock = Duplex.from({
+    readable: child.stdout,
+    writable: child.stdin,
+  });
+
+  let closedByOwner = false;
+  let cleanedUp = false;
+
+  const cleanup = (): void => {
+    if (cleanedUp) return;
+    cleanedUp = true;
+    closedByOwner = true;
+    sock.destroy();
+    child.stdin.destroy();
+    child.stdout.destroy();
+    child.stderr.destroy();
+    if (!child.killed) {
+      child.kill();
+    }
+  };
+
+  child.stderr.setEncoding('utf8');
+  child.stderr.on('data', (chunk: string) => {
+    const lines = chunk
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .filter(Boolean);
+    for (const line of lines) {
+      options.onDebug?.(`[ProxyCommand] ${line}`);
+    }
+  });
+
+  child.once('error', (error) => {
+    if (closedByOwner) return;
+    sock.destroy(error);
+  });
+
+  child.once('close', (code, signal) => {
+    if (closedByOwner) return;
+    const reason =
+      signal != null
+        ? `ProxyCommand exited with signal ${signal}`
+        : `ProxyCommand exited with code ${code ?? 'unknown'}`;
+    sock.destroy(new Error(reason));
+  });
+
+  return { sock, cleanup };
+}

--- a/src/main/core/ssh/ssh-connection-manager.ts
+++ b/src/main/core/ssh/ssh-connection-manager.ts
@@ -221,7 +221,6 @@ export class SshConnectionManager extends EventEmitter {
       };
 
       client.on('error', (error: Error) => {
-        config.cleanupTransport?.();
         log.error('SshConnectionManager: connection error', {
           connectionId: id,
           error: error.message,

--- a/src/main/core/ssh/ssh-connection-manager.ts
+++ b/src/main/core/ssh/ssh-connection-manager.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'node:events';
 import { eq } from 'drizzle-orm';
-import { Client, type ConnectConfig } from 'ssh2';
+import { Client } from 'ssh2';
 import { sshConnectionEventChannel } from '@shared/events/sshEvents';
 import type { ConnectionState } from '@shared/ssh';
 import { db } from '@main/db/client';
@@ -8,7 +8,7 @@ import { sshConnections } from '@main/db/schema';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { parseRemoteEnvOutput } from '@main/utils/userEnv';
-import { buildConnectConfigFromRow } from './build-connect-config';
+import { buildConnectConfigFromRow, type ManagedConnectConfig } from './build-connect-config';
 import { SshClientProxy } from './ssh-client-proxy';
 
 // ─── Error classes ────────────────────────────────────────────────────────────
@@ -188,7 +188,7 @@ export class SshConnectionManager extends EventEmitter {
 
   // ─── Private ─────────────────────────────────────────────────────────────
 
-  private createConnection(id: string, config: ConnectConfig): Promise<SshClientProxy> {
+  private createConnection(id: string, config: ManagedConnectConfig): Promise<SshClientProxy> {
     log.info('SshConnectionManager: creating connection', {
       connectionId: id,
       host: config.host,
@@ -221,6 +221,7 @@ export class SshConnectionManager extends EventEmitter {
       };
 
       client.on('error', (error: Error) => {
+        config.cleanupTransport?.();
         log.error('SshConnectionManager: connection error', {
           connectionId: id,
           error: error.message,
@@ -242,6 +243,7 @@ export class SshConnectionManager extends EventEmitter {
       });
 
       client.on('close', () => {
+        config.cleanupTransport?.();
         log.info('SshConnectionManager: connection closed', { connectionId: id });
 
         // Only react if this client is still the one backing the proxy.

--- a/src/main/core/ssh/sshConfigParser.test.ts
+++ b/src/main/core/ssh/sshConfigParser.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const readFile = vi.fn();
+
+vi.mock('node:fs/promises', () => ({
+  readFile,
+}));
+
+vi.mock('node:os', () => ({
+  homedir: () => '/Users/tester',
+}));
+
+describe('parseSshConfigFile', () => {
+  beforeEach(() => {
+    readFile.mockReset();
+  });
+
+  it('parses ProxyCommand entries from ssh config', async () => {
+    readFile.mockResolvedValue(`
+Host edge
+  HostName edge.example.com
+  User ubuntu
+  Port 2222
+  ProxyCommand cloudflared access ssh --hostname %h
+  IdentityFile ~/.ssh/id_ed25519
+`);
+
+    const { parseSshConfigFile } = await import('./sshConfigParser');
+    await expect(parseSshConfigFile()).resolves.toEqual([
+      {
+        host: 'edge',
+        hostname: 'edge.example.com',
+        user: 'ubuntu',
+        port: 2222,
+        proxyCommand: 'cloudflared access ssh --hostname %h',
+        identityFile: '/Users/tester/.ssh/id_ed25519',
+      },
+    ]);
+  });
+});

--- a/src/main/core/ssh/sshConfigParser.test.ts
+++ b/src/main/core/ssh/sshConfigParser.test.ts
@@ -37,4 +37,20 @@ Host edge
       },
     ]);
   });
+
+  it('normalizes ProxyCommand none to an unset value', async () => {
+    readFile.mockResolvedValue(`
+Host disabled-proxy
+  HostName disabled.example.com
+  ProxyCommand none
+`);
+
+    const { parseSshConfigFile } = await import('./sshConfigParser');
+    await expect(parseSshConfigFile()).resolves.toEqual([
+      {
+        host: 'disabled-proxy',
+        hostname: 'disabled.example.com',
+      },
+    ]);
+  });
 });

--- a/src/main/core/ssh/sshConfigParser.ts
+++ b/src/main/core/ssh/sshConfigParser.ts
@@ -86,6 +86,13 @@ export async function parseSshConfigFile(): Promise<SshConfigHost[]> {
       continue;
     }
 
+    // Match ProxyCommand
+    const proxyCommandMatch = trimmed.match(/^ProxyCommand\s+(.+)$/i);
+    if (proxyCommandMatch && currentHost) {
+      currentHost.proxyCommand = proxyCommandMatch[1].trim();
+      continue;
+    }
+
     // Match IdentityFile
     const identityMatch = trimmed.match(/^IdentityFile\s+(.+)$/i);
     if (identityMatch && currentHost) {

--- a/src/main/core/ssh/sshConfigParser.ts
+++ b/src/main/core/ssh/sshConfigParser.ts
@@ -2,6 +2,7 @@ import { readFile } from 'node:fs/promises';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 import type { SshConfigHost } from '@shared/ssh';
+import { normalizeProxyCommand } from './proxy-command';
 
 /**
  * Strips surrounding quotes (single or double) from a value string.
@@ -89,7 +90,10 @@ export async function parseSshConfigFile(): Promise<SshConfigHost[]> {
     // Match ProxyCommand
     const proxyCommandMatch = trimmed.match(/^ProxyCommand\s+(.+)$/i);
     if (proxyCommandMatch && currentHost) {
-      currentHost.proxyCommand = proxyCommandMatch[1].trim();
+      const proxyCommand = normalizeProxyCommand(proxyCommandMatch[1].trim());
+      if (proxyCommand) {
+        currentHost.proxyCommand = proxyCommand;
+      }
       continue;
     }
 

--- a/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -32,6 +32,7 @@ import {
 import { Input } from '@renderer/lib/ui/input';
 import { ModalLayout } from '@renderer/lib/ui/modal-layout';
 import { RadioGroup, RadioGroupItem } from '@renderer/lib/ui/radio-group';
+import { Textarea } from '@renderer/lib/ui/textarea';
 
 export interface AddSshConnModalProps extends BaseModalProps<{ connectionId: string }> {
   initialConfig?: SshConfig;
@@ -50,6 +51,7 @@ const formSchema = z
       .min(1, 'Port must be at least 1')
       .max(65535, 'Port must be at most 65535'),
     username: z.string().min(1, 'Username is required'),
+    proxyCommand: z.string(),
     authType: z.enum(['password', 'key', 'agent']),
     password: z.string(),
     privateKeyPath: z.string(),
@@ -91,6 +93,7 @@ export function AddSshConnModal({ onSuccess, onClose, initialConfig }: AddSshCon
       host: initialConfig?.host ?? '',
       port: initialConfig?.port ?? 22,
       username: initialConfig?.username ?? '',
+      proxyCommand: initialConfig?.proxyCommand ?? '',
       authType: (initialConfig?.authType ?? 'password') as AuthType,
       password: '',
       privateKeyPath: initialConfig?.privateKeyPath ?? '',
@@ -110,6 +113,7 @@ export function AddSshConnModal({ onSuccess, onClose, initialConfig }: AddSshCon
           host: value.host,
           port: value.port,
           username: value.username,
+          proxyCommand: value.proxyCommand.trim() || undefined,
           authType: value.authType,
           privateKeyPath: value.authType === 'key' ? value.privateKeyPath : undefined,
           useAgent: value.authType === 'agent',
@@ -132,6 +136,7 @@ export function AddSshConnModal({ onSuccess, onClose, initialConfig }: AddSshCon
       host: v.host,
       port: v.port,
       username: v.username,
+      proxyCommand: v.proxyCommand.trim() || undefined,
       authType: v.authType,
       privateKeyPath: v.authType === 'key' ? v.privateKeyPath : undefined,
       useAgent: v.authType === 'agent',
@@ -297,6 +302,27 @@ export function AddSshConnModal({ onSuccess, onClose, initialConfig }: AddSshCon
                   </Field>
                 );
               }}
+            </form.Field>
+
+            <form.Field name="proxyCommand">
+              {(field) => (
+                <Field>
+                  <FieldLabel htmlFor={field.name}>ProxyCommand</FieldLabel>
+                  <Textarea
+                    id={field.name}
+                    name={field.name}
+                    value={field.state.value}
+                    onBlur={field.handleBlur}
+                    onChange={(e) => field.handleChange(e.target.value)}
+                    placeholder="Optional. Example: cloudflared access ssh --hostname %h"
+                    rows={3}
+                    className="resize-y"
+                  />
+                  <FieldDescription>
+                    Optional local command used to proxy the SSH transport before authentication.
+                  </FieldDescription>
+                </Field>
+              )}
             </form.Field>
 
             {/* Auth type */}

--- a/src/shared/ssh.ts
+++ b/src/shared/ssh.ts
@@ -8,6 +8,7 @@ export interface SshConfig {
   host: string;
   port: number;
   username: string;
+  proxyCommand?: string;
   authType: 'password' | 'key' | 'agent';
   privateKeyPath?: string;
   useAgent?: boolean;
@@ -121,6 +122,7 @@ export interface SshConfigHost {
   hostname?: string;
   user?: string;
   port?: number;
+  proxyCommand?: string;
   identityFile?: string;
   identityAgent?: string;
 }


### PR DESCRIPTION
## Summary
- add ProxyCommand support to saved SSH connection config and the add/edit SSH connection UI
- execute ProxyCommand transports for SSH test/connect flows and persist the setting in SSH metadata
- parse ProxyCommand from ~/.ssh/config and add targeted tests for metadata, parsing, and transport handling

## Testing
- ./node_modules/.bin/vitest run src/main/core/ssh/proxy-command.test.ts src/main/core/ssh/sshConfigParser.test.ts src/main/core/ssh/utils.test.ts src/renderer/lib/stores/ssh-connection-store.test.ts
- manual verification: SSH connection test succeeds locally with ProxyCommand set to nc -X 5 -x 127.0.0.1:7897 %h %p
