### PR TITLE
feat(editor): compact single-child folder chains in file tree

### DIFF
--- a/src/renderer/features/tasks/editor/compacted-path-label.test.ts
+++ b/src/renderer/features/tasks/editor/compacted-path-label.test.ts
@@ -1,0 +1,72 @@
+import { describe, expect, it } from 'vitest';
+import { pickCompactedDisplay } from './compacted-path-label';
+
+const measureByLength = (text: string) => text.length;
+
+describe('pickCompactedDisplay', () => {
+  it('returns the joined path when every segment fits', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 35, measureByLength)
+    ).toBe('dossier1/dossier2/dossier3/dossier4');
+  });
+
+  it('drops the innermost middle segment first', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 30, measureByLength)
+    ).toBe('dossier1/dossier2/.../dossier4');
+  });
+
+  it('partially truncates the next-to-last front segment', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 24, measureByLength)
+    ).toBe('dossier1/dos.../dossier4');
+  });
+
+  it('fully drops the next-to-last front segment when partials no longer fit', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 21, measureByLength)
+    ).toBe('dossier1/.../dossier4');
+  });
+
+  it('partially truncates the first segment before dropping it', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 15, measureByLength)
+    ).toBe('dos.../dossier4');
+  });
+
+  it('drops every front segment when only `.../last` fits', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 12, measureByLength)
+    ).toBe('.../dossier4');
+  });
+
+  it('returns the last segment unprefixed when even `.../last` overflows', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 11, measureByLength)
+    ).toBe('dossier4');
+  });
+
+  it('truncates the last segment itself as a final fallback', () => {
+    expect(
+      pickCompactedDisplay(['dossier1', 'dossier2', 'dossier3', 'dossier4'], 7, measureByLength)
+    ).toBe('doss...');
+  });
+
+  it('handles a 3-segment chain by dropping the middle segment', () => {
+    expect(pickCompactedDisplay(['src', 'lib', 'core'], 12, measureByLength)).toBe('src/lib/core');
+    expect(pickCompactedDisplay(['src', 'lib', 'core'], 11, measureByLength)).toBe('sr.../core');
+  });
+
+  it('handles a 2-segment chain by skipping the inner partial-truncate', () => {
+    expect(pickCompactedDisplay(['alpha', 'beta'], 10, measureByLength)).toBe('alpha/beta');
+    expect(pickCompactedDisplay(['alpha', 'beta'], 8, measureByLength)).toBe('.../beta');
+  });
+
+  it('returns the only segment unmodified when it fits', () => {
+    expect(pickCompactedDisplay(['solo'], 10, measureByLength)).toBe('solo');
+  });
+
+  it('returns an empty string for an empty input', () => {
+    expect(pickCompactedDisplay([], 10, measureByLength)).toBe('');
+  });
+});

