### PR TITLE
feat(settings): show Claude and Codex usage limits in agent settings

### DIFF
--- a/src/main/core/providers/usage/claude-usage.ts
+++ b/src/main/core/providers/usage/claude-usage.ts
@@ -1,0 +1,189 @@
+import { execFile } from 'node:child_process';
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import type {
+  ProviderUsage,
+  ProviderUsageCredits,
+  ProviderUsageResult,
+  ProviderUsageWindow,
+} from '@shared/provider-usage';
+import { log } from '@main/lib/logger';
+
+const execFileP = promisify(execFile);
+
+const USAGE_URL = 'https://api.anthropic.com/api/oauth/usage';
+const TOKEN_URL = 'https://console.anthropic.com/v1/oauth/token';
+const OAUTH_CLIENT_ID = '9d1c250a-e61b-44d9-88ed-5944d1962f5e';
+const OAUTH_BETA_HEADER = 'oauth-2025-04-20';
+const KEYCHAIN_SERVICE = 'Claude Code-credentials';
+
+type ClaudeCreds = {
+  accessToken: string;
+  refreshToken: string | null;
+  subscriptionType: string | null;
+};
+
+type AnthropicUsageWindow = { utilization: number; resets_at: string | null } | null;
+
+type AnthropicExtraUsage = {
+  is_enabled?: boolean;
+  monthly_limit?: number;
+  used_credits?: number;
+  currency?: string;
+} | null;
+
+type AnthropicUsageResponse = {
+  five_hour?: AnthropicUsageWindow;
+  seven_day?: AnthropicUsageWindow;
+  seven_day_opus?: AnthropicUsageWindow;
+  seven_day_sonnet?: AnthropicUsageWindow;
+  extra_usage?: AnthropicExtraUsage;
+};
+
+async function readKeychainCreds(): Promise<ClaudeCreds | null> {
+  if (process.platform !== 'darwin') return null;
+  try {
+    const { stdout } = await execFileP('security', [
+      'find-generic-password',
+      '-s',
+      KEYCHAIN_SERVICE,
+      '-w',
+    ]);
+    const parsed = JSON.parse(stdout.trim()) as {
+      claudeAiOauth?: {
+        accessToken?: string;
+        refreshToken?: string;
+        subscriptionType?: string;
+      };
+    };
+    const oauth = parsed.claudeAiOauth;
+    if (!oauth?.accessToken) return null;
+    return {
+      accessToken: oauth.accessToken,
+      refreshToken: oauth.refreshToken ?? null,
+      subscriptionType: oauth.subscriptionType ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readFileCreds(): Promise<ClaudeCreds | null> {
+  const filePath = path.join(os.homedir(), '.claude', '.credentials.json');
+  try {
+    const raw = await fs.readFile(filePath, 'utf8');
+    const parsed = JSON.parse(raw) as {
+      claudeAiOauth?: {
+        accessToken?: string;
+        refreshToken?: string;
+        subscriptionType?: string;
+      };
+    };
+    const oauth = parsed.claudeAiOauth;
+    if (!oauth?.accessToken) return null;
+    return {
+      accessToken: oauth.accessToken,
+      refreshToken: oauth.refreshToken ?? null,
+      subscriptionType: oauth.subscriptionType ?? null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function readClaudeCreds(): Promise<ClaudeCreds | null> {
+  return (await readKeychainCreds()) ?? (await readFileCreds());
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<string | null> {
+  try {
+    const response = await fetch(TOKEN_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+      body: new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }).toString(),
+    });
+    if (!response.ok) return null;
+    const json = (await response.json()) as { access_token?: string };
+    return json.access_token ?? null;
+  } catch (error) {
+    log.warn('[claude-usage] token refresh failed', error);
+    return null;
+  }
+}
+
+async function callUsageApi(
+  accessToken: string
+): Promise<AnthropicUsageResponse | { unauthorized: true } | null> {
+  try {
+    const response = await fetch(USAGE_URL, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+        'anthropic-beta': OAUTH_BETA_HEADER,
+      },
+    });
+    if (response.status === 401 || response.status === 403) {
+      return { unauthorized: true };
+    }
+    if (!response.ok) return null;
+    return (await response.json()) as AnthropicUsageResponse;
+  } catch (error) {
+    log.warn('[claude-usage] usage API call failed', error);
+    return null;
+  }
+}
+
+function toWindow(label: string, raw: AnthropicUsageWindow): ProviderUsageWindow | null {
+  if (!raw) return null;
+  return {
+    label,
+    utilization: Math.max(0, Math.min(100, raw.utilization)),
+    resetsAt: raw.resets_at,
+  };
+}
+
+export async function fetchClaudeUsage(): Promise<ProviderUsageResult> {
+  const creds = await readClaudeCreds();
+  if (!creds) return { status: 'unauthenticated' };
+
+  let response = await callUsageApi(creds.accessToken);
+  if (response && 'unauthorized' in response && creds.refreshToken) {
+    const newToken = await refreshAccessToken(creds.refreshToken);
+    if (newToken) response = await callUsageApi(newToken);
+  }
+  if (!response) return { status: 'error', message: 'Failed to fetch usage' };
+  if ('unauthorized' in response) return { status: 'unauthenticated' };
+
+  const windows: ProviderUsageWindow[] = [
+    toWindow('5-hour limit', response.five_hour ?? null),
+    toWindow('Weekly (all models)', response.seven_day ?? null),
+    toWindow('Weekly Sonnet', response.seven_day_sonnet ?? null),
+    toWindow('Weekly Opus', response.seven_day_opus ?? null),
+  ].filter((w): w is ProviderUsageWindow => w !== null);
+
+  const extra = response.extra_usage;
+  const credits: ProviderUsageCredits | null =
+    extra && extra.is_enabled && typeof extra.monthly_limit === 'number'
+      ? {
+          label: 'Monthly credit pool',
+          used: extra.used_credits ?? 0,
+          limit: extra.monthly_limit,
+          currency: extra.currency ?? 'USD',
+        }
+      : null;
+
+  const usage: ProviderUsage = {
+    providerId: 'claude',
+    plan: creds.subscriptionType,
+    account: null,
+    windows,
+    credits,
+    fetchedAt: Date.now(),
+  };
+  return { status: 'ok', usage };
+}

--- a/src/main/core/providers/usage/codex-usage.ts
+++ b/src/main/core/providers/usage/codex-usage.ts
@@ -1,0 +1,182 @@
+import { promises as fs } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type {
+  ProviderUsage,
+  ProviderUsageResult,
+  ProviderUsageWindow,
+} from '@shared/provider-usage';
+import { log } from '@main/lib/logger';
+
+const AUTH_FILE = path.join(os.homedir(), '.codex', 'auth.json');
+const USAGE_URL = 'https://chatgpt.com/backend-api/wham/usage';
+const REFRESH_URL = 'https://auth.openai.com/oauth/token';
+const OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
+
+type CodexAuth = {
+  accessToken: string;
+  refreshToken: string | null;
+  accountId: string | null;
+  email: string | null;
+};
+
+type ChatGptWindow = {
+  used_percent?: number;
+  reset_at?: number;
+  limit_window_seconds?: number;
+} | null;
+
+type ChatGptUsageResponse = {
+  plan_type?: string;
+  email?: string;
+  rate_limit?: {
+    primary_window?: ChatGptWindow;
+    secondary_window?: ChatGptWindow;
+  };
+  credits?: {
+    has_credits?: boolean;
+    balance?: string;
+  };
+};
+
+function decodeJwt(token: string): Record<string, unknown> | null {
+  try {
+    const segments = token.split('.');
+    if (segments.length !== 3) return null;
+    const padded = segments[1].replace(/-/g, '+').replace(/_/g, '/');
+    const padding = padded.length % 4 === 0 ? '' : '='.repeat(4 - (padded.length % 4));
+    const decoded = Buffer.from(padded + padding, 'base64').toString('utf8');
+    return JSON.parse(decoded) as Record<string, unknown>;
+  } catch {
+    return null;
+  }
+}
+
+function extractClaims(idToken: string): { accountId: string | null; email: string | null } {
+  const claims = decodeJwt(idToken);
+  if (!claims) return { accountId: null, email: null };
+  const auth = claims['https://api.openai.com/auth'] as Record<string, unknown> | undefined;
+  const accountId = auth?.['chatgpt_account_id'];
+  const email = claims['email'];
+  return {
+    accountId: typeof accountId === 'string' ? accountId : null,
+    email: typeof email === 'string' ? email : null,
+  };
+}
+
+async function readCodexAuth(): Promise<CodexAuth | null> {
+  try {
+    const raw = await fs.readFile(AUTH_FILE, 'utf8');
+    const parsed = JSON.parse(raw) as {
+      tokens?: {
+        access_token?: string;
+        refresh_token?: string;
+        id_token?: string;
+      };
+    };
+    const tokens = parsed.tokens;
+    if (!tokens?.access_token) return null;
+    const { accountId, email } = tokens.id_token
+      ? extractClaims(tokens.id_token)
+      : { accountId: null, email: null };
+    return {
+      accessToken: tokens.access_token,
+      refreshToken: tokens.refresh_token ?? null,
+      accountId,
+      email,
+    };
+  } catch {
+    return null;
+  }
+}
+
+async function refreshAccessToken(refreshToken: string): Promise<string | null> {
+  try {
+    const response = await fetch(REFRESH_URL, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: OAUTH_CLIENT_ID,
+      }),
+    });
+    if (!response.ok) return null;
+    const json = (await response.json()) as { access_token?: string };
+    return json.access_token ?? null;
+  } catch (error) {
+    log.warn('[codex-usage] token refresh failed', error);
+    return null;
+  }
+}
+
+async function callUsageApi(
+  accessToken: string,
+  accountId: string | null
+): Promise<ChatGptUsageResponse | { unauthorized: true } | null> {
+  try {
+    const headers: Record<string, string> = {
+      Authorization: `Bearer ${accessToken}`,
+    };
+    if (accountId) headers['chatgpt-account-id'] = accountId;
+    const response = await fetch(USAGE_URL, { headers });
+    if (response.status === 401 || response.status === 403) {
+      return { unauthorized: true };
+    }
+    if (!response.ok) return null;
+    return (await response.json()) as ChatGptUsageResponse;
+  } catch (error) {
+    log.warn('[codex-usage] usage API call failed', error);
+    return null;
+  }
+}
+
+function toWindow(label: string, raw: ChatGptWindow): ProviderUsageWindow | null {
+  if (!raw || typeof raw.used_percent !== 'number') return null;
+  const resetsAt =
+    typeof raw.reset_at === 'number' ? new Date(raw.reset_at * 1000).toISOString() : null;
+  return {
+    label,
+    utilization: Math.max(0, Math.min(100, raw.used_percent)),
+    resetsAt,
+  };
+}
+
+export async function fetchCodexUsage(): Promise<ProviderUsageResult> {
+  const auth = await readCodexAuth();
+  if (!auth) return { status: 'unauthenticated' };
+
+  let response = await callUsageApi(auth.accessToken, auth.accountId);
+  if (response && 'unauthorized' in response && auth.refreshToken) {
+    const newToken = await refreshAccessToken(auth.refreshToken);
+    if (newToken) response = await callUsageApi(newToken, auth.accountId);
+  }
+  if (!response) return { status: 'error', message: 'Failed to fetch usage' };
+  if ('unauthorized' in response) return { status: 'unauthenticated' };
+
+  const rateLimit = response.rate_limit ?? {};
+  const primaryLabel = windowLabel(rateLimit.primary_window ?? null, '5-hour limit');
+  const secondaryLabel = windowLabel(rateLimit.secondary_window ?? null, 'Weekly limit');
+  const windows: ProviderUsageWindow[] = [
+    toWindow(primaryLabel, rateLimit.primary_window ?? null),
+    toWindow(secondaryLabel, rateLimit.secondary_window ?? null),
+  ].filter((w): w is ProviderUsageWindow => w !== null);
+
+  const usage: ProviderUsage = {
+    providerId: 'codex',
+    plan: response.plan_type ?? null,
+    account: response.email ?? auth.email,
+    windows,
+    credits: null,
+    fetchedAt: Date.now(),
+  };
+  return { status: 'ok', usage };
+}
+
+function windowLabel(raw: ChatGptWindow, fallback: string): string {
+  if (!raw || typeof raw.limit_window_seconds !== 'number') return fallback;
+  const seconds = raw.limit_window_seconds;
+  if (seconds <= 6 * 60 * 60) return `${Math.round(seconds / 3600)}-hour limit`;
+  const days = Math.round(seconds / (24 * 60 * 60));
+  return days === 7 ? 'Weekly limit' : `${days}-day limit`;
+}

