### PR TITLE
fix(tasks): search prs in create task modal

### DIFF
--- a/src/main/core/pull-requests/pr-query-service.db.test.ts
+++ b/src/main/core/pull-requests/pr-query-service.db.test.ts
@@ -1,0 +1,130 @@
+import { randomUUID } from 'node:crypto';
+import { openFixture } from '@tooling/utils/db';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AppDb } from '@main/db/client';
+import { projectRemotes, projects, pullRequests } from '@main/db/schema';
+import { prQueryService } from './pr-query-service';
+
+const mocks = vi.hoisted(() => ({
+  db: undefined as AppDb | undefined,
+}));
+
+vi.mock('@main/db/client', () => ({
+  get db() {
+    if (!mocks.db) throw new Error('Test database not initialized');
+    return mocks.db;
+  },
+}));
+
+const PROJECT_ID = 'project-1';
+const REPOSITORY_URL = 'https://github.com/acme/repo';
+const OTHER_REPOSITORY_URL = 'https://github.com/acme/other';
+
+function prRow(overrides: Partial<typeof pullRequests.$inferInsert>) {
+  return {
+    url: `https://github.com/acme/repo/pull/${overrides.identifier ?? randomUUID()}`,
+    repositoryUrl: REPOSITORY_URL,
+    baseRefName: 'main',
+    baseRefOid: 'base-oid',
+    headRepositoryUrl: REPOSITORY_URL,
+    headRefName: 'feature/default',
+    headRefOid: 'head-oid',
+    identifier: '#1',
+    title: 'Default PR',
+    status: 'open',
+    isDraft: 0,
+    ...overrides,
+  };
+}
+
+describe('PrQueryService', () => {
+  let fixture: Awaited<ReturnType<typeof openFixture>>;
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+    mocks.db = fixture.db;
+
+    await fixture.db.insert(projects).values({
+      id: PROJECT_ID,
+      name: 'Project',
+      path: '/repo',
+    });
+    await fixture.db.insert(projectRemotes).values({
+      projectId: PROJECT_ID,
+      remoteName: 'origin',
+      remoteUrl: REPOSITORY_URL,
+    });
+  });
+
+  afterEach(() => {
+    fixture.close();
+    mocks.db = undefined;
+  });
+
+  it('searches PR title, identifier, and head branch within repository and status scope', async () => {
+    await fixture.db.insert(pullRequests).values([
+      prRow({
+        url: 'https://github.com/acme/repo/pull/1',
+        identifier: '#1',
+        title: 'Update create task modal',
+        headRefName: 'feature/create-task-modal',
+      }),
+      prRow({
+        url: 'https://github.com/acme/repo/pull/2',
+        identifier: '#42',
+        title: 'Unrelated title',
+        headRefName: 'feature/unrelated',
+      }),
+      prRow({
+        url: 'https://github.com/acme/repo/pull/3',
+        identifier: '#3',
+        title: 'Branch-only match',
+        headRefName: 'jan/eng-1463-pr-search',
+      }),
+      prRow({
+        url: 'https://github.com/acme/repo/pull/4',
+        identifier: '#4',
+        title: 'Closed branch-only match',
+        headRefName: 'jan/eng-1463-closed',
+        status: 'closed',
+      }),
+      prRow({
+        url: 'https://github.com/acme/other/pull/5',
+        repositoryUrl: OTHER_REPOSITORY_URL,
+        headRepositoryUrl: OTHER_REPOSITORY_URL,
+        identifier: '#5',
+        title: 'Foreign repo branch-only match',
+        headRefName: 'jan/eng-1463-foreign',
+      }),
+    ]);
+
+    await expect(
+      prQueryService.listPullRequests(PROJECT_ID, {
+        repositoryUrl: REPOSITORY_URL,
+        filters: { status: 'open' },
+        searchQuery: 'eng-1463',
+      })
+    ).resolves.toMatchObject([
+      {
+        url: 'https://github.com/acme/repo/pull/3',
+        headRefName: 'jan/eng-1463-pr-search',
+      },
+    ]);
+
+    await expect(
+      prQueryService.listPullRequests(PROJECT_ID, {
+        repositoryUrl: REPOSITORY_URL,
+        filters: { status: 'open' },
+        searchQuery: '#42',
+      })
+    ).resolves.toMatchObject([{ url: 'https://github.com/acme/repo/pull/2' }]);
+
+    await expect(
+      prQueryService.listPullRequests(PROJECT_ID, {
+        repositoryUrl: REPOSITORY_URL,
+        filters: { status: 'open' },
+        searchQuery: 'create task',
+      })
+    ).resolves.toMatchObject([{ url: 'https://github.com/acme/repo/pull/1' }]);
+  });
+});

