### PR TITLE
feat(changes-panel): show git indicators on parent folders in tree view

### DIFF
--- a/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.test.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.test.ts
@@ -6,6 +6,13 @@ function change(path: string, status: GitChange['status'] = 'modified'): GitChan
   return { path, status, additions: 1, deletions: 0 };
 }
 
+const ADJACENT_STATUS_PAIRS: [GitChange['status'], GitChange['status']][] = [
+  ['conflicted', 'deleted'],
+  ['deleted', 'modified'],
+  ['modified', 'renamed'],
+  ['renamed', 'added'],
+];
+
 describe('buildDirectoryStatusByPath', () => {
   it('marks every ancestor directory of a changed file', () => {
     const statuses = buildDirectoryStatusByPath([
@@ -18,12 +25,19 @@ describe('buildDirectoryStatusByPath', () => {
     expect(statuses.has('src/components/ui/button.tsx')).toBe(false);
   });
 
-  it('keeps the highest-priority status when descendants differ', () => {
-    const statuses = buildDirectoryStatusByPath([
-      change('src/added.ts', 'added'),
-      change('src/lib/removed.ts', 'deleted'),
-    ]);
+  it.each(ADJACENT_STATUS_PAIRS)(
+    'prefers %s over %s on a shared parent directory',
+    (higher, lower) => {
+      const statuses = buildDirectoryStatusByPath([
+        change(`src/${lower}.ts`, lower),
+        change(`src/${higher}.ts`, higher),
+      ]);
+      expect(statuses.get('src')).toBe(higher);
+    }
+  );
 
+  it('does not promote status to sibling-only directories', () => {
+    const statuses = buildDirectoryStatusByPath([change('src/lib/removed.ts', 'deleted')]);
     expect(statuses.get('src')).toBe('deleted');
     expect(statuses.get('src/lib')).toBe('deleted');
   });

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.test.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import type { GitChange } from '@shared/git';
+import { buildChangesTree, buildDirectoryStatusByPath } from './changes-tree-utils';
+
+function change(path: string, status: GitChange['status'] = 'modified'): GitChange {
+  return { path, status, additions: 1, deletions: 0 };
+}
+
+describe('buildDirectoryStatusByPath', () => {
+  it('marks every ancestor directory of a changed file', () => {
+    const statuses = buildDirectoryStatusByPath([
+      change('src/components/ui/button.tsx', 'modified'),
+    ]);
+
+    expect(statuses.get('src')).toBe('modified');
+    expect(statuses.get('src/components')).toBe('modified');
+    expect(statuses.get('src/components/ui')).toBe('modified');
+    expect(statuses.has('src/components/ui/button.tsx')).toBe(false);
+  });
+
+  it('keeps the highest-priority status when descendants differ', () => {
+    const statuses = buildDirectoryStatusByPath([
+      change('src/added.ts', 'added'),
+      change('src/lib/removed.ts', 'deleted'),
+    ]);
+
+    expect(statuses.get('src')).toBe('deleted');
+    expect(statuses.get('src/lib')).toBe('deleted');
+  });
+
+  it('ignores root-level files with no parent directories', () => {
+    const statuses = buildDirectoryStatusByPath([change('README.md', 'modified')]);
+    expect(statuses.size).toBe(0);
+  });
+});
+
+describe('buildChangesTree', () => {
+  it('includes directoryStatusByPath on the built tree', () => {
+    const tree = buildChangesTree([change('pkg/a.ts'), change('pkg/nested/b.ts', 'added')]);
+
+    expect(tree.directoryStatusByPath.get('pkg')).toBe('modified');
+    expect(tree.directoryStatusByPath.get('pkg/nested')).toBe('added');
+    expect(tree.directoryPaths.has('pkg')).toBe(true);
+    expect(tree.directoryPaths.has('pkg/nested')).toBe(true);
+  });
+});

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.ts
@@ -1,12 +1,21 @@
 import { makeNode, sortFileNodes } from '@renderer/features/tasks/editor/stores/files-store-utils';
 import { type FileNode } from '@shared/fs';
-import { type GitChange } from '@shared/git';
+import { type GitChange, type GitChangeStatus } from '@shared/git';
 
 export interface ChangesTree {
   rootNodes: FileNode[];
   changeByPath: Map<string, GitChange>;
   directoryPaths: Set<string>;
+  directoryStatusByPath: Map<string, GitChangeStatus>;
 }
+
+const STATUS_PRIORITY: Record<GitChangeStatus, number> = {
+  conflicted: 5,
+  deleted: 4,
+  modified: 3,
+  renamed: 2,
+  added: 1,
+};
 
 export function buildChangesTree(changes: GitChange[]): ChangesTree {
   const nodesByPath = new Map<string, FileNode>();
@@ -48,7 +57,28 @@ export function buildChangesTree(changes: GitChange[]): ChangesTree {
     rootNodes: sortRecursively(rootNodes),
     changeByPath,
     directoryPaths,
+    directoryStatusByPath: buildDirectoryStatusByPath(changes),
   };
+}
+
+export function buildDirectoryStatusByPath(changes: GitChange[]): Map<string, GitChangeStatus> {
+  const directoryStatusByPath = new Map<string, GitChangeStatus>();
+
+  for (const change of changes) {
+    const parts = change.path.split('/').filter(Boolean);
+    if (parts.length < 2) continue;
+
+    let prefix = '';
+    for (let i = 0; i < parts.length - 1; i++) {
+      prefix = prefix ? `${prefix}/${parts[i]!}` : parts[i]!;
+      const existing = directoryStatusByPath.get(prefix);
+      if (!existing || STATUS_PRIORITY[change.status] > STATUS_PRIORITY[existing]) {
+        directoryStatusByPath.set(prefix, change.status);
+      }
+    }
+  }
+
+  return directoryStatusByPath;
 }
 
 function sortRecursively(nodes: FileNode[]): FileNode[] {

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.ts
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.ts
@@ -17,10 +17,22 @@ const STATUS_PRIORITY: Record<GitChangeStatus, number> = {
   added: 1,
 };
 
+function upsertDirectoryStatus(
+  directoryStatusByPath: Map<string, GitChangeStatus>,
+  dirPath: string,
+  status: GitChangeStatus
+): void {
+  const existing = directoryStatusByPath.get(dirPath);
+  if (!existing || STATUS_PRIORITY[status] > STATUS_PRIORITY[existing]) {
+    directoryStatusByPath.set(dirPath, status);
+  }
+}
+
 export function buildChangesTree(changes: GitChange[]): ChangesTree {
   const nodesByPath = new Map<string, FileNode>();
   const changeByPath = new Map<string, GitChange>();
   const directoryPaths = new Set<string>();
+  const directoryStatusByPath = new Map<string, GitChangeStatus>();
   const rootNodes: FileNode[] = [];
 
   for (const change of changes) {
@@ -37,6 +49,10 @@ export function buildChangesTree(changes: GitChange[]): ChangesTree {
       const isLeaf = i === parts.length - 1;
       const type = isLeaf ? 'file' : 'directory';
       const key = `${type}:${prefix}`;
+
+      if (!isLeaf) {
+        upsertDirectoryStatus(directoryStatusByPath, prefix, change.status);
+      }
 
       let node = nodesByPath.get(key);
       if (!node) {
@@ -57,28 +73,12 @@ export function buildChangesTree(changes: GitChange[]): ChangesTree {
     rootNodes: sortRecursively(rootNodes),
     changeByPath,
     directoryPaths,
-    directoryStatusByPath: buildDirectoryStatusByPath(changes),
+    directoryStatusByPath,
   };
 }
 
 export function buildDirectoryStatusByPath(changes: GitChange[]): Map<string, GitChangeStatus> {
-  const directoryStatusByPath = new Map<string, GitChangeStatus>();
-
-  for (const change of changes) {
-    const parts = change.path.split('/').filter(Boolean);
-    if (parts.length < 2) continue;
-
-    let prefix = '';
-    for (let i = 0; i < parts.length - 1; i++) {
-      prefix = prefix ? `${prefix}/${parts[i]!}` : parts[i]!;
-      const existing = directoryStatusByPath.get(prefix);
-      if (!existing || STATUS_PRIORITY[change.status] > STATUS_PRIORITY[existing]) {
-        directoryStatusByPath.set(prefix, change.status);
-      }
-    }
-  }
-
-  return directoryStatusByPath;
+  return buildChangesTree(changes).directoryStatusByPath;
 }
 
 function sortRecursively(nodes: FileNode[]): FileNode[] {

--- a/src/renderer/features/tasks/diff-view/changes-panel/components/virtualized-changes-tree.tsx
+++ b/src/renderer/features/tasks/diff-view/changes-panel/components/virtualized-changes-tree.tsx
@@ -8,8 +8,8 @@ import {
 } from '@renderer/features/tasks/editor/stores/files-store-utils';
 import { FileIcon } from '@renderer/lib/editor/file-icon';
 import { cn } from '@renderer/utils/utils';
-import { type GitChange } from '@shared/git';
-import { ChangeStatusAffordance } from './changes-list-item';
+import { type GitChange, type GitChangeStatus } from '@shared/git';
+import { ChangeStatusAffordance, GitChangeStatusIcon } from './changes-list-item';
 import { buildChangesTree } from './changes-tree-utils';
 
 export interface VirtualizedChangesTreeProps {
@@ -94,6 +94,7 @@ export function VirtualizedChangesTree({
               <DirectoryRow
                 key={`${node.type}:${node.path}`}
                 row={row}
+                status={tree.directoryStatusByPath.get(node.path)}
                 isExpanded={expanded}
                 onToggle={() => toggleChain(row.chain, expanded)}
                 style={style}
@@ -124,11 +125,13 @@ export function VirtualizedChangesTree({
 
 function DirectoryRow({
   row,
+  status,
   isExpanded,
   onToggle,
   style,
 }: {
   row: TreeRow;
+  status?: GitChangeStatus;
   isExpanded: boolean;
   onToggle: () => void;
   style: React.CSSProperties;
@@ -154,6 +157,11 @@ function DirectoryRow({
         {isExpanded ? <FolderOpen className="h-3.5 w-3.5" /> : <Folder className="h-3.5 w-3.5" />}
       </span>
       <span className="min-w-0 flex-1 truncate text-left text-sm">{displayName}</span>
+      {status !== undefined && (
+        <span className="flex shrink-0 items-center pr-0.5">
+          <GitChangeStatusIcon status={status} className="size-4" />
+        </span>
+      )}
     </button>
   );
 }


### PR DESCRIPTION
## Summary

- Propagate each changed file's git status to every ancestor directory in the Git Changes tree
- Show the existing `GitChangeStatusIcon` on folder rows in tree view (including when collapsed)
- When a folder has mixed descendant statuses, use the highest-priority status (conflicted → deleted → modified → renamed → added)

Closes #2337



<img width="1116" height="791" alt="Screenshot 2026-06-02 at 1 10 48 AM" src="https://github.com/user-attachments/assets/a3c997cf-aafa-49af-a334-bcd5ed6a736d" />

## Test plan

- [x] `pnpm exec vitest run src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.test.ts`
- [x] Manual: open a task with nested unstaged changes, switch Changes panel to **tree view**
- [x] Confirm parent folders (`src`, `src/components`, etc.) show status icons
- [x] Collapse a parent folder — icon remains visible on the folder row
- [x] Confirm flat list view and file-level indicators are unchanged
