### PR TITLE
feat: split pasted env assignments

### DIFF
--- a/src/renderer/features/mcp/components/KeyValueSection.tsx
+++ b/src/renderer/features/mcp/components/KeyValueSection.tsx
@@ -78,7 +78,6 @@ export const KeyValueSection: React.FC<KeyValueSectionProps> = ({
                     : ''
                 }`}
                 placeholder={isCredential ? (isRequired ? 'Required' : 'Optional') : 'value'}
-                onPaste={(e) => handlePaste(i, e)}
               />
               <Button
                 type="button"

--- a/src/renderer/features/mcp/components/KeyValueSection.tsx
+++ b/src/renderer/features/mcp/components/KeyValueSection.tsx
@@ -1,5 +1,6 @@
 import { X } from 'lucide-react';
 import React from 'react';
+import { parseEnvAssignmentPaste, replaceEnvEntryWithPaste } from '@renderer/lib/env-paste';
 import { Button } from '@renderer/lib/ui/button';
 import { Field, FieldLabel } from '@renderer/lib/ui/field';
 import { Input } from '@renderer/lib/ui/input';
@@ -17,6 +18,7 @@ interface KeyValueSectionProps {
   addLabel: string;
   makeId: () => number;
   credentialKeys: Map<string, boolean>;
+  splitEnvPaste?: boolean;
 }
 
 export const KeyValueSection: React.FC<KeyValueSectionProps> = ({
@@ -26,7 +28,23 @@ export const KeyValueSection: React.FC<KeyValueSectionProps> = ({
   addLabel,
   makeId,
   credentialKeys,
+  splitEnvPaste = false,
 }) => {
+  const handlePaste = (index: number, e: React.ClipboardEvent<HTMLInputElement>) => {
+    if (!splitEnvPaste) return;
+
+    const pasted = parseEnvAssignmentPaste(e.clipboardData.getData('text'));
+    if (pasted.length === 0) return;
+
+    e.preventDefault();
+    const pastedEntries = pasted.map((entry, pastedIndex) => ({
+      id: pastedIndex === 0 ? entries[index].id : makeId(),
+      key: entry.key,
+      value: entry.value,
+    }));
+    onChange(replaceEnvEntryWithPaste(entries, index, pastedEntries));
+  };
+
   return (
     <Field>
       <FieldLabel>{label}</FieldLabel>
@@ -45,6 +63,7 @@ export const KeyValueSection: React.FC<KeyValueSectionProps> = ({
                 }}
                 className="h-8 w-1/2"
                 placeholder="KEY"
+                onPaste={(e) => handlePaste(i, e)}
               />
               <Input
                 value={entry.value}
@@ -59,6 +78,7 @@ export const KeyValueSection: React.FC<KeyValueSectionProps> = ({
                     : ''
                 }`}
                 placeholder={isCredential ? (isRequired ? 'Required' : 'Optional') : 'value'}
+                onPaste={(e) => handlePaste(i, e)}
               />
               <Button
                 type="button"

--- a/src/renderer/features/mcp/components/McpModal.tsx
+++ b/src/renderer/features/mcp/components/McpModal.tsx
@@ -234,6 +234,7 @@ export const McpModal: React.FC<McpModalProps> = ({
                 addLabel="+ Add env var"
                 makeId={makeId}
                 credentialKeys={credentialKeys}
+                splitEnvPaste
               />
             )}
           </form.Field>

