### PR TITLE
feat(tasks): run lifecycle script on task creation

### DIFF
--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -11,8 +11,10 @@ import type {
 import { projectManager } from '@main/core/projects/project-manager';
 import { taskEvents } from '@main/core/tasks/task-events';
 import { taskManager } from '@main/core/tasks/task-manager';
+import { runLifecycleScript } from '@main/core/terminals/runLifecycleScript';
 import { db } from '@main/db/client';
 import { tasks } from '@main/db/schema';
+import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import { createConversation } from '../../conversations/createConversation';
 import { prQueryService } from '../../pull-requests/pr-query-service';
@@ -225,6 +227,20 @@ export async function createTask(
     project_id: params.projectId,
     task_id: params.id,
   });
+
+  if (params.runScriptOnCreate) {
+    void runLifecycleScript({
+      projectId: params.projectId,
+      workspaceId: provisionResult.data.persistData.workspaceId,
+      type: 'run',
+    }).catch((error: unknown) => {
+      log.warn('Failed to run task lifecycle script after task creation', {
+        projectId: params.projectId,
+        taskId: params.id,
+        error: String(error),
+      });
+    });
+  }
 
   if (params.initialConversation) {
     await createConversation({

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { getPrNumber, isForkPr, type PullRequest } from '@shared/pull-requests';
 import {
   getProjectManagerStore,
+  getProjectSettingsStore,
   getRepositoryStore,
   mountedProjectData,
 } from '@renderer/features/projects/stores/project-selectors';
@@ -66,6 +67,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   const [selectedStrategy, setSelectedStrategy] = useState<CreateTaskStrategy>(strategy);
   const [isTransitioning, setIsTransitioning] = useState(false);
   const [useBYOI, setUseBYOI] = useState(false);
+  const [runScriptOnCreate, setRunScriptOnCreate] = useState(false);
 
   const projectData = selectedProjectId
     ? mountedProjectData(getProjectManagerStore().projects.get(selectedProjectId))
@@ -75,6 +77,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   const initialConversation = useInitialConversationState(connectionId);
 
   useEffect(() => setUseBYOI(false), [selectedProjectId]);
+  useEffect(() => setRunScriptOnCreate(false), [selectedProjectId]);
   useEffect(() => {
     initialConversation.setProvider(null);
     initialConversation.setPrompt('');
@@ -88,6 +91,10 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   }, [isWorkspaceProviderEnabled]);
 
   const repo = selectedProjectId ? getRepositoryStore(selectedProjectId) : undefined;
+  const projectSettings = selectedProjectId
+    ? getProjectSettingsStore(selectedProjectId)
+    : undefined;
+  const hasRunScript = Boolean(projectSettings?.settings?.scripts?.run?.trim());
   const defaultBranch = repo?.defaultBranch;
   const isUnborn = repo?.isUnborn ?? false;
   const currentBranch = repo?.currentBranch ?? null;
@@ -142,6 +149,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
           sourceBranch: fromBranch.selectedBranch,
           strategy: useBYOI ? { kind: 'no-worktree' } : taskStrategy,
           workspaceProvider: useBYOI ? 'byoi' : undefined,
+          runScriptOnCreate: runScriptOnCreate && hasRunScript,
           initialConversation: builtInitialConversation,
         });
         break;
@@ -162,6 +170,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
           strategy: useBYOI ? { kind: 'no-worktree' } : taskStrategy,
           linkedIssue: fromIssue.linkedIssue ?? undefined,
           workspaceProvider: useBYOI ? 'byoi' : undefined,
+          runScriptOnCreate: runScriptOnCreate && hasRunScript,
           initialConversation: builtInitialConversation,
         });
         break;
@@ -187,6 +196,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
             fromPR.linkedPR.status === 'open' && !fromPR.linkedPR.isDraft ? 'review' : undefined,
           strategy: useBYOI ? { kind: 'no-worktree' } : taskStrategy,
           workspaceProvider: useBYOI ? 'byoi' : undefined,
+          runScriptOnCreate: runScriptOnCreate && hasRunScript,
           initialConversation: builtInitialConversation,
         });
         break;
@@ -203,6 +213,8 @@ export const CreateTaskModal = observer(function CreateTaskModal({
     fromPR,
     isUnborn,
     useBYOI,
+    runScriptOnCreate,
+    hasRunScript,
     initialConversation,
     activeMode.taskName,
     navigate,
@@ -249,6 +261,12 @@ export const CreateTaskModal = observer(function CreateTaskModal({
           <div className="flex items-center gap-2">
             <Switch size="sm" checked={useBYOI} onCheckedChange={setUseBYOI} />
             <span className="text-sm text-muted-foreground">Use BYOI infrastructure</span>
+          </div>
+        )}
+        {hasRunScript && (
+          <div className="flex items-center gap-2">
+            <Switch size="sm" checked={runScriptOnCreate} onCheckedChange={setRunScriptOnCreate} />
+            <span className="text-sm text-muted-foreground">Run script after task creation</span>
           </div>
         )}
         <AnimatedHeight onAnimatingChange={setIsTransitioning}>

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -75,6 +75,7 @@ export type CreateTaskParams = {
   /**  */
   initialConversation?: CreateConversationParams;
   initialStatus?: TaskLifecycleStatus;
+  runScriptOnCreate?: boolean;
   workspaceProvider?: 'byoi';
 };
 


### PR DESCRIPTION
- Adds a create-task checkbox to run the configured Run lifecycle script after provisioning.
- Threads runScriptOnCreate through task creation params.
- Starts the existing lifecycle runner in the main process and logs failures without blocking task creation.

Validation passed: pnpm run format:check, pnpm run typecheck, pnpm run lint, pnpm run test