--- a/src/main/core/pull-requests/pr-query-service.ts
+++ b/src/main/core/pull-requests/pr-query-service.ts
@@ -121,7 +121,11 @@ export class PrQueryService {
     if (options.searchQuery?.trim()) {
       const pattern = `%${options.searchQuery.trim()}%`;
       conditions.push(
-        or(like(pullRequests.title, pattern), like(pullRequests.identifier, pattern))!
+        or(
+          like(pullRequests.title, pattern),
+          like(pullRequests.identifier, pattern),
+          like(pullRequests.headRefName, pattern)
+        )!
       );
     }
 

--- a/src/renderer/features/tasks/components/pr-selector/pr-selector.test.ts
+++ b/src/renderer/features/tasks/components/pr-selector/pr-selector.test.ts
@@ -33,13 +33,38 @@ vi.mock('@renderer/lib/components/pr-status-icon', async () => {
 
 vi.mock('@renderer/lib/ui/select', async () => {
   const React = await import('react');
+  type SelectContextValue = {
+    onValueChange?: (value: string) => void;
+  };
+  const SelectContext = React.createContext<SelectContextValue>({});
+  function MockSelectItem({ children, value }: { children: React.ReactNode; value: string }) {
+    const { onValueChange } = React.useContext(SelectContext);
+    return React.createElement(
+      'button',
+      {
+        'data-testid': `status-${value}`,
+        onClick: () => onValueChange?.(value),
+      },
+      children
+    );
+  }
+
   return {
-    Select: ({ children }: { children: React.ReactNode }) =>
-      React.createElement('div', {}, children),
+    Select: ({
+      children,
+      onValueChange,
+    }: {
+      children: React.ReactNode;
+      onValueChange?: (value: string) => void;
+    }) =>
+      React.createElement(
+        SelectContext.Provider,
+        { value: { onValueChange } },
+        React.createElement('div', {}, children)
+      ),
     SelectContent: ({ children }: { children: React.ReactNode }) =>
       React.createElement('div', {}, children),
-    SelectItem: ({ children }: { children: React.ReactNode }) =>
-      React.createElement('div', {}, children),
+    SelectItem: MockSelectItem,
     SelectTrigger: ({ children }: { children: React.ReactNode }) =>
       React.createElement('div', {}, children),
   };
@@ -54,14 +79,25 @@ vi.mock('@renderer/lib/ui/combobox', async () => {
   };
 
   const ComboboxContext = React.createContext<ComboboxContextValue>({});
-  function MockComboboxInput({ placeholder }: { placeholder?: string }) {
+  function MockComboboxInput({
+    placeholder,
+    rightAddon,
+  }: {
+    placeholder?: string;
+    rightAddon?: React.ReactNode;
+  }) {
     const { inputValue, onInputValueChange } = React.useContext(ComboboxContext);
-    return React.createElement('button', {
-      'data-testid': 'search-input',
-      placeholder,
-      'data-input-value': inputValue ?? '',
-      onClick: () => onInputValueChange?.('eng-1463', { reason: 'input' }),
-    });
+    return React.createElement(
+      'div',
+      {},
+      React.createElement('button', {
+        'data-testid': 'search-input',
+        placeholder,
+        'data-input-value': inputValue ?? '',
+        onClick: () => onInputValueChange?.('eng-1463', { reason: 'input' }),
+      }),
+      rightAddon
+    );
   }
 
   return {
@@ -202,6 +238,55 @@ describe('PrSelector', () => {
     expect(mocks.listPullRequests).toHaveBeenLastCalledWith(
       PROJECT_ID,
       expect.objectContaining({ searchQuery: 'eng-1463' })
+    );
+  });
+
+  it('clears the active search query immediately when the status filter changes', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(PrSelector, {
+            value: null,
+            onValueChange: vi.fn(),
+            projectId: PROJECT_ID,
+            repositoryUrl: REPOSITORY_URL,
+          })
+        )
+      );
+    });
+
+    const input = container.querySelector('[data-testid="search-input"]');
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      input!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+    expect(mocks.listPullRequests).toHaveBeenLastCalledWith(
+      PROJECT_ID,
+      expect.objectContaining({
+        filters: { status: 'open' },
+        searchQuery: 'eng-1463',
+      })
+    );
+
+    const closedStatus = container.querySelector('[data-testid="status-not-open"]');
+    expect(closedStatus).not.toBeNull();
+
+    await act(async () => {
+      closedStatus!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(mocks.listPullRequests).toHaveBeenLastCalledWith(
+      PROJECT_ID,
+      expect.objectContaining({
+        filters: { status: 'not-open' },
+        searchQuery: undefined,
+      })
     );
   });
 });

--- a/src/renderer/features/tasks/components/pr-selector/pr-selector.test.ts
+++ b/src/renderer/features/tasks/components/pr-selector/pr-selector.test.ts
@@ -1,0 +1,207 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { PullRequest } from '@shared/pull-requests';
+import { PrSelector } from './pr-selector';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  listPullRequests: vi.fn(),
+  syncPullRequests: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    pullRequests: {
+      listPullRequests: mocks.listPullRequests,
+      syncPullRequests: mocks.syncPullRequests,
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/components/pr-status-icon', async () => {
+  const React = await import('react');
+  return {
+    StatusIcon: () => React.createElement('span', { 'data-testid': 'status-icon' }),
+  };
+});
+
+vi.mock('@renderer/lib/ui/select', async () => {
+  const React = await import('react');
+  return {
+    Select: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', {}, children),
+    SelectContent: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', {}, children),
+    SelectItem: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', {}, children),
+    SelectTrigger: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', {}, children),
+  };
+});
+
+vi.mock('@renderer/lib/ui/combobox', async () => {
+  const React = await import('react');
+
+  type ComboboxContextValue = {
+    inputValue?: string;
+    onInputValueChange?: (value: string, details: { reason: string }) => void;
+  };
+
+  const ComboboxContext = React.createContext<ComboboxContextValue>({});
+  function MockComboboxInput({ placeholder }: { placeholder?: string }) {
+    const { inputValue, onInputValueChange } = React.useContext(ComboboxContext);
+    return React.createElement('button', {
+      'data-testid': 'search-input',
+      placeholder,
+      'data-input-value': inputValue ?? '',
+      onClick: () => onInputValueChange?.('eng-1463', { reason: 'input' }),
+    });
+  }
+
+  return {
+    Combobox: ({
+      children,
+      inputValue,
+      onInputValueChange,
+    }: {
+      children: React.ReactNode;
+      inputValue?: string;
+      onInputValueChange?: (value: string, details: { reason: string }) => void;
+    }) =>
+      React.createElement(
+        ComboboxContext.Provider,
+        { value: { inputValue, onInputValueChange } },
+        children
+      ),
+    ComboboxContent: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', {}, children),
+    ComboboxEmpty: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', {}, children),
+    ComboboxInput: MockComboboxInput,
+    ComboboxItem: ({ children }: { children: React.ReactNode }) =>
+      React.createElement('div', {}, children),
+    ComboboxList: () => React.createElement('div', {}),
+    ComboboxTrigger: ({ render }: { render: React.ReactElement }) => render,
+    ComboboxValue: ({
+      children,
+      placeholder,
+    }: {
+      children?: React.ReactNode;
+      placeholder?: React.ReactNode;
+    }) => React.createElement('div', {}, children ?? placeholder),
+  };
+});
+
+const PROJECT_ID = 'project-1';
+const REPOSITORY_URL = 'https://github.com/acme/repo';
+
+function makePr(overrides: Partial<PullRequest> = {}): PullRequest {
+  return {
+    url: 'https://github.com/acme/repo/pull/1',
+    provider: 'github',
+    repositoryUrl: REPOSITORY_URL,
+    baseRefName: 'main',
+    baseRefOid: 'base-oid',
+    headRepositoryUrl: REPOSITORY_URL,
+    headRefName: 'feature/search',
+    headRefOid: 'head-oid',
+    identifier: '#1',
+    title: 'Search PR',
+    description: null,
+    status: 'open',
+    isDraft: false,
+    additions: null,
+    deletions: null,
+    changedFiles: null,
+    commitCount: null,
+    mergeableStatus: null,
+    mergeStateStatus: null,
+    reviewDecision: null,
+    createdAt: '2026-05-30T00:00:00.000Z',
+    updatedAt: '2026-05-30T00:00:00.000Z',
+    author: null,
+    labels: [],
+    assignees: [],
+    checks: [],
+    ...overrides,
+  };
+}
+
+describe('PrSelector', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    mocks.listPullRequests.mockResolvedValue({ success: true, data: { prs: [makePr()] } });
+    mocks.syncPullRequests.mockResolvedValue({ success: true });
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  it('passes debounced input text as the pull request search query', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(PrSelector, {
+            value: null,
+            onValueChange: vi.fn(),
+            projectId: PROJECT_ID,
+            repositoryUrl: REPOSITORY_URL,
+          })
+        )
+      );
+    });
+
+    expect(mocks.listPullRequests).toHaveBeenCalledWith(
+      PROJECT_ID,
+      expect.objectContaining({ searchQuery: undefined })
+    );
+
+    const input = container.querySelector('[data-testid="search-input"]');
+    expect(input).not.toBeNull();
+
+    await act(async () => {
+      input!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await act(async () => {
+      vi.advanceTimersByTime(200);
+    });
+
+    expect(mocks.listPullRequests).toHaveBeenLastCalledWith(
+      PROJECT_ID,
+      expect.objectContaining({ searchQuery: 'eng-1463' })
+    );
+  });
+});

