### PR TITLE
feat: make random branch name suffix optional

### DIFF
--- a/agents/workflows/worktrees.md
+++ b/agents/workflows/worktrees.md
@@ -11,6 +11,7 @@
 
 - task worktrees are created under the project's DB-backed worktree directory setting
 - branch prefix defaults to `emdash` and is configurable in app settings
+- generated task branch names use the configured prefix plus a random suffix by default; app repository settings can disable only the random suffix
 - selected gitignored files are preserved into worktrees
 - worktree creation is managed by the project provider pattern
 

--- a/src/main/core/settings/schema.ts
+++ b/src/main/core/settings/schema.ts
@@ -8,6 +8,7 @@ import { DEFAULT_AGENT_ID, DEFAULT_REVIEW_PROMPT } from './settings-registry';
 export const projectSettingsSchema = z.object({
   pushOnCreate: z.boolean(),
   branchPrefix: z.string(),
+  appendRandomBranchSuffix: z.boolean(),
   tmuxByDefault: z.boolean(),
 });
 

--- a/src/main/core/settings/settings-registry.ts
+++ b/src/main/core/settings/settings-registry.ts
@@ -17,6 +17,7 @@ export const SETTINGS_DEFAULTS = {
   project: {
     pushOnCreate: true,
     branchPrefix: 'emdash',
+    appendRandomBranchSuffix: true,
     tmuxByDefault: false,
   },
   localProject: () => ({

--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -45,7 +45,6 @@ export async function createTask(
 ): Promise<Result<CreateTaskSuccess, CreateTaskError>> {
   const { strategy } = params;
   const suffix = Math.random().toString(36).slice(2, 7);
-  const branchPrefix = (await appSettingsService.get('project')).branchPrefix ?? '';
   const agentAutoApproveDefaults = await appSettingsService.get('agentAutoApproveDefaults');
   let warning: CreateTaskWarning | undefined;
 
@@ -53,6 +52,9 @@ export async function createTask(
   if (!project) {
     return err({ type: 'project-not-found' });
   }
+  const projectDefaults = await appSettingsService.get('project');
+  const branchPrefix = projectDefaults.branchPrefix ?? '';
+  const appendRandomSuffix = projectDefaults.appendRandomBranchSuffix ?? true;
   const { baseRemote, pushRemote } = await project.repository.getConfiguredRemotes();
 
   // Determines what gets stored as taskBranch in the DB and how the worktree is prepared.
@@ -67,6 +69,7 @@ export async function createTask(
         rawBranch,
         branchPrefix,
         suffix,
+        appendRandomSuffix,
         linkedIssue: params.linkedIssue,
       });
       const repoInfo = await project.repository.getRepositoryInfo();
@@ -139,6 +142,7 @@ export async function createTask(
           rawBranch,
           branchPrefix,
           suffix,
+          appendRandomSuffix,
         });
         const createResult = await project.repository.createBranch(
           taskBranch,

--- a/src/main/core/tasks/operations/renameTask.ts
+++ b/src/main/core/tasks/operations/renameTask.ts
@@ -9,6 +9,15 @@ import { tasks } from '@main/db/schema';
 import { appSettingsService } from '../../settings/settings-service';
 import { resolveTaskBranchName } from '../resolveTaskBranchName';
 
+function parseLinkedIssueProvider(linkedIssue: unknown): unknown {
+  if (!linkedIssue || typeof linkedIssue !== 'string') return undefined;
+  try {
+    return (JSON.parse(linkedIssue) as { provider?: unknown }).provider;
+  } catch {
+    return undefined;
+  }
+}
+
 export async function renameTask(
   projectId: string,
   taskId: string,
@@ -37,16 +46,13 @@ export async function renameTask(
         const suffix = Math.random().toString(36).slice(2, 7);
         const projectDefaults = await appSettingsService.get('project');
         const branchPrefix = projectDefaults.branchPrefix ?? '';
-        const linkedIssue =
-          row.linkedIssue && typeof row.linkedIssue === 'string'
-            ? (JSON.parse(row.linkedIssue) as { provider?: unknown })
-            : undefined;
+        const linkedIssueProvider = parseLinkedIssueProvider(row.linkedIssue);
         newBranch = resolveTaskBranchName({
           rawBranch: newName,
           branchPrefix,
           suffix,
           appendRandomSuffix: projectDefaults.appendRandomBranchSuffix ?? true,
-          disableRandomSuffix: linkedIssue?.provider === 'linear',
+          disableRandomSuffix: linkedIssueProvider === 'linear',
         });
 
         const renameResult = await project.repository.renameBranch(oldBranch, newBranch);

--- a/src/main/core/tasks/operations/renameTask.ts
+++ b/src/main/core/tasks/operations/renameTask.ts
@@ -1,4 +1,6 @@
 import { and, eq, sql } from 'drizzle-orm';
+import { err, ok, type Result } from '@shared/result';
+import type { RenameTaskError, RenameTaskSuccess, RenameTaskWarning } from '@shared/tasks';
 import { projectManager } from '@main/core/projects/project-manager';
 import { taskEvents } from '@main/core/tasks/task-events';
 import { mapTaskRowToTask } from '@main/core/tasks/utils/utils';
@@ -11,16 +13,17 @@ export async function renameTask(
   projectId: string,
   taskId: string,
   newName: string
-): Promise<void> {
+): Promise<Result<RenameTaskSuccess, RenameTaskError>> {
   const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId)).limit(1);
-  if (!row) throw new Error(`Task not found: ${taskId}`);
+  if (!row) return err({ type: 'task-not-found', taskId });
 
   const project = projectManager.getProject(projectId);
-  if (!project) throw new Error(`Project not found: ${projectId}`);
+  if (!project) return err({ type: 'project-not-found', projectId });
 
   const oldBranch = row.taskBranch;
   const sourceBranch = row.sourceBranch ?? undefined;
   let newBranch: string | null = null;
+  let warning: RenameTaskWarning | undefined;
 
   if (oldBranch) {
     if (sourceBranch && oldBranch !== sourceBranch.branch) {
@@ -46,7 +49,29 @@ export async function renameTask(
           disableRandomSuffix: linkedIssue?.provider === 'linear',
         });
 
-        await project.repository.renameBranch(oldBranch, newBranch);
+        const renameResult = await project.repository.renameBranch(oldBranch, newBranch);
+        if (!renameResult.success) {
+          switch (renameResult.error.type) {
+            case 'already_exists':
+              return err({
+                type: 'branch-already-exists',
+                branch: renameResult.error.name,
+              });
+            case 'remote_push_failed':
+              warning = {
+                type: 'branch-remote-push-failed',
+                branch: newBranch,
+                message: renameResult.error.message,
+              };
+              break;
+            case 'error':
+              return err({
+                type: 'branch-rename-failed',
+                branch: newBranch,
+                message: renameResult.error.message,
+              });
+          }
+        }
       }
     }
   }
@@ -64,4 +89,6 @@ export async function renameTask(
   if (updatedRow) {
     taskEvents._emit('task:updated', mapTaskRowToTask(updatedRow));
   }
+
+  return ok({ warning });
 }

--- a/src/main/core/tasks/operations/renameTask.ts
+++ b/src/main/core/tasks/operations/renameTask.ts
@@ -5,6 +5,7 @@ import { mapTaskRowToTask } from '@main/core/tasks/utils/utils';
 import { db } from '@main/db/client';
 import { tasks } from '@main/db/schema';
 import { appSettingsService } from '../../settings/settings-service';
+import { resolveTaskBranchName } from '../resolveTaskBranchName';
 
 export async function renameTask(
   projectId: string,
@@ -31,8 +32,19 @@ export async function renameTask(
 
       if (siblings.length === 1) {
         const suffix = Math.random().toString(36).slice(2, 7);
-        const branchPrefix = (await appSettingsService.get('project')).branchPrefix ?? '';
-        newBranch = branchPrefix ? `${branchPrefix}/${newName}-${suffix}` : `${newName}-${suffix}`;
+        const projectDefaults = await appSettingsService.get('project');
+        const branchPrefix = projectDefaults.branchPrefix ?? '';
+        const linkedIssue =
+          row.linkedIssue && typeof row.linkedIssue === 'string'
+            ? (JSON.parse(row.linkedIssue) as { provider?: unknown })
+            : undefined;
+        newBranch = resolveTaskBranchName({
+          rawBranch: newName,
+          branchPrefix,
+          suffix,
+          appendRandomSuffix: projectDefaults.appendRandomBranchSuffix ?? true,
+          disableRandomSuffix: linkedIssue?.provider === 'linear',
+        });
 
         await project.repository.renameBranch(oldBranch, newBranch);
       }

--- a/src/main/core/tasks/resolveTaskBranchName.test.ts
+++ b/src/main/core/tasks/resolveTaskBranchName.test.ts
@@ -7,6 +7,7 @@ describe('resolveTaskBranchName', () => {
       rawBranch: 'linear-issue-branch-name-creation',
       branchPrefix: 'emdash',
       suffix: 'abc12',
+      appendRandomSuffix: true,
       linkedIssue: {
         provider: 'linear',
         url: 'https://linear.app/general-action/issue/GEN-626',
@@ -19,11 +20,12 @@ describe('resolveTaskBranchName', () => {
     expect(branchName).toBe('jona/gen-626-linear-issue-branch-name-creation');
   });
 
-  it('falls back to the existing prefixed and suffixed format when Linear branchName is absent', () => {
+  it('keeps Linear branch names unsuffixed when Linear branchName is absent', () => {
     const branchName = resolveTaskBranchName({
       rawBranch: 'linear-issue-branch-name-creation',
       branchPrefix: 'emdash',
       suffix: 'abc12',
+      appendRandomSuffix: true,
       linkedIssue: {
         provider: 'linear',
         url: 'https://linear.app/general-action/issue/GEN-626',
@@ -32,7 +34,7 @@ describe('resolveTaskBranchName', () => {
       },
     });
 
-    expect(branchName).toBe('emdash/linear-issue-branch-name-creation-abc12');
+    expect(branchName).toBe('emdash/linear-issue-branch-name-creation');
   });
 
   it('keeps the existing format for non-Linear issues', () => {
@@ -40,6 +42,7 @@ describe('resolveTaskBranchName', () => {
       rawBranch: 'bugfix-login',
       branchPrefix: 'emdash',
       suffix: 'xyz99',
+      appendRandomSuffix: true,
       linkedIssue: {
         provider: 'jira',
         url: 'https://example.atlassian.net/browse/APP-42',
@@ -50,5 +53,39 @@ describe('resolveTaskBranchName', () => {
     });
 
     expect(branchName).toBe('emdash/bugfix-login-xyz99');
+  });
+
+  it('omits only the random suffix when disabled', () => {
+    const branchName = resolveTaskBranchName({
+      rawBranch: 'bugfix-login',
+      branchPrefix: 'emdash',
+      suffix: 'xyz99',
+      appendRandomSuffix: false,
+    });
+
+    expect(branchName).toBe('emdash/bugfix-login');
+  });
+
+  it('omits the random suffix when explicitly disabled for a provider flow', () => {
+    const branchName = resolveTaskBranchName({
+      rawBranch: 'bugfix-login',
+      branchPrefix: 'emdash',
+      suffix: 'xyz99',
+      appendRandomSuffix: true,
+      disableRandomSuffix: true,
+    });
+
+    expect(branchName).toBe('emdash/bugfix-login');
+  });
+
+  it('can create the raw task name when suffix and prefix are disabled', () => {
+    const branchName = resolveTaskBranchName({
+      rawBranch: 'bugfix-login',
+      branchPrefix: '',
+      suffix: 'xyz99',
+      appendRandomSuffix: false,
+    });
+
+    expect(branchName).toBe('bugfix-login');
   });
 });

--- a/src/main/core/tasks/resolveTaskBranchName.ts
+++ b/src/main/core/tasks/resolveTaskBranchName.ts
@@ -4,14 +4,18 @@ type ResolveTaskBranchNameInput = {
   rawBranch: string;
   branchPrefix: string;
   suffix: string;
+  appendRandomSuffix: boolean;
   linkedIssue?: Issue;
+  disableRandomSuffix?: boolean;
 };
 
 export function resolveTaskBranchName({
   rawBranch,
   branchPrefix,
   suffix,
+  appendRandomSuffix,
   linkedIssue,
+  disableRandomSuffix = false,
 }: ResolveTaskBranchNameInput): string {
   const linearBranchName =
     linkedIssue?.provider === 'linear' ? linkedIssue.branchName?.trim() : undefined;
@@ -20,5 +24,8 @@ export function resolveTaskBranchName({
     return linearBranchName;
   }
 
-  return branchPrefix ? `${branchPrefix}/${rawBranch}-${suffix}` : `${rawBranch}-${suffix}`;
+  const shouldAppendSuffix =
+    appendRandomSuffix && !disableRandomSuffix && linkedIssue?.provider !== 'linear';
+  const branch = shouldAppendSuffix ? `${rawBranch}-${suffix}` : rawBranch;
+  return branchPrefix ? `${branchPrefix}/${branch}` : branch;
 }

--- a/src/renderer/features/settings/components/RepositorySettingsCard.tsx
+++ b/src/renderer/features/settings/components/RepositorySettingsCard.tsx
@@ -66,8 +66,8 @@ const RepositorySettingsCard: React.FC = () => {
         </div>
       </div>
       <SettingRow
-        title="Append random branch suffix"
-        description="Add a short random suffix to generated task branch names."
+        title="Random branch suffix"
+        description="Add a random suffix to branch names."
         control={
           <>
             <ResetToDefaultButton

--- a/src/renderer/features/settings/components/RepositorySettingsCard.tsx
+++ b/src/renderer/features/settings/components/RepositorySettingsCard.tsx
@@ -24,14 +24,17 @@ const RepositorySettingsCard: React.FC = () => {
   } = useAppSettingsKey('localProject');
 
   const branchPrefix = project?.branchPrefix ?? '';
+  const appendRandomBranchSuffix = project?.appendRandomBranchSuffix ?? true;
   const pushOnCreate = project?.pushOnCreate ?? true;
   const writeAgentConfigToGitIgnore = localProject?.writeAgentConfigToGitIgnore ?? true;
   const projectBusy = projectLoading || projectSaving;
   const localProjectBusy = localProjectLoading || localProjectSaving;
 
   const example = useMemo(() => {
-    return `${branchPrefix}/my-feature-a3f`;
-  }, [branchPrefix]);
+    const prefix = branchPrefix ? `${branchPrefix}/` : '';
+    const suffix = appendRandomBranchSuffix ? '-a3f' : '';
+    return `${prefix}my-feature${suffix}`;
+  }, [appendRandomBranchSuffix, branchPrefix]);
 
   return (
     <div className="grid gap-8">
@@ -62,6 +65,26 @@ const RepositorySettingsCard: React.FC = () => {
           Example: <code className="rounded bg-muted/60 px-1">{example}</code>
         </div>
       </div>
+      <SettingRow
+        title="Append random branch suffix"
+        description="Add a short random suffix to generated task branch names."
+        control={
+          <>
+            <ResetToDefaultButton
+              visible={isProjectFieldOverridden('appendRandomBranchSuffix')}
+              defaultLabel="on"
+              onReset={() => resetProjectField('appendRandomBranchSuffix')}
+              disabled={projectBusy}
+            />
+            <Switch
+              checked={appendRandomBranchSuffix}
+              onCheckedChange={(checked) => updateProject({ appendRandomBranchSuffix: checked })}
+              disabled={projectBusy}
+              aria-label="Append random branch suffix"
+            />
+          </>
+        }
+      />
       <SettingRow
         title="Auto-push on create"
         description="Push the new branch to the selected project remote and set upstream after creation."

--- a/src/renderer/features/tasks/rename-task-modal.tsx
+++ b/src/renderer/features/tasks/rename-task-modal.tsx
@@ -1,5 +1,7 @@
 import { observer } from 'mobx-react-lite';
 import { useCallback, useState } from 'react';
+import { toast } from 'sonner';
+import type { RenameTaskError } from '@shared/tasks';
 import { getTaskManagerStore } from '@renderer/features/tasks/stores/task-selectors';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
@@ -25,6 +27,19 @@ type RenameTaskModalArgs = {
 };
 
 type Props = BaseModalProps<void> & RenameTaskModalArgs;
+
+function formatRenameTaskError(error: RenameTaskError): string {
+  switch (error.type) {
+    case 'task-not-found':
+      return 'Task not found.';
+    case 'project-not-found':
+      return 'Project not found.';
+    case 'branch-already-exists':
+      return `Branch "${error.branch}" already exists. Try a different task name.`;
+    case 'branch-rename-failed':
+      return `Could not rename branch "${error.branch}": ${error.message}`;
+  }
+}
 
 export const RenameTaskModal = observer(function RenameTaskModal({
   projectId,
@@ -68,7 +83,17 @@ export const RenameTaskModal = observer(function RenameTaskModal({
     setIsSubmitting(true);
     setError(null);
     try {
-      await task.rename(normalizedName);
+      const result = await task.rename(normalizedName);
+      if (!result.success) {
+        setError(formatRenameTaskError(result.error));
+        setIsSubmitting(false);
+        return;
+      }
+      if (result.data.warning) {
+        toast.error(
+          `Branch was renamed locally to "${result.data.warning.branch}", but could not be pushed to the remote: ${result.data.warning.message}`
+        );
+      }
       onSuccess();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to rename task');

--- a/src/renderer/features/tasks/stores/task-store.ts
+++ b/src/renderer/features/tasks/stores/task-store.ts
@@ -1,5 +1,12 @@
 import { makeAutoObservable, observable, runInAction } from 'mobx';
-import type { Issue, Task, TaskLifecycleStatus } from '@shared/tasks';
+import { err, type Result } from '@shared/result';
+import type {
+  Issue,
+  RenameTaskError,
+  RenameTaskSuccess,
+  Task,
+  TaskLifecycleStatus,
+} from '@shared/tasks';
 import type { ProjectSettingsStore } from '@renderer/features/projects/stores/project-settings-store';
 import { DraftCommentsStore } from '@renderer/features/tasks/diff-view/stores/draft-comments-store';
 import { rpc } from '@renderer/lib/ipc';
@@ -174,19 +181,19 @@ export class TaskStore {
     return (this.data as Task).conversations;
   }
 
-  async rename(name: string): Promise<void> {
-    if (this.state !== 'provisioned') return;
+  async rename(name: string): Promise<Result<RenameTaskSuccess, RenameTaskError>> {
     const task = registeredTaskData(this);
-    if (!task) return;
+    if (!task) return err({ type: 'task-not-found', taskId: this.data.id });
     try {
-      await rpc.tasks.renameTask(task.projectId, task.id, name);
+      const result = await rpc.tasks.renameTask(task.projectId, task.id, name);
+      if (!result.success) {
+        return result;
+      }
       runInAction(() => {
         this.data.name = name;
       });
+      return result;
     } catch (e) {
-      runInAction(() => {
-        this.data.name = task.name;
-      });
       log.error(e);
       throw e;
     }

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -99,6 +99,22 @@ export type CreateTaskSuccess = {
   warning?: CreateTaskWarning;
 };
 
+export type RenameTaskError =
+  | { type: 'task-not-found'; taskId: string }
+  | { type: 'project-not-found'; projectId: string }
+  | { type: 'branch-already-exists'; branch: string }
+  | { type: 'branch-rename-failed'; branch: string; message: string };
+
+export type RenameTaskWarning = {
+  type: 'branch-remote-push-failed';
+  branch: string;
+  message: string;
+};
+
+export type RenameTaskSuccess = {
+  warning?: RenameTaskWarning;
+};
+
 export type ProvisionTaskResult = {
   path: string;
   workspaceId: string;


### PR DESCRIPTION
- add toggle to app settings to disable/enable random branch suffix
- branch suffix remains disabled for linear branch names
- make rename task return typed result in case renaming a task fails

<img width="1119" height="487" alt="Screenshot 2026-05-14 at 20 19 46" src="https://github.com/user-attachments/assets/22e1099f-ba91-450d-8e02-c466b0cf2f31" />
