### PR TITLE
fix project error wrapping

### DIFF
--- a/src/renderer/features/projects/components/main-panel/pending-project.tsx
+++ b/src/renderer/features/projects/components/main-panel/pending-project.tsx
@@ -35,8 +35,8 @@ export const PendingProjectStatus = observer(function PendingProjectStatus({
   };
 
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-6 p-8">
-      <div className="flex w-full max-w-sm flex-col gap-3">
+    <div className="flex min-w-0 flex-1 flex-col items-center justify-center gap-6 p-8">
+      <div className="flex w-full max-w-sm min-w-0 flex-col gap-3">
         <h2 className="mb-2 text-base">{project.name}</h2>
 
         {stages.map((stage, i) => {
@@ -69,10 +69,10 @@ export const PendingProjectStatus = observer(function PendingProjectStatus({
         })}
 
         {isError && (
-          <div className="mt-2 flex flex-col gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-3">
-            <div className="flex items-start gap-2">
+          <div className="mt-2 flex min-w-0 flex-col gap-3 rounded-md border border-destructive/40 bg-destructive/10 p-3">
+            <div className="flex min-w-0 items-start gap-2">
               <AlertCircle className="mt-0.5 h-4 w-4 shrink-0 text-destructive" />
-              <span className="text-sm text-destructive">
+              <span className="min-w-0 break-words text-sm text-destructive">
                 {project.error ?? 'An error occurred'}
               </span>
             </div>


### PR DESCRIPTION
## Summary

Fixes pending project error alerts so long repository creation errors, including unbroken GitHub API payloads and docs URLs, wrap inside the alert instead of overflowing the component.

The root cause was a long unbroken string inside nested flex containers that were not allowed to shrink. The error layout now opts into flex shrinking and applies word wrapping to the message text.

## Validation

- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm run test