### PR TITLE
Fix README download links

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,19 +50,19 @@ Connect to remote machines via SSH/SFTP to work with remote codebases. Emdash su
 # Installation
 
 ### macOS
-- Apple Silicon: https://github.com/generalaction/emdash/releases/latest/download/emdash-arm64.dmg
-- Intel x64: https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.dmg
+- Apple Silicon: https://releases.emdash.sh/emdash-arm64.dmg
+- Intel x64: https://releases.emdash.sh/emdash-x64.dmg
 
 [![Homebrew](https://img.shields.io/badge/-Homebrew-000000?style=for-the-badge&logo=homebrew&logoColor=FBB040)](https://formulae.brew.sh/cask/emdash)
 > macOS users can also: `brew install --cask emdash`
 
 ### Windows
-- Installer (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.msi
-- Portable (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.exe
+- Installer (x64): https://releases.emdash.sh/emdash-x64.msi
+- Portable (x64): https://releases.emdash.sh/emdash-x64.exe
 
 ### Linux
-- AppImage (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-x86_64.AppImage
-- Debian package (x64): https://github.com/generalaction/emdash/releases/latest/download/emdash-amd64.deb
+- AppImage (x64): https://releases.emdash.sh/emdash-x86_64.AppImage
+- Debian package (x64): https://releases.emdash.sh/emdash-amd64.deb
 
 ### Release Overview
 


### PR DESCRIPTION
## Summary
- updates README installation links to use releases.emdash.sh direct downloads
- keeps the existing platform labels for macOS, Windows, and Linux installers

## Validation
- verified all six release URLs return HTTP 200
- checked file signatures for DMG, EXE, MSI, AppImage, and DEB artifacts

Tests not run: docs-only change.