### PR TITLE
fix(renderer): preserve dropped file path formatting

### DIFF
--- a/src/renderer/lib/pty/prompt-injection.ts
+++ b/src/renderer/lib/pty/prompt-injection.ts
@@ -6,7 +6,7 @@ export function buildPromptInjectionPayload(args: {
   const trimmed = args.text.trim();
   const hasMultilinePayload = trimmed.includes('\n');
   const shouldUseBracketedPaste =
-    hasMultilinePayload && (args.forceBracketedPaste || args.providerId !== 'claude');
+    args.forceBracketedPaste || (hasMultilinePayload && args.providerId !== 'claude');
   if (!shouldUseBracketedPaste) return trimmed;
   return `\x1b[200~${trimmed}\x1b[201~`;
 }

--- a/src/renderer/lib/pty/pty-pane.tsx
+++ b/src/renderer/lib/pty/pty-pane.tsx
@@ -3,6 +3,7 @@ import { getDraggedFilePaths } from '@renderer/lib/drag-files';
 import { rpc } from '@renderer/lib/ipc';
 import { log } from '@renderer/utils/logger';
 import { cn } from '@renderer/utils/utils';
+import { pastePromptInjection } from './prompt-injection';
 import type { FrontendPty, SessionTheme } from './pty';
 import { usePty } from './use-pty';
 
@@ -81,17 +82,23 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
               try {
                 const result = await rpc.pty.uploadFiles({ sessionId, localPaths: paths });
                 if (result.success && result.data?.remotePaths) {
-                  const escaped = result.data.remotePaths
-                    .map((p: string) => `'${p.replace(/'/g, "'\\''")}'`)
-                    .join(' ');
-                  sendInput(`${escaped} `);
+                  await pastePromptInjection({
+                    providerId: undefined,
+                    text: formatDroppedPaths(result.data.remotePaths),
+                    forceBracketedPaste: true,
+                    sendInput: async (data) => sendInput(data),
+                  });
                 }
               } catch (error) {
                 log.warn('SSH file transfer failed', { error });
               }
             } else {
-              const escaped = paths.map((p) => `'${p.replace(/'/g, "'\\''")}'`).join(' ');
-              sendInput(`${escaped} `);
+              await pastePromptInjection({
+                providerId: undefined,
+                text: formatDroppedPaths(paths),
+                forceBracketedPaste: true,
+                sendInput: async (data) => sendInput(data),
+              });
             }
             focus();
           } catch (error) {
@@ -134,6 +141,10 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
     );
   }
 );
+
+function formatDroppedPaths(paths: string[]): string {
+  return `${paths.map((path) => `'${path.replace(/'/g, "'\\''")}'`).join(' ')} `;
+}
 
 PtyPaneComponent.displayName = 'TerminalPane';
 

--- a/src/renderer/lib/pty/pty-pane.tsx
+++ b/src/renderer/lib/pty/pty-pane.tsx
@@ -86,7 +86,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
                     providerId: undefined,
                     text: formatDroppedPaths(result.data.remotePaths),
                     forceBracketedPaste: true,
-                    sendInput: async (data) => sendInput(data),
+                    sendInput: async (data) => sendInput(`${data} `),
                   });
                 }
               } catch (error) {
@@ -97,7 +97,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
                 providerId: undefined,
                 text: formatDroppedPaths(paths),
                 forceBracketedPaste: true,
-                sendInput: async (data) => sendInput(data),
+                sendInput: async (data) => sendInput(`${data} `),
               });
             }
             focus();
@@ -143,7 +143,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
 );
 
 function formatDroppedPaths(paths: string[]): string {
-  return `${paths.map((path) => `'${path.replace(/'/g, "'\\''")}'`).join(' ')} `;
+  return paths.map((path) => `'${path.replace(/'/g, "'\\''")}'`).join(' ');
 }
 
 PtyPaneComponent.displayName = 'TerminalPane';

--- a/src/renderer/tests/prompt-injection.test.ts
+++ b/src/renderer/tests/prompt-injection.test.ts
@@ -26,4 +26,14 @@ describe('prompt injection', () => {
 
     expect(sendInput).toHaveBeenCalledWith('\x1b[200~Line one\nLine two\x1b[201~');
   });
+
+  it('can force bracketed paste for single-line file drops', () => {
+    expect(
+      buildPromptInjectionPayload({
+        providerId: undefined,
+        text: '/var/folders/example image.png',
+        forceBracketedPaste: true,
+      })
+    ).toBe('\x1b[200~/var/folders/example image.png\x1b[201~');
+  });
 });


### PR DESCRIPTION
# summary
- fixes images not being pastes "correctly"

example: (bottom left is prod, behind is dev)
https://streamable.com/xtzhyb