### PR TITLE
fix: clarify optional branch prefix

### DIFF
--- a/src/renderer/features/settings/components/RepositorySettingsCard.tsx
+++ b/src/renderer/features/settings/components/RepositorySettingsCard.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo } from 'react';
+import React from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { Input } from '@renderer/lib/ui/input';
 import { Switch } from '@renderer/lib/ui/switch';
@@ -30,12 +30,6 @@ const RepositorySettingsCard: React.FC = () => {
   const projectBusy = projectLoading || projectSaving;
   const localProjectBusy = localProjectLoading || localProjectSaving;
 
-  const example = useMemo(() => {
-    const prefix = branchPrefix ? `${branchPrefix}/` : '';
-    const suffix = appendRandomBranchSuffix ? '-a3f' : '';
-    return `${prefix}my-feature${suffix}`;
-  }, [appendRandomBranchSuffix, branchPrefix]);
-
   return (
     <div className="grid gap-8">
       <div className="grid gap-2">
@@ -61,8 +55,8 @@ const RepositorySettingsCard: React.FC = () => {
             disabled={projectBusy}
           />
         </div>
-        <div className="text-[11px] text-muted-foreground">
-          Example: <code className="rounded bg-muted/60 px-1">{example}</code>
+        <div className="text-xs text-foreground-passive">
+          Leave empty to create branches without a prefix.
         </div>
       </div>
       <SettingRow


### PR DESCRIPTION
## Summary

- Adds muted helper text explaining that the branch prefix can be left empty.

- Removes the generated branch-name example from the branch prefix setting.
## Validation
- pnpm run format
- pnpm run lint
- pnpm run typecheck

- pnpm run test





