### PR TITLE
feat: restore custom cli commands + env vars

### DIFF
--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -72,6 +72,16 @@ describe('buildAgentCommand', () => {
     expect(result.args).toEqual(['--resume', 'existing session', 'conv-1']);
   });
 
+  it('parses multi-token session id flags', () => {
+    const result = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: makeConfig({ sessionIdFlag: '--session id' }),
+      sessionId: 'conv-1',
+    });
+
+    expect(result.args).toEqual(['--session', 'id', 'conv-1']);
+  });
+
   it('appends extra args', () => {
     const result = buildAgentCommand({
       providerId: 'claude',

--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -1,17 +1,24 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
+import type { ProviderCustomConfig } from '@shared/app-settings';
 import { providerConfigDefaults } from '@main/core/settings/schema';
 import { buildAgentCommand } from './agent-command';
 
-vi.mock('@main/core/settings/provider-settings-service', () => ({
-  providerOverrideSettings: {
-    getItem: vi.fn(async (providerId: string) => providerConfigDefaults[providerId]),
-  },
-}));
+function makeConfig(overrides: Partial<ProviderCustomConfig> = {}): ProviderCustomConfig {
+  return {
+    cli: 'claude',
+    resumeFlag: '--resume',
+    autoApproveFlag: '--dangerously-skip-permissions',
+    initialPromptFlag: '',
+    sessionIdFlag: '--session-id',
+    ...overrides,
+  };
+}
 
 describe('buildAgentCommand', () => {
-  it('uses the current Codex bypass flag when auto-approve is enabled', async () => {
-    const command = await buildAgentCommand({
+  it('uses the current Codex bypass flag when auto-approve is enabled', () => {
+    const command = buildAgentCommand({
       providerId: 'codex',
+      providerConfig: providerConfigDefaults.codex,
       autoApprove: true,
       initialPrompt: 'Fix the issue',
       sessionId: 'session-1',
@@ -21,5 +28,90 @@ describe('buildAgentCommand', () => {
       command: 'codex',
       args: ['--dangerously-bypass-approvals-and-sandbox', 'Fix the issue'],
     });
+  });
+
+  it('supports custom CLI command prefixes and appends managed provider args', () => {
+    const result = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: makeConfig({
+        cli: 'caffeinate -i direnv exec . claude',
+      }),
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+    });
+
+    expect(result).toEqual({
+      command: 'caffeinate',
+      args: [
+        '-i',
+        'direnv',
+        'exec',
+        '.',
+        'claude',
+        '--session-id',
+        'conv-1',
+        '--dangerously-skip-permissions',
+        'Fix the bug',
+      ],
+    });
+  });
+
+  it('preserves quoted custom CLI and flag arguments', () => {
+    const result = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: makeConfig({
+        cli: '"/opt/Claude Code/bin/claude"',
+        resumeFlag: '--resume "existing session"',
+      }),
+      sessionId: 'conv-1',
+      isResuming: true,
+    });
+
+    expect(result.command).toBe('/opt/Claude Code/bin/claude');
+    expect(result.args).toEqual(['--resume', 'existing session', 'conv-1']);
+  });
+
+  it('appends extra args', () => {
+    const result = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: makeConfig({
+        extraArgs: '--model "Claude Sonnet"',
+      }),
+      sessionId: 'conv-1',
+    });
+
+    expect(result.args).toContain('--model');
+    expect(result.args).toContain('Claude Sonnet');
+  });
+
+  it('rejects shell control syntax that makes managed args ambiguous', () => {
+    expect(() =>
+      buildAgentCommand({
+        providerId: 'claude',
+        providerConfig: makeConfig({ cli: 'claude | tee log' }),
+        sessionId: 'conv-1',
+      })
+    ).toThrow(/executable command prefixes/);
+  });
+
+  it('rejects shell setup in the CLI command field', () => {
+    expect(() =>
+      buildAgentCommand({
+        providerId: 'claude',
+        providerConfig: makeConfig({ cli: 'source ~/.zshrc && claude' }),
+        sessionId: 'conv-1',
+      })
+    ).toThrow(/executable command prefixes/);
+  });
+
+  it('rejects inline environment assignment in the CLI command field', () => {
+    expect(() =>
+      buildAgentCommand({
+        providerId: 'claude',
+        providerConfig: makeConfig({ cli: 'FOO=bar claude' }),
+        sessionId: 'conv-1',
+      })
+    ).toThrow(/executable command prefixes/);
   });
 });

--- a/src/main/core/conversations/impl/agent-command.ts
+++ b/src/main/core/conversations/impl/agent-command.ts
@@ -115,7 +115,7 @@ export function buildAgentCommand({
       args.push(sessionId);
     }
   } else if (providerConfig?.sessionIdFlag) {
-    args.push(providerConfig.sessionIdFlag, sessionId);
+    args.push(...parseArgField(providerConfig.sessionIdFlag), sessionId);
   }
 
   if (autoApprove && providerConfig?.autoApproveFlag) {

--- a/src/main/core/conversations/impl/agent-command.ts
+++ b/src/main/core/conversations/impl/agent-command.ts
@@ -1,28 +1,117 @@
 import { getProvider, type AgentProviderId } from '@shared/agent-provider-registry';
-import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
+import type { ProviderCustomConfig } from '@shared/app-settings';
 
-export async function buildAgentCommand({
+export type AgentCommand = {
+  command: string;
+  args: string[];
+};
+
+const SHELL_SYNTAX_ERROR = 'Custom CLI commands support executable command prefixes only. ';
+
+const SHELL_BUILTINS = new Set(['.', 'source', 'eval', 'exec', 'cd', 'alias', 'export']);
+
+type ParsedWords = { ok: true; words: string[] } | { ok: false; reason: string };
+
+export function parseShellWords(
+  input: string,
+  options: { rejectShellSyntax?: boolean } = {}
+): ParsedWords {
+  const words: string[] = [];
+  let current = '';
+  let inSingleQuote = false;
+  let inDoubleQuote = false;
+  let escaped = false;
+
+  for (let i = 0; i < input.length; i += 1) {
+    const char = input[i];
+
+    if (escaped) {
+      current += char;
+      escaped = false;
+      continue;
+    }
+
+    if (char === '\\' && !inSingleQuote) {
+      escaped = true;
+      continue;
+    }
+
+    if (char === "'" && !inDoubleQuote) {
+      inSingleQuote = !inSingleQuote;
+      continue;
+    }
+
+    if (char === '"' && !inSingleQuote) {
+      inDoubleQuote = !inDoubleQuote;
+      continue;
+    }
+
+    if (options.rejectShellSyntax && !inSingleQuote && !inDoubleQuote) {
+      if (char === '$' || char === '`' || /[|&;<>]/.test(char)) {
+        return { ok: false, reason: SHELL_SYNTAX_ERROR };
+      }
+    }
+
+    if (/\s/.test(char) && !inSingleQuote && !inDoubleQuote) {
+      if (current.length > 0) {
+        words.push(current);
+        current = '';
+      }
+      continue;
+    }
+
+    current += char;
+  }
+
+  if (escaped) current += '\\';
+  if (inSingleQuote || inDoubleQuote) return { ok: false, reason: 'Unclosed quote.' };
+  if (current.length > 0) words.push(current);
+
+  return { ok: true, words };
+}
+
+function parseArgField(value: string | undefined): string[] {
+  if (!value) return [];
+  const parsed = parseShellWords(value);
+  if (!parsed.ok) throw new Error(parsed.reason);
+  return parsed.words;
+}
+
+function parseCliPrefix(value: string | undefined, providerId: AgentProviderId): string[] {
+  const cli = value?.trim();
+  if (!cli) throw new Error(`Missing CLI command for provider: ${providerId}`);
+
+  const parsed = parseShellWords(cli, { rejectShellSyntax: true });
+  if (!parsed.ok) throw new Error(parsed.reason);
+  const [command] = parsed.words;
+  if (!command) throw new Error(`Missing CLI command for provider: ${providerId}`);
+  if (/^[A-Za-z_][A-Za-z0-9_]*=/.test(command)) throw new Error(SHELL_SYNTAX_ERROR);
+  if (SHELL_BUILTINS.has(command)) throw new Error(SHELL_SYNTAX_ERROR);
+
+  return parsed.words;
+}
+
+export function buildAgentCommand({
   providerId,
+  providerConfig,
   autoApprove,
   initialPrompt,
   sessionId,
   isResuming,
 }: {
   providerId: AgentProviderId;
+  providerConfig: ProviderCustomConfig | undefined;
   autoApprove?: boolean;
   initialPrompt?: string;
   sessionId: string;
   isResuming?: boolean;
-}) {
-  const providerConfig = await providerOverrideSettings.getItem(providerId);
+}): AgentCommand {
   const providerDef = getProvider(providerId);
-
-  const cli = providerConfig?.cli;
-  const args: string[] = [];
+  const [command, ...args] = parseCliPrefix(providerConfig?.cli, providerId);
 
   if (isResuming && providerConfig?.resumeFlag) {
-    args.push(...providerConfig.resumeFlag.split(' '));
-    if (providerConfig?.sessionIdFlag) {
+    args.push(...parseArgField(providerConfig.resumeFlag));
+    if (providerConfig.sessionIdFlag) {
       args.push(sessionId);
     }
   } else if (providerConfig?.sessionIdFlag) {
@@ -30,19 +119,15 @@ export async function buildAgentCommand({
   }
 
   if (autoApprove && providerConfig?.autoApproveFlag) {
-    args.push(providerConfig.autoApproveFlag);
+    args.push(...parseArgField(providerConfig.autoApproveFlag));
   }
 
   if (!isResuming && initialPrompt && !providerDef?.useKeystrokeInjection) {
-    const flag = providerConfig?.initialPromptFlag;
-    if (flag) {
-      args.push(flag, initialPrompt);
-    } else {
-      args.push(initialPrompt);
-    }
+    args.push(...parseArgField(providerConfig?.initialPromptFlag), initialPrompt);
   }
 
   args.push(...(providerConfig?.defaultArgs ?? []));
+  args.push(...parseArgField(providerConfig?.extraArgs));
 
-  return { command: cli!, args };
+  return { command, args };
 }

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -23,6 +23,7 @@ import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import { buildAgentCommand } from './agent-command';
+import { resolveProviderEnv } from './provider-env';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -99,6 +100,7 @@ export class LocalConversationProvider implements ConversationProvider {
       isResuming,
       initialPrompt,
     });
+    const providerEnv = resolveProviderEnv(providerConfig);
 
     const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;
 
@@ -130,6 +132,7 @@ export class LocalConversationProvider implements ConversationProvider {
       env: {
         ...buildAgentEnv({
           hook: port > 0 ? { port, ptyId, token } : undefined,
+          providerVars: providerEnv,
         }),
         ...this.taskEnvVars,
       },

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -17,6 +17,7 @@ import { buildAgentEnv } from '@main/core/pty/pty-env';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/pty-spawn-platform';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import { appSettingsService } from '@main/core/settings/settings-service';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
@@ -89,8 +90,10 @@ export class LocalConversationProvider implements ConversationProvider {
     });
     await this.prepareHookConfig(conversation.providerId);
 
-    const { command, args } = await buildAgentCommand({
+    const providerConfig = await providerOverrideSettings.getItem(conversation.providerId);
+    const { command, args } = buildAgentCommand({
       providerId: conversation.providerId,
+      providerConfig,
       autoApprove: conversation.autoApprove,
       sessionId: conversation.id,
       isResuming,

--- a/src/main/core/conversations/impl/provider-env.test.ts
+++ b/src/main/core/conversations/impl/provider-env.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { resolveProviderEnv } from './provider-env';
+
+describe('resolveProviderEnv', () => {
+  it('returns valid provider environment variables', () => {
+    expect(
+      resolveProviderEnv({
+        env: {
+          ANTHROPIC_BASE_URL: 'https://example.test',
+          _TOKEN: 'secret',
+          'INVALID-NAME': 'ignored',
+          '1TOKEN': 'ignored',
+        },
+      })
+    ).toEqual({
+      ANTHROPIC_BASE_URL: 'https://example.test',
+      _TOKEN: 'secret',
+    });
+  });
+
+  it('returns undefined when no valid provider environment variables exist', () => {
+    expect(resolveProviderEnv(undefined)).toBeUndefined();
+    expect(resolveProviderEnv({ env: { 'INVALID-NAME': 'ignored' } })).toBeUndefined();
+  });
+});

--- a/src/main/core/conversations/impl/provider-env.ts
+++ b/src/main/core/conversations/impl/provider-env.ts
@@ -1,0 +1,16 @@
+import type { ProviderCustomConfig } from '@shared/app-settings';
+
+const ENV_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/;
+
+export function resolveProviderEnv(
+  providerConfig: ProviderCustomConfig | undefined
+): Record<string, string> | undefined {
+  if (!providerConfig?.env) return undefined;
+
+  const env: Record<string, string> = {};
+  for (const [key, value] of Object.entries(providerConfig.env)) {
+    if (ENV_NAME_PATTERN.test(key)) env[key] = value;
+  }
+
+  return Object.keys(env).length > 0 ? env : undefined;
+}

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -18,6 +18,7 @@ import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import { buildAgentCommand } from './agent-command';
+import { resolveProviderEnv } from './provider-env';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -96,6 +97,7 @@ export class SshConversationProvider implements ConversationProvider {
       isResuming,
       initialPrompt,
     });
+    const providerEnv = resolveProviderEnv(providerConfig);
 
     const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;
 
@@ -112,7 +114,7 @@ export class SshConversationProvider implements ConversationProvider {
       resume: isResuming,
     };
 
-    const sshCommand = resolveSshCommand('agent', cfg, this.taskEnvVars);
+    const sshCommand = resolveSshCommand('agent', cfg, { ...providerEnv, ...this.taskEnvVars });
 
     const result = await openSsh2Pty(this.proxy.client, {
       id: sessionId,

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -1,5 +1,5 @@
 import type { AgentSessionConfig } from '@shared/agent-session';
-import { type Conversation } from '@shared/conversations';
+import type { Conversation } from '@shared/conversations';
 import { agentSessionExitedChannel } from '@shared/events/agentEvents';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { wireAgentClassifier } from '@main/core/agent-hooks/classifier-wiring';
@@ -7,11 +7,12 @@ import { claudeTrustService } from '@main/core/agent-hooks/claude-trust-service'
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
-import { type Pty } from '@main/core/pty/pty';
+import type { Pty } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import type { SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
@@ -86,8 +87,10 @@ export class SshConversationProvider implements ConversationProvider {
       remoteFs: new SshFileSystem(this.proxy, '/'),
     });
 
-    const { command, args } = await buildAgentCommand({
+    const providerConfig = await providerOverrideSettings.getItem(conversation.providerId);
+    const { command, args } = buildAgentCommand({
       providerId: conversation.providerId,
+      providerConfig,
       autoApprove: conversation.autoApprove,
       sessionId: conversation.id,
       isResuming,

--- a/src/main/core/pty/pty-env.test.ts
+++ b/src/main/core/pty/pty-env.test.ts
@@ -57,4 +57,23 @@ describe('pty env Windows shell handling', () => {
 
     expect(env.SHELL).toBe('/bin/bash');
   });
+
+  it('adds provider vars while keeping hook variables authoritative', async () => {
+    const { buildAgentEnv } = await loadPtyEnv();
+    const env = buildAgentEnv({
+      agentApiVars: false,
+      hook: { port: 1234, ptyId: 'claude:conv-1', token: 'real-token' },
+      providerVars: {
+        ANTHROPIC_BASE_URL: 'https://example.test',
+        EMDASH_HOOK_PORT: '9999',
+        EMDASH_PTY_ID: 'wrong',
+        EMDASH_HOOK_TOKEN: 'wrong-token',
+      },
+    });
+
+    expect(env.ANTHROPIC_BASE_URL).toBe('https://example.test');
+    expect(env.EMDASH_HOOK_PORT).toBe('1234');
+    expect(env.EMDASH_PTY_ID).toBe('claude:conv-1');
+    expect(env.EMDASH_HOOK_TOKEN).toBe('real-token');
+  });
 });

--- a/src/main/core/pty/pty-env.ts
+++ b/src/main/core/pty/pty-env.ts
@@ -116,10 +116,9 @@ export interface AgentEnvOptions {
   };
 
   /**
-   * Per-provider custom env vars configured by the user.
-   * Keys are validated against ^[A-Za-z_][A-Za-z0-9_]*$.
+   * Per-provider variables configured in custom execution settings.
    */
-  customVars?: Record<string, string>;
+  providerVars?: Record<string, string>;
 }
 
 /**
@@ -175,7 +174,7 @@ export function buildTerminalEnv(): Record<string, string> {
  * find its own dependencies.
  */
 export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, string> {
-  const { agentApiVars = true, includeShellVar = false, hook, customVars } = options;
+  const { agentApiVars = true, includeShellVar = false, hook, providerVars } = options;
 
   // process.env.PATH is enriched at startup by resolveUserEnv() so it already
   // contains the full login-shell PATH (Homebrew, nvm, npm globals, etc.).
@@ -212,18 +211,14 @@ export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, str
     }
   }
 
+  if (providerVars) {
+    Object.assign(env, providerVars);
+  }
+
   if (hook && hook.port > 0) {
     env.EMDASH_HOOK_PORT = String(hook.port);
     env.EMDASH_PTY_ID = hook.ptyId;
     env.EMDASH_HOOK_TOKEN = hook.token;
-  }
-
-  if (customVars) {
-    for (const [key, val] of Object.entries(customVars)) {
-      if (typeof val === 'string' && /^[A-Za-z_][A-Za-z0-9_]*$/.test(key)) {
-        env[key] = val;
-      }
-    }
   }
 
   return env;

--- a/src/main/core/pty/spawn-utils.test.ts
+++ b/src/main/core/pty/spawn-utils.test.ts
@@ -20,7 +20,9 @@ describe('resolveSshCommand', () => {
   it('runs remote commands through a login shell so PATH matches install/probe', () => {
     const result = resolveSshCommand('agent', makeAgentConfig());
 
-    expect(result).toBe(`bash -l -c 'cd "/workspace" && claude --resume conv-1'`);
+    expect(result).toBe(
+      `bash -l -c 'cd "/workspace" && '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
+    );
   });
 
   it('adds SSH env exports before the remote command', () => {
@@ -29,7 +31,21 @@ describe('resolveSshCommand', () => {
     });
 
     expect(result).toBe(
-      `bash -l -c 'cd "/workspace" && export FOO='\\''bar'\\''; claude --resume conv-1'`
+      `bash -l -c 'cd "/workspace" && export FOO='\\''bar'\\''; '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
+    );
+  });
+
+  it('quotes remote agent argv tokens independently', () => {
+    const result = resolveSshCommand(
+      'agent',
+      makeAgentConfig({
+        command: 'caffeinate',
+        args: ['-i', 'direnv', 'exec', '.', '/opt/Claude Code/bin/claude', 'Fix the bug'],
+      })
+    );
+
+    expect(result).toBe(
+      `bash -l -c 'cd "/workspace" && '\\''caffeinate'\\'' '\\''-i'\\'' '\\''direnv'\\'' '\\''exec'\\'' '\\''.'\\'' '\\''/opt/Claude Code/bin/claude'\\'' '\\''Fix the bug'\\'''`
     );
   });
 
@@ -44,6 +60,6 @@ describe('resolveSshCommand', () => {
     expect(result).toContain('tmux has-session -t "agent-session"');
     expect(result).toContain('tmux new-session -d -s "agent-session"');
     expect(result).toContain('tmux attach-session -t "agent-session"');
-    expect(result).toContain('claude --resume conv-1');
+    expect(result).toContain("'\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\''");
   });
 });

--- a/src/main/core/pty/spawn-utils.ts
+++ b/src/main/core/pty/spawn-utils.ts
@@ -15,7 +15,7 @@ function posixShellLineForSsh(
   switch (type) {
     case 'agent': {
       const cfg = config as AgentSessionConfig;
-      const baseCmd = [cfg.command, ...cfg.args].join(' ');
+      const baseCmd = [cfg.command, ...cfg.args].map(quoteShellArg).join(' ');
       const line = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
       return {
         cwd: cfg.cwd,


### PR DESCRIPTION
issue:
- custom CLI commands + env vars regressed in v1 and were treated as a single executable causing "command not found"

fix
- restored support by parsing the configured CLI command into executable + argv tokens
- restored provider custom env support with a separate resolveProviderEnv helper
- wired provider env into local and SSH agent launch