### PR TITLE
fix(pr): render pull request description in sidebar

### DIFF
--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/checks-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/checks-list.tsx
@@ -10,9 +10,12 @@ import {
   type CheckRun,
   type CheckRunBucket,
 } from '@renderer/utils/github';
-import type { PullRequest } from '@shared/pull-requests';
+import type { PullRequest, PullRequestComment } from '@shared/pull-requests';
 import { CommentsList } from './comments-list';
+import { buildPullRequestConversationItems } from './pull-request-conversation';
 import { usePullRequestComments } from './use-pull-request-comments';
+
+const EMPTY_COMMENTS: PullRequestComment[] = [];
 
 const bucketOrder: Record<CheckRunBucket, number> = {
   fail: 0,
@@ -106,9 +109,13 @@ export function ChecksList({ checks }: { checks: CheckRun[] }) {
 export const PrChecksList = observer(function PrChecksList({ pr }: { pr: PullRequest }) {
   const { checks } = useSyncCheckRuns(pr);
   const commentsQuery = usePullRequestComments(pr);
-  const comments = commentsQuery.data ?? [];
+  const comments = commentsQuery.data ?? EMPTY_COMMENTS;
+  const conversationItems = useMemo(
+    () => buildPullRequestConversationItems(pr, comments),
+    [pr, comments]
+  );
 
-  if (checks.length === 0 && comments.length === 0 && !commentsQuery.isLoading) {
+  if (checks.length === 0 && conversationItems.length === 0 && !commentsQuery.isLoading) {
     return <EmptyState label="No checks or comments" description="Nothing available yet" />;
   }
 
@@ -125,7 +132,7 @@ export const PrChecksList = observer(function PrChecksList({ pr }: { pr: PullReq
           Comments
         </div>
         <CommentsList
-          comments={comments}
+          comments={conversationItems}
           isLoading={commentsQuery.isLoading}
           error={commentsQuery.error}
         />

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list.tsx
@@ -109,6 +109,12 @@ export function CommentsList({
       {sorted.map((comment) => (
         <CommentItem key={comment.id} comment={comment} />
       ))}
+      {isLoading && (
+        <div className="px-3 py-2 text-xs text-foreground-passive">Loading comments...</div>
+      )}
+      {error && (
+        <div className="px-3 py-2 text-xs text-foreground-passive">Unable to load comments</div>
+      )}
     </div>
   );
 }

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list.tsx
@@ -4,22 +4,25 @@ import { rpc } from '@renderer/lib/ipc';
 import { MarkdownRenderer } from '@renderer/lib/ui/markdown-renderer';
 import { RelativeTime } from '@renderer/lib/ui/relative-time';
 import { cn } from '@renderer/utils/utils';
-import type { PullRequestComment } from '@shared/pull-requests';
+import {
+  sortPullRequestConversationItems,
+  type PullRequestConversationItem,
+} from './pull-request-conversation';
 
-function commentAuthorLabel(comment: PullRequestComment): string {
+function commentAuthorLabel(comment: PullRequestConversationItem): string {
   return comment.author?.displayName ?? comment.author?.userName ?? 'Unknown author';
 }
 
-function commentLocationLabel(comment: PullRequestComment): string | null {
+function commentLocationLabel(comment: PullRequestConversationItem): string | null {
   if (!comment.path) return null;
   return comment.line ? `${comment.path}:${comment.line}` : comment.path;
 }
 
-function isBotAuthor(comment: PullRequestComment): boolean {
+function isBotAuthor(comment: PullRequestConversationItem): boolean {
   return comment.author?.userName.endsWith('[bot]') ?? false;
 }
 
-function CommentItem({ comment }: { comment: PullRequestComment }) {
+function CommentItem({ comment }: { comment: PullRequestConversationItem }) {
   const location = commentLocationLabel(comment);
   const author = commentAuthorLabel(comment);
   const avatarRadiusClass = isBotAuthor(comment) ? 'rounded' : 'rounded-full';
@@ -46,7 +49,7 @@ function CommentItem({ comment }: { comment: PullRequestComment }) {
         <div className="flex min-w-0 items-center gap-1.5 text-xs text-foreground-muted">
           <span className="truncate font-medium text-foreground">{author}</span>
           <span className="shrink-0 text-foreground-passive">/</span>
-          <RelativeTime compact value={comment.updatedAt} className="shrink-0" />
+          <RelativeTime compact value={comment.createdAt} className="shrink-0" />
           {comment.isResolved && (
             <>
               <span className="shrink-0 text-foreground-passive">/</span>
@@ -83,23 +86,17 @@ export function CommentsList({
   isLoading,
   error,
 }: {
-  comments: PullRequestComment[];
+  comments: PullRequestConversationItem[];
   isLoading?: boolean;
   error?: Error | null;
 }) {
-  const sorted = useMemo(
-    () =>
-      [...comments].sort(
-        (a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime()
-      ),
-    [comments]
-  );
+  const sorted = useMemo(() => [...comments].sort(sortPullRequestConversationItems), [comments]);
 
-  if (isLoading) {
+  if (isLoading && sorted.length === 0) {
     return <div className="px-3 py-2 text-xs text-foreground-passive">Loading comments...</div>;
   }
 
-  if (error) {
+  if (error && sorted.length === 0) {
     return <div className="px-3 py-2 text-xs text-foreground-passive">Unable to load comments</div>;
   }
 

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pull-request-conversation.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pull-request-conversation.ts
@@ -1,0 +1,61 @@
+import type { PullRequest, PullRequestComment } from '@shared/pull-requests';
+
+export type PullRequestDescriptionItem = {
+  id: string;
+  pullRequestUrl: string;
+  kind: 'description';
+  body: string;
+  url: string;
+  author: PullRequest['author'];
+  path: null;
+  line: null;
+  isResolved: false;
+  isOutdated: false;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type PullRequestConversationItem = PullRequestDescriptionItem | PullRequestComment;
+
+function descriptionItemForPr(pr: PullRequest): PullRequestDescriptionItem | null {
+  const body = pr.description?.trim();
+  if (!body) return null;
+
+  return {
+    id: `description:${pr.url}`,
+    pullRequestUrl: pr.url,
+    kind: 'description',
+    body,
+    url: pr.url,
+    author: pr.author,
+    path: null,
+    line: null,
+    isResolved: false,
+    isOutdated: false,
+    createdAt: pr.createdAt,
+    updatedAt: pr.updatedAt,
+  };
+}
+
+export function sortPullRequestConversationItems(
+  a: PullRequestConversationItem,
+  b: PullRequestConversationItem
+): number {
+  if (a.kind === 'description' && b.kind !== 'description') return -1;
+  if (a.kind !== 'description' && b.kind === 'description') return 1;
+
+  const createdAtDelta = new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime();
+  if (createdAtDelta !== 0) return createdAtDelta;
+
+  return new Date(a.updatedAt).getTime() - new Date(b.updatedAt).getTime();
+}
+
+export function buildPullRequestConversationItems(
+  pr: PullRequest,
+  comments: PullRequestComment[]
+): PullRequestConversationItem[] {
+  const description = descriptionItemForPr(pr);
+  return [...(description ? [description] : []), ...comments].sort(
+    sortPullRequestConversationItems
+  );
+}

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pull-request-conversation.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pull-request-conversation.ts
@@ -55,7 +55,5 @@ export function buildPullRequestConversationItems(
   comments: PullRequestComment[]
 ): PullRequestConversationItem[] {
   const description = descriptionItemForPr(pr);
-  return [...(description ? [description] : []), ...comments].sort(
-    sortPullRequestConversationItems
-  );
+  return [...(description ? [description] : []), ...comments];
 }

--- a/src/renderer/tests/pr-comments-list.test.ts
+++ b/src/renderer/tests/pr-comments-list.test.ts
@@ -2,7 +2,8 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { describe, expect, it, vi } from 'vitest';
 import { CommentsList } from '@renderer/features/tasks/diff-view/changes-panel/components/pr-entry/comments-list';
-import type { PullRequestComment } from '@shared/pull-requests';
+import { buildPullRequestConversationItems } from '@renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pull-request-conversation';
+import type { PullRequest, PullRequestComment } from '@shared/pull-requests';
 
 vi.mock('@renderer/lib/hooks/useTheme', () => ({
   useTheme: () => ({ effectiveTheme: 'emlight' }),
@@ -16,7 +17,10 @@ vi.mock('@renderer/lib/ipc', () => ({
   },
 }));
 
-function makeComment(body: string): PullRequestComment {
+function makeComment(
+  body: string,
+  overrides: Partial<PullRequestComment> = {}
+): PullRequestComment {
   return {
     id: 'issue-comment:1',
     pullRequestUrl: 'https://github.com/org/repo/pull/1',
@@ -38,6 +42,47 @@ function makeComment(body: string): PullRequestComment {
     isOutdated: false,
     createdAt: '2026-05-16T00:00:00Z',
     updatedAt: '2026-05-16T00:00:00Z',
+    ...overrides,
+  };
+}
+
+function makePullRequest(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    url: 'https://github.com/org/repo/pull/1',
+    provider: 'github',
+    repositoryUrl: 'https://github.com/org/repo',
+    baseRefName: 'main',
+    baseRefOid: 'base',
+    headRepositoryUrl: 'https://github.com/org/repo',
+    headRefName: 'feature',
+    headRefOid: 'head',
+    identifier: '#1',
+    title: 'Add feature',
+    description: 'PR body',
+    status: 'open',
+    isDraft: false,
+    additions: 1,
+    deletions: 0,
+    changedFiles: 1,
+    commitCount: 1,
+    mergeableStatus: 'MERGEABLE',
+    mergeStateStatus: 'CLEAN',
+    reviewDecision: null,
+    createdAt: '2026-05-10T00:00:00Z',
+    updatedAt: '2026-05-12T00:00:00Z',
+    author: {
+      userId: '1',
+      userName: 'arnestrickmann',
+      displayName: 'Arne Strickmann',
+      avatarUrl: null,
+      url: 'https://github.com/arnestrickmann',
+      userUpdatedAt: null,
+      userCreatedAt: null,
+    },
+    labels: [],
+    assignees: [],
+    checks: [],
+    ...overrides,
   };
 }
 
@@ -57,5 +102,40 @@ describe('CommentsList', () => {
     expect(html).toContain('max-w-full');
     expect(html).toContain('max-h-80');
     expect(html).toContain('object-contain');
+  });
+
+  it('renders comments by creation time rather than update time', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(CommentsList, {
+        comments: [
+          makeComment('Second comment edited later', {
+            id: 'issue-comment:2',
+            createdAt: '2026-05-12T00:00:00Z',
+            updatedAt: '2026-05-20T00:00:00Z',
+          }),
+          makeComment('First comment', {
+            id: 'issue-comment:1',
+            createdAt: '2026-05-11T00:00:00Z',
+            updatedAt: '2026-05-11T00:00:00Z',
+          }),
+        ],
+      })
+    );
+
+    expect(html.indexOf('First comment')).toBeLessThan(html.indexOf('Second comment edited later'));
+  });
+});
+
+describe('buildPullRequestConversationItems', () => {
+  it('prepends the pull request description before comments', () => {
+    const items = buildPullRequestConversationItems(makePullRequest(), [
+      makeComment('Earlier external comment', {
+        createdAt: '2026-05-09T00:00:00Z',
+        updatedAt: '2026-05-09T00:00:00Z',
+      }),
+    ]);
+
+    expect(items.map((item) => item.kind)).toEqual(['description', 'issue']);
+    expect(items[0]?.body).toBe('PR body');
   });
 });

--- a/src/renderer/tests/pr-comments-list.test.ts
+++ b/src/renderer/tests/pr-comments-list.test.ts
@@ -124,6 +124,18 @@ describe('CommentsList', () => {
 
     expect(html.indexOf('First comment')).toBeLessThan(html.indexOf('Second comment edited later'));
   });
+
+  it('keeps the error state visible when conversation items are present', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(CommentsList, {
+        comments: [makeComment('PR body')],
+        error: new Error('failed'),
+      })
+    );
+
+    expect(html).toContain('PR body');
+    expect(html).toContain('Unable to load comments');
+  });
 });
 
 describe('buildPullRequestConversationItems', () => {


### PR DESCRIPTION
- renders pull request descriptions as the first sidebar conversation item
- keeps comment fetching unchanged and composes the timeline in the renderer
- orders sidebar conversation items by creation time so edits do not move comments