### PR TITLE
feat(cli): emdash workspace CLI (list / create / remove / send)

### DIFF
--- a/bin/emdash-cli.mjs
+++ b/bin/emdash-cli.mjs
@@ -1,0 +1,53 @@
+#!/usr/bin/env node
+/**
+ * Launcher for the emdash CLI.
+ *
+ * Responsibilities (kept Electron-free so it can run under plain Node OR
+ * Electron-as-Node):
+ *   1. Resolve EMDASH_DB_FILE to the shared app database BEFORE the bundled CLI
+ *      loads, so `@main/db/client` never needs Electron's `app.getPath`.
+ *   2. Dynamically import the built bundle (out/main/cli.js), which parses argv
+ *      and runs the requested command.
+ *
+ * Intended to be run via Electron-as-Node so the better-sqlite3 native ABI
+ * matches the desktop build:
+ *   ELECTRON_RUN_AS_NODE=1 electron bin/emdash-cli.mjs workspace list
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+const CURRENT_DB_FILENAME = 'emdash4.db';
+
+function defaultUserDataPath() {
+  const home = process.env.HOME ?? os.homedir();
+  if (process.platform === 'darwin') {
+    return path.join(home, 'Library', 'Application Support', 'emdash');
+  }
+  if (process.platform === 'win32') {
+    const appData = process.env.APPDATA ?? path.join(home, 'AppData', 'Roaming');
+    return path.join(appData, 'emdash');
+  }
+  const xdgConfig = process.env.XDG_CONFIG_HOME ?? path.join(home, '.config');
+  return path.join(xdgConfig, 'emdash');
+}
+
+if (!process.env.EMDASH_DB_FILE || !process.env.EMDASH_DB_FILE.trim()) {
+  process.env.EMDASH_DB_FILE = path.join(defaultUserDataPath(), CURRENT_DB_FILENAME);
+}
+
+const here = path.dirname(fileURLToPath(import.meta.url));
+const bundlePath = path.resolve(here, '..', 'out', 'cli', 'index.cjs');
+
+try {
+  await import(pathToFileURL(bundlePath).href);
+} catch (error) {
+  if (error && (error.code === 'ERR_MODULE_NOT_FOUND' || error.code === 'MODULE_NOT_FOUND')) {
+    process.stderr.write(
+      `emdash CLI bundle not found at ${bundlePath}.\nRun \`pnpm build:cli\` first.\n`
+    );
+    process.exit(1);
+  }
+  throw error;
+}

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   "main": "./out/main/index.js",
   "scripts": {
     "d": "pnpm install && pnpm run dev",
+    "cli": "ELECTRON_RUN_AS_NODE=1 electron bin/emdash-cli.mjs",
+    "build:cli": "node scripts/build-cli.mjs",
     "dev": "electron-vite dev",
     "dev:debug": "VITE_LOG_LEVEL=debug electron-vite dev",
     "dev:main": "electron-vite dev --watch main",

--- a/scripts/build-cli.mjs
+++ b/scripts/build-cli.mjs
@@ -1,0 +1,49 @@
+#!/usr/bin/env node
+/**
+ * Bundles the emdash CLI (src/main/cli/index.ts) into a single CommonJS file at
+ * out/cli/index.cjs.
+ *
+ * Why CJS (and not the electron-vite ESM main build): the CLI runs under
+ * ELECTRON_RUN_AS_NODE so its better-sqlite3 native ABI matches the desktop
+ * build. In that mode the `electron` module is a plain CJS stub, so an ESM
+ * `import { app } from 'electron'` fails at instantiation. CJS `require('electron')`
+ * just yields `undefined` for those names, which is fine because every electron
+ * API use in the CLI's import graph is lazy/guarded and EMDASH_DB_FILE is set
+ * by the launcher before the bundle loads.
+ *
+ * All node_modules stay external (resolved at runtime from the repo), mirroring
+ * how electron-vite externalizes the main process.
+ */
+
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { build } from 'esbuild';
+
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const r = (p) => path.join(root, p);
+
+await build({
+  entryPoints: [r('src/main/cli/index.ts')],
+  outfile: r('out/cli/index.cjs'),
+  bundle: true,
+  platform: 'node',
+  format: 'cjs',
+  target: 'node20',
+  // Keep all third-party packages (and native addons) external; bundle only our source.
+  packages: 'external',
+  external: ['electron'],
+  // Vite-only globals that don't exist under CJS/Node. The CLI doesn't rely on
+  // build-time env (it sets EMDASH_DB_FILE explicitly), so an empty object is safe.
+  define: {
+    'import.meta.env': '{}',
+  },
+  alias: {
+    '@': r('src'),
+    '@main': r('src/main'),
+    '@shared': r('src/shared'),
+    '@renderer': r('src/renderer'),
+    '@root': root,
+    '@tooling': r('tooling'),
+  },
+  logLevel: 'info',
+});

