### PR TITLE
fix: Change sidebar update label

### DIFF
--- a/src/renderer/features/sidebar/update-section.tsx
+++ b/src/renderer/features/sidebar/update-section.tsx
@@ -19,7 +19,7 @@ export const UpdateSection = observer(function UpdateSection() {
           })
         }
       >
-        Upgrade
+        Update
       </Button>
     );
   }


### PR DESCRIPTION
## Summary
- Change the left sidebar update pill label from "Upgrade" to "Update".
- "Upgrade" is usually used to upgrade user's payment plans instead of updating the app version. 
- "Update" is a lot more intuitive in this context

## Validation
- pnpm run format
- commit hook ran prettier and eslint on the changed file