--- a/src/renderer/features/tasks/editor/compacted-path-label.tsx
+++ b/src/renderer/features/tasks/editor/compacted-path-label.tsx
@@ -1,0 +1,103 @@
+import { useLayoutEffect, useMemo, useRef, useState } from 'react';
+
+export type Measure = (text: string) => number;
+
+export function pickCompactedDisplay(
+  segments: string[],
+  maxWidth: number,
+  measure: Measure
+): string {
+  if (segments.length === 0) return '';
+  if (segments.length === 1) return fitOrEllipsize(segments[0], maxWidth, measure);
+
+  const last = segments[segments.length - 1];
+  const front = segments.slice(0, -1);
+
+  const full = segments.join('/');
+  if (measure(full) <= maxWidth) return full;
+
+  for (let keptCount = front.length - 1; keptCount >= 0; keptCount--) {
+    const kept = front.slice(0, keptCount);
+    const baseCandidate = kept.length > 0 ? `${kept.join('/')}/.../${last}` : `.../${last}`;
+    if (measure(baseCandidate) <= maxWidth) return baseCandidate;
+
+    if (keptCount === 0) continue;
+
+    const lastKept = kept[keptCount - 1];
+    const prefixSegs = kept.slice(0, keptCount - 1);
+    const prefix = prefixSegs.length > 0 ? `${prefixSegs.join('/')}/` : '';
+    for (let len = lastKept.length - 1; len >= 1; len--) {
+      const truncated = `${lastKept.slice(0, len)}...`;
+      const partial = `${prefix}${truncated}/${last}`;
+      if (measure(partial) <= maxWidth) return partial;
+    }
+  }
+
+  return fitOrEllipsize(last, maxWidth, measure);
+}
+
+function fitOrEllipsize(text: string, maxWidth: number, measure: Measure): string {
+  if (measure(text) <= maxWidth) return text;
+  for (let len = text.length - 1; len >= 1; len--) {
+    const truncated = `${text.slice(0, len)}...`;
+    if (measure(truncated) <= maxWidth) return truncated;
+  }
+  return '...';
+}
+
+let measureCanvas: HTMLCanvasElement | null = null;
+
+function getMeasureContext(): CanvasRenderingContext2D | null {
+  if (typeof document === 'undefined') return null;
+  if (!measureCanvas) measureCanvas = document.createElement('canvas');
+  return measureCanvas.getContext('2d');
+}
+
+function fontFromComputed(el: HTMLElement): string {
+  const cs = window.getComputedStyle(el);
+  const style = cs.fontStyle || 'normal';
+  const weight = cs.fontWeight || '400';
+  const size = cs.fontSize || '14px';
+  const family = cs.fontFamily || 'sans-serif';
+  return `${style} ${weight} ${size} ${family}`;
+}
+
+export function CompactedPathLabel({ path }: { path: string }) {
+  const ref = useRef<HTMLSpanElement>(null);
+  const segments = useMemo(() => path.split('/'), [path]);
+  const [display, setDisplay] = useState(path);
+
+  useLayoutEffect(() => {
+    const el = ref.current;
+    if (!el) return;
+    const ctx = getMeasureContext();
+    if (!ctx) return;
+
+    let frame = 0;
+    const recompute = () => {
+      const width = el.clientWidth;
+      if (width <= 0) return;
+      ctx.font = fontFromComputed(el);
+      const next = pickCompactedDisplay(segments, width, (s) => ctx.measureText(s).width);
+      setDisplay((prev) => (prev === next ? prev : next));
+    };
+
+    recompute();
+    const observer = new ResizeObserver(() => {
+      cancelAnimationFrame(frame);
+      frame = requestAnimationFrame(recompute);
+    });
+    observer.observe(el);
+
+    return () => {
+      observer.disconnect();
+      cancelAnimationFrame(frame);
+    };
+  }, [path, segments]);
+
+  return (
+    <span ref={ref} className="block overflow-hidden whitespace-nowrap" title={path}>
+      {display}
+    </span>
+  );
+}

--- a/src/renderer/features/tasks/editor/compacted-path-label.tsx
+++ b/src/renderer/features/tasks/editor/compacted-path-label.tsx
@@ -93,7 +93,7 @@ export function CompactedPathLabel({ path }: { path: string }) {
       observer.disconnect();
       cancelAnimationFrame(frame);
     };
