### PR TITLE
fix: update initial conversation label casing

### DIFF
--- a/src/renderer/features/tasks/create-task-modal/initial-conversation-section.tsx
+++ b/src/renderer/features/tasks/create-task-modal/initial-conversation-section.tsx
@@ -53,7 +53,7 @@ export function InitialConversationField({ state, linkedIssue }: InitialConversa
   return (
     <>
       <Field>
-        <FieldLabel>Initial Conversation</FieldLabel>
+        <FieldLabel>Initial conversation</FieldLabel>
         <div className="flex flex-col border border-border rounded-md">
           <AgentSelector
             value={state.provider}


### PR DESCRIPTION
## Summary
- Changed the create task modal label from "Initial Conversation" to "Initial conversation" for sentence-style casing.

## Testing
- Verified the updated label text in source.