### PR TITLE
fix: wrap tmux shell line in /bin/sh for fish compatibility

### DIFF
--- a/src/main/core/pty/spawn-utils.test.ts
+++ b/src/main/core/pty/spawn-utils.test.ts
@@ -93,9 +93,11 @@ describe('resolveSshCommand', () => {
       zshProfile
     );
 
-    expect(result).toContain('tmux has-session -t "agent-session"');
-    expect(result).toContain('tmux new-session -d -s "agent-session"');
-    expect(result).toContain('tmux attach-session -t "agent-session"');
+    expect(result).toContain('tmux has-session -t');
+    expect(result).toContain('agent-session');
+    expect(result).toContain('tmux new-session -d -s');
+    expect(result).toContain('tmux attach-session -t');
+    expect(result).toContain('/bin/sh -c');
     expect(result).toContain("'\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\''");
   });
 

--- a/src/main/core/pty/spawn-utils.test.ts
+++ b/src/main/core/pty/spawn-utils.test.ts
@@ -93,10 +93,9 @@ describe('resolveSshCommand', () => {
       zshProfile
     );
 
-    expect(result).toContain('tmux has-session -t');
-    expect(result).toContain('agent-session');
-    expect(result).toContain('tmux new-session -d -s');
-    expect(result).toContain('tmux attach-session -t');
+    expect(result).toContain('tmux has-session -t \\"agent-session\\"');
+    expect(result).toContain('tmux new-session -d -s \\"agent-session\\"');
+    expect(result).toContain('tmux attach-session -t \\"agent-session\\"');
     expect(result).toContain('/bin/sh -c');
     expect(result).toContain("'\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\''");
   });

--- a/src/main/core/pty/tmux-session-name.test.ts
+++ b/src/main/core/pty/tmux-session-name.test.ts
@@ -5,11 +5,14 @@ describe('buildTmuxShellLine', () => {
   it('enables tmux mouse scrolling and deep history before attach', () => {
     const result = buildTmuxShellLine('agent-session', 'exec /bin/zsh -il');
 
-    expect(result).toContain('tmux has-session -t "agent-session"');
-    expect(result).toContain('tmux new-session -d -s "agent-session" "exec /bin/zsh -il"');
-    expect(result).toContain('tmux set-option -t "agent-session" mouse on');
-    expect(result).toContain('tmux set-option -t "agent-session" history-limit 100000');
-    expect(result).toContain('tmux attach-session -t "agent-session"');
+    expect(result).toMatch(/^\/bin\/sh -c /);
+    expect(result).toContain('tmux has-session -t');
+    expect(result).toContain('agent-session');
+    expect(result).toContain('tmux new-session -d -s');
+    expect(result).toContain('exec /bin/zsh -il');
+    expect(result).toContain('mouse on');
+    expect(result).toContain('history-limit 100000');
+    expect(result).toContain('tmux attach-session -t');
     expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
     expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
   });

--- a/src/main/core/pty/tmux-session-name.test.ts
+++ b/src/main/core/pty/tmux-session-name.test.ts
@@ -6,13 +6,11 @@ describe('buildTmuxShellLine', () => {
     const result = buildTmuxShellLine('agent-session', 'exec /bin/zsh -il');
 
     expect(result).toMatch(/^\/bin\/sh -c /);
-    expect(result).toContain('tmux has-session -t');
-    expect(result).toContain('agent-session');
-    expect(result).toContain('tmux new-session -d -s');
-    expect(result).toContain('exec /bin/zsh -il');
-    expect(result).toContain('mouse on');
-    expect(result).toContain('history-limit 100000');
-    expect(result).toContain('tmux attach-session -t');
+    expect(result).toContain('tmux has-session -t \\"agent-session\\"');
+    expect(result).toContain('tmux new-session -d -s \\"agent-session\\" \\"exec /bin/zsh -il\\"');
+    expect(result).toContain('tmux set-option -t \\"agent-session\\" mouse on');
+    expect(result).toContain('tmux set-option -t \\"agent-session\\" history-limit 100000');
+    expect(result).toContain('tmux attach-session -t \\"agent-session\\"');
     expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
     expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
   });

--- a/src/main/core/pty/tmux-session-name.ts
+++ b/src/main/core/pty/tmux-session-name.ts
@@ -13,7 +13,8 @@ export function buildTmuxShellLine(sessionName: string, commandLine: string): st
   const setHistoryLimit = `tmux set-option -t ${quotedName} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
   const configure = `(${enableMouse}) && (${setHistoryLimit})`;
   const attach = `tmux attach-session -t ${quotedName}`;
-  return `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
+  const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
+  return `/bin/sh -c ${JSON.stringify(script)}`;
 }
 
 export function makeTmuxSessionName(sessionId: string): string {


### PR DESCRIPTION
## Summary

The `buildTmuxShellLine` function generated bash-style commands using parentheses for subshell grouping and `&&` / `||` operators. Fish shell interprets `(...)` as command substitution, causing `command substitutions not allowed in command position` errors when the user's login shell is fish.

## Fix

Wrap the tmux script in `/bin/sh -c` so it always executes under a POSIX shell regardless of the user's login shell. The user's preferred shell still runs inside the tmux session via the `commandLine` argument passed to `tmux new-session`.

## What was tested

- All 24 pty tests pass (`tmux-session-name.test.ts`, `spawn-utils.test.ts`, `pty-spawn-platform.test.ts`, `pty-env.test.ts`)

Closes #2011