### PR TITLE
fix(plain): preserve real ForbiddenError message from Plain API

### DIFF
--- a/src/main/core/plain/plain-connection-service.ts
+++ b/src/main/core/plain/plain-connection-service.ts
@@ -16,10 +16,7 @@ export function toPlainErrorMessage(error: unknown, fallback: string): string {
     return error.message || 'Plain authentication failed. Check your API key.';
   }
   if (error instanceof ForbiddenError) {
-    return (
-      error.message ||
-      'Plain API key was accepted but is missing required permissions. Create a key with thread read permissions.'
-    );
+    return error.message || 'Plain API key was accepted but is missing required permissions.';
   }
   if (error instanceof RateLimitError) {
     return 'Plain API rate limit exceeded. Please try again shortly.';
@@ -151,15 +148,12 @@ export class PlainConnectionService {
     try {
       await client.query.threads({ first: 1 });
     } catch (error) {
-      if (error instanceof ForbiddenError) {
-        throw new ForbiddenError(
-          'Insufficient permissions: this key cannot read threads. Ensure thread read permissions are enabled.'
-        );
-      }
-      if (error instanceof AuthenticationError || error instanceof RateLimitError) {
-        throw error;
-      }
-      if (error instanceof PlainError) {
+      if (
+        error instanceof ForbiddenError ||
+        error instanceof AuthenticationError ||
+        error instanceof RateLimitError ||
+        error instanceof PlainError
+      ) {
         throw error;
       }
       if (error instanceof Error) {


### PR DESCRIPTION
## Summary

`PlainConnectionService.validateToken` was catching the `ForbiddenError` thrown by `@team-plain/graphql` and re-throwing a new one with a hardcoded message:

```ts
'Insufficient permissions: this key cannot read threads. Ensure thread read permissions are enabled.'
```

That overwrote the SDK's original message, which already contained the *specific* permission detail Plain's API returned (e.g. `customer:read`, `thread:list`, workspace-scope issues, etc. — see `node_modules/@team-plain/graphql/dist/graphql-client.js:30`).

The result: users with valid `thread:read` permissions but a different missing scope got a misleading "ensure thread read permissions are enabled" error, sending them on a wild goose chase verifying a permission they already had.

This PR drops the rewrite and lets the SDK's `ForbiddenError` propagate. `toPlainErrorMessage` already returns `error.message` first, so the actual Plain-side reason now reaches the settings UI.

## Test plan

- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (823 passed)
- [x] Manually verified: connecting a Plain key with a missing non-thread permission now surfaces Plain's actual error string in the integrations card

🤖 Generated with [Claude Code](https://claude.com/claude-code)