### PR TITLE
fix(conversations): restore tab rename editing

### DIFF
--- a/src/main/core/conversations/renameConversation.ts
+++ b/src/main/core/conversations/renameConversation.ts
@@ -1,16 +1,19 @@
 import { eq } from 'drizzle-orm';
 import { db } from '@main/db/client';
 import { conversations } from '@main/db/schema';
+import { MAX_CONVERSATION_TITLE_LENGTH } from '@shared/conversations';
 import { conversationEvents } from './conversation-events';
 
 export async function renameConversation(conversationId: string, name: string) {
+  const title = name.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
+
   const [existing] = await db
     .select({ projectId: conversations.projectId, taskId: conversations.taskId })
     .from(conversations)
     .where(eq(conversations.id, conversationId))
     .limit(1);
 
-  await db.update(conversations).set({ title: name }).where(eq(conversations.id, conversationId));
+  await db.update(conversations).set({ title }).where(eq(conversations.id, conversationId));
 
   if (existing) {
     conversationEvents._emit(
@@ -18,7 +21,7 @@ export async function renameConversation(conversationId: string, name: string) {
       conversationId,
       existing.projectId,
       existing.taskId,
-      name
+      title
     );
   }
 }

--- a/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
+++ b/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
@@ -22,6 +22,7 @@ import { MicroLabel } from '@renderer/lib/ui/label';
 import { RelativeTime } from '@renderer/lib/ui/relative-time';
 import { agentConfig } from '@renderer/utils/agentConfig';
 import { cn } from '@renderer/utils/utils';
+import { MAX_CONVERSATION_TITLE_LENGTH } from '@shared/conversations';
 import { AgentStatusIndicator } from '../components/agent-status-indicator';
 
 const ROW_HEIGHT = 32;
@@ -32,7 +33,6 @@ const ConversationRow = observer(function ConversationRow({
   conversationId: string;
 }) {
   const [isEditing, setIsEditing] = useState(false);
-  const pendingRenameRef = useRef(false);
   const taskView = useWorkspaceViewModel();
   const conversations = useConversations();
   const { tabManager, tabGroupManager } = taskView;
@@ -44,14 +44,7 @@ const ConversationRow = observer(function ConversationRow({
   }, []);
 
   const handleRename = useCallback(() => {
-    pendingRenameRef.current = true;
-  }, []);
-
-  const handleContextMenuOpenChangeComplete = useCallback((open: boolean) => {
-    if (!open && pendingRenameRef.current) {
-      pendingRenameRef.current = false;
-      setIsEditing(true);
-    }
+    window.setTimeout(() => setIsEditing(true), 0);
   }, []);
 
   const conversation = conversations.conversations.get(conversationId);
@@ -89,8 +82,9 @@ const ConversationRow = observer(function ConversationRow({
           ref={handleRenameInputRef}
           className="w-full rounded bg-background-1 px-1.5 py-0.5 text-sm text-foreground ring-1 ring-foreground/20 outline-none focus:ring-foreground/40"
           defaultValue={rawTitle}
+          maxLength={MAX_CONVERSATION_TITLE_LENGTH}
           onBlur={(e) => {
-            const value = e.target.value.trim();
+            const value = e.target.value.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
             if (value && value !== rawTitle) {
               handleRenameSubmit(value);
             } else {
@@ -99,7 +93,7 @@ const ConversationRow = observer(function ConversationRow({
           }}
           onKeyDown={(e) => {
             if (e.key === 'Enter') {
-              const value = e.currentTarget.value.trim();
+              const value = e.currentTarget.value.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
               if (value && value !== rawTitle) {
                 handleRenameSubmit(value);
               } else {
@@ -115,7 +109,7 @@ const ConversationRow = observer(function ConversationRow({
   }
 
   return (
-    <ContextMenu onOpenChangeComplete={handleContextMenuOpenChangeComplete}>
+    <ContextMenu>
       <ContextMenuTrigger>
         <button
           onClick={() => tabGroupManager.openConversationPreview(conversationId)}
@@ -151,7 +145,7 @@ const ConversationRow = observer(function ConversationRow({
           </span>
         </button>
       </ContextMenuTrigger>
-      <ContextMenuContent>
+      <ContextMenuContent finalFocus={false}>
         <ContextMenuItem onClick={handleRename}>
           <Pencil className="size-4" />
           Rename

--- a/src/renderer/features/tasks/view/tab-bar/conversation-tab-item.tsx
+++ b/src/renderer/features/tasks/view/tab-bar/conversation-tab-item.tsx
@@ -10,6 +10,7 @@ import {
 } from '@renderer/lib/ui/context-menu';
 import { Separator } from '@renderer/lib/ui/separator';
 import { agentConfig } from '@renderer/utils/agentConfig';
+import { MAX_CONVERSATION_TITLE_LENGTH } from '@shared/conversations';
 import { AgentStatusIndicator } from '../../components/agent-status-indicator';
 import { formatConversationTitleForDisplay } from '../../conversations/conversation-title-utils';
 import type { ResolvedConversationTab } from '../../tabs/tab-manager-store';
@@ -31,7 +32,6 @@ export const ConversationTabItem = observer(function ConversationTabItem({
   onRenameSubmit: (newName: string) => void;
 }) {
   const [isEditing, setIsEditing] = useState(false);
-  const pendingRenameRef = useRef(false);
   const committedRef = useRef(false);
 
   const config = agentConfig[tab.store.data.providerId];
@@ -39,21 +39,19 @@ export const ConversationTabItem = observer(function ConversationTabItem({
   const rawTitle = tab.store.data.title ?? '';
 
   const handleRename = useCallback(() => {
-    pendingRenameRef.current = true;
+    committedRef.current = false;
+    window.setTimeout(() => setIsEditing(true), 0);
   }, []);
 
-  const handleContextMenuOpenChangeComplete = useCallback((open: boolean) => {
-    if (!open && pendingRenameRef.current) {
-      pendingRenameRef.current = false;
-      committedRef.current = false;
-      setIsEditing(true);
-    }
+  const handleRenameInputRef = useCallback((input: HTMLInputElement | null) => {
+    input?.focus();
+    input?.select();
   }, []);
 
   const commitRename = (value: string) => {
     if (committedRef.current) return;
     committedRef.current = true;
-    const trimmed = value.trim();
+    const trimmed = value.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
     if (trimmed && trimmed !== rawTitle) {
       onRenameSubmit(trimmed);
     }
@@ -74,12 +72,10 @@ export const ConversationTabItem = observer(function ConversationTabItem({
           />
         ) : null}
         <input
-          ref={(el) => {
-            el?.focus();
-            el?.select();
-          }}
+          ref={handleRenameInputRef}
           className="max-w-24 rounded bg-background-1 px-1 py-0.5 text-sm text-foreground ring-1 ring-foreground/20 outline-none focus:ring-foreground/40"
           defaultValue={rawTitle}
+          maxLength={MAX_CONVERSATION_TITLE_LENGTH}
           onBlur={(e) => commitRename(e.target.value)}
           onKeyDown={(e) => {
             if (e.key === 'Enter') commitRename(e.currentTarget.value);
@@ -95,7 +91,7 @@ export const ConversationTabItem = observer(function ConversationTabItem({
   }
 
   return (
-    <ContextMenu onOpenChangeComplete={handleContextMenuOpenChangeComplete}>
+    <ContextMenu>
       <ContextMenuTrigger>
         <TabItemShell
           tabId={tab.tabId}
@@ -129,7 +125,7 @@ export const ConversationTabItem = observer(function ConversationTabItem({
           />
         </TabItemShell>
       </ContextMenuTrigger>
-      <ContextMenuContent>
+      <ContextMenuContent finalFocus={false}>
         <ContextMenuItem onClick={handleRename}>
           <Pencil className="size-4" />
           Rename

--- a/src/shared/conversations.ts
+++ b/src/shared/conversations.ts
@@ -1,5 +1,7 @@
 import type { AgentProviderId } from '@shared/agent-provider-registry';
 
+export const MAX_CONVERSATION_TITLE_LENGTH = 100;
+
 export type Conversation = {
   id: string;
   projectId: string;


### PR DESCRIPTION
# summary
- fixes renaming tabs not working 
- adds max tab name length at 100 chars