### PR TITLE
fix(git): resolve git executable per execution context

### DIFF
--- a/src/main/core/execution-context/local-execution-context.test.ts
+++ b/src/main/core/execution-context/local-execution-context.test.ts
@@ -3,9 +3,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { GIT_EXECUTABLE } from '@main/core/utils/exec';
 
 const spawnMock = vi.hoisted(() => vi.fn());
+const execFileMock = vi.hoisted(() => vi.fn());
 
 vi.mock('node:child_process', () => ({
-  execFile: vi.fn(),
+  execFile: execFileMock,
   spawn: spawnMock,
 }));
 
@@ -19,7 +20,24 @@ class FakeChildProcess extends EventEmitter {
 
 describe('LocalExecutionContext', () => {
   beforeEach(() => {
+    execFileMock.mockReset();
     spawnMock.mockReset();
+  });
+
+  it('resolves logical git command for buffered local execution', async () => {
+    execFileMock.mockImplementation((_command, _args, _options, callback) => {
+      callback(null, { stdout: '', stderr: '' });
+    });
+    const ctx = new LocalExecutionContext({ root: '/repo' });
+
+    await ctx.exec('git', ['status']);
+
+    expect(execFileMock).toHaveBeenCalledWith(
+      GIT_EXECUTABLE,
+      ['status'],
+      expect.objectContaining({ cwd: '/repo' }),
+      expect.any(Function)
+    );
   });
 
   it('resolves logical git command for streaming local execution', async () => {

--- a/src/main/core/execution-context/local-execution-context.test.ts
+++ b/src/main/core/execution-context/local-execution-context.test.ts
@@ -1,0 +1,36 @@
+import { EventEmitter } from 'node:events';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { GIT_EXECUTABLE } from '@main/core/utils/exec';
+
+const spawnMock = vi.hoisted(() => vi.fn());
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  spawn: spawnMock,
+}));
+
+const { LocalExecutionContext } = await import('./local-execution-context');
+
+class FakeChildProcess extends EventEmitter {
+  stdout = Object.assign(new EventEmitter(), { setEncoding: vi.fn() });
+
+  kill = vi.fn();
+}
+
+describe('LocalExecutionContext', () => {
+  beforeEach(() => {
+    spawnMock.mockReset();
+  });
+
+  it('resolves logical git command for streaming local execution', async () => {
+    const child = new FakeChildProcess();
+    spawnMock.mockReturnValue(child);
+    const ctx = new LocalExecutionContext({ root: '/repo' });
+
+    const promise = ctx.execStreaming('git', ['status'], () => true);
+    child.emit('close', 0);
+    await promise;
+
+    expect(spawnMock).toHaveBeenCalledWith(GIT_EXECUTABLE, ['status'], { cwd: '/repo' });
+  });
+});

--- a/src/main/core/execution-context/local-execution-context.ts
+++ b/src/main/core/execution-context/local-execution-context.ts
@@ -1,5 +1,6 @@
 import { execFile, spawn } from 'node:child_process';
 import { promisify } from 'node:util';
+import { GIT_EXECUTABLE } from '@main/core/utils/exec';
 import type { ExecOptions, ExecResult, IExecutionContext } from './types';
 
 const execFileAsync = promisify(execFile);
@@ -20,9 +21,13 @@ export class LocalExecutionContext implements IExecutionContext {
     return AbortSignal.any(signals);
   }
 
+  private resolveCommand(command: string): string {
+    return command === 'git' ? GIT_EXECUTABLE : command;
+  }
+
   exec(command: string, args: string[] = [], opts: ExecOptions = {}): Promise<ExecResult> {
     const { timeout, maxBuffer } = opts;
-    return execFileAsync(command, args, {
+    return execFileAsync(this.resolveCommand(command), args, {
       cwd: this.root || undefined,
       timeout,
       maxBuffer,
@@ -44,7 +49,7 @@ export class LocalExecutionContext implements IExecutionContext {
         return;
       }
 
-      const child = spawn(command, args, { cwd: this.root || undefined });
+      const child = spawn(this.resolveCommand(command), args, { cwd: this.root || undefined });
 
       let settled = false;
 

--- a/src/main/core/git/impl/git-repo-utils.test.ts
+++ b/src/main/core/git/impl/git-repo-utils.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import { cloneRepository } from './git-repo-utils';
+
+function makeContext(): IExecutionContext & {
+  exec: ReturnType<typeof vi.fn>;
+} {
+  return {
+    root: '/repo-parent',
+    supportsLocalSpawn: false,
+    exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+    execStreaming: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as IExecutionContext & { exec: ReturnType<typeof vi.fn> };
+}
+
+describe('cloneRepository', () => {
+  it('passes logical git command to the execution context', async () => {
+    const ctx = makeContext();
+
+    await cloneRepository('https://github.com/example/repo.git', '/work/repo', ctx);
+
+    expect(ctx.exec).toHaveBeenCalledWith('git', [
+      'clone',
+      'https://github.com/example/repo.git',
+      '/work/repo',
+    ]);
+  });
+});

--- a/src/main/core/git/impl/git-repo-utils.ts
+++ b/src/main/core/git/impl/git-repo-utils.ts
@@ -9,7 +9,6 @@
 
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { FileSystemProvider } from '@main/core/fs/types';
-import { GIT_EXECUTABLE } from '@main/core/utils/exec';
 
 // ---------------------------------------------------------------------------
 // cloneRepository
@@ -26,7 +25,7 @@ export async function cloneRepository(
   ctx: IExecutionContext
 ): Promise<{ success: boolean; error?: string }> {
   try {
-    await ctx.exec(GIT_EXECUTABLE, ['clone', repoUrl, localPath]);
+    await ctx.exec('git', ['clone', repoUrl, localPath]);
     return { success: true };
   } catch (error) {
     return {
@@ -72,14 +71,14 @@ export async function initializeNewProject(
   const readmeContent = description ? `# ${name}\n\n${description}\n` : `# ${name}\n`;
   await fs.write('README.md', readmeContent);
 
-  await ctx.exec(GIT_EXECUTABLE, ['add', 'README.md']);
-  await ctx.exec(GIT_EXECUTABLE, ['commit', '-m', 'Initial commit']);
+  await ctx.exec('git', ['add', 'README.md']);
+  await ctx.exec('git', ['commit', '-m', 'Initial commit']);
 
   try {
-    await ctx.exec(GIT_EXECUTABLE, ['push', '-u', 'origin', 'main']);
+    await ctx.exec('git', ['push', '-u', 'origin', 'main']);
   } catch {
     try {
-      await ctx.exec(GIT_EXECUTABLE, ['push', '-u', 'origin', 'master']);
+      await ctx.exec('git', ['push', '-u', 'origin', 'master']);
     } catch {
       throw new Error('Failed to push to remote repository');
     }

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -32,7 +32,6 @@ import { parseGitHubRepository } from '@shared/github-repository';
 import { err, ok, type Result } from '@shared/result';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { FileSystemProvider } from '@main/core/fs/types';
-import { GIT_EXECUTABLE } from '@main/core/utils/exec';
 import type { IDisposable } from '@main/lib/lifecycle';
 import { type GitProvider } from '../types';
 import { CatFileBatch } from './cat-file-batch';
@@ -103,10 +102,10 @@ export class GitService implements GitProvider, IDisposable {
       const parser = new StatusParser();
       const [, stagedRes, unstagedRes, currentBranch] = await Promise.all([
         this._runStatusZ(parser),
-        this.ctx.exec(GIT_EXECUTABLE, ['diff', '--numstat', '--cached']).catch(() => ({
+        this.ctx.exec('git', ['diff', '--numstat', '--cached']).catch(() => ({
           stdout: '',
         })),
-        this.ctx.exec(GIT_EXECUTABLE, ['diff', '--numstat']).catch(() => ({ stdout: '' })),
+        this.ctx.exec('git', ['diff', '--numstat']).catch(() => ({ stdout: '' })),
         this.getCurrentBranch(),
       ]);
 
@@ -137,7 +136,7 @@ export class GitService implements GitProvider, IDisposable {
 
   private async _runStatusZ(parser: StatusParser): Promise<void> {
     await this.ctx.execStreaming(
-      GIT_EXECUTABLE,
+      'git',
       ['--no-optional-locks', 'status', '-z', '-uall'],
       (chunk) => {
         parser.update(chunk);
@@ -264,24 +263,24 @@ export class GitService implements GitProvider, IDisposable {
 
   async stageFiles(filePaths: string[]): Promise<void> {
     if (filePaths.length === 0) return;
-    await this.ctx.exec(GIT_EXECUTABLE, ['add', '--', ...filePaths]);
+    await this.ctx.exec('git', ['add', '--', ...filePaths]);
   }
 
   async stageAllFiles(): Promise<void> {
-    await this.ctx.exec(GIT_EXECUTABLE, ['add', '-A']);
+    await this.ctx.exec('git', ['add', '-A']);
   }
 
   async unstageFiles(filePaths: string[]): Promise<void> {
     if (filePaths.length === 0) return;
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['reset', 'HEAD', '--', ...filePaths]);
+      await this.ctx.exec('git', ['reset', 'HEAD', '--', ...filePaths]);
     } catch {
       // Fallback for edge cases (e.g. new files with no HEAD): unstage each via rm --cached
       for (const filePath of filePaths) {
         try {
-          await this.ctx.exec(GIT_EXECUTABLE, ['reset', 'HEAD', '--', filePath]);
+          await this.ctx.exec('git', ['reset', 'HEAD', '--', filePath]);
         } catch {
-          await this.ctx.exec(GIT_EXECUTABLE, ['rm', '--cached', '--', filePath]);
+          await this.ctx.exec('git', ['rm', '--cached', '--', filePath]);
         }
       }
     }
@@ -289,7 +288,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async unstageAllFiles(): Promise<void> {
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['reset', 'HEAD']);
+      await this.ctx.exec('git', ['reset', 'HEAD']);
     } catch {
       // Repo may have no commits yet; ignore.
     }
@@ -301,7 +300,7 @@ export class GitService implements GitProvider, IDisposable {
     // Determine which files exist in HEAD in a single command
     let trackedPaths = new Set<string>();
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+      const { stdout } = await this.ctx.exec('git', [
         'ls-tree',
         '--name-only',
         'HEAD',
@@ -317,7 +316,7 @@ export class GitService implements GitProvider, IDisposable {
     const untracked = filePaths.filter((f) => !trackedPaths.has(f));
 
     if (tracked.length > 0) {
-      await this.ctx.exec(GIT_EXECUTABLE, ['checkout', 'HEAD', '--', ...tracked]);
+      await this.ctx.exec('git', ['checkout', 'HEAD', '--', ...tracked]);
     }
 
     // Untracked files don't exist in git history — remove them from disk
@@ -333,11 +332,11 @@ export class GitService implements GitProvider, IDisposable {
     // Reset index and working tree for all tracked changes back to HEAD,
     // then remove any untracked files/directories.
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['reset', '--hard', 'HEAD']);
+      await this.ctx.exec('git', ['reset', '--hard', 'HEAD']);
     } catch {
       // Repo may have no commits yet; ignore.
     }
-    await this.ctx.exec(GIT_EXECUTABLE, ['clean', '-fd']);
+    await this.ctx.exec('git', ['clean', '-fd']);
   }
 
   // ---------------------------------------------------------------------------
@@ -358,7 +357,7 @@ export class GitService implements GitProvider, IDisposable {
       }
     }
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['show', `${ref}:${filePath}`], {
+      const { stdout } = await this.ctx.exec('git', ['show', `${ref}:${filePath}`], {
         maxBuffer: MAX_DIFF_CONTENT_BYTES,
       });
       return stripTrailingNewline(stdout);
@@ -377,7 +376,7 @@ export class GitService implements GitProvider, IDisposable {
       }
     }
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['show', `:0:${filePath}`], {
+      const { stdout } = await this.ctx.exec('git', ['show', `:0:${filePath}`], {
         maxBuffer: MAX_DIFF_CONTENT_BYTES,
       });
       return stripTrailingNewline(stdout);
@@ -412,7 +411,7 @@ export class GitService implements GitProvider, IDisposable {
 
     let diffStdout: string | undefined;
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, diffArgs, {
+      const { stdout } = await this.ctx.exec('git', diffArgs, {
         maxBuffer: MAX_DIFF_OUTPUT_BYTES,
       });
       diffStdout = stdout;
@@ -422,13 +421,9 @@ export class GitService implements GitProvider, IDisposable {
 
     const getOriginalContent = async (): Promise<string | undefined> => {
       try {
-        const { stdout } = await this.ctx.exec(
-          GIT_EXECUTABLE,
-          ['show', `${originalRef}:${filePath}`],
-          {
-            maxBuffer: MAX_DIFF_CONTENT_BYTES,
-          }
-        );
+        const { stdout } = await this.ctx.exec('git', ['show', `${originalRef}:${filePath}`], {
+          maxBuffer: MAX_DIFF_CONTENT_BYTES,
+        });
         return stripTrailingNewline(stdout);
       } catch {
         return undefined;
@@ -438,7 +433,7 @@ export class GitService implements GitProvider, IDisposable {
     const getModifiedContent = async (): Promise<string | undefined> => {
       if (isObjectRef) {
         try {
-          const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['show', `HEAD:${filePath}`], {
+          const { stdout } = await this.ctx.exec('git', ['show', `HEAD:${filePath}`], {
             maxBuffer: MAX_DIFF_CONTENT_BYTES,
           });
           return stripTrailingNewline(stdout);
@@ -506,7 +501,7 @@ export class GitService implements GitProvider, IDisposable {
   async getCommitFileDiff(commitHash: string, filePath: string): Promise<DiffResult> {
     const getContentAt = async (ref: string): Promise<string | undefined> => {
       try {
-        const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['show', `${ref}:${filePath}`], {
+        const { stdout } = await this.ctx.exec('git', ['show', `${ref}:${filePath}`], {
           maxBuffer: MAX_DIFF_CONTENT_BYTES,
         });
         return stripTrailingNewline(stdout);
@@ -517,7 +512,7 @@ export class GitService implements GitProvider, IDisposable {
 
     let hasParent = true;
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', `${commitHash}~1`]);
+      await this.ctx.exec('git', ['rev-parse', '--verify', `${commitHash}~1`]);
     } catch {
       hasParent = false;
     }
@@ -605,7 +600,7 @@ export class GitService implements GitProvider, IDisposable {
       if (base !== undefined) {
         // PR-relative count: compare explicitly against the PR base ref.
         try {
-          const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+          const { stdout } = await this.ctx.exec('git', [
             'rev-list',
             '--count',
             `${toRefString(base)}..${headStr}`,
@@ -616,7 +611,7 @@ export class GitService implements GitProvider, IDisposable {
         }
       } else {
         try {
-          const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+          const { stdout } = await this.ctx.exec('git', [
             'rev-list',
             '--count',
             '@{upstream}..HEAD',
@@ -624,13 +619,13 @@ export class GitService implements GitProvider, IDisposable {
           aheadCount = Number.parseInt(stdout.trim(), 10) || 0;
         } catch {
           try {
-            const { stdout: branchOut } = await this.ctx.exec(GIT_EXECUTABLE, [
+            const { stdout: branchOut } = await this.ctx.exec('git', [
               'rev-parse',
               '--abbrev-ref',
               'HEAD',
             ]);
             const currentBranch = branchOut.trim();
-            const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+            const { stdout } = await this.ctx.exec('git', [
               'rev-list',
               '--count',
               `${remote}/${currentBranch}..HEAD`,
@@ -638,13 +633,13 @@ export class GitService implements GitProvider, IDisposable {
             aheadCount = Number.parseInt(stdout.trim(), 10) || 0;
           } catch {
             try {
-              const { stdout: defaultBranchOut } = await this.ctx.exec(GIT_EXECUTABLE, [
+              const { stdout: defaultBranchOut } = await this.ctx.exec('git', [
                 'symbolic-ref',
                 '--short',
                 `refs/remotes/${remote}/HEAD`,
               ]);
               const defaultBranch = defaultBranchOut.trim();
-              const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+              const { stdout } = await this.ctx.exec('git', [
                 'rev-list',
                 '--count',
                 `${defaultBranch}..HEAD`,
@@ -664,7 +659,7 @@ export class GitService implements GitProvider, IDisposable {
     // When base is provided (PR view), use a range so only commits between
     // base and head are returned — not a raw linear walk from head.
     const rangeArg = base ? `${toRefString(base)}..${headStr}` : headStr;
-    const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+    const { stdout } = await this.ctx.exec('git', [
       'log',
       `--max-count=${maxCount}`,
       `--skip=${skip}`,
@@ -739,8 +734,8 @@ export class GitService implements GitProvider, IDisposable {
       : ['diff', '--name-status', ref];
 
     const [numstatResult, nameStatusResult] = await Promise.all([
-      this.ctx.exec(GIT_EXECUTABLE, diffArgs).catch(() => ({ stdout: '' })),
-      this.ctx.exec(GIT_EXECUTABLE, nameArgs).catch(() => ({ stdout: '' })),
+      this.ctx.exec('git', diffArgs).catch(() => ({ stdout: '' })),
+      this.ctx.exec('git', nameArgs).catch(() => ({ stdout: '' })),
     ]);
 
     const numstatMap = parseNumstat(numstatResult.stdout);
@@ -765,7 +760,7 @@ export class GitService implements GitProvider, IDisposable {
   }
 
   async getCommitFiles(commitHash: string): Promise<CommitFile[]> {
-    const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+    const { stdout } = await this.ctx.exec('git', [
       'diff-tree',
       '--root',
       '--no-commit-id',
@@ -776,7 +771,7 @@ export class GitService implements GitProvider, IDisposable {
       commitHash,
     ]);
 
-    const { stdout: nameStatus } = await this.ctx.exec(GIT_EXECUTABLE, [
+    const { stdout: nameStatus } = await this.ctx.exec('git', [
       'diff-tree',
       '--root',
       '--no-commit-id',
@@ -816,7 +811,7 @@ export class GitService implements GitProvider, IDisposable {
   async commit(message: string): Promise<Result<{ hash: string }, CommitError>> {
     if (!message || !message.trim()) return err({ type: 'empty_message' });
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['commit', '-m', message]);
+      await this.ctx.exec('git', ['commit', '-m', message]);
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || '';
       const stdout = (error as { stdout?: string })?.stdout || '';
@@ -827,7 +822,7 @@ export class GitService implements GitProvider, IDisposable {
       return err({ type: 'hook_failed', message: output });
     }
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', 'HEAD']);
+      const { stdout } = await this.ctx.exec('git', ['rev-parse', 'HEAD']);
       return ok({ hash: stdout.trim() });
     } catch (error: unknown) {
       return err({ type: 'error', message: String(error) });
@@ -836,7 +831,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async fetch(remote?: string): Promise<Result<void, FetchError>> {
     try {
-      const remotes = await this.ctx.exec(GIT_EXECUTABLE, ['remote']).catch(() => ({
+      const remotes = await this.ctx.exec('git', ['remote']).catch(() => ({
         stdout: '',
       }));
       const remoteNames = remotes.stdout
@@ -850,11 +845,9 @@ export class GitService implements GitProvider, IDisposable {
         return err({ type: 'remote_not_found', message: `Remote "${selectedRemote}" not found` });
       }
 
-      await this.authCtx.exec(
-        GIT_EXECUTABLE,
-        selectedRemote ? ['fetch', selectedRemote] : ['fetch'],
-        { maxBuffer: MAX_REF_LIST_BYTES }
-      );
+      await this.authCtx.exec('git', selectedRemote ? ['fetch', selectedRemote] : ['fetch'], {
+        maxBuffer: MAX_REF_LIST_BYTES,
+      });
       return ok();
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
@@ -891,7 +884,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async push(preferredRemote?: string): Promise<Result<{ output: string }, PushError>> {
     const doPush = async (args: string[]): Promise<string> => {
-      const { stdout, stderr } = await this.authCtx.exec(GIT_EXECUTABLE, args);
+      const { stdout, stderr } = await this.authCtx.exec('git', args);
       return (stdout || stderr || '').trim();
     };
 
@@ -912,14 +905,11 @@ export class GitService implements GitProvider, IDisposable {
         stderr.includes('upstream branch of your current branch does not match')
       ) {
         try {
-          const { stdout: branchOut } = await this.ctx.exec(GIT_EXECUTABLE, [
-            'branch',
-            '--show-current',
-          ]);
+          const { stdout: branchOut } = await this.ctx.exec('git', ['branch', '--show-current']);
           const currentBranch = branchOut.trim();
           let pushRemote = preferredRemote?.trim() || DEFAULT_REMOTE_NAME;
           try {
-            const { stdout: remoteOut } = await this.ctx.exec(GIT_EXECUTABLE, [
+            const { stdout: remoteOut } = await this.ctx.exec('git', [
               'config',
               '--get',
               `branch.${currentBranch}.remote`,
@@ -979,7 +969,7 @@ export class GitService implements GitProvider, IDisposable {
     remote = 'origin'
   ): Promise<Result<{ output: string }, PushError>> {
     const doPush = async (args: string[]): Promise<string> => {
-      const { stdout, stderr } = await this.authCtx.exec(GIT_EXECUTABLE, args);
+      const { stdout, stderr } = await this.authCtx.exec('git', args);
       return (stdout || stderr || '').trim();
     };
 
@@ -1000,7 +990,7 @@ export class GitService implements GitProvider, IDisposable {
         stderr.includes('non-fast-forward')
       ) {
         try {
-          await this.ctx.exec(GIT_EXECUTABLE, [
+          await this.ctx.exec('git', [
             'branch',
             `--set-upstream-to=${remote}/${branchName}`,
             branchName,
@@ -1047,7 +1037,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async pull(): Promise<Result<{ output: string }, PullError>> {
     try {
-      const { stdout } = await this.authCtx.exec(GIT_EXECUTABLE, ['pull']);
+      const { stdout } = await this.authCtx.exec('git', ['pull']);
       return ok({ output: stdout.trim() });
     } catch (error: unknown) {
       const stdout = (error as { stdout?: string })?.stdout || '';
@@ -1057,7 +1047,7 @@ export class GitService implements GitProvider, IDisposable {
       if (stdout.includes('CONFLICT') || stderr.includes('CONFLICT')) {
         let conflictedFiles: string[] = [];
         try {
-          const { stdout: conflictOut } = await this.ctx.exec(GIT_EXECUTABLE, [
+          const { stdout: conflictOut } = await this.ctx.exec('git', [
             'diff',
             '--name-only',
             '--diff-filter=U',
@@ -1113,7 +1103,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async softReset(): Promise<Result<{ subject: string; body: string }, SoftResetError>> {
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', 'HEAD~1']);
+      await this.ctx.exec('git', ['rev-parse', '--verify', 'HEAD~1']);
     } catch {
       return err({ type: 'initial_commit' });
     }
@@ -1124,18 +1114,10 @@ export class GitService implements GitProvider, IDisposable {
     }
 
     try {
-      const { stdout: subject } = await this.ctx.exec(GIT_EXECUTABLE, [
-        'log',
-        '-1',
-        '--pretty=format:%s',
-      ]);
-      const { stdout: body } = await this.ctx.exec(GIT_EXECUTABLE, [
-        'log',
-        '-1',
-        '--pretty=format:%b',
-      ]);
+      const { stdout: subject } = await this.ctx.exec('git', ['log', '-1', '--pretty=format:%s']);
+      const { stdout: body } = await this.ctx.exec('git', ['log', '-1', '--pretty=format:%b']);
 
-      await this.ctx.exec(GIT_EXECUTABLE, ['reset', '--soft', 'HEAD~1']);
+      await this.ctx.exec('git', ['reset', '--soft', 'HEAD~1']);
 
       return ok({ subject: subject.trim(), body: body.trim() });
     } catch (error: unknown) {
@@ -1145,11 +1127,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async getCurrentBranch(): Promise<string | null> {
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
-        'rev-parse',
-        '--symbolic-full-name',
-        'HEAD',
-      ]);
+      const { stdout } = await this.ctx.exec('git', ['rev-parse', '--symbolic-full-name', 'HEAD']);
       const ref = stdout.trim();
       if (ref === 'HEAD' || !ref) return null;
       if (ref.startsWith('refs/heads/')) return ref.slice('refs/heads/'.length);
@@ -1162,7 +1140,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async getWorktreeGitDir(mainDotGitAbs: string): Promise<string> {
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--git-dir']);
+      const { stdout } = await this.ctx.exec('git', ['rev-parse', '--git-dir']);
       const raw = stdout.trim();
       const root = this.ctx.root ?? '';
       const gitDirAbs = path.isAbsolute(raw) ? raw : path.resolve(root, raw);
@@ -1177,7 +1155,7 @@ export class GitService implements GitProvider, IDisposable {
     const remotes = await this.getRemotes();
     const remoteByName = new Map(remotes.map((remote) => [remote.name, remote]));
     const { stdout } = await this.ctx.exec(
-      GIT_EXECUTABLE,
+      'git',
       ['branch', '-a', '--format=%(refname:short)|%(upstream:short)|%(upstream:track)|%(refname)'],
       { maxBuffer: MAX_REF_LIST_BYTES }
     );
@@ -1228,7 +1206,7 @@ export class GitService implements GitProvider, IDisposable {
     // Heuristic 1: ask the remote what its HEAD points to (fast, no network call needed
     // because git caches this in refs/remotes/<remote>/HEAD after a fetch/clone).
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+      const { stdout } = await this.ctx.exec('git', [
         'symbolic-ref',
         `refs/remotes/${remote}/HEAD`,
         '--short',
@@ -1242,7 +1220,7 @@ export class GitService implements GitProvider, IDisposable {
 
     // Heuristic 2: ask the remote directly (requires a network call).
     try {
-      const { stdout } = await this.authCtx.exec(GIT_EXECUTABLE, ['remote', 'show', remote]);
+      const { stdout } = await this.authCtx.exec('git', ['remote', 'show', remote]);
       const match = /HEAD branch:\s*(\S+)/.exec(stdout);
       if (match?.[1]) return match[1];
     } catch {}
@@ -1258,7 +1236,7 @@ export class GitService implements GitProvider, IDisposable {
 
   private async _branchExistsLocally(branch: string): Promise<boolean> {
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', `refs/heads/${branch}`]);
+      await this.ctx.exec('git', ['rev-parse', '--verify', `refs/heads/${branch}`]);
       return true;
     } catch {
       return false;
@@ -1267,7 +1245,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async getRemotes(): Promise<{ name: string; url: string }[]> {
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['remote', '-v']);
+      const { stdout } = await this.ctx.exec('git', ['remote', '-v']);
       const seen = new Set<string>();
       const remotes: { name: string; url: string }[] = [];
       for (const line of stdout.split('\n')) {
@@ -1286,17 +1264,12 @@ export class GitService implements GitProvider, IDisposable {
   async getHeadState(): Promise<GitHeadState> {
     let headName: string | undefined;
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
-        'symbolic-ref',
-        '--quiet',
-        '--short',
-        'HEAD',
-      ]);
+      const { stdout } = await this.ctx.exec('git', ['symbolic-ref', '--quiet', '--short', 'HEAD']);
       headName = stdout.trim() || undefined;
     } catch {}
 
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', 'HEAD']);
+      await this.ctx.exec('git', ['rev-parse', '--verify', 'HEAD']);
       return { headName, isUnborn: false };
     } catch {
       return { headName, isUnborn: true };
@@ -1304,7 +1277,7 @@ export class GitService implements GitProvider, IDisposable {
   }
 
   async addRemote(name: string, url: string): Promise<void> {
-    await this.ctx.exec(GIT_EXECUTABLE, ['remote', 'add', name, url]);
+    await this.ctx.exec('git', ['remote', 'add', name, url]);
   }
 
   async createBranch(
@@ -1315,14 +1288,14 @@ export class GitService implements GitProvider, IDisposable {
   ): Promise<Result<void, CreateBranchError>> {
     if (syncWithRemote) {
       await this.authCtx
-        .exec(GIT_EXECUTABLE, ['fetch', remote], {
+        .exec('git', ['fetch', remote], {
           maxBuffer: MAX_REF_LIST_BYTES,
         })
         .catch(() => {});
     }
     const base = syncWithRemote ? `${remote}/${from}` : `refs/heads/${from}`;
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['branch', '--no-track', name, base]);
+      await this.ctx.exec('git', ['branch', '--no-track', name, base]);
       return ok();
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
@@ -1359,21 +1332,19 @@ export class GitService implements GitProvider, IDisposable {
       if (isFork) {
         const forkRemote = parseGitHubRepository(headRepositoryUrl)?.owner ?? 'fork';
         // Idempotently ensure remote exists with the correct URL
-        const remotes = await this.ctx
-          .exec(GIT_EXECUTABLE, ['remote'])
-          .catch(() => ({ stdout: '' }));
+        const remotes = await this.ctx.exec('git', ['remote']).catch(() => ({ stdout: '' }));
         const names = remotes.stdout
           .split('\n')
           .map((s) => s.trim())
           .filter(Boolean);
         if (!names.includes(forkRemote)) {
-          await this.ctx.exec(GIT_EXECUTABLE, ['remote', 'add', forkRemote, headRepositoryUrl]);
+          await this.ctx.exec('git', ['remote', 'add', forkRemote, headRepositoryUrl]);
         } else {
           await this.ctx
-            .exec(GIT_EXECUTABLE, ['remote', 'set-url', forkRemote, headRepositoryUrl])
+            .exec('git', ['remote', 'set-url', forkRemote, headRepositoryUrl])
             .catch(() => {});
         }
-        await this.authCtx.exec(GIT_EXECUTABLE, [
+        await this.authCtx.exec('git', [
           'fetch',
           forkRemote,
           `${headRefName}:refs/heads/${localBranch}`,
@@ -1381,22 +1352,18 @@ export class GitService implements GitProvider, IDisposable {
         ]);
         // Set tracking so `git push` targets the contributor's fork branch
         await this.ctx
-          .exec(GIT_EXECUTABLE, [
-            'branch',
-            `--set-upstream-to=${forkRemote}/${headRefName}`,
-            localBranch,
-          ])
+          .exec('git', ['branch', `--set-upstream-to=${forkRemote}/${headRefName}`, localBranch])
           .catch(() => {});
       } else {
         // Same-repo: GitHub always exposes refs/pull/{N}/head on origin
-        await this.authCtx.exec(GIT_EXECUTABLE, [
+        await this.authCtx.exec('git', [
           'fetch',
           configuredRemote,
           `refs/pull/${prNumber}/head:refs/heads/${localBranch}`,
           '--force',
         ]);
         await this.ctx
-          .exec(GIT_EXECUTABLE, [
+          .exec('git', [
             'branch',
             `--set-upstream-to=${configuredRemote}/${headRefName}`,
             localBranch,
@@ -1423,7 +1390,7 @@ export class GitService implements GitProvider, IDisposable {
   ): Promise<Result<{ remotePushed: boolean }, RenameBranchError>> {
     let remoteName: string | undefined;
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, [
+      const { stdout } = await this.ctx.exec('git', [
         'config',
         '--get',
         `branch.${oldBranch}.remote`,
@@ -1432,7 +1399,7 @@ export class GitService implements GitProvider, IDisposable {
     } catch {}
 
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['branch', '-m', oldBranch, newBranch]);
+      await this.ctx.exec('git', ['branch', '-m', oldBranch, newBranch]);
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
       if (stderr.includes('already exists')) {
@@ -1443,10 +1410,10 @@ export class GitService implements GitProvider, IDisposable {
 
     if (remoteName) {
       try {
-        await this.authCtx.exec(GIT_EXECUTABLE, ['push', remoteName, '--delete', oldBranch]);
+        await this.authCtx.exec('git', ['push', remoteName, '--delete', oldBranch]);
       } catch {}
       try {
-        await this.authCtx.exec(GIT_EXECUTABLE, ['push', '-u', remoteName, newBranch]);
+        await this.authCtx.exec('git', ['push', '-u', remoteName, newBranch]);
       } catch (error: unknown) {
         const stderr = (error as { stderr?: string })?.stderr || String(error);
         return err({ type: 'remote_push_failed', message: stderr });
@@ -1459,7 +1426,7 @@ export class GitService implements GitProvider, IDisposable {
   async deleteBranch(branch: string, force = true): Promise<Result<void, DeleteBranchError>> {
     const flag = force ? '-D' : '-d';
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['branch', flag, branch]);
+      await this.ctx.exec('git', ['branch', flag, branch]);
       return ok();
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
@@ -1482,7 +1449,7 @@ export class GitService implements GitProvider, IDisposable {
 
   async detectInfo(): Promise<GitInfo> {
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--is-inside-work-tree']);
+      await this.ctx.exec('git', ['rev-parse', '--is-inside-work-tree']);
     } catch {
       return { isGitRepo: false, baseRef: 'main', rootPath: this.ctx.root ?? '' };
     }
@@ -1490,27 +1457,27 @@ export class GitService implements GitProvider, IDisposable {
     let remoteName: string | undefined;
     let remote: string | undefined;
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['remote']);
+      const { stdout } = await this.ctx.exec('git', ['remote']);
       const remotes = stdout.trim().split('\n').filter(Boolean);
       remoteName = remotes.includes('origin') ? 'origin' : remotes[0];
     } catch {}
 
     if (remoteName) {
       try {
-        const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['remote', 'get-url', remoteName]);
+        const { stdout } = await this.ctx.exec('git', ['remote', 'get-url', remoteName]);
         remote = stdout.trim() || undefined;
       } catch {}
     }
 
     let branch: string | undefined;
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['branch', '--show-current']);
+      const { stdout } = await this.ctx.exec('git', ['branch', '--show-current']);
       branch = stdout.trim() || undefined;
     } catch {}
 
     if (!branch && remoteName) {
       try {
-        const { stdout } = await this.authCtx.exec(GIT_EXECUTABLE, ['remote', 'show', remoteName]);
+        const { stdout } = await this.authCtx.exec('git', ['remote', 'show', remoteName]);
         const match = /HEAD branch:\s*(\S+)/.exec(stdout);
         branch = match?.[1] ?? undefined;
       } catch {}
@@ -1518,7 +1485,7 @@ export class GitService implements GitProvider, IDisposable {
 
     let rootPath: string = this.ctx.root ?? '';
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--show-toplevel']);
+      const { stdout } = await this.ctx.exec('git', ['rev-parse', '--show-toplevel']);
       const trimmed = stdout.trim();
       if (trimmed) rootPath = trimmed;
     } catch {}
@@ -1533,6 +1500,6 @@ export class GitService implements GitProvider, IDisposable {
   }
 
   async initRepository(): Promise<void> {
-    await this.ctx.exec(GIT_EXECUTABLE, ['init']);
+    await this.ctx.exec('git', ['init']);
   }
 }

--- a/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -5,7 +5,6 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import type { Remote } from '@shared/git';
 import { ok } from '@shared/result';
 import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
-import { GIT_EXECUTABLE } from '@main/core/utils/exec';
 import type { ProjectSettingsProvider } from '../settings/schema';
 import { LocalWorktreeHost } from './hosts/local-worktree-host';
 import type { WorktreeHost } from './hosts/worktree-host';
@@ -16,7 +15,7 @@ async function git(
   opts: { cwd: string }
 ): Promise<{ stdout: string; stderr: string }> {
   const ctx = new LocalExecutionContext({ root: opts.cwd });
-  return ctx.exec(GIT_EXECUTABLE, args);
+  return ctx.exec('git', args);
 }
 
 async function initRepo(dir: string): Promise<void> {

--- a/src/main/core/projects/worktrees/worktree-service.ts
+++ b/src/main/core/projects/worktrees/worktree-service.ts
@@ -4,7 +4,6 @@ import type { Branch } from '@shared/git';
 import { DEFAULT_REMOTE_NAME } from '@shared/git-utils';
 import { err, ok, type Result } from '@shared/result';
 import type { IExecutionContext } from '@main/core/execution-context/types';
-import { GIT_EXECUTABLE } from '@main/core/utils/exec';
 import { log } from '@main/lib/logger';
 import type { ProjectSettingsProvider } from '../settings/schema';
 import type { WorktreeHost } from './hosts/worktree-host';
@@ -34,7 +33,7 @@ export class WorktreeService {
     this.ctx = args.ctx;
     this.host = args.host;
 
-    this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'prune']).catch(() => {});
+    this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
   }
 
   private enqueueGitOp<T>(fn: () => Promise<T>): Promise<T> {
@@ -73,7 +72,7 @@ export class WorktreeService {
 
   private async findCheckedOutPathForBranch(branchName: string): Promise<string | undefined> {
     try {
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'list', '--porcelain']);
+      const { stdout } = await this.ctx.exec('git', ['worktree', 'list', '--porcelain']);
       const branchLine = `branch refs/heads/${branchName}`;
       for (const block of stdout.split('\n\n')) {
         if (!block.split('\n').some((line) => line === branchLine)) {
@@ -85,7 +84,7 @@ export class WorktreeService {
         if (await this.isValidWorktree(candidatePath)) {
           return candidatePath;
         }
-        await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'prune']).catch(() => {});
+        await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
       }
     } catch {}
     return undefined;
@@ -99,7 +98,7 @@ export class WorktreeService {
     if (sourceBranch.type === 'local') {
       const localRef = `refs/heads/${sourceBranch.branch}`;
       try {
-        await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', localRef]);
+        await this.ctx.exec('git', ['rev-parse', '--verify', localRef]);
         return localRef;
       } catch {
         return undefined;
@@ -107,10 +106,10 @@ export class WorktreeService {
     }
 
     const remoteName = sourceBranch.remote.name;
-    await this.ctx.exec(GIT_EXECUTABLE, ['fetch', remoteName]).catch(() => {});
+    await this.ctx.exec('git', ['fetch', remoteName]).catch(() => {});
     const remoteRef = `refs/remotes/${remoteName}/${sourceBranch.branch}`;
     try {
-      await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', remoteRef]);
+      await this.ctx.exec('git', ['rev-parse', '--verify', remoteRef]);
       return remoteRef;
     } catch {
       return undefined;
@@ -126,7 +125,7 @@ export class WorktreeService {
 
     try {
       const realPoolPath = await this.host.realPathAbsolute(this.worktreePoolPath);
-      const { stdout } = await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'list', '--porcelain']);
+      const { stdout } = await this.ctx.exec('git', ['worktree', 'list', '--porcelain']);
       const branchLine = `branch refs/heads/${branchName}`;
       for (const block of stdout.split('\n\n')) {
         if (block.split('\n').some((line) => line === branchLine)) {
@@ -159,13 +158,13 @@ export class WorktreeService {
     if (await this.host.existsAbsolute(targetPath)) {
       if (await this.isValidWorktree(targetPath)) return ok(targetPath);
       await this.host.removeAbsolute(targetPath, { recursive: true }).catch(() => {});
-      await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'prune']).catch(() => {});
+      await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
     }
 
     try {
       let localExists = false;
       try {
-        await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', `refs/heads/${branchName}`]);
+        await this.ctx.exec('git', ['rev-parse', '--verify', `refs/heads/${branchName}`]);
         localExists = true;
       } catch {}
 
@@ -174,12 +173,12 @@ export class WorktreeService {
         if (!sourceRef) {
           return err({ type: 'branch-not-found', branch: sourceBranch?.branch ?? branchName });
         }
-        await this.ctx.exec(GIT_EXECUTABLE, ['branch', '--no-track', branchName, sourceRef]);
+        await this.ctx.exec('git', ['branch', '--no-track', branchName, sourceRef]);
       }
 
       await this.host.mkdirAbsolute(path.dirname(targetPath), { recursive: true });
-      await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'prune']).catch(() => {});
-      await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'add', targetPath, branchName]);
+      await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
+      await this.ctx.exec('git', ['worktree', 'add', targetPath, branchName]);
     } catch (cause) {
       return err({ type: 'worktree-setup-failed', cause });
     }
@@ -213,17 +212,17 @@ export class WorktreeService {
     if (await this.host.existsAbsolute(targetPath)) {
       if (await this.isValidWorktree(targetPath)) return ok(targetPath);
       await this.host.removeAbsolute(targetPath, { recursive: true });
-      await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'prune']).catch(() => {});
+      await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
     }
 
     try {
       await this.host.mkdirAbsolute(path.dirname(targetPath), { recursive: true });
       for (const remoteName of remoteCandidates) {
-        await this.ctx.exec(GIT_EXECUTABLE, ['fetch', remoteName]).catch(() => {});
+        await this.ctx.exec('git', ['fetch', remoteName]).catch(() => {});
       }
       let localExists = false;
       try {
-        await this.ctx.exec(GIT_EXECUTABLE, ['rev-parse', '--verify', `refs/heads/${branchName}`]);
+        await this.ctx.exec('git', ['rev-parse', '--verify', `refs/heads/${branchName}`]);
         localExists = true;
       } catch {}
 
@@ -231,7 +230,7 @@ export class WorktreeService {
         let trackingRemote: string | undefined;
         for (const remoteName of remoteCandidates) {
           try {
-            await this.ctx.exec(GIT_EXECUTABLE, [
+            await this.ctx.exec('git', [
               'rev-parse',
               '--verify',
               `refs/remotes/${remoteName}/${branchName}`,
@@ -243,7 +242,7 @@ export class WorktreeService {
         if (!trackingRemote) {
           return err({ type: 'branch-not-found', branch: branchName });
         }
-        await this.ctx.exec(GIT_EXECUTABLE, [
+        await this.ctx.exec('git', [
           'branch',
           '--track',
           branchName,
@@ -251,8 +250,8 @@ export class WorktreeService {
         ]);
       }
 
-      await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'prune']).catch(() => {});
-      await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'add', targetPath, branchName]);
+      await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
+      await this.ctx.exec('git', ['worktree', 'add', targetPath, branchName]);
     } catch (cause) {
       return err({ type: 'worktree-setup-failed', cause });
     }
@@ -268,12 +267,12 @@ export class WorktreeService {
   }
 
   async moveWorktree(oldPath: string, newPath: string): Promise<void> {
-    await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'move', oldPath, newPath]);
+    await this.ctx.exec('git', ['worktree', 'move', oldPath, newPath]);
   }
 
   async removeWorktree(worktreePath: string): Promise<void> {
     await this.host.removeAbsolute(worktreePath, { recursive: true }).catch(() => {});
-    await this.ctx.exec(GIT_EXECUTABLE, ['worktree', 'prune']).catch(() => {});
+    await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
   }
 
   private async copyPreservedFiles(targetPath: string): Promise<void> {


### PR DESCRIPTION
issue:
- remote clone failed because git call sites passed the locally resolved macOS path into SSH execution
- SSH/container remotes should resolve git in the remote environment, not reuse a host-specific local path

fix:
- git callers now call ctx.exec('git', ...)
- LocalExecutionContext resolves local git to GIT_EXECUTABLE internally, preserving macOS GUI app reliability
- SshExecutionContext receives logical git, so the remote shell resolves /usr/bin/git or whatever is on remote PATH