### PR TITLE
fix: surface step on task provision timeout

### DIFF
--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -31,6 +31,8 @@ function mapProvisionError(error: ProvisionTaskError): CreateTaskError {
         branch: error.branch,
         message: error.message,
       };
+    case 'timeout':
+      return { type: 'provision-timeout', timeoutMs: error.timeout, step: error.step };
     default:
       return { type: 'provision-failed', message: error.message };
   }

--- a/src/main/core/tasks/provision-task-error.ts
+++ b/src/main/core/tasks/provision-task-error.ts
@@ -1,11 +1,12 @@
+import type { ProvisionStep } from '@shared/events/taskEvents';
 import { TimeoutSignal } from '../projects/utils';
 import type { ServeWorktreeError } from '../projects/worktrees/worktree-service';
 
-export const TASK_TIMEOUT_MS = 600000;
+export const TASK_TIMEOUT_MS = 600_000;
 export const TEARDOWN_SCRIPT_WAIT_MS = 10_000;
 
 export type ProvisionTaskError =
-  | { type: 'timeout'; message: string; timeout: number }
+  | { type: 'timeout'; message: string; timeout: number; step: ProvisionStep | null }
   | { type: 'branch-not-found'; branch: string }
   | { type: 'worktree-setup-failed'; branch: string; message?: string }
   | { type: 'error'; message: string };
@@ -14,9 +15,13 @@ export type TeardownTaskError =
   | { type: 'timeout'; message: string; timeout: number }
   | { type: 'error'; message: string };
 
