### PR TITLE
feat(settings): preview terminal font options

### DIFF
--- a/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -203,7 +203,9 @@ const TerminalSettingsCard: React.FC = () => {
                       <ComboboxCollection>
                         {(item: FontOption) => (
                           <ComboboxItem key={item.value || '__default__'} value={item}>
-                            {item.label}
+                            <span style={{ fontFamily: item.value ? `"${item.value}"` : 'Menlo' }}>
+                              {item.label}
+                            </span>
                           </ComboboxItem>
                         )}
                       </ComboboxCollection>

--- a/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -46,9 +46,11 @@ const POPULAR_FONTS = [
   'MesloLGS NF',
 ];
 
+const DEFAULT_FONT_FAMILY = 'Menlo';
+
 const DEFAULT_OPTION: FontOption = {
   value: '',
-  label: 'Default (Menlo)',
+  label: `Default (${DEFAULT_FONT_FAMILY})`,
 };
 
 const clampFontSize = (size: number) =>
@@ -203,7 +205,11 @@ const TerminalSettingsCard: React.FC = () => {
                       <ComboboxCollection>
                         {(item: FontOption) => (
                           <ComboboxItem key={item.value || '__default__'} value={item}>
-                            <span style={{ fontFamily: item.value ? `"${item.value}"` : 'Menlo' }}>
+                            <span
+                              style={{
+                                fontFamily: item.value ? `"${item.value}"` : DEFAULT_FONT_FAMILY,
+                              }}
+                            >
                               {item.label}
                             </span>
                           </ComboboxItem>


### PR DESCRIPTION
<img width="181" height="304" alt="image" src="https://github.com/user-attachments/assets/fabf9037-6d07-4386-8341-46181382f00f" />
