### PR TITLE
feat: render images in PR comments

### DIFF
--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list.tsx
@@ -65,11 +65,7 @@ function CommentItem({ comment }: { comment: PullRequestComment }) {
             comment.isOutdated && 'text-foreground-passive'
           )}
         >
-          <MarkdownRenderer
-            content={comment.body}
-            variant="compact"
-            allowHtml={isBotAuthor(comment)}
-          />
+          <MarkdownRenderer content={comment.body} variant="compact" allowHtml />
         </div>
       </div>
       <button

--- a/src/renderer/lib/editor/image-renderer.tsx
+++ b/src/renderer/lib/editor/image-renderer.tsx
@@ -1,3 +1,5 @@
+import { ContainedImage } from '@renderer/lib/ui/contained-image';
+
 interface ImageRendererProps {
   file: { path: string; content: string };
 }
@@ -8,7 +10,7 @@ export function ImageRenderer({ file }: ImageRendererProps) {
 
   return (
     <div className="flex h-full items-center justify-center overflow-auto p-4">
-      <img src={file.content} alt={fileName} className="max-h-full max-w-full object-contain" />
+      <ContainedImage src={file.content} alt={fileName} className="max-h-full max-w-full" />
     </div>
   );
 }

--- a/src/renderer/lib/editor/svg-renderer.tsx
+++ b/src/renderer/lib/editor/svg-renderer.tsx
@@ -4,6 +4,7 @@ import { useMemo } from 'react';
 import { useWorkspaceViewModel } from '@renderer/features/tasks/task-view-context';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
+import { ContainedImage } from '@renderer/lib/ui/contained-image';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 
 interface SvgRendererProps {
@@ -31,7 +32,7 @@ export const SvgRenderer = observer(function SvgRenderer({ filePath }: SvgRender
   return (
     <div className="relative flex h-full items-center justify-center overflow-auto p-4">
       {svgUrl ? (
-        <img src={svgUrl} alt={fileName} className="max-h-full max-w-full object-contain" />
+        <ContainedImage src={svgUrl} alt={fileName} className="max-h-full max-w-full" />
       ) : (
         <div className="text-xs text-foreground-passive">Loading…</div>
       )}

--- a/src/renderer/lib/ui/contained-image.tsx
+++ b/src/renderer/lib/ui/contained-image.tsx
@@ -1,0 +1,8 @@
+import type React from 'react';
+import { cn } from '@renderer/utils/utils';
+
+type ContainedImageProps = React.ComponentPropsWithoutRef<'img'>;
+
+export function ContainedImage({ className, alt, ...props }: ContainedImageProps) {
+  return <img alt={alt ?? ''} className={cn('object-contain', className)} {...props} />;
+}

--- a/src/renderer/lib/ui/markdown-renderer.tsx
+++ b/src/renderer/lib/ui/markdown-renderer.tsx
@@ -11,6 +11,7 @@ import type { PluggableList } from 'unified';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import { rpc } from '@renderer/lib/ipc';
 import { cn } from '@renderer/utils/utils';
+import { ContainedImage } from './contained-image';
 import { normalizeLatexDelimiters } from './markdown-latex';
 import { MermaidDiagram } from './mermaid-diagram';
 
@@ -100,7 +101,7 @@ const ResolvedImage: React.FC<{
       <span className="my-3 inline-block text-xs text-muted-foreground">Loading image...</span>
     );
   }
-  return <img src={dataUrl} alt={alt} className="my-3 max-w-full rounded" />;
+  return <ContainedImage src={dataUrl} alt={alt} className="my-3 max-w-full rounded" />;
 };
 
 type WithChildren = { children?: React.ReactNode };
@@ -240,7 +241,7 @@ function useFullComponents(
         if (!isExternal && resolveImage && src) {
           return <ResolvedImage src={src} alt={alt || ''} resolveImage={resolveImage} />;
         }
-        return <img src={src} alt={alt || ''} className="my-3 max-w-full rounded" />;
+        return <ContainedImage src={src} alt={alt || ''} className="my-3 max-w-full rounded" />;
       },
       strong: ({ children }: WithChildren) => (
         <strong className="font-semibold text-foreground">{children}</strong>
@@ -322,6 +323,13 @@ function useCompactComponents(isDark: boolean) {
           </a>
         );
       },
+      img: ({ src, alt }: ImgProps) => (
+        <ContainedImage
+          src={src}
+          alt={alt || ''}
+          className="my-2 h-auto max-h-80 max-w-full rounded"
+        />
+      ),
     }),
     [isDark]
   );

