### PR TITLE
feat(sidebar): add search trigger that opens the command palette

### DIFF
--- a/src/renderer/features/sidebar/left-sidebar.tsx
+++ b/src/renderer/features/sidebar/left-sidebar.tsx
@@ -20,6 +20,7 @@ import {
   SidebarMenu,
   SidebarMenuButton,
 } from './sidebar-primitives';
+import { SidebarSearchTrigger } from './sidebar-search-trigger';
 import { SidebarSpace } from './sidebar-space';
 import { SidebarVirtualList } from './sidebar-virtual-list';
 import { UpdateSection } from './update-section';
@@ -53,6 +54,7 @@ export const LeftSidebar: React.FC = observer(function LeftSidebar() {
       <SidebarSpace />
       <SidebarContainer className="w-full border-r-0 flex-1 min-h-0">
         <SidebarContent className="flex flex-col">
+          <SidebarSearchTrigger />
           <SidebarPinnedTaskList />
           <SidebarGroup className="mb-0 min-h-0 flex-1 flex flex-col">
             <ProjectsGroupLabel />

--- a/src/renderer/features/sidebar/sidebar-search-trigger.tsx
+++ b/src/renderer/features/sidebar/sidebar-search-trigger.tsx
@@ -1,11 +1,11 @@
 import { Search } from 'lucide-react';
-import { useObserver } from 'mobx-react-lite';
+import { observer } from 'mobx-react-lite';
 import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-selectors';
 import { useParams, useWorkspaceSlots } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { ShortcutHint } from '@renderer/lib/ui/shortcut-hint';
 
-export function SidebarSearchTrigger() {
+export const SidebarSearchTrigger = observer(function SidebarSearchTrigger() {
   const showCommandPalette = useShowModal('commandPaletteModal');
   const { currentView } = useWorkspaceSlots();
   const { params: taskParams } = useParams('task');
@@ -19,10 +19,10 @@ export function SidebarSearchTrigger() {
         : undefined;
   const currentTaskId = currentView === 'task' ? taskParams.taskId : undefined;
 
-  const currentWorkspaceId = useObserver(() => {
-    if (!currentProjectId || !currentTaskId) return undefined;
-    return getRegisteredTaskData(currentProjectId, currentTaskId)?.workspaceId ?? undefined;
-  });
+  const currentWorkspaceId =
+    currentProjectId && currentTaskId
+      ? getRegisteredTaskData(currentProjectId, currentTaskId)?.workspaceId
+      : undefined;
 
   return (
     <div className="px-3 pt-3 pb-2">
@@ -44,4 +44,4 @@ export function SidebarSearchTrigger() {
       </button>
     </div>
   );
-}
+});

--- a/src/renderer/features/sidebar/sidebar-search-trigger.tsx
+++ b/src/renderer/features/sidebar/sidebar-search-trigger.tsx
@@ -1,0 +1,47 @@
+import { Search } from 'lucide-react';
+import { useObserver } from 'mobx-react-lite';
+import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-selectors';
+import { useParams, useWorkspaceSlots } from '@renderer/lib/layout/navigation-provider';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { ShortcutHint } from '@renderer/lib/ui/shortcut-hint';
+
+export function SidebarSearchTrigger() {
+  const showCommandPalette = useShowModal('commandPaletteModal');
+  const { currentView } = useWorkspaceSlots();
+  const { params: taskParams } = useParams('task');
+  const { params: projectParams } = useParams('project');
+
+  const currentProjectId =
+    currentView === 'task'
+      ? taskParams.projectId
+      : currentView === 'project'
+        ? projectParams.projectId
+        : undefined;
+  const currentTaskId = currentView === 'task' ? taskParams.taskId : undefined;
+
+  const currentWorkspaceId = useObserver(() => {
+    if (!currentProjectId || !currentTaskId) return undefined;
+    return getRegisteredTaskData(currentProjectId, currentTaskId)?.workspaceId ?? undefined;
+  });
+
+  return (
+    <div className="px-3 pt-3 pb-2">
+      <button
+        type="button"
+        onClick={() =>
+          showCommandPalette({
+            projectId: currentProjectId,
+            taskId: currentTaskId,
+            workspaceId: currentWorkspaceId,
+          })
+        }
+        aria-label="Search"
+        className="flex h-7 w-full min-w-0 items-center gap-2 rounded-md pl-2 pr-1 text-sm text-foreground-passive transition-colors hover:bg-background-tertiary-2 hover:text-foreground-muted focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-primary/30"
+      >
+        <Search className="size-3.5 shrink-0" />
+        <span className="flex-1 truncate text-left">Search…</span>
+        <ShortcutHint settingsKey="commandPalette" />
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a click-through search input above the projects list in the left sidebar that opens the ⌘K command palette modal, pre-populated with the current project/task/workspace context.

## Test plan
- [x] Click the search input in the sidebar — command palette opens
- [x] Keyboard shortcut (⌘K) still works
- [x] ⌘K hint right-aligns with the "5m ago" timestamps in task rows