### PR TITLE
fix: lifecycle scripts getting recognized in resource monitor

### DIFF
--- a/src/renderer/features/command-palette/resource-monitor-utils.ts
+++ b/src/renderer/features/command-palette/resource-monitor-utils.ts
@@ -8,6 +8,7 @@ import type {
   ResourcePtyEntry,
   ResourceSnapshot,
 } from '@shared/resource-monitor';
+import { createLifecycleScriptTerminalId } from '@shared/terminals';
 
 export type Entry = ResourcePtyEntry & {
   taskName?: string;
@@ -38,9 +39,9 @@ const UNKNOWN_PROJECT_ID = '__unknown__';
  * truncated "script-l…" leaf id.
  */
 const LIFECYCLE_SCRIPT_LABELS: Record<string, string> = {
-  'script-lifecycle-setup': 'Setup script',
-  'script-lifecycle-run': 'Run script',
-  'script-lifecycle-teardown': 'Teardown script',
+  [createLifecycleScriptTerminalId('setup')]: 'Setup script',
+  [createLifecycleScriptTerminalId('run')]: 'Run script',
+  [createLifecycleScriptTerminalId('teardown')]: 'Teardown script',
 };
 
 export function isLifecycleScriptEntry(entry: Pick<Entry, 'leafId'>): boolean {

--- a/src/renderer/features/command-palette/resource-monitor-utils.ts
+++ b/src/renderer/features/command-palette/resource-monitor-utils.ts
@@ -31,6 +31,34 @@ export type Group = {
 
 const UNKNOWN_PROJECT_ID = '__unknown__';
 
+/**
+ * Lifecycle-script PTYs are labelled by their terminal id (see
+ * `createLifecycleScriptTerminalId`), which has no provider/conversation
+ * metadata. Map those ids to friendly labels so they don't render as the
+ * truncated "script-l…" leaf id.
+ */
+const LIFECYCLE_SCRIPT_LABELS: Record<string, string> = {
+  'script-lifecycle-setup': 'Setup script',
+  'script-lifecycle-run': 'Run script',
+  'script-lifecycle-teardown': 'Teardown script',
+};
+
+export function isLifecycleScriptEntry(entry: Pick<Entry, 'leafId'>): boolean {
+  return entry.leafId in LIFECYCLE_SCRIPT_LABELS;
+}
+
+/** Single source of truth for an entry's display label. */
+export function entryLabel(entry: Entry): string {
+  const meta = entry.providerId ? agentMeta[entry.providerId] : undefined;
+  return (
+    entry.conversationTitle ||
+    meta?.label ||
+    entry.providerId ||
+    LIFECYCLE_SCRIPT_LABELS[entry.leafId] ||
+    entry.leafId.slice(0, 8)
+  );
+}
+
 export function formatReport(snapshot: ResourceSnapshot, groups: Group[]): string {
   const entryMem = snapshot.entries.reduce((n, e) => n + e.memory, 0);
   const entryCpu = snapshot.entries.reduce((n, e) => n + e.cpu, 0);
@@ -50,9 +78,7 @@ export function formatReport(snapshot: ResourceSnapshot, groups: Group[]): strin
   for (const g of groups) {
     for (const t of g.tasks) {
       for (const e of t.entries) {
-        const meta = e.providerId ? agentMeta[e.providerId] : undefined;
-        const label = e.conversationTitle || meta?.label || e.providerId || e.leafId.slice(0, 8);
-        const path = `${g.projectName} / ${t.taskName} / ${label}`;
+        const path = `${g.projectName} / ${t.taskName} / ${entryLabel(e)}`;
         const parts: string[] = [];
         if (e.pid !== undefined) parts.push(`pid=${e.pid}`);
         if (e.ppid !== undefined) parts.push(`ppid=${e.ppid}`);
@@ -87,11 +113,6 @@ export function sortAppProcesses(processes: ResourceAppProcess[]): ResourceAppPr
   });
 }
 
-function entryLabel(entry: Entry): string {
-  const meta = entry.providerId ? agentMeta[entry.providerId] : undefined;
-  return entry.conversationTitle || meta?.label || entry.providerId || entry.leafId.slice(0, 8);
-}
-
 export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
   const projects = appState.projects.projects;
   const byProject = new Map<string, { projectName: string; tasks: Map<string, TaskBucket> }>();
@@ -99,6 +120,10 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
   for (const entry of entries) {
     const projectStore = projects.get(entry.projectId);
     let taskName = entry.scopeId;
+    // The bucket key normally matches the entry's scopeId, but lifecycle
+    // scripts are scoped by workspaceId while agents are scoped by taskId.
+    // Resolving both to the owning task id groups them under the same branch.
+    let bucketKey = entry.scopeId;
     let providerId: AgentProviderId | undefined;
     let conversationTitle: string | undefined;
     let projectName = 'Other';
@@ -108,10 +133,24 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
       projectKey = entry.projectId;
       projectName = projectStore.name ?? projectStore.data?.name ?? entry.projectId.slice(0, 8);
       const mounted = projectStore.mountedProject;
-      const task = mounted?.taskManager.tasks.get(entry.scopeId);
+      // Agent PTYs use the task id as scopeId; lifecycle-script PTYs use the
+      // workspace id. Try the direct lookup first, then fall back to matching
+      // a task by its workspaceId so scripts attach to their owning branch.
+      let taskId = entry.scopeId;
+      let task = mounted?.taskManager.tasks.get(entry.scopeId);
+      if (!task && mounted) {
+        for (const [id, candidate] of mounted.taskManager.tasks) {
+          if (candidate.workspaceId === entry.scopeId) {
+            taskId = id;
+            task = candidate;
+            break;
+          }
+        }
+      }
       if (task) {
+        bucketKey = taskId;
         taskName = task.displayName;
-        const conv = conversationRegistry.get(entry.scopeId)?.conversations.get(entry.leafId);
+        const conv = conversationRegistry.get(taskId)?.conversations.get(entry.leafId);
         providerId = conv?.data.providerId;
         conversationTitle = conv?.data.title;
       }
@@ -126,15 +165,15 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
       projectName,
       tasks: new Map<string, TaskBucket>(),
     };
-    const taskBucket = project.tasks.get(entry.scopeId) ?? {
-      scopeId: entry.scopeId,
+    const taskBucket = project.tasks.get(bucketKey) ?? {
+      scopeId: bucketKey,
       taskName,
       entries: [],
       cpuSum: 0,
     };
     taskBucket.entries.push({ ...entry, taskName, providerId, conversationTitle });
     taskBucket.cpuSum += entry.cpu;
-    project.tasks.set(entry.scopeId, taskBucket);
+    project.tasks.set(bucketKey, taskBucket);
     byProject.set(projectKey, project);
   }
 

--- a/src/renderer/features/command-palette/resource-monitor-view.tsx
+++ b/src/renderer/features/command-palette/resource-monitor-view.tsx
@@ -1,4 +1,4 @@
-import { Activity, ArrowLeft, Check, Copy, Folder, GitBranch } from 'lucide-react';
+import { Activity, ArrowLeft, Check, Copy, Folder, GitBranch, Terminal } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useMemo, useRef, useState, type ReactNode } from 'react';
 import AgentLogo from '@renderer/lib/components/agent-logo';
@@ -10,7 +10,9 @@ import type { ResourceAppProcess, ResourceSnapshot } from '@shared/resource-moni
 import {
   appProcessLabel,
   buildGroups,
+  entryLabel,
   formatReport,
+  isLifecycleScriptEntry,
   sortAppProcesses,
   type Entry,
   type Group,
@@ -157,8 +159,7 @@ function TaskRow({ task }: { task: TaskBucket }) {
 function AgentRow({ entry }: { entry: Entry }) {
   const norm = appState.resourceMonitor.normalizedCpu(entry);
   const meta = entry.providerId ? agentMeta[entry.providerId] : undefined;
-  const label =
-    entry.conversationTitle || meta?.label || entry.providerId || entry.leafId.slice(0, 8);
+  const label = entryLabel(entry);
 
   return (
     <div
@@ -174,6 +175,10 @@ function AgentRow({ entry }: { entry: Entry }) {
             invertInDark={meta.invertInDark}
             className="h-3.5 w-3.5"
           />
+        </span>
+      ) : isLifecycleScriptEntry(entry) ? (
+        <span className="flex size-4 shrink-0 items-center justify-center">
+          <Terminal size={12} className="text-foreground/40" />
         </span>
       ) : (
         <span className="size-4 shrink-0" />


### PR DESCRIPTION
# summary
- before those lifecycle scripts were not grouped correclty in the resourcemonitor

this is after:
<img width="483" height="336" alt="Screenshot 2026-05-25 at 11 18 44" src="https://github.com/user-attachments/assets/f20225cc-413a-4761-a48a-96883e494f88" />
