### PR TITLE
feat(settings): toggle back from settings view

### DIFF
--- a/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -13,6 +13,7 @@ import {
   useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { modalStore } from '@renderer/lib/modal/modal-store';
 
 /**
  * Mounts global keyboard shortcut handlers for the entire application.
@@ -35,7 +36,7 @@ export function AppKeyboardShortcuts() {
   const newTaskHotkey = getEffectiveHotkey('newTask', keyboard);
 
   // Resolve current project context from whichever view is active
-  const { currentView } = useWorkspaceSlots();
+  const { currentView, previousView } = useWorkspaceSlots();
   const { params: taskParams } = useParams('task');
   const { params: projectParams } = useParams('project');
   const currentProjectId =
@@ -51,9 +52,28 @@ export function AppKeyboardShortcuts() {
     { enabled: commandPaletteHotkey !== null }
   );
 
-  useHotkey(getHotkeyRegistration('settings', keyboard), () => navigate('settings'), {
-    enabled: settingsHotkey !== null,
-  });
+  useHotkey(
+    getHotkeyRegistration('settings', keyboard),
+    () => {
+      if (currentView === 'settings') {
+        navigate(previousView ?? 'home');
+      } else {
+        navigate('settings');
+      }
+    },
+    {
+      enabled: settingsHotkey !== null,
+    }
+  );
+
+  useHotkey(
+    'Escape',
+    () => {
+      if (modalStore.isOpen) return;
+      navigate(previousView ?? 'home');
+    },
+    { enabled: currentView === 'settings', ignoreInputs: true }
+  );
 
   useHotkey(getHotkeyRegistration('toggleLeftSidebar', keyboard), () => toggleLeft(), {
     enabled: toggleLeftSidebarHotkey !== null,

--- a/src/renderer/lib/hooks/useTelemetryConsent.ts
+++ b/src/renderer/lib/hooks/useTelemetryConsent.ts
@@ -8,7 +8,41 @@ type TelemetryState = {
   loading: boolean;
 };
 
-const initialState: TelemetryState = {
+const CACHE_KEY = 'emdash:telemetry-consent-cache';
+
+const readCache = (): TelemetryState | null => {
+  try {
+    const raw = localStorage.getItem(CACHE_KEY);
+    if (!raw) return null;
+    const parsed = JSON.parse(raw) as Partial<TelemetryState>;
+    if (typeof parsed.prefEnabled !== 'boolean') return null;
+    return {
+      prefEnabled: parsed.prefEnabled,
+      envDisabled: !!parsed.envDisabled,
+      hasKeyAndHost: parsed.hasKeyAndHost !== false,
+      loading: true,
+    };
+  } catch {
+    return null;
+  }
+};
+
+const writeCache = (state: TelemetryState) => {
+  try {
+    localStorage.setItem(
+      CACHE_KEY,
+      JSON.stringify({
+        prefEnabled: state.prefEnabled,
+        envDisabled: state.envDisabled,
+        hasKeyAndHost: state.hasKeyAndHost,
+      })
+    );
+  } catch {
+    // ignore
+  }
+};
+
+const fallbackInitialState: TelemetryState = {
   prefEnabled: true,
   envDisabled: false,
   hasKeyAndHost: true,
@@ -16,18 +50,20 @@ const initialState: TelemetryState = {
 };
 
 export function useTelemetryConsent() {
-  const [state, setState] = useState<TelemetryState>(initialState);
+  const [state, setState] = useState<TelemetryState>(() => readCache() ?? fallbackInitialState);
 
   const applyStatus = useCallback(
     (res: Awaited<ReturnType<typeof rpc.telemetry.getStatus>> | null) => {
       if (res?.status) {
         const { envDisabled: envOff, userOptOut, hasKeyAndHost } = res.status;
-        setState({
+        const next: TelemetryState = {
           prefEnabled: !envOff && userOptOut !== true,
           envDisabled: !!envOff,
           hasKeyAndHost: !!hasKeyAndHost,
           loading: false,
-        });
+        };
+        writeCache(next);
+        setState(next);
       } else {
         setState((prev) => ({ ...prev, loading: false }));
       }

--- a/src/renderer/lib/layout/navigation-provider.tsx
+++ b/src/renderer/lib/layout/navigation-provider.tsx
@@ -25,6 +25,7 @@ export type SlotsContextValue = {
   MainPanel: ComponentType;
   RightPanel: ComponentType | null;
   currentView: string;
+  previousView: ViewId | null;
 };
 
 export type WrapParamsContextValue = {

--- a/src/renderer/lib/layout/provider.tsx
+++ b/src/renderer/lib/layout/provider.tsx
@@ -79,6 +79,7 @@ export function WorkspaceViewProvider({ children }: { children: ReactNode }) {
   const [viewParamsStore, setViewParamsStore] = useState<ViewParamsStore>(
     () => appState.navigation.viewParamsStore as ViewParamsStore
   );
+  const [previousViewId, setPreviousViewId] = useState<ViewId | null>(null);
   const [_, startTransition] = useTransition();
 
   // Sync React state back to the MobX persistence mirror after every commit.
@@ -120,6 +121,9 @@ export function WorkspaceViewProvider({ children }: { children: ReactNode }) {
       }
 
       startTransition(() => {
+        if (viewId !== currentViewId) {
+          setPreviousViewId(currentViewId);
+        }
         setCurrentViewId(viewId);
         // Only overwrite stored params when the caller explicitly passes them;
         // navigating without params preserves whatever was stored for that view.
@@ -158,8 +162,9 @@ export function WorkspaceViewProvider({ children }: { children: ReactNode }) {
       MainPanel: def.MainPanel,
       RightPanel: def.RightPanel ?? null,
       currentView: currentViewId,
+      previousView: previousViewId,
     };
-  }, [currentViewId]);
+  }, [currentViewId, previousViewId]);
 
   const wrapParamsValue = useMemo(
     (): WrapParamsContextValue => ({


### PR DESCRIPTION
go into the settings with cmd+, but now you can also leave them and go back to where you were (also the anon analytics toggle was flickering when quickly switching so i fixed that too)

https://github.com/user-attachments/assets/a85c0e90-34b6-4906-a616-ac7d1b1a73f6

