### PR TITLE
fix(ui): avoid stuck isAnimating state in AnimatedHeight

### DIFF
--- a/src/renderer/lib/ui/animated-height.tsx
+++ b/src/renderer/lib/ui/animated-height.tsx
@@ -12,6 +12,11 @@ export function AnimatedHeight({
   onAnimatingChange?: (isAnimating: boolean) => void;
 }) {
   const contentRef = useRef<HTMLDivElement>(null);
+  // Track the last observed height in a ref so the ResizeObserver callback
+  // can detect actual changes without putting a side effect (setIsAnimating)
+  // inside setHeight's updater function — pure-updater violations are
+  // fragile in React StrictMode where updaters run twice.
+  const lastHeightRef = useRef<number | undefined>(undefined);
   const [height, setHeight] = useState<number | undefined>(undefined);
   const [isAnimating, setIsAnimating] = useState(false);
 
@@ -21,7 +26,9 @@ export function AnimatedHeight({
   useLayoutEffect(() => {
     const el = contentRef.current;
     if (!el) return;
-    setHeight(el.offsetHeight);
+    const initial = el.offsetHeight;
+    lastHeightRef.current = initial;
+    setHeight(initial);
   }, []);
 
   useEffect(() => {
@@ -35,7 +42,10 @@ export function AnimatedHeight({
         isFirstCallback = false;
         return;
       }
-      setHeight(el.offsetHeight);
+      const next = el.offsetHeight;
+      if (lastHeightRef.current === next) return;
+      lastHeightRef.current = next;
+      setHeight(next);
       setIsAnimating(true);
     });
     ro.observe(el);


### PR DESCRIPTION
## Summary

`AnimatedHeight` could end up permanently locked in its animating state, which propagated through `onAnimatingChange` and made consumers — most visibly the create-task modal's issue selector — un-clickable.

The `ResizeObserver` callback unconditionally called both:

```ts
setHeight(el.offsetHeight);
setIsAnimating(true);
```

When `offsetHeight` returned the same integer that was already in state, React skipped the `setHeight` update, framer-motion had nothing to animate, and `onAnimationComplete` never fired. `isAnimating` then stayed pinned at `true`.

`create-task-modal.tsx` passes that flag down as `disabled={isTransitioning}` to `FromIssueContent` → `InlineIssueSelector`, which applies `pointer-events-none` to its entire wrapper. Net effect: after any transient resize that wasn't a real height change, the provider Select (and everything else inside) became non-interactive, with no way to recover until the modal was reopened.

Fix: track the last observed height in a ref so the `ResizeObserver` callback can detect actual changes without putting a side effect (`setIsAnimating`) inside a state-updater function. Both state setters now run outside any updater — pure-updater violations are fragile in React StrictMode where updaters run twice.

## Test plan

- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm run test` (823 passed)
- [x] Manually verified: with multiple issue providers connected (e.g. GitHub + Plain), the provider Select inside the create-task "From Issue" tab is consistently clickable

🤖 Generated with [Claude Code](https://claude.com/claude-code)