### PR TITLE
fix(terminals): focus new terminal from lifecycle drawer

### DIFF
--- a/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { Task } from '@shared/tasks';
+import type { TaskStore } from './task-store';
+import { WorkspaceViewModel } from './workspace-view-model';
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: { on: () => () => {} },
+  rpc: {
+    ssh: {
+      getConnections: async () => [],
+      getConnectionState: async () => ({}),
+      getHealthStates: async () => ({}),
+    },
+  },
+}));
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    projectId: 'project-1',
+    name: 'Task 1',
+    status: 'todo',
+    sourceBranch: undefined,
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    statusChangedAt: '2026-01-01T00:00:00.000Z',
+    isPinned: false,
+    prs: [],
+    conversations: {},
+    workspaceId: 'workspace-1',
+    ...overrides,
+  };
+}
+
+function makeViewModel(): WorkspaceViewModel {
+  return new WorkspaceViewModel({ data: makeTask() } as unknown as TaskStore);
+}
+
+describe('WorkspaceViewModel terminal drawer snapshot', () => {
+  it('persists and restores the active terminal drawer item', () => {
+    const source = makeViewModel();
+    source.setTerminalDrawerActiveItem({ kind: 'script', id: 'script-lifecycle-run' });
+
+    const restored = makeViewModel();
+    restored.restoreSnapshot(source.snapshot);
+
+    expect(restored.terminalDrawerActiveItem).toEqual({
+      kind: 'script',
+      id: 'script-lifecycle-run',
+    });
+
+    source.dispose();
+    restored.dispose();
+  });
+});

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -7,6 +7,7 @@ import { FileModelLifecycleStore } from '@renderer/features/tasks/editor/stores/
 import { DevServerStore } from '@renderer/features/tasks/stores/dev-server-store';
 import { TabGroupManagerStore } from '@renderer/features/tasks/tabs/tab-group-manager-store';
 import type { TabManagerStore } from '@renderer/features/tasks/tabs/tab-manager-store';
+import type { TerminalPanelActiveItem } from '@renderer/features/tasks/terminals/terminal-panel-selection';
 import { TerminalTabViewStore } from '@renderer/features/tasks/terminals/terminal-tab-view-store';
 import { type SidebarTab } from '@renderer/features/tasks/types';
 import { appState } from '@renderer/lib/stores/app-state';
