### PR TITLE
fix(workspaces): format Windows lifecycle scripts

### DIFF
--- a/src/main/core/terminals/format-lifecycle-script-input.test.ts
+++ b/src/main/core/terminals/format-lifecycle-script-input.test.ts
@@ -56,14 +56,18 @@ describe('formatLifecycleScriptInput', () => {
     );
   });
 
-  it('ignores blank lines', () => {
+  it('ignores blank lines for Windows only', () => {
     const script = 'pnpm install\n\npnpm build';
 
     expect(formatLifecycleScriptInput(script, { platform: 'win32' })).toBe(
       'pnpm install & pnpm build'
     );
-    expect(formatLifecycleScriptInput(script, { platform: 'darwin' })).toBe(
-      'pnpm install\npnpm build'
-    );
+    expect(formatLifecycleScriptInput(script, { platform: 'darwin' })).toBe(script);
+  });
+
+  it('preserves POSIX trailing whitespace', () => {
+    const script = 'pnpm install  \npnpm build\t';
+
+    expect(formatLifecycleScriptInput(script, { platform: 'darwin' })).toBe(script);
   });
 });

--- a/src/main/core/terminals/format-lifecycle-script-input.test.ts
+++ b/src/main/core/terminals/format-lifecycle-script-input.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { formatLifecycleScriptInput } from './format-lifecycle-script-input';
+
+describe('formatLifecycleScriptInput', () => {
+  const copyLine =
+    'copy "%USERPROFILE%\\Documents\\Github\\some-repo\\some-folder\\some-folder.env" "some-folder\\some-folder.env"';
+  const npmLine = 'npm --prefix some-folder/some-folder install';
+
+  it('joins newline-separated Windows setup commands with &', () => {
+    const script = `${copyLine}\n${npmLine}`;
+
+    expect(formatLifecycleScriptInput(script, { platform: 'win32' })).toBe(
+      `${copyLine} & ${npmLine}`
+    );
+  });
+
+  it('appends exit with & on Windows', () => {
+    expect(formatLifecycleScriptInput('pnpm install', { platform: 'win32', exit: true })).toBe(
+      'pnpm install & exit'
+    );
+  });
+
+  it('joins multiline Windows scripts before exit', () => {
+    const script = `${copyLine}\r\n${npmLine}`;
+
+    expect(formatLifecycleScriptInput(script, { platform: 'win32', exit: true })).toBe(
+      `${copyLine} & ${npmLine} & exit`
+    );
+  });
+
+  it('preserves POSIX newline-separated commands', () => {
+    const script = 'pnpm install\npnpm build';
+
+    expect(formatLifecycleScriptInput(script, { platform: 'darwin' })).toBe(script);
+  });
+
+  it('uses explicit shell kind instead of host platform', () => {
+    const script = 'pnpm install\npnpm build';
+
+    expect(formatLifecycleScriptInput(script, { platform: 'win32', shellKind: 'posix' })).toBe(
+      script
+    );
+  });
+
+  it('appends ; exit on POSIX', () => {
+    expect(formatLifecycleScriptInput('pnpm dev', { platform: 'linux', exit: true })).toBe(
+      'pnpm dev; exit'
+    );
+  });
+
+  it('preserves POSIX multiline scripts before exit', () => {
+    const script = 'pnpm install\npnpm build';
+
+    expect(formatLifecycleScriptInput(script, { platform: 'linux', exit: true })).toBe(
+      `${script}; exit`
+    );
+  });
+
+  it('ignores blank lines', () => {
+    const script = 'pnpm install\n\npnpm build';
+
+    expect(formatLifecycleScriptInput(script, { platform: 'win32' })).toBe(
+      'pnpm install & pnpm build'
+    );
+    expect(formatLifecycleScriptInput(script, { platform: 'darwin' })).toBe(
+      'pnpm install\npnpm build'
+    );
+  });
+});

--- a/src/main/core/terminals/format-lifecycle-script-input.ts
+++ b/src/main/core/terminals/format-lifecycle-script-input.ts
@@ -1,0 +1,38 @@
+export type LifecycleScriptInputOptions = {
+  exit?: boolean;
+  shellKind?: 'cmd' | 'posix';
+  platform?: NodeJS.Platform;
+};
+
+function splitScriptLines(script: string): string[] {
+  return script
+    .split(/\r?\n/)
+    .map((line) => line.trimEnd())
+    .filter((line) => line.length > 0);
+}
+
+/**
+ * Formats lifecycle script text for writing into an interactive shell PTY.
+ * Windows cmd.exe does not treat bare LF as a command boundary, so newline-separated
+ * commands are joined with `&`. POSIX shells accept newline-separated commands as-is.
+ */
+export function formatLifecycleScriptInput(
+  script: string,
+  {
+    exit = false,
+    platform = process.platform,
+    shellKind = platform === 'win32' ? 'cmd' : 'posix',
+  }: LifecycleScriptInputOptions = {}
+): string {
+  const lines = splitScriptLines(script);
+
+  if (shellKind === 'cmd') {
+    const body = lines.join(' & ');
+    if (!body) return exit ? 'exit' : '';
+    return exit ? `${body} & exit` : body;
+  }
+
+  const body = lines.join('\n');
+  if (!body) return exit ? 'exit' : '';
+  return exit ? `${body}; exit` : body;
+}

