### PR TITLE
fix(tasks): handle offline task creation

### DIFF
--- a/src/main/core/git/impl/git-service.test.ts
+++ b/src/main/core/git/impl/git-service.test.ts
@@ -425,7 +425,7 @@ describe('GitService.createBranch', () => {
     });
   });
 
-  it('fails remote source branch creation when fetch fails', async () => {
+  it('creates remote source branches from cached refs when fetch fails', async () => {
     const svc = makeService(async (_cmd, args = []) => {
       const key = args.join(' ');
       if (key === 'fetch origin') {
@@ -433,6 +433,46 @@ describe('GitService.createBranch', () => {
           stdout: '',
           stderr:
             "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+          code: 128,
+        });
+      }
+      if (key === 'rev-parse --verify refs/remotes/origin/main') {
+        return { stdout: 'abc123', stderr: '' };
+      }
+      if (key === 'branch --no-track task/remote origin/main') {
+        return { stdout: '', stderr: '' };
+      }
+      if (key === 'config branch.task/remote.base origin/main') {
+        return { stdout: '', stderr: '' };
+      }
+      throw Object.assign(new Error(`Unexpected git command: git ${key}`), {
+        stdout: '',
+        stderr: 'fatal: not expected',
+        code: 128,
+      });
+    });
+
+    await expect(svc.createBranch('task/remote', 'main', true, 'origin')).resolves.toEqual({
+      success: true,
+      data: undefined,
+    });
+  });
+
+  it('fails remote source branch creation when fetch fails and no cached ref exists', async () => {
+    const svc = makeService(async (_cmd, args = []) => {
+      const key = args.join(' ');
+      if (key === 'fetch origin') {
+        throw Object.assign(new Error('fetch failed'), {
+          stdout: '',
+          stderr:
+            "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+          code: 128,
+        });
+      }
+      if (key === 'rev-parse --verify refs/remotes/origin/main') {
+        throw Object.assign(new Error('missing ref'), {
+          stdout: '',
+          stderr: 'fatal: Needed a single revision',
           code: 128,
         });
       }

--- a/src/main/core/git/impl/git-service.ts
+++ b/src/main/core/git/impl/git-service.ts
@@ -1498,12 +1498,21 @@ export class GitService implements GitProvider, IDisposable {
         });
       } catch (error: unknown) {
         const stderr = (error as { stderr?: string })?.stderr || String(error);
-        return err({
-          type: 'fetch_failed',
-          remote,
-          branch: from,
-          error: classifyFetchError(stderr),
-        });
+        try {
+          await this.ctx.exec('git', ['rev-parse', '--verify', `refs/remotes/${remote}/${from}`]);
+          log.warn('GitService: failed to fetch remote before creating branch, using cached ref', {
+            remote,
+            branch: from,
+            error: stderr,
+          });
+        } catch {
+          return err({
+            type: 'fetch_failed',
+            remote,
+            branch: from,
+            error: classifyFetchError(stderr),
+          });
+        }
       }
     }
     const base = syncWithRemote ? `${remote}/${from}` : `refs/heads/${from}`;

--- a/src/main/core/tasks/operations/createTask.test.ts
+++ b/src/main/core/tasks/operations/createTask.test.ts
@@ -224,6 +224,63 @@ describe('createTask', () => {
     expect(mocks.createBranch).toHaveBeenCalledWith('task/local', 'main', false, undefined);
   });
 
+  it('creates no-worktree tasks without reading repository remotes', async () => {
+    mocks.getConfiguredRemotes.mockRejectedValueOnce(new Error('SSH connection failed'));
+
+    const insertTaskValues = vi.fn((values: Partial<TaskRow>) => ({
+      returning: vi.fn().mockResolvedValue([makeTaskRow(values)]),
+    }));
+    const insertWorkspaceValues = vi.fn().mockResolvedValue(undefined);
+    mocks.insert
+      .mockReturnValueOnce({ values: insertTaskValues })
+      .mockReturnValueOnce({ values: insertWorkspaceValues });
+
+    const result = await createTask({
+      id: 'task-1',
+      projectId: 'project-1',
+      name: 'No worktree task',
+      sourceBranch: { type: 'local', branch: 'main' },
+      strategy: { kind: 'no-worktree' },
+    });
+
+    expect(result.success).toBe(true);
+    expect(mocks.getConfiguredRemotes).not.toHaveBeenCalled();
+    expect(mocks.getRepositoryInfo).not.toHaveBeenCalled();
+    expect(insertTaskValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        taskBranch: undefined,
+        sourceBranch: toStoredBranch({ type: 'local', branch: 'main' }),
+      })
+    );
+  });
+
+  it('returns a typed branch creation failure when repository info cannot be read', async () => {
+    mocks.getRepositoryInfo.mockRejectedValueOnce(new Error('SSH connection failed'));
+
+    const result = await createTask({
+      id: 'task-1',
+      projectId: 'project-1',
+      name: 'Remote task',
+      sourceBranch: { type: 'local', branch: 'main' },
+      strategy: {
+        kind: 'new-branch',
+        taskBranch: 'task/remote',
+        pushBranch: false,
+      },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'branch-create-failed',
+        branch: 'task/remote',
+        error: { type: 'error', message: 'SSH connection failed' },
+      },
+    });
+    expect(mocks.createBranch).not.toHaveBeenCalled();
+    expect(mocks.insert).not.toHaveBeenCalled();
+  });
+
   it('blocks branch-based tasks when the selected remote source branch cannot be fetched', async () => {
     mocks.createBranch.mockResolvedValueOnce(
       err({

--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -18,6 +18,10 @@ import { appSettingsService } from '../../settings/settings-service';
 import { toStoredBranch } from '../stored-branch';
 import { mapTaskRowToTask } from '../utils/utils';
 
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
 export async function createTask(
   params: CreateTaskParams
 ): Promise<Result<CreateTaskSuccess, CreateTaskError>> {
@@ -28,15 +32,6 @@ export async function createTask(
   if (!project) {
     return err({ type: 'project-not-found' });
   }
-  const { baseRemote, pushRemote } = await project.repository.getConfiguredRemotes();
-
-  // Settings used by from-pull-request branch resolution (new-branch and from-issue resolve
-  // the branch name on the FE via resolveTaskBranchName before submission).
-  const projectDefaults = await appSettingsService.get('project');
-  const branchPrefix = projectDefaults.branchPrefix ?? '';
-  const appendRandomSuffix = projectDefaults.appendRandomBranchSuffix ?? true;
-  const suffix = Math.random().toString(36).slice(2, 7);
-
   // Determines what gets stored as taskBranch in the DB and how the worktree is prepared.
   let taskBranch: string | undefined;
   // sourceBranch stored in the DB — defaults to params.sourceBranch but overridden for PRs.
@@ -46,7 +41,16 @@ export async function createTask(
     case 'new-branch': {
       // The FE resolves the final branch name before submission via resolveTaskBranchName.
       taskBranch = strategy.taskBranch;
-      const repoInfo = await project.repository.getRepositoryInfo();
+      const repoInfo = await project.repository.getRepositoryInfo().catch((error: unknown) => ({
+        error: errorMessage(error),
+      }));
+      if ('error' in repoInfo) {
+        return err({
+          type: 'branch-create-failed',
+          branch: taskBranch,
+          error: { type: 'error', message: repoInfo.error },
+        });
+      }
       if (repoInfo.isUnborn) {
         return err({
           type: 'initial-commit-required',
@@ -71,6 +75,19 @@ export async function createTask(
           });
         }
       } else if (strategy.pushBranch) {
+        const remotes = await project.repository.getConfiguredRemotes().catch((error: unknown) => ({
+          error: errorMessage(error),
+        }));
+        if ('error' in remotes) {
+          warning = {
+            type: 'branch-publish-failed',
+            branch: taskBranch,
+            remote: 'remote',
+            error: { type: 'error', message: remotes.error },
+          };
+          break;
+        }
+        const { pushRemote } = remotes;
         const publishResult = await project.repository.publishBranch(taskBranch, pushRemote);
         if (!publishResult.success) {
           warning = {
@@ -91,6 +108,24 @@ export async function createTask(
     }
 
     case 'from-pull-request': {
+      const remotes = await project.repository.getConfiguredRemotes().catch((error: unknown) => ({
+        error: errorMessage(error),
+      }));
+      if ('error' in remotes) {
+        return err({
+          type: 'pr-fetch-failed',
+          error: { type: 'error', message: remotes.error },
+          remote: 'remote',
+        });
+      }
+      const { baseRemote, pushRemote } = remotes;
+      // Settings used by from-pull-request branch resolution (new-branch and from-issue resolve
+      // the branch name on the FE via resolveTaskBranchName before submission).
+      const projectDefaults = await appSettingsService.get('project');
+      const branchPrefix = projectDefaults.branchPrefix ?? '';
+      const appendRandomSuffix = projectDefaults.appendRandomBranchSuffix ?? true;
+      const suffix = Math.random().toString(36).slice(2, 7);
+
       // If the head branch is already checked out in a valid worktree, skip the fetch.
       // Git refuses to update a branch that is currently checked out, even with --force.
       const existingWorktree = await project.worktreeService.findBranchAnywhere(

--- a/src/main/core/tasks/operations/createTask.ts
+++ b/src/main/core/tasks/operations/createTask.ts
@@ -82,7 +82,7 @@ export async function createTask(
           warning = {
             type: 'branch-publish-failed',
             branch: taskBranch,
-            remote: 'remote',
+            remote: 'unknown',
             error: { type: 'error', message: remotes.error },
           };
           break;
@@ -115,7 +115,7 @@ export async function createTask(
         return err({
           type: 'pr-fetch-failed',
           error: { type: 'error', message: remotes.error },
-          remote: 'remote',
+          remote: 'unknown',
         });
       }
       const { baseRemote, pushRemote } = remotes;


### PR DESCRIPTION
### Description
- keep normal git fetch path unchanged for healthy connections
- falls back to cached remote refs when fetch fails during task creation

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
