### PR TITLE
fix: Show toast after integration setup

### DIFF
--- a/src/renderer/features/integrations/integration-setup-modal.tsx
+++ b/src/renderer/features/integrations/integration-setup-modal.tsx
@@ -1,5 +1,6 @@
 import { Loader2 } from 'lucide-react';
 import { useCallback, useState } from 'react';
+import { useToast } from '@renderer/lib/hooks/use-toast';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
@@ -68,6 +69,7 @@ export function IntegrationSetupModal({ integration, onSuccess, onClose }: Props
     isForgejoLoading,
     isFeaturebaseLoading,
   } = useIntegrationsContext();
+  const { toast } = useToast();
 
   // Linear state
   const [linearKey, setLinearKey] = useState('');
@@ -142,6 +144,10 @@ export function IntegrationSetupModal({ integration, onSuccess, onClose }: Props
           await connectFeaturebase(featurebaseKey.trim());
           break;
       }
+      toast({
+        title: 'Integration connected',
+        description: 'Integration set up successfully.',
+      });
       onSuccess();
     } catch (e) {
       setError((e as Error).message || 'Failed to connect.');
@@ -164,6 +170,7 @@ export function IntegrationSetupModal({ integration, onSuccess, onClose }: Props
     connectPlain,
     connectForgejo,
     connectFeaturebase,
+    toast,
     onSuccess,
   ]);
 


### PR DESCRIPTION
## Summary

- Show a success toast after an integration setup completes successfully.
- Keep the existing modal setup metadata unchanged.

## Validation

- pnpm run format
- pnpm run lint (passes with an existing unrelated command-palette hook dependency warning)
- pnpm run typecheck
- pnpm test (blocked by existing DB fixture/native-module issues unrelated to this UI change)
