### PR TITLE
fix: pass repositoryUrl to PR task picker

### DIFF
--- a/src/renderer/features/tasks/components/inline-pr-selector.tsx
+++ b/src/renderer/features/tasks/components/inline-pr-selector.tsx
@@ -61,6 +61,7 @@ export function InlinePrSelector({
         limit: 50,
         offset: 0,
         filters: { status: statusFilter },
+        repositoryUrl,
       });
       if (!response?.success) {
         throw new Error(


### PR DESCRIPTION
issue:
- create-task modal’s “From Pull Request” picker showing no PRs
- picker enabled its query based on repositoryUrl but did not send it to the backend, so PR lookup could fall back to empty or stale cached project remotes

fix:
- explicitly pass repositoryUrl to the listPr method