### PR TITLE
fix(conversations): parse configured agent cli arguments

### DIFF
--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -61,7 +61,7 @@ describe('buildAgentCommand', () => {
     });
   });
 
-  it('keeps custom Claude command names generic when they do not resolve to the system compiler', async () => {
+  it('keeps the custom cli when resolution fails', async () => {
     getItem.mockResolvedValue({
       cli: 'c --already-configured',
       autoApproveFlag: '--dangerously-skip-permissions',
@@ -80,6 +80,28 @@ describe('buildAgentCommand', () => {
     ).resolves.toEqual({
       command: 'c',
       args: ['--already-configured', '--session-id', 'session-1', '--dangerously-skip-permissions'],
+    });
+  });
+
+  it('keeps the custom cli when it resolves to a non-compiler binary', async () => {
+    getItem.mockResolvedValue({
+      cli: 'my-claude',
+      autoApproveFlag: '--dangerously-skip-permissions',
+      sessionIdFlag: '--session-id',
+      initialPromptFlag: '',
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '/opt/homebrew/bin/my-claude\n', stderr: '' });
+
+    await expect(
+      buildAgentCommand({
+        providerId: 'claude',
+        autoApprove: true,
+        sessionId: 'session-1',
+        exec,
+      })
+    ).resolves.toEqual({
+      command: 'my-claude',
+      args: ['--session-id', 'session-1', '--dangerously-skip-permissions'],
     });
   });
 

--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -1,0 +1,143 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
+import { buildAgentCommand, splitShellWords } from './agent-command';
+
+vi.mock('@main/core/settings/provider-settings-service', () => ({
+  providerOverrideSettings: {
+    getItem: vi.fn(),
+  },
+}));
+
+const getItem = vi.mocked(providerOverrideSettings.getItem);
+
+describe('splitShellWords', () => {
+  it('handles empty input and quoting', () => {
+    expect(splitShellWords('')).toEqual([]);
+    expect(splitShellWords('--foo=\'a b\'"c d"')).toEqual(['--foo=a bc d']);
+    expect(splitShellWords('--x "a b"')).toEqual(['--x', 'a b']);
+    expect(splitShellWords(`--x "that's ok"`)).toEqual(['--x', "that's ok"]);
+    expect(splitShellWords(`--x 'say "hi"'`)).toEqual(['--x', 'say "hi"']);
+  });
+
+  it('preserves non-special backslashes inside double quotes', () => {
+    expect(splitShellWords('--x "foo\\nbar"')).toEqual(['--x', 'foo\\nbar']);
+    expect(splitShellWords('--x "foo\\$bar"')).toEqual(['--x', 'foo$bar']);
+    expect(splitShellWords('--x foo\\')).toEqual(['--x', 'foo\\']);
+  });
+});
+
+describe('buildAgentCommand', () => {
+  beforeEach(() => {
+    getItem.mockReset();
+  });
+
+  it('parses cli command lines and puts extra args before a positional prompt', async () => {
+    getItem.mockResolvedValue({
+      cli: 'claude --model sonnet',
+      extraArgs: '--verbose',
+      autoApproveFlag: '--dangerously-skip-permissions',
+      sessionIdFlag: '--session-id',
+      initialPromptFlag: '',
+    });
+
+    await expect(
+      buildAgentCommand({
+        providerId: 'claude',
+        autoApprove: true,
+        sessionId: 'session-1',
+        initialPrompt: 'hello',
+      })
+    ).resolves.toEqual({
+      command: 'claude',
+      args: [
+        '--model',
+        'sonnet',
+        '--session-id',
+        'session-1',
+        '--dangerously-skip-permissions',
+        '--verbose',
+        'hello',
+      ],
+    });
+  });
+
+  it('keeps custom Claude command names generic when they do not resolve to the system compiler', async () => {
+    getItem.mockResolvedValue({
+      cli: 'c --already-configured',
+      autoApproveFlag: '--dangerously-skip-permissions',
+      sessionIdFlag: '--session-id',
+      initialPromptFlag: '',
+    });
+    const exec = vi.fn().mockRejectedValue(new Error('not found'));
+
+    await expect(
+      buildAgentCommand({
+        providerId: 'claude',
+        autoApprove: true,
+        sessionId: 'session-1',
+        exec,
+      })
+    ).resolves.toEqual({
+      command: 'c',
+      args: ['--already-configured', '--session-id', 'session-1', '--dangerously-skip-permissions'],
+    });
+  });
+
+  it('falls back to claude when a custom Claude command resolves to the system C compiler', async () => {
+    getItem.mockResolvedValue({
+      cli: 'cc',
+      autoApproveFlag: '--dangerously-skip-permissions',
+      sessionIdFlag: '--session-id',
+      initialPromptFlag: '',
+    });
+    const exec = vi.fn().mockResolvedValue({ stdout: '/usr/bin/cc\n', stderr: '' });
+
+    await expect(
+      buildAgentCommand({
+        providerId: 'claude',
+        autoApprove: true,
+        sessionId: 'session-1',
+        exec,
+      })
+    ).resolves.toEqual({
+      command: 'claude',
+      args: ['--session-id', 'session-1', '--dangerously-skip-permissions'],
+    });
+  });
+
+  it('falls back to the registry cli when the custom cli is blank', async () => {
+    getItem.mockResolvedValue({
+      cli: ' ',
+      autoApproveFlag: '--dangerously-skip-permissions',
+      sessionIdFlag: '--session-id',
+      initialPromptFlag: '',
+    });
+
+    await expect(
+      buildAgentCommand({
+        providerId: 'claude',
+        sessionId: 'session-1',
+      })
+    ).resolves.toEqual({ command: 'claude', args: ['--session-id', 'session-1'] });
+  });
+
+  it('tokenizes resume flags consistently with cli args', async () => {
+    getItem.mockResolvedValue({
+      cli: 'claude --model sonnet',
+      resumeFlag: '--resume "last session"',
+      sessionIdFlag: '--session-id',
+      initialPromptFlag: '',
+    });
+
+    await expect(
+      buildAgentCommand({
+        providerId: 'claude',
+        isResuming: true,
+        sessionId: 'session-1',
+      })
+    ).resolves.toEqual({
+      command: 'claude',
+      args: ['--model', 'sonnet', '--resume', 'last session', 'session-1'],
+    });
+  });
+});

--- a/src/main/core/conversations/impl/agent-command.ts
+++ b/src/main/core/conversations/impl/agent-command.ts
@@ -1,5 +1,91 @@
-import { AgentProviderId, getProvider } from '@shared/agent-provider-registry';
+import path from 'node:path';
+import { type AgentProviderId, getProvider } from '@shared/agent-provider-registry';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
+import type { ExecFn } from '@main/core/utils/exec';
+import { quoteShellArg } from '@main/utils/shellEscape';
+
+export function splitShellWords(input: string | undefined): string[] {
+  if (!input?.trim()) return [];
+
+  const words: string[] = [];
+  let current = '';
+  let quote: 'single' | 'double' | null = null;
+
+  for (let i = 0; i < input.trim().length; i++) {
+    const char = input.trim()[i];
+
+    if (char === "'" && quote !== 'double') {
+      quote = quote === 'single' ? null : 'single';
+      continue;
+    }
+
+    if (char === '"' && quote !== 'single') {
+      quote = quote === 'double' ? null : 'double';
+      continue;
+    }
+
+    if (char === '\\' && quote !== 'single') {
+      const next = input.trim()[i + 1];
+      if (!next) {
+        current += char;
+      } else if (
+        !quote ||
+        next === '\\' ||
+        next === '"' ||
+        next === '$' ||
+        next === '`' ||
+        next === '\n'
+      ) {
+        current += next;
+        i++;
+      } else {
+        current += char;
+      }
+      continue;
+    }
+
+    if (/\s/.test(char) && !quote) {
+      if (current) {
+        words.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (current) words.push(current);
+  return words;
+}
+
+async function maybeAvoidSystemCCompiler({
+  providerId,
+  cli,
+  fallbackCli,
+  exec,
+}: {
+  providerId: AgentProviderId;
+  cli: string;
+  fallbackCli?: string;
+  exec?: ExecFn;
+}): Promise<string> {
+  if (providerId !== 'claude' || !fallbackCli || cli === fallbackCli || !exec) return cli;
+
+  try {
+    const result = await exec('bash', ['-lc', `command -v -- ${quoteShellArg(cli)}`], {
+      timeout: 2000,
+      maxBuffer: 2048,
+    });
+    const resolved = result.stdout.trim().split(/\r?\n/)[0];
+    const basename = path.basename(resolved);
+    if (basename === 'cc' || basename === 'clang' || basename === 'gcc') return fallbackCli;
+  } catch {
+    // If resolution fails, keep the user's custom command and let the shell report the real error.
+  }
+
+  return cli;
+}
 
 export async function buildAgentCommand({
   providerId,
@@ -7,21 +93,31 @@ export async function buildAgentCommand({
   initialPrompt,
   sessionId,
   isResuming,
+  exec,
 }: {
   providerId: AgentProviderId;
   autoApprove?: boolean;
   initialPrompt?: string;
   sessionId: string;
   isResuming?: boolean;
+  exec?: ExecFn;
 }) {
   const providerConfig = await providerOverrideSettings.getItem(providerId);
   const providerDef = getProvider(providerId);
 
-  const cli = providerConfig?.cli;
-  const args: string[] = [];
+  const [configuredCli = providerDef?.cli, ...cliArgs] = splitShellWords(providerConfig?.cli);
+  if (!configuredCli) throw new Error(`No CLI configured for provider: ${providerId}`);
+
+  const cli = await maybeAvoidSystemCCompiler({
+    providerId,
+    cli: configuredCli,
+    fallbackCli: providerDef?.cli,
+    exec,
+  });
+  const args: string[] = [...cliArgs, ...(providerConfig?.defaultArgs ?? [])];
 
   if (isResuming && providerConfig?.resumeFlag) {
-    args.push(...providerConfig.resumeFlag.split(' '));
+    args.push(...splitShellWords(providerConfig.resumeFlag));
     if (providerConfig?.sessionIdFlag) {
       args.push(sessionId);
     }
@@ -29,9 +125,16 @@ export async function buildAgentCommand({
     args.push(providerConfig.sessionIdFlag, sessionId);
   }
 
-  if (autoApprove && providerConfig?.autoApproveFlag) {
+  if (
+    autoApprove &&
+    providerConfig?.autoApproveFlag &&
+    !args.includes(providerConfig.autoApproveFlag)
+  ) {
+    // Best-effort dedupe: equivalent aliases/flag values are provider-specific.
     args.push(providerConfig.autoApproveFlag);
   }
+
+  args.push(...splitShellWords(providerConfig?.extraArgs));
 
   if (!isResuming && initialPrompt && !providerDef?.useKeystrokeInjection) {
     const flag = providerConfig?.initialPromptFlag;
@@ -42,7 +145,5 @@ export async function buildAgentCommand({
     }
   }
 
-  args.push(...(providerConfig?.defaultArgs ?? []));
-
-  return { command: cli!, args };
+  return { command: cli, args };
 }

--- a/src/main/core/conversations/impl/agent-command.ts
+++ b/src/main/core/conversations/impl/agent-command.ts
@@ -1,18 +1,19 @@
 import path from 'node:path';
-import { type AgentProviderId, getProvider } from '@shared/agent-provider-registry';
+import { getProvider, type AgentProviderId } from '@shared/agent-provider-registry';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import type { ExecFn } from '@main/core/utils/exec';
 import { quoteShellArg } from '@main/utils/shellEscape';
 
 export function splitShellWords(input: string | undefined): string[] {
-  if (!input?.trim()) return [];
+  const trimmed = input?.trim();
+  if (!trimmed) return [];
 
   const words: string[] = [];
   let current = '';
   let quote: 'single' | 'double' | null = null;
 
-  for (let i = 0; i < input.trim().length; i++) {
-    const char = input.trim()[i];
+  for (let i = 0; i < trimmed.length; i++) {
+    const char = trimmed[i];
 
     if (char === "'" && quote !== 'double') {
       quote = quote === 'single' ? null : 'single';
@@ -25,7 +26,7 @@ export function splitShellWords(input: string | undefined): string[] {
     }
 
     if (char === '\\' && quote !== 'single') {
-      const next = input.trim()[i + 1];
+      const next = trimmed[i + 1];
       if (!next) {
         current += char;
       } else if (
@@ -59,6 +60,8 @@ export function splitShellWords(input: string | undefined): string[] {
   return words;
 }
 
+const compilerResolutionCache = new Map<string, Promise<string>>();
+
 async function maybeAvoidSystemCCompiler({
   providerId,
   cli,
@@ -72,19 +75,29 @@ async function maybeAvoidSystemCCompiler({
 }): Promise<string> {
   if (providerId !== 'claude' || !fallbackCli || cli === fallbackCli || !exec) return cli;
 
-  try {
-    const result = await exec('bash', ['-lc', `command -v -- ${quoteShellArg(cli)}`], {
-      timeout: 2000,
-      maxBuffer: 2048,
-    });
-    const resolved = result.stdout.trim().split(/\r?\n/)[0];
-    const basename = path.basename(resolved);
-    if (basename === 'cc' || basename === 'clang' || basename === 'gcc') return fallbackCli;
-  } catch {
-    // If resolution fails, keep the user's custom command and let the shell report the real error.
-  }
+  // Login-shell `command -v` is slow on macOS (sources zprofile/nvm/etc).
+  // The result is static for a given (providerId, cli, fallbackCli) within a process.
+  const key = `${providerId}|${cli}|${fallbackCli}`;
+  const cached = compilerResolutionCache.get(key);
+  if (cached) return cached;
 
-  return cli;
+  const pending = (async () => {
+    try {
+      const result = await exec('bash', ['-lc', `command -v -- ${quoteShellArg(cli)}`], {
+        timeout: 2000,
+        maxBuffer: 2048,
+      });
+      const resolved = result.stdout.trim().split(/\r?\n/)[0];
+      const basename = path.basename(resolved);
+      if (basename === 'cc' || basename === 'clang' || basename === 'gcc') return fallbackCli;
+    } catch {
+      // If resolution fails, keep the user's custom command and let the shell report the real error.
+    }
+    return cli;
+  })();
+
+  compilerResolutionCache.set(key, pending);
+  return pending;
 }
 
 export async function buildAgentCommand({
@@ -105,7 +118,9 @@ export async function buildAgentCommand({
   const providerConfig = await providerOverrideSettings.getItem(providerId);
   const providerDef = getProvider(providerId);
 
-  const [configuredCli = providerDef?.cli, ...cliArgs] = splitShellWords(providerConfig?.cli);
+  const cliTokens = splitShellWords(providerConfig?.cli);
+  const configuredCli = cliTokens[0] ?? providerDef?.cli;
+  const cliArgs = cliTokens.slice(1);
   if (!configuredCli) throw new Error(`No CLI configured for provider: ${providerId}`);
 
   const cli = await maybeAvoidSystemCCompiler({

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -95,6 +95,7 @@ export class LocalConversationProvider implements ConversationProvider {
       sessionId: conversation.id,
       isResuming,
       initialPrompt,
+      exec: this.exec,
     });
 
     const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -1,12 +1,12 @@
 import type { AgentSessionConfig } from '@shared/agent-session';
-import { Conversation } from '@shared/conversations';
+import { type Conversation } from '@shared/conversations';
 import { agentSessionExitedChannel } from '@shared/events/agentEvents';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { wireAgentClassifier } from '@main/core/agent-hooks/classifier-wiring';
 import { claudeTrustService } from '@main/core/agent-hooks/claude-trust-service';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
-import { Pty } from '@main/core/pty/pty';
+import { type Pty } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
@@ -92,6 +92,7 @@ export class SshConversationProvider implements ConversationProvider {
       sessionId: conversation.id,
       isResuming,
       initialPrompt,
+      exec: this.exec,
     });
 
     const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;


### PR DESCRIPTION
when using my alias "cc" for the agent claude code and then going to a new conversation (i had cc aliased to claude --dangerously....) i wuold get this erorr "clang: error: unknown argument: '--session-id'
clang: error: unknown argument: '--dangerously-skip-permissions'
clang: error: no such file or directory: 'acfc78e3-acac-4d2a-9a23-fe571efd3acd'
clang: error: no input files
clang: error: unknown argument: '--session-id'
clang: error: unknown argument: '--dangerously-skip-permissions'
clang: error: no such file or directory: 'acfc78e3-acac-4d2a-9a23-fe571efd3acd'
clang: error: no input files
clang: error: unknown argument: '--session-id'
clang: error: unknown argument: '--dangerously-skip-permissions'
clang: error: no such file or directory: 'acfc78e3-acac-4d2a-9a23-fe571efd3acd'
clang: error: no input file"

this fixes that :D 