### PR TITLE
fix: render deleted file diffs

### DIFF
--- a/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models.ts
@@ -50,10 +50,10 @@ export function usePrefetchDiffModels(
           .registerModel(projectId, workspaceId, root, filePath, language, 'disk')
           .catch(() => {});
         void modelRegistry
-          .registerModel(projectId, workspaceId, root, filePath, language, 'git', originalRef)
+          .registerModel(projectId, workspaceId, root, filePath, language, 'git', STAGED_REF)
           .catch(() => {});
         entry.diskUri = modelRegistry.toDiskUri(uri);
-        entry.gitUris = [modelRegistry.toGitUri(uri, originalRef)];
+        entry.gitUris = [modelRegistry.toGitUri(uri, STAGED_REF)];
       } else if (group === 'staged') {
         void modelRegistry
           .registerModel(projectId, workspaceId, root, filePath, language, 'git', HEAD_REF)

--- a/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -107,6 +107,9 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
   const language = getLanguageFromPath(tab.path);
 
   const originalUri = (() => {
+    if (tab.diffGroup === 'disk') {
+      return modelRegistry.toGitUri(uri, STAGED_REF);
+    }
     if (tab.diffGroup === 'git' || tab.diffGroup === 'pr') {
       return modelRegistry.toGitUri(uri, tab.originalRef);
     }
@@ -130,20 +133,19 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
     if (tab.diffGroup === 'disk') {
       const diskUri = modelRegistry.toDiskUri(uri);
       void (async () => {
-        // Disk read fails for deleted files (ENOENT). Swallow so the buffer
-        // still registers with an empty seed; the diff editor needs both
-        // sides 'ready' to render, otherwise it shows a blank page.
-        try {
-          await modelRegistry.registerModel(
-            projectId,
-            workspaceId,
-            root,
-            tab.path,
-            language,
-            'disk'
-          );
-        } catch (err) {
-          if (!isMissingFileError(err)) throw err;
+        if (tab.status !== 'deleted') {
+          try {
+            await modelRegistry.registerModel(
+              projectId,
+              workspaceId,
+              root,
+              tab.path,
+              language,
+              'disk'
+            );
+          } catch (err) {
+            if (!isMissingFileError(err)) throw err;
+          }
         }
         if (disposed) {
           modelRegistry.unregisterModel(diskUri);
@@ -162,7 +164,7 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
         }
       })().catch(() => {});
       void modelRegistry
-        .registerModel(projectId, workspaceId, root, tab.path, language, 'git', tab.originalRef)
+        .registerModel(projectId, workspaceId, root, tab.path, language, 'git', STAGED_REF)
         .catch(() => {});
     } else if (tab.diffGroup === 'staged') {
       void modelRegistry
@@ -206,6 +208,7 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
     tab.diffGroup,
     tab.originalRef,
     tab.modifiedRef,
+    tab.status,
     projectId,
     workspaceId,
     root,

--- a/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -130,7 +130,21 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
     if (tab.diffGroup === 'disk') {
       const diskUri = modelRegistry.toDiskUri(uri);
       void (async () => {
-        await modelRegistry.registerModel(projectId, workspaceId, root, tab.path, language, 'disk');
+        // Disk read fails for deleted files (ENOENT). Swallow so the buffer
+        // still registers with an empty seed; the diff editor needs both
+        // sides 'ready' to render, otherwise it shows a blank page.
+        try {
+          await modelRegistry.registerModel(
+            projectId,
+            workspaceId,
+            root,
+            tab.path,
+            language,
+            'disk'
+          );
+        } catch (err) {
+          if (!isMissingFileError(err)) throw err;
+        }
         if (disposed) {
           modelRegistry.unregisterModel(diskUri);
           return;
@@ -223,4 +237,9 @@ function tabToActiveFile(tab: DiffTabStore): ActiveFile {
     modifiedRef: tab.modifiedRef,
     prNumber: tab.prNumber,
   };
+}
+
+function isMissingFileError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /\b(ENOENT|File not found)\b/i.test(message);
 }

--- a/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -5,6 +5,7 @@ import { HEAD_REF, STAGED_REF } from '@shared/git';
 import type { ActiveFile } from '@shared/view-state';
 import { useDiffEditorComments } from '@renderer/features/tasks/diff-view/comments/use-diff-editor-comments';
 import { ImageDiffView } from '@renderer/features/tasks/diff-view/main-panel/image-diff-view';
+import { isMissingFileError } from '@renderer/features/tasks/diff-view/main-panel/missing-file-error';
 import { getTaskStore } from '@renderer/features/tasks/stores/task-selectors';
 import type { DiffTabStore } from '@renderer/features/tasks/tabs/diff-tab-store';
 import {
@@ -240,9 +241,4 @@ function tabToActiveFile(tab: DiffTabStore): ActiveFile {
     modifiedRef: tab.modifiedRef,
     prNumber: tab.prNumber,
   };
-}
-
-function isMissingFileError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return /\b(ENOENT|File not found)\b/i.test(message);
 }

--- a/src/renderer/features/tasks/diff-view/main-panel/missing-file-error.ts
+++ b/src/renderer/features/tasks/diff-view/main-panel/missing-file-error.ts
@@ -1,0 +1,4 @@
+export function isMissingFileError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /\b(ENOENT|File not found)\b/i.test(message);
+}

--- a/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
@@ -3,6 +3,7 @@ import { reaction } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import { Activity, useEffect, useMemo, useRef, useState } from 'react';
 import { HEAD_REF, STAGED_REF } from '@shared/git';
+import { isMissingFileError } from '@renderer/features/tasks/diff-view/main-panel/missing-file-error';
 import type { DiffViewStore } from '@renderer/features/tasks/diff-view/stores/diff-view-store';
 import {
   StackedDiffPanelStore,
@@ -247,6 +248,7 @@ const StackedFileSlot = observer(function StackedFileSlot({
     originalRef,
     modifiedRef,
     file,
+    file?.status,
     slotStore,
   ]);
 
@@ -329,8 +331,3 @@ const StackedFileSlot = observer(function StackedFileSlot({
     </div>
   );
 });
-
-function isMissingFileError(err: unknown): boolean {
-  const message = err instanceof Error ? err.message : String(err);
-  return /\b(ENOENT|File not found)\b/i.test(message);
-}

--- a/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
@@ -196,14 +196,20 @@ const StackedFileSlot = observer(function StackedFileSlot({
     } else {
       const diskUri = modelRegistry.toDiskUri(modifiedUri);
       void (async () => {
-        await modelRegistry.registerModel(
-          projectId,
-          workspaceId,
-          root,
-          file.path,
-          language,
-          'disk'
-        );
+        if (file.status !== 'deleted') {
+          try {
+            await modelRegistry.registerModel(
+              projectId,
+              workspaceId,
+              root,
+              file.path,
+              language,
+              'disk'
+            );
+          } catch (err) {
+            if (!isMissingFileError(err)) throw err;
+          }
+        }
         if (disposed) {
           modelRegistry.unregisterModel(diskUri);
           return;
@@ -221,7 +227,7 @@ const StackedFileSlot = observer(function StackedFileSlot({
         }
       })().catch(() => {});
       void modelRegistry
-        .registerModel(projectId, workspaceId, root, file.path, language, 'git', originalRef)
+        .registerModel(projectId, workspaceId, root, file.path, language, 'git', STAGED_REF)
         .catch(() => {});
     }
     return () => {
@@ -323,3 +329,8 @@ const StackedFileSlot = observer(function StackedFileSlot({
     </div>
   );
 });
+
+function isMissingFileError(err: unknown): boolean {
+  const message = err instanceof Error ? err.message : String(err);
+  return /\b(ENOENT|File not found)\b/i.test(message);
+}

--- a/src/renderer/features/tasks/diff-view/stores/stacked-diff-panel-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/stacked-diff-panel-store.ts
@@ -51,6 +51,8 @@ export class DiffSlotStore {
     if (this.diffType === 'git' || this.diffType === 'pr') {
       return modelRegistry.toGitUri(this.uri, this.originalRef);
     }
+    if (this.diffType === 'disk') return modelRegistry.toGitUri(this.uri, STAGED_REF);
+
     return modelRegistry.toGitUri(this.uri, HEAD_REF);
   }
 


### PR DESCRIPTION
# summary
instead of displaying an empty file we now display the real diff of a completely deleted file 

<img width="873" height="835" alt="image" src="https://github.com/user-attachments/assets/1ebf3d61-6946-439c-9bdb-05cd1ade4763" />
