### PR TITLE
fix(pty): use latest PowerShell for local agents

### DIFF
--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -80,11 +80,20 @@ vi.mock('@main/core/settings/provider-settings-service', () => ({
 
 vi.mock('@main/core/settings/settings-service', () => ({
   appSettingsService: {
-    get: vi.fn(async () => ({ writeAgentConfigToGitIgnore: true })),
+    get: vi.fn(async (key: string) =>
+      key === 'terminal'
+        ? { autoCopyOnSelection: false, defaultShell: 'system', fontSize: 13 }
+        : {
+            defaultProjectsDirectory: '',
+            defaultWorktreeDirectory: '',
+            writeAgentConfigToGitIgnore: true,
+          }
+    ),
   },
 }));
 
 const { events } = await import('@main/lib/events');
+const { appSettingsService } = await import('@main/core/settings/settings-service');
 const { buildAgentSessionCommand } = await import('./agent-command');
 
 type RespawnState = {
@@ -94,9 +103,20 @@ type RespawnState = {
 
 function localProvider({
   tmux = false,
+  shellProfile = {
+    id: 'sh',
+    resolvedShellId: 'sh',
+    resolvedFromSystem: true,
+    executable: 'sh',
+    available: true,
+    family: 'posix',
+    interactiveArgs: ['-i'],
+    commandArgs: ['-c'],
+  },
   ctx = {} as never,
 }: {
   tmux?: boolean;
+  shellProfile?: ConstructorParameters<typeof LocalConversationProvider>[0]['shellProfile'];
   ctx?: ConstructorParameters<typeof LocalConversationProvider>[0]['ctx'];
 } = {}) {
   return new LocalConversationProvider({
@@ -104,6 +124,7 @@ function localProvider({
     taskId: 'task-1',
     taskPath: '/tmp/task-1',
     tmux,
+    shellProfile,
     ctx,
   });
 }
@@ -151,11 +172,25 @@ function fakePty(exitHandlers: Array<(info: PtyExitInfo) => void>): Pty {
   };
 }
 
+function mockSettings(): void {
+  vi.mocked(appSettingsService.get).mockImplementation(async (key) => {
+    if (key === 'localProject') {
+      return {
+        defaultProjectsDirectory: '',
+        defaultWorktreeDirectory: '',
+        writeAgentConfigToGitIgnore: true,
+      } as never;
+    }
+    throw new Error(`Unexpected settings key: ${key}`);
+  });
+}
+
 describe('conversation provider respawn state', () => {
   beforeEach(() => {
     vi.useRealTimers();
     spawnLocalPty.mockReset();
     openSsh2Pty.mockReset();
+    mockSettings();
     vi.mocked(events.emit).mockClear();
     vi.mocked(buildAgentSessionCommand).mockClear();
     ptySessionRegistry.unregister('project-1:task-1:conversation-1');
@@ -180,6 +215,31 @@ describe('conversation provider respawn state', () => {
         process.env.EDITOR = previousEditor;
       }
     }
+  });
+
+  it('uses the injected shell profile for local agent sessions', async () => {
+    const shellProfile: ConstructorParameters<typeof LocalConversationProvider>[0]['shellProfile'] =
+      {
+        id: 'bash',
+        resolvedShellId: 'bash',
+        resolvedFromSystem: false,
+        executable: 'bash',
+        available: true,
+        family: 'posix',
+        interactiveArgs: ['-il'],
+        commandArgs: ['-lc'],
+      };
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+
+    await localProvider({ shellProfile }).startSession(conversation());
+
+    expect(spawnLocalPty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'bash',
+        args: ['-lc', 'agent'],
+      })
+    );
   });
 
   it('replaces a local conversation after clean exit by resuming the same provider session', async () => {

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -198,8 +198,10 @@ describe('conversation provider respawn state', () => {
 
   it('passes global editor variables to local agent sessions', async () => {
     const previousEditor = process.env.EDITOR;
+    const previousShell = process.env.SHELL;
     try {
       process.env.EDITOR = 'zed';
+      process.env.SHELL = '/bin/zsh';
       const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
       spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
 
@@ -207,12 +209,17 @@ describe('conversation provider respawn state', () => {
 
       const request = spawnLocalPty.mock.calls[0][0] as { env: Record<string, string> };
       expect(request.env.EDITOR).toBe('zed');
-      expect(request.env.SHELL).toBeUndefined();
+      expect(request.env.SHELL).toBe('sh');
     } finally {
       if (previousEditor === undefined) {
         delete process.env.EDITOR;
       } else {
         process.env.EDITOR = previousEditor;
+      }
+      if (previousShell === undefined) {
+        delete process.env.SHELL;
+      } else {
+        process.env.SHELL = previousShell;
       }
     }
   });
@@ -238,6 +245,30 @@ describe('conversation provider respawn state', () => {
       expect.objectContaining({
         command: 'bash',
         args: ['-lc', 'agent'],
+      })
+    );
+  });
+
+  it('sets SHELL to the injected POSIX shell for local agent sessions', async () => {
+    const shellProfile: ConstructorParameters<typeof LocalConversationProvider>[0]['shellProfile'] =
+      {
+        id: 'bash',
+        resolvedShellId: 'bash',
+        resolvedFromSystem: false,
+        executable: '/bin/bash',
+        available: true,
+        family: 'posix',
+        interactiveArgs: ['-il'],
+        commandArgs: ['-lc'],
+      };
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+
+    await localProvider({ shellProfile }).startSession(conversation());
+
+    expect(spawnLocalPty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        env: expect.objectContaining({ SHELL: '/bin/bash' }),
       })
     );
   });

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -16,6 +16,7 @@ import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/p
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import { appSettingsService } from '@main/core/settings/settings-service';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
@@ -42,6 +43,7 @@ export class LocalConversationProvider implements ConversationProvider {
   private readonly taskId: string;
   private readonly tmux: boolean;
   private readonly shellSetup?: string;
+  private readonly shellProfile: ResolvedShellProfile;
   private readonly ctx: IExecutionContext;
   private readonly taskEnvVars: Record<string, string>;
   private readonly hookConfigWriter: HookConfigWriter;
@@ -56,6 +58,7 @@ export class LocalConversationProvider implements ConversationProvider {
     taskId,
     tmux = false,
     shellSetup,
+    shellProfile,
     ctx,
     taskEnvVars = {},
   }: {
@@ -64,6 +67,7 @@ export class LocalConversationProvider implements ConversationProvider {
     taskId: string;
     tmux?: boolean;
     shellSetup?: string;
+    shellProfile: ResolvedShellProfile;
     ctx: IExecutionContext;
     taskEnvVars?: Record<string, string>;
   }) {
@@ -72,6 +76,7 @@ export class LocalConversationProvider implements ConversationProvider {
     this.taskId = taskId;
     this.tmux = tmux;
     this.shellSetup = shellSetup;
+    this.shellProfile = shellProfile;
     this.ctx = ctx;
     this.taskEnvVars = taskEnvVars;
     this.hookConfigWriter = new HookConfigWriter(new LocalFileSystem(taskPath), ctx);
@@ -144,6 +149,7 @@ export class LocalConversationProvider implements ConversationProvider {
           kind: 'run-command',
           cwd: this.taskPath,
           command: { kind: 'argv', command, args },
+          shellProfile: this.shellProfile,
           shellSetup: this.shellSetup,
           tmuxSessionName,
         },

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -178,6 +178,7 @@ export class LocalConversationProvider implements ConversationProvider {
           ...buildAgentEnv({
             hook: port > 0 ? { port, ptyId, token } : undefined,
             providerVars: providerEnv,
+            shellProfile: this.shellProfile,
           }),
           ...this.taskEnvVars,
           ...(ampHooksAvailable && !this.taskEnvVars['PLUGINS'] ? { PLUGINS: 'all' } : {}),

--- a/src/main/core/dependencies/dependency-manager.test.ts
+++ b/src/main/core/dependencies/dependency-manager.test.ts
@@ -3,6 +3,16 @@ import type { IExecutionContext } from '@main/core/execution-context/types';
 import { err, ok } from '@shared/result';
 import { DependencyManager } from './dependency-manager';
 
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: {
+    get: vi.fn(async () => ({
+      autoCopyOnSelection: false,
+      defaultShell: 'system',
+      fontSize: 13,
+    })),
+  },
+}));
+
 vi.mock('@main/lib/events', () => ({
   events: {
     emit: vi.fn(),

--- a/src/main/core/dependencies/dependency-manager.ts
+++ b/src/main/core/dependencies/dependency-manager.ts
@@ -246,12 +246,6 @@ export class DependencyManager implements IInitializable {
 async function resolveLocalInstallShellProfile() {
   return await resolveLocalAutomationShellWithSystemFallback({
     intent: 'system',
-    onFallback: (error) => {
-      log.warn('[DependencyManager] Preferred install shell unavailable, using fallback', {
-        shell: error.shell,
-        target: error.target,
-      });
-    },
   });
 }
 

--- a/src/main/core/dependencies/dependency-manager.ts
+++ b/src/main/core/dependencies/dependency-manager.ts
@@ -1,6 +1,7 @@
 import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
 import { SshExecutionContext } from '@main/core/execution-context/ssh-execution-context';
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import { appSettingsService } from '@main/core/settings/settings-service';
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
 import { resolveLocalAutomationShellWithSystemFallback } from '@main/core/terminal-shell/resolver';
 import { events } from '@main/lib/events';
@@ -244,8 +245,15 @@ export class DependencyManager implements IInitializable {
 }
 
 async function resolveLocalInstallShellProfile() {
+  const { defaultShell } = await appSettingsService.get('terminal');
   return await resolveLocalAutomationShellWithSystemFallback({
-    intent: 'system',
+    intent: defaultShell,
+    onFallback: (error) => {
+      log.warn('[DependencyManager] Preferred install shell unavailable, using fallback', {
+        shell: error.shell,
+        target: error.target,
+      });
+    },
   });
 }
 

--- a/src/main/core/dependencies/dependency-manager.ts
+++ b/src/main/core/dependencies/dependency-manager.ts
@@ -2,6 +2,7 @@ import { LocalExecutionContext } from '@main/core/execution-context/local-execut
 import { SshExecutionContext } from '@main/core/execution-context/ssh-execution-context';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
+import { resolveLocalAutomationShellWithSystemFallback } from '@main/core/terminal-shell/resolver';
 import { events } from '@main/lib/events';
 import type { IInitializable } from '@main/lib/lifecycle';
 import { log } from '@main/lib/logger';
@@ -15,8 +16,8 @@ import type {
 import { dependencyStatusUpdatedChannel } from '@shared/events/appEvents';
 import { err, ok } from '@shared/result';
 import {
+  createLocalInstallCommandRunner,
   createSshInstallCommandRunner,
-  runLocalInstallCommand,
   type InstallCommandRunner,
 } from './install-runner';
 import { resolveCommandPath, runVersionProbe } from './probe';
@@ -87,7 +88,7 @@ export class DependencyManager implements IInitializable {
     ctx: IExecutionContext,
     {
       emitEvents = true,
-      runInstallCommand = runLocalInstallCommand,
+      runInstallCommand = createLocalInstallCommandRunner(resolveLocalInstallShellProfile),
       connectionId,
     }: {
       emitEvents?: boolean;
@@ -240,6 +241,18 @@ export class DependencyManager implements IInitializable {
       });
     }
   }
+}
+
+async function resolveLocalInstallShellProfile() {
+  return await resolveLocalAutomationShellWithSystemFallback({
+    intent: 'system',
+    onFallback: (error) => {
+      log.warn('[DependencyManager] Preferred install shell unavailable, using fallback', {
+        shell: error.shell,
+        target: error.target,
+      });
+    },
+  });
 }
 
 export const localDependencyManager = new DependencyManager(new LocalExecutionContext());

--- a/src/main/core/dependencies/install-runner.test.ts
+++ b/src/main/core/dependencies/install-runner.test.ts
@@ -1,8 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LocalSpawnOptions } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import {
   classifyInstallCommandFailure,
+  createLocalInstallCommandRunner,
   createSshInstallCommandRunner,
   runLocalInstallCommand,
 } from './install-runner';
@@ -44,6 +46,28 @@ function createSuccessfulPty(): Pty {
     onExit: vi.fn((handler) => handler({ exitCode: 0 })),
   };
 }
+
+const cmdProfile: ResolvedShellProfile = {
+  id: 'target-default',
+  resolvedShellId: 'cmd',
+  resolvedFromSystem: true,
+  executable: 'C:\\Windows\\System32\\cmd.exe',
+  available: true,
+  family: 'windows-cmd',
+  interactiveArgs: [],
+  commandArgs: ['/d', '/s', '/c'],
+};
+
+const pwshProfile: ResolvedShellProfile = {
+  id: 'pwsh',
+  resolvedShellId: 'pwsh',
+  resolvedFromSystem: false,
+  executable: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+  available: true,
+  family: 'powershell',
+  interactiveArgs: [],
+  commandArgs: ['-NoLogo', '-Command'],
+};
 
 beforeEach(() => {
   mocks.spawnLocalPty.mockReturnValue(createSuccessfulPty());
@@ -96,7 +120,7 @@ describe('runLocalInstallCommand', () => {
     delete process.env.SHELL;
     process.env.ComSpec = 'C:\\Windows\\System32\\cmd.exe';
 
-    const result = await runLocalInstallCommand('npm install -g @openai/codex');
+    const result = await runLocalInstallCommand('npm install -g @openai/codex', cmdProfile);
 
     expect(result.success).toBe(true);
     expect(mocks.spawnLocalPty).toHaveBeenCalledWith(
@@ -105,6 +129,37 @@ describe('runLocalInstallCommand', () => {
         args: ['/d', '/s', '/c', 'npm install -g @openai/codex'],
         cwd: expect.any(String),
       } satisfies Partial<LocalSpawnOptions>)
+    );
+  });
+
+  it('runs Windows installs through the preferred automation PowerShell', async () => {
+    setPlatform('win32');
+
+    const result = await runLocalInstallCommand('npm install -g @openai/codex', pwshProfile);
+
+    expect(result.success).toBe(true);
+    expect(mocks.spawnLocalPty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+        args: ['-NoLogo', '-Command', 'npm install -g @openai/codex'],
+        cwd: expect.any(String),
+      } satisfies Partial<LocalSpawnOptions>)
+    );
+  });
+
+  it('resolves the local install shell outside the low-level runner', async () => {
+    setPlatform('win32');
+    const resolveShellProfile = vi.fn(async () => pwshProfile);
+    const runner = createLocalInstallCommandRunner(resolveShellProfile);
+
+    const result = await runner('npm install -g @openai/codex');
+
+    expect(result.success).toBe(true);
+    expect(resolveShellProfile).toHaveBeenCalledWith();
+    expect(mocks.spawnLocalPty).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      })
     );
   });
 });

--- a/src/main/core/dependencies/install-runner.ts
+++ b/src/main/core/dependencies/install-runner.ts
@@ -5,6 +5,7 @@ import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/p
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { buildRemoteShellCommand } from '@main/core/ssh/lifecycle/remote-shell-profile';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { log } from '@main/lib/logger';
 import { ensureUserBinDirsInPath } from '@main/utils/userEnv';
 import type { InstallCommandError } from '@shared/dependencies';
@@ -13,6 +14,8 @@ import { err, ok, type Result } from '@shared/result';
 export type InstallCommandRunner<TData = void, TError = InstallCommandError> = (
   command: string
 ) => Promise<Result<TData, TError>>;
+
+type ShellProfileResolver = () => Promise<ResolvedShellProfile>;
 
 const ANSI_RE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
 
@@ -59,8 +62,9 @@ function waitForInstallPty(pty: Pty): Promise<Result<void, InstallCommandError>>
   });
 }
 
-export function runLocalInstallCommand(
-  command: string
+export async function runLocalInstallCommand(
+  command: string,
+  shellProfile: ResolvedShellProfile
 ): Promise<Result<void, InstallCommandError>> {
   const installId = `install:${crypto.randomUUID()}`;
   const resolved = resolveLocalPtySpawn({
@@ -70,6 +74,7 @@ export function runLocalInstallCommand(
       kind: 'run-command',
       cwd: os.homedir(),
       command: { kind: 'shell-line', commandLine: command },
+      shellProfile,
     },
   });
   logLocalPtySpawnWarnings('DependencyManager', resolved.warnings, { installId });
@@ -96,6 +101,15 @@ export function runLocalInstallCommand(
     }
     return result;
   });
+}
+
+export function createLocalInstallCommandRunner(
+  resolveShellProfile: ShellProfileResolver
+): InstallCommandRunner {
+  return async (command) => {
+    const shellProfile = await resolveShellProfile();
+    return await runLocalInstallCommand(command, shellProfile);
+  };
 }
 
 export function createSshInstallCommandRunner(proxy: SshClientProxy): InstallCommandRunner {

--- a/src/main/core/pty/pty-env.test.ts
+++ b/src/main/core/pty/pty-env.test.ts
@@ -93,6 +93,28 @@ describe('buildAgentEnv provider env forwarding', () => {
     expect(buildAgentEnv({ agentApiVars: false, includeShellVar: true }).SHELL).toBe('/bin/zsh');
   });
 
+  it('uses the resolved POSIX shell profile for agent SHELL', async () => {
+    setPlatform('darwin');
+    process.env.SHELL = '/bin/zsh';
+
+    const { buildAgentEnv } = await loadPtyEnv();
+    const env = buildAgentEnv({
+      agentApiVars: false,
+      shellProfile: {
+        id: 'bash',
+        resolvedShellId: 'bash',
+        resolvedFromSystem: false,
+        executable: '/bin/bash',
+        available: true,
+        family: 'posix',
+        interactiveArgs: ['-il'],
+        commandArgs: ['-lc'],
+      },
+    });
+
+    expect(env.SHELL).toBe('/bin/bash');
+  });
+
   it('passes through documented provider launch environment variables', async () => {
     const providerEnv = {
       CLAUDE_CONFIG_DIR: '/tmp/claude-config',

--- a/src/main/core/pty/pty-env.ts
+++ b/src/main/core/pty/pty-env.ts
@@ -150,6 +150,13 @@ export interface AgentEnvOptions {
   includeShellVar?: boolean;
 
   /**
+   * Resolved shell used to launch the agent command. POSIX login shells can
+   * synthesize SHELL from the user's account default, so pass the configured
+   * shell explicitly when the command is shell-wrapped.
+   */
+  shellProfile?: ResolvedShellProfile;
+
+  /**
    * Emdash hook server connection details.  When set, injects
    * EMDASH_HOOK_PORT, EMDASH_PTY_ID, and EMDASH_HOOK_TOKEN so agent CLIs
    * can call back on lifecycle events.
@@ -224,7 +231,13 @@ export function buildTerminalEnv(
  * find its own dependencies.
  */
 export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, string> {
-  const { agentApiVars = true, includeShellVar = false, hook, providerVars } = options;
+  const {
+    agentApiVars = true,
+    includeShellVar = false,
+    hook,
+    providerVars,
+    shellProfile,
+  } = options;
 
   // process.env.PATH is enriched at startup by resolveUserEnv() so it already
   // contains the full login-shell PATH (Homebrew, nvm, npm globals, etc.).
@@ -248,7 +261,12 @@ export function buildAgentEnv(options: AgentEnvOptions = {}): Record<string, str
   const sshAuthSock = process.env.SSH_AUTH_SOCK ?? detectSshAuthSock();
   if (sshAuthSock) env.SSH_AUTH_SOCK = sshAuthSock;
 
-  if (includeShellVar && process.platform !== 'win32') {
+  if (
+    process.platform !== 'win32' &&
+    (shellProfile?.family === 'posix' || shellProfile?.family === 'csh')
+  ) {
+    env.SHELL = shellProfile.executable;
+  } else if (includeShellVar && process.platform !== 'win32') {
     env.SHELL = process.env.SHELL || '/bin/bash';
   } else if (includeShellVar && process.env.SHELL) {
     env.SHELL = process.env.SHELL;

--- a/src/main/core/pty/pty-spawn-platform.test.ts
+++ b/src/main/core/pty/pty-spawn-platform.test.ts
@@ -19,7 +19,7 @@ const pwshProfile = {
   available: true,
   family: 'powershell',
   interactiveArgs: [],
-  commandArgs: ['-NoProfile', '-Command'],
+  commandArgs: ['-NoLogo', '-Command'],
 } satisfies ResolvedShellProfile;
 
 function posixShellProfile({
@@ -204,7 +204,7 @@ describe('resolveLocalPtySpawn - Windows', () => {
     });
   });
 
-  it('wraps cmd and bat argv commands through cmd.exe when PowerShell is selected', () => {
+  it('runs cmd and bat argv commands through selected PowerShell when PowerShell is selected', () => {
     const result = resolveLocalPtySpawn({
       platform: 'win32',
       env: winEnv,
@@ -217,8 +217,8 @@ describe('resolveLocalPtySpawn - Windows', () => {
     });
 
     expect(result).toEqual({
-      command: 'C:\\Windows\\System32\\cmd.exe',
-      args: ['/d', '/s', '/c', 'pnpm.cmd run dev'],
+      command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      args: ['-NoLogo', '-Command', '& pnpm.cmd run dev'],
       cwd: 'C:\\repo',
       warnings: [],
     });
@@ -290,7 +290,7 @@ describe('resolveLocalPtySpawn - Windows', () => {
 
     expect(result).toEqual({
       command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
-      args: ['-NoProfile', '-Command', 'pnpm run dev'],
+      args: ['-NoLogo', '-Command', 'pnpm run dev'],
       cwd: 'C:\\repo',
       warnings: [],
     });
@@ -311,7 +311,37 @@ describe('resolveLocalPtySpawn - Windows', () => {
 
     expect(result).toEqual({
       command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
-      args: ['-NoProfile', '-Command', "& codex 'hello world' 'it''s ok'"],
+      args: ['-NoLogo', '-Command', "& codex 'hello world' 'it''s ok'"],
+      cwd: 'C:\\repo',
+      warnings: [],
+    });
+  });
+
+  it('prefers ps1 shims over cmd shims for selected PowerShell extensionless commands', () => {
+    const result = resolveLocalPtySpawn({
+      platform: 'win32',
+      env: windowsPathEnv,
+      fileExists: (candidate) =>
+        candidate === 'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.CMD' ||
+        candidate === 'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.PS1',
+      intent: {
+        kind: 'run-command',
+        cwd: 'C:\\repo',
+        shellProfile: pwshProfile,
+        command: { kind: 'argv', command: 'codex', args: ['hello world'] },
+      },
+    });
+
+    expect(result).toEqual({
+      command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+      args: [
+        '-NoLogo',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        'C:\\Users\\me\\AppData\\Roaming\\npm\\codex.PS1',
+        'hello world',
+      ],
       cwd: 'C:\\repo',
       warnings: [],
     });
@@ -366,7 +396,7 @@ describe('resolveLocalPtySpawn - POSIX', () => {
     available: true,
     family: 'powershell',
     interactiveArgs: [],
-    commandArgs: ['-NoProfile', '-Command'],
+    commandArgs: ['-NoLogo', '-Command'],
   };
 
   it('uses SHELL -il for interactive shells', () => {

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -240,8 +240,8 @@ function cmdShellLineSpawn({
   };
 }
 
-function powerShellFileArgs(loadProfile: boolean): string[] {
-  return [loadProfile ? '-NoLogo' : '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File'];
+function powerShellFileArgs(suppressProfile: boolean): string[] {
+  return [suppressProfile ? '-NoProfile' : '-NoLogo', '-ExecutionPolicy', 'Bypass', '-File'];
 }
 
 function resolveWindowsSpawn(
@@ -305,7 +305,7 @@ function resolveWindowsSpawn(
       intent.shellProfile?.family === 'powershell' ? intent.shellProfile : undefined;
     return {
       command: selectedPowerShell?.executable ?? 'powershell.exe',
-      args: [...powerShellFileArgs(selectedPowerShell !== undefined), resolvedCommand, ...args],
+      args: [...powerShellFileArgs(selectedPowerShell === undefined), resolvedCommand, ...args],
       cwd: intent.cwd,
       warnings,
     };

--- a/src/main/core/pty/pty-spawn-platform.ts
+++ b/src/main/core/pty/pty-spawn-platform.ts
@@ -119,14 +119,34 @@ function getWindowsPathDirs(env: NodeJS.ProcessEnv): string[] {
   return rawPath.split(path.win32.delimiter).filter(Boolean);
 }
 
-function getWindowsPathExts(env: NodeJS.ProcessEnv): string[] {
+function getWindowsPathExts(
+  env: NodeJS.ProcessEnv,
+  options: { powershell?: boolean } = {}
+): string[] {
   const rawPathExt =
     getWindowsEnvValue(env, 'PATHEXT') ?? '.COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC';
-  return rawPathExt
+  const exts = rawPathExt
     .split(';')
     .map((ext) => ext.trim())
     .filter(Boolean)
     .map((ext) => (ext.startsWith('.') ? ext : `.${ext}`));
+  if (!options.powershell) return exts;
+
+  const normalized = new Set(exts.map((ext) => ext.toUpperCase()));
+  if (!normalized.has('.PS1')) exts.push('.PS1');
+
+  const priority = new Map([
+    ['.COM', 0],
+    ['.EXE', 1],
+    ['.PS1', 2],
+    ['.CMD', 3],
+    ['.BAT', 4],
+  ]);
+  return [...exts].sort((a, b) => {
+    const aRank = priority.get(a.toUpperCase()) ?? 5;
+    const bRank = priority.get(b.toUpperCase()) ?? 5;
+    return aRank - bRank;
+  });
 }
 
 function hasWindowsPathSeparator(command: string): boolean {
@@ -138,11 +158,13 @@ function resolveWindowsCommandPath({
   cwd,
   env,
   fileExists,
+  powershell = false,
 }: {
   command: string;
   cwd: string;
   env: NodeJS.ProcessEnv;
   fileExists: FileExists;
+  powershell?: boolean;
 }): string | null {
   if (path.win32.extname(command)) {
     return null;
@@ -157,7 +179,7 @@ function resolveWindowsCommandPath({
         ];
 
   for (const base of baseCandidates) {
-    for (const ext of getWindowsPathExts(env)) {
+    for (const ext of getWindowsPathExts(env, { powershell })) {
       const candidate = `${base}${ext}`;
       if (fileExists(candidate)) return candidate;
     }
@@ -218,6 +240,10 @@ function cmdShellLineSpawn({
   };
 }
 
+function powerShellFileArgs(loadProfile: boolean): string[] {
+  return [loadProfile ? '-NoLogo' : '-NoProfile', '-ExecutionPolicy', 'Bypass', '-File'];
+}
+
 function resolveWindowsSpawn(
   intent: PtySpawnIntent,
   env: NodeJS.ProcessEnv,
@@ -252,10 +278,20 @@ function resolveWindowsSpawn(
       cwd: intent.cwd,
       env,
       fileExists,
+      powershell: intent.shellProfile?.family === 'powershell',
     }) ?? command;
   const ext = path.win32.extname(resolvedCommand).toLowerCase();
 
   if (ext === '.cmd' || ext === '.bat') {
+    if (intent.shellProfile?.family === 'powershell') {
+      return windowsShellLineSpawn({
+        commandLine: `& ${[resolvedCommand, ...args].map(quoteForPowerShell).join(' ')}`,
+        cwd: intent.cwd,
+        env,
+        shellProfile: intent.shellProfile,
+        warnings,
+      });
+    }
     return cmdShellLineSpawn({
       commandLine: [resolvedCommand, ...args].map(quoteForCmdExe).join(' '),
       cwd: intent.cwd,
@@ -265,12 +301,11 @@ function resolveWindowsSpawn(
   }
 
   if (ext === '.ps1') {
+    const selectedPowerShell =
+      intent.shellProfile?.family === 'powershell' ? intent.shellProfile : undefined;
     return {
-      command:
-        intent.shellProfile?.family === 'powershell'
-          ? intent.shellProfile.executable
-          : 'powershell.exe',
-      args: ['-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', resolvedCommand, ...args],
+      command: selectedPowerShell?.executable ?? 'powershell.exe',
+      args: [...powerShellFileArgs(selectedPowerShell !== undefined), resolvedCommand, ...args],
       cwd: intent.cwd,
       warnings,
     };

--- a/src/main/core/tasks/task-builder.ts
+++ b/src/main/core/tasks/task-builder.ts
@@ -156,17 +156,15 @@ export async function buildTaskFromWorkspace(
     settings
   );
 
-  const { conversations: conversationProvider, terminals: terminalProvider } = buildTaskProviders(
-    type,
-    {
+  const { conversations: conversationProvider, terminals: terminalProvider } =
+    await buildTaskProviders(type, {
       projectId,
       taskId: task.id,
       taskPath: workspace.path,
       tmuxEnabled,
       shellSetup,
       taskEnvVars,
-    }
-  );
+    });
 
   const taskProvider: TaskProvider = {
     taskId: task.id,

--- a/src/main/core/terminal-shell/resolver.test.ts
+++ b/src/main/core/terminal-shell/resolver.test.ts
@@ -89,6 +89,24 @@ describe('terminal shell resolver', () => {
       executable: 'C:\\Program Files\\PowerShell\\7.5.1\\pwsh.exe',
       family: 'powershell',
     });
+    expect(profile.commandArgs).toEqual(['-NoLogo', '-Command']);
+  });
+
+  it('keeps regular PowerShell command profiles non-profile-loading by default', async () => {
+    const profile = await resolveTerminalShell({
+      intent: 'pwsh',
+      target: {
+        kind: 'local',
+        platform: 'win32',
+        env: {
+          Path: 'C:\\Program Files\\PowerShell\\7',
+          PATHEXT: '.EXE;.CMD',
+        },
+      },
+      fileExists: (candidate) => candidate === 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
+    });
+
+    expect(profile.commandArgs).toEqual(['-NoProfile', '-Command']);
   });
 
   it('falls Windows automation shell back to Windows PowerShell before cmd', async () => {
@@ -134,6 +152,30 @@ describe('terminal shell resolver', () => {
       executable: 'C:\\Windows\\System32\\powershell.exe',
     });
     expect(readDirNames).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports each unavailable Windows automation fallback candidate', async () => {
+    const onFallback = vi.fn();
+
+    const profile = await resolveLocalAutomationShellWithSystemFallback({
+      intent: 'pwsh',
+      platform: 'win32',
+      env: {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+        ProgramFiles: 'C:\\Program Files',
+        Path: 'C:\\Windows\\System32',
+        PATHEXT: '.EXE;.CMD',
+      },
+      onFallback,
+      fileExists: () => false,
+    });
+
+    expect(profile).toMatchObject({
+      id: 'target-default',
+      resolvedShellId: 'cmd',
+    });
+    expect(onFallback).toHaveBeenCalledTimes(2);
+    expect(onFallback.mock.calls.map(([error]) => error.shell)).toEqual(['pwsh', 'powershell']);
   });
 
   it('reports Windows shells separately from POSIX shells', async () => {

--- a/src/main/core/terminal-shell/resolver.test.ts
+++ b/src/main/core/terminal-shell/resolver.test.ts
@@ -111,6 +111,31 @@ describe('terminal shell resolver', () => {
     });
   });
 
+  it('does not retry a failed explicit pwsh lookup before falling back', async () => {
+    const readDirNames = vi.fn((candidate: string) =>
+      candidate === 'C:\\Program Files\\PowerShell' ? ['7'] : []
+    );
+
+    const profile = await resolveLocalAutomationShellWithSystemFallback({
+      intent: 'pwsh',
+      platform: 'win32',
+      env: {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+        ProgramFiles: 'C:\\Program Files',
+        Path: 'C:\\Windows\\System32',
+        PATHEXT: '.EXE;.CMD',
+      },
+      readDirNames,
+      fileExists: (candidate) => candidate === 'C:\\Windows\\System32\\powershell.exe',
+    });
+
+    expect(profile).toMatchObject({
+      id: 'powershell',
+      executable: 'C:\\Windows\\System32\\powershell.exe',
+    });
+    expect(readDirNames).toHaveBeenCalledTimes(1);
+  });
+
   it('reports Windows shells separately from POSIX shells', async () => {
     const availability = await getLocalTerminalShellAvailability({
       platform: 'win32',

--- a/src/main/core/terminal-shell/resolver.test.ts
+++ b/src/main/core/terminal-shell/resolver.test.ts
@@ -3,6 +3,7 @@ import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import {
   getLocalTerminalShellAvailability,
   getRemoteTerminalShellAvailability,
+  resolveLocalAutomationShellWithSystemFallback,
   resolveTerminalShell,
   ShellUnavailableError,
 } from './resolver';
@@ -62,6 +63,51 @@ describe('terminal shell resolver', () => {
       resolvedShellId: 'cmd',
       executable: 'C:\\Windows\\System32\\cmd.exe',
       family: 'windows-cmd',
+    });
+  });
+
+  it('uses the latest installed pwsh for Windows automation shell fallback', async () => {
+    const profile = await resolveLocalAutomationShellWithSystemFallback({
+      intent: 'system',
+      platform: 'win32',
+      env: {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+        ProgramFiles: 'C:\\Program Files',
+        Path: 'C:\\Windows\\System32',
+        PATHEXT: '.EXE;.CMD',
+      },
+      readDirNames: (candidate) =>
+        candidate === 'C:\\Program Files\\PowerShell' ? ['7', '7.5.1', '6'] : [],
+      fileExists: (candidate) =>
+        candidate === 'C:\\Program Files\\PowerShell\\7\\pwsh.exe' ||
+        candidate === 'C:\\Program Files\\PowerShell\\7.5.1\\pwsh.exe',
+    });
+
+    expect(profile).toMatchObject({
+      id: 'pwsh',
+      resolvedShellId: 'pwsh',
+      executable: 'C:\\Program Files\\PowerShell\\7.5.1\\pwsh.exe',
+      family: 'powershell',
+    });
+  });
+
+  it('falls Windows automation shell back to Windows PowerShell before cmd', async () => {
+    const profile = await resolveLocalAutomationShellWithSystemFallback({
+      intent: 'system',
+      platform: 'win32',
+      env: {
+        ComSpec: 'C:\\Windows\\System32\\cmd.exe',
+        Path: 'C:\\Windows\\System32',
+        PATHEXT: '.EXE;.CMD',
+      },
+      fileExists: (candidate) => candidate === 'C:\\Windows\\System32\\powershell.exe',
+    });
+
+    expect(profile).toMatchObject({
+      id: 'powershell',
+      resolvedShellId: 'powershell',
+      executable: 'C:\\Windows\\System32\\powershell.exe',
+      family: 'powershell',
     });
   });
 

--- a/src/main/core/terminal-shell/resolver.ts
+++ b/src/main/core/terminal-shell/resolver.ts
@@ -345,7 +345,10 @@ export async function resolveLocalAutomationShellWithSystemFallback({
     }
   }
 
-  for (const candidate of ['pwsh', 'powershell'] as const) {
+  const fallbackCandidates = (['pwsh', 'powershell'] as const).filter(
+    (candidate) => candidate !== intent
+  );
+  for (const candidate of fallbackCandidates) {
     try {
       return await resolveTerminalShell({
         intent: candidate,

--- a/src/main/core/terminal-shell/resolver.ts
+++ b/src/main/core/terminal-shell/resolver.ts
@@ -213,6 +213,11 @@ function buildProfile({
   };
 }
 
+function withAutomationPowerShellArgs(profile: ResolvedShellProfile): ResolvedShellProfile {
+  if (profile.family !== 'powershell') return profile;
+  return { ...profile, commandArgs: ['-NoLogo', '-Command'] };
+}
+
 export async function resolveTerminalShell({
   intent,
   target,
@@ -338,7 +343,9 @@ export async function resolveLocalAutomationShellWithSystemFallback({
 
   if (intent !== 'system') {
     try {
-      return await resolveTerminalShell({ intent, target, fileExists, readDirNames: readDirs });
+      return withAutomationPowerShellArgs(
+        await resolveTerminalShell({ intent, target, fileExists, readDirNames: readDirs })
+      );
     } catch (error) {
       if (!(error instanceof ShellUnavailableError)) throw error;
       onFallback?.(error);
@@ -350,14 +357,17 @@ export async function resolveLocalAutomationShellWithSystemFallback({
   );
   for (const candidate of fallbackCandidates) {
     try {
-      return await resolveTerminalShell({
-        intent: candidate,
-        target,
-        fileExists,
-        readDirNames: readDirs,
-      });
+      return withAutomationPowerShellArgs(
+        await resolveTerminalShell({
+          intent: candidate,
+          target,
+          fileExists,
+          readDirNames: readDirs,
+        })
+      );
     } catch (error) {
       if (!(error instanceof ShellUnavailableError)) throw error;
+      onFallback?.(error);
     }
   }
 

--- a/src/main/core/terminal-shell/resolver.ts
+++ b/src/main/core/terminal-shell/resolver.ts
@@ -37,6 +37,7 @@ export class ShellUnavailableError extends Error {
 }
 
 type FileExists = (candidate: string) => boolean;
+type ReadDirNames = (candidate: string) => string[];
 
 function isExecutable(filePath: string): boolean {
   try {
@@ -44,6 +45,17 @@ function isExecutable(filePath: string): boolean {
     return fs.statSync(filePath).isFile();
   } catch {
     return false;
+  }
+}
+
+function readDirNames(dirPath: string): string[] {
+  try {
+    return fs
+      .readdirSync(dirPath, { withFileTypes: true })
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name);
+  } catch {
+    return [];
   }
 }
 
@@ -88,6 +100,50 @@ function findOnPath(
   return undefined;
 }
 
+function compareVersionParts(a: number[], b: number[]): number {
+  const len = Math.max(a.length, b.length);
+  for (let i = 0; i < len; i += 1) {
+    const diff = (a[i] ?? 0) - (b[i] ?? 0);
+    if (diff !== 0) return diff;
+  }
+  return 0;
+}
+
+function powerShellVersionParts(name: string): number[] | null {
+  const match = /^(\d+(?:\.\d+)*)(?:-.+)?$/.exec(name);
+  if (!match) return null;
+  return match[1].split('.').map((part) => Number(part));
+}
+
+function findLatestWindowsPwsh(
+  env: NodeJS.ProcessEnv,
+  fileExists: FileExists = isExecutable,
+  readDirs: ReadDirNames = readDirNames
+): string | undefined {
+  const roots = [
+    env.ProgramFiles,
+    env.ProgramW6432,
+    env.LOCALAPPDATA ? path.win32.join(env.LOCALAPPDATA, 'Microsoft') : undefined,
+  ]
+    .filter((root): root is string => Boolean(root))
+    .map((root) => path.win32.join(root, 'PowerShell'));
+
+  let best: { version: number[]; candidate: string } | undefined;
+  for (const root of [...new Set(roots)]) {
+    for (const dir of readDirs(root)) {
+      const version = powerShellVersionParts(dir);
+      if (!version) continue;
+      const candidate = path.win32.join(root, dir, 'pwsh.exe');
+      if (!fileExists(candidate)) continue;
+      if (!best || compareVersionParts(version, best.version) > 0) {
+        best = { version, candidate };
+      }
+    }
+  }
+
+  return best?.candidate ?? findOnPath('pwsh.exe', env, 'win32', fileExists);
+}
+
 function shellIdFromExecutable(
   executable: string,
   fallback: RuntimeTerminalShellId
@@ -110,12 +166,13 @@ function resolveLocalExplicitShell(
   shell: ExplicitTerminalShellId,
   platform: NodeJS.Platform,
   env: NodeJS.ProcessEnv,
-  fileExists?: FileExists
+  fileExists?: FileExists,
+  readDirs?: ReadDirNames
 ): string | undefined {
   if (platform === 'win32') {
     if (shell === 'cmd') return env.ComSpec || 'C:\\Windows\\System32\\cmd.exe';
     if (shell === 'powershell') return findOnPath('powershell.exe', env, platform, fileExists);
-    if (shell === 'pwsh') return findOnPath('pwsh.exe', env, platform, fileExists);
+    if (shell === 'pwsh') return findLatestWindowsPwsh(env, fileExists, readDirs);
     return findOnPath(shell, env, platform, fileExists);
   }
 
@@ -160,10 +217,12 @@ export async function resolveTerminalShell({
   intent,
   target,
   fileExists,
+  readDirNames: readDirs,
 }: {
   intent: TerminalShellId;
   target: ShellTarget;
   fileExists?: FileExists;
+  readDirNames?: ReadDirNames;
 }): Promise<ResolvedShellProfile> {
   if (target.kind === 'local') {
     const platform = target.platform ?? process.platform;
@@ -184,7 +243,7 @@ export async function resolveTerminalShell({
       });
     }
 
-    const executable = resolveLocalExplicitShell(intent, platform, env, fileExists);
+    const executable = resolveLocalExplicitShell(intent, platform, env, fileExists, readDirs);
     if (!executable) throw new ShellUnavailableError(intent, 'local');
     return buildProfile({
       id: intent,
@@ -225,32 +284,98 @@ export async function resolveTerminalShellWithSystemFallback({
   intent,
   target,
   fileExists,
+  readDirNames: readDirs,
   onFallback,
 }: {
   intent: TerminalShellId;
   target: ShellTarget;
   fileExists?: FileExists;
+  readDirNames?: ReadDirNames;
   onFallback?: (error: ShellUnavailableError) => void;
 }): Promise<ResolvedShellProfile> {
   try {
-    return await resolveTerminalShell({ intent, target, fileExists });
+    return await resolveTerminalShell({ intent, target, fileExists, readDirNames: readDirs });
   } catch (error) {
     if (intent === 'system' || !(error instanceof ShellUnavailableError)) {
       throw error;
     }
     onFallback?.(error);
-    return await resolveTerminalShell({ intent: 'system', target, fileExists });
+    return await resolveTerminalShell({
+      intent: 'system',
+      target,
+      fileExists,
+      readDirNames: readDirs,
+    });
   }
+}
+
+export async function resolveLocalAutomationShellWithSystemFallback({
+  intent,
+  platform = process.platform,
+  env = process.env,
+  fileExists,
+  readDirNames: readDirs,
+  onFallback,
+}: {
+  intent: TerminalShellId;
+  platform?: NodeJS.Platform;
+  env?: NodeJS.ProcessEnv;
+  fileExists?: FileExists;
+  readDirNames?: ReadDirNames;
+  onFallback?: (error: ShellUnavailableError) => void;
+}): Promise<ResolvedShellProfile> {
+  const target: ShellTarget = { kind: 'local', platform, env };
+
+  if (platform !== 'win32') {
+    return await resolveTerminalShellWithSystemFallback({
+      intent,
+      target,
+      fileExists,
+      readDirNames: readDirs,
+      onFallback,
+    });
+  }
+
+  if (intent !== 'system') {
+    try {
+      return await resolveTerminalShell({ intent, target, fileExists, readDirNames: readDirs });
+    } catch (error) {
+      if (!(error instanceof ShellUnavailableError)) throw error;
+      onFallback?.(error);
+    }
+  }
+
+  for (const candidate of ['pwsh', 'powershell'] as const) {
+    try {
+      return await resolveTerminalShell({
+        intent: candidate,
+        target,
+        fileExists,
+        readDirNames: readDirs,
+      });
+    } catch (error) {
+      if (!(error instanceof ShellUnavailableError)) throw error;
+    }
+  }
+
+  return await resolveTerminalShell({
+    intent: 'system',
+    target,
+    fileExists,
+    readDirNames: readDirs,
+  });
 }
 
 export async function getLocalTerminalShellAvailability({
   platform = process.platform,
   env = process.env,
   fileExists,
+  readDirNames: readDirs,
 }: {
   platform?: NodeJS.Platform;
   env?: NodeJS.ProcessEnv;
   fileExists?: FileExists;
+  readDirNames?: ReadDirNames;
 } = {}): Promise<TerminalShellAvailability[]> {
   const targetDefaultShell = localDefaultShell(platform, env);
   const targetDefaultId = shellIdFromExecutable(
@@ -269,7 +394,7 @@ export async function getLocalTerminalShellAvailability({
             available: true,
           };
         }
-        const executable = resolveLocalExplicitShell(shell, platform, env, fileExists);
+        const executable = resolveLocalExplicitShell(shell, platform, env, fileExists, readDirs);
         return {
           id: shell,
           label: shell,

--- a/src/main/core/workspaces/workspace-factory.ts
+++ b/src/main/core/workspaces/workspace-factory.ts
@@ -11,7 +11,10 @@ import { GitService } from '@main/core/git/impl/git-service';
 import { RemoteStatusFingerprintPoller } from '@main/core/git/remote-status-fingerprint-poller';
 import { GitRepositoryService } from '@main/core/git/repository-service';
 import { workspaceFileIndexService } from '@main/core/search/workspace-file-index-service';
+import { appSettingsService } from '@main/core/settings/settings-service';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
+import { resolveLocalAutomationShellWithSystemFallback } from '@main/core/terminal-shell/resolver';
+import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { LocalTerminalProvider } from '@main/core/terminals/impl/local-terminal-provider';
 import { SshTerminalProvider } from '@main/core/terminals/impl/ssh-terminal-provider';
 import { runLifecycleScriptWithPolicy } from '@main/core/terminals/lifecycle-script-coordinator';
@@ -255,14 +258,30 @@ type TaskProviderOpts = {
   taskEnvVars: Record<string, string>;
 };
 
+async function resolveLocalConversationShellProfile(taskId: string): Promise<ResolvedShellProfile> {
+  const { defaultShell } = await appSettingsService.get('terminal');
+  return await resolveLocalAutomationShellWithSystemFallback({
+    intent: defaultShell,
+    onFallback: (error) => {
+      log.warn(
+        'buildTaskProviders: preferred local conversation shell unavailable, using fallback',
+        {
+          shell: error.shell,
+          taskId,
+        }
+      );
+    },
+  });
+}
+
 /**
  * Creates task-scoped conversation and terminal providers for the given transport type.
  * The exec function is derived internally from the WorkspaceType.
  */
-export function buildTaskProviders(
+export async function buildTaskProviders(
   type: WorkspaceType,
   opts: TaskProviderOpts
-): { conversations: ConversationProvider; terminals: TerminalProvider } {
+): Promise<{ conversations: ConversationProvider; terminals: TerminalProvider }> {
   if (type.kind === 'ssh') {
     const ctx = new SshExecutionContext(type.proxy);
     return {
@@ -291,6 +310,7 @@ export function buildTaskProviders(
   }
 
   const ctx = new LocalExecutionContext();
+  const conversationShellProfile = await resolveLocalConversationShellProfile(opts.taskId);
   return {
     conversations: new LocalConversationProvider({
       projectId: opts.projectId,
@@ -298,6 +318,7 @@ export function buildTaskProviders(
       taskId: opts.taskId,
       tmux: opts.tmuxEnabled,
       shellSetup: opts.shellSetup,
+      shellProfile: conversationShellProfile,
       ctx,
       taskEnvVars: opts.taskEnvVars,
     }),

--- a/src/shared/terminal-settings.ts
+++ b/src/shared/terminal-settings.ts
@@ -78,7 +78,7 @@ export function terminalCommandArgs(shell: string): string[] {
     case 'windows-cmd':
       return ['/d', '/s', '/c'];
     case 'powershell':
-      return ['-NoLogo', '-Command'];
+      return ['-NoProfile', '-Command'];
     case 'posix':
     case 'csh':
       return BASIC_INTERACTIVE_SHELLS.has(terminalShellBasename(shell)) ? ['-c'] : ['-lc'];

--- a/src/shared/terminal-settings.ts
+++ b/src/shared/terminal-settings.ts
@@ -78,7 +78,7 @@ export function terminalCommandArgs(shell: string): string[] {
     case 'windows-cmd':
       return ['/d', '/s', '/c'];
     case 'powershell':
-      return ['-NoProfile', '-Command'];
+      return ['-NoLogo', '-Command'];
     case 'posix':
     case 'csh':
       return BASIC_INTERACTIVE_SHELLS.has(terminalShellBasename(shell)) ? ['-c'] : ['-lc'];


### PR DESCRIPTION
- prefer latest PowerShell for local automation shells before falling back to Windows PowerShell or cmd
- inject resolved shell profiles into local agent sessions instead of resolving shell state during spawn
- run local dependency installs through the same automation shell path
- prefer ps1 shims for PowerShell-backed commands and keep selected PowerShell profiles loaded