### PR TITLE
feat: fork workflow support — separate upstream and push remotes

### DIFF
--- a/src/main/core/github/services/fork-detection-service.test.ts
+++ b/src/main/core/github/services/fork-detection-service.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Remote } from '@shared/git';
+import { detectForkRelationship } from './fork-detection-service';
+
+const mockGetOctokit = vi.fn();
+
+vi.mock('./octokit-provider', () => ({
+  getOctokit: () => mockGetOctokit(),
+}));
+
+const originRemote: Remote = { name: 'origin', url: 'https://github.com/myuser/repo.git' };
+const upstreamRemote: Remote = { name: 'upstream', url: 'https://github.com/org/repo.git' };
+const gitlabRemote: Remote = { name: 'origin', url: 'https://gitlab.com/myuser/repo.git' };
+
+describe('detectForkRelationship', () => {
+  beforeEach(() => {
+    mockGetOctokit.mockReset();
+  });
+
+  it('detects a fork when origin is a fork and upstream matches parent', async () => {
+    mockGetOctokit.mockResolvedValue({
+      rest: {
+        repos: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              fork: true,
+              parent: { html_url: 'https://github.com/org/repo', full_name: 'org/repo' },
+            },
+          }),
+        },
+      },
+    });
+
+    const result = await detectForkRelationship([originRemote, upstreamRemote]);
+    expect(result).toEqual({
+      forkRemoteName: 'origin',
+      upstreamRemoteName: 'upstream',
+      upstreamOwnerRepo: 'org/repo',
+    });
+  });
+
+  it('returns null when the repo is not a fork', async () => {
+    mockGetOctokit.mockResolvedValue({
+      rest: {
+        repos: {
+          get: vi.fn().mockResolvedValue({
+            data: { fork: false },
+          }),
+        },
+      },
+    });
+
+    const result = await detectForkRelationship([originRemote, upstreamRemote]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null when fewer than 2 remotes', async () => {
+    const result = await detectForkRelationship([originRemote]);
+    expect(result).toBeNull();
+    expect(mockGetOctokit).not.toHaveBeenCalled();
+  });
+
+  it('returns null when no GitHub remotes', async () => {
+    const result = await detectForkRelationship([gitlabRemote]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null without API call when only one GitHub remote exists', async () => {
+    const nonGithubRemote: Remote = { name: 'upstream', url: 'https://gitlab.com/org/repo.git' };
+    const result = await detectForkRelationship([originRemote, nonGithubRemote]);
+    expect(result).toBeNull();
+    expect(mockGetOctokit).not.toHaveBeenCalled();
+  });
+
+  it('returns null when fork parent has no matching remote', async () => {
+    mockGetOctokit.mockResolvedValue({
+      rest: {
+        repos: {
+          get: vi.fn().mockResolvedValue({
+            data: {
+              fork: true,
+              parent: {
+                html_url: 'https://github.com/other-org/repo',
+                full_name: 'other-org/repo',
+              },
+            },
+          }),
+        },
+      },
+    });
+
+    const result = await detectForkRelationship([originRemote, upstreamRemote]);
+    expect(result).toBeNull();
+  });
+
+  it('returns null on API error', async () => {
+    mockGetOctokit.mockResolvedValue({
+      rest: {
+        repos: {
+          get: vi.fn().mockRejectedValue(new Error('network error')),
+        },
+      },
+    });
+
+    const result = await detectForkRelationship([originRemote, upstreamRemote]);
+    expect(result).toBeNull();
+  });
+});

--- a/src/main/core/github/services/fork-detection-service.ts
+++ b/src/main/core/github/services/fork-detection-service.ts
@@ -1,0 +1,52 @@
+import type { Remote } from '@shared/git';
+import { log } from '@main/lib/logger';
+import { getOctokit } from './octokit-provider';
+import { isGitHubUrl, normalizeGitHubUrl, splitNormalizedUrl } from './utils';
+
+export type ForkDetectionResult = {
+  forkRemoteName: string;
+  upstreamRemoteName: string;
+  upstreamOwnerRepo: string;
+};
+
+export async function detectForkRelationship(
+  remotes: Remote[]
+): Promise<ForkDetectionResult | null> {
+  const githubRemotes = remotes.filter((r) => isGitHubUrl(r.url));
+  if (githubRemotes.length < 2) return null;
+
+  const ordered = [
+    ...githubRemotes.filter((r) => r.name === 'origin'),
+    ...githubRemotes.filter((r) => r.name !== 'origin'),
+  ];
+
+  try {
+    const octokit = await getOctokit();
+
+    for (const candidate of ordered) {
+      const normalizedUrl = normalizeGitHubUrl(candidate.url);
+      const { owner, repo } = splitNormalizedUrl(normalizedUrl);
+      const { data } = await octokit.rest.repos.get({ owner, repo });
+
+      if (!data.fork || !data.parent) continue;
+
+      const parentUrl = normalizeGitHubUrl(data.parent.html_url);
+      const matchingUpstream = remotes.find(
+        (r) => r.name !== candidate.name && normalizeGitHubUrl(r.url) === parentUrl
+      );
+
+      if (!matchingUpstream) continue;
+
+      return {
+        forkRemoteName: candidate.name,
+        upstreamRemoteName: matchingUpstream.name,
+        upstreamOwnerRepo: data.parent.full_name,
+      };
+    }
+
+    return null;
+  } catch (e) {
+    log.warn('Fork detection failed', { error: String(e) });
+    return null;
+  }
+}

