### PR TITLE
Fix generic Linux runtime deps for RPM packaging

### DIFF
--- a/electron-builder.base.ts
+++ b/electron-builder.base.ts
@@ -1,0 +1,84 @@
+import type { Configuration } from 'electron-builder';
+import { injectLinuxRuntimeNodeModules } from './scripts/release/linux-runtime-node-modules';
+
+interface IdentityConfig {
+  appId: string;
+  artifactPrefix: string;
+  productName: string;
+  r2BaseUrl: string;
+  updateChannel: string;
+  macIcon: string;
+  winIcon: string;
+}
+
+export function createElectronBuilderConfig(identity: IdentityConfig): Configuration {
+  return {
+    appId: identity.appId,
+    productName: identity.productName,
+    directories: { output: 'release' },
+    artifactName: `${identity.artifactPrefix}-\${arch}.\${ext}`,
+    publish: [
+      {
+        provider: 'generic',
+        url: identity.r2BaseUrl,
+        channel: identity.updateChannel,
+      },
+    ],
+    generateUpdatesFilesForAllChannels: false,
+    files: ['out/**/*', 'node_modules/**/*', 'drizzle/**/*'],
+    asarUnpack: [
+      'node_modules/better-sqlite3/**',
+      'node_modules/node-pty/**',
+      'node_modules/@parcel/watcher/**',
+      '**/*.node',
+    ],
+    afterPack: injectLinuxRuntimeNodeModules,
+    mac: {
+      category: 'public.app-category.developer-tools',
+      hardenedRuntime: true,
+      entitlements: 'build/entitlements.mac.plist',
+      entitlementsInherit: 'build/entitlements.mac.plist',
+      target: [
+        { target: 'dmg', arch: ['arm64'] },
+        { target: 'zip', arch: ['arm64'] },
+      ],
+      icon: identity.macIcon,
+      notarize: false,
+    },
+    dmg: {
+      icon: identity.macIcon,
+    },
+    linux: {
+      category: 'Development',
+      target: [
+        { target: 'AppImage', arch: ['x64'] },
+        { target: 'deb', arch: ['x64'] },
+        { target: 'rpm', arch: ['x64'] },
+      ],
+    },
+    win: {
+      icon: identity.winIcon,
+      target: [
+        { target: 'nsis', arch: ['x64'] },
+        { target: 'msi', arch: ['x64'] },
+      ],
+      azureSignOptions: {
+        publisherName: 'General Action, Inc.',
+        endpoint: 'https://eus.codesigning.azure.net/',
+        certificateProfileName: 'emdash-public',
+        codeSigningAccountName: 'emdash',
+      },
+    },
+    msi: {
+      oneClick: false,
+      perMachine: false,
+    },
+    nsis: {
+      differentialPackage: true,
+      oneClick: false,
+      allowToChangeInstallationDirectory: true,
+      perMachine: false,
+    },
+    npmRebuild: false,
+  };
+}

