### PR TITLE
Confirm integration disconnects

### DIFF
--- a/src/renderer/features/settings/components/IntegrationsCard.tsx
+++ b/src/renderer/features/settings/components/IntegrationsCard.tsx
@@ -63,12 +63,34 @@ const IntegrationsCard: React.FC = () => {
   } = useIntegrationsContext();
 
   const showIntegrationSetup = useShowModal('integrationSetupModal');
+  const showConfirmDisconnect = useShowModal('confirmActionModal');
 
   const isCliManaged = authenticated && tokenSource === 'cli';
 
   useEffect(() => {
     void checkStatus();
   }, [checkStatus]);
+
+  const confirmDisconnect = ({
+    name,
+    credential,
+    onDisconnect,
+  }: {
+    name: string;
+    credential?: string;
+    onDisconnect: () => void | Promise<void>;
+  }) => {
+    showConfirmDisconnect({
+      title: `Disconnect ${name}`,
+      description: credential
+        ? `This will delete the saved ${name} ${credential} and disconnect ${name}.`
+        : `This will disconnect ${name}.`,
+      confirmLabel: 'Disconnect',
+      onSuccess: () => {
+        void onDisconnect();
+      },
+    });
+  };
 
   const integrations = [
     {
@@ -80,7 +102,7 @@ const IntegrationsCard: React.FC = () => {
       loading: isLoading || githubLoading,
       onConnect: handleGithubConnect,
       onCancel: cancelGithubConnect,
-      onDisconnect: logout,
+      onDisconnect: () => confirmDisconnect({ name: 'GitHub', onDisconnect: logout }),
       disabledTooltip: isCliManaged
         ? 'Run `gh auth logout` in your terminal to disconnect'
         : undefined,
@@ -96,7 +118,12 @@ const IntegrationsCard: React.FC = () => {
       connected: !!isLinearConnected,
       loading: isLinearLoading,
       onConnect: () => showIntegrationSetup({ integration: 'linear' }),
-      onDisconnect: disconnectLinear,
+      onDisconnect: () =>
+        confirmDisconnect({
+          name: 'Linear',
+          credential: 'API key',
+          onDisconnect: disconnectLinear,
+        }),
     },
     {
       id: 'jira',
@@ -109,7 +136,12 @@ const IntegrationsCard: React.FC = () => {
       connected: !!isJiraConnected,
       loading: isJiraLoading,
       onConnect: () => showIntegrationSetup({ integration: 'jira' }),
-      onDisconnect: disconnectJira,
+      onDisconnect: () =>
+        confirmDisconnect({
+          name: 'Jira',
+          credential: 'credentials',
+          onDisconnect: disconnectJira,
+        }),
     },
     {
       id: 'gitlab',
@@ -122,7 +154,12 @@ const IntegrationsCard: React.FC = () => {
       connected: !!isGitlabConnected,
       loading: isGitlabLoading,
       onConnect: () => showIntegrationSetup({ integration: 'gitlab' }),
-      onDisconnect: disconnectGitlab,
+      onDisconnect: () =>
+        confirmDisconnect({
+          name: 'GitLab',
+          credential: 'credentials',
+          onDisconnect: disconnectGitlab,
+        }),
     },
     {
       id: 'plain',
@@ -132,7 +169,12 @@ const IntegrationsCard: React.FC = () => {
       connected: !!isPlainConnected,
       loading: isPlainLoading,
       onConnect: () => showIntegrationSetup({ integration: 'plain' }),
-      onDisconnect: disconnectPlain,
+      onDisconnect: () =>
+        confirmDisconnect({
+          name: 'Plain',
+          credential: 'API key',
+          onDisconnect: disconnectPlain,
+        }),
     },
     {
       id: 'forgejo',
@@ -145,7 +187,12 @@ const IntegrationsCard: React.FC = () => {
       connected: !!isForgejoConnected,
       loading: isForgejoLoading,
       onConnect: () => showIntegrationSetup({ integration: 'forgejo' }),
-      onDisconnect: disconnectForgejo,
+      onDisconnect: () =>
+        confirmDisconnect({
+          name: 'Forgejo',
+          credential: 'credentials',
+          onDisconnect: disconnectForgejo,
+        }),
     },
   ];
 


### PR DESCRIPTION
## Summary
- add a confirmation modal before disconnecting enabled integrations
- reuse the existing confirm action modal with Cmd+Enter confirmation support
- keep CLI-managed GitHub disconnect disabled with its existing tooltip

## Validation
- manually verified Linear disconnect opens the modal and only clears the API key after confirmation
- not run: automated tests/format per request
<img width="672" height="386" alt="CleanShot 2026-05-05 at 22 16 48@2x" src="https://github.com/user-attachments/assets/0853870e-2c90-41a1-8b6b-ebcdd2b01b65" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI behavior change that gates existing disconnect actions behind a confirmation modal; primary risk is minor UX regression if modal wiring blocks disconnect flows.
> 
> **Overview**
> Adds a confirmation step before disconnecting any enabled integration in `IntegrationsCard` by routing all `onDisconnect` handlers through the existing `confirmActionModal`.
> 
> The modal copy is tailored per integration (e.g., calling out deletion of saved API keys/credentials), while preserving the existing CLI-managed GitHub disconnect disable/tooltip behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f8cd30b7114b319d1990bd1cd5ac6b39e507274. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->