### PR TITLE
feat: add copy branch action to task menus

### DIFF
--- a/src/renderer/features/projects/components/task-view/task-row.tsx
+++ b/src/renderer/features/projects/components/task-view/task-row.tsx
@@ -55,12 +55,14 @@ export const TaskRow = observer(function TaskRow({
   const canPin = task.state !== 'unregistered';
   const agentAttention = taskAgentStatus(task);
   const currentPr = task.data.prs ? selectCurrentPr(task.data.prs) : undefined;
+  const branchName = task.provisionedTask?.workspace.git.branchName ?? task.data.taskBranch;
 
   return (
     <TaskContextMenu
       isPinned={task.data.isPinned}
       canPin={canPin}
       isArchived={isArchived}
+      branchName={branchName}
       onPin={() => void task.setPinned(true)}
       onUnpin={() => void task.setPinned(false)}
       onRename={handleRename}

--- a/src/renderer/features/projects/components/task-view/task-row.tsx
+++ b/src/renderer/features/projects/components/task-view/task-row.tsx
@@ -6,6 +6,7 @@ import { TaskContextMenu } from '@renderer/features/tasks/components/task-contex
 import { TaskGitDiffStats } from '@renderer/features/tasks/components/task-git-diff-stats';
 import { type TaskStore } from '@renderer/features/tasks/stores/task';
 import {
+  asProvisioned,
   getTaskManagerStore,
   taskAgentStatus,
 } from '@renderer/features/tasks/stores/task-selectors';
@@ -55,7 +56,7 @@ export const TaskRow = observer(function TaskRow({
   const canPin = task.state !== 'unregistered';
   const agentAttention = taskAgentStatus(task);
   const currentPr = task.data.prs ? selectCurrentPr(task.data.prs) : undefined;
-  const branchName = task.provisionedTask?.workspace.git.branchName ?? task.data.taskBranch;
+  const branchName = asProvisioned(task)?.workspace.git.branchName ?? task.data.taskBranch;
 
   return (
     <TaskContextMenu

--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -75,7 +75,11 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
 
   const canPin = task.state !== 'unregistered';
 
-  const workspace = asProvisioned(task)?.workspace;
+  const provisionedTask = asProvisioned(task);
+  const branchName =
+    provisionedTask?.workspace.git.branchName ??
+    ('taskBranch' in task.data ? task.data.taskBranch : undefined);
+  const workspace = provisionedTask?.workspace;
   const handleReconnect =
     workspace?.connectionState != null ? () => workspace.reconnect() : undefined;
 
@@ -84,6 +88,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
       isPinned={task.data.isPinned}
       canPin={canPin}
       isArchived={false}
+      branchName={branchName}
       onPin={() => void task.setPinned(true)}
       onUnpin={() => void task.setPinned(false)}
       onRename={handleRename}

--- a/src/renderer/features/tasks/components/task-context-menu.tsx
+++ b/src/renderer/features/tasks/components/task-context-menu.tsx
@@ -1,5 +1,6 @@
-import { Archive, Pencil, Pin, PinOff, RotateCcw, Trash2 } from 'lucide-react';
+import { Archive, Copy, Pencil, Pin, PinOff, RotateCcw, Trash2 } from 'lucide-react';
 import React from 'react';
+import { toast } from '@renderer/lib/hooks/use-toast';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -13,6 +14,7 @@ interface TaskContextMenuProps {
   isPinned: boolean;
   canPin: boolean;
   isArchived: boolean;
+  branchName?: string;
   onPin: () => void;
   onUnpin: () => void;
   onRename: () => void;
@@ -27,6 +29,7 @@ export function TaskContextMenu({
   isPinned,
   canPin,
   isArchived,
+  branchName,
   onPin,
   onUnpin,
   onRename,
@@ -35,6 +38,21 @@ export function TaskContextMenu({
   onReconnect,
   onDelete,
 }: TaskContextMenuProps) {
+  const handleCopyBranchName = async () => {
+    if (!branchName) return;
+
+    try {
+      await navigator.clipboard.writeText(branchName);
+      toast({ title: 'Branch name copied' });
+    } catch {
+      toast({
+        title: 'Copy failed',
+        description: 'The branch name could not be copied to the clipboard.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   return (
     <ContextMenu>
       <ContextMenuTrigger>{children}</ContextMenuTrigger>
@@ -71,6 +89,12 @@ export function TaskContextMenu({
           <ContextMenuItem onClick={onRestore}>
             <RotateCcw className="size-4" />
             Restore
+          </ContextMenuItem>
+        )}
+        {branchName && (
+          <ContextMenuItem onClick={() => void handleCopyBranchName()}>
+            <Copy className="size-4" />
+            Copy branch name
           </ContextMenuItem>
         )}
         <ContextMenuSeparator />


### PR DESCRIPTION
## Summary
- add a Copy branch name action to the shared task context menu
- surface the action for sidebar task rows and project task list rows when a branch is available
- prefer the live workspace branch and fall back to the stored task branch

## Validation
- pnpm exec prettier --check src/renderer/features/tasks/components/task-context-menu.tsx
- pnpm exec eslint src/renderer/features/tasks/components/task-context-menu.tsx
- pnpm run lint
- pnpm run typecheck
- pnpm run test