### PR TITLE
Allow first click to focus terminal panes

### DIFF
--- a/src/main/app/window.ts
+++ b/src/main/app/window.ts
@@ -29,7 +29,11 @@ export function createMainWindow(): BrowserWindow {
       preload: join(__dirname, '../preload/index.mjs'),
     },
     ...(process.platform === 'darwin'
-      ? { titleBarStyle: 'hiddenInset', trafficLightPosition: { x: 10, y: 10 } }
+      ? {
+          titleBarStyle: 'hiddenInset',
+          trafficLightPosition: { x: 10, y: 10 },
+          acceptFirstMouse: true,
+        }
       : {}),
     show: false,
   });


### PR DESCRIPTION
## Summary
- Enable Electron's first-mouse click-through behavior for the main window
- Allows a click on an inactive app window to reach the terminal pane so its existing focus handler can move cursor focus there

## Verification
- Ran npm run type-check; it still fails on existing unrelated renderer issues: missing framer-motion, SiCss3 import mismatch, and implicit any parameters in LeftSidebar.tsx

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a small, macOS-only `BrowserWindow` option change that affects click/focus behavior but does not touch security- or data-sensitive logic.
> 
> **Overview**
> On macOS, the main Electron `BrowserWindow` is now created with `acceptFirstMouse: true`, allowing the first click on an inactive window to be delivered to the renderer (e.g., terminal panes) instead of only activating the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 97c099b59dfad9bbc3da1d57ca48232368a67437. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->