### PR TITLE
fix: branch search should prioritize exact matches

### DIFF
--- a/src/renderer/lib/components/branch-selector-utils.test.ts
+++ b/src/renderer/lib/components/branch-selector-utils.test.ts
@@ -66,6 +66,18 @@ describe('prioritizeExactBranchMatches', () => {
     ]);
   });
 
+  it('moves exact remote-label matches before partial matches', () => {
+    const matchingBranches: Branch[] = [
+      { type: 'remote', branch: 'feature/origin-main', remote: origin },
+      { type: 'remote', branch: 'main', remote: origin },
+    ];
+
+    expect(prioritizeExactBranchMatches(matchingBranches, 'origin/main')).toEqual([
+      { type: 'remote', branch: 'main', remote: origin },
+      { type: 'remote', branch: 'feature/origin-main', remote: origin },
+    ]);
+  });
+
   it('preserves branch order when there is no search query', () => {
     expect(prioritizeExactBranchMatches(branches, '  ')).toEqual(branches);
   });

--- a/src/renderer/lib/components/branch-selector-utils.test.ts
+++ b/src/renderer/lib/components/branch-selector-utils.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { Branch } from '@shared/git';
-import { filterBranchesForPicker } from './branch-selector-utils';
+import { filterBranchesForPicker, prioritizeExactBranchMatches } from './branch-selector-utils';
 
 const origin = { name: 'origin', url: 'git@github.com:example/repo.git' };
 const upstream = { name: 'upstream', url: 'git@github.com:example/upstream.git' };
@@ -36,5 +36,37 @@ describe('filterBranchesForPicker', () => {
       { type: 'remote', branch: 'main', remote: upstream },
       { type: 'remote', branch: 'feature/upstream', remote: upstream },
     ]);
+  });
+});
+
+describe('prioritizeExactBranchMatches', () => {
+  it('moves exact branch-name matches before partial matches', () => {
+    const matchingBranches: Branch[] = [
+      { type: 'local', branch: 'feature/main' },
+      { type: 'local', branch: 'main' },
+      { type: 'local', branch: 'maintenance/main' },
+    ];
+
+    expect(prioritizeExactBranchMatches(matchingBranches, 'main')).toEqual([
+      { type: 'local', branch: 'main' },
+      { type: 'local', branch: 'feature/main' },
+      { type: 'local', branch: 'maintenance/main' },
+    ]);
+  });
+
+  it('treats remote branch names as exact matches even when labels include the remote', () => {
+    const matchingBranches: Branch[] = [
+      { type: 'remote', branch: 'feature/main', remote: origin },
+      { type: 'remote', branch: 'main', remote: origin },
+    ];
+
+    expect(prioritizeExactBranchMatches(matchingBranches, 'main')).toEqual([
+      { type: 'remote', branch: 'main', remote: origin },
+      { type: 'remote', branch: 'feature/main', remote: origin },
+    ]);
+  });
+
+  it('preserves branch order when there is no search query', () => {
+    expect(prioritizeExactBranchMatches(branches, '  ')).toEqual(branches);
   });
 });

--- a/src/renderer/lib/components/branch-selector-utils.ts
+++ b/src/renderer/lib/components/branch-selector-utils.ts
@@ -1,5 +1,15 @@
 import type { Branch } from '@shared/git';
 
+export type BranchLabelRemoteMode = 'full' | 'short';
+
+export function getBranchLabel(
+  branch: Branch,
+  options: { remote?: BranchLabelRemoteMode } = {}
+): string {
+  if (branch.type !== 'remote') return branch.branch;
+  return options.remote === 'short' ? branch.branch : `${branch.remote.name}/${branch.branch}`;
+}
+
 export function filterBranchesForPicker(
   branches: ReadonlyArray<Branch>,
   tab: 'local' | 'remote',
@@ -10,4 +20,36 @@ export function filterBranchesForPicker(
       branch.type === tab &&
       (branch.type !== 'remote' || !remoteName || branch.remote.name === remoteName)
   );
+}
+
+export function prioritizeExactBranchMatches(
+  branches: ReadonlyArray<Branch>,
+  query: string,
+  branchLabelRemote: BranchLabelRemoteMode = 'full'
+): Branch[] {
+  const normalizedQuery = query.trim().toLocaleLowerCase();
+  if (!normalizedQuery) return [...branches];
+
+  return branches
+    .map((branch, index) => ({
+      branch,
+      index,
+      rank: getExactMatchRank(branch, normalizedQuery, branchLabelRemote),
+    }))
+    .sort((a, b) => a.rank - b.rank || a.index - b.index)
+    .map(({ branch }) => branch);
+}
+
+function getExactMatchRank(
+  branch: Branch,
+  normalizedQuery: string,
+  branchLabelRemote: BranchLabelRemoteMode
+): number {
+  if (branch.branch.toLocaleLowerCase() === normalizedQuery) return 0;
+  if (
+    getBranchLabel(branch, { remote: branchLabelRemote }).toLocaleLowerCase() === normalizedQuery
+  ) {
+    return 1;
+  }
+  return 2;
 }

