### PR TITLE
fix(tasks): require fresh fetch for remote source branches

### DIFF
--- a/src/main/core/git/impl/git-service.test.ts
+++ b/src/main/core/git/impl/git-service.test.ts
@@ -424,6 +424,72 @@ describe('GitService.createBranch', () => {
       data: undefined,
     });
   });
+
+  it('fails remote source branch creation when fetch fails', async () => {
+    const svc = makeService(async (_cmd, args = []) => {
+      const key = args.join(' ');
+      if (key === 'fetch origin') {
+        throw Object.assign(new Error('fetch failed'), {
+          stdout: '',
+          stderr:
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+          code: 128,
+        });
+      }
+      throw Object.assign(new Error(`Unexpected git command: git ${key}`), {
+        stdout: '',
+        stderr: 'fatal: not expected',
+        code: 128,
+      });
+    });
+
+    await expect(svc.createBranch('task/remote', 'main', true, 'origin')).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'fetch_failed',
+        remote: 'origin',
+        branch: 'main',
+        error: {
+          type: 'auth_failed',
+          message:
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+        },
+      },
+    });
+  });
+
+  it('classifies SSH connection failures while creating a remote source branch as network errors', async () => {
+    const message =
+      'ssh: connect to host github.com port 22: Undefined error: 0\nfatal: Could not read from remote repository.';
+    const svc = makeService(async (_cmd, args = []) => {
+      const key = args.join(' ');
+      if (key === 'fetch origin') {
+        throw Object.assign(new Error('fetch failed'), {
+          stdout: '',
+          stderr: message,
+          code: 128,
+        });
+      }
+      throw Object.assign(new Error(`Unexpected git command: git ${key}`), {
+        stdout: '',
+        stderr: 'fatal: not expected',
+        code: 128,
+      });
+    });
+
+    await expect(svc.createBranch('task/remote', 'main', true, 'origin')).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'fetch_failed',
+        remote: 'origin',
+        branch: 'main',
+        error: {
+          type: 'network_error',
+          message,
+        },
+      },
+    });
+  });
 });
 
 describe('GitService.fetch', () => {

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -96,7 +96,6 @@ function classifyFetchError(stderr: string): FetchError {
     stderr.includes('does not appear to be a git repository') ||
     stderr.includes('repository not found') ||
     stderr.includes('Repository not found') ||
-    stderr.includes('not found') ||
     stderr.includes('ERROR: Repository not found')
   ) {
     return { type: 'remote_not_found', message: stderr };

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -67,6 +67,43 @@ const STATUS_FINGERPRINT_TIMEOUT_MS: Record<GitStatusUntrackedMode, number> = {
   normal: 10_000,
 };
 
+function classifyFetchError(stderr: string): FetchError {
+  if (
+    stderr.includes('Authentication failed') ||
+    stderr.includes('authentication failed') ||
+    stderr.includes('Permission denied') ||
+    stderr.includes('could not read Username')
+  ) {
+    return { type: 'auth_failed', message: stderr };
+  }
+  if (
+    stderr.includes('Could not resolve host') ||
+    stderr.includes('could not resolve host') ||
+    stderr.includes('Network is unreachable') ||
+    stderr.includes('Connection refused') ||
+    stderr.includes('Connection timed out') ||
+    stderr.includes('No route to host') ||
+    stderr.includes('Network is down') ||
+    stderr.includes('Could not resolve hostname') ||
+    stderr.includes('Temporary failure in name resolution') ||
+    stderr.includes('Name or service not known') ||
+    stderr.includes('ssh: connect to host') ||
+    stderr.includes('unable to connect')
+  ) {
+    return { type: 'network_error', message: stderr };
+  }
+  if (
+    stderr.includes('does not appear to be a git repository') ||
+    stderr.includes('repository not found') ||
+    stderr.includes('Repository not found') ||
+    stderr.includes('not found') ||
+    stderr.includes('ERROR: Repository not found')
+  ) {
+    return { type: 'remote_not_found', message: stderr };
+  }
+  return { type: 'error', message: stderr };
+}
+
 const IMAGE_MIME_BY_EXT: Record<string, string> = {
   png: 'image/png',
   jpg: 'image/jpeg',
@@ -1013,34 +1050,7 @@ export class GitService implements GitProvider, IDisposable {
       return ok();
     } catch (error: unknown) {
       const stderr = (error as { stderr?: string })?.stderr || String(error);
-      if (
-        stderr.includes('Authentication failed') ||
-        stderr.includes('authentication failed') ||
-        stderr.includes('Permission denied') ||
-        stderr.includes('could not read Username')
-      ) {
-        return err({ type: 'auth_failed', message: stderr });
-      }
-      if (
-        stderr.includes('Could not resolve host') ||
-        stderr.includes('could not resolve host') ||
-        stderr.includes('Network is unreachable') ||
-        stderr.includes('Connection refused') ||
-        stderr.includes('Connection timed out') ||
-        stderr.includes('unable to connect')
-      ) {
-        return err({ type: 'network_error', message: stderr });
-      }
-      if (
-        stderr.includes('does not appear to be a git repository') ||
-        stderr.includes('repository not found') ||
-        stderr.includes('Repository not found') ||
-        stderr.includes('not found') ||
-        stderr.includes('ERROR: Repository not found')
-      ) {
-        return err({ type: 'remote_not_found', message: stderr });
-      }
-      return err({ type: 'error', message: stderr });
+      return err(classifyFetchError(stderr));
     }
   }
 
@@ -1483,11 +1493,19 @@ export class GitService implements GitProvider, IDisposable {
     remote = 'origin'
   ): Promise<Result<void, CreateBranchError>> {
     if (syncWithRemote) {
-      await this.ctx
-        .exec('git', ['fetch', remote], {
+      try {
+        await this.ctx.exec('git', ['fetch', remote], {
           maxBuffer: MAX_REF_LIST_BYTES,
-        })
-        .catch(() => {});
+        });
+      } catch (error: unknown) {
+        const stderr = (error as { stderr?: string })?.stderr || String(error);
+        return err({
+          type: 'fetch_failed',
+          remote,
+          branch: from,
+          error: classifyFetchError(stderr),
+        });
+      }
     }
     const base = syncWithRemote ? `${remote}/${from}` : `refs/heads/${from}`;
     try {

--- a/src/main/core/tasks/operations/createTask.test.ts
+++ b/src/main/core/tasks/operations/createTask.test.ts
@@ -14,6 +14,9 @@ const mocks = vi.hoisted(() => ({
   findBranchAnywhere: vi.fn(),
   fetchPrForReview: vi.fn(),
   getConfiguredRemotes: vi.fn(),
+  getRepositoryInfo: vi.fn(),
+  createBranch: vi.fn(),
+  publishBranch: vi.fn(),
 }));
 
 vi.mock('@main/db/client', () => ({
@@ -82,6 +85,9 @@ describe('createTask', () => {
     mocks.findBranchAnywhere.mockResolvedValue('/external/worktrees/pr-branch');
     mocks.fetchPrForReview.mockResolvedValue({ success: true });
     mocks.getConfiguredRemotes.mockResolvedValue({ baseRemote: 'origin', pushRemote: 'origin' });
+    mocks.getRepositoryInfo.mockResolvedValue({ isUnborn: false, currentBranch: 'main' });
+    mocks.createBranch.mockResolvedValue({ success: true, data: undefined });
+    mocks.publishBranch.mockResolvedValue({ success: true, data: { output: '' } });
     mocks.getProject.mockReturnValue({
       defaultWorkspaceType: { kind: 'local' },
       worktreeService: {
@@ -89,6 +95,9 @@ describe('createTask', () => {
       },
       repository: {
         getConfiguredRemotes: mocks.getConfiguredRemotes,
+        getRepositoryInfo: mocks.getRepositoryInfo,
+        createBranch: mocks.createBranch,
+        publishBranch: mocks.publishBranch,
         fetchPrForReview: mocks.fetchPrForReview,
       },
     });
@@ -188,5 +197,81 @@ describe('createTask', () => {
         }),
       })
     );
+  });
+
+  it('creates branch-based tasks from local source branches without remote sync', async () => {
+    const insertTaskValues = vi.fn((values: Partial<TaskRow>) => ({
+      returning: vi.fn().mockResolvedValue([makeTaskRow(values)]),
+    }));
+    const insertWorkspaceValues = vi.fn().mockResolvedValue(undefined);
+    mocks.insert
+      .mockReturnValueOnce({ values: insertTaskValues })
+      .mockReturnValueOnce({ values: insertWorkspaceValues });
+
+    const result = await createTask({
+      id: 'task-1',
+      projectId: 'project-1',
+      name: 'Local task',
+      sourceBranch: { type: 'local', branch: 'main' },
+      strategy: {
+        kind: 'new-branch',
+        taskBranch: 'task/local',
+        pushBranch: false,
+      },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.createBranch).toHaveBeenCalledWith('task/local', 'main', false, undefined);
+  });
+
+  it('blocks branch-based tasks when the selected remote source branch cannot be fetched', async () => {
+    mocks.createBranch.mockResolvedValueOnce(
+      err({
+        type: 'fetch_failed',
+        remote: 'origin',
+        branch: 'main',
+        error: {
+          type: 'auth_failed',
+          message:
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+        },
+      })
+    );
+
+    const result = await createTask({
+      id: 'task-1',
+      projectId: 'project-1',
+      name: 'Remote task',
+      sourceBranch: {
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin', url: 'https://github.com/example/repo.git' },
+      },
+      strategy: {
+        kind: 'new-branch',
+        taskBranch: 'task/remote',
+        pushBranch: false,
+      },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'branch-create-failed',
+        branch: 'task/remote',
+        error: {
+          type: 'fetch_failed',
+          remote: 'origin',
+          branch: 'main',
+          error: {
+            type: 'auth_failed',
+            message:
+              "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+          },
+        },
+      },
+    });
+    expect(mocks.createBranch).toHaveBeenCalledWith('task/remote', 'main', true, 'origin');
+    expect(mocks.insert).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -160,6 +160,8 @@ export const CreateTaskModal = observer(function CreateTaskModal({
 
     const { linkedType, linkedIssue, linkedPR, checkoutMode, branchSelection, branchNameState } =
       state;
+    const taskManager = projectStore.mountedProject!.taskManager;
+    const swallowHandledCreateError = () => {};
 
     if (linkedType === 'pr' && linkedPR) {
       const reviewBranch = linkedPR.headRefName;
@@ -172,16 +174,18 @@ export const CreateTaskModal = observer(function CreateTaskModal({
         taskBranch: state.taskName.effectiveTaskName,
         pushBranch: branchSelection.pushBranch,
       });
-      void projectStore.mountedProject!.taskManager.createTask({
-        id,
-        projectId: selectedProjectId,
-        name: state.taskName.effectiveTaskName,
-        sourceBranch: { type: 'local', branch: reviewBranch },
-        initialStatus: linkedPR.status === 'open' && !linkedPR.isDraft ? 'review' : undefined,
-        strategy: useBYOI ? { kind: 'no-worktree' } : taskStrategy,
-        workspaceProvider: useBYOI ? 'byoi' : undefined,
-        initialConversation: builtInitialConversation,
-      });
+      void taskManager
+        .createTask({
+          id,
+          projectId: selectedProjectId,
+          name: state.taskName.effectiveTaskName,
+          sourceBranch: { type: 'local', branch: reviewBranch },
+          initialStatus: linkedPR.status === 'open' && !linkedPR.isDraft ? 'review' : undefined,
+          strategy: useBYOI ? { kind: 'no-worktree' } : taskStrategy,
+          workspaceProvider: useBYOI ? 'byoi' : undefined,
+          initialConversation: builtInitialConversation,
+        })
+        .catch(swallowHandledCreateError);
     } else {
       if (!branchSelection.selectedBranch) return;
       const taskStrategy = resolveBranchLikeTaskStrategy({
@@ -190,16 +194,18 @@ export const CreateTaskModal = observer(function CreateTaskModal({
         taskBranch: branchNameState.branchName,
         pushBranch: branchSelection.pushBranch,
       });
-      void projectStore.mountedProject!.taskManager.createTask({
-        id,
-        projectId: selectedProjectId,
-        name: state.taskName.effectiveTaskName,
-        sourceBranch: branchSelection.selectedBranch,
-        strategy: useBYOI ? { kind: 'no-worktree' } : taskStrategy,
-        linkedIssue: linkedType === 'issue' ? (linkedIssue ?? undefined) : undefined,
-        workspaceProvider: useBYOI ? 'byoi' : undefined,
-        initialConversation: builtInitialConversation,
-      });
+      void taskManager
+        .createTask({
+          id,
+          projectId: selectedProjectId,
+          name: state.taskName.effectiveTaskName,
+          sourceBranch: branchSelection.selectedBranch,
+          strategy: useBYOI ? { kind: 'no-worktree' } : taskStrategy,
+          linkedIssue: linkedType === 'issue' ? (linkedIssue ?? undefined) : undefined,
+          workspaceProvider: useBYOI ? 'byoi' : undefined,
+          initialConversation: builtInitialConversation,
+        })
+        .catch(swallowHandledCreateError);
     }
 
     navigate('task', { projectId: selectedProjectId, taskId: id });

--- a/src/renderer/features/tasks/stores/task-manager.ts
+++ b/src/renderer/features/tasks/stores/task-manager.ts
@@ -43,7 +43,7 @@ function formatFetchErrorDetail(error: FetchError): string {
     case 'remote_not_found':
       return 'The remote repository was not found, or your local Git credentials do not have access.';
     case 'error':
-      return error.message;
+      return 'An unexpected error occurred while fetching from the remote.';
   }
 }
 

--- a/src/renderer/features/tasks/stores/task-manager.ts
+++ b/src/renderer/features/tasks/stores/task-manager.ts
@@ -8,6 +8,7 @@ import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
 import { log } from '@renderer/utils/logger';
 import { prSyncProgressChannel, prUpdatedChannel } from '@shared/events/prEvents';
 import { taskProvisionProgressChannel, taskStatusUpdatedChannel } from '@shared/events/taskEvents';
+import type { FetchError } from '@shared/git';
 import type {
   CreateTaskError,
   CreateTaskParams,
@@ -31,6 +32,21 @@ import {
 import { terminalRegistry } from './terminal-registry';
 import { workspaceRegistry } from './workspace-registry';
 
+function formatFetchErrorDetail(error: FetchError): string {
+  switch (error.type) {
+    case 'no_remote':
+      return 'No remote is configured for this repository.';
+    case 'auth_failed':
+      return 'Authentication failed. Authenticate Git on this machine, then try again.';
+    case 'network_error':
+      return 'Cannot reach the remote. Check your network connection, then try again.';
+    case 'remote_not_found':
+      return 'The remote repository was not found, or your local Git credentials do not have access.';
+    case 'error':
+      return error.message;
+  }
+}
+
 function formatCreateTaskError(error: CreateTaskError): string {
   switch (error.type) {
     case 'project-not-found':
@@ -41,6 +57,8 @@ function formatCreateTaskError(error: CreateTaskError): string {
       switch (error.error.type) {
         case 'already_exists':
           return `Branch "${error.error.name}" already exists. Try a different task name.`;
+        case 'fetch_failed':
+          return `Could not update "${error.error.remote}/${error.error.branch}" before creating the task: ${formatFetchErrorDetail(error.error.error)}`;
         case 'invalid_base':
           return `Source branch "${error.error.from}" is not a valid base. Check that it exists locally or on the selected remote.`;
         case 'invalid_name':

--- a/src/shared/git.ts
+++ b/src/shared/git.ts
@@ -288,6 +288,7 @@ export type SoftResetError =
 
 export type CreateBranchError =
   | { type: 'already_exists'; name: string }
+  | { type: 'fetch_failed'; remote: string; branch: string; error: FetchError }
   | { type: 'invalid_base'; from: string }
   | { type: 'invalid_name'; name: string }
   | { type: 'error'; message: string };


### PR DESCRIPTION
- require remote source branch fetches to succeed before creating task branches
- prevent tasks from silently using stale origin/main when auth or network access fails
- show clearer create-task errors for auth, network and missing remote failures
- classify offline SSH fetch failures as network errors
- handle create-task failures in the modal so the task error screen owns the failure state