### PR TITLE
fix: sqlite test routing

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "db:reset": "pnpm run db:reset:3 && pnpm run db:reset:4",
     "db:reset:3": "rm -f \"$HOME/Library/Application Support/emdash/emdash3.db\" \"$HOME/Library/Application Support/emdash/emdash3.db-wal\" \"$HOME/Library/Application Support/emdash/emdash3.db-shm\" \"$HOME/.config/emdash/emdash3.db\" \"$HOME/.config/emdash/emdash3.db-wal\" \"$HOME/.config/emdash/emdash3.db-shm\"",
     "db:reset:4": "rm -f \"$HOME/Library/Application Support/emdash/emdash4.db\" \"$HOME/Library/Application Support/emdash/emdash4.db-wal\" \"$HOME/Library/Application Support/emdash/emdash4.db-shm\" \"$HOME/.config/emdash/emdash4.db\" \"$HOME/.config/emdash/emdash4.db-wal\" \"$HOME/.config/emdash/emdash4.db-shm\"",
-    "test": "vitest run",
+    "test": "vitest run --project node --project main-db --project migrations --project browser",
     "build": "electron-vite build",
     "build:main": "electron-vite build --filter main",
     "build:renderer": "electron-vite build --filter renderer",

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -37,6 +37,7 @@ export default defineConfig({
             '**/_*/**',
             'src/renderer/tests/browser/**',
             'src/main/db/tests/migrations/**',
+            'src/main/db/legacy-port/**/*.test.ts',
             'src/main/core/**/*.db.test.ts',
           ],
         },
@@ -49,7 +50,7 @@ export default defineConfig({
         test: {
           name: 'main-db',
           environment: 'node',
-          include: ['src/main/core/**/*.db.test.ts'],
+          include: ['src/main/core/**/*.db.test.ts', 'src/main/db/legacy-port/**/*.test.ts'],
         },
       },
       {


### PR DESCRIPTION
- fixes the remaining better-sqlite3 ABI mismatch in the test suite by running legacy DB tests through the Vitest project that aliases better-sqlite3 to the system node build

- keeps the default test suite from running the fixture generator, since that project mutates the committed SQLite fixture files (really annoying to have them pop up all the time and restoring them again)