### PR TITLE
fix(agent-hooks): delegate codex notifications to script

### DIFF
--- a/src/main/core/agent-hooks/agent-notify-command.test.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.test.ts
@@ -41,20 +41,26 @@ describe('makeClaudeHookCommand', () => {
 
 describe('makeCodexNotifyHookCommand', () => {
   it('uses a short POSIX command that delegates native Codex hooks to the notify script', () => {
-    const content = makeCodexNotifyHookCommand('$HOME/.emdash/hooks/codex-notify.sh', {
+    const content = makeCodexNotifyHookCommand('$HOME/.emdash/hooks/codex-notify.sh', 'Stop', {
       platform: 'darwin',
     });
 
-    expect(content).toBe('EMDASH_AGENT_ID=codex sh "$HOME/.emdash/hooks/codex-notify.sh"');
+    expect(content).toBe(
+      'EMDASH_AGENT_ID=codex EMDASH_HOOK_EVENT=Stop sh "$HOME/.emdash/hooks/codex-notify.sh"'
+    );
   });
 
   it('uses a short Windows command that delegates native Codex hooks to the notify script', () => {
-    const content = makeCodexNotifyHookCommand('%USERPROFILE%\\.emdash\\hooks\\codex-notify.ps1', {
-      platform: 'win32',
-    });
+    const content = makeCodexNotifyHookCommand(
+      '%USERPROFILE%\\.emdash\\hooks\\codex-notify.ps1',
+      'PermissionRequest',
+      {
+        platform: 'win32',
+      }
+    );
 
     expect(content).toBe(
-      'cmd.exe /d /c "set EMDASH_AGENT_ID=codex&& powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""%USERPROFILE%\\.emdash\\hooks\\codex-notify.ps1"""'
+      'cmd.exe /d /c "set EMDASH_AGENT_ID=codex&& set EMDASH_HOOK_EVENT=PermissionRequest&& powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""%USERPROFILE%\\.emdash\\hooks\\codex-notify.ps1"""'
     );
   });
 });
@@ -69,6 +75,7 @@ describe('makeCodexNotifyScriptContent', () => {
     expect(content).toContain('X-Emdash-Agent-Id');
     expect(content).toContain('notification_type');
     expect(content).toContain('PermissionRequest');
+    expect(content).toContain('EMDASH_HOOK_EVENT');
     expect(content).toContain('input="${1:-$(cat)}"');
     expect(content).toContain('post_hook session-start');
     expect(content).toContain('-d @-');
@@ -86,6 +93,7 @@ describe('makeCodexNotifyPowerShellContent', () => {
     expect(content).toContain('notification_type');
     expect(content).toContain('[Console]::In.ReadToEnd()');
     expect(content).toContain('PermissionRequest');
+    expect(content).toContain('EMDASH_HOOK_EVENT');
     expect(content).toContain("'X-Emdash-Event-Type' = $eventType");
   });
 });

--- a/src/main/core/agent-hooks/agent-notify-command.test.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.test.ts
@@ -70,7 +70,7 @@ describe('makeCodexNotifyScriptContent', () => {
     expect(content).toContain('notification_type');
     expect(content).toContain('PermissionRequest');
     expect(content).toContain('input="${1:-$(cat)}"');
-    expect(content).toContain('X-Emdash-Event-Type: session-start');
+    expect(content).toContain('post_hook session-start');
     expect(content).toContain('-d @-');
   });
 });

--- a/src/main/core/agent-hooks/agent-notify-command.test.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.test.ts
@@ -2,8 +2,9 @@ import { describe, expect, it } from 'vitest';
 import {
   makeAmpPluginContent,
   makeClaudeHookCommand,
-  makeCodexHookCommand,
-  makeCodexSessionStartHookCommand,
+  makeCodexNotifyHookCommand,
+  makeCodexNotifyPowerShellContent,
+  makeCodexNotifyScriptContent,
   makeOpenCodePluginContent,
 } from './agent-notify-command';
 
@@ -38,38 +39,54 @@ describe('makeClaudeHookCommand', () => {
   });
 });
 
