### PR TITLE
fix(sidebar): improve voice control task switching

### DIFF
--- a/src/renderer/features/sidebar/project-item.tsx
+++ b/src/renderer/features/sidebar/project-item.tsx
@@ -39,7 +39,12 @@ import {
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
-import { SidebarItemMiniButton, SidebarMenuButton, SidebarMenuRow } from './sidebar-primitives';
+import {
+  SidebarItemMiniButton,
+  SidebarMenuAction,
+  SidebarMenuButton,
+  SidebarMenuRow,
+} from './sidebar-primitives';
 
 const UNREGISTERED_PHASE_LABEL: Record<UnregisteredProject['phase'], string> = {
   'creating-repo': 'Creating repository…',
@@ -94,6 +99,8 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
     : null;
   const canReconnect = sshConnectionState !== 'connected';
   const ProjectIcon = isSshProject ? FolderInput : FolderClosed;
+  const projectLabel = project.name ?? 'project';
+  const deleteProjectLabel = project.name ?? 'this project';
 
   const renderSpinnerWithTooltip = () => {
     if (!isUnregisteredProject(project)) return null;
@@ -117,8 +124,6 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
           className={cn('group/row h-8 justify-between flex px-1')}
           data-active={isProjectActive || undefined}
           isActive={isProjectActive}
-          onMouseDown={(e) => e.preventDefault()}
-          onClick={() => navigate('project', { projectId })}
         >
           <div className="flex min-w-0 flex-1 items-center gap-1">
             {project.state === 'unregistered' ? (
@@ -126,6 +131,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
             ) : (
               <SidebarItemMiniButton
                 type="button"
+                aria-label={`${isExpanded ? 'Collapse' : 'Expand'} ${projectLabel}`}
                 className="relative"
                 onClick={(e) => {
                   e.stopPropagation();
@@ -141,9 +147,11 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
                 />
               </SidebarItemMiniButton>
             )}
-            <span
+            <SidebarMenuAction
+              aria-label={`Open project ${projectLabel}`}
+              onClick={() => navigate('project', { projectId })}
               className={cn(
-                'flex-1 min-w-0 self-stretch flex items-center truncate text-left transition-colors select-none',
+                'truncate transition-colors select-none',
                 projectViewKind(getProjectStore(projectId)) === 'bootstrapping' &&
                   'text-foreground-tertiary-passive'
               )}
@@ -166,7 +174,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
                   )}
                 </span>
               )}
-            </span>
+            </SidebarMenuAction>
           </div>
           <Tooltip>
             <TooltipTrigger
@@ -174,6 +182,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
               render={
                 <SidebarItemMiniButton
                   type="button"
+                  aria-label={`New task for ${projectLabel}`}
                   className={
                     'opacity-0 transition-opacity duration-150 group-hover/row:opacity-100'
                   }
@@ -224,10 +233,9 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
         <ContextMenuItem
           variant="destructive"
           onClick={() => {
-            const projectLabel = project.name ?? 'this project';
             showConfirmDeleteProject({
               title: 'Delete project',
-              description: `"${projectLabel}" will be deleted. The project folder and worktrees will stay on the filesystem.`,
+              description: `"${deleteProjectLabel}" will be deleted. The project folder and worktrees will stay on the filesystem.`,
               confirmLabel: 'Delete',
               onSuccess: () => {
                 void getProjectManagerStore().deleteProject(projectId);

--- a/src/renderer/features/sidebar/project-item.tsx
+++ b/src/renderer/features/sidebar/project-item.tsx
@@ -101,6 +101,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
   const ProjectIcon = isSshProject ? FolderInput : FolderClosed;
   const projectLabel = project.name ?? 'project';
   const deleteProjectLabel = project.name ?? 'this project';
+  const openProject = () => navigate('project', { projectId });
 
   const renderSpinnerWithTooltip = () => {
     if (!isUnregisteredProject(project)) return null;
@@ -124,6 +125,8 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
           className={cn('group/row h-8 justify-between flex px-1')}
           data-active={isProjectActive || undefined}
           isActive={isProjectActive}
+          onMouseDown={(e) => e.preventDefault()}
+          onClick={openProject}
         >
           <div className="flex min-w-0 flex-1 items-center gap-1">
             {project.state === 'unregistered' ? (
@@ -149,7 +152,6 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
             )}
             <SidebarMenuAction
               aria-label={`Open project ${projectLabel}`}
-              onClick={() => navigate('project', { projectId })}
               className={cn(
                 'truncate transition-colors select-none',
                 projectViewKind(getProjectStore(projectId)) === 'bootstrapping' &&

--- a/src/renderer/features/sidebar/sidebar-primitives.tsx
+++ b/src/renderer/features/sidebar/sidebar-primitives.tsx
@@ -98,6 +98,8 @@ export const SidebarMenuButton = React.forwardRef<HTMLButtonElement, SidebarMenu
   )
 );
 
+// Sidebar row labels use this as the named voice-control target. Primary
+// activation is handled by the parent row's click handler via bubbling.
 export const SidebarMenuAction = React.forwardRef<
   HTMLButtonElement,
   React.ButtonHTMLAttributes<HTMLButtonElement>

--- a/src/renderer/features/sidebar/sidebar-primitives.tsx
+++ b/src/renderer/features/sidebar/sidebar-primitives.tsx
@@ -98,6 +98,23 @@ export const SidebarMenuButton = React.forwardRef<HTMLButtonElement, SidebarMenu
   )
 );
 
+export const SidebarMenuAction = React.forwardRef<
+  HTMLButtonElement,
+  React.ButtonHTMLAttributes<HTMLButtonElement>
+>(({ className, ...props }, ref) => (
+  <button
+    ref={ref}
+    type="button"
+    className={cn(
+      'flex min-w-0 flex-1 items-center self-stretch rounded-md text-left text-inherit outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-2',
+      className
+    )}
+    onMouseDown={(e) => e.preventDefault()}
+    {...props}
+  />
+));
+SidebarMenuAction.displayName = 'SidebarMenuAction';
+
 interface SidebarMenuRowProps extends React.HTMLAttributes<HTMLDivElement> {
   isActive?: boolean;
 }

--- a/src/renderer/features/sidebar/sidebar-virtual-list.tsx
+++ b/src/renderer/features/sidebar/sidebar-virtual-list.tsx
@@ -359,7 +359,7 @@ interface SortableRowProps {
 }
 
 function SortableRow({ dndId, style, children }: SortableRowProps) {
-  const { setNodeRef, transform, transition, isDragging, listeners, attributes } = useSortable({
+  const { setNodeRef, transform, transition, isDragging, listeners } = useSortable({
     id: dndId,
   });
 
@@ -372,7 +372,7 @@ function SortableRow({ dndId, style, children }: SortableRowProps) {
   };
 
   return (
-    <div ref={setNodeRef} style={combinedStyle} {...attributes} {...listeners}>
+    <div ref={setNodeRef} style={combinedStyle} {...listeners}>
       {children}
     </div>
   );

--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -103,7 +103,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
         isActive={isActive}
       >
         <SidebarMenuAction
-          aria-label={`Open task ${taskName}`}
+          aria-label={`Open task ${taskName || 'task'}`}
           onClick={() => {
             handleProvision();
             navigate('task', { projectId, taskId });

--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -18,7 +18,7 @@ import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { cn } from '@renderer/utils/utils';
 import { selectCurrentPr } from '@shared/pull-requests';
 import { PrBadge } from '../../lib/components/pr-badge';
-import { SidebarMenuRow } from './sidebar-primitives';
+import { SidebarMenuAction, SidebarMenuRow } from './sidebar-primitives';
 
 interface SidebarTaskItemProps {
   taskId: string;
@@ -101,13 +101,15 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
           rowVariant === 'pinned' ? 'pl-2' : 'pl-8'
         )}
         isActive={isActive}
-        onMouseDown={(e) => e.preventDefault()}
-        onClick={() => {
-          handleProvision();
-          navigate('task', { projectId, taskId });
-        }}
       >
-        <div className="flex min-w-0 flex-1 items-center gap-1 self-stretch overflow-hidden">
+        <SidebarMenuAction
+          aria-label={`Open task ${taskName}`}
+          onClick={() => {
+            handleProvision();
+            navigate('task', { projectId, taskId });
+          }}
+          className="gap-1 overflow-hidden"
+        >
           <span
             className={cn(
               'min-w-0 truncate text-left transition-colors',
@@ -118,7 +120,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
           </span>
           <TaskGitDiffStats task={task} className="flex h-full shrink-0 items-center pr-1 pl-1" />
           <RenderPrBadge task={task} />
-        </div>
+        </SidebarMenuAction>
         <TaskSidebarAgentStatus task={task} />
       </SidebarMenuRow>
     </TaskContextMenu>

--- a/src/renderer/features/sidebar/task-item.tsx
+++ b/src/renderer/features/sidebar/task-item.tsx
@@ -56,6 +56,11 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
     void taskManager?.provisionTask(taskId);
   };
 
+  const openTask = () => {
+    handleProvision();
+    navigate('task', { projectId, taskId });
+  };
+
   const handleArchive = () => {
     if (isActive) navigate('project', { projectId });
     void taskManager?.archiveTask(taskId);
@@ -101,13 +106,11 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
           rowVariant === 'pinned' ? 'pl-2' : 'pl-8'
         )}
         isActive={isActive}
+        onMouseDown={(e) => e.preventDefault()}
+        onClick={openTask}
       >
         <SidebarMenuAction
           aria-label={`Open task ${taskName || 'task'}`}
-          onClick={() => {
-            handleProvision();
-            navigate('task', { projectId, taskId });
-          }}
           className="gap-1 overflow-hidden"
         >
           <span
@@ -119,8 +122,8 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
             {taskName}
           </span>
           <TaskGitDiffStats task={task} className="flex h-full shrink-0 items-center pr-1 pl-1" />
-          <RenderPrBadge task={task} />
         </SidebarMenuAction>
+        <RenderPrBadge task={task} />
         <TaskSidebarAgentStatus task={task} />
       </SidebarMenuRow>
     </TaskContextMenu>
@@ -130,5 +133,9 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
 const RenderPrBadge = observer(function RenderPrBadge({ task }: { task: TaskStore }) {
   if (!('prs' in task.data)) return null;
   const pr = selectCurrentPr(task.data.prs);
-  return pr ? <PrBadge variant="compact" pr={pr} hoverDelay={100} /> : null;
+  return pr ? (
+    <span onMouseDown={(e) => e.stopPropagation()} onClick={(e) => e.stopPropagation()}>
+      <PrBadge variant="compact" pr={pr} hoverDelay={100} />
+    </span>
+  ) : null;
 });


### PR DESCRIPTION
- exposes sidebar project and task navigation as named buttons for voice control
- removes sortable wrapper accessibility metadata so number overlays target row actions
- preserves existing pointer drag behavior and context menu access