### PR TITLE
chore: optimize CLI spinner loop

### DIFF
--- a/src/renderer/features/tasks/components/cliSpinner.tsx
+++ b/src/renderer/features/tasks/components/cliSpinner.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useSyncExternalStore } from 'react';
 
 const FRAMES_1 = ['⠋', '⠙', '⠹', '⠸', '⠼', '⠴', '⠦', '⠧', '⠇', '⠏'];
 const FRAMES_2 = [
@@ -28,19 +28,60 @@ const FRAMES_2 = [
   '⠈',
 ];
 
-export function CLISpinner({ variant = '1' }: { variant?: '1' | '2' }) {
-  const [index, setIndex] = useState(0);
+type SpinnerVariant = '1' | '2';
 
-  useEffect(() => {
-    const interval = setInterval(() => {
-      setIndex((index + 1) % (variant === '1' ? FRAMES_1.length : FRAMES_2.length));
-    }, 80);
-    return () => clearInterval(interval);
-  }, [index, variant]);
+const FRAME_INTERVAL_MS = 80;
 
-  return (
-    <span className="text-foreground/60">
-      {variant === '1' ? FRAMES_1[index] : FRAMES_2[index]}
-    </span>
+let intervalId: ReturnType<typeof setInterval> | null = null;
+let tick = 0;
+
+const listeners = new Set<() => void>();
+
+const notifyListeners = () => {
+  tick += 1;
+  listeners.forEach((listener) => listener());
+};
+
+const stopSpinnerLoop = () => {
+  if (intervalId === null) {
+    return;
+  }
+
+  clearInterval(intervalId);
+  intervalId = null;
+};
+
+const startSpinnerLoop = () => {
+  if (intervalId !== null) {
+    return;
+  }
+
+  intervalId = setInterval(notifyListeners, FRAME_INTERVAL_MS);
+};
+
+const subscribeToSpinner = (listener: () => void) => {
+  listeners.add(listener);
+  startSpinnerLoop();
+
+  return () => {
+    listeners.delete(listener);
+
+    if (listeners.size === 0) {
+      stopSpinnerLoop();
+      tick = 0;
+    }
+  };
+};
+
+const getSpinnerSnapshot = () => tick;
+
+export function CLISpinner({ variant = '1' }: { variant?: SpinnerVariant }) {
+  const currentTick = useSyncExternalStore(
+    subscribeToSpinner,
+    getSpinnerSnapshot,
+    getSpinnerSnapshot
   );
+  const frames = variant === '1' ? FRAMES_1 : FRAMES_2;
+
+  return <span className="text-foreground/60">{frames[currentTick % frames.length]}</span>;
 }


### PR DESCRIPTION
# summary
- cli spinner "cleanup" 
- no more useEffect :D

<img width="745" height="199" alt="image" src="https://github.com/user-attachments/assets/ab027182-a6d9-4292-a04f-cb395cdb7440" />
