### PR TITLE
fix(resource-monitor): show real usage of processes

### DIFF
--- a/src/main/core/resource-monitor/resource-sampler.test.ts
+++ b/src/main/core/resource-monitor/resource-sampler.test.ts
@@ -99,7 +99,9 @@ describe('resource sampler', () => {
   it('samples a local PTY as the whole descendant process tree', async () => {
     mockProcessTree(['PID PPID', '100 1', '101 100', '102 101', '200 1', ''].join('\n'));
     pidusageMock.mockResolvedValue({
-      100: stat(1, 3 * MiB, 1),
+      // The PTY root is often just an idle shell wrapper. By itself this would
+      // have been filtered as stale, so this guards the "no PTYs visible" case.
+      100: stat(0, 1 * MiB, 1),
       101: stat(5, 50 * MiB, 100),
       102: stat(2, 20 * MiB, 101),
     });
@@ -112,8 +114,8 @@ describe('resource sampler', () => {
       sessionId: 'project-1:task-1:conversation-1',
       pid: 100,
       ppid: 1,
-      cpu: 8,
-      memory: 73 * MiB,
+      cpu: 7,
+      memory: 71 * MiB,
       providerId: 'amp',
       title: 'Amp',
     });
@@ -150,9 +152,7 @@ describe('resource sampler', () => {
         metadata: { providerId: 'amp', title: 'Amp 2' },
       },
     ];
-    mockProcessTree(
-      ['PID PPID', '100 1', '101 100', '102 100', '200 1', '201 200', ''].join('\n')
-    );
+    mockProcessTree(['PID PPID', '100 1', '101 100', '102 100', '200 1', '201 200', ''].join('\n'));
     pidusageMock.mockResolvedValue({
       100: stat(1, 3 * MiB, 1),
       101: stat(2, 10 * MiB, 100),

--- a/src/main/core/resource-monitor/resource-sampler.test.ts
+++ b/src/main/core/resource-monitor/resource-sampler.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const execFileMock = vi.hoisted(() => vi.fn());
+const getAppMetricsMock = vi.hoisted(() => vi.fn());
+const logWarnMock = vi.hoisted(() => vi.fn());
+const pidusageMock = vi.hoisted(() => Object.assign(vi.fn(), { clear: vi.fn() }));
+const registryState = vi.hoisted(() => ({
+  active: [] as Array<{
+    sessionId: string;
+    pid: number | undefined;
+    metadata?: { providerId?: 'amp'; title?: string };
+  }>,
+}));
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getAppMetrics: getAppMetricsMock,
+  },
+}));
+
+vi.mock('pidusage', () => ({
+  default: pidusageMock,
+}));
+
+vi.mock('@main/core/pty/pty-session-registry', () => ({
+  ptySessionRegistry: {
+    listActiveSessions: () => registryState.active,
+  },
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: {
+    get: vi.fn().mockResolvedValue({ enabled: true }),
+  },
+}));
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    emit: vi.fn(),
+  },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    warn: logWarnMock,
+  },
+}));
+
+const { sampleOnce } = await import('./resource-sampler');
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+const MiB = 1024 * 1024;
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    ...originalPlatform,
+    value: platform,
+  });
+}
+
+function mockProcessTree(stdout: string): void {
+  execFileMock.mockImplementation((_file, _args, _options, callback) => {
+    callback(null, stdout);
+  });
+}
+
+function stat(
+  cpu: number,
+  memory: number,
+  ppid: number
+): { cpu: number; memory: number; ppid: number } {
+  return { cpu, memory, ppid };
+}
+
+describe('resource sampler', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPlatform('linux');
+    registryState.active = [
+      {
+        sessionId: 'project-1:task-1:conversation-1',
+        pid: 100,
+        metadata: { providerId: 'amp', title: 'Amp' },
+      },
+    ];
+    getAppMetricsMock.mockReturnValue([]);
+  });
+
+  afterEach(() => {
+    if (originalPlatform) {
+      Object.defineProperty(process, 'platform', originalPlatform);
+    }
+  });
+
+  it('samples a local PTY as the whole descendant process tree', async () => {
+    mockProcessTree(['PID PPID', '100 1', '101 100', '102 101', '200 1', ''].join('\n'));
+    pidusageMock.mockResolvedValue({
+      100: stat(1, 3 * MiB, 1),
+      101: stat(5, 50 * MiB, 100),
+      102: stat(2, 20 * MiB, 101),
+    });
+
+    const snapshot = await sampleOnce();
+
+    expect(pidusageMock).toHaveBeenCalledWith([100, 101, 102]);
+    expect(snapshot.entries).toHaveLength(1);
+    expect(snapshot.entries[0]).toMatchObject({
+      sessionId: 'project-1:task-1:conversation-1',
+      pid: 100,
+      ppid: 1,
+      cpu: 8,
+      memory: 73 * MiB,
+      providerId: 'amp',
+      title: 'Amp',
+    });
+  });
+
+  it('falls back to sampling the root PID when process tree lookup fails', async () => {
+    execFileMock.mockImplementation((_file, _args, _options, callback) => {
+      callback(new Error('ps failed'));
+    });
+    pidusageMock.mockResolvedValue({
+      100: stat(4, 12 * MiB, 1),
+    });
+
+    const snapshot = await sampleOnce();
+
+    expect(logWarnMock).toHaveBeenCalledWith(
+      'resource-sampler: process tree lookup failed',
+      expect.any(Error)
+    );
+    expect(pidusageMock).toHaveBeenCalledWith([100]);
+    expect(snapshot.entries[0]).toMatchObject({
+      pid: 100,
+      ppid: 1,
+      cpu: 4,
+      memory: 12 * MiB,
+    });
+  });
+});

