### PR TITLE
fix(userEnv): scrub AppImage env from shell probe

### DIFF
--- a/src/main/utils/userEnv.test.ts
+++ b/src/main/utils/userEnv.test.ts
@@ -56,15 +56,23 @@ describe('ensureWindowsNpmGlobalBinInPath', () => {
 });
 
 describe('resolveUserEnv (AppImage env scrub)', () => {
-  const APPIMAGE_KEYS = ['APPIMAGE', 'APPDIR', 'ARGV0', 'OWD', 'CHROME_DESKTOP'] as const;
+  const SCRUBBED_KEYS = [
+    'APPIMAGE',
+    'APPDIR',
+    'ARGV0',
+    'OWD',
+    'CHROME_DESKTOP',
+    'GSETTINGS_SCHEMA_DIR',
+  ] as const;
+  const PATH_LIKE_KEYS = ['PATH', 'LD_LIBRARY_PATH', 'XDG_DATA_DIRS'] as const;
   const savedEnv: Partial<
-    Record<(typeof APPIMAGE_KEYS)[number] | 'PATH' | 'LD_LIBRARY_PATH', string | undefined>
+    Record<(typeof SCRUBBED_KEYS)[number] | (typeof PATH_LIKE_KEYS)[number], string | undefined>
   > = {};
 
   beforeEach(() => {
     execSyncMock.mockReset();
     execSyncMock.mockReturnValue('');
-    for (const key of [...APPIMAGE_KEYS, 'PATH' as const, 'LD_LIBRARY_PATH' as const]) {
+    for (const key of [...SCRUBBED_KEYS, ...PATH_LIKE_KEYS]) {
       savedEnv[key] = process.env[key];
     }
   });
@@ -76,13 +84,16 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
     }
   });
 
