### PR TITLE
fix(app): open file manager via Electron shell

### DIFF
--- a/src/main/core/app/service.test.ts
+++ b/src/main/core/app/service.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  exec: vi.fn(),
+  getVersion: vi.fn(() => '1.1.27'),
+  openExternal: vi.fn(),
+  openPath: vi.fn(),
+}));
+
+vi.mock('node:child_process', () => ({
+  exec: mocks.exec,
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    getAppPath: vi.fn(() => ''),
+    getVersion: mocks.getVersion,
+    quit: vi.fn(),
+  },
+  clipboard: {
+    writeText: vi.fn(),
+  },
+  dialog: {
+    showOpenDialog: vi.fn(),
+  },
+  shell: {
+    openExternal: mocks.openExternal,
+    openPath: mocks.openPath,
+  },
+}));
+
+vi.mock('@main/app/window', () => ({
+  getMainWindow: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {},
+}));
+
+vi.mock('@main/db/schema', () => ({
+  sshConnections: {},
+}));
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    on: vi.fn(() => vi.fn()),
+  },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@main/utils/childProcessEnv', () => ({
+  buildExternalToolEnv: () => ({}),
+}));
+
+const { appService } = await import('./service');
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
+
+function setPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', {
+    ...originalPlatform,
+    value: platform,
+  });
+}
+
+describe('AppService.openIn', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    setPlatform('win32');
+    mocks.openPath.mockResolvedValue('');
+    mocks.exec.mockImplementation(
+      (_command: string, _options: object, callback: (error: Error | null) => void) => {
+        callback(null);
+      }
+    );
+  });
+
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
+  it('opens the platform file manager with Electron shell.openPath instead of a shell command', async () => {
+    const target = 'C:/Users/Qwenzy/Desktop/ees_ams';
+
+    await appService.openIn({ app: 'finder', path: target });
+
+    expect(mocks.openPath).toHaveBeenCalledWith(target);
+    expect(mocks.exec).not.toHaveBeenCalled();
+  });
+});

--- a/src/main/core/app/service.test.ts
+++ b/src/main/core/app/service.test.ts
@@ -92,4 +92,15 @@ describe('AppService.openIn', () => {
     expect(mocks.openPath).toHaveBeenCalledWith(target);
     expect(mocks.exec).not.toHaveBeenCalled();
   });
+
+  it('throws when Electron shell.openPath returns an error message', async () => {
+    const target = 'C:/Users/Qwenzy/Desktop/missing';
+    mocks.openPath.mockResolvedValueOnce('Path does not exist');
+
+    await expect(appService.openIn({ app: 'finder', path: target })).rejects.toThrow(
+      'Path does not exist'
+    );
+    expect(mocks.openPath).toHaveBeenCalledWith(target);
+    expect(mocks.exec).not.toHaveBeenCalled();
+  });
 });

--- a/src/main/core/app/service.ts
+++ b/src/main/core/app/service.ts
@@ -263,7 +263,7 @@ class AppService implements IInitializable, IDisposable {
       return;
     }
 
-    await this.openInLocal({ label, target, platformConfig });
+    await this.openInLocal({ appId, label, target, platformConfig });
   }
 
   private async openInRemote(args: {
@@ -425,11 +425,18 @@ class AppService implements IInitializable, IDisposable {
   }
 
   private async openInLocal(args: {
+    appId: OpenInAppId;
     label: string;
     target: string;
     platformConfig: PlatformConfig | undefined;
   }): Promise<void> {
-    const { label, target, platformConfig } = args;
+    const { appId, label, target, platformConfig } = args;
+
+    if (appId === 'finder') {
+      const errorMessage = await shell.openPath(target);
+      if (errorMessage) throw new Error(errorMessage);
+      return;
+    }
 
     if (platformConfig?.openUrls) {
       for (const urlTemplate of platformConfig.openUrls) {

--- a/src/shared/openInApps.ts
+++ b/src/shared/openInApps.ts
@@ -64,15 +64,13 @@ const _OPEN_IN_APPS = {
     label: 'Finder',
     iconPath: ICON_PATHS.finder,
     alwaysAvailable: true,
+    // AppService opens the platform file manager via Electron shell.openPath.
     platforms: {
-      darwin: { openCommands: ['open {{path}}'] },
       win32: {
-        openCommands: ['explorer "{{path_raw}}"'],
         label: 'Explorer',
         iconPath: ICON_PATHS.explorer,
       },
       linux: {
-        openCommands: ['xdg-open {{path}}'],
         label: 'Files',
         iconPath: ICON_PATHS.files,
       },


### PR DESCRIPTION
### Description

Fixes the Windows Explorer project launcher by opening the platform file manager through Electron `shell.openPath` instead of constructing and executing an `explorer ...` shell command.

The previous Windows command path used forward slashes, which Explorer can misinterpret as command switches. That could open the wrong folder, such as Documents, or fail with an error toast. The file-manager launcher now uses Electron's native path opener while leaving editor and terminal launch templates unchanged.

### Related issues

Fixes #2338.

### Testing

- `pnpm exec vitest run --project node src/main/core/app/service.test.ts`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm exec oxfmt --check src/main/core/app/service.ts src/main/core/app/service.test.ts`
- `git diff --check`

Note: full `pnpm run format:check` still reports pre-existing formatting mismatches across many files outside this PR's scope.

### Screenshot/Recording (if applicable)

Not applicable; this is a main-process launcher fix covered by a regression test.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>