### PR TITLE
fix(renderer): enable Ctrl+V paste in terminal on Windows

### DIFF
--- a/src/renderer/lib/pty/pty-keybindings.ts
+++ b/src/renderer/lib/pty/pty-keybindings.ts
@@ -76,24 +76,33 @@ export function shouldKillLineFromTerminal(event: KeyEventLike, isMacPlatform: b
 }
 
 /**
- * Detect Ctrl+Shift+V paste shortcut on Linux.
- * Linux terminals use Ctrl+Shift+V as the standard paste shortcut,
- * unlike Windows/macOS which use Ctrl+V/Cmd+V.
+ * Detect paste shortcut for the terminal.
+ * - Windows: Ctrl+V (native convention) and Ctrl+Shift+V both paste from clipboard.
+ * - Linux: Ctrl+Shift+V (standard Linux terminal convention).
+ * - macOS: no interception — Cmd+V is handled natively by xterm/Electron.
  */
-export function shouldPasteToTerminal(event: KeyEventLike, isMacPlatform: boolean): boolean {
+export function shouldPasteToTerminal(
+  event: KeyEventLike,
+  isMacPlatform: boolean,
+  isWindowsPlatform = false
+): boolean {
   if (event.type !== 'keydown') return false;
   if (event.key.toLowerCase() !== 'v') return false;
+  if (isMacPlatform) return false;
 
   const ctrl = event.ctrlKey === true;
   const meta = event.metaKey === true;
   const alt = event.altKey === true;
   const shift = event.shiftKey === true;
 
-  // Ctrl+Shift+V is the standard paste shortcut in Linux terminals
-  // Only apply on non-Mac platforms (Linux/Windows with Linux-style terminals)
-  if (!isMacPlatform && ctrl && shift && !meta && !alt) {
+  if (meta || alt) return false;
+  if (!ctrl) return false;
+
+  if (isWindowsPlatform) {
+    // Windows: accept Ctrl+V and Ctrl+Shift+V.
     return true;
   }
 
-  return false;
+  // Linux: Ctrl+Shift+V only.
+  return shift;
 }

--- a/src/renderer/lib/pty/use-pty.ts
+++ b/src/renderer/lib/pty/use-pty.ts
@@ -57,6 +57,7 @@ const MIN_TERMINAL_COLS = 2;
 const MIN_TERMINAL_ROWS = 1;
 const IS_MAC_PLATFORM =
   typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+const IS_WINDOWS_PLATFORM = typeof navigator !== 'undefined' && /Win/.test(navigator.platform);
 
 export interface UsePtyOptions {
   /** Deterministic PTY session ID: makePtySessionId(projectId, scopeId, leafId). */
@@ -412,7 +413,7 @@ export function usePty(
           return false;
         }
 
-        if (shouldPasteToTerminal(event, IS_MAC_PLATFORM)) {
+        if (shouldPasteToTerminal(event, IS_MAC_PLATFORM, IS_WINDOWS_PLATFORM)) {
           event.preventDefault();
           event.stopImmediatePropagation();
           event.stopPropagation();

--- a/src/renderer/tests/terminalKeybindings.test.ts
+++ b/src/renderer/tests/terminalKeybindings.test.ts
@@ -98,48 +98,87 @@ describe('TerminalSessionManager - Shift+Enter to Ctrl+J mapping', () => {
     ).toBe(false);
   });
 
-  it('detects Ctrl+Shift+V paste on Linux only', () => {
+  it('detects paste shortcut per platform', () => {
     const isMac = true;
     const isNotMac = false;
+    const isWin = true;
+    const isNotWin = false;
 
-    // Ctrl+Shift+V on Linux should trigger paste
+    // Linux: Ctrl+Shift+V should trigger paste
     expect(
-      shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true, shiftKey: true }), isNotMac)
+      shouldPasteToTerminal(
+        makeEvent({ key: 'v', ctrlKey: true, shiftKey: true }),
+        isNotMac,
+        isNotWin
+      )
     ).toBe(true);
 
-    // Ctrl+Shift+V on macOS should NOT trigger paste (macOS uses Cmd+V)
+    // Linux: Ctrl+V alone should NOT trigger
+    expect(shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true }), isNotMac, isNotWin)).toBe(
+      false
+    );
+
+    // Windows: Ctrl+V should trigger paste (native convention)
+    expect(shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true }), isNotMac, isWin)).toBe(
+      true
+    );
+
+    // Windows: Ctrl+Shift+V should also trigger paste
     expect(
-      shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true, shiftKey: true }), isMac)
+      shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true, shiftKey: true }), isNotMac, isWin)
+    ).toBe(true);
+
+    // macOS: Ctrl+Shift+V should NOT trigger (macOS uses Cmd+V, handled natively)
+    expect(
+      shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true, shiftKey: true }), isMac, isNotWin)
     ).toBe(false);
 
-    // Ctrl+V alone should NOT trigger (that's SIGINT in terminals)
-    expect(shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true }), isNotMac)).toBe(false);
+    // macOS: Ctrl+V should NOT trigger
+    expect(shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true }), isMac, isNotWin)).toBe(
+      false
+    );
 
-    // Additional modifiers should NOT trigger
+    // Additional modifiers should NOT trigger on any platform
     expect(
       shouldPasteToTerminal(
         makeEvent({ key: 'v', ctrlKey: true, shiftKey: true, altKey: true }),
-        isNotMac
+        isNotMac,
+        isNotWin
       )
     ).toBe(false);
     expect(
       shouldPasteToTerminal(
         makeEvent({ key: 'v', ctrlKey: true, shiftKey: true, metaKey: true }),
-        isNotMac
+        isNotMac,
+        isWin
       )
     ).toBe(false);
+    expect(
+      shouldPasteToTerminal(makeEvent({ key: 'v', ctrlKey: true, altKey: true }), isNotMac, isWin)
+    ).toBe(false);
+
+    // Plain V without Ctrl should NOT trigger
+    expect(shouldPasteToTerminal(makeEvent({ key: 'v' }), isNotMac, isWin)).toBe(false);
 
     // Wrong key should NOT trigger
     expect(
-      shouldPasteToTerminal(makeEvent({ key: 'c', ctrlKey: true, shiftKey: true }), isNotMac)
+      shouldPasteToTerminal(
+        makeEvent({ key: 'c', ctrlKey: true, shiftKey: true }),
+        isNotMac,
+        isNotWin
+      )
     ).toBe(false);
 
     // keyup should NOT trigger
     expect(
       shouldPasteToTerminal(
         makeEvent({ type: 'keyup', key: 'v', ctrlKey: true, shiftKey: true }),
-        isNotMac
+        isNotMac,
+        isNotWin
       )
+    ).toBe(false);
+    expect(
+      shouldPasteToTerminal(makeEvent({ type: 'keyup', key: 'v', ctrlKey: true }), isNotMac, isWin)
     ).toBe(false);
   });
 


### PR DESCRIPTION
# summary
- Windows terminals now accept `Ctrl+V` (and still `Ctrl+Shift+V`) to paste from the clipboard.
- Linux behaviour is unchanged (`Ctrl+Shift+V` only); macOS continues to rely on the native `Cmd+V` handling.
- Updates the `shouldPasteToTerminal` tests to cover all three platforms.

# why
On Windows, pressing `Ctrl+V` inside the PTY pane previously dropped through to xterm.js, which sent the raw `0x16` control character to the running CLI agent instead of pasting clipboard text. The comment above `shouldPasteToTerminal` already documented the intended Windows behaviour, but the implementation only intercepted `Ctrl+Shift+V` on non-Mac platforms.