@@ -28,6 +29,7 @@ export class WorkspaceViewModel implements ILifecycle {
   isSidebarCollapsed: boolean;
   focusedRegion: 'main' | 'bottom';
   isTerminalDrawerOpen: boolean;
+  terminalDrawerActiveItem: TerminalPanelActiveItem | undefined;
 
   /** Stable sub-stores — live for the full WorkspaceViewModel lifetime. */
   readonly tabGroupManager: TabGroupManagerStore;
@@ -74,6 +76,7 @@ export class WorkspaceViewModel implements ILifecycle {
     this.isSidebarCollapsed = true;
     this.focusedRegion = 'main';
     this.isTerminalDrawerOpen = false;
+    this.terminalDrawerActiveItem = undefined;
 
     const workspaceId = taskData.workspaceId ?? taskData.id;
 
@@ -384,6 +387,10 @@ export class WorkspaceViewModel implements ILifecycle {
     this.setFocusedRegion(open ? 'bottom' : 'main');
   }
 
+  setTerminalDrawerActiveItem(item: TerminalPanelActiveItem): void {
+    this.terminalDrawerActiveItem = item;
+  }
+
   /** Opens the terminal drawer and always creates a new terminal session. */
   async openNewTerminal(): Promise<string | undefined> {
     this.isTerminalDrawerOpen = true;
@@ -391,7 +398,10 @@ export class WorkspaceViewModel implements ILifecycle {
 
     const terminalId = await this._createDefaultTerminal();
     if (!terminalId) return undefined;
-    runInAction(() => this.terminalTabs.setActiveTab(terminalId));
+    runInAction(() => {
+      this.terminalTabs.setActiveTab(terminalId);
+      this.terminalDrawerActiveItem = { kind: 'terminal', id: terminalId };
+    });
     return terminalId;
   }
 

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -1,13 +1,16 @@
 import { computed, makeAutoObservable, observable, reaction, runInAction } from 'mobx';
 import type { Task } from '@shared/tasks';
-import type { DiffViewSnapshot, TaskViewSnapshot } from '@shared/view-state';
+import type {
+  DiffViewSnapshot,
+  TaskViewSnapshot,
+  TerminalDrawerActiveItem,
+} from '@shared/view-state';
 import { DiffTabLifecycleStore } from '@renderer/features/tasks/diff-view/stores/diff-tab-lifecycle-store';
 import { DiffViewStore } from '@renderer/features/tasks/diff-view/stores/diff-view-store';
 import { FileModelLifecycleStore } from '@renderer/features/tasks/editor/stores/file-model-lifecycle-store';
 import { DevServerStore } from '@renderer/features/tasks/stores/dev-server-store';
 import { TabGroupManagerStore } from '@renderer/features/tasks/tabs/tab-group-manager-store';
 import type { TabManagerStore } from '@renderer/features/tasks/tabs/tab-manager-store';
-import type { TerminalPanelActiveItem } from '@renderer/features/tasks/terminals/terminal-panel-selection';
 import { TerminalTabViewStore } from '@renderer/features/tasks/terminals/terminal-tab-view-store';
 import { type SidebarTab } from '@renderer/features/tasks/types';
 import { appState } from '@renderer/lib/stores/app-state';
@@ -29,7 +32,7 @@ export class WorkspaceViewModel implements ILifecycle {
   isSidebarCollapsed: boolean;
   focusedRegion: 'main' | 'bottom';
   isTerminalDrawerOpen: boolean;
-  terminalDrawerActiveItem: TerminalPanelActiveItem | undefined;
+  terminalDrawerActiveItem: TerminalDrawerActiveItem | undefined;
 
   /** Stable sub-stores — live for the full WorkspaceViewModel lifetime. */
   readonly tabGroupManager: TabGroupManagerStore;
@@ -189,6 +192,7 @@ export class WorkspaceViewModel implements ILifecycle {
       isSidebarCollapsed: this.isSidebarCollapsed,
       focusedRegion: this.focusedRegion,
       isTerminalDrawerOpen: this.isTerminalDrawerOpen,
+      terminalDrawerActiveItem: this.terminalDrawerActiveItem,
       tabGroups: this.tabGroupManager.snapshot,
       terminals: this.terminalTabs.snapshot,
       editor: this.editorView.snapshot,
@@ -209,6 +213,7 @@ export class WorkspaceViewModel implements ILifecycle {
     this.isSidebarCollapsed = savedSnapshot.isSidebarCollapsed ?? true;
     this.focusedRegion = savedSnapshot.focusedRegion === 'bottom' ? 'bottom' : 'main';
     this.isTerminalDrawerOpen = savedSnapshot.isTerminalDrawerOpen ?? false;
+    this.terminalDrawerActiveItem = savedSnapshot.terminalDrawerActiveItem;
 
     if (savedSnapshot.tabGroups) {
       // Current format: multi-group snapshot.
@@ -387,7 +392,7 @@ export class WorkspaceViewModel implements ILifecycle {
     this.setFocusedRegion(open ? 'bottom' : 'main');
   }
 
-  setTerminalDrawerActiveItem(item: TerminalPanelActiveItem): void {
+  setTerminalDrawerActiveItem(item: TerminalDrawerActiveItem): void {
     this.terminalDrawerActiveItem = item;
   }
 

--- a/src/renderer/features/tasks/terminals/terminal-panel-selection.test.ts
+++ b/src/renderer/features/tasks/terminals/terminal-panel-selection.test.ts
@@ -34,4 +34,26 @@ describe('resolveTerminalPanelActiveItem', () => {
       })
     ).toEqual({ kind: 'terminal', id: 'terminal-1' });
   });
+
+  it('falls back to the active terminal when no item is requested', () => {
+    expect(
+      resolveTerminalPanelActiveItem({
+        requestedActiveItem: undefined,
+        activeTerminalId: 'terminal-1',
+        terminalIds: ['terminal-1'],
+        scriptIds: ['script-lifecycle-run'],
+      })
+    ).toEqual({ kind: 'terminal', id: 'terminal-1' });
+  });
+
+  it('falls back to the first script when no item is requested and no active terminal exists', () => {
+    expect(
+      resolveTerminalPanelActiveItem({
+        requestedActiveItem: undefined,
+        activeTerminalId: undefined,
+        terminalIds: [],
+        scriptIds: ['script-lifecycle-run'],
+      })
+    ).toEqual({ kind: 'script', id: 'script-lifecycle-run' });
+  });
 });

--- a/src/renderer/features/tasks/terminals/terminal-panel-selection.test.ts
+++ b/src/renderer/features/tasks/terminals/terminal-panel-selection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import { resolveTerminalPanelActiveItem } from './terminal-panel-selection';
+
+describe('resolveTerminalPanelActiveItem', () => {
+  it('keeps a selected lifecycle script when it is still available', () => {
+    expect(
+      resolveTerminalPanelActiveItem({
+        requestedActiveItem: { kind: 'script', id: 'script-lifecycle-run' },
+        activeTerminalId: 'terminal-1',
+        terminalIds: ['terminal-1'],
+        scriptIds: ['script-lifecycle-run'],
+      })
+    ).toEqual({ kind: 'script', id: 'script-lifecycle-run' });
+  });
+
+  it('uses a requested terminal even when the drawer was previously showing a lifecycle script', () => {
+    expect(
+      resolveTerminalPanelActiveItem({
+        requestedActiveItem: { kind: 'terminal', id: 'terminal-2' },
+        activeTerminalId: 'terminal-2',
+        terminalIds: ['terminal-1', 'terminal-2'],
+        scriptIds: ['script-lifecycle-run'],
+      })
+    ).toEqual({ kind: 'terminal', id: 'terminal-2' });
+  });
+
+  it('falls back to the active terminal when the requested item is gone', () => {
+    expect(
+      resolveTerminalPanelActiveItem({
+        requestedActiveItem: { kind: 'script', id: 'script-lifecycle-setup' },
+        activeTerminalId: 'terminal-1',
+        terminalIds: ['terminal-1'],
+        scriptIds: ['script-lifecycle-run'],
+      })
+    ).toEqual({ kind: 'terminal', id: 'terminal-1' });
+  });
+});

--- a/src/renderer/features/tasks/terminals/terminal-panel-selection.ts
+++ b/src/renderer/features/tasks/terminals/terminal-panel-selection.ts
@@ -1,0 +1,34 @@
+export type TerminalPanelActiveItem =
+  | { kind: 'terminal'; id: string }
+  | { kind: 'script'; id: string };
+
+export function resolveTerminalPanelActiveItem({
+  requestedActiveItem,
+  activeTerminalId,
+  terminalIds,
+  scriptIds,
+}: {
+  requestedActiveItem: TerminalPanelActiveItem | undefined;
+  activeTerminalId: string | undefined;
+  terminalIds: readonly string[];
+  scriptIds: readonly string[];
+}): TerminalPanelActiveItem {
+  if (requestedActiveItem?.kind === 'terminal' && terminalIds.includes(requestedActiveItem.id)) {
+    return requestedActiveItem;
+  }
+
+  if (requestedActiveItem?.kind === 'script' && scriptIds.includes(requestedActiveItem.id)) {
+    return requestedActiveItem;
+  }
+
+  if (activeTerminalId && terminalIds.includes(activeTerminalId)) {
+    return { kind: 'terminal', id: activeTerminalId };
+  }
+
+  const firstScriptId = scriptIds[0];
+  if (firstScriptId) {
+    return { kind: 'script', id: firstScriptId };
+  }
+
+  return { kind: 'terminal', id: terminalIds[0] ?? '' };
+}

--- a/src/renderer/features/tasks/terminals/terminal-panel-selection.ts
+++ b/src/renderer/features/tasks/terminals/terminal-panel-selection.ts
@@ -1,6 +1,4 @@
-export type TerminalPanelActiveItem =
-  | { kind: 'terminal'; id: string }
-  | { kind: 'script'; id: string };
+import type { TerminalDrawerActiveItem } from '@shared/view-state';
 
 export function resolveTerminalPanelActiveItem({
   requestedActiveItem,
@@ -8,11 +6,11 @@ export function resolveTerminalPanelActiveItem({
   terminalIds,
   scriptIds,
 }: {
-  requestedActiveItem: TerminalPanelActiveItem | undefined;
+  requestedActiveItem: TerminalDrawerActiveItem | undefined;
   activeTerminalId: string | undefined;
   terminalIds: readonly string[];
   scriptIds: readonly string[];
-}): TerminalPanelActiveItem {
+}): TerminalDrawerActiveItem {
   if (requestedActiveItem?.kind === 'terminal' && terminalIds.includes(requestedActiveItem.id)) {
     return requestedActiveItem;
   }

--- a/src/renderer/features/tasks/terminals/terminal-panel.tsx
+++ b/src/renderer/features/tasks/terminals/terminal-panel.tsx
@@ -1,6 +1,6 @@
 import { Terminal } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useMemo, useState } from 'react';
+import { useState } from 'react';
 import {
   useTaskViewContext,
   useTerminals,
@@ -17,9 +17,8 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@renderer/
 import { ShortcutHint } from '@renderer/lib/ui/shortcut-hint';
 import { useIsActiveTask } from '../hooks/use-is-active-task';
 import { TerminalDrawerSidebar } from './terminal-drawer-sidebar';
+import { resolveTerminalPanelActiveItem } from './terminal-panel-selection';
 import { TerminalPtyContent } from './terminal-pty-content';
-
-type ActiveItem = { kind: 'terminal'; id: string } | { kind: 'script'; id: string };
 
 export const TerminalsPanel = observer(function TerminalsPanel() {
   const { projectId, taskId } = useTaskViewContext();
@@ -36,37 +35,30 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
   const autoFocus =
     isActive && taskView.isTerminalDrawerOpen && taskView.focusedRegion === 'bottom';
 
+  const terminalTabs = terminalTabView.tabs;
+  const lifecycleScriptTabs = lifecycleScriptsMgr?.tabs ?? [];
+
   // Unified active item — spans both terminals and scripts sections.
-  const [activeItem, setActiveItem] = useState<ActiveItem>(() => {
-    if (terminalTabView.activeTabId) {
-      return { kind: 'terminal', id: terminalTabView.activeTabId };
-    }
-    const firstScript = lifecycleScriptsMgr?.tabs[0];
-    if (firstScript) {
-      return { kind: 'script', id: firstScript.data.id };
-    }
-    return { kind: 'terminal', id: '' };
+  const activeItem = resolveTerminalPanelActiveItem({
+    requestedActiveItem: taskView.terminalDrawerActiveItem,
+    activeTerminalId: terminalTabView.activeTabId,
+    terminalIds: terminalTabs.map((terminal) => terminal.data.id),
+    scriptIds: lifecycleScriptTabs.map((script) => script.data.id),
   });
 
-  // Always derive the active terminal id from the MobX-authoritative store so that
-  // auto-selection (e.g. after removal) is reflected without stale local state.
-  const activeTerminalId =
-    activeItem.kind === 'terminal' ? (terminalTabView.activeTabId ?? activeItem.id) : undefined;
+  const activeTerminalId = activeItem.kind === 'terminal' ? activeItem.id : undefined;
 
   const activeSession =
     activeItem.kind === 'terminal'
       ? (terminalMgr.sessions.get(activeTerminalId ?? '') ?? null)
-      : (lifecycleScriptsMgr?.tabs.find((s) => s.data.id === activeItem.id)?.session ?? null);
+      : (lifecycleScriptTabs.find((s) => s.data.id === activeItem.id)?.session ?? null);
 
-  const allSessionIds = useMemo(
-    () => [
-      ...terminalTabView.tabs
-        .map((t) => terminalMgr.sessions.get(t.data.id)?.sessionId)
-        .filter((id): id is string => Boolean(id)),
-      ...(lifecycleScriptsMgr?.tabs ?? []).map((s) => s.session.sessionId),
-    ],
-    [terminalTabView.tabs, terminalMgr.sessions, lifecycleScriptsMgr?.tabs]
-  );
+  const allSessionIds = [
+    ...terminalTabs
+      .map((t) => terminalMgr.sessions.get(t.data.id)?.sessionId)
+      .filter((id): id is string => Boolean(id)),
+    ...lifecycleScriptTabs.map((s) => s.session.sessionId),
+  ];
 
   const handleHoverTerminal = (id: string) => {
     const session = terminalMgr.sessions.get(id);
@@ -78,15 +70,14 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
   useTabShortcuts(activeStore, { focused: isPanelFocused });
 
   const handleCreate = async () => {
-    const id = await taskView.openNewTerminal();
-    if (id) setActiveItem({ kind: 'terminal', id });
+    await taskView.openNewTerminal();
   };
 
   const handleRunScript = (id: string) => {
     const script = lifecycleScriptsMgr?.tabs.find((s) => s.data.id === id);
     if (!script || script.isRunning) return;
     lifecycleScriptsMgr?.setActiveTab(id);
-    setActiveItem({ kind: 'script', id });
+    taskView.setTerminalDrawerActiveItem({ kind: 'script', id });
     script.markRunning();
     void rpc.terminals
       .runLifecycleScript({
@@ -167,7 +158,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
           activeScriptId={activeItem.kind === 'script' ? activeItem.id : undefined}
           onSelectScript={(id) => {
             lifecycleScriptsMgr?.setActiveTab(id);
-            setActiveItem({ kind: 'script', id });
+            taskView.setTerminalDrawerActiveItem({ kind: 'script', id });
           }}
           onRunScript={handleRunScript}
           onStopScript={handleStopScript}
@@ -175,7 +166,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
           activeTerminalId={activeTerminalId}
           onSelectTerminal={(id) => {
             terminalTabView.setActiveTab(id);
-            setActiveItem({ kind: 'terminal', id });
+            taskView.setTerminalDrawerActiveItem({ kind: 'terminal', id });
           }}
           onAddTerminal={() => void handleCreate()}
           onRemoveTerminal={(id) => terminalTabView.removeTab(id)}

--- a/src/shared/view-state.ts
+++ b/src/shared/view-state.ts
@@ -47,6 +47,10 @@ export type DiffViewSnapshot = {
   prTab?: 'files' | 'commits' | 'checks';
 };
 
+export type TerminalDrawerActiveItem =
+  | { kind: 'terminal'; id: string }
+  | { kind: 'script'; id: string };
+
 export interface ActiveFile {
   path: string;
   /** Storage layer: how content is fetched.
@@ -73,6 +77,7 @@ export type TaskViewSnapshot = {
   isSidebarCollapsed?: boolean;
   focusedRegion: 'main' | 'bottom';
   isTerminalDrawerOpen?: boolean;
+  terminalDrawerActiveItem?: TerminalDrawerActiveItem;
   /** Takes precedence over tabManager when present. */
   tabGroups?: TabGroupsSnapshot;
   /** @deprecated Use tabGroups. Kept for migration from single-pane snapshots. */


### PR DESCRIPTION
previously cmd+shift+t created and activated the new regular terminal in the terminal store, but the drawer kept rendering the lifecycle terminal because its active item lived in local component state. the drawer active item now lives in WorkspaceViewModel so command driven terminal creation can switch the drawer to the newly created terminal