### PR TITLE
fix(renderer): avoid deep-observing file tree

### DIFF
--- a/src/renderer/features/tasks/editor/stores/files-store.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.ts
@@ -67,7 +67,8 @@ export class FilesStore {
             if (changed) ctx.set({ nodes: this._nodes, rootNodes: this._rootNodes });
           },
         },
-      ]
+      ],
+      { refData: true }
     );
   }
 

--- a/src/renderer/lib/stores/resource.ts
+++ b/src/renderer/lib/stores/resource.ts
@@ -61,14 +61,14 @@ export class Resource<T, TEventData = void> {
   constructor(
     fetch: (() => Promise<T>) | null,
     strategies: ResourceStrategy<T, TEventData>[],
-    options?: { init?: T }
+    options?: { init?: T; refData?: boolean }
   ) {
     this._fetch = fetch;
     this._strategies = strategies;
     this.data = options?.init ?? null;
 
     makeObservable(this, {
-      data: observable,
+      data: options?.refData ? observable.ref : observable,
       loading: observable,
       error: observable,
       lastUpdatedAt: observable,

--- a/src/renderer/lib/stores/resource.ts
+++ b/src/renderer/lib/stores/resource.ts
@@ -61,7 +61,15 @@ export class Resource<T, TEventData = void> {
   constructor(
     fetch: (() => Promise<T>) | null,
     strategies: ResourceStrategy<T, TEventData>[],
-    options?: { init?: T; refData?: boolean }
+    options?: {
+      init?: T;
+      /**
+       * Track only data reference changes. Do not use ctx.mutate() with this
+       * option unless T contains its own MobX observable state; in-place plain
+       * object/array mutations will not notify observers. Use ctx.set() instead.
+       */
+      refData?: boolean;
+    }
   ) {
     this._fetch = fetch;
     this._strategies = strategies;


### PR DESCRIPTION
# summary
- fixes file tree ui lag
- fixes #2196 

<img width="830" height="309" alt="image" src="https://github.com/user-attachments/assets/14d5badb-b92c-41f7-bab0-e05070694fbe" />
