### PR TITLE
fix: Fix environment variable configuration for opencode MCPs

### DIFF
--- a/src/main/core/mcp/utils/adapters.test.ts
+++ b/src/main/core/mcp/utils/adapters.test.ts
@@ -74,6 +74,18 @@ describe('adaptForward (canonical → agent)', () => {
         enabled: true,
       });
     });
+
+    it('writes stdio env vars under `environment`, not `env`', () => {
+      const server = { command: 'npx', args: ['-y', 'foo'], env: { FOO: 'bar' } };
+      const result = adaptForward('opencode', { s1: server });
+      expect(result.s1).toEqual({
+        type: 'local',
+        command: ['npx', '-y', 'foo'],
+        enabled: true,
+        environment: { FOO: 'bar' },
+      });
+      expect(result.s1).not.toHaveProperty('env');
+    });
   });
 
   describe('copilot', () => {
@@ -196,6 +208,24 @@ describe('adaptReverse (agent → canonical)', () => {
       const result = adaptReverse('opencode', servers);
       expect(result.s1).toMatchObject({ command: 'npx', args: ['-y', 'foo'] });
       expect(result.s1).not.toHaveProperty('type');
+    });
+
+    it("translates opencode's `environment` back to canonical `env` for local servers", () => {
+      const servers: ServerMap = {
+        s1: {
+          type: 'local',
+          command: ['npx', '-y', 'foo'],
+          environment: { FOO: 'bar' },
+          enabled: true,
+        },
+      };
+      const result = adaptReverse('opencode', servers);
+      expect(result.s1).toEqual({
+        command: 'npx',
+        args: ['-y', 'foo'],
+        env: { FOO: 'bar' },
+      });
+      expect(result.s1).not.toHaveProperty('environment');
     });
   });
 

--- a/src/main/core/mcp/utils/adapters.ts
+++ b/src/main/core/mcp/utils/adapters.ts
@@ -100,14 +100,13 @@ function fwdOpencode(servers: ServerMap): ServerMap {
       };
       ensureHeader(headers, 'Accept', 'application/json, text/event-stream');
       const entry: RawServerEntry = { type: 'remote', url: v.url ?? '', headers, enabled: true };
-      if (v.env && typeof v.env === 'object') entry.env = v.env;
       result[k] = entry;
     } else if (isStdio(v)) {
       const cmdVec: string[] = [];
       if (typeof v.command === 'string' && v.command) cmdVec.push(v.command);
       if (Array.isArray(v.args)) cmdVec.push(...(v.args as string[]));
       const entry: RawServerEntry = { type: 'local', command: cmdVec, enabled: true };
-      if (v.env && typeof v.env === 'object') entry.env = v.env;
+      if (v.env && typeof v.env === 'object') entry.environment = v.env;
       result[k] = entry;
     } else {
       result[k] = deepClone(v);
@@ -183,6 +182,9 @@ function revOpencode(servers: ServerMap): ServerMap {
       const entry: RawServerEntry = {};
       if (command) entry.command = command;
       if (args.length) entry.args = args;
+      if (v.environment && typeof v.environment === 'object') {
+        entry.env = v.environment;
+      }
       result[k] = entry;
     } else {
       result[k] = deepClone(v);


### PR DESCRIPTION
This PR fixes environment variable handling when reading/writing opencode MCP configuration: opencode expects `environment`, but we were setting `env`. Additionally, it doesn't support setting either for remote MCPs. See McpLocalConfig and McpRemoteConfig on https://opencode.ai/config.json for reference