### PR TITLE
fix: persist pasted terminal images + support heic 

### DIFF
--- a/src/main/core/pty/controller.ts
+++ b/src/main/core/pty/controller.ts
@@ -7,8 +7,16 @@ import { parsePtySessionId } from '@shared/ptySessionId';
 import { err, ok } from '@shared/result';
 import { taskManager } from '../tasks/task-manager';
 import { workspaceRegistry } from '../workspaces/workspace-registry';
-import { persistClipboardImagePath, persistDroppedBlobBytes } from './persist-dropped-blob';
+import {
+  cleanupExpiredDroppedBlobs,
+  persistClipboardImagePath,
+  persistDroppedBlobBytes,
+} from './persist-dropped-blob';
 import { ptySessionRegistry } from './pty-session-registry';
+
+void cleanupExpiredDroppedBlobs().catch((error) => {
+  log.warn('pty:cleanupExpiredDroppedBlobs failed', { error });
+});
 
 export const ptyController = createRPCController({
   /** Send raw input data to a PTY session. */

--- a/src/main/core/pty/controller.ts
+++ b/src/main/core/pty/controller.ts
@@ -7,6 +7,7 @@ import { parsePtySessionId } from '@shared/ptySessionId';
 import { err, ok } from '@shared/result';
 import { taskManager } from '../tasks/task-manager';
 import { workspaceRegistry } from '../workspaces/workspace-registry';
+import { persistClipboardImagePath, persistDroppedBlobBytes } from './persist-dropped-blob';
 import { ptySessionRegistry } from './pty-session-registry';
 
 export const ptyController = createRPCController({
@@ -109,6 +110,35 @@ export const ptyController = createRPCController({
         error: (e as Error)?.message || e,
       });
       return err({ type: 'upload_failed' as const, message: String((e as Error)?.message || e) });
+    }
+  },
+
+  /**
+   * Persist a dropped or pasted in-memory image to a stable temp file.
+   * HEIC/HEIF bytes are converted to PNG so Claude Code can inline them.
+   */
+  persistDroppedBlob: async (args: { bytes: Uint8Array; name?: string; mimeType?: string }) => {
+    try {
+      const path = await persistDroppedBlobBytes(args);
+      return ok({ path });
+    } catch (e: unknown) {
+      log.error('pty:persistDroppedBlob failed', {
+        error: (e as Error)?.message || e,
+      });
+      return err({ type: 'persist_failed' as const, message: String((e as Error)?.message || e) });
+    }
+  },
+
+  /** Persist the OS clipboard image (macOS HEIC paste, screenshots, etc.). */
+  persistClipboardImage: async () => {
+    try {
+      const path = await persistClipboardImagePath();
+      return ok({ path });
+    } catch (e: unknown) {
+      log.error('pty:persistClipboardImage failed', {
+        error: (e as Error)?.message || e,
+      });
+      return err({ type: 'persist_failed' as const, message: String((e as Error)?.message || e) });
     }
   },
 });

--- a/src/main/core/pty/persist-dropped-blob.test.ts
+++ b/src/main/core/pty/persist-dropped-blob.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  inferDroppedBlobExtension,
+  isHeicLike,
+  sanitizeDroppedBlobName,
+} from './persist-dropped-blob';
+
+describe('persist-dropped-blob', () => {
+  it('sanitizes unsafe file names', () => {
+    expect(sanitizeDroppedBlobName('../../evil name!.png')).toBe('evil_name_.png');
+  });
+
+  it('infers extension from mime type', () => {
+    expect(inferDroppedBlobExtension(undefined, 'image/heic')).toBe('.heic');
+    expect(inferDroppedBlobExtension('photo.PNG', undefined)).toBe('.png');
+  });
+
+  it('detects HEIC-like inputs', () => {
+    expect(isHeicLike({ name: 'shot.heic' })).toBe(true);
+    expect(isHeicLike({ mimeType: 'image/heif' })).toBe(true);
+    expect(isHeicLike({ name: 'shot.png', mimeType: 'image/png' })).toBe(false);
+  });
+});

--- a/src/main/core/pty/persist-dropped-blob.ts
+++ b/src/main/core/pty/persist-dropped-blob.ts
@@ -108,6 +108,10 @@ export async function persistDroppedBlobBytes(args: {
     name: args.name,
     mimeType: args.mimeType,
   });
+  if (normalized.bytes.byteLength > MAX_DROPPED_BLOB_BYTES) {
+    throw new Error(`Dropped file is too large (${normalized.bytes.byteLength} bytes)`);
+  }
+
   const safe = sanitizeDroppedBlobName(args.name?.replace(/\.[^.]+$/, ''));
   const filename = `${DROPPED_BLOB_FILENAME_PREFIX}${randomUUID()}${safe ? `-${safe}` : ''}${normalized.ext}`;
   const fullPath = join(app.getPath('temp'), filename);

--- a/src/main/core/pty/persist-dropped-blob.ts
+++ b/src/main/core/pty/persist-dropped-blob.ts
@@ -1,0 +1,124 @@
+import { execFile } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { basename, extname, join } from 'node:path';
+import { promisify } from 'node:util';
+import { app, clipboard, nativeImage } from 'electron';
+
+export const MAX_DROPPED_BLOB_BYTES = 50 * 1024 * 1024;
+
+const execFileAsync = promisify(execFile);
+
+const MIME_TO_EXT: Record<string, string> = {
+  'image/png': '.png',
+  'image/jpeg': '.jpg',
+  'image/jpg': '.jpg',
+  'image/gif': '.gif',
+  'image/webp': '.webp',
+  'image/svg+xml': '.svg',
+  'image/bmp': '.bmp',
+  'image/tiff': '.tiff',
+  'image/heic': '.heic',
+  'image/heif': '.heif',
+};
+
+export function sanitizeDroppedBlobName(name: string | undefined): string {
+  if (!name) return '';
+  const base = basename(name).replace(/[^A-Za-z0-9._-]/g, '_');
+  return base.slice(0, 64);
+}
+
+export function inferDroppedBlobExtension(
+  name: string | undefined,
+  mimeType: string | undefined
+): string {
+  const fromName = name ? extname(name).toLowerCase() : '';
+  if (fromName) return fromName;
+  if (mimeType && MIME_TO_EXT[mimeType.toLowerCase()]) return MIME_TO_EXT[mimeType.toLowerCase()];
+  return '.bin';
+}
+
+export function isHeicLike(args: { name?: string; mimeType?: string; ext?: string }): boolean {
+  const ext = args.ext ?? inferDroppedBlobExtension(args.name, args.mimeType);
+  if (ext === '.heic' || ext === '.heif') return true;
+  const mime = args.mimeType?.toLowerCase() ?? '';
+  return mime.includes('heic') || mime.includes('heif');
+}
+
+/**
+ * Claude Code and most vision models cannot read HEIC directly. macOS clipboard
+ * and drag sources often supply HEIC — convert to PNG before persisting.
+ */
+export async function normalizeDroppedImageBytes(
+  bytes: Uint8Array,
+  args: { name?: string; mimeType?: string }
+): Promise<{ bytes: Uint8Array; ext: string }> {
+  const ext = inferDroppedBlobExtension(args.name, args.mimeType);
+  if (!isHeicLike({ ...args, ext })) {
+    return { bytes, ext };
+  }
+
+  const image = nativeImage.createFromBuffer(Buffer.from(bytes));
+  if (!image.isEmpty()) {
+    const png = image.toPNG();
+    if (png.byteLength > 0) return { bytes: new Uint8Array(png), ext: '.png' };
+  }
+
+  return { bytes: await convertHeicLikeBytesToPng(bytes, ext), ext: '.png' };
+}
+
+async function convertHeicLikeBytesToPng(bytes: Uint8Array, ext: string): Promise<Uint8Array> {
+  if (process.platform !== 'darwin') {
+    throw new Error('HEIC/HEIF image conversion is only supported on macOS');
+  }
+
+  const tempDir = await mkdtemp(join(app.getPath('temp'), 'emdash-heic-'));
+  const inputPath = join(tempDir, `input${ext === '.heif' ? '.heif' : '.heic'}`);
+  const outputPath = join(tempDir, 'output.png');
+
+  try {
+    await writeFile(inputPath, bytes);
+    await execFileAsync('/usr/bin/sips', ['-s', 'format', 'png', inputPath, '--out', outputPath]);
+    const png = await readFile(outputPath);
+    if (png.byteLength === 0) throw new Error('sips produced an empty PNG');
+    return new Uint8Array(png);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    throw new Error(`Failed to convert HEIC/HEIF image to PNG: ${message}`);
+  } finally {
+    await rm(tempDir, { recursive: true, force: true });
+  }
+}
+
+export async function persistDroppedBlobBytes(args: {
+  bytes: Uint8Array;
+  name?: string;
+  mimeType?: string;
+}): Promise<string> {
+  if (args.bytes.byteLength > MAX_DROPPED_BLOB_BYTES) {
+    throw new Error(`Dropped file is too large (${args.bytes.byteLength} bytes)`);
+  }
+
+  const normalized = await normalizeDroppedImageBytes(args.bytes, {
+    name: args.name,
+    mimeType: args.mimeType,
+  });
+  const safe = sanitizeDroppedBlobName(args.name?.replace(/\.[^.]+$/, ''));
+  const filename = `emdash-drop-${randomUUID()}${safe ? `-${safe}` : ''}${normalized.ext}`;
+  const fullPath = join(app.getPath('temp'), filename);
+  await writeFile(fullPath, normalized.bytes);
+  return fullPath;
+}
+
+/** Read a raster image from the OS clipboard and persist it as PNG. */
+export async function persistClipboardImagePath(): Promise<string | null> {
+  const image = clipboard.readImage();
+  if (image.isEmpty()) return null;
+  const png = image.toPNG();
+  if (png.byteLength === 0) return null;
+  return persistDroppedBlobBytes({
+    bytes: new Uint8Array(png),
+    name: 'paste.png',
+    mimeType: 'image/png',
+  });
+}

--- a/src/main/core/pty/persist-dropped-blob.ts
+++ b/src/main/core/pty/persist-dropped-blob.ts
@@ -1,13 +1,18 @@
 import { execFile } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { rmSync } from 'node:fs';
+import { mkdtemp, readdir, readFile, rm, stat, writeFile } from 'node:fs/promises';
 import { basename, extname, join } from 'node:path';
 import { promisify } from 'node:util';
 import { app, clipboard, nativeImage } from 'electron';
 
 export const MAX_DROPPED_BLOB_BYTES = 50 * 1024 * 1024;
+export const DROPPED_BLOB_FILENAME_PREFIX = 'emdash-drop-';
+export const DROPPED_BLOB_MAX_AGE_MS = 24 * 60 * 60 * 1000;
 
 const execFileAsync = promisify(execFile);
+const persistedDroppedBlobPaths = new Set<string>();
+let cleanupRegistered = false;
 
 const MIME_TO_EXT: Record<string, string> = {
   'image/png': '.png',
@@ -104,10 +109,52 @@ export async function persistDroppedBlobBytes(args: {
     mimeType: args.mimeType,
   });
   const safe = sanitizeDroppedBlobName(args.name?.replace(/\.[^.]+$/, ''));
-  const filename = `emdash-drop-${randomUUID()}${safe ? `-${safe}` : ''}${normalized.ext}`;
+  const filename = `${DROPPED_BLOB_FILENAME_PREFIX}${randomUUID()}${safe ? `-${safe}` : ''}${normalized.ext}`;
   const fullPath = join(app.getPath('temp'), filename);
   await writeFile(fullPath, normalized.bytes);
+  trackPersistedDroppedBlob(fullPath);
   return fullPath;
+}
+
+function trackPersistedDroppedBlob(path: string): void {
+  persistedDroppedBlobPaths.add(path);
+  if (cleanupRegistered) return;
+  cleanupRegistered = true;
+  app.once('will-quit', () => {
+    cleanupPersistedDroppedBlobsSync();
+  });
+}
+
+function cleanupPersistedDroppedBlobsSync(): void {
+  for (const path of persistedDroppedBlobPaths) {
+    rmSync(path, { force: true });
+    persistedDroppedBlobPaths.delete(path);
+  }
+}
+
+export async function cleanupPersistedDroppedBlobs(): Promise<void> {
+  const paths = [...persistedDroppedBlobPaths];
+  await Promise.all(
+    paths.map(async (path) => {
+      await rm(path, { force: true });
+      persistedDroppedBlobPaths.delete(path);
+    })
+  );
+}
+
+export async function cleanupExpiredDroppedBlobs(now = Date.now()): Promise<void> {
+  const tempDir = app.getPath('temp');
+  const entries = await readdir(tempDir);
+  await Promise.all(
+    entries.map(async (entry) => {
+      if (!entry.startsWith(DROPPED_BLOB_FILENAME_PREFIX)) return;
+      const path = join(tempDir, entry);
+      const info = await stat(path).catch(() => null);
+      if (!info?.isFile()) return;
+      if (now - info.mtimeMs < DROPPED_BLOB_MAX_AGE_MS) return;
+      await rm(path, { force: true });
+    })
+  );
 }
 
 /** Read a raster image from the OS clipboard and persist it as PNG. */

