### PR TITLE
fix(pty): direct-spawn Windows .cmd shims when path contains spaces

### DIFF
--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -70,6 +70,55 @@ describe('resolveLocalPtySpawn - Windows', () => {
     });
   });
 
+  it('direct-spawns extensionless commands that resolve to .cmd shims under paths with spaces', () => {
+    // Regression for npm globals installed under `C:\Program Files\nodejs`:
+    // the cmd.exe wrapper used to fail with `'"C:\Program Files\nodejs\codex.CMD"'
+    // is not recognized as an internal or external command`.
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: {
+        ...winEnv,
+        Path: 'C:\\Program Files\\nodejs',
+      },
+      fileExists: (candidate) => candidate === 'C:\\Program Files\\nodejs\\codex.CMD',
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'codex', args: ['--version'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Program Files\\nodejs\\codex.CMD',
+      args: ['--version'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('direct-spawns .cmd argv commands when the absolute command path contains spaces', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: {
+          kind: 'argv',
+          command: 'C:\\Program Files\\nodejs\\codex.cmd',
+          args: ['--version'],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Program Files\\nodejs\\codex.cmd',
+      args: ['--version'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
   it('direct-spawns extensionless commands that resolve to exe files', () => {
     const result = resolveLocalPtySpawn({
       platform: 'win32',

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -156,6 +156,15 @@ function resolveWindowsSpawn(
   const ext = path.win32.extname(resolvedCommand).toLowerCase();
 
   if (ext === '.cmd' || ext === '.bat') {
+    // When the resolved shim path contains whitespace (e.g. npm globals under
+    // `C:\Program Files\nodejs`), wrapping through `cmd.exe /d /s /c "..."`
+    // breaks because node-pty's argv escaping mangles the inner quotes and
+    // cmd.exe ends up trying to run `'"C:\Program Files\nodejs\codex.CMD"'`
+    // (quotes preserved literally). Spawn the shim directly — node-pty handles
+    // .cmd/.bat invocation on Windows correctly when given the absolute path.
+    if (/\s/.test(resolvedCommand)) {
+      return { command: resolvedCommand, args, cwd: intent.cwd, warnings };
+    }
     return {
       command: shell,
       args: ['/d', '/s', '/c', [resolvedCommand, ...args].map(quoteForCmdExe).join(' ')],


### PR DESCRIPTION
## Problem

Fixes #1927.

On Windows, when the npm global `codex.cmd` shim is installed under `%ProgramFiles%\nodejs` (or any path with a space), Codex provider startup fails with:

```
'"C:\Program Files\nodejs\codex.CMD"' is not recognized as an internal or external command,
operable program or batch file.
```

The same `codex` command works fine from a regular terminal.

## Root cause

`resolveWindowsSpawn` wraps `.cmd` / `.bat` shims through `cmd.exe /d /s /c "<quoted path> <args>"`. When the resolved shim path contains whitespace (e.g. `C:\Program Files\nodejs\codex.CMD`), `quoteForCmdExe` adds quotes around it, and the resulting `/c` argument needs to round-trip through node-pty's Windows argv escaping into `cmd.exe`'s own non-standard quote parsing. That round-trip mangles the inner quotes — `cmd.exe` ends up treating `"C:\Program Files\nodejs\codex.CMD"` (with the quotes) as the literal command name and fails to resolve it.

The issue author confirmed empirically that `pty.spawn("C:\\Program Files\\nodejs\\codex.cmd", ["--version"], …)` works directly — node-pty handles `.cmd` / `.bat` invocation on Windows correctly when given the absolute shim path.

## Solution

In `pty-spawn-platform.ts`, when the resolved `.cmd` / `.bat` path contains whitespace, skip the `cmd.exe /d /s /c` wrapper and spawn the shim directly. Paths without whitespace keep the existing wrapping behavior, so nothing changes for `pnpm.cmd`, `npm.cmd`, or shims under standard user-profile install locations (e.g. `C:\Users\<user>\AppData\Roaming\npm`).

This is the surgical fix the issue author suggested ("Avoid wrapping Windows `.cmd` / `.bat` shims through `cmd.exe /s /c` when `node-pty` can launch the `.cmd` file directly") scoped to the path-with-spaces case only.

## Testing

- `pnpm exec vitest run src/main/core/pty/pty-spawn-platform.test.ts` — all 15 tests pass (13 existing + 2 new regression tests for the Program Files case).
- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` — clean.

Added two regression tests covering both code paths into the `.cmd` branch:
- extensionless `codex` resolved via PATH to `C:\Program Files\nodejs\codex.CMD`
- explicit absolute `C:\Program Files\nodejs\codex.cmd` argv command

Manual Windows verification would still be valuable — I don't have a Windows environment, but the new test mirrors the exact path the issue reporter pasted, and the resulting spawn shape matches their working `pty.spawn(...)` example.