### PR TITLE
fix(worktrees): default new tasks to remote default branch

### DIFF
--- a/src/renderer/features/projects/stores/repository-store.ts
+++ b/src/renderer/features/projects/stores/repository-store.ts
@@ -154,17 +154,18 @@ export class RepositoryStore {
   get defaultBranch(): LocalBranch | RemoteBranch | undefined {
     const name = this.defaultBranchName;
     const raw = this.settingsStore.settings?.defaultBranch;
-    const isRemotePref = typeof raw === 'object' && raw.remote === true;
-
-    if (isRemotePref) {
-      const remote = this.remoteBranches.find(
-        (b) => b.branch === name && b.remote.name === this.configuredRemote.name
-      );
-      if (remote) return remote;
-    }
+    // Legacy string-form setting means the user explicitly picked a local branch.
+    const isExplicitLocal = typeof raw === 'string';
+    const remoteName = this.configuredRemote.name;
+    const remote = this.remoteBranches.find(
+      (b) => b.branch === name && b.remote.name === remoteName
+    );
     const local = this.localBranches.find((b) => b.branch === name);
-    if (local) return local;
-    return this.remoteBranches.find((b) => b.branch === name);
+
+    // Prefer the remote default so new worktrees branch off the up-to-date
+    // remote tip rather than a stale local copy of the default branch.
+    if (isExplicitLocal) return local ?? remote;
+    return remote ?? local;
   }
 
   isDefault(branch: LocalBranch | RemoteBranch): boolean {

--- a/src/renderer/lib/components/branch-selector.tsx
+++ b/src/renderer/lib/components/branch-selector.tsx
@@ -1,6 +1,6 @@
 import { GitBranch, RefreshCw } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
-import { Branch } from '@shared/git';
+import { type Branch } from '@shared/git';
 import { Badge } from '@renderer/lib/ui/badge';
 import {
   Combobox,
@@ -36,7 +36,9 @@ export function BranchSelector({
   onRefresh,
   isRefreshing = false,
 }: BranchSelectorProps) {
-  const [tab, setTab] = useState<'local' | 'remote'>(remoteOnly ? 'remote' : 'local');
+  const [tab, setTab] = useState<'local' | 'remote'>(
+    remoteOnly ? 'remote' : (value?.type ?? 'local')
+  );
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const localCount = useMemo(() => branches.filter((b) => b.type === 'local').length, [branches]);


### PR DESCRIPTION
## Summary

When creating a task from the **Create Task** popup, the default branch picker was pre-selecting the *local* default branch (e.g. `main`). That branch can be stale relative to the remote, so new worktrees ended up based on out-of-date code instead of the latest `origin/main`.

This change makes the popup default to the remote variant of the default branch (e.g. `origin/main`) so new worktrees always branch off the up-to-date remote tip.

### Changes

- `RepositoryStore.defaultBranch` now prefers the remote branch on the configured remote when no explicit local preference is stored in project settings. Legacy explicit-local string preferences (set via **Project Settings → Default branch**) still resolve to local first, so user intent is preserved.
- `BranchSelector` now opens on the tab matching the selected value's type, so a remote default isn't hidden under the **Local** tab.

The worktree service (`worktree-service.ts`) already runs `git fetch <remote>` and resolves `refs/remotes/<remote>/<branch>` when a remote `Branch` is passed, so no main-process changes are needed — passing the remote branch object through is enough to get fresh code.

### Why

Users reported that fresh worktrees were branching off stale local `main`. The fix lets `git fetch` happen as part of the existing checkout path instead of relying on the user to remember to pull `main` before creating each task.

## Test plan

- [x] `pnpm run format`
- [x] `pnpm run lint` (no new warnings)
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (no new failures vs. baseline; the 11 pre-existing failures in legacy-port and pr-merge-line tests are unrelated)
- [x] Manual: open Create Task → verify default branch is shown with remote tab active and `origin/<default>` is selected
- [x] Manual: create a task while local `main` is intentionally behind `origin/main` → verify the new worktree contains commits that are only on the remote
- [x] Manual: in **Project Settings → Default branch**, pick a local branch explicitly → verify the popup respects that preference (local-first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)