### PR TITLE
fix(prs): show GitHub pull requests in picker

### DIFF
--- a/src/main/core/pull-requests/pr-query-service.ts
+++ b/src/main/core/pull-requests/pr-query-service.ts
@@ -9,7 +9,7 @@ import {
   pullRequestUsers,
 } from '@main/db/schema';
 import type { Label, ListPrOptions, PrFilterOptions, PullRequest } from '@shared/pull-requests';
-import { assemblePullRequest, type PrRow } from './pr-utils';
+import { assemblePullRequest, pullRequestRepositoryScope, type PrRow } from './pr-utils';
 
 async function fetchRelated(rows: PrRow[]): Promise<PullRequest[]> {
   if (rows.length === 0) return [];
@@ -87,7 +87,7 @@ export class PrQueryService {
       repositoryUrls = remoteRows.map((r) => r.remoteUrl);
     }
 
-    const conditions = [inArray(pullRequests.repositoryUrl, repositoryUrls)];
+    const conditions = [pullRequestRepositoryScope(repositoryUrls)];
 
     const filters = options.filters;
     if (filters?.status && filters.status !== 'all') {
@@ -154,7 +154,7 @@ export class PrQueryService {
       .select()
       .from(pullRequests)
       .where(
-        and(eq(pullRequests.headRefName, taskBranch), eq(pullRequests.repositoryUrl, repositoryUrl))
+        and(eq(pullRequests.headRefName, taskBranch), pullRequestRepositoryScope([repositoryUrl]))
       );
 
     return fetchRelated(rows);
@@ -174,7 +174,7 @@ export class PrQueryService {
     const prUrlsSub = db
       .select({ url: pullRequests.url })
       .from(pullRequests)
-      .where(inArray(pullRequests.repositoryUrl, repositoryUrls));
+      .where(pullRequestRepositoryScope(repositoryUrls));
 
     const authorUserIdsSub = db
       .select({ userId: pullRequests.authorUserId })

--- a/src/main/core/pull-requests/pr-utils.test.ts
+++ b/src/main/core/pull-requests/pr-utils.test.ts
@@ -1,0 +1,27 @@
+import { SQLiteSyncDialect } from 'drizzle-orm/sqlite-core';
+import { describe, expect, it } from 'vitest';
+import { pullRequestRepositoryScope } from './pr-utils';
+
+describe('pullRequestRepositoryScope', () => {
+  it('matches pull requests by base or head repository URL', () => {
+    const dialect = new SQLiteSyncDialect();
+
+    const query = dialect.sqlToQuery(
+      pullRequestRepositoryScope(['https://github.com/contributor/repo'])
+    );
+
+    expect(query.sql).toContain('"pull_requests"."repository_url"');
+    expect(query.sql).toContain('"pull_requests"."head_repository_url"');
+    expect(query.sql).toContain(' or ');
+    expect(query.params).toEqual([
+      'https://github.com/contributor/repo',
+      'https://github.com/contributor/repo',
+    ]);
+  });
+
+  it('requires at least one repository URL', () => {
+    expect(() => pullRequestRepositoryScope([])).toThrow(
+      'pullRequestRepositoryScope requires at least one repository URL'
+    );
+  });
+});

--- a/src/main/core/pull-requests/pr-utils.ts
+++ b/src/main/core/pull-requests/pr-utils.ts
@@ -1,8 +1,9 @@
+import { inArray, or, type SQL } from 'drizzle-orm';
 import {
+  pullRequests,
   type pullRequestAssignees,
   type pullRequestChecks,
   type pullRequestLabels,
-  type pullRequests,
   type pullRequestUsers,
 } from '@main/db/schema';
 import type {
@@ -16,6 +17,14 @@ import type {
 } from '@shared/pull-requests';
 
 export type PrRow = typeof pullRequests.$inferSelect;
+
+/** Match PRs owned by or targeting a project remote (base or fork head). */
+export function pullRequestRepositoryScope(repositoryUrls: string[]): SQL {
+  return or(
+    inArray(pullRequests.repositoryUrl, repositoryUrls),
+    inArray(pullRequests.headRepositoryUrl, repositoryUrls)
+  )!;
+}
 export type PrUserRow = typeof pullRequestUsers.$inferSelect;
 export type PrLabelRow = typeof pullRequestLabels.$inferSelect;
 export type PrAssigneeRow = typeof pullRequestAssignees.$inferSelect;

--- a/src/main/core/pull-requests/pr-utils.ts
+++ b/src/main/core/pull-requests/pr-utils.ts
@@ -20,6 +20,10 @@ export type PrRow = typeof pullRequests.$inferSelect;
 
 /** Match PRs owned by or targeting a project remote (base or fork head). */
 export function pullRequestRepositoryScope(repositoryUrls: string[]): SQL {
+  if (repositoryUrls.length === 0) {
+    throw new Error('pullRequestRepositoryScope requires at least one repository URL');
+  }
+
   return or(
     inArray(pullRequests.repositoryUrl, repositoryUrls),
     inArray(pullRequests.headRepositoryUrl, repositoryUrls)

--- a/src/renderer/features/tasks/components/inline-pr-selector.tsx
+++ b/src/renderer/features/tasks/components/inline-pr-selector.tsx
@@ -54,10 +54,16 @@ export function InlinePrSelector({
 }: InlinePrSelectorProps) {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('open');
 
-  useEffect(() => {
-    if (!projectId || !repositoryUrl) return;
-    void rpc.pullRequests.syncPullRequests(projectId);
-  }, [projectId, repositoryUrl]);
+  useQuery({
+    queryKey: ['pull-requests-inline-sync', projectId, repositoryUrl],
+    queryFn: async () => {
+      await rpc.pullRequests.syncPullRequests(projectId!);
+      return null;
+    },
+    enabled: !!projectId && !!repositoryUrl,
+    staleTime: 60_000,
+    retry: false,
+  });
 
   const { data } = useQuery({
     queryKey: ['pull-requests-inline', projectId, repositoryUrl, statusFilter],

--- a/src/renderer/features/tasks/components/inline-pr-selector.tsx
+++ b/src/renderer/features/tasks/components/inline-pr-selector.tsx
@@ -54,6 +54,11 @@ export function InlinePrSelector({
 }: InlinePrSelectorProps) {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('open');
 
+  useEffect(() => {
+    if (!projectId || !repositoryUrl) return;
+    void rpc.pullRequests.syncPullRequests(projectId);
+  }, [projectId, repositoryUrl]);
+
   const { data } = useQuery({
     queryKey: ['pull-requests-inline', projectId, repositoryUrl, statusFilter],
     queryFn: async () => {

--- a/src/renderer/lib/pr-cache-invalidation.ts
+++ b/src/renderer/lib/pr-cache-invalidation.ts
@@ -1,13 +1,12 @@
 import { events } from '@renderer/lib/ipc';
 import { queryClient } from '@renderer/lib/query-client';
+import { shouldInvalidatePrListQuery } from '@renderer/lib/should-invalidate-pr-list-query';
 import { prSyncProgressChannel } from '@shared/events/prEvents';
 
 export function wirePrCacheInvalidation(): void {
   events.on(prSyncProgressChannel, (progress) => {
-    if (progress.status !== 'running' && progress.status !== 'done') return;
     void queryClient.invalidateQueries({
-      predicate: (query) =>
-        query.queryKey[0] === 'pull-requests' && query.queryKey[2] === progress.remoteUrl,
+      predicate: (query) => shouldInvalidatePrListQuery(query.queryKey, progress),
     });
   });
 }

--- a/src/renderer/lib/should-invalidate-pr-list-query.ts
+++ b/src/renderer/lib/should-invalidate-pr-list-query.ts
@@ -1,0 +1,17 @@
+import type { PrSyncProgress } from '@shared/pull-requests';
+
+export function shouldInvalidatePrListQuery(
+  queryKey: readonly unknown[],
+  progress: PrSyncProgress
+): boolean {
+  if (progress.status !== 'running' && progress.status !== 'done') return false;
+
+  const root = queryKey[0];
+  if (root === 'pull-requests-inline') {
+    return progress.status === 'done';
+  }
+  if (root === 'pull-requests') {
+    return queryKey[2] === progress.remoteUrl;
+  }
+  return false;
+}

--- a/src/renderer/lib/should-invalidate-pr-list-query.ts
+++ b/src/renderer/lib/should-invalidate-pr-list-query.ts
@@ -8,7 +8,7 @@ export function shouldInvalidatePrListQuery(
 
   const root = queryKey[0];
   if (root === 'pull-requests-inline') {
-    return progress.status === 'done';
+    return progress.status === 'done' && queryKey[2] === progress.remoteUrl;
   }
   if (root === 'pull-requests') {
     return queryKey[2] === progress.remoteUrl;

--- a/src/renderer/tests/pr-cache-invalidation.test.ts
+++ b/src/renderer/tests/pr-cache-invalidation.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import { shouldInvalidatePrListQuery } from '@renderer/lib/should-invalidate-pr-list-query';
+import type { PrSyncProgress } from '@shared/pull-requests';
+
+function progress(overrides: Partial<PrSyncProgress> = {}): PrSyncProgress {
+  return {
+    remoteUrl: 'https://github.com/acme/repo',
+    kind: 'full',
+    status: 'done',
+    ...overrides,
+  };
+}
+
+describe('shouldInvalidatePrListQuery', () => {
+  it('invalidates the project PR view when the synced remote matches', () => {
+    const key = ['pull-requests', 'project-1', 'https://github.com/acme/repo'] as const;
+    expect(shouldInvalidatePrListQuery(key, progress())).toBe(true);
+  });
+
+  it('does not invalidate the project PR view for unrelated remotes', () => {
+    const key = ['pull-requests', 'project-1', 'https://github.com/other/repo'] as const;
+    expect(shouldInvalidatePrListQuery(key, progress())).toBe(false);
+  });
+
+  it('invalidates inline PR picker queries after sync completes', () => {
+    const key = [
+      'pull-requests-inline',
+      'project-1',
+      'https://github.com/user/fork',
+      'open',
+    ] as const;
+    expect(shouldInvalidatePrListQuery(key, progress())).toBe(true);
+  });
+
+  it('does not invalidate inline PR picker queries while sync is still running', () => {
+    const key = [
+      'pull-requests-inline',
+      'project-1',
+      'https://github.com/user/fork',
+      'open',
+    ] as const;
+    expect(shouldInvalidatePrListQuery(key, progress({ status: 'running' }))).toBe(false);
+  });
+
+  it('ignores unrelated query keys', () => {
+    expect(shouldInvalidatePrListQuery(['issues'], progress())).toBe(false);
+  });
+});

--- a/src/renderer/tests/pr-cache-invalidation.test.ts
+++ b/src/renderer/tests/pr-cache-invalidation.test.ts
@@ -26,10 +26,20 @@ describe('shouldInvalidatePrListQuery', () => {
     const key = [
       'pull-requests-inline',
       'project-1',
-      'https://github.com/user/fork',
+      'https://github.com/acme/repo',
       'open',
     ] as const;
     expect(shouldInvalidatePrListQuery(key, progress())).toBe(true);
+  });
+
+  it('does not invalidate inline PR picker queries for unrelated remotes', () => {
+    const key = [
+      'pull-requests-inline',
+      'project-1',
+      'https://github.com/other/repo',
+      'open',
+    ] as const;
+    expect(shouldInvalidatePrListQuery(key, progress())).toBe(false);
   });
 
   it('does not invalidate inline PR picker queries while sync is still running', () => {


### PR DESCRIPTION
# sumamry
- fixes pr listing for fork-based github pull requests 
- refreshes create task pr modal after gh pr sync completes so from pr updates instead of staying empty