### PR TITLE
fix(pr-badge): make "Open PR on GitHub" button always visible

### DIFF
--- a/src/renderer/lib/components/pr-badge.tsx
+++ b/src/renderer/lib/components/pr-badge.tsx
@@ -58,7 +58,7 @@ export function PrBadge({ variant = 'default', pr, className }: PrBadgeProps) {
                   <Button
                     variant="ghost"
                     size="icon-xs"
-                    className="opacity-0 group-hover:opacity-100 transition-opacity"
+                    className="cursor-pointer"
                     onClick={() => rpc.app.openExternal(pr.url)}
                   >
                     <ExternalLink className="size-3.5" />


### PR DESCRIPTION
## Summary

The PR popover that opens when hovering the status icon next to a task name in the Projects sidebar contains an "Open PR on GitHub" `ExternalLink` button. It was rendered with `opacity-0 group-hover:opacity-100` but no `group` ancestor, so the button never became visible — there was no obvious way to jump to the PR from the popover.

- Removed the `opacity-0 group-hover:opacity-100 transition-opacity` classes
- Added `cursor-pointer` so the button shows a pointer cursor on hover

## Test plan

- [ ] `pnpm run dev`
- [ ] Open a project with a task linked to a PR
- [ ] Hover the PR status icon in the sidebar → popover opens with the ExternalLink button visible next to `#number`
- [ ] Hover the button → "Open PR on github" tooltip shows and cursor is a pointer
- [ ] Click the button → PR opens in the default browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)