### PR TITLE
feat: auto-rename task from first prompt

### DIFF
--- a/src/main/core/conversations/autoRenameTaskFromPrompt.test.ts
+++ b/src/main/core/conversations/autoRenameTaskFromPrompt.test.ts
@@ -115,6 +115,28 @@ describe('autoRenameTaskFromPrompt', () => {
     expect(mocks.logWarnMock.mock.calls[0][0]).toMatch(/auto-rename/i);
   });
 
+  it('does not consume the dedup slot when the toggle is off', async () => {
+    mocks.getMock.mockResolvedValueOnce({ autoRenameFromFirstPrompt: false });
+
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'first prompt',
+    });
+    expect(mocks.renameTaskMock).not.toHaveBeenCalled();
+
+    mocks.getMock.mockResolvedValueOnce({ autoRenameFromFirstPrompt: true });
+
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'second prompt after toggling on',
+    });
+    expect(mocks.renameTaskMock).toHaveBeenCalledTimes(1);
+  });
+
   it('only renames the same task once per app session', async () => {
     await autoRenameTaskFromPrompt({
       projectId: 'p1',

--- a/src/main/core/conversations/autoRenameTaskFromPrompt.test.ts
+++ b/src/main/core/conversations/autoRenameTaskFromPrompt.test.ts
@@ -1,0 +1,147 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  autoRenameTaskFromPrompt,
+  resetAutoRenamedTasksForTesting,
+} from './autoRenameTaskFromPrompt';
+
+const mocks = vi.hoisted(() => ({
+  getMock: vi.fn(),
+  generateTaskNameMock: vi.fn(),
+  renameTaskMock: vi.fn(),
+  logWarnMock: vi.fn(),
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: {
+    get: mocks.getMock,
+  },
+}));
+
+vi.mock('@main/core/tasks/generateTaskName', () => ({
+  generateTaskName: mocks.generateTaskNameMock,
+}));
+
+vi.mock('@main/core/tasks/renameTask', () => ({
+  renameTask: mocks.renameTaskMock,
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    warn: mocks.logWarnMock,
+  },
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  resetAutoRenamedTasksForTesting();
+  mocks.getMock.mockResolvedValue({ autoRenameFromFirstPrompt: true });
+  mocks.generateTaskNameMock.mockReturnValue('fix-dark-mode-toggle');
+  mocks.renameTaskMock.mockResolvedValue(undefined);
+});
+
+describe('autoRenameTaskFromPrompt', () => {
+  it('renames the task when toggle is on, first conversation, and prompt is non-empty', async () => {
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'fix the dark-mode toggle',
+    });
+
+    expect(mocks.generateTaskNameMock).toHaveBeenCalledWith({
+      title: 'fix the dark-mode toggle',
+    });
+    expect(mocks.renameTaskMock).toHaveBeenCalledWith('p1', 't1', 'fix-dark-mode-toggle');
+  });
+
+  it('does not rename when the toggle is off', async () => {
+    mocks.getMock.mockResolvedValue({ autoRenameFromFirstPrompt: false });
+
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'fix the dark-mode toggle',
+    });
+
+    expect(mocks.generateTaskNameMock).not.toHaveBeenCalled();
+    expect(mocks.renameTaskMock).not.toHaveBeenCalled();
+  });
+
+  it('does not rename when this is not the first conversation in the task', async () => {
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: false,
+      initialPrompt: 'fix the dark-mode toggle',
+    });
+
+    expect(mocks.getMock).not.toHaveBeenCalled();
+    expect(mocks.renameTaskMock).not.toHaveBeenCalled();
+  });
+
+  it('does not rename when the initial prompt is empty or whitespace', async () => {
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: '   ',
+    });
+
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: undefined,
+    });
+
+    expect(mocks.getMock).not.toHaveBeenCalled();
+    expect(mocks.renameTaskMock).not.toHaveBeenCalled();
+  });
+
+  it('swallows renameTask errors and logs a warning', async () => {
+    mocks.renameTaskMock.mockRejectedValue(new Error('boom'));
+
+    await expect(
+      autoRenameTaskFromPrompt({
+        projectId: 'p1',
+        taskId: 't1',
+        isFirstInTask: true,
+        initialPrompt: 'fix the dark-mode toggle',
+      })
+    ).resolves.toBeUndefined();
+
+    expect(mocks.logWarnMock).toHaveBeenCalledTimes(1);
+    expect(mocks.logWarnMock.mock.calls[0][0]).toMatch(/auto-rename/i);
+  });
+
+  it('only renames the same task once per app session', async () => {
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'first prompt',
+    });
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'second prompt',
+    });
+
+    expect(mocks.renameTaskMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips renameTask when generateTaskName returns an empty string', async () => {
+    mocks.generateTaskNameMock.mockReturnValue('');
+
+    await autoRenameTaskFromPrompt({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'something',
+    });
+
+    expect(mocks.renameTaskMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/core/conversations/autoRenameTaskFromPrompt.ts
+++ b/src/main/core/conversations/autoRenameTaskFromPrompt.ts
@@ -23,12 +23,12 @@ export async function autoRenameTaskFromPrompt(
   const trimmed = params.initialPrompt?.trim();
   if (!trimmed) return;
   if (renamedTaskIds.has(params.taskId)) return;
-  renamedTaskIds.add(params.taskId);
   try {
     const taskSettings = await appSettingsService.get('tasks');
     if (!taskSettings.autoRenameFromFirstPrompt) return;
     const newName = generateTaskName({ title: trimmed });
     if (!newName) return;
+    renamedTaskIds.add(params.taskId);
     await renameTask(params.projectId, params.taskId, newName);
   } catch (err) {
     log.warn('Failed to auto-rename task from first prompt', err);

--- a/src/main/core/conversations/autoRenameTaskFromPrompt.ts
+++ b/src/main/core/conversations/autoRenameTaskFromPrompt.ts
@@ -1,0 +1,36 @@
+import { log } from '@main/lib/logger';
+import { appSettingsService } from '../settings/settings-service';
+import { generateTaskName } from '../tasks/generateTaskName';
+import { renameTask } from '../tasks/renameTask';
+
+export interface AutoRenameTaskFromPromptParams {
+  projectId: string;
+  taskId: string;
+  isFirstInTask: boolean;
+  initialPrompt: string | undefined;
+}
+
+const renamedTaskIds = new Set<string>();
+
+export function resetAutoRenamedTasksForTesting(): void {
+  renamedTaskIds.clear();
+}
+
+export async function autoRenameTaskFromPrompt(
+  params: AutoRenameTaskFromPromptParams
+): Promise<void> {
+  if (!params.isFirstInTask) return;
+  const trimmed = params.initialPrompt?.trim();
+  if (!trimmed) return;
+  if (renamedTaskIds.has(params.taskId)) return;
+  renamedTaskIds.add(params.taskId);
+  try {
+    const taskSettings = await appSettingsService.get('tasks');
+    if (!taskSettings.autoRenameFromFirstPrompt) return;
+    const newName = generateTaskName({ title: trimmed });
+    if (!newName) return;
+    await renameTask(params.projectId, params.taskId, newName);
+  } catch (err) {
+    log.warn('Failed to auto-rename task from first prompt', err);
+  }
+}

--- a/src/main/core/conversations/createConversation.ts
+++ b/src/main/core/conversations/createConversation.ts
@@ -1,10 +1,11 @@
 import { randomUUID } from 'node:crypto';
 import { eq, sql } from 'drizzle-orm';
-import { Conversation, CreateConversationParams } from '@shared/conversations';
+import { type Conversation, type CreateConversationParams } from '@shared/conversations';
 import { db } from '@main/db/client';
 import { conversations } from '@main/db/schema';
 import { capture } from '@main/lib/telemetry';
 import { resolveTask } from '../projects/utils';
+import { autoRenameTaskFromPrompt } from './autoRenameTaskFromPrompt';
 import { mapConversationRowToConversation } from './utils';
 
 export async function createConversation(params: CreateConversationParams): Promise<Conversation> {
@@ -47,6 +48,14 @@ export async function createConversation(params: CreateConversationParams): Prom
     false,
     params.initialPrompt
   );
+
+  await autoRenameTaskFromPrompt({
+    projectId: params.projectId,
+    taskId: params.taskId,
+    isFirstInTask: existingConversation === undefined,
+    initialPrompt: params.initialPrompt,
+  });
+
   capture('conversation_created', {
     provider: params.provider,
     is_first_in_task: existingConversation === undefined,

--- a/src/main/core/settings/schema.ts
+++ b/src/main/core/settings/schema.ts
@@ -21,6 +21,7 @@ export const notificationSettingsSchema = z.object({
 export const taskSettingsSchema = z.object({
   autoGenerateName: z.boolean(),
   autoTrustWorktrees: z.boolean(),
+  autoRenameFromFirstPrompt: z.boolean(),
 });
 
 export const agentAutoApproveDefaultsSchema = z

--- a/src/main/core/settings/settings-registry.ts
+++ b/src/main/core/settings/settings-registry.ts
@@ -23,6 +23,7 @@ export const SETTINGS_DEFAULTS = {
   tasks: {
     autoGenerateName: true,
     autoTrustWorktrees: true,
+    autoRenameFromFirstPrompt: true,
   },
   agentAutoApproveDefaults: {},
   notifications: {

--- a/src/main/core/tasks/controller.ts
+++ b/src/main/core/tasks/controller.ts
@@ -11,6 +11,7 @@ import { renameTask } from './renameTask';
 import { restoreTask } from './restoreTask';
 import { setTaskPinned } from './setTaskPinned';
 import { teardownTask } from './teardownTask';
+import { tryAutoRenameFromPrompt } from './tryAutoRenameFromPrompt';
 import { updateLinkedIssue } from './updateLinkedIssue';
 import { updateTaskStatus } from './updateTaskStatus';
 
@@ -24,6 +25,7 @@ export const taskController = createRPCController({
   renameTask,
   provisionTask,
   teardownTask,
+  tryAutoRenameFromPrompt,
   getBootstrapStatus,
   getWorkspaceSettings,
   updateLinkedIssue,

--- a/src/main/core/tasks/renameTask.ts
+++ b/src/main/core/tasks/renameTask.ts
@@ -1,7 +1,9 @@
 import { and, eq, sql } from 'drizzle-orm';
+import { taskRenamedChannel } from '@shared/events/taskEvents';
 import { projectManager } from '@main/core/projects/project-manager';
 import { db } from '@main/db/client';
 import { tasks } from '@main/db/schema';
+import { events } from '@main/lib/events';
 import { appSettingsService } from '../settings/settings-service';
 
 export async function renameTask(
@@ -45,4 +47,11 @@ export async function renameTask(
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(tasks.id, taskId));
+
+  events.emit(taskRenamedChannel, {
+    taskId,
+    projectId: row.projectId,
+    name: newName,
+    taskBranch: newBranch ?? row.taskBranch,
+  });
 }

--- a/src/main/core/tasks/tryAutoRenameFromPrompt.test.ts
+++ b/src/main/core/tasks/tryAutoRenameFromPrompt.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { tryAutoRenameFromPrompt } from './tryAutoRenameFromPrompt';
+
+const mocks = vi.hoisted(() => ({
+  selectMock: vi.fn(),
+  fromMock: vi.fn(),
+  whereMock: vi.fn(),
+  limitMock: vi.fn(),
+  autoRenameMock: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: mocks.selectMock,
+  },
+}));
+
+vi.mock('@main/core/conversations/autoRenameTaskFromPrompt', () => ({
+  autoRenameTaskFromPrompt: mocks.autoRenameMock,
+}));
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.selectMock.mockReturnValue({ from: mocks.fromMock });
+  mocks.fromMock.mockReturnValue({ where: mocks.whereMock });
+  mocks.whereMock.mockReturnValue({ limit: mocks.limitMock });
+  mocks.autoRenameMock.mockResolvedValue(undefined);
+});
+
+describe('tryAutoRenameFromPrompt', () => {
+  it('delegates to autoRenameTaskFromPrompt when the task has exactly one conversation', async () => {
+    mocks.limitMock.mockResolvedValue([{ id: 'c1' }]);
+
+    await tryAutoRenameFromPrompt('p1', 't1', 'fix the bug');
+
+    expect(mocks.autoRenameMock).toHaveBeenCalledWith({
+      projectId: 'p1',
+      taskId: 't1',
+      isFirstInTask: true,
+      initialPrompt: 'fix the bug',
+    });
+  });
+
+  it('skips when the task has no conversations', async () => {
+    mocks.limitMock.mockResolvedValue([]);
+
+    await tryAutoRenameFromPrompt('p1', 't1', 'fix the bug');
+
+    expect(mocks.autoRenameMock).not.toHaveBeenCalled();
+  });
+
+  it('skips when the task already has more than one conversation', async () => {
+    mocks.limitMock.mockResolvedValue([{ id: 'c1' }, { id: 'c2' }]);
+
+    await tryAutoRenameFromPrompt('p1', 't1', 'fix the bug');
+
+    expect(mocks.autoRenameMock).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/core/tasks/tryAutoRenameFromPrompt.ts
+++ b/src/main/core/tasks/tryAutoRenameFromPrompt.ts
@@ -1,0 +1,25 @@
+import { eq } from 'drizzle-orm';
+import { autoRenameTaskFromPrompt } from '@main/core/conversations/autoRenameTaskFromPrompt';
+import { db } from '@main/db/client';
+import { conversations } from '@main/db/schema';
+
+export async function tryAutoRenameFromPrompt(
+  projectId: string,
+  taskId: string,
+  prompt: string
+): Promise<void> {
+  const conversationsForTask = await db
+    .select({ id: conversations.id })
+    .from(conversations)
+    .where(eq(conversations.taskId, taskId))
+    .limit(2);
+
+  if (conversationsForTask.length !== 1) return;
+
+  await autoRenameTaskFromPrompt({
+    projectId,
+    taskId,
+    isFirstInTask: true,
+    initialPrompt: prompt,
+  });
+}

--- a/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/src/renderer/features/settings/components/SettingsPage.tsx
@@ -12,7 +12,11 @@ import KeyboardSettingsCard from './KeyboardSettingsCard';
 import NotificationSettingsCard from './NotificationSettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
 import { ReviewPromptResetButton, ReviewPromptSettingsCard } from './ReviewPromptSettingsCard';
-import { AutoGenerateTaskNamesRow, AutoTrustWorktreesRow } from './TaskSettingsRows';
+import {
+  AutoGenerateTaskNamesRow,
+  AutoRenameFromFirstPromptRow,
+  AutoTrustWorktreesRow,
+} from './TaskSettingsRows';
 import TelemetryCard from './TelemetryCard';
 import TerminalSettingsCard from './TerminalSettingsCard';
 import ThemeCard from './ThemeCard';
@@ -71,6 +75,9 @@ export function SettingsPage({
         },
         {
           component: <AutoGenerateTaskNamesRow />,
+        },
+        {
+          component: <AutoRenameFromFirstPromptRow />,
         },
         {
           component: <AutoTrustWorktreesRow />,

--- a/src/renderer/features/settings/components/TaskSettingsRows.tsx
+++ b/src/renderer/features/settings/components/TaskSettingsRows.tsx
@@ -53,6 +53,32 @@ export const AutoGenerateTaskNamesRow: React.FC = () => {
   );
 };
 
+export const AutoRenameFromFirstPromptRow: React.FC = () => {
+  const taskSettings = useTaskSettings();
+
+  return (
+    <SettingRow
+      title="Auto-rename task from first prompt"
+      description="After you send the first prompt in a new task, replace the auto-generated name with one derived from the prompt."
+      control={
+        <>
+          <ResetToDefaultButton
+            visible={taskSettings.isFieldOverridden('autoRenameFromFirstPrompt')}
+            defaultLabel="on"
+            onReset={taskSettings.resetAutoRenameFromFirstPrompt}
+            disabled={taskSettings.loading || taskSettings.saving}
+          />
+          <Switch
+            checked={taskSettings.autoRenameFromFirstPrompt}
+            disabled={taskSettings.loading || taskSettings.saving}
+            onCheckedChange={taskSettings.updateAutoRenameFromFirstPrompt}
+          />
+        </>
+      }
+    />
+  );
+};
+
 export const AutoTrustWorktreesRow: React.FC = () => {
   const taskSettings = useTaskSettings();
 

--- a/src/renderer/features/tasks/conversations/conversations-panel.tsx
+++ b/src/renderer/features/tasks/conversations/conversations-panel.tsx
@@ -12,12 +12,13 @@ import {
   getHotkeyRegistration,
 } from '@renderer/lib/hooks/useKeyboardShortcuts';
 import { useTabShortcuts } from '@renderer/lib/hooks/useTabShortcuts';
+import { rpc } from '@renderer/lib/ipc';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { ShortcutHint } from '@renderer/lib/ui/shortcut-hint';
 import { ContextBar } from './context-bar';
-import { ConversationStore } from './conversation-manager';
+import { type ConversationStore } from './conversation-manager';
 import { ConversationsTabs } from './conversation-tabs';
 
 export const ConversationsPanel = observer(function ConversationsPanel() {
@@ -72,6 +73,9 @@ export const ConversationsPanel = observer(function ConversationsPanel() {
           paneId="conversations"
           getSession={(s) => s.session}
           onEnterPress={shouldSetWorkingOnEnter ? (s) => s.setWorking() : undefined}
+          onFirstUserPrompt={(_s, message) => {
+            void rpc.tasks.tryAutoRenameFromPrompt(projectId, taskId, message);
+          }}
           onInterruptPress={(s) => s.clearWorking()}
           mapShiftEnterToCtrlJ
           remoteConnectionId={remoteConnectionId}

--- a/src/renderer/features/tasks/hooks/useTaskSettings.ts
+++ b/src/renderer/features/tasks/hooks/useTaskSettings.ts
@@ -3,13 +3,18 @@ import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-
 export interface TaskSettingsModel {
   autoGenerateName: boolean;
   autoTrustWorktrees: boolean;
+  autoRenameFromFirstPrompt: boolean;
   loading: boolean;
   saving: boolean;
-  isFieldOverridden: (field: 'autoGenerateName' | 'autoTrustWorktrees') => boolean;
+  isFieldOverridden: (
+    field: 'autoGenerateName' | 'autoTrustWorktrees' | 'autoRenameFromFirstPrompt'
+  ) => boolean;
   updateAutoGenerateName: (next: boolean) => void;
   updateAutoTrustWorktrees: (next: boolean) => void;
+  updateAutoRenameFromFirstPrompt: (next: boolean) => void;
   resetAutoGenerateName: () => void;
   resetAutoTrustWorktrees: () => void;
+  resetAutoRenameFromFirstPrompt: () => void;
 }
 
 export function useTaskSettings(): TaskSettingsModel {
@@ -25,12 +30,15 @@ export function useTaskSettings(): TaskSettingsModel {
   return {
     autoGenerateName: tasks?.autoGenerateName ?? false,
     autoTrustWorktrees: tasks?.autoTrustWorktrees ?? false,
+    autoRenameFromFirstPrompt: tasks?.autoRenameFromFirstPrompt ?? false,
     loading,
     saving,
     isFieldOverridden,
     updateAutoGenerateName: (next) => update({ autoGenerateName: next }),
     updateAutoTrustWorktrees: (next) => update({ autoTrustWorktrees: next }),
+    updateAutoRenameFromFirstPrompt: (next) => update({ autoRenameFromFirstPrompt: next }),
     resetAutoGenerateName: () => resetField('autoGenerateName'),
     resetAutoTrustWorktrees: () => resetField('autoTrustWorktrees'),
+    resetAutoRenameFromFirstPrompt: () => resetField('autoRenameFromFirstPrompt'),
   };
 }

--- a/src/renderer/features/tasks/stores/task-manager.ts
+++ b/src/renderer/features/tasks/stores/task-manager.ts
@@ -1,7 +1,7 @@
 import { makeObservable, observable, reaction, runInAction, toJS } from 'mobx';
 import { toast } from 'sonner';
 import { prSyncProgressChannel, prUpdatedChannel } from '@shared/events/prEvents';
-import { taskStatusUpdatedChannel } from '@shared/events/taskEvents';
+import { taskRenamedChannel, taskStatusUpdatedChannel } from '@shared/events/taskEvents';
 import type {
   CreateTaskError,
   CreateTaskParams,
@@ -92,6 +92,19 @@ export class TaskManagerStore {
       if (store && isProvisioned(store)) {
         runInAction(() => {
           store.data.status = status as TaskLifecycleStatus;
+        });
+      }
+    });
+
+    events.on(taskRenamedChannel, ({ taskId, projectId: evtProjectId, name, taskBranch }) => {
+      if (evtProjectId !== this.projectId) return;
+      const store = this.tasks.get(taskId);
+      if (store && isProvisioned(store)) {
+        runInAction(() => {
+          store.data.name = name;
+          if (taskBranch !== null) {
+            store.data.taskBranch = taskBranch;
+          }
         });
       }
     });

--- a/src/renderer/features/tasks/stores/task-manager.ts
+++ b/src/renderer/features/tasks/stores/task-manager.ts
@@ -77,6 +77,8 @@ export class TaskManagerStore {
 
   private _unsubPrUpdated: (() => void) | null = null;
   private _unsubPrSyncProgress: (() => void) | null = null;
+  private _unsubTaskStatusUpdated: (() => void) | null = null;
+  private _unsubTaskRenamed: (() => void) | null = null;
   private _disposeRepositoryReaction: (() => void) | null = null;
 
   tasks = observable.map<string, TaskStore>();
@@ -86,28 +88,34 @@ export class TaskManagerStore {
     this._repository = repository;
     makeObservable(this, { tasks: observable });
 
-    events.on(taskStatusUpdatedChannel, ({ taskId, projectId: evtProjectId, status }) => {
-      if (evtProjectId !== this.projectId) return;
-      const store = this.tasks.get(taskId);
-      if (store && isProvisioned(store)) {
-        runInAction(() => {
-          store.data.status = status as TaskLifecycleStatus;
-        });
+    this._unsubTaskStatusUpdated = events.on(
+      taskStatusUpdatedChannel,
+      ({ taskId, projectId: evtProjectId, status }) => {
+        if (evtProjectId !== this.projectId) return;
+        const store = this.tasks.get(taskId);
+        if (store && isProvisioned(store)) {
+          runInAction(() => {
+            store.data.status = status as TaskLifecycleStatus;
+          });
+        }
       }
-    });
+    );
 
-    events.on(taskRenamedChannel, ({ taskId, projectId: evtProjectId, name, taskBranch }) => {
-      if (evtProjectId !== this.projectId) return;
-      const store = this.tasks.get(taskId);
-      if (store && isProvisioned(store)) {
-        runInAction(() => {
-          store.data.name = name;
-          if (taskBranch !== null) {
-            store.data.taskBranch = taskBranch;
-          }
-        });
+    this._unsubTaskRenamed = events.on(
+      taskRenamedChannel,
+      ({ taskId, projectId: evtProjectId, name, taskBranch }) => {
+        if (evtProjectId !== this.projectId) return;
+        const store = this.tasks.get(taskId);
+        if (store && isProvisioned(store)) {
+          runInAction(() => {
+            store.data.name = name;
+            if (taskBranch !== null) {
+              store.data.taskBranch = taskBranch;
+            }
+          });
+        }
       }
-    });
+    );
 
     this._unsubPrUpdated = events.on(prUpdatedChannel, ({ prs }) => {
       const repoUrl = this._repository.repositoryUrl;
@@ -418,6 +426,10 @@ export class TaskManagerStore {
     this._unsubPrUpdated = null;
     this._unsubPrSyncProgress?.();
     this._unsubPrSyncProgress = null;
+    this._unsubTaskStatusUpdated?.();
+    this._unsubTaskStatusUpdated = null;
+    this._unsubTaskRenamed?.();
+    this._unsubTaskRenamed = null;
     this._disposeRepositoryReaction?.();
     this._disposeRepositoryReaction = null;
   }

--- a/src/renderer/features/tasks/tabbed-pty-panel.tsx
+++ b/src/renderer/features/tasks/tabbed-pty-panel.tsx
@@ -2,10 +2,10 @@ import { observer } from 'mobx-react-lite';
 import React, { useEffect, useMemo, useRef } from 'react';
 import { PaneSizingProvider } from '@renderer/lib/pty/pane-sizing-context';
 import { PtyPane } from '@renderer/lib/pty/pty-pane';
-import { PtySession } from '@renderer/lib/pty/pty-session';
+import { type PtySession } from '@renderer/lib/pty/pty-session';
 import { TerminalSearchOverlay } from '@renderer/lib/pty/terminal-search-overlay';
 import { useTerminalSearch } from '@renderer/lib/pty/use-terminal-search';
-import { TabViewProvider } from '@renderer/lib/stores/generic-tab-view';
+import { type TabViewProvider } from '@renderer/lib/stores/generic-tab-view';
 import { cn } from '@renderer/utils/utils';
 import { getTabbedPtySessionIds } from './tabbed-pty-panel-sessions';
 
@@ -18,6 +18,7 @@ export interface TabbedPtyPanelProps<TEntity> {
   autoFocus?: boolean;
   onFocusChange?: (focused: boolean) => void;
   onEnterPress?: (entity: TEntity) => void;
+  onFirstUserPrompt?: (entity: TEntity, message: string) => void;
   onInterruptPress?: (entity: TEntity) => void;
   mapShiftEnterToCtrlJ?: boolean;
   remoteConnectionId?: string;
@@ -32,6 +33,7 @@ export const TabbedPtyPanel = observer(function TabbedPtyPanel<TEntity>({
   autoFocus,
   onFocusChange,
   onEnterPress,
+  onFirstUserPrompt,
   onInterruptPress,
   mapShiftEnterToCtrlJ,
   remoteConnectionId,
@@ -41,13 +43,17 @@ export const TabbedPtyPanel = observer(function TabbedPtyPanel<TEntity>({
 
   const allSessionIds = useMemo(
     () => getTabbedPtySessionIds(tabs, getSession),
-    // eslint-disable-next-line react-hooks/exhaustive-deps
+     
     [tabs, getSession]
   );
 
   const activeSession = activeTab ? getSession(activeTab) : null;
   const activeSessionId = activeSession?.sessionId ?? null;
   const activeOnEnterPress = activeTab && onEnterPress ? () => onEnterPress(activeTab) : undefined;
+  const activeOnFirstUserPrompt =
+    activeTab && onFirstUserPrompt
+      ? (message: string) => onFirstUserPrompt(activeTab, message)
+      : undefined;
   const activeOnInterruptPress =
     activeTab && onInterruptPress ? () => onInterruptPress(activeTab) : undefined;
 
@@ -132,6 +138,7 @@ export const TabbedPtyPanel = observer(function TabbedPtyPanel<TEntity>({
                   pty={activeSession.pty}
                   className="h-full w-full"
                   onEnterPress={activeOnEnterPress}
+                  onFirstUserPrompt={activeOnFirstUserPrompt}
                   onInterruptPress={activeOnInterruptPress}
                   mapShiftEnterToCtrlJ={mapShiftEnterToCtrlJ}
                   remoteConnectionId={remoteConnectionId}

--- a/src/renderer/features/tasks/tabbed-pty-panel.tsx
+++ b/src/renderer/features/tasks/tabbed-pty-panel.tsx
@@ -43,7 +43,7 @@ export const TabbedPtyPanel = observer(function TabbedPtyPanel<TEntity>({
 
   const allSessionIds = useMemo(
     () => getTabbedPtySessionIds(tabs, getSession),
-     
+
     [tabs, getSession]
   );
 

--- a/src/renderer/lib/pty/pty-pane.tsx
+++ b/src/renderer/lib/pty/pty-pane.tsx
@@ -19,7 +19,7 @@ type Props = {
   remoteConnectionId?: string;
   onActivity?: () => void;
   onExit?: (info: { exitCode: number | undefined; signal?: number }) => void;
-  onFirstMessage?: (message: string) => void;
+  onFirstUserPrompt?: (message: string) => void;
   onEnterPress?: (message: string) => void;
   onInterruptPress?: () => void;
 };
@@ -36,7 +36,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
       remoteConnectionId,
       onActivity,
       onExit,
-      onFirstMessage,
+      onFirstUserPrompt,
       onEnterPress,
       onInterruptPress,
     },
@@ -54,7 +54,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
         mapShiftEnterToCtrlJ,
         onActivity,
         onExit,
-        onFirstMessage,
+        onFirstUserPrompt,
         onEnterPress,
         onInterruptPress,
       },

--- a/src/renderer/lib/pty/use-pty.ts
+++ b/src/renderer/lib/pty/use-pty.ts
@@ -1,4 +1,4 @@
-import { Terminal } from '@xterm/xterm';
+import { type Terminal } from '@xterm/xterm';
 import { useCallback, useEffect, useRef, useSyncExternalStore } from 'react';
 import type { AppSettings } from '@shared/app-settings';
 import { appPasteChannel } from '@shared/events/appEvents';
@@ -65,7 +65,7 @@ export interface UsePtyOptions {
   mapShiftEnterToCtrlJ?: boolean;
   onActivity?: () => void;
   onExit?: (info: { exitCode: number | undefined; signal?: number }) => void;
-  onFirstMessage?: (message: string) => void;
+  onFirstUserPrompt?: (message: string) => void;
   onEnterPress?: (message: string) => void;
   onInterruptPress?: () => void;
 }
@@ -105,7 +105,7 @@ export function usePty(
     mapShiftEnterToCtrlJ,
     onActivity,
     onExit,
-    onFirstMessage,
+    onFirstUserPrompt,
     onEnterPress,
     onInterruptPress,
   } = options;
@@ -115,8 +115,8 @@ export function usePty(
   onActivityRef.current = onActivity;
   const onExitRef = useRef(onExit);
   onExitRef.current = onExit;
-  const onFirstMessageRef = useRef(onFirstMessage);
-  onFirstMessageRef.current = onFirstMessage;
+  const onFirstUserPromptRef = useRef(onFirstUserPrompt);
+  onFirstUserPromptRef.current = onFirstUserPrompt;
   const onEnterPressRef = useRef(onEnterPress);
   onEnterPressRef.current = onEnterPress;
   const onInterruptPressRef = useRef(onInterruptPress);
@@ -150,9 +150,8 @@ export function usePty(
   const pendingResizeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const lastSentResizeRef = useRef<{ cols: number; rows: number } | null>(null);
 
-  // First-message capture state.
-  const firstMessageSentRef = useRef(false);
-  const inputBufferRef = useRef('');
+  // Fires the onFirstUserPrompt callback exactly once per session-mount.
+  const firstUserPromptSentRef = useRef(false);
 
   // Tracks submitted user input while filtering terminal control traffic.
   const submittedInputBufferRef = useRef(new SubmittedInputBuffer());
@@ -276,6 +275,10 @@ export function usePty(
         for (const message of submittedMessages) {
           if (isRealTaskInput(message)) {
             onEnterPressRef.current?.(message);
+            if (!firstUserPromptSentRef.current) {
+              firstUserPromptSentRef.current = true;
+              onFirstUserPromptRef.current?.(message);
+            }
           }
         }
       }
@@ -464,17 +467,6 @@ export function usePty(
         }
         if (!filtered) return;
 
-        // First-message capture
-        if (!firstMessageSentRef.current && onFirstMessageRef.current) {
-          inputBufferRef.current += filtered;
-          const newlineIndex = inputBufferRef.current.indexOf('\r');
-          if (newlineIndex !== -1) {
-            const message = inputBufferRef.current.slice(0, newlineIndex);
-            onFirstMessageRef.current(message);
-            firstMessageSentRef.current = true;
-          }
-        }
-
         sendInput(filtered);
       };
 
@@ -574,8 +566,7 @@ export function usePty(
       pty.unmount();
       termRef.current = null;
       ptyStartedRef.current = false;
-      firstMessageSentRef.current = false;
-      inputBufferRef.current = '';
+      firstUserPromptSentRef.current = false;
       submittedInputBufferRef.current = new SubmittedInputBuffer();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/shared/events/taskEvents.ts
+++ b/src/shared/events/taskEvents.ts
@@ -7,6 +7,13 @@ export const taskStatusUpdatedChannel = defineEvent<{
   status: string;
 }>('task:status-updated');
 
+export const taskRenamedChannel = defineEvent<{
+  taskId: string;
+  projectId: string;
+  name: string;
+  taskBranch: string | null;
+}>('task:renamed');
+
 export const taskPrUpdatedChannel = defineEvent<{
   taskId: string;
   projectId: string;


### PR DESCRIPTION
## Summary

Adds a configurable `tasks.autoRenameFromFirstPrompt` setting (default on, alongside the existing `autoGenerateName` toggle) that replaces a freshly auto-generated task slug like `sunny-loops-warn` with one derived from the user's first prompt — addressing #409. Two trigger paths feed a shared helper: `createConversation` covers tasks created with an explicit `initialPrompt`, and a new `tasks.tryAutoRenameFromPrompt` RPC fires from the renderer when `SubmittedInputBuffer` captures the first `isRealTaskInput`-passing message typed into the running TUI; an in-memory dedup set in the helper guarantees a task is renamed at most once per app session even if both paths fire. The rename reuses the existing `generateTaskName` heuristic (no LLM, no network) and the existing `renameTask` RPC, so the underlying git branch follows when the task owns its own branch. A new `taskRenamedChannel` event lets `TaskManagerStore` reactively update the MobX store on server-driven renames so the sidebar label flips without a refresh; this also dropped some dead-code raw-keystroke `onFirstMessage` plumbing in `use-pty.ts` that had no upstream consumer. Tests cover the helper's branch matrix (toggle off, not-first-in-task, empty prompt, dedup, error swallow) and the RPC's conversation-count gating.

## Test plan

- [ ] `pnpm run format && pnpm run lint && pnpm run typecheck && pnpm test`
- [ ] Create a fresh task with no name → confirm slug like `happy-cat-jumps`
- [ ] Type a first prompt in Claude Code → sidebar label flips, git branch follows
- [ ] Send a second prompt in the same task → no further rename
- [ ] Toggle Settings → General → "Auto-rename task from first prompt" off → repeat → name stays
- [ ] Repeat with the create-task-with-initial-prompt flow (createConversation path)
- [ ] Sibling task sharing a branch → DB name updates, branch is not renamed (existing renameTask guard)

Closes #409.