### PR TITLE
feat: add migration for project configuration

### DIFF
--- a/src/main/core/projects/controller.ts
+++ b/src/main/core/projects/controller.ts
@@ -17,6 +17,8 @@ export const projectController = createRPCController({
     projectSettingsService.updateProjectSettings(projectId, settings),
   shareProjectSettingsToConfig: (projectId, request) =>
     projectSettingsService.shareProjectSettingsToConfig(projectId, request),
+  migrateProjectConfig: (projectId, request) =>
+    projectSettingsService.migrateProjectConfig(projectId, request),
   updateProjectConnection,
   openProject,
 });

--- a/src/main/core/projects/settings/project-settings-service.ts
+++ b/src/main/core/projects/settings/project-settings-service.ts
@@ -1,13 +1,12 @@
 import { projectSettingsChangedChannel } from '@shared/events/projectEvents';
 import {
-  SHAREABLE_PROJECT_SETTINGS_WRITE_FIELDS,
   type MigrateProjectConfigRequest,
   type MigrateProjectConfigResult,
   type ProjectSettings,
   type ProjectSettingsPage,
   type WriteProjectConfigRequest,
 } from '@shared/project-settings';
-import { SHAREABLE_FIELD_ACCESSORS } from '@shared/project-settings-fields';
+import { hasConfiguredShareableProjectSettings } from '@shared/project-settings-fields';
 import type { UpdateProjectSettingsError } from '@shared/projects';
 import { err, ok, type Result } from '@shared/result';
 import { events } from '@main/lib/events';
@@ -33,12 +32,6 @@ export type ProjectSettingsHooks = {
     settings: ProjectSettings;
   }) => void | Promise<void>;
 };
