### PR TITLE
feat(projects): add local project icons

### DIFF
--- a/src/main/core/projects/controller.ts
+++ b/src/main/core/projects/controller.ts
@@ -1,4 +1,5 @@
 import { createRPCController } from '@shared/ipc/rpc';
+import { clearProjectIcon } from './operations/clearProjectIcon';
 import {
   createLocalProject,
   createSshProject,
@@ -10,6 +11,7 @@ import { getProjectBootstrapStatus } from './operations/getProjectBootstrapStatu
 import { getLocalProjectByPath, getProjects, getSshProjectByPath } from './operations/getProjects';
 import { getProjectSettings } from './operations/getProjectSettings';
 import { openProject } from './operations/openProject';
+import { setProjectIcon } from './operations/setProjectIcon';
 import { updateProjectConnection } from './operations/updateProjectConnection';
 import { updateProjectSettings } from './operations/updateProjectSettings';
 
@@ -27,4 +29,6 @@ export const projectController = createRPCController({
   updateProjectConnection,
   getProjectBootstrapStatus,
   openProject,
+  setProjectIcon,
+  clearProjectIcon,
 });

--- a/src/main/core/projects/icons/storage.test.ts
+++ b/src/main/core/projects/icons/storage.test.ts
@@ -1,0 +1,247 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MAX_PROJECT_ICON_BYTES } from '@shared/projects';
+import {
+  clearStoredProjectIconForProject,
+  getStoredProjectIconDataUrl,
+  setStoredProjectIconForProject,
+} from './storage';
+
+const getPathMock = vi.fn();
+const createFromBufferMock = vi.fn();
+const cropMock = vi.fn();
+const resizeMock = vi.fn();
+const toPNGMock = vi.fn();
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: (name: string) => getPathMock(name),
+  },
+  nativeImage: {
+    createFromBuffer: (bytes: Buffer) => createFromBufferMock(bytes),
+  },
+}));
+
+describe('projectIconStorage', () => {
+  let tempDir: string;
+  let userDataDir: string;
+  let sourceDir: string;
+  const iconDir = () => path.join(userDataDir, 'project-icons');
+  const indexPath = () => path.join(userDataDir, 'project-icons.json');
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'project-icon-storage-test-'));
+    userDataDir = path.join(tempDir, 'user-data');
+    sourceDir = path.join(tempDir, 'source');
+
+    fs.mkdirSync(sourceDir, { recursive: true });
+    getPathMock.mockReturnValue(userDataDir);
+
+    cropMock.mockImplementation(
+      (rect: { x: number; y: number; width: number; height: number }) => ({
+        getSize: () => ({ width: rect.width, height: rect.height }),
+        crop: cropMock,
+        resize: resizeMock,
+        toPNG: toPNGMock,
+        isEmpty: () => false,
+      })
+    );
+    resizeMock.mockImplementation(() => ({ toPNG: toPNGMock }));
+    toPNGMock.mockReturnValue(Buffer.from('normalized-project-icon'));
+    createFromBufferMock.mockImplementation((bytes: Buffer) => {
+      const lowered = bytes.toString('utf8').toLowerCase();
+      const size =
+        lowered.includes('wide') || lowered.includes('webp') || lowered.includes('replacement')
+          ? { width: 480, height: 240 }
+          : { width: 128, height: 128 };
+      return {
+        isEmpty: () => false,
+        getSize: () => size,
+        crop: cropMock,
+        resize: resizeMock,
+        toPNG: toPNGMock,
+      };
+    });
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('writes the normalized PNG and the index entry, then returns a data URL', async () => {
+    const sourcePath = path.join(sourceDir, 'icon.png');
+    fs.writeFileSync(sourcePath, Buffer.from('png-test-bytes'));
+
+    const result = await setStoredProjectIconForProject({
+      projectId: 'project-1',
+      sourcePath,
+    });
+
+    const storedFile = path.join(iconDir(), 'project-1.png');
+    expect(fs.existsSync(storedFile)).toBe(true);
+    expect(fs.readFileSync(storedFile)).toEqual(Buffer.from('normalized-project-icon'));
+    expect(JSON.parse(fs.readFileSync(indexPath(), 'utf8'))).toEqual({
+      'project-1': path.join('project-icons', 'project-1.png'),
+    });
+    expect(result.iconDataUrl).toMatch(/^data:image\/png;base64,/);
+    expect(getStoredProjectIconDataUrl('project-1')).toBe(result.iconDataUrl);
+  });
+
+  it('always normalizes uploads to png even when the source format differs', async () => {
+    const original = path.join(sourceDir, 'icon.png');
+    const replacement = path.join(sourceDir, 'icon.webp');
+    fs.writeFileSync(original, Buffer.from('original-icon'));
+    fs.writeFileSync(replacement, Buffer.from('replacement-icon'));
+
+    await setStoredProjectIconForProject({ projectId: 'project-1', sourcePath: original });
+    await setStoredProjectIconForProject({ projectId: 'project-1', sourcePath: replacement });
+
+    expect(fs.existsSync(path.join(iconDir(), 'project-1.png'))).toBe(true);
+    expect(fs.existsSync(path.join(iconDir(), 'project-1.webp'))).toBe(false);
+    expect(JSON.parse(fs.readFileSync(indexPath(), 'utf8'))).toEqual({
+      'project-1': path.join('project-icons', 'project-1.png'),
+    });
+  });
+
+  it('clears both the stored icon file and the index entry', async () => {
+    const sourcePath = path.join(sourceDir, 'icon.png');
+    fs.writeFileSync(sourcePath, Buffer.from('png-test-bytes'));
+    await setStoredProjectIconForProject({ projectId: 'project-1', sourcePath });
+
+    await clearStoredProjectIconForProject('project-1');
+
+    expect(fs.existsSync(path.join(iconDir(), 'project-1.png'))).toBe(false);
+    expect(JSON.parse(fs.readFileSync(indexPath(), 'utf8'))).toEqual({});
+    expect(getStoredProjectIconDataUrl('project-1')).toBeNull();
+  });
+
+  it('sanitizes project ids and disambiguates collisions with a short hash suffix', async () => {
+    const sourcePath = path.join(sourceDir, 'icon.png');
+    fs.writeFileSync(sourcePath, Buffer.from('png-test-bytes'));
+
+    await setStoredProjectIconForProject({ projectId: '../private repo', sourcePath });
+    await setStoredProjectIconForProject({ projectId: '..-private-repo', sourcePath });
+
+    // Both ids collapse to the `private-repo` stem under sanitization, so the
+    // hash suffix is what keeps them from overwriting each other on disk.
+    const named = fs.readdirSync(iconDir()).filter((f) => f.startsWith('private-repo'));
+    expect(named).toHaveLength(2);
+    expect(named.every((f) => /^private-repo-[0-9a-f]{8}\.png$/.test(f))).toBe(true);
+
+    // Untouched ids stay flat (no hash suffix) so existing UUID-keyed installs
+    // don't need a migration.
+    await setStoredProjectIconForProject({ projectId: 'plain-uuid-style-id', sourcePath });
+    expect(fs.existsSync(path.join(iconDir(), 'plain-uuid-style-id.png'))).toBe(true);
+  });
+
+  it('rejects files larger than 2MB before writing any state', async () => {
+    const sourcePath = path.join(sourceDir, 'icon.png');
+    fs.writeFileSync(sourcePath, Buffer.alloc(MAX_PROJECT_ICON_BYTES + 1));
+
+    await expect(
+      setStoredProjectIconForProject({ projectId: 'project-1', sourcePath })
+    ).rejects.toThrow('Project icon must be 2MB or smaller.');
+
+    expect(fs.existsSync(indexPath())).toBe(false);
+  });
+
+  it('rejects unsupported source formats before writing any state', async () => {
+    const sourcePath = path.join(sourceDir, 'icon.txt');
+    fs.writeFileSync(sourcePath, Buffer.from('not-an-image'));
+
+    await expect(
+      setStoredProjectIconForProject({ projectId: 'project-1', sourcePath })
+    ).rejects.toThrow('Unsupported icon format.');
+
+    expect(fs.existsSync(indexPath())).toBe(false);
+  });
+
+  it('rejects images that nativeImage cannot decode', async () => {
+    const sourcePath = path.join(sourceDir, 'empty.png');
+    fs.writeFileSync(sourcePath, Buffer.from('bad-png'));
+    createFromBufferMock.mockReturnValueOnce({ isEmpty: () => true });
+
+    await expect(
+      setStoredProjectIconForProject({ projectId: 'project-1', sourcePath })
+    ).rejects.toThrow('Selected icon could not be processed.');
+
+    expect(fs.existsSync(indexPath())).toBe(false);
+  });
+
+  it('center-crops non-square sources before resizing', async () => {
+    const sourcePath = path.join(sourceDir, 'wide-icon.webp');
+    fs.writeFileSync(sourcePath, Buffer.from('wide-test-bytes'));
+
+    await setStoredProjectIconForProject({ projectId: 'project-1', sourcePath });
+
+    expect(cropMock).toHaveBeenCalledWith({ x: 120, y: 0, width: 240, height: 240 });
+    expect(resizeMock).toHaveBeenCalledWith({ width: 256, height: 256, quality: 'best' });
+  });
+
+  it('returns null from the read path when the managed icon file is deleted manually', async () => {
+    const sourcePath = path.join(sourceDir, 'icon.png');
+    fs.writeFileSync(sourcePath, Buffer.from('png-test-bytes'));
+    await setStoredProjectIconForProject({ projectId: 'project-1', sourcePath });
+
+    fs.rmSync(path.join(iconDir(), 'project-1.png'), { force: true });
+
+    expect(getStoredProjectIconDataUrl('project-1')).toBeNull();
+  });
+
+  it('rejects index entries that point outside the managed icon directory', () => {
+    fs.mkdirSync(userDataDir, { recursive: true });
+    const escape = path.join(tempDir, 'outside.png');
+    fs.writeFileSync(escape, Buffer.from('escape'));
+    fs.writeFileSync(indexPath(), JSON.stringify({ 'project-1': escape }));
+
+    expect(getStoredProjectIconDataUrl('project-1')).toBeNull();
+  });
+
+  it('serializes concurrent set operations so neither update is lost', async () => {
+    const sourceA = path.join(sourceDir, 'a.png');
+    const sourceB = path.join(sourceDir, 'b.png');
+    fs.writeFileSync(sourceA, Buffer.from('a-bytes'));
+    fs.writeFileSync(sourceB, Buffer.from('b-bytes'));
+
+    await Promise.all([
+      setStoredProjectIconForProject({ projectId: 'project-a', sourcePath: sourceA }),
+      setStoredProjectIconForProject({ projectId: 'project-b', sourcePath: sourceB }),
+    ]);
+
+    const index = JSON.parse(fs.readFileSync(indexPath(), 'utf8'));
+    expect(Object.keys(index).sort()).toEqual(['project-a', 'project-b']);
+  });
+
+  it('rejects symbolic-link sources before reading their bytes', async () => {
+    const real = path.join(sourceDir, 'real.png');
+    const link = path.join(sourceDir, 'link.png');
+    fs.writeFileSync(real, Buffer.from('png-test-bytes'));
+    fs.symlinkSync(real, link);
+
+    await expect(
+      setStoredProjectIconForProject({ projectId: 'project-1', sourcePath: link })
+    ).rejects.toBeInstanceOf(Error);
+
+    expect(fs.existsSync(indexPath())).toBe(false);
+  });
+
+  it('rolls back the new file when the index write fails for a fresh project', async () => {
+    const sourcePath = path.join(sourceDir, 'icon.png');
+    fs.writeFileSync(sourcePath, Buffer.from('png-test-bytes'));
+
+    // Force the rename inside the atomic writer to fail by occupying the index
+    // path with a non-empty directory (rename onto a non-empty dir throws).
+    fs.mkdirSync(userDataDir, { recursive: true });
+    fs.mkdirSync(indexPath());
+    fs.writeFileSync(path.join(indexPath(), 'block'), '');
+
+    await expect(
+      setStoredProjectIconForProject({ projectId: 'fresh-project', sourcePath })
+    ).rejects.toBeInstanceOf(Error);
+
+    expect(fs.existsSync(path.join(iconDir(), 'fresh-project.png'))).toBe(false);
+  });
+});

