### PR TITLE
feat(tasks): add From Branch worktree default setting

### DIFF
--- a/src/main/core/settings/schema.ts
+++ b/src/main/core/settings/schema.ts
@@ -26,6 +26,7 @@ export const notificationSettingsSchema = z.object({
 export const taskSettingsSchema = z.object({
   autoGenerateName: z.boolean(),
   autoTrustWorktrees: z.boolean(),
+  createBranchAndWorktree: z.boolean(),
 });
 
 export const agentAutoApproveDefaultsSchema = z

--- a/src/main/core/settings/settings-registry.ts
+++ b/src/main/core/settings/settings-registry.ts
@@ -26,6 +26,7 @@ export const SETTINGS_DEFAULTS = {
   tasks: {
     autoGenerateName: true,
     autoTrustWorktrees: true,
+    createBranchAndWorktree: true,
   },
   agentAutoApproveDefaults: {},
   notifications: {

--- a/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/src/renderer/features/settings/components/SettingsPage.tsx
@@ -13,7 +13,12 @@ import NotificationSettingsCard from './NotificationSettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
 import ResourceMonitorSettingsCard from './ResourceMonitorSettingsCard';
 import { ReviewPromptResetButton, ReviewPromptSettingsCard } from './ReviewPromptSettingsCard';
-import { AutoGenerateTaskNamesRow, AutoTrustWorktreesRow, EnableTmuxRow } from './TaskSettingsRows';
+import {
+  AutoGenerateTaskNamesRow,
+  AutoTrustWorktreesRow,
+  CreateBranchAndWorktreeRow,
+  EnableTmuxRow,
+} from './TaskSettingsRows';
 import TelemetryCard from './TelemetryCard';
 import TerminalSettingsCard from './TerminalSettingsCard';
 import ThemeCard from './ThemeCard';
@@ -75,6 +80,9 @@ export function SettingsPage({
         },
         {
           component: <AutoTrustWorktreesRow />,
+        },
+        {
+          component: <CreateBranchAndWorktreeRow />,
         },
         {
           component: <EnableTmuxRow />,

--- a/src/renderer/features/settings/components/TaskSettingsRows.tsx
+++ b/src/renderer/features/settings/components/TaskSettingsRows.tsx
@@ -88,6 +88,32 @@ export const AutoTrustWorktreesRow: React.FC = () => {
   );
 };
 
+export const CreateBranchAndWorktreeRow: React.FC = () => {
+  const taskSettings = useTaskSettings();
+
+  return (
+    <SettingRow
+      title="Create branch and worktree by default"
+      description="Start new From Branch tasks in a dedicated task branch and worktree unless changed in the task modal."
+      control={
+        <>
+          <ResetToDefaultButton
+            visible={taskSettings.isFieldOverridden('createBranchAndWorktree')}
+            defaultLabel="on"
+            onReset={taskSettings.resetCreateBranchAndWorktree}
+            disabled={taskSettings.loading || taskSettings.saving}
+          />
+          <Switch
+            checked={taskSettings.createBranchAndWorktree}
+            disabled={taskSettings.loading || taskSettings.saving}
+            onCheckedChange={taskSettings.updateCreateBranchAndWorktree}
+          />
+        </>
+      }
+    />
+  );
+};
+
 export const EnableTmuxRow: React.FC = () => {
   const {
     value: projects,

--- a/src/renderer/features/tasks/create-task-modal/use-branch-selection.ts
+++ b/src/renderer/features/tasks/create-task-modal/use-branch-selection.ts
@@ -8,14 +8,19 @@ export function useBranchSelection(
   selectedProjectId: string | undefined,
   defaultBranch: Branch | undefined,
   isUnborn: boolean,
-  currentBranchName?: string | null
+  currentBranchName?: string | null,
+  createBranchAndWorktreeByDefault = true
 ) {
   const { value: project } = useAppSettingsKey('project');
   const pushOnCreateByDefault = project?.pushOnCreate ?? true;
 
-  const [createBranchAndWorktreePreference, setCreateBranchAndWorktreePreference] = useState(true);
+  const [createBranchAndWorktreeOverride, setCreateBranchAndWorktreeOverride] = useState<
+    boolean | undefined
+  >(undefined);
   const [pushBranchOverride, setPushBranchOverride] = useState<boolean | undefined>(undefined);
   const pushBranch = pushBranchOverride ?? pushOnCreateByDefault;
+  const createBranchAndWorktreePreference =
+    createBranchAndWorktreeOverride ?? createBranchAndWorktreeByDefault;
   const createBranchAndWorktree = isUnborn ? false : createBranchAndWorktreePreference;
 
   // Store the user's branch override alongside the project it belongs to.
@@ -48,7 +53,7 @@ export function useBranchSelection(
   const setCreateBranchAndWorktree = useCallback(
     (value: boolean) => {
       if (isUnborn) return;
-      setCreateBranchAndWorktreePreference(value);
+      setCreateBranchAndWorktreeOverride(value);
     },
     [isUnborn]
   );

--- a/src/renderer/features/tasks/create-task-modal/use-from-branch-mode.ts
+++ b/src/renderer/features/tasks/create-task-modal/use-from-branch-mode.ts
@@ -14,13 +14,14 @@ export function useFromBranchMode(
   isUnborn: boolean,
   currentBranchName?: string | null
 ) {
+  const { autoGenerateName, createBranchAndWorktree } = useTaskSettings();
   const branchSelection = useBranchSelection(
     selectedProjectId,
     defaultBranch,
     isUnborn,
-    currentBranchName
+    currentBranchName,
+    createBranchAndWorktree
   );
-  const { autoGenerateName } = useTaskSettings();
 
   const stableKey = useMemo(() => crypto.randomUUID(), []);
 

--- a/src/renderer/features/tasks/hooks/useTaskSettings.ts
+++ b/src/renderer/features/tasks/hooks/useTaskSettings.ts
@@ -3,13 +3,18 @@ import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-
 export interface TaskSettingsModel {
   autoGenerateName: boolean;
   autoTrustWorktrees: boolean;
+  createBranchAndWorktree: boolean;
   loading: boolean;
   saving: boolean;
-  isFieldOverridden: (field: 'autoGenerateName' | 'autoTrustWorktrees') => boolean;
+  isFieldOverridden: (
+    field: 'autoGenerateName' | 'autoTrustWorktrees' | 'createBranchAndWorktree'
+  ) => boolean;
   updateAutoGenerateName: (next: boolean) => void;
   updateAutoTrustWorktrees: (next: boolean) => void;
+  updateCreateBranchAndWorktree: (next: boolean) => void;
   resetAutoGenerateName: () => void;
   resetAutoTrustWorktrees: () => void;
+  resetCreateBranchAndWorktree: () => void;
 }
 
 export function useTaskSettings(): TaskSettingsModel {
@@ -25,12 +30,15 @@ export function useTaskSettings(): TaskSettingsModel {
   return {
     autoGenerateName: tasks?.autoGenerateName ?? false,
     autoTrustWorktrees: tasks?.autoTrustWorktrees ?? false,
+    createBranchAndWorktree: tasks?.createBranchAndWorktree ?? true,
     loading,
     saving,
     isFieldOverridden,
     updateAutoGenerateName: (next) => update({ autoGenerateName: next }),
     updateAutoTrustWorktrees: (next) => update({ autoTrustWorktrees: next }),
+    updateCreateBranchAndWorktree: (next) => update({ createBranchAndWorktree: next }),
     resetAutoGenerateName: () => resetField('autoGenerateName'),
     resetAutoTrustWorktrees: () => resetField('autoTrustWorktrees'),
+    resetCreateBranchAndWorktree: () => resetField('createBranchAndWorktree'),
   };
 }


### PR DESCRIPTION
## Summary
- add a task-level app setting for creating a branch/worktree by default
- surface the setting in General settings next to the existing task/worktree controls
- apply the setting only to From Branch task creation; From Issue and PR flows retain their existing defaults

## Validation
- pnpm run format
- pnpm run format:check
- pnpm run typecheck
- pnpm run lint (passes with one existing warning in command-palette-modal.tsx)
- pnpm run test
- Computer Use local dev app verification: setting appears in General settings, can be toggled off, persists to app_settings, and From Branch task modal opens with Create task branch and worktree unchecked