--- a/src/main/cli/README.md
+++ b/src/main/cli/README.md
@@ -1,0 +1,101 @@
+# emdash CLI
+
+A headless command-line surface for emdash that operates on the **same SQLite
+database and git worktrees as the desktop app**, by reusing the app's own
+main-process modules (schema, key-hash, worktree service, agent-command builder,
+tmux session naming). The goal is that artifacts it creates are
+indistinguishable from UI-created ones.
+
+```
+emdash workspace list   [--project <name>] [--include-archived] [--json]
+emdash workspace create --project <p> --branch <b> [--base <branch>] [--name <n>]
+                        [--checkout-existing | --no-worktree] [--push-branch]
+                        [--prompt "<text>" [--agent <name>] [--auto-approve]] [--json]
+emdash workspace remove --project <p> (--branch <b> | --id <id>)
+                        [--pre-remove <cmd>] [--skip-hook] [--force] [--json]
+emdash workspace send   --project <p> (--branch <b> | --id <id>) --message "<text>" [--json]
+```
+
+## Build & run
+
+```bash
+pnpm build:cli          # esbuild bundle → out/cli/index.cjs
+pnpm cli workspace list # = ELECTRON_RUN_AS_NODE=1 electron bin/emdash-cli.mjs …
+```
+
+It runs under **Electron-as-Node** so `better-sqlite3`'s native ABI matches the
+desktop build. The bundle is **CJS** (not the app's ESM main) because under
+`ELECTRON_RUN_AS_NODE` the `electron` module is a stub with no named exports — a
+CJS `require('electron')` yields `undefined` for the unused APIs, which is fine
+because every electron use in the import graph is lazy/guarded and the launcher
+sets `EMDASH_DB_FILE` before the DB client loads.
+
+## Design
+
+- **Core is db-injected and Electron-free** (`workspace-commands.ts`,
+  `agent-dispatch.ts`, `local-worktree.ts`, `args.ts`) so it unit-tests against a
+  temp SQLite db via `openFixture`. The entry (`index.ts`) wires the real db,
+  settings provider, and agent dispatcher.
+- **Reuse over reimplementation:** worktree creation uses the app's
+  `WorktreeService`; the key hash uses `computeWorkspaceKey`; agent launch uses
+  `buildAgentSessionCommand`; the tmux session name uses
+  `makeTmuxSessionName(makePtySessionId(...))` — so the app re-attaches to a
+  CLI-launched agent.
+- **`create` is atomic:** the git worktree is created first; DB rows are written
+  only on success. **`remove` is hook-gated** (capture-before-delete) and
+  defaults to safe branch deletion (`-d`); `-D` only with `--force`.
+
+## Test coverage
+
+`src/main/cli/*.test.ts` (node) + `*.db.test.ts` (main-db, real SQLite + git):
+arg parsing, list filtering/archived, create (atomicity, idempotency, remote
+base, push, prompt-dispatch), remove (teardown, idempotency, hook abort/skip,
+unmerged-branch retention, cross-project `--id` refusal, out-of-pool rm guard),
+send (text+Enter sequence, no-active-session), and the pure tmux-argv builder.
+
+> **CI note:** emdash's CI (`code-consistency-check.yml`) runs only
+> `format:check` + `typecheck` + `lint` — it does **not** run the test suite.
+> These tests must be run locally (`pnpm test`) or CI should be extended to run
+> `vitest --project node --project main-db`.
+
+## Risks & known limitations
+
+**Safe:** `list` (read-only) and `create` (additive, atomic).
+
+**Sharp — `remove`:** force-deletes worktree + (with `--force`) branch + DB rows.
+Mitigations in place: safe branch delete by default, worktree-rm restricted to
+the project's worktree pool, `--id` scoped to the project, agent tmux session
+killed first, pre-remove capture hook that aborts on failure. Still, a wrong
+target tears down real state — treat as `rm`-class.
+
+**Deliberately scoped out / known gaps** (acceptable for a local/dogfood tool;
+listed for reviewers):
+
+- **Concurrency with the running app:** the CLI writes the live DB (WAL handles
+  locking) but assumes it isn't racing the app on the *same* task. No app-level
+  coordination.
+- **Orphaned child rows:** deleting a task leaves `conversations`/`terminals`/
+  `messages` rows (FK cascade is OFF on the connection app-wide; the app's own
+  `deleteTask` behaves the same — not changed here to avoid divergence).
+- **`create --prompt` adoption requires tmux mode ON** for the project; otherwise
+  the app spawns its own agent on open (the CLI warns). Hook env
+  (`EMDASH_HOOK_PORT`, …) and `.emdash.json` task env vars are not forwarded to
+  CLI-launched agents, so status detection / task env can differ until the app
+  adopts the session. Keystroke-injection providers (grok/hermes/…) don't get
+  the prompt at launch (reported `promptDelivered:false`, non-zero exit).
+- **No `--from-issue/--from-pr`, no prompt templates, local projects only.**
+- **Internal-module coupling:** importing `@main/*` (not a public API) means the
+  CLI must move in lockstep with the app; typecheck catches signature drift, but
+  *runtime* drift (tmux naming, command builder, prompt timing) would need a
+  smoke test to catch. A stale `out/cli/index.cjs` after an app upgrade can write
+  old-shape rows — rebuild on upgrade.
+- **`bin/emdash-cli.mjs` re-implements the default DB path** (it must stay
+  Electron-free and load before the build) — keep it in sync with
+  `src/main/db/default-path.ts`.
+
+## Unverified in the live app (needs a human eyeball)
+
+- A CLI-created workspace shows in the sidebar after a reload (confirmed once by
+  a tester; the app doesn't live-refresh external DB writes).
+- The app **re-attaches** to a `create --prompt` tmux agent (vs spawning a
+  duplicate) when tmux mode is on.

--- a/src/main/cli/agent-dispatch.test.ts
+++ b/src/main/cli/agent-dispatch.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, it } from 'vitest';
+import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { makePtySessionId } from '@shared/ptySessionId';
+import {
+  buildAgentTmuxArgv,
+  dispatchAgent,
+  type AgentDispatchInput,
+  type AgentSpawnRunner,
+} from './agent-dispatch';
+
+const base: AgentDispatchInput = {
+  projectId: 'proj',
+  taskId: 'task',
+  conversationId: 'conv',
+  providerId: 'opencode',
+  providerConfig: { cli: 'opencode', initialPromptFlag: '--prompt' },
+  autoApprove: false,
+  prompt: 'fix the bug',
+  cwd: '/work/tree',
+  env: { PATH: '/usr/bin', ANTHROPIC_API_KEY: 'sk-test' },
+};
+
+function fakeRunner(opts: { present?: string[]; spawnOk?: boolean } = {}) {
+  const live = new Set(opts.present ?? []);
+  const spawns: string[][] = [];
+  const envFiles: Array<Record<string, string>> = [];
+  const runner: AgentSpawnRunner = {
+    hasSession: (name) => live.has(name),
+    writeEnvFile: (env) => {
+      envFiles.push(env);
+      return '/tmp/fake-env.sh';
+    },
+    spawn: (argv) => {
+      spawns.push(argv);
+      return { ok: opts.spawnOk ?? true };
+    },
+  };
+  return { runner, spawns, envFiles };
+}
+
+describe('buildAgentTmuxArgv', () => {
+  it('builds a detached tmux new-session that sources env from a file (no secrets in argv)', () => {
+    const { tmuxSession, argv } = buildAgentTmuxArgv(base, { envFilePath: '/tmp/x.env' });
+
+    expect(tmuxSession).toBe(makeTmuxSessionName(makePtySessionId('proj', 'task', 'conv')));
+    expect(argv.slice(0, 6)).toEqual(['new-session', '-d', '-s', tmuxSession, '-c', '/work/tree']);
+    // Secrets must NOT appear in argv.
+    expect(argv.join(' ')).not.toContain('sk-test');
+    expect(argv).not.toContain('-e');
+
+    const agentLine = argv[argv.length - 1]!;
+    // Sources + removes the env file (shell-quoted), then launches the agent.
+    expect(agentLine).toContain(". '/tmp/x.env'");
+    expect(agentLine).toContain("rm -f '/tmp/x.env'");
+    expect(agentLine).toContain('opencode');
+    expect(agentLine).toContain('--prompt');
+    expect(agentLine).toContain('fix the bug');
+  });
+
+  it('prepends shellSetup when configured', () => {
+    const { argv } = buildAgentTmuxArgv(
+      { ...base, shellSetup: 'nvm use 20' },
+      { envFilePath: '/tmp/x.env' }
+    );
+    expect(argv[argv.length - 1]!).toContain('nvm use 20 && ');
+  });
+});
+
+describe('dispatchAgent', () => {
+  it('spawns the session and reports the prompt delivered at launch', async () => {
+    const { runner, spawns, envFiles } = fakeRunner();
+    const res = await dispatchAgent(base, runner);
+    expect(res).toMatchObject({ delivered: true, promptDelivered: true });
+    expect(spawns).toHaveLength(1);
+    expect(spawns[0]![0]).toBe('new-session');
+    // Env (incl. secrets) was handed to the env-file writer, not argv.
+    expect(envFiles).toHaveLength(1);
+    expect(envFiles[0]).toMatchObject({ ANTHROPIC_API_KEY: 'sk-test' });
+  });
+
+  it('treats an already-running session as up without re-spawning', async () => {
+    const tmuxSession = makeTmuxSessionName(makePtySessionId('proj', 'task', 'conv'));
+    const { runner, spawns } = fakeRunner({ present: [tmuxSession] });
+    const res = await dispatchAgent(base, runner);
+    expect(res).toMatchObject({ delivered: true, alreadyRunning: true });
+    expect(spawns).toHaveLength(0);
+  });
+
+  it('reports promptDelivered:false for keystroke-injection providers (grok)', async () => {
+    const { runner } = fakeRunner();
+    const res = await dispatchAgent(
+      { ...base, providerId: 'grok', providerConfig: { cli: 'grok' } },
+      runner
+    );
+    expect(res.delivered).toBe(true);
+    expect(res.promptDelivered).toBe(false);
+    expect(res.reason).toBe('keystroke-provider');
+  });
+
+  it('fails closed when the spawn fails', async () => {
+    const { runner } = fakeRunner({ spawnOk: false });
+    const res = await dispatchAgent(base, runner);
+    expect(res.delivered).toBe(false);
+    expect(res.reason).toBe('spawn-failed');
+  });
+});

--- a/src/main/cli/agent-dispatch.ts
+++ b/src/main/cli/agent-dispatch.ts
@@ -1,0 +1,141 @@
+/**
+ * Launches a coding agent for a conversation inside a DETACHED tmux session,
+ * reusing the app's own command builder so the invocation is identical to what
+ * the app would spawn. Because the tmux session name is derived deterministically
+ * from the conversation id, the app re-attaches to this same session when the
+ * task is later opened.
+ *
+ * Command construction is pure (no db / Electron), so it's unit-testable; the
+ * caller (the CLI entry) resolves the provider config + env and passes them in.
+ *
+ * Secrets (API keys) are delivered via a 0600 temp file the agent sources +
+ * deletes at launch — NOT via `tmux -e KEY=VALUE`, which would expose them in
+ * the tmux process argv (visible to `ps`) and in the session environment.
+ */
+
+import { spawnSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { buildAgentSessionCommand } from '@main/core/conversations/impl/agent-command';
+import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { quoteShellArg } from '@main/utils/shellEscape';
+import { getProvider, type AgentProviderId } from '@shared/agent-provider-registry';
+import type { ProviderCustomConfig } from '@shared/app-settings';
+import { makePtySessionId } from '@shared/ptySessionId';
+
+export type AgentDispatchInput = {
+  projectId: string;
+  taskId: string;
+  conversationId: string;
+  providerId: AgentProviderId;
+  /** Resolved provider config (registry defaults merged with user overrides). */
+  providerConfig: ProviderCustomConfig | undefined;
+  autoApprove: boolean;
+  prompt: string;
+  /** Worktree directory the agent runs in. */
+  cwd: string;
+  /** Agent env (API keys, PATH, …); written to a temp file the agent sources. */
+  env: Record<string, string>;
+  shellSetup?: string;
+};
+
+export type AgentDispatchResult = {
+  /** The tmux session is up (spawned now or already running). */
+  delivered: boolean;
+  /** Whether the prompt was delivered at launch (false for keystroke-only providers). */
+  promptDelivered: boolean;
+  tmuxSession: string;
+  reason?: 'spawn-failed' | 'keystroke-provider';
+  alreadyRunning?: boolean;
+};
+
+export type AgentSpawnRunner = {
+  hasSession(name: string): boolean;
+  /** Writes env to a private temp file (sourced at launch) and returns its path. */
+  writeEnvFile(env: Record<string, string>): string;
+  spawn(tmuxArgs: string[]): { ok: boolean; error?: string };
+};
+
+const defaultRunner: AgentSpawnRunner = {
+  hasSession: (name) =>
+    spawnSync('tmux', ['has-session', '-t', name], { stdio: 'ignore' }).status === 0,
+  writeEnvFile: (env) => {
+    const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-agent-'));
+    const file = path.join(dir, 'env.sh');
+    const body = Object.entries(env)
+      .map(([key, value]) => `export ${key}=${quoteShellArg(value)}`)
+      .join('\n');
+    fs.writeFileSync(file, `${body}\n`, { mode: 0o600 });
+    return file;
+  },
+  spawn: (tmuxArgs) => {
+    const r = spawnSync('tmux', tmuxArgs, { stdio: 'ignore' });
+    return { ok: r.status === 0, error: r.error?.message };
+  },
+};
+
+/**
+ * Pure: builds the `tmux new-session` argv that launches the agent detached.
+ * The agent command is built exactly as the app builds it (auto-approve flag,
+ * initial-prompt flag / trailing-arg / stdin-pipe per provider), wrapped in the
+ * project's shellSetup. Env is sourced from `envFilePath` (then the file is
+ * removed) so secrets never appear in argv.
+ */
+export function buildAgentTmuxArgv(
+  input: AgentDispatchInput,
+  opts: { envFilePath: string }
+): { tmuxSession: string; argv: string[] } {
+  const tmuxSession = makeTmuxSessionName(
+    makePtySessionId(input.projectId, input.taskId, input.conversationId)
+  );
+  const { command, args } = buildAgentSessionCommand({
+    providerId: input.providerId,
+    providerConfig: input.providerConfig,
+    autoApprove: input.autoApprove,
+    initialPrompt: input.prompt,
+    sessionId: input.conversationId,
+    isResuming: false,
+  });
+  const agentLine = [command, ...args].map(quoteShellArg).join(' ');
+  const quotedEnv = quoteShellArg(opts.envFilePath);
+  const setup = input.shellSetup ? `${input.shellSetup} && ` : '';
+  // Source the env file, delete it immediately, then run the agent.
+  const fullLine = `. ${quotedEnv}; rm -f ${quotedEnv}; ${setup}${agentLine}`;
+
+  const argv = ['new-session', '-d', '-s', tmuxSession, '-c', input.cwd, fullLine];
+  return { tmuxSession, argv };
+}
+
+/**
+ * Spawns the agent in a detached tmux session (idempotent: if the session
+ * already exists, treats it as up). Returns whether the prompt was delivered at
+ * launch — false for keystroke-only providers (grok/hermes/…), which the app
+ * injects after the TUI settles; for those, follow up with `workspace send`.
+ */
+export async function dispatchAgent(
+  input: AgentDispatchInput,
+  runner: AgentSpawnRunner = defaultRunner
+): Promise<AgentDispatchResult> {
+  const tmuxSession = makeTmuxSessionName(
+    makePtySessionId(input.projectId, input.taskId, input.conversationId)
+  );
+  const promptAtLaunch = !getProvider(input.providerId)?.useKeystrokeInjection;
+
+  if (runner.hasSession(tmuxSession)) {
+    return { delivered: true, promptDelivered: promptAtLaunch, tmuxSession, alreadyRunning: true };
+  }
+
+  const envFilePath = runner.writeEnvFile(input.env);
+  const { argv } = buildAgentTmuxArgv(input, { envFilePath });
+  const result = runner.spawn(argv);
+  if (!result.ok) {
+    return { delivered: false, promptDelivered: false, tmuxSession, reason: 'spawn-failed' };
+  }
+  return {
+    delivered: true,
+    promptDelivered: promptAtLaunch,
+    tmuxSession,
+    reason: promptAtLaunch ? undefined : 'keystroke-provider',
+  };
+}

--- a/src/main/cli/args.test.ts
+++ b/src/main/cli/args.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { getBool, getString, parseArgs } from './args';
+
+describe('parseArgs', () => {
+  it('parses positionals, value flags, and boolean flags', () => {
+    const a = parseArgs(['workspace', 'create', '--project', 'acme', '-b', 'feat/x', '--json']);
+    expect(a.positionals).toEqual(['workspace', 'create']);
+    expect(getString(a, 'project')).toBe('acme');
+    expect(getString(a, 'branch')).toBe('feat/x'); // -b alias
+    expect(getBool(a, 'json')).toBe(true);
+  });
+
+  it('supports --key=value', () => {
+    const a = parseArgs(['--base=origin/main', '--name=My Task']);
+    expect(getString(a, 'base')).toBe('origin/main');
+    expect(getString(a, 'name')).toBe('My Task');
+  });
+
+  it('consumes a value-flag value that begins with "-" (regression)', () => {
+    const a = parseArgs(['workspace', 'send', '-m', '-N5 run it']);
+    expect(getString(a, 'message')).toBe('-N5 run it');
+  });
+
+  it('stops option parsing at "--"', () => {
+    const a = parseArgs(['workspace', 'list', '--', '--not-a-flag']);
+    expect(getBool(a, 'not-a-flag')).toBe(false);
+    expect(a.positionals).toContain('--not-a-flag');
+  });
+
+  it('treats a value-flag with no following value as a bare flag', () => {
+    const a = parseArgs(['--message']);
+    expect(getString(a, 'message')).toBeUndefined();
+  });
+});

--- a/src/main/cli/args.ts
+++ b/src/main/cli/args.ts
@@ -1,0 +1,122 @@
+/**
+ * Minimal, dependency-free argv parser for the emdash CLI.
+ *
+ * Supports `--flag`, `--key value`, `--key=value`, short `-k value`, and bare
+ * positionals. Intentionally tiny — we don't pull in commander/yargs to avoid
+ * lockfile churn for a local-only tool.
+ */
+
+export type ParsedArgs = {
+  positionals: string[];
+  options: Record<string, string | boolean>;
+};
+
+/** Flags that never take a value (presence === true). */
+const BOOLEAN_FLAGS = new Set([
+  'json',
+  'include-archived',
+  'push',
+  'no-worktree',
+  'checkout-existing',
+  'auto-approve',
+  'push-branch',
+  'force',
+  'skip-hook',
+  'help',
+]);
+
+/** Flags that always take a value — so a value beginning with '-' is consumed, not misread as a flag. */
+const VALUE_FLAGS = new Set([
+  'project',
+  'branch',
+  'base',
+  'name',
+  'message',
+  'agent',
+  'id',
+  'pre-remove',
+  'prompt',
+]);
+
+const SHORT_ALIASES: Record<string, string> = {
+  p: 'project',
+  b: 'branch',
+  m: 'message',
+  h: 'help',
+};
+
+function normalizeKey(raw: string): string {
+  return SHORT_ALIASES[raw] ?? raw;
+}
+
+export function parseArgs(argv: string[]): ParsedArgs {
+  const positionals: string[] = [];
+  const options: Record<string, string | boolean> = {};
+
+  for (let i = 0; i < argv.length; i++) {
+    const token = argv[i]!;
+
+    if (token === '--') {
+      positionals.push(...argv.slice(i + 1));
+      break;
+    }
+
+    if (token.startsWith('--') || token.startsWith('-')) {
+      const isLong = token.startsWith('--');
+      const body = token.slice(isLong ? 2 : 1);
+      const eqIdx = body.indexOf('=');
+
+      if (eqIdx !== -1) {
+        const key = normalizeKey(body.slice(0, eqIdx));
+        options[key] = body.slice(eqIdx + 1);
+        continue;
+      }
+
+      const key = normalizeKey(body);
+      if (BOOLEAN_FLAGS.has(key)) {
+        options[key] = true;
+        continue;
+      }
+
+      const next = argv[i + 1];
+      // Known value-flags always consume the next token (even if it starts with
+      // '-', e.g. a message or branch literally beginning with a dash).
+      if (VALUE_FLAGS.has(key)) {
+        if (next === undefined || next === '--') {
+          options[key] = true;
+        } else {
+          options[key] = next;
+          i++;
+        }
+        continue;
+      }
+
+      // Unknown flag: consume the next token as a value unless it looks like another flag.
+      if (next === undefined || next.startsWith('-')) {
+        options[key] = true;
+      } else {
+        options[key] = next;
+        i++;
+      }
+      continue;
+    }
+
+    positionals.push(token);
+  }
+
+  return { positionals, options };
+}
+
+/** Reads a string option, returning undefined when absent or boolean-only. */
+export function getString(args: ParsedArgs, key: string): string | undefined {
+  const value = args.options[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Reads a boolean flag (presence or `--key=true`). */
+export function getBool(args: ParsedArgs, key: string): boolean {
+  const value = args.options[key];
+  if (typeof value === 'boolean') return value;
+  if (typeof value === 'string') return value !== 'false' && value !== '0';
+  return false;
+}

--- a/src/main/cli/index.ts
+++ b/src/main/cli/index.ts
@@ -1,0 +1,328 @@
+/**
+ * `emdash` CLI entry point.
+ *
+ * Runs against the same SQLite database as the desktop app. The launcher
+ * (bin/emdash-cli.mjs) sets EMDASH_DB_FILE before this module loads and runs us
+ * under Electron-as-Node so the better-sqlite3 native ABI matches.
+ *
+ * Commands:
+ *   emdash workspace list   [--project <name>] [--include-archived] [--json]
+ *   emdash workspace create --project <p> --branch <b> [--base <branch>]
+ *                           [--name <n>] [--checkout-existing | --no-worktree] [--json]
+ */
+
+import { resolveProviderEnv } from '@main/core/conversations/impl/provider-env';
+import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
+import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
+import { GitService } from '@main/core/git/impl/git-service';
+import { LocalProjectSettingsProvider } from '@main/core/projects/settings/providers/local-project-settings-provider';
+import { buildAgentEnv } from '@main/core/pty/pty-env';
+import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
+import { db } from '@main/db/client';
+import { dispatchAgent } from './agent-dispatch';
+import { getBool, getString, parseArgs, type ParsedArgs } from './args';
+import {
+  createWorkspace,
+  listWorkspaces,
+  removeWorkspace,
+  resolveProject,
+  sendToWorkspace,
+  type CreateAgentDispatcher,
+  type WorkspaceStrategy,
+} from './workspace-commands';
+
+const USAGE = `emdash — workspace CLI
+
+Usage:
+  emdash workspace list   [--project <name>] [--include-archived] [--json]
+  emdash workspace create --project <p> --branch <b> [--base <branch>] [--name <n>]
+                          [--checkout-existing | --no-worktree] [--push-branch]
+                          [--prompt "<text>" [--agent <name>] [--auto-approve]] [--json]
+  emdash workspace remove --project <p> (--branch <b> | --id <workspaceId>)
+                          [--pre-remove <cmd>] [--skip-hook] [--force] [--json]
+  emdash workspace send   --project <p> (--branch <b> | --id <workspaceId>)
+                          --message "<text>" [--json]
+
+Options:
+  -p, --project   Project name or id
+  -b, --branch    Branch name for the workspace
+  -m, --message   Message to dispatch to the worktree's agent (send)
+      --base      Source branch to fork from (default: project base ref, e.g. origin/main)
+      --name      Task display name (default: branch name)
+      --prompt    Launch the agent and seed it with this prompt (one-shot dispatch; needs tmux mode)
+      --agent     Agent provider for --prompt (default: claude)
+      --auto-approve  Launch the agent with permissions auto-approved
+      --push-branch   Publish the new branch to the push remote
+      --id        Target workspace id (remove / send)
+      --pre-remove <cmd>  Capture command run in the worktree before teardown
+                          (also reads EMDASH_PRE_REMOVE). Aborts remove if it fails.
+      --skip-hook Skip the pre-remove hook
+      --force     Remove even if the pre-remove hook fails
+      --json      Machine-readable JSON output
+      --include-archived  Include archived workspaces in the list
+`;
+
+async function runList(args: ParsedArgs): Promise<void> {
+  const items = await listWorkspaces(db, {
+    project: getString(args, 'project'),
+    includeArchived: getBool(args, 'include-archived'),
+  });
+
+  if (getBool(args, 'json')) {
+    process.stdout.write(`${JSON.stringify(items, null, 2)}\n`);
+    return;
+  }
+
+  if (items.length === 0) {
+    process.stdout.write('No workspaces found.\n');
+    return;
+  }
+
+  const rows = items.map((item) => ({
+    id: item.id,
+    project: item.project ?? '—',
+    branch: item.branch ?? '—',
+    type: item.type,
+    archived: item.archived ? 'yes' : 'no',
+    path: item.path ?? '—',
+  }));
+  const columns: Array<keyof (typeof rows)[number]> = [
+    'id',
+    'project',
+    'branch',
+    'type',
+    'archived',
+    'path',
+  ];
+  const widths = Object.fromEntries(
+    columns.map((col) => [col, Math.max(col.length, ...rows.map((r) => String(r[col]).length))])
+  ) as Record<string, number>;
+
+  const line = (cells: Record<string, string>) =>
+    columns.map((col) => String(cells[col]).padEnd(widths[col]!)).join('  ');
+
+  process.stdout.write(`${line(Object.fromEntries(columns.map((c) => [c, c])))}\n`);
+  for (const row of rows) {
+    process.stdout.write(`${line(row as Record<string, string>)}\n`);
+  }
+}
+
+/**
+ * Builds the real project settings provider so the worktree directory and
+ * preserve patterns match what the desktop app uses for this project.
+ */
+function projectSettingsFor(project: { id: string; path: string; baseRef: string }) {
+  const ctx = new LocalExecutionContext({ root: project.path });
+  const fs = new LocalFileSystem(project.path);
+  const git = new GitService(ctx, fs);
+  return new LocalProjectSettingsProvider(project.id, project.path, project.baseRef, { git });
+}
+
+/**
+ * Real agent dispatcher: resolves the provider config + env the way the app
+ * does, then launches the agent in a detached tmux session.
+ */
+function makeDispatcher(settings: LocalProjectSettingsProvider): CreateAgentDispatcher {
+  return async (a) => {
+    const providerConfig = await providerOverrideSettings.getItem(a.providerId);
+    const providerEnv = resolveProviderEnv(providerConfig, {
+      providerId: a.providerId,
+      autoApprove: a.autoApprove,
+    });
+    const env = buildAgentEnv({ providerVars: providerEnv });
+    const shellSetup = await settings
+      .get()
+      .then((s) => s.shellSetup)
+      .catch(() => undefined);
+    return dispatchAgent({
+      projectId: a.projectId,
+      taskId: a.taskId,
+      conversationId: a.conversationId,
+      providerId: a.providerId,
+      providerConfig,
+      autoApprove: a.autoApprove,
+      prompt: a.prompt,
+      cwd: a.cwd,
+      env,
+      shellSetup,
+    });
+  };
+}
+
+/** Returns the process exit code: 0 normally, 1 if a requested prompt wasn't delivered. */
+async function runCreate(args: ParsedArgs): Promise<number> {
+  const projectArg = getString(args, 'project');
+  if (!projectArg) throw new Error('--project <name|id> is required.');
+
+  const strategy: WorkspaceStrategy = getBool(args, 'no-worktree')
+    ? 'no-worktree'
+    : getBool(args, 'checkout-existing')
+      ? 'checkout-existing'
+      : 'new-branch';
+
+  const project = await resolveProject(db, projectArg);
+  const settings = projectSettingsFor(project);
+  const prompt = getString(args, 'prompt');
+
+  const result = await createWorkspace(db, {
+    project,
+    branch: getString(args, 'branch'),
+    base: getString(args, 'base'),
+    name: getString(args, 'name'),
+    strategy,
+    settings,
+    pushBranch: getBool(args, 'push-branch'),
+    prompt,
+    agent: getString(args, 'agent'),
+    autoApprove: getBool(args, 'auto-approve'),
+    dispatch: makeDispatcher(settings),
+  });
+
+  // Fail-closed: a requested prompt that wasn't delivered is an error.
+  const promptFailed = Boolean(prompt) && result.promptDelivered !== true;
+
+  if (getBool(args, 'json')) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return promptFailed ? 1 : 0;
+  }
+
+  const verb = result.reused ? 'Reused existing workspace' : 'Created workspace';
+  process.stdout.write(`${verb} ${result.workspaceId}\n`);
+  process.stdout.write(`  task:    ${result.taskId}\n`);
+  if (result.branch) process.stdout.write(`  branch:  ${result.branch}\n`);
+  process.stdout.write(`  path:    ${result.path}\n`);
+  if (result.pushed !== undefined) {
+    process.stdout.write(`  pushed:  ${result.pushed ? 'yes' : 'no'}\n`);
+  }
+  if (result.agent) {
+    process.stdout.write(`  agent:   ${result.agent} (conversation ${result.conversationId})\n`);
+    process.stdout.write(`  prompt:  ${result.promptDelivered ? 'delivered' : 'NOT delivered'}\n`);
+  }
+  if (result.warning) {
+    process.stderr.write(`Warning: ${result.warning}\n`);
+  }
+  if (promptFailed) {
+    process.stderr.write(
+      'Prompt was not delivered (agent may use keystroke injection, or tmux mode is off / no session). ' +
+        'Try `emdash workspace send` once the agent is up.\n'
+    );
+  }
+  return promptFailed ? 1 : 0;
+}
+
+async function runRemove(args: ParsedArgs): Promise<void> {
+  const projectArg = getString(args, 'project');
+  if (!projectArg) throw new Error('--project <name|id> is required.');
+
+  const project = await resolveProject(db, projectArg);
+  const settings = projectSettingsFor(project);
+
+  const result = await removeWorkspace(db, {
+    project,
+    branch: getString(args, 'branch'),
+    id: getString(args, 'id'),
+    preRemoveCmd: getString(args, 'pre-remove') ?? process.env.EMDASH_PRE_REMOVE,
+    skipHook: getBool(args, 'skip-hook'),
+    force: getBool(args, 'force'),
+    settings,
+  });
+
+  if (getBool(args, 'json')) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return;
+  }
+
+  if (result.alreadyGone) {
+    process.stdout.write('Nothing to remove (already torn down).\n');
+    return;
+  }
+  process.stdout.write(`Removed workspace ${result.workspaceId}\n`);
+  if (result.branch) process.stdout.write(`  branch:    ${result.branch}\n`);
+  if (result.hookRan) process.stdout.write('  hook:      ran\n');
+  process.stdout.write(`  worktree:  ${result.removedWorktree ? 'removed' : 'skipped'}\n`);
+  process.stdout.write(`  branch rm: ${result.removedBranch ? 'yes' : 'no'}\n`);
+  if (result.branchRetained === 'unmerged') {
+    process.stdout.write(
+      `  note:      branch "${result.branch}" kept (has unmerged commits); re-run with --force to delete it\n`
+    );
+  }
+  process.stdout.write(`  tasks:     ${result.deletedTasks} deleted\n`);
+}
+
+/** Returns the process exit code: 0 when delivered, 1 otherwise. */
+async function runSend(args: ParsedArgs): Promise<number> {
+  const projectArg = getString(args, 'project');
+  if (!projectArg) throw new Error('--project <name|id> is required.');
+  const message = getString(args, 'message');
+  if (!message) throw new Error('--message "<text>" is required.');
+
+  const project = await resolveProject(db, projectArg);
+  const result = await sendToWorkspace(db, {
+    project,
+    branch: getString(args, 'branch'),
+    id: getString(args, 'id'),
+    conversationId: getString(args, 'conversation'),
+    message,
+  });
+
+  if (getBool(args, 'json')) {
+    process.stdout.write(`${JSON.stringify(result, null, 2)}\n`);
+    return result.delivered ? 0 : 1;
+  }
+
+  if (result.delivered) {
+    process.stdout.write(`Delivered to ${result.tmuxSession}\n`);
+    return 0;
+  }
+  const hint =
+    result.reason === 'no-active-session'
+      ? ' (no live tmux session — is tmux mode enabled for this project and the agent running?)'
+      : '';
+  process.stderr.write(`Not delivered: ${result.reason}${hint}\n`);
+  return 1;
+}
+
+export async function main(argv: string[]): Promise<number> {
+  const args = parseArgs(argv);
+  const [group, command] = args.positionals;
+
+  if (getBool(args, 'help') || !group) {
+    process.stdout.write(USAGE);
+    return 0;
+  }
+
+  if (group !== 'workspace') {
+    process.stderr.write(`Unknown command group: ${group}\n\n${USAGE}`);
+    return 1;
+  }
+
+  try {
+    switch (command) {
+      case 'list':
+        await runList(args);
+        return 0;
+      case 'create':
+        return await runCreate(args);
+      case 'remove':
+        await runRemove(args);
+        return 0;
+      case 'send':
+        return await runSend(args);
+      default:
+        process.stderr.write(`Unknown workspace command: ${command ?? '(none)'}\n\n${USAGE}`);
+        return 1;
+    }
+  } catch (error) {
+    process.stderr.write(`Error: ${error instanceof Error ? error.message : String(error)}\n`);
+    return 1;
+  }
+}
+
+main(process.argv.slice(2))
+  .then((code) => {
+    process.exit(code);
+  })
+  .catch((error) => {
+    process.stderr.write(`Fatal: ${error instanceof Error ? error.stack : String(error)}\n`);
+    process.exit(1);
+  });

--- a/src/main/cli/local-worktree.ts
+++ b/src/main/cli/local-worktree.ts
@@ -1,0 +1,115 @@
+/**
+ * Builds a `WorktreeService` for a local project the same way the app does in
+ * `createLocalProvider` (see src/main/core/projects/create-project-provider.ts),
+ * but without the surrounding Electron/project-manager lifecycle.
+ *
+ * This is the shared building block the CLI uses to create worktrees that are
+ * byte-identical to UI-created ones (same git commands, same pool path layout).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
+import { LocalFileSystem } from '@main/core/fs/impl/local-fs';
+import { GitService } from '@main/core/git/impl/git-service';
+import type { ProjectSettingsProvider } from '@main/core/projects/settings/provider';
+import { LocalWorktreeHost } from '@main/core/projects/worktrees/hosts/local-worktree-host';
+import { WorktreeService } from '@main/core/projects/worktrees/worktree-service';
+import { safePathSegment } from '@shared/path-name';
+import { ok, type Result } from '@shared/result';
+
+/**
+ * A minimal settings provider for the CLI worktree path. Only the methods that
+ * `WorktreeService` actually calls during worktree creation are meaningful
+ * (`getWorktreeDirectory`, `getBaseRemote`, `get`); the rest return safe
+ * defaults. The real app injects `LocalProjectSettingsProvider`; tests inject
+ * this stub so they don't depend on the global app-settings singleton.
+ */
+export class CliWorktreeSettings implements ProjectSettingsProvider {
+  constructor(
+    private readonly worktreeDirectory: string,
+    private readonly baseRef: string,
+    private readonly baseRemote: string = 'origin'
+  ) {}
+
+  async getDefaultBranch(): Promise<string> {
+    return this.baseRef;
+  }
+  async getBaseRemote(): Promise<string> {
+    return this.baseRemote;
+  }
+  async getPushRemote(): Promise<string> {
+    return this.baseRemote;
+  }
+  async getDefaultWorktreeDirectory(): Promise<string> {
+    return this.worktreeDirectory;
+  }
+  async getWorktreeDirectory(): Promise<string> {
+    return this.worktreeDirectory;
+  }
+  async get(): Promise<Record<string, never>> {
+    return {};
+  }
+  async update(): Promise<Result<void, never>> {
+    return ok();
+  }
+  async patch(): Promise<Result<void, never>> {
+    return ok();
+  }
+  async ensure(): Promise<void> {}
+}
+
+export type LocalWorktreeContext = {
+  worktreeService: WorktreeService;
+  repoGit: GitService;
+  /** Absolute root of the worktree pool for this project (…/<worktreeDir>/<project>). */
+  poolPath: string;
+};
+
+/**
+ * Assembles the local git + worktree services for a project. Mirrors
+ * `createLocalProvider`'s worktree wiring exactly so the resulting worktrees
+ * are indistinguishable from those the UI creates.
+ */
+export async function buildLocalWorktreeContext(args: {
+  projectName: string;
+  projectId: string;
+  repoPath: string;
+  baseRef: string;
+  worktreeDirectory: string;
+  /** When supplied (production), used for preserve patterns / remotes parity. */
+  settings?: ProjectSettingsProvider;
+}): Promise<LocalWorktreeContext> {
+  const localFs = new LocalFileSystem(args.repoPath);
+  const ctx = new LocalExecutionContext({ root: args.repoPath });
+  const repoGit = new GitService(ctx, localFs);
+
+  const settings = args.settings ?? new CliWorktreeSettings(args.worktreeDirectory, args.baseRef);
+
+  await fs.promises.mkdir(args.worktreeDirectory, { recursive: true });
+  const worktreeHost = await LocalWorktreeHost.create({
+    allowedRoots: [args.repoPath, args.worktreeDirectory],
+  });
+
+  const poolPath = path.join(
+    args.worktreeDirectory,
+    safePathSegment(args.projectName, args.projectId)
+  );
+
+  const resolveWorktreePoolPath = async () => {
+    const directory = await settings.getWorktreeDirectory();
+    await fs.promises.mkdir(directory, { recursive: true });
+    await worktreeHost.allowRoot(directory);
+    return path.join(directory, safePathSegment(args.projectName, args.projectId));
+  };
+
+  const worktreeService = new WorktreeService({
+    repoPath: args.repoPath,
+    projectSettings: settings,
+    ctx,
+    host: worktreeHost,
+    resolveWorktreePoolPath,
+  });
+
+  return { worktreeService, repoGit, poolPath };
+}

--- a/src/main/cli/workspace-commands.db.test.ts
+++ b/src/main/cli/workspace-commands.db.test.ts
@@ -1,0 +1,668 @@
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { openFixture } from '@tooling/utils/db';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { computeWorkspaceKey } from '@main/core/workspaces/workspace-key';
+import { tasks, workspaces } from '@main/db/schema';
+import { makePtySessionId } from '@shared/ptySessionId';
+import {
+  createWorkspace,
+  listWorkspaces,
+  removeWorkspace,
+  resolveProject,
+  sendToWorkspace,
+  type TmuxRunner,
+} from './workspace-commands';
+
+type Fixture = Awaited<ReturnType<typeof openFixture>>;
+
+/** Records tmux calls and reports which sessions "exist". */
+function fakeTmux(present: string[] = []) {
+  const live = new Set(present);
+  const calls: Array<{ name: string; keys: string[] }> = [];
+  const runner: TmuxRunner = {
+    hasSession: (name) => live.has(name),
+    sendKeys: (name, keys) => {
+      calls.push({ name, keys });
+      return true;
+    },
+  };
+  return { runner, calls };
+}
+
+function git(cwd: string, ...args: string[]): string {
+  return execFileSync('git', args, {
+    cwd,
+    stdio: ['ignore', 'pipe', 'pipe'],
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Test',
+      GIT_AUTHOR_EMAIL: 'test@example.com',
+      GIT_COMMITTER_NAME: 'Test',
+      GIT_COMMITTER_EMAIL: 'test@example.com',
+    },
+  })
+    .toString()
+    .trim();
+}
+
+/** Creates a git repo with a single commit on `main`. */
+function initRepo(dir: string): void {
+  fs.mkdirSync(dir, { recursive: true });
+  git(dir, 'init');
+  git(dir, 'symbolic-ref', 'HEAD', 'refs/heads/main');
+  fs.writeFileSync(path.join(dir, 'README.md'), '# test\n');
+  git(dir, 'add', '.');
+  git(dir, 'commit', '-m', 'init');
+}
+
+function localBranches(repo: string): string[] {
+  return git(repo, 'branch', '--format=%(refname:short)')
+    .split('\n')
+    .map((b) => b.trim())
+    .filter(Boolean);
+}
+
+/** Adds a bare `origin` remote with `main` pushed + fetched (so origin/main exists). */
+function addOrigin(repo: string, dir: string): void {
+  git(dir, 'init', '--bare', 'origin.git');
+  git(repo, 'remote', 'add', 'origin', path.join(dir, 'origin.git'));
+  git(repo, 'push', 'origin', 'main');
+  git(repo, 'fetch', 'origin');
+}
+
+describe('workspace cli commands', () => {
+  let fixture: Fixture;
+  let tmpRoot: string;
+  let repoPath: string;
+  let worktreeDir: string;
+  const projectId = 'project-1';
+  const proj = (baseRef = 'main') => ({ id: projectId, name: 'Acme', path: repoPath, baseRef });
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-cli-test-'));
+    repoPath = path.join(tmpRoot, 'repo');
+    worktreeDir = path.join(tmpRoot, 'worktrees');
+    initRepo(repoPath);
+
+    fixture.sqlite
+      .prepare(
+        `INSERT INTO projects (id, name, path, workspace_provider, base_ref, created_at, updated_at)
+         VALUES (?, 'Acme', ?, 'local', 'main', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+      )
+      .run(projectId, repoPath);
+  });
+
+  afterEach(() => {
+    fixture.close();
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  describe('resolveProject', () => {
+    it('resolves by name (case-insensitive) and by id', async () => {
+      await expect(resolveProject(fixture.db, 'acme')).resolves.toMatchObject({
+        id: projectId,
+        name: 'Acme',
+        path: repoPath,
+      });
+      await expect(resolveProject(fixture.db, projectId)).resolves.toMatchObject({
+        id: projectId,
+      });
+    });
+
+    it('throws when the project is unknown', async () => {
+      await expect(resolveProject(fixture.db, 'nope')).rejects.toThrow(/not found/i);
+    });
+  });
+
+  describe('listWorkspaces', () => {
+    beforeEach(() => {
+      // Active workspace + task.
+      fixture.sqlite
+        .prepare(`INSERT INTO workspaces (id, type, path, key) VALUES (?, 'local', ?, ?)`)
+        .run('ws-active', '/x/worktrees/Acme/feat-a', 'key-a');
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO tasks (id, project_id, name, status, task_branch, workspace_id,
+             created_at, updated_at, status_changed_at)
+           VALUES ('t-active', ?, 'A', 'in_progress', 'feat-a', 'ws-active',
+             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run(projectId);
+
+      // Archived workspace + task.
+      fixture.sqlite
+        .prepare(`INSERT INTO workspaces (id, type, path, key) VALUES (?, 'local', ?, ?)`)
+        .run('ws-archived', '/x/worktrees/Acme/feat-b', 'key-b');
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO tasks (id, project_id, name, status, task_branch, workspace_id, archived_at,
+             created_at, updated_at, status_changed_at)
+           VALUES ('t-archived', ?, 'B', 'in_progress', 'feat-b', 'ws-archived', CURRENT_TIMESTAMP,
+             CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run(projectId);
+    });
+
+    it('returns non-archived workspaces by default', async () => {
+      const items = await listWorkspaces(fixture.db);
+      expect(items.map((i) => i.id)).toEqual(['ws-active']);
+      expect(items[0]).toMatchObject({
+        type: 'local',
+        branch: 'feat-a',
+        project: 'Acme',
+        archived: false,
+      });
+    });
+
+    it('includes archived workspaces with --include-archived', async () => {
+      const items = await listWorkspaces(fixture.db, { includeArchived: true });
+      expect(new Set(items.map((i) => i.id))).toEqual(new Set(['ws-active', 'ws-archived']));
+      expect(items.find((i) => i.id === 'ws-archived')?.archived).toBe(true);
+    });
+
+    it('filters by project name', async () => {
+      expect(await listWorkspaces(fixture.db, { project: 'acme' })).toHaveLength(1);
+      expect(await listWorkspaces(fixture.db, { project: 'other' })).toHaveLength(0);
+    });
+  });
+
+  describe('createWorkspace', () => {
+    it('creates a DB row + git worktree shaped like a UI-created workspace', async () => {
+      const result = await createWorkspace(fixture.db, {
+        project: { id: projectId, name: 'Acme', path: repoPath, baseRef: 'main' },
+        branch: 'feature/login',
+        base: 'main',
+        worktreeDirectory: worktreeDir,
+      });
+
+      expect(result.reused).toBe(false);
+      expect(result.type).toBe('local');
+      expect(result.branch).toBe('feature/login');
+
+      // Worktree exists on disk on the new branch.
+      expect(fs.existsSync(path.join(result.path, '.git'))).toBe(true);
+      expect(localBranches(repoPath)).toContain('feature/login');
+      expect(result.path.startsWith(worktreeDir)).toBe(true);
+
+      // Workspace row matches the in-app shape: type 'local' + sha256 key over the path.
+      const [ws] = await fixture.db
+        .select()
+        .from(workspaces)
+        .where(eq(workspaces.id, result.workspaceId));
+      expect(ws).toMatchObject({ type: 'local', path: result.path });
+      expect(ws!.key).toBe(computeWorkspaceKey('local', result.path));
+      expect(result.key).toBe(ws!.key);
+
+      // A parent task row was created and linked (so it shows in the sidebar).
+      const [task] = await fixture.db.select().from(tasks).where(eq(tasks.id, result.taskId));
+      expect(task).toMatchObject({
+        projectId,
+        taskBranch: 'feature/login',
+        status: 'in_progress',
+        workspaceId: result.workspaceId,
+      });
+      expect(JSON.parse(task!.sourceBranch as unknown as string)).toEqual({
+        type: 'local',
+        branch: 'main',
+      });
+    });
+
+    it('is idempotent: re-running returns the existing workspace', async () => {
+      const first = await createWorkspace(fixture.db, {
+        project: { id: projectId, name: 'Acme', path: repoPath, baseRef: 'main' },
+        branch: 'feature/dup',
+        worktreeDirectory: worktreeDir,
+      });
+      const second = await createWorkspace(fixture.db, {
+        project: { id: projectId, name: 'Acme', path: repoPath, baseRef: 'main' },
+        branch: 'feature/dup',
+        worktreeDirectory: worktreeDir,
+      });
+
+      expect(second.reused).toBe(true);
+      expect(second.workspaceId).toBe(first.workspaceId);
+
+      const branchTasks = await fixture.db
+        .select()
+        .from(tasks)
+        .where(eq(tasks.taskBranch, 'feature/dup'));
+      expect(branchTasks).toHaveLength(1);
+    });
+
+    it('checks out an existing branch', async () => {
+      git(repoPath, 'branch', 'already-here');
+      const result = await createWorkspace(fixture.db, {
+        project: { id: projectId, name: 'Acme', path: repoPath, baseRef: 'main' },
+        branch: 'already-here',
+        strategy: 'checkout-existing',
+        worktreeDirectory: worktreeDir,
+      });
+      expect(fs.existsSync(path.join(result.path, '.git'))).toBe(true);
+      expect(result.path.endsWith(path.join('already-here'))).toBe(true);
+    });
+
+    it('supports no-worktree workspaces rooted at the repo', async () => {
+      const result = await createWorkspace(fixture.db, {
+        project: { id: projectId, name: 'Acme', path: repoPath, baseRef: 'main' },
+        strategy: 'no-worktree',
+        name: 'rootless',
+        worktreeDirectory: worktreeDir,
+      });
+      expect(result.branch).toBeNull();
+      expect(result.path).toBe(repoPath);
+      expect(result.key).toBe(computeWorkspaceKey('local', repoPath));
+    });
+
+    // Regression: staub's base_ref is `origin/main` (remote), which used to fail
+    // with branch-not-found because the source was assumed to be a local ref.
+    it('forks from a remote base ref (origin/main)', async () => {
+      addOrigin(repoPath, tmpRoot);
+      const result = await createWorkspace(fixture.db, {
+        project: proj('origin/main'),
+        branch: 'feature/from-remote',
+        base: 'origin/main',
+        worktreeDirectory: worktreeDir,
+      });
+
+      expect(fs.existsSync(path.join(result.path, '.git'))).toBe(true);
+      expect(localBranches(repoPath)).toContain('feature/from-remote');
+
+      const [task] = await fixture.db.select().from(tasks).where(eq(tasks.id, result.taskId));
+      expect(JSON.parse(task!.sourceBranch as unknown as string)).toMatchObject({
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin' },
+      });
+    });
+
+    // Regression: a git failure must not leave orphaned task/workspace rows.
+    it('is atomic — a git failure writes no rows', async () => {
+      await expect(
+        createWorkspace(fixture.db, {
+          project: proj(),
+          branch: 'feature/atomic',
+          base: 'does-not-exist',
+          worktreeDirectory: worktreeDir,
+        })
+      ).rejects.toThrow(/Failed to create worktree|branch-not-found/);
+
+      expect(await fixture.db.select().from(tasks)).toHaveLength(0);
+      expect(await fixture.db.select().from(workspaces)).toHaveLength(0);
+    });
+
+    it('launches an agent and seeds the prompt (--prompt, default agent claude)', async () => {
+      const calls: Array<Record<string, unknown>> = [];
+      const result = await createWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/dispatch',
+        worktreeDirectory: worktreeDir,
+        prompt: 'do the thing',
+        autoApprove: true,
+        dispatch: async (a) => {
+          calls.push(a);
+          return { delivered: true, promptDelivered: true, tmuxSession: 'sess' };
+        },
+      });
+
+      expect(result.agent).toBe('claude');
+      expect(result.conversationId).toBeTruthy();
+      expect(result.promptDelivered).toBe(true);
+
+      // Dispatcher got the worktree cwd + prompt + provider.
+      expect(calls).toHaveLength(1);
+      expect(calls[0]).toMatchObject({
+        cwd: result.path,
+        prompt: 'do the thing',
+        providerId: 'claude',
+        autoApprove: true,
+        conversationId: result.conversationId,
+      });
+
+      // A conversation row was written (so the app adopts the same session).
+      const conv = fixture.sqlite
+        .prepare(
+          'SELECT id, provider, config, is_initial_conversation FROM conversations WHERE task_id = ?'
+        )
+        .get(result.taskId) as
+        | { id: string; provider: string; config: string | null; is_initial_conversation: number }
+        | undefined;
+      expect(conv?.provider).toBe('claude');
+      expect(conv?.is_initial_conversation).toBe(1);
+      expect(JSON.parse(conv!.config!)).toEqual({ autoApprove: true });
+    });
+
+    it('rejects an unknown agent provider', async () => {
+      await expect(
+        createWorkspace(fixture.db, {
+          project: proj(),
+          branch: 'feature/bad-agent',
+          worktreeDirectory: worktreeDir,
+          prompt: 'x',
+          agent: 'not-a-real-agent',
+          dispatch: async () => ({ delivered: true, promptDelivered: true, tmuxSession: 's' }),
+        })
+      ).rejects.toThrow(/unknown agent/i);
+    });
+
+    it('publishes the branch with --push-branch', async () => {
+      addOrigin(repoPath, tmpRoot);
+      const result = await createWorkspace(fixture.db, {
+        project: proj('origin/main'),
+        branch: 'feature/pushed',
+        base: 'origin/main',
+        worktreeDirectory: worktreeDir,
+        pushBranch: true,
+      });
+      expect(result.pushed).toBe(true);
+      // The branch now exists on the origin remote.
+      expect(git(repoPath, 'ls-remote', '--heads', 'origin', 'feature/pushed')).toContain(
+        'feature/pushed'
+      );
+    });
+  });
+
+  describe('removeWorkspace', () => {
+    const seed = (branch = 'feature/rm') =>
+      createWorkspace(fixture.db, { project: proj(), branch, worktreeDirectory: worktreeDir });
+
+    it('tears down worktree + branch + rows, idempotently', async () => {
+      const created = await seed();
+
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/rm',
+        worktreeDirectory: worktreeDir,
+      });
+
+      expect(res).toMatchObject({
+        removedWorktree: true,
+        removedBranch: true,
+        deletedWorkspace: true,
+        deletedTasks: 1,
+        alreadyGone: false,
+      });
+      expect(fs.existsSync(created.path)).toBe(false);
+      expect(localBranches(repoPath)).not.toContain('feature/rm');
+      expect(
+        await fixture.db.select().from(workspaces).where(eq(workspaces.id, created.workspaceId))
+      ).toHaveLength(0);
+
+      // Re-running is a no-op.
+      const again = await removeWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/rm',
+        worktreeDirectory: worktreeDir,
+      });
+      expect(again.alreadyGone).toBe(true);
+    });
+
+    it('removes by workspace id', async () => {
+      const created = await seed('feature/byid');
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(),
+        id: created.workspaceId,
+        worktreeDirectory: worktreeDir,
+      });
+      expect(res.deletedWorkspace).toBe(true);
+      expect(fs.existsSync(created.path)).toBe(false);
+    });
+
+    it('refuses to remove a workspace owned by another project (--id safety)', async () => {
+      // Seed a second project with its own workspace + task.
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO projects (id, name, path, workspace_provider, base_ref, created_at, updated_at)
+           VALUES ('other', 'Other', '/other/repo', 'local', 'main', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run();
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO workspaces (id, type, path, key) VALUES ('ws-other', 'local', '/x/y', 'k-other')`
+        )
+        .run();
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO tasks (id, project_id, name, status, task_branch, workspace_id, created_at, updated_at, status_changed_at)
+           VALUES ('t-other', 'other', 'O', 'in_progress', 'feat-o', 'ws-other', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run();
+
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(), // Acme — NOT the owner of ws-other
+        id: 'ws-other',
+        worktreeDirectory: worktreeDir,
+      });
+      expect(res.alreadyGone).toBe(true);
+      // The other project's workspace + task are untouched.
+      expect(
+        await fixture.db.select().from(workspaces).where(eq(workspaces.id, 'ws-other'))
+      ).toHaveLength(1);
+    });
+
+    it('does not delete a worktree path outside the project pool (rm guard)', async () => {
+      const strayDir = path.join(tmpRoot, 'stray-not-a-worktree');
+      fs.mkdirSync(strayDir, { recursive: true });
+      fs.writeFileSync(path.join(strayDir, 'important.txt'), 'keep me\n');
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO workspaces (id, type, path, key) VALUES ('ws-stray', 'local', ?, 'k-stray')`
+        )
+        .run(strayDir);
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO tasks (id, project_id, name, status, workspace_id, created_at, updated_at, status_changed_at)
+           VALUES ('t-stray', ?, 'S', 'in_progress', 'ws-stray', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run(projectId);
+
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(),
+        id: 'ws-stray',
+        worktreeDirectory: worktreeDir,
+      });
+      // Row deleted, but the out-of-pool directory is NOT recursively removed.
+      expect(res.deletedWorkspace).toBe(true);
+      expect(res.removedWorktree).toBe(false);
+      expect(fs.existsSync(path.join(strayDir, 'important.txt'))).toBe(true);
+    });
+
+    it('runs the pre-remove hook (capture) before teardown', async () => {
+      await seed('feature/hook');
+      const marker = path.join(tmpRoot, 'captured.txt');
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/hook',
+        worktreeDirectory: worktreeDir,
+        preRemoveCmd: `printf '%s' "$EMDASH_BRANCH" > ${marker}`,
+      });
+      expect(res.hookRan).toBe(true);
+      expect(fs.readFileSync(marker, 'utf8')).toBe('feature/hook');
+      expect(res.deletedWorkspace).toBe(true);
+    });
+
+    it('aborts when the hook fails — nothing deleted — unless forced', async () => {
+      const created = await seed('feature/abort');
+
+      await expect(
+        removeWorkspace(fixture.db, {
+          project: proj(),
+          branch: 'feature/abort',
+          worktreeDirectory: worktreeDir,
+          preRemoveCmd: 'exit 3',
+        })
+      ).rejects.toThrow(/code 3/);
+
+      // Hook failure → worktree + rows still present.
+      expect(fs.existsSync(created.path)).toBe(true);
+      expect(
+        await fixture.db.select().from(workspaces).where(eq(workspaces.id, created.workspaceId))
+      ).toHaveLength(1);
+
+      // --force tears down despite the failing hook.
+      const forced = await removeWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/abort',
+        worktreeDirectory: worktreeDir,
+        preRemoveCmd: 'exit 3',
+        force: true,
+      });
+      expect(forced.deletedWorkspace).toBe(true);
+      expect(fs.existsSync(created.path)).toBe(false);
+    });
+
+    const seedUnmerged = async (branch: string) => {
+      const created = await seed(branch);
+      fs.writeFileSync(path.join(created.path, 'extra.txt'), 'work\n');
+      git(created.path, 'add', '.');
+      git(created.path, 'commit', '-m', 'unmerged work');
+      return created;
+    };
+
+    it('keeps a branch with unmerged commits (no silent loss)', async () => {
+      await seedUnmerged('feature/unmerged');
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/unmerged',
+        worktreeDirectory: worktreeDir,
+      });
+      // Worktree + rows torn down, but the branch is preserved (has unmerged work).
+      expect(res.removedWorktree).toBe(true);
+      expect(res.deletedWorkspace).toBe(true);
+      expect(res.removedBranch).toBe(false);
+      expect(res.branchRetained).toBe('unmerged');
+      expect(localBranches(repoPath)).toContain('feature/unmerged');
+    });
+
+    it('force-deletes an unmerged branch with --force', async () => {
+      await seedUnmerged('feature/unmerged-forced');
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/unmerged-forced',
+        worktreeDirectory: worktreeDir,
+        force: true,
+      });
+      expect(res.removedBranch).toBe(true);
+      expect(res.branchRetained).toBeUndefined();
+      expect(localBranches(repoPath)).not.toContain('feature/unmerged-forced');
+    });
+
+    it('skips the hook with skipHook', async () => {
+      const created = await seed('feature/skip');
+      const res = await removeWorkspace(fixture.db, {
+        project: proj(),
+        branch: 'feature/skip',
+        worktreeDirectory: worktreeDir,
+        preRemoveCmd: 'exit 1',
+        skipHook: true,
+      });
+      expect(res.hookRan).toBe(false);
+      expect(res.deletedWorkspace).toBe(true);
+      expect(fs.existsSync(created.path)).toBe(false);
+    });
+  });
+
+  describe('sendToWorkspace', () => {
+    // Seeds a task + (optionally) a conversation, returning the derived tmux name.
+    function seedAgent(branch: string, opts: { conversationId?: string; initial?: boolean } = {}) {
+      const taskId = `task-${branch.replace(/\W/g, '-')}`;
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO tasks (id, project_id, name, status, task_branch, created_at, updated_at, status_changed_at, last_interacted_at)
+           VALUES (?, ?, ?, 'in_progress', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run(taskId, projectId, branch, branch);
+
+      let tmuxName: string | undefined;
+      if (opts.conversationId) {
+        fixture.sqlite
+          .prepare(
+            `INSERT INTO conversations (id, project_id, task_id, title, provider, is_initial_conversation, created_at, updated_at, last_interacted_at)
+             VALUES (?, ?, ?, 'Agent', 'claude', ?, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+          )
+          .run(opts.conversationId, projectId, taskId, opts.initial ? 1 : 0);
+        tmuxName = makeTmuxSessionName(makePtySessionId(projectId, taskId, opts.conversationId));
+      }
+      return { taskId, tmuxName };
+    }
+
+    it('dispatches text then a separate Enter into the agent tmux session', async () => {
+      const { tmuxName } = seedAgent('feature/send', { conversationId: 'conv-1', initial: true });
+      const { runner, calls } = fakeTmux([tmuxName!]);
+
+      const res = await sendToWorkspace(
+        fixture.db,
+        { project: proj(), branch: 'feature/send', message: 'run the tests' },
+        runner
+      );
+
+      expect(res).toMatchObject({
+        delivered: true,
+        conversationId: 'conv-1',
+        tmuxSession: tmuxName,
+      });
+      // Text and submit-Enter are TWO separate send-keys calls (TUI submit quirk);
+      // `--` ends option parsing so a message starting with '-' stays literal.
+      expect(calls).toEqual([
+        { name: tmuxName, keys: ['-l', '--', 'run the tests'] },
+        { name: tmuxName, keys: ['Enter'] },
+      ]);
+    });
+
+    it('does not silently drop when no live session exists', async () => {
+      seedAgent('feature/dead', { conversationId: 'conv-dead', initial: true });
+      const { runner, calls } = fakeTmux([]); // session not present
+
+      const res = await sendToWorkspace(
+        fixture.db,
+        { project: proj(), branch: 'feature/dead', message: 'hi' },
+        runner
+      );
+
+      expect(res.delivered).toBe(false);
+      expect(res.reason).toBe('no-active-session');
+      expect(calls).toHaveLength(0); // nothing sent
+    });
+
+    it('reports no-conversation when the task has no agent session', async () => {
+      seedAgent('feature/noconv'); // task but no conversation
+      const { runner } = fakeTmux();
+      const res = await sendToWorkspace(
+        fixture.db,
+        { project: proj(), branch: 'feature/noconv', message: 'hi' },
+        runner
+      );
+      expect(res.delivered).toBe(false);
+      expect(res.reason).toBe('no-conversation');
+    });
+
+    it('targets the initial conversation by default', async () => {
+      const { taskId } = seedAgent('feature/multi', {
+        conversationId: 'conv-secondary',
+        initial: false,
+      });
+      // Add the initial conversation for the same task.
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO conversations (id, project_id, task_id, title, provider, is_initial_conversation, created_at, updated_at, last_interacted_at)
+           VALUES ('conv-initial', ?, ?, 'Agent', 'claude', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run(projectId, taskId);
+      const initialTmux = makeTmuxSessionName(makePtySessionId(projectId, taskId, 'conv-initial'));
+      const { runner } = fakeTmux([initialTmux]);
+
+      const res = await sendToWorkspace(
+        fixture.db,
+        { project: proj(), branch: 'feature/multi', message: 'go' },
+        runner
+      );
+      expect(res.delivered).toBe(true);
+      expect(res.conversationId).toBe('conv-initial');
+    });
+  });
+});

