### PR TITLE
fix: reduce sidebar PR badge hover delay

### DIFF
--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -132,5 +132,5 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
 const RenderPrBadge = observer(function RenderPrBadge({ task }: { task: TaskStore }) {
   if (!('prs' in task.data)) return null;
   const pr = selectCurrentPr(task.data.prs);
-  return pr ? <PrBadge variant="compact" pr={pr} /> : null;
+  return pr ? <PrBadge variant="compact" pr={pr} hoverDelay={100} /> : null;
 });

--- a/src/renderer/lib/components/pr-badge.tsx
+++ b/src/renderer/lib/components/pr-badge.tsx
@@ -14,9 +14,10 @@ interface PrBadgeProps {
   variant?: 'default' | 'compact';
   pr: PullRequest;
   className?: string;
+  hoverDelay?: number;
 }
 
-export function PrBadge({ variant = 'default', pr, className }: PrBadgeProps) {
+export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBadgeProps) {
   const renderBadge = () => {
     switch (variant) {
       case 'default':
@@ -43,7 +44,9 @@ export function PrBadge({ variant = 'default', pr, className }: PrBadgeProps) {
 
   return (
     <Popover>
-      <PopoverTrigger openOnHover>{renderBadge()}</PopoverTrigger>
+      <PopoverTrigger openOnHover delay={hoverDelay}>
+        {renderBadge()}
+      </PopoverTrigger>
       <PopoverContent>
         <div className="flex flex-col gap-2">
           <div className="flex items-center gap-2 justify-between no-wrap">


### PR DESCRIPTION
## Summary
- Add an optional hover delay prop to `PrBadge`.
- Set the left sidebar PR badge popover delay to 100ms.

## Impact
This makes the PR status popover in the left sidebar feel more responsive while preserving the default delay for other PR badge usages.

## Validation
- `pnpm run format`
- `pnpm run lint` (passes with an existing `react-hooks/exhaustive-deps` warning in `src/renderer/features/command-palette/command-palette-modal.tsx`)
- `pnpm run typecheck`
- `pnpm run test` (fails: `src/main/db/tests/migrations/example.test.ts` expects 2 baseline projects but reads 0; initial native `better-sqlite3` ABI mismatch was resolved with `pnpm rebuild better-sqlite3 sqlite3`)
