### PR TITLE
fix(renderer): harden restored navigation state

### DIFF
--- a/src/renderer/app/view-registry.ts
+++ b/src/renderer/app/view-registry.ts
@@ -34,8 +34,11 @@ export type ViewDefinition<TParams extends object = Record<never, never>> = {
   /**
    * Called before navigation to this view is committed. Return { ok: false }
    * to redirect to a different view instead.
+   *
+   * Receives `unknown` because params can come from persisted snapshots written
+   * by older builds, so each guard must validate the shape before using it.
    */
-  canActivate?: (params: TParams) => GuardResult;
+  canActivate?: (params: unknown) => GuardResult;
 };
 
 type Views = typeof views;
@@ -54,13 +57,11 @@ export type GuardResult =
 
 export function setupNavigationGuards(): void {
   for (const [viewId, view] of Object.entries(views) as Array<
-    [string, ViewDefinition<Record<string, unknown>>]
+    [ViewId, ViewDefinition<Record<string, unknown>>]
   >) {
+    appState.navigation.registerView(viewId);
     if (view.canActivate) {
-      appState.navigation.registerGuard(
-        viewId as ViewId,
-        view.canActivate as (params: unknown) => GuardResult
-      );
+      appState.navigation.registerGuard(viewId, view.canActivate);
     }
   }
 }

--- a/src/renderer/features/projects/view.tsx
+++ b/src/renderer/features/projects/view.tsx
@@ -8,8 +8,15 @@ export const projectView = {
   WrapView: ProjectViewWrapper,
   TitlebarSlot: ProjectTitlebar,
   MainPanel: ProjectMainPanel,
-  canActivate: ({ projectId }: { projectId: string }): GuardResult =>
-    appState.projects.projects.has(projectId) || appState.projects.pendingCreationIds.has(projectId)
+  canActivate: (params: unknown): GuardResult => {
+    const projectId =
+      typeof params === 'object' && params !== null
+        ? (params as { projectId?: unknown }).projectId
+        : undefined;
+    if (typeof projectId !== 'string') return { ok: false, redirect: 'home' };
+    return appState.projects.projects.has(projectId) ||
+      appState.projects.pendingCreationIds.has(projectId)
       ? { ok: true }
-      : { ok: false, redirect: 'home' },
+      : { ok: false, redirect: 'home' };
+  },
 };

