### PR TITLE
fix(pty): prevent duplicate clipboard image paste

### DIFF
--- a/src/renderer/lib/pty/pty-pane.tsx
+++ b/src/renderer/lib/pty/pty-pane.tsx
@@ -62,6 +62,8 @@ async function injectTerminalImagePaths(args: {
   args.focus();
 }
 
+// Returns true only when an image was injected, so callers can scope their
+// duplicate-paste guard to the image path and leave plain-text pastes unguarded.
 async function pasteClipboardImageOrText(args: {
   sessionId: string;
   remoteConnectionId: string | undefined;
@@ -69,13 +71,16 @@ async function pasteClipboardImageOrText(args: {
   focus: TerminalInputHelpers['focus'];
   fallbackText?: string;
   preferText?: boolean;
-}): Promise<void> {
+  // Re-checked right before injecting an image; the image branch resolves
+  // asynchronously, so a competing paste path may have injected in the meantime.
+  shouldInjectImage?: () => boolean;
+}): Promise<boolean> {
   if (args.preferText) {
     try {
       const text = await navigator.clipboard.readText();
       if (text) {
         args.sendInput(text);
-        return;
+        return false;
       }
     } catch {
       // Clipboard text read denied or unavailable; try the image path below.
@@ -85,8 +90,9 @@ async function pasteClipboardImageOrText(args: {
   try {
     const result = await rpc.pty.persistClipboardImage();
     if (result.success && result.data.path) {
+      if (args.shouldInjectImage && !args.shouldInjectImage()) return false;
       await injectTerminalImagePaths({ ...args, paths: [result.data.path] });
-      return;
+      return true;
     }
   } catch (error) {
     log.warn('Terminal clipboard image paste failed', { error });
@@ -94,7 +100,7 @@ async function pasteClipboardImageOrText(args: {
 
   if (args.fallbackText !== undefined) {
     if (args.fallbackText) args.sendInput(args.fallbackText);
-    return;
+    return false;
   }
 
   try {
@@ -103,6 +109,7 @@ async function pasteClipboardImageOrText(args: {
   } catch {
     // Clipboard read denied or unavailable.
   }
+  return false;
 }
 
 const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
@@ -132,14 +139,19 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
     const handleSystemPaste = useCallback<PasteFromClipboardHandler>(
       ({ focus, sendInput }) => {
         if (isNearDuplicatePaste(lastDomImagePasteAtRef.current)) return;
-        lastSystemPasteAtRef.current = Date.now();
-        void pasteClipboardImageOrText({
-          sessionId,
-          remoteConnectionId,
-          focus,
-          sendInput,
-          preferText: true,
-        });
+        void (async () => {
+          const injectedImage = await pasteClipboardImageOrText({
+            sessionId,
+            remoteConnectionId,
+            focus,
+            sendInput,
+            preferText: true,
+            shouldInjectImage: () => !isNearDuplicatePaste(lastDomImagePasteAtRef.current),
+          });
+          // Only guard the DOM image path against a system paste that actually
+          // injected an image; plain-text pastes must not block it.
+          if (injectedImage) lastSystemPasteAtRef.current = Date.now();
+        })();
       },
       [remoteConnectionId, sessionId]
     );

--- a/src/renderer/lib/pty/pty-pane.tsx
+++ b/src/renderer/lib/pty/pty-pane.tsx
@@ -8,6 +8,7 @@ import {
   buildTerminalImageInjection,
   clipboardDataMayContainImage,
   extractClipboardImageFiles,
+  isNearDuplicatePaste,
 } from './terminal-image-paths';
 import { type PasteFromClipboardHandler, usePty } from './use-pty';
 
@@ -123,11 +124,15 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
     ref
   ) => {
     const containerRef = useRef<HTMLDivElement | null>(null);
+    const lastDomImagePasteAtRef = useRef(0);
+    const lastSystemPasteAtRef = useRef(0);
 
     const theme: SessionTheme = { override: themeOverride };
 
     const handleSystemPaste = useCallback<PasteFromClipboardHandler>(
       ({ focus, sendInput }) => {
+        if (isNearDuplicatePaste(lastDomImagePasteAtRef.current)) return;
+        lastSystemPasteAtRef.current = Date.now();
         void pasteClipboardImageOrText({
           sessionId,
           remoteConnectionId,
@@ -192,6 +197,10 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
         const imageFiles = extractClipboardImageFiles(clipboardData);
         if (imageFiles.length > 0) {
           event.preventDefault();
+          event.stopPropagation();
+          event.nativeEvent.stopImmediatePropagation();
+          if (isNearDuplicatePaste(lastSystemPasteAtRef.current)) return;
+          lastDomImagePasteAtRef.current = Date.now();
           void (async () => {
             try {
               const injected = await injectImageFiles(imageFiles);
@@ -213,6 +222,10 @@ const PtyPaneComponent = forwardRef<{ focus: () => void }, Props>(
         if (!clipboardDataMayContainImage(clipboardData)) return;
 
         event.preventDefault();
+        event.stopPropagation();
+        event.nativeEvent.stopImmediatePropagation();
+        if (isNearDuplicatePaste(lastSystemPasteAtRef.current)) return;
+        lastDomImagePasteAtRef.current = Date.now();
         void pasteClipboardImageOrText({
           sessionId,
           remoteConnectionId,

--- a/src/renderer/lib/pty/terminal-image-paths.ts
+++ b/src/renderer/lib/pty/terminal-image-paths.ts
@@ -38,6 +38,14 @@ export function extractClipboardImageFiles(clipboardData: DataTransfer | null): 
   }
 
   if (clipboardData.types.some((type) => type.toLowerCase().startsWith('image/'))) {
+    // Browser ordering of clipboard items is not guaranteed, so pick a lossless,
+    // widely-supported representation deterministically instead of trusting index 0.
+    const preferredOrder = ['image/png', 'image/jpeg', 'image/gif', 'image/webp'];
+    const rank = (type: string): number => {
+      const index = preferredOrder.indexOf(type.toLowerCase());
+      return index === -1 ? Number.MAX_SAFE_INTEGER : index;
+    };
+    imageFiles.sort((a, b) => rank(a.type) - rank(b.type));
     return imageFiles.slice(0, 1);
   }
 

--- a/src/renderer/lib/pty/terminal-image-paths.ts
+++ b/src/renderer/lib/pty/terminal-image-paths.ts
@@ -25,12 +25,27 @@ export function isHeicLikeFile(file: File): boolean {
 export function extractClipboardImageFiles(clipboardData: DataTransfer | null): File[] {
   if (!clipboardData?.items) return [];
   const imageFiles: File[] = [];
+  const seen = new Set<string>();
   for (const item of clipboardData.items) {
     if (item.kind !== 'file') continue;
     const file = item.getAsFile();
-    if (file && isClipboardImageFile(file)) imageFiles.push(file);
+    if (!file || !isClipboardImageFile(file)) continue;
+
+    const fingerprint = `${file.name}\0${file.type}\0${file.size}\0${file.lastModified}`;
+    if (seen.has(fingerprint)) continue;
+    seen.add(fingerprint);
+    imageFiles.push(file);
   }
+
+  if (clipboardData.types.some((type) => type.toLowerCase().startsWith('image/'))) {
+    return imageFiles.slice(0, 1);
+  }
+
   return imageFiles;
+}
+
+export function isNearDuplicatePaste(recentPasteAt: number, now = Date.now()): boolean {
+  return recentPasteAt > 0 && now >= recentPasteAt && now - recentPasteAt < 250;
 }
 
 export function clipboardDataMayContainImage(clipboardData: DataTransfer | null): boolean {

--- a/src/renderer/tests/terminal-image-injection.test.ts
+++ b/src/renderer/tests/terminal-image-injection.test.ts
@@ -62,6 +62,8 @@ describe('terminal-image-injection', () => {
   it('detects near-duplicate paste paths from the same user gesture', () => {
     expect(isNearDuplicatePaste(1_000, 1_249)).toBe(true);
     expect(isNearDuplicatePaste(1_000, 1_250)).toBe(false);
+    // initial ref value (0) must never be treated as a recent paste
+    expect(isNearDuplicatePaste(0, 100)).toBe(false);
   });
 
   it('wraps formatted paths for bracketed paste', () => {

--- a/src/renderer/tests/terminal-image-injection.test.ts
+++ b/src/renderer/tests/terminal-image-injection.test.ts
@@ -2,8 +2,10 @@ import { describe, expect, it } from 'vitest';
 import {
   escapePathForTerminal,
   escapeWindowsPathForTerminal,
+  extractClipboardImageFiles,
   formatTerminalImagePaths,
   isHeicLikeFile,
+  isNearDuplicatePaste,
   isUnstableDropPath,
   wrapAsBracketedPaste,
 } from '@renderer/lib/pty/terminal-image-paths';
@@ -28,6 +30,38 @@ describe('terminal-image-injection', () => {
   it('detects HEIC-like files without relying on image MIME types', () => {
     expect(isHeicLikeFile(new File([], 'photo.heic', { type: '' }))).toBe(true);
     expect(isHeicLikeFile(new File([], 'photo.png', { type: 'image/png' }))).toBe(false);
+  });
+
+  it('deduplicates identical clipboard image file items', () => {
+    const file = new File(['image'], 'image.png', { type: 'image/png', lastModified: 1 });
+    const clipboardData = {
+      items: [
+        { kind: 'file', getAsFile: () => file },
+        { kind: 'file', getAsFile: () => file },
+      ],
+      types: ['Files'],
+    } as unknown as DataTransfer;
+
+    expect(extractClipboardImageFiles(clipboardData)).toEqual([file]);
+  });
+
+  it('collapses alternate image representations from one clipboard image', () => {
+    const png = new File(['png'], 'image.png', { type: 'image/png', lastModified: 1 });
+    const tiff = new File(['tiff'], 'image.tiff', { type: 'image/tiff', lastModified: 1 });
+    const clipboardData = {
+      items: [
+        { kind: 'file', getAsFile: () => png },
+        { kind: 'file', getAsFile: () => tiff },
+      ],
+      types: ['image/png', 'image/tiff'],
+    } as unknown as DataTransfer;
+
+    expect(extractClipboardImageFiles(clipboardData)).toEqual([png]);
+  });
+
+  it('detects near-duplicate paste paths from the same user gesture', () => {
+    expect(isNearDuplicatePaste(1_000, 1_249)).toBe(true);
+    expect(isNearDuplicatePaste(1_000, 1_250)).toBe(false);
   });
 
   it('wraps formatted paths for bracketed paste', () => {


### PR DESCRIPTION
# summary
- fixes that cmd+v would double paste an image 
- control+v/cmd+v both still work 

demo of the fix:
https://streamable.com/fdx3s7