--- a/src/renderer/tests/markdown-renderer.test.ts
+++ b/src/renderer/tests/markdown-renderer.test.ts
@@ -1,0 +1,49 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { MarkdownRenderer } from '@renderer/lib/ui/markdown-renderer';
+
+vi.mock('@renderer/lib/hooks/useTheme', () => ({
+  useTheme: () => ({ effectiveTheme: 'emlight' }),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    app: {
+      openExternal: vi.fn(),
+    },
+  },
+}));
+
+describe('MarkdownRenderer', () => {
+  it('constrains markdown images in compact rendering', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MarkdownRenderer, {
+        content: '![Screenshot](https://example.com/screenshot.png)',
+        variant: 'compact',
+      })
+    );
+
+    expect(html).toContain('src="https://example.com/screenshot.png"');
+    expect(html).toContain('alt="Screenshot"');
+    expect(html).toContain('max-w-full');
+    expect(html).toContain('max-h-80');
+    expect(html).toContain('object-contain');
+  });
+
+  it('constrains allowed HTML images in compact rendering', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MarkdownRenderer, {
+        allowHtml: true,
+        content: '<img src="https://example.com/preview.png" alt="Preview">',
+        variant: 'compact',
+      })
+    );
+
+    expect(html).toContain('src="https://example.com/preview.png"');
+    expect(html).toContain('alt="Preview"');
+    expect(html).toContain('max-w-full');
+    expect(html).toContain('max-h-80');
+    expect(html).toContain('object-contain');
+  });
+});

--- a/src/renderer/tests/pr-comments-list.test.ts
+++ b/src/renderer/tests/pr-comments-list.test.ts
@@ -1,0 +1,60 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import type { PullRequestComment } from '@shared/pull-requests';
+import { CommentsList } from '@renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list';
+
+vi.mock('@renderer/lib/hooks/useTheme', () => ({
+  useTheme: () => ({ effectiveTheme: 'emlight' }),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    app: {
+      openExternal: vi.fn(),
+    },
+  },
+}));
+
+function makeComment(body: string): PullRequestComment {
+  return {
+    id: 'issue-comment:1',
+    pullRequestUrl: 'https://github.com/org/repo/pull/1',
+    kind: 'issue',
+    body,
+    url: 'https://github.com/org/repo/pull/1#issuecomment-1',
+    author: {
+      userId: '1',
+      userName: 'arnestrickmann',
+      displayName: 'Arne Strickmann',
+      avatarUrl: null,
+      url: 'https://github.com/arnestrickmann',
+      userUpdatedAt: null,
+      userCreatedAt: null,
+    },
+    path: null,
+    line: null,
+    isResolved: false,
+    isOutdated: false,
+    createdAt: '2026-05-16T00:00:00Z',
+    updatedAt: '2026-05-16T00:00:00Z',
+  };
+}
+
+describe('CommentsList', () => {
+  it('renders HTML image comments from non-bot authors', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(CommentsList, {
+        comments: [
+          makeComment('<img width="944" alt="Image" src="https://github.com/user/image.png">'),
+        ],
+      })
+    );
+
+    expect(html).toContain('src="https://github.com/user/image.png"');
+    expect(html).toContain('alt="Image"');
+    expect(html).toContain('max-w-full');
+    expect(html).toContain('max-h-80');
+    expect(html).toContain('object-contain');
+  });
+});


### PR DESCRIPTION
## Summary
- Render PR comment images in the right sidebar by allowing sanitized HTML comments.
- Share contained image styling across markdown, raster image, and SVG previews.
- Add coverage for compact markdown images and non-bot HTML image PR comments.

## Linear
https://linear.app/general-action/issue/ENG-1300/render-images-correctly-in-pr-comments-section

## Validation
- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm run test
