### PR TITLE
Add autorun for multiple open issues with concurrency limit

### DIFF
--- a/drizzle/0009_add_auto_create_pr.sql
+++ b/drizzle/0009_add_auto_create_pr.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `tasks` ADD `auto_create_pr` integer DEFAULT 0 NOT NULL;

--- a/drizzle/meta/0009_snapshot.json
+++ b/drizzle/meta/0009_snapshot.json
@@ -1,0 +1,1306 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "517c7236-745d-48a8-ba2c-e243be77d0bc",
+  "prevId": "f7518b53-ae00-412e-a92c-68667522bca3",
+  "tables": {
+    "app_secrets": {
+      "name": "app_secrets",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "secret": {
+          "name": "secret",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_app_secrets_key": {
+          "name": "idx_app_secrets_key",
+          "columns": ["key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "app_settings": {
+      "name": "app_settings",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_app_settings_key": {
+          "name": "idx_app_settings_key",
+          "columns": ["key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "conversations": {
+      "name": "conversations",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_interacted_at": {
+          "name": "last_interacted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_conversations_task_id": {
+          "name": "idx_conversations_task_id",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "conversations_project_id_projects_id_fk": {
+          "name": "conversations_project_id_projects_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "conversations_task_id_tasks_id_fk": {
+          "name": "conversations_task_id_tasks_id_fk",
+          "tableFrom": "conversations",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "editor_buffers": {
+      "name": "editor_buffers",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "file_path": {
+          "name": "file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_editor_buffers_workspace_file": {
+          "name": "idx_editor_buffers_workspace_file",
+          "columns": ["workspace_id", "file_path"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "editor_buffers_project_id_projects_id_fk": {
+          "name": "editor_buffers_project_id_projects_id_fk",
+          "tableFrom": "editor_buffers",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "kv": {
+      "name": "kv",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_kv_key": {
+          "name": "idx_kv_key",
+          "columns": ["key"],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "messages": {
+      "name": "messages",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conversation_id": {
+          "name": "conversation_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "sender": {
+          "name": "sender",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_messages_conversation_id": {
+          "name": "idx_messages_conversation_id",
+          "columns": ["conversation_id"],
+          "isUnique": false
+        },
+        "idx_messages_timestamp": {
+          "name": "idx_messages_timestamp",
+          "columns": ["timestamp"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "messages_conversation_id_conversations_id_fk": {
+          "name": "messages_conversation_id_conversations_id_fk",
+          "tableFrom": "messages",
+          "tableTo": "conversations",
+          "columnsFrom": ["conversation_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "project_remotes": {
+      "name": "project_remotes",
+      "columns": {
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_name": {
+          "name": "remote_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "remote_url": {
+          "name": "remote_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "project_remotes_project_id_projects_id_fk": {
+          "name": "project_remotes_project_id_projects_id_fk",
+          "tableFrom": "project_remotes",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "project_remotes_project_id_remote_name_pk": {
+          "columns": ["project_id", "remote_name"],
+          "name": "project_remotes_project_id_remote_name_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "projects": {
+      "name": "projects",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "workspace_provider": {
+          "name": "workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'local'"
+        },
+        "base_ref": {
+          "name": "base_ref",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "ssh_connection_id": {
+          "name": "ssh_connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_projects_path": {
+          "name": "idx_projects_path",
+          "columns": ["path"],
+          "isUnique": true
+        },
+        "idx_projects_ssh_connection_id": {
+          "name": "idx_projects_ssh_connection_id",
+          "columns": ["ssh_connection_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "projects_ssh_connection_id_ssh_connections_id_fk": {
+          "name": "projects_ssh_connection_id_ssh_connections_id_fk",
+          "tableFrom": "projects",
+          "tableTo": "ssh_connections",
+          "columnsFrom": ["ssh_connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pull_request_assignees": {
+      "name": "pull_request_assignees",
+      "columns": {
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_pra_pull_request_url": {
+          "name": "idx_pra_pull_request_url",
+          "columns": ["pull_request_url"],
+          "isUnique": false
+        },
+        "idx_pra_user_id": {
+          "name": "idx_pra_user_id",
+          "columns": ["user_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_assignees_pull_request_url_pull_requests_url_fk": {
+          "name": "pull_request_assignees_pull_request_url_pull_requests_url_fk",
+          "tableFrom": "pull_request_assignees",
+          "tableTo": "pull_requests",
+          "columnsFrom": ["pull_request_url"],
+          "columnsTo": ["url"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "pull_request_assignees_user_id_pull_request_users_user_id_fk": {
+          "name": "pull_request_assignees_user_id_pull_request_users_user_id_fk",
+          "tableFrom": "pull_request_assignees",
+          "tableTo": "pull_request_users",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pull_request_assignees_pull_request_url_user_id_pk": {
+          "columns": ["pull_request_url", "user_id"],
+          "name": "pull_request_assignees_pull_request_url_user_id_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "pull_request_checks": {
+      "name": "pull_request_checks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "pull_request_url": {
+          "name": "pull_request_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "commit_sha": {
+          "name": "commit_sha",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "conclusion": {
+          "name": "conclusion",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "details_url": {
+          "name": "details_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workflow_name": {
+          "name": "workflow_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_name": {
+          "name": "app_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "app_logo_url": {
+          "name": "app_logo_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_prc_pull_request_url": {
+          "name": "idx_prc_pull_request_url",
+          "columns": ["pull_request_url"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_checks_pull_request_url_pull_requests_url_fk": {
+          "name": "pull_request_checks_pull_request_url_pull_requests_url_fk",
+          "tableFrom": "pull_request_checks",
+          "tableTo": "pull_requests",
+          "columnsFrom": ["pull_request_url"],
+          "columnsTo": ["url"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pull_request_labels": {
+      "name": "pull_request_labels",
+      "columns": {
+        "pull_request_id": {
+          "name": "pull_request_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "color": {
+          "name": "color",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "idx_prl_name": {
+          "name": "idx_prl_name",
+          "columns": ["name"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_request_labels_pull_request_id_pull_requests_url_fk": {
+          "name": "pull_request_labels_pull_request_id_pull_requests_url_fk",
+          "tableFrom": "pull_request_labels",
+          "tableTo": "pull_requests",
+          "columnsFrom": ["pull_request_id"],
+          "columnsTo": ["url"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "pull_request_labels_pull_request_id_name_pk": {
+          "columns": ["pull_request_id", "name"],
+          "name": "pull_request_labels_pull_request_id_name_pk"
+        }
+      },
+      "uniqueConstraints": {}
+    },
+    "pull_request_users": {
+      "name": "pull_request_users",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_name": {
+          "name": "user_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avatar_url": {
+          "name": "avatar_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_updated_at": {
+          "name": "user_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "user_created_at": {
+          "name": "user_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "pull_requests": {
+      "name": "pull_requests",
+      "columns": {
+        "url": {
+          "name": "url",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'github'"
+        },
+        "repository_url": {
+          "name": "repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_ref_name": {
+          "name": "base_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "base_ref_oid": {
+          "name": "base_ref_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_repository_url": {
+          "name": "head_repository_url",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref_name": {
+          "name": "head_ref_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "head_ref_oid": {
+          "name": "head_ref_oid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'open'"
+        },
+        "is_draft": {
+          "name": "is_draft",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "author_user_id": {
+          "name": "author_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "additions": {
+          "name": "additions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "deletions": {
+          "name": "deletions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "changed_files": {
+          "name": "changed_files",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "commit_count": {
+          "name": "commit_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mergeable_status": {
+          "name": "mergeable_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "merge_state_status": {
+          "name": "merge_state_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "review_decision": {
+          "name": "review_decision",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "pull_request_created_at": {
+          "name": "pull_request_created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "pull_request_updated_at": {
+          "name": "pull_request_updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_pull_requests_url": {
+          "name": "idx_pull_requests_url",
+          "columns": ["url"],
+          "isUnique": true
+        },
+        "idx_pull_requests_repository_url": {
+          "name": "idx_pull_requests_repository_url",
+          "columns": ["repository_url"],
+          "isUnique": false
+        },
+        "idx_pull_requests_head_repository_url": {
+          "name": "idx_pull_requests_head_repository_url",
+          "columns": ["head_repository_url"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "pull_requests_author_user_id_pull_request_users_user_id_fk": {
+          "name": "pull_requests_author_user_id_pull_request_users_user_id_fk",
+          "tableFrom": "pull_requests",
+          "tableTo": "pull_request_users",
+          "columnsFrom": ["author_user_id"],
+          "columnsTo": ["user_id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "ssh_connections": {
+      "name": "ssh_connections",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "host": {
+          "name": "host",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "port": {
+          "name": "port",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 22
+        },
+        "username": {
+          "name": "username",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "auth_type": {
+          "name": "auth_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'agent'"
+        },
+        "private_key_path": {
+          "name": "private_key_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "use_agent": {
+          "name": "use_agent",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "metadata": {
+          "name": "metadata",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_ssh_connections_name": {
+          "name": "idx_ssh_connections_name",
+          "columns": ["name"],
+          "isUnique": true
+        },
+        "idx_ssh_connections_host": {
+          "name": "idx_ssh_connections_host",
+          "columns": ["host"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "tasks": {
+      "name": "tasks",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "source_branch": {
+          "name": "source_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "task_branch": {
+          "name": "task_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "linked_issue": {
+          "name": "linked_issue",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "archived_at": {
+          "name": "archived_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "last_interacted_at": {
+          "name": "last_interacted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "status_changed_at": {
+          "name": "status_changed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "is_pinned": {
+          "name": "is_pinned",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "workspace_provider": {
+          "name": "workspace_provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_id": {
+          "name": "workspace_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "workspace_provider_data": {
+          "name": "workspace_provider_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_create_pr": {
+          "name": "auto_create_pr",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_tasks_project_id": {
+          "name": "idx_tasks_project_id",
+          "columns": ["project_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "tasks_project_id_projects_id_fk": {
+          "name": "tasks_project_id_projects_id_fk",
+          "tableFrom": "tasks",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    },
+    "terminals": {
+      "name": "terminals",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "project_id": {
+          "name": "project_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "task_id": {
+          "name": "task_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "ssh": {
+          "name": "ssh",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "CURRENT_TIMESTAMP"
+        }
+      },
+      "indexes": {
+        "idx_terminals_task_id": {
+          "name": "idx_terminals_task_id",
+          "columns": ["task_id"],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "terminals_project_id_projects_id_fk": {
+          "name": "terminals_project_id_projects_id_fk",
+          "tableFrom": "terminals",
+          "tableTo": "projects",
+          "columnsFrom": ["project_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "terminals_task_id_tasks_id_fk": {
+          "name": "terminals_task_id_tasks_id_fk",
+          "tableFrom": "terminals",
+          "tableTo": "tasks",
+          "columnsFrom": ["task_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {}
+    }
+  },
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778075084353,
       "tag": "0008_past_shinko_yamashiro",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "6",
+      "when": 1778530955528,
+      "tag": "0009_add_auto_create_pr",
+      "breakpoints": true
     }
   ]
 }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       },
     },
     server: {
-      port: 3000,
+      port: Number(process.env.EMDASH_DEV_PORT) || 3000,
     },
   },
 });

--- a/src/main/core/projects/settings/schema.ts
+++ b/src/main/core/projects/settings/schema.ts
@@ -41,6 +41,12 @@ export const projectSettingsSchema = z.object({
       terminateCommand: z.string().min(1),
     })
     .optional(),
+  autorun: z
+    .object({
+      concurrency: z.number().int().min(1).max(10).optional(),
+      defaultCreateDraftPr: z.boolean().optional(),
+    })
+    .optional(),
 });
 
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;

--- a/src/main/core/tasks/auto-create-pr.ts
+++ b/src/main/core/tasks/auto-create-pr.ts
@@ -1,0 +1,91 @@
+import { eq, sql } from 'drizzle-orm';
+import { agentSessionExitedChannel, type AgentSessionExited } from '@shared/events/agentEvents';
+import type { Issue } from '@shared/tasks';
+import { projectManager } from '@main/core/projects/project-manager';
+import { resolveWorkspace } from '@main/core/projects/utils';
+import { prQueryService } from '@main/core/pull-requests/pr-query-service';
+import { prSyncEngine } from '@main/core/pull-requests/pr-sync-engine';
+import { db } from '@main/db/client';
+import { tasks } from '@main/db/schema';
+import { events } from '@main/lib/events';
+import { log } from '@main/lib/logger';
+import { telemetryService } from '@main/lib/telemetry';
+
+async function handleAgentExit(event: AgentSessionExited): Promise<void> {
+  if (event.exitCode !== 0) return;
+
+  const [row] = await db.select().from(tasks).where(eq(tasks.id, event.taskId)).limit(1);
+  if (!row || row.autoCreatePr !== 1) return;
+  // Clear the flag immediately so a respawn or repeat exit cannot fire a duplicate PR.
+  await db.update(tasks).set({ autoCreatePr: 0 }).where(eq(tasks.id, event.taskId));
+
+  if (!row.taskBranch) return;
+
+  const linkedIssue: Issue | undefined = row.linkedIssue
+    ? (JSON.parse(row.linkedIssue) as Issue)
+    : undefined;
+  if (linkedIssue?.provider !== 'github') return;
+
+  const project = projectManager.getProject(event.projectId);
+  if (!project) return;
+  const remoteInfo = await prQueryService.getProjectRemoteInfo(event.projectId);
+  if (remoteInfo.status !== 'ready') return;
+
+  const workspaceId = row.workspaceId;
+  if (!workspaceId) return;
+
+  const workspace = resolveWorkspace(event.projectId, workspaceId);
+  if (!workspace) return;
+
+  const remoteName = await project.repository.getConfiguredRemote().catch(() => 'origin');
+  const publishResult = await workspace.git.publishBranch(row.taskBranch, remoteName);
+  if (!publishResult.success) {
+    log.warn('auto-create-pr: publish branch failed', {
+      taskId: event.taskId,
+      branch: row.taskBranch,
+      error: publishResult.error,
+    });
+    return;
+  }
+
+  const baseBranch = await project.settings.getDefaultBranch();
+  const issueIdentifier = linkedIssue.identifier?.replace(/^#/, '') ?? '';
+  const closesLine = issueIdentifier ? `Closes #${issueIdentifier}\n\n` : '';
+  const body = `${closesLine}${linkedIssue.description ?? ''}`.trim() || undefined;
+
+  try {
+    const result = await prSyncEngine.createPullRequest({
+      repositoryUrl: remoteInfo.repositoryUrl,
+      head: row.taskBranch,
+      base: baseBranch,
+      title: linkedIssue.title || row.name,
+      body,
+      draft: true,
+    });
+    if (!result.success) {
+      log.warn('auto-create-pr: createPullRequest failed', {
+        taskId: event.taskId,
+        error: result.error,
+      });
+      return;
+    }
+    void prSyncEngine.syncSingle(remoteInfo.repositoryUrl, result.data.number);
+    telemetryService.capture('pr_created', { is_draft: true });
+    // Bump updatedAt so renderer task list refresh picks up the linked PR sync.
+    await db
+      .update(tasks)
+      .set({ updatedAt: sql`CURRENT_TIMESTAMP` })
+      .where(eq(tasks.id, event.taskId));
+  } catch (error) {
+    log.warn('auto-create-pr: unexpected failure', {
+      taskId: event.taskId,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
+events.on(agentSessionExitedChannel, (event) => {
+  void handleAgentExit(event).catch((error) => {
+    log.error('auto-create-pr: handler threw', { error });
+  });
+});

--- a/src/main/core/tasks/controller.ts
+++ b/src/main/core/tasks/controller.ts
@@ -1,4 +1,5 @@
 import { createRPCController } from '@shared/ipc/rpc';
+import './auto-create-pr';
 import { generateTaskName } from './name-generation/generateTaskName';
 import { archiveTask } from './operations/archiveTask';
 import { createTask } from './operations/createTask';

--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -195,6 +195,7 @@ export async function createTask(
       sourceBranch: toStoredBranch(dbSourceBranch),
       linkedIssue: params.linkedIssue ? JSON.stringify(params.linkedIssue) : null,
       workspaceProvider: params.workspaceProvider ?? null,
+      autoCreatePr: params.autoCreatePr ? 1 : 0,
       updatedAt: sql`CURRENT_TIMESTAMP`,
       statusChangedAt: sql`CURRENT_TIMESTAMP`,
       lastInteractedAt: sql`CURRENT_TIMESTAMP`,

--- a/src/main/core/tasks/utils/utils.ts
+++ b/src/main/core/tasks/utils/utils.ts
@@ -28,5 +28,6 @@ export function mapTaskRowToTask(
     workspaceProvider: (row.workspaceProvider as 'byoi') ?? undefined,
     workspaceId: row.workspaceId ?? undefined,
     workspaceProviderData: row.workspaceProviderData ?? undefined,
+    autoCreatePr: row.autoCreatePr === 1,
   };
 }

--- a/src/main/db/legacy-port/importers/relational/relational.test.ts
+++ b/src/main/db/legacy-port/importers/relational/relational.test.ts
@@ -60,7 +60,8 @@ function createAppDb(): {
       is_pinned INTEGER NOT NULL DEFAULT 0,
       workspace_provider TEXT,
       workspace_id TEXT,
-      workspace_provider_data TEXT
+      workspace_provider_data TEXT,
+      auto_create_pr INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE conversations (

--- a/src/main/db/legacy-port/service.test.ts
+++ b/src/main/db/legacy-port/service.test.ts
@@ -56,7 +56,8 @@ function createAppDb(): Database.Database {
       is_pinned INTEGER NOT NULL DEFAULT 0,
       workspace_provider TEXT,
       workspace_id TEXT,
-      workspace_provider_data TEXT
+      workspace_provider_data TEXT,
+      auto_create_pr INTEGER NOT NULL DEFAULT 0
     );
 
     CREATE TABLE conversations (

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -113,6 +113,7 @@ export const tasks = sqliteTable(
     workspaceProvider: text('workspace_provider'), // 'local' | 'ssh' | null (null = inherit from project settings)
     workspaceId: text('workspace_id'),
     workspaceProviderData: text('workspace_provider_data'), // JSON, BYOI only
+    autoCreatePr: integer('auto_create_pr').notNull().default(0), // boolean, 0=false, 1=true
   },
   (table) => ({
     projectIdIdx: index('idx_tasks_project_id').on(table.projectId),

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -27,15 +27,18 @@ import {
   resolveBranchLikeTaskStrategy,
   resolvePullRequestTaskStrategy,
 } from './create-task-strategy';
+import { FromAutorunContent } from './from-autorun-content';
 import { FromBranchContent } from './from-branch-content';
 import { FromIssueContent } from './from-issue-content';
 import { FromPrContent } from './from-pr-content';
 import { useInitialConversationState } from './initial-conversation-section';
+import { runAutorunBatch } from './run-autorun-batch';
+import { useFromAutorunMode } from './use-from-autorun-mode';
 import { useFromBranchMode } from './use-from-branch-mode';
 import { useFromIssueMode } from './use-from-issue-mode';
 import { useFromPullRequestMode } from './use-from-pull-request-mode';
 
-type CreateTaskStrategy = 'from-branch' | 'from-issue' | 'from-pull-request';
+type CreateTaskStrategy = 'from-branch' | 'from-issue' | 'from-pull-request' | 'autorun';
 
 export const CreateTaskModal = observer(function CreateTaskModal({
   projectId,
@@ -100,12 +103,14 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   const fromBranch = useFromBranchMode(selectedProjectId, defaultBranch, isUnborn, currentBranch);
   const fromIssue = useFromIssueMode(selectedProjectId, defaultBranch, isUnborn, currentBranch);
   const fromPR = useFromPullRequestMode(selectedProjectId, defaultBranch, isUnborn, initialPR);
+  const fromAutorun = useFromAutorunMode(selectedProjectId, defaultBranch, isUnborn, currentBranch);
   const fromPrUnavailable = selectedStrategy === 'from-pull-request' && !repositoryUrl;
 
   const activeMode = {
     'from-branch': fromBranch,
     'from-issue': fromIssue,
     'from-pull-request': fromPR,
+    autorun: fromAutorun,
   }[selectedStrategy];
   const canCreate = !!selectedProjectId && activeMode.isValid && !fromPrUnavailable;
 
@@ -166,6 +171,24 @@ export const CreateTaskModal = observer(function CreateTaskModal({
         });
         break;
       }
+      case 'autorun': {
+        if (!fromAutorun.selectedBranch || fromAutorun.selectedIssues.length === 0) return;
+        const taskManager = projectStore.mountedProject!.taskManager;
+        const provider = initialConversation.provider;
+        const sourceBranch = fromAutorun.selectedBranch;
+        const issues = fromAutorun.selectedIssues;
+        const opts = {
+          projectId: selectedProjectId,
+          sourceBranch,
+          provider,
+          concurrency: fromAutorun.concurrency,
+          autoCreatePr: fromAutorun.autoCreatePr,
+          extraPromptPrefix: fromAutorun.extraPrompt,
+        };
+        void runAutorunBatch(taskManager, issues, opts);
+        onClose();
+        return;
+      }
       case 'from-pull-request': {
         if (!fromPR.linkedPR) return;
         const reviewBranch = fromPR.linkedPR.headRefName;
@@ -201,6 +224,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
     fromBranch,
     fromIssue,
     fromPR,
+    fromAutorun,
     isUnborn,
     useBYOI,
     initialConversation,
@@ -225,10 +249,10 @@ export const CreateTaskModal = observer(function CreateTaskModal({
         <ChevronRight className="size-3.5 text-foreground-passive" />
         <DialogTitle>Create Task</DialogTitle>
       </DialogHeader>
-      <DialogContentArea className="gap-4">
+      <div className="px-6 pb-2 pt-1">
         <ToggleGroup
           className="w-full"
-          value={[selectedStrategy]}
+          value={[selectedStrategy === 'autorun' ? 'from-issue' : selectedStrategy]}
           onValueChange={([value]) => {
             if (value) {
               setSelectedStrategy(value as CreateTaskStrategy);
@@ -236,15 +260,17 @@ export const CreateTaskModal = observer(function CreateTaskModal({
           }}
         >
           <ToggleGroupItem className="flex-1" value="from-branch">
-            From Branch
+            Branch
           </ToggleGroupItem>
           <ToggleGroupItem className="flex-1" value="from-issue">
-            From Issue
+            Issue
           </ToggleGroupItem>
           <ToggleGroupItem className="flex-1" value="from-pull-request">
-            From Pull Request
+            Pull Request
           </ToggleGroupItem>
         </ToggleGroup>
+      </div>
+      <DialogContentArea className="gap-4">
         {isWorkspaceProviderEnabled && (
           <div className="flex items-center gap-2">
             <Switch size="sm" checked={useBYOI} onCheckedChange={setUseBYOI} />
@@ -262,18 +288,49 @@ export const CreateTaskModal = observer(function CreateTaskModal({
               connectionId={connectionId}
             />
           )}
-          {selectedStrategy === 'from-issue' && (
-            <FromIssueContent
-              state={fromIssue}
-              projectId={selectedProjectId}
-              currentBranch={currentBranch}
-              repositoryUrl={repositoryUrl}
-              projectPath={projectData?.path}
-              disabled={isTransitioning}
-              isUnborn={isUnborn}
-              initialConversation={initialConversation}
-              connectionId={connectionId}
-            />
+          {(selectedStrategy === 'from-issue' || selectedStrategy === 'autorun') && (
+            <div className="flex flex-col gap-4">
+              <ToggleGroup
+                className="w-full"
+                value={[selectedStrategy]}
+                onValueChange={([value]) => {
+                  if (value === 'from-issue' || value === 'autorun') {
+                    setSelectedStrategy(value);
+                  }
+                }}
+              >
+                <ToggleGroupItem className="flex-1" value="from-issue">
+                  Single issue
+                </ToggleGroupItem>
+                <ToggleGroupItem className="flex-1" value="autorun">
+                  Autorun issues
+                </ToggleGroupItem>
+              </ToggleGroup>
+              {selectedStrategy === 'from-issue' ? (
+                <FromIssueContent
+                  state={fromIssue}
+                  projectId={selectedProjectId}
+                  currentBranch={currentBranch}
+                  repositoryUrl={repositoryUrl}
+                  projectPath={projectData?.path}
+                  disabled={isTransitioning}
+                  isUnborn={isUnborn}
+                  initialConversation={initialConversation}
+                  connectionId={connectionId}
+                />
+              ) : (
+                <FromAutorunContent
+                  state={fromAutorun}
+                  projectId={selectedProjectId}
+                  currentBranch={currentBranch}
+                  repositoryUrl={repositoryUrl}
+                  projectPath={projectData?.path}
+                  isUnborn={isUnborn}
+                  initialConversation={initialConversation}
+                  connectionId={connectionId}
+                />
+              )}
+            </div>
           )}
           {selectedStrategy === 'from-pull-request' && (
             <div className="flex flex-col gap-3">
@@ -296,7 +353,9 @@ export const CreateTaskModal = observer(function CreateTaskModal({
       </DialogContentArea>
       <DialogFooter>
         <ConfirmButton size="sm" onClick={handleCreateTask} disabled={!canCreate}>
-          Create
+          {selectedStrategy === 'autorun'
+            ? `Run ${fromAutorun.selectedIssues.length} task${fromAutorun.selectedIssues.length === 1 ? '' : 's'}`
+            : 'Create'}
         </ConfirmButton>
       </DialogFooter>
     </>

--- a/src/renderer/features/tasks/create-task-modal/from-autorun-content.tsx
+++ b/src/renderer/features/tasks/create-task-modal/from-autorun-content.tsx
@@ -1,0 +1,244 @@
+import { Loader2, Search } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { useEffect, useRef, useState } from 'react';
+import type { Issue } from '@shared/tasks';
+import {
+  ISSUE_PROVIDER_META,
+  ISSUE_PROVIDER_ORDER,
+} from '@renderer/features/integrations/issue-provider-meta';
+import {
+  ConnectIssueIntegrationPlaceholder,
+  ProviderLogo,
+} from '@renderer/features/tasks/components/issue-selector/issue-selector';
+import { getLinkedIssueMap } from '@renderer/features/tasks/components/issue-selector/use-linked-issue-urls';
+import { useIssueSearch } from '@renderer/features/tasks/components/issue-selector/useIssueSearch';
+import { Checkbox } from '@renderer/lib/ui/checkbox';
+import { Field, FieldLabel } from '@renderer/lib/ui/field';
+import { Input } from '@renderer/lib/ui/input';
+import {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupInput,
+} from '@renderer/lib/ui/input-group';
+import { Select, SelectContent, SelectItem, SelectTrigger } from '@renderer/lib/ui/select';
+import { Switch } from '@renderer/lib/ui/switch';
+import { Textarea } from '@renderer/lib/ui/textarea';
+import { BranchPickerField } from './branch-picker-field';
+import {
+  InitialConversationField,
+  type InitialConversationState,
+} from './initial-conversation-section';
+import { type FromAutorunModeState } from './use-from-autorun-mode';
+
+interface FromAutorunContentProps {
+  state: FromAutorunModeState;
+  projectId?: string;
+  currentBranch?: string | null;
+  repositoryUrl?: string;
+  projectPath?: string;
+  isUnborn?: boolean;
+  initialConversation: InitialConversationState;
+  connectionId?: string;
+}
+
+export const FromAutorunContent = observer(function FromAutorunContent({
+  state,
+  projectId,
+  currentBranch,
+  repositoryUrl = '',
+  projectPath = '',
+  isUnborn,
+  initialConversation,
+  connectionId,
+}: FromAutorunContentProps) {
+  const {
+    issues,
+    issueProvider,
+    hasAnyIntegration,
+    isProviderLoading,
+    isProviderDisabled,
+    setSelectedIssueProvider,
+    handleSetSearchTerm,
+  } = useIssueSearch(repositoryUrl, projectPath, projectId);
+
+  const linkedIssueMap = getLinkedIssueMap(projectId);
+
+  const [query, setQuery] = useState('');
+  const handleQueryChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setQuery(e.target.value);
+    handleSetSearchTerm(e.target.value);
+  };
+
+  // Auto-select all unlinked issues the first time issues arrive for a given provider.
+  // Tracks last seen (provider + url set) so switching provider re-applies the default.
+  const initializedFor = useRef<string | null>(null);
+  useEffect(() => {
+    if (!issueProvider) return;
+    const key = `${issueProvider}:${issues.map((i) => i.url).join(',')}`;
+    if (initializedFor.current === key) return;
+    if (issues.length === 0) return;
+    initializedFor.current = key;
+    const unlinked = issues.filter((i) => !linkedIssueMap.has(i.url));
+    state.setSelectedIssues(unlinked);
+    // We intentionally re-run when the issue list shape changes; linkedIssueMap is computed each render.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [issueProvider, issues]);
+
+  if (!hasAnyIntegration) {
+    return <ConnectIssueIntegrationPlaceholder />;
+  }
+
+  const selectedUrls = new Set(state.selectedIssues.map((i) => i.url));
+  const allChecked = issues.length > 0 && issues.every((i) => selectedUrls.has(i.url));
+  const someChecked = issues.some((i) => selectedUrls.has(i.url)) && !allChecked;
+
+  const toggleIssue = (issue: Issue, checked: boolean) => {
+    const next = new Map(state.selectedIssues.map((i) => [i.url, i]));
+    if (checked) next.set(issue.url, issue);
+    else next.delete(issue.url);
+    state.setSelectedIssues(Array.from(next.values()));
+  };
+  const toggleAll = (checked: boolean) => {
+    if (checked) {
+      const merged = new Map(state.selectedIssues.map((i) => [i.url, i]));
+      for (const issue of issues) merged.set(issue.url, issue);
+      state.setSelectedIssues(Array.from(merged.values()));
+    } else {
+      const visible = new Set(issues.map((i) => i.url));
+      state.setSelectedIssues(state.selectedIssues.filter((i) => !visible.has(i.url)));
+    }
+  };
+
+  const isGithub = issueProvider === 'github';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div className="border border-border rounded-md overflow-hidden">
+        <InputGroup className="rounded-none border-0 border-b border-input shadow-none has-[[data-slot=input-group-control]:focus-visible]:ring-0 has-[[data-slot=input-group-control]:focus-visible]:border-input">
+          <InputGroupAddon align="inline-start">
+            {isProviderLoading ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin text-foreground/60" />
+            ) : (
+              <Select
+                value={issueProvider ?? undefined}
+                onValueChange={(v) => v && setSelectedIssueProvider(v as Issue['provider'])}
+              >
+                <SelectTrigger
+                  showChevron={false}
+                  className="h-6 gap-1 border-none bg-transparent px-1.5 shadow-none focus:ring-0"
+                >
+                  {issueProvider ? (
+                    <ProviderLogo provider={issueProvider} className="h-3.5 w-3.5" />
+                  ) : (
+                    <Search className="h-3.5 w-3.5 text-foreground-muted" />
+                  )}
+                </SelectTrigger>
+                <SelectContent>
+                  {ISSUE_PROVIDER_ORDER.map((p) => (
+                    <SelectItem key={p} value={p} disabled={isProviderDisabled(p)}>
+                      <ProviderLogo provider={p} className="h-3.5 w-3.5" />
+                      <span>{ISSUE_PROVIDER_META[p].displayName}</span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
+          </InputGroupAddon>
+          <InputGroupInput
+            value={query}
+            onChange={handleQueryChange}
+            placeholder={`Search ${issueProvider ?? 'issues'}…`}
+          />
+        </InputGroup>
+        <div className="flex items-center gap-3 px-3 py-1.5 border-b border-border bg-background-1 text-xs">
+          <Checkbox
+            checked={allChecked}
+            indeterminate={someChecked}
+            onCheckedChange={(c) => toggleAll(c)}
+          />
+          <span className="text-foreground-muted">
+            {state.selectedIssues.length} of {issues.length} selected
+          </span>
+        </div>
+        <ul className="max-h-60 overflow-auto">
+          {issues.length === 0 && (
+            <li className="px-3 py-4 text-sm text-foreground-muted text-center">
+              {query ? 'No issues match your search.' : `No open issues from ${issueProvider}.`}
+            </li>
+          )}
+          {issues.map((issue) => {
+            const checked = selectedUrls.has(issue.url);
+            const linkedTo = linkedIssueMap.get(issue.url);
+            return (
+              <li
+                key={issue.url}
+                className="flex items-start gap-3 px-3 py-2 border-b border-border last:border-b-0 text-sm"
+              >
+                <Checkbox checked={checked} onCheckedChange={(c) => toggleIssue(issue, c)} />
+                <div className="flex flex-col min-w-0 flex-1">
+                  <div className="flex items-baseline gap-2 min-w-0">
+                    <span className="text-foreground-muted text-xs shrink-0">
+                      {issue.identifier}
+                    </span>
+                    <span className="truncate">{issue.title}</span>
+                  </div>
+                  {linkedTo && (
+                    <span className="text-xs text-foreground-muted mt-0.5">
+                      Already linked to: {linkedTo.taskName}
+                    </span>
+                  )}
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      <BranchPickerField
+        state={state}
+        projectId={projectId}
+        currentBranch={currentBranch}
+        isUnborn={isUnborn}
+      />
+
+      <div className="grid grid-cols-2 gap-4">
+        <Field>
+          <FieldLabel>Concurrency</FieldLabel>
+          <Input
+            type="number"
+            min={1}
+            max={10}
+            value={state.concurrency}
+            onChange={(e) => {
+              const v = Number(e.target.value);
+              if (Number.isFinite(v))
+                state.setConcurrency(Math.max(1, Math.min(10, Math.floor(v))));
+            }}
+          />
+        </Field>
+        <Field>
+          <FieldLabel>
+            {isGithub ? 'Create draft PR on agent exit' : 'Draft PR (GitHub only)'}
+          </FieldLabel>
+          <Switch
+            checked={isGithub ? state.autoCreatePr : false}
+            disabled={!isGithub}
+            onCheckedChange={state.setAutoCreatePr}
+          />
+        </Field>
+      </div>
+
+      <Field>
+        <FieldLabel>Additional context for all agents (optional)</FieldLabel>
+        <Textarea
+          value={state.extraPrompt}
+          onChange={(e) => state.setExtraPrompt(e.target.value)}
+          placeholder="Prepended to each issue's initial prompt"
+          rows={2}
+        />
+      </Field>
+
+      <InitialConversationField state={initialConversation} connectionId={connectionId} />
+    </div>
+  );
+});

--- a/src/renderer/features/tasks/create-task-modal/run-autorun-batch.ts
+++ b/src/renderer/features/tasks/create-task-modal/run-autorun-batch.ts
@@ -1,0 +1,78 @@
+import { toast } from 'sonner';
+import type { AgentProviderId } from '@shared/agent-provider-registry';
+import type { Branch } from '@shared/git';
+import { formatIssueAsPrompt, type Issue } from '@shared/tasks';
+import type { TaskManagerStore } from '@renderer/features/tasks/stores/task-manager';
+import { normalizeTaskName } from '@renderer/utils/taskNames';
+
+export interface AutorunBatchOptions {
+  projectId: string;
+  sourceBranch: Branch;
+  provider: AgentProviderId | null;
+  concurrency: number;
+  autoCreatePr: boolean;
+  extraPromptPrefix?: string;
+}
+
+function buildTaskName(issue: Issue): string {
+  const base = `${issue.identifier ?? ''}-${issue.title ?? 'task'}`;
+  const normalized = normalizeTaskName(base);
+  return normalized || `issue-${Date.now().toString(36)}`;
+}
+
+function buildInitialPrompt(issue: Issue, extraPrefix?: string): string {
+  return formatIssueAsPrompt(issue, extraPrefix?.trim() || undefined);
+}
+
+/**
+ * Runs `taskManager.createTask` for every issue, capped at `concurrency` in flight.
+ * Each `createTask` resolves only after provisioning completes, so the workers
+ * naturally rate-limit concurrent worktree setups.
+ */
+export async function runAutorunBatch(
+  taskManager: TaskManagerStore,
+  issues: Issue[],
+  opts: AutorunBatchOptions
+): Promise<{ started: number; failed: number }> {
+  const queue = [...issues];
+  let started = 0;
+  let failed = 0;
+  const workers = Array.from({ length: Math.max(1, opts.concurrency) }, async () => {
+    while (queue.length > 0) {
+      const issue = queue.shift();
+      if (!issue) break;
+      const taskName = buildTaskName(issue);
+      const taskId = crypto.randomUUID();
+      try {
+        await taskManager.createTask({
+          id: taskId,
+          projectId: opts.projectId,
+          name: taskName,
+          sourceBranch: opts.sourceBranch,
+          strategy: { kind: 'new-branch', taskBranch: taskName },
+          linkedIssue: issue,
+          autoCreatePr: opts.autoCreatePr,
+          initialConversation: opts.provider
+            ? {
+                id: crypto.randomUUID(),
+                projectId: opts.projectId,
+                taskId,
+                provider: opts.provider,
+                title: taskName,
+                initialPrompt: buildInitialPrompt(issue, opts.extraPromptPrefix),
+                // Autorun is fire-and-forget: the agent must not pause on permission prompts.
+                autoApprove: true,
+              }
+            : undefined,
+        });
+        started += 1;
+      } catch (error) {
+        failed += 1;
+        const message = error instanceof Error ? error.message : String(error);
+        toast.error(`Task for ${issue.identifier ?? issue.title}: ${message}`);
+      }
+    }
+  });
+  await Promise.all(workers);
+  return { started, failed };
+}

--- a/src/renderer/features/tasks/create-task-modal/use-from-autorun-mode.ts
+++ b/src/renderer/features/tasks/create-task-modal/use-from-autorun-mode.ts
@@ -1,0 +1,51 @@
+import { useState } from 'react';
+import type { Branch } from '@shared/git';
+import type { Issue } from '@shared/tasks';
+import { getProjectSettingsStore } from '@renderer/features/projects/stores/project-selectors';
+import { useBranchSelection } from './use-branch-selection';
+
+export type FromAutorunModeState = ReturnType<typeof useFromAutorunMode>;
+
+export function useFromAutorunMode(
+  selectedProjectId: string | undefined,
+  defaultBranch: Branch | undefined,
+  isUnborn: boolean,
+  currentBranchName?: string | null
+) {
+  const branchSelection = useBranchSelection(
+    selectedProjectId,
+    defaultBranch,
+    isUnborn,
+    currentBranchName
+  );
+  const projectSettings = selectedProjectId
+    ? (getProjectSettingsStore(selectedProjectId)?.settings ?? null)
+    : null;
+  const autorunDefaults = projectSettings?.autorun;
+
+  const [selectedIssues, setSelectedIssues] = useState<Issue[]>([]);
+  const [concurrency, setConcurrency] = useState<number>(autorunDefaults?.concurrency ?? 3);
+  const [autoCreatePr, setAutoCreatePr] = useState<boolean>(
+    autorunDefaults?.defaultCreateDraftPr ?? false
+  );
+  const [extraPrompt, setExtraPrompt] = useState<string>('');
+
+  const isValid =
+    selectedIssues.length > 0 && branchSelection.selectedBranch !== undefined && concurrency >= 1;
+
+  return {
+    ...branchSelection,
+    selectedIssues,
+    setSelectedIssues,
+    concurrency,
+    setConcurrency,
+    autoCreatePr,
+    setAutoCreatePr,
+    extraPrompt,
+    setExtraPrompt,
+    isValid,
+    /** The modal's submit handler needs a taskName for the InitialConversation header; supply a placeholder. */
+    taskName: 'autorun-batch',
+    isPending: false as const,
+  };
+}

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -39,6 +39,7 @@ export type Task = {
   workspaceProvider?: 'byoi';
   workspaceId?: string;
   workspaceProviderData?: string; // JSON, BYOI only
+  autoCreatePr?: boolean;
 };
 
 export type TaskBootstrapStatus =
@@ -76,6 +77,8 @@ export type CreateTaskParams = {
   initialConversation?: CreateConversationParams;
   initialStatus?: TaskLifecycleStatus;
   workspaceProvider?: 'byoi';
+  /** When true, the main process creates a draft PR after the initial agent session exits cleanly. GitHub-only. */
+  autoCreatePr?: boolean;
 };
 
 export type CreateTaskError =


### PR DESCRIPTION
## Summary
- New **Autorun issues** sub-mode inside the Issue tab of the Create Task modal: batch-create tasks from selected open issues, each in its own worktree, with a user-configurable concurrency limit (default 3, max 10)
- Works with any connected issue provider (GitHub, Linear, Jira, GitLab, Forgejo, Plain) via a provider switcher; auto-PR option only enabled for GitHub
- Each agent starts with `autoApprove: true` and the issue body pre-loaded as initial prompt via `formatIssueAsPrompt`
- Optional **auto-create draft PR** when the initial agent session exits cleanly with a non-empty diff (GitHub-only); body uses `Closes #N` + issue description
- Per-project defaults via `.emdash.json` (`autorun.concurrency`, `autorun.defaultCreateDraftPr`)

## Implementation notes
- Concurrency = N async workers pulling from a shared queue, blocking on `taskManager.createTask` (which awaits provisioning). Only worktree setup is rate-limited; agents themselves run independently afterwards.
- New `auto_create_pr` column on `tasks` + Drizzle migration `0009_add_auto_create_pr.sql`. Legacy-port test fixtures updated to match.
- Auto-PR listener in `src/main/core/tasks/auto-create-pr.ts` subscribes to `agentSessionExitedChannel`, clears the flag immediately to prevent duplicate PRs on respawn, then pushes branch + creates draft PR via `prSyncEngine.createPullRequest`.
- `electron.vite.config.ts` now respects `EMDASH_DEV_PORT` env var (default 3000) so dev can run alongside the docs app on a different port.

## Test plan
- [ ] Sidebar **+** → Issue tab → **Autorun issues** sub-toggle: verify unlinked issues are pre-checked, linked ones are not
- [ ] Type in the search box → list filters live
- [ ] Switch provider in the dropdown (only enabled for connected integrations)
- [ ] Set Concurrency to 1, run 3 issues, verify worktrees are created sequentially
- [ ] Set Concurrency to 3, run 5+ issues, verify max 3 worktrees provision in parallel
- [ ] Enable "Create draft PR on agent exit" with a GitHub repo, complete one task, verify draft PR opens with `Closes #N` in body
- [ ] Disable Auto-PR or pick a non-GitHub provider → no PR is created
- [ ] `pnpm run format && pnpm run lint && pnpm run typecheck`

## Known caveats
- Auto-PR fires on PTY exit code 0. Agents running in interactive mode (Claude Code default) require the user to exit the session for the PR to fire. A future headless-mode option would close this gap.
- Tests need `pnpm rebuild better-sqlite3` for system Node and `pnpm run rebuild` for Electron; the cycle is environmental and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)