-describe('makeCodexHookCommand', () => {
-  it('posts native Codex hook events to the Emdash hook server on POSIX', () => {
-    const content = makeCodexHookCommand('idle_prompt', { platform: 'darwin' });
+describe('makeCodexNotifyHookCommand', () => {
+  it('uses a short POSIX command that delegates native Codex hooks to the notify script', () => {
+    const content = makeCodexNotifyHookCommand('$HOME/.emdash/hooks/codex-notify.sh', {
+      platform: 'darwin',
+    });
+
+    expect(content).toBe('EMDASH_AGENT_ID=codex sh "$HOME/.emdash/hooks/codex-notify.sh"');
+  });
+
+  it('uses a short Windows command that delegates native Codex hooks to the notify script', () => {
+    const content = makeCodexNotifyHookCommand('%USERPROFILE%\\.emdash\\hooks\\codex-notify.ps1', {
+      platform: 'win32',
+    });
+
+    expect(content).toBe(
+      'cmd.exe /d /c "set EMDASH_AGENT_ID=codex&& powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""%USERPROFILE%\\.emdash\\hooks\\codex-notify.ps1"""'
+    );
+  });
+});
+
+describe('makeCodexNotifyScriptContent', () => {
+  it('posts native Codex notification and SessionStart payloads to the Emdash hook server', () => {
+    const content = makeCodexNotifyScriptContent();
 
     expect(content).toContain('EMDASH_HOOK_PORT');
     expect(content).toContain('X-Emdash-Token');
     expect(content).toContain('X-Emdash-Pty-Id');
-    expect(content).toContain('{"notification_type":"idle_prompt"}');
-  });
-
-  it('posts native Codex hook events to the Emdash hook server on Windows', () => {
-    const content = makeCodexHookCommand('permission_prompt', { platform: 'win32' });
-    const script = decodeWindowsHookCommand(content);
-
-    expect(content).toContain('cmd.exe');
-    expect(content).toContain('powershell.exe');
-    expect(content).toContain('EMDASH_HOOK_PORT');
-    expect(content).toContain('-EncodedCommand');
-    expect(script).toContain('X-Emdash-Token');
-    expect(script).toContain('X-Emdash-Pty-Id');
-    expect(script).toContain('$payload = \'{"notification_type":"permission_prompt"}\'');
-    expect(script).toContain("'X-Emdash-Event-Type' = 'notification'");
+    expect(content).toContain('X-Emdash-Agent-Id');
+    expect(content).toContain('notification_type');
+    expect(content).toContain('PermissionRequest');
+    expect(content).toContain('input="${1:-$(cat)}"');
+    expect(content).toContain('X-Emdash-Event-Type: session-start');
+    expect(content).toContain('-d @-');
   });
 });
 
-describe('makeCodexSessionStartHookCommand', () => {
-  it('forwards Codex SessionStart hook stdin or argv to the Emdash hook server', () => {
-    const content = makeCodexSessionStartHookCommand({ platform: 'darwin' });
+describe('makeCodexNotifyPowerShellContent', () => {
+  it('posts native Codex notification and SessionStart payloads to the Emdash hook server', () => {
+    const content = makeCodexNotifyPowerShellContent();
 
-    expect(content).toContain('INPUT="${1:-$(cat)}"');
-    expect(content).toContain('X-Emdash-Event-Type: session-start');
-    expect(content).toContain('-d @-');
+    expect(content).toContain('EMDASH_HOOK_PORT');
+    expect(content).toContain('X-Emdash-Token');
+    expect(content).toContain('X-Emdash-Pty-Id');
+    expect(content).toContain('X-Emdash-Agent-Id');
+    expect(content).toContain('notification_type');
+    expect(content).toContain('[Console]::In.ReadToEnd()');
+    expect(content).toContain('PermissionRequest');
+    expect(content).toContain("'X-Emdash-Event-Type' = $eventType");
   });
 });
 

--- a/src/main/core/agent-hooks/agent-notify-command.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.ts
@@ -83,11 +83,12 @@ export function makeCodexNotifyPowerShellContent(): string {
 
 export function makeCodexNotifyHookCommand(
   scriptPath: string,
+  hookEvent: string,
   options: HookCommandOptions = {}
 ): string {
   if ((options.platform ?? process.platform) === 'win32') {
-    return `cmd.exe /d /c "set EMDASH_AGENT_ID=codex&& powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""${scriptPath}"""`;
+    return `cmd.exe /d /c "set EMDASH_AGENT_ID=codex&& set EMDASH_HOOK_EVENT=${hookEvent}&& powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""${scriptPath}"""`;
   }
 
-  return `EMDASH_AGENT_ID=codex sh "${scriptPath}"`;
+  return `EMDASH_AGENT_ID=codex EMDASH_HOOK_EVENT=${hookEvent} sh "${scriptPath}"`;
 }

--- a/src/main/core/agent-hooks/agent-notify-command.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.ts
@@ -71,27 +71,136 @@ export function makeAmpPluginContent(): string {
   return ampPluginContent;
 }
 
-export function makeCodexHookCommand(
-  notificationType: 'idle_prompt' | 'permission_prompt',
-  options: HookCommandOptions = {}
-): string {
-  return makeHookPostCommand({
-    eventType: 'notification',
-    payload: { json: { notification_type: notificationType } },
-    platform: options.platform,
-  });
+export function makeCodexNotifyScriptContent(): string {
+  return `#!/bin/sh
+set -u
+
+if [ -z "\${EMDASH_HOOK_PORT:-}" ] || [ -z "\${EMDASH_HOOK_TOKEN:-}" ] || [ -z "\${EMDASH_PTY_ID:-}" ]; then
+  exit 0
+fi
+
+input="\${1:-$(cat)}"
+event=$(printf '%s' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+if [ -z "$event" ]; then
+  codex_type=$(printf '%s' "$input" | grep -oE '"type"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+  case "$codex_type" in
+    agent-turn-complete|task_complete) event="Stop" ;;
+    exec_approval_request|apply_patch_approval_request|request_user_input) event="PermissionRequest" ;;
+  esac
+fi
+
+case "$event" in
+  Stop)
+    payload="{\"notification_type\":\"idle_prompt\"}"
+    printf '%s' "$payload" | curl -sf -X POST \\
+      -H "Content-Type: application/json" \\
+      -H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" \\
+      -H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" \\
+      -H "X-Emdash-Agent-Id: \${EMDASH_AGENT_ID:-}" \\
+      -H "X-Emdash-Event-Type: notification" \\
+      -d @- \\
+      "http://127.0.0.1:$EMDASH_HOOK_PORT/hook" >/dev/null || true
+    ;;
+  PermissionRequest)
+    payload="{\"notification_type\":\"permission_prompt\"}"
+    printf '%s' "$payload" | curl -sf -X POST \\
+      -H "Content-Type: application/json" \\
+      -H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" \\
+      -H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" \\
+      -H "X-Emdash-Agent-Id: \${EMDASH_AGENT_ID:-}" \\
+      -H "X-Emdash-Event-Type: notification" \\
+      -d @- \\
+      "http://127.0.0.1:$EMDASH_HOOK_PORT/hook" >/dev/null || true
+    ;;
+  SessionStart)
+    printf '%s' "$input" | curl -sf -X POST \\
+      -H "Content-Type: application/json" \\
+      -H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" \\
+      -H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" \\
+      -H "X-Emdash-Agent-Id: \${EMDASH_AGENT_ID:-}" \\
+      -H "X-Emdash-Event-Type: session-start" \\
+      -d @- \\
+      "http://127.0.0.1:$EMDASH_HOOK_PORT/hook" >/dev/null || true
+    ;;
+esac
+`;
 }
 
-function makeCodexStdinHookPostCommand(
-  eventType: string,
-  options: HookCommandOptions = {}
-): string {
-  const post = makeHookPostCommand({ eventType, payload: 'stdin', platform: options.platform });
-  if ((options.platform ?? process.platform) === 'win32') return post;
-
-  return `INPUT="\${1:-$(cat)}"; printf '%s' "$INPUT" | ${post}`;
+export function makeCodexNotifyPowerShellContent(): string {
+  return [
+    "$ErrorActionPreference = 'SilentlyContinue'",
+    '',
+    'if (-not $env:EMDASH_HOOK_PORT -or -not $env:EMDASH_HOOK_TOKEN -or -not $env:EMDASH_PTY_ID) {',
+    '  exit 0',
+    '}',
+    '',
+    'if ($args.Count -gt 0) {',
+    '  $inputPayload = $args[0]',
+    '} else {',
+    '  $inputPayload = [Console]::In.ReadToEnd()',
+    '}',
+    '',
+    '$event = $null',
+    'try {',
+    '  $body = $inputPayload | ConvertFrom-Json',
+    '  if ($body.hook_event_name) {',
+    '    $event = [string]$body.hook_event_name',
+    '  } elseif ($body.type) {',
+    '    switch ([string]$body.type) {',
+    "      'agent-turn-complete' { $event = 'Stop' }",
+    "      'task_complete' { $event = 'Stop' }",
+    "      'exec_approval_request' { $event = 'PermissionRequest' }",
+    "      'apply_patch_approval_request' { $event = 'PermissionRequest' }",
+    "      'request_user_input' { $event = 'PermissionRequest' }",
+    '    }',
+    '  }',
+    '} catch {',
+    '  exit 0',
+    '}',
+    '',
+    'switch ($event) {',
+    "  'Stop' {",
+    "    $payload = @{ notification_type = 'idle_prompt' } | ConvertTo-Json -Compress",
+    "    $eventType = 'notification'",
+    '  }',
+    "  'PermissionRequest' {",
+    "    $payload = @{ notification_type = 'permission_prompt' } | ConvertTo-Json -Compress",
+    "    $eventType = 'notification'",
+    '  }',
+    "  'SessionStart' {",
+    '    $payload = $inputPayload',
+    "    $eventType = 'session-start'",
+    '  }',
+    '  default {',
+    '    exit 0',
+    '  }',
+    '}',
+    '',
+    'try {',
+    '  Invoke-WebRequest -UseBasicParsing -Method POST `',
+    "    -Uri ('http://127.0.0.1:' + $env:EMDASH_HOOK_PORT + '/hook') `",
+    '    -Headers @{',
+    "      'Content-Type' = 'application/json'",
+    "      'X-Emdash-Token' = $env:EMDASH_HOOK_TOKEN",
+    "      'X-Emdash-Pty-Id' = $env:EMDASH_PTY_ID",
+    "      'X-Emdash-Agent-Id' = $env:EMDASH_AGENT_ID",
+    "      'X-Emdash-Event-Type' = $eventType",
+    '    } `',
+    '    -Body $payload | Out-Null',
+    '} catch {',
+    '  exit 0',
+    '}',
+    '',
+  ].join('\n');
 }
 
-export function makeCodexSessionStartHookCommand(options: HookCommandOptions = {}): string {
-  return makeCodexStdinHookPostCommand('session-start', options);
+export function makeCodexNotifyHookCommand(
+  scriptPath: string,
+  options: HookCommandOptions = {}
+): string {
+  if ((options.platform ?? process.platform) === 'win32') {
+    return `cmd.exe /d /c "set EMDASH_AGENT_ID=codex&& powershell.exe -NoProfile -ExecutionPolicy Bypass -File ""${scriptPath}"""`;
+  }
+
+  return `EMDASH_AGENT_ID=codex sh "${scriptPath}"`;
 }

--- a/src/main/core/agent-hooks/agent-notify-command.ts
+++ b/src/main/core/agent-hooks/agent-notify-command.ts
@@ -1,5 +1,7 @@
 import { Buffer } from 'node:buffer';
 import ampPluginContent from './amp-emdash-plugin.ts?raw';
+import codexNotifyPowerShellContent from './codex-notify.ps1?raw';
+import codexNotifyScriptContent from './codex-notify.sh?raw';
 import openCodePluginContent from './opencode-notifications-plugin.js?raw';
 
 type HookPostPayload = 'stdin' | { json: Record<string, string> };
@@ -72,126 +74,11 @@ export function makeAmpPluginContent(): string {
 }
 
 export function makeCodexNotifyScriptContent(): string {
-  return `#!/bin/sh
-set -u
-
-if [ -z "\${EMDASH_HOOK_PORT:-}" ] || [ -z "\${EMDASH_HOOK_TOKEN:-}" ] || [ -z "\${EMDASH_PTY_ID:-}" ]; then
-  exit 0
-fi
-
-input="\${1:-$(cat)}"
-event=$(printf '%s' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
-if [ -z "$event" ]; then
-  codex_type=$(printf '%s' "$input" | grep -oE '"type"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
-  case "$codex_type" in
-    agent-turn-complete|task_complete) event="Stop" ;;
-    exec_approval_request|apply_patch_approval_request|request_user_input) event="PermissionRequest" ;;
-  esac
-fi
-
-case "$event" in
-  Stop)
-    payload="{\"notification_type\":\"idle_prompt\"}"
-    printf '%s' "$payload" | curl -sf -X POST \\
-      -H "Content-Type: application/json" \\
-      -H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" \\
-      -H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" \\
-      -H "X-Emdash-Agent-Id: \${EMDASH_AGENT_ID:-}" \\
-      -H "X-Emdash-Event-Type: notification" \\
-      -d @- \\
-      "http://127.0.0.1:$EMDASH_HOOK_PORT/hook" >/dev/null || true
-    ;;
-  PermissionRequest)
-    payload="{\"notification_type\":\"permission_prompt\"}"
-    printf '%s' "$payload" | curl -sf -X POST \\
-      -H "Content-Type: application/json" \\
-      -H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" \\
-      -H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" \\
-      -H "X-Emdash-Agent-Id: \${EMDASH_AGENT_ID:-}" \\
-      -H "X-Emdash-Event-Type: notification" \\
-      -d @- \\
-      "http://127.0.0.1:$EMDASH_HOOK_PORT/hook" >/dev/null || true
-    ;;
-  SessionStart)
-    printf '%s' "$input" | curl -sf -X POST \\
-      -H "Content-Type: application/json" \\
-      -H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" \\
-      -H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" \\
-      -H "X-Emdash-Agent-Id: \${EMDASH_AGENT_ID:-}" \\
-      -H "X-Emdash-Event-Type: session-start" \\
-      -d @- \\
-      "http://127.0.0.1:$EMDASH_HOOK_PORT/hook" >/dev/null || true
-    ;;
-esac
-`;
+  return codexNotifyScriptContent;
 }
 
 export function makeCodexNotifyPowerShellContent(): string {
-  return [
-    "$ErrorActionPreference = 'SilentlyContinue'",
-    '',
-    'if (-not $env:EMDASH_HOOK_PORT -or -not $env:EMDASH_HOOK_TOKEN -or -not $env:EMDASH_PTY_ID) {',
-    '  exit 0',
-    '}',
-    '',
-    'if ($args.Count -gt 0) {',
-    '  $inputPayload = $args[0]',
-    '} else {',
-    '  $inputPayload = [Console]::In.ReadToEnd()',
-    '}',
-    '',
-    '$event = $null',
-    'try {',
-    '  $body = $inputPayload | ConvertFrom-Json',
-    '  if ($body.hook_event_name) {',
-    '    $event = [string]$body.hook_event_name',
-    '  } elseif ($body.type) {',
-    '    switch ([string]$body.type) {',
-    "      'agent-turn-complete' { $event = 'Stop' }",
-    "      'task_complete' { $event = 'Stop' }",
-    "      'exec_approval_request' { $event = 'PermissionRequest' }",
-    "      'apply_patch_approval_request' { $event = 'PermissionRequest' }",
-    "      'request_user_input' { $event = 'PermissionRequest' }",
-    '    }',
-    '  }',
-    '} catch {',
-    '  exit 0',
-    '}',
-    '',
-    'switch ($event) {',
-    "  'Stop' {",
-    "    $payload = @{ notification_type = 'idle_prompt' } | ConvertTo-Json -Compress",
-    "    $eventType = 'notification'",
-    '  }',
-    "  'PermissionRequest' {",
-    "    $payload = @{ notification_type = 'permission_prompt' } | ConvertTo-Json -Compress",
-    "    $eventType = 'notification'",
-    '  }',
-    "  'SessionStart' {",
-    '    $payload = $inputPayload',
-    "    $eventType = 'session-start'",
-    '  }',
-    '  default {',
-    '    exit 0',
-    '  }',
-    '}',
-    '',
-    'try {',
-    '  Invoke-WebRequest -UseBasicParsing -Method POST `',
-    "    -Uri ('http://127.0.0.1:' + $env:EMDASH_HOOK_PORT + '/hook') `",
-    '    -Headers @{',
-    "      'Content-Type' = 'application/json'",
-    "      'X-Emdash-Token' = $env:EMDASH_HOOK_TOKEN",
-    "      'X-Emdash-Pty-Id' = $env:EMDASH_PTY_ID",
-    "      'X-Emdash-Agent-Id' = $env:EMDASH_AGENT_ID",
-    "      'X-Emdash-Event-Type' = $eventType",
-    '    } `',
-    '    -Body $payload | Out-Null',
-    '} catch {',
-    '  exit 0',
-    '}',
-    '',
-  ].join('\n');
+  return codexNotifyPowerShellContent;
 }
 
 export function makeCodexNotifyHookCommand(

--- a/src/main/core/agent-hooks/codex-notify.ps1
+++ b/src/main/core/agent-hooks/codex-notify.ps1
@@ -1,0 +1,62 @@
+$ErrorActionPreference = 'SilentlyContinue'
+
+if (-not $env:EMDASH_HOOK_PORT -or -not $env:EMDASH_HOOK_TOKEN -or -not $env:EMDASH_PTY_ID) {
+  exit 0
+}
+
+if ($args.Count -gt 0) {
+  $inputPayload = $args[0]
+} else {
+  $inputPayload = [Console]::In.ReadToEnd()
+}
+
+$event = $null
+try {
+  $body = $inputPayload | ConvertFrom-Json
+  if ($body.hook_event_name) {
+    $event = [string]$body.hook_event_name
+  } elseif ($body.type) {
+    switch ([string]$body.type) {
+      'agent-turn-complete' { $event = 'Stop' }
+      'task_complete' { $event = 'Stop' }
+      'exec_approval_request' { $event = 'PermissionRequest' }
+      'apply_patch_approval_request' { $event = 'PermissionRequest' }
+      'request_user_input' { $event = 'PermissionRequest' }
+    }
+  }
+} catch {
+  exit 0
+}
+
+switch ($event) {
+  'Stop' {
+    $payload = @{ notification_type = 'idle_prompt' } | ConvertTo-Json -Compress
+    $eventType = 'notification'
+  }
+  'PermissionRequest' {
+    $payload = @{ notification_type = 'permission_prompt' } | ConvertTo-Json -Compress
+    $eventType = 'notification'
+  }
+  'SessionStart' {
+    $payload = $inputPayload
+    $eventType = 'session-start'
+  }
+  default {
+    exit 0
+  }
+}
+
+try {
+  Invoke-WebRequest -UseBasicParsing -Method POST `
+    -Uri ('http://127.0.0.1:' + $env:EMDASH_HOOK_PORT + '/hook') `
+    -Headers @{
+      'Content-Type' = 'application/json'
+      'X-Emdash-Token' = $env:EMDASH_HOOK_TOKEN
+      'X-Emdash-Pty-Id' = $env:EMDASH_PTY_ID
+      'X-Emdash-Agent-Id' = $env:EMDASH_AGENT_ID
+      'X-Emdash-Event-Type' = $eventType
+    } `
+    -Body $payload | Out-Null
+} catch {
+  exit 0
+}

--- a/src/main/core/agent-hooks/codex-notify.ps1
+++ b/src/main/core/agent-hooks/codex-notify.ps1
@@ -1,5 +1,3 @@
-$ErrorActionPreference = 'SilentlyContinue'
-
 if (-not $env:EMDASH_HOOK_PORT -or -not $env:EMDASH_HOOK_TOKEN -or -not $env:EMDASH_PTY_ID) {
   exit 0
 }
@@ -25,7 +23,11 @@ try {
     }
   }
 } catch {
-  exit 0
+  $event = $null
+}
+
+if (-not $event) {
+  $event = $env:EMDASH_HOOK_EVENT
 }
 
 switch ($event) {
@@ -48,6 +50,7 @@ switch ($event) {
 
 try {
   Invoke-WebRequest -UseBasicParsing -Method POST `
+    -ErrorAction SilentlyContinue `
     -Uri ('http://127.0.0.1:' + $env:EMDASH_HOOK_PORT + '/hook') `
     -Headers @{
       'Content-Type' = 'application/json'

--- a/src/main/core/agent-hooks/codex-notify.sh
+++ b/src/main/core/agent-hooks/codex-notify.sh
@@ -14,6 +14,9 @@ if [ -z "$event" ]; then
     exec_approval_request|apply_patch_approval_request|request_user_input) event="PermissionRequest" ;;
   esac
 fi
+if [ -z "$event" ]; then
+  event="${EMDASH_HOOK_EVENT:-}"
+fi
 
 post_hook() {
   event_type="$1"

--- a/src/main/core/agent-hooks/codex-notify.sh
+++ b/src/main/core/agent-hooks/codex-notify.sh
@@ -1,0 +1,40 @@
+#!/bin/sh
+set -u
+
+if [ -z "${EMDASH_HOOK_PORT:-}" ] || [ -z "${EMDASH_HOOK_TOKEN:-}" ] || [ -z "${EMDASH_PTY_ID:-}" ]; then
+  exit 0
+fi
+
+input="${1:-$(cat)}"
+event=$(printf '%s' "$input" | grep -oE '"hook_event_name"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+if [ -z "$event" ]; then
+  codex_type=$(printf '%s' "$input" | grep -oE '"type"[[:space:]]*:[[:space:]]*"[^"]*"' | grep -oE '"[^"]*"$' | tr -d '"')
+  case "$codex_type" in
+    agent-turn-complete|task_complete) event="Stop" ;;
+    exec_approval_request|apply_patch_approval_request|request_user_input) event="PermissionRequest" ;;
+  esac
+fi
+
+post_hook() {
+  event_type="$1"
+  curl -sf -X POST \
+    -H "Content-Type: application/json" \
+    -H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" \
+    -H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" \
+    -H "X-Emdash-Agent-Id: ${EMDASH_AGENT_ID:-}" \
+    -H "X-Emdash-Event-Type: $event_type" \
+    -d @- \
+    "http://127.0.0.1:$EMDASH_HOOK_PORT/hook" >/dev/null || true
+}
+
+case "$event" in
+  Stop)
+    printf '%s' '{"notification_type":"idle_prompt"}' | post_hook notification
+    ;;
+  PermissionRequest)
+    printf '%s' '{"notification_type":"permission_prompt"}' | post_hook notification
+    ;;
+  SessionStart)
+    printf '%s' "$input" | post_hook session-start
+    ;;
+esac

--- a/src/main/core/agent-hooks/codex-notify.sh
+++ b/src/main/core/agent-hooks/codex-notify.sh
@@ -35,6 +35,7 @@ case "$event" in
     printf '%s' '{"notification_type":"permission_prompt"}' | post_hook notification
     ;;
   SessionStart)
+    printf '%s' "$input" | grep -qE '"hook_event_name"[[:space:]]*:[[:space:]]*"SessionStart"' || exit 0
     printf '%s' "$input" | post_hook session-start
     ;;
 esac

--- a/src/main/core/agent-hooks/hook-config.test.ts
+++ b/src/main/core/agent-hooks/hook-config.test.ts
@@ -77,9 +77,7 @@ describe('HookConfigWriter', () => {
     expect(fs.files.has('.codex/config.toml')).toBe(false);
     expect(fs.files.has('.gitignore')).toBe(false);
 
-    expect(userFs.files.get('.emdash/hooks/codex-notify.sh')).toContain(
-      'post_hook session-start'
-    );
+    expect(userFs.files.get('.emdash/hooks/codex-notify.sh')).toContain('post_hook session-start');
     const config = JSON.parse(userFs.files.get('.codex/hooks.json')!);
     expect(config.hooks.Stop[0].hooks[0].command).toBe(
       'EMDASH_AGENT_ID=codex sh "$HOME/.emdash/hooks/codex-notify.sh"'

--- a/src/main/core/agent-hooks/hook-config.test.ts
+++ b/src/main/core/agent-hooks/hook-config.test.ts
@@ -78,7 +78,7 @@ describe('HookConfigWriter', () => {
     expect(fs.files.has('.gitignore')).toBe(false);
 
     expect(userFs.files.get('.emdash/hooks/codex-notify.sh')).toContain(
-      'X-Emdash-Event-Type: session-start'
+      'post_hook session-start'
     );
     const config = JSON.parse(userFs.files.get('.codex/hooks.json')!);
     expect(config.hooks.Stop[0].hooks[0].command).toBe(

--- a/src/main/core/agent-hooks/hook-config.test.ts
+++ b/src/main/core/agent-hooks/hook-config.test.ts
@@ -77,14 +77,19 @@ describe('HookConfigWriter', () => {
     expect(fs.files.has('.codex/config.toml')).toBe(false);
     expect(fs.files.has('.gitignore')).toBe(false);
 
-    const config = JSON.parse(userFs.files.get('.codex/hooks.json')!);
-    expect(config.hooks.Stop[0].hooks[0].command).toContain('{"notification_type":"idle_prompt"}');
-    expect(config.hooks.PermissionRequest[0].hooks[0].command).toContain(
-      '{"notification_type":"permission_prompt"}'
+    expect(userFs.files.get('.emdash/hooks/codex-notify.sh')).toContain(
+      'X-Emdash-Event-Type: session-start'
     );
-    expect(config.hooks.SessionStart[0].hooks[0].command).toContain('session-start');
-    expect(config.hooks.SessionStart[0].hooks[0].command).toContain('INPUT="${1:-$(cat)}"');
-    expect(config.hooks.Stop[0].hooks[0].command).toContain('X-Emdash-Pty-Id');
+    const config = JSON.parse(userFs.files.get('.codex/hooks.json')!);
+    expect(config.hooks.Stop[0].hooks[0].command).toBe(
+      'EMDASH_AGENT_ID=codex sh "$HOME/.emdash/hooks/codex-notify.sh"'
+    );
+    expect(config.hooks.PermissionRequest[0].hooks[0].command).toBe(
+      'EMDASH_AGENT_ID=codex sh "$HOME/.emdash/hooks/codex-notify.sh"'
+    );
+    expect(config.hooks.SessionStart[0].hooks[0].command).toBe(
+      'EMDASH_AGENT_ID=codex sh "$HOME/.emdash/hooks/codex-notify.sh"'
+    );
   });
 
   it('preserves unrelated Codex hooks while replacing Emdash-managed entries', async () => {
@@ -109,7 +114,9 @@ describe('HookConfigWriter', () => {
     const config = JSON.parse(userFs.files.get('.codex/hooks.json')!);
     expect(config.hooks.Stop).toHaveLength(2);
     expect(config.hooks.Stop[0].hooks[0].command).toBe('echo user hook');
-    expect(config.hooks.Stop[1].hooks[0].command).toContain('{"notification_type":"idle_prompt"}');
+    expect(config.hooks.Stop[1].hooks[0].command).toBe(
+      'EMDASH_AGENT_ID=codex sh "$HOME/.emdash/hooks/codex-notify.sh"'
+    );
   });
 
   it('removes only the legacy Emdash Codex notify key from project-local config', async () => {

--- a/src/main/core/agent-hooks/hook-config.ts
+++ b/src/main/core/agent-hooks/hook-config.ts
@@ -9,17 +9,26 @@ import type { AgentProviderId } from '@shared/agent-provider-registry';
 import {
   makeAmpPluginContent,
   makeClaudeHookCommand,
-  makeCodexHookCommand,
-  makeCodexSessionStartHookCommand,
+  makeCodexNotifyHookCommand,
+  makeCodexNotifyPowerShellContent,
+  makeCodexNotifyScriptContent,
   makeOpenCodePluginContent,
 } from './agent-notify-command';
 import piEmdashExtension from './pi-emdash-extension.ts?raw';
 
-const EMDASH_MARKER = 'EMDASH_HOOK_PORT';
+const EMDASH_MARKERS = [
+  'EMDASH_HOOK_PORT',
+  'EMDASH_CODEX_EVENT',
+  'emdash-notify',
+  'codex-notify',
+  '.emdash/hooks',
+];
 
 const CLAUDE_SETTINGS_PATH = '.claude/settings.local.json';
 const CODEX_CONFIG_PATH = '.codex/config.toml';
 const CODEX_HOOKS_PATH = '.codex/hooks.json';
+const CODEX_NOTIFY_SCRIPT_PATH = '.emdash/hooks/codex-notify.sh';
+const CODEX_NOTIFY_POWERSHELL_PATH = '.emdash/hooks/codex-notify.ps1';
 const DROID_SETTINGS_PATH = '.factory/settings.json';
 const AMP_PLUGIN_PATH = '.amp/plugins/emdash-hook.ts';
 const PI_EMDASH_EXTENSION_PATH = '.pi/extensions/emdash-hook.ts';
@@ -34,10 +43,9 @@ const HOOK_EVENT_MAP = [
   { eventType: 'stop', hookKey: 'Stop' },
 ] satisfies { eventType: string; hookKey: string }[];
 
-const CODEX_HOOK_EVENT_MAP = [
-  { hookKey: 'Stop', notificationType: 'idle_prompt' },
-  { hookKey: 'PermissionRequest', notificationType: 'permission_prompt' },
-] satisfies { hookKey: CodexHookEvent; notificationType: 'idle_prompt' | 'permission_prompt' }[];
+const CODEX_HOOK_EVENT_MAP = [{ hookKey: 'Stop' }, { hookKey: 'PermissionRequest' }] satisfies {
+  hookKey: CodexHookEvent;
+}[];
 
 const CODEX_SESSION_HOOK_EVENT_MAP = [{ hookKey: 'SessionStart' as const }] satisfies {
   hookKey: CodexHookEvent;
@@ -102,6 +110,8 @@ export class HookConfigWriter {
   async writeCodexHooks(): Promise<boolean> {
     if (!(await resolveCommandPath('codex', this.exec))) return false;
 
+    await this.writeCodexNotifyScripts();
+
     const config: Record<string, unknown> = (await this.userFs.exists(CODEX_HOOKS_PATH))
       ? await this.userFs
           .read(CODEX_HOOKS_PATH)
@@ -111,11 +121,11 @@ export class HookConfigWriter {
 
     const hooks = (config.hooks ?? {}) as Record<string, unknown[]>;
 
-    for (const { hookKey, notificationType } of CODEX_HOOK_EVENT_MAP) {
+    for (const { hookKey } of CODEX_HOOK_EVENT_MAP) {
       const existing = Array.isArray(hooks[hookKey]) ? hooks[hookKey] : [];
       hooks[hookKey] = this.buildHookEntries(
         existing,
-        makeCodexHookCommand(notificationType, { platform: this.platform })
+        makeCodexNotifyHookCommand(this.codexNotifyScriptCommandPath(), { platform: this.platform })
       );
     }
 
@@ -123,7 +133,7 @@ export class HookConfigWriter {
       const existing = Array.isArray(hooks[hookKey]) ? hooks[hookKey] : [];
       hooks[hookKey] = this.buildHookEntries(
         existing,
-        makeCodexSessionStartHookCommand({ platform: this.platform })
+        makeCodexNotifyHookCommand(this.codexNotifyScriptCommandPath(), { platform: this.platform })
       );
     }
 
@@ -132,6 +142,21 @@ export class HookConfigWriter {
       log.warn('CodexHooks: failed to remove legacy notify entry', { error: String(err) });
     });
     return true;
+  }
+
+  private async writeCodexNotifyScripts(): Promise<void> {
+    if (this.platform === 'win32') {
+      await this.userFs.write(CODEX_NOTIFY_POWERSHELL_PATH, makeCodexNotifyPowerShellContent());
+      return;
+    }
+
+    await this.userFs.write(CODEX_NOTIFY_SCRIPT_PATH, makeCodexNotifyScriptContent());
+  }
+
+  private codexNotifyScriptCommandPath(): string {
+    return this.platform === 'win32'
+      ? '%USERPROFILE%\\.emdash\\hooks\\codex-notify.ps1'
+      : '$HOME/.emdash/hooks/codex-notify.sh';
   }
 
   async writeDroidHooks(): Promise<boolean> {
@@ -263,7 +288,10 @@ export class HookConfigWriter {
   }
 
   private buildHookEntries(existing: unknown[], command: string): unknown[] {
-    const userEntries = existing.filter((entry) => !JSON.stringify(entry).includes(EMDASH_MARKER));
+    const userEntries = existing.filter((entry) => {
+      const serialized = JSON.stringify(entry);
+      return !EMDASH_MARKERS.some((marker) => serialized.includes(marker));
+    });
     return [...userEntries, { hooks: [{ type: 'command', command }] }];
   }
 

--- a/src/main/core/agent-hooks/hook-config.ts
+++ b/src/main/core/agent-hooks/hook-config.ts
@@ -121,11 +121,11 @@ export class HookConfigWriter {
 
     const hooks = (config.hooks ?? {}) as Record<string, unknown[]>;
 
-    const command = makeCodexNotifyHookCommand(this.codexNotifyScriptCommandPath(), {
-      platform: this.platform,
-    });
     for (const { hookKey } of CODEX_HOOK_EVENT_MAP) {
       const existing = Array.isArray(hooks[hookKey]) ? hooks[hookKey] : [];
+      const command = makeCodexNotifyHookCommand(this.codexNotifyScriptCommandPath(), hookKey, {
+        platform: this.platform,
+      });
       hooks[hookKey] = this.buildHookEntries(existing, command);
     }
 
@@ -138,11 +138,21 @@ export class HookConfigWriter {
 
   private async writeCodexNotifyScripts(): Promise<void> {
     if (this.platform === 'win32') {
-      await this.userFs.write(CODEX_NOTIFY_POWERSHELL_PATH, makeCodexNotifyPowerShellContent());
+      await this.writeIfChanged(CODEX_NOTIFY_POWERSHELL_PATH, makeCodexNotifyPowerShellContent());
       return;
     }
 
-    await this.userFs.write(CODEX_NOTIFY_SCRIPT_PATH, makeCodexNotifyScriptContent());
+    await this.writeIfChanged(CODEX_NOTIFY_SCRIPT_PATH, makeCodexNotifyScriptContent());
+  }
+
+  private async writeIfChanged(path: string, content: string): Promise<void> {
+    const existing = await this.userFs
+      .read(path)
+      .then((r) => r.content)
+      .catch(() => undefined);
+    if (existing === content) return;
+
+    await this.userFs.write(path, content);
   }
 
   private codexNotifyScriptCommandPath(): string {

--- a/src/main/core/agent-hooks/hook-config.ts
+++ b/src/main/core/agent-hooks/hook-config.ts
@@ -43,11 +43,11 @@ const HOOK_EVENT_MAP = [
   { eventType: 'stop', hookKey: 'Stop' },
 ] satisfies { eventType: string; hookKey: string }[];
 
-const CODEX_HOOK_EVENT_MAP = [{ hookKey: 'Stop' }, { hookKey: 'PermissionRequest' }] satisfies {
-  hookKey: CodexHookEvent;
-}[];
-
-const CODEX_SESSION_HOOK_EVENT_MAP = [{ hookKey: 'SessionStart' as const }] satisfies {
+const CODEX_HOOK_EVENT_MAP = [
+  { hookKey: 'Stop' },
+  { hookKey: 'PermissionRequest' },
+  { hookKey: 'SessionStart' },
+] satisfies {
   hookKey: CodexHookEvent;
 }[];
 
@@ -121,20 +121,12 @@ export class HookConfigWriter {
 
     const hooks = (config.hooks ?? {}) as Record<string, unknown[]>;
 
+    const command = makeCodexNotifyHookCommand(this.codexNotifyScriptCommandPath(), {
+      platform: this.platform,
+    });
     for (const { hookKey } of CODEX_HOOK_EVENT_MAP) {
       const existing = Array.isArray(hooks[hookKey]) ? hooks[hookKey] : [];
-      hooks[hookKey] = this.buildHookEntries(
-        existing,
-        makeCodexNotifyHookCommand(this.codexNotifyScriptCommandPath(), { platform: this.platform })
-      );
-    }
-
-    for (const { hookKey } of CODEX_SESSION_HOOK_EVENT_MAP) {
-      const existing = Array.isArray(hooks[hookKey]) ? hooks[hookKey] : [];
-      hooks[hookKey] = this.buildHookEntries(
-        existing,
-        makeCodexNotifyHookCommand(this.codexNotifyScriptCommandPath(), { platform: this.platform })
-      );
+      hooks[hookKey] = this.buildHookEntries(existing, command);
     }
 
     await this.userFs.write(CODEX_HOOKS_PATH, JSON.stringify({ ...config, hooks }, null, 2) + '\n');

--- a/src/main/core/agent-hooks/hook-server.ts
+++ b/src/main/core/agent-hooks/hook-server.ts
@@ -4,6 +4,7 @@ import { log } from '@main/lib/logger';
 
 export interface RawHookRequest {
   ptyId: string;
+  agentId?: string;
   type: string;
   body: string;
 }
@@ -42,6 +43,7 @@ export class HookServer {
 
       req.on('end', () => {
         const ptyId = String(req.headers['x-emdash-pty-id'] || '');
+        const agentId = String(req.headers['x-emdash-agent-id'] || '') || undefined;
         const type = String(req.headers['x-emdash-event-type'] || '');
         if (!ptyId || !type) {
           log.warn('HookServer: malformed request — missing ptyId or type headers');
@@ -49,7 +51,7 @@ export class HookServer {
           res.end();
           return;
         }
-        handler({ ptyId, type, body })
+        handler({ ptyId, agentId, type, body })
           .then(() => {
             res.writeHead(200);
             res.end();


### PR DESCRIPTION
# summary
- codex notifications now delegate to generated shell/powerhsll scripts
- session start/permissions/idle notifcations handled through same hook path

demo:
https://streamable.com/z88n8b