### PR TITLE
feat: emdash MCP server

### DIFF
--- a/agents/integrations/mcp.md
+++ b/agents/integrations/mcp.md
@@ -1,6 +1,15 @@
 # MCP
 
-## Main Files
+emdash interacts with the Model Context Protocol in two directions:
+
+- **Outbound** — emdash configures MCP servers for the agents it spawns (Claude
+  Code, Cursor, Codex). Documented under "Outbound" below.
+- **Inbound** — emdash exposes its own MCP server so external agents can drive
+  it. Documented under "Inbound" below.
+
+## Outbound: emdash configuring agent MCP servers
+
+### Main Files
 
 - `src/main/core/mcp/services/McpService.ts`
 - `src/main/core/mcp/utils/` — adapters, catalog, config IO, config paths, conversion
@@ -9,18 +18,116 @@
 - `src/renderer/components/mcp/`
 - `src/renderer/views/mcp-view.tsx`
 
-## Current Behavior
+### Current Behavior
 
 - MCP server configs are read, adapted, merged, and written across supported agent ecosystems
 - provider-specific config formats are handled through adapters in `src/main/core/mcp/utils/`
 - the renderer MCP UI manages installed servers and catalog entries
 
-## Important Constraint
+### Important Constraint
 
 - Codex currently supports stdio MCP servers only
 
-## Rules
+### Rules
 
 - do not assume all providers support the same MCP transport types
 - keep canonical MCP data in shared types and adapt at the edges
 - if you add provider-specific MCP behavior, update both service and UI compatibility handling
+
+## Inbound: emdash as an MCP server
+
+emdash also runs its own MCP server so external AI agents (Claude Code, Cursor,
+Codex, etc.) can drive emdash from the outside — creating tasks, managing
+projects, registering MCP servers and skills, and observing/writing to live
+PTY sessions. This is the inverse of the outbound integration above. Full
+design lives in `docs/superpowers/specs/2026-05-16-mcp-server-design.md`.
+
+### Enabling
+
+Settings → MCP Server → toggle on. Defaults:
+
+- Bind: `127.0.0.1:7457` (loopback only).
+- Auth: auto-generated bearer token persisted at `~/.emdash/mcp.json` with mode
+  `0600`. Rotatable from Settings.
+- Off by default; the toggle is stored in `appSettings.mcpServer.enabled`.
+
+### Architecture
+
+```
+external MCP client (Claude Code, Cursor, Codex)
+        │  stdio
+        ▼
+emdash-mcp                  (bin/emdash-mcp.ts — stdio bridge subprocess)
+        │  HTTP + Authorization: Bearer <token>
+        ▼
+McpHttpServer               (127.0.0.1:<port>, loopback only)
+        │
+        ▼
+McpServer                   (@modelcontextprotocol/sdk)
+        │
+        ▼
+Existing operation functions  (createTask, addProject, …)
+```
+
+External clients spawn the standalone `emdash-mcp` stdio bridge; the bridge
+reads `~/.emdash/mcp.json` and proxies JSON-RPC over loopback HTTP to the
+in-process `McpHttpServer`. The HTTP server is loopback-only and enforces a
+`Host`-header check to mitigate DNS rebinding.
+
+### Main Files
+
+- `src/main/core/mcp-server/service.ts` — singleton lifecycle (`IInitializable` / `IDisposable`); reconciles `appSettings.mcpServer.{enabled,port}`
+- `src/main/core/mcp-server/http-server.ts` — loopback HTTP transport, bearer auth, Host-header check, per-session `StreamableHTTPServerTransport`
+- `src/main/core/mcp-server/server.ts` — constructs the SDK `McpServer` and wires the tool + resource registries
+- `src/main/core/mcp-server/token-store.ts` — read / write / rotate `~/.emdash/mcp.json` (mode 0600)
+- `src/main/core/mcp-server/recent-calls.ts` — in-memory ring buffer of the last 200 tool invocations
+- `src/main/core/mcp-server/controller.ts` — renderer-facing RPC controller (`getStatus`, `setEnabled`, `setPort`, `rotateToken`, `getRecentCalls`)
+- `src/main/core/mcp-server/tools/` — `task-tools`, `project-tools`, `mcp-tools`, `skill-tools`, `worktree-tools`, `system-tools`
+- `src/main/core/mcp-server/resources/` — `project-resource`, `task-resource`, `task-session-resource` (PTY) + `pty-mcp-adapter`
+- `bin/emdash-mcp.ts` — standalone Node entrypoint that bridges stdio ↔ HTTP
+
+### Tool catalog (summary)
+
+One-line summary per group — see the design spec for the full per-tool reference.
+
+- **Tasks** — create / list / get / update / delete / archive / unarchive / sendInput / getOutput / listSessions / openInIDE
+- **Projects** — add / list / get / updateSettings / delete
+- **MCP servers** (the outbound ones emdash configures for agents) — list / add / remove
+- **Skills** — list / installFromCatalog / createCustom / uninstall
+- **Worktrees** — openInIDE
+- **System** — listEditors / health
+
+### Resources
+
+Resources let an MCP client subscribe to live state instead of polling.
+
+- `emdash://projects` — all projects; subscribe for add/remove
+- `emdash://projects/{id}/tasks` — tasks in a project; subscribe for create/update/archive/delete
+- `emdash://tasks/{id}` — single-task detail; subscribe for status/PR/metadata changes
+- `emdash://tasks/{id}/sessions/{sid}` — PTY session: `read` returns the current 64 KB ring-buffer snapshot + cursor, `subscribe` streams live output deltas
+- `emdash://mcp-servers` — configured outbound MCP servers across providers; subscribe for config-file changes
+- `emdash://skills` — installed + catalog skills; subscribe for install/uninstall
+
+### Safety notes
+
+- **Destructive tools require `confirm: true`** — `task.delete`, `project.delete`, `mcp.remove`, `skill.uninstall`. Without it the tool returns a structured "would delete X" error instead of touching state.
+- **Loopback only** — `McpHttpServer` binds explicitly to `127.0.0.1`; never `0.0.0.0` or a public address.
+- **Host-header check** — requests whose `Host` is not `127.0.0.1:<port>` or `localhost:<port>` get HTTP 421. This mitigates browser-based DNS-rebinding attacks.
+- **Token file permissions** — `~/.emdash/mcp.json` is written at mode `0600`; the service warns at startup if it has been clobbered to something more permissive.
+- **Token rotation** — Settings → MCP Server → rotate token regenerates the bearer, rewrites the file, and restarts the HTTP server so active sessions reconnect with the new token.
+
+### For agent authors using this MCP server
+
+Configure your MCP client by copy-pasting the provider-specific snippet from
+Settings → MCP Server → Connection (Claude Code, Cursor, Codex have different
+config shapes — the UI emits the right one for each). The snippet points the
+client at the `emdash-mcp` bridge binary; no manual token wiring is needed
+because the bridge reads `~/.emdash/mcp.json` directly.
+
+### Rules
+
+- Don't add network listeners outside `127.0.0.1`; loopback-only is a security invariant.
+- New tools belong in `src/main/core/mcp-server/tools/` and must be aggregated in `tools/index.ts`. Mark destructive tools as requiring `confirm: true`.
+- New resources belong in `src/main/core/mcp-server/resources/` and must be aggregated in `resources/index.ts`.
+- Tools call existing operation functions in-process — don't duplicate business logic; reuse the `Result<T, E>` shape.
+- The same `McpServer` instance is shared across all HTTP sessions; transports are tracked per-session via `onsessioninitialized` (see `http-server.ts`).

--- a/bin/emdash-mcp.test.ts
+++ b/bin/emdash-mcp.test.ts
@@ -1,0 +1,300 @@
+/**
+ * Tests for `bin/emdash-mcp.ts` — the stdio bridge that external MCP clients
+ * (Claude Code, Cursor, Codex) spawn to talk to a running emdash app.
+ *
+ * Strategy: **unit tests + in-memory end-to-end** (NOT subprocess smoke).
+ *
+ * The spec (T9) suggested a subprocess smoke test as the primary approach
+ * with a unit-test fallback if it turned out flaky. We took the unit route
+ * up-front because:
+ *
+ *  1. The subprocess approach requires either a built `out/main/emdash-mcp.js`
+ *     (electron-vite build step before the test runs — slow, not free in CI)
+ *     or `node --experimental-strip-types bin/emdash-mcp.ts` (works locally
+ *     on Node 22+ but `bin/emdash-mcp.ts` imports from `../src/...`, which
+ *     itself transitively imports vite-only `import.meta.env` — strip-types
+ *     can't transform that).
+ *  2. The bridge's interesting behaviour — request forwarding, notification
+ *     forwarding, retries on connect, graceful shutdown — is exercised more
+ *     directly by wiring two SDK `Server`s and a `Client` together via
+ *     `InMemoryTransport.createLinkedPair()`. The wire-format ping-pong is
+ *     already covered by the SDK's own test suite.
+ *
+ * What we cover:
+ *
+ *  - `resolveBridgeConfig`: token-file present / missing / port override.
+ *  - `buildMcpUrl`: loopback enforcement.
+ *  - `connectHttpWithRetry`: backoff + max-attempt behaviour.
+ *  - `installPassthroughHandlers`: request relay end-to-end against a stub
+ *    "upstream" `McpServer`.
+ *  - `installNotificationForwarder`: notification relay end-to-end.
+ */
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  CallToolResultSchema,
+  ListToolsRequestSchema,
+  ListToolsResultSchema,
+  ResourceUpdatedNotificationSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { z } from 'zod';
+import { __setEmdashDirForTests, writeTokenFile } from '../src/main/core/mcp-server/token-store';
+import {
+  buildMcpUrl,
+  connectHttpWithRetry,
+  createStdioServer,
+  installNotificationForwarder,
+  installPassthroughHandlers,
+  resolveBridgeConfig,
+} from './emdash-mcp';
+
+let tempDir: string;
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'emdash-mcp-bridge-'));
+  __setEmdashDirForTests(tempDir);
+});
+
+afterEach(async () => {
+  __setEmdashDirForTests(null);
+  await rm(tempDir, { recursive: true, force: true }).catch(() => undefined);
+});
+
+describe('resolveBridgeConfig', () => {
+  it('returns ok with the port + token from ~/.emdash/mcp.json', async () => {
+    await writeTokenFile({ version: 1, port: 7457, token: 'test-token-1' });
+    const result = await resolveBridgeConfig({});
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.config).toEqual({ port: 7457, token: 'test-token-1' });
+  });
+
+  it('falls back to a friendly diagnostic when no token file exists', async () => {
+    const result = await resolveBridgeConfig({});
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    // The diagnostic must mention the file path so users know what to fix.
+    expect(result.reason).toContain('mcp.json');
+  });
+
+  it('honours EMDASH_MCP_PORT when set', async () => {
+    await writeTokenFile({ version: 1, port: 7457, token: 'test-token-1' });
+    const result = await resolveBridgeConfig({ EMDASH_MCP_PORT: '12345' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.config.port).toBe(12345);
+    // Token still comes from the file.
+    expect(result.config.token).toBe('test-token-1');
+  });
+
+  it('rejects a non-numeric EMDASH_MCP_PORT by falling back to the file value', async () => {
+    await writeTokenFile({ version: 1, port: 7457, token: 'test-token-1' });
+    const result = await resolveBridgeConfig({ EMDASH_MCP_PORT: 'not-a-port' });
+    expect(result.ok).toBe(true);
+    if (!result.ok) throw new Error('expected ok');
+    expect(result.config.port).toBe(7457);
+  });
+
+  it('rejects a port outside 1..65535', async () => {
+    await writeTokenFile({ version: 1, port: 7457, token: 'test-token-1' });
+    const result = await resolveBridgeConfig({ EMDASH_MCP_PORT: '70000' });
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.reason).toMatch(/invalid mcp port/i);
+  });
+
+  it('rejects a malformed token file with a friendly diagnostic', async () => {
+    // Write garbage directly so we bypass `writeTokenFile`'s validation.
+    await writeFile(join(tempDir, 'mcp.json'), 'not valid json', 'utf8');
+    const result = await resolveBridgeConfig({});
+    expect(result.ok).toBe(false);
+    if (result.ok) throw new Error('expected error');
+    expect(result.reason).toContain('mcp.json');
+  });
+});
+
+describe('buildMcpUrl', () => {
+  it('always uses 127.0.0.1, never anything from the token file', () => {
+    // Even if a future revision tried to inject a host, this signature
+    // doesn't accept one — that's the security invariant we're locking in.
+    const url = buildMcpUrl(7457);
+    expect(url.hostname).toBe('127.0.0.1');
+    expect(url.protocol).toBe('http:');
+    expect(url.pathname).toBe('/mcp');
+    expect(url.port).toBe('7457');
+  });
+});
+
+describe('connectHttpWithRetry', () => {
+  it('retries up to maxAttempts before giving up', async () => {
+    // Use a port that is ~certain to refuse connections (RFC 6335 reserves
+    // 1; nothing should be listening on 127.0.0.1:1 in test environments).
+    const onAttempt = vi.fn();
+    await expect(
+      connectHttpWithRetry(
+        { port: 1, token: 'irrelevant' },
+        { maxAttempts: 3, initialBackoffMs: 5, onAttempt }
+      )
+    ).rejects.toBeInstanceOf(Error);
+    // Three failed attempts should have been recorded (each with an error).
+    expect(onAttempt).toHaveBeenCalledTimes(3);
+    for (const call of onAttempt.mock.calls) {
+      expect(call[1]).toBeInstanceOf(Error);
+    }
+  });
+});
+
+/**
+ * Integration: wire the bridge handlers between an "upstream" stub
+ * `McpServer` (using `InMemoryTransport`) and a "downstream" test `Client`
+ * (also `InMemoryTransport`). The bridge is in the middle: we use a real
+ * `Client` (upstream-facing) and a real `Server` (downstream-facing) and
+ * call `installPassthroughHandlers` / `installNotificationForwarder` exactly
+ * as `runBridge` does.
+ */
+describe('passthrough request handlers (in-memory end-to-end)', () => {
+  it('relays tools/list and tools/call to the upstream', async () => {
+    // ── 1. Upstream stub server (registers a single `echo` tool). ──
+    const upstream = new McpServer({ name: 'stub-emdash', version: '0.0.0' });
+    upstream.registerTool(
+      'echo',
+      {
+        description: 'Echoes the input text back.',
+        inputSchema: { text: z.string() },
+      },
+      async ({ text }) => ({
+        content: [{ type: 'text', text }],
+      })
+    );
+
+    // ── 2. Bridge's HTTP-side `Client` ↔ upstream over linked in-memory pair. ──
+    const [bridgeClientTransport, upstreamServerTransport] = InMemoryTransport.createLinkedPair();
+    const bridgeClient = new Client({ name: 'bridge-test', version: '1' }, { capabilities: {} });
+    await Promise.all([
+      bridgeClient.connect(bridgeClientTransport),
+      upstream.connect(upstreamServerTransport),
+    ]);
+
+    // ── 3. Bridge's stdio-side `Server` ↔ test `Client` over a linked pair. ──
+    const bridgeServer = createStdioServer();
+    installPassthroughHandlers(bridgeServer, bridgeClient);
+
+    const [downstreamClientTransport, bridgeServerTransport] = InMemoryTransport.createLinkedPair();
+    const downstreamClient = new Client(
+      { name: 'downstream-test', version: '1' },
+      { capabilities: {} }
+    );
+    await Promise.all([
+      bridgeServer.connect(bridgeServerTransport),
+      downstreamClient.connect(downstreamClientTransport),
+    ]);
+
+    try {
+      // ── 4. Drive a `tools/list` request through the bridge. ──
+      const tools = await downstreamClient.request(
+        { method: 'tools/list', params: {} },
+        ListToolsResultSchema
+      );
+      expect(tools.tools.map((t) => t.name)).toContain('echo');
+
+      // ── 5. Drive a `tools/call` request through the bridge. ──
+      const callResult = await downstreamClient.request(
+        {
+          method: 'tools/call',
+          params: { name: 'echo', arguments: { text: 'hello bridge' } },
+        },
+        CallToolResultSchema
+      );
+      expect(callResult.content?.[0]).toMatchObject({ type: 'text', text: 'hello bridge' });
+    } finally {
+      await Promise.allSettled([
+        downstreamClient.close(),
+        bridgeServer.close(),
+        bridgeClient.close(),
+        upstream.close(),
+      ]);
+    }
+  });
+});
+
+describe('notification forwarder (in-memory end-to-end)', () => {
+  it('relays an upstream `notifications/resources/updated` to the downstream client', async () => {
+    // ── Upstream stub: a low-level `Server` so we can call `.notification` directly. ──
+    // We need the low-level Server (not McpServer) because McpServer doesn't
+    // expose a generic notification sender for arbitrary methods.
+    const { Server: LowLevelServer } = await import('@modelcontextprotocol/sdk/server/index.js');
+    const upstream = new LowLevelServer(
+      { name: 'stub-emdash', version: '0.0.0' },
+      {
+        capabilities: {
+          tools: {},
+          resources: { subscribe: true, listChanged: true },
+        },
+      }
+    );
+    // The upstream needs at least one request handler so its capability set
+    // is honoured by the SDK's initialize negotiation.
+    upstream.setRequestHandler(ListToolsRequestSchema, async () => ({ tools: [] }));
+
+    // Bridge HTTP-side client ↔ upstream
+    const [bridgeClientTransport, upstreamServerTransport] = InMemoryTransport.createLinkedPair();
+    const bridgeClient = new Client({ name: 'bridge-test', version: '1' }, { capabilities: {} });
+    await Promise.all([
+      bridgeClient.connect(bridgeClientTransport),
+      upstream.connect(upstreamServerTransport),
+    ]);
+
+    // Bridge stdio-side server ↔ downstream test client
+    const bridgeServer = createStdioServer();
+    installPassthroughHandlers(bridgeServer, bridgeClient);
+    installNotificationForwarder(bridgeServer, bridgeClient);
+
+    const [downstreamClientTransport, bridgeServerTransport] = InMemoryTransport.createLinkedPair();
+    const downstreamClient = new Client(
+      { name: 'downstream-test', version: '1' },
+      { capabilities: {} }
+    );
+    await Promise.all([
+      bridgeServer.connect(bridgeServerTransport),
+      downstreamClient.connect(downstreamClientTransport),
+    ]);
+
+    try {
+      // Capture forwarded notifications on the downstream client.
+      const received: unknown[] = [];
+      downstreamClient.setNotificationHandler(
+        ResourceUpdatedNotificationSchema,
+        async (notification) => {
+          received.push(notification);
+        }
+      );
+
+      // Upstream emits a notification — the bridge should forward it.
+      await upstream.notification({
+        method: 'notifications/resources/updated',
+        params: { uri: 'emdash://tasks/abc/sessions/sess-1' },
+      });
+
+      // Allow microtasks (transport queue) to flush.
+      await new Promise<void>((resolve) => setTimeout(resolve, 20));
+
+      expect(received).toHaveLength(1);
+      expect(received[0]).toMatchObject({
+        method: 'notifications/resources/updated',
+        params: { uri: 'emdash://tasks/abc/sessions/sess-1' },
+      });
+    } finally {
+      await Promise.allSettled([
+        downstreamClient.close(),
+        bridgeServer.close(),
+        bridgeClient.close(),
+        upstream.close(),
+      ]);
+    }
+  });
+});

--- a/bin/emdash-mcp.ts
+++ b/bin/emdash-mcp.ts
@@ -3,21 +3,444 @@
  * external MCP clients like Claude Code, Cursor, Codex) to the loopback HTTP
  * MCP server hosted inside the Electron main process.
  *
- * Eventual responsibilities (see
+ * Architecture (see
  * `docs/superpowers/specs/2026-05-16-mcp-server-design.md`):
- * - Read `~/.emdash/mcp.json` to discover the local port and bearer token.
- * - Open an HTTP MCP session against `127.0.0.1:<port>` with
- *   `Authorization: Bearer <token>`.
- * - Pipe the SDK stdio transport on this process to the HTTP transport.
  *
- * Wiring into `electron.vite.config.ts` and `electron-builder.config.ts` is
- * deferred to task T9.
+ *   Claude Code  ──stdio──▶  emdash-mcp (this process)  ──HTTP──▶  emdash app
  *
- * Currently a stub — prints a message to stderr and exits 0.
+ * The bridge is a man-in-the-middle proxy:
+ *   - It ACTS AS A SERVER toward the external client over stdio
+ *     (`StdioServerTransport`).
+ *   - It ACTS AS A CLIENT toward the running emdash app over HTTP
+ *     (`StreamableHTTPClientTransport`).
+ *
+ * The SDK does not ship a built-in bridge: we implement the forwarding here
+ * with passthrough request handlers and a fallback notification handler that
+ * republishes server-initiated notifications onto the stdio side.
+ *
+ * Loopback-only: the HTTP side connects ONLY to `127.0.0.1:<port>`, never any
+ * other host, even if a malformed token file tries to redirect us.
  */
-function main(): void {
-  process.stderr.write('emdash-mcp stub\n');
-  process.exit(0);
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import {
+  CallToolRequestSchema,
+  CallToolResultSchema,
+  CompleteRequestSchema,
+  CompleteResultSchema,
+  EmptyResultSchema,
+  GetPromptRequestSchema,
+  GetPromptResultSchema,
+  ListPromptsRequestSchema,
+  ListPromptsResultSchema,
+  ListResourcesRequestSchema,
+  ListResourcesResultSchema,
+  ListResourceTemplatesRequestSchema,
+  ListResourceTemplatesResultSchema,
+  ListToolsRequestSchema,
+  ListToolsResultSchema,
+  ReadResourceRequestSchema,
+  ReadResourceResultSchema,
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+  type Notification,
+  type ServerCapabilities,
+} from '@modelcontextprotocol/sdk/types.js';
+import { readTokenFile } from '../src/main/core/mcp-server/token-store';
+
+const LOOPBACK_HOST = '127.0.0.1';
+const MCP_ENDPOINT = '/mcp';
+
+const SERVER_NAME = 'emdash-mcp-bridge';
+const SERVER_VERSION = '1';
+
+const MAX_RECONNECT_ATTEMPTS = 3;
+const INITIAL_BACKOFF_MS = 250;
+
+/** Resolved bridge configuration. */
+export interface BridgeConfig {
+  port: number;
+  token: string;
 }
 
-main();
+/**
+ * Resolve the port + token the bridge will use.
+ *
+ * Token always comes from `~/.emdash/mcp.json`. Port honors
+ * `EMDASH_MCP_PORT` (the snippet `mcpServerController.getConfigSnippets`
+ * emits) and falls back to whatever is recorded in the token file.
+ *
+ * Exported for unit tests.
+ */
+export async function resolveBridgeConfig(env: NodeJS.ProcessEnv = process.env): Promise<
+  | {
+      ok: true;
+      config: BridgeConfig;
+    }
+  | { ok: false; reason: string }
+> {
+  const file = await readTokenFile();
+  if (!file) {
+    return {
+      ok: false,
+      reason:
+        'No MCP token file found at ~/.emdash/mcp.json. Open emdash, go to Settings → MCP Server, enable the server, and try again.',
+    };
+  }
+  const overridePort = parsePortEnv(env.EMDASH_MCP_PORT);
+  const port = overridePort ?? file.port;
+  if (!isValidPort(port)) {
+    return {
+      ok: false,
+      reason: `Invalid MCP port (${port}). Expected an integer between 1 and 65535.`,
+    };
+  }
+  return {
+    ok: true,
+    config: { port, token: file.token },
+  };
+}
+
+function parsePortEnv(raw: string | undefined): number | null {
+  if (raw === undefined || raw === '') return null;
+  const n = Number(raw);
+  if (!Number.isInteger(n)) return null;
+  return n;
+}
+
+function isValidPort(port: number): boolean {
+  return Number.isInteger(port) && port > 0 && port < 65536;
+}
+
+/**
+ * Build the MCP HTTP URL. Always loopback — never read host from anywhere
+ * external. The token file format only carries a port; if a future revision
+ * tried to add a host field, this function would still ignore it.
+ */
+export function buildMcpUrl(port: number): URL {
+  return new URL(`http://${LOOPBACK_HOST}:${port}${MCP_ENDPOINT}`);
+}
+
+/**
+ * Construct the SDK `Client` and the underlying HTTP transport for a single
+ * connection attempt. The auth token is injected via `requestInit.headers`
+ * (the simplest form supported by `StreamableHTTPClientTransport`).
+ *
+ * Exported for unit tests.
+ */
+export function createHttpClient(config: BridgeConfig): {
+  client: Client;
+  transport: StreamableHTTPClientTransport;
+} {
+  const transport = new StreamableHTTPClientTransport(buildMcpUrl(config.port), {
+    requestInit: {
+      headers: {
+        Authorization: `Bearer ${config.token}`,
+      },
+    },
+  });
+  const client = new Client(
+    { name: SERVER_NAME, version: SERVER_VERSION },
+    {
+      // No client-side capabilities advertised — the bridge does not satisfy
+      // sampling/elicitation/roots itself; if the upstream server requests
+      // them they will simply fail (the external client could implement them
+      // in a future revision and we would forward them, but that's out of
+      // scope for v1 per the spec).
+      capabilities: {},
+    }
+  );
+  return { client, transport };
+}
+
+/**
+ * Build the SDK `Server` over stdio that fronts the external MCP client.
+ *
+ * We declare a permissive capability set: `tools`, `resources` (with
+ * `subscribe: true`), `prompts`, `completions`, `logging`. This is necessary
+ * because the SDK's `setRequestHandler` and `notification()` methods assert
+ * the capability before letting them through; the bridge has to be ready to
+ * forward whatever the upstream emdash server supports today and tomorrow.
+ *
+ * If the external client invokes a capability the upstream server does not
+ * actually implement (e.g. `prompts/list` against a tools-only build), the
+ * forwarded `client.request` will throw at the upstream `Client`'s capability
+ * assertion and that error is returned to the caller as a JSON-RPC error —
+ * which is the appropriate behaviour.
+ *
+ * Exported for unit tests.
+ */
+export function createStdioServer(): Server {
+  const capabilities: ServerCapabilities = {
+    tools: { listChanged: true },
+    resources: { subscribe: true, listChanged: true },
+    prompts: { listChanged: true },
+    completions: {},
+    logging: {},
+  };
+  return new Server({ name: SERVER_NAME, version: SERVER_VERSION }, { capabilities });
+}
+
+/**
+ * Wire passthrough request handlers from the stdio server through to the HTTP
+ * client. Each handler simply forwards `request.params` and returns the
+ * response unchanged — the SDK takes care of the JSON-RPC envelope on each
+ * side.
+ *
+ * Exported for unit tests so we can verify the handler set without spawning
+ * a subprocess.
+ */
+export function installPassthroughHandlers(server: Server, client: Client): void {
+  server.setRequestHandler(ListToolsRequestSchema, async (request) => {
+    return client.request({ method: 'tools/list', params: request.params }, ListToolsResultSchema);
+  });
+  server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    return client.request({ method: 'tools/call', params: request.params }, CallToolResultSchema);
+  });
+  server.setRequestHandler(ListResourcesRequestSchema, async (request) => {
+    return client.request(
+      { method: 'resources/list', params: request.params },
+      ListResourcesResultSchema
+    );
+  });
+  server.setRequestHandler(ListResourceTemplatesRequestSchema, async (request) => {
+    return client.request(
+      { method: 'resources/templates/list', params: request.params },
+      ListResourceTemplatesResultSchema
+    );
+  });
+  server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
+    return client.request(
+      { method: 'resources/read', params: request.params },
+      ReadResourceResultSchema
+    );
+  });
+  server.setRequestHandler(SubscribeRequestSchema, async (request) => {
+    return client.request(
+      { method: 'resources/subscribe', params: request.params },
+      EmptyResultSchema
+    );
+  });
+  server.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
+    return client.request(
+      { method: 'resources/unsubscribe', params: request.params },
+      EmptyResultSchema
+    );
+  });
+  server.setRequestHandler(ListPromptsRequestSchema, async (request) => {
+    return client.request(
+      { method: 'prompts/list', params: request.params },
+      ListPromptsResultSchema
+    );
+  });
+  server.setRequestHandler(GetPromptRequestSchema, async (request) => {
+    return client.request({ method: 'prompts/get', params: request.params }, GetPromptResultSchema);
+  });
+  server.setRequestHandler(CompleteRequestSchema, async (request) => {
+    return client.request(
+      { method: 'completion/complete', params: request.params },
+      CompleteResultSchema
+    );
+  });
+}
+
+/**
+ * Forward server-initiated notifications from the upstream HTTP client onto
+ * the stdio side. We use a single fallback handler so we don't have to
+ * enumerate every notification method the upstream might emit (per spec the
+ * bridge is method-agnostic for forwarding).
+ *
+ * Exported for unit tests.
+ */
+export function installNotificationForwarder(server: Server, client: Client): void {
+  client.fallbackNotificationHandler = async (notification: Notification) => {
+    try {
+      // The SDK's `notification` type is structurally compatible with
+      // `ServerNotification`, but the broad union forces a cast. We don't
+      // mutate the payload — just pass it through verbatim.
+      await server.notification(notification as Parameters<typeof server.notification>[0]);
+    } catch (err) {
+      // Don't crash the bridge if the stdio side rejects a notification (e.g.
+      // because the SDK's capability assertion blocks an unknown method).
+      // Log to stderr so it shows up in the host MCP client's logs without
+      // contaminating the JSON-RPC stdout channel.
+      process.stderr.write(
+        `[emdash-mcp] failed to forward notification ${notification.method}: ${(err as Error).message}\n`
+      );
+    }
+  };
+}
+
+/**
+ * Connect the HTTP client to the upstream emdash MCP server with bounded
+ * retries.
+ *
+ * Returns the connected `Client` + transport on success. On the final
+ * failure, throws the underlying error.
+ *
+ * Exported for unit tests.
+ */
+export async function connectHttpWithRetry(
+  config: BridgeConfig,
+  options: {
+    maxAttempts?: number;
+    initialBackoffMs?: number;
+    onAttempt?: (attempt: number, err: Error | null) => void;
+  } = {}
+): Promise<{ client: Client; transport: StreamableHTTPClientTransport }> {
+  const maxAttempts = options.maxAttempts ?? MAX_RECONNECT_ATTEMPTS;
+  const initialBackoff = options.initialBackoffMs ?? INITIAL_BACKOFF_MS;
+
+  let lastErr: unknown;
+  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+    const { client, transport } = createHttpClient(config);
+    try {
+      await client.connect(transport);
+      options.onAttempt?.(attempt, null);
+      return { client, transport };
+    } catch (err) {
+      lastErr = err;
+      options.onAttempt?.(attempt, err as Error);
+      // Best-effort cleanup of the half-open transport before retrying.
+      try {
+        await transport.close();
+      } catch {
+        // ignore
+      }
+      if (attempt < maxAttempts) {
+        const delay = initialBackoff * 2 ** (attempt - 1);
+        await sleep(delay);
+      }
+    }
+  }
+  throw lastErr instanceof Error ? lastErr : new Error(String(lastErr));
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Diagnostic message printed to stderr on startup failure. Centralised so the
+ * tone is consistent across all "emdash isn't reachable" paths.
+ */
+function diagnostic(reason: string): string {
+  return [
+    `emdash-mcp: ${reason}`,
+    '',
+    'Make sure the emdash app is running and that the MCP server is enabled',
+    'in Settings → MCP Server.',
+    '',
+  ].join('\n');
+}
+
+/**
+ * Main entrypoint. Boots the bridge end-to-end:
+ *  1. Resolve port + token.
+ *  2. Connect the HTTP client (with bounded retries).
+ *  3. Open the stdio server, install handlers + notification forwarder.
+ *  4. Wait for either side to close, then exit cleanly.
+ */
+export async function runBridge(): Promise<void> {
+  const resolved = await resolveBridgeConfig();
+  if (!resolved.ok) {
+    process.stderr.write(diagnostic(resolved.reason));
+    process.exit(1);
+  }
+
+  let httpClient: Client;
+  let httpTransport: StreamableHTTPClientTransport;
+  try {
+    ({ client: httpClient, transport: httpTransport } = await connectHttpWithRetry(
+      resolved.config
+    ));
+  } catch (err) {
+    process.stderr.write(
+      diagnostic(
+        `failed to connect to emdash MCP server at ${LOOPBACK_HOST}:${resolved.config.port}${MCP_ENDPOINT}: ${(err as Error).message}`
+      )
+    );
+    process.exit(1);
+  }
+
+  const stdioServer = createStdioServer();
+  const stdioTransport = new StdioServerTransport();
+
+  installPassthroughHandlers(stdioServer, httpClient);
+  installNotificationForwarder(stdioServer, httpClient);
+
+  // Bridge shutdown signalling. `done` resolves when either side closes
+  // (client disconnect, upstream HTTP drop, SIGINT, SIGTERM, etc.).
+  let resolveDone!: () => void;
+  const done = new Promise<void>((r) => {
+    resolveDone = r;
+  });
+
+  const cleanup = async (): Promise<void> => {
+    try {
+      await stdioServer.close();
+    } catch {
+      // ignore
+    }
+    try {
+      await httpClient.close();
+    } catch {
+      // ignore
+    }
+    try {
+      await httpTransport.close();
+    } catch {
+      // ignore
+    }
+    resolveDone();
+  };
+
+  // If the stdio side closes (parent MCP client exited), shut down.
+  stdioServer.onclose = () => {
+    void cleanup();
+  };
+  // If the HTTP side drops, shut down — clients will respawn the bridge.
+  httpClient.onclose = () => {
+    void cleanup();
+  };
+
+  // Graceful shutdown signals.
+  const signals: NodeJS.Signals[] = ['SIGINT', 'SIGTERM'];
+  for (const sig of signals) {
+    process.once(sig, () => {
+      void cleanup();
+    });
+  }
+
+  try {
+    await stdioServer.connect(stdioTransport);
+  } catch (err) {
+    process.stderr.write(diagnostic(`failed to attach stdio transport: ${(err as Error).message}`));
+    await cleanup();
+    process.exit(1);
+  }
+
+  await done;
+}
+
+// Only auto-run when this file is the entrypoint. The unit tests import the
+// helpers above without triggering `runBridge()`.
+const isEntrypoint = (() => {
+  try {
+    const argv1 = process.argv[1];
+    if (!argv1) return false;
+    const here = new URL(import.meta.url).pathname;
+    return argv1 === here || argv1.endsWith('/emdash-mcp.js') || argv1.endsWith('/emdash-mcp.ts');
+  } catch {
+    return false;
+  }
+})();
+
+if (isEntrypoint) {
+  runBridge().catch((err) => {
+    process.stderr.write(diagnostic(`unexpected error: ${(err as Error).message}\n`));
+    process.exit(1);
+  });
+}

--- a/bin/emdash-mcp.ts
+++ b/bin/emdash-mcp.ts
@@ -1,0 +1,23 @@
+/**
+ * `emdash-mcp` — standalone Node entrypoint that bridges stdio (used by
+ * external MCP clients like Claude Code, Cursor, Codex) to the loopback HTTP
+ * MCP server hosted inside the Electron main process.
+ *
+ * Eventual responsibilities (see
+ * `docs/superpowers/specs/2026-05-16-mcp-server-design.md`):
+ * - Read `~/.emdash/mcp.json` to discover the local port and bearer token.
+ * - Open an HTTP MCP session against `127.0.0.1:<port>` with
+ *   `Authorization: Bearer <token>`.
+ * - Pipe the SDK stdio transport on this process to the HTTP transport.
+ *
+ * Wiring into `electron.vite.config.ts` and `electron-builder.config.ts` is
+ * deferred to task T9.
+ *
+ * Currently a stub — prints a message to stderr and exits 0.
+ */
+function main(): void {
+  process.stderr.write('emdash-mcp stub\n');
+  process.exit(0);
+}
+
+main();

--- a/docs/superpowers/specs/2026-05-16-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-05-16-mcp-server-design.md
@@ -1,0 +1,226 @@
+# emdash MCP Server — Design Spec
+
+**Date:** 2026-05-16
+**Status:** Approved (foundational decisions confirmed via brainstorming)
+**Owner:** Lord Niklas Flaig
+
+## Goal
+
+Expose emdash as a Model Context Protocol (MCP) server so external AI agents
+(Claude Code, Cursor, Codex, etc.) can drive emdash from the outside: create
+tasks, manage projects, register MCP servers and skills, observe and write to
+running agent sessions, and open worktrees in IDEs.
+
+This is the inverse of emdash's existing MCP integration, which configures
+*outbound* MCP servers for the agents emdash spawns. Here, emdash itself is
+the server.
+
+## Foundational decisions (locked)
+
+| Question | Decision |
+|---|---|
+| Transport | **stdio bridge → in-process HTTP**. External clients spawn `emdash-mcp` (stdio); the bridge proxies to a local HTTP MCP server inside the Electron main process. |
+| Lifecycle / discovery | **Always on at fixed port + bearer token**, gated by a user-controlled toggle stored in `appSettings`. Defaults to **off**. |
+| Auth | **Auto-generated bearer token**, persisted to `~/.emdash/mcp.json` at mode `0600`. Rotatable from Settings. |
+| PTY interaction | **MCP resources + tools, with subscriptions.** Each PTY session is a resource; `task.sendInput` writes input. |
+| Destructive ops | **Require explicit `confirm: true` argument.** Without it, tools return a structured "would delete X" error. |
+| Skill add | **Both** `skill.installFromCatalog` (catalog) and `skill.createCustom` (new local skill). |
+| Settings UI | **New "MCP Server" section in Settings** with toggle, connection info, token controls, recent calls. |
+| Internal architecture | **Approach A:** new `core/mcp-server/` module with hand-curated tools that call existing operation functions in-process. |
+
+## Architecture
+
+A new domain module `src/main/core/mcp-server/` follows emdash's existing
+service/controller pattern (`agents/conventions/main-patterns.md`).
+
+```
+external MCP client (Claude Code, Cursor, Codex)
+        │  stdio
+        ▼
+emdash-mcp  (bin/emdash-mcp.ts — stdio bridge subprocess)
+        │  HTTP + Authorization: Bearer <token>
+        ▼
+McpHttpServer (127.0.0.1:7457, loopback only)
+        │
+        ▼
+McpServer (@modelcontextprotocol/sdk) ── Tool registry
+                                       └─ Resource registry
+        │
+        ▼
+Existing operation functions (createTask, addProject, …)
+        │
+        ▼
+SQLite • PTY registry • Workspace registry • Event bus
+```
+
+### Module layout
+
+```
+src/main/core/mcp-server/
+├── service.ts                 McpServerService singleton (IInitializable, IDisposable)
+├── http-server.ts             Loopback HTTP transport, Host-header check, bearer auth
+├── server.ts                  Wires @modelcontextprotocol/sdk Server, mounts tools + resources
+├── controller.ts              RPC controller for the renderer Settings page
+├── token-store.ts             Reads/writes ~/.emdash/mcp.json with mode 0600
+├── recent-calls.ts            Ring buffer of recent tool invocations (last 200)
+├── tools/
+│   ├── index.ts               Aggregates tool registrations
+│   ├── task-tools.ts
+│   ├── project-tools.ts
+│   ├── mcp-tools.ts
+│   ├── skill-tools.ts
+│   ├── worktree-tools.ts
+│   └── system-tools.ts
+└── resources/
+    ├── index.ts
+    ├── project-resource.ts
+    ├── task-resource.ts
+    └── task-session-resource.ts   PTY ring buffer + subscriptions
+
+bin/
+└── emdash-mcp.ts              Standalone Node entrypoint — stdio ↔ HTTP bridge
+
+src/renderer/views/settings/mcp-server/   New Settings view
+```
+
+Tools call into existing operation functions (e.g.
+`src/main/core/tasks/operations/createTask.ts`) **directly, in-process**. No
+IPC round-trip; no duplicated business logic.
+
+## Tool catalog (v1)
+
+Each tool returns the same `Result<T, E>` shape as the underlying op.
+Destructive tools require `confirm: true`.
+
+### Tasks
+
+| Tool | Description (LLM-facing summary) | Key args |
+|---|---|---|
+| `task.create` | Create a new task in a project; provisions a worktree and PTY by default. | `projectId`, `name`, `sourceBranch?`, `taskBranch?`, `strategy?`, `provision?` |
+| `task.list` | List tasks in a project, filtered by status / archived state. | `projectId`, `status?`, `includeArchived?` |
+| `task.get` | Full task detail incl. workspace info, PR list, conversation counts. | `taskId` |
+| `task.update` | Edit name, status, source branch, linked issue, pin state. | `taskId`, `patch` |
+| `task.delete` | Hard delete after teardown. **Requires `confirm: true`.** | `taskId`, `confirm` |
+| `task.archive` / `task.unarchive` | Soft delete / restore. | `taskId` |
+| `task.sendInput` | Write a string (with optional trailing CR) to a running PTY session. | `taskId`, `sessionId`, `data`, `appendEnter?` |
+| `task.getOutput` | Read PTY ring buffer; supports `sinceCursor` for incremental reads. | `taskId`, `sessionId`, `sinceCursor?`, `bytes?` |
+| `task.listSessions` | List PTY sessions and their status (running, exited, exit code). | `taskId` |
+| `task.openInIDE` | Open task's worktree in a configured editor. | `taskId`, `editor` (`vscode`, `cursor`, `zed`, `sublime`, `terminal`) |
+
+### Projects
+
+| Tool | Description | Key args |
+|---|---|---|
+| `project.add` | Add a local project (Git repo path) or a remote project (SSH connection). | `path` or `{sshConnectionId, remotePath}`, `name?`, `baseRef?` |
+| `project.list` | List all projects. | — |
+| `project.get` | Project detail incl. settings, remotes, branches. | `projectId` |
+| `project.updateSettings` | Patch base/shareable settings (worktreeDirectory, baseRemote, scripts, tmux, …). | `projectId`, `patch` |
+| `project.delete` | Remove project from emdash (does not touch the on-disk repo). **Requires `confirm: true`.** | `projectId`, `confirm` |
+
+### MCP servers (the outbound ones emdash configures for agents)
+
+| Tool | Description | Key args |
+|---|---|---|
+| `mcp.list` | List configured MCP servers across providers. | `provider?` |
+| `mcp.add` | Add or update an MCP server entry for one or more providers. | `name`, `transport`, `command?`, `args?`, `url?`, `headers?`, `env?`, `providers` |
+| `mcp.remove` | Remove an MCP server entry. **Requires `confirm: true`.** | `name`, `providers?`, `confirm` |
+
+### Skills
+
+| Tool | Description | Key args |
+|---|---|---|
+| `skill.list` | List catalog and installed skills. | `installedOnly?` |
+| `skill.installFromCatalog` | Install a skill from the catalog (anthropic / openai / local). | `skillId` |
+| `skill.createCustom` | Create a brand-new local skill (writes a new SKILL.md). | `name`, `description`, `content` |
+| `skill.uninstall` | Remove an installed skill. **Requires `confirm: true`.** | `skillId`, `confirm` |
+
+### Worktrees & system
+
+| Tool | Description | Key args |
+|---|---|---|
+| `worktree.openInIDE` | Open a workspace path in an editor (lower-level than `task.openInIDE`). | `workspaceId`, `editor` |
+| `system.listEditors` | Detected IDE/editor binaries on this machine. | — |
+| `system.health` | Server version, uptime, app version, recent-error count. | — |
+
+## Resources
+
+Resources let an MCP client subscribe to live state instead of polling.
+
+| URI | Reads | Subscribes |
+|---|---|---|
+| `emdash://projects` | All projects | Add / remove |
+| `emdash://projects/{id}/tasks` | Tasks in a project | Create / update / archive / delete |
+| `emdash://tasks/{id}` | Single-task detail | Status / PR / metadata changes |
+| `emdash://tasks/{id}/sessions/{sid}` | Current ring-buffer snapshot + cursor | Live output deltas |
+| `emdash://mcp-servers` | Configured MCP servers across providers | Config-file changes |
+| `emdash://skills` | Installed + catalog skills | Install / uninstall |
+
+The PTY session resource is the centerpiece of "look into task." A client
+`read` returns the same 64 KB ring buffer the renderer uses; `subscribe`
+streams `update` notifications with deltas. Backed by a new `PtyMcpAdapter`
+that wraps the existing `pty-session-registry` event stream.
+
+## Auth, lifecycle, settings
+
+- **Token storage:** On first start, generate `crypto.randomBytes(32).toString('base64url')`. Persist `{ port, token, version }` in `~/.emdash/mcp.json` at mode `0600`. The stdio bridge reads this file. HTTP clients send `Authorization: Bearer <token>`.
+- **Enable toggle:** New `appSettings` key `mcpServer.enabled` (default `false`). Service reacts to changes — flipping on starts the HTTP server, flipping off shuts it down cleanly.
+- **Port:** Configurable in settings; default `7457`. If port is in use, server publishes a structured error visible in the Settings UI.
+- **Rotate token:** Settings button regenerates token, rewrites `mcp.json`, terminates active sessions so they reconnect with the new token.
+- **Recent calls ring buffer:** In-memory only; last 200 calls (tool name, ms, status, error?). Surfaced in Settings.
+- **Bind:** `127.0.0.1` only. Reject requests whose `Host` header isn't `127.0.0.1:<port>` or `localhost:<port>` to mitigate DNS rebinding.
+
+## Settings UI (renderer)
+
+New Settings view registered in `src/renderer/core/view/registry.ts`.
+
+1. **Status:** Enabled toggle, "Running on `127.0.0.1:7457`" indicator, uptime.
+2. **Connection:** Token field with reveal/copy/rotate; copy-paste config snippets for Claude Code, Cursor, Codex.
+3. **Recent calls:** Live-updating list (tool name, ms, status). Backed by `mcpServer.getRecentCalls` + an event channel.
+4. **Advanced:** Port input, "Open `mcp.json`" button.
+
+Backed by a new `mcpServerController` exposing `getStatus`, `setEnabled`, `setPort`, `rotateToken`, `getRecentCalls`. The view subscribes to a new event channel for live status / recent-call updates.
+
+## Data flow examples
+
+### Create-and-watch a task (Claude Code over stdio)
+
+1. Claude Code spawns `emdash-mcp` (stdio).
+2. Bridge reads `~/.emdash/mcp.json`, opens HTTP MCP session against the running app.
+3. Claude calls `task.create { projectId, name, provision: true }` → in-process `createTask` op → returns `{ taskId, sessions: [{id, ...}] }`.
+4. Claude `subscribe`s to `emdash://tasks/<id>/sessions/<sid>`, gets initial ring-buffer snapshot + live updates.
+5. Claude calls `task.sendInput { taskId, sessionId, data: "ls\n" }` to drive the agent.
+
+### Edit project settings
+
+1. `project.updateSettings { projectId, patch: { worktreeDirectory: "..." } }` → existing `updateProjectSettings` op → emits the existing `projectChanged` event → renderer auto-refreshes via React Query, identical to manual edits.
+
+## Error handling
+
+- Tool handlers translate `Result<T, E>` into MCP responses:
+  - `Ok` → `{ content: [{ type: 'text', text: JSON.stringify(data) }] }`.
+  - `Err` → `isError: true`; `content` carries `{ code, message, details? }`.
+- Auth failure: HTTP `401`. Missing `confirm` on a destructive tool returns a structured error listing what would be deleted.
+- Server-level: missing project / task ID → `code: 'NOT_FOUND'`. Workspace ref-counting conflict → `code: 'WORKSPACE_BUSY'`.
+- Bridge translates HTTP 5xx into MCP transport errors so clients reconnect.
+
+## Testing
+
+- **Unit:** Each tool handler tested in isolation against an in-memory DB using existing `task-manager` fixtures (`vitest`).
+- **Integration:** Spin the HTTP server on an ephemeral port, drive it with `@modelcontextprotocol/sdk`'s test client. Cover token auth, `confirm` enforcement, PTY subscribe with live writes, workspace ref-counting on `task.delete`.
+- **Bridge:** Smoke test — spawn `emdash-mcp` against a stub HTTP server, verify stdio framing.
+- **CI gates:** `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`, `pnpm test`.
+
+## Risks & follow-ups (not blocking v1)
+
+- **Late subscribers miss early PTY output beyond 64 KB.** Acceptable for v1 — same limitation the renderer has. Future: opt-in larger buffer per session.
+- **Concurrent `task.delete` while a session is being written to** — covered by existing workspace ref-counting; new tool surfaces the busy state via `WORKSPACE_BUSY`.
+- **Token leakage if `~/.emdash/mcp.json` permissions get clobbered.** Service re-checks mode on startup and refuses to expose token if world-readable; logs a warning.
+- **No multi-user / per-client tokens in v1** — tracked for v2; Settings UI leaves room for it.
+- **No telemetry on MCP usage in v1.** If `TELEMETRY_ENABLED` is set, opt-in event for `mcpServer.toolCalled` (tool name only, no args) is a follow-up.
+
+## Out of scope (explicit)
+
+- Exposing emdash MCP over the network (non-loopback). Loopback only.
+- Per-tool ACLs / scopes. v1 trusts the bearer token holistically.
+- Browser-based MCP clients. We actively block them via Host-header check.
+- Auto-config injection into Claude Code / Cursor settings. Settings UI shows copy-paste snippets; user pastes them.

--- a/docs/superpowers/specs/2026-05-16-mcp-server-design.md
+++ b/docs/superpowers/specs/2026-05-16-mcp-server-design.md
@@ -87,6 +87,13 @@ Tools call into existing operation functions (e.g.
 `src/main/core/tasks/operations/createTask.ts`) **directly, in-process**. No
 IPC round-trip; no duplicated business logic.
 
+**Per-session `McpServer` instances.** The SDK's `McpServer` may only be
+connected to one transport at a time. `StreamableHTTPServerTransport` is
+one transport per HTTP session, so each new session mints a fresh `McpServer`
+via a factory (`createMcpServer`). Tool / resource registration is cheap
+(map inserts), and per-session isolation also keeps subscriptions and
+request handlers from leaking between clients.
+
 ## Tool catalog (v1)
 
 Each tool returns the same `Result<T, E>` shape as the underlying op.

--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -27,6 +27,18 @@ const config: Configuration = {
     'node_modules/@parcel/watcher/**',
     '**/*.node',
   ],
+  // Ship the standalone `emdash-mcp` stdio bridge as an unpacked resource so
+  // it can be spawned as a Node script by external MCP clients (Claude Code,
+  // Cursor, Codex). Its in-app source lives at `bin/emdash-mcp.ts` and is
+  // built to `out/main/emdash-mcp.js` by `electron.vite.config.ts`.
+  // Resolved at runtime from the path emitted by `getBridgeCommand()` in
+  // `src/main/core/mcp-server/service.ts`.
+  extraResources: [
+    {
+      from: 'out/main/emdash-mcp.js',
+      to: 'bin/emdash-mcp.js',
+    },
+  ],
   mac: {
     category: 'public.app-category.developer-tools',
     hardenedRuntime: true,

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -15,6 +15,22 @@ export default defineConfig({
         '@root': resolve('.'),
       },
     },
+    // Build the standalone `emdash-mcp` stdio bridge alongside the main
+    // process. External MCP clients (Claude Code, Cursor, Codex) spawn this
+    // bin and it proxies stdio ↔ the in-process HTTP MCP server (see
+    // `bin/emdash-mcp.ts` and the spec
+    // `docs/superpowers/specs/2026-05-16-mcp-server-design.md`).
+    //
+    // The output ends up at `out/main/emdash-mcp.js` and is shipped as an
+    // extraResource by `electron-builder.config.ts`.
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve('src/main/index.ts'),
+          'emdash-mcp': resolve('bin/emdash-mcp.ts'),
+        },
+      },
+    },
   },
   preload: {
     root: 'src/preload',

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "build": "electron-vite build",
     "build:main": "electron-vite build --filter main",
     "build:renderer": "electron-vite build --filter renderer",
+    "mcp:bridge": "electron-vite build --filter main && node out/main/emdash-mcp.js",
     "package": "pnpm run build && electron-builder --config electron-builder.config.ts",
     "package:mac": "pnpm run build && electron-builder --mac --config electron-builder.config.ts",
     "package:linux": "pnpm run build && electron-builder --linux --publish never --config electron-builder.config.ts",

--- a/package.json
+++ b/package.json
@@ -104,6 +104,7 @@
     "@isaacs/brace-expansion": "^5.0.1",
     "@linear/sdk": "^77.0.0",
     "@llamaduck/forgejo-ts": "^14.0.3",
+    "@modelcontextprotocol/sdk": "^1.29.0",
     "@monaco-editor/react": "^4.7.0",
     "@octokit/auth-oauth-device": "^8.0.3",
     "@octokit/rest": "^22.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       '@llamaduck/forgejo-ts':
         specifier: ^14.0.3
         version: 14.0.3
+      '@modelcontextprotocol/sdk':
+        specifier: ^1.29.0
+        version: 1.29.0(zod@4.3.6)
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1218,6 +1221,12 @@ packages:
     peerDependencies:
       graphql: ^0.8.0 || ^0.9.0 || ^0.10.0 || ^0.11.0 || ^0.12.0 || ^0.13.0 || ^14.0.0 || ^15.0.0 || ^16.0.0 || ^17.0.0
 
+  '@hono/node-server@1.19.14':
+    resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
+    engines: {node: '>=18.14.1'}
+    peerDependencies:
+      hono: ^4
+
   '@humanfs/core@0.19.2':
     resolution: {integrity: sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==}
     engines: {node: '>=18.18.0'}
@@ -1316,6 +1325,16 @@ packages:
 
   '@mermaid-js/parser@0.6.3':
     resolution: {integrity: sha512-lnjOhe7zyHjc+If7yT4zoedx2vo4sHaTmtkl1+or8BRTnCtDmcTpAjpzDSfCZrshM5bCoz0GyidzadJAH1xobA==}
+
+  '@modelcontextprotocol/sdk@1.29.0':
+    resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@cfworker/json-schema': ^4.1.1
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@cfworker/json-schema':
+        optional: true
 
   '@monaco-editor/loader@1.7.0':
     resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
@@ -2750,6 +2769,10 @@ packages:
     resolution: {integrity: sha512-AO2ac6pjRB3SJmGJo+v5/aK6Omggp6fsLrs6wN9bd35ulu4cCwaAU9+7ZhXjeqHVkaHThLuzH0nZr0YpCDhygg==}
     engines: {node: ^18.17.0 || >=20.5.0}
 
+  accepts@2.0.0:
+    resolution: {integrity: sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==}
+    engines: {node: '>= 0.6'}
+
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -2776,6 +2799,14 @@ packages:
     resolution: {integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==}
     engines: {node: '>=8'}
 
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
   ajv-keywords@3.5.2:
     resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
     peerDependencies:
@@ -2786,6 +2817,9 @@ packages:
 
   ajv@6.15.0:
     resolution: {integrity: sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==}
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   allotment@1.20.5:
     resolution: {integrity: sha512-7i4NT7ieXEyAd5lBrXmE7WHz/e7hRuo97+j+TwrPE85ha6kyFURoc76nom0dWSZ1pTKVEAMJy/+f3/Isfu/41A==}
@@ -2941,6 +2975,10 @@ packages:
   bluebird@3.7.2:
     resolution: {integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==}
 
+  body-parser@2.2.2:
+    resolution: {integrity: sha512-oP5VkATKlNwcgvxi0vM0p/D3n2C3EReYVX+DNYs5TjZFn/oQt2j+4sVJtSMr18pdRr8wjTcBl6LoV+FUwzPmNA==}
+    engines: {node: '>=18'}
+
   boolean@3.2.0:
     resolution: {integrity: sha512-d0II/GO9uf9lfUHH2BQsjxzRJZBdsjgsBiW4BvhWk/3qoKwQFjIDVN19PfX8F2D/r9PCMTtLWjYVCFrpeYUzsw==}
     deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
@@ -2994,6 +3032,10 @@ packages:
 
   builder-util@26.8.1:
     resolution: {integrity: sha512-pm1lTYbGyc90DHgCDO7eo8Rl4EqKLciayNbZqGziqnH9jrlKe8ZANGdityLZU+pJh16dfzjAx2xQq9McuIPEtw==}
+
+  bytes@3.1.2:
+    resolution: {integrity: sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==}
+    engines: {node: '>= 0.8'}
 
   cac@6.7.14:
     resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
@@ -3220,14 +3262,38 @@ packages:
   console-control-strings@1.1.0:
     resolution: {integrity: sha512-ty/fTekppD2fIwRvnZAVdeOiGd1c7YXEixbgJTNzqcxJWKQnjJ/V1bNEEE6hygpM3WjwHFUVK6HTjWSzV4a8sQ==}
 
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  content-type@1.0.5:
+    resolution: {integrity: sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==}
+    engines: {node: '>= 0.6'}
+
+  content-type@2.0.0:
+    resolution: {integrity: sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==}
+    engines: {node: '>=18'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie-signature@1.2.2:
+    resolution: {integrity: sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==}
+    engines: {node: '>=6.6.0'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
 
   core-util-is@1.0.2:
     resolution: {integrity: sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==}
 
   core-util-is@1.0.3:
     resolution: {integrity: sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
 
   cose-base@1.0.3:
     resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
@@ -3487,6 +3553,10 @@ packages:
   delegates@1.0.0:
     resolution: {integrity: sha512-bd2L678uiWATM6m5Z1VzNCErI3jiGzt6HGY8OVICs40JQq/HALfbyNJmp0UDakEY4pMMaN0Ly5om/B1VI/+xfQ==}
 
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
@@ -3650,6 +3720,9 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
+  ee-first@1.1.1:
+    resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
+
   efrt@2.7.0:
     resolution: {integrity: sha512-/RInbCy1d4P6Zdfa+TMVsf/ufZVotat5hCw3QXmWtjU+3pFEOvOQ7ibo3aIxyCJw2leIeAMjmPj+1SLJiCpdrQ==}
     engines: {node: '>=12.0.0'}
@@ -3703,6 +3776,10 @@ packages:
 
   emoji-regex@9.2.2:
     resolution: {integrity: sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==}
+
+  encodeurl@2.0.0:
+    resolution: {integrity: sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==}
+    engines: {node: '>= 0.8'}
 
   encoding@0.1.13:
     resolution: {integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==}
@@ -3779,6 +3856,9 @@ packages:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
 
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
@@ -3845,8 +3925,20 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  etag@1.8.1:
+    resolution: {integrity: sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==}
+    engines: {node: '>= 0.6'}
+
   eventemitter3@5.0.4:
     resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+
+  eventsource-parser@3.0.8:
+    resolution: {integrity: sha512-70QWGkr4snxr0OXLRWsFLeRBIRPuQOvt4s8QYjmUlmlkyTZkRqS7EDVRZtzU3TiyDbXSzaOeF0XUKy8PchzukQ==}
+    engines: {node: '>=18.0.0'}
+
+  eventsource@3.0.7:
+    resolution: {integrity: sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==}
+    engines: {node: '>=18.0.0'}
 
   execa@5.1.1:
     resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
@@ -3862,6 +3954,16 @@ packages:
 
   exponential-backoff@3.1.3:
     resolution: {integrity: sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA==}
+
+  express-rate-limit@8.5.2:
+    resolution: {integrity: sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==}
+    engines: {node: '>= 16'}
+    peerDependencies:
+      express: '>= 4.11'
+
+  express@5.2.1:
+    resolution: {integrity: sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==}
+    engines: {node: '>= 18'}
 
   extend@3.0.2:
     resolution: {integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==}
@@ -3886,6 +3988,9 @@ packages:
 
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
 
   fault@1.0.4:
     resolution: {integrity: sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==}
@@ -3915,6 +4020,10 @@ packages:
   fill-range@7.1.1:
     resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
     engines: {node: '>=8'}
+
+  finalhandler@2.1.1:
+    resolution: {integrity: sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==}
+    engines: {node: '>= 18.0.0'}
 
   find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -3952,6 +4061,10 @@ packages:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
     engines: {node: '>=0.4.x'}
 
+  forwarded@0.2.0:
+    resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
+    engines: {node: '>= 0.6'}
+
   framer-motion@12.33.0:
     resolution: {integrity: sha512-ca8d+rRPcDP5iIF+MoT3WNc0KHJMjIyFAbtVLvM9eA7joGSpeqDfiNH/kCs1t4CHi04njYvWyj0jS4QlEK/rJQ==}
     peerDependencies:
@@ -3965,6 +4078,10 @@ packages:
         optional: true
       react-dom:
         optional: true
+
+  fresh@2.0.0:
+    resolution: {integrity: sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==}
+    engines: {node: '>= 0.8'}
 
   fs-constants@1.0.0:
     resolution: {integrity: sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==}
@@ -4193,6 +4310,10 @@ packages:
   highlightjs-vue@1.0.0:
     resolution: {integrity: sha512-PDEfEF102G23vHmPhLyPboFCD+BkMGu+GuJe2d9/eH4FsCwvgBpnc9n0pGE+ffKdph38s6foEZiEjdgHdzp+IA==}
 
+  hono@4.12.18:
+    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+    engines: {node: '>=16.9.0'}
+
   hosted-git-info@4.1.0:
     resolution: {integrity: sha512-kyCuEOWjJqZuDbRHzL8V93NzQhwIB71oFWSyzVo+KPZI+pnQPPxucdkrOZvkLRnrf5URsQM+IJ09Dw29cRALIA==}
     engines: {node: '>=10'}
@@ -4209,6 +4330,10 @@ packages:
 
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
 
   http-proxy-agent@4.0.1:
     resolution: {integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==}
@@ -4257,6 +4382,10 @@ packages:
 
   iconv-lite@0.6.3:
     resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  iconv-lite@0.7.2:
+    resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
     engines: {node: '>=0.10.0'}
 
   ieee754@1.2.1:
@@ -4308,6 +4437,14 @@ packages:
   ip-address@10.1.0:
     resolution: {integrity: sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==}
     engines: {node: '>= 12'}
+
+  ip-address@10.2.0:
+    resolution: {integrity: sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==}
+    engines: {node: '>= 12'}
+
+  ipaddr.js@1.9.1:
+    resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
+    engines: {node: '>= 0.10'}
 
   is-alphabetical@1.0.4:
     resolution: {integrity: sha512-DwzsA04LQ10FHTZuL0/grVDk4rFoVH1pjAToYwBrHSxcrBIGQuXrQMtD5U1b0U2XVgKZCTLLP8u2Qxqhy3l2Vg==}
@@ -4371,6 +4508,9 @@ packages:
   is-potential-custom-element-name@1.0.1:
     resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
 
+  is-promise@4.0.0:
+    resolution: {integrity: sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==}
+
   is-stream@2.0.1:
     resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
     engines: {node: '>=8'}
@@ -4409,6 +4549,9 @@ packages:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
 
+  jose@6.2.3:
+    resolution: {integrity: sha512-YYVDInQKFJfR/xa3ojUTl8c2KoTwiL1R5Wg9YCydwH0x0B9grbzlg5HC7mMjCtUJjbQ/YnGEZIhI5tCgfTb4Hw==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
 
@@ -4435,6 +4578,12 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -4754,6 +4903,14 @@ packages:
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
 
+  media-typer@1.1.0:
+    resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
+    engines: {node: '>= 0.8'}
+
+  merge-descriptors@2.0.0:
+    resolution: {integrity: sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==}
+    engines: {node: '>=18'}
+
   merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
 
@@ -4884,9 +5041,17 @@ packages:
     resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
     engines: {node: '>= 0.6'}
 
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
   mime-types@2.1.35:
     resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
 
   mime@2.6.0:
     resolution: {integrity: sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==}
@@ -5133,6 +5298,10 @@ packages:
     engines: {node: ^12.13.0 || ^14.15.0 || >=16.0.0}
     deprecated: This package is no longer supported.
 
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
   object-inspect@1.13.4:
     resolution: {integrity: sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==}
     engines: {node: '>= 0.4'}
@@ -5143,6 +5312,10 @@ packages:
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
+  on-finished@2.4.1:
+    resolution: {integrity: sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==}
+    engines: {node: '>= 0.8'}
 
   once@1.4.0:
     resolution: {integrity: sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==}
@@ -5211,6 +5384,10 @@ packages:
   parse5@8.0.1:
     resolution: {integrity: sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==}
 
+  parseurl@1.3.3:
+    resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
+    engines: {node: '>= 0.8'}
+
   path-data-parser@0.1.0:
     resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
 
@@ -5233,6 +5410,9 @@ packages:
   path-scurry@2.0.2:
     resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
     engines: {node: 18 || 20 || >=22}
+
+  path-to-regexp@8.4.2:
+    resolution: {integrity: sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==}
 
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
@@ -5262,6 +5442,10 @@ packages:
   pidusage@4.0.1:
     resolution: {integrity: sha512-yCH2dtLHfEBnzlHUJymR/Z1nN2ePG3m392Mv8TFlTP1B0xkpMQNHAnfkY0n2tAi6ceKO6YWhxYfZ96V4vVkh/g==}
     engines: {node: '>=18'}
+
+  pkce-challenge@5.0.1:
+    resolution: {integrity: sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==}
+    engines: {node: '>=16.20.0'}
 
   pkg-types@1.3.1:
     resolution: {integrity: sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ==}
@@ -5413,6 +5597,10 @@ packages:
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
 
+  proxy-addr@2.0.7:
+    resolution: {integrity: sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==}
+    engines: {node: '>= 0.10'}
+
   proxy-from-env@2.1.0:
     resolution: {integrity: sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==}
     engines: {node: '>=10'}
@@ -5432,8 +5620,16 @@ packages:
     resolution: {integrity: sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==}
     engines: {node: '>=10'}
 
+  range-parser@1.2.1:
+    resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
+    engines: {node: '>= 0.6'}
+
   rate-limiter-flexible@8.3.0:
     resolution: {integrity: sha512-mzwlfipDLlRinPgELqVDJetke6Snq26nL565m8nLWXIcWgosYSeNRgqwh7ZrZ4MfYs8CNfmLvR5SBVz3rISQsQ==}
+
+  raw-body@3.0.2:
+    resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
+    engines: {node: '>= 0.10'}
 
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
@@ -5660,6 +5856,10 @@ packages:
   roughjs@4.6.6:
     resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
+  router@2.2.0:
+    resolution: {integrity: sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==}
+    engines: {node: '>= 18'}
+
   rw@1.3.3:
     resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
 
@@ -5709,12 +5909,23 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  send@1.2.1:
+    resolution: {integrity: sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==}
+    engines: {node: '>= 18'}
+
   serialize-error@7.0.1:
     resolution: {integrity: sha512-8I8TjW5KMOKsZQTvoxjuSIa7foAwPWGOts+6o7sgjz41/qMD9VQHEDxi6PBvK2l0MXUmqZyNpUK+T2tQaaElvw==}
     engines: {node: '>=10'}
 
+  serve-static@2.2.1:
+    resolution: {integrity: sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==}
+    engines: {node: '>= 18'}
+
   set-blocking@2.0.0:
     resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -5860,6 +6071,10 @@ packages:
 
   state-local@1.0.7:
     resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
 
   std-env@4.0.0:
     resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
@@ -6026,6 +6241,10 @@ packages:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
 
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
@@ -6083,6 +6302,10 @@ packages:
   type-fest@0.13.1:
     resolution: {integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==}
     engines: {node: '>=10'}
+
+  type-is@2.1.0:
+    resolution: {integrity: sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==}
+    engines: {node: '>= 18'}
 
   typescript-eslint@8.59.0:
     resolution: {integrity: sha512-BU3ONW9X+v90EcCH9ZS6LMackcVtxRLlI3XrYyqZIwVSHIk7Qf7bFw1z0M9Q0IUxhTMZCf8piY9hTYaNEIASrw==}
@@ -6166,6 +6389,10 @@ packages:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
 
+  unpipe@1.0.0:
+    resolution: {integrity: sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==}
+    engines: {node: '>= 0.8'}
+
   update-browserslist-db@1.2.3:
     resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
     hasBin: true
@@ -6215,6 +6442,10 @@ packages:
   uuid@11.1.0:
     resolution: {integrity: sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==}
     hasBin: true
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
@@ -6464,6 +6695,11 @@ packages:
   zip-stream@4.1.1:
     resolution: {integrity: sha512-9qv4rlDiopXg4E69k+vMHjNN63YFMe9sZMrdlvKnCjlCRWeCBswPPMPUfx+ipsAWq1LXHe70RcbaHdJJpS6hyQ==}
     engines: {node: '>= 10'}
+
+  zod-to-json-schema@3.25.2:
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
 
   zod-validation-error@4.0.2:
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
@@ -7219,6 +7455,10 @@ snapshots:
     dependencies:
       graphql: 16.13.1
 
+  '@hono/node-server@1.19.14(hono@4.12.18)':
+    dependencies:
+      hono: 4.12.18
+
   '@humanfs/core@0.19.2':
     dependencies:
       '@humanfs/types': 0.15.0
@@ -7324,6 +7564,28 @@ snapshots:
   '@mermaid-js/parser@0.6.3':
     dependencies:
       langium: 3.3.1
+
+  '@modelcontextprotocol/sdk@1.29.0(zod@4.3.6)':
+    dependencies:
+      '@hono/node-server': 1.19.14(hono@4.12.18)
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      content-type: 1.0.5
+      cors: 2.8.6
+      cross-spawn: 7.0.6
+      eventsource: 3.0.7
+      eventsource-parser: 3.0.8
+      express: 5.2.1
+      express-rate-limit: 8.5.2(express@5.2.1)
+      hono: 4.12.18
+      jose: 6.2.3
+      json-schema-typed: 8.0.2
+      pkce-challenge: 5.0.1
+      raw-body: 3.0.2
+      zod: 4.3.6
+      zod-to-json-schema: 3.25.2(zod@4.3.6)
+    transitivePeerDependencies:
+      - supports-color
 
   '@monaco-editor/loader@1.7.0':
     dependencies:
@@ -8800,6 +9062,11 @@ snapshots:
 
   abbrev@3.0.1: {}
 
+  accepts@2.0.0:
+    dependencies:
+      mime-types: 3.0.2
+      negotiator: 1.0.0
+
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -8825,6 +9092,10 @@ snapshots:
       indent-string: 4.0.0
     optional: true
 
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
   ajv-keywords@3.5.2(ajv@6.12.6):
     dependencies:
       ajv: 6.12.6
@@ -8842,6 +9113,13 @@ snapshots:
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   allotment@1.20.5(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
@@ -9075,6 +9353,20 @@ snapshots:
 
   bluebird@3.7.2: {}
 
+  body-parser@2.2.2:
+    dependencies:
+      bytes: 3.1.2
+      content-type: 1.0.5
+      debug: 4.4.3
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      on-finished: 2.4.1
+      qs: 6.15.0
+      raw-body: 3.0.2
+      type-is: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
   boolean@3.2.0:
     optional: true
 
@@ -9172,6 +9464,8 @@ snapshots:
       tiny-async-pool: 1.3.0
     transitivePeerDependencies:
       - supports-color
+
+  bytes@3.1.2: {}
 
   cac@6.7.14: {}
 
@@ -9417,12 +9711,27 @@ snapshots:
   console-control-strings@1.1.0:
     optional: true
 
+  content-disposition@1.1.0: {}
+
+  content-type@1.0.5: {}
+
+  content-type@2.0.0: {}
+
   convert-source-map@2.0.0: {}
+
+  cookie-signature@1.2.2: {}
+
+  cookie@0.7.2: {}
 
   core-util-is@1.0.2:
     optional: true
 
   core-util-is@1.0.3: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
 
   cose-base@1.0.3:
     dependencies:
@@ -9711,6 +10020,8 @@ snapshots:
   delegates@1.0.0:
     optional: true
 
+  depd@2.0.0: {}
+
   dequal@2.0.3: {}
 
   detect-libc@2.1.2: {}
@@ -9753,7 +10064,7 @@ snapshots:
     dependencies:
       '@types/plist': 3.0.5
       '@types/verror': 1.10.11
-      ajv: 6.12.6
+      ajv: 6.15.0
       crc: 3.8.0
       iconv-corefoundation: 1.1.7
       plist: 3.1.0
@@ -9808,6 +10119,8 @@ snapshots:
       gopd: 1.2.0
 
   eastasianwidth@0.2.0: {}
+
+  ee-first@1.1.1: {}
 
   efrt@2.7.0: {}
 
@@ -9906,6 +10219,8 @@ snapshots:
   emoji-regex@8.0.0: {}
 
   emoji-regex@9.2.2: {}
+
+  encodeurl@2.0.0: {}
 
   encoding@0.1.13:
     dependencies:
@@ -10040,6 +10355,8 @@ snapshots:
 
   escalade@3.2.0: {}
 
+  escape-html@1.0.3: {}
+
   escape-string-regexp@4.0.0: {}
 
   escape-string-regexp@5.0.0: {}
@@ -10131,7 +10448,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  etag@1.8.1: {}
+
   eventemitter3@5.0.4: {}
+
+  eventsource-parser@3.0.8: {}
+
+  eventsource@3.0.7:
+    dependencies:
+      eventsource-parser: 3.0.8
 
   execa@5.1.1:
     dependencies:
@@ -10150,6 +10475,44 @@ snapshots:
   expect-type@1.3.0: {}
 
   exponential-backoff@3.1.3: {}
+
+  express-rate-limit@8.5.2(express@5.2.1):
+    dependencies:
+      express: 5.2.1
+      ip-address: 10.2.0
+
+  express@5.2.1:
+    dependencies:
+      accepts: 2.0.0
+      body-parser: 2.2.2
+      content-disposition: 1.1.0
+      content-type: 1.0.5
+      cookie: 0.7.2
+      cookie-signature: 1.2.2
+      debug: 4.4.3
+      depd: 2.0.0
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      finalhandler: 2.1.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      merge-descriptors: 2.0.0
+      mime-types: 3.0.2
+      on-finished: 2.4.1
+      once: 1.4.0
+      parseurl: 1.3.3
+      proxy-addr: 2.0.7
+      qs: 6.15.0
+      range-parser: 1.2.1
+      router: 2.2.0
+      send: 1.2.1
+      serve-static: 2.2.1
+      statuses: 2.0.2
+      type-is: 2.1.0
+      vary: 1.1.2
+    transitivePeerDependencies:
+      - supports-color
 
   extend@3.0.2: {}
 
@@ -10173,6 +10536,8 @@ snapshots:
   fast-json-stable-stringify@2.1.0: {}
 
   fast-levenshtein@2.0.6: {}
+
+  fast-uri@3.1.2: {}
 
   fault@1.0.4:
     dependencies:
@@ -10199,6 +10564,17 @@ snapshots:
   fill-range@7.1.1:
     dependencies:
       to-regex-range: 5.0.1
+
+  finalhandler@2.1.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      on-finished: 2.4.1
+      parseurl: 1.3.3
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
 
   find-up@5.0.0:
     dependencies:
@@ -10233,6 +10609,8 @@ snapshots:
 
   format@0.2.2: {}
 
+  forwarded@0.2.0: {}
+
   framer-motion@12.33.0(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
       motion-dom: 12.33.0
@@ -10241,6 +10619,8 @@ snapshots:
     optionalDependencies:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
+
+  fresh@2.0.0: {}
 
   fs-constants@1.0.0: {}
 
@@ -10577,6 +10957,8 @@ snapshots:
 
   highlightjs-vue@1.0.0: {}
 
+  hono@4.12.18: {}
+
   hosted-git-info@4.1.0:
     dependencies:
       lru-cache: 6.0.0
@@ -10592,6 +10974,14 @@ snapshots:
   html-void-elements@3.0.0: {}
 
   http-cache-semantics@4.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
 
   http-proxy-agent@4.0.1:
     dependencies:
@@ -10657,6 +11047,10 @@ snapshots:
     dependencies:
       safer-buffer: 2.1.2
 
+  iconv-lite@0.7.2:
+    dependencies:
+      safer-buffer: 2.1.2
+
   ieee754@1.2.1: {}
 
   ignore@5.3.2: {}
@@ -10692,6 +11086,10 @@ snapshots:
   internmap@2.0.3: {}
 
   ip-address@10.1.0: {}
+
+  ip-address@10.2.0: {}
+
+  ipaddr.js@1.9.1: {}
 
   is-alphabetical@1.0.4: {}
 
@@ -10742,6 +11140,8 @@ snapshots:
 
   is-potential-custom-element-name@1.0.1: {}
 
+  is-promise@4.0.0: {}
+
   is-stream@2.0.1: {}
 
   is-unicode-supported@0.1.0: {}
@@ -10769,6 +11169,8 @@ snapshots:
       picocolors: 1.1.1
 
   jiti@2.6.1: {}
+
+  jose@6.2.3: {}
 
   js-tokens@4.0.0: {}
 
@@ -10807,6 +11209,10 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 
@@ -11233,6 +11639,10 @@ snapshots:
 
   mdn-data@2.27.1: {}
 
+  media-typer@1.1.0: {}
+
+  merge-descriptors@2.0.0: {}
+
   merge-stream@2.0.0: {}
 
   mermaid@11.12.2:
@@ -11498,9 +11908,15 @@ snapshots:
 
   mime-db@1.52.0: {}
 
+  mime-db@1.54.0: {}
+
   mime-types@2.1.35:
     dependencies:
       mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
 
   mime@2.6.0: {}
 
@@ -11741,12 +12157,18 @@ snapshots:
       set-blocking: 2.0.0
     optional: true
 
+  object-assign@4.1.1: {}
+
   object-inspect@1.13.4: {}
 
   object-keys@1.1.1:
     optional: true
 
   obug@2.1.1: {}
+
+  on-finished@2.4.1:
+    dependencies:
+      ee-first: 1.1.1
 
   once@1.4.0:
     dependencies:
@@ -11841,6 +12263,8 @@ snapshots:
     dependencies:
       entities: 8.0.0
 
+  parseurl@1.3.3: {}
+
   path-data-parser@0.1.0: {}
 
   path-exists@4.0.0: {}
@@ -11859,6 +12283,8 @@ snapshots:
       lru-cache: 11.2.6
       minipass: 7.1.3
 
+  path-to-regexp@8.4.2: {}
+
   pathe@2.0.3: {}
 
   pe-library@0.4.1: {}
@@ -11876,6 +12302,8 @@ snapshots:
   pidusage@4.0.1:
     dependencies:
       safe-buffer: 5.2.1
+
+  pkce-challenge@5.0.1: {}
 
   pkg-types@1.3.1:
     dependencies:
@@ -11973,6 +12401,11 @@ snapshots:
 
   property-information@7.1.0: {}
 
+  proxy-addr@2.0.7:
+    dependencies:
+      forwarded: 0.2.0
+      ipaddr.js: 1.9.1
+
   proxy-from-env@2.1.0: {}
 
   pump@3.0.3:
@@ -11988,7 +12421,16 @@ snapshots:
 
   quick-lru@5.1.1: {}
 
+  range-parser@1.2.1: {}
+
   rate-limiter-flexible@8.3.0: {}
+
+  raw-body@3.0.2:
+    dependencies:
+      bytes: 3.1.2
+      http-errors: 2.0.1
+      iconv-lite: 0.7.2
+      unpipe: 1.0.0
 
   rc@1.2.8:
     dependencies:
@@ -12309,6 +12751,16 @@ snapshots:
       points-on-curve: 0.2.0
       points-on-path: 0.2.1
 
+  router@2.2.0:
+    dependencies:
+      debug: 4.4.3
+      depd: 2.0.0
+      is-promise: 4.0.0
+      parseurl: 1.3.3
+      path-to-regexp: 8.4.2
+    transitivePeerDependencies:
+      - supports-color
+
   rw@1.3.3: {}
 
   rxjs@7.8.2:
@@ -12344,13 +12796,40 @@ snapshots:
 
   semver@7.7.4: {}
 
+  send@1.2.1:
+    dependencies:
+      debug: 4.4.3
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      etag: 1.8.1
+      fresh: 2.0.0
+      http-errors: 2.0.1
+      mime-types: 3.0.2
+      ms: 2.1.3
+      on-finished: 2.4.1
+      range-parser: 1.2.1
+      statuses: 2.0.2
+    transitivePeerDependencies:
+      - supports-color
+
   serialize-error@7.0.1:
     dependencies:
       type-fest: 0.13.1
     optional: true
 
+  serve-static@2.2.1:
+    dependencies:
+      encodeurl: 2.0.0
+      escape-html: 1.0.3
+      parseurl: 1.3.3
+      send: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
+
   set-blocking@2.0.0:
     optional: true
+
+  setprototypeof@1.2.0: {}
 
   shebang-command@2.0.0:
     dependencies:
@@ -12529,6 +13008,8 @@ snapshots:
   stat-mode@1.0.0: {}
 
   state-local@1.0.7: {}
+
+  statuses@2.0.2: {}
 
   std-env@4.0.0: {}
 
@@ -12728,6 +13209,8 @@ snapshots:
     dependencies:
       is-number: 7.0.0
 
+  toidentifier@1.0.1: {}
+
   totalist@3.0.1: {}
 
   tough-cookie@6.0.1:
@@ -12777,6 +13260,12 @@ snapshots:
 
   type-fest@0.13.1:
     optional: true
+
+  type-is@2.1.0:
+    dependencies:
+      content-type: 2.0.0
+      media-typer: 1.1.0
+      mime-types: 3.0.2
 
   typescript-eslint@8.59.0(eslint@9.39.4(jiti@2.6.1))(typescript@6.0.2):
     dependencies:
@@ -12870,6 +13359,8 @@ snapshots:
 
   universalify@2.0.1: {}
 
+  unpipe@1.0.0: {}
+
   update-browserslist-db@1.2.3(browserslist@4.28.1):
     dependencies:
       browserslist: 4.28.1
@@ -12909,6 +13400,8 @@ snapshots:
   util-deprecate@1.0.2: {}
 
   uuid@11.1.0: {}
+
+  vary@1.1.2: {}
 
   verror@1.10.1:
     dependencies:
@@ -13112,6 +13605,10 @@ snapshots:
       archiver-utils: 3.0.4
       compress-commons: 4.1.2
       readable-stream: 3.6.2
+
+  zod-to-json-schema@3.25.2(zod@4.3.6):
+    dependencies:
+      zod: 4.3.6
 
   zod-validation-error@4.0.2(zod@4.3.6):
     dependencies:

--- a/src/main/core/mcp-server/controller.test.ts
+++ b/src/main/core/mcp-server/controller.test.ts
@@ -1,0 +1,205 @@
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { mcpServerController } from './controller';
+import { recentCallsRing } from './recent-calls';
+
+/**
+ * Controller-level unit tests. We mock the service + settings-store seams
+ * directly so each handler can be exercised in isolation without booting the
+ * HTTP transport or hitting the SQLite db.
+ */
+
+const mockGetStatus = vi.hoisted(() => vi.fn());
+const mockReconcile = vi.hoisted(() => vi.fn());
+const mockRotateToken = vi.hoisted(() => vi.fn());
+const mockSettingsGet = vi.hoisted(() => vi.fn());
+const mockSettingsUpdate = vi.hoisted(() => vi.fn());
+
+vi.mock('./service', () => ({
+  mcpServerService: {
+    getStatus: mockGetStatus,
+    reconcile: mockReconcile,
+    rotateToken: mockRotateToken,
+  },
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: {
+    get: mockSettingsGet,
+    update: mockSettingsUpdate,
+  },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { warn: vi.fn(), info: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+// Stub the main-process event bus so loading the singleton ring buffer
+// doesn't transitively pull in Electron / the DB client.
+vi.mock('@main/lib/events', () => ({
+  events: { emit: vi.fn(), on: vi.fn(), once: vi.fn() },
+}));
+
+const DEFAULT_SETTINGS = { enabled: false, port: 7457 };
+
+beforeEach(() => {
+  mockGetStatus.mockReset();
+  mockReconcile.mockReset();
+  mockRotateToken.mockReset();
+  mockSettingsGet.mockReset();
+  mockSettingsUpdate.mockReset();
+  mockSettingsGet.mockResolvedValue({ ...DEFAULT_SETTINGS });
+  mockSettingsUpdate.mockResolvedValue(undefined);
+  mockReconcile.mockResolvedValue(undefined);
+  recentCallsRing.clear();
+});
+
+describe('mcpServerController', () => {
+  describe('getStatus', () => {
+    it('proxies through to the service', async () => {
+      const status = {
+        enabled: true,
+        running: true,
+        port: 7457,
+        tokenPresent: true,
+        uptimeMs: 1234,
+        lastError: null,
+      };
+      mockGetStatus.mockResolvedValue(status);
+      const result = await mcpServerController.getStatus();
+      expect(result).toEqual({ success: true, data: status });
+      expect(mockGetStatus).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('setEnabled', () => {
+    it('updates the enabled flag and reconciles', async () => {
+      const result = await mcpServerController.setEnabled({ enabled: true });
+      expect(result).toEqual({ success: true, data: undefined });
+      expect(mockSettingsGet).toHaveBeenCalledWith('mcpServer');
+      expect(mockSettingsUpdate).toHaveBeenCalledWith('mcpServer', {
+        enabled: true,
+        port: 7457,
+      });
+      expect(mockReconcile).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an Err if the underlying update throws', async () => {
+      mockSettingsUpdate.mockRejectedValueOnce(new Error('boom'));
+      const result = await mcpServerController.setEnabled({ enabled: true });
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('boom');
+      expect(mockReconcile).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('setPort', () => {
+    it('updates the port and reconciles', async () => {
+      const result = await mcpServerController.setPort({ port: 8000 });
+      expect(result).toEqual({ success: true, data: undefined });
+      expect(mockSettingsUpdate).toHaveBeenCalledWith('mcpServer', {
+        enabled: false,
+        port: 8000,
+      });
+      expect(mockReconcile).toHaveBeenCalledTimes(1);
+    });
+
+    it('propagates validation errors as an Err', async () => {
+      mockSettingsUpdate.mockRejectedValueOnce(new Error('port out of range'));
+      const result = await mcpServerController.setPort({ port: 99999 });
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('port out of range');
+    });
+  });
+
+  describe('rotateToken', () => {
+    it('returns the new token and triggers the service rotation', async () => {
+      mockRotateToken.mockResolvedValue({ token: 'new-token-xyz' });
+      const result = await mcpServerController.rotateToken();
+      expect(result).toEqual({ success: true, data: { token: 'new-token-xyz' } });
+      expect(mockRotateToken).toHaveBeenCalledTimes(1);
+    });
+
+    it('returns an Err if rotation fails', async () => {
+      mockRotateToken.mockRejectedValueOnce(new Error('disk full'));
+      const result = await mcpServerController.rotateToken();
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error).toBe('disk full');
+    });
+  });
+
+  describe('getRecentCalls', () => {
+    it('returns whatever is in the ring, most-recent first', async () => {
+      recentCallsRing.record({ tool: 'task.create', status: 'ok', ms: 1 });
+      recentCallsRing.record({ tool: 'task.list', status: 'ok', ms: 1 });
+      const result = await mcpServerController.getRecentCalls();
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected ok');
+      expect(result.data.map((e) => e.tool)).toEqual(['task.list', 'task.create']);
+    });
+
+    it('forwards filter args to the ring', async () => {
+      recentCallsRing.record({ tool: 'task.ok', status: 'ok', ms: 1 });
+      recentCallsRing.record({ tool: 'task.err', status: 'error', ms: 1, errorCode: 'X' });
+      const result = await mcpServerController.getRecentCalls({ status: 'error', limit: 5 });
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected ok');
+      expect(result.data.map((e) => e.tool)).toEqual(['task.err']);
+    });
+
+    it('returns an empty array when the ring is empty', async () => {
+      const result = await mcpServerController.getRecentCalls();
+      expect(result).toEqual({ success: true, data: [] });
+    });
+  });
+
+  describe('revealTokenFile', () => {
+    it('returns the absolute path to the token file', async () => {
+      const result = await mcpServerController.revealTokenFile();
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected ok');
+      expect(result.data.path).toBe(join(homedir(), '.emdash', 'mcp.json'));
+    });
+  });
+
+  describe('getConfigSnippets', () => {
+    it('produces Claude Code, Cursor, and Codex snippets containing the current port', async () => {
+      mockGetStatus.mockResolvedValue({
+        enabled: true,
+        running: true,
+        port: 7457,
+        tokenPresent: true,
+        uptimeMs: 100,
+        lastError: null,
+      });
+      const result = await mcpServerController.getConfigSnippets();
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected ok');
+      expect(result.data.claudeCode).toContain('7457');
+      expect(result.data.cursor).toContain('7457');
+      expect(result.data.codex).toContain('7457');
+      // Each snippet should mention the stdio bridge bin name.
+      for (const snippet of Object.values(result.data)) {
+        expect(snippet).toContain('emdash-mcp');
+      }
+    });
+
+    it('falls back to the configured port when the server is not running', async () => {
+      mockGetStatus.mockResolvedValue({
+        enabled: false,
+        running: false,
+        port: null,
+        tokenPresent: false,
+        uptimeMs: 0,
+        lastError: null,
+      });
+      mockSettingsGet.mockResolvedValue({ enabled: false, port: 9999 });
+      const result = await mcpServerController.getConfigSnippets();
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected ok');
+      expect(result.data.claudeCode).toContain('9999');
+      expect(result.data.codex).toContain('9999');
+    });
+  });
+});

--- a/src/main/core/mcp-server/controller.test.ts
+++ b/src/main/core/mcp-server/controller.test.ts
@@ -22,6 +22,13 @@ vi.mock('./service', () => ({
     reconcile: mockReconcile,
     rotateToken: mockRotateToken,
   },
+  // The controller's `getConfigSnippets` calls `getBridgeCommand()` to build
+  // the snippet body. Stub it with a deterministic value so the assertions
+  // can pin the substring without depending on the real `process.cwd()`.
+  getBridgeCommand: () => ({
+    command: 'node',
+    args: ['/abs/path/to/out/main/emdash-mcp.js'],
+  }),
 }));
 
 vi.mock('@main/core/settings/settings-service', () => ({

--- a/src/main/core/mcp-server/controller.test.ts
+++ b/src/main/core/mcp-server/controller.test.ts
@@ -183,6 +183,7 @@ describe('mcpServerController', () => {
       const result = await mcpServerController.getConfigSnippets();
       expect(result.success).toBe(true);
       if (!result.success) throw new Error('expected ok');
+      expect(result.data.claudeCodeCli).toContain('7457');
       expect(result.data.claudeCode).toContain('7457');
       expect(result.data.cursor).toContain('7457');
       expect(result.data.codex).toContain('7457');
@@ -190,6 +191,27 @@ describe('mcpServerController', () => {
       for (const snippet of Object.values(result.data)) {
         expect(snippet).toContain('emdash-mcp');
       }
+    });
+
+    it('emits a `claude mcp add` one-liner with user scope, env, and the bridge command', async () => {
+      mockGetStatus.mockResolvedValue({
+        enabled: true,
+        running: true,
+        port: 7457,
+        tokenPresent: true,
+        uptimeMs: 100,
+        lastError: null,
+      });
+      const result = await mcpServerController.getConfigSnippets();
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected ok');
+      // Single-line, starts with the CLI invocation, uses user scope, mirrors
+      // the env var the JSON form sets, and ends with `-- node <bridge-path>`.
+      expect(result.data.claudeCodeCli).not.toContain('\n');
+      expect(result.data.claudeCodeCli).toMatch(/^claude mcp add emdash\b/);
+      expect(result.data.claudeCodeCli).toContain('--scope user');
+      expect(result.data.claudeCodeCli).toContain('-e EMDASH_MCP_PORT=7457');
+      expect(result.data.claudeCodeCli).toContain('-- node /abs/path/to/out/main/emdash-mcp.js');
     });
 
     it('falls back to the configured port when the server is not running', async () => {
@@ -205,6 +227,7 @@ describe('mcpServerController', () => {
       const result = await mcpServerController.getConfigSnippets();
       expect(result.success).toBe(true);
       if (!result.success) throw new Error('expected ok');
+      expect(result.data.claudeCodeCli).toContain('9999');
       expect(result.data.claudeCode).toContain('9999');
       expect(result.data.codex).toContain('9999');
     });

--- a/src/main/core/mcp-server/controller.ts
+++ b/src/main/core/mcp-server/controller.ts
@@ -1,13 +1,188 @@
-import { createRPCController } from '@shared/ipc/rpc';
-
 /**
  * RPC controller for the renderer Settings page that drives the emdash MCP
  * server (start/stop, port changes, token rotation, recent calls).
  *
- * Eventual handlers (per design spec):
- * - `getStatus`, `setEnabled`, `setPort`, `rotateToken`, `getRecentCalls`.
- *
- * Currently a stub — empty handler map. Wiring into `src/main/rpc.ts` is
- * deferred until the controller has real handlers.
+ * The renderer Settings view (T8) consumes this via the auto-generated
+ * `mcpServer.*` RPC namespace.
  */
-export const mcpServerController = createRPCController({});
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import type { McpServerStatus } from '@shared/events/mcpServerEvents';
+import { createRPCController } from '@shared/ipc/rpc';
+import { err, ok, type Result } from '@shared/result';
+import { appSettingsService } from '@main/core/settings/settings-service';
+import { log } from '@main/lib/logger';
+import {
+  recentCallsRing,
+  type RecentCallEntry,
+  type RecentCallSnapshotOptions,
+} from './recent-calls';
+import { mcpServerService } from './service';
+
+/**
+ * Returns the live status snapshot. Never fails (the underlying service
+ * always returns a status, defaulting to `enabled=false, running=false`).
+ */
+async function getStatus(): Promise<Result<McpServerStatus, never>> {
+  const status = await mcpServerService.getStatus();
+  return ok(status);
+}
+
+/**
+ * Toggle `appSettings.mcpServer.enabled` and reconcile the service so the
+ * HTTP transport starts/stops to match.
+ */
+async function setEnabled(args: { enabled: boolean }): Promise<Result<void, string>> {
+  try {
+    const current = await appSettingsService.get('mcpServer');
+    await appSettingsService.update('mcpServer', { ...current, enabled: args.enabled });
+    await mcpServerService.reconcile();
+    return ok(undefined);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error('[mcp-server] setEnabled failed', error);
+    return err(message);
+  }
+}
+
+/**
+ * Update `appSettings.mcpServer.port` (and reconcile). Port validation lives
+ * in the settings schema — invalid values bubble out via the Zod failure
+ * message.
+ */
+async function setPort(args: { port: number }): Promise<Result<void, string>> {
+  try {
+    const current = await appSettingsService.get('mcpServer');
+    await appSettingsService.update('mcpServer', { ...current, port: args.port });
+    await mcpServerService.reconcile();
+    return ok(undefined);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error('[mcp-server] setPort failed', error);
+    return err(message);
+  }
+}
+
+/**
+ * Regenerate the bearer token, persist it to `~/.emdash/mcp.json`, and
+ * restart the running HTTP transport so live sessions are forced to
+ * reconnect with the new token.
+ */
+async function rotateToken(): Promise<Result<{ token: string }, string>> {
+  try {
+    const result = await mcpServerService.rotateToken();
+    return ok(result);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error('[mcp-server] rotateToken failed', error);
+    return err(message);
+  }
+}
+
+/** Read the recent-calls ring buffer for the Settings page's live list. */
+async function getRecentCalls(
+  args?: RecentCallSnapshotOptions
+): Promise<Result<RecentCallEntry[], never>> {
+  return ok(recentCallsRing.snapshot(args ?? {}));
+}
+
+/**
+ * Return the absolute path of the token file. The renderer uses the existing
+ * shell APIs to open it; the controller intentionally does not perform any
+ * filesystem reveal itself (separation of concerns + testability).
+ */
+async function revealTokenFile(): Promise<Result<{ path: string }, string>> {
+  try {
+    const path = join(homedir(), '.emdash', 'mcp.json');
+    return ok({ path });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    return err(message);
+  }
+}
+
+/**
+ * Generate copy-paste config snippets for popular MCP clients. Uses the
+ * **stdio bridge** form — external clients spawn `emdash-mcp` (a small
+ * stdio→HTTP shim) instead of speaking HTTP directly so they don't have to
+ * juggle a bearer token themselves.
+ *
+ * The bin is shipped with the packaged app; in dev / non-packaged runs it
+ * lives at `bin/emdash-mcp` relative to the install. Per spec these snippets
+ * are display-only and the user pastes them by hand, so referring to the
+ * `emdash-mcp` bin name is sufficient for v1.
+ *
+ * Token + port are inlined into each snippet so the user has everything they
+ * need in one block.
+ */
+async function getConfigSnippets(): Promise<
+  Result<{ claudeCode: string; cursor: string; codex: string }, string>
+> {
+  try {
+    const status = await mcpServerService.getStatus();
+    // Fall back to the configured (not necessarily bound) port if the server
+    // isn't running yet — the snippet is still useful for "I'll start it
+    // later" workflows.
+    const settings = await appSettingsService.get('mcpServer');
+    const port = status.port ?? settings.port;
+    // Mirror the stdio bridge contract: the bin reads ~/.emdash/mcp.json for
+    // the token itself, so the snippet does NOT inline the bearer token.
+    // The bridge bin path is referenced by name; the user installs the
+    // packaged app which puts `emdash-mcp` on PATH.
+    const bin = 'emdash-mcp';
+
+    const claudeCode = JSON.stringify(
+      {
+        mcpServers: {
+          emdash: {
+            command: bin,
+            args: [],
+            env: { EMDASH_MCP_PORT: String(port) },
+          },
+        },
+      },
+      null,
+      2
+    );
+
+    const cursor = JSON.stringify(
+      {
+        mcpServers: {
+          emdash: {
+            command: bin,
+            args: [],
+            env: { EMDASH_MCP_PORT: String(port) },
+          },
+        },
+      },
+      null,
+      2
+    );
+
+    // Codex's MCP config uses a TOML block.
+    const codex = [
+      '[mcp_servers.emdash]',
+      `command = "${bin}"`,
+      'args = []',
+      '',
+      '[mcp_servers.emdash.env]',
+      `EMDASH_MCP_PORT = "${port}"`,
+    ].join('\n');
+
+    return ok({ claudeCode, cursor, codex });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    log.error('[mcp-server] getConfigSnippets failed', error);
+    return err(message);
+  }
+}
+
+export const mcpServerController = createRPCController({
+  getStatus,
+  setEnabled,
+  setPort,
+  rotateToken,
+  getRecentCalls,
+  revealTokenFile,
+  getConfigSnippets,
+});

--- a/src/main/core/mcp-server/controller.ts
+++ b/src/main/core/mcp-server/controller.ts
@@ -1,0 +1,13 @@
+import { createRPCController } from '@shared/ipc/rpc';
+
+/**
+ * RPC controller for the renderer Settings page that drives the emdash MCP
+ * server (start/stop, port changes, token rotation, recent calls).
+ *
+ * Eventual handlers (per design spec):
+ * - `getStatus`, `setEnabled`, `setPort`, `rotateToken`, `getRecentCalls`.
+ *
+ * Currently a stub — empty handler map. Wiring into `src/main/rpc.ts` is
+ * deferred until the controller has real handlers.
+ */
+export const mcpServerController = createRPCController({});

--- a/src/main/core/mcp-server/controller.ts
+++ b/src/main/core/mcp-server/controller.ts
@@ -115,7 +115,7 @@ async function revealTokenFile(): Promise<Result<{ path: string }, string>> {
  * can override the file's port without a restart).
  */
 async function getConfigSnippets(): Promise<
-  Result<{ claudeCode: string; cursor: string; codex: string }, string>
+  Result<{ claudeCodeCli: string; claudeCode: string; cursor: string; codex: string }, string>
 > {
   try {
     const status = await mcpServerService.getStatus();
@@ -125,6 +125,19 @@ async function getConfigSnippets(): Promise<
     const settings = await appSettingsService.get('mcpServer');
     const port = status.port ?? settings.port;
     const { command, args } = getBridgeCommand();
+
+    // One-liner that writes the same config the JSON block below would, via
+    // `claude mcp add`. `--scope user` so it's available from any directory;
+    // `-e EMDASH_MCP_PORT=<port>` mirrors the env we set in the JSON form. The
+    // `--` separator hands the rest verbatim to the spawned stdio bridge.
+    const claudeCodeCli = [
+      'claude mcp add emdash',
+      '--scope user',
+      `-e EMDASH_MCP_PORT=${port}`,
+      '--',
+      shellQuote(command),
+      ...args.map(shellQuote),
+    ].join(' ');
 
     const claudeCode = JSON.stringify(
       {
@@ -164,12 +177,23 @@ async function getConfigSnippets(): Promise<
       `EMDASH_MCP_PORT = "${port}"`,
     ].join('\n');
 
-    return ok({ claudeCode, cursor, codex });
+    return ok({ claudeCodeCli, claudeCode, cursor, codex });
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.error('[mcp-server] getConfigSnippets failed', error);
     return err(message);
   }
+}
+
+/**
+ * Minimal POSIX-shell quoter: bare words stay bare, anything else gets single
+ * quotes (with any embedded `'` rewritten as `'\''`). Sufficient for paths and
+ * args we emit into copy-paste snippets — we don't try to be a full shell
+ * tokenizer.
+ */
+function shellQuote(value: string): string {
+  if (value.length > 0 && /^[A-Za-z0-9_\-./:=@%+,]+$/.test(value)) return value;
+  return `'${value.replace(/'/g, `'\\''`)}'`;
 }
 
 export const mcpServerController = createRPCController({

--- a/src/main/core/mcp-server/controller.ts
+++ b/src/main/core/mcp-server/controller.ts
@@ -17,7 +17,7 @@ import {
   type RecentCallEntry,
   type RecentCallSnapshotOptions,
 } from './recent-calls';
-import { mcpServerService } from './service';
+import { getBridgeCommand, mcpServerService } from './service';
 
 /**
  * Returns the live status snapshot. Never fails (the underlying service
@@ -107,13 +107,12 @@ async function revealTokenFile(): Promise<Result<{ path: string }, string>> {
  * stdio→HTTP shim) instead of speaking HTTP directly so they don't have to
  * juggle a bearer token themselves.
  *
- * The bin is shipped with the packaged app; in dev / non-packaged runs it
- * lives at `bin/emdash-mcp` relative to the install. Per spec these snippets
- * are display-only and the user pastes them by hand, so referring to the
- * `emdash-mcp` bin name is sufficient for v1.
- *
- * Token + port are inlined into each snippet so the user has everything they
- * need in one block.
+ * `getBridgeCommand()` resolves the actually-deployable command: the
+ * unpacked resource path inside the packaged app, or the dev-time
+ * `out/main/emdash-mcp.js` build artifact otherwise. The bin reads
+ * `~/.emdash/mcp.json` for the token itself, so we never inline the bearer
+ * token here — only the port (mirrored into `EMDASH_MCP_PORT` so the bridge
+ * can override the file's port without a restart).
  */
 async function getConfigSnippets(): Promise<
   Result<{ claudeCode: string; cursor: string; codex: string }, string>
@@ -125,18 +124,14 @@ async function getConfigSnippets(): Promise<
     // later" workflows.
     const settings = await appSettingsService.get('mcpServer');
     const port = status.port ?? settings.port;
-    // Mirror the stdio bridge contract: the bin reads ~/.emdash/mcp.json for
-    // the token itself, so the snippet does NOT inline the bearer token.
-    // The bridge bin path is referenced by name; the user installs the
-    // packaged app which puts `emdash-mcp` on PATH.
-    const bin = 'emdash-mcp';
+    const { command, args } = getBridgeCommand();
 
     const claudeCode = JSON.stringify(
       {
         mcpServers: {
           emdash: {
-            command: bin,
-            args: [],
+            command,
+            args,
             env: { EMDASH_MCP_PORT: String(port) },
           },
         },
@@ -149,8 +144,8 @@ async function getConfigSnippets(): Promise<
       {
         mcpServers: {
           emdash: {
-            command: bin,
-            args: [],
+            command,
+            args,
             env: { EMDASH_MCP_PORT: String(port) },
           },
         },
@@ -162,8 +157,8 @@ async function getConfigSnippets(): Promise<
     // Codex's MCP config uses a TOML block.
     const codex = [
       '[mcp_servers.emdash]',
-      `command = "${bin}"`,
-      'args = []',
+      `command = "${command}"`,
+      `args = ${JSON.stringify(args)}`,
       '',
       '[mcp_servers.emdash.env]',
       `EMDASH_MCP_PORT = "${port}"`,

--- a/src/main/core/mcp-server/http-server.test.ts
+++ b/src/main/core/mcp-server/http-server.test.ts
@@ -16,8 +16,11 @@ describe('McpHttpServer', () => {
   let port: number;
 
   async function startServer(token = TOKEN, listenPort = 0): Promise<number> {
-    const mcpServer = createMcpServer();
-    const { port: bound } = await server.start({ port: listenPort, token, mcpServer });
+    const { port: bound } = await server.start({
+      port: listenPort,
+      token,
+      mcpServerFactory: createMcpServer,
+    });
     return bound;
   }
 
@@ -203,8 +206,9 @@ describe('McpHttpServer', () => {
       const placeholder = await listenOnEphemeralPort();
       const taken = (placeholder.address() as AddressInfo).port;
       try {
-        const mcpServer = createMcpServer();
-        await expect(server.start({ port: taken, token: TOKEN, mcpServer })).rejects.toMatchObject({
+        await expect(
+          server.start({ port: taken, token: TOKEN, mcpServerFactory: createMcpServer })
+        ).rejects.toMatchObject({
           name: 'McpServerStartError',
           code: 'PORT_IN_USE',
         });

--- a/src/main/core/mcp-server/http-server.test.ts
+++ b/src/main/core/mcp-server/http-server.test.ts
@@ -1,0 +1,293 @@
+import { createServer, type Server as NodeHttpServer } from 'node:http';
+import type { AddressInfo } from 'node:net';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { McpHttpServer, McpServerStartError } from './http-server';
+import { createMcpServer } from './server';
+
+/**
+ * Integration-flavoured tests for `McpHttpServer`. We avoid driving the MCP
+ * protocol itself here — that belongs in T4+ tool tests. What we cover is
+ * the *gateway* concerns the transport doesn't enforce: bearer auth, host
+ * header, port-in-use surfacing, and idempotent shutdown.
+ */
+describe('McpHttpServer', () => {
+  const TOKEN = 'test-token-abcdef';
+  let server: McpHttpServer;
+  let port: number;
+
+  async function startServer(token = TOKEN, listenPort = 0): Promise<number> {
+    const mcpServer = createMcpServer();
+    const { port: bound } = await server.start({ port: listenPort, token, mcpServer });
+    return bound;
+  }
+
+  beforeEach(() => {
+    server = new McpHttpServer();
+  });
+
+  afterEach(async () => {
+    await server.stop();
+  });
+
+  describe('auth', () => {
+    beforeEach(async () => {
+      port = await startServer();
+    });
+
+    it('returns 401 when the Authorization header is missing', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(res.status).toBe(401);
+      expect(res.headers.get('WWW-Authenticate')).toMatch(/Bearer/);
+      await res.body?.cancel();
+    });
+
+    it('returns 401 when the bearer token does not match', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer wrong-token',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(res.status).toBe(401);
+      await res.body?.cancel();
+    });
+
+    it('returns 401 when the scheme is not Bearer', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Basic ${TOKEN}`,
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(res.status).toBe(401);
+      await res.body?.cancel();
+    });
+
+    it('returns 401 when the token differs in length (constant-time guard)', async () => {
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          // intentionally shorter than TOKEN to exercise the length-mismatch branch
+          Authorization: 'Bearer short',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(res.status).toBe(401);
+      await res.body?.cancel();
+    });
+  });
+
+  describe('host header', () => {
+    beforeEach(async () => {
+      port = await startServer();
+    });
+
+    it('returns 421 when the Host header is something other than loopback', async () => {
+      // fetch() won't let us spoof Host, so go through the raw http client.
+      const body = await rawRequest({
+        port,
+        method: 'POST',
+        path: '/mcp',
+        headers: {
+          Host: 'evil.example.com',
+          Authorization: `Bearer ${TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(body.statusCode).toBe(421);
+    });
+
+    it('returns 421 when the Host header port differs from the bound port', async () => {
+      const body = await rawRequest({
+        port,
+        method: 'POST',
+        path: '/mcp',
+        headers: {
+          Host: `127.0.0.1:${port + 1}`,
+          Authorization: `Bearer ${TOKEN}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(body.statusCode).toBe(421);
+    });
+
+    it('accepts the 127.0.0.1:<port> Host header (auth passes through to MCP)', async () => {
+      // We're not running a real MCP handshake here — just confirming that the
+      // request gets past the gateway (i.e. is NOT a 421 or 401). The transport
+      // will respond with its own error for a malformed initialize, but the
+      // status code will not be 421/401.
+      const body = await rawRequest({
+        port,
+        method: 'POST',
+        path: '/mcp',
+        headers: {
+          Host: `127.0.0.1:${port}`,
+          Authorization: `Bearer ${TOKEN}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(body.statusCode).not.toBe(421);
+      expect(body.statusCode).not.toBe(401);
+    });
+
+    it('accepts the localhost:<port> Host header', async () => {
+      const body = await rawRequest({
+        port,
+        method: 'POST',
+        path: '/mcp',
+        headers: {
+          Host: `localhost:${port}`,
+          Authorization: `Bearer ${TOKEN}`,
+          'Content-Type': 'application/json',
+          Accept: 'application/json, text/event-stream',
+        },
+        body: JSON.stringify({ jsonrpc: '2.0', id: 1, method: 'ping' }),
+      });
+      expect(body.statusCode).not.toBe(421);
+      expect(body.statusCode).not.toBe(401);
+    });
+  });
+
+  describe('routing', () => {
+    it('returns 404 for paths outside /mcp (after auth passes)', async () => {
+      port = await startServer();
+      const res = await fetch(`http://127.0.0.1:${port}/not-mcp`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      expect(res.status).toBe(404);
+      await res.body?.cancel();
+    });
+  });
+
+  describe('lifecycle', () => {
+    it('exposes isRunning() and getPort() correctly', async () => {
+      expect(server.isRunning()).toBe(false);
+      expect(server.getPort()).toBeNull();
+      port = await startServer();
+      expect(server.isRunning()).toBe(true);
+      expect(server.getPort()).toBe(port);
+      await server.stop();
+      expect(server.isRunning()).toBe(false);
+      expect(server.getPort()).toBeNull();
+    });
+
+    it('stop() is idempotent', async () => {
+      port = await startServer();
+      await expect(server.stop()).resolves.toBeUndefined();
+      await expect(server.stop()).resolves.toBeUndefined();
+      await expect(server.stop()).resolves.toBeUndefined();
+    });
+
+    it('rejects a second start() without an intervening stop()', async () => {
+      port = await startServer();
+      await expect(startServer(TOKEN, port)).rejects.toThrow(McpServerStartError);
+    });
+
+    it('throws McpServerStartError with code PORT_IN_USE when the port is taken', async () => {
+      // Grab an ephemeral port via a placeholder server, then try to start our
+      // McpHttpServer on the same port.
+      const placeholder = await listenOnEphemeralPort();
+      const taken = (placeholder.address() as AddressInfo).port;
+      try {
+        const mcpServer = createMcpServer();
+        await expect(server.start({ port: taken, token: TOKEN, mcpServer })).rejects.toMatchObject({
+          name: 'McpServerStartError',
+          code: 'PORT_IN_USE',
+        });
+      } finally {
+        await new Promise<void>((resolve) => placeholder.close(() => resolve()));
+      }
+    });
+
+    it('rejects WebSocket upgrade requests', async () => {
+      port = await startServer();
+      // We can't easily test upgrade without a WS client; assert that opening
+      // a raw TCP socket and asking for an Upgrade gets the connection killed
+      // (closed without an HTTP response). Doing that with `node:net` adds
+      // flake; instead just verify that the server still works after the test
+      // by re-issuing an authorized request. Smoke-level coverage is fine —
+      // the production guard is `server.on('upgrade', socket.destroy)`.
+      const res = await fetch(`http://127.0.0.1:${port}/mcp`, {
+        method: 'GET',
+        headers: { Authorization: `Bearer ${TOKEN}` },
+      });
+      // Any non-401, non-421 response means the gateway forwarded to the
+      // MCP transport, which is the success criterion here.
+      expect([200, 400, 405, 406]).toContain(res.status);
+      await res.body?.cancel();
+    });
+  });
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+/**
+ * Sends an HTTP request with full control over the headers (including `Host`,
+ * which `fetch()` reserves) and returns the parsed response. Body is read in
+ * full — only safe for small responses, which is what our test assertions
+ * compare against.
+ */
+async function rawRequest(opts: {
+  port: number;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body?: string;
+}): Promise<{ statusCode: number; body: string }> {
+  const { request } = await import('node:http');
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        host: '127.0.0.1',
+        port: opts.port,
+        method: opts.method,
+        path: opts.path,
+        headers: opts.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+        res.on('error', reject);
+      }
+    );
+    req.on('error', reject);
+    if (opts.body) req.write(opts.body);
+    req.end();
+  });
+}
+
+/**
+ * Listens on an OS-assigned ephemeral port and returns the underlying server
+ * so the test can read the port number and close the server on teardown.
+ */
+async function listenOnEphemeralPort(): Promise<NodeHttpServer> {
+  const placeholder = createServer((_req, res) => {
+    res.statusCode = 204;
+    res.end();
+  });
+  await new Promise<void>((resolve, reject) => {
+    placeholder.once('error', reject);
+    placeholder.listen(0, '127.0.0.1', () => resolve());
+  });
+  return placeholder;
+}

--- a/src/main/core/mcp-server/http-server.ts
+++ b/src/main/core/mcp-server/http-server.ts
@@ -1,23 +1,308 @@
+import { randomUUID, timingSafeEqual } from 'node:crypto';
+import {
+  createServer,
+  type IncomingMessage,
+  type Server as NodeHttpServer,
+  type ServerResponse,
+} from 'node:http';
+import type { AddressInfo } from 'node:net';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js';
+import { log } from '@main/lib/logger';
+
+/**
+ * Loopback bind address. Hard-coded — the spec is explicit that emdash MCP
+ * is loopback-only. Never bind to `0.0.0.0`, never accept LAN traffic.
+ */
+const LOOPBACK_HOST = '127.0.0.1';
+
+/** The single endpoint the MCP transport answers on. */
+const MCP_ENDPOINT = '/mcp';
+
+/** Header used by stateful `StreamableHTTPServerTransport` sessions. */
+const MCP_SESSION_HEADER = 'mcp-session-id';
+
+/**
+ * Typed startup failure. Surface this through the service so the renderer
+ * can show a useful Settings-page error (e.g. "port already in use").
+ */
+export class McpServerStartError extends Error {
+  constructor(
+    public readonly code: 'PORT_IN_USE' | 'BIND_FAILED' | 'ALREADY_RUNNING',
+    message: string,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'McpServerStartError';
+  }
+}
+
+export interface McpHttpServerStartOptions {
+  port: number;
+  token: string;
+  mcpServer: McpServer;
+}
+
 /**
  * Loopback HTTP transport for the emdash MCP server.
  *
- * Eventual responsibilities:
+ * Responsibilities:
  * - Bind a Node `http.Server` to `127.0.0.1:<port>` (loopback only).
- * - Validate the `Authorization: Bearer <token>` header against the persisted
- *   token from `token-store`.
  * - Reject requests whose `Host` header is not `127.0.0.1:<port>` or
- *   `localhost:<port>` (DNS-rebinding mitigation).
- * - Hand authenticated sessions off to the `@modelcontextprotocol/sdk`
- *   `Server` instance produced by `createMcpServer`.
+ *   `localhost:<port>` (DNS-rebinding mitigation, HTTP 421).
+ * - Require `Authorization: Bearer <token>` matching the configured token,
+ *   compared in constant time (HTTP 401 on missing/mismatch).
+ * - Hand authenticated requests to the SDK `StreamableHTTPServerTransport`
+ *   bound to the supplied `McpServer`.
+ * - Surface `EADDRINUSE` as a typed `McpServerStartError`.
  *
- * Currently a stub — `start` and `stop` are no-ops.
+ * NOT responsible for:
+ * - Tool / resource registration (see `server.ts` and the `tools/` +
+ *   `resources/` modules).
+ * - Token storage or rotation (see `token-store.ts`).
+ * - Settings reconciliation (see `service.ts`).
  */
 export class McpHttpServer {
-  async start(_port: number, _token: string): Promise<void> {
-    return Promise.resolve();
+  private httpServer: NodeHttpServer | null = null;
+  private boundPort: number | null = null;
+  private tokenBuffer: Buffer | null = null;
+
+  /**
+   * One transport per session. The SDK transport is stateful — for SSE
+   * subscriptions to work across multiple HTTP requests the client must keep
+   * sending the same `mcp-session-id`, and we must hand the request to the
+   * same transport instance each time.
+   */
+  private readonly transports = new Map<string, StreamableHTTPServerTransport>();
+
+  /**
+   * The active `McpServer` for the current run. Connected to every new
+   * transport so that all sessions share the same tool/resource registry.
+   */
+  private mcpServer: McpServer | null = null;
+
+  /**
+   * Starts the HTTP server. Rejects with `McpServerStartError` on bind
+   * failure (typically `EADDRINUSE`). Resolves with the actually-bound port.
+   *
+   * `port: 0` is allowed and asks the OS to pick an ephemeral port (used by
+   * tests). The resolved value reflects what the OS gave us.
+   */
+  async start(opts: McpHttpServerStartOptions): Promise<{ port: number }> {
+    if (this.httpServer) {
+      throw new McpServerStartError(
+        'ALREADY_RUNNING',
+        'MCP HTTP server is already running; call stop() first.'
+      );
+    }
+    if (!opts.token || typeof opts.token !== 'string') {
+      throw new Error('McpHttpServer.start requires a non-empty token');
+    }
+
+    this.tokenBuffer = Buffer.from(opts.token, 'utf8');
+    this.mcpServer = opts.mcpServer;
+
+    const server = createServer((req, res) => {
+      this.handle(req, res).catch((err) => {
+        log.error('[mcp-server] unhandled error in request handler', err);
+        if (!res.headersSent) {
+          this.respondJson(res, 500, { error: 'internal_error' });
+        } else {
+          try {
+            res.end();
+          } catch {
+            // ignore
+          }
+        }
+      });
+    });
+
+    // Reject WebSocket / CONNECT upgrade attempts outright. The MCP transport
+    // only needs HTTP (with SSE streaming as the response body); we don't want
+    // accidental upgrade routes that bypass auth.
+    server.on('upgrade', (_req, socket) => {
+      socket.destroy();
+    });
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        const onError = (err: NodeJS.ErrnoException) => {
+          server.removeListener('listening', onListening);
+          reject(err);
+        };
+        const onListening = () => {
+          server.removeListener('error', onError);
+          resolve();
+        };
+        server.once('error', onError);
+        server.once('listening', onListening);
+        // IMPORTANT: bind to loopback only. Never pass undefined / '0.0.0.0'.
+        server.listen(opts.port, LOOPBACK_HOST);
+      });
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code === 'EADDRINUSE') {
+        throw new McpServerStartError(
+          'PORT_IN_USE',
+          `MCP server cannot bind to ${LOOPBACK_HOST}:${opts.port}: address already in use`,
+          err
+        );
+      }
+      throw new McpServerStartError(
+        'BIND_FAILED',
+        `MCP server failed to bind to ${LOOPBACK_HOST}:${opts.port}: ${(err as Error).message}`,
+        err
+      );
+    }
+
+    const addr = server.address();
+    if (!addr || typeof addr === 'string') {
+      // Should never happen with TCP listen; defensive cleanup.
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+      throw new McpServerStartError('BIND_FAILED', 'MCP server bound to a non-TCP address');
+    }
+    this.httpServer = server;
+    this.boundPort = (addr as AddressInfo).port;
+    return { port: this.boundPort };
   }
 
+  /**
+   * Gracefully stops the HTTP server and tears down every active transport.
+   * Safe to call when not running (idempotent).
+   */
   async stop(): Promise<void> {
-    return Promise.resolve();
+    const server = this.httpServer;
+    this.httpServer = null;
+    this.boundPort = null;
+    this.tokenBuffer = null;
+    this.mcpServer = null;
+
+    // Close all open transports first so in-flight SSE streams shut down
+    // before we kill the underlying socket.
+    const transports = Array.from(this.transports.values());
+    this.transports.clear();
+    await Promise.allSettled(transports.map((t) => t.close()));
+
+    if (!server) return;
+    await new Promise<void>((resolve) => {
+      server.close(() => resolve());
+      // Force-disconnect idle keep-alive connections so close() returns
+      // promptly even if a client is holding the socket open.
+      server.closeIdleConnections?.();
+    });
+  }
+
+  isRunning(): boolean {
+    return this.httpServer !== null;
+  }
+
+  getPort(): number | null {
+    return this.boundPort;
+  }
+
+  // ── Request handling ────────────────────────────────────────────────────
+
+  private async handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    // DNS-rebinding protection: the Host header must match a loopback name
+    // bound to the actual port we're listening on. This blocks browser-based
+    // attacks where a malicious DNS record points at our loopback IP.
+    if (!this.isHostHeaderAllowed(req.headers.host)) {
+      this.respondJson(res, 421, {
+        error: 'misdirected_request',
+        message: 'Host header must be 127.0.0.1 or localhost on the bound port.',
+      });
+      return;
+    }
+
+    if (!this.isAuthorized(req.headers.authorization)) {
+      // WWW-Authenticate signals Bearer scheme so clients can prompt.
+      res.setHeader('WWW-Authenticate', 'Bearer realm="emdash-mcp"');
+      this.respondJson(res, 401, { error: 'unauthorized' });
+      return;
+    }
+
+    const url = req.url ?? '/';
+    if (!url.startsWith(MCP_ENDPOINT)) {
+      this.respondJson(res, 404, { error: 'not_found' });
+      return;
+    }
+
+    await this.routeMcp(req, res);
+  }
+
+  private isHostHeaderAllowed(host: string | undefined): boolean {
+    if (!host || this.boundPort === null) return false;
+    // The OS may surface IPv6 loopback as `[::1]`; we don't bind to ::1 (we
+    // bind to 127.0.0.1 explicitly), so we don't need to accept it here.
+    const allowed = new Set([`127.0.0.1:${this.boundPort}`, `localhost:${this.boundPort}`]);
+    return allowed.has(host);
+  }
+
+  private isAuthorized(header: string | undefined): boolean {
+    if (!header || !this.tokenBuffer) return false;
+    // Header format: "Bearer <token>". Be strict — no other schemes.
+    if (!header.startsWith('Bearer ')) return false;
+    const presented = header.slice('Bearer '.length).trim();
+    if (presented.length === 0) return false;
+    const presentedBuf = Buffer.from(presented, 'utf8');
+    // timingSafeEqual requires identical byte lengths; bail (still constant
+    // time w.r.t. token bytes) if the lengths differ.
+    if (presentedBuf.length !== this.tokenBuffer.length) return false;
+    return timingSafeEqual(presentedBuf, this.tokenBuffer);
+  }
+
+  private async routeMcp(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const sessionHeader = req.headers[MCP_SESSION_HEADER];
+    const sessionId = Array.isArray(sessionHeader) ? sessionHeader[0] : sessionHeader;
+
+    let transport = sessionId ? this.transports.get(sessionId) : undefined;
+
+    if (!transport) {
+      const mcpServer = this.mcpServer;
+      if (!mcpServer) {
+        this.respondJson(res, 503, { error: 'mcp_server_not_ready' });
+        return;
+      }
+      transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        onsessionclosed: (closedId) => {
+          const existing = this.transports.get(closedId);
+          if (existing) {
+            this.transports.delete(closedId);
+            existing.close().catch((err) => {
+              log.warn('[mcp-server] error closing transport on session-closed', err);
+            });
+          }
+        },
+      });
+
+      const createdTransport = transport;
+      const originalOnClose = createdTransport.onclose;
+      createdTransport.onclose = () => {
+        // Remove from the map whenever the transport closes for any reason
+        // (client disconnect, explicit close, etc.).
+        if (createdTransport.sessionId) {
+          this.transports.delete(createdTransport.sessionId);
+        }
+        originalOnClose?.();
+      };
+
+      await mcpServer.connect(createdTransport);
+
+      if (createdTransport.sessionId) {
+        this.transports.set(createdTransport.sessionId, createdTransport);
+      }
+    }
+
+    await transport.handleRequest(req, res);
+  }
+
+  private respondJson(res: ServerResponse, status: number, body: unknown): void {
+    if (res.headersSent) return;
+    const payload = JSON.stringify(body);
+    res.statusCode = status;
+    res.setHeader('Content-Type', 'application/json');
+    res.setHeader('Content-Length', Buffer.byteLength(payload).toString());
+    res.end(payload);
   }
 }

--- a/src/main/core/mcp-server/http-server.ts
+++ b/src/main/core/mcp-server/http-server.ts
@@ -263,8 +263,26 @@ export class McpHttpServer {
         this.respondJson(res, 503, { error: 'mcp_server_not_ready' });
         return;
       }
-      transport = new StreamableHTTPServerTransport({
+      // `onsessioninitialized` fires from inside `handleRequest` once the
+      // SDK has assigned a session id to the transport. This is the only
+      // point at which `createdTransport.sessionId` is guaranteed to be set,
+      // so it is the correct hook for registering the transport in our map
+      // — doing it *before* `handleRequest` runs would always observe
+      // `undefined`. (See `StreamableHTTPServerTransport` in
+      // `@modelcontextprotocol/sdk`.)
+      //
+      // The closures reference `createdTransport` via a one-element ref so
+      // we can build the SDK options object before the transport itself
+      // exists (the SDK assigns `this` to a per-instance setup, so it must
+      // see the same reference both ways).
+      const transportRef: { current: StreamableHTTPServerTransport | null } = { current: null };
+      const createdTransport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => randomUUID(),
+        onsessioninitialized: (initializedId) => {
+          if (transportRef.current) {
+            this.transports.set(initializedId, transportRef.current);
+          }
+        },
         onsessionclosed: (closedId) => {
           const existing = this.transports.get(closedId);
           if (existing) {
@@ -275,8 +293,9 @@ export class McpHttpServer {
           }
         },
       });
+      transportRef.current = createdTransport;
+      transport = createdTransport;
 
-      const createdTransport = transport;
       const originalOnClose = createdTransport.onclose;
       createdTransport.onclose = () => {
         // Remove from the map whenever the transport closes for any reason
@@ -288,10 +307,6 @@ export class McpHttpServer {
       };
 
       await mcpServer.connect(createdTransport);
-
-      if (createdTransport.sessionId) {
-        this.transports.set(createdTransport.sessionId, createdTransport);
-      }
     }
 
     await transport.handleRequest(req, res);

--- a/src/main/core/mcp-server/http-server.ts
+++ b/src/main/core/mcp-server/http-server.ts
@@ -1,0 +1,23 @@
+/**
+ * Loopback HTTP transport for the emdash MCP server.
+ *
+ * Eventual responsibilities:
+ * - Bind a Node `http.Server` to `127.0.0.1:<port>` (loopback only).
+ * - Validate the `Authorization: Bearer <token>` header against the persisted
+ *   token from `token-store`.
+ * - Reject requests whose `Host` header is not `127.0.0.1:<port>` or
+ *   `localhost:<port>` (DNS-rebinding mitigation).
+ * - Hand authenticated sessions off to the `@modelcontextprotocol/sdk`
+ *   `Server` instance produced by `createMcpServer`.
+ *
+ * Currently a stub — `start` and `stop` are no-ops.
+ */
+export class McpHttpServer {
+  async start(_port: number, _token: string): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async stop(): Promise<void> {
+    return Promise.resolve();
+  }
+}

--- a/src/main/core/mcp-server/http-server.ts
+++ b/src/main/core/mcp-server/http-server.ts
@@ -40,7 +40,17 @@ export class McpServerStartError extends Error {
 export interface McpHttpServerStartOptions {
   port: number;
   token: string;
-  mcpServer: McpServer;
+  /**
+   * Builds a fresh `McpServer` for each new session.
+   *
+   * The MCP SDK forbids connecting a single `McpServer` to more than one
+   * transport at a time, and `StreamableHTTPServerTransport` is one transport
+   * per HTTP session. So every new session needs its own `McpServer`. Tool
+   * and resource registration is cheap (just map inserts), and per-session
+   * isolation also keeps any per-connection state — subscriptions, request
+   * handlers — from leaking between clients.
+   */
+  mcpServerFactory: () => McpServer;
 }
 
 /**
@@ -68,18 +78,26 @@ export class McpHttpServer {
   private tokenBuffer: Buffer | null = null;
 
   /**
-   * One transport per session. The SDK transport is stateful — for SSE
-   * subscriptions to work across multiple HTTP requests the client must keep
-   * sending the same `mcp-session-id`, and we must hand the request to the
-   * same transport instance each time.
+   * One session entry per active client. The SDK transport is stateful — for
+   * SSE subscriptions to work across multiple HTTP requests the client must
+   * keep sending the same `mcp-session-id`, and we must hand the request to
+   * the same transport (and its bound `McpServer`) each time.
+   *
+   * Each session pairs a `StreamableHTTPServerTransport` with the
+   * `McpServer` it's connected to. We keep a reference to the `McpServer` so
+   * we can `close()` it when the session ends, releasing per-session
+   * subscriptions and handlers held by the SDK.
    */
-  private readonly transports = new Map<string, StreamableHTTPServerTransport>();
+  private readonly sessions = new Map<
+    string,
+    { transport: StreamableHTTPServerTransport; mcpServer: McpServer }
+  >();
 
   /**
-   * The active `McpServer` for the current run. Connected to every new
-   * transport so that all sessions share the same tool/resource registry.
+   * Factory for the active run. Invoked once per new session to mint an
+   * `McpServer` with the full tool / resource catalog registered.
    */
-  private mcpServer: McpServer | null = null;
+  private mcpServerFactory: (() => McpServer) | null = null;
 
   /**
    * Starts the HTTP server. Rejects with `McpServerStartError` on bind
@@ -100,7 +118,7 @@ export class McpHttpServer {
     }
 
     this.tokenBuffer = Buffer.from(opts.token, 'utf8');
-    this.mcpServer = opts.mcpServer;
+    this.mcpServerFactory = opts.mcpServerFactory;
 
     const server = createServer((req, res) => {
       this.handle(req, res).catch((err) => {
@@ -175,13 +193,16 @@ export class McpHttpServer {
     this.httpServer = null;
     this.boundPort = null;
     this.tokenBuffer = null;
-    this.mcpServer = null;
+    this.mcpServerFactory = null;
 
-    // Close all open transports first so in-flight SSE streams shut down
-    // before we kill the underlying socket.
-    const transports = Array.from(this.transports.values());
-    this.transports.clear();
-    await Promise.allSettled(transports.map((t) => t.close()));
+    // Close all open sessions first so in-flight SSE streams shut down before
+    // we kill the underlying socket. Close the transport AND its paired
+    // McpServer so per-session subscriptions don't leak.
+    const sessions = Array.from(this.sessions.values());
+    this.sessions.clear();
+    await Promise.allSettled(
+      sessions.flatMap(({ transport, mcpServer }) => [transport.close(), mcpServer.close()])
+    );
 
     if (!server) return;
     await new Promise<void>((resolve) => {
@@ -255,61 +276,81 @@ export class McpHttpServer {
     const sessionHeader = req.headers[MCP_SESSION_HEADER];
     const sessionId = Array.isArray(sessionHeader) ? sessionHeader[0] : sessionHeader;
 
-    let transport = sessionId ? this.transports.get(sessionId) : undefined;
+    const existing = sessionId ? this.sessions.get(sessionId) : undefined;
+    if (existing) {
+      await existing.transport.handleRequest(req, res);
+      return;
+    }
 
-    if (!transport) {
-      const mcpServer = this.mcpServer;
-      if (!mcpServer) {
-        this.respondJson(res, 503, { error: 'mcp_server_not_ready' });
-        return;
-      }
-      // `onsessioninitialized` fires from inside `handleRequest` once the
-      // SDK has assigned a session id to the transport. This is the only
-      // point at which `createdTransport.sessionId` is guaranteed to be set,
-      // so it is the correct hook for registering the transport in our map
-      // — doing it *before* `handleRequest` runs would always observe
-      // `undefined`. (See `StreamableHTTPServerTransport` in
-      // `@modelcontextprotocol/sdk`.)
-      //
-      // The closures reference `createdTransport` via a one-element ref so
-      // we can build the SDK options object before the transport itself
-      // exists (the SDK assigns `this` to a per-instance setup, so it must
-      // see the same reference both ways).
-      const transportRef: { current: StreamableHTTPServerTransport | null } = { current: null };
-      const createdTransport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        onsessioninitialized: (initializedId) => {
-          if (transportRef.current) {
-            this.transports.set(initializedId, transportRef.current);
-          }
-        },
-        onsessionclosed: (closedId) => {
-          const existing = this.transports.get(closedId);
-          if (existing) {
-            this.transports.delete(closedId);
-            existing.close().catch((err) => {
-              log.warn('[mcp-server] error closing transport on session-closed', err);
-            });
-          }
-        },
-      });
-      transportRef.current = createdTransport;
-      transport = createdTransport;
+    const factory = this.mcpServerFactory;
+    if (!factory) {
+      this.respondJson(res, 503, { error: 'mcp_server_not_ready' });
+      return;
+    }
 
-      const originalOnClose = createdTransport.onclose;
-      createdTransport.onclose = () => {
-        // Remove from the map whenever the transport closes for any reason
-        // (client disconnect, explicit close, etc.).
-        if (createdTransport.sessionId) {
-          this.transports.delete(createdTransport.sessionId);
+    // Mint a brand-new McpServer for this session. The SDK forbids connecting
+    // a single McpServer to more than one transport at a time, so each new
+    // session gets its own; tool/resource registration is cheap.
+    const sessionMcpServer = factory();
+
+    // `onsessioninitialized` fires from inside `handleRequest` once the SDK
+    // assigns a session id to the transport — that's the only point at which
+    // `transport.sessionId` is guaranteed to be set, so it's the correct hook
+    // for registering the session. The closures reach `transport` via a
+    // one-element ref so we can build the SDK options object before the
+    // transport itself exists.
+    const transportRef: { current: StreamableHTTPServerTransport | null } = { current: null };
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      onsessioninitialized: (initializedId) => {
+        const t = transportRef.current;
+        if (t) {
+          this.sessions.set(initializedId, { transport: t, mcpServer: sessionMcpServer });
         }
-        originalOnClose?.();
-      };
+      },
+      onsessionclosed: (closedId) => {
+        this.dropSession(closedId);
+      },
+    });
+    transportRef.current = transport;
 
-      await mcpServer.connect(createdTransport);
+    const originalOnClose = transport.onclose;
+    transport.onclose = () => {
+      // Remove on any close (client disconnect, explicit close, etc.). The
+      // SDK calls onsessionclosed too in many cases but this catches early
+      // disconnects before a session id was ever assigned.
+      if (transport.sessionId) {
+        this.dropSession(transport.sessionId);
+      } else {
+        sessionMcpServer.close().catch((err) => {
+          log.warn('[mcp-server] error closing per-session McpServer on early disconnect', err);
+        });
+      }
+      originalOnClose?.();
+    };
+
+    try {
+      await sessionMcpServer.connect(transport);
+    } catch (err) {
+      // Connect failure means the transport never became part of a session;
+      // drop the brand-new McpServer so we don't leak it.
+      await sessionMcpServer.close().catch(() => {});
+      throw err;
     }
 
     await transport.handleRequest(req, res);
+  }
+
+  private dropSession(sessionId: string): void {
+    const existing = this.sessions.get(sessionId);
+    if (!existing) return;
+    this.sessions.delete(sessionId);
+    existing.transport.close().catch((err) => {
+      log.warn('[mcp-server] error closing transport on session-closed', err);
+    });
+    existing.mcpServer.close().catch((err) => {
+      log.warn('[mcp-server] error closing McpServer on session-closed', err);
+    });
   }
 
   private respondJson(res: ServerResponse, status: number, body: unknown): void {

--- a/src/main/core/mcp-server/integration.test.ts
+++ b/src/main/core/mcp-server/integration.test.ts
@@ -50,7 +50,7 @@ describe('mcp-server end-to-end (HTTP + SDK client)', () => {
     const { port: bound } = await httpServer.start({
       port: 0,
       token,
-      mcpServer: buildTestMcpServer(),
+      mcpServerFactory: buildTestMcpServer,
     });
     port = bound;
   });
@@ -153,6 +153,28 @@ describe('mcp-server end-to-end (HTTP + SDK client)', () => {
     expect(body.statusCode).toBe(421);
   });
 
+  it('supports multiple concurrent sessions on the same server', async () => {
+    // Regression: a single McpServer instance can only be connected to one
+    // transport at a time (the SDK throws "Already connected to a transport"
+    // on the second connect()). The server must mint a fresh McpServer per
+    // session via the factory. Drive two sequential `initialize` round-trips
+    // and confirm both succeed and both can call tools.
+    const first = await connectClient({ port, token });
+    try {
+      const second = await connectClient({ port, token });
+      try {
+        const r1 = await first.callTool({ name: 'echo', arguments: { text: 'first' } });
+        const r2 = await second.callTool({ name: 'echo', arguments: { text: 'second' } });
+        expect(r1.content).toMatchObject([{ type: 'text', text: 'first' }]);
+        expect(r2.content).toMatchObject([{ type: 'text', text: 'second' }]);
+      } finally {
+        await second.close().catch(() => undefined);
+      }
+    } finally {
+      await first.close().catch(() => undefined);
+    }
+  });
+
   it('stop() releases the port so a second server can bind to the same port', async () => {
     // The fixture's `afterEach` will run a second `stop()` — that's fine
     // because `stop()` is idempotent. What we assert here is that *during*
@@ -167,7 +189,7 @@ describe('mcp-server end-to-end (HTTP + SDK client)', () => {
       const { port: reboundPort } = await second.start({
         port: previousPort,
         token: generateToken(),
-        mcpServer: buildTestMcpServer(),
+        mcpServerFactory: buildTestMcpServer,
       });
       expect(reboundPort).toBe(previousPort);
       expect(second.isRunning()).toBe(true);

--- a/src/main/core/mcp-server/integration.test.ts
+++ b/src/main/core/mcp-server/integration.test.ts
@@ -1,0 +1,235 @@
+/**
+ * End-to-end integration test for the emdash MCP server stack.
+ *
+ * The other tests in this directory cover each layer in isolation:
+ *  - `http-server.test.ts` exercises the raw HTTP gateway concerns (auth,
+ *    Host header, lifecycle) with no MCP client on the other side.
+ *  - `bin/emdash-mcp.test.ts` exercises the stdio bridge using
+ *    `InMemoryTransport` instead of a real HTTP server.
+ *  - The `tools/*.test.ts` and `resources/*.test.ts` suites exercise
+ *    individual handlers in isolation.
+ *
+ * This test ties everything together: a real {@link McpHttpServer} on an
+ * ephemeral port, a real token minted via {@link generateToken}, and a real
+ * SDK {@link Client} over {@link StreamableHTTPClientTransport}. The goal is
+ * to prove the transport + auth + SDK plumbing cooperates end-to-end —
+ * **not** to re-test the full tool catalog (which would drag in Electron +
+ * the DB). For that reason we hand-register a single trivial `echo` tool on
+ * a fresh `McpServer` rather than calling `createMcpServer()`.
+ */
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { z } from 'zod';
+import { McpHttpServer } from './http-server';
+import { generateToken } from './token-store';
+
+/** Builds a minimal `McpServer` with a single deterministic `echo` tool. */
+function buildTestMcpServer(): McpServer {
+  const server = new McpServer({ name: 'emdash-integration-test', version: '0.0.0' });
+  server.registerTool(
+    'echo',
+    {
+      description: 'Echoes the input text back as a single text content block.',
+      inputSchema: { text: z.string() },
+    },
+    async ({ text }) => ({ content: [{ type: 'text', text }] })
+  );
+  return server;
+}
+
+describe('mcp-server end-to-end (HTTP + SDK client)', () => {
+  let httpServer: McpHttpServer;
+  let token: string;
+  let port: number;
+
+  beforeEach(async () => {
+    httpServer = new McpHttpServer();
+    token = generateToken();
+    const { port: bound } = await httpServer.start({
+      port: 0,
+      token,
+      mcpServer: buildTestMcpServer(),
+    });
+    port = bound;
+  });
+
+  afterEach(async () => {
+    await httpServer.stop();
+  });
+
+  it('initialize succeeds with the correct bearer token', async () => {
+    const transport = new StreamableHTTPClientTransport(new URL(`http://127.0.0.1:${port}/mcp`), {
+      requestInit: {
+        headers: { Authorization: `Bearer ${token}` },
+      },
+    });
+    const client = new Client({ name: 'integration-test', version: '1' }, { capabilities: {} });
+    try {
+      await client.connect(transport);
+      // If connect() resolves without throwing the MCP `initialize` round-trip
+      // succeeded — that is the assertion. The server identity is whatever the
+      // McpServer reported during initialize, so confirm it matches.
+      const info = client.getServerVersion();
+      expect(info).toMatchObject({ name: 'emdash-integration-test' });
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
+  it('initialize fails without a bearer token (HTTP 401)', async () => {
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${port}/mcp`)
+      // No requestInit.headers — Authorization is intentionally absent.
+    );
+    const client = new Client({ name: 'integration-test', version: '1' }, { capabilities: {} });
+    let caught: unknown;
+    try {
+      await client.connect(transport);
+    } catch (err) {
+      caught = err;
+    } finally {
+      await client.close().catch(() => undefined);
+      await transport.close().catch(() => undefined);
+    }
+    expect(caught).toBeInstanceOf(Error);
+    // The SDK surfaces the HTTP transport error from the failed POST. Our
+    // gateway returns `{"error":"unauthorized"}` with a 401 status; the SDK
+    // bubbles up the body in the message, so we match on the body keyword.
+    expect(String(caught)).toMatch(/unauthorized/i);
+  });
+
+  it('tools/list returns the registered tools', async () => {
+    const client = await connectClient({ port, token });
+    try {
+      const result = await client.listTools();
+      const names = result.tools.map((t) => t.name);
+      expect(names).toContain('echo');
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
+  it('tools/call round-trips through the SDK + HTTP transport', async () => {
+    const client = await connectClient({ port, token });
+    try {
+      const result = await client.callTool({
+        name: 'echo',
+        arguments: { text: 'hello from integration test' },
+      });
+      expect(result.isError).not.toBe(true);
+      expect(result.content).toMatchObject([{ type: 'text', text: 'hello from integration test' }]);
+    } finally {
+      await client.close().catch(() => undefined);
+    }
+  });
+
+  it('rejects requests whose Host header does not match the bound port (HTTP 421)', async () => {
+    // The SDK client always sets the right Host header, so to exercise the
+    // DNS-rebinding guard we drive HTTP directly. We send the same JSON-RPC
+    // initialize the SDK would, just with a spoofed Host.
+    const body = await rawRequest({
+      port,
+      method: 'POST',
+      path: '/mcp',
+      headers: {
+        Host: 'evil.example.com',
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json, text/event-stream',
+      },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'host-header-probe', version: '0' },
+        },
+      }),
+    });
+    expect(body.statusCode).toBe(421);
+  });
+
+  it('stop() releases the port so a second server can bind to the same port', async () => {
+    // The fixture's `afterEach` will run a second `stop()` — that's fine
+    // because `stop()` is idempotent. What we assert here is that *during*
+    // the test the port really is freed: a fresh `McpHttpServer` can claim
+    // it. This catches regressions where a lingering socket / transport
+    // keeps the port held open after `stop()` returns.
+    const previousPort = port;
+    await httpServer.stop();
+
+    const second = new McpHttpServer();
+    try {
+      const { port: reboundPort } = await second.start({
+        port: previousPort,
+        token: generateToken(),
+        mcpServer: buildTestMcpServer(),
+      });
+      expect(reboundPort).toBe(previousPort);
+      expect(second.isRunning()).toBe(true);
+    } finally {
+      await second.stop();
+    }
+  });
+});
+
+// ── helpers ───────────────────────────────────────────────────────────────
+
+async function connectClient(opts: { port: number; token: string }): Promise<Client> {
+  const transport = new StreamableHTTPClientTransport(
+    new URL(`http://127.0.0.1:${opts.port}/mcp`),
+    {
+      requestInit: {
+        headers: { Authorization: `Bearer ${opts.token}` },
+      },
+    }
+  );
+  const client = new Client({ name: 'integration-test', version: '1' }, { capabilities: {} });
+  await client.connect(transport);
+  return client;
+}
+
+/**
+ * Send an HTTP request with full control over headers (including `Host`,
+ * which `fetch()` reserves). Mirrors the helper in `http-server.test.ts` —
+ * intentionally duplicated rather than shared so this test file remains a
+ * self-contained "wire up the whole stack" probe.
+ */
+async function rawRequest(opts: {
+  port: number;
+  method: string;
+  path: string;
+  headers: Record<string, string>;
+  body?: string;
+}): Promise<{ statusCode: number; body: string }> {
+  const { request } = await import('node:http');
+  return new Promise((resolve, reject) => {
+    const req = request(
+      {
+        host: '127.0.0.1',
+        port: opts.port,
+        method: opts.method,
+        path: opts.path,
+        headers: opts.headers,
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on('data', (chunk: Buffer) => chunks.push(chunk));
+        res.on('end', () => {
+          resolve({
+            statusCode: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString('utf8'),
+          });
+        });
+        res.on('error', reject);
+      }
+    );
+    req.on('error', reject);
+    if (opts.body) req.write(opts.body);
+    req.end();
+  });
+}

--- a/src/main/core/mcp-server/recent-calls.test.ts
+++ b/src/main/core/mcp-server/recent-calls.test.ts
@@ -1,0 +1,164 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RecentCallEntry } from '@shared/events/mcpServerEvents';
+import { RECENT_CALLS_CAPACITY, RecentCallsRing } from './recent-calls';
+
+// Replace the main-process event bus with a stub so importing the ring's
+// `recent-calls` module doesn't transitively load Electron / DB modules.
+vi.mock('@main/lib/events', () => ({
+  events: { emit: vi.fn(), on: vi.fn(), once: vi.fn() },
+}));
+
+/**
+ * Unit tests for the in-memory recent-calls ring buffer. The singleton in
+ * `recent-calls.ts` shares behaviour with this class — we exercise the class
+ * directly so tests stay hermetic (no global emitter, no leaked state).
+ */
+describe('RecentCallsRing', () => {
+  function makeRing(capacity?: number) {
+    const emitter = { emit: vi.fn<(data: RecentCallEntry) => void>() };
+    const ring = new RecentCallsRing(capacity, emitter);
+    return { ring, emitter };
+  }
+
+  describe('record', () => {
+    it('assigns id and ts on every entry', () => {
+      const { ring } = makeRing();
+      const before = Date.now();
+      const entry = ring.record({ tool: 'task.create', status: 'ok', ms: 12 });
+      const after = Date.now();
+      expect(entry.id).toMatch(/^[0-9a-f-]{36}$/i);
+      expect(entry.ts).toBeGreaterThanOrEqual(before);
+      expect(entry.ts).toBeLessThanOrEqual(after);
+      expect(entry.tool).toBe('task.create');
+      expect(entry.status).toBe('ok');
+      expect(entry.ms).toBe(12);
+    });
+
+    it('emits the entry on the recent-call channel', () => {
+      const { ring, emitter } = makeRing();
+      const entry = ring.record({ tool: 'task.list', status: 'ok', ms: 4 });
+      expect(emitter.emit).toHaveBeenCalledTimes(1);
+      expect(emitter.emit).toHaveBeenCalledWith(entry);
+    });
+
+    it('returns the stored entry shape (id + ts + caller fields)', () => {
+      const { ring } = makeRing();
+      const entry = ring.record({
+        tool: 'task.delete',
+        status: 'error',
+        ms: 7,
+        errorCode: 'CONFIRM_REQUIRED',
+        errorMessage: 'Set confirm: true to delete this task',
+      });
+      expect(entry.errorCode).toBe('CONFIRM_REQUIRED');
+      expect(entry.errorMessage).toBe('Set confirm: true to delete this task');
+    });
+  });
+
+  describe('snapshot', () => {
+    it('returns entries most-recent first', () => {
+      const { ring } = makeRing();
+      ring.record({ tool: 'a', status: 'ok', ms: 1 });
+      ring.record({ tool: 'b', status: 'ok', ms: 2 });
+      ring.record({ tool: 'c', status: 'ok', ms: 3 });
+      const snap = ring.snapshot();
+      expect(snap.map((e) => e.tool)).toEqual(['c', 'b', 'a']);
+    });
+
+    it('wraps around at capacity, evicting the oldest entries', () => {
+      const { ring } = makeRing(3);
+      ring.record({ tool: 'a', status: 'ok', ms: 1 });
+      ring.record({ tool: 'b', status: 'ok', ms: 1 });
+      ring.record({ tool: 'c', status: 'ok', ms: 1 });
+      ring.record({ tool: 'd', status: 'ok', ms: 1 });
+      ring.record({ tool: 'e', status: 'ok', ms: 1 });
+      const snap = ring.snapshot();
+      expect(snap.map((e) => e.tool)).toEqual(['e', 'd', 'c']);
+      expect(ring.size()).toBe(3);
+    });
+
+    it('saturates size() at the default capacity (200)', () => {
+      const { ring } = makeRing();
+      for (let i = 0; i < RECENT_CALLS_CAPACITY + 50; i += 1) {
+        ring.record({ tool: `t${i}`, status: 'ok', ms: 0 });
+      }
+      expect(ring.size()).toBe(RECENT_CALLS_CAPACITY);
+      const snap = ring.snapshot();
+      expect(snap).toHaveLength(RECENT_CALLS_CAPACITY);
+      // Most recent should be the very last write.
+      expect(snap[0]?.tool).toBe(`t${RECENT_CALLS_CAPACITY + 49}`);
+      // Oldest surviving entry should be at the eviction boundary.
+      expect(snap[snap.length - 1]?.tool).toBe(`t${50}`);
+    });
+
+    it('respects the limit filter', () => {
+      const { ring } = makeRing();
+      ring.record({ tool: 'a', status: 'ok', ms: 0 });
+      ring.record({ tool: 'b', status: 'ok', ms: 0 });
+      ring.record({ tool: 'c', status: 'ok', ms: 0 });
+      expect(ring.snapshot({ limit: 2 }).map((e) => e.tool)).toEqual(['c', 'b']);
+    });
+
+    it('filters by status', () => {
+      const { ring } = makeRing();
+      ring.record({ tool: 'a', status: 'ok', ms: 0 });
+      ring.record({ tool: 'b', status: 'error', ms: 0, errorCode: 'X' });
+      ring.record({ tool: 'c', status: 'ok', ms: 0 });
+      expect(ring.snapshot({ status: 'error' }).map((e) => e.tool)).toEqual(['b']);
+      expect(ring.snapshot({ status: 'ok' }).map((e) => e.tool)).toEqual(['c', 'a']);
+    });
+
+    it('filters by sinceTs (strict greater-than)', async () => {
+      const { ring } = makeRing();
+      const a = ring.record({ tool: 'a', status: 'ok', ms: 0 });
+      // Force a different ts on subsequent entries.
+      await new Promise((r) => setTimeout(r, 5));
+      const b = ring.record({ tool: 'b', status: 'ok', ms: 0 });
+      await new Promise((r) => setTimeout(r, 5));
+      const c = ring.record({ tool: 'c', status: 'ok', ms: 0 });
+      expect(b.ts).toBeGreaterThan(a.ts);
+      expect(c.ts).toBeGreaterThan(b.ts);
+      const sinceA = ring.snapshot({ sinceTs: a.ts });
+      expect(sinceA.map((e) => e.tool)).toEqual(['c', 'b']);
+      const sinceC = ring.snapshot({ sinceTs: c.ts });
+      expect(sinceC).toEqual([]);
+    });
+
+    it('combines limit + filters', () => {
+      const { ring } = makeRing();
+      for (let i = 0; i < 5; i += 1) {
+        ring.record({ tool: `t${i}`, status: i % 2 === 0 ? 'ok' : 'error', ms: 0 });
+      }
+      // Most-recent-first: t4(ok), t3(error), t2(ok), t1(error), t0(ok)
+      const errs = ring.snapshot({ status: 'error', limit: 1 });
+      expect(errs.map((e) => e.tool)).toEqual(['t3']);
+    });
+  });
+
+  describe('clear', () => {
+    it('drops every entry and resets size to 0', () => {
+      const { ring } = makeRing();
+      ring.record({ tool: 'a', status: 'ok', ms: 0 });
+      ring.record({ tool: 'b', status: 'ok', ms: 0 });
+      ring.clear();
+      expect(ring.size()).toBe(0);
+      expect(ring.snapshot()).toEqual([]);
+    });
+
+    it('lets the buffer be reused after clearing', () => {
+      const { ring } = makeRing();
+      ring.record({ tool: 'a', status: 'ok', ms: 0 });
+      ring.clear();
+      ring.record({ tool: 'z', status: 'ok', ms: 0 });
+      expect(ring.snapshot().map((e) => e.tool)).toEqual(['z']);
+    });
+  });
+
+  describe('constructor', () => {
+    it('rejects non-positive capacity', () => {
+      expect(() => new RecentCallsRing(0)).toThrow(/positive integer/);
+      expect(() => new RecentCallsRing(-1)).toThrow(/positive integer/);
+      expect(() => new RecentCallsRing(1.5)).toThrow(/positive integer/);
+    });
+  });
+});

--- a/src/main/core/mcp-server/recent-calls.ts
+++ b/src/main/core/mcp-server/recent-calls.ts
@@ -1,0 +1,17 @@
+/**
+ * In-memory ring buffer of recent MCP tool invocations (target capacity: 200).
+ *
+ * Eventual responsibilities:
+ * - `record(call)`: append `{ tool, ms, status, error? }` entries, evicting
+ *   the oldest when capacity is reached.
+ * - `snapshot()`: return a chronological copy for the Settings UI to render.
+ *
+ * Currently a stub — both methods are no-ops.
+ */
+export class RecentCallsRing {
+  record(): void {}
+
+  snapshot(): unknown {
+    return [];
+  }
+}

--- a/src/main/core/mcp-server/recent-calls.ts
+++ b/src/main/core/mcp-server/recent-calls.ts
@@ -1,31 +1,147 @@
 /**
- * In-memory ring buffer of recent MCP tool invocations (target capacity: 200).
+ * In-memory ring buffer of recent MCP tool invocations (fixed capacity: 200).
  *
- * Eventual responsibilities:
- * - `record(call)`: append `{ tool, ms, status, error? }` entries, evicting
- *   the oldest when capacity is reached.
- * - `snapshot()`: return a chronological copy for the Settings UI to render.
+ * Used by the Settings page (`mcpServer.getRecentCalls`) and surfaced live via
+ * the `mcpServerRecentCallChannel` event so the renderer can append entries
+ * without polling.
  *
- * Currently a stub — `record` is a no-op and `snapshot` returns an empty
- * array. T7 fills in the actual storage. The signature is finalised here so
- * tool handlers can wire `withRecording()` against the right shape today.
+ * The buffer is intentionally in-memory only — it resets when the app
+ * restarts. Persistence is out of scope for v1 (see spec).
  */
+import { randomUUID } from 'node:crypto';
+import { mcpServerRecentCallChannel, type RecentCallEntry } from '@shared/events/mcpServerEvents';
+import type * as MainEvents from '@main/lib/events';
+
+export type { RecentCallEntry } from '@shared/events/mcpServerEvents';
 
 export type RecentCallStatus = 'ok' | 'error';
 
-export interface RecentCallEntry {
-  tool: string;
-  ms: number;
-  status: RecentCallStatus;
-  error?: string;
+/** Fixed capacity of the ring buffer. Matches the spec ("last 200 calls"). */
+export const RECENT_CALLS_CAPACITY = 200;
+
+export interface RecentCallSnapshotOptions {
+  /** Max number of entries to return (most-recent first). Defaults to all. */
+  limit?: number;
+  /** Only entries with `ts > sinceTs`. */
+  sinceTs?: number;
+  /** Filter to only `'ok'` or only `'error'` entries. */
+  status?: RecentCallStatus;
 }
 
-export class RecentCallsRing {
-  record(_entry: RecentCallEntry): void {}
+export interface RecentCallEventEmitter {
+  emit: (data: RecentCallEntry) => void;
+}
 
-  snapshot(): RecentCallEntry[] {
-    return [];
+/**
+ * The default emitter wraps the main-process `events` bus + the
+ * `mcpServerRecentCallChannel` channel. The bus is required lazily on the
+ * first emit so simply *constructing* the singleton ring in a test or in
+ * the stdio bridge (which has no Electron context) does not transitively
+ * pull in `@main/lib/events` → `electron` → `@main/db/client`.
+ *
+ * If the require fails (e.g. tests that exercise tool handlers without
+ * setting up the Electron stubs), the emit is silently dropped — the ring
+ * itself is the source of truth and the UI uses the channel only as a
+ * "wake up and re-snapshot" hint.
+ */
+function defaultEmitter(): RecentCallEventEmitter {
+  return {
+    emit: (data) => {
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-require-imports
+        const mod: typeof MainEvents = require('@main/lib/events');
+        mod.events.emit(mcpServerRecentCallChannel, data);
+      } catch {
+        // ignore — see comment above defaultEmitter.
+      }
+    },
+  };
+}
+
+/**
+ * Fixed-capacity ring buffer of recent tool calls.
+ *
+ * The internal storage is a plain array of length `capacity`; `head` points at
+ * the next write slot and wraps modulo `capacity`. `count` tracks how many
+ * slots are populated (saturates at `capacity`). Reads via `snapshot()` walk
+ * from newest to oldest.
+ */
+export class RecentCallsRing {
+  private readonly buffer: Array<RecentCallEntry | null>;
+  private readonly capacity: number;
+  private head = 0;
+  private count = 0;
+  private readonly emitter: RecentCallEventEmitter;
+
+  constructor(
+    capacity: number = RECENT_CALLS_CAPACITY,
+    emitter: RecentCallEventEmitter | null = null
+  ) {
+    if (!Number.isInteger(capacity) || capacity <= 0) {
+      throw new Error(`RecentCallsRing capacity must be a positive integer (got ${capacity})`);
+    }
+    this.capacity = capacity;
+    this.buffer = new Array<RecentCallEntry | null>(capacity).fill(null);
+    this.emitter = emitter ?? defaultEmitter();
+  }
+
+  /**
+   * Append a new call entry. Assigns a fresh `id` and `ts`, then pushes into
+   * the ring (oldest entry evicted if full). Emits the entry on
+   * `mcpServerRecentCallChannel` for live UI updates.
+   */
+  record(entry: Omit<RecentCallEntry, 'id' | 'ts'>): RecentCallEntry {
+    const full: RecentCallEntry = {
+      ...entry,
+      id: randomUUID(),
+      ts: Date.now(),
+    };
+    this.buffer[this.head] = full;
+    this.head = (this.head + 1) % this.capacity;
+    if (this.count < this.capacity) this.count += 1;
+    try {
+      this.emitter.emit(full);
+    } catch {
+      // Emitter failures must never break tool invocation; the ring buffer
+      // itself is still updated.
+    }
+    return full;
+  }
+
+  /**
+   * Returns entries most-recent first, optionally filtered.
+   *
+   * Filtering order: `status` and `sinceTs` are applied first; `limit` caps
+   * the result length after filtering.
+   */
+  snapshot(opts: RecentCallSnapshotOptions = {}): RecentCallEntry[] {
+    const out: RecentCallEntry[] = [];
+    const { limit, sinceTs, status } = opts;
+    for (let i = 0; i < this.count; i += 1) {
+      // Walk backwards from the most-recently-written slot.
+      const idx = (this.head - 1 - i + this.capacity) % this.capacity;
+      const entry = this.buffer[idx];
+      if (!entry) continue;
+      if (sinceTs !== undefined && entry.ts <= sinceTs) continue;
+      if (status !== undefined && entry.status !== status) continue;
+      out.push(entry);
+      if (limit !== undefined && out.length >= limit) break;
+    }
+    return out;
+  }
+
+  /** Drop every entry. */
+  clear(): void {
+    this.buffer.fill(null);
+    this.head = 0;
+    this.count = 0;
+  }
+
+  /** Current number of buffered entries (≤ capacity). */
+  size(): number {
+    return this.count;
   }
 }
 
+/** Singleton used by `withRecording()` and the RPC controller. */
 export const recentCallsRing = new RecentCallsRing();

--- a/src/main/core/mcp-server/recent-calls.ts
+++ b/src/main/core/mcp-server/recent-calls.ts
@@ -6,12 +6,26 @@
  *   the oldest when capacity is reached.
  * - `snapshot()`: return a chronological copy for the Settings UI to render.
  *
- * Currently a stub — both methods are no-ops.
+ * Currently a stub — `record` is a no-op and `snapshot` returns an empty
+ * array. T7 fills in the actual storage. The signature is finalised here so
+ * tool handlers can wire `withRecording()` against the right shape today.
  */
-export class RecentCallsRing {
-  record(): void {}
 
-  snapshot(): unknown {
+export type RecentCallStatus = 'ok' | 'error';
+
+export interface RecentCallEntry {
+  tool: string;
+  ms: number;
+  status: RecentCallStatus;
+  error?: string;
+}
+
+export class RecentCallsRing {
+  record(_entry: RecentCallEntry): void {}
+
+  snapshot(): RecentCallEntry[] {
     return [];
   }
 }
+
+export const recentCallsRing = new RecentCallsRing();

--- a/src/main/core/mcp-server/resources/_helpers.ts
+++ b/src/main/core/mcp-server/resources/_helpers.ts
@@ -1,0 +1,75 @@
+/**
+ * Shared helpers for MCP resource handlers.
+ *
+ * Resource read-callbacks all return the same `{ contents: [...] }` shape
+ * defined by `ReadResourceResultSchema` in the MCP SDK. `formatResourceContent`
+ * centralises that translation so per-domain resource modules stay focused
+ * on what to put *into* the payload.
+ *
+ * `parseEmdashUri` is a small URI splitter shared by resource read-callbacks
+ * that need to peel out the trailing path segments (project id, task id,
+ * session id, …).
+ *
+ * Resource payloads are JSON-serialised text content with `application/json`
+ * mime by default. The SDK schema also allows binary blobs, but emdash's v1
+ * resources are all structured JSON.
+ */
+export type ResourceReadResult = {
+  contents: Array<{ uri: string; mimeType: string; text: string }>;
+};
+
+/**
+ * Wrap a serialisable payload in the canonical
+ * `ReadResourceResultSchema`-shaped reply.
+ *
+ * `payload` is JSON-stringified with 2-space indent (matches the tool layer's
+ * `formatOk` for consistency in recent-calls / logs). For raw string payloads
+ * the caller can pass `payload` as a string; we still JSON-encode it so the
+ * `text` field is always valid JSON.
+ */
+export function formatResourceContent(
+  uri: string,
+  mime: string,
+  payload: unknown
+): ResourceReadResult {
+  return {
+    contents: [
+      {
+        uri,
+        mimeType: mime,
+        text: JSON.stringify(payload ?? null, null, 2),
+      },
+    ],
+  };
+}
+
+/**
+ * Parse an `emdash://...` URI into its scheme + path segments. Returns
+ * `null` for any non-`emdash://` URI so callers can short-circuit.
+ *
+ * Examples:
+ *   emdash://projects                                → { scheme: 'emdash', parts: ['projects'] }
+ *   emdash://projects/abc/tasks                      → { scheme: 'emdash', parts: ['projects', 'abc', 'tasks'] }
+ *   emdash://tasks/t-1/sessions/s-1                  → { scheme: 'emdash', parts: ['tasks', 't-1', 'sessions', 's-1'] }
+ *
+ * Note: the SDK already matches templated URIs against `ResourceTemplate`
+ * patterns and passes the extracted variables into the read callback; this
+ * helper exists for static-URI handlers and for tests that need a
+ * lightweight parser without spinning up a `UriTemplate`.
+ */
+export function parseEmdashUri(uri: string): { scheme: string; parts: string[] } | null {
+  // Use the standard URL parser so we get host/pathname normalisation for free.
+  let url: URL;
+  try {
+    url = new URL(uri);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== 'emdash:') return null;
+  // `emdash://projects/foo` → host='projects', pathname='/foo'
+  const host = url.host;
+  const path = url.pathname.replace(/^\/+/, '').replace(/\/+$/, '');
+  const tail = path.length > 0 ? path.split('/') : [];
+  const parts = host.length > 0 ? [host, ...tail] : tail;
+  return { scheme: 'emdash', parts };
+}

--- a/src/main/core/mcp-server/resources/index.ts
+++ b/src/main/core/mcp-server/resources/index.ts
@@ -1,9 +1,11 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
 /**
- * Aggregates registration of every MCP resource onto the SDK `Server`.
+ * Aggregates registration of every MCP resource onto the SDK `McpServer`.
  *
  * Eventual responsibilities: call `register(server)` from each per-domain
  * resource module (projects, tasks, task sessions).
  *
- * Currently a stub — no-op.
+ * Currently a stub — no-op. Filled in by T4+.
  */
-export function registerAllResources(_server: unknown): void {}
+export function registerAllResources(_server: McpServer): void {}

--- a/src/main/core/mcp-server/resources/index.ts
+++ b/src/main/core/mcp-server/resources/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Aggregates registration of every MCP resource onto the SDK `Server`.
+ *
+ * Eventual responsibilities: call `register(server)` from each per-domain
+ * resource module (projects, tasks, task sessions).
+ *
+ * Currently a stub — no-op.
+ */
+export function registerAllResources(_server: unknown): void {}

--- a/src/main/core/mcp-server/resources/index.ts
+++ b/src/main/core/mcp-server/resources/index.ts
@@ -1,11 +1,53 @@
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-
 /**
  * Aggregates registration of every MCP resource onto the SDK `McpServer`.
  *
- * Eventual responsibilities: call `register(server)` from each per-domain
- * resource module (projects, tasks, task sessions).
+ * Construction order matters: `task-session-resource` wires the shared
+ * `resources/subscribe` / `resources/unsubscribe` handlers and the
+ * transport-close cleanup. The project/task resources only register read
+ * callbacks; their subscriptions are deferred to v2 and rely on the shared
+ * handler accepting non-PTY URIs without installing a listener.
  *
- * Currently a stub — no-op. Filled in by T4+.
+ * A single `PtyMcpAdapter` is shared with the task-session resource. The
+ * adapter — and the underlying `ptySessionRegistry` import it depends on —
+ * are resolved lazily on the first read/subscribe call so that simply
+ * constructing an `McpServer` (e.g. in `http-server.test.ts`) does not pull
+ * in `@main/lib/events` → `electron` / `@main/db/...` at module load time.
+ * This mirrors the deferred-import pattern in `tools/task-tools.ts`.
  */
-export function registerAllResources(_server: McpServer): void {}
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerProjectResource } from './project-resource';
+import { PtyMcpAdapter } from './pty-mcp-adapter';
+import { registerTaskResource } from './task-resource';
+import { registerTaskSessionResource } from './task-session-resource';
+
+let cachedAdapter: PtyMcpAdapter | null = null;
+let cachedAdapterPromise: Promise<PtyMcpAdapter> | null = null;
+
+async function loadAdapter(): Promise<PtyMcpAdapter> {
+  if (cachedAdapter) return cachedAdapter;
+  if (cachedAdapterPromise) return cachedAdapterPromise;
+  cachedAdapterPromise = (async () => {
+    const mod = await import('@main/core/pty/pty-session-registry');
+    cachedAdapter = new PtyMcpAdapter(mod.ptySessionRegistry);
+    return cachedAdapter;
+  })();
+  return cachedAdapterPromise;
+}
+
+/** @internal — for tests: inject a ready-made adapter. */
+export function _setResourceAdapter(adapter: PtyMcpAdapter): void {
+  cachedAdapter = adapter;
+  cachedAdapterPromise = Promise.resolve(adapter);
+}
+
+/** @internal — for tests: clear cached adapter. */
+export function _resetResourceAdapter(): void {
+  cachedAdapter = null;
+  cachedAdapterPromise = null;
+}
+
+export function registerAllResources(server: McpServer): void {
+  registerTaskSessionResource(server, loadAdapter);
+  registerProjectResource(server);
+  registerTaskResource(server);
+}

--- a/src/main/core/mcp-server/resources/project-resource.test.ts
+++ b/src/main/core/mcp-server/resources/project-resource.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Tests for the `emdash://projects` (static) and
+ * `emdash://projects/{projectId}/tasks` (templated) resources.
+ *
+ * Drives a real `McpServer` instance; deps are injected via
+ * `_setProjectResourceDeps` so we don't pull the real DB / electron at
+ * import time (the resource module itself uses the lazy `loadDeps()`
+ * pattern — same as `tools/task-tools.ts`).
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { LocalProject } from '@shared/projects';
+import type { Task } from '@shared/tasks';
+import {
+  _resetProjectResourceDeps,
+  _setProjectResourceDeps,
+  registerProjectResource,
+} from './project-resource';
+
+type ServerInternals = {
+  _registeredResources: Record<
+    string,
+    {
+      name: string;
+      metadata: { mimeType?: string };
+      readCallback: (
+        uri: URL,
+        extra: unknown
+      ) => Promise<{ contents: Array<{ uri: string; mimeType: string; text: string }> }>;
+    }
+  >;
+  _registeredResourceTemplates: Record<
+    string,
+    {
+      resourceTemplate: { uriTemplate: { toString(): string } };
+      metadata: { mimeType?: string };
+      readCallback: (
+        uri: URL,
+        variables: Record<string, string>,
+        extra: unknown
+      ) => Promise<{ contents: Array<{ uri: string; mimeType: string; text: string }> }>;
+    }
+  >;
+};
+
+function makeServer(): McpServer {
+  return new McpServer({ name: 'test', version: '0.0.0' });
+}
+
+function makeLocalProject(overrides: Partial<LocalProject> = {}): LocalProject {
+  const base: LocalProject = {
+    type: 'local',
+    id: 'proj-1',
+    name: 'Demo project',
+    path: '/tmp/demo',
+    baseRef: 'main',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+  };
+  return { ...base, ...overrides };
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  const base: Task = {
+    id: 'task-1',
+    projectId: 'proj-1',
+    name: 'My task',
+    status: 'in_progress',
+    sourceBranch: { type: 'local', branch: 'main' },
+    taskBranch: 'feat/my-task',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    statusChangedAt: '2026-01-01T00:00:00.000Z',
+    isPinned: false,
+    prs: [],
+    conversations: {},
+  };
+  return { ...base, ...overrides };
+}
+
+describe('project-resource', () => {
+  afterEach(() => {
+    _resetProjectResourceDeps();
+  });
+
+  describe('emdash://projects (collection)', () => {
+    it('registers a static resource at emdash://projects with application/json mime', () => {
+      const server = makeServer();
+      registerProjectResource(server);
+      const internals = server as unknown as ServerInternals;
+      const entry = internals._registeredResources['emdash://projects'];
+      expect(entry).toBeDefined();
+      expect(entry!.name).toBe('projects');
+      expect(entry!.metadata.mimeType).toBe('application/json');
+    });
+
+    it('read returns the project list as JSON', async () => {
+      const server = makeServer();
+      const project = makeLocalProject();
+      _setProjectResourceDeps({
+        getProjects: vi.fn().mockResolvedValue([project]),
+        getTasks: vi.fn().mockResolvedValue([]),
+      });
+      registerProjectResource(server);
+
+      const internals = server as unknown as ServerInternals;
+      const entry = internals._registeredResources['emdash://projects']!;
+      const uri = new URL('emdash://projects');
+      const result = await entry.readCallback(uri, {});
+
+      expect(result.contents).toHaveLength(1);
+      expect(result.contents[0]!.uri).toBe('emdash://projects');
+      expect(result.contents[0]!.mimeType).toBe('application/json');
+      expect(JSON.parse(result.contents[0]!.text)).toEqual([project]);
+    });
+  });
+
+  describe('emdash://projects/{projectId}/tasks (template)', () => {
+    it('registers a templated resource at emdash://projects/{projectId}/tasks', () => {
+      const server = makeServer();
+      registerProjectResource(server);
+      const internals = server as unknown as ServerInternals;
+      const entry = internals._registeredResourceTemplates['project-tasks'];
+      expect(entry).toBeDefined();
+      expect(entry!.resourceTemplate.uriTemplate.toString()).toBe(
+        'emdash://projects/{projectId}/tasks'
+      );
+      expect(entry!.metadata.mimeType).toBe('application/json');
+    });
+
+    it('read returns the task list scoped to the projectId', async () => {
+      const server = makeServer();
+      const task = makeTask();
+      const getTasks = vi.fn().mockResolvedValue([task]);
+      _setProjectResourceDeps({
+        getProjects: vi.fn().mockResolvedValue([]),
+        getTasks,
+      });
+      registerProjectResource(server);
+
+      const internals = server as unknown as ServerInternals;
+      const entry = internals._registeredResourceTemplates['project-tasks']!;
+      const uri = new URL('emdash://projects/proj-1/tasks');
+      const result = await entry.readCallback(uri, { projectId: 'proj-1' }, {});
+
+      expect(getTasks).toHaveBeenCalledWith('proj-1');
+      expect(result.contents).toHaveLength(1);
+      expect(result.contents[0]!.uri).toBe('emdash://projects/proj-1/tasks');
+      expect(result.contents[0]!.mimeType).toBe('application/json');
+      expect(JSON.parse(result.contents[0]!.text)).toEqual([task]);
+    });
+  });
+});

--- a/src/main/core/mcp-server/resources/project-resource.ts
+++ b/src/main/core/mcp-server/resources/project-resource.ts
@@ -1,8 +1,98 @@
 /**
- * Registers the `emdash://projects` and `emdash://projects/{id}/tasks`
- * resources, including subscription support for project add/remove and task
- * create/update/archive/delete events.
+ * Registers two project-scoped resources:
  *
- * Currently a stub — no-op.
+ *   emdash://projects                          (collection)   read-only in v1
+ *   emdash://projects/{projectId}/tasks        (template)     read-only in v1
+ *
+ * Both expose JSON snapshots. Subscribe support is intentionally deferred to
+ * v2 — the SDK's `resources/subscribe` handler in `task-session-resource.ts`
+ * accepts subscribes for non-PTY URIs but installs no listener, so clients
+ * won't error.
+ *
+ * Runtime deps are loaded lazily so simply constructing an `McpServer`
+ * doesn't pull Electron / the DB at import time — same pattern as the tool
+ * modules.
  */
-export function register(_server: unknown): void {}
+import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { LocalProject, SshProject } from '@shared/projects';
+import type { Task } from '@shared/tasks';
+import { formatResourceContent } from './_helpers';
+
+const COLLECTION_URI = 'emdash://projects';
+const TASKS_URI_TEMPLATE = 'emdash://projects/{projectId}/tasks';
+const MIME_JSON = 'application/json';
+
+type ProjectResourceDeps = {
+  getProjects: () => Promise<(LocalProject | SshProject)[]>;
+  getTasks: (projectId?: string) => Promise<Task[]>;
+};
+
+let cachedDeps: ProjectResourceDeps | null = null;
+let cachedDepsPromise: Promise<ProjectResourceDeps> | null = null;
+
+async function loadDeps(): Promise<ProjectResourceDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const [getProjectsMod, getTasksMod] = await Promise.all([
+      import('@main/core/projects/operations/getProjects'),
+      import('@main/core/tasks/operations/getTasks'),
+    ]);
+    cachedDeps = {
+      getProjects: getProjectsMod.getProjects,
+      getTasks: getTasksMod.getTasks,
+    };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — tests inject deps. */
+export function _setProjectResourceDeps(deps: ProjectResourceDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — tests reset deps. */
+export function _resetProjectResourceDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+export function registerProjectResource(server: McpServer): void {
+  // emdash://projects — flat collection.
+  server.registerResource(
+    'projects',
+    COLLECTION_URI,
+    {
+      title: 'Projects',
+      description: 'All projects known to emdash. JSON array of project records.',
+      mimeType: MIME_JSON,
+    },
+    async (uri) => {
+      const deps = await loadDeps();
+      const projects = await deps.getProjects();
+      return formatResourceContent(uri.toString(), MIME_JSON, projects);
+    }
+  );
+
+  // emdash://projects/{projectId}/tasks — per-project task listing.
+  server.registerResource(
+    'project-tasks',
+    new ResourceTemplate(TASKS_URI_TEMPLATE, { list: undefined }),
+    {
+      title: 'Tasks for a project',
+      description:
+        'All tasks belonging to a project. JSON array of task records (mirrors task.list).',
+      mimeType: MIME_JSON,
+    },
+    async (uri, variables) => {
+      const projectId = String(variables.projectId ?? '');
+      const deps = await loadDeps();
+      const tasks = await deps.getTasks(projectId);
+      return formatResourceContent(uri.toString(), MIME_JSON, tasks);
+    }
+  );
+}
+
+export { registerProjectResource as register };

--- a/src/main/core/mcp-server/resources/project-resource.ts
+++ b/src/main/core/mcp-server/resources/project-resource.ts
@@ -1,0 +1,8 @@
+/**
+ * Registers the `emdash://projects` and `emdash://projects/{id}/tasks`
+ * resources, including subscription support for project add/remove and task
+ * create/update/archive/delete events.
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/resources/pty-mcp-adapter.test.ts
+++ b/src/main/core/mcp-server/resources/pty-mcp-adapter.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Unit tests for `PtyMcpAdapter`.
+ *
+ * Covers:
+ *  - `snapshot()` returns the ring buffer without registering an IPC consumer
+ *    (i.e. doesn't touch `activeConsumers`).
+ *  - `subscribeForResource()` returns an unsubscribe whose call leaves the
+ *    registry's listener set empty.
+ *  - Multiple subscribers receive independent deltas and unsubscribing one
+ *    doesn't disturb the other.
+ *
+ * `@main/lib/events` is stubbed out because `pty-session-registry` imports
+ * it eagerly, and the real module pulls in `electron` → `@main/db/...`
+ * (which calls `app.getPath()` at import — fatal outside Electron). The stub
+ * exposes the same `emit` / `on` shape the registry uses; we don't care
+ * about the IPC fan-out in these adapter tests.
+ */
+import { describe, expect, it, vi } from 'vitest';
+import type { Pty } from '@main/core/pty/pty';
+import { PtySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { PtyMcpAdapter } from './pty-mcp-adapter';
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    emit: vi.fn(),
+    on: vi.fn(() => () => undefined),
+  },
+}));
+
+// Minimal fake Pty — we only need onData / onExit hooks so the registry can
+// install its data pipeline. `write`/`resize`/`kill` are no-ops.
+function makeFakePty(): { pty: Pty; emit: (chunk: string) => void; exit: () => void } {
+  let dataHandler: ((d: string) => void) | undefined;
+  let exitHandler: ((info: { exitCode?: number }) => void) | undefined;
+  const pty: Pty = {
+    write: () => undefined,
+    resize: () => undefined,
+    kill: () => undefined,
+    onData: (h) => {
+      dataHandler = h;
+    },
+    onExit: (h) => {
+      exitHandler = h;
+    },
+    getPid: () => 1234,
+  };
+  return {
+    pty,
+    emit: (chunk: string) => dataHandler?.(chunk),
+    exit: () => exitHandler?.({ exitCode: 0 }),
+  };
+}
+
+describe('PtyMcpAdapter', () => {
+  describe('snapshot', () => {
+    it('returns the ring-buffer contents without affecting active consumers', () => {
+      const registry = new PtySessionRegistry();
+      const { pty, emit } = makeFakePty();
+      registry.register('sess-1', pty);
+      emit('hello ');
+      emit('world');
+
+      const adapter = new PtyMcpAdapter(registry);
+      // Drive snapshot a handful of times; even after many reads the
+      // renderer-facing consumer set must stay empty (the subscribe() leak
+      // T4 flagged would manifest here).
+      for (let i = 0; i < 5; i++) {
+        const snap = adapter.snapshot('sess-1');
+        expect(snap.data).toBe('hello world');
+        expect(snap.cursor).toBe('hello world'.length);
+        expect(snap.eof).toBe(false);
+      }
+
+      // `activeConsumers` is private — assert via internals cast. The
+      // important invariant: never grew past 0 from snapshot calls.
+      const internals = registry as unknown as { activeConsumers: Set<string> };
+      expect(internals.activeConsumers.size).toBe(0);
+    });
+
+    it('returns eof=true when the session has no live PTY', () => {
+      const registry = new PtySessionRegistry();
+      const adapter = new PtyMcpAdapter(registry);
+      const snap = adapter.snapshot('unknown');
+      expect(snap.data).toBe('');
+      expect(snap.eof).toBe(true);
+    });
+
+    it('returns the latest buffer slice when emissions exceed individual reads', () => {
+      const registry = new PtySessionRegistry();
+      const { pty, emit } = makeFakePty();
+      registry.register('sess-1', pty);
+      const adapter = new PtyMcpAdapter(registry);
+
+      emit('AAA');
+      expect(adapter.snapshot('sess-1').data).toBe('AAA');
+      emit('BBB');
+      expect(adapter.snapshot('sess-1').data).toBe('AAABBB');
+    });
+  });
+
+  describe('subscribeForResource', () => {
+    it('delivers live deltas to the listener and stops after unsubscribe', () => {
+      const registry = new PtySessionRegistry();
+      const { pty, emit } = makeFakePty();
+      registry.register('sess-1', pty);
+      const adapter = new PtyMcpAdapter(registry);
+
+      const received: string[] = [];
+      const off = adapter.subscribeForResource('sess-1', (d) => received.push(d.data));
+
+      emit('one');
+      emit('two');
+      off();
+      emit('three');
+
+      expect(received).toEqual(['one', 'two']);
+
+      // After unsubscribe the registry's data-listener bucket should be
+      // gone (size drops to zero → entry removed).
+      const internals = registry as unknown as {
+        dataListeners: Map<string, Set<unknown>>;
+        activeConsumers: Set<string>;
+      };
+      expect(internals.dataListeners.has('sess-1')).toBe(false);
+      // And subscriptions must never have leaked into activeConsumers.
+      expect(internals.activeConsumers.size).toBe(0);
+    });
+
+    it('supports multiple independent subscribers', () => {
+      const registry = new PtySessionRegistry();
+      const { pty, emit } = makeFakePty();
+      registry.register('sess-1', pty);
+      const adapter = new PtyMcpAdapter(registry);
+
+      const a: string[] = [];
+      const b: string[] = [];
+      const offA = adapter.subscribeForResource('sess-1', (d) => a.push(d.data));
+      const offB = adapter.subscribeForResource('sess-1', (d) => b.push(d.data));
+
+      emit('x');
+      offA();
+      emit('y');
+      offB();
+      emit('z');
+
+      expect(a).toEqual(['x']);
+      expect(b).toEqual(['x', 'y']);
+
+      const internals = registry as unknown as { dataListeners: Map<string, Set<unknown>> };
+      expect(internals.dataListeners.has('sess-1')).toBe(false);
+    });
+
+    it('does not deliver the historical buffer to late subscribers', () => {
+      const registry = new PtySessionRegistry();
+      const { pty, emit } = makeFakePty();
+      registry.register('sess-1', pty);
+      const adapter = new PtyMcpAdapter(registry);
+
+      emit('earlier');
+      const got: string[] = [];
+      const off = adapter.subscribeForResource('sess-1', (d) => got.push(d.data));
+      emit('later');
+      off();
+
+      // Subscribe is delta-only by contract — backfill is the caller's job
+      // (read snapshot first if you want history).
+      expect(got).toEqual(['later']);
+    });
+  });
+});

--- a/src/main/core/mcp-server/resources/pty-mcp-adapter.ts
+++ b/src/main/core/mcp-server/resources/pty-mcp-adapter.ts
@@ -1,0 +1,96 @@
+/**
+ * `PtyMcpAdapter` — a thin wrapper around `pty-session-registry` for the MCP
+ * resource layer.
+ *
+ * Why this exists
+ * ───────────────
+ * The renderer-facing `subscribe(sessionId)` method on the registry doubles
+ * as both "snapshot the ring buffer" *and* "register an IPC consumer" — the
+ * second half exists so the registry can refcount active renderers per
+ * session. The MCP resource and tool layers, however:
+ *
+ *  - Don't talk to the renderer (no IPC consumer needs registering).
+ *  - Need a snapshot-only read for `read` calls and per-session
+ *    fan-out for `subscribe` calls — both decoupled from the renderer
+ *    refcount.
+ *
+ * Using `subscribe()` from MCP handlers would silently inflate the
+ * `activeConsumers` set and never decrement it (the T4 code review caught
+ * this as a consumer-leak risk). This adapter calls the new
+ * `registry.peek()` and `registry.onData()` instead — both leave
+ * `activeConsumers` untouched.
+ *
+ * Lifetime
+ * ────────
+ * One instance per MCP server. Owned by `resources/index.ts` so the lifetime
+ * tracks the server itself. Multiple subscribers per session are supported
+ * — the registry's listener set is keyed by sessionId.
+ */
+import type { PtySessionRegistry } from '@main/core/pty/pty-session-registry';
+
+/**
+ * Snapshot reply from `PtyMcpAdapter.snapshot()` — the same shape an MCP
+ * resource `read` response carries inside its `text` payload, and what the
+ * subscribe callback fires with on each delta.
+ */
+export type PtySessionSnapshot = {
+  /** Bytes of ring-buffer content (for snapshots) or the delta chunk (for subscribe deltas). */
+  data: string;
+  /**
+   * Cursor for the *end* of the data slice the caller now has. Clients can
+   * pass this back via `task.getOutput`'s `sinceCursor`. For snapshots this
+   * equals `data.length`; for subscribe deltas it equals the byte offset of
+   * the *end* of this chunk within the producer's monotonic byte stream
+   * (set to 0 — deltas are append-only and the receiver maintains its own
+   * cursor by accumulating `data.length`).
+   */
+  cursor: number;
+  /** True iff the PTY has exited (no future data will arrive). */
+  eof: boolean;
+};
+
+/**
+ * Listener callback for `subscribeForResource`. Fires with a delta payload
+ * on every PTY data chunk. `eof: true` arrives at most once, as a final
+ * delta with empty `data`, when the PTY exits.
+ */
+export type PtySnapshotListener = (delta: PtySessionSnapshot) => void;
+
+/**
+ * Minimal slice of `PtySessionRegistry` the adapter needs — narrowed so tests
+ * can pass a stub without constructing the real registry (and to keep the
+ * "thin wrapper" contract honest).
+ */
+export type PtyMcpAdapterDeps = Pick<PtySessionRegistry, 'peek' | 'onData' | 'get'>;
+
+export class PtyMcpAdapter {
+  constructor(private readonly registry: PtyMcpAdapterDeps) {}
+
+  /**
+   * Synchronous snapshot of the session's ring buffer. Returns an empty
+   * string for unknown sessions (matches `peek` semantics). `eof` is true
+   * when the session is no longer registered as an active PTY.
+   */
+  snapshot(sessionId: string): PtySessionSnapshot {
+    const data = this.registry.peek(sessionId);
+    const eof = this.registry.get(sessionId) === undefined;
+    return { data, cursor: data.length, eof };
+  }
+
+  /**
+   * Subscribe to live PTY output deltas for a session. The listener fires
+   * once per `pty.onData` chunk; the returned function unsubscribes.
+   *
+   * The listener does NOT receive the initial ring-buffer snapshot — callers
+   * should pair this with a `snapshot()` call if they want to backfill,
+   * mirroring the MCP `read` + `subscribe` pattern.
+   */
+  subscribeForResource(sessionId: string, onUpdate: PtySnapshotListener): () => void {
+    return this.registry.onData(sessionId, (delta: string) => {
+      // `cursor` is 0 here: the receiver maintains its own monotonic offset
+      // by summing delta lengths. `eof` is always false for live deltas;
+      // an exit notification, if needed, can be layered on top later.
+      onUpdate({ data: delta, cursor: 0, eof: false });
+    });
+  }
+}

--- a/src/main/core/mcp-server/resources/task-resource.test.ts
+++ b/src/main/core/mcp-server/resources/task-resource.test.ts
@@ -1,0 +1,103 @@
+/**
+ * Tests for the `emdash://tasks/{taskId}` resource.
+ *
+ * Drives a real `McpServer` instance; deps are injected via
+ * `_setTaskResourceDeps` so we don't pull the real DB / electron at import
+ * time (the resource module itself uses the lazy `loadDeps()` pattern —
+ * same as `tools/task-tools.ts`).
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Task } from '@shared/tasks';
+import {
+  _resetTaskResourceDeps,
+  _setTaskResourceDeps,
+  registerTaskResource,
+} from './task-resource';
+
+type ServerInternals = {
+  _registeredResourceTemplates: Record<
+    string,
+    {
+      resourceTemplate: { uriTemplate: { toString(): string } };
+      metadata: { mimeType?: string };
+      readCallback: (
+        uri: URL,
+        variables: Record<string, string>,
+        extra: unknown
+      ) => Promise<{ contents: Array<{ uri: string; mimeType: string; text: string }> }>;
+    }
+  >;
+};
+
+function makeServer(): McpServer {
+  return new McpServer({ name: 'test', version: '0.0.0' });
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  const base: Task = {
+    id: 'task-1',
+    projectId: 'proj-1',
+    name: 'My task',
+    status: 'in_progress',
+    sourceBranch: { type: 'local', branch: 'main' },
+    taskBranch: 'feat/my-task',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    statusChangedAt: '2026-01-01T00:00:00.000Z',
+    isPinned: false,
+    prs: [],
+    conversations: {},
+  };
+  return { ...base, ...overrides };
+}
+
+describe('task-resource', () => {
+  afterEach(() => {
+    _resetTaskResourceDeps();
+  });
+
+  it('registers a templated resource at emdash://tasks/{taskId} with application/json mime', () => {
+    const server = makeServer();
+    registerTaskResource(server);
+    const internals = server as unknown as ServerInternals;
+    const entry = internals._registeredResourceTemplates['task'];
+    expect(entry).toBeDefined();
+    expect(entry!.resourceTemplate.uriTemplate.toString()).toBe('emdash://tasks/{taskId}');
+    expect(entry!.metadata.mimeType).toBe('application/json');
+  });
+
+  it('read returns the matching task as JSON', async () => {
+    const server = makeServer();
+    const target = makeTask({ id: 'task-2', name: 'Other task' });
+    _setTaskResourceDeps({
+      getTasks: vi.fn().mockResolvedValue([makeTask(), target, makeTask({ id: 'task-3' })]),
+    });
+    registerTaskResource(server);
+
+    const internals = server as unknown as ServerInternals;
+    const entry = internals._registeredResourceTemplates['task']!;
+    const uri = new URL('emdash://tasks/task-2');
+    const result = await entry.readCallback(uri, { taskId: 'task-2' }, {});
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0]!.uri).toBe('emdash://tasks/task-2');
+    expect(result.contents[0]!.mimeType).toBe('application/json');
+    expect(JSON.parse(result.contents[0]!.text)).toEqual(target);
+  });
+
+  it('read returns null payload when the task is unknown', async () => {
+    const server = makeServer();
+    _setTaskResourceDeps({
+      getTasks: vi.fn().mockResolvedValue([makeTask({ id: 'other' })]),
+    });
+    registerTaskResource(server);
+
+    const internals = server as unknown as ServerInternals;
+    const entry = internals._registeredResourceTemplates['task']!;
+    const uri = new URL('emdash://tasks/missing');
+    const result = await entry.readCallback(uri, { taskId: 'missing' }, {});
+
+    expect(JSON.parse(result.contents[0]!.text)).toBeNull();
+  });
+});

--- a/src/main/core/mcp-server/resources/task-resource.ts
+++ b/src/main/core/mcp-server/resources/task-resource.ts
@@ -1,0 +1,7 @@
+/**
+ * Registers the `emdash://tasks/{id}` resource with subscriptions for
+ * status / PR / metadata changes on a single task.
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/resources/task-resource.ts
+++ b/src/main/core/mcp-server/resources/task-resource.ts
@@ -1,7 +1,67 @@
 /**
- * Registers the `emdash://tasks/{id}` resource with subscriptions for
- * status / PR / metadata changes on a single task.
+ * Registers the `emdash://tasks/{taskId}` resource — read-only task detail.
  *
- * Currently a stub — no-op.
+ * No per-id `getTask` operation exists today, so we filter the project-wide
+ * listing (same pattern as the `task.get` tool). Subscriptions are deferred
+ * to v2 — the shared subscribe handler in `task-session-resource.ts` will
+ * silently accept the request and install no listener.
  */
-export function register(_server: unknown): void {}
+import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { Task } from '@shared/tasks';
+import { formatResourceContent } from './_helpers';
+
+const URI_TEMPLATE = 'emdash://tasks/{taskId}';
+const MIME_JSON = 'application/json';
+
+type TaskResourceDeps = {
+  getTasks: (projectId?: string) => Promise<Task[]>;
+};
+
+let cachedDeps: TaskResourceDeps | null = null;
+let cachedDepsPromise: Promise<TaskResourceDeps> | null = null;
+
+async function loadDeps(): Promise<TaskResourceDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const getTasksMod = await import('@main/core/tasks/operations/getTasks');
+    cachedDeps = { getTasks: getTasksMod.getTasks };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — tests inject deps. */
+export function _setTaskResourceDeps(deps: TaskResourceDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — tests reset deps. */
+export function _resetTaskResourceDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+export function registerTaskResource(server: McpServer): void {
+  server.registerResource(
+    'task',
+    new ResourceTemplate(URI_TEMPLATE, { list: undefined }),
+    {
+      title: 'Task detail',
+      description:
+        'Single-task detail by id. JSON record matching the task.get tool. ' +
+        'Returns an empty JSON null payload when the task is unknown.',
+      mimeType: MIME_JSON,
+    },
+    async (uri, variables) => {
+      const taskId = String(variables.taskId ?? '');
+      const deps = await loadDeps();
+      const all = await deps.getTasks();
+      const found = all.find((t) => t.id === taskId) ?? null;
+      return formatResourceContent(uri.toString(), MIME_JSON, found);
+    }
+  );
+}
+
+export { registerTaskResource as register };

--- a/src/main/core/mcp-server/resources/task-session-resource.test.ts
+++ b/src/main/core/mcp-server/resources/task-session-resource.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Tests for the `emdash://tasks/{taskId}/sessions/{sessionId}` resource.
+ *
+ * Drives a real `McpServer` instance and exercises:
+ *   - read: returns `{ data, cursor, eof }` JSON via the templated URI.
+ *   - subscribe: invoking the underlying SubscribeRequest handler registers
+ *     a listener on the adapter that, when fired, sends a
+ *     `notifications/resources/updated` notification.
+ *   - unsubscribe / shared subscribe handler for non-PTY URIs is a no-op.
+ */
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { describe, expect, it, vi } from 'vitest';
+import type { PtyMcpAdapter, PtySnapshotListener } from './pty-mcp-adapter';
+import { _resetSubscriptionsFor, registerTaskSessionResource } from './task-session-resource';
+
+type ServerInternals = {
+  _registeredResourceTemplates: Record<
+    string,
+    {
+      resourceTemplate: { uriTemplate: { toString(): string } };
+      readCallback: (
+        uri: URL,
+        variables: Record<string, string>,
+        extra: unknown
+      ) => Promise<{ contents: Array<{ uri: string; mimeType: string; text: string }> }>;
+    }
+  >;
+};
+
+function makeServer(): McpServer {
+  return new McpServer({ name: 'test', version: '0.0.0' });
+}
+
+function makeAdapter(overrides: Partial<PtyMcpAdapter> = {}): PtyMcpAdapter {
+  const base: PtyMcpAdapter = {
+    snapshot: vi.fn().mockReturnValue({ data: '', cursor: 0, eof: false }),
+    subscribeForResource: vi.fn().mockReturnValue(() => undefined),
+  } as unknown as PtyMcpAdapter;
+  return Object.assign(base, overrides);
+}
+
+describe('task-session-resource', () => {
+  it('registers a templated resource at emdash://tasks/{taskId}/sessions/{sessionId}', () => {
+    const server = makeServer();
+    const adapter = makeAdapter();
+    registerTaskSessionResource(server, adapter);
+
+    const internals = server as unknown as ServerInternals;
+    const entry = internals._registeredResourceTemplates['task-session'];
+    expect(entry).toBeDefined();
+    expect(entry!.resourceTemplate.uriTemplate.toString()).toBe(
+      'emdash://tasks/{taskId}/sessions/{sessionId}'
+    );
+    _resetSubscriptionsFor(server);
+  });
+
+  it('read returns JSON snapshot { data, cursor, eof } with application/json mime', async () => {
+    const server = makeServer();
+    const adapter = makeAdapter({
+      snapshot: vi.fn().mockReturnValue({ data: 'hello', cursor: 5, eof: false }),
+    } as Partial<PtyMcpAdapter>);
+    registerTaskSessionResource(server, adapter);
+
+    const internals = server as unknown as ServerInternals;
+    const entry = internals._registeredResourceTemplates['task-session']!;
+    const uri = new URL('emdash://tasks/t-1/sessions/s-1');
+    const result = await entry.readCallback(uri, { taskId: 't-1', sessionId: 's-1' }, {});
+
+    expect(adapter.snapshot).toHaveBeenCalledWith('s-1');
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0]!.uri).toBe('emdash://tasks/t-1/sessions/s-1');
+    expect(result.contents[0]!.mimeType).toBe('application/json');
+    expect(JSON.parse(result.contents[0]!.text)).toEqual({
+      data: 'hello',
+      cursor: 5,
+      eof: false,
+    });
+    _resetSubscriptionsFor(server);
+  });
+
+  it('subscribe wires a listener that fires resource-updated notifications on deltas', async () => {
+    const server = makeServer();
+    let installed: PtySnapshotListener | undefined;
+    const unsubscribe = vi.fn();
+    const adapter = makeAdapter({
+      subscribeForResource: vi.fn((_sid: string, cb: PtySnapshotListener) => {
+        installed = cb;
+        return unsubscribe;
+      }),
+    } as Partial<PtyMcpAdapter>);
+    registerTaskSessionResource(server, adapter);
+
+    // The McpServer's underlying Server holds the request handlers. We poke
+    // the registered handlers directly via the protocol internals — the
+    // alternative (a paired in-memory transport) would be overkill here.
+    type Protocol = {
+      _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+    };
+    const protocol = server.server as unknown as Protocol;
+    const subscribeHandler = protocol._requestHandlers.get('resources/subscribe');
+    expect(subscribeHandler).toBeDefined();
+
+    // Spy on the notification path.
+    const sendSpy = vi.spyOn(server.server, 'sendResourceUpdated').mockResolvedValue(undefined);
+
+    const uri = 'emdash://tasks/t-1/sessions/s-1';
+    await subscribeHandler!(
+      { method: 'resources/subscribe', params: { uri } },
+      { sendNotification: vi.fn() }
+    );
+    expect(adapter.subscribeForResource).toHaveBeenCalledWith('s-1', expect.any(Function));
+
+    // Simulate a PTY delta — should trigger sendResourceUpdated for the URI.
+    installed!({ data: 'chunk', cursor: 0, eof: false });
+    expect(sendSpy).toHaveBeenCalledWith({ uri });
+
+    // Unsubscribe cleans up the registry listener.
+    const unsubscribeHandler = protocol._requestHandlers.get('resources/unsubscribe');
+    expect(unsubscribeHandler).toBeDefined();
+    await unsubscribeHandler!(
+      { method: 'resources/unsubscribe', params: { uri } },
+      { sendNotification: vi.fn() }
+    );
+    expect(unsubscribe).toHaveBeenCalled();
+
+    _resetSubscriptionsFor(server);
+  });
+
+  it('subscribe to a non-PTY URI is accepted but installs no listener (v1 placeholder)', async () => {
+    const server = makeServer();
+    const adapter = makeAdapter();
+    registerTaskSessionResource(server, adapter);
+
+    type Protocol = {
+      _requestHandlers: Map<string, (req: unknown, extra: unknown) => Promise<unknown>>;
+    };
+    const protocol = server.server as unknown as Protocol;
+    const subscribeHandler = protocol._requestHandlers.get('resources/subscribe')!;
+
+    await subscribeHandler(
+      { method: 'resources/subscribe', params: { uri: 'emdash://projects' } },
+      { sendNotification: vi.fn() }
+    );
+    expect(adapter.subscribeForResource).not.toHaveBeenCalled();
+    _resetSubscriptionsFor(server);
+  });
+});

--- a/src/main/core/mcp-server/resources/task-session-resource.ts
+++ b/src/main/core/mcp-server/resources/task-session-resource.ts
@@ -1,0 +1,14 @@
+/**
+ * Registers the `emdash://tasks/{id}/sessions/{sid}` resource — the PTY
+ * session ring buffer + cursor.
+ *
+ * Eventual responsibilities:
+ * - On `read`: return the current 64 KB ring-buffer snapshot from
+ *   `pty-session-registry` plus a cursor.
+ * - On `subscribe`: stream `update` notifications with deltas as the PTY
+ *   produces output, via a `PtyMcpAdapter` wrapping the registry's event
+ *   stream.
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/resources/task-session-resource.ts
+++ b/src/main/core/mcp-server/resources/task-session-resource.ts
@@ -1,14 +1,178 @@
 /**
- * Registers the `emdash://tasks/{id}/sessions/{sid}` resource — the PTY
- * session ring buffer + cursor.
+ * Registers the `emdash://tasks/{taskId}/sessions/{sessionId}` resource — the
+ * PTY session ring buffer + live deltas.
  *
- * Eventual responsibilities:
- * - On `read`: return the current 64 KB ring-buffer snapshot from
- *   `pty-session-registry` plus a cursor.
- * - On `subscribe`: stream `update` notifications with deltas as the PTY
- *   produces output, via a `PtyMcpAdapter` wrapping the registry's event
- *   stream.
+ * - `read` returns a JSON snapshot `{ data, cursor, eof }` built from
+ *   `PtyMcpAdapter.snapshot()`. Snapshot does NOT register an IPC consumer
+ *   (see the adapter docs for the consumer-leak rationale).
+ * - `subscribe` is wired via `setRequestHandler(SubscribeRequestSchema, …)`
+ *   on the underlying `Server` instance because the high-level `McpServer`
+ *   does not auto-wire `resources/subscribe` / `resources/unsubscribe`.
+ *   On `subscribe`, we register a per-URI listener via
+ *   `PtyMcpAdapter.subscribeForResource(...)` and send
+ *   `notifications/resources/updated` for that URI on every delta. The
+ *   unsubscribe is tracked in a per-server `Map<uri, () => void>` and
+ *   cleaned up on `unsubscribe` or transport close.
  *
- * Currently a stub — no-op.
+ * URI template: `emdash://tasks/{taskId}/sessions/{sessionId}`.
  */
-export function register(_server: unknown): void {}
+import { ResourceTemplate, type McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import {
+  SubscribeRequestSchema,
+  UnsubscribeRequestSchema,
+} from '@modelcontextprotocol/sdk/types.js';
+import { formatResourceContent } from './_helpers';
+import type { PtyMcpAdapter } from './pty-mcp-adapter';
+
+const URI_TEMPLATE = 'emdash://tasks/{taskId}/sessions/{sessionId}';
+const MIME_JSON = 'application/json';
+
+/**
+ * Per-server subscription bookkeeping. The MCP SDK does not expose a built-in
+ * "client unsubscribed" event for the high-level `McpServer`, so we own the
+ * Map ourselves and clean up on `resources/unsubscribe` requests + transport
+ * close.
+ */
+type SubscriptionMap = Map<string, () => void>;
+
+const subscriptionsByServer = new WeakMap<McpServer, SubscriptionMap>();
+const wiredServers = new WeakSet<McpServer>();
+
+function getSubscriptions(server: McpServer): SubscriptionMap {
+  let map = subscriptionsByServer.get(server);
+  if (!map) {
+    map = new Map();
+    subscriptionsByServer.set(server, map);
+  }
+  return map;
+}
+
+function clearAll(server: McpServer): void {
+  const map = subscriptionsByServer.get(server);
+  if (!map) return;
+  for (const off of map.values()) {
+    try {
+      off();
+    } catch {
+      // ignore
+    }
+  }
+  map.clear();
+}
+
+/**
+ * Extracts the `sessionId` segment from an `emdash://tasks/{tid}/sessions/{sid}`
+ * URI. Returns null if the URI doesn't match the expected shape.
+ */
+function sessionIdFromUri(uri: string): string | null {
+  const match = /^emdash:\/\/tasks\/[^/]+\/sessions\/([^/]+)\/?$/.exec(uri);
+  return match?.[1] ?? null;
+}
+
+/**
+ * The adapter slot accepts either a ready-made `PtyMcpAdapter` (the test
+ * path) or a `() => Promise<PtyMcpAdapter>` factory (the production path
+ * from `resources/index.ts`, which defers the `pty-session-registry` import
+ * so module load doesn't pull in Electron / the DB).
+ */
+export type PtyMcpAdapterProvider = PtyMcpAdapter | (() => Promise<PtyMcpAdapter>);
+
+function asAdapterFactory(provider: PtyMcpAdapterProvider): () => Promise<PtyMcpAdapter> {
+  if (typeof provider === 'function') return provider;
+  const resolved = Promise.resolve(provider);
+  return () => resolved;
+}
+
+export function registerTaskSessionResource(
+  server: McpServer,
+  adapterProvider: PtyMcpAdapterProvider
+): void {
+  const getAdapter = asAdapterFactory(adapterProvider);
+
+  // read handler ─ uses the SDK's templated registerResource overload. The
+  // callback is async so we can `await` the lazy adapter factory in
+  // production. For tests that pass an adapter directly, the awaited value
+  // resolves synchronously on the microtask queue.
+  server.registerResource(
+    'task-session',
+    new ResourceTemplate(URI_TEMPLATE, { list: undefined }),
+    {
+      title: 'Task PTY session',
+      description:
+        'Live ring buffer (snapshot + deltas) for a PTY session attached to a task. ' +
+        'Read returns { data, cursor, eof }; subscribe streams resource-updated ' +
+        'notifications as the PTY produces output.',
+      mimeType: MIME_JSON,
+    },
+    async (uri, variables) => {
+      const sessionId = String(variables.sessionId ?? '');
+      const adapter = await getAdapter();
+      const snapshot = adapter.snapshot(sessionId);
+      return formatResourceContent(uri.toString(), MIME_JSON, snapshot);
+    }
+  );
+
+  // subscribe / unsubscribe handlers ─ on the underlying Server. We wire
+  // these once per McpServer instance; later resources for the same server
+  // (project, task, etc.) share the same handlers and look up the right
+  // listener-factory by URI prefix.
+  if (wiredServers.has(server)) return;
+  wiredServers.add(server);
+
+  const subs = getSubscriptions(server);
+  const underlying = server.server;
+
+  underlying.setRequestHandler(SubscribeRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    const sessionId = sessionIdFromUri(uri);
+    if (sessionId === null) {
+      // Other resource types (project, task) don't expose live subscriptions
+      // in v1 — silently accept the subscribe so the client doesn't error,
+      // but install no listener. Tracked for v2.
+      return {};
+    }
+    // De-dupe: a re-subscribe replaces the prior listener.
+    subs.get(uri)?.();
+    const adapter = await getAdapter();
+    const off = adapter.subscribeForResource(sessionId, () => {
+      // Fire-and-forget the resource-updated notification. The SDK serialises
+      // it as `notifications/resources/updated` with `{ uri }`.
+      void underlying.sendResourceUpdated({ uri });
+    });
+    subs.set(uri, off);
+    return {};
+  });
+
+  underlying.setRequestHandler(UnsubscribeRequestSchema, async (request) => {
+    const uri = request.params.uri;
+    subs.get(uri)?.();
+    subs.delete(uri);
+    return {};
+  });
+
+  // Best-effort cleanup when the transport closes. `onclose` is on the
+  // underlying Server / Protocol; assigning to it leaves any existing
+  // handlers intact by chaining.
+  const prevOnClose = underlying.onclose;
+  underlying.onclose = () => {
+    clearAll(server);
+    prevOnClose?.();
+  };
+
+  // Declare the `resources.subscribe` capability so the SDK advertises it
+  // in `initialize` responses. `listChanged` is already registered by
+  // `registerResource`.
+  underlying.registerCapabilities({
+    resources: {
+      subscribe: true,
+    },
+  });
+}
+
+/** @internal — tests reset per-server subscription bookkeeping. */
+export function _resetSubscriptionsFor(server: McpServer): void {
+  clearAll(server);
+  subscriptionsByServer.delete(server);
+}
+
+export { registerTaskSessionResource as register };

--- a/src/main/core/mcp-server/server.ts
+++ b/src/main/core/mcp-server/server.ts
@@ -1,16 +1,70 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { log } from '@main/lib/logger';
+import { registerAllResources } from './resources';
+import { registerAllTools } from './tools';
+
+const UNKNOWN_VERSION = '0.0.0';
+
 /**
- * Constructs the `@modelcontextprotocol/sdk` `Server` instance and wires the
- * curated tool and resource registries into it.
+ * Resolves the emdash package version at module load.
  *
- * Eventual responsibilities:
- * - Instantiate the SDK `Server` with emdash metadata (name, version,
- *   capabilities for tools + resources + subscriptions).
- * - Call `registerAllTools(server)` and `registerAllResources(server)` to
- *   mount the curated catalog.
- *
- * Currently a stub — returns `undefined` typed as `unknown` because the SDK
- * is not yet wired in.
+ * The MCP SDK's `McpServer` constructor needs the version synchronously, and
+ * we want this module to be testable without booting Electron. Reading
+ * `package.json` from the repo root works in dev, in unit tests, and in the
+ * packaged app (where `package.json` is co-located with the compiled main).
  */
-export function createMcpServer(): unknown {
-  return undefined;
+function resolvePackageVersionSync(): string {
+  // In the Electron main bundle, `import.meta.url` resolves under `out/main/`.
+  // In tests / dev, it resolves under `src/main/core/mcp-server/`. Walk up to
+  // the project root looking for the first `package.json` that declares
+  // `name: "emdash"`.
+  let here: string;
+  try {
+    here = dirname(fileURLToPath(import.meta.url));
+  } catch {
+    here = process.cwd();
+  }
+  const candidates = [
+    join(here, '..', '..', '..', '..', 'package.json'),
+    join(here, '..', '..', '..', '..', '..', 'package.json'),
+    join(process.cwd(), 'package.json'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = readFileSync(candidate, 'utf8');
+      const parsed = JSON.parse(raw) as { name?: string; version?: string };
+      if (parsed.name === 'emdash' && typeof parsed.version === 'string' && parsed.version) {
+        return parsed.version;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  log.warn('[mcp-server] could not resolve emdash package version; using fallback');
+  return UNKNOWN_VERSION;
+}
+
+const PACKAGE_VERSION = resolvePackageVersionSync();
+
+/**
+ * Constructs the `@modelcontextprotocol/sdk` `McpServer` instance and wires
+ * the curated tool and resource registries into it.
+ *
+ * The actual tool/resource catalogs are still stubs in T3 — they will be
+ * filled in by later tasks (T4+). The service in `service.ts` already
+ * tolerates a `null` return so the lifecycle can be exercised before the
+ * catalogs exist, but in T3 onwards we always return a real server so the
+ * transport has something to connect to.
+ */
+export function createMcpServer(): McpServer {
+  const server = new McpServer({
+    name: 'emdash',
+    version: PACKAGE_VERSION,
+  });
+  registerAllTools(server);
+  registerAllResources(server);
+  return server;
 }

--- a/src/main/core/mcp-server/server.ts
+++ b/src/main/core/mcp-server/server.ts
@@ -1,0 +1,16 @@
+/**
+ * Constructs the `@modelcontextprotocol/sdk` `Server` instance and wires the
+ * curated tool and resource registries into it.
+ *
+ * Eventual responsibilities:
+ * - Instantiate the SDK `Server` with emdash metadata (name, version,
+ *   capabilities for tools + resources + subscriptions).
+ * - Call `registerAllTools(server)` and `registerAllResources(server)` to
+ *   mount the curated catalog.
+ *
+ * Currently a stub — returns `undefined` typed as `unknown` because the SDK
+ * is not yet wired in.
+ */
+export function createMcpServer(): unknown {
+  return undefined;
+}

--- a/src/main/core/mcp-server/service.ts
+++ b/src/main/core/mcp-server/service.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import {
   mcpServerErrorChannel,
   mcpServerStatusChannel,
@@ -10,6 +11,57 @@ import { log } from '@main/lib/logger';
 import { McpHttpServer, McpServerStartError } from './http-server';
 import { createMcpServer } from './server';
 import { ensureTokenFile, readTokenFile, rotateToken as rotateTokenFile } from './token-store';
+
+/**
+ * Returns the command external MCP clients should run to spawn the
+ * `emdash-mcp` stdio bridge.
+ *
+ * - **Packaged app:** the bridge JS lives in the unpacked resources directory
+ *   (`process.resourcesPath/bin/emdash-mcp.js`, configured in
+ *   `electron-builder.config.ts`). We invoke it via the platform Node, so the
+ *   user never has to chmod or codesign anything themselves.
+ * - **Dev / test:** the bundled output sits at `out/main/emdash-mcp.js` after
+ *   `electron-vite build`. We point at it relative to the cwd; if the file
+ *   doesn't exist yet (fresh checkout that hasn't been built) the snippet
+ *   still tells the developer the correct command — running it without a
+ *   build will fail loudly, which is the correct signal.
+ *
+ * The exposed shape is `{ command, args }` rather than a single string so the
+ * snippet generator can emit each transport's preferred config format
+ * (Claude Code uses `command + args`, Codex uses TOML keys, etc.).
+ */
+export interface BridgeCommand {
+  command: string;
+  args: string[];
+}
+
+export function getBridgeCommand(): BridgeCommand {
+  // `process.resourcesPath` is only set when running inside the Electron
+  // runtime (and even then is only meaningful for the packaged app).
+  // `process.defaultApp` is `true` in `electron .` dev mode and `undefined`
+  // in the packaged app — the inverse of the packaged check we want here.
+  // Together they let us decide between the dev path and the packaged path
+  // without taking a hard runtime dependency on the `electron` module
+  // (which keeps unit tests happy without `vi.mock('electron', …)`).
+  const resourcesPath = (process as NodeJS.Process & { resourcesPath?: string }).resourcesPath;
+  const isPackaged =
+    typeof resourcesPath === 'string' &&
+    resourcesPath.length > 0 &&
+    (process as NodeJS.Process & { defaultApp?: boolean }).defaultApp !== true;
+
+  const bridgeFileName = 'emdash-mcp.js';
+  const bridgePath = isPackaged
+    ? join(resourcesPath as string, 'bin', bridgeFileName)
+    : join(process.cwd(), 'out', 'main', bridgeFileName);
+
+  // `node` is universally available wherever Electron itself runs (and the
+  // packaged app ships its own; advanced users can override `command` in
+  // their MCP client config if they prefer a specific runtime).
+  return {
+    command: 'node',
+    args: [bridgePath],
+  };
+}
 
 /**
  * Singleton service that owns the lifecycle of the in-process emdash MCP HTTP

--- a/src/main/core/mcp-server/service.ts
+++ b/src/main/core/mcp-server/service.ts
@@ -1,0 +1,27 @@
+import type { IDisposable, IInitializable } from '@main/lib/lifecycle';
+
+/**
+ * Singleton service that owns the lifecycle of the in-process emdash MCP HTTP
+ * server.
+ *
+ * Eventual responsibilities (see `docs/superpowers/specs/2026-05-16-mcp-server-design.md`):
+ * - React to the `mcpServer.enabled` app setting and start/stop the
+ *   loopback `McpHttpServer` accordingly.
+ * - Coordinate token rotation (`token-store`) and recent-call telemetry
+ *   (`recent-calls`) for the Settings UI.
+ * - Wire `@modelcontextprotocol/sdk` tools and resources via `createMcpServer`.
+ *
+ * Currently a stub — `initialize()` and `dispose()` are no-ops. Wiring into
+ * `src/main/index.ts` is deferred to task T3.
+ */
+export class McpServerService implements IInitializable, IDisposable {
+  async initialize(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  async dispose(): Promise<void> {
+    return Promise.resolve();
+  }
+}
+
+export const mcpServerService = new McpServerService();

--- a/src/main/core/mcp-server/service.ts
+++ b/src/main/core/mcp-server/service.ts
@@ -1,26 +1,183 @@
+import {
+  mcpServerErrorChannel,
+  mcpServerStatusChannel,
+  type McpServerStatus,
+} from '@shared/events/mcpServerEvents';
+import { appSettingsService } from '@main/core/settings/settings-service';
+import { events } from '@main/lib/events';
 import type { IDisposable, IInitializable } from '@main/lib/lifecycle';
+import { log } from '@main/lib/logger';
+import { McpHttpServer, McpServerStartError } from './http-server';
+import { createMcpServer } from './server';
+import { ensureTokenFile, readTokenFile } from './token-store';
 
 /**
  * Singleton service that owns the lifecycle of the in-process emdash MCP HTTP
  * server.
  *
- * Eventual responsibilities (see `docs/superpowers/specs/2026-05-16-mcp-server-design.md`):
- * - React to the `mcpServer.enabled` app setting and start/stop the
+ * Responsibilities (per `docs/superpowers/specs/2026-05-16-mcp-server-design.md`):
+ * - Read `appSettings.mcpServer.{enabled,port}` and start/stop the
  *   loopback `McpHttpServer` accordingly.
- * - Coordinate token rotation (`token-store`) and recent-call telemetry
- *   (`recent-calls`) for the Settings UI.
- * - Wire `@modelcontextprotocol/sdk` tools and resources via `createMcpServer`.
+ * - Get reconciled by the settings controller whenever those keys change
+ *   (same pattern as `reconcileResourceSampler` — see
+ *   `src/main/core/settings/controller.ts`).
+ * - Ensure the bearer token file exists before starting the transport
+ *   (`token-store.ensureTokenFile`).
+ * - Emit `mcpServerStatusChannel` on every state change so the renderer
+ *   Settings page can reflect status without polling.
  *
- * Currently a stub — `initialize()` and `dispose()` are no-ops. Wiring into
- * `src/main/index.ts` is deferred to task T3.
+ * The service tolerates a partially-initialized MCP server (`createMcpServer`
+ * may return `undefined`-shaped data while T4 wires the real registries),
+ * but the current implementation always returns a real `McpServer`.
  */
 export class McpServerService implements IInitializable, IDisposable {
+  private readonly httpServer = new McpHttpServer();
+  private startedAt: number | null = null;
+  private lastError: string | null = null;
+  private currentEnabled = false;
+  private currentPort: number | null = null;
+
+  /**
+   * Initial reconcile + emit. Idempotent: safe to call more than once
+   * (subsequent calls behave like `reconcile()`).
+   */
   async initialize(): Promise<void> {
-    return Promise.resolve();
+    await this.reconcile();
   }
 
   async dispose(): Promise<void> {
-    return Promise.resolve();
+    try {
+      await this.httpServer.stop();
+    } catch (err) {
+      log.warn('[mcp-server] error during dispose', err);
+    }
+    this.startedAt = null;
+    this.lastError = null;
+    this.currentEnabled = false;
+    this.currentPort = null;
+  }
+
+  /**
+   * Returns the current status snapshot. Mirrors the payload emitted on
+   * `mcpServerStatusChannel`.
+   */
+  async getStatus(): Promise<McpServerStatus> {
+    const tokenFile = await readTokenFile();
+    return {
+      enabled: this.currentEnabled,
+      running: this.httpServer.isRunning(),
+      port: this.httpServer.getPort(),
+      tokenPresent: tokenFile !== null,
+      uptimeMs: this.startedAt === null ? 0 : Date.now() - this.startedAt,
+      lastError: this.lastError,
+    };
+  }
+
+  /**
+   * Reconciles the live server against `appSettings.mcpServer`. Call this
+   * from the settings controller whenever the `mcpServer` key changes; the
+   * controller already follows the same pattern for `resourceMonitor`.
+   *
+   * - enabled flipped on  → ensure-token + start
+   * - enabled flipped off → stop
+   * - port changed while enabled → stop + ensure-token(newPort) + start
+   * - no change → no-op
+   */
+  async reconcile(): Promise<void> {
+    let settings: { enabled: boolean; port: number };
+    try {
+      settings = await appSettingsService.get('mcpServer');
+    } catch (err) {
+      log.error('[mcp-server] failed to read mcpServer settings', err);
+      return;
+    }
+
+    const wasEnabled = this.currentEnabled;
+    const previousPort = this.currentPort;
+
+    if (!settings.enabled) {
+      if (this.httpServer.isRunning()) {
+        await this.stopAndEmit('disabled');
+      }
+      this.currentEnabled = false;
+      this.currentPort = null;
+      if (wasEnabled) {
+        await this.emitStatus();
+      }
+      return;
+    }
+
+    const portChanged = previousPort !== null && previousPort !== settings.port;
+    if (this.httpServer.isRunning() && !portChanged) {
+      // Already running on the correct port — nothing to do.
+      this.currentEnabled = true;
+      this.currentPort = settings.port;
+      return;
+    }
+
+    if (this.httpServer.isRunning()) {
+      await this.stopAndEmit('port-change');
+    }
+
+    await this.startAndEmit(settings.port);
+  }
+
+  private async startAndEmit(port: number): Promise<void> {
+    try {
+      const tokenFile = await ensureTokenFile(port);
+      const mcpServer = createMcpServer();
+      // Defensive: if a future refactor reverts `createMcpServer` to a stub,
+      // skip starting rather than crash. The spec contract is that the
+      // service tolerates an absent server until tools are wired up.
+      if (!mcpServer) {
+        this.lastError = 'createMcpServer() returned no server; transport not started.';
+        log.warn('[mcp-server]', this.lastError);
+        await this.emitStatus();
+        return;
+      }
+      const { port: boundPort } = await this.httpServer.start({
+        port,
+        token: tokenFile.token,
+        mcpServer,
+      });
+      this.startedAt = Date.now();
+      this.lastError = null;
+      this.currentEnabled = true;
+      this.currentPort = boundPort;
+      log.info(`[mcp-server] listening on 127.0.0.1:${boundPort}`);
+      await this.emitStatus();
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      this.lastError = message;
+      this.currentEnabled = true; // user intent is still "enabled"
+      this.currentPort = port;
+      this.startedAt = null;
+      log.error('[mcp-server] failed to start', err);
+      events.emit(mcpServerErrorChannel, {
+        code: err instanceof McpServerStartError ? err.code : 'BIND_FAILED',
+        message,
+      });
+      await this.emitStatus();
+    }
+  }
+
+  private async stopAndEmit(reason: 'disabled' | 'port-change' | 'dispose'): Promise<void> {
+    try {
+      await this.httpServer.stop();
+      log.info(`[mcp-server] stopped (${reason})`);
+    } catch (err) {
+      log.warn('[mcp-server] error stopping http server', err);
+    }
+    this.startedAt = null;
+  }
+
+  private async emitStatus(): Promise<void> {
+    try {
+      const status = await this.getStatus();
+      events.emit(mcpServerStatusChannel, status);
+    } catch (err) {
+      log.warn('[mcp-server] failed to emit status', err);
+    }
   }
 }
 

--- a/src/main/core/mcp-server/service.ts
+++ b/src/main/core/mcp-server/service.ts
@@ -9,7 +9,7 @@ import type { IDisposable, IInitializable } from '@main/lib/lifecycle';
 import { log } from '@main/lib/logger';
 import { McpHttpServer, McpServerStartError } from './http-server';
 import { createMcpServer } from './server';
-import { ensureTokenFile, readTokenFile } from './token-store';
+import { ensureTokenFile, readTokenFile, rotateToken as rotateTokenFile } from './token-store';
 
 /**
  * Singleton service that owns the lifecycle of the in-process emdash MCP HTTP
@@ -120,6 +120,39 @@ export class McpServerService implements IInitializable, IDisposable {
     }
 
     await this.startAndEmit(settings.port);
+  }
+
+  /**
+   * Regenerates the bearer token, rewrites `~/.emdash/mcp.json`, and
+   * reconciles the running server so all transports pick up the new token
+   * (effectively kicking active sessions).
+   *
+   * Returns the freshly-generated token so the renderer can display it
+   * exactly once on the Settings page.
+   */
+  async rotateToken(): Promise<{ token: string }> {
+    let settings: { enabled: boolean; port: number };
+    try {
+      settings = await appSettingsService.get('mcpServer');
+    } catch (err) {
+      log.error('[mcp-server] failed to read mcpServer settings for rotateToken', err);
+      throw err;
+    }
+    const port = this.currentPort ?? settings.port;
+    const file = await rotateTokenFile(port);
+    // Reconcile after rotation: if the server is enabled we restart it so the
+    // HTTP transport reads the new token; this terminates all in-flight
+    // sessions, which is the desired behaviour per spec ("terminates active
+    // sessions so they reconnect with the new token").
+    if (settings.enabled) {
+      if (this.httpServer.isRunning()) {
+        await this.stopAndEmit('port-change');
+      }
+      await this.startAndEmit(port);
+    } else {
+      await this.emitStatus();
+    }
+    return { token: file.token };
   }
 
   private async startAndEmit(port: number): Promise<void> {

--- a/src/main/core/mcp-server/service.ts
+++ b/src/main/core/mcp-server/service.ts
@@ -210,20 +210,23 @@ export class McpServerService implements IInitializable, IDisposable {
   private async startAndEmit(port: number): Promise<void> {
     try {
       const tokenFile = await ensureTokenFile(port);
-      const mcpServer = createMcpServer();
-      // Defensive: if a future refactor reverts `createMcpServer` to a stub,
-      // skip starting rather than crash. The spec contract is that the
-      // service tolerates an absent server until tools are wired up.
-      if (!mcpServer) {
+      // Pass `createMcpServer` itself as the factory — each new HTTP session
+      // gets its own McpServer instance (the SDK forbids reusing one across
+      // transports). Smoke-check by minting one upfront so we fail loudly at
+      // start time rather than on the first client request.
+      const probe = createMcpServer();
+      if (!probe) {
         this.lastError = 'createMcpServer() returned no server; transport not started.';
         log.warn('[mcp-server]', this.lastError);
         await this.emitStatus();
         return;
       }
+      // The probe was just a sanity check; close it so it doesn't leak.
+      await probe.close().catch(() => {});
       const { port: boundPort } = await this.httpServer.start({
         port,
         token: tokenFile.token,
-        mcpServer,
+        mcpServerFactory: () => createMcpServer(),
       });
       this.startedAt = Date.now();
       this.lastError = null;

--- a/src/main/core/mcp-server/token-store.test.ts
+++ b/src/main/core/mcp-server/token-store.test.ts
@@ -1,0 +1,194 @@
+import { mkdir, mkdtemp, readFile, stat, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  __setEmdashDirForTests,
+  checkPermissions,
+  ensureTokenFile,
+  generateToken,
+  getTokenFilePath,
+  readTokenFile,
+  rotateToken,
+  writeTokenFile,
+  type McpTokenFile,
+} from './token-store';
+
+const isPosix = process.platform !== 'win32';
+
+describe('token-store', () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(join(tmpdir(), 'emdash-token-store-'));
+    __setEmdashDirForTests(dir);
+  });
+
+  afterEach(() => {
+    __setEmdashDirForTests(null);
+  });
+
+  describe('generateToken', () => {
+    it('returns a non-empty base64url string', () => {
+      const token = generateToken();
+      expect(token.length).toBeGreaterThan(0);
+      // base64url uses [A-Za-z0-9_-] only, no padding.
+      expect(token).toMatch(/^[A-Za-z0-9_-]+$/);
+    });
+
+    it('produces a different token on each call', () => {
+      const a = generateToken();
+      const b = generateToken();
+      expect(a).not.toBe(b);
+    });
+
+    it('encodes 32 bytes (43 base64url chars)', () => {
+      // 32 bytes -> ceil(32 * 4 / 3) = 43 chars without padding.
+      expect(generateToken()).toHaveLength(43);
+    });
+  });
+
+  describe('getTokenFilePath', () => {
+    it('honors the test override and points at <dir>/mcp.json', () => {
+      expect(getTokenFilePath()).toBe(join(dir, 'mcp.json'));
+    });
+  });
+
+  describe('readTokenFile', () => {
+    it('returns null when the file does not exist', async () => {
+      await expect(readTokenFile()).resolves.toBeNull();
+    });
+
+    it('returns null and does not throw on invalid JSON', async () => {
+      await writeFile(join(dir, 'mcp.json'), 'not-json{', 'utf8');
+      await expect(readTokenFile()).resolves.toBeNull();
+    });
+
+    it('returns null when the schema is invalid', async () => {
+      await writeFile(
+        join(dir, 'mcp.json'),
+        JSON.stringify({ version: 2, port: 7457, token: 'abc' }),
+        'utf8'
+      );
+      await expect(readTokenFile()).resolves.toBeNull();
+    });
+
+    it('returns null when the token is empty', async () => {
+      await writeFile(
+        join(dir, 'mcp.json'),
+        JSON.stringify({ version: 1, port: 7457, token: '' }),
+        'utf8'
+      );
+      await expect(readTokenFile()).resolves.toBeNull();
+    });
+  });
+
+  describe('writeTokenFile + readTokenFile round trip', () => {
+    it('persists and reads back the same content', async () => {
+      const file: McpTokenFile = { version: 1, port: 7457, token: generateToken() };
+      await writeTokenFile(file);
+      await expect(readTokenFile()).resolves.toEqual(file);
+    });
+
+    it('overwrites an existing file atomically', async () => {
+      const a: McpTokenFile = { version: 1, port: 7457, token: generateToken() };
+      const b: McpTokenFile = { version: 1, port: 7458, token: generateToken() };
+      await writeTokenFile(a);
+      await writeTokenFile(b);
+      await expect(readTokenFile()).resolves.toEqual(b);
+      // No leftover .tmp files in the directory.
+      const raw = await readFile(getTokenFilePath(), 'utf8');
+      expect(raw.trim().endsWith('}')).toBe(true);
+    });
+
+    it.runIf(isPosix)('writes the file with mode 0600', async () => {
+      await writeTokenFile({ version: 1, port: 7457, token: generateToken() });
+      const info = await stat(getTokenFilePath());
+      expect(info.mode & 0o777).toBe(0o600);
+    });
+
+    it.runIf(isPosix)('creates the parent directory with mode 0700', async () => {
+      // Use a fresh nested dir that does not yet exist so writeTokenFile has
+      // to create it. Wrapping path keeps the override pointed at a dir we
+      // control.
+      const nested = join(dir, 'nested', '.emdash');
+      __setEmdashDirForTests(nested);
+      await writeTokenFile({ version: 1, port: 7457, token: generateToken() });
+      const info = await stat(nested);
+      expect(info.mode & 0o777).toBe(0o700);
+    });
+  });
+
+  describe('ensureTokenFile', () => {
+    it('creates and returns a new file when none exists', async () => {
+      const file = await ensureTokenFile(7457);
+      expect(file).toEqual({ version: 1, port: 7457, token: expect.any(String) });
+      expect(file.token.length).toBeGreaterThan(0);
+      await expect(readTokenFile()).resolves.toEqual(file);
+    });
+
+    it('returns the existing file unchanged when port matches', async () => {
+      const first = await ensureTokenFile(7457);
+      const second = await ensureTokenFile(7457);
+      expect(second).toEqual(first);
+    });
+
+    it('regenerates the token when the port differs', async () => {
+      const first = await ensureTokenFile(7457);
+      const second = await ensureTokenFile(7458);
+      expect(second.port).toBe(7458);
+      expect(second.token).not.toBe(first.token);
+    });
+  });
+
+  describe('rotateToken', () => {
+    it('always produces a different token even at the same port', async () => {
+      const first = await ensureTokenFile(7457);
+      const rotated = await rotateToken(7457);
+      expect(rotated.port).toBe(7457);
+      expect(rotated.token).not.toBe(first.token);
+      await expect(readTokenFile()).resolves.toEqual(rotated);
+    });
+  });
+
+  describe('checkPermissions', () => {
+    it.runIf(isPosix)('returns ok for a freshly written file (mode 0600)', async () => {
+      await writeTokenFile({ version: 1, port: 7457, token: generateToken() });
+      await expect(checkPermissions()).resolves.toEqual({ ok: true });
+    });
+
+    it.runIf(isPosix)('flags world-readable files', async () => {
+      const path = getTokenFilePath();
+      await mkdir(dir, { recursive: true });
+      await writeFile(path, JSON.stringify({ version: 1, port: 7457, token: 'tok' }), {
+        mode: 0o644,
+      });
+      const result = await checkPermissions();
+      expect(result.ok).toBe(false);
+      expect(result.warning).toMatch(/insecure permissions/);
+      expect(result.warning).toMatch(/644/);
+    });
+
+    it.runIf(isPosix)('flags group-readable files', async () => {
+      const path = getTokenFilePath();
+      await mkdir(dir, { recursive: true });
+      await writeFile(path, JSON.stringify({ version: 1, port: 7457, token: 'tok' }), {
+        mode: 0o640,
+      });
+      const result = await checkPermissions();
+      expect(result.ok).toBe(false);
+      expect(result.warning).toMatch(/640/);
+    });
+
+    it.runIf(isPosix)('reports a missing file', async () => {
+      const result = await checkPermissions();
+      expect(result.ok).toBe(false);
+      expect(result.warning).toMatch(/does not exist/);
+    });
+
+    it.runIf(!isPosix)('skips the mode check on Windows', async () => {
+      // No setup needed: the function should short-circuit on win32.
+      await expect(checkPermissions()).resolves.toEqual({ ok: true });
+    });
+  });
+});

--- a/src/main/core/mcp-server/token-store.ts
+++ b/src/main/core/mcp-server/token-store.ts
@@ -1,24 +1,198 @@
+import { randomBytes } from 'node:crypto';
+import { chmod, mkdir, readFile, rename, stat, unlink, writeFile } from 'node:fs/promises';
+import { homedir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { log } from '@main/lib/logger';
+
 /**
- * Reads/writes `~/.emdash/mcp.json` containing `{ port, token, version }` at
- * mode `0600`.
+ * Persisted shape of `~/.emdash/mcp.json`.
  *
- * Eventual responsibilities:
- * - `readTokenFile()`: load and validate the persisted token file; refuse to
- *   surface the token if file permissions are too permissive.
- * - `writeTokenFile()`: persist the token atomically with mode `0600`.
- * - `regenerateToken()`: produce a fresh `crypto.randomBytes(32)` base64url
- *   token, persist it, and return the new value.
- *
- * Currently stubs — return undefined.
+ * The file is bound to a single emdash install. It is read by both the
+ * Electron main process (to validate incoming bearer tokens) and the
+ * standalone `emdash-mcp` stdio bridge (to authenticate outgoing requests).
  */
-export async function readTokenFile(): Promise<unknown> {
-  return undefined;
+export interface McpTokenFile {
+  version: 1;
+  port: number;
+  token: string;
 }
 
-export async function writeTokenFile(): Promise<unknown> {
-  return undefined;
+const EMDASH_DIR_NAME = '.emdash';
+const TOKEN_FILE_NAME = 'mcp.json';
+
+/**
+ * Resolves the on-disk location of the token file for the *current* user.
+ *
+ * Tests should not call this directly — use {@link getTokenFilePath} below,
+ * which honors the test-only directory override.
+ */
+function defaultEmdashDir(): string {
+  return join(homedir(), EMDASH_DIR_NAME);
 }
 
-export async function regenerateToken(): Promise<unknown> {
-  return undefined;
+let emdashDirOverride: string | null = null;
+
+/**
+ * Test-only: redirect token-store filesystem operations to a different
+ * directory. Pass `null` to restore the default (`~/.emdash`).
+ *
+ * Production code MUST NOT call this. It exists so unit tests can use a
+ * temporary directory without mutating `process.env.HOME` (which would
+ * affect any other code that reads `os.homedir()` during the test run).
+ */
+export function __setEmdashDirForTests(dir: string | null): void {
+  emdashDirOverride = dir;
+}
+
+function emdashDir(): string {
+  return emdashDirOverride ?? defaultEmdashDir();
+}
+
+export function getTokenFilePath(): string {
+  return join(emdashDir(), TOKEN_FILE_NAME);
+}
+
+async function ensureParentDir(filePath: string): Promise<void> {
+  const dir = dirname(filePath);
+  await mkdir(dir, { recursive: true, mode: 0o700 });
+  // mkdir's mode is masked by umask; tighten explicitly so the directory
+  // is owner-only even when the user's umask is permissive.
+  if (process.platform !== 'win32') {
+    try {
+      await chmod(dir, 0o700);
+    } catch (err) {
+      log.warn('[mcp-server] failed to chmod 0700 on emdash dir', dir, err);
+    }
+  }
+}
+
+function isValidTokenFile(value: unknown): value is McpTokenFile {
+  if (typeof value !== 'object' || value === null) return false;
+  const obj = value as Record<string, unknown>;
+  if (obj.version !== 1) return false;
+  if (typeof obj.port !== 'number' || !Number.isFinite(obj.port)) return false;
+  if (typeof obj.token !== 'string' || obj.token.length === 0) return false;
+  return true;
+}
+
+export async function readTokenFile(): Promise<McpTokenFile | null> {
+  const path = getTokenFilePath();
+  let raw: string;
+  try {
+    raw = await readFile(path, 'utf8');
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') return null;
+    log.warn('[mcp-server] failed to read token file', path, err);
+    return null;
+  }
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    log.warn('[mcp-server] token file is not valid JSON', path, err);
+    return null;
+  }
+  if (!isValidTokenFile(parsed)) {
+    log.warn('[mcp-server] token file failed validation', path);
+    return null;
+  }
+  return parsed;
+}
+
+export async function writeTokenFile(file: McpTokenFile): Promise<void> {
+  const path = getTokenFilePath();
+  await ensureParentDir(path);
+  const tmpPath = `${path}.${process.pid}.${Date.now()}.tmp`;
+  const payload = `${JSON.stringify(file, null, 2)}\n`;
+  // Write the temp file with mode 0600 so it is never world/group readable,
+  // even between the write and the rename.
+  await writeFile(tmpPath, payload, { mode: 0o600 });
+  if (process.platform !== 'win32') {
+    try {
+      await chmod(tmpPath, 0o600);
+    } catch (err) {
+      // If chmod fails we still try to clean up the temp file before
+      // surfacing the error.
+      await unlink(tmpPath).catch(() => undefined);
+      throw err;
+    }
+  }
+  try {
+    await rename(tmpPath, path);
+  } catch (err) {
+    await unlink(tmpPath).catch(() => undefined);
+    throw err;
+  }
+  if (process.platform !== 'win32') {
+    // rename preserves the source's mode, but make it explicit on the final
+    // path in case the destination existed with a more permissive mode.
+    try {
+      await chmod(path, 0o600);
+    } catch (err) {
+      log.warn('[mcp-server] failed to chmod 0600 on token file', path, err);
+    }
+  }
+}
+
+export function generateToken(): string {
+  return randomBytes(32).toString('base64url');
+}
+
+export async function ensureTokenFile(port: number): Promise<McpTokenFile> {
+  const existing = await readTokenFile();
+  if (existing && existing.port === port) {
+    return existing;
+  }
+  // Per spec: if the file is missing OR its port differs, regenerate the
+  // token and write a new file with the requested port. Rotating on port
+  // change prevents an attacker who learned the old port+token from
+  // continuing to authenticate against the new server.
+  const next: McpTokenFile = {
+    version: 1,
+    port,
+    token: generateToken(),
+  };
+  await writeTokenFile(next);
+  return next;
+}
+
+export async function rotateToken(port: number): Promise<McpTokenFile> {
+  const next: McpTokenFile = {
+    version: 1,
+    port,
+    token: generateToken(),
+  };
+  await writeTokenFile(next);
+  return next;
+}
+
+export async function checkPermissions(): Promise<{ ok: boolean; warning?: string }> {
+  if (process.platform === 'win32') {
+    // POSIX modes do not apply on Windows; ACL inspection is out of scope
+    // for v1. The token file lives under the user's profile directory which
+    // is access-controlled by default.
+    return { ok: true };
+  }
+  const path = getTokenFilePath();
+  let info;
+  try {
+    info = await stat(path);
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException).code === 'ENOENT') {
+      return { ok: false, warning: `Token file ${path} does not exist.` };
+    }
+    return {
+      ok: false,
+      warning: `Failed to stat token file ${path}: ${(err as Error).message}`,
+    };
+  }
+  // Mask out the file-type bits and look only at the permission bits.
+  const mode = info.mode & 0o777;
+  if (mode !== 0o600) {
+    return {
+      ok: false,
+      warning: `Token file ${path} has insecure permissions (mode ${mode.toString(8).padStart(3, '0')}); expected 600. Group or other users may be able to read the bearer token.`,
+    };
+  }
+  return { ok: true };
 }

--- a/src/main/core/mcp-server/token-store.ts
+++ b/src/main/core/mcp-server/token-store.ts
@@ -1,0 +1,24 @@
+/**
+ * Reads/writes `~/.emdash/mcp.json` containing `{ port, token, version }` at
+ * mode `0600`.
+ *
+ * Eventual responsibilities:
+ * - `readTokenFile()`: load and validate the persisted token file; refuse to
+ *   surface the token if file permissions are too permissive.
+ * - `writeTokenFile()`: persist the token atomically with mode `0600`.
+ * - `regenerateToken()`: produce a fresh `crypto.randomBytes(32)` base64url
+ *   token, persist it, and return the new value.
+ *
+ * Currently stubs — return undefined.
+ */
+export async function readTokenFile(): Promise<unknown> {
+  return undefined;
+}
+
+export async function writeTokenFile(): Promise<unknown> {
+  return undefined;
+}
+
+export async function regenerateToken(): Promise<unknown> {
+  return undefined;
+}

--- a/src/main/core/mcp-server/tools/_helpers.ts
+++ b/src/main/core/mcp-server/tools/_helpers.ts
@@ -19,8 +19,36 @@
  * tool name + duration + status lands in the recent-calls ring buffer that
  * the Settings UI surfaces.
  */
+import { z } from 'zod';
+import type { OpenInAppId } from '@shared/openInApps';
 import type { Result } from '@shared/result';
 import { recentCallsRing } from '../recent-calls';
+
+// ─── Shared schemas / mappings ─────────────────────────────────────────────
+
+/**
+ * Editor enum exposed to MCP clients. Kept short on purpose — the catalog of
+ * `OPEN_IN_APPS` (in `src/shared/openInApps.ts`) is much larger, but those
+ * are renderer-facing and over-specific for the LLM surface. Anything not
+ * present here can still be opened via the renderer.
+ */
+export const editorSchema = z.enum(['vscode', 'cursor', 'zed', 'sublime', 'terminal']);
+export type EditorChoice = z.infer<typeof editorSchema>;
+
+/**
+ * Maps the MCP-facing `editor` value to a canonical `OpenInAppId`.
+ *
+ * `sublime` isn't in OPEN_IN_APPS today; it falls back to `zed` so the
+ * external client gets *something* rather than a hard error. Adding a real
+ * Sublime entry to `OPEN_IN_APPS` is a follow-up.
+ */
+export const editorToOpenInAppId: Record<EditorChoice, OpenInAppId> = {
+  vscode: 'vscode',
+  cursor: 'cursor',
+  zed: 'zed',
+  sublime: 'zed',
+  terminal: 'terminal',
+};
 
 /**
  * Shape of the message body returned by every emdash MCP tool handler.

--- a/src/main/core/mcp-server/tools/_helpers.ts
+++ b/src/main/core/mcp-server/tools/_helpers.ts
@@ -145,14 +145,57 @@ export function withRecording<Args>(
     try {
       const reply = await handler(args);
       const ms = Date.now() - startedAt;
-      const status: 'ok' | 'error' = 'isError' in reply && reply.isError ? 'error' : 'ok';
-      recentCallsRing.record({ tool: name, ms, status });
+      const isError = 'isError' in reply && reply.isError === true;
+      if (isError) {
+        const { code, message } = extractErrorFields(reply);
+        recentCallsRing.record({
+          tool: name,
+          ms,
+          status: 'error',
+          errorCode: code,
+          errorMessage: message,
+        });
+      } else {
+        recentCallsRing.record({ tool: name, ms, status: 'ok' });
+      }
       return reply;
     } catch (err) {
       const ms = Date.now() - startedAt;
       const message = err instanceof Error ? err.message : String(err);
-      recentCallsRing.record({ tool: name, ms, status: 'error', error: message });
+      recentCallsRing.record({
+        tool: name,
+        ms,
+        status: 'error',
+        errorCode: 'UNHANDLED',
+        errorMessage: message,
+      });
       return formatErr('UNHANDLED', message);
     }
   };
+}
+
+/**
+ * Pull `{ code, message }` out of an MCP error reply's JSON-text body. The
+ * fields are best-effort — a malformed body still yields `undefined`s, which
+ * the ring buffer is happy to store.
+ */
+function extractErrorFields(reply: McpToolReply): {
+  code: string | undefined;
+  message: string | undefined;
+} {
+  const text = reply.content[0]?.text;
+  if (typeof text !== 'string') return { code: undefined, message: undefined };
+  try {
+    const parsed = JSON.parse(text) as unknown;
+    if (parsed && typeof parsed === 'object') {
+      const obj = parsed as Record<string, unknown>;
+      return {
+        code: typeof obj.code === 'string' ? obj.code : undefined,
+        message: typeof obj.message === 'string' ? obj.message : undefined,
+      };
+    }
+  } catch {
+    // ignore — non-JSON error bodies are rare but tolerated
+  }
+  return { code: undefined, message: undefined };
 }

--- a/src/main/core/mcp-server/tools/_helpers.ts
+++ b/src/main/core/mcp-server/tools/_helpers.ts
@@ -1,0 +1,130 @@
+/**
+ * Shared helpers for MCP tool handlers.
+ *
+ * All emdash tool handlers are thin adapters around existing operation
+ * functions: they validate args (via Zod, in the registration site), delegate
+ * to the op, and translate the result into an MCP `CallToolResult`. These
+ * helpers centralise the response shape so every tool answers the same way.
+ *
+ * Conventions:
+ * - Success → `{ content: [{ type: 'text', text: <json> }] }` (pretty-printed
+ *   JSON, 2-space indent).
+ * - Error   → `{ isError: true, content: [{ type: 'text', text: <json> }] }`
+ *   where the JSON is `{ code, message, details? }`.
+ * - Destructive ops (`task.delete`, `project.delete`, `mcp.remove`,
+ *   `skill.uninstall`) require `confirm: true` and use `requireConfirm()` to
+ *   short-circuit with a `CONFIRM_REQUIRED` error.
+ *
+ * Every wired handler should also be wrapped with `withRecording()` so the
+ * tool name + duration + status lands in the recent-calls ring buffer that
+ * the Settings UI surfaces.
+ */
+import type { Result } from '@shared/result';
+import { recentCallsRing } from '../recent-calls';
+
+/**
+ * Shape of the message body returned by every emdash MCP tool handler.
+ *
+ * Matches `CallToolResult` from `@modelcontextprotocol/sdk` closely enough
+ * for the SDK to serialise it without further wrapping.
+ */
+export type McpToolReply =
+  | { content: Array<{ type: 'text'; text: string }> }
+  | { isError: true; content: Array<{ type: 'text'; text: string }> };
+
+/** Format a successful tool result as a JSON-text reply. */
+export function formatOk(data: unknown): {
+  content: [{ type: 'text'; text: string }];
+} {
+  return {
+    content: [{ type: 'text', text: JSON.stringify(data ?? null, null, 2) }],
+  };
+}
+
+/** Format a structured error reply. */
+export function formatErr(
+  code: string,
+  message: string,
+  details?: unknown
+): { isError: true; content: [{ type: 'text'; text: string }] } {
+  const payload = details === undefined ? { code, message } : { code, message, details };
+  return {
+    isError: true,
+    content: [{ type: 'text', text: JSON.stringify(payload, null, 2) }],
+  };
+}
+
+/**
+ * Returns a `CONFIRM_REQUIRED` error reply unless `args.confirm === true`.
+ *
+ * Destructive tools call this at the top of their handler and bail out if it
+ * returns a non-null reply:
+ *
+ * ```ts
+ * const guard = requireConfirm(args, 'delete this task', { taskId });
+ * if (guard) return guard;
+ * ```
+ */
+export function requireConfirm(
+  args: { confirm?: boolean },
+  action: string,
+  target: unknown
+): null | ReturnType<typeof formatErr> {
+  if (args.confirm === true) return null;
+  return formatErr('CONFIRM_REQUIRED', `Set confirm: true to ${action}`, target);
+}
+
+/**
+ * Translates a `Result<T, E>` from an existing operation function into an
+ * MCP reply. `Ok` becomes a success payload; `Err` becomes a structured
+ * error whose `details` field carries the original error object.
+ */
+export function fromResult<T, E>(
+  result: Result<T, E>,
+  errorCode = 'OPERATION_FAILED'
+): McpToolReply {
+  if (result.success) return formatOk(result.data);
+  const error = result.error as unknown;
+  const errType =
+    typeof error === 'object' && error !== null && 'type' in error
+      ? String((error as { type: unknown }).type)
+      : undefined;
+  const errMessage =
+    typeof error === 'object' && error !== null && 'message' in error
+      ? String((error as { message: unknown }).message ?? errType ?? errorCode)
+      : typeof error === 'string'
+        ? error
+        : (errType ?? errorCode);
+  return formatErr(errType ?? errorCode, errMessage, error);
+}
+
+/**
+ * Wraps a tool handler so its invocation is recorded in the recent-calls
+ * ring buffer (tool name, duration, success/failure). Caller should use the
+ * returned function as the handler passed to `server.registerTool`.
+ *
+ * The wrapper also normalises thrown exceptions into a structured
+ * `UNHANDLED` error reply so the SDK never sees a rejected promise — that
+ * keeps the protocol response consistent and means recent-calls always
+ * captures the true latency.
+ */
+export function withRecording<Args>(
+  name: string,
+  handler: (args: Args) => Promise<McpToolReply> | McpToolReply
+): (args: Args) => Promise<McpToolReply> {
+  return async (args: Args): Promise<McpToolReply> => {
+    const startedAt = Date.now();
+    try {
+      const reply = await handler(args);
+      const ms = Date.now() - startedAt;
+      const status: 'ok' | 'error' = 'isError' in reply && reply.isError ? 'error' : 'ok';
+      recentCallsRing.record({ tool: name, ms, status });
+      return reply;
+    } catch (err) {
+      const ms = Date.now() - startedAt;
+      const message = err instanceof Error ? err.message : String(err);
+      recentCallsRing.record({ tool: name, ms, status: 'error', error: message });
+      return formatErr('UNHANDLED', message);
+    }
+  };
+}

--- a/src/main/core/mcp-server/tools/helpers.test.ts
+++ b/src/main/core/mcp-server/tools/helpers.test.ts
@@ -1,0 +1,80 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { recentCallsRing } from '../recent-calls';
+import { formatErr, formatOk, withRecording } from './_helpers';
+
+// `recent-calls.ts` imports the main-process event emitter, which in turn
+// pulls in Electron + the DB client. Stub it so the helpers test stays a
+// pure unit test.
+vi.mock('@main/lib/events', () => ({
+  events: { emit: vi.fn(), on: vi.fn(), once: vi.fn() },
+}));
+
+/**
+ * `withRecording` is the only seam between the tool layer and the recent-calls
+ * ring buffer. These tests confirm the end-to-end wiring: an invocation
+ * produces a ring entry with the right status / error fields, and thrown
+ * exceptions are normalised into an `UNHANDLED` reply (still recorded).
+ */
+describe('withRecording', () => {
+  beforeEach(() => {
+    recentCallsRing.clear();
+  });
+
+  afterEach(() => {
+    recentCallsRing.clear();
+  });
+
+  it('records a successful invocation as status=ok', async () => {
+    const wrapped = withRecording('task.list', async () => formatOk({ tasks: [] }));
+    const reply = await wrapped({});
+    expect('isError' in reply ? reply.isError : false).toBe(false);
+    const snap = recentCallsRing.snapshot();
+    expect(snap).toHaveLength(1);
+    expect(snap[0]).toMatchObject({ tool: 'task.list', status: 'ok' });
+    expect(snap[0]?.errorCode).toBeUndefined();
+    expect(snap[0]?.id).toBeTruthy();
+    expect(snap[0]?.ts).toBeGreaterThan(0);
+  });
+
+  it('records an MCP error reply as status=error, extracting code/message', async () => {
+    const wrapped = withRecording('task.delete', async () =>
+      formatErr('CONFIRM_REQUIRED', 'Set confirm: true to delete this task', { taskId: 't1' })
+    );
+    const reply = await wrapped({});
+    expect('isError' in reply && reply.isError).toBe(true);
+    const snap = recentCallsRing.snapshot();
+    expect(snap).toHaveLength(1);
+    expect(snap[0]).toMatchObject({
+      tool: 'task.delete',
+      status: 'error',
+      errorCode: 'CONFIRM_REQUIRED',
+      errorMessage: 'Set confirm: true to delete this task',
+    });
+  });
+
+  it('records thrown exceptions as UNHANDLED errors and never rejects', async () => {
+    const wrapped = withRecording('task.create', async () => {
+      throw new Error('explode');
+    });
+    const reply = await wrapped({});
+    expect('isError' in reply && reply.isError).toBe(true);
+    const snap = recentCallsRing.snapshot();
+    expect(snap).toHaveLength(1);
+    expect(snap[0]).toMatchObject({
+      tool: 'task.create',
+      status: 'error',
+      errorCode: 'UNHANDLED',
+      errorMessage: 'explode',
+    });
+  });
+
+  it('measures handler duration roughly accurately', async () => {
+    const wrapped = withRecording('task.slow', async () => {
+      await new Promise((r) => setTimeout(r, 20));
+      return formatOk(null);
+    });
+    await wrapped({});
+    const snap = recentCallsRing.snapshot();
+    expect(snap[0]?.ms).toBeGreaterThanOrEqual(15);
+  });
+});

--- a/src/main/core/mcp-server/tools/index.ts
+++ b/src/main/core/mcp-server/tools/index.ts
@@ -1,9 +1,11 @@
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+
 /**
- * Aggregates registration of every MCP tool category onto the SDK `Server`.
+ * Aggregates registration of every MCP tool category onto the SDK `McpServer`.
  *
  * Eventual responsibilities: call `register(server)` from each per-domain
  * tool module (tasks, projects, mcp, skills, worktrees, system).
  *
- * Currently a stub — no-op.
+ * Currently a stub — no-op. Filled in by T4+.
  */
-export function registerAllTools(_server: unknown): void {}
+export function registerAllTools(_server: McpServer): void {}

--- a/src/main/core/mcp-server/tools/index.ts
+++ b/src/main/core/mcp-server/tools/index.ts
@@ -1,15 +1,22 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerMcpTools } from './mcp-tools';
+import { registerProjectTools } from './project-tools';
+import { registerSkillTools } from './skill-tools';
+import { registerSystemTools } from './system-tools';
 import { registerTaskTools } from './task-tools';
+import { registerWorktreeTools } from './worktree-tools';
 
 /**
  * Aggregates registration of every MCP tool category onto the SDK `McpServer`.
  *
  * Per-domain tool modules are registered in alphabetical order so the tool
  * list the SDK reports back to clients is deterministic.
- *
- * T4 wired the `task.*` tools. T5+ will fill in the remaining domains
- * (projects, mcp servers, skills, worktrees, system).
  */
 export function registerAllTools(server: McpServer): void {
+  registerMcpTools(server);
+  registerProjectTools(server);
+  registerSkillTools(server);
+  registerSystemTools(server);
   registerTaskTools(server);
+  registerWorktreeTools(server);
 }

--- a/src/main/core/mcp-server/tools/index.ts
+++ b/src/main/core/mcp-server/tools/index.ts
@@ -1,11 +1,15 @@
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { registerTaskTools } from './task-tools';
 
 /**
  * Aggregates registration of every MCP tool category onto the SDK `McpServer`.
  *
- * Eventual responsibilities: call `register(server)` from each per-domain
- * tool module (tasks, projects, mcp, skills, worktrees, system).
+ * Per-domain tool modules are registered in alphabetical order so the tool
+ * list the SDK reports back to clients is deterministic.
  *
- * Currently a stub — no-op. Filled in by T4+.
+ * T4 wired the `task.*` tools. T5+ will fill in the remaining domains
+ * (projects, mcp servers, skills, worktrees, system).
  */
-export function registerAllTools(_server: McpServer): void {}
+export function registerAllTools(server: McpServer): void {
+  registerTaskTools(server);
+}

--- a/src/main/core/mcp-server/tools/index.ts
+++ b/src/main/core/mcp-server/tools/index.ts
@@ -1,0 +1,9 @@
+/**
+ * Aggregates registration of every MCP tool category onto the SDK `Server`.
+ *
+ * Eventual responsibilities: call `register(server)` from each per-domain
+ * tool module (tasks, projects, mcp, skills, worktrees, system).
+ *
+ * Currently a stub — no-op.
+ */
+export function registerAllTools(_server: unknown): void {}

--- a/src/main/core/mcp-server/tools/mcp-tools.test.ts
+++ b/src/main/core/mcp-server/tools/mcp-tools.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Unit tests for the `mcp.*` MCP tools (managing emdash's outbound MCP
+ * server config).
+ */
+import type { McpServer as SdkMcpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { McpServer } from '@shared/mcp/types';
+import { _resetMcpDeps, _setMcpDeps, registerMcpTools } from './mcp-tools';
+
+type CapturedHandler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+interface TestServer extends Pick<SdkMcpServer, 'registerTool'> {
+  handlers: Map<string, CapturedHandler>;
+}
+
+function makeTestServer(): TestServer {
+  const handlers = new Map<string, CapturedHandler>();
+  const server: TestServer = {
+    handlers,
+    registerTool: ((name: string, _config: unknown, handler: CapturedHandler) => {
+      handlers.set(name, handler);
+      return { remove: () => undefined } as never;
+    }) as SdkMcpServer['registerTool'],
+  };
+  return server;
+}
+
+function parseReply(reply: unknown): { isError: boolean; payload: unknown } {
+  const r = reply as {
+    isError?: boolean;
+    content: Array<{ type: 'text'; text: string }>;
+  };
+  return {
+    isError: r.isError === true,
+    payload: JSON.parse(r.content[0].text) as unknown,
+  };
+}
+
+interface MockDeps {
+  loadAll: ReturnType<typeof vi.fn>;
+  saveServer: ReturnType<typeof vi.fn>;
+  removeServer: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDeps(): MockDeps {
+  return {
+    loadAll: vi.fn().mockResolvedValue({ installed: [], catalog: [] }),
+    saveServer: vi.fn().mockResolvedValue(undefined),
+    removeServer: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function installMockDeps(m: MockDeps): void {
+  _setMcpDeps({
+    mcpService: {
+      loadAll: m.loadAll,
+      saveServer: m.saveServer,
+      removeServer: m.removeServer,
+    },
+  } as unknown as Parameters<typeof _setMcpDeps>[0]);
+}
+
+describe('mcp-tools', () => {
+  let server: TestServer;
+  let deps: MockDeps;
+
+  beforeEach(() => {
+    server = makeTestServer();
+    registerMcpTools(server as unknown as SdkMcpServer);
+    deps = makeMockDeps();
+    installMockDeps(deps);
+  });
+
+  afterEach(() => {
+    _resetMcpDeps();
+    vi.clearAllMocks();
+  });
+
+  it('registers the expected tool catalogue under mcp.* names', () => {
+    expect([...server.handlers.keys()].sort()).toEqual(['mcp.add', 'mcp.list', 'mcp.remove']);
+  });
+
+  describe('mcp.list', () => {
+    it('returns the full installed + catalog payload by default', async () => {
+      const installedA: McpServer = {
+        name: 'a',
+        transport: 'stdio',
+        command: 'a',
+        providers: ['claude-code'],
+      };
+      const installedB: McpServer = {
+        name: 'b',
+        transport: 'http',
+        url: 'http://x',
+        providers: ['cursor'],
+      };
+      deps.loadAll.mockResolvedValue({ installed: [installedA, installedB], catalog: [] });
+      const handler = server.handlers.get('mcp.list')!;
+      const reply = await handler({});
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { installed: McpServer[] };
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.installed).toHaveLength(2);
+    });
+
+    it('filters by provider when one is given', async () => {
+      const installedA: McpServer = {
+        name: 'a',
+        transport: 'stdio',
+        command: 'a',
+        providers: ['claude-code'],
+      };
+      const installedB: McpServer = {
+        name: 'b',
+        transport: 'http',
+        url: 'http://x',
+        providers: ['cursor'],
+      };
+      deps.loadAll.mockResolvedValue({ installed: [installedA, installedB], catalog: [] });
+      const handler = server.handlers.get('mcp.list')!;
+      const reply = await handler({ provider: 'cursor' });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { installed: McpServer[] };
+      };
+      expect(parsed.payload.installed.map((s) => s.name)).toEqual(['b']);
+    });
+  });
+
+  describe('mcp.add', () => {
+    it('passes the canonical McpServer shape to saveServer', async () => {
+      const handler = server.handlers.get('mcp.add')!;
+      const reply = await handler({
+        name: 'linear',
+        transport: 'stdio',
+        command: 'linear-mcp',
+        args: ['--debug'],
+        env: { TOKEN: 'x' },
+        providers: ['claude-code', 'cursor'],
+      });
+      expect(deps.saveServer).toHaveBeenCalledTimes(1);
+      const saved = deps.saveServer.mock.calls[0]![0] as McpServer;
+      expect(saved.name).toBe('linear');
+      expect(saved.transport).toBe('stdio');
+      expect(saved.command).toBe('linear-mcp');
+      expect(saved.providers).toEqual(['claude-code', 'cursor']);
+      expect(parseReply(reply).isError).toBe(false);
+    });
+
+    it('surfaces UNHANDLED when the service throws', async () => {
+      deps.saveServer.mockRejectedValue(new Error('config write failed'));
+      const handler = server.handlers.get('mcp.add')!;
+      const reply = await handler({
+        name: 'broken',
+        transport: 'stdio',
+        command: 'x',
+        providers: ['claude-code'],
+      });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { code: string; message: string };
+      };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('UNHANDLED');
+      expect(parsed.payload.message).toContain('config write failed');
+    });
+  });
+
+  describe('mcp.remove', () => {
+    it('without confirm returns CONFIRM_REQUIRED and does not call removeServer', async () => {
+      const handler = server.handlers.get('mcp.remove')!;
+      const reply = await handler({ name: 'linear' });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('CONFIRM_REQUIRED');
+      expect(deps.removeServer).not.toHaveBeenCalled();
+    });
+
+    it('with confirm: true calls removeServer(name)', async () => {
+      const handler = server.handlers.get('mcp.remove')!;
+      const reply = await handler({ name: 'linear', confirm: true });
+      expect(deps.removeServer).toHaveBeenCalledWith('linear');
+      expect(parseReply(reply).isError).toBe(false);
+    });
+  });
+});

--- a/src/main/core/mcp-server/tools/mcp-tools.ts
+++ b/src/main/core/mcp-server/tools/mcp-tools.ts
@@ -1,0 +1,8 @@
+/**
+ * Registers MCP-server-management tools (`mcp.list`, `mcp.add`, `mcp.remove`)
+ * — these manage the *outbound* MCP servers that emdash configures for the
+ * agents it spawns, not the inbound emdash server itself.
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/tools/mcp-tools.ts
+++ b/src/main/core/mcp-server/tools/mcp-tools.ts
@@ -1,8 +1,162 @@
 /**
- * Registers MCP-server-management tools (`mcp.list`, `mcp.add`, `mcp.remove`)
- * — these manage the *outbound* MCP servers that emdash configures for the
- * agents it spawns, not the inbound emdash server itself.
+ * Registers the `mcp.*` MCP tools — these manage emdash's *outbound* MCP
+ * servers (the ones it configures for spawned agents), not the inbound
+ * emdash-as-MCP-server itself.
  *
- * Currently a stub — no-op.
+ * Thin adapters over `McpService` (`src/main/core/mcp/services/McpService.ts`):
+ *
+ *   mcp.list   → `mcpService.loadAll`     (returns installed + catalog)
+ *   mcp.add    → `mcpService.saveServer`  (upsert across selected providers)
+ *   mcp.remove → `mcpService.removeServer`(removes from every provider that has it)
+ *
+ * Runtime deps are loaded lazily so constructing the server doesn't trigger
+ * MCP config IO at import time.
  */
-export function register(_server: unknown): void {}
+import type { McpServer as SdkMcpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { McpLoadAllResponse, McpServer } from '@shared/mcp/types';
+import type { mcpService as McpServiceSingleton } from '@main/core/mcp/services/McpService';
+import { formatOk, requireConfirm, withRecording } from './_helpers';
+
+// ─── Lazy deps ────────────────────────────────────────────────────────────
+
+type McpDeps = {
+  mcpService: typeof McpServiceSingleton;
+};
+
+let cachedDeps: McpDeps | null = null;
+let cachedDepsPromise: Promise<McpDeps> | null = null;
+
+async function loadDeps(): Promise<McpDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const mod = await import('@main/core/mcp/services/McpService');
+    cachedDeps = { mcpService: mod.mcpService };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — for tests: inject a ready-made deps object. */
+export function _setMcpDeps(deps: McpDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — for tests: clear cached deps. */
+export function _resetMcpDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+// ─── Zod fragments ────────────────────────────────────────────────────────
+
+const transportSchema = z.enum(['stdio', 'http']);
+
+const mcpServerSchema = z.object({
+  name: z.string().regex(/^[\w\-._]+$/),
+  transport: transportSchema,
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  url: z.string().optional(),
+  headers: z.record(z.string(), z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  providers: z.array(z.string()),
+});
+
+// ─── Tool registration ────────────────────────────────────────────────────
+
+export function registerMcpTools(server: SdkMcpServer): void {
+  // mcp.list ───────────────────────────────────────────────────────────────
+  const listInput = { provider: z.string().optional() };
+  server.registerTool(
+    'mcp.list',
+    {
+      title: 'List MCP servers',
+      description:
+        'List MCP servers emdash has configured for spawned agents. ' +
+        'Returns `{ installed, catalog }`. When `provider` is set, only the ' +
+        'installed entries that target that provider are returned.',
+      inputSchema: listInput,
+    },
+    withRecording('mcp.list', async (args: z.infer<z.ZodObject<typeof listInput>>) => {
+      const deps = await loadDeps();
+      const all: McpLoadAllResponse = await deps.mcpService.loadAll();
+      if (args.provider) {
+        return formatOk({
+          installed: all.installed.filter((s) => s.providers.includes(args.provider!)),
+          catalog: all.catalog,
+        });
+      }
+      return formatOk(all);
+    }) as never
+  );
+
+  // mcp.add ────────────────────────────────────────────────────────────────
+  const addInput = {
+    name: mcpServerSchema.shape.name,
+    transport: mcpServerSchema.shape.transport,
+    command: mcpServerSchema.shape.command,
+    args: mcpServerSchema.shape.args,
+    url: mcpServerSchema.shape.url,
+    headers: mcpServerSchema.shape.headers,
+    env: mcpServerSchema.shape.env,
+    providers: mcpServerSchema.shape.providers,
+  };
+  server.registerTool(
+    'mcp.add',
+    {
+      title: 'Add or update an MCP server',
+      description:
+        'Add or update an MCP server entry for one or more providers. ' +
+        'Upserts: passing a name that already exists overwrites the existing entry.',
+      inputSchema: addInput,
+    },
+    withRecording('mcp.add', async (args: z.infer<z.ZodObject<typeof addInput>>) => {
+      const deps = await loadDeps();
+      const payload: McpServer = {
+        name: args.name,
+        transport: args.transport,
+        command: args.command,
+        args: args.args,
+        url: args.url,
+        headers: args.headers,
+        env: args.env,
+        providers: args.providers,
+      };
+      await deps.mcpService.saveServer(payload);
+      return formatOk({ name: args.name, providers: args.providers, saved: true });
+    }) as never
+  );
+
+  // mcp.remove ─────────────────────────────────────────────────────────────
+  const removeInput = {
+    name: z.string(),
+    // Accepted for API symmetry with the spec, but the underlying service
+    // removes the server from every provider that has it — there is no
+    // per-provider remove op today.
+    providers: z.array(z.string()).optional(),
+    confirm: z.boolean().optional(),
+  };
+  server.registerTool(
+    'mcp.remove',
+    {
+      title: 'Remove an MCP server',
+      description:
+        'Remove an MCP server entry across providers. Destructive — requires confirm: true. ' +
+        'The `providers` argument is currently informational; the entry is removed from every ' +
+        'provider that has it.',
+      inputSchema: removeInput,
+    },
+    withRecording('mcp.remove', async (args: z.infer<z.ZodObject<typeof removeInput>>) => {
+      const guard = requireConfirm(args, 'remove this MCP server', { name: args.name });
+      if (guard) return guard;
+      const deps = await loadDeps();
+      await deps.mcpService.removeServer(args.name);
+      return formatOk({ name: args.name, removed: true });
+    }) as never
+  );
+}
+
+export { registerMcpTools as register };

--- a/src/main/core/mcp-server/tools/project-tools.test.ts
+++ b/src/main/core/mcp-server/tools/project-tools.test.ts
@@ -1,0 +1,311 @@
+/**
+ * Unit tests for the `project.*` MCP tools.
+ *
+ * Same fake-server + injected-deps pattern as `task-tools.test.ts`.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ok } from '@shared/result';
+import { _resetProjectDeps, _setProjectDeps, registerProjectTools } from './project-tools';
+
+type CapturedHandler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+interface TestServer extends Pick<McpServer, 'registerTool'> {
+  handlers: Map<string, CapturedHandler>;
+}
+
+function makeTestServer(): TestServer {
+  const handlers = new Map<string, CapturedHandler>();
+  const server: TestServer = {
+    handlers,
+    registerTool: ((name: string, _config: unknown, handler: CapturedHandler) => {
+      handlers.set(name, handler);
+      return { remove: () => undefined } as never;
+    }) as McpServer['registerTool'],
+  };
+  return server;
+}
+
+function parseReply(reply: unknown): { isError: boolean; payload: unknown } {
+  const r = reply as {
+    isError?: boolean;
+    content: Array<{ type: 'text'; text: string }>;
+  };
+  return {
+    isError: r.isError === true,
+    payload: JSON.parse(r.content[0].text) as unknown,
+  };
+}
+
+interface MockDeps {
+  createProject: ReturnType<typeof vi.fn>;
+  getProjects: ReturnType<typeof vi.fn>;
+  getProjectById: ReturnType<typeof vi.fn>;
+  deleteProject: ReturnType<typeof vi.fn>;
+  pmGetProject: ReturnType<typeof vi.fn>;
+  settingsGet: ReturnType<typeof vi.fn>;
+  getRemoteState: ReturnType<typeof vi.fn>;
+  updateProjectSettings: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDeps(): MockDeps {
+  return {
+    createProject: vi.fn(),
+    getProjects: vi.fn().mockResolvedValue([]),
+    getProjectById: vi.fn().mockResolvedValue(undefined),
+    deleteProject: vi.fn().mockResolvedValue(undefined),
+    pmGetProject: vi.fn().mockReturnValue(undefined),
+    settingsGet: vi.fn().mockResolvedValue({}),
+    getRemoteState: vi.fn().mockResolvedValue({ hasRemote: false, selectedRemoteUrl: null }),
+    updateProjectSettings: vi.fn(),
+  };
+}
+
+function installMockDeps(m: MockDeps): void {
+  _setProjectDeps({
+    createProject: m.createProject,
+    getProjects: m.getProjects,
+    getProjectById: m.getProjectById,
+    deleteProject: m.deleteProject,
+    projectManager: {
+      getProject: (id: string) => {
+        const provider = (m.pmGetProject as (id: string) => unknown)(id);
+        return provider;
+      },
+    },
+    projectSettingsService: {
+      updateProjectSettings: m.updateProjectSettings,
+    },
+  } as unknown as Parameters<typeof _setProjectDeps>[0]);
+}
+
+describe('project-tools', () => {
+  let server: TestServer;
+  let deps: MockDeps;
+
+  beforeEach(() => {
+    server = makeTestServer();
+    registerProjectTools(server as unknown as McpServer);
+    deps = makeMockDeps();
+    installMockDeps(deps);
+  });
+
+  afterEach(() => {
+    _resetProjectDeps();
+    vi.clearAllMocks();
+  });
+
+  it('registers the expected tool catalogue under project.* names', () => {
+    expect([...server.handlers.keys()].sort()).toEqual([
+      'project.add',
+      'project.delete',
+      'project.get',
+      'project.list',
+      'project.updateSettings',
+    ]);
+  });
+
+  describe('project.add', () => {
+    it('with path → creates a local project', async () => {
+      deps.createProject.mockResolvedValue({
+        type: 'local',
+        id: 'p1',
+        name: 'my-repo',
+        path: '/tmp/my-repo',
+        baseRef: 'main',
+        createdAt: 't',
+        updatedAt: 't',
+      });
+      const handler = server.handlers.get('project.add')!;
+      const reply = await handler({ path: '/tmp/my-repo' });
+      const parsed = parseReply(reply);
+      expect(parsed.isError).toBe(false);
+      const call = deps.createProject.mock.calls[0]![0] as { type: string; name: string };
+      expect(call.type).toBe('local');
+      expect(call.name).toBe('my-repo');
+    });
+
+    it('with ssh → creates an SSH project using the connectionId', async () => {
+      deps.createProject.mockResolvedValue({
+        type: 'ssh',
+        id: 'p2',
+        name: 'remote-repo',
+        path: '/srv/remote-repo',
+        baseRef: 'main',
+        connectionId: 'conn-1',
+        createdAt: 't',
+        updatedAt: 't',
+      });
+      const handler = server.handlers.get('project.add')!;
+      const reply = await handler({
+        ssh: { connectionId: 'conn-1', remotePath: '/srv/remote-repo' },
+      });
+      const parsed = parseReply(reply);
+      expect(parsed.isError).toBe(false);
+      const call = deps.createProject.mock.calls[0]![0] as {
+        type: string;
+        connectionId: string;
+        path: string;
+      };
+      expect(call.type).toBe('ssh');
+      expect(call.connectionId).toBe('conn-1');
+      expect(call.path).toBe('/srv/remote-repo');
+    });
+
+    it('rejects when both path and ssh are provided', async () => {
+      const handler = server.handlers.get('project.add')!;
+      const reply = await handler({
+        path: '/tmp/x',
+        ssh: { connectionId: 'c', remotePath: '/srv/x' },
+      });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('INVALID_ARGS');
+      expect(deps.createProject).not.toHaveBeenCalled();
+    });
+
+    it('rejects when neither path nor ssh is provided', async () => {
+      const handler = server.handlers.get('project.add')!;
+      const reply = await handler({});
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('INVALID_ARGS');
+    });
+  });
+
+  describe('project.list', () => {
+    it('returns the persisted project list', async () => {
+      deps.getProjects.mockResolvedValue([
+        { type: 'local', id: 'p1', name: 'a', path: '/a', baseRef: 'main' },
+      ]);
+      const handler = server.handlers.get('project.list')!;
+      const reply = await handler({});
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: Array<{ id: string }>;
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload).toHaveLength(1);
+      expect(parsed.payload[0].id).toBe('p1');
+    });
+  });
+
+  describe('project.get', () => {
+    it('returns project + settings + remotes when the project is mounted', async () => {
+      const project = {
+        type: 'local' as const,
+        id: 'p1',
+        name: 'a',
+        path: '/a',
+        baseRef: 'main',
+        createdAt: 't',
+        updatedAt: 't',
+      };
+      deps.getProjectById.mockResolvedValue(project);
+      deps.pmGetProject.mockReturnValue({
+        settings: { get: deps.settingsGet },
+        getRemoteState: deps.getRemoteState,
+      });
+      deps.settingsGet.mockResolvedValue({ worktreeDirectory: '.worktrees' });
+      deps.getRemoteState.mockResolvedValue({
+        hasRemote: true,
+        selectedRemoteUrl: 'git@github.com:x/y.git',
+      });
+      const handler = server.handlers.get('project.get')!;
+      const reply = await handler({ projectId: 'p1' });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { project: { id: string }; settings: unknown; remotes: unknown };
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.project.id).toBe('p1');
+      expect(parsed.payload.settings).toEqual({ worktreeDirectory: '.worktrees' });
+      expect(parsed.payload.remotes).toEqual({
+        hasRemote: true,
+        selectedRemoteUrl: 'git@github.com:x/y.git',
+      });
+    });
+
+    it('returns NOT_FOUND when the project does not exist', async () => {
+      deps.getProjectById.mockResolvedValue(undefined);
+      const handler = server.handlers.get('project.get')!;
+      const reply = await handler({ projectId: 'missing' });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('project.updateSettings', () => {
+    it('merges the patch into current settings and calls the service', async () => {
+      deps.pmGetProject.mockReturnValue({
+        settings: { get: deps.settingsGet },
+        getRemoteState: deps.getRemoteState,
+      });
+      deps.settingsGet.mockResolvedValue({ worktreeDirectory: 'old', tmux: false });
+      deps.updateProjectSettings.mockResolvedValue(ok({ worktreeDirectory: 'new', tmux: true }));
+      const handler = server.handlers.get('project.updateSettings')!;
+      const reply = await handler({
+        projectId: 'p1',
+        patch: { worktreeDirectory: 'new', tmux: true },
+      });
+      expect(deps.updateProjectSettings).toHaveBeenCalledTimes(1);
+      const [projectId, merged] = deps.updateProjectSettings.mock.calls[0]!;
+      expect(projectId).toBe('p1');
+      expect(merged).toMatchObject({ worktreeDirectory: 'new', tmux: true });
+      const parsed = parseReply(reply);
+      expect(parsed.isError).toBe(false);
+    });
+
+    it('returns NOT_FOUND when the project is not mounted', async () => {
+      deps.pmGetProject.mockReturnValue(undefined);
+      const handler = server.handlers.get('project.updateSettings')!;
+      const reply = await handler({
+        projectId: 'missing',
+        patch: { worktreeDirectory: 'x' },
+      });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('NOT_FOUND');
+      expect(deps.updateProjectSettings).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('project.delete', () => {
+    it('without confirm returns CONFIRM_REQUIRED and does not call deleteProject', async () => {
+      const handler = server.handlers.get('project.delete')!;
+      const reply = await handler({ projectId: 'p1' });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('CONFIRM_REQUIRED');
+      expect(deps.deleteProject).not.toHaveBeenCalled();
+    });
+
+    it('with confirm: true on a known project deletes it', async () => {
+      deps.getProjectById.mockResolvedValue({
+        type: 'local',
+        id: 'p1',
+        name: 'a',
+        path: '/a',
+        baseRef: 'main',
+        createdAt: 't',
+        updatedAt: 't',
+      });
+      const handler = server.handlers.get('project.delete')!;
+      const reply = await handler({ projectId: 'p1', confirm: true });
+      expect(deps.deleteProject).toHaveBeenCalledWith('p1');
+      const parsed = parseReply(reply);
+      expect(parsed.isError).toBe(false);
+    });
+
+    it('with confirm: true on an unknown project returns NOT_FOUND', async () => {
+      deps.getProjectById.mockResolvedValue(undefined);
+      const handler = server.handlers.get('project.delete')!;
+      const reply = await handler({ projectId: 'missing', confirm: true });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('NOT_FOUND');
+      expect(deps.deleteProject).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/core/mcp-server/tools/project-tools.ts
+++ b/src/main/core/mcp-server/tools/project-tools.ts
@@ -1,0 +1,7 @@
+/**
+ * Registers project-related MCP tools (`project.add`, `project.list`,
+ * `project.get`, `project.updateSettings`, `project.delete`).
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/tools/project-tools.ts
+++ b/src/main/core/mcp-server/tools/project-tools.ts
@@ -1,7 +1,284 @@
 /**
- * Registers project-related MCP tools (`project.add`, `project.list`,
- * `project.get`, `project.updateSettings`, `project.delete`).
+ * Registers the `project.*` MCP tools.
  *
- * Currently a stub — no-op.
+ * Thin adapters over the project operation functions in
+ * `src/main/core/projects/operations/` and `project-settings-service`. No
+ * business logic lives here. Same conventions as `task-tools.ts`:
+ *
+ *   project.add            → `createProject`              (operations/createProject.ts)
+ *   project.list           → `getProjects`                (operations/getProjects.ts)
+ *   project.get            → `getProjectById` + settings + remoteState
+ *   project.updateSettings → `projectSettingsService.updateProjectSettings`
+ *   project.delete         → `deleteProject`              (operations/deleteProject.ts)
+ *
+ * Runtime deps are loaded lazily so constructing an `McpServer` doesn't
+ * pull Electron / the DB at import time.
  */
-export function register(_server: unknown): void {}
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import { baseProjectSettingsSchema } from '@shared/project-settings';
+import type {
+  CreateProjectParams,
+  LocalProject,
+  Project,
+  ProjectRemoteState,
+  SshProject,
+  UpdateProjectSettingsError,
+} from '@shared/projects';
+import type { Result } from '@shared/result';
+import type { projectManager as ProjectManager } from '@main/core/projects/project-manager';
+import type { projectSettingsService as ProjectSettingsService } from '@main/core/projects/settings/project-settings-service';
+import { formatErr, formatOk, fromResult, requireConfirm, withRecording } from './_helpers';
+
+// ─── Lazy deps ────────────────────────────────────────────────────────────
+
+type ProjectDeps = {
+  createProject: (params: CreateProjectParams) => Promise<LocalProject | SshProject>;
+  getProjects: () => Promise<(LocalProject | SshProject)[]>;
+  getProjectById: (projectId: string) => Promise<LocalProject | SshProject | undefined>;
+  deleteProject: (id: string) => Promise<void>;
+  projectManager: typeof ProjectManager;
+  projectSettingsService: typeof ProjectSettingsService;
+};
+
+let cachedDeps: ProjectDeps | null = null;
+let cachedDepsPromise: Promise<ProjectDeps> | null = null;
+
+async function loadDeps(): Promise<ProjectDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const [createProjectMod, getProjectsMod, deleteProjectMod, projectManagerMod, settingsMod] =
+      await Promise.all([
+        import('@main/core/projects/operations/createProject'),
+        import('@main/core/projects/operations/getProjects'),
+        import('@main/core/projects/operations/deleteProject'),
+        import('@main/core/projects/project-manager'),
+        import('@main/core/projects/settings/project-settings-service'),
+      ]);
+    cachedDeps = {
+      createProject: createProjectMod.createProject,
+      getProjects: getProjectsMod.getProjects,
+      getProjectById: getProjectsMod.getProjectById,
+      deleteProject: deleteProjectMod.deleteProject,
+      projectManager: projectManagerMod.projectManager,
+      projectSettingsService: settingsMod.projectSettingsService,
+    };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — for tests: inject a ready-made deps object. */
+export function _setProjectDeps(deps: ProjectDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — for tests: clear cached deps. */
+export function _resetProjectDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+// ─── Zod fragments ────────────────────────────────────────────────────────
+
+const addInput = {
+  path: z.string().optional(),
+  ssh: z
+    .object({
+      connectionId: z.string(),
+      remotePath: z.string(),
+    })
+    .optional(),
+  name: z.string().optional(),
+  // Accepted for API symmetry with the spec; the underlying operation
+  // currently resolves the base ref itself, so this field is informational.
+  baseRef: z.string().optional(),
+};
+
+const updateSettingsInput = {
+  projectId: z.string(),
+  // We validate the patch against the *base* settings schema only — the
+  // shareable bits go through a different write path (`shareProjectSettingsToConfig`).
+  // `.strict()` rejects unknown keys.
+  patch: baseProjectSettingsSchema.strict(),
+};
+
+// ─── Tool registration ────────────────────────────────────────────────────
+
+export function registerProjectTools(server: McpServer): void {
+  // project.add ────────────────────────────────────────────────────────────
+  server.registerTool(
+    'project.add',
+    {
+      title: 'Add project',
+      description:
+        'Add a local project (Git repo path) or a remote SSH project. ' +
+        'Exactly one of `path` or `ssh` must be provided. ' +
+        'Returns the persisted project record.',
+      inputSchema: addInput,
+    },
+    withRecording('project.add', async (args: z.infer<z.ZodObject<typeof addInput>>) => {
+      const hasPath = typeof args.path === 'string' && args.path.length > 0;
+      const hasSsh = !!args.ssh;
+      if (hasPath && hasSsh) {
+        return formatErr(
+          'INVALID_ARGS',
+          'Provide exactly one of `path` (local) or `ssh` (remote), not both.'
+        );
+      }
+      if (!hasPath && !hasSsh) {
+        return formatErr('INVALID_ARGS', 'Provide either `path` (local) or `ssh` (remote).');
+      }
+
+      const deps = await loadDeps();
+      // `name` is required by the underlying op; default to the last path
+      // segment when the caller omits it.
+      const derivePathName = (p: string): string => {
+        const trimmed = p.replace(/\/+$/, '');
+        const idx = trimmed.lastIndexOf('/');
+        return idx >= 0 ? trimmed.slice(idx + 1) : trimmed;
+      };
+
+      let params: CreateProjectParams;
+      if (hasPath) {
+        params = {
+          type: 'local',
+          id: randomUUID(),
+          path: args.path!,
+          name: args.name ?? derivePathName(args.path!),
+        };
+      } else {
+        params = {
+          type: 'ssh',
+          id: randomUUID(),
+          path: args.ssh!.remotePath,
+          name: args.name ?? derivePathName(args.ssh!.remotePath),
+          connectionId: args.ssh!.connectionId,
+        };
+      }
+
+      const project = await deps.createProject(params);
+      return formatOk(project);
+    }) as never
+  );
+
+  // project.list ───────────────────────────────────────────────────────────
+  server.registerTool(
+    'project.list',
+    {
+      title: 'List projects',
+      description: 'Return all projects (local + SSH), sorted by most recently updated.',
+      inputSchema: {},
+    },
+    withRecording('project.list', async () => {
+      const deps = await loadDeps();
+      const projects = await deps.getProjects();
+      return formatOk(projects);
+    }) as never
+  );
+
+  // project.get ────────────────────────────────────────────────────────────
+  const getInput = { projectId: z.string() };
+  server.registerTool(
+    'project.get',
+    {
+      title: 'Get project',
+      description:
+        'Return a project record with its current settings and remote state. ' +
+        'Settings and remotes are best-effort — both may be `null` if the project is not mounted.',
+      inputSchema: getInput,
+    },
+    withRecording('project.get', async (args: z.infer<z.ZodObject<typeof getInput>>) => {
+      const deps = await loadDeps();
+      const project: Project | undefined = await deps.getProjectById(args.projectId);
+      if (!project) {
+        return formatErr('NOT_FOUND', `Project not found: ${args.projectId}`, {
+          projectId: args.projectId,
+        });
+      }
+      const provider = deps.projectManager.getProject(args.projectId);
+      let settings: unknown = null;
+      let remotes: ProjectRemoteState | null = null;
+      if (provider) {
+        try {
+          settings = await provider.settings.get();
+        } catch {
+          settings = null;
+        }
+        try {
+          remotes = await provider.getRemoteState();
+        } catch {
+          remotes = null;
+        }
+      }
+      return formatOk({ project, settings, remotes });
+    }) as never
+  );
+
+  // project.updateSettings ─────────────────────────────────────────────────
+  server.registerTool(
+    'project.updateSettings',
+    {
+      title: 'Update project settings',
+      description:
+        'Patch base project settings (worktreeDirectory, defaultBranch, baseRemote, ' +
+        'pushRemote, tmux, workspaceProvider). Unknown keys are rejected. ' +
+        'Shareable settings (preservePatterns, shellSetup, scripts) go through a ' +
+        'different write path and are not editable here.',
+      inputSchema: updateSettingsInput,
+    },
+    withRecording(
+      'project.updateSettings',
+      async (args: z.infer<z.ZodObject<typeof updateSettingsInput>>) => {
+        const deps = await loadDeps();
+        // Merge the patch onto current settings so the underlying op gets
+        // the full ProjectSettings shape it expects.
+        const provider = deps.projectManager.getProject(args.projectId);
+        if (!provider) {
+          return formatErr('NOT_FOUND', `Project not mounted: ${args.projectId}`, {
+            projectId: args.projectId,
+          });
+        }
+        const current = await provider.settings.get();
+        const merged = { ...current, ...args.patch };
+        const result: Result<unknown, UpdateProjectSettingsError> =
+          await deps.projectSettingsService.updateProjectSettings(args.projectId, merged);
+        return fromResult(result);
+      }
+    ) as never
+  );
+
+  // project.delete ─────────────────────────────────────────────────────────
+  const deleteInput = {
+    projectId: z.string(),
+    confirm: z.boolean().optional(),
+  };
+  server.registerTool(
+    'project.delete',
+    {
+      title: 'Delete project',
+      description:
+        'Remove a project from emdash (does NOT touch the on-disk repo). ' +
+        'Destructive — requires confirm: true.',
+      inputSchema: deleteInput,
+    },
+    withRecording('project.delete', async (args: z.infer<z.ZodObject<typeof deleteInput>>) => {
+      const guard = requireConfirm(args, 'delete this project', { projectId: args.projectId });
+      if (guard) return guard;
+      const deps = await loadDeps();
+      const existing = await deps.getProjectById(args.projectId);
+      if (!existing) {
+        return formatErr('NOT_FOUND', `Project not found: ${args.projectId}`, {
+          projectId: args.projectId,
+        });
+      }
+      await deps.deleteProject(args.projectId);
+      return formatOk({ projectId: args.projectId, deleted: true });
+    }) as never
+  );
+}
+
+export { registerProjectTools as register };

--- a/src/main/core/mcp-server/tools/skill-tools.test.ts
+++ b/src/main/core/mcp-server/tools/skill-tools.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Unit tests for the `skill.*` MCP tools.
+ *
+ * Same fake-server + injected-deps pattern as `task-tools.test.ts`.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CatalogIndex, CatalogSkill, SkillFrontmatter } from '@shared/skills/types';
+import { _resetSkillDeps, _setSkillDeps, registerSkillTools } from './skill-tools';
+
+type CapturedHandler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+interface TestServer extends Pick<McpServer, 'registerTool'> {
+  handlers: Map<string, CapturedHandler>;
+}
+
+function makeTestServer(): TestServer {
+  const handlers = new Map<string, CapturedHandler>();
+  const server: TestServer = {
+    handlers,
+    registerTool: ((name: string, _config: unknown, handler: CapturedHandler) => {
+      handlers.set(name, handler);
+      return { remove: () => undefined } as never;
+    }) as McpServer['registerTool'],
+  };
+  return server;
+}
+
+function parseReply(reply: unknown): { isError: boolean; payload: unknown } {
+  const r = reply as {
+    isError?: boolean;
+    content: Array<{ type: 'text'; text: string }>;
+  };
+  return {
+    isError: r.isError === true,
+    payload: JSON.parse(r.content[0].text) as unknown,
+  };
+}
+
+function makeFrontmatter(name: string): SkillFrontmatter {
+  return { name, description: `desc for ${name}` };
+}
+
+function makeSkill(overrides: Partial<CatalogSkill> = {}): CatalogSkill {
+  const base: CatalogSkill = {
+    id: 'sample-skill',
+    displayName: 'Sample Skill',
+    description: 'A sample skill',
+    source: 'local',
+    frontmatter: makeFrontmatter('sample-skill'),
+    installed: false,
+  };
+  return { ...base, ...overrides };
+}
+
+interface MockDeps {
+  getCatalog: ReturnType<typeof vi.fn>;
+  install: ReturnType<typeof vi.fn>;
+  create: ReturnType<typeof vi.fn>;
+  uninstall: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDeps(): MockDeps {
+  return {
+    getCatalog: vi.fn(),
+    install: vi.fn(),
+    create: vi.fn(),
+    uninstall: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function installMockDeps(m: MockDeps): void {
+  _setSkillDeps({
+    getCatalog: m.getCatalog as unknown as () => Promise<CatalogIndex>,
+    install: m.install as unknown as (id: string) => Promise<CatalogSkill>,
+    create: m.create as unknown as (
+      name: string,
+      description: string,
+      content: string
+    ) => Promise<CatalogSkill>,
+    uninstall: m.uninstall as unknown as (id: string) => Promise<void>,
+  });
+}
+
+describe('skill-tools', () => {
+  let server: TestServer;
+  let deps: MockDeps;
+
+  beforeEach(() => {
+    server = makeTestServer();
+    registerSkillTools(server as unknown as McpServer);
+    deps = makeMockDeps();
+    installMockDeps(deps);
+  });
+
+  afterEach(() => {
+    _resetSkillDeps();
+    vi.clearAllMocks();
+  });
+
+  it('registers the expected tool catalogue under skill.* names', () => {
+    expect([...server.handlers.keys()].sort()).toEqual([
+      'skill.createCustom',
+      'skill.installFromCatalog',
+      'skill.list',
+      'skill.uninstall',
+    ]);
+  });
+
+  describe('skill.list', () => {
+    it('returns the full catalog by default', async () => {
+      const catalog: CatalogIndex = {
+        version: 1,
+        lastUpdated: '2026-01-01T00:00:00.000Z',
+        skills: [makeSkill({ id: 'a', installed: false }), makeSkill({ id: 'b', installed: true })],
+      };
+      deps.getCatalog.mockResolvedValue(catalog);
+
+      const handler = server.handlers.get('skill.list')!;
+      const reply = await handler({});
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: CatalogIndex;
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.skills.map((s) => s.id)).toEqual(['a', 'b']);
+    });
+
+    it('filters to installed skills when installedOnly is true', async () => {
+      const catalog: CatalogIndex = {
+        version: 1,
+        lastUpdated: '2026-01-01T00:00:00.000Z',
+        skills: [makeSkill({ id: 'a', installed: false }), makeSkill({ id: 'b', installed: true })],
+      };
+      deps.getCatalog.mockResolvedValue(catalog);
+
+      const handler = server.handlers.get('skill.list')!;
+      const reply = await handler({ installedOnly: true });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: CatalogIndex;
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.skills.map((s) => s.id)).toEqual(['b']);
+    });
+  });
+
+  describe('skill.uninstall', () => {
+    it('without confirm returns CONFIRM_REQUIRED and does not call uninstall', async () => {
+      const handler = server.handlers.get('skill.uninstall')!;
+      const reply = await handler({ skillId: 'a' });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('CONFIRM_REQUIRED');
+      expect(deps.uninstall).not.toHaveBeenCalled();
+    });
+
+    it('with confirm: true calls uninstall(skillId)', async () => {
+      const handler = server.handlers.get('skill.uninstall')!;
+      const reply = await handler({ skillId: 'a', confirm: true });
+      expect(deps.uninstall).toHaveBeenCalledWith('a');
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { skillId: string; uninstalled: boolean };
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload).toEqual({ skillId: 'a', uninstalled: true });
+    });
+  });
+
+  describe('skill.createCustom', () => {
+    it('happy path → calls create with name, description, content and returns the new skill', async () => {
+      const created = makeSkill({ id: 'my-skill', installed: true });
+      deps.create.mockResolvedValue(created);
+
+      const handler = server.handlers.get('skill.createCustom')!;
+      const reply = await handler({
+        name: 'my-skill',
+        description: 'My new skill',
+        content: '# my-skill\n\nBody.',
+      });
+
+      expect(deps.create).toHaveBeenCalledWith('my-skill', 'My new skill', '# my-skill\n\nBody.');
+      const parsed = parseReply(reply) as { isError: boolean; payload: CatalogSkill };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.id).toBe('my-skill');
+    });
+  });
+});

--- a/src/main/core/mcp-server/tools/skill-tools.ts
+++ b/src/main/core/mcp-server/tools/skill-tools.ts
@@ -1,0 +1,7 @@
+/**
+ * Registers skill-related MCP tools (`skill.list`, `skill.installFromCatalog`,
+ * `skill.createCustom`, `skill.uninstall`).
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/tools/skill-tools.ts
+++ b/src/main/core/mcp-server/tools/skill-tools.ts
@@ -1,7 +1,159 @@
 /**
- * Registers skill-related MCP tools (`skill.list`, `skill.installFromCatalog`,
- * `skill.createCustom`, `skill.uninstall`).
+ * Registers the `skill.*` MCP tools.
  *
- * Currently a stub — no-op.
+ * Thin adapters over `SkillsService` (`src/main/core/skills/SkillsService.ts`).
+ * The service method names differ slightly from the spec's verbs — the spec
+ * says `getCatalog / install / create / uninstall`, the service exposes
+ * `getCatalogIndex / installSkill / createSkill / uninstallSkill`. We use
+ * the actual service names; the MCP tool surface matches the spec.
+ *
+ *   skill.list                → `skillsService.getCatalogIndex`
+ *   skill.installFromCatalog  → `skillsService.installSkill`
+ *   skill.createCustom        → `skillsService.createSkill`
+ *   skill.uninstall           → `skillsService.uninstallSkill`
  */
-export function register(_server: unknown): void {}
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { CatalogIndex, CatalogSkill } from '@shared/skills/types';
+import type { skillsService as SkillsServiceSingleton } from '@main/core/skills/SkillsService';
+import { formatOk, requireConfirm, withRecording } from './_helpers';
+
+// ─── Lazy deps ────────────────────────────────────────────────────────────
+
+type SkillDeps = {
+  getCatalog: () => Promise<CatalogIndex>;
+  install: (skillId: string) => Promise<CatalogSkill>;
+  create: (name: string, description: string, content: string) => Promise<CatalogSkill>;
+  uninstall: (skillId: string) => Promise<void>;
+};
+
+let cachedDeps: SkillDeps | null = null;
+let cachedDepsPromise: Promise<SkillDeps> | null = null;
+
+async function loadDeps(): Promise<SkillDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const mod: { skillsService: typeof SkillsServiceSingleton } = await import(
+      '@main/core/skills/SkillsService'
+    );
+    cachedDeps = {
+      getCatalog: () => mod.skillsService.getCatalogIndex(),
+      install: (id) => mod.skillsService.installSkill(id),
+      create: (name, description, content) =>
+        mod.skillsService.createSkill(name, description, content),
+      uninstall: (id) => mod.skillsService.uninstallSkill(id),
+    };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — for tests: inject a ready-made deps object. */
+export function _setSkillDeps(deps: SkillDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — for tests: clear cached deps. */
+export function _resetSkillDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+// ─── Tool registration ────────────────────────────────────────────────────
+
+export function registerSkillTools(server: McpServer): void {
+  // skill.list ─────────────────────────────────────────────────────────────
+  const listInput = { installedOnly: z.boolean().optional() };
+  server.registerTool(
+    'skill.list',
+    {
+      title: 'List skills',
+      description:
+        'Return the merged catalog of available skills (anthropic / openai / local), ' +
+        'each tagged with its `installed` state. Pass `installedOnly: true` to filter ' +
+        'down to only installed skills.',
+      inputSchema: listInput,
+    },
+    withRecording('skill.list', async (args: z.infer<z.ZodObject<typeof listInput>>) => {
+      const deps = await loadDeps();
+      const catalog = await deps.getCatalog();
+      if (args.installedOnly) {
+        return formatOk({
+          ...catalog,
+          skills: catalog.skills.filter((s) => s.installed),
+        });
+      }
+      return formatOk(catalog);
+    }) as never
+  );
+
+  // skill.installFromCatalog ───────────────────────────────────────────────
+  const installInput = { skillId: z.string() };
+  server.registerTool(
+    'skill.installFromCatalog',
+    {
+      title: 'Install skill from catalog',
+      description:
+        'Install a skill from the merged catalog. Writes the SKILL.md to `~/.agentskills/<id>` ' +
+        'and symlinks it into every detected agent skill directory.',
+      inputSchema: installInput,
+    },
+    withRecording(
+      'skill.installFromCatalog',
+      async (args: z.infer<z.ZodObject<typeof installInput>>) => {
+        const deps = await loadDeps();
+        const skill = await deps.install(args.skillId);
+        return formatOk(skill);
+      }
+    ) as never
+  );
+
+  // skill.createCustom ─────────────────────────────────────────────────────
+  const createInput = {
+    name: z.string(),
+    description: z.string(),
+    content: z.string(),
+  };
+  server.registerTool(
+    'skill.createCustom',
+    {
+      title: 'Create a custom skill',
+      description:
+        'Create a brand-new local skill (writes a new SKILL.md under `~/.agentskills/<name>`). ' +
+        'Skill names must be lowercase letters, numbers, and hyphens (1-64 chars).',
+      inputSchema: createInput,
+    },
+    withRecording('skill.createCustom', async (args: z.infer<z.ZodObject<typeof createInput>>) => {
+      const deps = await loadDeps();
+      const skill = await deps.create(args.name, args.description, args.content);
+      return formatOk(skill);
+    }) as never
+  );
+
+  // skill.uninstall ────────────────────────────────────────────────────────
+  const uninstallInput = {
+    skillId: z.string(),
+    confirm: z.boolean().optional(),
+  };
+  server.registerTool(
+    'skill.uninstall',
+    {
+      title: 'Uninstall skill',
+      description:
+        'Remove a previously-installed skill from `~/.agentskills` and unlink it from agent ' +
+        'directories. Destructive — requires confirm: true.',
+      inputSchema: uninstallInput,
+    },
+    withRecording('skill.uninstall', async (args: z.infer<z.ZodObject<typeof uninstallInput>>) => {
+      const guard = requireConfirm(args, 'uninstall this skill', { skillId: args.skillId });
+      if (guard) return guard;
+      const deps = await loadDeps();
+      await deps.uninstall(args.skillId);
+      return formatOk({ skillId: args.skillId, uninstalled: true });
+    }) as never
+  );
+}
+
+export { registerSkillTools as register };

--- a/src/main/core/mcp-server/tools/system-tools.test.ts
+++ b/src/main/core/mcp-server/tools/system-tools.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for the `system.*` MCP tools.
+ *
+ * Same fake-server + injected-deps pattern as `task-tools.test.ts`.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetSystemDeps, _setSystemDeps, registerSystemTools } from './system-tools';
+
+type CapturedHandler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+interface TestServer extends Pick<McpServer, 'registerTool'> {
+  handlers: Map<string, CapturedHandler>;
+}
+
+function makeTestServer(): TestServer {
+  const handlers = new Map<string, CapturedHandler>();
+  const server: TestServer = {
+    handlers,
+    registerTool: ((name: string, _config: unknown, handler: CapturedHandler) => {
+      handlers.set(name, handler);
+      return { remove: () => undefined } as never;
+    }) as McpServer['registerTool'],
+  };
+  return server;
+}
+
+function parseReply(reply: unknown): { isError: boolean; payload: unknown } {
+  const r = reply as {
+    isError?: boolean;
+    content: Array<{ type: 'text'; text: string }>;
+  };
+  return {
+    isError: r.isError === true,
+    payload: JSON.parse(r.content[0].text) as unknown,
+  };
+}
+
+interface MockDeps {
+  checkInstalledApps: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDeps(): MockDeps {
+  return {
+    checkInstalledApps: vi.fn().mockResolvedValue({}),
+  };
+}
+
+function installMockDeps(m: MockDeps): void {
+  _setSystemDeps({
+    appService: {
+      checkInstalledApps: m.checkInstalledApps,
+    },
+  } as unknown as Parameters<typeof _setSystemDeps>[0]);
+}
+
+describe('system-tools', () => {
+  let server: TestServer;
+  let deps: MockDeps;
+
+  beforeEach(() => {
+    server = makeTestServer();
+    registerSystemTools(server as unknown as McpServer);
+    deps = makeMockDeps();
+    installMockDeps(deps);
+  });
+
+  afterEach(() => {
+    _resetSystemDeps();
+    vi.clearAllMocks();
+  });
+
+  it('registers the expected tool catalogue under system.* names', () => {
+    expect([...server.handlers.keys()].sort()).toEqual(['system.health', 'system.listEditors']);
+  });
+
+  describe('system.health', () => {
+    it('returns the canonical shape: { name, version, uptimeMs, recentErrorCount }', async () => {
+      const handler = server.handlers.get('system.health')!;
+      const reply = await handler({});
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: {
+          name: string;
+          version: string;
+          uptimeMs: number;
+          recentErrorCount: number;
+        };
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.name).toBe('emdash');
+      expect(typeof parsed.payload.version).toBe('string');
+      expect(parsed.payload.version.length).toBeGreaterThan(0);
+      expect(typeof parsed.payload.uptimeMs).toBe('number');
+      expect(parsed.payload.uptimeMs).toBeGreaterThanOrEqual(0);
+      expect(typeof parsed.payload.recentErrorCount).toBe('number');
+      expect(parsed.payload.recentErrorCount).toBeGreaterThanOrEqual(0);
+    });
+  });
+
+  describe('system.listEditors', () => {
+    it('returns the detected-editor availability map from appService', async () => {
+      deps.checkInstalledApps.mockResolvedValue({
+        vscode: true,
+        cursor: false,
+        zed: true,
+      });
+      const handler = server.handlers.get('system.listEditors')!;
+      const reply = await handler({});
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: Record<string, boolean>;
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload).toEqual({ vscode: true, cursor: false, zed: true });
+      expect(deps.checkInstalledApps).toHaveBeenCalledTimes(1);
+    });
+
+    it('falls back to the static catalog when checkInstalledApps throws', async () => {
+      deps.checkInstalledApps.mockRejectedValue(new Error('not in electron'));
+      const handler = server.handlers.get('system.listEditors')!;
+      const reply = await handler({});
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: Record<string, boolean>;
+      };
+      expect(parsed.isError).toBe(false);
+      // All entries should be present and false in the fallback.
+      const values = Object.values(parsed.payload);
+      expect(values.length).toBeGreaterThan(0);
+      for (const v of values) {
+        expect(v).toBe(false);
+      }
+    });
+  });
+});

--- a/src/main/core/mcp-server/tools/system-tools.ts
+++ b/src/main/core/mcp-server/tools/system-tools.ts
@@ -1,0 +1,6 @@
+/**
+ * Registers system-level MCP tools (`system.listEditors`, `system.health`).
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/tools/system-tools.ts
+++ b/src/main/core/mcp-server/tools/system-tools.ts
@@ -1,6 +1,139 @@
 /**
- * Registers system-level MCP tools (`system.listEditors`, `system.health`).
+ * Registers the `system.*` MCP tools.
  *
- * Currently a stub — no-op.
+ *   system.listEditors → `appService.checkInstalledApps` (detected app map);
+ *                        falls back to the static OPEN_IN_APPS catalog if the
+ *                        service throws (e.g. on a non-Electron host).
+ *   system.health      → process uptime + emdash version + recent-error count
+ *                        from the recent-calls ring buffer.
+ *
+ * The version is read the same way `server.ts` already does (lazy, sync,
+ * walks up from `import.meta.url` looking for the `emdash` package.json) so
+ * the two stay in sync without a shared mutable module export.
  */
-export function register(_server: unknown): void {}
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { OPEN_IN_APPS } from '@shared/openInApps';
+import type { appService as AppService } from '@main/core/app/service';
+import { recentCallsRing } from '../recent-calls';
+import { formatOk, withRecording } from './_helpers';
+
+// ─── Lazy deps ────────────────────────────────────────────────────────────
+
+type SystemDeps = {
+  appService: typeof AppService;
+};
+
+let cachedDeps: SystemDeps | null = null;
+let cachedDepsPromise: Promise<SystemDeps> | null = null;
+
+async function loadDeps(): Promise<SystemDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const mod = await import('@main/core/app/service');
+    cachedDeps = { appService: mod.appService };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — for tests: inject a ready-made deps object. */
+export function _setSystemDeps(deps: SystemDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — for tests: clear cached deps. */
+export function _resetSystemDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+// ─── Version resolution (mirrors server.ts) ───────────────────────────────
+
+const UNKNOWN_VERSION = '0.0.0';
+
+function resolvePackageVersionSync(): string {
+  let here: string;
+  try {
+    here = dirname(fileURLToPath(import.meta.url));
+  } catch {
+    here = process.cwd();
+  }
+  const candidates = [
+    join(here, '..', '..', '..', '..', 'package.json'),
+    join(here, '..', '..', '..', '..', '..', 'package.json'),
+    join(process.cwd(), 'package.json'),
+  ];
+  for (const candidate of candidates) {
+    try {
+      const raw = readFileSync(candidate, 'utf8');
+      const parsed = JSON.parse(raw) as { name?: string; version?: string };
+      if (parsed.name === 'emdash' && typeof parsed.version === 'string' && parsed.version) {
+        return parsed.version;
+      }
+    } catch {
+      // try next candidate
+    }
+  }
+  return UNKNOWN_VERSION;
+}
+
+const PACKAGE_VERSION = resolvePackageVersionSync();
+
+// ─── Tool registration ────────────────────────────────────────────────────
+
+export function registerSystemTools(server: McpServer): void {
+  // system.listEditors ─────────────────────────────────────────────────────
+  server.registerTool(
+    'system.listEditors',
+    {
+      title: 'List detected editors',
+      description:
+        'Return the availability map of every editor / terminal emdash knows about ' +
+        '(key = app id, value = true if detected). Falls back to the static catalog ' +
+        'if detection fails.',
+      inputSchema: {},
+    },
+    withRecording('system.listEditors', async () => {
+      try {
+        const deps = await loadDeps();
+        const availability = await deps.appService.checkInstalledApps();
+        return formatOk(availability);
+      } catch {
+        // Fall back to the static catalog when checkInstalledApps isn't
+        // usable (e.g. running outside Electron in a test).
+        const fallback: Record<string, boolean> = {};
+        for (const id of Object.keys(OPEN_IN_APPS)) fallback[id] = false;
+        return formatOk(fallback);
+      }
+    }) as never
+  );
+
+  // system.health ──────────────────────────────────────────────────────────
+  server.registerTool(
+    'system.health',
+    {
+      title: 'Server health',
+      description:
+        'Return basic emdash MCP server health: { name, version, uptimeMs, recentErrorCount }.',
+      inputSchema: {},
+    },
+    withRecording('system.health', async () => {
+      const recentErrorCount = recentCallsRing
+        .snapshot()
+        .filter((c) => c.status === 'error').length;
+      return formatOk({
+        name: 'emdash',
+        version: PACKAGE_VERSION,
+        uptimeMs: Math.round(process.uptime() * 1000),
+        recentErrorCount,
+      });
+    }) as never
+  );
+}
+
+export { registerSystemTools as register };

--- a/src/main/core/mcp-server/tools/task-tools.test.ts
+++ b/src/main/core/mcp-server/tools/task-tools.test.ts
@@ -1,0 +1,482 @@
+/**
+ * Unit tests for the `task.*` MCP tools.
+ *
+ * The tools are thin adapters over operation functions and the PTY registry.
+ * Runtime deps are loaded lazily inside `task-tools.ts` (so simply
+ * constructing an `McpServer` doesn't pull in Electron / the DB), which
+ * means we test by injecting a deps object via `_setTaskDeps()` rather than
+ * `vi.mock()`-ing the underlying modules. This also keeps the test fast and
+ * keeps the deferred-import indirection honest.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { ok, type Result } from '@shared/result';
+import type { CreateTaskParams, Task } from '@shared/tasks';
+import { _resetTaskDeps, _setTaskDeps, registerTaskTools } from './task-tools';
+
+// ── Test harness ────────────────────────────────────────────────────────────
+// We don't need a real `McpServer` — we capture the `(name, config, handler)`
+// triples passed to `registerTool` into a map, then drive each handler
+// directly. This keeps the tests fast and SDK-version-agnostic.
+
+type CapturedHandler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+interface TestServer extends Pick<McpServer, 'registerTool'> {
+  handlers: Map<string, CapturedHandler>;
+  configs: Map<string, { title?: string; description?: string; inputSchema?: unknown }>;
+}
+
+function makeTestServer(): TestServer {
+  const handlers = new Map<string, CapturedHandler>();
+  const configs = new Map<
+    string,
+    { title?: string; description?: string; inputSchema?: unknown }
+  >();
+  const server: TestServer = {
+    handlers,
+    configs,
+    registerTool: ((name: string, config: unknown, handler: CapturedHandler) => {
+      handlers.set(name, handler);
+      configs.set(name, config as { title?: string; description?: string; inputSchema?: unknown });
+      return { remove: () => undefined } as never;
+    }) as McpServer['registerTool'],
+  };
+  return server;
+}
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  const base: Task = {
+    id: 'task-1',
+    projectId: 'proj-1',
+    name: 'My task',
+    status: 'in_progress',
+    sourceBranch: { type: 'local', branch: 'main' },
+    taskBranch: 'feat/my-task',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    statusChangedAt: '2026-01-01T00:00:00.000Z',
+    isPinned: false,
+    prs: [],
+    conversations: {},
+    workspaceId: 'ws-1',
+  };
+  return { ...base, ...overrides };
+}
+
+function parseReply(reply: unknown): { isError: boolean; payload: unknown } {
+  const r = reply as {
+    isError?: boolean;
+    content: Array<{ type: 'text'; text: string }>;
+  };
+  return {
+    isError: r.isError === true,
+    payload: JSON.parse(r.content[0].text) as unknown,
+  };
+}
+
+// ── Mock deps factory ──────────────────────────────────────────────────────
+
+interface MockDeps {
+  createTask: ReturnType<typeof vi.fn>;
+  getTasks: ReturnType<typeof vi.fn>;
+  deleteTask: ReturnType<typeof vi.fn>;
+  archiveTask: ReturnType<typeof vi.fn>;
+  restoreTask: ReturnType<typeof vi.fn>;
+  renameTask: ReturnType<typeof vi.fn>;
+  updateTaskStatus: ReturnType<typeof vi.fn>;
+  updateLinkedIssue: ReturnType<typeof vi.fn>;
+  setTaskPinned: ReturnType<typeof vi.fn>;
+  ptyGet: ReturnType<typeof vi.fn>;
+  ptySubscribe: ReturnType<typeof vi.fn>;
+  ptyList: ReturnType<typeof vi.fn>;
+  wsGet: ReturnType<typeof vi.fn>;
+  appOpenIn: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDeps(): MockDeps {
+  return {
+    createTask: vi.fn(),
+    getTasks: vi.fn().mockResolvedValue([]),
+    deleteTask: vi.fn().mockResolvedValue(undefined),
+    archiveTask: vi.fn().mockResolvedValue(undefined),
+    restoreTask: vi.fn().mockResolvedValue(undefined),
+    renameTask: vi.fn(),
+    updateTaskStatus: vi.fn().mockResolvedValue(undefined),
+    updateLinkedIssue: vi.fn().mockResolvedValue(undefined),
+    setTaskPinned: vi.fn().mockResolvedValue(undefined),
+    ptyGet: vi.fn(),
+    ptySubscribe: vi.fn().mockReturnValue(''),
+    ptyList: vi.fn().mockReturnValue([]),
+    wsGet: vi.fn(),
+    appOpenIn: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function installMockDeps(m: MockDeps): void {
+  // Build a structurally-compatible TaskDeps from our raw mocks. We cast
+  // through `unknown` so we don't have to perfectly mirror every Result
+  // discriminant in the test mocks — the tools only ever look at
+  // `result.success` and pass the rest through `fromResult`.
+  _setTaskDeps({
+    createTask: m.createTask,
+    getTasks: m.getTasks,
+    deleteTask: m.deleteTask,
+    archiveTask: m.archiveTask,
+    restoreTask: m.restoreTask,
+    renameTask: m.renameTask,
+    updateTaskStatus: m.updateTaskStatus,
+    updateLinkedIssue: m.updateLinkedIssue,
+    setTaskPinned: m.setTaskPinned,
+    ptySessionRegistry: {
+      get: m.ptyGet,
+      subscribe: m.ptySubscribe,
+      listActiveSessions: m.ptyList,
+    },
+    workspaceRegistry: {
+      get: m.wsGet,
+    },
+    appService: {
+      openIn: m.appOpenIn,
+    },
+  } as unknown as Parameters<typeof _setTaskDeps>[0]);
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe('task-tools', () => {
+  let server: TestServer;
+  let deps: MockDeps;
+
+  beforeEach(() => {
+    server = makeTestServer();
+    registerTaskTools(server as unknown as McpServer);
+    deps = makeMockDeps();
+    installMockDeps(deps);
+  });
+
+  afterEach(() => {
+    _resetTaskDeps();
+    vi.clearAllMocks();
+  });
+
+  it('registers the expected tool catalogue under task.* names', () => {
+    expect([...server.handlers.keys()].sort()).toEqual([
+      'task.archive',
+      'task.create',
+      'task.delete',
+      'task.get',
+      'task.getOutput',
+      'task.list',
+      'task.listSessions',
+      'task.openInIDE',
+      'task.sendInput',
+      'task.unarchive',
+      'task.update',
+    ]);
+  });
+
+  describe('task.create', () => {
+    it('happy path → calls createTask with the new-branch strategy and returns the task', async () => {
+      const task = makeTask();
+      deps.createTask.mockResolvedValue(ok({ task }));
+
+      const handler = server.handlers.get('task.create')!;
+      const reply = await handler({
+        projectId: 'proj-1',
+        name: 'My task',
+      });
+
+      expect(deps.createTask).toHaveBeenCalledTimes(1);
+      const callArgs = deps.createTask.mock.calls[0]![0] as CreateTaskParams;
+      expect(callArgs.projectId).toBe('proj-1');
+      expect(callArgs.name).toBe('My task');
+      expect(callArgs.strategy).toEqual({ kind: 'new-branch', taskBranch: 'My task' });
+      expect(callArgs.sourceBranch).toEqual({ type: 'local', branch: 'main' });
+
+      const parsed = parseReply(reply);
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload).toEqual({ task });
+    });
+
+    it('rejects from-pull-request strategy with STRATEGY_NOT_SUPPORTED', async () => {
+      const handler = server.handlers.get('task.create')!;
+      const reply = await handler({
+        projectId: 'proj-1',
+        name: 'My task',
+        strategy: 'from-pull-request',
+      });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { code: string };
+      };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('STRATEGY_NOT_SUPPORTED');
+      expect(deps.createTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('task.delete', () => {
+    it('without confirm returns CONFIRM_REQUIRED and does not call deleteTask', async () => {
+      const handler = server.handlers.get('task.delete')!;
+      const reply = await handler({ taskId: 'task-1' });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { code: string; details?: { taskId: string } };
+      };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('CONFIRM_REQUIRED');
+      expect(parsed.payload.details).toEqual({ taskId: 'task-1' });
+      expect(deps.deleteTask).not.toHaveBeenCalled();
+    });
+
+    it('with confirm: true looks up the task and calls deleteTask(projectId, taskId)', async () => {
+      deps.getTasks.mockResolvedValue([makeTask()]);
+
+      const handler = server.handlers.get('task.delete')!;
+      const reply = await handler({ taskId: 'task-1', confirm: true });
+
+      expect(deps.deleteTask).toHaveBeenCalledWith('proj-1', 'task-1');
+      const parsed = parseReply(reply);
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload).toEqual({ taskId: 'task-1', deleted: true });
+    });
+
+    it('with confirm: true on an unknown task returns NOT_FOUND', async () => {
+      deps.getTasks.mockResolvedValue([]);
+
+      const handler = server.handlers.get('task.delete')!;
+      const reply = await handler({ taskId: 'missing', confirm: true });
+
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('NOT_FOUND');
+      expect(deps.deleteTask).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('task.update', () => {
+    it('patches a single field via the corresponding op (status)', async () => {
+      const before = makeTask({ status: 'in_progress' });
+      const after = makeTask({ status: 'review' });
+      // First call resolves the projectId; second returns the post-update view.
+      deps.getTasks.mockResolvedValueOnce([before]).mockResolvedValueOnce([after]);
+
+      const handler = server.handlers.get('task.update')!;
+      const reply = await handler({
+        taskId: 'task-1',
+        patch: { status: 'review' },
+      });
+
+      expect(deps.updateTaskStatus).toHaveBeenCalledWith('task-1', 'review');
+      // No other op should fire when only status is patched.
+      expect(deps.setTaskPinned).not.toHaveBeenCalled();
+      expect(deps.renameTask).not.toHaveBeenCalled();
+
+      const parsed = parseReply(reply) as { isError: boolean; payload: Task };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.status).toBe('review');
+    });
+
+    it('patches multiple fields and returns the refreshed task', async () => {
+      const before = makeTask();
+      const after = makeTask({ name: 'New name', isPinned: true });
+      deps.getTasks.mockResolvedValueOnce([before]).mockResolvedValueOnce([after]);
+      deps.renameTask.mockResolvedValue(ok({ warning: undefined }));
+
+      const handler = server.handlers.get('task.update')!;
+      const reply = await handler({
+        taskId: 'task-1',
+        patch: { name: 'New name', isPinned: true },
+      });
+
+      expect(deps.setTaskPinned).toHaveBeenCalledWith('task-1', true);
+      expect(deps.renameTask).toHaveBeenCalledWith('proj-1', 'task-1', 'New name');
+      const parsed = parseReply(reply) as { isError: boolean; payload: Task };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.name).toBe('New name');
+      expect(parsed.payload.isPinned).toBe(true);
+    });
+
+    it('returns NOT_FOUND when the task does not exist', async () => {
+      deps.getTasks.mockResolvedValue([]);
+      const handler = server.handlers.get('task.update')!;
+      const reply = await handler({ taskId: 'missing', patch: { status: 'done' } });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('NOT_FOUND');
+      expect(deps.updateTaskStatus).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('task.archive / task.unarchive', () => {
+    it('task.archive calls archiveTask(projectId, taskId)', async () => {
+      deps.getTasks.mockResolvedValue([makeTask()]);
+      const handler = server.handlers.get('task.archive')!;
+      const reply = await handler({ taskId: 'task-1' });
+      expect(deps.archiveTask).toHaveBeenCalledWith('proj-1', 'task-1');
+      expect(parseReply(reply).isError).toBe(false);
+    });
+
+    it('task.unarchive calls restoreTask(taskId)', async () => {
+      const handler = server.handlers.get('task.unarchive')!;
+      const reply = await handler({ taskId: 'task-1' });
+      expect(deps.restoreTask).toHaveBeenCalledWith('task-1');
+      expect(parseReply(reply).isError).toBe(false);
+    });
+  });
+
+  describe('task.sendInput', () => {
+    it('writes the data to the PTY session, optionally appending newline', async () => {
+      const writeSpy = vi.fn();
+      deps.ptyGet.mockReturnValue({ write: writeSpy });
+
+      const handler = server.handlers.get('task.sendInput')!;
+      const reply = await handler({
+        taskId: 'task-1',
+        sessionId: 'proj-1:task-1:leaf-1',
+        data: 'echo hi',
+        appendEnter: true,
+      });
+
+      expect(deps.ptyGet).toHaveBeenCalledWith('proj-1:task-1:leaf-1');
+      expect(writeSpy).toHaveBeenCalledWith('echo hi\n');
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { sessionId: string; bytesWritten: number };
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.bytesWritten).toBe('echo hi\n'.length);
+    });
+
+    it('returns NOT_FOUND when the session is unknown', async () => {
+      deps.ptyGet.mockReturnValue(undefined);
+      const handler = server.handlers.get('task.sendInput')!;
+      const reply = await handler({
+        taskId: 'task-1',
+        sessionId: 'no-such',
+        data: 'x',
+      });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('NOT_FOUND');
+    });
+  });
+
+  describe('task.getOutput', () => {
+    it('returns the ring buffer contents and a usable cursor', async () => {
+      const buffer = 'hello world\n';
+      deps.ptySubscribe.mockReturnValue(buffer);
+      // PTY is still alive → eof=false
+      deps.ptyGet.mockReturnValue({});
+
+      const handler = server.handlers.get('task.getOutput')!;
+      const reply = await handler({
+        taskId: 'task-1',
+        sessionId: 'proj-1:task-1:leaf-1',
+      });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { data: string; cursor: number; eof: boolean };
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.data).toBe(buffer);
+      expect(parsed.payload.cursor).toBe(buffer.length);
+      expect(parsed.payload.eof).toBe(false);
+    });
+
+    it('honours sinceCursor for incremental reads', async () => {
+      const buffer = 'AAAABBBB';
+      deps.ptySubscribe.mockReturnValue(buffer);
+      deps.ptyGet.mockReturnValue(undefined); // session exited → eof=true
+
+      const handler = server.handlers.get('task.getOutput')!;
+      const reply = await handler({
+        taskId: 'task-1',
+        sessionId: 'proj-1:task-1:leaf-1',
+        sinceCursor: 4,
+      });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { data: string; cursor: number; eof: boolean };
+      };
+      expect(parsed.payload.data).toBe('BBBB');
+      expect(parsed.payload.cursor).toBe(8);
+      expect(parsed.payload.eof).toBe(true);
+    });
+  });
+
+  describe('task.listSessions', () => {
+    it('filters active sessions to those whose sessionId scope matches the task id', async () => {
+      deps.ptyList.mockReturnValue([
+        { sessionId: 'proj-1:task-1:conv-a', pid: 1234, metadata: { title: 'Codex' } },
+        { sessionId: 'proj-1:task-2:conv-b', pid: 5678, metadata: undefined },
+        { sessionId: 'proj-1:task-1:term-c', pid: undefined, metadata: undefined },
+      ]);
+
+      const handler = server.handlers.get('task.listSessions')!;
+      const reply = await handler({ taskId: 'task-1' });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: Array<{ sessionId: string }>;
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload.map((s) => s.sessionId)).toEqual([
+        'proj-1:task-1:conv-a',
+        'proj-1:task-1:term-c',
+      ]);
+    });
+  });
+
+  describe('task.openInIDE', () => {
+    it('opens the workspace path in the requested editor', async () => {
+      deps.getTasks.mockResolvedValue([makeTask({ workspaceId: 'ws-1' })]);
+      deps.wsGet.mockReturnValue({ path: '/tmp/worktree' });
+
+      const handler = server.handlers.get('task.openInIDE')!;
+      const reply = await handler({ taskId: 'task-1', editor: 'cursor' });
+
+      expect(deps.appOpenIn).toHaveBeenCalledWith({ app: 'cursor', path: '/tmp/worktree' });
+      const parsed = parseReply(reply);
+      expect(parsed.isError).toBe(false);
+    });
+
+    it('returns NOT_PROVISIONED when the task has no workspaceId', async () => {
+      deps.getTasks.mockResolvedValue([makeTask({ workspaceId: undefined })]);
+      const handler = server.handlers.get('task.openInIDE')!;
+      const reply = await handler({ taskId: 'task-1', editor: 'cursor' });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('NOT_PROVISIONED');
+      expect(deps.appOpenIn).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('handler error normalisation', () => {
+    it('catches thrown errors and surfaces them as UNHANDLED', async () => {
+      deps.getTasks.mockRejectedValue(new Error('db unavailable'));
+      const handler = server.handlers.get('task.list')!;
+      const reply = await handler({ projectId: 'proj-1' });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { code: string; message: string };
+      };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('UNHANDLED');
+      expect(parsed.payload.message).toContain('db unavailable');
+    });
+
+    it('passes Result-Err shapes through fromResult preserving the error type', async () => {
+      const errResult: Result<{ task: Task }, { type: 'project-not-found' }> = {
+        success: false,
+        error: { type: 'project-not-found' },
+      };
+      deps.createTask.mockResolvedValue(errResult);
+
+      const handler = server.handlers.get('task.create')!;
+      const reply = await handler({ projectId: 'missing', name: 'x' });
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('project-not-found');
+    });
+  });
+});

--- a/src/main/core/mcp-server/tools/task-tools.test.ts
+++ b/src/main/core/mcp-server/tools/task-tools.test.ts
@@ -87,7 +87,7 @@ interface MockDeps {
   updateLinkedIssue: ReturnType<typeof vi.fn>;
   setTaskPinned: ReturnType<typeof vi.fn>;
   ptyGet: ReturnType<typeof vi.fn>;
-  ptySubscribe: ReturnType<typeof vi.fn>;
+  ptyPeek: ReturnType<typeof vi.fn>;
   ptyList: ReturnType<typeof vi.fn>;
   wsGet: ReturnType<typeof vi.fn>;
   appOpenIn: ReturnType<typeof vi.fn>;
@@ -105,7 +105,7 @@ function makeMockDeps(): MockDeps {
     updateLinkedIssue: vi.fn().mockResolvedValue(undefined),
     setTaskPinned: vi.fn().mockResolvedValue(undefined),
     ptyGet: vi.fn(),
-    ptySubscribe: vi.fn().mockReturnValue(''),
+    ptyPeek: vi.fn().mockReturnValue(''),
     ptyList: vi.fn().mockReturnValue([]),
     wsGet: vi.fn(),
     appOpenIn: vi.fn().mockResolvedValue(undefined),
@@ -129,7 +129,7 @@ function installMockDeps(m: MockDeps): void {
     setTaskPinned: m.setTaskPinned,
     ptySessionRegistry: {
       get: m.ptyGet,
-      subscribe: m.ptySubscribe,
+      peek: m.ptyPeek,
       listActiveSessions: m.ptyList,
     },
     workspaceRegistry: {
@@ -365,7 +365,7 @@ describe('task-tools', () => {
   describe('task.getOutput', () => {
     it('returns the ring buffer contents and a usable cursor', async () => {
       const buffer = 'hello world\n';
-      deps.ptySubscribe.mockReturnValue(buffer);
+      deps.ptyPeek.mockReturnValue(buffer);
       // PTY is still alive → eof=false
       deps.ptyGet.mockReturnValue({});
 
@@ -386,7 +386,7 @@ describe('task-tools', () => {
 
     it('honours sinceCursor for incremental reads', async () => {
       const buffer = 'AAAABBBB';
-      deps.ptySubscribe.mockReturnValue(buffer);
+      deps.ptyPeek.mockReturnValue(buffer);
       deps.ptyGet.mockReturnValue(undefined); // session exited → eof=true
 
       const handler = server.handlers.get('task.getOutput')!;

--- a/src/main/core/mcp-server/tools/task-tools.ts
+++ b/src/main/core/mcp-server/tools/task-tools.ts
@@ -1,9 +1,593 @@
 /**
- * Registers task-related MCP tools (`task.create`, `task.list`, `task.get`,
- * `task.update`, `task.delete`, `task.archive`, `task.unarchive`,
- * `task.sendInput`, `task.getOutput`, `task.listSessions`,
- * `task.openInIDE`).
+ * Registers the `task.*` MCP tools.
  *
- * Currently a stub — no-op.
+ * These are thin adapters over the existing operation functions in
+ * `src/main/core/tasks/operations/` and the `pty-session-registry`. No
+ * business logic lives here — every tool either:
+ *
+ * 1. Validates args with Zod (the SDK enforces this from the registered
+ *    `inputSchema`).
+ * 2. Calls a single existing op or registry method.
+ * 3. Translates the result into the MCP reply shape via `formatOk` /
+ *    `formatErr` / `fromResult`.
+ *
+ * Wired ops (one-line audit, kept here so future readers can `git grep` to
+ * the source):
+ *
+ *   task.create       → `createTask`           (operations/createTask.ts)
+ *   task.list         → `getTasks`             (operations/getTasks.ts)
+ *   task.get          → `getTasks` + filter    (no per-id op exists today)
+ *   task.update       → renameTask / updateTaskStatus / updateLinkedIssue
+ *                       / setTaskPinned        (operations/*.ts)
+ *   task.delete       → `deleteTask`           (operations/deleteTask.ts)
+ *   task.archive      → `archiveTask`          (operations/archiveTask.ts)
+ *   task.unarchive    → `restoreTask`          (operations/restoreTask.ts)
+ *   task.sendInput    → `pty.write`            (pty/pty-session-registry.ts)
+ *   task.getOutput    → `ringBuffer subscribe` (pty/pty-session-registry.ts)
+ *   task.listSessions → `listActiveSessions`   (pty/pty-session-registry.ts)
+ *   task.openInIDE    → `appService.openIn`    (app/service.ts)
+ *
+ * Implementation note — runtime deps are loaded lazily inside `loadDeps()`
+ * so that simply *constructing* an `McpServer` (e.g. in
+ * `http-server.test.ts`) does not pull in the database client, Electron, or
+ * the rest of the main-process surface area. The first tool invocation pays
+ * a one-time import cost; subsequent calls hit the cached module.
  */
-export function register(_server: unknown): void {}
+import { randomUUID } from 'node:crypto';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { OpenInAppId } from '@shared/openInApps';
+import type { Result } from '@shared/result';
+import type {
+  CreateTaskError,
+  CreateTaskParams,
+  CreateTaskStrategy,
+  CreateTaskSuccess,
+  Issue,
+  RenameTaskError,
+  RenameTaskSuccess,
+  Task,
+  TaskLifecycleStatus,
+} from '@shared/tasks';
+import type { appService as AppService } from '@main/core/app/service';
+// `type`-only imports below pull from the original source modules. They are
+// erased at runtime, so they do NOT trigger the eager module evaluation
+// (Electron / `@main/db/client`) that we are deliberately deferring with the
+// dynamic `import()` inside `loadDeps()`.
+import type { ptySessionRegistry as PtySessionRegistry } from '@main/core/pty/pty-session-registry';
+import type { workspaceRegistry as WorkspaceRegistry } from '@main/core/workspaces/workspace-registry';
+import {
+  formatErr,
+  formatOk,
+  fromResult,
+  requireConfirm,
+  withRecording,
+  type McpToolReply,
+} from './_helpers';
+
+// ─── Lazy deps ────────────────────────────────────────────────────────────
+/**
+ * Imports every runtime dependency on first use. Keeping this off the
+ * module's top-level imports lets `createMcpServer()` run in environments
+ * (tests, the bridge stub) where Electron / `@main/db/client` would crash
+ * at import time.
+ */
+type TaskDeps = {
+  createTask: (params: CreateTaskParams) => Promise<Result<CreateTaskSuccess, CreateTaskError>>;
+  getTasks: (projectId?: string) => Promise<Task[]>;
+  deleteTask: (projectId: string, taskId: string) => Promise<void>;
+  archiveTask: (projectId: string, taskId: string) => Promise<void>;
+  restoreTask: (taskId: string) => Promise<void>;
+  renameTask: (
+    projectId: string,
+    taskId: string,
+    newName: string
+  ) => Promise<Result<RenameTaskSuccess, RenameTaskError>>;
+  updateTaskStatus: (taskId: string, status: TaskLifecycleStatus) => Promise<void>;
+  updateLinkedIssue: (taskId: string, issue?: Issue) => Promise<unknown>;
+  setTaskPinned: (taskId: string, isPinned: boolean) => Promise<void>;
+  ptySessionRegistry: typeof PtySessionRegistry;
+  workspaceRegistry: typeof WorkspaceRegistry;
+  appService: typeof AppService;
+};
+
+let cachedDeps: TaskDeps | null = null;
+let cachedDepsPromise: Promise<TaskDeps> | null = null;
+
+async function loadDeps(): Promise<TaskDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const [
+      createTaskMod,
+      getTasksMod,
+      deleteTaskMod,
+      archiveTaskMod,
+      restoreTaskMod,
+      renameTaskMod,
+      updateTaskStatusMod,
+      updateLinkedIssueMod,
+      setTaskPinnedMod,
+      ptyRegistryMod,
+      workspaceRegistryMod,
+      appServiceMod,
+    ] = await Promise.all([
+      import('@main/core/tasks/operations/createTask'),
+      import('@main/core/tasks/operations/getTasks'),
+      import('@main/core/tasks/operations/deleteTask'),
+      import('@main/core/tasks/operations/archiveTask'),
+      import('@main/core/tasks/operations/restoreTask'),
+      import('@main/core/tasks/operations/renameTask'),
+      import('@main/core/tasks/operations/updateTaskStatus'),
+      import('@main/core/tasks/operations/updateLinkedIssue'),
+      import('@main/core/tasks/operations/setTaskPinned'),
+      import('@main/core/pty/pty-session-registry'),
+      import('@main/core/workspaces/workspace-registry'),
+      import('@main/core/app/service'),
+    ]);
+    cachedDeps = {
+      createTask: createTaskMod.createTask,
+      getTasks: getTasksMod.getTasks,
+      deleteTask: deleteTaskMod.deleteTask,
+      archiveTask: archiveTaskMod.archiveTask,
+      restoreTask: restoreTaskMod.restoreTask,
+      renameTask: renameTaskMod.renameTask,
+      updateTaskStatus: updateTaskStatusMod.updateTaskStatus,
+      updateLinkedIssue: updateLinkedIssueMod.updateLinkedIssue,
+      setTaskPinned: setTaskPinnedMod.setTaskPinned,
+      ptySessionRegistry: ptyRegistryMod.ptySessionRegistry,
+      workspaceRegistry: workspaceRegistryMod.workspaceRegistry,
+      appService: appServiceMod.appService,
+    };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — for tests: inject a ready-made deps object. */
+export function _setTaskDeps(deps: TaskDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — for tests: clear cached deps. */
+export function _resetTaskDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+// ─── Zod fragments ────────────────────────────────────────────────────────
+
+const taskLifecycleStatusSchema = z.enum(['todo', 'in_progress', 'review', 'done', 'cancelled']);
+
+const branchSchema = z.union([
+  z.object({
+    type: z.literal('local'),
+    branch: z.string(),
+    remote: z.unknown().optional(),
+  }),
+  z.object({
+    type: z.literal('remote'),
+    branch: z.string(),
+    remote: z.unknown(),
+  }),
+]);
+
+const issueSchema = z.object({
+  provider: z.enum(['github', 'linear', 'jira', 'gitlab', 'plain', 'forgejo', 'featurebase']),
+  url: z.string(),
+  title: z.string(),
+  identifier: z.string(),
+  description: z.string().optional(),
+  branchName: z.string().optional(),
+  status: z.string().optional(),
+  assignees: z.array(z.string()).optional(),
+  project: z.string().optional(),
+  updatedAt: z.string().optional(),
+  fetchedAt: z.string().optional(),
+});
+
+const taskCreateStrategyKindSchema = z.enum([
+  'new-branch',
+  'checkout-existing',
+  'from-pull-request',
+  'no-worktree',
+]);
+
+const editorSchema = z.enum(['vscode', 'cursor', 'zed', 'sublime', 'terminal']);
+
+// `sublime` isn't in OPEN_IN_APPS; map it to a sensible fallback so the
+// LLM-facing enum can stay short. (Sublime support would need a new entry
+// in `src/shared/openInApps.ts` — a follow-up, not part of this task.)
+const editorToOpenInAppId: Record<z.infer<typeof editorSchema>, OpenInAppId> = {
+  vscode: 'vscode',
+  cursor: 'cursor',
+  zed: 'zed',
+  sublime: 'zed', // best-effort fallback until a sublime entry is added
+  terminal: 'terminal',
+};
+
+// ─── Tool registration ────────────────────────────────────────────────────
+
+export function registerTaskTools(server: McpServer): void {
+  // task.create ────────────────────────────────────────────────────────────
+  const createInput = {
+    projectId: z.string(),
+    name: z.string(),
+    sourceBranch: branchSchema.optional(),
+    taskBranch: z.string().optional(),
+    strategy: taskCreateStrategyKindSchema.optional(),
+    provision: z.boolean().optional(),
+  };
+  server.registerTool(
+    'task.create',
+    {
+      title: 'Create task',
+      description:
+        'Create a new task in a project. Provisions a worktree and PTY by default. ' +
+        'Returns the created task summary.',
+      inputSchema: createInput,
+    },
+    withRecording('task.create', async (args: z.infer<z.ZodObject<typeof createInput>>) => {
+      const strategyKind = args.strategy ?? 'new-branch';
+      // Default the source branch to a generic local "main" when none is
+      // given. The op rejects unknown branches with `branch-not-found`,
+      // so callers should normally pass an explicit `sourceBranch`.
+      const sourceBranch = args.sourceBranch ?? { type: 'local', branch: 'main' };
+
+      let strategy: CreateTaskStrategy;
+      switch (strategyKind) {
+        case 'new-branch':
+          strategy = { kind: 'new-branch', taskBranch: args.taskBranch ?? args.name };
+          break;
+        case 'checkout-existing':
+          strategy = { kind: 'checkout-existing' };
+          break;
+        case 'no-worktree':
+          strategy = { kind: 'no-worktree' };
+          break;
+        case 'from-pull-request':
+          // The op needs a PR number + head metadata that the LLM cannot
+          // synthesise from `task.create` alone. Direct callers should use
+          // the renderer flow for now.
+          return formatErr(
+            'STRATEGY_NOT_SUPPORTED',
+            "task.create does not support strategy 'from-pull-request' yet — call this from the UI instead.",
+            { strategy: strategyKind }
+          );
+      }
+
+      const params: CreateTaskParams = {
+        id: randomUUID(),
+        projectId: args.projectId,
+        name: args.name,
+        sourceBranch: sourceBranch as CreateTaskParams['sourceBranch'],
+        strategy,
+      };
+      const deps = await loadDeps();
+      const result = await deps.createTask(params);
+      return fromResult(result);
+    }) as never
+  );
+
+  // task.list ──────────────────────────────────────────────────────────────
+  const listInput = {
+    projectId: z.string(),
+    status: taskLifecycleStatusSchema.optional(),
+    includeArchived: z.boolean().optional(),
+  };
+  server.registerTool(
+    'task.list',
+    {
+      title: 'List tasks',
+      description: 'List tasks in a project, optionally filtered by status / archived state.',
+      inputSchema: listInput,
+    },
+    withRecording('task.list', async (args: z.infer<z.ZodObject<typeof listInput>>) => {
+      const deps = await loadDeps();
+      const all = await deps.getTasks(args.projectId);
+      const filtered = all.filter((t) => {
+        if (!args.includeArchived && t.archivedAt) return false;
+        if (args.status && t.status !== args.status) return false;
+        return true;
+      });
+      return formatOk(filtered);
+    }) as never
+  );
+
+  // task.get ───────────────────────────────────────────────────────────────
+  const getInput = { taskId: z.string() };
+  server.registerTool(
+    'task.get',
+    {
+      title: 'Get task',
+      description: 'Fetch full task detail by id.',
+      inputSchema: getInput,
+    },
+    withRecording('task.get', async (args: z.infer<z.ZodObject<typeof getInput>>) => {
+      const deps = await loadDeps();
+      // No per-id op exists today; filter the project-wide listing. We don't
+      // know the project id, so fall back to listing across all projects.
+      const all = await deps.getTasks();
+      const found = all.find((t) => t.id === args.taskId);
+      if (!found) {
+        return formatErr('NOT_FOUND', `Task not found: ${args.taskId}`, { taskId: args.taskId });
+      }
+      return formatOk(found);
+    }) as never
+  );
+
+  // task.update ────────────────────────────────────────────────────────────
+  const updateInput = {
+    taskId: z.string(),
+    patch: z
+      .object({
+        name: z.string().optional(),
+        status: taskLifecycleStatusSchema.optional(),
+        // sourceBranch updates are intentionally not supported: there is no
+        // existing operation function for them. Tracked for follow-up.
+        linkedIssue: issueSchema.optional(),
+        isPinned: z.boolean().optional(),
+      })
+      .strict(),
+  };
+  server.registerTool(
+    'task.update',
+    {
+      title: 'Update task',
+      description:
+        'Patch task fields (name, status, linkedIssue, isPinned). ' +
+        'Each field maps to a dedicated emdash operation; multiple fields are applied in series.',
+      inputSchema: updateInput,
+    },
+    withRecording('task.update', async (args: z.infer<z.ZodObject<typeof updateInput>>) => {
+      const { taskId, patch } = args;
+      const deps = await loadDeps();
+      // We need projectId for renameTask; fetch it from the task row via
+      // getTasks (matches `task.get`'s lookup pattern).
+      const allTasks = await deps.getTasks();
+      const target = allTasks.find((t) => t.id === taskId);
+      if (!target) {
+        return formatErr('NOT_FOUND', `Task not found: ${taskId}`, { taskId });
+      }
+
+      // Apply ops in a stable order; bail on the first one that returns Err.
+      // Each op already emits `task:updated`, which is the desired side
+      // effect — the renderer / MCP resource layer reacts.
+      if (patch.status !== undefined) {
+        await deps.updateTaskStatus(taskId, patch.status as TaskLifecycleStatus);
+      }
+      if (patch.isPinned !== undefined) {
+        await deps.setTaskPinned(taskId, patch.isPinned);
+      }
+      if (patch.linkedIssue !== undefined) {
+        await deps.updateLinkedIssue(taskId, patch.linkedIssue);
+      }
+      if (patch.name !== undefined) {
+        const renameResult = await deps.renameTask(target.projectId, taskId, patch.name);
+        if (!renameResult.success) return fromResult(renameResult);
+      }
+
+      // Return the freshly-applied state.
+      const refreshed = (await deps.getTasks()).find((t) => t.id === taskId);
+      return formatOk(refreshed ?? null);
+    }) as never
+  );
+
+  // task.delete ────────────────────────────────────────────────────────────
+  const deleteInput = {
+    taskId: z.string(),
+    confirm: z.boolean().optional(),
+  };
+  server.registerTool(
+    'task.delete',
+    {
+      title: 'Delete task',
+      description:
+        'Hard-delete a task and tear down its workspace. Destructive — requires confirm: true.',
+      inputSchema: deleteInput,
+    },
+    withRecording('task.delete', async (args: z.infer<z.ZodObject<typeof deleteInput>>) => {
+      const guard = requireConfirm(args, 'delete this task', { taskId: args.taskId });
+      if (guard) return guard;
+      const deps = await loadDeps();
+      const all = await deps.getTasks();
+      const target = all.find((t) => t.id === args.taskId);
+      if (!target) {
+        return formatErr('NOT_FOUND', `Task not found: ${args.taskId}`, { taskId: args.taskId });
+      }
+      await deps.deleteTask(target.projectId, args.taskId);
+      return formatOk({ taskId: args.taskId, deleted: true });
+    }) as never
+  );
+
+  // task.archive ───────────────────────────────────────────────────────────
+  const archiveInput = { taskId: z.string() };
+  server.registerTool(
+    'task.archive',
+    {
+      title: 'Archive task',
+      description: 'Soft-delete (archive) a task. Reversible via task.unarchive.',
+      inputSchema: archiveInput,
+    },
+    withRecording('task.archive', async (args: z.infer<z.ZodObject<typeof archiveInput>>) => {
+      const deps = await loadDeps();
+      const all = await deps.getTasks();
+      const target = all.find((t) => t.id === args.taskId);
+      if (!target) {
+        return formatErr('NOT_FOUND', `Task not found: ${args.taskId}`, { taskId: args.taskId });
+      }
+      await deps.archiveTask(target.projectId, args.taskId);
+      return formatOk({ taskId: args.taskId, archived: true });
+    }) as never
+  );
+
+  // task.unarchive ─────────────────────────────────────────────────────────
+  server.registerTool(
+    'task.unarchive',
+    {
+      title: 'Unarchive task',
+      description: 'Restore a previously-archived task.',
+      inputSchema: archiveInput,
+    },
+    withRecording('task.unarchive', async (args: z.infer<z.ZodObject<typeof archiveInput>>) => {
+      const deps = await loadDeps();
+      await deps.restoreTask(args.taskId);
+      return formatOk({ taskId: args.taskId, archived: false });
+    }) as never
+  );
+
+  // task.sendInput ─────────────────────────────────────────────────────────
+  const sendInput = {
+    taskId: z.string(),
+    sessionId: z.string(),
+    data: z.string(),
+    appendEnter: z.boolean().optional(),
+  };
+  server.registerTool(
+    'task.sendInput',
+    {
+      title: 'Send input to PTY session',
+      description:
+        'Write a string to a running PTY session for the given task. ' +
+        'Set appendEnter: true to append a newline (most agents need this to submit).',
+      inputSchema: sendInput,
+    },
+    withRecording('task.sendInput', async (args: z.infer<z.ZodObject<typeof sendInput>>) => {
+      const deps = await loadDeps();
+      const pty = deps.ptySessionRegistry.get(args.sessionId);
+      if (!pty) {
+        return formatErr('NOT_FOUND', `PTY session not found: ${args.sessionId}`, {
+          sessionId: args.sessionId,
+        });
+      }
+      const payload = args.appendEnter ? `${args.data}\n` : args.data;
+      pty.write(payload);
+      return formatOk({ sessionId: args.sessionId, bytesWritten: payload.length });
+    }) as never
+  );
+
+  // task.getOutput ─────────────────────────────────────────────────────────
+  const outputInput = {
+    taskId: z.string(),
+    sessionId: z.string(),
+    sinceCursor: z.number().int().nonnegative().optional(),
+    bytes: z.number().int().positive().optional(),
+  };
+  server.registerTool(
+    'task.getOutput',
+    {
+      title: 'Read PTY ring buffer',
+      description:
+        'Snapshot a PTY session ring buffer. Pass sinceCursor (received from a prior call) ' +
+        'to get only new output. Returns { data, cursor, eof }. Note the buffer is bounded ' +
+        'at 64 KB per session — long-running output may be truncated.',
+      inputSchema: outputInput,
+    },
+    withRecording('task.getOutput', async (args: z.infer<z.ZodObject<typeof outputInput>>) => {
+      const deps = await loadDeps();
+      const buffer = deps.ptySessionRegistry.subscribe(args.sessionId);
+      const eof = deps.ptySessionRegistry.get(args.sessionId) === undefined;
+      // The registry buffer is a string; `cursor` is the byte length of the
+      // delivered slice — clients pass the value back as `sinceCursor` to
+      // resume.
+      const sliceFrom =
+        typeof args.sinceCursor === 'number' && args.sinceCursor < buffer.length
+          ? args.sinceCursor
+          : 0;
+      let slice = buffer.slice(sliceFrom);
+      if (typeof args.bytes === 'number' && slice.length > args.bytes) {
+        slice = slice.slice(0, args.bytes);
+      }
+      return formatOk({
+        data: slice,
+        cursor: sliceFrom + slice.length,
+        eof,
+      });
+    }) as never
+  );
+
+  // task.listSessions ──────────────────────────────────────────────────────
+  const listSessionsInput = { taskId: z.string() };
+  server.registerTool(
+    'task.listSessions',
+    {
+      title: 'List PTY sessions for a task',
+      description: 'List active PTY sessions associated with a task and their status.',
+      inputSchema: listSessionsInput,
+    },
+    withRecording(
+      'task.listSessions',
+      async (args: z.infer<z.ZodObject<typeof listSessionsInput>>) => {
+        const deps = await loadDeps();
+        // Session IDs are formatted `<projectId>:<scopeId>:<leafId>` — the
+        // task id is the scopeId. Filter the active list to those whose
+        // scope matches.
+        const sessions = deps.ptySessionRegistry.listActiveSessions().filter((s) => {
+          const parts = s.sessionId.split(':');
+          return parts[1] === args.taskId;
+        });
+        return formatOk(
+          sessions.map((s) => ({
+            sessionId: s.sessionId,
+            pid: s.pid,
+            metadata: s.metadata,
+            status: 'running' as const,
+          }))
+        );
+      }
+    ) as never
+  );
+
+  // task.openInIDE ─────────────────────────────────────────────────────────
+  const openInIdeInput = {
+    taskId: z.string(),
+    editor: editorSchema,
+  };
+  server.registerTool(
+    'task.openInIDE',
+    {
+      title: 'Open task workspace in editor',
+      description:
+        "Open the task's worktree in a configured editor (vscode | cursor | zed | sublime | terminal).",
+      inputSchema: openInIdeInput,
+    },
+    withRecording('task.openInIDE', async (args: z.infer<z.ZodObject<typeof openInIdeInput>>) => {
+      const deps = await loadDeps();
+      const all = await deps.getTasks();
+      const target = all.find((t) => t.id === args.taskId);
+      if (!target) {
+        return formatErr('NOT_FOUND', `Task not found: ${args.taskId}`, { taskId: args.taskId });
+      }
+      if (!target.workspaceId) {
+        return formatErr('NOT_PROVISIONED', 'Task has no workspace', { taskId: args.taskId });
+      }
+      const ws = deps.workspaceRegistry.get(target.workspaceId);
+      if (!ws) {
+        return formatErr(
+          'WORKSPACE_NOT_READY',
+          'Workspace is not currently mounted; provision the task first.',
+          { workspaceId: target.workspaceId }
+        );
+      }
+      const appId = editorToOpenInAppId[args.editor];
+      await deps.appService.openIn({ app: appId, path: ws.path });
+      return formatOk({ taskId: args.taskId, editor: args.editor, path: ws.path });
+    }) as never
+  );
+}
+
+// Re-export under the conventional `register` name so `tools/index.ts` can
+// import a uniform symbol per file in T5+ when it grows.
+export { registerTaskTools as register };
+
+/**
+ * Internal helper exposed for tests so they can drive the Result-returning
+ * branch of `fromResult` without spinning up a real op. Not part of the
+ * public surface — do not import from outside `mcp-server/tools`.
+ *
+ * @internal
+ */
+export function _testWrapResult<T, E>(r: Result<T, E>): McpToolReply {
+  return fromResult(r);
+}

--- a/src/main/core/mcp-server/tools/task-tools.ts
+++ b/src/main/core/mcp-server/tools/task-tools.ts
@@ -1,0 +1,9 @@
+/**
+ * Registers task-related MCP tools (`task.create`, `task.list`, `task.get`,
+ * `task.update`, `task.delete`, `task.archive`, `task.unarchive`,
+ * `task.sendInput`, `task.getOutput`, `task.listSessions`,
+ * `task.openInIDE`).
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/tools/task-tools.ts
+++ b/src/main/core/mcp-server/tools/task-tools.ts
@@ -23,7 +23,9 @@
  *   task.archive      → `archiveTask`          (operations/archiveTask.ts)
  *   task.unarchive    → `restoreTask`          (operations/restoreTask.ts)
  *   task.sendInput    → `pty.write`            (pty/pty-session-registry.ts)
- *   task.getOutput    → `ringBuffer subscribe` (pty/pty-session-registry.ts)
+ *   task.getOutput    → `ringBuffer peek`     (pty/pty-session-registry.ts) — uses
+ *                       `peek()` rather than `subscribe()` to avoid leaking
+ *                       an active-consumer registration (see T4 review).
  *   task.listSessions → `listActiveSessions`   (pty/pty-session-registry.ts)
  *   task.openInIDE    → `appService.openIn`    (app/service.ts)
  *
@@ -474,7 +476,9 @@ export function registerTaskTools(server: McpServer): void {
     },
     withRecording('task.getOutput', async (args: z.infer<z.ZodObject<typeof outputInput>>) => {
       const deps = await loadDeps();
-      const buffer = deps.ptySessionRegistry.subscribe(args.sessionId);
+      // `peek` returns the ring buffer WITHOUT registering an IPC consumer —
+      // every MCP call would otherwise leak one into `activeConsumers`.
+      const buffer = deps.ptySessionRegistry.peek(args.sessionId);
       const eof = deps.ptySessionRegistry.get(args.sessionId) === undefined;
       // The registry buffer is a string; `cursor` is the byte length of the
       // delivered slice — clients pass the value back as `sinceCursor` to

--- a/src/main/core/mcp-server/tools/task-tools.ts
+++ b/src/main/core/mcp-server/tools/task-tools.ts
@@ -36,7 +36,6 @@
 import { randomUUID } from 'node:crypto';
 import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import { z } from 'zod';
-import type { OpenInAppId } from '@shared/openInApps';
 import type { Result } from '@shared/result';
 import type {
   CreateTaskError,
@@ -57,6 +56,8 @@ import type { appService as AppService } from '@main/core/app/service';
 import type { ptySessionRegistry as PtySessionRegistry } from '@main/core/pty/pty-session-registry';
 import type { workspaceRegistry as WorkspaceRegistry } from '@main/core/workspaces/workspace-registry';
 import {
+  editorSchema,
+  editorToOpenInAppId,
   formatErr,
   formatOk,
   fromResult,
@@ -193,19 +194,6 @@ const taskCreateStrategyKindSchema = z.enum([
   'from-pull-request',
   'no-worktree',
 ]);
-
-const editorSchema = z.enum(['vscode', 'cursor', 'zed', 'sublime', 'terminal']);
-
-// `sublime` isn't in OPEN_IN_APPS; map it to a sensible fallback so the
-// LLM-facing enum can stay short. (Sublime support would need a new entry
-// in `src/shared/openInApps.ts` — a follow-up, not part of this task.)
-const editorToOpenInAppId: Record<z.infer<typeof editorSchema>, OpenInAppId> = {
-  vscode: 'vscode',
-  cursor: 'cursor',
-  zed: 'zed',
-  sublime: 'zed', // best-effort fallback until a sublime entry is added
-  terminal: 'terminal',
-};
 
 // ─── Tool registration ────────────────────────────────────────────────────
 

--- a/src/main/core/mcp-server/tools/worktree-tools.test.ts
+++ b/src/main/core/mcp-server/tools/worktree-tools.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Unit tests for the `worktree.*` MCP tools.
+ *
+ * Same fake-server + injected-deps pattern as `task-tools.test.ts`.
+ */
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { _resetWorktreeDeps, _setWorktreeDeps, registerWorktreeTools } from './worktree-tools';
+
+type CapturedHandler = (args: Record<string, unknown>) => Promise<unknown> | unknown;
+
+interface TestServer extends Pick<McpServer, 'registerTool'> {
+  handlers: Map<string, CapturedHandler>;
+}
+
+function makeTestServer(): TestServer {
+  const handlers = new Map<string, CapturedHandler>();
+  const server: TestServer = {
+    handlers,
+    registerTool: ((name: string, _config: unknown, handler: CapturedHandler) => {
+      handlers.set(name, handler);
+      return { remove: () => undefined } as never;
+    }) as McpServer['registerTool'],
+  };
+  return server;
+}
+
+function parseReply(reply: unknown): { isError: boolean; payload: unknown } {
+  const r = reply as {
+    isError?: boolean;
+    content: Array<{ type: 'text'; text: string }>;
+  };
+  return {
+    isError: r.isError === true,
+    payload: JSON.parse(r.content[0].text) as unknown,
+  };
+}
+
+interface MockDeps {
+  wsGet: ReturnType<typeof vi.fn>;
+  appOpenIn: ReturnType<typeof vi.fn>;
+}
+
+function makeMockDeps(): MockDeps {
+  return {
+    wsGet: vi.fn(),
+    appOpenIn: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function installMockDeps(m: MockDeps): void {
+  _setWorktreeDeps({
+    workspaceRegistry: {
+      get: m.wsGet,
+    },
+    appService: {
+      openIn: m.appOpenIn,
+    },
+  } as unknown as Parameters<typeof _setWorktreeDeps>[0]);
+}
+
+describe('worktree-tools', () => {
+  let server: TestServer;
+  let deps: MockDeps;
+
+  beforeEach(() => {
+    server = makeTestServer();
+    registerWorktreeTools(server as unknown as McpServer);
+    deps = makeMockDeps();
+    installMockDeps(deps);
+  });
+
+  afterEach(() => {
+    _resetWorktreeDeps();
+    vi.clearAllMocks();
+  });
+
+  it('registers the expected tool catalogue under worktree.* names', () => {
+    expect([...server.handlers.keys()].sort()).toEqual(['worktree.openInIDE']);
+  });
+
+  describe('worktree.openInIDE', () => {
+    it('happy path → resolves the workspace and opens it in the editor', async () => {
+      deps.wsGet.mockReturnValue({ path: '/tmp/worktrees/abc' });
+
+      const handler = server.handlers.get('worktree.openInIDE')!;
+      const reply = await handler({ workspaceId: 'ws-1', editor: 'cursor' });
+
+      expect(deps.wsGet).toHaveBeenCalledWith('ws-1');
+      expect(deps.appOpenIn).toHaveBeenCalledWith({ app: 'cursor', path: '/tmp/worktrees/abc' });
+      const parsed = parseReply(reply) as {
+        isError: boolean;
+        payload: { workspaceId: string; editor: string; path: string };
+      };
+      expect(parsed.isError).toBe(false);
+      expect(parsed.payload).toEqual({
+        workspaceId: 'ws-1',
+        editor: 'cursor',
+        path: '/tmp/worktrees/abc',
+      });
+    });
+
+    it('returns WORKSPACE_NOT_READY when the workspace is not mounted', async () => {
+      deps.wsGet.mockReturnValue(undefined);
+
+      const handler = server.handlers.get('worktree.openInIDE')!;
+      const reply = await handler({ workspaceId: 'missing', editor: 'vscode' });
+
+      const parsed = parseReply(reply) as { isError: boolean; payload: { code: string } };
+      expect(parsed.isError).toBe(true);
+      expect(parsed.payload.code).toBe('WORKSPACE_NOT_READY');
+      expect(deps.appOpenIn).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/main/core/mcp-server/tools/worktree-tools.ts
+++ b/src/main/core/mcp-server/tools/worktree-tools.ts
@@ -1,0 +1,7 @@
+/**
+ * Registers worktree-related MCP tools (`worktree.openInIDE` — lower-level
+ * counterpart to `task.openInIDE` operating on raw workspace IDs).
+ *
+ * Currently a stub — no-op.
+ */
+export function register(_server: unknown): void {}

--- a/src/main/core/mcp-server/tools/worktree-tools.ts
+++ b/src/main/core/mcp-server/tools/worktree-tools.ts
@@ -1,7 +1,93 @@
 /**
- * Registers worktree-related MCP tools (`worktree.openInIDE` — lower-level
- * counterpart to `task.openInIDE` operating on raw workspace IDs).
+ * Registers the `worktree.*` MCP tools.
  *
- * Currently a stub — no-op.
+ * Lower-level than `task.openInIDE`: resolves a workspace path directly from
+ * the `workspace-registry` and delegates to `appService.openIn`.
+ *
+ *   worktree.openInIDE → `workspaceRegistry.get` + `appService.openIn`
+ *
+ * The editor enum + mapping is shared with `task-tools.ts` via `_helpers.ts`.
  */
-export function register(_server: unknown): void {}
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { z } from 'zod';
+import type { appService as AppService } from '@main/core/app/service';
+import type { workspaceRegistry as WorkspaceRegistry } from '@main/core/workspaces/workspace-registry';
+import { editorSchema, editorToOpenInAppId, formatErr, formatOk, withRecording } from './_helpers';
+
+// ─── Lazy deps ────────────────────────────────────────────────────────────
+
+type WorktreeDeps = {
+  workspaceRegistry: typeof WorkspaceRegistry;
+  appService: typeof AppService;
+};
+
+let cachedDeps: WorktreeDeps | null = null;
+let cachedDepsPromise: Promise<WorktreeDeps> | null = null;
+
+async function loadDeps(): Promise<WorktreeDeps> {
+  if (cachedDeps) return cachedDeps;
+  if (cachedDepsPromise) return cachedDepsPromise;
+  cachedDepsPromise = (async () => {
+    const [workspaceMod, appMod] = await Promise.all([
+      import('@main/core/workspaces/workspace-registry'),
+      import('@main/core/app/service'),
+    ]);
+    cachedDeps = {
+      workspaceRegistry: workspaceMod.workspaceRegistry,
+      appService: appMod.appService,
+    };
+    return cachedDeps;
+  })();
+  return cachedDepsPromise;
+}
+
+/** @internal — for tests: inject a ready-made deps object. */
+export function _setWorktreeDeps(deps: WorktreeDeps): void {
+  cachedDeps = deps;
+  cachedDepsPromise = Promise.resolve(deps);
+}
+
+/** @internal — for tests: clear cached deps. */
+export function _resetWorktreeDeps(): void {
+  cachedDeps = null;
+  cachedDepsPromise = null;
+}
+
+// ─── Tool registration ────────────────────────────────────────────────────
+
+export function registerWorktreeTools(server: McpServer): void {
+  const openInIdeInput = {
+    workspaceId: z.string(),
+    editor: editorSchema,
+  };
+  server.registerTool(
+    'worktree.openInIDE',
+    {
+      title: 'Open workspace in editor',
+      description:
+        'Open a workspace path directly in the requested editor ' +
+        '(vscode | cursor | zed | sublime | terminal). Lower-level than ' +
+        'task.openInIDE — operates on raw workspace IDs.',
+      inputSchema: openInIdeInput,
+    },
+    withRecording(
+      'worktree.openInIDE',
+      async (args: z.infer<z.ZodObject<typeof openInIdeInput>>) => {
+        const deps = await loadDeps();
+        const ws = deps.workspaceRegistry.get(args.workspaceId);
+        if (!ws) {
+          return formatErr(
+            'WORKSPACE_NOT_READY',
+            'Workspace is not currently mounted; provision its task first.',
+            { workspaceId: args.workspaceId }
+          );
+        }
+        const appId = editorToOpenInAppId[args.editor];
+        await deps.appService.openIn({ app: appId, path: ws.path });
+        return formatOk({ workspaceId: args.workspaceId, editor: args.editor, path: ws.path });
+      }
+    ) as never
+  );
+}
+
+export { registerWorktreeTools as register };

--- a/src/main/core/pty/pty-session-registry.ts
+++ b/src/main/core/pty/pty-session-registry.ts
@@ -11,12 +11,18 @@ export interface PtySessionMetadata {
 const FLUSH_INTERVAL_MS = 16; // ~60 fps
 const RING_BUFFER_CAP = 64 * 1024; // 64 KB per session
 
+export type PtyDataListener = (delta: string) => void;
+
 export class PtySessionRegistry {
   private ptyMap: Map<string, Pty> = new Map();
   private ptyInputSubscriptions: Map<string, () => void> = new Map();
   private ringBuffers: Map<string, string> = new Map();
   private activeConsumers: Set<string> = new Set();
   private metadata: Map<string, PtySessionMetadata> = new Map();
+  // In-process data listeners (e.g. MCP resource subscriptions). Distinct
+  // from `activeConsumers` (renderer IPC) — listeners fire on every PTY data
+  // chunk and never affect consumer-count accounting.
+  private dataListeners: Map<string, Set<PtyDataListener>> = new Map();
 
   register(
     sessionId: string,
@@ -29,6 +35,8 @@ export class PtySessionRegistry {
     this.ringBuffers.delete(sessionId);
     this.activeConsumers.delete(sessionId);
     this.metadata.delete(sessionId);
+    // Don't clear `dataListeners` — a long-lived MCP resource subscription
+    // for this sessionId should keep working across respawns.
     if (options?.metadata) this.metadata.set(sessionId, options.metadata);
 
     this.ptyMap.set(sessionId, pty);
@@ -53,6 +61,17 @@ export class PtySessionRegistry {
       let rb = (this.ringBuffers.get(sessionId) ?? '') + data;
       if (rb.length > RING_BUFFER_CAP) rb = rb.slice(-RING_BUFFER_CAP);
       this.ringBuffers.set(sessionId, rb);
+      // Fan out to in-process listeners (MCP resource subscriptions, etc).
+      const listeners = this.dataListeners.get(sessionId);
+      if (listeners) {
+        for (const listener of listeners) {
+          try {
+            listener(data);
+          } catch {
+            // Swallow — a misbehaving listener must not break PTY plumbing.
+          }
+        }
+      }
     });
 
     pty.onExit((info) => {
@@ -90,6 +109,37 @@ export class PtySessionRegistry {
     this.ringBuffers.delete(sessionId);
     this.activeConsumers.delete(sessionId);
     this.metadata.delete(sessionId);
+    this.dataListeners.delete(sessionId);
+  }
+
+  /**
+   * Snapshot the ring buffer without registering an IPC consumer. Use this
+   * from in-process readers (MCP tools / resources) that must not affect
+   * renderer consumer-count accounting.
+   */
+  peek(sessionId: string): string {
+    return this.ringBuffers.get(sessionId) ?? '';
+  }
+
+  /**
+   * Subscribe to in-process PTY data deltas for a session. The listener is
+   * invoked with the raw chunk for every `pty.onData` event. Returns an
+   * unsubscribe function. Does NOT touch `activeConsumers` — that set is
+   * reserved for renderer IPC delivery.
+   */
+  onData(sessionId: string, listener: PtyDataListener): () => void {
+    let listeners = this.dataListeners.get(sessionId);
+    if (!listeners) {
+      listeners = new Set();
+      this.dataListeners.set(sessionId, listeners);
+    }
+    listeners.add(listener);
+    return () => {
+      const set = this.dataListeners.get(sessionId);
+      if (!set) return;
+      set.delete(listener);
+      if (set.size === 0) this.dataListeners.delete(sessionId);
+    };
   }
 
   get(sessionId: string): Pty | undefined {

--- a/src/main/core/settings/controller.ts
+++ b/src/main/core/settings/controller.ts
@@ -1,6 +1,15 @@
 import { createRPCController } from '@/shared/ipc/rpc';
+import { mcpServerService } from '@main/core/mcp-server/service';
 import { reconcileResourceSampler } from '@main/core/resource-monitor/resource-sampler';
 import { appSettingsService, type AppSettings, type AppSettingsKey } from './settings-service';
+
+async function reconcileForKey(key: AppSettingsKey): Promise<void> {
+  if (key === 'resourceMonitor') {
+    await reconcileResourceSampler();
+  } else if (key === 'mcpServer') {
+    await mcpServerService.reconcile();
+  }
+}
 
 export const appSettingsController = createRPCController({
   get: <T extends AppSettingsKey>(key: T): Promise<AppSettings[T]> => appSettingsService.get(key),
@@ -17,16 +26,16 @@ export const appSettingsController = createRPCController({
 
   update: async <T extends AppSettingsKey>(key: T, value: AppSettings[T]): Promise<void> => {
     await appSettingsService.update(key, value);
-    if (key === 'resourceMonitor') await reconcileResourceSampler();
+    await reconcileForKey(key);
   },
 
   reset: async <T extends AppSettingsKey>(key: T): Promise<void> => {
     await appSettingsService.reset(key);
-    if (key === 'resourceMonitor') await reconcileResourceSampler();
+    await reconcileForKey(key);
   },
 
   resetField: async <T extends AppSettingsKey>(key: T, field: string): Promise<void> => {
     await appSettingsService.resetField(key, field as keyof AppSettings[T]);
-    if (key === 'resourceMonitor') await reconcileResourceSampler();
+    await reconcileForKey(key);
   },
 });

--- a/src/main/core/settings/schema.ts
+++ b/src/main/core/settings/schema.ts
@@ -100,6 +100,17 @@ export const browserPreviewSettingsSchema = z.object({ enabled: z.boolean() });
 
 export const resourceMonitorSettingsSchema = z.object({ enabled: z.boolean() });
 
+/**
+ * MCP server settings — controls whether emdash exposes itself as an MCP
+ * server (`mcpServer.enabled`) and which loopback port it binds
+ * (`mcpServer.port`). See
+ * `docs/superpowers/specs/2026-05-16-mcp-server-design.md` for context.
+ */
+export const mcpServerSettingsSchema = z.object({
+  enabled: z.boolean(),
+  port: z.number().int().min(1).max(65535),
+});
+
 export const openInSettingsSchema = z.object({
   default: openInAppIdSchema,
   hidden: z.array(openInAppIdSchema),
@@ -120,6 +131,7 @@ export const APP_SETTINGS_SCHEMA_MAP = {
   terminal: terminalSettingsSchema,
   browserPreview: browserPreviewSettingsSchema,
   resourceMonitor: resourceMonitorSettingsSchema,
+  mcpServer: mcpServerSettingsSchema,
 } as const;
 
 export const appSettingsSchema = z.object({
@@ -137,4 +149,5 @@ export const appSettingsSchema = z.object({
   terminal: terminalSettingsSchema,
   browserPreview: browserPreviewSettingsSchema,
   resourceMonitor: resourceMonitorSettingsSchema,
+  mcpServer: mcpServerSettingsSchema,
 });

--- a/src/main/core/settings/settings-registry.ts
+++ b/src/main/core/settings/settings-registry.ts
@@ -59,6 +59,15 @@ export const SETTINGS_DEFAULTS = {
   resourceMonitor: {
     enabled: false,
   },
+  mcpServer: {
+    // Whether to expose emdash as an MCP server. Defaults to off; the user
+    // opts in from the Settings UI and the service then starts the loopback
+    // HTTP transport.
+    enabled: false,
+    // Port for the MCP HTTP server (loopback only). 7457 is unassigned by
+    // IANA and unlikely to collide with common dev tooling.
+    port: 7457,
+  },
 } satisfies SettingsDefaultsMap;
 
 export function getDefaultForKey<K extends AppSettingsKey>(key: K): AppSettings[K] {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -15,6 +15,7 @@ import { localDependencyManager } from './core/dependencies/dependency-manager';
 import { editorBufferService } from './core/editor/editor-buffer-service';
 import { gitWatcherRegistry } from './core/git/git-watcher-registry';
 import { githubConnectionService } from './core/github/services/github-connection-service';
+import { mcpServerService } from './core/mcp-server/service';
 import { projectManager } from './core/projects/project-manager';
 import { projectSettingsService } from './core/projects/settings/project-settings-service';
 import { prSyncScheduler } from './core/pull-requests/pr-sync-scheduler';
@@ -133,6 +134,13 @@ void app.whenReady().then(async () => {
 
   void reconcileResourceSampler();
 
+  // MCP server is gated by appSettings.mcpServer.enabled (default off).
+  // initialize() reads settings and only binds the loopback HTTP transport
+  // when the user has explicitly opted in from the Settings UI.
+  mcpServerService.initialize().catch((e) => {
+    log.error('Failed to initialize MCP server service:', e);
+  });
+
   localDependencyManager.probeAll().catch((e) => {
     log.error('Failed to probe dependencies:', e);
   });
@@ -158,6 +166,9 @@ app.on('before-quit', (event) => {
     stopResourceSampler();
     updateService.dispose();
     prSyncScheduler.dispose();
+    void mcpServerService.dispose().catch((e) => {
+      log.error('Failed to shutdown MCP server service:', e);
+    });
     void gitWatcherRegistry.dispose();
     void projectManager.dispose().catch((e) => {
       log.error('Failed to shutdown project manager:', e);

--- a/src/main/rpc.ts
+++ b/src/main/rpc.ts
@@ -13,6 +13,7 @@ import { gitlabController } from './core/gitlab/controller';
 import { issueController } from './core/issues/controller';
 import { jiraController } from './core/jira/controller';
 import { linearController } from './core/linear/controller';
+import { mcpServerController } from './core/mcp-server/controller';
 import { mcpController } from './core/mcp/controller';
 import { plainController } from './core/plain/controller';
 import { projectController } from './core/projects/controller';
@@ -61,6 +62,7 @@ export const rpcRouter = createRPCRouter({
   git: gitController,
   dependencies: dependenciesController,
   mcp: mcpController,
+  mcpServer: mcpServerController,
   editorBuffer: editorBufferController,
   telemetry: telemetryController,
   pullRequests: pullRequestController,

--- a/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/src/renderer/features/settings/components/SettingsPage.tsx
@@ -9,6 +9,10 @@ import DefaultAgentSettingsCard from './DefaultAgentSettingsCard';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
 import IntegrationsCard from './IntegrationsCard';
 import KeyboardSettingsCard from './KeyboardSettingsCard';
+import { McpServerAdvancedCard } from './mcp-server/McpServerAdvancedCard';
+import { McpServerConnectionCard } from './mcp-server/McpServerConnectionCard';
+import { McpServerRecentCallsCard } from './mcp-server/McpServerRecentCallsCard';
+import { McpServerStatusCard } from './mcp-server/McpServerStatusCard';
 import NotificationSettingsCard from './NotificationSettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
 import ResourceMonitorSettingsCard from './ResourceMonitorSettingsCard';
@@ -31,6 +35,7 @@ export type SettingsPageTab =
   | 'clis-models'
   | 'integrations'
   | 'connections'
+  | 'mcp-server'
   | 'repository'
   | 'interface'
   | 'docs';
@@ -62,6 +67,7 @@ export function SettingsPage({
     { id: 'clis-models', label: 'Agents' },
     { id: 'integrations', label: 'Integrations' },
     { id: 'connections', label: 'Connections' },
+    { id: 'mcp-server', label: 'MCP Server' },
     { id: 'repository', label: 'Repository' },
     { id: 'interface', label: 'Interface' },
     { id: 'docs', label: 'Docs', isExternal: true },
@@ -132,6 +138,17 @@ export function SettingsPage({
       title: 'Connections',
       description: 'Manage reusable SSH connections for remote projects.',
       sections: [{ component: <SshConnectionsSettingsCard /> }],
+    },
+    'mcp-server': {
+      title: 'MCP Server',
+      description:
+        'Expose emdash as a local MCP server so external agents (Claude Code, Cursor, Codex) can drive it.',
+      sections: [
+        { title: 'Status', component: <McpServerStatusCard /> },
+        { title: 'Connection', component: <McpServerConnectionCard /> },
+        { title: 'Recent calls', component: <McpServerRecentCallsCard /> },
+        { title: 'Advanced', component: <McpServerAdvancedCard /> },
+      ],
     },
     repository: {
       title: 'Repository',

--- a/src/renderer/features/settings/components/mcp-server/McpServerAdvancedCard.tsx
+++ b/src/renderer/features/settings/components/mcp-server/McpServerAdvancedCard.tsx
@@ -1,0 +1,139 @@
+import { FolderOpen } from 'lucide-react';
+import React, { useCallback, useEffect, useState } from 'react';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+import { Button } from '@renderer/lib/ui/button';
+import { Input } from '@renderer/lib/ui/input';
+import { SettingRow } from '../SettingRow';
+
+function isValidPort(value: number): boolean {
+  return Number.isInteger(value) && value >= 1 && value <= 65535;
+}
+
+export function McpServerAdvancedCard() {
+  const { value: mcpServer, isLoading, isSaving } = useAppSettingsKey('mcpServer');
+
+  const persistedPort = mcpServer?.port ?? null;
+  const [draftPort, setDraftPort] = useState<string>(persistedPort?.toString() ?? '');
+  const [isPersisting, setIsPersisting] = useState(false);
+
+  // Keep the draft input in sync when the underlying value changes (e.g. from
+  // another renderer instance or after `setPort` resolves).
+  useEffect(() => {
+    if (persistedPort !== null) {
+      setDraftPort(persistedPort.toString());
+    }
+  }, [persistedPort]);
+
+  const parsed = Number.parseInt(draftPort, 10);
+  const isValid = Number.isFinite(parsed) && isValidPort(parsed);
+  const isDirty = persistedPort !== null && parsed !== persistedPort;
+  const busy = isLoading || isSaving || isPersisting;
+
+  const handleSavePort = useCallback(async () => {
+    if (!isValid || !isDirty) return;
+    setIsPersisting(true);
+    try {
+      const result = await rpc.mcpServer.setPort({ port: parsed });
+      if (!result.success) {
+        toast({
+          title: 'Failed to update MCP server port',
+          description: result.error,
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Failed to update MCP server port',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      });
+    } finally {
+      setIsPersisting(false);
+    }
+  }, [isDirty, isValid, parsed]);
+
+  const handleRevealTokenFile = useCallback(async () => {
+    try {
+      const result = await rpc.mcpServer.revealTokenFile();
+      if (!result.success) {
+        toast({
+          title: 'Failed to locate mcp.json',
+          description: result.error,
+          variant: 'destructive',
+        });
+        return;
+      }
+      const openResult = await rpc.app.openIn({ app: 'finder', path: result.data.path });
+      if (!openResult.success) {
+        toast({
+          title: 'Failed to open mcp.json',
+          description: openResult.error,
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Failed to open mcp.json',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      });
+    }
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-5">
+      <SettingRow
+        title="Loopback port"
+        description="The MCP HTTP server binds to 127.0.0.1 on this port. Valid range: 1–65535."
+        control={
+          <div className="flex items-center gap-2">
+            <Input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={65535}
+              value={draftPort}
+              onChange={(e) => setDraftPort(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && isValid && isDirty) {
+                  e.preventDefault();
+                  void handleSavePort();
+                }
+              }}
+              disabled={busy}
+              aria-label="MCP server port"
+              aria-invalid={!isValid}
+              className="h-8 w-24 text-right tabular-nums"
+            />
+            <Button
+              type="button"
+              variant="outline"
+              size="sm"
+              onClick={() => void handleSavePort()}
+              disabled={busy || !isValid || !isDirty}
+            >
+              Save
+            </Button>
+          </div>
+        }
+      />
+      <SettingRow
+        title="Token file"
+        description="Open ~/.emdash/mcp.json in Finder. The file is created on first start and holds the bearer token used by external MCP clients."
+        control={
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => void handleRevealTokenFile()}
+          >
+            <FolderOpen className="h-3.5 w-3.5" />
+            Open in Finder
+          </Button>
+        }
+      />
+    </div>
+  );
+}

--- a/src/renderer/features/settings/components/mcp-server/McpServerConnectionCard.tsx
+++ b/src/renderer/features/settings/components/mcp-server/McpServerConnectionCard.tsx
@@ -1,0 +1,235 @@
+import { useQuery } from '@tanstack/react-query';
+import { Check, Copy, Eye, EyeOff, RefreshCw } from 'lucide-react';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { Button } from '@renderer/lib/ui/button';
+import { useMcpServerStatus } from './use-mcp-server-status';
+
+type SnippetKey = 'claudeCode' | 'cursor' | 'codex';
+
+const SNIPPET_LABELS: Record<SnippetKey, string> = {
+  claudeCode: 'Claude Code',
+  cursor: 'Cursor',
+  codex: 'Codex',
+};
+
+/**
+ * Snippets are sourced from `rpc.mcpServer.getConfigSnippets()` so the
+ * displayed port stays in sync with `appSettings.mcpServer.port` — refetched
+ * whenever the live status changes.
+ */
+function useConfigSnippets(port: number | null) {
+  return useQuery({
+    // Include port in the key so the snippets update when the user changes it.
+    queryKey: ['mcpServer', 'configSnippets', port] as const,
+    queryFn: async () => {
+      const result = await rpc.mcpServer.getConfigSnippets();
+      return result.success ? result.data : null;
+    },
+    staleTime: 30_000,
+  });
+}
+
+/**
+ * Inline copy-to-clipboard helper used for both the token and the snippets.
+ * Shows a transient "copied" state on the trigger button.
+ */
+function useCopyToClipboard(resetMs = 1600) {
+  const [copied, setCopied] = useState(false);
+  const timerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+    },
+    []
+  );
+
+  const copy = useCallback(
+    async (text: string) => {
+      if (!text || typeof navigator === 'undefined' || !navigator.clipboard?.writeText) {
+        return;
+      }
+      try {
+        await navigator.clipboard.writeText(text);
+        setCopied(true);
+        if (timerRef.current !== null) window.clearTimeout(timerRef.current);
+        timerRef.current = window.setTimeout(() => {
+          setCopied(false);
+          timerRef.current = null;
+        }, resetMs);
+      } catch {
+        setCopied(false);
+      }
+    },
+    [resetMs]
+  );
+
+  return { copied, copy };
+}
+
+function SnippetBlock({ label, snippet }: { label: string; snippet: string }) {
+  const { copied, copy } = useCopyToClipboard();
+  const CopyIcon = copied ? Check : Copy;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-center justify-between">
+        <span className="text-xs text-foreground-muted">{label}</span>
+        <Button
+          type="button"
+          variant="ghost"
+          size="xs"
+          onClick={() => void copy(snippet)}
+          aria-label={`Copy ${label} config snippet`}
+        >
+          <CopyIcon className="h-3 w-3" />
+          {copied ? 'Copied' : 'Copy'}
+        </Button>
+      </div>
+      <pre className="max-h-48 overflow-auto rounded-md border border-border/60 bg-muted/30 p-2 text-[11px] leading-relaxed text-foreground-muted">
+        <code>{snippet}</code>
+      </pre>
+    </div>
+  );
+}
+
+export function McpServerConnectionCard() {
+  const { status } = useMcpServerStatus();
+  const { data: snippets } = useConfigSnippets(status?.port ?? null);
+  const tokenPresent = status?.tokenPresent ?? false;
+  const showConfirmRotate = useShowModal('confirmActionModal');
+  const tokenCopy = useCopyToClipboard();
+
+  // The main process never exposes the existing bearer token over RPC, so we
+  // can only display it when the user explicitly rotates it (the rotate RPC
+  // returns the new value). Until then, the field is masked.
+  const [revealedToken, setRevealedToken] = useState<string | null>(null);
+  const [revealed, setRevealed] = useState(false);
+  const [isRotating, setIsRotating] = useState(false);
+
+  const performRotate = useCallback(async () => {
+    setIsRotating(true);
+    try {
+      const result = await rpc.mcpServer.rotateToken();
+      if (result.success) {
+        setRevealedToken(result.data.token);
+        setRevealed(true);
+        toast({
+          title: 'Token rotated',
+          description: 'External MCP clients must reconnect with the new token.',
+        });
+      } else {
+        toast({
+          title: 'Failed to rotate token',
+          description: result.error,
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Failed to rotate token',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      });
+    } finally {
+      setIsRotating(false);
+    }
+  }, []);
+
+  const handleRotateClick = useCallback(() => {
+    showConfirmRotate({
+      title: 'Rotate MCP bearer token?',
+      description:
+        'This invalidates the current token. Any external MCP clients (Claude Code, Cursor, Codex) using the old token must reconnect with the new one.',
+      confirmLabel: 'Rotate token',
+      onSuccess: () => void performRotate(),
+    });
+  }, [performRotate, showConfirmRotate]);
+
+  const displayValue = (() => {
+    if (revealed && revealedToken) return revealedToken;
+    if (!tokenPresent) return '';
+    return '••••••••••••••••••••••••';
+  })();
+
+  const RevealIcon = revealed ? EyeOff : Eye;
+  const CopyIcon = tokenCopy.copied ? Check : Copy;
+
+  return (
+    <div className="flex flex-col gap-5">
+      <div className="flex flex-col gap-2">
+        <label htmlFor="mcp-server-token" className="text-sm font-normal text-foreground">
+          Bearer token
+        </label>
+        <div className="flex items-center gap-2">
+          <input
+            id="mcp-server-token"
+            readOnly
+            type="text"
+            value={displayValue}
+            placeholder={tokenPresent ? '' : 'No token yet — rotate to generate one.'}
+            className="h-8 flex-1 truncate rounded-md border border-border bg-transparent px-2.5 py-1 font-mono text-xs text-foreground-muted outline-none disabled:opacity-50"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            disabled={!revealedToken}
+            onClick={() => setRevealed((prev) => !prev)}
+            aria-label={revealed ? 'Hide token' : 'Reveal token'}
+            title={
+              revealedToken
+                ? revealed
+                  ? 'Hide token'
+                  : 'Reveal token'
+                : 'Rotate to reveal the token'
+            }
+          >
+            <RevealIcon className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon-sm"
+            disabled={!revealedToken}
+            onClick={() => revealedToken && void tokenCopy.copy(revealedToken)}
+            aria-label="Copy token"
+            title={revealedToken ? 'Copy token' : 'Rotate to copy the token'}
+          >
+            <CopyIcon className="h-3.5 w-3.5" />
+          </Button>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={handleRotateClick}
+            disabled={isRotating}
+            aria-label="Rotate token"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${isRotating ? 'animate-spin' : ''}`} />
+            Rotate
+          </Button>
+        </div>
+        <p className="text-xs text-foreground-passive">
+          {tokenPresent
+            ? 'A token is stored in ~/.emdash/mcp.json. Reveal/copy is only available right after rotation; the existing value is never read back over IPC.'
+            : 'No bearer token has been generated yet. The MCP server creates one automatically when it first starts.'}
+        </p>
+      </div>
+
+      <div className="flex flex-col gap-3">
+        <span className="text-sm font-normal text-foreground">Client config snippets</span>
+        {snippets ? (
+          (Object.keys(SNIPPET_LABELS) as SnippetKey[]).map((key) => (
+            <SnippetBlock key={key} label={SNIPPET_LABELS[key]} snippet={snippets[key]} />
+          ))
+        ) : (
+          <p className="text-xs text-foreground-passive">Loading snippets…</p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/settings/components/mcp-server/McpServerConnectionCard.tsx
+++ b/src/renderer/features/settings/components/mcp-server/McpServerConnectionCard.tsx
@@ -7,10 +7,11 @@ import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
 import { useMcpServerStatus } from './use-mcp-server-status';
 
-type SnippetKey = 'claudeCode' | 'cursor' | 'codex';
+type SnippetKey = 'claudeCodeCli' | 'claudeCode' | 'cursor' | 'codex';
 
 const SNIPPET_LABELS: Record<SnippetKey, string> = {
-  claudeCode: 'Claude Code',
+  claudeCodeCli: 'Claude Code (CLI)',
+  claudeCode: 'Claude Code (config file)',
   cursor: 'Cursor',
   codex: 'Codex',
 };

--- a/src/renderer/features/settings/components/mcp-server/McpServerRecentCallsCard.tsx
+++ b/src/renderer/features/settings/components/mcp-server/McpServerRecentCallsCard.tsx
@@ -1,0 +1,78 @@
+import { CircleDashed } from 'lucide-react';
+import React from 'react';
+import { Badge } from '@renderer/lib/ui/badge';
+import { RelativeTime } from '@renderer/lib/ui/relative-time';
+import { useMcpRecentCalls } from './use-mcp-recent-calls';
+
+/**
+ * Shows the most recent 20 MCP tool invocations. Hydrates from
+ * `mcpServer.getRecentCalls` and live-updates via
+ * `mcpServerRecentCallChannel` (handled inside `useMcpRecentCalls`).
+ */
+export function McpServerRecentCallsCard() {
+  const { calls, isLoading } = useMcpRecentCalls(20);
+
+  if (isLoading && calls.length === 0) {
+    return <p className="text-xs text-foreground-passive">Loading recent calls…</p>;
+  }
+
+  if (calls.length === 0) {
+    return (
+      <div className="flex flex-col items-center justify-center gap-2 rounded-lg border border-dashed border-border/60 bg-muted/10 p-8 text-center">
+        <CircleDashed className="h-5 w-5 text-foreground-passive" />
+        <div className="flex flex-col gap-0.5">
+          <p className="text-sm text-foreground">No recent MCP calls</p>
+          <p className="text-xs text-foreground-passive">
+            Tool invocations from external MCP clients will appear here.
+          </p>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="overflow-hidden rounded-lg border border-border/60">
+      <table className="w-full table-fixed text-sm">
+        <thead className="bg-muted/20 text-xs text-foreground-muted">
+          <tr>
+            <th className="px-3 py-2 text-left font-normal">Tool</th>
+            <th className="w-20 px-3 py-2 text-left font-normal">Status</th>
+            <th className="w-20 px-3 py-2 text-right font-normal">Duration</th>
+            <th className="w-24 px-3 py-2 text-right font-normal">When</th>
+          </tr>
+        </thead>
+        <tbody>
+          {calls.map((call) => (
+            <tr
+              key={call.id}
+              className="border-t border-border/40 transition-colors hover:bg-muted/20"
+            >
+              <td className="truncate px-3 py-2 font-mono text-xs text-foreground">
+                <span title={call.tool}>{call.tool}</span>
+                {call.status === 'error' && call.errorMessage && (
+                  <span
+                    className="ml-2 text-[10px] text-foreground-passive"
+                    title={call.errorMessage}
+                  >
+                    {call.errorCode ?? 'error'}
+                  </span>
+                )}
+              </td>
+              <td className="px-3 py-2">
+                <Badge variant={call.status === 'ok' ? 'secondary' : 'destructive'}>
+                  {call.status === 'ok' ? 'OK' : 'Error'}
+                </Badge>
+              </td>
+              <td className="px-3 py-2 text-right text-xs tabular-nums text-foreground-muted">
+                {Math.round(call.ms)}ms
+              </td>
+              <td className="px-3 py-2 text-right text-xs text-foreground-muted">
+                <RelativeTime value={call.ts} compact ago />
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}

--- a/src/renderer/features/settings/components/mcp-server/McpServerStatusCard.tsx
+++ b/src/renderer/features/settings/components/mcp-server/McpServerStatusCard.tsx
@@ -1,0 +1,99 @@
+import React from 'react';
+import { SettingRow } from '@renderer/features/settings/components/SettingRow';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+import { Switch } from '@renderer/lib/ui/switch';
+import { useMcpServerStatus } from './use-mcp-server-status';
+
+function formatUptime(ms: number): string {
+  if (!ms || ms < 1000) return '0s';
+  const totalSeconds = Math.floor(ms / 1000);
+  const h = Math.floor(totalSeconds / 3600);
+  const m = Math.floor((totalSeconds % 3600) / 60);
+  const s = totalSeconds % 60;
+  const parts: string[] = [];
+  if (h > 0) parts.push(`${h}h`);
+  if (h > 0 || m > 0) parts.push(`${m}m`);
+  parts.push(`${s}s`);
+  return parts.join(' ');
+}
+
+export function McpServerStatusCard() {
+  const { status, isLoading } = useMcpServerStatus();
+  const [isPending, setIsPending] = React.useState(false);
+
+  const enabled = status?.enabled ?? false;
+  const running = status?.running ?? false;
+  const port = status?.port ?? null;
+  const uptime = status?.uptimeMs ?? 0;
+
+  const handleToggle = async (next: boolean) => {
+    setIsPending(true);
+    try {
+      const result = await rpc.mcpServer.setEnabled({ enabled: next });
+      if (!result.success) {
+        toast({
+          title: 'Failed to update MCP server',
+          description: result.error,
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Failed to update MCP server',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      });
+    } finally {
+      setIsPending(false);
+    }
+  };
+
+  const indicatorClass = running
+    ? 'bg-emerald-500'
+    : enabled
+      ? 'bg-amber-500'
+      : 'bg-muted-foreground/50';
+
+  const statusLabel = running
+    ? `Running on 127.0.0.1:${port ?? '—'}`
+    : enabled
+      ? 'Starting…'
+      : 'Stopped';
+
+  return (
+    <div className="flex flex-col gap-4">
+      <SettingRow
+        title="Enable MCP server"
+        description="Expose emdash as a local MCP server so external agents (Claude Code, Cursor, Codex) can drive it."
+        control={
+          <Switch
+            checked={enabled}
+            disabled={isLoading || isPending}
+            onCheckedChange={handleToggle}
+            aria-label="Enable MCP server"
+          />
+        }
+      />
+      <SettingRow
+        title="Status"
+        description={
+          <span className="flex items-center gap-2">
+            <span className={`h-1.5 w-1.5 rounded-full ${indicatorClass}`} />
+            {statusLabel}
+            {running && uptime > 0 && (
+              <>
+                <span className="text-foreground-passive">·</span>
+                <span>Uptime {formatUptime(uptime)}</span>
+              </>
+            )}
+          </span>
+        }
+        control={null}
+      />
+      {status?.lastError && (
+        <p className="text-xs text-destructive">Last error: {status.lastError}</p>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/features/settings/components/mcp-server/use-mcp-recent-calls.ts
+++ b/src/renderer/features/settings/components/mcp-server/use-mcp-recent-calls.ts
@@ -1,0 +1,41 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { mcpServerRecentCallChannel, type RecentCallEntry } from '@shared/events/mcpServerEvents';
+import { events, rpc } from '@renderer/lib/ipc';
+
+const QUERY_KEY = ['mcpServer', 'recentCalls'] as const;
+
+/**
+ * Live-updating ring buffer of recent MCP tool invocations.
+ *
+ * Hydrates from `mcpServer.getRecentCalls` (most-recent first, capped to
+ * `limit`) and then unshifts entries as the main process publishes them on
+ * `mcpServerRecentCallChannel`.
+ */
+export function useMcpRecentCalls(limit = 20) {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<RecentCallEntry[]>({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      const result = await rpc.mcpServer.getRecentCalls({ limit });
+      return result.success ? result.data : [];
+    },
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    const unsubscribe = events.on(mcpServerRecentCallChannel, (entry) => {
+      queryClient.setQueryData<RecentCallEntry[]>(QUERY_KEY, (prev) => {
+        const next = [entry, ...(prev ?? [])];
+        return next.slice(0, limit);
+      });
+    });
+    return unsubscribe;
+  }, [queryClient, limit]);
+
+  return {
+    calls: query.data ?? [],
+    isLoading: query.isLoading,
+  };
+}

--- a/src/renderer/features/settings/components/mcp-server/use-mcp-server-status.ts
+++ b/src/renderer/features/settings/components/mcp-server/use-mcp-server-status.ts
@@ -1,0 +1,40 @@
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { useEffect } from 'react';
+import { mcpServerStatusChannel, type McpServerStatus } from '@shared/events/mcpServerEvents';
+import { events, rpc } from '@renderer/lib/ipc';
+
+const QUERY_KEY = ['mcpServer', 'status'] as const;
+
+/**
+ * Live status of the in-process emdash MCP HTTP server.
+ *
+ * Initial value is fetched via `mcpServer.getStatus` (React Query); thereafter
+ * the cache is patched in-place whenever the main process emits on
+ * `mcpServerStatusChannel`, so the Settings page reflects start/stop/port
+ * changes without polling.
+ */
+export function useMcpServerStatus() {
+  const queryClient = useQueryClient();
+
+  const query = useQuery<McpServerStatus | null>({
+    queryKey: QUERY_KEY,
+    queryFn: async () => {
+      const result = await rpc.mcpServer.getStatus();
+      return result.success ? result.data : null;
+    },
+    staleTime: 30_000,
+  });
+
+  useEffect(() => {
+    const unsubscribe = events.on(mcpServerStatusChannel, (next) => {
+      queryClient.setQueryData(QUERY_KEY, next);
+    });
+    return unsubscribe;
+  }, [queryClient]);
+
+  return {
+    status: query.data ?? null,
+    isLoading: query.isLoading,
+    refetch: query.refetch,
+  };
+}

--- a/src/shared/events/mcpServerEvents.ts
+++ b/src/shared/events/mcpServerEvents.ts
@@ -35,3 +35,32 @@ export const mcpServerErrorChannel = defineEvent<{
   code: string;
   message: string;
 }>('mcp-server:error');
+
+/**
+ * Single recent-call entry surfaced on `mcpServerRecentCallChannel` and
+ * returned by `mcpServer.getRecentCalls`. The renderer Settings page renders
+ * the last 200 entries as a live-updating list.
+ */
+export interface RecentCallEntry {
+  /** Stable identifier (UUID) so the renderer can key list items. */
+  id: string;
+  /** Fully-qualified tool name (e.g. `task.create`). */
+  tool: string;
+  /** Whether the tool reply was an MCP error reply. */
+  status: 'ok' | 'error';
+  /** End-to-end handler duration in milliseconds. */
+  ms: number;
+  /** Wall-clock timestamp (ms since epoch) when the call completed. */
+  ts: number;
+  /** Structured error code (e.g. `CONFIRM_REQUIRED`) when `status === 'error'`. */
+  errorCode?: string;
+  /** Human-readable error message when `status === 'error'`. */
+  errorMessage?: string;
+}
+
+/**
+ * Channel for individual recent-call events. Emitted once per tool invocation
+ * after the handler resolves so the Settings page can append to its
+ * live-updating list without polling `getRecentCalls`.
+ */
+export const mcpServerRecentCallChannel = defineEvent<RecentCallEntry>('mcp-server:recent-call');

--- a/src/shared/events/mcpServerEvents.ts
+++ b/src/shared/events/mcpServerEvents.ts
@@ -1,0 +1,37 @@
+import { defineEvent } from '@shared/ipc/events';
+
+/**
+ * Live status of the in-process emdash MCP HTTP server. Emitted whenever the
+ * service starts, stops, restarts, or encounters an error so the renderer
+ * Settings page can reflect the current state without polling.
+ */
+export interface McpServerStatus {
+  /** User-visible toggle from `appSettings.mcpServer.enabled`. */
+  enabled: boolean;
+  /** True iff the loopback HTTP server is currently accepting connections. */
+  running: boolean;
+  /** Bound TCP port (`null` when the server is not running). */
+  port: number | null;
+  /** True iff `~/.emdash/mcp.json` exists and parsed successfully. */
+  tokenPresent: boolean;
+  /** Milliseconds since the current run started; `0` when not running. */
+  uptimeMs: number;
+  /** Last error message surfaced by the service, or `null` if healthy. */
+  lastError: string | null;
+}
+
+/**
+ * Channel for live MCP server status updates. Fired on every state change
+ * (enable/disable, restart, port change, error → recovery).
+ */
+export const mcpServerStatusChannel = defineEvent<McpServerStatus>('mcp-server:status');
+
+/**
+ * Channel for one-shot MCP server errors that should be surfaced to the user
+ * (e.g. EADDRINUSE on startup). The status channel also carries `lastError`
+ * for steady-state display; this channel is intended for transient toasts.
+ */
+export const mcpServerErrorChannel = defineEvent<{
+  code: string;
+  message: string;
+}>('mcp-server:error');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -31,7 +31,8 @@
     "src/shared/**/*",
     "src/types/**/*",
     "src/test/**/*",
-    "tooling/**/*"
+    "tooling/**/*",
+    "bin/**/*"
   ],
   "exclude": ["node_modules", "dist", "out", "**/_*/**"]
 }

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -32,7 +32,11 @@ export default defineConfig({
         test: {
           name: 'node',
           environment: 'node',
-          include: ['src/**/*.test.ts'],
+          // `bin/` ships the standalone `emdash-mcp` stdio bridge that
+          // external MCP clients spawn (T9). It lives outside `src/` because
+          // `electron-vite` builds it as a separate Node bundle, but its unit
+          // tests still belong in the same suite as everything else.
+          include: ['src/**/*.test.ts', 'bin/**/*.test.ts'],
           exclude: [
             '**/_*/**',
             'src/renderer/tests/browser/**',


### PR DESCRIPTION
## Summary

Adds an inbound **MCP server** to emdash so external AI agents (Claude Code, Cursor, Codex) can drive it: create / edit / delete tasks, add projects, install MCP servers + skills, observe running agents and write to their PTYs, edit project settings, and open worktrees in IDEs.

- **In-process loopback HTTP server** speaking the MCP Streamable HTTP transport (`127.0.0.1` only). A small `emdash-mcp` stdio bridge bin ships alongside so external clients connect over stdio without juggling a bearer token themselves.
- **New Settings → MCP Server section** with status, port, recent-calls feed, token rotation, and copy-paste config snippets (`claude mcp add` one-liner, Claude Code config-file JSON, Cursor JSON, Codex TOML).
- **Disabled by default.** Existing users see no change until they flip the toggle.

## Security posture

- Loopback-only bind. Rejects any `Host` header that isn't `127.0.0.1:<port>` or `localhost:<port>` with HTTP 421 (DNS-rebinding guard).
- Bearer token persisted at `~/.emdash/mcp.json` mode `0600`, parent dir `0700`. Compared with `crypto.timingSafeEqual`.
- Token is never read back over IPC — it's only ever surfaced once, right after explicit user-initiated rotation.
- Destructive tools (`task.delete`, `project.delete`, etc.) require an explicit `confirm: true` argument.
- WebSocket upgrade requests are rejected at the gateway.

## Architecture notes

- New module at `src/main/core/mcp-server/` (HTTP gateway, service lifecycle, token store, tool catalog, resources, recent-calls ring, RPC controller).
- Per-session `McpServer` instances: the SDK's `McpServer` is 1-to-1 with a transport, so each HTTP session mints a fresh `McpServer` via a factory. Closed in `stop()` and on session drop.
- New PTY surface area is read-only: `peek()` + `onData()` listener API on `pty-session-registry` for the resource adapter. No changes to existing PTY consumers / lifecycle.
- `electron-vite.config.ts` adds a sibling rollup input for `bin/emdash-mcp.ts` → `out/main/emdash-mcp.js`; `electron-builder.config.ts` ships it as `extraResources` under `<Resources>/bin/`.
- Settings UI: new tab in the existing settings registry; no view/modal registry surgery elsewhere.

## What's *not* in scope

- No auto-updater changes.
- No DB schema / migration changes.
- No SSH or PTY orchestration changes (only the additive read-only API noted above).

## Test plan

- [x] `pnpm test` — 847 passed / 1 skipped locally (Playwright browser cache failure is unrelated and pre-existing)
- [x] `pnpm run typecheck` + `pnpm run lint` + `pnpm run format` — clean
- [x] Local dev: `pnpm run d`, enable in Settings, `claude mcp add emdash --scope user -- node ./out/main/emdash-mcp.js`, `/mcp` in Claude Code lists `emdash`, tool calls round-trip
- [x] Two concurrent SDK clients on the same port (regression for the "Already connected to a transport" bug surfaced during preview) — covered by `integration.test.ts`
- [ ] Packaged build: `pnpm run build` + launch produced artifact; confirm Settings → MCP Server → Connection's snippet path resolves into `<App>/Contents/Resources/bin/emdash-mcp.js` and that the bridge connects
- [ ] Toggle off → on, change port, rotate token — external clients reconnect with the new token

🤖 Generated with [Claude Code](https://claude.com/claude-code)