### PR TITLE
feat: improve GitHub auth source handling and connection flow

### DIFF
--- a/src/main/core/github/controller.ts
+++ b/src/main/core/github/controller.ts
@@ -3,6 +3,7 @@ import * as path from 'node:path';
 import type {
   GitHubAuthResponse,
   GitHubConnectResponse,
+  GitHubStatusOptions,
   GitHubStatusResponse,
 } from '@shared/github';
 import { createRPCController } from '@shared/ipc/rpc';
@@ -21,9 +22,9 @@ import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 
 export const githubController = createRPCController({
-  getStatus: async (): Promise<GitHubStatusResponse> => {
+  getStatus: async (options?: GitHubStatusOptions): Promise<GitHubStatusResponse> => {
     try {
-      return await githubConnectionService.getStatus();
+      return await githubConnectionService.getStatus(options);
     } catch (error) {
       log.error('GitHub status check failed:', error);
       return { authenticated: false, user: null, tokenSource: null };

--- a/src/main/core/github/services/github-connection-service.test.ts
+++ b/src/main/core/github/services/github-connection-service.test.ts
@@ -152,4 +152,50 @@ describe('GitHubConnectionServiceImpl token caching', () => {
 
     expect(mockGetSecret).toHaveBeenCalledTimes(1);
   });
+
+  it('keeps CLI-sourced getToken() cached while the TTL is warm', async () => {
+    mockGetSecret.mockResolvedValue('gho_cached_cli');
+    mockKvGet.mockResolvedValue('cli');
+    mockExtractGhCliToken.mockResolvedValue('gho_cached_cli');
+
+    const first = await service.getToken();
+    const second = await service.getToken();
+
+    expect(first).toBe('gho_cached_cli');
+    expect(second).toBe('gho_cached_cli');
+    expect(mockExtractGhCliToken).toHaveBeenCalledTimes(1);
+  });
+
+  it('force-refreshes CLI-sourced status when requested', async () => {
+    mockGetSecret.mockResolvedValue('gho_stale_cli');
+    mockKvGet.mockResolvedValue('cli');
+    mockExtractGhCliToken.mockResolvedValueOnce('gho_stale_cli').mockResolvedValueOnce(null);
+
+    await service.getToken();
+    const status = await service.getStatus({ refresh: true });
+
+    expect(status).toEqual({ authenticated: false, user: null, tokenSource: null });
+    expect(mockExtractGhCliToken).toHaveBeenCalledTimes(2);
+    expect(mockDeleteSecret).toHaveBeenCalledWith('emdash-github-token');
+    expect(mockKvDel).toHaveBeenCalledWith('tokenSource');
+  });
+
+  it('getStatus({ refresh: true }) detects GitHub CLI after a cached miss', async () => {
+    const user = {
+      id: 1,
+      login: 'octocat',
+      name: 'Octocat',
+      email: '',
+      avatar_url: 'https://github.com/octocat.png',
+    };
+    mockExtractGhCliToken.mockResolvedValueOnce(null).mockResolvedValueOnce('gho_cli');
+    vi.spyOn(service, 'getUserInfo').mockResolvedValue(user);
+
+    await service.getToken();
+    const status = await service.getStatus({ refresh: true });
+
+    expect(status).toEqual({ authenticated: true, user, tokenSource: 'cli' });
+    expect(mockSetSecret).toHaveBeenCalledWith('emdash-github-token', 'gho_cli');
+    expect(mockKvSet).toHaveBeenCalledWith('tokenSource', 'cli');
+  });
 });

--- a/src/main/core/github/services/github-connection-service.ts
+++ b/src/main/core/github/services/github-connection-service.ts
@@ -6,7 +6,7 @@ import {
   githubAuthErrorChannel,
   githubAuthSuccessChannel,
 } from '@shared/events/githubEvents';
-import type { GitHubConnectResponse, GitHubUser } from '@shared/github';
+import type { GitHubConnectResponse, GitHubStatusOptions, GitHubUser } from '@shared/github';
 import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
 import { encryptedAppSecretsStore } from '@main/core/secrets/encrypted-app-secrets-store';
 import { executeOAuthFlow } from '@main/core/shared/oauth-flow';
@@ -34,14 +34,14 @@ export interface DeviceCodeResult {
 
 /**
  * Manages GitHub authentication tokens regardless of how they were obtained
- * (Emdash Account OAuth, Device Flow, PAT, or extracted from gh CLI).
+ * (Emdash Account OAuth, Device Flow, or extracted from gh CLI).
  */
-export type TokenSource = 'secure_storage' | 'cli' | null;
+export type TokenSource = 'secure_storage' | 'cli' | 'emdash_oauth' | 'device_flow' | null;
 
 export interface GitHubConnectionService {
   getToken(): Promise<string | null>;
   getTokenSource(): Promise<TokenSource>;
-  getStatus(): Promise<{
+  getStatus(options?: GitHubStatusOptions): Promise<{
     authenticated: boolean;
     user: GitHubUser | null;
     tokenSource: TokenSource;
@@ -51,7 +51,7 @@ export interface GitHubConnectionService {
   getUserInfo(token: string): Promise<GitHubUser | null>;
   startOAuthFlow(authServerBaseUrl: string): Promise<AuthResult>;
   startDeviceFlowAuth(): Promise<DeviceCodeResult>;
-  storeToken(token: string): Promise<void>;
+  storeToken(token: string, source?: Exclude<TokenSource, null>): Promise<void>;
   cancelAuth(): void;
   logout(): Promise<void>;
 }
@@ -78,7 +78,12 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
   }>(5 * 60 * 1000);
 
   private parseTokenSource(raw: unknown): Exclude<TokenSource, null> | null {
-    return raw === 'cli' || raw === 'secure_storage' ? raw : null;
+    return raw === 'cli' ||
+      raw === 'secure_storage' ||
+      raw === 'emdash_oauth' ||
+      raw === 'device_flow'
+      ? raw
+      : null;
   }
 
   private async getStoredTokenSource(): Promise<Exclude<TokenSource, null> | null> {
@@ -124,6 +129,11 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
 
   private resolveTokenRecord(): Promise<{ token: string | null; source: TokenSource }> {
     return this._tokenRecordCache.get(() => this._doResolveTokenRecord());
+  }
+
+  private async forceRefreshTokenRecord(): Promise<{ token: string | null; source: TokenSource }> {
+    this._invalidateTokenCache();
+    return this.resolveTokenRecord();
   }
 
   private async _doResolveTokenRecord(): Promise<{ token: string | null; source: TokenSource }> {
@@ -177,12 +187,14 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
     return source ?? 'secure_storage';
   }
 
-  async getStatus(): Promise<{
+  async getStatus(options: GitHubStatusOptions = {}): Promise<{
     authenticated: boolean;
     user: GitHubUser | null;
     tokenSource: TokenSource;
   }> {
-    const { token, source } = await this.resolveTokenRecord();
+    const { token, source } = options.refresh
+      ? await this.forceRefreshTokenRecord()
+      : await this.resolveTokenRecord();
     if (!token) {
       return { authenticated: false, user: null, tokenSource: null };
     }
@@ -236,7 +248,7 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
         return { success: false, error: 'No access token in response' };
       }
 
-      await this.storeToken(accessToken);
+      await this.storeToken(accessToken, 'emdash_oauth');
       const user = await this.getUserInfo(accessToken);
       return { success: true, token: accessToken, user: user || undefined };
     } catch (error) {
@@ -277,7 +289,7 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
       const result = await Promise.race([authPromise, cancelPromise]);
       const token = result.token;
 
-      await this.storeToken(token);
+      await this.storeToken(token, 'device_flow');
 
       const user = await this.getUserInfo(token);
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -129,7 +129,9 @@ void app.whenReady().then(async () => {
     log.warn('Failed to load account session token:', e);
   });
 
-  providerTokenRegistry.register('github', (token) => githubConnectionService.storeToken(token));
+  providerTokenRegistry.register('github', (token) =>
+    githubConnectionService.storeToken(token, 'emdash_oauth')
+  );
 
   registerRPCRouter(rpcRouter, ipcMain);
 

--- a/src/renderer/app/modal-registry.ts
+++ b/src/renderer/app/modal-registry.ts
@@ -5,6 +5,7 @@ import { McpModal } from '@renderer/features/mcp/components/McpModal';
 import { AddProjectModal } from '@renderer/features/projects/components/add-project-modal/add-project-modal';
 import { ProjectConfigImportModal } from '@renderer/features/projects/components/settings-view/project-config-import-modal';
 import { ShareProjectConfigModal } from '@renderer/features/projects/components/settings-view/share-project-config-modal';
+import { GithubConnectModal } from '@renderer/features/settings/components/github-connect-modal';
 import { CreateSkillModal } from '@renderer/features/skills/components/CreateSkillModal';
 import { AddRemoteModal } from '@renderer/features/tasks/add-remote-modal';
 import { CreateConversationModal } from '@renderer/features/tasks/conversations/create-conversation-modal';
@@ -56,6 +57,7 @@ export const modalRegistry = {
   shareProjectConfigModal: createModal(ShareProjectConfigModal, { size: 'md' }),
   projectConfigImportModal: createModal(ProjectConfigImportModal, { size: 'md' }),
   integrationSetupModal: createModal(IntegrationSetupModal, { size: 'md' }),
+  githubConnectModal: createModal(GithubConnectModal, { size: 'md' }),
   addRemoteModal: createModal(AddRemoteModal),
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
 } satisfies Record<string, ModalRegistryEntry<any, any>>;

--- a/src/renderer/features/onboarding/sign-in-step.tsx
+++ b/src/renderer/features/onboarding/sign-in-step.tsx
@@ -1,13 +1,16 @@
-import { CheckCircle, Github, LogIn, User } from 'lucide-react';
+import { AlertCircle, CheckCircle, Github, LogIn, User } from 'lucide-react';
 import { useRef, useState } from 'react';
 import { useAccountSession, useAccountSignIn } from '@renderer/lib/hooks/useAccount';
+import { useGithubContext } from '@renderer/lib/providers/github-context-provider';
 import { Button } from '@renderer/lib/ui/button';
 
 export function SignInStep({ onComplete }: { onComplete: () => void }) {
   const { data: session, isLoading: sessionLoading } = useAccountSession();
+  const { authenticated: githubAuthenticated, tokenSource } = useGithubContext();
   const signInMutation = useAccountSignIn();
   const skippedSignInRef = useRef(false);
   const [error, setError] = useState<string | null>(null);
+  const isUsingGhCli = githubAuthenticated && tokenSource === 'cli';
 
   const handleSignIn = async () => {
     skippedSignInRef.current = false;
@@ -80,20 +83,25 @@ export function SignInStep({ onComplete }: { onComplete: () => void }) {
       <div className="flex flex-col items-center justify-center gap-6">
         <Github className="h-10 w-10" absoluteStrokeWidth strokeWidth={1.5} />
         <div className="flex flex-col items-center justify-center gap-2">
-          <h1 className="text-xl text-center">Connect your GitHub account to Emdash</h1>
+          <h1 className="text-xl text-center">Connect GitHub</h1>
           <p className="text-md text-foreground-muted text-center">
-            This will allow you to work with your GitHub repositories in Emdash
+            Emdash uses GitHub for git operations, pull requests and issues.
           </p>
         </div>
       </div>
-      {error && <p className="text-sm text-destructive text-center">{error}</p>}
       <div className="flex flex-col w-full gap-2">
         <Button size={'lg'} onClick={handleSignIn} disabled={signInMutation.isPending}>
           <LogIn className="h-4 w-4" />
-          {signInMutation.isPending ? 'Signing in...' : 'Sign in with GitHub'}
+          {signInMutation.isPending ? 'Signing in…' : 'Sign in with GitHub'}
         </Button>
-        <Button variant="ghost" onClick={handleSkip}>
-          Skip
+        {error && (
+          <div className="flex items-start gap-1.5 rounded-md bg-destructive/10 px-2.5 py-2 text-xs text-destructive">
+            <AlertCircle className="mt-px h-3.5 w-3.5 shrink-0" />
+            <span>{error}</span>
+          </div>
+        )}
+        <Button size={'lg'} variant="outline" onClick={handleSkip}>
+          {isUsingGhCli ? 'Continue with GitHub CLI' : 'Skip for now'}
         </Button>
       </div>
     </div>

--- a/src/renderer/features/settings/components/IntegrationsCard.tsx
+++ b/src/renderer/features/settings/components/IntegrationsCard.tsx
@@ -1,5 +1,5 @@
-import { Check, Loader2, Plus } from 'lucide-react';
-import React, { useEffect } from 'react';
+import { Check, Loader2, Plus, RefreshCw } from 'lucide-react';
+import React, { useEffect, useState } from 'react';
 import asanaSvg from '@/assets/images/Asana.svg?raw';
 import featurebaseSvg from '@/assets/images/Featurebase.svg?raw';
 import forgejoSvg from '@/assets/images/Forgejo.svg?raw';
@@ -9,6 +9,7 @@ import jiraSvg from '@/assets/images/Jira.svg?raw';
 import linearSvg from '@/assets/images/Linear.svg?raw';
 import plainSvg from '@/assets/images/Plain.svg?raw';
 import { useIntegrationsContext } from '@renderer/features/integrations/integrations-provider';
+import { useToast } from '@renderer/lib/hooks/use-toast';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { useGithubContext } from '@renderer/lib/providers/github-context-provider';
@@ -34,17 +35,40 @@ const SvgLogo = ({ raw }: { raw: string }) => {
   );
 };
 
+function githubAuthSourceLabel(tokenSource: string | null): string {
+  switch (tokenSource) {
+    case 'cli':
+      return 'GitHub CLI';
+    case 'emdash_oauth':
+      return 'OAuth';
+    case 'device_flow':
+      return 'device flow';
+    case 'secure_storage':
+      return 'saved token';
+    default:
+      return 'GitHub';
+  }
+}
+
+type IntegrationCardItem = {
+  id: string;
+  name: string;
+  description: string;
+  logoSvg: string;
+  avatarUrl?: string;
+  connected: boolean;
+  loading: boolean;
+  onConnect?: () => void;
+  onCancel?: () => void;
+  onDisconnect?: () => void | Promise<void>;
+  rightAction?: React.ReactNode;
+  disabledTooltip?: string;
+};
+
 const IntegrationsCard: React.FC = () => {
-  const {
-    authenticated,
-    isLoading,
-    githubLoading,
-    handleGithubConnect,
-    cancelGithubConnect,
-    logout,
-    tokenSource,
-    checkStatus,
-  } = useGithubContext();
+  const { authenticated, user, isLoading, logout, tokenSource, checkStatus } = useGithubContext();
+  const { toast } = useToast();
+  const [githubCliRefreshing, setGithubCliRefreshing] = useState(false);
   const {
     connectionStatus,
     isLinearConnected,
@@ -71,9 +95,16 @@ const IntegrationsCard: React.FC = () => {
   } = useIntegrationsContext();
 
   const showIntegrationSetup = useShowModal('integrationSetupModal');
+  const showGithubConnect = useShowModal('githubConnectModal');
   const showConfirmDisconnect = useShowModal('confirmActionModal');
 
-  const isCliManaged = authenticated && tokenSource === 'cli';
+  const isGithubCliConnected = authenticated && tokenSource === 'cli';
+  const isGithubStoredTokenConnected = authenticated && tokenSource !== 'cli';
+  const githubAuthSource = githubAuthSourceLabel(tokenSource);
+  const githubDescription =
+    authenticated && user
+      ? `@${user.login} via ${githubAuthSource}`
+      : 'Connect your GitHub repositories';
 
   useEffect(() => {
     void checkStatus();
@@ -100,20 +131,77 @@ const IntegrationsCard: React.FC = () => {
     });
   };
 
-  const integrations = [
+  const refreshGithubCliStatus = async () => {
+    setGithubCliRefreshing(true);
+    try {
+      const status = await checkStatus({ refresh: true });
+      if (status.authenticated && status.tokenSource === 'cli') {
+        toast({
+          title: 'GitHub CLI is still authenticated',
+          description: status.user
+            ? `Run gh auth logout to disconnect @${status.user.login}.`
+            : 'Run gh auth logout to disconnect.',
+        });
+      } else {
+        toast({
+          title: 'GitHub CLI disconnected',
+          description: 'Emdash no longer has access to GitHub',
+        });
+      }
+    } finally {
+      setGithubCliRefreshing(false);
+    }
+  };
+
+  const githubAction = isGithubCliConnected ? (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger>
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            disabled={githubCliRefreshing}
+            onClick={() => void refreshGithubCliStatus()}
+            aria-label="Refresh GitHub CLI status"
+          >
+            {githubCliRefreshing ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <RefreshCw className="h-4 w-4" />
+            )}
+          </Button>
+        </TooltipTrigger>
+        <TooltipContent side="top">
+          <p className="text-xs">Run `gh auth logout`, then refresh</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  ) : isGithubStoredTokenConnected ? (
+    <Button
+      type="button"
+      variant="outline"
+      size="icon"
+      className="h-8 w-8 shrink-0"
+      onClick={() => confirmDisconnect({ name: 'GitHub', onDisconnect: logout })}
+      aria-label="Disconnect GitHub"
+    >
+      <Check className="h-4 w-4 text-emerald-600 dark:text-emerald-400" />
+    </Button>
+  ) : undefined;
+
+  const integrations: IntegrationCardItem[] = [
     {
       id: 'github',
       name: 'GitHub',
-      description: 'Connect your repositories',
+      description: githubDescription,
       logoSvg: githubSvg,
+      avatarUrl: authenticated ? user?.avatar_url : undefined,
       connected: authenticated,
-      loading: isLoading || githubLoading,
-      onConnect: handleGithubConnect,
-      onCancel: cancelGithubConnect,
-      onDisconnect: () => confirmDisconnect({ name: 'GitHub', onDisconnect: logout }),
-      disabledTooltip: isCliManaged
-        ? 'Run `gh auth logout` in your terminal to disconnect'
-        : undefined,
+      loading: isLoading,
+      onConnect: () => showGithubConnect({}),
+      rightAction: githubAction,
     },
     {
       id: 'linear',
@@ -243,11 +331,13 @@ const IntegrationsCard: React.FC = () => {
             <div className="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg bg-muted/50">
               <SvgLogo raw={integration.logoSvg} />
             </div>
-            <div className="flex flex-1 flex-col gap-0.5">
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5">
               <h3 className="text-sm font-medium text-foreground">{integration.name}</h3>
               <p className="text-sm text-muted-foreground">{integration.description}</p>
             </div>
-            {integration.connected ? (
+            {integration.rightAction ? (
+              integration.rightAction
+            ) : integration.connected ? (
               integration.disabledTooltip ? (
                 <TooltipProvider>
                   <Tooltip>

--- a/src/renderer/features/settings/components/IntegrationsCard.tsx
+++ b/src/renderer/features/settings/components/IntegrationsCard.tsx
@@ -55,7 +55,6 @@ type IntegrationCardItem = {
   name: string;
   description: string;
   logoSvg: string;
-  avatarUrl?: string;
   connected: boolean;
   loading: boolean;
   onConnect?: () => void;
@@ -197,7 +196,6 @@ const IntegrationsCard: React.FC = () => {
       name: 'GitHub',
       description: githubDescription,
       logoSvg: githubSvg,
-      avatarUrl: authenticated ? user?.avatar_url : undefined,
       connected: authenticated,
       loading: isLoading,
       onConnect: () => showGithubConnect({}),

--- a/src/renderer/features/settings/components/github-connect-modal.tsx
+++ b/src/renderer/features/settings/components/github-connect-modal.tsx
@@ -1,0 +1,150 @@
+import { useQueryClient } from '@tanstack/react-query';
+import { AlertCircle, Github, Loader2, Terminal } from 'lucide-react';
+import { useState } from 'react';
+import { useToast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
+import { useGithubContext } from '@renderer/lib/providers/github-context-provider';
+import { Button } from '@renderer/lib/ui/button';
+import {
+  DialogContentArea,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@renderer/lib/ui/dialog';
+
+const ISSUE_CONNECTION_STATUS_QUERY_KEY = ['issues:connection-status'] as const;
+
+type MethodError = { method: 'oauth' | 'cli'; message: string } | null;
+
+export function GithubConnectModal({ onSuccess, onClose }: BaseModalProps<void>) {
+  const { toast } = useToast();
+  const queryClient = useQueryClient();
+  const { checkStatus } = useGithubContext();
+  const [oauthLoading, setOauthLoading] = useState(false);
+  const [cliLoading, setCliLoading] = useState(false);
+  const [error, setError] = useState<MethodError>(null);
+
+  const anyLoading = oauthLoading || cliLoading;
+
+  const connectOAuth = async () => {
+    setError(null);
+    setOauthLoading(true);
+    try {
+      const result = await rpc.github.connectOAuth();
+      if (!result.success) {
+        setError({
+          method: 'oauth',
+          message: result.error ?? 'Connection failed. Please try again.',
+        });
+        return;
+      }
+
+      await checkStatus();
+      void queryClient.invalidateQueries({ queryKey: ISSUE_CONNECTION_STATUS_QUERY_KEY });
+      toast({
+        title: 'Connected to GitHub',
+        description: result.user ? `Signed in as ${result.user.login}` : undefined,
+      });
+      onSuccess();
+    } finally {
+      setOauthLoading(false);
+    }
+  };
+
+  const connectCli = async () => {
+    setError(null);
+    setCliLoading(true);
+    try {
+      const result = await rpc.github.connectCli();
+      if (!result.success) {
+        setError({
+          method: 'cli',
+          message: result.error ?? 'No GitHub CLI session found. Run gh auth login first.',
+        });
+        return;
+      }
+
+      await checkStatus();
+      void queryClient.invalidateQueries({ queryKey: ISSUE_CONNECTION_STATUS_QUERY_KEY });
+      toast({
+        title: 'GitHub CLI detected',
+        description: result.user ? `Using @${result.user.login} via GitHub CLI.` : undefined,
+      });
+      onSuccess();
+    } finally {
+      setCliLoading(false);
+    }
+  };
+
+  return (
+    <>
+      <DialogHeader>
+        <DialogTitle>Connect GitHub</DialogTitle>
+      </DialogHeader>
+      <DialogContentArea className="gap-2">
+        <div className="rounded-lg border border-border p-3">
+          <div className="flex items-center gap-3">
+            <Github className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-medium text-foreground">GitHub OAuth</h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">Sign in with your browser</p>
+            </div>
+            <Button onClick={() => void connectOAuth()} disabled={anyLoading}>
+              {oauthLoading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Connecting…
+                </>
+              ) : (
+                'Connect'
+              )}
+            </Button>
+          </div>
+          {error?.method === 'oauth' && <InlineError message={error.message} />}
+        </div>
+
+        <div className="rounded-lg border border-border p-3">
+          <div className="flex items-center gap-3">
+            <Terminal className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <div className="min-w-0 flex-1">
+              <h3 className="text-sm font-medium text-foreground">GitHub CLI</h3>
+              <p className="mt-0.5 text-xs text-muted-foreground">
+                Run{' '}
+                <code className="rounded bg-background-1 px-1 py-0.5 font-mono text-[11px] text-foreground">
+                  gh auth login
+                </code>{' '}
+                in your terminal
+              </p>
+            </div>
+            <Button variant="outline" onClick={() => void connectCli()} disabled={anyLoading}>
+              {cliLoading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Checking…
+                </>
+              ) : (
+                'Detect'
+              )}
+            </Button>
+          </div>
+          {error?.method === 'cli' && <InlineError message={error.message} />}
+        </div>
+      </DialogContentArea>
+      <DialogFooter>
+        <Button variant="outline" onClick={onClose} disabled={anyLoading}>
+          Cancel
+        </Button>
+      </DialogFooter>
+    </>
+  );
+}
+
+function InlineError({ message }: { message: string }) {
+  return (
+    <div className="mt-2 flex items-start gap-1.5 rounded-md bg-destructive/10 px-2.5 py-2 text-xs text-destructive">
+      <AlertCircle className="mt-px h-3.5 w-3.5 shrink-0" />
+      <span>{message}</span>
+    </div>
+  );
+}

--- a/src/renderer/features/settings/components/github-connect-modal.tsx
+++ b/src/renderer/features/settings/components/github-connect-modal.tsx
@@ -52,24 +52,23 @@ export function GithubConnectModal({ onSuccess, onClose }: BaseModalProps<void>)
     }
   };
 
-  const connectCli = async () => {
+  const refreshCliAuth = async () => {
     setError(null);
     setCliLoading(true);
     try {
-      const result = await rpc.github.connectCli();
-      if (!result.success) {
+      const status = await checkStatus({ refresh: true });
+      if (!status.authenticated || status.tokenSource !== 'cli') {
         setError({
           method: 'cli',
-          message: result.error ?? 'No GitHub CLI session found. Run gh auth login first.',
+          message: 'No GitHub CLI session found. Run gh auth login first.',
         });
         return;
       }
 
-      await checkStatus();
       void queryClient.invalidateQueries({ queryKey: ISSUE_CONNECTION_STATUS_QUERY_KEY });
       toast({
         title: 'GitHub CLI detected',
-        description: result.user ? `Using @${result.user.login} via GitHub CLI.` : undefined,
+        description: status.user ? `Using @${status.user.login} via GitHub CLI.` : undefined,
       });
       onSuccess();
     } finally {
@@ -117,14 +116,14 @@ export function GithubConnectModal({ onSuccess, onClose }: BaseModalProps<void>)
                 in your terminal
               </p>
             </div>
-            <Button variant="outline" onClick={() => void connectCli()} disabled={anyLoading}>
+            <Button variant="outline" onClick={() => void refreshCliAuth()} disabled={anyLoading}>
               {cliLoading ? (
                 <>
                   <Loader2 className="h-4 w-4 animate-spin" />
                   Checking…
                 </>
               ) : (
-                'Detect'
+                'Refresh'
               )}
             </Button>
           </div>

--- a/src/renderer/lib/providers/github-context-provider.tsx
+++ b/src/renderer/lib/providers/github-context-provider.tsx
@@ -7,6 +7,7 @@ import {
 } from '@shared/events/githubEvents';
 import type {
   GitHubAuthResponse,
+  GitHubStatusOptions,
   GitHubStatusResponse,
   GitHubTokenSource,
   GitHubUser,
@@ -30,7 +31,7 @@ type GithubContextValue = {
   cancelGithubConnect: () => void;
   login: () => Promise<GitHubAuthResponse>;
   logout: () => Promise<void>;
-  checkStatus: () => Promise<GitHubStatusResponse>;
+  checkStatus: (options?: GitHubStatusOptions) => Promise<GitHubStatusResponse>;
 };
 
 const GITHUB_STATUS_KEY = ['github:status'] as const;
@@ -93,13 +94,16 @@ export function GithubContextProvider({ children }: { children: React.ReactNode 
 
   const isLoading = isFetching || loginMutation.isPending || logoutMutation.isPending;
 
-  const checkStatus = useCallback(async () => {
-    return queryClient.fetchQuery<GitHubStatusResponse>({
-      queryKey: GITHUB_STATUS_KEY,
-      queryFn: () => rpc.github.getStatus(),
-      staleTime: 0,
-    });
-  }, [queryClient]);
+  const checkStatus = useCallback(
+    async (options?: GitHubStatusOptions) => {
+      return queryClient.fetchQuery<GitHubStatusResponse>({
+        queryKey: GITHUB_STATUS_KEY,
+        queryFn: () => rpc.github.getStatus(options),
+        staleTime: 0,
+      });
+    },
+    [queryClient]
+  );
 
   const login = useCallback(() => loginMutation.mutateAsync(), [loginMutation]);
 

--- a/src/renderer/lib/providers/github-context-provider.tsx
+++ b/src/renderer/lib/providers/github-context-provider.tsx
@@ -35,6 +35,7 @@ type GithubContextValue = {
 };
 
 const GITHUB_STATUS_KEY = ['github:status'] as const;
+const GITHUB_STATUS_REFRESH_KEY = [...GITHUB_STATUS_KEY, 'refresh'] as const;
 const ISSUE_CONNECTION_STATUS_QUERY_KEY = ['issues:connection-status'] as const;
 
 const GithubContext = createContext<GithubContextValue | null>(null);
@@ -96,9 +97,19 @@ export function GithubContextProvider({ children }: { children: React.ReactNode 
 
   const checkStatus = useCallback(
     async (options?: GitHubStatusOptions) => {
+      if (options?.refresh) {
+        const result = await queryClient.fetchQuery<GitHubStatusResponse>({
+          queryKey: GITHUB_STATUS_REFRESH_KEY,
+          queryFn: () => rpc.github.getStatus(options),
+          staleTime: 0,
+        });
+        queryClient.setQueryData(GITHUB_STATUS_KEY, result);
+        return result;
+      }
+
       return queryClient.fetchQuery<GitHubStatusResponse>({
         queryKey: GITHUB_STATUS_KEY,
-        queryFn: () => rpc.github.getStatus(options),
+        queryFn: () => rpc.github.getStatus(),
         staleTime: 0,
       });
     },

--- a/src/shared/github.ts
+++ b/src/shared/github.ts
@@ -6,12 +6,16 @@ export interface GitHubUser {
   avatar_url: string;
 }
 
-export type GitHubTokenSource = 'secure_storage' | 'cli' | null;
+export type GitHubTokenSource = 'secure_storage' | 'cli' | 'emdash_oauth' | 'device_flow' | null;
 
 export interface GitHubStatusResponse {
   authenticated: boolean;
   user: GitHubUser | null;
   tokenSource: GitHubTokenSource;
+}
+
+export interface GitHubStatusOptions {
+  refresh?: boolean;
 }
 
 export interface GitHubAuthResponse {


### PR DESCRIPTION
summary:
- add refreshable github auth status so cli auth changes can be detected immediately
- track github token source as oauth, device flow, cli or saved token (legacy)
- add a lean github connection chooser in settings for oauth vs github cli



<img width="490" height="406" alt="Screenshot 2026-05-17 at 13 49 39" src="https://github.com/user-attachments/assets/a165cec0-5c1d-400a-ab74-ea9f19a8ab3e" />
<img width="490" height="278" alt="Screenshot 2026-05-17 at 13 50 14" src="https://github.com/user-attachments/assets/eef97fa9-6e6d-403f-ae5b-f90b97a8606f" />