--- a/src/main/core/projects/settings/project-settings.ts
+++ b/src/main/core/projects/settings/project-settings.ts
@@ -99,6 +99,12 @@ export class LocalProjectSettingsProvider implements ProjectSettingsProvider {
     return settings.remote ?? 'origin';
   }
 
+  async getPushRemote(): Promise<string> {
+    const settings = await this.get();
+    if (settings.pushRemote) return settings.pushRemote;
+    return this.getRemote();
+  }
+
   async getWorktreeDirectory(): Promise<string> {
     const settings = await this.get();
     const defaultWorktreeDirectory = (await appSettingsService.get('localProject'))
@@ -213,6 +219,12 @@ export class SshProjectSettingsProvider implements ProjectSettingsProvider {
   async getRemote(): Promise<string> {
     const settings = await this.get();
     return settings.remote ?? 'origin';
+  }
+
+  async getPushRemote(): Promise<string> {
+    const settings = await this.get();
+    if (settings.pushRemote) return settings.pushRemote;
+    return this.getRemote();
   }
 
   async getWorktreeDirectory(): Promise<string> {

--- a/src/main/core/projects/settings/schema.ts
+++ b/src/main/core/projects/settings/schema.ts
@@ -34,6 +34,8 @@ export const projectSettingsSchema = z.object({
   worktreeDirectory: z.string().trim().optional(),
   defaultBranch: defaultBranchSettingSchema.optional(),
   remote: z.string().optional(),
+  pushRemote: z.string().optional(),
+  forkDetectionDismissed: z.boolean().optional(),
 });
 
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
@@ -41,6 +43,7 @@ export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
 export interface ProjectSettingsProvider {
   getDefaultBranch(): Promise<string>;
   getRemote(): Promise<string>;
+  getPushRemote(): Promise<string>;
   getWorktreeDirectory(): Promise<string>;
   get(): Promise<ProjectSettings>;
   update(settings: ProjectSettings): Promise<Result<void, UpdateProjectSettingsError>>;

--- a/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -26,6 +26,7 @@ function makeSettings(preservePatterns: string[] = []): ProjectSettingsProvider 
     getWorktreeDirectory: async () => '',
     getDefaultBranch: async () => 'main',
     getRemote: async () => 'origin',
+    getPushRemote: async () => 'origin',
   } as ProjectSettingsProvider;
 }
 

--- a/src/main/core/pull-requests/pr-sync-scheduler.ts
+++ b/src/main/core/pull-requests/pr-sync-scheduler.ts
@@ -1,8 +1,11 @@
 import { eq } from 'drizzle-orm';
+import { forkDetectedChannel } from '@shared/events/forkEvents';
+import { detectForkRelationship } from '@main/core/github/services/fork-detection-service';
 import { isGitHubUrl, normalizeGitHubUrl } from '@main/core/github/services/utils';
 import { projectManager } from '@main/core/projects/project-manager';
 import { db } from '@main/db/client';
 import { projectRemotes } from '@main/db/schema';
+import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { prSyncEngine } from './pr-sync-engine';
 import { syncProjectRemotes } from './project-remotes-service';
@@ -18,6 +21,8 @@ export class PrSyncScheduler {
   private readonly _intervals = new Map<string, ReturnType<typeof setInterval>[]>();
   /** Per-project set of known GitHub remote URLs (for cleanup on unmount). */
   private readonly _projectRemoteUrls = new Map<string, string[]>();
+  /** Projects already checked for fork relationship in this session. */
+  private readonly _forkChecked = new Set<string>();
 
   initialize(): void {
     projectManager.registerOnProjectOpened((id) => this.onProjectMounted(id));
@@ -29,6 +34,7 @@ export class PrSyncScheduler {
   async onProjectMounted(projectId: string): Promise<void> {
     log.info('PrSyncScheduler: onProjectMounted', { projectId });
     const remoteUrls = await this._syncAndGetGitHubRemotes(projectId);
+    void this._detectForkIfNeeded(projectId);
     if (remoteUrls.length === 0) {
       log.info('PrSyncScheduler: no GitHub remotes found, skipping sync', { projectId });
       return;
@@ -67,6 +73,7 @@ export class PrSyncScheduler {
       prSyncEngine.cancel(url);
     }
     this._projectRemoteUrls.delete(projectId);
+    this._forkChecked.delete(projectId);
   }
 
   // ── Task lifecycle ─────────────────────────────────────────────────────────
@@ -124,6 +131,34 @@ export class PrSyncScheduler {
   }
 
   // ── Private helpers ────────────────────────────────────────────────────────
+
+  private async _detectForkIfNeeded(projectId: string): Promise<void> {
+    if (this._forkChecked.has(projectId)) return;
+    this._forkChecked.add(projectId);
+
+    try {
+      const project = projectManager.getProject(projectId);
+      if (!project) return;
+
+      const settings = await project.settings.get();
+      if (settings.pushRemote || settings.forkDetectionDismissed) return;
+
+      const remotes = await project.repository.getRemotes();
+      const result = await detectForkRelationship(remotes);
+      if (!result) return;
+
+      log.info('PrSyncScheduler: fork detected', { projectId, ...result });
+
+      events.emit(forkDetectedChannel, {
+        projectId,
+        forkRemoteName: result.forkRemoteName,
+        upstreamRemoteName: result.upstreamRemoteName,
+        upstreamOwnerRepo: result.upstreamOwnerRepo,
+      });
+    } catch (e) {
+      log.warn('PrSyncScheduler: fork detection error', { projectId, error: String(e) });
+    }
+  }
 
   private async _syncAndGetGitHubRemotes(projectId: string): Promise<string[]> {
     const project = projectManager.getProject(projectId);

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -4,6 +4,7 @@ import { WelcomeScreen } from './app/welcome';
 import { Workspace } from './app/workspace';
 import { IntegrationsProvider } from './features/integrations/integrations-provider';
 import { Onboarding } from './features/onboarding/onboarding';
+import { ForkDetectionListener } from './features/projects/components/fork-detection-listener';
 import { useAccountSession } from './lib/hooks/useAccount';
 import { useLegacyPortStatus } from './lib/hooks/useLegacyPort';
 import { WorkspaceLayoutContextProvider } from './lib/layout/layout-provider';
@@ -72,6 +73,7 @@ function AppContent() {
   return (
     <TooltipProvider delay={300}>
       <ModalProvider>
+        <ForkDetectionListener />
         <WorkspaceLayoutContextProvider>
           <TerminalPoolProvider>
             <GithubContextProvider>

--- a/src/renderer/app/modal-registry.ts
+++ b/src/renderer/app/modal-registry.ts
@@ -1,6 +1,7 @@
 import { IntegrationSetupModal } from '@renderer/features/integrations/integration-setup-modal';
 import { McpModal } from '@renderer/features/mcp/components/McpModal';
 import { AddProjectModal } from '@renderer/features/projects/components/add-project-modal/add-project-modal';
+import { ForkDetectionModal } from '@renderer/features/projects/components/fork-detection-modal';
 import { CreateSkillModal } from '@renderer/features/skills/components/CreateSkillModal';
 import { AddRemoteModal } from '@renderer/features/tasks/add-remote-modal';
 import { CreateConversationModal } from '@renderer/features/tasks/conversations/create-conversation-modal';
@@ -13,7 +14,7 @@ import { ChangeProjectConnectionModal } from '@renderer/lib/components/change-pr
 import { ConfirmActionDialog } from '@renderer/lib/components/confirm-action-dialog';
 import { FeedbackModal } from '@renderer/lib/components/feedback-modal/feedback-modal';
 import { GithubDeviceFlowModalOverlay } from '@renderer/lib/components/github-device-flow-modal';
-import { ModalComponent } from '@renderer/lib/modal/modal-provider';
+import { type ModalComponent } from '@renderer/lib/modal/modal-provider';
 
 export type ModalSize = 'xs' | 'sm' | 'md' | 'lg';
 
@@ -45,5 +46,6 @@ export const modalRegistry = {
   renameTaskModal: createModal(RenameTaskModal, { size: 'xs' }),
   integrationSetupModal: createModal(IntegrationSetupModal, { size: 'md' }),
   addRemoteModal: createModal(AddRemoteModal),
+  forkDetectionModal: createModal(ForkDetectionModal, { size: 'sm' }),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } satisfies Record<string, ModalRegistryEntry<any, any>>;

--- a/src/renderer/features/projects/components/fork-detection-listener.tsx
+++ b/src/renderer/features/projects/components/fork-detection-listener.tsx
@@ -1,0 +1,57 @@
+import { useEffect } from 'react';
+import { forkDetectedChannel } from '@shared/events/forkEvents';
+import { events, rpc } from '@renderer/lib/ipc';
+import { useModalContext } from '@renderer/lib/modal/modal-provider';
+import { log } from '@renderer/utils/logger';
+
+function dismissForkDetection(projectId: string): void {
+  void (async () => {
+    try {
+      const currentSettings = await rpc.projects.getProjectSettings(projectId);
+      await rpc.projects.updateProjectSettings(projectId, {
+        ...currentSettings,
+        forkDetectionDismissed: true,
+      });
+    } catch (e) {
+      log.error('[ForkDetection] failed to dismiss fork detection', e);
+    }
+  })();
+}
+
+export function ForkDetectionListener() {
+  const { showModal } = useModalContext();
+
+  useEffect(() => {
+    const cleanup = events.on(forkDetectedChannel, (payload) => {
+      log.info('[ForkDetection] fork detected event received', payload);
+      showModal('forkDetectionModal', {
+        ...payload,
+        onSuccess: ({ accepted }) => {
+          void (async () => {
+            try {
+              const currentSettings = await rpc.projects.getProjectSettings(payload.projectId);
+              if (accepted) {
+                await rpc.projects.updateProjectSettings(payload.projectId, {
+                  ...currentSettings,
+                  remote: payload.upstreamRemoteName,
+                  pushRemote: payload.forkRemoteName,
+                });
+              } else {
+                dismissForkDetection(payload.projectId);
+              }
+            } catch (e) {
+              log.error('[ForkDetection] failed to update settings', e);
+            }
+          })();
+        },
+        onClose: () => {
+          dismissForkDetection(payload.projectId);
+        },
+      });
+    });
+
+    return cleanup;
+  }, [showModal]);
+
+  return null;
+}

--- a/src/renderer/features/projects/components/fork-detection-modal.tsx
+++ b/src/renderer/features/projects/components/fork-detection-modal.tsx
@@ -1,0 +1,48 @@
+import type { ForkDetectedPayload } from '@shared/events/forkEvents';
+import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
+import { Button } from '@renderer/lib/ui/button';
+import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
+import {
+  DialogContentArea,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/lib/ui/dialog';
+
+export type ForkDetectionModalArgs = ForkDetectedPayload;
+
+type Props = BaseModalProps<{ accepted: boolean }> & ForkDetectionModalArgs;
+
+export function ForkDetectionModal({
+  forkRemoteName,
+  upstreamRemoteName,
+  upstreamOwnerRepo,
+  onSuccess,
+}: Props) {
+  return (
+    <div className="flex flex-col overflow-hidden">
+      <DialogHeader>
+        <DialogTitle>Fork detected</DialogTitle>
+      </DialogHeader>
+      <DialogContentArea className="space-y-3">
+        <p className="text-sm">
+          This repository appears to be a fork of{' '}
+          <code className="font-mono text-xs">{upstreamOwnerRepo}</code>.
+        </p>
+        <p className="text-sm text-muted-foreground">
+          Would you like to fetch from{' '}
+          <code className="font-mono text-xs">{upstreamRemoteName}</code> and push to{' '}
+          <code className="font-mono text-xs">{forkRemoteName}</code>?
+        </p>
+      </DialogContentArea>
+      <DialogFooter>
+        <Button variant="ghost" size="sm" onClick={() => onSuccess({ accepted: false })}>
+          No, keep current settings
+        </Button>
+        <ConfirmButton size="sm" onClick={() => onSuccess({ accepted: true })}>
+          Yes, configure
+        </ConfirmButton>
+      </DialogFooter>
+    </div>
+  );
+}

--- a/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
@@ -34,6 +34,7 @@ type FormState = {
   worktreeDirectory: string;
   defaultBranch: Branch | null;
   remote: string;
+  pushRemote: string;
 };
 
 function normalizeScript(val: string | string[] | undefined): string {
@@ -72,10 +73,11 @@ export function settingsToForm(
     worktreeDirectory: s.worktreeDirectory ?? '',
     defaultBranch,
     remote: s.remote ?? '',
+    pushRemote: s.pushRemote ?? '',
   };
 }
 
-export function formToSettings(f: FormState): ProjectSettings {
+export function formToSettings(f: FormState, original: ProjectSettings): ProjectSettings {
   let defaultBranch: ProjectSettings['defaultBranch'];
   if (f.defaultBranch) {
     defaultBranch =
@@ -84,6 +86,7 @@ export function formToSettings(f: FormState): ProjectSettings {
         : f.defaultBranch.branch;
   }
   return {
+    ...original,
     preservePatterns: f.preservePatterns
       .split('\n')
       .map((p) => p.trim())
@@ -98,6 +101,7 @@ export function formToSettings(f: FormState): ProjectSettings {
     worktreeDirectory: f.worktreeDirectory || undefined,
     defaultBranch,
     remote: f.remote || undefined,
+    pushRemote: f.pushRemote || undefined,
   };
 }
 
@@ -123,7 +127,6 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
 
   const baseline = useMemo(
     () => settingsToForm(initial, configuredRemote, remotes),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
     [initial, configuredRemote, remotes]
   );
   const [form, setForm] = useState<FormState>(baseline);
@@ -150,7 +153,9 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
     const formAtSubmit = form;
     setSaveStatus('saving');
 
-    const result = await save(formToSettings(formAtSubmit)).catch(() => err({ type: 'error' }));
+    const result = await save(formToSettings(formAtSubmit, initial)).catch(() =>
+      err({ type: 'error' })
+    );
 
     if (result.success) {
       setWorktreeDirectoryError(null);
@@ -257,6 +262,33 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
               </SelectContent>
             </Select>
           </Field>
+
+          {remotes.length >= 2 && (
+            <Field>
+              <FieldTitle>Push remote</FieldTitle>
+              <FieldDescription>
+                The remote where branches are pushed and published. Defaults to the fetch remote
+                above.
+              </FieldDescription>
+              <Select
+                value={form.pushRemote || ''}
+                onValueChange={(value) => update('pushRemote', value ?? '')}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Same as fetch remote" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Same as fetch remote</SelectItem>
+                  {remotes.map((r) => (
+                    <SelectItem key={r.name} value={r.name}>
+                      {r.name}
+                      <span className="ml-2 text-xs text-muted-foreground">{r.url}</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          )}
 
           <Separator />
 

--- a/src/renderer/features/projects/stores/repository-store.ts
+++ b/src/renderer/features/projects/stores/repository-store.ts
@@ -7,7 +7,12 @@ import type {
   RemoteBranch,
   RemoteBranchesPayload,
 } from '@shared/git';
-import { bareRefName, computeDefaultBranch, selectPreferredRemote } from '@shared/git-utils';
+import {
+  bareRefName,
+  computeDefaultBranch,
+  selectPreferredPushRemote,
+  selectPreferredRemote,
+} from '@shared/git-utils';
 import { events, rpc } from '@renderer/lib/ipc';
 import { Resource } from '@renderer/lib/stores/resource';
 import { isGitHubUrl, normalizeGitHubUrl } from '@renderer/utils/github/utils';
@@ -63,7 +68,11 @@ export class RepositoryStore {
 
     // Invalidate remote data when settings that affect remote resolution change.
     this._settingsDisposer = reaction(
-      () => [settingsStore.settings?.remote, settingsStore.settings?.defaultBranch],
+      () => [
+        settingsStore.settings?.remote,
+        settingsStore.settings?.pushRemote,
+        settingsStore.settings?.defaultBranch,
+      ],
       () => this.remoteData.invalidate()
     );
 
@@ -74,6 +83,8 @@ export class RepositoryStore {
       localBranches: computed,
       remoteBranches: computed,
       configuredRemote: computed,
+      configuredPushRemote: computed,
+      pushRepositoryUrl: computed,
       defaultBranchName: computed,
       defaultBranch: computed,
       remotes: computed,
@@ -115,6 +126,19 @@ export class RepositoryStore {
     const setting = this.settingsStore.settings?.remote;
     const remotes = this.remoteData.data?.remotes ?? [];
     return selectPreferredRemote(setting, remotes);
+  }
+
+  get configuredPushRemote(): Remote {
+    const pushSetting = this.settingsStore.settings?.pushRemote;
+    const fetchSetting = this.settingsStore.settings?.remote;
+    const remotes = this.remoteData.data?.remotes ?? [];
+    return selectPreferredPushRemote(pushSetting, fetchSetting, remotes);
+  }
+
+  get pushRepositoryUrl(): string | null {
+    const url = this.configuredPushRemote.url;
+    if (!url || !isGitHubUrl(url)) return null;
+    return normalizeGitHubUrl(url);
   }
 
   get remotes(): Remote[] {
@@ -172,7 +196,7 @@ export class RepositoryStore {
   }
 
   isBranchOnRemote(branchName: string): boolean {
-    const remoteName = this.configuredRemote.name;
+    const remoteName = this.configuredPushRemote.name;
     return this.remoteBranches.some((b) => b.branch === branchName && b.remote.name === remoteName);
   }
 

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.test.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Branch } from '@shared/git';
-import { resolveInitialBaseBranch, toShortBranchName } from './base-branch';
+import { resolveEffectiveHead, resolveInitialBaseBranch, toShortBranchName } from './base-branch';
 
 const originRemote = { name: 'origin', url: 'git@github.com:owner/repo.git' };
 
@@ -51,5 +51,35 @@ describe('resolveInitialBaseBranch', () => {
     const branches: Branch[] = [{ type: 'remote', remote: originRemote, branch: 'main' }];
 
     expect(resolveInitialBaseBranch(branches, undefined, undefined)).toBeUndefined();
+  });
+});
+
+describe('resolveEffectiveHead', () => {
+  it('returns branch name when not cross-fork', () => {
+    expect(resolveEffectiveHead('feature-x', false, null, null)).toBe('feature-x');
+  });
+
+  it('returns branch name when not cross-fork even with override set', () => {
+    expect(resolveEffectiveHead('feature-x', false, 'myuser:feature-x', 'myuser')).toBe(
+      'feature-x'
+    );
+  });
+
+  it('returns owner:branch in cross-fork mode with no override', () => {
+    expect(resolveEffectiveHead('feature-x', true, null, 'myuser')).toBe('myuser:feature-x');
+  });
+
+  it('returns override when set in cross-fork mode', () => {
+    expect(resolveEffectiveHead('feature-x', true, 'other:feature-x', 'myuser')).toBe(
+      'other:feature-x'
+    );
+  });
+
+  it('falls back to default when override is empty string', () => {
+    expect(resolveEffectiveHead('feature-x', true, '', 'myuser')).toBe('myuser:feature-x');
+  });
+
+  it('returns plain branch name in cross-fork mode when no owner available', () => {
+    expect(resolveEffectiveHead('feature-x', true, null, null)).toBe('feature-x');
   });
 });

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.ts
@@ -31,6 +31,17 @@ export function toShortBranchName(
   return trimmed;
 }
 
+export function resolveEffectiveHead(
+  branchName: string,
+  isCrossFork: boolean,
+  headOverride: string | null,
+  defaultForkOwner: string | null
+): string {
+  if (!isCrossFork) return branchName;
+  if (headOverride) return headOverride;
+  return defaultForkOwner ? `${defaultForkOwner}:${branchName}` : branchName;
+}
+
 export function resolveInitialBaseBranch(
   branches: Branch[],
   preferredBaseRef: string | undefined,

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
@@ -23,11 +23,13 @@ import { Input } from '@renderer/lib/ui/input';
 import { Separator } from '@renderer/lib/ui/separator';
 import { SplitButton } from '@renderer/lib/ui/split-button';
 import { Textarea } from '@renderer/lib/ui/textarea';
+import { extractOwner } from '@renderer/utils/github/utils';
 import { log } from '@renderer/utils/logger';
-import { resolveInitialBaseBranch } from './base-branch';
+import { resolveEffectiveHead, resolveInitialBaseBranch } from './base-branch';
 
 export type CreatePrModalArgs = {
   nameWithOwner: string; // kept as-is for modal registry compatibility; value is a repositoryUrl
+  pushRepositoryUrl: string | null;
   branchName: string;
   draft: boolean;
   workspaceId: string;
@@ -37,12 +39,24 @@ type Props = BaseModalProps<void> & CreatePrModalArgs;
 
 export const CreatePrModal = observer(function CreatePrModal({
   nameWithOwner: repositoryUrl,
+  pushRepositoryUrl,
   branchName,
   draft,
   workspaceId,
   onSuccess,
 }: Props) {
   const { projectId, taskId } = useTaskViewContext();
+  const isCrossFork = Boolean(
+    pushRepositoryUrl && repositoryUrl && pushRepositoryUrl !== repositoryUrl
+  );
+  const defaultForkOwner = pushRepositoryUrl ? extractOwner(pushRepositoryUrl) : null;
+  const [headOverride, setHeadOverride] = useState<string | null>(null);
+  const effectiveHead = resolveEffectiveHead(
+    branchName,
+    isCrossFork,
+    headOverride,
+    defaultForkOwner
+  );
   const [title, setTitle] = useState(branchName);
   const [description, setDescription] = useState('');
   const [selectedBaseOverride, setSelectedBaseOverride] = useState<Branch | undefined>();
@@ -65,16 +79,13 @@ export const CreatePrModal = observer(function CreatePrModal({
     );
 
   const doCreate = async (push: boolean) => {
-    if (!title.trim() || !repositoryUrl || !selectedBase?.branch) return;
+    if (!title.trim() || !repositoryUrl || !selectedBase?.branch || !effectiveHead.trim()) return;
     setError(null);
     setIsCreating(true);
     try {
       if (push) {
-        const pushResult = await rpc.git.push(
-          projectId,
-          workspaceId,
-          repo?.configuredRemote.name ?? 'origin'
-        );
+        const pushRemoteName = repo?.configuredPushRemote.name ?? 'origin';
+        const pushResult = await rpc.git.push(projectId, workspaceId, pushRemoteName);
         if (!pushResult.success) {
           log.error('Failed to push branch:', pushResult.error);
           setError(
@@ -86,7 +97,7 @@ export const CreatePrModal = observer(function CreatePrModal({
 
       const result = await rpc.pullRequests.createPullRequest({
         repositoryUrl,
-        head: branchName,
+        head: effectiveHead,
         base: selectedBase.branch,
         title: title.trim(),
         body: description.trim() || undefined,
@@ -143,6 +154,22 @@ export const CreatePrModal = observer(function CreatePrModal({
             }
           />
         </div>
+        {isCrossFork && (
+          <div className="space-y-2">
+            <p className="text-xs text-muted-foreground">
+              From <code className="font-mono">{pushRepositoryUrl}</code> →{' '}
+              <code className="font-mono">{repositoryUrl}</code>
+            </p>
+            <Field>
+              <FieldLabel>Head</FieldLabel>
+              <Input
+                value={effectiveHead}
+                onChange={(e) => setHeadOverride(e.target.value)}
+                placeholder={`${defaultForkOwner}:${branchName}`}
+              />
+            </Field>
+          </div>
+        )}
         <Separator />
         <FieldGroup>
           <Field>
@@ -179,7 +206,9 @@ export const CreatePrModal = observer(function CreatePrModal({
             size="sm"
             loading={isCreating}
             loadingLabel="Creating..."
-            disabled={!hasGitHubRemote || !selectedBase?.branch || !title.trim()}
+            disabled={
+              !hasGitHubRemote || !selectedBase?.branch || !title.trim() || !effectiveHead.trim()
+            }
             actions={[
               {
                 value: 'push-and-create',
@@ -198,7 +227,13 @@ export const CreatePrModal = observer(function CreatePrModal({
           <ConfirmButton
             size="sm"
             onClick={() => void doCreate(false)}
-            disabled={!hasGitHubRemote || !selectedBase?.branch || !title.trim() || isCreating}
+            disabled={
+              !hasGitHubRemote ||
+              !selectedBase?.branch ||
+              !title.trim() ||
+              !effectiveHead.trim() ||
+              isCreating
+            }
           >
             {isCreating ? 'Creating...' : draft ? 'Create Draft' : 'Create PR'}
           </ConfirmButton>

--- a/src/renderer/features/tasks/diff-view/changes-panel/pr-section.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/pr-section.tsx
@@ -39,6 +39,7 @@ export const PullRequestsSection = observer(function PullRequestsSection({
             ? () =>
                 showCreatePrModal({
                   nameWithOwner: repositoryUrl ?? '',
+                  pushRepositoryUrl: provisioned.repositoryStore.pushRepositoryUrl,
                   branchName: taskBranch,
                   draft: false,
                   workspaceId: provisioned.workspaceId,

--- a/src/renderer/features/tasks/diff-view/stores/git-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/git-store.ts
@@ -336,7 +336,7 @@ export class GitStore {
   }
 
   async push() {
-    const remote = this.repositoryStore.configuredRemote.name;
+    const remote = this.repositoryStore.configuredPushRemote.name;
     const result = await rpc.git.push(this.projectId, this.workspaceId, remote);
     if (result.success) {
       this.repositoryStore.refreshLocal(); // divergence resets to 0
@@ -353,7 +353,7 @@ export class GitStore {
   async publishBranch() {
     const branchName = this.branchName;
     if (!branchName) return err({ type: 'git_error' as const, message: 'No branch checked out' });
-    const remote = this.repositoryStore.configuredRemote.name;
+    const remote = this.repositoryStore.configuredPushRemote.name;
     const result = await rpc.git.publishBranch(
       this.projectId,
       this.workspaceId,

--- a/src/renderer/lib/modal/modal-renderer.tsx
+++ b/src/renderer/lib/modal/modal-renderer.tsx
@@ -51,7 +51,7 @@ export const ModalRenderer = observer(function ModalRenderer() {
       const isPassiveDismiss =
         eventDetails.reason === 'outside-press' || eventDetails.reason === 'escape-key';
       if (modalStore.closeGuardActive && isPassiveDismiss) return;
-      modalStore.closeModal();
+      modalStore.activeModalArgs?.onClose?.();
     }
   };
 

--- a/src/renderer/utils/github/utils.test.ts
+++ b/src/renderer/utils/github/utils.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { extractOwner } from './utils';
+
+describe('extractOwner', () => {
+  it('extracts owner from normalized HTTPS URL', () => {
+    expect(extractOwner('https://github.com/myuser/repo')).toBe('myuser');
+  });
+
+  it('extracts owner from HTTPS URL with .git suffix', () => {
+    expect(extractOwner('https://github.com/myuser/repo.git')).toBe('myuser');
+  });
+
+  it('extracts owner from SSH URL', () => {
+    expect(extractOwner('git@github.com:myuser/repo.git')).toBe('myuser');
+  });
+
+  it('extracts owner from explicit SSH URL', () => {
+    expect(extractOwner('ssh://git@github.com/myuser/repo.git')).toBe('myuser');
+  });
+
+  it('extracts owner from HTTPS URL with query params', () => {
+    expect(extractOwner('https://github.com/myuser/repo?foo=bar')).toBe('myuser');
+  });
+
+  it('returns null for non-GitHub URLs', () => {
+    expect(extractOwner('https://gitlab.com/myuser/repo')).toBeNull();
+  });
+
+  it('returns null for empty string', () => {
+    expect(extractOwner('')).toBeNull();
+  });
+});

--- a/src/renderer/utils/github/utils.ts
+++ b/src/renderer/utils/github/utils.ts
@@ -20,6 +20,21 @@ export function normalizeGitHubUrl(url: string): string {
   return url.replace(/\.git$/, '');
 }
 
+/**
+ * Extracts the owner (user or org) from a GitHub remote URL.
+ * Handles HTTPS (`https://github.com/owner/repo.git?...`),
+ * SSH (`git@github.com:owner/repo.git`), and explicit SSH
+ * (`ssh://git@github.com/owner/repo`) formats.
+ * Returns `null` for non-GitHub URLs or unparseable input.
+ */
+export function extractOwner(remoteUrl: string): string | null {
+  const https = /github\.com\/([^/]+)\/[^/?#]+/.exec(remoteUrl);
+  if (https) return https[1];
+  const ssh = /github\.com:([^/]+)\//.exec(remoteUrl);
+  if (ssh) return ssh[1];
+  return null;
+}
+
 export type CheckRunBucket = 'pass' | 'fail' | 'pending' | 'skipping' | 'cancel';
 
 /** Derive a display bucket from a check's raw status and conclusion fields. */

--- a/src/shared/events/forkEvents.ts
+++ b/src/shared/events/forkEvents.ts
@@ -1,0 +1,10 @@
+import { defineEvent } from '@shared/ipc/events';
+
+export type ForkDetectedPayload = {
+  projectId: string;
+  forkRemoteName: string;
+  upstreamRemoteName: string;
+  upstreamOwnerRepo: string;
+};
+
+export const forkDetectedChannel = defineEvent<ForkDetectedPayload>('fork:detected');

--- a/src/shared/git-utils.test.ts
+++ b/src/shared/git-utils.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'vitest';
+import type { Remote } from './git';
+import { selectPreferredPushRemote } from './git-utils';
+
+const remotes: Remote[] = [
+  { name: 'origin', url: 'https://github.com/myuser/repo' },
+  { name: 'upstream', url: 'https://github.com/org/repo' },
+];
+
+describe('selectPreferredPushRemote', () => {
+  it('returns pushRemote setting when it matches a known remote', () => {
+    const result = selectPreferredPushRemote('origin', 'upstream', remotes);
+    expect(result.name).toBe('origin');
+  });
+
+  it('falls back to fetchRemote when pushRemote is undefined', () => {
+    const result = selectPreferredPushRemote(undefined, 'upstream', remotes);
+    expect(result.name).toBe('upstream');
+  });
+
+  it('falls back to fetchRemote when pushRemote is empty string', () => {
+    const result = selectPreferredPushRemote('', 'upstream', remotes);
+    expect(result.name).toBe('upstream');
+  });
+
+  it('falls back to origin when both are undefined', () => {
+    const result = selectPreferredPushRemote(undefined, undefined, remotes);
+    expect(result.name).toBe('origin');
+  });
+});

--- a/src/shared/git-utils.ts
+++ b/src/shared/git-utils.ts
@@ -16,6 +16,24 @@ export function selectPreferredRemote(
 }
 
 /**
+ * Resolves the preferred remote for push operations.
+ *
+ * Fallback chain: pushRemoteSetting → fetchRemoteSetting → "origin" → first remote.
+ */
+export function selectPreferredPushRemote(
+  pushRemoteSetting: string | undefined,
+  fetchRemoteSetting: string | undefined,
+  remotes: ReadonlyArray<Remote>
+): Remote {
+  const preferred = pushRemoteSetting?.trim();
+  if (preferred) {
+    const found = remotes.find((r) => r.name === preferred);
+    if (found) return found;
+  }
+  return selectPreferredRemote(fetchRemoteSetting, remotes);
+}
+
+/**
  * Strips the remote prefix from a fully-qualified remote tracking ref.
  * e.g. "origin/main" → "main", "main" → "main"
  */


### PR DESCRIPTION
## Summary

Adds support for fork-based development workflows where contributors fetch from an upstream repo but push to their own fork. Currently emdash uses a single `remote` setting for everything — this change adds a `pushRemote` setting that splits push operations from fetch/sync/PR-base operations.

When a project has 2+ remotes, a "Push remote" dropdown appears in project settings with a "Same as fetch remote" reset option. Push and publish operations route through the push remote, while fetch, sync, default branch resolution, issue queries, and PR targeting continue using the existing remote.

For PR creation, when the push and fetch remotes differ, the modal detects the cross-fork scenario and formats the head ref as `forkOwner:branchName` (what the GitHub API expects). An editable Head field lets users override this for non-GitHub remotes or unusual setups.

On project mount, emdash checks the GitHub API to see if any configured remote is a fork with a parent matching another local remote. If detected, a modal prompts the user to auto-configure their remotes. The detection runs once per session, respects a dismiss flag, and silently skips on API errors or non-GitHub remotes.

Also fixes a general bug in the modal system where dismissing via backdrop click or ESC key silently dropped `onClose` callbacks instead of invoking them.

<img width="706" height="210" alt="image" src="https://github.com/user-attachments/assets/ff05ef7d-664d-4e84-a4d3-37d848e08bb1" />

Closes #1800

## How to test
- [ ] Import a forked repo with two remotes — fork detection modal should appear
- [ ] Accept auto-configuration — `.emdash.json` should have `remote: "upstream"` and `pushRemote: "origin"`
- [ ] Dismiss via backdrop/ESC — `forkDetectionDismissed: true` persisted, modal doesn't reappear
- [ ] Open project settings with 2+ remotes — "Push remote" dropdown visible with reset option
- [ ] Push a branch — should target the push remote, not upstream
- [ ] Create PR in fork workflow — cross-fork info line and editable Head field shown
- [ ] Single-remote project — push remote dropdown hidden, behavior unchanged