### PR TITLE
ui: use solid fill for agent status indicator dots

### DIFF
--- a/src/renderer/features/tasks/components/agent-status-indicator.tsx
+++ b/src/renderer/features/tasks/components/agent-status-indicator.tsx
@@ -32,7 +32,7 @@ export function AgentStatusIndicator({
       case 'awaiting-input':
         return (
           <span
-            className={cn('rounded-full bg-blue-200 border size-2 border-blue-500', className)}
+            className={cn('rounded-full bg-blue-500 size-2', className)}
             aria-label="Agent is awaiting input"
             title="Agent is awaiting input"
           />
@@ -40,7 +40,7 @@ export function AgentStatusIndicator({
       case 'error':
         return (
           <span
-            className={cn('rounded-full bg-red-200 border size-2 border-red-500', className)}
+            className={cn('rounded-full bg-red-500 size-2', className)}
             aria-label="Agent error"
             title="Agent error"
           />
@@ -48,7 +48,7 @@ export function AgentStatusIndicator({
       case 'completed':
         return (
           <span
-            className={cn('rounded-full bg-green-200 border size-2 border-green-500', className)}
+            className={cn('rounded-full bg-green-500 size-2', className)}
             aria-label="Agent completed"
             title="Agent completed"
           />


### PR DESCRIPTION
## Summary
- Replace the light fill + border style on agent status indicator dots with a single solid fill color
- Affects the awaiting-input (blue), error (red), and completed (green) indicators

## Test plan
- [ ] Verify the three agent status dots render as solid colored circles in the sidebar and task views
<img width="506" height="150" alt="CleanShot 2026-05-15 at 13 41 20@2x" src="https://github.com/user-attachments/assets/b9d0ab2a-4332-4b9e-91bb-39e1a889c402" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI-only change that adjusts Tailwind classes for status indicators without changing behavior or data flow.
> 
> **Overview**
> Updates the `AgentStatusIndicator` dots for `awaiting-input`, `error`, and `completed` to use a **single solid background color** (`bg-*-500`) instead of the previous light fill plus border styling.
> 
> No functional changes to status logic, tooltip behavior, or the `working` spinner—only the visual appearance of these indicators across all usages.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb969ef4d0dcb09264ce9cc048bb2052ee8a0f28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->