--- a/src/main/cli/workspace-commands.db.test.ts
+++ b/src/main/cli/workspace-commands.db.test.ts
@@ -664,5 +664,36 @@ describe('workspace cli commands', () => {
       expect(res.delivered).toBe(true);
       expect(res.conversationId).toBe('conv-initial');
     });
+
+    it('falls back to a live conversation when the preferred conversation is stale', async () => {
+      const { taskId } = seedAgent('feature/stale-initial', {
+        conversationId: 'conv-stale-initial',
+        initial: true,
+      });
+      fixture.sqlite
+        .prepare(
+          `INSERT INTO conversations (id, project_id, task_id, title, provider, is_initial_conversation, created_at, updated_at, last_interacted_at)
+           VALUES ('conv-live', ?, ?, 'Agent', 'claude', 0, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)`
+        )
+        .run(projectId, taskId);
+      const liveTmux = makeTmuxSessionName(makePtySessionId(projectId, taskId, 'conv-live'));
+      const { runner, calls } = fakeTmux([liveTmux]);
+
+      const res = await sendToWorkspace(
+        fixture.db,
+        { project: proj(), branch: 'feature/stale-initial', message: 'still there?' },
+        runner
+      );
+
+      expect(res).toMatchObject({
+        delivered: true,
+        conversationId: 'conv-live',
+        tmuxSession: liveTmux,
+      });
+      expect(calls).toEqual([
+        { name: liveTmux, keys: ['-l', '--', 'still there?'] },
+        { name: liveTmux, keys: ['Enter'] },
+      ]);
+    });
   });
 });

