### PR TITLE
feat: add quit confirmation modal

### DIFF
--- a/src/main/app/menu.ts
+++ b/src/main/app/menu.ts
@@ -3,11 +3,26 @@ import {
   menuCheckForUpdatesChannel,
   menuCloseTabChannel,
   menuOpenSettingsChannel,
+  menuQuitRequestedChannel,
   menuRedoChannel,
   menuUndoChannel,
 } from '@shared/events/appEvents';
 import { EMDASH_DOCS_URL, EMDASH_RELEASES_URL } from '@shared/urls';
 import { events } from '@main/lib/events';
+import { getMainWindow } from './window';
+
+function requestQuit(): void {
+  const win = getMainWindow();
+  if (!win || win.webContents.isLoading()) {
+    app.quit();
+    return;
+  }
+
+  if (win.isMinimized()) win.restore();
+  win.show();
+  win.focus();
+  events.emit(menuQuitRequestedChannel, undefined);
+}
 
 export function setupApplicationMenu(): void {
   const isMac = process.platform === 'darwin';
@@ -43,7 +58,7 @@ export function setupApplicationMenu(): void {
               {
                 label: `Quit ${app.name}`,
                 accelerator: 'CmdOrCtrl+Q',
-                click: () => app.quit(),
+                click: requestQuit,
               },
             ],
           } as Electron.MenuItemConstructorOptions,
@@ -70,7 +85,11 @@ export function setupApplicationMenu(): void {
               accelerator: 'CmdOrCtrl+W',
               click: () => events.emit(menuCloseTabChannel, undefined),
             }
-          : { role: 'quit' as const },
+          : {
+              label: 'Quit',
+              accelerator: 'CmdOrCtrl+Q',
+              click: requestQuit,
+            },
       ],
     },
     // Edit menu