--- a/src/main/core/providers/usage/controller.ts
+++ b/src/main/core/providers/usage/controller.ts
@@ -1,0 +1,29 @@
+import { createRPCController } from '@shared/ipc/rpc';
+import type { ProviderUsageResult } from '@shared/provider-usage';
+import { TTLCache } from '@main/core/utils/ttl-cache';
+import { fetchClaudeUsage } from './claude-usage';
+import { fetchCodexUsage } from './codex-usage';
+
+const CACHE_TTL_MS = 5 * 60 * 1000;
+
+const claudeCache = new TTLCache<ProviderUsageResult>(CACHE_TTL_MS);
+const codexCache = new TTLCache<ProviderUsageResult>(CACHE_TTL_MS);
+
+export const providerUsageController = createRPCController({
+  get: async (providerId: string): Promise<ProviderUsageResult> => {
+    if (providerId === 'claude') return claudeCache.get(fetchClaudeUsage);
+    if (providerId === 'codex') return codexCache.get(fetchCodexUsage);
+    return { status: 'unsupported' };
+  },
+  refresh: async (providerId: string): Promise<ProviderUsageResult> => {
+    if (providerId === 'claude') {
+      claudeCache.invalidate();
+      return claudeCache.get(fetchClaudeUsage);
+    }
+    if (providerId === 'codex') {
+      codexCache.invalidate();
+      return codexCache.get(fetchCodexUsage);
+    }
+    return { status: 'unsupported' };
+  },
+});

