### PR TITLE
fix(release): build linux packages against glibc 2.35

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -14,13 +14,26 @@ permissions:
 jobs:
   release-linux:
     runs-on: ubuntu-latest
+    container: ubuntu:22.04
     permissions:
       contents: read
     environment: release
     steps:
-      - uses: actions/checkout@v4
       - name: Install system build dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config libsecret-1-dev rpm
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: >
+          apt-get update &&
+          apt-get install -y
+          build-essential
+          ca-certificates
+          curl
+          git
+          libsecret-1-dev
+          pkg-config
+          rpm
+          xz-utils
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
           posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
@@ -36,6 +49,9 @@ jobs:
           node --experimental-strip-types scripts/release/build.ts
           --platform linux --arch x64
           --config electron-builder.canary.config.ts
+
+      - name: Verify Linux native modules
+        run: node --experimental-strip-types scripts/release/verify-linux.ts
 
       - uses: ./.github/actions/upload-r2
         with:

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -15,13 +15,26 @@ jobs:
   release-linux:
     if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
+    container: ubuntu:22.04
     permissions:
       contents: read
     environment: release
     steps:
-      - uses: actions/checkout@v4
       - name: Install system build dependencies
-        run: sudo apt-get update && sudo apt-get install -y build-essential pkg-config libsecret-1-dev rpm
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: >
+          apt-get update &&
+          apt-get install -y
+          build-essential
+          ca-certificates
+          curl
+          git
+          libsecret-1-dev
+          pkg-config
+          rpm
+          xz-utils
+      - uses: actions/checkout@v4
       - uses: ./.github/actions/setup-build
         with:
           posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
@@ -35,6 +48,9 @@ jobs:
         run: >
           node --experimental-strip-types scripts/release/build.ts
           --platform linux --arch x64
+
+      - name: Verify Linux native modules
+        run: node --experimental-strip-types scripts/release/verify-linux.ts
 
       - uses: ./.github/actions/upload-r2
         with:

