### PR TITLE
fix(diff-view): allow large section selection

### DIFF
--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -650,18 +650,19 @@
     --monaco-line-highlight: var(--neutral-5);
     --monaco-line-number: color(display-p3 0.227 0.227 0.227);
     --monaco-gutter: var(--monaco-bg);
-    --monaco-inserted-text-bg: color(display-p3 0.145 0.282 0.176);
-    --monaco-inserted-line-bg: color(display-p3 0.106 0.165 0.118);
-    --monaco-inserted-text-border: color(display-p3 0.145 0.282 0.176);
-    --monaco-removed-text-bg: color(display-p3 0.38 0.086 0.137);
-    --monaco-removed-line-bg: color(display-p3 0.231 0.071 0.098);
-    --monaco-removed-text-border: color(display-p3 0.38 0.086 0.137);
+    /* Semi-transparent so the selection layer beneath stays visible (ENG-1248). */
+    --monaco-inserted-text-bg: color(display-p3 0.145 0.282 0.176 / 0.45);
+    --monaco-inserted-line-bg: color(display-p3 0.106 0.165 0.118 / 0.55);
+    --monaco-inserted-text-border: color(display-p3 0.145 0.282 0.176 / 0.65);
+    --monaco-removed-text-bg: color(display-p3 0.38 0.086 0.137 / 0.45);
+    --monaco-removed-line-bg: color(display-p3 0.231 0.071 0.098 / 0.55);
+    --monaco-removed-text-border: color(display-p3 0.38 0.086 0.137 / 0.65);
     --monaco-unchanged-region-bg: color(display-p3 0.165 0.165 0.165);
     --monaco-diff-border: color(display-p3 0.227 0.227 0.227);
     --monaco-diff-diagonal-fill: color(display-p3 0.165 0.165 0.165);
-    --monaco-selection-bg: color(display-p3 0 0.2 0.384);
-    --monaco-selection-fg: color(display-p3 0.439 0.722 1);
-    --monaco-inactive-selection-bg: color(display-p3 1 1 1 / 0.133);
+    --monaco-selection-bg: color(display-p3 0.3 0.52 0.82 / 0.7);
+    --monaco-selection-fg: color(display-p3 0.95 0.96 0.98);
+    --monaco-inactive-selection-bg: color(display-p3 0.3 0.52 0.82 / 0.35);
 
     /* xterm terminals */
     --xterm-bg: var(--background-1);

--- a/src/renderer/lib/monaco/editorConfig.ts
+++ b/src/renderer/lib/monaco/editorConfig.ts
@@ -11,7 +11,7 @@ export const DIFF_EDITOR_BASE_OPTIONS: editor.IDiffEditorConstructionOptions = {
   lineNumbers: 'on',
   lineNumbersMinChars: 2,
   readOnly: true,
-  renderIndicators: false,
+  renderIndicators: true,
   overviewRulerLanes: 3,
   renderOverviewRuler: true,
   overviewRulerBorder: false,
@@ -29,6 +29,8 @@ export const DIFF_EDITOR_BASE_OPTIONS: editor.IDiffEditorConstructionOptions = {
     verticalSliderSize: 4,
     horizontalSliderSize: 4,
   },
+  // Collapsed unchanged regions break drag-selection across large diffs (ENG-1248).
+  hideUnchangedRegions: { enabled: false },
   diffWordWrap: 'on',
   enableSplitViewResizing: false,
   smoothScrolling: true,

--- a/src/renderer/tests/editor-config.test.ts
+++ b/src/renderer/tests/editor-config.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import { DIFF_EDITOR_BASE_OPTIONS } from '@renderer/lib/monaco/editorConfig';
+
+describe('DIFF_EDITOR_BASE_OPTIONS', () => {
+  it('keeps unchanged diff regions visible for large text selection', () => {
+    expect(DIFF_EDITOR_BASE_OPTIONS.hideUnchangedRegions?.enabled).toBe(false);
+  });
+
+  it('renders +/- gutter indicators for added and removed lines', () => {
+    expect(DIFF_EDITOR_BASE_OPTIONS.renderIndicators).toBe(true);
+  });
+});


### PR DESCRIPTION
# summary
- fixes text selection
 
before:
<img width="696" height="561" alt="Screenshot 2026-05-25 at 11 45 33" src="https://github.com/user-attachments/assets/de35c7df-788f-44d5-904a-bba2c1770d87" />

after:
<img width="544" height="440" alt="Screenshot 2026-05-25 at 14 03 32" src="https://github.com/user-attachments/assets/b0cd2408-3dc4-415a-9b24-5bf600da8567" />
<img width="695" height="577" alt="Screenshot 2026-05-25 at 14 03 24" src="https://github.com/user-attachments/assets/326af0eb-baa1-4bd6-867f-5ea9b88248e3" />