-export function toProvisionError(e: unknown): ProvisionTaskError {
+export function toProvisionError(
+  e: unknown,
+  step: ProvisionStep | null = null
+): ProvisionTaskError {
   if (isProvisionTaskError(e)) return e;
-  if (e instanceof TimeoutSignal) return { type: 'timeout', message: e.message, timeout: e.ms };
+  if (e instanceof TimeoutSignal)
+    return { type: 'timeout', message: e.message, timeout: e.ms, step };
   return { type: 'error', message: e instanceof Error ? e.message : String(e) };
 }
 
@@ -55,6 +60,7 @@ export function isProvisionTaskError(e: unknown): e is ProvisionTaskError {
 export function formatProvisionTaskError(error: ProvisionTaskError): string {
   switch (error.type) {
     case 'timeout':
+      return error.step ? `${error.message} (step: ${error.step})` : error.message;
     case 'error':
       return error.message;
     case 'branch-not-found':

--- a/src/main/core/tasks/task-manager.ts
+++ b/src/main/core/tasks/task-manager.ts
@@ -1,5 +1,6 @@
 import path from 'node:path';
 import type { Conversation } from '@shared/conversations';
+import { taskProvisionProgressChannel, type ProvisionStep } from '@shared/events/taskEvents';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { err, ok, type Result } from '@shared/result';
 import type { Task, TaskBootstrapStatus } from '@shared/tasks';
@@ -10,6 +11,7 @@ import type { ExecFn } from '@main/core/utils/exec';
 import { provisionBYOITask } from '@main/core/workspaces/byoi/provision-byoi-task';
 import { localWorkspaceId, sshWorkspaceId } from '@main/core/workspaces/workspace-id';
 import { workspaceRegistry, type TeardownMode } from '@main/core/workspaces/workspace-registry';
+import { events } from '@main/lib/events';
 import { HookCore, type Hookable } from '@main/lib/hookable';
 import { LifecycleMap } from '@main/lib/lifecycle-map';
 import { log } from '@main/lib/logger';
@@ -151,6 +153,10 @@ class TaskManager {
     terminals: Terminal[]
   ): Promise<Result<ProvisionResult, ProvisionTaskError>> {
     return this._lifecycle.provision(task.id, async () => {
+      let lastStep: ProvisionStep | null = null;
+      const unsubscribe = events.on(taskProvisionProgressChannel, (progress) => {
+        if (progress.taskId === task.id) lastStep = progress.step;
+      });
       try {
         const result = await withTimeout(
           executeProvision(provider, task, conversations, terminals),
@@ -176,13 +182,15 @@ class TaskManager {
 
         return ok(stored);
       } catch (e) {
-        const provisionError = toProvisionError(e);
+        const provisionError = toProvisionError(e, lastStep);
         log.error('TaskManager: failed to provision task', {
           taskId: task.id,
           projectId: provider.projectId,
           error: String(e),
         });
         return err(provisionError);
+      } finally {
+        unsubscribe();
       }
     });
   }

--- a/src/renderer/features/tasks/stores/task-manager.ts
+++ b/src/renderer/features/tasks/stores/task-manager.ts
@@ -54,6 +54,30 @@ function formatCreateTaskError(error: CreateTaskError): string {
         : `Could not set up the worktree for branch "${error.branch}".`;
     case 'provision-failed':
       return `Task could not be provisioned: ${error.message}`;
+    case 'provision-timeout': {
+      const seconds = Math.round(error.timeoutMs / 1000);
+      const stepLabel = (() => {
+        switch (error.step) {
+          case 'resolving-worktree':
+            return 'resolving the worktree';
+          case 'initialising-workspace':
+            return 'initialising the workspace';
+          case 'running-provision-script':
+            return 'running the provision script';
+          case 'connecting':
+            return 'connecting to the workspace';
+          case 'setting-up-workspace':
+            return 'setting up the workspace';
+          case 'starting-sessions':
+            return 'starting sessions';
+          case null:
+            return null;
+        }
+      })();
+      return stepLabel
+        ? `Task setup timed out after ${seconds}s while ${stepLabel}.`
+        : `Task setup timed out after ${seconds}s before any step started.`;
+    }
   }
 }
 

--- a/src/shared/events/taskEvents.ts
+++ b/src/shared/events/taskEvents.ts
@@ -14,15 +14,17 @@ export const taskPrUpdatedChannel = defineEvent<{
   prs: PullRequest[];
 }>('task:pr-updated');
 
+export type ProvisionStep =
+  | 'resolving-worktree'
+  | 'initialising-workspace'
+  | 'running-provision-script'
+  | 'connecting'
+  | 'setting-up-workspace'
+  | 'starting-sessions';
+
 export const taskProvisionProgressChannel = defineEvent<{
   taskId: string;
   projectId: string;
-  step:
-    | 'resolving-worktree'
-    | 'initialising-workspace'
-    | 'running-provision-script'
-    | 'connecting'
-    | 'setting-up-workspace'
-    | 'starting-sessions';
+  step: ProvisionStep;
   message: string;
 }>('task:provision-progress');

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -1,4 +1,5 @@
 import type { CreateConversationParams } from '@shared/conversations';
+import type { ProvisionStep } from '@shared/events/taskEvents';
 import type { Branch, CreateBranchError, FetchPrForReviewError, PushError } from '@shared/git';
 import type { PullRequest } from '@shared/pull-requests';
 
@@ -84,7 +85,8 @@ export type CreateTaskError =
   | { type: 'pr-fetch-failed'; error: FetchPrForReviewError; remote: string }
   | { type: 'branch-not-found'; branch: string }
   | { type: 'worktree-setup-failed'; branch: string; message?: string }
-  | { type: 'provision-failed'; message: string };
+  | { type: 'provision-failed'; message: string }
+  | { type: 'provision-timeout'; timeoutMs: number; step: ProvisionStep | null };
 
 export type CreateTaskWarning = {
   type: 'branch-publish-failed';


### PR DESCRIPTION
## Summary
- Capture the most recent step from `taskProvisionProgressChannel` while a task is provisioning, so timeout errors can say which step was running instead of just "Operation timed out after Nms".
- Add a dedicated `provision-timeout` variant to `CreateTaskError` and render a matter-of-fact, step-aware message in the renderer (e.g. "Task setup timed out after 600s while resolving the worktree.").

## Test plan
- [ ] Create a task on a small repo — provisions normally.
- [ ] Force a timeout (e.g. point at a huge repo / artificially slow `git worktree add`) and confirm the renderer shows the step-aware message.
- [ ] `pnpm run typecheck`, `pnpm run lint`, `pnpm run format` (all clean).