### PR TITLE
ENG-1118: Review individual commits in PR sidebar

### DIFF
--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -817,7 +817,7 @@ export class GitService implements GitProvider, IDisposable {
 
     const FIELD_SEP = '---FIELD_SEP---';
     const RECORD_SEP = '---RECORD_SEP---';
-    const format = `${RECORD_SEP}%H${FIELD_SEP}%s${FIELD_SEP}%an${FIELD_SEP}%aI${FIELD_SEP}%D${FIELD_SEP}%b`;
+    const format = `${RECORD_SEP}%H${FIELD_SEP}%P${FIELD_SEP}%s${FIELD_SEP}%an${FIELD_SEP}%aI${FIELD_SEP}%D${FIELD_SEP}%b`;
     // When base is provided (PR view), use a range so only commits between
     // base and head are returned — not a raw linear walk from head.
     const rangeArg = base ? `${toRefString(base)}..${headStr}` : headStr;
@@ -837,7 +837,7 @@ export class GitService implements GitProvider, IDisposable {
       .filter((entry) => entry.trim())
       .map((entry, index) => {
         const parts = entry.trim().split(FIELD_SEP);
-        const refs = parts[4] || '';
+        const refs = parts[5] || '';
         const tags = refs
           .split(',')
           .map((r) => r.trim())
@@ -845,10 +845,11 @@ export class GitService implements GitProvider, IDisposable {
           .map((r) => r.slice(5));
         return {
           hash: parts[0] || '',
-          subject: parts[1] || '',
-          body: (parts[5] || '').trim(),
-          author: parts[2] || '',
-          date: parts[3] || '',
+          parents: (parts[1] || '').split(' ').filter(Boolean),
+          subject: parts[2] || '',
+          body: (parts[6] || '').trim(),
+          author: parts[3] || '',
+          date: parts[4] || '',
           isPushed: skip + index >= aheadCount,
           tags,
         };

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -24,6 +24,7 @@ import {
   type FetchPrForReviewError,
   type FullGitStatus,
   type GitChange,
+  type GitChangeStatus,
   type GitHeadState,
   type GitInfo,
   type GitObjectRef,
@@ -946,7 +947,7 @@ export class GitService implements GitProvider, IDisposable {
     const statLines = stdout.trim().split('\n').filter(Boolean);
     const statusLines = nameStatus.trim().split('\n').filter(Boolean);
 
-    const statusMap = new Map<string, string>();
+    const statusMap = new Map<string, GitChangeStatus>();
     for (const line of statusLines) {
       const [code, ...pathParts] = line.split('\t');
       const filePath = pathParts[pathParts.length - 1] || '';

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/commits-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/commits-list.tsx
@@ -1,6 +1,7 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronDown, ChevronRight } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useMemo, useState } from 'react';
+import { useMemo, useRef, useState } from 'react';
 import { usePrefetchDiffModels } from '@renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models';
 import {
   useTaskViewContext,
@@ -15,6 +16,9 @@ import { ChangesListItem } from '../changes-list-item';
 import { useCommitFiles } from './use-commit-files';
 import { usePrCommits } from './use-pr-commits';
 
+const ESTIMATED_COMMIT_ROW_HEIGHT = 43;
+const COMMIT_ROW_GAP = 4;
+
 export const PrCommitsList = observer(function PrCommitsList() {
   const { projectId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
@@ -28,6 +32,16 @@ export const PrCommitsList = observer(function PrCommitsList() {
   );
 
   const commits = data?.pages.flat() ?? [];
+  const parentRef = useRef<HTMLDivElement>(null);
+  const virtualizer = useVirtualizer({
+    count: commits.length,
+    estimateSize: () => ESTIMATED_COMMIT_ROW_HEIGHT,
+    gap: COMMIT_ROW_GAP,
+    getItemKey: (index) => commits[index]?.hash ?? index,
+    getScrollElement: () => parentRef.current,
+    overscan: 5,
+  });
+
   const toggleExpanded = (hash: string) => {
     setExpandedHashes((current) => {
       const next = new Set(current);
@@ -45,18 +59,33 @@ export const PrCommitsList = observer(function PrCommitsList() {
   }
 
   return (
-    <div className="h-full overflow-x-hidden overflow-y-auto py-2">
-      <div className="flex flex-col gap-1">
-        {commits.map((commit, index) => (
-          <CommitItem
-            key={commit.hash}
-            commit={commit}
-            isExpanded={expandedHashes.has(commit.hash)}
-            isFirst={index === 0}
-            isLast={index === commits.length - 1}
-            onToggleExpanded={() => toggleExpanded(commit.hash)}
-          />
-        ))}
+    <div ref={parentRef} className="h-full overflow-x-hidden overflow-y-auto py-2">
+      <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((virtualItem) => {
+          const commit = commits[virtualItem.index]!;
+          return (
+            <div
+              key={virtualItem.key}
+              data-index={virtualItem.index}
+              ref={virtualizer.measureElement}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${virtualItem.start}px)`,
+              }}
+            >
+              <CommitItem
+                commit={commit}
+                isExpanded={expandedHashes.has(commit.hash)}
+                isFirst={virtualItem.index === 0}
+                isLast={virtualItem.index === commits.length - 1}
+                onToggleExpanded={() => toggleExpanded(commit.hash)}
+              />
+            </div>
+          );
+        })}
       </div>
       {hasNextPage && (
         <div className="flex justify-center py-2">
@@ -135,10 +164,6 @@ function CommitItem({
   );
 }
 
-const parentRefForCommit = (commit: Commit): GitObjectRef => commitRef(`${commit.hash}^`);
-
-const commitRefForCommit = (commit: Commit): GitObjectRef => commitRef(commit.hash);
-
 const refsMatch = (left: GitObjectRef | undefined, right: GitObjectRef): boolean =>
   left !== undefined && refsEqual(left, right);
 
@@ -146,8 +171,8 @@ const CommitFilesList = observer(function CommitFilesList({ commit }: { commit: 
   const { projectId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
   const taskView = useWorkspaceViewModel();
-  const originalRef = useMemo(() => parentRefForCommit(commit), [commit]);
-  const modifiedRef = useMemo(() => commitRefForCommit(commit), [commit]);
+  const originalRef = useMemo(() => commitRef(`${commit.hash}^`), [commit.hash]);
+  const modifiedRef = useMemo(() => commitRef(commit.hash), [commit.hash]);
   const filesQuery = useCommitFiles(projectId, workspaceId, commit.hash, true);
   const prefetchDiff = usePrefetchDiffModels(
     projectId,

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/commits-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/commits-list.tsx
@@ -164,6 +164,13 @@ function CommitItem({
   );
 }
 
+const parentShaForCommit = (commit: Commit): string | null => commit.parents[0] ?? null;
+
+const parentRefForCommit = (commit: Commit): GitObjectRef =>
+  commitRef(parentShaForCommit(commit) ?? `${commit.hash}^`);
+
+const commitRefForCommit = (commit: Commit): GitObjectRef => commitRef(commit.hash);
+
 const refsMatch = (left: GitObjectRef | undefined, right: GitObjectRef): boolean =>
   left !== undefined && refsEqual(left, right);
 
@@ -171,8 +178,9 @@ const CommitFilesList = observer(function CommitFilesList({ commit }: { commit: 
   const { projectId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
   const taskView = useWorkspaceViewModel();
-  const originalRef = useMemo(() => commitRef(`${commit.hash}^`), [commit.hash]);
-  const modifiedRef = useMemo(() => commitRef(commit.hash), [commit.hash]);
+  const originalRef = useMemo(() => parentRefForCommit(commit), [commit]);
+  const modifiedRef = useMemo(() => commitRefForCommit(commit), [commit]);
+  const originalSha = useMemo(() => parentShaForCommit(commit), [commit]);
   const filesQuery = useCommitFiles(projectId, workspaceId, commit.hash, true);
   const prefetchDiff = usePrefetchDiffModels(
     projectId,
@@ -198,6 +206,8 @@ const CommitFilesList = observer(function CommitFilesList({ commit }: { commit: 
         group: 'git',
         originalRef,
         modifiedRef,
+        commitOriginalSha: originalSha,
+        commitModifiedSha: commit.hash,
       },
       change.status
     );
@@ -211,6 +221,8 @@ const CommitFilesList = observer(function CommitFilesList({ commit }: { commit: 
         group: 'git',
         originalRef,
         modifiedRef,
+        commitOriginalSha: originalSha,
+        commitModifiedSha: commit.hash,
       },
       change.status
     );

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/commits-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/commits-list.tsx
@@ -1,6 +1,7 @@
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useRef } from 'react';
+import { useMemo, useState } from 'react';
+import { usePrefetchDiffModels } from '@renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models';
 import {
   useTaskViewContext,
   useWorkspaceId,
@@ -9,16 +10,17 @@ import {
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { RelativeTime } from '@renderer/lib/ui/relative-time';
 import { cn } from '@renderer/utils/utils';
-import type { Commit } from '@shared/git';
+import { commitRef, refsEqual, type Commit, type GitChange, type GitObjectRef } from '@shared/git';
+import { ChangesListItem } from '../changes-list-item';
+import { useCommitFiles } from './use-commit-files';
 import { usePrCommits } from './use-pr-commits';
-
-const ITEM_HEIGHT = 43;
 
 export const PrCommitsList = observer(function PrCommitsList() {
   const { projectId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
   const taskView = useWorkspaceViewModel();
   const pr = taskView.prStore?.currentPr;
+  const [expandedHashes, setExpandedHashes] = useState<Set<string>>(() => new Set());
   const { data, isFetchingNextPage, hasNextPage, fetchNextPage } = usePrCommits(
     projectId,
     workspaceId,
@@ -26,43 +28,35 @@ export const PrCommitsList = observer(function PrCommitsList() {
   );
 
   const commits = data?.pages.flat() ?? [];
-  const parentRef = useRef<HTMLDivElement>(null);
-
-  const virtualizer = useVirtualizer({
-    count: commits.length,
-    getScrollElement: () => parentRef.current,
-    estimateSize: () => ITEM_HEIGHT,
-    overscan: 5,
-  });
+  const toggleExpanded = (hash: string) => {
+    setExpandedHashes((current) => {
+      const next = new Set(current);
+      if (next.has(hash)) {
+        next.delete(hash);
+      } else {
+        next.add(hash);
+      }
+      return next;
+    });
+  };
 
   if (commits.length === 0 && !isFetchingNextPage) {
     return <EmptyState label="No commits" description="No commits available" />;
   }
 
   return (
-    <div ref={parentRef} className="h-full overflow-x-hidden overflow-y-auto py-2">
-      <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
-        {virtualizer.getVirtualItems().map((virtualItem) => {
-          const commit = commits[virtualItem.index]!;
-          return (
-            <div
-              key={commit.hash}
-              style={{
-                position: 'absolute',
-                top: virtualItem.start,
-                left: 0,
-                width: '100%',
-                height: ITEM_HEIGHT,
-              }}
-            >
-              <CommitItem
-                commit={commit}
-                isFirst={virtualItem.index === 0}
-                isLast={virtualItem.index === commits.length - 1}
-              />
-            </div>
-          );
-        })}
+    <div className="h-full overflow-x-hidden overflow-y-auto py-2">
+      <div className="flex flex-col gap-1">
+        {commits.map((commit, index) => (
+          <CommitItem
+            key={commit.hash}
+            commit={commit}
+            isExpanded={expandedHashes.has(commit.hash)}
+            isFirst={index === 0}
+            isLast={index === commits.length - 1}
+            onToggleExpanded={() => toggleExpanded(commit.hash)}
+          />
+        ))}
       </div>
       {hasNextPage && (
         <div className="flex justify-center py-2">
@@ -71,7 +65,7 @@ export const PrCommitsList = observer(function PrCommitsList() {
             onClick={() => void fetchNextPage()}
             disabled={isFetchingNextPage}
           >
-            {isFetchingNextPage ? 'Loading…' : 'Load more'}
+            {isFetchingNextPage ? 'Loading...' : 'Load more'}
           </button>
         </div>
       )}
@@ -81,32 +75,150 @@ export const PrCommitsList = observer(function PrCommitsList() {
 
 function CommitItem({
   commit,
+  isExpanded,
   isFirst,
   isLast,
+  onToggleExpanded,
 }: {
   commit: Commit;
+  isExpanded: boolean;
   isFirst: boolean;
   isLast: boolean;
+  onToggleExpanded: () => void;
 }) {
   const shortHash = commit.hash.slice(0, 7);
 
   return (
     <div className="flex items-stretch">
-      <div className="flex w-3.5 shrink-0 flex-col items-center">
-        <div className={cn('w-px flex-1 bg-border', isFirst && 'invisible')} />
-        <div className="size-1.5 shrink-0 rounded-full bg-foreground-passive" />
-        <div className={cn('w-px flex-1 bg-border', isLast && 'invisible')} />
+      <div className="relative w-3.5 shrink-0">
+        <div
+          className={cn(
+            'absolute left-1/2 top-0 h-[19px] w-px -translate-x-1/2 bg-border',
+            isFirst && 'invisible'
+          )}
+        />
+        <div className="absolute top-[19px] left-1/2 size-1.5 -translate-x-1/2 rounded-full bg-foreground-passive" />
+        <div
+          className={cn(
+            'absolute bottom-0 left-1/2 top-[25px] w-px -translate-x-1/2 bg-border',
+            isLast && 'invisible'
+          )}
+        />
       </div>
-      <div className="min-w-0 flex-1 rounded-md px-2 py-1">
-        <div className="truncate text-sm">{commit.subject}</div>
-        <div className="flex min-w-0 items-center gap-1 text-xs text-foreground-muted">
-          <span className="min-w-0 truncate font-medium">{commit.author}</span>
-          {'·'}
-          <RelativeTime compact value={commit.date} className="text-foreground-muted" />
-          {'·'}
-          <span className="font-mono text-foreground-passive">{shortHash}</span>
-        </div>
+      <div className="min-w-0 flex-1">
+        <button
+          className={cn(
+            'group flex w-full rounded-md px-1.5 py-1 text-left hover:bg-background-1',
+            isExpanded && 'bg-background-1'
+          )}
+          onClick={onToggleExpanded}
+        >
+          <span className="min-w-0 flex-1">
+            <span className="block truncate text-sm">{commit.subject}</span>
+            <span className="flex min-w-0 items-center gap-1 text-xs text-foreground-muted">
+              <span className="min-w-0 truncate font-medium">{commit.author}</span>
+              {'·'}
+              <RelativeTime compact value={commit.date} className="text-foreground-muted" />
+              {'·'}
+              <span className="font-mono text-foreground-passive">{shortHash}</span>
+              {isExpanded ? (
+                <ChevronDown className="size-3.5 shrink-0 text-foreground-muted" />
+              ) : (
+                <ChevronRight className="size-3.5 shrink-0 text-foreground-muted" />
+              )}
+            </span>
+          </span>
+        </button>
+        {isExpanded && <CommitFilesList commit={commit} />}
       </div>
     </div>
   );
 }
+
+const parentRefForCommit = (commit: Commit): GitObjectRef => commitRef(`${commit.hash}^`);
+
+const commitRefForCommit = (commit: Commit): GitObjectRef => commitRef(commit.hash);
+
+const refsMatch = (left: GitObjectRef | undefined, right: GitObjectRef): boolean =>
+  left !== undefined && refsEqual(left, right);
+
+const CommitFilesList = observer(function CommitFilesList({ commit }: { commit: Commit }) {
+  const { projectId } = useTaskViewContext();
+  const workspaceId = useWorkspaceId();
+  const taskView = useWorkspaceViewModel();
+  const originalRef = useMemo(() => parentRefForCommit(commit), [commit]);
+  const modifiedRef = useMemo(() => commitRefForCommit(commit), [commit]);
+  const filesQuery = useCommitFiles(projectId, workspaceId, commit.hash, true);
+  const prefetchDiff = usePrefetchDiffModels(
+    projectId,
+    workspaceId,
+    'git',
+    originalRef,
+    modifiedRef
+  );
+
+  const activePath =
+    taskView.tabManager.activeDescriptor?.kind === 'diff' &&
+    taskView.tabManager.activeDescriptor.diffGroup === 'git' &&
+    refsEqual(taskView.tabManager.activeDescriptor.originalRef, originalRef) &&
+    refsMatch(taskView.tabManager.activeDescriptor.modifiedRef, modifiedRef)
+      ? taskView.tabManager.activeDescriptor.path
+      : undefined;
+
+  const openPreview = (change: GitChange) => {
+    taskView.tabManager.openDiffPreview(
+      {
+        path: change.path,
+        type: 'git',
+        group: 'git',
+        originalRef,
+        modifiedRef,
+      },
+      change.status
+    );
+  };
+
+  const openDiff = (change: GitChange) => {
+    taskView.tabManager.openDiff(
+      {
+        path: change.path,
+        type: 'git',
+        group: 'git',
+        originalRef,
+        modifiedRef,
+      },
+      change.status
+    );
+  };
+
+  if (filesQuery.isLoading) {
+    return <div className="px-6 py-2 text-xs text-foreground-passive">Loading files...</div>;
+  }
+
+  if (filesQuery.isError) {
+    return <div className="px-6 py-2 text-xs text-foreground-passive">Unable to load files</div>;
+  }
+
+  const files = filesQuery.data ?? [];
+  if (files.length === 0) {
+    return <div className="px-6 py-2 text-xs text-foreground-passive">No file changes</div>;
+  }
+
+  return (
+    <div className="pr-1 pb-1 pl-5">
+      <div className="flex flex-col gap-0.5">
+        {files.map((change) => (
+          <ChangesListItem
+            key={change.path}
+            change={change}
+            isActive={change.path === activePath}
+            className="h-7"
+            onClick={() => openPreview(change)}
+            onDoubleClick={() => openDiff(change)}
+            onMouseEnter={() => prefetchDiff(change.path)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+});

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/files-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/files-list.tsx
@@ -1,12 +1,11 @@
 import { observer } from 'mobx-react-lite';
-import { getRepositoryStore } from '@renderer/features/projects/stores/project-selectors';
 import { usePrefetchDiffModels } from '@renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models';
 import {
   useTaskViewContext,
   useWorkspaceId,
   useWorkspaceViewModel,
 } from '@renderer/features/tasks/task-view-context';
-import { commitRef, remoteRef, type GitChange } from '@shared/git';
+import { commitRef, refsEqual, type GitChange } from '@shared/git';
 import { getPrNumber, type PullRequest } from '@shared/pull-requests';
 import { VirtualizedChangesList } from '../virtualized-changes-list';
 
@@ -16,8 +15,8 @@ export const PrFilesList = observer(function PrFilesList({ pr }: { pr: PullReque
   const taskView = useWorkspaceViewModel();
   const prStore = taskView.prStore!;
 
-  const repo = getRepositoryStore(projectId);
-  const baseRef = remoteRef(repo?.baseRemote ?? 'origin', pr.baseRefName);
+  const prNumber = getPrNumber(pr) ?? undefined;
+  const baseRef = commitRef(pr.baseRefOid);
   const modifiedRef = commitRef(pr.headRefOid);
   const prFiles = prStore.getFiles(pr).data ?? [];
 
@@ -25,7 +24,10 @@ export const PrFilesList = observer(function PrFilesList({ pr }: { pr: PullReque
 
   const activePath =
     taskView.tabManager.activeDescriptor?.kind === 'diff' &&
-    taskView.tabManager.activeDescriptor.diffGroup === 'pr'
+    taskView.tabManager.activeDescriptor.diffGroup === 'pr' &&
+    taskView.tabManager.activeDescriptor.prNumber === prNumber &&
+    refsEqual(taskView.tabManager.activeDescriptor.originalRef, baseRef) &&
+    refsEqual(taskView.tabManager.activeDescriptor.modifiedRef ?? modifiedRef, modifiedRef)
       ? taskView.tabManager.activeDescriptor.path
       : undefined;
 
@@ -37,7 +39,9 @@ export const PrFilesList = observer(function PrFilesList({ pr }: { pr: PullReque
         group: 'pr',
         originalRef: baseRef,
         modifiedRef,
-        prNumber: getPrNumber(pr) ?? undefined,
+        prNumber,
+        prBaseOid: pr.baseRefOid,
+        prHeadOid: pr.headRefOid,
       },
       change.status
     );
@@ -51,7 +55,9 @@ export const PrFilesList = observer(function PrFilesList({ pr }: { pr: PullReque
         group: 'pr',
         originalRef: baseRef,
         modifiedRef,
-        prNumber: getPrNumber(pr) ?? undefined,
+        prNumber,
+        prBaseOid: pr.baseRefOid,
+        prHeadOid: pr.headRefOid,
       },
       change.status
     );

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-commit-files.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-commit-files.ts
@@ -1,0 +1,24 @@
+import { useQuery } from '@tanstack/react-query';
+import { rpc } from '@renderer/lib/ipc';
+import type { GitChange } from '@shared/git';
+
+export const commitFilesQueryKey = (workspaceId: string, commitHash: string) =>
+  [workspaceId, 'commit-files', commitHash] as const;
+
+export function useCommitFiles(
+  projectId: string,
+  workspaceId: string,
+  commitHash: string,
+  enabled: boolean
+) {
+  return useQuery({
+    queryKey: commitFilesQueryKey(workspaceId, commitHash),
+    queryFn: async (): Promise<GitChange[]> => {
+      const result = await rpc.git.getCommitFiles(projectId, workspaceId, commitHash);
+      if (!result.success) throw new Error('Failed to load commit files');
+      return result.data.files;
+    },
+    enabled,
+    staleTime: 5 * 60_000,
+  });
+}

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-commit-files.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-commit-files.ts
@@ -2,8 +2,8 @@ import { useQuery } from '@tanstack/react-query';
 import { rpc } from '@renderer/lib/ipc';
 import type { GitChange } from '@shared/git';
 
-export const commitFilesQueryKey = (workspaceId: string, commitHash: string) =>
-  [workspaceId, 'commit-files', commitHash] as const;
+export const commitFilesQueryKey = (projectId: string, workspaceId: string, commitHash: string) =>
+  [projectId, workspaceId, 'commit-files', commitHash] as const;
 
 export function useCommitFiles(
   projectId: string,
@@ -12,7 +12,7 @@ export function useCommitFiles(
   enabled: boolean
 ) {
   return useQuery({
-    queryKey: commitFilesQueryKey(workspaceId, commitHash),
+    queryKey: commitFilesQueryKey(projectId, workspaceId, commitHash),
     queryFn: async (): Promise<GitChange[]> => {
       const result = await rpc.git.getCommitFiles(projectId, workspaceId, commitHash);
       if (!result.success) throw new Error('Failed to load commit files');

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-pr-commits.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-pr-commits.ts
@@ -5,12 +5,16 @@ import type { PullRequest } from '@shared/pull-requests';
 
 const PAGE_SIZE = 50;
 
-export const prCommitsQueryKey = (workspaceId: string, headRefOid: string) =>
-  [workspaceId, 'pr-commits', headRefOid] as const;
+export const prCommitsQueryKey = (
+  projectId: string,
+  workspaceId: string,
+  baseRefOid: string,
+  headRefOid: string
+) => [projectId, workspaceId, 'pr-commits', baseRefOid, headRefOid] as const;
 
 export function usePrCommits(projectId: string, workspaceId: string, pr: PullRequest | undefined) {
   return useInfiniteQuery({
-    queryKey: prCommitsQueryKey(workspaceId, pr?.headRefOid ?? ''),
+    queryKey: prCommitsQueryKey(projectId, workspaceId, pr?.baseRefOid ?? '', pr?.headRefOid ?? ''),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
       const result = await rpc.git.getLog(
         projectId,

--- a/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models.ts
@@ -15,7 +15,7 @@ interface PrefetchEntry {
  * clicks to open a diff the models are already loaded. Models are unregistered on unmount.
  * TTL eviction (60 s after last subscriber leaves) handles any remaining cleanup.
  *
- * Pass `modifiedRef` for the 'pr' group to pre-warm the PR head SHA instead of HEAD.
+ * Pass `modifiedRef` for 'git'/'pr' groups to pre-warm a fixed modified-side ref instead of HEAD.
  */
 export function usePrefetchDiffModels(
   projectId: string,
@@ -66,7 +66,8 @@ export function usePrefetchDiffModels(
           modelRegistry.toGitUri(uri, STAGED_REF),
         ];
       } else {
-        const effectiveModifiedRef = group === 'pr' && modifiedRef ? modifiedRef : HEAD_REF;
+        const effectiveModifiedRef =
+          (group === 'git' || group === 'pr') && modifiedRef ? modifiedRef : HEAD_REF;
         void modelRegistry
           .registerModel(projectId, workspaceId, root, filePath, language, 'git', originalRef)
           .catch(() => {});

--- a/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -123,7 +123,7 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
       return modelRegistry.toGitUri(uri, tab.modifiedRef ?? HEAD_REF);
     }
     if (tab.diffGroup === 'git') {
-      return modelRegistry.toGitUri(uri, HEAD_REF);
+      return modelRegistry.toGitUri(uri, tab.modifiedRef ?? HEAD_REF);
     }
     return uri;
   })();
@@ -179,7 +179,9 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
         .registerModel(projectId, workspaceId, root, tab.path, language, 'git', tab.originalRef)
         .catch(() => {});
       const effectiveModifiedRef =
-        tab.diffGroup === 'pr' ? (tab.modifiedRef ?? HEAD_REF) : HEAD_REF;
+        tab.diffGroup === 'git' || tab.diffGroup === 'pr'
+          ? (tab.modifiedRef ?? HEAD_REF)
+          : HEAD_REF;
       void modelRegistry
         .registerModel(
           projectId,

--- a/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -15,7 +15,8 @@ import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
 import { StickyDiffEditor } from '@renderer/lib/monaco/sticky-diff-editor';
 import { getLanguageFromPath } from '@renderer/utils/languageUtils';
-import { HEAD_REF, STAGED_REF } from '@shared/git';
+import { gitRefToString, HEAD_REF, STAGED_REF, type GitObjectRef } from '@shared/git';
+import { getDraftCommentTargetKey, type DraftCommentTarget } from '@shared/lineComments';
 import type { ActiveFile } from '@shared/view-state';
 
 interface DiffFileRendererProps {
@@ -65,20 +66,21 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
 
   const [editor, setEditor] = useState<monaco.editor.IStandaloneDiffEditor | null>(null);
 
-  const filePath = tab.path;
-  const comments = draftComments?.getCommentsForFile(filePath) ?? [];
+  const commentTarget = diffTabToCommentTarget(tab);
+  const commentTargetKey = getDraftCommentTargetKey(commentTarget);
+  const comments = draftComments?.getCommentsForTarget(commentTargetKey) ?? [];
 
   const handleAddComment = useCallback(
     (lineNumber: number, content: string, lineContent?: string) => {
       if (!draftComments) return;
       draftComments.addComment({
-        filePath,
+        target: commentTarget,
         lineNumber,
         lineContent: lineContent ?? null,
         content,
       });
     },
-    [filePath, draftComments]
+    [commentTarget, draftComments]
   );
 
   const handleEditComment = useCallback(
@@ -231,6 +233,35 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
   );
 });
 
+function refShaOrString(ref: GitObjectRef | undefined): string {
+  if (!ref) return gitRefToString(HEAD_REF);
+  return ref.kind === 'commit' ? ref.sha : gitRefToString(ref);
+}
+
+function diffTabToCommentTarget(tab: DiffTabStore): DraftCommentTarget {
+  if (tab.diffGroup === 'disk' || tab.diffGroup === 'staged') {
+    return { kind: 'working-tree', group: tab.diffGroup, path: tab.path };
+  }
+
+  if (tab.diffGroup === 'pr') {
+    return {
+      kind: 'pr',
+      prNumber: tab.prNumber ?? 0,
+      baseOid: tab.prBaseOid ?? refShaOrString(tab.originalRef),
+      headOid: tab.prHeadOid ?? refShaOrString(tab.modifiedRef),
+      path: tab.path,
+    };
+  }
+
+  return {
+    kind: 'commit',
+    originalSha:
+      tab.commitOriginalSha !== undefined ? tab.commitOriginalSha : refShaOrString(tab.originalRef),
+    modifiedSha: tab.commitModifiedSha ?? refShaOrString(tab.modifiedRef),
+    path: tab.path,
+  };
+}
+
 function tabToActiveFile(tab: DiffTabStore): ActiveFile {
   return {
     path: tab.path,
@@ -239,5 +270,9 @@ function tabToActiveFile(tab: DiffTabStore): ActiveFile {
     originalRef: tab.originalRef,
     modifiedRef: tab.modifiedRef,
     prNumber: tab.prNumber,
+    prBaseOid: tab.prBaseOid,
+    prHeadOid: tab.prHeadOid,
+    commitOriginalSha: tab.commitOriginalSha,
+    commitModifiedSha: tab.commitModifiedSha,
   };
 }

--- a/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -178,10 +178,7 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
       void modelRegistry
         .registerModel(projectId, workspaceId, root, tab.path, language, 'git', tab.originalRef)
         .catch(() => {});
-      const effectiveModifiedRef =
-        tab.diffGroup === 'git' || tab.diffGroup === 'pr'
-          ? (tab.modifiedRef ?? HEAD_REF)
-          : HEAD_REF;
+      const effectiveModifiedRef = tab.modifiedRef ?? HEAD_REF;
       void modelRegistry
         .registerModel(
           projectId,

--- a/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
@@ -119,7 +119,8 @@ const StackedDiffPanel = observer(function StackedDiffPanel({ panelStore }: Stac
         type: slot.diffType === 'disk' ? 'disk' : 'git',
         group: slot.diffType,
         originalRef: slot.originalRef,
-        modifiedRef: slot.diffType === 'pr' ? slot.modifiedRef : undefined,
+        modifiedRef:
+          slot.diffType === 'git' || slot.diffType === 'pr' ? slot.modifiedRef : undefined,
       });
     }, 150);
   }
@@ -180,7 +181,8 @@ const StackedFileSlot = observer(function StackedFileSlot({
         .registerModel(projectId, workspaceId, root, file.path, language, 'git', STAGED_REF)
         .catch(() => {});
     } else if (diffType === 'git' || diffType === 'pr') {
-      const effectiveModifiedRef = diffType === 'pr' ? modifiedRef : HEAD_REF;
+      const effectiveModifiedRef =
+        diffType === 'git' || diffType === 'pr' ? (modifiedRef ?? HEAD_REF) : HEAD_REF;
       void modelRegistry
         .registerModel(projectId, workspaceId, root, file.path, language, 'git', originalRef)
         .catch(() => {});

--- a/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
@@ -121,6 +121,11 @@ const StackedDiffPanel = observer(function StackedDiffPanel({ panelStore }: Stac
         originalRef: slot.originalRef,
         modifiedRef:
           slot.diffType === 'git' || slot.diffType === 'pr' ? slot.modifiedRef : undefined,
+        prNumber: slot.prNumber,
+        prBaseOid: slot.prBaseOid,
+        prHeadOid: slot.prHeadOid,
+        commitOriginalSha: slot.commitOriginalSha,
+        commitModifiedSha: slot.commitModifiedSha,
       });
     }, 150);
   }

--- a/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/stacked-diff-view.tsx
@@ -181,8 +181,7 @@ const StackedFileSlot = observer(function StackedFileSlot({
         .registerModel(projectId, workspaceId, root, file.path, language, 'git', STAGED_REF)
         .catch(() => {});
     } else if (diffType === 'git' || diffType === 'pr') {
-      const effectiveModifiedRef =
-        diffType === 'git' || diffType === 'pr' ? (modifiedRef ?? HEAD_REF) : HEAD_REF;
+      const effectiveModifiedRef = modifiedRef ?? HEAD_REF;
       void modelRegistry
         .registerModel(projectId, workspaceId, root, file.path, language, 'git', originalRef)
         .catch(() => {});

--- a/src/renderer/features/tasks/diff-view/stores/diff-tab-lifecycle-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/diff-tab-lifecycle-store.ts
@@ -42,6 +42,10 @@ export class DiffTabLifecycleStore {
               originalRef: tab.originalRef,
               modifiedRef: tab.modifiedRef,
               prNumber: tab.prNumber,
+              prBaseOid: tab.prBaseOid,
+              prHeadOid: tab.prHeadOid,
+              commitOriginalSha: tab.commitOriginalSha,
+              commitModifiedSha: tab.commitModifiedSha,
             };
             this.diffView.setActiveFile(activeFile);
           }

--- a/src/renderer/features/tasks/diff-view/stores/draft-comments-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/draft-comments-store.ts
@@ -1,5 +1,10 @@
 import { makeAutoObservable } from 'mobx';
-import { formatCommentsForAgent } from '@shared/lineComments';
+import {
+  formatCommentsForAgent,
+  getDraftCommentTargetKey,
+  getDraftCommentTargetPath,
+  type DraftCommentTarget,
+} from '@shared/lineComments';
 
 const MAX_COMMENTS_PER_TASK = 200;
 
@@ -7,6 +12,8 @@ export type DraftComment = {
   id: string;
   taskId: string;
   filePath: string;
+  target: DraftCommentTarget;
+  targetKey: string;
   lineNumber: number;
   lineContent?: string | null;
   content: string;
@@ -15,7 +22,7 @@ export type DraftComment = {
 };
 
 type CreateDraftCommentInput = {
-  filePath: string;
+  target: DraftCommentTarget;
   lineNumber: number;
   lineContent?: string | null;
   content: string;
@@ -31,7 +38,7 @@ export class DraftCommentsStore {
   readonly commentsById = new Map<string, DraftComment>();
 
   constructor(readonly taskId: string) {
-    makeAutoObservable(this, { getCommentsForFile: false }, { autoBind: true });
+    makeAutoObservable(this, { getCommentsForTarget: false }, { autoBind: true });
   }
 
   get comments(): DraftComment[] {
@@ -46,9 +53,9 @@ export class DraftCommentsStore {
     return formatCommentsForAgent(this.comments, { includeIntro: false });
   }
 
-  getCommentsForFile(filePath: string): DraftComment[] {
+  getCommentsForTarget(targetKey: string): DraftComment[] {
     return this.comments
-      .filter((comment) => comment.filePath === filePath)
+      .filter((comment) => comment.targetKey === targetKey)
       .sort((a, b) => a.lineNumber - b.lineNumber || a.createdAt.localeCompare(b.createdAt));
   }
 
@@ -62,11 +69,15 @@ export class DraftCommentsStore {
 
     const now = new Date().toISOString();
     const id = crypto.randomUUID();
+    const filePath = getDraftCommentTargetPath(input.target);
+    const targetKey = getDraftCommentTargetKey(input.target);
 
     this.commentsById.set(id, {
       id,
       taskId: this.taskId,
-      filePath: input.filePath,
+      filePath,
+      target: input.target,
+      targetKey,
       lineNumber: input.lineNumber,
       lineContent: input.lineContent ?? null,
       content: input.content,

--- a/src/renderer/features/tasks/diff-view/stores/stacked-diff-panel-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/stacked-diff-panel-store.ts
@@ -65,7 +65,7 @@ export class DiffSlotStore {
     }
 
     if (this.diffType === 'git') {
-      return modelRegistry.toGitUri(this.uri, HEAD_REF);
+      return modelRegistry.toGitUri(this.uri, this.modifiedRef ?? HEAD_REF);
     }
 
     return this.uri;

--- a/src/renderer/features/tasks/diff-view/stores/stacked-diff-panel-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/stacked-diff-panel-store.ts
@@ -16,6 +16,11 @@ interface SlotContext {
   diffType: DiffType;
   originalRef: GitObjectRef;
   modifiedRef?: GitObjectRef;
+  prNumber?: number;
+  prBaseOid?: string;
+  prHeadOid?: string;
+  commitOriginalSha?: string | null;
+  commitModifiedSha?: string;
 }
 
 export class DiffSlotStore {
@@ -23,6 +28,11 @@ export class DiffSlotStore {
   diffType: DiffType = 'disk';
   originalRef: GitObjectRef = commitRef('HEAD');
   modifiedRef: GitObjectRef | undefined = undefined;
+  prNumber: number | undefined = undefined;
+  prBaseOid: string | undefined = undefined;
+  prHeadOid: string | undefined = undefined;
+  commitOriginalSha: string | null | undefined = undefined;
+  commitModifiedSha: string | undefined = undefined;
 
   constructor(
     readonly projectId: string,
@@ -33,6 +43,11 @@ export class DiffSlotStore {
       diffType: observable,
       originalRef: observable.ref,
       modifiedRef: observable.ref,
+      prNumber: observable,
+      prBaseOid: observable,
+      prHeadOid: observable,
+      commitOriginalSha: observable,
+      commitModifiedSha: observable,
       uri: computed,
       originalUri: computed,
       modifiedUri: computed,
@@ -162,11 +177,21 @@ export class StackedDiffPanelStore {
         diffType: 'pr',
         originalRef: activeFile.originalRef,
         modifiedRef: activeFile.modifiedRef,
+        prNumber: activeFile.prNumber,
+        prBaseOid: activeFile.prBaseOid,
+        prHeadOid: activeFile.prHeadOid,
       };
     }
 
     if (activeFile.group === 'git') {
-      return { files: [], diffType: 'git', originalRef: activeFile.originalRef };
+      return {
+        files: [],
+        diffType: 'git',
+        originalRef: activeFile.originalRef,
+        modifiedRef: activeFile.modifiedRef,
+        commitOriginalSha: activeFile.commitOriginalSha,
+        commitModifiedSha: activeFile.commitModifiedSha,
+      };
     }
 
     const isStaged = activeFile.group === 'staged';
@@ -177,7 +202,17 @@ export class StackedDiffPanelStore {
     };
   }
 
-  private _applyContext({ files, diffType, originalRef, modifiedRef }: SlotContext): void {
+  private _applyContext({
+    files,
+    diffType,
+    originalRef,
+    modifiedRef,
+    prNumber,
+    prBaseOid,
+    prHeadOid,
+    commitOriginalSha,
+    commitModifiedSha,
+  }: SlotContext): void {
     const count = Math.min(files.length, MAX_STACKED_FILES);
     this._count = count;
 
@@ -187,6 +222,11 @@ export class StackedDiffPanelStore {
       slot.diffType = diffType;
       slot.originalRef = originalRef;
       slot.modifiedRef = modifiedRef;
+      slot.prNumber = prNumber;
+      slot.prBaseOid = prBaseOid;
+      slot.prHeadOid = prHeadOid;
+      slot.commitOriginalSha = commitOriginalSha;
+      slot.commitModifiedSha = commitModifiedSha;
     }
 
     const currentPaths = new Set(files.map((f) => f.path));

--- a/src/renderer/features/tasks/stores/pr-store.ts
+++ b/src/renderer/features/tasks/stores/pr-store.ts
@@ -28,7 +28,7 @@ function prNumberFromIdentifier(identifier: string | null): number | null {
 export class PrStore {
   private readonly _prFiles = new Map<
     string,
-    { resource: Resource<GitChange[]>; headRefOid: string }
+    { resource: Resource<GitChange[]>; baseRefOid: string; headRefOid: string }
   >();
 
   constructor(
@@ -52,7 +52,10 @@ export class PrStore {
   getFiles(pr: PullRequest): Resource<GitChange[]> {
     const key = pr.url;
     const existing = this._prFiles.get(key);
-    if (existing && existing.headRefOid !== pr.headRefOid) {
+    if (
+      existing &&
+      (existing.baseRefOid !== pr.baseRefOid || existing.headRefOid !== pr.headRefOid)
+    ) {
       existing.resource.dispose();
       this._prFiles.delete(key);
     }
@@ -99,7 +102,11 @@ export class PrStore {
         ]
       );
       resource.start();
-      this._prFiles.set(key, { resource, headRefOid: pr.headRefOid });
+      this._prFiles.set(key, {
+        resource,
+        baseRefOid: pr.baseRefOid,
+        headRefOid: pr.headRefOid,
+      });
     }
     return this._prFiles.get(key)!.resource;
   }
@@ -175,11 +182,7 @@ export class PrStore {
   }
 
   private async _fetchPrFiles(pr: PullRequest): Promise<GitChange[]> {
-    const remote = this.repositoryStore.baseRemote;
-    // Dereference the MobX-observable Remote into a plain object — MobX proxies
-    // cannot be structured-cloned by Electron IPC and will throw.
-    const plainRemote = { name: remote.name, url: remote.url };
-    const baseRef = remoteRef(plainRemote, pr.baseRefName);
+    const baseRef = commitRef(pr.baseRefOid);
     const headRef = commitRef(pr.headRefOid);
     const range = mergeBaseRange(baseRef, headRef);
 
@@ -187,16 +190,22 @@ export class PrStore {
       const result = await rpc.git.getChangedFiles(this.projectId, this.workspaceId, range);
       if (!result.success) return null;
       const changes = result.data.changes;
-      const expectedChangedFiles = pr.changedFiles ?? 0;
-      if (expectedChangedFiles > 0 && changes.length === 0) return null;
-      if (expectedChangedFiles > 0 && changes.length > expectedChangedFiles * 2) return null;
+      const expectedChangedFiles = pr.changedFiles;
+      if (changes.length === 0 && expectedChangedFiles !== 0) return null;
+      if (
+        expectedChangedFiles != null &&
+        expectedChangedFiles > 0 &&
+        changes.length > expectedChangedFiles * 2
+      ) {
+        return null;
+      }
       return changes;
     };
 
     const first = await tryRange();
     if (first) return first;
 
-    // headRefOid not available locally — fetch the PR branch then retry
+    await rpc.repository.fetch(this.projectId, this.workspaceId);
     const prNumber = prNumberFromIdentifier(pr.identifier);
     if (prNumber) {
       await rpc.repository.fetchPrForReview(
@@ -207,6 +216,8 @@ export class PrStore {
         isForkPr(pr)
       );
     }
-    return (await tryRange()) ?? [];
+
+    const retry = await tryRange();
+    return retry ?? [];
   }
 }

--- a/src/renderer/features/tasks/tabs/diff-tab-store.ts
+++ b/src/renderer/features/tasks/tabs/diff-tab-store.ts
@@ -19,6 +19,10 @@ export class DiffTabStore {
   originalRef: GitObjectRef;
   modifiedRef: GitObjectRef | undefined;
   prNumber: number | undefined;
+  prBaseOid: string | undefined;
+  prHeadOid: string | undefined;
+  commitOriginalSha: string | null | undefined;
+  commitModifiedSha: string | undefined;
   status: GitChangeStatus | undefined;
 
   constructor(
@@ -35,6 +39,10 @@ export class DiffTabStore {
     this.originalRef = activeFile.originalRef;
     this.modifiedRef = activeFile.modifiedRef;
     this.prNumber = activeFile.prNumber;
+    this.prBaseOid = activeFile.prBaseOid;
+    this.prHeadOid = activeFile.prHeadOid;
+    this.commitOriginalSha = activeFile.commitOriginalSha;
+    this.commitModifiedSha = activeFile.commitModifiedSha;
     this.status = status;
 
     makeObservable(this, {
@@ -44,6 +52,10 @@ export class DiffTabStore {
       originalRef: observable,
       modifiedRef: observable,
       prNumber: observable,
+      prBaseOid: observable,
+      prHeadOid: observable,
+      commitOriginalSha: observable,
+      commitModifiedSha: observable,
       status: observable,
       transition: action,
       pin: action,
@@ -64,6 +76,10 @@ export class DiffTabStore {
     this.originalRef = newOriginalRef;
     this.modifiedRef = undefined;
     this.prNumber = undefined;
+    this.prBaseOid = undefined;
+    this.prHeadOid = undefined;
+    this.commitOriginalSha = undefined;
+    this.commitModifiedSha = undefined;
     this.status = status;
   }
 

--- a/src/renderer/features/tasks/tabs/tab-manager-store.ts
+++ b/src/renderer/features/tasks/tabs/tab-manager-store.ts
@@ -18,7 +18,7 @@ import {
   setTabActiveIndex as tabUtilsSetTabActiveIndex,
 } from '@renderer/lib/stores/tab-utils';
 import { setTelemetryConversationScope } from '@renderer/utils/telemetry-scope';
-import type { GitChangeStatus, GitObjectRef } from '@shared/git';
+import { refsEqual, type GitChangeStatus, type GitObjectRef } from '@shared/git';
 import type { ActiveFile, TabDescriptor, TabManagerSnapshot } from '@shared/view-state';
 
 // ---------------------------------------------------------------------------
@@ -48,6 +48,11 @@ export class ConversationTabEntry {
 }
 
 export type TabEntry = FileTabStore | DiffTabStore | ConversationTabEntry;
+
+function optionalRefsEqual(left: GitObjectRef | undefined, right: GitObjectRef | undefined) {
+  if (left === undefined || right === undefined) return left === right;
+  return refsEqual(left, right);
+}
 
 // ---------------------------------------------------------------------------
 // Resolved tabs — enriched with live store references and derived state
@@ -447,7 +452,7 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
   // ---------------------------------------------------------------------------
 
   openDiff(activeFile: ActiveFile, status?: GitChangeStatus): void {
-    const existing = this._findDiffEntryByKey(activeFile.path, activeFile.group);
+    const existing = this._findDiffEntry(activeFile);
     if (existing) {
       existing.isPreview = false;
       if (status !== undefined) existing.status = status;
@@ -461,7 +466,7 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
   }
 
   openDiffPreview(activeFile: ActiveFile, status?: GitChangeStatus): void {
-    const existing = this._findDiffEntryByKey(activeFile.path, activeFile.group);
+    const existing = this._findDiffEntry(activeFile);
     if (existing) {
       this.activeTabId = existing.tabId;
       return;
@@ -698,10 +703,20 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
     return undefined;
   }
 
-  private _findDiffEntryByKey(path: string, group: string): DiffTabStore | undefined {
+  private _findDiffEntry(activeFile: ActiveFile): DiffTabStore | undefined {
     for (const id of this.tabOrder) {
       const entry = this.entries.get(id);
-      if (entry?.kind === 'diff' && entry.path === path && entry.diffGroup === group) return entry;
+      if (
+        entry?.kind !== 'diff' ||
+        entry.path !== activeFile.path ||
+        entry.diffGroup !== activeFile.group
+      ) {
+        continue;
+      }
+      if (activeFile.group === 'disk' || activeFile.group === 'staged') return entry;
+      if (!refsEqual(entry.originalRef, activeFile.originalRef)) continue;
+      if (!optionalRefsEqual(entry.modifiedRef, activeFile.modifiedRef)) continue;
+      return entry;
     }
     return undefined;
   }

--- a/src/renderer/features/tasks/tabs/tab-manager-store.ts
+++ b/src/renderer/features/tasks/tabs/tab-manager-store.ts
@@ -85,6 +85,10 @@ export type ResolvedDiffTab = {
   originalRef: GitObjectRef;
   modifiedRef?: GitObjectRef;
   prNumber?: number;
+  prBaseOid?: string;
+  prHeadOid?: string;
+  commitOriginalSha?: string | null;
+  commitModifiedSha?: string;
   status?: GitChangeStatus;
   isPreview: boolean;
   isActive: boolean;
@@ -310,6 +314,10 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
           originalRef: entry.originalRef,
           modifiedRef: entry.modifiedRef,
           prNumber: entry.prNumber,
+          prBaseOid: entry.prBaseOid,
+          prHeadOid: entry.prHeadOid,
+          commitOriginalSha: entry.commitOriginalSha,
+          commitModifiedSha: entry.commitModifiedSha,
           status: entry.status,
           isPreview: entry.isPreview,
           isActive: effectiveActiveId === entry.tabId,
@@ -351,6 +359,10 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
           originalRef: entry.originalRef,
           modifiedRef: entry.modifiedRef,
           prNumber: entry.prNumber,
+          prBaseOid: entry.prBaseOid,
+          prHeadOid: entry.prHeadOid,
+          commitOriginalSha: entry.commitOriginalSha,
+          commitModifiedSha: entry.commitModifiedSha,
           status: entry.status,
           isPreview: entry.isPreview,
         });
@@ -641,6 +653,10 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
               originalRef: t.originalRef,
               modifiedRef: t.modifiedRef,
               prNumber: t.prNumber,
+              prBaseOid: t.prBaseOid,
+              prHeadOid: t.prHeadOid,
+              commitOriginalSha: t.commitOriginalSha,
+              commitModifiedSha: t.commitModifiedSha,
             },
             t.isPreview,
             t.tabId,

--- a/src/renderer/tests/context-actions.test.ts
+++ b/src/renderer/tests/context-actions.test.ts
@@ -7,6 +7,7 @@ import {
   buildTaskContextActions,
 } from '@renderer/features/tasks/conversations/context-actions';
 import type { DraftComment } from '@renderer/features/tasks/diff-view/stores/draft-comments-store';
+import { getDraftCommentTargetKey, type DraftCommentTarget } from '@shared/lineComments';
 import type { Issue } from '@shared/tasks';
 
 function makeIssue(overrides: Partial<Issue> = {}): Issue {
@@ -26,10 +27,17 @@ function makeIssue(overrides: Partial<Issue> = {}): Issue {
 }
 
 function makeDraftComment(overrides: Partial<DraftComment> = {}): DraftComment {
+  const target: DraftCommentTarget = overrides.target ?? {
+    kind: 'working-tree',
+    group: 'disk',
+    path: overrides.filePath ?? 'src/foo.ts',
+  };
   return {
     id: crypto.randomUUID(),
     taskId: 'task-1',
-    filePath: 'src/foo.ts',
+    filePath: target.path,
+    target,
+    targetKey: getDraftCommentTargetKey(target),
     lineNumber: 10,
     lineContent: 'const x = 1;',
     content: 'This looks wrong.',

--- a/src/renderer/tests/draft-comments-reactivity.test.ts
+++ b/src/renderer/tests/draft-comments-reactivity.test.ts
@@ -1,6 +1,9 @@
 import { autorun, isObservableMap } from 'mobx';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DraftCommentsStore } from '@renderer/features/tasks/diff-view/stores/draft-comments-store';
+import type { DraftCommentTarget } from '@shared/lineComments';
+
+const target: DraftCommentTarget = { kind: 'working-tree', group: 'disk', path: 'a.ts' };
 
 describe('DraftCommentsStore reactivity', () => {
   beforeEach(() => {
@@ -24,7 +27,7 @@ describe('DraftCommentsStore reactivity', () => {
       seen.push(store.count);
     });
 
-    store.addComment({ filePath: 'a.ts', lineNumber: 1, content: 'note' });
+    store.addComment({ target, lineNumber: 1, content: 'note' });
     store.deleteComment('11111111-1111-1111-1111-111111111111');
     dispose();
 

--- a/src/renderer/tests/draft-comments-store.test.ts
+++ b/src/renderer/tests/draft-comments-store.test.ts
@@ -1,11 +1,29 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { DraftCommentsStore } from '@renderer/features/tasks/diff-view/stores/draft-comments-store';
+import { getDraftCommentTargetKey, type DraftCommentTarget } from '@shared/lineComments';
+
+const diskTarget: DraftCommentTarget = {
+  kind: 'working-tree',
+  group: 'disk',
+  path: 'src/example.ts',
+};
+
+const stagedTarget: DraftCommentTarget = {
+  kind: 'working-tree',
+  group: 'staged',
+  path: 'src/example.ts',
+};
 
 describe('DraftCommentsStore', () => {
   beforeEach(() => {
     vi.restoreAllMocks();
-    vi.spyOn(globalThis.crypto, 'randomUUID').mockReturnValue(
-      '11111111-1111-1111-1111-111111111111'
+    const ids = [
+      '11111111-1111-1111-1111-111111111111',
+      '22222222-2222-2222-2222-222222222222',
+    ] as const;
+    let index = 0;
+    vi.spyOn(globalThis.crypto, 'randomUUID').mockImplementation(
+      () => ids[index++] ?? '33333333-3333-3333-3333-333333333333'
     );
   });
 
@@ -13,7 +31,7 @@ describe('DraftCommentsStore', () => {
     const store = new DraftCommentsStore('task-1');
 
     store.addComment({
-      filePath: 'src/example.ts',
+      target: diskTarget,
       lineNumber: 12,
       lineContent: 'const value = 1;',
       content: 'Rename this to be clearer.',
@@ -28,5 +46,28 @@ describe('DraftCommentsStore', () => {
     expect(store.count).toBe(0);
     expect(store.comments).toEqual([]);
     expect(store.formattedForAgent).toBe('');
+  });
+
+  it('filters comments by exact target, not file path', () => {
+    const store = new DraftCommentsStore('task-1');
+
+    store.addComment({
+      target: diskTarget,
+      lineNumber: 12,
+      content: 'Working tree comment.',
+    });
+    store.addComment({
+      target: stagedTarget,
+      lineNumber: 12,
+      content: 'Staged comment.',
+    });
+
+    const diskComments = store.getCommentsForTarget(getDraftCommentTargetKey(diskTarget));
+    const stagedComments = store.getCommentsForTarget(getDraftCommentTargetKey(stagedTarget));
+
+    expect(diskComments).toHaveLength(1);
+    expect(diskComments[0]?.content).toBe('Working tree comment.');
+    expect(stagedComments).toHaveLength(1);
+    expect(stagedComments[0]?.content).toBe('Staged comment.');
   });
 });

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -216,6 +216,7 @@ export function tagRef(name: string): GitObjectRef {
 
 export type Commit = {
   hash: string;
+  parents: string[];
   subject: string;
   body: string;
   author: string;

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -226,7 +226,7 @@ export type Commit = {
 
 export type CommitFile = {
   path: string;
-  status: string;
+  status: GitChangeStatus;
   additions: number;
   deletions: number;
 };

--- a/src/shared/lineComments.test.ts
+++ b/src/shared/lineComments.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+import {
+  formatCommentsForAgent,
+  getDraftCommentTargetKey,
+  type DraftCommentTarget,
+  type LineCommentLike,
+} from './lineComments';
+
+function comment(target: DraftCommentTarget, content: string): LineCommentLike {
+  return {
+    filePath: target.path,
+    target,
+    targetKey: getDraftCommentTargetKey(target),
+    lineNumber: 10,
+    content,
+  };
+}
+
+describe('formatCommentsForAgent', () => {
+  it('groups comments by exact diff target and includes commit metadata', () => {
+    const targetA: DraftCommentTarget = {
+      kind: 'commit',
+      originalSha: 'aaa111',
+      modifiedSha: 'bbb222',
+      path: 'foo.ts',
+    };
+    const targetB: DraftCommentTarget = {
+      kind: 'commit',
+      originalSha: 'ccc333',
+      modifiedSha: 'ddd444',
+      path: 'foo.ts',
+    };
+
+    const formatted = formatCommentsForAgent([
+      comment(targetA, 'Comment for commit A'),
+      comment(targetB, 'Comment for commit B'),
+    ]);
+
+    expect(formatted).toContain(
+      '<target kind="commit" originalSha="aaa111" modifiedSha="bbb222" path="foo.ts">'
+    );
+    expect(formatted).toContain(
+      '<target kind="commit" originalSha="ccc333" modifiedSha="ddd444" path="foo.ts">'
+    );
+    expect(formatted).toContain('Comment for commit A');
+    expect(formatted).toContain('Comment for commit B');
+  });
+
+  it('includes PR and working-tree target metadata', () => {
+    const prTarget: DraftCommentTarget = {
+      kind: 'pr',
+      prNumber: 42,
+      baseOid: 'base123',
+      headOid: 'head456',
+      path: 'foo.ts',
+    };
+    const diskTarget: DraftCommentTarget = {
+      kind: 'working-tree',
+      group: 'disk',
+      path: 'foo.ts',
+    };
+
+    const formatted = formatCommentsForAgent([
+      comment(prTarget, 'PR comment'),
+      comment(diskTarget, 'Working tree comment'),
+    ]);
+
+    expect(formatted).toContain(
+      '<target kind="pr" prNumber="42" baseOid="base123" headOid="head456" path="foo.ts">'
+    );
+    expect(formatted).toContain('<target kind="working-tree" group="disk" path="foo.ts">');
+  });
+
+  it('escapes XML in paths and comment content', () => {
+    const target: DraftCommentTarget = {
+      kind: 'working-tree',
+      group: 'disk',
+      path: 'src/a&b.ts',
+    };
+
+    const formatted = formatCommentsForAgent([comment(target, 'Use <safe> & "clear" text')]);
+
+    expect(formatted).toContain('path="src/a&amp;b.ts"');
+    expect(formatted).toContain('Use &lt;safe&gt; &amp; "clear" text');
+  });
+});

--- a/src/shared/lineComments.ts
+++ b/src/shared/lineComments.ts
@@ -1,24 +1,78 @@
 export type LineCommentLike = {
   filePath: string;
+  target?: DraftCommentTarget;
+  targetKey?: string;
   lineNumber: number;
   content: string;
 };
+
+export type DraftCommentTarget =
+  | { kind: 'working-tree'; group: 'disk' | 'staged'; path: string }
+  | { kind: 'pr'; prNumber: number; baseOid: string; headOid: string; path: string }
+  | { kind: 'commit'; originalSha: string | null; modifiedSha: string; path: string };
 
 type FormatOptions = {
   includeIntro?: boolean;
   leadingNewline?: boolean;
 };
 
+export function getDraftCommentTargetPath(target: DraftCommentTarget): string {
+  return target.path;
+}
+
+export function getDraftCommentTargetKey(target: DraftCommentTarget): string {
+  switch (target.kind) {
+    case 'working-tree':
+      return JSON.stringify(['working-tree', target.group, target.path]);
+    case 'pr':
+      return JSON.stringify(['pr', target.prNumber, target.baseOid, target.headOid, target.path]);
+    case 'commit':
+      return JSON.stringify(['commit', target.originalSha, target.modifiedSha, target.path]);
+  }
+}
+
+function escapeXmlText(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function escapeXmlAttribute(value: string | number): string {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
 const COMMENT_LINE = (c: LineCommentLike) => {
-  return `    <comment line="${c.lineNumber}">${c.content}</comment>`;
+  return `    <comment line="${escapeXmlAttribute(c.lineNumber)}">${escapeXmlText(c.content)}</comment>`;
 };
 
-const FILE_BLOCK = (filePath: string, comments: LineCommentLike[]) => `  <file path="${filePath}">
+function targetAttributes(target: DraftCommentTarget): string {
+  switch (target.kind) {
+    case 'working-tree':
+      return `kind="working-tree" group="${escapeXmlAttribute(target.group)}" path="${escapeXmlAttribute(target.path)}"`;
+    case 'pr':
+      return `kind="pr" prNumber="${escapeXmlAttribute(target.prNumber)}" baseOid="${escapeXmlAttribute(target.baseOid)}" headOid="${escapeXmlAttribute(target.headOid)}" path="${escapeXmlAttribute(target.path)}"`;
+    case 'commit':
+      return `kind="commit" originalSha="${escapeXmlAttribute(target.originalSha ?? 'root')}" modifiedSha="${escapeXmlAttribute(target.modifiedSha)}" path="${escapeXmlAttribute(target.path)}"`;
+  }
+}
+
+const TARGET_BLOCK = (target: DraftCommentTarget, comments: LineCommentLike[]) =>
+  `  <target ${targetAttributes(target)}>
 ${comments
   .sort((a, b) => a.lineNumber - b.lineNumber)
   .map(COMMENT_LINE)
   .join('\n')}
-  </file>`;
+  </target>`;
+
+const FILE_BLOCK = (filePath: string, comments: LineCommentLike[]) =>
+  `  <target kind="file" path="${escapeXmlAttribute(filePath)}">
+${comments
+  .sort((a, b) => a.lineNumber - b.lineNumber)
+  .map(COMMENT_LINE)
+  .join('\n')}
+  </target>`;
 
 const COMMENTS_WRAPPER = (
   fileBlocks: string[]
@@ -28,12 +82,13 @@ const COMMENTS_WRAPPER = (
 ${fileBlocks.join('\n')}
 </user_comments>`;
 
-function groupByFile(comments: LineCommentLike[]): Map<string, LineCommentLike[]> {
+function groupByTarget(comments: LineCommentLike[]): Map<string, LineCommentLike[]> {
   const groups = new Map<string, LineCommentLike[]>();
   for (const c of comments) {
-    const existing = groups.get(c.filePath) ?? [];
+    const key = c.targetKey ?? (c.target ? getDraftCommentTargetKey(c.target) : c.filePath);
+    const existing = groups.get(key) ?? [];
     existing.push(c);
-    groups.set(c.filePath, existing);
+    groups.set(key, existing);
   }
   return groups;
 }
@@ -44,10 +99,12 @@ export function formatCommentsForAgent(
 ): string {
   if (!comments.length) return '';
 
-  const byFile = groupByFile(comments);
-  const fileBlocks = Array.from(byFile.entries()).map(([filePath, fileComments]) =>
-    FILE_BLOCK(filePath, fileComments)
-  );
+  const byTarget = groupByTarget(comments);
+  const fileBlocks = Array.from(byTarget.values()).map((targetComments) => {
+    const target = targetComments[0]?.target;
+    if (target) return TARGET_BLOCK(target, targetComments);
+    return FILE_BLOCK(targetComments[0]?.filePath ?? '', targetComments);
+  });
   const prefix = leadingNewline ? '\n' : '';
 
   if (includeIntro) {

--- a/src/shared/view-state.ts
+++ b/src/shared/view-state.ts
@@ -16,6 +16,10 @@ export type TabDescriptor =
       originalRef: GitObjectRef;
       modifiedRef?: GitObjectRef;
       prNumber?: number;
+      prBaseOid?: string;
+      prHeadOid?: string;
+      commitOriginalSha?: string | null;
+      commitModifiedSha?: string;
       status?: GitChangeStatus;
       isPreview: boolean;
     };
@@ -70,6 +74,12 @@ export interface ActiveFile {
   modifiedRef?: GitObjectRef;
   /** Set only when group === 'pr'. Identifies the PR for store lookups. */
   prNumber?: number;
+  /** Exact PR base/head OIDs for comment scoping and stable target identity. */
+  prBaseOid?: string;
+  prHeadOid?: string;
+  /** Exact commit diff endpoints for comment scoping. Root commits use null original. */
+  commitOriginalSha?: string | null;
+  commitModifiedSha?: string;
 }
 
 export type TaskViewSnapshot = {

--- a/src/shared/view-state.ts
+++ b/src/shared/view-state.ts
@@ -65,8 +65,8 @@ export interface ActiveFile {
    *  'pr'     = PR diff (originalRef is remote-tracking base) */
   group: 'disk' | 'staged' | 'git' | 'pr';
   originalRef: GitObjectRef;
-  /** PR head SHA for the modified side of a 'pr' group diff.
-   *  When absent the diff stack falls back to HEAD_REF. */
+  /** Fixed modified-side ref for 'git' and 'pr' diffs.
+   *  When absent the diff viewer falls back to HEAD_REF. */
   modifiedRef?: GitObjectRef;
   /** Set only when group === 'pr'. Identifies the PR for store lookups. */
   prNumber?: number;


### PR DESCRIPTION
## Summary

- Adds expandable commit rows in the PR commits sidebar.
- Shows changed files for each expanded commit and opens them in the existing diff viewer.
- Generalizes fixed git ref-to-ref diffs so commit file diffs compare parent commit to commit instead of HEAD.
- Keeps PR file diffs, image/binary handling, prefetching, and line comments on the existing diff infrastructure.

## Validation

- pnpm run format
- pnpm run typecheck
- pnpm run lint
- pnpm run test