-  it('strips AppImage runtime vars and /tmp/.mount_* PATH entries from the probe shell env', async () => {
+  it('strips AppImage runtime vars and /tmp/.mount_* path entries from the probe shell env', async () => {
     process.env.APPIMAGE = '/home/user/emdash.AppImage';
     process.env.APPDIR = '/tmp/.mount_emdashTest';
     process.env.ARGV0 = '/home/user/emdash.AppImage';
     process.env.OWD = '/home/user';
+    process.env.CHROME_DESKTOP = 'emdash.desktop';
+    process.env.GSETTINGS_SCHEMA_DIR = '/tmp/.mount_emdashTest/usr/share/glib-2.0/schemas';
     process.env.PATH = '/tmp/.mount_emdashTest/usr/bin:/usr/local/bin:/usr/bin';
     process.env.LD_LIBRARY_PATH = '/tmp/.mount_emdashTest/usr/lib:/usr/lib';
+    process.env.XDG_DATA_DIRS = '/tmp/.mount_emdashTest/usr/share:/usr/local/share:/usr/share';
 
     await resolveUserEnv();
 
@@ -90,12 +101,12 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
     const opts = execSyncMock.mock.calls[0]?.[1] as { env?: NodeJS.ProcessEnv } | undefined;
     expect(opts?.env).toBeDefined();
     const probeEnv = opts!.env!;
-    expect(probeEnv.APPIMAGE).toBeUndefined();
-    expect(probeEnv.APPDIR).toBeUndefined();
-    expect(probeEnv.ARGV0).toBeUndefined();
-    expect(probeEnv.OWD).toBeUndefined();
-    expect(probeEnv.PATH ?? '').not.toContain('/tmp/.mount_');
-    expect(probeEnv.LD_LIBRARY_PATH ?? '').not.toContain('/tmp/.mount_');
+    for (const key of SCRUBBED_KEYS) {
+      expect(probeEnv[key]).toBeUndefined();
+    }
+    for (const key of PATH_LIKE_KEYS) {
+      expect(probeEnv[key] ?? '').not.toContain('/tmp/.mount_');
+    }
     // Helper hint vars must still be set so oh-my-zsh / tmux plugins stay quiet.
     expect(probeEnv.DISABLE_AUTO_UPDATE).toBe('true');
     expect(probeEnv.ZSH_TMUX_AUTOSTART).toBe('false');

--- a/src/main/utils/userEnv.test.ts
+++ b/src/main/utils/userEnv.test.ts
@@ -84,7 +84,8 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
     }
   });
 
-  it('strips AppImage runtime vars and /tmp/.mount_* path entries from the probe shell env', async () => {
+  it('strips AppImage runtime vars and /tmp/.mount_* path entries from the probe shell env and final PATH', async () => {
+    execSyncMock.mockReturnValue('PATH=/usr/local/bin:/usr/bin\n');
     process.env.APPIMAGE = '/home/user/emdash.AppImage';
     process.env.APPDIR = '/tmp/.mount_emdashTest';
     process.env.ARGV0 = '/home/user/emdash.AppImage';
@@ -107,6 +108,7 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
     for (const key of PATH_LIKE_KEYS) {
       expect(probeEnv[key] ?? '').not.toContain('/tmp/.mount_');
     }
+    expect(process.env.PATH ?? '').not.toContain('/tmp/.mount_');
     // Helper hint vars must still be set so oh-my-zsh / tmux plugins stay quiet.
     expect(probeEnv.DISABLE_AUTO_UPDATE).toBe('true');
     expect(probeEnv.ZSH_TMUX_AUTOSTART).toBe('false');

--- a/src/main/utils/userEnv.test.ts
+++ b/src/main/utils/userEnv.test.ts
@@ -1,8 +1,17 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it } from 'vitest';
-import { ensureUserBinDirsInPath, ensureWindowsNpmGlobalBinInPath } from './userEnv';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execSyncMock = vi.fn();
+
+vi.mock('node:child_process', () => ({
+  execSync: execSyncMock,
+}));
+
+const { ensureUserBinDirsInPath, ensureWindowsNpmGlobalBinInPath, resolveUserEnv } = await import(
+  './userEnv'
+);
 
 const originalPath = process.env.PATH;
 
@@ -43,5 +52,52 @@ describe('ensureWindowsNpmGlobalBinInPath', () => {
 
     expect(added).toBe('C:\\Users\\test\\AppData\\Roaming\\npm');
     expect(env.Path).toBe('C:\\Users\\test\\AppData\\Roaming\\npm;C:\\Windows\\System32');
+  });
+});
+
+describe('resolveUserEnv (AppImage env scrub)', () => {
+  const APPIMAGE_KEYS = ['APPIMAGE', 'APPDIR', 'ARGV0', 'OWD', 'CHROME_DESKTOP'] as const;
+  const savedEnv: Partial<
+    Record<(typeof APPIMAGE_KEYS)[number] | 'PATH' | 'LD_LIBRARY_PATH', string | undefined>
+  > = {};
+
+  beforeEach(() => {
+    execSyncMock.mockReset();
+    execSyncMock.mockReturnValue('');
+    for (const key of [...APPIMAGE_KEYS, 'PATH' as const, 'LD_LIBRARY_PATH' as const]) {
+      savedEnv[key] = process.env[key];
+    }
+  });
+
+  afterEach(() => {
+    for (const [key, value] of Object.entries(savedEnv)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  });
+
+  it('strips AppImage runtime vars and /tmp/.mount_* PATH entries from the probe shell env', async () => {
+    process.env.APPIMAGE = '/home/user/emdash.AppImage';
+    process.env.APPDIR = '/tmp/.mount_emdashTest';
+    process.env.ARGV0 = '/home/user/emdash.AppImage';
+    process.env.OWD = '/home/user';
+    process.env.PATH = '/tmp/.mount_emdashTest/usr/bin:/usr/local/bin:/usr/bin';
+    process.env.LD_LIBRARY_PATH = '/tmp/.mount_emdashTest/usr/lib:/usr/lib';
+
+    await resolveUserEnv();
+
+    expect(execSyncMock).toHaveBeenCalledTimes(1);
+    const opts = execSyncMock.mock.calls[0]?.[1] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(opts?.env).toBeDefined();
+    const probeEnv = opts!.env!;
+    expect(probeEnv.APPIMAGE).toBeUndefined();
+    expect(probeEnv.APPDIR).toBeUndefined();
+    expect(probeEnv.ARGV0).toBeUndefined();
+    expect(probeEnv.OWD).toBeUndefined();
+    expect(probeEnv.PATH ?? '').not.toContain('/tmp/.mount_');
+    expect(probeEnv.LD_LIBRARY_PATH ?? '').not.toContain('/tmp/.mount_');
+    // Helper hint vars must still be set so oh-my-zsh / tmux plugins stay quiet.
+    expect(probeEnv.DISABLE_AUTO_UPDATE).toBe('true');
+    expect(probeEnv.ZSH_TMUX_AUTOSTART).toBe('false');
   });
 });

--- a/src/main/utils/userEnv.ts
+++ b/src/main/utils/userEnv.ts
@@ -115,6 +115,7 @@ export async function resolveUserEnv(): Promise<void> {
   }
 
   const shell = process.env.SHELL ?? (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+  const baseEnv = buildExternalToolEnv();
 
   try {
     const raw = execSync(`${shell} -ilc 'env'`, {
@@ -126,7 +127,7 @@ export async function resolveUserEnv(): Promise<void> {
       // name through PATH (mise/starship/oh-my-zsh) can re-enter the AppImage
       // and fork-bomb the app on Linux. See #1679.
       env: {
-        ...buildExternalToolEnv(),
+        ...baseEnv,
         ...SHELL_ENV_CAPTURE_GUARD,
       },
     });
@@ -137,7 +138,7 @@ export async function resolveUserEnv(): Promise<void> {
       if (PRESERVE_KEYS.has(key)) continue;
 
       if (key === 'PATH') {
-        const current = process.env.PATH ?? '';
+        const current = baseEnv.PATH ?? '';
         process.env.PATH = mergePath(value, current);
       } else {
         process.env[key] = value;

--- a/src/main/utils/userEnv.ts
+++ b/src/main/utils/userEnv.ts
@@ -3,6 +3,7 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import { log } from '@main/lib/logger';
+import { buildExternalToolEnv } from './childProcessEnv';
 import { getWindowsEnvValue, prependWindowsPathEntry } from './windows-env';
 
 /**
@@ -113,8 +114,13 @@ export async function resolveUserEnv(): Promise<void> {
     const raw = execSync(`${shell} -ilc 'env'`, {
       encoding: 'utf8',
       timeout: 5_000,
+      // Route through buildExternalToolEnv so AppImage runtime vars (APPIMAGE,
+      // APPDIR, ARGV0, ...) and `/tmp/.mount_*` PATH entries don't leak into
+      // the probe shell. Otherwise login-shell hooks that resolve a binary by
+      // name through PATH (mise/starship/oh-my-zsh) can re-enter the AppImage
+      // and fork-bomb the app on Linux. See #1679.
       env: {
-        ...process.env,
+        ...buildExternalToolEnv(),
         // Prevent oh-my-zsh and tmux plugins from producing extra output or
         // blocking the env capture.
         DISABLE_AUTO_UPDATE: 'true',


### PR DESCRIPTION
## Summary
- `src/main/utils/userEnv.ts` (`resolveUserEnv`) spawned `$SHELL -ilc 'env'` with `...process.env` passed wholesale, leaking `APPIMAGE` / `APPDIR` / `ARGV0` / `OWD` / `/tmp/.mount_*` PATH entries into the probe shell.
- On Linux AppImage installs, any shell-init code that resolves a binary by name through PATH (`mise activate`, `starship init`, oh-my-zsh completions) then re-enters the AppImage binary and fork-bombs Emdash. The main process hangs in `fuse_dev_do_read`, waiting on a probe that keeps spawning copies of itself, and no window is ever shown.
- Route the probe env through `buildExternalToolEnv()` from `src/main/utils/childProcessEnv.ts` — the same helper already used by `ptyManager.ts` and `appIpc.ts` for the same reason. `userEnv.ts` was the remaining `process.env`-wholesale call site.
- Adds a regression test that mocks `execSync` and asserts the spawned env has `APPIMAGE` / `APPDIR` / `ARGV0` / `OWD` stripped and that no `/tmp/.mount_*` entries remain in `PATH` / `LD_LIBRARY_PATH`.

## Fixes
Fixes #1679. Supersedes #1680 (same fix, rebased onto v1 `main` where `shellEnv.ts` was split into `userEnv.ts`).

## Test plan
- [x] `pnpm exec prettier --check` — clean on changed files
- [x] `pnpm run lint` — 0 errors
- [x] `pnpm run typecheck` — clean
- [x] `pnpm exec vitest run src/main/utils/userEnv.test.ts` — 4/4 passing
- [x] Regression test verified by stash-and-rerun: fails without the fix (`expected '/home/user/emdash.AppImage' to be undefined`), passes with it
- [x] Manual end-to-end against a real v1 AppImage build: extracted, patched the bundled `userEnv.ts` in `app.asar`, repacked, ran from `AppRun` — Emdash launches and the window appears immediately on Hyprland; the original wedge-on-launch is gone
- [x] Full `pnpm exec vitest run` shows the same 10 unrelated `legacy-port` failures on `main` without these changes too — i.e. no regressions introduced here