### PR TITLE
fix: restore focus to previous element when modal closes

### DIFF
--- a/src/renderer/lib/modal/modal-renderer.tsx
+++ b/src/renderer/lib/modal/modal-renderer.tsx
@@ -1,6 +1,6 @@
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
 import { observer } from 'mobx-react-lite';
-import { useCallback, useRef } from 'react';
+import { useCallback, useEffect, useRef } from 'react';
 import {
   modalRegistry,
   type ModalPosition,
@@ -62,6 +62,20 @@ export const ModalRenderer = observer(function ModalRenderer() {
   };
 
   const popupRef = useRef<HTMLDivElement>(null);
+  const previousFocusRef = useRef<HTMLElement | null>(null);
+
+  // Capture the focused element when the modal opens; restore it when it closes.
+  useEffect(() => {
+    if (modalStore.isOpen) {
+      previousFocusRef.current = document.activeElement as HTMLElement | null;
+    } else if (previousFocusRef.current) {
+      const el = previousFocusRef.current;
+      previousFocusRef.current = null;
+      requestAnimationFrame(() => {
+        if (el.isConnected) el.focus();
+      });
+    }
+  }, [modalStore.isOpen]);
   const initialFocus = useCallback(() => {
     const target = popupRef.current?.querySelector<HTMLElement>('[data-autofocus]');
     if (!target) return true;

--- a/src/renderer/lib/modal/modal-renderer.tsx
+++ b/src/renderer/lib/modal/modal-renderer.tsx
@@ -62,15 +62,12 @@ export const ModalRenderer = observer(function ModalRenderer() {
   };
 
   const popupRef = useRef<HTMLDivElement>(null);
-  const previousFocusRef = useRef<HTMLElement | null>(null);
 
-  // Capture the focused element when the modal opens; restore it when it closes.
+  // Restore focus to the element captured by modalStore.setModal when the modal closes.
   useEffect(() => {
-    if (modalStore.isOpen) {
-      previousFocusRef.current = document.activeElement as HTMLElement | null;
-    } else if (previousFocusRef.current) {
-      const el = previousFocusRef.current;
-      previousFocusRef.current = null;
+    if (!modalStore.isOpen && modalStore.previousFocus) {
+      const el = modalStore.previousFocus;
+      modalStore.previousFocus = null;
       requestAnimationFrame(() => {
         if (el.isConnected) el.focus();
       });

--- a/src/renderer/lib/modal/modal-renderer.tsx
+++ b/src/renderer/lib/modal/modal-renderer.tsx
@@ -73,6 +73,7 @@ export const ModalRenderer = observer(function ModalRenderer() {
       });
     }
   }, [modalStore.isOpen]);
+
   const initialFocus = useCallback(() => {
     const target = popupRef.current?.querySelector<HTMLElement>('[data-autofocus]');
     if (!target) return true;

--- a/src/renderer/lib/modal/modal-renderer.tsx
+++ b/src/renderer/lib/modal/modal-renderer.tsx
@@ -1,4 +1,5 @@
 import { Dialog as DialogPrimitive } from '@base-ui/react/dialog';
+import { reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useRef } from 'react';
 import {
@@ -64,15 +65,22 @@ export const ModalRenderer = observer(function ModalRenderer() {
   const popupRef = useRef<HTMLDivElement>(null);
 
   // Restore focus to the element captured by modalStore.setModal when the modal closes.
-  useEffect(() => {
-    if (!modalStore.isOpen && modalStore.previousFocus) {
-      const el = modalStore.previousFocus;
-      modalStore.previousFocus = null;
-      requestAnimationFrame(() => {
-        if (el.isConnected) el.focus();
-      });
-    }
-  }, [modalStore.isOpen]);
+  useEffect(
+    () =>
+      reaction(
+        () => modalStore.isOpen,
+        (isOpen) => {
+          if (!isOpen && modalStore.previousFocus) {
+            const el = modalStore.previousFocus;
+            modalStore.previousFocus = null;
+            requestAnimationFrame(() => {
+              if (el.isConnected) el.focus();
+            });
+          }
+        }
+      ),
+    []
+  );
 
   const initialFocus = useCallback(() => {
     const target = popupRef.current?.querySelector<HTMLElement>('[data-autofocus]');

--- a/src/renderer/lib/modal/modal-store.ts
+++ b/src/renderer/lib/modal/modal-store.ts
@@ -5,15 +5,18 @@ class ModalStore {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   activeModalArgs: Record<string, any> | null = null;
   closeGuardActive = false;
+  previousFocus: HTMLElement | null = null;
 
   constructor() {
     makeAutoObservable(this, {
       activeModalArgs: observable.ref,
+      previousFocus: observable.ref,
     });
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   setModal(id: string, args: Record<string, any>) {
+    this.previousFocus = document.activeElement as HTMLElement | null;
     this.activeModalId = id;
     this.activeModalArgs = args;
   }


### PR DESCRIPTION
When a modal closes without navigating away (e.g. selecting the current task in the tab switcher or dismissing cmd+k), focus was lost because `finalFocus={false}` prevents base-ui from restoring it and no navigation transition re-triggers terminal focus.

This captures `document.activeElement` when the modal opens and restores focus to it on close if the element is still in the DOM (`el.isConnected`). When navigation does occur, the old element is unmounted so no stale focus is forced.

Closes #2029

## Before
<img width="3514" height="3868" alt="2026-05-14 15 13 43" src="https://github.com/user-attachments/assets/be6e3d4c-e4d1-4e6f-8f65-005c57312cc6" />

## After
<img width="3514" height="3868" alt="2026-05-14 15 12 34" src="https://github.com/user-attachments/assets/3a9387cc-8aa2-4b74-b9d7-e51d5f352049" />
