### PR TITLE
fix(github): route Octokit by host to support GitHub Enterprise

### DIFF
--- a/src/main/core/github/github-issue-provider.test.ts
+++ b/src/main/core/github/github-issue-provider.test.ts
@@ -32,6 +32,7 @@ describe('githubIssueProvider', () => {
 
     expect(mockIssueService.listIssues).toHaveBeenCalledWith(
       {
+        host: 'github.com',
         owner: 'owner',
         repo: 'repo',
         nameWithOwner: 'owner/repo',
@@ -52,6 +53,7 @@ describe('githubIssueProvider', () => {
 
     expect(mockIssueService.searchIssues).toHaveBeenCalledWith(
       {
+        host: 'github.com',
         owner: 'owner',
         repo: 'repo',
         nameWithOwner: 'owner/repo',

--- a/src/main/core/github/services/gh-cli-token.ts
+++ b/src/main/core/github/services/gh-cli-token.ts
@@ -1,17 +1,28 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import { GITHUB_DOT_COM_HOST } from '@shared/github-repository';
 
-export async function isGhCliAuthenticated(ctx: IExecutionContext): Promise<boolean> {
+function hostnameArgs(host: string): string[] {
+  return host === GITHUB_DOT_COM_HOST ? [] : ['--hostname', host];
+}
+
+export async function isGhCliAuthenticated(
+  ctx: IExecutionContext,
+  host: string = GITHUB_DOT_COM_HOST
+): Promise<boolean> {
   try {
-    await ctx.exec('gh', ['auth', 'status']);
+    await ctx.exec('gh', ['auth', 'status', ...hostnameArgs(host)]);
     return true;
   } catch {
     return false;
   }
 }
 
-export async function extractGhCliToken(ctx: IExecutionContext): Promise<string | null> {
+export async function extractGhCliToken(
+  ctx: IExecutionContext,
+  host: string = GITHUB_DOT_COM_HOST
+): Promise<string | null> {
   try {
-    const { stdout } = await ctx.exec('gh', ['auth', 'token']);
+    const { stdout } = await ctx.exec('gh', ['auth', 'token', ...hostnameArgs(host)]);
     const token = stdout.trim();
     return token || null;
   } catch {

--- a/src/main/core/github/services/github-connection-service.ts
+++ b/src/main/core/github/services/github-connection-service.ts
@@ -14,6 +14,7 @@ import {
   githubAuthSuccessChannel,
 } from '@shared/events/githubEvents';
 import type { GitHubConnectResponse, GitHubStatusOptions, GitHubUser } from '@shared/github';
+import { apiBaseUrlForHost, GITHUB_DOT_COM_HOST } from '@shared/github-repository';
 import { extractGhCliToken } from './gh-cli-token';
 
 // ---------------------------------------------------------------------------
@@ -39,7 +40,13 @@ export interface DeviceCodeResult {
 export type TokenSource = 'secure_storage' | 'cli' | 'emdash_oauth' | 'device_flow' | null;
 
 export interface GitHubConnectionService {
-  getToken(): Promise<string | null>;
+  /**
+   * Returns a token usable against the given host's API. Defaults to github.com.
+   * For non-github.com hosts (GitHub Enterprise), the token is read directly from
+   * the `gh` CLI's per-host auth state — emdash's encrypted secure storage only
+   * holds the github.com token.
+   */
+  getToken(host?: string): Promise<string | null>;
   getTokenSource(): Promise<TokenSource>;
   getStatus(options?: GitHubStatusOptions): Promise<{
     authenticated: boolean;
@@ -48,7 +55,7 @@ export interface GitHubConnectionService {
   }>;
   isAuthenticated(): Promise<boolean>;
   getCurrentUser(): Promise<GitHubUser | null>;
-  getUserInfo(token: string): Promise<GitHubUser | null>;
+  getUserInfo(token: string, host?: string): Promise<GitHubUser | null>;
   startOAuthFlow(authServerBaseUrl: string): Promise<AuthResult>;
   startDeviceFlowAuth(): Promise<DeviceCodeResult>;
   storeToken(token: string, source?: Exclude<TokenSource, null>): Promise<void>;
@@ -176,7 +183,12 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
     return { token: cliToken, source: 'cli' };
   }
 
-  async getToken(): Promise<string | null> {
+  async getToken(host: string = GITHUB_DOT_COM_HOST): Promise<string | null> {
+    if (host !== GITHUB_DOT_COM_HOST) {
+      // Enterprise hosts: read directly from gh CLI per-host auth. We don't cache because
+      // the existing TTL cache holds the github.com token under a single key.
+      return extractGhCliToken(new LocalExecutionContext(), host);
+    }
     const { token } = await this.resolveTokenRecord();
     return token;
   }
@@ -218,9 +230,9 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
     return this.getUserInfo(token);
   }
 
-  async getUserInfo(token: string): Promise<GitHubUser | null> {
+  async getUserInfo(token: string, host: string = GITHUB_DOT_COM_HOST): Promise<GitHubUser | null> {
     try {
-      const octokit = new Octokit({ auth: token });
+      const octokit = new Octokit({ auth: token, baseUrl: apiBaseUrlForHost(host) });
       const { data } = await octokit.rest.users.getAuthenticated();
       return {
         id: data.id,

--- a/src/main/core/github/services/github-connection-service.ts
+++ b/src/main/core/github/services/github-connection-service.ts
@@ -84,6 +84,12 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
     source: TokenSource;
   }>(5 * 60 * 1000);
 
+  // Per-host TTL cache for Enterprise tokens (github.com uses the richer
+  // `_tokenRecordCache` above). Bypassing this would shell out to
+  // `gh auth token --hostname …` on every getOctokit call.
+  private readonly _enterpriseTokenCache = new Map<string, { token: string; expiresAt: number }>();
+  private static readonly ENTERPRISE_TOKEN_TTL_MS = 5 * 60 * 1000;
+
   private parseTokenSource(raw: unknown): Exclude<TokenSource, null> | null {
     return raw === 'cli' ||
       raw === 'secure_storage' ||
@@ -132,6 +138,7 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
 
   private _invalidateTokenCache(): void {
     this._tokenRecordCache.invalidate();
+    this._enterpriseTokenCache.clear();
   }
 
   private resolveTokenRecord(): Promise<{ token: string | null; source: TokenSource }> {
@@ -185,11 +192,26 @@ export class GitHubConnectionServiceImpl implements GitHubConnectionService {
 
   async getToken(host: string = GITHUB_DOT_COM_HOST): Promise<string | null> {
     if (host !== GITHUB_DOT_COM_HOST) {
-      // Enterprise hosts: read directly from gh CLI per-host auth. We don't cache because
-      // the existing TTL cache holds the github.com token under a single key.
-      return extractGhCliToken(new LocalExecutionContext(), host);
+      return this.resolveEnterpriseToken(host);
     }
     const { token } = await this.resolveTokenRecord();
+    return token;
+  }
+
+  private async resolveEnterpriseToken(host: string): Promise<string | null> {
+    const cached = this._enterpriseTokenCache.get(host);
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.token;
+    }
+    const token = await extractGhCliToken(new LocalExecutionContext(), host);
+    if (token) {
+      this._enterpriseTokenCache.set(host, {
+        token,
+        expiresAt: Date.now() + GitHubConnectionServiceImpl.ENTERPRISE_TOKEN_TTL_MS,
+      });
+    } else {
+      this._enterpriseTokenCache.delete(host);
+    }
     return token;
   }
 

--- a/src/main/core/github/services/issue-service.test.ts
+++ b/src/main/core/github/services/issue-service.test.ts
@@ -58,6 +58,7 @@ const expectedIssue = {
 };
 
 const repository = {
+  host: 'github.com',
   owner: 'owner',
   repo: 'repo',
   nameWithOwner: 'owner/repo',

--- a/src/main/core/github/services/issue-service.ts
+++ b/src/main/core/github/services/issue-service.ts
@@ -57,12 +57,12 @@ interface RestIssue {
 // ---------------------------------------------------------------------------
 
 export class GitHubIssueServiceImpl implements GitHubIssueService {
-  constructor(private readonly getOctokit: () => Promise<Octokit>) {}
+  constructor(private readonly getOctokit: (host: string) => Promise<Octokit>) {}
 
   async listIssues(repository: GitHubRepositoryRef, limit: number = 50): Promise<GitHubIssue[]> {
-    const { owner, repo } = repository;
+    const { owner, repo, host } = repository;
     try {
-      const octokit = await this.getOctokit();
+      const octokit = await this.getOctokit(host);
       const { data } = await octokit.rest.issues.listForRepo({
         owner,
         repo,
@@ -86,9 +86,9 @@ export class GitHubIssueServiceImpl implements GitHubIssueService {
   ): Promise<GitHubIssue[]> {
     const term = searchTerm.trim();
     if (!term) return [];
-    const { owner, repo } = repository;
+    const { owner, repo, host } = repository;
     try {
-      const octokit = await this.getOctokit();
+      const octokit = await this.getOctokit(host);
       const { data } = await octokit.rest.search.issuesAndPullRequests({
         q: `${term} repo:${owner}/${repo} is:issue is:open`,
         per_page: Math.min(Math.max(limit, 1), 100),
@@ -105,9 +105,9 @@ export class GitHubIssueServiceImpl implements GitHubIssueService {
     repository: GitHubRepositoryRef,
     issueNumber: number
   ): Promise<GitHubIssueDetail | null> {
-    const { owner, repo } = repository;
+    const { owner, repo, host } = repository;
     try {
-      const octokit = await this.getOctokit();
+      const octokit = await this.getOctokit(host);
       const { data } = await octokit.rest.issues.get({
         owner,
         repo,

--- a/src/main/core/github/services/octokit-provider.ts
+++ b/src/main/core/github/services/octokit-provider.ts
@@ -1,20 +1,29 @@
 import { Octokit } from '@octokit/rest';
+import { apiBaseUrlForHost, GITHUB_DOT_COM_HOST } from '@shared/github-repository';
 import { githubConnectionService } from './github-connection-service';
 
-let cachedOctokit: Octokit | null = null;
-let cachedToken: string | null = null;
+// Cache one Octokit per (host, token) pair so multiple Enterprise hosts can coexist and
+// token rotation cleanly invalidates only the affected entry. Keyed on `${host}|${token}`.
+const cache = new Map<string, Octokit>();
 
-export async function getOctokit(): Promise<Octokit> {
-  const token = await githubConnectionService.getToken();
+function cacheKey(host: string, token: string): string {
+  return `${host}|${token}`;
+}
+
+export async function getOctokit(host: string = GITHUB_DOT_COM_HOST): Promise<Octokit> {
+  const token = await githubConnectionService.getToken(host);
   if (!token) throw new Error('Not authenticated');
-  if (token !== cachedToken) {
-    cachedOctokit = new Octokit({ auth: token });
-    cachedToken = token;
-  }
-  return cachedOctokit!;
+  const key = cacheKey(host, token);
+  const cached = cache.get(key);
+  if (cached) return cached;
+  const octokit = new Octokit({
+    auth: token,
+    baseUrl: apiBaseUrlForHost(host),
+  });
+  cache.set(key, octokit);
+  return octokit;
 }
 
 export function clearOctokitCache(): void {
-  cachedOctokit = null;
-  cachedToken = null;
+  cache.clear();
 }

--- a/src/main/core/github/services/repo-service.ts
+++ b/src/main/core/github/services/repo-service.ts
@@ -1,4 +1,5 @@
 import type { Octokit } from '@octokit/rest';
+import { GITHUB_DOT_COM_HOST } from '@shared/github-repository';
 import { getOctokit } from './octokit-provider';
 
 // ---------------------------------------------------------------------------
@@ -90,10 +91,10 @@ const RESERVED_NAMES = new Set([
 ]);
 
 export class GitHubRepositoryServiceImpl implements GitHubRepositoryService {
-  constructor(private readonly getOctokit: () => Promise<Octokit>) {}
+  constructor(private readonly getOctokit: (host: string) => Promise<Octokit>) {}
 
   async listRepositories(): Promise<GitHubRepo[]> {
-    const octokit = await this.getOctokit();
+    const octokit = await this.getOctokit(GITHUB_DOT_COM_HOST);
     const { data } = await octokit.rest.repos.listForAuthenticatedUser({
       per_page: 100,
       sort: 'updated',
@@ -103,7 +104,7 @@ export class GitHubRepositoryServiceImpl implements GitHubRepositoryService {
   }
 
   async getOwners(): Promise<GitHubOwner[]> {
-    const octokit = await this.getOctokit();
+    const octokit = await this.getOctokit(GITHUB_DOT_COM_HOST);
     const { data: user } = await octokit.rest.users.getAuthenticated();
     const owners: GitHubOwner[] = [{ login: user.login, type: 'User' }];
 
@@ -123,7 +124,7 @@ export class GitHubRepositoryServiceImpl implements GitHubRepositoryService {
     owner: string;
     isPrivate: boolean;
   }): Promise<{ url: string; defaultBranch: string; nameWithOwner: string }> {
-    const octokit = await this.getOctokit();
+    const octokit = await this.getOctokit(GITHUB_DOT_COM_HOST);
     const { data: user } = await octokit.rest.users.getAuthenticated();
     const isCurrentUser = params.owner === user.login;
 
@@ -145,12 +146,12 @@ export class GitHubRepositoryServiceImpl implements GitHubRepositoryService {
   }
 
   async deleteRepository(owner: string, name: string): Promise<void> {
-    const octokit = await this.getOctokit();
+    const octokit = await this.getOctokit(GITHUB_DOT_COM_HOST);
     await octokit.rest.repos.delete({ owner, repo: name });
   }
 
   async checkRepositoryExists(owner: string, name: string): Promise<boolean> {
-    const octokit = await this.getOctokit();
+    const octokit = await this.getOctokit(GITHUB_DOT_COM_HOST);
     try {
       await octokit.rest.repos.get({ owner, repo: name });
       return true;

--- a/src/main/core/pull-requests/pr-sync-engine.host-routing.test.ts
+++ b/src/main/core/pull-requests/pr-sync-engine.host-routing.test.ts
@@ -1,0 +1,99 @@
+import type { Octokit } from '@octokit/rest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Stub electron-dependent transitive imports so we can exercise the engine in isolation.
+vi.mock('@main/core/github/services/octokit-provider', () => ({
+  getOctokit: vi.fn(),
+}));
+vi.mock('@main/db/client', () => ({ db: {} }));
+vi.mock('@main/db/kv', () => ({
+  KV: class {
+    constructor(_namespace: string) {}
+    async get() {
+      return null;
+    }
+    async set() {}
+    async del() {}
+  },
+}));
+vi.mock('@main/lib/events', () => ({ events: { emit: vi.fn(), on: vi.fn(() => () => {}) } }));
+vi.mock('@main/lib/logger', () => ({
+  log: { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+import { PrSyncEngine } from './pr-sync-engine';
+
+/**
+ * Regression test for issue #2181 — GitHub Enterprise PR creation. The engine must route
+ * Octokit lookups by the repo's host so that Enterprise URLs hit the right API base.
+ */
+describe('PrSyncEngine host routing', () => {
+  function makeMockOctokit(pullsCreate = vi.fn()): Octokit {
+    return {
+      rest: {
+        pulls: {
+          create: pullsCreate.mockResolvedValue({
+            data: { html_url: 'https://ghe.example.com/org/repo/pull/42', number: 42 },
+          }),
+        },
+      },
+    } as unknown as Octokit;
+  }
+
+  it('passes the host parsed from the repositoryUrl through to getOctokit', async () => {
+    const mockOctokit = makeMockOctokit();
+    const getOctokit = vi.fn(async () => mockOctokit);
+    const engine = new PrSyncEngine(getOctokit);
+
+    await engine.createPullRequest({
+      repositoryUrl: 'https://ghe.example.com/org/repo',
+      head: 'feature',
+      base: 'main',
+      title: 'Test PR',
+      draft: true,
+    });
+
+    expect(getOctokit).toHaveBeenCalledWith('ghe.example.com');
+  });
+
+  it('still routes github.com URLs to the public host', async () => {
+    const mockOctokit = makeMockOctokit();
+    const getOctokit = vi.fn(async () => mockOctokit);
+    const engine = new PrSyncEngine(getOctokit);
+
+    await engine.createPullRequest({
+      repositoryUrl: 'https://github.com/owner/repo',
+      head: 'feature',
+      base: 'main',
+      title: 'Test PR',
+      draft: false,
+    });
+
+    expect(getOctokit).toHaveBeenCalledWith('github.com');
+  });
+
+  it('calls the API with the parsed owner and repo, not the full URL', async () => {
+    const pullsCreate = vi.fn();
+    const mockOctokit = makeMockOctokit(pullsCreate);
+    const engine = new PrSyncEngine(vi.fn(async () => mockOctokit));
+
+    await engine.createPullRequest({
+      repositoryUrl: 'git@ghe.example.com:org/repo.git',
+      head: 'feature',
+      base: 'main',
+      title: 'Test PR',
+      body: 'Body text',
+      draft: true,
+    });
+
+    expect(pullsCreate).toHaveBeenCalledWith({
+      owner: 'org',
+      repo: 'repo',
+      head: 'feature',
+      base: 'main',
+      title: 'Test PR',
+      body: 'Body text',
+      draft: true,
+    });
+  });
+});

--- a/src/main/core/pull-requests/pr-sync-engine.ts
+++ b/src/main/core/pull-requests/pr-sync-engine.ts
@@ -162,7 +162,7 @@ export class PrSyncEngine {
   private readonly _singleInflight = new Map<string, Promise<void>>();
   private readonly _checksInflight = new Map<string, Promise<void>>();
 
-  constructor(private readonly getOctokit: () => Promise<Octokit>) {}
+  constructor(private readonly getOctokit: (host: string) => Promise<Octokit>) {}
 
   // ── Public sync API ────────────────────────────────────────────────────────
 
@@ -276,8 +276,8 @@ export class PrSyncEngine {
       });
       return;
     }
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit().catch((e: unknown) => {
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host).catch((e: unknown) => {
       log.warn('PrSyncEngine: runFullSync — failed to get Octokit (not authenticated?)', {
         repositoryUrl,
         error: String(e),
@@ -380,8 +380,8 @@ export class PrSyncEngine {
       });
       return;
     }
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit().catch((e: unknown) => {
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host).catch((e: unknown) => {
       log.warn('PrSyncEngine: runIncrementalSync — failed to get Octokit (not authenticated?)', {
         repositoryUrl,
         error: String(e),
@@ -552,8 +552,8 @@ export class PrSyncEngine {
 
     const repository = parseGitHubRepositoryResult(repositoryUrl);
     if (!repository.success) return null;
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit();
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host);
 
     const response = await withRetry(() =>
       githubRateLimiter.acquire().then(() =>
@@ -643,8 +643,8 @@ export class PrSyncEngine {
 
     const repository = parseGitHubRepository(pr[0].repositoryUrl);
     if (!repository) return false;
-    const { owner, repo } = repository;
-    const octokit = await this.getOctokit();
+    const { owner, repo, host } = repository;
+    const octokit = await this.getOctokit(host);
 
     type CheckNode = GqlCheckRunNode | GqlStatusContextNode;
     const allNodes: CheckNode[] = [];
@@ -1032,8 +1032,8 @@ export class PrSyncEngine {
   }): Promise<Result<{ url: string; number: number }, GitHubRepositoryParseError>> {
     const repository = parseGitHubRepositoryResult(params.repositoryUrl);
     if (!repository.success) return repository;
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit();
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host);
     const response = await octokit.rest.pulls.create({
       owner,
       repo,
@@ -1054,8 +1054,8 @@ export class PrSyncEngine {
   ): Promise<Result<{ sha: string | null; merged: boolean }, GitHubRepositoryParseError>> {
     const repository = parseGitHubRepositoryResult(repositoryUrl);
     if (!repository.success) return repository;
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit();
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host);
     const response = await octokit.rest.pulls.merge({
       owner,
       repo,
@@ -1072,8 +1072,8 @@ export class PrSyncEngine {
   ): Promise<Result<void, GitHubRepositoryParseError>> {
     const repository = parseGitHubRepositoryResult(repositoryUrl);
     if (!repository.success) return repository;
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit();
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host);
     const { data } = await octokit.rest.pulls.get({ owner, repo, pull_number: prNumber });
     await octokit.graphql(
       `mutation MarkReadyForReview($id: ID!) {
@@ -1092,8 +1092,8 @@ export class PrSyncEngine {
   ): Promise<Result<PullRequestComment[], GitHubRepositoryParseError>> {
     const repository = parseGitHubRepositoryResult(repositoryUrl);
     if (!repository.success) return repository;
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit();
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host);
     const pullRequestUrl = `${repository.data.repositoryUrl}/pull/${prNumber}`;
 
     const [issueComments, reviewComments, reviews] = await Promise.all([
@@ -1184,8 +1184,8 @@ export class PrSyncEngine {
   ): Promise<Result<PullRequestFile[], GitHubRepositoryParseError>> {
     const repository = parseGitHubRepositoryResult(repositoryUrl);
     if (!repository.success) return repository;
-    const { owner, repo } = repository.data;
-    const octokit = await this.getOctokit();
+    const { owner, repo, host } = repository.data;
+    const octokit = await this.getOctokit(host);
     const files = await octokit.paginate(octokit.rest.pulls.listFiles, {
       owner,
       repo,

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/target-remote.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/target-remote.ts
@@ -1,16 +1,24 @@
 import type { Remote } from '@shared/git';
-import { parseGitHubRepository, type GitHubRepositoryRef } from '@shared/github-repository';
+import {
+  isGitHubDotCom,
+  parseGitHubRepository,
+  type GitHubRepositoryRef,
+} from '@shared/github-repository';
 
 export type GitHubTargetRemote = {
   remote: Remote;
   repository: GitHubRepositoryRef;
 };
 
+// The URL parser is intentionally permissive about host (Enterprise instances can use any
+// domain), so callers that want to filter to "known GitHub remotes" must apply an explicit
+// host check. For now this picker is github.com-only; broadening to user-authenticated
+// Enterprise hosts is tracked as a follow-up.
 export function getGitHubTargetRemotes(remotes: ReadonlyArray<Remote>): GitHubTargetRemote[] {
   return remotes
     .map((remote) => {
       const repository = parseGitHubRepository(remote.url);
-      return repository ? { remote, repository } : null;
+      return repository && isGitHubDotCom(repository) ? { remote, repository } : null;
     })
     .filter((option): option is GitHubTargetRemote => option !== null);
 }

--- a/src/shared/github-repository.test.ts
+++ b/src/shared/github-repository.test.ts
@@ -1,13 +1,17 @@
 import { describe, expect, it } from 'vitest';
 import {
+  apiBaseUrlForHost,
+  GITHUB_DOT_COM_HOST,
+  isGitHubDotCom,
   parseGitHubRepository,
   parseGitHubRepositoryResult,
   splitNameWithOwner,
 } from './github-repository';
 
 describe('parseGitHubRepository', () => {
-  it('parses canonical owner/repo values', () => {
+  it('parses canonical owner/repo values, defaulting host to github.com', () => {
     expect(parseGitHubRepository('owner/repo')).toEqual({
+      host: 'github.com',
       owner: 'owner',
       repo: 'repo',
       nameWithOwner: 'owner/repo',
@@ -15,8 +19,9 @@ describe('parseGitHubRepository', () => {
     });
   });
 
-  it('parses GitHub repository URLs and remotes to a single shape', () => {
+  it('parses github.com repository URLs and remotes to the same shape', () => {
     const expected = {
+      host: 'github.com',
       owner: 'owner',
       repo: 'repo',
       nameWithOwner: 'owner/repo',
@@ -25,13 +30,59 @@ describe('parseGitHubRepository', () => {
 
     expect(parseGitHubRepository('https://github.com/owner/repo')).toEqual(expected);
     expect(parseGitHubRepository('https://github.com/owner/repo.git')).toEqual(expected);
+    expect(parseGitHubRepository('https://www.github.com/owner/repo')).toEqual(expected);
     expect(parseGitHubRepository('git@github.com:owner/repo.git')).toEqual(expected);
+    expect(parseGitHubRepository('https://github.com/owner/repo/pulls/1')).toEqual(expected);
   });
 
-  it('returns null for non-GitHub and malformed values', () => {
-    expect(parseGitHubRepository('https://gitlab.com/owner/repo')).toBeNull();
+  it('captures the host for GitHub Enterprise URLs', () => {
+    const expected = {
+      host: 'ghe.example.com',
+      owner: 'org',
+      repo: 'service',
+      nameWithOwner: 'org/service',
+      repositoryUrl: 'https://ghe.example.com/org/service',
+    };
+
+    expect(parseGitHubRepository('https://ghe.example.com/org/service')).toEqual(expected);
+    expect(parseGitHubRepository('https://ghe.example.com/org/service.git')).toEqual(expected);
+    expect(parseGitHubRepository('git@ghe.example.com:org/service.git')).toEqual(expected);
+  });
+
+  it('preserves a non-default port in the host', () => {
+    expect(parseGitHubRepository('https://ghe.example.com:8443/org/service')).toEqual({
+      host: 'ghe.example.com:8443',
+      owner: 'org',
+      repo: 'service',
+      nameWithOwner: 'org/service',
+      repositoryUrl: 'https://ghe.example.com:8443/org/service',
+    });
+  });
+
+  it('lowercases the host so different casings produce the same ref', () => {
+    expect(parseGitHubRepository('https://Github.com/Owner/Repo')?.host).toEqual('github.com');
+    expect(parseGitHubRepository('git@GHE.Example.COM:org/repo.git')?.host).toEqual(
+      'ghe.example.com'
+    );
+  });
+
+  it('returns null for inputs without an owner/repo pair', () => {
     expect(parseGitHubRepository('owner')).toBeNull();
     expect(parseGitHubRepository('')).toBeNull();
+    expect(parseGitHubRepository(null)).toBeNull();
+    expect(parseGitHubRepository(undefined)).toBeNull();
+  });
+
+  it('parses non-GitHub hosts permissively so Enterprise instances on arbitrary domains work', () => {
+    // Validation that a host actually speaks the GitHub API is left to the API layer —
+    // there is no reliable way to know from a URL alone.
+    expect(parseGitHubRepository('https://gitlab.com/owner/repo')).toEqual({
+      host: 'gitlab.com',
+      owner: 'owner',
+      repo: 'repo',
+      nameWithOwner: 'owner/repo',
+      repositoryUrl: 'https://gitlab.com/owner/repo',
+    });
   });
 });
 
@@ -48,23 +99,44 @@ describe('splitNameWithOwner', () => {
 });
 
 describe('parseGitHubRepositoryResult', () => {
-  it('returns a typed result for valid and invalid inputs', () => {
+  it('returns a typed result for valid inputs', () => {
     expect(parseGitHubRepositoryResult('https://github.com/owner/repo')).toEqual({
       success: true,
       data: {
+        host: 'github.com',
         owner: 'owner',
         repo: 'repo',
         nameWithOwner: 'owner/repo',
         repositoryUrl: 'https://github.com/owner/repo',
       },
     });
+  });
 
-    expect(parseGitHubRepositoryResult('https://gitlab.com/owner/repo')).toEqual({
+  it('returns a typed error for unparseable inputs', () => {
+    expect(parseGitHubRepositoryResult('not a url')).toEqual({
       success: false,
       error: {
         type: 'invalid-github-repository',
-        input: 'https://gitlab.com/owner/repo',
+        input: 'not a url',
       },
     });
+  });
+});
+
+describe('isGitHubDotCom', () => {
+  it('distinguishes github.com from Enterprise hosts', () => {
+    expect(isGitHubDotCom(parseGitHubRepository('https://github.com/o/r')!)).toBe(true);
+    expect(isGitHubDotCom(parseGitHubRepository('https://ghe.example.com/o/r')!)).toBe(false);
+  });
+});
+
+describe('apiBaseUrlForHost', () => {
+  it('returns api.github.com for the public host', () => {
+    expect(apiBaseUrlForHost(GITHUB_DOT_COM_HOST)).toBe('https://api.github.com');
+  });
+
+  it('returns /api/v3 for Enterprise hosts', () => {
+    expect(apiBaseUrlForHost('ghe.example.com')).toBe('https://ghe.example.com/api/v3');
+    expect(apiBaseUrlForHost('ghe.example.com:8443')).toBe('https://ghe.example.com:8443/api/v3');
   });
 });

--- a/src/shared/github-repository.test.ts
+++ b/src/shared/github-repository.test.ts
@@ -49,6 +49,16 @@ describe('parseGitHubRepository', () => {
     expect(parseGitHubRepository('git@ghe.example.com:org/service.git')).toEqual(expected);
   });
 
+  it('preserves a leading www. on Enterprise hosts (only github.com is collapsed)', () => {
+    expect(parseGitHubRepository('https://www.ghe.example.com/org/service')).toEqual({
+      host: 'www.ghe.example.com',
+      owner: 'org',
+      repo: 'service',
+      nameWithOwner: 'org/service',
+      repositoryUrl: 'https://www.ghe.example.com/org/service',
+    });
+  });
+
   it('preserves a non-default port in the host', () => {
     expect(parseGitHubRepository('https://ghe.example.com:8443/org/service')).toEqual({
       host: 'ghe.example.com:8443',

--- a/src/shared/github-repository.ts
+++ b/src/shared/github-repository.ts
@@ -1,9 +1,14 @@
 import { err, ok, type Result } from './result';
 
+export const GITHUB_DOT_COM_HOST = 'github.com';
+
 export type GitHubRepositoryRef = {
+  /** Lowercase host, e.g. "github.com" or "ghe.example.com". May include a port. */
+  host: string;
   owner: string;
   repo: string;
   nameWithOwner: string;
+  /** Canonical URL `https://${host}/${nameWithOwner}` — used as a stable identifier. */
   repositoryUrl: string;
 };
 
@@ -17,36 +22,42 @@ function stripGitSuffix(value: string): string {
 }
 
 function toRepositoryRef(
+  host: string | undefined,
   owner: string | undefined,
   repo: string | undefined
 ): GitHubRepositoryRef | null {
+  const normalizedHost = (host ?? GITHUB_DOT_COM_HOST).trim().toLowerCase();
   const normalizedOwner = owner?.trim();
   const normalizedRepo = stripGitSuffix(repo?.trim() ?? '');
-  if (!normalizedOwner || !normalizedRepo) return null;
+  if (!normalizedHost || !normalizedOwner || !normalizedRepo) return null;
   const nameWithOwner = `${normalizedOwner}/${normalizedRepo}`;
   return {
+    host: normalizedHost,
     owner: normalizedOwner,
     repo: normalizedRepo,
     nameWithOwner,
-    repositoryUrl: `https://github.com/${nameWithOwner}`,
+    repositoryUrl: `https://${normalizedHost}/${nameWithOwner}`,
   };
 }
 
+// Parser is intentionally permissive about host — GitHub Enterprise instances can use any
+// hostname, and there is no reliable way to detect "this URL points at a GitHub-compatible
+// server" from the URL alone. Callers that need to short-circuit github.com vs. Enterprise
+// can use `isGitHubDotCom(ref)`.
 export function parseGitHubRepository(input?: string | null): GitHubRepositoryRef | null {
   const value = input?.trim();
   if (!value) return null;
 
-  const sshMatch = /^git@github\.com:([^/\s]+)\/([^/\s?#]+?)(?:\.git)?$/i.exec(value);
-  if (sshMatch) return toRepositoryRef(sshMatch[1], sshMatch[2]);
+  const sshMatch = value.match(/^git@([^:/\s]+):([^/\s]+)\/([^/\s?#]+?)(?:\.git)?$/i);
+  if (sshMatch) return toRepositoryRef(sshMatch[1], sshMatch[2], sshMatch[3]);
 
-  const urlMatch =
-    /^https?:\/\/(?:www\.)?github\.com\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?(?:[/?#].*)?$/i.exec(
-      value
-    );
-  if (urlMatch) return toRepositoryRef(urlMatch[1], urlMatch[2]);
+  const urlMatch = value.match(
+    /^https?:\/\/(?:www\.)?([^/\s]+)\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?(?:[/?#].*)?$/i
+  );
+  if (urlMatch) return toRepositoryRef(urlMatch[1], urlMatch[2], urlMatch[3]);
 
-  const canonicalMatch = /^([^/\s:]+)\/([^/\s?#]+?)(?:\.git)?$/i.exec(value);
-  if (canonicalMatch) return toRepositoryRef(canonicalMatch[1], canonicalMatch[2]);
+  const canonicalMatch = value.match(/^([^/\s:]+)\/([^/\s?#]+?)(?:\.git)?$/i);
+  if (canonicalMatch) return toRepositoryRef(undefined, canonicalMatch[1], canonicalMatch[2]);
 
   return null;
 }
@@ -69,4 +80,16 @@ export function splitNameWithOwner(nameWithOwner: string): { owner: string; repo
     throw new Error(`Invalid nameWithOwner: "${nameWithOwner}" (expected "owner/repo")`);
   }
   return { owner: parsed.owner, repo: parsed.repo };
+}
+
+export function isGitHubDotCom(ref: GitHubRepositoryRef): boolean {
+  return ref.host === GITHUB_DOT_COM_HOST;
+}
+
+/**
+ * Octokit baseUrl for the given host. github.com uses the public API; Enterprise Server
+ * exposes its API at `https://${host}/api/v3` per GHES convention.
+ */
+export function apiBaseUrlForHost(host: string): string {
+  return host === GITHUB_DOT_COM_HOST ? 'https://api.github.com' : `https://${host}/api/v3`;
 }

--- a/src/shared/github-repository.ts
+++ b/src/shared/github-repository.ts
@@ -21,12 +21,20 @@ function stripGitSuffix(value: string): string {
   return value.endsWith('.git') ? value.slice(0, -4) : value;
 }
 
+// Only the public `www.github.com` redirect is collapsed to its canonical host.
+// Enterprise instances whose DNS legitimately starts with `www.` (e.g. `www.ghe.corp.com`)
+// keep the prefix so API calls hit the address that actually resolves.
+function normalizeHost(rawHost: string): string {
+  const lower = rawHost.trim().toLowerCase();
+  return lower === `www.${GITHUB_DOT_COM_HOST}` ? GITHUB_DOT_COM_HOST : lower;
+}
+
 function toRepositoryRef(
   host: string | undefined,
   owner: string | undefined,
   repo: string | undefined
 ): GitHubRepositoryRef | null {
-  const normalizedHost = (host ?? GITHUB_DOT_COM_HOST).trim().toLowerCase();
+  const normalizedHost = normalizeHost(host ?? GITHUB_DOT_COM_HOST);
   const normalizedOwner = owner?.trim();
   const normalizedRepo = stripGitSuffix(repo?.trim() ?? '');
   if (!normalizedHost || !normalizedOwner || !normalizedRepo) return null;
@@ -52,7 +60,7 @@ export function parseGitHubRepository(input?: string | null): GitHubRepositoryRe
   if (sshMatch) return toRepositoryRef(sshMatch[1], sshMatch[2], sshMatch[3]);
 
   const urlMatch = value.match(
-    /^https?:\/\/(?:www\.)?([^/\s]+)\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?(?:[/?#].*)?$/i
+    /^https?:\/\/([^/\s]+)\/([^/\s]+)\/([^/\s?#]+?)(?:\.git)?(?:[/?#].*)?$/i
   );
   if (urlMatch) return toRepositoryRef(urlMatch[1], urlMatch[2], urlMatch[3]);
 


### PR DESCRIPTION
Closes #2181.

## Summary

- Routes Octokit lookups by host so Enterprise URLs hit `https://{host}/api/v3` instead of always hitting public `api.github.com`
- Generalizes the URL parser to capture host (was hardcoded to `github.com`)
- Propagates host through `pr-sync-engine`, `issue-service`, and `gh-cli-token` so PR sync, PR creation, and merge all use the right API
- Preserves existing behavior for `github.com` users — the parser still defaults the shorthand `owner/repo` to `github.com`, and the create-PR target picker is still `github.com`-only (broadening it to known Enterprise hosts is a follow-up)

## Root cause

Two hardcodes:

1. `Octokit` was always constructed without a `baseUrl`, so every API call hit `api.github.com` regardless of the actual repo host
2. The URL parser regexes only matched `github.com`, so GHE remotes parsed to `null` — surfacing as "invalid GitHub repository"

That's why the reporter sees PR creation fail _and_ existing PRs not getting found _and_ Project settings appear broken: they all funnel through the same parser + Octokit.

## Design notes

- The parser is intentionally permissive about host. Enterprise instances can live on any domain, so there's no reliable URL-only way to tell "this is a GitHub-compatible server." Verifying that a host actually speaks the GitHub API moves to the call layer (auth failure becomes a clearer error than silent rejection).
- For callers that _do_ want a strict `github.com`-only check (currently the create-PR target picker), a new `isGitHubDotCom(ref)` helper is exported. Used in `target-remote.ts` to preserve previous behavior.
- `getOctokit(host)` caches per `(host, token)` so multiple Enterprise hosts coexist cleanly and token rotation only invalidates the affected entry.
- For non-`github.com` hosts, `getToken(host)` reads directly from `gh auth token --hostname <host>` because emdash's encrypted secure storage only holds one token under a single key. This means GHE users rely on `gh auth login --hostname …` being configured, which is the standard GHE workflow.

## Test plan

- [x] `pnpm run format`
- [x] `pnpm run lint`
- [x] `pnpm run typecheck`
- [x] `pnpm test` — 834 passing
- [x] New parser tests cover github.com SSH/HTTPS, GHE SSH/HTTPS, ports, case normalization, shorthand
- [x] New `pr-sync-engine.host-routing.test.ts` proves the engine routes a GHE URL to `getOctokit('ghe.example.com')` and a github.com URL to `getOctokit('github.com')`
- [x] Manual: `github.com` PR creation still works locally

## What I couldn't validate

I don't have access to a GitHub Enterprise instance, so the end-to-end "create a PR against GHE" path is not directly verified. The unit + integration tests cover the routing logic, and the `github.com` path is fully validated, but the actual `api/v3` round-trip against a real GHE 3.x server would benefit from a second pair of eyes.

@bondfelix — if you have a moment, would you mind pulling this branch and confirming PR creation works on your GHE instance? `gh pr checkout` from this PR should pick up the branch.

## Out of scope (intentional follow-ups)

- Broadening the create-PR target picker to include Enterprise remotes (currently filters to `github.com` to keep this PR minimal)
- A GHE host setting in the UI (auto-detection from the repo remote should be enough for the bug fix)
- Multi-host repo browsing in the "Add Project" picker