### PR TITLE
ui: add issue selector affordances

### DIFF
--- a/src/renderer/features/tasks/components/issue-selector/inline-issue-selector.tsx
+++ b/src/renderer/features/tasks/components/issue-selector/inline-issue-selector.tsx
@@ -122,8 +122,8 @@ export const InlineIssueSelector = observer(function InlineIssueSelector({
         onValueChange={(v) => v && handleProviderChange(v as Issue['provider'])}
       >
         <SelectTrigger
-          showChevron={false}
-          className="h-6 gap-0 border-none bg-transparent px-1.5 shadow-none focus:ring-0"
+          aria-label="Select issue provider"
+          className="h-6 gap-1 border-none bg-transparent px-1.5 shadow-none focus:ring-0"
         >
           <ProviderLogo provider={issueProvider} className="h-3.5 w-3.5" />
         </SelectTrigger>

--- a/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
+++ b/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
@@ -174,8 +174,8 @@ export const IssueSelector = observer(function IssueSelector({
         }}
       >
         <SelectTrigger
-          showChevron={false}
-          className="h-6 gap-0 border-none bg-transparent px-1.5 shadow-none focus:ring-0"
+          aria-label="Select issue provider"
+          className="h-6 gap-1 border-none bg-transparent px-1.5 shadow-none focus:ring-0"
         >
           <ProviderLogo provider={issueProvider} className="h-3.5 w-3.5" />
         </SelectTrigger>

--- a/src/renderer/features/tasks/task-titlebar.tsx
+++ b/src/renderer/features/tasks/task-titlebar.tsx
@@ -138,13 +138,20 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
           </button>
           <span className="text-sm text-foreground-passive">/</span>
           <Popover>
-            <PopoverTrigger className="flex items-center gap-1 text-sm text-foreground-muted hover:text-foreground">
-              <span className="flex items-center gap-1.5 min-w-0">
-                <span className="truncate max-w-56">{taskDisplayName(taskStore)}</span>
-                <ConnectionStatusDot state={workspace.connectionState} />
-              </span>
-              <ChevronDown className="size-3.5 shrink-0" />
-            </PopoverTrigger>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <PopoverTrigger className="flex items-center gap-1 text-sm text-foreground-muted hover:text-foreground">
+                    <span className="flex items-center gap-1.5 min-w-0">
+                      <span className="truncate max-w-56">{taskDisplayName(taskStore)}</span>
+                      <ConnectionStatusDot state={workspace.connectionState} />
+                    </span>
+                    <ChevronDown className="size-3.5 shrink-0" />
+                  </PopoverTrigger>
+                }
+              />
+              <TooltipContent>Link to issue</TooltipContent>
+            </Tooltip>
             <PopoverContent align="start" className="w-96 p-4 flex flex-col gap-2">
               <div className="flex flex-col gap-1 w-full">
                 <MicroLabel className="text-foreground-passive items-center flex">Task</MicroLabel>


### PR DESCRIPTION
## Summary
- show a compact chevron on the issue provider selector when multiple trackers are configured
- add an accessible label for the icon-only provider selector
- add a `Link to issue` tooltip to the task header popover trigger

## Validation
- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm run test