--- a/scripts/release/verify-linux.ts
+++ b/scripts/release/verify-linux.ts
@@ -1,0 +1,97 @@
+import { execFileSync } from 'node:child_process';
+import { existsSync, readdirSync, statSync } from 'node:fs';
+import path from 'node:path';
+import { fail, info, warn } from './lib/log.ts';
+
+const DEFAULT_MAX_GLIBC = '2.35';
+const RELEASE_DIR = 'release';
+const maxGlibc = process.env.EMDASH_MAX_GLIBC ?? DEFAULT_MAX_GLIBC;
+
+interface GlibcSymbol {
+  file: string;
+  version: string;
+}
+
+function parseVersion(version: string): [number, number] {
+  const match = /^(\d+)\.(\d+)$/.exec(version);
+  if (!match) fail(`Invalid GLIBC version: ${version}`);
+  return [Number(match[1]), Number(match[2])];
+}
+
+function isGreaterVersion(actual: string, max: string): boolean {
+  const [actualMajor, actualMinor] = parseVersion(actual);
+  const [maxMajor, maxMinor] = parseVersion(max);
+  return actualMajor > maxMajor || (actualMajor === maxMajor && actualMinor > maxMinor);
+}
+
+function findNativeModules(dir: string): string[] {
+  const results: string[] = [];
+
+  for (const entry of readdirSync(dir)) {
+    const fullPath = path.join(dir, entry);
+    const stat = statSync(fullPath);
+
+    if (stat.isDirectory()) {
+      results.push(...findNativeModules(fullPath));
+      continue;
+    }
+
+    if (
+      entry.endsWith('.node') &&
+      !fullPath.includes('/darwin-') &&
+      !fullPath.includes('/win32-')
+    ) {
+      results.push(fullPath);
+    }
+  }
+
+  return results;
+}
+
+function readGlibcSymbols(file: string): string[] {
+  try {
+    const output = execFileSync('objdump', ['-T', file], {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    return Array.from(output.matchAll(/GLIBC_(\d+\.\d+)/g), (match) => match[1]);
+  } catch {
+    warn(`Skipping native module that objdump could not inspect: ${file}`);
+    return [];
+  }
+}
+
+if (!existsSync(RELEASE_DIR)) {
+  fail(`Cannot verify Linux native modules because ${RELEASE_DIR}/ does not exist`);
+}
+
+const nativeModules = findNativeModules(RELEASE_DIR);
+if (nativeModules.length === 0) {
+  fail(`Cannot verify Linux native modules because no .node files were found in ${RELEASE_DIR}/`);
+}
+
+const violations: GlibcSymbol[] = [];
+let inspected = 0;
+
+for (const file of nativeModules) {
+  const symbols = readGlibcSymbols(file);
+  if (symbols.length === 0) continue;
+
+  inspected += 1;
+  for (const version of new Set(symbols)) {
+    if (isGreaterVersion(version, maxGlibc)) {
+      violations.push({ file, version });
+    }
+  }
+}
+
+if (inspected === 0) {
+  fail('Cannot verify Linux native modules because objdump found no GLIBC symbols');
+}
+
+if (violations.length > 0) {
+  const details = violations.map(({ file, version }) => `  ${file}: GLIBC_${version}`).join('\n');
+  fail(`Linux native modules require GLIBC newer than ${maxGlibc}:\n${details}`);
+}
+
+info(`Verified ${inspected} Linux native module(s) against GLIBC <= ${maxGlibc}`);

--- a/scripts/release/verify-linux.ts
+++ b/scripts/release/verify-linux.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import { existsSync, readdirSync, statSync } from 'node:fs';
 import path from 'node:path';
-import { fail, info, warn } from './lib/log.ts';
+import { fail, info } from './lib/log.ts';
 
 const DEFAULT_MAX_GLIBC = '2.35';
 const RELEASE_DIR = 'release';
@@ -48,16 +48,28 @@ function findNativeModules(dir: string): string[] {
   return results;
 }
 
-function readGlibcSymbols(file: string): string[] {
+interface GlibcInspection {
+  file: string;
+  symbols: string[];
+  error?: string;
+}
+
+function inspectGlibcSymbols(file: string): GlibcInspection {
   try {
     const output = execFileSync('objdump', ['-T', file], {
       encoding: 'utf8',
       stdio: ['ignore', 'pipe', 'pipe'],
     });
-    return Array.from(output.matchAll(/GLIBC_(\d+\.\d+)/g), (match) => match[1]);
-  } catch {
-    warn(`Skipping native module that objdump could not inspect: ${file}`);
-    return [];
+    return {
+      file,
+      symbols: Array.from(output.matchAll(/GLIBC_(\d+\.\d+)/g), (match) => match[1]),
+    };
+  } catch (error) {
+    return {
+      file,
+      symbols: [],
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -71,10 +83,17 @@ if (nativeModules.length === 0) {
 }
 
 const violations: GlibcSymbol[] = [];
+const inspectionFailures: GlibcInspection[] = [];
 let inspected = 0;
 
 for (const file of nativeModules) {
-  const symbols = readGlibcSymbols(file);
+  const inspection = inspectGlibcSymbols(file);
+  if (inspection.error) {
+    inspectionFailures.push(inspection);
+    continue;
+  }
+
+  const { symbols } = inspection;
   if (symbols.length === 0) continue;
 
   inspected += 1;
@@ -83,6 +102,11 @@ for (const file of nativeModules) {
       violations.push({ file, version });
     }
   }
+}
+
+if (inspectionFailures.length > 0) {
+  const details = inspectionFailures.map(({ file, error }) => `  ${file}: ${error}`).join('\n');
+  fail(`Cannot verify Linux native modules because objdump failed for:\n${details}`);
 }
 
 if (inspected === 0) {

--- a/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -215,6 +215,7 @@ describe('WorktreeService', () => {
         readFileAbsolute: vi.fn(async () => ''),
         copyFileAbsolute: vi.fn(async () => {}),
         statAbsolute: vi.fn(async () => null),
+        pathApi: path,
       };
       const svc = new WorktreeService({
         repoPath: repoDir,


### PR DESCRIPTION
fixes Linux native module GLIBC compatibility by building Linux release artifacts inside an Ubuntu 22.04 container instead of the latest GitHub runner environment

this prevents rebuilt native modules such as better-sqlite3, node-pty, and @parcel/watcher from accidentally linking against newer GLIBC symbols like GLIBC_2.38, which breaks Ubuntu 22.04 and other distros with older glibc