### PR TITLE
fix: default branch resolution for project base refs

### DIFF
--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -1455,19 +1455,11 @@ export class GitService implements GitProvider, IDisposable {
     }
 
     let remoteName: string | undefined;
-    let remote: string | undefined;
     try {
       const { stdout } = await this.ctx.exec('git', ['remote']);
       const remotes = stdout.trim().split('\n').filter(Boolean);
       remoteName = remotes.includes('origin') ? 'origin' : remotes[0];
     } catch {}
-
-    if (remoteName) {
-      try {
-        const { stdout } = await this.ctx.exec('git', ['remote', 'get-url', remoteName]);
-        remote = stdout.trim() || undefined;
-      } catch {}
-    }
 
     let branch: string | undefined;
     try {
@@ -1492,8 +1484,6 @@ export class GitService implements GitProvider, IDisposable {
 
     return {
       isGitRepo: true,
-      remote,
-      branch,
       baseRef: computeBaseRef(undefined, remoteName, branch),
       rootPath,
     };

--- a/src/main/core/git/repository-service.ts
+++ b/src/main/core/git/repository-service.ts
@@ -12,7 +12,7 @@ import type {
   RemoteBranchesPayload,
   RenameBranchError,
 } from '@shared/git';
-import { computeDefaultBranch, selectPreferredRemote } from '@shared/git-utils';
+import { selectPreferredRemote } from '@shared/git-utils';
 import type { ProjectRemoteState } from '@shared/projects';
 import type { Result } from '@shared/result';
 import type { ProjectSettingsProvider } from '@main/core/projects/settings/schema';
@@ -30,14 +30,6 @@ export class GitRepositoryService {
       this.git.getRemotes().catch(() => []),
     ]);
     return selectPreferredRemote(configured, remotes).name;
-  }
-
-  async getDefaultBranchName(): Promise<string> {
-    const configured = await this.settings.getDefaultBranch();
-    const remote = await this.getConfiguredRemote();
-    const branches = await this.git.getBranches();
-    const gitDefault = await this.git.getDefaultBranch(remote);
-    return computeDefaultBranch(configured, branches, remote, gitDefault);
   }
 
   async getRepositoryInfo(): Promise<{ isUnborn: boolean; currentBranch: string | null }> {

--- a/src/main/core/projects/operations/createProject.test.ts
+++ b/src/main/core/projects/operations/createProject.test.ts
@@ -6,6 +6,8 @@ import { createLocalProject, createSshProject, getSshProjectPathStatus } from '.
 
 const mocks = vi.hoisted(() => ({
   detectInfoMock: vi.fn(),
+  getBranchesMock: vi.fn(),
+  getDefaultBranchMock: vi.fn(),
   initRepositoryMock: vi.fn(),
   openProjectMock: vi.fn(),
   getProjectMock: vi.fn(),
@@ -20,6 +22,8 @@ vi.mock('@main/core/git/impl/git-service', () => ({
   GitService: vi.fn(function MockGitService() {
     return {
       detectInfo: mocks.detectInfoMock,
+      getBranches: mocks.getBranchesMock,
+      getDefaultBranch: mocks.getDefaultBranchMock,
       initRepository: mocks.initRepositoryMock,
     };
   }),
@@ -59,6 +63,8 @@ beforeEach(() => {
   mocks.valuesMock.mockReturnValue({ returning: mocks.returningMock });
   mocks.openProjectMock.mockResolvedValue(undefined);
   mocks.getProjectMock.mockReturnValue(undefined);
+  mocks.getBranchesMock.mockResolvedValue([]);
+  mocks.getDefaultBranchMock.mockResolvedValue('main');
   mocks.initRepositoryMock.mockResolvedValue(undefined);
   mocks.sshConnectMock.mockResolvedValue({ id: 'ssh-proxy' });
   mocks.sshStatMock.mockResolvedValue({ path: '', type: 'dir' });
@@ -172,6 +178,84 @@ describe('createLocalProject', () => {
     expect(mocks.initRepositoryMock).not.toHaveBeenCalled();
     expect(mocks.detectInfoMock).toHaveBeenCalledTimes(1);
   });
+
+  it('stores the git remote default branch as baseRef instead of the current feature branch', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-project-'));
+    tempDirs.push(projectPath);
+    const row = {
+      id: 'project-id',
+      name: 'Project',
+      path: projectPath,
+      baseRef: 'origin/main',
+      createdAt: '2026-04-16T00:00:00.000Z',
+      updatedAt: '2026-04-16T00:00:00.000Z',
+    };
+
+    mocks.detectInfoMock.mockResolvedValue({
+      isGitRepo: true,
+      baseRef: 'origin/feature/current',
+      rootPath: projectPath,
+    });
+    mocks.getDefaultBranchMock.mockResolvedValue('main');
+    mocks.getBranchesMock.mockResolvedValue([
+      {
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin', url: 'git@github.com:example/repo.git' },
+      },
+    ]);
+    mocks.returningMock.mockResolvedValue([row]);
+
+    const created = await createLocalProject({
+      id: 'project-id',
+      name: 'Project',
+      path: projectPath,
+    });
+
+    expect(mocks.valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ baseRef: 'origin/main' })
+    );
+    expect(created.baseRef).toBe('origin/main');
+  });
+
+  it('keeps the detected baseRef when the git default branch is not present on the remote', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-project-'));
+    tempDirs.push(projectPath);
+    const row = {
+      id: 'project-id',
+      name: 'Project',
+      path: projectPath,
+      baseRef: 'origin/feature/current',
+      createdAt: '2026-04-16T00:00:00.000Z',
+      updatedAt: '2026-04-16T00:00:00.000Z',
+    };
+
+    mocks.detectInfoMock.mockResolvedValue({
+      isGitRepo: true,
+      baseRef: 'origin/feature/current',
+      rootPath: projectPath,
+    });
+    mocks.getDefaultBranchMock.mockResolvedValue('main');
+    mocks.getBranchesMock.mockResolvedValue([
+      {
+        type: 'remote',
+        branch: 'develop',
+        remote: { name: 'origin', url: 'git@github.com:example/repo.git' },
+      },
+    ]);
+    mocks.returningMock.mockResolvedValue([row]);
+
+    const created = await createLocalProject({
+      id: 'project-id',
+      name: 'Project',
+      path: projectPath,
+    });
+
+    expect(mocks.valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ baseRef: 'origin/feature/current' })
+    );
+    expect(created.baseRef).toBe('origin/feature/current');
+  });
 });
 
 describe('createSshProject', () => {
@@ -261,6 +345,40 @@ describe('createSshProject', () => {
 
     expect(mocks.detectInfoMock).not.toHaveBeenCalled();
     expect(mocks.initRepositoryMock).not.toHaveBeenCalled();
+  });
+
+  it('stores the git remote default branch as the SSH project baseRef', async () => {
+    const rowWithDefault = {
+      ...row,
+      baseRef: 'origin/main',
+    };
+
+    mocks.detectInfoMock.mockResolvedValue({
+      isGitRepo: true,
+      baseRef: 'origin/feature/current',
+      rootPath: row.path,
+    });
+    mocks.getDefaultBranchMock.mockResolvedValue('main');
+    mocks.getBranchesMock.mockResolvedValue([
+      {
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin', url: 'git@github.com:example/repo.git' },
+      },
+    ]);
+    mocks.returningMock.mockResolvedValue([rowWithDefault]);
+
+    const created = await createSshProject({
+      id: 'project-id',
+      name: 'Project',
+      path: projectPath,
+      connectionId: 'connection-id',
+    });
+
+    expect(mocks.valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({ baseRef: 'origin/main' })
+    );
+    expect(created.baseRef).toBe('origin/main');
   });
 });
 

--- a/src/main/core/projects/operations/createProject.ts
+++ b/src/main/core/projects/operations/createProject.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { sql } from 'drizzle-orm';
+import { remoteNameFromQualifiedRef, resolveBaseRefFromRemoteDefault } from '@shared/git-utils';
 import { type LocalProject, type ProjectPathStatus, type SshProject } from '@shared/projects';
 import { GitHubAuthExecutionContext } from '@main/core/execution-context/github-auth-execution-context';
 import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
@@ -13,7 +14,28 @@ import { projectManager } from '@main/core/projects/project-manager';
 import { sshConnectionManager } from '@main/core/ssh/ssh-connection-manager';
 import { db } from '@main/db/client';
 import { projects } from '@main/db/schema';
+import { log } from '@main/lib/logger';
 import { checkIsValidDirectory } from '../path-utils';
+
+async function resolveProjectBaseRef(git: GitService, detectedBaseRef: string): Promise<string> {
+  const remoteName = remoteNameFromQualifiedRef(detectedBaseRef);
+  if (!remoteName) return detectedBaseRef;
+
+  try {
+    const [gitDefaultBranch, branches] = await Promise.all([
+      git.getDefaultBranch(remoteName),
+      git.getBranches(),
+    ]);
+    return resolveBaseRefFromRemoteDefault({ detectedBaseRef, gitDefaultBranch, branches });
+  } catch (error) {
+    log.debug('Failed to resolve project base ref, using detected base ref', {
+      detectedBaseRef,
+      error,
+    });
+  }
+
+  return detectedBaseRef;
+}
 
 async function ensureGitRepository(
   git: GitService,
@@ -53,6 +75,7 @@ export async function createLocalProject(params: CreateLocalProjectParams): Prom
   const authCtx = new GitHubAuthExecutionContext(baseCtx, () => githubConnectionService.getToken());
   const git = new GitService(baseCtx, authCtx, fs);
   const gitInfo = await ensureGitRepository(git, params.initGitRepository);
+  const baseRef = await resolveProjectBaseRef(git, gitInfo.baseRef);
 
   const [row] = await db
     .insert(projects)
@@ -61,7 +84,7 @@ export async function createLocalProject(params: CreateLocalProjectParams): Prom
       name: params.name,
       path: gitInfo.rootPath,
       workspaceProvider: 'local',
-      baseRef: gitInfo.baseRef,
+      baseRef,
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .returning();
@@ -71,7 +94,7 @@ export async function createLocalProject(params: CreateLocalProjectParams): Prom
     id: row.id,
     name: row.name,
     path: row.path,
-    baseRef: row.baseRef ?? gitInfo.baseRef,
+    baseRef: row.baseRef ?? baseRef,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };
@@ -119,6 +142,7 @@ export async function createSshProject(params: CreateSshProjectParams): Promise<
   const git = new GitService(baseSshCtx, authSshCtx, sshFs);
 
   const gitInfo = await ensureGitRepository(git, params.initGitRepository);
+  const baseRef = await resolveProjectBaseRef(git, gitInfo.baseRef);
 
   const [row] = await db
     .insert(projects)
@@ -128,7 +152,7 @@ export async function createSshProject(params: CreateSshProjectParams): Promise<
       path: gitInfo.rootPath,
       workspaceProvider: 'ssh',
       sshConnectionId: params.connectionId,
-      baseRef: gitInfo.baseRef,
+      baseRef,
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
     .returning();
@@ -139,7 +163,7 @@ export async function createSshProject(params: CreateSshProjectParams): Promise<
     name: row.name,
     path: row.path,
     connectionId: params.connectionId,
-    baseRef: row.baseRef ?? gitInfo.baseRef,
+    baseRef: row.baseRef ?? baseRef,
     createdAt: row.createdAt,
     updatedAt: row.updatedAt,
   };

