### PR TITLE
fix(charm): preserve charm logo colors in dark mode

### DIFF
--- a/src/renderer/utils/agentConfig.ts
+++ b/src/renderer/utils/agentConfig.ts
@@ -109,6 +109,6 @@ export const agentConfig: Record<AgentProviderId, AgentInfo> = {
     isSvg: true,
     invertInDark: true,
   },
-  charm: { name: 'Charm', logo: charmLogo, alt: 'Charm Crush', invertInDark: true },
+  charm: { name: 'Charm', logo: charmLogo, alt: 'Charm Crush' },
   rovo: { name: 'Rovo Dev', logo: atlassianLogo, alt: 'Rovo Dev' },
 };

--- a/src/shared/agent-provider-registry.ts
+++ b/src/shared/agent-provider-registry.ts
@@ -336,7 +336,6 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     autoApproveFlag: '--yolo',
     icon: 'charm.png',
     alt: 'Charm CLI',
-    invertInDark: true,
     terminalOnly: true,
   },
   {


### PR DESCRIPTION
# summary
- fixes charm logo in dark mode (doesnt need inverting)

demo:
<img width="385" height="414" alt="image" src="https://github.com/user-attachments/assets/438de3b8-2e18-433d-b18e-7b7eabb015b9" />