-
-function hasShareableProjectSettings(settings: ProjectSettings): boolean {
-  return SHAREABLE_PROJECT_SETTINGS_WRITE_FIELDS.some(
-    (field) => SHAREABLE_FIELD_ACCESSORS[field].displayValue(settings) !== null
-  );
-}
 
 export class ProjectSettingsService implements Hookable<ProjectSettingsHooks>, IInitializable {
   private readonly _hooks = new HookCore<ProjectSettingsHooks>((name, e) =>
@@ -104,7 +97,7 @@ export class ProjectSettingsService implements Hookable<ProjectSettingsHooks>, I
     if (!project.success) return project;
 
     const settings = await project.data.settings.get();
-    if (hasShareableProjectSettings(settings)) {
+    if (hasConfiguredShareableProjectSettings(settings)) {
       return err({
         type: 'write-config-failed',
         message: 'Shareable project settings are already configured.',
@@ -134,7 +127,7 @@ export class ProjectSettingsService implements Hookable<ProjectSettingsHooks>, I
     const resolvedTargets = await resolveAllProjectSettingsTargets(project);
     const writeTargets = getProjectSettingsWriteTargets(resolvedTargets);
     const overrideState = await computeProjectSettingsOverrideState(resolvedTargets);
-    const configMigrations = hasShareableProjectSettings(settings)
+    const configMigrations = hasConfiguredShareableProjectSettings(settings)
       ? []
       : await inspectProjectConfigMigrations(project.fs);
     return {

--- a/src/main/core/projects/settings/project-settings-service.ts
+++ b/src/main/core/projects/settings/project-settings-service.ts
@@ -1,9 +1,13 @@
 import { projectSettingsChangedChannel } from '@shared/events/projectEvents';
-import type {
-  ProjectSettings,
-  ProjectSettingsPage,
-  WriteProjectConfigRequest,
+import {
+  SHAREABLE_PROJECT_SETTINGS_WRITE_FIELDS,
+  type MigrateProjectConfigRequest,
+  type MigrateProjectConfigResult,
+  type ProjectSettings,
+  type ProjectSettingsPage,
+  type WriteProjectConfigRequest,
 } from '@shared/project-settings';
+import { SHAREABLE_FIELD_ACCESSORS } from '@shared/project-settings-fields';
 import type { UpdateProjectSettingsError } from '@shared/projects';
 import { err, ok, type Result } from '@shared/result';
 import { events } from '@main/lib/events';
@@ -12,6 +16,10 @@ import type { IInitializable } from '@main/lib/lifecycle';
 import { log } from '@main/lib/logger';
 import { projectManager } from '../project-manager';
 import type { ProjectProvider } from '../project-provider';
+import {
+  inspectProjectConfigMigrations,
+  migrateProjectConfigFromProvider,
+} from './sharing/config-migration';
 import { computeProjectSettingsOverrideState } from './sharing/project-settings-override-state';
 import {
   getProjectSettingsWriteTargets,
@@ -25,6 +33,12 @@ export type ProjectSettingsHooks = {
     settings: ProjectSettings;
   }) => void | Promise<void>;
 };
+
+function hasShareableProjectSettings(settings: ProjectSettings): boolean {
+  return SHAREABLE_PROJECT_SETTINGS_WRITE_FIELDS.some(
+    (field) => SHAREABLE_FIELD_ACCESSORS[field].displayValue(settings) !== null
+  );
+}
 
 export class ProjectSettingsService implements Hookable<ProjectSettingsHooks>, IInitializable {
   private readonly _hooks = new HookCore<ProjectSettingsHooks>((name, e) =>
@@ -82,6 +96,29 @@ export class ProjectSettingsService implements Hookable<ProjectSettingsHooks>, I
     return ok(page);
   }
 
+  async migrateProjectConfig(
+    projectId: string,
+    request: MigrateProjectConfigRequest
+  ): Promise<Result<MigrateProjectConfigResult, UpdateProjectSettingsError>> {
+    const project = this.requireProject(projectId);
+    if (!project.success) return project;
+
+    const settings = await project.data.settings.get();
+    if (hasShareableProjectSettings(settings)) {
+      return err({
+        type: 'write-config-failed',
+        message: 'Shareable project settings are already configured.',
+      });
+    }
+
+    const result = await migrateProjectConfigFromProvider(project.data, request);
+    if (!result.success) return result;
+
+    const page = await this.getProjectSettingsPageForProject(project.data);
+    this.emitSettingsChanged(projectId, page.settings);
+    return ok({ page, migration: result.data });
+  }
+
   private requireProject(projectId: string): Result<ProjectProvider, UpdateProjectSettingsError> {
     const project = projectManager.getProject(projectId);
     return project ? ok(project) : err({ type: 'project-not-found' });
@@ -97,7 +134,17 @@ export class ProjectSettingsService implements Hookable<ProjectSettingsHooks>, I
     const resolvedTargets = await resolveAllProjectSettingsTargets(project);
     const writeTargets = getProjectSettingsWriteTargets(resolvedTargets);
     const overrideState = await computeProjectSettingsOverrideState(resolvedTargets);
-    return { settings, defaults, writeTargets, overrideState };
+    const configMigrations = hasShareableProjectSettings(settings)
+      ? []
+      : await inspectProjectConfigMigrations(project.fs);
+    return {
+      settings,
+      defaults,
+      writeTargets,
+      overrideState,
+      configMigrations,
+      shouldPromptConfigMigration: configMigrations.length > 0,
+    };
   }
 
   private emitSettingsChanged(projectId: string, settings: ProjectSettings): void {

--- a/src/main/core/projects/settings/sharing/codex-config-migration.ts
+++ b/src/main/core/projects/settings/sharing/codex-config-migration.ts
@@ -1,0 +1,178 @@
+import * as toml from 'smol-toml';
+import z from 'zod';
+import {
+  type MigrateProjectConfigRequest,
+  type ProjectConfigMigration,
+  type ShareableProjectSettings,
+  type ShareableProjectSettingsWriteField,
+} from '@shared/project-settings';
+import { mergeShareableProjectSettings } from '@shared/project-settings-fields';
+import type { UpdateProjectSettingsError } from '@shared/projects';
+import { err, ok, type Result } from '@shared/result';
+import type { FileSystemProvider } from '@main/core/fs/types';
+import { log } from '@main/lib/logger';
+import type { ProjectProvider } from '../../project-provider';
+import type { ProjectConfigMigrator } from './config-migration';
+import { CONFIG_FILE } from './workspace-config-file';
+
+const CODEX_ENVIRONMENT_FILE = '.codex/environments/environment.toml';
+
+const codexScriptSectionSchema = z
+  .object({
+    script: z.string().optional(),
+  })
+  .passthrough();
+
+const codexActionSchema = z
+  .object({
+    name: z.string().optional(),
+    icon: z.string().optional(),
+    command: z.string().optional(),
+  })
+  .passthrough();
+
+const codexEnvironmentSchema = z
+  .object({
+    setup: codexScriptSectionSchema.optional(),
+    cleanup: codexScriptSectionSchema.optional(),
+    actions: z.array(codexActionSchema).optional(),
+  })
+  .passthrough();
+
+type CodexMigrationData = {
+  settings: ShareableProjectSettings;
+  files: string[];
+  fields: ShareableProjectSettingsWriteField[];
+  unsupportedFields: string[];
+};
+
+function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {
+  return err({ type: 'write-config-failed', message });
+}
+
+function trimmedText(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function setScript(
+  settings: ShareableProjectSettings,
+  field: ShareableProjectSettingsWriteField,
+  value: string
+): void {
+  settings.scripts ??= {};
+  if (field === 'scripts.setup') settings.scripts.setup = value;
+  if (field === 'scripts.teardown') settings.scripts.teardown = value;
+}
+
+function addScript(
+  data: CodexMigrationData,
+  field: ShareableProjectSettingsWriteField,
+  value: string | undefined
+): void {
+  if (!value) return;
+  setScript(data.settings, field, value);
+  data.fields.push(field);
+}
+
+function actionLabel(action: z.infer<typeof codexActionSchema>, index: number): string {
+  const name = action.name?.trim();
+  return name ? name : String(index);
+}
+
+function addUnsupportedActions(
+  data: CodexMigrationData,
+  actions: z.infer<typeof codexEnvironmentSchema>['actions']
+): void {
+  if (!actions) return;
+
+  actions.forEach((action, index) => {
+    const label = actionLabel(action, index);
+    if (action.command !== undefined) data.unsupportedFields.push(`actions.${label}.command`);
+    if (action.icon !== undefined) data.unsupportedFields.push(`actions.${label}.icon`);
+  });
+}
+
+function toCodexMigration(data: CodexMigrationData): ProjectConfigMigration | null {
+  if (data.fields.length === 0) return null;
+  return {
+    provider: 'codex',
+    label: 'Codex',
+    files: data.files,
+    fields: data.fields,
+    unsupportedFields: data.unsupportedFields,
+  };
+}
+
+async function readCodexMigrationData(
+  fs: Pick<FileSystemProvider, 'exists' | 'read'>
+): Promise<CodexMigrationData> {
+  const data: CodexMigrationData = {
+    settings: {},
+    files: [],
+    fields: [],
+    unsupportedFields: [],
+  };
+
+  if (!(await fs.exists(CODEX_ENVIRONMENT_FILE))) return data;
+
+  const { content } = await fs.read(CODEX_ENVIRONMENT_FILE);
+  const codexEnvironment = codexEnvironmentSchema.parse(toml.parse(content));
+  data.files.push(CODEX_ENVIRONMENT_FILE);
+
+  addScript(data, 'scripts.setup', trimmedText(codexEnvironment.setup?.script));
+  addScript(data, 'scripts.teardown', trimmedText(codexEnvironment.cleanup?.script));
+  addUnsupportedActions(data, codexEnvironment.actions);
+
+  return data;
+}
+
+async function migrateCodexConfig(
+  project: ProjectProvider,
+  request: MigrateProjectConfigRequest
+): Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>> {
+  try {
+    const data = await readCodexMigrationData(project.fs);
+    const migration = toCodexMigration(data);
+    if (!migration) {
+      return writeConfigFailed('No supported Codex settings were found.');
+    }
+
+    if (request.destination === 'local') {
+      const currentSettings = await project.settings.get();
+      const shareableSettings = mergeShareableProjectSettings(currentSettings, data.settings);
+      const updateResult = await project.settings.update({
+        ...currentSettings,
+        ...shareableSettings,
+      });
+      if (!updateResult.success) return updateResult;
+      return ok(migration);
+    }
+
+    const writeResult = await project.fs.write(
+      CONFIG_FILE,
+      `${JSON.stringify(data.settings, null, 2)}\n`
+    );
+    if (!writeResult.success) {
+      log.warn('Failed to write migrated project config file', writeResult.error);
+      return writeConfigFailed(writeResult.error ?? `Failed to write ${CONFIG_FILE}.`);
+    }
+
+    const clearResult = await project.settings.patch({ clearShareableFields: data.fields });
+    if (!clearResult.success) {
+      log.warn('Failed to clear imported local project settings', clearResult.error);
+      return writeConfigFailed(`Wrote ${CONFIG_FILE}, but failed to clear local project settings.`);
+    }
+
+    return ok(migration);
+  } catch (error) {
+    log.warn('Failed to migrate Codex config to project config', error);
+    return writeConfigFailed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export const codexConfigMigrator: ProjectConfigMigrator = {
+  provider: 'codex',
+  inspect: async (fs) => toCodexMigration(await readCodexMigrationData(fs)),
+  migrate: migrateCodexConfig,
+};

--- a/src/main/core/projects/settings/sharing/conductor-config-migration.ts
+++ b/src/main/core/projects/settings/sharing/conductor-config-migration.ts
@@ -76,7 +76,8 @@ async function readConductorMigrationData(
     unsupportedFields: [],
   };
 
-  if (await fs.exists(CONDUCTOR_CONFIG_FILE)) {
+  const hasConductorConfig = await fs.exists(CONDUCTOR_CONFIG_FILE);
+  if (hasConductorConfig) {
     const { content } = await fs.read(CONDUCTOR_CONFIG_FILE);
     const conductorConfig = conductorConfigSchema.parse(parseJsonObject(content));
     data.files.push(CONDUCTOR_CONFIG_FILE);

--- a/src/main/core/projects/settings/sharing/conductor-config-migration.ts
+++ b/src/main/core/projects/settings/sharing/conductor-config-migration.ts
@@ -1,0 +1,171 @@
+import z from 'zod';
+import {
+  type MigrateProjectConfigRequest,
+  type ProjectConfigMigration,
+  type ShareableProjectSettings,
+  type ShareableProjectSettingsWriteField,
+} from '@shared/project-settings';
+import { mergeShareableProjectSettings } from '@shared/project-settings-fields';
+import type { UpdateProjectSettingsError } from '@shared/projects';
+import { err, ok, type Result } from '@shared/result';
+import type { FileSystemProvider } from '@main/core/fs/types';
+import { log } from '@main/lib/logger';
+import type { ProjectProvider } from '../../project-provider';
+import { parseJsonObject } from '../project-settings-json';
+import type { ProjectConfigMigrator } from './config-migration';
+import { CONFIG_FILE } from './workspace-config-file';
+
+const CONDUCTOR_CONFIG_FILE = 'conductor.json';
+const CONDUCTOR_WORKTREE_INCLUDE_FILE = '.worktreeinclude';
+
+const conductorConfigSchema = z
+  .object({
+    scripts: z
+      .object({
+        setup: z.string().optional(),
+        run: z.string().optional(),
+        archive: z.string().optional(),
+      })
+      .optional(),
+    runScriptMode: z.enum(['concurrent', 'nonconcurrent']).optional(),
+    enterpriseDataPrivacy: z.boolean().optional(),
+  })
+  .passthrough();
+
+type ConductorMigrationData = {
+  settings: ShareableProjectSettings;
+  files: string[];
+  fields: ShareableProjectSettingsWriteField[];
+  unsupportedFields: string[];
+};
+
+function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {
+  return err({ type: 'write-config-failed', message });
+}
+
+function trimmedText(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+function parseWorktreeInclude(content: string): string[] {
+  return content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+}
+
+function toConductorMigration(data: ConductorMigrationData): ProjectConfigMigration | null {
+  if (data.fields.length === 0) return null;
+  return {
+    provider: 'conductor',
+    label: 'Conductor',
+    files: data.files,
+    fields: data.fields,
+    unsupportedFields: data.unsupportedFields,
+  };
+}
+
+async function readConductorMigrationData(
+  fs: Pick<FileSystemProvider, 'exists' | 'read'>
+): Promise<ConductorMigrationData> {
+  const data: ConductorMigrationData = {
+    settings: {},
+    files: [],
+    fields: [],
+    unsupportedFields: [],
+  };
+
+  if (await fs.exists(CONDUCTOR_CONFIG_FILE)) {
+    const { content } = await fs.read(CONDUCTOR_CONFIG_FILE);
+    const conductorConfig = conductorConfigSchema.parse(parseJsonObject(content));
+    data.files.push(CONDUCTOR_CONFIG_FILE);
+
+    const setup = trimmedText(conductorConfig.scripts?.setup);
+    const run = trimmedText(conductorConfig.scripts?.run);
+    const archive = trimmedText(conductorConfig.scripts?.archive);
+
+    if (setup) {
+      data.settings.scripts ??= {};
+      data.settings.scripts.setup = setup;
+      data.fields.push('scripts.setup');
+    }
+    if (run) {
+      data.settings.scripts ??= {};
+      data.settings.scripts.run = run;
+      data.fields.push('scripts.run');
+    }
+    if (archive) {
+      data.settings.scripts ??= {};
+      data.settings.scripts.teardown = archive;
+      data.fields.push('scripts.teardown');
+    }
+
+    if (conductorConfig.runScriptMode !== undefined) data.unsupportedFields.push('runScriptMode');
+    if (conductorConfig.enterpriseDataPrivacy !== undefined) {
+      data.unsupportedFields.push('enterpriseDataPrivacy');
+    }
+  }
+
+  if (await fs.exists(CONDUCTOR_WORKTREE_INCLUDE_FILE)) {
+    const { content } = await fs.read(CONDUCTOR_WORKTREE_INCLUDE_FILE);
+    const patterns = parseWorktreeInclude(content);
+    if (patterns.length > 0) {
+      data.files.push(CONDUCTOR_WORKTREE_INCLUDE_FILE);
+      data.settings.preservePatterns = patterns;
+      data.fields.push('preservePatterns');
+    }
+  }
+
+  return data;
+}
+
+async function migrateConductorConfig(
+  project: ProjectProvider,
+  request: MigrateProjectConfigRequest
+): Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>> {
+  try {
+    const data = await readConductorMigrationData(project.fs);
+    const migration = toConductorMigration(data);
+    if (!migration) {
+      return writeConfigFailed('No supported Conductor settings were found.');
+    }
+
+    if (request.destination === 'local') {
+      const currentSettings = await project.settings.get();
+      const shareableSettings = mergeShareableProjectSettings(currentSettings, data.settings);
+      const updateResult = await project.settings.update({
+        ...currentSettings,
+        ...shareableSettings,
+      });
+      if (!updateResult.success) return updateResult;
+      return ok(migration);
+    }
+
+    const writeResult = await project.fs.write(
+      CONFIG_FILE,
+      `${JSON.stringify(data.settings, null, 2)}\n`
+    );
+    if (!writeResult.success) {
+      log.warn('Failed to write migrated project config file', writeResult.error);
+      return writeConfigFailed(writeResult.error ?? `Failed to write ${CONFIG_FILE}.`);
+    }
+
+    const clearResult = await project.settings.patch({ clearShareableFields: data.fields });
+    if (!clearResult.success) {
+      log.warn('Failed to clear imported local project settings', clearResult.error);
+      return writeConfigFailed(`Wrote ${CONFIG_FILE}, but failed to clear local project settings.`);
+    }
+
+    return ok(migration);
+  } catch (error) {
+    log.warn('Failed to migrate Conductor config to project config', error);
+    return writeConfigFailed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export const conductorConfigMigrator: ProjectConfigMigrator = {
+  provider: 'conductor',
+  inspect: async (fs) => toConductorMigration(await readConductorMigrationData(fs)),
+  migrate: migrateConductorConfig,
+};

--- a/src/main/core/projects/settings/sharing/config-migration.test.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.test.ts
@@ -148,6 +148,120 @@ describe('config migration', () => {
     });
   });
 
+  it('detects importable Superset settings', async () => {
+    const fs = createFs({
+      '.superset/config.json': JSON.stringify({
+        setup: ['bun install', 'cp "$SUPERSET_ROOT_PATH/.env" .env'],
+        run: ['./.superset/run.sh'],
+        teardown: ['docker-compose down'],
+      }),
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([
+      {
+        provider: 'superset',
+        label: 'Superset',
+        files: ['.superset/config.json'],
+        fields: ['scripts.setup', 'scripts.run', 'scripts.teardown'],
+        unsupportedFields: [],
+      },
+    ]);
+  });
+
+  it('writes Superset settings into .emdash.json', async () => {
+    const fs = createFs({
+      '.superset/config.json': JSON.stringify({
+        setup: ['bun install', 'cp "$SUPERSET_ROOT_PATH/.env" .env'],
+        run: ['./.superset/run.sh'],
+        teardown: ['docker-compose down'],
+      }),
+    });
+    const patch = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          patch,
+        },
+      } as never,
+      { provider: 'superset', destination: 'shared' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(fs.content('.emdash.json') ?? '{}')).toEqual({
+      scripts: {
+        setup: 'bun install\ncp "$SUPERSET_ROOT_PATH/.env" .env',
+        run: './.superset/run.sh',
+        teardown: 'docker-compose down',
+      },
+    });
+    expect(patch).toHaveBeenCalledWith({
+      clearShareableFields: ['scripts.setup', 'scripts.run', 'scripts.teardown'],
+    });
+  });
+
+  it('imports Superset settings into local project settings', async () => {
+    const fs = createFs({
+      '.superset/config.json': JSON.stringify({
+        run: ['./.superset/run.sh'],
+      }),
+    });
+    const update = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          get: vi.fn().mockResolvedValue({
+            scripts: {
+              setup: 'bun install',
+            },
+          }),
+          update,
+        },
+      } as never,
+      { provider: 'superset', destination: 'local' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(fs.write).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith({
+      scripts: {
+        setup: 'bun install',
+        run: './.superset/run.sh',
+      },
+    });
+  });
+
+  it('does not import Superset before and after script extensions', async () => {
+    const fs = createFs({
+      '.superset/config.json': JSON.stringify({
+        setup: {
+          before: ["echo 'running pre-setup'"],
+          after: ['./.superset/my-post-setup.sh'],
+        },
+        teardown: {
+          after: ['./.superset/my-cleanup.sh'],
+        },
+      }),
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([]);
+    await expect(
+      migrateProjectConfigFromProvider({ fs } as never, {
+        provider: 'superset',
+        destination: 'shared',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'write-config-failed',
+        message: 'No supported Superset settings were found.',
+      },
+    });
+  });
+
   it('returns an error when no supported Conductor settings exist', async () => {
     const fs = createFs({
       'conductor.json': JSON.stringify({

--- a/src/main/core/projects/settings/sharing/config-migration.test.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.test.ts
@@ -262,6 +262,138 @@ describe('config migration', () => {
     });
   });
 
+  it('detects importable Paseo settings', async () => {
+    const fs = createFs({
+      'paseo.json': JSON.stringify({
+        worktree: {
+          setup: ['npm ci', 'cp "$PASEO_SOURCE_CHECKOUT_PATH/.env" .env', 'npm run db:migrate'],
+          teardown: 'npm run db:drop || true',
+          terminals: [{ name: 'logs', command: 'tail -f dev.log' }],
+        },
+        scripts: {
+          test: { command: 'npm test' },
+          web: { command: 'npm run dev -- --port $PASEO_PORT', type: 'service', port: 3000 },
+        },
+      }),
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([
+      {
+        provider: 'paseo',
+        label: 'Paseo',
+        files: ['paseo.json'],
+        fields: ['scripts.setup', 'scripts.teardown'],
+        unsupportedFields: [
+          'scripts.test.command',
+          'scripts.web.command',
+          'scripts.web.type',
+          'scripts.web.port',
+          'worktree.terminals',
+        ],
+      },
+    ]);
+  });
+
+  it('writes Paseo settings into .emdash.json', async () => {
+    const fs = createFs({
+      'paseo.json': JSON.stringify({
+        worktree: {
+          setup: 'npm ci',
+          teardown: ['rm -rf .cache'],
+        },
+        scripts: {
+          web: { command: 'npm run dev', type: 'service', port: 3000 },
+          lint: { command: 'npm run lint' },
+        },
+      }),
+    });
+    const patch = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          patch,
+        },
+      } as never,
+      { provider: 'paseo', destination: 'shared' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(fs.content('.emdash.json') ?? '{}')).toEqual({
+      scripts: {
+        setup: 'npm ci',
+        teardown: 'rm -rf .cache',
+      },
+    });
+    expect(patch).toHaveBeenCalledWith({
+      clearShareableFields: ['scripts.setup', 'scripts.teardown'],
+    });
+  });
+
+  it('imports Paseo settings into local project settings', async () => {
+    const fs = createFs({
+      'paseo.json': JSON.stringify({
+        worktree: {
+          setup: 'npm ci',
+        },
+        scripts: {
+          web: { command: 'npm run dev', type: 'service' },
+        },
+      }),
+    });
+    const update = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          get: vi.fn().mockResolvedValue({
+            scripts: {
+              teardown: 'docker compose down',
+            },
+          }),
+          update,
+        },
+      } as never,
+      { provider: 'paseo', destination: 'local' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(fs.write).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith({
+      scripts: {
+        setup: 'npm ci',
+        teardown: 'docker compose down',
+      },
+    });
+  });
+
+  it('does not import when only Paseo scripts are configured', async () => {
+    const fs = createFs({
+      'paseo.json': JSON.stringify({
+        scripts: {
+          test: { command: 'npm test' },
+          web: { command: 'npm run dev', type: 'service' },
+        },
+      }),
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([]);
+    await expect(
+      migrateProjectConfigFromProvider({ fs } as never, {
+        provider: 'paseo',
+        destination: 'shared',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'write-config-failed',
+        message: 'No supported Paseo settings were found.',
+      },
+    });
+  });
+
   it('returns an error when no supported Conductor settings exist', async () => {
     const fs = createFs({
       'conductor.json': JSON.stringify({

--- a/src/main/core/projects/settings/sharing/config-migration.test.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  inspectProjectConfigMigrations,
+  migrateProjectConfigFromProvider,
+} from './config-migration';
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    warn: vi.fn(),
+  },
+}));
+
+function createFs(initialFiles: Record<string, string>) {
+  const files = new Map(Object.entries(initialFiles));
+  return {
+    exists: vi.fn((filePath: string) => Promise.resolve(files.has(filePath))),
+    read: vi.fn((filePath: string) => {
+      const content = files.get(filePath);
+      if (content === undefined) throw new Error(`Missing file: ${filePath}`);
+      return Promise.resolve({
+        content,
+        truncated: false,
+        totalSize: Buffer.byteLength(content),
+      });
+    }),
+    write: vi.fn((filePath: string, content: string) => {
+      files.set(filePath, content);
+      return Promise.resolve({
+        success: true,
+        bytesWritten: Buffer.byteLength(content),
+      });
+    }),
+    content(filePath: string) {
+      return files.get(filePath);
+    },
+  };
+}
+
+describe('config migration', () => {
+  it('detects importable Conductor settings', async () => {
+    const fs = createFs({
+      'conductor.json': JSON.stringify({
+        scripts: {
+          setup: 'pnpm install',
+          run: 'pnpm dev',
+          archive: 'pnpm cleanup',
+        },
+        runScriptMode: 'nonconcurrent',
+        enterpriseDataPrivacy: true,
+      }),
+      '.worktreeinclude': `
+        # local env
+        .env
+        .env.local
+        !*.example
+      `,
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([
+      {
+        provider: 'conductor',
+        label: 'Conductor',
+        files: ['conductor.json', '.worktreeinclude'],
+        fields: ['scripts.setup', 'scripts.run', 'scripts.teardown', 'preservePatterns'],
+        unsupportedFields: ['runScriptMode', 'enterpriseDataPrivacy'],
+      },
+    ]);
+  });
+
+  it('writes Conductor settings into .emdash.json', async () => {
+    const fs = createFs({
+      'conductor.json': JSON.stringify({
+        scripts: {
+          setup: 'pnpm install',
+          run: 'pnpm dev',
+          archive: 'pnpm cleanup',
+        },
+      }),
+      '.worktreeinclude': '.env\n.env.local\n',
+    });
+    const patch = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          patch,
+        },
+      } as never,
+      { provider: 'conductor', destination: 'shared' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(fs.content('.emdash.json') ?? '{}')).toEqual({
+      scripts: {
+        setup: 'pnpm install',
+        run: 'pnpm dev',
+        teardown: 'pnpm cleanup',
+      },
+      preservePatterns: ['.env', '.env.local'],
+    });
+    expect(patch).toHaveBeenCalledWith({
+      clearShareableFields: [
+        'scripts.setup',
+        'scripts.run',
+        'scripts.teardown',
+        'preservePatterns',
+      ],
+    });
+  });
+
+  it('imports Conductor settings into local project settings', async () => {
+    const fs = createFs({
+      'conductor.json': JSON.stringify({
+        scripts: {
+          run: 'pnpm dev',
+        },
+      }),
+      '.worktreeinclude': '.env\n.env.local\n',
+    });
+    const update = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          get: vi.fn().mockResolvedValue({
+            shellSetup: 'source .envrc',
+            scripts: {
+              setup: 'pnpm install',
+            },
+          }),
+          update,
+        },
+      } as never,
+      { provider: 'conductor', destination: 'local' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(fs.write).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith({
+      shellSetup: 'source .envrc',
+      scripts: {
+        setup: 'pnpm install',
+        run: 'pnpm dev',
+      },
+      preservePatterns: ['.env', '.env.local'],
+    });
+  });
+
+  it('returns an error when no supported Conductor settings exist', async () => {
+    const fs = createFs({
+      'conductor.json': JSON.stringify({
+        runScriptMode: 'concurrent',
+      }),
+    });
+
+    await expect(
+      migrateProjectConfigFromProvider({ fs } as never, {
+        provider: 'conductor',
+        destination: 'shared',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'write-config-failed',
+        message: 'No supported Conductor settings were found.',
+      },
+    });
+  });
+
+  it('does not import when .emdash.json already exists', async () => {
+    const fs = createFs({
+      'conductor.json': JSON.stringify({
+        scripts: {
+          run: 'pnpm dev',
+        },
+      }),
+      '.emdash.json': JSON.stringify({ scripts: { run: 'pnpm dev' } }),
+    });
+
+    const result = await migrateProjectConfigFromProvider({ fs } as never, {
+      provider: 'conductor',
+      destination: 'shared',
+    });
+
+    expect(result.success).toBe(false);
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'write-config-failed',
+        message: '.emdash.json already exists.',
+      },
+    });
+    expect(fs.write).not.toHaveBeenCalled();
+  });
+
+  it('returns an error for unknown providers', async () => {
+    const fs = createFs({});
+
+    await expect(
+      migrateProjectConfigFromProvider({ fs } as never, {
+        provider: 'unknown' as never,
+        destination: 'shared',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'write-config-failed',
+        message: 'Unsupported config provider.',
+      },
+    });
+  });
+});

--- a/src/main/core/projects/settings/sharing/config-migration.test.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.test.ts
@@ -109,6 +109,47 @@ describe('config migration', () => {
     });
   });
 
+  it('does not import Conductor files to copy when .worktreeinclude is missing', async () => {
+    const fs = createFs({
+      'conductor.json': JSON.stringify({
+        scripts: {
+          setup: 'pnpm install',
+        },
+      }),
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([
+      {
+        provider: 'conductor',
+        label: 'Conductor',
+        files: ['conductor.json'],
+        fields: ['scripts.setup'],
+        unsupportedFields: [],
+      },
+    ]);
+
+    const patch = vi.fn().mockResolvedValue({ success: true });
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          patch,
+        },
+      } as never,
+      { provider: 'conductor', destination: 'shared' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(fs.content('.emdash.json') ?? '{}')).toEqual({
+      scripts: {
+        setup: 'pnpm install',
+      },
+    });
+    expect(patch).toHaveBeenCalledWith({
+      clearShareableFields: ['scripts.setup'],
+    });
+  });
+
   it('imports Conductor settings into local project settings', async () => {
     const fs = createFs({
       'conductor.json': JSON.stringify({
@@ -529,6 +570,7 @@ describe('config migration', () => {
       'conductor.json': JSON.stringify({
         runScriptMode: 'concurrent',
       }),
+      '.worktreeinclude': '',
     });
 
     await expect(

--- a/src/main/core/projects/settings/sharing/config-migration.test.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.test.ts
@@ -394,6 +394,136 @@ describe('config migration', () => {
     });
   });
 
+  it('detects importable Codex local environment settings', async () => {
+    const fs = createFs({
+      '.codex/environments/environment.toml': `
+        version = 1
+        name = "emdash"
+
+        [setup]
+        script = """
+        npm install
+        npm run build
+        """
+
+        [cleanup]
+        script = "docker compose down"
+
+        [[actions]]
+        name = "Run"
+        icon = "run"
+        command = "npm run dev"
+      `,
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([
+      {
+        provider: 'codex',
+        label: 'Codex',
+        files: ['.codex/environments/environment.toml'],
+        fields: ['scripts.setup', 'scripts.teardown'],
+        unsupportedFields: ['actions.Run.command', 'actions.Run.icon'],
+      },
+    ]);
+  });
+
+  it('writes Codex local environment settings into .emdash.json', async () => {
+    const fs = createFs({
+      '.codex/environments/environment.toml': `
+        [setup]
+        script = "npm ci"
+
+        [cleanup]
+        script = "rm -rf .cache"
+
+        [[actions]]
+        name = "Test"
+        command = "npm test"
+      `,
+    });
+    const patch = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          patch,
+        },
+      } as never,
+      { provider: 'codex', destination: 'shared' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(JSON.parse(fs.content('.emdash.json') ?? '{}')).toEqual({
+      scripts: {
+        setup: 'npm ci',
+        teardown: 'rm -rf .cache',
+      },
+    });
+    expect(patch).toHaveBeenCalledWith({
+      clearShareableFields: ['scripts.setup', 'scripts.teardown'],
+    });
+  });
+
+  it('imports Codex local environment settings into local project settings', async () => {
+    const fs = createFs({
+      '.codex/environments/environment.toml': `
+        [setup]
+        script = "npm ci"
+      `,
+    });
+    const update = vi.fn().mockResolvedValue({ success: true });
+
+    const result = await migrateProjectConfigFromProvider(
+      {
+        fs,
+        settings: {
+          get: vi.fn().mockResolvedValue({
+            scripts: {
+              teardown: 'docker compose down',
+            },
+          }),
+          update,
+        },
+      } as never,
+      { provider: 'codex', destination: 'local' }
+    );
+
+    expect(result.success).toBe(true);
+    expect(fs.write).not.toHaveBeenCalled();
+    expect(update).toHaveBeenCalledWith({
+      scripts: {
+        setup: 'npm ci',
+        teardown: 'docker compose down',
+      },
+    });
+  });
+
+  it('does not import when only Codex actions are configured', async () => {
+    const fs = createFs({
+      '.codex/environments/environment.toml': `
+        [[actions]]
+        name = "Run"
+        icon = "run"
+        command = "npm run dev"
+      `,
+    });
+
+    await expect(inspectProjectConfigMigrations(fs)).resolves.toEqual([]);
+    await expect(
+      migrateProjectConfigFromProvider({ fs } as never, {
+        provider: 'codex',
+        destination: 'shared',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'write-config-failed',
+        message: 'No supported Codex settings were found.',
+      },
+    });
+  });
+
   it('returns an error when no supported Conductor settings exist', async () => {
     const fs = createFs({
       'conductor.json': JSON.stringify({

--- a/src/main/core/projects/settings/sharing/config-migration.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.ts
@@ -1,0 +1,70 @@
+import type { MigrateProjectConfigRequest, ProjectConfigMigration } from '@shared/project-settings';
+import type { UpdateProjectSettingsError } from '@shared/projects';
+import { err, type Result } from '@shared/result';
+import type { FileSystemProvider } from '@main/core/fs/types';
+import { log } from '@main/lib/logger';
+import type { ProjectProvider } from '../../project-provider';
+import { conductorConfigMigrator } from './conductor-config-migration';
+import { CONFIG_FILE } from './workspace-config-file';
+
+export type ProjectConfigMigrator = {
+  provider: ProjectConfigMigration['provider'];
+  inspect: (
+    fs: Pick<FileSystemProvider, 'exists' | 'read'>
+  ) => Promise<ProjectConfigMigration | null>;
+  migrate: (
+    project: ProjectProvider,
+    request: MigrateProjectConfigRequest
+  ) => Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>>;
+};
+
+const PROJECT_CONFIG_MIGRATORS = [conductorConfigMigrator] as const;
+
+function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {
+  return err({ type: 'write-config-failed', message });
+}
+
+export async function inspectProjectConfigMigrations(
+  fs: Pick<FileSystemProvider, 'exists' | 'read'>
+): Promise<ProjectConfigMigration[]> {
+  try {
+    if (await fs.exists(CONFIG_FILE)) return [];
+  } catch (error) {
+    log.warn(`Failed to inspect ${CONFIG_FILE} before config migration`, error);
+    return [];
+  }
+
+  const migrations = await Promise.all(
+    PROJECT_CONFIG_MIGRATORS.map(async (migrator) => {
+      try {
+        return await migrator.inspect(fs);
+      } catch (error) {
+        log.warn(`Failed to inspect ${migrator.provider} config for migration`, error);
+        return null;
+      }
+    })
+  );
+
+  return migrations.filter((migration): migration is ProjectConfigMigration => migration !== null);
+}
+
+export async function migrateProjectConfigFromProvider(
+  project: ProjectProvider,
+  request: MigrateProjectConfigRequest
+): Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>> {
+  try {
+    if (await project.fs.exists(CONFIG_FILE)) {
+      return writeConfigFailed(`${CONFIG_FILE} already exists.`);
+    }
+
+    const migrator = PROJECT_CONFIG_MIGRATORS.find(
+      (candidate) => candidate.provider === request.provider
+    );
+    if (!migrator) return writeConfigFailed('Unsupported config provider.');
+
+    return await migrator.migrate(project, request);
+  } catch (error) {
+    log.warn(`Failed to migrate ${request.provider} config to project config`, error);
+    return writeConfigFailed(error instanceof Error ? error.message : String(error));
+  }
+}

--- a/src/main/core/projects/settings/sharing/config-migration.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.ts
@@ -5,6 +5,7 @@ import type { FileSystemProvider } from '@main/core/fs/types';
 import { log } from '@main/lib/logger';
 import type { ProjectProvider } from '../../project-provider';
 import { conductorConfigMigrator } from './conductor-config-migration';
+import { paseoConfigMigrator } from './paseo-config-migration';
 import { supersetConfigMigrator } from './superset-config-migration';
 import { CONFIG_FILE } from './workspace-config-file';
 
@@ -19,7 +20,11 @@ export type ProjectConfigMigrator = {
   ) => Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>>;
 };
 
-const PROJECT_CONFIG_MIGRATORS = [conductorConfigMigrator, supersetConfigMigrator] as const;
+const PROJECT_CONFIG_MIGRATORS = [
+  conductorConfigMigrator,
+  supersetConfigMigrator,
+  paseoConfigMigrator,
+] as const;
 
 function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {
   return err({ type: 'write-config-failed', message });

--- a/src/main/core/projects/settings/sharing/config-migration.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.ts
@@ -4,6 +4,7 @@ import { err, type Result } from '@shared/result';
 import type { FileSystemProvider } from '@main/core/fs/types';
 import { log } from '@main/lib/logger';
 import type { ProjectProvider } from '../../project-provider';
+import { codexConfigMigrator } from './codex-config-migration';
 import { conductorConfigMigrator } from './conductor-config-migration';
 import { paseoConfigMigrator } from './paseo-config-migration';
 import { supersetConfigMigrator } from './superset-config-migration';
@@ -24,6 +25,7 @@ const PROJECT_CONFIG_MIGRATORS = [
   conductorConfigMigrator,
   supersetConfigMigrator,
   paseoConfigMigrator,
+  codexConfigMigrator,
 ] as const;
 
 function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {

--- a/src/main/core/projects/settings/sharing/config-migration.ts
+++ b/src/main/core/projects/settings/sharing/config-migration.ts
@@ -5,6 +5,7 @@ import type { FileSystemProvider } from '@main/core/fs/types';
 import { log } from '@main/lib/logger';
 import type { ProjectProvider } from '../../project-provider';
 import { conductorConfigMigrator } from './conductor-config-migration';
+import { supersetConfigMigrator } from './superset-config-migration';
 import { CONFIG_FILE } from './workspace-config-file';
 
 export type ProjectConfigMigrator = {
@@ -18,7 +19,7 @@ export type ProjectConfigMigrator = {
   ) => Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>>;
 };
 
-const PROJECT_CONFIG_MIGRATORS = [conductorConfigMigrator] as const;
+const PROJECT_CONFIG_MIGRATORS = [conductorConfigMigrator, supersetConfigMigrator] as const;
 
 function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {
   return err({ type: 'write-config-failed', message });

--- a/src/main/core/projects/settings/sharing/paseo-config-migration.ts
+++ b/src/main/core/projects/settings/sharing/paseo-config-migration.ts
@@ -95,7 +95,7 @@ function addUnsupportedScripts(
   data: PaseoMigrationData,
   scripts: z.infer<typeof paseoConfigSchema>['scripts']
 ): void {
-  if (!scripts) return undefined;
+  if (!scripts) return;
 
   for (const [name, script] of Object.entries(scripts)) {
     if (script.command !== undefined) data.unsupportedFields.push(`scripts.${name}.command`);

--- a/src/main/core/projects/settings/sharing/paseo-config-migration.ts
+++ b/src/main/core/projects/settings/sharing/paseo-config-migration.ts
@@ -1,0 +1,182 @@
+import z from 'zod';
+import {
+  type MigrateProjectConfigRequest,
+  type ProjectConfigMigration,
+  type ShareableProjectSettings,
+  type ShareableProjectSettingsWriteField,
+} from '@shared/project-settings';
+import { mergeShareableProjectSettings } from '@shared/project-settings-fields';
+import type { UpdateProjectSettingsError } from '@shared/projects';
+import { err, ok, type Result } from '@shared/result';
+import type { FileSystemProvider } from '@main/core/fs/types';
+import { log } from '@main/lib/logger';
+import type { ProjectProvider } from '../../project-provider';
+import { parseJsonObject } from '../project-settings-json';
+import type { ProjectConfigMigrator } from './config-migration';
+import { CONFIG_FILE } from './workspace-config-file';
+
+const PASEO_CONFIG_FILE = 'paseo.json';
+
+const paseoCommandSchema = z.union([z.string(), z.array(z.string())]);
+
+const paseoScriptSchema = z
+  .object({
+    command: z.string().optional(),
+    type: z.string().optional(),
+    port: z.number().optional(),
+  })
+  .passthrough();
+
+const paseoConfigSchema = z
+  .object({
+    worktree: z
+      .object({
+        setup: paseoCommandSchema.optional(),
+        teardown: paseoCommandSchema.optional(),
+        terminals: z.array(z.unknown()).optional(),
+      })
+      .passthrough()
+      .optional(),
+    scripts: z.record(z.string(), paseoScriptSchema).optional(),
+  })
+  .passthrough();
+
+type PaseoMigrationData = {
+  settings: ShareableProjectSettings;
+  files: string[];
+  fields: ShareableProjectSettingsWriteField[];
+  unsupportedFields: string[];
+};
+
+function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {
+  return err({ type: 'write-config-failed', message });
+}
+
+function normalizeCommand(value: string | string[] | undefined): string | undefined {
+  if (value === undefined) return undefined;
+
+  const commands = Array.isArray(value) ? value : [value];
+  const normalized = commands.map((command) => command.trim()).filter(Boolean);
+  return normalized.length > 0 ? normalized.join('\n') : undefined;
+}
+
+function setScript(
+  settings: ShareableProjectSettings,
+  field: ShareableProjectSettingsWriteField,
+  value: string
+): void {
+  settings.scripts ??= {};
+  if (field === 'scripts.setup') settings.scripts.setup = value;
+  if (field === 'scripts.teardown') settings.scripts.teardown = value;
+}
+
+function addScript(
+  data: PaseoMigrationData,
+  field: ShareableProjectSettingsWriteField,
+  value: string | undefined
+): void {
+  if (!value) return;
+  setScript(data.settings, field, value);
+  data.fields.push(field);
+}
+
+function toPaseoMigration(data: PaseoMigrationData): ProjectConfigMigration | null {
+  if (data.fields.length === 0) return null;
+  return {
+    provider: 'paseo',
+    label: 'Paseo',
+    files: data.files,
+    fields: data.fields,
+    unsupportedFields: data.unsupportedFields,
+  };
+}
+
+function addUnsupportedScripts(
+  data: PaseoMigrationData,
+  scripts: z.infer<typeof paseoConfigSchema>['scripts']
+): void {
+  if (!scripts) return undefined;
+
+  for (const [name, script] of Object.entries(scripts)) {
+    if (script.command !== undefined) data.unsupportedFields.push(`scripts.${name}.command`);
+    if (script.type !== undefined) data.unsupportedFields.push(`scripts.${name}.type`);
+    if (script.port !== undefined) data.unsupportedFields.push(`scripts.${name}.port`);
+  }
+}
+
+async function readPaseoMigrationData(
+  fs: Pick<FileSystemProvider, 'exists' | 'read'>
+): Promise<PaseoMigrationData> {
+  const data: PaseoMigrationData = {
+    settings: {},
+    files: [],
+    fields: [],
+    unsupportedFields: [],
+  };
+
+  if (!(await fs.exists(PASEO_CONFIG_FILE))) return data;
+
+  const { content } = await fs.read(PASEO_CONFIG_FILE);
+  const paseoConfig = paseoConfigSchema.parse(parseJsonObject(content));
+  data.files.push(PASEO_CONFIG_FILE);
+
+  addScript(data, 'scripts.setup', normalizeCommand(paseoConfig.worktree?.setup));
+  addScript(data, 'scripts.teardown', normalizeCommand(paseoConfig.worktree?.teardown));
+  addUnsupportedScripts(data, paseoConfig.scripts);
+
+  if (paseoConfig.worktree?.terminals !== undefined) {
+    data.unsupportedFields.push('worktree.terminals');
+  }
+
+  return data;
+}
+
+async function migratePaseoConfig(
+  project: ProjectProvider,
+  request: MigrateProjectConfigRequest
+): Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>> {
+  try {
+    const data = await readPaseoMigrationData(project.fs);
+    const migration = toPaseoMigration(data);
+    if (!migration) {
+      return writeConfigFailed('No supported Paseo settings were found.');
+    }
+
+    if (request.destination === 'local') {
+      const currentSettings = await project.settings.get();
+      const shareableSettings = mergeShareableProjectSettings(currentSettings, data.settings);
+      const updateResult = await project.settings.update({
+        ...currentSettings,
+        ...shareableSettings,
+      });
+      if (!updateResult.success) return updateResult;
+      return ok(migration);
+    }
+
+    const writeResult = await project.fs.write(
+      CONFIG_FILE,
+      `${JSON.stringify(data.settings, null, 2)}\n`
+    );
+    if (!writeResult.success) {
+      log.warn('Failed to write migrated project config file', writeResult.error);
+      return writeConfigFailed(writeResult.error ?? `Failed to write ${CONFIG_FILE}.`);
+    }
+
+    const clearResult = await project.settings.patch({ clearShareableFields: data.fields });
+    if (!clearResult.success) {
+      log.warn('Failed to clear imported local project settings', clearResult.error);
+      return writeConfigFailed(`Wrote ${CONFIG_FILE}, but failed to clear local project settings.`);
+    }
+
+    return ok(migration);
+  } catch (error) {
+    log.warn('Failed to migrate Paseo config to project config', error);
+    return writeConfigFailed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export const paseoConfigMigrator: ProjectConfigMigrator = {
+  provider: 'paseo',
+  inspect: async (fs) => toPaseoMigration(await readPaseoMigrationData(fs)),
+  migrate: migratePaseoConfig,
+};

--- a/src/main/core/projects/settings/sharing/share-project-settings-to-config.test.ts
+++ b/src/main/core/projects/settings/sharing/share-project-settings-to-config.test.ts
@@ -1,11 +1,11 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ShareableProjectSettings } from '@shared/project-settings';
-import { computeProjectSettingsOverrideState } from './sharing/project-settings-override-state';
+import { computeProjectSettingsOverrideState } from './project-settings-override-state';
 import {
   getProjectSettingsWriteTargets,
   resolveAllProjectSettingsTargets,
-} from './sharing/project-settings-target-resolver';
-import { shareProjectSettingsToConfig } from './sharing/share-project-settings-to-config';
+} from './project-settings-target-resolver';
+import { shareProjectSettingsToConfig } from './share-project-settings-to-config';
 
 const mocks = vi.hoisted(() => ({
   select: vi.fn(),

--- a/src/main/core/projects/settings/sharing/superset-config-migration.ts
+++ b/src/main/core/projects/settings/sharing/superset-config-migration.ts
@@ -1,0 +1,178 @@
+import z from 'zod';
+import {
+  type MigrateProjectConfigRequest,
+  type ProjectConfigMigration,
+  type ShareableProjectSettings,
+  type ShareableProjectSettingsWriteField,
+} from '@shared/project-settings';
+import { mergeShareableProjectSettings } from '@shared/project-settings-fields';
+import type { UpdateProjectSettingsError } from '@shared/projects';
+import { err, ok, type Result } from '@shared/result';
+import type { FileSystemProvider } from '@main/core/fs/types';
+import { log } from '@main/lib/logger';
+import type { ProjectProvider } from '../../project-provider';
+import { parseJsonObject } from '../project-settings-json';
+import type { ProjectConfigMigrator } from './config-migration';
+import { CONFIG_FILE } from './workspace-config-file';
+
+const SUPERSET_CONFIG_FILE = '.superset/config.json';
+
+const supersetScriptOverrideSchema = z
+  .object({
+    before: z.array(z.string()).optional(),
+    after: z.array(z.string()).optional(),
+  })
+  .passthrough();
+
+const supersetScriptSchema = z.union([z.array(z.string()), supersetScriptOverrideSchema]);
+
+const supersetConfigSchema = z
+  .object({
+    setup: supersetScriptSchema.optional(),
+    teardown: supersetScriptSchema.optional(),
+    run: supersetScriptSchema.optional(),
+  })
+  .passthrough();
+
+type SupersetScriptConfig = z.infer<typeof supersetScriptSchema>;
+
+type SupersetMigrationData = {
+  settings: ShareableProjectSettings;
+  files: string[];
+  fields: ShareableProjectSettingsWriteField[];
+  unsupportedFields: string[];
+};
+
+const SUPERSET_SCRIPT_FIELDS = [
+  { source: 'setup', target: 'scripts.setup' },
+  { source: 'run', target: 'scripts.run' },
+  { source: 'teardown', target: 'scripts.teardown' },
+] as const satisfies Array<{
+  source: 'setup' | 'run' | 'teardown';
+  target: ShareableProjectSettingsWriteField;
+}>;
+
+function writeConfigFailed(message: string): Result<never, UpdateProjectSettingsError> {
+  return err({ type: 'write-config-failed', message });
+}
+
+function normalizeCommands(commands: string[]): string | undefined {
+  const normalized = commands.map((command) => command.trim()).filter(Boolean);
+  return normalized.length > 0 ? normalized.join('\n') : undefined;
+}
+
+function addUnsupportedOverrideFields(
+  data: SupersetMigrationData,
+  source: 'setup' | 'run' | 'teardown',
+  script: SupersetScriptConfig
+): void {
+  if (Array.isArray(script)) return;
+  if (script.before !== undefined) data.unsupportedFields.push(`${source}.before`);
+  if (script.after !== undefined) data.unsupportedFields.push(`${source}.after`);
+}
+
+function setScript(
+  settings: ShareableProjectSettings,
+  field: ShareableProjectSettingsWriteField,
+  value: string
+): void {
+  settings.scripts ??= {};
+  if (field === 'scripts.setup') settings.scripts.setup = value;
+  if (field === 'scripts.run') settings.scripts.run = value;
+  if (field === 'scripts.teardown') settings.scripts.teardown = value;
+}
+
+function toSupersetMigration(data: SupersetMigrationData): ProjectConfigMigration | null {
+  if (data.fields.length === 0) return null;
+  return {
+    provider: 'superset',
+    label: 'Superset',
+    files: data.files,
+    fields: data.fields,
+    unsupportedFields: data.unsupportedFields,
+  };
+}
+
+async function readSupersetMigrationData(
+  fs: Pick<FileSystemProvider, 'exists' | 'read'>
+): Promise<SupersetMigrationData> {
+  const data: SupersetMigrationData = {
+    settings: {},
+    files: [],
+    fields: [],
+    unsupportedFields: [],
+  };
+
+  if (!(await fs.exists(SUPERSET_CONFIG_FILE))) return data;
+
+  const { content } = await fs.read(SUPERSET_CONFIG_FILE);
+  const config = supersetConfigSchema.parse(parseJsonObject(content));
+  data.files.push(SUPERSET_CONFIG_FILE);
+
+  for (const { source, target } of SUPERSET_SCRIPT_FIELDS) {
+    const script = config[source];
+    if (script === undefined) continue;
+
+    if (Array.isArray(script)) {
+      const value = normalizeCommands(script);
+      if (!value) continue;
+      setScript(data.settings, target, value);
+      data.fields.push(target);
+      continue;
+    }
+
+    addUnsupportedOverrideFields(data, source, script);
+  }
+
+  return data;
+}
+
+async function migrateSupersetConfig(
+  project: ProjectProvider,
+  request: MigrateProjectConfigRequest
+): Promise<Result<ProjectConfigMigration, UpdateProjectSettingsError>> {
+  try {
+    const data = await readSupersetMigrationData(project.fs);
+    const migration = toSupersetMigration(data);
+    if (!migration) {
+      return writeConfigFailed('No supported Superset settings were found.');
+    }
+
+    if (request.destination === 'local') {
+      const currentSettings = await project.settings.get();
+      const shareableSettings = mergeShareableProjectSettings(currentSettings, data.settings);
+      const updateResult = await project.settings.update({
+        ...currentSettings,
+        ...shareableSettings,
+      });
+      if (!updateResult.success) return updateResult;
+      return ok(migration);
+    }
+
+    const writeResult = await project.fs.write(
+      CONFIG_FILE,
+      `${JSON.stringify(data.settings, null, 2)}\n`
+    );
+    if (!writeResult.success) {
+      log.warn('Failed to write migrated project config file', writeResult.error);
+      return writeConfigFailed(writeResult.error ?? `Failed to write ${CONFIG_FILE}.`);
+    }
+
+    const clearResult = await project.settings.patch({ clearShareableFields: data.fields });
+    if (!clearResult.success) {
+      log.warn('Failed to clear imported local project settings', clearResult.error);
+      return writeConfigFailed(`Wrote ${CONFIG_FILE}, but failed to clear local project settings.`);
+    }
+
+    return ok(migration);
+  } catch (error) {
+    log.warn('Failed to migrate Superset config to project config', error);
+    return writeConfigFailed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export const supersetConfigMigrator: ProjectConfigMigrator = {
+  provider: 'superset',
+  inspect: async (fs) => toSupersetMigration(await readSupersetMigrationData(fs)),
+  migrate: migrateSupersetConfig,
+};

--- a/src/renderer/app/modal-registry.ts
+++ b/src/renderer/app/modal-registry.ts
@@ -2,6 +2,7 @@ import { CommandPaletteModal } from '@renderer/features/command-palette/command-
 import { IntegrationSetupModal } from '@renderer/features/integrations/integration-setup-modal';
 import { McpModal } from '@renderer/features/mcp/components/McpModal';
 import { AddProjectModal } from '@renderer/features/projects/components/add-project-modal/add-project-modal';
+import { ProjectConfigImportModal } from '@renderer/features/projects/components/settings-view/project-config-import-modal';
 import { ShareProjectConfigModal } from '@renderer/features/projects/components/settings-view/share-project-config-modal';
 import { CreateSkillModal } from '@renderer/features/skills/components/CreateSkillModal';
 import { AddRemoteModal } from '@renderer/features/tasks/add-remote-modal';
@@ -51,6 +52,7 @@ export const modalRegistry = {
   createPrModal: createModal(CreatePrModal, { size: 'md' }),
   renameTaskModal: createModal(RenameTaskModal, { size: 'xs' }),
   shareProjectConfigModal: createModal(ShareProjectConfigModal, { size: 'md' }),
+  projectConfigImportModal: createModal(ProjectConfigImportModal, { size: 'md' }),
   integrationSetupModal: createModal(IntegrationSetupModal, { size: 'md' }),
   addRemoteModal: createModal(AddRemoteModal),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
+++ b/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
@@ -3,7 +3,10 @@ import { Home, Server } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useMemo, useState } from 'react';
 import { SshConnectionSelector } from '@renderer/features/projects/components/add-project-modal/ssh-connection-selector';
-import { getProjectManagerStore } from '@renderer/features/projects/stores/project-selectors';
+import {
+  getProjectManagerStore,
+  getProjectSettingsStore,
+} from '@renderer/features/projects/stores/project-selectors';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
@@ -78,6 +81,34 @@ export const AddProjectModal = observer(function AddProjectModal({
   const showSshConnModal = useShowModal('addSshConnModal');
   const showAddProjectModal = useShowModal('addProjectModal');
   const showConfirm = useShowModal('confirmActionModal');
+  const showProjectConfigImportModal = useShowModal('projectConfigImportModal');
+
+  const maybeShowProjectConfigImportPrompt = async (projectId: string) => {
+    const projectManager = getProjectManagerStore();
+    await projectManager.mountProject(projectId).catch((error) => {
+      log.error(error);
+    });
+
+    const settingsStore = getProjectSettingsStore(projectId);
+    if (!settingsStore) return;
+
+    await settingsStore.load();
+    if (!settingsStore.shouldPromptConfigMigration) return;
+
+    const migrations = settingsStore.configMigrations ?? [];
+    if (migrations.length === 0) return;
+
+    showProjectConfigImportModal({
+      migrations,
+      migrateProjectConfig: (request) => settingsStore.migrateProjectConfig(request),
+      onSuccess: ({ migration }) => {
+        toast({
+          title: `${migration.label} config imported`,
+          description: `${migration.files.join(', ')} was imported successfully.`,
+        });
+      },
+    });
+  };
 
   const handleAddConnection = () => {
     showSshConnModal({
@@ -239,9 +270,10 @@ export const AddProjectModal = observer(function AddProjectModal({
         ? { type: 'ssh' as const, connectionId: selectedConnectionId }
         : { type: 'local' as const };
 
+    let createPromise: Promise<string | undefined>;
     switch (mode) {
       case 'pick':
-        void getProjectManagerStore().createProject(
+        createPromise = getProjectManagerStore().createProject(
           projectType,
           {
             mode: 'pick',
@@ -253,7 +285,7 @@ export const AddProjectModal = observer(function AddProjectModal({
         );
         break;
       case 'new':
-        void getProjectManagerStore().createProject(
+        createPromise = getProjectManagerStore().createProject(
           projectType,
           {
             mode: 'new',
@@ -267,7 +299,7 @@ export const AddProjectModal = observer(function AddProjectModal({
         );
         break;
       case 'clone':
-        void getProjectManagerStore().createProject(
+        createPromise = getProjectManagerStore().createProject(
           projectType,
           {
             mode: 'clone',
@@ -279,6 +311,13 @@ export const AddProjectModal = observer(function AddProjectModal({
         );
         break;
     }
+    void createPromise
+      .then((createdProjectId) => {
+        if (createdProjectId === id) void maybeShowProjectConfigImportPrompt(createdProjectId);
+      })
+      .catch((error) => {
+        log.error(error);
+      });
     onClose();
     navigate('project', { projectId: id });
   };

--- a/src/renderer/features/projects/components/settings-view/config-migration-notice.tsx
+++ b/src/renderer/features/projects/components/settings-view/config-migration-notice.tsx
@@ -1,0 +1,27 @@
+import type { ProjectConfigMigration } from '@shared/project-settings';
+
+export function ConfigMigrationNotice({
+  migrations,
+  disabled,
+  onImport,
+}: {
+  migrations: ProjectConfigMigration[];
+  disabled: boolean;
+  onImport: () => void;
+}) {
+  if (migrations.length === 0) return null;
+
+  return (
+    <p className="text-xs text-foreground-muted">
+      Detected external project config.{' '}
+      <button
+        type="button"
+        onClick={onImport}
+        disabled={disabled}
+        className="text-foreground hover:underline"
+      >
+        Import into Emdash
+      </button>
+    </p>
+  );
+}

--- a/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
@@ -1,0 +1,216 @@
+import { Check, Loader2 } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import type {
+  MigrateProjectConfigRequest,
+  MigrateProjectConfigResult,
+  ProjectConfigMigration,
+  ProjectConfigMigrationDestination,
+  ProjectConfigMigrationProvider,
+} from '@shared/project-settings';
+import type { UpdateProjectSettingsError } from '@shared/projects';
+import { err, type Result } from '@shared/result';
+import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
+import { Button } from '@renderer/lib/ui/button';
+import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
+import {
+  DialogContentArea,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/lib/ui/dialog';
+import { Field, FieldGroup, FieldTitle } from '@renderer/lib/ui/field';
+import { RadioGroup, RadioGroupItem } from '@renderer/lib/ui/radio-group';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@renderer/lib/ui/select';
+import { SHAREABLE_FIELD_DESCRIPTOR_BY_ID } from './shareable-project-settings-fields';
+
+type ImportStatus = 'idle' | 'importing' | 'imported' | 'error';
+
+export type ProjectConfigImportModalArgs = {
+  migrations: ProjectConfigMigration[];
+  migrateProjectConfig: (
+    request: MigrateProjectConfigRequest
+  ) => Promise<Result<MigrateProjectConfigResult, UpdateProjectSettingsError>>;
+};
+
+type Props = BaseModalProps<MigrateProjectConfigResult> & ProjectConfigImportModalArgs;
+
+function unknownErrorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function fieldLabel(field: ProjectConfigMigration['fields'][number]): string {
+  return SHAREABLE_FIELD_DESCRIPTOR_BY_ID[field].modalLabel;
+}
+
+function filesLabel(files: string[]): string {
+  return files.length === 1 ? files[0] : files.join(', ');
+}
+
+function sourceLabel(migration: ProjectConfigMigration | undefined): string {
+  if (!migration) return 'No config selected';
+  return `${migration.label} (${filesLabel(migration.files)})`;
+}
+
+export function ProjectConfigImportModal({
+  migrations,
+  migrateProjectConfig,
+  onSuccess,
+  onClose,
+}: Props) {
+  const [selectedProvider, setSelectedProvider] = useState<ProjectConfigMigrationProvider>(
+    migrations[0]?.provider ?? 'conductor'
+  );
+  const [destination, setDestination] = useState<ProjectConfigMigrationDestination>('local');
+  const [status, setStatus] = useState<ImportStatus>('idle');
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const selectedMigration = useMemo(
+    () => migrations.find((migration) => migration.provider === selectedProvider) ?? migrations[0],
+    [migrations, selectedProvider]
+  );
+
+  const disabled = !selectedMigration || status === 'importing';
+
+  async function handleImport() {
+    if (!selectedMigration) return;
+
+    setStatus('importing');
+    setErrorMessage(null);
+    const result = await migrateProjectConfig({
+      provider: selectedMigration.provider,
+      destination,
+    }).catch((error) =>
+      err({
+        type: 'write-config-failed' as const,
+        message: unknownErrorMessage(error),
+      })
+    );
+
+    if (result.success) {
+      setStatus('imported');
+      onSuccess(result.data);
+      return;
+    }
+
+    setErrorMessage(
+      result.error.type === 'write-config-failed'
+        ? result.error.message
+        : 'Failed to import project config.'
+    );
+    setStatus('error');
+  }
+
+  return (
+    <>
+      <DialogHeader showCloseButton={false}>
+        <DialogTitle>Import project config</DialogTitle>
+      </DialogHeader>
+      <DialogContentArea className="pt-0">
+        <FieldGroup>
+          <Field>
+            {migrations.length > 1 ? (
+              <Select
+                value={selectedMigration?.provider ?? ''}
+                onValueChange={(value) =>
+                  setSelectedProvider(value as ProjectConfigMigrationProvider)
+                }
+              >
+                <SelectTrigger className="w-full min-w-0">
+                  <span className="min-w-0 truncate">{sourceLabel(selectedMigration)}</span>
+                </SelectTrigger>
+                <SelectContent align="start" alignItemWithTrigger={false} sideOffset={6}>
+                  {migrations.map((migration) => (
+                    <SelectItem key={migration.provider} value={migration.provider}>
+                      {sourceLabel(migration)}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : (
+              <p className="text-sm text-foreground-muted">
+                Found {sourceLabel(selectedMigration)}.
+              </p>
+            )}
+          </Field>
+
+          <div className="grid gap-4 rounded-md border border-border bg-background-secondary/40 p-3">
+            <div className="space-y-2">
+              <FieldTitle>Will import</FieldTitle>
+              <div className="flex flex-wrap gap-2">
+                {selectedMigration?.fields.map((field) => (
+                  <span
+                    key={field}
+                    className="rounded-md border border-border bg-background px-2 py-1 text-xs"
+                  >
+                    {fieldLabel(field)}
+                  </span>
+                ))}
+              </div>
+            </div>
+
+            {selectedMigration?.unsupportedFields.length ? (
+              <div className="space-y-2">
+                <FieldTitle>Will skip</FieldTitle>
+                <div className="flex flex-wrap gap-2">
+                  {selectedMigration.unsupportedFields.map((field) => (
+                    <span
+                      key={field}
+                      className="rounded-md border border-border px-2 py-1 text-xs text-foreground-muted"
+                    >
+                      {field}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            ) : null}
+          </div>
+
+          <Field>
+            <FieldTitle>Save imported settings</FieldTitle>
+            <RadioGroup
+              value={destination}
+              onValueChange={(value) => setDestination(value as ProjectConfigMigrationDestination)}
+              className="grid gap-2"
+            >
+              <label className="flex items-start gap-3 rounded-md border border-border px-3 py-2 text-sm">
+                <RadioGroupItem value="local" className="mt-0.5" />
+                <span className="flex min-w-0 flex-col gap-0.5">
+                  <span>Local project settings</span>
+                  <span className="text-xs text-foreground-muted">
+                    Only apply them on this device.
+                  </span>
+                </span>
+              </label>
+              <label className="flex items-start gap-3 rounded-md border border-border px-3 py-2 text-sm">
+                <RadioGroupItem value="shared" className="mt-0.5" />
+                <span className="flex min-w-0 flex-col gap-0.5">
+                  <span>.emdash.json</span>
+                  <span className="text-xs text-foreground-muted">
+                    Commit the file to share them with your team.
+                  </span>
+                </span>
+              </label>
+            </RadioGroup>
+          </Field>
+          {status === 'error' ? <p className="text-xs text-red-500">{errorMessage}</p> : null}
+        </FieldGroup>
+      </DialogContentArea>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose} disabled={status === 'importing'}>
+          Cancel
+        </Button>
+        <ConfirmButton onClick={() => void handleImport()} disabled={disabled}>
+          <span className="inline-flex items-center justify-center gap-1.5">
+            {status === 'importing' && <Loader2 className="size-4 animate-spin" aria-hidden />}
+            {status === 'imported' && <Check className="size-4" aria-hidden />}
+            {status === 'importing'
+              ? 'Importing...'
+              : status === 'imported'
+                ? 'Imported'
+                : 'Import'}
+          </span>
+        </ConfirmButton>
+      </DialogFooter>
+    </>
+  );
+}

--- a/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
@@ -68,7 +68,7 @@ export function ProjectConfigImportModal({
       ? `Found configuration file from ${selectedMigration.label} that can be imported into Emdash.`
       : 'Found configuration files that can be imported into Emdash.';
 
-  const disabled = !selectedMigration || status === 'importing';
+  const disabled = !selectedMigration || status === 'importing' || status === 'imported';
 
   async function handleImport() {
     if (!selectedMigration) return;
@@ -170,7 +170,7 @@ export function ProjectConfigImportModal({
       </DialogContentArea>
       <DialogFooter>
         <Button variant="outline" onClick={onClose} disabled={status === 'importing'}>
-          Cancel
+          {status === 'imported' ? 'Close' : 'Cancel'}
         </Button>
         <ConfirmButton onClick={() => void handleImport()} disabled={disabled}>
           <span className="inline-flex items-center justify-center gap-1.5">

--- a/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
@@ -18,7 +18,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
-import { Field, FieldGroup, FieldTitle } from '@renderer/lib/ui/field';
+import { Field, FieldGroup } from '@renderer/lib/ui/field';
 import { RadioGroup, RadioGroupItem } from '@renderer/lib/ui/radio-group';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@renderer/lib/ui/select';
 import { SHAREABLE_FIELD_DESCRIPTOR_BY_ID } from './shareable-project-settings-fields';
@@ -142,29 +142,29 @@ export function ProjectConfigImportModal({
             </div>
           ) : null}
 
-          <Field>
-            <FieldTitle>Save to</FieldTitle>
+          <div className="space-y-2 text-sm">
+            <p>Save to</p>
             <RadioGroup
               value={destination}
               onValueChange={(value) => setDestination(value as ProjectConfigMigrationDestination)}
               className="grid"
             >
-              <label className="grid grid-cols-[1rem_1fr] items-center gap-3 rounded-md text-sm">
-                <RadioGroupItem value="local" />
+              <label className="flex items-center gap-3 rounded-md text-sm">
+                <RadioGroupItem value="local" className="translate-y-px" />
                 <span className="flex min-w-0 flex-row gap-1.5">
                   <p>Settings</p>
                   <p className="text-foreground-muted">– local to this machine</p>
                 </span>
               </label>
-              <label className="grid grid-cols-[1rem_1fr] items-center gap-3 rounded-md text-sm">
-                <RadioGroupItem value="shared" />
+              <label className="flex items-center gap-3 rounded-md text-sm">
+                <RadioGroupItem value="shared" className="translate-y-px" />
                 <span className="flex min-w-0 flex-row gap-1.5">
                   <p>.emdash.json</p>
                   <p className="text-foreground-muted">– commit to share with team</p>
                 </span>
               </label>
             </RadioGroup>
-          </Field>
+          </div>
           {status === 'error' ? <p className="text-xs text-red-500">{errorMessage}</p> : null}
         </FieldGroup>
       </DialogContentArea>

--- a/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-config-import-modal.tsx
@@ -46,11 +46,6 @@ function filesLabel(files: string[]): string {
   return files.length === 1 ? files[0] : files.join(', ');
 }
 
-function sourceLabel(migration: ProjectConfigMigration | undefined): string {
-  if (!migration) return 'No config selected';
-  return `${migration.label} (${filesLabel(migration.files)})`;
-}
-
 export function ProjectConfigImportModal({
   migrations,
   migrateProjectConfig,
@@ -68,6 +63,10 @@ export function ProjectConfigImportModal({
     () => migrations.find((migration) => migration.provider === selectedProvider) ?? migrations[0],
     [migrations, selectedProvider]
   );
+  const description =
+    migrations.length === 1 && selectedMigration
+      ? `Found configuration file from ${selectedMigration.label} that can be imported into Emdash.`
+      : 'Found configuration files that can be imported into Emdash.';
 
   const disabled = !selectedMigration || status === 'importing';
 
@@ -107,8 +106,9 @@ export function ProjectConfigImportModal({
       </DialogHeader>
       <DialogContentArea className="pt-0">
         <FieldGroup>
-          <Field>
-            {migrations.length > 1 ? (
+          <p className="text-sm text-foreground-muted">{description}</p>
+          {migrations.length > 1 && (
+            <Field>
               <Select
                 value={selectedMigration?.provider ?? ''}
                 onValueChange={(value) =>
@@ -116,78 +116,51 @@ export function ProjectConfigImportModal({
                 }
               >
                 <SelectTrigger className="w-full min-w-0">
-                  <span className="min-w-0 truncate">{sourceLabel(selectedMigration)}</span>
+                  <span className="min-w-0 truncate">
+                    {selectedMigration?.label ?? 'Select config'}
+                  </span>
                 </SelectTrigger>
                 <SelectContent align="start" alignItemWithTrigger={false} sideOffset={6}>
                   {migrations.map((migration) => (
                     <SelectItem key={migration.provider} value={migration.provider}>
-                      {sourceLabel(migration)}
+                      {migration.label} ({filesLabel(migration.files)})
                     </SelectItem>
                   ))}
                 </SelectContent>
               </Select>
-            ) : (
-              <p className="text-sm text-foreground-muted">
-                Found {sourceLabel(selectedMigration)}.
-              </p>
-            )}
-          </Field>
+            </Field>
+          )}
 
-          <div className="grid gap-4 rounded-md border border-border bg-background-secondary/40 p-3">
-            <div className="space-y-2">
-              <FieldTitle>Will import</FieldTitle>
-              <div className="flex flex-wrap gap-2">
-                {selectedMigration?.fields.map((field) => (
-                  <span
-                    key={field}
-                    className="rounded-md border border-border bg-background px-2 py-1 text-xs"
-                  >
-                    {fieldLabel(field)}
-                  </span>
+          {selectedMigration ? (
+            <div className="space-y-2 text-sm">
+              <p>Settings to import</p>
+              <ul className="list-disc space-y-1 pl-5 text-foreground-muted">
+                {selectedMigration.fields.map((field) => (
+                  <li key={field}>{fieldLabel(field)}</li>
                 ))}
-              </div>
+              </ul>
             </div>
-
-            {selectedMigration?.unsupportedFields.length ? (
-              <div className="space-y-2">
-                <FieldTitle>Will skip</FieldTitle>
-                <div className="flex flex-wrap gap-2">
-                  {selectedMigration.unsupportedFields.map((field) => (
-                    <span
-                      key={field}
-                      className="rounded-md border border-border px-2 py-1 text-xs text-foreground-muted"
-                    >
-                      {field}
-                    </span>
-                  ))}
-                </div>
-              </div>
-            ) : null}
-          </div>
+          ) : null}
 
           <Field>
-            <FieldTitle>Save imported settings</FieldTitle>
+            <FieldTitle>Save to</FieldTitle>
             <RadioGroup
               value={destination}
               onValueChange={(value) => setDestination(value as ProjectConfigMigrationDestination)}
-              className="grid gap-2"
+              className="grid"
             >
-              <label className="flex items-start gap-3 rounded-md border border-border px-3 py-2 text-sm">
-                <RadioGroupItem value="local" className="mt-0.5" />
-                <span className="flex min-w-0 flex-col gap-0.5">
-                  <span>Local project settings</span>
-                  <span className="text-xs text-foreground-muted">
-                    Only apply them on this device.
-                  </span>
+              <label className="grid grid-cols-[1rem_1fr] items-center gap-3 rounded-md text-sm">
+                <RadioGroupItem value="local" />
+                <span className="flex min-w-0 flex-row gap-1.5">
+                  <p>Settings</p>
+                  <p className="text-foreground-muted">– local to this machine</p>
                 </span>
               </label>
-              <label className="flex items-start gap-3 rounded-md border border-border px-3 py-2 text-sm">
-                <RadioGroupItem value="shared" className="mt-0.5" />
-                <span className="flex min-w-0 flex-col gap-0.5">
-                  <span>.emdash.json</span>
-                  <span className="text-xs text-foreground-muted">
-                    Commit the file to share them with your team.
-                  </span>
+              <label className="grid grid-cols-[1rem_1fr] items-center gap-3 rounded-md text-sm">
+                <RadioGroupItem value="shared" />
+                <span className="flex min-w-0 flex-row gap-1.5">
+                  <p>.emdash.json</p>
+                  <p className="text-foreground-muted">– commit to share with team</p>
                 </span>
               </label>
             </RadioGroup>

--- a/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
@@ -1,6 +1,9 @@
 import { observer } from 'mobx-react-lite';
 import type { Remote } from '@shared/git';
 import type {
+  MigrateProjectConfigRequest,
+  MigrateProjectConfigResult,
+  ProjectConfigMigration,
   ProjectSettings,
   ProjectSettingsOverrideState,
   ProjectSettingsPage,
@@ -24,23 +27,30 @@ export interface ProjectSettingsFormProps {
   defaults: ProjectSettingsPage['defaults'];
   writeTargets: ProjectSettingsWriteTargetOption[];
   overrideState: ProjectSettingsOverrideState;
+  configMigrations: ProjectConfigMigration[];
   onSuccess: () => void;
   save: (settings: ProjectSettings) => Promise<Result<ProjectSettings, UpdateProjectSettingsError>>;
   writeConfigToRepo: (
     request: WriteProjectConfigRequest
   ) => Promise<Result<ProjectSettingsPage, UpdateProjectSettingsError>>;
+  migrateProjectConfig: (
+    request: MigrateProjectConfigRequest
+  ) => Promise<Result<MigrateProjectConfigResult, UpdateProjectSettingsError>>;
 }
 
 const EMPTY_REMOTES: Remote[] = [];
+
 export const ProjectSettingsForm = observer(function ProjectSettingsForm({
   projectId,
   initial,
   defaults,
   writeTargets,
   overrideState,
+  configMigrations,
   onSuccess,
   save,
   writeConfigToRepo,
+  migrateProjectConfig,
 }: ProjectSettingsFormProps) {
   const repo = getRepositoryStore(projectId);
   const remotes = repo?.remotes ?? EMPTY_REMOTES;
@@ -52,9 +62,11 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
     remotes,
     writeTargets,
     overrideState,
+    configMigrations,
     onSuccess,
     save,
     writeConfigToRepo,
+    migrateProjectConfig,
   });
 
   return (
@@ -83,6 +95,9 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
             form={formModel.form}
             update={formModel.update}
             getOverrideSources={formModel.getOverrideSources}
+            configMigrations={formModel.configMigrations}
+            importDisabled={formModel.importDisabled}
+            openImportConfigModal={formModel.openImportConfigModal}
           />
         </FieldGroup>
       </div>

--- a/src/renderer/features/projects/components/settings-view/sections/shareable-project-settings-section.tsx
+++ b/src/renderer/features/projects/components/settings-view/sections/shareable-project-settings-section.tsx
@@ -1,4 +1,6 @@
+import { Fragment } from 'react';
 import type {
+  ProjectConfigMigration,
   ProjectSettingsOverrideState,
   ShareableProjectSettingsWriteField,
 } from '@shared/project-settings';
@@ -8,6 +10,7 @@ import { Field, FieldDescription, FieldTitle } from '@renderer/lib/ui/field';
 import { Input } from '@renderer/lib/ui/input';
 import { Separator } from '@renderer/lib/ui/separator';
 import { Textarea } from '@renderer/lib/ui/textarea';
+import { ConfigMigrationNotice } from '../config-migration-notice';
 import type { FormState, FormUpdate } from '../project-settings-form-model';
 import {
   SHAREABLE_FIELD_DESCRIPTORS,
@@ -21,6 +24,9 @@ type ShareableSettingsSectionProps = {
   getOverrideSources: (
     field: ShareableProjectSettingsWriteField
   ) => ProjectSettingsOverrideState[ShareableProjectSettingsWriteField];
+  configMigrations: ProjectConfigMigration[];
+  importDisabled: boolean;
+  openImportConfigModal: () => void;
 };
 
 function titleCase(value: string): string {
@@ -74,6 +80,9 @@ export function ShareableSettingsSection({
   form,
   update,
   getOverrideSources,
+  configMigrations,
+  importDisabled,
+  openImportConfigModal,
 }: ShareableSettingsSectionProps) {
   const topLevelFields = SHAREABLE_FIELD_DESCRIPTORS.filter((descriptor) => !descriptor.group);
   const lifecycleFields = SHAREABLE_FIELD_DESCRIPTORS.filter(
@@ -84,14 +93,16 @@ export function ShareableSettingsSection({
     <>
       <Separator />
 
-      {topLevelFields.map((descriptor) => (
-        <ShareableField
-          key={descriptor.id}
-          descriptor={descriptor}
-          form={form}
-          update={update}
-          getOverrideSources={getOverrideSources}
-        />
+      {topLevelFields.map((descriptor, index) => (
+        <Fragment key={descriptor.id}>
+          {index > 0 ? <Separator /> : null}
+          <ShareableField
+            descriptor={descriptor}
+            form={form}
+            update={update}
+            getOverrideSources={getOverrideSources}
+          />
+        </Fragment>
       ))}
 
       <Separator />
@@ -129,6 +140,12 @@ export function ShareableSettingsSection({
             getOverrideSources={getOverrideSources}
           />
         ))}
+
+        <ConfigMigrationNotice
+          migrations={configMigrations}
+          disabled={importDisabled}
+          onImport={openImportConfigModal}
+        />
       </div>
     </>
   );

--- a/src/renderer/features/projects/components/settings-view/settings-panel.tsx
+++ b/src/renderer/features/projects/components/settings-view/settings-panel.tsx
@@ -13,8 +13,9 @@ export const SettingsPanel = observer(function SettingsPanel() {
   const defaults = store?.defaults;
   const writeTargets = store?.writeTargets;
   const overrideState = store?.overrideState;
+  const configMigrations = store?.configMigrations;
 
-  if (!store || !settings || !defaults || !writeTargets || !overrideState) {
+  if (!store || !settings || !defaults || !writeTargets || !overrideState || !configMigrations) {
     return (
       <div className="flex items-center justify-center py-10">
         <Spinner />
@@ -30,9 +31,11 @@ export const SettingsPanel = observer(function SettingsPanel() {
       defaults={defaults}
       writeTargets={writeTargets}
       overrideState={overrideState}
+      configMigrations={configMigrations}
       onSuccess={() => {}}
       save={(s) => store.save(s)}
       writeConfigToRepo={(request) => store.writeConfigToRepo(request)}
+      migrateProjectConfig={(request) => store.migrateProjectConfig(request)}
     />
   );
 });

--- a/src/renderer/features/projects/components/settings-view/use-project-settings-form.ts
+++ b/src/renderer/features/projects/components/settings-view/use-project-settings-form.ts
@@ -2,6 +2,9 @@ import { useCallback, useMemo, useState } from 'react';
 import type { Remote } from '@shared/git';
 import {
   emptyProjectSettingsOverrideState,
+  type MigrateProjectConfigRequest,
+  type MigrateProjectConfigResult,
+  type ProjectConfigMigration,
   type ProjectSettings,
   type ProjectSettingsOverrideState,
   type ProjectSettingsPage,
@@ -36,11 +39,15 @@ type UseProjectSettingsFormArgs = {
   remotes: Remote[];
   writeTargets: ProjectSettingsWriteTargetOption[];
   overrideState: ProjectSettingsOverrideState;
+  configMigrations: ProjectConfigMigration[];
   onSuccess: () => void;
   save: (settings: ProjectSettings) => Promise<Result<ProjectSettings, UpdateProjectSettingsError>>;
   writeConfigToRepo: (
     request: WriteProjectConfigRequest
   ) => Promise<Result<ProjectSettingsPage, UpdateProjectSettingsError>>;
+  migrateProjectConfig: (
+    request: MigrateProjectConfigRequest
+  ) => Promise<Result<MigrateProjectConfigResult, UpdateProjectSettingsError>>;
 };
 
 type FormSnapshot = {
@@ -61,9 +68,11 @@ export function useProjectSettingsForm({
   remotes,
   writeTargets,
   overrideState,
+  configMigrations,
   onSuccess,
   save,
   writeConfigToRepo,
+  migrateProjectConfig,
 }: UseProjectSettingsFormArgs) {
   const { showModal } = useModalContext();
   const { toast } = useToast();
@@ -90,6 +99,8 @@ export function useProjectSettingsForm({
   const dirty = !areFormStatesEqual(form, savedForm);
   const canShareConfig = availableWriteFields.length > 0 && writeTargets.length > 0;
   const shareDisabled = dirty;
+  const canImportConfig = configMigrations.length > 0;
+  const importDisabled = dirty;
   const initialWriteTarget = writeTargets[0]
     ? projectConfigTargetValue(writeTargets[0])
     : 'project:repository';
@@ -203,6 +214,37 @@ export function useProjectSettingsForm({
     writeTargets,
   ]);
 
+  const openImportConfigModal = useCallback(() => {
+    if (!canImportConfig || importDisabled) return;
+    showModal('projectConfigImportModal', {
+      migrations: configMigrations,
+      migrateProjectConfig,
+      onSuccess: ({ page, migration }) => {
+        const nextForm = settingsToForm(page.settings, baseRemote, remotes);
+        setFormSnapshot({
+          baseline: nextForm,
+          form: nextForm,
+          savedForm: nextForm,
+        });
+        toast({
+          title: `${migration.label} config imported`,
+          description: `${migration.files.join(', ')} was imported successfully.`,
+        });
+        onSuccess();
+      },
+    });
+  }, [
+    baseRemote,
+    canImportConfig,
+    configMigrations,
+    importDisabled,
+    migrateProjectConfig,
+    onSuccess,
+    remotes,
+    showModal,
+    toast,
+  ]);
+
   const handleUndo = useCallback(() => {
     setFormSnapshot({
       ...resolvedSnapshot,
@@ -219,12 +261,16 @@ export function useProjectSettingsForm({
     saveStatus,
     canShareConfig,
     shareDisabled,
+    canImportConfig,
+    importDisabled,
+    configMigrations,
     worktreeDirectoryError: visibleWorktreeDirectoryError,
     workspaceProviderErrors: visibleWorkspaceProviderErrors,
     update,
     getOverrideSources,
     handleSave,
     openShareConfigModal,
+    openImportConfigModal,
     handleUndo,
   };
 }

--- a/src/renderer/features/projects/stores/project-settings-store.ts
+++ b/src/renderer/features/projects/stores/project-settings-store.ts
@@ -1,6 +1,10 @@
 import { fsWatchEventChannel } from '@shared/events/fsEvents';
+import { projectSettingsChangedChannel } from '@shared/events/projectEvents';
 import {
   PROJECT_CONFIG_FILE,
+  type MigrateProjectConfigRequest,
+  type MigrateProjectConfigResult,
+  type ProjectConfigMigration,
   type ProjectSettings,
   type ProjectSettingsOverrideState,
   type ProjectSettingsPage,
@@ -15,6 +19,7 @@ import { Resource } from '@renderer/lib/stores/resource';
 export class ProjectSettingsStore {
   readonly pageData: Resource<ProjectSettingsPage>;
   private readonly _unsubscribeConfigWatch: () => void;
+  private readonly _unsubscribeSettingsChanged: () => void;
 
   constructor(private readonly projectId: string) {
     this.pageData = new Resource(async () => {
@@ -39,6 +44,12 @@ export class ProjectSettingsStore {
         this.pageData.invalidate();
       }
     });
+
+    this._unsubscribeSettingsChanged = events.on(projectSettingsChangedChannel, (data) => {
+      if (data.projectId === projectId) {
+        this.pageData.invalidate();
+      }
+    });
   }
 
   get settings(): ProjectSettings | null {
@@ -55,6 +66,19 @@ export class ProjectSettingsStore {
 
   get overrideState(): ProjectSettingsOverrideState | null {
     return this.pageData.data?.overrideState ?? null;
+  }
+
+  get configMigrations(): ProjectConfigMigration[] | null {
+    return this.pageData.data?.configMigrations ?? null;
+  }
+
+  get shouldPromptConfigMigration(): boolean {
+    return this.pageData.data?.shouldPromptConfigMigration ?? false;
+  }
+
+  async load(): Promise<ProjectSettingsPage | null> {
+    await this.pageData.load();
+    return this.pageData.data;
   }
 
   async save(
@@ -79,8 +103,19 @@ export class ProjectSettingsStore {
     return result;
   }
 
+  async migrateProjectConfig(
+    request: MigrateProjectConfigRequest
+  ): Promise<Result<MigrateProjectConfigResult, UpdateProjectSettingsError>> {
+    const result = await rpc.projects.migrateProjectConfig(this.projectId, request);
+    if (result.success) {
+      this.pageData.setValue(result.data.page);
+    }
+    return result;
+  }
+
   dispose(): void {
     this._unsubscribeConfigWatch();
+    this._unsubscribeSettingsChanged();
     this.pageData.dispose();
   }
 }

--- a/src/shared/project-settings-fields.test.ts
+++ b/src/shared/project-settings-fields.test.ts
@@ -11,6 +11,14 @@ describe('hasConfiguredShareableProjectSettings', () => {
     ).toBe(false);
   });
 
+  it('does not treat reordered default preserve patterns as configured settings', () => {
+    expect(
+      hasConfiguredShareableProjectSettings({
+        preservePatterns: [...DEFAULT_PRESERVE_PATTERNS].reverse(),
+      })
+    ).toBe(false);
+  });
+
   it('treats non-default preserve patterns as configured settings', () => {
     expect(
       hasConfiguredShareableProjectSettings({

--- a/src/shared/project-settings-fields.test.ts
+++ b/src/shared/project-settings-fields.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_PRESERVE_PATTERNS, type ProjectSettings } from './project-settings';
+import { hasConfiguredShareableProjectSettings } from './project-settings-fields';
+
+describe('hasConfiguredShareableProjectSettings', () => {
+  it('does not treat seeded default preserve patterns as configured settings', () => {
+    expect(
+      hasConfiguredShareableProjectSettings({
+        preservePatterns: [...DEFAULT_PRESERVE_PATTERNS],
+      })
+    ).toBe(false);
+  });
+
+  it('treats non-default preserve patterns as configured settings', () => {
+    expect(
+      hasConfiguredShareableProjectSettings({
+        preservePatterns: ['.env*'],
+      })
+    ).toBe(true);
+  });
+
+  it('treats scripts and shell setup as configured settings', () => {
+    const settings: ProjectSettings = {
+      preservePatterns: [...DEFAULT_PRESERVE_PATTERNS],
+      shellSetup: 'nvm use',
+      scripts: {
+        setup: 'npm install',
+      },
+    };
+
+    expect(hasConfiguredShareableProjectSettings(settings)).toBe(true);
+  });
+});

--- a/src/shared/project-settings-fields.ts
+++ b/src/shared/project-settings-fields.ts
@@ -1,4 +1,5 @@
 import {
+  DEFAULT_PRESERVE_PATTERNS,
   SHAREABLE_PROJECT_SETTINGS_WRITE_FIELDS,
   type ProjectSettings,
   type ShareableProjectSettings,
@@ -30,6 +31,28 @@ function compactScripts(settings: ShareableProjectSettings): void {
   }
 }
 
+function normalizePatterns(patterns: string[] | undefined): string[] {
+  return patterns?.map((pattern) => pattern.trim()).filter(Boolean) ?? [];
+}
+
+export function hasDefaultPreservePatterns(settings: ShareableProjectSettings): boolean {
+  const patterns = normalizePatterns(settings.preservePatterns);
+  return (
+    patterns.length === DEFAULT_PRESERVE_PATTERNS.length &&
+    patterns.every((pattern, index) => pattern === DEFAULT_PRESERVE_PATTERNS[index])
+  );
+}
+
+export function hasConfiguredShareableProjectSettings(settings: ProjectSettings): boolean {
+  return SHAREABLE_PROJECT_SETTINGS_WRITE_FIELDS.some((field) => {
+    if (field === 'preservePatterns') {
+      const patterns = normalizePatterns(settings.preservePatterns);
+      return patterns.length > 0 && !hasDefaultPreservePatterns(settings);
+    }
+    return SHAREABLE_FIELD_ACCESSORS[field].displayValue(settings) !== null;
+  });
+}
+
 export const SHAREABLE_FIELD_ACCESSORS = {
   preservePatterns: {
     path: ['preservePatterns'],
@@ -41,7 +64,7 @@ export const SHAREABLE_FIELD_ACCESSORS = {
       delete settings.preservePatterns;
     },
     displayValue: (settings) => {
-      const value = settings.preservePatterns?.filter((pattern) => pattern.trim());
+      const value = normalizePatterns(settings.preservePatterns);
       return value?.length ? value.join('\n') : null;
     },
   },

--- a/src/shared/project-settings-fields.ts
+++ b/src/shared/project-settings-fields.ts
@@ -37,10 +37,9 @@ function normalizePatterns(patterns: string[] | undefined): string[] {
 
 export function hasDefaultPreservePatterns(settings: ShareableProjectSettings): boolean {
   const patterns = normalizePatterns(settings.preservePatterns);
-  return (
-    patterns.length === DEFAULT_PRESERVE_PATTERNS.length &&
-    patterns.every((pattern, index) => pattern === DEFAULT_PRESERVE_PATTERNS[index])
-  );
+  if (patterns.length !== DEFAULT_PRESERVE_PATTERNS.length) return false;
+  const patternSet = new Set(patterns);
+  return DEFAULT_PRESERVE_PATTERNS.every((pattern) => patternSet.has(pattern));
 }
 
 export function hasConfiguredShareableProjectSettings(settings: ProjectSettings): boolean {

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -82,6 +82,8 @@ export type ProjectSettingsPage = {
   };
   writeTargets: ProjectSettingsWriteTargetOption[];
   overrideState: ProjectSettingsOverrideState;
+  configMigrations: ProjectConfigMigration[];
+  shouldPromptConfigMigration: boolean;
 };
 
 export type ProjectSettingsWriteTarget =
@@ -124,6 +126,28 @@ export type ProjectSettingsOverrideState = Record<
   ShareableProjectSettingsWriteField,
   ProjectSettingsOverrideSource[]
 >;
+
+export type ProjectConfigMigrationProvider = 'conductor';
+
+export type ProjectConfigMigration = {
+  provider: ProjectConfigMigrationProvider;
+  label: string;
+  files: string[];
+  fields: ShareableProjectSettingsWriteField[];
+  unsupportedFields: string[];
+};
+
+export type ProjectConfigMigrationDestination = 'local' | 'shared';
+
+export type MigrateProjectConfigRequest = {
+  provider: ProjectConfigMigrationProvider;
+  destination: ProjectConfigMigrationDestination;
+};
+
+export type MigrateProjectConfigResult = {
+  page: ProjectSettingsPage;
+  migration: ProjectConfigMigration;
+};
 
 export function emptyProjectSettingsOverrideState(): ProjectSettingsOverrideState {
   return {

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -127,7 +127,7 @@ export type ProjectSettingsOverrideState = Record<
   ProjectSettingsOverrideSource[]
 >;
 
-export type ProjectConfigMigrationProvider = 'conductor';
+export type ProjectConfigMigrationProvider = 'conductor' | 'superset';
 
 export type ProjectConfigMigration = {
   provider: ProjectConfigMigrationProvider;

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -127,7 +127,7 @@ export type ProjectSettingsOverrideState = Record<
   ProjectSettingsOverrideSource[]
 >;
 
-export type ProjectConfigMigrationProvider = 'conductor' | 'superset' | 'paseo';
+export type ProjectConfigMigrationProvider = 'conductor' | 'superset' | 'paseo' | 'codex';
 
 export type ProjectConfigMigration = {
   provider: ProjectConfigMigrationProvider;

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -127,7 +127,7 @@ export type ProjectSettingsOverrideState = Record<
   ProjectSettingsOverrideSource[]
 >;
 
-export type ProjectConfigMigrationProvider = 'conductor' | 'superset';
+export type ProjectConfigMigrationProvider = 'conductor' | 'superset' | 'paseo';
 
 export type ProjectConfigMigration = {
   provider: ProjectConfigMigrationProvider;


### PR DESCRIPTION
summary:
- add stateless project config, best effort migration flow
- detect repo configs from codex, conductor, paseo and superset
- map to emdash concepts, ignore settings for concepts that do not exist in emdash
- let users import into local project settings or write .emdash.json
- show import once on project creation if no .emdash.json exists and at least one supported external config exists
- if user skips import, keep on showing import option in settings as long as no .emdash.json exists, no shareable emdash settings are configured and at least one supported external config exists

limits:
- convenience variables may be used in the configs, but are not mapped


<img width="497" height="368" alt="Screenshot 2026-05-14 at 20 44 11" src="https://github.com/user-attachments/assets/6be3cde5-a2dc-4f40-a56d-b71486c98476" />

<img width="539" height="404" alt="Screenshot 2026-05-14 at 20 43 17" src="https://github.com/user-attachments/assets/da2b44dd-69ec-48c1-a091-00d81802e28a" />
