### PR TITLE
fix(tasks): tolerate legacy source branch formats

### DIFF
--- a/src/main/core/tasks/operations/createTask.test.ts
+++ b/src/main/core/tasks/operations/createTask.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { TaskRow } from '@main/db/schema';
 import { err } from '@shared/result';
+import { toStoredBranch } from '../stored-branch';
 import { createTask } from './createTask';
 
 const mocks = vi.hoisted(() => ({
@@ -131,7 +132,10 @@ describe('createTask', () => {
     expect(insertTaskValues).toHaveBeenCalledWith(
       expect.objectContaining({
         taskBranch: 'claude/add-french-translations-ud2fs',
-        sourceBranch: { type: 'local', branch: 'claude/add-french-translations-ud2fs' },
+        sourceBranch: toStoredBranch({
+          type: 'local',
+          branch: 'claude/add-french-translations-ud2fs',
+        }),
       })
     );
   });
@@ -178,7 +182,10 @@ describe('createTask', () => {
     expect(insertTaskValues).toHaveBeenCalledWith(
       expect.objectContaining({
         taskBranch: 'claude/add-french-translations-ud2fs',
-        sourceBranch: { type: 'local', branch: 'claude/add-french-translations-ud2fs' },
+        sourceBranch: toStoredBranch({
+          type: 'local',
+          branch: 'claude/add-french-translations-ud2fs',
+        }),
       })
     );
   });

--- a/src/main/core/tasks/operations/deleteTask.ts
+++ b/src/main/core/tasks/operations/deleteTask.ts
@@ -7,6 +7,7 @@ import { tasks, workspaces } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import type { DeleteTaskOptions } from '@shared/tasks';
+import { fromStoredBranch } from '../stored-branch';
 import { removeWorktreeIfUnused } from './task-lifecycle-utils';
 
 export async function deleteTask(
@@ -18,7 +19,7 @@ export async function deleteTask(
 
   const [task] = await db.select().from(tasks).where(eq(tasks.id, taskId)).limit(1);
   if (!task) return;
-  const sourceBranch = task.sourceBranch ?? undefined;
+  const sourceBranch = fromStoredBranch(task.sourceBranch);
 
   const project = projectManager.getProject(projectId);
 

--- a/src/main/core/tasks/operations/getDeletePreflight.ts
+++ b/src/main/core/tasks/operations/getDeletePreflight.ts
@@ -4,6 +4,7 @@ import { db } from '@main/db/client';
 import { tasks } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import type { DeletePreflightResult, TaskDeletePreflightItem } from '@shared/tasks';
+import { fromStoredBranch } from '../stored-branch';
 
 async function getTaskPreflight(
   projectId: string,
@@ -28,7 +29,7 @@ async function getTaskPreflight(
 
   const hasWorktree = siblings.length === 0;
 
-  const sourceBranch = task.sourceBranch ?? undefined;
+  const sourceBranch = fromStoredBranch(task.sourceBranch);
   const hasDeletableBranch =
     hasWorktree && !!sourceBranch && task.taskBranch !== sourceBranch.branch;
 

--- a/src/main/core/tasks/operations/getTasks.db.test.ts
+++ b/src/main/core/tasks/operations/getTasks.db.test.ts
@@ -1,0 +1,70 @@
+import { openFixture } from '@tooling/utils/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppDb } from '@main/db/client';
+import { getTasks } from './getTasks';
+
+const mocks = vi.hoisted(() => ({
+  db: undefined as AppDb | undefined,
+}));
+
+vi.mock('@main/db/client', () => ({
+  get db() {
+    if (!mocks.db) throw new Error('Test database not initialized');
+    return mocks.db;
+  },
+}));
+
+describe('getTasks', () => {
+  let fixture: Awaited<ReturnType<typeof openFixture>>;
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+    mocks.db = fixture.db;
+
+    fixture.sqlite
+      .prepare(
+        `INSERT INTO projects (id, name, path, created_at, updated_at)
+         VALUES ('project-1', 'Project', '/repo', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+      )
+      .run();
+  });
+
+  afterEach(() => {
+    fixture.close();
+    mocks.db = undefined;
+  });
+
+  it('loads tasks whose source_branch is a historical raw branch string', async () => {
+    fixture.sqlite
+      .prepare(
+        `INSERT INTO tasks (
+           id,
+           project_id,
+           name,
+           status,
+           source_branch,
+           task_branch,
+           created_at,
+           updated_at,
+           status_changed_at
+         )
+         VALUES (
+           'task-1',
+           'project-1',
+           'Raw Branch Task',
+           'in_progress',
+           'main',
+           'feature/raw-branch',
+           CURRENT_TIMESTAMP,
+           CURRENT_TIMESTAMP,
+           CURRENT_TIMESTAMP
+         )`
+      )
+      .run();
+
+    const rows = await getTasks('project-1');
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.sourceBranch).toEqual({ type: 'local', branch: 'main' });
+  });
+});

--- a/src/main/core/tasks/operations/renameTask.ts
+++ b/src/main/core/tasks/operations/renameTask.ts
@@ -7,6 +7,7 @@ import { resolveTaskBranchName } from '@shared/resolveTaskBranchName';
 import { err, ok, type Result } from '@shared/result';
 import type { RenameTaskError, RenameTaskSuccess, RenameTaskWarning } from '@shared/tasks';
 import { appSettingsService } from '../../settings/settings-service';
+import { fromStoredBranch } from '../stored-branch';
 
 function parseLinkedIssueProvider(linkedIssue: unknown): unknown {
   if (!linkedIssue || typeof linkedIssue !== 'string') return undefined;
@@ -29,7 +30,7 @@ export async function renameTask(
   if (!project) return err({ type: 'project-not-found', projectId });
 
   const oldBranch = row.taskBranch;
-  const sourceBranch = row.sourceBranch ?? undefined;
+  const sourceBranch = fromStoredBranch(row.sourceBranch);
   let newBranch: string | null = null;
   let warning: RenameTaskWarning | undefined;
 

--- a/src/main/core/tasks/stored-branch.test.ts
+++ b/src/main/core/tasks/stored-branch.test.ts
@@ -42,4 +42,14 @@ describe('stored-branch', () => {
   it('treats valid JSON primitives as historical raw branch strings', () => {
     expect(fromStoredBranch('123')).toEqual({ type: 'local', branch: '123' });
   });
+
+  it('returns undefined for null, undefined, and empty string', () => {
+    expect(fromStoredBranch(null)).toBeUndefined();
+    expect(fromStoredBranch(undefined)).toBeUndefined();
+    expect(fromStoredBranch('')).toBeUndefined();
+  });
+
+  it('returns undefined for literal JSON null', () => {
+    expect(fromStoredBranch('null')).toBeUndefined();
+  });
 });

--- a/src/main/core/tasks/stored-branch.test.ts
+++ b/src/main/core/tasks/stored-branch.test.ts
@@ -6,7 +6,7 @@ describe('stored-branch', () => {
   it('serializes and deserializes local branches', () => {
     const branch: Branch = { type: 'local', branch: 'main' };
     const persisted = toStoredBranch(branch);
-    expect(persisted).toEqual({ type: 'local', branch: 'main' });
+    expect(persisted).toBe(JSON.stringify({ type: 'local', branch: 'main' }));
     expect(fromStoredBranch(persisted)).toEqual(branch);
   });
 
@@ -17,11 +17,29 @@ describe('stored-branch', () => {
       remote: { name: 'origin', url: 'git@github.com:owner/repo.git' },
     };
     const persisted = toStoredBranch(branch);
-    expect(persisted).toEqual({
-      type: 'remote',
-      branch: 'main',
-      remote: { name: 'origin', url: 'git@github.com:owner/repo.git' },
-    });
+    expect(persisted).toBe(
+      JSON.stringify({
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin', url: 'git@github.com:owner/repo.git' },
+      })
+    );
     expect(fromStoredBranch(persisted)).toEqual(branch);
+  });
+
+  it('deserializes historical raw branch strings', () => {
+    expect(fromStoredBranch('main')).toEqual({ type: 'local', branch: 'main' });
+    expect(fromStoredBranch('felix/edu-2408-videos-added-to-lessons-dont-work-in-app')).toEqual({
+      type: 'local',
+      branch: 'felix/edu-2408-videos-added-to-lessons-dont-work-in-app',
+    });
+  });
+
+  it('deserializes historical JSON string branch values', () => {
+    expect(fromStoredBranch('"main"')).toEqual({ type: 'local', branch: 'main' });
+  });
+
+  it('treats valid JSON primitives as historical raw branch strings', () => {
+    expect(fromStoredBranch('123')).toEqual({ type: 'local', branch: '123' });
   });
 });

--- a/src/main/core/tasks/stored-branch.ts
+++ b/src/main/core/tasks/stored-branch.ts
@@ -19,6 +19,8 @@ export function fromStoredBranch(raw: string | Branch | null | undefined): Branc
     const decoded = decodeStoredBranchValue(parsed);
     if (decoded) return decoded;
 
+    if (parsed === null) return undefined;
+
     // A historical plain branch name can itself be valid JSON, e.g. "123" or "true".
     return isStructuredJson(raw) ? undefined : { type: 'local', branch: raw };
   } catch {

--- a/src/main/core/tasks/stored-branch.ts
+++ b/src/main/core/tasks/stored-branch.ts
@@ -1,16 +1,66 @@
 import type { Branch } from '@shared/git';
 
 /**
- * The persisted form of a Branch stored in SQLite.
- * Now identical to the lean Branch type — local branches are stored without
- * the optional `remote` field (which is fine since the field is optional).
+ * The persisted form of a Branch stored in SQLite. The column is plain text so
+ * app code, not Drizzle, owns compatibility with historical storage formats.
  */
-export type StoredBranch = Branch;
+export type StoredBranch = string & { readonly __storedBranch: unique symbol };
 
-export function toStoredBranch(branch: Branch): StoredBranch {
-  return branch;
+export function toStoredBranch(branch: Branch | null | undefined): StoredBranch | null {
+  return branch ? (JSON.stringify(branch) as StoredBranch) : null;
 }
 
-export function fromStoredBranch(branch: StoredBranch): Branch {
-  return branch;
+export function fromStoredBranch(raw: string | Branch | null | undefined): Branch | undefined {
+  if (!raw) return undefined;
+  if (typeof raw !== 'string') return decodeStoredBranchValue(raw);
+
+  try {
+    const parsed = JSON.parse(raw) as unknown;
+    const decoded = decodeStoredBranchValue(parsed);
+    if (decoded) return decoded;
+
+    // A historical plain branch name can itself be valid JSON, e.g. "123" or "true".
+    return isStructuredJson(raw) ? undefined : { type: 'local', branch: raw };
+  } catch {
+    return { type: 'local', branch: raw };
+  }
+}
+
+function decodeStoredBranchValue(value: unknown): Branch | undefined {
+  if (typeof value === 'string') {
+    return value ? { type: 'local', branch: value } : undefined;
+  }
+
+  if (!isRecord(value) || typeof value.branch !== 'string' || value.branch.length === 0) {
+    return undefined;
+  }
+
+  if (value.type === 'local') {
+    const remote = decodeRemote(value.remote);
+    return remote
+      ? { type: 'local', branch: value.branch, remote }
+      : { type: 'local', branch: value.branch };
+  }
+
+  if (value.type === 'remote') {
+    const remote = decodeRemote(value.remote);
+    return remote ? { type: 'remote', branch: value.branch, remote } : undefined;
+  }
+
+  return undefined;
+}
+
+function decodeRemote(value: unknown): Branch['remote'] | undefined {
+  if (!isRecord(value)) return undefined;
+  if (typeof value.name !== 'string' || typeof value.url !== 'string') return undefined;
+  return { name: value.name, url: value.url };
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function isStructuredJson(raw: string): boolean {
+  const first = raw.trimStart()[0];
+  return first === '{' || first === '[';
 }

--- a/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -2,7 +2,9 @@ import crypto from 'node:crypto';
 import { openFixture } from '@tooling/utils/db';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { toStoredBranch } from '@main/core/tasks/stored-branch';
 import { projects, tasks, workspaces } from '@main/db/schema';
+import type { Branch } from '@shared/git';
 import { WorkspaceBootstrapService, type WorktreeContext } from './workspace-bootstrap-service';
 import { computeWorkspaceKey } from './workspace-key';
 
@@ -240,10 +242,10 @@ describe('WorkspaceBootstrapService', () => {
     });
 
     it('uses checkoutBranchWorktree when sourceBranch differs from taskBranch', async () => {
-      const sourceBranch = { type: 'local', branch: 'main' };
+      const sourceBranch: Branch = { type: 'local', branch: 'main' };
       await fixture.db
         .update(tasks)
-        .set({ taskBranch: 'feature/x', sourceBranch: sourceBranch as never })
+        .set({ taskBranch: 'feature/x', sourceBranch: toStoredBranch(sourceBranch) })
         .where(eq(tasks.id, TASK_ID));
 
       const ctx = makeCtx({

--- a/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -5,6 +5,7 @@ import { tasks, workspaces } from '@main/db/schema';
 import type { WorkspaceResolution, WorkspaceType } from '@shared/workspaces';
 import type { WorktreeBootstrapOps } from '../projects/worktrees/worktree-service';
 import { mapWorktreeErrorToProvisionError } from '../tasks/provision-task-error';
+import { fromStoredBranch } from '../tasks/stored-branch';
 import { computeWorkspaceKey } from './workspace-key';
 
 export type WorktreeContext = {
@@ -108,20 +109,22 @@ export class WorkspaceBootstrapService {
 
     if (!taskRow.taskBranch) {
       worktreePath = ctx.repoPath;
-    } else if (
-      !taskRow.sourceBranch ||
-      taskRow.taskBranch === (taskRow.sourceBranch as { branch?: string }).branch
-    ) {
-      const result = await ctx.worktreeService.checkoutExistingBranch(taskRow.taskBranch);
-      if (!result.success) throw mapWorktreeErrorToProvisionError(taskRow.taskBranch, result.error);
-      worktreePath = result.data;
     } else {
-      const result = await ctx.worktreeService.checkoutBranchWorktree(
-        taskRow.sourceBranch as Parameters<typeof ctx.worktreeService.checkoutBranchWorktree>[0],
-        taskRow.taskBranch
-      );
-      if (!result.success) throw mapWorktreeErrorToProvisionError(taskRow.taskBranch, result.error);
-      worktreePath = result.data;
+      const sourceBranch = fromStoredBranch(taskRow.sourceBranch);
+      if (!sourceBranch || taskRow.taskBranch === sourceBranch.branch) {
+        const result = await ctx.worktreeService.checkoutExistingBranch(taskRow.taskBranch);
+        if (!result.success)
+          throw mapWorktreeErrorToProvisionError(taskRow.taskBranch, result.error);
+        worktreePath = result.data;
+      } else {
+        const result = await ctx.worktreeService.checkoutBranchWorktree(
+          sourceBranch,
+          taskRow.taskBranch
+        );
+        if (!result.success)
+          throw mapWorktreeErrorToProvisionError(taskRow.taskBranch, result.error);
+        worktreePath = result.data;
+      }
     }
 
     await this._persistPathForTask(

--- a/src/main/db/legacy-port/importers/relational/tasks.ts
+++ b/src/main/db/legacy-port/importers/relational/tasks.ts
@@ -1,3 +1,4 @@
+import { toStoredBranch } from '@main/core/tasks/stored-branch';
 import { tasks } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import { readLegacyRows, toInteger, toIsoTimestamp, toTrimmedString } from './helpers';
@@ -147,7 +148,7 @@ export async function portTasks({ appDb, legacyDb, remap }: PortContext): Promis
       projectId: mappedProjectId,
       name: toTrimmedString(row.name) ?? branch ?? `Legacy Task ${legacyTaskId.slice(0, 8)}`,
       status: coerceTaskStatus(toTrimmedString(row.status)),
-      sourceBranch,
+      sourceBranch: toStoredBranch(sourceBranch),
       taskBranch: taskBranch ?? null,
       archivedAt: toTrimmedString(row.archived_at) ?? null,
       createdAt,

--- a/src/main/db/schema.ts
+++ b/src/main/db/schema.ts
@@ -110,7 +110,7 @@ export const tasks = sqliteTable(
       .references(() => projects.id, { onDelete: 'cascade' }),
     name: text('name').notNull(),
     status: text('status').notNull(),
-    sourceBranch: text('source_branch', { mode: 'json' }).$type<StoredBranch>(),
+    sourceBranch: text('source_branch').$type<StoredBranch>(),
     taskBranch: text('task_branch'),
     linkedIssue: text('linked_issue'),
     archivedAt: text('archived_at'), // null = active, timestamp = archived

--- a/tooling/seeds/baseline.ts
+++ b/tooling/seeds/baseline.ts
@@ -1,3 +1,4 @@
+import { toStoredBranch } from '@main/core/tasks/stored-branch';
 import type { AppDb } from '@main/db/client';
 import { conversations, projectRemotes, projects, projectSettings, tasks } from '@main/db/schema';
 import type { Branch } from '@shared/git';
@@ -63,7 +64,7 @@ export async function baseline(db: AppDb): Promise<void> {
       name: 'Add workspace database entity',
       status: 'in_progress',
       taskBranch: 'feat/workspace-db',
-      sourceBranch: mainBranch,
+      sourceBranch: toStoredBranch(mainBranch),
       workspaceId: `local:${PROJECT_A_ID}:branch:feat/workspace-db`,
     },
     {
@@ -72,7 +73,7 @@ export async function baseline(db: AppDb): Promise<void> {
       name: 'Improve migration test tooling',
       status: 'review',
       taskBranch: 'feat/migration-testing',
-      sourceBranch: mainBranch,
+      sourceBranch: toStoredBranch(mainBranch),
       workspaceId: `local:${PROJECT_A_ID}:branch:feat/migration-testing`,
     },
     {
@@ -81,7 +82,7 @@ export async function baseline(db: AppDb): Promise<void> {
       name: 'Fix SSH connection timeout',
       status: 'done',
       taskBranch: 'fix/ssh-timeout',
-      sourceBranch: mainBranch,
+      sourceBranch: toStoredBranch(mainBranch),
       archivedAt: '2026-04-01T10:00:00.000Z',
       workspaceId: `local:${PROJECT_A_ID}:branch:fix/ssh-timeout`,
     },
@@ -91,7 +92,7 @@ export async function baseline(db: AppDb): Promise<void> {
       name: 'Add rate limiting middleware',
       status: 'todo',
       taskBranch: 'feat/rate-limiting',
-      sourceBranch: mainBranch,
+      sourceBranch: toStoredBranch(mainBranch),
     },
   ]);
 


### PR DESCRIPTION
- stop Drizzle from JSON-parsing tasks.source_branch during row materialization
- add a source branch codec that reads raw legacy strings, JSON strings, and current branch objects
- update task/workspace paths to decode stored branches before branch comparisons