### PR TITLE
fix(resource-monitor): label terminal sessions

### DIFF
--- a/src/main/core/terminals/impl/local-terminal-provider.test.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { PtyExitInfo } from '@main/core/pty/pty';
+import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { makePtySessionId } from '@shared/ptySessionId';
 import type { Terminal } from '@shared/terminals';
 import { LocalTerminalProvider } from './local-terminal-provider';
@@ -50,6 +51,25 @@ const ctx = {
 describe('LocalTerminalProvider', () => {
   beforeEach(() => {
     ptyMock.exitHandlers.length = 0;
+    vi.mocked(ptySessionRegistry.register).mockClear();
+  });
+
+  it('registers user terminals with their display name for resource monitor labels', async () => {
+    const provider = new LocalTerminalProvider({
+      projectId: terminal.projectId,
+      scopeId: terminal.taskId,
+      taskPath: '/repo',
+      ctx,
+    });
+
+    await provider.spawnTerminal(terminal);
+
+    const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
+    expect(ptySessionRegistry.register).toHaveBeenCalledWith(
+      sessionId,
+      expect.anything(),
+      expect.objectContaining({ metadata: { title: terminal.name } })
+    );
   });
 
   it('cleans up cached shell profiles after a non-respawned exit', async () => {

--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -3,7 +3,7 @@ import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import { buildTerminalEnv } from '@main/core/pty/pty-env';
-import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { ptySessionRegistry, type PtySessionMetadata } from '@main/core/pty/pty-session-registry';
 import {
   logLocalPtySpawnWarnings,
   resolveLocalPtySpawn,
@@ -88,6 +88,7 @@ export class LocalTerminalProvider implements TerminalProvider {
         : undefined,
       undefined,
       options.shell ?? terminal.shellId,
+      { title: terminal.name },
       {
         respawnOnExit: true,
         preserveBufferOnExit: false,
@@ -111,6 +112,7 @@ export class LocalTerminalProvider implements TerminalProvider {
       command === undefined ? undefined : { kind: 'shell-line', commandLine: command },
       shellSetup,
       'system',
+      undefined,
       {
         respawnOnExit,
         preserveBufferOnExit,
@@ -125,6 +127,7 @@ export class LocalTerminalProvider implements TerminalProvider {
     command: PtyCommandSpec | undefined,
     shellSetup: string | undefined,
     shellIntent: TerminalShellId,
+    metadata: PtySessionMetadata | undefined,
     policy: SpawnPolicy
   ): Promise<void> {
     const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
@@ -204,6 +207,7 @@ export class LocalTerminalProvider implements TerminalProvider {
             command,
             shellSetup,
             shellIntent,
+            metadata,
             policy
           ).catch((e) => {
             log.error('LocalTerminalProvider: respawn failed', {
@@ -219,6 +223,7 @@ export class LocalTerminalProvider implements TerminalProvider {
 
     ptySessionRegistry.register(sessionId, pty, {
       preserveBufferOnExit: policy.preserveBufferOnExit,
+      metadata,
     });
     this.sessions.set(sessionId, pty);
   }

--- a/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { PtyExitInfo } from '@main/core/pty/pty';
+import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import { makePtySessionId } from '@shared/ptySessionId';
 import type { Terminal } from '@shared/terminals';
@@ -68,10 +69,31 @@ const proxy = {
 describe('SshTerminalProvider', () => {
   beforeEach(() => {
     ptyMock.exitHandlers.length = 0;
+    vi.mocked(ptySessionRegistry.register).mockClear();
     proxy.getRemoteShellProfile = vi.fn(async () => ({
       shell: '/bin/bash',
       env: { PATH: '/usr/bin', HOME: '/home/me' },
     }));
+  });
+
+  it('registers user terminals with their display name for resource monitor labels', async () => {
+    const provider = new SshTerminalProvider({
+      projectId: terminal.projectId,
+      scopeId: terminal.taskId,
+      taskPath: '/repo',
+      ctx,
+      proxy,
+      connectionId: 'ssh-1',
+    });
+
+    await provider.spawnTerminal(terminal);
+
+    const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
+    expect(ptySessionRegistry.register).toHaveBeenCalledWith(
+      sessionId,
+      expect.anything(),
+      expect.objectContaining({ metadata: { title: terminal.name, isRemote: true } })
+    );
   });
 
   it('cleans up cached shell profiles after a non-respawned exit', async () => {

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -1,7 +1,7 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { isUnexpectedPtyExit } from '@main/core/pty/exit-classification';
 import type { Pty } from '@main/core/pty/pty';
-import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { ptySessionRegistry, type PtySessionMetadata } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
@@ -107,6 +107,7 @@ export class SshTerminalProvider implements TerminalProvider {
       options.command,
       undefined,
       options.shell ?? terminal.shellId,
+      { title: terminal.name, isRemote: true },
       {
         respawnOnExit: true,
         preserveBufferOnExit: false,
@@ -131,6 +132,7 @@ export class SshTerminalProvider implements TerminalProvider {
       command === undefined ? undefined : { command, args: [] },
       shellSetup,
       'system',
+      { isRemote: true },
       {
         respawnOnExit,
         preserveBufferOnExit,
@@ -146,6 +148,7 @@ export class SshTerminalProvider implements TerminalProvider {
     command: { command: string; args: string[] } | undefined,
     shellSetup: string | undefined,
     shellIntent: TerminalShellId,
+    metadata: PtySessionMetadata | undefined,
     policy: SpawnPolicy
   ): Promise<void> {
     const sessionId = makePtySessionId(terminal.projectId, terminal.taskId, terminal.id);
@@ -223,6 +226,7 @@ export class SshTerminalProvider implements TerminalProvider {
             command,
             shellSetup,
             shellIntent,
+            metadata,
             policy
           ).catch((e) => {
             log.error('SshTerminalProvider: respawn failed', {
@@ -238,6 +242,7 @@ export class SshTerminalProvider implements TerminalProvider {
 
     ptySessionRegistry.register(sessionId, pty, {
       preserveBufferOnExit: policy.preserveBufferOnExit,
+      metadata,
     });
     this.sessions.set(sessionId, pty);
   }

--- a/src/renderer/features/command-palette/resource-monitor-utils.ts
+++ b/src/renderer/features/command-palette/resource-monitor-utils.ts
@@ -1,4 +1,7 @@
-import { conversationRegistry } from '@renderer/features/tasks/stores/conversation-registry';
+import {
+  getConversationsForTask,
+  getTerminalsForTask,
+} from '@renderer/features/tasks/stores/task-selectors';
 import { agentMeta } from '@renderer/lib/providers/meta';
 import { appState } from '@renderer/lib/stores/app-state';
 import { formatBytes } from '@renderer/utils/formatBytes';
@@ -13,7 +16,7 @@ import { createLifecycleScriptTerminalId } from '@shared/terminals';
 export type Entry = ResourcePtyEntry & {
   taskName?: string;
   providerId?: AgentProviderId;
-  conversationTitle?: string;
+  displayTitle?: string;
 };
 
 export type TaskBucket = {
@@ -52,10 +55,10 @@ export function isLifecycleScriptEntry(entry: Pick<Entry, 'leafId'>): boolean {
 export function entryLabel(entry: Entry): string {
   const meta = entry.providerId ? agentMeta[entry.providerId] : undefined;
   return (
-    entry.conversationTitle ||
+    LIFECYCLE_SCRIPT_LABELS[entry.leafId] ||
+    entry.displayTitle ||
     meta?.label ||
     entry.providerId ||
-    LIFECYCLE_SCRIPT_LABELS[entry.leafId] ||
     entry.leafId.slice(0, 8)
   );
 }
@@ -126,7 +129,7 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
     // Resolving both to the owning task id groups them under the same branch.
     let bucketKey = entry.scopeId;
     let providerId: AgentProviderId | undefined;
-    let conversationTitle: string | undefined;
+    let displayTitle: string | undefined;
     let projectName = 'Other';
     let projectKey = UNKNOWN_PROJECT_ID;
 
@@ -151,16 +154,17 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
       if (task) {
         bucketKey = taskId;
         taskName = task.displayName;
-        const conv = conversationRegistry.get(taskId)?.conversations.get(entry.leafId);
+        const conv = getConversationsForTask(taskId)?.conversations.get(entry.leafId);
+        const terminal = getTerminalsForTask(taskId)?.terminals.get(entry.leafId);
         providerId = conv?.data.providerId;
-        conversationTitle = conv?.data.title;
+        displayTitle = conv?.data.title ?? terminal?.data.name;
       }
     }
 
     // Fall back to metadata supplied by the sampler (covers cases where the
-    // owning project isn't mounted, so the conversation join above misses).
+    // owning project isn't mounted, so the conversation/terminal join above misses).
     providerId ??= entry.providerId;
-    conversationTitle ??= entry.title;
+    displayTitle ??= entry.title;
 
     const project = byProject.get(projectKey) ?? {
       projectName,
@@ -172,7 +176,7 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
       entries: [],
       cpuSum: 0,
     };
-    taskBucket.entries.push({ ...entry, taskName, providerId, conversationTitle });
+    taskBucket.entries.push({ ...entry, taskName, providerId, displayTitle });
     taskBucket.cpuSum += entry.cpu;
     project.tasks.set(bucketKey, taskBucket);
     byProject.set(projectKey, project);

--- a/src/renderer/features/command-palette/resource-monitor-view.tsx
+++ b/src/renderer/features/command-palette/resource-monitor-view.tsx
@@ -69,7 +69,7 @@ export const ResourceMonitorView = observer(function ResourceMonitorView({
           </Section>
         )}
 
-        <Section heading="Active agents">
+        <Section heading="Active sessions">
           {hasProjects ? (
             <div className="flex flex-col gap-1">
               {groups.map((g) => (
@@ -78,7 +78,7 @@ export const ResourceMonitorView = observer(function ResourceMonitorView({
             </div>
           ) : (
             <div className="rounded-md py-6 text-center text-xs text-foreground/40">
-              No active agents
+              No active sessions
             </div>
           )}
         </Section>
@@ -182,7 +182,7 @@ function AgentRow({ entry }: { entry: Entry }) {
             className="h-3.5 w-3.5"
           />
         </span>
-      ) : isLifecycleScriptEntry(entry) ? (
+      ) : isLifecycleScriptEntry(entry) || !entry.providerId ? (
         <span className="flex size-4 shrink-0 items-center justify-center">
           <Terminal size={12} className="text-foreground/40" />
         </span>

--- a/src/shared/resource-monitor.ts
+++ b/src/shared/resource-monitor.ts
@@ -5,10 +5,10 @@ import type { AgentProviderId } from '@shared/agent-provider-registry';
  * on multi-core systems). `memory` is RSS in bytes. `pid` is undefined for
  * remote (SSH) PTYs where the owning process runs on the remote host.
  *
- * `providerId` and `title` are populated for agent-conversation PTYs and
- * absent for plain shell terminals. They are sourced from the registry at
- * register-time so the renderer can label entries even when the owning
- * project isn't mounted (in which case the renderer-side conversation join
+ * `providerId` is populated for agent-conversation PTYs. `title` is populated
+ * for conversations and user-created shell terminals. They are sourced from
+ * the registry at register-time so the renderer can label entries even when
+ * the owning project isn't mounted (in which case the renderer-side store join
  * would fail and the row would fall back to a leafId hex).
  */
 export interface ResourcePtyEntry {


### PR DESCRIPTION
# summary
- fixes that open terminals would just get displayed as uuids instead of "temrinal 1" for example

demo:
<img width="492" height="313" alt="image" src="https://github.com/user-attachments/assets/555d648a-76ed-4a01-89c8-3d1d5170d181" />
before: https://streamable.com/re2ub0