### PR TITLE
fix(feedback): validate contact email

### DIFF
--- a/src/renderer/lib/components/feedback-modal/feedback-modal.tsx
+++ b/src/renderer/lib/components/feedback-modal/feedback-modal.tsx
@@ -77,7 +77,9 @@ export function FeedbackModal({ onSuccess, blurb }: Props) {
     setContactEmail,
     submitting,
     errorMessage,
+    contactEmailError,
     clearError,
+    clearContactEmailError,
     handleSubmit,
     canSubmit,
   } = useFeedbackSubmit({
@@ -149,11 +151,23 @@ export function FeedbackModal({ onSuccess, blurb }: Props) {
               type="text"
               placeholder="productive@example.com (optional)"
               value={contactEmail}
+              aria-invalid={contactEmailError ? 'true' : undefined}
+              aria-describedby={contactEmailError ? 'feedback-contact-error' : undefined}
               onChange={(event) => {
                 setContactEmail(event.target.value);
                 if (errorMessage) clearError();
+                if (contactEmailError) clearContactEmailError();
               }}
             />
+            {contactEmailError ? (
+              <p
+                id="feedback-contact-error"
+                className="text-xs text-foreground-destructive"
+                role="alert"
+              >
+                {contactEmailError}
+              </p>
+            ) : null}
           </div>
 
           <div className="space-y-2">

--- a/src/renderer/lib/components/feedback-modal/schemas/feedback-email.ts
+++ b/src/renderer/lib/components/feedback-modal/schemas/feedback-email.ts
@@ -1,0 +1,6 @@
+import * as z from 'zod';
+
+export const FEEDBACK_EMAIL_SCHEMA = z.union([
+  z.literal(''),
+  z.string().email('Please enter a valid email address.'),
+]);

--- a/src/renderer/lib/components/feedback-modal/use-feedback-submit.test.ts
+++ b/src/renderer/lib/components/feedback-modal/use-feedback-submit.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import { FEEDBACK_EMAIL_SCHEMA } from './schemas/feedback-email';
 import { buildFeedbackContent } from './use-feedback-submit';
 
 describe('buildFeedbackContent', () => {
@@ -25,5 +26,24 @@ describe('buildFeedbackContent', () => {
     });
 
     expect(content).toBe('Needs improvement');
+  });
+});
+
+describe('FEEDBACK_EMAIL_SCHEMA', () => {
+  it('accepts blank optional email', () => {
+    expect(FEEDBACK_EMAIL_SCHEMA.safeParse('').success).toBe(true);
+  });
+
+  it('accepts valid email', () => {
+    expect(FEEDBACK_EMAIL_SCHEMA.safeParse('person@example.com').success).toBe(true);
+  });
+
+  it('rejects invalid email', () => {
+    const result = FEEDBACK_EMAIL_SCHEMA.safeParse('person');
+
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.issues[0]?.message).toBe('Please enter a valid email address.');
+    }
   });
 });

--- a/src/renderer/lib/components/feedback-modal/use-feedback-submit.ts
+++ b/src/renderer/lib/components/feedback-modal/use-feedback-submit.ts
@@ -162,6 +162,6 @@ export function useFeedbackSubmit({ githubUser, appVersion, onSuccess }: Feedbac
     clearContactEmailError,
     reset,
     handleSubmit,
-    canSubmit: feedbackDetails.trim().length > 0 && !submitting,
+    canSubmit: feedbackDetails.trim().length > 0 && !submitting && !contactEmailError,
   };
 }

--- a/src/renderer/lib/components/feedback-modal/use-feedback-submit.ts
+++ b/src/renderer/lib/components/feedback-modal/use-feedback-submit.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from 'react';
 import { useToast } from '@renderer/lib/hooks/use-toast';
 import { log } from '@renderer/utils/logger';
+import { FEEDBACK_EMAIL_SCHEMA } from './schemas/feedback-email';
 
 const DISCORD_WEBHOOK_URL =
   'https://discord.com/api/webhooks/1473390363388416230/eRIo1UhylapH94KpqUUp5PDzkLhjBvcnjjyE_JezfHiAyfN3QEbRyEIJaSl8QQUz7Mak';
@@ -66,10 +67,15 @@ export function useFeedbackSubmit({ githubUser, appVersion, onSuccess }: Feedbac
   const [contactEmail, setContactEmail] = useState('');
   const [submitting, setSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
+  const [contactEmailError, setContactEmailError] = useState<string | null>(null);
   const { toast } = useToast();
 
   const clearError = useCallback(() => {
     setErrorMessage(null);
+  }, []);
+
+  const clearContactEmailError = useCallback(() => {
+    setContactEmailError(null);
   }, []);
 
   const reset = useCallback(() => {
@@ -77,22 +83,31 @@ export function useFeedbackSubmit({ githubUser, appVersion, onSuccess }: Feedbac
     setContactEmail('');
     setSubmitting(false);
     setErrorMessage(null);
+    setContactEmailError(null);
   }, []);
 
   const handleSubmit = useCallback(
     async (attachments: File[]) => {
       const trimmedFeedback = feedbackDetails.trim();
+      const trimmedContactEmail = contactEmail.trim();
       if (!trimmedFeedback) {
         setErrorMessage('Please enter some feedback before sending.');
         return;
       }
 
+      const emailValidation = FEEDBACK_EMAIL_SCHEMA.safeParse(trimmedContactEmail);
+      if (!emailValidation.success) {
+        setContactEmailError(emailValidation.error.issues[0]?.message ?? 'Invalid email address.');
+        return;
+      }
+
       setSubmitting(true);
       setErrorMessage(null);
+      setContactEmailError(null);
 
       const content = buildFeedbackContent({
         feedback: trimmedFeedback,
-        contactEmail,
+        contactEmail: trimmedContactEmail,
         githubUser,
         appVersion,
       });
@@ -142,7 +157,9 @@ export function useFeedbackSubmit({ githubUser, appVersion, onSuccess }: Feedbac
     setContactEmail,
     submitting,
     errorMessage,
+    contactEmailError,
     clearError,
+    clearContactEmailError,
     reset,
     handleSubmit,
     canSubmit: feedbackDetails.trim().length > 0 && !submitting,


### PR DESCRIPTION
# Summary

* validate the optional feedback contact email before submitting
* show an inline red error message when the email is invalid
* add schema coverage for blank, valid, and invalid email values

## Why?

To prevent invalid emails cause if you put one might aswell validate it