--- a/src/main/core/terminals/format-lifecycle-script-input.ts
+++ b/src/main/core/terminals/format-lifecycle-script-input.ts
@@ -1,6 +1,8 @@
+export type LifecycleScriptShellKind = 'cmd' | 'posix';
+
 export type LifecycleScriptInputOptions = {
   exit?: boolean;
-  shellKind?: 'cmd' | 'posix';
+  shellKind?: LifecycleScriptShellKind;
   platform?: NodeJS.Platform;
 };
 
@@ -27,6 +29,7 @@ export function formatLifecycleScriptInput(
   const lines = splitScriptLines(script);
 
   if (shellKind === 'cmd') {
+    // `&` continues on error, matching POSIX shells without `set -e`.
     const body = lines.join(' & ');
     if (!body) return exit ? 'exit' : '';
     return exit ? `${body} & exit` : body;

--- a/src/main/core/terminals/format-lifecycle-script-input.ts
+++ b/src/main/core/terminals/format-lifecycle-script-input.ts
@@ -6,7 +6,7 @@ export type LifecycleScriptInputOptions = {
   platform?: NodeJS.Platform;
 };
 
-function splitScriptLines(script: string): string[] {
+function splitCmdScriptLines(script: string): string[] {
   return script
     .split(/\r?\n/)
     .map((line) => line.trimEnd())
@@ -26,16 +26,13 @@ export function formatLifecycleScriptInput(
     shellKind = platform === 'win32' ? 'cmd' : 'posix',
   }: LifecycleScriptInputOptions = {}
 ): string {
-  const lines = splitScriptLines(script);
-
   if (shellKind === 'cmd') {
     // `&` continues on error, matching POSIX shells without `set -e`.
-    const body = lines.join(' & ');
+    const body = splitCmdScriptLines(script).join(' & ');
     if (!body) return exit ? 'exit' : '';
     return exit ? `${body} & exit` : body;
   }
 
-  const body = lines.join('\n');
-  if (!body) return exit ? 'exit' : '';
-  return exit ? `${body}; exit` : body;
+  if (!script) return exit ? 'exit' : '';
+  return exit ? `${script}; exit` : script;
 }

--- a/src/main/core/workspaces/workspace-factory.ts
+++ b/src/main/core/workspaces/workspace-factory.ts
@@ -121,6 +121,7 @@ export function createWorkspaceFactory(
       projectId: context.projectId,
       workspaceId,
       terminals: workspaceTerminals,
+      shellKind: type.kind === 'ssh' ? 'posix' : process.platform === 'win32' ? 'cmd' : 'posix',
     });
 
     const baseGitCtx =

--- a/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -5,7 +5,10 @@ import { makePtySessionId } from '@shared/ptySessionId';
 import { createLifecycleScriptTerminalId } from '@shared/terminals';
 import type { Pty } from '../pty/pty';
 import { ptySessionRegistry } from '../pty/pty-session-registry';
+import { formatLifecycleScriptInput } from '../terminals/format-lifecycle-script-input';
 import type { TerminalProvider } from '../terminals/terminal-provider';
+
+type LifecycleScriptShellKind = 'cmd' | 'posix';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -25,6 +28,7 @@ export class LifecycleScriptService implements IDisposable {
   private readonly projectId: string;
   private readonly workspaceId: string;
   private readonly terminals: TerminalProvider;
+  private readonly shellKind: LifecycleScriptShellKind;
   private readonly sessionsWithRespawnHandler = new Set<string>();
   private readonly latestRespawnRequest = new Map<string, LifecycleRespawnRequest>();
   private disposed = false;
@@ -33,14 +37,17 @@ export class LifecycleScriptService implements IDisposable {
     projectId,
     workspaceId,
     terminals,
+    shellKind = process.platform === 'win32' ? 'cmd' : 'posix',
   }: {
     projectId: string;
     workspaceId: string;
     terminals: TerminalProvider;
+    shellKind?: LifecycleScriptShellKind;
   }) {
     this.projectId = projectId;
     this.workspaceId = workspaceId;
     this.terminals = terminals;
+    this.shellKind = shellKind;
   }
 
   private respawnAfterExit(sessionId: string): void {
@@ -139,7 +146,7 @@ export class LifecycleScriptService implements IDisposable {
         })
       : null;
 
-    const command = exit ? `${script.script}; exit` : script.script;
+    const command = formatLifecycleScriptInput(script.script, { exit, shellKind: this.shellKind });
     pty.write(`${command}\n`);
 
     if (exitPromise) {

--- a/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -5,10 +5,11 @@ import { makePtySessionId } from '@shared/ptySessionId';
 import { createLifecycleScriptTerminalId } from '@shared/terminals';
 import type { Pty } from '../pty/pty';
 import { ptySessionRegistry } from '../pty/pty-session-registry';
-import { formatLifecycleScriptInput } from '../terminals/format-lifecycle-script-input';
+import {
+  formatLifecycleScriptInput,
+  type LifecycleScriptShellKind,
+} from '../terminals/format-lifecycle-script-input';
 import type { TerminalProvider } from '../terminals/terminal-provider';
-
-type LifecycleScriptShellKind = 'cmd' | 'posix';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;


### PR DESCRIPTION
# summary
- fix windows lifecycle script execution
- joining newline-separated commands with a valid cmd separator