### PR TITLE
  fix(tasks): hydrate conversations and terminals on demand

### DIFF
--- a/src/main/core/conversations/controller.ts
+++ b/src/main/core/conversations/controller.ts
@@ -1,14 +1,18 @@
 import { createRPCController } from '@shared/ipc/rpc';
 import { createConversation } from './createConversation';
+import { dehydrateConversation } from './dehydrateConversation';
 import { deleteConversation } from './deleteConversation';
 import { getConversations } from './getConversations';
 import { getConversationsForTask } from './getConversationsForTask';
+import { hydrateConversation } from './hydrateConversation';
 import { renameConversation } from './renameConversation';
 
 export const conversationController = createRPCController({
   getConversations,
   createConversation,
   deleteConversation,
+  hydrateConversation,
+  dehydrateConversation,
   renameConversation,
   getConversationsForTask,
 });

--- a/src/main/core/conversations/dehydrateConversation.ts
+++ b/src/main/core/conversations/dehydrateConversation.ts
@@ -1,0 +1,10 @@
+import { resolveTask } from '../projects/utils';
+
+export async function dehydrateConversation(
+  projectId: string,
+  taskId: string,
+  conversationId: string
+): Promise<void> {
+  const task = resolveTask(projectId, taskId);
+  await task?.conversations.stopSession(conversationId);
+}

--- a/src/main/core/conversations/hydrateConversation.ts
+++ b/src/main/core/conversations/hydrateConversation.ts
@@ -1,0 +1,33 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '@main/db/client';
+import { conversations } from '@main/db/schema';
+import { resolveTask } from '../projects/utils';
+import { mapConversationRowToConversation } from './utils';
+
+export async function hydrateConversation(
+  projectId: string,
+  taskId: string,
+  conversationId: string
+): Promise<void> {
+  const task = resolveTask(projectId, taskId);
+  if (!task) throw new Error('Task not found');
+
+  const [row] = await db
+    .select()
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.id, conversationId),
+        eq(conversations.projectId, projectId),
+        eq(conversations.taskId, taskId)
+      )
+    )
+    .limit(1);
+  if (!row) throw new Error('Conversation not found');
+
+  await task.conversations.startSession(
+    mapConversationRowToConversation(row, true),
+    undefined,
+    true
+  );
+}

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it, vi } from 'vitest';
+import { makePtySessionId } from '@shared/ptySessionId';
+import { LocalConversationProvider } from './local-conversation';
+import { SshConversationProvider } from './ssh-conversation';
+
+vi.mock('@main/core/agent-hooks/agent-hook-service', () => ({
+  agentHookService: {},
+}));
+
+vi.mock('@main/core/agent-hooks/classifier-wiring', () => ({
+  wireAgentClassifier: vi.fn(),
+}));
+
+vi.mock('@main/core/agent-hooks/claude-trust-service', () => ({
+  claudeTrustService: {
+    maybeAutoTrustLocal: vi.fn(),
+    maybeAutoTrustSsh: vi.fn(),
+  },
+}));
+
+vi.mock('@main/core/agent-hooks/hook-config', () => ({
+  HookConfigWriter: class {},
+}));
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    emit: vi.fn(),
+  },
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: {
+    capture: vi.fn(),
+  },
+}));
+
+vi.mock('@main/core/settings/provider-settings-service', () => ({
+  providerOverrideSettings: {
+    getItem: vi.fn(),
+  },
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: {
+    getItem: vi.fn(),
+  },
+}));
+
+type RespawnState = {
+  respawnCounts: Map<string, number>;
+};
+
+function localProvider() {
+  return new LocalConversationProvider({
+    projectId: 'project-1',
+    taskId: 'task-1',
+    taskPath: '/tmp/task-1',
+    ctx: {} as never,
+  });
+}
+
+function sshProvider() {
+  return new SshConversationProvider({
+    projectId: 'project-1',
+    taskId: 'task-1',
+    taskPath: '/tmp/task-1',
+    ctx: {} as never,
+    proxy: {} as never,
+  });
+}
+
+describe('conversation provider respawn state', () => {
+  it('clears local respawn counts when explicitly stopping a session', async () => {
+    const provider = localProvider();
+    const sessionId = makePtySessionId('project-1', 'task-1', 'conversation-1');
+    (provider as unknown as RespawnState).respawnCounts.set(sessionId, 3);
+
+    await provider.stopSession('conversation-1');
+
+    expect((provider as unknown as RespawnState).respawnCounts.has(sessionId)).toBe(false);
+  });
+
+  it('clears SSH respawn counts when explicitly stopping a session', async () => {
+    const provider = sshProvider();
+    const sessionId = makePtySessionId('project-1', 'task-1', 'conversation-1');
+    (provider as unknown as RespawnState).respawnCounts.set(sessionId, 3);
+
+    await provider.stopSession('conversation-1');
+
+    expect((provider as unknown as RespawnState).respawnCounts.has(sessionId)).toBe(false);
+  });
+});

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -1,10 +1,18 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Pty, PtyExitInfo } from '@main/core/pty/pty';
+import type { Conversation } from '@shared/conversations';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { LocalConversationProvider } from './local-conversation';
 import { SshConversationProvider } from './ssh-conversation';
 
