### PR TITLE
fix(projects): show creating state during project creation preflight

### DIFF
--- a/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
+++ b/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
@@ -3,6 +3,10 @@ import { Home, Server } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useMemo, useState } from 'react';
 import { SshConnectionSelector } from '@renderer/features/projects/components/add-project-modal/ssh-connection-selector';
+import type {
+  ModeData as ProjectCreationModeData,
+  ProjectType,
+} from '@renderer/features/projects/stores/project-creation-types';
 import {
   getProjectManagerStore,
   getProjectSettingsStore,
@@ -11,7 +15,11 @@ import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { useNavigate } from '@renderer/lib/layout/navigation-provider';
-import { useShowModal, type BaseModalProps } from '@renderer/lib/modal/modal-provider';
+import {
+  useModalContext,
+  useShowModal,
+  type BaseModalProps,
+} from '@renderer/lib/modal/modal-provider';
 import { useGithubContext } from '@renderer/lib/providers/github-context-provider';
 import { appState } from '@renderer/lib/stores/app-state';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
@@ -33,24 +41,6 @@ export type Strategy = 'local' | 'ssh';
 
 export type Mode = 'pick' | 'new' | 'clone';
 
-export interface BaseModeData {
-  name: string;
-  path: string;
-  initGitRepository?: boolean;
-}
-
-export interface NewModeData extends BaseModeData {
-  repositoryName: string;
-  repositoryOwner: string;
-  repositoryVisibility: 'public' | 'private';
-}
-
-export interface CloneModeData extends BaseModeData {
-  repositoryUrl: string;
-}
-
-export type ModeData = BaseModeData | NewModeData | CloneModeData;
-
 export interface AddProjectModalProps extends BaseModalProps<void> {
   strategy?: Strategy;
   mode?: Mode;
@@ -66,6 +56,7 @@ export const AddProjectModal = observer(function AddProjectModal({
   const [strategy, setStrategy] = useState<Strategy>(strategyProp ?? 'local');
   const [mode, setMode] = useState<Mode>(modeProp ?? 'pick');
   const [connectionId, setConnectionId] = useState<string | undefined>(connectionIdProp);
+  const [submitState, setSubmitState] = useState<'idle' | 'checking'>('idle');
   const { connections } = appState.sshConnections;
   const availableConnectionIds = useMemo(
     () =>
@@ -76,6 +67,7 @@ export const AddProjectModal = observer(function AddProjectModal({
     strategy === 'ssh' ? (connectionId ?? availableConnectionIds[0]) : connectionId;
 
   const { navigate } = useNavigate();
+  const { setCloseGuard } = useModalContext();
   const { isInitialized, needsGhAuth } = useGithubContext();
 
   const showSshConnModal = useShowModal('addSshConnModal');
@@ -242,97 +234,98 @@ export const AddProjectModal = observer(function AddProjectModal({
     pickPathStatusQuery.data.isGitRepo === false;
   const isCheckingPickPathStatus = shouldCheckPickPathStatus && pickPathStatusQuery.isPending;
 
-  const canCreate =
+  const canSubmit =
     activeMode.isValid &&
     (strategy === 'local' || !!selectedConnectionId) &&
     !isCheckingPickPathStatus &&
-    (!requiresGitInitialization || pickState.initGitRepository);
+    (!requiresGitInitialization || pickState.initGitRepository) &&
+    submitState === 'idle';
 
   const handleSubmit = async () => {
-    try {
-      const inspection = await rpc.projects.inspectProjectPath(
-        strategy === 'ssh'
-          ? { type: 'ssh', path: pickState.path, connectionId: selectedConnectionId! }
-          : { type: 'local', path: pickState.path }
-      );
-      if (inspection.existingProject) {
-        navigate('project', { projectId: inspection.existingProject.id });
-        onClose();
-        return;
-      }
-    } catch (e) {
-      log.error(e);
-    }
+    if (!canSubmit) return;
+    setSubmitState('checking');
+    setCloseGuard(true);
 
     const id = crypto.randomUUID();
-    const projectType =
+    const projectType: ProjectType =
       strategy === 'ssh' && selectedConnectionId
         ? { type: 'ssh' as const, connectionId: selectedConnectionId }
         : { type: 'local' as const };
 
-    let createPromise: Promise<string | undefined>;
+    let data: ProjectCreationModeData;
     switch (mode) {
       case 'pick':
-        createPromise = getProjectManagerStore().createProject(
-          projectType,
-          {
-            mode: 'pick',
-            name: pickState.name,
-            path: pickState.path,
-            initGitRepository: pickState.initGitRepository,
-          },
-          id
-        );
+        data = {
+          mode: 'pick',
+          name: pickState.name,
+          path: pickState.path,
+          initGitRepository: pickState.initGitRepository,
+        };
         break;
       case 'new':
-        createPromise = getProjectManagerStore().createProject(
-          projectType,
-          {
-            mode: 'new',
-            name: newState.name,
-            path: newState.path,
-            repositoryName: newState.repositoryName,
-            repositoryOwner: newState.repositoryOwner?.value ?? '',
-            repositoryVisibility: newState.repositoryVisibility,
-          },
-          id
-        );
+        data = {
+          mode: 'new',
+          name: newState.name,
+          path: newState.path,
+          repositoryName: newState.repositoryName,
+          repositoryOwner: newState.repositoryOwner?.value ?? '',
+          repositoryVisibility: newState.repositoryVisibility,
+        };
         break;
       case 'clone':
-        createPromise = getProjectManagerStore().createProject(
-          projectType,
-          {
-            mode: 'clone',
-            name: cloneState.name,
-            path: cloneState.path,
-            repositoryUrl: cloneState.repositoryUrl,
-          },
-          id
-        );
+        data = {
+          mode: 'clone',
+          name: cloneState.name,
+          path: cloneState.path,
+          repositoryUrl: cloneState.repositoryUrl,
+        };
         break;
     }
-    void createPromise
-      .then((createdProjectId) => {
-        if (createdProjectId === id) void maybeShowProjectConfigImportPrompt(createdProjectId);
-      })
-      .catch((error) => {
-        log.error(error);
+
+    try {
+      const result = await getProjectManagerStore().startProjectCreation(projectType, data, { id });
+      setCloseGuard(false);
+
+      if (result.kind === 'existing') {
+        setSubmitState('idle');
+        onClose();
+        navigate('project', { projectId: result.projectId });
+        return;
+      }
+
+      void result.completion
+        .then(() => {
+          void maybeShowProjectConfigImportPrompt(result.projectId);
+        })
+        .catch((error) => {
+          log.error(error);
+        });
+      setSubmitState('idle');
+      onClose();
+      navigate('project', { projectId: result.projectId });
+    } catch (error) {
+      log.error(error);
+      setCloseGuard(false);
+      setSubmitState('idle');
+      toast({
+        title: 'Failed to check project',
+        description: String(error),
+        variant: 'destructive',
       });
-    onClose();
-    navigate('project', { projectId: id });
+    }
   };
 
   return (
     <ModalLayout
       header={
-        <DialogHeader>
+        <DialogHeader showCloseButton={submitState === 'idle'}>
           <DialogTitle>Add Project</DialogTitle>
         </DialogHeader>
       }
       footer={
         <DialogFooter>
-          <ConfirmButton type="button" onClick={() => void handleSubmit()} disabled={!canCreate}>
-            Create
+          <ConfirmButton type="button" onClick={() => void handleSubmit()} disabled={!canSubmit}>
+            {submitState === 'checking' ? 'Creating...' : 'Create'}
           </ConfirmButton>
         </DialogFooter>
       }

--- a/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
+++ b/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
@@ -56,7 +56,7 @@ export const AddProjectModal = observer(function AddProjectModal({
   const [strategy, setStrategy] = useState<Strategy>(strategyProp ?? 'local');
   const [mode, setMode] = useState<Mode>(modeProp ?? 'pick');
   const [connectionId, setConnectionId] = useState<string | undefined>(connectionIdProp);
-  const [submitState, setSubmitState] = useState<'idle' | 'checking'>('idle');
+  const [submitState, setSubmitState] = useState<'idle' | 'creating'>('idle');
   const { connections } = appState.sshConnections;
   const availableConnectionIds = useMemo(
     () =>
@@ -243,7 +243,7 @@ export const AddProjectModal = observer(function AddProjectModal({
 
   const handleSubmit = async () => {
     if (!canSubmit) return;
-    setSubmitState('checking');
+    setSubmitState('creating');
     setCloseGuard(true);
 
     const id = crypto.randomUUID();
@@ -325,7 +325,7 @@ export const AddProjectModal = observer(function AddProjectModal({
       footer={
         <DialogFooter>
           <ConfirmButton type="button" onClick={() => void handleSubmit()} disabled={!canSubmit}>
-            {submitState === 'checking' ? 'Creating...' : 'Create'}
+            {submitState === 'creating' ? 'Creating...' : 'Create'}
           </ConfirmButton>
         </DialogFooter>
       }

--- a/src/renderer/features/projects/stores/project-creation-types.ts
+++ b/src/renderer/features/projects/stores/project-creation-types.ts
@@ -1,0 +1,33 @@
+interface BaseModeData {
+  name: string;
+  path: string;
+}
+
+export interface PickModeData extends BaseModeData {
+  mode: 'pick';
+  initGitRepository?: boolean;
+}
+
+export interface CloneModeData extends BaseModeData {
+  mode: 'clone';
+  repositoryUrl: string;
+}
+
+export interface NewModeData extends BaseModeData {
+  mode: 'new';
+  repositoryName: string;
+  repositoryOwner: string;
+  repositoryVisibility: 'public' | 'private';
+}
+
+export type ModeData = PickModeData | CloneModeData | NewModeData;
+
+export type ProjectType = { type: 'local' } | { type: 'ssh'; connectionId: string };
+
+export type StartProjectCreationResult =
+  | { kind: 'existing'; projectId: string }
+  | { kind: 'creating'; projectId: string; completion: Promise<void> };
+
+export interface StartProjectCreationOptions {
+  id?: string;
+}

--- a/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/src/renderer/features/projects/stores/project-manager.test.ts
@@ -1,0 +1,178 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { LocalProject } from '@shared/projects';
+import { isUnregisteredProject } from './project';
+import { ProjectManagerStore } from './project-manager';
+
+const mocks = vi.hoisted(() => ({
+  cloneRepository: vi.fn(),
+  createGithubRepository: vi.fn(),
+  createProject: vi.fn(),
+  initializeProject: vi.fn(),
+  inspectProjectPath: vi.fn(),
+  openProject: vi.fn(),
+  eventOn: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: {
+    on: mocks.eventOn,
+  },
+  rpc: {
+    github: {
+      cloneRepository: mocks.cloneRepository,
+      createRepository: mocks.createGithubRepository,
+      initializeProject: mocks.initializeProject,
+    },
+    projects: {
+      createProject: mocks.createProject,
+      getProjects: vi.fn(async () => []),
+      inspectProjectPath: mocks.inspectProjectPath,
+      openProject: mocks.openProject,
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/stores/app-state', () => ({
+  appState: {
+    navigation: {
+      currentViewId: 'home',
+      revalidate: vi.fn(),
+      viewParamsStore: {},
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/stores/view-state-cache', () => ({
+  viewStateCache: {
+    get: vi.fn(async () => undefined),
+  },
+}));
+
+vi.mock('@renderer/utils/telemetryClient', () => ({
+  captureTelemetry: vi.fn(),
+}));
+
+function localProject(overrides: Partial<LocalProject> = {}): LocalProject {
+  return {
+    type: 'local',
+    id: 'project-id',
+    name: 'Project',
+    path: '/project',
+    baseRef: 'main',
+    createdAt: '2026-05-28T00:00:00.000Z',
+    updatedAt: '2026-05-28T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('ProjectManagerStore project creation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.inspectProjectPath.mockResolvedValue({ isDirectory: true, isGitRepo: true });
+    mocks.createProject.mockResolvedValue(localProject());
+    mocks.openProject.mockReturnValue(new Promise(() => {}));
+    mocks.cloneRepository.mockReturnValue(new Promise(() => {}));
+    mocks.createGithubRepository.mockResolvedValue({
+      success: true,
+      repoUrl: 'https://github.com/acme/project.git',
+      nameWithOwner: 'acme/project',
+    });
+    mocks.initializeProject.mockResolvedValue({ success: true });
+  });
+
+  it('returns an existing project without starting creation', async () => {
+    const existingProject = localProject({ id: 'existing-project' });
+    mocks.inspectProjectPath.mockResolvedValueOnce({
+      isDirectory: true,
+      isGitRepo: true,
+      existingProject,
+    });
+    const store = new ProjectManagerStore();
+
+    const result = await store.startProjectCreation(
+      { type: 'local' },
+      { mode: 'pick', name: 'Project', path: '/project' },
+      { id: 'optimistic-project' }
+    );
+
+    expect(result).toEqual({ kind: 'existing', projectId: 'existing-project' });
+    expect(mocks.createProject).not.toHaveBeenCalled();
+    expect(store.projects.has('optimistic-project')).toBe(false);
+    expect(store.pendingCreationIds.has('optimistic-project')).toBe(false);
+  });
+
+  it('creates unregistered project state before returning creating', async () => {
+    let resolveCreateProject: (project: LocalProject) => void = () => {};
+    mocks.createProject.mockReturnValueOnce(
+      new Promise<LocalProject>((resolve) => {
+        resolveCreateProject = resolve;
+      })
+    );
+    const store = new ProjectManagerStore();
+
+    const result = await store.startProjectCreation(
+      { type: 'local' },
+      { mode: 'pick', name: 'Project', path: '/project' },
+      { id: 'optimistic-project' }
+    );
+
+    expect(result.kind).toBe('creating');
+    const pendingProject = store.projects.get('optimistic-project');
+    expect(pendingProject && isUnregisteredProject(pendingProject)).toBe(true);
+    expect(pendingProject?.phase).toBe('registering');
+    expect(store.pendingCreationIds.has('optimistic-project')).toBe(true);
+    expect(mocks.inspectProjectPath).toHaveBeenCalledTimes(1);
+
+    resolveCreateProject(localProject({ id: 'optimistic-project' }));
+    if (result.kind === 'creating') await result.completion;
+
+    expect(mocks.inspectProjectPath).toHaveBeenCalledTimes(1);
+    expect(store.pendingCreationIds.has('optimistic-project')).toBe(false);
+  });
+
+  it('inspects the final clone path instead of the parent directory', async () => {
+    const store = new ProjectManagerStore();
+
+    const result = await store.startProjectCreation(
+      { type: 'local' },
+      {
+        mode: 'clone',
+        name: 'child-project',
+        path: '/parent',
+        repositoryUrl: 'https://github.com/acme/child-project.git',
+      },
+      { id: 'optimistic-project' }
+    );
+
+    if (result.kind === 'creating') void result.completion.catch(() => {});
+    expect(mocks.inspectProjectPath).toHaveBeenCalledWith({
+      type: 'local',
+      path: '/parent/child-project',
+    });
+  });
+
+  it('does not let a project registered at the clone parent path short-circuit creation', async () => {
+    const parentProject = localProject({ id: 'parent-project', path: '/parent' });
+    mocks.inspectProjectPath.mockImplementation(async ({ path }: { path: string }) => ({
+      isDirectory: true,
+      isGitRepo: true,
+      existingProject: path === '/parent' ? parentProject : undefined,
+    }));
+    const store = new ProjectManagerStore();
+
+    const result = await store.startProjectCreation(
+      { type: 'local' },
+      {
+        mode: 'clone',
+        name: 'child-project',
+        path: '/parent',
+        repositoryUrl: 'https://github.com/acme/child-project.git',
+      },
+      { id: 'optimistic-project' }
+    );
+
+    if (result.kind === 'creating') void result.completion.catch(() => {});
+    expect(result.kind).toBe('creating');
+    expect(store.projects.has('optimistic-project')).toBe(true);
+  });
+});

--- a/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/src/renderer/features/projects/stores/project-manager.test.ts
@@ -151,6 +151,29 @@ describe('ProjectManagerStore project creation', () => {
     });
   });
 
+  it('inspects the final new-project path instead of the parent directory', async () => {
+    const store = new ProjectManagerStore();
+
+    const result = await store.startProjectCreation(
+      { type: 'local' },
+      {
+        mode: 'new',
+        name: 'child-project',
+        path: '/parent',
+        repositoryName: 'child-project',
+        repositoryOwner: 'acme',
+        repositoryVisibility: 'private',
+      },
+      { id: 'optimistic-project' }
+    );
+
+    if (result.kind === 'creating') void result.completion.catch(() => {});
+    expect(mocks.inspectProjectPath).toHaveBeenCalledWith({
+      type: 'local',
+      path: '/parent/child-project',
+    });
+  });
+
   it('does not let a project registered at the clone parent path short-circuit creation', async () => {
     const parentProject = localProject({ id: 'parent-project', path: '/parent' });
     mocks.inspectProjectPath.mockImplementation(async ({ path }: { path: string }) => ({
@@ -167,6 +190,33 @@ describe('ProjectManagerStore project creation', () => {
         name: 'child-project',
         path: '/parent',
         repositoryUrl: 'https://github.com/acme/child-project.git',
+      },
+      { id: 'optimistic-project' }
+    );
+
+    if (result.kind === 'creating') void result.completion.catch(() => {});
+    expect(result.kind).toBe('creating');
+    expect(store.projects.has('optimistic-project')).toBe(true);
+  });
+
+  it('does not let a project registered at the new-project parent path short-circuit creation', async () => {
+    const parentProject = localProject({ id: 'parent-project', path: '/parent' });
+    mocks.inspectProjectPath.mockImplementation(async ({ path }: { path: string }) => ({
+      isDirectory: true,
+      isGitRepo: true,
+      existingProject: path === '/parent' ? parentProject : undefined,
+    }));
+    const store = new ProjectManagerStore();
+
+    const result = await store.startProjectCreation(
+      { type: 'local' },
+      {
+        mode: 'new',
+        name: 'child-project',
+        path: '/parent',
+        repositoryName: 'child-project',
+        repositoryOwner: 'acme',
+        repositoryVisibility: 'private',
       },
       { id: 'optimistic-project' }
     );

--- a/src/renderer/features/projects/stores/project-manager.ts
+++ b/src/renderer/features/projects/stores/project-manager.ts
@@ -15,32 +15,12 @@ import {
   type ProjectStore,
   type UnregisteredProjectPhase,
 } from './project';
-
-interface BaseModeData {
-  name: string;
-  path: string;
-}
-
-export interface PickModeData extends BaseModeData {
-  mode: 'pick';
-  initGitRepository?: boolean;
-}
-
-export interface CloneModeData extends BaseModeData {
-  mode: 'clone';
-  repositoryUrl: string;
-}
-
-export interface NewModeData extends BaseModeData {
-  mode: 'new';
-  repositoryName: string;
-  repositoryOwner: string;
-  repositoryVisibility: 'public' | 'private';
-}
-
-export type ModeData = PickModeData | CloneModeData | NewModeData;
-
-export type ProjectType = { type: 'local' } | { type: 'ssh'; connectionId: string };
+import type {
+  ModeData,
+  ProjectType,
+  StartProjectCreationOptions,
+  StartProjectCreationResult,
+} from './project-creation-types';
 
 export class ProjectManagerStore {
   projects = observable.map<string, ProjectStore>();
@@ -91,46 +71,66 @@ export class ProjectManagerStore {
     data: ModeData,
     id?: string
   ): Promise<string | undefined> {
-    const projectId = id ?? crypto.randomUUID();
-    runInAction(() => this.pendingCreationIds.add(projectId));
-    try {
-      return await this._doCreateProject(projectType, data, projectId);
-    } finally {
-      runInAction(() => this.pendingCreationIds.delete(projectId));
+    const result = await this.startProjectCreation(projectType, data, { id });
+    if (result.kind === 'existing') return result.projectId;
+
+    await result.completion;
+    return result.projectId;
+  }
+
+  async startProjectCreation(
+    projectType: ProjectType,
+    data: ModeData,
+    options: StartProjectCreationOptions = {}
+  ): Promise<StartProjectCreationResult> {
+    const isSsh = projectType.type === 'ssh';
+    const projectId = options.id ?? crypto.randomUUID();
+    const targetPath = data.mode === 'pick' ? data.path : `${data.path}/${data.name}`;
+    const inspection = await rpc.projects.inspectProjectPath(
+      isSsh
+        ? { type: 'ssh', path: targetPath, connectionId: projectType.connectionId }
+        : { type: 'local', path: targetPath }
+    );
+    if (inspection.existingProject) {
+      return { kind: 'existing', projectId: inspection.existingProject.id };
     }
+
+    runInAction(() => {
+      this.pendingCreationIds.add(projectId);
+      this.projects.set(
+        projectId,
+        createUnregisteredProject(projectId, data.name, initialCreationPhase(data.mode), data.mode)
+      );
+    });
+
+    const completion = this._doCreateProject(projectType, data, projectId, targetPath).finally(
+      () => {
+        runInAction(() => this.pendingCreationIds.delete(projectId));
+      }
+    );
+
+    return { kind: 'creating', projectId, completion };
   }
 
   private async _doCreateProject(
     projectType: ProjectType,
     data: ModeData,
-    projectId: string
-  ): Promise<string | undefined> {
+    projectId: string,
+    targetPath: string
+  ): Promise<void> {
     const isSsh = projectType.type === 'ssh';
-    const inspection = await rpc.projects.inspectProjectPath(
-      isSsh
-        ? { type: 'ssh', path: data.path, connectionId: projectType.connectionId }
-        : { type: 'local', path: data.path }
-    );
-    if (inspection.existingProject) return inspection.existingProject.id;
-
     const projectTelemetryType: 'local' | 'ssh' = isSsh ? 'ssh' : 'local';
     const projectTelemetryStrategy: 'open' | 'create' | 'clone' =
       data.mode === 'clone' ? 'clone' : data.mode === 'new' ? 'create' : 'open';
 
     switch (data.mode) {
       case 'pick': {
-        runInAction(() => {
-          this.projects.set(
-            projectId,
-            createUnregisteredProject(projectId, data.name, 'registering', 'pick')
-          );
-        });
         try {
           const project = isSsh
             ? await rpc.projects.createProject({
                 type: 'ssh',
                 id: projectId,
-                path: data.path,
+                path: targetPath,
                 name: data.name,
                 connectionId: projectType.connectionId,
                 initGitRepository: data.initGitRepository,
@@ -138,7 +138,7 @@ export class ProjectManagerStore {
             : await rpc.projects.createProject({
                 type: 'local',
                 id: projectId,
-                path: data.path,
+                path: targetPath,
                 name: data.name,
                 initGitRepository: data.initGitRepository,
               });
@@ -161,18 +161,11 @@ export class ProjectManagerStore {
       }
 
       case 'clone': {
-        runInAction(() => {
-          this.projects.set(
-            projectId,
-            createUnregisteredProject(projectId, data.name, 'cloning', 'clone')
-          );
-        });
         try {
-          const clonePath = `${data.path}/${data.name}`;
           const connectionId = isSsh ? projectType.connectionId : undefined;
           const cloneResult = await rpc.github.cloneRepository(
             data.repositoryUrl,
-            clonePath,
+            targetPath,
             connectionId
           );
           if (!cloneResult.success) throw new Error(cloneResult.error);
@@ -181,14 +174,14 @@ export class ProjectManagerStore {
             ? await rpc.projects.createProject({
                 type: 'ssh',
                 id: projectId,
-                path: clonePath,
+                path: targetPath,
                 name: data.name,
                 connectionId: projectType.connectionId,
               })
             : await rpc.projects.createProject({
                 type: 'local',
                 id: projectId,
-                path: clonePath,
+                path: targetPath,
                 name: data.name,
               });
           this._setAndOpenProject(projectId, project);
@@ -210,12 +203,6 @@ export class ProjectManagerStore {
       }
 
       case 'new': {
-        runInAction(() => {
-          this.projects.set(
-            projectId,
-            createUnregisteredProject(projectId, data.name, 'creating-repo', 'new')
-          );
-        });
         try {
           const connectionId = isSsh ? projectType.connectionId : undefined;
           const repoResult = await rpc.github.createRepository({
@@ -226,13 +213,12 @@ export class ProjectManagerStore {
           if (!repoResult.success || !repoResult.repoUrl) throw new Error(repoResult.error);
 
           this._updatePhase(projectId, 'cloning');
-          const clonePath = `${data.path}/${data.name}`;
           const cloneUrl = `https://github.com/${repoResult.nameWithOwner}.git`;
-          const cloneResult = await rpc.github.cloneRepository(cloneUrl, clonePath, connectionId);
+          const cloneResult = await rpc.github.cloneRepository(cloneUrl, targetPath, connectionId);
           if (!cloneResult.success) throw new Error(cloneResult.error);
 
           const initResult = await rpc.github.initializeProject({
-            targetPath: clonePath,
+            targetPath,
             name: data.name,
             connectionId,
           });
@@ -243,14 +229,14 @@ export class ProjectManagerStore {
             ? await rpc.projects.createProject({
                 type: 'ssh',
                 id: projectId,
-                path: clonePath,
+                path: targetPath,
                 name: data.name,
                 connectionId: projectType.connectionId,
               })
             : await rpc.projects.createProject({
                 type: 'local',
                 id: projectId,
-                path: clonePath,
+                path: targetPath,
                 name: data.name,
               });
           this._setAndOpenProject(projectId, project);
@@ -271,8 +257,6 @@ export class ProjectManagerStore {
         break;
       }
     }
-
-    return projectId;
   }
 
   mountProject(projectId: string): Promise<void> {
@@ -437,5 +421,16 @@ export class ProjectManagerStore {
         store.error = err instanceof Error ? err.message : String(err);
       }
     });
+  }
+}
+
+function initialCreationPhase(mode: ModeData['mode']): UnregisteredProjectPhase {
+  switch (mode) {
+    case 'pick':
+      return 'registering';
+    case 'clone':
+      return 'cloning';
+    case 'new':
+      return 'creating-repo';
   }
 }


### PR DESCRIPTION
- moved Add Project submit preflight into ProjectManagerStore
- removed duplicate submit-time project path inspection
- added immediate modal feedback with disabled Creating... button
- ensured optimistic project state exists before navigating
- fixed new and clone modes to inspect the final project path