### PR TITLE
feat: stop all servers button

### DIFF
--- a/src/main/core/terminals/controller.ts
+++ b/src/main/core/terminals/controller.ts
@@ -9,6 +9,7 @@ import { stopLifecycleScriptSession } from './lifecycle-script-coordinator';
 import { prepareLifecycleScript } from './prepareLifecycleScript';
 import { renameTerminal } from './renameTerminal';
 import { runLifecycleScript } from './runLifecycleScript';
+import { stopDevServers } from './stopDevServers';
 
 export const terminalsController = createRPCController({
   getAllTerminals,
@@ -20,6 +21,7 @@ export const terminalsController = createRPCController({
   renameTerminal,
   getTerminalsForTask,
   runLifecycleScript,
+  stopDevServers,
   stopLifecycleScript: (args: {
     projectId: string;
     taskId: string;

--- a/src/main/core/terminals/dev-server-watcher.ts
+++ b/src/main/core/terminals/dev-server-watcher.ts
@@ -10,6 +10,11 @@ const PROBE_FAILURES_TO_CLOSE = 2;
 
 const URL_PATTERN = /https?:\/\/(?:localhost|127\.0\.0\.1|0\.0\.0\.0)(:\d{2,5})?(?:\/\S*)?/;
 const MAX_BUFFER = 4096;
+const activeDevServerCleanups = new Map<string, () => void>();
+
+function devServerKey(scopeId: string, terminalId: string): string {
+  return `${scopeId}:${terminalId}`;
+}
 
 function normalizeUrl(raw: string): string {
   return raw.replace('0.0.0.0', '127.0.0.1');
@@ -79,13 +84,22 @@ function startProbe(url: string, onClosed: () => void): () => void {
   };
 }
 
+export function clearTerminalDevServer(scopeId: string, terminalId: string): boolean {
+  const cleanup = activeDevServerCleanups.get(devServerKey(scopeId, terminalId));
+  if (!cleanup) return false;
+  cleanup();
+  return true;
+}
+
 export function wireTerminalDevServerWatcher({
   pty,
+  projectId,
   scopeId,
   terminalId,
   probe = true,
 }: {
   pty: Pty;
+  projectId: string;
   scopeId: string;
   terminalId: string;
   /** Set to false for SSH sessions where remote ports are not locally reachable */
@@ -94,14 +108,21 @@ export function wireTerminalDevServerWatcher({
   let buffer = '';
   let found = false;
   let stopProbe: (() => void) | null = null;
+  const activeKey = devServerKey(scopeId, terminalId);
 
   const cleanup = () => {
     buffer = '';
     stopProbe?.();
     stopProbe = null;
+    activeDevServerCleanups.delete(activeKey);
     if (found) {
       found = false;
-      events.emit(hostPreviewEventChannel, { type: 'exit', taskId: scopeId, terminalId });
+      events.emit(hostPreviewEventChannel, {
+        type: 'exit',
+        projectId,
+        taskId: scopeId,
+        terminalId,
+      });
     }
   };
 
@@ -120,8 +141,15 @@ export function wireTerminalDevServerWatcher({
     if (!match) return;
 
     found = true;
+    activeDevServerCleanups.set(activeKey, cleanup);
     const url = normalizeUrl(match[0]);
-    events.emit(hostPreviewEventChannel, { type: 'url', taskId: scopeId, terminalId, url });
+    events.emit(hostPreviewEventChannel, {
+      type: 'url',
+      projectId,
+      taskId: scopeId,
+      terminalId,
+      url,
+    });
 
     if (probe) {
       stopProbe = startProbe(url, cleanup);

--- a/src/main/core/terminals/impl/local-terminal-provider.test.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.test.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import { spawnLocalPty } from '@main/core/pty/local-pty';
 import type { PtyExitInfo } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { makePtySessionId } from '@shared/ptySessionId';
@@ -8,18 +9,25 @@ import { LocalTerminalProvider } from './local-terminal-provider';
 
 const ptyMock = vi.hoisted(() => ({
   exitHandlers: [] as Array<(info: PtyExitInfo) => void>,
+  sessions: [] as Array<{
+    kill: ReturnType<typeof vi.fn>;
+  }>,
 }));
 
 vi.mock('@main/core/pty/local-pty', () => ({
-  spawnLocalPty: vi.fn(() => ({
-    write: vi.fn(),
-    resize: vi.fn(),
-    kill: vi.fn(),
-    onData: vi.fn(),
-    onExit: vi.fn((handler: (info: PtyExitInfo) => void) => {
-      ptyMock.exitHandlers.push(handler);
-    }),
-  })),
+  spawnLocalPty: vi.fn(() => {
+    const session = {
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      onData: vi.fn(),
+      onExit: vi.fn((handler: (info: PtyExitInfo) => void) => {
+        ptyMock.exitHandlers.push(handler);
+      }),
+    };
+    ptyMock.sessions.push(session);
+    return session;
+  }),
 }));
 
 vi.mock('@main/core/pty/pty-session-registry', () => ({
@@ -50,7 +58,9 @@ const ctx = {
 
 describe('LocalTerminalProvider', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     ptyMock.exitHandlers.length = 0;
+    ptyMock.sessions.length = 0;
     vi.mocked(ptySessionRegistry.register).mockClear();
   });
 
@@ -95,5 +105,32 @@ describe('LocalTerminalProvider', () => {
     expect(
       (provider as unknown as { shellProfiles: Map<string, unknown> }).shellProfiles.has(sessionId)
     ).toBe(false);
+  });
+
+  it('does not respawn when a manual terminal kill exits synchronously', async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new LocalTerminalProvider({
+        projectId: terminal.projectId,
+        scopeId: terminal.taskId,
+        taskPath: '/repo',
+        ctx,
+      });
+
+      await provider.spawnTerminal(terminal);
+
+      const pty = ptyMock.sessions[0];
+      pty.kill.mockImplementation(() => {
+        for (const handler of [...ptyMock.exitHandlers]) handler({ signal: 'SIGTERM' });
+      });
+      vi.mocked(spawnLocalPty).mockClear();
+
+      await provider.killTerminal(terminal.id);
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(spawnLocalPty).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -173,7 +173,12 @@ export class LocalTerminalProvider implements TerminalProvider {
     });
 
     if (policy.watchDevServer) {
-      wireTerminalDevServerWatcher({ pty, scopeId: this.scopeId, terminalId: terminal.id });
+      wireTerminalDevServerWatcher({
+        pty,
+        projectId: this.projectId,
+        scopeId: this.scopeId,
+        terminalId: terminal.id,
+      });
     }
 
     pty.onExit((info) => {
@@ -252,14 +257,15 @@ export class LocalTerminalProvider implements TerminalProvider {
     const sessionId = makePtySessionId(this.projectId, this.scopeId, terminalId);
     this.knownSessionIds.delete(sessionId);
     const pty = this.sessions.get(sessionId);
+    this.sessions.delete(sessionId);
+    this.respawnCounts.delete(sessionId);
+    this.shellProfiles.delete(sessionId);
     if (pty) {
       try {
         pty.kill();
       } catch {}
-      this.sessions.delete(sessionId);
       ptySessionRegistry.unregister(sessionId);
     }
-    this.shellProfiles.delete(sessionId);
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }

--- a/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { PtyExitInfo } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import { makePtySessionId } from '@shared/ptySessionId';
 import type { Terminal } from '@shared/terminals';
@@ -9,12 +10,14 @@ import { SshTerminalProvider } from './ssh-terminal-provider';
 
 const ptyMock = vi.hoisted(() => ({
   exitHandlers: [] as Array<(info: PtyExitInfo) => void>,
+  sessions: [] as Array<{
+    kill: ReturnType<typeof vi.fn>;
+  }>,
 }));
 
 vi.mock('@main/core/pty/ssh2-pty', () => ({
-  openSsh2Pty: vi.fn(async () => ({
-    success: true,
-    data: {
+  openSsh2Pty: vi.fn(async () => {
+    const session = {
       write: vi.fn(),
       resize: vi.fn(),
       kill: vi.fn(),
@@ -22,8 +25,13 @@ vi.mock('@main/core/pty/ssh2-pty', () => ({
       onExit: vi.fn((handler: (info: PtyExitInfo) => void) => {
         ptyMock.exitHandlers.push(handler);
       }),
-    },
-  })),
+    };
+    ptyMock.sessions.push(session);
+    return {
+      success: true,
+      data: session,
+    };
+  }),
 }));
 
 vi.mock('@main/core/pty/pty-session-registry', () => ({
@@ -68,7 +76,9 @@ const proxy = {
 
 describe('SshTerminalProvider', () => {
   beforeEach(() => {
+    vi.clearAllMocks();
     ptyMock.exitHandlers.length = 0;
+    ptyMock.sessions.length = 0;
     vi.mocked(ptySessionRegistry.register).mockClear();
     proxy.getRemoteShellProfile = vi.fn(async () => ({
       shell: '/bin/bash',
@@ -121,5 +131,34 @@ describe('SshTerminalProvider', () => {
     expect(
       (provider as unknown as { shellProfiles: Map<string, unknown> }).shellProfiles.has(sessionId)
     ).toBe(false);
+  });
+
+  it('does not respawn when a manual terminal kill exits synchronously', async () => {
+    vi.useFakeTimers();
+    try {
+      const provider = new SshTerminalProvider({
+        projectId: terminal.projectId,
+        scopeId: terminal.taskId,
+        taskPath: '/repo',
+        ctx,
+        proxy,
+        connectionId: 'ssh-1',
+      });
+
+      await provider.spawnTerminal(terminal);
+
+      const pty = ptyMock.sessions[0];
+      pty.kill.mockImplementation(() => {
+        for (const handler of [...ptyMock.exitHandlers]) handler({ signal: 'SIGTERM' });
+      });
+      vi.mocked(openSsh2Pty).mockClear();
+
+      await provider.killTerminal(terminal.id);
+      await vi.advanceTimersByTimeAsync(600);
+
+      expect(openSsh2Pty).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -189,6 +189,7 @@ export class SshTerminalProvider implements TerminalProvider {
     if (policy.watchDevServer) {
       wireTerminalDevServerWatcher({
         pty,
+        projectId: this.projectId,
         scopeId: this.scopeId,
         terminalId: terminal.id,
         probe: false,
@@ -293,15 +294,16 @@ export class SshTerminalProvider implements TerminalProvider {
     const sessionId = makePtySessionId(this.projectId, this.scopeId, terminalId);
     this.knownSessionIds.delete(sessionId);
     const pty = this.sessions.get(sessionId);
+    this.sessions.delete(sessionId);
+    this.respawnCounts.delete(sessionId);
+    this.terminals.delete(terminalId);
+    this.shellProfiles.delete(sessionId);
     if (pty) {
       try {
         pty.kill();
       } catch {}
-      this.sessions.delete(sessionId);
       ptySessionRegistry.unregister(sessionId);
     }
-    this.terminals.delete(terminalId);
-    this.shellProfiles.delete(sessionId);
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }

--- a/src/main/core/terminals/stopDevServers.test.ts
+++ b/src/main/core/terminals/stopDevServers.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { hostPreviewEventChannel } from '@shared/events/hostPreviewEvents';
+import { createLifecycleScriptTerminalId } from '@shared/terminals';
+import { clearTerminalDevServer } from './dev-server-watcher';
+import { stopLifecycleScriptSession } from './lifecycle-script-coordinator';
+import { stopDevServers } from './stopDevServers';
+
+const mocks = vi.hoisted(() => ({
+  emit: vi.fn(),
+  logWarn: vi.fn(),
+  ptyGet: vi.fn(),
+  ptyUnregister: vi.fn(),
+}));
+
+vi.mock('@main/core/pty/pty-session-registry', () => ({
+  ptySessionRegistry: {
+    get: mocks.ptyGet,
+    unregister: mocks.ptyUnregister,
+  },
+}));
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    emit: mocks.emit,
+  },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    warn: mocks.logWarn,
+  },
+}));
+
+vi.mock('./dev-server-watcher', () => ({
+  clearTerminalDevServer: vi.fn(),
+}));
+
+vi.mock('./lifecycle-script-coordinator', () => ({
+  stopLifecycleScriptSession: vi.fn(),
+}));
+
+describe('stopDevServers', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(clearTerminalDevServer).mockReturnValue(false);
+    vi.mocked(stopLifecycleScriptSession).mockReturnValue(false);
+  });
+
+  it('interrupts task-scoped terminal servers without killing the terminal PTY', async () => {
+    const write = vi.fn();
+    const kill = vi.fn();
+    mocks.ptyGet.mockReturnValue({ write, kill });
+
+    await stopDevServers({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+      servers: [
+        { scopeId: 'task-1', terminalId: 'terminal-1' },
+        { scopeId: 'task-1', terminalId: 'terminal-2' },
+      ],
+    });
+
+    expect(write).toHaveBeenCalledTimes(2);
+    expect(write).toHaveBeenCalledWith('\x03');
+    expect(kill).not.toHaveBeenCalled();
+    expect(mocks.ptyUnregister).not.toHaveBeenCalled();
+    expect(mocks.emit).toHaveBeenCalledWith(hostPreviewEventChannel, {
+      type: 'exit',
+      projectId: 'project-1',
+      taskId: 'task-1',
+      terminalId: 'terminal-1',
+    });
+    expect(mocks.emit).toHaveBeenCalledWith(hostPreviewEventChannel, {
+      type: 'exit',
+      projectId: 'project-1',
+      taskId: 'task-1',
+      terminalId: 'terminal-2',
+    });
+  });
+
+  it('uses watcher cleanup to reset future URL detection for interrupted terminals', async () => {
+    const write = vi.fn();
+    mocks.ptyGet.mockReturnValue({ write });
+    vi.mocked(clearTerminalDevServer).mockReturnValue(true);
+
+    await stopDevServers({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+      servers: [{ scopeId: 'task-1', terminalId: 'terminal-1' }],
+    });
+
+    expect(write).toHaveBeenCalledWith('\x03');
+    expect(clearTerminalDevServer).toHaveBeenCalledWith('task-1', 'terminal-1');
+    expect(mocks.emit).not.toHaveBeenCalled();
+  });
+
+  it('stops the workspace run script through the lifecycle coordinator', async () => {
+    vi.mocked(stopLifecycleScriptSession).mockReturnValue(true);
+
+    await stopDevServers({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+      servers: [{ scopeId: 'workspace-1', terminalId: createLifecycleScriptTerminalId('run') }],
+    });
+
+    expect(stopLifecycleScriptSession).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+      type: 'run',
+      origin: 'manual',
+    });
+    expect(mocks.ptyGet).not.toHaveBeenCalled();
+    expect(mocks.emit).toHaveBeenCalledWith(hostPreviewEventChannel, {
+      type: 'exit',
+      projectId: 'project-1',
+      taskId: 'workspace-1',
+      terminalId: createLifecycleScriptTerminalId('run'),
+    });
+  });
+
+  it('falls back to killing the registered PTY when a workspace server is not coordinator-owned', async () => {
+    const kill = vi.fn();
+    mocks.ptyGet.mockReturnValue({ kill });
+
+    await stopDevServers({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+      servers: [{ scopeId: 'workspace-1', terminalId: createLifecycleScriptTerminalId('run') }],
+    });
+
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(mocks.ptyUnregister).toHaveBeenCalledWith(
+      `project-1:workspace-1:${createLifecycleScriptTerminalId('run')}`
+    );
+    expect(mocks.emit).toHaveBeenCalledWith(hostPreviewEventChannel, {
+      type: 'exit',
+      projectId: 'project-1',
+      taskId: 'workspace-1',
+      terminalId: createLifecycleScriptTerminalId('run'),
+    });
+  });
+
+  it('kills a run-script server from another project instead of using the current task coordinator', async () => {
+    const kill = vi.fn();
+    mocks.ptyGet.mockReturnValue({ kill });
+
+    await stopDevServers({
+      projectId: 'project-1',
+      taskId: 'task-1',
+      workspaceId: 'workspace-1',
+      servers: [
+        {
+          projectId: 'project-2',
+          scopeId: 'workspace-2',
+          terminalId: createLifecycleScriptTerminalId('run'),
+        },
+      ],
+    });
+
+    expect(stopLifecycleScriptSession).not.toHaveBeenCalled();
+    expect(kill).toHaveBeenCalledTimes(1);
+    expect(mocks.ptyUnregister).toHaveBeenCalledWith(
+      `project-2:workspace-2:${createLifecycleScriptTerminalId('run')}`
+    );
+    expect(mocks.emit).toHaveBeenCalledWith(hostPreviewEventChannel, {
+      type: 'exit',
+      projectId: 'project-2',
+      taskId: 'workspace-2',
+      terminalId: createLifecycleScriptTerminalId('run'),
+    });
+  });
+});

--- a/src/main/core/terminals/stopDevServers.ts
+++ b/src/main/core/terminals/stopDevServers.ts
@@ -1,0 +1,117 @@
+import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import { events } from '@main/lib/events';
+import { log } from '@main/lib/logger';
+import { hostPreviewEventChannel } from '@shared/events/hostPreviewEvents';
+import { makePtySessionId } from '@shared/ptySessionId';
+import { createLifecycleScriptTerminalId } from '@shared/terminals';
+import { clearTerminalDevServer } from './dev-server-watcher';
+import { stopLifecycleScriptSession } from './lifecycle-script-coordinator';
+
+type DevServerRef = {
+  projectId?: string;
+  scopeId: string;
+  terminalId: string;
+};
+
+const CTRL_C = '\x03';
+
+function emitDevServerExit(projectId: string, scopeId: string, terminalId: string): void {
+  if (clearTerminalDevServer(scopeId, terminalId)) return;
+  events.emit(hostPreviewEventChannel, {
+    type: 'exit',
+    projectId,
+    taskId: scopeId,
+    terminalId,
+  });
+}
+
+function stopRegisteredPty(projectId: string, scopeId: string, terminalId: string): void {
+  const sessionId = makePtySessionId(projectId, scopeId, terminalId);
+  const pty = ptySessionRegistry.get(sessionId);
+  if (!pty) return;
+
+  try {
+    pty.kill();
+  } catch (error) {
+    log.warn('stopDevServers: failed to kill PTY', { sessionId, error: String(error) });
+  }
+  ptySessionRegistry.unregister(sessionId);
+}
+
+function interruptRegisteredPty(projectId: string, scopeId: string, terminalId: string): void {
+  const sessionId = makePtySessionId(projectId, scopeId, terminalId);
+  const pty = ptySessionRegistry.get(sessionId);
+  if (!pty) return;
+
+  try {
+    pty.write(CTRL_C);
+  } catch (error) {
+    log.warn('stopDevServers: failed to interrupt PTY', { sessionId, error: String(error) });
+  }
+}
+
+async function stopDevServer({
+  projectId,
+  taskId,
+  workspaceId,
+  server,
+}: {
+  projectId: string;
+  taskId: string;
+  workspaceId: string;
+  server: DevServerRef;
+}): Promise<void> {
+  const serverProjectId = server.projectId ?? projectId;
+  const runScriptTerminalId = createLifecycleScriptTerminalId('run');
+
+  if (server.terminalId === runScriptTerminalId) {
+    if (serverProjectId === projectId && server.scopeId === workspaceId) {
+      const stopped = stopLifecycleScriptSession({
+        projectId,
+        taskId,
+        workspaceId,
+        type: 'run',
+        origin: 'manual',
+      });
+      if (stopped) {
+        emitDevServerExit(serverProjectId, server.scopeId, server.terminalId);
+        return;
+      }
+    }
+
+    stopRegisteredPty(serverProjectId, server.scopeId, server.terminalId);
+  } else {
+    interruptRegisteredPty(serverProjectId, server.scopeId, server.terminalId);
+  }
+
+  // Optimistically hide the pill after sending the stop signal. If a process ignores Ctrl+C,
+  // the existing port probe has already been torn down and fresh detection requires new output.
+  emitDevServerExit(serverProjectId, server.scopeId, server.terminalId);
+}
+
+export async function stopDevServers({
+  projectId,
+  taskId,
+  workspaceId,
+  servers,
+}: {
+  projectId: string;
+  taskId: string;
+  workspaceId: string;
+  servers: DevServerRef[];
+}): Promise<void> {
+  await Promise.all(
+    servers.map((server) =>
+      stopDevServer({ projectId, taskId, workspaceId, server }).catch((error) => {
+        log.warn('stopDevServers: failed to stop dev server', {
+          projectId,
+          taskId,
+          workspaceId,
+          scopeId: server.scopeId,
+          terminalId: server.terminalId,
+          error: String(error),
+        });
+      })
+    )
+  );
+}

--- a/src/renderer/features/automations/components/AutomationTaskTitlebar.tsx
+++ b/src/renderer/features/automations/components/AutomationTaskTitlebar.tsx
@@ -9,6 +9,7 @@ import {
   projectDisplayName,
 } from '@renderer/features/projects/stores/project-selectors';
 import { DevServerPills } from '@renderer/features/tasks/components/dev-server-pills';
+import { DevServerStore } from '@renderer/features/tasks/stores/dev-server-store';
 import {
   getRegisteredTaskData,
   getTaskStore,
@@ -38,6 +39,7 @@ import { slugFromRunId } from '@shared/automations/run-slug';
 import type { Automation, AutomationRun } from '@shared/automations/types';
 
 const AUTOMATION_RUNS_POPOVER_LIMIT = 50;
+const globalDevServers = new DevServerStore();
 
 export const AutomationTaskTitlebar = observer(function AutomationTaskTitlebar() {
   const { projectId, taskId } = useTaskViewContext();
@@ -268,7 +270,7 @@ const AutomationTitlebarRightSlot = observer(function AutomationTitlebarRightSlo
 
   return (
     <div className="flex items-center gap-2">
-      <DevServerPills projectId={projectId} taskId={taskId} />
+      <DevServerPills projectId={projectId} taskId={taskId} devServers={globalDevServers} />
       <OpenInMenu
         path={workspace.path}
         className="h-7 bg-background"

--- a/src/renderer/features/tasks/components/dev-server-pills.tsx
+++ b/src/renderer/features/tasks/components/dev-server-pills.tsx
@@ -1,8 +1,17 @@
-import { ExternalLink, Globe } from 'lucide-react';
+import { Ban, ChevronDown, ExternalLink, Globe, Server } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import { useCallback, useRef, useState } from 'react';
 import { rpc } from '@renderer/lib/ipc';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
-import { useDevServers } from '../task-view-context';
+import { Button } from '@renderer/lib/ui/button';
+import { Popover, PopoverContent, PopoverTrigger } from '@renderer/lib/ui/popover';
+import type { DevServerStore } from '../stores/dev-server-store';
+import { useWorkspaceId } from '../task-view-context';
+
+type ServerRef = {
+  projectId?: string;
+  scopeId: string;
+  terminalId: string;
+};
 
 function formatUrl(url: string): string {
   try {
@@ -13,37 +22,149 @@ function formatUrl(url: string): string {
   }
 }
 
+function getServerKey(server: ServerRef): string {
+  return `${server.projectId ?? ''}:${server.scopeId}:${server.terminalId}`;
+}
+
 export const DevServerPills = observer(function DevServerPills({
-  projectId: _projectId,
-  taskId: _taskId,
+  projectId,
+  taskId,
+  devServers,
 }: {
   projectId: string;
   taskId: string;
+  devServers: DevServerStore;
 }) {
-  const urls = useDevServers().urls;
+  const workspaceId = useWorkspaceId();
+  const entries = devServers.entries;
+  const [stoppingKey, setStoppingKey] = useState<string | null>(null);
+  const mountedRef = useRef(true);
+  const setRootRef = useCallback((node: HTMLDivElement | null) => {
+    mountedRef.current = node !== null;
+  }, []);
 
-  if (urls.length === 0) return null;
+  const stopServers = async (servers: ServerRef[], key: string) => {
+    if (stoppingKey || servers.length === 0) return;
+    setStoppingKey(key);
+    try {
+      await rpc.terminals.stopDevServers({
+        projectId,
+        taskId,
+        workspaceId,
+        servers,
+      });
+    } catch {
+      // Best-effort action; the pills stay visible if the backend cannot stop a server.
+    } finally {
+      if (mountedRef.current) {
+        setStoppingKey(null);
+      }
+    }
+  };
+
+  if (entries.length === 0) return null;
+
+  const firstEntry = entries[0];
+  const triggerLabel = formatUrl(firstEntry.url);
+
+  const hiddenServerCount = entries.length - 1;
+  const allServerRefs = entries.map(({ projectId, scopeId, terminalId }) => ({
+    projectId,
+    scopeId,
+    terminalId,
+  }));
 
   return (
-    <>
-      {urls.map((url) => (
-        <Tooltip key={url}>
-          <TooltipTrigger>
-            <button
-              type="button"
-              onClick={() => rpc.app.openExternal(url)}
-              className="flex h-7 items-center gap-1.5 rounded-lg bg-background-info px-2 text-xs text-foreground-muted transition-colors hover:border-border-info hover:bg-background-info-hover hover:text-foreground"
-            >
-              <Globe className="size-3 shrink-0 text-foreground-info" />
-              <span className="text-foreground-info">{formatUrl(url)}</span>
-              <ExternalLink className="size-3 shrink-0 text-foreground-info" />
-            </button>
-          </TooltipTrigger>
-          <TooltipContent side="bottom" className="text-xs">
-            Dev server running at {url}
-          </TooltipContent>
-        </Tooltip>
-      ))}
-    </>
+    <Popover>
+      <div
+        ref={setRootRef}
+        className="flex h-7 max-w-72 min-w-0 items-center overflow-hidden rounded-lg bg-background-info text-xs text-foreground-info shadow-xs ring-1 ring-foreground-info/10 transition-colors hover:bg-background-info-hover"
+      >
+        <PopoverTrigger
+          type="button"
+          className="focus-visible:ring-ring/50 flex h-7 shrink-0 items-center gap-1 border-r border-foreground-info/10 px-2 text-foreground-info transition-colors hover:bg-background-info-hover focus-visible:ring-2 focus-visible:outline-none"
+          aria-label="Open dev servers menu"
+          title="Open dev servers menu"
+        >
+          <Globe className="size-3.5 shrink-0" />
+          <ChevronDown className="size-3 shrink-0" />
+        </PopoverTrigger>
+        <button
+          type="button"
+          className="focus-visible:ring-ring/50 flex min-w-0 flex-1 items-center gap-1.5 px-2 text-left transition-colors hover:bg-background-info-hover focus-visible:ring-2 focus-visible:outline-none"
+          aria-label={`Open ${formatUrl(firstEntry.url)}`}
+          title={firstEntry.url}
+          onClick={() => void rpc.app.openExternal(firstEntry.url)}
+        >
+          <span className="min-w-0 truncate font-medium">{triggerLabel}</span>
+          {hiddenServerCount > 0 && (
+            <span className="shrink-0 rounded-full bg-background-info-hover px-1.5 text-[10px] leading-4 font-medium tabular-nums">
+              +{hiddenServerCount}
+            </span>
+          )}
+          <ExternalLink className="size-3 shrink-0" />
+        </button>
+      </div>
+      <PopoverContent
+        align="start"
+        sideOffset={6}
+        className="w-64 gap-1 rounded-xl bg-background-quaternary p-2 shadow-lg"
+      >
+        <div className="px-1.5 pb-1.5">
+          <span className="text-sm font-medium text-foreground-muted">Servers</span>
+        </div>
+        <div className="flex flex-col gap-0.5">
+          {entries.map(({ projectId: serverProjectId, scopeId, terminalId, url }) => {
+            const key = getServerKey({ projectId: serverProjectId, scopeId, terminalId });
+            const isStopping = stoppingKey === key;
+            return (
+              <div
+                key={key}
+                className="group/server flex h-8 items-center gap-1.5 rounded-lg px-1.5 text-sm text-foreground transition-colors hover:bg-background-quaternary-1"
+              >
+                <button
+                  type="button"
+                  className="focus-visible:ring-ring/50 flex min-w-0 flex-1 items-center gap-1.5 text-left transition-colors hover:text-foreground-info focus-visible:ring-2 focus-visible:outline-none"
+                  title={url}
+                  onClick={() => void rpc.app.openExternal(url)}
+                >
+                  <Server className="size-3.5 shrink-0 text-foreground-info" />
+                  <span className="truncate">{formatUrl(url)}</span>
+                  <ExternalLink className="size-3 shrink-0 text-foreground-passive transition-colors group-hover/server:text-foreground-info" />
+                </button>
+                <Button
+                  variant="outline"
+                  size="xs"
+                  className="h-7 rounded-lg border-border bg-background px-2.5 text-sm text-foreground hover:border-border-destructive hover:bg-background-destructive hover:text-foreground-destructive"
+                  disabled={stoppingKey !== null}
+                  onClick={() =>
+                    void stopServers([{ projectId: serverProjectId, scopeId, terminalId }], key)
+                  }
+                >
+                  {isStopping ? 'Stopping...' : 'Stop'}
+                </Button>
+              </div>
+            );
+          })}
+        </div>
+        <div className="my-1.5 h-px bg-border" />
+        <Button
+          variant="destructive"
+          size="sm"
+          className="border-destructive/50 bg-destructive text-destructive-foreground hover:bg-destructive/90 h-9 w-full gap-1.5 rounded-lg text-sm"
+          disabled={stoppingKey !== null}
+          onClick={() => void stopServers(allServerRefs, 'all')}
+        >
+          <Ban className="size-4 shrink-0" />
+          {stoppingKey === 'all'
+            ? entries.length === 1
+              ? 'Stopping server...'
+              : 'Stopping servers...'
+            : entries.length === 1
+              ? 'Stop server'
+              : 'Stop all servers'}
+        </Button>
+      </PopoverContent>
+    </Popover>
   );
 });

--- a/src/renderer/features/tasks/stores/dev-server-store.ts
+++ b/src/renderer/features/tasks/stores/dev-server-store.ts
@@ -4,31 +4,43 @@ import { Resource } from '@renderer/lib/stores/resource';
 import { hostPreviewEventChannel } from '@shared/events/hostPreviewEvents';
 import type { HostPreviewEvent } from '@shared/hostPreview';
 
+export type DevServerEntry = {
+  projectId?: string;
+  scopeId: string;
+  terminalId: string;
+  url: string;
+};
+
 export class DevServerStore implements IDisposable {
   /**
    * Event-driven resource — starts empty, updated by `hostPreviewEventChannel`
    * events. Each event atomically replaces the map to trigger MobX reactivity.
    */
-  readonly servers: Resource<Map<string, string>, HostPreviewEvent>;
+  readonly servers: Resource<Map<string, DevServerEntry>, HostPreviewEvent>;
 
-  constructor(taskId: string, workspaceId: string) {
-    this.servers = new Resource<Map<string, string>, HostPreviewEvent>(
+  constructor(taskId?: string, workspaceId?: string) {
+    this.servers = new Resource<Map<string, DevServerEntry>, HostPreviewEvent>(
       null,
       [
         {
           kind: 'event',
           subscribe: (handler) =>
             events.on(hostPreviewEventChannel, (event) => {
-              if (event.taskId === taskId || event.taskId === workspaceId) {
+              if (!taskId || event.taskId === taskId || event.taskId === workspaceId) {
                 handler(event);
               }
             }),
           onEvent: (event, ctx) => {
             const next = new Map(ctx.data ?? []);
             if (event.type === 'url' && event.terminalId && event.url) {
-              next.set(event.terminalId, event.url);
+              next.set(`${event.projectId ?? ''}:${event.taskId}:${event.terminalId}`, {
+                projectId: event.projectId,
+                scopeId: event.taskId,
+                terminalId: event.terminalId,
+                url: event.url,
+              });
             } else if (event.type === 'exit' && event.terminalId) {
-              next.delete(event.terminalId);
+              next.delete(`${event.projectId ?? ''}:${event.taskId}:${event.terminalId}`);
             }
             ctx.set(next);
           },
@@ -41,6 +53,10 @@ export class DevServerStore implements IDisposable {
   }
 
   get urls(): string[] {
+    return this.entries.map((server) => server.url);
+  }
+
+  get entries(): DevServerEntry[] {
     return Array.from(this.servers.data?.values() ?? []);
   }
 

--- a/src/renderer/features/tasks/task-titlebar.tsx
+++ b/src/renderer/features/tasks/task-titlebar.tsx
@@ -47,8 +47,11 @@ import { cn } from '@renderer/utils/utils';
 import type { Issue } from '@shared/tasks';
 import { DevServerPills } from './components/dev-server-pills';
 import { IssueSelector, ProviderLogo } from './components/issue-selector/issue-selector';
+import { DevServerStore } from './stores/dev-server-store';
 import { type SidebarTab } from './types';
 import { useGitActions } from './use-git-actions';
+
+const globalDevServers = new DevServerStore();
 
 export const TaskTitlebar = observer(function TaskTitlebar() {
   const { projectId, taskId } = useTaskViewContext();
@@ -305,7 +308,7 @@ const ActiveTaskTitlebar = observer(function ActiveTaskTitlebar({
       }
       rightSlot={
         <div className="flex items-center gap-2">
-          <DevServerPills projectId={projectId} taskId={taskId} />
+          <DevServerPills projectId={projectId} taskId={taskId} devServers={globalDevServers} />
           <OpenInMenu
             path={workspace.path}
             className="h-7 bg-transparent"

--- a/src/shared/hostPreview.ts
+++ b/src/shared/hostPreview.ts
@@ -1,5 +1,6 @@
 export type HostPreviewEvent = {
   type: 'url' | 'setup' | 'exit';
+  projectId?: string;
   taskId: string;
   terminalId?: string;
   url?: string;


### PR DESCRIPTION
### Description
- task-scoped stop all control next to dev server pill in task titlebar
- tracks dev server entires with scopeid,terminalid,url so each can be killed reliablly
- stop normal terminal-backend dev servers throuhg ctrl+c,keeping terminal session open
- stop run lifecycle script server through the lifecycle coordinator

### Screenshot/Recording (if applicable)
https://streamable.com/1i4wux

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
