### PR TITLE
fix(renderer): queue resource reloads during in-flight loads

### DIFF
--- a/src/renderer/lib/stores/resource.test.ts
+++ b/src/renderer/lib/stores/resource.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import { Resource } from './resource';
+
+describe('Resource', () => {
+  it('queues event reloads that arrive during an in-flight load', async () => {
+    let fetchCount = 0;
+    let releaseFirst: (() => void) | undefined;
+    let secondLoadComplete: (() => void) | undefined;
+    let emitReload: (() => void) | undefined;
+    const secondLoad = new Promise<void>((resolve) => {
+      secondLoadComplete = resolve;
+    });
+
+    const resource = new Resource(async () => {
+      fetchCount += 1;
+      if (fetchCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        return 'stale';
+      }
+      secondLoadComplete?.();
+      return 'fresh';
+    }, [
+      {
+        kind: 'event',
+        subscribe: (handler) => {
+          emitReload = () => handler(undefined);
+          return () => {};
+        },
+        onEvent: 'reload',
+      },
+    ]);
+
+    resource.start();
+    emitReload?.();
+    releaseFirst?.();
+
+    await secondLoad;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchCount).toBe(2);
+    expect(resource.data).toBe('fresh');
+  });
+
+  it('runs one fresh reload after an invalidation arrives during an in-flight load', async () => {
+    let fetchCount = 0;
+    let releaseFirst: (() => void) | undefined;
+    let secondLoadComplete: (() => void) | undefined;
+    const secondLoad = new Promise<void>((resolve) => {
+      secondLoadComplete = resolve;
+    });
+
+    const resource = new Resource(async () => {
+      fetchCount += 1;
+      if (fetchCount === 1) {
+        await new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        });
+        return 'stale';
+      }
+      secondLoadComplete?.();
+      return 'fresh';
+    }, []);
+
+    const firstLoad = resource.load();
+    resource.invalidate();
+    releaseFirst?.();
+
+    await firstLoad;
+    await secondLoad;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(fetchCount).toBe(2);
+    expect(resource.data).toBe('fresh');
+  });
+
+  it('dedupes overlapping direct loads without queueing an extra reload', async () => {
+    let fetchCount = 0;
+    let releaseFirst: (() => void) | undefined;
+
+    const resource = new Resource(async () => {
+      fetchCount += 1;
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      return 'loaded';
+    }, []);
+
+    const firstLoad = resource.load();
+    const secondLoad = resource.load();
+    releaseFirst?.();
+
+    await Promise.all([firstLoad, secondLoad]);
+
+    expect(fetchCount).toBe(1);
+    expect(resource.data).toBe('loaded');
+  });
+});

--- a/src/renderer/lib/stores/resource.test.ts
+++ b/src/renderer/lib/stores/resource.test.ts
@@ -1,3 +1,4 @@
+import { autorun } from 'mobx';
 import { describe, expect, it } from 'vitest';
 import { Resource } from './resource';
 
@@ -73,6 +74,44 @@ describe('Resource', () => {
 
     expect(fetchCount).toBe(2);
     expect(resource.data).toBe('fresh');
+  });
+
+  it('keeps loading true between an in-flight load and its queued reload', async () => {
+    let fetchCount = 0;
+    let releaseFirst: (() => void) | undefined;
+    let releaseSecond: (() => void) | undefined;
+
+    const resource = new Resource(async () => {
+      fetchCount += 1;
+      await new Promise<void>((resolve) => {
+        if (fetchCount === 1) {
+          releaseFirst = resolve;
+        } else {
+          releaseSecond = resolve;
+        }
+      });
+      return fetchCount === 1 ? 'stale' : 'fresh';
+    }, []);
+
+    const loadingStates: boolean[] = [];
+    const dispose = autorun(() => {
+      loadingStates.push(resource.loading);
+    });
+
+    const firstLoad = resource.load();
+    resource.invalidate();
+    releaseFirst?.();
+    await firstLoad;
+
+    expect(fetchCount).toBe(2);
+    expect(loadingStates).toEqual([false, true]);
+
+    releaseSecond?.();
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+
+    expect(resource.data).toBe('fresh');
+    expect(loadingStates).toEqual([false, true, false]);
+    dispose();
   });
 
   it('dedupes overlapping direct loads without queueing an extra reload', async () => {

--- a/src/renderer/lib/stores/resource.ts
+++ b/src/renderer/lib/stores/resource.ts
@@ -136,7 +136,7 @@ export class Resource<T, TEventData = void> {
       .then((data) => {
         runInAction(() => {
           this.data = data;
-          this.loading = false;
+          this.loading = this._reloadQueued;
           this.error = undefined;
           this.lastUpdatedAt = Date.now();
         });
@@ -144,7 +144,7 @@ export class Resource<T, TEventData = void> {
       .catch((e: unknown) => {
         runInAction(() => {
           this.error = e instanceof Error ? e.message : String(e);
-          this.loading = false;
+          this.loading = this._reloadQueued;
         });
       })
       .finally(() => {

--- a/src/renderer/lib/stores/resource.ts
+++ b/src/renderer/lib/stores/resource.ts
@@ -55,6 +55,7 @@ export class Resource<T, TEventData = void> {
   private readonly _fetch: (() => Promise<T>) | null;
   private readonly _strategies: ResourceStrategy<T, TEventData>[];
   private _inFlight: Promise<void> | null = null;
+  private _reloadQueued = false;
   private _stopFns: Array<() => void> = [];
   private readonly _ctx: ResourceContext<T>;
 
@@ -148,6 +149,10 @@ export class Resource<T, TEventData = void> {
       })
       .finally(() => {
         this._inFlight = null;
+        if (this._reloadQueued) {
+          this._reloadQueued = false;
+          void this.load();
+        }
       });
 
     return this._inFlight;
@@ -155,6 +160,10 @@ export class Resource<T, TEventData = void> {
 
   /** Schedule a fresh load (fire-and-forget). */
   invalidate(): void {
+    if (this._inFlight) {
+      this._reloadQueued = true;
+      return;
+    }
     void this.load();
   }
 
@@ -189,6 +198,7 @@ export class Resource<T, TEventData = void> {
 
   /** Stop all timers and unsubscribe all listeners. */
   dispose(): void {
+    this._reloadQueued = false;
     for (const stop of this._stopFns) stop();
     this._stopFns = [];
   }
@@ -274,9 +284,9 @@ export class Resource<T, TEventData = void> {
       if (strategy.onEvent === 'reload') {
         if (strategy.debounceMs) {
           if (debounceTimer) clearTimeout(debounceTimer);
-          debounceTimer = setTimeout(() => void this.load(), strategy.debounceMs);
+          debounceTimer = setTimeout(() => this.invalidate(), strategy.debounceMs);
         } else {
-          void this.load();
+          this.invalidate();
         }
       } else {
         runInAction(() => {


### PR DESCRIPTION
- fixes stale diff panel updates when file-watch events arrive during an in-flight Git status load
- changes Resource.invalidate() to queue one follow-up reload instead of dropping invalidations while _inFlight exists
- routes event-based reload strategies through invalidate() so watcher-triggered refreshes get the same queued behavior
- preserves direct load() deduping to avoid extra startup fetches