### PR TITLE
feat: add auto-approve permissions for Kiro

### DIFF
--- a/src/shared/agent-provider-registry.ts
+++ b/src/shared/agent-provider-registry.ts
@@ -363,6 +363,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     versionArgs: ['--version'],
     cli: 'kiro-cli',
     defaultArgs: ['chat'],
+    autoApproveFlag: '--trust-all-tools',
     initialPromptFlag: '',
     icon: 'kiro.png',
     alt: 'Kiro CLI',


### PR DESCRIPTION
Adds `--trust-all-tools` as the auto-approve flag for the Kiro (AWS) CLI provider.

## Changes

- Added `autoApproveFlag: '--trust-all-tools'` to the Kiro provider definition in `agent-provider-registry.ts`

## What this enables

When users toggle "Auto-approve permissions" for a Kiro task, Emdash will pass `--trust-all-tools` to the `kiro-cli chat` command, allowing the agent to run without stopping for tool approval prompts.

Closes #2020 