--- a/electron-builder.canary.config.ts
+++ b/electron-builder.canary.config.ts
@@ -1,4 +1,4 @@
-import type { Configuration } from 'electron-builder';
+import { createElectronBuilderConfig } from './electron-builder.base';
 import {
   APP_ID,
   ARTIFACT_PREFIX,
@@ -7,73 +7,14 @@ import {
   UPDATE_CHANNEL,
 } from './src/shared/app-identity.canary';
 
-const config: Configuration = {
+const config = createElectronBuilderConfig({
   appId: APP_ID,
+  artifactPrefix: ARTIFACT_PREFIX,
   productName: PRODUCT_NAME,
-  directories: { output: 'release' },
-  artifactName: `${ARTIFACT_PREFIX}-\${arch}.\${ext}`,
-  publish: [
-    {
-      provider: 'generic',
-      url: R2_BASE_URL,
-      channel: UPDATE_CHANNEL,
-    },
-  ],
-  generateUpdatesFilesForAllChannels: false,
-  files: ['out/**/*', 'node_modules/**/*', 'drizzle/**/*'],
-  asarUnpack: [
-    'node_modules/better-sqlite3/**',
-    'node_modules/node-pty/**',
-    'node_modules/@parcel/watcher/**',
-    '**/*.node',
-  ],
-  mac: {
-    category: 'public.app-category.developer-tools',
-    hardenedRuntime: true,
-    entitlements: 'build/entitlements.mac.plist',
-    entitlementsInherit: 'build/entitlements.mac.plist',
-    target: [
-      { target: 'dmg', arch: ['arm64'] },
-      { target: 'zip', arch: ['arm64'] },
-    ],
-    icon: 'src/assets/images/emdash/emdash-canary.icns',
-    notarize: false,
-  },
-  dmg: {
-    icon: 'src/assets/images/emdash/emdash-canary.icns',
-  },
-  linux: {
-    category: 'Development',
-    target: [
-      { target: 'AppImage', arch: ['x64'] },
-      { target: 'deb', arch: ['x64'] },
-      { target: 'rpm', arch: ['x64'] },
-    ],
-  },
-  win: {
-    icon: 'src/assets/images/emdash/app-icon-canary.png',
-    target: [
-      { target: 'nsis', arch: ['x64'] },
-      { target: 'msi', arch: ['x64'] },
-    ],
-    azureSignOptions: {
-      publisherName: 'General Action, Inc.',
-      endpoint: 'https://eus.codesigning.azure.net/',
-      certificateProfileName: 'emdash-public',
-      codeSigningAccountName: 'emdash',
-    },
-  },
-  msi: {
-    oneClick: false,
-    perMachine: false,
-  },
-  nsis: {
-    differentialPackage: true,
-    oneClick: false,
-    allowToChangeInstallationDirectory: true,
-    perMachine: false,
-  },
-  npmRebuild: false,
-};
+  r2BaseUrl: R2_BASE_URL,
+  updateChannel: UPDATE_CHANNEL,
+  macIcon: 'src/assets/images/emdash/emdash-canary.icns',
+  winIcon: 'src/assets/images/emdash/app-icon-canary.png',
+});
 
 export default config;

--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -1,4 +1,4 @@
-import type { Configuration } from 'electron-builder';
+import { createElectronBuilderConfig } from './electron-builder.base';
 import {
   APP_ID,
   ARTIFACT_PREFIX,
@@ -7,73 +7,14 @@ import {
   UPDATE_CHANNEL,
 } from './src/shared/app-identity';
 
-const config: Configuration = {
+const config = createElectronBuilderConfig({
   appId: APP_ID,
+  artifactPrefix: ARTIFACT_PREFIX,
   productName: PRODUCT_NAME,
-  directories: { output: 'release' },
-  artifactName: `${ARTIFACT_PREFIX}-\${arch}.\${ext}`,
-  publish: [
-    {
-      provider: 'generic',
-      url: R2_BASE_URL,
-      channel: UPDATE_CHANNEL,
-    },
-  ],
-  generateUpdatesFilesForAllChannels: false,
-  files: ['out/**/*', 'node_modules/**/*', 'drizzle/**/*'],
-  asarUnpack: [
-    'node_modules/better-sqlite3/**',
-    'node_modules/node-pty/**',
-    'node_modules/@parcel/watcher/**',
-    '**/*.node',
-  ],
-  mac: {
-    category: 'public.app-category.developer-tools',
-    hardenedRuntime: true,
-    entitlements: 'build/entitlements.mac.plist',
-    entitlementsInherit: 'build/entitlements.mac.plist',
-    target: [
-      { target: 'dmg', arch: ['arm64'] },
-      { target: 'zip', arch: ['arm64'] },
-    ],
-    icon: 'src/assets/images/emdash/emdash-beta.icns',
-    notarize: false,
-  },
-  dmg: {
-    icon: 'src/assets/images/emdash/emdash-beta.icns',
-  },
-  linux: {
-    category: 'Development',
-    target: [
-      { target: 'AppImage', arch: ['x64'] },
-      { target: 'deb', arch: ['x64'] },
-      { target: 'rpm', arch: ['x64'] },
-    ],
-  },
-  win: {
-    icon: 'src/assets/images/emdash/app-icon-beta.png',
-    target: [
-      { target: 'nsis', arch: ['x64'] },
-      { target: 'msi', arch: ['x64'] },
-    ],
-    azureSignOptions: {
-      publisherName: 'General Action, Inc.',
-      endpoint: 'https://eus.codesigning.azure.net/',
-      certificateProfileName: 'emdash-public',
-      codeSigningAccountName: 'emdash',
-    },
-  },
-  msi: {
-    oneClick: false,
-    perMachine: false,
-  },
-  nsis: {
-    differentialPackage: true,
-    oneClick: false,
-    allowToChangeInstallationDirectory: true,
-    perMachine: false,
-  },
-  npmRebuild: false,
-};
+  r2BaseUrl: R2_BASE_URL,
+  updateChannel: UPDATE_CHANNEL,
+  macIcon: 'src/assets/images/emdash/emdash-beta.icns',
+  winIcon: 'src/assets/images/emdash/app-icon-beta.png',
+});
 
 export default config;

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "emdash",
   "version": "1.1.5",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
+  "homepage": "https://emdash.sh",
   "license": "Apache-2.0",
   "type": "module",
   "main": "./out/main/index.js",

--- a/scripts/release/linux-runtime-node-modules.ts
+++ b/scripts/release/linux-runtime-node-modules.ts
@@ -4,6 +4,7 @@ import type { AfterPackContext } from 'app-builder-lib';
 import fs from 'fs-extra';
 
 const require = createRequire(import.meta.url);
+const LINUX_RUNTIME_NODE_MODULES_SENTINEL = '__emdashLinuxRuntimeNodeModulesInjected';
 
 function isLinuxPack(context: AfterPackContext): boolean {
   return context.electronPlatformName === 'linux';
@@ -87,8 +88,8 @@ async function resolveInstalledPackageDir(parentDir: string, packageName: string
 async function copyPackageFiles(sourceDir: string, destinationDir: string): Promise<void> {
   await fs.copy(sourceDir, destinationDir, {
     dereference: false,
-    filter: (_source, destinationLike) => {
-      const rel = path.relative(sourceDir, destinationLike);
+    filter: (sourceLike) => {
+      const rel = path.relative(sourceDir, sourceLike);
       if (rel === '') {
         return true;
       }
@@ -154,19 +155,25 @@ export async function injectLinuxRuntimeNodeModules(context: AfterPackContext): 
     return;
   }
 
+  const guard = context as AfterPackContext & {
+    [LINUX_RUNTIME_NODE_MODULES_SENTINEL]?: boolean;
+  };
+  if (guard[LINUX_RUNTIME_NODE_MODULES_SENTINEL]) {
+    return;
+  }
+  guard[LINUX_RUNTIME_NODE_MODULES_SENTINEL] = true;
+
   const projectDir = context.packager.projectDir;
   const resourcesDir = path.join(context.appOutDir, 'resources');
   const runtimeNodeModulesDir = path.join(resourcesDir, 'node_modules');
   const projectPackageJson = await readPackageJson(projectDir);
-  const rootDependencies = {
-    ...(projectPackageJson.dependencies ?? {}),
-    ...(projectPackageJson.optionalDependencies ?? {}),
-  };
+  const rootDependencies = Object.keys(projectPackageJson.dependencies ?? {});
+  const rootOptionalDependencies = Object.keys(projectPackageJson.optionalDependencies ?? {});
 
   await fs.remove(runtimeNodeModulesDir);
   await fs.ensureDir(runtimeNodeModulesDir);
 
-  for (const packageName of Object.keys(rootDependencies)) {
+  for (const packageName of rootDependencies) {
     const packageDir = await resolveInstalledPackageDir(projectDir, packageName);
     await copyRuntimePackageTree(
       packageName,
@@ -174,5 +181,19 @@ export async function injectLinuxRuntimeNodeModules(context: AfterPackContext): 
       path.join(runtimeNodeModulesDir, ...splitPackagePath(packageName)),
       new Set()
     );
+  }
+
+  for (const packageName of rootOptionalDependencies) {
+    try {
+      const packageDir = await resolveInstalledPackageDir(projectDir, packageName);
+      await copyRuntimePackageTree(
+        packageName,
+        packageDir,
+        path.join(runtimeNodeModulesDir, ...splitPackagePath(packageName)),
+        new Set()
+      );
+    } catch {
+      continue;
+    }
   }
 }

--- a/scripts/release/linux-runtime-node-modules.ts
+++ b/scripts/release/linux-runtime-node-modules.ts
@@ -1,0 +1,178 @@
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import type { AfterPackContext } from 'app-builder-lib';
+import fs from 'fs-extra';
+
+const require = createRequire(import.meta.url);
+
+function isLinuxPack(context: AfterPackContext): boolean {
+  return context.electronPlatformName === 'linux';
+}
+
+function splitPackagePath(packageName: string): string[] {
+  return packageName.startsWith('@') ? packageName.split('/') : [packageName];
+}
+
+async function readPackageJson(packageDir: string): Promise<{
+  name: string;
+  version: string;
+  dependencies?: Record<string, string>;
+  optionalDependencies?: Record<string, string>;
+}> {
+  return fs.readJson(path.join(packageDir, 'package.json'));
+}
+
+async function findPackageJsonFromEntry(entryPath: string, packageName: string): Promise<string> {
+  let current = path.dirname(entryPath);
+  while (true) {
+    const packageJsonPath = path.join(current, 'package.json');
+    if (await fs.pathExists(packageJsonPath)) {
+      const packageJson = await fs.readJson(packageJsonPath);
+      if (packageJson?.name === packageName) {
+        return packageJsonPath;
+      }
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  throw new Error(`Unable to find package.json for ${packageName} from ${entryPath}`);
+}
+
+async function findPackageDirByNodeModulesLookup(
+  parentDir: string,
+  packageName: string
+): Promise<string | null> {
+  let current = path.resolve(parentDir);
+
+  while (true) {
+    const candidateDir = path.join(current, 'node_modules', ...splitPackagePath(packageName));
+    const candidatePackageJson = path.join(candidateDir, 'package.json');
+
+    if (await fs.pathExists(candidatePackageJson)) {
+      const packageJson = await fs.readJson(candidatePackageJson);
+      if (packageJson?.name === packageName) {
+        return candidateDir;
+      }
+    }
+
+    const parent = path.dirname(current);
+    if (parent === current) {
+      break;
+    }
+    current = parent;
+  }
+
+  return null;
+}
+
+async function resolveInstalledPackageDir(parentDir: string, packageName: string): Promise<string> {
+  try {
+    const entryPath = require.resolve(packageName, { paths: [parentDir] });
+    const packageJsonPath = await findPackageJsonFromEntry(entryPath, packageName);
+    return path.dirname(packageJsonPath);
+  } catch {
+    const packageDir = await findPackageDirByNodeModulesLookup(parentDir, packageName);
+    if (packageDir) {
+      return packageDir;
+    }
+    throw new Error(`Unable to resolve installed package dir for ${packageName} from ${parentDir}`);
+  }
+}
+
+async function copyPackageFiles(sourceDir: string, destinationDir: string): Promise<void> {
+  await fs.copy(sourceDir, destinationDir, {
+    dereference: false,
+    filter: (_source, destinationLike) => {
+      const rel = path.relative(sourceDir, destinationLike);
+      if (rel === '') {
+        return true;
+      }
+      return !rel.split(path.sep).includes('node_modules');
+    },
+  });
+}
+
+async function copyRuntimePackageTree(
+  packageName: string,
+  packageDir: string,
+  destinationDir: string,
+  ancestry: Set<string>
+): Promise<void> {
+  const realPackageDir = await fs.realpath(packageDir);
+  if (ancestry.has(realPackageDir)) {
+    return;
+  }
+
+  const nextAncestry = new Set(ancestry);
+  nextAncestry.add(realPackageDir);
+
+  await copyPackageFiles(packageDir, destinationDir);
+
+  const packageJson = await readPackageJson(packageDir);
+  const prodDependencies = packageJson.dependencies ?? {};
+  const optionalDependencies = packageJson.optionalDependencies ?? {};
+
+  for (const dependencyName of Object.keys(prodDependencies)) {
+    const dependencyDir = await resolveInstalledPackageDir(realPackageDir, dependencyName);
+    await copyRuntimePackageTree(
+      dependencyName,
+      dependencyDir,
+      path.join(destinationDir, 'node_modules', ...splitPackagePath(dependencyName)),
+      nextAncestry
+    );
+  }
+
+  for (const dependencyName of Object.keys(optionalDependencies)) {
+    try {
+      const dependencyDir = await resolveInstalledPackageDir(realPackageDir, dependencyName);
+      await copyRuntimePackageTree(
+        dependencyName,
+        dependencyDir,
+        path.join(destinationDir, 'node_modules', ...splitPackagePath(dependencyName)),
+        nextAncestry
+      );
+    } catch {
+      continue;
+    }
+  }
+
+  const copiedPackageJson = path.join(destinationDir, 'package.json');
+  if (await fs.pathExists(copiedPackageJson)) {
+    const copiedPackage = await fs.readJson(copiedPackageJson);
+    delete copiedPackage.scripts;
+    await fs.writeJson(copiedPackageJson, copiedPackage, { spaces: 2 });
+  }
+}
+
+export async function injectLinuxRuntimeNodeModules(context: AfterPackContext): Promise<void> {
+  if (!isLinuxPack(context)) {
+    return;
+  }
+
+  const projectDir = context.packager.projectDir;
+  const resourcesDir = path.join(context.appOutDir, 'resources');
+  const runtimeNodeModulesDir = path.join(resourcesDir, 'node_modules');
+  const projectPackageJson = await readPackageJson(projectDir);
+  const rootDependencies = {
+    ...(projectPackageJson.dependencies ?? {}),
+    ...(projectPackageJson.optionalDependencies ?? {}),
+  };
+
+  await fs.remove(runtimeNodeModulesDir);
+  await fs.ensureDir(runtimeNodeModulesDir);
+
+  for (const packageName of Object.keys(rootDependencies)) {
+    const packageDir = await resolveInstalledPackageDir(projectDir, packageName);
+    await copyRuntimePackageTree(
+      packageName,
+      packageDir,
+      path.join(runtimeNodeModulesDir, ...splitPackagePath(packageName)),
+      new Set()
+    );
+  }
+}


### PR DESCRIPTION
## Summary
- extract shared electron-builder config into a single base factory for stable and canary builds
- inject Linux runtime production dependencies after pack so rpm/deb/appimage builds work with hoisted pnpm node_modules layouts
- add package homepage metadata required by rpm packaging

## Validation
- `mise exec node@24.14.0 -- pnpm run build:main`
- `mise exec node@24.14.0 -- pnpm run typecheck`
- `mise exec node@24.14.0 -- node --experimental-strip-types scripts/release/rebuild-native.ts --arch x64`
- `mise exec node@24.14.0 -- pnpm exec electron-builder --linux rpm --x64 --publish never --config electron-builder.config.ts --config.npmRebuild=false`
- installed rebuilt rpm locally and verified app startup no longer fails with `ERR_MODULE_NOT_FOUND` for `better-sqlite3`

## Notes
- local `pnpm test` is not fully green on current upstream main due to pre-existing baseline issues unrelated to this packaging change, including the `pr-merge-line` expectation mismatch and an existing legacy-port task import test failure
