### PR TITLE
fix(editor): render file tree from normalized children

### DIFF
--- a/src/main/core/fs/impl/local-fs.ts
+++ b/src/main/core/fs/impl/local-fs.ts
@@ -190,7 +190,7 @@ export class LocalFileSystem implements FileSystemProvider {
    * Get relative path from absolute path
    */
   private relPath(fullPath: string): string {
-    return relative(this.projectPath, fullPath);
+    return relative(this.projectPath, fullPath).replace(/\\/g, '/');
   }
 
   /**

--- a/src/renderer/features/tasks/editor/editor-file-tree.tsx
+++ b/src/renderer/features/tasks/editor/editor-file-tree.tsx
@@ -346,9 +346,7 @@ export const EditorFileTree = observer(function EditorFileTree() {
   const editorView = taskView.editorView;
   const [isDragOverRoot, setIsDragOverRoot] = useState(false);
 
-  const visibleRows = files
-    ? buildVisibleRows(files.nodes, files.childIndex, editorView.expandedPaths)
-    : [];
+  const visibleRows = files ? buildVisibleRows(files.rootNodes, editorView.expandedPaths) : [];
 
   const parentRef = useRef<HTMLDivElement>(null);
 

--- a/src/renderer/features/tasks/editor/stores/files-store-utils.test.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store-utils.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { buildVisibleRows, makeNode, sortFileNodes } from './files-store-utils';
+
+describe('file tree utils', () => {
+  it('normalizes Windows paths into stable POSIX node identities', () => {
+    const node = makeNode('src\\components\\Button.tsx', 'file');
+
+    expect(node.path).toBe('src/components/Button.tsx');
+    expect(node.name).toBe('Button.tsx');
+    expect(node.parentPath).toBe('src/components');
+    expect(node.depth).toBe(2);
+    expect(node.children).toEqual([]);
+  });
+
+  it('hides loaded descendants for collapsed directories', () => {
+    const src = makeNode('src', 'directory');
+    src.children.push(makeNode('src/index.ts', 'file'));
+
+    const rows = buildVisibleRows([src, makeNode('README.md', 'file')], new Set());
+
+    expect(rows.map((row) => row.path)).toEqual(['src', 'README.md']);
+  });
+
+  it('reveals expanded directory children recursively', () => {
+    const src = makeNode('src', 'directory');
+    const components = makeNode('src/components', 'directory');
+    components.children.push(makeNode('src/components/Button.tsx', 'file'));
+    src.children.push(components, makeNode('src/index.ts', 'file'));
+
+    const rows = buildVisibleRows(
+      [src, makeNode('README.md', 'file')],
+      new Set(['src', 'src/components'])
+    );
+
+    expect(rows.map((row) => row.path)).toEqual([
+      'src',
+      'src/components',
+      'src/components/Button.tsx',
+      'src/index.ts',
+      'README.md',
+    ]);
+  });
+
+  it('sorts siblings with directories first and names alphabetically', () => {
+    const nodes = [
+      makeNode('z-file.ts', 'file'),
+      makeNode('alpha', 'directory'),
+      makeNode('beta.ts', 'file'),
+      makeNode('components', 'directory'),
+    ];
+
+    expect(sortFileNodes(nodes).map((node) => node.path)).toEqual([
+      'alpha',
+      'components',
+      'beta.ts',
+      'z-file.ts',
+    ]);
+  });
+
+  it('does not render file nodes as expandable parents', () => {
+    const file = makeNode('README.md', 'file');
+    file.children.push(makeNode('README.md/README.md', 'file'));
+
+    const rows = buildVisibleRows([file], new Set(['README.md']));
+
+    expect(rows.map((row) => row.path)).toEqual(['README.md']);
+  });
+});

--- a/src/renderer/features/tasks/editor/stores/files-store-utils.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store-utils.ts
@@ -1,6 +1,5 @@
 // ---------------------------------------------------------------------------
-// Excluded directory/file names — kept in sync with DEFAULT_TREE_EXCLUDE in
-// editor-file-tree.tsx so the flat tree and renderer agree on visibility.
+// Excluded directory/file names for the task editor file tree.
 // ---------------------------------------------------------------------------
 
 import { type FileNode } from '@shared/fs';
@@ -54,19 +53,25 @@ export function isExcluded(path: string): boolean {
 // Helpers for building FileNode from a raw entry path
 // ---------------------------------------------------------------------------
 
+export function normalizeFileTreePath(path: string): string {
+  return path.replace(/\\/g, '/').split('/').filter(Boolean).join('/');
+}
+
 export function makeNode(relPath: string, type: 'file' | 'directory', mtime?: Date): FileNode {
-  const parts = relPath.split('/').filter(Boolean);
-  const name = parts[parts.length - 1] ?? relPath;
+  const path = normalizeFileTreePath(relPath);
+  const parts = path.split('/').filter(Boolean);
+  const name = parts[parts.length - 1] ?? path;
   const parentPath = parts.length > 1 ? parts.slice(0, -1).join('/') : null;
   const depth = parts.length - 1;
   const extension = type === 'file' && name.includes('.') ? name.split('.').pop() : undefined;
 
   return {
-    path: relPath,
+    path,
     name,
     parentPath,
     depth,
     type,
+    children: [],
     isHidden: name.startsWith('.'),
     extension,
     mtime,
@@ -74,17 +79,14 @@ export function makeNode(relPath: string, type: 'file' | 'directory', mtime?: Da
 }
 
 // ---------------------------------------------------------------------------
-// Sorted insertion into childIndex
+// Sibling sorting
 // Directories come before files; within each group, alphabetical order.
 // ---------------------------------------------------------------------------
 
-export function sortedChildPaths(paths: string[], nodes: Map<string, FileNode>): string[] {
-  return [...paths].sort((a, b) => {
-    const na = nodes.get(a);
-    const nb = nodes.get(b);
-    if (!na || !nb) return 0;
-    if (na.type !== nb.type) return na.type === 'directory' ? -1 : 1;
-    return na.name.localeCompare(nb.name);
+export function sortFileNodes(nodes: readonly FileNode[]): FileNode[] {
+  return [...nodes].sort((a, b) => {
+    if (a.type !== b.type) return a.type === 'directory' ? -1 : 1;
+    return a.name.localeCompare(b.name);
   });
 }
 
@@ -93,23 +95,20 @@ export function sortedChildPaths(paths: string[], nodes: Map<string, FileNode>):
 // ---------------------------------------------------------------------------
 
 export function buildVisibleRows(
-  nodes: Map<string, FileNode>,
-  childIndex: Map<string | null, string[]>,
+  rootNodes: readonly FileNode[],
   expandedPaths: Set<string>
 ): FileNode[] {
   const rows: FileNode[] = [];
 
-  function walk(parent: string | null) {
-    for (const path of childIndex.get(parent) ?? []) {
-      const node = nodes.get(path);
-      if (!node) continue;
+  function walk(nodes: readonly FileNode[]) {
+    for (const node of nodes) {
       rows.push(node);
-      if (node.type === 'directory' && expandedPaths.has(path)) {
-        walk(path);
+      if (node.type === 'directory' && expandedPaths.has(node.path)) {
+        walk(node.children);
       }
     }
   }
 
-  walk(null);
+  walk(rootNodes);
   return rows;
 }

--- a/src/renderer/features/tasks/editor/stores/files-store.test.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.test.ts
@@ -1,0 +1,154 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { FilesStore } from './files-store';
+
+const mocks = vi.hoisted(() => ({
+  listFiles: vi.fn(),
+  watchSetPaths: vi.fn(),
+  watchStop: vi.fn(),
+  eventOn: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    fs: {
+      listFiles: mocks.listFiles,
+      watchSetPaths: mocks.watchSetPaths,
+      watchStop: mocks.watchStop,
+    },
+  },
+  events: {
+    on: mocks.eventOn,
+  },
+}));
+
+type Entry = {
+  path: string;
+  type: 'file' | 'dir';
+};
+
+function okEntries(entries: Entry[]) {
+  return {
+    success: true as const,
+    data: {
+      entries,
+      total: entries.length,
+    },
+  };
+}
+
+function setupListFiles(entriesByDir: Record<string, Entry[]>): void {
+  mocks.listFiles.mockImplementation(
+    async (_projectId: string, _workspaceId: string, dirPath: string) => {
+      const key = dirPath === '.' ? '' : dirPath;
+      return okEntries(entriesByDir[key] ?? []);
+    }
+  );
+}
+
+describe('FilesStore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.listFiles.mockReset();
+    mocks.watchSetPaths.mockReset();
+    mocks.watchStop.mockReset();
+    mocks.eventOn.mockReset();
+  });
+
+  afterEach(() => {
+    vi.clearAllTimers();
+    vi.useRealTimers();
+  });
+
+  it('loads only the root directory on initial load', async () => {
+    setupListFiles({
+      '': [
+        { path: 'src', type: 'dir' },
+        { path: 'README.md', type: 'file' },
+      ],
+      src: [{ path: 'src/index.ts', type: 'file' }],
+    });
+
+    const store = new FilesStore('project-1', 'workspace-1');
+    await store.tree.load();
+    store.dispose();
+
+    expect(mocks.listFiles).toHaveBeenCalledTimes(1);
+    expect(mocks.listFiles).toHaveBeenCalledWith('project-1', 'workspace-1', '.', {
+      recursive: false,
+      includeHidden: true,
+    });
+    expect(store.loadedPaths.has('')).toBe(true);
+    expect(store.loadedPaths.has('src')).toBe(false);
+    expect(store.rootNodes.map((node) => node.path)).toEqual(['src', 'README.md']);
+  });
+
+  it('loads a child directory on demand', async () => {
+    setupListFiles({
+      '': [{ path: 'src', type: 'dir' }],
+      src: [{ path: 'src/index.ts', type: 'file' }],
+    });
+
+    const store = new FilesStore('project-1', 'workspace-1');
+    await store.tree.load();
+    await store.loadDir('src');
+    vi.runOnlyPendingTimers();
+
+    expect(mocks.listFiles).toHaveBeenCalledWith('project-1', 'workspace-1', 'src', {
+      recursive: false,
+      includeHidden: true,
+    });
+    expect(store.loadedPaths.has('src')).toBe(true);
+    expect(store.nodes.has('src/index.ts')).toBe(true);
+    expect(store.nodes.get('src')?.children.map((node) => node.path)).toEqual(['src/index.ts']);
+    store.dispose();
+  });
+
+  it('normalizes loaded child paths into the current folder children', async () => {
+    setupListFiles({
+      '': [{ path: 'src', type: 'dir' }],
+      src: [
+        { path: 'src\\components', type: 'dir' },
+        { path: 'src\\index.ts', type: 'file' },
+      ],
+    });
+
+    const store = new FilesStore('project-1', 'workspace-1');
+    await store.tree.load();
+    await store.loadDir('src');
+    vi.runOnlyPendingTimers();
+
+    expect(store.rootNodes.map((node) => node.path)).toEqual(['src']);
+    expect(store.nodes.get('src')?.children.map((node) => node.path)).toEqual([
+      'src/components',
+      'src/index.ts',
+    ]);
+    expect(store.nodes.has('src\\components')).toBe(false);
+    store.dispose();
+  });
+
+  it('loads and expands ancestor directories when revealing a file', async () => {
+    setupListFiles({
+      '': [{ path: 'src', type: 'dir' }],
+      src: [{ path: 'src/a', type: 'dir' }],
+      'src/a': [{ path: 'src/a/b.ts', type: 'file' }],
+    });
+
+    const store = new FilesStore('project-1', 'workspace-1');
+    const expandedPaths = new Set<string>();
+
+    await store.tree.load();
+    await store.revealFile('src/a/b.ts', expandedPaths);
+
+    expect(mocks.listFiles).toHaveBeenCalledWith('project-1', 'workspace-1', 'src', {
+      recursive: false,
+      includeHidden: true,
+    });
+    expect(mocks.listFiles).toHaveBeenCalledWith('project-1', 'workspace-1', 'src/a', {
+      recursive: false,
+      includeHidden: true,
+    });
+    expect([...expandedPaths]).toEqual(['src', 'src/a']);
+    expect(store.nodes.has('src/a/b.ts')).toBe(true);
+    store.dispose();
+  });
+});

--- a/src/renderer/features/tasks/editor/stores/files-store.test.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { FileWatchEvent } from '@shared/fs';
 import { FilesStore } from './files-store';
 
 const mocks = vi.hoisted(() => ({
@@ -45,6 +46,12 @@ function setupListFiles(entriesByDir: Record<string, Entry[]>): void {
   );
 }
 
+async function flushAsyncWork(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('FilesStore', () => {
   beforeEach(() => {
     vi.useFakeTimers();
@@ -52,6 +59,8 @@ describe('FilesStore', () => {
     mocks.watchSetPaths.mockReset();
     mocks.watchStop.mockReset();
     mocks.eventOn.mockReset();
+    mocks.watchSetPaths.mockResolvedValue({ success: true, data: { supported: true } });
+    mocks.watchStop.mockResolvedValue({ success: true, data: {} });
   });
 
   afterEach(() => {
@@ -59,7 +68,7 @@ describe('FilesStore', () => {
     vi.useRealTimers();
   });
 
-  it('loads only the root directory on initial load', async () => {
+  it('loads the root directory and warms discovered child directories in the background', async () => {
     setupListFiles({
       '': [
         { path: 'src', type: 'dir' },
@@ -70,15 +79,19 @@ describe('FilesStore', () => {
 
     const store = new FilesStore('project-1', 'workspace-1');
     await store.tree.load();
+    await flushAsyncWork();
     store.dispose();
 
-    expect(mocks.listFiles).toHaveBeenCalledTimes(1);
     expect(mocks.listFiles).toHaveBeenCalledWith('project-1', 'workspace-1', '.', {
       recursive: false,
       includeHidden: true,
     });
+    expect(mocks.listFiles).toHaveBeenCalledWith('project-1', 'workspace-1', 'src', {
+      recursive: false,
+      includeHidden: true,
+    });
     expect(store.loadedPaths.has('')).toBe(true);
-    expect(store.loadedPaths.has('src')).toBe(false);
+    expect(store.loadedPaths.has('src')).toBe(true);
     expect(store.rootNodes.map((node) => node.path)).toEqual(['src', 'README.md']);
   });
 
@@ -103,6 +116,28 @@ describe('FilesStore', () => {
     store.dispose();
   });
 
+  it('sorts loaded directory entries once after applying the batch', async () => {
+    setupListFiles({
+      '': [
+        { path: 'z-file.ts', type: 'file' },
+        { path: 'components', type: 'dir' },
+        { path: 'a-file.ts', type: 'file' },
+        { path: 'alpha', type: 'dir' },
+      ],
+    });
+
+    const store = new FilesStore('project-1', 'workspace-1');
+    await store.tree.load();
+
+    expect(store.rootNodes.map((node) => node.path)).toEqual([
+      'alpha',
+      'components',
+      'a-file.ts',
+      'z-file.ts',
+    ]);
+    store.dispose();
+  });
+
   it('normalizes loaded child paths into the current folder children', async () => {
     setupListFiles({
       '': [{ path: 'src', type: 'dir' }],
@@ -123,6 +158,64 @@ describe('FilesStore', () => {
       'src/index.ts',
     ]);
     expect(store.nodes.has('src\\components')).toBe(false);
+    store.dispose();
+  });
+
+  it('removes stale descendants and loaded markers when a loaded directory becomes a file', async () => {
+    const entriesByDir: Record<string, Entry[]> = {
+      '': [{ path: 'src', type: 'dir' }],
+      src: [{ path: 'src/components', type: 'dir' }],
+      'src/components': [{ path: 'src/components/Button.tsx', type: 'file' }],
+    };
+    setupListFiles(entriesByDir);
+
+    const store = new FilesStore('project-1', 'workspace-1');
+    await store.tree.load();
+    await flushAsyncWork();
+
+    expect(store.nodes.has('src/components/Button.tsx')).toBe(true);
+    expect(store.loadedPaths.has('src/components')).toBe(true);
+
+    entriesByDir.src = [{ path: 'src/components', type: 'file' }];
+    await store.loadDir('src', true);
+    vi.runOnlyPendingTimers();
+
+    expect(store.nodes.get('src/components')?.type).toBe('file');
+    expect(store.nodes.get('src/components')?.children).toEqual([]);
+    expect(store.nodes.has('src/components/Button.tsx')).toBe(false);
+    expect(store.loadedPaths.has('src/components')).toBe(false);
+    expect(store.nodes.get('src')?.children.map((node) => node.path)).toEqual(['src/components']);
+    store.dispose();
+  });
+
+  it('sorts watch-created siblings after processing the event batch', async () => {
+    let emit: ((data: { workspaceId: string; events: FileWatchEvent[] }) => void) | undefined;
+    mocks.eventOn.mockImplementation((_channel: string, handler: typeof emit) => {
+      emit = handler;
+      return vi.fn();
+    });
+    setupListFiles({ '': [] });
+
+    const store = new FilesStore('project-1', 'workspace-1');
+    store.startWatching();
+    await store.tree.load();
+
+    emit?.({
+      workspaceId: 'workspace-1',
+      events: [
+        { type: 'create', entryType: 'file', path: 'z-file.ts' },
+        { type: 'create', entryType: 'directory', path: 'components' },
+        { type: 'create', entryType: 'file', path: 'a-file.ts' },
+        { type: 'create', entryType: 'directory', path: 'alpha' },
+      ],
+    });
+
+    expect(store.rootNodes.map((node) => node.path)).toEqual([
+      'alpha',
+      'components',
+      'a-file.ts',
+      'z-file.ts',
+    ]);
     store.dispose();
   });
 

--- a/src/renderer/features/tasks/editor/stores/files-store.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.ts
@@ -3,7 +3,8 @@ import { type FileNode, type FileWatchEvent } from '@shared/fs';
 import {
   isExcluded,
   makeNode,
-  sortedChildPaths,
+  normalizeFileTreePath,
+  sortFileNodes,
 } from '@renderer/features/tasks/editor/stores/files-store-utils';
 import { events, rpc } from '@renderer/lib/ipc';
 import { Resource } from '@renderer/lib/stores/resource';
@@ -14,7 +15,7 @@ import { Resource } from '@renderer/lib/stores/resource';
 
 export interface FilesData {
   nodes: Map<string, FileNode>;
-  childIndex: Map<string | null, string[]>;
+  rootNodes: FileNode[];
 }
 
 // ---------------------------------------------------------------------------
@@ -24,14 +25,14 @@ export interface FilesData {
 export class FilesStore {
   // Non-observable imperative maps — tree.data drives reactive re-renders.
   private readonly _nodes = new Map<string, FileNode>();
-  private readonly _childIndex = new Map<string | null, string[]>();
+  private _rootNodes: FileNode[] = [];
   private readonly _loadedPaths = new Set<string>();
   private readonly _pendingPaths = new Set<string>();
   private _bumpTimer: ReturnType<typeof setTimeout> | null = null;
 
   /**
    * The reactive container for the file tree. Components observe `tree.data`
-   * (or access `nodes`/`childIndex` getters which read through `tree.data`).
+   * (or access `nodes`/`rootNodes` getters which read through `tree.data`).
    * The data object reference is replaced whenever the tree structure changes,
    * triggering MobX re-renders — replacing the old `generation` counter.
    */
@@ -63,7 +64,7 @@ export class FilesStore {
               return;
             }
             const changed = this._applyWatchEventsInternal(watchEvents);
-            if (changed) ctx.set({ nodes: this._nodes, childIndex: this._childIndex });
+            if (changed) ctx.set({ nodes: this._nodes, rootNodes: this._rootNodes });
           },
         },
       ]
