### PR TITLE
fix(terminal): improve file path link activation

### DIFF
--- a/src/renderer/lib/pty/file-link-detection.ts
+++ b/src/renderer/lib/pty/file-link-detection.ts
@@ -108,7 +108,10 @@ function expandHardLineBreakPathContinuations(
 ): LogicalLine {
   let expanded = logicalLine;
   const firstLine = expanded.lineTexts[0];
-  const previousLine = buffer.getLine(expanded.startBufferIndex - 1)?.translateToString(true);
+  const previousBufferLine = buffer.getLine(expanded.startBufferIndex - 1);
+  const previousLine = previousBufferLine?.isWrapped
+    ? undefined
+    : previousBufferLine?.translateToString(true);
   if (
     firstLine !== undefined &&
     previousLine !== undefined &&

--- a/src/renderer/lib/pty/file-link-detection.ts
+++ b/src/renderer/lib/pty/file-link-detection.ts
@@ -1,0 +1,199 @@
+import type { ILink } from '@xterm/xterm';
+
+// Lookbehind on `:` keeps URLs (`https://...`) with WebLinksAddon.
+const FILE_PATH_PATTERN =
+  '(?<![\\w\\-./@:])(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
+const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+const MAX_WRAPPED_LINE_LENGTH = 4096;
+
+export type BufferLineLike = {
+  isWrapped: boolean;
+  translateToString(trimRight?: boolean): string;
+};
+
+export type BufferLike = {
+  getLine(index: number): BufferLineLike | undefined;
+};
+
+export type FileLinkMatch = {
+  range: ILink['range'];
+  text: string;
+  isExternal: boolean;
+};
+
+type LogicalLine = {
+  startBufferIndex: number;
+  lineTexts: string[];
+  lineStartColumns: number[];
+  text: string;
+};
+
+export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): FileLinkMatch[] {
+  const logicalLine = getWrappedLogicalLine(buffer, bufferLineNumber - 1);
+  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('/') === -1) {
+    return [];
+  }
+
+  const links: FileLinkMatch[] = [];
+  // Fresh regex per call — module-level /g state isn't safe across reentrancy.
+  const regex = new RegExp(FILE_PATH_PATTERN, 'g');
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(logicalLine.text)) !== null) {
+    const matched = match[0];
+    const startOffset = match.index;
+    if (isEmbeddedInUrl(logicalLine.text, startOffset)) continue;
+    const endOffset = startOffset + matched.length;
+    const range = mapOffsetRangeToBufferRange(logicalLine, startOffset, endOffset);
+    if (!range) continue;
+
+    links.push({
+      range,
+      text: matched,
+      isExternal: matched.startsWith('~/') || matched.startsWith('/'),
+    });
+  }
+  return links;
+}
+
+function isEmbeddedInUrl(text: string, startCol: number): boolean {
+  const prefix = text.slice(0, startCol);
+  const tokenStart = Math.max(prefix.lastIndexOf(' '), prefix.lastIndexOf('\t'), -1) + 1;
+  return URL_PROTOCOL_PATTERN.test(prefix.slice(tokenStart));
+}
+
+function getWrappedLogicalLine(buffer: BufferLike, bufferIndex: number): LogicalLine | null {
+  const line = buffer.getLine(bufferIndex);
+  if (!line) return null;
+
+  let startBufferIndex = bufferIndex;
+  while (startBufferIndex > 0 && buffer.getLine(startBufferIndex)?.isWrapped) {
+    startBufferIndex -= 1;
+  }
+
+  const lineTexts: string[] = [];
+  const lineStartColumns: number[] = [];
+  let currentIndex = startBufferIndex;
+  let totalLength = 0;
+  while (true) {
+    const currentLine = buffer.getLine(currentIndex);
+    if (!currentLine) break;
+
+    const text = currentLine.translateToString(true);
+    lineTexts.push(text);
+    lineStartColumns.push(0);
+    totalLength += text.length;
+    if (totalLength > MAX_WRAPPED_LINE_LENGTH) return null;
+
+    const nextLine = buffer.getLine(currentIndex + 1);
+    if (!nextLine?.isWrapped) break;
+    currentIndex += 1;
+  }
+
+  return expandHardLineBreakPathContinuations(buffer, {
+    startBufferIndex,
+    lineTexts,
+    lineStartColumns,
+    text: lineTexts.join(''),
+  });
+}
+
+function expandHardLineBreakPathContinuations(
+  buffer: BufferLike,
+  logicalLine: LogicalLine
+): LogicalLine {
+  let expanded = logicalLine;
+  const firstLine = expanded.lineTexts[0];
+  const previousLine = buffer.getLine(expanded.startBufferIndex - 1)?.translateToString(true);
+  if (
+    firstLine !== undefined &&
+    previousLine !== undefined &&
+    endsWithPathContinuation(previousLine) &&
+    startsWithPathContinuation(firstLine)
+  ) {
+    expanded = {
+      startBufferIndex: expanded.startBufferIndex - 1,
+      lineTexts: [
+        previousLine,
+        trimPathContinuationStart(firstLine),
+        ...expanded.lineTexts.slice(1),
+      ],
+      lineStartColumns: [
+        0,
+        countLeadingWhitespace(firstLine),
+        ...expanded.lineStartColumns.slice(1),
+      ],
+      text: '',
+    };
+    expanded.text = expanded.lineTexts.join('');
+  }
+
+  const lastLineIndex = expanded.startBufferIndex + expanded.lineTexts.length - 1;
+  const nextLine = buffer.getLine(lastLineIndex + 1)?.translateToString(true);
+  if (
+    nextLine !== undefined &&
+    endsWithPathContinuation(expanded.text) &&
+    startsWithPathContinuation(nextLine)
+  ) {
+    const trimmedNextLine = trimPathContinuationStart(nextLine);
+    expanded = {
+      startBufferIndex: expanded.startBufferIndex,
+      lineTexts: [...expanded.lineTexts, trimmedNextLine],
+      lineStartColumns: [...expanded.lineStartColumns, countLeadingWhitespace(nextLine)],
+      text: expanded.text + trimmedNextLine,
+    };
+  }
+
+  return expanded.text.length > MAX_WRAPPED_LINE_LENGTH ? logicalLine : expanded;
+}
+
+function endsWithPathContinuation(text: string): boolean {
+  const fragment = trailingToken(text);
+  return fragment.includes('/') && !isEmbeddedInUrl(text, text.length - fragment.length);
+}
+
+function startsWithPathContinuation(text: string): boolean {
+  const trimmed = trimPathContinuationStart(text);
+  return /^[\w.\-@]+(?:\/|[\w.\-@]*\.[a-zA-Z][a-zA-Z0-9]{0,9}\b)/.test(trimmed);
+}
+
+function trimPathContinuationStart(text: string): string {
+  return text.slice(countLeadingWhitespace(text));
+}
+
+function countLeadingWhitespace(text: string): number {
+  return text.length - text.trimStart().length;
+}
+
+function trailingToken(text: string): string {
+  const match = /[^\s([{"'`<]+$/.exec(text);
+  return match?.[0] ?? '';
+}
+
+function mapOffsetRangeToBufferRange(
+  logicalLine: LogicalLine,
+  startOffset: number,
+  endOffset: number
+): ILink['range'] | null {
+  const start = mapOffsetToBufferPosition(logicalLine, startOffset);
+  const end = mapOffsetToBufferPosition(logicalLine, endOffset - 1);
+  if (!start || !end) return null;
+  return { start, end };
+}
+
+function mapOffsetToBufferPosition(
+  logicalLine: LogicalLine,
+  offset: number
+): ILink['range']['start'] | null {
+  let remaining = offset;
+  for (let lineIndex = 0; lineIndex < logicalLine.lineTexts.length; lineIndex += 1) {
+    const lineLength = logicalLine.lineTexts[lineIndex]?.length ?? 0;
+    if (remaining < lineLength) {
+      return {
+        x: (logicalLine.lineStartColumns[lineIndex] ?? 0) + remaining + 1,
+        y: logicalLine.startBufferIndex + lineIndex + 1,
+      };
+    }
+    remaining -= lineLength;
+  }
+  return null;
+}

--- a/src/renderer/lib/pty/file-link-detection.ts
+++ b/src/renderer/lib/pty/file-link-detection.ts
@@ -46,11 +46,16 @@ export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): Fil
     const range = mapOffsetRangeToBufferRange(logicalLine, startOffset, endOffset);
     if (!range) continue;
 
-    links.push({
-      range,
-      text: matched,
-      isExternal: matched.startsWith('~/') || matched.startsWith('/'),
-    });
+    const visibleRanges = mapOffsetRangeToVisibleBufferRanges(logicalLine, startOffset, endOffset);
+    const linkRanges = shouldUseVisibleRanges(visibleRanges) ? visibleRanges : [range];
+    for (const linkRange of linkRanges) {
+      if (!rangeContainsBufferLine(linkRange, bufferLineNumber)) continue;
+      links.push({
+        range: linkRange,
+        text: matched,
+        isExternal: matched.startsWith('~/') || matched.startsWith('/'),
+      });
+    }
   }
   return links;
 }
@@ -178,6 +183,45 @@ function mapOffsetRangeToBufferRange(
   const end = mapOffsetToBufferPosition(logicalLine, endOffset - 1);
   if (!start || !end) return null;
   return { start, end };
+}
+
+function mapOffsetRangeToVisibleBufferRanges(
+  logicalLine: LogicalLine,
+  startOffset: number,
+  endOffset: number
+): ILink['range'][] {
+  const ranges: ILink['range'][] = [];
+  let lineStartOffset = 0;
+  for (let lineIndex = 0; lineIndex < logicalLine.lineTexts.length; lineIndex += 1) {
+    const lineLength = logicalLine.lineTexts[lineIndex]?.length ?? 0;
+    const lineEndOffset = lineStartOffset + lineLength;
+    const segmentStartOffset = Math.max(startOffset, lineStartOffset);
+    const segmentEndOffset = Math.min(endOffset, lineEndOffset);
+    if (segmentStartOffset < segmentEndOffset) {
+      const xOffset = logicalLine.lineStartColumns[lineIndex] ?? 0;
+      const y = logicalLine.startBufferIndex + lineIndex + 1;
+      ranges.push({
+        start: {
+          x: xOffset + segmentStartOffset - lineStartOffset + 1,
+          y,
+        },
+        end: {
+          x: xOffset + segmentEndOffset - lineStartOffset,
+          y,
+        },
+      });
+    }
+    lineStartOffset = lineEndOffset;
+  }
+  return ranges;
+}
+
+function shouldUseVisibleRanges(ranges: ILink['range'][]): boolean {
+  return ranges.some((range, index) => index > 0 && range.start.x > 1);
+}
+
+function rangeContainsBufferLine(range: ILink['range'], bufferLineNumber: number): boolean {
+  return range.start.y <= bufferLineNumber && range.end.y >= bufferLineNumber;
 }
 
 function mapOffsetToBufferPosition(

--- a/src/renderer/lib/pty/file-link-provider.ts
+++ b/src/renderer/lib/pty/file-link-provider.ts
@@ -1,10 +1,34 @@
 import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm';
 import { findFileLinks, type FileLinkMatch } from './file-link-detection';
 
-let activationModifierPressed = false;
 let activationModifierListenersAttached = false;
 
 type LinkDecorations = NonNullable<ILink['decorations']>;
+type ActivationModifierEvent = Pick<MouseEvent, 'ctrlKey' | 'metaKey'>;
+
+export class ActivationModifierTracker {
+  private pressed = false;
+
+  constructor(private readonly isMac = isMacPlatform()) {}
+
+  decorations(): LinkDecorations {
+    return {
+      pointerCursor: this.pressed,
+      underline: this.pressed,
+    };
+  }
+
+  update(event: ActivationModifierEvent): boolean {
+    this.pressed = isActivationModifierPressed(event, this.isMac);
+    return this.pressed;
+  }
+
+  reset(): void {
+    this.pressed = false;
+  }
+}
+
+const activationModifierTracker = new ActivationModifierTracker();
 
 export class FileLinkProvider implements ILinkProvider {
   constructor(
@@ -23,16 +47,13 @@ export class FileLinkProvider implements ILinkProvider {
   }
 
   private toXtermLink(match: FileLinkMatch): ILink {
-    const decorations: LinkDecorations = {
-      pointerCursor: activationModifierPressed,
-      underline: activationModifierPressed,
-    };
+    const decorations = activationModifierTracker.decorations();
     const link: ILink = {
       range: match.range,
       text: match.text,
       decorations,
       hover: (event) => {
-        setDecorations(link.decorations ?? decorations, isActivationModifierPressed(event));
+        setDecorations(link.decorations ?? decorations, activationModifierTracker.update(event));
       },
       leave: () => {
         setDecorations(link.decorations ?? decorations, false);
@@ -67,21 +88,24 @@ function attachActivationModifierListeners(): void {
   activationModifierListenersAttached = true;
   window.addEventListener('keydown', updateActivationModifierState, true);
   window.addEventListener('keyup', updateActivationModifierState, true);
+  window.addEventListener('mousemove', updateActivationModifierState, true);
+  window.addEventListener('mousedown', updateActivationModifierState, true);
+  window.addEventListener('mouseup', updateActivationModifierState, true);
   window.addEventListener(
     'blur',
     () => {
-      activationModifierPressed = false;
+      activationModifierTracker.reset();
     },
     true
   );
 }
 
-function updateActivationModifierState(event: KeyboardEvent): void {
-  activationModifierPressed = isActivationModifierPressed(event);
+function updateActivationModifierState(event: ActivationModifierEvent): void {
+  activationModifierTracker.update(event);
 }
 
 export function isActivationModifierPressed(
-  event: Pick<MouseEvent, 'ctrlKey' | 'metaKey'>,
+  event: ActivationModifierEvent,
   isMac = isMacPlatform()
 ): boolean {
   return isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;

--- a/src/renderer/lib/pty/file-link-provider.ts
+++ b/src/renderer/lib/pty/file-link-provider.ts
@@ -5,8 +5,12 @@ let activationModifierListenersAttached = false;
 
 type LinkDecorations = NonNullable<ILink['decorations']>;
 type ActivationModifierEvent = Pick<MouseEvent, 'ctrlKey' | 'metaKey'>;
+type NavigatorWithUserAgentData = Navigator & {
+  userAgentData?: { platform?: string };
+};
 
 export class ActivationModifierTracker {
+  private hoveredDecorations: LinkDecorations | null = null;
   private pressed = false;
 
   constructor(private readonly isMac = isMacPlatform()) {}
@@ -20,11 +24,30 @@ export class ActivationModifierTracker {
 
   update(event: ActivationModifierEvent): boolean {
     this.pressed = isActivationModifierPressed(event, this.isMac);
+    this.syncHoveredDecorations();
     return this.pressed;
+  }
+
+  hover(decorations: LinkDecorations, event: ActivationModifierEvent): void {
+    this.hoveredDecorations = decorations;
+    this.update(event);
+  }
+
+  leave(decorations: LinkDecorations): void {
+    if (this.hoveredDecorations === decorations) {
+      this.hoveredDecorations = null;
+    }
+    setDecorations(decorations, false);
   }
 
   reset(): void {
     this.pressed = false;
+    this.syncHoveredDecorations();
+  }
+
+  private syncHoveredDecorations(): void {
+    if (!this.hoveredDecorations) return;
+    setDecorations(this.hoveredDecorations, this.pressed);
   }
 }
 
@@ -53,10 +76,10 @@ export class FileLinkProvider implements ILinkProvider {
       text: match.text,
       decorations,
       hover: (event) => {
-        setDecorations(link.decorations ?? decorations, activationModifierTracker.update(event));
+        activationModifierTracker.hover(link.decorations ?? decorations, event);
       },
       leave: () => {
-        setDecorations(link.decorations ?? decorations, false);
+        activationModifierTracker.leave(link.decorations ?? decorations);
       },
       activate: (event, linkText) => {
         if (!isActivationModifierPressed(event)) return;
@@ -67,7 +90,7 @@ export class FileLinkProvider implements ILinkProvider {
         }
       },
       dispose: () => {
-        setDecorations(link.decorations ?? decorations, false);
+        activationModifierTracker.leave(link.decorations ?? decorations);
       },
     };
     return link;
@@ -112,5 +135,8 @@ export function isActivationModifierPressed(
 }
 
 function isMacPlatform(): boolean {
-  return typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+  if (typeof navigator === 'undefined') return false;
+  const platform =
+    (navigator as NavigatorWithUserAgentData).userAgentData?.platform ?? navigator.platform;
+  return /Mac|iPod|iPhone|iPad/i.test(platform);
 }

--- a/src/renderer/lib/pty/file-link-provider.ts
+++ b/src/renderer/lib/pty/file-link-provider.ts
@@ -23,9 +23,13 @@ export class ActivationModifierTracker {
   }
 
   update(event: ActivationModifierEvent): boolean {
-    this.pressed = isActivationModifierPressed(event, this.isMac);
+    this.pressed = this.isPressed(event);
     this.syncHoveredDecorations();
     return this.pressed;
+  }
+
+  isPressed(event: ActivationModifierEvent): boolean {
+    return isActivationModifierPressed(event, this.isMac);
   }
 
   hover(decorations: LinkDecorations, event: ActivationModifierEvent): void {
@@ -57,7 +61,8 @@ export class FileLinkProvider implements ILinkProvider {
   constructor(
     private readonly terminal: Terminal,
     private readonly onOpenFile: (filePath: string) => void,
-    private readonly onOpenExternal: (filePath: string) => void
+    private readonly onOpenExternal: (filePath: string) => void,
+    private readonly tracker = activationModifierTracker
   ) {
     attachActivationModifierListeners();
   }
@@ -70,19 +75,19 @@ export class FileLinkProvider implements ILinkProvider {
   }
 
   private toXtermLink(match: FileLinkMatch): ILink {
-    const decorations = activationModifierTracker.decorations();
+    const decorations = this.tracker.decorations();
     const link: ILink = {
       range: match.range,
       text: match.text,
       decorations,
       hover: (event) => {
-        activationModifierTracker.hover(link.decorations ?? decorations, event);
+        this.tracker.hover(link.decorations ?? decorations, event);
       },
       leave: () => {
-        activationModifierTracker.leave(link.decorations ?? decorations);
+        this.tracker.leave(link.decorations ?? decorations);
       },
       activate: (event, linkText) => {
-        if (!isActivationModifierPressed(event)) return;
+        if (!this.tracker.isPressed(event)) return;
         if (match.isExternal) {
           this.onOpenExternal(linkText);
         } else {
@@ -90,7 +95,7 @@ export class FileLinkProvider implements ILinkProvider {
         }
       },
       dispose: () => {
-        activationModifierTracker.leave(link.decorations ?? decorations);
+        this.tracker.leave(link.decorations ?? decorations);
       },
     };
     return link;

--- a/src/renderer/lib/pty/file-link-provider.ts
+++ b/src/renderer/lib/pty/file-link-provider.ts
@@ -1,29 +1,10 @@
 import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm';
+import { findFileLinks, type FileLinkMatch } from './file-link-detection';
 
-// Lookbehind on `:` keeps URLs (`https://...`) with WebLinksAddon.
-const FILE_PATH_PATTERN =
-  '(?<![\\w\\-./@:])(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
-const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
-const MAX_WRAPPED_LINE_LENGTH = 4096;
 let activationModifierPressed = false;
 let activationModifierListenersAttached = false;
 
 type LinkDecorations = NonNullable<ILink['decorations']>;
-
-type BufferLineLike = {
-  isWrapped: boolean;
-  translateToString(trimRight?: boolean): string;
-};
-
-type BufferLike = {
-  getLine(index: number): BufferLineLike | undefined;
-};
-
-type FileLinkMatch = {
-  range: ILink['range'];
-  text: string;
-  isExternal: boolean;
-};
 
 export class FileLinkProvider implements ILinkProvider {
   constructor(
@@ -76,12 +57,6 @@ function normalizeFilePath(filePath: string): string {
   return filePath.replace(/^\.\//, '');
 }
 
-function isEmbeddedInUrl(text: string, startCol: number): boolean {
-  const prefix = text.slice(0, startCol);
-  const tokenStart = Math.max(prefix.lastIndexOf(' '), prefix.lastIndexOf('\t'), -1) + 1;
-  return URL_PROTOCOL_PATTERN.test(prefix.slice(tokenStart));
-}
-
 function setDecorations(decorations: LinkDecorations, enabled: boolean): void {
   decorations.pointerCursor = enabled;
   decorations.underline = enabled;
@@ -112,177 +87,6 @@ export function isActivationModifierPressed(
   return isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
 }
 
-export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): FileLinkMatch[] {
-  const logicalLine = getWrappedLogicalLine(buffer, bufferLineNumber - 1);
-  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('/') === -1) {
-    return [];
-  }
-
-  const links: FileLinkMatch[] = [];
-  // Fresh regex per call — module-level /g state isn't safe across reentrancy.
-  const regex = new RegExp(FILE_PATH_PATTERN, 'g');
-  let match: RegExpExecArray | null;
-  while ((match = regex.exec(logicalLine.text)) !== null) {
-    const matched = match[0];
-    const startOffset = match.index;
-    if (isEmbeddedInUrl(logicalLine.text, startOffset)) continue;
-    const endOffset = startOffset + matched.length;
-    const range = mapOffsetRangeToBufferRange(logicalLine, startOffset, endOffset);
-    if (!range) continue;
-
-    links.push({
-      range,
-      text: matched,
-      isExternal: matched.startsWith('~/') || matched.startsWith('/'),
-    });
-  }
-  return links;
-}
-
 function isMacPlatform(): boolean {
   return typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
-}
-
-type LogicalLine = {
-  startBufferIndex: number;
-  lineTexts: string[];
-  lineStartColumns: number[];
-  text: string;
-};
-
-function getWrappedLogicalLine(buffer: BufferLike, bufferIndex: number): LogicalLine | null {
-  const line = buffer.getLine(bufferIndex);
-  if (!line) return null;
-
-  let startBufferIndex = bufferIndex;
-  while (startBufferIndex > 0 && buffer.getLine(startBufferIndex)?.isWrapped) {
-    startBufferIndex -= 1;
-  }
-
-  const lineTexts: string[] = [];
-  const lineStartColumns: number[] = [];
-  let currentIndex = startBufferIndex;
-  let totalLength = 0;
-  while (true) {
-    const currentLine = buffer.getLine(currentIndex);
-    if (!currentLine) break;
-
-    const text = currentLine.translateToString(true);
-    lineTexts.push(text);
-    lineStartColumns.push(0);
-    totalLength += text.length;
-    if (totalLength > MAX_WRAPPED_LINE_LENGTH) return null;
-
-    const nextLine = buffer.getLine(currentIndex + 1);
-    if (!nextLine?.isWrapped) break;
-    currentIndex += 1;
-  }
-
-  return expandHardLineBreakPathContinuations(buffer, {
-    startBufferIndex,
-    lineTexts,
-    lineStartColumns,
-    text: lineTexts.join(''),
-  });
-}
-
-function expandHardLineBreakPathContinuations(
-  buffer: BufferLike,
-  logicalLine: LogicalLine
-): LogicalLine {
-  let expanded = logicalLine;
-  const firstLine = expanded.lineTexts[0];
-  const previousLine = buffer.getLine(expanded.startBufferIndex - 1)?.translateToString(true);
-  if (
-    firstLine !== undefined &&
-    previousLine !== undefined &&
-    endsWithPathContinuation(previousLine) &&
-    startsWithPathContinuation(firstLine)
-  ) {
-    expanded = {
-      startBufferIndex: expanded.startBufferIndex - 1,
-      lineTexts: [
-        previousLine,
-        trimPathContinuationStart(firstLine),
-        ...expanded.lineTexts.slice(1),
-      ],
-      lineStartColumns: [
-        0,
-        countLeadingWhitespace(firstLine),
-        ...expanded.lineStartColumns.slice(1),
-      ],
-      text: '',
-    };
-    expanded.text = expanded.lineTexts.join('');
-  }
-
-  const lastLineIndex = expanded.startBufferIndex + expanded.lineTexts.length - 1;
-  const nextLine = buffer.getLine(lastLineIndex + 1)?.translateToString(true);
-  if (
-    nextLine !== undefined &&
-    endsWithPathContinuation(expanded.text) &&
-    startsWithPathContinuation(nextLine)
-  ) {
-    const trimmedNextLine = trimPathContinuationStart(nextLine);
-    expanded = {
-      startBufferIndex: expanded.startBufferIndex,
-      lineTexts: [...expanded.lineTexts, trimmedNextLine],
-      lineStartColumns: [...expanded.lineStartColumns, countLeadingWhitespace(nextLine)],
-      text: expanded.text + trimmedNextLine,
-    };
-  }
-
-  return expanded.text.length > MAX_WRAPPED_LINE_LENGTH ? logicalLine : expanded;
-}
-
-function endsWithPathContinuation(text: string): boolean {
-  const fragment = trailingToken(text);
-  return fragment.includes('/') && !isEmbeddedInUrl(text, text.length - fragment.length);
-}
-
-function startsWithPathContinuation(text: string): boolean {
-  const trimmed = trimPathContinuationStart(text);
-  return /^[\w.\-@]+(?:\/|[\w.\-@]*\.[a-zA-Z][a-zA-Z0-9]{0,9}\b)/.test(trimmed);
-}
-
-function trimPathContinuationStart(text: string): string {
-  return text.slice(countLeadingWhitespace(text));
-}
-
-function countLeadingWhitespace(text: string): number {
-  return text.length - text.trimStart().length;
-}
-
-function trailingToken(text: string): string {
-  const match = /[^\s([{"'`<]+$/.exec(text);
-  return match?.[0] ?? '';
-}
-
-function mapOffsetRangeToBufferRange(
-  logicalLine: LogicalLine,
-  startOffset: number,
-  endOffset: number
-): ILink['range'] | null {
-  const start = mapOffsetToBufferPosition(logicalLine, startOffset);
-  const end = mapOffsetToBufferPosition(logicalLine, endOffset - 1);
-  if (!start || !end) return null;
-  return { start, end };
-}
-
-function mapOffsetToBufferPosition(
-  logicalLine: LogicalLine,
-  offset: number
-): ILink['range']['start'] | null {
-  let remaining = offset;
-  for (let lineIndex = 0; lineIndex < logicalLine.lineTexts.length; lineIndex += 1) {
-    const lineLength = logicalLine.lineTexts[lineIndex]?.length ?? 0;
-    if (remaining < lineLength) {
-      return {
-        x: (logicalLine.lineStartColumns[lineIndex] ?? 0) + remaining + 1,
-        y: logicalLine.startBufferIndex + lineIndex + 1,
-      };
-    }
-    remaining -= lineLength;
-  }
-  return null;
 }

--- a/src/renderer/lib/pty/file-link-provider.ts
+++ b/src/renderer/lib/pty/file-link-provider.ts
@@ -4,55 +4,71 @@ import type { ILink, ILinkProvider, Terminal } from '@xterm/xterm';
 const FILE_PATH_PATTERN =
   '(?<![\\w\\-./@:])(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
 const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+const MAX_WRAPPED_LINE_LENGTH = 4096;
+let activationModifierPressed = false;
+let activationModifierListenersAttached = false;
+
+type LinkDecorations = NonNullable<ILink['decorations']>;
+
+type BufferLineLike = {
+  isWrapped: boolean;
+  translateToString(trimRight?: boolean): string;
+};
+
+type BufferLike = {
+  getLine(index: number): BufferLineLike | undefined;
+};
+
+type FileLinkMatch = {
+  range: ILink['range'];
+  text: string;
+  isExternal: boolean;
+};
 
 export class FileLinkProvider implements ILinkProvider {
   constructor(
     private readonly terminal: Terminal,
     private readonly onOpenFile: (filePath: string) => void,
     private readonly onOpenExternal: (filePath: string) => void
-  ) {}
+  ) {
+    attachActivationModifierListeners();
+  }
 
   provideLinks(bufferLineNumber: number, callback: (links: ILink[] | undefined) => void): void {
-    const buffer = this.terminal.buffer.active;
-    const line = buffer.getLine(bufferLineNumber - 1);
-    if (!line) {
-      callback(undefined);
-      return;
-    }
-    const text = line.translateToString(true);
-    if (!text || text.indexOf('/') === -1) {
-      callback(undefined);
-      return;
-    }
-
-    const links: ILink[] = [];
-    // Fresh regex per call — module-level /g state isn't safe across reentrancy.
-    const regex = new RegExp(FILE_PATH_PATTERN, 'g');
-    let match: RegExpExecArray | null;
-    while ((match = regex.exec(text)) !== null) {
-      const matched = match[0];
-      const startCol = match.index;
-      if (isEmbeddedInUrl(text, startCol)) continue;
-      const endCol = startCol + matched.length;
-      const isExternal = matched.startsWith('~/') || matched.startsWith('/');
-
-      links.push({
-        range: {
-          start: { x: startCol + 1, y: bufferLineNumber },
-          end: { x: endCol, y: bufferLineNumber },
-        },
-        text: matched,
-        decorations: { pointerCursor: true, underline: true },
-        activate: (_event, linkText) => {
-          if (isExternal) {
-            this.onOpenExternal(linkText);
-          } else {
-            this.onOpenFile(normalizeFilePath(linkText));
-          }
-        },
-      });
-    }
+    const links = findFileLinks(this.terminal.buffer.active, bufferLineNumber).map((match) =>
+      this.toXtermLink(match)
+    );
     callback(links.length > 0 ? links : undefined);
+  }
+
+  private toXtermLink(match: FileLinkMatch): ILink {
+    const decorations: LinkDecorations = {
+      pointerCursor: activationModifierPressed,
+      underline: activationModifierPressed,
+    };
+    const link: ILink = {
+      range: match.range,
+      text: match.text,
+      decorations,
+      hover: (event) => {
+        setDecorations(link.decorations ?? decorations, isActivationModifierPressed(event));
+      },
+      leave: () => {
+        setDecorations(link.decorations ?? decorations, false);
+      },
+      activate: (event, linkText) => {
+        if (!isActivationModifierPressed(event)) return;
+        if (match.isExternal) {
+          this.onOpenExternal(linkText);
+        } else {
+          this.onOpenFile(normalizeFilePath(linkText));
+        }
+      },
+      dispose: () => {
+        setDecorations(link.decorations ?? decorations, false);
+      },
+    };
+    return link;
   }
 }
 
@@ -64,4 +80,209 @@ function isEmbeddedInUrl(text: string, startCol: number): boolean {
   const prefix = text.slice(0, startCol);
   const tokenStart = Math.max(prefix.lastIndexOf(' '), prefix.lastIndexOf('\t'), -1) + 1;
   return URL_PROTOCOL_PATTERN.test(prefix.slice(tokenStart));
+}
+
+function setDecorations(decorations: LinkDecorations, enabled: boolean): void {
+  decorations.pointerCursor = enabled;
+  decorations.underline = enabled;
+}
+
+function attachActivationModifierListeners(): void {
+  if (activationModifierListenersAttached || typeof window === 'undefined') return;
+  activationModifierListenersAttached = true;
+  window.addEventListener('keydown', updateActivationModifierState, true);
+  window.addEventListener('keyup', updateActivationModifierState, true);
+  window.addEventListener(
+    'blur',
+    () => {
+      activationModifierPressed = false;
+    },
+    true
+  );
+}
+
+function updateActivationModifierState(event: KeyboardEvent): void {
+  activationModifierPressed = isActivationModifierPressed(event);
+}
+
+export function isActivationModifierPressed(
+  event: Pick<MouseEvent, 'ctrlKey' | 'metaKey'>,
+  isMac = isMacPlatform()
+): boolean {
+  return isMac ? event.metaKey && !event.ctrlKey : event.ctrlKey && !event.metaKey;
+}
+
+export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): FileLinkMatch[] {
+  const logicalLine = getWrappedLogicalLine(buffer, bufferLineNumber - 1);
+  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('/') === -1) {
+    return [];
+  }
+
+  const links: FileLinkMatch[] = [];
+  // Fresh regex per call — module-level /g state isn't safe across reentrancy.
+  const regex = new RegExp(FILE_PATH_PATTERN, 'g');
+  let match: RegExpExecArray | null;
+  while ((match = regex.exec(logicalLine.text)) !== null) {
+    const matched = match[0];
+    const startOffset = match.index;
+    if (isEmbeddedInUrl(logicalLine.text, startOffset)) continue;
+    const endOffset = startOffset + matched.length;
+    const range = mapOffsetRangeToBufferRange(logicalLine, startOffset, endOffset);
+    if (!range) continue;
+
+    links.push({
+      range,
+      text: matched,
+      isExternal: matched.startsWith('~/') || matched.startsWith('/'),
+    });
+  }
+  return links;
+}
+
+function isMacPlatform(): boolean {
+  return typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.platform);
+}
+
+type LogicalLine = {
+  startBufferIndex: number;
+  lineTexts: string[];
+  lineStartColumns: number[];
+  text: string;
+};
+
+function getWrappedLogicalLine(buffer: BufferLike, bufferIndex: number): LogicalLine | null {
+  const line = buffer.getLine(bufferIndex);
+  if (!line) return null;
+
+  let startBufferIndex = bufferIndex;
+  while (startBufferIndex > 0 && buffer.getLine(startBufferIndex)?.isWrapped) {
+    startBufferIndex -= 1;
+  }
+
+  const lineTexts: string[] = [];
+  const lineStartColumns: number[] = [];
+  let currentIndex = startBufferIndex;
+  let totalLength = 0;
+  while (true) {
+    const currentLine = buffer.getLine(currentIndex);
+    if (!currentLine) break;
+
+    const text = currentLine.translateToString(true);
+    lineTexts.push(text);
+    lineStartColumns.push(0);
+    totalLength += text.length;
+    if (totalLength > MAX_WRAPPED_LINE_LENGTH) return null;
+
+    const nextLine = buffer.getLine(currentIndex + 1);
+    if (!nextLine?.isWrapped) break;
+    currentIndex += 1;
+  }
+
+  return expandHardLineBreakPathContinuations(buffer, {
+    startBufferIndex,
+    lineTexts,
+    lineStartColumns,
+    text: lineTexts.join(''),
+  });
+}
+
+function expandHardLineBreakPathContinuations(
+  buffer: BufferLike,
+  logicalLine: LogicalLine
+): LogicalLine {
+  let expanded = logicalLine;
+  const firstLine = expanded.lineTexts[0];
+  const previousLine = buffer.getLine(expanded.startBufferIndex - 1)?.translateToString(true);
+  if (
+    firstLine !== undefined &&
+    previousLine !== undefined &&
+    endsWithPathContinuation(previousLine) &&
+    startsWithPathContinuation(firstLine)
+  ) {
+    expanded = {
+      startBufferIndex: expanded.startBufferIndex - 1,
+      lineTexts: [
+        previousLine,
+        trimPathContinuationStart(firstLine),
+        ...expanded.lineTexts.slice(1),
+      ],
+      lineStartColumns: [
+        0,
+        countLeadingWhitespace(firstLine),
+        ...expanded.lineStartColumns.slice(1),
+      ],
+      text: '',
+    };
+    expanded.text = expanded.lineTexts.join('');
+  }
+
+  const lastLineIndex = expanded.startBufferIndex + expanded.lineTexts.length - 1;
+  const nextLine = buffer.getLine(lastLineIndex + 1)?.translateToString(true);
+  if (
+    nextLine !== undefined &&
+    endsWithPathContinuation(expanded.text) &&
+    startsWithPathContinuation(nextLine)
+  ) {
+    const trimmedNextLine = trimPathContinuationStart(nextLine);
+    expanded = {
+      startBufferIndex: expanded.startBufferIndex,
+      lineTexts: [...expanded.lineTexts, trimmedNextLine],
+      lineStartColumns: [...expanded.lineStartColumns, countLeadingWhitespace(nextLine)],
+      text: expanded.text + trimmedNextLine,
+    };
+  }
+
+  return expanded.text.length > MAX_WRAPPED_LINE_LENGTH ? logicalLine : expanded;
+}
+
+function endsWithPathContinuation(text: string): boolean {
+  const fragment = trailingToken(text);
+  return fragment.includes('/') && !isEmbeddedInUrl(text, text.length - fragment.length);
+}
+
+function startsWithPathContinuation(text: string): boolean {
+  const trimmed = trimPathContinuationStart(text);
+  return /^[\w.\-@]+(?:\/|[\w.\-@]*\.[a-zA-Z][a-zA-Z0-9]{0,9}\b)/.test(trimmed);
+}
+
+function trimPathContinuationStart(text: string): string {
+  return text.slice(countLeadingWhitespace(text));
+}
+
+function countLeadingWhitespace(text: string): number {
+  return text.length - text.trimStart().length;
+}
+
+function trailingToken(text: string): string {
+  const match = /[^\s([{"'`<]+$/.exec(text);
+  return match?.[0] ?? '';
+}
+
+function mapOffsetRangeToBufferRange(
+  logicalLine: LogicalLine,
+  startOffset: number,
+  endOffset: number
+): ILink['range'] | null {
+  const start = mapOffsetToBufferPosition(logicalLine, startOffset);
+  const end = mapOffsetToBufferPosition(logicalLine, endOffset - 1);
+  if (!start || !end) return null;
+  return { start, end };
+}
+
+function mapOffsetToBufferPosition(
+  logicalLine: LogicalLine,
+  offset: number
+): ILink['range']['start'] | null {
+  let remaining = offset;
+  for (let lineIndex = 0; lineIndex < logicalLine.lineTexts.length; lineIndex += 1) {
+    const lineLength = logicalLine.lineTexts[lineIndex]?.length ?? 0;
+    if (remaining < lineLength) {
+      return {
+        x: (logicalLine.lineStartColumns[lineIndex] ?? 0) + remaining + 1,
+        y: logicalLine.startBufferIndex + lineIndex + 1,
+      };
+    }
+    remaining -= lineLength;
+  }
+  return null;
 }

--- a/src/renderer/tests/file-link-provider.test.ts
+++ b/src/renderer/tests/file-link-provider.test.ts
@@ -164,7 +164,8 @@ describe('file link provider', () => {
     const provider = new FileLinkProvider(
       { buffer: { active: buffer } } as never,
       (filePath) => openedFiles.push(filePath),
-      (filePath) => openedExternal.push(filePath)
+      (filePath) => openedExternal.push(filePath),
+      new ActivationModifierTracker(true)
     );
 
     let links: ILink[] = [];

--- a/src/renderer/tests/file-link-provider.test.ts
+++ b/src/renderer/tests/file-link-provider.test.ts
@@ -86,6 +86,16 @@ describe('file link provider', () => {
     expect(findFileLinks(buffer, 2)).toEqual([]);
   });
 
+  it('does not join backward from the middle of a wrapped line chain', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('src/foo/'),
+      new MockBufferLine('bar/', true),
+      new MockBufferLine('  baz.ts'),
+    ]);
+
+    expect(findFileLinks(buffer, 3)).toEqual([]);
+  });
+
   it('classifies absolute and home-relative paths as external', () => {
     const buffer = makeBuffer([
       new MockBufferLine('open /tmp/output/report.md and ~/notes/todo.md'),

--- a/src/renderer/tests/file-link-provider.test.ts
+++ b/src/renderer/tests/file-link-provider.test.ts
@@ -2,6 +2,7 @@ import type { ILink } from '@xterm/xterm';
 import { describe, expect, it } from 'vitest';
 import { findFileLinks } from '@renderer/lib/pty/file-link-detection';
 import {
+  ActivationModifierTracker,
   FileLinkProvider,
   isActivationModifierPressed,
 } from '@renderer/lib/pty/file-link-provider';
@@ -115,6 +116,16 @@ describe('file link provider', () => {
     expect(isActivationModifierPressed({ metaKey: true, ctrlKey: false }, false)).toBe(false);
     expect(isActivationModifierPressed({ metaKey: true, ctrlKey: true }, true)).toBe(false);
     expect(isActivationModifierPressed({ metaKey: true, ctrlKey: true }, false)).toBe(false);
+  });
+
+  it('clears initial underline decorations from mouse events without the modifier', () => {
+    const tracker = new ActivationModifierTracker(true);
+
+    expect(tracker.update({ metaKey: true, ctrlKey: false })).toBe(true);
+    expect(tracker.decorations()).toEqual({ pointerCursor: true, underline: true });
+
+    expect(tracker.update({ metaKey: false, ctrlKey: false })).toBe(false);
+    expect(tracker.decorations()).toEqual({ pointerCursor: false, underline: false });
   });
 
   it('only opens links when the activation modifier is pressed', () => {

--- a/src/renderer/tests/file-link-provider.test.ts
+++ b/src/renderer/tests/file-link-provider.test.ts
@@ -56,16 +56,24 @@ describe('file link provider', () => {
       ),
     ]);
 
-    const expectedLink = {
+    const expectedFirstLineLink = {
       range: {
         start: { x: 66, y: 1 },
+        end: { x: 79, y: 1 },
+      },
+      text: 'src/main/core/conversations/impl/local-conversation.ts',
+      isExternal: false,
+    };
+    const expectedSecondLineLink = {
+      range: {
+        start: { x: 3, y: 2 },
         end: { x: 42, y: 2 },
       },
       text: 'src/main/core/conversations/impl/local-conversation.ts',
       isExternal: false,
     };
-    expect(findFileLinks(buffer, 1)).toEqual([expectedLink]);
-    expect(findFileLinks(buffer, 2)).toEqual([expectedLink]);
+    expect(findFileLinks(buffer, 1)).toEqual([expectedFirstLineLink]);
+    expect(findFileLinks(buffer, 2)).toEqual([expectedSecondLineLink]);
   });
 
   it('does not join unrelated hard line breaks', () => {

--- a/src/renderer/tests/file-link-provider.test.ts
+++ b/src/renderer/tests/file-link-provider.test.ts
@@ -136,6 +136,17 @@ describe('file link provider', () => {
     expect(tracker.decorations()).toEqual({ pointerCursor: false, underline: false });
   });
 
+  it('updates hovered decorations when the modifier changes without mouse movement', () => {
+    const tracker = new ActivationModifierTracker(true);
+    const decorations = tracker.decorations();
+
+    tracker.hover(decorations, { metaKey: true, ctrlKey: false });
+    expect(decorations).toEqual({ pointerCursor: true, underline: true });
+
+    tracker.update({ metaKey: false, ctrlKey: false });
+    expect(decorations).toEqual({ pointerCursor: false, underline: false });
+  });
+
   it('only opens links when the activation modifier is pressed', () => {
     const openedFiles: string[] = [];
     const openedExternal: string[] = [];

--- a/src/renderer/tests/file-link-provider.test.ts
+++ b/src/renderer/tests/file-link-provider.test.ts
@@ -1,0 +1,146 @@
+import type { ILink } from '@xterm/xterm';
+import { describe, expect, it } from 'vitest';
+import {
+  FileLinkProvider,
+  findFileLinks,
+  isActivationModifierPressed,
+} from '@renderer/lib/pty/file-link-provider';
+
+class MockBufferLine {
+  constructor(
+    private readonly text: string,
+    readonly isWrapped = false
+  ) {}
+
+  translateToString(): string {
+    return this.text;
+  }
+}
+
+function makeBuffer(lines: MockBufferLine[]) {
+  return {
+    getLine(index: number): MockBufferLine | undefined {
+      return lines[index];
+    },
+  };
+}
+
+describe('file link provider', () => {
+  it('detects one path across wrapped terminal lines', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('error in src/renderer/lib/pty/file-link-'),
+      new MockBufferLine('provider.ts', true),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([
+      {
+        range: {
+          start: { x: 10, y: 1 },
+          end: { x: 11, y: 2 },
+        },
+        text: 'src/renderer/lib/pty/file-link-provider.ts',
+        isExternal: false,
+      },
+    ]);
+    expect(findFileLinks(buffer, 2)[0]?.text).toBe('src/renderer/lib/pty/file-link-provider.ts');
+  });
+
+  it('detects one path split by adjacent hard line breaks', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine(
+        '  Local agents do not use the terminal shell resolver at all. In src/main/core/'
+      ),
+      new MockBufferLine(
+        '  conversations/impl/local-conversation.ts:140, agent sessions call resolveLocalPtySpawn'
+      ),
+    ]);
+
+    const expectedLink = {
+      range: {
+        start: { x: 66, y: 1 },
+        end: { x: 42, y: 2 },
+      },
+      text: 'src/main/core/conversations/impl/local-conversation.ts',
+      isExternal: false,
+    };
+    expect(findFileLinks(buffer, 1)).toEqual([expectedLink]);
+    expect(findFileLinks(buffer, 2)).toEqual([expectedLink]);
+  });
+
+  it('does not join unrelated hard line breaks', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('  See src/main/core/'),
+      new MockBufferLine('  for more implementation details.'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+    expect(findFileLinks(buffer, 2)).toEqual([]);
+  });
+
+  it('classifies absolute and home-relative paths as external', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('open /tmp/output/report.md and ~/notes/todo.md'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([
+      {
+        range: {
+          start: { x: 6, y: 1 },
+          end: { x: 26, y: 1 },
+        },
+        text: '/tmp/output/report.md',
+        isExternal: true,
+      },
+      {
+        range: {
+          start: { x: 32, y: 1 },
+          end: { x: 46, y: 1 },
+        },
+        text: '~/notes/todo.md',
+        isExternal: true,
+      },
+    ]);
+  });
+
+  it('keeps URL paths delegated to the web links addon', () => {
+    const buffer = makeBuffer([new MockBufferLine('see https://example.com/src/file.ts')]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('requires Command on macOS and Control elsewhere', () => {
+    expect(isActivationModifierPressed({ metaKey: true, ctrlKey: false }, true)).toBe(true);
+    expect(isActivationModifierPressed({ metaKey: false, ctrlKey: true }, true)).toBe(false);
+    expect(isActivationModifierPressed({ metaKey: false, ctrlKey: true }, false)).toBe(true);
+    expect(isActivationModifierPressed({ metaKey: true, ctrlKey: false }, false)).toBe(false);
+    expect(isActivationModifierPressed({ metaKey: true, ctrlKey: true }, true)).toBe(false);
+    expect(isActivationModifierPressed({ metaKey: true, ctrlKey: true }, false)).toBe(false);
+  });
+
+  it('only opens links when the activation modifier is pressed', () => {
+    const openedFiles: string[] = [];
+    const openedExternal: string[] = [];
+    const buffer = makeBuffer([new MockBufferLine('open ./src/app.ts and /tmp/report.md')]);
+    const provider = new FileLinkProvider(
+      { buffer: { active: buffer } } as never,
+      (filePath) => openedFiles.push(filePath),
+      (filePath) => openedExternal.push(filePath)
+    );
+
+    let links: ILink[] = [];
+    provider.provideLinks(1, (providedLinks) => {
+      links = providedLinks ?? [];
+    });
+
+    const relativeLink = links[0]!;
+    relativeLink.activate({ metaKey: false, ctrlKey: false } as MouseEvent, relativeLink.text);
+    relativeLink.activate({ metaKey: true, ctrlKey: false } as MouseEvent, relativeLink.text);
+
+    const externalLink = links[1]!;
+    externalLink.activate({ metaKey: false, ctrlKey: false } as MouseEvent, externalLink.text);
+    externalLink.activate({ metaKey: true, ctrlKey: false } as MouseEvent, externalLink.text);
+
+    expect(openedFiles).toEqual(['src/app.ts']);
+    expect(openedExternal).toEqual(['/tmp/report.md']);
+  });
+});

--- a/src/renderer/tests/file-link-provider.test.ts
+++ b/src/renderer/tests/file-link-provider.test.ts
@@ -1,8 +1,8 @@
 import type { ILink } from '@xterm/xterm';
 import { describe, expect, it } from 'vitest';
+import { findFileLinks } from '@renderer/lib/pty/file-link-detection';
 import {
   FileLinkProvider,
-  findFileLinks,
   isActivationModifierPressed,
 } from '@renderer/lib/pty/file-link-provider';
 


### PR DESCRIPTION
- require command on macOS and control elsewhere before terminal file links show pointer underline or open
- detect file paths split across wrapped and adjacent terminal lines
- split indented multi-line link ranges so underline starts at visible path text