### PR TITLE
fix: cmdk file search not working when stuck

### DIFF
--- a/src/main/core/search/search-service.ts
+++ b/src/main/core/search/search-service.ts
@@ -113,7 +113,7 @@ class SearchService {
     }));
 
     if (context?.workspaceId) {
-      await workspaceFileIndexService.ensureIndexed(context.workspaceId);
+      await workspaceFileIndexService.prepareForSearch(context.workspaceId);
       const fileHits = workspaceFileIndexService.search(context.workspaceId, query);
       for (const h of fileHits) {
         results.push({

--- a/src/main/core/search/search-service.ts
+++ b/src/main/core/search/search-service.ts
@@ -57,7 +57,7 @@ class SearchService {
     this.seedCommands();
   }
 
-  search({ query, context }: CommandPaletteQuery): SearchItem[] {
+  async search({ query, context }: CommandPaletteQuery): Promise<SearchItem[]> {
     if (!query.trim()) return this.recents(context);
 
     // Trigram tokenizer requires each term to be at least 3 characters.
@@ -113,6 +113,7 @@ class SearchService {
     }));
 
     if (context?.workspaceId) {
+      await workspaceFileIndexService.ensureIndexed(context.workspaceId);
       const fileHits = workspaceFileIndexService.search(context.workspaceId, query);
       for (const h of fileHits) {
         results.push({

--- a/src/main/core/search/workspace-file-index-service.ts
+++ b/src/main/core/search/workspace-file-index-service.ts
@@ -5,6 +5,7 @@ import { sqlite } from '@main/db/client';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { fsWatchEventChannel } from '@shared/events/fsEvents';
+import { workspaceFileIndexUpdatedChannel } from '@shared/events/searchEvents';
 
 const STALE_DAYS = 14;
 const MAX_FILES = 50_000;
@@ -158,6 +159,7 @@ class WorkspaceFileIndexService {
       })();
 
       this.touchMeta(workspaceId);
+      events.emit(workspaceFileIndexUpdatedChannel, { workspaceId });
       log.info('WorkspaceFileIndexService: indexed workspace', {
         workspaceId,
         count: files.length,

--- a/src/main/core/search/workspace-file-index-service.ts
+++ b/src/main/core/search/workspace-file-index-service.ts
@@ -60,7 +60,7 @@ class WorkspaceFileIndexService {
   }
 
   async onWorkspaceCreated(workspaceId: string, workspace: Workspace): Promise<void> {
-    if (this.hasIndexEntries(workspaceId)) {
+    if (this.hasCompletedCrawl(workspaceId)) {
       this.touchMeta(workspaceId);
       return;
     }
@@ -69,7 +69,7 @@ class WorkspaceFileIndexService {
   }
 
   async prepareForSearch(workspaceId: string): Promise<void> {
-    if (this.hasIndexEntries(workspaceId)) {
+    if (this.hasCompletedCrawl(workspaceId)) {
       this.touchMeta(workspaceId);
       return;
     }
@@ -179,13 +179,13 @@ class WorkspaceFileIndexService {
     ]);
   }
 
-  private hasIndexEntries(workspaceId: string): boolean {
+  private hasCompletedCrawl(workspaceId: string): boolean {
     try {
       return !!sqlite
-        .prepare(`SELECT 1 FROM workspace_file_index WHERE workspace_id = ? LIMIT 1`)
+        .prepare(`SELECT 1 FROM workspace_file_index_meta WHERE workspace_id = ? LIMIT 1`)
         .get(workspaceId);
     } catch (e) {
-      log.warn('WorkspaceFileIndexService: hasIndexEntries failed', {
+      log.warn('WorkspaceFileIndexService: hasCompletedCrawl failed', {
         workspaceId,
         error: String(e),
       });

--- a/src/main/core/search/workspace-file-index-service.ts
+++ b/src/main/core/search/workspace-file-index-service.ts
@@ -9,6 +9,7 @@ import { fsWatchEventChannel } from '@shared/events/fsEvents';
 const STALE_DAYS = 14;
 const MAX_FILES = 50_000;
 const CRAWL_TIMEOUT_MS = 30_000;
+const SEARCH_INDEX_WAIT_MS = 250;
 const REINDEX_DEBOUNCE_MS = 3_000;
 
 const CRAWL_IGNORED_DIRS = new Set([
@@ -66,7 +67,7 @@ class WorkspaceFileIndexService {
     await this.crawl(workspaceId, workspace);
   }
 
-  async ensureIndexed(workspaceId: string): Promise<void> {
+  async prepareForSearch(workspaceId: string): Promise<void> {
     if (this.hasIndexEntries(workspaceId)) {
       this.touchMeta(workspaceId);
       return;
@@ -74,7 +75,7 @@ class WorkspaceFileIndexService {
 
     const workspace = workspaceRegistry.get(workspaceId);
     if (!workspace) return;
-    await this.crawl(workspaceId, workspace);
+    await this.waitForSearchIndex(this.crawl(workspaceId, workspace));
   }
 
   onWorkspaceDestroyed(_workspaceId: string): void {
@@ -165,6 +166,15 @@ class WorkspaceFileIndexService {
     } catch (e) {
       log.warn('WorkspaceFileIndexService: crawl failed', { workspaceId, error: String(e) });
     }
+  }
+
+  private async waitForSearchIndex(crawl: Promise<void>): Promise<void> {
+    await Promise.race([
+      crawl,
+      new Promise<void>((resolve) => {
+        setTimeout(resolve, SEARCH_INDEX_WAIT_MS);
+      }),
+    ]);
   }
 
   private hasIndexEntries(workspaceId: string): boolean {

--- a/src/main/core/search/workspace-file-index-service.ts
+++ b/src/main/core/search/workspace-file-index-service.ts
@@ -46,7 +46,7 @@ const CRAWL_IGNORED_DIRS = new Set([
 type FileHit = { path: string; filename: string };
 
 class WorkspaceFileIndexService {
-  private crawling = new Set<string>();
+  private crawling = new Map<string, Promise<void>>();
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
 
   initialize(): void {
@@ -58,15 +58,22 @@ class WorkspaceFileIndexService {
   }
 
   async onWorkspaceCreated(workspaceId: string, workspace: Workspace): Promise<void> {
-    const alreadyIndexed = sqlite
-      .prepare(`SELECT 1 FROM workspace_file_index_meta WHERE workspace_id = ?`)
-      .get(workspaceId);
-
-    if (alreadyIndexed) {
+    if (this.hasIndexEntries(workspaceId)) {
       this.touchMeta(workspaceId);
       return;
     }
 
+    await this.crawl(workspaceId, workspace);
+  }
+
+  async ensureIndexed(workspaceId: string): Promise<void> {
+    if (this.hasIndexEntries(workspaceId)) {
+      this.touchMeta(workspaceId);
+      return;
+    }
+
+    const workspace = workspaceRegistry.get(workspaceId);
+    if (!workspace) return;
     await this.crawl(workspaceId, workspace);
   }
 
@@ -117,9 +124,17 @@ class WorkspaceFileIndexService {
   }
 
   private async crawl(workspaceId: string, workspace: Workspace): Promise<void> {
-    if (this.crawling.has(workspaceId)) return;
-    this.crawling.add(workspaceId);
+    const existing = this.crawling.get(workspaceId);
+    if (existing) return existing;
 
+    const pending = this.crawlWorkspace(workspaceId, workspace).finally(() => {
+      this.crawling.delete(workspaceId);
+    });
+    this.crawling.set(workspaceId, pending);
+    return pending;
+  }
+
+  private async crawlWorkspace(workspaceId: string, workspace: Workspace): Promise<void> {
     try {
       const result = await workspace.fs.list('', {
         recursive: true,
@@ -149,8 +164,20 @@ class WorkspaceFileIndexService {
       });
     } catch (e) {
       log.warn('WorkspaceFileIndexService: crawl failed', { workspaceId, error: String(e) });
-    } finally {
-      this.crawling.delete(workspaceId);
+    }
+  }
+
+  private hasIndexEntries(workspaceId: string): boolean {
+    try {
+      return !!sqlite
+        .prepare(`SELECT 1 FROM workspace_file_index WHERE workspace_id = ? LIMIT 1`)
+        .get(workspaceId);
+    } catch (e) {
+      log.warn('WorkspaceFileIndexService: hasIndexEntries failed', {
+        workspaceId,
+        error: String(e),
+      });
+      return false;
     }
   }
 

--- a/src/renderer/features/command-palette/command-palette-modal.tsx
+++ b/src/renderer/features/command-palette/command-palette-modal.tsx
@@ -163,7 +163,9 @@ export function CommandPaletteModal({
 
     return events.on(workspaceFileIndexUpdatedChannel, ({ workspaceId: updatedWorkspaceId }) => {
       if (updatedWorkspaceId !== workspaceId) return;
-      void queryClient.invalidateQueries({ queryKey: ['cmdk-search'] });
+      void queryClient.invalidateQueries({
+        predicate: ({ queryKey }) => queryKey[0] === 'cmdk-search' && queryKey[4] === workspaceId,
+      });
     });
   }, [queryClient, workspaceId]);
 

--- a/src/renderer/features/command-palette/command-palette-modal.tsx
+++ b/src/renderer/features/command-palette/command-palette-modal.tsx
@@ -10,13 +10,14 @@ import { commandRegistry } from '@renderer/lib/commands/registry';
 import { FileIcon } from '@renderer/lib/editor/file-icon';
 import { useDebounce } from '@renderer/lib/hooks/useDebounce';
 import { getEffectiveHotkey } from '@renderer/lib/hooks/useKeyboardShortcuts';
-import { rpc } from '@renderer/lib/ipc';
+import { events, rpc } from '@renderer/lib/ipc';
 import { useNavigate } from '@renderer/lib/layout/navigation-provider';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { appState } from '@renderer/lib/stores/app-state';
 import { Shortcut } from '@renderer/lib/ui/shortcut';
 import { cn } from '@renderer/utils/utils';
 import { ALL_COMMAND_DEFS, type CommandDef } from '@shared/commands';
+import { workspaceFileIndexUpdatedChannel } from '@shared/events/searchEvents';
 import type { SearchItem } from '@shared/search';
 import { getCommandIcon } from './command-icons';
 import { PaletteConversationItem } from './palette-conversation-item';
@@ -156,6 +157,15 @@ export function CommandPaletteModal({
     });
     // oxlint-disable-next-line react/exhaustive-deps
   }, []);
+
+  useEffect(() => {
+    if (!workspaceId) return;
+
+    return events.on(workspaceFileIndexUpdatedChannel, ({ workspaceId: updatedWorkspaceId }) => {
+      if (updatedWorkspaceId !== workspaceId) return;
+      void queryClient.invalidateQueries({ queryKey: ['cmdk-search'] });
+    });
+  }, [queryClient, workspaceId]);
 
   const { data: dbResults = [] } = useQuery({
     queryKey: ['cmdk-search', debouncedQuery, projectId, taskId, workspaceId],

--- a/src/renderer/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/lib/hooks/useKeyboardShortcuts.ts
@@ -34,6 +34,7 @@ export function getHotkeyRegistration(
   custom?: ShortcutOverrides
 ): Hotkey {
   const def = APP_SHORTCUTS[key];
-  return (getEffectiveHotkey(key, custom) ?? (def ? resolveDefaultHotkey(def) : undefined) ??
+  return (getEffectiveHotkey(key, custom) ??
+    (def ? resolveDefaultHotkey(def) : undefined) ??
     '') as Hotkey;
 }

--- a/src/renderer/lib/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/lib/hooks/useKeyboardShortcuts.ts
@@ -16,9 +16,12 @@ export function getEffectiveHotkey(
   key: ShortcutSettingsKey,
   custom?: ShortcutOverrides
 ): Hotkey | null {
+  const def = APP_SHORTCUTS[key];
+  if (!def) return null;
+
   const configured = custom?.[key];
   if (configured === null) return null;
-  const resolved = configured ?? resolveDefaultHotkey(APP_SHORTCUTS[key]);
+  const resolved = configured ?? resolveDefaultHotkey(def);
   return resolved != null ? (resolved as Hotkey) : null;
 }
 
@@ -30,7 +33,7 @@ export function getHotkeyRegistration(
   key: ShortcutSettingsKey,
   custom?: ShortcutOverrides
 ): Hotkey {
-  return (getEffectiveHotkey(key, custom) ??
-    resolveDefaultHotkey(APP_SHORTCUTS[key]) ??
+  const def = APP_SHORTCUTS[key];
+  return (getEffectiveHotkey(key, custom) ?? (def ? resolveDefaultHotkey(def) : undefined) ??
     '') as Hotkey;
 }

--- a/src/shared/events/searchEvents.ts
+++ b/src/shared/events/searchEvents.ts
@@ -1,0 +1,5 @@
+import { defineEvent } from '@shared/ipc/events';
+
+export const workspaceFileIndexUpdatedChannel = defineEvent<{
+  workspaceId: string;
+}>('search:workspace-file-index-updated');


### PR DESCRIPTION
# summary
- fixes file search in cmdk when workspace no t indexed yet
- lazy workspace file indexing on search as a fallback
- max waiting 250ms for indexing to prevent lag 
- refreshes cmdk results after bg refresh finishes