### PR TITLE
feat: use tabs in project view

### DIFF
--- a/src/renderer/features/projects/components/main-panel/active-project.tsx
+++ b/src/renderer/features/projects/components/main-panel/active-project.tsx
@@ -3,7 +3,49 @@ import { PullRequestView } from '@renderer/features/projects/components/pr-view/
 import { SettingsPanel } from '@renderer/features/projects/components/settings-view/settings-panel';
 import { TaskList } from '@renderer/features/projects/components/task-view/task-list';
 import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
+import type { ProjectView } from '@renderer/features/projects/stores/project-view';
 import { useParams } from '@renderer/lib/layout/navigation-provider';
+import { cn } from '@renderer/utils/utils';
+
+const projectViewItems: Array<{ id: ProjectView; label: string }> = [
+  { id: 'tasks', label: 'Tasks' },
+  { id: 'pull-request', label: 'Pull Requests' },
+  { id: 'settings', label: 'Settings' },
+];
+
+function ProjectViewNav({
+  activeView,
+  onChange,
+}: {
+  activeView: ProjectView;
+  onChange: (view: ProjectView) => void;
+}) {
+  return (
+    <div className="py-10">
+      <nav className="flex min-h-0 w-52 flex-col gap-0.5 overflow-y-auto" aria-label="Project">
+        {projectViewItems.map((item) => {
+          const isActive = item.id === activeView;
+
+          return (
+            <button
+              key={item.id}
+              type="button"
+              onClick={() => onChange(item.id)}
+              aria-current={isActive ? 'page' : undefined}
+              className={cn(
+                'flex w-full items-center gap-2 rounded-md px-3 py-2 text-sm font-normal text-foreground-muted transition-colors hover:bg-background-1 hover:text-foreground',
+                isActive &&
+                  'bg-background-2 text-foreground hover:bg-background-2 hover:text-foreground'
+              )}
+            >
+              <span className="truncate text-left">{item.label}</span>
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}
 
 export const ActiveProject = observer(function ActiveProject() {
   const {
@@ -16,10 +58,22 @@ export const ActiveProject = observer(function ActiveProject() {
   const activeView = store.view.activeView;
 
   return (
-    <>
-      {activeView === 'tasks' && <TaskList />}
-      {activeView === 'pull-request' && <PullRequestView />}
-      {activeView === 'settings' && <SettingsPanel />}
-    </>
+    <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
+      <div className="mx-auto flex h-full min-h-0 w-full max-w-[1060px] flex-col gap-6 px-8">
+        <div className="grid min-h-0 flex-1 grid-cols-[13rem_minmax(0,1fr)] gap-8 overflow-hidden">
+          <ProjectViewNav
+            activeView={activeView}
+            onChange={(view) => store.view.setProjectView(view)}
+          />
+          <div className="min-h-0 min-w-0 flex-1 justify-center overflow-x-hidden overflow-y-auto">
+            <div className="mx-auto flex h-full min-h-0 w-full max-w-4xl flex-col px-1 py-10">
+              {activeView === 'tasks' && <TaskList />}
+              {activeView === 'pull-request' && <PullRequestView />}
+              {activeView === 'settings' && <SettingsPanel />}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
   );
 });

--- a/src/renderer/features/projects/components/main-panel/active-project.tsx
+++ b/src/renderer/features/projects/components/main-panel/active-project.tsx
@@ -65,7 +65,7 @@ export const ActiveProject = observer(function ActiveProject() {
             activeView={activeView}
             onChange={(view) => store.view.setProjectView(view)}
           />
-          <div className="min-h-0 min-w-0 flex-1 justify-center overflow-x-hidden overflow-y-auto">
+          <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
             <div className="mx-auto flex h-full min-h-0 w-full max-w-4xl flex-col px-1 py-10">
               {activeView === 'tasks' && <TaskList />}
               {activeView === 'pull-request' && <PullRequestView />}

--- a/src/renderer/features/projects/components/pr-view/pr-view.tsx
+++ b/src/renderer/features/projects/components/pr-view/pr-view.tsx
@@ -247,7 +247,7 @@ export const PullRequestView = observer(function PullRequestView() {
 
   if (!repositoryUrl) {
     return (
-      <div className="flex flex-col max-w-3xl mx-auto w-full h-full pt-6 px-6 min-h-0">
+      <div className="flex h-full min-h-0 w-full flex-col">
         <p className="text-sm text-muted-foreground text-center py-4">
           Pull requests are currently available only for configured GitHub remotes. You can change
           the remote in the project settings.
@@ -258,7 +258,7 @@ export const PullRequestView = observer(function PullRequestView() {
 
   if (needsGhAuth) {
     return (
-      <div className="flex flex-col max-w-3xl mx-auto w-full h-full pt-6 px-6 min-h-0">
+      <div className="flex h-full min-h-0 w-full flex-col">
         <div className="flex w-full flex-col items-center justify-center gap-5 rounded-md border border-border border-dashed p-8 mt-4">
           <span className="relative flex size-8 items-center justify-center overflow-hidden rounded-full bg-background-2">
             <Github className="size-4 text-foreground-muted" />
@@ -285,7 +285,7 @@ export const PullRequestView = observer(function PullRequestView() {
   }
 
   return (
-    <div className="relative flex flex-col max-w-3xl mx-auto w-full h-full pt-6 px-6 min-h-0">
+    <div className="relative flex h-full min-h-0 w-full flex-col">
       {/* ── Header controls ── */}
       <div className="flex flex-col gap-4 border-b border-border pb-2">
         <div className="flex items-center gap-2 shrink-0 flex-wrap justify-between">

--- a/src/renderer/features/projects/components/project-titlebar.tsx
+++ b/src/renderer/features/projects/components/project-titlebar.tsx
@@ -9,7 +9,6 @@ import {
   projectDisplayName,
   projectViewKind,
 } from '@renderer/features/projects/stores/project-selectors';
-import type { ProjectView } from '@renderer/features/projects/stores/project-view';
 import { OpenInMenu } from '@renderer/lib/components/titlebar/open-in-menu';
 import { Titlebar } from '@renderer/lib/components/titlebar/Titlebar';
 import { rpc } from '@renderer/lib/ipc';
@@ -22,7 +21,6 @@ import {
   DropdownMenuTrigger,
 } from '@renderer/lib/ui/dropdown-menu';
 import { Separator } from '@renderer/lib/ui/separator';
-import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 
 const MountedProjectTitlebarLeft = observer(function ProjectTitlebarLeft({
   projectId,
@@ -132,28 +130,11 @@ export const ProjectTitlebar = observer(function ProjectTitlebar() {
     <Titlebar
       leftSlot={<MountedProjectTitlebarLeft projectId={projectId} />}
       rightSlot={
-        <div className="flex items-center gap-2 mr-2">
-          {!isRemote && <OpenInMenu path={mounted.data.path} className="h-7 bg-background" />}
-          <ToggleGroup
-            variant="outline"
-            size="sm"
-            value={[mounted.view.activeView]}
-            className="rounded-lg overflow-hidden shadow-none h-7 border border-border mx-1"
-            onValueChange={([value]) => {
-              if (value) mounted.view.setProjectView(value as ProjectView);
-            }}
-          >
-            <ToggleGroupItem value="tasks" size="sm">
-              Tasks
-            </ToggleGroupItem>
-            <ToggleGroupItem value="pull-request" size="sm">
-              Pull Requests
-            </ToggleGroupItem>
-            <ToggleGroupItem value="settings" size="sm">
-              Settings
-            </ToggleGroupItem>
-          </ToggleGroup>
-        </div>
+        !isRemote ? (
+          <div className="flex items-center gap-2 mr-2">
+            <OpenInMenu path={mounted.data.path} className="h-7 bg-background" />
+          </div>
+        ) : undefined
       }
     />
   );

--- a/src/renderer/features/projects/components/settings-view/project-settings-footer.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-footer.tsx
@@ -29,7 +29,7 @@ export function ProjectSettingsFooter({
   const saveDisabled = saving || !dirty;
 
   return (
-    <div className="flex justify-between gap-2 pt-5 pb-10">
+    <div className="flex justify-between gap-2 pt-5">
       <TooltipProvider delay={150}>
         <Tooltip>
           <TooltipTrigger>

--- a/src/renderer/features/projects/components/settings-view/project-settings-footer.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-footer.tsx
@@ -29,7 +29,7 @@ export function ProjectSettingsFooter({
   const saveDisabled = saving || !dirty;
 
   return (
-    <div className="flex justify-between gap-2 pt-5 pb-10 px-10">
+    <div className="flex justify-between gap-2 pt-5 pb-10">
       <TooltipProvider delay={150}>
         <Tooltip>
           <TooltipTrigger>

--- a/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
@@ -58,10 +58,10 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
   });
 
   return (
-    <div className="flex flex-col max-w-3xl mx-auto w-full h-full overflow-hidden">
-      <h1 className="text-lg font-medium pt-10 pb-5 px-10">Project Settings</h1>
+    <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
+      <h1 className="pb-5 text-xl">Project Settings</h1>
       <div
-        className="flex-1 overflow-y-auto overflow-x-hidden px-10 py-2"
+        className="flex-1 overflow-y-auto overflow-x-hidden py-2"
         style={{ scrollbarWidth: 'none' }}
       >
         <FieldGroup>

--- a/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
@@ -59,7 +59,6 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
 
   return (
     <div className="flex h-full min-h-0 w-full flex-col overflow-hidden">
-      <h1 className="pb-5 text-xl">Project Settings</h1>
       <div
         className="flex-1 overflow-y-auto overflow-x-hidden py-2"
         style={{ scrollbarWidth: 'none' }}

--- a/src/renderer/features/projects/components/task-view/task-list.tsx
+++ b/src/renderer/features/projects/components/task-view/task-list.tsx
@@ -178,7 +178,7 @@ export const TaskList = observer(function TaskList() {
   };
 
   return (
-    <div className="relative flex flex-col max-w-3xl mx-auto w-full h-full pt-6 px-6 min-h-0">
+    <div className="relative flex h-full min-h-0 w-full flex-col">
       <div className="flex flex-col gap-4 border-b border-border pb-3 shrink-0">
         <div className="flex items-center gap-2 flex-wrap justify-between">
           <ToggleGroup


### PR DESCRIPTION
- move project view navigation from the titlebar into a left side nav matching app settings layout
- make settings and pull requests more discoverable


<img width="1118" height="896" alt="Screenshot 2026-05-14 at 15 26 43" src="https://github.com/user-attachments/assets/6fa12457-2351-4757-aad5-f2178dac5342" />

<img width="1119" height="902" alt="Screenshot 2026-05-14 at 15 26 51" src="https://github.com/user-attachments/assets/44639d72-0ecf-4d05-b410-86f5cb0ea71f" />

