### PR TITLE
feat: add line stats in changes file list

### DIFF
--- a/src/renderer/features/tasks/diff-view/changes-panel/components/changes-list-item.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/changes-list-item.tsx
@@ -4,6 +4,7 @@ import { type GitChange, type GitChangeStatus } from '@shared/git';
 import { splitPath } from '@renderer/features/tasks/utils';
 import { FileIcon } from '@renderer/lib/editor/file-icon';
 import { Checkbox } from '@renderer/lib/ui/checkbox';
+import { formatDiffLineCount } from '@renderer/utils/format-diff-line-count';
 import { cn } from '@renderer/utils/utils';
 
 interface ChangesListItemProps extends ButtonHTMLAttributes<HTMLButtonElement> {
@@ -31,37 +32,58 @@ export const ChangesListItem = forwardRef<HTMLButtonElement, ChangesListItemProp
           <span className="text-sm truncate">{filename}</span>
           {directory && <span className="text-xs text-foreground-muted truncate">{directory}</span>}
         </div>
-        <div className="relative size-4 shrink-0 flex items-center justify-center">
-          <span
-            className={cn(
-              'transition-opacity',
-              onToggleSelect && 'group-hover/item:opacity-0',
-              isSelected && 'opacity-0'
-            )}
-          >
-            <GitChangeStatusIcon status={change.status} className="size-4" />
-          </span>
-          {onToggleSelect && (
+        <div
+          className="flex shrink-0 items-center gap-1.5"
+          aria-label={`${change.additions} lines added, ${change.deletions} lines removed`}
+        >
+          <DiffLineStats additions={change.additions} deletions={change.deletions} />
+          <span className="relative flex size-4 items-center justify-center">
             <span
               className={cn(
-                'absolute inset-0 flex items-center justify-center transition-opacity',
-                'opacity-0 group-hover/item:opacity-100',
-                isSelected && 'opacity-100'
+                'transition-opacity',
+                onToggleSelect && 'group-hover/item:opacity-0',
+                isSelected && 'opacity-0'
               )}
             >
-              <Checkbox
-                checked={isSelected ?? false}
-                onCheckedChange={() => onToggleSelect(change.path)}
-                onClick={(e) => e.stopPropagation()}
-                aria-label={`Select ${filename}`}
-              />
+              <GitChangeStatusIcon status={change.status} className="size-4" />
             </span>
-          )}
+            {onToggleSelect && (
+              <span
+                className={cn(
+                  'absolute inset-0 flex items-center justify-center transition-opacity',
+                  'opacity-0 group-hover/item:opacity-100',
+                  isSelected && 'opacity-100'
+                )}
+              >
+                <Checkbox
+                  checked={isSelected ?? false}
+                  onCheckedChange={() => onToggleSelect(change.path)}
+                  onClick={(e) => e.stopPropagation()}
+                  aria-label={`Select ${filename}`}
+                />
+              </span>
+            )}
+          </span>
         </div>
       </button>
     );
   }
 );
+
+function DiffLineStats({ additions, deletions }: { additions: number; deletions: number }) {
+  if (additions === 0 && deletions === 0) return null;
+
+  return (
+    <span className="flex shrink-0 items-center gap-1 tabular-nums text-xs leading-none">
+      {additions > 0 && (
+        <span className="text-foreground-diff-added">+{formatDiffLineCount(additions)}</span>
+      )}
+      {deletions > 0 && (
+        <span className="text-foreground-diff-deleted">-{formatDiffLineCount(deletions)}</span>
+      )}
+    </span>
+  );
+}
 
 export function GitChangeStatusIcon({
   status,


### PR DESCRIPTION
## Summary
- Show per-file added and removed line counts in the changes view file list.
- Keep the existing status icon and checkbox hover behavior intact.

## Impact
Users can scan line-level change size directly from the changes list without opening each diff.

## Validation
- pnpm run format
- pnpm run lint (passes with one unrelated existing warning in command-palette-modal.tsx)
- pnpm run typecheck
- pnpm test