### PR TITLE
feat: support external session rename via hook server

### DIFF
--- a/agents/architecture/main-process.md
+++ b/agents/architecture/main-process.md
@@ -7,7 +7,7 @@ The main process is organized into domain modules under `src/main/core/`. Each d
 ## Domain Modules (`src/main/core/`)
 
 - **account** — Emdash account service, credential store, provider token registry
-- **agent-hooks** — HTTP hook server for agent callbacks, event enrichment, OS notifications, hook config writer (Claude/Codex)
+- **agent-hooks** — HTTP hook server for agent callbacks, event enrichment, OS notifications, hook config writer (Claude/Codex), external session rename (conversation title and task name)
 - **app** — App lifecycle service and controller
 - **conversations** — Conversation CRUD, session start, agent event classifiers (per-provider terminal output parsers)
 - **dependencies** — CLI agent detection, probing, dependency management
@@ -35,7 +35,7 @@ The main process is organized into domain modules under `src/main/core/`. Each d
 - `src/main/lib/` — Logger, telemetry, events, result type, updater error
 - `src/main/db/` — Database schema and initialization
 - `src/main/utils/` — Shell environment, shell escaping, child process env, external links
-- `src/main/core/agent-hooks/` — Hook server, event enrichment, OS notifications, hook config writer for Claude/Codex
+- `src/main/core/agent-hooks/` — Hook server, event enrichment, OS notifications, hook config writer for Claude/Codex, external session rename
 
 ## IPC / RPC Structure
 

--- a/src/main/core/agent-hooks/agent-hook-service.ts
+++ b/src/main/core/agent-hooks/agent-hook-service.ts
@@ -1,5 +1,6 @@
 import { agentEventChannel, type AgentEvent } from '@shared/events/agentEvents';
 import { conversationChangedChannel } from '@shared/events/conversationEvents';
+import { conversationRenamedChannel, taskRenamedChannel } from '@shared/events/taskEvents';
 import { conversationEvents } from '@main/core/conversations/conversation-events';
 import { touchConversation } from '@main/core/conversations/touchConversation';
 import { events } from '@main/lib/events';
@@ -8,12 +9,33 @@ import { telemetryService } from '@main/lib/telemetry';
 import { enrichEvent } from './event-enricher';
 import { HookServer } from './hook-server';
 import { isAppFocused, maybeShowNotification } from './notification';
