### PR TITLE
feat: render markdown previews in diff viewer

### DIFF
--- a/src/renderer/features/tasks/diff-view/main-panel/diff-toolbar.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/diff-toolbar.tsx
@@ -1,9 +1,10 @@
-import { AlignJustify, Columns2 } from 'lucide-react';
+import { AlignJustify, Columns2, Eye, Pencil } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useMemo } from 'react';
 import { useProvisionedTask } from '@renderer/features/tasks/task-view-context';
 import { splitPath } from '@renderer/features/tasks/utils';
 import { FileIcon } from '@renderer/lib/editor/file-icon';
+import { isMarkdownPath } from '@renderer/lib/editor/utils';
 import { Badge } from '@renderer/lib/ui/badge';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 
@@ -14,6 +15,7 @@ export const DiffToolbar = observer(function DiffToolbar() {
 
   const filePath = activeFile?.path ?? undefined;
   const { filename, directory } = filePath ? splitPath(filePath) : { filename: '', directory: '' };
+  const isMarkdown = filePath ? isMarkdownPath(filePath) : false;
 
   const diffSourceLabel = useMemo(() => {
     if (activeFile?.group === 'staged') return 'Staged';
@@ -38,6 +40,25 @@ export const DiffToolbar = observer(function DiffToolbar() {
         {diffSourceLabel && <Badge variant="outline">{diffSourceLabel}</Badge>}
       </div>
       <div className="flex items-center gap-2">
+        {isMarkdown && (
+          <ToggleGroup
+            size="sm"
+            multiple={false}
+            value={[diffView.markdownDiffMode]}
+            onValueChange={([value]) => {
+              if (value) {
+                diffView.setMarkdownDiffMode(value as 'preview' | 'source');
+              }
+            }}
+          >
+            <ToggleGroupItem value="preview" aria-label="Preview">
+              <Eye className="h-3.5 w-3.5" />
+            </ToggleGroupItem>
+            <ToggleGroupItem value="source" aria-label="View source">
+              <Pencil className="h-3.5 w-3.5" />
+            </ToggleGroupItem>
+          </ToggleGroup>
+        )}
         <ToggleGroup
           size="sm"
           multiple={false}

--- a/src/renderer/features/tasks/diff-view/main-panel/file-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/file-diff-view.tsx
@@ -3,11 +3,13 @@ import { useEffect } from 'react';
 import { HEAD_REF, STAGED_REF } from '@shared/git';
 import { useProvisionedTask, useTaskViewContext } from '@renderer/features/tasks/task-view-context';
 import { isBinaryForDiff } from '@renderer/lib/editor/fileKind';
+import { isMarkdownPath } from '@renderer/lib/editor/utils';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
 import { StickyDiffEditor } from '@renderer/lib/monaco/sticky-diff-editor';
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { getLanguageFromPath } from '@renderer/utils/languageUtils';
+import { MarkdownDiffPreview } from './markdown-diff-preview';
 
 export const FileDiffView = observer(function FileDiffView() {
   const { projectId } = useTaskViewContext();
@@ -17,7 +19,9 @@ export const FileDiffView = observer(function FileDiffView() {
   const activeFile = diffView.activeFile;
 
   const isBinary = activeFile ? isBinaryForDiff(activeFile.path) : false;
-  const showEditor = activeFile !== null && !isBinary;
+  const isMarkdown = activeFile ? isMarkdownPath(activeFile.path) : false;
+  const showMarkdownPreview = isMarkdown && diffView.markdownDiffMode === 'preview';
+  const showDiff = activeFile !== null && !isBinary;
 
   // Compute URIs from activeFile (same rules as DiffSlotStore).
   const root = `workspace:${workspaceId}`;
@@ -92,7 +96,16 @@ export const FileDiffView = observer(function FileDiffView() {
   return (
     <div className="flex h-full flex-col">
       <div className="relative min-h-0 flex-1">
-        {showEditor && (
+        {showDiff && showMarkdownPreview && (
+          <MarkdownDiffPreview
+            filePath={activeFile.path}
+            workspaceId={workspaceId}
+            originalUri={originalUri}
+            modifiedUri={modifiedUri}
+            diffStyle={diffView.diffStyle}
+          />
+        )}
+        {showDiff && !showMarkdownPreview && (
           <StickyDiffEditor
             originalUri={originalUri}
             modifiedUri={modifiedUri}

--- a/src/renderer/features/tasks/diff-view/main-panel/markdown-diff-preview.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/markdown-diff-preview.tsx
@@ -1,0 +1,129 @@
+import { observer } from 'mobx-react-lite';
+import { useCallback, useLayoutEffect, useRef } from 'react';
+import { useTaskViewContext } from '@renderer/features/tasks/task-view-context';
+import { rpc } from '@renderer/lib/ipc';
+import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
+import { MarkdownRenderer } from '@renderer/lib/ui/markdown-renderer';
+import { Spinner } from '@renderer/lib/ui/spinner';
+import { cn } from '@renderer/utils/utils';
+
+interface MarkdownDiffPreviewProps {
+  filePath: string;
+  workspaceId: string;
+  originalUri: string;
+  modifiedUri: string;
+  diffStyle: 'unified' | 'split';
+  onHeightChange?: (height: number) => void;
+}
+
+export const MarkdownDiffPreview = observer(function MarkdownDiffPreview({
+  filePath,
+  workspaceId,
+  originalUri,
+  modifiedUri,
+  diffStyle,
+  onHeightChange,
+}: MarkdownDiffPreviewProps) {
+  const { projectId } = useTaskViewContext();
+  const rootRef = useRef<HTMLDivElement>(null);
+  const originalStatus = modelRegistry.modelStatus.get(originalUri);
+  const modifiedStatus = modelRegistry.modelStatus.get(modifiedUri);
+
+  // Subscribe to content invalidations before reading model values.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _originalVersion = modelRegistry.modelVersions.get(originalUri);
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const _modifiedVersion = modelRegistry.modelVersions.get(modifiedUri);
+
+  const originalContent = modelRegistry.getModelByUri(originalUri)?.getValue() ?? '';
+  const modifiedContent = modelRegistry.getModelByUri(modifiedUri)?.getValue() ?? '';
+  const isLoading = originalStatus !== 'ready' || modifiedStatus !== 'ready';
+  const hasError = originalStatus === 'error' || modifiedStatus === 'error';
+  const fileDir = filePath.includes('/') ? filePath.substring(0, filePath.lastIndexOf('/')) : '';
+
+  const resolveImage = useCallback(
+    async (src: string): Promise<string | null> => {
+      const imagePath = fileDir ? `${fileDir}/${src}` : src;
+      const result = await rpc.fs.readImage(projectId, workspaceId, imagePath);
+      return result.success ? (result.data?.dataUrl ?? null) : null;
+    },
+    [projectId, workspaceId, fileDir]
+  );
+
+  useLayoutEffect(() => {
+    if (!onHeightChange || !rootRef.current) return;
+    const node = rootRef.current;
+    const updateHeight = () => onHeightChange(node.scrollHeight);
+    updateHeight();
+    const resizeObserver = new ResizeObserver(updateHeight);
+    resizeObserver.observe(node);
+    return () => resizeObserver.disconnect();
+  }, [onHeightChange, originalContent, modifiedContent, diffStyle]);
+
+  if (hasError) {
+    return (
+      <div className="flex h-full items-center justify-center text-sm text-muted-foreground">
+        Markdown preview unavailable
+      </div>
+    );
+  }
+
+  if (isLoading) {
+    return (
+      <div className="flex h-full items-center justify-center text-muted-foreground">
+        <Spinner size="sm" />
+      </div>
+    );
+  }
+
+  return (
+    <div ref={rootRef} className="h-full overflow-auto bg-background-secondary-1">
+      <div
+        className={cn(
+          'grid min-h-full',
+          diffStyle === 'split' ? 'grid-cols-2 divide-x divide-border' : 'grid-cols-1'
+        )}
+      >
+        <MarkdownPreviewPane
+          label="Original"
+          content={originalContent}
+          resolveImage={resolveImage}
+          className={diffStyle === 'unified' ? 'border-b border-border' : undefined}
+        />
+        <MarkdownPreviewPane
+          label="Modified"
+          content={modifiedContent}
+          resolveImage={resolveImage}
+        />
+      </div>
+    </div>
+  );
+});
+
+interface MarkdownPreviewPaneProps {
+  label: string;
+  content: string;
+  resolveImage: (src: string) => Promise<string | null>;
+  className?: string;
+}
+
+function MarkdownPreviewPane({
+  label,
+  content,
+  resolveImage,
+  className,
+}: MarkdownPreviewPaneProps) {
+  return (
+    <section className={cn('min-w-0', className)}>
+      <div className="sticky top-0 z-10 border-b border-border bg-background-secondary-1/95 px-4 py-2 text-xs font-medium text-foreground-muted backdrop-blur">
+        {label}
+      </div>
+      <MarkdownRenderer
+        content={content}
+        variant="full"
+        className="w-full max-w-none px-6 py-5"
+        resolveImage={resolveImage}
+      />
+    </section>
+  );
+}

--- a/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
@@ -9,10 +9,12 @@ import {
 } from '@renderer/features/tasks/diff-view/stores/stacked-diff-panel-store';
 import { useProvisionedTask, useTaskViewContext } from '@renderer/features/tasks/task-view-context';
 import { FileIcon } from '@renderer/lib/editor/file-icon';
+import { isMarkdownPath } from '@renderer/lib/editor/utils';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { StickyDiffEditor } from '@renderer/lib/monaco/sticky-diff-editor';
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { cn } from '@renderer/utils/utils';
+import { MarkdownDiffPreview } from './markdown-diff-preview';
 
 const LARGE_DIFF_LINE_THRESHOLD = 1500;
 
@@ -190,6 +192,8 @@ const StackedFileSlot = observer(function StackedFileSlot({
   const forceLoad = panelStore.isForceLoaded(file.path);
   const totalDiffLines = file.additions + file.deletions;
   const isLarge = totalDiffLines > LARGE_DIFF_LINE_THRESHOLD;
+  const isMarkdown = isMarkdownPath(file.path);
+  const showMarkdownPreview = isMarkdown && diffView.markdownDiffMode === 'preview';
   const diffStyle = diffView.diffStyle;
 
   const editorHeight =
@@ -248,6 +252,15 @@ const StackedFileSlot = observer(function StackedFileSlot({
                 Load anyway
               </button>
             </div>
+          ) : showMarkdownPreview ? (
+            <MarkdownDiffPreview
+              filePath={file.path}
+              workspaceId={slotStore.workspaceId}
+              originalUri={originalUri}
+              modifiedUri={modifiedUri}
+              diffStyle={diffStyle}
+              onHeightChange={setContentHeight}
+            />
           ) : (
             <StickyDiffEditor
               originalUri={originalUri}

--- a/src/renderer/features/tasks/diff-view/stores/diff-view-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/diff-view-store.ts
@@ -21,6 +21,7 @@ function isValidGitObjectRef(raw: unknown): raw is GitObjectRef {
 export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
   activeFileOverride: ActiveFile | null = null;
   diffStyle: 'unified' | 'split' = 'unified';
+  markdownDiffMode: 'preview' | 'source' = 'preview';
   readonly viewMode = 'file' as const;
   commitAction: 'commit' | 'commit-push' | null = null;
 
@@ -46,9 +47,11 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
       activeFileOverride: observable,
       activeFile: computed,
       diffStyle: observable,
+      markdownDiffMode: observable,
       commitAction: observable,
       setActiveFile: action,
       setDiffStyle: action,
+      setMarkdownDiffMode: action,
     });
 
     // Auto-expand the changes panel section that contains the newly selected file.
@@ -118,11 +121,13 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
       viewMode: 'file',
       activeFile: this.activeFileOverride ?? undefined,
       commitAction: this.commitAction,
+      markdownDiffMode: this.markdownDiffMode,
     };
   }
 
   restoreSnapshot(snapshot: Partial<DiffViewSnapshot>): void {
     if (snapshot.diffStyle) this.diffStyle = snapshot.diffStyle;
+    if (snapshot.markdownDiffMode) this.markdownDiffMode = snapshot.markdownDiffMode;
     // viewMode is always 'file' — ignore any persisted value
     if (snapshot.activeFile && isValidGitObjectRef(snapshot.activeFile.originalRef)) {
       this.activeFileOverride = snapshot.activeFile;
@@ -157,6 +162,10 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
 
   setDiffStyle(style: 'unified' | 'split'): void {
     this.diffStyle = style;
+  }
+
+  setMarkdownDiffMode(mode: 'preview' | 'source'): void {
+    this.markdownDiffMode = mode;
   }
 
   dispose(): void {

--- a/src/renderer/lib/monaco/monaco-model-registry.ts
+++ b/src/renderer/lib/monaco/monaco-model-registry.ts
@@ -152,6 +152,13 @@ export class MonacoModelRegistry {
   readonly bufferVersions = observable.map<string, number>();
 
   /**
+   * Monotonically-increasing content version for each typed model URI.
+   * Covers disk:// and git:// snapshots so non-Monaco renderers can react to
+   * model invalidations without attaching an editor.
+   */
+  readonly modelVersions = observable.map<string, number>();
+
+  /**
    * 60 s TTL timers. Started in unregisterModel when refs drop to 0.
    * Cancelled if the model is re-registered before the timer fires.
    */
@@ -294,6 +301,7 @@ export class MonacoModelRegistry {
     this.modelMap.set(diskUri, entry);
 
     this.modelStatus.set(diskUri, 'ready');
+    this.modelVersions.set(diskUri, 1);
 
     return uri;
   }
@@ -356,6 +364,7 @@ export class MonacoModelRegistry {
     this.modelMap.set(gitUri, entry);
 
     this.modelStatus.set(gitUri, 'ready');
+    this.modelVersions.set(gitUri, 1);
 
     return uri;
   }
@@ -465,6 +474,7 @@ export class MonacoModelRegistry {
     }
 
     this.modelStatus.set(uri, 'ready');
+    this.modelVersions.set(uri, 1);
     // Mark the buffer as having content so markdown/other renderers that depend
     // on bufferVersions can react to the initial population.
     runInAction(() => {
@@ -509,6 +519,7 @@ export class MonacoModelRegistry {
       if (!e.model.isDisposed()) e.model.dispose();
       this.modelMap.delete(uri);
       this.modelStatus.delete(uri);
+      this.modelVersions.delete(uri);
       if (e.type === 'buffer') {
         this.bufferContentDisposables.get(uri)?.dispose();
         this.bufferContentDisposables.delete(uri);
@@ -731,6 +742,7 @@ export class MonacoModelRegistry {
             );
       if (res.success && res.data.content !== null) {
         entry.model.setValue(res.data.content);
+        this.modelVersions.set(uri, (this.modelVersions.get(uri) ?? 0) + 1);
       }
     }
   }
@@ -789,6 +801,7 @@ export class MonacoModelRegistry {
     const newMatchesBuffer = bufValue === newContent;
 
     entry.model.setValue(newContent);
+    this.modelVersions.set(diskUri, (this.modelVersions.get(diskUri) ?? 0) + 1);
 
     if (!wasDirty || newMatchesBuffer) {
       if (bufEntry?.type === 'buffer' && !newMatchesBuffer) {

--- a/src/shared/view-state.ts
+++ b/src/shared/view-state.ts
@@ -16,6 +16,7 @@ export type DiffViewSnapshot = {
   viewMode: 'file';
   activeFile?: ActiveFile;
   commitAction: 'commit' | 'commit-push' | null;
+  markdownDiffMode?: 'preview' | 'source';
 };
 
 export interface ActiveFile {


### PR DESCRIPTION
## Summary
- Render Markdown and MDX diffs as before/after previews in the diff viewer.
- Add a Markdown preview/source toggle that mirrors the file editor interaction pattern.
- Track disk/git model versions so rendered previews react to model invalidations.

## Validation
- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm test