### PR TITLE
feat: add skills.sh search backend

### DIFF
--- a/src/main/core/skills/SkillsService.test.ts
+++ b/src/main/core/skills/SkillsService.test.ts
@@ -1,0 +1,94 @@
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { afterEach, describe, expect, it } from 'vitest';
+import { isValidSkillName } from '@shared/skills/validation';
+import { SkillsService } from './SkillsService';
+
+type SkillsServiceInternals = {
+  getSkillShInstallName(sourceRef: string, skillPath: string): string;
+  removeSyncedAgentSkillLink(targetDir: string): Promise<void>;
+};
+
+describe('SkillsService Skills.SH install names', () => {
+  const service = new SkillsService() as unknown as SkillsServiceInternals;
+
+  it('keeps nested Skills.SH paths distinct even when the leaf name matches', () => {
+    const first = service.getSkillShInstallName('owner/repo', 'skills/react');
+    const second = service.getSkillShInstallName('owner/repo', 'examples/react');
+
+    expect(first).not.toBe(second);
+    expect(isValidSkillName(first)).toBe(true);
+    expect(isValidSkillName(second)).toBe(true);
+  });
+
+  it('keeps owner and repo boundaries distinct when hyphens collide', () => {
+    const first = service.getSkillShInstallName('foo-bar/baz', 'qux');
+    const second = service.getSkillShInstallName('foo/bar-baz', 'qux');
+
+    expect(first).not.toBe(second);
+    expect(isValidSkillName(first)).toBe(true);
+    expect(isValidSkillName(second)).toBe(true);
+  });
+
+  it('sanitizes uppercase and punctuation in Skills.SH paths', () => {
+    const installName = service.getSkillShInstallName('Owner/Repo', 'skills/React:Components');
+
+    expect(installName).toMatch(/^skillssh-owner-repo-skills-react-components-[a-f0-9]{8}$/);
+    expect(isValidSkillName(installName)).toBe(true);
+  });
+
+  it('truncates long Skills.SH install names to the local skill name limit', () => {
+    const installName = service.getSkillShInstallName(
+      'very-long-owner-name/very-long-repository-name',
+      'skills/very-long-skill-name-that-would-otherwise-exceed-the-sixty-four-character-limit'
+    );
+
+    expect(installName.length).toBeLessThanOrEqual(64);
+    expect(installName).toMatch(/-[a-f0-9]{8}$/);
+    expect(isValidSkillName(installName)).toBe(true);
+  });
+});
+
+describe('SkillsService uninstall and sync safety', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(async () => {
+    await Promise.all(tempDirs.map((dir) => fs.promises.rm(dir, { recursive: true, force: true })));
+    tempDirs.length = 0;
+  });
+
+  it('rejects non-Skills.SH uninstall ids that are not valid local skill names', async () => {
+    const service = new SkillsService();
+
+    await expect(service.uninstallSkill('../outside')).rejects.toThrow(
+      'Invalid skill install name'
+    );
+  });
+
+  it('does not delete real directories when replacing synced agent skill targets', async () => {
+    const service = new SkillsService() as unknown as SkillsServiceInternals;
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'emdash-skills-test-'));
+    tempDirs.push(root);
+    const targetDir = path.join(root, 'agent-skill');
+    await fs.promises.mkdir(targetDir);
+    await fs.promises.writeFile(path.join(targetDir, 'SKILL.md'), '# User managed\n');
+
+    await service.removeSyncedAgentSkillLink(targetDir);
+
+    await expect(fs.promises.stat(path.join(targetDir, 'SKILL.md'))).resolves.toBeDefined();
+  });
+
+  it('unlinks synced symlinks that point into the central skills root', async () => {
+    const service = new SkillsService() as unknown as SkillsServiceInternals;
+    const root = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'emdash-skills-test-'));
+    tempDirs.push(root);
+    const targetDir = path.join(root, 'agent-skill');
+    const centralSkillDir = path.join(os.homedir(), '.agentskills', 'agent-skill');
+    await fs.promises.symlink(centralSkillDir, targetDir, 'junction');
+
+    await service.removeSyncedAgentSkillLink(targetDir);
+
+    await expect(fs.promises.lstat(targetDir)).rejects.toMatchObject({ code: 'ENOENT' });
+  });
+});

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -12,6 +12,18 @@ import bundledCatalog from './bundled-catalog.json';
 const SKILLS_ROOT = path.join(os.homedir(), '.agentskills');
 const EMDASH_META = path.join(SKILLS_ROOT, '.emdash');
 const CATALOG_INDEX_PATH = path.join(EMDASH_META, 'catalog-index.json');
+const SKILLSH_INSTALLS_PATH = path.join(EMDASH_META, 'skillssh-installs.json');
+
+/**
+ * Persisted Skills.SH provenance, keyed by local install directory name.
+ * Lets us reattach the skillssh source + icon to installed skills, which the
+ * filesystem scan alone cannot recover.
+ */
+interface SkillShInstallRecord {
+  sourceRef: string;
+  catalogSkillId: string;
+  skillShPath: string;
+}
 
 const MAX_REDIRECTS = 5;
 const MAX_HTTP_RESPONSE_BYTES = 2 * 1024 * 1024;
