### PR TITLE
fix(jira): migrate issue search to enhanced jql

### DIFF
--- a/src/main/core/jira/jira-http-client.ts
+++ b/src/main/core/jira/jira-http-client.ts
@@ -1,0 +1,76 @@
+import { request } from 'node:https';
+import type { URL } from 'node:url';
+
+const REQUEST_TIMEOUT_MS = 30_000;
+
+function encodeBasic(email: string, token: string): string {
+  return Buffer.from(`${email}:${token}`).toString('base64');
+}
+
+export function doJiraGet(url: URL, email: string, token: string): Promise<string> {
+  return doJiraRequest(url, email, token, 'GET');
+}
+
+export function doJiraPost(
+  url: URL,
+  email: string,
+  token: string,
+  payload: string
+): Promise<string> {
+  return doJiraRequest(url, email, token, 'POST', payload, {
+    'Content-Type': 'application/json',
+  });
+}
+
+function doJiraRequest(
+  url: URL,
+  email: string,
+  token: string,
+  method: 'GET' | 'POST',
+  payload?: string,
+  extraHeaders?: Record<string, string>
+): Promise<string> {
+  const auth = encodeBasic(email, token);
+
+  return new Promise<string>((resolve, reject) => {
+    const req = request(
+      {
+        hostname: url.hostname,
+        ...(url.port ? { port: Number(url.port) } : {}),
+        path: url.pathname + url.search,
+        protocol: url.protocol,
+        method,
+        headers: {
+          Authorization: `Basic ${auth}`,
+          Accept: 'application/json',
+          ...(extraHeaders || {}),
+        },
+      },
+      (res) => {
+        let data = '';
+        res.on('error', reject);
+        res.on('data', (chunk) => {
+          data += chunk;
+        });
+        res.on('end', () => {
+          if (res.statusCode && res.statusCode >= 400) {
+            const snippet = data?.slice(0, 200) || '';
+            reject(new Error(`Jira API error ${res.statusCode}${snippet ? `: ${snippet}` : ''}`));
+            return;
+          }
+
+          resolve(data);
+        });
+      }
+    );
+
+    req.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      req.destroy(new Error(`Jira request timed out after ${REQUEST_TIMEOUT_MS / 1000}s`));
+    });
+    req.on('error', reject);
+    if (payload && method === 'POST') {
+      req.write(payload);
+    }
+    req.end();
+  });
+}

