### PR TITLE
fix: skip archived tasks in task navigation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ Thumbs.db
 
 src/main/appConfig.json
 .pi/extensions/emdash-hook.ts
+.opencode/plugins/emdash-notifications.js

--- a/src/renderer/features/sidebar/sidebar-store.ts
+++ b/src/renderer/features/sidebar/sidebar-store.ts
@@ -134,6 +134,27 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
     return pairs.map(({ projectId, task }) => ({ projectId, taskId: task.data.id }));
   }
 
+  /**
+   * Visible task IDs for a project in sidebar order: pinned first, then
+   * non-pinned. Archived tasks are excluded. Independent of expand state so
+   * Next/Previous Task navigation works even when the project is collapsed.
+   */
+  visibleTaskIdsForProject(projectId: string): string[] {
+    const project = this.projectManager.projects.get(projectId);
+    if (!project?.mountedProject) return [];
+    const all = Array.from(project.mountedProject.taskManager.tasks.values()).filter(
+      (t) => t.state === 'unregistered' || !('archivedAt' in t.data && t.data.archivedAt)
+    );
+    const pinned = all.filter((t) => t.data.isPinned);
+    const unpinned = all.filter((t) => !t.data.isPinned);
+    pinned.sort((a, b) => this.compareSidebarTasks(a, b));
+    const manualOrder = this.taskOrderByProject[projectId];
+    const orderedUnpinned = manualOrder?.length
+      ? this.mergeTaskOrder(projectId, unpinned)
+      : this.sortTasksForSidebar(unpinned);
+    return [...pinned.map((t) => t.data.id), ...orderedUnpinned.map((t) => t.data.id)];
+  }
+
   get isEmpty(): boolean {
     return this.projectManager.projects.size === 0;
   }

--- a/src/renderer/features/sidebar/sidebar-store.ts
+++ b/src/renderer/features/sidebar/sidebar-store.ts
@@ -135,24 +135,23 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   }
 
   /**
-   * Visible task IDs for a project in sidebar order: pinned first, then
-   * non-pinned. Archived tasks are excluded. Independent of expand state so
-   * Next/Previous Task navigation works even when the project is collapsed.
+   * Visible unpinned task IDs for a project in sidebar order. Archived tasks are
+   * excluded. Independent of expand state so Next/Previous Task navigation works
+   * even when the project is collapsed.
    */
   visibleTaskIdsForProject(projectId: string): string[] {
     const project = this.projectManager.projects.get(projectId);
     if (!project?.mountedProject) return [];
-    const all = Array.from(project.mountedProject.taskManager.tasks.values()).filter(
-      (t) => t.state === 'unregistered' || !('archivedAt' in t.data && t.data.archivedAt)
+    const tasks = Array.from(project.mountedProject.taskManager.tasks.values()).filter(
+      (t) =>
+        !t.data.isPinned &&
+        (t.state === 'unregistered' || !('archivedAt' in t.data && t.data.archivedAt))
     );
-    const pinned = all.filter((t) => t.data.isPinned);
-    const unpinned = all.filter((t) => !t.data.isPinned);
-    pinned.sort((a, b) => this.compareSidebarTasks(a, b));
     const manualOrder = this.taskOrderByProject[projectId];
-    const orderedUnpinned = manualOrder?.length
-      ? this.mergeTaskOrder(projectId, unpinned)
-      : this.sortTasksForSidebar(unpinned);
-    return [...pinned.map((t) => t.data.id), ...orderedUnpinned.map((t) => t.data.id)];
+    const ordered = manualOrder?.length
+      ? this.mergeTaskOrder(projectId, tasks)
+      : this.sortTasksForSidebar(tasks);
+    return ordered.map((t) => t.data.id);
   }
 
   get isEmpty(): boolean {

--- a/src/renderer/features/tasks/commands.ts
+++ b/src/renderer/features/tasks/commands.ts
@@ -3,14 +3,13 @@ import {
   asProvisioned,
   getRegisteredTaskData,
   getTaskGitStore,
-  getTaskManagerStore,
   getTaskStore,
   getTaskView,
 } from '@renderer/features/tasks/stores/task-selectors';
 import type { CommandProvider } from '@renderer/lib/commands/types';
 import type { ShortcutSettingsKey } from '@renderer/lib/hooks/useKeyboardShortcuts';
 import { showModal } from '@renderer/lib/modal/modal-provider';
-import { appState } from '@renderer/lib/stores/app-state';
+import { appState, sidebarStore } from '@renderer/lib/stores/app-state';
 
 /**
  * Returns a CommandProvider for the task scope.
@@ -37,8 +36,7 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
       const connectionId =
         mountedProject?.data.type === 'ssh' ? mountedProject.data.connectionId : undefined;
 
-      const taskMgr = getTaskManagerStore(projectId);
-      const taskIds = taskMgr ? Array.from(taskMgr.tasks.keys()) : [];
+      const taskIds = sidebarStore.visibleTaskIdsForProject(projectId);
       const currentIdx = taskIds.indexOf(taskId);
 
       const git = getTaskGitStore(projectId, taskId);


### PR DESCRIPTION
# summary
before next/previous task cycled through all tasks, now it follow the sidebar visible task order 