### PR TITLE
fix(settings): simplify account display name

### DIFF
--- a/src/renderer/features/settings/components/AccountTab.tsx
+++ b/src/renderer/features/settings/components/AccountTab.tsx
@@ -41,7 +41,7 @@ export function AccountTab() {
       }
       toast({
         title: 'Signed in to Emdash',
-        description: result.user ? `Connected as @${result.user.username}` : 'Signed in',
+        description: result.user ? `Connected as ${result.user.username}` : 'Signed in',
       });
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Sign in failed';
@@ -101,9 +101,7 @@ export function AccountTab() {
             </div>
           )}
           <div className="flex-1">
-            <p className="text-sm font-medium text-foreground">
-              Connected as <span className="font-semibold">@{user.username}</span>
-            </p>
+            <p className="text-sm font-semibold text-foreground">{user.username}</p>
             {user.email && <p className="text-xs text-muted-foreground">{user.email}</p>}
           </div>
           <Button


### PR DESCRIPTION
# Summary

* remove the `Connected as` label from the signed-in settings account row
* remove the `@` prefix from the settings sign-in success toast
* keep the account card focused on the stored account name and email

## Why?

The @ prefix makes no sense since its the github display name not the username, if in the future you store the real github username you could display it as e.g. @janburzinski under the display name :D