--- a/src/main/core/jira/jira-issue-provider.test.ts
+++ b/src/main/core/jira/jira-issue-provider.test.ts
@@ -64,6 +64,7 @@ describe('jiraIssueProvider', () => {
     expect(buildSearchJql('deprecated "search" endpoint')).toBe(
       'text ~ "deprecated \\"search\\" endpoint"'
     );
+    expect(buildSearchJql('path \\')).toBe('text ~ "path \\\\"');
   });
 
   it('lists Jira issues through enhanced search with nextPageToken pagination', async () => {
@@ -120,6 +121,24 @@ describe('jiraIssueProvider', () => {
     expect(mockDoJiraPost).toHaveBeenCalledTimes(2);
     expect(postPayload(0).jql).toBe(buildListJql('mine'));
     expect(postPayload(1).jql).toBe(buildListJql('mine-fallback'));
+  });
+
+  it('continues to broad list fallback when assignee-only JQL fails', async () => {
+    mockDoJiraPost
+      .mockRejectedValueOnce(new Error('Jira API error 403: reporter is not queryable'))
+      .mockRejectedValueOnce(new Error('Jira API error 500: temporary outage'))
+      .mockResolvedValueOnce(JSON.stringify({ issues: [jiraIssue('ENG-4')], isLast: true }));
+
+    const result = await jiraIssueProvider.listIssues({ limit: 10 });
+
+    expect(result).toEqual({
+      success: true,
+      issues: [expect.objectContaining({ provider: 'jira', identifier: 'ENG-4' })],
+    });
+    expect(mockDoJiraPost).toHaveBeenCalledTimes(3);
+    expect(postPayload(0).jql).toBe(buildListJql('mine'));
+    expect(postPayload(1).jql).toBe(buildListJql('mine-fallback'));
+    expect(postPayload(2).jql).toBe(buildListJql('all'));
   });
 
   it('does not hide auth failures behind broad list fallbacks', async () => {

--- a/src/main/core/jira/jira-issue-provider.test.ts
+++ b/src/main/core/jira/jira-issue-provider.test.ts
@@ -1,0 +1,155 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { jiraConnectionService } from './jira-connection-service';
+import { doJiraGet, doJiraPost } from './jira-http-client';
+import { buildListJql, buildSearchJql, jiraIssueProvider } from './jira-issue-provider';
+
+vi.mock('./jira-connection-service', () => ({
+  jiraConnectionService: {
+    requireAuth: vi.fn(),
+    checkConnection: vi.fn(),
+  },
+}));
+
+vi.mock('./jira-http-client', () => ({
+  doJiraGet: vi.fn(),
+  doJiraPost: vi.fn(),
+}));
+
+const mockRequireAuth = vi.mocked(jiraConnectionService.requireAuth);
+const mockDoJiraGet = vi.mocked(doJiraGet);
+const mockDoJiraPost = vi.mocked(doJiraPost);
+
+function jiraIssue(key: string, summary = `${key} summary`) {
+  return {
+    id: key,
+    key,
+    fields: {
+      summary,
+      description: null,
+      updated: '2026-05-30T12:00:00.000+0000',
+      project: { key: key.split('-')[0], name: 'Project' },
+      status: { name: 'To Do' },
+      assignee: { displayName: 'Jona' },
+    },
+  };
+}
+
+function postPayload(callIndex: number) {
+  return JSON.parse(String(mockDoJiraPost.mock.calls[callIndex]?.[3] || '{}')) as Record<
+    string,
+    unknown
+  >;
+}
+
+describe('jiraIssueProvider', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRequireAuth.mockResolvedValue({
+      siteUrl: 'https://example.atlassian.net',
+      email: 'user@example.com',
+      token: 'token',
+    });
+  });
+
+  it('builds list JQL for mine, fallback, and bounded all modes', () => {
+    expect(buildListJql('mine')).toBe(
+      '(assignee = currentUser() OR reporter = currentUser()) ORDER BY updated DESC'
+    );
+    expect(buildListJql('mine-fallback')).toBe('assignee = currentUser() ORDER BY updated DESC');
+    expect(buildListJql('all')).toBe('updated >= -90d ORDER BY updated DESC');
+  });
+
+  it('builds search JQL for key-shaped and plain text terms', () => {
+    expect(buildSearchJql('ENG-976')).toBe('(key = "ENG-976" OR text ~ "ENG-976")');
+    expect(buildSearchJql('deprecated "search" endpoint')).toBe(
+      'text ~ "deprecated \\"search\\" endpoint"'
+    );
+  });
+
+  it('lists Jira issues through enhanced search with nextPageToken pagination', async () => {
+    mockDoJiraPost
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          issues: [jiraIssue('ENG-1')],
+          nextPageToken: 'page-2',
+          isLast: false,
+        })
+      )
+      .mockResolvedValueOnce(
+        JSON.stringify({
+          issues: [jiraIssue('ENG-2')],
+          isLast: true,
+        })
+      );
+
+    const result = await jiraIssueProvider.listIssues({ limit: 2 });
+
+    expect(result).toEqual({
+      success: true,
+      issues: [
+        expect.objectContaining({ provider: 'jira', identifier: 'ENG-1' }),
+        expect.objectContaining({ provider: 'jira', identifier: 'ENG-2' }),
+      ],
+    });
+    expect(mockDoJiraPost).toHaveBeenCalledTimes(2);
+    expect(mockDoJiraPost.mock.calls[0]?.[0].pathname).toBe('/rest/api/3/search/jql');
+    expect(postPayload(0)).toEqual({
+      jql: buildListJql('mine'),
+      maxResults: 2,
+      fields: ['summary', 'description', 'updated', 'project', 'status', 'assignee'],
+    });
+    expect(postPayload(1)).toEqual({
+      jql: buildListJql('mine'),
+      maxResults: 1,
+      fields: ['summary', 'description', 'updated', 'project', 'status', 'assignee'],
+      nextPageToken: 'page-2',
+    });
+  });
+
+  it('retries list issues with assignee-only JQL when reporter query is not permitted', async () => {
+    mockDoJiraPost
+      .mockRejectedValueOnce(new Error('Jira API error 403: reporter is not queryable'))
+      .mockResolvedValueOnce(JSON.stringify({ issues: [jiraIssue('ENG-3')], isLast: true }));
+
+    const result = await jiraIssueProvider.listIssues({ limit: 10 });
+
+    expect(result).toEqual({
+      success: true,
+      issues: [expect.objectContaining({ provider: 'jira', identifier: 'ENG-3' })],
+    });
+    expect(mockDoJiraPost).toHaveBeenCalledTimes(2);
+    expect(postPayload(0).jql).toBe(buildListJql('mine'));
+    expect(postPayload(1).jql).toBe(buildListJql('mine-fallback'));
+  });
+
+  it('does not hide auth failures behind broad list fallbacks', async () => {
+    mockDoJiraPost.mockRejectedValueOnce(new Error('Jira API error 401: unauthorized'));
+
+    const result = await jiraIssueProvider.listIssues({ limit: 10 });
+
+    expect(result).toEqual({ success: false, error: 'Jira API error 401: unauthorized' });
+    expect(mockDoJiraPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('falls back from exact issue lookup to enhanced JQL search for key-shaped terms', async () => {
+    mockDoJiraGet.mockResolvedValueOnce(
+      JSON.stringify({ errorMessages: ['Issue does not exist'] })
+    );
+    mockDoJiraPost.mockResolvedValueOnce(
+      JSON.stringify({ issues: [jiraIssue('ENG-976')], isLast: true })
+    );
+
+    const result = await jiraIssueProvider.searchIssues({
+      searchTerm: 'ENG-976',
+      limit: 5,
+    });
+
+    expect(result).toEqual({
+      success: true,
+      issues: [expect.objectContaining({ provider: 'jira', identifier: 'ENG-976' })],
+    });
+    expect(mockDoJiraGet.mock.calls[0]?.[0].pathname).toBe('/rest/api/3/issue/ENG-976');
+    expect(mockDoJiraPost.mock.calls[0]?.[0].pathname).toBe('/rest/api/3/search/jql');
+    expect(postPayload(0).jql).toBe('(key = "ENG-976" OR text ~ "ENG-976") ORDER BY updated DESC');
+  });
+});

--- a/src/main/core/jira/jira-issue-provider.ts
+++ b/src/main/core/jira/jira-issue-provider.ts
@@ -1,10 +1,10 @@
-import { request } from 'node:https';
 import { URL } from 'node:url';
-import { normalizeSearchTerm } from '@main/core/issues/helpers/provider-inputs';
+import { clampIssueLimit, normalizeSearchTerm } from '@main/core/issues/helpers/provider-inputs';
 import type { IssueProvider } from '@main/core/issues/issue-provider';
 import { ISSUE_PROVIDER_CAPABILITIES, type IssueListResult } from '@shared/issue-providers';
 import type { Issue } from '@shared/tasks';
 import { jiraConnectionService } from './jira-connection-service';
+import { doJiraGet, doJiraPost } from './jira-http-client';
 
 interface RawJiraIssueFields {
   summary?: string;
@@ -24,6 +24,8 @@ interface RawJiraIssue {
 
 interface RawJiraSearchResult {
   issues?: RawJiraIssue[];
+  nextPageToken?: string;
+  isLast?: boolean;
 }
 
 interface AdfNode {
@@ -42,35 +44,50 @@ interface JiraPickerResult {
 
 let projectKeys: string[] = [];
 
-function encodeBasic(email: string, token: string): string {
-  return Buffer.from(`${email}:${token}`).toString('base64');
-}
+const SEARCH_FIELDS = ['summary', 'description', 'updated', 'project', 'status', 'assignee'];
+const PAGE_SIZE = 100;
+const JIRA_KEY_PATTERN = /^[A-Za-z][A-Za-z0-9_]*-\d+$/;
 
 async function listIssues(limit = 50): Promise<IssueListResult> {
   try {
     const { siteUrl, email, token } = await jiraConnectionService.requireAuth();
-    const jqlCandidates = [
-      'assignee = currentUser() ORDER BY updated DESC',
-      'reporter = currentUser() ORDER BY updated DESC',
-      'ORDER BY updated DESC',
-    ];
+    const sanitizedLimit = clampIssueLimit(limit, 50, 500);
+    try {
+      const issues = await searchJql(siteUrl, email, token, buildListJql('mine'), sanitizedLimit);
+      if (issues.length > 0) {
+        return { success: true, issues: normalizeIssues(siteUrl, issues) };
+      }
+    } catch (error) {
+      if (!isJqlPermissionError(error)) {
+        throw error;
+      }
 
-    for (const jql of jqlCandidates) {
-      try {
-        const issues = await searchRaw(siteUrl, email, token, jql, limit);
-        if (issues.length > 0) {
-          return { success: true, issues: normalizeIssues(siteUrl, issues) };
-        }
-      } catch {
-        // Try next candidate.
+      const issues = await searchJql(
+        siteUrl,
+        email,
+        token,
+        buildListJql('mine-fallback'),
+        sanitizedLimit
+      );
+      if (issues.length > 0) {
+        return { success: true, issues: normalizeIssues(siteUrl, issues) };
       }
     }
 
     try {
-      const keys = await getRecentIssueKeys(siteUrl, email, token, limit);
+      const issues = await searchJql(siteUrl, email, token, buildListJql('all'), sanitizedLimit);
+      if (issues.length > 0) {
+        return { success: true, issues: normalizeIssues(siteUrl, issues) };
+      }
+    } catch {
+      // Try picker fallback.
+    }
+
+    try {
+      const keys = await getRecentIssueKeys(siteUrl, email, token, sanitizedLimit);
       if (keys.length > 0) {
         const results: RawJiraIssue[] = [];
-        for (const key of keys.slice(0, limit)) {
+        for (const key of keys.slice(0, sanitizedLimit)) {
           try {
             const issue = await getIssueByKey(siteUrl, email, token, key);
             if (issue) {
@@ -91,7 +108,10 @@ async function listIssues(limit = 50): Promise<IssueListResult> {
 
     return { success: true, issues: [] };
   } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
@@ -117,9 +137,6 @@ async function smartSearchIssues(searchTerm: string, limit = 20): Promise<IssueL
       }
     }
 
-    const sanitized = term.replace(/"/g, '\\"');
-    const extraKey = looksLikeKey ? ` OR issueKey = ${term.toUpperCase()}` : '';
-
     const isNumeric = /^\d+$/.test(term);
     if (isNumeric && projectKeys.length === 0) {
       projectKeys = await fetchProjectKeys(siteUrl, email, token);
@@ -127,44 +144,121 @@ async function smartSearchIssues(searchTerm: string, limit = 20): Promise<IssueL
 
     const keyClause =
       isNumeric && projectKeys.length
-        ? ` OR key IN (${projectKeys.map((projectKey) => `"${projectKey}-${term}"`).join(',')})`
+        ? ` OR key IN (${projectKeys
+            .map((projectKey) => `"${escapeJqlValue(`${projectKey}-${term}`)}"`)
+            .join(',')})`
         : '';
 
-    const jql = `text ~ "${sanitized}"${extraKey}${keyClause}`;
-    const data = await searchRaw(siteUrl, email, token, jql, limit);
+    const data = await searchJql(
+      siteUrl,
+      email,
+      token,
+      `${buildSearchJql(term)}${keyClause} ORDER BY updated DESC`,
+      clampIssueLimit(limit, 20, 500)
+    );
 
     return { success: true, issues: normalizeIssues(siteUrl, data) };
   } catch (error) {
-    return { success: false, error: error instanceof Error ? error.message : String(error) };
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : String(error),
+    };
   }
 }
 
-async function searchRaw(
+type ListMode = 'mine' | 'mine-fallback' | 'all';
+
+export function buildListJql(mode: ListMode): string {
+  if (mode === 'mine') {
+    return '(assignee = currentUser() OR reporter = currentUser()) ORDER BY updated DESC';
+  }
+
+  if (mode === 'mine-fallback') {
+    return 'assignee = currentUser() ORDER BY updated DESC';
+  }
+
+  return 'updated >= -90d ORDER BY updated DESC';
+}
+
+export function buildSearchJql(searchTerm: string): string {
+  const term = normalizeSearchTerm(searchTerm);
+  const escaped = escapeJqlValue(term);
+
+  if (JIRA_KEY_PATTERN.test(term)) {
+    return `(key = "${escaped}" OR text ~ "${escaped}")`;
+  }
+
+  return `text ~ "${escaped}"`;
+}
+
+function escapeJqlValue(value: string): string {
+  return value.replace(/"/g, '\\"');
+}
+
+function isJqlPermissionError(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : String(error);
+  return /Jira API error (400|403)/.test(message);
+}
+
+async function searchJql(
   siteUrl: string,
   email: string,
   token: string,
   jql: string,
   limit: number
 ): Promise<RawJiraIssue[]> {
-  const url = new URL('/rest/api/3/search', siteUrl);
-  const payload = JSON.stringify({
+  const effectiveLimit = clampIssueLimit(limit, 20, 500);
+  const issues: RawJiraIssue[] = [];
+  let nextPageToken: string | undefined;
+
+  while (issues.length < effectiveLimit) {
+    const remaining = effectiveLimit - issues.length;
+    const data = await fetchSearchPage(
+      siteUrl,
+      email,
+      token,
+      jql,
+      Math.min(PAGE_SIZE, remaining),
+      nextPageToken
+    );
+    const pageIssues = Array.isArray(data?.issues) ? data.issues : [];
+    issues.push(...pageIssues);
+
+    if (pageIssues.length === 0 || data?.isLast === true || !data?.nextPageToken) {
+      break;
+    }
+    nextPageToken = data.nextPageToken;
+  }
+
+  return issues.slice(0, effectiveLimit);
+}
+
+async function fetchSearchPage(
+  siteUrl: string,
+  email: string,
+  token: string,
+  jql: string,
+  maxResults: number,
+  nextPageToken?: string
+): Promise<RawJiraSearchResult> {
+  const url = new URL('/rest/api/3/search/jql', siteUrl);
+  const payload: Record<string, unknown> = {
     jql,
-    maxResults: Math.min(Math.max(limit, 1), 100),
-    fields: ['summary', 'description', 'updated', 'project', 'status', 'assignee'],
-  });
+    maxResults,
+    fields: SEARCH_FIELDS,
+  };
+  if (nextPageToken) {
+    payload.nextPageToken = nextPageToken;
+  }
 
-  const body = await doRequest(url, email, token, 'POST', payload, {
-    'Content-Type': 'application/json',
-  });
-
-  const data = JSON.parse(body || '{}') as RawJiraSearchResult;
-  return Array.isArray(data?.issues) ? data.issues : [];
+  const body = await doJiraPost(url, email, token, JSON.stringify(payload));
+  return JSON.parse(body || '{}') as RawJiraSearchResult;
 }
 
 async function fetchProjectKeys(siteUrl: string, email: string, token: string): Promise<string[]> {
   try {
     const url = new URL('/rest/api/3/project', siteUrl);
-    const body = await doGet(url, email, token);
+    const body = await doJiraGet(url, email, token);
     const data = JSON.parse(body || '[]') as Array<{ key?: string }>;
     if (!Array.isArray(data)) return [];
     return data.map((project) => String(project?.key || '')).filter(Boolean);
@@ -182,7 +276,7 @@ async function getIssueByKey(
   const url = new URL(`/rest/api/3/issue/${encodeURIComponent(key)}`, siteUrl);
   url.searchParams.set('fields', 'summary,description,updated,project,status,assignee');
 
-  const body = await doGet(url, email, token);
+  const body = await doJiraGet(url, email, token);
   const data = JSON.parse(body || '{}') as RawJiraIssue;
   if (!data || data.errorMessages) {
     return null;
@@ -201,7 +295,7 @@ async function getRecentIssueKeys(
   url.searchParams.set('query', '');
   url.searchParams.set('currentJQL', '');
 
-  const body = await doGet(url, email, token);
+  const body = await doJiraGet(url, email, token);
   const data = JSON.parse(body || '{}') as JiraPickerResult;
 
   const keys: string[] = [];
@@ -223,58 +317,6 @@ async function getRecentIssueKeys(
   }
 
   return keys;
-}
-
-async function doGet(url: URL, email: string, token: string): Promise<string> {
-  return doRequest(url, email, token, 'GET');
-}
-
-async function doRequest(
-  url: URL,
-  email: string,
-  token: string,
-  method: 'GET' | 'POST',
-  payload?: string,
-  extraHeaders?: Record<string, string>
-): Promise<string> {
-  const auth = encodeBasic(email, token);
-
-  return new Promise<string>((resolve, reject) => {
-    const req = request(
-      {
-        hostname: url.hostname,
-        path: url.pathname + url.search,
-        protocol: url.protocol,
-        method,
-        headers: {
-          Authorization: `Basic ${auth}`,
-          Accept: 'application/json',
-          ...(extraHeaders || {}),
-        },
-      },
-      (res) => {
-        let data = '';
-        res.on('data', (chunk) => {
-          data += chunk;
-        });
-        res.on('end', () => {
-          if (res.statusCode && res.statusCode >= 400) {
-            const snippet = data?.slice(0, 200) || '';
-            reject(new Error(`Jira API error ${res.statusCode}${snippet ? `: ${snippet}` : ''}`));
-            return;
-          }
-
-          resolve(data);
-        });
-      }
-    );
-
-    req.on('error', reject);
-    if (payload && method === 'POST') {
-      req.write(payload);
-    }
-    req.end();
-  });
 }
 
 function flattenAdf(node: AdfNode | string | null | undefined): string {

--- a/src/main/core/jira/jira-issue-provider.ts
+++ b/src/main/core/jira/jira-issue-provider.ts
@@ -62,15 +62,19 @@ async function listIssues(limit = 50): Promise<IssueListResult> {
         throw error;
       }
 
-      const issues = await searchJql(
-        siteUrl,
-        email,
-        token,
-        buildListJql('mine-fallback'),
-        sanitizedLimit
-      );
-      if (issues.length > 0) {
-        return { success: true, issues: normalizeIssues(siteUrl, issues) };
+      try {
+        const issues = await searchJql(
+          siteUrl,
+          email,
+          token,
+          buildListJql('mine-fallback'),
+          sanitizedLimit
+        );
+        if (issues.length > 0) {
+          return { success: true, issues: normalizeIssues(siteUrl, issues) };
+        }
+      } catch {
+        // Try all-issues and picker fallbacks.
       }
     }
 
@@ -124,7 +128,7 @@ async function smartSearchIssues(searchTerm: string, limit = 20): Promise<IssueL
   try {
     const { siteUrl, email, token } = await jiraConnectionService.requireAuth();
 
-    const looksLikeKey = /^[A-Za-z][A-Za-z0-9_]*-\d+$/.test(term);
+    const looksLikeKey = JIRA_KEY_PATTERN.test(term);
     if (looksLikeKey) {
       const keyUpper = term.toUpperCase();
       try {
@@ -192,7 +196,7 @@ export function buildSearchJql(searchTerm: string): string {
 }
 
 function escapeJqlValue(value: string): string {
-  return value.replace(/"/g, '\\"');
+  return value.replace(/\\/g, '\\\\').replace(/"/g, '\\"');
 }
 
 function isJqlPermissionError(error: unknown): boolean {


### PR DESCRIPTION
- switches jira issue listing and search to the enhanced search jql endpoint
- adds token pagination for nextPageToken and isLast responses
- keeps exact issue lookup and issue picker fallback while tightening key shaped JQL
- adds a small jira http helper for shared auth headers timeout handling and JSON requests