--- a/src/renderer/features/settings/components/CustomCommandModal.tsx
+++ b/src/renderer/features/settings/components/CustomCommandModal.tsx
@@ -300,7 +300,6 @@ const CustomCommandModal: React.FC<CustomCommandModalProps> = ({ isOpen, onClose
                         onChange={(e) => setEnvEntry(i, { value: e.target.value })}
                         placeholder="value"
                         className="min-w-0 flex-1 font-mono text-sm"
-                        onPaste={(e) => handleEnvPaste(i, e)}
                       />
                       <Button
                         type="button"

--- a/src/renderer/features/settings/components/CustomCommandModal.tsx
+++ b/src/renderer/features/settings/components/CustomCommandModal.tsx
@@ -3,6 +3,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { AGENT_PROVIDERS, type AgentProviderDefinition } from '@shared/agent-provider-registry';
 import type { ProviderCustomConfig } from '@shared/app-settings';
 import { useProviderSettings } from '@renderer/features/settings/use-provider-settings';
+import { parseEnvAssignmentPaste, replaceEnvEntryWithPaste } from '@renderer/lib/env-paste';
 import { Button } from '@renderer/lib/ui/button';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@renderer/lib/ui/dialog';
@@ -95,6 +96,17 @@ const CustomCommandModal: React.FC<CustomCommandModalProps> = ({ isOpen, onClose
     setForm((prev) => ({
       ...prev,
       envEntries: prev.envEntries.filter((_, i) => i !== index),
+    }));
+  }, []);
+
+  const handleEnvPaste = useCallback((index: number, e: React.ClipboardEvent<HTMLInputElement>) => {
+    const pasted = parseEnvAssignmentPaste(e.clipboardData.getData('text'));
+    if (pasted.length === 0) return;
+
+    e.preventDefault();
+    setForm((prev) => ({
+      ...prev,
+      envEntries: replaceEnvEntryWithPaste(prev.envEntries, index, pasted),
     }));
   }, []);
 
@@ -281,12 +293,14 @@ const CustomCommandModal: React.FC<CustomCommandModalProps> = ({ isOpen, onClose
                         onChange={(e) => setEnvEntry(i, { key: e.target.value })}
                         placeholder="KEY"
                         className="min-w-0 flex-1 font-mono text-sm"
+                        onPaste={(e) => handleEnvPaste(i, e)}
                       />
                       <Input
                         value={entry.value}
                         onChange={(e) => setEnvEntry(i, { value: e.target.value })}
                         placeholder="value"
                         className="min-w-0 flex-1 font-mono text-sm"
+                        onPaste={(e) => handleEnvPaste(i, e)}
                       />
                       <Button
                         type="button"

--- a/src/renderer/lib/env-paste.test.ts
+++ b/src/renderer/lib/env-paste.test.ts
@@ -8,11 +8,15 @@ describe('parseEnvAssignmentPaste', () => {
         # ignored
         FOO=bar
         export API_KEY="secret=value"
+        WITH_COMMENT=value # comment
+        QUOTED_HASH="value # not a comment"
         EMPTY=
       `)
     ).toEqual([
       { key: 'FOO', value: 'bar' },
       { key: 'API_KEY', value: 'secret=value' },
+      { key: 'WITH_COMMENT', value: 'value' },
+      { key: 'QUOTED_HASH', value: 'value # not a comment' },
       { key: 'EMPTY', value: '' },
     ]);
   });

--- a/src/renderer/lib/env-paste.test.ts
+++ b/src/renderer/lib/env-paste.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { parseEnvAssignmentPaste, replaceEnvEntryWithPaste } from './env-paste';
+
+describe('parseEnvAssignmentPaste', () => {
+  it('parses dotenv-style assignments', () => {
+    expect(
+      parseEnvAssignmentPaste(`
+        # ignored
+        FOO=bar
+        export API_KEY="secret=value"
+        EMPTY=
+      `)
+    ).toEqual([
+      { key: 'FOO', value: 'bar' },
+      { key: 'API_KEY', value: 'secret=value' },
+      { key: 'EMPTY', value: '' },
+    ]);
+  });
+
+  it('rejects non-assignment paste content', () => {
+    expect(parseEnvAssignmentPaste('not an env file')).toEqual([]);
+    expect(parseEnvAssignmentPaste('FOO=bar\nnot an env file')).toEqual([]);
+  });
+});
+
+describe('replaceEnvEntryWithPaste', () => {
+  it('replaces the target row and preserves following rows', () => {
+    const entries = [
+      { key: 'KEEP', value: 'before' },
+      { key: '', value: '' },
+      { key: 'AFTER', value: 'after' },
+    ];
+
+    expect(
+      replaceEnvEntryWithPaste(entries, 1, [
+        { key: 'FOO', value: 'bar' },
+        { key: 'BAZ', value: 'qux' },
+      ])
+    ).toEqual([
+      { key: 'KEEP', value: 'before' },
+      { key: 'FOO', value: 'bar' },
+      { key: 'BAZ', value: 'qux' },
+      { key: 'AFTER', value: 'after' },
+    ]);
+  });
+});

--- a/src/renderer/lib/env-paste.ts
+++ b/src/renderer/lib/env-paste.ts
@@ -1,0 +1,48 @@
+export interface EnvPasteEntry {
+  key: string;
+  value: string;
+}
+
+const ENV_ASSIGNMENT_RE = /^(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$/;
+
+export function parseEnvAssignmentPaste(text: string): EnvPasteEntry[] {
+  const parsed: EnvPasteEntry[] = [];
+
+  for (const rawLine of text.split(/\r?\n/)) {
+    const line = rawLine.trim();
+    if (!line || line.startsWith('#')) continue;
+
+    const match = ENV_ASSIGNMENT_RE.exec(line);
+    if (!match) return [];
+
+    parsed.push({
+      key: match[1],
+      value: normalizeEnvValue(match[2]),
+    });
+  }
+
+  return parsed;
+}
+
+export function replaceEnvEntryWithPaste<T extends EnvPasteEntry>(
+  entries: readonly T[],
+  startIndex: number,
+  pasted: readonly T[]
+): T[] {
+  if (pasted.length === 0) return [...entries];
+
+  return [...entries.slice(0, startIndex), ...pasted, ...entries.slice(startIndex + 1)];
+}
+
+function normalizeEnvValue(value: string): string {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+  if (
+    trimmed.length >= 2 &&
+    (quote === '"' || quote === "'" || quote === '`') &&
+    trimmed[trimmed.length - 1] === quote
+  ) {
+    return trimmed.slice(1, -1);
+  }
+  return trimmed;
+}

--- a/src/renderer/lib/env-paste.ts
+++ b/src/renderer/lib/env-paste.ts
@@ -17,7 +17,7 @@ export function parseEnvAssignmentPaste(text: string): EnvPasteEntry[] {
 
     parsed.push({
       key: match[1],
-      value: normalizeEnvValue(match[2]),
+      value: normalizeEnvValue(stripInlineComment(match[2])),
     });
   }
 
@@ -32,6 +32,29 @@ export function replaceEnvEntryWithPaste<T extends EnvPasteEntry>(
   if (pasted.length === 0) return [...entries];
 
   return [...entries.slice(0, startIndex), ...pasted, ...entries.slice(startIndex + 1)];
+}
+
+function stripInlineComment(value: string): string {
+  let quote: string | undefined;
+
+  for (let i = 0; i < value.length; i++) {
+    const char = value[i];
+    if (quote) {
+      if (char === quote) quote = undefined;
+      continue;
+    }
+
+    if (char === '"' || char === "'" || char === '`') {
+      quote = char;
+      continue;
+    }
+
+    if (char === '#' && i > 0 && /\s/.test(value[i - 1])) {
+      return value.slice(0, i);
+    }
+  }
+
+  return value;
 }
 
 function normalizeEnvValue(value: string): string {


### PR DESCRIPTION
## Summary
- split pasted dotenv-style assignments into env key/value rows
- enable split paste for provider and MCP env fields
- add parser coverage

## Tests
- pnpm exec vitest run --project node src/renderer/lib/env-paste.test.ts
- pnpm exec eslint src/renderer/lib/env-paste.ts src/renderer/lib/env-paste.test.ts src/renderer/features/mcp/components/KeyValueSection.tsx src/renderer/features/mcp/components/McpModal.tsx src/renderer/features/settings/components/CustomCommandModal.tsx
- pnpm exec tsc --noEmit