### PR TITLE
fix: remote agent detection after install

### DIFF
--- a/src/main/core/dependencies/dependency-manager.test.ts
+++ b/src/main/core/dependencies/dependency-manager.test.ts
@@ -16,12 +16,18 @@ vi.mock('../ssh/ssh-connection-manager', () => ({
 }));
 
 function makeCtx(
-  handler: (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>
+  handler: (command: string, args: string[]) => Promise<{ stdout: string; stderr: string }>,
+  options: {
+    refreshShellEnv?: () => Promise<void>;
+  } = {}
 ): IExecutionContext {
   return {
     root: undefined,
     supportsLocalSpawn: false,
     exec: vi.fn().mockImplementation(handler),
+    refreshShellEnv: options.refreshShellEnv
+      ? vi.fn().mockImplementation(options.refreshShellEnv)
+      : undefined,
     execStreaming: vi.fn(),
     dispose: vi.fn(),
   } as unknown as IExecutionContext;
@@ -112,6 +118,35 @@ describe('DependencyManager install', () => {
 
     expect(result.success).toBe(true);
     if (result.success) expect(result.data.status).toBe('available');
+  });
+
+  it('refreshes cached shell environment after install before probing', async () => {
+    let shellEnvRefreshed = false;
+    const ctx = makeCtx(
+      async (command, args = []) => {
+        if (command === 'which' && args[0] === 'codex' && shellEnvRefreshed) {
+          return { stdout: '/home/user/.local/bin/codex\n', stderr: '' };
+        }
+        if (command === '/home/user/.local/bin/codex' && args[0] === '--version') {
+          return { stdout: 'codex-cli 1.2.3\n', stderr: '' };
+        }
+        throw new Error('missing');
+      },
+      {
+        refreshShellEnv: async () => {
+          shellEnvRefreshed = true;
+        },
+      }
+    );
+    const manager = new DependencyManager(ctx, {
+      emitEvents: false,
+      runInstallCommand: async () => ok<void>(),
+    });
+
+    const result = await manager.install('codex');
+
+    expect(result.success).toBe(true);
+    expect(ctx.refreshShellEnv).toHaveBeenCalled();
   });
 
   it('emits dependency updates with the SSH connection id', async () => {

--- a/src/main/core/dependencies/dependency-manager.ts
+++ b/src/main/core/dependencies/dependency-manager.ts
@@ -199,6 +199,8 @@ export class DependencyManager implements IInitializable {
       return err(installResult.error);
     }
 
+    await this.ctx.refreshShellEnv?.();
+
     const state = await this.probe(id);
     if (state.status !== 'available') {
       return err({ type: 'not-detected-after-install', id });

--- a/src/main/core/execution-context/github-auth-execution-context.ts
+++ b/src/main/core/execution-context/github-auth-execution-context.ts
@@ -21,6 +21,10 @@ export class GitHubAuthExecutionContext implements IExecutionContext {
     return this.inner.exec(command, args, opts);
   }
 
+  refreshShellEnv(): Promise<void> {
+    return this.inner.refreshShellEnv?.() ?? Promise.resolve();
+  }
+
   execStreaming(
     command: string,
     args: string[],

--- a/src/main/core/execution-context/ssh-execution-context.ts
+++ b/src/main/core/execution-context/ssh-execution-context.ts
@@ -98,6 +98,10 @@ export class SshExecutionContext implements IExecutionContext {
     });
   }
 
+  async refreshShellEnv(): Promise<void> {
+    await this.proxy.refreshRemoteShellProfile();
+  }
+
   async execStreaming(
     command: string,
     args: string[],

--- a/src/main/core/execution-context/types.ts
+++ b/src/main/core/execution-context/types.ts
@@ -28,6 +28,13 @@ export interface IExecutionContext {
   exec(command: string, args?: string[], opts?: ExecOptions): Promise<ExecResult>;
 
   /**
+   * Refresh any cached shell environment for this context. Installers often
+   * write shell startup files or install into paths that become visible only
+   * after recapturing the user's shell environment.
+   */
+  refreshShellEnv?(): Promise<void>;
+
+  /**
    * Run a command and stream stdout chunks to `onChunk`.
    * Return false from `onChunk` to abort the process early (resolves normally).
    * Passing `signal` rejects with an AbortError when the signal fires.

--- a/src/main/core/ssh/remote-shell-profile.test.ts
+++ b/src/main/core/ssh/remote-shell-profile.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildRemoteShellCommand,
   FALLBACK_REMOTE_SHELL_PROFILE,
+  includeRemoteUserBinDirs,
   normalizeRemoteShell,
   type RemoteShellProfile,
 } from './remote-shell-profile';
@@ -41,6 +42,18 @@ describe('remote shell profile command building', () => {
     expect(command).toContain("export PATH='\\''/task/bin:/usr/bin'\\''");
     expect(command.indexOf('/captured/bin')).toBeLessThan(command.indexOf('/task/bin'));
     expect(command).toContain("export FOO='\\''task'\\''; node --version");
+  });
+
+  it('adds ~/.local/bin to captured remote PATH', () => {
+    expect(
+      includeRemoteUserBinDirs({
+        HOME: '/root',
+        PATH: '/usr/local/bin:/usr/bin',
+      })
+    ).toEqual({
+      HOME: '/root',
+      PATH: '/root/.local/bin:/usr/local/bin:/usr/bin',
+    });
   });
 
   it('uses /bin/sh without login flags for the fallback profile', () => {

--- a/src/main/core/ssh/remote-shell-profile.ts
+++ b/src/main/core/ssh/remote-shell-profile.ts
@@ -67,6 +67,20 @@ export function buildRemoteShellCommand(
   )}`;
 }
 
+export function includeRemoteUserBinDirs(env: Record<string, string>): Record<string, string> {
+  const home = env.HOME?.replace(/\/+$/, '');
+  if (!home) return env;
+
+  const userBin = `${home}/.local/bin`;
+  const pathEntries = (env.PATH ?? '').split(':').filter(Boolean);
+  if (pathEntries.includes(userBin)) return env;
+
+  return {
+    ...env,
+    PATH: [userBin, ...pathEntries].join(':'),
+  };
+}
+
 export async function captureRemoteShellProfile(
   client: RemoteShellExecClient
 ): Promise<RemoteShellProfile> {
@@ -94,11 +108,11 @@ async function captureRemoteEnv(
       shell
     )} ${quoteShellArg('env')}`;
     const { stdout } = await execRaw(client, capture, CAPTURE_TIMEOUT_MS);
-    return parseRemoteEnvOutput(stdout);
+    return includeRemoteUserBinDirs(parseRemoteEnvOutput(stdout));
   } catch {
     try {
       const { stdout } = await execRaw(client, 'env', CAPTURE_TIMEOUT_MS);
-      return parseRemoteEnvOutput(stdout);
+      return includeRemoteUserBinDirs(parseRemoteEnvOutput(stdout));
     } catch {
       return {};
     }

--- a/src/main/core/ssh/ssh-client-proxy.test.ts
+++ b/src/main/core/ssh/ssh-client-proxy.test.ts
@@ -109,6 +109,38 @@ describe('SshClientProxy remote shell profile', () => {
     });
     expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(2);
   });
+
+  it('deduplicates get calls while a refresh is in flight', async () => {
+    let resolveRefresh!: (profile: { shell: string; env: Record<string, string> }) => void;
+    const refreshCapture = new Promise<{ shell: string; env: Record<string, string> }>(
+      (resolve) => {
+        resolveRefresh = resolve;
+      }
+    );
+    const client = {};
+    mocks.captureRemoteShellProfile.mockReturnValueOnce(refreshCapture);
+    const proxy = new SshClientProxy('ssh-1');
+    proxy.update(client as never);
+
+    const refresh = proxy.refreshRemoteShellProfile();
+    const concurrentGet = proxy.getRemoteShellProfile();
+    resolveRefresh({ shell: '/bin/zsh', env: { PATH: '/refreshed:/usr/bin' } });
+
+    await expect(refresh).resolves.toEqual({
+      shell: '/bin/zsh',
+      env: { PATH: '/refreshed:/usr/bin' },
+    });
+    await expect(concurrentGet).resolves.toEqual({
+      shell: '/bin/zsh',
+      env: { PATH: '/refreshed:/usr/bin' },
+    });
+    expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(1);
+    await expect(proxy.getRemoteShellProfile()).resolves.toEqual({
+      shell: '/bin/zsh',
+      env: { PATH: '/refreshed:/usr/bin' },
+    });
+    expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('SshClientProxy channel health reporting', () => {

--- a/src/main/core/ssh/ssh-client-proxy.test.ts
+++ b/src/main/core/ssh/ssh-client-proxy.test.ts
@@ -86,6 +86,29 @@ describe('SshClientProxy remote shell profile', () => {
     expect(profile).toEqual({ shell: '/bin/bash', env: { PATH: '/second' } });
     expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(2);
   });
+
+  it('recaptures the remote shell profile on explicit refresh', async () => {
+    const client = {};
+    mocks.captureRemoteShellProfile
+      .mockResolvedValueOnce({ shell: '/bin/zsh', env: { PATH: '/old' } })
+      .mockResolvedValueOnce({ shell: '/bin/zsh', env: { PATH: '/new:/usr/bin' } });
+    const proxy = new SshClientProxy('ssh-1');
+    proxy.update(client as never);
+
+    await expect(proxy.getRemoteShellProfile()).resolves.toEqual({
+      shell: '/bin/zsh',
+      env: { PATH: '/old' },
+    });
+    await expect(proxy.refreshRemoteShellProfile()).resolves.toEqual({
+      shell: '/bin/zsh',
+      env: { PATH: '/new:/usr/bin' },
+    });
+    await expect(proxy.getRemoteShellProfile()).resolves.toEqual({
+      shell: '/bin/zsh',
+      env: { PATH: '/new:/usr/bin' },
+    });
+    expect(mocks.captureRemoteShellProfile).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe('SshClientProxy channel health reporting', () => {

--- a/src/main/core/ssh/ssh-client-proxy.ts
+++ b/src/main/core/ssh/ssh-client-proxy.ts
@@ -60,12 +60,18 @@ export class SshClientProxy {
 
   async refreshRemoteShellProfile(): Promise<RemoteShellProfile> {
     const client = this.client;
-    this._remoteShellProfileState = { kind: 'empty' };
-    const profile = await captureRemoteShellProfile(this);
-    if (this._client === client) {
-      this._remoteShellProfileState = { kind: 'ready', client, profile };
-    }
-    return profile;
+    const promise = captureRemoteShellProfile(this).then((profile) => {
+      if (
+        this._client === client &&
+        this._remoteShellProfileState.kind === 'loading' &&
+        this._remoteShellProfileState.promise === promise
+      ) {
+        this._remoteShellProfileState = { kind: 'ready', client, profile };
+      }
+      return profile;
+    });
+    this._remoteShellProfileState = { kind: 'loading', client, promise };
+    return promise;
   }
 
   exec(command: string, callback: ClientCallback): void;

--- a/src/main/core/ssh/ssh-client-proxy.ts
+++ b/src/main/core/ssh/ssh-client-proxy.ts
@@ -58,6 +58,16 @@ export class SshClientProxy {
     return promise;
   }
 
+  async refreshRemoteShellProfile(): Promise<RemoteShellProfile> {
+    const client = this.client;
+    this._remoteShellProfileState = { kind: 'empty' };
+    const profile = await captureRemoteShellProfile(this);
+    if (this._client === client) {
+      this._remoteShellProfileState = { kind: 'ready', client, profile };
+    }
+    return profile;
+  }
+
   exec(command: string, callback: ClientCallback): void;
   exec(command: string, options: ExecOptions, callback: ClientCallback): void;
   exec(

--- a/src/renderer/lib/components/agent-selector/agent-selector-options.ts
+++ b/src/renderer/lib/components/agent-selector/agent-selector-options.ts
@@ -17,7 +17,8 @@ export interface AgentGroup {
 
 export function buildAgentGroups(
   installedAgents: string[],
-  assumedInstalledAgents: string[] = []
+  assumedInstalledAgents: string[] = [],
+  installingAgents: ReadonlySet<AgentProviderId> = new Set()
 ): AgentGroup[] {
   const installedSet = new Set(
     [...installedAgents, ...assumedInstalledAgents].filter((id) => id in agentConfig)
@@ -25,11 +26,11 @@ export function buildAgentGroups(
   const allAgentIds = Object.keys(agentConfig) as AgentProviderId[];
 
   const installedOptions: AgentOption[] = allAgentIds
-    .filter((id) => installedSet.has(id))
+    .filter((id) => installedSet.has(id) && !installingAgents.has(id))
     .map((id) => ({ value: id, label: agentConfig[id].name, agentId: id, disabled: false }));
 
   const notInstalledOptions: AgentOption[] = allAgentIds
-    .filter((id) => !installedSet.has(id))
+    .filter((id) => !installedSet.has(id) || installingAgents.has(id))
     .map((id) => ({ value: id, label: agentConfig[id].name, agentId: id, disabled: true }));
 
   return [

--- a/src/renderer/lib/components/agent-selector/agent-selector.test.ts
+++ b/src/renderer/lib/components/agent-selector/agent-selector.test.ts
@@ -31,6 +31,29 @@ describe('buildAgentGroups', () => {
     );
   });
 
+  it('keeps installing agents in the not-installed group until install resolves', () => {
+    const groups = buildAgentGroups(['codex', 'claude'], [], new Set(['claude']));
+
+    expect(groups.find((group) => group.value === 'installed')?.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ agentId: 'codex', disabled: false })])
+    );
+    expect(groups.find((group) => group.value === 'installed')?.items).not.toEqual(
+      expect.arrayContaining([expect.objectContaining({ agentId: 'claude' })])
+    );
+    expect(groups.find((group) => group.value === 'not-installed')?.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ agentId: 'claude', disabled: true })])
+    );
+  });
+
+  it('does not assume an installing selected agent is installed', () => {
+    const groups = buildAgentGroups([], ['claude'], new Set(['claude']));
+
+    expect(groups.find((group) => group.value === 'installed')?.items).toBeUndefined();
+    expect(groups.find((group) => group.value === 'not-installed')?.items).toEqual(
+      expect.arrayContaining([expect.objectContaining({ agentId: 'claude', disabled: true })])
+    );
+  });
+
   it('keeps the selected agent installed when dependency data is partial', () => {
     const assumedInstalledAgents = getAssumedInstalledAgents('codex', {
       claude: {

--- a/src/renderer/lib/components/agent-selector/use-agent-availability.ts
+++ b/src/renderer/lib/components/agent-selector/use-agent-availability.ts
@@ -34,18 +34,13 @@ export function useAgentAvailability({
     [value, dependencyData]
   );
 
-  const groups = useMemo(
-    () => buildAgentGroups(installedAgents, assumedInstalledAgents),
-    [installedAgents, assumedInstalledAgents]
-  );
   const installingAgents = new Set<AgentProviderId>();
-  for (const group of groups) {
-    for (const item of group.items) {
-      if (appState.dependencies.isInstalling(item.agentId, connectionId)) {
-        installingAgents.add(item.agentId);
-      }
+  for (const id of Object.keys(agentConfig) as AgentProviderId[]) {
+    if (appState.dependencies.isInstalling(id, connectionId)) {
+      installingAgents.add(id);
     }
   }
+  const groups = buildAgentGroups(installedAgents, assumedInstalledAgents, installingAgents);
 
   async function installAgent(agentId: AgentProviderId): Promise<void> {
     if (appState.dependencies.isInstalling(agentId, connectionId)) return;


### PR DESCRIPTION
- add remote $HOME/.local/bin to captured SSH shell profiles so per-user agent installs are detected
- refresh cached remote shell profiles after dependency installs before re probing
- keep installing agents in the not installed state until install detection fully resolves