--- a/src/main/core/resource-monitor/resource-sampler.test.ts
+++ b/src/main/core/resource-monitor/resource-sampler.test.ts
@@ -119,6 +119,70 @@ describe('resource sampler', () => {
     });
   });
 
+  it('samples only the root PID on Windows without calling ps', async () => {
+    setPlatform('win32');
+    pidusageMock.mockResolvedValue({
+      100: stat(4, 12 * MiB, 1),
+    });
+
+    const snapshot = await sampleOnce();
+
+    expect(execFileMock).not.toHaveBeenCalled();
+    expect(pidusageMock).toHaveBeenCalledWith([100]);
+    expect(snapshot.entries[0]).toMatchObject({
+      pid: 100,
+      ppid: 1,
+      cpu: 4,
+      memory: 12 * MiB,
+    });
+  });
+
+  it('attributes separate process trees to separate active sessions', async () => {
+    registryState.active = [
+      {
+        sessionId: 'project-1:task-1:conversation-1',
+        pid: 100,
+        metadata: { providerId: 'amp', title: 'Amp 1' },
+      },
+      {
+        sessionId: 'project-2:task-2:conversation-2',
+        pid: 200,
+        metadata: { providerId: 'amp', title: 'Amp 2' },
+      },
+    ];
+    mockProcessTree(
+      ['PID PPID', '100 1', '101 100', '102 100', '200 1', '201 200', ''].join('\n')
+    );
+    pidusageMock.mockResolvedValue({
+      100: stat(1, 3 * MiB, 1),
+      101: stat(2, 10 * MiB, 100),
+      102: stat(3, 20 * MiB, 100),
+      200: stat(4, 4 * MiB, 1),
+      201: stat(5, 40 * MiB, 200),
+    });
+
+    const snapshot = await sampleOnce();
+
+    expect(pidusageMock).toHaveBeenCalledWith([100, 102, 101, 200, 201]);
+    expect(snapshot.entries).toHaveLength(2);
+    expect(snapshot.entries[0]).toMatchObject({
+      sessionId: 'project-1:task-1:conversation-1',
+      pid: 100,
+      ppid: 1,
+      cpu: 6,
+      memory: 33 * MiB,
+      title: 'Amp 1',
+    });
+    expect(snapshot.entries[1]).toMatchObject({
+      sessionId: 'project-2:task-2:conversation-2',
+      pid: 200,
+      ppid: 1,
+      cpu: 9,
+      memory: 44 * MiB,
+      title: 'Amp 2',
+    });
+  });
+
   it('falls back to sampling the root PID when process tree lookup fails', async () => {
     execFileMock.mockImplementation((_file, _args, _options, callback) => {
       callback(new Error('ps failed'));

--- a/src/main/core/resource-monitor/resource-sampler.ts
+++ b/src/main/core/resource-monitor/resource-sampler.ts
@@ -1,3 +1,4 @@
+import { execFile } from 'node:child_process';
 import os from 'node:os';
 import { app } from 'electron';
 import pidusage from 'pidusage';
@@ -19,36 +20,25 @@ const CPU_COUNT = os.cpus().length;
 const TOTAL_MEMORY_BYTES = os.totalmem();
 const STALE_LOCAL_PTY_MEMORY_BYTES = 2 * 1024 * 1024;
 
+type ProcessUsage = { cpu: number; memory: number; ppid?: number };
+type ProcessUsageMap = Record<string, ProcessUsage>;
+
 export async function sampleOnce(): Promise<ResourceSnapshot> {
   const active = ptySessionRegistry.listActiveSessions();
   const localPids = active
     .map((a) => a.pid)
     .filter((p): p is number => typeof p === 'number' && p > 0);
 
-  let usage: Record<string, { cpu: number; memory: number; ppid?: number }> = {};
-  if (localPids.length > 0) {
-    try {
-      usage = await pidusage(localPids);
-    } catch {
-      // A dead PID rejects the whole batch — fall back to per-pid sampling in parallel.
-      const results = await Promise.allSettled(localPids.map((pid) => pidusage(pid)));
-      results.forEach((r, i) => {
-        if (r.status === 'fulfilled') {
-          usage[String(localPids[i])] = {
-            cpu: r.value.cpu,
-            memory: r.value.memory,
-            ppid: r.value.ppid,
-          };
-        }
-      });
-    }
-  }
+  const processTrees = await listProcessTrees(localPids);
+  const sampledPids = [...new Set([...processTrees.values()].flat())];
+  const usage = await samplePidUsage(sampledPids);
 
   const entries: ResourcePtyEntry[] = [];
   for (const a of active) {
     const parsed = parsePtySessionId(a.sessionId);
     if (!parsed) continue;
-    const u = typeof a.pid === 'number' ? usage[String(a.pid)] : undefined;
+    const tree = typeof a.pid === 'number' ? processTrees.get(a.pid) : undefined;
+    const u = tree ? aggregateProcessUsage(tree, usage) : undefined;
     if (isStaleLocalPty(a.pid, u)) continue;
     entries.push({
       sessionId: a.sessionId,
@@ -56,7 +46,7 @@ export async function sampleOnce(): Promise<ResourceSnapshot> {
       scopeId: parsed.scopeId,
       leafId: parsed.leafId,
       pid: a.pid,
-      ppid: u?.ppid,
+      ppid: typeof a.pid === 'number' ? usage[String(a.pid)]?.ppid : undefined,
       cpu: u?.cpu ?? 0,
       memory: u?.memory ?? 0,
       providerId: a.metadata?.providerId,
@@ -75,10 +65,99 @@ export async function sampleOnce(): Promise<ResourceSnapshot> {
   };
 }
 
-function isStaleLocalPty(
-  pid: number | undefined,
-  usage: { cpu: number; memory: number; ppid?: number } | undefined
-): boolean {
+async function samplePidUsage(localPids: number[]): Promise<ProcessUsageMap> {
+  if (localPids.length === 0) return {};
+  try {
+    return await pidusage(localPids);
+  } catch {
+    // A dead PID rejects the whole batch — fall back to per-pid sampling in parallel.
+    const usage: ProcessUsageMap = {};
+    const results = await Promise.allSettled(localPids.map((pid) => pidusage(pid)));
+    results.forEach((r, i) => {
+      if (r.status === 'fulfilled') {
+        usage[String(localPids[i])] = {
+          cpu: r.value.cpu,
+          memory: r.value.memory,
+          ppid: r.value.ppid,
+        };
+      }
+    });
+    return usage;
+  }
+}
+
+/**
+ * node-pty gives us the PTY's process group leader, which is usually a tiny
+ * shell wrapper (`sh -c ...`). Agent CLIs and lifecycle scripts run as children
+ * of that wrapper, so sampling only the root PID makes active agents look like
+ * 3-6 MB shells. On POSIX, include descendants so the monitor reflects the
+ * resource cost of the whole PTY session. Windows falls back to root PID
+ * sampling, matching the previous behavior.
+ */
+async function listProcessTrees(localPids: number[]): Promise<Map<number, number[]>> {
+  const fallback = new Map(localPids.map((pid) => [pid, [pid]]));
+  if (localPids.length === 0 || process.platform === 'win32') return fallback;
+
+  try {
+    const stdout = await execFileText('ps', ['-axo', 'pid=,ppid=']);
+    const childrenByParent = new Map<number, number[]>();
+    for (const line of stdout.split('\n')) {
+      const [pidText, ppidText] = line.trim().split(/\s+/);
+      const pid = Number(pidText);
+      const ppid = Number(ppidText);
+      if (!Number.isInteger(pid) || !Number.isInteger(ppid) || pid <= 0 || ppid < 0) continue;
+      const siblings = childrenByParent.get(ppid) ?? [];
+      siblings.push(pid);
+      childrenByParent.set(ppid, siblings);
+    }
+
+    const trees = new Map<number, number[]>();
+    for (const rootPid of localPids) {
+      const visited = new Set<number>();
+      const stack = [rootPid];
+      while (stack.length > 0) {
+        const pid = stack.pop();
+        if (pid === undefined || visited.has(pid)) continue;
+        visited.add(pid);
+        const children = childrenByParent.get(pid);
+        if (children) stack.push(...children);
+      }
+      trees.set(rootPid, [...visited]);
+    }
+    return trees;
+  } catch (err) {
+    log.warn('resource-sampler: process tree lookup failed', err);
+    return fallback;
+  }
+}
+
+function execFileText(file: string, args: string[]): Promise<string> {
+  return new Promise((resolve, reject) => {
+    execFile(file, args, { maxBuffer: 10 * 1024 * 1024 }, (err, stdout) => {
+      if (err) {
+        reject(err);
+        return;
+      }
+      resolve(String(stdout));
+    });
+  });
+}
+
+function aggregateProcessUsage(pids: number[], usage: ProcessUsageMap): ProcessUsage | undefined {
+  let cpu = 0;
+  let memory = 0;
+  let found = false;
+  for (const pid of pids) {
+    const item = usage[String(pid)];
+    if (!item) continue;
+    found = true;
+    cpu += item.cpu;
+    memory += item.memory;
+  }
+  return found ? { cpu, memory } : undefined;
+}
+
+function isStaleLocalPty(pid: number | undefined, usage: ProcessUsage | undefined): boolean {
   if (pid === undefined || !usage) return false;
   return usage.cpu === 0 && usage.memory < STALE_LOCAL_PTY_MEMORY_BYTES;
 }

--- a/src/main/core/resource-monitor/resource-sampler.ts
+++ b/src/main/core/resource-monitor/resource-sampler.ts
@@ -22,6 +22,7 @@ const STALE_LOCAL_PTY_MEMORY_BYTES = 2 * 1024 * 1024;
 
 type ProcessUsage = { cpu: number; memory: number; ppid?: number };
 type ProcessUsageMap = Record<string, ProcessUsage>;
+type ProcessTreeSnapshot = { trees: Map<number, number[]>; sampledPids: number[] };
 
 export async function sampleOnce(): Promise<ResourceSnapshot> {
   const active = ptySessionRegistry.listActiveSessions();
@@ -29,8 +30,7 @@ export async function sampleOnce(): Promise<ResourceSnapshot> {
     .map((a) => a.pid)
     .filter((p): p is number => typeof p === 'number' && p > 0);
 
-  const processTrees = await listProcessTrees(localPids);
-  const sampledPids = [...new Set([...processTrees.values()].flat())];
+  const { trees: processTrees, sampledPids } = await listProcessTrees(localPids);
   const usage = await samplePidUsage(sampledPids);
 
   const entries: ResourcePtyEntry[] = [];
@@ -94,18 +94,21 @@ async function samplePidUsage(localPids: number[]): Promise<ProcessUsageMap> {
  * resource cost of the whole PTY session. Windows falls back to root PID
  * sampling, matching the previous behavior.
  */
-async function listProcessTrees(localPids: number[]): Promise<Map<number, number[]>> {
+async function listProcessTrees(localPids: number[]): Promise<ProcessTreeSnapshot> {
   const fallback = new Map(localPids.map((pid) => [pid, [pid]]));
-  if (localPids.length === 0 || process.platform === 'win32') return fallback;
+  const fallbackSnapshot = { trees: fallback, sampledPids: localPids };
+  if (localPids.length === 0 || process.platform === 'win32') return fallbackSnapshot;
 
   try {
     const stdout = await execFileText('ps', ['-axo', 'pid=,ppid=']);
+    const livePids = new Set<number>();
     const childrenByParent = new Map<number, number[]>();
     for (const line of stdout.split('\n')) {
       const [pidText, ppidText] = line.trim().split(/\s+/);
       const pid = Number(pidText);
       const ppid = Number(ppidText);
       if (!Number.isInteger(pid) || !Number.isInteger(ppid) || pid <= 0 || ppid < 0) continue;
+      livePids.add(pid);
       const siblings = childrenByParent.get(ppid) ?? [];
       siblings.push(pid);
       childrenByParent.set(ppid, siblings);
@@ -124,10 +127,11 @@ async function listProcessTrees(localPids: number[]): Promise<Map<number, number
       }
       trees.set(rootPid, [...visited]);
     }
-    return trees;
+    const sampledPids = [...new Set([...trees.values()].flat())].filter((pid) => livePids.has(pid));
+    return { trees, sampledPids };
   } catch (err) {
     log.warn('resource-sampler: process tree lookup failed', err);
-    return fallback;
+    return fallbackSnapshot;
   }
 }
 


### PR DESCRIPTION
# summary
- count full pty process tree, not just shell wrapper PIDs
- fix underreported agent/script cpu and memory