### PR TITLE
fix(renderer): enable tsx and jsx syntax highlighting in diff view

### DIFF
--- a/src/renderer/utils/languageUtils.ts
+++ b/src/renderer/utils/languageUtils.ts
@@ -4,15 +4,15 @@
 
 /**
  * Detect programming language from file path extension.
- * Returns a language identifier compatible with syntax highlighters (e.g., Prism).
+ * Returns a language identifier compatible with Monaco Editor.
  */
 export function getLanguageFromPath(path: string): string {
   const ext = path.split('.').pop()?.toLowerCase() || '';
   const langMap: Record<string, string> = {
     js: 'javascript',
-    jsx: 'jsx',
+    jsx: 'javascript',
     ts: 'typescript',
-    tsx: 'tsx',
+    tsx: 'typescript',
     py: 'python',
     java: 'java',
     c: 'c',


### PR DESCRIPTION
## Summary

- Restore syntax colors for React component files (.tsx and .jsx) in the diff view.
- Keep existing highlighting working for .ts and .js files.