### PR TITLE
release: remove --latest flag from v0 release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,9 +1,6 @@
-name: Release
+name: Release (v0)
 
 on:
-  push:
-    tags:
-      - 'v*'
   workflow_dispatch:
     inputs:
       arch:
@@ -257,7 +254,7 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --draft=false --prerelease=false
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes || gh release edit "$TAG" --draft=false --prerelease=false
+            gh release create "$TAG" --title "$TAG" --generate-notes --latest=false || gh release edit "$TAG" --draft=false --prerelease=false
           fi
           # Upload Linux packages and metadata
           FILES=(release/emdash-*.AppImage release/emdash-*.deb release/emdash-*.rpm)
@@ -424,7 +421,7 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --draft=false --prerelease=false
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes || gh release edit "$TAG" --draft=false --prerelease=false
+            gh release create "$TAG" --title "$TAG" --generate-notes --latest=false || gh release edit "$TAG" --draft=false --prerelease=false
           fi
           FILES=(release/emdash-*.exe release/emdash-*.msi)
           if ls release/*.blockmap >/dev/null 2>&1; then FILES+=(release/*.blockmap); fi
@@ -758,7 +755,7 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --draft=false --prerelease=false
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes || gh release edit "$TAG" --draft=false --prerelease=false
+            gh release create "$TAG" --title "$TAG" --generate-notes --latest=false || gh release edit "$TAG" --draft=false --prerelease=false
           fi
           # Upload stapled DMGs, ZIPs (for auto-update), and update files
           FILES=(release/emdash-*.dmg release/emdash-*.zip)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -257,7 +257,7 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --draft=false --prerelease=false
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes --latest || gh release edit "$TAG" --draft=false --prerelease=false
+            gh release create "$TAG" --title "$TAG" --generate-notes || gh release edit "$TAG" --draft=false --prerelease=false
           fi
           # Upload Linux packages and metadata
           FILES=(release/emdash-*.AppImage release/emdash-*.deb release/emdash-*.rpm)
@@ -424,7 +424,7 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --draft=false --prerelease=false
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes --latest || gh release edit "$TAG" --draft=false --prerelease=false
+            gh release create "$TAG" --title "$TAG" --generate-notes || gh release edit "$TAG" --draft=false --prerelease=false
           fi
           FILES=(release/emdash-*.exe release/emdash-*.msi)
           if ls release/*.blockmap >/dev/null 2>&1; then FILES+=(release/*.blockmap); fi
@@ -758,7 +758,7 @@ jobs:
           if gh release view "$TAG" >/dev/null 2>&1; then
             gh release edit "$TAG" --draft=false --prerelease=false
           else
-            gh release create "$TAG" --title "$TAG" --generate-notes --latest || gh release edit "$TAG" --draft=false --prerelease=false
+            gh release create "$TAG" --title "$TAG" --generate-notes || gh release edit "$TAG" --draft=false --prerelease=false
           fi
           # Upload stapled DMGs, ZIPs (for auto-update), and update files
           FILES=(release/emdash-*.dmg release/emdash-*.zip)


### PR DESCRIPTION
Removes --latest from gh release create in all 3 release jobs (Linux, Windows, Mac). v0 releases will no longer be marked as "Latest" on GitHub, so v1 releases on main keep that badge. No other changes to the release workflow.   