--- a/src/main/cli/workspace-commands.ts
+++ b/src/main/cli/workspace-commands.ts
@@ -1,0 +1,853 @@
+/**
+ * Core (db-injected, Electron-free) implementations of the `emdash workspace`
+ * CLI command group. Kept free of eager db-bound singletons so it can be unit
+ * tested against a temp SQLite database via `openFixture`.
+ *
+ * `createWorkspace` reuses the same git/worktree services and the same
+ * key-hash logic the app uses, so the rows + worktree it produces are
+ * indistinguishable from a UI-created workspace.
+ */
+
+import { spawnSync } from 'node:child_process';
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { and, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import type { GitService } from '@main/core/git/impl/git-service';
+import type { ProjectSettingsProvider } from '@main/core/projects/settings/provider';
+import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { fromStoredBranch, toStoredBranch } from '@main/core/tasks/stored-branch';
+import { computeWorkspaceKey } from '@main/core/workspaces/workspace-key';
+import type { AppDb } from '@main/db/client';
+import { conversations, projects, tasks, workspaces } from '@main/db/schema';
+import { getProvider, type AgentProviderId } from '@shared/agent-provider-registry';
+import { serializeConversationConfig } from '@shared/conversation-config';
+import type { Branch } from '@shared/git';
+import { makePtySessionId } from '@shared/ptySessionId';
+import type { AgentDispatchResult } from './agent-dispatch';
+import { buildLocalWorktreeContext, type LocalWorktreeContext } from './local-worktree';
+
+/**
+ * Launches the agent for a freshly-created conversation. Injected by the CLI
+ * entry (which resolves provider config + env); tests pass a fake. Returns
+ * whether the agent session is up and whether the prompt was delivered.
+ */
+export type CreateAgentDispatcher = (args: {
+  projectId: string;
+  taskId: string;
+  conversationId: string;
+  providerId: AgentProviderId;
+  autoApprove: boolean;
+  prompt: string;
+  cwd: string;
+}) => Promise<AgentDispatchResult>;
+
+export type WorkspaceStrategy = 'new-branch' | 'checkout-existing' | 'no-worktree';
+
+export type ResolvedProject = {
+  id: string;
+  name: string;
+  path: string;
+  baseRef: string;
+};
+
+export type CreateWorkspaceOptions = {
+  project: ResolvedProject;
+  /** Required for worktree strategies; ignored for `no-worktree`. */
+  branch?: string;
+  /** Source branch to fork from (defaults to the project's base ref). */
+  base?: string;
+  /** Task display name (defaults to the branch name). */
+  name?: string;
+  strategy?: WorkspaceStrategy;
+  /** Resolved worktree pool directory. Falls back to `settings` when omitted. */
+  worktreeDirectory?: string;
+  /** Real project settings (production) for parity; optional in tests. */
+  settings?: ProjectSettingsProvider;
+  /** Initial prompt — when set, launches the agent and seeds it (one-shot dispatch). */
+  prompt?: string;
+  /** Agent provider id (defaults to `claude`). */
+  agent?: string;
+  /** Launch the agent with permissions auto-approved. */
+  autoApprove?: boolean;
+  /** Publish the new branch to the push remote after creating the worktree. */
+  pushBranch?: boolean;
+  /** Agent launcher (injected by the entry; required when `prompt` is set). */
+  dispatch?: CreateAgentDispatcher;
+};
+
+export type CreateWorkspaceResult = {
+  workspaceId: string;
+  taskId: string;
+  branch: string | null;
+  path: string;
+  key: string | null;
+  type: 'local';
+  /** True when an existing workspace for this branch was returned unchanged. */
+  reused: boolean;
+  /** Agent provider id (when --prompt launched one). */
+  agent?: string;
+  /** Conversation id of the launched agent session. */
+  conversationId?: string;
+  /** Whether the initial prompt was delivered to the agent. */
+  promptDelivered?: boolean;
+  /** Whether the branch was pushed (when --push-branch). */
+  pushed?: boolean;
+  /** Non-fatal warning (e.g. tmux mode off → the app won't adopt the dispatched agent). */
+  warning?: string;
+};
+
+export type WorkspaceListItem = {
+  id: string;
+  type: string;
+  branch: string | null;
+  project: string | null;
+  path: string | null;
+  linesAdded: number | null;
+  linesDeleted: number | null;
+  archived: boolean;
+  createdAt: string;
+};
+
+export type ListWorkspacesOptions = {
+  /** Filter by project name or id (case-insensitive). */
+  project?: string;
+  includeArchived?: boolean;
+};
+
+export type RemoveWorkspaceOptions = {
+  project: ResolvedProject;
+  /** Target by branch (the create counterpart) … */
+  branch?: string;
+  /** … or by workspace id. */
+  id?: string;
+  /** Command run in the worktree before teardown (capture-before-delete). */
+  preRemoveCmd?: string;
+  /** Skip the pre-remove hook entirely. */
+  skipHook?: boolean;
+  /** Proceed with teardown even if the hook fails / force-remove the worktree. */
+  force?: boolean;
+  worktreeDirectory?: string;
+  settings?: ProjectSettingsProvider;
+};
+
+export type RemoveWorkspaceResult = {
+  workspaceId: string | null;
+  branch: string | null;
+  hookRan: boolean;
+  removedWorktree: boolean;
+  removedBranch: boolean;
+  /** Branch kept (not deleted) because it has unmerged commits; pass --force to delete. */
+  branchRetained?: 'unmerged';
+  deletedTasks: number;
+  deletedWorkspace: boolean;
+  /** Nothing matched — already torn down (idempotent no-op). */
+  alreadyGone: boolean;
+};
+
+/**
+ * Resolves a project by id or (case-insensitive) name. Throws a descriptive
+ * error when nothing matches or a name is ambiguous.
+ */
+export async function resolveProject(db: AppDb, nameOrId: string): Promise<ResolvedProject> {
+  const rows = await db.select().from(projects);
+  const matches = rows.filter(
+    (r) => r.id === nameOrId || r.name.toLowerCase() === nameOrId.toLowerCase()
+  );
+  if (matches.length === 0) {
+    throw new Error(`Project not found: ${nameOrId}`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      `Ambiguous project "${nameOrId}" — matches ${matches.length} projects; pass the project id instead.`
+    );
+  }
+  const row = matches[0]!;
+  if (row.workspaceProvider !== 'local') {
+    throw new Error(
+      `Project "${row.name}" is not a local project (CLI supports local projects only).`
+    );
+  }
+  return { id: row.id, name: row.name, path: row.path, baseRef: row.baseRef ?? 'main' };
+}
+
+/**
+ * Resolves a base ref string (which may be local like `main`, or remote like
+ * `origin/main`) into a typed `Branch`. This is what lets `create` fork from a
+ * remote default branch — the common real-world case where there's no local
+ * branch of that name.
+ */
+async function resolveBaseBranch(repoGit: GitService, base: string): Promise<Branch> {
+  const trimmed = base.trim();
+
+  const remotes = await repoGit.getRemotes().catch(() => []);
+  for (const remote of remotes) {
+    if (trimmed.startsWith(`${remote.name}/`)) {
+      return {
+        type: 'remote',
+        branch: trimmed.slice(remote.name.length + 1),
+        remote: { name: remote.name, url: remote.url },
+      };
+    }
+  }
+
+  const branches = await repoGit.getBranches().catch(() => []);
+  if (branches.some((b) => b.type === 'local' && b.branch === trimmed)) {
+    return { type: 'local', branch: trimmed };
+  }
+  const remoteMatch = branches.find((b) => b.type === 'remote' && b.branch === trimmed);
+  if (remoteMatch && remoteMatch.type === 'remote') {
+    return { type: 'remote', branch: trimmed, remote: remoteMatch.remote };
+  }
+
+  // Fall back to a local ref; downstream produces a clear branch-not-found error.
+  return { type: 'local', branch: trimmed };
+}
+
+type WorktreeServiceLike = LocalWorktreeContext['worktreeService'];
+
+function describeWorktreeError(error: unknown): string {
+  if (error && typeof error === 'object' && 'type' in error) {
+    return String((error as { type: unknown }).type);
+  }
+  return String(error);
+}
+
+/**
+ * Creates (or reuses) the git worktree for a branch and returns its absolute
+ * path. Pure git work — performs NO database writes, so the caller can persist
+ * rows only after this succeeds (atomic create).
+ */
+async function materializeWorktree(
+  worktreeService: WorktreeServiceLike,
+  args: { taskBranch: string | null; sourceBranch: Branch | undefined; repoPath: string }
+): Promise<string> {
+  if (!args.taskBranch) {
+    return args.repoPath;
+  }
+  if (!args.sourceBranch || args.taskBranch === args.sourceBranch.branch) {
+    const result = await worktreeService.checkoutExistingBranch(args.taskBranch);
+    if (!result.success) {
+      throw new Error(
+        `Failed to check out branch "${args.taskBranch}": ${describeWorktreeError(result.error)}`
+      );
+    }
+    return result.data;
+  }
+  const result = await worktreeService.checkoutBranchWorktree(args.sourceBranch, args.taskBranch);
+  if (!result.success) {
+    throw new Error(
+      `Failed to create worktree for "${args.taskBranch}": ${describeWorktreeError(result.error)}`
+    );
+  }
+  return result.data;
+}
+
+/**
+ * Creates a workspace (and its parent task) for a local project, reusing the
+ * in-app worktree + key-hash path.
+ *
+ * Atomic: the git worktree is created first; database rows are written only
+ * after the worktree succeeds, so a git failure never leaves orphaned rows.
+ *
+ * Idempotent: if a non-archived task already owns the branch, the existing
+ * workspace's worktree is ensured and returned instead of duplicating.
+ */
+export async function createWorkspace(
+  db: AppDb,
+  opts: CreateWorkspaceOptions
+): Promise<CreateWorkspaceResult> {
+  const strategy: WorkspaceStrategy = opts.strategy ?? 'new-branch';
+  const base = (opts.base ?? opts.project.baseRef ?? 'main').trim();
+
+  if (strategy !== 'no-worktree' && !opts.branch) {
+    throw new Error('--branch is required (omit only with --no-worktree).');
+  }
+
+  const taskBranch = strategy === 'no-worktree' ? null : opts.branch!.trim();
+  const name = (opts.name ?? taskBranch ?? 'workspace').trim();
+
+  const worktreeDirectory = opts.worktreeDirectory ?? (await opts.settings?.getWorktreeDirectory());
+  if (!worktreeDirectory) {
+    throw new Error('Could not resolve a worktree directory for this project.');
+  }
+
+  const { worktreeService, repoGit } = await buildLocalWorktreeContext({
+    projectName: opts.project.name,
+    projectId: opts.project.id,
+    repoPath: opts.project.path,
+    baseRef: opts.project.baseRef,
+    worktreeDirectory,
+    settings: opts.settings,
+  });
+
+  // Resolve the source branch up front — handles both local (`main`) and remote
+  // (`origin/main`) bases. checkout-existing forks from the branch itself.
+  const sourceBranch: Branch | undefined =
+    taskBranch === null
+      ? { type: 'local', branch: base }
+      : strategy === 'checkout-existing'
+        ? { type: 'local', branch: taskBranch }
+        : await resolveBaseBranch(repoGit, base);
+
+  // Idempotency: an existing, non-archived task on the same branch already owns
+  // a workspace — ensure its worktree exists and return it unchanged.
+  if (taskBranch) {
+    const [existingTask] = await db
+      .select()
+      .from(tasks)
+      .where(
+        and(
+          eq(tasks.projectId, opts.project.id),
+          eq(tasks.taskBranch, taskBranch),
+          isNull(tasks.archivedAt)
+        )
+      )
+      .orderBy(desc(tasks.createdAt))
+      .limit(1);
+
+    if (existingTask?.workspaceId) {
+      const [ws] = await db
+        .select()
+        .from(workspaces)
+        .where(eq(workspaces.id, existingTask.workspaceId));
+      if (ws) {
+        const wpath = await materializeWorktree(worktreeService, {
+          taskBranch,
+          sourceBranch: fromStoredBranch(existingTask.sourceBranch) ?? sourceBranch,
+          repoPath: opts.project.path,
+        });
+        const key = computeWorkspaceKey('local', wpath);
+        await db
+          .update(workspaces)
+          .set({ path: wpath, key, updatedAt: sql`CURRENT_TIMESTAMP` })
+          .where(eq(workspaces.id, ws.id));
+        return {
+          workspaceId: ws.id,
+          taskId: existingTask.id,
+          branch: taskBranch,
+          path: wpath,
+          key,
+          type: 'local',
+          reused: true,
+        };
+      }
+    }
+  }
+
+  // --- Git first (atomic): nothing is written to the DB until this succeeds.
+  const workspacePath = await materializeWorktree(worktreeService, {
+    taskBranch,
+    sourceBranch,
+    repoPath: opts.project.path,
+  });
+
+  const key = computeWorkspaceKey('local', workspacePath);
+
+  // persistPath dedupe: if a workspace already owns this path, reuse it.
+  const [existingWs] = await db.select().from(workspaces).where(eq(workspaces.key, key));
+  let workspaceId: string;
+  let reused: boolean;
+  if (existingWs) {
+    workspaceId = existingWs.id;
+    reused = true;
+    await db
+      .update(workspaces)
+      .set({ path: workspacePath, key, updatedAt: sql`CURRENT_TIMESTAMP` })
+      .where(eq(workspaces.id, workspaceId));
+  } else {
+    workspaceId = crypto.randomUUID();
+    reused = false;
+    await db
+      .insert(workspaces)
+      .values({ id: workspaceId, type: 'local', path: workspacePath, key });
+  }
+
+  const taskId = crypto.randomUUID();
+  try {
+    await db.insert(tasks).values({
+      id: taskId,
+      projectId: opts.project.id,
+      name,
+      taskBranch,
+      status: 'in_progress',
+      sourceBranch: toStoredBranch(sourceBranch),
+      workspaceProvider: null,
+      workspaceId,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+      statusChangedAt: sql`CURRENT_TIMESTAMP`,
+      lastInteractedAt: sql`CURRENT_TIMESTAMP`,
+    });
+  } catch (error) {
+    // Roll back the freshly-created workspace row so a task-insert failure
+    // doesn't leave an orphan.
+    if (!reused) {
+      await db
+        .delete(workspaces)
+        .where(eq(workspaces.id, workspaceId))
+        .catch(() => {});
+    }
+    throw error;
+  }
+
+  // Optionally publish the new branch.
+  let pushed: boolean | undefined;
+  if (opts.pushBranch && taskBranch) {
+    const pushRemote = (await opts.settings?.getPushRemote().catch(() => undefined)) ?? 'origin';
+    const result = await repoGit.publishBranch(taskBranch, pushRemote);
+    pushed = result.success;
+  }
+
+  // Optionally launch the agent and seed it with the initial prompt (one-shot
+  // dispatch: create → open → send collapsed into one call).
+  let agent: string | undefined;
+  let conversationId: string | undefined;
+  let promptDelivered: boolean | undefined;
+  let warning: string | undefined;
+  if (opts.prompt) {
+    const providerId = (opts.agent ?? 'claude') as AgentProviderId;
+    if (!getProvider(providerId)) {
+      throw new Error(`Unknown agent provider: ${providerId}`);
+    }
+    if (!opts.dispatch) {
+      throw new Error('Agent dispatch is unavailable (no dispatcher wired).');
+    }
+    // The app only adopts a tmux-backed agent session when the project has tmux
+    // mode on; otherwise opening the task spawns a second (non-tmux) agent.
+    const tmuxOn = (await opts.settings?.get().catch(() => undefined))?.tmux ?? false;
+    if (!tmuxOn) {
+      warning =
+        'tmux mode is off for this project — the desktop app will spawn its own agent ' +
+        'when this task is opened instead of adopting the CLI-launched one. Enable tmux ' +
+        'mode (project setting) for one-shot dispatch to be adopted by the app.';
+    }
+    agent = providerId;
+    conversationId = crypto.randomUUID();
+    await db.insert(conversations).values({
+      id: conversationId,
+      projectId: opts.project.id,
+      taskId,
+      title: getProvider(providerId)?.name ?? providerId,
+      provider: providerId,
+      config: opts.autoApprove ? serializeConversationConfig({ autoApprove: true }) : null,
+      isInitialConversation: true,
+      updatedAt: sql`CURRENT_TIMESTAMP`,
+      // Match the app: ISO string (not CURRENT_TIMESTAMP) so text-sorted
+      // `desc(lastInteractedAt)` orders CLI- and app-created conversations correctly.
+      lastInteractedAt: new Date().toISOString(),
+    });
+    const dispatched = await opts.dispatch({
+      projectId: opts.project.id,
+      taskId,
+      conversationId,
+      providerId,
+      autoApprove: opts.autoApprove ?? false,
+      prompt: opts.prompt,
+      cwd: workspacePath,
+    });
+    promptDelivered = dispatched.delivered && dispatched.promptDelivered;
+  }
+
+  return {
+    workspaceId,
+    taskId,
+    branch: taskBranch,
+    path: workspacePath,
+    key,
+    type: 'local',
+    reused,
+    agent,
+    conversationId,
+    promptDelivered,
+    pushed,
+    warning,
+  };
+}
+
+function runPreRemoveHook(
+  cmd: string,
+  cwd: string,
+  env: Record<string, string>
+): { ok: boolean; code: number | null } {
+  const result = spawnSync('sh', ['-c', cmd], {
+    cwd,
+    env: { ...process.env, ...env },
+    stdio: 'inherit',
+  });
+  if (result.error) {
+    throw new Error(`Pre-remove hook failed to start: ${result.error.message}`);
+  }
+  return { ok: result.status === 0, code: result.status };
+}
+
+/**
+ * Tears down a workspace: runs an optional capture hook, then removes the git
+ * worktree, deletes the branch, and deletes the workspace + its task rows.
+ *
+ * Idempotent (re-running after a partial/complete removal succeeds) and
+ * hook-safe: if the pre-remove hook fails, nothing is deleted unless `force`.
+ */
+export async function removeWorkspace(
+  db: AppDb,
+  opts: RemoveWorkspaceOptions
+): Promise<RemoveWorkspaceResult> {
+  if (!opts.branch && !opts.id) {
+    throw new Error('Pass --branch <b> or --id <workspaceId> to remove.');
+  }
+
+  // Resolve the target workspace + the tasks pointing at it.
+  let workspaceId: string | undefined = opts.id;
+  let branch: string | null = opts.branch ?? null;
+
+  if (!workspaceId && opts.branch) {
+    const [task] = await db
+      .select()
+      .from(tasks)
+      .where(and(eq(tasks.projectId, opts.project.id), eq(tasks.taskBranch, opts.branch)))
+      .orderBy(desc(tasks.createdAt))
+      .limit(1);
+    workspaceId = task?.workspaceId ?? undefined;
+  }
+
+  const emptyResult: RemoveWorkspaceResult = {
+    workspaceId: workspaceId ?? null,
+    branch,
+    hookRan: false,
+    removedWorktree: false,
+    removedBranch: false,
+    deletedTasks: 0,
+    deletedWorkspace: false,
+    alreadyGone: true,
+  };
+
+  if (!workspaceId) {
+    // Nothing matched — treat as already-removed (idempotent).
+    return emptyResult;
+  }
+
+  const [ws] = await db.select().from(workspaces).where(eq(workspaces.id, workspaceId));
+  const allLinkedTasks = await db.select().from(tasks).where(eq(tasks.workspaceId, workspaceId));
+
+  // Safety: never act on a workspace that belongs to a different project (e.g.
+  // `--project A --id <belongs-to-B>`). Only operate on this project's tasks.
+  const linkedTasks = allLinkedTasks.filter((t) => t.projectId === opts.project.id);
+  if (allLinkedTasks.length > 0 && linkedTasks.length === 0) {
+    return emptyResult; // workspace is owned by another project
+  }
+
+  if (!ws && linkedTasks.length === 0) {
+    return emptyResult;
+  }
+
+  if (!branch) {
+    branch = linkedTasks.find((t) => t.taskBranch)?.taskBranch ?? null;
+  }
+
+  const worktreeDirectory = opts.worktreeDirectory ?? (await opts.settings?.getWorktreeDirectory());
+  const worktreePath = ws?.path ?? null;
+
+  const { worktreeService, repoGit, poolPath } = await buildLocalWorktreeContext({
+    projectName: opts.project.name,
+    projectId: opts.project.id,
+    repoPath: opts.project.path,
+    baseRef: opts.project.baseRef,
+    worktreeDirectory: worktreeDirectory ?? opts.project.path,
+    settings: opts.settings,
+  });
+
+  const pathExists = worktreePath ? fs.existsSync(worktreePath) : false;
+
+  // --- Pre-remove hook (capture-before-delete). Abort on failure unless forced.
+  let hookRan = false;
+  if (opts.preRemoveCmd && !opts.skipHook) {
+    const cwd = pathExists ? worktreePath! : opts.project.path;
+    const { ok, code } = runPreRemoveHook(opts.preRemoveCmd, cwd, {
+      EMDASH_WORKSPACE_ID: workspaceId,
+      EMDASH_WORKSPACE_PATH: worktreePath ?? '',
+      EMDASH_BRANCH: branch ?? '',
+      EMDASH_PROJECT: opts.project.name,
+    });
+    hookRan = true;
+    if (!ok && !opts.force) {
+      throw new Error(
+        `Pre-remove hook exited with code ${code}; aborting (nothing deleted). ` +
+          `Use --force to remove anyway or --skip-hook to bypass.`
+      );
+    }
+  }
+
+  // --- Kill any live agent tmux sessions for this workspace BEFORE removing the
+  // worktree, so we don't delete the cwd out from under a running agent or leave
+  // an orphaned session (mirrors the app's teardownTask killing the session).
+  const convs = linkedTasks.length
+    ? await db
+        .select()
+        .from(conversations)
+        .where(
+          inArray(
+            conversations.taskId,
+            linkedTasks.map((t) => t.id)
+          )
+        )
+    : [];
+  for (const conv of convs) {
+    const sessionName = makeTmuxSessionName(
+      makePtySessionId(opts.project.id, conv.taskId, conv.id)
+    );
+    spawnSync('tmux', ['kill-session', '-t', sessionName], { stdio: 'ignore' });
+  }
+
+  // --- Teardown (best-effort + idempotent).
+  // Guard: only remove a worktree that lives inside this project's worktree pool
+  // (never rm an arbitrary path a stale/mistargeted row might hold, nor the repo root).
+  const insidePool =
+    !!worktreePath &&
+    worktreePath !== opts.project.path &&
+    (worktreePath === poolPath || worktreePath.startsWith(poolPath + path.sep));
+  let removedWorktree = false;
+  if (pathExists && insidePool) {
+    await worktreeService.removeWorktree(worktreePath!);
+    removedWorktree = true;
+  }
+
+  // Don't delete the project's own base branch.
+  const baseLocalName = opts.project.baseRef.includes('/')
+    ? opts.project.baseRef.slice(opts.project.baseRef.indexOf('/') + 1)
+    : opts.project.baseRef;
+  let removedBranch = false;
+  let branchRetained: 'unmerged' | undefined;
+  if (branch && branch !== baseLocalName) {
+    // Safe delete by default (-d, fails on unmerged commits → keeps the branch
+    // so work is never silently lost). --force uses -D to delete regardless.
+    const result = await repoGit.deleteBranch(branch, opts.force ?? false);
+    removedBranch = result.success;
+    if (!result.success && result.error.type === 'unmerged') {
+      branchRetained = 'unmerged';
+    }
+  }
+
+  let deletedTasks = 0;
+  for (const task of linkedTasks) {
+    await db.delete(tasks).where(eq(tasks.id, task.id));
+    deletedTasks++;
+  }
+
+  let deletedWorkspace = false;
+  if (ws) {
+    await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
+    deletedWorkspace = true;
+  }
+
+  return {
+    workspaceId,
+    branch,
+    hookRan,
+    removedWorktree,
+    removedBranch,
+    branchRetained,
+    deletedTasks,
+    deletedWorkspace,
+    alreadyGone: false,
+  };
+}
+
+export type SendWorkspaceOptions = {
+  project: ResolvedProject;
+  /** Target by branch … */
+  branch?: string;
+  /** … or by workspace id. */
+  id?: string;
+  /** Target a specific conversation; defaults to the task's primary agent session. */
+  conversationId?: string;
+  message: string;
+};
+
+export type SendWorkspaceResult = {
+  delivered: boolean;
+  reason?: 'no-task' | 'no-conversation' | 'no-active-session' | 'send-failed';
+  taskId: string | null;
+  conversationId: string | null;
+  /** The tmux session targeted (derived identically to the app). */
+  tmuxSession: string | null;
+};
+
+/** Indirection over `tmux` so the dispatch logic is unit-testable without tmux. */
+export type TmuxRunner = {
+  hasSession(name: string): boolean;
+  sendKeys(name: string, keys: string[]): boolean;
+};
+
+const defaultTmuxRunner: TmuxRunner = {
+  hasSession(name) {
+    return spawnSync('tmux', ['has-session', '-t', name], { stdio: 'ignore' }).status === 0;
+  },
+  sendKeys(name, keys) {
+    return spawnSync('tmux', ['send-keys', '-t', name, ...keys], { stdio: 'ignore' }).status === 0;
+  },
+};
+
+/**
+ * Dispatches a message to a worktree's live agent by writing into the tmux
+ * session emdash runs the agent in (requires tmux mode enabled for the
+ * project). One-way / fire-and-forget.
+ *
+ * The text and the submit key are sent as TWO separate `send-keys` calls: a
+ * trailing newline in the same call lands the text but doesn't submit a TUI
+ * agent like Claude — a bare Enter as its own key event does.
+ *
+ * Never silently drops: returns `delivered:false` with a clear `reason`
+ * (`no-active-session` when the agent isn't running in tmux).
+ */
+export async function sendToWorkspace(
+  db: AppDb,
+  opts: SendWorkspaceOptions,
+  tmux: TmuxRunner = defaultTmuxRunner
+): Promise<SendWorkspaceResult> {
+  if (!opts.message) throw new Error('--message <text> is required.');
+  if (!opts.branch && !opts.id) {
+    throw new Error('Pass --branch <b> or --id <workspaceId> to send.');
+  }
+
+  const taskWhere = opts.branch
+    ? and(eq(tasks.projectId, opts.project.id), eq(tasks.taskBranch, opts.branch))
+    : and(eq(tasks.projectId, opts.project.id), eq(tasks.workspaceId, opts.id!));
+  const [task] = await db
+    .select()
+    .from(tasks)
+    .where(taskWhere)
+    .orderBy(desc(tasks.lastInteractedAt))
+    .limit(1);
+
+  const base = { taskId: task?.id ?? null, conversationId: null, tmuxSession: null } as const;
+  if (!task) {
+    return { delivered: false, reason: 'no-task', ...base };
+  }
+
+  let conversationId = opts.conversationId;
+  if (!conversationId) {
+    const convs = await db
+      .select()
+      .from(conversations)
+      .where(eq(conversations.taskId, task.id))
+      .orderBy(desc(conversations.isInitialConversation), desc(conversations.lastInteractedAt));
+    conversationId = convs[0]?.id;
+  }
+  if (!conversationId) {
+    return {
+      delivered: false,
+      reason: 'no-conversation',
+      taskId: task.id,
+      conversationId: null,
+      tmuxSession: null,
+    };
+  }
+
+  const tmuxSession = makeTmuxSessionName(
+    makePtySessionId(opts.project.id, task.id, conversationId)
+  );
+
+  if (!tmux.hasSession(tmuxSession)) {
+    return {
+      delivered: false,
+      reason: 'no-active-session',
+      taskId: task.id,
+      conversationId,
+      tmuxSession,
+    };
+  }
+
+  // `-l` = literal text; `--` ends option parsing so a message starting with
+  // '-' isn't misread as a send-keys flag. Enter is sent as its own key event.
+  const sentText = tmux.sendKeys(tmuxSession, ['-l', '--', opts.message]);
+  const sentEnter = sentText && tmux.sendKeys(tmuxSession, ['Enter']);
+  if (!sentText || !sentEnter) {
+    return {
+      delivered: false,
+      reason: 'send-failed',
+      taskId: task.id,
+      conversationId,
+      tmuxSession,
+    };
+  }
+
+  return { delivered: true, taskId: task.id, conversationId, tmuxSession };
+}
+
+/** Best-effort project name derived from a worktree path (…/worktrees/<project>/<branch>). */
+function deriveProjectFromPath(p: string | null): string | null {
+  if (!p) return null;
+  const parts = p.split(path.sep).filter(Boolean);
+  const idx = parts.lastIndexOf('worktrees');
+  if (idx !== -1 && idx + 1 < parts.length) return parts[idx + 1]!;
+  return null;
+}
+
+/**
+ * Lists workspaces from the workspaces table, enriched (via a tasks/projects
+ * join) with the owning project name, branch and archived state. Defaults to
+ * non-archived only.
+ */
+export async function listWorkspaces(
+  db: AppDb,
+  opts: ListWorkspacesOptions = {}
+): Promise<WorkspaceListItem[]> {
+  const rows = await db
+    .select({
+      ws: workspaces,
+      taskId: tasks.id,
+      taskBranch: tasks.taskBranch,
+      archivedAt: tasks.archivedAt,
+      projectName: projects.name,
+    })
+    .from(workspaces)
+    .leftJoin(tasks, eq(tasks.workspaceId, workspaces.id))
+    .leftJoin(projects, eq(projects.id, tasks.projectId))
+    .orderBy(desc(workspaces.createdAt));
+
+  // Collapse one-or-more task rows per workspace into a single item. Prefer a
+  // non-archived task for the displayed branch/project.
+  const byId = new Map<string, WorkspaceListItem>();
+  for (const row of rows) {
+    const hasTask = row.taskId !== null;
+    const taskArchived = hasTask && row.archivedAt !== null;
+    const existing = byId.get(row.ws.id);
+
+    if (!existing) {
+      byId.set(row.ws.id, {
+        id: row.ws.id,
+        type: row.ws.type,
+        branch: row.taskBranch ?? null,
+        project: row.projectName ?? deriveProjectFromPath(row.ws.path),
+        path: row.ws.path,
+        linesAdded: row.ws.linesAdded,
+        linesDeleted: row.ws.linesDeleted,
+        // A workspace with tasks is archived only when ALL its tasks are.
+        archived: hasTask ? taskArchived : false,
+        createdAt: row.ws.createdAt,
+      });
+      continue;
+    }
+
+    // Merge additional task rows: an active task wins for display + archived.
+    if (hasTask && !taskArchived) {
+      existing.archived = false;
+      existing.branch = row.taskBranch ?? existing.branch;
+      existing.project = row.projectName ?? existing.project;
+    } else if (hasTask && existing.archived) {
+      existing.branch = existing.branch ?? row.taskBranch ?? null;
+    }
+  }
+
+  let items = Array.from(byId.values());
+
+  if (!opts.includeArchived) {
+    items = items.filter((item) => !item.archived);
+  }
+
+  if (opts.project) {
+    const needle = opts.project.toLowerCase();
+    items = items.filter((item) => (item.project ?? '').toLowerCase() === needle);
+  }
+
+  return items;
+}

--- a/src/main/cli/workspace-commands.ts
+++ b/src/main/cli/workspace-commands.ts
@@ -723,16 +723,50 @@ export async function sendToWorkspace(
     return { delivered: false, reason: 'no-task', ...base };
   }
 
-  let conversationId = opts.conversationId;
-  if (!conversationId) {
+  let conversationId: string | undefined;
+  let tmuxSession: string | undefined;
+  let activeSession = false;
+
+  if (opts.conversationId) {
+    conversationId = opts.conversationId;
+    tmuxSession = makeTmuxSessionName(makePtySessionId(opts.project.id, task.id, conversationId));
+    activeSession = tmux.hasSession(tmuxSession);
+  } else {
     const convs = await db
       .select()
       .from(conversations)
       .where(eq(conversations.taskId, task.id))
       .orderBy(desc(conversations.isInitialConversation), desc(conversations.lastInteractedAt));
-    conversationId = convs[0]?.id;
+    if (convs.length === 0) {
+      return {
+        delivered: false,
+        reason: 'no-conversation',
+        taskId: task.id,
+        conversationId: null,
+        tmuxSession: null,
+      };
+    }
+
+    for (const conv of convs) {
+      const candidateSession = makeTmuxSessionName(
+        makePtySessionId(opts.project.id, task.id, conv.id)
+      );
+      if (tmux.hasSession(candidateSession)) {
+        conversationId = conv.id;
+        tmuxSession = candidateSession;
+        activeSession = true;
+        break;
+      }
+    }
+
+    if (!conversationId || !tmuxSession) {
+      const preferred = convs[0]!;
+      conversationId = preferred.id;
+      tmuxSession = makeTmuxSessionName(makePtySessionId(opts.project.id, task.id, preferred.id));
+    }
   }
-  if (!conversationId) {
+
+  if (!conversationId || !tmuxSession) {
     return {
       delivered: false,
       reason: 'no-conversation',
@@ -742,11 +776,7 @@ export async function sendToWorkspace(
     };
   }
 
-  const tmuxSession = makeTmuxSessionName(
-    makePtySessionId(opts.project.id, task.id, conversationId)
-  );
-
-  if (!tmux.hasSession(tmuxSession)) {
+  if (!activeSession) {
     return {
       delivered: false,
       reason: 'no-active-session',

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -39,6 +39,7 @@ export default defineConfig({
             'src/main/db/tests/migrations/**',
             'src/main/db/legacy-port/**/*.test.ts',
             'src/main/core/**/*.db.test.ts',
+            'src/main/cli/**/*.db.test.ts',
           ],
         },
       },
@@ -50,7 +51,11 @@ export default defineConfig({
         test: {
           name: 'main-db',
           environment: 'node',
-          include: ['src/main/core/**/*.db.test.ts', 'src/main/db/legacy-port/**/*.test.ts'],
+          include: [
+            'src/main/core/**/*.db.test.ts',
+            'src/main/cli/**/*.db.test.ts',
+            'src/main/db/legacy-port/**/*.test.ts',
+          ],
         },
       },
       {


### PR DESCRIPTION
> **Draft / for discussion.** This is a headless CLI we built while dogfooding emdash. Opening it to get your read on the *approach* (especially the coupling to `@main/*` internals) before polishing for merge — not asking to land as-is.

## What it is

An `emdash` command-line surface that operates on the **same SQLite DB + git worktrees as the desktop app**, by reusing the app's own main-process modules (Drizzle schema, `computeWorkspaceKey`, `WorktreeService`, `buildAgentSessionCommand`, `makeTmuxSessionName`/`makePtySessionId`) so the rows/worktrees/agent sessions it creates match UI-created ones.

```
emdash workspace list   [--project <name>] [--include-archived] [--json]
emdash workspace create --project <p> --branch <b> [--base <branch>] [--name <n>]
                        [--checkout-existing | --no-worktree] [--push-branch]
                        [--prompt "<text>" [--agent <name>] [--auto-approve]] [--json]
emdash workspace remove --project <p> (--branch <b> | --id <id>)
                        [--pre-remove <cmd>] [--skip-hook] [--force] [--json]
emdash workspace send   --project <p> (--branch <b> | --id <id>) --message "<text>" [--json]
```

The motivating use case: an external orchestrator can spin a worktree and dispatch its agent in one call — `create --branch X --prompt "<packet>"` — then `send` follow-ups, `list` as a board, and `remove` (with a capture-before-delete hook) to tear down.

## How it runs

CJS bundle (esbuild → `out/cli/index.cjs`) run under `ELECTRON_RUN_AS_NODE` so `better-sqlite3`'s native ABI matches the desktop build. `pnpm build:cli` then `pnpm cli workspace list`.

## Design

- **Core is db-injected and Electron-free** (`src/main/cli/{workspace-commands,agent-dispatch,local-worktree,args}.ts`) → unit-tested against a temp SQLite DB via `openFixture`. The entry (`index.ts`) wires the real DB + settings + agent dispatcher.
- **`create` is atomic** (git worktree first, DB rows only on success), idempotent by branch, and resolves remote base refs (`origin/main`).
- **`remove` is hook-gated**, defaults to safe branch delete (`-d`; `-D` only with `--force`), kills the agent's tmux session first, scopes `--id` to the project, and only removes worktrees inside the project's pool.
- **`create --prompt`** launches the agent in a *detached tmux session* named the way the app expects, so the app re-attaches when the task is opened (requires tmux mode on).

## Tests

`src/main/cli/*.test.ts` (node) + `*.db.test.ts` (main-db, real SQLite + git): 38 tests covering arg parsing, list, create (atomicity/idempotency/remote-base/push/prompt-dispatch), remove (teardown/idempotency/hook-abort/unmerged-branch retention/cross-project `--id` refusal/out-of-pool rm guard), send, and the pure tmux-argv builder.

> ⚠️ emdash CI (`code-consistency-check.yml`) runs only format/typecheck/lint — **not** the test suite. These were run locally (all green). Happy to add a CI step to run `vitest --project node --project main-db` if you'd want that.

## Honest risk register (full version in `src/main/cli/README.md`)

- **Couples to `@main/*` internals** (not a public API) — the CLI must move in lockstep with the app. Typecheck catches signature drift (this branch rebased cleanly onto current `main`, 86 commits of churn, no changes needed); *runtime* drift (tmux naming, command builder) would need a smoke test. The biggest open question for you: is this coupling acceptable, or should the shared bits be extracted into a package both consume?
- **`remove` is `rm`-class** — mitigated (safe branch delete, pool-scoped worktree rm, project-scoped `--id`, session kill, capture hook) but it tears down real state.
- **No app-concurrency coordination** (writes the live DB while the app may run; WAL handles locking, not logical races).
- **Deleting a task leaves orphaned `conversations`/`terminals`/`messages` rows** — this matches the app's own `deleteTask` (FK cascade is off app-wide); not changed here to avoid divergence.
- **`create --prompt` adoption needs tmux mode on**; hook env / `.emdash.json` task env aren't forwarded to CLI-launched agents; keystroke-injection providers don't get the prompt at launch (reported, non-zero exit).
- **Scope:** local projects only; no `--from-issue/--from-pr`, no prompt templates.

## Not yet verified in the live app

- A CLI-created workspace appears in the sidebar after reload (confirmed once by a tester; the app doesn't live-refresh external DB writes).
- The app re-attaches to a `create --prompt` tmux agent (vs spawning a duplicate) with tmux mode on.
