### PR TITLE
fix: restore hover-state delete icon on task sidebar

### DIFF
--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -122,7 +122,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
         </div>
         <TaskSidebarAgentStatus task={task} />
         <SidebarItemMiniButton
-          className="shrink-0 opacity-0 transition-opacity group-hover/row:opacity-100"
+          className="shrink-0 opacity-0 transition-opacity group-hover/row:opacity-100 focus-visible:opacity-100"
           onClick={(e) => {
             e.stopPropagation();
             if (hoverAction === 'archive') {

--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -1,5 +1,7 @@
+import { Archive, Trash2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { selectCurrentPr } from '@shared/pull-requests';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { TaskSidebarAgentStatus } from '@renderer/features/sidebar/task-sidebar-agent-status';
 import { TaskContextMenu } from '@renderer/features/tasks/components/task-context-menu';
 import { TaskGitDiffStats } from '@renderer/features/tasks/components/task-git-diff-stats';
@@ -17,7 +19,7 @@ import {
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { cn } from '@renderer/utils/utils';
 import { PrBadge } from '../../lib/components/pr-badge';
-import { SidebarMenuRow } from './sidebar-primitives';
+import { SidebarItemMiniButton, SidebarMenuRow } from './sidebar-primitives';
 
 interface SidebarTaskItemProps {
   taskId: string;
@@ -34,6 +36,9 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
   const { navigate } = useNavigate();
   const showRename = useShowModal('renameTaskModal');
   const showConfirm = useShowModal('confirmActionModal');
+
+  const { value: interfaceSettings } = useAppSettingsKey('interface');
+  const hoverAction = interfaceSettings?.taskHoverAction ?? 'delete';
 
   const { currentView } = useWorkspaceSlots();
   const { params } = useParams('task');
@@ -116,6 +121,24 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
           <RenderPrBadge task={task} />
         </div>
         <TaskSidebarAgentStatus task={task} />
+        <SidebarItemMiniButton
+          className="shrink-0 opacity-0 transition-opacity group-hover/row:opacity-100"
+          onClick={(e) => {
+            e.stopPropagation();
+            if (hoverAction === 'archive') {
+              handleArchive();
+            } else {
+              handleDelete();
+            }
+          }}
+          aria-label={hoverAction === 'archive' ? 'Archive task' : 'Delete task'}
+        >
+          {hoverAction === 'archive' ? (
+            <Archive className="size-3.5" />
+          ) : (
+            <Trash2 className="size-3.5" />
+          )}
+        </SidebarItemMiniButton>
       </SidebarMenuRow>
     </TaskContextMenu>
   );


### PR DESCRIPTION
Fixes #1778 

### Description
In v1.x, hovering over a task in the sidebar no longer revealed the inline delete/archive icon, leaving the `taskHoverAction` setting orphaned. This PR wires that setting back up to the UI.

Changes made:
- Read `taskHoverAction` via `useAppSettingsKey('interface')` (defaults to 'delete').
- Added the existing `SidebarItemMiniButton` primitive to the `SidebarMenuRow` in `task-item.tsx`.
- The icon (either `Trash2` or `Archive`) is revealed on row hover via `group-hover/row`.
- Clicking the icon triggers the existing `handleDelete` (with confirmation) or `handleArchive` functions.
- Added `e.stopPropagation()` so clicking the icon doesn't also navigate to the task.

### Testing
- [x] Verified hover icon appears when mousing over a task row.
- [x] Verified clicking the trash icon opens the delete confirmation modal.
- [x] Verified the icon updates based on the `taskHoverAction` setting.
- [x] Ran `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`, and `pnpm test` locally.

### UI Changes
*(Please see the screenshot/GIF below demonstrating the hover state)*
<img width="369" height="127" alt="Screenshot 2026-05-04 125358" src="https://github.com/user-attachments/assets/919558b9-2da9-4099-9eca-fc4f5fbc3fef" />