--- a/src/main/core/projects/icons/storage.ts
+++ b/src/main/core/projects/icons/storage.ts
@@ -1,0 +1,279 @@
+import { createHash } from 'node:crypto';
+import fs from 'node:fs';
+import fsp from 'node:fs/promises';
+import path from 'node:path';
+import { app, nativeImage } from 'electron';
+import { MAX_PROJECT_ICON_BYTES } from '@shared/projects';
+
+const PROJECT_ICON_DIR = 'project-icons';
+const PROJECT_ICON_INDEX_FILE = 'project-icons.json';
+const NORMALIZED_PROJECT_ICON_SIZE = 256;
+const ALLOWED_SOURCE_EXTENSIONS = new Set(['.jpeg', '.jpg', '.png', '.webp']);
+
+function userDataRoot(): string {
+  return app.getPath('userData');
+}
+
+function iconRoot(): string {
+  return path.join(userDataRoot(), PROJECT_ICON_DIR);
+}
+
+function indexFilePath(): string {
+  return path.join(userDataRoot(), PROJECT_ICON_INDEX_FILE);
+}
+
+function buildIconFileStem(projectId: string): string {
+  const trimmed = projectId.trim();
+  const sanitized = trimmed.replace(/[^A-Za-z0-9_-]+/g, '-').replace(/^-+|-+$/g, '');
+  if (!sanitized) {
+    throw new Error('projectId is invalid');
+  }
+  // For ids that are already filesystem-safe (UUIDs etc.) the stem matches the
+  // raw id and stays migration-friendly. Otherwise append a short hash so two
+  // ids that collapse to the same sanitized form ("foo.bar", "foo-bar") can't
+  // overwrite each other on disk.
+  if (sanitized === trimmed) return sanitized;
+  const hash = createHash('sha1').update(projectId).digest('hex').slice(0, 8);
+  return `${sanitized}-${hash}`;
+}
+
+function resolveStoredIconAbsolutePath(relativeIconPath: string): string {
+  if (path.isAbsolute(relativeIconPath)) return relativeIconPath;
+  return path.join(userDataRoot(), relativeIconPath);
+}
+
+// Resolve symlinks via realpathSync where possible so an attacker can't slip a
+// symlink into the managed dir to escape it. Falls back to lexical resolve for
+// paths that don't yet exist (the creation-time case).
+function realpathOrResolve(target: string): string {
+  try {
+    return fs.realpathSync(target);
+  } catch {
+    return path.resolve(target);
+  }
+}
+
+function isWithinManagedDir(absolutePath: string): boolean {
+  const root = realpathOrResolve(iconRoot());
+  const resolved = realpathOrResolve(absolutePath);
+  return resolved === root || resolved.startsWith(`${root}${path.sep}`);
+}
+
+function readIndex(): Record<string, string> {
+  try {
+    if (!fs.existsSync(indexFilePath())) return {};
+    const parsed = JSON.parse(fs.readFileSync(indexFilePath(), 'utf8'));
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return {};
+    return Object.fromEntries(
+      Object.entries(parsed).filter(
+        (entry): entry is [string, string] =>
+          typeof entry[0] === 'string' && typeof entry[1] === 'string'
+      )
+    );
+  } catch {
+    return {};
+  }
+}
+
+// Cache the parsed index by mtime so a single getProjects() call doesn't
+// re-read + reparse the JSON for every project row. Writers stay on
+// readIndex() directly so their R-M-W loop never sees a stale snapshot.
+let indexReadCache: { mtimeMs: number; index: Record<string, string> } | null = null;
+function readIndexCached(): Record<string, string> {
+  try {
+    const stat = fs.statSync(indexFilePath(), { throwIfNoEntry: false });
+    if (!stat) {
+      indexReadCache = null;
+      return {};
+    }
+    if (indexReadCache && indexReadCache.mtimeMs === stat.mtimeMs) {
+      return indexReadCache.index;
+    }
+    const fresh = readIndex();
+    indexReadCache = { mtimeMs: stat.mtimeMs, index: fresh };
+    return fresh;
+  } catch {
+    return readIndex();
+  }
+}
+
+// Atomic write: serialize JSON to a sibling .tmp file then rename, so a crash
+// mid-write can't truncate the index and silently wipe every project's icon
+// mapping on the next read.
+async function writeIndexAtomic(index: Record<string, string>): Promise<void> {
+  const target = indexFilePath();
+  const tmp = `${target}.tmp`;
+  await fsp.mkdir(userDataRoot(), { recursive: true });
+  await fsp.writeFile(tmp, JSON.stringify(index, null, 2));
+  await fsp.rename(tmp, target);
+}
+
+// Serialize all index-mutating async operations through a single promise chain
+// so two concurrent IPC calls (set + clear, or two sets) cannot read the same
+// baseline and stomp each other's update.
+let indexQueue: Promise<unknown> = Promise.resolve();
+function enqueue<T>(work: () => Promise<T>): Promise<T> {
+  const next = indexQueue.then(work, work);
+  indexQueue = next.catch(() => undefined);
+  return next as Promise<T>;
+}
+
+// Cache base64 data URLs by absolute path keyed on mtime so the per-project
+// read on every getProjects() doesn't re-encode a 256x256 PNG on the
+// main-process hot path. Invalidates whenever the file is rewritten.
+const dataUrlCache = new Map<string, { mtimeMs: number; dataUrl: string }>();
+
+function readDataUrl(relativeIconPath: string): string | null {
+  const absolutePath = resolveStoredIconAbsolutePath(relativeIconPath);
+  if (!isWithinManagedDir(absolutePath)) return null;
+  const stat = fs.statSync(absolutePath, { throwIfNoEntry: false });
+  if (!stat || !stat.isFile()) return null;
+  const cached = dataUrlCache.get(absolutePath);
+  if (cached && cached.mtimeMs === stat.mtimeMs) return cached.dataUrl;
+  // The on-disk format is always PNG (the write path always emits toPNG()), so
+  // pin the served MIME instead of inferring it from the extension.
+  const data = fs.readFileSync(absolutePath);
+  const dataUrl = `data:image/png;base64,${data.toString('base64')}`;
+  dataUrlCache.set(absolutePath, { mtimeMs: stat.mtimeMs, dataUrl });
+  return dataUrl;
+}
+
+function invalidateDataUrlCache(relativeIconPath: string | null | undefined): void {
+  if (!relativeIconPath) return;
+  dataUrlCache.delete(resolveStoredIconAbsolutePath(relativeIconPath));
+}
+
+async function removeManagedIconFile(relativeIconPath: string | null | undefined): Promise<void> {
+  if (!relativeIconPath) return;
+  const absolutePath = resolveStoredIconAbsolutePath(relativeIconPath);
+  if (!isWithinManagedDir(absolutePath)) return;
+  await fsp.rm(absolutePath, { force: true });
+  invalidateDataUrlCache(relativeIconPath);
+}
+
+function renderNormalizedPng(sourceBytes: Buffer): Buffer {
+  const image = nativeImage.createFromBuffer(sourceBytes);
+  if (image.isEmpty()) {
+    throw new Error('Selected icon could not be processed.');
+  }
+  const { width, height } = image.getSize();
+  if (width <= 0 || height <= 0) {
+    throw new Error('Selected icon has invalid dimensions.');
+  }
+  const cropSize = Math.min(width, height);
+  const cropped =
+    width === height
+      ? image
+      : image.crop({
+          x: Math.max(0, Math.floor((width - cropSize) / 2)),
+          y: Math.max(0, Math.floor((height - cropSize) / 2)),
+          width: cropSize,
+          height: cropSize,
+        });
+  return cropped
+    .resize({
+      width: NORMALIZED_PROJECT_ICON_SIZE,
+      height: NORMALIZED_PROJECT_ICON_SIZE,
+      quality: 'best',
+    })
+    .toPNG();
+}
+
+async function readSourceBytesNoFollow(absoluteSourcePath: string): Promise<Buffer> {
+  // Open with O_NOFOLLOW so a symlink at the leaf throws ELOOP before any read,
+  // then stat + read from the same fd to close the TOCTOU window where a swap
+  // could happen between stat and read. fs.constants.O_NOFOLLOW is undefined
+  // on Windows; OR'ing 0 there is a no-op (Windows doesn't follow POSIX
+  // symlinks for opens anyway).
+  const noFollow = (fs.constants.O_NOFOLLOW as number | undefined) ?? 0;
+  const handle = await fsp.open(absoluteSourcePath, fs.constants.O_RDONLY | noFollow);
+  try {
+    const stat = await handle.stat();
+    if (!stat.isFile()) {
+      throw new Error('Selected icon must be a regular file.');
+    }
+    if (stat.size > MAX_PROJECT_ICON_BYTES) {
+      throw new Error('Project icon must be 2MB or smaller.');
+    }
+    return await handle.readFile();
+  } finally {
+    await handle.close();
+  }
+}
+
+/** Returns the renderer-facing data URL for a project's icon, or null. */
+export function getStoredProjectIconDataUrl(projectId: string): string | null {
+  const id = projectId?.trim();
+  if (!id) return null;
+  const relativeIconPath = readIndexCached()[id];
+  if (!relativeIconPath) return null;
+  return readDataUrl(relativeIconPath);
+}
+
+export function setStoredProjectIconForProject(args: {
+  projectId: string;
+  sourcePath: string;
+}): Promise<{ iconDataUrl: string }> {
+  return enqueue(async () => {
+    const id = args.projectId?.trim();
+    if (!id) throw new Error('projectId is required');
+    const sourcePath = args.sourcePath?.trim();
+    if (!sourcePath) throw new Error('sourcePath is required');
+
+    const absoluteSourcePath = path.resolve(sourcePath);
+    if (!ALLOWED_SOURCE_EXTENSIONS.has(path.extname(absoluteSourcePath).toLowerCase())) {
+      throw new Error('Unsupported icon format. Use PNG, JPG, or WEBP.');
+    }
+    const sourceBytes = await readSourceBytesNoFollow(absoluteSourcePath);
+
+    const stem = buildIconFileStem(id);
+    const relativeIconPath = path.join(PROJECT_ICON_DIR, `${stem}.png`);
+    const absoluteDestPath = resolveStoredIconAbsolutePath(relativeIconPath);
+    const normalizedPng = renderNormalizedPng(sourceBytes);
+
+    await fsp.mkdir(iconRoot(), { recursive: true });
+    await fsp.writeFile(absoluteDestPath, normalizedPng);
+    invalidateDataUrlCache(relativeIconPath);
+
+    const index = readIndex();
+    const previousIconPath = index[id] ?? null;
+    const wasOverwrite =
+      previousIconPath &&
+      path.resolve(resolveStoredIconAbsolutePath(previousIconPath)) ===
+        path.resolve(absoluteDestPath);
+
+    index[id] = relativeIconPath;
+    try {
+      await writeIndexAtomic(index);
+    } catch (error) {
+      // Roll back the freshly-written file (unless it overwrote the previous
+      // entry's file, in which case we'd be deleting still-indexed bytes).
+      if (!wasOverwrite) {
+        await fsp.rm(absoluteDestPath, { force: true }).catch(() => undefined);
+      }
+      throw error;
+    }
+
+    if (previousIconPath && !wasOverwrite) {
+      await removeManagedIconFile(previousIconPath).catch(() => undefined);
+    }
+
+    const dataUrl = readDataUrl(relativeIconPath);
+    if (!dataUrl) throw new Error('Failed to read newly-written project icon');
+    return { iconDataUrl: dataUrl };
+  });
+}
+
+export function clearStoredProjectIconForProject(projectId: string): Promise<void> {
+  return enqueue(async () => {
+    const id = projectId?.trim();
+    if (!id) return;
+    const index = readIndex();
+    const existing = index[id];
+    if (existing === undefined) return;
+
+    delete index[id];
+    await writeIndexAtomic(index);
+    await removeManagedIconFile(existing);
+  });
+}

--- a/src/main/core/projects/operations/clearProjectIcon.ts
+++ b/src/main/core/projects/operations/clearProjectIcon.ts
@@ -1,0 +1,8 @@
+import { clearStoredProjectIconForProject } from '../icons/storage';
+
+export async function clearProjectIcon(projectId: string): Promise<void> {
+  if (typeof projectId !== 'string' || !projectId.trim()) {
+    throw new Error('projectId is required');
+  }
+  await clearStoredProjectIconForProject(projectId.trim());
+}

--- a/src/main/core/projects/operations/createProject.ts
+++ b/src/main/core/projects/operations/createProject.ts
@@ -67,6 +67,7 @@ export async function createLocalProject(params: CreateLocalProjectParams): Prom
     name: row.name,
     path: row.path,
     baseRef: row.baseRef ?? gitInfo.baseRef,
+    iconDataUrl: null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -133,6 +134,7 @@ export async function createSshProject(params: CreateSshProjectParams): Promise<
     path: row.path,
     connectionId: params.connectionId,
     baseRef: row.baseRef ?? gitInfo.baseRef,
+    iconDataUrl: null,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/src/main/core/projects/operations/deleteProject.ts
+++ b/src/main/core/projects/operations/deleteProject.ts
@@ -1,4 +1,5 @@
 import { eq } from 'drizzle-orm';