-  }, [path, segments]);
+  }, [path]);
 
   return (
     <span ref={ref} className="block overflow-hidden whitespace-nowrap" title={path}>

--- a/src/renderer/features/tasks/editor/editor-file-tree.tsx
+++ b/src/renderer/features/tasks/editor/editor-file-tree.tsx
@@ -2,9 +2,14 @@ import { useVirtualizer } from '@tanstack/react-virtual';
 import { ChevronDown, ChevronRight, Copy, FileText, Folder, FolderOpen } from 'lucide-react';
 import { runInAction } from 'mobx';
 import { observer } from 'mobx-react-lite';
-import React, { useRef, useState } from 'react';
+import React, { useEffect, useRef, useState } from 'react';
+import { CompactedPathLabel } from '@renderer/features/tasks/editor/compacted-path-label';
 import type { FilesStore } from '@renderer/features/tasks/editor/stores/files-store';
-import { buildVisibleRows } from '@renderer/features/tasks/editor/stores/files-store-utils';
+import {
+  buildVisibleRows,
+  isChainExpanded,
+  type TreeRow,
+} from '@renderer/features/tasks/editor/stores/files-store-utils';
 import {
   useTaskViewContext,
   useWorkspace,
@@ -23,7 +28,6 @@ import {
   ContextMenuTrigger,
 } from '@renderer/lib/ui/context-menu';
 import { cn } from '@renderer/utils/utils';
-import type { FileNode } from '@shared/fs';
 import { basenameFromAnyPath } from '@shared/path-name';
 
 const MAX_COPY_FILE_BYTES = 10 * 1024 * 1024;
@@ -113,10 +117,10 @@ async function importLocalFiles(args: {
 }
 
 const FileTreeRow = observer(function FileTreeRow({
-  node,
+  row,
   style,
 }: {
-  node: FileNode;
+  row: TreeRow;
   style: React.CSSProperties;
 }) {
   const taskView = useWorkspaceViewModel();
@@ -125,18 +129,25 @@ const FileTreeRow = observer(function FileTreeRow({
   const workspace = useWorkspace();
   const editorView = taskView.editorView;
 
-  const isExpanded = editorView.expandedPaths.has(node.path);
+  const node = row.node;
+  const isExpanded = isChainExpanded(row.chain, editorView.expandedPaths);
   const isSelected = taskView.tabManager.activeFilePath === node.path;
   const fileStatus = workspace.git.fileChanges?.find((c) => c.path === node.path)?.status;
-  const paddingLeft = node.depth * 12 + 4;
+  const paddingLeft = row.renderDepth * 12 + 4;
   const targetDirPath = node.type === 'directory' ? node.path : (node.parentPath ?? '');
+  const chainPath = row.chain.length > 1 ? row.chain.map((n) => n.name).join('/') : null;
+  const isHidden = row.chain.some((n) => n.isHidden);
 
   const toggleExpand = () => {
     runInAction(() => {
-      if (editorView.expandedPaths.has(node.path)) {
-        editorView.expandedPaths.delete(node.path);
+      if (isChainExpanded(row.chain, editorView.expandedPaths)) {
+        for (const segment of row.chain) {
+          editorView.expandedPaths.delete(segment.path);
+        }
       } else {
-        editorView.expandedPaths.add(node.path);
+        for (const segment of row.chain) {
+          editorView.expandedPaths.add(segment.path);
+        }
         if (!workspace.files.loadedPaths.has(node.path)) {
           void workspace.files.loadDir(node.path);
         }
@@ -242,9 +253,11 @@ const FileTreeRow = observer(function FileTreeRow({
     void (async () => {
       // Expand and load the target directory so optimistic nodes can be inserted immediately.
       if (node.type === 'directory') {
-        if (!editorView.expandedPaths.has(node.path)) {
-          runInAction(() => editorView.expandedPaths.add(node.path));
-        }
+        runInAction(() => {
+          for (const segment of row.chain) {
+            editorView.expandedPaths.add(segment.path);
+          }
+        });
         if (!workspace.files.loadedPaths.has(node.path)) {
           await workspace.files.loadDir(node.path);
         }
@@ -268,7 +281,7 @@ const FileTreeRow = observer(function FileTreeRow({
           'flex h-7 cursor-pointer select-none items-center gap-1.5 rounded-md pr-2 hover:bg-background-1',
           isSelected && 'bg-background-2 hover:bg-background-2',
           isDropTarget && 'bg-blue-500/15 outline outline-1 outline-blue-500/60',
-          node.isHidden && 'opacity-60'
+          isHidden && 'opacity-60'
         )}
         tabIndex={0}
         onClick={handleClick}
@@ -314,7 +327,7 @@ const FileTreeRow = observer(function FileTreeRow({
             fileStatus === 'renamed' && 'text-blue-500'
           )}
         >
-          {node.name}
+          {chainPath !== null ? <CompactedPathLabel path={chainPath} /> : node.name}
         </span>
       </ContextMenuTrigger>
       <ContextMenuContent>
@@ -347,6 +360,25 @@ export const EditorFileTree = observer(function EditorFileTree() {
   const [isDragOverRoot, setIsDragOverRoot] = useState(false);
 
   const visibleRows = files ? buildVisibleRows(files.rootNodes, editorView.expandedPaths) : [];
+
+  const prefetchKey = files
+    ? visibleRows
+        .filter(
+          (row) =>
+            row.node.type === 'directory' &&
+            !files.loadedPaths.has(row.node.path) &&
+            !files.pendingPaths.has(row.node.path)
+        )
+        .map((row) => row.node.path)
+        .join('\0')
+    : '';
+
+  useEffect(() => {
+    if (!files || !prefetchKey) return;
+    for (const path of prefetchKey.split('\0')) {
+      void files.loadDir(path);
+    }
+  }, [prefetchKey, files]);
 
   const parentRef = useRef<HTMLDivElement>(null);
 
@@ -427,11 +459,11 @@ export const EditorFileTree = observer(function EditorFileTree() {
       <div ref={parentRef} className="flex-1 overflow-y-auto px-2 py-2" role="tree">
         <div style={{ height: virtualizer.getTotalSize(), position: 'relative' }}>
           {virtualizer.getVirtualItems().map((vItem) => {
-            const node = visibleRows[vItem.index] as FileNode;
+            const row = visibleRows[vItem.index];
             return (
               <FileTreeRow
-                key={node.path}
-                node={node}
+                key={row.node.path}
+                row={row}
                 style={{
                   position: 'absolute',
                   top: vItem.start,

--- a/src/renderer/features/tasks/editor/stores/files-store-utils.test.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store-utils.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from 'vitest';
+import type { FileNode } from '@shared/fs';
 import { buildVisibleRows, makeNode, sortFileNodes } from './files-store-utils';
+
+function attach(parent: FileNode, child: FileNode): FileNode {
+  parent.children.push(child);
+  return child;
+}
 
 describe('file tree utils', () => {
   it('normalizes Windows paths into stable POSIX node identities', () => {
@@ -14,25 +20,26 @@ describe('file tree utils', () => {
 
   it('hides loaded descendants for collapsed directories', () => {
     const src = makeNode('src', 'directory');
-    src.children.push(makeNode('src/index.ts', 'file'));
+    attach(src, makeNode('src/index.ts', 'file'));
 
     const rows = buildVisibleRows([src, makeNode('README.md', 'file')], new Set());
 
-    expect(rows.map((row) => row.path)).toEqual(['src', 'README.md']);
+    expect(rows.map((row) => row.node.path)).toEqual(['src', 'README.md']);
   });
 
   it('reveals expanded directory children recursively', () => {
     const src = makeNode('src', 'directory');
     const components = makeNode('src/components', 'directory');
-    components.children.push(makeNode('src/components/Button.tsx', 'file'));
-    src.children.push(components, makeNode('src/index.ts', 'file'));
+    attach(components, makeNode('src/components/Button.tsx', 'file'));
+    attach(src, components);
+    attach(src, makeNode('src/index.ts', 'file'));
 
     const rows = buildVisibleRows(
       [src, makeNode('README.md', 'file')],
       new Set(['src', 'src/components'])
     );
 
-    expect(rows.map((row) => row.path)).toEqual([
+    expect(rows.map((row) => row.node.path)).toEqual([
       'src',
       'src/components',
       'src/components/Button.tsx',
@@ -63,6 +70,124 @@ describe('file tree utils', () => {
 
     const rows = buildVisibleRows([file], new Set(['README.md']));
 
-    expect(rows.map((row) => row.path)).toEqual(['README.md']);
+    expect(rows.map((row) => row.node.path)).toEqual(['README.md']);
+  });
+
+  it('fuses single-child directory chains into one row', () => {
+    const src = makeNode('src', 'directory');
+    const components = makeNode('src/components', 'directory');
+    const ui = makeNode('src/components/ui', 'directory');
+    attach(components, ui);
+    attach(src, components);
+
+    const rows = buildVisibleRows([src], new Set());
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].node.path).toBe('src/components/ui');
+    expect(rows[0].chain.map((n) => n.name)).toEqual(['src', 'components', 'ui']);
+    expect(rows[0].renderDepth).toBe(0);
+  });
+
+  it('does not fuse when a directory has a file child', () => {
+    const src = makeNode('src', 'directory');
+    const components = makeNode('src/components', 'directory');
+    attach(src, components);
+    attach(src, makeNode('src/index.ts', 'file'));
+
+    const rows = buildVisibleRows([src], new Set(['src']));
+
+    expect(rows.map((row) => row.chain.map((n) => n.name))).toEqual([
+      ['src'],
+      ['components'],
+      ['index.ts'],
+    ]);
+  });
+
+  it('does not fuse when a directory has multiple directory children', () => {
+    const src = makeNode('src', 'directory');
+    attach(src, makeNode('src/components', 'directory'));
+    attach(src, makeNode('src/lib', 'directory'));
+
+    const rows = buildVisibleRows([src], new Set(['src']));
+
+    expect(rows.map((row) => row.chain.map((n) => n.name))).toEqual([
+      ['src'],
+      ['components'],
+      ['lib'],
+    ]);
+  });
+
+  it('expands the terminal segment of a fused chain', () => {
+    const src = makeNode('src', 'directory');
+    const components = makeNode('src/components', 'directory');
+    const ui = makeNode('src/components/ui', 'directory');
+    attach(ui, makeNode('src/components/ui/button.tsx', 'file'));
+    attach(ui, makeNode('src/components/ui/card.tsx', 'file'));
+    attach(components, ui);
+    attach(src, components);
+
+    const rows = buildVisibleRows([src], new Set(['src/components/ui']));
+
+    expect(rows.map((row) => row.node.path)).toEqual([
+      'src/components/ui',
+      'src/components/ui/button.tsx',
+      'src/components/ui/card.tsx',
+    ]);
+    expect(rows[1].renderDepth).toBe(1);
+    expect(rows[2].renderDepth).toBe(1);
+  });
+
+  it('stops fusing at a directory with file children', () => {
+    const a = makeNode('a', 'directory');
+    const b = makeNode('a/b', 'directory');
+    const c = makeNode('a/b/c', 'directory');
+    attach(c, makeNode('a/b/c/file.ts', 'file'));
+    attach(b, c);
+    attach(a, b);
+
+    const rows = buildVisibleRows([a], new Set(['a/b/c']));
+
+    expect(rows[0].chain.map((n) => n.name)).toEqual(['a', 'b', 'c']);
+    expect(rows[0].node.path).toBe('a/b/c');
+    expect(rows[1].node.path).toBe('a/b/c/file.ts');
+  });
+
+  it('expands a fused chain when an intermediate segment is in expandedPaths', () => {
+    const src = makeNode('src', 'directory');
+    const components = makeNode('src/components', 'directory');
+    const ui = makeNode('src/components/ui', 'directory');
+    attach(ui, makeNode('src/components/ui/button.tsx', 'file'));
+    attach(components, ui);
+    attach(src, components);
+
+    const rows = buildVisibleRows([src], new Set(['src/components']));
+
+    expect(rows.map((row) => row.node.path)).toEqual([
+      'src/components/ui',
+      'src/components/ui/button.tsx',
+    ]);
+  });
+
+  it('terminates extendChain on a self-referential FileNode graph', () => {
+    const loop = makeNode('loop', 'directory');
+    loop.children.push(loop);
+
+    const rows = buildVisibleRows([loop], new Set());
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].chain).toHaveLength(1);
+    expect(rows[0].node.path).toBe('loop');
+  });
+
+  it('terminates extendChain on a two-node directory cycle', () => {
+    const a = makeNode('a', 'directory');
+    const b = makeNode('a/b', 'directory');
+    a.children.push(b);
+    b.children.push(a);
+
+    const rows = buildVisibleRows([a], new Set());
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].chain.map((n) => n.path)).toEqual(['a', 'a/b']);
   });
 });

--- a/src/renderer/features/tasks/editor/stores/files-store-utils.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store-utils.ts
@@ -94,21 +94,53 @@ export function sortFileNodes(nodes: readonly FileNode[]): FileNode[] {
 // Visible rows derivation
 // ---------------------------------------------------------------------------
 
+export interface TreeRow {
+  node: FileNode;
+  chain: FileNode[];
+  renderDepth: number;
+}
+
+function extendChain(node: FileNode): FileNode[] {
+  const chain: FileNode[] = [node];
+  const visited = new Set<string>([node.path]);
+  let current = node;
+  while (
+    current.type === 'directory' &&
+    current.children.length === 1 &&
+    current.children[0].type === 'directory' &&
+    !visited.has(current.children[0].path)
+  ) {
+    current = current.children[0];
+    visited.add(current.path);
+    chain.push(current);
+  }
+  return chain;
+}
+
+export function isChainExpanded(chain: readonly FileNode[], expandedPaths: Set<string>): boolean {
+  for (const segment of chain) {
+    if (expandedPaths.has(segment.path)) return true;
+  }
+  return false;
+}
+
 export function buildVisibleRows(
   rootNodes: readonly FileNode[],
   expandedPaths: Set<string>
-): FileNode[] {
-  const rows: FileNode[] = [];
+): TreeRow[] {
+  const rows: TreeRow[] = [];
 
-  function walk(nodes: readonly FileNode[]) {
+  function walk(nodes: readonly FileNode[], renderDepth: number) {
     for (const node of nodes) {
-      rows.push(node);
-      if (node.type === 'directory' && expandedPaths.has(node.path)) {
-        walk(node.children);
+      const chain = node.type === 'directory' ? extendChain(node) : [node];
+      const terminus = chain[chain.length - 1];
+      rows.push({ node: terminus, chain, renderDepth });
+      if (terminus.type === 'directory' && isChainExpanded(chain, expandedPaths)) {
+        walk(terminus.children, renderDepth + 1);
       }
     }
   }
 
-  walk(rootNodes);
+  walk(rootNodes, 0);
   return rows;
 }

--- a/src/renderer/features/tasks/editor/stores/files-store.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.ts
@@ -403,8 +403,9 @@ export class FilesStore {
   }
 
   private _bumpTreeDebounced(): void {
-    if (this._bumpTimer) clearTimeout(this._bumpTimer);
+    if (this._bumpTimer) return;
     this._bumpTimer = setTimeout(() => {
+      this._bumpTimer = null;
       this._bumpTree();
     }, 50);
   }


### PR DESCRIPTION
## Summary

- Fuse chains of single-child folders into one row in the file tree (e.g. `src/components/ui` shown together instead of three separate rows).
- Truncate the path label with priority: always keep the last segment visible, then the first, dropping middles first.
- Show chains automatically as the file tree loads, without requiring a click on the parent folder.

## Test plan

- [ ] Open a project with deep single-child folder chains; verify they render as one row.
- [ ] Resize the sidebar narrow; verify path truncates through the documented stages.
- [ ] Open a fresh project; verify chains appear without clicking.
- [ ] Expand a chain; verify the deepest folder's children show.
- [ ] Drag-drop a file onto a chain row; verify it lands in the chain's deepest folder.