### PR TITLE
feat: git remote split for fork workflows

### DIFF
--- a/agents/workflows/worktrees.md
+++ b/agents/workflows/worktrees.md
@@ -28,7 +28,8 @@ Base project settings are DB-backed Project Settings, not runtime `.emdash.json`
 
 - `worktreeDirectory`
 - `defaultBranch`
-- `remote`
+- `baseRemote`
+- `pushRemote`
 - `tmux`
 - `workspaceProvider`
 

--- a/src/main/core/git/git-fetch-service.ts
+++ b/src/main/core/git/git-fetch-service.ts
@@ -13,7 +13,8 @@ export class GitFetchService {
 
   constructor(
     private readonly git: GitService,
-    private readonly hasGitHubToken: () => Promise<boolean>
+    private readonly hasGitHubToken: () => Promise<boolean>,
+    private readonly getRemote: () => Promise<string | undefined>
   ) {}
 
   /** Start the background fetch loop: immediate fetch, then every `intervalMs`. */
@@ -41,8 +42,8 @@ export class GitFetchService {
 
   private _doFetch(): Promise<Result<void, FetchError>> {
     if (this._inflight) return this._inflight;
-    this._inflight = this.git
-      .fetch()
+    this._inflight = this.getRemote()
+      .then((remote) => this.git.fetch(remote))
       .catch((e): Result<void, FetchError> => {
         log.warn('GitFetchService: fetch threw unexpectedly', { error: String(e) });
         return err({ type: 'error', message: String(e) });

--- a/src/main/core/git/impl/git-service.test.ts
+++ b/src/main/core/git/impl/git-service.test.ts
@@ -312,3 +312,19 @@ describe('computeBaseRef', () => {
     expect(computeBaseRef('/main')).toBe('main');
   });
 });
+
+describe('GitService.push', () => {
+  it('pushes the current branch to the preferred remote explicitly', async () => {
+    const svc = makeService(
+      makeExec({
+        'branch --show-current': 'feature/test\n',
+        'push fork HEAD:feature/test': 'pushed',
+      })
+    );
+
+    await expect(svc.push('fork')).resolves.toEqual({
+      success: true,
+      data: { output: 'pushed' },
+    });
+  });
+});

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -982,6 +982,16 @@ export class GitService implements GitProvider, IDisposable {
     };
 
     try {
+      const remote = preferredRemote?.trim();
+      if (remote) {
+        const { stdout } = await this.ctx.exec('git', ['branch', '--show-current']);
+        const currentBranch = stdout.trim();
+        if (!currentBranch) {
+          return err({ type: 'error', message: 'No branch checked out' });
+        }
+        const output = await doPush(['push', remote, `HEAD:${currentBranch}`]);
+        return ok({ output });
+      }
       const output = await doPush(['push']);
       return ok({ output });
     } catch (error: unknown) {
@@ -1000,15 +1010,7 @@ export class GitService implements GitProvider, IDisposable {
         try {
           const { stdout: branchOut } = await this.ctx.exec('git', ['branch', '--show-current']);
           const currentBranch = branchOut.trim();
-          let pushRemote = preferredRemote?.trim() || DEFAULT_REMOTE_NAME;
-          try {
-            const { stdout: remoteOut } = await this.ctx.exec('git', [
-              'config',
-              '--get',
-              `branch.${currentBranch}.remote`,
-            ]);
-            if (remoteOut.trim()) pushRemote = remoteOut.trim();
-          } catch {}
+          const pushRemote = preferredRemote?.trim() || DEFAULT_REMOTE_NAME;
           const output = await doPush(['push', '--set-upstream', pushRemote, currentBranch]);
           return ok({ output });
         } catch (upstreamError: unknown) {

--- a/src/main/core/git/remote-preference.test.ts
+++ b/src/main/core/git/remote-preference.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { DEFAULT_REMOTE_NAME, selectPreferredRemote } from '@shared/git-utils';
+import {
+  DEFAULT_REMOTE_NAME,
+  resolveConfiguredRemotes,
+  selectPreferredRemote,
+} from '@shared/git-utils';
 
 const r = (name: string, url = '') => ({ name, url });
 
@@ -20,5 +24,37 @@ describe('selectPreferredRemote', () => {
 
   it('falls back to sentinel when no remotes are listed', () => {
     expect(selectPreferredRemote('upstream', [])).toEqual({ name: DEFAULT_REMOTE_NAME, url: '' });
+  });
+});
+
+describe('resolveConfiguredRemotes', () => {
+  it('resolves configured base and push remotes when both exist', () => {
+    expect(
+      resolveConfiguredRemotes({ baseRemote: 'upstream', pushRemote: 'origin' }, [
+        r('origin'),
+        r('upstream'),
+      ])
+    ).toEqual({
+      baseRemote: r('upstream'),
+      pushRemote: r('origin'),
+    });
+  });
+
+  it('falls back to base remote when push remote is unset or unknown', () => {
+    expect(
+      resolveConfiguredRemotes({ baseRemote: 'upstream' }, [r('origin'), r('upstream')])
+    ).toEqual({
+      baseRemote: r('upstream'),
+      pushRemote: r('upstream'),
+    });
+    expect(
+      resolveConfiguredRemotes({ baseRemote: 'upstream', pushRemote: 'missing' }, [
+        r('origin'),
+        r('upstream'),
+      ])
+    ).toEqual({
+      baseRemote: r('upstream'),
+      pushRemote: r('upstream'),
+    });
   });
 });

--- a/src/main/core/git/repository-service.ts
+++ b/src/main/core/git/repository-service.ts
@@ -12,7 +12,7 @@ import type {
   RemoteBranchesPayload,
   RenameBranchError,
 } from '@shared/git';
-import { selectPreferredRemote } from '@shared/git-utils';
+import { resolveConfiguredRemotes } from '@shared/git-utils';
 import type { ProjectRemoteState } from '@shared/projects';
 import type { Result } from '@shared/result';
 import type { ProjectSettingsProvider } from '@main/core/projects/settings/provider';
@@ -24,21 +24,24 @@ export class GitRepositoryService {
     private readonly settings: ProjectSettingsProvider
   ) {}
 
-  async getBaseRemote(): Promise<string> {
-    const [configured, remotes] = await Promise.all([
-      this.settings.getBaseRemote().catch(() => undefined),
+  async getConfiguredRemotes(): Promise<{ baseRemote: string; pushRemote: string }> {
+    const [settings, remotes] = await Promise.all([
+      this.settings.get().catch(() => undefined),
       this.git.getRemotes().catch(() => []),
     ]);
-    return selectPreferredRemote(configured, remotes).name;
+    const configured = resolveConfiguredRemotes(settings, remotes);
+    return {
+      baseRemote: configured.baseRemote.name,
+      pushRemote: configured.pushRemote.name,
+    };
+  }
+
+  async getBaseRemote(): Promise<string> {
+    return (await this.getConfiguredRemotes()).baseRemote;
   }
 
   async getPushRemote(): Promise<string> {
-    const [configured, baseRemote, remotes] = await Promise.all([
-      this.settings.getPushRemote().catch(() => undefined),
-      this.getBaseRemote(),
-      this.git.getRemotes().catch(() => []),
-    ]);
-    return selectPreferredRemote(configured ?? baseRemote, remotes).name;
+    return (await this.getConfiguredRemotes()).pushRemote;
   }
 
   async getRepositoryInfo(): Promise<{ isUnborn: boolean; currentBranch: string | null }> {

--- a/src/main/core/git/repository-service.ts
+++ b/src/main/core/git/repository-service.ts
@@ -24,12 +24,21 @@ export class GitRepositoryService {
     private readonly settings: ProjectSettingsProvider
   ) {}
 
-  async getConfiguredRemote(): Promise<string> {
+  async getBaseRemote(): Promise<string> {
     const [configured, remotes] = await Promise.all([
-      this.settings.getRemote().catch(() => undefined),
+      this.settings.getBaseRemote().catch(() => undefined),
       this.git.getRemotes().catch(() => []),
     ]);
     return selectPreferredRemote(configured, remotes).name;
+  }
+
+  async getPushRemote(): Promise<string> {
+    const [configured, baseRemote, remotes] = await Promise.all([
+      this.settings.getPushRemote().catch(() => undefined),
+      this.getBaseRemote(),
+      this.git.getRemotes().catch(() => []),
+    ]);
+    return selectPreferredRemote(configured ?? baseRemote, remotes).name;
   }
 
   async getRepositoryInfo(): Promise<{ isUnborn: boolean; currentBranch: string | null }> {
@@ -42,7 +51,7 @@ export class GitRepositoryService {
 
   async getBranchesPayload(): Promise<BranchesPayload> {
     const remotes = await this.git.getRemotes();
-    const remote = await this.getConfiguredRemote();
+    const remote = await this.getBaseRemote();
     const branches = await this.git.getBranches();
     const gitDefaultBranch = await this.git.getDefaultBranch(remote);
 
@@ -124,7 +133,7 @@ export class GitRepositoryService {
   }
 
   async getBranches(): Promise<Branch[]> {
-    await this.fetch();
+    await this.fetch(await this.getBaseRemote());
     return this.git.getBranches();
   }
 
@@ -147,7 +156,7 @@ export class GitRepositoryService {
     const [branches, remotes, remote] = await Promise.all([
       this.git.getBranches(),
       this.git.getRemotes(),
-      this.getConfiguredRemote(),
+      this.getBaseRemote(),
     ]);
     const remoteBranches = branches.filter((b): b is RemoteBranch => b.type === 'remote');
     const gitDefaultBranch = await this.git.getDefaultBranch(remote);
@@ -157,7 +166,7 @@ export class GitRepositoryService {
   async getRemoteState(): Promise<ProjectRemoteState> {
     try {
       const remotes = await this.getRemotes();
-      const remoteName = await this.getConfiguredRemote();
+      const remoteName = await this.getBaseRemote();
       const remoteUrl = remotes.find((r) => r.name === remoteName)?.url;
       return { hasRemote: remotes.length > 0, selectedRemoteUrl: remoteUrl ?? null };
     } catch {

--- a/src/main/core/issues/controller.ts
+++ b/src/main/core/issues/controller.ts
@@ -57,7 +57,7 @@ async function withResolvedRemote<T extends IssueQueryOpts>(opts: T): Promise<T>
   const project = projectManager.getProject(opts.projectId);
   if (!project) return opts;
 
-  const remote = await project.repository.getConfiguredRemote().catch(() => undefined);
+  const remote = await project.repository.getBaseRemote().catch(() => undefined);
   return { ...opts, remote };
 }
 

--- a/src/main/core/projects/create-project-provider.ts
+++ b/src/main/core/projects/create-project-provider.ts
@@ -154,7 +154,9 @@ function buildProvider(
     ctx,
     host: worktreeHost,
   });
-  const gitFetchService = new GitFetchService(repoGit, hasGitHubToken);
+  const gitFetchService = new GitFetchService(repoGit, hasGitHubToken, () =>
+    repository.getBaseRemote()
+  );
   gitFetchService.start();
 
   return new ProjectProvider(

--- a/src/main/core/projects/settings/effective-task-settings.test.ts
+++ b/src/main/core/projects/settings/effective-task-settings.test.ts
@@ -45,6 +45,7 @@ describe('getEffectiveTaskSettings', () => {
     });
     expect(settings).not.toHaveProperty('tmux');
     expect(settings).not.toHaveProperty('remote');
+    expect(settings).not.toHaveProperty('baseRemote');
   });
 
   it('falls back to defaults plus project settings when the task config is invalid', async () => {

--- a/src/main/core/projects/settings/legacy-project-settings-migration.ts
+++ b/src/main/core/projects/settings/legacy-project-settings-migration.ts
@@ -1,9 +1,9 @@
 import { remoteNameFromQualifiedRef } from '@shared/git-utils';
 import {
   baseProjectSettingsSchema,
+  legacyBaseProjectSettingsSchema,
   legacyProjectConfigSchema,
   type BaseProjectSettings,
-  type ProjectSettings,
 } from '@shared/project-settings';
 import type { UpdateProjectSettingsError } from '@shared/projects';
 import type { Result } from '@shared/result';
@@ -24,10 +24,10 @@ export type LegacyProjectSettingsMigrationArgs = {
 };
 
 function normalizeLegacyDefaultBranch(
-  branch: ProjectSettings['defaultBranch'],
+  branch: BaseProjectSettings['defaultBranch'],
   remote: string | undefined,
   fallback: string
-): ProjectSettings['defaultBranch'] {
+): BaseProjectSettings['defaultBranch'] {
   if (!branch) return undefined;
   const branchName = typeof branch === 'string' ? branch.trim() : branch.name.trim();
   if (!branchName) return undefined;
@@ -38,7 +38,12 @@ function normalizeLegacyDefaultBranch(
 
 async function readLegacyProjectConfig(
   configReader: Pick<FileSystemProvider, 'exists' | 'read'> | undefined
-): Promise<ProjectSettings | undefined> {
+): Promise<
+  | (BaseProjectSettings & {
+      remote?: string;
+    })
+  | undefined
+> {
   if (!configReader) return undefined;
   try {
     if (!(await configReader.exists('.emdash.json'))) return undefined;
@@ -67,22 +72,28 @@ export async function migrateLegacyProjectSettingsIfNeeded({
 
   const current = readJson(
     row.baseProjectSettingsJson,
-    baseProjectSettingsSchema,
+    legacyBaseProjectSettingsSchema,
     'base project settings'
   );
+  const { remote, ...currentSettings } = current;
   const legacy = await readLegacyProjectConfig(configReader);
-  const next: BaseProjectSettings = { ...current };
+  const next: BaseProjectSettings = baseProjectSettingsSchema.parse({
+    ...currentSettings,
+    baseRemote: currentSettings.baseRemote ?? remote,
+  });
 
   if (legacy) {
     if (legacy.worktreeDirectory !== undefined) {
       const normalized = await normalizeStoredWorktreeDirectory(legacy.worktreeDirectory);
       if (normalized.success) next.worktreeDirectory = normalized.data;
     }
-    if (legacy.remote !== undefined) next.remote = legacy.remote;
+    if (legacy.remote !== undefined) next.baseRemote = legacy.remote;
+    if (legacy.baseRemote !== undefined) next.baseRemote = legacy.baseRemote;
+    if (legacy.pushRemote !== undefined) next.pushRemote = legacy.pushRemote;
     if (legacy.defaultBranch !== undefined) {
       next.defaultBranch = normalizeLegacyDefaultBranch(
         legacy.defaultBranch,
-        legacy.remote ?? next.remote,
+        legacy.baseRemote ?? legacy.remote ?? next.baseRemote,
         defaultBranchFallback
       );
     }

--- a/src/main/core/projects/settings/project-settings.test.ts
+++ b/src/main/core/projects/settings/project-settings.test.ts
@@ -111,6 +111,32 @@ describe('ProjectSettingsProvider worktreeDirectory validation', () => {
     await expect(provider.getWorktreeDirectory()).resolves.toBe('/tmp/emdash/worktrees');
   });
 
+  it('migrates legacy remote setting to baseRemote', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-local-'));
+    tempDirs.push(projectPath);
+    const row = {
+      baseProjectSettingsJson: JSON.stringify({ remote: 'upstream' }),
+      shareableProjectSettingsJson: '{}',
+      legacyConfigMigratedAt: null,
+    };
+    const settingsStorage: ProjectSettingsStorage = {
+      get: async () => row,
+      insertIfMissing: vi.fn(),
+      update: async (_projectId, settings) => {
+        Object.assign(row, settings);
+      },
+    };
+    const provider = new LocalProjectSettingsProvider(
+      projectId(),
+      projectPath,
+      'main',
+      settingsStorage
+    );
+
+    await expect(provider.get()).resolves.toMatchObject({ baseRemote: 'upstream' });
+    expect(JSON.parse(row.baseProjectSettingsJson)).toEqual({ baseRemote: 'upstream' });
+  });
+
   it('keeps computed worktreeDirectory default separate from configured overrides', async () => {
     const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-local-'));
     tempDirs.push(projectPath);

--- a/src/main/core/projects/settings/provider.ts
+++ b/src/main/core/projects/settings/provider.ts
@@ -8,7 +8,8 @@ export type ProjectSettingsPatch = {
 
 export interface ProjectSettingsProvider {
   getDefaultBranch(): Promise<string>;
-  getRemote(): Promise<string>;
+  getBaseRemote(): Promise<string>;
+  getPushRemote(): Promise<string>;
   getDefaultWorktreeDirectory(): Promise<string>;
   getWorktreeDirectory(): Promise<string>;
   get(): Promise<ProjectSettings>;

--- a/src/main/core/projects/settings/providers/db-project-settings-provider.ts
+++ b/src/main/core/projects/settings/providers/db-project-settings-provider.ts
@@ -2,6 +2,7 @@ import { remoteNameFromQualifiedRef } from '@shared/git-utils';
 import {
   baseProjectSettingsSchema,
   DEFAULT_PRESERVE_PATTERNS,
+  legacyBaseProjectSettingsSchema,
   projectSettingsSchema,
   shareableProjectSettingsSchema,
   type BaseProjectSettings,
@@ -49,7 +50,7 @@ export abstract class DbProjectSettingsProvider implements ProjectSettingsProvid
     const projectDefaults = await appSettingsService.get('project');
     return {
       defaultBranch,
-      remote: remoteNameFromQualifiedRef(defaultBranch) ?? 'origin',
+      baseRemote: remoteNameFromQualifiedRef(defaultBranch) ?? 'origin',
       tmux: projectDefaults.tmuxByDefault,
     };
   }
@@ -100,12 +101,18 @@ export abstract class DbProjectSettingsProvider implements ProjectSettingsProvid
         legacyConfigMigratedAt: null,
       };
     }
+    const baseSettings = readJson(
+      row.baseProjectSettingsJson,
+      legacyBaseProjectSettingsSchema,
+      'base project settings'
+    );
+    const { remote, ...canonicalBaseSettings } = baseSettings;
+
     return {
-      base: readJson(
-        row.baseProjectSettingsJson,
-        baseProjectSettingsSchema,
-        'base project settings'
-      ),
+      base: baseProjectSettingsSchema.parse({
+        ...canonicalBaseSettings,
+        baseRemote: canonicalBaseSettings.baseRemote ?? remote,
+      }),
       shareable: readJson(
         row.shareableProjectSettingsJson,
         shareableProjectSettingsSchema,
@@ -214,13 +221,18 @@ export abstract class DbProjectSettingsProvider implements ProjectSettingsProvid
     const branch = settings.defaultBranch;
     if (!branch) return this.defaultBranchFallback;
     if (typeof branch === 'string') return branch;
-    const remote = settings.remote ?? 'origin';
+    const remote = settings.baseRemote ?? 'origin';
     return `${remote}/${branch.name}`;
   }
 
-  async getRemote(): Promise<string> {
+  async getBaseRemote(): Promise<string> {
     const settings = await this.get();
-    return settings.remote ?? 'origin';
+    return settings.baseRemote ?? 'origin';
+  }
+
+  async getPushRemote(): Promise<string> {
+    const settings = await this.get();
+    return settings.pushRemote ?? settings.baseRemote ?? 'origin';
   }
 
   async getDefaultWorktreeDirectory(): Promise<string> {

--- a/src/main/core/projects/settings/share-project-settings-to-config.test.ts
+++ b/src/main/core/projects/settings/share-project-settings-to-config.test.ts
@@ -54,7 +54,7 @@ describe('shareProjectSettingsToConfig', () => {
       settings: {
         get: vi.fn().mockResolvedValue({
           defaultBranch: 'origin/main',
-          remote: 'origin',
+          baseRemote: 'origin',
           tmux: true,
           preservePatterns: ['.env', '.env.local'],
           shellSetup: 'nvm use',

--- a/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -35,7 +35,8 @@ function makeSettings(preservePatterns: string[] = []): ProjectSettingsProvider 
     getDefaultWorktreeDirectory: async () => '',
     getWorktreeDirectory: async () => '',
     getDefaultBranch: async () => 'main',
-    getRemote: async () => 'origin',
+    getBaseRemote: async () => 'origin',
+    getPushRemote: async () => 'origin',
   } as ProjectSettingsProvider;
 }
 

--- a/src/main/core/projects/worktrees/worktree-service.ts
+++ b/src/main/core/projects/worktrees/worktree-service.ts
@@ -65,11 +65,11 @@ export class WorktreeService {
   }
 
   private async getRemoteCandidates(): Promise<string[]> {
-    const configuredRemote = (await this.projectSettings.getRemote().catch(() => '')).trim();
-    if (!configuredRemote || configuredRemote === DEFAULT_REMOTE_NAME) {
+    const baseRemote = (await this.projectSettings.getBaseRemote().catch(() => '')).trim();
+    if (!baseRemote || baseRemote === DEFAULT_REMOTE_NAME) {
       return [DEFAULT_REMOTE_NAME];
     }
-    return [configuredRemote, DEFAULT_REMOTE_NAME];
+    return [baseRemote, DEFAULT_REMOTE_NAME];
   }
 
   private async findCheckedOutPathForBranch(branchName: string): Promise<string | undefined> {

--- a/src/main/core/repository/controller.ts
+++ b/src/main/core/repository/controller.ts
@@ -104,12 +104,14 @@ export const repositoryController = createRPCController({
   ) => {
     const project = projectManager.getProject(projectId);
     if (!project) return err({ type: 'not_found' as const });
+    const baseRemote = await project.repository.getBaseRemote();
     const result = await project.repository.fetchPrForReview(
       prNumber,
       headRefName,
       headRepositoryUrl,
       headRefName,
-      isFork
+      isFork,
+      baseRemote
     );
     if (!result.success) return err(result.error);
     return ok({ localBranch: headRefName });

--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -52,9 +52,9 @@ export async function createTask(
   if (!project) {
     return err({ type: 'project-not-found' });
   }
-  const [, configuredRemote] = await Promise.all([
-    project.repository.getRemotes(),
-    project.repository.getConfiguredRemote(),
+  const [baseRemote, pushRemote] = await Promise.all([
+    project.repository.getBaseRemote(),
+    project.repository.getPushRemote(),
   ]);
 
   // Determines what gets stored as taskBranch in the DB and how the worktree is prepared.
@@ -88,12 +88,12 @@ export async function createTask(
         return err({ type: 'branch-create-failed', branch: taskBranch, error: createResult.error });
       }
       if (strategy.pushBranch) {
-        const publishResult = await project.repository.publishBranch(taskBranch, configuredRemote);
+        const publishResult = await project.repository.publishBranch(taskBranch, pushRemote);
         if (!publishResult.success) {
           warning = {
             type: 'branch-publish-failed',
             branch: taskBranch,
-            remote: configuredRemote,
+            remote: pushRemote,
             error: publishResult.error,
           };
         }
@@ -121,13 +121,13 @@ export async function createTask(
           strategy.headRepositoryUrl,
           strategy.headBranch,
           strategy.isFork,
-          configuredRemote
+          baseRemote
         );
         if (!fetchResult.success) {
           return err({
             type: 'pr-fetch-failed',
             error: fetchResult.error,
-            remote: configuredRemote,
+            remote: baseRemote,
           });
         }
       }
@@ -155,15 +155,12 @@ export async function createTask(
           });
         }
         if (strategy.pushBranch) {
-          const publishResult = await project.repository.publishBranch(
-            taskBranch,
-            configuredRemote
-          );
+          const publishResult = await project.repository.publishBranch(taskBranch, pushRemote);
           if (!publishResult.success) {
             warning = {
               type: 'branch-publish-failed',
               branch: taskBranch,
-              remote: configuredRemote,
+              remote: pushRemote,
               error: publishResult.error,
             };
           }

--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -52,10 +52,7 @@ export async function createTask(
   if (!project) {
     return err({ type: 'project-not-found' });
   }
-  const [baseRemote, pushRemote] = await Promise.all([
-    project.repository.getBaseRemote(),
-    project.repository.getPushRemote(),
-  ]);
+  const { baseRemote, pushRemote } = await project.repository.getConfiguredRemotes();
 
   // Determines what gets stored as taskBranch in the DB and how the worktree is prepared.
   let taskBranch: string | undefined;

--- a/src/main/core/workspaces/workspace-factory.ts
+++ b/src/main/core/workspaces/workspace-factory.ts
@@ -134,7 +134,8 @@ export function createWorkspaceFactory(
       context.fetchService ??
       new GitFetchService(
         gitService,
-        async () => (await githubConnectionService.getToken()) !== null
+        async () => (await githubConnectionService.getToken()) !== null,
+        () => repository.getBaseRemote()
       );
 
     const workspace: Workspace = {

--- a/src/renderer/features/projects/components/project-titlebar.tsx
+++ b/src/renderer/features/projects/components/project-titlebar.tsx
@@ -35,8 +35,8 @@ const MountedProjectTitlebarLeft = observer(function ProjectTitlebarLeft({
   const showConfirmDeleteProject = useShowModal('confirmActionModal');
 
   const repo = getRepositoryStore(projectId);
-  const configuredRemote = repo?.configuredRemote;
-  const remoteUrl = configuredRemote?.url;
+  const baseRemote = repo?.baseRemote;
+  const remoteUrl = baseRemote?.url;
   const repositoryUrl = repo?.repositoryUrl;
   const repository = parseGitHubRepository(repositoryUrl);
 

--- a/src/renderer/features/projects/components/settings-view/project-settings-form-model.test.ts
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form-model.test.ts
@@ -24,7 +24,8 @@ function makeForm(overrides: Partial<FormState> = {}): FormState {
     scriptTeardown: '',
     worktreeDirectory: '',
     defaultBranch: null,
-    remote: '',
+    baseRemote: '',
+    pushRemote: '',
     provisionCommand: '',
     terminateCommand: '',
     ...overrides,
@@ -45,7 +46,8 @@ describe('project settings form model', () => {
         },
         worktreeDirectory: '../worktrees',
         defaultBranch: 'upstream/main',
-        remote: 'upstream',
+        baseRemote: 'upstream',
+        pushRemote: 'origin',
         workspaceProvider: {
           type: 'script',
           provisionCommand: './provision.sh',
@@ -65,7 +67,8 @@ describe('project settings form model', () => {
       scriptTeardown: 'docker compose down',
       worktreeDirectory: '../worktrees',
       defaultBranch: { type: 'remote', branch: 'main', remote: upstream },
-      remote: 'upstream',
+      baseRemote: 'upstream',
+      pushRemote: 'origin',
       provisionCommand: './provision.sh',
       terminateCommand: './terminate.sh',
     });
@@ -100,7 +103,8 @@ describe('project settings form model', () => {
           scriptRun: 'pnpm dev',
           worktreeDirectory: '../worktrees',
           defaultBranch: { type: 'remote', branch: 'main', remote: origin },
-          remote: 'origin',
+          baseRemote: 'origin',
+          pushRemote: '',
           provisionCommand: ' ./provision.sh ',
           terminateCommand: ' ./terminate.sh ',
         })
@@ -116,7 +120,7 @@ describe('project settings form model', () => {
       },
       worktreeDirectory: '../worktrees',
       defaultBranch: 'origin/main',
-      remote: 'origin',
+      baseRemote: 'origin',
       workspaceProvider: {
         type: 'script',
         provisionCommand: './provision.sh',

--- a/src/renderer/features/projects/components/settings-view/project-settings-form-model.ts
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form-model.ts
@@ -16,7 +16,8 @@ export type FormState = {
   scriptTeardown: string;
   worktreeDirectory: string;
   defaultBranch: Branch | null;
-  remote: string;
+  baseRemote: string;
+  pushRemote: string;
   provisionCommand: string;
   terminateCommand: string;
 };
@@ -39,11 +40,11 @@ function blankToUndefined(value: string): string | undefined {
 
 export function settingsToForm(
   s: ProjectSettings,
-  configuredRemote: string,
+  baseRemote: string,
   remotes: { name: string; url: string }[]
 ): FormState {
-  const configuredRemoteMeta = remotes.find((remote) => remote.name === configuredRemote) ?? {
-    name: configuredRemote,
+  const baseRemoteMeta = remotes.find((remote) => remote.name === baseRemote) ?? {
+    name: baseRemote,
     url: '',
   };
 
@@ -55,9 +56,9 @@ export function settingsToForm(
     scriptRun: normalizeScript(s.scripts?.run),
     scriptTeardown: normalizeScript(s.scripts?.teardown),
     worktreeDirectory: s.worktreeDirectory ?? '',
-    defaultBranch:
-      projectDefaultBranchToBranch(s.defaultBranch, configuredRemoteMeta, remotes) ?? null,
-    remote: s.remote ?? '',
+    defaultBranch: projectDefaultBranchToBranch(s.defaultBranch, baseRemoteMeta, remotes) ?? null,
+    baseRemote: s.baseRemote ?? '',
+    pushRemote: s.pushRemote ?? '',
     provisionCommand: s.workspaceProvider?.provisionCommand ?? '',
     terminateCommand: s.workspaceProvider?.terminateCommand ?? '',
   };
@@ -90,7 +91,11 @@ export function formToSettings(f: FormState): ProjectSettings {
     scripts: hasScripts ? scripts : undefined,
     worktreeDirectory: blankToUndefined(f.worktreeDirectory),
     defaultBranch,
-    remote: blankToUndefined(f.remote),
+    baseRemote: blankToUndefined(f.baseRemote),
+    pushRemote:
+      f.pushRemote.trim() && f.pushRemote.trim() !== f.baseRemote.trim()
+        ? f.pushRemote.trim()
+        : undefined,
     workspaceProvider:
       provisionCommand && terminateCommand
         ? {

--- a/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
@@ -44,11 +44,11 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
 }: ProjectSettingsFormProps) {
   const repo = getRepositoryStore(projectId);
   const remotes = repo?.remotes ?? EMPTY_REMOTES;
-  const configuredRemote = repo?.configuredRemote.name ?? 'origin';
+  const baseRemote = repo?.baseRemote.name ?? 'origin';
   const isWorkspaceProviderEnabled = useFeatureFlag('workspace-provider');
   const formModel = useProjectSettingsForm({
     initial,
-    configuredRemote,
+    baseRemote,
     remotes,
     writeTargets,
     overrideState,

--- a/src/renderer/features/projects/components/settings-view/sections/base-project-settings-section.tsx
+++ b/src/renderer/features/projects/components/settings-view/sections/base-project-settings-section.tsx
@@ -1,5 +1,9 @@
 import type { Branch, Remote } from '@shared/git';
 import { ProjectBranchSelector } from '@renderer/lib/components/project-branch-selector';
+import {
+  RemoteSelectContent,
+  RemoteSelectItem,
+} from '@renderer/lib/components/remote-select-content';
 import { Field, FieldDescription, FieldTitle } from '@renderer/lib/ui/field';
 import { Input } from '@renderer/lib/ui/input';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@renderer/lib/ui/select';
@@ -88,28 +92,7 @@ export function BaseProjectSettingsSection({
               </span>
             </div>
           </SelectTrigger>
-          <SelectContent align="start" alignItemWithTrigger={false} sideOffset={6}>
-            {remotes.length > 0 ? (
-              remotes.map((r) => (
-                <SelectItem key={r.name} value={r.name} className="py-2">
-                  <div className="flex min-w-0 flex-1 items-center gap-2">
-                    <span className="relative -top-px shrink-0">{r.name}</span>
-                    {r.url ? (
-                      <span className="min-w-0 flex-1 truncate text-xs text-foreground-muted">
-                        {r.url}
-                      </span>
-                    ) : null}
-                  </div>
-                </SelectItem>
-              ))
-            ) : (
-              <SelectItem value="origin" className="py-2">
-                <div className="flex min-w-0 flex-1 items-center gap-2">
-                  <span className="relative -top-px shrink-0 font-medium">origin</span>
-                </div>
-              </SelectItem>
-            )}
-          </SelectContent>
+          <RemoteSelectContent remotes={remotes} />
         </Select>
       </Field>
 
@@ -139,17 +122,8 @@ export function BaseProjectSettingsSection({
             <SelectItem value={SAME_AS_BASE_REMOTE} className="py-2">
               <span className="relative -top-px shrink-0 font-medium">Same as base remote</span>
             </SelectItem>
-            {remotes.map((r) => (
-              <SelectItem key={r.name} value={r.name} className="py-2">
-                <div className="flex min-w-0 flex-1 items-center gap-2">
-                  <span className="relative -top-px shrink-0">{r.name}</span>
-                  {r.url ? (
-                    <span className="min-w-0 flex-1 truncate text-xs text-foreground-muted">
-                      {r.url}
-                    </span>
-                  ) : null}
-                </div>
-              </SelectItem>
+            {remotes.map((remote) => (
+              <RemoteSelectItem key={remote.name} remote={remote} />
             ))}
           </SelectContent>
         </Select>

--- a/src/renderer/features/projects/components/settings-view/sections/base-project-settings-section.tsx
+++ b/src/renderer/features/projects/components/settings-view/sections/base-project-settings-section.tsx
@@ -8,6 +8,8 @@ import { Switch } from '@renderer/lib/ui/switch';
 import { cn } from '@renderer/utils/utils';
 import type { FormState, FormUpdate } from '../project-settings-form-model';
 
+const SAME_AS_BASE_REMOTE = '__same_as_base_remote__';
+
 type BaseProjectSettingsSectionProps = {
   projectId: string;
   form: FormState;
@@ -25,8 +27,10 @@ export function BaseProjectSettingsSection({
   worktreeDirectoryError,
   update,
 }: BaseProjectSettingsSectionProps) {
-  const remoteValue = form.remote || 'origin';
-  const selectedRemote = remotes.find((remote) => remote.name === remoteValue);
+  const baseRemoteValue = form.baseRemote || 'origin';
+  const pushRemoteValue = form.pushRemote || SAME_AS_BASE_REMOTE;
+  const selectedBaseRemote = remotes.find((remote) => remote.name === baseRemoteValue);
+  const selectedPushRemote = remotes.find((remote) => remote.name === pushRemoteValue);
 
   return (
     <>
@@ -68,15 +72,20 @@ export function BaseProjectSettingsSection({
       <Separator />
 
       <Field>
-        <FieldTitle>Remote</FieldTitle>
+        <FieldTitle>Base remote</FieldTitle>
         <FieldDescription className="text-foreground-muted">
-          The git remote used for fetching and syncing worktrees. Defaults to{' '}
-          <code className="font-mono text-xs">origin</code>.
+          Used for fetching remote branches, choosing task base branches and targeting pull
+          requests.
         </FieldDescription>
-        <Select value={remoteValue} onValueChange={(value) => update('remote', value ?? '')}>
+        <Select
+          value={baseRemoteValue}
+          onValueChange={(value) => update('baseRemote', value ?? '')}
+        >
           <SelectTrigger className="w-full min-w-0">
             <div className="flex min-w-0 flex-1 items-center gap-2 text-left">
-              <span className="min-w-0 truncate">{selectedRemote?.name ?? remoteValue}</span>
+              <span className="min-w-0 truncate">
+                {selectedBaseRemote?.name ?? baseRemoteValue}
+              </span>
             </div>
           </SelectTrigger>
           <SelectContent align="start" alignItemWithTrigger={false} sideOffset={6}>
@@ -100,6 +109,48 @@ export function BaseProjectSettingsSection({
                 </div>
               </SelectItem>
             )}
+          </SelectContent>
+        </Select>
+      </Field>
+
+      <Separator />
+
+      <Field>
+        <FieldTitle>Push remote</FieldTitle>
+        <FieldDescription className="text-foreground-muted">
+          Used when publishing task branches and pushing commits.
+        </FieldDescription>
+        <Select
+          value={pushRemoteValue}
+          onValueChange={(value) =>
+            update('pushRemote', value === SAME_AS_BASE_REMOTE ? '' : (value ?? ''))
+          }
+        >
+          <SelectTrigger className="w-full min-w-0">
+            <div className="flex min-w-0 flex-1 items-center gap-2 text-left">
+              <span className="min-w-0 truncate">
+                {pushRemoteValue === SAME_AS_BASE_REMOTE
+                  ? 'Same as base remote'
+                  : (selectedPushRemote?.name ?? pushRemoteValue)}
+              </span>
+            </div>
+          </SelectTrigger>
+          <SelectContent align="start" alignItemWithTrigger={false} sideOffset={6}>
+            <SelectItem value={SAME_AS_BASE_REMOTE} className="py-2">
+              <span className="relative -top-px shrink-0 font-medium">Same as base remote</span>
+            </SelectItem>
+            {remotes.map((r) => (
+              <SelectItem key={r.name} value={r.name} className="py-2">
+                <div className="flex min-w-0 flex-1 items-center gap-2">
+                  <span className="relative -top-px shrink-0">{r.name}</span>
+                  {r.url ? (
+                    <span className="min-w-0 flex-1 truncate text-xs text-foreground-muted">
+                      {r.url}
+                    </span>
+                  ) : null}
+                </div>
+              </SelectItem>
+            ))}
           </SelectContent>
         </Select>
       </Field>

--- a/src/renderer/features/projects/components/settings-view/use-project-settings-form.ts
+++ b/src/renderer/features/projects/components/settings-view/use-project-settings-form.ts
@@ -32,7 +32,7 @@ import {
 
 type UseProjectSettingsFormArgs = {
   initial: ProjectSettings;
-  configuredRemote: string;
+  baseRemote: string;
   remotes: Remote[];
   writeTargets: ProjectSettingsWriteTargetOption[];
   overrideState: ProjectSettingsOverrideState;
@@ -57,7 +57,7 @@ function resolveFormSnapshot(snapshot: FormSnapshot, baseline: FormState): FormS
 
 export function useProjectSettingsForm({
   initial,
-  configuredRemote,
+  baseRemote,
   remotes,
   writeTargets,
   overrideState,
@@ -68,8 +68,8 @@ export function useProjectSettingsForm({
   const { showModal } = useModalContext();
   const { toast } = useToast();
   const baseline = useMemo(
-    () => settingsToForm(initial, configuredRemote, remotes),
-    [initial, configuredRemote, remotes]
+    () => settingsToForm(initial, baseRemote, remotes),
+    [initial, baseRemote, remotes]
   );
   const [formSnapshot, setFormSnapshot] = useState<FormSnapshot>({
     baseline,
@@ -144,7 +144,7 @@ export function useProjectSettingsForm({
     const result = await save(formToSettings(formAtSubmit)).catch(() => err({ type: 'error' }));
 
     if (result.success) {
-      const canonicalForm = settingsToForm(result.data, configuredRemote, remotes);
+      const canonicalForm = settingsToForm(result.data, baseRemote, remotes);
       setWorktreeDirectoryError(null);
       setFormSnapshot({
         baseline: canonicalForm,
@@ -164,7 +164,7 @@ export function useProjectSettingsForm({
 
     setWorktreeDirectoryError(null);
     setSaveStatus('error');
-  }, [configuredRemote, form, onSuccess, remotes, save]);
+  }, [baseRemote, form, onSuccess, remotes, save]);
 
   const openShareConfigModal = useCallback(() => {
     if (!canShareConfig || shareDisabled) return;
@@ -175,7 +175,7 @@ export function useProjectSettingsForm({
       targets: writeTargets,
       writeConfigToRepo,
       onSuccess: ({ page }) => {
-        const nextForm = settingsToForm(page.settings, configuredRemote, remotes);
+        const nextForm = settingsToForm(page.settings, baseRemote, remotes);
         setFormSnapshot({
           baseline: nextForm,
           form: nextForm,
@@ -190,8 +190,8 @@ export function useProjectSettingsForm({
     });
   }, [
     availableWriteFields,
+    baseRemote,
     canShareConfig,
-    configuredRemote,
     defaultSelectedWriteFields,
     initialWriteTarget,
     onSuccess,

--- a/src/renderer/features/projects/stores/repository-store.ts
+++ b/src/renderer/features/projects/stores/repository-store.ts
@@ -10,8 +10,9 @@ import type {
 } from '@shared/git';
 import {
   projectDefaultBranchToBranch,
+  resolveConfiguredRemotes,
   resolveDefaultBranch,
-  selectPreferredRemote,
+  type ConfiguredRemotes,
 } from '@shared/git-utils';
 import { parseGitHubRepository } from '@shared/github-repository';
 import { events, rpc } from '@renderer/lib/ipc';
@@ -80,12 +81,13 @@ export class RepositoryStore {
       () => this.remoteData.invalidate()
     );
 
-    makeObservable<this, 'defaultBranchPreference'>(this, {
+    makeObservable<this, 'configuredRemotes' | 'defaultBranchPreference'>(this, {
       isUnborn: computed,
       currentBranch: computed,
       branches: computed,
       localBranches: computed,
       remoteBranches: computed,
+      configuredRemotes: computed,
       baseRemote: computed,
       pushRemote: computed,
       defaultBranchPreference: computed,
@@ -126,18 +128,17 @@ export class RepositoryStore {
     return this.remoteData.data?.remoteBranches ?? [];
   }
 
-  get baseRemote(): Remote {
-    const setting = this.settingsStore.settings?.baseRemote;
+  private get configuredRemotes(): ConfiguredRemotes {
     const remotes = this.remoteData.data?.remotes ?? [];
-    return selectPreferredRemote(setting, remotes);
+    return resolveConfiguredRemotes(this.settingsStore.settings ?? undefined, remotes);
+  }
+
+  get baseRemote(): Remote {
+    return this.configuredRemotes.baseRemote;
   }
 
   get pushRemote(): Remote {
-    const setting = this.settingsStore.settings?.pushRemote;
-    const remotes = this.remoteData.data?.remotes ?? [];
-    const preferred = setting?.trim();
-    const found = preferred ? remotes.find((r) => r.name === preferred) : undefined;
-    return found ?? this.baseRemote;
+    return this.configuredRemotes.pushRemote;
   }
 
   get remotes(): Remote[] {

--- a/src/renderer/features/projects/stores/repository-store.ts
+++ b/src/renderer/features/projects/stores/repository-store.ts
@@ -72,7 +72,11 @@ export class RepositoryStore {
 
     // Invalidate remote data when settings that affect remote resolution change.
     this._settingsDisposer = reaction(
-      () => [settingsStore.settings?.remote, settingsStore.settings?.defaultBranch],
+      () => [
+        settingsStore.settings?.baseRemote,
+        settingsStore.settings?.pushRemote,
+        settingsStore.settings?.defaultBranch,
+      ],
       () => this.remoteData.invalidate()
     );
 
@@ -82,13 +86,15 @@ export class RepositoryStore {
       branches: computed,
       localBranches: computed,
       remoteBranches: computed,
-      configuredRemote: computed,
+      baseRemote: computed,
+      pushRemote: computed,
       defaultBranchPreference: computed,
       defaultBranch: computed,
       remotes: computed,
       loading: computed,
       isGitHubRemote: computed,
       repositoryUrl: computed,
+      pushRepositoryUrl: computed,
     });
   }
 
@@ -120,35 +126,48 @@ export class RepositoryStore {
     return this.remoteData.data?.remoteBranches ?? [];
   }
 
-  get configuredRemote(): Remote {
-    const setting = this.settingsStore.settings?.remote;
+  get baseRemote(): Remote {
+    const setting = this.settingsStore.settings?.baseRemote;
     const remotes = this.remoteData.data?.remotes ?? [];
     return selectPreferredRemote(setting, remotes);
+  }
+
+  get pushRemote(): Remote {
+    const setting = this.settingsStore.settings?.pushRemote;
+    const remotes = this.remoteData.data?.remotes ?? [];
+    const preferred = setting?.trim();
+    const found = preferred ? remotes.find((r) => r.name === preferred) : undefined;
+    return found ?? this.baseRemote;
   }
 
   get remotes(): Remote[] {
     return this.remoteData.data?.remotes ?? [];
   }
 
-  /** True when the configured remote points to a GitHub.com repository. */
+  /** True when the base remote points to a GitHub.com repository. */
   get isGitHubRemote(): boolean {
-    const url = this.configuredRemote.url;
+    const url = this.baseRemote.url;
     return parseGitHubRepository(url) !== null;
   }
 
   /**
-   * The normalised HTTPS GitHub URL for the configured remote
+   * The normalised HTTPS GitHub URL for the base remote
    * (e.g. `https://github.com/owner/repo`), or `null` if not a GitHub remote.
    */
   get repositoryUrl(): string | null {
-    const url = this.configuredRemote.url;
+    const url = this.baseRemote.url;
+    return parseGitHubRepository(url)?.repositoryUrl ?? null;
+  }
+
+  get pushRepositoryUrl(): string | null {
+    const url = this.pushRemote.url;
     return parseGitHubRepository(url)?.repositoryUrl ?? null;
   }
 
   private get defaultBranchPreference(): Branch | undefined {
     return projectDefaultBranchToBranch(
       this.settingsStore.settings?.defaultBranch,
-      this.configuredRemote,
+      this.baseRemote,
       this.remotes
     );
   }
@@ -159,7 +178,7 @@ export class RepositoryStore {
     return resolveDefaultBranch({
       preference: this.defaultBranchPreference,
       branches: this.branches,
-      configuredRemoteName: this.configuredRemote.name,
+      configuredRemoteName: this.baseRemote.name,
       gitDefaultBranch: d.gitDefaultBranch,
       baseRef: this.baseRef,
     });
@@ -178,7 +197,7 @@ export class RepositoryStore {
   }
 
   isBranchOnRemote(branchName: string): boolean {
-    const remoteName = this.configuredRemote.name;
+    const remoteName = this.pushRemote.name;
     return this.remoteBranches.some((b) => b.branch === branchName && b.remote.name === remoteName);
   }
 

--- a/src/renderer/features/tasks/add-remote-modal.tsx
+++ b/src/renderer/features/tasks/add-remote-modal.tsx
@@ -56,7 +56,7 @@ export function AddRemoteModal({
     queryKey: ['owners'],
     queryFn: () => rpc.github.getOwners(),
   });
-  const selectedRemote = getRepositoryStore(projectId)?.configuredRemote.name ?? 'origin';
+  const selectedRemote = getRepositoryStore(projectId)?.pushRemote.name ?? 'origin';
 
   const owners = data?.owners?.map((o) => ({ value: o.login, label: o.login })) ?? [];
   const owner = selectedOwner ?? owners[0] ?? null;

--- a/src/renderer/features/tasks/create-task-modal/branch-picker-field.tsx
+++ b/src/renderer/features/tasks/create-task-modal/branch-picker-field.tsx
@@ -36,6 +36,7 @@ export function BranchPickerField({
           projectId={projectId}
           value={state.selectedBranch}
           onValueChange={state.setSelectedBranch}
+          showRemoteSelectorFooter
           trigger={
             <ComboboxTrigger className="flex w-full items-center gap-2 justify-between hover:bg-background-1 data-popup-open:bg-background-1 p-2 outline-none">
               <div className="flex flex-col text-left text-sm gap-0.5">

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.test.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.test.ts
@@ -3,6 +3,7 @@ import type { Branch } from '@shared/git';
 import { resolveInitialBaseBranch, toShortBranchName } from './base-branch';
 
 const originRemote = { name: 'origin', url: 'git@github.com:owner/repo.git' };
+const upstreamRemote = { name: 'upstream', url: 'git@github.com:upstream/repo.git' };
 
 describe('toShortBranchName', () => {
   it('keeps exact branch names unchanged', () => {
@@ -30,9 +31,37 @@ describe('resolveInitialBaseBranch', () => {
     ];
     const defaultBranch: Branch = { type: 'local', branch: 'main' };
 
-    expect(resolveInitialBaseBranch(branches, 'release/v2', defaultBranch)).toEqual({
+    expect(
+      resolveInitialBaseBranch(
+        branches,
+        { type: 'local', branch: 'release/v2' },
+        defaultBranch,
+        'origin'
+      )
+    ).toEqual({
       type: 'local',
       branch: 'release/v2',
+    });
+  });
+
+  it('preserves the source branch remote when multiple remotes share the branch name', () => {
+    const branches: Branch[] = [
+      { type: 'remote', remote: originRemote, branch: 'main' },
+      { type: 'remote', remote: upstreamRemote, branch: 'main' },
+    ];
+    const defaultBranch: Branch = { type: 'remote', remote: originRemote, branch: 'main' };
+
+    expect(
+      resolveInitialBaseBranch(
+        branches,
+        { type: 'remote', remote: upstreamRemote, branch: 'main' },
+        defaultBranch,
+        'upstream'
+      )
+    ).toEqual({
+      type: 'remote',
+      remote: upstreamRemote,
+      branch: 'main',
     });
   });
 
@@ -40,7 +69,14 @@ describe('resolveInitialBaseBranch', () => {
     const branches: Branch[] = [{ type: 'remote', remote: originRemote, branch: 'main' }];
     const defaultBranch: Branch = { type: 'remote', remote: originRemote, branch: 'main' };
 
-    expect(resolveInitialBaseBranch(branches, 'release/v2', defaultBranch)).toEqual({
+    expect(
+      resolveInitialBaseBranch(
+        branches,
+        { type: 'local', branch: 'release/v2' },
+        defaultBranch,
+        'origin'
+      )
+    ).toEqual({
       type: 'remote',
       remote: originRemote,
       branch: 'main',
@@ -50,6 +86,6 @@ describe('resolveInitialBaseBranch', () => {
   it('returns undefined when no preferred branch and no default branch', () => {
     const branches: Branch[] = [{ type: 'remote', remote: originRemote, branch: 'main' }];
 
-    expect(resolveInitialBaseBranch(branches, undefined, undefined)).toBeUndefined();
+    expect(resolveInitialBaseBranch(branches, undefined, undefined, 'origin')).toBeUndefined();
   });
 });

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/base-branch.ts
@@ -33,21 +33,38 @@ export function toShortBranchName(
 
 export function resolveInitialBaseBranch(
   branches: Branch[],
-  preferredBaseRef: string | undefined,
-  defaultBranch: Branch | undefined
+  preferredBase: Branch | undefined,
+  defaultBranch: Branch | undefined,
+  projectRemoteName: string
 ): Branch | undefined {
-  const preferredName = toShortBranchName(preferredBaseRef, branches);
+  const projectRemoteBranches = branches.filter(
+    (branch) => branch.type === 'remote' && branch.remote.name === projectRemoteName
+  );
+  const preferredName = preferredBase?.branch;
   if (preferredName) {
+    if (preferredBase?.type === 'remote' && preferredBase.remote.name === projectRemoteName) {
+      const preferredRemote = projectRemoteBranches.find(
+        (branch) => branch.branch === preferredName
+      );
+      if (preferredRemote) return preferredRemote;
+    }
+
     const preferredLocal = branches.find(
       (branch) => branch.type === 'local' && branch.branch === preferredName
     );
     if (preferredLocal) return preferredLocal;
 
-    const preferredRemote = branches.find(
-      (branch) => branch.type === 'remote' && branch.branch === preferredName
-    );
+    const preferredRemote = projectRemoteBranches.find((branch) => branch.branch === preferredName);
     if (preferredRemote) return preferredRemote;
   }
 
-  return defaultBranch;
+  if (!defaultBranch) return undefined;
+  if (defaultBranch.type === 'remote') {
+    return projectRemoteBranches.find((branch) => branch.branch === defaultBranch.branch);
+  }
+
+  return (
+    branches.find((branch) => branch.type === 'local' && branch.branch === defaultBranch.branch) ??
+    projectRemoteBranches.find((branch) => branch.branch === defaultBranch.branch)
+  );
 }

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
@@ -2,6 +2,7 @@ import { ChevronDown, CircleAlert, GitBranch } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 import type { Branch } from '@shared/git';
+import { parseGitHubRepository } from '@shared/github-repository';
 import { pullRequestErrorMessage } from '@shared/pull-requests';
 import { getRepositoryStore } from '@renderer/features/projects/stores/project-selectors';
 import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-selectors';
@@ -54,7 +55,13 @@ export const CreatePrModal = observer(function CreatePrModal({
   const taskPayload = getRegisteredTaskData(projectId, taskId);
   const isOnRemote = repo?.isBranchOnRemote(branchName) ?? false;
   const aheadCount = repo?.getBranchDivergence(branchName)?.ahead ?? 0;
-  const needsPush = !isOnRemote || aheadCount > 0;
+  const usesSeparatePushRemote = repo ? repo.pushRemote.name !== repo.baseRemote.name : false;
+  const needsPush = !isOnRemote || aheadCount > 0 || usesSeparatePushRemote;
+  const pushRepository = parseGitHubRepository(repo?.pushRepositoryUrl ?? '');
+  const head =
+    pushRepository && pushRepository.repositoryUrl !== repositoryUrl
+      ? `${pushRepository.owner}:${branchName}`
+      : branchName;
 
   const hasGitHubRemote = Boolean(repositoryUrl);
   const selectedBase =
@@ -74,7 +81,7 @@ export const CreatePrModal = observer(function CreatePrModal({
         const pushResult = await rpc.git.push(
           projectId,
           workspaceId,
-          repo?.configuredRemote.name ?? 'origin'
+          repo?.pushRemote.name ?? 'origin'
         );
         if (!pushResult.success) {
           log.error('Failed to push branch:', pushResult.error);
@@ -87,7 +94,7 @@ export const CreatePrModal = observer(function CreatePrModal({
 
       const result = await rpc.pullRequests.createPullRequest({
         repositoryUrl,
-        head: branchName,
+        head,
         base: selectedBase.branch,
         title: title.trim(),
         body: description.trim() || undefined,

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
@@ -59,8 +59,7 @@ export const CreatePrModal = observer(function CreatePrModal({
   const taskPayload = getRegisteredTaskData(projectId, taskId);
   const isOnRemote = repo?.isBranchOnRemote(branchName) ?? false;
   const aheadCount = repo?.getBranchDivergence(branchName)?.ahead ?? 0;
-  const usesSeparatePushRemote = repo ? repo.pushRemote.name !== repo.baseRemote.name : false;
-  const needsPush = !isOnRemote || aheadCount > 0 || usesSeparatePushRemote;
+  const needsPush = !isOnRemote || aheadCount > 0;
   const projectRemoteName = repo?.baseRemote.name ?? 'origin';
   const githubTargetRemotes = useMemo(
     () => getGitHubTargetRemotes(repo?.remotes ?? []),
@@ -91,7 +90,11 @@ export const CreatePrModal = observer(function CreatePrModal({
   };
 
   const doCreate = async (push: boolean) => {
-    if (!title.trim() || !targetRepositoryUrl || !selectedBase?.branch) return;
+    if (!selectedBase?.branch) {
+      setError('Select a base branch before creating the pull request.');
+      return;
+    }
+    if (!title.trim() || !targetRepositoryUrl) return;
     setError(null);
     setIsCreating(true);
     try {

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
@@ -1,6 +1,6 @@
-import { ChevronDown, CircleAlert, GitBranch } from 'lucide-react';
+import { ChevronDown, CircleAlert, GitBranch, GitPullRequest } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import type { Branch } from '@shared/git';
 import { parseGitHubRepository } from '@shared/github-repository';
 import { pullRequestErrorMessage } from '@shared/pull-requests';
@@ -9,6 +9,7 @@ import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-sele
 import { useTaskViewContext } from '@renderer/features/tasks/task-view-context';
 import { BranchDisplay } from '@renderer/lib/components/branch-display';
 import { ProjectBranchSelector } from '@renderer/lib/components/project-branch-selector';
+import { RemoteSelectContent } from '@renderer/lib/components/remote-select-content';
 import { rpc } from '@renderer/lib/ipc';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { Alert, AlertDescription, AlertTitle } from '@renderer/lib/ui/alert';
@@ -22,11 +23,13 @@ import {
 } from '@renderer/lib/ui/dialog';
 import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
 import { Input } from '@renderer/lib/ui/input';
+import { Select, SelectTrigger } from '@renderer/lib/ui/select';
 import { Separator } from '@renderer/lib/ui/separator';
 import { SplitButton } from '@renderer/lib/ui/split-button';
 import { Textarea } from '@renderer/lib/ui/textarea';
 import { log } from '@renderer/utils/logger';
 import { resolveInitialBaseBranch } from './base-branch';
+import { getGitHubTargetRemotes, resolveCreatePrTargetRemote } from './target-remote';
 
 export type CreatePrModalArgs = {
   repositoryUrl: string;
@@ -48,6 +51,7 @@ export const CreatePrModal = observer(function CreatePrModal({
   const [title, setTitle] = useState(branchName);
   const [description, setDescription] = useState('');
   const [selectedBaseOverride, setSelectedBaseOverride] = useState<Branch | undefined>();
+  const [selectedTargetRemoteName, setSelectedTargetRemoteName] = useState<string | undefined>();
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const repo = getRepositoryStore(projectId);
@@ -57,23 +61,37 @@ export const CreatePrModal = observer(function CreatePrModal({
   const aheadCount = repo?.getBranchDivergence(branchName)?.ahead ?? 0;
   const usesSeparatePushRemote = repo ? repo.pushRemote.name !== repo.baseRemote.name : false;
   const needsPush = !isOnRemote || aheadCount > 0 || usesSeparatePushRemote;
-  const pushRepository = parseGitHubRepository(repo?.pushRepositoryUrl ?? '');
-  const head =
-    pushRepository && pushRepository.repositoryUrl !== repositoryUrl
-      ? `${pushRepository.owner}:${branchName}`
-      : branchName;
+  const projectRemoteName = repo?.baseRemote.name ?? 'origin';
+  const githubTargetRemotes = useMemo(
+    () => getGitHubTargetRemotes(repo?.remotes ?? []),
+    [repo?.remotes]
+  );
+  const targetRemote = resolveCreatePrTargetRemote({
+    options: githubTargetRemotes,
+    projectRemoteName,
+    selectedRemoteName: selectedTargetRemoteName,
+    fallbackRepositoryUrl: repositoryUrl,
+  });
+  const targetRepositoryUrl = targetRemote?.repository.repositoryUrl ?? repositoryUrl;
 
-  const hasGitHubRemote = Boolean(repositoryUrl);
+  const hasGitHubRemote = Boolean(targetRepositoryUrl);
   const selectedBase =
     selectedBaseOverride ??
     resolveInitialBaseBranch(
       repo?.remoteBranches ?? [],
-      taskPayload?.sourceBranch?.branch,
-      defaultBranch
+      taskPayload?.sourceBranch,
+      defaultBranch,
+      targetRemote?.remote.name ?? projectRemoteName
     );
 
+  const handleTargetRemoteChange = (remoteName: string | null) => {
+    if (!remoteName) return;
+    setSelectedTargetRemoteName(remoteName);
+    setSelectedBaseOverride(undefined);
+  };
+
   const doCreate = async (push: boolean) => {
-    if (!title.trim() || !repositoryUrl || !selectedBase?.branch) return;
+    if (!title.trim() || !targetRepositoryUrl || !selectedBase?.branch) return;
     setError(null);
     setIsCreating(true);
     try {
@@ -92,8 +110,19 @@ export const CreatePrModal = observer(function CreatePrModal({
         }
       }
 
+      const baseRepository = parseGitHubRepository(targetRepositoryUrl);
+      const headRepository = repo?.pushRemote.url
+        ? parseGitHubRepository(repo.pushRemote.url)
+        : null;
+      const head =
+        baseRepository &&
+        headRepository &&
+        headRepository.repositoryUrl !== baseRepository.repositoryUrl
+          ? `${headRepository.owner}:${branchName}`
+          : branchName;
+
       const result = await rpc.pullRequests.createPullRequest({
-        repositoryUrl,
+        repositoryUrl: targetRepositoryUrl,
         head,
         base: selectedBase.branch,
         title: title.trim(),
@@ -128,11 +157,35 @@ export const CreatePrModal = observer(function CreatePrModal({
             branchName={branchName}
             className="border border-border rounded-md"
           />
+          {githubTargetRemotes.length > 1 && targetRemote ? (
+            <Select value={targetRemote.remote.name} onValueChange={handleTargetRemoteChange}>
+              <SelectTrigger
+                showChevron={false}
+                className="flex min-h-[58px] w-full items-center gap-2 justify-between rounded-md border border-border p-2 text-left outline-none data-[size=default]:h-auto"
+              >
+                <div className="flex flex-col gap-0.5 text-left text-sm">
+                  <span className="text-xs text-foreground-passive">Target</span>
+                  <span className="flex items-center gap-1">
+                    <GitPullRequest
+                      absoluteStrokeWidth
+                      strokeWidth={2}
+                      className="size-3.5 shrink-0 text-foreground-muted"
+                    />
+                    <span className="min-w-0 truncate">{targetRemote.remote.name}</span>
+                  </span>
+                </div>
+                <ChevronDown className="size-4 shrink-0 text-foreground-muted" />
+              </SelectTrigger>
+              <RemoteSelectContent remotes={githubTargetRemotes.map(({ remote }) => remote)} />
+            </Select>
+          ) : null}
           <ProjectBranchSelector
             projectId={projectId}
             value={selectedBase}
             onValueChange={setSelectedBaseOverride}
             remoteOnly
+            remoteName={targetRemote?.remote.name}
+            branchLabelRemote="short"
             trigger={
               <ComboboxTrigger className="flex w-full items-center gap-2 justify-between border border-border rounded-md p-2 text-left outline-none">
                 <div className="flex flex-col text-left text-sm gap-0.5">

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/files-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/files-list.tsx
@@ -12,7 +12,7 @@ export const PrFilesList = observer(function PrFilesList({ pr }: { pr: PullReque
   const prStore = provisioned.workspace.pr;
 
   const repo = getRepositoryStore(projectId);
-  const baseRef = remoteRef(repo?.configuredRemote ?? 'origin', pr.baseRefName);
+  const baseRef = remoteRef(repo?.baseRemote ?? 'origin', pr.baseRefName);
   const modifiedRef = commitRef(pr.headRefOid);
   const prFiles = prStore.getFiles(pr).data ?? [];
 

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/target-remote.test.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/target-remote.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+import type { Remote } from '@shared/git';
+import { getGitHubTargetRemotes, resolveCreatePrTargetRemote } from './target-remote';
+
+const remotes: Remote[] = [
+  { name: 'origin', url: 'git@github.com:user/repo.git' },
+  { name: 'upstream', url: 'git@github.com:org/repo.git' },
+  { name: 'gitlab', url: 'git@gitlab.com:user/repo.git' },
+];
+
+describe('getGitHubTargetRemotes', () => {
+  it('returns only remotes that point at GitHub repositories', () => {
+    expect(getGitHubTargetRemotes(remotes).map((option) => option.remote.name)).toEqual([
+      'origin',
+      'upstream',
+    ]);
+  });
+});
+
+describe('resolveCreatePrTargetRemote', () => {
+  const options = getGitHubTargetRemotes(remotes);
+
+  it('defaults to the project remote when it is a GitHub remote', () => {
+    expect(
+      resolveCreatePrTargetRemote({
+        options,
+        projectRemoteName: 'upstream',
+      })?.remote.name
+    ).toBe('upstream');
+  });
+
+  it('uses the selected modal target when provided', () => {
+    expect(
+      resolveCreatePrTargetRemote({
+        options,
+        projectRemoteName: 'upstream',
+        selectedRemoteName: 'origin',
+      })?.remote.name
+    ).toBe('origin');
+  });
+
+  it('falls back to the repository URL when the project remote is not GitHub', () => {
+    expect(
+      resolveCreatePrTargetRemote({
+        options,
+        projectRemoteName: 'gitlab',
+        fallbackRepositoryUrl: 'https://github.com/org/repo',
+      })?.remote.name
+    ).toBe('upstream');
+  });
+});

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/target-remote.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/target-remote.ts
@@ -1,0 +1,46 @@
+import type { Remote } from '@shared/git';
+import { parseGitHubRepository, type GitHubRepositoryRef } from '@shared/github-repository';
+
+export type GitHubTargetRemote = {
+  remote: Remote;
+  repository: GitHubRepositoryRef;
+};
+
+export function getGitHubTargetRemotes(remotes: ReadonlyArray<Remote>): GitHubTargetRemote[] {
+  return remotes
+    .map((remote) => {
+      const repository = parseGitHubRepository(remote.url);
+      return repository ? { remote, repository } : null;
+    })
+    .filter((option): option is GitHubTargetRemote => option !== null);
+}
+
+export function resolveCreatePrTargetRemote({
+  options,
+  projectRemoteName,
+  selectedRemoteName,
+  fallbackRepositoryUrl,
+}: {
+  options: ReadonlyArray<GitHubTargetRemote>;
+  projectRemoteName: string;
+  selectedRemoteName?: string;
+  fallbackRepositoryUrl?: string;
+}): GitHubTargetRemote | undefined {
+  const selected = selectedRemoteName
+    ? options.find((option) => option.remote.name === selectedRemoteName)
+    : undefined;
+  if (selected) return selected;
+
+  const projectRemote = options.find((option) => option.remote.name === projectRemoteName);
+  if (projectRemote) return projectRemote;
+
+  const fallbackRepository = parseGitHubRepository(fallbackRepositoryUrl);
+  if (fallbackRepository) {
+    const fallback = options.find(
+      (option) => option.repository.repositoryUrl === fallbackRepository.repositoryUrl
+    );
+    if (fallback) return fallback;
+  }
+
+  return options[0];
+}

--- a/src/renderer/features/tasks/diff-view/stores/git-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/git-store.ts
@@ -336,7 +336,7 @@ export class GitStore {
   }
 
   async push() {
-    const remote = this.repositoryStore.configuredRemote.name;
+    const remote = this.repositoryStore.pushRemote.name;
     const result = await rpc.git.push(this.projectId, this.workspaceId, remote);
     if (result.success) {
       this.repositoryStore.refreshLocal(); // divergence resets to 0
@@ -353,7 +353,7 @@ export class GitStore {
   async publishBranch() {
     const branchName = this.branchName;
     if (!branchName) return err({ type: 'git_error' as const, message: 'No branch checked out' });
-    const remote = this.repositoryStore.configuredRemote.name;
+    const remote = this.repositoryStore.pushRemote.name;
     const result = await rpc.git.publishBranch(
       this.projectId,
       this.workspaceId,

--- a/src/renderer/features/tasks/stores/pr-store.ts
+++ b/src/renderer/features/tasks/stores/pr-store.ts
@@ -70,16 +70,13 @@ export class PrStore {
               });
               const unsubBaseRef = events.on(gitRefChangedChannel, (p) => {
                 if (p.projectId !== this.projectId || p.kind !== 'remote-refs') return;
-                const baseRef = remoteRef(this.repositoryStore.configuredRemote, pr.baseRefName);
+                const baseRef = remoteRef(this.repositoryStore.baseRemote, pr.baseRefName);
                 const relevant = !p.changedRefs || p.changedRefs.some((r) => refsEqual(r, baseRef));
                 if (relevant) handler();
               });
               const unsubPrHead = events.on(gitRefChangedChannel, (p) => {
                 if (p.projectId !== this.projectId || p.kind !== 'remote-refs') return;
-                const sameRepoRef = remoteRef(
-                  this.repositoryStore.configuredRemote,
-                  pr.headRefName
-                );
+                const sameRepoRef = remoteRef(this.repositoryStore.baseRemote, pr.headRefName);
                 const forkOwner = isForkPr(pr)
                   ? (parseGitHubRepository(pr.headRepositoryUrl)?.owner ?? null)
                   : null;
@@ -179,7 +176,7 @@ export class PrStore {
   }
 
   private async _fetchPrFiles(pr: PullRequest): Promise<GitChange[]> {
-    const remote = this.repositoryStore.configuredRemote;
+    const remote = this.repositoryStore.baseRemote;
     // Dereference the MobX-observable Remote into a plain object — MobX proxies
     // cannot be structured-cloned by Electron IPC and will throw.
     const plainRemote = { name: remote.name, url: remote.url };

--- a/src/renderer/lib/components/branch-selector-utils.test.ts
+++ b/src/renderer/lib/components/branch-selector-utils.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import type { Branch } from '@shared/git';
+import { filterBranchesForPicker } from './branch-selector-utils';
+
+const origin = { name: 'origin', url: 'git@github.com:example/repo.git' };
+const upstream = { name: 'upstream', url: 'git@github.com:example/upstream.git' };
+
+const branches: Branch[] = [
+  { type: 'local', branch: 'main' },
+  { type: 'local', branch: 'feature/local' },
+  { type: 'remote', branch: 'main', remote: origin },
+  { type: 'remote', branch: 'feature/origin', remote: origin },
+  { type: 'remote', branch: 'main', remote: upstream },
+  { type: 'remote', branch: 'feature/upstream', remote: upstream },
+];
+
+describe('filterBranchesForPicker', () => {
+  it('returns local branches without applying a remote filter', () => {
+    expect(filterBranchesForPicker(branches, 'local', 'upstream')).toEqual([
+      { type: 'local', branch: 'main' },
+      { type: 'local', branch: 'feature/local' },
+    ]);
+  });
+
+  it('filters remote branches to the selected remote', () => {
+    expect(filterBranchesForPicker(branches, 'remote', 'upstream')).toEqual([
+      { type: 'remote', branch: 'main', remote: upstream },
+      { type: 'remote', branch: 'feature/upstream', remote: upstream },
+    ]);
+  });
+
+  it('keeps all remote branches when no remote filter is provided', () => {
+    expect(filterBranchesForPicker(branches, 'remote')).toEqual([
+      { type: 'remote', branch: 'main', remote: origin },
+      { type: 'remote', branch: 'feature/origin', remote: origin },
+      { type: 'remote', branch: 'main', remote: upstream },
+      { type: 'remote', branch: 'feature/upstream', remote: upstream },
+    ]);
+  });
+});

--- a/src/renderer/lib/components/branch-selector-utils.ts
+++ b/src/renderer/lib/components/branch-selector-utils.ts
@@ -1,0 +1,13 @@
+import type { Branch } from '@shared/git';
+
+export function filterBranchesForPicker(
+  branches: ReadonlyArray<Branch>,
+  tab: 'local' | 'remote',
+  remoteName?: string
+): Branch[] {
+  return branches.filter(
+    (branch) =>
+      branch.type === tab &&
+      (branch.type !== 'remote' || !remoteName || branch.remote.name === remoteName)
+  );
+}

--- a/src/renderer/lib/components/branch-selector.tsx
+++ b/src/renderer/lib/components/branch-selector.tsx
@@ -18,9 +18,14 @@ import { cn } from '@renderer/utils/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
 
 type BranchSelectorTab = 'local' | 'remote';
+export type BranchLabelRemoteMode = 'full' | 'short';
 
-function getBranchLabel(branch: Branch): string {
-  return branch.type === 'remote' ? `${branch.remote.name}/${branch.branch}` : branch.branch;
+export function getBranchLabel(
+  branch: Branch,
+  options: { remote?: BranchLabelRemoteMode } = {}
+): string {
+  if (branch.type !== 'remote') return branch.branch;
+  return options.remote === 'short' ? branch.branch : `${branch.remote.name}/${branch.branch}`;
 }
 
 interface BranchSelectorProps {
@@ -28,6 +33,7 @@ interface BranchSelectorProps {
   value?: Branch;
   onValueChange: (value: Branch) => void;
   remoteOnly?: boolean;
+  branchLabelRemote?: BranchLabelRemoteMode;
   trigger?: React.ReactNode;
   onRefresh?: () => void;
   isRefreshing?: boolean;
@@ -38,6 +44,7 @@ export function BranchSelector({
   value,
   onValueChange,
   remoteOnly = false,
+  branchLabelRemote = 'full',
   trigger,
   onRefresh,
   isRefreshing = false,
@@ -62,10 +69,10 @@ export function BranchSelector({
     () =>
       filteredBranches.map((branch) => ({
         value: branch,
-        label: getBranchLabel(branch),
+        label: getBranchLabel(branch, { remote: branchLabelRemote }),
         disabled: branch.branch.startsWith('_reserve'),
       })),
-    [filteredBranches]
+    [branchLabelRemote, filteredBranches]
   );
 
   return (
@@ -76,7 +83,7 @@ export function BranchSelector({
         value
           ? {
               value,
-              label: getBranchLabel(value),
+              label: getBranchLabel(value, { remote: branchLabelRemote }),
             }
           : undefined
       }

--- a/src/renderer/lib/components/branch-selector.tsx
+++ b/src/renderer/lib/components/branch-selector.tsx
@@ -1,6 +1,6 @@
 import { GitBranch, RefreshCw } from 'lucide-react';
 import React, { useMemo, useState } from 'react';
-import { type Branch } from '@shared/git';
+import { type Branch, type Remote } from '@shared/git';
 import { Badge } from '@renderer/lib/ui/badge';
 import {
   Combobox,
@@ -13,9 +13,12 @@ import {
   ComboboxValue,
 } from '@renderer/lib/ui/combobox';
 import { InputGroupButton } from '@renderer/lib/ui/input-group';
+import { Select, SelectTrigger } from '@renderer/lib/ui/select';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { cn } from '@renderer/utils/utils';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
+import { filterBranchesForPicker } from './branch-selector-utils';
+import { RemoteSelectContent } from './remote-select-content';
 
 type BranchSelectorTab = 'local' | 'remote';
 export type BranchLabelRemoteMode = 'full' | 'short';
@@ -37,6 +40,8 @@ interface BranchSelectorProps {
   trigger?: React.ReactNode;
   onRefresh?: () => void;
   isRefreshing?: boolean;
+  remotes?: Remote[];
+  selectedRemoteName?: string;
 }
 
 export function BranchSelector({
@@ -48,6 +53,8 @@ export function BranchSelector({
   trigger,
   onRefresh,
   isRefreshing = false,
+  remotes,
+  selectedRemoteName,
 }: BranchSelectorProps) {
   const valueKey =
     value?.type === 'remote'
@@ -59,11 +66,27 @@ export function BranchSelector({
   const overriddenTab = tabOverride?.valueKey === valueKey ? tabOverride.tab : undefined;
   const tab = remoteOnly ? 'remote' : (overriddenTab ?? value?.type ?? 'local');
   const inputRef = React.useRef<HTMLInputElement>(null);
+  const keepOpenForRemoteSelectRef = React.useRef(false);
+  const [open, setOpen] = useState(false);
+  const [remoteSelectOpen, setRemoteSelectOpen] = useState(false);
+  const [draftRemoteName, setDraftRemoteName] = useState<string | undefined>(undefined);
+  const showRemoteFooter = selectedRemoteName !== undefined;
+  const activeRemoteName =
+    showRemoteFooter && open ? (draftRemoteName ?? selectedRemoteName) : selectedRemoteName;
 
   const localCount = useMemo(() => branches.filter((b) => b.type === 'local').length, [branches]);
-  const remoteCount = useMemo(() => branches.filter((b) => b.type === 'remote').length, [branches]);
+  const remoteCount = useMemo(
+    () =>
+      branches.filter(
+        (b) => b.type === 'remote' && (!showRemoteFooter || b.remote.name === activeRemoteName)
+      ).length,
+    [activeRemoteName, branches, showRemoteFooter]
+  );
 
-  const filteredBranches = useMemo(() => branches.filter((b) => b.type === tab), [branches, tab]);
+  const filteredBranches = useMemo(
+    () => filterBranchesForPicker(branches, tab, showRemoteFooter ? activeRemoteName : undefined),
+    [activeRemoteName, branches, showRemoteFooter, tab]
+  );
 
   const options = useMemo(
     () =>
@@ -77,6 +100,15 @@ export function BranchSelector({
 
   return (
     <Combobox
+      open={open}
+      onOpenChange={(nextOpen) => {
+        if (!nextOpen && keepOpenForRemoteSelectRef.current) {
+          setOpen(true);
+          return;
+        }
+        setOpen(nextOpen);
+        setDraftRemoteName(nextOpen ? selectedRemoteName : undefined);
+      }}
       items={options}
       autoHighlight
       value={
@@ -105,7 +137,9 @@ export function BranchSelector({
           </div>
         </ComboboxTrigger>
       )}
-      <ComboboxContent className="min-w-(--anchor-width) pb-1 border">
+      <ComboboxContent
+        className={cn('min-w-(--anchor-width) border', showRemoteFooter ? 'pb-0' : 'pb-1')}
+      >
         {!remoteOnly && (
           <ToggleGroup
             value={[tab]}
@@ -173,6 +207,47 @@ export function BranchSelector({
           )}
         </ComboboxList>
         <ComboboxEmpty>{branches.length === 0 ? 'no branches exist' : 'no results'}</ComboboxEmpty>
+        {showRemoteFooter && (
+          <div className="border-t border-border">
+            <Select
+              open={remoteSelectOpen}
+              onOpenChange={(nextOpen) => {
+                setRemoteSelectOpen(nextOpen);
+                keepOpenForRemoteSelectRef.current = true;
+                if (nextOpen) {
+                  setOpen(true);
+                } else {
+                  requestAnimationFrame(() => {
+                    keepOpenForRemoteSelectRef.current = false;
+                  });
+                }
+              }}
+              value={activeRemoteName}
+              onValueChange={(remoteName) => {
+                if (!remoteName) return;
+                keepOpenForRemoteSelectRef.current = true;
+                setDraftRemoteName(remoteName);
+                setTabOverride({ tab: 'remote', valueKey });
+                setOpen(true);
+                requestAnimationFrame(() => {
+                  setOpen(true);
+                  inputRef.current?.focus();
+                  keepOpenForRemoteSelectRef.current = false;
+                });
+              }}
+            >
+              <SelectTrigger className="h-7 w-full rounded-none border-0 bg-transparent px-3 text-sm shadow-none hover:bg-background-quaternary-1 focus-visible:ring-0">
+                <span className="min-w-0 flex-1 truncate text-left text-foreground-muted">
+                  {activeRemoteName}
+                </span>
+              </SelectTrigger>
+              <RemoteSelectContent
+                remotes={remotes ?? []}
+                fallbackRemoteName={activeRemoteName ?? selectedRemoteName}
+              />
+            </Select>
+          </div>
+        )}
       </ComboboxContent>
     </Combobox>
   );

--- a/src/renderer/lib/components/project-branch-selector.tsx
+++ b/src/renderer/lib/components/project-branch-selector.tsx
@@ -20,11 +20,11 @@ export const ProjectBranchSelector = observer(function ProjectBranchSelector({
   trigger,
 }: ProjectBranchSelectorProps) {
   const repo = getRepositoryStore(projectId);
-  const configuredRemoteName = repo?.configuredRemote.name ?? 'origin';
+  const baseRemoteName = repo?.baseRemote.name ?? 'origin';
 
   const branches: Branch[] = repo
     ? repo.branches.filter(
-        (b) => b.type === 'local' || (b.type === 'remote' && b.remote.name === configuredRemoteName)
+        (b) => b.type === 'local' || (b.type === 'remote' && b.remote.name === baseRemoteName)
       )
     : [];
 

--- a/src/renderer/lib/components/project-branch-selector.tsx
+++ b/src/renderer/lib/components/project-branch-selector.tsx
@@ -12,6 +12,7 @@ export interface ProjectBranchSelectorProps {
   remoteName?: string;
   branchLabelRemote?: BranchLabelRemoteMode;
   trigger?: React.ReactNode;
+  showRemoteSelectorFooter?: boolean;
 }
 
 export const ProjectBranchSelector = observer(function ProjectBranchSelector({
@@ -22,15 +23,17 @@ export const ProjectBranchSelector = observer(function ProjectBranchSelector({
   remoteName,
   branchLabelRemote,
   trigger,
+  showRemoteSelectorFooter = false,
 }: ProjectBranchSelectorProps) {
   const repo = getRepositoryStore(projectId);
-  const selectedRemoteName = remoteName ?? repo?.baseRemote.name ?? 'origin';
+  const selectedRemoteName =
+    remoteName ??
+    (value?.type === 'remote' ? value.remote.name : undefined) ??
+    repo?.baseRemote.name ??
+    'origin';
 
-  const branches: Branch[] = repo
-    ? repo.branches.filter(
-        (b) => b.type === 'local' || (b.type === 'remote' && b.remote.name === selectedRemoteName)
-      )
-    : [];
+  const branches: Branch[] = repo ? [...repo.localBranches, ...repo.remoteBranches] : [];
+  const canSelectRemote = showRemoteSelectorFooter && remoteName === undefined;
 
   return (
     <BranchSelector
@@ -42,6 +45,10 @@ export const ProjectBranchSelector = observer(function ProjectBranchSelector({
       trigger={trigger}
       onRefresh={() => repo?.refresh()}
       isRefreshing={repo?.loading ?? false}
+      remotes={canSelectRemote ? repo?.remotes : undefined}
+      selectedRemoteName={
+        showRemoteSelectorFooter || remoteName !== undefined ? selectedRemoteName : undefined
+      }
     />
   );
 });

--- a/src/renderer/lib/components/project-branch-selector.tsx
+++ b/src/renderer/lib/components/project-branch-selector.tsx
@@ -2,13 +2,15 @@ import { observer } from 'mobx-react-lite';
 import React from 'react';
 import type { Branch } from '@shared/git';
 import { getRepositoryStore } from '@renderer/features/projects/stores/project-selectors';
-import { BranchSelector } from './branch-selector';
+import { BranchSelector, type BranchLabelRemoteMode } from './branch-selector';
 
 export interface ProjectBranchSelectorProps {
   projectId: string;
   value?: Branch;
   onValueChange: (value: Branch) => void;
   remoteOnly?: boolean;
+  remoteName?: string;
+  branchLabelRemote?: BranchLabelRemoteMode;
   trigger?: React.ReactNode;
 }
 
@@ -17,14 +19,16 @@ export const ProjectBranchSelector = observer(function ProjectBranchSelector({
   value,
   onValueChange,
   remoteOnly,
+  remoteName,
+  branchLabelRemote,
   trigger,
 }: ProjectBranchSelectorProps) {
   const repo = getRepositoryStore(projectId);
-  const baseRemoteName = repo?.baseRemote.name ?? 'origin';
+  const selectedRemoteName = remoteName ?? repo?.baseRemote.name ?? 'origin';
 
   const branches: Branch[] = repo
     ? repo.branches.filter(
-        (b) => b.type === 'local' || (b.type === 'remote' && b.remote.name === baseRemoteName)
+        (b) => b.type === 'local' || (b.type === 'remote' && b.remote.name === selectedRemoteName)
       )
     : [];
 
@@ -34,6 +38,7 @@ export const ProjectBranchSelector = observer(function ProjectBranchSelector({
       value={value}
       onValueChange={onValueChange}
       remoteOnly={remoteOnly}
+      branchLabelRemote={branchLabelRemote}
       trigger={trigger}
       onRefresh={() => repo?.refresh()}
       isRefreshing={repo?.loading ?? false}

--- a/src/renderer/lib/components/remote-select-content.tsx
+++ b/src/renderer/lib/components/remote-select-content.tsx
@@ -1,0 +1,41 @@
+import type { Remote } from '@shared/git';
+import { SelectContent, SelectItem } from '@renderer/lib/ui/select';
+
+type RemoteSelectContentProps = {
+  remotes: Remote[];
+  fallbackRemoteName?: string;
+};
+
+export function RemoteSelectContent({
+  remotes,
+  fallbackRemoteName = 'origin',
+}: RemoteSelectContentProps) {
+  return (
+    <SelectContent align="start" alignItemWithTrigger={false} sideOffset={6}>
+      {remotes.length > 0 ? (
+        remotes.map((remote) => <RemoteSelectItem key={remote.name} remote={remote} />)
+      ) : (
+        <SelectItem value={fallbackRemoteName} className="py-2">
+          <div className="flex min-w-0 flex-1 items-center gap-2">
+            <span className="relative -top-px shrink-0 font-medium">{fallbackRemoteName}</span>
+          </div>
+        </SelectItem>
+      )}
+    </SelectContent>
+  );
+}
+
+export function RemoteSelectItem({ remote }: { remote: Remote }) {
+  return (
+    <SelectItem value={remote.name} className="py-2">
+      <div className="flex min-w-0 flex-1 items-center gap-2">
+        <span className="relative -top-px shrink-0">{remote.name}</span>
+        {remote.url ? (
+          <span className="min-w-0 flex-1 truncate text-xs text-foreground-muted">
+            {remote.url}
+          </span>
+        ) : null}
+      </div>
+    </SelectItem>
+  );
+}

--- a/src/shared/git-utils.ts
+++ b/src/shared/git-utils.ts
@@ -16,6 +16,27 @@ export function selectPreferredRemote(
   );
 }
 
+export type ConfiguredRemotes = {
+  baseRemote: Remote;
+  pushRemote: Remote;
+};
+
+export function resolveConfiguredRemotes(
+  settings: { baseRemote?: string; pushRemote?: string } | undefined,
+  remotes: ReadonlyArray<Remote>
+): ConfiguredRemotes {
+  const baseRemote = selectPreferredRemote(settings?.baseRemote, remotes);
+  const pushRemoteName = settings?.pushRemote?.trim();
+  const pushRemote = pushRemoteName
+    ? remotes.find((remote) => remote.name === pushRemoteName)
+    : undefined;
+
+  return {
+    baseRemote,
+    pushRemote: pushRemote ?? baseRemote,
+  };
+}
+
 /**
  * Strips the remote prefix from a fully-qualified remote tracking ref.
  * e.g. "origin/main" → "main", "main" → "main"

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -43,7 +43,8 @@ export type ShareableProjectSettings = z.infer<typeof shareableProjectSettingsSc
 export const baseProjectSettingsSchema = z.object({
   worktreeDirectory: z.string().trim().optional(),
   defaultBranch: defaultBranchSettingSchema.optional(),
-  remote: z.string().optional(),
+  baseRemote: z.string().optional(),
+  pushRemote: z.string().optional(),
   tmux: z.boolean().optional(),
   workspaceProvider: z
     .object({
@@ -56,11 +57,17 @@ export const baseProjectSettingsSchema = z.object({
 
 export type BaseProjectSettings = z.infer<typeof baseProjectSettingsSchema>;
 
+export const legacyBaseProjectSettingsSchema = baseProjectSettingsSchema.extend({
+  remote: z.string().optional(),
+});
+
 export const projectSettingsSchema = baseProjectSettingsSchema.merge(
   shareableProjectSettingsSchema
 );
 
-export const legacyProjectConfigSchema = projectSettingsSchema;
+export const legacyProjectConfigSchema = legacyBaseProjectSettingsSchema.merge(
+  shareableProjectSettingsSchema
+);
 
 export function defaultShareableProjectSettings(): ShareableProjectSettings {
   return shareableProjectSettingsWithDefaultsSchema.parse({});


### PR DESCRIPTION
- added project setting for baseRemote and pushRemote
- migrated legacy remote to baseRemote
- fetch/branches/PR sync use baseRemote
- push/publish use pushRemote
- updated settings UI for Base/Push remote
- branch picker only shows baseRemote branches
- create PR can target another GitHub remote
- shared remote dropdown UI between settings and create pr modal