### PR TITLE
fix: automations kill pty session after agent marks done

### DIFF
--- a/src/main/core/agent-hooks/agent-hook-service.ts
+++ b/src/main/core/agent-hooks/agent-hook-service.ts
@@ -5,6 +5,7 @@ import type { IDisposable, IInitializable } from '@main/lib/lifecycle';
 import { telemetryService } from '@main/lib/telemetry';
 import { agentEventChannel, type AgentEvent } from '@shared/events/agentEvents';
 import { conversationChangedChannel } from '@shared/events/conversationEvents';
+import { stopAutomationSessionAfterDone } from './automation-pty-cleanup';
 import { handleCodexSessionStartHook } from './codex-session-start';
 import { enrichEvent } from './event-enricher';
 import { handleProviderSessionHook } from './handle-provider-session-hook';
@@ -31,6 +32,7 @@ class AgentHookService implements IInitializable, IDisposable {
       const appFocused = isAppFocused();
       await maybeShowNotification(event, appFocused);
       events.emit(agentEventChannel, { event, appFocused });
+      void stopAutomationSessionAfterDone(event);
     });
 
     conversationEvents.on(

--- a/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AgentEvent } from '@shared/events/agentEvents';
+import { taskWasCreatedByAutomationRun } from '../automations/repo';
+import { taskManager } from '../tasks/task-manager';
+import { stopAutomationSessionAfterDone } from './automation-pty-cleanup';
+
+vi.mock('../automations/repo', () => ({ taskWasCreatedByAutomationRun: vi.fn() }));
+vi.mock('../tasks/task-manager', () => ({ taskManager: { getTask: vi.fn() } }));
+vi.mock('@main/lib/logger', () => ({ log: { warn: vi.fn() } }));
+
+const stopEvent: AgentEvent = {
+  type: 'stop',
+  source: 'hook',
+  providerId: 'claude',
+  projectId: 'project-1',
+  taskId: 'task-1',
+  conversationId: 'conversation-1',
+  timestamp: 1,
+  payload: {},
+};
+
+describe('stopAutomationSessionAfterDone', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('stops the conversation PTY when an automation agent marks done', async () => {
+    const stopSession = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(taskWasCreatedByAutomationRun).mockResolvedValue(true);
+    vi.mocked(taskManager.getTask).mockReturnValue({ conversations: { stopSession } } as never);
+
+    await stopAutomationSessionAfterDone(stopEvent);
+
+    expect(stopSession).toHaveBeenCalledWith('conversation-1');
+  });
+
+  it('leaves non-automation tasks running after done', async () => {
+    vi.mocked(taskWasCreatedByAutomationRun).mockResolvedValue(false);
+
+    await stopAutomationSessionAfterDone(stopEvent);
+
+    expect(taskManager.getTask).not.toHaveBeenCalled();
+  });
+
+  it('ignores non-stop agent events', async () => {
+    await stopAutomationSessionAfterDone({ ...stopEvent, type: 'start' });
+
+    expect(taskWasCreatedByAutomationRun).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
@@ -42,9 +42,10 @@ describe('stopAutomationSessionAfterDone', () => {
     const stopEvent = makeStopEvent('conversation-dedupe');
     let finishStopSession!: () => void;
     const stopSession = vi.fn(
-      () => new Promise<void>((resolve) => {
-        finishStopSession = resolve;
-      })
+      () =>
+        new Promise<void>((resolve) => {
+          finishStopSession = resolve;
+        })
     );
     vi.mocked(taskWasCreatedByAutomationRun).mockResolvedValue(true);
     vi.mocked(taskManager.getTask).mockReturnValue({ conversations: { stopSession } } as never);
@@ -56,6 +57,18 @@ describe('stopAutomationSessionAfterDone', () => {
     await Promise.all([hookStop, classifierStop]);
 
     expect(stopSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows a later stop event after the previous stop finishes', async () => {
+    const stopEvent = makeStopEvent('conversation-repeat');
+    const stopSession = vi.fn().mockResolvedValue(undefined);
+    vi.mocked(taskWasCreatedByAutomationRun).mockResolvedValue(true);
+    vi.mocked(taskManager.getTask).mockReturnValue({ conversations: { stopSession } } as never);
+
+    await stopAutomationSessionAfterDone(stopEvent);
+    await stopAutomationSessionAfterDone(stopEvent);
+
+    expect(stopSession).toHaveBeenCalledTimes(2);
   });
 
   it('leaves non-automation tasks running after done', async () => {

--- a/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
@@ -9,16 +9,18 @@ vi.mock('../automations/repo', () => ({ taskWasCreatedByAutomationRun: vi.fn() }
 vi.mock('../tasks/task-manager', () => ({ taskManager: { getTask: vi.fn() } }));
 vi.mock('@main/lib/logger', () => ({ log: { warn: vi.fn() } }));
 
-const stopEvent: AgentEvent = {
-  type: 'stop',
-  source: 'hook',
-  providerId: 'claude',
-  projectId: 'project-1',
-  taskId: 'task-1',
-  conversationId: 'conversation-1',
-  timestamp: 1,
-  payload: {},
-};
+function makeStopEvent(conversationId: string): AgentEvent {
+  return {
+    type: 'stop',
+    source: 'hook',
+    providerId: 'claude',
+    projectId: 'project-1',
+    taskId: 'task-1',
+    conversationId,
+    timestamp: 1,
+    payload: {},
+  };
+}
 
 describe('stopAutomationSessionAfterDone', () => {
   beforeEach(() => {
@@ -26,16 +28,38 @@ describe('stopAutomationSessionAfterDone', () => {
   });
 
   it('stops the conversation PTY when an automation agent marks done', async () => {
+    const stopEvent = makeStopEvent('conversation-stop');
     const stopSession = vi.fn().mockResolvedValue(undefined);
     vi.mocked(taskWasCreatedByAutomationRun).mockResolvedValue(true);
     vi.mocked(taskManager.getTask).mockReturnValue({ conversations: { stopSession } } as never);
 
     await stopAutomationSessionAfterDone(stopEvent);
 
-    expect(stopSession).toHaveBeenCalledWith('conversation-1');
+    expect(stopSession).toHaveBeenCalledWith('conversation-stop');
+  });
+
+  it('deduplicates concurrent stop events for the same conversation', async () => {
+    const stopEvent = makeStopEvent('conversation-dedupe');
+    let finishStopSession!: () => void;
+    const stopSession = vi.fn(
+      () => new Promise<void>((resolve) => {
+        finishStopSession = resolve;
+      })
+    );
+    vi.mocked(taskWasCreatedByAutomationRun).mockResolvedValue(true);
+    vi.mocked(taskManager.getTask).mockReturnValue({ conversations: { stopSession } } as never);
+
+    const hookStop = stopAutomationSessionAfterDone(stopEvent);
+    const classifierStop = stopAutomationSessionAfterDone({ ...stopEvent, source: 'classifier' });
+    await Promise.resolve();
+    finishStopSession();
+    await Promise.all([hookStop, classifierStop]);
+
+    expect(stopSession).toHaveBeenCalledTimes(1);
   });
 
   it('leaves non-automation tasks running after done', async () => {
+    const stopEvent = makeStopEvent('conversation-non-automation');
     vi.mocked(taskWasCreatedByAutomationRun).mockResolvedValue(false);
 
     await stopAutomationSessionAfterDone(stopEvent);
@@ -44,12 +68,14 @@ describe('stopAutomationSessionAfterDone', () => {
   });
 
   it('ignores non-stop agent events', async () => {
+    const stopEvent = makeStopEvent('conversation-non-stop');
     await stopAutomationSessionAfterDone({ ...stopEvent, type: 'start' });
 
     expect(taskWasCreatedByAutomationRun).not.toHaveBeenCalled();
   });
 
   it('logs lookup failures instead of rejecting', async () => {
+    const stopEvent = makeStopEvent('conversation-lookup-failure');
     vi.mocked(taskWasCreatedByAutomationRun).mockRejectedValue(new Error('db closed'));
 
     await expect(stopAutomationSessionAfterDone(stopEvent)).resolves.toBeUndefined();

--- a/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { log } from '@main/lib/logger';
 import type { AgentEvent } from '@shared/events/agentEvents';
 import { taskWasCreatedByAutomationRun } from '../automations/repo';
 import { taskManager } from '../tasks/task-manager';
@@ -46,5 +47,16 @@ describe('stopAutomationSessionAfterDone', () => {
     await stopAutomationSessionAfterDone({ ...stopEvent, type: 'start' });
 
     expect(taskWasCreatedByAutomationRun).not.toHaveBeenCalled();
+  });
+
+  it('logs lookup failures instead of rejecting', async () => {
+    vi.mocked(taskWasCreatedByAutomationRun).mockRejectedValue(new Error('db closed'));
+
+    await expect(stopAutomationSessionAfterDone(stopEvent)).resolves.toBeUndefined();
+
+    expect(log.warn).toHaveBeenCalledWith(
+      'agent-hooks: failed to stop completed automation PTY',
+      expect.objectContaining({ taskId: 'task-1', error: 'Error: db closed' })
+    );
   });
 });

--- a/src/main/core/agent-hooks/automation-pty-cleanup.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.ts
@@ -24,6 +24,7 @@ export async function stopAutomationSessionAfterDone(event: AgentEvent): Promise
     }
 
     await task.conversations.stopSession(event.conversationId);
+    stoppingAutomationSessions.delete(event.conversationId);
   } catch (error) {
     stoppingAutomationSessions.delete(event.conversationId);
     log.warn('agent-hooks: failed to stop completed automation PTY', {

--- a/src/main/core/agent-hooks/automation-pty-cleanup.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.ts
@@ -1,0 +1,22 @@
+import { taskWasCreatedByAutomationRun } from '@main/core/automations/repo';
+import { taskManager } from '@main/core/tasks/task-manager';
+import { log } from '@main/lib/logger';
+import type { AgentEvent } from '@shared/events/agentEvents';
+
+export async function stopAutomationSessionAfterDone(event: AgentEvent): Promise<void> {
+  if (event.type !== 'stop') return;
+  if (!(await taskWasCreatedByAutomationRun(event.taskId))) return;
+
+  const task = taskManager.getTask(event.taskId);
+  if (!task) return;
+
+  try {
+    await task.conversations.stopSession(event.conversationId);
+  } catch (error) {
+    log.warn('agent-hooks: failed to stop completed automation PTY', {
+      taskId: event.taskId,
+      conversationId: event.conversationId,
+      error: String(error),
+    });
+  }
+}

--- a/src/main/core/agent-hooks/automation-pty-cleanup.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.ts
@@ -3,17 +3,29 @@ import { taskManager } from '@main/core/tasks/task-manager';
 import { log } from '@main/lib/logger';
 import type { AgentEvent } from '@shared/events/agentEvents';
 
+const stoppingAutomationSessions = new Set<string>();
+
 export async function stopAutomationSessionAfterDone(event: AgentEvent): Promise<void> {
   if (event.type !== 'stop') return;
 
+  if (stoppingAutomationSessions.has(event.conversationId)) return;
+  stoppingAutomationSessions.add(event.conversationId);
+
   try {
-    if (!(await taskWasCreatedByAutomationRun(event.taskId))) return;
+    if (!(await taskWasCreatedByAutomationRun(event.taskId))) {
+      stoppingAutomationSessions.delete(event.conversationId);
+      return;
+    }
 
     const task = taskManager.getTask(event.taskId);
-    if (!task) return;
+    if (!task) {
+      stoppingAutomationSessions.delete(event.conversationId);
+      return;
+    }
 
     await task.conversations.stopSession(event.conversationId);
   } catch (error) {
+    stoppingAutomationSessions.delete(event.conversationId);
     log.warn('agent-hooks: failed to stop completed automation PTY', {
       taskId: event.taskId,
       conversationId: event.conversationId,

--- a/src/main/core/agent-hooks/automation-pty-cleanup.ts
+++ b/src/main/core/agent-hooks/automation-pty-cleanup.ts
@@ -5,12 +5,13 @@ import type { AgentEvent } from '@shared/events/agentEvents';
 
 export async function stopAutomationSessionAfterDone(event: AgentEvent): Promise<void> {
   if (event.type !== 'stop') return;
-  if (!(await taskWasCreatedByAutomationRun(event.taskId))) return;
-
-  const task = taskManager.getTask(event.taskId);
-  if (!task) return;
 
   try {
+    if (!(await taskWasCreatedByAutomationRun(event.taskId))) return;
+
+    const task = taskManager.getTask(event.taskId);
+    if (!task) return;
+
     await task.conversations.stopSession(event.conversationId);
   } catch (error) {
     log.warn('agent-hooks: failed to stop completed automation PTY', {

--- a/src/main/core/agent-hooks/classifier-wiring.ts
+++ b/src/main/core/agent-hooks/classifier-wiring.ts
@@ -5,6 +5,7 @@ import { log } from '@main/lib/logger';
 import { type AgentProviderId } from '@shared/agent-provider-registry';
 import { agentEventChannel, type AgentEvent } from '@shared/events/agentEvents';
 import { makePtyId } from '@shared/ptyId';
+import { stopAutomationSessionAfterDone } from './automation-pty-cleanup';
 import { createClassifier } from './classifiers';
 import { stripAnsi, type ClassificationResult } from './classifiers/base';
 import { maybeShowNotification } from './notification';
@@ -118,6 +119,7 @@ export function wireAgentClassifier({
         const appFocused = isAppFocused();
         void maybeShowNotification(event, appFocused);
         events.emit(agentEventChannel, { event, appFocused });
+        void stopAutomationSessionAfterDone(event);
       } catch (err) {
         log.warn('wireAgentClassifier: idle check failed', { error: String(err) });
       }

--- a/src/main/core/automations/repo.test.ts
+++ b/src/main/core/automations/repo.test.ts
@@ -6,6 +6,7 @@ import {
   enqueueAutomationRun,
   listRecentRuns,
   listRuns,
+  taskWasCreatedByAutomationRun,
   updateAutomation,
 } from './repo';
 import { detachProject, setAutomationEnabled } from './service';
@@ -315,6 +316,12 @@ describe('automations repo', () => {
     );
 
     expect(dbMock.all).toHaveBeenCalledTimes(1);
+  });
+
+  it('identifies automation tasks after createdTaskId is cleared', async () => {
+    dbMock.selectLimit.mockReturnValueOnce(dbMock.rowsResult([{ id: 'run-1' }]));
+
+    await expect(taskWasCreatedByAutomationRun('task-2')).resolves.toBe(true);
   });
 
   it('hydrates run agent provider from the created task conversation', async () => {

--- a/src/main/core/automations/repo.test.ts
+++ b/src/main/core/automations/repo.test.ts
@@ -318,10 +318,16 @@ describe('automations repo', () => {
     expect(dbMock.all).toHaveBeenCalledTimes(1);
   });
 
-  it('identifies automation tasks after createdTaskId is cleared', async () => {
+  it('identifies in-flight automation tasks after createdTaskId is cleared', async () => {
     dbMock.selectLimit.mockReturnValueOnce(dbMock.rowsResult([{ id: 'run-1' }]));
 
     await expect(taskWasCreatedByAutomationRun('task-2')).resolves.toBe(true);
+  });
+
+  it('does not identify completed automation tasks as in-flight automation runs', async () => {
+    dbMock.selectLimit.mockReturnValueOnce(dbMock.rowsResult([]));
+
+    await expect(taskWasCreatedByAutomationRun('task-1')).resolves.toBe(false);
   });
 
   it('hydrates run agent provider from the created task conversation', async () => {

--- a/src/main/core/automations/repo.ts
+++ b/src/main/core/automations/repo.ts
@@ -674,10 +674,7 @@ export async function taskWasCreatedByAutomationRun(taskIdValue: string): Promis
     .select({ id: automationRuns.id })
     .from(automationRuns)
     .where(
-      or(
-        eq(automationRuns.createdTaskId, taskIdValue),
-        and(eq(automationRuns.taskId, taskIdValue), isNotNull(automationRuns.createdTaskId))
-      )
+      or(eq(automationRuns.createdTaskId, taskIdValue), eq(automationRuns.taskId, taskIdValue))
     )
     .limit(1);
   return rows.length > 0;

--- a/src/main/core/automations/repo.ts
+++ b/src/main/core/automations/repo.ts
@@ -673,7 +673,12 @@ export async function taskWasCreatedByAutomationRun(taskIdValue: string): Promis
   const rows = await db
     .select({ id: automationRuns.id })
     .from(automationRuns)
-    .where(eq(automationRuns.createdTaskId, taskIdValue))
+    .where(
+      or(
+        eq(automationRuns.createdTaskId, taskIdValue),
+        and(eq(automationRuns.taskId, taskIdValue), isNotNull(automationRuns.createdTaskId))
+      )
+    )
     .limit(1);
   return rows.length > 0;
 }

--- a/src/main/core/automations/repo.ts
+++ b/src/main/core/automations/repo.ts
@@ -669,6 +669,15 @@ export async function taskExists(taskId: string): Promise<boolean> {
   return rows.length > 0;
 }
 
+export async function taskWasCreatedByAutomationRun(taskIdValue: string): Promise<boolean> {
+  const rows = await db
+    .select({ id: automationRuns.id })
+    .from(automationRuns)
+    .where(eq(automationRuns.createdTaskId, taskIdValue))
+    .limit(1);
+  return rows.length > 0;
+}
+
 export async function recoverQueuedRuns(): Promise<number> {
   const rows = await db
     .update(automationRuns)

--- a/src/main/core/automations/repo.ts
+++ b/src/main/core/automations/repo.ts
@@ -674,7 +674,10 @@ export async function taskWasCreatedByAutomationRun(taskIdValue: string): Promis
     .select({ id: automationRuns.id })
     .from(automationRuns)
     .where(
-      or(eq(automationRuns.createdTaskId, taskIdValue), eq(automationRuns.taskId, taskIdValue))
+      and(
+        inArray(automationRuns.status, ['queued', 'running']),
+        or(eq(automationRuns.createdTaskId, taskIdValue), eq(automationRuns.taskId, taskIdValue))
+      )
     )
     .limit(1);
   return rows.length > 0;

--- a/src/main/core/automations/runtime.test.ts
+++ b/src/main/core/automations/runtime.test.ts
@@ -101,7 +101,7 @@ describe('runQueuedAutomation', () => {
     expect(automationEvents._emit).toHaveBeenCalledWith('automation:run:skipped', skippedRun);
   });
 
-  it('runs multiple actions and keeps the first created task id', async () => {
+  it('runs multiple actions and keeps the first created task id while linking the latest task', async () => {
     const multiActionAutomation = {
       ...automation,
       actions: [
@@ -120,7 +120,7 @@ describe('runQueuedAutomation', () => {
     expect(updateRun).toHaveBeenLastCalledWith(run.id, {
       status: 'success',
       finishedAt: expect.any(Number),
-      taskId: 'task-1',
+      taskId: 'task-2',
       createdTaskId: 'task-1',
     });
   });

--- a/src/main/core/automations/runtime.ts
+++ b/src/main/core/automations/runtime.ts
@@ -12,6 +12,7 @@ export async function runQueuedAutomation(
 ): Promise<Result<AutomationRun, string>> {
   let run = initialRun;
   let firstTaskId: string | null = null;
+  let latestTaskId: string | null = null;
   const ctx = { automation, run };
 
   if (automation.projectId == null) {
@@ -41,7 +42,8 @@ export async function runQueuedAutomation(
       })
     );
     if (!result.success) {
-      const failedTaskId = firstTaskId ?? result.error.taskId ?? null;
+      const failedTaskId = result.error.taskId ?? latestTaskId ?? firstTaskId ?? null;
+      const createdTaskId = firstTaskId ?? result.error.taskId ?? null;
       const message = result.error.message;
       log.error('Automation action failed', {
         automationId: automation.id,
@@ -54,7 +56,7 @@ export async function runQueuedAutomation(
         error: message,
         finishedAt,
         taskId: failedTaskId,
-        createdTaskId: failedTaskId,
+        createdTaskId,
       });
       return err(message);
     }
@@ -62,12 +64,13 @@ export async function runQueuedAutomation(
       firstTaskId = result.data.taskId;
       run = { ...run, taskId: firstTaskId, createdTaskId: firstTaskId };
     }
+    latestTaskId = result.data.taskId ?? latestTaskId;
   }
 
   const finishedAt = Date.now();
   run = await markRunSucceeded(run.id, {
     finishedAt,
-    taskId: firstTaskId,
+    taskId: latestTaskId,
     createdTaskId: firstTaskId,
   });
   await updateAutomationSchedule(automation.id, { lastRunAt: run.startedAt ?? Date.now() });

--- a/src/main/core/tasks/operations/convertAutomationTask.test.ts
+++ b/src/main/core/tasks/operations/convertAutomationTask.test.ts
@@ -51,13 +51,16 @@ describe('convertAutomationTask', () => {
   });
 
   it('detaches automation metadata in the same transaction as the active-run guard', async () => {
+    const set = vi.fn(() => ({ where: vi.fn(() => ({ run: vi.fn() })) }));
     dbMock.update.mockReturnValue({
-      set: vi.fn(() => ({ where: vi.fn(() => ({ run: vi.fn() })) })),
+      set,
     });
 
     await convertAutomationTask('task-1');
 
     expect(dbMock.transaction).toHaveBeenCalledOnce();
-    expect(dbMock.update).toHaveBeenCalledTimes(2);
+    expect(dbMock.update).toHaveBeenCalledTimes(3);
+    expect(set).toHaveBeenCalledWith({ createdTaskId: null });
+    expect(set).toHaveBeenCalledWith({ taskId: null });
   });
 });

--- a/src/main/core/tasks/operations/convertAutomationTask.ts
+++ b/src/main/core/tasks/operations/convertAutomationTask.ts
@@ -24,7 +24,12 @@ export async function convertAutomationTask(taskId: string): Promise<Task | null
 
     tx.update(automationRuns)
       .set({ createdTaskId: null })
-      .where(or(eq(automationRuns.createdTaskId, taskId), eq(automationRuns.taskId, taskId)))
+      .where(eq(automationRuns.createdTaskId, taskId))
+      .run();
+
+    tx.update(automationRuns)
+      .set({ taskId: null })
+      .where(eq(automationRuns.taskId, taskId))
       .run();
 
     tx.update(tasks)

--- a/src/main/core/tasks/operations/convertAutomationTask.ts
+++ b/src/main/core/tasks/operations/convertAutomationTask.ts
@@ -27,10 +27,7 @@ export async function convertAutomationTask(taskId: string): Promise<Task | null
       .where(eq(automationRuns.createdTaskId, taskId))
       .run();
 
-    tx.update(automationRuns)
-      .set({ taskId: null })
-      .where(eq(automationRuns.taskId, taskId))
-      .run();
+    tx.update(automationRuns).set({ taskId: null }).where(eq(automationRuns.taskId, taskId)).run();
 
     tx.update(tasks)
       .set({ updatedAt: sql`CURRENT_TIMESTAMP` })


### PR DESCRIPTION
### Description
- stop automations pty sessions reliably after agent comlpetion
- link automations run to latest task while preserving first task created

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