@@ -84,8 +85,8 @@ export class FilesStore {
     return this.tree.data?.nodes ?? this._nodes;
   }
 
-  get childIndex(): Map<string | null, string[]> {
-    return this.tree.data?.childIndex ?? this._childIndex;
+  get rootNodes(): FileNode[] {
+    return this.tree.data?.rootNodes ?? this._rootNodes;
   }
 
   get loadedPaths(): Set<string> {
@@ -126,7 +127,7 @@ export class FilesStore {
   // ---------------------------------------------------------------------------
 
   async loadDir(dirPath: string, force = false): Promise<void> {
-    await this._loadDirInternal(dirPath, force);
+    await this._loadDirInternal(normalizeFileTreePath(dirPath), force);
     this._bumpTreeDebounced();
   }
 
@@ -135,13 +136,14 @@ export class FilesStore {
     const inserted: string[] = [];
 
     for (const { relPath, type } of nodes) {
-      if (!relPath || isExcluded(relPath) || this._nodes.has(relPath)) continue;
+      const path = normalizeFileTreePath(relPath);
+      if (!path || isExcluded(path) || this._nodes.has(path)) continue;
 
-      const parent = relPath.includes('/') ? relPath.slice(0, relPath.lastIndexOf('/')) : '';
+      const parent = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
       if (!this._loadedPaths.has(parent)) continue;
 
-      this._addNode(makeNode(relPath, type));
-      inserted.push(relPath);
+      this._addNode(makeNode(path, type));
+      inserted.push(path);
     }
 
     if (inserted.length > 0) this._bumpTree();
@@ -149,13 +151,14 @@ export class FilesStore {
   }
 
   removeNode(relPath: string): void {
-    if (!this._nodes.has(relPath)) return;
-    this._removeNode(relPath);
+    const path = normalizeFileTreePath(relPath);
+    if (!this._nodes.has(path)) return;
+    this._removeNode(path);
     this._bumpTree();
   }
 
   async revealFile(filePath: string, expandedPaths: Set<string>): Promise<void> {
-    const parts = filePath.split('/').filter(Boolean);
+    const parts = normalizeFileTreePath(filePath).split('/').filter(Boolean);
     const dirs: string[] = [];
     for (let i = 1; i < parts.length; i++) {
       dirs.push(parts.slice(0, i).join('/'));
@@ -173,18 +176,19 @@ export class FilesStore {
   // Private helpers
   // ---------------------------------------------------------------------------
 
-  /** Full recursive load used as the Resource's fetch function. */
+  /** Initial load used as the Resource's fetch function. */
   private async _fetchAll(): Promise<FilesData> {
     this._nodes.clear();
-    this._childIndex.clear();
+    this._rootNodes = [];
     this._loadedPaths.clear();
     this._pendingPaths.clear();
     await this._loadDirInternal('');
-    return { nodes: this._nodes, childIndex: this._childIndex };
+    return { nodes: this._nodes, rootNodes: this._rootNodes };
   }
 
   /** Load a single directory level into the backing Maps. No reactivity bump. */
   private async _loadDirInternal(dirPath: string, force = false): Promise<void> {
+    dirPath = normalizeFileTreePath(dirPath);
     if (!force && (this._loadedPaths.has(dirPath) || this._pendingPaths.has(dirPath))) return;
     this._pendingPaths.add(dirPath);
 
@@ -198,12 +202,6 @@ export class FilesStore {
 
       this._applyEntries(dirPath, result.data.entries);
 
-      for (const entry of result.data.entries) {
-        if (entry.type === 'dir' && !isExcluded(entry.path)) {
-          void this._loadDirInternal(entry.path);
-        }
-      }
-
       this._bumpTreeDebounced();
     } catch {
       // Silently ignore errors for individual directories
@@ -216,60 +214,98 @@ export class FilesStore {
     dirPath: string,
     entries: Array<{ path: string; type: 'file' | 'dir'; mtime?: Date }>
   ): void {
-    const affectedParents = new Set<string | null>();
+    const normalizedDirPath = normalizeFileTreePath(dirPath);
+    const parent = this._ensureDirectory(normalizedDirPath);
+    const nextChildren = new Set<string>();
 
     for (const entry of entries) {
-      if (isExcluded(entry.path)) continue;
-      const node = makeNode(entry.path, entry.type === 'dir' ? 'directory' : 'file', entry.mtime);
+      const path = normalizeFileTreePath(entry.path);
+      if (!path || isExcluded(path)) continue;
 
-      this._nodes.set(node.path, node);
+      const node = makeNode(path, entry.type === 'dir' ? 'directory' : 'file', entry.mtime);
+      if ((node.parentPath ?? '') !== normalizedDirPath) continue;
 
-      const parent = node.parentPath;
-      const siblings = this._childIndex.get(parent) ?? [];
-      if (!siblings.includes(node.path)) {
-        siblings.push(node.path);
-        this._childIndex.set(parent, siblings);
-      }
-      affectedParents.add(parent);
+      nextChildren.add(node.path);
+      this._addNode(node);
     }
 
-    for (const parent of affectedParents) {
-      const children = this._childIndex.get(parent);
-      if (children) {
-        this._childIndex.set(parent, sortedChildPaths(children, this._nodes));
+    const currentChildren = parent?.children ?? this._rootNodes;
+    for (const child of [...currentChildren]) {
+      if (!nextChildren.has(child.path)) {
+        this._removeNode(child.path);
       }
     }
 
-    this._loadedPaths.add(dirPath);
+    this._sortChildren(parent);
+    this._loadedPaths.add(normalizedDirPath);
+  }
+
+  private _ensureDirectory(path: string): FileNode | null {
+    if (!path) return null;
+
+    const parts = path.split('/').filter(Boolean);
+    let currentPath = '';
+    let current: FileNode | null = null;
+
+    for (const part of parts) {
+      currentPath = currentPath ? `${currentPath}/${part}` : part;
+      const existing = this._nodes.get(currentPath);
+      if (existing) {
+        current = existing;
+        continue;
+      }
+
+      current = makeNode(currentPath, 'directory');
+      this._addNode(current);
+    }
+
+    return current;
   }
 
   private _addNode(node: FileNode): void {
-    this._nodes.set(node.path, node);
-    const parent = node.parentPath;
-    const existing = this._childIndex.get(parent) ?? [];
-    if (!existing.includes(node.path)) {
-      this._childIndex.set(parent, sortedChildPaths([...existing, node.path], this._nodes));
+    const existing = this._nodes.get(node.path);
+    if (existing) {
+      existing.type = node.type;
+      existing.mtime = node.mtime;
+      existing.extension = node.extension;
+      existing.isHidden = node.isHidden;
+      if (node.type === 'file') existing.children = [];
+      this._sortChildren(existing.parentPath ? this._nodes.get(existing.parentPath) : null);
+      return;
     }
+
+    this._nodes.set(node.path, node);
+    const parent = node.parentPath ? this._nodes.get(node.parentPath) : null;
+    const siblings = parent?.children ?? this._rootNodes;
+    if (!siblings.some((child) => child.path === node.path)) siblings.push(node);
+    this._sortChildren(parent);
   }
 
   private _removeNode(path: string): void {
     const node = this._nodes.get(path);
     if (!node) return;
 
-    const siblings = this._childIndex.get(node.parentPath) ?? [];
-    this._childIndex.set(
-      node.parentPath,
-      siblings.filter((p) => p !== path)
-    );
+    const parent = node.parentPath ? this._nodes.get(node.parentPath) : null;
+    const siblings = parent?.children ?? this._rootNodes;
+    const index = siblings.findIndex((child) => child.path === path);
+    if (index !== -1) siblings.splice(index, 1);
 
-    const toRemove: string[] = [path];
-    while (toRemove.length) {
-      const p = toRemove.pop()!;
-      this._nodes.delete(p);
-      this._loadedPaths.delete(p);
-      const children = this._childIndex.get(p) ?? [];
-      toRemove.push(...children);
-      this._childIndex.delete(p);
+    this._removeNodeFromMaps(node);
+  }
+
+  private _removeNodeFromMaps(node: FileNode): void {
+    for (const child of [...node.children]) {
+      this._removeNodeFromMaps(child);
+    }
+    this._nodes.delete(node.path);
+    this._loadedPaths.delete(node.path);
+  }
+
+  private _sortChildren(parent: FileNode | null | undefined): void {
+    if (parent) {
+      parent.children = sortFileNodes(parent.children);
+    } else {
+      this._rootNodes = sortFileNodes(this._rootNodes);
     }
   }
 
@@ -278,32 +314,34 @@ export class FilesStore {
     let changed = false;
 
     for (const evt of watchEvents) {
-      if (isExcluded(evt.path)) continue;
+      const path = normalizeFileTreePath(evt.path);
+      if (isExcluded(path)) continue;
 
       if (evt.type === 'create') {
-        const node = makeNode(evt.path, evt.entryType);
+        const node = makeNode(path, evt.entryType);
         const parentLoaded = this._loadedPaths.has(node.parentPath ?? '');
-        if (parentLoaded && !this._nodes.has(evt.path)) {
+        if (parentLoaded && !this._nodes.has(node.path)) {
           this._addNode(node);
           changed = true;
         }
       } else if (evt.type === 'delete') {
-        if (this._nodes.has(evt.path)) {
-          this._removeNode(evt.path);
+        if (this._nodes.has(path)) {
+          this._removeNode(path);
           changed = true;
         }
       } else if (evt.type === 'modify') {
-        const existing = this._nodes.get(evt.path);
+        const existing = this._nodes.get(path);
         if (existing) {
-          this._nodes.set(evt.path, { ...existing, mtime: new Date() });
+          existing.mtime = new Date();
           changed = true;
         }
       } else if (evt.type === 'rename' && evt.oldPath) {
-        if (this._nodes.has(evt.oldPath)) {
-          this._removeNode(evt.oldPath);
+        const oldPath = normalizeFileTreePath(evt.oldPath);
+        if (this._nodes.has(oldPath)) {
+          this._removeNode(oldPath);
           changed = true;
         }
-        const node = makeNode(evt.path, evt.entryType);
+        const node = makeNode(path, evt.entryType);
         const parentLoaded = this._loadedPaths.has(node.parentPath ?? '');
         if (parentLoaded) {
           this._addNode(node);
@@ -316,7 +354,7 @@ export class FilesStore {
   }
 
   private _bumpTree(): void {
-    this.tree.setValue({ nodes: this._nodes, childIndex: this._childIndex });
+    this.tree.setValue({ nodes: this._nodes, rootNodes: this._rootNodes });
   }
 
   private _bumpTreeDebounced(): void {

--- a/src/renderer/features/tasks/editor/stores/files-store.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.ts
@@ -134,6 +134,7 @@ export class FilesStore {
   /** Optimistically insert dropped nodes and bump the tree once. */
   addOptimisticNodes(nodes: Array<{ relPath: string; type: 'file' | 'directory' }>): string[] {
     const inserted: string[] = [];
+    const affectedParents = new Set<string | null>();
 
     for (const { relPath, type } of nodes) {
       const path = normalizeFileTreePath(relPath);
@@ -142,11 +143,18 @@ export class FilesStore {
       const parent = path.includes('/') ? path.slice(0, path.lastIndexOf('/')) : '';
       if (!this._loadedPaths.has(parent)) continue;
 
-      this._addNode(makeNode(path, type));
+      const node = makeNode(path, type);
+      this._addNode(node);
+      affectedParents.add(node.parentPath);
       inserted.push(path);
     }
 
-    if (inserted.length > 0) this._bumpTree();
+    if (inserted.length > 0) {
+      for (const parentPath of affectedParents) {
+        this._sortChildren(parentPath ? this._nodes.get(parentPath) : null);
+      }
+      this._bumpTree();
+    }
     return inserted;
   }
 
@@ -201,6 +209,13 @@ export class FilesStore {
       if (!result.success) return;
 
       this._applyEntries(dirPath, result.data.entries);
+
+      for (const entry of result.data.entries) {
+        const path = normalizeFileTreePath(entry.path);
+        if (entry.type === 'dir' && path && !isExcluded(path)) {
+          void this._loadDirInternal(path);
+        }
+      }
 
       this._bumpTreeDebounced();
     } catch {
@@ -265,12 +280,7 @@ export class FilesStore {
   private _addNode(node: FileNode): void {
     const existing = this._nodes.get(node.path);
     if (existing) {
-      existing.type = node.type;
-      existing.mtime = node.mtime;
-      existing.extension = node.extension;
-      existing.isHidden = node.isHidden;
-      if (node.type === 'file') existing.children = [];
-      this._sortChildren(existing.parentPath ? this._nodes.get(existing.parentPath) : null);
+      this._replaceExistingNode(existing, node);
       return;
     }
 
@@ -278,7 +288,33 @@ export class FilesStore {
     const parent = node.parentPath ? this._nodes.get(node.parentPath) : null;
     const siblings = parent?.children ?? this._rootNodes;
     if (!siblings.some((child) => child.path === node.path)) siblings.push(node);
-    this._sortChildren(parent);
+  }
+
+  private _replaceExistingNode(existing: FileNode, next: FileNode): void {
+    if (existing.type === 'directory' && next.type === 'file') {
+      this._replaceDirectoryWithFile(existing, next);
+      return;
+    }
+
+    existing.type = next.type;
+    existing.mtime = next.mtime;
+    existing.extension = next.extension;
+    existing.isHidden = next.isHidden;
+  }
+
+  private _replaceDirectoryWithFile(existing: FileNode, next: FileNode): void {
+    const parent = existing.parentPath ? this._nodes.get(existing.parentPath) : null;
+    const siblings = parent?.children ?? this._rootNodes;
+    const index = siblings.findIndex((child) => child.path === existing.path);
+
+    this._removeNodeFromMaps(existing);
+    this._nodes.set(next.path, next);
+
+    if (index === -1) {
+      siblings.push(next);
+    } else {
+      siblings[index] = next;
+    }
   }
 
   private _removeNode(path: string): void {
@@ -312,6 +348,7 @@ export class FilesStore {
   /** Mutate the backing maps for watch events. Returns true if anything changed. */
   private _applyWatchEventsInternal(watchEvents: FileWatchEvent[]): boolean {
     let changed = false;
+    const affectedParents = new Set<string | null>();
 
     for (const evt of watchEvents) {
       const path = normalizeFileTreePath(evt.path);
@@ -322,10 +359,13 @@ export class FilesStore {
         const parentLoaded = this._loadedPaths.has(node.parentPath ?? '');
         if (parentLoaded && !this._nodes.has(node.path)) {
           this._addNode(node);
+          affectedParents.add(node.parentPath);
           changed = true;
         }
       } else if (evt.type === 'delete') {
-        if (this._nodes.has(path)) {
+        const existing = this._nodes.get(path);
+        if (existing) {
+          affectedParents.add(existing.parentPath);
           this._removeNode(path);
           changed = true;
         }
@@ -345,9 +385,14 @@ export class FilesStore {
         const parentLoaded = this._loadedPaths.has(node.parentPath ?? '');
         if (parentLoaded) {
           this._addNode(node);
+          affectedParents.add(node.parentPath);
           changed = true;
         }
       }
+    }
+
+    for (const parentPath of affectedParents) {
+      this._sortChildren(parentPath ? this._nodes.get(parentPath) : null);
     }
 
     return changed;

--- a/src/shared/fs.ts
+++ b/src/shared/fs.ts
@@ -4,6 +4,7 @@ export interface FileNode {
   parentPath: string | null;
   depth: number;
   type: 'file' | 'directory';
+  children: FileNode[];
   isHidden: boolean;
   extension?: string;
   mtime?: Date;


### PR DESCRIPTION

<img width="1384" height="835" alt="File tree QA" src="https://github.com/user-attachments/assets/dd195195-e90e-4668-92e0-42a7de08204b" />
Fixes #1952.

## Summary
- Refactor the task editor file tree to use a normalized hierarchical node model with stable POSIX paths and per-folder `children`.
- Keep initial file loading root-only, with directory contents loaded lazily on expansion or reveal.
- Normalize local filesystem relative paths on Windows so nested files do not render as duplicated root-level wrappers.

## Root Cause
The renderer tree was backed by a flat parent index and Windows local file paths could arrive with backslashes. That allowed nested entries such as `src\routes\+page.svelte` to be treated as a single root identity instead of `src -> routes -> +page.svelte`, producing repeated folder/file-looking rows.

## Implementation
- Add `children` to `FileNode` and derive visible rows from `rootNodes` by walking each expanded directory's own children.
- Normalize file-tree paths before storing, loading, revealing, adding, removing, or processing watch events.
- Preserve task-scoped expansion state through existing `expandedPaths` snapshots.
- Update `LocalFileSystem.relPath()` to return POSIX-style relative paths.
- Add focused unit tests for path normalization, collapsed/expanded visibility, directory-first sorting, leaf file behavior, lazy loading, and reveal loading.

## Validation
- `pnpm run format` passed
- `pnpm run lint` passed
- `pnpm run typecheck` passed
- `pnpm exec vitest run --project node src/renderer/features/tasks/editor/stores/files-store.test.ts src/renderer/features/tasks/editor/stores/files-store-utils.test.ts src/main/core/fs/impl/local-fs.test.ts` passed: 61 tests
- Electron rendered QA passed: root-only initially, `src` expands to direct children, `routes` expands to direct children, and no duplicated folder/file wrappers appeared.

## Notes
- `pnpm run test` still has unrelated existing Windows/environment-sensitive failures in migration fixture paths, MCP config path separator expectations, dependency probe mocks, user env mocks, PTY env, and worktree path assertions.