### PR TITLE
feat: support namespaces in rpc

### DIFF
--- a/src/main/rpc.ts
+++ b/src/main/rpc.ts
@@ -1,4 +1,4 @@
-import { createRPCRouter } from '../shared/ipc/rpc';
+import { createRPCNamespace, createRPCRouter } from '../shared/ipc/rpc';
 import { accountController } from './core/account/controller';
 import { appController } from './core/app/controller';
 import { asanaController } from './core/asana/controller';
@@ -45,7 +45,6 @@ export const rpcRouter = createRPCRouter({
   appSettings: appSettingsController,
   providerSettings: providerSettingsController,
   repository: repositoryController,
-  fs: filesController,
   update: updateController,
   pty: ptyController,
   resourceMonitor: resourceMonitorController,
@@ -65,16 +64,19 @@ export const rpcRouter = createRPCRouter({
   tasks: taskController,
   conversations: conversationController,
   terminals: terminalsController,
-  git: gitController,
   dependencies: dependenciesController,
   mcp: mcpController,
-  editorBuffer: editorBufferController,
   telemetry: telemetryController,
   pullRequests: pullRequestController,
   viewState: viewStateController,
   search: searchController,
   workspaces: workspaceController,
   projectSettings: projectSettingsController,
+  workspace: createRPCNamespace({
+    git: gitController,
+    fs: filesController,
+    editor: editorBufferController,
+  }),
 });
 
 export type RpcRouter = typeof rpcRouter;

--- a/src/renderer/features/tasks/add-remote-modal.tsx
+++ b/src/renderer/features/tasks/add-remote-modal.tsx
@@ -112,7 +112,7 @@ export function AddRemoteModal({
         return;
       }
 
-      const publishResult = await rpc.git.publishBranch(
+      const publishResult = await rpc.workspace.git.publishBranch(
         projectId,
         workspaceId,
         branchName,

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/create-pr-modal.tsx
@@ -106,7 +106,7 @@ export const CreatePrModal = observer(function CreatePrModal({
     setIsCreating(true);
     try {
       if (push) {
-        const pushResult = await rpc.git.push(
+        const pushResult = await rpc.workspace.git.push(
           projectId,
           workspaceId,
           repo?.pushRemote.name ?? 'origin'

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-commit-files.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-commit-files.ts
@@ -14,7 +14,7 @@ export function useCommitFiles(
   return useQuery({
     queryKey: commitFilesQueryKey(projectId, workspaceId, commitHash),
     queryFn: async (): Promise<GitChange[]> => {
-      const result = await rpc.git.getCommitFiles(projectId, workspaceId, commitHash);
+      const result = await rpc.workspace.git.getCommitFiles(projectId, workspaceId, commitHash);
       if (!result.success) throw new Error('Failed to load commit files');
       return result.data.files;
     },

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-pr-commits.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/use-pr-commits.ts
@@ -16,7 +16,7 @@ export function usePrCommits(projectId: string, workspaceId: string, pr: PullReq
   return useInfiniteQuery({
     queryKey: prCommitsQueryKey(projectId, workspaceId, pr?.baseRefOid ?? '', pr?.headRefOid ?? ''),
     queryFn: async ({ pageParam }: { pageParam: number }) => {
-      const result = await rpc.git.getLog(
+      const result = await rpc.workspace.git.getLog(
         projectId,
         workspaceId,
         PAGE_SIZE,

--- a/src/renderer/features/tasks/diff-view/main-panel/image-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/image-diff-view.tsx
@@ -75,7 +75,7 @@ function loadFromRef(
   ref: GitRef
 ): Promise<SideState> {
   return loadGitImage(() =>
-    rpc.git.getImageAtRef(projectId, workspaceId, filePath, gitRefToString(ref))
+    rpc.workspace.git.getImageAtRef(projectId, workspaceId, filePath, gitRefToString(ref))
   );
 }
 
@@ -84,7 +84,7 @@ async function loadFromDisk(
   workspaceId: string,
   filePath: string
 ): Promise<SideState> {
-  const res = await rpc.fs.readImage(projectId, workspaceId, filePath);
+  const res = await rpc.workspace.fs.readImage(projectId, workspaceId, filePath);
   if (!res.success) return { status: 'unavailable', reason: 'git-error' };
   const image = res.data;
   if (!image?.success) {
@@ -119,7 +119,7 @@ function loadModified(
     case 'disk':
       return loadFromDisk(projectId, workspaceId, activeFile.path);
     case 'staged':
-      return loadGitImage(() => rpc.git.getImageAtIndex(projectId, workspaceId, activeFile.path));
+      return loadGitImage(() => rpc.workspace.git.getImageAtIndex(projectId, workspaceId, activeFile.path));
     case 'git':
     case 'pr':
       return loadFromRef(

--- a/src/renderer/features/tasks/diff-view/main-panel/image-diff-view.tsx
+++ b/src/renderer/features/tasks/diff-view/main-panel/image-diff-view.tsx
@@ -119,7 +119,9 @@ function loadModified(
     case 'disk':
       return loadFromDisk(projectId, workspaceId, activeFile.path);
     case 'staged':
-      return loadGitImage(() => rpc.workspace.git.getImageAtIndex(projectId, workspaceId, activeFile.path));
+      return loadGitImage(() =>
+        rpc.workspace.git.getImageAtIndex(projectId, workspaceId, activeFile.path)
+      );
     case 'git':
     case 'pr':
       return loadFromRef(

--- a/src/renderer/features/tasks/diff-view/stores/git-store.test.ts
+++ b/src/renderer/features/tasks/diff-view/stores/git-store.test.ts
@@ -14,12 +14,14 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@renderer/lib/ipc', () => ({
   rpc: {
-    git: {
-      getFullStatus: mocks.getFullStatus,
-    },
-    fs: {
-      watchSetPaths: mocks.watchSetPaths,
-      watchStop: mocks.watchStop,
+    workspace: {
+      git: {
+        getFullStatus: mocks.getFullStatus,
+      },
+      fs: {
+        watchSetPaths: mocks.watchSetPaths,
+        watchStop: mocks.watchStop,
+      },
     },
   },
   events: {

--- a/src/renderer/features/tasks/diff-view/stores/git-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/git-store.ts
@@ -70,7 +70,9 @@ export class GitStore {
         {
           kind: 'event',
           subscribe: (handler) => {
-            rpc.workspace.fs.watchSetPaths(projectId, workspaceId, [''], 'git-store-status').catch(() => {});
+            rpc.workspace.fs
+              .watchSetPaths(projectId, workspaceId, [''], 'git-store-status')
+              .catch(() => {});
             const unsub = events.on(fsWatchEventChannel, (payload) => {
               if (payload.workspaceId !== workspaceId) return;
               const relevant = payload.events.some((e) => {
@@ -82,7 +84,9 @@ export class GitStore {
             });
             return () => {
               unsub();
-              rpc.workspace.fs.watchStop(projectId, workspaceId, 'git-store-status').catch(() => {});
+              rpc.workspace.fs
+                .watchStop(projectId, workspaceId, 'git-store-status')
+                .catch(() => {});
             };
           },
           onEvent: 'reload',

--- a/src/renderer/features/tasks/diff-view/stores/git-store.ts
+++ b/src/renderer/features/tasks/diff-view/stores/git-store.ts
@@ -70,7 +70,7 @@ export class GitStore {
         {
           kind: 'event',
           subscribe: (handler) => {
-            rpc.fs.watchSetPaths(projectId, workspaceId, [''], 'git-store-status').catch(() => {});
+            rpc.workspace.fs.watchSetPaths(projectId, workspaceId, [''], 'git-store-status').catch(() => {});
             const unsub = events.on(fsWatchEventChannel, (payload) => {
               if (payload.workspaceId !== workspaceId) return;
               const relevant = payload.events.some((e) => {
@@ -82,7 +82,7 @@ export class GitStore {
             });
             return () => {
               unsub();
-              rpc.fs.watchStop(projectId, workspaceId, 'git-store-status').catch(() => {});
+              rpc.workspace.fs.watchStop(projectId, workspaceId, 'git-store-status').catch(() => {});
             };
           },
           onEvent: 'reload',
@@ -254,7 +254,7 @@ export class GitStore {
       };
     });
     try {
-      await rpc.git.stageFiles(this.projectId, this.workspaceId, paths);
+      await rpc.workspace.git.stageFiles(this.projectId, this.workspaceId, paths);
       this.fullStatus.invalidate();
     } catch (e) {
       if (previous) this.fullStatus.setValue(previous);
@@ -274,7 +274,7 @@ export class GitStore {
       };
     });
     try {
-      await rpc.git.stageAllFiles(this.projectId, this.workspaceId);
+      await rpc.workspace.git.stageAllFiles(this.projectId, this.workspaceId);
       this.fullStatus.invalidate();
     } catch (e) {
       if (previous) this.fullStatus.setValue(previous);
@@ -295,7 +295,7 @@ export class GitStore {
       };
     });
     try {
-      await rpc.git.unstageFiles(this.projectId, this.workspaceId, paths);
+      await rpc.workspace.git.unstageFiles(this.projectId, this.workspaceId, paths);
       this.fullStatus.invalidate();
     } catch (e) {
       if (previous) this.fullStatus.setValue(previous);
@@ -312,7 +312,7 @@ export class GitStore {
       totalDeleted: 0,
     }));
     try {
-      await rpc.git.unstageAllFiles(this.projectId, this.workspaceId);
+      await rpc.workspace.git.unstageAllFiles(this.projectId, this.workspaceId);
       this.fullStatus.invalidate();
     } catch (e) {
       if (previous) this.fullStatus.setValue(previous);
@@ -327,7 +327,7 @@ export class GitStore {
       unstaged: prev.unstaged.filter((c) => !pathSet.has(c.path)),
     }));
     try {
-      await rpc.git.revertFiles(this.projectId, this.workspaceId, paths);
+      await rpc.workspace.git.revertFiles(this.projectId, this.workspaceId, paths);
       this.fullStatus.invalidate();
     } catch (e) {
       if (previous) this.fullStatus.setValue(previous);
@@ -338,7 +338,7 @@ export class GitStore {
   async discardAllFiles(): Promise<void> {
     const previous = this._applyOptimistic((prev) => ({ ...prev, unstaged: [] }));
     try {
-      await rpc.git.revertAllFiles(this.projectId, this.workspaceId);
+      await rpc.workspace.git.revertAllFiles(this.projectId, this.workspaceId);
       this.fullStatus.invalidate();
     } catch (e) {
       if (previous) this.fullStatus.setValue(previous);
@@ -347,7 +347,7 @@ export class GitStore {
   }
 
   async commit(message: string) {
-    const result = await rpc.git.commit(this.projectId, this.workspaceId, message);
+    const result = await rpc.workspace.git.commit(this.projectId, this.workspaceId, message);
     if (result.success) {
       // Clear staged list immediately so the UI doesn't flash stale state
       // while the authoritative reload is in flight.
@@ -379,7 +379,7 @@ export class GitStore {
 
   async push() {
     const remote = this.repositoryStore.pushRemote.name;
-    const result = await rpc.git.push(this.projectId, this.workspaceId, remote);
+    const result = await rpc.workspace.git.push(this.projectId, this.workspaceId, remote);
     if (result.success) {
       this.repositoryStore.refreshLocal(); // divergence resets to 0
       this.repositoryStore.refreshRemote(); // remote now has the commits
@@ -395,7 +395,7 @@ export class GitStore {
     const branchName = this.branchName;
     if (!branchName) return err({ type: 'git_error' as const, message: 'No branch checked out' });
     const remote = this.repositoryStore.pushRemote.name;
-    const result = await rpc.git.publishBranch(
+    const result = await rpc.workspace.git.publishBranch(
       this.projectId,
       this.workspaceId,
       branchName,
@@ -412,7 +412,7 @@ export class GitStore {
   }
 
   async pull() {
-    const result = await rpc.git.pull(this.projectId, this.workspaceId);
+    const result = await rpc.workspace.git.pull(this.projectId, this.workspaceId);
     if (result.success) {
       this.fullStatus.invalidate();
       this.repositoryStore.refreshLocal(); // local branch updated with pulled commits
@@ -424,7 +424,7 @@ export class GitStore {
   }
 
   private async _fetchFullStatus(): Promise<FullGitStatus> {
-    const result = await rpc.git.getFullStatus(this.projectId, this.workspaceId);
+    const result = await rpc.workspace.git.getFullStatus(this.projectId, this.workspaceId);
     if (!result.success) {
       if (result.error.type === 'too_many_files') {
         throw new Error(TOO_MANY_FILES_MSG);

--- a/src/renderer/features/tasks/editor/editor-file-tree.tsx
+++ b/src/renderer/features/tasks/editor/editor-file-tree.tsx
@@ -75,9 +75,15 @@ async function importLocalFiles(args: {
   );
 
   try {
-    const result = await rpc.workspace.fs.copyLocalFiles(projectId, workspaceId, srcPaths, destDirPath, {
-      overwrite,
-    });
+    const result = await rpc.workspace.fs.copyLocalFiles(
+      projectId,
+      workspaceId,
+      srcPaths,
+      destDirPath,
+      {
+        overwrite,
+      }
+    );
     if (!result.success) throw new Error(resultErrorMessage(result.error));
   } catch (error) {
     for (const p of inserted) files.removeNode(p);
@@ -186,7 +192,12 @@ const FileTreeRow = observer(function FileTreeRow({
     if (node.type !== 'file') return;
 
     try {
-      const result = await rpc.workspace.fs.readFile(projectId, workspaceId, node.path, MAX_COPY_FILE_BYTES);
+      const result = await rpc.workspace.fs.readFile(
+        projectId,
+        workspaceId,
+        node.path,
+        MAX_COPY_FILE_BYTES
+      );
       if (!result.success) throw new Error(resultErrorMessage(result.error));
       if (result.data.truncated) throw new Error('File is too large to copy.');
       await rpc.app.clipboardWriteText(result.data.content);

--- a/src/renderer/features/tasks/editor/editor-file-tree.tsx
+++ b/src/renderer/features/tasks/editor/editor-file-tree.tsx
@@ -75,7 +75,7 @@ async function importLocalFiles(args: {
   );
 
   try {
-    const result = await rpc.fs.copyLocalFiles(projectId, workspaceId, srcPaths, destDirPath, {
+    const result = await rpc.workspace.fs.copyLocalFiles(projectId, workspaceId, srcPaths, destDirPath, {
       overwrite,
     });
     if (!result.success) throw new Error(resultErrorMessage(result.error));
@@ -186,7 +186,7 @@ const FileTreeRow = observer(function FileTreeRow({
     if (node.type !== 'file') return;
 
     try {
-      const result = await rpc.fs.readFile(projectId, workspaceId, node.path, MAX_COPY_FILE_BYTES);
+      const result = await rpc.workspace.fs.readFile(projectId, workspaceId, node.path, MAX_COPY_FILE_BYTES);
       if (!result.success) throw new Error(resultErrorMessage(result.error));
       if (result.data.truncated) throw new Error('File is too large to copy.');
       await rpc.app.clipboardWriteText(result.data.content);
@@ -202,7 +202,7 @@ const FileTreeRow = observer(function FileTreeRow({
 
   const copyPath = async () => {
     try {
-      const result = await rpc.fs.getAbsolutePath(projectId, workspaceId, node.path);
+      const result = await rpc.workspace.fs.getAbsolutePath(projectId, workspaceId, node.path);
       if (!result.success) throw new Error(resultErrorMessage(result.error));
       await rpc.app.clipboardWriteText(result.data.path);
       toast({ title: 'Path copied' });

--- a/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
+++ b/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
@@ -176,7 +176,7 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
     if (accept) {
       modelRegistry.reloadFromDisk(uri);
       const filePath = uri.replace(`file://${this.modelRootPath}/`, '');
-      void rpc.editorBuffer.clearBuffer(this.projectId, this.workspaceId, filePath);
+      void rpc.workspace.editor.clearBuffer(this.projectId, this.workspaceId, filePath);
     } else {
       runInAction(() => {
         this.isSaving = true;
@@ -197,7 +197,7 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
    */
   async restoreBuffers(): Promise<void> {
     try {
-      const buffers = await rpc.editorBuffer.listBuffers(this.projectId, this.workspaceId);
+      const buffers = await rpc.workspace.editor.listBuffers(this.projectId, this.workspaceId);
       for (const { filePath, content } of buffers) {
         const uri = buildMonacoModelPath(this.modelRootPath, filePath);
         const model = modelRegistry.getModelByUri(uri);
@@ -242,7 +242,7 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
     const kind = getFileKind(filePath);
 
     if (kind === 'image') {
-      const result = await rpc.fs.readImage(this.projectId, this.workspaceId, filePath);
+      const result = await rpc.workspace.fs.readImage(this.projectId, this.workspaceId, filePath);
       const imageContent = result.success ? (result.data?.dataUrl ?? '') : '';
       runInAction(() => {
         for (const { tabManager } of this.tabGroupManager.groups) {
@@ -309,6 +309,6 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
     modelRegistry.unregisterModel(uri);
     modelRegistry.unregisterModel(modelRegistry.toDiskUri(uri));
     modelRegistry.unregisterModel(modelRegistry.toGitUri(uri, HEAD_REF));
-    void rpc.editorBuffer.clearBuffer(this.projectId, this.workspaceId, filePath);
+    void rpc.workspace.editor.clearBuffer(this.projectId, this.workspaceId, filePath);
   }
 }

--- a/src/renderer/features/tasks/editor/stores/files-store.test.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.test.ts
@@ -11,10 +11,12 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('@renderer/lib/ipc', () => ({
   rpc: {
-    fs: {
-      listFiles: mocks.listFiles,
-      watchSetPaths: mocks.watchSetPaths,
-      watchStop: mocks.watchStop,
+    workspace: {
+      fs: {
+        listFiles: mocks.listFiles,
+        watchSetPaths: mocks.watchSetPaths,
+        watchStop: mocks.watchStop,
+      },
     },
   },
   events: {

--- a/src/renderer/features/tasks/editor/stores/files-store.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.ts
@@ -48,7 +48,9 @@ export class FilesStore {
         {
           kind: 'event',
           subscribe: (handler) => {
-            rpc.workspace.fs.watchSetPaths(projectId, workspaceId, [''], 'filetree').catch(() => {});
+            rpc.workspace.fs
+              .watchSetPaths(projectId, workspaceId, [''], 'filetree')
+              .catch(() => {});
             const unsub = events.on(fsWatchEventChannel, (data) => {
               if (data.workspaceId !== workspaceId) return;
               handler(data.events);
@@ -202,10 +204,15 @@ export class FilesStore {
     this._pendingPaths.add(dirPath);
 
     try {
-      const result = await rpc.workspace.fs.listFiles(this.projectId, this.workspaceId, dirPath || '.', {
-        recursive: false,
-        includeHidden: true,
-      });
+      const result = await rpc.workspace.fs.listFiles(
+        this.projectId,
+        this.workspaceId,
+        dirPath || '.',
+        {
+          recursive: false,
+          includeHidden: true,
+        }
+      );
 
       if (!result.success) return;
 

--- a/src/renderer/features/tasks/editor/stores/files-store.ts
+++ b/src/renderer/features/tasks/editor/stores/files-store.ts
@@ -48,14 +48,14 @@ export class FilesStore {
         {
           kind: 'event',
           subscribe: (handler) => {
-            rpc.fs.watchSetPaths(projectId, workspaceId, [''], 'filetree').catch(() => {});
+            rpc.workspace.fs.watchSetPaths(projectId, workspaceId, [''], 'filetree').catch(() => {});
             const unsub = events.on(fsWatchEventChannel, (data) => {
               if (data.workspaceId !== workspaceId) return;
               handler(data.events);
             });
             return () => {
               unsub();
-              rpc.fs.watchStop(projectId, workspaceId, 'filetree').catch(() => {});
+              rpc.workspace.fs.watchStop(projectId, workspaceId, 'filetree').catch(() => {});
             };
           },
           onEvent: (watchEvents, ctx) => {
@@ -202,7 +202,7 @@ export class FilesStore {
     this._pendingPaths.add(dirPath);
 
     try {
-      const result = await rpc.fs.listFiles(this.projectId, this.workspaceId, dirPath || '.', {
+      const result = await rpc.workspace.fs.listFiles(this.projectId, this.workspaceId, dirPath || '.', {
         recursive: false,
         includeHidden: true,
       });

--- a/src/renderer/features/tasks/stores/lifecycle-scripts.test.ts
+++ b/src/renderer/features/tasks/stores/lifecycle-scripts.test.ts
@@ -22,9 +22,11 @@ vi.mock('@renderer/lib/ipc', () => ({
     projectSettings: {
       getSettings,
     },
-    fs: {
-      watchSetPaths,
-      watchStop,
+    workspace: {
+      fs: {
+        watchSetPaths,
+        watchStop,
+      },
     },
   },
 }));

--- a/src/renderer/features/tasks/stores/lifecycle-scripts.ts
+++ b/src/renderer/features/tasks/stores/lifecycle-scripts.ts
@@ -184,9 +184,9 @@ export class LifecycleScriptsStore implements TabViewProvider<LifecycleScriptSto
   private async watchConfig(): Promise<void> {
     if (this._watchingConfig || this._disposed) return;
     try {
-      await rpc.fs.watchSetPaths(this.projectId, this.workspaceId, [''], 'lifecycle-scripts');
+      await rpc.workspace.fs.watchSetPaths(this.projectId, this.workspaceId, [''], 'lifecycle-scripts');
       if (this._disposed) {
-        void rpc.fs.watchStop(this.projectId, this.workspaceId, 'lifecycle-scripts');
+        void rpc.workspace.fs.watchStop(this.projectId, this.workspaceId, 'lifecycle-scripts');
         return;
       }
       this._watchingConfig = true;
@@ -256,7 +256,7 @@ export class LifecycleScriptsStore implements TabViewProvider<LifecycleScriptSto
     this._refreshSeq++;
     for (const unsubscribe of this._unsubscribes) unsubscribe();
     if (this._watchingConfig) {
-      void rpc.fs.watchStop(this.projectId, this.workspaceId, 'lifecycle-scripts');
+      void rpc.workspace.fs.watchStop(this.projectId, this.workspaceId, 'lifecycle-scripts');
     }
     for (const script of this.scripts.values()) {
       script.dispose();

--- a/src/renderer/features/tasks/stores/lifecycle-scripts.ts
+++ b/src/renderer/features/tasks/stores/lifecycle-scripts.ts
@@ -184,7 +184,12 @@ export class LifecycleScriptsStore implements TabViewProvider<LifecycleScriptSto
   private async watchConfig(): Promise<void> {
     if (this._watchingConfig || this._disposed) return;
     try {
-      await rpc.workspace.fs.watchSetPaths(this.projectId, this.workspaceId, [''], 'lifecycle-scripts');
+      await rpc.workspace.fs.watchSetPaths(
+        this.projectId,
+        this.workspaceId,
+        [''],
+        'lifecycle-scripts'
+      );
       if (this._disposed) {
         void rpc.workspace.fs.watchStop(this.projectId, this.workspaceId, 'lifecycle-scripts');
         return;

--- a/src/renderer/features/tasks/stores/open-file-in-file-editor.ts
+++ b/src/renderer/features/tasks/stores/open-file-in-file-editor.ts
@@ -18,7 +18,7 @@ export async function openFileInTaskEditor(
   // Agent output often points at paths that don't exist in the worktree
   // (subdirectory-relative, deleted, etc.) — precheck so we can toast a
   // useful error instead of opening an empty tab.
-  const exists = await rpc.fs.fileExists(projectId, provisioned.workspaceId, filePath);
+  const exists = await rpc.workspace.fs.fileExists(projectId, provisioned.workspaceId, filePath);
   if (!exists.success || !exists.data.exists) {
     toast.error(`File not found in workspace: ${filePath}`);
     return;

--- a/src/renderer/features/tasks/stores/pr-store.ts
+++ b/src/renderer/features/tasks/stores/pr-store.ts
@@ -187,7 +187,11 @@ export class PrStore {
     const range = mergeBaseRange(baseRef, headRef);
 
     const tryRange = async (): Promise<GitChange[] | null> => {
-      const result = await rpc.workspace.git.getChangedFiles(this.projectId, this.workspaceId, range);
+      const result = await rpc.workspace.git.getChangedFiles(
+        this.projectId,
+        this.workspaceId,
+        range
+      );
       if (!result.success) return null;
       const changes = result.data.changes;
       const expectedChangedFiles = pr.changedFiles;

--- a/src/renderer/features/tasks/stores/pr-store.ts
+++ b/src/renderer/features/tasks/stores/pr-store.ts
@@ -187,7 +187,7 @@ export class PrStore {
     const range = mergeBaseRange(baseRef, headRef);
 
     const tryRange = async (): Promise<GitChange[] | null> => {
-      const result = await rpc.git.getChangedFiles(this.projectId, this.workspaceId, range);
+      const result = await rpc.workspace.git.getChangedFiles(this.projectId, this.workspaceId, range);
       if (!result.success) return null;
       const changes = result.data.changes;
       const expectedChangedFiles = pr.changedFiles;

--- a/src/renderer/lib/editor/html-renderer.tsx
+++ b/src/renderer/lib/editor/html-renderer.tsx
@@ -257,7 +257,7 @@ async function readWorkspaceText(
   workspaceId: string,
   filePath: string
 ): Promise<string | null> {
-  const result = await rpc.fs.readFile(projectId, workspaceId, filePath);
+  const result = await rpc.workspace.fs.readFile(projectId, workspaceId, filePath);
   return result.success ? (result.data?.content ?? null) : null;
 }
 
@@ -266,7 +266,7 @@ async function readWorkspaceImage(
   workspaceId: string,
   filePath: string
 ): Promise<string | null> {
-  const result = await rpc.fs.readImage(projectId, workspaceId, filePath);
+  const result = await rpc.workspace.fs.readImage(projectId, workspaceId, filePath);
   return result.success ? (result.data?.dataUrl ?? null) : null;
 }
 

--- a/src/renderer/lib/editor/markdown-renderer.tsx
+++ b/src/renderer/lib/editor/markdown-renderer.tsx
@@ -45,7 +45,7 @@ export const MarkdownEditorRenderer = observer(function MarkdownEditorRenderer({
   const resolveImage = useCallback(
     async (src: string): Promise<string | null> => {
       const imagePath = fileDir ? `${fileDir}/${src}` : src;
-      const result = await rpc.fs.readImage(projectId, workspaceId, imagePath);
+      const result = await rpc.workspace.fs.readImage(projectId, workspaceId, imagePath);
       return result.success ? (result.data?.dataUrl ?? null) : null;
     },
     [projectId, workspaceId, fileDir]

--- a/src/renderer/lib/monaco/monaco-model-registry.test.ts
+++ b/src/renderer/lib/monaco/monaco-model-registry.test.ts
@@ -9,25 +9,27 @@ const rpcState = vi.hoisted(() => ({
 
 vi.mock('@renderer/lib/ipc', () => ({
   rpc: {
-    fs: {
-      readFile: vi.fn(async () => ({
-        success: true,
-        data: { content: 'base', truncated: false, totalSize: 4 },
-      })),
-    },
-    git: {
-      getFileAtIndex: vi.fn(async () => ({
-        success: true,
-        data: { content: rpcState.indexContent },
-      })),
-      getFileAtRef: vi.fn(async () => ({
-        success: true,
-        data: { content: rpcState.refContent },
-      })),
-    },
-    editorBuffer: {
-      saveBuffer: vi.fn(),
-      clearBuffer: vi.fn(),
+    workspace: {
+      fs: {
+        readFile: vi.fn(async () => ({
+          success: true,
+          data: { content: 'base', truncated: false, totalSize: 4 },
+        })),
+      },
+      git: {
+        getFileAtIndex: vi.fn(async () => ({
+          success: true,
+          data: { content: rpcState.indexContent },
+        })),
+        getFileAtRef: vi.fn(async () => ({
+          success: true,
+          data: { content: rpcState.refContent },
+        })),
+      },
+      editor: {
+        saveBuffer: vi.fn(),
+        clearBuffer: vi.fn(),
+      },
     },
   },
 }));

--- a/src/renderer/lib/monaco/monaco-model-registry.ts
+++ b/src/renderer/lib/monaco/monaco-model-registry.ts
@@ -273,7 +273,7 @@ export class MonacoModelRegistry {
       type DiskFetchResult = { content: string; truncated: boolean; totalSize: number };
       const [fetchResult, monaco_] = await Promise.all([
         this.dedupFetch<DiskFetchResult>(fetchKey, async () => {
-          const res = await rpc.fs.readFile(projectId, workspaceId, filePath);
+          const res = await rpc.workspace.fs.readFile(projectId, workspaceId, filePath);
           if (!res.success)
             throw new Error(`registerModel(disk): readFile failed for ${filePath}: ${res.error}`);
           const result = res.data.content;
@@ -346,10 +346,10 @@ export class MonacoModelRegistry {
     const [content, m] = await Promise.all([
       this.dedupFetch(fetchKey, async () => {
         if (ref.kind === 'staged') {
-          const res = await rpc.git.getFileAtIndex(projectId, workspaceId, filePath);
+          const res = await rpc.workspace.git.getFileAtIndex(projectId, workspaceId, filePath);
           return res.success ? res.data.content : null;
         }
-        const res = await rpc.git.getFileAtRef(
+        const res = await rpc.workspace.git.getFileAtRef(
           projectId,
           workspaceId,
           filePath,
@@ -411,7 +411,7 @@ export class MonacoModelRegistry {
               if (!currentEntry || currentEntry.type !== 'buffer') return;
               if (!this.isDirty(uri)) return;
               const value = currentEntry.model.getValue();
-              void rpc.editorBuffer.saveBuffer(
+              void rpc.workspace.editor.saveBuffer(
                 currentEntry.projectId,
                 currentEntry.workspaceId,
                 currentEntry.filePath,
@@ -472,7 +472,7 @@ export class MonacoModelRegistry {
             if (!currentEntry || currentEntry.type !== 'buffer') return;
             if (!this.isDirty(uri)) return;
             const value = currentEntry.model.getValue();
-            void rpc.editorBuffer.saveBuffer(
+            void rpc.workspace.editor.saveBuffer(
               currentEntry.projectId,
               currentEntry.workspaceId,
               currentEntry.filePath,
@@ -727,12 +727,12 @@ export class MonacoModelRegistry {
     if (!buf || buf.type !== 'buffer') return null;
 
     const content = buf.model.getValue();
-    const result = await rpc.fs.writeFile(buf.projectId, buf.workspaceId, buf.filePath, content);
+    const result = await rpc.workspace.fs.writeFile(buf.projectId, buf.workspaceId, buf.filePath, content);
     if (!result.success) return null;
 
     this.markSaved(uri);
     this.pendingConflicts.delete(uri);
-    void rpc.editorBuffer.clearBuffer(buf.projectId, buf.workspaceId, buf.filePath);
+    void rpc.workspace.editor.clearBuffer(buf.projectId, buf.workspaceId, buf.filePath);
     return content;
   }
 
@@ -748,13 +748,13 @@ export class MonacoModelRegistry {
     const entry = this.modelMap.get(uri);
     if (!entry) return;
     if (entry.type === 'disk') {
-      const res = await rpc.fs.readFile(entry.projectId, entry.workspaceId, entry.filePath);
+      const res = await rpc.workspace.fs.readFile(entry.projectId, entry.workspaceId, entry.filePath);
       if (res.success) this.applyDiskUpdate(uri, entry, res.data.content);
     } else if (entry.type === 'git') {
       const res =
         entry.ref.kind === 'staged'
-          ? await rpc.git.getFileAtIndex(entry.projectId, entry.workspaceId, entry.filePath)
-          : await rpc.git.getFileAtRef(
+          ? await rpc.workspace.git.getFileAtIndex(entry.projectId, entry.workspaceId, entry.filePath)
+          : await rpc.workspace.git.getFileAtRef(
               entry.projectId,
               entry.workspaceId,
               entry.filePath,

--- a/src/renderer/lib/monaco/monaco-model-registry.ts
+++ b/src/renderer/lib/monaco/monaco-model-registry.ts
@@ -727,7 +727,12 @@ export class MonacoModelRegistry {
     if (!buf || buf.type !== 'buffer') return null;
 
     const content = buf.model.getValue();
-    const result = await rpc.workspace.fs.writeFile(buf.projectId, buf.workspaceId, buf.filePath, content);
+    const result = await rpc.workspace.fs.writeFile(
+      buf.projectId,
+      buf.workspaceId,
+      buf.filePath,
+      content
+    );
     if (!result.success) return null;
 
     this.markSaved(uri);
@@ -748,12 +753,20 @@ export class MonacoModelRegistry {
     const entry = this.modelMap.get(uri);
     if (!entry) return;
     if (entry.type === 'disk') {
-      const res = await rpc.workspace.fs.readFile(entry.projectId, entry.workspaceId, entry.filePath);
+      const res = await rpc.workspace.fs.readFile(
+        entry.projectId,
+        entry.workspaceId,
+        entry.filePath
+      );
       if (res.success) this.applyDiskUpdate(uri, entry, res.data.content);
     } else if (entry.type === 'git') {
       const res =
         entry.ref.kind === 'staged'
-          ? await rpc.workspace.git.getFileAtIndex(entry.projectId, entry.workspaceId, entry.filePath)
+          ? await rpc.workspace.git.getFileAtIndex(
+              entry.projectId,
+              entry.workspaceId,
+              entry.filePath
+            )
           : await rpc.workspace.git.getFileAtRef(
               entry.projectId,
               entry.workspaceId,

--- a/src/shared/ipc/rpc.test.ts
+++ b/src/shared/ipc/rpc.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, expectTypeOf, it, vi } from 'vitest';
+import {
+  createRPCClient,
+  createRPCController,
+  createRPCNamespace,
+  createRPCRouter,
+  registerRPCRouter,
+} from './rpc';
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const gitController = createRPCController({
+  commit: (msg: string) => Promise.resolve(`committed: ${msg}`),
+  status: () => Promise.resolve('clean'),
+});
+
+const fsController = createRPCController({
+  read: (path: string) => Promise.resolve(`content of ${path}`),
+  write: (path: string, data: string) => Promise.resolve(data.length),
+});
+
+const wsGitController = createRPCController({
+  clone: (url: string) => Promise.resolve(`cloned ${url}`),
+});
+
+const wsFsController = createRPCController({
+  list: (dir: string) => Promise.resolve([dir]),
+});
+
+const workspaceNamespace = createRPCNamespace({
+  git: wsGitController,
+  fs: wsFsController,
+});
+
+const router = createRPCRouter({
+  git: gitController,
+  fs: fsController,
+  workspace: workspaceNamespace,
+});
+
+type Router = typeof router;
+
+// Minimal IpcMain stub — only the `handle` method is needed.
+function makeIpcMainStub() {
+  const registered = new Map<string, (...args: unknown[]) => unknown>();
+  return {
+    handle(channel: string, handler: (...args: unknown[]) => unknown) {
+      registered.set(channel, handler);
+    },
+    invoke(channel: string, ...args: unknown[]) {
+      const handler = registered.get(channel);
+      if (!handler) throw new Error(`No handler registered for channel: ${channel}`);
+      return handler({} /* _event */, ...args);
+    },
+    registeredChannels() {
+      return [...registered.keys()];
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createRPCClient — runtime behavior
+// ---------------------------------------------------------------------------
+
+describe('createRPCClient', () => {
+  it('calls invoke with the flat channel and args for a 2-level call', async () => {
+    const invoke = vi.fn().mockResolvedValue('ok');
+    const rpc = createRPCClient<Router>(invoke);
+
+    await rpc.git.commit('hello');
+
+    expect(invoke).toHaveBeenCalledWith('git.commit', 'hello');
+  });
+
+  it('calls invoke with the nested channel and args for a 3-level call', async () => {
+    const invoke = vi.fn().mockResolvedValue('ok');
+    const rpc = createRPCClient<Router>(invoke);
+
+    await rpc.workspace.git.clone('https://example.com/repo');
+
+    expect(invoke).toHaveBeenCalledWith('workspace.git.clone', 'https://example.com/repo');
+  });
+
+  it('forwards multiple arguments correctly', async () => {
+    const invoke = vi.fn().mockResolvedValue(0);
+    const rpc = createRPCClient<Router>(invoke);
+
+    await rpc.fs.write('file.txt', 'content');
+
+    expect(invoke).toHaveBeenCalledWith('fs.write', 'file.txt', 'content');
+  });
+
+  it('returns the value resolved by invoke', async () => {
+    const invoke = vi.fn().mockResolvedValue('clean');
+    const rpc = createRPCClient<Router>(invoke);
+
+    const result = await rpc.git.status();
+
+    expect(result).toBe('clean');
+  });
+
+  it('constructs the correct channel for a second nested namespace', async () => {
+    const invoke = vi.fn().mockResolvedValue([]);
+    const rpc = createRPCClient<Router>(invoke);
+
+    await rpc.workspace.fs.list('projects');
+
+    expect(invoke).toHaveBeenCalledWith('workspace.fs.list', 'projects');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// registerRPCRouter — runtime behavior
+// ---------------------------------------------------------------------------
+
+describe('registerRPCRouter', () => {
+  it('registers flat handlers at their 2-segment channel', () => {
+    const ipc = makeIpcMainStub();
+    registerRPCRouter(router, ipc as never);
+
+    expect(ipc.registeredChannels()).toContain('git.commit');
+    expect(ipc.registeredChannels()).toContain('git.status');
+    expect(ipc.registeredChannels()).toContain('fs.read');
+    expect(ipc.registeredChannels()).toContain('fs.write');
+  });
+
+  it('registers nested handlers at their 3-segment channel', () => {
+    const ipc = makeIpcMainStub();
+    registerRPCRouter(router, ipc as never);
+
+    expect(ipc.registeredChannels()).toContain('workspace.git.clone');
+    expect(ipc.registeredChannels()).toContain('workspace.fs.list');
+  });
+
+  it('calls through to the original handler function with args', async () => {
+    const ipc = makeIpcMainStub();
+    registerRPCRouter(router, ipc as never);
+
+    const result = await ipc.invoke('git.commit', 'my message');
+    expect(result).toBe('committed: my message');
+  });
+
+  it('calls through to a nested handler function with args', async () => {
+    const ipc = makeIpcMainStub();
+    registerRPCRouter(router, ipc as never);
+
+    const result = await ipc.invoke('workspace.git.clone', 'https://example.com');
+    expect(result).toBe('cloned https://example.com');
+  });
+
+  it('does not register any channel for non-function, non-object values', () => {
+    const ipc = makeIpcMainStub();
+    // @ts-expect-error intentionally passing an invalid router value to test robustness
+    registerRPCRouter({ broken: null }, ipc as never);
+    expect(ipc.registeredChannels()).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// IpcClient type-safety (compile-time, verified by expectTypeOf)
+// ---------------------------------------------------------------------------
+
+describe('IpcClient type-safety', () => {
+  const invoke = vi.fn().mockResolvedValue(undefined);
+  const rpc = createRPCClient<Router>(invoke);
+
+  it('types a flat procedure as an async function with the original signature', () => {
+    expectTypeOf(rpc.git.commit).toEqualTypeOf<(msg: string) => Promise<string>>();
+  });
+
+  it('types a flat zero-arg procedure correctly', () => {
+    expectTypeOf(rpc.git.status).toEqualTypeOf<() => Promise<string>>();
+  });
+
+  it('types a flat multi-arg procedure correctly', () => {
+    expectTypeOf(rpc.fs.write).toEqualTypeOf<(path: string, data: string) => Promise<number>>();
+  });
+
+  it('types a nested procedure as an async function with the original signature', () => {
+    expectTypeOf(rpc.workspace.git.clone).toEqualTypeOf<(url: string) => Promise<string>>();
+  });
+
+  it('types a nested namespace as a sub-namespace object, not a callable', () => {
+    expectTypeOf(rpc.workspace).toEqualTypeOf<{
+      git: { clone: (url: string) => Promise<string> };
+      fs: { list: (dir: string) => Promise<string[]> };
+    }>();
+  });
+
+  it('wraps a synchronous return value in Promise', () => {
+    const syncController = createRPCController({
+      greet: (name: string) => `Hello, ${name}`,
+    });
+    const syncRouter = createRPCRouter({ greeter: syncController });
+    type SyncRouter = typeof syncRouter;
+
+    const syncRpc = createRPCClient<SyncRouter>(invoke);
+    expectTypeOf(syncRpc.greeter.greet).toEqualTypeOf<(name: string) => Promise<string>>();
+  });
+
+  it('unwraps a Promise return value so it is not double-wrapped', () => {
+    // gitController.commit returns Promise<string> — IpcClient should give Promise<string>, not Promise<Promise<string>>
+    expectTypeOf(rpc.git.commit).returns.toEqualTypeOf<Promise<string>>();
+  });
+});

--- a/src/shared/ipc/rpc.ts
+++ b/src/shared/ipc/rpc.ts
@@ -7,28 +7,69 @@ export function createRPCController<T extends ProcedureMap>(handlers: T): T {
   return handlers;
 }
 
-type RouterMap = Record<string, ProcedureMap>;
+// Groups multiple controllers under a shared namespace prefix so they can be
+// registered as rpc.<group>.<namespace>.<procedure>() at the next level up.
+export function createRPCNamespace<T extends Record<string, ProcedureMap>>(controllers: T): T {
+  return controllers;
+}
+
+// Accepts both flat controllers (ProcedureMap values) and namespace groups
+// (Record<string, ProcedureMap> values) at the top level.
+// oxlint-disable-next-line typescript/no-explicit-any
+type RouterMap = Record<string, Record<string, any>>;
 
 export function createRPCRouter<T extends RouterMap>(routers: T): T {
   return routers;
 }
 
-export function registerRPCRouter(router: RouterMap, ipcMain: IpcMain): void {
-  for (const [ns, handlers] of Object.entries(router)) {
-    for (const [key, fn] of Object.entries(handlers)) {
-      const channel = `${ns}.${key}`;
-      ipcMain.handle(channel, (_event, ...args: unknown[]) => fn(...args));
+// Recursively walks the handler tree and registers every leaf function with
+// ipcMain at its full dot-joined path (e.g. "git.commit", "workspace.git.commit").
+function registerHandlers(ipcMain: IpcMain, prefix: string, value: unknown): void {
+  if (typeof value === 'function') {
+    ipcMain.handle(prefix, (_event, ...args: unknown[]) =>
+      (value as (...a: unknown[]) => unknown)(...args)
+    );
+  } else if (value !== null && typeof value === 'object') {
+    for (const [key, child] of Object.entries(value)) {
+      registerHandlers(ipcMain, `${prefix}.${key}`, child);
     }
   }
 }
 
-type IpcClient<R extends RouterMap> = {
-  [NS in keyof R]: {
-    [P in keyof R[NS]]: R[NS][P] extends (...args: infer A) => infer Ret
-      ? (...args: A) => Promise<Awaited<Ret>>
-      : never;
-  };
+export function registerRPCRouter(router: RouterMap, ipcMain: IpcMain): void {
+  for (const [ns, handlers] of Object.entries(router)) {
+    registerHandlers(ipcMain, ns, handlers);
+  }
+}
+
+// Recursively maps every leaf function to its async client equivalent.
+// Non-function values recurse, so both 2-level (rpc.git.commit) and
+// 3-level (rpc.workspace.git.commit) shapes are handled by a single type.
+type IpcClient<R> = {
+  [K in keyof R]: R[K] extends (...args: infer A) => infer Ret
+    ? (...args: A) => Promise<Awaited<Ret>>
+    : IpcClient<R[K]>;
 };
+
+// Returns a callable Proxy that accumulates the dot-joined channel path on each
+// property access and calls invoke() when invoked as a function.
+// Supports arbitrary nesting depth without any knowledge of the router shape.
+function makeChannelProxy(
+  invoke: (channel: string, ...args: unknown[]) => Promise<unknown>,
+  parts: string[]
+): unknown {
+  return new Proxy(
+    function (...args: unknown[]) {
+      return invoke(parts.join('.'), ...args);
+    },
+    {
+      get(_, key: string) {
+        if (typeof key !== 'string' || key === 'then') return undefined;
+        return makeChannelProxy(invoke, [...parts, key]);
+      },
+    }
+  );
+}
 
 export function createRPCClient<Router extends RouterMap>(
   invoke: (channel: string, ...args: unknown[]) => Promise<unknown>
@@ -38,15 +79,7 @@ export function createRPCClient<Router extends RouterMap>(
     {
       get(_, ns: string) {
         if (typeof ns !== 'string' || ns === 'then') return undefined;
-        return new Proxy(
-          {},
-          {
-            get(_, procedure: string) {
-              if (typeof procedure !== 'string' || procedure === 'then') return undefined;
-              return (...args: unknown[]) => invoke(`${ns}.${procedure}`, ...args);
-            },
-          }
-        );
+        return makeChannelProxy(invoke, [ns]);
       },
     }
   ) as IpcClient<Router>;

--- a/src/shared/ipc/rpc.ts
+++ b/src/shared/ipc/rpc.ts
@@ -43,7 +43,7 @@ export function registerRPCRouter(router: RouterMap, ipcMain: IpcMain): void {
 }
 
 // Recursively maps every leaf function to its async client equivalent.
-// Non-function values recurse, so both 2-level (rpc.git.commit) and
+// Non-function values recurse, so both 2-level (rpc.repository.fetch) and
 // 3-level (rpc.workspace.git.commit) shapes are handled by a single type.
 type IpcClient<R> = {
   [K in keyof R]: R[K] extends (...args: infer A) => infer Ret


### PR DESCRIPTION
Currently our typesafe rpc utilities are hardcoded to only support one level of namespaces (e.g [namespace].function). To better group rpc methods (mostly for workspace interaction).
