### PR TITLE
fix: create task from PR failing when branch already checked out in external worktree

### DIFF
--- a/src/main/core/projects/settings/sharing/project-settings-target-resolver.ts
+++ b/src/main/core/projects/settings/sharing/project-settings-target-resolver.ts
@@ -59,7 +59,7 @@ async function resolveTaskTarget(
   }
 
   if (!targetPath && task.taskBranch) {
-    targetPath = (await project.worktreeService.getWorktree(task.taskBranch)) ?? null;
+    targetPath = (await project.worktreeService.findBranchAnywhere(task.taskBranch)) ?? null;
   }
   if (!targetPath) return null;
   if (targetPath === project.repoPath) return null;

--- a/src/main/core/projects/settings/sharing/share-project-settings-to-config.test.ts
+++ b/src/main/core/projects/settings/sharing/share-project-settings-to-config.test.ts
@@ -331,15 +331,15 @@ describe('shareProjectSettingsToConfig', () => {
     });
   });
 
-  it('includes task worktrees from stored task state, not only active workspaces', async () => {
-    const getWorktree = vi.fn().mockResolvedValue('/repo/.emdash/worktrees/task-one');
+  it('includes task worktrees from git branch discovery, not only active workspaces', async () => {
+    const findBranchAnywhere = vi.fn().mockResolvedValue('/external/worktrees/task-one');
     const project = {
       projectId: 'project-1',
       repoPath: '/repo',
       fs: {},
       defaultWorkspaceType: { kind: 'local' },
       worktreeService: {
-        getWorktree,
+        findBranchAnywhere,
       },
     };
     mocks.select
@@ -372,10 +372,10 @@ describe('shareProjectSettingsToConfig', () => {
         type: 'task',
         taskId: 'task-1',
         label: 'Task One',
-        path: '/repo/.emdash/worktrees/task-one',
+        path: '/external/worktrees/task-one',
       },
     ]);
-    expect(getWorktree).toHaveBeenCalledWith('emdash/task-one');
+    expect(findBranchAnywhere).toHaveBeenCalledWith('emdash/task-one');
   });
 
   it('excludes task targets that use the project root working directory', async () => {
@@ -391,14 +391,14 @@ describe('shareProjectSettingsToConfig', () => {
         content: JSON.stringify({ shellSetup: 'worktree setup' }),
       }),
     };
-    const getWorktree = vi.fn();
+    const findBranchAnywhere = vi.fn();
     const project = {
       projectId: 'project-1',
       repoPath: '/repo',
       fs: projectRootFs,
       defaultWorkspaceType: { kind: 'local' },
       worktreeService: {
-        getWorktree,
+        findBranchAnywhere,
       },
     };
     mocks.workspaceGet.mockImplementation((workspaceId: string) => {
@@ -448,7 +448,7 @@ describe('shareProjectSettingsToConfig', () => {
         path: '/repo/.emdash/worktrees/task-two',
       },
     ]);
-    expect(getWorktree).not.toHaveBeenCalled();
+    expect(findBranchAnywhere).not.toHaveBeenCalled();
     expect(overrideState.shellSetup).toEqual([
       { label: 'Repo Name', path: '/repo', value: 'root setup' },
       {
@@ -460,14 +460,14 @@ describe('shareProjectSettingsToConfig', () => {
   });
 
   it('skips task target resolution when the project row no longer exists', async () => {
-    const getWorktree = vi.fn();
+    const findBranchAnywhere = vi.fn();
     const project = {
       projectId: 'project-1',
       repoPath: '/repo',
       fs: {},
       defaultWorkspaceType: { kind: 'local' },
       worktreeService: {
-        getWorktree,
+        findBranchAnywhere,
       },
     };
     mocks.select.mockReturnValueOnce({
@@ -484,7 +484,7 @@ describe('shareProjectSettingsToConfig', () => {
 
     expect(targets).toEqual([{ type: 'project', label: 'Project repository', path: '/repo' }]);
     expect(mocks.select).toHaveBeenCalledTimes(1);
-    expect(getWorktree).not.toHaveBeenCalled();
+    expect(findBranchAnywhere).not.toHaveBeenCalled();
   });
 
   it('detects workspace setting overrides from .emdash.json files', async () => {
@@ -507,7 +507,7 @@ describe('shareProjectSettingsToConfig', () => {
       },
       defaultWorkspaceType: { kind: 'local' },
       worktreeService: {
-        getWorktree: vi.fn(),
+        findBranchAnywhere: vi.fn(),
       },
     };
     mocks.select

--- a/src/main/core/tasks/operations/createTask.test.ts
+++ b/src/main/core/tasks/operations/createTask.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TaskRow } from '@main/db/schema';
+import { createTask } from './createTask';
+
+const mocks = vi.hoisted(() => ({
+  insert: vi.fn(),
+  update: vi.fn(),
+  getProject: vi.fn(),
+  provisionTask: vi.fn(),
+  getAppSetting: vi.fn(),
+  getProjectRemoteInfo: vi.fn(),
+  getTaskPullRequests: vi.fn(),
+  createConversation: vi.fn(),
+  telemetryCapture: vi.fn(),
+  findBranchAnywhere: vi.fn(),
+  fetchPrForReview: vi.fn(),
+  getConfiguredRemotes: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    insert: mocks.insert,
+    update: mocks.update,
+  },
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: {
+    getProject: mocks.getProject,
+  },
+}));
+
+vi.mock('@main/core/tasks/task-manager', () => ({
+  taskManager: {
+    provisionTask: mocks.provisionTask,
+  },
+}));
+
+vi.mock('../../settings/settings-service', () => ({
+  appSettingsService: {
+    get: mocks.getAppSetting,
+  },
+}));
+
+vi.mock('../../pull-requests/pr-query-service', () => ({
+  prQueryService: {
+    getProjectRemoteInfo: mocks.getProjectRemoteInfo,
+    getTaskPullRequests: mocks.getTaskPullRequests,
+  },
+}));
+
+vi.mock('../../conversations/createConversation', () => ({
+  createConversation: mocks.createConversation,
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: {
+    capture: mocks.telemetryCapture,
+  },
+}));
+
+function makeTaskRow(values: Partial<TaskRow>): TaskRow {
+  return {
+    id: values.id ?? 'task-1',
+    projectId: values.projectId ?? 'project-1',
+    name: values.name ?? 'Review PR',
+    status: values.status ?? 'in_progress',
+    sourceBranch: values.sourceBranch ?? null,
+    taskBranch: values.taskBranch ?? null,
+    linkedIssue: values.linkedIssue ?? null,
+    archivedAt: values.archivedAt ?? null,
+    createdAt: values.createdAt ?? '2026-05-18 12:00:00',
+    updatedAt: values.updatedAt ?? '2026-05-18 12:00:00',
+    lastInteractedAt: values.lastInteractedAt ?? null,
+    statusChangedAt: values.statusChangedAt ?? '2026-05-18 12:00:00',
+    isPinned: values.isPinned ?? 0,
+    workspaceProvider: values.workspaceProvider ?? null,
+    workspaceId: values.workspaceId ?? null,
+    workspaceProviderData: values.workspaceProviderData ?? null,
+  };
+}
+
+describe('createTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mocks.getAppSetting.mockImplementation((key: string) => {
+      if (key === 'project') {
+        return Promise.resolve({ branchPrefix: 'emdash', appendRandomBranchSuffix: true });
+      }
+      if (key === 'agentAutoApproveDefaults') {
+        return Promise.resolve({});
+      }
+      return Promise.resolve(undefined);
+    });
+
+    mocks.findBranchAnywhere.mockResolvedValue('/external/worktrees/pr-branch');
+    mocks.fetchPrForReview.mockResolvedValue({ success: true });
+    mocks.getConfiguredRemotes.mockResolvedValue({ baseRemote: 'origin', pushRemote: 'origin' });
+    mocks.getProject.mockReturnValue({
+      defaultWorkspaceType: { kind: 'local' },
+      worktreeService: {
+        findBranchAnywhere: mocks.findBranchAnywhere,
+      },
+      repository: {
+        getConfiguredRemotes: mocks.getConfiguredRemotes,
+        fetchPrForReview: mocks.fetchPrForReview,
+      },
+    });
+    mocks.getProjectRemoteInfo.mockResolvedValue({ status: 'unavailable' });
+    mocks.provisionTask.mockResolvedValue({ success: true, data: undefined });
+
+    const updateWhere = vi.fn().mockResolvedValue(undefined);
+    const updateSet = vi.fn(() => ({ where: updateWhere }));
+    mocks.update.mockReturnValue({ set: updateSet });
+  });
+
+  it('skips fetching a pull request branch that is already checked out in any worktree', async () => {
+    const insertTaskValues = vi.fn((values: Partial<TaskRow>) => ({
+      returning: vi.fn().mockResolvedValue([makeTaskRow(values)]),
+    }));
+    const insertWorkspaceValues = vi.fn().mockResolvedValue(undefined);
+    mocks.insert
+      .mockReturnValueOnce({ values: insertTaskValues })
+      .mockReturnValueOnce({ values: insertWorkspaceValues });
+
+    const result = await createTask({
+      id: 'task-1',
+      projectId: 'project-1',
+      name: 'Review PR',
+      sourceBranch: {
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin', url: 'https://github.com/example/repo.git' },
+      },
+      strategy: {
+        kind: 'from-pull-request',
+        prNumber: 123,
+        headBranch: 'claude/add-french-translations-ud2fs',
+        headRepositoryUrl: 'https://github.com/example/repo.git',
+        isFork: false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.findBranchAnywhere).toHaveBeenCalledWith('claude/add-french-translations-ud2fs');
+    expect(mocks.fetchPrForReview).not.toHaveBeenCalled();
+    expect(insertTaskValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskBranch: 'claude/add-french-translations-ud2fs',
+        sourceBranch: { type: 'local', branch: 'claude/add-french-translations-ud2fs' },
+      })
+    );
+    expect(mocks.provisionTask).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        taskBranch: 'claude/add-french-translations-ud2fs',
+        sourceBranch: { type: 'local', branch: 'claude/add-french-translations-ud2fs' },
+      }),
+      [],
+      [],
+      expect.objectContaining({ type: 'local' })
+    );
+  });
+});

--- a/src/main/core/tasks/operations/createTask.test.ts
+++ b/src/main/core/tasks/operations/createTask.test.ts
@@ -162,4 +162,51 @@ describe('createTask', () => {
       expect.objectContaining({ type: 'local' })
     );
   });
+
+  it('fetches the pull request branch when it is not already checked out', async () => {
+    mocks.findBranchAnywhere.mockResolvedValue(undefined);
+
+    const insertTaskValues = vi.fn((values: Partial<TaskRow>) => ({
+      returning: vi.fn().mockResolvedValue([makeTaskRow(values)]),
+    }));
+    const insertWorkspaceValues = vi.fn().mockResolvedValue(undefined);
+    mocks.insert
+      .mockReturnValueOnce({ values: insertTaskValues })
+      .mockReturnValueOnce({ values: insertWorkspaceValues });
+
+    const result = await createTask({
+      id: 'task-1',
+      projectId: 'project-1',
+      name: 'Review PR',
+      sourceBranch: {
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin', url: 'https://github.com/example/repo.git' },
+      },
+      strategy: {
+        kind: 'from-pull-request',
+        prNumber: 123,
+        headBranch: 'claude/add-french-translations-ud2fs',
+        headRepositoryUrl: 'https://github.com/example/repo.git',
+        isFork: false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.findBranchAnywhere).toHaveBeenCalledWith('claude/add-french-translations-ud2fs');
+    expect(mocks.fetchPrForReview).toHaveBeenCalledWith(
+      123,
+      'claude/add-french-translations-ud2fs',
+      'https://github.com/example/repo.git',
+      'claude/add-french-translations-ud2fs',
+      false,
+      'origin'
+    );
+    expect(insertTaskValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskBranch: 'claude/add-french-translations-ud2fs',
+        sourceBranch: { type: 'local', branch: 'claude/add-french-translations-ud2fs' },
+      })
+    );
+  });
 });

--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -111,7 +111,9 @@ export async function createTask(
     case 'from-pull-request': {
       // If the head branch is already checked out in a valid worktree, skip the fetch.
       // Git refuses to update a branch that is currently checked out, even with --force.
-      const existingWorktree = await project.getWorktreeForBranch(strategy.headBranch);
+      const existingWorktree = await project.worktreeService.findBranchAnywhere(
+        strategy.headBranch
+      );
 
       if (!existingWorktree) {
         // Fetch the PR head — handles same-repo and fork PRs.


### PR DESCRIPTION
- reuse an existing linked worktree when creating a task from a PR branch
- avoid fetching the PR branch when git already has that branch checked out elsewhere
- resolve inactive task settings targets via branch discovery so external worktrees are included