### PR TITLE
fix(git): disable interactive credential prompts

### DIFF
--- a/src/main/core/execution-context/local-execution-context.test.ts
+++ b/src/main/core/execution-context/local-execution-context.test.ts
@@ -35,7 +35,15 @@ describe('LocalExecutionContext', () => {
     expect(execFileMock).toHaveBeenCalledWith(
       GIT_EXECUTABLE,
       ['status'],
-      expect.objectContaining({ cwd: '/repo' }),
+      expect.objectContaining({
+        cwd: '/repo',
+        env: expect.objectContaining({
+          GIT_ASKPASS: '',
+          GIT_TERMINAL_PROMPT: '0',
+          GCM_INTERACTIVE: 'never',
+          SSH_ASKPASS: '',
+        }),
+      }),
       expect.any(Function)
     );
   });
@@ -62,7 +70,19 @@ describe('LocalExecutionContext', () => {
     child.emit('close', 0);
     await promise;
 
-    expect(spawnMock).toHaveBeenCalledWith(GIT_EXECUTABLE, ['status'], { cwd: '/repo' });
+    expect(spawnMock).toHaveBeenCalledWith(
+      GIT_EXECUTABLE,
+      ['status'],
+      expect.objectContaining({
+        cwd: '/repo',
+        env: expect.objectContaining({
+          GIT_ASKPASS: '',
+          GIT_TERMINAL_PROMPT: '0',
+          GCM_INTERACTIVE: 'never',
+          SSH_ASKPASS: '',
+        }),
+      })
+    );
   });
 
   it('explains when git is missing during streaming local execution', async () => {

--- a/src/main/core/execution-context/local-execution-context.ts
+++ b/src/main/core/execution-context/local-execution-context.ts
@@ -5,9 +5,17 @@ import {
   isMissingGitExecutableError,
   missingGitExecutableError,
 } from '@main/core/utils/exec';
+import { NON_INTERACTIVE_GIT_ENV } from './non-interactive-git-env';
 import type { ExecOptions, ExecResult, IExecutionContext } from './types';
 
 const execFileAsync = promisify(execFile);
+
+function buildNonInteractiveGitEnv(): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...NON_INTERACTIVE_GIT_ENV,
+  };
+}
 
 export class LocalExecutionContext implements IExecutionContext {
   readonly root: string;
@@ -33,6 +41,7 @@ export class LocalExecutionContext implements IExecutionContext {
     const { timeout, maxBuffer } = opts;
     return execFileAsync(this.resolveCommand(command), args, {
       cwd: this.root || undefined,
+      env: command === 'git' ? buildNonInteractiveGitEnv() : undefined,
       timeout,
       maxBuffer,
       signal: this._signal(opts.signal),
@@ -58,7 +67,10 @@ export class LocalExecutionContext implements IExecutionContext {
         return;
       }
 
-      const child = spawn(this.resolveCommand(command), args, { cwd: this.root || undefined });
+      const child = spawn(this.resolveCommand(command), args, {
+        cwd: this.root || undefined,
+        env: command === 'git' ? buildNonInteractiveGitEnv() : undefined,
+      });
 
       let settled = false;
 

--- a/src/main/core/execution-context/non-interactive-git-env.ts
+++ b/src/main/core/execution-context/non-interactive-git-env.ts
@@ -1,0 +1,6 @@
+export const NON_INTERACTIVE_GIT_ENV = {
+  GIT_ASKPASS: '',
+  GIT_TERMINAL_PROMPT: '0',
+  GCM_INTERACTIVE: 'never',
+  SSH_ASKPASS: '',
+} as const;

--- a/src/main/core/execution-context/ssh-execution-context.test.ts
+++ b/src/main/core/execution-context/ssh-execution-context.test.ts
@@ -25,4 +25,12 @@ describe('buildSshCommand', () => {
       "'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; cd '\\''/workspace/project'\\'' && which '\\''claude'\\'''"
     );
   });
+
+  it('disables interactive Git credential prompts for SSH exec commands', () => {
+    const command = buildSshCommand('/workspace/project', 'git', ['fetch', 'origin']);
+
+    expect(command).toBe(
+      "'/bin/sh' -c 'cd '\\''/workspace/project'\\'' && GIT_ASKPASS='\\'''\\'' GIT_TERMINAL_PROMPT='\\''0'\\'' GCM_INTERACTIVE='\\''never'\\'' SSH_ASKPASS='\\'''\\'' git '\\''fetch'\\'' '\\''origin'\\'''"
+    );
+  });
 });

--- a/src/main/core/execution-context/ssh-execution-context.ts
+++ b/src/main/core/execution-context/ssh-execution-context.ts
@@ -5,7 +5,16 @@ import {
 } from '@main/core/ssh/lifecycle/remote-shell-profile';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import { quoteShellArg } from '@main/utils/shellEscape';
+import { NON_INTERACTIVE_GIT_ENV } from './non-interactive-git-env';
 import type { ExecOptions, ExecResult, IExecutionContext } from './types';
+
+function withNonInteractiveGitEnv(command: string): string {
+  if (command !== 'git') return command;
+  const envPrefix = Object.entries(NON_INTERACTIVE_GIT_ENV)
+    .map(([key, value]) => `${key}=${quoteShellArg(value)}`)
+    .join(' ');
+  return `${envPrefix} ${command}`;
+}
 
 /**
  * Builds the full shell command string to send over SSH.
@@ -19,7 +28,8 @@ export function buildSshCommand(
   profile?: RemoteShellProfile
 ): string {
   const escaped = args.map(quoteShellArg).join(' ');
-  const inner = args.length ? `${command} ${escaped}` : command;
+  const executable = withNonInteractiveGitEnv(command);
+  const inner = args.length ? `${executable} ${escaped}` : executable;
   const body = root ? `cd ${quoteShellArg(root)} && ${inner}` : inner;
   return buildRemoteShellCommand(profile ?? FALLBACK_REMOTE_SHELL_PROFILE, body);
 }

--- a/src/renderer/features/tasks/diff-view/stores/git-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/git-store.ts
@@ -7,6 +7,7 @@ import { fsWatchEventChannel } from '@shared/events/fsEvents';
 import { gitRefChangedChannel, gitWorkspaceChangedChannel } from '@shared/events/gitEvents';
 import { localRef, refsEqual, type FullGitStatus, type GitChange } from '@shared/git';
 import { err, ok } from '@shared/result';
+import { formatPushErrorDetail } from '../../utils';
 
 const TOO_MANY_FILES_MSG = 'Too many files changed to display';
 
@@ -384,8 +385,7 @@ export class GitStore {
       this.repositoryStore.refreshRemote(); // remote now has the commits
       return ok();
     } else {
-      const detail =
-        'message' in result.error ? (result.error.message ?? result.error.type) : result.error.type;
+      const detail = formatPushErrorDetail(result.error);
       toast.error(`Failed to push: ${detail}`);
       return err(result.error);
     }
@@ -405,8 +405,7 @@ export class GitStore {
       this.repositoryStore.refreshRemote(); // branch now exists on remote
       return ok();
     } else {
-      const detail =
-        'message' in result.error ? (result.error.message ?? result.error.type) : result.error.type;
+      const detail = formatPushErrorDetail(result.error);
       toast.error(`Failed to publish branch: ${detail}`);
       return err(result.error);
     }

--- a/src/renderer/features/tasks/stores/task-manager.ts
+++ b/src/renderer/features/tasks/stores/task-manager.ts
@@ -17,6 +17,7 @@ import type {
   TaskLifecycleStatus,
 } from '@shared/tasks';
 import type { TaskViewSnapshot } from '@shared/view-state';
+import { formatPushErrorDetail } from '../utils';
 import { conversationRegistry } from './conversation-registry';
 import {
   createUnprovisionedTask,
@@ -64,10 +65,7 @@ function formatCreateTaskError(error: CreateTaskError): string {
 function formatCreateTaskWarning(warning: CreateTaskWarning): string {
   switch (warning.type) {
     case 'branch-publish-failed': {
-      const detail =
-        'message' in warning.error
-          ? (warning.error.message ?? warning.error.type)
-          : warning.error.type;
+      const detail = formatPushErrorDetail(warning.error);
       return `Failed to publish branch "${warning.branch}" to "${warning.remote}": ${detail}`;
     }
   }

--- a/src/renderer/features/tasks/utils.test.ts
+++ b/src/renderer/features/tasks/utils.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { formatPushErrorDetail } from './utils';
+
+describe('formatPushErrorDetail', () => {
+  it('explains GitHub repository-not-found push failures as credential or write-access issues', () => {
+    const detail = formatPushErrorDetail({
+      type: 'error',
+      message:
+        "remote: Repository not found.\nfatal: repository 'https://github.com/orbit-logistics/orbit/' not found",
+    });
+
+    expect(detail).toBe(
+      'GitHub could not find the repository, or your local Git credentials do not have write access.'
+    );
+  });
+
+  it('preserves unrelated git error messages', () => {
+    const detail = formatPushErrorDetail({
+      type: 'rejected',
+      message: 'Updates were rejected because the remote contains work that you do not have.',
+    });
+
+    expect(detail).toBe(
+      'Updates were rejected because the remote contains work that you do not have.'
+    );
+  });
+});

--- a/src/renderer/features/tasks/utils.test.ts
+++ b/src/renderer/features/tasks/utils.test.ts
@@ -14,6 +14,17 @@ describe('formatPushErrorDetail', () => {
     );
   });
 
+  it('explains disabled GitHub credential prompts as local Git authentication failures', () => {
+    const detail = formatPushErrorDetail({
+      type: 'auth_failed',
+      message: "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+    });
+
+    expect(detail).toBe(
+      'GitHub authentication failed. Authenticate Git on this machine, or configure a fork as the project push remote.'
+    );
+  });
+
   it('preserves unrelated git error messages', () => {
     const detail = formatPushErrorDetail({
       type: 'rejected',

--- a/src/renderer/features/tasks/utils.test.ts
+++ b/src/renderer/features/tasks/utils.test.ts
@@ -25,6 +25,17 @@ describe('formatPushErrorDetail', () => {
     );
   });
 
+  it('does not classify generic fatal repository messages as repository-not-found failures', () => {
+    const message =
+      "fatal: repository 'https://github.com/orbit-logistics/orbit/' is not accessible (You are missing read permission...)";
+    const detail = formatPushErrorDetail({
+      type: 'error',
+      message,
+    });
+
+    expect(detail).toBe(message);
+  });
+
   it('preserves unrelated git error messages', () => {
     const detail = formatPushErrorDetail({
       type: 'rejected',

--- a/src/renderer/features/tasks/utils.ts
+++ b/src/renderer/features/tasks/utils.ts
@@ -1,3 +1,7 @@
+import type { PushError } from '@shared/git';
+
+type PushLikeError = PushError | { type: string; message?: string };
+
 export function extractErrorMessage(error: unknown): string {
   if (error && typeof error === 'object' && 'message' in error) {
     return String((error as { message: unknown }).message);
@@ -27,4 +31,23 @@ export function friendlyGitError(raw: string): string {
   if (s.includes('nothing to commit')) return 'Nothing to commit.';
   const firstLine = raw.split('\n').find((l) => l.trim().length > 0) || raw;
   return firstLine.length > 120 ? firstLine.slice(0, 120) + '...' : firstLine;
+}
+
+const GITHUB_REPOSITORY_ACCESS_ERROR =
+  'GitHub could not find the repository, or your local Git credentials do not have write access.';
+
+export function formatPushErrorDetail(error: PushLikeError): string {
+  const message = 'message' in error ? (error.message ?? error.type) : error.type;
+  const normalized = message.toLowerCase();
+
+  if (
+    normalized.includes('github.com') &&
+    (normalized.includes('repository not found') ||
+      normalized.includes('fatal: repository') ||
+      normalized.includes('not found'))
+  ) {
+    return GITHUB_REPOSITORY_ACCESS_ERROR;
+  }
+
+  return message;
 }

--- a/src/renderer/features/tasks/utils.ts
+++ b/src/renderer/features/tasks/utils.ts
@@ -45,7 +45,7 @@ export function formatPushErrorDetail(error: PushLikeError): string {
   if (
     normalized.includes('github.com') &&
     (normalized.includes('repository not found') ||
-      normalized.includes('fatal: repository') ||
+      (normalized.includes('fatal: repository') && normalized.includes('not found')) ||
       normalized.includes('not found'))
   ) {
     return GITHUB_REPOSITORY_ACCESS_ERROR;

--- a/src/renderer/features/tasks/utils.ts
+++ b/src/renderer/features/tasks/utils.ts
@@ -35,6 +35,8 @@ export function friendlyGitError(raw: string): string {
 
 const GITHUB_REPOSITORY_ACCESS_ERROR =
   'GitHub could not find the repository, or your local Git credentials do not have write access.';
+const GITHUB_AUTHENTICATION_ERROR =
+  'GitHub authentication failed. Authenticate Git on this machine, or configure a fork as the project push remote.';
 
 export function formatPushErrorDetail(error: PushLikeError): string {
   const message = 'message' in error ? (error.message ?? error.type) : error.type;
@@ -47,6 +49,16 @@ export function formatPushErrorDetail(error: PushLikeError): string {
       normalized.includes('not found'))
   ) {
     return GITHUB_REPOSITORY_ACCESS_ERROR;
+  }
+
+  if (
+    normalized.includes('github.com') &&
+    (normalized.includes('could not read username') ||
+      normalized.includes('terminal prompts disabled') ||
+      normalized.includes('authentication failed') ||
+      normalized.includes('permission denied'))
+  ) {
+    return GITHUB_AUTHENTICATION_ERROR;
   }
 
   return message;


### PR DESCRIPTION
- prevent main-process git commands from opening credential prompts when credentials are missing
- add shared non-interactive git environment values for local and ssh execution contexts
- keep local and ssh transport-specific env application in their respective execution contexts
- verified missing https credentials now fail fast with "terminal prompts disabled" instead of hanging at a username prompt