### PR TITLE
feat(sidebar): inline "+" button to add project from Projects header

### DIFF
--- a/src/renderer/features/sidebar/projects-group-label.tsx
+++ b/src/renderer/features/sidebar/projects-group-label.tsx
@@ -54,17 +54,19 @@ export const ProjectsGroupLabel = observer(function ProjectsGroupLabel() {
           </DropdownMenuContent>
         </DropdownMenu>
         <Tooltip>
-          <TooltipTrigger asChild>
-            <Button
-              size="icon-xs"
-              variant="ghost"
-              className="hover:bg-transparent text-foreground-muted hover:text-foreground"
-              aria-label="Add Project"
-              onClick={() => showAddProjectModal({})}
-            >
-              <Plus />
-            </Button>
-          </TooltipTrigger>
+          <TooltipTrigger
+            render={
+              <Button
+                size="icon-xs"
+                variant="ghost"
+                className="hover:bg-transparent text-foreground-muted hover:text-foreground"
+                aria-label="Add Project"
+                onClick={() => showAddProjectModal({})}
+              >
+                <Plus />
+              </Button>
+            }
+          />
           <TooltipContent className="flex items-center gap-2">
             Add Project
             <ShortcutHint settingsKey="newProject" />

--- a/src/renderer/features/sidebar/projects-group-label.tsx
+++ b/src/renderer/features/sidebar/projects-group-label.tsx
@@ -13,6 +13,8 @@ import {
   DropdownMenuTrigger,
 } from '@renderer/lib/ui/dropdown-menu';
 import { MicroLabel } from '@renderer/lib/ui/label';
+import { ShortcutHint } from '@renderer/lib/ui/shortcut-hint';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 
 export const ProjectsGroupLabel = observer(function ProjectsGroupLabel() {
   const showAddProjectModal = useShowModal('addProjectModal');
@@ -51,15 +53,23 @@ export const ProjectsGroupLabel = observer(function ProjectsGroupLabel() {
             </DropdownMenuGroup>
           </DropdownMenuContent>
         </DropdownMenu>
-        <Button
-          size="icon-xs"
-          variant="ghost"
-          className="hover:bg-transparent text-foreground-muted hover:text-foreground"
-          aria-label="Add Project"
-          onClick={() => showAddProjectModal({})}
-        >
-          <Plus />
-        </Button>
+        <Tooltip>
+          <TooltipTrigger asChild>
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              className="hover:bg-transparent text-foreground-muted hover:text-foreground"
+              aria-label="Add Project"
+              onClick={() => showAddProjectModal({})}
+            >
+              <Plus />
+            </Button>
+          </TooltipTrigger>
+          <TooltipContent className="flex items-center gap-2">
+            Add Project
+            <ShortcutHint settingsKey="newProject" />
+          </TooltipContent>
+        </Tooltip>
       </div>
     </div>
   );

--- a/src/renderer/features/sidebar/projects-group-label.tsx
+++ b/src/renderer/features/sidebar/projects-group-label.tsx
@@ -1,5 +1,6 @@
-import { ListFilter } from 'lucide-react';
+import { ListFilter, Plus } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { sidebarStore } from '@renderer/lib/stores/app-state';
 import { Button } from '@renderer/lib/ui/button';
 import {
@@ -14,39 +15,52 @@ import {
 import { MicroLabel } from '@renderer/lib/ui/label';
 
 export const ProjectsGroupLabel = observer(function ProjectsGroupLabel() {
+  const showAddProjectModal = useShowModal('addProjectModal');
+
   return (
     <div className="flex items-center justify-between pl-5 pr-2.5 h-[40px]">
       <MicroLabel className="text-foreground-tertiary-passive">Projects</MicroLabel>
-      <DropdownMenu>
-        <DropdownMenuTrigger>
-          <Button
-            size="icon-xs"
-            variant="ghost"
-            className="hover:bg-transparent text-foreground-muted hover:text-foreground"
-          >
-            <ListFilter />
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent className="min-w-48">
-          <DropdownMenuGroup>
-            <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-            <DropdownMenuRadioGroup value={sidebarStore.taskSortBy}>
-              <DropdownMenuRadioItem
-                value="created-at"
-                onClick={() => sidebarStore.applySort('created-at')}
-              >
-                Created at
-              </DropdownMenuRadioItem>
-              <DropdownMenuRadioItem
-                value="updated-at"
-                onClick={() => sidebarStore.applySort('updated-at')}
-              >
-                Last used
-              </DropdownMenuRadioItem>
-            </DropdownMenuRadioGroup>
-          </DropdownMenuGroup>
-        </DropdownMenuContent>
-      </DropdownMenu>
+      <div className="flex items-center">
+        <DropdownMenu>
+          <DropdownMenuTrigger>
+            <Button
+              size="icon-xs"
+              variant="ghost"
+              className="hover:bg-transparent text-foreground-muted hover:text-foreground"
+            >
+              <ListFilter />
+            </Button>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent className="min-w-48">
+            <DropdownMenuGroup>
+              <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+              <DropdownMenuRadioGroup value={sidebarStore.taskSortBy}>
+                <DropdownMenuRadioItem
+                  value="created-at"
+                  onClick={() => sidebarStore.applySort('created-at')}
+                >
+                  Created at
+                </DropdownMenuRadioItem>
+                <DropdownMenuRadioItem
+                  value="updated-at"
+                  onClick={() => sidebarStore.applySort('updated-at')}
+                >
+                  Last used
+                </DropdownMenuRadioItem>
+              </DropdownMenuRadioGroup>
+            </DropdownMenuGroup>
+          </DropdownMenuContent>
+        </DropdownMenu>
+        <Button
+          size="icon-xs"
+          variant="ghost"
+          className="hover:bg-transparent text-foreground-muted hover:text-foreground"
+          aria-label="Add Project"
+          onClick={() => showAddProjectModal({})}
+        >
+          <Plus />
+        </Button>
+      </div>
     </div>
   );
 });


### PR DESCRIPTION
Adds a `+` button next to the sort filter so you can create a project straight from the sidebar header without scrolling to the footer button. Opinionated tweak from me — totally fine to close if it's not the direction you want.

Preview:

<img width="416" height="260" alt="8oAprrb6oAS" src="https://github.com/user-attachments/assets/b546b3ef-39cc-4c7f-95ae-bd1ff261b346" />