+import { handleConversationRename, handleTaskRename } from './rename-handler';
 
 class AgentHookService implements IInitializable, IDisposable {
   private server = new HookServer();
 
   async initialize(): Promise<void> {
     await this.server.start(async (raw) => {
+      if (raw.type === 'rename-conversation') {
+        const result = await handleConversationRename(raw);
+        events.emit(conversationRenamedChannel, {
+          conversationId: result.conversationId,
+          taskId: result.taskId,
+          projectId: result.projectId,
+          title: result.title,
+        });
+        return;
+      }
+      if (raw.type === 'rename-task') {
+        const result = await handleTaskRename(raw);
+        events.emit(taskRenamedChannel, {
+          taskId: result.taskId,
+          projectId: result.projectId,
+          name: result.name,
+        });
+        return;
+      }
+
       const event = await enrichEvent(raw);
       event.source = 'hook';
       const appFocused = isAppFocused();

--- a/src/main/core/agent-hooks/rename-handler.ts
+++ b/src/main/core/agent-hooks/rename-handler.ts
@@ -1,0 +1,97 @@
+import { eq } from 'drizzle-orm';
+import { parsePtyId } from '@shared/ptyId';
+import { renameConversation } from '@main/core/conversations/renameConversation';
+import { renameTask } from '@main/core/tasks/operations/renameTask';
+import { db } from '@main/db/client';
+import { conversations } from '@main/db/schema';
+import { log } from '@main/lib/logger';
+import type { RawHookRequest } from './hook-server';
+
+export interface ConversationRenameResult {
+  conversationId: string;
+  taskId: string;
+  projectId: string;
+  title: string;
+}
+
+export interface TaskRenameResult {
+  taskId: string;
+  projectId: string;
+  name: string;
+}
+
+function parseTitle(raw: RawHookRequest): string {
+  let body: Record<string, unknown>;
+  try {
+    body = raw.body ? JSON.parse(raw.body) : {};
+  } catch {
+    throw new Error('rename hook: invalid JSON in request body');
+  }
+  const title = body.title;
+  if (!title || typeof title !== 'string') {
+    throw new Error('rename hook requires a "title" field in the request body');
+  }
+  return title;
+}
+
+async function lookupConversation(raw: RawHookRequest) {
+  const parsed = parsePtyId(raw.ptyId);
+  if (!parsed) {
+    throw new Error(`Unrecognised ptyId: ${raw.ptyId}`);
+  }
+
+  const [conv] = await db
+    .select({
+      taskId: conversations.taskId,
+      projectId: conversations.projectId,
+    })
+    .from(conversations)
+    .where(eq(conversations.id, parsed.conversationId))
+    .limit(1);
+
+  if (!conv) {
+    throw new Error(`Conversation not found: ${parsed.conversationId}`);
+  }
+
+  return { conversationId: parsed.conversationId, ...conv };
+}
+
+export async function handleConversationRename(
+  raw: RawHookRequest
+): Promise<ConversationRenameResult> {
+  const title = parseTitle(raw);
+  const conv = await lookupConversation(raw);
+
+  await renameConversation(conv.conversationId, title);
+
+  log.info('RenameHandler: conversation renamed via hook', {
+    conversationId: conv.conversationId,
+    taskId: conv.taskId,
+    title,
+  });
+
+  return {
+    conversationId: conv.conversationId,
+    taskId: conv.taskId,
+    projectId: conv.projectId,
+    title,
+  };
+}
+
+export async function handleTaskRename(raw: RawHookRequest): Promise<TaskRenameResult> {
+  const title = parseTitle(raw);
+  const conv = await lookupConversation(raw);
+
+  await renameTask(conv.projectId, conv.taskId, title);
+
+  log.info('RenameHandler: task renamed via hook', {
+    taskId: conv.taskId,
+    title,
+  });
+
+  return {
+    taskId: conv.taskId,
+    projectId: conv.projectId,
+    name: title,
+  };
+}

--- a/src/renderer/features/tasks/conversations/conversation-manager.ts
+++ b/src/renderer/features/tasks/conversations/conversation-manager.ts
@@ -7,6 +7,7 @@ import {
   type NotificationType,
 } from '@shared/events/agentEvents';
 import { conversationChangedChannel } from '@shared/events/conversationEvents';
+import { conversationRenamedChannel } from '@shared/events/taskEvents';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { events, rpc } from '@renderer/lib/ipc';
 import { PtySession } from '@renderer/lib/pty/pty-session';
@@ -21,6 +22,7 @@ export class ConversationManagerStore implements IDisposable {
   private offAgentEvents: (() => void) | null = null;
   private offSessionExited: (() => void) | null = null;
   private offConversationChanges: (() => void) | null = null;
+  private offConversationRenamed: (() => void) | null = null;
   private readonly _disposeReaction: () => void;
 
   /** Data layer: plain Conversation records loaded from the main process. */
@@ -99,6 +101,7 @@ export class ConversationManagerStore implements IDisposable {
     this.offAgentEvents = this.listenToAgentEvents();
     this.offSessionExited = this.listenToSessionExited();
     this.offConversationChanges = this.listenToConversationChanges();
+    this.offConversationRenamed = this.listenToConversationRenamed();
   }
 
   private listenToAgentEvents(): () => void {
@@ -144,6 +147,17 @@ export class ConversationManagerStore implements IDisposable {
       if (!store) return;
       runInAction(() => {
         Object.assign(store.data, event.changes);
+      });
+    });
+  }
+
+  private listenToConversationRenamed(): () => void {
+    return events.on(conversationRenamedChannel, ({ conversationId, taskId, title }) => {
+      if (taskId !== this.taskId) return;
+      const store = this.conversations.get(conversationId);
+      if (!store) return;
+      runInAction(() => {
+        store.data.title = title;
       });
     });
   }
@@ -250,6 +264,8 @@ export class ConversationManagerStore implements IDisposable {
     this.offSessionExited = null;
     this.offConversationChanges?.();
     this.offConversationChanges = null;
+    this.offConversationRenamed?.();
+    this.offConversationRenamed = null;
     for (const session of this.sessions.values()) {
       session.dispose();
     }

--- a/src/renderer/features/tasks/stores/task-manager.ts
+++ b/src/renderer/features/tasks/stores/task-manager.ts
@@ -1,7 +1,11 @@
 import { makeObservable, observable, reaction, runInAction, toJS } from 'mobx';
 import { toast } from 'sonner';
 import { prSyncProgressChannel, prUpdatedChannel } from '@shared/events/prEvents';
-import { taskProvisionProgressChannel, taskStatusUpdatedChannel } from '@shared/events/taskEvents';
+import {
+  taskProvisionProgressChannel,
+  taskRenamedChannel,
+  taskStatusUpdatedChannel,
+} from '@shared/events/taskEvents';
 import type {
   CreateTaskError,
   CreateTaskParams,
@@ -128,6 +132,7 @@ export class TaskManagerStore {
   private _unsubPrUpdated: (() => void) | null = null;
   private _unsubPrSyncProgress: (() => void) | null = null;
   private _unsubProvisionProgress: (() => void) | null = null;
+  private _unsubTaskRenamed: (() => void) | null = null;
   private _disposeRepositoryReaction: (() => void) | null = null;
 
   tasks = observable.map<string, TaskStore>();
@@ -153,6 +158,19 @@ export class TaskManagerStore {
         });
       }
     });
+
+    this._unsubTaskRenamed = events.on(
+      taskRenamedChannel,
+      ({ taskId, projectId: evtProjectId, name }) => {
+        if (evtProjectId !== this.projectId) return;
+        const store = this.tasks.get(taskId);
+        if (store && isProvisioned(store)) {
+          runInAction(() => {
+            store.data.name = name;
+          });
+        }
+      }
+    );
 
     this._unsubProvisionProgress = events.on(
       taskProvisionProgressChannel,
@@ -626,6 +644,8 @@ export class TaskManagerStore {
     this._unsubPrSyncProgress = null;
     this._unsubProvisionProgress?.();
     this._unsubProvisionProgress = null;
+    this._unsubTaskRenamed?.();
+    this._unsubTaskRenamed = null;
     this._disposeRepositoryReaction?.();
     this._disposeRepositoryReaction = null;
   }

--- a/src/shared/events/taskEvents.ts
+++ b/src/shared/events/taskEvents.ts
@@ -28,3 +28,16 @@ export const taskProvisionProgressChannel = defineEvent<{
   step: ProvisionStep;
   message: string;
 }>('task:provision-progress');
+
+export const taskRenamedChannel = defineEvent<{
+  taskId: string;
+  projectId: string;
+  name: string;
+}>('task:renamed');
+
+export const conversationRenamedChannel = defineEvent<{
+  conversationId: string;
+  taskId: string;
+  projectId: string;
+  title: string;
+}>('conversation:renamed');


### PR DESCRIPTION
## Summary

Adds two new hook event types — `rename-conversation` and `rename-task` — that let CLI agents rename conversations (tab bar) and tasks (sidebar) through the existing hook server HTTP interface.

When an agent POSTs to `/hook` with `X-Emdash-Event-Type: rename-conversation` (or `rename-task`) and a JSON body `{"title": "..."}`, the handler:
1. Resolves the conversation from the pty ID header
2. Delegates to the existing `renameConversation()` / `renameTask()` service functions
3. Emits IPC events so the renderer updates the UI in real time

**Use case:** Agents managing multiple sessions (orchestrators, task managers) can label conversations and tasks programmatically without needing direct DB access.

## Files Changed

- `src/shared/events/taskEvents.ts` — new `taskRenamedChannel` and `conversationRenamedChannel` IPC events
- `src/main/core/agent-hooks/rename-handler.ts` — new handler that parses the request, looks up the conversation, and delegates to service functions
- `src/main/core/agent-hooks/agent-hook-service.ts` — routes `rename-conversation` and `rename-task` event types before the generic agent event path
- `src/renderer/.../conversation-manager.ts` — listens for `conversationRenamedChannel` and updates conversation title in the store
- `src/renderer/.../task-manager.ts` — listens for `taskRenamedChannel` and updates task name in the store

## Test Plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes