### PR TITLE
ENG-1196: Validate SSH modal input whitespace

### DIFF
--- a/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -144,6 +144,12 @@ export function AddSshConnModal({
     };
   };
 
+  const validateConnectionForm = async (): Promise<boolean> => {
+    await form.validateAllFields('submit');
+    await form.validate('submit');
+    return form.state.isValid;
+  };
+
   const sshConfigHostsQuery = useSshConfigHosts();
   const resolvedSshConfigHostQuery = useSshConfigHost(selectedSshConfigAlias);
   const sshConfigHosts = sshConfigHostsQuery.data ?? EMPTY_SSH_CONFIG_HOSTS;
@@ -192,9 +198,15 @@ export function AddSshConnModal({
   };
 
   const handleTestConnection = async () => {
-    setTestState('testing');
     setTestResult(null);
     setShowDebugLogs(false);
+    const isValid = await validateConnectionForm();
+    if (!isValid) {
+      setTestState('idle');
+      return;
+    }
+
+    setTestState('testing');
     try {
       const result = await sshConnections.testConnection(buildTestConfig());
       setTestResult(result);

--- a/src/renderer/lib/components/ssh-connection-form-schema.test.ts
+++ b/src/renderer/lib/components/ssh-connection-form-schema.test.ts
@@ -21,6 +21,55 @@ const baseValues: SshConnectionFormValues = {
 };
 
 describe('sshConnectionFormSchema', () => {
+  it.each([
+    ['name', ' Conn', 'Connection name cannot start or end with spaces'],
+    ['host', 'dev.internal ', 'Host cannot start or end with spaces'],
+    ['username', ' alice', 'Username cannot start or end with spaces'],
+    ['privateKeyPath', '~/.ssh/id_rsa ', 'Private key path cannot start or end with spaces'],
+    ['sshConfigAlias', ' corp-dev', 'SSH config alias cannot start or end with spaces'],
+    ['proxyJump', 'bastion ', 'ProxyJump cannot start or end with spaces'],
+  ] as const)('rejects leading or trailing spaces in %s', (field, value, message) => {
+    const result = sshConnectionFormSchema.safeParse({
+      ...baseValues,
+      authType: field === 'privateKeyPath' ? 'key' : baseValues.authType,
+      privateKeyPath: field === 'privateKeyPath' ? value : baseValues.privateKeyPath,
+      [field]: value,
+    });
+
+    expect(result.success).toBe(false);
+    expect(result.error?.issues).toEqual(
+      expect.arrayContaining([expect.objectContaining({ path: [field], message })])
+    );
+  });
+
+  it('allows spaces inside fields that can contain composite values', () => {
+    expect(
+      sshConnectionFormSchema.safeParse({
+        ...baseValues,
+        name: 'Staging Server',
+        proxyJump: 'alice@bastion:2222,bob@internal-bastion:2222',
+      }).success
+    ).toBe(true);
+  });
+
+  it('does not reject leading or trailing spaces in password credentials', () => {
+    expect(
+      sshConnectionFormSchema.safeParse({
+        ...baseValues,
+        authType: 'password',
+        password: ' secret ',
+      }).success
+    ).toBe(true);
+    expect(
+      sshConnectionFormSchema.safeParse({
+        ...baseValues,
+        authType: 'key',
+        privateKeyPath: '~/.ssh/id_rsa',
+        passphrase: ' secret ',
+      }).success
+    ).toBe(true);
+  });
+
   it('allows alias-backed key auth without a manually entered private key path', () => {
     expect(
       sshConnectionFormSchema.safeParse({

--- a/src/renderer/lib/components/ssh-connection-form-schema.ts
+++ b/src/renderer/lib/components/ssh-connection-form-schema.ts
@@ -3,6 +3,22 @@ import * as z from 'zod';
 const manualHostPattern = /^[a-zA-Z0-9._\-[\]:]+$/;
 const sshAliasPattern = /^[A-Za-z0-9._@%+:/[\]-]+$/;
 
+function hasLeadingOrTrailingWhitespace(value: string): boolean {
+  return value !== value.trim();
+}
+
+function addWhitespaceIssue(
+  ctx: z.RefinementCtx,
+  path: 'name' | 'host' | 'username' | 'privateKeyPath' | 'sshConfigAlias' | 'proxyJump',
+  label: string
+): void {
+  ctx.addIssue({
+    code: z.ZodIssueCode.custom,
+    message: `${label} cannot start or end with spaces`,
+    path: [path],
+  });
+}
+
 export const sshConnectionFormSchema = z
   .object({
     name: z.string().min(1, 'Name is required'),
@@ -24,15 +40,37 @@ export const sshConnectionFormSchema = z
     isEditing: z.boolean(),
   })
   .superRefine((val, ctx) => {
+    if (hasLeadingOrTrailingWhitespace(val.name)) {
+      addWhitespaceIssue(ctx, 'name', 'Connection name');
+    }
+    if (hasLeadingOrTrailingWhitespace(val.host)) {
+      addWhitespaceIssue(ctx, 'host', 'Host');
+    }
+    if (hasLeadingOrTrailingWhitespace(val.username)) {
+      addWhitespaceIssue(ctx, 'username', 'Username');
+    }
+    if (hasLeadingOrTrailingWhitespace(val.privateKeyPath)) {
+      addWhitespaceIssue(ctx, 'privateKeyPath', 'Private key path');
+    }
+    if (hasLeadingOrTrailingWhitespace(val.sshConfigAlias)) {
+      addWhitespaceIssue(ctx, 'sshConfigAlias', 'SSH config alias');
+    }
+    if (hasLeadingOrTrailingWhitespace(val.proxyJump)) {
+      addWhitespaceIssue(ctx, 'proxyJump', 'ProxyJump');
+    }
+
     if (val.sshConfigAlias) {
-      if (val.sshConfigAlias.startsWith('-') || !sshAliasPattern.test(val.sshConfigAlias)) {
+      if (
+        !hasLeadingOrTrailingWhitespace(val.sshConfigAlias) &&
+        (val.sshConfigAlias.startsWith('-') || !sshAliasPattern.test(val.sshConfigAlias))
+      ) {
         ctx.addIssue({
           code: z.ZodIssueCode.custom,
           message: 'Invalid SSH config alias',
           path: ['sshConfigAlias'],
         });
       }
-    } else if (!manualHostPattern.test(val.host)) {
+    } else if (!hasLeadingOrTrailingWhitespace(val.host) && !manualHostPattern.test(val.host)) {
       ctx.addIssue({
         code: z.ZodIssueCode.custom,
         message: 'Invalid hostname or IP address',


### PR DESCRIPTION
## Summary
- Reject leading and trailing spaces in SSH modal fields that feed connection metadata.
- Run the same validation before Test Connection so invalid input cannot bypass Save validation.
- Preserve password and passphrase values as entered.

## Validation
- pnpm run format
- pnpm run lint
- pnpm run typecheck
- pnpm run test
