### PR TITLE
[codex] prevent orphaned task sessions

### DIFF
--- a/src/main/core/conversations/controller.ts
+++ b/src/main/core/conversations/controller.ts
@@ -4,6 +4,7 @@ import { deleteConversation } from './deleteConversation';
 import { getConversations } from './getConversations';
 import { getConversationsForTask } from './getConversationsForTask';
 import { renameConversation } from './renameConversation';
+import { startConversationSession, stopConversationSession } from './sessionLifecycle';
 
 export const conversationController = createRPCController({
   getConversations,
@@ -11,4 +12,6 @@ export const conversationController = createRPCController({
   deleteConversation,
   renameConversation,
   getConversationsForTask,
+  startConversationSession,
+  stopConversationSession,
 });

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -6,6 +6,7 @@ import { HookConfigWriter } from '@main/core/agent-hooks/hook-config';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import { buildAgentEnv } from '@main/core/pty/pty-env';
@@ -156,9 +157,10 @@ export class LocalConversationProvider implements ConversationProvider {
       });
     }
 
-    pty.onExit(({ exitCode }) => {
+    pty.onExit(({ exitCode, signal }) => {
       ptySessionRegistry.unregister(sessionId);
-      const shouldRespawn = this.sessions.has(sessionId);
+      const shouldRespawn =
+        this.sessions.has(sessionId) && isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       events.emit(agentSessionExitedChannel, {
         sessionId,
@@ -171,7 +173,7 @@ export class LocalConversationProvider implements ConversationProvider {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
         this.respawnCounts.set(sessionId, count);
 
-        if (count > MAX_RESPAWNS && !isResuming) {
+        if (count > MAX_RESPAWNS) {
           log.error('LocalConversationProvider: respawn limit reached, giving up', {
             conversationId: conversation.id,
           });
@@ -179,11 +181,8 @@ export class LocalConversationProvider implements ConversationProvider {
           return;
         }
 
-        const resumeNext = isResuming && count <= MAX_RESPAWNS;
-        if (count > MAX_RESPAWNS) this.respawnCounts.set(sessionId, 0);
-
         setTimeout(() => {
-          this.startSession(conversation, initialSize, resumeNext, initialPrompt).catch((e) => {
+          this.startSession(conversation, initialSize, false, initialPrompt).catch((e) => {
             log.error('LocalConversationProvider: respawn failed', {
               conversationId: conversation.id,
               error: String(e),

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -3,6 +3,7 @@ import { claudeTrustService } from '@main/core/agent-hooks/claude-trust-service'
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import type { Pty } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
@@ -147,9 +148,10 @@ export class SshConversationProvider implements ConversationProvider {
       conversationId: conversation.id,
     });
 
-    pty.onExit(({ exitCode }) => {
+    pty.onExit(({ exitCode, signal }) => {
       ptySessionRegistry.unregister(sessionId);
-      const shouldRespawn = this.sessions.has(sessionId);
+      const shouldRespawn =
+        this.sessions.has(sessionId) && isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       events.emit(agentSessionExitedChannel, {
         sessionId,
@@ -162,7 +164,7 @@ export class SshConversationProvider implements ConversationProvider {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
         this.respawnCounts.set(sessionId, count);
 
-        if (count > MAX_RESPAWNS && !isResuming) {
+        if (count > MAX_RESPAWNS) {
           log.error('SshConversationProvider: respawn limit reached, giving up', {
             conversationId: conversation.id,
           });
@@ -170,11 +172,8 @@ export class SshConversationProvider implements ConversationProvider {
           return;
         }
 
-        const resumeNext = isResuming && count <= MAX_RESPAWNS;
-        if (count > MAX_RESPAWNS) this.respawnCounts.set(sessionId, 0);
-
         setTimeout(() => {
-          this.startSession(conversation, initialSize, resumeNext, initialPrompt).catch((e) => {
+          this.startSession(conversation, initialSize, false, initialPrompt).catch((e) => {
             log.error('SshConversationProvider: respawn failed', {
               conversationId: conversation.id,
               error: String(e),

--- a/src/main/core/conversations/sessionLifecycle.ts
+++ b/src/main/core/conversations/sessionLifecycle.ts
@@ -1,0 +1,41 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '@main/db/client';
+import { conversations } from '@main/db/schema';
+import { resolveTask } from '../projects/utils';
+import { mapConversationRowToConversation } from './utils';
+
+export async function startConversationSession(
+  projectId: string,
+  taskId: string,
+  conversationId: string
+): Promise<void> {
+  const [row] = await db
+    .select()
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.id, conversationId),
+        eq(conversations.projectId, projectId),
+        eq(conversations.taskId, taskId)
+      )
+    )
+    .limit(1);
+
+  if (!row) return;
+
+  const task = resolveTask(projectId, taskId);
+  await task?.conversations.startSession(
+    mapConversationRowToConversation(row, true),
+    undefined,
+    true
+  );
+}
+
+export async function stopConversationSession(
+  projectId: string,
+  taskId: string,
+  conversationId: string
+): Promise<void> {
+  const task = resolveTask(projectId, taskId);
+  await task?.conversations.stopSession(conversationId);
+}

--- a/src/main/core/pty/exit-classification.test.ts
+++ b/src/main/core/pty/exit-classification.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isUnexpectedPtyExit } from './exit-classification';
+
+describe('isUnexpectedPtyExit', () => {
+  it('treats a zero exit code without signal as expected', () => {
+    expect(isUnexpectedPtyExit({ exitCode: 0 })).toBe(false);
+  });
+
+  it('treats non-zero exit codes as unexpected', () => {
+    expect(isUnexpectedPtyExit({ exitCode: 1 })).toBe(true);
+  });
+
+  it('treats signal exits as unexpected even when exitCode is zero', () => {
+    expect(isUnexpectedPtyExit({ exitCode: 0, signal: 'SIGTERM' })).toBe(true);
+  });
+
+  it('treats missing exit status as unexpected', () => {
+    expect(isUnexpectedPtyExit({})).toBe(true);
+  });
+});

--- a/src/main/core/pty/exit-classification.ts
+++ b/src/main/core/pty/exit-classification.ts
@@ -1,0 +1,5 @@
+import type { PtyExitInfo } from './pty';
+
+export function isUnexpectedPtyExit({ exitCode, signal }: PtyExitInfo): boolean {
+  return exitCode !== 0 || signal !== undefined;
+}

--- a/src/main/core/pty/local-pty.test.ts
+++ b/src/main/core/pty/local-pty.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocalPtySession } from './local-pty';
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+describe('LocalPtySession', () => {
+  type MockPtyProcess = ConstructorParameters<typeof LocalPtySession>[1];
+
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  let mockProc: MockPtyProcess;
+  let pty: LocalPtySession;
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      ...originalPlatform,
+      value: platform,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    mockProc = {
+      pid: 1234,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+    } as unknown as MockPtyProcess;
+    pty = new LocalPtySession('test-id', mockProc);
+
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('kill() sends SIGTERM to process group on POSIX', () => {
+    setPlatform('linux');
+
+    pty.kill();
+
+    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGTERM');
+    expect(mockProc.kill).toHaveBeenCalled();
+  });
+
+  it('kill() follows up with SIGKILL after 2 seconds if not exited', () => {
+    setPlatform('linux');
+
+    pty.kill();
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+
+    vi.advanceTimersByTime(2000);
+    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGKILL');
+  });
+
+  it('kill() does not send SIGKILL if process exits before timeout', () => {
+    setPlatform('linux');
+
+    let exitHandler: ((info: { exitCode: number; signal: number }) => void) | undefined;
+    vi.mocked(mockProc.onExit).mockImplementation((handler) => {
+      exitHandler = handler;
+      return { dispose: vi.fn() };
+    });
+
+    pty.onExit(() => {}); // This triggers registration
+    pty.kill();
+
+    // Simulate exit
+    exitHandler?.({ exitCode: 0, signal: 0 });
+
+    vi.advanceTimersByTime(2000);
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+  });
+
+  it('kill() does not use process groups on Windows', () => {
+    setPlatform('win32');
+
+    pty.kill();
+
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, expect.any(String));
+    expect(mockProc.kill).toHaveBeenCalled();
+  });
+
+  it('kill() is idempotent', () => {
+    setPlatform('linux');
+
+    pty.kill();
+    pty.kill();
+
+    expect(process.kill).toHaveBeenCalledTimes(1); // One SIGTERM, no second one
+    expect(mockProc.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/core/pty/local-pty.ts
+++ b/src/main/core/pty/local-pty.ts
@@ -46,6 +46,8 @@ export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
 
 export class LocalPtySession implements Pty {
   readonly id: string;
+  private killTimer: ReturnType<typeof setTimeout> | null = null;
+  private killed = false;
 
   constructor(
     id: string,
@@ -73,7 +75,28 @@ export class LocalPtySession implements Pty {
   }
 
   kill(): void {
-    this.proc.kill();
+    if (this.killed) return;
+    this.killed = true;
+
+    const pid = this.proc.pid;
+
+    // On POSIX, prefer signaling the process group so wrapper shells do not
+    // leave long-lived grandchildren (agent daemons, browser helpers) behind.
+    if (process.platform !== 'win32' && Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(-pid, 'SIGTERM');
+      } catch {}
+      this.killTimer = setTimeout(() => {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch {}
+        this.killTimer = null;
+      }, 2000);
+    }
+
+    try {
+      this.proc.kill();
+    } catch {}
   }
 
   onData(handler: (data: string) => void): void {
@@ -82,6 +105,10 @@ export class LocalPtySession implements Pty {
 
   onExit(handler: (info: PtyExitInfo) => void): void {
     this.proc.onExit(({ exitCode, signal }) => {
+      if (this.killTimer) {
+        clearTimeout(this.killTimer);
+        this.killTimer = null;
+      }
       handler({ exitCode, signal: normalizeSignal(signal) });
     });
   }

--- a/src/main/core/tasks/hydration.ts
+++ b/src/main/core/tasks/hydration.ts
@@ -1,0 +1,64 @@
+import type { Conversation } from '@shared/conversations';
+import type { Terminal } from '@shared/terminals';
+import type { TabDescriptor, TaskViewSnapshot } from '@shared/view-state';
+
+export function pickConversationsForHydration(
+  conversations: Conversation[],
+  snapshot: Partial<TaskViewSnapshot> | null
+): Conversation[] {
+  if (conversations.length <= 1) return conversations;
+
+  const openConversationIds = getOpenConversationIds(snapshot);
+  if (openConversationIds.size > 0) {
+    const openConversations = conversations.filter((conversation) =>
+      openConversationIds.has(conversation.id)
+    );
+    if (openConversations.length > 0) return openConversations;
+  }
+
+  const byRecentInteraction = [...conversations].sort((a, b) => {
+    const ta = Date.parse(a.lastInteractedAt ?? '') || 0;
+    const tb = Date.parse(b.lastInteractedAt ?? '') || 0;
+    if (tb !== ta) return tb - ta;
+    return a.id.localeCompare(b.id);
+  });
+
+  return [byRecentInteraction[0]];
+}
+
+export function pickTerminalsForHydration(
+  terminals: Terminal[],
+  snapshot: Partial<TaskViewSnapshot> | null
+): Terminal[] {
+  if (terminals.length === 0) return [];
+  if (terminals.length === 1) return terminals;
+
+  const openTerminalIds = getOpenTerminalIds(snapshot);
+  if (openTerminalIds.size > 0) {
+    return terminals.filter((terminal) => openTerminalIds.has(terminal.id));
+  }
+  return [];
+}
+
+function getOpenConversationIds(snapshot: Partial<TaskViewSnapshot> | null): Set<string> {
+  const ids = new Set<string>();
+  for (const tab of getSnapshotTabs(snapshot)) {
+    if (tab.kind === 'conversation') ids.add(tab.conversationId);
+  }
+  if (snapshot?.conversations?.tabOrder) {
+    for (const id of snapshot.conversations.tabOrder) ids.add(id);
+  }
+  return ids;
+}
+
+function getOpenTerminalIds(snapshot: Partial<TaskViewSnapshot> | null): Set<string> {
+  return new Set(snapshot?.terminals?.tabOrder ?? []);
+}
+
+function getSnapshotTabs(snapshot: Partial<TaskViewSnapshot> | null): TabDescriptor[] {
+  if (!snapshot) return [];
+  if (snapshot.tabGroups) {
+    return snapshot.tabGroups.groups.flatMap((group) => group.tabManager.tabs);
+  }
+  return snapshot.tabManager?.tabs ?? [];
+}

--- a/src/main/core/tasks/task-builder.test.ts
+++ b/src/main/core/tasks/task-builder.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import type { Conversation } from '@shared/conversations';
+import type { Terminal } from '@shared/terminals';
+import type { TaskViewSnapshot } from '@shared/view-state';
+import { pickConversationsForHydration, pickTerminalsForHydration } from './hydration';
+
+describe('task-builder hydration logic', () => {
+  const conv1 = { id: 'c1', lastInteractedAt: '2023-01-01T00:00:00Z' } as Conversation;
+  const conv2 = { id: 'c2', lastInteractedAt: '2023-01-02T00:00:00Z' } as Conversation;
+  const conversations = [conv1, conv2];
+
+  const term1 = { id: 't1' } as Terminal;
+  const term2 = { id: 't2' } as Terminal;
+  const terminals = [term1, term2];
+
+  describe('pickConversationsForHydration', () => {
+    it('returns all if length <= 1', () => {
+      expect(pickConversationsForHydration([conv1], null)).toEqual([conv1]);
+    });
+
+    it('returns explicitly open conversations from snapshot (tabGroups)', () => {
+      const snapshot: Partial<TaskViewSnapshot> = {
+        tabGroups: {
+          groups: [
+            {
+              tabManager: {
+                tabs: [{ kind: 'conversation', conversationId: 'c2' } as any],
+              } as any,
+            } as any,
+          ],
+          activeGroupId: 'g1',
+          paneSizes: [100],
+        },
+      };
+      expect(pickConversationsForHydration(conversations, snapshot)).toEqual([conv2]);
+    });
+
+    it('returns explicitly open conversations from snapshot (legacy tabManager)', () => {
+      const snapshot: Partial<TaskViewSnapshot> = {
+        tabManager: {
+          tabs: [{ kind: 'conversation', conversationId: 'c1' } as any],
+        } as any,
+      };
+      expect(pickConversationsForHydration(conversations, snapshot)).toEqual([conv1]);
+    });
+
+    it('returns conversations from tabOrder', () => {
+      const snapshot: Partial<TaskViewSnapshot> = {
+        conversations: { tabOrder: ['c2'] } as any,
+      };
+      expect(pickConversationsForHydration(conversations, snapshot)).toEqual([conv2]);
+    });
+
+    it('falls back to most recent if open snapshot conversations are stale', () => {
+      const snapshot: Partial<TaskViewSnapshot> = {
+        tabManager: {
+          tabs: [{ kind: 'conversation', conversationId: 'deleted' } as any],
+        } as any,
+      };
+      expect(pickConversationsForHydration(conversations, snapshot)).toEqual([conv2]);
+    });
+
+    it('returns most recent if no snapshot is available', () => {
+      // conv2 is more recent (Jan 2nd vs Jan 1st)
+      expect(pickConversationsForHydration(conversations, null)).toEqual([conv2]);
+    });
+  });
+
+  describe('pickTerminalsForHydration', () => {
+    it('returns empty if no terminals', () => {
+      expect(pickTerminalsForHydration([], null)).toEqual([]);
+    });
+
+    it('returns all if only one terminal', () => {
+      expect(pickTerminalsForHydration([term1], null)).toEqual([term1]);
+    });
+
+    it('returns explicitly open terminals from tabOrder', () => {
+      const snapshot: Partial<TaskViewSnapshot> = {
+        terminals: { tabOrder: ['t2'] } as any,
+      };
+      expect(pickTerminalsForHydration(terminals, snapshot)).toEqual([term2]);
+    });
+
+    it('returns none if no snapshot is available', () => {
+      expect(pickTerminalsForHydration(terminals, null)).toEqual([]);
+    });
+  });
+});

--- a/src/main/core/tasks/task-builder.ts
+++ b/src/main/core/tasks/task-builder.ts
@@ -10,16 +10,19 @@ import type { Conversation } from '@shared/conversations';
 import { taskProvisionProgressChannel } from '@shared/events/taskEvents';
 import type { Task } from '@shared/tasks';
 import type { Terminal } from '@shared/terminals';
+import type { TaskViewSnapshot } from '@shared/view-state';
 import type { ProvisionResult, TaskProvider } from '../projects/project-provider';
 import type { ProjectSettingsProvider } from '../projects/settings/provider';
 import { resolveTaskWorkDir } from '../projects/worktrees/utils';
 import type { WorktreeService } from '../projects/worktrees/worktree-service';
+import { viewStateService } from '../view-state/view-state-service';
 import {
   buildTaskProviders,
   createWorkspaceFactory,
   resolveTaskEnv,
   type WorkspaceType,
 } from '../workspaces/workspace-factory';
+import { pickConversationsForHydration, pickTerminalsForHydration } from './hydration';
 
 export type BuildTaskResult = {
   taskProvider: TaskProvider;
@@ -182,8 +185,17 @@ export async function buildTaskFromWorkspace(
     terminals: terminalProvider,
   };
 
+  const taskViewSnapshot = (await viewStateService.get(
+    `task:${task.id}`
+  )) as Partial<TaskViewSnapshot> | null;
+  const conversationsToHydrate = pickConversationsForHydration(
+    hydrate.conversations,
+    taskViewSnapshot
+  );
+  const terminalsToHydrate = pickTerminalsForHydration(hydrate.terminals, taskViewSnapshot);
+
   void Promise.all(
-    hydrate.terminals.map((term) =>
+    terminalsToHydrate.map((term) =>
       terminalProvider.spawnTerminal(term).catch((e) => {
         log.error(`${logPrefix}: failed to hydrate terminal`, {
           terminalId: term.id,
@@ -194,7 +206,7 @@ export async function buildTaskFromWorkspace(
   );
 
   void Promise.all(
-    hydrate.conversations.map((conv) =>
+    conversationsToHydrate.map((conv) =>
       conversationProvider.startSession(conv, undefined, true).catch((e) => {
         log.error(`${logPrefix}: failed to hydrate conversation`, {
           conversationId: conv.id,

--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -1,4 +1,5 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import { buildTerminalEnv } from '@main/core/pty/pty-env';
@@ -154,8 +155,11 @@ export class LocalTerminalProvider implements TerminalProvider {
       wireTerminalDevServerWatcher({ pty, scopeId: this.scopeId, terminalId: terminal.id });
     }
 
-    pty.onExit(() => {
-      const shouldRespawn = policy.respawnOnExit && this.sessions.has(sessionId);
+    pty.onExit(({ exitCode, signal }) => {
+      const shouldRespawn =
+        policy.respawnOnExit &&
+        this.sessions.has(sessionId) &&
+        isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       if (!policy.preserveBufferOnExit) {
         ptySessionRegistry.unregister(sessionId);

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -1,4 +1,5 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import type { Pty } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
@@ -177,8 +178,11 @@ export class SshTerminalProvider implements TerminalProvider {
       });
     }
 
-    pty.onExit(() => {
-      const shouldRespawn = policy.respawnOnExit && this.sessions.has(sessionId);
+    pty.onExit(({ exitCode, signal }) => {
+      const shouldRespawn =
+        policy.respawnOnExit &&
+        this.sessions.has(sessionId) &&
+        isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       if (!policy.preserveBufferOnExit) {
         ptySessionRegistry.unregister(sessionId);

--- a/src/renderer/features/tasks/conversations/conversation-manager.ts
+++ b/src/renderer/features/tasks/conversations/conversation-manager.ts
@@ -222,6 +222,15 @@ export class ConversationManagerStore implements IDisposable {
     }
   }
 
+  async startSession(conversationId: string): Promise<void> {
+    if (!this.conversations.has(conversationId)) return;
+    await rpc.conversations.startConversationSession(this.projectId, this.taskId, conversationId);
+  }
+
+  async stopSession(conversationId: string): Promise<void> {
+    await rpc.conversations.stopConversationSession(this.projectId, this.taskId, conversationId);
+  }
+
   async renameConversation(conversationId: string, name: string): Promise<void> {
     const store = this.conversations.get(conversationId);
     if (!store) return;

--- a/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
+++ b/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
@@ -35,13 +35,20 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
   expandedPaths = observable.set<string>();
 
   private readonly projectId: string;
+  private readonly taskId: string;
   private readonly workspaceId: string;
   private readonly tabGroupManager: TabGroupManagerStore;
   private readonly disposers: (() => void)[] = [];
 
-  constructor(tabGroupManager: TabGroupManagerStore, projectId: string, workspaceId: string) {
+  constructor(
+    tabGroupManager: TabGroupManagerStore,
+    projectId: string,
+    taskId: string,
+    workspaceId: string
+  ) {
     this.tabGroupManager = tabGroupManager;
     this.projectId = projectId;
+    this.taskId = taskId;
     this.workspaceId = workspaceId;
     this.modelRootPath = `workspace:${workspaceId}`;
 
@@ -87,6 +94,18 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
             if (modelRegistry.isDirty(uri)) {
               const result = await this._confirmClose(entry.path);
               if (result === 'cancel') return;
+            }
+          } else if (entry.kind === 'conversation') {
+            const stillOpen = this.tabGroupManager.groups.some(
+              (g) =>
+                g.tabManager !== tabManager && g.tabManager.hasConversationTab(entry.conversationId)
+            );
+            if (!stillOpen) {
+              await rpc.conversations.stopConversationSession(
+                this.projectId,
+                this.taskId,
+                entry.conversationId
+              );
             }
           }
           tabManager.closeTab(tabId);

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -91,6 +91,7 @@ export class WorkspaceViewModel implements ILifecycle {
     this.editorView = new FileModelLifecycleStore(
       this.tabGroupManager,
       taskData.projectId,
+      taskData.id,
       workspaceId
     );
 

--- a/src/renderer/features/tasks/tabs/tab-group-manager-store.ts
+++ b/src/renderer/features/tasks/tabs/tab-group-manager-store.ts
@@ -221,7 +221,21 @@ export class TabGroupManagerStore {
         return;
       }
     }
+
+    const previousPreviewConversationId = this.focusedGroup.previewConversationId;
+    const shouldStopPreviousPreview =
+      previousPreviewConversationId !== undefined &&
+      previousPreviewConversationId !== conversationId &&
+      !this.groups.some(
+        ({ tabManager }) =>
+          tabManager !== this.focusedGroup &&
+          tabManager.hasConversationTab(previousPreviewConversationId)
+      );
+
     this.focusedGroup.openConversationPreview(conversationId);
+    if (shouldStopPreviousPreview) {
+      void this._getConversations()?.stopSession(previousPreviewConversationId);
+    }
   }
 
   get snapshot(): TabGroupsSnapshot {

--- a/src/renderer/features/tasks/tabs/tab-manager-store.ts
+++ b/src/renderer/features/tasks/tabs/tab-manager-store.ts
@@ -370,12 +370,14 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
     if (existing) {
       existing.isPreview = false;
       this.activeTabId = existing.tabId;
+      void this._getConversations()?.startSession(conversationId);
       return;
     }
     const entry = new ConversationTabEntry(conversationId, false);
     this.entries.set(entry.tabId, entry);
     addTabId(this, entry.tabId);
     this.activeTabId = entry.tabId;
+    void this._getConversations()?.startSession(conversationId);
   }
 
   openConversationPreview(conversationId: string): void {
@@ -383,6 +385,7 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
     if (existing) {
       // Already open (stable or preview) — just activate; never demote stable → preview.
       this.activeTabId = existing.tabId;
+      void this._getConversations()?.startSession(conversationId);
       return;
     }
     const previewEntry = this._findConversationPreviewEntry();
@@ -390,12 +393,14 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
       // Replace in-place: mutate conversationId so the same tabId and slot are reused.
       previewEntry.conversationId = conversationId;
       this.activeTabId = previewEntry.tabId;
+      void this._getConversations()?.startSession(conversationId);
       return;
     }
     const entry = new ConversationTabEntry(conversationId, true);
     this.entries.set(entry.tabId, entry);
     addTabId(this, entry.tabId);
     this.activeTabId = entry.tabId;
+    void this._getConversations()?.startSession(conversationId);
   }
 
   // ---------------------------------------------------------------------------
@@ -612,6 +617,10 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
 
   hasConversationTab(conversationId: string): boolean {
     return this._findConversationEntry(conversationId) !== undefined;
+  }
+
+  get previewConversationId(): string | undefined {
+    return this._findConversationPreviewEntry()?.conversationId;
   }
 
   // ---------------------------------------------------------------------------

--- a/src/renderer/features/tasks/view/tab-bar.tsx
+++ b/src/renderer/features/tasks/view/tab-bar.tsx
@@ -23,7 +23,7 @@ function makeTabRenderers(tabManager: ReturnType<typeof useTabGroupContext>['tab
         tab={tab}
         onSelect={() => tabManager.setActiveTab(tab.tabId)}
         onPin={() => tabManager.openConversation(tab.conversationId)}
-        onClose={() => tabManager.closeTab(tab.tabId)}
+        onClose={() => tabManager.closeTabWithGuard(tab.tabId)}
       />
     ),
     diff: (tab: ResolvedDiffTab): ReactNode => (


### PR DESCRIPTION
## What changed
- Added explicit conversation session start/stop RPCs so opening and closing conversation tabs can control the underlying agent session lifecycle.
- Updated PTY kill behavior to terminate process groups on POSIX and added a fallback SIGKILL timeout.
- Reduced hydration to only restore sessions that are actually represented in the current task view snapshot, with a fallback to the most recent conversation when snapshots are stale.
- Added tests for PTY exit classification, local PTY kill behavior, and hydration selection.

## Why
This fixes a memory/leak-style bug where task sessions could remain running after the UI no longer had a live tab for them, especially when tabs were replaced or when stale snapshot state was present during task hydration.

## Validation
- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec vitest run src/main/core/pty/exit-classification.test.ts src/main/core/pty/local-pty.test.ts src/main/core/tasks/task-builder.test.ts`
- `pnpm exec vitest run --project node --project main-db --project migrations`

## Note
- `pnpm run test` could not complete the browser project in this environment because Playwright Chromium is not installed and the available Playwright package does not support `ubuntu26.04-x64` here.
