### PR TITLE
fix(conversations): preserve tmux sessions on close

### DIFF
--- a/src/main/core/conversations/dehydrateConversation.ts
+++ b/src/main/core/conversations/dehydrateConversation.ts
@@ -6,5 +6,5 @@ export async function dehydrateConversation(
   conversationId: string
 ): Promise<void> {
   const task = resolveTask(projectId, taskId);
-  await task?.conversations.stopSession(conversationId);
+  await task?.conversations.detachSession(conversationId);
 }

--- a/src/main/core/conversations/deleteConversation.ts
+++ b/src/main/core/conversations/deleteConversation.ts
@@ -1,7 +1,10 @@
 import { and, eq } from 'drizzle-orm';
+import { projectManager } from '@main/core/projects/project-manager';
+import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { db } from '@main/db/client';
 import { conversations } from '@main/db/schema';
 import { telemetryService } from '@main/lib/telemetry';
+import { makePtySessionId } from '@shared/ptySessionId';
 import { resolveTask } from '../projects/utils';
 import { conversationEvents } from './conversation-events';
 
@@ -23,7 +26,17 @@ export async function deleteConversation(
   conversationEvents._emit('conversation:deleted', conversationId);
 
   const task = resolveTask(projectId, taskId);
-  await task?.conversations.stopSession(conversationId);
+  if (task) {
+    await task.conversations.stopSession(conversationId);
+  } else {
+    const project = projectManager.getProject(projectId);
+    if (project) {
+      await killTmuxSession(
+        project.ctx,
+        makeTmuxSessionName(makePtySessionId(projectId, taskId, conversationId))
+      );
+    }
+  }
   telemetryService.capture('conversation_deleted', {
     project_id: projectId,
     task_id: taskId,

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -86,23 +86,39 @@ const { events } = await import('@main/lib/events');
 
 type RespawnState = {
   respawnCounts: Map<string, number>;
+  knownSessionIds: Set<string>;
+  sessions: Map<string, Pty>;
 };
 
-function localProvider() {
+function localProvider({
+  tmux = false,
+  ctx = {} as never,
+}: {
+  tmux?: boolean;
+  ctx?: ConstructorParameters<typeof LocalConversationProvider>[0]['ctx'];
+} = {}) {
   return new LocalConversationProvider({
     projectId: 'project-1',
     taskId: 'task-1',
     taskPath: '/tmp/task-1',
-    ctx: {} as never,
+    tmux,
+    ctx,
   });
 }
 
-function sshProvider(proxy = { getRemoteShellProfile: vi.fn(async () => ({})) }) {
+function sshProvider(
+  proxy = { getRemoteShellProfile: vi.fn(async () => ({})) },
+  {
+    tmux = false,
+    ctx = {} as never,
+  }: { tmux?: boolean; ctx?: ConstructorParameters<typeof SshConversationProvider>[0]['ctx'] } = {}
+) {
   return new SshConversationProvider({
     projectId: 'project-1',
     taskId: 'task-1',
     taskPath: '/tmp/task-1',
-    ctx: {} as never,
+    tmux,
+    ctx,
     proxy: proxy as never,
   });
 }
@@ -240,5 +256,147 @@ describe('conversation provider respawn state', () => {
     await provider.stopSession('conversation-1');
 
     expect((provider as unknown as RespawnState).respawnCounts.has(sessionId)).toBe(false);
+  });
+
+  it('detaches local tmux conversations without killing the tmux session', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    const pty = fakePty(exitHandlers);
+    spawnLocalPty.mockReturnValue(pty);
+    const ctx = {
+      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
+    };
+    const provider = localProvider({ tmux: true, ctx: ctx as never });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    vi.mocked(events.emit).mockClear();
+    await provider.detachSession(item.id);
+    for (const handler of exitHandlers) handler({ exitCode: 0 });
+
+    expect(pty.kill).toHaveBeenCalledTimes(1);
+    expect(ctx.exec).not.toHaveBeenCalled();
+    expect(events.emit).not.toHaveBeenCalledWith(
+      agentSessionExitedChannel,
+      expect.objectContaining({ sessionId })
+    );
+    expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(true);
+  });
+
+  it('detaches SSH tmux conversations without killing the tmux session', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    const pty = fakePty(exitHandlers);
+    openSsh2Pty.mockResolvedValue({ success: true, data: pty });
+    const ctx = {
+      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
+    };
+    const provider = sshProvider(undefined, { tmux: true, ctx: ctx as never });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    vi.mocked(events.emit).mockClear();
+    await provider.detachSession(item.id);
+    for (const handler of exitHandlers) handler({ exitCode: 0 });
+
+    expect(pty.kill).toHaveBeenCalledTimes(1);
+    expect(ctx.exec).not.toHaveBeenCalled();
+    expect(events.emit).not.toHaveBeenCalledWith(
+      agentSessionExitedChannel,
+      expect.objectContaining({ sessionId })
+    );
+    expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(true);
+  });
+
+  it('kills tmux when explicitly stopping a detached local conversation', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+    const ctx = {
+      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
+    };
+    const provider = localProvider({ tmux: true, ctx: ctx as never });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    await provider.detachSession(item.id);
+    await provider.stopSession(item.id);
+
+    expect(ctx.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
+    ]);
+    expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
+  });
+
+  it('kills tmux when explicitly stopping a detached SSH conversation', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    openSsh2Pty.mockResolvedValue({ success: true, data: fakePty(exitHandlers) });
+    const ctx = {
+      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
+    };
+    const provider = sshProvider(undefined, { tmux: true, ctx: ctx as never });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    await provider.detachSession(item.id);
+    await provider.stopSession(item.id);
+
+    expect(ctx.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
+    ]);
+    expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
+  });
+
+  it('ignores stale local attach exits after a tmux conversation is rehydrated', async () => {
+    const firstExitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    const secondExitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    const firstPty = fakePty(firstExitHandlers);
+    const secondPty = fakePty(secondExitHandlers);
+    spawnLocalPty.mockReturnValueOnce(firstPty).mockReturnValueOnce(secondPty);
+    const provider = localProvider({ tmux: true });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    await provider.detachSession(item.id);
+    await provider.startSession(item);
+    vi.mocked(events.emit).mockClear();
+    for (const handler of firstExitHandlers) handler({ exitCode: 0 });
+
+    expect((provider as unknown as RespawnState).sessions.get(sessionId)).toBe(secondPty);
+    expect(events.emit).not.toHaveBeenCalledWith(
+      agentSessionExitedChannel,
+      expect.objectContaining({ sessionId })
+    );
+  });
+
+  it('ignores stale SSH attach exits after a tmux conversation is rehydrated', async () => {
+    const firstExitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    const secondExitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    const firstPty = fakePty(firstExitHandlers);
+    const secondPty = fakePty(secondExitHandlers);
+    openSsh2Pty
+      .mockResolvedValueOnce({ success: true, data: firstPty })
+      .mockResolvedValueOnce({ success: true, data: secondPty });
+    const provider = sshProvider(undefined, { tmux: true });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    await provider.detachSession(item.id);
+    await provider.startSession(item);
+    vi.mocked(events.emit).mockClear();
+    for (const handler of firstExitHandlers) handler({ exitCode: 0 });
+
+    expect((provider as unknown as RespawnState).sessions.get(sessionId)).toBe(secondPty);
+    expect(events.emit).not.toHaveBeenCalledWith(
+      agentSessionExitedChannel,
+      expect.objectContaining({ sessionId })
+    );
   });
 });

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -37,6 +37,7 @@ export class LocalConversationProvider implements ConversationProvider {
   private sessions = new Map<string, Pty>();
   private knownSessionIds = new Set<string>();
   private respawnCounts = new Map<string, number>();
+  private suppressedExitPtys = new WeakSet<Pty>();
   private readonly projectId: string;
   private readonly taskPath: string;
   private readonly taskId: string;
@@ -186,17 +187,22 @@ export class LocalConversationProvider implements ConversationProvider {
     }
 
     pty.onExit(({ exitCode, signal }) => {
+      const currentPty = this.sessions.get(sessionId);
+      if (currentPty !== undefined && currentPty !== pty) return;
+
       ptySessionRegistry.unregister(sessionId);
-      const shouldRespawn =
-        this.sessions.has(sessionId) && isUnexpectedPtyExit({ exitCode, signal });
+      const shouldRespawn = currentPty === pty && isUnexpectedPtyExit({ exitCode, signal });
       this.sessions.delete(sessionId);
-      events.emit(agentSessionExitedChannel, {
-        sessionId,
-        projectId: conversation.projectId,
-        conversationId: conversation.id,
-        taskId: conversation.taskId,
-        exitCode,
-      });
+      const suppressExitEvent = this.suppressedExitPtys.has(pty);
+      if (!suppressExitEvent) {
+        events.emit(agentSessionExitedChannel, {
+          sessionId,
+          projectId: conversation.projectId,
+          conversationId: conversation.id,
+          taskId: conversation.taskId,
+          exitCode,
+        });
+      }
       if (shouldRespawn && !this.tmux) {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
         this.respawnCounts.set(sessionId, count);
@@ -258,20 +264,36 @@ export class LocalConversationProvider implements ConversationProvider {
     }
   }
 
-  async stopSession(conversationId: string): Promise<void> {
-    const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.knownSessionIds.delete(sessionId);
+  private detachPty(sessionId: string): void {
     this.respawnCounts.delete(sessionId);
     const pty = this.sessions.get(sessionId);
+    this.sessions.delete(sessionId);
+    ptySessionRegistry.unregister(sessionId);
     if (pty) {
       try {
         pty.kill();
       } catch (e) {
         log.warn('LocalAgentProvider: error killing PTY', { sessionId, error: String(e) });
       }
-      this.sessions.delete(sessionId);
-      ptySessionRegistry.unregister(sessionId);
     }
+  }
+
+  async detachSession(conversationId: string): Promise<void> {
+    const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
+    const pty = this.sessions.get(sessionId);
+    if (this.tmux && pty) {
+      this.suppressedExitPtys.add(pty);
+    }
+    this.detachPty(sessionId);
+    if (!this.tmux) {
+      this.knownSessionIds.delete(sessionId);
+    }
+  }
+
+  async stopSession(conversationId: string): Promise<void> {
+    const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
+    this.knownSessionIds.delete(sessionId);
+    this.detachPty(sessionId);
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
@@ -288,6 +310,9 @@ export class LocalConversationProvider implements ConversationProvider {
 
   async detachAll(): Promise<void> {
     for (const [sessionId, pty] of this.sessions) {
+      if (this.tmux) {
+        this.suppressedExitPtys.add(pty);
+      }
       try {
         pty.kill();
       } catch {}

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -31,6 +31,7 @@ export class SshConversationProvider implements ConversationProvider {
   private sessions = new Map<string, Pty>();
   private knownSessionIds = new Set<string>();
   private respawnCounts = new Map<string, number>();
+  private suppressedExitPtys = new WeakSet<Pty>();
   private readonly projectId: string;
   private readonly taskPath: string;
   private readonly taskId: string;
@@ -171,6 +172,9 @@ export class SshConversationProvider implements ConversationProvider {
     });
 
     pty.onExit(({ exitCode, signal }) => {
+      const currentPty = this.sessions.get(sessionId);
+      if (currentPty !== undefined && currentPty !== pty) return;
+
       ptySessionRegistry.unregister(sessionId);
       const sessionWasActive = this.sessions.has(sessionId);
       const shouldRetryAfterShellRefresh =
@@ -197,13 +201,16 @@ export class SshConversationProvider implements ConversationProvider {
         return;
       }
 
-      events.emit(agentSessionExitedChannel, {
-        sessionId,
-        projectId: conversation.projectId,
-        conversationId: conversation.id,
-        taskId: conversation.taskId,
-        exitCode,
-      });
+      const suppressExitEvent = this.suppressedExitPtys.has(pty);
+      if (!suppressExitEvent) {
+        events.emit(agentSessionExitedChannel, {
+          sessionId,
+          projectId: conversation.projectId,
+          conversationId: conversation.id,
+          taskId: conversation.taskId,
+          exitCode,
+        });
+      }
 
       if (shouldRespawn && !this.tmux) {
         const count = (this.respawnCounts.get(sessionId) ?? 0) + 1;
@@ -242,20 +249,36 @@ export class SshConversationProvider implements ConversationProvider {
     });
   }
 
-  async stopSession(conversationId: string): Promise<void> {
-    const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.knownSessionIds.delete(sessionId);
+  private detachPty(sessionId: string): void {
     this.respawnCounts.delete(sessionId);
     const pty = this.sessions.get(sessionId);
+    this.sessions.delete(sessionId);
+    ptySessionRegistry.unregister(sessionId);
     if (pty) {
       try {
         pty.kill();
       } catch (e) {
         log.warn('SshAgentProvider: error killing PTY', { sessionId, error: String(e) });
       }
-      this.sessions.delete(sessionId);
-      ptySessionRegistry.unregister(sessionId);
     }
+  }
+
+  async detachSession(conversationId: string): Promise<void> {
+    const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
+    const pty = this.sessions.get(sessionId);
+    if (this.tmux && pty) {
+      this.suppressedExitPtys.add(pty);
+    }
+    this.detachPty(sessionId);
+    if (!this.tmux) {
+      this.knownSessionIds.delete(sessionId);
+    }
+  }
+
+  async stopSession(conversationId: string): Promise<void> {
+    const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
+    this.knownSessionIds.delete(sessionId);
+    this.detachPty(sessionId);
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
@@ -272,6 +295,9 @@ export class SshConversationProvider implements ConversationProvider {
 
   async detachAll(): Promise<void> {
     for (const [sessionId, pty] of this.sessions) {
+      if (this.tmux) {
+        this.suppressedExitPtys.add(pty);
+      }
       try {
         pty.kill();
       } catch {}

--- a/src/main/core/conversations/types.ts
+++ b/src/main/core/conversations/types.ts
@@ -7,6 +7,7 @@ export interface ConversationProvider {
     isResuming?: boolean,
     initialPrompt?: string
   ): Promise<void>;
+  detachSession(conversationId: string): Promise<void>;
   stopSession(conversationId: string): Promise<void>;
   destroyAll(): Promise<void>;
   detachAll(): Promise<void>;


### PR DESCRIPTION
- detach conversation PTYs during dehydrate instead of killing the underlying tmux session
- suppress exit events from intentional tmux detach so active conversations keep their working state
- prevent stale attach PTY exits from clearing a newly rehydrated session
- clean up deterministic tmux sessions when deleting conversations without a mounted task provider