--- a/src/renderer/features/tasks/task-titlebar.tsx
+++ b/src/renderer/features/tasks/task-titlebar.tsx
@@ -67,7 +67,7 @@ const PendingTaskTitlebar = observer(function PendingTaskTitlebar({
   taskId: string;
   projectId: string;
 }) {
-  const taskStore = getTaskStore(projectId, taskId)!;
+  const taskStore = getTaskStore(projectId, taskId);
   const projectName = projectDisplayName(getProjectStore(projectId));
   const name = taskDisplayName(taskStore);
   const { navigate } = useNavigate();
@@ -100,8 +100,8 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
   projectId: string;
   taskId: string;
 }) {
-  const taskStore = getTaskStore(projectId, taskId)!;
-  const taskPayload = getRegisteredTaskData(projectId, taskId)!;
+  const taskStore = getTaskStore(projectId, taskId);
+  const taskPayload = getRegisteredTaskData(projectId, taskId);
   const workspace = useWorkspace();
   const taskView = useWorkspaceViewModel();
 
@@ -123,6 +123,8 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
 
   const projectName = projectDisplayName(getProjectStore(projectId));
   const { navigate } = useNavigate();
+
+  if (!taskStore || !taskPayload) return null;
 
   const isRemoteProject = projectStore?.data.type === 'ssh';
   return (

--- a/src/renderer/features/tasks/view.tsx
+++ b/src/renderer/features/tasks/view.tsx
@@ -57,8 +57,28 @@ export const taskView = {
   MainPanel: TaskMainPanel,
   commandProvider: ({ projectId, taskId }: { projectId: string; taskId: string }) =>
     createTaskCommandProvider(projectId, taskId),
-  canActivate: ({ projectId }: { projectId: string; taskId: string }): GuardResult =>
-    appState.projects.projects.has(projectId) || appState.projects.pendingCreationIds.has(projectId)
-      ? { ok: true }
-      : { ok: false, redirect: 'home' },
+  canActivate: (params: unknown): GuardResult => {
+    const projectId =
+      typeof params === 'object' && params !== null
+        ? (params as { projectId?: unknown }).projectId
+        : undefined;
+    const taskId =
+      typeof params === 'object' && params !== null
+        ? (params as { taskId?: unknown }).taskId
+        : undefined;
+    if (typeof projectId !== 'string' || typeof taskId !== 'string') {
+      return { ok: false, redirect: 'home' };
+    }
+    if (
+      !appState.projects.projects.has(projectId) &&
+      !appState.projects.pendingCreationIds.has(projectId)
+    ) {
+      return { ok: false, redirect: 'home' };
+    }
+    const taskManager = getTaskManagerStore(projectId);
+    if (taskManager && !taskManager.tasks.has(taskId)) {
+      return { ok: false, redirect: 'project', params: { projectId } };
+    }
+    return { ok: true };
+  },
 } satisfies ViewDefinition<{ projectId: string; taskId: string }>;

--- a/src/renderer/lib/layout/navigation-provider.tsx
+++ b/src/renderer/lib/layout/navigation-provider.tsx
@@ -55,16 +55,16 @@ export function useNavigate(): { navigate: NavigateFnTyped } {
 export function useWorkspaceSlots(): SlotsContextValue {
   return useObserver(() => {
     const viewId = appState.navigation.currentViewId;
-    const def = (views as unknown as Record<string, ViewDefinition<Record<string, unknown>>>)[
-      viewId
-    ];
+    const registry = views as unknown as Record<string, ViewDefinition<Record<string, unknown>>>;
+    const def = registry[viewId] ?? registry.home;
+    const resolvedViewId = registry[viewId] ? viewId : 'home';
     return {
       WrapView: (def.WrapView ?? Fragment) as ComponentType<
         { children: ReactNode } & Record<string, unknown>
       >,
       TitlebarSlot: def.TitlebarSlot ?? (() => null),
       MainPanel: def.MainPanel,
-      currentView: viewId,
+      currentView: resolvedViewId,
       lastNonSettingsView: appState.navigation.lastNonSettingsView,
     };
   });

--- a/src/renderer/lib/layout/navigation-provider.tsx
+++ b/src/renderer/lib/layout/navigation-provider.tsx
@@ -56,8 +56,9 @@ export function useWorkspaceSlots(): SlotsContextValue {
   return useObserver(() => {
     const viewId = appState.navigation.currentViewId;
     const registry = views as unknown as Record<string, ViewDefinition<Record<string, unknown>>>;
-    const def = registry[viewId] ?? registry.home;
-    const resolvedViewId = registry[viewId] ? viewId : 'home';
+    const viewDef = registry[viewId];
+    const def = viewDef ?? registry.home;
+    const resolvedViewId = viewDef ? viewId : 'home';
     return {
       WrapView: (def.WrapView ?? Fragment) as ComponentType<
         { children: ReactNode } & Record<string, unknown>

--- a/src/renderer/lib/stores/navigation-store.test.ts
+++ b/src/renderer/lib/stores/navigation-store.test.ts
@@ -1,0 +1,86 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@renderer/lib/modal/modal-store', () => ({
+  modalStore: { closeModal: vi.fn() },
+}));
+
+vi.mock('@renderer/utils/focus-tracker', () => ({
+  focusTracker: { transition: vi.fn(() => null) },
+}));
+
+vi.mock('@renderer/utils/telemetryClient', () => ({
+  captureTelemetry: vi.fn(),
+}));
+
+vi.mock('./app-state', () => ({
+  appState: {
+    history: { push: vi.fn() },
+  },
+}));
+
+const { NavigationStore } = await import('./navigation-store');
+
+function buildStore() {
+  const store = new NavigationStore();
+  store.registerView('home');
+  store.registerView('project');
+  store.registerView('settings');
+  return store;
+}
+
+describe('NavigationStore.restoreSnapshot', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('restores a snapshot whose view is registered', () => {
+    const store = buildStore();
+    store.restoreSnapshot({
+      currentViewId: 'project',
+      viewParams: { project: { projectId: 'p1' } },
+    });
+    expect(store.currentViewId).toBe('project');
+    expect(store.viewParamsStore.project).toEqual({ projectId: 'p1' });
+    expect(store.lastNonSettingsView).toBe('project');
+  });
+
+  it('falls back to home when the persisted view is not in the registry', () => {
+    const store = buildStore();
+    store.restoreSnapshot({
+      currentViewId: 'phantom-view-from-old-build',
+      viewParams: { project: { projectId: 'p1' } },
+    });
+    expect(store.currentViewId).toBe('home');
+    expect(store.lastNonSettingsView).toBe('home');
+  });
+
+  it('strips viewParams entries whose key is not a registered view', () => {
+    const store = buildStore();
+    store.restoreSnapshot({
+      currentViewId: 'home',
+      viewParams: {
+        project: { projectId: 'p1' },
+        ghostView: { stale: true },
+      },
+    });
+    expect(store.viewParamsStore.project).toEqual({ projectId: 'p1' });
+    expect((store.viewParamsStore as Record<string, unknown>).ghostView).toBeUndefined();
+  });
+
+  it('does not touch lastNonSettingsView when the persisted view is settings', () => {
+    const store = buildStore();
+    store.restoreSnapshot({ currentViewId: 'settings' });
+    expect(store.currentViewId).toBe('settings');
+    expect(store.lastNonSettingsView).toBe('home');
+  });
+
+  it('honors a guard redirect after a valid view is restored', () => {
+    const store = buildStore();
+    store.registerGuard('project', () => ({ ok: false, redirect: 'home' }));
+    store.restoreSnapshot({
+      currentViewId: 'project',
+      viewParams: { project: { projectId: 'gone' } },
+    });
+    expect(store.currentViewId).toBe('home');
+  });
+});

--- a/src/renderer/lib/stores/navigation-store.ts
+++ b/src/renderer/lib/stores/navigation-store.ts
@@ -36,9 +36,18 @@ export class NavigationStore implements Snapshottable<NavigationSnapshot> {
   lastNonSettingsView: NonSettingsViewId = 'home';
 
   private readonly _guards = new Map<ViewId, (params: unknown) => GuardResult>();
+  private readonly _registeredViewIds = new Set<ViewId>();
 
   constructor() {
     makeAutoObservable(this);
+  }
+
+  registerView(viewId: ViewId): void {
+    this._registeredViewIds.add(viewId);
+  }
+
+  isRegisteredViewId(value: unknown): value is ViewId {
+    return typeof value === 'string' && this._registeredViewIds.has(value as ViewId);
   }
 
   registerGuard(viewId: ViewId, guard: (params: unknown) => GuardResult): void {
@@ -113,13 +122,21 @@ export class NavigationStore implements Snapshottable<NavigationSnapshot> {
   }
 
   restoreSnapshot(snapshot: Partial<NavigationSnapshot>): void {
-    if (snapshot.currentViewId) {
-      this.currentViewId = snapshot.currentViewId as ViewId;
+    if (this.isRegisteredViewId(snapshot.currentViewId)) {
+      this.currentViewId = snapshot.currentViewId;
       if (snapshot.currentViewId !== 'settings') {
         this.lastNonSettingsView = snapshot.currentViewId as NonSettingsViewId;
       }
     }
-    if (snapshot.viewParams) this.viewParamsStore = snapshot.viewParams as ViewParamsStore;
+    if (snapshot.viewParams) {
+      const filtered: ViewParamsStore = {};
+      for (const [key, value] of Object.entries(snapshot.viewParams)) {
+        if (this.isRegisteredViewId(key)) {
+          (filtered as Record<ViewId, unknown>)[key] = value;
+        }
+      }
+      this.viewParamsStore = filtered;
+    }
 
     // Validate after params are loaded so the guard has full context.
     const guard = this._runGuard(this.currentViewId, this.viewParamsStore[this.currentViewId]);


### PR DESCRIPTION
- harden restored renderer navigation state against stale data from older builds.
- register valid view IDs during startup and ignore persisted currentViewId values that are no longer supported.
- fall back to home if the workspace slot resolver encounters an unknown view ID
- make project/task navigation guards validate unknown persisted params before use.
- redirect stale or missing task routes back to the project view instead of crashing.