@@ -166,6 +178,7 @@ export class SkillsService {
     await this.initialize();
     const seen = new Set<string>();
     const skills: CatalogSkill[] = [];
+    const skillShInstalls = await this.readPrunedSkillShInstalls();
 
     // Scan all known skill directories (central + agent-specific)
     const dirsToScan = [SKILLS_ROOT, ...skillScanPaths];
@@ -201,11 +214,20 @@ export class SkillsService {
           const content = await fs.promises.readFile(skillMdPath, 'utf-8');
           const { frontmatter } = parseFrontmatter(content);
           seen.add(entry.name);
+          const skillSh = skillShInstalls[entry.name];
           skills.push({
-            id: entry.name,
+            id: skillSh ? this.toSkillShId(skillSh.sourceRef, skillSh.skillShPath) : entry.name,
+            installId: skillSh ? entry.name : undefined,
             displayName: frontmatter.name || entry.name,
-            description: frontmatter.description || '',
-            source: 'local',
+            description: frontmatter.description || skillSh?.sourceRef || '',
+            source: skillSh ? 'skillssh' : 'local',
+            sourceRef: skillSh?.sourceRef,
+            catalogSkillId: skillSh?.catalogSkillId,
+            skillShPath: skillSh?.skillShPath,
+            sourceUrl: skillSh
+              ? this.getSkillShUrl(skillSh.sourceRef, skillSh.skillShPath)
+              : undefined,
+            iconUrl: skillSh ? this.getSkillShIconUrl(skillSh.sourceRef) : undefined,
             frontmatter,
             installed: true,
             localPath: skillDir,
@@ -332,6 +354,15 @@ export class SkillsService {
       // Sync to agents
       await this.syncToAgents(installName);
 
+      // Persist Skills.SH provenance so the installed skill keeps its source + icon
+      if (skill.source === 'skillssh' && skill.sourceRef && skill.catalogSkillId) {
+        await this.writeSkillShInstall(installName, {
+          sourceRef: skill.sourceRef,
+          catalogSkillId: skill.catalogSkillId,
+          skillShPath: skill.skillShPath ?? skill.catalogSkillId,
+        });
+      }
+
       // Invalidate cache
       this.catalogCache = null;
       this.skillShSearchCache.clear();
@@ -384,6 +415,9 @@ export class SkillsService {
         throw error;
       }
     }
+
+    // Drop any persisted Skills.SH provenance for this install
+    await this.removeSkillShInstall(installName);
 
     // Invalidate cache
     this.catalogCache = null;
@@ -759,6 +793,62 @@ export class SkillsService {
     const maxBaseLength = MAX_SKILL_NAME_LENGTH - hash.length - 1;
     const truncatedBase = base.slice(0, maxBaseLength).replace(/-+$/g, '') || 'skillssh';
     return `${truncatedBase}-${hash}`;
+  }
+
+  private async readSkillShInstalls(): Promise<Record<string, SkillShInstallRecord>> {
+    try {
+      const data = await fs.promises.readFile(SKILLSH_INSTALLS_PATH, 'utf-8');
+      const parsed = JSON.parse(data) as Record<string, SkillShInstallRecord>;
+      return parsed && typeof parsed === 'object' ? parsed : {};
+    } catch {
+      return {};
+    }
+  }
+
+  private async writeSkillShInstall(
+    installName: string,
+    record: SkillShInstallRecord
+  ): Promise<void> {
+    const installs = await this.readSkillShInstalls();
+    installs[installName] = record;
+    await fs.promises.mkdir(EMDASH_META, { recursive: true });
+    await fs.promises.writeFile(SKILLSH_INSTALLS_PATH, JSON.stringify(installs, null, 2));
+  }
+
+  private async removeSkillShInstall(installName: string): Promise<void> {
+    const installs = await this.readSkillShInstalls();
+    if (!(installName in installs)) return;
+    delete installs[installName];
+    await fs.promises.writeFile(SKILLSH_INSTALLS_PATH, JSON.stringify(installs, null, 2));
+  }
+
+  /**
+   * Read the provenance index, dropping entries whose install directory no
+   * longer exists (e.g. deleted outside the app). Existence is checked against
+   * the real directory — never the SKILL.md parse — so a transient read error
+   * can never discard provenance. Writes back only when something was pruned.
+   */
+  private async readPrunedSkillShInstalls(): Promise<Record<string, SkillShInstallRecord>> {
+    const installs = await this.readSkillShInstalls();
+    const live: Record<string, SkillShInstallRecord> = {};
+    let pruned = false;
+    for (const [installName, record] of Object.entries(installs)) {
+      try {
+        await fs.promises.access(path.resolve(SKILLS_ROOT, installName));
+        live[installName] = record;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === 'ENOENT') {
+          pruned = true;
+        } else {
+          // Unknown error (e.g. permissions) — keep the entry to stay safe
+          live[installName] = record;
+        }
+      }
+    }
+    if (pruned) {
+      await fs.promises.writeFile(SKILLSH_INSTALLS_PATH, JSON.stringify(live, null, 2));
+    }
+    return live;
   }
 
   private getLegacySkillShInstallName(sourceRef: string, catalogSkillId: string): string | null {

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -545,11 +545,13 @@ export class SkillsService {
         skills.push(skill);
       }
 
-      const mergedSkills = (await this.mergeInstalledState({
-        version: SkillsService.CATALOG_VERSION,
-        lastUpdated: new Date().toISOString(),
-        skills,
-      })).skills;
+      const mergedSkills = (
+        await this.mergeInstalledState({
+          version: SkillsService.CATALOG_VERSION,
+          lastUpdated: new Date().toISOString(),
+          skills,
+        })
+      ).skills;
 
       this.skillShSearchCache.set(trimmed, {
         expiresAt: Date.now() + SKILLSH_SEARCH_CACHE_TTL_MS,

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -1,3 +1,4 @@
+import { createHash } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as https from 'node:https';
 import * as os from 'node:os';
@@ -16,6 +17,7 @@ const MAX_REDIRECTS = 5;
 const MAX_HTTP_RESPONSE_BYTES = 2 * 1024 * 1024;
 const SKILLSH_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
 const SKILLSH_SKILL_CACHE_MAX_ENTRIES = 200;
+const MAX_SKILL_NAME_LENGTH = 64;
 
 class HttpStatusError extends Error {
   constructor(
@@ -290,11 +292,13 @@ export class SkillsService {
     const tmpDir = `${skillDir}.tmp-${Date.now()}`;
     let finalDirCreated = false;
     try {
-      try {
-        await fs.promises.access(skillDir);
-        throw new Error(`Skill "${installName}" is already installed`);
-      } catch (err) {
-        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      for (const candidateName of this.getInstallNameCandidates(skill)) {
+        try {
+          await fs.promises.access(path.resolve(SKILLS_ROOT, candidateName));
+          throw new Error(`Skill "${candidateName}" is already installed`);
+        } catch (err) {
+          if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+        }
       }
 
       await fs.promises.mkdir(tmpDir, { recursive: true });
@@ -326,6 +330,8 @@ export class SkillsService {
 
       // Invalidate cache
       this.catalogCache = null;
+      this.skillShSearchCache.clear();
+      this.skillShSkillCache.clear();
 
       return {
         ...skill,
@@ -345,9 +351,14 @@ export class SkillsService {
   }
 
   async uninstallSkill(skillId: string): Promise<void> {
-    const skill = await this.resolveSkillShId(skillId);
-    const installName = skill ? this.getInstallName(skill) : skillId;
-    const skillDir = path.join(SKILLS_ROOT, installName);
+    const installName = await this.getInstallNameForUninstall(skillId);
+    if (!isValidSkillName(installName)) {
+      throw new Error(`Invalid skill install name "${installName}"`);
+    }
+    const skillDir = path.resolve(SKILLS_ROOT, installName);
+    if (!this.isPathInsideSkillsRoot(skillDir)) {
+      throw new Error(`Invalid skill install path for "${installName}"`);
+    }
 
     // Remove agent symlinks first. Never delete real directories from agent config paths —
     // those may be user-managed skills that Emdash only discovered.
@@ -372,6 +383,8 @@ export class SkillsService {
 
     // Invalidate cache
     this.catalogCache = null;
+    this.skillShSearchCache.clear();
+    this.skillShSkillCache.clear();
   }
 
   async createSkill(name: string, description: string, content?: string): Promise<CatalogSkill> {
@@ -426,15 +439,7 @@ export class SkillsService {
         const parentDir = path.dirname(targetDir);
         await fs.promises.mkdir(parentDir, { recursive: true });
 
-        // Remove existing symlink/dir if present
-        try {
-          const stat = await fs.promises.lstat(targetDir);
-          if (stat.isSymbolicLink() || stat.isDirectory()) {
-            await fs.promises.rm(targetDir, { recursive: true, force: true });
-          }
-        } catch {
-          // Doesn't exist, that's fine
-        }
+        await this.removeSyncedAgentSkillLink(targetDir);
 
         await fs.promises.symlink(skillDir, targetDir, 'junction');
       } catch (err) {
@@ -518,17 +523,19 @@ export class SkillsService {
         if (!this.isSkillShGithubSource(entry.source)) continue;
         if (skills.length >= 24) break;
 
-        const catalogSkillId = this.normalizeSkillShSkillId(entry.skillId);
-        if (!isValidSkillName(catalogSkillId)) continue;
-        const skillId = this.toSkillShId(entry.source, catalogSkillId);
-        if (skills.some((skill) => skill.id === skillId)) continue;
         const skillShPath = this.normalizeSkillShPath(entry.skillId);
+        if (!this.isSafeSkillShPath(skillShPath)) continue;
+        const catalogSkillId = this.normalizeSkillShSkillId(skillShPath);
+        if (!catalogSkillId) continue;
+        const skillId = this.toSkillShId(entry.source, skillShPath);
+        if (skills.some((skill) => skill.id === skillId)) continue;
         const displayName = entry.name || catalogSkillId;
         const description = entry.source;
-        const sourceUrl = this.getSkillShUrl(entry.source, catalogSkillId);
+        const sourceUrl = this.getSkillShUrl(entry.source, skillShPath);
 
         const skill: CatalogSkill = {
           id: skillId,
+          installId: this.getSkillShInstallName(entry.source, skillShPath),
           displayName,
           description,
           source: 'skillssh',
@@ -573,8 +580,8 @@ export class SkillsService {
 
   // --- Private helpers ---
 
-  private toSkillShId(sourceRef: string, skillId: string): string {
-    return `skillssh:${sourceRef}/${this.normalizeSkillShSkillId(skillId)}`;
+  private toSkillShId(sourceRef: string, skillPath: string): string {
+    return `skillssh:${sourceRef}/${this.normalizeSkillShPath(skillPath)}`;
   }
 
   private normalizeSkillShSearchQuery(query: string): string {
@@ -634,32 +641,28 @@ export class SkillsService {
     if (cached) return cached;
     if (!skillId.startsWith('skillssh:')) return null;
 
-    const fullId = skillId.slice('skillssh:'.length);
-    const parts = fullId.split('/');
-    if (parts.length < 3) return null;
+    const parsed = this.parseSkillShRemoteId(skillId);
+    if (!parsed) return null;
 
-    const sourceRef = parts.slice(0, 2).join('/');
-    if (!this.isSkillShGithubSource(sourceRef)) return null;
-
-    const catalogSkillId = this.normalizeSkillShSkillId(parts.slice(2).join('/'));
-    if (!isValidSkillName(catalogSkillId)) return null;
-
-    const sourceUrl = this.getSkillShUrl(sourceRef, catalogSkillId);
+    const sourceUrl = this.getSkillShUrl(parsed.sourceRef, parsed.skillShPath);
     const pageDescription = await this.fetchSkillShPageDescription(sourceUrl).catch(() => null);
-    if (!pageDescription) return null;
 
     const skill: CatalogSkill = {
       id: skillId,
-      displayName: catalogSkillId,
-      description: `${sourceRef}`,
+      installId: this.getSkillShInstallName(parsed.sourceRef, parsed.skillShPath),
+      displayName: parsed.catalogSkillId,
+      description: `${parsed.sourceRef}`,
       source: 'skillssh',
-      sourceRef,
+      sourceRef: parsed.sourceRef,
       sourceUrl,
-      catalogSkillId,
-      skillShPath: catalogSkillId,
-      iconUrl: this.getSkillShIconUrl(sourceRef),
+      catalogSkillId: parsed.catalogSkillId,
+      skillShPath: parsed.skillShPath,
+      iconUrl: this.getSkillShIconUrl(parsed.sourceRef),
       brandColor: '#000000',
-      frontmatter: { name: catalogSkillId, description: pageDescription },
+      frontmatter: {
+        name: parsed.catalogSkillId,
+        description: pageDescription ?? parsed.sourceRef,
+      },
       installed: false,
     };
     this.setSkillShSkillCache(skill.id, skill);
@@ -667,14 +670,130 @@ export class SkillsService {
   }
 
   private getInstallName(skill: CatalogSkill): string {
-    if (skill.source !== 'skillssh' || !skill.sourceRef || !skill.catalogSkillId) return skill.id;
-
-    const [owner, repo] = skill.sourceRef.split('/');
-    return `skillssh-${owner}-${repo}-${this.normalizeSkillShSkillId(skill.catalogSkillId)}`;
+    return this.getInstallNameCandidates(skill)[0] ?? skill.id;
   }
 
-  private getSkillShUrl(sourceRef: string, skillId: string): string {
-    return `https://skills.sh/${sourceRef}/${skillId}`;
+  private getInstallNameCandidates(skill: CatalogSkill): string[] {
+    if (skill.source !== 'skillssh' || !skill.sourceRef || !skill.catalogSkillId) return [skill.id];
+
+    const installNames = [
+      skill.installId ??
+        this.getSkillShInstallName(skill.sourceRef, skill.skillShPath ?? skill.catalogSkillId),
+    ];
+    const legacyInstallName = this.getLegacySkillShInstallName(
+      skill.sourceRef,
+      skill.catalogSkillId
+    );
+    if (legacyInstallName && !installNames.includes(legacyInstallName)) {
+      installNames.push(legacyInstallName);
+    }
+    return installNames;
+  }
+
+  private async getInstallNameForUninstall(skillId: string): Promise<string> {
+    const cachedSkill = this.parseSkillShId(skillId);
+    if (cachedSkill) return this.getExistingInstallName(cachedSkill);
+    if (!skillId.startsWith('skillssh:')) return skillId;
+
+    const parsed = this.parseSkillShRemoteId(skillId);
+    if (!parsed) {
+      throw new Error(`Invalid Skills.SH skill id "${skillId}"`);
+    }
+    return this.getExistingInstallName({
+      id: skillId,
+      displayName: parsed.catalogSkillId,
+      description: parsed.sourceRef,
+      source: 'skillssh',
+      sourceRef: parsed.sourceRef,
+      catalogSkillId: parsed.catalogSkillId,
+      skillShPath: parsed.skillShPath,
+      frontmatter: { name: parsed.catalogSkillId, description: parsed.sourceRef },
+      installed: false,
+    });
+  }
+
+  private async getExistingInstallName(skill: CatalogSkill): Promise<string> {
+    const installNames = this.getInstallNameCandidates(skill);
+    for (const installName of installNames) {
+      try {
+        await fs.promises.access(path.resolve(SKILLS_ROOT, installName));
+        return installName;
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code !== 'ENOENT') throw error;
+      }
+    }
+    return installNames[0] ?? skill.id;
+  }
+
+  private parseSkillShRemoteId(
+    skillId: string
+  ): { sourceRef: string; catalogSkillId: string; skillShPath: string } | null {
+    const fullId = skillId.slice('skillssh:'.length);
+    const parts = fullId.split('/');
+    if (parts.length < 3) return null;
+
+    const sourceRef = parts.slice(0, 2).join('/');
+    if (!this.isSkillShGithubSource(sourceRef)) return null;
+
+    const skillShPath = this.normalizeSkillShPath(parts.slice(2).join('/'));
+    if (!this.isSafeSkillShPath(skillShPath)) return null;
+    const catalogSkillId = this.normalizeSkillShSkillId(skillShPath);
+    if (!catalogSkillId) return null;
+    return { sourceRef, catalogSkillId, skillShPath };
+  }
+
+  private getSkillShInstallName(sourceRef: string, skillPath: string): string {
+    const sourceSlug = this.toSkillNameSlug(sourceRef.replace(/\//g, '-'));
+    const normalizedSkillPath = this.normalizeSkillShPath(skillPath);
+    const skillSlug = this.toSkillNameSlug(normalizedSkillPath);
+    const hash = createHash('sha256')
+      .update(`${sourceRef}/${normalizedSkillPath}`)
+      .digest('hex')
+      .slice(0, 8);
+    const base = `skillssh-${sourceSlug}-${skillSlug}`;
+
+    const maxBaseLength = MAX_SKILL_NAME_LENGTH - hash.length - 1;
+    const truncatedBase = base.slice(0, maxBaseLength).replace(/-+$/g, '') || 'skillssh';
+    return `${truncatedBase}-${hash}`;
+  }
+
+  private getLegacySkillShInstallName(sourceRef: string, catalogSkillId: string): string | null {
+    const [owner, repo] = sourceRef.split('/');
+    const installName = `skillssh-${owner}-${repo}-${this.normalizeSkillShSkillId(catalogSkillId)}`;
+    return isValidSkillName(installName) ? installName : null;
+  }
+
+  private async removeSyncedAgentSkillLink(targetDir: string): Promise<void> {
+    try {
+      const stat = await fs.promises.lstat(targetDir);
+      if (!stat.isSymbolicLink()) return;
+
+      const linkTarget = await fs.promises.readlink(targetDir);
+      const resolved = path.resolve(path.dirname(targetDir), linkTarget);
+      if (this.isPathInsideSkillsRoot(resolved)) {
+        await fs.promises.unlink(targetDir);
+      }
+    } catch (error) {
+      const code = (error as NodeJS.ErrnoException).code;
+      if (code !== 'ENOENT') throw error;
+    }
+  }
+
+  private toSkillNameSlug(value: string): string {
+    return (
+      value
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, '-')
+        .replace(/^-+|-+$/g, '') || 'skill'
+    );
+  }
+
+  private getSkillShUrl(sourceRef: string, skillPath: string): string {
+    const encodedSkillPath = this.normalizeSkillShPath(skillPath)
+      .split('/')
+      .map(encodeURIComponent)
+      .join('/');
+    return `https://skills.sh/${sourceRef}/${encodedSkillPath}`;
   }
 
   private getSkillShIconUrl(sourceRef: string): string | undefined {
@@ -694,6 +813,11 @@ export class SkillsService {
 
     if (!skill.skillShPath) {
       throw new Error(`Could not find SKILL.md for ${skill.sourceRef}/${skill.catalogSkillId}`);
+    }
+    if (!this.isSafeSkillShPath(skill.skillShPath)) {
+      throw new Error(
+        `Invalid Skills.SH skill path for ${skill.sourceRef}/${skill.catalogSkillId}`
+      );
     }
 
     const candidatePaths = [`${skill.skillShPath}/SKILL.md`];
@@ -789,6 +913,11 @@ export class SkillsService {
     return !relativePath.startsWith('..') && !path.isAbsolute(relativePath);
   }
 
+  private isSafeSkillShPath(skillPath: string): boolean {
+    if (!skillPath || path.posix.isAbsolute(skillPath)) return false;
+    return !skillPath.split('/').some((part) => !part || part === '.' || part === '..');
+  }
+
   private loadBundledCatalog(): CatalogIndex {
     return bundledCatalog as CatalogIndex;
   }
@@ -805,13 +934,17 @@ export class SkillsService {
       return true;
     });
 
-    const mergedSkills = dedupedSkills.map((skill) => {
-      const installName = this.getInstallName(skill);
-      const local = installedMap.get(skill.id) ?? installedMap.get(installName);
+    const mergedSkills: CatalogSkill[] = dedupedSkills.map((skill) => {
+      const installNames = this.getInstallNameCandidates(skill);
+      const installName = installNames[0] ?? skill.id;
+      const local =
+        installedMap.get(skill.id) ??
+        installNames.map((name) => installedMap.get(name)).find(Boolean);
       if (local) {
         installedMap.delete(local.id);
         return {
           ...skill,
+          installId: installName !== skill.id ? installName : skill.installId,
           displayName: local.displayName || skill.displayName,
           description: local.description || skill.description,
           frontmatter: { ...skill.frontmatter, ...local.frontmatter },
@@ -820,7 +953,11 @@ export class SkillsService {
           skillMdContent: local.skillMdContent,
         };
       }
-      return { ...skill, installed: false };
+      return {
+        ...skill,
+        installId: installName !== skill.id ? installName : skill.installId,
+        installed: false,
+      };
     });
 
     // Add locally-installed skills not in the catalog

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -15,6 +15,17 @@ const CATALOG_INDEX_PATH = path.join(EMDASH_META, 'catalog-index.json');
 const MAX_REDIRECTS = 5;
 const MAX_HTTP_RESPONSE_BYTES = 2 * 1024 * 1024;
 const SKILLSH_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
+const SKILLSH_SKILL_CACHE_MAX_ENTRIES = 200;
+
+class HttpStatusError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    url: string
+  ) {
+    super(`HTTP ${statusCode} for ${url}`);
+    this.name = 'HttpStatusError';
+  }
+}
 
 function httpsGet(
   url: string,
@@ -42,7 +53,7 @@ function httpsGet(
           }
         }
         if (res.statusCode && res.statusCode >= 400) {
-          reject(new Error(`HTTP ${res.statusCode} for ${url}`));
+          reject(new HttpStatusError(res.statusCode, url));
           return;
         }
         let data = '';
@@ -334,11 +345,13 @@ export class SkillsService {
   }
 
   async uninstallSkill(skillId: string): Promise<void> {
-    const skillDir = path.join(SKILLS_ROOT, skillId);
+    const skill = await this.resolveSkillShId(skillId);
+    const installName = skill ? this.getInstallName(skill) : skillId;
+    const skillDir = path.join(SKILLS_ROOT, installName);
 
     // Remove agent symlinks first. Never delete real directories from agent config paths —
     // those may be user-managed skills that Emdash only discovered.
-    await this.unsyncFromAgents(skillId);
+    await this.unsyncFromAgents(installName);
 
     try {
       const stat = await fs.promises.lstat(skillDir);
@@ -501,19 +514,23 @@ export class SkillsService {
 
       const skills: CatalogSkill[] = [];
       for (const entry of result.skills ?? []) {
+        if (entry.isDuplicate) continue;
         if (!this.isSkillShGithubSource(entry.source)) continue;
         if (skills.length >= 24) break;
 
         const catalogSkillId = this.normalizeSkillShSkillId(entry.skillId);
         if (!isValidSkillName(catalogSkillId)) continue;
+        const skillId = this.toSkillShId(entry.source, catalogSkillId);
+        if (skills.some((skill) => skill.id === skillId)) continue;
         const skillShPath = this.normalizeSkillShPath(entry.skillId);
         const displayName = entry.name || catalogSkillId;
+        const description = entry.source;
         const sourceUrl = this.getSkillShUrl(entry.source, catalogSkillId);
 
-        skills.push({
-          id: this.toSkillShId(entry.source, catalogSkillId),
+        const skill: CatalogSkill = {
+          id: skillId,
           displayName,
-          description: `${entry.source}${entry.installs ? ` • ${entry.installs.toLocaleString()} installs` : ''}`,
+          description,
           source: 'skillssh',
           sourceRef: entry.source,
           sourceUrl,
@@ -522,19 +539,26 @@ export class SkillsService {
           installs: entry.installs,
           iconUrl: this.getSkillShIconUrl(entry.source),
           brandColor: '#000000',
-          frontmatter: { name: catalogSkillId, description: displayName },
+          frontmatter: { name: catalogSkillId, description },
           installed: false,
-        });
+        };
+        skills.push(skill);
       }
+
+      const mergedSkills = (await this.mergeInstalledState({
+        version: SkillsService.CATALOG_VERSION,
+        lastUpdated: new Date().toISOString(),
+        skills,
+      })).skills;
 
       this.skillShSearchCache.set(trimmed, {
         expiresAt: Date.now() + SKILLSH_SEARCH_CACHE_TTL_MS,
-        skills,
+        skills: mergedSkills,
       });
-      for (const skill of skills) {
-        this.skillShSkillCache.set(skill.id, skill);
+      for (const skill of mergedSkills) {
+        this.setSkillShSkillCache(skill.id, skill);
       }
-      return skills;
+      return mergedSkills;
     } catch (error) {
       if (cached) {
         log.warn(`Skills.SH search failed for "${trimmed}", using stale cache`, error);
@@ -552,12 +576,13 @@ export class SkillsService {
   }
 
   private normalizeSkillShSearchQuery(query: string): string {
-    const trimmed = query.trim().toLowerCase();
+    const trimmed = query.trim();
     if (!trimmed) return '';
 
     try {
       const url = new URL(trimmed);
-      if (url.hostname === 'skills.sh' || url.hostname === 'www.skills.sh') {
+      const hostname = url.hostname.toLowerCase();
+      if (hostname === 'skills.sh' || hostname === 'www.skills.sh') {
         const parts = url.pathname.split('/').filter(Boolean);
         return parts.at(-1) ?? '';
       }
@@ -565,7 +590,7 @@ export class SkillsService {
       // Not a URL; use the plain search query.
     }
 
-    return trimmed;
+    return trimmed.toLowerCase();
   }
 
   private normalizeSkillShSkillId(skillId: string): string {
@@ -588,6 +613,18 @@ export class SkillsService {
 
   private parseSkillShId(skillId: string): CatalogSkill | null {
     return this.skillShSkillCache.get(skillId) ?? null;
+  }
+
+  private setSkillShSkillCache(skillId: string, skill: CatalogSkill): void {
+    if (this.skillShSkillCache.has(skillId)) {
+      this.skillShSkillCache.delete(skillId);
+    }
+    this.skillShSkillCache.set(skillId, skill);
+    while (this.skillShSkillCache.size > SKILLSH_SKILL_CACHE_MAX_ENTRIES) {
+      const oldestKey = this.skillShSkillCache.keys().next().value;
+      if (!oldestKey) break;
+      this.skillShSkillCache.delete(oldestKey);
+    }
   }
 
   private async resolveSkillShId(skillId: string): Promise<CatalogSkill | null> {
@@ -623,14 +660,15 @@ export class SkillsService {
       frontmatter: { name: catalogSkillId, description: pageDescription },
       installed: false,
     };
-    this.skillShSkillCache.set(skill.id, skill);
+    this.setSkillShSkillCache(skill.id, skill);
     return skill;
   }
 
   private getInstallName(skill: CatalogSkill): string {
-    return skill.source === 'skillssh' && skill.catalogSkillId
-      ? this.normalizeSkillShSkillId(skill.catalogSkillId)
-      : skill.id;
+    if (skill.source !== 'skillssh' || !skill.sourceRef || !skill.catalogSkillId) return skill.id;
+
+    const [owner, repo] = skill.sourceRef.split('/');
+    return `skillssh-${owner}-${repo}-${this.normalizeSkillShSkillId(skill.catalogSkillId)}`;
   }
 
   private getSkillShUrl(sourceRef: string, skillId: string): string {
@@ -668,7 +706,7 @@ export class SkillsService {
           `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${encodedPath}`
         );
       } catch (error) {
-        if (!String(error).includes('HTTP 404')) throw error;
+        if (!(error instanceof HttpStatusError) || error.statusCode !== 404) throw error;
       }
     }
 
@@ -766,9 +804,10 @@ export class SkillsService {
     });
 
     const mergedSkills = dedupedSkills.map((skill) => {
-      const local = installedMap.get(skill.id);
+      const installName = this.getInstallName(skill);
+      const local = installedMap.get(skill.id) ?? installedMap.get(installName);
       if (local) {
-        installedMap.delete(skill.id);
+        installedMap.delete(local.id);
         return {
           ...skill,
           displayName: local.displayName || skill.displayName,

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -60,16 +60,20 @@ function httpsGet(
         }
         let data = '';
         let bytes = 0;
+        let destroyed = false;
         const maxBytes = options.maxBytes ?? MAX_HTTP_RESPONSE_BYTES;
         res.on('data', (chunk: Buffer | string) => {
           bytes += Buffer.byteLength(chunk);
           if (bytes > maxBytes) {
+            destroyed = true;
             req.destroy(new Error(`Response too large for ${url}`));
             return;
           }
           data += chunk;
         });
-        res.on('end', () => resolve(data));
+        res.on('end', () => {
+          if (!destroyed) resolve(data);
+        });
         res.on('error', reject);
       }
     );

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -13,10 +13,15 @@ const EMDASH_META = path.join(SKILLS_ROOT, '.emdash');
 const CATALOG_INDEX_PATH = path.join(EMDASH_META, 'catalog-index.json');
 
 const MAX_REDIRECTS = 5;
+const MAX_HTTP_RESPONSE_BYTES = 2 * 1024 * 1024;
 const SKILLSH_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
 
-function httpsGet(url: string, redirectCount = 0): Promise<string> {
+function httpsGet(
+  url: string,
+  options: { maxBytes?: number; redirectCount?: number } = {}
+): Promise<string> {
   return new Promise((resolve, reject) => {
+    const redirectCount = options.redirectCount ?? 0;
     if (redirectCount >= MAX_REDIRECTS) {
       reject(new Error(`Too many redirects (>${MAX_REDIRECTS}) for ${url}`));
       return;
@@ -29,7 +34,10 @@ function httpsGet(url: string, redirectCount = 0): Promise<string> {
           const location = res.headers.location;
           if (location) {
             const resolved = new URL(location, url).href;
-            httpsGet(resolved, redirectCount + 1).then(resolve, reject);
+            httpsGet(resolved, { ...options, redirectCount: redirectCount + 1 }).then(
+              resolve,
+              reject
+            );
             return;
           }
         }
@@ -38,7 +46,16 @@ function httpsGet(url: string, redirectCount = 0): Promise<string> {
           return;
         }
         let data = '';
-        res.on('data', (chunk) => (data += chunk));
+        let bytes = 0;
+        const maxBytes = options.maxBytes ?? MAX_HTTP_RESPONSE_BYTES;
+        res.on('data', (chunk: Buffer | string) => {
+          bytes += Buffer.byteLength(chunk);
+          if (bytes > maxBytes) {
+            req.destroy(new Error(`Response too large for ${url}`));
+            return;
+          }
+          data += chunk;
+        });
         res.on('end', () => resolve(data));
         res.on('error', reject);
       }
@@ -54,6 +71,7 @@ export class SkillsService {
   private static readonly CATALOG_VERSION = 2;
   private catalogCache: CatalogIndex | null = null;
   private skillShSearchCache = new Map<string, { expiresAt: number; skills: CatalogSkill[] }>();
+  private skillShSkillCache = new Map<string, CatalogSkill>();
 
   async initialize(): Promise<void> {
     await fs.promises.mkdir(SKILLS_ROOT, { recursive: true });
@@ -479,33 +497,41 @@ export class SkillsService {
         }>;
       };
 
-      const skills = (result.skills ?? [])
-        .filter((entry) => this.isSkillShGithubSource(entry.source))
-        .slice(0, 24)
-        .map((entry) => {
-          const catalogSkillId = this.normalizeSkillShSkillId(entry.skillId);
-          const displayName = entry.name || catalogSkillId;
-          const sourceUrl = this.getSkillShUrl(entry.source, catalogSkillId);
-          return {
-            id: this.toSkillShId(entry.source, catalogSkillId),
-            displayName,
-            description: `${entry.source}${entry.installs ? ` • ${entry.installs.toLocaleString()} installs` : ''}`,
-            source: 'skillssh',
-            sourceRef: entry.source,
-            sourceUrl,
-            catalogSkillId,
-            installs: entry.installs,
-            iconUrl: this.getSkillShIconUrl(entry.source),
-            brandColor: '#000000',
-            frontmatter: { name: catalogSkillId, description: displayName },
-            installed: false,
-          } satisfies CatalogSkill;
+      const skills: CatalogSkill[] = [];
+      for (const entry of result.skills ?? []) {
+        if (!this.isSkillShGithubSource(entry.source)) continue;
+        if (skills.length >= 24) break;
+
+        const catalogSkillId = this.normalizeSkillShSkillId(entry.skillId);
+        if (!isValidSkillName(catalogSkillId)) continue;
+        const skillShPath = this.normalizeSkillShPath(entry.skillId);
+        const displayName = entry.name || catalogSkillId;
+        const sourceUrl = this.getSkillShUrl(entry.source, catalogSkillId);
+
+        skills.push({
+          id: this.toSkillShId(entry.source, catalogSkillId),
+          displayName,
+          description: `${entry.source}${entry.installs ? ` • ${entry.installs.toLocaleString()} installs` : ''}`,
+          source: 'skillssh',
+          sourceRef: entry.source,
+          sourceUrl,
+          catalogSkillId,
+          skillShPath,
+          installs: entry.installs,
+          iconUrl: this.getSkillShIconUrl(entry.source),
+          brandColor: '#000000',
+          frontmatter: { name: catalogSkillId, description: displayName },
+          installed: false,
         });
+      }
 
       this.skillShSearchCache.set(trimmed, {
         expiresAt: Date.now() + SKILLSH_SEARCH_CACHE_TTL_MS,
         skills,
       });
+      for (const skill of skills) {
+        this.skillShSkillCache.set(skill.id, skill);
+      }
       return skills;
     } catch (error) {
       if (cached) {
@@ -531,33 +557,18 @@ export class SkillsService {
     return path.posix.basename(withoutSkillMd);
   }
 
+  private normalizeSkillShPath(skillId: string): string {
+    const normalized = skillId.replace(/\\/g, '/').replace(/^\/+|\/+$/g, '');
+    return normalized.endsWith('/SKILL.md') ? normalized.slice(0, -'/SKILL.md'.length) : normalized;
+  }
+
   private isSkillShGithubSource(sourceRef: string): boolean {
     const parts = sourceRef.split('/');
     return parts.length === 2 && Boolean(parts[0]) && Boolean(parts[1]);
   }
 
   private parseSkillShId(skillId: string): CatalogSkill | null {
-    if (!skillId.startsWith('skillssh:')) return null;
-    const fullId = skillId.slice('skillssh:'.length);
-    const parts = fullId.split('/');
-    if (parts.length < 3) return null;
-    const sourceRef = parts.slice(0, 2).join('/');
-    if (!this.isSkillShGithubSource(sourceRef)) return null;
-    const catalogSkillId = this.normalizeSkillShSkillId(parts.slice(2).join('/'));
-    if (!catalogSkillId) return null;
-    return {
-      id: skillId,
-      displayName: catalogSkillId,
-      description: sourceRef,
-      source: 'skillssh',
-      sourceRef,
-      sourceUrl: this.getSkillShUrl(sourceRef, catalogSkillId),
-      catalogSkillId,
-      iconUrl: this.getSkillShIconUrl(sourceRef),
-      brandColor: '#000000',
-      frontmatter: { name: catalogSkillId, description: sourceRef },
-      installed: false,
-    };
+    return this.skillShSkillCache.get(skillId) ?? null;
   }
 
   private getInstallName(skill: CatalogSkill): string {
@@ -585,25 +596,13 @@ export class SkillsService {
       throw new Error(`Skills.SH source "${skill.sourceRef}" is not a GitHub repository`);
     }
 
-    const treeData = await httpsGet(
-      `https://api.github.com/repos/${owner}/${repo}/git/trees/HEAD?recursive=1`
-    );
-    const tree = JSON.parse(treeData) as { tree?: Array<{ path: string; type: string }> };
-    const skillMdEntries =
-      tree.tree?.filter((entry) => entry.type === 'blob' && entry.path.endsWith('/SKILL.md')) ?? [];
-    const skillMd =
-      skillMdEntries.find((entry) => entry.path.split('/').at(-2) === skill.catalogSkillId) ??
-      skillMdEntries.find((entry) => {
-        const directoryName = entry.path.split('/').at(-2);
-        return Boolean(directoryName && skill.catalogSkillId?.endsWith(`-${directoryName}`));
-      });
-    if (!skillMd) {
+    if (!skill.skillShPath) {
       throw new Error(`Could not find SKILL.md for ${skill.sourceRef}/${skill.catalogSkillId}`);
     }
 
-    return httpsGet(
-      `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${encodeURI(skillMd.path)}`
-    );
+    const skillMdPath = `${skill.skillShPath}/SKILL.md`;
+    const encodedPath = skillMdPath.split('/').map(encodeURIComponent).join('/');
+    return httpsGet(`https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${encodedPath}`);
   }
 
   private isPathInsideSkillsRoot(candidatePath: string): boolean {

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -633,6 +633,9 @@ export class SkillsService {
         installedMap.delete(skill.id);
         return {
           ...skill,
+          displayName: local.displayName || skill.displayName,
+          description: local.description || skill.description,
+          frontmatter: { ...skill.frontmatter, ...local.frontmatter },
           installed: true,
           localPath: local.localPath,
           skillMdContent: local.skillMdContent,

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -205,7 +205,8 @@ export class SkillsService {
 
   async getSkillDetail(skillId: string): Promise<CatalogSkill | null> {
     const catalog = await this.getCatalogIndex();
-    const skill = catalog.skills.find((s) => s.id === skillId) ?? this.parseSkillShId(skillId);
+    const skill =
+      catalog.skills.find((s) => s.id === skillId) ?? (await this.resolveSkillShId(skillId));
     if (!skill) return null;
 
     // If installed, load the full SKILL.md from disk
@@ -222,7 +223,7 @@ export class SkillsService {
     if (!skill.installed && !skill.skillMdContent) {
       try {
         if (skill.source === 'skillssh') {
-          const content = await this.fetchSkillShSkillMd(skill);
+          const content = await this.fetchSkillShContent(skill);
           return { ...skill, skillMdContent: content };
         } else {
           const mdUrl = this.getSkillMdUrl(skill);
@@ -262,7 +263,8 @@ export class SkillsService {
   async installSkill(skillId: string): Promise<CatalogSkill> {
     await this.initialize();
     const catalog = await this.getCatalogIndex();
-    const skill = catalog.skills.find((s) => s.id === skillId) ?? this.parseSkillShId(skillId);
+    const skill =
+      catalog.skills.find((s) => s.id === skillId) ?? (await this.resolveSkillShId(skillId));
     if (!skill) throw new Error(`Skill "${skillId}" not found in catalog`);
     if (skill.installed) throw new Error(`Skill "${skillId}" is already installed`);
 
@@ -289,7 +291,7 @@ export class SkillsService {
       // Try to download the real SKILL.md from GitHub; fall back to generated stub
       let content: string;
       if (skill.source === 'skillssh') {
-        content = await this.fetchSkillShSkillMd(skill);
+        content = await this.fetchSkillShContent(skill);
       } else {
         try {
           const mdUrl = this.getSkillMdUrl(skill);
@@ -477,7 +479,7 @@ export class SkillsService {
   }
 
   async searchSkillSh(query: string): Promise<CatalogSkill[]> {
-    const trimmed = query.trim().toLowerCase();
+    const trimmed = this.normalizeSkillShSearchQuery(query);
     if (!trimmed) return [];
 
     const cached = this.skillShSearchCache.get(trimmed);
@@ -549,6 +551,23 @@ export class SkillsService {
     return `skillssh:${sourceRef}/${this.normalizeSkillShSkillId(skillId)}`;
   }
 
+  private normalizeSkillShSearchQuery(query: string): string {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return '';
+
+    try {
+      const url = new URL(trimmed);
+      if (url.hostname === 'skills.sh' || url.hostname === 'www.skills.sh') {
+        const parts = url.pathname.split('/').filter(Boolean);
+        return parts.at(-1) ?? '';
+      }
+    } catch {
+      // Not a URL; use the plain search query.
+    }
+
+    return trimmed;
+  }
+
   private normalizeSkillShSkillId(skillId: string): string {
     const normalized = skillId.replace(/\\/g, '/').replace(/\/+$/, '');
     const withoutSkillMd = normalized.endsWith('/SKILL.md')
@@ -569,6 +588,43 @@ export class SkillsService {
 
   private parseSkillShId(skillId: string): CatalogSkill | null {
     return this.skillShSkillCache.get(skillId) ?? null;
+  }
+
+  private async resolveSkillShId(skillId: string): Promise<CatalogSkill | null> {
+    const cached = this.parseSkillShId(skillId);
+    if (cached) return cached;
+    if (!skillId.startsWith('skillssh:')) return null;
+
+    const fullId = skillId.slice('skillssh:'.length);
+    const parts = fullId.split('/');
+    if (parts.length < 3) return null;
+
+    const sourceRef = parts.slice(0, 2).join('/');
+    if (!this.isSkillShGithubSource(sourceRef)) return null;
+
+    const catalogSkillId = this.normalizeSkillShSkillId(parts.slice(2).join('/'));
+    if (!isValidSkillName(catalogSkillId)) return null;
+
+    const sourceUrl = this.getSkillShUrl(sourceRef, catalogSkillId);
+    const pageDescription = await this.fetchSkillShPageDescription(sourceUrl).catch(() => null);
+    if (!pageDescription) return null;
+
+    const skill: CatalogSkill = {
+      id: skillId,
+      displayName: catalogSkillId,
+      description: `${sourceRef}`,
+      source: 'skillssh',
+      sourceRef,
+      sourceUrl,
+      catalogSkillId,
+      skillShPath: catalogSkillId,
+      iconUrl: this.getSkillShIconUrl(sourceRef),
+      brandColor: '#000000',
+      frontmatter: { name: catalogSkillId, description: pageDescription },
+      installed: false,
+    };
+    this.skillShSkillCache.set(skill.id, skill);
+    return skill;
   }
 
   private getInstallName(skill: CatalogSkill): string {
@@ -600,9 +656,92 @@ export class SkillsService {
       throw new Error(`Could not find SKILL.md for ${skill.sourceRef}/${skill.catalogSkillId}`);
     }
 
-    const skillMdPath = `${skill.skillShPath}/SKILL.md`;
-    const encodedPath = skillMdPath.split('/').map(encodeURIComponent).join('/');
-    return httpsGet(`https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${encodedPath}`);
+    const candidatePaths = [`${skill.skillShPath}/SKILL.md`];
+    if (!skill.skillShPath.startsWith('skills/')) {
+      candidatePaths.push(`skills/${skill.skillShPath}/SKILL.md`);
+    }
+
+    for (const skillMdPath of candidatePaths) {
+      const encodedPath = skillMdPath.split('/').map(encodeURIComponent).join('/');
+      try {
+        return await httpsGet(
+          `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${encodedPath}`
+        );
+      } catch (error) {
+        if (!String(error).includes('HTTP 404')) throw error;
+      }
+    }
+
+    const treePath = await this.findSkillShSkillMdPath(owner, repo, skill.skillShPath);
+    if (treePath) {
+      const encodedPath = treePath.split('/').map(encodeURIComponent).join('/');
+      return httpsGet(`https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${encodedPath}`);
+    }
+
+    throw new Error(`Could not fetch SKILL.md for ${skill.sourceRef}/${skill.catalogSkillId}`);
+  }
+
+  private async findSkillShSkillMdPath(
+    owner: string,
+    repo: string,
+    skillPath: string
+  ): Promise<string | null> {
+    const treeData = await httpsGet(
+      `https://api.github.com/repos/${owner}/${repo}/git/trees/HEAD?recursive=1`
+    );
+    const tree = JSON.parse(treeData) as { tree?: Array<{ path: string; type: string }> };
+    const candidates =
+      tree.tree?.filter((entry) => {
+        if (entry.type !== 'blob') return false;
+        if (entry.path === `${skillPath}/SKILL.md`) return true;
+        if (entry.path.endsWith(`/skills/${skillPath}/SKILL.md`)) return true;
+        return entry.path.endsWith(`/${skillPath}/SKILL.md`);
+      }) ?? [];
+
+    return candidates[0]?.path ?? null;
+  }
+
+  private async fetchSkillShContent(skill: CatalogSkill): Promise<string> {
+    try {
+      return await this.fetchSkillShSkillMd(skill);
+    } catch (error) {
+      log.warn(`Failed to fetch Skills.SH SKILL.md for ${skill.id}, using page metadata`, error);
+      const description = await this.fetchSkillShDescription(skill).catch(() => skill.description);
+      return generateSkillMd(skill.displayName, description);
+    }
+  }
+
+  private async fetchSkillShDescription(skill: CatalogSkill): Promise<string> {
+    if (!skill.sourceUrl) return skill.description;
+
+    return this.fetchSkillShPageDescription(skill.sourceUrl);
+  }
+
+  private async fetchSkillShPageDescription(sourceUrl: string): Promise<string> {
+    const html = await httpsGet(sourceUrl);
+    const description =
+      this.extractHtmlMetaContent(html, 'description') ??
+      this.extractHtmlMetaContent(html, 'og:description') ??
+      '';
+    return this.decodeHtmlEntities(description).trim();
+  }
+
+  private extractHtmlMetaContent(html: string, name: string): string | null {
+    const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(
+      `<meta[^>]+(?:name|property)=["']${escapedName}["'][^>]+content=["']([^"']*)["'][^>]*>`,
+      'i'
+    );
+    return html.match(pattern)?.[1] ?? null;
+  }
+
+  private decodeHtmlEntities(value: string): string {
+    return value
+      .replace(/&quot;/g, '"')
+      .replace(/&#x27;|&#39;/g, "'")
+      .replace(/&amp;/g, '&')
+      .replace(/&lt;/g, '<')
+      .replace(/&gt;/g, '>');
   }
 
   private isPathInsideSkillsRoot(candidatePath: string): boolean {

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -896,11 +896,16 @@ export class SkillsService {
 
   private extractHtmlMetaContent(html: string, name: string): string | null {
     const escapedName = name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-    const pattern = new RegExp(
-      `<meta[^>]+(?:name|property)=["']${escapedName}["'][^>]+content=["']([^"']*)["'][^>]*>`,
+    // Match either attribute order: name/property before content, or content first.
+    const nameBeforeContent = new RegExp(
+      `<meta[^>]+(?:name|property)=["']${escapedName}["'][^>]+content=["']([^"']*)["']`,
       'i'
     );
-    return html.match(pattern)?.[1] ?? null;
+    const contentBeforeName = new RegExp(
+      `<meta[^>]+content=["']([^"']*)["'][^>]+(?:name|property)=["']${escapedName}["']`,
+      'i'
+    );
+    return html.match(nameBeforeContent)?.[1] ?? html.match(contentBeforeName)?.[1] ?? null;
   }
 
   private decodeHtmlEntities(value: string): string {

--- a/src/main/core/skills/SkillsService.ts
+++ b/src/main/core/skills/SkillsService.ts
@@ -13,6 +13,7 @@ const EMDASH_META = path.join(SKILLS_ROOT, '.emdash');
 const CATALOG_INDEX_PATH = path.join(EMDASH_META, 'catalog-index.json');
 
 const MAX_REDIRECTS = 5;
+const SKILLSH_SEARCH_CACHE_TTL_MS = 5 * 60 * 1000;
 
 function httpsGet(url: string, redirectCount = 0): Promise<string> {
   return new Promise((resolve, reject) => {
@@ -52,6 +53,7 @@ function httpsGet(url: string, redirectCount = 0): Promise<string> {
 export class SkillsService {
   private static readonly CATALOG_VERSION = 2;
   private catalogCache: CatalogIndex | null = null;
+  private skillShSearchCache = new Map<string, { expiresAt: number; skills: CatalogSkill[] }>();
 
   async initialize(): Promise<void> {
     await fs.promises.mkdir(SKILLS_ROOT, { recursive: true });
@@ -185,7 +187,7 @@ export class SkillsService {
 
   async getSkillDetail(skillId: string): Promise<CatalogSkill | null> {
     const catalog = await this.getCatalogIndex();
-    const skill = catalog.skills.find((s) => s.id === skillId);
+    const skill = catalog.skills.find((s) => s.id === skillId) ?? this.parseSkillShId(skillId);
     if (!skill) return null;
 
     // If installed, load the full SKILL.md from disk
@@ -201,8 +203,12 @@ export class SkillsService {
     // For uninstalled catalog skills, fetch SKILL.md from GitHub
     if (!skill.installed && !skill.skillMdContent) {
       try {
-        const mdUrl = this.getSkillMdUrl(skill);
-        if (mdUrl) {
+        if (skill.source === 'skillssh') {
+          const content = await this.fetchSkillShSkillMd(skill);
+          return { ...skill, skillMdContent: content };
+        } else {
+          const mdUrl = this.getSkillMdUrl(skill);
+          if (!mdUrl) return skill;
           const content = await httpsGet(mdUrl);
           return { ...skill, skillMdContent: content };
         }
@@ -215,6 +221,9 @@ export class SkillsService {
   }
 
   private getSkillMdUrl(skill: CatalogSkill): string | null {
+    if (skill.source === 'skillssh' && skill.sourceRef && skill.catalogSkillId) {
+      return null;
+    }
     if (skill.source === 'openai' && skill.sourceUrl) {
       // e.g. https://github.com/openai/skills/tree/main/skills/.curated/linear
       // → https://raw.githubusercontent.com/openai/skills/main/skills/.curated/linear/SKILL.md
@@ -235,43 +244,61 @@ export class SkillsService {
   async installSkill(skillId: string): Promise<CatalogSkill> {
     await this.initialize();
     const catalog = await this.getCatalogIndex();
-    const skill = catalog.skills.find((s) => s.id === skillId);
+    const skill = catalog.skills.find((s) => s.id === skillId) ?? this.parseSkillShId(skillId);
     if (!skill) throw new Error(`Skill "${skillId}" not found in catalog`);
     if (skill.installed) throw new Error(`Skill "${skillId}" is already installed`);
 
-    const skillDir = path.join(SKILLS_ROOT, skillId);
+    const installName = this.getInstallName(skill);
+    if (!isValidSkillName(installName)) {
+      throw new Error(`Invalid skill install name "${installName}"`);
+    }
+    const skillDir = path.resolve(SKILLS_ROOT, installName);
+    if (!this.isPathInsideSkillsRoot(skillDir)) {
+      throw new Error(`Invalid skill install path for "${installName}"`);
+    }
     const tmpDir = `${skillDir}.tmp-${Date.now()}`;
+    let finalDirCreated = false;
     try {
+      try {
+        await fs.promises.access(skillDir);
+        throw new Error(`Skill "${installName}" is already installed`);
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
+      }
+
       await fs.promises.mkdir(tmpDir, { recursive: true });
 
       // Try to download the real SKILL.md from GitHub; fall back to generated stub
       let content: string;
-      try {
-        const mdUrl = this.getSkillMdUrl(skill);
-        if (mdUrl) {
-          content = await httpsGet(mdUrl);
-        } else {
+      if (skill.source === 'skillssh') {
+        content = await this.fetchSkillShSkillMd(skill);
+      } else {
+        try {
+          const mdUrl = this.getSkillMdUrl(skill);
+          if (mdUrl) {
+            content = await httpsGet(mdUrl);
+          } else {
+            content = generateSkillMd(skill.displayName, skill.description);
+          }
+        } catch {
           content = generateSkillMd(skill.displayName, skill.description);
         }
-      } catch {
-        content = generateSkillMd(skill.displayName, skill.description);
       }
       await fs.promises.writeFile(path.join(tmpDir, 'SKILL.md'), content);
 
-      // Remove stale target dir if present (e.g. from a previous failed install)
-      await fs.promises.rm(skillDir, { recursive: true, force: true }).catch(() => {});
-
       // Atomic move: rename tmp dir to final location
       await fs.promises.rename(tmpDir, skillDir);
+      finalDirCreated = true;
 
       // Sync to agents
-      await this.syncToAgents(skillId);
+      await this.syncToAgents(installName);
 
       // Invalidate cache
       this.catalogCache = null;
 
       return {
         ...skill,
+        id: installName,
         installed: true,
         localPath: skillDir,
         skillMdContent: content,
@@ -279,7 +306,9 @@ export class SkillsService {
     } catch (error) {
       // Clean up partial install
       await fs.promises.rm(tmpDir, { recursive: true, force: true }).catch(() => {});
-      await fs.promises.rm(skillDir, { recursive: true, force: true }).catch(() => {});
+      if (finalDirCreated) {
+        await fs.promises.rm(skillDir, { recursive: true, force: true }).catch(() => {});
+      }
       throw error;
     }
   }
@@ -429,7 +458,153 @@ export class SkillsService {
     return agents;
   }
 
+  async searchSkillSh(query: string): Promise<CatalogSkill[]> {
+    const trimmed = query.trim().toLowerCase();
+    if (!trimmed) return [];
+
+    const cached = this.skillShSearchCache.get(trimmed);
+    if (cached && cached.expiresAt > Date.now()) return cached.skills;
+
+    const url = `https://skills.sh/api/search?q=${encodeURIComponent(trimmed)}`;
+    try {
+      const data = await httpsGet(url);
+      const result = JSON.parse(data) as {
+        skills?: Array<{
+          id: string;
+          skillId: string;
+          name?: string;
+          source: string;
+          installs?: number;
+          isDuplicate?: boolean;
+        }>;
+      };
+
+      const skills = (result.skills ?? [])
+        .filter((entry) => this.isSkillShGithubSource(entry.source))
+        .slice(0, 24)
+        .map((entry) => {
+          const catalogSkillId = this.normalizeSkillShSkillId(entry.skillId);
+          const displayName = entry.name || catalogSkillId;
+          const sourceUrl = this.getSkillShUrl(entry.source, catalogSkillId);
+          return {
+            id: this.toSkillShId(entry.source, catalogSkillId),
+            displayName,
+            description: `${entry.source}${entry.installs ? ` • ${entry.installs.toLocaleString()} installs` : ''}`,
+            source: 'skillssh',
+            sourceRef: entry.source,
+            sourceUrl,
+            catalogSkillId,
+            installs: entry.installs,
+            iconUrl: this.getSkillShIconUrl(entry.source),
+            brandColor: '#000000',
+            frontmatter: { name: catalogSkillId, description: displayName },
+            installed: false,
+          } satisfies CatalogSkill;
+        });
+
+      this.skillShSearchCache.set(trimmed, {
+        expiresAt: Date.now() + SKILLSH_SEARCH_CACHE_TTL_MS,
+        skills,
+      });
+      return skills;
+    } catch (error) {
+      if (cached) {
+        log.warn(`Skills.SH search failed for "${trimmed}", using stale cache`, error);
+        return cached.skills;
+      }
+      log.warn(`Skills.SH search failed for "${trimmed}"`, error);
+      return [];
+    }
+  }
+
   // --- Private helpers ---
+
+  private toSkillShId(sourceRef: string, skillId: string): string {
+    return `skillssh:${sourceRef}/${this.normalizeSkillShSkillId(skillId)}`;
+  }
+
+  private normalizeSkillShSkillId(skillId: string): string {
+    const normalized = skillId.replace(/\\/g, '/').replace(/\/+$/, '');
+    const withoutSkillMd = normalized.endsWith('/SKILL.md')
+      ? normalized.slice(0, -'/SKILL.md'.length)
+      : normalized;
+    return path.posix.basename(withoutSkillMd);
+  }
+
+  private isSkillShGithubSource(sourceRef: string): boolean {
+    const parts = sourceRef.split('/');
+    return parts.length === 2 && Boolean(parts[0]) && Boolean(parts[1]);
+  }
+
+  private parseSkillShId(skillId: string): CatalogSkill | null {
+    if (!skillId.startsWith('skillssh:')) return null;
+    const fullId = skillId.slice('skillssh:'.length);
+    const parts = fullId.split('/');
+    if (parts.length < 3) return null;
+    const sourceRef = parts.slice(0, 2).join('/');
+    if (!this.isSkillShGithubSource(sourceRef)) return null;
+    const catalogSkillId = this.normalizeSkillShSkillId(parts.slice(2).join('/'));
+    if (!catalogSkillId) return null;
+    return {
+      id: skillId,
+      displayName: catalogSkillId,
+      description: sourceRef,
+      source: 'skillssh',
+      sourceRef,
+      sourceUrl: this.getSkillShUrl(sourceRef, catalogSkillId),
+      catalogSkillId,
+      iconUrl: this.getSkillShIconUrl(sourceRef),
+      brandColor: '#000000',
+      frontmatter: { name: catalogSkillId, description: sourceRef },
+      installed: false,
+    };
+  }
+
+  private getInstallName(skill: CatalogSkill): string {
+    return skill.source === 'skillssh' && skill.catalogSkillId
+      ? this.normalizeSkillShSkillId(skill.catalogSkillId)
+      : skill.id;
+  }
+
+  private getSkillShUrl(sourceRef: string, skillId: string): string {
+    return `https://skills.sh/${sourceRef}/${skillId}`;
+  }
+
+  private getSkillShIconUrl(sourceRef: string): string | undefined {
+    const [owner, repo] = sourceRef.split('/');
+    if (!owner || !repo || sourceRef.split('/').length !== 2) return undefined;
+    return `https://github.com/${owner}.png?size=80`;
+  }
+
+  private async fetchSkillShSkillMd(skill: CatalogSkill): Promise<string> {
+    if (!skill.sourceRef || !skill.catalogSkillId) {
+      throw new Error('Invalid Skills.SH skill reference');
+    }
+    const [owner, repo] = skill.sourceRef.split('/');
+    if (!owner || !repo || skill.sourceRef.split('/').length !== 2) {
+      throw new Error(`Skills.SH source "${skill.sourceRef}" is not a GitHub repository`);
+    }
+
+    const treeData = await httpsGet(
+      `https://api.github.com/repos/${owner}/${repo}/git/trees/HEAD?recursive=1`
+    );
+    const tree = JSON.parse(treeData) as { tree?: Array<{ path: string; type: string }> };
+    const skillMdEntries =
+      tree.tree?.filter((entry) => entry.type === 'blob' && entry.path.endsWith('/SKILL.md')) ?? [];
+    const skillMd =
+      skillMdEntries.find((entry) => entry.path.split('/').at(-2) === skill.catalogSkillId) ??
+      skillMdEntries.find((entry) => {
+        const directoryName = entry.path.split('/').at(-2);
+        return Boolean(directoryName && skill.catalogSkillId?.endsWith(`-${directoryName}`));
+      });
+    if (!skillMd) {
+      throw new Error(`Could not find SKILL.md for ${skill.sourceRef}/${skill.catalogSkillId}`);
+    }
+
+    return httpsGet(
+      `https://raw.githubusercontent.com/${owner}/${repo}/HEAD/${encodeURI(skillMd.path)}`
+    );
+  }
 
   private isPathInsideSkillsRoot(candidatePath: string): boolean {
     const relativePath = path.relative(SKILLS_ROOT, candidatePath);

--- a/src/main/core/skills/controller.ts
+++ b/src/main/core/skills/controller.ts
@@ -23,6 +23,16 @@ export const skillsController = createRPCController({
     }
   },
 
+  searchSkillSh: async (args: { query: string }) => {
+    try {
+      const skills = await skillsService.searchSkillSh(args.query);
+      return { success: true, data: skills };
+    } catch (error) {
+      log.error('Failed to search Skills.SH:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
   install: async (args: { skillId: string }) => {
     try {
       const skill = await skillsService.installSkill(args.skillId);

--- a/src/renderer/features/skills/components/SkillDetailModal.tsx
+++ b/src/renderer/features/skills/components/SkillDetailModal.tsx
@@ -15,8 +15,15 @@ import type { CatalogSkill } from '@shared/skills/types';
 import { parseFrontmatter } from '@shared/skills/validation';
 import { SkillIconRenderer } from './SkillIconRenderer';
 
+const sourceMeta = {
+  openai: { name: 'OpenAI', icon: 'https://github.com/openai.png' },
+  anthropic: { name: 'Anthropic', icon: 'https://github.com/anthropics.png' },
+  skillssh: { name: 'Skills.SH', icon: 'https://skills.sh/favicon.ico' },
+} as const;
+
 interface SkillDetailModalProps {
   skill: CatalogSkill | null;
+  isLoading: boolean;
   isOpen: boolean;
   onClose: () => void;
   onInstall: (skillId: string) => Promise<boolean>;
@@ -26,6 +33,7 @@ interface SkillDetailModalProps {
 
 export const SkillDetailModal: React.FC<SkillDetailModalProps> = ({
   skill,
+  isLoading,
   isOpen,
   onClose,
   onInstall,
@@ -59,6 +67,9 @@ export const SkillDetailModal: React.FC<SkillDetailModalProps> = ({
   if (!skill) return null;
 
   const body = skill.skillMdContent ? parseFrontmatter(skill.skillMdContent).body.trim() : '';
+  const visibleBody = isSkillShPathBody(body) ? '' : body;
+  const meta = skill.source === 'local' ? null : sourceMeta[skill.source];
+  const showLoadingContent = isLoading && !skill.skillMdContent;
 
   return (
     <Dialog open={isOpen} onOpenChange={(open) => !open && !isProcessing && onClose()}>
@@ -70,27 +81,19 @@ export const SkillDetailModal: React.FC<SkillDetailModalProps> = ({
               <DialogTitle className="font-sans text-base tracking-normal text-foreground normal-case">
                 {skill.displayName}
               </DialogTitle>
-              {skill.source !== 'local' && (
+              {meta && (
                 <div className="text-muted-foreground mt-0.5 flex items-center gap-1.5 text-xs">
-                  <img
-                    src={
-                      skill.source === 'openai'
-                        ? 'https://github.com/openai.png'
-                        : 'https://github.com/anthropics.png'
-                    }
-                    alt=""
-                    className="h-4 w-4 rounded-sm"
-                  />
-                  <span>
-                    From {skill.source === 'openai' ? 'OpenAI' : 'Anthropic'} skill library
-                  </span>
+                  <img src={meta.icon} alt="" className="h-4 w-4 rounded-sm" />
+                  <span>From {meta.name} skill library</span>
                 </div>
               )}
             </div>
           </div>
         </DialogHeader>
         <DialogContentArea>
-          {skill.defaultPrompt && (
+          {showLoadingContent && <SkillDetailShimmer />}
+
+          {!showLoadingContent && skill.defaultPrompt && (
             <div className="bg-muted/40 space-y-1 rounded-md pb-2">
               <p className="text-muted-foreground text-xs font-medium">Example prompt</p>
               <pre className="text-xs wrap-break-word whitespace-pre-wrap text-foreground">
@@ -99,9 +102,9 @@ export const SkillDetailModal: React.FC<SkillDetailModalProps> = ({
             </div>
           )}
 
-          {body && (
+          {!showLoadingContent && visibleBody && (
             <MarkdownRenderer
-              content={body}
+              content={visibleBody}
               variant="compact"
               className="bg-muted/20 text-muted-foreground rounded-md px-3 py-2 text-xs"
             />
@@ -139,3 +142,29 @@ export const SkillDetailModal: React.FC<SkillDetailModalProps> = ({
     </Dialog>
   );
 };
+
+function isSkillShPathBody(body: string): boolean {
+  return /^\.\.\/.*\/SKILL\.md$/.test(body);
+}
+
+function SkillDetailShimmer() {
+  const lineClass = 'h-3 animate-pulse rounded-full bg-foreground/10 dark:bg-white/15';
+
+  return (
+    <div
+      className="min-h-32 space-y-4 rounded-md border border-border bg-background-quaternary-1 px-3 py-3"
+      aria-label="Loading skill details"
+    >
+      <div className="space-y-2">
+        <div className={`${lineClass} w-24`} />
+        <div className={`${lineClass} w-full`} />
+        <div className={`${lineClass} w-5/6`} />
+      </div>
+      <div className="space-y-2">
+        <div className={`${lineClass} w-32`} />
+        <div className={`${lineClass} w-11/12`} />
+        <div className={`${lineClass} w-2/3`} />
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/features/skills/components/SkillIconRenderer.tsx
+++ b/src/renderer/features/skills/components/SkillIconRenderer.tsx
@@ -20,31 +20,39 @@ export const SkillIconRenderer: React.FC<SkillIconRendererProps> = ({ skill }) =
 
   const letter = skill.displayName.charAt(0).toUpperCase();
 
+  const renderImageIcon = () => {
+    if (!skill.iconUrl || imgError) return null;
+    const filter =
+      skill.source === 'skillssh'
+        ? undefined
+        : isDark
+          ? 'brightness(0) invert(1)'
+          : 'brightness(0)';
+    return (
+      <img
+        src={skill.iconUrl}
+        alt=""
+        className="h-full w-full rounded-lg object-contain"
+        style={{ filter }}
+        onError={() => setImgError(true)}
+        loading="lazy"
+      />
+    );
+  };
+
   const renderIcon = () => {
-    if (skill.iconUrl && !imgError) {
-      const filter =
-        skill.source === 'skillssh'
-          ? undefined
-          : isDark
-            ? 'brightness(0) invert(1)'
-            : 'brightness(0)';
-      return (
-        <img
-          src={skill.iconUrl}
-          alt=""
-          className="h-full w-full rounded-lg object-contain"
-          style={{ filter }}
-          onError={() => setImgError(true)}
-          loading="lazy"
-        />
-      );
+    if (skill.source === 'skillssh') {
+      const imageIcon = renderImageIcon();
+      if (imageIcon) return imageIcon;
     }
+
     const svg = resolveSkillIcon(skill.catalogSkillId ?? skill.id, skill.source);
     if (svg) {
       const html = processSvg(svg, isDark ? '#ffffff' : '#000000');
       return <div dangerouslySetInnerHTML={{ __html: html }} />;
     }
-    return letter;
+
+    return renderImageIcon() ?? letter;
   };
 
   return (

--- a/src/renderer/features/skills/components/SkillIconRenderer.tsx
+++ b/src/renderer/features/skills/components/SkillIconRenderer.tsx
@@ -21,13 +21,13 @@ export const SkillIconRenderer: React.FC<SkillIconRendererProps> = ({ skill }) =
   const letter = skill.displayName.charAt(0).toUpperCase();
 
   const renderIcon = () => {
-    const svg = resolveSkillIcon(skill.id, skill.source);
-    if (svg) {
-      const html = processSvg(svg, isDark ? '#ffffff' : '#000000');
-      return <div dangerouslySetInnerHTML={{ __html: html }} />;
-    }
     if (skill.iconUrl && !imgError) {
-      const filter = isDark ? 'brightness(0) invert(1)' : 'brightness(0)';
+      const filter =
+        skill.source === 'skillssh'
+          ? undefined
+          : isDark
+            ? 'brightness(0) invert(1)'
+            : 'brightness(0)';
       return (
         <img
           src={skill.iconUrl}
@@ -38,6 +38,11 @@ export const SkillIconRenderer: React.FC<SkillIconRendererProps> = ({ skill }) =
           loading="lazy"
         />
       );
+    }
+    const svg = resolveSkillIcon(skill.catalogSkillId ?? skill.id, skill.source);
+    if (svg) {
+      const html = processSvg(svg, isDark ? '#ffffff' : '#000000');
+      return <div dangerouslySetInnerHTML={{ __html: html }} />;
     }
     return letter;
   };

--- a/src/renderer/features/skills/components/SkillsView.tsx
+++ b/src/renderer/features/skills/components/SkillsView.tsx
@@ -18,9 +18,12 @@ export const SkillsView: React.FC = () => {
     searchQuery,
     setSearchQuery,
     selectedSkill,
+    isLoadingDetail,
     showDetailModal,
     installedSkills,
     recommendedSkills,
+    skillShSearchSkills,
+    isSearchingSkillSh,
     refresh,
     install,
     uninstall,
@@ -118,10 +121,25 @@ export const SkillsView: React.FC = () => {
               ))}
             </CardGridSection>
           )}
+          {(isSearchingSkillSh || skillShSearchSkills.length > 0) && (
+            <CardGridSection title={isSearchingSkillSh ? 'Searching Skills.SH...' : 'Skills.SH'}>
+              {skillShSearchSkills.map((skill) => (
+                <SkillCard
+                  key={skill.id}
+                  skill={skill}
+                  isInstalled={false}
+                  onInstall={install}
+                  onUninstall={handleUninstallRequest}
+                  onClick={() => openDetail(skill)}
+                />
+              ))}
+            </CardGridSection>
+          )}
         </div>
       </div>
       <SkillDetailModal
         skill={selectedSkill}
+        isLoading={isLoadingDetail}
         isOpen={showDetailModal}
         onClose={closeDetail}
         onInstall={install}

--- a/src/renderer/features/skills/components/skillIcons.ts
+++ b/src/renderer/features/skills/components/skillIcons.ts
@@ -105,7 +105,6 @@ const keywordRules: Array<{ test: (id: string) => boolean; icon: string }> = [
 const sourceIcons: Record<string, string> = {
   openai: 'openai',
   anthropic: 'anthropic',
-  skillssh: 'vercel',
 };
 
 export function resolveSkillIcon(skillId: string, source: string): string | undefined {

--- a/src/renderer/features/skills/components/skillIcons.ts
+++ b/src/renderer/features/skills/components/skillIcons.ts
@@ -1,9 +1,9 @@
-const skillSvgs = import.meta.glob<string>('../../assets/images/skills/*.svg', {
+const skillSvgs = import.meta.glob<string>('../../../../assets/images/skills/*.svg', {
   query: '?raw',
   import: 'default',
   eager: true,
 });
-const mcpSvgs = import.meta.glob<string>('../../assets/images/mcp/*.svg', {
+const mcpSvgs = import.meta.glob<string>('../../../../assets/images/mcp/*.svg', {
   query: '?raw',
   import: 'default',
   eager: true,
@@ -47,6 +47,7 @@ const skillToIcon: Record<string, string> = {
   wrangler: 'cloudflare',
   'ai-sdk': 'vercel',
   'vercel-react-best-practices': 'vercel',
+  'find-docs': 'context7',
   'gh-issue-fix-flow': 'github',
   shadcn: 'shadcn',
   mysql: 'mysql',
@@ -60,6 +61,9 @@ const skillToIcon: Record<string, string> = {
   'frontend-design': 'anthropic',
   'webapp-testing': 'anthropic',
   'web-artifacts-builder': 'anthropic',
+  'find-skills': 'anthropic',
+  'review-and-refactor': 'anthropic',
+  'web-design-guidelines': 'anthropic',
   'mcp-builder': 'anthropic',
   'algorithmic-art': 'anthropic',
   'canvas-design': 'anthropic',
@@ -101,6 +105,7 @@ const keywordRules: Array<{ test: (id: string) => boolean; icon: string }> = [
 const sourceIcons: Record<string, string> = {
   openai: 'openai',
   anthropic: 'anthropic',
+  skillssh: 'vercel',
 };
 
 export function resolveSkillIcon(skillId: string, source: string): string | undefined {

--- a/src/renderer/features/skills/components/skillIcons.ts
+++ b/src/renderer/features/skills/components/skillIcons.ts
@@ -105,6 +105,7 @@ const keywordRules: Array<{ test: (id: string) => boolean; icon: string }> = [
 const sourceIcons: Record<string, string> = {
   openai: 'openai',
   anthropic: 'anthropic',
+  skillssh: 'vercel',
 };
 
 export function resolveSkillIcon(skillId: string, source: string): string | undefined {

--- a/src/renderer/features/skills/components/useSkills.ts
+++ b/src/renderer/features/skills/components/useSkills.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback, useMemo, useState } from 'react';
 import { useToast } from '@renderer/lib/hooks/use-toast';
+import { useDebounce } from '@renderer/lib/hooks/useDebounce';
 import { rpc } from '@renderer/lib/ipc';
 import { log } from '@renderer/utils/logger';
 import { captureTelemetry } from '@renderer/utils/telemetryClient';
@@ -122,7 +123,7 @@ export function useSkills() {
     enabled: !!selectedSkillId && showDetailModal,
   });
 
-  const skillShQuery = searchQuery.trim();
+  const skillShQuery = useDebounce(searchQuery.trim(), 300);
   const { data: skillShSkills = [], isFetching: isSearchingSkillSh } = useQuery({
     queryKey: ['skills', 'skillssh-search', skillShQuery],
     queryFn: async () => {
@@ -177,12 +178,8 @@ export function useSkills() {
   );
 
   const skillShSearchSkills = useMemo(() => {
-    const installedIds = new Set(catalog?.skills.filter((s) => s.installed).map((s) => s.id));
     const installedNames = new Set(catalog?.skills.filter((s) => s.installed).map((s) => s.id));
-    return skillShSkills.filter(
-      (skill) =>
-        !installedIds.has(skill.id) && !installedNames.has(skill.catalogSkillId ?? skill.id)
-    );
+    return skillShSkills.filter((skill) => !installedNames.has(skill.catalogSkillId ?? skill.id));
   }, [catalog, skillShSkills]);
 
   return {

--- a/src/renderer/features/skills/components/useSkills.ts
+++ b/src/renderer/features/skills/components/useSkills.ts
@@ -112,7 +112,7 @@ export function useSkills() {
     [uninstallMutation]
   );
 
-  const { data: detailData } = useQuery({
+  const { data: detailData, isFetching: isLoadingDetail } = useQuery({
     queryKey: ['skills', 'detail', selectedSkillId],
     queryFn: async () => {
       const result = await rpc.skills.getDetail({ skillId: selectedSkillId! });
@@ -122,10 +122,27 @@ export function useSkills() {
     enabled: !!selectedSkillId && showDetailModal,
   });
 
+  const skillShQuery = searchQuery.trim();
+  const { data: skillShSkills = [], isFetching: isSearchingSkillSh } = useQuery({
+    queryKey: ['skills', 'skillssh-search', skillShQuery],
+    queryFn: async () => {
+      const result = await rpc.skills.searchSkillSh({ query: skillShQuery });
+      if (result.success && result.data) return result.data;
+      throw new Error(result.error ?? 'Failed to search Skills.SH');
+    },
+    enabled: skillShQuery.length >= 2,
+    staleTime: 60_000,
+  });
+
   const selectedSkill = useMemo<CatalogSkill | null>(() => {
     if (!selectedSkillId || !showDetailModal) return null;
-    return detailData ?? catalog?.skills.find((s) => s.id === selectedSkillId) ?? null;
-  }, [selectedSkillId, showDetailModal, detailData, catalog]);
+    return (
+      detailData ??
+      catalog?.skills.find((s) => s.id === selectedSkillId) ??
+      skillShSkills.find((s) => s.id === selectedSkillId) ??
+      null
+    );
+  }, [selectedSkillId, showDetailModal, detailData, catalog, skillShSkills]);
 
   const openDetail = useCallback((skill: CatalogSkill) => {
     setSelectedSkillId(skill.id);
@@ -159,6 +176,15 @@ export function useSkills() {
     [filteredSkills]
   );
 
+  const skillShSearchSkills = useMemo(() => {
+    const installedIds = new Set(catalog?.skills.filter((s) => s.installed).map((s) => s.id));
+    const installedNames = new Set(catalog?.skills.filter((s) => s.installed).map((s) => s.id));
+    return skillShSkills.filter(
+      (skill) =>
+        !installedIds.has(skill.id) && !installedNames.has(skill.catalogSkillId ?? skill.id)
+    );
+  }, [catalog, skillShSkills]);
+
   return {
     catalog,
     isLoading,
@@ -166,10 +192,13 @@ export function useSkills() {
     searchQuery,
     setSearchQuery,
     selectedSkill,
+    isLoadingDetail,
     showDetailModal,
     filteredSkills,
     installedSkills,
     recommendedSkills,
+    skillShSearchSkills,
+    isSearchingSkillSh,
     refresh,
     install,
     uninstall,

--- a/src/renderer/features/skills/components/useSkills.ts
+++ b/src/renderer/features/skills/components/useSkills.ts
@@ -65,6 +65,8 @@ export function useSkills() {
         description: `${skillId} is now available across your agents`,
       });
       void queryClient.invalidateQueries({ queryKey: CATALOG_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: ['skills', 'skillssh-search'] });
+      queryClient.removeQueries({ queryKey: ['skills', 'detail'] });
     },
   });
 
@@ -98,6 +100,8 @@ export function useSkills() {
 
       toast({ title: 'Skill removed', description: 'Skill has been uninstalled' });
       void queryClient.invalidateQueries({ queryKey: CATALOG_QUERY_KEY });
+      void queryClient.invalidateQueries({ queryKey: ['skills', 'skillssh-search'] });
+      queryClient.removeQueries({ queryKey: ['skills', 'detail'] });
     },
   });
 
@@ -178,8 +182,19 @@ export function useSkills() {
   );
 
   const skillShSearchSkills = useMemo(() => {
-    const installedNames = new Set(catalog?.skills.filter((s) => s.installed).map((s) => s.id));
-    return skillShSkills.filter((skill) => !installedNames.has(skill.catalogSkillId ?? skill.id));
+    const installedKeys = new Set<string>();
+    for (const skill of catalog?.skills ?? []) {
+      if (!skill.installed) continue;
+      installedKeys.add(skill.id);
+      if (skill.installId) installedKeys.add(skill.installId);
+    }
+
+    return skillShSkills.filter(
+      (skill) =>
+        !skill.installed &&
+        !installedKeys.has(skill.id) &&
+        (!skill.installId || !installedKeys.has(skill.installId))
+    );
   }, [catalog, skillShSkills]);
 
   return {

--- a/src/renderer/lib/ui/markdown-renderer.tsx
+++ b/src/renderer/lib/ui/markdown-renderer.tsx
@@ -274,10 +274,12 @@ function useCompactComponents(isDark: boolean) {
       ),
       p: ({ children }: WithChildren) => <p className="mb-2 leading-relaxed">{children}</p>,
       ul: ({ children }: WithChildren) => (
-        <ul className="mb-2 ml-4 list-disc space-y-0.5">{children}</ul>
+        <ul className="marker:text-muted-foreground mb-2 ml-4 list-disc space-y-1">{children}</ul>
       ),
       ol: ({ children }: WithChildren) => (
-        <ol className="mb-2 ml-4 list-decimal space-y-0.5">{children}</ol>
+        <ol className="marker:text-muted-foreground mb-2 ml-4 list-decimal space-y-1">
+          {children}
+        </ol>
       ),
       li: ({ children }: WithChildren) => <li className="leading-relaxed">{children}</li>,
       code: ({ children, className }: WithChildrenAndClass) => {
@@ -287,12 +289,16 @@ function useCompactComponents(isDark: boolean) {
         const { isBlock } = getCodeBlock(children, className);
         if (isBlock) {
           return (
-            <code className="bg-muted/60 block overflow-x-auto rounded p-2 text-[11px]">
+            <code className="bg-muted/60 block overflow-x-auto rounded-md border border-border p-2 text-[11px] leading-relaxed">
               {children}
             </code>
           );
         }
-        return <code className="bg-muted/60 rounded px-1 py-0.5 text-[11px]">{children}</code>;
+        return (
+          <code className="bg-muted/60 rounded px-1 py-0.5 font-mono text-[0.92em]">
+            {children}
+          </code>
+        );
       },
       pre: ({ children }: WithChildren) =>
         isOnlyMermaidDiagramChild(children) ? (
@@ -300,6 +306,32 @@ function useCompactComponents(isDark: boolean) {
         ) : (
           <pre className="mb-2 overflow-x-auto">{children}</pre>
         ),
+      blockquote: ({ children }: WithChildren) => (
+        <blockquote className="text-muted-foreground mb-2 border-l-2 border-border pl-3 italic">
+          {children}
+        </blockquote>
+      ),
+      table: ({ children }: WithChildren) => (
+        <div className="my-3 overflow-x-auto rounded-md border border-border">
+          <table className="w-full min-w-max border-collapse text-left text-[11px] leading-snug">
+            {children}
+          </table>
+        </div>
+      ),
+      thead: ({ children }: WithChildren) => (
+        <thead className="bg-muted/50 border-b border-border text-foreground">{children}</thead>
+      ),
+      th: ({ children }: WithChildren) => (
+        <th className="border-r border-border px-2.5 py-1.5 font-semibold last:border-r-0">
+          {children}
+        </th>
+      ),
+      td: ({ children }: WithChildren) => (
+        <td className="border-t border-r border-border px-2.5 py-1.5 align-top last:border-r-0">
+          {children}
+        </td>
+      ),
+      hr: () => <hr className="my-4 border-border" />,
       strong: ({ children }: WithChildren) => (
         <strong className="font-semibold text-foreground">{children}</strong>
       ),

--- a/src/renderer/tests/markdown-renderer.test.ts
+++ b/src/renderer/tests/markdown-renderer.test.ts
@@ -46,4 +46,20 @@ describe('MarkdownRenderer', () => {
     expect(html).toContain('max-h-80');
     expect(html).toContain('object-contain');
   });
+
+  it('renders compact markdown tables with visible structure', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(MarkdownRenderer, {
+        content:
+          '| Layer | What | How |\n| --- | --- | --- |\n| Primary | Headline | Display size |',
+        variant: 'compact',
+      })
+    );
+
+    expect(html).toContain('<table');
+    expect(html).toContain('border-collapse');
+    expect(html).toContain('<th');
+    expect(html).toContain('<td');
+    expect(html).toContain('Primary');
+  });
 });

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -15,7 +15,7 @@ export interface CatalogSkill {
   /** Short description */
   description: string;
   /** Catalog source */
-  source: 'openai' | 'anthropic' | 'local';
+  source: 'openai' | 'anthropic' | 'skillssh' | 'local';
   /** GitHub URL */
   sourceUrl?: string;
   /** Icon URL (OpenAI skills have SVG/PNG) */
@@ -24,6 +24,12 @@ export interface CatalogSkill {
   brandColor?: string;
   /** Example prompt */
   defaultPrompt?: string;
+  /** Skills.SH source repository, e.g. owner/repo */
+  sourceRef?: string;
+  /** Original skill id inside the source repository */
+  catalogSkillId?: string;
+  /** Public install count when provided by a catalog */
+  installs?: number;
   /** Full SKILL.md content (loaded lazily) */
   skillMdContent?: string;
   /** Parsed frontmatter */

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -10,6 +10,8 @@ export interface SkillFrontmatter {
 export interface CatalogSkill {
   /** Skill directory name */
   id: string;
+  /** Local install directory name when it differs from the catalog id */
+  installId?: string;
   /** Human-readable display name */
   displayName: string;
   /** Short description */
@@ -26,7 +28,7 @@ export interface CatalogSkill {
   defaultPrompt?: string;
   /** Skills.SH source repository, e.g. owner/repo */
   sourceRef?: string;
-  /** Original skill id inside the source repository */
+  /** Leaf skill id/name inside the source repository */
   catalogSkillId?: string;
   /** Exact SKILL.md-relative directory path from Skills.SH */
   skillShPath?: string;

--- a/src/shared/skills/types.ts
+++ b/src/shared/skills/types.ts
@@ -28,6 +28,8 @@ export interface CatalogSkill {
   sourceRef?: string;
   /** Original skill id inside the source repository */
   catalogSkillId?: string;
+  /** Exact SKILL.md-relative directory path from Skills.SH */
+  skillShPath?: string;
   /** Public install count when provided by a catalog */
   installs?: number;
   /** Full SKILL.md content (loaded lazily) */

--- a/src/shared/skills/validation.test.ts
+++ b/src/shared/skills/validation.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { parseFrontmatter } from './validation';
+
+describe('parseFrontmatter', () => {
+  it('parses single-line quoted values', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: "review"
+description: "Review code changes"
+---
+
+# Review
+`);
+
+    expect(frontmatter).toEqual({
+      name: 'review',
+      description: 'Review code changes',
+      license: undefined,
+      compatibility: undefined,
+      'allowed-tools': undefined,
+    });
+  });
+
+  it('parses literal block descriptions without exposing the YAML marker', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: docs
+description: |
+  Edit documentation.
+  Keep the prose direct.
+---
+
+# Docs
+`);
+
+    expect(frontmatter.description).toBe('Edit documentation.\nKeep the prose direct.');
+  });
+
+  it('parses folded block descriptions as display-friendly text', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: docs
+description: >
+  Edit documentation.
+  Keep the prose direct.
+---
+
+# Docs
+`);
+
+    expect(frontmatter.description).toBe('Edit documentation. Keep the prose direct.');
+  });
+
+  it('continues parsing fields after a block scalar', () => {
+    const { frontmatter } = parseFrontmatter(`---
+name: docs
+description: |-
+  Edit documentation.
+license: MIT
+---
+
+# Docs
+`);
+
+    expect(frontmatter.description).toBe('Edit documentation.');
+    expect(frontmatter.license).toBe('MIT');
+  });
+});

--- a/src/shared/skills/validation.ts
+++ b/src/shared/skills/validation.ts
@@ -1,5 +1,7 @@
 import type { SkillFrontmatter } from './types';
 
+type BlockScalarStyle = 'literal' | 'folded';
+
 /** Validate a skill name: lowercase, hyphens, 1-64 chars */
 export function isValidSkillName(name: string): boolean {
   return /^[a-z0-9][a-z0-9-]{0,62}[a-z0-9]?$/.test(name) && !name.includes('--');
@@ -21,21 +23,21 @@ export function parseFrontmatter(content: string): {
   const yamlBlock = match[1];
   const body = match[2];
   const frontmatter: Record<string, string> = {};
+  const lines = yamlBlock.split('\n');
 
-  for (const line of yamlBlock.split('\n')) {
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
     const colonIdx = line.indexOf(':');
     if (colonIdx === -1) continue;
     const key = line.slice(0, colonIdx).trim();
     let value = line.slice(colonIdx + 1).trim();
-    const wasDoubleQuoted = value.startsWith('"') && value.endsWith('"');
-    const wasSingleQuoted = value.startsWith("'") && value.endsWith("'");
-    if (wasDoubleQuoted || wasSingleQuoted) {
-      value = value.slice(1, -1);
-      if (wasDoubleQuoted) {
-        value = value.replace(/\\"/g, '"').replace(/\\\\/g, '\\');
-      } else if (wasSingleQuoted) {
-        value = value.replace(/''/g, "'");
-      }
+    const blockScalarStyle = getBlockScalarStyle(value);
+    if (blockScalarStyle) {
+      const { value: blockValue, nextIndex } = parseBlockScalar(lines, i, blockScalarStyle);
+      value = blockValue;
+      i = nextIndex;
+    } else {
+      value = unquoteYamlValue(value);
     }
     if (key) {
       frontmatter[key] = value;
@@ -52,6 +54,58 @@ export function parseFrontmatter(content: string): {
     },
     body,
   };
+}
+
+function getBlockScalarStyle(value: string): BlockScalarStyle | null {
+  if (/^\|[+-]?$/.test(value)) return 'literal';
+  if (/^>[+-]?$/.test(value)) return 'folded';
+  return null;
+}
+
+function parseBlockScalar(
+  lines: string[],
+  headerIndex: number,
+  style: BlockScalarStyle
+): { value: string; nextIndex: number } {
+  const headerIndent = countIndent(lines[headerIndex]);
+  const blockLines: string[] = [];
+  let nextIndex = headerIndex;
+
+  for (let i = headerIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (line.trim() && countIndent(line) <= headerIndent) break;
+    blockLines.push(line);
+    nextIndex = i;
+  }
+
+  const contentIndent = Math.min(
+    ...blockLines.filter((line) => line.trim()).map((line) => countIndent(line))
+  );
+  const normalizedLines = blockLines.map((line) =>
+    Number.isFinite(contentIndent) ? line.slice(contentIndent) : ''
+  );
+
+  if (style === 'folded') {
+    return {
+      value: normalizedLines.join(' ').replace(/\s+/g, ' ').trim(),
+      nextIndex,
+    };
+  }
+
+  return { value: normalizedLines.join('\n').trim(), nextIndex };
+}
+
+function countIndent(line: string): number {
+  const match = line.match(/^\s*/);
+  return match ? match[0].length : 0;
+}
+
+function unquoteYamlValue(value: string): string {
+  const wasDoubleQuoted = value.startsWith('"') && value.endsWith('"');
+  const wasSingleQuoted = value.startsWith("'") && value.endsWith("'");
+  if (wasDoubleQuoted) return value.slice(1, -1).replace(/\\"/g, '"').replace(/\\\\/g, '\\');
+  if (wasSingleQuoted) return value.slice(1, -1).replace(/''/g, "'");
+  return value;
 }
 
 function escapeYamlDoubleQuoted(s: string): string {


### PR DESCRIPTION
# summary
- adds support for skills.sh in skills
- Parse multiline skill descriptions so YAML block markers do not appear in the skills catalog. (@mezotv )