### PR TITLE
Fix: agent detection on macOS remotes

### DIFF
--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -114,7 +114,13 @@ export class SshConversationProvider implements ConversationProvider {
       resume: isResuming,
     };
 
-    const sshCommand = resolveSshCommand('agent', cfg, { ...providerEnv, ...this.taskEnvVars });
+    const profile = await this.proxy.getRemoteShellProfile();
+    const sshCommand = resolveSshCommand(
+      'agent',
+      cfg,
+      { ...providerEnv, ...this.taskEnvVars },
+      profile
+    );
 
     const result = await openSsh2Pty(this.proxy.client, {
       id: sessionId,

--- a/src/main/core/dependencies/install-runner.test.ts
+++ b/src/main/core/dependencies/install-runner.test.ts
@@ -1,11 +1,20 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LocalSpawnOptions } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
-import { classifyInstallCommandFailure, runLocalInstallCommand } from './install-runner';
+import {
+  classifyInstallCommandFailure,
+  createSshInstallCommandRunner,
+  runLocalInstallCommand,
+} from './install-runner';
 
 const mocks = vi.hoisted(() => ({
+  openSsh2Pty: vi.fn(),
   spawnLocalPty: vi.fn(),
   ensureUserBinDirsInPath: vi.fn(),
+}));
+
+vi.mock('@main/core/pty/ssh2-pty', () => ({
+  openSsh2Pty: mocks.openSsh2Pty,
 }));
 
 vi.mock('@main/core/pty/local-pty', () => ({
@@ -38,6 +47,7 @@ function createSuccessfulPty(): Pty {
 
 beforeEach(() => {
   mocks.spawnLocalPty.mockReturnValue(createSuccessfulPty());
+  mocks.openSsh2Pty.mockResolvedValue({ success: true, data: createSuccessfulPty() });
 });
 
 afterEach(() => {
@@ -95,6 +105,33 @@ describe('runLocalInstallCommand', () => {
         args: ['/d', '/s', '/c', 'npm install -g @openai/codex'],
         cwd: expect.any(String),
       } satisfies Partial<LocalSpawnOptions>)
+    );
+  });
+});
+
+describe('createSshInstallCommandRunner', () => {
+  it('runs remote installs through the captured remote shell profile', async () => {
+    const proxy = {
+      client: {},
+      getRemoteShellProfile: vi.fn(async () => ({
+        shell: '/bin/zsh',
+        env: {
+          PATH: '/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin',
+        },
+      })),
+    };
+    const runner = createSshInstallCommandRunner(proxy as never);
+
+    const result = await runner('npm install -g @anthropic-ai/claude-code');
+
+    expect(result.success).toBe(true);
+    expect(proxy.getRemoteShellProfile).toHaveBeenCalledWith();
+    expect(mocks.openSsh2Pty).toHaveBeenCalledWith(
+      proxy.client,
+      expect.objectContaining({
+        command:
+          "'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; npm install -g @anthropic-ai/claude-code'",
+      })
     );
   });
 });

--- a/src/main/core/dependencies/install-runner.ts
+++ b/src/main/core/dependencies/install-runner.ts
@@ -5,10 +5,10 @@ import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/pty-spawn-platform';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
+import { buildRemoteShellCommand } from '@main/core/ssh/remote-shell-profile';
 import type { SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
 import { log } from '@main/lib/logger';
 import { ensureUserBinDirsInPath } from '@main/utils/userEnv';
-import { quoteShellArg } from '../../utils/shellEscape';
 
 export type InstallCommandRunner<TData = void, TError = InstallCommandError> = (
   command: string
@@ -100,9 +100,10 @@ export function runLocalInstallCommand(
 
 export function createSshInstallCommandRunner(proxy: SshClientProxy): InstallCommandRunner {
   return async (command: string) => {
+    const profile = await proxy.getRemoteShellProfile();
     const result = await openSsh2Pty(proxy.client, {
       id: `install:${crypto.randomUUID()}`,
-      command: `bash -l -c ${quoteShellArg(command)}`,
+      command: buildRemoteShellCommand(profile, command),
       cols: 80,
       rows: 24,
     });

--- a/src/main/core/execution-context/ssh-execution-context.test.ts
+++ b/src/main/core/execution-context/ssh-execution-context.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import type { RemoteShellProfile } from '@main/core/ssh/remote-shell-profile';
+import { buildSshCommand } from './ssh-execution-context';
+
+describe('buildSshCommand', () => {
+  it('uses the shared remote shell command builder for fallback SSH exec commands', () => {
+    const command = buildSshCommand('/workspace/project', 'which', ['claude']);
+
+    expect(command).toBe(
+      "'/bin/sh' -c 'cd '\\''/workspace/project'\\'' && which '\\''claude'\\'''"
+    );
+  });
+
+  it('uses the remote shell profile and cwd when building SSH exec commands', () => {
+    const profile: RemoteShellProfile = {
+      shell: '/bin/zsh',
+      env: {
+        PATH: '/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin',
+      },
+    };
+
+    const command = buildSshCommand('/workspace/project', 'which', ['claude'], profile);
+
+    expect(command).toBe(
+      "'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; cd '\\''/workspace/project'\\'' && which '\\''claude'\\'''"
+    );
+  });
+});

--- a/src/main/core/execution-context/ssh-execution-context.ts
+++ b/src/main/core/execution-context/ssh-execution-context.ts
@@ -1,3 +1,8 @@
+import {
+  buildRemoteShellCommand,
+  FALLBACK_REMOTE_SHELL_PROFILE,
+  type RemoteShellProfile,
+} from '@main/core/ssh/remote-shell-profile';
 import type { SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
 import { quoteShellArg } from '@main/utils/shellEscape';
 import type { ExecOptions, ExecResult, IExecutionContext } from './types';
@@ -7,11 +12,16 @@ import type { ExecOptions, ExecResult, IExecutionContext } from './types';
  * When `root` is provided the command runs inside `cd root &&`.
  * Args are shell-escaped for safe remote execution.
  */
-export function buildSshCommand(root: string | undefined, command: string, args: string[]): string {
+export function buildSshCommand(
+  root: string | undefined,
+  command: string,
+  args: string[],
+  profile?: RemoteShellProfile
+): string {
   const escaped = args.map(quoteShellArg).join(' ');
   const inner = args.length ? `${command} ${escaped}` : command;
   const body = root ? `cd ${quoteShellArg(root)} && ${inner}` : inner;
-  return `bash -l -c ${quoteShellArg(body)}`;
+  return buildRemoteShellCommand(profile ?? FALLBACK_REMOTE_SHELL_PROFILE, body);
 }
 
 export class SshExecutionContext implements IExecutionContext {
@@ -27,9 +37,10 @@ export class SshExecutionContext implements IExecutionContext {
     this.root = opts.root;
   }
 
-  exec(command: string, args: string[] = [], opts: ExecOptions = {}): Promise<ExecResult> {
+  async exec(command: string, args: string[] = [], opts: ExecOptions = {}): Promise<ExecResult> {
     const { signal } = opts;
-    const full = buildSshCommand(this.root, command, args);
+    const profile = await this.proxy.getRemoteShellProfile();
+    const full = buildSshCommand(this.root, command, args, profile);
     const combined = this._signal(signal);
 
     return new Promise((resolve, reject) => {
@@ -87,14 +98,15 @@ export class SshExecutionContext implements IExecutionContext {
     });
   }
 
-  execStreaming(
+  async execStreaming(
     command: string,
     args: string[],
     onChunk: (chunk: string) => boolean,
     opts: { signal?: AbortSignal } = {}
   ): Promise<void> {
     const { signal } = opts;
-    const full = buildSshCommand(this.root, command, args);
+    const profile = await this.proxy.getRemoteShellProfile();
+    const full = buildSshCommand(this.root, command, args, profile);
     const combined = this._signal(signal);
 
     return new Promise((resolve, reject) => {

--- a/src/main/core/fs/impl/ssh-fs.ts
+++ b/src/main/core/fs/impl/ssh-fs.ts
@@ -5,6 +5,7 @@
 
 import type { SFTPWrapper } from 'ssh2';
 import type { FileWatchEvent } from '@shared/fs';
+import { buildRemoteShellCommand } from '@main/core/ssh/remote-shell-profile';
 import type { SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
 import { log } from '@main/lib/logger';
 import { quoteShellArg } from '@main/utils/shellEscape';
@@ -83,8 +84,11 @@ export class SshFileSystem implements FileSystemProvider {
     });
   }
 
-  private exec(command: string): Promise<{ stdout: string; stderr: string; exitCode: number }> {
-    const full = `bash -l -c ${quoteShellArg(command)}`;
+  private async exec(
+    command: string
+  ): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+    const profile = await this.proxy.getRemoteShellProfile();
+    const full = buildRemoteShellCommand(profile, command);
     return new Promise((resolve, reject) => {
       this.proxy.client.exec(full, (err, stream) => {
         if (err) return reject(err);

--- a/src/main/core/pty/spawn-utils.test.ts
+++ b/src/main/core/pty/spawn-utils.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import type { AgentSessionConfig } from '@shared/agent-session';
+import type { GeneralSessionConfig } from '@shared/general-session';
+import type { RemoteShellProfile } from '@main/core/ssh/remote-shell-profile';
 import { resolveSshCommand } from './spawn-utils';
 
 function makeAgentConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSessionConfig {
@@ -16,22 +18,52 @@ function makeAgentConfig(overrides: Partial<AgentSessionConfig> = {}): AgentSess
   };
 }
 
+function makeGeneralConfig(overrides: Partial<GeneralSessionConfig> = {}): GeneralSessionConfig {
+  return {
+    taskId: 'task-1',
+    cwd: '/workspace',
+    ...overrides,
+  };
+}
+
+const zshProfile: RemoteShellProfile = {
+  shell: '/bin/zsh',
+  env: {
+    PATH: '/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin',
+  },
+};
+
 describe('resolveSshCommand', () => {
   it('runs remote commands through a login shell so PATH matches install/probe', () => {
-    const result = resolveSshCommand('agent', makeAgentConfig());
+    const result = resolveSshCommand('agent', makeAgentConfig(), undefined, zshProfile);
 
     expect(result).toBe(
-      `bash -l -c 'cd "/workspace" && '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
+      `'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; cd "/workspace" && '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
     );
   });
 
   it('adds SSH env exports before the remote command', () => {
+    const result = resolveSshCommand(
+      'agent',
+      makeAgentConfig(),
+      {
+        FOO: 'bar',
+      },
+      zshProfile
+    );
+
+    expect(result).toBe(
+      `'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; export FOO='\\''bar'\\''; cd "/workspace" && '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
+    );
+  });
+
+  it('uses the shared remote shell command builder for fallback SSH commands', () => {
     const result = resolveSshCommand('agent', makeAgentConfig(), {
       FOO: 'bar',
     });
 
     expect(result).toBe(
-      `bash -l -c 'cd "/workspace" && export FOO='\\''bar'\\''; '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
+      `'/bin/sh' -c 'export FOO='\\''bar'\\''; cd "/workspace" && '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
     );
   });
 
@@ -41,11 +73,13 @@ describe('resolveSshCommand', () => {
       makeAgentConfig({
         command: 'caffeinate',
         args: ['-i', 'direnv', 'exec', '.', '/opt/Claude Code/bin/claude', 'Fix the bug'],
-      })
+      }),
+      undefined,
+      zshProfile
     );
 
     expect(result).toBe(
-      `bash -l -c 'cd "/workspace" && '\\''caffeinate'\\'' '\\''-i'\\'' '\\''direnv'\\'' '\\''exec'\\'' '\\''.'\\'' '\\''/opt/Claude Code/bin/claude'\\'' '\\''Fix the bug'\\'''`
+      `'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; cd "/workspace" && '\\''caffeinate'\\'' '\\''-i'\\'' '\\''direnv'\\'' '\\''exec'\\'' '\\''.'\\'' '\\''/opt/Claude Code/bin/claude'\\'' '\\''Fix the bug'\\'''`
     );
   });
 
@@ -54,12 +88,22 @@ describe('resolveSshCommand', () => {
       'agent',
       makeAgentConfig({
         tmuxSessionName: 'agent-session',
-      })
+      }),
+      undefined,
+      zshProfile
     );
 
     expect(result).toContain('tmux has-session -t "agent-session"');
     expect(result).toContain('tmux new-session -d -s "agent-session"');
     expect(result).toContain('tmux attach-session -t "agent-session"');
     expect(result).toContain("'\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\''");
+  });
+
+  it('launches remote general terminals with the captured remote shell', () => {
+    const result = resolveSshCommand('general', makeGeneralConfig(), undefined, zshProfile);
+
+    expect(result).toBe(
+      `'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; cd "/workspace" && exec /bin/zsh -il'`
+    );
   });
 });

--- a/src/main/core/pty/spawn-utils.ts
+++ b/src/main/core/pty/spawn-utils.ts
@@ -1,5 +1,10 @@
 import type { AgentSessionConfig } from '@shared/agent-session';
 import type { GeneralSessionConfig } from '@shared/general-session';
+import {
+  buildRemoteShellCommand,
+  FALLBACK_REMOTE_SHELL_PROFILE,
+  type RemoteShellProfile,
+} from '@main/core/ssh/remote-shell-profile';
 import { quoteShellArg } from '@main/utils/shellEscape';
 import { buildTmuxShellLine } from './tmux-session-name';
 
@@ -8,9 +13,10 @@ export type SessionConfig = AgentSessionConfig | GeneralSessionConfig;
 
 function posixShellLineForSsh(
   type: SessionType,
-  config: SessionConfig
+  config: SessionConfig,
+  profile: RemoteShellProfile
 ): { cwd: string; line: string } {
-  const shell = process.env.SHELL ?? '/bin/sh';
+  const shell = profile.shell;
 
   switch (type) {
     case 'agent': {
@@ -44,18 +50,11 @@ function posixShellLineForSsh(
 export function resolveSshCommand(
   type: SessionType,
   config: SessionConfig,
-  envVars?: Record<string, string>
+  envVars?: Record<string, string>,
+  profile?: RemoteShellProfile
 ): string {
-  const { cwd, line } = posixShellLineForSsh(type, config);
-  const envPrefix = envVars ? buildSshEnvPrefix(envVars) : '';
-  const commandString = `cd ${JSON.stringify(cwd)} && ${envPrefix}${line}`;
-
-  return `bash -l -c ${quoteShellArg(commandString)}`;
-}
-
-export function buildSshEnvPrefix(vars: Record<string, string>): string {
-  const entries = Object.entries(vars);
-  if (entries.length === 0) return '';
-  const exports = entries.map(([k, v]) => `export ${k}='${v.replace(/'/g, "'\\''")}'`).join('; ');
-  return exports + '; ';
+  const effectiveProfile = profile ?? FALLBACK_REMOTE_SHELL_PROFILE;
+  const { cwd, line } = posixShellLineForSsh(type, config, effectiveProfile);
+  const commandString = `cd ${JSON.stringify(cwd)} && ${line}`;
+  return buildRemoteShellCommand(effectiveProfile, commandString, envVars);
 }

--- a/src/main/core/ssh/remote-shell-profile.test.ts
+++ b/src/main/core/ssh/remote-shell-profile.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildRemoteShellCommand,
+  FALLBACK_REMOTE_SHELL_PROFILE,
+  normalizeRemoteShell,
+  type RemoteShellProfile,
+} from './remote-shell-profile';
+
+describe('remote shell profile command building', () => {
+  it('runs commands through the captured remote shell and exports captured PATH', () => {
+    const profile: RemoteShellProfile = {
+      shell: '/bin/zsh',
+      env: {
+        PATH: '/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin',
+        NVM_DIR: '/Users/jona/.nvm',
+      },
+    };
+
+    const command = buildRemoteShellCommand(profile, 'which claude');
+
+    expect(command).toBe(
+      "'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; export NVM_DIR='\\''/Users/jona/.nvm'\\''; which claude'"
+    );
+  });
+
+  it('lets explicit command env override captured profile env', () => {
+    const profile: RemoteShellProfile = {
+      shell: '/bin/zsh',
+      env: {
+        PATH: '/captured/bin:/usr/bin',
+        FOO: 'captured',
+      },
+    };
+
+    const command = buildRemoteShellCommand(profile, 'node --version', {
+      PATH: '/task/bin:/usr/bin',
+      FOO: 'task',
+    });
+
+    expect(command).toContain("export PATH='\\''/captured/bin:/usr/bin'\\''");
+    expect(command).toContain("export PATH='\\''/task/bin:/usr/bin'\\''");
+    expect(command.indexOf('/captured/bin')).toBeLessThan(command.indexOf('/task/bin'));
+    expect(command).toContain("export FOO='\\''task'\\''; node --version");
+  });
+
+  it('uses /bin/sh without login flags for the fallback profile', () => {
+    const command = buildRemoteShellCommand(FALLBACK_REMOTE_SHELL_PROFILE, 'which claude');
+
+    expect(command).toBe("'/bin/sh' -c 'which claude'");
+  });
+
+  it('filters volatile and invalid environment variables from command exports', () => {
+    const command = buildRemoteShellCommand(
+      {
+        shell: '/bin/zsh',
+        env: {
+          PATH: '/usr/bin',
+          PWD: '/tmp',
+          'BAD-NAME': 'nope',
+          GOOD_NAME: 'value',
+        },
+      },
+      'env',
+      {
+        SHLVL: '2',
+        ALSO_GOOD: 'yes',
+      }
+    );
+
+    expect(command).toBe(
+      "'/bin/zsh' -lc 'export PATH='\\''/usr/bin'\\''; export GOOD_NAME='\\''value'\\''; export ALSO_GOOD='\\''yes'\\''; env'"
+    );
+  });
+
+  it('falls back to /bin/sh when the remote shell is empty or not absolute', () => {
+    expect(normalizeRemoteShell('')).toBe('/bin/sh');
+    expect(normalizeRemoteShell('zsh')).toBe('/bin/sh');
+    expect(normalizeRemoteShell('/bin/zsh\n')).toBe('/bin/zsh');
+  });
+});

--- a/src/main/core/ssh/remote-shell-profile.test.ts
+++ b/src/main/core/ssh/remote-shell-profile.test.ts
@@ -77,4 +77,11 @@ describe('remote shell profile command building', () => {
     expect(normalizeRemoteShell('zsh')).toBe('/bin/sh');
     expect(normalizeRemoteShell('/bin/zsh\n')).toBe('/bin/zsh');
   });
+
+  it('falls back to /bin/sh for unsupported remote shells', () => {
+    expect(normalizeRemoteShell('/usr/local/bin/fish')).toBe('/bin/sh');
+    expect(buildRemoteShellCommand({ shell: '/usr/local/bin/fish', env: {} }, 'echo ok')).toBe(
+      "'/bin/sh' -c 'echo ok'"
+    );
+  });
 });

--- a/src/main/core/ssh/remote-shell-profile.ts
+++ b/src/main/core/ssh/remote-shell-profile.ts
@@ -1,0 +1,161 @@
+import type { Client, ClientChannel } from 'ssh2';
+import { isValidEnvVarName, quoteShellArg } from '@main/utils/shellEscape';
+import { parseRemoteEnvOutput, SHELL_ENV_CAPTURE_GUARD } from '@main/utils/userEnv';
+
+export type RemoteShellProfile = {
+  shell: string;
+  env: Record<string, string>;
+};
+
+export const DEFAULT_REMOTE_SHELL = '/bin/sh';
+
+export const FALLBACK_REMOTE_SHELL_PROFILE: RemoteShellProfile = {
+  shell: DEFAULT_REMOTE_SHELL,
+  env: {},
+};
+
+const CAPTURE_TIMEOUT_MS = 5_000;
+const SHELL_TIMEOUT_MS = 3_000;
+
+const VOLATILE_ENV_KEYS = new Set(['_', 'PWD', 'OLDPWD', 'SHLVL', 'COLUMNS', 'LINES']);
+
+type RawExecResult = {
+  stdout: string;
+  stderr: string;
+};
+
+export function normalizeRemoteShell(raw: string | undefined | null): string {
+  const shell = raw?.trim();
+  if (!shell || !shell.startsWith('/')) {
+    return DEFAULT_REMOTE_SHELL;
+  }
+  return shell;
+}
+
+function buildRemoteShellEnvPrefix(env: Record<string, string>): string {
+  const exports = Object.entries(env)
+    .filter(([key]) => shouldForwardEnvKey(key))
+    .map(([key, value]) => `export ${key}=${quoteShellArg(value)}`);
+
+  return exports.length > 0 ? `${exports.join('; ')}; ` : '';
+}
+
+function buildRemoteShellProcessEnvPrefix(env: Record<string, string>): string {
+  const assignments = Object.entries(env)
+    .filter(([key]) => shouldForwardEnvKey(key))
+    .map(([key, value]) => quoteShellArg(`${key}=${value}`));
+
+  return assignments.length > 0 ? `env ${assignments.join(' ')} ` : '';
+}
+
+export function buildRemoteShellCommand(
+  profile: RemoteShellProfile,
+  command: string,
+  env: Record<string, string> = {}
+): string {
+  const prefix = `${buildRemoteShellEnvPrefix(profile.env)}${buildRemoteShellEnvPrefix(env)}`;
+  return `${quoteShellArg(profile.shell)} ${remoteShellCommandFlag(profile.shell)} ${quoteShellArg(
+    `${prefix}${command}`
+  )}`;
+}
+
+export async function captureRemoteShellProfile(client: Client): Promise<RemoteShellProfile> {
+  const shell = await resolveRemoteShell(client);
+  const env = await captureRemoteEnv(client, shell);
+  return { shell, env };
+}
+
+async function resolveRemoteShell(client: Client): Promise<string> {
+  try {
+    const { stdout } = await execRaw(client, 'printf %s "$SHELL"', SHELL_TIMEOUT_MS);
+    return normalizeRemoteShell(stdout);
+  } catch {
+    return DEFAULT_REMOTE_SHELL;
+  }
+}
+
+async function captureRemoteEnv(client: Client, shell: string): Promise<Record<string, string>> {
+  try {
+    const guard = buildRemoteShellProcessEnvPrefix(SHELL_ENV_CAPTURE_GUARD);
+    const capture = `${guard}${quoteShellArg(shell)} ${remoteShellEnvCaptureFlag(
+      shell
+    )} ${quoteShellArg('env')}`;
+    const { stdout } = await execRaw(client, capture, CAPTURE_TIMEOUT_MS);
+    return parseRemoteEnvOutput(stdout);
+  } catch {
+    try {
+      const { stdout } = await execRaw(client, 'env', CAPTURE_TIMEOUT_MS);
+      return parseRemoteEnvOutput(stdout);
+    } catch {
+      return {};
+    }
+  }
+}
+
+function shouldForwardEnvKey(key: string): boolean {
+  return isValidEnvVarName(key) && !VOLATILE_ENV_KEYS.has(key);
+}
+
+function remoteShellCommandFlag(shell: string): string {
+  return shell.endsWith('/sh') ? '-c' : '-lc';
+}
+
+function remoteShellEnvCaptureFlag(shell: string): string {
+  return shell.endsWith('/sh') ? '-ic' : '-ilc';
+}
+
+function execRaw(client: Client, command: string, timeoutMs: number): Promise<RawExecResult> {
+  return new Promise((resolve, reject) => {
+    let stream: ClientChannel | undefined;
+    let settled = false;
+    let stdout = '';
+    let stderr = '';
+
+    const timer = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      stream?.destroy();
+      reject(new Error(`Remote command timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    client.exec(command, (err, channel) => {
+      if (settled) return;
+      if (err) {
+        clearTimeout(timer);
+        settled = true;
+        reject(err);
+        return;
+      }
+
+      stream = channel;
+      channel.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf-8');
+      });
+      channel.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8');
+      });
+      channel.on('close', (exitCode: number | null) => {
+        if (settled) return;
+        clearTimeout(timer);
+        settled = true;
+        if ((exitCode ?? 0) === 0) {
+          resolve({ stdout, stderr });
+          return;
+        }
+        reject(
+          Object.assign(new Error(stderr || `Process exited with code ${exitCode}`), {
+            stdout,
+            stderr,
+            exitCode,
+          })
+        );
+      });
+      channel.on('error', (error: Error) => {
+        if (settled) return;
+        clearTimeout(timer);
+        settled = true;
+        reject(error);
+      });
+    });
+  });
+}

--- a/src/main/core/ssh/remote-shell-profile.ts
+++ b/src/main/core/ssh/remote-shell-profile.ts
@@ -17,6 +17,9 @@ export const FALLBACK_REMOTE_SHELL_PROFILE: RemoteShellProfile = {
 const CAPTURE_TIMEOUT_MS = 5_000;
 const SHELL_TIMEOUT_MS = 3_000;
 
+const LOGIN_SHELLS = new Set(['bash', 'ksh', 'zsh']);
+const BASIC_POSIX_SHELLS = new Set(['dash', 'sh']);
+const SUPPORTED_REMOTE_SHELLS = new Set([...BASIC_POSIX_SHELLS, ...LOGIN_SHELLS]);
 const VOLATILE_ENV_KEYS = new Set(['_', 'PWD', 'OLDPWD', 'SHLVL', 'COLUMNS', 'LINES']);
 
 type RawExecResult = {
@@ -26,7 +29,7 @@ type RawExecResult = {
 
 export function normalizeRemoteShell(raw: string | undefined | null): string {
   const shell = raw?.trim();
-  if (!shell || !shell.startsWith('/')) {
+  if (!shell || !shell.startsWith('/') || !SUPPORTED_REMOTE_SHELLS.has(shellBasename(shell))) {
     return DEFAULT_REMOTE_SHELL;
   }
   return shell;
@@ -53,8 +56,9 @@ export function buildRemoteShellCommand(
   command: string,
   env: Record<string, string> = {}
 ): string {
+  const shell = normalizeRemoteShell(profile.shell);
   const prefix = `${buildRemoteShellEnvPrefix(profile.env)}${buildRemoteShellEnvPrefix(env)}`;
-  return `${quoteShellArg(profile.shell)} ${remoteShellCommandFlag(profile.shell)} ${quoteShellArg(
+  return `${quoteShellArg(shell)} ${remoteShellCommandFlag(shell)} ${quoteShellArg(
     `${prefix}${command}`
   )}`;
 }
@@ -97,11 +101,15 @@ function shouldForwardEnvKey(key: string): boolean {
 }
 
 function remoteShellCommandFlag(shell: string): string {
-  return shell.endsWith('/sh') ? '-c' : '-lc';
+  return BASIC_POSIX_SHELLS.has(shellBasename(shell)) ? '-c' : '-lc';
 }
 
 function remoteShellEnvCaptureFlag(shell: string): string {
-  return shell.endsWith('/sh') ? '-ic' : '-ilc';
+  return BASIC_POSIX_SHELLS.has(shellBasename(shell)) ? '-ic' : '-ilc';
+}
+
+function shellBasename(shell: string): string {
+  return shell.split('/').pop() ?? '';
 }
 
 function execRaw(client: Client, command: string, timeoutMs: number): Promise<RawExecResult> {

--- a/src/main/core/ssh/ssh-client-proxy.test.ts
+++ b/src/main/core/ssh/ssh-client-proxy.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as RemoteShellProfileModule from './remote-shell-profile';
+import { SshClientProxy } from './ssh-client-proxy';
+
+const mocks = vi.hoisted(() => ({
+  captureRemoteShellProfile: vi.fn(),
+}));
+
+vi.mock('./remote-shell-profile', async (importOriginal) => {
+  const actual = (await importOriginal()) as typeof RemoteShellProfileModule;
+  return {
+    ...actual,
+    captureRemoteShellProfile: mocks.captureRemoteShellProfile,
+  };
+});
+
+describe('SshClientProxy remote shell profile', () => {
+  beforeEach(() => {
+    mocks.captureRemoteShellProfile.mockReset();
+  });
+
+  it('captures and caches the remote shell profile behind the proxy API', async () => {
+    const client = {};
+    const profile = {
+      shell: '/bin/zsh',
+      env: { PATH: '/opt/homebrew/bin:/usr/bin' },
+    };
+    mocks.captureRemoteShellProfile.mockResolvedValue(profile);
+    const proxy = new SshClientProxy();
+    proxy.update(client as never);
+
+    await expect(proxy.getRemoteShellProfile()).resolves.toBe(profile);
+    await expect(proxy.getRemoteShellProfile()).resolves.toBe(profile);
+
+    expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(1);
+    expect(mocks.captureRemoteShellProfile).toHaveBeenCalledWith(client);
+  });
+
+  it('clears cached shell profile on invalidate', async () => {
+    const firstClient = {};
+    const secondClient = {};
+    mocks.captureRemoteShellProfile
+      .mockResolvedValueOnce({ shell: '/bin/zsh', env: { PATH: '/first' } })
+      .mockResolvedValueOnce({ shell: '/bin/bash', env: { PATH: '/second' } });
+    const proxy = new SshClientProxy();
+
+    proxy.update(firstClient as never);
+    await proxy.getRemoteShellProfile();
+    proxy.invalidate();
+    proxy.update(secondClient as never);
+    const profile = await proxy.getRemoteShellProfile();
+
+    expect(profile).toEqual({ shell: '/bin/bash', env: { PATH: '/second' } });
+    expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(2);
+  });
+});

--- a/src/main/core/ssh/ssh-client-proxy.test.ts
+++ b/src/main/core/ssh/ssh-client-proxy.test.ts
@@ -19,6 +19,12 @@ describe('SshClientProxy remote shell profile', () => {
     mocks.captureRemoteShellProfile.mockReset();
   });
 
+  it('returns a rejected promise when the SSH connection is unavailable', async () => {
+    const proxy = new SshClientProxy();
+
+    await expect(proxy.getRemoteShellProfile()).rejects.toThrow('SSH connection is not available');
+  });
+
   it('captures and caches the remote shell profile behind the proxy API', async () => {
     const client = {};
     const profile = {
@@ -34,6 +40,33 @@ describe('SshClientProxy remote shell profile', () => {
 
     expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(1);
     expect(mocks.captureRemoteShellProfile).toHaveBeenCalledWith(client);
+  });
+
+  it('does not cache an in-flight shell profile after invalidation', async () => {
+    let resolveFirst!: (profile: { shell: string; env: Record<string, string> }) => void;
+    const firstCapture = new Promise<{ shell: string; env: Record<string, string> }>((resolve) => {
+      resolveFirst = resolve;
+    });
+    const firstClient = {};
+    const secondClient = {};
+    mocks.captureRemoteShellProfile
+      .mockReturnValueOnce(firstCapture)
+      .mockResolvedValueOnce({ shell: '/bin/bash', env: { PATH: '/second' } });
+    const proxy = new SshClientProxy();
+
+    proxy.update(firstClient as never);
+    const staleCapture = proxy.getRemoteShellProfile();
+    proxy.invalidate();
+    proxy.update(secondClient as never);
+    resolveFirst({ shell: '/bin/zsh', env: { PATH: '/first' } });
+    await staleCapture;
+
+    await expect(proxy.getRemoteShellProfile()).resolves.toEqual({
+      shell: '/bin/bash',
+      env: { PATH: '/second' },
+    });
+    expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(2);
+    expect(mocks.captureRemoteShellProfile).toHaveBeenNthCalledWith(2, secondClient);
   });
 
   it('clears cached shell profile on invalidate', async () => {

--- a/src/main/core/ssh/ssh-client-proxy.ts
+++ b/src/main/core/ssh/ssh-client-proxy.ts
@@ -1,4 +1,5 @@
 import type { Client } from 'ssh2';
+import { captureRemoteShellProfile, type RemoteShellProfile } from './remote-shell-profile';
 
 /**
  * Stable reference to an ssh2 Client that survives reconnects.
@@ -12,35 +13,34 @@ import type { Client } from 'ssh2';
  */
 export class SshClientProxy {
   private _client: Client | null = null;
-  private _remoteEnv: Record<string, string> | null = null;
+  private _remoteShellProfile: RemoteShellProfile | null = null;
+  private _remoteShellProfileInFlight: Promise<RemoteShellProfile> | null = null;
 
   /** Called by SshConnectionManager when a connection becomes ready. */
   update(client: Client): void {
     this._client = client;
   }
 
-  /**
-   * Called by SshConnectionManager after the connection is ready with the
-   * remote machine's login-shell environment. Stored here so downstream
-   * consumers (probers, providers) can use it without re-capturing per command.
-   */
-  updateRemoteEnv(env: Record<string, string>): void {
-    this._remoteEnv = env;
+  getRemoteShellProfile(): Promise<RemoteShellProfile> {
+    if (this._remoteShellProfile) return Promise.resolve(this._remoteShellProfile);
+    if (!this._remoteShellProfileInFlight) {
+      this._remoteShellProfileInFlight = captureRemoteShellProfile(this.client)
+        .then((profile) => {
+          this._remoteShellProfile = profile;
+          return profile;
+        })
+        .finally(() => {
+          this._remoteShellProfileInFlight = null;
+        });
+    }
+    return this._remoteShellProfileInFlight;
   }
 
   /** Called by SshConnectionManager when the connection drops. */
   invalidate(): void {
     this._client = null;
-    this._remoteEnv = null;
-  }
-
-  /**
-   * The remote machine's login-shell environment, captured once after the
-   * connection becomes ready. `null` until the capture completes or if
-   * capture failed — callers should fall back to `bash -l -c` in that case.
-   */
-  get remoteEnv(): Record<string, string> | null {
-    return this._remoteEnv;
+    this._remoteShellProfile = null;
+    this._remoteShellProfileInFlight = null;
   }
 
   /**

--- a/src/main/core/ssh/ssh-client-proxy.ts
+++ b/src/main/core/ssh/ssh-client-proxy.ts
@@ -1,6 +1,11 @@
 import type { Client } from 'ssh2';
 import { captureRemoteShellProfile, type RemoteShellProfile } from './remote-shell-profile';
 
+type RemoteShellProfileState =
+  | { kind: 'empty' }
+  | { kind: 'loading'; client: Client; promise: Promise<RemoteShellProfile> }
+  | { kind: 'ready'; client: Client; profile: RemoteShellProfile };
+
 /**
  * Stable reference to an ssh2 Client that survives reconnects.
  *
@@ -13,34 +18,45 @@ import { captureRemoteShellProfile, type RemoteShellProfile } from './remote-she
  */
 export class SshClientProxy {
   private _client: Client | null = null;
-  private _remoteShellProfile: RemoteShellProfile | null = null;
-  private _remoteShellProfileInFlight: Promise<RemoteShellProfile> | null = null;
+  private _remoteShellProfileState: RemoteShellProfileState = { kind: 'empty' };
 
   /** Called by SshConnectionManager when a connection becomes ready. */
   update(client: Client): void {
+    if (this._client !== client) {
+      this._remoteShellProfileState = { kind: 'empty' };
+    }
     this._client = client;
   }
 
-  getRemoteShellProfile(): Promise<RemoteShellProfile> {
-    if (this._remoteShellProfile) return Promise.resolve(this._remoteShellProfile);
-    if (!this._remoteShellProfileInFlight) {
-      this._remoteShellProfileInFlight = captureRemoteShellProfile(this.client)
-        .then((profile) => {
-          this._remoteShellProfile = profile;
-          return profile;
-        })
-        .finally(() => {
-          this._remoteShellProfileInFlight = null;
-        });
+  async getRemoteShellProfile(): Promise<RemoteShellProfile> {
+    const client = this.client;
+    const state = this._remoteShellProfileState;
+
+    if (state.kind === 'ready' && state.client === client) {
+      return state.profile;
     }
-    return this._remoteShellProfileInFlight;
+    if (state.kind === 'loading' && state.client === client) {
+      return state.promise;
+    }
+
+    const promise = captureRemoteShellProfile(client).then((profile) => {
+      if (
+        this._client === client &&
+        this._remoteShellProfileState.kind === 'loading' &&
+        this._remoteShellProfileState.promise === promise
+      ) {
+        this._remoteShellProfileState = { kind: 'ready', client, profile };
+      }
+      return profile;
+    });
+    this._remoteShellProfileState = { kind: 'loading', client, promise };
+    return promise;
   }
 
   /** Called by SshConnectionManager when the connection drops. */
   invalidate(): void {
     this._client = null;
-    this._remoteShellProfile = null;
-    this._remoteShellProfileInFlight = null;
+    this._remoteShellProfileState = { kind: 'empty' };
   }
 
   /**

--- a/src/main/core/ssh/ssh-connection-manager.ts
+++ b/src/main/core/ssh/ssh-connection-manager.ts
@@ -7,7 +7,6 @@ import { db } from '@main/db/client';
 import { sshConnections } from '@main/db/schema';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
-import { parseRemoteEnvOutput } from '@main/utils/userEnv';
 import { buildConnectConfigFromRow } from './build-connect-config';
 import { SshClientProxy } from './ssh-client-proxy';
 
@@ -285,10 +284,10 @@ export class SshConnectionManager extends EventEmitter {
 
         proxy.update(client);
 
-        // Capture the remote login-shell env once, non-blocking. Failures are
+        // Capture the remote login-shell profile once, non-blocking. Failures are
         // warned but do not prevent the connection from being used.
-        this.captureRemoteEnv(proxy).catch((err: unknown) => {
-          log.warn('SshConnectionManager: remote env capture failed', {
+        proxy.getRemoteShellProfile().catch((err: unknown) => {
+          log.warn('SshConnectionManager: remote shell profile capture failed', {
             connectionId: id,
             error: err instanceof Error ? err.message : String(err),
           });
@@ -312,43 +311,6 @@ export class SshConnectionManager extends EventEmitter {
       });
 
       client.connect(config);
-    });
-  }
-
-  /**
-   * Runs `bash -l -c 'env'` on the remote machine and stores the result on
-   * the proxy. This is a one-shot operation per connection — callers that need
-   * the remote env before the capture completes can fall back to `bash -l -c`
-   * wrappers on individual commands.
-   */
-  private captureRemoteEnv(proxy: SshClientProxy): Promise<void> {
-    const TIMEOUT_MS = 5_000;
-    return new Promise((resolve, reject) => {
-      const timer = setTimeout(() => {
-        reject(new Error('remote env capture timed out'));
-      }, TIMEOUT_MS);
-
-      proxy.client.exec("bash -l -c 'env'", (execErr, stream) => {
-        if (execErr) {
-          clearTimeout(timer);
-          reject(execErr);
-          return;
-        }
-
-        let stdout = '';
-        stream.on('data', (chunk: Buffer) => {
-          stdout += chunk.toString('utf-8');
-        });
-        stream.on('close', () => {
-          clearTimeout(timer);
-          proxy.updateRemoteEnv(parseRemoteEnvOutput(stdout));
-          resolve();
-        });
-        stream.on('error', (err: Error) => {
-          clearTimeout(timer);
-          reject(err);
-        });
-      });
     });
   }
 

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -146,7 +146,8 @@ export class SshTerminalProvider implements TerminalProvider {
       args: command?.args,
     };
 
-    const sshCommand = resolveSshCommand('general', cfg, this.taskEnvVars);
+    const profile = await this.proxy.getRemoteShellProfile();
+    const sshCommand = resolveSshCommand('general', cfg, this.taskEnvVars, profile);
 
     const result = await openSsh2Pty(this.proxy.client, {
       id: sessionId,

--- a/src/main/utils/userEnv.ts
+++ b/src/main/utils/userEnv.ts
@@ -30,6 +30,12 @@ const PRESERVE_KEYS = new Set([
   'NODE_ENV',
 ]);
 
+export const SHELL_ENV_CAPTURE_GUARD: Record<string, string> = {
+  DISABLE_AUTO_UPDATE: 'true',
+  ZSH_TMUX_AUTOSTART: 'false',
+  ZSH_TMUX_AUTOSTARTED: 'true',
+};
+
 const USER_BIN_DIRS = [path.join(os.homedir(), '.local', 'bin')];
 
 function pathEntryExists(entry: string): boolean {
@@ -115,11 +121,7 @@ export async function resolveUserEnv(): Promise<void> {
       timeout: 5_000,
       env: {
         ...process.env,
-        // Prevent oh-my-zsh and tmux plugins from producing extra output or
-        // blocking the env capture.
-        DISABLE_AUTO_UPDATE: 'true',
-        ZSH_TMUX_AUTOSTART: 'false',
-        ZSH_TMUX_AUTOSTARTED: 'true',
+        ...SHELL_ENV_CAPTURE_GUARD,
       },
     });
 


### PR DESCRIPTION
issue:
- SSH remote projects hardcoded bash -l -c for many command paths.
- on macOS remotes, users usually run zsh, and agent CLIs often depend on zsh-configured PATH entries

fix:
- detect the remote $SHELL
- capture its shell environment once per SSH connection
- cache it on SshClientProxy
- invalidate on reconnect
- updated SSH command consumers to use the shared remote shell profile instead of assuming bash

closes #1867 