### PR TITLE
fix(integrations): stack setup modal descriptions

### DIFF
--- a/src/renderer/features/integrations/integration-setup-modal.tsx
+++ b/src/renderer/features/integrations/integration-setup-modal.tsx
@@ -195,11 +195,11 @@ export function IntegrationSetupModal({ integration, onSuccess, onClose }: Props
 
   return (
     <>
-      <DialogHeader showCloseButton={false}>
+      <DialogHeader className="flex-col items-start gap-1" showCloseButton={false}>
         <DialogTitle>{title}</DialogTitle>
         <DialogDescription className="text-xs">{subtitle}</DialogDescription>
       </DialogHeader>
-      <DialogContentArea>
+      <DialogContentArea className="pt-1">
         {integration === 'linear' && (
           <LinearSetupForm apiKey={linearKey} onChange={setLinearKey} error={error} />
         )}


### PR DESCRIPTION
## Summary
- stack integration setup descriptions under their titles
- add spacing so focused inputs are not clipped

Preview:
<img width="658" height="354" alt="image" src="https://github.com/user-attachments/assets/7b23bf86-c19a-4809-af81-36f913e9a913" />
