### PR TITLE
fix: prevent trailing slash in branch prefixes

### DIFF
--- a/src/main/core/settings/schema.ts
+++ b/src/main/core/settings/schema.ts
@@ -1,5 +1,6 @@
 import z from 'zod';
 import { AGENT_PROVIDER_IDS, AGENT_PROVIDERS } from '@shared/agent-provider-registry';
+import { normalizeBranchPrefix } from '@shared/branch-prefix';
 import { openInAppIdSchema } from '@shared/openInApps';
 import { APP_SHORTCUTS } from '@shared/shortcuts';
 import { TERMINAL_FONT_SIZE_MAX, TERMINAL_FONT_SIZE_MIN } from '@shared/terminal-settings';
@@ -7,7 +8,7 @@ import { DEFAULT_AGENT_ID } from './settings-registry';
 
 export const projectSettingsSchema = z.object({
   pushOnCreate: z.boolean(),
-  branchPrefix: z.string(),
+  branchPrefix: z.string().transform(normalizeBranchPrefix),
   appendRandomBranchSuffix: z.boolean(),
   tmuxByDefault: z.boolean(),
 });

--- a/src/renderer/features/settings/components/RepositorySettingsCard.tsx
+++ b/src/renderer/features/settings/components/RepositorySettingsCard.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { Input } from '@renderer/lib/ui/input';
 import { Switch } from '@renderer/lib/ui/switch';
+import { normalizeBranchPrefix } from '@shared/branch-prefix';
 import { ResetToDefaultButton } from './ResetToDefaultButton';
 import { SettingRow } from './SettingRow';
 
@@ -38,7 +39,8 @@ const RepositorySettingsCard: React.FC = () => {
             key={branchPrefix}
             defaultValue={branchPrefix}
             onBlur={(e) => {
-              const next = e.target.value;
+              const next = normalizeBranchPrefix(e.currentTarget.value);
+              e.currentTarget.value = next;
               if (next !== branchPrefix) {
                 updateProject({ branchPrefix: next });
               }

--- a/src/renderer/features/settings/components/RepositorySettingsCard.tsx
+++ b/src/renderer/features/settings/components/RepositorySettingsCard.tsx
@@ -38,7 +38,7 @@ const RepositorySettingsCard: React.FC = () => {
             key={branchPrefix}
             defaultValue={branchPrefix}
             onBlur={(e) => {
-              const next = e.target.value.trim();
+              const next = e.target.value;
               if (next !== branchPrefix) {
                 updateProject({ branchPrefix: next });
               }

--- a/src/shared/branch-prefix.test.ts
+++ b/src/shared/branch-prefix.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeBranchPrefix } from './branch-prefix';
+
+describe('normalizeBranchPrefix', () => {
+  it('strips trailing slashes', () => {
+    expect(normalizeBranchPrefix('emdash/')).toBe('emdash');
+    expect(normalizeBranchPrefix('emdash///')).toBe('emdash');
+  });
+
+  it('trims whitespace', () => {
+    expect(normalizeBranchPrefix('  emdash/  ')).toBe('emdash');
+  });
+
+  it('preserves internal slashes', () => {
+    expect(normalizeBranchPrefix('team/emdash')).toBe('team/emdash');
+  });
+
+  it('leaves valid prefixes unchanged', () => {
+    expect(normalizeBranchPrefix('emdash')).toBe('emdash');
+    expect(normalizeBranchPrefix('')).toBe('');
+  });
+});

--- a/src/shared/branch-prefix.test.ts
+++ b/src/shared/branch-prefix.test.ts
@@ -7,6 +7,12 @@ describe('normalizeBranchPrefix', () => {
     expect(normalizeBranchPrefix('emdash///')).toBe('emdash');
   });
 
+  it('strips leading slashes', () => {
+    expect(normalizeBranchPrefix('/emdash')).toBe('emdash');
+    expect(normalizeBranchPrefix('///emdash')).toBe('emdash');
+    expect(normalizeBranchPrefix('/team/emdash/')).toBe('team/emdash');
+  });
+
   it('trims whitespace', () => {
     expect(normalizeBranchPrefix('  emdash/  ')).toBe('emdash');
   });

--- a/src/shared/branch-prefix.ts
+++ b/src/shared/branch-prefix.ts
@@ -1,4 +1,4 @@
-/** Strip trailing path separators so `${prefix}/${branch}` stays a valid ref. */
+/** Strip leading/trailing path separators so `${prefix}/${branch}` stays a valid ref. */
 export function normalizeBranchPrefix(prefix: string): string {
-  return prefix.trim().replace(/\/+$/, '');
+  return prefix.trim().replace(/^\/+|\/+$/g, '');
 }

--- a/src/shared/branch-prefix.ts
+++ b/src/shared/branch-prefix.ts
@@ -1,0 +1,4 @@
+/** Strip trailing path separators so `${prefix}/${branch}` stays a valid ref. */
+export function normalizeBranchPrefix(prefix: string): string {
+  return prefix.trim().replace(/\/+$/, '');
+}


### PR DESCRIPTION
# summary
- prevent branch prefixes from ending with "/" to avoid double invalid generated branch names liek emdash//name
- normalize or validate configured branch prefix 