### PR TITLE
fix: windows issues

### DIFF
--- a/src/main/core/agent-hooks/agent-notify-command.test.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it, vi } from 'vitest';
+import { makeCodexNotifyCommand } from './agent-notify-command';
+
+describe('makeCodexNotifyCommand', () => {
+  it('writes the Windows notify script only once per script path', () => {
+    const writeFile = vi.fn();
+    const mkdir = vi.fn();
+    const scriptPath = 'C:\\Temp\\emdash-codex-notify.ps1';
+
+    makeCodexNotifyCommand({ platform: 'win32', scriptPath, mkdir, writeFile });
+    makeCodexNotifyCommand({ platform: 'win32', scriptPath, mkdir, writeFile });
+
+    expect(mkdir).toHaveBeenCalledTimes(1);
+    expect(writeFile).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/core/agent-hooks/agent-notify-command.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.ts
@@ -10,6 +10,8 @@ export type CodexNotifyCommandOptions = {
   scriptPath?: string;
 };
 
+const ensuredWindowsCodexNotifyScriptPaths = new Set<string>();
+
 export function makeClaudeHookCommand(eventType: string): string {
   return (
     'curl -sf -X POST ' +
@@ -59,6 +61,10 @@ function windowsCodexNotifyScript(): string {
 function ensureWindowsCodexNotifyScript(options: CodexNotifyCommandOptions): string {
   const platform = options.platform ?? process.platform;
   const scriptPath = options.scriptPath ?? join(tmpdir(), 'emdash-codex-notify.ps1');
+  if (ensuredWindowsCodexNotifyScriptPaths.has(scriptPath)) {
+    return scriptPath;
+  }
+
   const scriptDir = platform === 'win32' ? win32.dirname(scriptPath) : dirname(scriptPath);
   const mkdir = options.mkdir ?? ((path: string) => mkdirSync(path, { recursive: true }));
   const writeFile = options.writeFile ?? writeFileSync;
@@ -66,6 +72,7 @@ function ensureWindowsCodexNotifyScript(options: CodexNotifyCommandOptions): str
   try {
     mkdir(scriptDir);
     writeFile(scriptPath, windowsCodexNotifyScript());
+    ensuredWindowsCodexNotifyScriptPaths.add(scriptPath);
   } catch (err) {
     log.warn('CodexNotifyCommand: failed to write Windows notify script', {
       path: scriptPath,

--- a/src/main/core/agent-hooks/agent-notify-command.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, win32 } from 'node:path';
+import { log } from '@main/lib/logger';
+
+export type CodexNotifyCommandOptions = {
+  platform?: NodeJS.Platform;
+  writeFile?: (path: string, content: string) => void;
+  mkdir?: (path: string) => void;
+  scriptPath?: string;
+};
+
+export function makeClaudeHookCommand(eventType: string): string {
+  return (
+    'curl -sf -X POST ' +
+    '-H "Content-Type: application/json" ' +
+    '-H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" ' +
+    '-H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" ' +
+    `-H "X-Emdash-Event-Type: ${eventType}" ` +
+    '-d @- ' +
+    '"http://127.0.0.1:$EMDASH_HOOK_PORT/hook" || true'
+  );
+}
+
+function makePosixCodexNotifyCommand(): string[] {
+  return [
+    'bash',
+    '-c',
+    'curl -sf -X POST ' +
+      "-H 'Content-Type: application/json' " +
+      '-H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" ' +
+      '-H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" ' +
+      '-H "X-Emdash-Event-Type: notification" ' +
+      '-d "$1" ' +
+      '"http://127.0.0.1:$EMDASH_HOOK_PORT/hook" || true',
+    '_',
+  ];
+}
+
+function windowsCodexNotifyScript(): string {
+  return [
+    'param([string]$payload)',
+    'try {',
+    '  Invoke-WebRequest -UseBasicParsing -Method POST ' +
+      "-Uri ('http://127.0.0.1:' + $env:EMDASH_HOOK_PORT + '/hook') " +
+      '-Headers @{ ' +
+      "'Content-Type' = 'application/json'; " +
+      "'X-Emdash-Token' = $env:EMDASH_HOOK_TOKEN; " +
+      "'X-Emdash-Pty-Id' = $env:EMDASH_PTY_ID; " +
+      "'X-Emdash-Event-Type' = 'notification' " +
+      '} -Body $payload | Out-Null',
+    '} catch {',
+    '  exit 0',
+    '}',
+    '',
+  ].join('\n');
+}
+
+function ensureWindowsCodexNotifyScript(options: CodexNotifyCommandOptions): string {
+  const platform = options.platform ?? process.platform;
+  const scriptPath = options.scriptPath ?? join(tmpdir(), 'emdash-codex-notify.ps1');
+  const scriptDir = platform === 'win32' ? win32.dirname(scriptPath) : dirname(scriptPath);
+  const mkdir = options.mkdir ?? ((path: string) => mkdirSync(path, { recursive: true }));
+  const writeFile = options.writeFile ?? writeFileSync;
+
+  try {
+    mkdir(scriptDir);
+    writeFile(scriptPath, windowsCodexNotifyScript());
+  } catch (err) {
+    log.warn('CodexNotifyCommand: failed to write Windows notify script', {
+      path: scriptPath,
+      error: String(err),
+    });
+  }
+
+  return scriptPath;
+}
+
+function makeWindowsCodexNotifyCommand(options: CodexNotifyCommandOptions): string[] {
+  return ['powershell.exe', '-NoProfile', '-File', ensureWindowsCodexNotifyScript(options)];
+}
+
+export function makeCodexNotifyCommand(options: CodexNotifyCommandOptions = {}): string[] {
+  const platform = options.platform ?? process.platform;
+  return platform === 'win32'
+    ? makeWindowsCodexNotifyCommand(options)
+    : makePosixCodexNotifyCommand();
+}

--- a/src/main/core/agent-hooks/hook-config.ts
+++ b/src/main/core/agent-hooks/hook-config.ts
@@ -4,6 +4,7 @@ import { resolveCommandPath } from '@main/core/dependencies/probe';
 import type { FileSystemProvider } from '@main/core/fs/types';
 import type { ExecFn } from '@main/core/utils/exec';
 import { log } from '@main/lib/logger';
+import { makeClaudeHookCommand, makeCodexNotifyCommand } from './agent-notify-command';
 
 const EMDASH_MARKER = 'EMDASH_HOOK_PORT';
 
@@ -16,33 +17,6 @@ const HOOK_EVENT_MAP = [
   { eventType: 'notification', hookKey: 'Notification' },
   { eventType: 'stop', hookKey: 'Stop' },
 ] satisfies { eventType: string; hookKey: string }[];
-
-function makeClaudeHookCommand(eventType: string): string {
-  return (
-    'curl -sf -X POST ' +
-    '-H "Content-Type: application/json" ' +
-    '-H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" ' +
-    '-H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" ' +
-    `-H "X-Emdash-Event-Type: ${eventType}" ` +
-    '-d @- ' +
-    '"http://127.0.0.1:$EMDASH_HOOK_PORT/hook" || true'
-  );
-}
-
-function makeCodexNotifyCommand(): string[] {
-  return [
-    'bash',
-    '-c',
-    'curl -sf -X POST ' +
-      "-H 'Content-Type: application/json' " +
-      '-H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" ' +
-      '-H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" ' +
-      '-H "X-Emdash-Event-Type: notification" ' +
-      '-d "$1" ' +
-      '"http://127.0.0.1:$EMDASH_HOOK_PORT/hook" || true',
-    '_',
-  ];
-}
 
 export class HookConfigWriter {
   constructor(

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -1,7 +1,6 @@
 import { homedir } from 'node:os';
 import { getProvider } from '@shared/agent-provider-registry';
-import type { AgentSessionConfig } from '@shared/agent-session';
-import { Conversation } from '@shared/conversations';
+import type { Conversation } from '@shared/conversations';
 import { agentSessionExitedChannel } from '@shared/events/agentEvents';
 import { makePtyId } from '@shared/ptyId';
 import { makePtySessionId } from '@shared/ptySessionId';
@@ -12,10 +11,10 @@ import { HookConfigWriter } from '@main/core/agent-hooks/hook-config';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
-import { Pty } from '@main/core/pty/pty';
+import type { Pty } from '@main/core/pty/pty';
 import { buildAgentEnv } from '@main/core/pty/pty-env';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
-import { resolveSpawnParams } from '@main/core/pty/spawn-utils';
+import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/pty-spawn-platform';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { appSettingsService } from '@main/core/settings/settings-service';
 import type { ExecFn } from '@main/core/utils/exec';
@@ -100,29 +99,31 @@ export class LocalConversationProvider implements ConversationProvider {
 
     const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;
 
-    const cfg: AgentSessionConfig = {
-      taskId: this.taskId,
-      conversationId: conversation.id,
-      providerId: conversation.providerId,
-      command,
-      args,
-      cwd: this.taskPath,
-      shellSetup: this.shellSetup,
-      tmuxSessionName,
-      autoApprove: conversation.autoApprove ?? false,
-      resume: isResuming,
-    };
+    const resolved = resolveLocalPtySpawn({
+      platform: process.platform,
+      env: process.env,
+      intent: {
+        kind: 'run-command',
+        cwd: this.taskPath,
+        command: { kind: 'argv', command, args },
+        shellSetup: this.shellSetup,
+        tmuxSessionName,
+      },
+    });
 
-    const spawnParams = resolveSpawnParams('agent', cfg);
+    logLocalPtySpawnWarnings('LocalConversationProvider', resolved.warnings, {
+      conversationId: conversation.id,
+      sessionId,
+    });
 
     const ptyId = makePtyId(conversation.providerId, conversation.id);
     const port = agentHookService.getPort();
     const token = agentHookService.getToken();
     const pty = spawnLocalPty({
       id: sessionId,
-      command: spawnParams.command,
-      args: spawnParams.args,
-      cwd: this.taskPath,
+      command: resolved.command,
+      args: resolved.args,
+      cwd: resolved.cwd,
       env: {
         ...buildAgentEnv({
           hook: port > 0 ? { port, ptyId, token } : undefined,

--- a/src/main/core/dependencies/install-runner.test.ts
+++ b/src/main/core/dependencies/install-runner.test.ts
@@ -1,5 +1,52 @@
-import { describe, expect, it } from 'vitest';
-import { classifyInstallCommandFailure } from './install-runner';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LocalSpawnOptions } from '@main/core/pty/local-pty';
+import type { Pty } from '@main/core/pty/pty';
+import { classifyInstallCommandFailure, runLocalInstallCommand } from './install-runner';
+
+const mocks = vi.hoisted(() => ({
+  spawnLocalPty: vi.fn(),
+  ensureUserBinDirsInPath: vi.fn(),
+}));
+
+vi.mock('@main/core/pty/local-pty', () => ({
+  spawnLocalPty: mocks.spawnLocalPty,
+}));
+
+vi.mock('@main/utils/userEnv', () => ({
+  ensureUserBinDirsInPath: mocks.ensureUserBinDirsInPath,
+}));
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalEnv = { ...process.env };
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+}
+
+function createSuccessfulPty(): Pty {
+  return {
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn((handler) => handler({ exitCode: 0 })),
+  };
+}
+
+beforeEach(() => {
+  mocks.spawnLocalPty.mockReturnValue(createSuccessfulPty());
+});
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform);
+  }
+  vi.clearAllMocks();
+});
 
 describe('classifyInstallCommandFailure', () => {
   it('summarizes permission errors from npm global installs', () => {
@@ -30,5 +77,24 @@ describe('classifyInstallCommandFailure', () => {
       output: 'network unavailable',
       message: 'Install command failed.',
     });
+  });
+});
+
+describe('runLocalInstallCommand', () => {
+  it('runs Windows installs through the local PTY platform resolver', async () => {
+    setPlatform('win32');
+    delete process.env.SHELL;
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+    const result = await runLocalInstallCommand('npm install -g @openai/codex');
+
+    expect(result.success).toBe(true);
+    expect(mocks.spawnLocalPty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'C:\\Windows\\System32\\cmd.exe',
+        args: ['/d', '/s', '/c', 'npm install -g @openai/codex'],
+        cwd: expect.any(String),
+      } satisfies Partial<LocalSpawnOptions>)
+    );
   });
 });

--- a/src/main/core/dependencies/install-runner.ts
+++ b/src/main/core/dependencies/install-runner.ts
@@ -3,6 +3,7 @@ import type { InstallCommandError } from '@shared/dependencies';
 import { err, ok, type Result } from '@shared/result';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
+import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/pty-spawn-platform';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import type { SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
 import { log } from '@main/lib/logger';
@@ -61,14 +62,25 @@ function waitForInstallPty(pty: Pty): Promise<Result<void, InstallCommandError>>
 export function runLocalInstallCommand(
   command: string
 ): Promise<Result<void, InstallCommandError>> {
-  const shell = process.env.SHELL ?? '/bin/sh';
+  const installId = `install:${crypto.randomUUID()}`;
+  const resolved = resolveLocalPtySpawn({
+    platform: process.platform,
+    env: process.env,
+    intent: {
+      kind: 'run-command',
+      cwd: os.homedir(),
+      command: { kind: 'shell-line', commandLine: command },
+    },
+  });
+  logLocalPtySpawnWarnings('DependencyManager', resolved.warnings, { installId });
+
   let pty: Pty;
   try {
     pty = spawnLocalPty({
-      id: `install:${crypto.randomUUID()}`,
-      command: shell,
-      args: ['-c', command],
-      cwd: os.homedir(),
+      id: installId,
+      command: resolved.command,
+      args: resolved.args,
+      cwd: resolved.cwd,
       env: process.env as Record<string, string>,
       cols: 80,
       rows: 24,

--- a/src/main/core/projects/impl/local-project-provider.ts
+++ b/src/main/core/projects/impl/local-project-provider.ts
@@ -1,15 +1,15 @@
 import fs from 'node:fs';
 import path from 'node:path';
-import { Conversation } from '@shared/conversations';
+import type { Conversation } from '@shared/conversations';
 import { gitRefChangedChannel } from '@shared/events/gitEvents';
 import type { FetchError } from '@shared/git';
 import { bareRefName } from '@shared/git-utils';
-import { LocalProject } from '@shared/projects';
+import type { LocalProject } from '@shared/projects';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { err, ok, type Result } from '@shared/result';
 import { getTaskEnvVars } from '@shared/task/envVars';
-import { Task, type TaskBootstrapStatus } from '@shared/tasks';
-import { type Terminal } from '@shared/terminals';
+import type { Task, TaskBootstrapStatus } from '@shared/tasks';
+import type { Terminal } from '@shared/terminals';
 import { workspaceKey } from '@shared/workspace-key';
 import { LocalConversationProvider } from '@main/core/conversations/impl/local-conversation';
 import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
@@ -45,6 +45,8 @@ import { LocalProjectSettingsProvider } from '../settings/project-settings';
 import type { ProjectSettingsProvider } from '../settings/schema';
 import { getEffectiveTaskSettings } from '../settings/task-settings';
 import { TimeoutSignal, withTimeout } from '../utils';
+import { LocalWorktreeHost } from '../worktrees/hosts/local-worktree-host';
+import type { WorktreeHost } from '../worktrees/hosts/worktree-host';
 import { WorktreeService } from '../worktrees/worktree-service';
 
 const TASK_TIMEOUT_MS = 60_000;
@@ -61,20 +63,25 @@ function toTeardownError(e: unknown): TeardownTaskError {
   return { type: 'error', message: e instanceof Error ? e.message : String(e) };
 }
 
-export async function createLocalProvider(
-  project: LocalProject,
-  rootFs: FileSystemProvider
-): Promise<LocalProjectProvider> {
-  const settings = new LocalProjectSettingsProvider(
-    project.path,
-    bareRefName(project.baseRef),
-    rootFs
-  );
-  const worktreePoolPath = path.join(await settings.getWorktreeDirectory(), project.name);
+export async function createLocalProvider(project: LocalProject): Promise<LocalProjectProvider> {
+  const settings = new LocalProjectSettingsProvider(project.path, bareRefName(project.baseRef));
+  const worktreeDirectory = await settings.getWorktreeDirectory();
+  await fs.promises.mkdir(worktreeDirectory, { recursive: true });
 
-  await fs.promises.mkdir(worktreePoolPath, { recursive: true });
+  const projectFs = new LocalFileSystem(project.path);
+  const worktreeHost = await LocalWorktreeHost.create({
+    allowedRoots: [project.path, worktreeDirectory],
+  });
+  const worktreePoolPath = path.join(worktreeDirectory, project.name);
 
-  return new LocalProjectProvider(project, rootFs, { settings, worktreePoolPath });
+  await worktreeHost.mkdirAbsolute(worktreePoolPath, { recursive: true });
+
+  return new LocalProjectProvider(project, {
+    projectFs,
+    worktreeHost,
+    settings,
+    worktreePoolPath,
+  });
 }
 
 export class LocalProjectProvider implements ProjectProvider {
@@ -96,14 +103,15 @@ export class LocalProjectProvider implements ProjectProvider {
 
   constructor(
     private readonly project: LocalProject,
-    readonly rootFs: FileSystemProvider,
     options: {
+      projectFs: FileSystemProvider;
+      worktreeHost: WorktreeHost;
       settings: ProjectSettingsProvider;
       worktreePoolPath: string;
     }
   ) {
     this.settings = options.settings;
-    this.fs = new LocalFileSystem(project.path);
+    this.fs = options.projectFs;
     const gitExec = getGitLocalExec(() => githubConnectionService.getToken());
     const repoGit = new GitService(project.path, gitExec, this.fs);
     this.repository = new GitRepositoryService(repoGit, this.settings);
@@ -112,7 +120,7 @@ export class LocalProjectProvider implements ProjectProvider {
       repoPath: project.path,
       projectSettings: this.settings,
       exec: gitExec,
-      rootFs: rootFs,
+      host: options.worktreeHost,
     });
     this._gitWatcher = new GitWatcherService(project.id, project.path);
     void this._gitWatcher.start();

--- a/src/main/core/projects/impl/ssh-project-provider.ts
+++ b/src/main/core/projects/impl/ssh-project-provider.ts
@@ -21,7 +21,10 @@ import { githubConnectionService } from '@main/core/github/services/github-conne
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { prSyncScheduler } from '@main/core/pull-requests/pr-sync-scheduler';
 import { type SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
-import { type SshConnectionEvent, sshConnectionManager } from '@main/core/ssh/ssh-connection-manager';
+import {
+  sshConnectionManager,
+  type SshConnectionEvent,
+} from '@main/core/ssh/ssh-connection-manager';
 import { getTaskSessionLeafIds } from '@main/core/tasks/session-targets';
 import { SshTerminalProvider } from '@main/core/terminals/impl/ssh-terminal-provider';
 import { getGitSshExec, getSshExec } from '@main/core/utils/exec';

--- a/src/main/core/projects/impl/ssh-project-provider.ts
+++ b/src/main/core/projects/impl/ssh-project-provider.ts
@@ -1,15 +1,15 @@
 import { randomUUID } from 'node:crypto';
 import path from 'node:path';
 import type { SFTPWrapper } from 'ssh2';
-import { Conversation } from '@shared/conversations';
+import { type Conversation } from '@shared/conversations';
 import type { FetchError } from '@shared/git';
 import { bareRefName } from '@shared/git-utils';
 import type { SshProject } from '@shared/projects';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { err, ok, type Result } from '@shared/result';
 import { getTaskEnvVars } from '@shared/task/envVars';
-import { Task, type TaskBootstrapStatus } from '@shared/tasks';
-import { Terminal } from '@shared/terminals';
+import { type Task, type TaskBootstrapStatus } from '@shared/tasks';
+import { type Terminal } from '@shared/terminals';
 import { workspaceKey } from '@shared/workspace-key';
 import { SshConversationProvider } from '@main/core/conversations/impl/ssh-conversation';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
@@ -20,8 +20,8 @@ import { GitRepositoryService } from '@main/core/git/repository-service';
 import { githubConnectionService } from '@main/core/github/services/github-connection-service';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { prSyncScheduler } from '@main/core/pull-requests/pr-sync-scheduler';
-import { SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
-import { SshConnectionEvent, sshConnectionManager } from '@main/core/ssh/ssh-connection-manager';
+import { type SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
+import { type SshConnectionEvent, sshConnectionManager } from '@main/core/ssh/ssh-connection-manager';
 import { getTaskSessionLeafIds } from '@main/core/tasks/session-targets';
 import { SshTerminalProvider } from '@main/core/terminals/impl/ssh-terminal-provider';
 import { getGitSshExec, getSshExec } from '@main/core/utils/exec';
@@ -45,6 +45,8 @@ import { SshProjectSettingsProvider } from '../settings/project-settings';
 import type { ProjectSettingsProvider } from '../settings/schema';
 import { getEffectiveTaskSettings } from '../settings/task-settings';
 import { TimeoutSignal, withTimeout } from '../utils';
+import { SshWorktreeHost } from '../worktrees/hosts/ssh-worktree-host';
+import type { WorktreeHost } from '../worktrees/hosts/worktree-host';
 import { WorktreeService } from '../worktrees/worktree-service';
 
 const TASK_TIMEOUT_MS = 60_000;
@@ -78,10 +80,12 @@ export async function createSshProvider(
       exec
     );
     const worktreePoolPath = path.posix.join(await settings.getWorktreeDirectory(), project.name);
-    await rootFs.mkdir(worktreePoolPath, { recursive: true });
+    const worktreeHost = new SshWorktreeHost(rootFs);
+    await worktreeHost.mkdirAbsolute(worktreePoolPath, { recursive: true });
 
-    return new SshProjectProvider(project, rootFs, proxy, {
+    return new SshProjectProvider(project, proxy, {
       fs: projectFs,
+      worktreeHost,
       settings,
       worktreePoolPath,
     });
@@ -113,10 +117,10 @@ export class SshProjectProvider implements ProjectProvider {
 
   constructor(
     private readonly project: SshProject,
-    rootFs: FileSystemProvider,
     private readonly proxy: SshClientProxy,
     options: {
       fs: SshFileSystem;
+      worktreeHost: WorktreeHost;
       settings: ProjectSettingsProvider;
       worktreePoolPath: string;
     }
@@ -131,7 +135,7 @@ export class SshProjectProvider implements ProjectProvider {
       repoPath: project.path,
       projectSettings: this.settings,
       exec: gitExec,
-      rootFs: rootFs,
+      host: options.worktreeHost,
     });
     this._gitFetchService = new GitFetchService(repoGit);
     this._gitFetchService.start();

--- a/src/main/core/projects/project-manager.ts
+++ b/src/main/core/projects/project-manager.ts
@@ -6,7 +6,6 @@ import type {
 } from '@shared/projects';
 import { err, ok, type Result } from '@shared/result';
 import { log } from '@main/lib/logger';
-import { LocalFileSystem } from '../fs/impl/local-fs';
 import { SshFileSystem } from '../fs/impl/ssh-fs';
 import { checkIsValidDirectory } from '../git/impl/detectGitInfo';
 import { getProjectById, getProjects } from '../projects/operations/getProjects';
@@ -172,8 +171,7 @@ async function createProvider(project: LocalProject | SshProject): Promise<Proje
     const rootFs = new SshFileSystem(proxy, '/');
     return createSshProvider(project, rootFs, proxy);
   }
-  const rootFs = new LocalFileSystem('/');
-  return createLocalProvider(project, rootFs);
+  return createLocalProvider(project);
 }
 
 export const projectManager = new ProjectManager();

--- a/src/main/core/projects/settings/project-settings.test.ts
+++ b/src/main/core/projects/settings/project-settings.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
+import type { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
 import type { ExecFn } from '@main/core/utils/exec';
 import { LocalProjectSettingsProvider, SshProjectSettingsProvider } from './project-settings';
 
@@ -32,36 +32,27 @@ describe('ProjectSettingsProvider worktreeDirectory validation', () => {
   it('normalizes and canonicalizes local worktreeDirectory on update', async () => {
     const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-local-'));
     tempDirs.push(projectPath);
-    const rootFs = {
-      mkdir: vi.fn().mockResolvedValue(undefined),
-      realPath: vi.fn().mockResolvedValue('/canonical/worktrees'),
-    };
 
-    const provider = new LocalProjectSettingsProvider(projectPath, 'main', rootFs);
+    const provider = new LocalProjectSettingsProvider(projectPath, 'main');
     const result = await provider.update({ preservePatterns: [], worktreeDirectory: 'worktrees' });
     expect(result.success).toBe(true);
 
-    expect(rootFs.mkdir).toHaveBeenCalledWith(path.resolve(projectPath, 'worktrees'), {
-      recursive: true,
-    });
-    expect(rootFs.realPath).toHaveBeenCalledWith(path.resolve(projectPath, 'worktrees'));
+    const expectedPath = path.resolve(projectPath, 'worktrees');
+    expect(fs.existsSync(expectedPath)).toBe(true);
 
     const persisted = JSON.parse(fs.readFileSync(path.join(projectPath, '.emdash.json'), 'utf8'));
-    expect(persisted.worktreeDirectory).toBe('/canonical/worktrees');
+    expect(persisted.worktreeDirectory).toBe(fs.realpathSync(expectedPath));
   });
 
   it('surfaces local worktreeDirectory validation errors', async () => {
     const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-local-'));
     tempDirs.push(projectPath);
-    const rootFs = {
-      mkdir: vi.fn().mockRejectedValue(new Error('EACCES')),
-      realPath: vi.fn(),
-    };
+    fs.writeFileSync(path.join(projectPath, 'not-a-directory'), 'file');
 
-    const provider = new LocalProjectSettingsProvider(projectPath, 'main', rootFs);
+    const provider = new LocalProjectSettingsProvider(projectPath, 'main');
     const result = await provider.update({
       preservePatterns: [],
-      worktreeDirectory: '/restricted',
+      worktreeDirectory: path.join(projectPath, 'not-a-directory', 'worktrees'),
     });
     expect(result).toEqual({
       success: false,
@@ -72,16 +63,11 @@ describe('ProjectSettingsProvider worktreeDirectory validation', () => {
   it('clears blank local worktreeDirectory values', async () => {
     const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-local-'));
     tempDirs.push(projectPath);
-    const rootFs = {
-      mkdir: vi.fn().mockResolvedValue(undefined),
-      realPath: vi.fn().mockResolvedValue('/unused'),
-    };
 
-    const provider = new LocalProjectSettingsProvider(projectPath, 'main', rootFs);
+    const provider = new LocalProjectSettingsProvider(projectPath, 'main');
     const result = await provider.update({ preservePatterns: [], worktreeDirectory: '   ' });
     expect(result.success).toBe(true);
 
-    expect(rootFs.mkdir).not.toHaveBeenCalled();
     const persisted = JSON.parse(fs.readFileSync(path.join(projectPath, '.emdash.json'), 'utf8'));
     expect(persisted.worktreeDirectory).toBeUndefined();
   });

--- a/src/main/core/projects/settings/project-settings.ts
+++ b/src/main/core/projects/settings/project-settings.ts
@@ -16,7 +16,6 @@ import {
   type ProjectSettingsProvider,
 } from './schema';
 import {
-  defaultLocalWorktreeFs,
   normalizeWorktreeDirectory,
   resolveAndValidateWorktreeDirectory,
 } from './worktree-directory';
@@ -57,7 +56,12 @@ export class LocalProjectSettingsProvider implements ProjectSettingsProvider {
       {
         projectPath: this.projectPath,
         pathApi: path,
-        fs: defaultLocalWorktreeFs,
+        fs: {
+          mkdir: async (p, options) => {
+            await fs.promises.mkdir(p, options);
+          },
+          realPath: async (p) => fs.promises.realpath(p),
+        },
         homeDirectory: os.homedir(),
       }
     );

--- a/src/main/core/projects/settings/project-settings.ts
+++ b/src/main/core/projects/settings/project-settings.ts
@@ -3,14 +3,18 @@ import os from 'node:os';
 import path from 'node:path';
 import type { UpdateProjectSettingsError } from '@shared/projects';
 import { err, ok, type Result } from '@shared/result';
-import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
+import type { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
 import type { FileSystemProvider } from '@main/core/fs/types';
 import { appSettingsService } from '@main/core/settings/settings-service';
 import { getDefaultSshWorktreeDirectory } from '@main/core/settings/worktree-defaults';
 import { resolveRemoteHome } from '@main/core/ssh/utils';
 import type { ExecFn } from '@main/core/utils/exec';
 import { log } from '@main/lib/logger';
-import { ProjectSettings, ProjectSettingsProvider, projectSettingsSchema } from './schema';
+import {
+  projectSettingsSchema,
+  type ProjectSettings,
+  type ProjectSettingsProvider,
+} from './schema';
 import {
   defaultLocalWorktreeFs,
   normalizeWorktreeDirectory,
@@ -31,8 +35,7 @@ function parseSettingsOrDefault(raw: string, source: string): ProjectSettings {
 export class LocalProjectSettingsProvider implements ProjectSettingsProvider {
   constructor(
     private readonly projectPath: string,
-    private readonly defaultBranchFallback: string = 'main',
-    private readonly rootFs?: Pick<FileSystemProvider, 'mkdir' | 'realPath'>
+    private readonly defaultBranchFallback: string = 'main'
   ) {}
 
   async get(): Promise<ProjectSettings> {
@@ -54,7 +57,7 @@ export class LocalProjectSettingsProvider implements ProjectSettingsProvider {
       {
         projectPath: this.projectPath,
         pathApi: path,
-        fs: this.rootFs ?? defaultLocalWorktreeFs,
+        fs: defaultLocalWorktreeFs,
         homeDirectory: os.homedir(),
       }
     );

--- a/src/main/core/projects/settings/worktree-directory.ts
+++ b/src/main/core/projects/settings/worktree-directory.ts
@@ -1,10 +1,7 @@
-import fs from 'node:fs';
-import path from 'node:path';
+import type path from 'node:path';
 import type { UpdateProjectSettingsError } from '@shared/projects';
 import { err, ok, type Result } from '@shared/result';
 import type { FileSystemProvider } from '@main/core/fs/types';
-
-export type WorktreeDirectoryFs = Pick<FileSystemProvider, 'mkdir' | 'realPath'>;
 
 type PathApi = Pick<typeof path, 'isAbsolute' | 'join' | 'resolve'>;
 
@@ -44,7 +41,7 @@ export async function normalizeWorktreeDirectory(
 
 export async function canonicalizeWorktreeDirectory(
   directory: string,
-  fs: WorktreeDirectoryFs
+  fs: Pick<FileSystemProvider, 'mkdir' | 'realPath'>
 ): Promise<Result<string, UpdateProjectSettingsError>> {
   try {
     await fs.mkdir(directory, { recursive: true });
@@ -54,19 +51,12 @@ export async function canonicalizeWorktreeDirectory(
   }
 }
 
-export const defaultLocalWorktreeFs: WorktreeDirectoryFs = {
-  mkdir: async (p, options) => {
-    await fs.promises.mkdir(p, options);
-  },
-  realPath: async (p) => fs.promises.realpath(p),
-};
-
 export async function resolveAndValidateWorktreeDirectory(
   input: string | undefined,
   options: {
     projectPath: string;
     pathApi: Pick<typeof path, 'isAbsolute' | 'join' | 'resolve'>;
-    fs: WorktreeDirectoryFs;
+    fs: Pick<FileSystemProvider, 'mkdir' | 'realPath'>;
     homeDirectory?: string;
     resolveHomeDirectory?: () => Promise<string>;
   }

--- a/src/main/core/projects/worktrees/hosts/local-worktree-host.test.ts
+++ b/src/main/core/projects/worktrees/hosts/local-worktree-host.test.ts
@@ -1,0 +1,109 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { FileSystemErrorCodes } from '@main/core/fs/types';
+import { isPathInsideRoot, LocalWorktreeHost } from './local-worktree-host';
+
+describe('LocalWorktreeHost', () => {
+  let repoDir: string;
+  let worktreeDir: string;
+  let outsideDir: string;
+
+  beforeEach(() => {
+    repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-wtfs-repo-'));
+    worktreeDir = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-wtfs-worktrees-'));
+    outsideDir = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-wtfs-outside-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(repoDir, { recursive: true, force: true });
+    fs.rmSync(worktreeDir, { recursive: true, force: true });
+    fs.rmSync(outsideDir, { recursive: true, force: true });
+  });
+
+  async function makeHost(): Promise<LocalWorktreeHost> {
+    return LocalWorktreeHost.create({
+      allowedRoots: [repoDir, worktreeDir],
+    });
+  }
+
+  it('copies files between separate allowed roots using absolute paths', async () => {
+    const host = await makeHost();
+    const src = path.join(repoDir, '.env');
+    const dest = path.join(worktreeDir, 'task-1', '.env');
+    fs.writeFileSync(src, 'SECRET=abc');
+
+    await host.mkdirAbsolute(path.dirname(dest), { recursive: true });
+    await host.copyFileAbsolute(src, dest);
+
+    expect(fs.readFileSync(dest, 'utf8')).toBe('SECRET=abc');
+  });
+
+  it('rejects relative paths', async () => {
+    const host = await makeHost();
+
+    await expect(host.mkdirAbsolute('relative/path', { recursive: true })).rejects.toMatchObject({
+      code: FileSystemErrorCodes.INVALID_PATH,
+    });
+  });
+
+  it('rejects paths outside the allowed roots', async () => {
+    const host = await makeHost();
+    const src = path.join(outsideDir, 'secret.txt');
+    const dest = path.join(worktreeDir, 'secret.txt');
+    fs.writeFileSync(src, 'outside');
+
+    await expect(host.copyFileAbsolute(src, dest)).rejects.toMatchObject({
+      code: FileSystemErrorCodes.PATH_ESCAPE,
+    });
+  });
+
+  it('rejects symlink escapes outside the allowed roots', async () => {
+    if (process.platform === 'win32') {
+      return;
+    }
+
+    const host = await makeHost();
+    const secret = path.join(outsideDir, 'passwords.txt');
+    const escape = path.join(worktreeDir, 'escape');
+    fs.writeFileSync(secret, 'outside');
+    fs.symlinkSync(outsideDir, escape);
+
+    await expect(host.realPathAbsolute(path.join(escape, 'passwords.txt'))).rejects.toMatchObject({
+      code: FileSystemErrorCodes.PATH_ESCAPE,
+    });
+  });
+
+  it('returns false/null for out-of-scope existence checks', async () => {
+    const host = await makeHost();
+    const outside = path.join(outsideDir, 'file.txt');
+    fs.writeFileSync(outside, 'outside');
+
+    await expect(host.existsAbsolute(outside)).resolves.toBe(false);
+    await expect(host.statAbsolute(outside)).resolves.toBeNull();
+  });
+
+  it('matches Windows paths by drive-aware containment rules', () => {
+    expect(
+      isPathInsideRoot(String.raw`C:\repo\.env`, String.raw`C:\repo`, {
+        pathApi: path.win32,
+      })
+    ).toBe(true);
+    expect(
+      isPathInsideRoot(String.raw`C:\repo2\.env`, String.raw`C:\repo`, {
+        pathApi: path.win32,
+      })
+    ).toBe(false);
+    expect(
+      isPathInsideRoot(String.raw`D:\repo\.env`, String.raw`C:\repo`, {
+        pathApi: path.win32,
+      })
+    ).toBe(false);
+    expect(
+      isPathInsideRoot(String.raw`c:\repo\.env`, String.raw`C:\Repo`, {
+        pathApi: path.win32,
+      })
+    ).toBe(true);
+  });
+});

--- a/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
+++ b/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
@@ -1,0 +1,177 @@
+import { promises as fs } from 'node:fs';
+import path from 'node:path';
+import { glob } from 'glob';
+import { FileSystemError, FileSystemErrorCodes, type FileEntry } from '@main/core/fs/types';
+import type { WorktreeHost } from './worktree-host';
+
+type PathApi = Pick<typeof path, 'isAbsolute' | 'relative'>;
+
+export function isPathInsideRoot(
+  child: string,
+  parent: string,
+  options: { pathApi?: PathApi } = {}
+): boolean {
+  const pathApi = options.pathApi ?? path;
+  const rel = pathApi.relative(parent, child);
+  return rel === '' || (!rel.startsWith('..') && !pathApi.isAbsolute(rel));
+}
+
+function isNotFound(error: unknown): boolean {
+  const code = (error as NodeJS.ErrnoException).code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
+}
+
+export class LocalWorktreeHost implements WorktreeHost {
+  private constructor(private readonly roots: string[]) {}
+
+  static async create(args: { allowedRoots: string[] }): Promise<LocalWorktreeHost> {
+    if (args.allowedRoots.length === 0) {
+      throw new FileSystemError(
+        'At least one allowed root is required',
+        FileSystemErrorCodes.INVALID_PATH
+      );
+    }
+
+    const roots = await Promise.all(
+      args.allowedRoots.map(async (root) => {
+        const resolved = path.resolve(root);
+        if (!path.isAbsolute(resolved)) {
+          throw new FileSystemError(
+            `Expected absolute allowed root: ${root}`,
+            FileSystemErrorCodes.INVALID_PATH,
+            root
+          );
+        }
+        return fs.realpath(resolved);
+      })
+    );
+
+    return new LocalWorktreeHost(roots);
+  }
+
+  private assertAbsolute(input: string): string {
+    const resolved = path.resolve(input);
+    if (!path.isAbsolute(input)) {
+      throw new FileSystemError(
+        `Expected absolute path: ${input}`,
+        FileSystemErrorCodes.INVALID_PATH,
+        input
+      );
+    }
+    return resolved;
+  }
+
+  private assertInsideAllowedRoots(resolved: string, originalPath: string): void {
+    if (!this.roots.some((root) => isPathInsideRoot(resolved, root))) {
+      throw new FileSystemError(
+        `Path outside allowed roots: ${originalPath}`,
+        FileSystemErrorCodes.PATH_ESCAPE,
+        originalPath
+      );
+    }
+  }
+
+  private async validateExisting(input: string): Promise<string> {
+    const resolved = this.assertAbsolute(input);
+    const real = await fs.realpath(resolved);
+    this.assertInsideAllowedRoots(real, input);
+    return real;
+  }
+
+  private async nearestExistingPath(resolved: string): Promise<{
+    realAncestor: string;
+    unresolvedSegments: string[];
+  }> {
+    const unresolvedSegments: string[] = [];
+    let current = resolved;
+
+    while (true) {
+      try {
+        return {
+          realAncestor: await fs.realpath(current),
+          unresolvedSegments: unresolvedSegments.reverse(),
+        };
+      } catch (error) {
+        if (!isNotFound(error)) throw error;
+        const parent = path.dirname(current);
+        if (parent === current) throw error;
+        unresolvedSegments.push(path.basename(current));
+        current = parent;
+      }
+    }
+  }
+
+  private async validateTarget(input: string): Promise<string> {
+    const resolved = this.assertAbsolute(input);
+    try {
+      return await this.validateExisting(resolved);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+    }
+
+    const { realAncestor, unresolvedSegments } = await this.nearestExistingPath(resolved);
+    this.assertInsideAllowedRoots(realAncestor, input);
+    const target = path.join(realAncestor, ...unresolvedSegments);
+    this.assertInsideAllowedRoots(target, input);
+    return target;
+  }
+
+  async existsAbsolute(filePath: string): Promise<boolean> {
+    try {
+      await this.validateExisting(filePath);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async mkdirAbsolute(dirPath: string, options?: { recursive?: boolean }): Promise<void> {
+    const target = await this.validateTarget(dirPath);
+    await fs.mkdir(target, { recursive: options?.recursive ?? false });
+  }
+
+  async removeAbsolute(
+    filePath: string,
+    options?: { recursive?: boolean }
+  ): Promise<{ success: boolean; error?: string }> {
+    try {
+      const target = await this.validateExisting(filePath);
+      await fs.rm(target, { recursive: options?.recursive ?? false, force: false });
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  }
+
+  async realPathAbsolute(filePath: string): Promise<string> {
+    return this.validateExisting(filePath);
+  }
+
+  async globAbsolute(pattern: string, options: { cwd: string; dot?: boolean }): Promise<string[]> {
+    const cwd = await this.validateExisting(options.cwd);
+    return glob(pattern, { cwd, dot: options.dot ?? false, absolute: false });
+  }
+
+  async copyFileAbsolute(src: string, dest: string): Promise<void> {
+    const safeSrc = await this.validateExisting(src);
+    const safeDest = await this.validateTarget(dest);
+    await fs.copyFile(safeSrc, safeDest);
+  }
+
+  async statAbsolute(filePath: string): Promise<FileEntry | null> {
+    try {
+      const fullPath = await this.validateExisting(filePath);
+      const stat = await fs.stat(fullPath);
+      return {
+        path: fullPath,
+        type: stat.isDirectory() ? 'dir' : 'file',
+        size: stat.size,
+        mtime: stat.mtime,
+        ctime: stat.ctime,
+        mode: stat.mode,
+      };
+    } catch {
+      return null;
+    }
+  }
+}

--- a/src/main/core/projects/worktrees/hosts/ssh-worktree-host.test.ts
+++ b/src/main/core/projects/worktrees/hosts/ssh-worktree-host.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it, vi } from 'vitest';
+import { FileSystemErrorCodes, type FileSystemProvider } from '@main/core/fs/types';
+import { SshWorktreeHost } from './ssh-worktree-host';
+
+function makeFs(): Pick<
+  FileSystemProvider,
+  'exists' | 'mkdir' | 'remove' | 'realPath' | 'glob' | 'copyFile' | 'stat'
+> {
+  return {
+    exists: vi.fn().mockResolvedValue(true),
+    mkdir: vi.fn().mockResolvedValue(undefined),
+    remove: vi.fn().mockResolvedValue({ success: true }),
+    realPath: vi.fn().mockResolvedValue('/real/path'),
+    glob: vi.fn().mockResolvedValue(['.env']),
+    copyFile: vi.fn().mockResolvedValue(undefined),
+    stat: vi.fn().mockResolvedValue(null),
+  };
+}
+
+describe('SshWorktreeHost', () => {
+  it('delegates absolute POSIX paths to the wrapped filesystem', async () => {
+    const fs = makeFs();
+    const host = new SshWorktreeHost(fs);
+
+    await host.mkdirAbsolute('/remote/worktrees/project', { recursive: true });
+    await host.copyFileAbsolute('/remote/repo/.env', '/remote/worktrees/project/task/.env');
+    await host.globAbsolute('.env', { cwd: '/remote/repo', dot: true });
+
+    expect(fs.mkdir).toHaveBeenCalledWith('/remote/worktrees/project', { recursive: true });
+    expect(fs.copyFile).toHaveBeenCalledWith(
+      '/remote/repo/.env',
+      '/remote/worktrees/project/task/.env'
+    );
+    expect(fs.glob).toHaveBeenCalledWith('.env', { cwd: '/remote/repo', dot: true });
+  });
+
+  it('rejects relative paths before delegating', async () => {
+    const fs = makeFs();
+    const host = new SshWorktreeHost(fs);
+
+    await expect(host.existsAbsolute('relative/path')).rejects.toMatchObject({
+      code: FileSystemErrorCodes.INVALID_PATH,
+    });
+    expect(fs.exists).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/core/projects/worktrees/hosts/ssh-worktree-host.ts
+++ b/src/main/core/projects/worktrees/hosts/ssh-worktree-host.ts
@@ -1,0 +1,62 @@
+import path from 'node:path';
+import {
+  FileSystemError,
+  FileSystemErrorCodes,
+  type FileEntry,
+  type FileSystemProvider,
+} from '@main/core/fs/types';
+import type { WorktreeHost } from './worktree-host';
+
+type SshWorktreeFs = Pick<
+  FileSystemProvider,
+  'exists' | 'mkdir' | 'remove' | 'realPath' | 'glob' | 'copyFile' | 'stat'
+>;
+
+export class SshWorktreeHost implements WorktreeHost {
+  constructor(private readonly fs: SshWorktreeFs) {}
+
+  private validateAbsolute(input: string): string {
+    if (!path.posix.isAbsolute(input)) {
+      throw new FileSystemError(
+        `Expected absolute POSIX path: ${input}`,
+        FileSystemErrorCodes.INVALID_PATH,
+        input
+      );
+    }
+    return input;
+  }
+
+  async existsAbsolute(filePath: string): Promise<boolean> {
+    return this.fs.exists(this.validateAbsolute(filePath));
+  }
+
+  async mkdirAbsolute(dirPath: string, options?: { recursive?: boolean }): Promise<void> {
+    return this.fs.mkdir(this.validateAbsolute(dirPath), options);
+  }
+
+  async removeAbsolute(
+    filePath: string,
+    options?: { recursive?: boolean }
+  ): Promise<{ success: boolean; error?: string }> {
+    return this.fs.remove(this.validateAbsolute(filePath), options);
+  }
+
+  async realPathAbsolute(filePath: string): Promise<string> {
+    return this.fs.realPath(this.validateAbsolute(filePath));
+  }
+
+  async globAbsolute(pattern: string, options: { cwd: string; dot?: boolean }): Promise<string[]> {
+    return this.fs.glob(pattern, {
+      ...options,
+      cwd: this.validateAbsolute(options.cwd),
+    });
+  }
+
+  async copyFileAbsolute(src: string, dest: string): Promise<void> {
+    return this.fs.copyFile(this.validateAbsolute(src), this.validateAbsolute(dest));
+  }
+
+  async statAbsolute(filePath: string): Promise<FileEntry | null> {
+    return this.fs.stat(this.validateAbsolute(filePath));
+  }
+}

--- a/src/main/core/projects/worktrees/hosts/worktree-host.ts
+++ b/src/main/core/projects/worktrees/hosts/worktree-host.ts
@@ -1,0 +1,14 @@
+import type { FileEntry } from '@main/core/fs/types';
+
+export interface WorktreeHost {
+  existsAbsolute(path: string): Promise<boolean>;
+  mkdirAbsolute(path: string, options?: { recursive?: boolean }): Promise<void>;
+  removeAbsolute(
+    path: string,
+    options?: { recursive?: boolean }
+  ): Promise<{ success: boolean; error?: string }>;
+  realPathAbsolute(path: string): Promise<string>;
+  globAbsolute(pattern: string, options: { cwd: string; dot?: boolean }): Promise<string[]>;
+  copyFileAbsolute(src: string, dest: string): Promise<void>;
+  statAbsolute(path: string): Promise<FileEntry | null>;
+}

--- a/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -4,9 +4,10 @@ import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Remote } from '@shared/git';
 import { ok } from '@shared/result';
-import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
 import { getLocalExec, type ExecFn } from '@main/core/utils/exec';
 import type { ProjectSettingsProvider } from '../settings/schema';
+import { LocalWorktreeHost } from './hosts/local-worktree-host';
+import type { WorktreeHost } from './hosts/worktree-host';
 import { WorktreeService } from './worktree-service';
 
 async function initRepo(dir: string, exec: ExecFn): Promise<void> {
@@ -34,12 +35,16 @@ describe('WorktreeService', () => {
   let repoDir: string;
   let poolDir: string;
   let exec: ExecFn;
+  let host: WorktreeHost;
 
   beforeEach(async () => {
     repoDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-repo-'));
     poolDir = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-pool-'));
     exec = getLocalExec();
     await initRepo(repoDir, exec);
+    host = await LocalWorktreeHost.create({
+      allowedRoots: [repoDir, poolDir],
+    });
   });
 
   afterEach(() => {
@@ -59,7 +64,7 @@ describe('WorktreeService', () => {
       worktreePoolPath: poolDir,
       repoPath: repoDir,
       exec,
-      rootFs: new LocalFileSystem('/'),
+      host,
       projectSettings: makeSettings(),
       ...overrides,
     });

--- a/src/main/core/projects/worktrees/worktree-service.ts
+++ b/src/main/core/projects/worktrees/worktree-service.ts
@@ -1,11 +1,11 @@
 import path from 'node:path';
 import type { Branch } from '@shared/git';
 import { DEFAULT_REMOTE_NAME } from '@shared/git-utils';
-import { err, ok, Result } from '@shared/result';
-import { FileSystemProvider } from '@main/core/fs/types';
-import { ExecFn } from '@main/core/utils/exec';
+import { err, ok, type Result } from '@shared/result';
+import type { ExecFn } from '@main/core/utils/exec';
 import { log } from '@main/lib/logger';
-import { ProjectSettingsProvider } from '../settings/schema';
+import type { ProjectSettingsProvider } from '../settings/schema';
+import type { WorktreeHost } from './hosts/worktree-host';
 
 export type ServeWorktreeError =
   | { type: 'worktree-setup-failed'; cause: unknown }
@@ -16,21 +16,21 @@ export class WorktreeService {
   private readonly worktreePoolPath: string;
   private readonly repoPath: string;
   private readonly exec: ExecFn;
-  private readonly rootFs: FileSystemProvider;
+  private readonly host: WorktreeHost;
   private readonly projectSettings: ProjectSettingsProvider;
 
   constructor(args: {
     worktreePoolPath: string;
     repoPath: string;
     exec: ExecFn;
-    rootFs: FileSystemProvider;
+    host: WorktreeHost;
     projectSettings: ProjectSettingsProvider;
   }) {
     this.worktreePoolPath = args.worktreePoolPath;
     this.repoPath = args.repoPath;
     this.projectSettings = args.projectSettings;
     this.exec = args.exec;
-    this.rootFs = args.rootFs;
+    this.host = args.host;
 
     this.exec('git', ['worktree', 'prune'], { cwd: this.repoPath }).catch(() => {});
   }
@@ -51,7 +51,7 @@ export class WorktreeService {
   }
 
   private async ensureWorktreePoolDirExists(): Promise<void> {
-    await this.rootFs.mkdir(this.worktreePoolPath, { recursive: true });
+    await this.host.mkdirAbsolute(this.worktreePoolPath, { recursive: true });
   }
 
   private async getRemoteCandidates(): Promise<string[]> {
@@ -112,13 +112,13 @@ export class WorktreeService {
 
   async getWorktree(branchName: string): Promise<string | undefined> {
     const worktreePath = path.join(this.worktreePoolPath, branchName);
-    if (await this.rootFs.exists(worktreePath)) {
+    if (await this.host.existsAbsolute(worktreePath)) {
       if (await this.isValidWorktree(worktreePath)) return worktreePath;
-      await this.rootFs.remove(worktreePath, { recursive: true }).catch(() => {});
+      await this.host.removeAbsolute(worktreePath, { recursive: true }).catch(() => {});
     }
 
     try {
-      const realPoolPath = await this.rootFs.realPath(this.worktreePoolPath);
+      const realPoolPath = await this.host.realPathAbsolute(this.worktreePoolPath);
       const { stdout } = await this.exec('git', ['worktree', 'list', '--porcelain'], {
         cwd: this.repoPath,
       });
@@ -151,9 +151,9 @@ export class WorktreeService {
     }
 
     const targetPath = path.join(this.worktreePoolPath, branchName);
-    if (await this.rootFs.exists(targetPath)) {
+    if (await this.host.existsAbsolute(targetPath)) {
       if (await this.isValidWorktree(targetPath)) return ok(targetPath);
-      await this.rootFs.remove(targetPath, { recursive: true }).catch(() => {});
+      await this.host.removeAbsolute(targetPath, { recursive: true }).catch(() => {});
       await this.exec('git', ['worktree', 'prune'], { cwd: this.repoPath }).catch(() => {});
     }
 
@@ -176,7 +176,7 @@ export class WorktreeService {
         });
       }
 
-      await this.rootFs.mkdir(path.dirname(targetPath), { recursive: true });
+      await this.host.mkdirAbsolute(path.dirname(targetPath), { recursive: true });
       await this.exec('git', ['worktree', 'prune'], { cwd: this.repoPath }).catch(() => {});
       await this.exec('git', ['worktree', 'add', targetPath, branchName], {
         cwd: this.repoPath,
@@ -211,14 +211,14 @@ export class WorktreeService {
     const targetPath = path.join(this.worktreePoolPath, branchName);
     const remoteCandidates = await this.getRemoteCandidates();
 
-    if (await this.rootFs.exists(targetPath)) {
+    if (await this.host.existsAbsolute(targetPath)) {
       if (await this.isValidWorktree(targetPath)) return ok(targetPath);
-      await this.rootFs.remove(targetPath, { recursive: true });
+      await this.host.removeAbsolute(targetPath, { recursive: true });
       await this.exec('git', ['worktree', 'prune'], { cwd: this.repoPath }).catch(() => {});
     }
 
     try {
-      await this.rootFs.mkdir(path.dirname(targetPath), { recursive: true });
+      await this.host.mkdirAbsolute(path.dirname(targetPath), { recursive: true });
       for (const remoteName of remoteCandidates) {
         await this.exec('git', ['fetch', remoteName], { cwd: this.repoPath }).catch(() => {});
       }
@@ -280,7 +280,7 @@ export class WorktreeService {
   }
 
   async removeWorktree(worktreePath: string): Promise<void> {
-    await this.rootFs.remove(worktreePath, { recursive: true }).catch(() => {});
+    await this.host.removeAbsolute(worktreePath, { recursive: true }).catch(() => {});
     await this.exec('git', ['worktree', 'prune'], { cwd: this.repoPath }).catch(() => {});
   }
 
@@ -288,17 +288,17 @@ export class WorktreeService {
     const settings = await this.projectSettings.get();
     const patterns = settings.preservePatterns ?? [];
     for (const pattern of patterns) {
-      const matches = await this.rootFs.glob(pattern, {
+      const matches = await this.host.globAbsolute(pattern, {
         cwd: this.repoPath,
         dot: true,
       });
       for (const relPath of matches) {
         const src = path.join(this.repoPath, relPath);
-        const stat = await this.rootFs.stat(src).catch(() => null);
+        const stat = await this.host.statAbsolute(src).catch(() => null);
         if (!stat || stat.type !== 'file') continue;
         const dest = path.join(targetPath, relPath);
-        await this.rootFs.mkdir(path.dirname(dest), { recursive: true });
-        await this.rootFs.copyFile(src, dest);
+        await this.host.mkdirAbsolute(path.dirname(dest), { recursive: true });
+        await this.host.copyFileAbsolute(src, dest);
       }
     }
   }

--- a/src/main/core/pty/local-pty.ts
+++ b/src/main/core/pty/local-pty.ts
@@ -2,6 +2,7 @@ import * as nodePty from 'node-pty';
 import type { IPty } from 'node-pty';
 import { log } from '@main/lib/logger';
 import { normalizeSignal } from './exit-signals';
+import { suppressExpectedNodePtyErrors } from './node-pty-errors';
 import type { Pty, PtyDimensions, PtyExitInfo } from './pty';
 
 export interface LocalSpawnOptions extends PtyDimensions {
@@ -35,6 +36,7 @@ export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
       cwd,
       env,
     });
+    suppressExpectedNodePtyErrors(proc);
     return new LocalPtySession(id, proc);
   } catch (e: unknown) {
     const message = e instanceof Error ? e.message : String(e);

--- a/src/main/core/pty/local-pty.ts
+++ b/src/main/core/pty/local-pty.ts
@@ -1,4 +1,3 @@
-import path from 'node:path';
 import * as nodePty from 'node-pty';
 import type { IPty } from 'node-pty';
 import { log } from '@main/lib/logger';
@@ -18,19 +17,18 @@ const MIN_ROWS = 1;
 
 export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
   const { id, command, args, cwd, env, cols, rows } = options;
-  const spawnSpec = resolveWindowsPtySpawn(command, args);
 
   log.info('LocalPtySession:spawn', {
     id,
-    command: spawnSpec.command,
-    args: spawnSpec.args,
+    command,
+    args,
     cwd,
     cols,
     rows,
   });
 
   try {
-    const proc = nodePty.spawn(spawnSpec.command, spawnSpec.args, {
+    const proc = nodePty.spawn(command, args, {
       name: 'xterm-256color',
       cols,
       rows,
@@ -85,35 +83,4 @@ export class LocalPtySession implements Pty {
       handler({ exitCode, signal: normalizeSignal(signal) });
     });
   }
-}
-
-function resolveWindowsPtySpawn(
-  command: string,
-  args: string[]
-): { command: string; args: string[] } {
-  if (process.platform !== 'win32') return { command, args };
-
-  const quoteForCmdExe = (input: string): string => {
-    if (input.length === 0) return '""';
-    if (!/[\s"^&|<>()%!]/.test(input)) return input;
-    return `"${input
-      .replace(/%/g, '%%')
-      .replace(/!/g, '^!')
-      .replace(/(["^&|<>()])/g, '^$1')}"`;
-  };
-
-  const ext = path.extname(command).toLowerCase();
-  if (ext === '.cmd' || ext === '.bat') {
-    const comspec = process.env.ComSpec || String.raw`C:\\Windows\\System32\\cmd.exe`;
-    const fullCommandString = [command, ...args].map(quoteForCmdExe).join(' ');
-    return { command: comspec, args: ['/d', '/s', '/c', fullCommandString] };
-  }
-  if (ext === '.ps1') {
-    return {
-      command: 'powershell.exe',
-      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', command, ...args],
-    };
-  }
-
-  return { command, args };
 }

--- a/src/main/core/pty/node-pty-errors.ts
+++ b/src/main/core/pty/node-pty-errors.ts
@@ -1,0 +1,21 @@
+import type { IPty } from 'node-pty';
+import { log } from '@main/lib/logger';
+
+type NodePtyWithErrorEvents = IPty & {
+  on?: (event: 'error', handler: (error: NodeJS.ErrnoException) => void) => void;
+};
+
+export function suppressExpectedNodePtyErrors(
+  proc: IPty,
+  platform: NodeJS.Platform = process.platform
+): void {
+  if (platform !== 'win32') return;
+
+  (proc as NodePtyWithErrorEvents).on?.('error', (error) => {
+    if (error.code === 'EPIPE' || error.code === 'EIO') return;
+    log.warn('node-pty: unexpected PTY error', {
+      code: error.code,
+      message: error.message,
+    });
+  });
+}

--- a/src/main/core/pty/pty-env.test.ts
+++ b/src/main/core/pty/pty-env.test.ts
@@ -1,0 +1,60 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+const originalEnv = { ...process.env };
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    value: platform,
+    configurable: true,
+  });
+}
+
+async function loadPtyEnv() {
+  vi.resetModules();
+  return import('./pty-env');
+}
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  if (originalPlatform) {
+    Object.defineProperty(process, 'platform', originalPlatform);
+  }
+  vi.resetModules();
+});
+
+describe('pty env Windows shell handling', () => {
+  it('does not synthesize /bin/bash as SHELL for Windows terminals', async () => {
+    setPlatform('win32');
+    delete process.env.SHELL;
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+    const { buildTerminalEnv } = await loadPtyEnv();
+    const env = buildTerminalEnv();
+
+    expect(env.SHELL).toBeUndefined();
+    expect(env.ComSpec).toBe('C:\\Windows\\System32\\cmd.exe');
+  });
+
+  it('does not synthesize /bin/bash when includeShellVar is true on Windows', async () => {
+    setPlatform('win32');
+    delete process.env.SHELL;
+    process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
+
+    const { buildAgentEnv } = await loadPtyEnv();
+    const env = buildAgentEnv({ includeShellVar: true, agentApiVars: false });
+
+    expect(env.SHELL).toBeUndefined();
+    expect(env.ComSpec).toBe('C:\\Windows\\System32\\cmd.exe');
+  });
+
+  it('keeps POSIX shell fallback for non-Windows terminal envs', async () => {
+    setPlatform('linux');
+    delete process.env.SHELL;
+
+    const { buildTerminalEnv } = await loadPtyEnv();
+    const env = buildTerminalEnv();
+
+    expect(env.SHELL).toBe('/bin/bash');
+  });
+});

--- a/src/main/core/pty/pty-env.ts
+++ b/src/main/core/pty/pty-env.ts
@@ -1,5 +1,6 @@
 import os from 'node:os';
 import { detectSshAuthSock } from '@main/utils/shellEnv';
+import { getWindowsEnvValue } from '@main/utils/windows-env';
 
 export const AGENT_ENV_VARS = [
   'AMP_API_KEY',
@@ -60,25 +61,31 @@ function getWindowsEssentialEnv(resolvedPath: string): Record<string, string> {
   const home = os.homedir();
   return {
     PATH: resolvedPath,
-    PATHEXT: process.env.PATHEXT || '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC',
-    SystemRoot: process.env.SystemRoot || 'C:\\Windows',
-    ComSpec: process.env.ComSpec || 'C:\\Windows\\System32\\cmd.exe',
-    TEMP: process.env.TEMP || process.env.TMP || '',
-    TMP: process.env.TMP || process.env.TEMP || '',
-    USERPROFILE: process.env.USERPROFILE || home,
-    APPDATA: process.env.APPDATA || '',
-    LOCALAPPDATA: process.env.LOCALAPPDATA || '',
-    HOMEDRIVE: process.env.HOMEDRIVE || '',
-    HOMEPATH: process.env.HOMEPATH || '',
-    USERNAME: process.env.USERNAME || os.userInfo().username,
-    ProgramFiles: process.env.ProgramFiles || 'C:\\Program Files',
-    'ProgramFiles(x86)': process.env['ProgramFiles(x86)'] || 'C:\\Program Files (x86)',
-    ProgramData: process.env.ProgramData || 'C:\\ProgramData',
-    CommonProgramFiles: process.env.CommonProgramFiles || 'C:\\Program Files\\Common Files',
+    PATHEXT:
+      getWindowsEnvValue(process.env, 'PATHEXT') ||
+      '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC',
+    SystemRoot: getWindowsEnvValue(process.env, 'SystemRoot') || 'C:\\Windows',
+    ComSpec: getWindowsEnvValue(process.env, 'ComSpec') || 'C:\\Windows\\System32\\cmd.exe',
+    TEMP: getWindowsEnvValue(process.env, 'TEMP') || getWindowsEnvValue(process.env, 'TMP') || '',
+    TMP: getWindowsEnvValue(process.env, 'TMP') || getWindowsEnvValue(process.env, 'TEMP') || '',
+    USERPROFILE: getWindowsEnvValue(process.env, 'USERPROFILE') || home,
+    APPDATA: getWindowsEnvValue(process.env, 'APPDATA') || '',
+    LOCALAPPDATA: getWindowsEnvValue(process.env, 'LOCALAPPDATA') || '',
+    HOMEDRIVE: getWindowsEnvValue(process.env, 'HOMEDRIVE') || '',
+    HOMEPATH: getWindowsEnvValue(process.env, 'HOMEPATH') || '',
+    USERNAME: getWindowsEnvValue(process.env, 'USERNAME') || os.userInfo().username,
+    ProgramFiles: getWindowsEnvValue(process.env, 'ProgramFiles') || 'C:\\Program Files',
+    'ProgramFiles(x86)':
+      getWindowsEnvValue(process.env, 'ProgramFiles(x86)') || 'C:\\Program Files (x86)',
+    ProgramData: getWindowsEnvValue(process.env, 'ProgramData') || 'C:\\ProgramData',
+    CommonProgramFiles:
+      getWindowsEnvValue(process.env, 'CommonProgramFiles') || 'C:\\Program Files\\Common Files',
     'CommonProgramFiles(x86)':
-      process.env['CommonProgramFiles(x86)'] || 'C:\\Program Files (x86)\\Common Files',
-    ProgramW6432: process.env.ProgramW6432 || 'C:\\Program Files',
-    CommonProgramW6432: process.env.CommonProgramW6432 || 'C:\\Program Files\\Common Files',
+      getWindowsEnvValue(process.env, 'CommonProgramFiles(x86)') ||
+      'C:\\Program Files (x86)\\Common Files',
+    ProgramW6432: getWindowsEnvValue(process.env, 'ProgramW6432') || 'C:\\Program Files',
+    CommonProgramW6432:
+      getWindowsEnvValue(process.env, 'CommonProgramW6432') || 'C:\\Program Files\\Common Files',
   };
 }
 
@@ -172,7 +179,7 @@ export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, str
   // contains the full login-shell PATH (Homebrew, nvm, npm globals, etc.).
   const resolvedPath =
     process.platform === 'win32'
-      ? (process.env.PATH ?? process.env.Path ?? '')
+      ? (getWindowsEnvValue(process.env, 'PATH') ?? '')
       : (process.env.PATH ?? '');
   const env: Record<string, string> = {
     TERM: 'xterm-256color',

--- a/src/main/core/pty/pty-env.ts
+++ b/src/main/core/pty/pty-env.ts
@@ -120,8 +120,9 @@ export interface AgentEnvOptions {
  * feels identical to one opened in Ghostty or Terminal.app — the user's
  * EDITOR, MANPATH, JAVA_HOME, custom vars, etc. are all present.
  *
- * TERM, COLORTERM, TERM_PROGRAM, and SHELL are always set or overridden so
- * the shell and programs inside it report the correct terminal identity.
+ * TERM, COLORTERM, and TERM_PROGRAM are always set or overridden so programs
+ * inside the terminal report the correct terminal identity. SHELL is only
+ * synthesized on POSIX platforms.
  * SSH_AUTH_SOCK is injected via the same cached detector used for agents,
  * since GUI-launched apps often don't inherit it from the user's login shell.
  */
@@ -137,8 +138,13 @@ export function buildTerminalEnv(): Record<string, string> {
   env.COLORTERM = 'truecolor';
   env.TERM_PROGRAM = 'emdash';
 
-  // Ensure SHELL reflects the user's configured shell (may be absent in GUI).
-  env.SHELL = process.env.SHELL ?? (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+  // Ensure SHELL reflects the user's configured shell on POSIX. Native Windows
+  // shells are selected via ComSpec by the spawn resolver, not SHELL.
+  if (process.platform !== 'win32') {
+    env.SHELL = process.env.SHELL ?? (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+  } else if (process.env.SHELL) {
+    env.SHELL = process.env.SHELL;
+  }
 
   // SSH_AUTH_SOCK is normally set by resolveUserEnv() at startup. The
   // detectSshAuthSock() fallback covers cases where that failed (timeout,
@@ -181,8 +187,10 @@ export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, str
   const sshAuthSock = process.env.SSH_AUTH_SOCK ?? detectSshAuthSock();
   if (sshAuthSock) env.SSH_AUTH_SOCK = sshAuthSock;
 
-  if (includeShellVar) {
+  if (includeShellVar && process.platform !== 'win32') {
     env.SHELL = process.env.SHELL || '/bin/bash';
+  } else if (includeShellVar && process.env.SHELL) {
+    env.SHELL = process.env.SHELL;
   }
 
   if (agentApiVars) {

--- a/src/main/core/pty/pty-env.ts
+++ b/src/main/core/pty/pty-env.ts
@@ -170,7 +170,10 @@ export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, str
 
   // process.env.PATH is enriched at startup by resolveUserEnv() so it already
   // contains the full login-shell PATH (Homebrew, nvm, npm globals, etc.).
-  const resolvedPath = process.env.PATH ?? '';
+  const resolvedPath =
+    process.platform === 'win32'
+      ? (process.env.PATH ?? process.env.Path ?? '')
+      : (process.env.PATH ?? '');
   const env: Record<string, string> = {
     TERM: 'xterm-256color',
     COLORTERM: 'truecolor',

--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -1,0 +1,192 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLocalPtySpawn } from './pty-spawn-platform';
+
+const winEnv = {
+  ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+  PATHEXT: '.COM;.EXE;.BAT;.CMD;.PS1',
+} satisfies NodeJS.ProcessEnv;
+
+const posixEnv = {
+  SHELL: '/bin/bash',
+} satisfies NodeJS.ProcessEnv;
+
+describe('resolveLocalPtySpawn - Windows', () => {
+  it('uses ComSpec for interactive shells without POSIX flags', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: { kind: 'interactive-shell', cwd: 'C:\\repo' },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: [],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('direct-spawns argv commands when no Windows-unsupported shell features are present', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'node.exe', args: ['--version'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'node.exe',
+      args: ['--version'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('wraps cmd and bat argv commands through cmd.exe', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'pnpm.cmd', args: ['run', 'dev'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'pnpm.cmd run dev'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('quotes cmd wrapper arguments that contain Windows metacharacters', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'tool.cmd', args: ['hello world', 'A&B'] },
+      },
+    });
+
+    expect(result.args).toEqual(['/d', '/s', '/c', 'tool.cmd "hello world" "A^&B"']);
+  });
+
+  it('wraps PowerShell scripts through powershell.exe -File', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'scripts\\setup.ps1', args: ['-Verbose'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'powershell.exe',
+      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', 'scripts\\setup.ps1', '-Verbose'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('runs shell-line commands through cmd.exe /d /s /c', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'shell-line', commandLine: 'pnpm run dev' },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'pnpm run dev'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('returns warnings for ignored shellSetup and tmux on Windows', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'interactive-shell',
+        cwd: 'C:\\repo',
+        shellSetup: 'source ~/.nvm/nvm.sh',
+        tmuxSessionName: 'session-1',
+      },
+    });
+
+    expect(result.warnings).toEqual([
+      'shell_setup_ignored_on_windows',
+      'tmux_unsupported_on_windows',
+    ]);
+  });
+});
+
+describe('resolveLocalPtySpawn - POSIX', () => {
+  it('uses SHELL -il for interactive shells', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'darwin',
+      env: posixEnv,
+      intent: { kind: 'interactive-shell', cwd: '/repo' },
+    });
+
+    expect(result).toEqual({
+      command: '/bin/bash',
+      args: ['-il'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('quotes argv commands before shell wrapping', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'linux',
+      env: posixEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: '/repo',
+        command: { kind: 'argv', command: 'node', args: ['script name.js', "it's ok"] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: '/bin/bash',
+      args: ['-c', "node 'script name.js' 'it'\\''s ok'"],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('prepends shellSetup to shell-line commands', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'linux',
+      env: posixEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: '/repo',
+        shellSetup: 'source ~/.nvm/nvm.sh',
+        command: { kind: 'shell-line', commandLine: 'pnpm run dev' },
+      },
+    });
+
+    expect(result).toEqual({
+      command: '/bin/bash',
+      args: ['-c', 'source ~/.nvm/nvm.sh && pnpm run dev'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+});

--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -11,6 +11,11 @@ const posixEnv = {
 } satisfies NodeJS.ProcessEnv;
 
 describe('resolveLocalPtySpawn - Windows', () => {
+  const windowsPathEnv = {
+    ...winEnv,
+    Path: 'C:\\Users\\me\\AppData\\Roaming\\npm;C:\\Program Files\\nodejs',
+  } satisfies NodeJS.ProcessEnv;
+
   it('uses ComSpec for interactive shells without POSIX flags', () => {
     const result = resolveLocalPtySpawn({
       platform: 'win32',
@@ -40,6 +45,66 @@ describe('resolveLocalPtySpawn - Windows', () => {
     expect(result).toEqual({
       command: 'node.exe',
       args: ['--version'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('resolves extensionless commands through PATH and PATHEXT before wrapping cmd shims', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: windowsPathEnv,
+      fileExists: (candidate) => candidate === 'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.CMD',
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'codex', args: ['hello world'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.CMD "hello world"'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('direct-spawns extensionless commands that resolve to exe files', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: windowsPathEnv,
+      fileExists: (candidate) => candidate === 'C:\\Program Files\\nodejs\\node.EXE',
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'node', args: ['--version'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Program Files\\nodejs\\node.EXE',
+      args: ['--version'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('falls back to cmd.exe for unresolved extensionless commands', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: windowsPathEnv,
+      fileExists: () => false,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'codex', args: ['A&B', '100%'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'codex "A^&B" "100%%"'],
       cwd: 'C:\\repo',
       warnings: [],
     });

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -1,0 +1,187 @@
+import path from 'node:path';
+import { log } from '@main/lib/logger';
+import { buildTmuxShellLine } from './tmux-session-name';
+
+export type PtyCommandSpec =
+  | { kind: 'argv'; command: string; args: string[] }
+  | { kind: 'shell-line'; commandLine: string };
+
+export type PtySpawnIntent =
+  | {
+      kind: 'interactive-shell';
+      cwd: string;
+      shellSetup?: string;
+      tmuxSessionName?: string;
+    }
+  | {
+      kind: 'run-command';
+      cwd: string;
+      command: PtyCommandSpec;
+      shellSetup?: string;
+      tmuxSessionName?: string;
+    };
+
+export type LocalPtySpawnWarning = 'shell_setup_ignored_on_windows' | 'tmux_unsupported_on_windows';
+
+export type ResolvedLocalPtySpawn = {
+  command: string;
+  args: string[];
+  cwd: string;
+  warnings: LocalPtySpawnWarning[];
+};
+
+function getPosixShell(env: NodeJS.ProcessEnv): string {
+  return env.SHELL || '/bin/sh';
+}
+
+function getWindowsShell(env: NodeJS.ProcessEnv): string {
+  return env.ComSpec || 'C:\\Windows\\System32\\cmd.exe';
+}
+
+function isWindows(platform: NodeJS.Platform): boolean {
+  return platform === 'win32';
+}
+
+function quotePosixArg(input: string): string {
+  if (input.length === 0) return "''";
+  if (!/[\s'"\\$`\n\r\t;&|<>(){}[\]*?!]/.test(input)) return input;
+  return `'${input.replace(/'/g, "'\\''")}'`;
+}
+
+function argvToPosixShellLine(command: string, args: string[]): string {
+  return [command, ...args].map(quotePosixArg).join(' ');
+}
+
+function quoteForCmdExe(input: string): string {
+  if (input.length === 0) return '""';
+  if (!/[\s"^&|<>()%!]/.test(input)) return input;
+  return `"${input
+    .replace(/%/g, '%%')
+    .replace(/!/g, '^!')
+    .replace(/(["^&|<>()])/g, '^$1')}"`;
+}
+
+function windowsWarnings(intent: PtySpawnIntent): LocalPtySpawnWarning[] {
+  const warnings: LocalPtySpawnWarning[] = [];
+  if (intent.shellSetup) warnings.push('shell_setup_ignored_on_windows');
+  if (intent.tmuxSessionName) warnings.push('tmux_unsupported_on_windows');
+  return warnings;
+}
+
+function resolveWindowsSpawn(
+  intent: PtySpawnIntent,
+  env: NodeJS.ProcessEnv
+): ResolvedLocalPtySpawn {
+  const warnings = windowsWarnings(intent);
+  const shell = getWindowsShell(env);
+
+  if (intent.kind === 'interactive-shell') {
+    return { command: shell, args: [], cwd: intent.cwd, warnings };
+  }
+
+  if (intent.command.kind === 'shell-line') {
+    return {
+      command: shell,
+      args: ['/d', '/s', '/c', intent.command.commandLine],
+      cwd: intent.cwd,
+      warnings,
+    };
+  }
+
+  const { command, args } = intent.command;
+  const ext = path.extname(command).toLowerCase();
+
+  if (ext === '.cmd' || ext === '.bat') {
+    return {
+      command: shell,
+      args: ['/d', '/s', '/c', [command, ...args].map(quoteForCmdExe).join(' ')],
+      cwd: intent.cwd,
+      warnings,
+    };
+  }
+
+  if (ext === '.ps1') {
+    return {
+      command: 'powershell.exe',
+      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', command, ...args],
+      cwd: intent.cwd,
+      warnings,
+    };
+  }
+
+  return { command, args, cwd: intent.cwd, warnings };
+}
+
+function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): ResolvedLocalPtySpawn {
+  const shell = getPosixShell(env);
+
+  if (intent.kind === 'interactive-shell') {
+    if (intent.tmuxSessionName) {
+      const commandLine = intent.shellSetup
+        ? `${intent.shellSetup} && exec ${quotePosixArg(shell)} -il`
+        : `exec ${quotePosixArg(shell)} -il`;
+      return {
+        command: shell,
+        args: ['-c', buildTmuxShellLine(intent.tmuxSessionName, commandLine)],
+        cwd: intent.cwd,
+        warnings: [],
+      };
+    }
+
+    if (intent.shellSetup) {
+      return {
+        command: shell,
+        args: ['-c', `${intent.shellSetup} && exec ${quotePosixArg(shell)} -il`],
+        cwd: intent.cwd,
+        warnings: [],
+      };
+    }
+
+    return { command: shell, args: ['-il'], cwd: intent.cwd, warnings: [] };
+  }
+
+  const commandLine =
+    intent.command.kind === 'shell-line'
+      ? intent.command.commandLine
+      : argvToPosixShellLine(intent.command.command, intent.command.args);
+  const fullCommandLine = intent.shellSetup
+    ? `${intent.shellSetup} && ${commandLine}`
+    : commandLine;
+
+  if (intent.tmuxSessionName) {
+    return {
+      command: shell,
+      args: ['-c', buildTmuxShellLine(intent.tmuxSessionName, fullCommandLine)],
+      cwd: intent.cwd,
+      warnings: [],
+    };
+  }
+
+  return {
+    command: shell,
+    args: ['-c', fullCommandLine],
+    cwd: intent.cwd,
+    warnings: [],
+  };
+}
+
+export function resolveLocalPtySpawn({
+  intent,
+  platform,
+  env,
+}: {
+  intent: PtySpawnIntent;
+  platform: NodeJS.Platform;
+  env: NodeJS.ProcessEnv;
+}): ResolvedLocalPtySpawn {
+  return isWindows(platform) ? resolveWindowsSpawn(intent, env) : resolvePosixSpawn(intent, env);
+}
+
+export function logLocalPtySpawnWarnings(
+  source: string,
+  warnings: LocalPtySpawnWarning[],
+  context: Record<string, string>
+): void {
+  if (warnings.length === 0) return;
+  log.warn(`${source}: local PTY platform warning`, { ...context, warnings });
+}

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -1,3 +1,4 @@
+import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { log } from '@main/lib/logger';
 import { buildTmuxShellLine } from './tmux-session-name';
@@ -30,6 +31,8 @@ export type ResolvedLocalPtySpawn = {
   warnings: LocalPtySpawnWarning[];
 };
 
+type FileExists = (candidate: string) => boolean;
+
 function getPosixShell(env: NodeJS.ProcessEnv): string {
   return env.SHELL || '/bin/sh';
 }
@@ -61,6 +64,64 @@ function quoteForCmdExe(input: string): string {
     .replace(/(["^&|<>()])/g, '^$1')}"`;
 }
 
+function getWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const lowerKey = key.toLowerCase();
+  const envKey = Object.keys(env).find((candidate) => candidate.toLowerCase() === lowerKey);
+  return envKey ? env[envKey] : undefined;
+}
+
+function getWindowsPathDirs(env: NodeJS.ProcessEnv): string[] {
+  const rawPath = getWindowsEnvValue(env, 'PATH') ?? '';
+  return rawPath.split(path.win32.delimiter).filter(Boolean);
+}
+
+function getWindowsPathExts(env: NodeJS.ProcessEnv): string[] {
+  const rawPathExt =
+    getWindowsEnvValue(env, 'PATHEXT') ?? '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC';
+  return rawPathExt
+    .split(';')
+    .map((ext) => ext.trim())
+    .filter(Boolean)
+    .map((ext) => (ext.startsWith('.') ? ext : `.${ext}`));
+}
+
+function hasWindowsPathSeparator(command: string): boolean {
+  return command.includes('\\') || command.includes('/');
+}
+
+function resolveWindowsCommandPath({
+  command,
+  cwd,
+  env,
+  fileExists,
+}: {
+  command: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  fileExists: FileExists;
+}): string | null {
+  if (path.win32.extname(command)) {
+    return null;
+  }
+
+  const baseCandidates =
+    hasWindowsPathSeparator(command) || path.win32.isAbsolute(command)
+      ? [path.win32.isAbsolute(command) ? command : path.win32.join(cwd, command)]
+      : [
+          path.win32.join(cwd, command),
+          ...getWindowsPathDirs(env).map((dir) => path.win32.join(dir, command)),
+        ];
+
+  for (const base of baseCandidates) {
+    for (const ext of getWindowsPathExts(env)) {
+      const candidate = `${base}${ext}`;
+      if (fileExists(candidate)) return candidate;
+    }
+  }
+
+  return null;
+}
+
 function windowsWarnings(intent: PtySpawnIntent): LocalPtySpawnWarning[] {
   const warnings: LocalPtySpawnWarning[] = [];
   if (intent.shellSetup) warnings.push('shell_setup_ignored_on_windows');
@@ -70,7 +131,8 @@ function windowsWarnings(intent: PtySpawnIntent): LocalPtySpawnWarning[] {
 
 function resolveWindowsSpawn(
   intent: PtySpawnIntent,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  fileExists: FileExists
 ): ResolvedLocalPtySpawn {
   const warnings = windowsWarnings(intent);
   const shell = getWindowsShell(env);
@@ -89,12 +151,19 @@ function resolveWindowsSpawn(
   }
 
   const { command, args } = intent.command;
-  const ext = path.extname(command).toLowerCase();
+  const resolvedCommand =
+    resolveWindowsCommandPath({
+      command,
+      cwd: intent.cwd,
+      env,
+      fileExists,
+    }) ?? command;
+  const ext = path.win32.extname(resolvedCommand).toLowerCase();
 
   if (ext === '.cmd' || ext === '.bat') {
     return {
       command: shell,
-      args: ['/d', '/s', '/c', [command, ...args].map(quoteForCmdExe).join(' ')],
+      args: ['/d', '/s', '/c', [resolvedCommand, ...args].map(quoteForCmdExe).join(' ')],
       cwd: intent.cwd,
       warnings,
     };
@@ -103,13 +172,22 @@ function resolveWindowsSpawn(
   if (ext === '.ps1') {
     return {
       command: 'powershell.exe',
-      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', command, ...args],
+      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', resolvedCommand, ...args],
       cwd: intent.cwd,
       warnings,
     };
   }
 
-  return { command, args, cwd: intent.cwd, warnings };
+  if (!ext) {
+    return {
+      command: shell,
+      args: ['/d', '/s', '/c', [command, ...args].map(quoteForCmdExe).join(' ')],
+      cwd: intent.cwd,
+      warnings,
+    };
+  }
+
+  return { command: resolvedCommand, args, cwd: intent.cwd, warnings };
 }
 
 function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): ResolvedLocalPtySpawn {
@@ -169,12 +247,16 @@ export function resolveLocalPtySpawn({
   intent,
   platform,
   env,
+  fileExists = existsSync,
 }: {
   intent: PtySpawnIntent;
   platform: NodeJS.Platform;
   env: NodeJS.ProcessEnv;
+  fileExists?: FileExists;
 }): ResolvedLocalPtySpawn {
-  return isWindows(platform) ? resolveWindowsSpawn(intent, env) : resolvePosixSpawn(intent, env);
+  return isWindows(platform)
+    ? resolveWindowsSpawn(intent, env, fileExists)
+    : resolvePosixSpawn(intent, env);
 }
 
 export function logLocalPtySpawnWarnings(

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { log } from '@main/lib/logger';
+import { getWindowsEnvValue } from '@main/utils/windows-env';
 import { buildTmuxShellLine } from './tmux-session-name';
 
 export type PtyCommandSpec =
@@ -62,12 +63,6 @@ function quoteForCmdExe(input: string): string {
     .replace(/%/g, '%%')
     .replace(/!/g, '^!')
     .replace(/(["^&|<>()])/g, '^$1')}"`;
-}
-
-function getWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
-  const lowerKey = key.toLowerCase();
-  const envKey = Object.keys(env).find((candidate) => candidate.toLowerCase() === lowerKey);
-  return envKey ? env[envKey] : undefined;
 }
 
 function getWindowsPathDirs(env: NodeJS.ProcessEnv): string[] {

--- a/src/main/core/pty/spawn-utils.test.ts
+++ b/src/main/core/pty/spawn-utils.test.ts
@@ -1,9 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { AgentSessionConfig } from '@shared/agent-session';
-import type { GeneralSessionConfig } from '@shared/general-session';
-import { buildTmuxParams, resolveSpawnParams, resolveSshCommand } from './spawn-utils';
-
-const SHELL = '/bin/bash';
+import { resolveSshCommand } from './spawn-utils';
 
 function makeAgentConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSessionConfig {
   return {
@@ -19,172 +16,34 @@ function makeAgentConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSess
   };
 }
 
-function makeGeneralConfig(overrides: Partial<GeneralSessionConfig> = {}): GeneralSessionConfig {
-  return {
-    cwd: '/workspace',
-    ...overrides,
-  };
-}
-
-describe('resolveSpawnParams – agent type', () => {
-  it('no tmux, no shellSetup → shell -c with command joined', () => {
-    const config = makeAgentConfig();
-    const result = resolveSpawnParams('agent', config);
-
-    expect(result.cwd).toBe('/workspace');
-    expect(result.command).toBe(process.env.SHELL ?? '/bin/sh');
-    expect(result.args[0]).toBe('-c');
-    expect(result.args[1]).toBe('claude --resume conv-1');
-  });
-
-  it('with shellSetup → shellSetup prepended with &&', () => {
-    const config = makeAgentConfig({ shellSetup: 'source ~/.nvm/nvm.sh' });
-    const result = resolveSpawnParams('agent', config);
-
-    expect(result.args[0]).toBe('-c');
-    expect(result.args[1]).toBe('source ~/.nvm/nvm.sh && claude --resume conv-1');
-  });
-
-  it('with tmuxSessionName → tmux command contains has-session and session name', () => {
-    const config = makeAgentConfig({ tmuxSessionName: 'my-session' });
-    const result = resolveSpawnParams('agent', config);
-
-    expect(result.args[0]).toBe('-c');
-    const cmd = result.args[1];
-    expect(cmd).toContain('tmux has-session');
-    expect(cmd).toContain('"my-session"');
-    expect(cmd).toContain('tmux attach-session');
-  });
-
-  it('with both shellSetup and tmuxSessionName → tmux command contains shellSetup', () => {
-    const config = makeAgentConfig({
-      shellSetup: 'export NVM_DIR="$HOME/.nvm"',
-      tmuxSessionName: 'agent-session',
-    });
-    const result = resolveSpawnParams('agent', config);
-
-    expect(result.args[0]).toBe('-c');
-    const cmd = result.args[1];
-    expect(cmd).toContain('tmux has-session');
-    expect(cmd).toContain('"agent-session"');
-    expect(cmd).toContain('export NVM_DIR=\\"$HOME/.nvm\\"');
-    expect(cmd).toContain('claude --resume conv-1');
-  });
-});
-
-describe('resolveSpawnParams – general type', () => {
-  it('no command, no shellSetup → shell -c exec shell -il', () => {
-    const config = makeGeneralConfig();
-    const result = resolveSpawnParams('general', config);
-
-    const shell = process.env.SHELL ?? '/bin/sh';
-    expect(result.command).toBe(shell);
-    expect(result.args[0]).toBe('-il');
-    expect(result.cwd).toBe('/workspace');
-  });
-
-  it('with shellSetup → shell -c with shellSetup && exec shell -il', () => {
-    const config = makeGeneralConfig({ shellSetup: 'source /opt/homebrew/bin/brew shellenv' });
-    const result = resolveSpawnParams('general', config);
-
-    expect(result.args[0]).toBe('-c');
-    const cmd = result.args[1];
-    expect(cmd).toContain('source /opt/homebrew/bin/brew shellenv');
-    expect(cmd).toContain('exec');
-    expect(cmd).toContain('-il');
-  });
-
-  it('with tmuxSessionName → tmux wrapping', () => {
-    const config = makeGeneralConfig({ tmuxSessionName: 'general-session' });
-    const result = resolveSpawnParams('general', config);
-
-    expect(result.args[0]).toBe('-c');
-    const cmd = result.args[1];
-    expect(cmd).toContain('tmux has-session');
-    expect(cmd).toContain('"general-session"');
-    expect(cmd).toContain('tmux attach-session');
-  });
-
-  it('with both shellSetup and tmuxSessionName → tmux command contains shellSetup', () => {
-    const config = makeGeneralConfig({
-      shellSetup: 'eval "$(rbenv init -)"',
-      tmuxSessionName: 'ruby-session',
-    });
-    const result = resolveSpawnParams('general', config);
-
-    expect(result.args[0]).toBe('-c');
-    const cmd = result.args[1];
-    expect(cmd).toContain('tmux has-session');
-    expect(cmd).toContain('"ruby-session"');
-    expect(cmd).toContain('rbenv init');
-  });
-
-  it('with command → shell -c with the command instead of interactive shell', () => {
-    const config = makeGeneralConfig({ command: 'npm', args: ['install'] });
-    const result = resolveSpawnParams('general', config);
-
-    expect(result.args[0]).toBe('-c');
-    expect(result.args[1]).toBe('npm install');
-  });
-
-  it('with command and shellSetup → shellSetup prepended to command', () => {
-    const config = makeGeneralConfig({ command: 'npm', args: ['install'], shellSetup: 'nvm use' });
-    const result = resolveSpawnParams('general', config);
-
-    expect(result.args[0]).toBe('-c');
-    expect(result.args[1]).toBe('nvm use && npm install');
-  });
-
-  it('with command and tmuxSessionName → tmux wrapping around the command', () => {
-    const config = makeGeneralConfig({
-      command: 'npm',
-      args: ['install'],
-      tmuxSessionName: 'setup-session',
-    });
-    const result = resolveSpawnParams('general', config);
-
-    expect(result.args[0]).toBe('-c');
-    const cmd = result.args[1];
-    expect(cmd).toContain('tmux has-session');
-    expect(cmd).toContain('"setup-session"');
-    expect(cmd).toContain('npm install');
-  });
-});
-
-describe('buildTmuxParams', () => {
-  it('produces attach-or-create command with has-session, new-session -d, and attach-session', () => {
-    const result = buildTmuxParams(SHELL, 'my-tmux-session', 'claude --resume conv-42', '/tmp');
-
-    expect(result.command).toBe(SHELL);
-    expect(result.cwd).toBe('/tmp');
-    expect(result.args[0]).toBe('-c');
-
-    const cmd = result.args[1];
-    expect(cmd).toContain('tmux has-session -t "my-tmux-session"');
-    expect(cmd).toContain('tmux new-session -d -s "my-tmux-session"');
-    expect(cmd).toContain('tmux attach-session -t "my-tmux-session"');
-    const attachCount = (cmd.match(/tmux attach-session/g) ?? []).length;
-    expect(attachCount).toBe(2);
-  });
-
-  it('JSON-encodes the session name and command', () => {
-    const result = buildTmuxParams(SHELL, 'session with spaces', 'echo hello', '/home/user');
-
-    const cmd = result.args[1];
-    expect(cmd).toContain('"session with spaces"');
-    expect(cmd).toContain('"echo hello"');
-  });
-
-  it('uses the provided cwd', () => {
-    const result = buildTmuxParams(SHELL, 'sess', 'cmd', '/custom/path');
-    expect(result.cwd).toBe('/custom/path');
-  });
-});
-
 describe('resolveSshCommand', () => {
   it('runs remote commands through a login shell so PATH matches install/probe', () => {
     const result = resolveSshCommand('agent', makeAgentConfig());
 
     expect(result).toBe(`bash -l -c 'cd "/workspace" && claude --resume conv-1'`);
+  });
+
+  it('adds SSH env exports before the remote command', () => {
+    const result = resolveSshCommand('agent', makeAgentConfig(), {
+      FOO: 'bar',
+    });
+
+    expect(result).toBe(
+      `bash -l -c 'cd "/workspace" && export FOO='\\''bar'\\''; claude --resume conv-1'`
+    );
+  });
+
+  it('preserves remote tmux wrapping for SSH commands', () => {
+    const result = resolveSshCommand(
+      'agent',
+      makeAgentConfig({
+        tmuxSessionName: 'agent-session',
+      })
+    );
+
+    expect(result).toContain('tmux has-session -t "agent-session"');
+    expect(result).toContain('tmux new-session -d -s "agent-session"');
+    expect(result).toContain('tmux attach-session -t "agent-session"');
+    expect(result).toContain('claude --resume conv-1');
   });
 });

--- a/src/main/core/pty/spawn-utils.ts
+++ b/src/main/core/pty/spawn-utils.ts
@@ -1,91 +1,41 @@
 import type { AgentSessionConfig } from '@shared/agent-session';
 import type { GeneralSessionConfig } from '@shared/general-session';
 import { quoteShellArg } from '@main/utils/shellEscape';
+import { buildTmuxShellLine } from './tmux-session-name';
 
-export type SessionType = 'agent' | 'general' | 'lifecycle';
+export type SessionType = 'agent' | 'general';
 export type SessionConfig = AgentSessionConfig | GeneralSessionConfig;
 
-export interface SpawnParams {
-  command: string;
-  args: string[];
-  cwd: string;
-}
-
-/**
- * Derive the executable, arguments, and working directory from a session config.
- * Applies shellSetup and tmux wrapping where relevant.
- */
-export function resolveSpawnParams(type: SessionType, config: SessionConfig): SpawnParams {
+function posixShellLineForSsh(
+  type: SessionType,
+  config: SessionConfig
+): { cwd: string; line: string } {
   const shell = process.env.SHELL ?? '/bin/sh';
 
   switch (type) {
     case 'agent': {
       const cfg = config as AgentSessionConfig;
       const baseCmd = [cfg.command, ...cfg.args].join(' ');
-      const fullCmd = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
-
-      if (cfg.tmuxSessionName) {
-        return buildTmuxParams(shell, cfg.tmuxSessionName, fullCmd, cfg.cwd);
-      }
-
+      const line = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
       return {
-        command: shell,
-        args: ['-c', fullCmd],
         cwd: cfg.cwd,
+        line: cfg.tmuxSessionName ? buildTmuxShellLine(cfg.tmuxSessionName, line) : line,
       };
     }
-
     case 'general': {
       const cfg = config as GeneralSessionConfig;
       const baseCmd = cfg.command
         ? [cfg.command, ...(cfg.args ?? [])].join(' ')
         : `exec ${shell} -il`;
-      const fullCmd = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
-
-      if (cfg.tmuxSessionName) {
-        return buildTmuxParams(shell, cfg.tmuxSessionName, fullCmd, cfg.cwd);
-      }
-
-      if (cfg.command || cfg.shellSetup) {
-        return { command: shell, args: ['-c', fullCmd], cwd: cfg.cwd };
-      }
-
-      return { command: shell, args: ['-il'], cwd: cfg.cwd };
+      const line = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
+      return {
+        cwd: cfg.cwd,
+        line: cfg.tmuxSessionName ? buildTmuxShellLine(cfg.tmuxSessionName, line) : line,
+      };
     }
-
-    default: {
+    default:
       throw new Error(`Unsupported session type: ${type}`);
-    }
   }
-}
-
-/**
- * Build spawn params that wrap a command in a tmux session for persistence.
- *
- * Behaviour:
- * - If a tmux session named `sessionName` already exists → attach to it.
- * - Otherwise → create a detached session running `cmd`, then attach.
- */
-export function buildTmuxParams(
-  shell: string,
-  sessionName: string,
-  cmd: string,
-  cwd: string
-): SpawnParams {
-  const quotedName = JSON.stringify(sessionName);
-  const quotedCmd = JSON.stringify(cmd);
-
-  const checkExists = `tmux has-session -t ${quotedName} 2>/dev/null`;
-  const newSession = `tmux new-session -d -s ${quotedName} ${quotedCmd}`;
-  const attach = `tmux attach-session -t ${quotedName}`;
-
-  const tmuxCmd = `(${checkExists} && ${attach}) || (${newSession} && ${attach})`;
-
-  return {
-    command: shell,
-    args: ['-c', tmuxCmd],
-    cwd,
-  };
 }
 
 /**
@@ -96,12 +46,9 @@ export function resolveSshCommand(
   config: SessionConfig,
   envVars?: Record<string, string>
 ): string {
-  const { command, args, cwd } = resolveSpawnParams(type, config);
-  const shell = process.env.SHELL ?? '/bin/sh';
-
-  const innerCmd = command === shell && args[0] === '-c' ? args[1] : [command, ...args].join(' ');
+  const { cwd, line } = posixShellLineForSsh(type, config);
   const envPrefix = envVars ? buildSshEnvPrefix(envVars) : '';
-  const commandString = `cd ${JSON.stringify(cwd)} && ${envPrefix}${innerCmd}`;
+  const commandString = `cd ${JSON.stringify(cwd)} && ${envPrefix}${line}`;
 
   return `bash -l -c ${quoteShellArg(commandString)}`;
 }

--- a/src/main/core/pty/tmux-session-name.ts
+++ b/src/main/core/pty/tmux-session-name.ts
@@ -3,6 +3,15 @@ import { log } from '@main/lib/logger';
 
 const TMUX_SESSION_PREFIX = 'emdash-';
 
+export function buildTmuxShellLine(sessionName: string, commandLine: string): string {
+  const quotedName = JSON.stringify(sessionName);
+  const quotedCmd = JSON.stringify(commandLine);
+  const checkExists = `tmux has-session -t ${quotedName} 2>/dev/null`;
+  const newSession = `tmux new-session -d -s ${quotedName} ${quotedCmd}`;
+  const attach = `tmux attach-session -t ${quotedName}`;
+  return `(${checkExists} && ${attach}) || (${newSession} && ${attach})`;
+}
+
 export function makeTmuxSessionName(sessionId: string): string {
   const encoded = Buffer.from(sessionId, 'utf8').toString('base64url');
   return `${TMUX_SESSION_PREFIX}${encoded}`;

--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -1,11 +1,15 @@
-import type { GeneralSessionConfig } from '@shared/general-session';
 import { makePtySessionId } from '@shared/ptySessionId';
-import { Terminal } from '@shared/terminals';
+import type { Terminal } from '@shared/terminals';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
-import { Pty } from '@main/core/pty/pty';
+import type { Pty } from '@main/core/pty/pty';
 import { buildTerminalEnv } from '@main/core/pty/pty-env';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
-import { resolveSpawnParams } from '@main/core/pty/spawn-utils';
+import {
+  logLocalPtySpawnWarnings,
+  resolveLocalPtySpawn,
+  type PtyCommandSpec,
+  type PtySpawnIntent,
+} from '@main/core/pty/pty-spawn-platform';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import type { ExecFn } from '@main/core/utils/exec';
 import { log } from '@main/lib/logger';
@@ -65,11 +69,16 @@ export class LocalTerminalProvider implements TerminalProvider {
     initialSize: { cols: number; rows: number } = { cols: DEFAULT_COLS, rows: DEFAULT_ROWS },
     command?: { command: string; args: string[] }
   ): Promise<void> {
-    return this.spawnWithPolicy(terminal, initialSize, command, {
-      respawnOnExit: true,
-      preserveBufferOnExit: false,
-      watchDevServer: true,
-    });
+    return this.spawnWithPolicy(
+      terminal,
+      initialSize,
+      command ? { kind: 'argv', command: command.command, args: command.args } : undefined,
+      {
+        respawnOnExit: true,
+        preserveBufferOnExit: false,
+        watchDevServer: true,
+      }
+    );
   }
 
   async spawnLifecycleScript({
@@ -83,7 +92,7 @@ export class LocalTerminalProvider implements TerminalProvider {
     return this.spawnWithPolicy(
       terminal,
       initialSize,
-      { command, args: [] },
+      { kind: 'shell-line', commandLine: command },
       {
         respawnOnExit,
         preserveBufferOnExit,
@@ -95,28 +104,43 @@ export class LocalTerminalProvider implements TerminalProvider {
   private async spawnWithPolicy(
     terminal: Terminal,
     initialSize: { cols: number; rows: number },
-    command: { command: string; args: string[] } | undefined,
+    command: PtyCommandSpec | undefined,
     policy: SpawnPolicy
   ): Promise<void> {
     const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
     this.knownSessionIds.add(sessionId);
     if (this.sessions.has(sessionId)) return;
 
-    const cfg: GeneralSessionConfig = {
-      taskId: this.scopeId,
-      cwd: this.taskPath,
-      shellSetup: this.shellSetup,
-      tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
-      command: command?.command,
-      args: command?.args,
-    };
-    const params = resolveSpawnParams('general', cfg);
+    const intent: PtySpawnIntent = command
+      ? {
+          kind: 'run-command',
+          cwd: this.taskPath,
+          command,
+          shellSetup: this.shellSetup,
+          tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
+        }
+      : {
+          kind: 'interactive-shell',
+          cwd: this.taskPath,
+          shellSetup: this.shellSetup,
+          tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
+        };
+    const resolved = resolveLocalPtySpawn({
+      platform: process.platform,
+      env: process.env,
+      intent,
+    });
+
+    logLocalPtySpawnWarnings('LocalTerminalProvider', resolved.warnings, {
+      terminalId: terminal.id,
+      sessionId,
+    });
 
     const pty = spawnLocalPty({
       id: sessionId,
-      command: params.command,
-      args: params.args,
-      cwd: this.taskPath,
+      command: resolved.command,
+      args: resolved.args,
+      cwd: resolved.cwd,
       env: { ...buildTerminalEnv(), ...this.taskEnvVars },
       cols: initialSize.cols,
       rows: initialSize.rows,

--- a/src/main/utils/userEnv.test.ts
+++ b/src/main/utils/userEnv.test.ts
@@ -2,7 +2,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { afterEach, describe, expect, it } from 'vitest';
-import { ensureUserBinDirsInPath } from './userEnv';
+import { ensureUserBinDirsInPath, ensureWindowsNpmGlobalBinInPath } from './userEnv';
 
 const originalPath = process.env.PATH;
 
@@ -29,5 +29,19 @@ describe('ensureUserBinDirsInPath', () => {
 
     expect(added).toEqual([]);
     expect(process.env.PATH).toBe([dir, '/usr/bin'].join(path.delimiter));
+  });
+});
+
+describe('ensureWindowsNpmGlobalBinInPath', () => {
+  it('uses APPDATA case-insensitively when prepending npm global bin', () => {
+    const env: NodeJS.ProcessEnv = {
+      appdata: 'C:\\Users\\test\\AppData\\Roaming',
+      Path: 'C:\\Windows\\System32',
+    };
+
+    const added = ensureWindowsNpmGlobalBinInPath(env);
+
+    expect(added).toBe('C:\\Users\\test\\AppData\\Roaming\\npm');
+    expect(env.Path).toBe('C:\\Users\\test\\AppData\\Roaming\\npm;C:\\Windows\\System32');
   });
 });

--- a/src/main/utils/userEnv.ts
+++ b/src/main/utils/userEnv.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { log } from '@main/lib/logger';
+import { prependWindowsPathEntry } from './windows-env';
 
 /**
  * Keys that must never be overwritten from the shell env capture.
@@ -80,6 +81,16 @@ export function ensureUserBinDirsInPath(candidates: string[] = USER_BIN_DIRS): s
   return additions;
 }
 
+export function ensureWindowsNpmGlobalBinInPath(
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  const appData = env.APPDATA;
+  if (!appData) return null;
+
+  const npmPath = path.win32.join(appData, 'npm');
+  return prependWindowsPathEntry(env, npmPath) ? npmPath : null;
+}
+
 /**
  * Spawns `$SHELL -ilc 'env'` with a 5 s timeout. On any error (timeout,
  * missing shell, restricted environment) the function logs a warning and
@@ -92,6 +103,7 @@ export function ensureUserBinDirsInPath(candidates: string[] = USER_BIN_DIRS): s
 export async function resolveUserEnv(): Promise<void> {
   if (process.platform === 'win32') {
     // Windows PATH is managed differently; no login-shell capture needed.
+    ensureWindowsNpmGlobalBinInPath();
     return;
   }
 

--- a/src/main/utils/userEnv.ts
+++ b/src/main/utils/userEnv.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { log } from '@main/lib/logger';
-import { prependWindowsPathEntry } from './windows-env';
+import { getWindowsEnvValue, prependWindowsPathEntry } from './windows-env';
 
 /**
  * Keys that must never be overwritten from the shell env capture.
@@ -84,7 +84,7 @@ export function ensureUserBinDirsInPath(candidates: string[] = USER_BIN_DIRS): s
 export function ensureWindowsNpmGlobalBinInPath(
   env: NodeJS.ProcessEnv = process.env
 ): string | null {
-  const appData = env.APPDATA;
+  const appData = getWindowsEnvValue(env, 'APPDATA');
   if (!appData) return null;
 
   const npmPath = path.win32.join(appData, 'npm');

--- a/src/main/utils/windows-env.ts
+++ b/src/main/utils/windows-env.ts
@@ -1,0 +1,30 @@
+import path from 'node:path';
+
+export function getWindowsEnvKey(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  if (env[key] !== undefined) return key;
+
+  const lowerKey = key.toLowerCase();
+  return Object.keys(env).find((candidate) => candidate.toLowerCase() === lowerKey);
+}
+
+export function getWindowsEnvValue(env: NodeJS.ProcessEnv, key: string): string | undefined {
+  const envKey = getWindowsEnvKey(env, key);
+  return envKey ? env[envKey] : undefined;
+}
+
+export function getWindowsPathEnvKey(env: NodeJS.ProcessEnv): string {
+  return getWindowsEnvKey(env, 'PATH') ?? 'PATH';
+}
+
+export function prependWindowsPathEntry(env: NodeJS.ProcessEnv, entry: string): boolean {
+  const pathKey = getWindowsPathEnvKey(env);
+  const entries = (env[pathKey] ?? '').split(path.win32.delimiter).filter(Boolean);
+  const existing = new Set(entries.map((item) => item.toLowerCase()));
+
+  if (existing.has(entry.toLowerCase())) {
+    return false;
+  }
+
+  env[pathKey] = [entry, ...entries].join(path.win32.delimiter);
+  return true;
+}


### PR DESCRIPTION
- added platform-aware PTY spawning for Windows, POSIX, command shims, PowerShell scripts, and tmux cases
- removed /bin/sh fallbacks from Windows local terminal, agent, and dependency install paths
- fixed Windows env handling: preserves Path casing, reads env keys case-insensitively, avoids fake SHELL
- added %APPDATA%\npm to PATH on Windows so npm global CLIs can be found
- suppressed expected Windows node-pty pipe errors during PTY cleanup
- made Codex notification hooks use PowerShell on Windows instead of bash/curl
- introduced WorktreeHost abstraction for local vs SSH worktree filesystem operations
- added local worktree path safety checks for allowed roots, absolute paths, and symlink escapes
- refactored worktree service to use the new filesystem host abstraction