### PR TITLE
fix(terminals): preserve scrollback after lifecycle script exit

### DIFF
--- a/src/renderer/features/tasks/stores/lifecycle-scripts.ts
+++ b/src/renderer/features/tasks/stores/lifecycle-scripts.ts
@@ -38,12 +38,17 @@ export class LifecycleScriptStore {
 
   constructor(data: LifecycleScriptData, projectId: string, workspaceId: string) {
     this.data = data;
-    this.session = new PtySession(makePtySessionId(projectId, workspaceId, data.id), () =>
-      rpc.terminals.prepareLifecycleScript({
-        projectId,
-        workspaceId,
-        type: data.type,
-      })
+    this.session = new PtySession(
+      makePtySessionId(projectId, workspaceId, data.id),
+      () =>
+        rpc.terminals.prepareLifecycleScript({
+          projectId,
+          workspaceId,
+          type: data.type,
+        }),
+      undefined,
+      undefined,
+      { replaceFrontendOnBackendStart: false }
     );
     this.offStatus = events.on(lifecycleScriptStatusChannel, (event) => {
       if (

--- a/src/renderer/features/tasks/terminals/terminal-manager.ts
+++ b/src/renderer/features/tasks/terminals/terminal-manager.ts
@@ -191,7 +191,8 @@ export class TerminalManagerStore implements IDisposable {
       makePtySessionId(terminal.projectId, terminal.taskId, terminal.id),
       () => this.hydrateTerminal(terminal.id),
       handlers.onOpenFile,
-      handlers.onOpenExternal
+      handlers.onOpenExternal,
+      { replaceFrontendOnBackendStart: false }
     );
   }
 }

--- a/src/renderer/lib/pty/pty-session.test.ts
+++ b/src/renderer/lib/pty/pty-session.test.ts
@@ -6,6 +6,7 @@ import { PtySession } from './pty-session';
 const frontendConnect = vi.hoisted(() => vi.fn());
 const frontendDispose = vi.hoisted(() => vi.fn());
 const frontendInstances = vi.hoisted(() => [] as Array<{ sessionId: string }>);
+const frontendConnectedSessionIds = vi.hoisted(() => [] as string[]);
 
 vi.mock('@renderer/lib/ipc', () => ({
   events: {
@@ -19,7 +20,10 @@ vi.mock('@renderer/lib/pty/pty', () => ({
       frontendInstances.push(this);
     }
 
-    connect = frontendConnect;
+    connect = () => {
+      frontendConnectedSessionIds.push(this.sessionId);
+      return frontendConnect();
+    };
     dispose = frontendDispose;
   },
 }));
@@ -46,6 +50,7 @@ describe('PtySession', () => {
     frontendConnect.mockReset();
     frontendDispose.mockReset();
     frontendInstances.length = 0;
+    frontendConnectedSessionIds.length = 0;
     vi.mocked(events.on).mockReset();
     vi.mocked(events.on).mockReturnValue(() => {});
   });
@@ -102,6 +107,29 @@ describe('PtySession', () => {
     expect(frontendDispose).toHaveBeenCalledTimes(1);
     expect(frontendInstances).toHaveLength(2);
     expect(session.pty).not.toBe(initialPty);
+    expect(session.status).toBe('ready');
+  });
+
+  it('keeps the frontend PTY when backend replacement is configured to preserve scrollback', async () => {
+    frontendConnect.mockResolvedValue(undefined);
+    const session = new PtySession('session-1', undefined, undefined, undefined, {
+      replaceFrontendOnBackendStart: false,
+    });
+
+    await session.connect();
+    const initialPty = session.pty;
+    expect(initialPty).not.toBeNull();
+
+    for (const listener of ptyStartedListeners()) {
+      listener({ id: 'session-1', epoch: 2 });
+    }
+    await Promise.resolve();
+
+    expect(frontendDispose).not.toHaveBeenCalled();
+    expect(frontendInstances).toHaveLength(1);
+    expect(frontendConnect).toHaveBeenCalledTimes(1);
+    expect(frontendConnectedSessionIds).toEqual(['session-1']);
+    expect(session.pty).toBe(initialPty);
     expect(session.status).toBe('ready');
   });
 

--- a/src/renderer/lib/pty/pty-session.ts
+++ b/src/renderer/lib/pty/pty-session.ts
@@ -5,6 +5,10 @@ import { ptyStartedChannel } from '@shared/events/appEvents';
 
 export type PtySessionStatus = 'disconnected' | 'connecting' | 'ready';
 
+export type PtySessionOptions = {
+  replaceFrontendOnBackendStart?: boolean;
+};
+
 export class PtySession {
   pty: FrontendPty | null = null;
   status: PtySessionStatus = 'disconnected';
@@ -12,13 +16,16 @@ export class PtySession {
   private version = 0;
   private lastSeenEpoch = 0;
   private offPtyStarted: (() => void) | null = null;
+  private readonly replaceFrontendOnBackendStart: boolean;
 
   constructor(
     readonly sessionId: string,
     private readonly prepare?: () => Promise<void>,
     private readonly onOpenFile?: (filePath: string) => void,
-    private readonly onOpenExternal?: (filePath: string) => void
+    private readonly onOpenExternal?: (filePath: string) => void,
+    options: PtySessionOptions = {}
   ) {
+    this.replaceFrontendOnBackendStart = options.replaceFrontendOnBackendStart ?? true;
     makeAutoObservable(this, {
       pty: false,
     });
@@ -88,6 +95,8 @@ export class PtySession {
     }
 
     this.lastSeenEpoch = epoch;
+    if (!this.replaceFrontendOnBackendStart) return;
+
     this.version++;
     this.connectPromise = null;
     this.pty?.dispose();


### PR DESCRIPTION
- preserves terminal scrollback when lifecycle scripts exit and restore their idle prompt
- keeps conversation sessions on the existing fresh frontend replacement path
- scopes backend restart handling through a PtySession option so main process pty events stay generic