### PR TITLE
README: update cli providers

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ Connect to remote machines via SSH/SFTP to work with remote codebases. Emdash su
 
 ### Supported CLI Providers
 
-Emdash currently supports 24 CLI providers, and we are adding new ones regularly. If you miss one, let us know or create a PR.
+Emdash currently supports 26 CLI providers, and we are adding new ones regularly. If you miss one, let us know or create a PR.
 
 | CLI Provider | Status | Install |
 | ----------- | ------ | ----------- |


### PR DESCRIPTION
## Summary
- add Letta as a CLI provider
- add Letta classifier and icon metadata
- ensure new Letta conversations pass --new and update provider docs

## Testing
- Not run (node_modules is not installed in this worktree; ./node_modules/.bin/vitest was unavailable)