### PR TITLE
Name initial conversation by provider instead of task name

### DIFF
--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -24,6 +24,7 @@ import {
 } from '@renderer/lib/ui/dialog';
 import { Switch } from '@renderer/lib/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
+import { nextDefaultConversationTitle } from '@renderer/features/tasks/conversations/conversation-title-utils';
 import {
   resolveBranchLikeTaskStrategy,
   resolvePullRequestTaskStrategy,
@@ -123,7 +124,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
           projectId: selectedProjectId,
           taskId: id,
           provider: initialConversation.provider,
-          title: activeMode.taskName,
+          title: nextDefaultConversationTitle(initialConversation.provider, []),
           initialPrompt: initialConversation.prompt.trim() || undefined,
           autoApprove: autoApproveDefaults.getDefault(initialConversation.provider),
         }

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -7,6 +7,7 @@ import {
   getRepositoryStore,
   mountedProjectData,
 } from '@renderer/features/projects/stores/project-selectors';
+import { nextDefaultConversationTitle } from '@renderer/features/tasks/conversations/conversation-title-utils';
 import { ProjectSelector } from '@renderer/features/tasks/create-task-modal/project-selector';
 import { useAgentAutoApproveDefaults } from '@renderer/features/tasks/hooks/useAgentAutoApproveDefaults';
 import { useFeatureFlag } from '@renderer/lib/hooks/useFeatureFlag';
@@ -24,7 +25,6 @@ import {
 } from '@renderer/lib/ui/dialog';
 import { Switch } from '@renderer/lib/ui/switch';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
-import { nextDefaultConversationTitle } from '@renderer/features/tasks/conversations/conversation-title-utils';
 import {
   resolveBranchLikeTaskStrategy,
   resolvePullRequestTaskStrategy,

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -209,7 +209,6 @@ export const CreateTaskModal = observer(function CreateTaskModal({
     useBYOI,
     initialConversation,
     autoApproveDefaults,
-    activeMode.taskName,
     navigate,
     onClose,
   ]);


### PR DESCRIPTION
## Summary
- Initial conversations now get titles like "Claude (1)" instead of the task name
- Consistent with how additional conversations created via the modal are already named

## Test plan
- [ ] Create a new task with Claude → first conversation should be titled "Claude (1)"
- [ ] Create a second conversation in the same task → should be "Claude (2)"
- [ ] Create a task with a different provider → should use that provider's name

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI/UX change that only affects how the initial conversation title is generated when creating a task; no auth, persistence, or workflow logic changes beyond naming.
> 
> **Overview**
> Initial task creation now titles the *first* conversation using the provider-based default format via `nextDefaultConversationTitle` (e.g. `Claude (1)`) instead of reusing the task name.
> 
> This also removes the now-unused dependency on `activeMode.taskName` in the `handleCreateTask` callback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4ed7f94aea0acbbeee81ab4a941c620752c01c30. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->