--- a/src/renderer/features/tasks/components/pr-selector/pr-selector.tsx
+++ b/src/renderer/features/tasks/components/pr-selector/pr-selector.tsx
@@ -1,6 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { type ReactNode, useState } from 'react';
 import { StatusIcon } from '@renderer/lib/components/pr-status-icon';
+import { useDebounce } from '@renderer/lib/hooks/useDebounce';
 import { rpc } from '@renderer/lib/ipc';
 import {
   Combobox,
@@ -71,6 +72,8 @@ export function PrSelector({
   renderPlaceholder,
 }: PrSelectorProps) {
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('open');
+  const [query, setQuery] = useState('');
+  const debouncedQuery = useDebounce(query.trim(), 200);
 
   // Trigger a background incremental sync when the selector mounts, at most once per 60 s.
   useQuery({
@@ -81,12 +84,13 @@ export function PrSelector({
   });
 
   const { data } = useQuery({
-    queryKey: ['pull-requests-selector', projectId, repositoryUrl, statusFilter],
+    queryKey: ['pull-requests-selector', projectId, repositoryUrl, statusFilter, debouncedQuery],
     queryFn: async () => {
       const response = await rpc.pullRequests.listPullRequests(projectId!, {
         limit: 50,
         offset: 0,
         filters: { status: statusFilter },
+        searchQuery: debouncedQuery || undefined,
         repositoryUrl,
       });
       if (!response?.success) {
@@ -122,7 +126,10 @@ export function PrSelector({
     <Select
       value={statusFilter}
       onValueChange={(v) => {
-        if (v === 'open' || v === 'not-open') setStatusFilter(v);
+        if (v === 'open' || v === 'not-open') {
+          setStatusFilter(v);
+          setQuery('');
+        }
       }}
     >
       <SelectTrigger
@@ -148,7 +155,14 @@ export function PrSelector({
           pr ? `${pr.identifier ?? ''} ${pr.title} ${pr.headRefName}` : ''
         }
         value={value}
-        onValueChange={(next: PullRequest | null) => onValueChange(next)}
+        onValueChange={(next: PullRequest | null) => {
+          onValueChange(next);
+          setQuery('');
+        }}
+        inputValue={query}
+        onInputValueChange={(nextQuery: string, { reason }: { reason: string }) => {
+          if (reason !== 'item-press') setQuery(nextQuery);
+        }}
         disabled={disabled}
       >
         <ComboboxTrigger

--- a/src/renderer/features/tasks/components/pr-selector/pr-selector.tsx
+++ b/src/renderer/features/tasks/components/pr-selector/pr-selector.tsx
@@ -74,6 +74,7 @@ export function PrSelector({
   const [statusFilter, setStatusFilter] = useState<StatusFilter>('open');
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query.trim(), 200);
+  const searchQuery = query.trim() ? debouncedQuery : '';
 
   // Trigger a background incremental sync when the selector mounts, at most once per 60 s.
   useQuery({
@@ -84,13 +85,13 @@ export function PrSelector({
   });
 
   const { data } = useQuery({
-    queryKey: ['pull-requests-selector', projectId, repositoryUrl, statusFilter, debouncedQuery],
+    queryKey: ['pull-requests-selector', projectId, repositoryUrl, statusFilter, searchQuery],
     queryFn: async () => {
       const response = await rpc.pullRequests.listPullRequests(projectId!, {
         limit: 50,
         offset: 0,
         filters: { status: statusFilter },
-        searchQuery: debouncedQuery || undefined,
+        searchQuery: searchQuery || undefined,
         repositoryUrl,
       });
       if (!response?.success) {


### PR DESCRIPTION
- searches pull requests from the create task modal through the existing listPullRequests rpc path
- matches cached pull requests by title, identifier and head branch while preserving repository and status filters
- keeps selector filtering server-backed so results are not limited to the initially loaded page