+import { clearStoredProjectIconForProject } from '@main/core/projects/icons/storage';
 import { projectManager } from '@main/core/projects/project-manager';
 import { prSyncEngine } from '@main/core/pull-requests/pr-sync-engine';
 import { getTasks } from '@main/core/tasks/getTasks';
@@ -20,6 +21,7 @@ export async function deleteProject(id: string): Promise<void> {
   await prSyncEngine.deleteProjectData(id);
 
   await db.delete(projects).where(eq(projects.id, id));
+  await clearStoredProjectIconForProject(id).catch(() => undefined);
   void viewStateService.del(`project:${id}`);
   await projectManager.closeProject(id);
   capture('project_deleted', { project_id: id });

--- a/src/main/core/projects/operations/getProjects.ts
+++ b/src/main/core/projects/operations/getProjects.ts
@@ -1,5 +1,6 @@
 import { and, desc, eq } from 'drizzle-orm';
 import type { LocalProject, SshProject } from '@shared/projects';
+import { getStoredProjectIconDataUrl } from '@main/core/projects/icons/storage';
 import { db } from '@main/db/client';
 import { projects } from '@main/db/schema';
 
@@ -13,6 +14,7 @@ export async function getProjects(): Promise<(LocalProject | SshProject)[]> {
           name: row.name,
           path: row.path,
           baseRef: row.baseRef ?? 'main',
+          iconDataUrl: getStoredProjectIconDataUrl(row.id),
           createdAt: row.createdAt,
           updatedAt: row.updatedAt,
         }
@@ -23,6 +25,7 @@ export async function getProjects(): Promise<(LocalProject | SshProject)[]> {
           path: row.path,
           baseRef: row.baseRef ?? 'main',
           connectionId: row.sshConnectionId!,
+          iconDataUrl: getStoredProjectIconDataUrl(row.id),
           createdAt: row.createdAt,
           updatedAt: row.updatedAt,
         }
@@ -41,6 +44,7 @@ export async function getProjectById(
       name: row.name,
       path: row.path,
       baseRef: row.baseRef ?? 'main',
+      iconDataUrl: getStoredProjectIconDataUrl(row.id),
       createdAt: row.createdAt,
       updatedAt: row.updatedAt,
     };
@@ -52,6 +56,7 @@ export async function getProjectById(
     path: row.path,
     baseRef: row.baseRef ?? 'main',
     connectionId: row.sshConnectionId!,
+    iconDataUrl: getStoredProjectIconDataUrl(row.id),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -66,6 +71,7 @@ export async function getLocalProjectByPath(path: string): Promise<LocalProject 
     name: row.name,
     path: row.path,
     baseRef: row.baseRef ?? 'main',
+    iconDataUrl: getStoredProjectIconDataUrl(row.id),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -88,6 +94,7 @@ export async function getSshProjectByPath(
     path: row.path,
     baseRef: row.baseRef ?? 'main',
     connectionId: row.sshConnectionId!,
+    iconDataUrl: getStoredProjectIconDataUrl(row.id),
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/src/main/core/projects/operations/setProjectIcon.ts
+++ b/src/main/core/projects/operations/setProjectIcon.ts
@@ -1,0 +1,33 @@
+import path from 'node:path';
+import { setStoredProjectIconForProject } from '../icons/storage';
+
+function requireString(value: unknown, field: string): string {
+  if (typeof value !== 'string') {
+    throw new Error(`${field} must be a string`);
+  }
+  const trimmed = value.trim();
+  if (!trimmed) {
+    throw new Error(`${field} is required`);
+  }
+  return trimmed;
+}
+
+function requireAbsolutePath(value: unknown, field: string): string {
+  const trimmed = requireString(value, field);
+  if (!path.isAbsolute(trimmed)) {
+    throw new Error(`${field} must be an absolute path`);
+  }
+  if (trimmed.includes('\0')) {
+    throw new Error(`${field} must not contain null bytes`);
+  }
+  return trimmed;
+}
+
+export async function setProjectIcon(
+  projectId: string,
+  sourcePath: string
+): Promise<{ iconDataUrl: string }> {
+  const id = requireString(projectId, 'projectId');
+  const source = requireAbsolutePath(sourcePath, 'sourcePath');
+  return setStoredProjectIconForProject({ projectId: id, sourcePath: source });
+}

--- a/src/renderer/features/projects/components/project-avatar.tsx
+++ b/src/renderer/features/projects/components/project-avatar.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { cn } from '@renderer/utils/utils';
+
+type ProjectAvatarSize = 'sm' | 'md' | 'lg';
+
+const SIZE_CLASSES: Record<ProjectAvatarSize, string> = {
+  sm: 'h-6 w-6 rounded-md text-[10px]',
+  md: 'h-8 w-8 rounded-lg text-xs',
+  lg: 'h-14 w-14 rounded-2xl text-base',
+};
+
+interface ProjectAvatarProps {
+  iconDataUrl: string;
+  size?: ProjectAvatarSize;
+  className?: string;
+}
+
+export const ProjectAvatar: React.FC<ProjectAvatarProps> = ({
+  iconDataUrl,
+  size = 'md',
+  className,
+}) => {
+  return (
+    <span
+      className={cn(
+        'flex shrink-0 items-center justify-center overflow-hidden font-semibold text-foreground/70',
+        SIZE_CLASSES[size],
+        className
+      )}
+    >
+      <img
+        src={iconDataUrl}
+        alt=""
+        draggable={false}
+        className="block h-full w-full object-cover"
+      />
+    </span>
+  );
+};

--- a/src/renderer/features/projects/components/project-titlebar.tsx
+++ b/src/renderer/features/projects/components/project-titlebar.tsx
@@ -1,5 +1,6 @@
 import { ChevronDown, Ellipsis, ExternalLink, GithubIcon, Globe, Trash2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import { ProjectAvatar } from '@renderer/features/projects/components/project-avatar';
 import {
   asMounted,
   getProjectManagerStore,
@@ -30,7 +31,9 @@ const MountedProjectTitlebarLeft = observer(function ProjectTitlebarLeft({
 }) {
   const { navigate } = useNavigate();
   const store = getProjectStore(projectId);
+  const mounted = asMounted(store);
   const displayName = projectDisplayName(store);
+  const iconDataUrl = mounted?.data.iconDataUrl ?? null;
   const showConfirmDeleteProject = useShowModal('confirmActionModal');
 
   const repo = getRepositoryStore(projectId);
@@ -49,6 +52,9 @@ const MountedProjectTitlebarLeft = observer(function ProjectTitlebarLeft({
         <DropdownMenuTrigger
           render={
             <button className="flex items-center gap-1.5 text-foreground-muted text-sm hover:text-foreground group">
+              {iconDataUrl ? (
+                <ProjectAvatar iconDataUrl={iconDataUrl} className="h-4 w-4 rounded-sm" />
+              ) : null}
               <span className="text-sm">{displayName}</span>
               <ChevronDown className="size-3.5" />
             </button>

--- a/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
@@ -1,11 +1,16 @@
-import { Check, Loader2, Undo2 } from 'lucide-react';
+import { Check, FolderClosed, Image as ImageIcon, Loader2, Trash2, Undo2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import type { Branch } from '@shared/git';
-import type { UpdateProjectSettingsError } from '@shared/projects';
+import { MAX_PROJECT_ICON_BYTES, type UpdateProjectSettingsError } from '@shared/projects';
 import { err, type Result } from '@shared/result';
 import type { ProjectSettings } from '@main/core/projects/settings/schema';
-import { getRepositoryStore } from '@renderer/features/projects/stores/project-selectors';
+import { ProjectAvatar } from '@renderer/features/projects/components/project-avatar';
+import {
+  getProjectManagerStore,
+  getProjectStore,
+  getRepositoryStore,
+} from '@renderer/features/projects/stores/project-selectors';
 import { ProjectBranchSelector } from '@renderer/lib/components/project-branch-selector';
 import { rpc } from '@renderer/lib/ipc';
 import { Button } from '@renderer/lib/ui/button';
@@ -111,6 +116,8 @@ export interface ProjectSettingsFormProps {
 type SaveStatus = 'idle' | 'saving' | 'saved' | 'error';
 const EMPTY_REMOTES: { name: string; url: string }[] = [];
 
+type IconDraft = { kind: 'set'; sourcePath: string; previewUrl: string } | { kind: 'clear' } | null;
+
 export const ProjectSettingsForm = observer(function ProjectSettingsForm({
   projectId,
   initial,
@@ -120,6 +127,7 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
   const repo = getRepositoryStore(projectId);
   const remotes = repo?.remotes ?? EMPTY_REMOTES;
   const configuredRemote = repo?.configuredRemote.name ?? 'origin';
+  const persistedIconDataUrl = getProjectStore(projectId)?.data?.iconDataUrl ?? null;
 
   const baseline = useMemo(
     () => settingsToForm(initial, configuredRemote, remotes),
@@ -130,13 +138,34 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
   const [savedForm, setSavedForm] = useState<FormState>(baseline);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>('idle');
   const [worktreeDirectoryError, setWorktreeDirectoryError] = useState<string | null>(null);
+  const [iconDraft, setIconDraft] = useState<IconDraft>(null);
+  const [iconError, setIconError] = useState<string | null>(null);
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Revoke blob URLs when the draft changes or the form unmounts so a long
+  // session doesn't accumulate held-over preview images.
+  useEffect(() => {
+    return () => {
+      if (iconDraft?.kind === 'set') URL.revokeObjectURL(iconDraft.previewUrl);
+    };
+  }, [iconDraft]);
 
   const formSnapshot = useMemo(() => JSON.stringify(form), [form]);
   const savedSnapshot = useMemo(() => JSON.stringify(savedForm), [savedForm]);
-  const dirty = formSnapshot !== savedSnapshot;
+  const formDirty = formSnapshot !== savedSnapshot;
+  const iconDirty = iconDraft !== null;
+  const dirty = formDirty || iconDirty;
   const saving = saveStatus === 'saving';
   const saved = saveStatus === 'saved' && !dirty;
   const saveDisabled = saving || !dirty;
+
+  // Avatar source: pending preview > pending clear > persisted icon.
+  const previewIconDataUrl =
+    iconDraft?.kind === 'set'
+      ? iconDraft.previewUrl
+      : iconDraft?.kind === 'clear'
+        ? null
+        : persistedIconDataUrl;
 
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((current) => ({ ...current, [key]: value }));
@@ -146,28 +175,94 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
     }
   }
 
-  async function handleSave() {
-    const formAtSubmit = form;
-    setSaveStatus('saving');
-
-    const result = await save(formToSettings(formAtSubmit)).catch(() => err({ type: 'error' }));
-
-    if (result.success) {
-      setWorktreeDirectoryError(null);
-      setSavedForm(formAtSubmit);
-      setSaveStatus('saved');
-      onSuccess();
+  function handleFilePick(event: React.ChangeEvent<HTMLInputElement>) {
+    const file = event.target.files?.[0];
+    // Reset the input value so picking the same file twice in a row still fires onChange.
+    event.target.value = '';
+    if (!file) return;
+    if (file.size > MAX_PROJECT_ICON_BYTES) {
+      setIconError('Project icon must be 2MB or smaller.');
       return;
     }
-
-    if (result.error.type === 'invalid-worktree-directory') {
-      setWorktreeDirectoryError('Invalid worktree directory');
-      setSaveStatus('idle');
+    const sourcePath = window.electronAPI.getPathForFile(file);
+    if (!sourcePath) {
+      setIconError('Could not resolve the selected file path.');
       return;
+    }
+    setIconError(null);
+    setSaveStatus((current) => (current === 'idle' ? current : 'idle'));
+    setIconDraft({ kind: 'set', sourcePath, previewUrl: URL.createObjectURL(file) });
+  }
+
+  function handleClearIcon() {
+    setIconError(null);
+    setSaveStatus((current) => (current === 'idle' ? current : 'idle'));
+    if (persistedIconDataUrl) {
+      setIconDraft({ kind: 'clear' });
+    } else {
+      // Nothing persisted; just discard any pending pick.
+      setIconDraft(null);
+    }
+  }
+
+  function resetForm() {
+    setForm(savedForm);
+    setIconDraft(null);
+    setIconError(null);
+    setWorktreeDirectoryError(null);
+    if (saveStatus === 'error') setSaveStatus('idle');
+  }
+
+  async function handleSave() {
+    const formAtSubmit = form;
+    // Capturing the icon draft is safe because the Replace/Remove/Save
+    // buttons are all `disabled={saving}` — the user cannot mutate iconDraft
+    // mid-flight, so this captured value still equals iconDraft on completion.
+    const iconDraftAtSubmit = iconDraft;
+    setSaveStatus('saving');
+
+    if (formDirty) {
+      const result = await save(formToSettings(formAtSubmit)).catch(() => err({ type: 'error' }));
+
+      if (!result.success) {
+        if (result.error.type === 'invalid-worktree-directory') {
+          setWorktreeDirectoryError('Invalid worktree directory');
+          setSaveStatus('idle');
+          return;
+        }
+        setWorktreeDirectoryError(null);
+        setSaveStatus('error');
+        return;
+      }
+      // Commit the form baseline as soon as the JSON write succeeds, so a
+      // retry after a downstream icon failure doesn't re-write .emdash.json.
+      setSavedForm(formAtSubmit);
+    }
+
+    if (iconDraftAtSubmit) {
+      try {
+        if (iconDraftAtSubmit.kind === 'set') {
+          const { iconDataUrl: nextDataUrl } = await rpc.projects.setProjectIcon(
+            projectId,
+            iconDraftAtSubmit.sourcePath
+          );
+          getProjectManagerStore().applyProjectIconUpdate(projectId, nextDataUrl);
+        } else {
+          await rpc.projects.clearProjectIcon(projectId);
+          getProjectManagerStore().applyProjectIconUpdate(projectId, null);
+        }
+        setIconDraft(null);
+        setIconError(null);
+      } catch (e) {
+        setIconError(e instanceof Error ? e.message : 'Failed to save project icon');
+        setSaveStatus('error');
+        return;
+      }
     }
 
     setWorktreeDirectoryError(null);
-    setSaveStatus('error');
+    setSaveStatus('saved');
+    onSuccess();
   }
 
   return (
@@ -342,18 +437,67 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
               />
             </Field>
           </div>
+
+          <Separator />
+
+          <Field>
+            <FieldTitle>Project icon</FieldTitle>
+            <FieldDescription>
+              Local only. Stored in Emdash app data, not committed to the repo. PNG, JPG, or WEBP up
+              to 2MB. Center-cropped and resized to 256×256.
+            </FieldDescription>
+            <div className="flex items-center gap-4 rounded-md border p-3">
+              {previewIconDataUrl ? (
+                <ProjectAvatar
+                  iconDataUrl={previewIconDataUrl}
+                  size="md"
+                  className="shadow-sm shadow-black/5"
+                />
+              ) : (
+                <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg border border-dashed border-border/70 bg-muted/30 text-muted-foreground">
+                  <FolderClosed className="h-4 w-4" />
+                </div>
+              )}
+              <div className="min-w-0 flex-1 space-y-2">
+                <input
+                  ref={fileInputRef}
+                  type="file"
+                  accept="image/png,image/jpeg,image/webp"
+                  className="hidden"
+                  onChange={handleFilePick}
+                />
+                <div className="flex flex-wrap gap-2">
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    onClick={() => fileInputRef.current?.click()}
+                    disabled={saving}
+                  >
+                    <ImageIcon />
+                    {previewIconDataUrl ? 'Replace icon' : 'Upload icon'}
+                  </Button>
+                  {previewIconDataUrl ? (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleClearIcon}
+                      disabled={saving}
+                    >
+                      <Trash2 />
+                      Remove icon
+                    </Button>
+                  ) : null}
+                </div>
+                {iconError ? <p className="text-xs text-red-500">{iconError}</p> : null}
+              </div>
+            </div>
+          </Field>
         </FieldGroup>
       </div>
       <div className="flex justify-end gap-2 pt-5 pb-10">
-        <Button
-          variant="outline"
-          onClick={() => {
-            setForm(savedForm);
-            setWorktreeDirectoryError(null);
-            if (saveStatus === 'error') setSaveStatus('idle');
-          }}
-          disabled={!dirty || saving}
-        >
+        <Button variant="outline" onClick={resetForm} disabled={!dirty || saving}>
           <Undo2 />
         </Button>
         <ConfirmButton onClick={() => void handleSave()} disabled={saveDisabled}>

--- a/src/renderer/features/projects/stores/project-manager.ts
+++ b/src/renderer/features/projects/stores/project-manager.ts
@@ -380,6 +380,24 @@ export class ProjectManagerStore {
     this.mountProject(projectId).catch(() => {});
   }
 
+  applyProjectIconUpdate(projectId: string, iconDataUrl: string | null): void {
+    runInAction(() => {
+      const store = this.projects.get(projectId);
+      if (!store || !store.data) return;
+      // ProjectStore and MountedProject each pass `data` through their own
+      // makeAutoObservable wrapper, producing independent observable proxies
+      // over the same underlying object. A mutation through one proxy does
+      // not notify the other proxy's observers, so write through both. The
+      // field assignment is type-safe even though MountedProject.data is
+      // declared `readonly` — `readonly` blocks reassigning the reference,
+      // not mutating fields whose own type isn't readonly.
+      store.data.iconDataUrl = iconDataUrl;
+      if (store.mountedProject) {
+        store.mountedProject.data.iconDataUrl = iconDataUrl;
+      }
+    });
+  }
+
   removeUnregisteredProject(projectId: string): void {
     runInAction(() => {
       const store = this.projects.get(projectId);

--- a/src/renderer/features/sidebar/project-item.tsx
+++ b/src/renderer/features/sidebar/project-item.tsx
@@ -11,6 +11,7 @@ import {
 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import React, { useCallback, useEffect } from 'react';
+import { ProjectAvatar } from '@renderer/features/projects/components/project-avatar';
 import {
   isUnregisteredProject,
   UnregisteredProject,
@@ -92,6 +93,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
     : null;
   const canReconnect = sshConnectionState !== 'connected';
   const ProjectIcon = isSshProject ? FolderInput : FolderClosed;
+  const iconDataUrl = project.data?.iconDataUrl ?? null;
   const isReconnecting =
     sshConnectionState === 'connecting' || sshConnectionState === 'reconnecting';
   const sshStateDotClass =
@@ -138,7 +140,14 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
                   sidebarStore.toggleProjectExpanded(projectId);
                 }}
               >
-                <ProjectIcon className="absolute h-4 w-4 transition-opacity duration-150 opacity-100 group-hover/row:opacity-0" />
+                {iconDataUrl ? (
+                  <ProjectAvatar
+                    iconDataUrl={iconDataUrl}
+                    className="absolute h-4 w-4 rounded-sm transition-opacity duration-150 opacity-100 group-hover/row:opacity-0"
+                  />
+                ) : (
+                  <ProjectIcon className="absolute h-4 w-4 transition-opacity duration-150 opacity-100 group-hover/row:opacity-0" />
+                )}
                 <ChevronRight
                   className={cn(
                     'absolute h-4 w-4 transition-all duration-150 opacity-0 group-hover/row:opacity-100',

--- a/src/shared/projects.ts
+++ b/src/shared/projects.ts
@@ -1,3 +1,5 @@
+export const MAX_PROJECT_ICON_BYTES = 2 * 1024 * 1024;
+
 export type ProjectBootstrapStatus =
   | { status: 'ready' }
   | { status: 'bootstrapping' }
@@ -15,6 +17,7 @@ export type LocalProject = {
   name: string;
   path: string;
   baseRef: string;
+  iconDataUrl: string | null;
   createdAt: string;
   updatedAt: string;
 };
@@ -26,6 +29,7 @@ export type SshProject = {
   path: string;
   baseRef: string;
   connectionId: string;
+  iconDataUrl: string | null;
   createdAt: string;
   updatedAt: string;
 };


### PR DESCRIPTION
## Why

Had a small itch — agent-harness UIs are taking off and none of them (GitHub included) seem to support per-project icons. This adds a local-only, opt-in version: if you want one, you upload an image; if you don't, nothing about emdash changes.

## Summary

Per-project icon shown in the sidebar and project header. Users pick an image in the project Config modal; the main process normalizes it to a 256×256 PNG via Electron's `nativeImage` and stores it under `userData/project-icons/`, indexed by a `project-icons.json` sidecar.

Fully opt-in: projects without a custom icon render exactly as upstream — same `FolderOpen` / `FolderClosed` pair, same click-to-collapse, byte-identical default behavior.

## Screenshots

![Sidebar with project icons](https://raw.githubusercontent.com/BeelixGit/emdash/main/.pr-assets/sidebar-rounded-tiles.png)

![Config modal — Project icon section](https://raw.githubusercontent.com/BeelixGit/emdash/main/.pr-assets/config-modal-icon-section.png)

## Implementation notes

- **No DB schema changes** — icon state is a JSON sidecar alongside the DB.
- **No new dependencies.**
- Renderer transport: base64 data URLs computed in `mapDrizzleProjectRow`, cached by absolute path keyed on mtime so subsequent `getProjects()` calls don't re-encode.
- Source-file open uses `O_NOFOLLOW` (Windows-safe fallback) + buffer-based decode to close a TOCTOU symlink-swap window. Managed-dir check uses `realpathSync`. IPC args validated at the boundary. Index writes are mutex'd + atomic (`.tmp` + `rename`); a failed write rolls back the new PNG.
- Filename stems are sanitized; an 8-char SHA-1 suffix is appended only when sanitization had to alter the raw id, so existing UUID-keyed installs need no migration.
- Project deletion already calls `clearStoredProjectIconForProject`, so icon files don't outlive their rows.

## Behavior

- **Local + remote projects supported.** SSH-attached remote projects can have icons; they're stored on the local install only (the modal helper text says "Local only. Stored in Emdash app data, not committed to the repo.").
- **Accepted formats:** PNG, JPG/JPEG, WEBP. SVG is excluded because Electron's `nativeImage.createFromBuffer` doesn't decode it; users with SVG sources can convert externally.
- **Out of scope:** theme adaptation (images stored as-is), syncing across machines, a built-in glyph picker (potential follow-up).

## Test plan

- [x] `pnpm run format`, `pnpm run lint`, `pnpm run type-check`, `pnpm exec vitest run` all pass — 912/912 tests including 14 new storage tests + 2 renderer tests.
- [x] Upload / replace / clear flows through Config modal verified on macOS.
- [x] Sidebar correctly conditional-renders avatar vs default folder.
- [x] Icons persist across restarts.
- [ ] _(Maintainer)_ Windows / Linux verification welcome.
