### PR TITLE
fix: raise maxBuffer for branch listing and fetch on large repos

### DIFF
--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -33,13 +33,14 @@ import { ownerFromUrl } from '@shared/pull-requests';
 import { err, ok, type Result } from '@shared/result';
 import type { FileSystemProvider } from '@main/core/fs/types';
 import { GIT_EXECUTABLE, type ExecFn } from '@main/core/utils/exec';
-import { GitProvider } from '../types';
+import { type GitProvider } from '../types';
 import { CatFileBatch } from './cat-file-batch';
 import {
   computeBaseRef,
   mapStatus,
   MAX_DIFF_CONTENT_BYTES,
   MAX_DIFF_OUTPUT_BYTES,
+  MAX_REF_LIST_BYTES,
   parseDiffLines,
   stripTrailingNewline,
 } from './git-utils';
@@ -893,6 +894,7 @@ export class GitService implements GitProvider {
 
       await this.exec('git', selectedRemote ? ['fetch', selectedRemote] : ['fetch'], {
         cwd: this.path,
+        maxBuffer: MAX_REF_LIST_BYTES,
       });
       return ok();
     } catch (error: unknown) {
@@ -1212,7 +1214,7 @@ export class GitService implements GitProvider {
     const { stdout } = await this.exec(
       'git',
       ['branch', '-a', '--format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(refname)'],
-      { cwd: this.path }
+      { cwd: this.path, maxBuffer: MAX_REF_LIST_BYTES }
     );
 
     const branches: Branch[] = [];
@@ -1346,7 +1348,10 @@ export class GitService implements GitProvider {
     remote = 'origin'
   ): Promise<Result<void, CreateBranchError>> {
     if (syncWithRemote) {
-      await this.exec('git', ['fetch', remote], { cwd: this.path }).catch(() => {});
+      await this.exec('git', ['fetch', remote], {
+        cwd: this.path,
+        maxBuffer: MAX_REF_LIST_BYTES,
+      }).catch(() => {});
     }
     const base = syncWithRemote ? `${remote}/${from}` : `refs/heads/${from}`;
     try {

--- a/src/main/core/git/impl/git-utils.ts
+++ b/src/main/core/git/impl/git-utils.ts
@@ -6,6 +6,13 @@ export const MAX_DIFF_CONTENT_BYTES = 512 * 1024;
 /** Maximum bytes for `git diff` output (larger than content limit due to headers/context). */
 export const MAX_DIFF_OUTPUT_BYTES = 10 * 1024 * 1024;
 
+/**
+ * Maximum bytes for ref-listing / fetch output. Repos with many thousands of refs
+ * (e.g. monorepos) easily exceed Node's 1 MB default `maxBuffer`, which would otherwise
+ * cause `git branch -a` and `git fetch` to fail silently with no branches surfaced.
+ */
+export const MAX_REF_LIST_BYTES = 64 * 1024 * 1024;
+
 /** Headers emitted by `git diff` that should be skipped when parsing hunks. */
 const DIFF_HEADER_PREFIXES = [
   'diff ',


### PR DESCRIPTION
## Summary

- On repos with many refs (e.g. a monorepo with ~25k refs producing ~2.7 MB of `git branch -a --format=...` output), Node's `execFile` rejects with `ERR_CHILD_PROCESS_STDOUT_MAXBUFFER_EXCEEDED` because of the 1 MB default `maxBuffer`. The error propagates up and the UI surfaces no local branches and no remote PRs (PR mapping joins against the branch list, so it comes up empty too).
- Fetch progress output can hit the same ceiling on stale large repos.
- Adds a `MAX_REF_LIST_BYTES = 64 MB` constant and passes it as `maxBuffer` to `git branch -a` in `getBranches()` and to `git fetch` in `fetch()`.

## Test plan

- [ ] Open a large repo (e.g. one with >1 MB of `git branch -a --format=...` output) in emdash and confirm local branches populate
- [ ] Confirm remote GitHub PRs sync for the same repo
- [ ] Sanity check on a small repo: no regression in branch / PR listing
- [ ] `pnpm run typecheck`, `pnpm run lint`, `pnpm run format`, `pnpm test`
