### PR TITLE
Increase SSH test container session limits

### DIFF
--- a/testing/docker-ssh/dockerfile
+++ b/testing/docker-ssh/dockerfile
@@ -87,6 +87,8 @@ RUN sed -i 's/#PasswordAuthentication yes/PasswordAuthentication yes/' /etc/ssh/
     && echo 'PermitUserEnvironment yes' >> /etc/ssh/sshd_config \
     && echo 'ClientAliveInterval 60' >> /etc/ssh/sshd_config \
     && echo 'ClientAliveCountMax 10' >> /etc/ssh/sshd_config \
+    && echo 'MaxSessions 100' >> /etc/ssh/sshd_config \
+    && echo 'MaxStartups 100:30:200' >> /etc/ssh/sshd_config \
     && echo 'X11Forwarding no' >> /etc/ssh/sshd_config
 
 # ── Git global defaults for devuser ─────────────────────────────────────────


### PR DESCRIPTION
## Summary
- raise OpenSSH MaxSessions in the Docker SSH test fixture
- raise MaxStartups to allow more concurrent connection attempts during SSH feature testing

## Testing
- Not run; pushed first so SSH reproduction/fix work can continue separately.