--- a/src/renderer/lib/pty/pty-pane.tsx
+++ b/src/renderer/lib/pty/pty-pane.tsx
@@ -56,8 +56,8 @@ async function injectTerminalImagePaths(args: {
   const platform = args.remoteConnectionId
     ? 'linux'
     : ((await rpc.app.getPlatform()) as NodeJS.Platform);
-  const payload = await buildTerminalImageInjection(paths, platform);
-  args.sendInput(`${payload} `);
+  const payload = buildTerminalImageInjection(paths, platform);
+  args.sendInput(`${payload} `, { track: false });
   args.focus();
 }
 
@@ -67,7 +67,20 @@ async function pasteClipboardImageOrText(args: {
   sendInput: TerminalInputHelpers['sendInput'];
   focus: TerminalInputHelpers['focus'];
   fallbackText?: string;
+  preferText?: boolean;
 }): Promise<void> {
+  if (args.preferText) {
+    try {
+      const text = await navigator.clipboard.readText();
+      if (text) {
+        args.sendInput(text);
+        return;
+      }
+    } catch {
+      // Clipboard text read denied or unavailable; try the image path below.
+    }
+  }
+
   try {
     const result = await rpc.pty.persistClipboardImage();
     if (result.success && result.data.path) {
@@ -120,6 +133,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
           remoteConnectionId,
           focus,
           sendInput,
+          preferText: true,
         });
       },
       [remoteConnectionId, sessionId]
@@ -257,7 +271,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
           }}
           onClick={handleFocus}
           onMouseDown={handleFocus}
-          onPaste={handlePaste}
+          onPasteCapture={handlePaste}
           onDragOver={(event) => event.preventDefault()}
           onDrop={handleDrop}
         />

--- a/src/renderer/lib/pty/pty-pane.tsx
+++ b/src/renderer/lib/pty/pty-pane.tsx
@@ -1,11 +1,15 @@
-import React, { forwardRef, useImperativeHandle, useRef } from 'react';
-import { getDraggedFilePaths } from '@renderer/lib/drag-files';
+import React, { forwardRef, useCallback, useImperativeHandle, useRef } from 'react';
 import { rpc } from '@renderer/lib/ipc';
 import { log } from '@renderer/utils/logger';
 import { cn } from '@renderer/utils/utils';
-import { pastePromptInjection } from './prompt-injection';
 import type { FrontendPty, SessionTheme } from './pty';
