### PR TITLE
fix: keep onboarding skip safe during sign-in

### DIFF
--- a/src/renderer/features/onboarding/sign-in-step.tsx
+++ b/src/renderer/features/onboarding/sign-in-step.tsx
@@ -1,16 +1,11 @@
 import { CheckCircle, Github, LogIn, User } from 'lucide-react';
 import { useRef, useState } from 'react';
-import {
-  useAccountSession,
-  useAccountSignIn,
-  useAccountSignOut,
-} from '@renderer/lib/hooks/useAccount';
+import { useAccountSession, useAccountSignIn } from '@renderer/lib/hooks/useAccount';
 import { Button } from '@renderer/lib/ui/button';
 
 export function SignInStep({ onComplete }: { onComplete: () => void }) {
   const { data: session, isLoading: sessionLoading } = useAccountSession();
   const signInMutation = useAccountSignIn();
-  const signOutMutation = useAccountSignOut();
   const skippedSignInRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -25,7 +20,6 @@ export function SignInStep({ onComplete }: { onComplete: () => void }) {
         return;
       }
       if (skippedSignInRef.current) {
-        await signOutMutation.mutateAsync();
         return;
       }
       onComplete();

--- a/src/renderer/features/onboarding/sign-in-step.tsx
+++ b/src/renderer/features/onboarding/sign-in-step.tsx
@@ -1,25 +1,43 @@
 import { CheckCircle, Github, LogIn, User } from 'lucide-react';
-import { useState } from 'react';
-import { useAccountSession, useAccountSignIn } from '@renderer/lib/hooks/useAccount';
+import { useRef, useState } from 'react';
+import {
+  useAccountSession,
+  useAccountSignIn,
+  useAccountSignOut,
+} from '@renderer/lib/hooks/useAccount';
 import { Button } from '@renderer/lib/ui/button';
 
 export function SignInStep({ onComplete }: { onComplete: () => void }) {
   const { data: session, isLoading: sessionLoading } = useAccountSession();
   const signInMutation = useAccountSignIn();
+  const signOutMutation = useAccountSignOut();
+  const skippedSignInRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
 
   const handleSignIn = async () => {
+    skippedSignInRef.current = false;
     setError(null);
     try {
       const result = await signInMutation.mutateAsync(undefined);
       if (!result.success) {
+        if (skippedSignInRef.current) return;
         setError(result.error || 'Sign in failed');
+        return;
+      }
+      if (skippedSignInRef.current) {
+        await signOutMutation.mutateAsync();
         return;
       }
       onComplete();
     } catch (err) {
+      if (skippedSignInRef.current) return;
       setError(err instanceof Error ? err.message : 'Sign in failed');
     }
+  };
+
+  const handleSkip = () => {
+    skippedSignInRef.current = true;
+    onComplete();
   };
 
   if (sessionLoading) {
@@ -80,7 +98,7 @@ export function SignInStep({ onComplete }: { onComplete: () => void }) {
           <LogIn className="h-4 w-4" />
           {signInMutation.isPending ? 'Signing in...' : 'Sign in with GitHub'}
         </Button>
-        <Button variant="ghost" onClick={onComplete} disabled={signInMutation.isPending}>
+        <Button variant="ghost" onClick={handleSkip}>
           Skip
         </Button>
       </div>


### PR DESCRIPTION
# summary
- make "skip" not disabled when signin was already started
- sign in will still work even if you press skip 