--- a/src/main/rpc.ts
+++ b/src/main/rpc.ts
@@ -16,6 +16,7 @@ import { linearController } from './core/linear/controller';
 import { mcpController } from './core/mcp/controller';
 import { plainController } from './core/plain/controller';
 import { projectController } from './core/projects/controller';
+import { providerUsageController } from './core/providers/usage/controller';
 import { ptyController } from './core/pty/controller';
 import { pullRequestController } from './core/pull-requests/controller';
 import { repositoryController } from './core/repository/controller';
@@ -38,6 +39,7 @@ export const rpcRouter = createRPCRouter({
   app: appController,
   appSettings: appSettingsController,
   providerSettings: providerSettingsController,
+  providerUsage: providerUsageController,
   repository: repositoryController,
   fs: filesController,
   update: updateController,

--- a/src/renderer/features/settings/components/CliAgentsList.tsx
+++ b/src/renderer/features/settings/components/CliAgentsList.tsx
@@ -10,6 +10,7 @@ import type { DependencyState } from '@shared/dependencies';
 import { type CliAgentStatus } from '@renderer/features/settings/components/connections';
 import CustomCommandModal from '@renderer/features/settings/components/CustomCommandModal';
 import IntegrationRow from '@renderer/features/settings/components/IntegrationRow';
+import { ProviderUsageBar } from '@renderer/features/settings/components/ProviderUsageBar';
 import { getAgentInstallErrorMessage } from '@renderer/lib/components/agent-selector/agent-install';
 import { AgentInstallButton } from '@renderer/lib/components/agent-selector/agent-install-button';
 import { useToast } from '@renderer/lib/hooks/use-toast';
@@ -59,6 +60,8 @@ type AgentRowActions = {
   onSettingsClick: (id: string) => void;
 };
 
+const USAGE_BAR_PROVIDERS = new Set<string>(['claude', 'codex']);
+
 const renderAgentRow = (agent: CliAgentStatus, actions: AgentRowActions) => {
   const logo = agentMeta[agent.id as keyof typeof agentMeta]?.icon;
   const providerId = isValidProviderId(agent.id) ? agent.id : null;
@@ -76,59 +79,62 @@ const renderAgentRow = (agent: CliAgentStatus, actions: AgentRowActions) => {
   const isDetected = agent.status === 'connected';
   const indicatorClass = isDetected ? 'bg-emerald-500' : 'bg-muted-foreground/50';
   const statusLabel = isDetected ? 'Detected' : 'Not detected';
+  const showUsageBar = isDetected && USAGE_BAR_PROVIDERS.has(agent.id);
 
   return (
-    <IntegrationRow
-      key={agent.id}
-      logoSrc={logo}
-      icon={
-        logo ? undefined : (
-          <Sparkles className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
-        )
-      }
-      name={agent.name}
-      onNameClick={handleNameClick}
-      status={agent.status}
-      statusLabel={statusLabel}
-      showStatusPill={false}
-      installCommand={agent.installCommand}
-      middle={
-        <span className="flex items-center gap-2 text-sm text-muted-foreground">
-          <span className={`h-1.5 w-1.5 rounded-full ${indicatorClass}`} />
-          {statusLabel}
-        </span>
-      }
-      rightExtra={
-        isDetected ? (
-          <TooltipProvider delay={150}>
-            <Tooltip>
-              <TooltipTrigger>
-                <button
-                  type="button"
-                  onClick={() => actions.onSettingsClick(agent.id)}
-                  className={ICON_BUTTON}
-                  aria-label={`${agent.name} execution settings`}
-                >
-                  <Settings2 className="h-4 w-4" aria-hidden="true" />
-                </button>
-              </TooltipTrigger>
-              <TooltipContent side="top" className="text-xs">
-                Execution settings
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-        ) : providerId ? (
-          <AgentInstallButton
-            agentId={providerId}
-            canInstall={!!agent.installCommand}
-            isInstalled={isDetected}
-            isInstalling={actions.isInstalling(providerId)}
-            tooltipSide="top"
-            onInstall={() => actions.onInstallClick(agent)}
-          />
-        ) : null
-      }
-    />
+    <div key={agent.id}>
+      <IntegrationRow
+        logoSrc={logo}
+        icon={
+          logo ? undefined : (
+            <Sparkles className="h-3.5 w-3.5 text-muted-foreground" aria-hidden="true" />
+          )
+        }
+        name={agent.name}
+        onNameClick={handleNameClick}
+        status={agent.status}
+        statusLabel={statusLabel}
+        showStatusPill={false}
+        installCommand={agent.installCommand}
+        middle={
+          <span className="flex items-center gap-2 text-sm text-muted-foreground">
+            <span className={`h-1.5 w-1.5 rounded-full ${indicatorClass}`} />
+            {statusLabel}
+          </span>
+        }
+        rightExtra={
+          isDetected ? (
+            <TooltipProvider delay={150}>
+              <Tooltip>
+                <TooltipTrigger>
+                  <button
+                    type="button"
+                    onClick={() => actions.onSettingsClick(agent.id)}
+                    className={ICON_BUTTON}
+                    aria-label={`${agent.name} execution settings`}
+                  >
+                    <Settings2 className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </TooltipTrigger>
+                <TooltipContent side="top" className="text-xs">
+                  Execution settings
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+          ) : providerId ? (
+            <AgentInstallButton
+              agentId={providerId}
+              canInstall={!!agent.installCommand}
+              isInstalled={isDetected}
+              isInstalling={actions.isInstalling(providerId)}
+              tooltipSide="top"
+              onInstall={() => actions.onInstallClick(agent)}
+            />
+          ) : null
+        }
+      />
+      {showUsageBar ? <ProviderUsageBar providerId={agent.id as 'claude' | 'codex'} /> : null}
+    </div>
   );
 };
 

--- a/src/renderer/features/settings/components/ProviderUsageBar.tsx
+++ b/src/renderer/features/settings/components/ProviderUsageBar.tsx
@@ -1,0 +1,193 @@
+import { useQuery } from '@tanstack/react-query';
+import { ChevronRight, RefreshCw } from 'lucide-react';
+import React, { useState } from 'react';
+import type {
+  ProviderUsage,
+  ProviderUsageResult,
+  ProviderUsageWindow,
+} from '@shared/provider-usage';
+import { rpc } from '@renderer/lib/ipc';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@renderer/lib/ui/collapsible';
+
+type Props = {
+  providerId: 'claude' | 'codex';
+};
+
+const PLAN_LABELS: Record<string, string> = {
+  pro: 'Pro',
+  max: 'Max',
+  max5x: 'Max 5×',
+  max20x: 'Max 20×',
+  plus: 'Plus',
+  business: 'Business',
+  team: 'Team',
+  enterprise: 'Enterprise',
+  free: 'Free',
+};
+
+function formatPlan(plan: string | null): string | null {
+  if (!plan) return null;
+  return PLAN_LABELS[plan.toLowerCase()] ?? plan.charAt(0).toUpperCase() + plan.slice(1);
+}
+
+function formatReset(resetsAt: string | null): string | null {
+  if (!resetsAt) return null;
+  const date = new Date(resetsAt);
+  if (Number.isNaN(date.getTime())) return null;
+  const diffMs = date.getTime() - Date.now();
+  if (diffMs <= 0) return 'resets soon';
+  const absolute = date.toLocaleString(undefined, {
+    weekday: 'short',
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  const hours = Math.floor(diffMs / (60 * 60 * 1000));
+  if (hours >= 48) return `${absolute} (${Math.floor(hours / 24)}d)`;
+  if (hours >= 1) return `${absolute} (${hours}h)`;
+  const minutes = Math.max(1, Math.floor(diffMs / (60 * 1000)));
+  return `${absolute} (${minutes}m)`;
+}
+
+function utilizationTone(value: number): string {
+  if (value >= 90) return 'bg-destructive';
+  if (value >= 75) return 'bg-amber-500';
+  return 'bg-primary';
+}
+
+function UsageWindowRow({ window }: { window: ProviderUsageWindow }) {
+  const reset = formatReset(window.resetsAt);
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between gap-2 text-tiny">
+        <span className="font-medium text-foreground">{window.label}</span>
+        <span className="tabular-nums text-muted-foreground">
+          {window.utilization.toFixed(0)}% used
+        </span>
+      </div>
+      <div className="relative h-1.5 w-full overflow-hidden rounded-full bg-muted">
+        <div
+          className={`h-full transition-all ${utilizationTone(window.utilization)}`}
+          style={{ width: `${window.utilization}%` }}
+        />
+      </div>
+      {reset ? <div className="text-tiny text-muted-foreground/80">Resets {reset}</div> : null}
+    </div>
+  );
+}
+
+function UsageDetails({
+  usage,
+  onRefresh,
+  isRefreshing,
+}: {
+  usage: ProviderUsage;
+  onRefresh: () => void;
+  isRefreshing: boolean;
+}) {
+  const planLabel = formatPlan(usage.plan);
+  const updated = new Date(usage.fetchedAt).toLocaleTimeString(undefined, {
+    hour: 'numeric',
+    minute: '2-digit',
+  });
+  return (
+    <div className="mt-2 space-y-3 rounded-md border border-border/60 bg-muted/20 px-3 py-2.5">
+      <div className="flex items-center justify-between gap-2">
+        <div className="flex items-baseline gap-2">
+          {planLabel ? (
+            <span className="rounded-full border border-border/60 bg-background px-2 py-0.5 text-tiny font-medium">
+              {planLabel} plan
+            </span>
+          ) : null}
+          {usage.account ? (
+            <span className="truncate text-tiny text-muted-foreground">{usage.account}</span>
+          ) : null}
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={isRefreshing}
+          className="inline-flex h-6 items-center gap-1 rounded-md px-1.5 text-tiny text-muted-foreground transition hover:bg-muted/40 disabled:opacity-60"
+          aria-label="Refresh usage"
+        >
+          <RefreshCw
+            className={`h-3 w-3 ${isRefreshing ? 'animate-spin' : ''}`}
+            aria-hidden="true"
+          />
+          <span>Updated {updated}</span>
+        </button>
+      </div>
+      <div className="space-y-2.5">
+        {usage.windows.map((window) => (
+          <UsageWindowRow key={window.label} window={window} />
+        ))}
+      </div>
+      {usage.credits ? (
+        <div className="border-t border-border/60 pt-2 text-tiny">
+          <div className="flex items-center justify-between">
+            <span className="font-medium text-foreground">{usage.credits.label}</span>
+            <span className="tabular-nums text-muted-foreground">
+              {usage.credits.used.toFixed(2)} / {usage.credits.limit} {usage.credits.currency}
+            </span>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+export const ProviderUsageBar: React.FC<Props> = ({ providerId }) => {
+  const [open, setOpen] = useState(false);
+
+  const { data, isFetching, refetch } = useQuery<ProviderUsageResult>({
+    queryKey: ['providerUsage', providerId] as const,
+    queryFn: () => rpc.providerUsage.get(providerId) as Promise<ProviderUsageResult>,
+    staleTime: 5 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    retry: false,
+    enabled: open,
+  });
+
+  const handleRefresh = () => {
+    void rpc.providerUsage.refresh(providerId).then(() => refetch());
+  };
+
+  const usage = data?.status === 'ok' ? data.usage : null;
+  const summaryUtilization =
+    usage?.windows.reduce((max, w) => Math.max(max, w.utilization), 0) ?? null;
+
+  return (
+    <div className="pl-9 pr-3 pb-2">
+      <Collapsible open={open} onOpenChange={setOpen}>
+        <CollapsibleTrigger className="group flex w-full items-center gap-1.5 text-tiny text-muted-foreground transition hover:text-foreground focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2 focus-visible:ring-offset-background">
+          <ChevronRight
+            className={`h-3 w-3 transition-transform ${open ? 'rotate-90' : ''}`}
+            aria-hidden="true"
+          />
+          <span>Usage limits</span>
+          {summaryUtilization !== null && !open ? (
+            <span className="tabular-nums text-muted-foreground/70">
+              · peak {summaryUtilization.toFixed(0)}%
+            </span>
+          ) : null}
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          {data?.status === 'ok' && usage ? (
+            <UsageDetails usage={usage} onRefresh={handleRefresh} isRefreshing={isFetching} />
+          ) : data?.status === 'unauthenticated' ? (
+            <div className="mt-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-tiny text-muted-foreground">
+              Sign in to {providerId === 'claude' ? 'Claude Code' : 'Codex'} to see usage.
+            </div>
+          ) : data?.status === 'error' ? (
+            <div className="mt-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-tiny text-muted-foreground">
+              {data.message}
+            </div>
+          ) : (
+            <div className="mt-2 rounded-md border border-border/60 bg-muted/20 px-3 py-2 text-tiny text-muted-foreground">
+              {isFetching ? 'Loading usage…' : 'No usage data.'}
+            </div>
+          )}
+        </CollapsibleContent>
+      </Collapsible>
+    </div>
+  );
+};

--- a/src/shared/provider-usage.ts
+++ b/src/shared/provider-usage.ts
@@ -1,0 +1,27 @@
+export type ProviderUsageWindow = {
+  label: string;
+  utilization: number;
+  resetsAt: string | null;
+};
+
+export type ProviderUsageCredits = {
+  label: string;
+  used: number;
+  limit: number;
+  currency: string;
+};
+
+export type ProviderUsage = {
+  providerId: 'claude' | 'codex';
+  plan: string | null;
+  account: string | null;
+  windows: ProviderUsageWindow[];
+  credits: ProviderUsageCredits | null;
+  fetchedAt: number;
+};
+
+export type ProviderUsageResult =
+  | { status: 'ok'; usage: ProviderUsage }
+  | { status: 'unauthenticated' }
+  | { status: 'unsupported' }
+  | { status: 'error'; message: string };


### PR DESCRIPTION
## Summary
- Adds a collapsible "Usage limits" bar under detected Claude and Codex rows in the CLI agents settings list, showing rate-limit windows, reset times, plan badge, and optional credit-pool details with a manual refresh button.
- Reads OAuth credentials from the macOS keychain (`Claude Code-credentials`) or the on-disk fallbacks (`~/.claude/.credentials.json`, `~/.codex/auth.json`), refreshes access tokens on 401, and calls the Anthropic and ChatGPT usage endpoints.
- New `providerUsage` RPC controller backed by a 5-minute `TTLCache` per provider, plus shared `ProviderUsage*` types in `src/shared/provider-usage.ts`.

## Test plan
- [ ] Open Settings → Integrations and confirm Claude/Codex rows show the new "Usage limits" toggle only when detected
- [ ] Expand each bar while signed in and verify windows, reset times, plan badge, and refresh button render correctly
- [ ] Sign out (or remove creds) and verify the unauthenticated message
- [ ] Force a non-Claude/non-Codex provider id and confirm no usage bar renders