### PR TITLE
fix(pty): codex returned back to running after /new

### DIFF
--- a/src/main/core/pty/controller.ts
+++ b/src/main/core/pty/controller.ts
@@ -7,6 +7,7 @@ import { parsePtySessionId } from '@shared/ptySessionId';
 import { err, ok } from '@shared/result';
 import { taskManager } from '../tasks/task-manager';
 import { workspaceRegistry } from '../workspaces/workspace-registry';
+import { PtyInputSubmissionTracker } from './input-submission-tracker';
 import {
   cleanupExpiredDroppedBlobs,
   persistClipboardImagePath,
@@ -14,17 +15,19 @@ import {
 } from './persist-dropped-blob';
 import { ptySessionRegistry } from './pty-session-registry';
 
+const inputSubmissionTracker = new PtyInputSubmissionTracker();
+
 void cleanupExpiredDroppedBlobs().catch((error) => {
   log.warn('pty:cleanupExpiredDroppedBlobs failed', { error });
 });
 
 export const ptyController = createRPCController({
   /** Send raw input data to a PTY session. */
-  sendInput: (sessionId: string, data: string) => {
+  sendInput: (sessionId: string, data: string, options?: { track?: boolean }) => {
     const pty = ptySessionRegistry.get(sessionId);
     if (!pty) return err({ type: 'not_found' as const });
     pty.write(data);
-    if (data.includes('\r')) {
+    if ((options?.track ?? true) && inputSubmissionTracker.feed(sessionId, data)) {
       const meta = ptySessionRegistry.getMetadata(sessionId);
       if (meta?.providerId && !meta.isRemote) {
         const parsed = parsePtySessionId(sessionId);
@@ -76,6 +79,7 @@ export const ptyController = createRPCController({
         log.warn('ptyController.kill: error killing PTY', { sessionId, error: String(e) });
       }
     }
+    inputSubmissionTracker.clear(sessionId);
     ptySessionRegistry.unregister(sessionId);
     return ok();
   },
@@ -95,6 +99,7 @@ export const ptyController = createRPCController({
     const parsed = parsePtySessionId(sessionId);
     if (!parsed) return err({ type: 'invalid_session' as const });
     const { scopeId, leafId } = parsed;
+    inputSubmissionTracker.clear(sessionId);
 
     // Agents and terminals are scoped by task id, so the task lookup resolves
     // the owning provider. Conversation PTYs carry a providerId in their
@@ -128,6 +133,7 @@ export const ptyController = createRPCController({
         log.warn('ptyController.stopSession: error killing PTY', { sessionId, error: String(e) });
       }
     }
+    inputSubmissionTracker.clear(sessionId);
     ptySessionRegistry.unregister(sessionId);
     return ok();
   },

--- a/src/main/core/pty/input-submission-tracker.test.ts
+++ b/src/main/core/pty/input-submission-tracker.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { isRealAgentPrompt, PtyInputSubmissionTracker } from './input-submission-tracker';
+
+describe('PtyInputSubmissionTracker', () => {
+  it('detects natural-language prompts submitted across chunks', () => {
+    const tracker = new PtyInputSubmissionTracker();
+
+    expect(tracker.feed('session-1', 'fix the')).toBe(false);
+    expect(tracker.feed('session-1', ' bug\r')).toBe(true);
+  });
+
+  it('does not treat slash commands as agent prompts', () => {
+    const tracker = new PtyInputSubmissionTracker();
+
+    expect(tracker.feed('session-1', '/new\r')).toBe(false);
+  });
+
+  it('continues tracking after a skipped slash command', () => {
+    const tracker = new PtyInputSubmissionTracker();
+
+    expect(tracker.feed('session-1', '/model\r')).toBe(false);
+    expect(tracker.feed('session-1', 'fix auth flow\r')).toBe(true);
+  });
+
+  it('treats line feed as multiline draft input, not submission', () => {
+    const tracker = new PtyInputSubmissionTracker();
+
+    expect(tracker.feed('session-1', 'fix the bug\n')).toBe(false);
+    expect(tracker.feed('session-1', 'and add tests\r')).toBe(true);
+  });
+
+  it('handles backspace and line clear before submit', () => {
+    const tracker = new PtyInputSubmissionTracker();
+
+    expect(tracker.feed('session-1', '/new\x15fix bug\r')).toBe(true);
+    expect(tracker.feed('session-2', '/new\x7f\x7f\x7f\x7ffix bug\r')).toBe(true);
+  });
+});
+
+describe('isRealAgentPrompt', () => {
+  it('filters non-task terminal submissions', () => {
+    expect(isRealAgentPrompt('/new')).toBe(false);
+    expect(isRealAgentPrompt('y')).toBe(false);
+    expect(isRealAgentPrompt('123')).toBe(false);
+    expect(isRealAgentPrompt('fix')).toBe(true);
+  });
+});

--- a/src/main/core/pty/input-submission-tracker.ts
+++ b/src/main/core/pty/input-submission-tracker.ts
@@ -1,22 +1,7 @@
-const SKIP_PATTERNS = [
-  /^\//,
-  /^y(es)?$/i,
-  /^n(o)?$/i,
-  /^ok$/i,
-  /^q(uit)?$/i,
-  /^exit$/i,
-  /^help$/i,
-  /^\d+$/,
-];
-
-const HAS_ALPHA = /[A-Za-z]/;
-const MIN_MESSAGE_LENGTH = 2;
+import { isRealTaskLikeInput } from '@shared/pty-input-filters';
 
 export function isRealAgentPrompt(message: string): boolean {
-  const trimmed = message.trim();
-  if (!trimmed || trimmed.length < MIN_MESSAGE_LENGTH) return false;
-  if (!HAS_ALPHA.test(trimmed)) return false;
-  return !SKIP_PATTERNS.some((pattern) => pattern.test(trimmed));
+  return isRealTaskLikeInput(message);
 }
 
 export class PtyInputSubmissionTracker {
@@ -26,6 +11,8 @@ export class PtyInputSubmissionTracker {
     let buffer = this.buffers.get(sessionId) ?? '';
     let submittedRealPrompt = false;
 
+    // This lightweight tracker does not decode ANSI escape sequences; it only needs
+    // enough text state to distinguish slash commands from real submitted prompts.
     for (const ch of data) {
       if (ch === '\r') {
         submittedRealPrompt ||= isRealAgentPrompt(buffer);
@@ -53,7 +40,7 @@ export class PtyInputSubmissionTracker {
       }
     }
 
-    if (buffer) {
+    if (buffer.trim()) {
       this.buffers.set(sessionId, buffer);
     } else {
       this.buffers.delete(sessionId);

--- a/src/main/core/pty/input-submission-tracker.ts
+++ b/src/main/core/pty/input-submission-tracker.ts
@@ -1,0 +1,68 @@
+const SKIP_PATTERNS = [
+  /^\//,
+  /^y(es)?$/i,
+  /^n(o)?$/i,
+  /^ok$/i,
+  /^q(uit)?$/i,
+  /^exit$/i,
+  /^help$/i,
+  /^\d+$/,
+];
+
+const HAS_ALPHA = /[A-Za-z]/;
+const MIN_MESSAGE_LENGTH = 2;
+
+export function isRealAgentPrompt(message: string): boolean {
+  const trimmed = message.trim();
+  if (!trimmed || trimmed.length < MIN_MESSAGE_LENGTH) return false;
+  if (!HAS_ALPHA.test(trimmed)) return false;
+  return !SKIP_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+export class PtyInputSubmissionTracker {
+  private readonly buffers = new Map<string, string>();
+
+  feed(sessionId: string, data: string): boolean {
+    let buffer = this.buffers.get(sessionId) ?? '';
+    let submittedRealPrompt = false;
+
+    for (const ch of data) {
+      if (ch === '\r') {
+        submittedRealPrompt ||= isRealAgentPrompt(buffer);
+        buffer = '';
+        continue;
+      }
+
+      if (ch === '\n') {
+        buffer += ch;
+        continue;
+      }
+
+      if (ch === '\x7f' || ch === '\b') {
+        buffer = buffer.slice(0, -1);
+        continue;
+      }
+
+      if (ch === '\x15') {
+        buffer = '';
+        continue;
+      }
+
+      if (ch.charCodeAt(0) >= 32) {
+        buffer += ch;
+      }
+    }
+
+    if (buffer) {
+      this.buffers.set(sessionId, buffer);
+    } else {
+      this.buffers.delete(sessionId);
+    }
+
+    return submittedRealPrompt;
+  }
+
+  clear(sessionId: string): void {
+    this.buffers.delete(sessionId);
+  }
+}

--- a/src/renderer/lib/pty/pty-input-buffer.ts
+++ b/src/renderer/lib/pty/pty-input-buffer.ts
@@ -1,3 +1,5 @@
+import { isRealTaskLikeInput } from '@shared/pty-input-filters';
+
 /**
  * One-shot capture of the user's first "real" terminal message.
  *
@@ -5,21 +7,6 @@
  * and fires the `onCapture` callback once when a confirmed submit
  * passes validation. After firing, the buffer disables itself.
  */
-
-/** Strings that look like non-task-related input (confirmations, slash commands, etc.) */
-const SKIP_PATTERNS = [
-  /^\//,
-  /^y(es)?$/i,
-  /^n(o)?$/i,
-  /^ok$/i,
-  /^q(uit)?$/i,
-  /^exit$/i,
-  /^help$/i,
-  /^\d+$/,
-];
-
-const MIN_MESSAGE_LENGTH = 2;
-const HAS_ALPHA = /[A-Za-z]/;
 
 type SanitizerMode = 'normal' | 'escape' | 'csi' | 'osc' | 'osc-escape' | 'ss3';
 type InputAction =
@@ -246,13 +233,7 @@ export class SubmittedInputBuffer {
 
 /** Returns true if the message looks like a real task description. */
 export function isRealTaskInput(message: string): boolean {
-  const trimmed = message.trim();
-  if (!trimmed || trimmed.length < MIN_MESSAGE_LENGTH) return false;
-  if (!HAS_ALPHA.test(trimmed)) return false;
-  for (const pattern of SKIP_PATTERNS) {
-    if (pattern.test(trimmed)) return false;
-  }
-  return true;
+  return isRealTaskLikeInput(message);
 }
 
 export class TerminalInputBuffer {

--- a/src/renderer/lib/pty/use-pty.ts
+++ b/src/renderer/lib/pty/use-pty.ts
@@ -306,7 +306,7 @@ export function usePty(
           }
         }
       }
-      void rpc.pty.sendInput(sessionId, data);
+      void rpc.pty.sendInput(sessionId, data, options);
     },
     [sessionId]
   );

--- a/src/shared/pty-input-filters.ts
+++ b/src/shared/pty-input-filters.ts
@@ -1,0 +1,22 @@
+/** Returns true if terminal input looks like a real user task/prompt. */
+export function isRealTaskLikeInput(message: string): boolean {
+  const trimmed = message.trim();
+  if (!trimmed || trimmed.length < MIN_MESSAGE_LENGTH) return false;
+  if (!HAS_ALPHA.test(trimmed)) return false;
+  return !SKIP_PATTERNS.some((pattern) => pattern.test(trimmed));
+}
+
+/** Strings that look like non-task-related input (confirmations, slash commands, etc.) */
+const SKIP_PATTERNS = [
+  /^\//,
+  /^y(es)?$/i,
+  /^n(o)?$/i,
+  /^ok$/i,
+  /^q(uit)?$/i,
+  /^exit$/i,
+  /^help$/i,
+  /^\d+$/,
+];
+
+const HAS_ALPHA = /[A-Za-z]/;
+const MIN_MESSAGE_LENGTH = 2;


### PR DESCRIPTION
### Description
- pty tracking so agent state only changes after a real prompt submitted 

### Screenshot/Recording (if applicable)
https://streamable.com/efm2zf

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
