### PR TITLE
fix(tasks): prevent task rename from closing pull requests

### DIFF
--- a/src/main/core/git/impl/git-service.test.ts
+++ b/src/main/core/git/impl/git-service.test.ts
@@ -426,6 +426,21 @@ describe('GitService.createBranch', () => {
   });
 });
 
+describe('GitService.renameBranch', () => {
+  it('renames only the local branch ref', async () => {
+    const svc = makeService(
+      makeExec({
+        'branch -m emdash/old-name emdash/new-name': '',
+      })
+    );
+
+    await expect(svc.renameBranch('emdash/old-name', 'emdash/new-name')).resolves.toEqual({
+      success: true,
+      data: undefined,
+    });
+  });
+});
+
 describe('GitService.fetch', () => {
   it('fetches through plain git without injected GitHub auth config', async () => {
     const svc = makeService(

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -1584,19 +1584,10 @@ export class GitService implements GitProvider, IDisposable {
   async renameBranch(
     oldBranch: string,
     newBranch: string
-  ): Promise<Result<{ remotePushed: boolean }, RenameBranchError>> {
-    let remoteName: string | undefined;
-    try {
-      const { stdout } = await this.ctx.exec('git', [
-        'config',
-        '--get',
-        `branch.${oldBranch}.remote`,
-      ]);
-      remoteName = stdout.trim() || undefined;
-    } catch {}
-
+  ): Promise<Result<void, RenameBranchError>> {
     try {
       await this.ctx.exec('git', ['branch', '-m', oldBranch, newBranch]);
+      return ok();
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
       if (stderr.includes('already exists')) {
@@ -1604,20 +1595,6 @@ export class GitService implements GitProvider, IDisposable {
       }
       return err({ type: 'error', message: stderr });
     }
-
-    if (remoteName) {
-      try {
-        await this.ctx.exec('git', ['push', remoteName, '--delete', oldBranch]);
-      } catch {}
-      try {
-        await this.ctx.exec('git', ['push', '-u', remoteName, newBranch]);
-      } catch (error: unknown) {
-        const stderr = (error as { stderr?: string })?.stderr || String(error);
-        return err({ type: 'remote_push_failed', message: stderr });
-      }
-    }
-
-    return ok({ remotePushed: !!remoteName });
   }
 
   async deleteBranch(branch: string, force = true): Promise<Result<void, DeleteBranchError>> {

--- a/src/main/core/git/repository-git-provider.ts
+++ b/src/main/core/git/repository-git-provider.ts
@@ -24,10 +24,7 @@ export interface RepositoryGitProvider {
     syncWithRemote?: boolean,
     remote?: string
   ): Promise<Result<void, CreateBranchError>>;
-  renameBranch(
-    oldBranch: string,
-    newBranch: string
-  ): Promise<Result<{ remotePushed: boolean }, RenameBranchError>>;
+  renameBranch(oldBranch: string, newBranch: string): Promise<Result<void, RenameBranchError>>;
   deleteBranch(branch: string, force?: boolean): Promise<Result<void, DeleteBranchError>>;
   fetchPrForReview(
     prNumber: number,

--- a/src/main/core/git/repository-service.ts
+++ b/src/main/core/git/repository-service.ts
@@ -98,7 +98,7 @@ export class GitRepositoryService {
   async renameBranch(
     oldBranch: string,
     newBranch: string
-  ): Promise<Result<{ remotePushed: boolean }, RenameBranchError>> {
+  ): Promise<Result<void, RenameBranchError>> {
     return this.git.renameBranch(oldBranch, newBranch);
   }
 

--- a/src/main/core/repository/controller.ts
+++ b/src/main/core/repository/controller.ts
@@ -70,7 +70,7 @@ export const repositoryController = createRPCController({
     if (!project) return err({ type: 'not_found' as const });
     const result = await project.repository.renameBranch(oldBranch, newBranch);
     if (!result.success) return err(result.error);
-    return ok({ remotePushed: result.data.remotePushed });
+    return ok();
   },
 
   fetch: async (projectId: string, workspaceId?: string) => {

--- a/src/main/core/tasks/controller.ts
+++ b/src/main/core/tasks/controller.ts
@@ -3,6 +3,7 @@ import type {
   CreateTaskParams,
   DeleteTaskOptions,
   Issue,
+  RenameTaskOptions,
   TaskLifecycleStatus,
 } from '@shared/tasks';
 import { generateTaskName } from './name-generation/generateTaskName';
@@ -31,8 +32,13 @@ export const taskController = createRPCController({
   async restoreTask(id: string) {
     return taskService.restoreTask(id);
   },
-  async renameTask(projectId: string, taskId: string, newName: string) {
-    return taskService.renameTask(projectId, taskId, newName);
+  async renameTask(
+    projectId: string,
+    taskId: string,
+    newName: string,
+    options?: RenameTaskOptions
+  ) {
+    return taskService.renameTask(projectId, taskId, newName, options);
   },
   async updateLinkedIssue(taskId: string, issue?: Issue) {
     return taskService.updateLinkedIssue(taskId, issue);

--- a/src/main/core/tasks/operations/renameTask.test.ts
+++ b/src/main/core/tasks/operations/renameTask.test.ts
@@ -1,0 +1,258 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TaskRow } from '@main/db/schema';
+import { toStoredBranch } from '../stored-branch';
+import { renameTask } from './renameTask';
+
+const mocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  update: vi.fn(),
+  getProject: vi.fn(),
+  getAppSetting: vi.fn(),
+  renameBranch: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: mocks.select,
+    update: mocks.update,
+  },
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: {
+    getProject: mocks.getProject,
+  },
+}));
+
+vi.mock('../../settings/settings-service', () => ({
+  appSettingsService: {
+    get: mocks.getAppSetting,
+  },
+}));
+
+function makeTaskRow(values: Partial<TaskRow>): TaskRow {
+  return {
+    id: values.id ?? 'task-1',
+    projectId: values.projectId ?? 'project-1',
+    name: values.name ?? 'old-title',
+    status: values.status ?? 'in_progress',
+    sourceBranch: values.sourceBranch ?? null,
+    taskBranch: values.taskBranch ?? null,
+    linkedIssue: values.linkedIssue ?? null,
+    archivedAt: values.archivedAt ?? null,
+    createdAt: values.createdAt ?? '2026-05-28 12:00:00',
+    updatedAt: values.updatedAt ?? '2026-05-28 12:00:00',
+    lastInteractedAt: values.lastInteractedAt ?? null,
+    statusChangedAt: values.statusChangedAt ?? '2026-05-28 12:00:00',
+    isPinned: values.isPinned ?? 0,
+    workspaceProvider: values.workspaceProvider ?? null,
+    workspaceId: values.workspaceId ?? null,
+    workspaceProviderData: values.workspaceProviderData ?? null,
+  };
+}
+
+function mockSelectRows(rows: unknown[]) {
+  return mockSelectRowsSequence([rows]);
+}
+
+function mockSelectRowsSequence(rowsByCall: unknown[][]) {
+  const calls = rowsByCall.map((rows) => {
+    const limit = vi.fn().mockResolvedValue(rows);
+    const where = vi.fn(() => Object.assign(Promise.resolve(rows), { limit }));
+    const from = vi.fn(() => ({ where }));
+    return { from, where, limit };
+  });
+  const firstCall = calls[0];
+  mocks.select.mockImplementation(() => {
+    const call = calls.shift();
+    if (!call) throw new Error('Unexpected select call');
+    return { from: call.from };
+  });
+  return firstCall;
+}
+
+function mockUpdateRows(rows: TaskRow[]) {
+  const returning = vi.fn().mockResolvedValue(rows);
+  const where = vi.fn(() => ({ returning }));
+  const set = vi.fn(() => ({ where }));
+  mocks.update.mockReturnValue({ set });
+  return { set, where, returning };
+}
+
+describe('renameTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getProject.mockReturnValue({
+      repository: {
+        renameBranch: mocks.renameBranch,
+      },
+    });
+    mocks.getAppSetting.mockResolvedValue({
+      branchPrefix: 'emdash',
+      appendRandomBranchSuffix: true,
+    });
+    mocks.renameBranch.mockResolvedValue({ success: true, data: undefined });
+  });
+
+  it('renames only Emdash task metadata and leaves the git branch unchanged', async () => {
+    const originalRow = makeTaskRow({
+      name: 'old-title',
+      sourceBranch: toStoredBranch({ type: 'local', branch: 'main' }),
+      taskBranch: 'jona/eng-1431-old-title',
+      linkedIssue: JSON.stringify({
+        provider: 'linear',
+        url: 'https://linear.app/general-action/issue/ENG-1431',
+        title: 'Old title',
+        identifier: 'ENG-1431',
+        branchName: 'jona/eng-1431-old-title',
+      }),
+    });
+    const updatedRow = makeTaskRow({
+      ...originalRow,
+      name: 'new-title',
+      taskBranch: 'jona/eng-1431-old-title',
+    });
+
+    mockSelectRows([originalRow]);
+    const update = mockUpdateRows([updatedRow]);
+
+    const result = await renameTask('project-1', 'task-1', 'new-title');
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.task.name).toBe('new-title');
+    expect(result.data.task.taskBranch).toBe('jona/eng-1431-old-title');
+    expect(update.set).toHaveBeenCalledWith(
+      expect.not.objectContaining({ taskBranch: expect.anything() })
+    );
+    expect(mocks.renameBranch).not.toHaveBeenCalled();
+    expect(mocks.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('renames the local branch when requested and leaves remotes untouched', async () => {
+    const originalRow = makeTaskRow({
+      name: 'old-title',
+      sourceBranch: toStoredBranch({ type: 'local', branch: 'main' }),
+      taskBranch: 'emdash/old-title',
+    });
+    const updatedRow = makeTaskRow({
+      ...originalRow,
+      name: 'new-title',
+      taskBranch: 'emdash/new-title',
+    });
+
+    mockSelectRowsSequence([
+      [originalRow],
+      [{ ...originalRow, id: 'task-1' }],
+      [{ remoteUrl: 'https://github.com/example/repo.git' }],
+      [],
+    ]);
+    const update = mockUpdateRows([updatedRow]);
+
+    const result = await renameTask('project-1', 'task-1', 'new-title', {
+      renameBranch: true,
+    });
+
+    expect(result.success).toBe(true);
+    if (!result.success) return;
+    expect(result.data.task.name).toBe('new-title');
+    expect(result.data.task.taskBranch).toBe('emdash/new-title');
+    expect(mocks.renameBranch).toHaveBeenCalledWith('emdash/old-title', 'emdash/new-title');
+    expect(update.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: 'new-title',
+        taskBranch: 'emdash/new-title',
+      })
+    );
+  });
+
+  it('does not rename branches with open pull requests', async () => {
+    const originalRow = makeTaskRow({
+      name: 'old-title',
+      sourceBranch: toStoredBranch({ type: 'local', branch: 'main' }),
+      taskBranch: 'emdash/open-pr-branch',
+    });
+
+    mockSelectRowsSequence([
+      [originalRow],
+      [{ ...originalRow, id: 'task-1' }],
+      [{ remoteUrl: 'https://github.com/example/repo.git' }],
+      [{ url: 'https://github.com/example/repo/pull/123' }],
+    ]);
+
+    const result = await renameTask('project-1', 'task-1', 'new-title', {
+      renameBranch: true,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: { type: 'branch-has-open-pr', branch: 'emdash/open-pr-branch' },
+    });
+    expect(mocks.renameBranch).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('does not rename branches managed by Linear issues', async () => {
+    const originalRow = makeTaskRow({
+      name: 'old-title',
+      sourceBranch: toStoredBranch({ type: 'local', branch: 'main' }),
+      taskBranch: 'jona/eng-1431-old-title',
+      linkedIssue: JSON.stringify({
+        provider: 'linear',
+        url: 'https://linear.app/general-action/issue/ENG-1431',
+        title: 'Old title',
+        identifier: 'ENG-1431',
+        branchName: 'jona/eng-1431-old-title',
+      }),
+    });
+
+    mockSelectRows([originalRow]);
+
+    const result = await renameTask('project-1', 'task-1', 'new-title', {
+      renameBranch: true,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: { type: 'branch-managed-by-linked-issue', provider: 'linear' },
+    });
+    expect(mocks.renameBranch).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('returns an error when local branch rename is requested for a shared branch', async () => {
+    const originalRow = makeTaskRow({
+      name: 'old-title',
+      sourceBranch: toStoredBranch({ type: 'local', branch: 'main' }),
+      taskBranch: 'emdash/shared-branch',
+    });
+
+    mockSelectRowsSequence([
+      [originalRow],
+      [originalRow, makeTaskRow({ id: 'task-2', taskBranch: 'emdash/shared-branch' })],
+    ]);
+
+    const result = await renameTask('project-1', 'task-1', 'new-title', {
+      renameBranch: true,
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: { type: 'branch-has-siblings', branch: 'emdash/shared-branch' },
+    });
+    expect(mocks.renameBranch).not.toHaveBeenCalled();
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+
+  it('returns task-not-found when the task does not exist in the requested project', async () => {
+    mockSelectRows([]);
+
+    const result = await renameTask('project-1', 'missing-task', 'new-title');
+
+    expect(result).toEqual({
+      success: false,
+      error: { type: 'task-not-found', taskId: 'missing-task' },
+    });
+    expect(mocks.update).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/core/tasks/operations/renameTask.ts
+++ b/src/main/core/tasks/operations/renameTask.ts
@@ -1,18 +1,19 @@
 import { and, eq, sql } from 'drizzle-orm';
 import { projectManager } from '@main/core/projects/project-manager';
+import { pullRequestRepositoryScope } from '@main/core/pull-requests/pr-utils';
 import { mapTaskRowToTask } from '@main/core/tasks/utils/utils';
 import { db } from '@main/db/client';
-import { tasks } from '@main/db/schema';
+import { projectRemotes, pullRequests, tasks } from '@main/db/schema';
 import { resolveTaskBranchName } from '@shared/resolveTaskBranchName';
 import { err, ok, type Result } from '@shared/result';
-import type { RenameTaskError, RenameTaskSuccess, RenameTaskWarning } from '@shared/tasks';
+import type { Issue, RenameTaskError, RenameTaskOptions, RenameTaskSuccess } from '@shared/tasks';
 import { appSettingsService } from '../../settings/settings-service';
 import { fromStoredBranch } from '../stored-branch';
 
-function parseLinkedIssueProvider(linkedIssue: unknown): unknown {
+function parseLinkedIssue(linkedIssue: unknown): Issue | undefined {
   if (!linkedIssue || typeof linkedIssue !== 'string') return undefined;
   try {
-    return (JSON.parse(linkedIssue) as { provider?: unknown }).provider;
+    return JSON.parse(linkedIssue) as Issue;
   } catch {
     return undefined;
   }
@@ -21,41 +22,74 @@ function parseLinkedIssueProvider(linkedIssue: unknown): unknown {
 export async function renameTask(
   projectId: string,
   taskId: string,
-  newName: string
+  newName: string,
+  options: RenameTaskOptions = {}
 ): Promise<Result<RenameTaskSuccess, RenameTaskError>> {
-  const [row] = await db.select().from(tasks).where(eq(tasks.id, taskId)).limit(1);
+  const [row] = await db
+    .select()
+    .from(tasks)
+    .where(and(eq(tasks.id, taskId), eq(tasks.projectId, projectId)))
+    .limit(1);
   if (!row) return err({ type: 'task-not-found', taskId });
 
-  const project = projectManager.getProject(projectId);
-  if (!project) return err({ type: 'project-not-found', projectId });
+  let taskBranch = row.taskBranch;
 
-  const oldBranch = row.taskBranch;
-  const sourceBranch = fromStoredBranch(row.sourceBranch);
-  let newBranch: string | null = null;
-  let warning: RenameTaskWarning | undefined;
+  if (options.renameBranch && row.taskBranch) {
+    const linkedIssue = parseLinkedIssue(row.linkedIssue);
+    if (linkedIssue?.provider === 'linear') {
+      return err({ type: 'branch-managed-by-linked-issue', provider: linkedIssue.provider });
+    }
 
-  if (oldBranch) {
-    if (sourceBranch && oldBranch !== sourceBranch.branch) {
+    const sourceBranch = fromStoredBranch(row.sourceBranch);
+
+    if (sourceBranch && row.taskBranch !== sourceBranch.branch) {
       const siblings = await db
         .select({ id: tasks.id })
         .from(tasks)
-        .where(and(eq(tasks.projectId, row.projectId), eq(tasks.taskBranch, oldBranch)))
+        .where(and(eq(tasks.projectId, row.projectId), eq(tasks.taskBranch, row.taskBranch)))
         .limit(2);
 
-      if (siblings.length === 1) {
-        const suffix = Math.random().toString(36).slice(2, 7);
-        const projectDefaults = await appSettingsService.get('project');
-        const branchPrefix = projectDefaults.branchPrefix ?? '';
-        const linkedIssueProvider = parseLinkedIssueProvider(row.linkedIssue);
-        newBranch = resolveTaskBranchName({
-          rawBranch: newName,
-          branchPrefix,
-          suffix,
-          appendRandomSuffix: projectDefaults.appendRandomBranchSuffix ?? true,
-          disableRandomSuffix: linkedIssueProvider === 'linear',
-        });
+      if (siblings.length > 1) {
+        return err({ type: 'branch-has-siblings', branch: row.taskBranch });
+      }
 
-        const renameResult = await project.repository.renameBranch(oldBranch, newBranch);
+      const remoteRows = await db
+        .select({ remoteUrl: projectRemotes.remoteUrl })
+        .from(projectRemotes)
+        .where(eq(projectRemotes.projectId, row.projectId));
+      const repositoryUrls = remoteRows.map((remote) => remote.remoteUrl);
+
+      if (repositoryUrls.length > 0) {
+        const openPrRows = await db
+          .select({ url: pullRequests.url })
+          .from(pullRequests)
+          .where(
+            and(
+              eq(pullRequests.headRefName, row.taskBranch),
+              eq(pullRequests.status, 'open'),
+              pullRequestRepositoryScope(repositoryUrls)
+            )
+          )
+          .limit(1);
+
+        if (openPrRows.length > 0) {
+          return err({ type: 'branch-has-open-pr', branch: row.taskBranch });
+        }
+      }
+
+      const project = projectManager.getProject(projectId);
+      if (!project) return err({ type: 'project-not-found', projectId });
+
+      const projectDefaults = await appSettingsService.get('project');
+      const newBranch = resolveTaskBranchName({
+        rawBranch: newName,
+        branchPrefix: projectDefaults.branchPrefix ?? '',
+        suffix: '',
+        appendRandomSuffix: false,
+      });
+
+      if (newBranch !== row.taskBranch) {
+        const renameResult = await project.repository.renameBranch(row.taskBranch, newBranch);
         if (!renameResult.success) {
           switch (renameResult.error.type) {
             case 'already_exists':
@@ -63,13 +97,6 @@ export async function renameTask(
                 type: 'branch-already-exists',
                 branch: renameResult.error.name,
               });
-            case 'remote_push_failed':
-              warning = {
-                type: 'branch-remote-push-failed',
-                branch: newBranch,
-                message: renameResult.error.message,
-              };
-              break;
             case 'error':
               return err({
                 type: 'branch-rename-failed',
@@ -78,6 +105,8 @@ export async function renameTask(
               });
           }
         }
+
+        taskBranch = newBranch;
       }
     }
   }
@@ -86,14 +115,14 @@ export async function renameTask(
     .update(tasks)
     .set({
       name: newName,
-      taskBranch: newBranch ?? row.taskBranch,
+      ...(taskBranch !== row.taskBranch ? { taskBranch } : {}),
       updatedAt: sql`CURRENT_TIMESTAMP`,
     })
-    .where(eq(tasks.id, taskId))
+    .where(and(eq(tasks.id, taskId), eq(tasks.projectId, projectId)))
     .returning();
 
   const task = updatedRow
     ? mapTaskRowToTask(updatedRow)
     : mapTaskRowToTask({ ...row, name: newName });
-  return ok({ task, warning });
+  return ok({ task });
 }

--- a/src/main/core/tasks/task-service.ts
+++ b/src/main/core/tasks/task-service.ts
@@ -16,6 +16,7 @@ import type {
   Issue,
   ProvisionTaskResult,
   RenameTaskError,
+  RenameTaskOptions,
   RenameTaskSuccess,
   Task,
 } from '@shared/tasks';
@@ -179,9 +180,10 @@ export class TaskService implements Hookable<TaskCrudHooks> {
   async renameTask(
     projectId: string,
     taskId: string,
-    newName: string
+    newName: string,
+    options?: RenameTaskOptions
   ): Promise<Result<RenameTaskSuccess, RenameTaskError>> {
-    const result = await renameTask(projectId, taskId, newName);
+    const result = await renameTask(projectId, taskId, newName, options);
     if (result.success) this._hooks.callHookBackground('task:updated', result.data.task);
     return result;
   }

--- a/src/renderer/features/tasks/rename-task-modal.tsx
+++ b/src/renderer/features/tasks/rename-task-modal.tsx
@@ -1,10 +1,11 @@
 import { observer } from 'mobx-react-lite';
 import { useCallback, useState } from 'react';
-import { toast } from 'sonner';
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
 import { getTaskManagerStore } from '@renderer/features/tasks/stores/task-selectors';
+import { isRegistered } from '@renderer/features/tasks/stores/task-store';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
+import { Checkbox } from '@renderer/lib/ui/checkbox';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
 import {
   DialogContentArea,
@@ -14,6 +15,7 @@ import {
 } from '@renderer/lib/ui/dialog';
 import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
 import { Input } from '@renderer/lib/ui/input';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import {
   liveTransformTaskName,
   MAX_TASK_NAME_LENGTH,
@@ -36,6 +38,12 @@ function formatRenameTaskError(error: RenameTaskError): string {
       return 'Task not found.';
     case 'project-not-found':
       return 'Project not found.';
+    case 'branch-managed-by-linked-issue':
+      return 'Branch name is managed by the linked issue.';
+    case 'branch-has-open-pr':
+      return `Branch "${error.branch}" has an open pull request. Rename the task without renaming the branch.`;
+    case 'branch-has-siblings':
+      return `Branch "${error.branch}" is used by another task. Rename the task without renaming the branch.`;
     case 'branch-already-exists':
       return `Branch "${error.branch}" already exists. Try a different task name.`;
     case 'branch-rename-failed':
@@ -51,6 +59,7 @@ export const RenameTaskModal = observer(function RenameTaskModal({
   onClose,
 }: Props) {
   const [name, setName] = useState(currentName);
+  const [renameBranch, setRenameBranch] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const { preserveNameCapitalization } = useTaskSettings();
@@ -69,6 +78,41 @@ export const RenameTaskModal = observer(function RenameTaskModal({
   const isUnchanged = normalizedName === currentName;
   const isEmpty = normalizedName.length === 0;
   const isValid = !isEmpty && !isDuplicate && !isUnchanged;
+  const task = taskManager?.tasks.get(taskId);
+  const taskPayload = task && isRegistered(task) ? task.data : undefined;
+  const taskBranch = taskPayload?.taskBranch;
+  const branchHasSiblings = Boolean(
+    taskBranch &&
+    Array.from(taskManager?.tasks.values() ?? []).some(
+      (candidate) =>
+        isRegistered(candidate) &&
+        candidate.data.id !== taskId &&
+        candidate.data.taskBranch === taskBranch
+    )
+  );
+  const hasOpenPullRequest = taskPayload?.prs.some((pr) => pr.status === 'open') ?? false;
+  const branchManagedByLinkedIssue = taskPayload?.linkedIssue?.provider === 'linear';
+  const canRenameLocalBranch = Boolean(
+    taskBranch &&
+    taskPayload?.sourceBranch &&
+    taskBranch !== taskPayload.sourceBranch.branch &&
+    !hasOpenPullRequest &&
+    !branchHasSiblings &&
+    !branchManagedByLinkedIssue
+  );
+  const branchRenameDisabledReason = (() => {
+    if (
+      !taskBranch ||
+      !taskPayload?.sourceBranch ||
+      taskBranch === taskPayload.sourceBranch.branch
+    ) {
+      return 'This task has no separate branch to rename';
+    }
+    if (branchManagedByLinkedIssue) return 'Linear manages this branch name';
+    if (hasOpenPullRequest) return 'Open pull requests must keep their current branch';
+    if (branchHasSiblings) return 'Another task uses this branch';
+    return null;
+  })();
 
   const validationMessage = isDuplicate
     ? 'A task with this name already exists in this project.'
@@ -78,7 +122,11 @@ export const RenameTaskModal = observer(function RenameTaskModal({
 
   const handleNameChange = useCallback(
     (value: string) => {
-      setName(liveTransformTaskName(value, { preserveCapitalization: preserveNameCapitalization }));
+      setName(
+        liveTransformTaskName(value, {
+          preserveCapitalization: preserveNameCapitalization,
+        })
+      );
       setError(null);
     },
     [preserveNameCapitalization]
@@ -91,23 +139,20 @@ export const RenameTaskModal = observer(function RenameTaskModal({
     setIsSubmitting(true);
     setError(null);
     try {
-      const result = await task.rename(normalizedName);
+      const result = await task.rename(normalizedName, {
+        renameBranch: renameBranch && canRenameLocalBranch,
+      });
       if (!result.success) {
         setError(formatRenameTaskError(result.error));
         setIsSubmitting(false);
         return;
-      }
-      if (result.data.warning) {
-        toast.error(
-          `Branch was renamed locally to "${result.data.warning.branch}", but could not be pushed to the remote: ${result.data.warning.message}`
-        );
       }
       onSuccess();
     } catch (e) {
       setError(e instanceof Error ? e.message : 'Failed to rename task');
       setIsSubmitting(false);
     }
-  }, [isValid, taskManager, taskId, normalizedName, onSuccess]);
+  }, [isValid, taskManager, taskId, normalizedName, renameBranch, canRenameLocalBranch, onSuccess]);
 
   return (
     <>
@@ -132,6 +177,24 @@ export const RenameTaskModal = observer(function RenameTaskModal({
             )}
             {error && <p className="text-destructive mt-1 text-xs">{error}</p>}
           </Field>
+          <Tooltip>
+            <TooltipTrigger>
+              <label
+                className="flex cursor-pointer items-center gap-2 text-sm aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+                aria-disabled={!canRenameLocalBranch}
+              >
+                <Checkbox
+                  checked={renameBranch}
+                  onCheckedChange={(checked) => setRenameBranch(Boolean(checked))}
+                  disabled={!canRenameLocalBranch}
+                />
+                Rename local branch
+              </label>
+            </TooltipTrigger>
+            {branchRenameDisabledReason ? (
+              <TooltipContent>{branchRenameDisabledReason}</TooltipContent>
+            ) : null}
+          </Tooltip>
         </FieldGroup>
       </DialogContentArea>
       <DialogFooter>

--- a/src/renderer/features/tasks/stores/task-store.ts
+++ b/src/renderer/features/tasks/stores/task-store.ts
@@ -7,6 +7,7 @@ import { err, type Result } from '@shared/result';
 import type {
   Issue,
   RenameTaskError,
+  RenameTaskOptions,
   RenameTaskSuccess,
   Task,
   TaskLifecycleStatus,
@@ -181,16 +182,23 @@ export class TaskStore {
     return (this.data as Task).conversations;
   }
 
-  async rename(name: string): Promise<Result<RenameTaskSuccess, RenameTaskError>> {
+  async rename(
+    name: string,
+    options?: RenameTaskOptions
+  ): Promise<Result<RenameTaskSuccess, RenameTaskError>> {
     const task = registeredTaskData(this);
     if (!task) return err({ type: 'task-not-found', taskId: this.data.id });
     try {
-      const result = await rpc.tasks.renameTask(task.projectId, task.id, name);
+      const result = await rpc.tasks.renameTask(task.projectId, task.id, name, options);
       if (!result.success) {
         return result;
       }
       runInAction(() => {
-        this.data.name = name;
+        const current = registeredTaskData(this);
+        if (current) {
+          current.name = name;
+          current.taskBranch = result.data.task.taskBranch;
+        }
       });
       return result;
     } catch (e) {

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -294,7 +294,6 @@ export type CreateBranchError =
 
 export type RenameBranchError =
   | { type: 'already_exists'; name: string }
-  | { type: 'remote_push_failed'; message: string }
   | { type: 'error'; message: string };
 
 export type DeleteBranchError =

--- a/src/shared/tasks.ts
+++ b/src/shared/tasks.ts
@@ -108,18 +108,18 @@ export type CreateTaskSuccess = {
 export type RenameTaskError =
   | { type: 'task-not-found'; taskId: string }
   | { type: 'project-not-found'; projectId: string }
+  | { type: 'branch-managed-by-linked-issue'; provider: Issue['provider'] }
+  | { type: 'branch-has-open-pr'; branch: string }
+  | { type: 'branch-has-siblings'; branch: string }
   | { type: 'branch-already-exists'; branch: string }
   | { type: 'branch-rename-failed'; branch: string; message: string };
 
-export type RenameTaskWarning = {
-  type: 'branch-remote-push-failed';
-  branch: string;
-  message: string;
-};
-
 export type RenameTaskSuccess = {
   task: Task;
-  warning?: RenameTaskWarning;
+};
+
+export type RenameTaskOptions = {
+  renameBranch?: boolean;
 };
 
 export type ProvisionTaskResult = {


### PR DESCRIPTION
- keep branch rename local-only and remove remote branch delete and push behavior
- add an optional rename branch checkbox to RenameTaskModal
- disable branch rename for linear-linked tasks, open pull requests and shared branches
- update renameTask to rename task metadata by default and only rename the branch when requested
- add backend guards so stale callers cannot rename protected branches