### PR TITLE
feat(ssh): add setup field info tooltips

### DIFF
--- a/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -496,7 +496,7 @@ export function AddSshConnModal({
             <form.Field name="authType">
               {(field) => (
                 <FieldSet>
-                  <div className="mb-3 flex w-fit items-center gap-1.5">
+                  <div className="flex w-fit items-center gap-1.5">
                     <FieldLegend variant="label" className="mb-0">
                       Authentication
                     </FieldLegend>

--- a/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -58,28 +58,26 @@ const EMPTY_SSH_CONFIG_HOSTS: SshConfigHost[] = [];
 
 function FieldInfoTooltip({ label, children }: { label: string; children: ReactNode }) {
   return (
-    <TooltipProvider delay={150}>
-      <Tooltip>
-        <TooltipTrigger
-          render={
-            <button
-              type="button"
-              className="focus-visible:ring-primary/30 relative inline-flex size-4 shrink-0 items-center justify-center rounded-full text-foreground-passive transition-colors before:absolute before:-inset-2.5 before:content-[''] hover:text-foreground focus-visible:ring-2 focus-visible:outline-none"
-              aria-label={`About ${label}`}
-            >
-              <InfoIcon className="size-3.5" aria-hidden="true" />
-            </button>
-          }
-        />
-        <TooltipContent
-          side="top"
-          align="start"
-          className="max-w-[240px] items-start text-left leading-relaxed whitespace-normal"
-        >
-          {children}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <button
+            type="button"
+            className="focus-visible:ring-primary/30 relative inline-flex size-4 shrink-0 items-center justify-center rounded-full text-foreground-passive transition-colors before:absolute before:-inset-2.5 before:content-[''] hover:text-foreground focus-visible:ring-2 focus-visible:outline-none"
+            aria-label={`About ${label}`}
+          >
+            <InfoIcon className="size-3.5" aria-hidden="true" />
+          </button>
+        }
+      />
+      <TooltipContent
+        side="top"
+        align="start"
+        className="max-w-[240px] items-start text-left leading-relaxed whitespace-normal"
+      >
+        {children}
+      </TooltipContent>
+    </Tooltip>
   );
 }
 
@@ -323,111 +321,22 @@ export function AddSshConnModal({
       }
     >
       <DialogContentArea>
-        <form
-          id="add-ssh-conn-form"
-          onSubmit={(e) => {
-            e.preventDefault();
-            void form.handleSubmit();
-          }}
-        >
-          <FieldGroup>
-            {/* Connection name */}
-            <form.Field name="name">
-              {(field) => {
-                const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-                return (
-                  <Field data-invalid={isInvalid}>
-                    <FieldLabel htmlFor={field.name}>Connection Name</FieldLabel>
-                    <Input
-                      id={field.name}
-                      name={field.name}
-                      value={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      aria-invalid={isInvalid}
-                      placeholder="My Server"
-                    />
-                    {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                  </Field>
-                );
-              }}
-            </form.Field>
-
-            {shouldShowSshConfigField && (
-              <form.Field name="sshConfigAlias">
-                {(field) => {
-                  const selectedHost = sshConfigHostsByAlias.get(field.state.value);
-                  return (
-                    <Field>
-                      <FieldLabelWithInfo info="Select an entry from ~/.ssh/config to prefill host, user, key, proxy, and agent forwarding settings.">
-                        SSH Config
-                      </FieldLabelWithInfo>
-                      {sshConfigHosts.length > 0 && (
-                        <Select
-                          value={field.state.value || MANUAL_CONNECTION_VALUE}
-                          onValueChange={(value) => {
-                            if (!value) return;
-                            if (value === MANUAL_CONNECTION_VALUE) {
-                              setSelectedSshConfigAlias('');
-                              field.handleChange('');
-                              form.setFieldValue('name', '');
-                              form.setFieldValue('host', '');
-                              form.setFieldValue('port', 22);
-                              form.setFieldValue('username', '');
-                              form.setFieldValue('authType', 'password');
-                              form.setFieldValue('privateKeyPath', '');
-                              form.setFieldValue('passphrase', '');
-                              form.setFieldValue('forwardAgent', false);
-                              form.setFieldValue('proxyJump', '');
-                              form.setFieldValue('proxyCommand', '');
-                              setIsAdvancedOpen(false);
-                              return;
-                            }
-                            const host = sshConfigHostsByAlias.get(value);
-                            if (host) applySshConfigHost(host);
-                          }}
-                        >
-                          <SelectTrigger className="w-full">
-                            <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
-                              {selectedHost ? (
-                                <span className="truncate">{selectedHost.host}</span>
-                              ) : field.state.value ? (
-                                <span className="truncate">{field.state.value}</span>
-                              ) : (
-                                'Manual connection'
-                              )}
-                            </span>
-                          </SelectTrigger>
-                          <SelectContent>
-                            <SelectItem value={MANUAL_CONNECTION_VALUE}>
-                              Manual connection
-                            </SelectItem>
-                            {sshConfigHosts.map((host) => (
-                              <SelectItem key={host.host} value={host.host}>
-                                <span className="truncate">{host.host}</span>
-                              </SelectItem>
-                            ))}
-                          </SelectContent>
-                        </Select>
-                      )}
-                      {sshConfigLoadError && (
-                        <FieldDescription>{sshConfigLoadError}</FieldDescription>
-                      )}
-                    </Field>
-                  );
-                }}
-              </form.Field>
-            )}
-
-            {/* Host + Port */}
-            <div className="grid grid-cols-[1fr_6rem] gap-3">
-              <form.Field name="host">
+        <TooltipProvider delay={150}>
+          <form
+            id="add-ssh-conn-form"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void form.handleSubmit();
+            }}
+          >
+            <FieldGroup>
+              {/* Connection name */}
+              <form.Field name="name">
                 {(field) => {
                   const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-                  const isAliasBacked = !!form.state.values.sshConfigAlias;
                   return (
                     <Field data-invalid={isInvalid}>
-                      <FieldLabel htmlFor={field.name}>Host</FieldLabel>
+                      <FieldLabel htmlFor={field.name}>Connection Name</FieldLabel>
                       <Input
                         id={field.name}
                         name={field.name}
@@ -435,29 +344,145 @@ export function AddSshConnModal({
                         onBlur={field.handleBlur}
                         onChange={(e) => field.handleChange(e.target.value)}
                         aria-invalid={isInvalid}
-                        placeholder="example.com"
-                        disabled={isAliasBacked}
+                        placeholder="My Server"
                       />
                       {isInvalid && <FieldError errors={field.state.meta.errors} />}
                     </Field>
                   );
                 }}
               </form.Field>
-              <form.Field name="port">
+
+              {shouldShowSshConfigField && (
+                <form.Field name="sshConfigAlias">
+                  {(field) => {
+                    const selectedHost = sshConfigHostsByAlias.get(field.state.value);
+                    return (
+                      <Field>
+                        <FieldLabelWithInfo info="Select an entry from ~/.ssh/config to prefill host, user, key, proxy, and agent forwarding settings.">
+                          SSH Config
+                        </FieldLabelWithInfo>
+                        {sshConfigHosts.length > 0 && (
+                          <Select
+                            value={field.state.value || MANUAL_CONNECTION_VALUE}
+                            onValueChange={(value) => {
+                              if (!value) return;
+                              if (value === MANUAL_CONNECTION_VALUE) {
+                                setSelectedSshConfigAlias('');
+                                field.handleChange('');
+                                form.setFieldValue('name', '');
+                                form.setFieldValue('host', '');
+                                form.setFieldValue('port', 22);
+                                form.setFieldValue('username', '');
+                                form.setFieldValue('authType', 'password');
+                                form.setFieldValue('privateKeyPath', '');
+                                form.setFieldValue('passphrase', '');
+                                form.setFieldValue('forwardAgent', false);
+                                form.setFieldValue('proxyJump', '');
+                                form.setFieldValue('proxyCommand', '');
+                                setIsAdvancedOpen(false);
+                                return;
+                              }
+                              const host = sshConfigHostsByAlias.get(value);
+                              if (host) applySshConfigHost(host);
+                            }}
+                          >
+                            <SelectTrigger className="w-full">
+                              <span className="flex min-w-0 flex-1 items-center gap-1.5 text-left">
+                                {selectedHost ? (
+                                  <span className="truncate">{selectedHost.host}</span>
+                                ) : field.state.value ? (
+                                  <span className="truncate">{field.state.value}</span>
+                                ) : (
+                                  'Manual connection'
+                                )}
+                              </span>
+                            </SelectTrigger>
+                            <SelectContent>
+                              <SelectItem value={MANUAL_CONNECTION_VALUE}>
+                                Manual connection
+                              </SelectItem>
+                              {sshConfigHosts.map((host) => (
+                                <SelectItem key={host.host} value={host.host}>
+                                  <span className="truncate">{host.host}</span>
+                                </SelectItem>
+                              ))}
+                            </SelectContent>
+                          </Select>
+                        )}
+                        {sshConfigLoadError && (
+                          <FieldDescription>{sshConfigLoadError}</FieldDescription>
+                        )}
+                      </Field>
+                    );
+                  }}
+                </form.Field>
+              )}
+
+              {/* Host + Port */}
+              <div className="grid grid-cols-[1fr_6rem] gap-3">
+                <form.Field name="host">
+                  {(field) => {
+                    const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+                    const isAliasBacked = !!form.state.values.sshConfigAlias;
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Host</FieldLabel>
+                        <Input
+                          id={field.name}
+                          name={field.name}
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(e.target.value)}
+                          aria-invalid={isInvalid}
+                          placeholder="example.com"
+                          disabled={isAliasBacked}
+                        />
+                        {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                      </Field>
+                    );
+                  }}
+                </form.Field>
+                <form.Field name="port">
+                  {(field) => {
+                    const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+                    const isAliasBacked = !!form.state.values.sshConfigAlias;
+                    return (
+                      <Field data-invalid={isInvalid}>
+                        <FieldLabel htmlFor={field.name}>Port</FieldLabel>
+                        <Input
+                          id={field.name}
+                          name={field.name}
+                          type="number"
+                          value={field.state.value}
+                          onBlur={field.handleBlur}
+                          onChange={(e) => field.handleChange(Number(e.target.value))}
+                          aria-invalid={isInvalid}
+                          disabled={isAliasBacked}
+                        />
+                        {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                      </Field>
+                    );
+                  }}
+                </form.Field>
+              </div>
+
+              {/* Username */}
+              <form.Field name="username">
                 {(field) => {
                   const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
                   const isAliasBacked = !!form.state.values.sshConfigAlias;
                   return (
                     <Field data-invalid={isInvalid}>
-                      <FieldLabel htmlFor={field.name}>Port</FieldLabel>
+                      <FieldLabel htmlFor={field.name}>Username</FieldLabel>
                       <Input
                         id={field.name}
                         name={field.name}
-                        type="number"
                         value={field.state.value}
                         onBlur={field.handleBlur}
-                        onChange={(e) => field.handleChange(Number(e.target.value))}
+                        onChange={(e) => field.handleChange(e.target.value)}
                         aria-invalid={isInvalid}
+                        placeholder="ubuntu"
+                        autoComplete="off"
                         disabled={isAliasBacked}
                       />
                       {isInvalid && <FieldError errors={field.state.meta.errors} />}
@@ -465,305 +490,281 @@ export function AddSshConnModal({
                   );
                 }}
               </form.Field>
-            </div>
 
-            {/* Username */}
-            <form.Field name="username">
-              {(field) => {
-                const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-                const isAliasBacked = !!form.state.values.sshConfigAlias;
-                return (
-                  <Field data-invalid={isInvalid}>
-                    <FieldLabel htmlFor={field.name}>Username</FieldLabel>
-                    <Input
-                      id={field.name}
-                      name={field.name}
-                      value={field.state.value}
-                      onBlur={field.handleBlur}
-                      onChange={(e) => field.handleChange(e.target.value)}
-                      aria-invalid={isInvalid}
-                      placeholder="ubuntu"
-                      autoComplete="off"
-                      disabled={isAliasBacked}
-                    />
-                    {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                  </Field>
-                );
-              }}
-            </form.Field>
-
-            {/* Auth type */}
-            <form.Field name="authType">
-              {(field) => (
-                <FieldSet>
-                  <div className="flex w-fit items-center gap-1.5">
-                    <FieldLegend variant="label" className="mb-0">
+              {/* Auth type */}
+              <form.Field name="authType">
+                {(field) => (
+                  <FieldSet>
+                    <FieldLegend variant="label" className="mb-0 flex w-fit items-center gap-1.5">
                       Authentication
+                      <FieldInfoTooltip label="Authentication">
+                        Choose how Emdash authenticates to the remote server. SSH config entries can
+                        preselect the best option.
+                      </FieldInfoTooltip>
                     </FieldLegend>
-                    <FieldInfoTooltip label="Authentication">
-                      Choose how Emdash authenticates to the remote server. SSH config entries can
-                      preselect the best option.
-                    </FieldInfoTooltip>
-                  </div>
-                  <RadioGroup
-                    value={field.state.value}
-                    onValueChange={(v) => field.handleChange(v as AuthType)}
-                    className="grid-cols-3"
-                  >
-                    {(['password', 'key', 'agent'] as const).map((type) => (
-                      <label
-                        key={type}
-                        className="flex cursor-pointer items-center gap-2 text-sm font-normal"
-                      >
-                        <RadioGroupItem value={type} />
-                        {type === 'password' ? 'Password' : type === 'key' ? 'SSH Key' : 'Agent'}
-                      </label>
-                    ))}
-                  </RadioGroup>
-                </FieldSet>
-              )}
-            </form.Field>
+                    <RadioGroup
+                      value={field.state.value}
+                      onValueChange={(v) => field.handleChange(v as AuthType)}
+                      className="grid-cols-3"
+                    >
+                      {(['password', 'key', 'agent'] as const).map((type) => (
+                        <label
+                          key={type}
+                          className="flex cursor-pointer items-center gap-2 text-sm font-normal"
+                        >
+                          <RadioGroupItem value={type} />
+                          {type === 'password' ? 'Password' : type === 'key' ? 'SSH Key' : 'Agent'}
+                        </label>
+                      ))}
+                    </RadioGroup>
+                  </FieldSet>
+                )}
+              </form.Field>
 
-            {/* Auth credential fields — reactive to authType */}
-            <form.Subscribe
-              selector={(state) => ({
-                authType: state.values.authType,
-                sshConfigAlias: state.values.sshConfigAlias,
-              })}
-            >
-              {({ authType, sshConfigAlias }) => {
-                if (authType === 'password') {
-                  return (
-                    <form.Field name="password">
-                      {(field) => {
-                        const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
-                        return (
-                          <Field data-invalid={isInvalid}>
-                            <FieldLabel htmlFor={field.name}>Password</FieldLabel>
-                            <Input
-                              id={field.name}
-                              name={field.name}
-                              type="password"
-                              value={field.state.value ?? ''}
-                              onBlur={field.handleBlur}
-                              onChange={(e) => field.handleChange(e.target.value)}
-                              aria-invalid={isInvalid}
-                              autoComplete="current-password"
-                              placeholder={isEditing ? 'Leave blank to keep existing' : undefined}
-                            />
-                            {isInvalid && <FieldError errors={field.state.meta.errors} />}
-                          </Field>
-                        );
-                      }}
-                    </form.Field>
-                  );
-                }
-
-                if (authType === 'key') {
-                  return (
-                    <>
-                      <form.Field name="privateKeyPath">
+              {/* Auth credential fields — reactive to authType */}
+              <form.Subscribe
+                selector={(state) => ({
+                  authType: state.values.authType,
+                  sshConfigAlias: state.values.sshConfigAlias,
+                })}
+              >
+                {({ authType, sshConfigAlias }) => {
+                  if (authType === 'password') {
+                    return (
+                      <form.Field name="password">
                         {(field) => {
                           const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
                           return (
                             <Field data-invalid={isInvalid}>
-                              <FieldLabelWithInfo
-                                htmlFor={field.name}
-                                info="Path on this machine to the private key used for the connection, for example ~/.ssh/id_ed25519."
-                              >
-                                Private Key Path
-                              </FieldLabelWithInfo>
+                              <FieldLabel htmlFor={field.name}>Password</FieldLabel>
                               <Input
                                 id={field.name}
                                 name={field.name}
+                                type="password"
                                 value={field.state.value ?? ''}
                                 onBlur={field.handleBlur}
                                 onChange={(e) => field.handleChange(e.target.value)}
                                 aria-invalid={isInvalid}
-                                placeholder="~/.ssh/id_rsa"
-                                disabled={!!sshConfigAlias}
+                                autoComplete="current-password"
+                                placeholder={isEditing ? 'Leave blank to keep existing' : undefined}
                               />
                               {isInvalid && <FieldError errors={field.state.meta.errors} />}
                             </Field>
                           );
                         }}
                       </form.Field>
-                      <form.Field name="passphrase">
-                        {(field) => (
-                          <Field>
-                            <FieldLabelWithInfo
-                              htmlFor={field.name}
-                              info="Only needed if the selected private key is encrypted with a passphrase."
-                            >
-                              Passphrase
-                            </FieldLabelWithInfo>
-                            <Input
-                              id={field.name}
-                              name={field.name}
-                              type="password"
-                              value={field.state.value ?? ''}
-                              onBlur={field.handleBlur}
-                              onChange={(e) => field.handleChange(e.target.value)}
-                              placeholder={isEditing ? 'Leave blank to keep existing' : 'Optional'}
-                              autoComplete="off"
-                            />
-                            {!isEditing && (
-                              <FieldDescription>
-                                Leave empty if your key has no passphrase.
-                              </FieldDescription>
-                            )}
-                          </Field>
-                        )}
-                      </form.Field>
-                    </>
-                  );
-                }
+                    );
+                  }
 
-                return (
-                  <FieldDescription>
-                    The SSH agent running on this machine will be used for authentication. Make sure
-                    your key is loaded into the agent.
-                  </FieldDescription>
-                );
-              }}
-            </form.Subscribe>
-
-            <form.Subscribe
-              selector={(state) => ({
-                sshConfigAlias: state.values.sshConfigAlias,
-                proxyCommand: state.values.proxyCommand,
-              })}
-            >
-              {({ sshConfigAlias, proxyCommand }) => {
-                const isAliasBacked = !!sshConfigAlias;
-                const showProxyCommand = isAliasBacked && proxyCommand.trim().length > 0;
-                return (
-                  <Collapsible
-                    open={isAliasBacked || isAdvancedOpen}
-                    onOpenChange={isAliasBacked ? undefined : setIsAdvancedOpen}
-                  >
-                    <CollapsibleTrigger
-                      type="button"
-                      className="flex h-8 w-full items-center justify-between rounded-md px-0 text-sm font-medium text-foreground-muted hover:text-foreground"
-                      disabled={isAliasBacked}
-                    >
-                      <span>Advanced</span>
-                      {isAliasBacked || isAdvancedOpen ? (
-                        <ChevronUp className="size-4" />
-                      ) : (
-                        <ChevronDown className="size-4" />
-                      )}
-                    </CollapsibleTrigger>
-                    <CollapsibleContent className="grid gap-3 pt-2">
-                      {showProxyCommand ? (
-                        <form.Field name="proxyCommand">
+                  if (authType === 'key') {
+                    return (
+                      <>
+                        <form.Field name="privateKeyPath">
+                          {(field) => {
+                            const isInvalid =
+                              field.state.meta.isTouched && !field.state.meta.isValid;
+                            return (
+                              <Field data-invalid={isInvalid}>
+                                <FieldLabelWithInfo
+                                  htmlFor={field.name}
+                                  info="Path on this machine to the private key used for the connection, for example ~/.ssh/id_ed25519."
+                                >
+                                  Private Key Path
+                                </FieldLabelWithInfo>
+                                <Input
+                                  id={field.name}
+                                  name={field.name}
+                                  value={field.state.value ?? ''}
+                                  onBlur={field.handleBlur}
+                                  onChange={(e) => field.handleChange(e.target.value)}
+                                  aria-invalid={isInvalid}
+                                  placeholder="~/.ssh/id_rsa"
+                                  disabled={!!sshConfigAlias}
+                                />
+                                {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                              </Field>
+                            );
+                          }}
+                        </form.Field>
+                        <form.Field name="passphrase">
                           {(field) => (
                             <Field>
                               <FieldLabelWithInfo
                                 htmlFor={field.name}
-                                info="Command from your SSH config used to reach this host through a proxy. It is read-only here because it comes from ~/.ssh/config."
+                                info="Only needed if the selected private key is encrypted with a passphrase."
                               >
-                                ProxyCommand
+                                Passphrase
                               </FieldLabelWithInfo>
                               <Input
                                 id={field.name}
                                 name={field.name}
-                                value={field.state.value}
-                                disabled
+                                type="password"
+                                value={field.state.value ?? ''}
+                                onBlur={field.handleBlur}
+                                onChange={(e) => field.handleChange(e.target.value)}
+                                placeholder={
+                                  isEditing ? 'Leave blank to keep existing' : 'Optional'
+                                }
+                                autoComplete="off"
                               />
+                              {!isEditing && (
+                                <FieldDescription>
+                                  Leave empty if your key has no passphrase.
+                                </FieldDescription>
+                              )}
                             </Field>
                           )}
                         </form.Field>
-                      ) : (
-                        <form.Field name="proxyJump">
+                      </>
+                    );
+                  }
+
+                  return (
+                    <FieldDescription>
+                      The SSH agent running on this machine will be used for authentication. Make
+                      sure your key is loaded into the agent.
+                    </FieldDescription>
+                  );
+                }}
+              </form.Subscribe>
+
+              <form.Subscribe
+                selector={(state) => ({
+                  sshConfigAlias: state.values.sshConfigAlias,
+                  proxyCommand: state.values.proxyCommand,
+                })}
+              >
+                {({ sshConfigAlias, proxyCommand }) => {
+                  const isAliasBacked = !!sshConfigAlias;
+                  const showProxyCommand = isAliasBacked && proxyCommand.trim().length > 0;
+                  return (
+                    <Collapsible
+                      open={isAliasBacked || isAdvancedOpen}
+                      onOpenChange={isAliasBacked ? undefined : setIsAdvancedOpen}
+                    >
+                      <CollapsibleTrigger
+                        type="button"
+                        className="flex h-8 w-full items-center justify-between rounded-md px-0 text-sm font-medium text-foreground-muted hover:text-foreground"
+                        disabled={isAliasBacked}
+                      >
+                        <span>Advanced</span>
+                        {isAliasBacked || isAdvancedOpen ? (
+                          <ChevronUp className="size-4" />
+                        ) : (
+                          <ChevronDown className="size-4" />
+                        )}
+                      </CollapsibleTrigger>
+                      <CollapsibleContent className="grid gap-3 pt-2">
+                        {showProxyCommand ? (
+                          <form.Field name="proxyCommand">
+                            {(field) => (
+                              <Field>
+                                <FieldLabelWithInfo
+                                  htmlFor={field.name}
+                                  info="Command from your SSH config used to reach this host through a proxy. It is read-only here because it comes from ~/.ssh/config."
+                                >
+                                  ProxyCommand
+                                </FieldLabelWithInfo>
+                                <Input
+                                  id={field.name}
+                                  name={field.name}
+                                  value={field.state.value}
+                                  disabled
+                                />
+                              </Field>
+                            )}
+                          </form.Field>
+                        ) : (
+                          <form.Field name="proxyJump">
+                            {(field) => (
+                              <Field>
+                                <FieldLabelWithInfo
+                                  htmlFor={field.name}
+                                  info="Optional bastion host to connect through before reaching the target server, for example user@bastion:2222."
+                                >
+                                  ProxyJump
+                                </FieldLabelWithInfo>
+                                <Input
+                                  id={field.name}
+                                  name={field.name}
+                                  value={field.state.value}
+                                  onBlur={field.handleBlur}
+                                  onChange={(e) => field.handleChange(e.target.value)}
+                                  placeholder="bastion or user@bastion:2222"
+                                  autoComplete="off"
+                                  disabled={isAliasBacked}
+                                />
+                              </Field>
+                            )}
+                          </form.Field>
+                        )}
+                        <form.Field name="forwardAgent">
                           {(field) => (
-                            <Field>
+                            <Field className="flex-row items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
                               <FieldLabelWithInfo
                                 htmlFor={field.name}
-                                info="Optional bastion host to connect through before reaching the target server, for example user@bastion:2222."
+                                info="Forward your local SSH agent to the remote server so nested SSH and Git commands can use your loaded local keys. Enable only for trusted hosts."
                               >
-                                ProxyJump
+                                ForwardAgent
                               </FieldLabelWithInfo>
-                              <Input
+                              <Switch
                                 id={field.name}
-                                name={field.name}
-                                value={field.state.value}
-                                onBlur={field.handleBlur}
-                                onChange={(e) => field.handleChange(e.target.value)}
-                                placeholder="bastion or user@bastion:2222"
-                                autoComplete="off"
+                                checked={field.state.value}
+                                onCheckedChange={(checked) => field.handleChange(checked)}
                                 disabled={isAliasBacked}
                               />
                             </Field>
                           )}
                         </form.Field>
-                      )}
-                      <form.Field name="forwardAgent">
-                        {(field) => (
-                          <Field className="flex-row items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
-                            <FieldLabelWithInfo
-                              htmlFor={field.name}
-                              info="Forward your local SSH agent to the remote server so nested SSH and Git commands can use your loaded local keys. Enable only for trusted hosts."
-                            >
-                              ForwardAgent
-                            </FieldLabelWithInfo>
-                            <Switch
-                              id={field.name}
-                              checked={field.state.value}
-                              onCheckedChange={(checked) => field.handleChange(checked)}
-                              disabled={isAliasBacked}
-                            />
-                          </Field>
-                        )}
-                      </form.Field>
-                    </CollapsibleContent>
-                  </Collapsible>
-                );
-              }}
-            </form.Subscribe>
-          </FieldGroup>
-        </form>
-        {/* Test connection result */}
-        {testState !== 'idle' && (
-          <div className="border-input rounded-md border px-3 py-2 text-sm">
-            <div className="flex items-center gap-2">
-              {testState === 'testing' && (
-                <LoaderCircle className="text-muted-foreground size-4 animate-spin" />
-              )}
-              {testState === 'success' && (
-                <CheckCircle2 className="size-4 text-foreground-success" />
-              )}
-              {testState === 'error' && <XCircle className="text-destructive size-4" />}
-              <span className="flex-1 font-medium">
-                {testState === 'testing' && 'Testing connection…'}
-                {testState === 'success' &&
-                  'Connected' + (testResult?.latency ? ' (' + testResult.latency + 'ms)' : '')}
-                {testState === 'error' && (testResult?.error ?? 'Connection failed')}
-              </span>
-              {testState === 'error' &&
-                testResult?.debugLogs &&
-                testResult.debugLogs.length > 0 && (
-                  <button
-                    type="button"
-                    onClick={() => setShowDebugLogs((v) => !v)}
-                    className="text-muted-foreground flex items-center gap-1 text-xs hover:text-foreground"
-                  >
-                    {showDebugLogs ? (
-                      <ChevronUp className="size-3" />
-                    ) : (
-                      <ChevronDown className="size-3" />
-                    )}
-                    Logs
-                  </button>
+                      </CollapsibleContent>
+                    </Collapsible>
+                  );
+                }}
+              </form.Subscribe>
+            </FieldGroup>
+          </form>
+          {/* Test connection result */}
+          {testState !== 'idle' && (
+            <div className="border-input rounded-md border px-3 py-2 text-sm">
+              <div className="flex items-center gap-2">
+                {testState === 'testing' && (
+                  <LoaderCircle className="text-muted-foreground size-4 animate-spin" />
                 )}
+                {testState === 'success' && (
+                  <CheckCircle2 className="size-4 text-foreground-success" />
+                )}
+                {testState === 'error' && <XCircle className="text-destructive size-4" />}
+                <span className="flex-1 font-medium">
+                  {testState === 'testing' && 'Testing connection…'}
+                  {testState === 'success' &&
+                    'Connected' + (testResult?.latency ? ' (' + testResult.latency + 'ms)' : '')}
+                  {testState === 'error' && (testResult?.error ?? 'Connection failed')}
+                </span>
+                {testState === 'error' &&
+                  testResult?.debugLogs &&
+                  testResult.debugLogs.length > 0 && (
+                    <button
+                      type="button"
+                      onClick={() => setShowDebugLogs((v) => !v)}
+                      className="text-muted-foreground flex items-center gap-1 text-xs hover:text-foreground"
+                    >
+                      {showDebugLogs ? (
+                        <ChevronUp className="size-3" />
+                      ) : (
+                        <ChevronDown className="size-3" />
+                      )}
+                      Logs
+                    </button>
+                  )}
+              </div>
+              {showDebugLogs && testResult?.debugLogs && (
+                <pre className="bg-muted text-muted-foreground mt-2 max-h-32 overflow-y-auto rounded px-2 py-1.5 text-xs">
+                  {testResult.debugLogs.join('\n')}
+                </pre>
+              )}
             </div>
-            {showDebugLogs && testResult?.debugLogs && (
-              <pre className="bg-muted text-muted-foreground mt-2 max-h-32 overflow-y-auto rounded px-2 py-1.5 text-xs">
-                {testResult.debugLogs.join('\n')}
-              </pre>
-            )}
-          </div>
-        )}
+          )}
+        </TooltipProvider>
       </DialogContentArea>
     </ModalLayout>
   );

--- a/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -4,10 +4,18 @@ import {
   CheckCircle2,
   ChevronDown,
   ChevronUp,
+  InfoIcon,
   LoaderCircle,
   XCircle,
 } from 'lucide-react';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useState,
+  type ComponentProps,
+  type ReactNode,
+} from 'react';
 import { useSshConfigHost, useSshConfigHosts } from '@renderer/lib/hooks/use-ssh-config-hosts';
 import type { BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { appState } from '@renderer/lib/stores/app-state';
@@ -34,6 +42,7 @@ import { ModalLayout } from '@renderer/lib/ui/modal-layout';
 import { RadioGroup, RadioGroupItem } from '@renderer/lib/ui/radio-group';
 import { Select, SelectContent, SelectItem, SelectTrigger } from '@renderer/lib/ui/select';
 import { Switch } from '@renderer/lib/ui/switch';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import type { ConnectionTestResult, SshConfig, SshConfigHost } from '@shared/ssh';
 import { suggestedAuthTypeForSshConfigHost, type AuthType } from './ssh-connection-form-model';
 import { sshConnectionFormSchema } from './ssh-connection-form-schema';
@@ -46,6 +55,48 @@ export interface AddSshConnModalProps extends BaseModalProps<{ connectionId: str
 type TestState = 'idle' | 'testing' | 'success' | 'error';
 const MANUAL_CONNECTION_VALUE = '__manual__';
 const EMPTY_SSH_CONFIG_HOSTS: SshConfigHost[] = [];
+
+function FieldInfoTooltip({ label, children }: { label: string; children: ReactNode }) {
+  return (
+    <TooltipProvider delay={150}>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <button
+              type="button"
+              className="focus-visible:ring-primary/30 relative inline-flex size-4 shrink-0 items-center justify-center rounded-full text-foreground-passive transition-colors before:absolute before:-inset-2.5 before:content-[''] hover:text-foreground focus-visible:ring-2 focus-visible:outline-none"
+              aria-label={`About ${label}`}
+            >
+              <InfoIcon className="size-3.5" aria-hidden="true" />
+            </button>
+          }
+        />
+        <TooltipContent
+          side="top"
+          align="start"
+          className="max-w-[240px] items-start text-left leading-relaxed whitespace-normal"
+        >
+          {children}
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function FieldLabelWithInfo({
+  children,
+  info,
+  ...props
+}: ComponentProps<typeof FieldLabel> & { info: ReactNode }) {
+  const tooltipLabel = typeof children === 'string' ? children : 'this field';
+
+  return (
+    <div className="flex w-fit items-center gap-1.5">
+      <FieldLabel {...props}>{children}</FieldLabel>
+      <FieldInfoTooltip label={tooltipLabel}>{info}</FieldInfoTooltip>
+    </div>
+  );
+}
 
 export function AddSshConnModal({
   onSuccess,
@@ -308,7 +359,9 @@ export function AddSshConnModal({
                   const selectedHost = sshConfigHostsByAlias.get(field.state.value);
                   return (
                     <Field>
-                      <FieldLabel>SSH Config</FieldLabel>
+                      <FieldLabelWithInfo info="Select an entry from ~/.ssh/config to prefill host, user, key, proxy, and agent forwarding settings.">
+                        SSH Config
+                      </FieldLabelWithInfo>
                       {sshConfigHosts.length > 0 && (
                         <Select
                           value={field.state.value || MANUAL_CONNECTION_VALUE}
@@ -443,7 +496,15 @@ export function AddSshConnModal({
             <form.Field name="authType">
               {(field) => (
                 <FieldSet>
-                  <FieldLegend variant="label">Authentication</FieldLegend>
+                  <div className="mb-3 flex w-fit items-center gap-1.5">
+                    <FieldLegend variant="label" className="mb-0">
+                      Authentication
+                    </FieldLegend>
+                    <FieldInfoTooltip label="Authentication">
+                      Choose how Emdash authenticates to the remote server. SSH config entries can
+                      preselect the best option.
+                    </FieldInfoTooltip>
+                  </div>
                   <RadioGroup
                     value={field.state.value}
                     onValueChange={(v) => field.handleChange(v as AuthType)}
@@ -506,7 +567,12 @@ export function AddSshConnModal({
                           const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
                           return (
                             <Field data-invalid={isInvalid}>
-                              <FieldLabel htmlFor={field.name}>Private Key Path</FieldLabel>
+                              <FieldLabelWithInfo
+                                htmlFor={field.name}
+                                info="Path on this machine to the private key used for the connection, for example ~/.ssh/id_ed25519."
+                              >
+                                Private Key Path
+                              </FieldLabelWithInfo>
                               <Input
                                 id={field.name}
                                 name={field.name}
@@ -525,7 +591,12 @@ export function AddSshConnModal({
                       <form.Field name="passphrase">
                         {(field) => (
                           <Field>
-                            <FieldLabel htmlFor={field.name}>Passphrase</FieldLabel>
+                            <FieldLabelWithInfo
+                              htmlFor={field.name}
+                              info="Only needed if the selected private key is encrypted with a passphrase."
+                            >
+                              Passphrase
+                            </FieldLabelWithInfo>
                             <Input
                               id={field.name}
                               name={field.name}
@@ -588,7 +659,12 @@ export function AddSshConnModal({
                         <form.Field name="proxyCommand">
                           {(field) => (
                             <Field>
-                              <FieldLabel htmlFor={field.name}>ProxyCommand</FieldLabel>
+                              <FieldLabelWithInfo
+                                htmlFor={field.name}
+                                info="Command from your SSH config used to reach this host through a proxy. It is read-only here because it comes from ~/.ssh/config."
+                              >
+                                ProxyCommand
+                              </FieldLabelWithInfo>
                               <Input
                                 id={field.name}
                                 name={field.name}
@@ -602,7 +678,12 @@ export function AddSshConnModal({
                         <form.Field name="proxyJump">
                           {(field) => (
                             <Field>
-                              <FieldLabel htmlFor={field.name}>ProxyJump</FieldLabel>
+                              <FieldLabelWithInfo
+                                htmlFor={field.name}
+                                info="Optional bastion host to connect through before reaching the target server, for example user@bastion:2222."
+                              >
+                                ProxyJump
+                              </FieldLabelWithInfo>
                               <Input
                                 id={field.name}
                                 name={field.name}
@@ -620,7 +701,12 @@ export function AddSshConnModal({
                       <form.Field name="forwardAgent">
                         {(field) => (
                           <Field className="flex-row items-center justify-between gap-3 rounded-md border border-border px-3 py-2">
-                            <FieldLabel htmlFor={field.name}>ForwardAgent</FieldLabel>
+                            <FieldLabelWithInfo
+                              htmlFor={field.name}
+                              info="Forward your local SSH agent to the remote server so nested SSH and Git commands can use your loaded local keys. Enable only for trusted hosts."
+                            >
+                              ForwardAgent
+                            </FieldLabelWithInfo>
                             <Switch
                               id={field.name}
                               checked={field.state.value}


### PR DESCRIPTION
added these texts:
- SSH Config “Select an entry from ~/.ssh/config to prefill host, user, key, proxy, and agent forwarding settings.”
- Authentication “Choose how Emdash authenticates to the remote server. SSH config entries can preselect the best option.”
- Private Key Path “Path on this machine to the private key used for the connection, for example ~/.ssh/id_ed25519.”
- Passphrase “Only needed if the selected private key is encrypted with a passphrase.”
- ProxyCommand “Command from your SSH config used to reach this host through a proxy. It is read-only here because it comes from ~/.ssh/config.”
- ProxyJump “Optional bastion host to connect through before reaching the target server, for example user@bastion:2222.”
- ForwardAgent “Forward your local SSH agent to the remote server so nested SSH and Git commands can use your loaded local keys. Enable only for trusted hosts.”

demo:
https://streamable.com/m88nel