### PR TITLE
fix: make command in lifecycle scripts optional

### DIFF
--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -92,7 +92,7 @@ export class LocalTerminalProvider implements TerminalProvider {
     return this.spawnWithPolicy(
       terminal,
       initialSize,
-      { kind: 'shell-line', commandLine: command },
+      command === undefined ? undefined : { kind: 'shell-line', commandLine: command },
       {
         respawnOnExit,
         preserveBufferOnExit,

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -114,7 +114,7 @@ export class SshTerminalProvider implements TerminalProvider {
     return this.spawnWithPolicy(
       terminal,
       initialSize,
-      { command, args: [] },
+      command === undefined ? undefined : { command, args: [] },
       {
         respawnOnExit,
         preserveBufferOnExit,

--- a/src/main/core/terminals/terminal-provider.ts
+++ b/src/main/core/terminals/terminal-provider.ts
@@ -2,7 +2,7 @@ import type { Terminal } from '@shared/terminals';
 
 export type LifecycleScriptSpawnRequest = {
   terminal: Terminal;
-  command: string;
+  command?: string;
   initialSize?: { cols: number; rows: number };
   respawnOnExit?: boolean;
   preserveBufferOnExit?: boolean;

--- a/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -61,7 +61,6 @@ export class LifecycleScriptService {
         taskId: this.workspaceId,
         name: script.type,
       },
-      command: '',
       initialSize,
       respawnOnExit: false,
       preserveBufferOnExit: true,


### PR DESCRIPTION
issue:
- lifecycle setup/run tabs prepared their PTY with command: '', which local spawning resolved to shell -c "".
- that shell exited immediately, so later writes like pnpm I had nowhere to run

fix:
- made lifecycle spawn command optional
- omitted command now explicitly means “prepare an interactive shell"