+const spawnLocalPty = vi.hoisted(() => vi.fn());
+const openSsh2Pty = vi.hoisted(() => vi.fn());
+
 vi.mock('@main/core/agent-hooks/agent-hook-service', () => ({
-  agentHookService: {},
+  agentHookService: {
+    getPort: vi.fn(() => 0),
+    getToken: vi.fn(() => 'token'),
+  },
 }));
 
 vi.mock('@main/core/agent-hooks/classifier-wiring', () => ({
@@ -19,12 +27,39 @@ vi.mock('@main/core/agent-hooks/claude-trust-service', () => ({
 }));
 
 vi.mock('@main/core/agent-hooks/hook-config', () => ({
-  HookConfigWriter: class {},
+  HookConfigWriter: class {
+    writeForProvider = vi.fn(async () => false);
+  },
+}));
+
+vi.mock('@main/core/pty/local-pty', () => ({
+  spawnLocalPty,
+}));
+
+vi.mock('@main/core/pty/spawn-utils', () => ({
+  resolveSshCommand: vi.fn(() => 'ssh command'),
+}));
+
+vi.mock('@main/core/pty/ssh2-pty', () => ({
+  openSsh2Pty,
+}));
+
+vi.mock('./agent-command', () => ({
+  buildAgentSessionCommand: vi.fn(() => ({ command: 'agent', args: [] })),
+}));
+
+vi.mock('./keystroke-injection', () => ({
+  scheduleInitialPromptInjection: vi.fn(),
+}));
+
+vi.mock('./provider-env', () => ({
+  resolveProviderEnv: vi.fn(() => ({})),
 }));
 
 vi.mock('@main/lib/events', () => ({
   events: {
     emit: vi.fn(),
+    on: vi.fn(() => () => {}),
   },
 }));
 
@@ -36,13 +71,13 @@ vi.mock('@main/lib/telemetry', () => ({
 
 vi.mock('@main/core/settings/provider-settings-service', () => ({
   providerOverrideSettings: {
-    getItem: vi.fn(),
+    getItem: vi.fn(async () => undefined),
   },
 }));
 
 vi.mock('@main/core/settings/settings-service', () => ({
   appSettingsService: {
-    getItem: vi.fn(),
+    get: vi.fn(async () => ({ writeAgentConfigToGitIgnore: true })),
   },
 }));
 
@@ -65,11 +100,84 @@ function sshProvider() {
     taskId: 'task-1',
     taskPath: '/tmp/task-1',
     ctx: {} as never,
-    proxy: {} as never,
+    proxy: { getRemoteShellProfile: vi.fn(async () => ({})) } as never,
   });
 }
 
+function conversation(): Conversation {
+  return {
+    id: 'conversation-1',
+    projectId: 'project-1',
+    taskId: 'task-1',
+    providerId: 'codex',
+    title: 'Conversation 1',
+    lastInteractedAt: null,
+    providerSessionId: 'provider-session-1',
+    isInitialConversation: false,
+  };
+}
+
+function fakePty(exitHandlers: Array<(info: PtyExitInfo) => void>): Pty {
+  return {
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn((handler) => exitHandlers.push(handler)),
+  };
+}
+
 describe('conversation provider respawn state', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    spawnLocalPty.mockReset();
+    openSsh2Pty.mockReset();
+  });
+
+  it('preserves resume mode when a local resumed session respawns', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+      spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+      const provider = localProvider();
+      const size = { cols: 100, rows: 40 };
+      const initialPrompt = 'continue';
+      const item = conversation();
+
+      await provider.startSession(item, size, true, initialPrompt);
+      const respawn = vi.spyOn(provider, 'startSession').mockResolvedValue(undefined);
+
+      for (const handler of exitHandlers) handler({ exitCode: 1 });
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(respawn).toHaveBeenCalledWith(item, size, true, initialPrompt);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('preserves resume mode when an SSH resumed session respawns', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+      openSsh2Pty.mockResolvedValue({ success: true, data: fakePty(exitHandlers) });
+      const provider = sshProvider();
+      const size = { cols: 100, rows: 40 };
+      const initialPrompt = 'continue';
+      const item = conversation();
+
+      await provider.startSession(item, size, true, initialPrompt);
+      const respawn = vi.spyOn(provider, 'startSession').mockResolvedValue(undefined);
+
+      for (const handler of exitHandlers) handler({ exitCode: 1 });
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(respawn).toHaveBeenCalledWith(item, size, true, initialPrompt);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('clears local respawn counts when explicitly stopping a session', async () => {
     const provider = localProvider();
     const sessionId = makePtySessionId('project-1', 'task-1', 'conversation-1');

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -254,6 +254,7 @@ export class LocalConversationProvider implements ConversationProvider {
   async stopSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
     this.knownSessionIds.delete(sessionId);
+    this.respawnCounts.delete(sessionId);
     const pty = this.sessions.get(sessionId);
     if (pty) {
       try {
@@ -286,5 +287,6 @@ export class LocalConversationProvider implements ConversationProvider {
       ptySessionRegistry.unregister(sessionId);
     }
     this.sessions.clear();
+    this.respawnCounts.clear();
   }
 }

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -6,6 +6,7 @@ import { HookConfigWriter } from '@main/core/agent-hooks/hook-config';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import { buildAgentEnv } from '@main/core/pty/pty-env';
@@ -170,9 +171,10 @@ export class LocalConversationProvider implements ConversationProvider {
       });
     }
 
-    pty.onExit(({ exitCode }) => {
+    pty.onExit(({ exitCode, signal }) => {
       ptySessionRegistry.unregister(sessionId);
-      const shouldRespawn = this.sessions.has(sessionId);
+      const shouldRespawn =
+        this.sessions.has(sessionId) && isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       events.emit(agentSessionExitedChannel, {
         sessionId,
@@ -185,7 +187,7 @@ export class LocalConversationProvider implements ConversationProvider {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
         this.respawnCounts.set(sessionId, count);
 
-        if (count > MAX_RESPAWNS && !isResuming) {
+        if (count > MAX_RESPAWNS) {
           log.error('LocalConversationProvider: respawn limit reached, giving up', {
             conversationId: conversation.id,
           });
@@ -193,11 +195,8 @@ export class LocalConversationProvider implements ConversationProvider {
           return;
         }
 
-        const resumeNext = isResuming && count <= MAX_RESPAWNS;
-        if (count > MAX_RESPAWNS) this.respawnCounts.set(sessionId, 0);
-
         setTimeout(() => {
-          this.startSession(conversation, initialSize, resumeNext, initialPrompt).catch((e) => {
+          this.startSession(conversation, initialSize, false, initialPrompt).catch((e) => {
             log.error('LocalConversationProvider: respawn failed', {
               conversationId: conversation.id,
               error: String(e),

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -203,8 +203,9 @@ export class LocalConversationProvider implements ConversationProvider {
           return;
         }
 
+        const resumeNext = isResuming && count <= MAX_RESPAWNS;
         setTimeout(() => {
-          this.startSession(conversation, initialSize, false, initialPrompt).catch((e) => {
+          this.startSession(conversation, initialSize, resumeNext, initialPrompt).catch((e) => {
             log.error('LocalConversationProvider: respawn failed', {
               conversationId: conversation.id,
               error: String(e),

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -178,8 +178,9 @@ export class SshConversationProvider implements ConversationProvider {
           return;
         }
 
+        const resumeNext = isResuming && count <= MAX_RESPAWNS;
         setTimeout(() => {
-          this.startSession(conversation, initialSize, false, initialPrompt).catch((e) => {
+          this.startSession(conversation, initialSize, resumeNext, initialPrompt).catch((e) => {
             log.error('SshConversationProvider: respawn failed', {
               conversationId: conversation.id,
               error: String(e),

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -3,6 +3,7 @@ import { claudeTrustService } from '@main/core/agent-hooks/claude-trust-service'
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import type { Pty } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
@@ -153,9 +154,10 @@ export class SshConversationProvider implements ConversationProvider {
       conversationId: conversation.id,
     });
 
-    pty.onExit(({ exitCode }) => {
+    pty.onExit(({ exitCode, signal }) => {
       ptySessionRegistry.unregister(sessionId);
-      const shouldRespawn = this.sessions.has(sessionId);
+      const shouldRespawn =
+        this.sessions.has(sessionId) && isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       events.emit(agentSessionExitedChannel, {
         sessionId,
@@ -168,7 +170,7 @@ export class SshConversationProvider implements ConversationProvider {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
         this.respawnCounts.set(sessionId, count);
 
-        if (count > MAX_RESPAWNS && !isResuming) {
+        if (count > MAX_RESPAWNS) {
           log.error('SshConversationProvider: respawn limit reached, giving up', {
             conversationId: conversation.id,
           });
@@ -176,11 +178,8 @@ export class SshConversationProvider implements ConversationProvider {
           return;
         }
 
-        const resumeNext = isResuming && count <= MAX_RESPAWNS;
-        if (count > MAX_RESPAWNS) this.respawnCounts.set(sessionId, 0);
-
         setTimeout(() => {
-          this.startSession(conversation, initialSize, resumeNext, initialPrompt).catch((e) => {
+          this.startSession(conversation, initialSize, false, initialPrompt).catch((e) => {
             log.error('SshConversationProvider: respawn failed', {
               conversationId: conversation.id,
               error: String(e),

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -205,6 +205,7 @@ export class SshConversationProvider implements ConversationProvider {
   async stopSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
     this.knownSessionIds.delete(sessionId);
+    this.respawnCounts.delete(sessionId);
     const pty = this.sessions.get(sessionId);
     if (pty) {
       try {
@@ -237,5 +238,6 @@ export class SshConversationProvider implements ConversationProvider {
       ptySessionRegistry.unregister(sessionId);
     }
     this.sessions.clear();
+    this.respawnCounts.clear();
   }
 }

--- a/src/main/core/pty/exit-classification.test.ts
+++ b/src/main/core/pty/exit-classification.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isUnexpectedPtyExit } from './exit-classification';
+
+describe('isUnexpectedPtyExit', () => {
+  it('treats a zero exit code without signal as expected', () => {
+    expect(isUnexpectedPtyExit({ exitCode: 0 })).toBe(false);
+  });
+
+  it('treats non-zero exit codes as unexpected', () => {
+    expect(isUnexpectedPtyExit({ exitCode: 1 })).toBe(true);
+  });
+
+  it('treats signal exits as unexpected even when exitCode is zero', () => {
+    expect(isUnexpectedPtyExit({ exitCode: 0, signal: 'SIGTERM' })).toBe(true);
+  });
+
+  it('treats missing exit status as unexpected', () => {
+    expect(isUnexpectedPtyExit({})).toBe(true);
+  });
+});

--- a/src/main/core/pty/exit-classification.ts
+++ b/src/main/core/pty/exit-classification.ts
@@ -1,0 +1,5 @@
+import type { PtyExitInfo } from './pty';
+
+export function isUnexpectedPtyExit({ exitCode, signal }: PtyExitInfo): boolean {
+  return exitCode !== 0 || signal !== undefined;
+}

--- a/src/main/core/pty/local-pty.test.ts
+++ b/src/main/core/pty/local-pty.test.ts
@@ -1,0 +1,101 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LocalPtySession } from './local-pty';
+
+vi.mock('node-pty', () => ({
+  spawn: vi.fn(),
+}));
+
+describe('LocalPtySession', () => {
+  type MockPtyProcess = ConstructorParameters<typeof LocalPtySession>[1];
+
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+  let mockProc: MockPtyProcess;
+  let pty: LocalPtySession;
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      ...originalPlatform,
+      value: platform,
+    });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+
+    mockProc = {
+      pid: 1234,
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn(),
+    } as unknown as MockPtyProcess;
+    pty = new LocalPtySession('test-id', mockProc);
+
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('kill() sends SIGTERM to process group on POSIX', () => {
+    setPlatform('linux');
+
+    pty.kill();
+
+    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGTERM');
+    expect(mockProc.kill).toHaveBeenCalled();
+  });
+
+  it('kill() follows up with SIGKILL after 2 seconds if not exited', () => {
+    setPlatform('linux');
+
+    pty.kill();
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+
+    vi.advanceTimersByTime(2000);
+    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGKILL');
+  });
+
+  it('kill() does not send SIGKILL if process exits before timeout', () => {
+    setPlatform('linux');
+
+    let exitHandler: ((info: { exitCode: number; signal: number }) => void) | undefined;
+    vi.mocked(mockProc.onExit).mockImplementation((handler) => {
+      exitHandler = handler;
+      return { dispose: vi.fn() };
+    });
+
+    pty.onExit(() => {});
+    pty.kill();
+    exitHandler?.({ exitCode: 0, signal: 0 });
+
+    vi.advanceTimersByTime(2000);
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+  });
+
+  it('kill() does not use process groups on Windows', () => {
+    setPlatform('win32');
+
+    pty.kill();
+
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, expect.any(String));
+    expect(mockProc.kill).toHaveBeenCalled();
+  });
+
+  it('kill() is idempotent', () => {
+    setPlatform('linux');
+
+    pty.kill();
+    pty.kill();
+
+    expect(process.kill).toHaveBeenCalledTimes(1);
+    expect(mockProc.kill).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/main/core/pty/local-pty.ts
+++ b/src/main/core/pty/local-pty.ts
@@ -46,6 +46,8 @@ export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
 
 export class LocalPtySession implements Pty {
   readonly id: string;
+  private killTimer: ReturnType<typeof setTimeout> | null = null;
+  private killed = false;
 
   constructor(
     id: string,
@@ -73,7 +75,25 @@ export class LocalPtySession implements Pty {
   }
 
   kill(): void {
-    this.proc.kill();
+    if (this.killed) return;
+    this.killed = true;
+
+    const pid = this.proc.pid;
+    if (process.platform !== 'win32' && Number.isInteger(pid) && pid > 0) {
+      try {
+        process.kill(-pid, 'SIGTERM');
+      } catch {}
+      this.killTimer = setTimeout(() => {
+        try {
+          process.kill(-pid, 'SIGKILL');
+        } catch {}
+        this.killTimer = null;
+      }, 2000);
+    }
+
+    try {
+      this.proc.kill();
+    } catch {}
   }
 
   onData(handler: (data: string) => void): void {
@@ -82,6 +102,10 @@ export class LocalPtySession implements Pty {
 
   onExit(handler: (info: PtyExitInfo) => void): void {
     this.proc.onExit(({ exitCode, signal }) => {
+      if (this.killTimer) {
+        clearTimeout(this.killTimer);
+        this.killTimer = null;
+      }
       handler({ exitCode, signal: normalizeSignal(signal) });
     });
   }

--- a/src/main/core/tasks/hydration.test.ts
+++ b/src/main/core/tasks/hydration.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import type { TaskViewSnapshot } from '@shared/view-state';
+import { getConversationIdsForInitialHydration } from './hydration';
+
+describe('getConversationIdsForInitialHydration', () => {
+  it('returns conversations from multi-pane tab groups', () => {
+    const snapshot: Partial<TaskViewSnapshot> = {
+      tabGroups: {
+        activeGroupId: 'g1',
+        paneSizes: [50, 50],
+        groups: [
+          {
+            groupId: 'g1',
+            tabManager: {
+              activeTabId: 'tab-1',
+              tabs: [
+                {
+                  kind: 'conversation',
+                  tabId: 'tab-1',
+                  conversationId: 'conv-1',
+                  isPreview: false,
+                },
+                { kind: 'file', tabId: 'tab-2', path: 'README.md', isPreview: false },
+              ],
+            },
+          },
+          {
+            groupId: 'g2',
+            tabManager: {
+              activeTabId: 'tab-3',
+              tabs: [
+                {
+                  kind: 'conversation',
+                  tabId: 'tab-3',
+                  conversationId: 'conv-2',
+                  isPreview: true,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    };
+
+    expect([...getConversationIdsForInitialHydration(snapshot)]).toEqual(['conv-1', 'conv-2']);
+  });
+
+  it('supports legacy conversation tab snapshots', () => {
+    const snapshot: Partial<TaskViewSnapshot> = {
+      conversations: {
+        tabOrder: ['conv-legacy'],
+        activeTabId: 'conv-legacy',
+      },
+    };
+
+    expect([...getConversationIdsForInitialHydration(snapshot)]).toEqual(['conv-legacy']);
+  });
+
+  it('does not invent fallback conversations when no conversation tabs are persisted', () => {
+    expect([...getConversationIdsForInitialHydration(null)]).toEqual([]);
+    expect([...getConversationIdsForInitialHydration({})]).toEqual([]);
+  });
+});

--- a/src/main/core/tasks/hydration.ts
+++ b/src/main/core/tasks/hydration.ts
@@ -1,0 +1,25 @@
+import type { TabDescriptor, TaskViewSnapshot } from '@shared/view-state';
+
+export function getConversationIdsForInitialHydration(
+  snapshot: Partial<TaskViewSnapshot> | null | undefined
+): Set<string> {
+  const ids = new Set<string>();
+
+  for (const tab of getSnapshotTabs(snapshot)) {
+    if (tab.kind === 'conversation') ids.add(tab.conversationId);
+  }
+
+  if (snapshot?.conversations?.tabOrder) {
+    for (const id of snapshot.conversations.tabOrder) ids.add(id);
+  }
+
+  return ids;
+}
+
+function getSnapshotTabs(snapshot: Partial<TaskViewSnapshot> | null | undefined): TabDescriptor[] {
+  if (!snapshot) return [];
+  if (snapshot.tabGroups) {
+    return snapshot.tabGroups.groups.flatMap((group) => group.tabManager.tabs);
+  }
+  return snapshot.tabManager?.tabs ?? [];
+}

--- a/src/main/core/tasks/load-initial-conversations.ts
+++ b/src/main/core/tasks/load-initial-conversations.ts
@@ -1,0 +1,37 @@
+import { and, eq, inArray } from 'drizzle-orm';
+import { mapConversationRowToConversation } from '@main/core/conversations/utils';
+import { viewStateService } from '@main/core/view-state/view-state-service';
+import { db } from '@main/db/client';
+import { conversations } from '@main/db/schema';
+import type { Conversation } from '@shared/conversations';
+import type { TaskViewSnapshot } from '@shared/view-state';
+import { getConversationIdsForInitialHydration } from './hydration';
+
+export async function loadConversationsForInitialHydration(
+  projectId: string,
+  taskId: string
+): Promise<Conversation[]> {
+  const snapshot = (await viewStateService.get(`task:${taskId}`)) as
+    | Partial<TaskViewSnapshot>
+    | null
+    | undefined;
+  const ids = [...getConversationIdsForInitialHydration(snapshot)];
+  if (ids.length === 0) return [];
+
+  const rows = await db
+    .select()
+    .from(conversations)
+    .where(
+      and(
+        eq(conversations.projectId, projectId),
+        eq(conversations.taskId, taskId),
+        inArray(conversations.id, ids)
+      )
+    );
+
+  const byId = new Map(rows.map((row) => [row.id, row]));
+  return ids.flatMap((id) => {
+    const row = byId.get(id);
+    return row ? [mapConversationRowToConversation(row, true)] : [];
+  });
+}

--- a/src/main/core/tasks/task-builder.ts
+++ b/src/main/core/tasks/task-builder.ts
@@ -9,7 +9,6 @@ import { log } from '@main/lib/logger';
 import type { Conversation } from '@shared/conversations';
 import { taskProvisionProgressChannel } from '@shared/events/taskEvents';
 import type { Task } from '@shared/tasks';
-import type { Terminal } from '@shared/terminals';
 import type { ProvisionResult, TaskProvider } from '../projects/project-provider';
 import type { ProjectSettingsProvider } from '../projects/settings/provider';
 import { resolveTaskWorkDir } from '../projects/worktrees/utils';
@@ -29,8 +28,7 @@ export type BuildTaskResult = {
 
 export type ProvisionLocalTaskParams = {
   task: Task;
-  conversations: Conversation[];
-  terminals: Terminal[];
+  conversationsToHydrate?: Conversation[];
   workspaceId: string;
   type: WorkspaceType;
   projectId: string;
@@ -63,8 +61,7 @@ export async function provisionLocalTask(
 ): Promise<ProvisionLocalTaskResult> {
   const {
     task,
-    conversations,
-    terminals,
+    conversationsToHydrate = [],
     workspaceId,
     type,
     projectId,
@@ -111,7 +108,7 @@ export async function provisionLocalTask(
       taskId: task.id,
       projectId,
       step: 'starting-sessions',
-      message: 'Starting sessions…',
+      message: 'Preparing task…',
     });
     const buildTaskResult = await buildTaskFromWorkspace(
       task,
@@ -120,8 +117,7 @@ export async function provisionLocalTask(
       projectId,
       projectPath,
       settings,
-      { conversations, terminals },
-      logPrefix
+      conversationsToHydrate
     );
     log.debug(`${logPrefix}: provisionLocalTask DONE`, { taskId: task.id });
     provisionSucceeded = true;
@@ -151,8 +147,7 @@ export async function buildTaskFromWorkspace(
   projectId: string,
   projectPath: string,
   settings: ProjectSettingsProvider,
-  hydrate: { conversations: Conversation[]; terminals: Terminal[] },
-  logPrefix: string
+  conversationsToHydrate: Conversation[] = []
 ): Promise<BuildTaskResult> {
   const { taskEnvVars, tmuxEnabled, shellSetup } = await resolveTaskEnv(
     task,
@@ -182,21 +177,10 @@ export async function buildTaskFromWorkspace(
     terminals: terminalProvider,
   };
 
-  void Promise.all(
-    hydrate.terminals.map((term) =>
-      terminalProvider.spawnTerminal(term).catch((e) => {
-        log.error(`${logPrefix}: failed to hydrate terminal`, {
-          terminalId: term.id,
-          error: String(e),
-        });
-      })
-    )
-  );
-
-  void Promise.all(
-    hydrate.conversations.map((conv) =>
+  await Promise.all(
+    conversationsToHydrate.map((conv) =>
       conversationProvider.startSession(conv, undefined, true).catch((e) => {
-        log.error(`${logPrefix}: failed to hydrate conversation`, {
+        log.error('buildTaskFromWorkspace: failed to hydrate conversation from view state', {
           conversationId: conv.id,
           error: String(e),
         });

--- a/src/main/core/tasks/task-manager.ts
+++ b/src/main/core/tasks/task-manager.ts
@@ -13,10 +13,10 @@ import { taskProvisionProgressChannel, type ProvisionStep } from '@shared/events
 import { makePtySessionId } from '@shared/ptySessionId';
 import { err, ok, type Result } from '@shared/result';
 import type { Task, TaskBootstrapStatus } from '@shared/tasks';
-import type { Terminal } from '@shared/terminals';
 import type { WorkspaceType as SharedWorkspaceType } from '@shared/workspaces';
 import type { ProjectProvider, ProvisionResult, TaskProvider } from '../projects/project-provider';
 import { withTimeout } from '../projects/utils';
+import { loadConversationsForInitialHydration } from './load-initial-conversations';
 import {
   formatProvisionTaskError,
   TASK_TIMEOUT_MS,
@@ -53,9 +53,8 @@ export type TaskManagerHooks = {
 async function executeProvision(
   provider: ProjectProvider,
   task: Task,
-  conversations: Conversation[],
-  terminals: Terminal[],
-  hint: WorkspaceHint
+  hint: WorkspaceHint,
+  conversationsToHydrate: Conversation[]
 ): Promise<ProvisionResult> {
   const workspaceId = hint.id;
 
@@ -69,8 +68,6 @@ async function executeProvision(
     }
     return provisionBYOITask({
       task,
-      conversations,
-      terminals,
       wpConfig: projectSettings.workspaceProvider,
       ctx: provider.ctx,
       projectId: provider.projectId,
@@ -78,13 +75,12 @@ async function executeProvision(
       settings: provider.settings,
       logPrefix: `${provider.type}ProjectProvider[byoi]`,
       workspaceId,
+      conversationsToHydrate,
     });
   }
 
   const { provisionResult, workspace } = await provisionLocalTask({
     task,
-    conversations,
-    terminals,
     workspaceId,
     type: provider.defaultWorkspaceType,
     projectId: provider.projectId,
@@ -95,6 +91,7 @@ async function executeProvision(
     repository: provider.repository,
     logPrefix: `${provider.type}ProjectProvider`,
     workDir: hint.path,
+    conversationsToHydrate,
   });
 
   if (provider.defaultWorkspaceType.kind === 'local') {
@@ -165,8 +162,6 @@ class TaskManager {
   async provisionTask(
     provider: ProjectProvider,
     task: Task,
-    conversations: Conversation[],
-    terminals: Terminal[],
     hint: WorkspaceHint
   ): Promise<Result<ProvisionResult, ProvisionTaskError>> {
     return this._lifecycle.provision(task.id, async () => {
@@ -175,8 +170,12 @@ class TaskManager {
         if (progress.taskId === task.id) lastStep = progress.step;
       });
       try {
+        const conversationsToHydrate = await loadConversationsForInitialHydration(
+          provider.projectId,
+          task.id
+        );
         const result = await withTimeout(
-          executeProvision(provider, task, conversations, terminals, hint),
+          executeProvision(provider, task, hint, conversationsToHydrate),
           TASK_TIMEOUT_MS
         );
         const stored: StoredTask = {

--- a/src/main/core/tasks/task-service.ts
+++ b/src/main/core/tasks/task-service.ts
@@ -1,12 +1,10 @@
 import { eq, sql } from 'drizzle-orm';
-import { mapConversationRowToConversation } from '@main/core/conversations/utils';
 import { projectManager } from '@main/core/projects/project-manager';
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
-import { mapTerminalRowToTerminal } from '@main/core/terminals/core';
 import { workspaceBootstrapService } from '@main/core/workspaces/workspace-bootstrap-service';
 import { workspaceRegistry } from '@main/core/workspaces/workspace-registry';
 import { db } from '@main/db/client';
-import { conversations, tasks, terminals, workspaces } from '@main/db/schema';
+import { tasks, workspaces } from '@main/db/schema';
 import { HookCore, type Hookable } from '@main/lib/hookable';
 import { log } from '@main/lib/logger';
 import { err, ok, type Result } from '@shared/result';
@@ -79,20 +77,6 @@ export class TaskService implements Hookable<TaskCrudHooks> {
       });
     }
 
-    // Load existing sessions (empty arrays for brand-new tasks).
-    const [existingTerminals, existingConversations] = await Promise.all([
-      db
-        .select()
-        .from(terminals)
-        .where(eq(terminals.taskId, taskId))
-        .then((rows) => rows.map(mapTerminalRowToTerminal)),
-      db
-        .select()
-        .from(conversations)
-        .where(eq(conversations.taskId, taskId))
-        .then((rows) => rows.map((r) => mapConversationRowToConversation(r, true))),
-    ]);
-
     if (!row.workspaceId) throw new Error(`Task ${taskId} has no workspace — cannot provision`);
 
     const workspaceRow = await db
@@ -111,13 +95,7 @@ export class TaskService implements Hookable<TaskCrudHooks> {
       path: workspaceRow.path ?? undefined,
     };
 
-    const result = await taskManager.provisionTask(
-      project,
-      task,
-      existingConversations,
-      existingTerminals,
-      hint
-    );
+    const result = await taskManager.provisionTask(project, task, hint);
     if (!result.success) return err(result.error);
 
     const { persistData } = result.data;

--- a/src/main/core/terminals/controller.ts
+++ b/src/main/core/terminals/controller.ts
@@ -3,6 +3,8 @@ import { createTerminal } from './createTerminal';
 import { deleteTerminal } from './deleteTerminal';
 import { getAllTerminals } from './getAllTerminals';
 import { getTerminalsForTask } from './getTerminalsForTask';
+import { hydrateTerminal } from './hydrateTerminal';
+import { prepareLifecycleScript } from './prepareLifecycleScript';
 import { renameTerminal } from './renameTerminal';
 import { runLifecycleScript } from './runLifecycleScript';
 
@@ -10,6 +12,8 @@ export const terminalsController = createRPCController({
   getAllTerminals,
   createTerminal,
   deleteTerminal,
+  hydrateTerminal,
+  prepareLifecycleScript,
   renameTerminal,
   getTerminalsForTask,
   runLifecycleScript,

--- a/src/main/core/terminals/hydrateTerminal.ts
+++ b/src/main/core/terminals/hydrateTerminal.ts
@@ -1,0 +1,33 @@
+import { and, eq } from 'drizzle-orm';
+import { db } from '@main/db/client';
+import { terminals } from '@main/db/schema';
+import { resolveTask } from '../projects/utils';
+import { mapTerminalRowToTerminal } from './core';
+
+export async function hydrateTerminal({
+  projectId,
+  taskId,
+  terminalId,
+}: {
+  projectId: string;
+  taskId: string;
+  terminalId: string;
+}): Promise<void> {
+  const task = resolveTask(projectId, taskId);
+  if (!task) throw new Error('Task not found');
+
+  const [row] = await db
+    .select()
+    .from(terminals)
+    .where(
+      and(
+        eq(terminals.id, terminalId),
+        eq(terminals.projectId, projectId),
+        eq(terminals.taskId, taskId)
+      )
+    )
+    .limit(1);
+  if (!row) throw new Error('Terminal not found');
+
+  await task.terminals.spawnTerminal(mapTerminalRowToTerminal(row));
+}

--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -1,4 +1,5 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import { buildTerminalEnv } from '@main/core/pty/pty-env';
@@ -154,8 +155,11 @@ export class LocalTerminalProvider implements TerminalProvider {
       wireTerminalDevServerWatcher({ pty, scopeId: this.scopeId, terminalId: terminal.id });
     }
 
-    pty.onExit(() => {
-      const shouldRespawn = policy.respawnOnExit && this.sessions.has(sessionId);
+    pty.onExit(({ exitCode, signal }) => {
+      const shouldRespawn =
+        policy.respawnOnExit &&
+        this.sessions.has(sessionId) &&
+        isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       if (!policy.preserveBufferOnExit) {
         ptySessionRegistry.unregister(sessionId);

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -1,4 +1,5 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import type { Pty } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
@@ -175,8 +176,11 @@ export class SshTerminalProvider implements TerminalProvider {
       });
     }
 
-    pty.onExit(() => {
-      const shouldRespawn = policy.respawnOnExit && this.sessions.has(sessionId);
+    pty.onExit(({ exitCode, signal }) => {
+      const shouldRespawn =
+        policy.respawnOnExit &&
+        this.sessions.has(sessionId) &&
+        isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
       if (!policy.preserveBufferOnExit) {
         ptySessionRegistry.unregister(sessionId);

--- a/src/main/core/terminals/prepareLifecycleScript.ts
+++ b/src/main/core/terminals/prepareLifecycleScript.ts
@@ -1,0 +1,28 @@
+import { getEffectiveTaskSettings } from '../projects/settings/effective-task-settings';
+import { resolveWorkspace } from '../projects/utils';
+
+export async function prepareLifecycleScript({
+  projectId,
+  workspaceId,
+  type,
+}: {
+  projectId: string;
+  workspaceId: string;
+  type: 'setup' | 'run' | 'teardown';
+}): Promise<void> {
+  const workspace = resolveWorkspace(projectId, workspaceId);
+  if (!workspace) throw new Error('Workspace not found');
+
+  const settings = await getEffectiveTaskSettings({
+    projectSettings: workspace.settings,
+    taskFs: workspace.fs,
+  });
+  const script = settings.scripts?.[type];
+  if (!script) return;
+
+  await workspace.lifecycleService.prepareLifecycleScript({
+    type,
+    script,
+    shellSetup: settings.shellSetup,
+  });
+}

--- a/src/main/core/workspaces/byoi/provision-byoi-task.ts
+++ b/src/main/core/workspaces/byoi/provision-byoi-task.ts
@@ -13,12 +13,9 @@ import type { Conversation } from '@shared/conversations';
 import { taskProvisionProgressChannel } from '@shared/events/taskEvents';
 import type { ProjectSettings } from '@shared/project-settings';
 import type { Task } from '@shared/tasks';
-import type { Terminal } from '@shared/terminals';
 
 export type ProvisionBYOITaskParams = {
   task: Task;
-  conversations: Conversation[];
-  terminals: Terminal[];
   /** Workspace provider config read from project settings (`workspaceProvider.type === 'script'`). */
   wpConfig: NonNullable<ProjectSettings['workspaceProvider']>;
   /** Execution context for running provision/terminate scripts. */
@@ -29,6 +26,7 @@ export type ProvisionBYOITaskParams = {
   logPrefix: string;
   /** UUID from the workspaces table — used as the workspace registry key. */
   workspaceId: string;
+  conversationsToHydrate?: Conversation[];
 };
 
 /**
@@ -40,14 +38,13 @@ export type ProvisionBYOITaskParams = {
 export async function provisionBYOITask(params: ProvisionBYOITaskParams): Promise<ProvisionResult> {
   const {
     task,
-    conversations,
-    terminals,
     wpConfig,
     ctx,
     projectId,
     projectPath,
     settings,
     logPrefix,
+    conversationsToHydrate = [],
   } = params;
 
   events.emit(taskProvisionProgressChannel, {
@@ -127,7 +124,7 @@ export async function provisionBYOITask(params: ProvisionBYOITaskParams): Promis
       taskId: task.id,
       projectId,
       step: 'starting-sessions',
-      message: 'Starting sessions…',
+      message: 'Preparing task…',
     });
     const { taskProvider } = await buildTaskFromWorkspace(
       task,
@@ -136,8 +133,7 @@ export async function provisionBYOITask(params: ProvisionBYOITaskParams): Promis
       projectId,
       projectPath,
       settings,
-      { conversations, terminals },
-      logPrefix
+      conversationsToHydrate
     );
     log.debug(`${logPrefix}: provisionBYOITask DONE`, { taskId: task.id });
     provisionSucceeded = true;

--- a/src/main/core/workspaces/workspace-factory.ts
+++ b/src/main/core/workspaces/workspace-factory.ts
@@ -196,20 +196,6 @@ export function createWorkspaceFactory(
             shellSetup,
           });
         }
-        if (scripts?.run) {
-          void ws.lifecycleService.prepareLifecycleScript({
-            type: 'run',
-            script: scripts.run,
-            shellSetup,
-          });
-        }
-        if (scripts?.teardown) {
-          void ws.lifecycleService.prepareLifecycleScript({
-            type: 'teardown',
-            script: scripts.teardown,
-            shellSetup,
-          });
-        }
       },
 
       onCreate: context.extraHooks?.onCreate,

--- a/src/renderer/features/tasks/conversations/conversation-manager.test.ts
+++ b/src/renderer/features/tasks/conversations/conversation-manager.test.ts
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ConversationManagerStore } from './conversation-manager';
+
+const hydrateConversation = vi.hoisted(() => vi.fn());
+const dehydrateConversation = vi.hoisted(() => vi.fn());
+const frontendConnect = vi.hoisted(() => vi.fn());
+const frontendDispose = vi.hoisted(() => vi.fn());
+
+vi.mock('@renderer/features/tasks/stores/open-file-in-file-editor', () => ({
+  makeFileLinkHandlers: () => ({
+    onOpenExternal: vi.fn(),
+    onOpenFile: vi.fn(),
+  }),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: { on: () => () => {} },
+  rpc: {
+    conversations: {
+      dehydrateConversation,
+      getConversationsForTask: vi.fn(),
+      hydrateConversation,
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/pty/pty', () => ({
+  FrontendPty: class {
+    constructor(readonly sessionId: string) {}
+
+    connect = frontendConnect;
+    dispose = frontendDispose;
+  },
+}));
+
+describe('ConversationManagerStore session hydration', () => {
+  beforeEach(() => {
+    hydrateConversation.mockReset();
+    dehydrateConversation.mockReset();
+    frontendConnect.mockReset();
+    frontendDispose.mockReset();
+
+    hydrateConversation.mockResolvedValue(undefined);
+    dehydrateConversation.mockResolvedValue(undefined);
+    frontendConnect.mockResolvedValue(undefined);
+  });
+
+  it('does not hydrate conversations from the PTY session connect path', async () => {
+    const store = new ConversationManagerStore('project-1', 'task-1', [
+      {
+        id: 'conversation-1',
+        projectId: 'project-1',
+        taskId: 'task-1',
+        providerId: 'codex',
+        title: 'Conversation 1',
+        lastInteractedAt: null,
+        isInitialConversation: false,
+      },
+    ]);
+
+    const session = store.sessions.get('conversation-1');
+    expect(session).toBeDefined();
+
+    await session?.connect();
+
+    expect(hydrateConversation).not.toHaveBeenCalled();
+    expect(frontendConnect).toHaveBeenCalledTimes(1);
+
+    store.dispose();
+  });
+});

--- a/src/renderer/features/tasks/conversations/conversation-manager.ts
+++ b/src/renderer/features/tasks/conversations/conversation-manager.ts
@@ -265,7 +265,7 @@ export class ConversationManagerStore implements IDisposable {
     const handlers = makeFileLinkHandlers(conversation.projectId, conversation.taskId);
     return new PtySession(
       makePtySessionId(conversation.projectId, conversation.taskId, conversation.id),
-      () => this.hydrateConversation(conversation.id),
+      undefined,
       handlers.onOpenFile,
       handlers.onOpenExternal
     );

--- a/src/renderer/features/tasks/conversations/conversation-manager.ts
+++ b/src/renderer/features/tasks/conversations/conversation-manager.ts
@@ -59,12 +59,7 @@ export class ConversationManagerStore implements IDisposable {
             this.conversations.set(conversation.id, new ConversationStore(conversation));
           }
           if (!this.sessions.has(conversation.id)) {
-            this.sessions.set(
-              conversation.id,
-              new PtySession(
-                makePtySessionId(conversation.projectId, conversation.taskId, conversation.id)
-              )
-            );
+            this.sessions.set(conversation.id, this.createSession(conversation));
           }
         }
       });
@@ -83,12 +78,7 @@ export class ConversationManagerStore implements IDisposable {
               this.conversations.set(conversation.id, new ConversationStore(conversation));
             }
             if (!this.sessions.has(conversation.id)) {
-              this.sessions.set(
-                conversation.id,
-                new PtySession(
-                  makePtySessionId(conversation.projectId, conversation.taskId, conversation.id)
-                )
-              );
+              this.sessions.set(conversation.id, this.createSession(conversation));
             }
           }
         });
@@ -178,12 +168,7 @@ export class ConversationManagerStore implements IDisposable {
         this.conversations.set(conversation.id, new ConversationStore(conversation));
       }
       if (!this.sessions.has(conversation.id)) {
-        this.sessions.set(
-          conversation.id,
-          new PtySession(
-            makePtySessionId(conversation.projectId, conversation.taskId, conversation.id)
-          )
-        );
+        this.sessions.set(conversation.id, this.createSession(conversation));
       }
       if (params.initialPrompt?.trim()) {
         this.conversations.get(conversation.id)?.setWorking();
@@ -208,6 +193,16 @@ export class ConversationManagerStore implements IDisposable {
       }
       store.setWorking();
     });
+  }
+
+  async hydrateConversation(conversationId: string): Promise<void> {
+    await rpc.conversations.hydrateConversation(this.projectId, this.taskId, conversationId);
+  }
+
+  async dehydrateConversation(conversationId: string): Promise<void> {
+    const session = this.sessions.get(conversationId);
+    session?.dispose();
+    await rpc.conversations.dehydrateConversation(this.projectId, this.taskId, conversationId);
   }
 
   async deleteConversation(conversationId: string): Promise<void> {
@@ -263,6 +258,13 @@ export class ConversationManagerStore implements IDisposable {
     for (const session of this.sessions.values()) {
       session.dispose();
     }
+  }
+
+  private createSession(conversation: Conversation): PtySession {
+    return new PtySession(
+      makePtySessionId(conversation.projectId, conversation.taskId, conversation.id),
+      () => this.hydrateConversation(conversation.id)
+    );
   }
 }
 

--- a/src/renderer/features/tasks/stores/conversation-hydration-reconciler.test.ts
+++ b/src/renderer/features/tasks/stores/conversation-hydration-reconciler.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   ConversationHydrationReconciler,
+  DEHYDRATE_RETRY_DELAY_MS,
   type ConversationSessionAdapter,
 } from './conversation-hydration-reconciler';
 
@@ -141,5 +142,31 @@ describe('ConversationHydrationReconciler', () => {
 
     expect(dehydrateConversation).toHaveBeenCalledTimes(1);
     expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('retries failed dehydrate without waiting for another sync', async () => {
+    vi.useFakeTimers();
+    try {
+      const { reconciler, dehydrateConversation, logger } = makeHarness();
+      dehydrateConversation
+        .mockRejectedValueOnce(new Error('dehydrate failed'))
+        .mockResolvedValueOnce(undefined);
+
+      reconciler.sync(['conversation-1']);
+      await Promise.resolve();
+
+      reconciler.sync([]);
+      await Promise.resolve();
+
+      expect(dehydrateConversation).toHaveBeenCalledTimes(1);
+      expect(logger.warn).toHaveBeenCalledTimes(1);
+
+      await vi.advanceTimersByTimeAsync(DEHYDRATE_RETRY_DELAY_MS);
+
+      expect(dehydrateConversation).toHaveBeenCalledTimes(2);
+      expect(dehydrateConversation).toHaveBeenLastCalledWith('conversation-1');
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/renderer/features/tasks/stores/conversation-hydration-reconciler.test.ts
+++ b/src/renderer/features/tasks/stores/conversation-hydration-reconciler.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  ConversationHydrationReconciler,
+  type ConversationSessionAdapter,
+} from './conversation-hydration-reconciler';
+
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+function makeHarness() {
+  const adapter: ConversationSessionAdapter = {
+    hydrateConversation: vi.fn().mockResolvedValue(undefined),
+    dehydrateConversation: vi.fn().mockResolvedValue(undefined),
+  };
+  const logger = { warn: vi.fn() };
+  const reconciler = new ConversationHydrationReconciler({
+    taskId: 'task-1',
+    getConversations: () => adapter,
+    log: logger,
+  });
+  return {
+    adapter,
+    logger,
+    reconciler,
+    hydrateConversation: vi.mocked(adapter.hydrateConversation),
+    dehydrateConversation: vi.mocked(adapter.dehydrateConversation),
+  };
+}
+
+describe('ConversationHydrationReconciler', () => {
+  it('hydrates desired conversations', async () => {
+    const { reconciler, hydrateConversation } = makeHarness();
+
+    reconciler.sync(['conversation-1']);
+    await Promise.resolve();
+
+    expect(hydrateConversation).toHaveBeenCalledTimes(1);
+    expect(hydrateConversation).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('dedupes repeated syncs while hydrate is in flight', () => {
+    const { reconciler, hydrateConversation } = makeHarness();
+    hydrateConversation.mockReturnValue(deferred().promise);
+
+    reconciler.sync(['conversation-1']);
+    reconciler.sync(['conversation-1']);
+
+    expect(hydrateConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('dehydrates when hydrate finishes after the conversation is no longer desired', async () => {
+    const { reconciler, hydrateConversation, dehydrateConversation } = makeHarness();
+    const hydrate = deferred();
+    hydrateConversation.mockReturnValue(hydrate.promise);
+
+    reconciler.sync(['conversation-1']);
+    reconciler.sync([]);
+
+    expect(dehydrateConversation).not.toHaveBeenCalled();
+
+    hydrate.resolve();
+    await hydrate.promise;
+    await Promise.resolve();
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(1);
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('accepts a hydrate that finishes after close and reopen', async () => {
+    const { reconciler, hydrateConversation, dehydrateConversation } = makeHarness();
+    const hydrate = deferred();
+    hydrateConversation.mockReturnValue(hydrate.promise);
+
+    reconciler.sync(['conversation-1']);
+    reconciler.sync([]);
+    reconciler.sync(['conversation-1']);
+
+    hydrate.resolve();
+    await hydrate.promise;
+    await Promise.resolve();
+
+    expect(dehydrateConversation).not.toHaveBeenCalled();
+    expect(hydrateConversation).toHaveBeenCalledTimes(1);
+  });
+
+  it('rehydrates when dehydrate finishes after the conversation is desired again', async () => {
+    const { reconciler, hydrateConversation, dehydrateConversation } = makeHarness();
+    const dehydrate = deferred();
+    dehydrateConversation.mockReturnValueOnce(dehydrate.promise);
+
+    reconciler.sync(['conversation-1']);
+    await Promise.resolve();
+    expect(hydrateConversation).toHaveBeenCalledTimes(1);
+
+    reconciler.sync([]);
+    reconciler.sync(['conversation-1']);
+
+    dehydrate.resolve();
+    await dehydrate.promise;
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(hydrateConversation).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not mark as hydrated when hydrate fails', async () => {
+    const { reconciler, hydrateConversation, dehydrateConversation, logger } = makeHarness();
+    hydrateConversation.mockRejectedValueOnce(new Error('hydrate failed'));
+
+    reconciler.sync(['conversation-1']);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(logger.warn).toHaveBeenCalledTimes(1);
+
+    reconciler.sync([]);
+    await Promise.resolve();
+
+    expect(dehydrateConversation).not.toHaveBeenCalled();
+  });
+
+  it('stops hydrated conversations on dispose', async () => {
+    const { reconciler, dehydrateConversation } = makeHarness();
+
+    reconciler.sync(['conversation-1']);
+    await Promise.resolve();
+
+    reconciler.dispose();
+    await Promise.resolve();
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(1);
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
+  });
+});

--- a/src/renderer/features/tasks/stores/conversation-hydration-reconciler.ts
+++ b/src/renderer/features/tasks/stores/conversation-hydration-reconciler.ts
@@ -1,0 +1,138 @@
+import type { IDisposable } from '@renderer/lib/stores/lifecycle';
+
+export type ConversationSessionAdapter = {
+  hydrateConversation(conversationId: string): Promise<void>;
+  dehydrateConversation(conversationId: string): Promise<void>;
+};
+
+type Logger = {
+  warn(message: string, data?: unknown): void;
+};
+
+type ConversationHydrationReconcilerOptions = {
+  taskId: string;
+  getConversations: () => ConversationSessionAdapter | undefined;
+  log: Logger;
+};
+
+type SessionState = 'stopped' | 'starting' | 'running' | 'stopping';
+
+type Entry = {
+  desired: boolean;
+  state: SessionState;
+};
+
+export class ConversationHydrationReconciler implements IDisposable {
+  private readonly taskId: string;
+  private readonly getConversations: () => ConversationSessionAdapter | undefined;
+  private readonly log: Logger;
+  private readonly entries = new Map<string, Entry>();
+
+  constructor({ taskId, getConversations, log }: ConversationHydrationReconcilerOptions) {
+    this.taskId = taskId;
+    this.getConversations = getConversations;
+    this.log = log;
+  }
+
+  sync(openConversationIds: Iterable<string>): void {
+    const desired = new Set(openConversationIds);
+    const ids = new Set([...this.entries.keys(), ...desired]);
+
+    for (const id of ids) {
+      const entry = this.getOrCreateEntry(id);
+      entry.desired = desired.has(id);
+      this.reconcile(id, entry);
+      this.cleanupIfIdle(id, entry);
+    }
+  }
+
+  dispose(): void {
+    for (const [id, entry] of this.entries) {
+      entry.desired = false;
+      this.reconcile(id, entry);
+      this.cleanupIfIdle(id, entry);
+    }
+  }
+
+  private getOrCreateEntry(id: string): Entry {
+    const existing = this.entries.get(id);
+    if (existing) return existing;
+    const entry: Entry = { desired: false, state: 'stopped' };
+    this.entries.set(id, entry);
+    return entry;
+  }
+
+  private reconcile(id: string, entry: Entry): void {
+    if (entry.desired && entry.state === 'stopped') {
+      void this.hydrate(id, entry);
+      return;
+    }
+    if (!entry.desired && entry.state === 'running') {
+      void this.dehydrate(id, entry);
+    }
+  }
+
+  private async hydrate(id: string, entry: Entry): Promise<void> {
+    const conversations = this.getConversations();
+    if (!conversations) return;
+
+    entry.state = 'starting';
+    try {
+      await conversations.hydrateConversation(id);
+    } catch (error) {
+      entry.state = 'stopped';
+      this.log.warn('ConversationHydrationReconciler: failed to hydrate conversation', {
+        taskId: this.taskId,
+        conversationId: id,
+        error,
+      });
+      this.cleanupIfIdle(id, entry);
+      return;
+    }
+
+    entry.state = 'running';
+    // intent may have flipped while we awaited — tear down if no longer wanted
+    if (entry.desired) return;
+    void this.dehydrate(id, entry, 'stale-hydrate');
+  }
+
+  private async dehydrate(
+    id: string,
+    entry: Entry,
+    reason: 'sync' | 'stale-hydrate' = 'sync'
+  ): Promise<void> {
+    const conversations = this.getConversations();
+    if (!conversations) return;
+
+    entry.state = 'stopping';
+    try {
+      await conversations.dehydrateConversation(id);
+    } catch (error) {
+      entry.state = 'running';
+      this.log.warn(
+        reason === 'stale-hydrate'
+          ? 'ConversationHydrationReconciler: failed to dehydrate stale conversation'
+          : 'ConversationHydrationReconciler: failed to dehydrate conversation',
+        {
+          taskId: this.taskId,
+          conversationId: id,
+          error,
+        }
+      );
+      return;
+    }
+
+    entry.state = 'stopped';
+    // intent may have flipped while we awaited — restart if wanted again
+    if (entry.desired) {
+      this.reconcile(id, entry);
+      return;
+    }
+    this.cleanupIfIdle(id, entry);
+  }
+
+  private cleanupIfIdle(id: string, entry: Entry): void {
+    if (entry.desired || entry.state !== 'stopped') return;
+    this.entries.delete(id);
+  }
+}

--- a/src/renderer/features/tasks/stores/conversation-hydration-reconciler.ts
+++ b/src/renderer/features/tasks/stores/conversation-hydration-reconciler.ts
@@ -17,9 +17,12 @@ type ConversationHydrationReconcilerOptions = {
 
 type SessionState = 'stopped' | 'starting' | 'running' | 'stopping';
 
+export const DEHYDRATE_RETRY_DELAY_MS = 500;
+
 type Entry = {
   desired: boolean;
   state: SessionState;
+  dehydrateRetryTimer: ReturnType<typeof setTimeout> | null;
 };
 
 export class ConversationHydrationReconciler implements IDisposable {
@@ -27,6 +30,7 @@ export class ConversationHydrationReconciler implements IDisposable {
   private readonly getConversations: () => ConversationSessionAdapter | undefined;
   private readonly log: Logger;
   private readonly entries = new Map<string, Entry>();
+  private disposed = false;
 
   constructor({ taskId, getConversations, log }: ConversationHydrationReconcilerOptions) {
     this.taskId = taskId;
@@ -35,19 +39,24 @@ export class ConversationHydrationReconciler implements IDisposable {
   }
 
   sync(openConversationIds: Iterable<string>): void {
+    if (this.disposed) return;
+
     const desired = new Set(openConversationIds);
     const ids = new Set([...this.entries.keys(), ...desired]);
 
     for (const id of ids) {
       const entry = this.getOrCreateEntry(id);
       entry.desired = desired.has(id);
+      if (entry.desired) this.clearDehydrateRetry(entry);
       this.reconcile(id, entry);
       this.cleanupIfIdle(id, entry);
     }
   }
 
   dispose(): void {
+    this.disposed = true;
     for (const [id, entry] of this.entries) {
+      this.clearDehydrateRetry(entry);
       entry.desired = false;
       this.reconcile(id, entry);
       this.cleanupIfIdle(id, entry);
@@ -57,7 +66,7 @@ export class ConversationHydrationReconciler implements IDisposable {
   private getOrCreateEntry(id: string): Entry {
     const existing = this.entries.get(id);
     if (existing) return existing;
-    const entry: Entry = { desired: false, state: 'stopped' };
+    const entry: Entry = { desired: false, state: 'stopped', dehydrateRetryTimer: null };
     this.entries.set(id, entry);
     return entry;
   }
@@ -102,7 +111,11 @@ export class ConversationHydrationReconciler implements IDisposable {
     reason: 'sync' | 'stale-hydrate' = 'sync'
   ): Promise<void> {
     const conversations = this.getConversations();
-    if (!conversations) return;
+    if (!conversations) {
+      entry.state = 'stopped';
+      this.cleanupIfIdle(id, entry);
+      return;
+    }
 
     entry.state = 'stopping';
     try {
@@ -119,10 +132,12 @@ export class ConversationHydrationReconciler implements IDisposable {
           error,
         }
       );
+      if (!entry.desired) this.scheduleDehydrateRetry(id, entry);
       return;
     }
 
     entry.state = 'stopped';
+    this.clearDehydrateRetry(entry);
     // intent may have flipped while we awaited — restart if wanted again
     if (entry.desired) {
       this.reconcile(id, entry);
@@ -133,6 +148,23 @@ export class ConversationHydrationReconciler implements IDisposable {
 
   private cleanupIfIdle(id: string, entry: Entry): void {
     if (entry.desired || entry.state !== 'stopped') return;
+    this.clearDehydrateRetry(entry);
     this.entries.delete(id);
+  }
+
+  private scheduleDehydrateRetry(id: string, entry: Entry): void {
+    if (this.disposed || entry.dehydrateRetryTimer) return;
+    entry.dehydrateRetryTimer = setTimeout(() => {
+      entry.dehydrateRetryTimer = null;
+      if (this.entries.get(id) !== entry || entry.desired) return;
+      this.reconcile(id, entry);
+      this.cleanupIfIdle(id, entry);
+    }, DEHYDRATE_RETRY_DELAY_MS);
+  }
+
+  private clearDehydrateRetry(entry: Entry): void {
+    if (!entry.dehydrateRetryTimer) return;
+    clearTimeout(entry.dehydrateRetryTimer);
+    entry.dehydrateRetryTimer = null;
   }
 }

--- a/src/renderer/features/tasks/stores/lifecycle-scripts.ts
+++ b/src/renderer/features/tasks/stores/lifecycle-scripts.ts
@@ -33,7 +33,13 @@ export class LifecycleScriptStore {
 
   constructor(data: LifecycleScriptData, projectId: string, workspaceId: string) {
     this.data = data;
-    this.session = new PtySession(makePtySessionId(projectId, workspaceId, data.id));
+    this.session = new PtySession(makePtySessionId(projectId, workspaceId, data.id), () =>
+      rpc.terminals.prepareLifecycleScript({
+        projectId,
+        workspaceId,
+        type: data.type,
+      })
+    );
     this.offPtyExit = events.on(ptyExitChannel, () => this.markExited(), this.session.sessionId);
     makeObservable(this, {
       data: observable,
@@ -218,7 +224,6 @@ export class LifecycleScriptsStore implements TabViewProvider<LifecycleScriptSto
           const store = new LifecycleScriptStore(data, this.projectId, this.workspaceId);
           this.scripts.set(entry.id, store);
           addTabId(this, entry.id);
-          void store.session.connect();
         }
       }
 

--- a/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -22,6 +22,20 @@ type HydrationHarness = {
   syncConversationHydration(openIds: string[]): void;
 };
 
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+} {
+  let resolve: (value: T | PromiseLike<T>) => void = () => {};
+  let reject: (reason?: unknown) => void = () => {};
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
     id: 'task-1',
@@ -84,10 +98,11 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 });
 
 describe('WorkspaceViewModel conversation hydration', () => {
-  it('hydrates an opened conversation exactly once', () => {
+  it('hydrates an opened conversation exactly once', async () => {
     const viewModel = makeViewModel();
     const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
     const hydrateConversation = vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
+    vi.spyOn(conversations, 'dehydrateConversation').mockResolvedValue();
 
     viewModel.tabManager.openConversation('conversation-1');
     asHydrationHarness(viewModel).syncConversationHydration(
@@ -100,10 +115,11 @@ describe('WorkspaceViewModel conversation hydration', () => {
     expect(hydrateConversation).toHaveBeenCalledTimes(1);
     expect(hydrateConversation).toHaveBeenCalledWith('conversation-1');
 
+    await Promise.resolve();
     viewModel.dispose();
   });
 
-  it('dehydrates the last closed conversation and preview replacement', () => {
+  it('dehydrates the last closed conversation and preview replacement', async () => {
     const viewModel = makeViewModel();
     const conversations = conversationRegistry.acquire('task-1', 'project-1', [
       makeConversation({ id: 'conversation-1', title: 'Conversation 1' }),
@@ -118,10 +134,13 @@ describe('WorkspaceViewModel conversation hydration', () => {
     asHydrationHarness(viewModel).syncConversationHydration(
       asHydrationHarness(viewModel).openConversationIds
     );
+    await Promise.resolve();
+
     viewModel.tabGroupManager.openConversationPreview('conversation-2');
     asHydrationHarness(viewModel).syncConversationHydration(
       asHydrationHarness(viewModel).openConversationIds
     );
+    await Promise.resolve();
 
     expect(dehydrateConversation).toHaveBeenCalledTimes(1);
     expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
@@ -137,7 +156,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
     viewModel.dispose();
   });
 
-  it('keeps a conversation hydrated while it remains open in another pane', () => {
+  it('keeps a conversation hydrated while it remains open in another pane', async () => {
     const viewModel = makeViewModel();
     const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
     const hydrateConversation = vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
@@ -185,6 +204,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
     asHydrationHarness(viewModel).syncConversationHydration(
       asHydrationHarness(viewModel).openConversationIds
     );
+    await Promise.resolve();
 
     expect(hydrateConversation).toHaveBeenCalledTimes(1);
 
@@ -207,7 +227,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
     viewModel.dispose();
   });
 
-  it('dehydrates all hydrated conversations on suspend', () => {
+  it('dehydrates all hydrated conversations on suspend', async () => {
     const viewModel = makeViewModel();
     const conversations = conversationRegistry.acquire('task-1', 'project-1', [
       makeConversation({ id: 'conversation-1', title: 'Conversation 1' }),
@@ -223,12 +243,79 @@ describe('WorkspaceViewModel conversation hydration', () => {
     asHydrationHarness(viewModel).syncConversationHydration(
       asHydrationHarness(viewModel).openConversationIds
     );
+    await Promise.resolve();
 
     viewModel.suspend();
 
     expect(dehydrateConversation).toHaveBeenCalledTimes(2);
     expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
     expect(dehydrateConversation).toHaveBeenCalledWith('conversation-2');
+
+    viewModel.dispose();
+  });
+
+  it('dehydrates a stale conversation when its hydrate finishes after the tab closed', async () => {
+    const viewModel = makeViewModel();
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const hydrate = deferred();
+    vi.spyOn(conversations, 'hydrateConversation').mockReturnValue(hydrate.promise);
+    const dehydrateConversation = vi
+      .spyOn(conversations, 'dehydrateConversation')
+      .mockResolvedValue();
+
+    viewModel.tabManager.openConversation('conversation-1');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    viewModel.tabManager.closeTab(viewModel.tabManager.resolvedActiveTabId!);
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(dehydrateConversation).not.toHaveBeenCalled();
+
+    hydrate.resolve();
+    await hydrate.promise;
+    await Promise.resolve();
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(1);
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
+
+    viewModel.dispose();
+  });
+
+  it('does not mark failed hydrations as hydrated and can retry', async () => {
+    const viewModel = makeViewModel();
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const hydrateConversation = vi
+      .spyOn(conversations, 'hydrateConversation')
+      .mockRejectedValueOnce(new Error('hydrate failed'))
+      .mockResolvedValueOnce(undefined);
+    const dehydrateConversation = vi
+      .spyOn(conversations, 'dehydrateConversation')
+      .mockResolvedValue();
+
+    viewModel.tabManager.openConversation('conversation-1');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+    await Promise.resolve();
+
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+    await Promise.resolve();
+
+    expect(hydrateConversation).toHaveBeenCalledTimes(2);
+
+    viewModel.tabManager.closeTab(viewModel.tabManager.resolvedActiveTabId!);
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(1);
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
 
     viewModel.dispose();
   });

--- a/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -1,5 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { Conversation } from '@shared/conversations';
 import type { Task } from '@shared/tasks';
+import type { TaskViewSnapshot } from '@shared/view-state';
+import { conversationRegistry } from './conversation-registry';
 import type { TaskStore } from './task-store';
 import { WorkspaceViewModel } from './workspace-view-model';
 
@@ -13,6 +16,11 @@ vi.mock('@renderer/lib/ipc', () => ({
     },
   },
 }));
+
+type HydrationHarness = {
+  openConversationIds: string[];
+  syncConversationHydration(openIds: string[]): void;
+};
 
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
@@ -32,9 +40,30 @@ function makeTask(overrides: Partial<Task> = {}): Task {
   };
 }
 
+function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
+  return {
+    id: 'conversation-1',
+    projectId: 'project-1',
+    taskId: 'task-1',
+    providerId: 'codex',
+    title: 'Conversation 1',
+    lastInteractedAt: null,
+    isInitialConversation: false,
+    ...overrides,
+  };
+}
+
 function makeViewModel(): WorkspaceViewModel {
   return new WorkspaceViewModel({ data: makeTask() } as unknown as TaskStore);
 }
+
+function asHydrationHarness(viewModel: WorkspaceViewModel): HydrationHarness {
+  return viewModel as unknown as HydrationHarness;
+}
+
+afterEach(() => {
+  conversationRegistry.release('task-1');
+});
 
 describe('WorkspaceViewModel terminal drawer snapshot', () => {
   it('persists and restores the active terminal drawer item', () => {
@@ -51,5 +80,156 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 
     source.dispose();
     restored.dispose();
+  });
+});
+
+describe('WorkspaceViewModel conversation hydration', () => {
+  it('hydrates an opened conversation exactly once', () => {
+    const viewModel = makeViewModel();
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const hydrateConversation = vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
+
+    viewModel.tabManager.openConversation('conversation-1');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(hydrateConversation).toHaveBeenCalledTimes(1);
+    expect(hydrateConversation).toHaveBeenCalledWith('conversation-1');
+
+    viewModel.dispose();
+  });
+
+  it('dehydrates the last closed conversation and preview replacement', () => {
+    const viewModel = makeViewModel();
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [
+      makeConversation({ id: 'conversation-1', title: 'Conversation 1' }),
+      makeConversation({ id: 'conversation-2', title: 'Conversation 2' }),
+    ]);
+    vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
+    const dehydrateConversation = vi
+      .spyOn(conversations, 'dehydrateConversation')
+      .mockResolvedValue();
+
+    viewModel.tabGroupManager.openConversationPreview('conversation-1');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+    viewModel.tabGroupManager.openConversationPreview('conversation-2');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(1);
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
+
+    viewModel.tabManager.closeTab(viewModel.tabManager.resolvedActiveTabId!);
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(2);
+    expect(dehydrateConversation).toHaveBeenLastCalledWith('conversation-2');
+
+    viewModel.dispose();
+  });
+
+  it('keeps a conversation hydrated while it remains open in another pane', () => {
+    const viewModel = makeViewModel();
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const hydrateConversation = vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
+    const dehydrateConversation = vi
+      .spyOn(conversations, 'dehydrateConversation')
+      .mockResolvedValue();
+
+    viewModel.restoreSnapshot({
+      tabGroups: {
+        activeGroupId: 'group-1',
+        paneSizes: [50, 50],
+        groups: [
+          {
+            groupId: 'group-1',
+            tabManager: {
+              activeTabId: 'tab-1',
+              tabs: [
+                {
+                  kind: 'conversation',
+                  tabId: 'tab-1',
+                  conversationId: 'conversation-1',
+                  isPreview: false,
+                },
+              ],
+            },
+          },
+          {
+            groupId: 'group-2',
+            tabManager: {
+              activeTabId: 'tab-2',
+              tabs: [
+                {
+                  kind: 'conversation',
+                  tabId: 'tab-2',
+                  conversationId: 'conversation-1',
+                  isPreview: false,
+                },
+              ],
+            },
+          },
+        ],
+      },
+    } as TaskViewSnapshot);
+
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(hydrateConversation).toHaveBeenCalledTimes(1);
+
+    const [firstGroup, secondGroup] = viewModel.tabGroupManager.groups;
+    firstGroup.tabManager.closeTab('tab-1');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(dehydrateConversation).not.toHaveBeenCalled();
+
+    secondGroup.tabManager.closeTab('tab-2');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(1);
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
+
+    viewModel.dispose();
+  });
+
+  it('dehydrates all hydrated conversations on suspend', () => {
+    const viewModel = makeViewModel();
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [
+      makeConversation({ id: 'conversation-1', title: 'Conversation 1' }),
+      makeConversation({ id: 'conversation-2', title: 'Conversation 2' }),
+    ]);
+    vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
+    const dehydrateConversation = vi
+      .spyOn(conversations, 'dehydrateConversation')
+      .mockResolvedValue();
+
+    viewModel.tabManager.openConversation('conversation-1');
+    viewModel.tabManager.openConversation('conversation-2');
+    asHydrationHarness(viewModel).syncConversationHydration(
+      asHydrationHarness(viewModel).openConversationIds
+    );
+
+    viewModel.suspend();
+
+    expect(dehydrateConversation).toHaveBeenCalledTimes(2);
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-1');
+    expect(dehydrateConversation).toHaveBeenCalledWith('conversation-2');
+
+    viewModel.dispose();
   });
 });

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -67,6 +67,7 @@ export class WorkspaceViewModel implements ILifecycle {
   /** Saved whenever suspend() is called, restored in next initialize(). */
   private _savedDiffViewSnapshot: DiffViewSnapshot | undefined;
   private _isCreatingTerminal = false;
+  private readonly _hydratedConversationIds = new Set<string>();
 
   readonly taskId: string;
 
@@ -299,6 +300,13 @@ export class WorkspaceViewModel implements ILifecycle {
     // Register snapshot with the persistence layer.
     this._snapshotDisposer = snapshotRegistry.register(`task:${this.taskId}`, () => this.snapshot);
 
+    const conversationHydrationDisposer = reaction(
+      () => this.openConversationIds,
+      (ids) => this.syncConversationHydration(ids),
+      { fireImmediately: true }
+    );
+    this._sessionDisposers.push(conversationHydrationDisposer);
+
     // Auto-create a terminal when the drawer is open and no terminals exist.
     const terminalsDisposer = reaction(
       () => {
@@ -335,6 +343,8 @@ export class WorkspaceViewModel implements ILifecycle {
     this.prStore = null;
     this.devServers?.dispose();
     this.devServers = null;
+
+    this.dehydrateAllConversations();
 
     // Stop snapshot persistence.
     this._snapshotDisposer?.();
@@ -426,5 +436,65 @@ export class WorkspaceViewModel implements ILifecycle {
         this._isCreatingTerminal = false;
       });
     }
+  }
+
+  private get openConversationIds(): string[] {
+    const ids = new Set<string>();
+    for (const { tabManager } of this.tabGroupManager.groups) {
+      for (const tabId of tabManager.tabOrder) {
+        const entry = tabManager.entries.get(tabId);
+        if (entry?.kind === 'conversation') ids.add(entry.conversationId);
+      }
+    }
+    return [...ids].sort();
+  }
+
+  private syncConversationHydration(openIds: string[]): void {
+    const conversations = conversationRegistry.get(this.taskId);
+    if (!conversations) return;
+
+    const next = new Set(openIds);
+    for (const id of next) {
+      if (this._hydratedConversationIds.has(id)) continue;
+      this._hydratedConversationIds.add(id);
+      void conversations.hydrateConversation(id).catch((error) => {
+        log.warn('WorkspaceViewModel: failed to hydrate conversation', {
+          taskId: this.taskId,
+          conversationId: id,
+          error,
+        });
+      });
+    }
+
+    for (const id of [...this._hydratedConversationIds]) {
+      if (next.has(id)) continue;
+      this._hydratedConversationIds.delete(id);
+      void conversations.dehydrateConversation(id).catch((error) => {
+        log.warn('WorkspaceViewModel: failed to dehydrate conversation', {
+          taskId: this.taskId,
+          conversationId: id,
+          error,
+        });
+      });
+    }
+  }
+
+  private dehydrateAllConversations(): void {
+    const conversations = conversationRegistry.get(this.taskId);
+    if (!conversations) {
+      this._hydratedConversationIds.clear();
+      return;
+    }
+
+    for (const id of [...this._hydratedConversationIds]) {
+      void conversations.dehydrateConversation(id).catch((error) => {
+        log.warn('WorkspaceViewModel: failed to dehydrate conversation during suspend', {
+          taskId: this.taskId,
+          conversationId: id,
+          error,
+        });
+      });
+    }
+    this._hydratedConversationIds.clear();
   }
 }

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -18,6 +18,7 @@ import type {
   TaskViewSnapshot,
   TerminalDrawerActiveItem,
 } from '@shared/view-state';
+import { ConversationHydrationReconciler } from './conversation-hydration-reconciler';
 import { conversationRegistry } from './conversation-registry';
 import { PrStore } from './pr-store';
 import type { TaskStore } from './task-store';
@@ -67,13 +68,18 @@ export class WorkspaceViewModel implements ILifecycle {
   /** Saved whenever suspend() is called, restored in next initialize(). */
   private _savedDiffViewSnapshot: DiffViewSnapshot | undefined;
   private _isCreatingTerminal = false;
-  private readonly _hydratedConversationIds = new Set<string>();
+  private readonly _conversationHydration: ConversationHydrationReconciler;
 
   readonly taskId: string;
 
   constructor(private readonly _taskStore: TaskStore) {
     const taskData = _taskStore.data as Task;
     this.taskId = taskData.id;
+    this._conversationHydration = new ConversationHydrationReconciler({
+      taskId: this.taskId,
+      getConversations: () => conversationRegistry.get(this.taskId),
+      log,
+    });
 
     // UI state defaults — overridden by restoreSnapshot when called
     this.sidebarTab = 'conversations';
@@ -95,10 +101,11 @@ export class WorkspaceViewModel implements ILifecycle {
       workspaceId
     );
 
-    makeAutoObservable(this, {
+    makeAutoObservable<WorkspaceViewModel, '_conversationHydration'>(this, {
       tabGroupManager: false,
       terminalTabs: false,
       editorView: false,
+      _conversationHydration: false,
       diffView: observable.ref,
       activeRenderer: computed,
     });
@@ -344,7 +351,7 @@ export class WorkspaceViewModel implements ILifecycle {
     this.devServers?.dispose();
     this.devServers = null;
 
-    this.dehydrateAllConversations();
+    this._conversationHydration.dispose();
 
     // Stop snapshot persistence.
     this._snapshotDisposer?.();
@@ -450,51 +457,6 @@ export class WorkspaceViewModel implements ILifecycle {
   }
 
   private syncConversationHydration(openIds: string[]): void {
-    const conversations = conversationRegistry.get(this.taskId);
-    if (!conversations) return;
-
-    const next = new Set(openIds);
-    for (const id of next) {
-      if (this._hydratedConversationIds.has(id)) continue;
-      this._hydratedConversationIds.add(id);
-      void conversations.hydrateConversation(id).catch((error) => {
-        log.warn('WorkspaceViewModel: failed to hydrate conversation', {
-          taskId: this.taskId,
-          conversationId: id,
-          error,
-        });
-      });
-    }
-
-    for (const id of [...this._hydratedConversationIds]) {
-      if (next.has(id)) continue;
-      this._hydratedConversationIds.delete(id);
-      void conversations.dehydrateConversation(id).catch((error) => {
-        log.warn('WorkspaceViewModel: failed to dehydrate conversation', {
-          taskId: this.taskId,
-          conversationId: id,
-          error,
-        });
-      });
-    }
-  }
-
-  private dehydrateAllConversations(): void {
-    const conversations = conversationRegistry.get(this.taskId);
-    if (!conversations) {
-      this._hydratedConversationIds.clear();
-      return;
-    }
-
-    for (const id of [...this._hydratedConversationIds]) {
-      void conversations.dehydrateConversation(id).catch((error) => {
-        log.warn('WorkspaceViewModel: failed to dehydrate conversation during suspend', {
-          taskId: this.taskId,
-          conversationId: id,
-          error,
-        });
-      });
-    }
-    this._hydratedConversationIds.clear();
+    this._conversationHydration.sync(openIds);
   }
 }

--- a/src/renderer/features/tasks/terminals/terminal-manager.test.ts
+++ b/src/renderer/features/tasks/terminals/terminal-manager.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TerminalManagerStore } from './terminal-manager';
+
+const createTerminal = vi.hoisted(() => vi.fn());
+const getTerminalsForTask = vi.hoisted(() => vi.fn());
+const hydrateTerminal = vi.hoisted(() => vi.fn());
+const renameTerminal = vi.hoisted(() => vi.fn());
+const deleteTerminal = vi.hoisted(() => vi.fn());
+const frontendConnect = vi.hoisted(() => vi.fn());
+const frontendDispose = vi.hoisted(() => vi.fn());
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    terminals: {
+      createTerminal,
+      deleteTerminal,
+      getTerminalsForTask,
+      hydrateTerminal,
+      renameTerminal,
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/pty/pty', () => ({
+  FrontendPty: class {
+    constructor(readonly sessionId: string) {}
+
+    connect = frontendConnect;
+    dispose = frontendDispose;
+  },
+}));
+
+describe('TerminalManagerStore session hydration', () => {
+  beforeEach(() => {
+    createTerminal.mockReset();
+    getTerminalsForTask.mockReset();
+    hydrateTerminal.mockReset();
+    renameTerminal.mockReset();
+    deleteTerminal.mockReset();
+    frontendConnect.mockReset();
+    frontendDispose.mockReset();
+
+    createTerminal.mockImplementation(async (terminal) => terminal);
+    getTerminalsForTask.mockResolvedValue([]);
+    hydrateTerminal.mockResolvedValue(undefined);
+    renameTerminal.mockResolvedValue(undefined);
+    deleteTerminal.mockResolvedValue(undefined);
+    frontendConnect.mockResolvedValue(undefined);
+  });
+
+  it('creates terminal sessions from records without hydrating until the session connects', async () => {
+    getTerminalsForTask.mockResolvedValue([
+      {
+        id: 'terminal-1',
+        projectId: 'project-1',
+        taskId: 'task-1',
+        name: 'Terminal 1',
+      },
+    ]);
+    const store = new TerminalManagerStore('project-1', 'task-1');
+
+    store.list.setValue([
+      {
+        id: 'terminal-1',
+        projectId: 'project-1',
+        taskId: 'task-1',
+        name: 'Terminal 1',
+      },
+    ]);
+
+    expect(hydrateTerminal).not.toHaveBeenCalled();
+
+    const session = store.sessions.get('terminal-1');
+    expect(session).toBeDefined();
+
+    await session?.connect();
+
+    expect(hydrateTerminal).toHaveBeenCalledTimes(1);
+    expect(hydrateTerminal).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      terminalId: 'terminal-1',
+    });
+    expect(frontendConnect).toHaveBeenCalledTimes(1);
+
+    await session?.connect();
+
+    expect(hydrateTerminal).toHaveBeenCalledTimes(1);
+    expect(frontendConnect).toHaveBeenCalledTimes(1);
+
+    store.dispose();
+  });
+});

--- a/src/renderer/features/tasks/terminals/terminal-manager.ts
+++ b/src/renderer/features/tasks/terminals/terminal-manager.ts
@@ -49,10 +49,7 @@ export class TerminalManagerStore implements IDisposable {
               this.terminals.set(terminal.id, new TerminalStore(terminal));
             }
             if (!this.sessions.has(terminal.id)) {
-              this.sessions.set(
-                terminal.id,
-                new PtySession(makePtySessionId(terminal.projectId, terminal.taskId, terminal.id))
-              );
+              this.sessions.set(terminal.id, this.createSession(terminal));
             }
           }
 
@@ -83,10 +80,7 @@ export class TerminalManagerStore implements IDisposable {
 
     runInAction(() => {
       this.terminals.set(params.id, new TerminalStore(optimistic));
-      this.sessions.set(
-        params.id,
-        new PtySession(makePtySessionId(params.projectId, params.taskId, params.id))
-      );
+      this.sessions.set(params.id, this.createSession(optimistic));
     });
 
     try {
@@ -141,6 +135,16 @@ export class TerminalManagerStore implements IDisposable {
     }
   }
 
+  async hydrateTerminal(terminalId: string): Promise<void> {
+    const store = this.terminals.get(terminalId);
+    if (!store) return;
+    await rpc.terminals.hydrateTerminal({
+      projectId: this.projectId,
+      taskId: this.taskId,
+      terminalId,
+    });
+  }
+
   dispose(): void {
     this._disposeReaction();
     for (const session of this.sessions.values()) {
@@ -167,6 +171,12 @@ export class TerminalManagerStore implements IDisposable {
       });
       throw err;
     }
+  }
+
+  private createSession(terminal: Terminal): PtySession {
+    return new PtySession(makePtySessionId(terminal.projectId, terminal.taskId, terminal.id), () =>
+      this.hydrateTerminal(terminal.id)
+    );
   }
 }
 

--- a/src/renderer/lib/pty/pty-session.test.ts
+++ b/src/renderer/lib/pty/pty-session.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { PtySession } from './pty-session';
+
+const frontendConnect = vi.hoisted(() => vi.fn());
+const frontendDispose = vi.hoisted(() => vi.fn());
+
+vi.mock('@renderer/lib/pty/pty', () => ({
+  FrontendPty: class {
+    constructor(readonly sessionId: string) {}
+
+    connect = frontendConnect;
+    dispose = frontendDispose;
+  },
+}));
+
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('PtySession', () => {
+  it('does not mark the session ready when disposed while connect is in flight', async () => {
+    const connect = deferred<void>();
+    frontendConnect.mockReturnValue(connect.promise);
+
+    const session = new PtySession('session-1');
+    const connectPromise = session.connect();
+    await Promise.resolve();
+
+    expect(session.status).toBe('connecting');
+    expect(session.pty).not.toBeNull();
+
+    session.dispose();
+
+    expect(session.status).toBe('disconnected');
+    expect(session.pty).toBeNull();
+
+    connect.resolve();
+    await connectPromise;
+
+    expect(session.status).toBe('disconnected');
+    expect(session.pty).toBeNull();
+    expect(frontendDispose).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/lib/pty/pty-session.ts
+++ b/src/renderer/lib/pty/pty-session.ts
@@ -35,11 +35,13 @@ export class PtySession {
       await this.prepare?.();
       if (version !== this.version) return;
       if (this.pty) return;
-      this.pty = new FrontendPty(this.sessionId, undefined, this.onOpenFile, this.onOpenExternal);
+      const pty = new FrontendPty(this.sessionId, undefined, this.onOpenFile, this.onOpenExternal);
+      this.pty = pty;
       runInAction(() => {
         this.status = 'connecting';
       });
-      await this.pty.connect();
+      await pty.connect();
+      if (version !== this.version || this.pty !== pty) return;
       runInAction(() => {
         this.status = 'ready';
       });

--- a/src/renderer/lib/pty/pty-session.ts
+++ b/src/renderer/lib/pty/pty-session.ts
@@ -6,8 +6,13 @@ export type PtySessionStatus = 'disconnected' | 'connecting' | 'ready';
 export class PtySession {
   pty: FrontendPty | null = null;
   status: PtySessionStatus = 'disconnected';
+  private connectPromise: Promise<void> | null = null;
+  private version = 0;
 
-  constructor(readonly sessionId: string) {
+  constructor(
+    readonly sessionId: string,
+    private readonly prepare?: () => Promise<void>
+  ) {
     makeAutoObservable(this, {
       pty: false,
     });
@@ -21,17 +26,30 @@ export class PtySession {
 
   async connect() {
     if (this.pty) return;
-    this.pty = new FrontendPty(this.sessionId);
-    runInAction(() => {
-      this.status = 'connecting';
+    if (this.connectPromise) return this.connectPromise;
+
+    const version = this.version;
+    this.connectPromise = (async () => {
+      await this.prepare?.();
+      if (version !== this.version) return;
+      if (this.pty) return;
+      this.pty = new FrontendPty(this.sessionId);
+      runInAction(() => {
+        this.status = 'connecting';
+      });
+      await this.pty.connect();
+      runInAction(() => {
+        this.status = 'ready';
+      });
+    })().finally(() => {
+      this.connectPromise = null;
     });
-    await this.pty.connect();
-    runInAction(() => {
-      this.status = 'ready';
-    });
+
+    return this.connectPromise;
   }
 
   dispose() {
+    this.version++;
     this.pty?.dispose();
     runInAction(() => {
       this.pty = null;


### PR DESCRIPTION
- bounds PTY respawns to unexpected exits to avoid runaway process growth
- loads only initially open conversations during task hydration
- hydrates conversation sessions only while their tabs are open, then dehydrates them when closed
- hydrates terminal sessions lazily on first frontend connection
- extracts conversation hydration reconciliation into a focused disposable state machine