### PR TITLE
docs: add Homebrew install command and clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,14 +27,6 @@
     <img src="https://emdash.sh/media/readme/downloadforlinux.png" alt="Download for Linux" height="40">
   </a>
 
-  <h3>
-    <a href="https://emdash.sh/download">Download Emdash v1</a>
-  </h3>
-  <p>
-    Stable v1 is now available for macOS, Windows, and Linux ·
-    <a href="https://emdash.sh/blog/emdash-v1-stable">Read the launch post</a>
-  </p>
-
 </div>
 
 <br />
@@ -58,6 +50,7 @@ Connect to remote machines via SSH/SFTP to work with remote codebases. Emdash su
 # Installation
 
 ### macOS
+- Homebrew: `brew install --cask emdash`
 - Apple Silicon: https://releases.emdash.sh/emdash-arm64.dmg
 - Intel x64: https://releases.emdash.sh/emdash-x64.dmg
 


### PR DESCRIPTION
## Summary
- Added `brew install --cask emdash` as the first macOS installation option
- Removed the "Download Emdash v1" heading and launch post link from the hero section

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to installation instructions and README layout; no runtime or behavioral impact.
> 
> **Overview**
> Simplifies the README hero area by removing the extra **“Download Emdash v1”** heading and launch-post link.
> 
> Updates macOS installation docs to include a Homebrew cask command (``brew install --cask emdash``) as the first option ahead of the direct DMG links.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7698860fe326d7e3fde29ee0ab293ed8b205d004. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->