--- a/src/renderer/features/projects/stores/repository-store.ts
+++ b/src/renderer/features/projects/stores/repository-store.ts
@@ -1,13 +1,14 @@
 import { computed, makeObservable, reaction } from 'mobx';
 import { gitRefChangedChannel, type GitRefChange } from '@shared/events/gitEvents';
 import type {
+  Branch,
   LocalBranch,
   LocalBranchesPayload,
   Remote,
   RemoteBranch,
   RemoteBranchesPayload,
 } from '@shared/git';
-import { bareRefName, computeDefaultBranch, selectPreferredRemote } from '@shared/git-utils';
+import { resolveDefaultBranch, selectPreferredRemote } from '@shared/git-utils';
 import { parseGitHubRepository } from '@shared/github-repository';
 import { events, rpc } from '@renderer/lib/ipc';
 import { Resource } from '@renderer/lib/stores/resource';
@@ -78,7 +79,6 @@ export class RepositoryStore {
       localBranches: computed,
       remoteBranches: computed,
       configuredRemote: computed,
-      defaultBranchName: computed,
       defaultBranch: computed,
       remotes: computed,
       loading: computed,
@@ -140,38 +140,35 @@ export class RepositoryStore {
     return parseGitHubRepository(url)?.repositoryUrl ?? null;
   }
 
-  get defaultBranchName(): string {
-    const d = this.remoteData.data;
-    if (!d) return 'main';
+  private get defaultBranchPreference(): Branch | undefined {
     const raw = this.settingsStore.settings?.defaultBranch;
-    const configured =
-      raw === undefined ? bareRefName(this.baseRef) : typeof raw === 'string' ? raw : raw.name;
-    return computeDefaultBranch(
-      configured,
-      this.branches,
-      this.configuredRemote.name,
-      d.gitDefaultBranch
-    );
+    if (raw === undefined) return undefined;
+    if (typeof raw === 'string') return { type: 'local', branch: raw };
+    return { type: 'remote', branch: raw.name, remote: this.configuredRemote };
   }
 
   get defaultBranch(): LocalBranch | RemoteBranch | undefined {
-    const name = this.defaultBranchName;
-    const raw = this.settingsStore.settings?.defaultBranch;
-    const isRemotePref = typeof raw === 'object' && raw.remote === true;
-
-    if (isRemotePref) {
-      const remote = this.remoteBranches.find(
-        (b) => b.branch === name && b.remote.name === this.configuredRemote.name
-      );
-      if (remote) return remote;
-    }
-    const local = this.localBranches.find((b) => b.branch === name);
-    if (local) return local;
-    return this.remoteBranches.find((b) => b.branch === name);
+    const d = this.remoteData.data;
+    if (!d) return undefined;
+    return resolveDefaultBranch({
+      preference: this.defaultBranchPreference,
+      branches: this.branches,
+      configuredRemoteName: this.configuredRemote.name,
+      gitDefaultBranch: d.gitDefaultBranch,
+      baseRef: this.baseRef,
+    });
   }
 
   isDefault(branch: LocalBranch | RemoteBranch): boolean {
-    return branch.branch === this.defaultBranchName;
+    const defaultBranch = this.defaultBranch;
+    if (!defaultBranch) return false;
+    if (branch.type !== defaultBranch.type) return false;
+    if (branch.type === 'remote' && defaultBranch.type === 'remote') {
+      return (
+        branch.branch === defaultBranch.branch && branch.remote.name === defaultBranch.remote.name
+      );
+    }
+    return branch.branch === defaultBranch.branch;
   }
 
   isBranchOnRemote(branchName: string): boolean {

--- a/src/renderer/features/projects/stores/repository-store.ts
+++ b/src/renderer/features/projects/stores/repository-store.ts
@@ -72,13 +72,14 @@ export class RepositoryStore {
       () => this.remoteData.invalidate()
     );
 
-    makeObservable(this, {
+    makeObservable<this, 'defaultBranchPreference'>(this, {
       isUnborn: computed,
       currentBranch: computed,
       branches: computed,
       localBranches: computed,
       remoteBranches: computed,
       configuredRemote: computed,
+      defaultBranchPreference: computed,
       defaultBranch: computed,
       remotes: computed,
       loading: computed,

--- a/src/renderer/lib/components/branch-selector.tsx
+++ b/src/renderer/lib/components/branch-selector.tsx
@@ -17,6 +17,12 @@ import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { cn } from '@renderer/utils/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 
+type BranchSelectorTab = 'local' | 'remote';
+
+function getBranchLabel(branch: Branch): string {
+  return branch.type === 'remote' ? `${branch.remote.name}/${branch.branch}` : branch.branch;
+}
+
 interface BranchSelectorProps {
   branches: Branch[];
   value?: Branch;
@@ -36,7 +42,8 @@ export function BranchSelector({
   onRefresh,
   isRefreshing = false,
 }: BranchSelectorProps) {
-  const [tab, setTab] = useState<'local' | 'remote'>(remoteOnly ? 'remote' : 'local');
+  const [tabOverride, setTabOverride] = useState<BranchSelectorTab | undefined>(undefined);
+  const tab = remoteOnly ? 'remote' : (tabOverride ?? value?.type ?? 'local');
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const localCount = useMemo(() => branches.filter((b) => b.type === 'local').length, [branches]);
@@ -45,7 +52,12 @@ export function BranchSelector({
   const filteredBranches = useMemo(() => branches.filter((b) => b.type === tab), [branches, tab]);
 
   const options = useMemo(
-    () => filteredBranches.map((branch) => ({ value: branch, label: branch.branch })),
+    () =>
+      filteredBranches.map((branch) => ({
+        value: branch,
+        label: getBranchLabel(branch),
+        disabled: branch.branch.startsWith('_reserve'),
+      })),
     [filteredBranches]
   );
 
@@ -53,7 +65,14 @@ export function BranchSelector({
     <Combobox
       items={options}
       autoHighlight
-      value={value ? { value: value, label: value.branch } : undefined}
+      value={
+        value
+          ? {
+              value,
+              label: getBranchLabel(value),
+            }
+          : undefined
+      }
       onValueChange={(v) => v !== null && onValueChange(v.value)}
       isItemEqualToValue={(a, b) => {
         if (a.value.type !== b.value.type) return false;
@@ -78,7 +97,7 @@ export function BranchSelector({
             value={[tab]}
             onValueChange={([value]) => {
               if (value) {
-                setTab(value as 'local' | 'remote');
+                setTabOverride(value as BranchSelectorTab);
                 inputRef.current?.focus();
               }
             }}
@@ -134,7 +153,7 @@ export function BranchSelector({
         />
         <ComboboxList>
           {(item) => (
-            <ComboboxItem value={item} disabled={item.label.startsWith('_reserve')}>
+            <ComboboxItem value={item} disabled={item.disabled}>
               {item.label}
             </ComboboxItem>
           )}

--- a/src/renderer/lib/components/branch-selector.tsx
+++ b/src/renderer/lib/components/branch-selector.tsx
@@ -42,8 +42,15 @@ export function BranchSelector({
   onRefresh,
   isRefreshing = false,
 }: BranchSelectorProps) {
-  const [tabOverride, setTabOverride] = useState<BranchSelectorTab | undefined>(undefined);
-  const tab = remoteOnly ? 'remote' : (tabOverride ?? value?.type ?? 'local');
+  const valueKey =
+    value?.type === 'remote'
+      ? `${value.type}:${value.remote.name}/${value.branch}`
+      : `${value?.type ?? 'none'}:${value?.branch ?? ''}`;
+  const [tabOverride, setTabOverride] = useState<
+    { tab: BranchSelectorTab; valueKey: string } | undefined
+  >(undefined);
+  const overriddenTab = tabOverride?.valueKey === valueKey ? tabOverride.tab : undefined;
+  const tab = remoteOnly ? 'remote' : (overriddenTab ?? value?.type ?? 'local');
   const inputRef = React.useRef<HTMLInputElement>(null);
 
   const localCount = useMemo(() => branches.filter((b) => b.type === 'local').length, [branches]);
@@ -97,7 +104,7 @@ export function BranchSelector({
             value={[tab]}
             onValueChange={([value]) => {
               if (value) {
-                setTabOverride(value as BranchSelectorTab);
+                setTabOverride({ tab: value as BranchSelectorTab, valueKey });
                 inputRef.current?.focus();
               }
             }}

--- a/src/shared/git-utils.test.ts
+++ b/src/shared/git-utils.test.ts
@@ -1,0 +1,112 @@
+import { describe, expect, it } from 'vitest';
+import type { Branch } from './git';
+import { resolveBaseRefFromRemoteDefault, resolveDefaultBranch } from './git-utils';
+
+const origin = { name: 'origin', url: 'git@github.com:example/repo.git' };
+const fork = { name: 'fork', url: 'git@github.com:user/repo.git' };
+
+const branches: Branch[] = [
+  { type: 'local', branch: 'feature/current' },
+  { type: 'local', branch: 'develop' },
+  { type: 'remote', branch: 'main', remote: origin },
+  { type: 'remote', branch: 'develop', remote: origin },
+  { type: 'remote', branch: 'main', remote: fork },
+];
+
+describe('resolveDefaultBranch', () => {
+  it('prefers a valid explicit project default over the remote default', () => {
+    const preference: Branch = { type: 'local', branch: 'develop' };
+
+    expect(
+      resolveDefaultBranch({
+        preference,
+        branches,
+        configuredRemoteName: 'origin',
+        gitDefaultBranch: 'main',
+      })
+    ).toEqual({ type: 'local', branch: 'develop' });
+  });
+
+  it('prefers the configured remote default when there is no explicit project default', () => {
+    expect(
+      resolveDefaultBranch({
+        branches,
+        configuredRemoteName: 'origin',
+        gitDefaultBranch: 'main',
+        baseRef: 'origin/feature/current',
+      })
+    ).toEqual({ type: 'remote', branch: 'main', remote: origin });
+  });
+
+  it('uses baseRef only when the remote default cannot be resolved', () => {
+    expect(
+      resolveDefaultBranch({
+        branches,
+        configuredRemoteName: 'origin',
+        gitDefaultBranch: 'release',
+        baseRef: 'origin/feature/current',
+      })
+    ).toEqual({ type: 'local', branch: 'feature/current' });
+  });
+
+  it('falls back to an existing conventional branch instead of inventing origin/main', () => {
+    expect(
+      resolveDefaultBranch({
+        branches: [{ type: 'local', branch: 'master' }],
+        configuredRemoteName: 'origin',
+        gitDefaultBranch: 'main',
+        baseRef: 'origin/missing',
+      })
+    ).toEqual({ type: 'local', branch: 'master' });
+  });
+
+  it('returns undefined when no candidate resolves to an existing branch', () => {
+    expect(
+      resolveDefaultBranch({
+        branches: [],
+        configuredRemoteName: 'origin',
+        gitDefaultBranch: 'main',
+        baseRef: 'origin/feature/current',
+      })
+    ).toBeUndefined();
+  });
+
+  it('uses the explicit remote preference even when another remote is configured', () => {
+    const preference: Branch = {
+      type: 'remote',
+      branch: 'main',
+      remote: fork,
+    };
+
+    expect(
+      resolveDefaultBranch({
+        preference,
+        branches,
+        configuredRemoteName: 'origin',
+        gitDefaultBranch: 'develop',
+      })
+    ).toEqual({ type: 'remote', branch: 'main', remote: fork });
+  });
+});
+
+describe('resolveBaseRefFromRemoteDefault', () => {
+  it('replaces a detected feature baseRef with the remote default when it exists', () => {
+    expect(
+      resolveBaseRefFromRemoteDefault({
+        detectedBaseRef: 'origin/feature/current',
+        gitDefaultBranch: 'main',
+        branches,
+      })
+    ).toBe('origin/main');
+  });
+
+  it('keeps the detected baseRef when the remote default does not exist', () => {
+    expect(
+      resolveBaseRefFromRemoteDefault({
+        detectedBaseRef: 'origin/feature/current',
+        gitDefaultBranch: 'release',
+        branches,
+      })
+    ).toBe('origin/feature/current');
+  });
+});

--- a/src/shared/git-utils.ts
+++ b/src/shared/git-utils.ts
@@ -24,25 +24,100 @@ export function bareRefName(ref: string): string {
   return slash !== -1 ? ref.slice(slash + 1) : ref;
 }
 
-/**
- * Resolves the canonical default branch name from user settings, the branch
- * list, and the git-heuristic fallback. Shared between main and renderer.
- *
- * @param configured - Already-resolved user preference (settings.defaultBranch ?? bareRefName(baseRef))
- * @param branches   - Full branch list (local + remote)
- * @param remote     - The configured remote name
- * @param gitDefaultBranch - Git-heuristic default (symbolic-ref / remote show / well-known names)
- */
-export function computeDefaultBranch(
-  configured: string,
-  branches: Branch[],
-  remote: string,
-  gitDefaultBranch: string
-): string {
-  const existsLocally = branches.some((b) => b.type === 'local' && b.branch === configured);
-  const isOnRemote = branches.some(
-    (b) => b.type === 'remote' && b.branch === configured && b.remote.name === remote
+type DefaultBranchResolutionArgs<TBranch extends Branch = Branch> = {
+  preference?: Branch;
+  branches: ReadonlyArray<TBranch>;
+  configuredRemoteName: string;
+  gitDefaultBranch?: string;
+  baseRef?: string;
+};
+
+type BaseRefResolutionArgs = {
+  detectedBaseRef: string;
+  gitDefaultBranch?: string;
+  branches: ReadonlyArray<Branch>;
+};
+
+function findLocalBranch<TBranch extends Branch>(
+  branches: ReadonlyArray<TBranch>,
+  branchName: string
+): TBranch | undefined {
+  return branches.find((b) => b.type === 'local' && b.branch === branchName);
+}
+
+function findRemoteBranch<TBranch extends Branch>(
+  branches: ReadonlyArray<TBranch>,
+  branchName: string,
+  remoteName: string
+): TBranch | undefined {
+  return branches.find(
+    (b) => b.type === 'remote' && b.branch === branchName && b.remote.name === remoteName
   );
-  if (existsLocally || isOnRemote) return configured;
-  return gitDefaultBranch;
+}
+
+function findAnyBranch<TBranch extends Branch>(
+  branches: ReadonlyArray<TBranch>,
+  branchName: string,
+  remoteName: string
+): TBranch | undefined {
+  return (
+    findLocalBranch(branches, branchName) ?? findRemoteBranch(branches, branchName, remoteName)
+  );
+}
+
+function resolvePreference<TBranch extends Branch>(
+  preference: Branch | undefined,
+  branches: ReadonlyArray<TBranch>,
+  configuredRemoteName: string
+): TBranch | undefined {
+  if (!preference) return undefined;
+  return preference.type === 'remote'
+    ? findRemoteBranch(branches, preference.branch, preference.remote.name)
+    : (findLocalBranch(branches, preference.branch) ??
+        findRemoteBranch(branches, preference.branch, configuredRemoteName));
+}
+
+export function remoteNameFromQualifiedRef(ref: string): string | undefined {
+  const trimmed = ref.trim();
+  const slash = trimmed.indexOf('/');
+  if (slash <= 0) return undefined;
+  return trimmed.slice(0, slash);
+}
+
+export function resolveDefaultBranch<TBranch extends Branch = Branch>(
+  args: DefaultBranchResolutionArgs<TBranch>
+): TBranch | undefined {
+  const { preference, branches, configuredRemoteName, gitDefaultBranch, baseRef } = args;
+
+  const explicit = resolvePreference(preference, branches, configuredRemoteName);
+  if (explicit) return explicit;
+
+  const remoteDefault = gitDefaultBranch?.trim()
+    ? findRemoteBranch(branches, bareRefName(gitDefaultBranch), configuredRemoteName)
+    : undefined;
+  if (remoteDefault) return remoteDefault;
+
+  const trimmedBaseRef = baseRef?.trim();
+  const baseBranch = trimmedBaseRef ? bareRefName(trimmedBaseRef) : undefined;
+  const base = baseBranch ? findAnyBranch(branches, baseBranch, configuredRemoteName) : undefined;
+  if (base) return base;
+
+  for (const candidate of ['main', 'master', 'develop', 'trunk']) {
+    const branch = findAnyBranch(branches, candidate, configuredRemoteName);
+    if (branch) return branch;
+  }
+
+  return undefined;
+}
+
+export function resolveBaseRefFromRemoteDefault(args: BaseRefResolutionArgs): string {
+  const remoteName = remoteNameFromQualifiedRef(args.detectedBaseRef);
+  if (!remoteName) return args.detectedBaseRef;
+
+  const defaultBranch = args.gitDefaultBranch?.trim();
+  if (!defaultBranch) return args.detectedBaseRef;
+
+  const defaultBranchName = bareRefName(defaultBranch);
+  const remoteDefault = findRemoteBranch(args.branches, defaultBranchName, remoteName);
+  return remoteDefault ? `${remoteName}/${defaultBranchName}` : args.detectedBaseRef;
 }

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -27,8 +27,6 @@ export interface DiffResult {
 
 export interface GitInfo {
   isGitRepo: boolean;
-  remote?: string;
-  branch?: string;
   baseRef: string;
   rootPath: string;
 }


### PR DESCRIPTION
issue:
- project creation could store the currently checked-out feature branch as baseRef
- default branch resolution used plain strings, making local and remote branches ambiguous
- GitInfo returned unused remote and branch fields and performed an unnecessary remote URL lookup

fix:
- project creation resolves and stores the remote’s actual default branch
- default branch resolution now returns concrete Branch objects and respects explicit local/remote preferences
- remote branch labels now render as remote/branch