--- a/src/renderer/lib/components/branch-selector.tsx
+++ b/src/renderer/lib/components/branch-selector.tsx
@@ -105,13 +105,16 @@ export function BranchSelector({
     <Combobox
       open={open}
       inputValue={inputValue}
-      onInputValueChange={setInputValue}
+      onInputValueChange={(nextInputValue: string, { reason }: { reason: string }) => {
+        if (reason !== 'item-press') setInputValue(nextInputValue);
+      }}
       onOpenChange={(nextOpen) => {
         if (!nextOpen && keepOpenForRemoteSelectRef.current) {
           setOpen(true);
           return;
         }
         setOpen(nextOpen);
+        if (!nextOpen) setInputValue('');
         setDraftRemoteName(nextOpen ? selectedRemoteName : undefined);
       }}
       items={options}

--- a/src/renderer/lib/components/branch-selector.tsx
+++ b/src/renderer/lib/components/branch-selector.tsx
@@ -17,19 +17,16 @@ import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { cn } from '@renderer/utils/utils';
 import { type Branch, type Remote } from '@shared/git';
 import { Tooltip, TooltipContent, TooltipTrigger } from '../ui/tooltip';
-import { filterBranchesForPicker } from './branch-selector-utils';
+import {
+  filterBranchesForPicker,
+  getBranchLabel,
+  prioritizeExactBranchMatches,
+  type BranchLabelRemoteMode,
+} from './branch-selector-utils';
 import { RemoteSelectContent } from './remote-select-content';
 
 type BranchSelectorTab = 'local' | 'remote';
-export type BranchLabelRemoteMode = 'full' | 'short';
-
-export function getBranchLabel(
-  branch: Branch,
-  options: { remote?: BranchLabelRemoteMode } = {}
-): string {
-  if (branch.type !== 'remote') return branch.branch;
-  return options.remote === 'short' ? branch.branch : `${branch.remote.name}/${branch.branch}`;
-}
+export { getBranchLabel, type BranchLabelRemoteMode } from './branch-selector-utils';
 
 interface BranchSelectorProps {
   branches: Branch[];
@@ -68,6 +65,7 @@ export function BranchSelector({
   const inputRef = React.useRef<HTMLInputElement>(null);
   const keepOpenForRemoteSelectRef = React.useRef(false);
   const [open, setOpen] = useState(false);
+  const [inputValue, setInputValue] = useState('');
   const [remoteSelectOpen, setRemoteSelectOpen] = useState(false);
   const [draftRemoteName, setDraftRemoteName] = useState<string | undefined>(undefined);
   const showRemoteFooter = selectedRemoteName !== undefined;
@@ -84,8 +82,13 @@ export function BranchSelector({
   );
 
   const filteredBranches = useMemo(
-    () => filterBranchesForPicker(branches, tab, showRemoteFooter ? activeRemoteName : undefined),
-    [activeRemoteName, branches, showRemoteFooter, tab]
+    () =>
+      prioritizeExactBranchMatches(
+        filterBranchesForPicker(branches, tab, showRemoteFooter ? activeRemoteName : undefined),
+        inputValue,
+        branchLabelRemote
+      ),
+    [activeRemoteName, branchLabelRemote, branches, inputValue, showRemoteFooter, tab]
   );
 
   const options = useMemo(
@@ -101,6 +104,8 @@ export function BranchSelector({
   return (
     <Combobox
       open={open}
+      inputValue={inputValue}
+      onInputValueChange={setInputValue}
       onOpenChange={(nextOpen) => {
         if (!nextOpen && keepOpenForRemoteSelectRef.current) {
           setOpen(true);


### PR DESCRIPTION
### Description
- prioritize exact branch name matches in branch search

### Screenshot/Recording (if applicable)
https://streamable.com/4yjoye

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [Xt] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
