### PR TITLE
Fix DeepSec security findings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,4 @@ Thumbs.db
 
 src/main/appConfig.json
 .pi/extensions/emdash-hook.ts
+.opencode/plugins/emdash-notifications.js

--- a/scripts/release/build.ts
+++ b/scripts/release/build.ts
@@ -20,6 +20,9 @@ if (!platform || !['mac', 'linux', 'win'].includes(platform)) {
 }
 
 const archInput = values.arch ?? 'both';
+if (!['x64', 'arm64', 'both'].includes(archInput)) {
+  fail(`Invalid --arch: ${archInput} (expected one of: x64, arm64, both)`);
+}
 const archs: string[] = archInput === 'both' ? ['x64', 'arm64'] : [archInput];
 
 const defaultTargets: Record<string, string> = {
@@ -27,6 +30,27 @@ const defaultTargets: Record<string, string> = {
   linux: 'AppImage deb rpm',
   win: 'nsis msi',
 };
+const ALLOWED_TARGETS = new Set([
+  'dmg',
+  'zip',
+  'AppImage',
+  'deb',
+  'rpm',
+  'nsis',
+  'msi',
+  'tar.gz',
+  'snap',
+  'pkg',
+  'mas',
+]);
+if (values.targets) {
+  const parts = values.targets.split(',').map((t) => t.trim());
+  for (const part of parts) {
+    if (!ALLOWED_TARGETS.has(part)) {
+      fail(`Invalid --targets segment: ${JSON.stringify(part)}`);
+    }
+  }
+}
 const targets = values.targets ? values.targets.split(',').join(' ') : defaultTargets[platform];
 
 for (const arch of archs) {

--- a/scripts/release/notarize-mac.ts
+++ b/scripts/release/notarize-mac.ts
@@ -22,7 +22,13 @@ if (!values['app-bundle']) {
   fail('--app-bundle is required (e.g. --app-bundle "Emdash.app")');
 }
 
-const appBundle = values['app-bundle'];
+const appBundle = values['app-bundle']!;
+// Reject path separators / shell metacharacters so the value can't escape its
+// quoted interpolation into `xcrun stapler …` or join() into a path outside
+// the per-DMG mountpoint.
+if (!/^[A-Za-z0-9 _.-]+\.app$/.test(appBundle)) {
+  fail(`Invalid --app-bundle: ${JSON.stringify(appBundle)}`);
+}
 
 const apiKeyPath = process.env.APPLE_API_KEY ?? process.env.APPLE_API_KEY_CONTENT;
 const apiKeyId = process.env.APPLE_API_KEY_ID;
@@ -34,10 +40,15 @@ if (!apiKeyPath || !apiKeyId || !apiIssuer) {
 }
 
 let keyFile = apiKeyPath;
+let keyTmpDir: string | undefined;
 if (apiKeyPath.includes('BEGIN PRIVATE KEY') || apiKeyPath.length > 500) {
   const { writeFileSync } = await import('node:fs');
-  keyFile = join(tmpdir(), `apple_api_key_${Date.now()}.p8`);
-  writeFileSync(keyFile, apiKeyPath);
+  // mkdtempSync gives us a 0700 directory under tmpdir — write the key with
+  // 0600 inside it so other local users can't read the notarization key, and
+  // delete the whole directory in finally below.
+  keyTmpDir = mkdtempSync(join(tmpdir(), 'apple-api-'));
+  keyFile = join(keyTmpDir, 'apple_api_key.p8');
+  writeFileSync(keyFile, apiKeyPath, { mode: 0o600 });
 }
 
 const dmgs = readdirSync(RELEASE_DIR)
@@ -46,54 +57,65 @@ const dmgs = readdirSync(RELEASE_DIR)
 
 if (dmgs.length === 0) {
   warn('No DMG files found — nothing to notarize.');
+  if (keyTmpDir) rmSync(keyTmpDir, { recursive: true, force: true });
   process.exit(0);
 }
 
-for (const dmg of dmgs) {
-  step(`Notarizing ${dmg}`);
-  exec(
-    `xcrun notarytool submit "${dmg}" --key "${keyFile}" --key-id "${apiKeyId}" --issuer "${apiIssuer}" --wait`,
-    { echo: true }
-  );
+try {
+  for (const dmg of dmgs) {
+    step(`Notarizing ${dmg}`);
+    exec(
+      `xcrun notarytool submit "${dmg}" --key "${keyFile}" --key-id "${apiKeyId}" --issuer "${apiIssuer}" --wait`,
+      { echo: true }
+    );
 
-  info('Stapling DMG');
-  exec(`xcrun stapler staple -v "${dmg}"`, { echo: true });
-  exec(`xcrun stapler validate "${dmg}"`, { echo: true });
-}
-
-step('Staple app bundles');
-const macDirs = readdirSync(RELEASE_DIR)
-  .filter((d) => d.startsWith('mac'))
-  .map((d) => join(RELEASE_DIR, d, appBundle))
-  .filter((p) => existsSync(p));
-
-for (const appDir of macDirs) {
-  info(`Stapling ${appDir}`);
-  try {
-    exec(`xcrun stapler staple "${appDir}"`, { echo: true });
-    exec(`xcrun stapler validate "${appDir}"`, { echo: true });
-  } catch {
-    warn(`App staple failed for ${appDir} (may not be individually notarized)`);
+    info('Stapling DMG');
+    exec(`xcrun stapler staple -v "${dmg}"`, { echo: true });
+    exec(`xcrun stapler validate "${dmg}"`, { echo: true });
   }
-}
 
-step('Gatekeeper check (app inside DMG)');
-for (const dmg of dmgs) {
-  const mnt = mkdtempSync(join(tmpdir(), 'dmg-'));
-  try {
-    exec(`hdiutil attach "${dmg}" -mountpoint "${mnt}" -nobrowse -quiet`, { echo: true });
-    const appPath = join(mnt, appBundle);
-    if (!existsSync(appPath)) {
-      fail(`No ${appBundle} found inside ${dmg}`);
-    }
-    exec(`spctl -a -vv --type execute "${appPath}"`, { echo: true });
-    info(`Gatekeeper passed for ${dmg}`);
-  } finally {
+  step('Staple app bundles');
+  const macDirs = readdirSync(RELEASE_DIR)
+    .filter((d) => d.startsWith('mac'))
+    .map((d) => join(RELEASE_DIR, d, appBundle))
+    .filter((p) => existsSync(p));
+
+  for (const appDir of macDirs) {
+    info(`Stapling ${appDir}`);
     try {
-      exec(`hdiutil detach "${mnt}" -quiet`);
+      exec(`xcrun stapler staple "${appDir}"`, { echo: true });
+      exec(`xcrun stapler validate "${appDir}"`, { echo: true });
+    } catch {
+      warn(`App staple failed for ${appDir} (may not be individually notarized)`);
+    }
+  }
+
+  step('Gatekeeper check (app inside DMG)');
+  for (const dmg of dmgs) {
+    const mnt = mkdtempSync(join(tmpdir(), 'dmg-'));
+    try {
+      exec(`hdiutil attach "${dmg}" -mountpoint "${mnt}" -nobrowse -quiet`, { echo: true });
+      const appPath = join(mnt, appBundle);
+      if (!existsSync(appPath)) {
+        fail(`No ${appBundle} found inside ${dmg}`);
+      }
+      exec(`spctl -a -vv --type execute "${appPath}"`, { echo: true });
+      info(`Gatekeeper passed for ${dmg}`);
+    } finally {
+      try {
+        exec(`hdiutil detach "${mnt}" -quiet`);
+      } catch {
+        /* best effort */
+      }
+      rmSync(mnt, { recursive: true, force: true });
+    }
+  }
+} finally {
+  if (keyTmpDir) {
+    try {
+      rmSync(keyTmpDir, { recursive: true, force: true });
     } catch {
       /* best effort */
     }
-    rmSync(mnt, { recursive: true, force: true });
   }
 }

--- a/src/main/core/agent-hooks/claude-trust-service.test.ts
+++ b/src/main/core/agent-hooks/claude-trust-service.test.ts
@@ -12,6 +12,7 @@ const mockReadFile = vi.hoisted(() => vi.fn());
 const mockWriteFile = vi.hoisted(() => vi.fn());
 const mockRename = vi.hoisted(() => vi.fn());
 const mockRm = vi.hoisted(() => vi.fn());
+const mockStat = vi.hoisted(() => vi.fn());
 const mockWarn = vi.hoisted(() => vi.fn());
 
 vi.mock('node:fs', () => ({
@@ -20,6 +21,7 @@ vi.mock('node:fs', () => ({
     writeFile: mockWriteFile,
     rename: mockRename,
     rm: mockRm,
+    stat: mockStat,
   },
 }));
 
@@ -69,6 +71,10 @@ describe('ClaudeTrustService', () => {
     mockWriteFile.mockResolvedValue(undefined);
     mockRename.mockResolvedValue(undefined);
     mockRm.mockResolvedValue(undefined);
+    // The optimistic-concurrency stamp just has to round-trip across the
+    // pre-read and pre-rename stat calls. Returning the same value both times
+    // is sufficient — these tests don't simulate Claude writing between reads.
+    mockStat.mockResolvedValue({ size: 0, mtimeMs: 0 });
   });
 
   it('skips non-Claude providers', async () => {

--- a/src/main/core/agent-hooks/claude-trust-service.ts
+++ b/src/main/core/agent-hooks/claude-trust-service.ts
@@ -11,6 +11,7 @@ import {
 import { appSettingsService } from '@main/core/settings/settings-service';
 import { resolveRemoteHome } from '@main/core/ssh/utils';
 import { log } from '@main/lib/logger';
+import { quoteShellArg } from '@main/utils/shellEscape';
 
 const CLAUDE_PROVIDER_ID: AgentProviderId = 'claude';
 const CLAUDE_CONFIG_NAME = '.claude.json';
@@ -40,8 +41,13 @@ export class ClaudeTrustService {
     const configPath = path.join(homedir, CLAUDE_CONFIG_NAME);
     await this.withLock(configPath, () =>
       this.ensureTrusted(normalizedPath, {
-        readConfig: () => readLocalConfig(configPath),
-        writeConfig: (content) => writeLocalConfigAtomic(configPath, content),
+        readConfig: async () => {
+          const content = await readLocalConfig(configPath);
+          const stamp = await readLocalStamp(configPath);
+          return { content, stamp };
+        },
+        writeConfig: (content, expectedStamp) =>
+          writeLocalConfigAtomic(configPath, content, expectedStamp),
       })
     );
   }
@@ -66,8 +72,13 @@ export class ClaudeTrustService {
 
     await this.withLock(configPath, () =>
       this.ensureTrusted(normalizedPath, {
-        readConfig: () => readRemoteConfig(remoteFs, configPath),
-        writeConfig: (content) => writeRemoteConfigAtomic(remoteFs, ctx, configPath, content),
+        readConfig: async () => {
+          const content = await readRemoteConfig(remoteFs, configPath);
+          const stamp = await readRemoteStamp(ctx, configPath);
+          return { content, stamp };
+        },
+        writeConfig: (content, expectedStamp) =>
+          writeRemoteConfigAtomic(remoteFs, ctx, configPath, content, expectedStamp),
       })
     );
   }
@@ -88,23 +99,42 @@ export class ClaudeTrustService {
   private async ensureTrusted(
     normalizedPath: string,
     io: {
-      readConfig: () => Promise<string | null>;
-      writeConfig: (content: string) => Promise<void>;
+      readConfig: () => Promise<{ content: string | null; stamp: string | null }>;
+      writeConfig: (content: string, expectedStamp: string | null) => Promise<void>;
     }
   ): Promise<void> {
-    try {
-      const rawConfig = await io.readConfig();
-      const config = parseConfig(rawConfig);
-      if (!config) return;
-      const nextConfig = withTrustedProject(config, normalizedPath);
-      if (!nextConfig) return;
-      await io.writeConfig(JSON.stringify(nextConfig, null, 2) + '\n');
-    } catch (error: unknown) {
-      log.warn('ClaudeTrustService: failed to auto-trust worktree', {
-        path: normalizedPath,
-        error: String(error),
-      });
+    // Retry up to 3 times if Claude (or another writer) modifies the file
+    // between our read and our rename — the stamp passed to writeConfig is
+    // re-checked against the current file before the rename, and we throw on
+    // mismatch so we re-merge with the latest content instead of clobbering it.
+    const MAX_ATTEMPTS = 3;
+    for (let attempt = 1; attempt <= MAX_ATTEMPTS; attempt++) {
+      try {
+        const { content: rawConfig, stamp } = await io.readConfig();
+        const config = parseConfig(rawConfig);
+        if (!config) return;
+        const nextConfig = withTrustedProject(config, normalizedPath);
+        if (!nextConfig) return;
+        await io.writeConfig(JSON.stringify(nextConfig, null, 2) + '\n', stamp);
+        return;
+      } catch (error: unknown) {
+        const isStaleStamp = error instanceof ClaudeConfigChangedError;
+        if (isStaleStamp && attempt < MAX_ATTEMPTS) continue;
+        log.warn('ClaudeTrustService: failed to auto-trust worktree', {
+          path: normalizedPath,
+          error: String(error),
+          attempt,
+        });
+        return;
+      }
     }
+  }
+}
+
+class ClaudeConfigChangedError extends Error {
+  constructor() {
+    super('Claude config changed between read and write');
+    this.name = 'ClaudeConfigChangedError';
   }
 }
 
@@ -162,10 +192,31 @@ async function readLocalConfig(configPath: string): Promise<string | null> {
   }
 }
 
-async function writeLocalConfigAtomic(configPath: string, content: string): Promise<void> {
+async function readLocalStamp(configPath: string): Promise<string | null> {
+  try {
+    const stat = await fs.stat(configPath);
+    return `${stat.size}:${stat.mtimeMs}`;
+  } catch (error: unknown) {
+    if (isNodeNotFound(error)) return null;
+    throw error;
+  }
+}
+
+async function writeLocalConfigAtomic(
+  configPath: string,
+  content: string,
+  expectedStamp: string | null
+): Promise<void> {
   const tmpPath = `${configPath}.${randomUUID()}.tmp`;
   try {
     await fs.writeFile(tmpPath, content, 'utf8');
+    // Re-stat right before the rename — if the source file changed since we
+    // read it, abort so the caller can re-merge with the new content instead
+    // of overwriting another writer's changes.
+    const currentStamp = await readLocalStamp(configPath);
+    if (currentStamp !== expectedStamp) {
+      throw new ClaudeConfigChangedError();
+    }
     await fs.rename(tmpPath, configPath);
   } catch (error: unknown) {
     try {
@@ -188,15 +239,35 @@ async function readRemoteConfig(
   }
 }
 
+async function readRemoteStamp(ctx: IExecutionContext, configPath: string): Promise<string | null> {
+  try {
+    // BSD `stat -f` and GNU `stat -c` differ; portable fallback via wc + ls -ln.
+    // We just need any value that changes when the file changes — size + mtime.
+    const { stdout } = await ctx.exec('sh', [
+      '-c',
+      `f=${quoteShellArg(configPath)}; [ -e "$f" ] && (stat -c '%s:%Y' "$f" 2>/dev/null || stat -f '%z:%m' "$f")`,
+    ]);
+    const trimmed = stdout.trim();
+    return trimmed || null;
+  } catch {
+    return null;
+  }
+}
+
 async function writeRemoteConfigAtomic(
   remoteFs: Pick<FileSystemProvider, 'write'>,
   ctx: IExecutionContext,
   configPath: string,
-  content: string
+  content: string,
+  expectedStamp: string | null
 ): Promise<void> {
   const tmpPath = `${configPath}.${randomUUID()}.tmp`;
   try {
     await remoteFs.write(tmpPath, content);
+    const currentStamp = await readRemoteStamp(ctx, configPath);
+    if (currentStamp !== expectedStamp) {
+      throw new ClaudeConfigChangedError();
+    }
     await ctx.exec('mv', [tmpPath, configPath]);
   } catch (error: unknown) {
     try {

--- a/src/main/core/execution-context/github-auth-execution-context.ts
+++ b/src/main/core/execution-context/github-auth-execution-context.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import { addGitHubAuthConfig } from '@main/core/utils/exec';
+import { buildGitHubAuthEnv } from '@main/core/utils/exec';
 import type { ExecOptions, ExecResult, IExecutionContext } from './types';
 
 export class GitHubAuthExecutionContext implements IExecutionContext {
@@ -16,7 +16,9 @@ export class GitHubAuthExecutionContext implements IExecutionContext {
 
   async exec(command: string, args: string[] = [], opts?: ExecOptions): Promise<ExecResult> {
     if (path.basename(command) === 'git') {
-      args = await addGitHubAuthConfig(args, this.getToken);
+      const { args: nextArgs, env } = await buildGitHubAuthEnv(args, this.getToken);
+      const mergedEnv = Object.keys(env).length > 0 ? { ...(opts?.env ?? {}), ...env } : opts?.env;
+      return this.inner.exec(command, nextArgs, { ...opts, env: mergedEnv });
     }
     return this.inner.exec(command, args, opts);
   }

--- a/src/main/core/execution-context/local-execution-context.ts
+++ b/src/main/core/execution-context/local-execution-context.ts
@@ -26,12 +26,13 @@ export class LocalExecutionContext implements IExecutionContext {
   }
 
   exec(command: string, args: string[] = [], opts: ExecOptions = {}): Promise<ExecResult> {
-    const { timeout, maxBuffer } = opts;
+    const { timeout, maxBuffer, env } = opts;
     return execFileAsync(this.resolveCommand(command), args, {
       cwd: this.root || undefined,
       timeout,
       maxBuffer,
       signal: this._signal(opts.signal),
+      env: env ? { ...process.env, ...env } : undefined,
     }) as Promise<ExecResult>;
   }
 

--- a/src/main/core/execution-context/ssh-execution-context.ts
+++ b/src/main/core/execution-context/ssh-execution-context.ts
@@ -16,10 +16,17 @@ export function buildSshCommand(
   root: string | undefined,
   command: string,
   args: string[],
-  profile?: RemoteShellProfile
+  profile?: RemoteShellProfile,
+  env?: Record<string, string>
 ): string {
   const escaped = args.map(quoteShellArg).join(' ');
-  const inner = args.length ? `${command} ${escaped}` : command;
+  const envPrefix = env
+    ? Object.entries(env)
+        .map(([k, v]) => `${k}=${quoteShellArg(v)}`)
+        .join(' ')
+    : '';
+  const cmdWithEnv = envPrefix ? `${envPrefix} ${command}` : command;
+  const inner = args.length ? `${cmdWithEnv} ${escaped}` : cmdWithEnv;
   const body = root ? `cd ${quoteShellArg(root)} && ${inner}` : inner;
   return buildRemoteShellCommand(profile ?? FALLBACK_REMOTE_SHELL_PROFILE, body);
 }
@@ -38,9 +45,9 @@ export class SshExecutionContext implements IExecutionContext {
   }
 
   async exec(command: string, args: string[] = [], opts: ExecOptions = {}): Promise<ExecResult> {
-    const { signal } = opts;
+    const { signal, env } = opts;
     const profile = await this.proxy.getRemoteShellProfile();
-    const full = buildSshCommand(this.root, command, args, profile);
+    const full = buildSshCommand(this.root, command, args, profile, env);
     const combined = this._signal(signal);
 
     return new Promise((resolve, reject) => {

--- a/src/main/core/execution-context/types.ts
+++ b/src/main/core/execution-context/types.ts
@@ -7,6 +7,13 @@ export interface ExecOptions {
   timeout?: number;
   maxBuffer?: number;
   signal?: AbortSignal;
+  /**
+   * Extra environment variables to expose to the child. Merged on top of the
+   * inherited process env. Used by GitHubAuthExecutionContext to pass the
+   * Authorization header via `GIT_CONFIG_*` rather than argv so the token is
+   * not visible in `ps`/process listings.
+   */
+  env?: Record<string, string>;
 }
 
 /**

--- a/src/main/core/git/impl/git-repo-utils.test.ts
+++ b/src/main/core/git/impl/git-repo-utils.test.ts
@@ -22,6 +22,7 @@ describe('cloneRepository', () => {
 
     expect(ctx.exec).toHaveBeenCalledWith('git', [
       'clone',
+      '--',
       'https://github.com/example/repo.git',
       '/work/repo',
     ]);

--- a/src/main/core/git/impl/git-repo-utils.ts
+++ b/src/main/core/git/impl/git-repo-utils.ts
@@ -24,8 +24,15 @@ export async function cloneRepository(
   localPath: string,
   ctx: IExecutionContext
 ): Promise<{ success: boolean; error?: string }> {
+  // Reject values that could be reparsed by git as options (`--upload-pack=…`
+  // and friends in the CVE-2017-1000117 / CVE-2018-17456 / CVE-2024-32002
+  // family). Modern git also blocks most of these, but `--` is the canonical
+  // hardening and costs nothing.
+  if (repoUrl.startsWith('-') || localPath.startsWith('-')) {
+    return { success: false, error: 'Invalid clone arguments' };
+  }
   try {
-    await ctx.exec('git', ['clone', repoUrl, localPath]);
+    await ctx.exec('git', ['clone', '--', repoUrl, localPath]);
     return { success: true };
   } catch (error) {
     return {

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -74,6 +74,17 @@ function imageMimeForPath(filePath: string): string | null {
 
 const LFS_POINTER_PREFIX = Buffer.from('version https://git-lfs.github.com/spec/');
 
+/**
+ * Defense-in-depth: refuse to pass a value to git as a positional argument when
+ * it begins with `-`. Git parses leading-dash args as flags, and renderer-/RPC-
+ * supplied refs are otherwise interpolated verbatim into commands like
+ * `git show <ref>:<path>` (no `--` separator possible because `<ref>:<path>` is
+ * a single argv element).
+ */
+function refLooksLikeFlag(ref: string): boolean {
+  return ref.startsWith('-');
+}
+
 // Without an LFS smudge filter, cat-file returns pointer text instead of image bytes.
 function looksLikeLfsPointer(buffer: Buffer): boolean {
   if (buffer.length > 1024) return false;
@@ -377,6 +388,7 @@ export class GitService implements GitProvider, IDisposable {
   }
 
   async getFileAtRef(filePath: string, ref: string): Promise<string | null> {
+    if (refLooksLikeFlag(ref)) return null;
     const cf = this._getCatFile();
     if (cf) {
       try {
@@ -415,6 +427,7 @@ export class GitService implements GitProvider, IDisposable {
   }
 
   async getImageAtRef(filePath: string, ref: string): Promise<ImageReadResult> {
+    if (refLooksLikeFlag(ref)) return { kind: 'unavailable', reason: 'unsupported' };
     return this._readImageBlob(`${ref}:${filePath}`, filePath);
   }
 
@@ -482,6 +495,9 @@ export class GitService implements GitProvider, IDisposable {
     filePath: string,
     base: DiffMode | GitObjectRef = HEAD_MODE
   ): Promise<DiffResult> {
+    if (base.kind !== 'head' && base.kind !== 'staged') {
+      if (refLooksLikeFlag(toRefString(base))) return { lines: [] };
+    }
     const diffArgs = (() => {
       switch (base.kind) {
         case 'staged':
@@ -592,6 +608,7 @@ export class GitService implements GitProvider, IDisposable {
   }
 
   async getCommitFileDiff(commitHash: string, filePath: string): Promise<DiffResult> {
+    if (refLooksLikeFlag(commitHash)) return { lines: [] };
     const getContentAt = async (ref: string): Promise<string | undefined> => {
       try {
         const { stdout } = await this.ctx.exec('git', ['show', `${ref}:${filePath}`], {
@@ -1387,8 +1404,13 @@ export class GitService implements GitProvider, IDisposable {
         .catch(() => {});
     }
     const base = syncWithRemote ? `${remote}/${from}` : `refs/heads/${from}`;
+    if (name.startsWith('-') || base.startsWith('-')) {
+      return err({ type: 'invalid_name', name });
+    }
     try {
-      await this.ctx.exec('git', ['branch', '--no-track', name, base]);
+      // `--` ends option parsing so a name like `-D` can't be reinterpreted by
+      // `git branch` as a delete flag against the base branch.
+      await this.ctx.exec('git', ['branch', '--no-track', '--', name, base]);
       return ok();
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
@@ -1421,9 +1443,21 @@ export class GitService implements GitProvider, IDisposable {
     isFork: boolean,
     configuredRemote = 'origin'
   ): Promise<Result<void, FetchPrForReviewError>> {
+    // Reject fork-controlled / renderer-supplied positional args that could be
+    // reparsed by git as flags. Fork owner regex permits a leading `-`, and
+    // PR head ref names come from GitHub API responses we don't control.
+    if (
+      headRefName.startsWith('-') ||
+      headRepositoryUrl.startsWith('-') ||
+      localBranch.startsWith('-') ||
+      configuredRemote.startsWith('-')
+    ) {
+      return err({ type: 'error', message: 'Invalid PR fetch arguments' });
+    }
     try {
       if (isFork) {
-        const forkRemote = parseGitHubRepository(headRepositoryUrl)?.owner ?? 'fork';
+        const parsedOwner = parseGitHubRepository(headRepositoryUrl)?.owner;
+        const forkRemote = parsedOwner && !parsedOwner.startsWith('-') ? parsedOwner : 'fork';
         // Idempotently ensure remote exists with the correct URL
         const remotes = await this.ctx.exec('git', ['remote']).catch(() => ({ stdout: '' }));
         const names = remotes.stdout
@@ -1491,8 +1525,11 @@ export class GitService implements GitProvider, IDisposable {
       remoteName = stdout.trim() || undefined;
     } catch {}
 
+    if (oldBranch.startsWith('-') || newBranch.startsWith('-')) {
+      return err({ type: 'error', message: 'Invalid branch name' });
+    }
     try {
-      await this.ctx.exec('git', ['branch', '-m', oldBranch, newBranch]);
+      await this.ctx.exec('git', ['branch', '-m', '--', oldBranch, newBranch]);
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
       if (stderr.includes('already exists')) {
@@ -1518,8 +1555,11 @@ export class GitService implements GitProvider, IDisposable {
 
   async deleteBranch(branch: string, force = true): Promise<Result<void, DeleteBranchError>> {
     const flag = force ? '-D' : '-d';
+    if (branch.startsWith('-')) {
+      return err({ type: 'error', message: 'Invalid branch name' });
+    }
     try {
-      await this.ctx.exec('git', ['branch', flag, branch]);
+      await this.ctx.exec('git', ['branch', flag, '--', branch]);
       return ok();
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);

--- a/src/main/core/projects/settings/legacy-project-settings-migration.ts
+++ b/src/main/core/projects/settings/legacy-project-settings-migration.ts
@@ -87,8 +87,16 @@ export async function migrateLegacyProjectSettingsIfNeeded({
       );
     }
     if (legacy.tmux !== undefined) next.tmux = legacy.tmux;
+    // Intentionally NOT migrating `workspaceProvider` from .emdash.json.
+    // Its `provisionCommand` / `terminateCommand` are executed via /bin/sh -c when
+    // the user toggles BYOI, so silently planting them from a repo-controlled file
+    // would let a malicious clone configure shell commands that the user never typed.
+    // Users who relied on this field must re-enter the commands in the Settings UI.
     if (legacy.workspaceProvider !== undefined) {
-      next.workspaceProvider = legacy.workspaceProvider;
+      log.warn(
+        `Ignoring workspaceProvider from .emdash.json for project ${projectId}: ` +
+          `repo-controlled shell commands cannot be auto-migrated. Re-enter the provider in Settings.`
+      );
     }
   }
 

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -12,6 +12,17 @@ const SKILLS_ROOT = path.join(os.homedir(), '.agentskills');
 const EMDASH_META = path.join(SKILLS_ROOT, '.emdash');
 const CATALOG_INDEX_PATH = path.join(EMDASH_META, 'catalog-index.json');
 
+/**
+ * Throws on any skillId that could cause a filesystem operation to escape
+ * SKILLS_ROOT (e.g. `..`, absolute path, separator, NUL). Use BEFORE any
+ * path.join(SKILLS_ROOT, skillId) followed by mkdir/rm/rename/write.
+ */
+function assertSafeSkillId(skillId: string): void {
+  if (!isValidSkillName(skillId)) {
+    throw new Error(`Invalid skill id`);
+  }
+}
+
 const MAX_REDIRECTS = 5;
 
 function httpsGet(url: string, redirectCount = 0): Promise<string> {
@@ -184,6 +195,7 @@ export class SkillsService {
   }
 
   async getSkillDetail(skillId: string): Promise<CatalogSkill | null> {
+    assertSafeSkillId(skillId);
     const catalog = await this.getCatalogIndex();
     const skill = catalog.skills.find((s) => s.id === skillId);
     if (!skill) return null;
@@ -233,6 +245,7 @@ export class SkillsService {
   }
 
   async installSkill(skillId: string): Promise<CatalogSkill> {
+    assertSafeSkillId(skillId);
     await this.initialize();
     const catalog = await this.getCatalogIndex();
     const skill = catalog.skills.find((s) => s.id === skillId);
@@ -285,6 +298,7 @@ export class SkillsService {
   }
 
   async uninstallSkill(skillId: string): Promise<void> {
+    assertSafeSkillId(skillId);
     const skillDir = path.join(SKILLS_ROOT, skillId);
 
     // Remove agent symlinks first
@@ -345,6 +359,7 @@ export class SkillsService {
   }
 
   async syncToAgents(skillId: string): Promise<void> {
+    assertSafeSkillId(skillId);
     const skillDir = path.join(SKILLS_ROOT, skillId);
     for (const target of agentTargets) {
       try {
@@ -376,15 +391,18 @@ export class SkillsService {
   }
 
   async unsyncFromAgents(skillId: string): Promise<void> {
+    assertSafeSkillId(skillId);
     for (const target of agentTargets) {
       try {
         const targetDir = target.getSkillDir(skillId);
         const stat = await fs.promises.lstat(targetDir);
         if (stat.isSymbolicLink()) {
-          // Only remove symlinks that point into our central skills root
+          // Only remove symlinks that point into our central skills root.
+          // Compare against SKILLS_ROOT + path.sep so adjacent dirs like
+          // `.agentskillsX` can never match the SKILLS_ROOT prefix.
           const linkTarget = await fs.promises.readlink(targetDir);
           const resolved = path.resolve(path.dirname(targetDir), linkTarget);
-          if (resolved.startsWith(SKILLS_ROOT)) {
+          if (resolved === SKILLS_ROOT || resolved.startsWith(SKILLS_ROOT + path.sep)) {
             await fs.promises.unlink(targetDir);
           }
         }

--- a/src/main/core/ssh/controller.ts
+++ b/src/main/core/ssh/controller.ts
@@ -19,6 +19,23 @@ import { sshConnectionManager } from './ssh-connection-manager';
 import { sshCredentialService } from './ssh-credential-service';
 import { resolveIdentityAgent } from './utils';
 
+/**
+ * Reject host/username values that could be re-parsed by `ssh` as an option
+ * (`-oProxyCommand=...` → RCE on the local machine). Enforced server-side so
+ * malicious rows can never enter the DB, regardless of renderer-side checks.
+ */
+function assertSafeSshHost(host: string): void {
+  if (!host || host.startsWith('-') || !/^[A-Za-z0-9._\-[\]:]+$/.test(host)) {
+    throw new Error(`Invalid SSH host`);
+  }
+}
+
+function assertSafeSshUsername(username: string): void {
+  if (username && (username.startsWith('-') || !/^[A-Za-z0-9._-]+$/.test(username))) {
+    throw new Error(`Invalid SSH username`);
+  }
+}
+
 export const sshController = createRPCController({
   /** List all saved SSH connections (no secrets). */
   getConnections: async (): Promise<SshConfig[]> => {
@@ -41,6 +58,9 @@ export const sshController = createRPCController({
     config: Partial<Pick<SshConfig, 'id'>> &
       Omit<SshConfig, 'id'> & { password?: string; passphrase?: string }
   ): Promise<SshConfig> => {
+    assertSafeSshHost(config.host);
+    assertSafeSshUsername(config.username);
+
     const connectionId = config.id ?? randomUUID();
 
     // Only update stored credentials when a non-empty value is provided.

--- a/src/main/core/utils/exec.ts
+++ b/src/main/core/utils/exec.ts
@@ -25,28 +25,40 @@ function shouldUseHttpRemote(args: string[]): boolean {
   return subcommand === 'remote' && args[1] === 'show';
 }
 
-export async function addGitHubAuthConfig(
+/**
+ * Builds GitHub auth as a git-config-via-env payload + the args that need
+ * to be merged into the command. The token is passed via `GIT_CONFIG_*`
+ * environment variables instead of `-c` argv entries so it does not appear
+ * in `ps`/process listings on either the local or remote host.
+ *
+ * See `git-config[1]`'s "GIT_CONFIG_COUNT" docs (git ≥ 2.31).
+ */
+export async function buildGitHubAuthEnv(
   args: string[],
   getToken: () => Promise<string | null>
-): Promise<string[]> {
+): Promise<{ args: string[]; env: Record<string, string> }> {
   const rawToken = await getToken();
-  if (!rawToken) return args;
+  if (!rawToken) return { args, env: {} };
 
   const token = Buffer.from(`x-access-token:${rawToken}`).toString('base64');
-  if (!token) return args;
 
-  const withAuth = ['-c', `http.https://github.com/.extraHeader=Authorization: Basic ${token}`];
+  const pairs: Array<[string, string]> = [
+    ['http.https://github.com/.extraHeader', `Authorization: Basic ${token}`],
+  ];
 
   if (shouldUseHttpRemote(args)) {
-    withAuth.push(
-      '-c',
-      'url.https://github.com/.insteadOf=git@github.com:',
-      '-c',
-      'url.https://github.com/.insteadOf=ssh://git@github.com:',
-      '-c',
-      'url.https://github.com/.insteadOf=ssh://git@github.com/'
+    pairs.push(
+      ['url.https://github.com/.insteadOf', 'git@github.com:'],
+      ['url.https://github.com/.insteadOf', 'ssh://git@github.com:'],
+      ['url.https://github.com/.insteadOf', 'ssh://git@github.com/']
     );
   }
 
-  return [...withAuth, ...args];
+  const env: Record<string, string> = { GIT_CONFIG_COUNT: String(pairs.length) };
+  pairs.forEach(([key, value], i) => {
+    env[`GIT_CONFIG_KEY_${i}`] = key;
+    env[`GIT_CONFIG_VALUE_${i}`] = value;
+  });
+
+  return { args, env };
 }

--- a/src/main/core/workspaces/byoi/provision-byoi-task.ts
+++ b/src/main/core/workspaces/byoi/provision-byoi-task.ts
@@ -71,12 +71,33 @@ export async function provisionBYOITask(params: ProvisionBYOITaskParams): Promis
     message: `Connecting to ${output.host}…`,
   });
 
+  // Require the provision script to emit its own SSH credentials. Silently
+  // substituting `process.env.USER` and `SSH_AUTH_SOCK` would let a buggy or
+  // partially-malicious script authenticate to an attacker-chosen `output.host`
+  // using whatever identities the local agent holds.
+  if (!output.username) {
+    throw new Error(
+      'BYOI provision script did not emit a `username`. Refusing to fall back to local $USER.'
+    );
+  }
+  if (!output.password && !output.useAgent) {
+    throw new Error(
+      'BYOI provision script did not emit a `password` and did not set `useAgent: true`. Refusing silent SSH agent fallback.'
+    );
+  }
+  const agentSocket = output.useAgent ? process.env['SSH_AUTH_SOCK'] : undefined;
+  if (output.useAgent && !agentSocket) {
+    throw new Error(
+      'BYOI provision script requested `useAgent: true` but $SSH_AUTH_SOCK is not set.'
+    );
+  }
+
   const connectionId = `task:${task.id}`;
   const proxy = await sshConnectionManager.connectFromConfig(connectionId, {
     host: output.host,
     port: output.port ?? 22,
-    username: output.username ?? process.env['USER'],
-    ...(output.password ? { password: output.password } : { agent: process.env['SSH_AUTH_SOCK'] }),
+    username: output.username,
+    ...(output.password ? { password: output.password } : { agent: agentSocket }),
   });
 
   events.emit(taskProvisionProgressChannel, {

--- a/src/main/core/workspaces/byoi/provision-output.ts
+++ b/src/main/core/workspaces/byoi/provision-output.ts
@@ -8,6 +8,9 @@ const provisionOutputSchema = z.object({
   username: z.string().optional(),
   worktreePath: z.string().optional(),
   password: z.string().optional(),
+  // Opt-in to using the caller's SSH agent. Without this, missing credentials
+  // are an error rather than silently falling back to $USER / $SSH_AUTH_SOCK.
+  useAgent: z.boolean().optional(),
 });
 
 export type ProvisionOutput = z.infer<typeof provisionOutputSchema>;

--- a/src/main/db/database-file.ts
+++ b/src/main/db/database-file.ts
@@ -28,6 +28,10 @@ function clearCopiedAppSecrets(databasePath: string): void {
       .get('app_secrets');
     if (hasAppSecretsTable) {
       copied.exec('DELETE FROM app_secrets');
+      // DELETE only marks the pages as free — original secret bytes stay on
+      // disk until SQLite reuses the pages. VACUUM rewrites the database so
+      // backups, sync clients, and forensic tools can't recover them.
+      copied.exec('VACUUM');
     }
   } finally {
     copied.close();
@@ -42,8 +46,20 @@ export function resolveDefaultDatabasePath(userDataPath: string): string {
 
   const previousPath = join(userDataPath, PREVIOUS_DB_FILENAME);
   if (fs.existsSync(previousPath)) {
-    copySqliteDatabase(previousPath, currentPath);
-    clearCopiedAppSecrets(currentPath);
+    // Stage in a temp file so a crash between VACUUM INTO and DELETE FROM
+    // app_secrets can't leave the migrated DB sitting at currentPath with the
+    // secrets still inside. We only rename after the secrets are gone.
+    const stagingPath = `${currentPath}.migrating-${process.pid}-${Date.now()}`;
+    try {
+      copySqliteDatabase(previousPath, stagingPath);
+      clearCopiedAppSecrets(stagingPath);
+      fs.renameSync(stagingPath, currentPath);
+    } catch (error) {
+      try {
+        fs.rmSync(stagingPath, { force: true });
+      } catch {}
+      throw error;
+    }
   }
 
   return currentPath;

--- a/src/main/db/initialize.ts
+++ b/src/main/db/initialize.ts
@@ -31,7 +31,10 @@ function runBundledMigrations(connection: BetterSqlite3.Database): void {
     for (const entry of (journal as { entries: JournalEntry[] }).entries) {
       if (entry.when <= lastTimestamp) continue;
 
-      const sqlKey = Object.keys(sqlFiles).find((k) => k.includes(entry.tag));
+      // Match the exact migration filename (`/<tag>.sql`) instead of a
+      // substring — substring matches are ambiguous if a future tag like
+      // `0001_foo` is a prefix of another tag like `0001_foo_extra`.
+      const sqlKey = Object.keys(sqlFiles).find((k) => k.endsWith(`/${entry.tag}.sql`));
       if (!sqlKey) throw new Error(`Missing bundled SQL for migration: ${entry.tag}`);
 
       const sql = sqlFiles[sqlKey];

--- a/src/main/db/legacy-port/service.ts
+++ b/src/main/db/legacy-port/service.ts
@@ -87,18 +87,23 @@ async function withAtomicDestinationImport<T>(
   action: () => Promise<T>
 ): Promise<T> {
   const foreignKeys = sqlite.pragma('foreign_keys', { simple: true }) as number;
-  sqlite.pragma('foreign_keys = OFF');
-  sqlite.exec('BEGIN IMMEDIATE');
-
+  // Set the FK pragma INSIDE the try/finally so a throw from BEGIN IMMEDIATE
+  // (e.g. lock contention) can't leak `foreign_keys = OFF` to subsequent
+  // writes on the same connection.
   try {
-    const result = await action();
-    sqlite.exec('COMMIT');
-    return result;
-  } catch (error) {
-    if (sqlite.inTransaction) {
-      sqlite.exec('ROLLBACK');
+    sqlite.pragma('foreign_keys = OFF');
+    sqlite.exec('BEGIN IMMEDIATE');
+
+    try {
+      const result = await action();
+      sqlite.exec('COMMIT');
+      return result;
+    } catch (error) {
+      if (sqlite.inTransaction) {
+        sqlite.exec('ROLLBACK');
+      }
+      throw error;
     }
-    throw error;
   } finally {
     sqlite.pragma(`foreign_keys = ${foreignKeys ? 'ON' : 'OFF'}`);
   }

--- a/src/main/utils/externalLinks.ts
+++ b/src/main/utils/externalLinks.ts
@@ -9,23 +9,38 @@ export function registerExternalLinkHandlers(win: BrowserWindow, isDev: boolean)
   const wc = win.webContents;
 
   const isInternalAppUrl = (url: string) => {
-    if (isDev) return url.startsWith(process.env.ELECTRON_RENDERER_URL!);
-    return url.startsWith('file://') || /^http:\/\/(127\.0\.0\.1|localhost):\d+(?:\/|$)/i.test(url);
+    if (isDev) {
+      const rendererUrl = process.env.ELECTRON_RENDERER_URL;
+      // In dev, only treat URLs from the explicitly-configured renderer origin
+      // as internal. If ELECTRON_RENDERER_URL is unset, fail closed.
+      return !!rendererUrl && url.startsWith(rendererUrl);
+    }
+    return /^http:\/\/(127\.0\.0\.1|localhost):\d+(?:\/|$)/i.test(url);
   };
 
-  // Handle window.open and target="_blank"
+  // Handle window.open and target="_blank".
+  // Default-deny: only http(s) external URLs are handed off to the OS browser,
+  // and only same-origin internal URLs may open a new BrowserWindow. Any other
+  // scheme (file:, data:, javascript:, custom app schemes, …) is rejected so
+  // a rendered link can never escape the app:// origin into a privileged
+  // BrowserWindow context.
   wc.setWindowOpenHandler(({ url }) => {
-    if (!isInternalAppUrl(url) && /^https?:\/\//i.test(url)) {
+    if (/^https?:\/\//i.test(url)) {
+      if (isInternalAppUrl(url)) return { action: 'allow' };
       void shell.openExternal(url);
       return { action: 'deny' };
     }
-    return { action: 'allow' };
+    return { action: 'deny' };
   });
 
-  // Intercept navigations that would leave the app
+  // Intercept navigations that would leave the app. Block anything that isn't
+  // an explicitly-recognised internal URL — including file://, custom schemes,
+  // and unknown http(s) origins — so a link in renderer content can't replace
+  // the app:// origin with file:// and pivot to preload-exposed APIs.
   wc.on('will-navigate', (event, url) => {
-    if (!isInternalAppUrl(url) && /^https?:\/\//i.test(url)) {
-      event.preventDefault();
+    if (isInternalAppUrl(url)) return;
+    event.preventDefault();
+    if (/^https?:\/\//i.test(url)) {
       void shell.openExternal(url);
     }
   });

--- a/src/main/utils/remoteOpenIn.ts
+++ b/src/main/utils/remoteOpenIn.ts
@@ -2,15 +2,44 @@ import { quoteShellArg } from './shellEscape';
 
 type RemoteEditorScheme = 'vscode' | 'vscodium' | 'cursor';
 
+/**
+ * Reject SSH host/username values that could be misinterpreted by `ssh` as an
+ * option (`-oProxyCommand=...` → RCE) or by URL/shell layers as metacharacters.
+ * Allows the conventional set for usernames and hostnames/IPs and refuses any
+ * leading `-`, whitespace, or shell-meaningful characters.
+ */
+function assertSafeSshHost(host: string): void {
+  if (!host || host.startsWith('-') || !/^[A-Za-z0-9._\-[\]:]+$/.test(host)) {
+    throw new Error(`Refusing unsafe SSH host: ${JSON.stringify(host)}`);
+  }
+}
+
+function assertSafeSshUsername(username: string): void {
+  // Empty username is fine (falls back to system default), but if provided it
+  // must look like a real account name and never look like an SSH option.
+  if (username && (username.startsWith('-') || !/^[A-Za-z0-9._-]+$/.test(username))) {
+    throw new Error(`Refusing unsafe SSH username: ${JSON.stringify(username)}`);
+  }
+}
+
 export function buildRemoteSshAuthority(host: string, username: string): string {
   const normalizedHost = host.trim();
   if (!normalizedHost) return normalizedHost;
 
   // Keep host as-is when caller already included user info (for SSH aliases like user@host).
-  if (normalizedHost.includes('@')) return normalizedHost;
+  if (normalizedHost.includes('@')) {
+    const [userPart, ...hostParts] = normalizedHost.split('@');
+    const hostPart = hostParts.join('@');
+    assertSafeSshUsername(userPart);
+    assertSafeSshHost(hostPart);
+    return normalizedHost;
+  }
+
+  assertSafeSshHost(normalizedHost);
 
   const normalizedUsername = username.trim();
   if (!normalizedUsername) return normalizedHost;
+  assertSafeSshUsername(normalizedUsername);
 
   return `${normalizedUsername}@${normalizedHost}`;
 }
@@ -23,8 +52,11 @@ export function buildRemoteEditorUrl(
 ): string {
   const authority = buildRemoteSshAuthority(host, username);
   const encodedAuthority = encodeURIComponent(authority);
-  const normalizedTargetPath = targetPath.startsWith('/') ? targetPath : `/${targetPath}`;
-  return `${scheme}://vscode-remote/ssh-remote+${encodedAuthority}${normalizedTargetPath}`;
+  // Percent-encode each path segment so `?`/`#`/metacharacters can't smuggle
+  // query strings or fragments into the vscode-remote URL handler.
+  const segments = targetPath.split('/').filter((s) => s.length > 0);
+  const encodedPath = '/' + segments.map((s) => encodeURIComponent(s)).join('/');
+  return `${scheme}://vscode-remote/ssh-remote+${encodedAuthority}${encodedPath}`;
 }
 
 type RemoteTerminalExecInput = {

--- a/src/main/utils/userEnv.test.ts
+++ b/src/main/utils/userEnv.test.ts
@@ -3,10 +3,10 @@ import os from 'node:os';
 import path from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
-const execSyncMock = vi.fn();
+const execFileSyncMock = vi.fn();
 
 vi.mock('node:child_process', () => ({
-  execSync: execSyncMock,
+  execFileSync: execFileSyncMock,
 }));
 
 const { ensureUserBinDirsInPath, ensureWindowsNpmGlobalBinInPath, resolveUserEnv } = await import(
@@ -70,8 +70,8 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
   > = {};
 
   beforeEach(() => {
-    execSyncMock.mockReset();
-    execSyncMock.mockReturnValue('');
+    execFileSyncMock.mockReset();
+    execFileSyncMock.mockReturnValue('');
     for (const key of [...SCRUBBED_KEYS, ...PATH_LIKE_KEYS]) {
       savedEnv[key] = process.env[key];
     }
@@ -85,7 +85,7 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
   });
 
   it('strips AppImage runtime vars and /tmp/.mount_* path entries from the probe shell env and final PATH', async () => {
-    execSyncMock.mockReturnValue('PATH=/usr/local/bin:/usr/bin\n');
+    execFileSyncMock.mockReturnValue('PATH=/usr/local/bin:/usr/bin\n');
     process.env.APPIMAGE = '/home/user/emdash.AppImage';
     process.env.APPDIR = '/tmp/.mount_emdashTest';
     process.env.ARGV0 = '/home/user/emdash.AppImage';
@@ -98,8 +98,8 @@ describe('resolveUserEnv (AppImage env scrub)', () => {
 
     await resolveUserEnv();
 
-    expect(execSyncMock).toHaveBeenCalledTimes(1);
-    const opts = execSyncMock.mock.calls[0]?.[1] as { env?: NodeJS.ProcessEnv } | undefined;
+    expect(execFileSyncMock).toHaveBeenCalledTimes(1);
+    const opts = execFileSyncMock.mock.calls[0]?.[2] as { env?: NodeJS.ProcessEnv } | undefined;
     expect(opts?.env).toBeDefined();
     const probeEnv = opts!.env!;
     for (const key of SCRUBBED_KEYS) {

--- a/src/main/utils/userEnv.ts
+++ b/src/main/utils/userEnv.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
@@ -114,11 +114,21 @@ export async function resolveUserEnv(): Promise<void> {
     return;
   }
 
-  const shell = process.env.SHELL ?? (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+  const rawShell = process.env.SHELL ?? (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+  // Only accept absolute, simple paths — defends against a maliciously-set
+  // SHELL like `bash; touch /tmp/pwn; #` that would otherwise be parsed as
+  // a shell command if we used execSync. We pass argv directly with execFile,
+  // but the validation also rules out non-binaries that wouldn't make sense.
+  const shell =
+    rawShell.startsWith('/') && /^[A-Za-z0-9_./-]+$/.test(rawShell)
+      ? rawShell
+      : process.platform === 'darwin'
+        ? '/bin/zsh'
+        : '/bin/bash';
   const baseEnv = buildExternalToolEnv();
 
   try {
-    const raw = execSync(`${shell} -ilc 'env'`, {
+    const raw = execFileSync(shell, ['-ilc', 'env'], {
       encoding: 'utf8',
       timeout: 5_000,
       // Route through buildExternalToolEnv so AppImage runtime vars (APPIMAGE,


### PR DESCRIPTION
## Summary
- Fixes the DeepSec high-severity findings for repo-controlled BYOI command migration and SSH/remote-editor argument injection.
- Hardens Git, SSH, skill filesystem, Electron navigation, release-script, SQLite migration, and Claude trust-file paths against injection, traversal, and stale-write risks.
- Moves GitHub auth tokens out of argv and removes implicit credential fallbacks for BYOI provisioning.

## What Was Done
- Blocked silent migration of `.emdash.json` `workspaceProvider` commands so repo-controlled shell commands are not imported without user intent.
- Added SSH host/username validation and percent-encoded vscode-remote authorities/paths to prevent `ProxyCommand`/URL injection.
- Added allowlists and separators for release CLI flags and Git positional arguments, including clone, branch operations, PR fetch inputs, refs used in show/diff, and GitHub-controller clone flow via shared clone utils.
- Added skill-id validation and strict `SKILLS_ROOT` symlink checks for install/uninstall/sync paths.
- Passed GitHub auth via `GIT_CONFIG_*` environment variables instead of `git -c ...` argv so tokens are not exposed in process listings locally or remotely.
- Required BYOI provision output to explicitly include `username` and either `password` or `useAgent: true`, avoiding silent fallback to local `$USER`/`SSH_AUTH_SOCK`.
- Vacuumed copied app secrets and made the app-secret database migration atomic via a staging path before rename.
- Default-denied non-internal Electron navigations/window opens and removed `file://` from internal URL handling.
- Replaced shell-string env probing with `execFileSync` plus conservative `$SHELL` validation.
- Added optimistic concurrency checks and retries for `.claude.json` trust updates to avoid TOCTOU clobbering.
- Tightened bundled migration lookup to exact migration filenames and restored `foreign_keys` reliably on legacy import failures.

## Why
DeepSec identified multiple places where untrusted repo, renderer, GitHub API, CLI, filesystem, or environment values could be reinterpreted as shell/Git/SSH options, escape expected paths, leak credentials, or leave sensitive deleted bytes recoverable. These changes fail closed at trust boundaries, prefer argv/env-safe APIs, and make migration/update operations atomic where needed.

## DeepSec Coverage
- HIGH: 2/2 fixed
- MEDIUM: 16/16 fixed
- HIGH_BUG: 1/1 fixed
- BUG: 8/9 fixed
- Not fixed: migration SHA-256 verification, because the report itself marks it as not a security vulnerability and this PR intentionally leaves it as-is.

## Validation
- `pnpm run format` passed
- `pnpm run lint` passed
- `pnpm run typecheck` passed
- `pnpm run test` failed: existing Featurebase test mock issue in `src/main/core/featurebase/featurebase-issue-provider.test.ts` where the mocked `./featurebase-connection-service` does not export `NOT_CONFIGURED_ERROR`.

## Commits
- `fix: harden git and ssh arguments`
- `fix: avoid implicit credential exposure`
- `fix: harden filesystem and release paths`