### PR TITLE
fix(skills): parse multiline skill descriptions

### DIFF
--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -458,6 +458,9 @@ export class SkillsService {
         installedMap.delete(skill.id);
         return {
           ...skill,
+          displayName: local.displayName || skill.displayName,
+          description: local.description || skill.description,
+          frontmatter: { ...skill.frontmatter, ...local.frontmatter },
           installed: true,
           localPath: local.localPath,
           skillMdContent: local.skillMdContent,

--- a/src/shared/skills/validation.test.ts
+++ b/src/shared/skills/validation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from './validation';
+
+describe('parseFrontmatter', () => {
+  it('parses single-line quoted values', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: "review"
+description: "Review code changes"
+---
+
+# Review
+`);
+
+    expect(frontmatter).toEqual({
+      name: 'review',
+      description: 'Review code changes',
+      license: undefined,
+      compatibility: undefined,
+      'allowed-tools': undefined,
+    });
+  });
+
+  it('parses literal block descriptions without exposing the YAML marker', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: docs
+description: |
+  Edit documentation.
+  Keep the prose direct.
+---
+
+# Docs
+`);
+
+    expect(frontmatter.description).toBe('Edit documentation.\nKeep the prose direct.');
+  });
+
+  it('parses folded block descriptions as display-friendly text', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: docs
+description: >
+  Edit documentation.
+  Keep the prose direct.
+---
+
+# Docs
+`);
+
+    expect(frontmatter.description).toBe('Edit documentation. Keep the prose direct.');
+  });
+
+  it('continues parsing fields after a block scalar', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: docs
+description: |-
+  Edit documentation.
+license: MIT
+---
+
+# Docs
+`);
+
+    expect(frontmatter.description).toBe('Edit documentation.');
+    expect(frontmatter.license).toBe('MIT');
+  });
+});

--- a/src/shared/skills/validation.ts
+++ b/src/shared/skills/validation.ts
@@ -1,5 +1,7 @@
 import type { SkillFrontmatter } from './types';
 
+type BlockScalarStyle = 'literal' | 'folded';
+
 /** Validate a skill name: lowercase, hyphens, 1-64 chars */
 export function isValidSkillName(name: string): boolean {
   return /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]?$/.test(name) && !name.includes('--');
@@ -21,21 +23,21 @@ export function parseFrontmatter(content: string): {
   const yamlBlock = match[1];
   const body = match[2];
   const frontmatter: Record<string, string> = {};
+  const lines = yamlBlock.split('\n');
 
-  for (const line of yamlBlock.split('\n')) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     const colonIdx = line.indexOf(':');
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
     let value = line.slice(colonIdx + 1).trim();
-    const wasDoubleQuoted = value.startsWith('"') && value.endsWith('"');
-    const wasSingleQuoted = value.startsWith("'") && value.endsWith("'");
-    if (wasDoubleQuoted || wasSingleQuoted) {
-      value = value.slice(1, -1);
-      if (wasDoubleQuoted) {
-        value = value.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
-      } else if (wasSingleQuoted) {
-        value = value.replace(/''/g, "'");
-      }
+    const blockScalarStyle = getBlockScalarStyle(value);
+    if (blockScalarStyle) {
+      const { value: blockValue, nextIndex } = parseBlockScalar(lines, i, blockScalarStyle);
+      value = blockValue;
+      i = nextIndex;
+    } else {
+      value = unquoteYamlValue(value);
     }
     if (key) {
       frontmatter[key] = value;
@@ -52,6 +54,58 @@ export function parseFrontmatter(content: string): {
     },
     body,
   };
+}
+
+function getBlockScalarStyle(value: string): BlockScalarStyle | null {
+  if (/^\|[+-]?$/.test(value)) return 'literal';
+  if (/^>[+-]?$/.test(value)) return 'folded';
+  return null;
+}
+
+function parseBlockScalar(
+  lines: string[],
+  headerIndex: number,
+  style: BlockScalarStyle
+): { value: string; nextIndex: number } {
+  const headerIndent = countIndent(lines[headerIndex]);
+  const blockLines: string[] = [];
+  let nextIndex = headerIndex;
+
+  for (let i = headerIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() && countIndent(line) <= headerIndent) break;
+    blockLines.push(line);
+    nextIndex = i;
+  }
+
+  const contentIndent = Math.min(
+    ...blockLines.filter((line) => line.trim()).map((line) => countIndent(line))
+  );
+  const normalizedLines = blockLines.map((line) =>
+    Number.isFinite(contentIndent) ? line.slice(contentIndent) : ''
+  );
+
+  if (style === 'folded') {
+    return {
+      value: normalizedLines.join(' ').replace(/\s+/g, ' ').trim(),
+      nextIndex,
+    };
+  }
+
+  return { value: normalizedLines.join('\n').trim(), nextIndex };
+}
+
+function countIndent(line: string): number {
+  const match = line.match(/^\s*/);
+  return match ? match[0].length : 0;
+}
+
+function unquoteYamlValue(value: string): string {
+  const wasDoubleQuoted = value.startsWith('"') && value.endsWith('"');
+  const wasSingleQuoted = value.startsWith("'") && value.endsWith("'");
+  if (wasDoubleQuoted) return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  if (wasSingleQuoted) return value.slice(1, -1).replace(/''/g, "'");
+  return value;
 }
 
 function escapeYamlDoubleQuoted(s: string): string {


### PR DESCRIPTION
Parse multiline skill descriptions so YAML block markers do not appear in the skills catalog.