### PR TITLE
fix: track agent turns from real user messages

### DIFF
--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -21,7 +21,6 @@ import { providerOverrideSettings } from '@main/core/settings/provider-settings-
 import { appSettingsService } from '@main/core/settings/settings-service';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
-import { telemetryService } from '@main/lib/telemetry';
 import { buildAgentCommand } from './agent-command';
 import { resolveProviderEnv } from './provider-env';
 
@@ -161,13 +160,6 @@ export class LocalConversationProvider implements ConversationProvider {
       ptySessionRegistry.unregister(sessionId);
       const shouldRespawn = this.sessions.has(sessionId);
       this.sessions.delete(sessionId);
-      telemetryService.capture('agent_run_finished', {
-        provider: conversation.providerId,
-        exit_code: typeof exitCode === 'number' ? exitCode : -1,
-        project_id: conversation.projectId,
-        task_id: conversation.taskId,
-        conversation_id: conversation.id,
-      });
       events.emit(agentSessionExitedChannel, {
         sessionId,
         projectId: conversation.projectId,
@@ -205,12 +197,6 @@ export class LocalConversationProvider implements ConversationProvider {
       metadata: { providerId: conversation.providerId, title: conversation.title },
     });
     this.sessions.set(sessionId, pty);
-    telemetryService.capture('agent_run_started', {
-      provider: conversation.providerId,
-      project_id: conversation.projectId,
-      task_id: conversation.taskId,
-      conversation_id: conversation.id,
-    });
   }
 
   private async prepareHookConfig(providerId: Conversation['providerId']): Promise<boolean> {

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -16,7 +16,6 @@ import { providerOverrideSettings } from '@main/core/settings/provider-settings-
 import type { SshClientProxy } from '@main/core/ssh/ssh-client-proxy';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
-import { telemetryService } from '@main/lib/telemetry';
 import { buildAgentCommand } from './agent-command';
 import { resolveProviderEnv } from './provider-env';
 
@@ -152,13 +151,6 @@ export class SshConversationProvider implements ConversationProvider {
       ptySessionRegistry.unregister(sessionId);
       const shouldRespawn = this.sessions.has(sessionId);
       this.sessions.delete(sessionId);
-      telemetryService.capture('agent_run_finished', {
-        provider: conversation.providerId,
-        exit_code: typeof exitCode === 'number' ? exitCode : -1,
-        project_id: conversation.projectId,
-        task_id: conversation.taskId,
-        conversation_id: conversation.id,
-      });
       events.emit(agentSessionExitedChannel, {
         sessionId,
         projectId: conversation.projectId,
@@ -196,12 +188,6 @@ export class SshConversationProvider implements ConversationProvider {
       metadata: { providerId: conversation.providerId, title: conversation.title },
     });
     this.sessions.set(sessionId, pty);
-    telemetryService.capture('agent_run_started', {
-      provider: conversation.providerId,
-      project_id: conversation.projectId,
-      task_id: conversation.taskId,
-      conversation_id: conversation.id,
-    });
   }
 
   async stopSession(conversationId: string): Promise<void> {

--- a/src/renderer/features/tasks/conversations/conversations-panel.tsx
+++ b/src/renderer/features/tasks/conversations/conversations-panel.tsx
@@ -17,6 +17,7 @@ import { useTerminalSearch } from '@renderer/lib/pty/use-terminal-search';
 import { Button } from '@renderer/lib/ui/button';
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
+import { captureTelemetry } from '@renderer/utils/telemetryClient';
 import { ContextBar } from './context-bar';
 import type { ConversationStore } from './conversation-manager';
 
@@ -97,13 +98,21 @@ export const ConversationsPanel = observer(function ConversationsPanel() {
     }
   }, [sessionStatus]);
 
-  const onEnterPress =
-    shouldSetWorkingOnEnter && activeConversation
-      ? () => {
+  const onEnterPress = activeConversation
+    ? () => {
+        captureTelemetry('agent_run_started', {
+          provider: activeConversation.data.providerId,
+          project_id: activeConversation.data.projectId,
+          task_id: activeConversation.data.taskId,
+          conversation_id: activeConversation.data.id,
+        });
+
+        if (shouldSetWorkingOnEnter) {
           activeConversation.setWorking();
           void conversations.touchConversation(activeConversation.data.id);
         }
-      : undefined;
+      }
+    : undefined;
 
   const onInterruptPress = activeConversation ? () => activeConversation.clearWorking() : undefined;
 

--- a/src/shared/telemetry.ts
+++ b/src/shared/telemetry.ts
@@ -74,7 +74,6 @@ export type TelemetryEventProperties = {
   conversation_created: { provider: AgentProviderId; is_first_in_task: boolean };
   conversation_deleted: EmptyProps;
   agent_run_started: { provider: AgentProviderId };
-  agent_run_finished: { provider: AgentProviderId; exit_code: number };
 
   terminal_created: { terminal_id: string };
   terminal_deleted: { terminal_id: string };


### PR DESCRIPTION
- capture turns instead of pty spawns and exits