### PR TITLE
Rename 'Junie CLI' to 'Junie'

### DIFF
--- a/src/renderer/utils/agentConfig.ts
+++ b/src/renderer/utils/agentConfig.ts
@@ -58,7 +58,7 @@ export const agentConfig: Record<AgentProviderId, AgentInfo> = {
   junie: {
     name: 'Junie',
     logo: junieLogo,
-    alt: 'Junie',
+    alt: 'Junie CLI',
   },
   amp: { name: 'Amp', logo: ampLogo, alt: 'Amp Code' },
   // Without initial prompt support

--- a/src/renderer/utils/agentConfig.ts
+++ b/src/renderer/utils/agentConfig.ts
@@ -56,9 +56,9 @@ export const agentConfig: Record<AgentProviderId, AgentInfo> = {
   continue: { name: 'Continue', logo: continueLogo, alt: 'Continue CLI' },
   codebuff: { name: 'Codebuff', logo: codebuffLogo, alt: 'Codebuff CLI' },
   junie: {
-    name: 'Junie CLI',
+    name: 'Junie',
     logo: junieLogo,
-    alt: 'Junie CLI',
+    alt: 'Junie',
   },
   amp: { name: 'Amp', logo: ampLogo, alt: 'Amp Code' },
   // Without initial prompt support

--- a/src/shared/agent-provider-registry.ts
+++ b/src/shared/agent-provider-registry.ts
@@ -447,7 +447,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     initialPromptFlag: '--task',
     sessionIdFlag: '--session-id',
     icon: 'junie-color.png',
-    alt: 'Junie',
+    alt: 'Junie CLI',
     terminalOnly: true,
   },
   {

--- a/src/shared/agent-provider-registry.ts
+++ b/src/shared/agent-provider-registry.ts
@@ -436,7 +436,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
   },
   {
     id: 'junie',
-    name: 'Junie CLI',
+    name: 'Junie',
     description:
       'JetBrains agentic coding CLI for interactive terminal and headless project workflows.',
     docUrl: 'https://junie.jetbrains.com/docs/junie-cli.html',
@@ -447,7 +447,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     initialPromptFlag: '--task',
     sessionIdFlag: '--session-id',
     icon: 'junie-color.png',
-    alt: 'Junie CLI',
+    alt: 'Junie',
     terminalOnly: true,
   },
   {


### PR DESCRIPTION
## Summary
- Renames "Junie CLI" to "Junie" in the agent provider registry and renderer config, consistent with how every other provider is named (Cursor, Claude Code, Codex, etc.)

## Test plan
- [ ] Verify Junie appears correctly in the agent provider list
- [ ] Verify Junie icon alt text renders properly

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only updates the provider display name for `junie` in UI config and the shared registry; no runtime/CLI flags or detection logic changes.
> 
> **Overview**
> Renames the `junie` provider’s display name from **"Junie CLI"** to **"Junie"** in both the renderer `agentConfig` and the shared `AGENT_PROVIDERS` registry, aligning naming with other providers. No changes to IDs, commands, flags, icons, or alt text.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit edd7f1b18f68010355375ef0ac9c494612c6d4d6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->