### PR TITLE
feat: support deeplinks to linear agents in emdash

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,4 +81,3 @@ tooling/db/dev.db-shm
 tooling/node-deps/node_modules/
 .pi/extensions/emdash-hook.ts
 .opencode/plugins/emdash-notifications.js
-.amp/plugins/emdash-hook.ts

--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,4 @@ tooling/db/dev.db-shm
 tooling/node-deps/node_modules/
 .pi/extensions/emdash-hook.ts
 .opencode/plugins/emdash-notifications.js
+.amp/plugins/emdash-hook.ts

--- a/electron-builder.canary.config.ts
+++ b/electron-builder.canary.config.ts
@@ -10,6 +10,7 @@ import {
 const config: Configuration = {
   appId: APP_ID,
   productName: PRODUCT_NAME,
+  protocols: [{ name: PRODUCT_NAME, schemes: [ARTIFACT_PREFIX] }],
   directories: { output: 'release' },
   artifactName: `${ARTIFACT_PREFIX}-\${arch}.\${ext}`,
   publish: [

--- a/electron-builder.config.ts
+++ b/electron-builder.config.ts
@@ -10,6 +10,7 @@ import {
 const config: Configuration = {
   appId: APP_ID,
   productName: PRODUCT_NAME,
+  protocols: [{ name: PRODUCT_NAME, schemes: [ARTIFACT_PREFIX] }],
   directories: { output: 'release' },
   artifactName: `${ARTIFACT_PREFIX}-\${arch}.\${ext}`,
   publish: [

--- a/src/main/core/app/controller.ts
+++ b/src/main/core/app/controller.ts
@@ -49,6 +49,7 @@ export const appController = createRPCController({
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
+  drainPendingDeepLinks: () => appService.drainPendingDeepLinks(),
   openIn: async (args: {
     app: OpenInAppId;
     path: string;

--- a/src/main/core/app/deep-link.test.ts
+++ b/src/main/core/app/deep-link.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { parseLinearAgentDeepLink } from './deep-link';
+
+describe('parseLinearAgentDeepLink', () => {
+  it('parses Linear agent deeplinks with issue metadata', () => {
+    const deepLink = parseLinearAgentDeepLink(
+      'emdash://linear-agent?issue=eng-1450&projectId=project-1&agentProvider=codex&prompt=Fix%20it&issueTitle=Title&issueDescription=Desc&branchName=user/eng-1450-title'
+    );
+
+    expect(deepLink).toEqual({
+      type: 'linear-agent',
+      projectId: 'project-1',
+      agentProvider: 'codex',
+      prompt: 'Fix it',
+      issue: {
+        identifier: 'ENG-1450',
+        url: undefined,
+        title: 'Title',
+        description: 'Desc',
+        branchName: 'user/eng-1450-title',
+      },
+    });
+  });
+
+  it('extracts the issue identifier from Linear URLs and ignores invalid providers', () => {
+    const deepLink = parseLinearAgentDeepLink(
+      'emdash://linear/agent?url=https%3A%2F%2Flinear.app%2Fgeneral-action%2Fissue%2FENG-1450%2Ftitle&provider=unknown'
+    );
+
+    expect(deepLink?.agentProvider).toBeUndefined();
+    expect(deepLink?.issue.identifier).toBe('ENG-1450');
+    expect(deepLink?.issue.url).toBe('https://linear.app/general-action/issue/ENG-1450/title');
+  });
+
+  it('rejects unsupported schemes, actions, and missing identifiers', () => {
+    expect(parseLinearAgentDeepLink('https://linear-agent?issue=ENG-1450')).toBeNull();
+    expect(parseLinearAgentDeepLink('emdash://settings?issue=ENG-1450')).toBeNull();
+    expect(parseLinearAgentDeepLink('emdash://linear-agent')).toBeNull();
+  });
+});

--- a/src/main/core/app/deep-link.ts
+++ b/src/main/core/app/deep-link.ts
@@ -1,0 +1,89 @@
+import { AGENT_PROVIDER_IDS, type AgentProviderId } from '@shared/agent-provider-registry';
+import { APP_NAME_LOWER } from '@shared/app-identity';
+import type { AppDeepLinkEvent } from '@shared/events/appEvents';
+
+const LINEAR_IDENTIFIER_RE = /[A-Z][A-Z0-9]+-\d+/i;
+const AGENT_PROVIDER_ID_SET = new Set<string>(AGENT_PROVIDER_IDS);
+
+function firstQueryValue(params: URLSearchParams, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = params.get(name)?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function parseLinearIssueIdentifier(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    const match = parsed.pathname.match(LINEAR_IDENTIFIER_RE);
+    if (match) return match[0].toUpperCase();
+  } catch {}
+
+  const match = value.match(LINEAR_IDENTIFIER_RE);
+  return match?.[0].toUpperCase();
+}
+
+function parseAgentProvider(value: string | undefined): AgentProviderId | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  return AGENT_PROVIDER_ID_SET.has(normalized) ? (normalized as AgentProviderId) : undefined;
+}
+
+export function parseLinearAgentDeepLink(rawUrl: string): AppDeepLinkEvent | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== `${APP_NAME_LOWER}:`) return null;
+
+  const pathParts = parsed.pathname.split('/').filter(Boolean);
+  const host = parsed.hostname.toLowerCase();
+  const action = [host, ...pathParts].join('/').toLowerCase();
+  const isLinearAgentAction =
+    action === 'linear-agent' ||
+    action.startsWith('linear-agent/') ||
+    action === 'linear/agent' ||
+    action.startsWith('linear/agent/') ||
+    action === 'linear/agents' ||
+    action.startsWith('linear/agents/') ||
+    action === 'agents/linear' ||
+    action.startsWith('agents/linear/');
+
+  if (!isLinearAgentAction) return null;
+
+  const issueUrl = firstQueryValue(parsed.searchParams, ['issueUrl', 'issueURL', 'url']);
+  const identifier = parseLinearIssueIdentifier(
+    firstQueryValue(parsed.searchParams, [
+      'identifier',
+      'issueIdentifier',
+      'issueKey',
+      'issue',
+      'key',
+    ]) ??
+      issueUrl ??
+      pathParts.at(-1)
+  );
+
+  if (!identifier) return null;
+
+  return {
+    type: 'linear-agent',
+    projectId: firstQueryValue(parsed.searchParams, ['projectId', 'project']),
+    agentProvider: parseAgentProvider(
+      firstQueryValue(parsed.searchParams, ['agentProvider', 'provider', 'agent'])
+    ),
+    prompt: firstQueryValue(parsed.searchParams, ['prompt', 'message', 'instructions']),
+    issue: {
+      identifier,
+      url: issueUrl,
+      title: firstQueryValue(parsed.searchParams, ['issueTitle', 'title']),
+      description: firstQueryValue(parsed.searchParams, ['issueDescription', 'description']),
+      branchName: firstQueryValue(parsed.searchParams, ['branchName', 'branch']),
+    },
+  };
+}

--- a/src/main/core/app/service.ts
+++ b/src/main/core/app/service.ts
@@ -16,7 +16,15 @@ import {
   buildRemoteSshCommand,
   buildRemoteTerminalExecArgs,
 } from '@main/utils/remoteOpenIn';
-import { appPasteChannel, appRedoChannel, appUndoChannel } from '@shared/events/appEvents';
+import { AGENT_PROVIDER_IDS, type AgentProviderId } from '@shared/agent-provider-registry';
+import { APP_NAME_LOWER } from '@shared/app-identity';
+import {
+  appDeepLinkChannel,
+  appPasteChannel,
+  appRedoChannel,
+  appUndoChannel,
+  type AppDeepLinkEvent,
+} from '@shared/events/appEvents';
 import {
   getAppById,
   getResolvedLabel,
@@ -38,6 +46,8 @@ import {
 
 const FONT_CACHE_TTL_MS = 5 * 60 * 1_000;
 const MAX_AUDIO_FILE_BYTES = 20 * 1024 * 1024;
+const LINEAR_IDENTIFIER_RE = /[A-Z][A-Z0-9]+-\d+/i;
+const AGENT_PROVIDER_ID_SET = new Set<string>(AGENT_PROVIDER_IDS);
 
 const AUDIO_MIME_TYPES: Record<string, string> = {
   '.aac': 'audio/aac',
@@ -74,10 +84,94 @@ type RemoteTerminalLaunchAttempt = {
   args: string[];
 };
 
+function firstQueryValue(params: URLSearchParams, names: string[]): string | undefined {
+  for (const name of names) {
+    const value = params.get(name)?.trim();
+    if (value) return value;
+  }
+  return undefined;
+}
+
+function parseLinearIssueIdentifier(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const parsed = new URL(value);
+    const match = parsed.pathname.match(LINEAR_IDENTIFIER_RE);
+    if (match) return match[0].toUpperCase();
+  } catch {}
+
+  const match = value.match(LINEAR_IDENTIFIER_RE);
+  return match?.[0].toUpperCase();
+}
+
+function parseAgentProvider(value: string | undefined): AgentProviderId | undefined {
+  if (!value) return undefined;
+  const normalized = value.trim().toLowerCase();
+  return AGENT_PROVIDER_ID_SET.has(normalized) ? (normalized as AgentProviderId) : undefined;
+}
+
+function parseLinearAgentDeepLink(rawUrl: string): AppDeepLinkEvent | null {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    return null;
+  }
+
+  if (parsed.protocol !== `${APP_NAME_LOWER}:`) return null;
+
+  const pathParts = parsed.pathname.split('/').filter(Boolean);
+  const host = parsed.hostname.toLowerCase();
+  const action = [host, ...pathParts].join('/').toLowerCase();
+  const isLinearAgentAction =
+    action === 'linear-agent' ||
+    action.startsWith('linear-agent/') ||
+    action === 'linear/agent' ||
+    action.startsWith('linear/agent/') ||
+    action === 'linear/agents' ||
+    action.startsWith('linear/agents/') ||
+    action === 'agents/linear';
+
+  if (!isLinearAgentAction) return null;
+
+  const issueUrl = firstQueryValue(parsed.searchParams, ['issueUrl', 'issueURL', 'url']);
+  const identifier = parseLinearIssueIdentifier(
+    firstQueryValue(parsed.searchParams, [
+      'identifier',
+      'issueIdentifier',
+      'issueKey',
+      'issue',
+      'key',
+    ]) ??
+      issueUrl ??
+      pathParts.at(-1)
+  );
+
+  if (!identifier) return null;
+
+  return {
+    type: 'linear-agent',
+    projectId: firstQueryValue(parsed.searchParams, ['projectId', 'project']),
+    agentProvider: parseAgentProvider(
+      firstQueryValue(parsed.searchParams, ['agentProvider', 'provider', 'agent'])
+    ),
+    prompt: firstQueryValue(parsed.searchParams, ['prompt', 'message', 'instructions']),
+    issue: {
+      identifier,
+      url: issueUrl,
+      title: firstQueryValue(parsed.searchParams, ['issueTitle', 'title']),
+      description: firstQueryValue(parsed.searchParams, ['issueDescription', 'description']),
+      branchName: firstQueryValue(parsed.searchParams, ['branchName', 'branch']),
+    },
+  };
+}
+
 class AppService implements IInitializable, IDisposable {
   private cachedAppVersion: string | null = null;
   private cachedAppVersionPromise: Promise<string> | null = null;
   private cachedInstalledFonts: { fonts: string[]; fetchedAt: number } | null = null;
+  private pendingDeepLinks: AppDeepLinkEvent[] = [];
+  private rendererReadyForDeepLinks = false;
   private _unsubscribes: Array<() => void> = [];
 
   initialize(): void {
@@ -233,6 +327,30 @@ class AppService implements IInitializable, IDisposable {
 
   quit(): void {
     app.quit();
+  }
+
+  handleDeepLink(rawUrl: string): boolean {
+    const deepLink = parseLinearAgentDeepLink(rawUrl);
+    if (!deepLink) return false;
+
+    const win = getMainWindow();
+    if (win?.isMinimized()) win.restore();
+    win?.focus();
+
+    if (this.rendererReadyForDeepLinks && win && !win.isDestroyed()) {
+      events.emit(appDeepLinkChannel, deepLink);
+    } else {
+      this.pendingDeepLinks.push(deepLink);
+    }
+
+    return true;
+  }
+
+  drainPendingDeepLinks(): AppDeepLinkEvent[] {
+    this.rendererReadyForDeepLinks = true;
+    const pending = this.pendingDeepLinks;
+    this.pendingDeepLinks = [];
+    return pending;
   }
 
   async openIn(args: {

--- a/src/main/core/app/service.ts
+++ b/src/main/core/app/service.ts
@@ -130,7 +130,8 @@ function parseLinearAgentDeepLink(rawUrl: string): AppDeepLinkEvent | null {
     action.startsWith('linear/agent/') ||
     action === 'linear/agents' ||
     action.startsWith('linear/agents/') ||
-    action === 'agents/linear';
+    action === 'agents/linear' ||
+    action.startsWith('agents/linear/');
 
   if (!isLinearAgentAction) return null;
 
@@ -334,6 +335,7 @@ class AppService implements IInitializable, IDisposable {
     if (!deepLink) return false;
 
     const win = getMainWindow();
+    if (!win || win.isDestroyed()) this.rendererReadyForDeepLinks = false;
     if (win?.isMinimized()) win.restore();
     win?.focus();
 

--- a/src/main/core/app/service.ts
+++ b/src/main/core/app/service.ts
@@ -16,8 +16,6 @@ import {
   buildRemoteSshCommand,
   buildRemoteTerminalExecArgs,
 } from '@main/utils/remoteOpenIn';
-import { AGENT_PROVIDER_IDS, type AgentProviderId } from '@shared/agent-provider-registry';
-import { APP_NAME_LOWER } from '@shared/app-identity';
 import {
   appDeepLinkChannel,
   appPasteChannel,
@@ -33,6 +31,7 @@ import {
   type PlatformConfig,
   type PlatformKey,
 } from '@shared/openInApps';
+import { parseLinearAgentDeepLink } from './deep-link';
 import {
   checkCommand,
   checkMacApp,
@@ -46,8 +45,7 @@ import {
 
 const FONT_CACHE_TTL_MS = 5 * 60 * 1_000;
 const MAX_AUDIO_FILE_BYTES = 20 * 1024 * 1024;
-const LINEAR_IDENTIFIER_RE = /[A-Z][A-Z0-9]+-\d+/i;
-const AGENT_PROVIDER_ID_SET = new Set<string>(AGENT_PROVIDER_IDS);
+const MAX_PENDING_DEEP_LINKS = 20;
 
 const AUDIO_MIME_TYPES: Record<string, string> = {
   '.aac': 'audio/aac',
@@ -83,89 +81,6 @@ type RemoteTerminalLaunchAttempt = {
   file: string;
   args: string[];
 };
-
-function firstQueryValue(params: URLSearchParams, names: string[]): string | undefined {
-  for (const name of names) {
-    const value = params.get(name)?.trim();
-    if (value) return value;
-  }
-  return undefined;
-}
-
-function parseLinearIssueIdentifier(value: string | undefined): string | undefined {
-  if (!value) return undefined;
-  try {
-    const parsed = new URL(value);
-    const match = parsed.pathname.match(LINEAR_IDENTIFIER_RE);
-    if (match) return match[0].toUpperCase();
-  } catch {}
-
-  const match = value.match(LINEAR_IDENTIFIER_RE);
-  return match?.[0].toUpperCase();
-}
-
-function parseAgentProvider(value: string | undefined): AgentProviderId | undefined {
-  if (!value) return undefined;
-  const normalized = value.trim().toLowerCase();
-  return AGENT_PROVIDER_ID_SET.has(normalized) ? (normalized as AgentProviderId) : undefined;
-}
-
-function parseLinearAgentDeepLink(rawUrl: string): AppDeepLinkEvent | null {
-  let parsed: URL;
-  try {
-    parsed = new URL(rawUrl);
-  } catch {
-    return null;
-  }
-
-  if (parsed.protocol !== `${APP_NAME_LOWER}:`) return null;
-
-  const pathParts = parsed.pathname.split('/').filter(Boolean);
-  const host = parsed.hostname.toLowerCase();
-  const action = [host, ...pathParts].join('/').toLowerCase();
-  const isLinearAgentAction =
-    action === 'linear-agent' ||
-    action.startsWith('linear-agent/') ||
-    action === 'linear/agent' ||
-    action.startsWith('linear/agent/') ||
-    action === 'linear/agents' ||
-    action.startsWith('linear/agents/') ||
-    action === 'agents/linear' ||
-    action.startsWith('agents/linear/');
-
-  if (!isLinearAgentAction) return null;
-
-  const issueUrl = firstQueryValue(parsed.searchParams, ['issueUrl', 'issueURL', 'url']);
-  const identifier = parseLinearIssueIdentifier(
-    firstQueryValue(parsed.searchParams, [
-      'identifier',
-      'issueIdentifier',
-      'issueKey',
-      'issue',
-      'key',
-    ]) ??
-      issueUrl ??
-      pathParts.at(-1)
-  );
-
-  if (!identifier) return null;
-
-  return {
-    type: 'linear-agent',
-    projectId: firstQueryValue(parsed.searchParams, ['projectId', 'project']),
-    agentProvider: parseAgentProvider(
-      firstQueryValue(parsed.searchParams, ['agentProvider', 'provider', 'agent'])
-    ),
-    prompt: firstQueryValue(parsed.searchParams, ['prompt', 'message', 'instructions']),
-    issue: {
-      identifier,
-      url: issueUrl,
-      title: firstQueryValue(parsed.searchParams, ['issueTitle', 'title']),
-      description: firstQueryValue(parsed.searchParams, ['issueDescription', 'description']),
-      branchName: firstQueryValue(parsed.searchParams, ['branchName', 'branch']),
-    },
-  };
-}
 
 class AppService implements IInitializable, IDisposable {
   private cachedAppVersion: string | null = null;
@@ -342,7 +257,7 @@ class AppService implements IInitializable, IDisposable {
     if (this.rendererReadyForDeepLinks && win && !win.isDestroyed()) {
       events.emit(appDeepLinkChannel, deepLink);
     } else {
-      this.pendingDeepLinks.push(deepLink);
+      this.enqueuePendingDeepLink(deepLink);
     }
 
     return true;
@@ -353,6 +268,21 @@ class AppService implements IInitializable, IDisposable {
     const pending = this.pendingDeepLinks;
     this.pendingDeepLinks = [];
     return pending;
+  }
+
+  markRendererDeepLinksNotReady(): void {
+    this.rendererReadyForDeepLinks = false;
+  }
+
+  private enqueuePendingDeepLink(deepLink: AppDeepLinkEvent): void {
+    const existingIndex = this.pendingDeepLinks.findIndex(
+      (pending) => pending.issue.identifier === deepLink.issue.identifier
+    );
+    if (existingIndex !== -1) this.pendingDeepLinks.splice(existingIndex, 1);
+    this.pendingDeepLinks.push(deepLink);
+    if (this.pendingDeepLinks.length > MAX_PENDING_DEEP_LINKS) {
+      this.pendingDeepLinks.splice(0, this.pendingDeepLinks.length - MAX_PENDING_DEEP_LINKS);
+    }
   }
 
   async openIn(args: {

--- a/src/main/core/app/service.ts
+++ b/src/main/core/app/service.ts
@@ -251,8 +251,6 @@ class AppService implements IInitializable, IDisposable {
 
     const win = getMainWindow();
     if (!win || win.isDestroyed()) this.rendererReadyForDeepLinks = false;
-    if (win?.isMinimized()) win.restore();
-    win?.focus();
 
     if (this.rendererReadyForDeepLinks && win && !win.isDestroyed()) {
       events.emit(appDeepLinkChannel, deepLink);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1,8 +1,10 @@
+import { createServer, request } from 'node:http';
+import type { Server } from 'node:http';
 import { join } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';
 import dockIcon from '@/assets/images/emdash/icon-dock.png?asset';
-import { PRODUCT_NAME } from '@shared/app-identity';
+import { APP_NAME_LOWER, PRODUCT_NAME } from '@shared/app-identity';
 import { registerRPCRouter } from '@shared/ipc/rpc';
 import { setupApplicationMenu } from './app/menu';
 import { registerAppScheme, setupAppProtocol } from './app/protocol';
@@ -55,7 +57,141 @@ initializeFileLogger();
 registerProcessErrorLogging(log);
 registerRendererLogHandler(ipcMain);
 
-app.on('second-instance', () => {
+const appDeepLinkScheme = `${APP_NAME_LOWER}:`;
+const DEV_DEEP_LINK_BRIDGE_PORT = 49375;
+let devDeepLinkBridge: Server | null = null;
+
+function findDeepLinkUrl(args: string[]): string | undefined {
+  return args.find((arg) => arg.toLowerCase().startsWith(appDeepLinkScheme));
+}
+
+const initialDeepLinkUrl = findDeepLinkUrl(process.argv);
+
+function forwardDeepLinkToDevInstance(url: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const body = JSON.stringify({ url });
+    const req = request(
+      {
+        hostname: '127.0.0.1',
+        port: DEV_DEEP_LINK_BRIDGE_PORT,
+        path: '/deep-link',
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-length': Buffer.byteLength(body),
+        },
+        timeout: 500,
+      },
+      (res) => {
+        res.resume();
+        resolve((res.statusCode ?? 500) >= 200 && (res.statusCode ?? 500) < 300);
+      }
+    );
+
+    req.on('error', () => resolve(false));
+    req.on('timeout', () => {
+      req.destroy();
+      resolve(false);
+    });
+    req.end(body);
+  });
+}
+
+function startDevDeepLinkBridge(): void {
+  if (!import.meta.env.DEV || devDeepLinkBridge) return;
+
+  devDeepLinkBridge = createServer((req, res) => {
+    if (req.method !== 'POST' || req.url !== '/deep-link') {
+      res.writeHead(404).end();
+      return;
+    }
+
+    let body = '';
+    req.setEncoding('utf8');
+    req.on('data', (chunk) => {
+      body += chunk;
+      if (body.length > 8_192) req.destroy();
+    });
+    req.on('end', () => {
+      try {
+        const payload = JSON.parse(body) as { url?: unknown };
+        if (typeof payload.url !== 'string' || !payload.url.startsWith(appDeepLinkScheme)) {
+          res.writeHead(400).end();
+          return;
+        }
+
+        handleDeepLinkUrl(payload.url);
+        res.writeHead(204).end();
+      } catch {
+        res.writeHead(400).end();
+      }
+    });
+  });
+
+  devDeepLinkBridge.on('error', (error: NodeJS.ErrnoException) => {
+    if (error.code === 'EADDRINUSE') {
+      log.warn(
+        'Dev deep link bridge port is already in use; deeplinks may target another dev instance.'
+      );
+    } else {
+      log.warn('Dev deep link bridge failed:', error);
+    }
+    devDeepLinkBridge = null;
+  });
+
+  devDeepLinkBridge.listen(DEV_DEEP_LINK_BRIDGE_PORT, '127.0.0.1');
+}
+
+if (import.meta.env.DEV && initialDeepLinkUrl) {
+  const forwarded = await forwardDeepLinkToDevInstance(initialDeepLinkUrl);
+  if (forwarded) {
+    app.quit();
+    process.exit(0);
+  }
+}
+
+function registerDeepLinkProtocol(): void {
+  try {
+    if (import.meta.env.DEV) {
+      app.setAsDefaultProtocolClient(
+        APP_NAME_LOWER,
+        process.execPath,
+        process.argv[1] ? [process.argv[1]] : []
+      );
+    } else {
+      app.setAsDefaultProtocolClient(APP_NAME_LOWER);
+    }
+  } catch (error) {
+    log.warn('Failed to register app deep link protocol:', error);
+  }
+}
+
+function handleDeepLinkUrl(url: string): void {
+  if (!appService.handleDeepLink(url)) return;
+
+  if (!app.isReady()) return;
+
+  if (BrowserWindow.getAllWindows().length === 0) {
+    createMainWindow();
+  }
+
+  const win = BrowserWindow.getAllWindows()[0];
+  if (win?.isMinimized()) win.restore();
+  win?.focus();
+}
+
+app.on('open-url', (event, url) => {
+  event.preventDefault();
+  handleDeepLinkUrl(url);
+});
+
+app.on('second-instance', (_event, commandLine) => {
+  const deepLinkUrl = findDeepLinkUrl(commandLine);
+  if (deepLinkUrl) {
+    handleDeepLinkUrl(deepLinkUrl);
+    return;
+  }
+
   const win = BrowserWindow.getAllWindows()[0];
   if (win?.isMinimized()) win.restore();
   win?.focus();
@@ -87,6 +223,7 @@ app.on('activate', () => {
 });
 
 void app.whenReady().then(async () => {
+  registerDeepLinkProtocol();
   await resolveUserEnv();
 
   try {
@@ -126,6 +263,7 @@ void app.whenReady().then(async () => {
   projectSettingsService.initialize();
   prSyncScheduler.initialize();
   appService.initialize();
+  startDevDeepLinkBridge();
   await appSettingsService.initialize();
   await promptLibraryService.initialize();
 
@@ -152,6 +290,7 @@ void app.whenReady().then(async () => {
   setupAppProtocol(join(app.getAppPath(), 'out', 'renderer'));
   setupApplicationMenu();
   createMainWindow();
+  if (initialDeepLinkUrl) handleDeepLinkUrl(initialDeepLinkUrl);
 
   try {
     await updateService.initialize();
@@ -170,6 +309,8 @@ app.on('before-quit', (event) => {
     stopResourceSampler();
     updateService.dispose();
     prSyncScheduler.dispose();
+    devDeepLinkBridge?.close();
+    devDeepLinkBridge = null;
     void gitWatcherRegistry.dispose();
     void projectManager.dispose().catch((e) => {
       log.error('Failed to shutdown project manager:', e);

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -67,6 +67,15 @@ function findDeepLinkUrl(args: string[]): string | undefined {
 
 const initialDeepLinkUrl = findDeepLinkUrl(process.argv);
 
+function createTrackedMainWindow(): BrowserWindow {
+  appService.markRendererDeepLinksNotReady();
+  const win = createMainWindow();
+  win.webContents.on('did-start-loading', () => appService.markRendererDeepLinksNotReady());
+  win.webContents.on('render-process-gone', () => appService.markRendererDeepLinksNotReady());
+  win.on('closed', () => appService.markRendererDeepLinksNotReady());
+  return win;
+}
+
 function forwardDeepLinkToDevInstance(url: string): Promise<boolean> {
   return new Promise((resolve) => {
     const body = JSON.stringify({ url });
@@ -176,7 +185,7 @@ function handleDeepLinkUrl(url: string): boolean {
   if (!app.isReady()) return true;
 
   if (BrowserWindow.getAllWindows().length === 0) {
-    createMainWindow();
+    createTrackedMainWindow();
   }
 
   const win = BrowserWindow.getAllWindows()[0];
@@ -192,8 +201,7 @@ app.on('open-url', (event, url) => {
 
 app.on('second-instance', (_event, commandLine) => {
   const deepLinkUrl = findDeepLinkUrl(commandLine);
-  if (deepLinkUrl) {
-    handleDeepLinkUrl(deepLinkUrl);
+  if (deepLinkUrl && handleDeepLinkUrl(deepLinkUrl)) {
     return;
   }
 
@@ -223,7 +231,7 @@ app.on('window-all-closed', () => {
 
 app.on('activate', () => {
   if (BrowserWindow.getAllWindows().length === 0) {
-    createMainWindow();
+    createTrackedMainWindow();
   }
 });
 
@@ -294,7 +302,7 @@ void app.whenReady().then(async () => {
 
   setupAppProtocol(join(app.getAppPath(), 'out', 'renderer'));
   setupApplicationMenu();
-  createMainWindow();
+  createTrackedMainWindow();
   if (initialDeepLinkUrl) handleDeepLinkUrl(initialDeepLinkUrl);
 
   try {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -120,7 +120,11 @@ function startDevDeepLinkBridge(): void {
           return;
         }
 
-        handleDeepLinkUrl(payload.url);
+        if (!handleDeepLinkUrl(payload.url)) {
+          res.writeHead(422).end();
+          return;
+        }
+
         res.writeHead(204).end();
       } catch {
         res.writeHead(400).end();
@@ -166,10 +170,10 @@ function registerDeepLinkProtocol(): void {
   }
 }
 
-function handleDeepLinkUrl(url: string): void {
-  if (!appService.handleDeepLink(url)) return;
+function handleDeepLinkUrl(url: string): boolean {
+  if (!appService.handleDeepLink(url)) return false;
 
-  if (!app.isReady()) return;
+  if (!app.isReady()) return true;
 
   if (BrowserWindow.getAllWindows().length === 0) {
     createMainWindow();
@@ -178,6 +182,7 @@ function handleDeepLinkUrl(url: string): void {
   const win = BrowserWindow.getAllWindows()[0];
   if (win?.isMinimized()) win.restore();
   win?.focus();
+  return true;
 }
 
 app.on('open-url', (event, url) => {

--- a/src/renderer/app/app-menu-events.tsx
+++ b/src/renderer/app/app-menu-events.tsx
@@ -15,6 +15,8 @@ import {
 } from '@shared/events/appEvents';
 import type { Issue } from '@shared/tasks';
 
+const ISSUE_CONTEXT_TIMEOUT_MS = 2_000;
+
 function buildIssueFromDeepLink(deepLink: AppDeepLinkEvent): Issue {
   const { issue } = deepLink;
   return {
@@ -30,9 +32,10 @@ function buildIssueFromDeepLink(deepLink: AppDeepLinkEvent): Issue {
 async function resolveLinearIssueFromDeepLink(deepLink: AppDeepLinkEvent): Promise<Issue> {
   const fallbackIssue = buildIssueFromDeepLink(deepLink);
 
-  const result = await rpc.issues
-    .getIssueContext('linear', { identifier: deepLink.issue.identifier })
-    .catch(() => null);
+  const result = await Promise.race([
+    rpc.issues.getIssueContext('linear', { identifier: deepLink.issue.identifier }),
+    new Promise<null>((resolve) => setTimeout(() => resolve(null), ISSUE_CONTEXT_TIMEOUT_MS)),
+  ]).catch(() => null);
 
   if (!result?.success) return fallbackIssue;
 
@@ -53,14 +56,12 @@ export function AppMenuEvents({ onOpenSettings }: { onOpenSettings?: () => boole
 
   useEffect(() => {
     let disposed = false;
-    let latestDeepLinkId = 0;
 
     const handleDeepLink = (deepLink: AppDeepLinkEvent) => {
       if (deepLink.type !== 'linear-agent') return;
-      const deepLinkId = ++latestDeepLinkId;
 
       void resolveLinearIssueFromDeepLink(deepLink).then((issue) => {
-        if (disposed || deepLinkId !== latestDeepLinkId) return;
+        if (disposed) return;
         showTaskModal({
           strategy: 'from-issue',
           projectId: deepLink.projectId,

--- a/src/renderer/app/app-menu-events.tsx
+++ b/src/renderer/app/app-menu-events.tsx
@@ -6,17 +6,83 @@ import { useNavigate, useWorkspaceSlots } from '@renderer/lib/layout/navigation-
 import { toggleSettingsView } from '@renderer/lib/layout/settings-toggle';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import {
+  appDeepLinkChannel,
+  type AppDeepLinkEvent,
   menuGiveFeedbackChannel,
   menuOpenSettingsChannel,
   menuQuitRequestedChannel,
   notificationFocusTaskChannel,
 } from '@shared/events/appEvents';
+import type { Issue } from '@shared/tasks';
+
+function buildIssueFromDeepLink(deepLink: AppDeepLinkEvent): Issue {
+  const { issue } = deepLink;
+  return {
+    provider: 'linear',
+    identifier: issue.identifier,
+    url: issue.url ?? `https://linear.app/issue/${issue.identifier}`,
+    title: issue.title ?? issue.identifier,
+    description: issue.description,
+    branchName: issue.branchName,
+  };
+}
+
+async function resolveLinearIssueFromDeepLink(deepLink: AppDeepLinkEvent): Promise<Issue> {
+  const fallbackIssue = buildIssueFromDeepLink(deepLink);
+
+  const result = await rpc.issues
+    .getIssueContext('linear', { identifier: deepLink.issue.identifier })
+    .catch(() => null);
+
+  if (!result?.success) return fallbackIssue;
+
+  return {
+    ...fallbackIssue,
+    ...result.issue,
+    url: result.issue.url || fallbackIssue.url,
+    title: result.issue.title || fallbackIssue.title,
+  };
+}
 
 export function AppMenuEvents({ onOpenSettings }: { onOpenSettings?: () => boolean | void }) {
   const { navigate } = useNavigate();
   const { currentView, lastNonSettingsView } = useWorkspaceSlots();
   const showConfirmQuitModal = useShowModal('confirmActionModal');
   const showFeedbackModal = useShowModal('feedbackModal');
+  const showTaskModal = useShowModal('taskModal');
+
+  useEffect(() => {
+    let disposed = false;
+    let latestDeepLinkId = 0;
+
+    const handleDeepLink = (deepLink: AppDeepLinkEvent) => {
+      if (deepLink.type !== 'linear-agent') return;
+      const deepLinkId = ++latestDeepLinkId;
+
+      void resolveLinearIssueFromDeepLink(deepLink).then((issue) => {
+        if (disposed || deepLinkId !== latestDeepLinkId) return;
+        showTaskModal({
+          strategy: 'from-issue',
+          projectId: deepLink.projectId,
+          initialIssue: issue,
+          initialAgentProvider: deepLink.agentProvider,
+          initialPrompt: deepLink.prompt,
+        });
+      });
+    };
+
+    const unlisten = events.on(appDeepLinkChannel, handleDeepLink);
+
+    void rpc.app.drainPendingDeepLinks().then((deepLinks) => {
+      if (disposed) return;
+      deepLinks.forEach(handleDeepLink);
+    });
+
+    return () => {
+      disposed = true;
+      unlisten();
+    };
+  }, [showTaskModal]);
 
   useEffect(() => {
     return events.on(menuOpenSettingsChannel, () => {

--- a/src/renderer/app/app-menu-events.tsx
+++ b/src/renderer/app/app-menu-events.tsx
@@ -20,7 +20,7 @@ function buildIssueFromDeepLink(deepLink: AppDeepLinkEvent): Issue {
   return {
     provider: 'linear',
     identifier: issue.identifier,
-    url: issue.url ?? `https://linear.app/issue/${issue.identifier}`,
+    url: issue.url ?? '',
     title: issue.title ?? issue.identifier,
     description: issue.description,
     branchName: issue.branchName,

--- a/src/renderer/app/app-menu-events.tsx
+++ b/src/renderer/app/app-menu-events.tsx
@@ -44,6 +44,8 @@ async function resolveLinearIssueFromDeepLink(deepLink: AppDeepLinkEvent): Promi
     ...result.issue,
     url: result.issue.url || fallbackIssue.url,
     title: result.issue.title || fallbackIssue.title,
+    description: result.issue.description ?? fallbackIssue.description,
+    branchName: result.issue.branchName ?? fallbackIssue.branchName,
   };
 }
 

--- a/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
+++ b/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
@@ -150,7 +150,7 @@ export const IssueSelector = observer(function IssueSelector({
     connectedProviderCount,
     handleSetSearchTerm,
     setSelectedIssueProvider,
-  } = useIssueSearch(repositoryUrl, projectPath, projectId);
+  } = useIssueSearch(repositoryUrl, projectPath, projectId, value?.provider);
 
   const [comboboxOpen, setComboboxOpen] = useState(false);
   const providerSelectOpenRef = useRef(false);

--- a/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
+++ b/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
@@ -296,6 +296,8 @@ export const IssueSelector = observer(function IssueSelector({
             </ComboboxList>
           </ComboboxContent>
         </Combobox>
+      ) : value ? (
+        selectedContent
       ) : (
         <ConnectIssueIntegrationPlaceholder />
       )}

--- a/src/renderer/features/tasks/components/issue-selector/useIssueSearch.ts
+++ b/src/renderer/features/tasks/components/issue-selector/useIssueSearch.ts
@@ -18,7 +18,12 @@ function isProviderUsable(
   return true;
 }
 
-export function useIssueSearch(repositoryUrl: string, projectPath = '', projectId?: string) {
+export function useIssueSearch(
+  repositoryUrl: string,
+  projectPath = '',
+  projectId?: string,
+  preferredProvider?: Issue['provider']
+) {
   const { connectionStatus, isCheckingConnections } = useIntegrationsContext();
   const context = useMemo(() => ({ projectPath, repositoryUrl }), [projectPath, repositoryUrl]);
 
@@ -52,6 +57,10 @@ export function useIssueSearch(repositoryUrl: string, projectPath = '', projectI
   const hasAnyIntegration = connectedProviders.length > 0;
 
   const issueProvider = useMemo(() => {
+    if (preferredProvider && isProviderUsable(connectionStatus[preferredProvider], context)) {
+      return preferredProvider;
+    }
+
     if (
       selectedIssueProvider &&
       isProviderUsable(connectionStatus[selectedIssueProvider], context)
@@ -60,7 +69,7 @@ export function useIssueSearch(repositoryUrl: string, projectPath = '', projectI
     }
 
     return connectedProviders[0] ?? null;
-  }, [connectedProviders, connectionStatus, context, selectedIssueProvider]);
+  }, [connectedProviders, connectionStatus, context, preferredProvider, selectedIssueProvider]);
 
   const issuesHook = useIssues(issueProvider, {
     projectId,

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -45,6 +45,7 @@ function resolveMountedProjectId(projectId: string | undefined): string | undefi
   if (projectId && mountedProjectData(getProjectManagerStore().projects.get(projectId))) {
     return projectId;
   }
+  if (projectId) return undefined;
 
   const nav = appState.navigation;
   const navProjectId =

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -1,5 +1,5 @@
 import { observer } from 'mobx-react-lite';
-import { useCallback, useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useIntegrationsContext } from '@renderer/features/integrations/integrations-provider';
 import { ISSUE_PROVIDER_ORDER } from '@renderer/features/integrations/issue-provider-meta';
 import {
@@ -141,21 +141,21 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   const autoApproveDefaults = useAgentAutoApproveDefaults();
   const isWorkspaceProviderEnabled = useFeatureFlag('workspace-provider');
   const { navigate } = useNavigate();
+  const isFirstProjectEffect = useRef(true);
 
   useEffect(() => setUseBYOI(false), [selectedProjectId]);
   useEffect(() => {
     if (!isWorkspaceProviderEnabled) setUseBYOI(false);
   }, [isWorkspaceProviderEnabled]);
   useEffect(() => {
-    initialConversation.setProvider(null);
+    initialConversation.setProvider(
+      isFirstProjectEffect.current ? (initialAgentProvider ?? null) : null
+    );
+    isFirstProjectEffect.current = false;
     initialConversation.setPrompt(initialPrompt ?? '');
     initialConversation.setIssueContext(null);
     // oxlint-disable-next-line react/exhaustive-deps
   }, [selectedProjectId]);
-  useEffect(() => {
-    if (initialAgentProvider) initialConversation.setProvider(initialAgentProvider);
-    // oxlint-disable-next-line react/exhaustive-deps
-  }, []);
 
   const canCreate = !!selectedProjectId && state.isValid;
 

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -21,7 +21,9 @@ import {
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
+import type { AgentProviderId } from '@shared/agent-provider-registry';
 import { getPrNumber, isForkPr, type PullRequest } from '@shared/pull-requests';
+import type { Issue } from '@shared/tasks';
 import {
   resolveBranchLikeTaskStrategy,
   resolvePullRequestTaskStrategy,
@@ -42,12 +44,18 @@ type SectionTab = 'conversation' | 'workspace';
 export const CreateTaskModal = observer(function CreateTaskModal({
   projectId,
   strategy: initialStrategy = 'from-branch',
+  initialIssue,
   initialPR,
+  initialAgentProvider,
+  initialPrompt,
   onClose,
 }: BaseModalProps & {
   projectId?: string;
   strategy?: 'from-branch' | 'from-issue' | 'from-pull-request';
+  initialIssue?: Issue;
   initialPR?: PullRequest;
+  initialAgentProvider?: AgentProviderId;
+  initialPrompt?: string;
 }) {
   const [selectedProjectId, _setSelectedProjectId] = useState<string | undefined>(() => {
     if (projectId) return projectId;
@@ -108,12 +116,14 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   }, []); // computed once on mount
 
   const resolvedInitialPR = initialStrategy === 'from-pull-request' ? initialPR : undefined;
+  const resolvedInitialIssue = initialStrategy === 'from-issue' ? initialIssue : undefined;
   const state = useCreateTaskState(
     selectedProjectId,
     defaultBranch,
     isUnborn,
     currentBranch,
     resolvedInitialPR,
+    resolvedInitialIssue,
     defaultLinkedType
   );
 
@@ -128,10 +138,14 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   }, [isWorkspaceProviderEnabled]);
   useEffect(() => {
     initialConversation.setProvider(null);
-    initialConversation.setPrompt('');
+    initialConversation.setPrompt(initialPrompt ?? '');
     initialConversation.setIssueContext(null);
     // oxlint-disable-next-line react/exhaustive-deps
   }, [selectedProjectId]);
+  useEffect(() => {
+    if (initialAgentProvider) initialConversation.setProvider(initialAgentProvider);
+    // oxlint-disable-next-line react/exhaustive-deps
+  }, []);
 
   const canCreate = !!selectedProjectId && state.isValid;
 

--- a/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -41,6 +41,28 @@ import { WorkspaceSettingsSection } from './workspace-settings-section';
 
 type SectionTab = 'conversation' | 'workspace';
 
+function resolveMountedProjectId(projectId: string | undefined): string | undefined {
+  if (projectId && mountedProjectData(getProjectManagerStore().projects.get(projectId))) {
+    return projectId;
+  }
+
+  const nav = appState.navigation;
+  const navProjectId =
+    nav.currentViewId === 'task'
+      ? (nav.viewParamsStore['task'] as { projectId?: string } | undefined)?.projectId
+      : nav.currentViewId === 'project'
+        ? (nav.viewParamsStore['project'] as { projectId?: string } | undefined)?.projectId
+        : undefined;
+
+  if (navProjectId && mountedProjectData(getProjectManagerStore().projects.get(navProjectId))) {
+    return navProjectId;
+  }
+
+  return Array.from(getProjectManagerStore().projects.values())
+    .reverse()
+    .find((p) => p.state === 'mounted')?.data?.id;
+}
+
 export const CreateTaskModal = observer(function CreateTaskModal({
   projectId,
   strategy: initialStrategy = 'from-branch',
@@ -58,20 +80,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
   initialPrompt?: string;
 }) {
   const [selectedProjectId, _setSelectedProjectId] = useState<string | undefined>(() => {
-    if (projectId) return projectId;
-    const nav = appState.navigation;
-    const navProjectId =
-      nav.currentViewId === 'task'
-        ? (nav.viewParamsStore['task'] as { projectId?: string } | undefined)?.projectId
-        : nav.currentViewId === 'project'
-          ? (nav.viewParamsStore['project'] as { projectId?: string } | undefined)?.projectId
-          : undefined;
-    return (
-      navProjectId ??
-      Array.from(getProjectManagerStore().projects.values())
-        .reverse()
-        .find((p) => p.state === 'mounted')?.data?.id
-    );
+    return resolveMountedProjectId(projectId);
   });
 
   const [sectionTab, setSectionTab] = useState<SectionTab>('conversation');

--- a/src/renderer/features/tasks/create-task-modal/use-create-task-state.ts
+++ b/src/renderer/features/tasks/create-task-modal/use-create-task-state.ts
@@ -21,12 +21,15 @@ export function useCreateTaskState(
   isUnborn: boolean,
   currentBranch: string | null,
   initialPR?: PullRequest,
+  initialIssue?: Issue,
   initialLinkedType: LinkedType = null
 ) {
   const { autoGenerateName, createBranchAndWorktree } = useTaskSettings();
 
-  const [linkedType, setLinkedTypeRaw] = useState<LinkedType>(initialPR ? 'pr' : initialLinkedType);
-  const [linkedIssue, setLinkedIssueRaw] = useState<Issue | null>(null);
+  const [linkedType, setLinkedTypeRaw] = useState<LinkedType>(
+    initialPR ? 'pr' : initialIssue ? 'issue' : initialLinkedType
+  );
+  const [linkedIssue, setLinkedIssueRaw] = useState<Issue | null>(initialIssue ?? null);
   const [linkedPR, setLinkedPRRaw] = useState<PullRequest | null>(initialPR ?? null);
   const [checkoutMode, setCheckoutMode] = useState<CheckoutMode>('checkout');
   const [prevProjectId, setPrevProjectId] = useState(projectId);

--- a/src/renderer/lib/modal/modal-renderer.tsx
+++ b/src/renderer/lib/modal/modal-renderer.tsx
@@ -38,9 +38,11 @@ export const ModalRenderer = observer(function ModalRenderer() {
   // oxlint-disable-next-line typescript/no-explicit-any
   const lastComponentRef = useRef<React.ComponentType<any> | null>(null);
   const lastArgsRef = useRef<Record<string, unknown> | null>(null);
+  const lastArgsKeyRef = useRef(0);
   const lastEntryRef = useRef<ModalRegistryEntry | null>(null);
 
   if (modalStore.isOpen && Component && modalStore.activeModalArgs) {
+    if (lastArgsRef.current !== modalStore.activeModalArgs) lastArgsKeyRef.current += 1;
     lastComponentRef.current = Component;
     lastArgsRef.current = modalStore.activeModalArgs;
     lastEntryRef.current = entry;
@@ -49,6 +51,7 @@ export const ModalRenderer = observer(function ModalRenderer() {
   const DisplayComponent = lastComponentRef.current;
   const displayArgs = lastArgsRef.current;
   const displayEntry = lastEntryRef.current;
+  const displayKey = lastArgsKeyRef.current;
 
   const handleOpenChange = (
     open: boolean,
@@ -111,7 +114,9 @@ export const ModalRenderer = observer(function ModalRenderer() {
             SIZE_CLASSES[displayEntry?.size ?? 'md']
           )}
         >
-          {DisplayComponent && displayArgs ? <DisplayComponent {...displayArgs} /> : null}
+          {DisplayComponent && displayArgs ? (
+            <DisplayComponent key={displayKey} {...displayArgs} />
+          ) : null}
         </DialogPrimitive.Popup>
       </DialogPortal>
     </Dialog>

--- a/src/shared/events/appEvents.ts
+++ b/src/shared/events/appEvents.ts
@@ -1,3 +1,4 @@
+import type { AgentProviderId } from '@shared/agent-provider-registry';
 import type { DependencyStatusUpdatedEvent } from '@shared/dependencies';
 import { defineEvent } from '@shared/ipc/events';
 
@@ -25,6 +26,22 @@ export const notificationFocusTaskChannel = defineEvent<{
   taskId: string;
   conversationId?: string;
 }>('notification:focus-task');
+
+export type AppDeepLinkEvent = {
+  type: 'linear-agent';
+  projectId?: string;
+  agentProvider?: AgentProviderId;
+  prompt?: string;
+  issue: {
+    identifier: string;
+    url?: string;
+    title?: string;
+    description?: string;
+    branchName?: string;
+  };
+};
+
+export const appDeepLinkChannel = defineEvent<AppDeepLinkEvent>('app:deep-link');
 
 export const ptyStartedChannel = defineEvent<{
   id: string;


### PR DESCRIPTION
# summary
- adds support for deeplinking into emdash
- adds emdash:// or emdash-canary://
- renderer handling to open create task modal prefilled with linear issue, (optional) agent provider and initial prompt

format:
emdash://linear-agent?issueIdentifier=ENG-1450 
emdash://linear-agent?issueIdentifier=ENG-1450&agentProvider=codex&prompt=Bitte%20umsetzen 
emdash-canary://linear-agent?issueIdentifier=ENG-1450

for linear:
emdash://linear-agent?issueIdentifier={issueIdentifier}&issueUrl={issueUrl}&title={issueTitle} 

available query params:
issueIdentifier=ENG-1450
issueUrl=https://linear.app/general-action/issue/ENG-1450/...
title=Issue title
description=issue description
branchName=jan/eng-1450-support-deeplinks
agentProvider=codex
prompt=bitte umsetzen
projectId=<emdash-project-id>