### PR TITLE
feat: keep agent running during e.g. update

### DIFF
--- a/src/main/app/menu.ts
+++ b/src/main/app/menu.ts
@@ -1,5 +1,7 @@
 import { app, clipboard, Menu, shell } from 'electron';
+import { appService } from '@main/core/app/service';
 import { events } from '@main/lib/events';
+import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import {
   menuCheckForUpdatesChannel,
@@ -141,6 +143,20 @@ export function setupApplicationMenu(): void {
         { role: 'zoomOut' as const },
         { type: 'separator' as const },
         { role: 'togglefullscreen' as const },
+        ...(import.meta.env.DEV
+          ? ([
+              { type: 'separator' as const },
+              {
+                label: 'Simulate App Close',
+                accelerator: 'Shift+CmdOrCtrl+Q',
+                click: () => {
+                  void appService.simulateAppClose().catch((error) => {
+                    log.error('[dev] simulateAppClose failed', error);
+                  });
+                },
+              },
+            ] satisfies Electron.MenuItemConstructorOptions[])
+          : []),
       ],
     },
     // Window menu

--- a/src/main/core/app/background-shutdown.test.ts
+++ b/src/main/core/app/background-shutdown.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  disposeProjects: vi.fn(async () => {}),
+  listProjectIds: vi.fn(() => ['proj-1']),
+  listActiveSessions: vi.fn(() => []),
+  stopResourceSampler: vi.fn(),
+  reconcileResourceSampler: vi.fn(),
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: {
+    listProjectIds: mocks.listProjectIds,
+    dispose: mocks.disposeProjects,
+  },
+}));
+
+vi.mock('@main/core/pty/pty-session-registry', () => ({
+  ptySessionRegistry: {
+    listActiveSessions: mocks.listActiveSessions,
+  },
+}));
+
+vi.mock('@main/core/resource-monitor/resource-sampler', () => ({
+  stopResourceSampler: mocks.stopResourceSampler,
+  reconcileResourceSampler: mocks.reconcileResourceSampler,
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: {
+    capture: vi.fn(),
+    dispose: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock('@main/core/agent-hooks/agent-hook-service', () => ({
+  agentHookService: { dispose: vi.fn() },
+}));
+
+vi.mock('@main/core/updates/update-service', () => ({
+  updateService: { dispose: vi.fn() },
+}));
+
+vi.mock('@main/core/pull-requests/pr-sync-scheduler', () => ({
+  prSyncScheduler: { dispose: vi.fn() },
+}));
+
+vi.mock('@main/core/git/git-watcher-registry', () => ({
+  gitWatcherRegistry: { dispose: vi.fn(async () => {}) },
+}));
+
+import { runBackgroundShutdown } from './background-shutdown';
+
+describe('runBackgroundShutdown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('simulates shutdown without disposing global services', async () => {
+    const result = await runBackgroundShutdown('simulate');
+
+    expect(result.projectIds).toEqual(['proj-1']);
+    expect(mocks.disposeProjects).toHaveBeenCalledTimes(1);
+    expect(mocks.stopResourceSampler).toHaveBeenCalledTimes(1);
+    expect(mocks.reconcileResourceSampler).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/core/app/background-shutdown.ts
+++ b/src/main/core/app/background-shutdown.ts
@@ -1,0 +1,95 @@
+import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
+import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
+import { gitWatcherRegistry } from '@main/core/git/git-watcher-registry';
+import { projectManager } from '@main/core/projects/project-manager';
+import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { prSyncScheduler } from '@main/core/pull-requests/pr-sync-scheduler';
+import {
+  reconcileResourceSampler,
+  stopResourceSampler,
+} from '@main/core/resource-monitor/resource-sampler';
+import { updateService } from '@main/core/updates/update-service';
+import { log } from '@main/lib/logger';
+import { telemetryService } from '@main/lib/telemetry';
+import type { DevBackgroundShutdownSimulatedEvent } from '@shared/events/appEvents';
+import { parsePtySessionId } from '@shared/ptySessionId';
+
+export type BackgroundShutdownMode = 'simulate' | 'exit';
+
+function captureAgentSessionSnapshots(): DevBackgroundShutdownSimulatedEvent['sessions'] {
+  return ptySessionRegistry.listActiveSessions().flatMap((session) => {
+    if (!session.metadata?.providerId) return [];
+    const parsed = parsePtySessionId(session.sessionId);
+    return [
+      {
+        sessionId: session.sessionId,
+        projectId: parsed?.projectId,
+        taskId: parsed?.scopeId,
+        conversationId: parsed?.leafId,
+        providerId: session.metadata.providerId,
+        title: session.metadata.title,
+        isRemote: session.metadata.isRemote,
+        tmuxSessionName: session.metadata.tmuxSessionName,
+      },
+    ];
+  });
+}
+
+async function markTmuxSessionsAlive(
+  sessions: DevBackgroundShutdownSimulatedEvent['sessions']
+): Promise<void> {
+  const ctx = new LocalExecutionContext();
+  await Promise.all(
+    sessions.map(async (session) => {
+      if (!session.tmuxSessionName || session.isRemote) return;
+      try {
+        await ctx.exec('tmux', ['has-session', '-t', session.tmuxSessionName]);
+        session.tmuxAlive = true;
+      } catch {
+        session.tmuxAlive = false;
+      }
+    })
+  );
+}
+
+export async function runBackgroundShutdown(
+  mode: BackgroundShutdownMode
+): Promise<DevBackgroundShutdownSimulatedEvent> {
+  const projectIds = projectManager.listProjectIds();
+  const sessions = captureAgentSessionSnapshots();
+
+  stopResourceSampler();
+
+  if (mode === 'exit') {
+    telemetryService.capture('app_closed');
+    await telemetryService.dispose();
+    agentHookService.dispose();
+    updateService.dispose();
+    prSyncScheduler.dispose();
+    await gitWatcherRegistry.dispose().catch((e) => {
+      log.warn('Failed to dispose git watcher registry:', e);
+    });
+  }
+
+  try {
+    await projectManager.dispose();
+  } catch (e) {
+    log.error('Failed to shutdown project manager:', e);
+    throw e;
+  }
+
+  if (mode === 'simulate') {
+    await markTmuxSessionsAlive(sessions);
+    void reconcileResourceSampler();
+    log.info('[dev] Simulated app close (agents detached, UI will reload)', {
+      projectIds,
+      sessions: sessions.map((s) => ({
+        sessionId: s.sessionId,
+        tmuxSessionName: s.tmuxSessionName,
+        tmuxAlive: s.tmuxAlive,
+      })),
+    });
+  }
+
+  return { projectIds, sessions };
+}

--- a/src/main/core/app/controller.ts
+++ b/src/main/core/app/controller.ts
@@ -62,4 +62,20 @@ export const appController = createRPCController({
   getAppVersion: () => appService.getCachedAppVersion(),
   getElectronVersion: () => process.versions.electron,
   getPlatform: () => process.platform,
+
+  /** Dev-only: detach agents like a real app close, reload the UI — reopen task to verify output continued. */
+  simulateAppClose: async () => {
+    if (!import.meta.env.DEV) {
+      return { success: false as const, error: 'Only available in development builds' };
+    }
+    try {
+      const result = await appService.simulateAppClose();
+      return { success: true as const, result };
+    } catch (error) {
+      return {
+        success: false as const,
+        error: error instanceof Error ? error.message : String(error),
+      };
+    }
+  },
 });

--- a/src/main/core/app/service.ts
+++ b/src/main/core/app/service.ts
@@ -5,6 +5,7 @@ import { extname, resolve, sep } from 'node:path';
 import { eq } from 'drizzle-orm';
 import { app, clipboard, dialog, shell } from 'electron';
 import { getMainWindow } from '@main/app/window';
+import { runBackgroundShutdown } from '@main/core/app/background-shutdown';
 import { db } from '@main/db/client';
 import { sshConnections } from '@main/db/schema';
 import { events } from '@main/lib/events';
@@ -16,7 +17,13 @@ import {
   buildRemoteSshCommand,
   buildRemoteTerminalExecArgs,
 } from '@main/utils/remoteOpenIn';
-import { appPasteChannel, appRedoChannel, appUndoChannel } from '@shared/events/appEvents';
+import {
+  appPasteChannel,
+  appRedoChannel,
+  appUndoChannel,
+  devBackgroundShutdownSimulatedChannel,
+  type DevBackgroundShutdownSimulatedEvent,
+} from '@shared/events/appEvents';
 import {
   getAppById,
   getResolvedLabel,
@@ -194,6 +201,25 @@ class AppService implements IInitializable, IDisposable {
 
   quit(): void {
     app.quit();
+  }
+
+  async simulateAppClose(): Promise<DevBackgroundShutdownSimulatedEvent> {
+    if (!import.meta.env.DEV) {
+      throw new Error('simulateAppClose is only available in development builds');
+    }
+    const result = await runBackgroundShutdown('simulate');
+    events.emit(devBackgroundShutdownSimulatedChannel, result);
+
+    const win = getMainWindow();
+    if (win && !win.isDestroyed()) {
+      const payload = JSON.stringify(result);
+      await win.webContents.executeJavaScript(
+        `sessionStorage.setItem('emdash:dev-app-close-sim', ${JSON.stringify(payload)})`
+      );
+      win.webContents.reload();
+    }
+
+    return result;
   }
 
   async openIn(args: {

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -6,6 +6,7 @@ import { HookConfigWriter } from '@main/core/agent-hooks/hook-config';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
+import { canUseTmuxForAgentSessions } from '@main/core/pty/agent-session-persistence';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import { buildAgentEnv } from '@main/core/pty/pty-env';
@@ -37,10 +38,10 @@ export class LocalConversationProvider implements ConversationProvider {
   private readonly projectId: string;
   private readonly taskPath: string;
   private readonly taskId: string;
-  private readonly tmux: boolean;
   private readonly shellSetup?: string;
   private readonly ctx: IExecutionContext;
   private readonly taskEnvVars: Record<string, string>;
+  private tmuxAvailability: Promise<boolean> | undefined;
   private readonly hookConfigWriter: HookConfigWriter;
   private readonly preparedHookProviders = new Map<
     string,
@@ -51,7 +52,6 @@ export class LocalConversationProvider implements ConversationProvider {
     projectId,
     taskPath,
     taskId,
-    tmux = false,
     shellSetup,
     ctx,
     taskEnvVars = {},
@@ -59,7 +59,6 @@ export class LocalConversationProvider implements ConversationProvider {
     projectId: string;
     taskPath: string;
     taskId: string;
-    tmux?: boolean;
     shellSetup?: string;
     ctx: IExecutionContext;
     taskEnvVars?: Record<string, string>;
@@ -67,11 +66,15 @@ export class LocalConversationProvider implements ConversationProvider {
     this.projectId = projectId;
     this.taskPath = taskPath;
     this.taskId = taskId;
-    this.tmux = tmux;
     this.shellSetup = shellSetup;
     this.ctx = ctx;
     this.taskEnvVars = taskEnvVars;
     this.hookConfigWriter = new HookConfigWriter(new LocalFileSystem(taskPath), ctx);
+  }
+
+  private canPersistWithTmux(): Promise<boolean> {
+    this.tmuxAvailability ??= canUseTmuxForAgentSessions(this.ctx);
+    return this.tmuxAvailability;
   }
 
   async startSession(
@@ -110,7 +113,8 @@ export class LocalConversationProvider implements ConversationProvider {
       autoApprove: conversation.autoApprove,
     });
 
-    const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;
+    const persistWithTmux = await this.canPersistWithTmux();
+    const tmuxSessionName = persistWithTmux ? makeTmuxSessionName(sessionId) : undefined;
 
     const resolved = resolveLocalPtySpawn({
       platform: process.platform,
@@ -172,7 +176,7 @@ export class LocalConversationProvider implements ConversationProvider {
         taskId: conversation.taskId,
         exitCode,
       });
-      if (shouldRespawn && !this.tmux) {
+      if (shouldRespawn && !persistWithTmux) {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
         this.respawnCounts.set(sessionId, count);
 
@@ -199,7 +203,7 @@ export class LocalConversationProvider implements ConversationProvider {
     });
 
     ptySessionRegistry.register(sessionId, pty, {
-      metadata: { providerId: conversation.providerId, title: conversation.title },
+      metadata: { providerId: conversation.providerId, title: conversation.title, tmuxSessionName },
     });
     this.sessions.set(sessionId, pty);
     scheduleInitialPromptInjection({ pty, conversation, initialPrompt, isResuming });
@@ -248,7 +252,7 @@ export class LocalConversationProvider implements ConversationProvider {
       this.sessions.delete(sessionId);
       ptySessionRegistry.unregister(sessionId);
     }
-    if (this.tmux) {
+    if (await this.canPersistWithTmux()) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
   }
@@ -256,7 +260,7 @@ export class LocalConversationProvider implements ConversationProvider {
   async destroyAll(): Promise<void> {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
-    if (this.tmux) {
+    if (await this.canPersistWithTmux()) {
       await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
     }
     this.knownSessionIds.clear();

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -3,6 +3,7 @@ import { claudeTrustService } from '@main/core/agent-hooks/claude-trust-service'
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
+import { canUseTmuxForAgentSessions } from '@main/core/pty/agent-session-persistence';
 import type { Pty } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
@@ -33,17 +34,16 @@ export class SshConversationProvider implements ConversationProvider {
   private readonly taskPath: string;
   private readonly taskId: string;
   private readonly taskEnvVars: Record<string, string>;
-  private readonly tmux: boolean = false;
   private readonly shellSetup?: string;
   private readonly ctx: IExecutionContext;
   private readonly proxy: SshClientProxy;
+  private tmuxAvailability: Promise<boolean> | undefined;
 
   constructor({
     projectId,
     taskPath,
     taskId,
     taskEnvVars = {},
-    tmux = false,
     shellSetup,
     ctx,
     proxy,
@@ -52,7 +52,6 @@ export class SshConversationProvider implements ConversationProvider {
     taskPath: string;
     taskId: string;
     taskEnvVars?: Record<string, string>;
-    tmux?: boolean;
     shellSetup?: string;
     ctx: IExecutionContext;
     proxy: SshClientProxy;
@@ -61,10 +60,14 @@ export class SshConversationProvider implements ConversationProvider {
     this.taskPath = taskPath;
     this.taskId = taskId;
     this.taskEnvVars = taskEnvVars;
-    this.tmux = tmux;
     this.shellSetup = shellSetup;
     this.ctx = ctx;
     this.proxy = proxy;
+  }
+
+  private canPersistWithTmux(): Promise<boolean> {
+    this.tmuxAvailability ??= canUseTmuxForAgentSessions(this.ctx);
+    return this.tmuxAvailability;
   }
 
   async startSession(
@@ -103,7 +106,8 @@ export class SshConversationProvider implements ConversationProvider {
       autoApprove: conversation.autoApprove,
     });
 
-    const tmuxSessionName = this.tmux ? makeTmuxSessionName(sessionId) : undefined;
+    const persistWithTmux = await this.canPersistWithTmux();
+    const tmuxSessionName = persistWithTmux ? makeTmuxSessionName(sessionId) : undefined;
 
     const cfg: AgentSessionConfig = {
       taskId: this.taskId,
@@ -163,7 +167,7 @@ export class SshConversationProvider implements ConversationProvider {
         taskId: conversation.taskId,
         exitCode,
       });
-      if (shouldRespawn && !this.tmux) {
+      if (shouldRespawn && !persistWithTmux) {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
         this.respawnCounts.set(sessionId, count);
 
@@ -190,7 +194,12 @@ export class SshConversationProvider implements ConversationProvider {
     });
 
     ptySessionRegistry.register(sessionId, pty, {
-      metadata: { providerId: conversation.providerId, title: conversation.title, isRemote: true },
+      metadata: {
+        providerId: conversation.providerId,
+        title: conversation.title,
+        isRemote: true,
+        tmuxSessionName,
+      },
     });
     this.sessions.set(sessionId, pty);
     scheduleInitialPromptInjection({ pty, conversation, initialPrompt, isResuming });
@@ -215,7 +224,7 @@ export class SshConversationProvider implements ConversationProvider {
       this.sessions.delete(sessionId);
       ptySessionRegistry.unregister(sessionId);
     }
-    if (this.tmux) {
+    if (await this.canPersistWithTmux()) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
   }
@@ -223,7 +232,7 @@ export class SshConversationProvider implements ConversationProvider {
   async destroyAll(): Promise<void> {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
-    if (this.tmux) {
+    if (await this.canPersistWithTmux()) {
       await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
     }
     this.knownSessionIds.clear();

--- a/src/main/core/projects/project-manager.ts
+++ b/src/main/core/projects/project-manager.ts
@@ -84,6 +84,10 @@ class ProjectManager implements Hookable<ProjectManagerHooks>, IDisposable {
     return this._lifecycle.get(projectId);
   }
 
+  listProjectIds(): string[] {
+    return Array.from(this._lifecycle.keys());
+  }
+
   async dispose(): Promise<void> {
     const ids = Array.from(this._lifecycle.keys());
     await Promise.allSettled(ids.map((id) => this.closeProject(id)));

--- a/src/main/core/projects/project-provider.ts
+++ b/src/main/core/projects/project-provider.ts
@@ -8,6 +8,7 @@ import type { Branch, FetchError } from '@shared/git';
 import type { ProjectRemoteState } from '@shared/projects';
 import type { Result } from '@shared/result';
 import type { ConversationProvider } from '../conversations/types';
+import { getProjectTeardownMode } from '../pty/agent-session-persistence';
 import { taskManager } from '../tasks/task-manager';
 import type { TerminalProvider } from '../terminals/terminal-provider';
 import type { WorkspaceType } from '../workspaces/workspace-factory';
@@ -117,7 +118,7 @@ export class ProjectProvider implements IDisposable {
     this._dispose();
     this.gitFetchService.stop();
     const projectSettings = await this.settings.get();
-    const mode = projectSettings.tmux ? 'detach' : 'terminate';
+    const mode = await getProjectTeardownMode(this.projectId, projectSettings, this.ctx);
     await taskManager.teardownAllForProject(this.projectId, mode);
     await workspaceRegistry.releaseAllForProject(this.projectId, mode);
   }

--- a/src/main/core/projects/settings/tmux-enabled.test.ts
+++ b/src/main/core/projects/settings/tmux-enabled.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { resolveProjectTmuxEnabled } from '@shared/project-settings';
+
+describe('resolveProjectTmuxEnabled', () => {
+  it('uses the project override when set', () => {
+    expect(resolveProjectTmuxEnabled({ tmux: false }, true)).toBe(false);
+    expect(resolveProjectTmuxEnabled({ tmux: true }, false)).toBe(true);
+  });
+
+  it('falls back to the app default when the project setting is unset', () => {
+    expect(resolveProjectTmuxEnabled({}, true)).toBe(true);
+    expect(resolveProjectTmuxEnabled({}, false)).toBe(false);
+  });
+});

--- a/src/main/core/projects/settings/tmux-enabled.ts
+++ b/src/main/core/projects/settings/tmux-enabled.ts
@@ -1,0 +1,9 @@
+import { appSettingsService } from '@main/core/settings/settings-service';
+import { resolveProjectTmuxEnabled, type ProjectSettings } from '@shared/project-settings';
+
+export { resolveProjectTmuxEnabled };
+
+export async function getProjectTmuxEnabled(projectSettings: ProjectSettings): Promise<boolean> {
+  const { tmuxByDefault } = await appSettingsService.get('project');
+  return resolveProjectTmuxEnabled(projectSettings, tmuxByDefault);
+}

--- a/src/main/core/pty/agent-session-persistence.test.ts
+++ b/src/main/core/pty/agent-session-persistence.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePtySessionId } from '@shared/ptySessionId';
+import type { IExecutionContext } from '../execution-context/types';
+import type { Pty } from './pty';
+import { ptySessionRegistry } from './pty-session-registry';
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    emit: vi.fn(),
+    on: vi.fn(() => vi.fn()),
+  },
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: {
+    get: vi.fn(async () => ({ tmuxByDefault: false })),
+  },
+}));
+
+const {
+  getProjectTeardownMode,
+  hasActiveAgentSessionsForProject,
+  hasActivePersistedAgentSessionsForProject,
+} = await import('./agent-session-persistence');
+
+class FakePty implements Pty {
+  write(): void {}
+  resize(): void {}
+  kill(): void {}
+  onData(): void {}
+  onExit(): void {}
+}
+
+function makeCtx(tmuxAvailable: boolean): Pick<IExecutionContext, 'exec' | 'supportsLocalSpawn'> {
+  return {
+    supportsLocalSpawn: false,
+    exec: vi.fn(async () => {
+      if (!tmuxAvailable) throw new Error('tmux unavailable');
+      return { stdout: 'tmux 3.5', stderr: '' };
+    }),
+  };
+}
+
+describe('agent-session-persistence', () => {
+  beforeEach(() => {
+    for (const session of ptySessionRegistry.listActiveSessions()) {
+      ptySessionRegistry.unregister(session.sessionId);
+    }
+  });
+
+  it('detects active agent sessions for a project', () => {
+    const sessionId = makePtySessionId('proj-1', 'task-1', 'conv-1');
+    ptySessionRegistry.register(sessionId, new FakePty(), {
+      metadata: { providerId: 'claude' },
+    });
+
+    expect(hasActiveAgentSessionsForProject('proj-1')).toBe(true);
+    expect(hasActiveAgentSessionsForProject('proj-2')).toBe(false);
+    expect(hasActivePersistedAgentSessionsForProject('proj-1')).toBe(false);
+  });
+
+  it('uses detach on shutdown when persisted agent sessions are active without project tmux', async () => {
+    const sessionId = makePtySessionId('proj-1', 'task-1', 'conv-1');
+    ptySessionRegistry.register(sessionId, new FakePty(), {
+      metadata: { providerId: 'claude', tmuxSessionName: 'emdash-session' },
+    });
+
+    expect(hasActivePersistedAgentSessionsForProject('proj-1')).toBe(true);
+
+    const mode = await getProjectTeardownMode('proj-1', {}, makeCtx(false));
+    expect(mode).toBe('detach');
+  });
+
+  it('uses detach when project tmux is enabled and tmux is available', async () => {
+    const mode = await getProjectTeardownMode('proj-1', { tmux: true }, makeCtx(true));
+
+    expect(mode).toBe('detach');
+  });
+
+  it('uses terminate when project tmux is enabled but tmux is unavailable', async () => {
+    const mode = await getProjectTeardownMode('proj-1', { tmux: true }, makeCtx(false));
+
+    expect(mode).toBe('terminate');
+  });
+
+  it('uses terminate when there are no active agent sessions and tmux is off', async () => {
+    const mode = await getProjectTeardownMode('proj-1', {}, makeCtx(false));
+    expect(mode).toBe('terminate');
+  });
+});

--- a/src/main/core/pty/agent-session-persistence.ts
+++ b/src/main/core/pty/agent-session-persistence.ts
@@ -1,0 +1,68 @@
+import type { ProjectSettings } from '@shared/project-settings';
+import { parsePtySessionId } from '@shared/ptySessionId';
+import type { IExecutionContext } from '../execution-context/types';
+import { getProjectTmuxEnabled } from '../projects/settings/tmux-enabled';
+import type { TeardownMode } from '../workspaces/workspace-registry';
+import { ptySessionRegistry } from './pty-session-registry';
+
+const TMUX_AVAILABILITY_CHECK_TIMEOUT_MS = 2_000;
+
+/** Agent sessions can survive app restarts via tmux on POSIX platforms. */
+export function canPersistAgentSessions(): boolean {
+  return process.platform !== 'win32';
+}
+
+export async function canUseTmuxForAgentSessions(
+  ctx: Pick<IExecutionContext, 'exec' | 'supportsLocalSpawn'>
+): Promise<boolean> {
+  if (ctx.supportsLocalSpawn && !canPersistAgentSessions()) return false;
+
+  const controller = new AbortController();
+  let timeout: ReturnType<typeof setTimeout> | undefined;
+  const timeoutPromise = new Promise<false>((resolve) => {
+    timeout = setTimeout(() => {
+      controller.abort();
+      resolve(false);
+    }, TMUX_AVAILABILITY_CHECK_TIMEOUT_MS);
+  });
+  const checkPromise = ctx
+    .exec('tmux', ['-V'], { signal: controller.signal })
+    .then(() => true)
+    .catch(() => false);
+
+  try {
+    return await Promise.race([checkPromise, timeoutPromise]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
+
+export function hasActiveAgentSessionsForProject(projectId: string): boolean {
+  return ptySessionRegistry.listActiveSessions().some((session) => {
+    if (!session.metadata?.providerId) return false;
+    const parsed = parsePtySessionId(session.sessionId);
+    return parsed?.projectId === projectId;
+  });
+}
+
+export function hasActivePersistedAgentSessionsForProject(projectId: string): boolean {
+  return ptySessionRegistry.listActiveSessions().some((session) => {
+    if (!session.metadata?.providerId || !session.metadata.tmuxSessionName) return false;
+    const parsed = parsePtySessionId(session.sessionId);
+    return parsed?.projectId === projectId;
+  });
+}
+
+export async function getProjectTeardownMode(
+  projectId: string,
+  projectSettings: ProjectSettings,
+  ctx: Pick<IExecutionContext, 'exec' | 'supportsLocalSpawn'>
+): Promise<TeardownMode> {
+  if ((await getProjectTmuxEnabled(projectSettings)) && (await canUseTmuxForAgentSessions(ctx))) {
+    return 'detach';
+  }
+  if (hasActivePersistedAgentSessionsForProject(projectId)) {
+    return 'detach';
+  }
+  return 'terminate';
+}

--- a/src/main/core/pty/pty-session-registry.ts
+++ b/src/main/core/pty/pty-session-registry.ts
@@ -7,6 +7,7 @@ export interface PtySessionMetadata {
   providerId?: AgentProviderId;
   title?: string;
   isRemote?: boolean;
+  tmuxSessionName?: string;
 }
 
 const FLUSH_INTERVAL_MS = 16; // ~60 fps

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -88,6 +88,10 @@ export class SshTerminalProvider implements TerminalProvider {
     sshConnectionManager.on('connection-event', this._handleReconnect);
   }
 
+  private removeReconnectListener(): void {
+    sshConnectionManager.off('connection-event', this._handleReconnect);
+  }
+
   async spawnTerminal(
     terminal: Terminal,
     initialSize: { cols: number; rows: number } = { cols: DEFAULT_COLS, rows: DEFAULT_ROWS },
@@ -250,7 +254,7 @@ export class SshTerminalProvider implements TerminalProvider {
   }
 
   async destroyAll(): Promise<void> {
-    sshConnectionManager.off('connection-event', this._handleReconnect);
+    this.removeReconnectListener();
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
     if (this.tmux) {
@@ -261,6 +265,7 @@ export class SshTerminalProvider implements TerminalProvider {
   }
 
   async detachAll(): Promise<void> {
+    this.removeReconnectListener();
     for (const [sessionId, pty] of this.sessions) {
       try {
         pty.kill();
@@ -268,5 +273,7 @@ export class SshTerminalProvider implements TerminalProvider {
       ptySessionRegistry.unregister(sessionId);
     }
     this.sessions.clear();
+    this.knownSessionIds.clear();
+    this.terminals.clear();
   }
 }

--- a/src/main/core/workspaces/workspace-factory.ts
+++ b/src/main/core/workspaces/workspace-factory.ts
@@ -27,6 +27,7 @@ import { getTaskEnvVars } from '@shared/task/envVars';
 import type { Task } from '@shared/tasks';
 import { getEffectiveTaskSettings } from '../projects/settings/effective-task-settings';
 import type { ProjectSettingsProvider } from '../projects/settings/provider';
+import { getProjectTmuxEnabled } from '../projects/settings/tmux-enabled';
 import { TimeoutSignal, withTimeout } from '../projects/utils';
 import { TEARDOWN_SCRIPT_WAIT_MS } from '../tasks/provision-task-error';
 
@@ -85,7 +86,7 @@ export function createWorkspaceFactory(
       defaultBranch,
       portSeed: workDir,
     });
-    const tmuxEnabled = projectSettings.tmux ?? false;
+    const tmuxEnabled = await getProjectTmuxEnabled(projectSettings);
     const taskLevelSettings = await getEffectiveTaskSettings({
       projectSettings: context.settings,
       taskFs: workspaceFs,
@@ -286,7 +287,6 @@ export function buildTaskProviders(
         projectId: opts.projectId,
         taskPath: opts.taskPath,
         taskId: opts.taskId,
-        tmux: opts.tmuxEnabled,
         shellSetup: opts.shellSetup,
         ctx,
         proxy: type.proxy,
@@ -312,7 +312,6 @@ export function buildTaskProviders(
       projectId: opts.projectId,
       taskPath: opts.taskPath,
       taskId: opts.taskId,
-      tmux: opts.tmuxEnabled,
       shellSetup: opts.shellSetup,
       ctx,
       taskEnvVars: opts.taskEnvVars,
@@ -358,7 +357,7 @@ export async function resolveTaskEnv(
       defaultBranch,
       portSeed: workspace.path,
     }),
-    tmuxEnabled: projectSettings.tmux ?? false,
+    tmuxEnabled: await getProjectTmuxEnabled(projectSettings),
     shellSetup: taskLevelSettings.shellSetup ?? projectSettings.shellSetup,
   };
 }

--- a/src/main/core/workspaces/workspace-lifecycle-service.test.ts
+++ b/src/main/core/workspaces/workspace-lifecycle-service.test.ts
@@ -126,4 +126,25 @@ describe('WorkspaceLifecycleService', () => {
     expect(requests).toHaveLength(2);
     expect(requests[1].shellSetup).toBe('source new-env');
   });
+
+  it('detach calls terminal detachAll instead of destroyAll', async () => {
+    const detachAll = vi.fn(async () => {});
+    const destroyAll = vi.fn(async () => {});
+    const service = new LifecycleScriptService({
+      projectId: 'project-4',
+      workspaceId: 'branch:feature',
+      terminals: {
+        async spawnTerminal() {},
+        async spawnLifecycleScript() {},
+        async killTerminal() {},
+        detachAll,
+        destroyAll,
+      },
+    });
+
+    await service.detach();
+
+    expect(detachAll).toHaveBeenCalledTimes(1);
+    expect(destroyAll).not.toHaveBeenCalled();
+  });
 });

--- a/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -160,6 +160,14 @@ export class LifecycleScriptService implements IDisposable {
     await this.runLifecycleScript(script, { initialSize, ...executeOptions });
   }
 
+  /** Detach lifecycle PTYs without killing tmux-backed sessions. Used on app shutdown. */
+  async detach(): Promise<void> {
+    this.disposed = true;
+    this.sessionsWithRespawnHandler.clear();
+    this.latestRespawnRequest.clear();
+    await this.terminals.detachAll();
+  }
+
   async dispose(): Promise<void> {
     this.disposed = true;
     this.sessionsWithRespawnHandler.clear();

--- a/src/main/core/workspaces/workspace-registry.test.ts
+++ b/src/main/core/workspaces/workspace-registry.test.ts
@@ -5,9 +5,11 @@ import { WorkspaceRegistry } from './workspace-registry';
 function makeWorkspace(id: string): {
   workspace: Workspace;
   dispose: ReturnType<typeof vi.fn>;
+  detach: ReturnType<typeof vi.fn>;
   gitDispose: ReturnType<typeof vi.fn>;
 } {
   const dispose = vi.fn(async () => {});
+  const detach = vi.fn(async () => {});
   const gitDispose = vi.fn();
 
   return {
@@ -19,11 +21,13 @@ function makeWorkspace(id: string): {
       settings: {} as Workspace['settings'],
       lifecycleService: {
         dispose,
+        detach,
       } as unknown as Workspace['lifecycleService'],
       repository: {} as Workspace['repository'],
       fetchService: {} as Workspace['fetchService'],
     },
     dispose,
+    detach,
     gitDispose,
   };
 }
@@ -178,7 +182,7 @@ describe('WorkspaceRegistry', () => {
     expect(onDestroy).toHaveBeenCalledWith(workspace);
   });
 
-  it('calls onDestroy before git.dispose and lifecycleService.dispose', async () => {
+  it('disposes git before onDestroy and lifecycleService on terminate', async () => {
     const registry = new WorkspaceRegistry();
     const { workspace, dispose, gitDispose } = makeWorkspace('branch:main');
     const order: string[] = [];
@@ -200,7 +204,7 @@ describe('WorkspaceRegistry', () => {
     await registry.acquire('branch:main', 'test-project', factory);
     await registry.release('branch:main');
 
-    expect(order).toEqual(['onDestroy', 'gitDispose', 'lifecycleDispose']);
+    expect(order).toEqual(['gitDispose', 'onDestroy', 'lifecycleDispose']);
   });
 
   it('calls onDestroy for each entry in releaseAll', async () => {
@@ -289,5 +293,22 @@ describe('WorkspaceRegistry', () => {
 
     expect(onDetach).toHaveBeenCalledTimes(1);
     expect(onDestroy).not.toHaveBeenCalled();
+  });
+
+  it('releaseAllForProject force releases shared workspaces in detach mode', async () => {
+    const registry = new WorkspaceRegistry();
+    const { workspace, detach, gitDispose } = makeWorkspace('branch:main');
+    const onDetach = vi.fn(async () => {});
+
+    await registry.acquire('branch:main', 'test-project', async () => ({ workspace, onDetach }));
+    await registry.acquire('branch:main', 'test-project', async () => ({ workspace, onDetach }));
+
+    await registry.releaseAllForProject('test-project', 'detach');
+
+    expect(registry.get('branch:main')).toBeUndefined();
+    expect(registry.refCount('branch:main')).toBe(0);
+    expect(gitDispose).toHaveBeenCalledTimes(1);
+    expect(detach).toHaveBeenCalledTimes(1);
+    expect(onDetach).toHaveBeenCalledTimes(1);
   });
 });

--- a/src/main/core/workspaces/workspace-registry.ts
+++ b/src/main/core/workspaces/workspace-registry.ts
@@ -80,14 +80,7 @@ export class WorkspaceRegistry {
     }
 
     this.entries.delete(key);
-    if (mode === 'terminate') {
-      await entry.onDestroy?.(entry.workspace);
-    }
-    entry.workspace.git.dispose();
-    await entry.workspace.lifecycleService.dispose();
-    if (mode === 'detach') {
-      await entry.onDetach?.(entry.workspace);
-    }
+    await this.teardownEntry(entry, mode);
   }
 
   get(key: string): Workspace | undefined {
@@ -105,27 +98,28 @@ export class WorkspaceRegistry {
   }
 
   async releaseAllForProject(projectId: string, mode: TeardownMode = 'terminate'): Promise<void> {
-    const keys = Array.from(this.entries.entries())
-      .filter(([, e]) => e.projectId === projectId)
-      .map(([k]) => k);
-    await Promise.all(keys.map((k) => this.release(k, mode)));
+    const entries = Array.from(this.entries.entries()).filter(([, e]) => e.projectId === projectId);
+    for (const [key] of entries) {
+      this.entries.delete(key);
+    }
+    await Promise.all(entries.map(([, entry]) => this.teardownEntry(entry, mode)));
   }
 
   async releaseAll(mode: TeardownMode = 'terminate'): Promise<void> {
     const entries = Array.from(this.entries.values());
     this.entries.clear();
-    await Promise.all(
-      entries.map(async (entry) => {
-        if (mode === 'terminate') {
-          await entry.onDestroy?.(entry.workspace);
-        }
-        entry.workspace.git.dispose();
-        await entry.workspace.lifecycleService.dispose();
-        if (mode === 'detach') {
-          await entry.onDetach?.(entry.workspace);
-        }
-      })
-    );
+    await Promise.all(entries.map((entry) => this.teardownEntry(entry, mode)));
+  }
+
+  private async teardownEntry(entry: WorkspaceEntry, mode: TeardownMode): Promise<void> {
+    entry.workspace.git.dispose();
+    if (mode === 'terminate') {
+      await entry.onDestroy?.(entry.workspace);
+      await entry.workspace.lifecycleService.dispose();
+    } else {
+      await entry.workspace.lifecycleService.detach();
+      await entry.onDetach?.(entry.workspace);
+    }
   }
 }
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -10,19 +10,16 @@ import { createMainWindow } from './app/window';
 import { providerTokenRegistry } from './core/account/provider-token-registry';
 import { emdashAccountService } from './core/account/services/emdash-account-service';
 import { agentHookService } from './core/agent-hooks/agent-hook-service';
+import { runBackgroundShutdown } from './core/app/background-shutdown';
 import { appService } from './core/app/service';
 import { localDependencyManager } from './core/dependencies/dependency-manager';
 import { editorBufferService } from './core/editor/editor-buffer-service';
 import { gitWatcherRegistry } from './core/git/git-watcher-registry';
 import { githubConnectionService } from './core/github/services/github-connection-service';
-import { projectManager } from './core/projects/project-manager';
 import { projectSettingsService } from './core/projects/settings/project-settings-service';
 import { promptLibraryService } from './core/prompt-library/service';
 import { prSyncScheduler } from './core/pull-requests/pr-sync-scheduler';
-import {
-  reconcileResourceSampler,
-  stopResourceSampler,
-} from './core/resource-monitor/resource-sampler';
+import { reconcileResourceSampler } from './core/resource-monitor/resource-sampler';
 import { searchService } from './core/search/search-service';
 import { workspaceFileIndexService } from './core/search/workspace-file-index-service';
 import { appSettingsService } from './core/settings/settings-service';
@@ -156,16 +153,7 @@ void app.whenReady().then(async () => {
 
 app.on('before-quit', (event) => {
   event.preventDefault();
-  telemetryService.capture('app_closed');
-  void telemetryService.dispose().finally(() => {
-    agentHookService.dispose();
-    stopResourceSampler();
-    updateService.dispose();
-    prSyncScheduler.dispose();
-    void gitWatcherRegistry.dispose();
-    void projectManager.dispose().catch((e) => {
-      log.error('Failed to shutdown project manager:', e);
-    });
+  void runBackgroundShutdown('exit').finally(() => {
     app.exit(0);
   });
 });

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,7 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { useCallback, useEffect, useState } from 'react';
 import { AppMenuEvents } from './app/app-menu-events';
+import { DevShutdownEvents } from './app/dev-shutdown-events';
 import { WelcomeScreen } from './app/welcome';
 import { Workspace } from './app/workspace';
 import { IntegrationsProvider } from './features/integrations/integrations-provider';
@@ -84,6 +85,7 @@ function AppContent() {
             <IntegrationsProvider>
               <WorkspaceViewProvider>
                 <AppMenuEvents onOpenSettings={handleOpenSettingsFromMenu} />
+                <DevShutdownEvents />
                 <RightSidebarProvider>
                   <ThemeProvider>
                     <ModalRenderer />

--- a/src/renderer/app/dev-shutdown-events.tsx
+++ b/src/renderer/app/dev-shutdown-events.tsx
@@ -1,0 +1,50 @@
+import { useEffect } from 'react';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import type { DevBackgroundShutdownSimulatedEvent } from '@shared/events/appEvents';
+
+const SESSION_KEY = 'emdash:dev-app-close-sim';
+
+function useMountEffect(effect: () => void | (() => void)): void {
+  // eslint-disable-next-line no-restricted-syntax
+  // oxlint-disable-next-line react/exhaustive-deps
+  useEffect(effect, []);
+}
+
+function readSimulatedClosePayload(): DevBackgroundShutdownSimulatedEvent | null {
+  const raw = sessionStorage.getItem(SESSION_KEY);
+  if (!raw) return null;
+  sessionStorage.removeItem(SESSION_KEY);
+  try {
+    return JSON.parse(raw) as DevBackgroundShutdownSimulatedEvent;
+  } catch {
+    return null;
+  }
+}
+
+export function DevShutdownEvents() {
+  useMountEffect(() => {
+    if (!import.meta.env.DEV) return;
+
+    const payload = readSimulatedClosePayload();
+    if (!payload) return;
+
+    const checkedSessions = payload.sessions.filter((s) => s.tmuxAlive !== undefined);
+    const alive = checkedSessions.filter((s) => s.tmuxAlive).length;
+    const total = payload.sessions.length;
+    const unchecked = total - checkedSessions.length;
+    const checkedSummary =
+      checkedSessions.length > 0
+        ? `${alive}/${checkedSessions.length} checked agent session(s) kept running in the background.`
+        : 'No agent sessions could be checked.';
+
+    toast({
+      title: 'App close simulated',
+      description:
+        total > 0
+          ? `${checkedSummary}${unchecked > 0 ? ` ${unchecked} remote or non-tmux session(s) were not checked.` : ''} Navigate back to your task — the agent should still be running with new output.`
+          : 'Navigate to a task with a running agent to verify sessions survive a close.',
+    });
+  });
+
+  return null;
+}

--- a/src/shared/events/appEvents.ts
+++ b/src/shared/events/appEvents.ts
@@ -66,3 +66,22 @@ export const shellSessionStartedChannel = defineEvent<{
 export const dependencyStatusUpdatedChannel = defineEvent<DependencyStatusUpdatedEvent>(
   'dependency:status-updated'
 );
+
+/** Dev-only: main finished a simulated app quit (detach) without exiting the process. */
+export type DevBackgroundShutdownSimulatedEvent = {
+  projectIds: string[];
+  sessions: Array<{
+    sessionId: string;
+    projectId?: string;
+    taskId?: string;
+    conversationId?: string;
+    providerId?: string;
+    title?: string;
+    isRemote?: boolean;
+    tmuxSessionName?: string;
+    tmuxAlive?: boolean;
+  }>;
+};
+
+export const devBackgroundShutdownSimulatedChannel =
+  defineEvent<DevBackgroundShutdownSimulatedEvent>('dev:background-shutdown-simulated');

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -75,6 +75,13 @@ export function defaultShareableProjectSettings(): ShareableProjectSettings {
 
 export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
 
+export function resolveProjectTmuxEnabled(
+  projectSettings: Pick<ProjectSettings, 'tmux'>,
+  tmuxByDefault: boolean
+): boolean {
+  return projectSettings.tmux ?? tmuxByDefault;
+}
+
 export type ProjectSettingsPage = {
   settings: ProjectSettings;
   defaults: {


### PR DESCRIPTION
# summary
- agents keep running on quit/update via tmux
- quit/update detaches instead of killing sessions when tmux is there

### without tmux/windows
- plain pty -> terminate on quit

### open questions
- maybe put this in experiemntal
- have to find a better way because this would be tmux only
- every session by default?