### PR TITLE
fix(release): run tooling npm install through shell on windows

### DIFF
--- a/scripts/postinstall.ts
+++ b/scripts/postinstall.ts
@@ -10,6 +10,7 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const toolingInstall = spawnSync('npm', ['install', '--prefix', 'tooling/node-deps'], {
   stdio: 'inherit',
   cwd: path.resolve(__dirname, '..'),
+  shell: process.platform === 'win32',
 });
 if (toolingInstall.error) {
   console.error(


### PR DESCRIPTION
fixes error in release flow:

. postinstall$ node --experimental-strip-types scripts/postinstall.ts
. postinstall: postinstall: failed to run npm install for tooling/node-deps: Error: spawnSync npm ENOENT
. postinstall:     at Object.spawnSync (node:internal/child_process:1143:20)
. postinstall:     at spawnSync (node:child_process:911:24)
. postinstall:     at file:///D:/a/emdash/emdash/scripts/postinstall.ts:10:24
. postinstall:     at ModuleJob.run (node:internal/modules/esm/module_job:437:25)
. postinstall:     at async node:internal/modules/esm/loader:639:26
. postinstall:     at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:101:5) {
. postinstall:   errno: -4058,
. postinstall:   code: 'ENOENT',
. postinstall:   syscall: 'spawnSync npm',
. postinstall:   path: 'npm',
. postinstall:   spawnargs: [ 'install', '--prefix', 'tooling/node-deps' ]
. postinstall: }
. postinstall: Failed
 ELIFECYCLE  Command failed with exit code 1.