### PR TITLE
fix: remote agent selection in create conversation

### DIFF
--- a/src/renderer/features/projects/components/project-titlebar.tsx
+++ b/src/renderer/features/projects/components/project-titlebar.tsx
@@ -127,21 +127,13 @@ export const ProjectTitlebar = observer(function ProjectTitlebar() {
   if (!mounted) return <Titlebar leftSlot={<ProjectTitlebarLeft projectId={projectId} />} />;
 
   const isRemote = mounted.data.type === 'ssh';
-  const sshConnectionId = mounted.data.type === 'ssh' ? mounted.data.connectionId : null;
 
   return (
     <Titlebar
       leftSlot={<MountedProjectTitlebarLeft projectId={projectId} />}
       rightSlot={
         <div className="flex items-center gap-2 mr-2">
-          {!isRemote && (
-            <OpenInMenu
-              path={mounted.data.path}
-              isRemote={isRemote}
-              sshConnectionId={sshConnectionId}
-              className="h-7 bg-background"
-            />
-          )}
+          {!isRemote && <OpenInMenu path={mounted.data.path} className="h-7 bg-background" />}
           <ToggleGroup
             variant="outline"
             size="sm"

--- a/src/renderer/features/projects/stores/project-selectors.ts
+++ b/src/renderer/features/projects/stores/project-selectors.ts
@@ -58,6 +58,12 @@ export function mountedProjectData(
   return store?.mountedProject?.data ?? null;
 }
 
+/** Returns the SSH connection id for a mounted SSH project, otherwise undefined. */
+export function getProjectSshConnectionId(projectId: string): string | undefined {
+  const data = mountedProjectData(getProjectStore(projectId));
+  return data?.type === 'ssh' ? data.connectionId : undefined;
+}
+
 /** Returns the display name from any project store variant. */
 export function projectDisplayName(store: ProjectStore | undefined): string | undefined {
   return store?.name ?? undefined;

--- a/src/renderer/features/tasks/commands.ts
+++ b/src/renderer/features/tasks/commands.ts
@@ -1,5 +1,4 @@
 import { TASK_COMMAND_DEFS, type CommandDef, type TaskCommandId } from '@shared/commands';
-import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import {
   asProvisioned,
   getRegisteredTaskData,
@@ -36,10 +35,6 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
       const taskView = getTaskView(projectId, taskId);
       const tabManager = taskView?.tabManager;
 
-      const mountedProject = asMounted(getProjectStore(projectId));
-      const connectionId =
-        mountedProject?.data.type === 'ssh' ? mountedProject.data.connectionId : undefined;
-
       const taskMgr = getTaskManagerStore(projectId);
       const taskIds = taskMgr ? Array.from(taskMgr.tasks.keys()) : [];
       const currentIdx = taskIds.indexOf(taskId);
@@ -74,7 +69,6 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
             showModal('createConversationModal', {
               projectId,
               taskId,
-              connectionId,
               onSuccess: ({ conversationId }) => {
                 tabManager?.openConversation(conversationId);
                 taskView?.setFocusedRegion('main');

--- a/src/renderer/features/tasks/conversations/conversations-panel.tsx
+++ b/src/renderer/features/tasks/conversations/conversations-panel.tsx
@@ -1,7 +1,6 @@
 import { MessageSquare } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useMemo, useRef } from 'react';
-import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import { useIsActiveTask } from '@renderer/features/tasks/hooks/use-is-active-task';
 import { useProvisionedTask, useTaskViewContext } from '@renderer/features/tasks/task-view-context';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
@@ -22,16 +21,13 @@ export const ConversationsPanel = observer(function ConversationsPanel() {
   const { tabManager: tm } = provisioned.taskView;
   const showCreateConversationModal = useShowModal('createConversationModal');
   const isActive = useIsActiveTask(taskId);
-  const mountedProject = asMounted(getProjectStore(projectId));
-  const shouldSetWorkingOnEnter = mountedProject?.data.type !== 'ssh';
-  const remoteConnectionId =
-    mountedProject?.data.type === 'ssh' ? mountedProject.data.connectionId : undefined;
+  const remoteConnectionId = provisioned.workspace.sshConnectionId;
+  const shouldSetWorkingOnEnter = !remoteConnectionId;
 
   const autoFocus = isActive && provisioned.taskView.focusedRegion === 'main';
 
   const handleCreate = () =>
     showCreateConversationModal({
-      connectionId: remoteConnectionId,
       projectId,
       taskId,
       onSuccess: ({ conversationId }) => {

--- a/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
+++ b/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
@@ -1,5 +1,6 @@
 import { observer } from 'mobx-react-lite';
 import { useCallback, useState } from 'react';
+import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { useAgentAutoApproveDefaults } from '@renderer/features/tasks/hooks/useAgentAutoApproveDefaults';
 import { asProvisioned, getTaskStore } from '@renderer/features/tasks/stores/task-selectors';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
@@ -24,15 +25,14 @@ function getConversationsPaneSize() {
 }
 
 export const CreateConversationModal = observer(function CreateConversationModal({
-  connectionId,
   onSuccess,
   projectId,
   taskId,
 }: BaseModalProps<{ conversationId: string }> & {
-  connectionId?: string;
   projectId: string;
   taskId: string;
 }) {
+  const connectionId = getProjectSshConnectionId(projectId);
   const { providerId, setProviderOverride, createDisabled } = useEffectiveProvider(connectionId);
   const conversationMgr = asProvisioned(getTaskStore(projectId, taskId))?.conversations;
   const autoApproveDefaults = useAgentAutoApproveDefaults();

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -72,9 +72,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   const projectData = selectedProjectId
     ? mountedProjectData(getProjectManagerStore().projects.get(selectedProjectId))
     : null;
-  const connectionId = projectData?.type === 'ssh' ? projectData.connectionId : undefined;
-
-  const initialConversation = useInitialConversationState(connectionId);
+  const initialConversation = useInitialConversationState(selectedProjectId);
   const autoApproveDefaults = useAgentAutoApproveDefaults();
 
   useEffect(() => setUseBYOI(false), [selectedProjectId]);
@@ -263,7 +261,6 @@ export const CreateTaskModal = observer(function CreateTaskModal({
               currentBranch={currentBranch}
               isUnborn={isUnborn}
               initialConversation={initialConversation}
-              connectionId={connectionId}
             />
           )}
           {selectedStrategy === 'from-issue' && (
@@ -276,7 +273,6 @@ export const CreateTaskModal = observer(function CreateTaskModal({
               disabled={isTransitioning}
               isUnborn={isUnborn}
               initialConversation={initialConversation}
-              connectionId={connectionId}
             />
           )}
           {selectedStrategy === 'from-pull-request' && (
@@ -292,7 +288,6 @@ export const CreateTaskModal = observer(function CreateTaskModal({
                 repositoryUrl={repositoryUrl}
                 disabled={isTransitioning || fromPrUnavailable}
                 initialConversation={initialConversation}
-                connectionId={connectionId}
               />
             </div>
           )}

--- a/src/renderer/features/tasks/create-task-modal/from-branch-content.tsx
+++ b/src/renderer/features/tasks/create-task-modal/from-branch-content.tsx
@@ -12,7 +12,6 @@ interface FromBranchContentProps {
   currentBranch?: string | null;
   isUnborn?: boolean;
   initialConversation: InitialConversationState;
-  connectionId?: string;
 }
 
 export function FromBranchContent({
@@ -21,7 +20,6 @@ export function FromBranchContent({
   currentBranch,
   isUnborn,
   initialConversation,
-  connectionId,
 }: FromBranchContentProps) {
   return (
     <div className="flex flex-col gap-4">
@@ -32,7 +30,7 @@ export function FromBranchContent({
         isUnborn={isUnborn}
       />
       <TaskNameField state={state} />
-      <InitialConversationField state={initialConversation} connectionId={connectionId} />
+      <InitialConversationField state={initialConversation} />
     </div>
   );
 }

--- a/src/renderer/features/tasks/create-task-modal/from-issue-content.tsx
+++ b/src/renderer/features/tasks/create-task-modal/from-issue-content.tsx
@@ -18,7 +18,6 @@ interface FromIssueContentProps {
   disabled?: boolean;
   isUnborn?: boolean;
   initialConversation: InitialConversationState;
-  connectionId?: string;
 }
 
 export function FromIssueContent({
@@ -30,7 +29,6 @@ export function FromIssueContent({
   disabled,
   isUnborn,
   initialConversation,
-  connectionId,
 }: FromIssueContentProps) {
   const [isSelecting, setIsSelecting] = useState(!state.linkedIssue);
 
@@ -76,7 +74,6 @@ export function FromIssueContent({
       <InitialConversationField
         state={initialConversation}
         linkedIssue={state.linkedIssue ?? undefined}
-        connectionId={connectionId}
       />
     </div>
   );

--- a/src/renderer/features/tasks/create-task-modal/from-pr-content.tsx
+++ b/src/renderer/features/tasks/create-task-modal/from-pr-content.tsx
@@ -13,7 +13,6 @@ interface FromPrContentProps {
   repositoryUrl?: string;
   disabled?: boolean;
   initialConversation: InitialConversationState;
-  connectionId?: string;
 }
 
 export function FromPrContent({
@@ -22,7 +21,6 @@ export function FromPrContent({
   repositoryUrl,
   disabled,
   initialConversation,
-  connectionId,
 }: FromPrContentProps) {
   return (
     <div className="flex flex-col gap-4">
@@ -40,7 +38,7 @@ export function FromPrContent({
         disabled={disabled}
       />
       <TaskNameField state={state} />
-      <InitialConversationField state={initialConversation} connectionId={connectionId} />
+      <InitialConversationField state={initialConversation} />
     </div>
   );
 }

--- a/src/renderer/features/tasks/create-task-modal/initial-conversation-section.tsx
+++ b/src/renderer/features/tasks/create-task-modal/initial-conversation-section.tsx
@@ -1,6 +1,7 @@
 import { useMemo, useState } from 'react';
 import type { AgentProviderId } from '@shared/agent-provider-registry';
 import type { Issue } from '@shared/tasks';
+import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { buildTaskContextActions } from '@renderer/features/tasks/conversations/context-actions';
 import { useEffectiveProvider } from '@renderer/features/tasks/conversations/use-effective-provider';
@@ -16,25 +17,28 @@ export type InitialConversationState = {
   setProvider: (provider: AgentProviderId | null) => void;
   prompt: string;
   setPrompt: (prompt: string) => void;
+  connectionId?: string;
 };
 
-export function useInitialConversationState(connectionId?: string): InitialConversationState {
+export function useInitialConversationState(projectId?: string): InitialConversationState {
+  const connectionId = projectId ? getProjectSshConnectionId(projectId) : undefined;
   const { providerId, setProviderOverride } = useEffectiveProvider(connectionId);
   const [prompt, setPrompt] = useState('');
-  return { provider: providerId, setProvider: setProviderOverride, prompt, setPrompt };
+  return {
+    provider: providerId,
+    setProvider: setProviderOverride,
+    prompt,
+    setPrompt,
+    connectionId,
+  };
 }
 
 interface InitialConversationFieldProps {
   state: InitialConversationState;
   linkedIssue?: Issue;
-  connectionId?: string;
 }
 
-export function InitialConversationField({
-  state,
-  linkedIssue,
-  connectionId,
-}: InitialConversationFieldProps) {
+export function InitialConversationField({ state, linkedIssue }: InitialConversationFieldProps) {
   const { value: reviewPrompt } = useAppSettingsKey('reviewPrompt');
   const autoApproveDefaults = useAgentAutoApproveDefaults();
   const contextActions = useMemo(
@@ -54,7 +58,7 @@ export function InitialConversationField({
           <AgentSelector
             value={state.provider}
             onChange={(provider) => state.setProvider(provider)}
-            connectionId={connectionId}
+            connectionId={state.connectionId}
             className="rounded-none border-0 border-b"
           />
           <Textarea

--- a/src/renderer/features/tasks/task-titlebar.tsx
+++ b/src/renderer/features/tasks/task-titlebar.tsx
@@ -133,7 +133,7 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
                 <MicroLabel className="text-foreground-passive items-center flex">Task</MicroLabel>
                 <span className="text-sm tracking-tight">{taskDisplayName(taskStore)}</span>
               </div>
-              <OpenInMenu path={provisionedTask.path} />
+              {!isRemoteProject && <OpenInMenu path={provisionedTask.path} />}
               <div className="flex flex-col gap-1 border border-border rounded-md p-2">
                 <span className="flex items-center gap-1 text-foreground-muted">
                   <GitBranch className="size-3.5" />

--- a/src/renderer/features/tasks/terminals/terminal-panel.tsx
+++ b/src/renderer/features/tasks/terminals/terminal-panel.tsx
@@ -2,7 +2,6 @@ import { useHotkey } from '@tanstack/react-hotkeys';
 import { Terminal } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useMemo, useState } from 'react';
-import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { useProvisionedTask, useTaskViewContext } from '@renderer/features/tasks/task-view-context';
 import {
@@ -32,9 +31,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
   const lifecycleScriptsMgr = provisionedTask.workspace.lifecycleScripts ?? null;
   const { value: keyboard } = useAppSettingsKey('keyboard');
   const isActive = useIsActiveTask(taskId);
-  const mountedProject = asMounted(getProjectStore(projectId));
-  const remoteConnectionId =
-    mountedProject?.data.type === 'ssh' ? mountedProject.data.connectionId : undefined;
+  const remoteConnectionId = provisionedTask.workspace.sshConnectionId;
   const [isPanelFocused, setIsPanelFocused] = useState(false);
   const newTerminalHotkey = getEffectiveHotkey('newTerminal', keyboard);
 

--- a/src/renderer/lib/components/titlebar/open-in-menu.tsx
+++ b/src/renderer/lib/components/titlebar/open-in-menu.tsx
@@ -17,19 +17,11 @@ import { cn } from '@renderer/utils/utils';
 
 interface OpenInMenuProps {
   path: string;
-  isRemote?: boolean;
-  sshConnectionId?: string | null;
   className?: string;
   borderless?: boolean;
 }
 
-export const OpenInMenu: React.FC<OpenInMenuProps> = ({
-  path,
-  className,
-  isRemote = false,
-  sshConnectionId = null,
-  borderless = false,
-}) => {
+export const OpenInMenu: React.FC<OpenInMenuProps> = ({ path, className, borderless = false }) => {
   const { toast } = useToast();
   const { icons, labels, installedApps, availability, loading } = useOpenInApps();
   const { value: openIn, update } = useAppSettingsKey('openIn');
@@ -53,8 +45,6 @@ export const OpenInMenu: React.FC<OpenInMenuProps> = ({
         const res = await rpc.app.openIn({
           app: appId,
           path,
-          isRemote,
-          sshConnectionId: sshConnectionId ?? undefined,
         });
         if (!res?.success) {
           toast({
@@ -71,7 +61,7 @@ export const OpenInMenu: React.FC<OpenInMenuProps> = ({
         });
       }
     },
-    [labels, path, isRemote, sshConnectionId, toast]
+    [labels, path, toast]
   );
 
   const sortedApps = useMemo(() => {


### PR DESCRIPTION
issue:
- connectionId was not passed, therefore dependencies were probed for local context and not remote context

fix:
- derive ssh connection context at project/task boundaries instead of threading it through conversation call sites
- ensure create conversation and initial conversation agent selection uses remote dependency state for ssh projects
- hide Open In menu for remote projects and remove remote props from OpenInMenu component