### PR TITLE
fix(claude): sync theme with terminal background

### DIFF
--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -100,9 +100,9 @@ describe('buildAgentCommand', () => {
     expect(command).toEqual({
       command: 'agy',
       args: ['--conversation=session-1', '--dangerously-skip-permissions', '-i', 'Fix the issue'],
-    });
-  });
-
+    }); 
+  }); 
+ 
   it('supports custom CLI command prefixes and appends managed provider args', () => {
     const result = buildAgentCommand({
       providerId: 'claude',
@@ -122,6 +122,29 @@ describe('buildAgentCommand', () => {
         'exec',
         '.',
         'claude',
+        '--session-id',
+        'conv-1',
+        '--dangerously-skip-permissions',
+        'Fix the bug',
+      ],
+    });
+  });
+
+  it('puts managed default args before session, permission, and prompt args', () => {
+    const result = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: makeConfig(),
+      managedDefaultArgs: ['--settings', '{"theme":"auto"}'],
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+    });
+
+    expect(result).toEqual({
+      command: 'claude',
+      args: [
+        '--settings',
+        '{"theme":"auto"}',
         '--session-id',
         'conv-1',
         '--dangerously-skip-permissions',

--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -166,6 +166,19 @@ describe('buildAgentCommand', () => {
     expect(result.args).toEqual(['--settings', '{"theme":"dark"}', '--session-id', 'conv-1']);
   });
 
+  it('does not duplicate managed settings when extra args include user settings', () => {
+    const result = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: makeConfig({
+        extraArgs: '--settings \'{"theme":"dark"}\'',
+      }),
+      managedDefaultArgs: ['--settings', '{"theme":"auto"}'],
+      sessionId: 'conv-1',
+    });
+
+    expect(result.args).toEqual(['--session-id', 'conv-1', '--settings', '{"theme":"dark"}']);
+  });
+
   it('preserves quoted custom CLI and flag arguments', () => {
     const result = buildAgentCommand({
       providerId: 'claude',

--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -100,9 +100,9 @@ describe('buildAgentCommand', () => {
     expect(command).toEqual({
       command: 'agy',
       args: ['--conversation=session-1', '--dangerously-skip-permissions', '-i', 'Fix the issue'],
-    }); 
-  }); 
- 
+    });
+  });
+
   it('supports custom CLI command prefixes and appends managed provider args', () => {
     const result = buildAgentCommand({
       providerId: 'claude',

--- a/src/main/core/conversations/impl/agent-command.test.ts
+++ b/src/main/core/conversations/impl/agent-command.test.ts
@@ -153,6 +153,19 @@ describe('buildAgentCommand', () => {
     });
   });
 
+  it('does not duplicate managed settings when default args include user settings', () => {
+    const result = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: makeConfig({
+        defaultArgs: ['--settings', '{"theme":"dark"}'],
+      }),
+      managedDefaultArgs: ['--settings', '{"theme":"auto"}'],
+      sessionId: 'conv-1',
+    });
+
+    expect(result.args).toEqual(['--settings', '{"theme":"dark"}', '--session-id', 'conv-1']);
+  });
+
   it('preserves quoted custom CLI and flag arguments', () => {
     const result = buildAgentCommand({
       providerId: 'claude',

--- a/src/main/core/conversations/impl/agent-command.ts
+++ b/src/main/core/conversations/impl/agent-command.ts
@@ -103,6 +103,27 @@ function appendSessionId(args: string[], flag: string, sessionId: string): void 
   args.push(...parts, sessionId);
 }
 
+function hasSettingsArg(args: string[]): boolean {
+  return args.some((arg) => arg === '--settings' || arg.startsWith('--settings='));
+}
+
+function mergeDefaultArgs(defaultArgs: string[], managedDefaultArgs: string[]): string[] {
+  if (!hasSettingsArg(defaultArgs)) return [...defaultArgs, ...managedDefaultArgs];
+
+  const filteredManagedArgs: string[] = [];
+  for (let i = 0; i < managedDefaultArgs.length; i += 1) {
+    const arg = managedDefaultArgs[i];
+    if (arg === '--settings') {
+      i += 1;
+      continue;
+    }
+    if (arg.startsWith('--settings=')) continue;
+    filteredManagedArgs.push(arg);
+  }
+
+  return [...defaultArgs, ...filteredManagedArgs];
+}
+
 export function buildAgentCommand({
   providerId,
   providerConfig,
@@ -126,8 +147,7 @@ export function buildAgentCommand({
   const [command, ...args] = parseCliPrefix(providerConfig?.cli, providerId);
   const initialPromptFlag = providerConfig?.initialPromptFlag;
 
-  args.push(...(providerConfig?.defaultArgs ?? []));
-  args.push(...(managedDefaultArgs ?? []));
+  args.push(...mergeDefaultArgs(providerConfig?.defaultArgs ?? [], managedDefaultArgs ?? []));
 
   const sessionIdFlag = providerConfig?.sessionIdFlag;
   const shouldPassSessionId =

--- a/src/main/core/conversations/impl/agent-command.ts
+++ b/src/main/core/conversations/impl/agent-command.ts
@@ -107,21 +107,32 @@ function hasSettingsArg(args: string[]): boolean {
   return args.some((arg) => arg === '--settings' || arg.startsWith('--settings='));
 }
 
-function mergeDefaultArgs(defaultArgs: string[], managedDefaultArgs: string[]): string[] {
-  if (!hasSettingsArg(defaultArgs)) return [...defaultArgs, ...managedDefaultArgs];
-
-  const filteredManagedArgs: string[] = [];
-  for (let i = 0; i < managedDefaultArgs.length; i += 1) {
-    const arg = managedDefaultArgs[i];
+function removeSettingsArg(args: string[]): string[] {
+  const filteredArgs: string[] = [];
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
     if (arg === '--settings') {
       i += 1;
       continue;
     }
     if (arg.startsWith('--settings=')) continue;
-    filteredManagedArgs.push(arg);
+    filteredArgs.push(arg);
   }
 
-  return [...defaultArgs, ...filteredManagedArgs];
+  return filteredArgs;
+}
+
+function mergeDefaultArgs(
+  defaultArgs: string[],
+  managedDefaultArgs: string[],
+  extraArgs: string[]
+): string[] {
+  const shouldSkipManagedSettings = hasSettingsArg(defaultArgs) || hasSettingsArg(extraArgs);
+  const nextManagedDefaultArgs = shouldSkipManagedSettings
+    ? removeSettingsArg(managedDefaultArgs)
+    : managedDefaultArgs;
+
+  return [...defaultArgs, ...nextManagedDefaultArgs];
 }
 
 export function buildAgentCommand({
@@ -147,7 +158,10 @@ export function buildAgentCommand({
   const [command, ...args] = parseCliPrefix(providerConfig?.cli, providerId);
   const initialPromptFlag = providerConfig?.initialPromptFlag;
 
-  args.push(...mergeDefaultArgs(providerConfig?.defaultArgs ?? [], managedDefaultArgs ?? []));
+  const extraArgs = parseArgField(providerConfig?.extraArgs);
+  args.push(
+    ...mergeDefaultArgs(providerConfig?.defaultArgs ?? [], managedDefaultArgs ?? [], extraArgs)
+  );
 
   const sessionIdFlag = providerConfig?.sessionIdFlag;
   const shouldPassSessionId =
@@ -182,7 +196,7 @@ export function buildAgentCommand({
     args.push(...parseArgField(initialPromptFlag), initialPrompt);
   }
 
-  args.push(...parseArgField(providerConfig?.extraArgs));
+  args.push(...extraArgs);
 
   return { command, args };
 }

--- a/src/main/core/conversations/impl/agent-command.ts
+++ b/src/main/core/conversations/impl/agent-command.ts
@@ -111,6 +111,7 @@ export function buildAgentCommand({
   sessionId,
   providerSessionId,
   isResuming,
+  managedDefaultArgs,
 }: {
   providerId: AgentProviderId;
   providerConfig: ProviderCustomConfig | undefined;
@@ -119,12 +120,14 @@ export function buildAgentCommand({
   sessionId: string;
   providerSessionId?: string;
   isResuming?: boolean;
+  managedDefaultArgs?: string[];
 }): AgentCommand {
   const providerDef = getProvider(providerId);
   const [command, ...args] = parseCliPrefix(providerConfig?.cli, providerId);
   const initialPromptFlag = providerConfig?.initialPromptFlag;
 
   args.push(...(providerConfig?.defaultArgs ?? []));
+  args.push(...(managedDefaultArgs ?? []));
 
   const sessionIdFlag = providerConfig?.sessionIdFlag;
   const shouldPassSessionId =
@@ -178,6 +181,7 @@ export function buildAgentSessionCommand(args: {
   sessionId: string;
   providerSessionId?: string;
   isResuming?: boolean;
+  managedDefaultArgs?: string[];
 }): AgentCommand {
   const command = buildAgentCommand(args);
   const prompt = args.initialPrompt?.trim();

--- a/src/main/core/conversations/impl/claude-theme-settings.test.ts
+++ b/src/main/core/conversations/impl/claude-theme-settings.test.ts
@@ -1,0 +1,8 @@
+import { describe, expect, it } from 'vitest';
+import { getClaudeThemeSettingsArgs } from './claude-theme-settings';
+
+describe('Claude theme settings', () => {
+  it('builds temporary --settings args that let Claude follow terminal background changes', () => {
+    expect(getClaudeThemeSettingsArgs()).toEqual(['--settings', '{"theme":"auto"}']);
+  });
+});

--- a/src/main/core/conversations/impl/claude-theme-settings.ts
+++ b/src/main/core/conversations/impl/claude-theme-settings.ts
@@ -1,0 +1,5 @@
+const CLAUDE_THEME_SETTINGS = JSON.stringify({ theme: 'auto' });
+
+export function getClaudeThemeSettingsArgs(): string[] {
+  return ['--settings', CLAUDE_THEME_SETTINGS];
+}

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -25,6 +25,7 @@ import { agentSessionExitedChannel } from '@shared/events/agentEvents';
 import { makePtyId } from '@shared/ptyId';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { buildAgentSessionCommand } from './agent-command';
+import { getClaudeThemeSettingsArgs } from './claude-theme-settings';
 import { syncGrokThemeWithAppTheme } from './grok-theme-config';
 import { scheduleInitialPromptInjection } from './keystroke-injection';
 import { resolveProviderEnv } from './provider-env';
@@ -118,9 +119,12 @@ export class LocalConversationProvider implements ConversationProvider {
       const providerConfig = await providerOverrideSettings.getItem(conversation.providerId);
       const providerDef = getProvider(conversation.providerId);
       const agentSession = resolveAgentSessionCommandArgs(conversation, isResuming);
+      const managedDefaultArgs =
+        conversation.providerId === 'claude' ? getClaudeThemeSettingsArgs() : undefined;
       const { command, args } = buildAgentSessionCommand({
         providerId: conversation.providerId,
         providerConfig,
+        managedDefaultArgs,
         autoApprove: conversation.autoApprove,
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.providerSessionId,

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -20,6 +20,7 @@ import type { Conversation } from '@shared/conversations';
 import { agentSessionExitedChannel } from '@shared/events/agentEvents';
 import { makePtySessionId } from '@shared/ptySessionId';
 import { buildAgentSessionCommand } from './agent-command';
+import { getClaudeThemeSettingsArgs } from './claude-theme-settings';
 import { scheduleInitialPromptInjection } from './keystroke-injection';
 import { resolveProviderEnv } from './provider-env';
 
@@ -114,9 +115,12 @@ export class SshConversationProvider implements ConversationProvider {
       const agentSession = resolveAgentSessionCommandArgs(conversation, isResuming, {
         requireProviderSessionId: false,
       });
+      const managedDefaultArgs =
+        conversation.providerId === 'claude' ? getClaudeThemeSettingsArgs() : undefined;
       const { command, args } = buildAgentSessionCommand({
         providerId: conversation.providerId,
         providerConfig,
+        managedDefaultArgs,
         autoApprove: conversation.autoApprove,
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.providerSessionId,


### PR DESCRIPTION
# summary
- launches claude code now with --settings '{theme: auto}' 
- user's claude settings.json doesnt get touched