-import { usePty } from './use-pty';
+import { resolveDroppedFile } from './terminal-image-injection';
+import {
+  buildTerminalImageInjection,
+  clipboardDataMayContainImage,
+  extractClipboardImageFiles,
+} from './terminal-image-paths';
+import { type PasteFromClipboardHandler, usePty } from './use-pty';
 
 type Props = {
   /**
@@ -17,7 +21,7 @@ type Props = {
   className?: string;
   contentFilter?: string;
   mapShiftEnterToCtrlJ?: boolean;
-  /** SSH connection ID — used for remote file drag-and-drop only. */
+  /** SSH connection ID — used for remote file drag-and-drop and image paste. */
   remoteConnectionId?: string;
   themeOverride?: SessionTheme['override'];
   onActivity?: () => void;
@@ -26,6 +30,66 @@ type Props = {
   onEnterPress?: (message: string) => void;
   onInterruptPress?: () => void;
 };
+
+type TerminalInputHelpers = Parameters<PasteFromClipboardHandler>[0];
+
+async function injectTerminalImagePaths(args: {
+  paths: string[];
+  sessionId: string;
+  remoteConnectionId: string | undefined;
+  sendInput: TerminalInputHelpers['sendInput'];
+  focus: TerminalInputHelpers['focus'];
+}): Promise<void> {
+  if (args.paths.length === 0) return;
+
+  let paths = args.paths;
+  if (args.remoteConnectionId) {
+    const result = await rpc.pty.uploadFiles({ sessionId: args.sessionId, localPaths: paths });
+    if (!result.success) {
+      log.warn('SSH file transfer failed', { error: result.error });
+      return;
+    }
+    paths = result.data.remotePaths;
+    if (paths.length === 0) return;
+  }
+
+  const platform = args.remoteConnectionId
+    ? 'linux'
+    : ((await rpc.app.getPlatform()) as NodeJS.Platform);
+  const payload = await buildTerminalImageInjection(paths, platform);
+  args.sendInput(`${payload} `);
+  args.focus();
+}
+
+async function pasteClipboardImageOrText(args: {
+  sessionId: string;
+  remoteConnectionId: string | undefined;
+  sendInput: TerminalInputHelpers['sendInput'];
+  focus: TerminalInputHelpers['focus'];
+  fallbackText?: string;
+}): Promise<void> {
+  try {
+    const result = await rpc.pty.persistClipboardImage();
+    if (result.success && result.data.path) {
+      await injectTerminalImagePaths({ ...args, paths: [result.data.path] });
+      return;
+    }
+  } catch (error) {
+    log.warn('Terminal clipboard image paste failed', { error });
+  }
+
+  if (args.fallbackText !== undefined) {
+    if (args.fallbackText) args.sendInput(args.fallbackText);
+    return;
+  }
+
+  try {
+    const text = await navigator.clipboard.readText();
+    if (text) args.sendInput(text);
+  } catch {
+    // Clipboard read denied or unavailable.
+  }
+}
 
 const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
   (
@@ -49,6 +113,18 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
 
     const theme: SessionTheme = { override: themeOverride };
 
+    const handleSystemPaste = useCallback<PasteFromClipboardHandler>(
+      ({ focus, sendInput }) => {
+        void pasteClipboardImageOrText({
+          sessionId,
+          remoteConnectionId,
+          focus,
+          sendInput,
+        });
+      },
+      [remoteConnectionId, sessionId]
+    );
+
     const { focus, sendInput } = usePty(
       {
         sessionId,
@@ -60,47 +136,94 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
         onFirstMessage,
         onEnterPress,
         onInterruptPress,
+        onPasteFromClipboard: handleSystemPaste,
       },
       containerRef
     );
 
     useImperativeHandle(ref, () => ({ focus }), [focus]);
 
+    const injectImagePaths = useCallback(
+      async (paths: string[]) => {
+        await injectTerminalImagePaths({
+          paths,
+          sessionId,
+          remoteConnectionId,
+          focus,
+          sendInput,
+        });
+      },
+      [focus, remoteConnectionId, sendInput, sessionId]
+    );
+
+    const injectImageFiles = useCallback(
+      async (files: File[]): Promise<boolean> => {
+        const resolved = await Promise.all(files.map((file) => resolveDroppedFile(file)));
+        const paths = resolved.filter((path): path is string => Boolean(path));
+        if (paths.length === 0) return false;
+        await injectImagePaths(paths);
+        return true;
+      },
+      [injectImagePaths]
+    );
+
     const handleFocus = () => {
       focus();
     };
 
+    const handlePaste = useCallback(
+      (event: React.ClipboardEvent<HTMLDivElement>) => {
+        const clipboardData = event.clipboardData;
+        const fallbackText = clipboardData?.getData('text/plain') ?? '';
+        const imageFiles = extractClipboardImageFiles(clipboardData);
+        if (imageFiles.length > 0) {
+          event.preventDefault();
+          void (async () => {
+            try {
+              const injected = await injectImageFiles(imageFiles);
+              if (injected) return;
+              await pasteClipboardImageOrText({
+                sessionId,
+                remoteConnectionId,
+                focus,
+                sendInput,
+                fallbackText,
+              });
+            } catch (error) {
+              log.warn('Terminal image paste failed', { error });
+            }
+          })();
+          return;
+        }
+
+        if (!clipboardDataMayContainImage(clipboardData)) return;
+
+        event.preventDefault();
+        void pasteClipboardImageOrText({
+          sessionId,
+          remoteConnectionId,
+          focus,
+          sendInput,
+          fallbackText,
+        });
+      },
+      [focus, injectImageFiles, remoteConnectionId, sendInput, sessionId]
+    );
+
     const handleDrop: React.DragEventHandler<HTMLDivElement> = (event) => {
       try {
         event.preventDefault();
-        const paths = getDraggedFilePaths(event.dataTransfer);
-        if (paths.length === 0) return;
+        const dt = event.dataTransfer;
+        if (!dt?.files?.length) return;
+
+        const files = Array.from(dt.files);
 
         void (async () => {
           try {
-            if (remoteConnectionId) {
-              try {
-                const result = await rpc.pty.uploadFiles({ sessionId, localPaths: paths });
-                if (result.success && result.data?.remotePaths) {
-                  await pastePromptInjection({
-                    providerId: undefined,
-                    text: formatDroppedPaths(result.data.remotePaths),
-                    forceBracketedPaste: true,
-                    sendInput: async (data) => sendInput(`${data} `),
-                  });
-                }
-              } catch (error) {
-                log.warn('SSH file transfer failed', { error });
-              }
-            } else {
-              await pastePromptInjection({
-                providerId: undefined,
-                text: formatDroppedPaths(paths),
-                forceBracketedPaste: true,
-                sendInput: async (data) => sendInput(`${data} `),
-              });
-            }
-            focus();
+            const resolved = await Promise.all(files.map((file) => resolveDroppedFile(file)));
+            const paths = resolved.filter((path): path is string => Boolean(path));
+            if (paths.length === 0) return;
+            await injectImagePaths(paths);
           } catch (error) {
             log.warn('Terminal drop failed', { error });
           }
@@ -134,6 +257,7 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
           }}
           onClick={handleFocus}
           onMouseDown={handleFocus}
+          onPaste={handlePaste}
           onDragOver={(event) => event.preventDefault()}
           onDrop={handleDrop}
         />
@@ -141,10 +265,6 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
     );
   }
 );
-
-function formatDroppedPaths(paths: string[]): string {
-  return paths.map((path) => `'${path.replace(/'/g, "'\\''")}'`).join(' ');
-}
 
 PtyPaneComponent.displayName = 'TerminalPane';
 

--- a/src/renderer/lib/pty/terminal-image-injection.ts
+++ b/src/renderer/lib/pty/terminal-image-injection.ts
@@ -1,0 +1,23 @@
+import { rpc } from '@renderer/lib/ipc';
+import { log } from '@renderer/utils/logger';
+import { isHeicLikeFile, isUnstableDropPath } from './terminal-image-paths';
+
+export async function resolveDroppedFile(file: File): Promise<string | null> {
+  const originalPath = window.electronAPI.getPathForFile(file).trim();
+  if (originalPath && !isUnstableDropPath(originalPath) && !isHeicLikeFile(file)) {
+    return originalPath;
+  }
+  try {
+    const bytes = new Uint8Array(await file.arrayBuffer());
+    const result = await rpc.pty.persistDroppedBlob({
+      bytes,
+      name: file.name,
+      mimeType: file.type,
+    });
+    if (result.success) return result.data.path;
+    log.warn('Dropped file persist failed', { error: result.error });
+  } catch (error) {
+    log.warn('Dropped file arrayBuffer failed', { error });
+  }
+  return null;
+}

--- a/src/renderer/lib/pty/terminal-image-injection.ts
+++ b/src/renderer/lib/pty/terminal-image-injection.ts
@@ -2,10 +2,16 @@ import { rpc } from '@renderer/lib/ipc';
 import { log } from '@renderer/utils/logger';
 import { isHeicLikeFile, isUnstableDropPath } from './terminal-image-paths';
 
+const MAX_DROPPED_BLOB_BYTES = 50 * 1024 * 1024;
+
 export async function resolveDroppedFile(file: File): Promise<string | null> {
   const originalPath = window.electronAPI.getPathForFile(file).trim();
   if (originalPath && !isUnstableDropPath(originalPath) && !isHeicLikeFile(file)) {
     return originalPath;
+  }
+  if (file.size > MAX_DROPPED_BLOB_BYTES) {
+    log.warn('Dropped file is too large to persist', { size: file.size, name: file.name });
+    return null;
   }
   try {
     const bytes = new Uint8Array(await file.arrayBuffer());

--- a/src/renderer/lib/pty/terminal-image-paths.ts
+++ b/src/renderer/lib/pty/terminal-image-paths.ts
@@ -3,7 +3,7 @@
 // drop/paste completes, before Claude/Codex can read them.
 export function isUnstableDropPath(path: string): boolean {
   if (!path) return true;
-  if (/^\/(?:private\/)?var\/folders\//.test(path)) return true;
+  if (/^\/(?:private\/)?var\/folders\/.*\/T\/Drops\//.test(path)) return true;
   if (/[\\/](?:tmp|temp)[\\/]/i.test(path) && /(?:drop|chromium|electron)/i.test(path)) {
     return true;
   }
@@ -63,10 +63,7 @@ export function wrapAsBracketedPaste(text: string): string {
   return `\x1b[200~${text}\x1b[201~`;
 }
 
-export async function buildTerminalImageInjection(
-  paths: string[],
-  platform: NodeJS.Platform
-): Promise<string> {
+export function buildTerminalImageInjection(paths: string[], platform: NodeJS.Platform): string {
   const formatted = formatTerminalImagePaths(paths, platform);
   return wrapAsBracketedPaste(formatted);
 }

--- a/src/renderer/lib/pty/terminal-image-paths.ts
+++ b/src/renderer/lib/pty/terminal-image-paths.ts
@@ -1,0 +1,72 @@
+// Chromium hands out drag-temp paths under the OS temp tree (e.g.
+// /var/folders/.../T/Drops/... on macOS). Those files are deleted right after
+// drop/paste completes, before Claude/Codex can read them.
+export function isUnstableDropPath(path: string): boolean {
+  if (!path) return true;
+  if (/^\/(?:private\/)?var\/folders\//.test(path)) return true;
+  if (/[\\/](?:tmp|temp)[\\/]/i.test(path) && /(?:drop|chromium|electron)/i.test(path)) {
+    return true;
+  }
+  if (/[\\/]AppData[\\/]Local[\\/]Temp[\\/]/i.test(path)) return true;
+  return false;
+}
+
+export function isClipboardImageFile(file: File): boolean {
+  if (file.type.startsWith('image/')) return true;
+  return isHeicLikeFile(file);
+}
+
+export function isHeicLikeFile(file: File): boolean {
+  const type = file.type.toLowerCase();
+  if (type.includes('heic') || type.includes('heif')) return true;
+  return /\.(heic|heif)$/i.test(file.name);
+}
+
+export function extractClipboardImageFiles(clipboardData: DataTransfer | null): File[] {
+  if (!clipboardData?.items) return [];
+  const imageFiles: File[] = [];
+  for (const item of clipboardData.items) {
+    if (item.kind !== 'file') continue;
+    const file = item.getAsFile();
+    if (file && isClipboardImageFile(file)) imageFiles.push(file);
+  }
+  return imageFiles;
+}
+
+export function clipboardDataMayContainImage(clipboardData: DataTransfer | null): boolean {
+  if (!clipboardData) return false;
+  if (extractClipboardImageFiles(clipboardData).length > 0) return true;
+  return clipboardData.types.some((type) => {
+    const lower = type.toLowerCase();
+    return lower.startsWith('image/') || lower.includes('heic') || lower.includes('heif');
+  });
+}
+
+// POSIX backslash escaping keeps the path a single shell token without quote
+// literals that break Claude Code image detection.
+export function escapePathForTerminal(path: string): string {
+  return path.replace(/([\s'"\\$`!*?()[\]{}|;<>&#~])/g, '\\$1');
+}
+
+export function escapeWindowsPathForTerminal(path: string): string {
+  return `"${path.replace(/"/g, '""')}"`;
+}
+
+export function formatTerminalImagePaths(paths: string[], platform: NodeJS.Platform): string {
+  if (platform === 'win32') {
+    return paths.map(escapeWindowsPathForTerminal).join(' ');
+  }
+  return paths.map(escapePathForTerminal).join(' ');
+}
+
+export function wrapAsBracketedPaste(text: string): string {
+  return `\x1b[200~${text}\x1b[201~`;
+}
+
+export async function buildTerminalImageInjection(
+  paths: string[],
+  platform: NodeJS.Platform
+): Promise<string> {
+  const formatted = formatTerminalImagePaths(paths, platform);
+  return wrapAsBracketedPaste(formatted);
+}

--- a/src/renderer/lib/pty/use-pty.ts
+++ b/src/renderer/lib/pty/use-pty.ts
@@ -71,6 +71,7 @@ export interface UsePtyOptions {
   onFirstMessage?: (message: string) => void;
   onEnterPress?: (message: string) => void;
   onInterruptPress?: () => void;
+  onPasteFromClipboard?: PasteFromClipboardHandler;
 }
 
 export interface UseTerminalReturn {
@@ -78,6 +79,11 @@ export interface UseTerminalReturn {
   setTheme: (theme: SessionTheme) => void;
   sendInput: (data: string, options?: { track?: boolean }) => void;
 }
+
+export type PasteFromClipboardHandler = (helpers: {
+  focus: UseTerminalReturn['focus'];
+  sendInput: UseTerminalReturn['sendInput'];
+}) => void;
 
 /**
  * React hook that manages a full xterm.js terminal instance attached to
@@ -111,6 +117,7 @@ export function usePty(
     onFirstMessage,
     onEnterPress,
     onInterruptPress,
+    onPasteFromClipboard,
   } = options;
 
   // Stable refs for callbacks so the effect doesn't re-run on every render.
@@ -124,6 +131,8 @@ export function usePty(
   onEnterPressRef.current = onEnterPress;
   const onInterruptPressRef = useRef(onInterruptPress);
   onInterruptPressRef.current = onInterruptPress;
+  const onPasteFromClipboardRef = useRef(onPasteFromClipboard);
+  onPasteFromClipboardRef.current = onPasteFromClipboard;
   const themeRef = useRef(theme);
   themeRef.current = theme;
 
@@ -294,13 +303,21 @@ export function usePty(
   );
 
   const pasteFromClipboard = useCallback(() => {
-    navigator.clipboard
-      .readText()
-      .then((text) => {
+    const customPasteFromClipboard = onPasteFromClipboardRef.current;
+    if (customPasteFromClipboard) {
+      customPasteFromClipboard({ focus, sendInput });
+      return;
+    }
+
+    void (async () => {
+      try {
+        const text = await navigator.clipboard.readText();
         if (text) sendInput(text);
-      })
-      .catch(() => {});
-  }, [sendInput]);
+      } catch {
+        // Clipboard read denied or unavailable.
+      }
+    })();
+  }, [focus, sendInput]);
 
   // ─── Main effect: mount terminal once per sessionId ────────────────────────
 

--- a/src/renderer/tests/terminal-image-injection.test.ts
+++ b/src/renderer/tests/terminal-image-injection.test.ts
@@ -11,6 +11,7 @@ import {
 describe('terminal-image-injection', () => {
   it('detects unstable Chromium drop paths', () => {
     expect(isUnstableDropPath('/var/folders/xx/T/Drops/image.png')).toBe(true);
+    expect(isUnstableDropPath('/var/folders/xx/T/emdash-drop-123-image.png')).toBe(false);
     expect(isUnstableDropPath('/Users/me/Desktop/shot.png')).toBe(false);
   });
 

--- a/src/renderer/tests/terminal-image-injection.test.ts
+++ b/src/renderer/tests/terminal-image-injection.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  escapePathForTerminal,
+  escapeWindowsPathForTerminal,
+  formatTerminalImagePaths,
+  isHeicLikeFile,
+  isUnstableDropPath,
+  wrapAsBracketedPaste,
+} from '@renderer/lib/pty/terminal-image-paths';
+
+describe('terminal-image-injection', () => {
+  it('detects unstable Chromium drop paths', () => {
+    expect(isUnstableDropPath('/var/folders/xx/T/Drops/image.png')).toBe(true);
+    expect(isUnstableDropPath('/Users/me/Desktop/shot.png')).toBe(false);
+  });
+
+  it('escapes spaces without wrapping in quotes', () => {
+    expect(escapePathForTerminal('/tmp/my image.png')).toBe('/tmp/my\\ image.png');
+  });
+
+  it('quotes Windows paths instead of POSIX-escaping spaces', () => {
+    expect(escapeWindowsPathForTerminal('C:\\Users\\me\\my image.png')).toBe(
+      '"C:\\Users\\me\\my image.png"'
+    );
+  });
+
+  it('detects HEIC-like files without relying on image MIME types', () => {
+    expect(isHeicLikeFile(new File([], 'photo.heic', { type: '' }))).toBe(true);
+    expect(isHeicLikeFile(new File([], 'photo.png', { type: 'image/png' }))).toBe(false);
+  });
+
+  it('wraps formatted paths for bracketed paste', () => {
+    const payload = wrapAsBracketedPaste(formatTerminalImagePaths(['/tmp/a.png'], 'darwin'));
+    expect(payload).toBe('\x1b[200~/tmp/a.png\x1b[201~');
+    expect(payload.charCodeAt(0)).toBe(27);
+  });
+});


### PR DESCRIPTION
# summary
- persistent terminal images as stable tmp files
- convert heic/heif images to png 
- fall back to native clipboard images

https://streamable.com/s87pie (ignore my macbook dying usually it doesnt take that long lol)