### PR TITLE
fix: prioritize path truncation in changes sidebar

### DIFF
--- a/src/renderer/features/tasks/diff-view/changes-panel/components/changes-list-item.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/changes-list-item.tsx
@@ -27,10 +27,16 @@ export const ChangesListItem = forwardRef<HTMLButtonElement, ChangesListItemProp
         ref={ref}
         {...props}
       >
-        <div className="flex items-center gap-1.5 min-w-0">
+        <div className="flex min-w-0 flex-1 items-center gap-1.5">
           <FileIcon filename={filename} size={12} />
-          <span className="text-sm truncate">{filename}</span>
-          {directory && <span className="text-xs text-foreground-muted truncate">{directory}</span>}
+          <span className="flex min-w-0 flex-1 items-baseline gap-1.5">
+            <span className="max-w-full shrink-0 truncate text-sm">{filename}</span>
+            {directory && (
+              <span className="min-w-0 shrink truncate text-xs text-foreground-muted">
+                {directory}
+              </span>
+            )}
+          </span>
         </div>
         <div
           className="flex shrink-0 items-center gap-1.5"


### PR DESCRIPTION
- adjusts changes sidebar file row layout so the directory path truncates before the filename
- keeps the path directly next to the filename when there is enough horizontal space
- allows the filename to truncate only once the path has collapsed under tight space