### PR TITLE
 feat(terminals): allow selecting shell for new terminals

### DIFF
--- a/src/main/core/pty/pty-env.ts
+++ b/src/main/core/pty/pty-env.ts
@@ -1,4 +1,5 @@
 import os from 'node:os';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { detectSshAuthSock } from '@main/utils/shellEnv';
 import { getWindowsEnvValue } from '@main/utils/windows-env';
 
@@ -169,7 +170,9 @@ export interface AgentEnvOptions {
  * SSH_AUTH_SOCK is injected via the same cached detector used for agents,
  * since GUI-launched apps often don't inherit it from the user's login shell.
  */
-export function buildTerminalEnv(): Record<string, string> {
+export function buildTerminalEnv(
+  options: { shellProfile?: ResolvedShellProfile } = {}
+): Record<string, string> {
   // Inherit the full process environment, stripping undefined values.
   const env: Record<string, string> = {};
   for (const [key, val] of Object.entries(process.env)) {
@@ -184,7 +187,10 @@ export function buildTerminalEnv(): Record<string, string> {
   // Ensure SHELL reflects the user's configured shell on POSIX. Native Windows
   // shells are selected via ComSpec by the spawn resolver, not SHELL.
   if (process.platform !== 'win32') {
-    env.SHELL = process.env.SHELL ?? (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+    env.SHELL =
+      options.shellProfile?.family === 'posix' || options.shellProfile?.family === 'csh'
+        ? options.shellProfile.executable
+        : (process.env.SHELL ?? (process.platform === 'darwin' ? '/bin/zsh' : '/bin/bash'));
   } else if (process.env.SHELL) {
     env.SHELL = process.env.SHELL;
   }

--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -540,7 +540,7 @@ describe('resolveLocalPtySpawn - POSIX', () => {
 
     expect(result).toEqual({
       command: 'tcsh',
-      args: ['-c', "printf 'hello\\!'"],
+      args: ['-c', "'printf' 'hello\\!'"],
       cwd: '/repo',
       warnings: [],
     });

--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { resolveLocalPtySpawn } from './pty-spawn-platform';
 
 const winEnv = {
@@ -9,6 +10,42 @@ const winEnv = {
 const posixEnv = {
   SHELL: '/bin/bash',
 } satisfies NodeJS.ProcessEnv;
+
+const pwshProfile = {
+  id: 'pwsh',
+  resolvedShellId: 'pwsh',
+  resolvedFromAuto: false,
+  executable: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+  displayName: 'pwsh',
+  available: true,
+  family: 'powershell',
+  interactiveArgs: [],
+  commandArgs: ['-NoProfile', '-Command'],
+} satisfies ResolvedShellProfile;
+
+function posixShellProfile({
+  shell,
+  family = 'posix',
+  interactiveArgs,
+  commandArgs,
+}: {
+  shell: 'bash' | 'dash' | 'sh' | 'tcsh';
+  family?: 'posix' | 'csh';
+  interactiveArgs: string[];
+  commandArgs: string[];
+}): ResolvedShellProfile {
+  return {
+    id: shell,
+    resolvedShellId: shell,
+    resolvedFromAuto: false,
+    executable: shell,
+    displayName: shell,
+    available: true,
+    family,
+    interactiveArgs,
+    commandArgs,
+  };
+}
 
 describe('resolveLocalPtySpawn - Windows', () => {
   const windowsPathEnv = {
@@ -169,6 +206,26 @@ describe('resolveLocalPtySpawn - Windows', () => {
     });
   });
 
+  it('wraps cmd and bat argv commands through cmd.exe when PowerShell is selected', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        shellProfile: pwshProfile,
+        command: { kind: 'argv', command: 'pnpm.cmd', args: ['run', 'dev'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Windows\\System32\\cmd.exe',
+      args: ['/d', '/s', '/c', 'pnpm.cmd run dev'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
   it('quotes cmd wrapper arguments that contain Windows metacharacters', () => {
     const result = resolveLocalPtySpawn({
       platform: 'win32',
@@ -221,6 +278,47 @@ describe('resolveLocalPtySpawn - Windows', () => {
     });
   });
 
+  it('runs shell-line commands through selected PowerShell', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: winEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        shellProfile: pwshProfile,
+        command: { kind: 'shell-line', commandLine: 'pnpm run dev' },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      args: ['-NoProfile', '-Command', 'pnpm run dev'],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('runs unresolved extensionless commands through selected PowerShell', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: windowsPathEnv,
+      fileExists: () => false,
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        shellProfile: pwshProfile,
+        command: { kind: 'argv', command: 'codex', args: ['hello world', "it's ok"] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      args: ['-NoProfile', '-Command', "& codex 'hello world' 'it''s ok'"],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
   it('returns warnings for ignored shellSetup and tmux on Windows', () => {
     const result = resolveLocalPtySpawn({
       platform: 'win32',
@@ -241,6 +339,39 @@ describe('resolveLocalPtySpawn - Windows', () => {
 });
 
 describe('resolveLocalPtySpawn - POSIX', () => {
+  const bashProfile = posixShellProfile({
+    shell: 'bash',
+    interactiveArgs: ['-il'],
+    commandArgs: ['-lc'],
+  });
+  const dashProfile = posixShellProfile({
+    shell: 'dash',
+    interactiveArgs: ['-i'],
+    commandArgs: ['-c'],
+  });
+  const shProfile = posixShellProfile({
+    shell: 'sh',
+    interactiveArgs: ['-i'],
+    commandArgs: ['-c'],
+  });
+  const tcshProfile = posixShellProfile({
+    shell: 'tcsh',
+    family: 'csh',
+    interactiveArgs: ['-i'],
+    commandArgs: ['-c'],
+  });
+  const posixPwshProfile: ResolvedShellProfile = {
+    id: 'pwsh',
+    resolvedShellId: 'pwsh',
+    resolvedFromAuto: false,
+    executable: 'pwsh',
+    displayName: 'pwsh',
+    available: true,
+    family: 'powershell',
+    interactiveArgs: [],
+    commandArgs: ['-NoProfile', '-Command'],
+  };
+
   it('uses SHELL -il for interactive shells', () => {
     const result = resolveLocalPtySpawn({
       platform: 'darwin',
@@ -251,6 +382,71 @@ describe('resolveLocalPtySpawn - POSIX', () => {
     expect(result).toEqual({
       command: '/bin/bash',
       args: ['-il'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('uses the selected terminal shell profile for interactive shells', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'darwin',
+      env: posixEnv,
+      intent: { kind: 'interactive-shell', cwd: '/repo', shellProfile: bashProfile },
+    });
+
+    expect(result).toEqual({
+      command: 'bash',
+      args: ['-il'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('does not pass login flags to basic POSIX interactive shells', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'darwin',
+      env: posixEnv,
+      intent: { kind: 'interactive-shell', cwd: '/repo', shellProfile: dashProfile },
+    });
+
+    expect(result).toEqual({
+      command: 'dash',
+      args: ['-i'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('does not pass login flags to csh-family interactive shells', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'darwin',
+      env: posixEnv,
+      intent: { kind: 'interactive-shell', cwd: '/repo', shellProfile: tcshProfile },
+    });
+
+    expect(result).toEqual({
+      command: 'tcsh',
+      args: ['-i'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('does not pass login flags to basic POSIX interactive shells after setup', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'darwin',
+      env: posixEnv,
+      intent: {
+        kind: 'interactive-shell',
+        cwd: '/repo',
+        shellProfile: shProfile,
+        shellSetup: 'export FOO=bar',
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'sh',
+      args: ['-c', 'export FOO=bar && exec sh -i'],
       cwd: '/repo',
       warnings: [],
     });
@@ -270,6 +466,61 @@ describe('resolveLocalPtySpawn - POSIX', () => {
     expect(result).toEqual({
       command: '/bin/bash',
       args: ['-c', "node 'script name.js' 'it'\\''s ok'"],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('uses the selected terminal shell profile for shell-wrapped commands', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'linux',
+      env: posixEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: '/repo',
+        shellProfile: shProfile,
+        command: { kind: 'argv', command: 'node', args: ['--version'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'sh',
+      args: ['-c', 'node --version'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
+  it('rejects POSIX run-command wrapping through PowerShell shells', () => {
+    expect(() =>
+      resolveLocalPtySpawn({
+        platform: 'linux',
+        env: posixEnv,
+        intent: {
+          kind: 'run-command',
+          cwd: '/repo',
+          shellProfile: posixPwshProfile,
+          command: { kind: 'argv', command: 'node', args: ['script name.js'] },
+        },
+      })
+    ).toThrow('Cannot run POSIX shell-wrapped commands through pwsh');
+  });
+
+  it('escapes history expansion for csh-family argv commands', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'linux',
+      env: posixEnv,
+      intent: {
+        kind: 'run-command',
+        cwd: '/repo',
+        shellProfile: tcshProfile,
+        command: { kind: 'argv', command: 'printf', args: ['hello!'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'tcsh',
+      args: ['-c', "printf 'hello\\!'"],
       cwd: '/repo',
       warnings: [],
     });

--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -402,6 +402,26 @@ describe('resolveLocalPtySpawn - POSIX', () => {
     });
   });
 
+  it('uses a non-login setup wrapper before execing selected login shells', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'darwin',
+      env: posixEnv,
+      intent: {
+        kind: 'interactive-shell',
+        cwd: '/repo',
+        shellProfile: bashProfile,
+        shellSetup: 'export FOO=bar',
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'bash',
+      args: ['-c', 'export FOO=bar && exec bash -il'],
+      cwd: '/repo',
+      warnings: [],
+    });
+  });
+
   it('does not pass login flags to basic POSIX interactive shells', () => {
     const result = resolveLocalPtySpawn({
       platform: 'darwin',

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -2,6 +2,7 @@ import { existsSync } from 'node:fs';
 import path from 'node:path';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { log } from '@main/lib/logger';
+import { quoteCshArg } from '@main/utils/shellEscape';
 import { getWindowsEnvValue } from '@main/utils/windows-env';
 import { buildTmuxShellLine } from './tmux-session-name';
 
@@ -81,10 +82,6 @@ function quotePosixArg(input: string): string {
   if (input.length === 0) return "''";
   if (!/[\s'"\\$`\n\r\t;&|<>(){}[\]*?!]/.test(input)) return input;
   return `'${input.replace(/'/g, "'\\''")}'`;
-}
-
-function quoteCshArg(input: string): string {
-  return quotePosixArg(input).replace(/!/g, '\\!');
 }
 
 function argvToPosixShellLine(intent: PtySpawnIntent, command: string, args: string[]): string {

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -57,6 +57,18 @@ function getCommandArgs(intent: PtySpawnIntent): string[] {
   return intent.shellProfile?.commandArgs ?? ['-c'];
 }
 
+function getSetupWrapperArgs(intent: PtySpawnIntent): string[] {
+  if (!intent.shellProfile) return ['-c'];
+  switch (intent.shellProfile.family) {
+    case 'posix':
+    case 'csh':
+      return ['-c'];
+    case 'windows-cmd':
+    case 'powershell':
+      return intent.shellProfile.commandArgs;
+  }
+}
+
 function shellArgQuoter(intent: PtySpawnIntent): (input: string) => string {
   return intent.shellProfile?.family === 'csh' ? quoteCshArg : quotePosixArg;
 }
@@ -292,6 +304,7 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
   const shell = getResolvedShell(intent, env);
   const interactiveArgs = getInteractiveArgs(intent);
   const commandArgs = getCommandArgs(intent);
+  const setupWrapperArgs = getSetupWrapperArgs(intent);
 
   if (intent.kind === 'interactive-shell') {
     if (intent.tmuxSessionName) {
@@ -300,7 +313,10 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
         : `exec ${quotePosixArg(shell)} ${interactiveArgs.join(' ')}`;
       return {
         command: shell,
-        args: [...commandArgs, buildTmuxShellLine(intent.tmuxSessionName, commandLine)],
+        args: [
+          ...(intent.shellSetup ? setupWrapperArgs : commandArgs),
+          buildTmuxShellLine(intent.tmuxSessionName, commandLine),
+        ],
         cwd: intent.cwd,
         warnings: [],
       };
@@ -310,7 +326,7 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
       return {
         command: shell,
         args: [
-          ...commandArgs,
+          ...setupWrapperArgs,
           `${intent.shellSetup} && exec ${quotePosixArg(shell)} ${interactiveArgs.join(' ')}`,
         ],
         cwd: intent.cwd,

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -1,5 +1,6 @@
 import { existsSync } from 'node:fs';
 import path from 'node:path';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { log } from '@main/lib/logger';
 import { getWindowsEnvValue } from '@main/utils/windows-env';
 import { buildTmuxShellLine } from './tmux-session-name';
@@ -12,6 +13,7 @@ export type PtySpawnIntent =
   | {
       kind: 'interactive-shell';
       cwd: string;
+      shellProfile?: ResolvedShellProfile;
       shellSetup?: string;
       tmuxSessionName?: string;
     }
@@ -19,6 +21,7 @@ export type PtySpawnIntent =
       kind: 'run-command';
       cwd: string;
       command: PtyCommandSpec;
+      shellProfile?: ResolvedShellProfile;
       shellSetup?: string;
       tmuxSessionName?: string;
     };
@@ -42,6 +45,22 @@ function getWindowsShell(env: NodeJS.ProcessEnv): string {
   return env.ComSpec || 'C:\\Windows\\System32\\cmd.exe';
 }
 
+function getResolvedShell(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): string {
+  return intent.shellProfile?.executable ?? getPosixShell(env);
+}
+
+function getInteractiveArgs(intent: PtySpawnIntent): string[] {
+  return intent.shellProfile?.interactiveArgs ?? ['-il'];
+}
+
+function getCommandArgs(intent: PtySpawnIntent): string[] {
+  return intent.shellProfile?.commandArgs ?? ['-c'];
+}
+
+function shellArgQuoter(intent: PtySpawnIntent): (input: string) => string {
+  return intent.shellProfile?.family === 'csh' ? quoteCshArg : quotePosixArg;
+}
+
 function isWindows(platform: NodeJS.Platform): boolean {
   return platform === 'win32';
 }
@@ -52,8 +71,12 @@ function quotePosixArg(input: string): string {
   return `'${input.replace(/'/g, "'\\''")}'`;
 }
 
-function argvToPosixShellLine(command: string, args: string[]): string {
-  return [command, ...args].map(quotePosixArg).join(' ');
+function quoteCshArg(input: string): string {
+  return quotePosixArg(input).replace(/!/g, '\\!');
+}
+
+function argvToPosixShellLine(intent: PtySpawnIntent, command: string, args: string[]): string {
+  return [command, ...args].map(shellArgQuoter(intent)).join(' ');
 }
 
 function quoteForCmdExe(input: string): string {
@@ -63,6 +86,12 @@ function quoteForCmdExe(input: string): string {
     .replace(/%/g, '%%')
     .replace(/!/g, '^!')
     .replace(/(["^&|<>()])/g, '^$1')}"`;
+}
+
+function quoteForPowerShell(input: string): string {
+  if (input.length === 0) return "''";
+  if (!/[\s'`"$;&|<>(){}[\],]/.test(input)) return input;
+  return `'${input.replace(/'/g, "''")}'`;
 }
 
 /**
@@ -135,25 +164,76 @@ function windowsWarnings(intent: PtySpawnIntent): LocalPtySpawnWarning[] {
   return warnings;
 }
 
+function windowsShellLineSpawn({
+  commandLine,
+  cwd,
+  env,
+  shellProfile,
+  warnings,
+}: {
+  commandLine: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  shellProfile: PtySpawnIntent['shellProfile'];
+  warnings: LocalPtySpawnWarning[];
+}): ResolvedLocalPtySpawn {
+  const shell = shellProfile?.executable ?? getWindowsShell(env);
+  const commandArgs = shellProfile?.commandArgs ?? ['/d', '/s', '/c'];
+  return {
+    command: shell,
+    args:
+      shellProfile?.family === 'powershell'
+        ? [...commandArgs, commandLine]
+        : [...commandArgs, wrapCmdExeCommandLine(commandLine)],
+    cwd,
+    warnings,
+  };
+}
+
+function cmdShellLineSpawn({
+  commandLine,
+  cwd,
+  env,
+  warnings,
+}: {
+  commandLine: string;
+  cwd: string;
+  env: NodeJS.ProcessEnv;
+  warnings: LocalPtySpawnWarning[];
+}): ResolvedLocalPtySpawn {
+  return {
+    command: getWindowsShell(env),
+    args: ['/d', '/s', '/c', wrapCmdExeCommandLine(commandLine)],
+    cwd,
+    warnings,
+  };
+}
+
 function resolveWindowsSpawn(
   intent: PtySpawnIntent,
   env: NodeJS.ProcessEnv,
   fileExists: FileExists
 ): ResolvedLocalPtySpawn {
   const warnings = windowsWarnings(intent);
-  const shell = getWindowsShell(env);
+  const shell = intent.shellProfile?.executable ?? getWindowsShell(env);
 
   if (intent.kind === 'interactive-shell') {
-    return { command: shell, args: [], cwd: intent.cwd, warnings };
-  }
-
-  if (intent.command.kind === 'shell-line') {
     return {
       command: shell,
-      args: ['/d', '/s', '/c', wrapCmdExeCommandLine(intent.command.commandLine)],
+      args: intent.shellProfile?.interactiveArgs ?? [],
       cwd: intent.cwd,
       warnings,
     };
+  }
+
+  if (intent.command.kind === 'shell-line') {
+    return windowsShellLineSpawn({
+      commandLine: intent.command.commandLine,
+      cwd: intent.cwd,
+      env,
+      shellProfile: intent.shellProfile,
+      warnings,
+    });
   }
 
   const { command, args } = intent.command;
@@ -167,22 +247,20 @@ function resolveWindowsSpawn(
   const ext = path.win32.extname(resolvedCommand).toLowerCase();
 
   if (ext === '.cmd' || ext === '.bat') {
-    return {
-      command: shell,
-      args: [
-        '/d',
-        '/s',
-        '/c',
-        wrapCmdExeCommandLine([resolvedCommand, ...args].map(quoteForCmdExe).join(' ')),
-      ],
+    return cmdShellLineSpawn({
+      commandLine: [resolvedCommand, ...args].map(quoteForCmdExe).join(' '),
       cwd: intent.cwd,
+      env,
       warnings,
-    };
+    });
   }
 
   if (ext === '.ps1') {
     return {
-      command: 'powershell.exe',
+      command:
+        intent.shellProfile?.family === 'powershell'
+          ? intent.shellProfile.executable
+          : 'powershell.exe',
       args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', resolvedCommand, ...args],
       cwd: intent.cwd,
       warnings,
@@ -190,33 +268,39 @@ function resolveWindowsSpawn(
   }
 
   if (!ext) {
-    return {
-      command: shell,
-      args: [
-        '/d',
-        '/s',
-        '/c',
-        wrapCmdExeCommandLine([command, ...args].map(quoteForCmdExe).join(' ')),
-      ],
+    if (intent.shellProfile?.family === 'powershell') {
+      return windowsShellLineSpawn({
+        commandLine: `& ${[command, ...args].map(quoteForPowerShell).join(' ')}`,
+        cwd: intent.cwd,
+        env,
+        shellProfile: intent.shellProfile,
+        warnings,
+      });
+    }
+    return cmdShellLineSpawn({
+      commandLine: [command, ...args].map(quoteForCmdExe).join(' '),
       cwd: intent.cwd,
+      env,
       warnings,
-    };
+    });
   }
 
   return { command: resolvedCommand, args, cwd: intent.cwd, warnings };
 }
 
 function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): ResolvedLocalPtySpawn {
-  const shell = getPosixShell(env);
+  const shell = getResolvedShell(intent, env);
+  const interactiveArgs = getInteractiveArgs(intent);
+  const commandArgs = getCommandArgs(intent);
 
   if (intent.kind === 'interactive-shell') {
     if (intent.tmuxSessionName) {
       const commandLine = intent.shellSetup
-        ? `${intent.shellSetup} && exec ${quotePosixArg(shell)} -il`
-        : `exec ${quotePosixArg(shell)} -il`;
+        ? `${intent.shellSetup} && exec ${quotePosixArg(shell)} ${interactiveArgs.join(' ')}`
+        : `exec ${quotePosixArg(shell)} ${interactiveArgs.join(' ')}`;
       return {
         command: shell,
-        args: ['-c', buildTmuxShellLine(intent.tmuxSessionName, commandLine)],
+        args: [...commandArgs, buildTmuxShellLine(intent.tmuxSessionName, commandLine)],
         cwd: intent.cwd,
         warnings: [],
       };
@@ -225,19 +309,31 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
     if (intent.shellSetup) {
       return {
         command: shell,
-        args: ['-c', `${intent.shellSetup} && exec ${quotePosixArg(shell)} -il`],
+        args: [
+          ...commandArgs,
+          `${intent.shellSetup} && exec ${quotePosixArg(shell)} ${interactiveArgs.join(' ')}`,
+        ],
         cwd: intent.cwd,
         warnings: [],
       };
     }
 
-    return { command: shell, args: ['-il'], cwd: intent.cwd, warnings: [] };
+    return { command: shell, args: interactiveArgs, cwd: intent.cwd, warnings: [] };
+  }
+
+  if (
+    intent.shellProfile?.family === 'powershell' ||
+    intent.shellProfile?.family === 'windows-cmd'
+  ) {
+    throw new Error(
+      `Cannot run POSIX shell-wrapped commands through ${intent.shellProfile.displayName}`
+    );
   }
 
   const commandLine =
     intent.command.kind === 'shell-line'
       ? intent.command.commandLine
-      : argvToPosixShellLine(intent.command.command, intent.command.args);
+      : argvToPosixShellLine(intent, intent.command.command, intent.command.args);
   const fullCommandLine = intent.shellSetup
     ? `${intent.shellSetup} && ${commandLine}`
     : commandLine;
@@ -245,7 +341,7 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
   if (intent.tmuxSessionName) {
     return {
       command: shell,
-      args: ['-c', buildTmuxShellLine(intent.tmuxSessionName, fullCommandLine)],
+      args: [...commandArgs, buildTmuxShellLine(intent.tmuxSessionName, fullCommandLine)],
       cwd: intent.cwd,
       warnings: [],
     };
@@ -253,7 +349,7 @@ function resolvePosixSpawn(intent: PtySpawnIntent, env: NodeJS.ProcessEnv): Reso
 
   return {
     command: shell,
-    args: ['-c', fullCommandLine],
+    args: [...commandArgs, fullCommandLine],
     cwd: intent.cwd,
     warnings: [],
   };

--- a/src/main/core/pty/spawn-utils.test.ts
+++ b/src/main/core/pty/spawn-utils.test.ts
@@ -34,6 +34,13 @@ const zshProfile: RemoteShellProfile = {
   },
 };
 
+const tcshLoginProfile: RemoteShellProfile = {
+  shell: '/bin/tcsh',
+  env: {
+    PATH: '/usr/bin',
+  },
+};
+
 const bashRemoteProfile: ResolvedShellProfile = {
   id: 'bash',
   resolvedShellId: 'bash',
@@ -55,7 +62,7 @@ const tcshRemoteProfile: ResolvedShellProfile = {
   id: 'tcsh',
   resolvedShellId: 'tcsh',
   resolvedFromAuto: false,
-  executable: '/bin/tcsh',
+  executable: 'tcsh',
   displayName: 'tcsh',
   available: true,
   family: 'csh',
@@ -65,6 +72,7 @@ const tcshRemoteProfile: ResolvedShellProfile = {
   capturedEnv: {
     PATH: '/usr/bin',
   },
+  remotePathLookup: true,
 };
 
 describe('resolveSshCommand', () => {
@@ -98,6 +106,21 @@ describe('resolveSshCommand', () => {
 
     expect(result).toBe(
       `'/bin/sh' -c 'export FOO='\\''bar'\\''; cd "/workspace" && '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
+    );
+  });
+
+  it('keeps captured csh-family login shells on the supported sh fallback for agents', () => {
+    const result = resolveSshCommand(
+      'agent',
+      makeAgentConfig({
+        shellSetup: 'export FOO=bar',
+      }),
+      undefined,
+      tcshLoginProfile
+    );
+
+    expect(result).toBe(
+      `'/bin/sh' -c 'export PATH='\\''/usr/bin'\\''; cd "/workspace" && export FOO=bar && '\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\'''`
     );
   });
 
@@ -181,7 +204,7 @@ describe('resolveSshCommand', () => {
       tcshRemoteProfile
     );
 
-    expect(result).toContain("'/bin/tcsh' -c");
+    expect(result).toContain("'/usr/bin/env' 'PATH=/usr/bin' 'tcsh' -c");
     expect(result).toContain("'\\''hello\\!'\\''");
   });
 });

--- a/src/main/core/pty/spawn-utils.test.ts
+++ b/src/main/core/pty/spawn-utils.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { RemoteShellProfile } from '@main/core/ssh/lifecycle/remote-shell-profile';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import type { AgentSessionConfig } from '@shared/agent-session';
 import type { GeneralSessionConfig } from '@shared/general-session';
 import { resolveSshCommand } from './spawn-utils';
@@ -30,6 +31,39 @@ const zshProfile: RemoteShellProfile = {
   shell: '/bin/zsh',
   env: {
     PATH: '/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin',
+  },
+};
+
+const bashRemoteProfile: ResolvedShellProfile = {
+  id: 'bash',
+  resolvedShellId: 'bash',
+  resolvedFromAuto: false,
+  executable: 'bash',
+  displayName: 'bash',
+  available: true,
+  family: 'posix',
+  interactiveArgs: ['-il'],
+  commandArgs: ['-lc'],
+  envCaptureArgs: ['-ilc'],
+  capturedEnv: {
+    PATH: '/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin',
+  },
+  remotePathLookup: true,
+};
+
+const tcshRemoteProfile: ResolvedShellProfile = {
+  id: 'tcsh',
+  resolvedShellId: 'tcsh',
+  resolvedFromAuto: false,
+  executable: '/bin/tcsh',
+  displayName: 'tcsh',
+  available: true,
+  family: 'csh',
+  interactiveArgs: ['-i'],
+  commandArgs: ['-c'],
+  envCaptureArgs: ['-i', '-c'],
+  capturedEnv: {
+    PATH: '/usr/bin',
   },
 };
 
@@ -106,5 +140,48 @@ describe('resolveSshCommand', () => {
     expect(result).toBe(
       `'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; cd "/workspace" && exec /bin/zsh -il'`
     );
+  });
+
+  it('uses the selected remote shell profile with PATH lookup for general terminals', () => {
+    const result = resolveSshCommand('general', makeGeneralConfig(), undefined, bashRemoteProfile);
+
+    expect(result).toContain(
+      `'/usr/bin/env' 'PATH=/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin' 'bash' -lc`
+    );
+    expect(result).toContain(
+      `export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''`
+    );
+    expect(result).toContain(`export SHELL='\\''bash'\\''`);
+    expect(result).toContain(`cd "/workspace" && exec bash -il`);
+  });
+
+  it('uses task PATH overrides when looking up the selected remote shell', () => {
+    const result = resolveSshCommand(
+      'general',
+      makeGeneralConfig(),
+      { PATH: '/task/bin:/usr/bin' },
+      bashRemoteProfile
+    );
+
+    expect(result).toContain(`'/usr/bin/env' 'PATH=/task/bin:/usr/bin' 'bash' -lc`);
+    expect(result.indexOf('/Users/jona/.local/bin')).toBeLessThan(
+      result.lastIndexOf('/task/bin:/usr/bin')
+    );
+    expect(result).toContain(`export SHELL='\\''bash'\\''`);
+  });
+
+  it('escapes history expansion for csh-family remote argv commands', () => {
+    const result = resolveSshCommand(
+      'agent',
+      makeAgentConfig({
+        command: 'printf',
+        args: ['hello!'],
+      }),
+      undefined,
+      tcshRemoteProfile
+    );
+
+    expect(result).toContain("'/bin/tcsh' -c");
+    expect(result).toContain("'\\''hello\\!'\\''");
   });
 });

--- a/src/main/core/pty/spawn-utils.ts
+++ b/src/main/core/pty/spawn-utils.ts
@@ -6,7 +6,7 @@ import {
   type RemoteShellProfile,
 } from '@main/core/ssh/lifecycle/remote-shell-profile';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
-import { quoteShellArg } from '@main/utils/shellEscape';
+import { quoteCshArg, quoteShellArg } from '@main/utils/shellEscape';
 import type { AgentSessionConfig } from '@shared/agent-session';
 import type { GeneralSessionConfig } from '@shared/general-session';
 import {
@@ -53,10 +53,6 @@ function posixShellLineForSsh(
     default:
       throw new Error(`Unsupported session type: ${type}`);
   }
-}
-
-function quoteCshArg(value: string): string {
-  return quoteShellArg(value).replace(/!/g, '\\!');
 }
 
 /**

--- a/src/main/core/pty/spawn-utils.ts
+++ b/src/main/core/pty/spawn-utils.ts
@@ -1,11 +1,20 @@
 import {
   buildRemoteShellCommand,
+  buildRemoteShellCommandWithPathLookup,
   FALLBACK_REMOTE_SHELL_PROFILE,
   type RemoteShellProfile,
 } from '@main/core/ssh/lifecycle/remote-shell-profile';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { quoteShellArg } from '@main/utils/shellEscape';
 import type { AgentSessionConfig } from '@shared/agent-session';
 import type { GeneralSessionConfig } from '@shared/general-session';
+import {
+  isCshShell,
+  terminalCommandArgs,
+  terminalEnvCaptureArgs,
+  terminalInteractiveShellArgs,
+  terminalShellBasename,
+} from '@shared/terminal-settings';
 import { buildTmuxShellLine } from './tmux-session-name';
 
 export type SessionType = 'agent' | 'general';
@@ -14,14 +23,15 @@ export type SessionConfig = AgentSessionConfig | GeneralSessionConfig;
 function posixShellLineForSsh(
   type: SessionType,
   config: SessionConfig,
-  profile: RemoteShellProfile
+  profile: ResolvedShellProfile
 ): { cwd: string; line: string } {
-  const shell = profile.shell;
+  const shell = profile.executable;
+  const quoteArg = isCshShell(shell) ? quoteCshArg : quoteShellArg;
 
   switch (type) {
     case 'agent': {
       const cfg = config as AgentSessionConfig;
-      const baseCmd = [cfg.command, ...cfg.args].map(quoteShellArg).join(' ');
+      const baseCmd = [cfg.command, ...cfg.args].map(quoteArg).join(' ');
       const line = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
       return {
         cwd: cfg.cwd,
@@ -32,7 +42,7 @@ function posixShellLineForSsh(
       const cfg = config as GeneralSessionConfig;
       const baseCmd = cfg.command
         ? [cfg.command, ...(cfg.args ?? [])].join(' ')
-        : `exec ${shell} -il`;
+        : `exec ${shell} ${profile.interactiveArgs.join(' ')}`;
       const line = cfg.shellSetup ? `${cfg.shellSetup} && ${baseCmd}` : baseCmd;
       return {
         cwd: cfg.cwd,
@@ -44,6 +54,10 @@ function posixShellLineForSsh(
   }
 }
 
+function quoteCshArg(value: string): string {
+  return quoteShellArg(value).replace(/!/g, '\\!');
+}
+
 /**
  * Build a single command string for SSH remote execution.
  */
@@ -51,10 +65,58 @@ export function resolveSshCommand(
   type: SessionType,
   config: SessionConfig,
   envVars?: Record<string, string>,
-  profile?: RemoteShellProfile
+  profile?: ResolvedShellProfile | RemoteShellProfile
 ): string {
-  const effectiveProfile = profile ?? FALLBACK_REMOTE_SHELL_PROFILE;
+  const effectiveProfile = toResolvedShellProfile(profile);
   const { cwd, line } = posixShellLineForSsh(type, config, effectiveProfile);
   const commandString = `cd ${JSON.stringify(cwd)} && ${line}`;
-  return buildRemoteShellCommand(effectiveProfile, commandString, envVars);
+  const remoteProfile = {
+    shell: effectiveProfile.executable,
+    env: effectiveProfile.capturedEnv ?? {},
+  };
+  if (effectiveProfile.remotePathLookup) {
+    return buildRemoteShellCommandWithPathLookup(
+      remoteProfile,
+      effectiveProfile.executable,
+      commandString,
+      envVars
+    );
+  }
+  return buildRemoteShellCommand(remoteProfile, commandString, envVars);
+}
+
+function toResolvedShellProfile(
+  profile: ResolvedShellProfile | RemoteShellProfile | undefined
+): ResolvedShellProfile {
+  if (profile && 'executable' in profile) return profile;
+  if (profile) {
+    const shellId = terminalShellBasename(profile.shell) || 'sh';
+    return {
+      id: 'target-default',
+      resolvedShellId:
+        shellId === 'zsh' || shellId === 'bash' || shellId === 'ksh' ? shellId : 'sh',
+      resolvedFromAuto: true,
+      executable: profile.shell,
+      displayName: `Auto - ${shellId}`,
+      available: true,
+      family: isCshShell(profile.shell) ? 'csh' : 'posix',
+      interactiveArgs: terminalInteractiveShellArgs(profile.shell),
+      commandArgs: terminalCommandArgs(profile.shell),
+      envCaptureArgs: terminalEnvCaptureArgs(profile.shell),
+      capturedEnv: profile.env,
+    };
+  }
+  return {
+    id: 'target-default',
+    resolvedShellId: 'sh',
+    resolvedFromAuto: true,
+    executable: FALLBACK_REMOTE_SHELL_PROFILE.shell,
+    displayName: 'Auto - sh',
+    available: true,
+    family: 'posix',
+    interactiveArgs: ['-i'],
+    commandArgs: ['-c'],
+    envCaptureArgs: ['-ic'],
+    capturedEnv: FALLBACK_REMOTE_SHELL_PROFILE.env,
+  };
 }

--- a/src/main/core/pty/spawn-utils.ts
+++ b/src/main/core/pty/spawn-utils.ts
@@ -2,6 +2,7 @@ import {
   buildRemoteShellCommand,
   buildRemoteShellCommandWithPathLookup,
   FALLBACK_REMOTE_SHELL_PROFILE,
+  normalizeRemoteShell,
   type RemoteShellProfile,
 } from '@main/core/ssh/lifecycle/remote-shell-profile';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
@@ -90,19 +91,20 @@ function toResolvedShellProfile(
 ): ResolvedShellProfile {
   if (profile && 'executable' in profile) return profile;
   if (profile) {
-    const shellId = terminalShellBasename(profile.shell) || 'sh';
+    const executable = normalizeRemoteShell(profile.shell);
+    const shellId = terminalShellBasename(executable) || 'sh';
     return {
       id: 'target-default',
       resolvedShellId:
         shellId === 'zsh' || shellId === 'bash' || shellId === 'ksh' ? shellId : 'sh',
       resolvedFromAuto: true,
-      executable: profile.shell,
+      executable,
       displayName: `Auto - ${shellId}`,
       available: true,
-      family: isCshShell(profile.shell) ? 'csh' : 'posix',
-      interactiveArgs: terminalInteractiveShellArgs(profile.shell),
-      commandArgs: terminalCommandArgs(profile.shell),
-      envCaptureArgs: terminalEnvCaptureArgs(profile.shell),
+      family: isCshShell(executable) ? 'csh' : 'posix',
+      interactiveArgs: terminalInteractiveShellArgs(executable),
+      commandArgs: terminalCommandArgs(executable),
+      envCaptureArgs: terminalEnvCaptureArgs(executable),
       capturedEnv: profile.env,
     };
   }

--- a/src/main/core/ssh/lifecycle/remote-shell-profile.test.ts
+++ b/src/main/core/ssh/lifecycle/remote-shell-profile.test.ts
@@ -2,6 +2,8 @@ import { describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import {
   buildRemoteShellCommand,
+  buildRemoteShellCommandWithPathLookup,
+  captureRemoteShellProfile,
   FALLBACK_REMOTE_SHELL_PROFILE,
   includeRemoteUserBinDirs,
   normalizeRemoteShell,
@@ -17,6 +19,35 @@ function makeCtx(stdout: string): IExecutionContext {
     execStreaming: vi.fn(),
     dispose: vi.fn(),
   } as unknown as IExecutionContext;
+}
+
+function makeRemoteShellClient(outputs: string[]) {
+  const commands: string[] = [];
+  const exec = vi.fn(
+    (command: string, callback: (error: Error | undefined, channel: unknown) => void) => {
+      commands.push(command);
+      const stdout = outputs.shift() ?? '';
+      const listeners = new Map<string, (value: unknown) => void>();
+      const channel = {
+        on: vi.fn((event: string, handler: (value: unknown) => void) => {
+          listeners.set(event, handler);
+          return channel;
+        }),
+        stderr: {
+          on: vi.fn(() => channel.stderr),
+        },
+        destroy: vi.fn(),
+      };
+
+      callback(undefined, channel);
+      queueMicrotask(() => {
+        listeners.get('data')?.(Buffer.from(stdout));
+        listeners.get('close')?.(0);
+      });
+    }
+  );
+
+  return { commands, exec };
 }
 
 describe('remote shell profile command building', () => {
@@ -74,6 +105,62 @@ describe('remote shell profile command building', () => {
     expect(command).toBe("'/bin/sh' -c 'which claude'");
   });
 
+  it('uses csh-compatible environment setup for csh shells', () => {
+    const command = buildRemoteShellCommand(
+      {
+        shell: '/bin/tcsh',
+        env: {
+          PATH: '/usr/bin',
+        },
+      },
+      'which claude',
+      { FOO: 'bar!' }
+    );
+
+    expect(command).toContain("'/bin/tcsh' -c");
+    expect(command).toContain('setenv PATH');
+    expect(command).toContain('bar\\!');
+    expect(command).toContain('which claude');
+  });
+
+  it.each(['/bin/csh', '/bin/tcsh'])(
+    'captures %s shell env with separate interactive and command flags',
+    async (shell) => {
+      const client = makeRemoteShellClient([shell, 'HOME=/Users/jona\nPATH=/usr/bin\n']);
+
+      await expect(captureRemoteShellProfile(client)).resolves.toEqual({
+        shell,
+        env: {
+          HOME: '/Users/jona',
+          PATH: '/Users/jona/.local/bin:/usr/bin',
+        },
+      });
+
+      expect(client.commands[1]).toContain(`'${shell}' -i -c 'env'`);
+    }
+  );
+
+  it('uses csh-compatible environment setup for explicit remote csh path lookup', () => {
+    const command = buildRemoteShellCommandWithPathLookup(
+      {
+        shell: '/bin/tcsh',
+        env: {
+          PATH: '/usr/bin',
+          SHELL: '/bin/tcsh',
+        },
+      },
+      'tcsh',
+      'echo ready',
+      { FOO: 'bar!' }
+    );
+
+    expect(command).toContain("'/usr/bin/env' 'PATH=/usr/bin' 'tcsh' -c");
+    expect(command).toContain("setenv PATH '\\''/usr/bin'\\''");
+    expect(command).toContain("setenv SHELL '\\''tcsh'\\''");
+    expect(command).toContain("setenv FOO '\\''bar\\!'\\''");
+    expect(command).toContain('echo ready');
+  });
+
   it('filters volatile and invalid environment variables from command exports', () => {
     const command = buildRemoteShellCommand(
       {
@@ -101,6 +188,7 @@ describe('remote shell profile command building', () => {
     expect(normalizeRemoteShell('')).toBe('/bin/sh');
     expect(normalizeRemoteShell('zsh')).toBe('/bin/sh');
     expect(normalizeRemoteShell('/bin/zsh\n')).toBe('/bin/zsh');
+    expect(normalizeRemoteShell('/bin/tcsh')).toBe('/bin/tcsh');
   });
 
   it('falls back to /bin/sh for unsupported remote shells', () => {

--- a/src/main/core/ssh/lifecycle/remote-shell-profile.test.ts
+++ b/src/main/core/ssh/lifecycle/remote-shell-profile.test.ts
@@ -105,7 +105,7 @@ describe('remote shell profile command building', () => {
     expect(command).toBe("'/bin/sh' -c 'which claude'");
   });
 
-  it('uses csh-compatible environment setup for csh shells', () => {
+  it('falls back to sh for captured csh-family login shells', () => {
     const command = buildRemoteShellCommand(
       {
         shell: '/bin/tcsh',
@@ -117,26 +117,25 @@ describe('remote shell profile command building', () => {
       { FOO: 'bar!' }
     );
 
-    expect(command).toContain("'/bin/tcsh' -c");
-    expect(command).toContain('setenv PATH');
-    expect(command).toContain('bar\\!');
-    expect(command).toContain('which claude');
+    expect(command).toBe(
+      "'/bin/sh' -c 'export PATH='\\''/usr/bin'\\''; export FOO='\\''bar!'\\''; which claude'"
+    );
   });
 
   it.each(['/bin/csh', '/bin/tcsh'])(
-    'captures %s shell env with separate interactive and command flags',
+    'captures %s login shell env through the supported sh fallback',
     async (shell) => {
       const client = makeRemoteShellClient([shell, 'HOME=/Users/jona\nPATH=/usr/bin\n']);
 
       await expect(captureRemoteShellProfile(client)).resolves.toEqual({
-        shell,
+        shell: '/bin/sh',
         env: {
           HOME: '/Users/jona',
           PATH: '/Users/jona/.local/bin:/usr/bin',
         },
       });
 
-      expect(client.commands[1]).toContain(`'${shell}' -i -c 'env'`);
+      expect(client.commands[1]).toContain("'/bin/sh' -ic 'env'");
     }
   );
 
@@ -188,7 +187,7 @@ describe('remote shell profile command building', () => {
     expect(normalizeRemoteShell('')).toBe('/bin/sh');
     expect(normalizeRemoteShell('zsh')).toBe('/bin/sh');
     expect(normalizeRemoteShell('/bin/zsh\n')).toBe('/bin/zsh');
-    expect(normalizeRemoteShell('/bin/tcsh')).toBe('/bin/tcsh');
+    expect(normalizeRemoteShell('/bin/tcsh')).toBe('/bin/sh');
   });
 
   it('falls back to /bin/sh for unsupported remote shells', () => {

--- a/src/main/core/ssh/lifecycle/remote-shell-profile.ts
+++ b/src/main/core/ssh/lifecycle/remote-shell-profile.ts
@@ -2,6 +2,12 @@ import type { ClientCallback, ClientChannel } from 'ssh2';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { isValidEnvVarName, quoteShellArg } from '@main/utils/shellEscape';
 import { parseRemoteEnvOutput, SHELL_ENV_CAPTURE_GUARD } from '@main/utils/userEnv';
+import {
+  isCshShell,
+  terminalCommandArgs,
+  terminalEnvCaptureArgs,
+  terminalShellBasename,
+} from '@shared/terminal-settings';
 
 export type RemoteShellProfile = {
   shell: string;
@@ -18,7 +24,7 @@ export const FALLBACK_REMOTE_SHELL_PROFILE: RemoteShellProfile = {
 const CAPTURE_TIMEOUT_MS = 5_000;
 const SHELL_TIMEOUT_MS = 3_000;
 
-const LOGIN_SHELLS = new Set(['bash', 'ksh', 'zsh']);
+const LOGIN_SHELLS = new Set(['bash', 'csh', 'ksh', 'tcsh', 'zsh']);
 const BASIC_POSIX_SHELLS = new Set(['dash', 'sh']);
 const SUPPORTED_REMOTE_SHELLS = new Set([...BASIC_POSIX_SHELLS, ...LOGIN_SHELLS]);
 const VOLATILE_ENV_KEYS = new Set(['_', 'PWD', 'OLDPWD', 'SHLVL', 'COLUMNS', 'LINES']);
@@ -34,18 +40,30 @@ type RemoteShellExecClient = {
 
 export function normalizeRemoteShell(raw: string | undefined | null): string {
   const shell = raw?.trim();
-  if (!shell || !shell.startsWith('/') || !SUPPORTED_REMOTE_SHELLS.has(shellBasename(shell))) {
+  if (
+    !shell ||
+    !shell.startsWith('/') ||
+    !SUPPORTED_REMOTE_SHELLS.has(terminalShellBasename(shell))
+  ) {
     return DEFAULT_REMOTE_SHELL;
   }
   return shell;
 }
 
-function buildRemoteShellEnvPrefix(env: Record<string, string>): string {
+function buildRemoteShellEnvPrefix(shell: string, env: Record<string, string>): string {
   const exports = Object.entries(env)
     .filter(([key]) => shouldForwardEnvKey(key))
-    .map(([key, value]) => `export ${key}=${quoteShellArg(value)}`);
+    .map(([key, value]) =>
+      isCshShell(shell)
+        ? `setenv ${key} ${quoteCshArg(value)}`
+        : `export ${key}=${quoteShellArg(value)}`
+    );
 
   return exports.length > 0 ? `${exports.join('; ')}; ` : '';
+}
+
+function quoteCshArg(value: string): string {
+  return quoteShellArg(value).replace(/!/g, '\\!');
 }
 
 function buildRemoteShellProcessEnvPrefix(env: Record<string, string>): string {
@@ -62,10 +80,31 @@ export function buildRemoteShellCommand(
   env: Record<string, string> = {}
 ): string {
   const shell = normalizeRemoteShell(profile.shell);
-  const prefix = `${buildRemoteShellEnvPrefix(profile.env)}${buildRemoteShellEnvPrefix(env)}`;
-  return `${quoteShellArg(shell)} ${remoteShellCommandFlag(shell)} ${quoteShellArg(
+  const prefix = `${buildRemoteShellEnvPrefix(shell, profile.env)}${buildRemoteShellEnvPrefix(
+    shell,
+    env
+  )}`;
+  return `${quoteShellArg(shell)} ${terminalCommandArgs(shell).join(' ')} ${quoteShellArg(
     `${prefix}${command}`
   )}`;
+}
+
+export function buildRemoteShellCommandWithPathLookup(
+  profile: RemoteShellProfile,
+  shellName: string,
+  command: string,
+  env: Record<string, string> = {}
+): string {
+  const selectedShellEnv = { ...env, SHELL: shellName };
+  const prefix = `${buildRemoteShellEnvPrefix(
+    shellName,
+    withoutShellEnv(profile.env)
+  )}${buildRemoteShellEnvPrefix(shellName, selectedShellEnv)}`;
+  const remotePath = env.PATH ?? profile.env.PATH;
+  const pathArg = remotePath ? `${quoteShellArg(`PATH=${remotePath}`)} ` : '';
+  return `${quoteShellArg('/usr/bin/env')} ${pathArg}${quoteShellArg(
+    shellName
+  )} ${terminalCommandArgs(shellName).join(' ')} ${quoteShellArg(`${prefix}${command}`)}`;
 }
 
 export function includeRemoteUserBinDirs(env: Record<string, string>): Record<string, string> {
@@ -114,9 +153,10 @@ async function captureRemoteEnv(
 ): Promise<Record<string, string>> {
   try {
     const guard = buildRemoteShellProcessEnvPrefix(SHELL_ENV_CAPTURE_GUARD);
-    const capture = `${guard}${quoteShellArg(shell)} ${remoteShellEnvCaptureFlag(
-      shell
-    )} ${quoteShellArg('env')}`;
+    const envCaptureArgs = terminalEnvCaptureArgs(shell) ?? ['-ic'];
+    const capture = `${guard}${quoteShellArg(shell)} ${envCaptureArgs.join(' ')} ${quoteShellArg(
+      'env'
+    )}`;
     const { stdout } = await execRaw(client, capture, CAPTURE_TIMEOUT_MS);
     return includeRemoteUserBinDirs(parseRemoteEnvOutput(stdout));
   } catch {
@@ -133,16 +173,9 @@ function shouldForwardEnvKey(key: string): boolean {
   return isValidEnvVarName(key) && !VOLATILE_ENV_KEYS.has(key);
 }
 
-function remoteShellCommandFlag(shell: string): string {
-  return BASIC_POSIX_SHELLS.has(shellBasename(shell)) ? '-c' : '-lc';
-}
-
-function remoteShellEnvCaptureFlag(shell: string): string {
-  return BASIC_POSIX_SHELLS.has(shellBasename(shell)) ? '-ic' : '-ilc';
-}
-
-function shellBasename(shell: string): string {
-  return shell.split('/').pop() ?? '';
+function withoutShellEnv(env: Record<string, string>): Record<string, string> {
+  const { SHELL: _shell, ...rest } = env;
+  return rest;
 }
 
 function execRaw(

--- a/src/main/core/ssh/lifecycle/remote-shell-profile.ts
+++ b/src/main/core/ssh/lifecycle/remote-shell-profile.ts
@@ -1,6 +1,6 @@
 import type { ClientCallback, ClientChannel } from 'ssh2';
 import type { IExecutionContext } from '@main/core/execution-context/types';
-import { isValidEnvVarName, quoteShellArg } from '@main/utils/shellEscape';
+import { isValidEnvVarName, quoteCshArg, quoteShellArg } from '@main/utils/shellEscape';
 import { parseRemoteEnvOutput, SHELL_ENV_CAPTURE_GUARD } from '@main/utils/userEnv';
 import {
   isCshShell,
@@ -60,10 +60,6 @@ function buildRemoteShellEnvPrefix(shell: string, env: Record<string, string>): 
     );
 
   return exports.length > 0 ? `${exports.join('; ')}; ` : '';
-}
-
-function quoteCshArg(value: string): string {
-  return quoteShellArg(value).replace(/!/g, '\\!');
 }
 
 function buildRemoteShellProcessEnvPrefix(env: Record<string, string>): string {

--- a/src/main/core/ssh/lifecycle/remote-shell-profile.ts
+++ b/src/main/core/ssh/lifecycle/remote-shell-profile.ts
@@ -24,7 +24,7 @@ export const FALLBACK_REMOTE_SHELL_PROFILE: RemoteShellProfile = {
 const CAPTURE_TIMEOUT_MS = 5_000;
 const SHELL_TIMEOUT_MS = 3_000;
 
-const LOGIN_SHELLS = new Set(['bash', 'csh', 'ksh', 'tcsh', 'zsh']);
+const LOGIN_SHELLS = new Set(['bash', 'ksh', 'zsh']);
 const BASIC_POSIX_SHELLS = new Set(['dash', 'sh']);
 const SUPPORTED_REMOTE_SHELLS = new Set([...BASIC_POSIX_SHELLS, ...LOGIN_SHELLS]);
 const VOLATILE_ENV_KEYS = new Set(['_', 'PWD', 'OLDPWD', 'SHLVL', 'COLUMNS', 'LINES']);

--- a/src/main/core/terminal-shell/resolver.test.ts
+++ b/src/main/core/terminal-shell/resolver.test.ts
@@ -1,0 +1,180 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
+import {
+  getLocalTerminalShellAvailability,
+  resolveTerminalShell,
+  ShellUnavailableError,
+} from './resolver';
+
+describe('terminal shell resolver', () => {
+  it('keeps auto intent while recording the concrete local shell', async () => {
+    const profile = await resolveTerminalShell({
+      intent: 'auto',
+      target: {
+        kind: 'local',
+        platform: 'darwin',
+        env: { SHELL: '/bin/zsh' },
+      },
+    });
+
+    expect(profile).toMatchObject({
+      id: 'target-default',
+      resolvedShellId: 'zsh',
+      resolvedFromAuto: true,
+      executable: '/bin/zsh',
+    });
+  });
+
+  it('keeps login-shell args for unknown local auto shells', async () => {
+    const profile = await resolveTerminalShell({
+      intent: 'auto',
+      target: {
+        kind: 'local',
+        platform: 'darwin',
+        env: { SHELL: '/opt/homebrew/bin/fish' },
+      },
+    });
+
+    expect(profile).toMatchObject({
+      id: 'target-default',
+      resolvedShellId: 'sh',
+      resolvedFromAuto: true,
+      executable: '/opt/homebrew/bin/fish',
+      displayName: 'Auto - fish',
+      family: 'posix',
+      interactiveArgs: ['-il'],
+      commandArgs: ['-lc'],
+    });
+  });
+
+  it('uses ComSpec as the Windows auto shell', async () => {
+    const profile = await resolveTerminalShell({
+      intent: 'auto',
+      target: {
+        kind: 'local',
+        platform: 'win32',
+        env: { ComSpec: 'C:\\Windows\\System32\\cmd.exe' },
+      },
+    });
+
+    expect(profile).toMatchObject({
+      id: 'target-default',
+      resolvedShellId: 'cmd',
+      executable: 'C:\\Windows\\System32\\cmd.exe',
+      family: 'windows-cmd',
+    });
+  });
+
+  it('reports Windows shells separately from POSIX shells', async () => {
+    const availability = await getLocalTerminalShellAvailability({
+      platform: 'win32',
+      env: {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+        Path: 'C:\\Windows\\System32',
+        PATHEXT: '.EXE;.CMD',
+      },
+      fileExists: (candidate) => candidate === 'C:\\Windows\\System32\\powershell.exe',
+    });
+
+    expect(availability.find((entry) => entry.shell === 'auto')).toMatchObject({
+      available: true,
+      displayName: 'Auto - cmd',
+    });
+    expect(availability.find((entry) => entry.shell === 'cmd')?.available).toBe(true);
+    expect(availability.find((entry) => entry.shell === 'powershell')?.available).toBe(true);
+    expect(availability.find((entry) => entry.shell === 'pwsh')?.available).toBe(false);
+    expect(availability.find((entry) => entry.shell === 'zsh')).toBeUndefined();
+    expect(availability.map((entry) => entry.shell)).toEqual([
+      'auto',
+      'cmd',
+      'powershell',
+      'pwsh',
+      'bash',
+    ]);
+  });
+
+  it('filters Windows-only shells out of POSIX local availability', async () => {
+    const availability = await getLocalTerminalShellAvailability({
+      platform: 'darwin',
+      env: { PATH: '/bin:/usr/bin' },
+      fileExists: (candidate) => candidate === '/bin/zsh' || candidate === '/bin/bash',
+    });
+
+    expect(availability.find((entry) => entry.shell === 'cmd')).toBeUndefined();
+    expect(availability.find((entry) => entry.shell === 'powershell')).toBeUndefined();
+    expect(availability.find((entry) => entry.shell === 'auto')?.displayName).toBe('Auto - zsh');
+    expect(availability.find((entry) => entry.shell === 'bash')?.available).toBe(true);
+    expect(availability.find((entry) => entry.shell === 'zsh')?.available).toBe(true);
+    expect(availability.at(-1)?.available).toBe(false);
+  });
+
+  it('labels unknown local auto shells by executable basename', async () => {
+    const availability = await getLocalTerminalShellAvailability({
+      platform: 'darwin',
+      env: { SHELL: '/opt/homebrew/bin/fish', PATH: '/bin:/usr/bin' },
+      fileExists: () => false,
+    });
+
+    expect(availability.find((entry) => entry.shell === 'auto')?.displayName).toBe('Auto - fish');
+  });
+
+  it('throws for unavailable explicit local shells', async () => {
+    await expect(
+      resolveTerminalShell({
+        intent: 'zsh',
+        target: { kind: 'local', platform: 'linux', env: { PATH: '/usr/bin' } },
+        fileExists: () => false,
+      })
+    ).rejects.toBeInstanceOf(ShellUnavailableError);
+  });
+
+  it('marks explicit remote shells for PATH lookup after availability succeeds', async () => {
+    const proxy = {
+      exec: vi.fn((_command, callback) => {
+        callback(undefined, {
+          on(event: string, handler: (code?: number | null) => void) {
+            if (event === 'close') handler(0);
+            return this;
+          },
+          stderr: { on: vi.fn() },
+        });
+      }),
+    } as unknown as SshClientProxy;
+
+    const profile = await resolveTerminalShell({
+      intent: 'bash',
+      target: {
+        kind: 'ssh',
+        proxy,
+        profile: { shell: '/bin/zsh', env: { PATH: '/usr/local/bin:/usr/bin' } },
+      },
+    });
+
+    expect(profile).toMatchObject({
+      id: 'bash',
+      resolvedShellId: 'bash',
+      executable: 'bash',
+      remotePathLookup: true,
+    });
+  });
+
+  it('keeps login-shell args for unknown remote auto shells after normalization', async () => {
+    const profile = await resolveTerminalShell({
+      intent: 'auto',
+      target: {
+        kind: 'ssh',
+        profile: { shell: '/usr/local/bin/fish', env: { PATH: '/usr/local/bin:/usr/bin' } },
+      },
+    });
+
+    expect(profile).toMatchObject({
+      id: 'target-default',
+      resolvedShellId: 'sh',
+      resolvedFromAuto: true,
+      executable: '/bin/sh',
+      displayName: 'Auto - sh',
+      interactiveArgs: ['-i'],
+      commandArgs: ['-c'],
+    });
+  });
+});

--- a/src/main/core/terminal-shell/resolver.test.ts
+++ b/src/main/core/terminal-shell/resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import {
   getLocalTerminalShellAvailability,
+  getRemoteTerminalShellAvailability,
   resolveTerminalShell,
   ShellUnavailableError,
 } from './resolver';
@@ -102,6 +103,7 @@ describe('terminal shell resolver', () => {
 
     expect(availability.find((entry) => entry.shell === 'cmd')).toBeUndefined();
     expect(availability.find((entry) => entry.shell === 'powershell')).toBeUndefined();
+    expect(availability.find((entry) => entry.shell === 'pwsh')).toBeUndefined();
     expect(availability.find((entry) => entry.shell === 'auto')?.displayName).toBe('Auto - zsh');
     expect(availability.find((entry) => entry.shell === 'bash')?.available).toBe(true);
     expect(availability.find((entry) => entry.shell === 'zsh')?.available).toBe(true);
@@ -156,6 +158,43 @@ describe('terminal shell resolver', () => {
       executable: 'bash',
       remotePathLookup: true,
     });
+  });
+
+  it('does not offer PowerShell shells for SSH targets', async () => {
+    const proxy = {
+      exec: vi.fn((_command, callback) => {
+        callback(undefined, {
+          on(event: string, handler: (code?: number | null) => void) {
+            if (event === 'close') handler(0);
+            return this;
+          },
+          stderr: { on: vi.fn() },
+        });
+      }),
+    } as unknown as SshClientProxy;
+
+    const availability = await getRemoteTerminalShellAvailability(proxy, {
+      shell: '/bin/zsh',
+      env: { PATH: '/usr/local/bin:/usr/bin' },
+    });
+
+    expect(availability.find((entry) => entry.shell === 'pwsh')).toBeUndefined();
+    expect(availability.find((entry) => entry.shell === 'powershell')).toBeUndefined();
+  });
+
+  it('rejects explicit remote pwsh even when a proxy is provided', async () => {
+    const proxy = { exec: vi.fn() } as unknown as SshClientProxy;
+
+    await expect(
+      resolveTerminalShell({
+        intent: 'pwsh',
+        target: {
+          kind: 'ssh',
+          proxy,
+          profile: { shell: '/bin/zsh', env: { PATH: '/usr/local/bin:/usr/bin' } },
+        },
+      })
+    ).rejects.toBeInstanceOf(ShellUnavailableError);
   });
 
   it('keeps login-shell args for unknown remote auto shells after normalization', async () => {

--- a/src/main/core/terminal-shell/resolver.ts
+++ b/src/main/core/terminal-shell/resolver.ts
@@ -1,0 +1,352 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import {
+  DEFAULT_REMOTE_SHELL,
+  normalizeRemoteShell,
+  type RemoteShellProfile,
+} from '@main/core/ssh/lifecycle/remote-shell-profile';
+import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
+import { quoteShellArg } from '@main/utils/shellEscape';
+import {
+  isExplicitTerminalShellId,
+  terminalCommandArgs,
+  terminalEnvCaptureArgs,
+  terminalInteractiveShellArgs,
+  terminalShellBasename,
+  terminalShellDisplayName,
+  terminalShellFamily,
+  type ExplicitTerminalShellId,
+  type TerminalShellAvailability,
+  type TerminalShellId,
+} from '@shared/terminal-settings';
+import type { ResolvedShellProfile } from './types';
+
+export type ShellTarget =
+  | { kind: 'local'; platform?: NodeJS.Platform; env?: NodeJS.ProcessEnv }
+  | { kind: 'ssh'; profile: RemoteShellProfile; proxy?: SshClientProxy };
+
+export class ShellUnavailableError extends Error {
+  constructor(
+    readonly shell: TerminalShellId,
+    readonly target: ShellTarget['kind'],
+    message = `${terminalShellDisplayName(shell)} is not available on the ${target} target`
+  ) {
+    super(message);
+    this.name = 'ShellUnavailableError';
+  }
+}
+
+type FileExists = (candidate: string) => boolean;
+
+function isExecutable(filePath: string): boolean {
+  try {
+    fs.accessSync(filePath, fs.constants.X_OK);
+    return fs.statSync(filePath).isFile();
+  } catch {
+    return false;
+  }
+}
+
+function pathDirs(env: NodeJS.ProcessEnv, platform: NodeJS.Platform): string[] {
+  const rawPath =
+    platform === 'win32' ? (env.Path ?? env.PATH ?? env.path ?? '') : (env.PATH ?? '');
+  return rawPath
+    .split(platform === 'win32' ? path.win32.delimiter : path.delimiter)
+    .filter(Boolean);
+}
+
+function windowsPathExts(env: NodeJS.ProcessEnv): string[] {
+  const raw = env.PATHEXT ?? '.COM;.EXE;.BAT;.CMD';
+  return raw
+    .split(';')
+    .map((ext) => ext.trim())
+    .filter(Boolean)
+    .map((ext) => (ext.startsWith('.') ? ext : `.${ext}`));
+}
+
+function findOnPath(
+  shell: string,
+  env: NodeJS.ProcessEnv,
+  platform: NodeJS.Platform,
+  fileExists: FileExists = isExecutable
+): string | undefined {
+  const pathApi = platform === 'win32' ? path.win32 : path;
+  if (pathApi.isAbsolute(shell) && fileExists(shell)) return shell;
+
+  for (const dir of pathDirs(env, platform)) {
+    const candidate = pathApi.join(dir, shell);
+    if (fileExists(candidate)) return candidate;
+
+    if (platform === 'win32' && !path.extname(shell)) {
+      for (const ext of windowsPathExts(env)) {
+        const winCandidate = `${candidate}${ext}`;
+        if (fileExists(winCandidate)) return winCandidate;
+      }
+    }
+  }
+
+  return undefined;
+}
+
+function shellIdFromExecutable(
+  executable: string,
+  fallback: ExplicitTerminalShellId
+): ExplicitTerminalShellId {
+  const base = terminalShellBasename(executable).replace(/\.exe$/, '');
+  return isExplicitTerminalShellId(base) ? base : fallback;
+}
+
+function shellLabelFromExecutable(executable: string, fallback: ExplicitTerminalShellId): string {
+  const base = terminalShellBasename(executable).replace(/\.exe$/, '');
+  return base || terminalShellDisplayName(fallback);
+}
+
+function localDefaultShell(platform: NodeJS.Platform, env: NodeJS.ProcessEnv): string {
+  if (platform === 'win32') return env.ComSpec || 'C:\\Windows\\System32\\cmd.exe';
+  return env.SHELL ?? (platform === 'darwin' ? '/bin/zsh' : '/bin/bash');
+}
+
+function resolveLocalExplicitShell(
+  shell: ExplicitTerminalShellId,
+  platform: NodeJS.Platform,
+  env: NodeJS.ProcessEnv,
+  fileExists?: FileExists
+): string | undefined {
+  if (platform === 'win32') {
+    if (shell === 'cmd') return env.ComSpec || 'C:\\Windows\\System32\\cmd.exe';
+    if (shell === 'powershell')
+      return findOnPath('powershell.exe', env, platform, fileExists) ?? 'powershell.exe';
+    if (shell === 'pwsh') return findOnPath('pwsh.exe', env, platform, fileExists);
+    return findOnPath(shell, env, platform, fileExists);
+  }
+
+  if (shell === 'cmd' || shell === 'powershell') return undefined;
+  return findOnPath(shell, env, platform, fileExists);
+}
+
+function buildProfile({
+  id,
+  resolvedShellId,
+  executable,
+  resolvedFromAuto,
+  capturedEnv,
+  remotePathLookup,
+  shellForArgs = resolvedShellId,
+  displayName,
+}: {
+  id: ExplicitTerminalShellId | 'target-default';
+  resolvedShellId: ExplicitTerminalShellId;
+  executable: string;
+  resolvedFromAuto: boolean;
+  capturedEnv?: Record<string, string>;
+  remotePathLookup?: boolean;
+  shellForArgs?: string;
+  displayName?: string;
+}): ResolvedShellProfile {
+  const family = terminalShellFamily(shellForArgs);
+  return {
+    id,
+    resolvedShellId,
+    resolvedFromAuto,
+    executable,
+    displayName:
+      displayName ??
+      (resolvedFromAuto
+        ? `Auto - ${terminalShellDisplayName(resolvedShellId)}`
+        : terminalShellDisplayName(resolvedShellId)),
+    available: true,
+    family,
+    interactiveArgs: terminalInteractiveShellArgs(shellForArgs),
+    commandArgs: terminalCommandArgs(shellForArgs),
+    envCaptureArgs: terminalEnvCaptureArgs(shellForArgs),
+    capturedEnv,
+    remotePathLookup,
+  };
+}
+
+export async function resolveTerminalShell({
+  intent,
+  target,
+  fileExists,
+}: {
+  intent: TerminalShellId;
+  target: ShellTarget;
+  fileExists?: FileExists;
+}): Promise<ResolvedShellProfile> {
+  if (target.kind === 'local') {
+    const platform = target.platform ?? process.platform;
+    const env = target.env ?? process.env;
+
+    if (intent === 'auto') {
+      const executable = localDefaultShell(platform, env);
+      const resolvedShellId = shellIdFromExecutable(
+        executable,
+        platform === 'win32' ? 'cmd' : 'sh'
+      );
+      return buildProfile({
+        id: 'target-default',
+        resolvedShellId,
+        executable,
+        resolvedFromAuto: true,
+        shellForArgs: executable,
+        displayName: `Auto - ${shellLabelFromExecutable(executable, resolvedShellId)}`,
+      });
+    }
+
+    const executable = resolveLocalExplicitShell(intent, platform, env, fileExists);
+    if (!executable) throw new ShellUnavailableError(intent, 'local');
+    return buildProfile({
+      id: intent,
+      resolvedShellId: intent,
+      executable,
+      resolvedFromAuto: false,
+    });
+  }
+
+  if (intent === 'auto') {
+    const executable = normalizeRemoteShell(target.profile.shell);
+    const resolvedShellId = shellIdFromExecutable(executable, 'sh');
+    return buildProfile({
+      id: 'target-default',
+      resolvedShellId,
+      executable,
+      resolvedFromAuto: true,
+      capturedEnv: target.profile.env,
+      shellForArgs: executable,
+      displayName: `Auto - ${shellLabelFromExecutable(executable, resolvedShellId)}`,
+    });
+  }
+
+  if (target.proxy && !(await isRemoteShellAvailable(target.proxy, intent, target.profile.env))) {
+    throw new ShellUnavailableError(intent, 'ssh');
+  }
+
+  return buildProfile({
+    id: intent,
+    resolvedShellId: intent,
+    executable: intent,
+    resolvedFromAuto: false,
+    capturedEnv: target.profile.env,
+    remotePathLookup: true,
+  });
+}
+
+export async function getLocalTerminalShellAvailability({
+  platform = process.platform,
+  env = process.env,
+  fileExists,
+}: {
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  fileExists?: FileExists;
+} = {}): Promise<TerminalShellAvailability[]> {
+  const targetDefaultShell = localDefaultShell(platform, env);
+  const targetDefaultId = shellIdFromExecutable(
+    targetDefaultShell,
+    platform === 'win32' ? 'cmd' : 'sh'
+  );
+  return sortShellAvailability(
+    shellIdsForLocalPlatform(platform).map((shell) => {
+      if (shell === 'auto') {
+        return {
+          shell,
+          displayName: `Auto - ${shellLabelFromExecutable(targetDefaultShell, targetDefaultId)}`,
+          available: true,
+        };
+      }
+      const executable = resolveLocalExplicitShell(shell, platform, env, fileExists);
+      return {
+        shell,
+        displayName: terminalShellDisplayName(shell),
+        available: executable !== undefined,
+        reason: executable === undefined ? 'Not found on this machine' : undefined,
+      };
+    })
+  );
+}
+
+export async function getRemoteTerminalShellAvailability(
+  proxy: SshClientProxy,
+  profile: RemoteShellProfile
+): Promise<TerminalShellAvailability[]> {
+  const targetDefaultId = shellIdFromExecutable(normalizeRemoteShell(profile.shell), 'sh');
+  const availability = await Promise.all(
+    remoteShellIds().map(async (shell) => {
+      if (shell === 'auto') {
+        return {
+          shell,
+          displayName: `Auto - ${terminalShellDisplayName(targetDefaultId)}`,
+          available: true,
+        };
+      }
+      const available = await isRemoteShellAvailable(proxy, shell, profile.env);
+      return {
+        shell,
+        displayName: terminalShellDisplayName(shell),
+        available,
+        reason: available ? undefined : 'Not found on this SSH target',
+      };
+    })
+  );
+  return sortShellAvailability(availability);
+}
+
+async function isRemoteShellAvailable(
+  proxy: SshClientProxy,
+  shell: ExplicitTerminalShellId,
+  env: Record<string, string>
+): Promise<boolean> {
+  if (shell === 'cmd' || shell === 'powershell') return false;
+  const pathPrefix = env.PATH ? `PATH=${quoteShellArg(env.PATH)} ` : '';
+  const command = `${pathPrefix}command -v ${quoteShellArg(shell)} >/dev/null 2>&1`;
+  try {
+    const result = await execRemote(proxy, `${DEFAULT_REMOTE_SHELL} -c ${quoteShellArg(command)}`);
+    return result.exitCode === 0;
+  } catch {
+    return false;
+  }
+}
+
+function shellIdsForLocalPlatform(platform: NodeJS.Platform): TerminalShellId[] {
+  if (platform === 'win32') return ['auto', 'cmd', 'powershell', 'pwsh', 'bash'];
+  return ['auto', 'bash', 'csh', 'dash', 'ksh', 'pwsh', 'sh', 'tcsh', 'zsh'];
+}
+
+function remoteShellIds(): TerminalShellId[] {
+  return ['auto', 'bash', 'csh', 'dash', 'ksh', 'pwsh', 'sh', 'tcsh', 'zsh'];
+}
+
+function sortShellAvailability(entries: TerminalShellAvailability[]): TerminalShellAvailability[] {
+  return [...entries].sort((a, b) => {
+    if (a.shell === 'auto') return -1;
+    if (b.shell === 'auto') return 1;
+    if (a.available !== b.available) return a.available ? -1 : 1;
+    return 0;
+  });
+}
+
+function execRemote(
+  proxy: SshClientProxy,
+  command: string
+): Promise<{ exitCode: number | null; stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    let stdout = '';
+    let stderr = '';
+    proxy.exec(command, (err, channel) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      channel.on('data', (chunk: Buffer) => {
+        stdout += chunk.toString('utf-8');
+      });
+      channel.stderr.on('data', (chunk: Buffer) => {
+        stderr += chunk.toString('utf-8');
+      });
+      channel.on('close', (code: number | null) => {
+        resolve({ exitCode: code, stdout, stderr });
+      });
+      channel.on('error', reject);
+    });
+  });
+}

--- a/src/main/core/terminal-shell/resolver.ts
+++ b/src/main/core/terminal-shell/resolver.ts
@@ -120,7 +120,7 @@ function resolveLocalExplicitShell(
     return findOnPath(shell, env, platform, fileExists);
   }
 
-  if (shell === 'cmd' || shell === 'powershell') return undefined;
+  if (shell === 'cmd' || shell === 'powershell' || shell === 'pwsh') return undefined;
   return findOnPath(shell, env, platform, fileExists);
 }
 
@@ -296,7 +296,7 @@ async function isRemoteShellAvailable(
   shell: ExplicitTerminalShellId,
   env: Record<string, string>
 ): Promise<boolean> {
-  if (shell === 'cmd' || shell === 'powershell') return false;
+  if (shell === 'cmd' || shell === 'powershell' || shell === 'pwsh') return false;
   const pathPrefix = env.PATH ? `PATH=${quoteShellArg(env.PATH)} ` : '';
   const command = `${pathPrefix}command -v ${quoteShellArg(shell)} >/dev/null 2>&1`;
   try {
@@ -309,11 +309,11 @@ async function isRemoteShellAvailable(
 
 function shellIdsForLocalPlatform(platform: NodeJS.Platform): TerminalShellId[] {
   if (platform === 'win32') return ['auto', 'cmd', 'powershell', 'pwsh', 'bash'];
-  return ['auto', 'bash', 'csh', 'dash', 'ksh', 'pwsh', 'sh', 'tcsh', 'zsh'];
+  return ['auto', 'bash', 'csh', 'dash', 'ksh', 'sh', 'tcsh', 'zsh'];
 }
 
 function remoteShellIds(): TerminalShellId[] {
-  return ['auto', 'bash', 'csh', 'dash', 'ksh', 'pwsh', 'sh', 'tcsh', 'zsh'];
+  return ['auto', 'bash', 'csh', 'dash', 'ksh', 'sh', 'tcsh', 'zsh'];
 }
 
 function sortShellAvailability(entries: TerminalShellAvailability[]): TerminalShellAvailability[] {

--- a/src/main/core/terminal-shell/types.ts
+++ b/src/main/core/terminal-shell/types.ts
@@ -1,0 +1,16 @@
+import type { ExplicitTerminalShellId, TerminalShellFamily } from '@shared/terminal-settings';
+
+export type ResolvedShellProfile = {
+  id: ExplicitTerminalShellId | 'target-default';
+  resolvedShellId: ExplicitTerminalShellId;
+  resolvedFromAuto: boolean;
+  executable: string;
+  displayName: string;
+  available: true;
+  family: TerminalShellFamily;
+  interactiveArgs: string[];
+  commandArgs: string[];
+  envCaptureArgs?: string[];
+  capturedEnv?: Record<string, string>;
+  remotePathLookup?: boolean;
+};

--- a/src/main/core/terminals/controller.ts
+++ b/src/main/core/terminals/controller.ts
@@ -3,6 +3,7 @@ import { createTerminal } from './createTerminal';
 import { deleteTerminal } from './deleteTerminal';
 import { getAllTerminals } from './getAllTerminals';
 import { getTerminalsForTask } from './getTerminalsForTask';
+import { getTerminalShellAvailability } from './getTerminalShellAvailability';
 import { hydrateTerminal } from './hydrateTerminal';
 import { prepareLifecycleScript } from './prepareLifecycleScript';
 import { renameTerminal } from './renameTerminal';
@@ -12,6 +13,7 @@ export const terminalsController = createRPCController({
   getAllTerminals,
   createTerminal,
   deleteTerminal,
+  getTerminalShellAvailability,
   hydrateTerminal,
   prepareLifecycleScript,
   renameTerminal,

--- a/src/main/core/terminals/createTerminal.ts
+++ b/src/main/core/terminals/createTerminal.ts
@@ -30,7 +30,8 @@ export async function createTerminal(params: CreateTerminalParams): Promise<Term
 
   const terminal = mapTerminalRowToTerminal(row);
   await withCompensation({
-    action: () => task.terminals.spawnTerminal(terminal, initialSize),
+    action: () =>
+      task.terminals.spawnTerminal(terminal, initialSize, { shell: params.shell ?? 'auto' }),
     compensate: async () => {
       await db.delete(terminals).where(eq(terminals.id, row.id)).execute();
     },

--- a/src/main/core/terminals/getTerminalShellAvailability.ts
+++ b/src/main/core/terminals/getTerminalShellAvailability.ts
@@ -1,0 +1,21 @@
+import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
+import {
+  getLocalTerminalShellAvailability,
+  getRemoteTerminalShellAvailability,
+} from '@main/core/terminal-shell/resolver';
+
+export async function getTerminalShellAvailability(
+  target?:
+    | {
+        kind: 'local';
+      }
+    | {
+        kind: 'ssh';
+        connectionId: string;
+      }
+) {
+  if (!target || target.kind === 'local') return await getLocalTerminalShellAvailability();
+  const proxy = await sshConnectionManager.connect(target.connectionId);
+  const profile = await proxy.getRemoteShellProfile();
+  return await getRemoteTerminalShellAvailability(proxy, profile);
+}

--- a/src/main/core/terminals/impl/local-terminal-provider.test.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.test.ts
@@ -1,0 +1,78 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import type { PtyExitInfo } from '@main/core/pty/pty';
+import { makePtySessionId } from '@shared/ptySessionId';
+import type { Terminal } from '@shared/terminals';
+import { LocalTerminalProvider } from './local-terminal-provider';
+
+const ptyMock = vi.hoisted(() => ({
+  exitHandlers: [] as Array<(info: PtyExitInfo) => void>,
+}));
+
+vi.mock('@main/core/pty/local-pty', () => ({
+  spawnLocalPty: vi.fn(() => ({
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn((handler: (info: PtyExitInfo) => void) => {
+      ptyMock.exitHandlers.push(handler);
+    }),
+  })),
+}));
+
+vi.mock('@main/core/pty/pty-session-registry', () => ({
+  ptySessionRegistry: {
+    register: vi.fn(),
+    unregister: vi.fn(),
+  },
+}));
+
+vi.mock('../dev-server-watcher', () => ({
+  wireTerminalDevServerWatcher: vi.fn(),
+}));
+
+const terminal: Terminal = {
+  id: 'terminal-1',
+  projectId: 'project-1',
+  taskId: 'task-1',
+  name: 'Terminal 1',
+};
+
+const ctx = {
+  supportsLocalSpawn: true,
+  exec: vi.fn(),
+  execStreaming: vi.fn(),
+  dispose: vi.fn(),
+} satisfies IExecutionContext;
+
+describe('LocalTerminalProvider', () => {
+  beforeEach(() => {
+    ptyMock.exitHandlers.length = 0;
+  });
+
+  it('cleans up cached shell profiles after a non-respawned exit', async () => {
+    const provider = new LocalTerminalProvider({
+      projectId: terminal.projectId,
+      scopeId: terminal.taskId,
+      taskPath: '/repo',
+      ctx,
+    });
+
+    await provider.spawnLifecycleScript({
+      terminal,
+      command: 'echo ready',
+    });
+
+    const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
+    expect(
+      (provider as unknown as { shellProfiles: Map<string, unknown> }).shellProfiles.has(sessionId)
+    ).toBe(true);
+
+    for (const handler of ptyMock.exitHandlers) handler({ exitCode: 0 });
+
+    expect(
+      (provider as unknown as { shellProfiles: Map<string, unknown> }).shellProfiles.has(sessionId)
+    ).toBe(false);
+  });
+});

--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -11,11 +11,18 @@ import {
   type PtySpawnIntent,
 } from '@main/core/pty/pty-spawn-platform';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { resolveTerminalShell } from '@main/core/terminal-shell/resolver';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { log } from '@main/lib/logger';
 import { makePtySessionId } from '@shared/ptySessionId';
+import type { TerminalShellId } from '@shared/terminal-settings';
 import type { Terminal } from '@shared/terminals';
 import { wireTerminalDevServerWatcher } from '../dev-server-watcher';
-import { type LifecycleScriptSpawnRequest, type TerminalProvider } from '../terminal-provider';
+import {
+  type LifecycleScriptSpawnRequest,
+  type TerminalProvider,
+  type TerminalSpawnOptions,
+} from '../terminal-provider';
 
 const DEFAULT_COLS = 80;
 const DEFAULT_ROWS = 24;
@@ -30,6 +37,7 @@ type SpawnPolicy = {
 export class LocalTerminalProvider implements TerminalProvider {
   private sessions = new Map<string, Pty>();
   private knownSessionIds = new Set<string>();
+  private shellProfiles = new Map<string, ResolvedShellProfile>();
   private respawnCounts = new Map<string, number>();
   private readonly projectId: string;
   private readonly scopeId: string;
@@ -68,13 +76,16 @@ export class LocalTerminalProvider implements TerminalProvider {
   async spawnTerminal(
     terminal: Terminal,
     initialSize: { cols: number; rows: number } = { cols: DEFAULT_COLS, rows: DEFAULT_ROWS },
-    command?: { command: string; args: string[] }
+    options: TerminalSpawnOptions = {}
   ): Promise<void> {
     return this.spawnWithPolicy(
       terminal,
       initialSize,
-      command ? { kind: 'argv', command: command.command, args: command.args } : undefined,
+      options.command
+        ? { kind: 'argv', command: options.command.command, args: options.command.args }
+        : undefined,
       undefined,
+      options.shell ?? 'auto',
       {
         respawnOnExit: true,
         preserveBufferOnExit: false,
@@ -97,6 +108,7 @@ export class LocalTerminalProvider implements TerminalProvider {
       initialSize,
       command === undefined ? undefined : { kind: 'shell-line', commandLine: command },
       shellSetup,
+      'auto',
       {
         respawnOnExit,
         preserveBufferOnExit,
@@ -110,23 +122,27 @@ export class LocalTerminalProvider implements TerminalProvider {
     initialSize: { cols: number; rows: number },
     command: PtyCommandSpec | undefined,
     shellSetup: string | undefined,
+    shellIntent: TerminalShellId,
     policy: SpawnPolicy
   ): Promise<void> {
     const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
     this.knownSessionIds.add(sessionId);
     if (this.sessions.has(sessionId)) return;
+    const shellProfile = await this.getSessionShellProfile(sessionId, shellIntent);
 
     const intent: PtySpawnIntent = command
       ? {
           kind: 'run-command',
           cwd: this.taskPath,
           command,
+          shellProfile,
           shellSetup: shellSetup ?? this.shellSetup,
           tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
         }
       : {
           kind: 'interactive-shell',
           cwd: this.taskPath,
+          shellProfile,
           shellSetup: shellSetup ?? this.shellSetup,
           tmuxSessionName: this.tmux ? makeTmuxSessionName(sessionId) : undefined,
         };
@@ -146,7 +162,7 @@ export class LocalTerminalProvider implements TerminalProvider {
       command: resolved.command,
       args: resolved.args,
       cwd: resolved.cwd,
-      env: { ...buildTerminalEnv(), ...this.taskEnvVars },
+      env: { ...buildTerminalEnv({ shellProfile }), ...this.taskEnvVars },
       cols: initialSize.cols,
       rows: initialSize.rows,
     });
@@ -178,7 +194,14 @@ export class LocalTerminalProvider implements TerminalProvider {
         }
 
         setTimeout(() => {
-          this.spawnWithPolicy(terminal, initialSize, command, shellSetup, policy).catch((e) => {
+          this.spawnWithPolicy(
+            terminal,
+            initialSize,
+            command,
+            shellSetup,
+            shellIntent,
+            policy
+          ).catch((e) => {
             log.error('LocalTerminalProvider: respawn failed', {
               terminalId: terminal.id,
               error: String(e),
@@ -194,6 +217,20 @@ export class LocalTerminalProvider implements TerminalProvider {
     this.sessions.set(sessionId, pty);
   }
 
+  private async getSessionShellProfile(
+    sessionId: string,
+    shellIntent: TerminalShellId
+  ): Promise<ResolvedShellProfile> {
+    const existing = this.shellProfiles.get(sessionId);
+    if (existing) return existing;
+    const profile = await resolveTerminalShell({
+      intent: shellIntent,
+      target: { kind: 'local' },
+    });
+    this.shellProfiles.set(sessionId, profile);
+    return profile;
+  }
+
   async killTerminal(terminalId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.scopeId, terminalId);
     this.knownSessionIds.delete(sessionId);
@@ -205,6 +242,7 @@ export class LocalTerminalProvider implements TerminalProvider {
       this.sessions.delete(sessionId);
       ptySessionRegistry.unregister(sessionId);
     }
+    this.shellProfiles.delete(sessionId);
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
@@ -217,6 +255,7 @@ export class LocalTerminalProvider implements TerminalProvider {
       await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
     }
     this.knownSessionIds.clear();
+    this.shellProfiles.clear();
   }
 
   async detachAll(): Promise<void> {
@@ -225,6 +264,7 @@ export class LocalTerminalProvider implements TerminalProvider {
         pty.kill();
       } catch {}
       ptySessionRegistry.unregister(sessionId);
+      this.shellProfiles.delete(sessionId);
     }
     this.sessions.clear();
   }

--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -190,6 +190,7 @@ export class LocalTerminalProvider implements TerminalProvider {
             respawnCount: count,
           });
           this.respawnCounts.delete(sessionId);
+          this.shellProfiles.delete(sessionId);
           return;
         }
 
@@ -208,6 +209,8 @@ export class LocalTerminalProvider implements TerminalProvider {
             });
           });
         }, 500);
+      } else {
+        this.shellProfiles.delete(sessionId);
       }
     });
 

--- a/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import type { PtyExitInfo } from '@main/core/pty/pty';
+import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
+import { makePtySessionId } from '@shared/ptySessionId';
+import type { Terminal } from '@shared/terminals';
+import { SshTerminalProvider } from './ssh-terminal-provider';
+
+const ptyMock = vi.hoisted(() => ({
+  exitHandlers: [] as Array<(info: PtyExitInfo) => void>,
+}));
+
+vi.mock('@main/core/pty/ssh2-pty', () => ({
+  openSsh2Pty: vi.fn(async () => ({
+    success: true,
+    data: {
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn((handler: (info: PtyExitInfo) => void) => {
+        ptyMock.exitHandlers.push(handler);
+      }),
+    },
+  })),
+}));
+
+vi.mock('@main/core/pty/pty-session-registry', () => ({
+  ptySessionRegistry: {
+    register: vi.fn(),
+    unregister: vi.fn(),
+  },
+}));
+
+vi.mock('@main/core/ssh/lifecycle/production-ssh-connection-manager', () => ({
+  sshConnectionManager: {
+    on: vi.fn(),
+    off: vi.fn(),
+  },
+}));
+
+vi.mock('../dev-server-watcher', () => ({
+  wireTerminalDevServerWatcher: vi.fn(),
+}));
+
+const terminal: Terminal = {
+  id: 'terminal-1',
+  projectId: 'project-1',
+  taskId: 'task-1',
+  name: 'Terminal 1',
+};
+
+const ctx = {
+  supportsLocalSpawn: false,
+  exec: vi.fn(),
+  execStreaming: vi.fn(),
+  dispose: vi.fn(),
+} satisfies IExecutionContext;
+
+const proxy = {
+  getRemoteShellProfile: vi.fn(async () => ({
+    shell: '/bin/bash',
+    env: { PATH: '/usr/bin', HOME: '/home/me' },
+  })),
+} satisfies Partial<SshClientProxy> as unknown as SshClientProxy;
+
+describe('SshTerminalProvider', () => {
+  beforeEach(() => {
+    ptyMock.exitHandlers.length = 0;
+    proxy.getRemoteShellProfile = vi.fn(async () => ({
+      shell: '/bin/bash',
+      env: { PATH: '/usr/bin', HOME: '/home/me' },
+    }));
+  });
+
+  it('cleans up cached shell profiles after a non-respawned exit', async () => {
+    const provider = new SshTerminalProvider({
+      projectId: terminal.projectId,
+      scopeId: terminal.taskId,
+      taskPath: '/repo',
+      ctx,
+      proxy,
+      connectionId: 'ssh-1',
+    });
+
+    await provider.spawnLifecycleScript({
+      terminal,
+      command: 'echo ready',
+    });
+
+    const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
+    expect(
+      (provider as unknown as { shellProfiles: Map<string, unknown> }).shellProfiles.has(sessionId)
+    ).toBe(true);
+
+    for (const handler of ptyMock.exitHandlers) handler({ exitCode: 0 });
+
+    expect(
+      (provider as unknown as { shellProfiles: Map<string, unknown> }).shellProfiles.has(sessionId)
+    ).toBe(false);
+  });
+});

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -209,6 +209,7 @@ export class SshTerminalProvider implements TerminalProvider {
             respawnCount: count,
           });
           this.respawnCounts.delete(sessionId);
+          this.shellProfiles.delete(sessionId);
           return;
         }
 
@@ -227,6 +228,8 @@ export class SshTerminalProvider implements TerminalProvider {
             });
           });
         }, 500);
+      } else {
+        this.shellProfiles.delete(sessionId);
       }
     });
 

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -8,13 +8,17 @@ import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-sessio
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import type { SshConnectionManagerEvent } from '@main/core/ssh/lifecycle/ssh-connection-manager';
+import { resolveTerminalShell } from '@main/core/terminal-shell/resolver';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import {
   type LifecycleScriptSpawnRequest,
   type TerminalProvider,
+  type TerminalSpawnOptions,
 } from '@main/core/terminals/terminal-provider';
 import { log } from '@main/lib/logger';
 import type { GeneralSessionConfig } from '@shared/general-session';
 import { makePtySessionId } from '@shared/ptySessionId';
+import type { TerminalShellId } from '@shared/terminal-settings';
 import type { Terminal } from '@shared/terminals';
 import { wireTerminalDevServerWatcher } from '../dev-server-watcher';
 
@@ -32,6 +36,7 @@ type SpawnPolicy = {
 export class SshTerminalProvider implements TerminalProvider {
   private sessions = new Map<string, Pty>();
   private knownSessionIds = new Set<string>();
+  private shellProfiles = new Map<string, ResolvedShellProfile>();
   private respawnCounts = new Map<string, number>();
   private terminals = new Map<string, Terminal>();
   private readonly projectId: string;
@@ -92,14 +97,21 @@ export class SshTerminalProvider implements TerminalProvider {
   async spawnTerminal(
     terminal: Terminal,
     initialSize: { cols: number; rows: number } = { cols: DEFAULT_COLS, rows: DEFAULT_ROWS },
-    command?: { command: string; args: string[] }
+    options: TerminalSpawnOptions = {}
   ): Promise<void> {
-    return this.spawnWithPolicy(terminal, initialSize, command, undefined, {
-      respawnOnExit: true,
-      preserveBufferOnExit: false,
-      watchDevServer: true,
-      trackForRehydrate: true,
-    });
+    return this.spawnWithPolicy(
+      terminal,
+      initialSize,
+      options.command,
+      undefined,
+      options.shell ?? 'auto',
+      {
+        respawnOnExit: true,
+        preserveBufferOnExit: false,
+        watchDevServer: true,
+        trackForRehydrate: true,
+      }
+    );
   }
 
   async spawnLifecycleScript({
@@ -116,6 +128,7 @@ export class SshTerminalProvider implements TerminalProvider {
       initialSize,
       command === undefined ? undefined : { command, args: [] },
       shellSetup,
+      'auto',
       {
         respawnOnExit,
         preserveBufferOnExit,
@@ -130,6 +143,7 @@ export class SshTerminalProvider implements TerminalProvider {
     initialSize: { cols: number; rows: number },
     command: { command: string; args: string[] } | undefined,
     shellSetup: string | undefined,
+    shellIntent: TerminalShellId,
     policy: SpawnPolicy
   ): Promise<void> {
     const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
@@ -148,8 +162,8 @@ export class SshTerminalProvider implements TerminalProvider {
       args: command?.args,
     };
 
-    const profile = await this.proxy.getRemoteShellProfile();
-    const sshCommand = resolveSshCommand('general', cfg, this.taskEnvVars, profile);
+    const shellProfile = await this.getSessionShellProfile(sessionId, shellIntent);
+    const sshCommand = resolveSshCommand('general', cfg, this.taskEnvVars, shellProfile);
 
     const result = await openSsh2Pty(this.proxy, {
       id: sessionId,
@@ -199,7 +213,14 @@ export class SshTerminalProvider implements TerminalProvider {
         }
 
         setTimeout(() => {
-          this.spawnWithPolicy(terminal, initialSize, command, shellSetup, policy).catch((e) => {
+          this.spawnWithPolicy(
+            terminal,
+            initialSize,
+            command,
+            shellSetup,
+            shellIntent,
+            policy
+          ).catch((e) => {
             log.error('SshTerminalProvider: respawn failed', {
               terminalId: terminal.id,
               error: String(e),
@@ -213,6 +234,21 @@ export class SshTerminalProvider implements TerminalProvider {
       preserveBufferOnExit: policy.preserveBufferOnExit,
     });
     this.sessions.set(sessionId, pty);
+  }
+
+  private async getSessionShellProfile(
+    sessionId: string,
+    shellIntent: TerminalShellId
+  ): Promise<ResolvedShellProfile> {
+    const existing = this.shellProfiles.get(sessionId);
+    if (existing) return existing;
+    const remoteProfile = await this.proxy.getRemoteShellProfile();
+    const profile = await resolveTerminalShell({
+      intent: shellIntent,
+      target: { kind: 'ssh', proxy: this.proxy, profile: remoteProfile },
+    });
+    this.shellProfiles.set(sessionId, profile);
+    return profile;
   }
 
   /**
@@ -248,6 +284,7 @@ export class SshTerminalProvider implements TerminalProvider {
       ptySessionRegistry.unregister(sessionId);
     }
     this.terminals.delete(terminalId);
+    this.shellProfiles.delete(sessionId);
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
@@ -262,6 +299,7 @@ export class SshTerminalProvider implements TerminalProvider {
     }
     this.knownSessionIds.clear();
     this.terminals.clear();
+    this.shellProfiles.clear();
   }
 
   async detachAll(): Promise<void> {
@@ -270,6 +308,7 @@ export class SshTerminalProvider implements TerminalProvider {
         pty.kill();
       } catch {}
       ptySessionRegistry.unregister(sessionId);
+      this.shellProfiles.delete(sessionId);
     }
     this.sessions.clear();
   }

--- a/src/main/core/terminals/terminal-provider.ts
+++ b/src/main/core/terminals/terminal-provider.ts
@@ -1,3 +1,4 @@
+import type { TerminalShellId } from '@shared/terminal-settings';
 import type { Terminal } from '@shared/terminals';
 
 export type LifecycleScriptSpawnRequest = {
@@ -10,11 +11,16 @@ export type LifecycleScriptSpawnRequest = {
   watchDevServer?: boolean;
 };
 
+export type TerminalSpawnOptions = {
+  command?: { command: string; args: string[] };
+  shell?: TerminalShellId;
+};
+
 export interface TerminalProvider {
   spawnTerminal(
     terminal: Terminal,
     initialSize?: { cols: number; rows: number },
-    command?: { command: string; args: string[] }
+    options?: TerminalSpawnOptions
   ): Promise<void>;
   spawnLifecycleScript(request: LifecycleScriptSpawnRequest): Promise<void>;
   killTerminal(terminalId: string): Promise<void>;

--- a/src/main/utils/shellEscape.ts
+++ b/src/main/utils/shellEscape.ts
@@ -10,6 +10,10 @@ export function quoteShellArg(arg: string): string {
   return `'${arg.replace(/'/g, "'\\''")}'`;
 }
 
+export function quoteCshArg(arg: string): string {
+  return quoteShellArg(arg).replace(/!/g, '\\!');
+}
+
 /**
  * Validates that a string is a safe POSIX environment variable name.
  * Must start with a letter or underscore, followed by letters, digits, or underscores.

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -13,6 +13,7 @@ import { snapshotRegistry } from '@renderer/lib/stores/snapshot-registry';
 import { focusTracker } from '@renderer/utils/focus-tracker';
 import { log } from '@renderer/utils/logger';
 import type { Task } from '@shared/tasks';
+import type { TerminalShellId } from '@shared/terminal-settings';
 import type {
   DiffViewSnapshot,
   TaskViewSnapshot,
@@ -326,7 +327,7 @@ export class WorkspaceViewModel implements ILifecycle {
         );
       },
       (shouldCreate) => {
-        if (shouldCreate) void this._createDefaultTerminal();
+        if (shouldCreate) void this._createDefaultTerminal('auto');
       }
     );
     this._sessionDisposers.push(terminalsDisposer);
@@ -414,11 +415,11 @@ export class WorkspaceViewModel implements ILifecycle {
   }
 
   /** Opens the terminal drawer and always creates a new terminal session. */
-  async openNewTerminal(): Promise<string | undefined> {
+  async openNewTerminal(shell: TerminalShellId = 'auto'): Promise<string | undefined> {
     this.isTerminalDrawerOpen = true;
     this.setFocusedRegion('bottom');
 
-    const terminalId = await this._createDefaultTerminal();
+    const terminalId = await this._createDefaultTerminal(shell);
     if (!terminalId) return undefined;
     runInAction(() => {
       this.terminalTabs.setActiveTab(terminalId);
@@ -427,12 +428,12 @@ export class WorkspaceViewModel implements ILifecycle {
     return terminalId;
   }
 
-  private async _createDefaultTerminal(): Promise<string | undefined> {
+  private async _createDefaultTerminal(shell: TerminalShellId): Promise<string | undefined> {
     if (this._isCreatingTerminal) return undefined;
 
     this._isCreatingTerminal = true;
     try {
-      const terminal = await terminalRegistry.get(this.taskId)?.createDefaultTerminal();
+      const terminal = await terminalRegistry.get(this.taskId)?.createDefaultTerminal(shell);
       if (!terminal) return undefined;
       return terminal.id;
     } catch (error) {

--- a/src/renderer/features/tasks/terminals/terminal-drawer-sidebar.tsx
+++ b/src/renderer/features/tasks/terminals/terminal-drawer-sidebar.tsx
@@ -1,14 +1,22 @@
-import { Pause, Play, Plus, Settings, Terminal, X } from 'lucide-react';
+import { ChevronDown, Pause, Play, Plus, Settings, Terminal, X } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useEffect, useRef, useState, type ReactNode } from 'react';
 import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import { type LifecycleScriptsStore } from '@renderer/features/tasks/stores/lifecycle-scripts';
 import { type TerminalTabViewStore } from '@renderer/features/tasks/terminals/terminal-tab-view-store';
 import { useNavigate } from '@renderer/lib/layout/navigation-provider';
+import { Button } from '@renderer/lib/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@renderer/lib/ui/dropdown-menu';
 import { MicroLabel } from '@renderer/lib/ui/label';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
+import type { TerminalShellAvailability, TerminalShellId } from '@shared/terminal-settings';
 import { scriptIcon } from './terminal-tabs';
 
 interface TerminalDrawerSidebarProps {
@@ -19,8 +27,9 @@ interface TerminalDrawerSidebarProps {
   onStopScript: (id: string) => void;
   terminalTabView: TerminalTabViewStore;
   activeTerminalId: string | undefined;
+  shellAvailability: TerminalShellAvailability[];
   onSelectTerminal: (id: string) => void;
-  onAddTerminal: () => void;
+  onAddTerminal: (shell?: TerminalShellId) => void;
   onRemoveTerminal: (id: string) => void;
   onRenameTerminal: (id: string, name: string) => void;
   onHoverTerminal?: (id: string) => void;
@@ -36,6 +45,7 @@ export const TerminalDrawerSidebar = observer(function TerminalDrawerSidebar({
   onStopScript,
   terminalTabView,
   activeTerminalId,
+  shellAvailability,
   onSelectTerminal,
   onAddTerminal,
   onRemoveTerminal,
@@ -55,19 +65,47 @@ export const TerminalDrawerSidebar = observer(function TerminalDrawerSidebar({
       <Section
         label="Terminals"
         action={
-          <Tooltip>
-            <TooltipTrigger>
-              <button
-                className="flex size-5 items-center justify-center rounded text-foreground-muted hover:bg-background-2 hover:text-foreground"
-                onClick={onAddTerminal}
+          <div className="flex items-center">
+            <Tooltip>
+              <TooltipTrigger>
+                <button
+                  className="flex size-5 items-center justify-center rounded-l text-foreground-muted hover:bg-background-2 hover:text-foreground"
+                  onClick={() => onAddTerminal('auto')}
+                >
+                  <Plus className="size-3" />
+                </button>
+              </TooltipTrigger>
+              <TooltipContent>
+                New terminal <BoundShortcut settingsKey="newTerminal" variant="badge" />
+              </TooltipContent>
+            </Tooltip>
+            <DropdownMenu>
+              <DropdownMenuTrigger
+                render={
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    className="size-5 rounded-l-none px-0 text-foreground-muted hover:bg-background-2 hover:text-foreground"
+                    aria-label="New terminal with shell"
+                  />
+                }
               >
-                <Plus className="size-3" />
-              </button>
-            </TooltipTrigger>
-            <TooltipContent>
-              New terminal <BoundShortcut settingsKey="newTerminal" variant="badge" />
-            </TooltipContent>
-          </Tooltip>
+                <ChevronDown className="size-3" />
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-40">
+                {shellAvailability.map((entry) => (
+                  <DropdownMenuItem
+                    key={entry.shell}
+                    disabled={!entry.available}
+                    title={entry.reason}
+                    onClick={() => onAddTerminal(entry.shell)}
+                  >
+                    {entry.displayName}
+                  </DropdownMenuItem>
+                ))}
+              </DropdownMenuContent>
+            </DropdownMenu>
+          </div>
         }
       >
         {terminals.map((terminal) => (

--- a/src/renderer/features/tasks/terminals/terminal-drawer-sidebar.tsx
+++ b/src/renderer/features/tasks/terminals/terminal-drawer-sidebar.tsx
@@ -28,6 +28,7 @@ interface TerminalDrawerSidebarProps {
   terminalTabView: TerminalTabViewStore;
   activeTerminalId: string | undefined;
   shellAvailability: TerminalShellAvailability[];
+  onShellMenuOpen: () => void;
   onSelectTerminal: (id: string) => void;
   onAddTerminal: (shell?: TerminalShellId) => void;
   onRemoveTerminal: (id: string) => void;
@@ -46,6 +47,7 @@ export const TerminalDrawerSidebar = observer(function TerminalDrawerSidebar({
   terminalTabView,
   activeTerminalId,
   shellAvailability,
+  onShellMenuOpen,
   onSelectTerminal,
   onAddTerminal,
   onRemoveTerminal,
@@ -79,7 +81,7 @@ export const TerminalDrawerSidebar = observer(function TerminalDrawerSidebar({
                 New terminal <BoundShortcut settingsKey="newTerminal" variant="badge" />
               </TooltipContent>
             </Tooltip>
-            <DropdownMenu>
+            <DropdownMenu onOpenChange={(open) => open && onShellMenuOpen()}>
               <DropdownMenuTrigger
                 render={
                   <Button

--- a/src/renderer/features/tasks/terminals/terminal-manager.ts
+++ b/src/renderer/features/tasks/terminals/terminal-manager.ts
@@ -5,6 +5,7 @@ import { PtySession } from '@renderer/lib/pty/pty-session';
 import type { IDisposable } from '@renderer/lib/stores/lifecycle';
 import { Resource } from '@renderer/lib/stores/resource';
 import { makePtySessionId } from '@shared/ptySessionId';
+import type { TerminalShellId } from '@shared/terminal-settings';
 import { type CreateTerminalParams, type Terminal } from '@shared/terminals';
 import { nextTerminalName } from './terminal-tabs';
 
@@ -103,11 +104,17 @@ export class TerminalManagerStore implements IDisposable {
     }
   }
 
-  async createDefaultTerminal(): Promise<Terminal> {
+  async createDefaultTerminal(shell: TerminalShellId = 'auto'): Promise<Terminal> {
     const names = Array.from(this.terminals.values()).map((t) => t.data.name);
     const name = nextTerminalName(names);
     const id = crypto.randomUUID();
-    return this.createTerminal({ id, projectId: this.projectId, taskId: this.taskId, name });
+    return this.createTerminal({
+      id,
+      projectId: this.projectId,
+      taskId: this.taskId,
+      name,
+      shell,
+    });
   }
 
   async deleteTerminal(terminalId: string): Promise<void> {

--- a/src/renderer/features/tasks/terminals/terminal-panel.tsx
+++ b/src/renderer/features/tasks/terminals/terminal-panel.tsx
@@ -36,8 +36,9 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
   const isActive = useIsActiveTask(taskId);
   const remoteConnectionId = workspace.sshConnectionId;
   const [isPanelFocused, setIsPanelFocused] = useState(false);
+  const [shouldLoadShellAvailability, setShouldLoadShellAvailability] = useState(false);
   const { data: shellAvailability = DEFAULT_TERMINAL_SHELL_AVAILABILITY } =
-    useTerminalShellAvailability(remoteConnectionId);
+    useTerminalShellAvailability(remoteConnectionId, { enabled: shouldLoadShellAvailability });
 
   const autoFocus =
     isActive && taskView.isTerminalDrawerOpen && taskView.focusedRegion === 'bottom';
@@ -172,6 +173,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
           terminalTabView={terminalTabView}
           activeTerminalId={activeTerminalId}
           shellAvailability={shellAvailability}
+          onShellMenuOpen={() => setShouldLoadShellAvailability(true)}
           onSelectTerminal={(id) => {
             terminalTabView.setActiveTab(id);
             taskView.setTerminalDrawerActiveItem({ kind: 'terminal', id });

--- a/src/renderer/features/tasks/terminals/terminal-panel.tsx
+++ b/src/renderer/features/tasks/terminals/terminal-panel.tsx
@@ -15,10 +15,15 @@ import { Button } from '@renderer/lib/ui/button';
 import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@renderer/lib/ui/resizable';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
+import type { TerminalShellId } from '@shared/terminal-settings';
 import { useIsActiveTask } from '../hooks/use-is-active-task';
 import { TerminalDrawerSidebar } from './terminal-drawer-sidebar';
 import { resolveTerminalPanelActiveItem } from './terminal-panel-selection';
 import { TerminalPtyContent } from './terminal-pty-content';
+import {
+  DEFAULT_TERMINAL_SHELL_AVAILABILITY,
+  useTerminalShellAvailability,
+} from './use-terminal-shell-availability';
 
 export const TerminalsPanel = observer(function TerminalsPanel() {
   const { projectId, taskId } = useTaskViewContext();
@@ -31,6 +36,8 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
   const isActive = useIsActiveTask(taskId);
   const remoteConnectionId = workspace.sshConnectionId;
   const [isPanelFocused, setIsPanelFocused] = useState(false);
+  const { data: shellAvailability = DEFAULT_TERMINAL_SHELL_AVAILABILITY } =
+    useTerminalShellAvailability(remoteConnectionId);
 
   const autoFocus =
     isActive && taskView.isTerminalDrawerOpen && taskView.focusedRegion === 'bottom';
@@ -69,8 +76,8 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
     activeItem.kind === 'terminal' ? terminalTabView : (lifecycleScriptsMgr ?? undefined);
   useTabShortcuts(activeStore, { focused: isPanelFocused });
 
-  const handleCreate = async () => {
-    await taskView.openNewTerminal();
+  const handleCreate = async (shell: TerminalShellId = 'auto') => {
+    await taskView.openNewTerminal(shell);
   };
 
   const handleRunScript = (id: string) => {
@@ -105,7 +112,7 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
         <Button
           size="sm"
           variant="outline"
-          onClick={handleCreate}
+          onClick={() => void handleCreate()}
           className="flex items-center gap-2"
         >
           New terminal
@@ -164,11 +171,12 @@ export const TerminalsPanel = observer(function TerminalsPanel() {
           onStopScript={handleStopScript}
           terminalTabView={terminalTabView}
           activeTerminalId={activeTerminalId}
+          shellAvailability={shellAvailability}
           onSelectTerminal={(id) => {
             terminalTabView.setActiveTab(id);
             taskView.setTerminalDrawerActiveItem({ kind: 'terminal', id });
           }}
-          onAddTerminal={() => void handleCreate()}
+          onAddTerminal={(shell) => void handleCreate(shell)}
           onRemoveTerminal={(id) => terminalTabView.removeTab(id)}
           onRenameTerminal={(id, name) => void terminalMgr?.renameTerminal(id, name)}
           onHoverTerminal={handleHoverTerminal}

--- a/src/renderer/features/tasks/terminals/use-terminal-shell-availability.ts
+++ b/src/renderer/features/tasks/terminals/use-terminal-shell-availability.ts
@@ -10,6 +10,7 @@ export function useTerminalShellAvailability(
   remoteConnectionId: string | undefined,
   options: { enabled?: boolean } = {}
 ) {
+  const isRemote = Boolean(remoteConnectionId);
   return useQuery({
     queryKey: ['terminal-shell-availability', remoteConnectionId ?? 'local'],
     queryFn: () =>
@@ -19,7 +20,7 @@ export function useTerminalShellAvailability(
             connectionId: remoteConnectionId,
           })
         : rpc.terminals.getTerminalShellAvailability({ kind: 'local' }),
-    staleTime: 30_000,
+    staleTime: isRemote ? 5_000 : 30_000,
     enabled: options.enabled ?? true,
   });
 }

--- a/src/renderer/features/tasks/terminals/use-terminal-shell-availability.ts
+++ b/src/renderer/features/tasks/terminals/use-terminal-shell-availability.ts
@@ -6,7 +6,10 @@ export const DEFAULT_TERMINAL_SHELL_AVAILABILITY: TerminalShellAvailability[] = 
   { shell: 'auto', displayName: 'Auto', available: true },
 ];
 
-export function useTerminalShellAvailability(remoteConnectionId: string | undefined) {
+export function useTerminalShellAvailability(
+  remoteConnectionId: string | undefined,
+  options: { enabled?: boolean } = {}
+) {
   return useQuery({
     queryKey: ['terminal-shell-availability', remoteConnectionId ?? 'local'],
     queryFn: () =>
@@ -17,5 +20,6 @@ export function useTerminalShellAvailability(remoteConnectionId: string | undefi
           })
         : rpc.terminals.getTerminalShellAvailability({ kind: 'local' }),
     staleTime: 30_000,
+    enabled: options.enabled ?? true,
   });
 }

--- a/src/renderer/features/tasks/terminals/use-terminal-shell-availability.ts
+++ b/src/renderer/features/tasks/terminals/use-terminal-shell-availability.ts
@@ -1,0 +1,21 @@
+import { useQuery } from '@tanstack/react-query';
+import { rpc } from '@renderer/lib/ipc';
+import type { TerminalShellAvailability } from '@shared/terminal-settings';
+
+export const DEFAULT_TERMINAL_SHELL_AVAILABILITY: TerminalShellAvailability[] = [
+  { shell: 'auto', displayName: 'Auto', available: true },
+];
+
+export function useTerminalShellAvailability(remoteConnectionId: string | undefined) {
+  return useQuery({
+    queryKey: ['terminal-shell-availability', remoteConnectionId ?? 'local'],
+    queryFn: () =>
+      remoteConnectionId
+        ? rpc.terminals.getTerminalShellAvailability({
+            kind: 'ssh',
+            connectionId: remoteConnectionId,
+          })
+        : rpc.terminals.getTerminalShellAvailability({ kind: 'local' }),
+    staleTime: 30_000,
+  });
+}

--- a/src/shared/terminal-settings.ts
+++ b/src/shared/terminal-settings.ts
@@ -1,3 +1,97 @@
 export const TERMINAL_FONT_SIZE_DEFAULT = 13;
 export const TERMINAL_FONT_SIZE_MIN = 8;
 export const TERMINAL_FONT_SIZE_MAX = 32;
+
+export const TERMINAL_SHELL_IDS = [
+  'auto',
+  'bash',
+  'cmd',
+  'csh',
+  'dash',
+  'ksh',
+  'powershell',
+  'pwsh',
+  'sh',
+  'tcsh',
+  'zsh',
+] as const;
+
+export type TerminalShellId = (typeof TERMINAL_SHELL_IDS)[number];
+export type ExplicitTerminalShellId = Exclude<TerminalShellId, 'auto'>;
+export type TerminalShellFamily = 'posix' | 'csh' | 'windows-cmd' | 'powershell';
+
+export type TerminalShellAvailability = {
+  shell: TerminalShellId;
+  displayName: string;
+  available: boolean;
+  reason?: string;
+};
+
+const CSH_SHELLS = new Set<string>(['csh', 'tcsh']);
+const BASIC_INTERACTIVE_SHELLS = new Set<string>(['csh', 'dash', 'sh', 'tcsh']);
+
+export function terminalShellBasename(shell: string): string {
+  return shell.split(/[\\/]/).pop()?.toLowerCase() ?? '';
+}
+
+export function isExplicitTerminalShellId(shell: string): shell is ExplicitTerminalShellId {
+  return TERMINAL_SHELL_IDS.includes(shell as TerminalShellId) && shell !== 'auto';
+}
+
+export function terminalShellDisplayName(shell: TerminalShellId): string {
+  switch (shell) {
+    case 'auto':
+      return 'Auto';
+    case 'cmd':
+      return 'cmd';
+    case 'powershell':
+      return 'powershell';
+    case 'pwsh':
+      return 'pwsh';
+    default:
+      return shell;
+  }
+}
+
+export function isCshShell(shell: string): boolean {
+  return CSH_SHELLS.has(terminalShellBasename(shell));
+}
+
+export function terminalShellFamily(shell: string): TerminalShellFamily {
+  const base = terminalShellBasename(shell);
+  if (base === 'cmd' || base === 'cmd.exe') return 'windows-cmd';
+  if (base === 'powershell' || base === 'powershell.exe' || base === 'pwsh' || base === 'pwsh.exe')
+    return 'powershell';
+  if (CSH_SHELLS.has(base)) return 'csh';
+  return 'posix';
+}
+
+export function terminalInteractiveShellArgs(shell: string): string[] {
+  const family = terminalShellFamily(shell);
+  if (family === 'windows-cmd' || family === 'powershell') return [];
+  return BASIC_INTERACTIVE_SHELLS.has(terminalShellBasename(shell)) ? ['-i'] : ['-il'];
+}
+
+export function terminalCommandArgs(shell: string): string[] {
+  switch (terminalShellFamily(shell)) {
+    case 'windows-cmd':
+      return ['/d', '/s', '/c'];
+    case 'powershell':
+      return ['-NoProfile', '-Command'];
+    case 'posix':
+    case 'csh':
+      return BASIC_INTERACTIVE_SHELLS.has(terminalShellBasename(shell)) ? ['-c'] : ['-lc'];
+  }
+}
+
+export function terminalEnvCaptureArgs(shell: string): string[] | undefined {
+  switch (terminalShellFamily(shell)) {
+    case 'csh':
+      return ['-i', '-c'];
+    case 'posix':
+      return BASIC_INTERACTIVE_SHELLS.has(terminalShellBasename(shell)) ? ['-ic'] : ['-ilc'];
+    case 'windows-cmd':
+    case 'powershell':
+      return undefined;
+  }
+}

--- a/src/shared/terminals.ts
+++ b/src/shared/terminals.ts
@@ -1,3 +1,4 @@
+import type { TerminalShellId } from './terminal-settings';
 import { createHash } from './utils';
 
 export type Terminal = {
@@ -13,6 +14,7 @@ export type CreateTerminalParams = {
   projectId: string;
   taskId: string;
   name: string;
+  shell?: TerminalShellId;
   initialSize?: { cols: number; rows: number };
 };
 


### PR DESCRIPTION
- added terminal shell profiles with auto, POSIX shells and Windows shells
- added main-process shell resolution for local and SSH targets
- added terminal drawer dropdown for creating a new terminal with a selected shell
- kept + behavior as Auto, using the target’s default shell
- added shell-family-aware spawn args for interactive terminals and commands
- added availability checks so unsupported shells are disabled or hidden per platform/target