--- a/src/main/core/app/controller.ts
+++ b/src/main/core/app/controller.ts
@@ -21,6 +21,10 @@ export const appController = createRPCController({
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
+  quit: () => {
+    appService.quit();
+    return { success: true };
+  },
   openIn: async (args: {
     app: OpenInAppId;
     path: string;

--- a/src/main/core/app/controller.ts
+++ b/src/main/core/app/controller.ts
@@ -22,8 +22,12 @@ export const appController = createRPCController({
     }
   },
   quit: () => {
-    appService.quit();
-    return { success: true };
+    try {
+      appService.quit();
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
   },
   openIn: async (args: {
     app: OpenInAppId;

--- a/src/main/core/app/service.ts
+++ b/src/main/core/app/service.ts
@@ -1,6 +1,6 @@
 import { exec } from 'node:child_process';
 import { eq } from 'drizzle-orm';
-import { clipboard, dialog, shell } from 'electron';
+import { app, clipboard, dialog, shell } from 'electron';
 import { appPasteChannel, appRedoChannel, appUndoChannel } from '@shared/events/appEvents';
 import {
   getAppById,
@@ -174,6 +174,10 @@ class AppService implements IInitializable, IDisposable {
   clipboardWriteText(text: string): void {
     if (typeof text !== 'string') throw new Error('Invalid clipboard text');
     clipboard.writeText(text);
+  }
+
+  quit(): void {
+    app.quit();
   }
 
   async openIn(args: {

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -9,6 +9,7 @@ import { useAccountSession } from './lib/hooks/useAccount';
 import { useLegacyPortStatus } from './lib/hooks/useLegacyPort';
 import { WorkspaceLayoutContextProvider } from './lib/layout/layout-provider';
 import { WorkspaceViewProvider } from './lib/layout/provider';
+import { ModalRenderer } from './lib/modal/modal-renderer';
 import { FeatureFlagProvider } from './lib/providers/feature-flag-override-context';
 import { GithubContextProvider } from './lib/providers/github-context-provider';
 import { ThemeProvider } from './lib/providers/theme-provider';
@@ -84,7 +85,10 @@ function AppContent() {
               <WorkspaceViewProvider>
                 <AppMenuEvents onOpenSettings={handleOpenSettingsFromMenu} />
                 <RightSidebarProvider>
-                  <ThemeProvider>{renderContent()}</ThemeProvider>
+                  <ThemeProvider>
+                    <ModalRenderer />
+                    {renderContent()}
+                  </ThemeProvider>
                 </RightSidebarProvider>
               </WorkspaceViewProvider>
             </IntegrationsProvider>

--- a/src/renderer/app/app-menu-events.tsx
+++ b/src/renderer/app/app-menu-events.tsx
@@ -1,14 +1,20 @@
 import { when } from 'mobx';
 import { useEffect } from 'react';
-import { menuOpenSettingsChannel, notificationFocusTaskChannel } from '@shared/events/appEvents';
+import {
+  menuOpenSettingsChannel,
+  menuQuitRequestedChannel,
+  notificationFocusTaskChannel,
+} from '@shared/events/appEvents';
 import { getTaskView } from '@renderer/features/tasks/stores/task-selectors';
-import { events } from '@renderer/lib/ipc';
+import { events, rpc } from '@renderer/lib/ipc';
 import { useNavigate, useWorkspaceSlots } from '@renderer/lib/layout/navigation-provider';
 import { toggleSettingsView } from '@renderer/lib/layout/settings-toggle';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
 
 export function AppMenuEvents({ onOpenSettings }: { onOpenSettings?: () => boolean | void }) {
   const { navigate } = useNavigate();
   const { currentView, lastNonSettingsView } = useWorkspaceSlots();
+  const showConfirmQuitModal = useShowModal('confirmActionModal');
 
   useEffect(() => {
     return events.on(menuOpenSettingsChannel, () => {
@@ -20,6 +26,19 @@ export function AppMenuEvents({ onOpenSettings }: { onOpenSettings?: () => boole
       toggleSettingsView(navigate, currentView, lastNonSettingsView);
     });
   }, [navigate, onOpenSettings, currentView, lastNonSettingsView]);
+
+  useEffect(() => {
+    return events.on(menuQuitRequestedChannel, () => {
+      showConfirmQuitModal({
+        title: 'Quit Emdash?',
+        description: 'Active terminal sessions and running agents will stop when the app quits.',
+        confirmLabel: 'Quit',
+        onSuccess: () => {
+          void rpc.app.quit();
+        },
+      });
+    });
+  }, [showConfirmQuitModal]);
 
   useEffect(() => {
     const disposers = new Set<() => void>();

--- a/src/renderer/app/workspace.tsx
+++ b/src/renderer/app/workspace.tsx
@@ -8,7 +8,6 @@ import {
   useWorkspaceWrapParams,
 } from '@renderer/lib/layout/navigation-provider';
 import { WorkspaceContentLayout, WorkspaceLayout } from '@renderer/lib/layout/workspace-layout';
-import { ModalRenderer } from '@renderer/lib/modal/modal-renderer';
 import { Toaster } from '@renderer/lib/ui/toaster';
 
 export function Workspace() {
@@ -25,7 +24,6 @@ export function Workspace() {
         leftSidebar={<LeftSidebar />}
         mainContent={
           <WrapView {...wrapParams}>
-            <ModalRenderer />
             <WorkspaceViewContent />
           </WrapView>
         }

--- a/src/shared/events/appEvents.ts
+++ b/src/shared/events/appEvents.ts
@@ -12,6 +12,7 @@ export const menuCheckForUpdatesChannel = defineEvent<void>('menu:check-for-upda
 export const menuUndoChannel = defineEvent<void>('menu:undo');
 export const menuRedoChannel = defineEvent<void>('menu:redo');
 export const menuCloseTabChannel = defineEvent<void>('menu:close-tab');
+export const menuQuitRequestedChannel = defineEvent<void>('menu:quit-requested');
 
 export const gitStatusChangedChannel = defineEvent<{
   taskPath: string;


### PR DESCRIPTION
## Summary
- Route Cmd+Q / Quit menu actions through a renderer confirmation prompt.
- Reuse the existing shared confirmation modal and add a typed app-menu event for quit requests.
- Add an app RPC quit method so confirming the modal still uses the normal Electron shutdown path.

## Impact
Users get a chance to cancel accidental app quits before active terminals and running agents are stopped.

## Validation
- pnpm run format
- pnpm run lint (passes with one existing warning in command-palette-modal.tsx)
- pnpm run typecheck
- pnpm run test