### PR TITLE
fix: show tooltip for truncated sidebar task names

### DIFF
--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -1,4 +1,5 @@
 import { observer } from 'mobx-react-lite';
+import { useCallback, useRef, useState } from 'react';
 import { selectCurrentPr } from '@shared/pull-requests';
 import { TaskSidebarAgentStatus } from '@renderer/features/sidebar/task-sidebar-agent-status';
 import { TaskContextMenu } from '@renderer/features/tasks/components/task-context-menu';
@@ -16,6 +17,7 @@ import {
   useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
 import { PrBadge } from '../../lib/components/pr-badge';
 import { SidebarMenuRow } from './sidebar-primitives';
@@ -112,14 +114,10 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
         onDoubleClick={() => setCollapsed('left', true)}
       >
         <div className="flex min-w-0 flex-1 items-center gap-1 self-stretch overflow-hidden">
-          <span
-            className={cn(
-              'min-w-0 truncate text-left transition-colors',
-              isBootstrapping && 'text-foreground/40'
-            )}
-          >
-            {taskName}
-          </span>
+          <TaskNameWithOverflowTooltip
+            taskName={taskName}
+            className={cn(isBootstrapping && 'text-foreground/40')}
+          />
           <TaskGitDiffStats task={task} className="h-full shrink-0 flex items-center pl-1 pr-1" />
           <RenderPrBadge task={task} />
         </div>
@@ -128,6 +126,46 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
     </TaskContextMenu>
   );
 });
+
+function TaskNameWithOverflowTooltip({
+  taskName,
+  className,
+}: {
+  taskName: string;
+  className?: string;
+}) {
+  const textRef = useRef<HTMLSpanElement>(null);
+  const [isTruncated, setIsTruncated] = useState(false);
+
+  const updateTruncation = useCallback(() => {
+    const element = textRef.current;
+    if (!element) return;
+    setIsTruncated(element.scrollWidth > element.clientWidth);
+  }, []);
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        className="h-auto min-w-0"
+        render={
+          <span
+            ref={textRef}
+            className={cn('min-w-0 truncate text-left transition-colors', className)}
+            onPointerEnter={updateTruncation}
+            onFocus={updateTruncation}
+          >
+            {taskName}
+          </span>
+        }
+      />
+      {isTruncated ? (
+        <TooltipContent side="right" align="center" className="max-w-80 break-words text-xs">
+          {taskName}
+        </TooltipContent>
+      ) : null}
+    </Tooltip>
+  );
+}
 
 const RenderPrBadge = observer(function RenderPrBadge({ task }: { task: TaskStore }) {
   if (!('prs' in task.data)) return null;

--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -135,13 +135,14 @@ function TaskNameWithOverflowTooltip({
   className?: string;
 }) {
   const textRef = useRef<HTMLSpanElement>(null);
-  const [isTruncated, setIsTruncated] = useState(false);
+  const [truncation, setTruncation] = useState({ taskName, isTruncated: false });
+  const isTruncated = truncation.taskName === taskName && truncation.isTruncated;
 
   const updateTruncation = useCallback(() => {
     const element = textRef.current;
     if (!element) return;
-    setIsTruncated(element.scrollWidth > element.clientWidth);
-  }, []);
+    setTruncation({ taskName, isTruncated: element.scrollWidth > element.clientWidth });
+  }, [taskName]);
 
   return (
     <Tooltip>


### PR DESCRIPTION
adds
<img width="537" height="58" alt="image" src="https://github.com/user-attachments/assets/117c03d3-9e9a-4252-bd29-96d4b7bd47a9" />

fixes
<img width="190" height="23" alt="Screenshot 2026-05-12 at 14 14 03" src="https://github.com/user-attachments/assets/3aed1615-3803-4aa2-bd6a-65d12d6b5eaf" />
