### PR TITLE
fix: enter in cmdk doing the wrong action

### DIFF
--- a/src/renderer/lib/hooks/use-arrow-key-navigation.ts
+++ b/src/renderer/lib/hooks/use-arrow-key-navigation.ts
@@ -3,9 +3,7 @@ import { modalStore } from '@renderer/lib/modal/modal-store';
 
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
-  return (
-    target.closest('input, textarea, select, [contenteditable], [role="textbox"]') !== null
-  );
+  return target.closest('input, textarea, select, [contenteditable], [role="textbox"]') !== null;
 }
 
 function isInteractiveTarget(target: EventTarget | null): boolean {

--- a/src/renderer/lib/hooks/use-arrow-key-navigation.ts
+++ b/src/renderer/lib/hooks/use-arrow-key-navigation.ts
@@ -4,8 +4,7 @@ import { modalStore } from '@renderer/lib/modal/modal-store';
 function isEditableTarget(target: EventTarget | null): boolean {
   if (!(target instanceof HTMLElement)) return false;
   return (
-    target.isContentEditable ||
-    target.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]') !== null
+    target.closest('input, textarea, select, [contenteditable], [role="textbox"]') !== null
   );
 }
 

--- a/src/renderer/lib/hooks/use-arrow-key-navigation.ts
+++ b/src/renderer/lib/hooks/use-arrow-key-navigation.ts
@@ -1,4 +1,28 @@
 import { useEffect, useRef, useState } from 'react';
+import { modalStore } from '@renderer/lib/modal/modal-store';
+
+function isEditableTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.isContentEditable ||
+    target.closest('input, textarea, select, [contenteditable="true"], [role="textbox"]') !== null
+  );
+}
+
+function isInteractiveTarget(target: EventTarget | null): boolean {
+  if (!(target instanceof HTMLElement)) return false;
+  return (
+    target.closest(
+      'button, a[href], [role="button"], [role="link"], [role="menuitem"], [role="option"], [role="tab"], [role="checkbox"], [role="radio"], [role="switch"]'
+    ) !== null
+  );
+}
+
+function isFromDialog(event: KeyboardEvent): boolean {
+  return event
+    .composedPath()
+    .some((target) => target instanceof HTMLElement && target.dataset.slot === 'dialog-content');
+}
 
 export function useArrowKeyNavigation(count: number, onEnter: (index: number) => void) {
   const [selectedIndex, setSelectedIndex] = useState(0);
@@ -15,6 +39,16 @@ export function useArrowKeyNavigation(count: number, onEnter: (index: number) =>
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
+      if (
+        e.defaultPrevented ||
+        modalStore.isOpen ||
+        isFromDialog(e) ||
+        isEditableTarget(e.target) ||
+        isInteractiveTarget(e.target)
+      ) {
+        return;
+      }
+
       if (e.key === 'ArrowDown') {
         e.preventDefault();
         setSelectedIndex((i) => (i + 1) % count);
@@ -22,6 +56,7 @@ export function useArrowKeyNavigation(count: number, onEnter: (index: number) =>
         e.preventDefault();
         setSelectedIndex((i) => (i - 1 + count) % count);
       } else if (e.key === 'Enter') {
+        e.preventDefault();
         onEnterRef.current(selectedIndexRef.current);
       }
     };


### PR DESCRIPTION
# summary
when in the cmdk and "beneath" the cmdk is a different keybind selected that would get used, but that doesnt maek sense since you're in the cmdk 

this fixes this bug:
https://github.com/user-attachments/assets/91d9a231-c6af-4594-87c7-70f4806c2a3a

