### PR TITLE
fix(pty): double-wrap cmd.exe command lines so Claude launches from paths with spaces on Windows

### DIFF
--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -70,6 +70,26 @@ describe('resolveLocalPtySpawn - Windows', () => {
     });
   });
 
+  it('double-wraps cmd shim paths containing spaces so /S /C does not eat the outer quotes', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: windowsPathEnv,
+      fileExists: (candidate) => candidate === 'C:\\Program Files\\nodejs\\claude.CMD',
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'claude', args: [] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', '""C:\\Program Files\\nodejs\\claude.CMD""'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
   it('direct-spawns extensionless commands that resolve to exe files', () => {
     const result = resolveLocalPtySpawn({
       platform: 'win32',

--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -90,6 +90,26 @@ describe('resolveLocalPtySpawn - Windows', () => {
     });
   });
 
+  it('double-wraps spaced-path cmd shims even when arguments are present', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: windowsPathEnv,
+      fileExists: (candidate) => candidate === 'C:\\Program Files\\nodejs\\claude.CMD',
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        command: { kind: 'argv', command: 'claude', args: ['--version'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', '""C:\\Program Files\\nodejs\\claude.CMD" --version"'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
   it('direct-spawns extensionless commands that resolve to exe files', () => {
     const result = resolveLocalPtySpawn({
       platform: 'win32',

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -65,6 +65,17 @@ function quoteForCmdExe(input: string): string {
     .replace(/(["^&|<>()])/g, '^$1')}"`;
 }
 
+/**
+ * cmd.exe + /S /C has a quirk: if the command string starts with a quote, the
+ * outer quotes are taken as part of the executable name (printed back as
+ * `'"C:\Program Files\..."' is not recognized`). The documented workaround is
+ * to wrap the entire command line in an extra pair of outer quotes so cmd.exe
+ * strips one layer and runs the still-quoted path.
+ */
+function wrapCmdExeCommandLine(commandLine: string): string {
+  return commandLine.startsWith('"') ? `"${commandLine}"` : commandLine;
+}
+
 function getWindowsPathDirs(env: NodeJS.ProcessEnv): string[] {
   const rawPath = getWindowsEnvValue(env, 'PATH') ?? '';
   return rawPath.split(path.win32.delimiter).filter(Boolean);
@@ -139,7 +150,7 @@ function resolveWindowsSpawn(
   if (intent.command.kind === 'shell-line') {
     return {
       command: shell,
-      args: ['/d', '/s', '/c', intent.command.commandLine],
+      args: ['/d', '/s', '/c', wrapCmdExeCommandLine(intent.command.commandLine)],
       cwd: intent.cwd,
       warnings,
     };
@@ -158,7 +169,12 @@ function resolveWindowsSpawn(
   if (ext === '.cmd' || ext === '.bat') {
     return {
       command: shell,
-      args: ['/d', '/s', '/c', [resolvedCommand, ...args].map(quoteForCmdExe).join(' ')],
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        wrapCmdExeCommandLine([resolvedCommand, ...args].map(quoteForCmdExe).join(' ')),
+      ],
       cwd: intent.cwd,
       warnings,
     };
@@ -176,7 +192,12 @@ function resolveWindowsSpawn(
   if (!ext) {
     return {
       command: shell,
-      args: ['/d', '/s', '/c', [command, ...args].map(quoteForCmdExe).join(' ')],
+      args: [
+        '/d',
+        '/s',
+        '/c',
+        wrapCmdExeCommandLine([command, ...args].map(quoteForCmdExe).join(' ')),
+      ],
       cwd: intent.cwd,
       warnings,
     };


### PR DESCRIPTION
# Fix Claude CLI failing to launch on Windows when installed under a path with spaces

## Summary
On Windows, launching the Claude CLI through a PTY failed when its `.cmd` shim lived under a path containing spaces (e.g. `C:\Program Files\nodejs\claude.CMD`). cmd.exe would echo back:

```
'"C:\Program Files\nodejs\claude.CMD"' is not recognized as an internal or external command
```

## Root cause
`cmd.exe /S /C` has a long-standing quirk: when the command line passed after `/C` begins with a `"`, cmd.exe strips the **outer** pair of quotes and treats whatever's between them as the executable name. For a path like `"C:\Program Files\nodejs\claude.CMD"`, that leaves cmd.exe trying to run `C:\Program` with `Files\nodejs\claude.CMD"` as an argument — hence the error.

This behaviour is documented in cmd.exe's own help (`cmd /?`, under the rules for how `/C` and `/K` process quote characters): when `/S` is passed (or the simple-case conditions aren't met), cmd.exe will "strip the leading character and remove the last quote character on the command line." The standard workaround that falls out of those rules — also reflected in Microsoft's [cmd reference](https://learn.microsoft.com/en-us/windows-server/administration/windows-commands/cmd) and in Node.js's own handling in `child_process` — is to wrap the entire command line in an **extra** outer pair of quotes, so cmd.exe strips one layer and still sees a properly quoted path.

## Fix
Introduced `wrapCmdExeCommandLine()` in [src/main/core/pty/pty-spawn-platform.ts](src/main/core/pty/pty-spawn-platform.ts) which adds the extra outer quotes when (and only when) the constructed command line begins with `"`. Applied it to the three code paths that build a `/d /s /c` invocation:

- `shell-line` intents
- `.cmd` / `.bat` resolved targets
- Extensionless commands resolved via PATH

## Test
Added a regression test in [src/main/core/pty/pty-spawn-platform.test.ts](src/main/core/pty/pty-spawn-platform.test.ts) covering the canonical failing case — resolving `claude` to `C:\Program Files\nodejs\claude.CMD` — and asserting the args end with `""C:\Program Files\nodejs\claude.CMD""` (double-wrapped).

## Test plan
- [x] `pnpm run test` — new unit test passes alongside existing Windows spawn cases
- [x] Manual: launch a Claude task on a Windows machine where `claude.cmd` resolves under `C:\Program Files\...` and confirm the PTY starts cleanly
- [x] Verify no regression for paths without spaces (covered by existing tests in the same file)

## Reference in Discord
https://discord.com/channels/1422831935553667175/1504999128768319539