### PR TITLE
  fix(conversations): stabilize agent respawn recovery

### DIFF
--- a/src/main/core/conversations/conversation-session-supervisor.test.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Pty } from '@main/core/pty/pty';
 import {
-  MAX_CONVERSATION_RESUME_REPLACEMENTS,
+  MAX_CONVERSATION_RESUME_ATTEMPTS,
   ConversationSessionSupervisor,
 } from './conversation-session-supervisor';
 
@@ -27,7 +27,7 @@ describe('ConversationSessionSupervisor', () => {
     expect(supervisor.acceptSpawn('session-1', token!, pty)).toBe(false);
   });
 
-  it('falls back to a fresh replacement after three resume exits', () => {
+  it('falls back to a fresh replacement after one resume exit', () => {
     const supervisor = new ConversationSessionSupervisor();
     const initial = fakePty();
     const initialToken = supervisor.beginStart('session-1', { mode: 'fresh' });
@@ -35,7 +35,7 @@ describe('ConversationSessionSupervisor', () => {
 
     expect(supervisor.handleExit('session-1', initial)).toEqual({ kind: 'respawnResume' });
 
-    for (let attempt = 1; attempt <= MAX_CONVERSATION_RESUME_REPLACEMENTS; attempt += 1) {
+    for (let attempt = 1; attempt <= MAX_CONVERSATION_RESUME_ATTEMPTS; attempt += 1) {
       const pty = fakePty();
       const token = supervisor.beginStart('session-1', {
         requireDesired: true,
@@ -44,7 +44,7 @@ describe('ConversationSessionSupervisor', () => {
       expect(supervisor.acceptSpawn('session-1', token!, pty)).toBe(true);
 
       const decision = supervisor.handleExit('session-1', pty);
-      if (attempt < MAX_CONVERSATION_RESUME_REPLACEMENTS) {
+      if (attempt < MAX_CONVERSATION_RESUME_ATTEMPTS) {
         expect(decision).toEqual({ kind: 'respawnResume' });
       } else {
         expect(decision).toEqual({ kind: 'respawnFresh' });
@@ -58,7 +58,7 @@ describe('ConversationSessionSupervisor', () => {
     const firstToken = supervisor.beginStart('session-1', { mode: 'resume' });
     expect(supervisor.acceptSpawn('session-1', firstToken!, first)).toBe(true);
 
-    expect(supervisor.handleExit('session-1', first)).toEqual({ kind: 'respawnResume' });
+    expect(supervisor.handleExit('session-1', first)).toEqual({ kind: 'respawnFresh' });
 
     const fresh = fakePty();
     const freshToken = supervisor.beginStart('session-1', {
@@ -74,6 +74,6 @@ describe('ConversationSessionSupervisor', () => {
       mode: 'resume',
     });
     expect(supervisor.acceptSpawn('session-1', retryToken!, retry)).toBe(true);
-    expect(supervisor.handleExit('session-1', retry)).toEqual({ kind: 'respawnResume' });
+    expect(supervisor.handleExit('session-1', retry)).toEqual({ kind: 'respawnFresh' });
   });
 });

--- a/src/main/core/conversations/conversation-session-supervisor.test.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it, vi } from 'vitest';
 import type { Pty } from '@main/core/pty/pty';
 import {
   MAX_CONVERSATION_RESUME_REPLACEMENTS,
-  type ConversationSpawnMode,
   ConversationSessionSupervisor,
 } from './conversation-session-supervisor';
 
@@ -34,26 +33,21 @@ describe('ConversationSessionSupervisor', () => {
     const initialToken = supervisor.beginStart('session-1', { mode: 'fresh' });
     expect(supervisor.acceptSpawn('session-1', initialToken!, initial)).toBe(true);
 
-    expect(supervisor.handleExit('session-1', initial)).toEqual({
-      kind: 'replace',
-      mode: 'resume',
-    });
+    expect(supervisor.handleExit('session-1', initial)).toEqual({ kind: 'respawnResume' });
 
-    let nextMode: ConversationSpawnMode = 'resume';
     for (let attempt = 1; attempt <= MAX_CONVERSATION_RESUME_REPLACEMENTS; attempt += 1) {
       const pty = fakePty();
       const token = supervisor.beginStart('session-1', {
         requireDesired: true,
-        mode: nextMode,
+        mode: 'resume',
       });
       expect(supervisor.acceptSpawn('session-1', token!, pty)).toBe(true);
 
       const decision = supervisor.handleExit('session-1', pty);
       if (attempt < MAX_CONVERSATION_RESUME_REPLACEMENTS) {
-        expect(decision).toEqual({ kind: 'replace', mode: 'resume' });
-        nextMode = 'resume';
+        expect(decision).toEqual({ kind: 'respawnResume' });
       } else {
-        expect(decision).toEqual({ kind: 'replace', mode: 'fresh' });
+        expect(decision).toEqual({ kind: 'respawnFresh' });
       }
     }
   });
@@ -64,10 +58,7 @@ describe('ConversationSessionSupervisor', () => {
     const firstToken = supervisor.beginStart('session-1', { mode: 'resume' });
     expect(supervisor.acceptSpawn('session-1', firstToken!, first)).toBe(true);
 
-    expect(supervisor.handleExit('session-1', first)).toEqual({
-      kind: 'replace',
-      mode: 'resume',
-    });
+    expect(supervisor.handleExit('session-1', first)).toEqual({ kind: 'respawnResume' });
 
     const fresh = fakePty();
     const freshToken = supervisor.beginStart('session-1', {
@@ -75,10 +66,7 @@ describe('ConversationSessionSupervisor', () => {
       mode: 'fresh',
     });
     expect(supervisor.acceptSpawn('session-1', freshToken!, fresh)).toBe(true);
-    expect(supervisor.handleExit('session-1', fresh)).toEqual({
-      kind: 'replace',
-      mode: 'resume',
-    });
+    expect(supervisor.handleExit('session-1', fresh)).toEqual({ kind: 'respawnResume' });
 
     const retry = fakePty();
     const retryToken = supervisor.beginStart('session-1', {
@@ -86,9 +74,6 @@ describe('ConversationSessionSupervisor', () => {
       mode: 'resume',
     });
     expect(supervisor.acceptSpawn('session-1', retryToken!, retry)).toBe(true);
-    expect(supervisor.handleExit('session-1', retry)).toEqual({
-      kind: 'replace',
-      mode: 'resume',
-    });
+    expect(supervisor.handleExit('session-1', retry)).toEqual({ kind: 'respawnResume' });
   });
 });

--- a/src/main/core/conversations/conversation-session-supervisor.test.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Pty } from '@main/core/pty/pty';
 import {
-  CONVERSATION_REPLACEMENT_SUSTAINED_MS,
+  MAX_CONVERSATION_RESUME_REPLACEMENTS,
+  type ConversationSpawnMode,
   ConversationSessionSupervisor,
 } from './conversation-session-supervisor';
 
@@ -16,7 +17,7 @@ function fakePty(): Pty {
 }
 
 describe('ConversationSessionSupervisor', () => {
-  it('rejects and kills a spawn that returns after explicit stop invalidated its generation', () => {
+  it('rejects and kills a spawn that returns after explicit stop invalidated its token', () => {
     const supervisor = new ConversationSessionSupervisor();
     const token = supervisor.beginStart('session-1');
     expect(token).toBeDefined();
@@ -27,56 +28,67 @@ describe('ConversationSessionSupervisor', () => {
     expect(supervisor.acceptSpawn('session-1', token!, pty)).toBe(false);
   });
 
-  it('allows one replacement inside a failure window and then fails until sustained running resets it', () => {
-    vi.useFakeTimers();
-    try {
-      const supervisor = new ConversationSessionSupervisor();
-      const first = fakePty();
-      const second = fakePty();
-      const firstToken = supervisor.beginStart('session-1');
-      expect(supervisor.acceptSpawn('session-1', firstToken!, first)).toBe(true);
+  it('falls back to a fresh replacement after three resume exits', () => {
+    const supervisor = new ConversationSessionSupervisor();
+    const initial = fakePty();
+    const initialToken = supervisor.beginStart('session-1', { mode: 'fresh' });
+    expect(supervisor.acceptSpawn('session-1', initialToken!, initial)).toBe(true);
 
-      expect(supervisor.handleExit('session-1', first)).toEqual({ kind: 'replace' });
-      const secondToken = supervisor.beginStart('session-1', {
-        requireDesired: true,
-      });
-      expect(supervisor.acceptSpawn('session-1', secondToken!, second)).toBe(true);
-      expect(supervisor.handleExit('session-1', second)).toEqual({ kind: 'failed' });
+    expect(supervisor.handleExit('session-1', initial)).toEqual({
+      kind: 'replace',
+      mode: 'resume',
+    });
 
-      const third = fakePty();
-      const thirdToken = supervisor.beginStart('session-2');
-      expect(supervisor.acceptSpawn('session-2', thirdToken!, third)).toBe(true);
-      expect(supervisor.handleExit('session-2', third)).toEqual({ kind: 'replace' });
-      const fourth = fakePty();
-      const fourthToken = supervisor.beginStart('session-2', {
+    let nextMode: ConversationSpawnMode = 'resume';
+    for (let attempt = 1; attempt <= MAX_CONVERSATION_RESUME_REPLACEMENTS; attempt += 1) {
+      const pty = fakePty();
+      const token = supervisor.beginStart('session-1', {
         requireDesired: true,
+        mode: nextMode,
       });
-      expect(supervisor.acceptSpawn('session-2', fourthToken!, fourth)).toBe(true);
-      vi.advanceTimersByTime(CONVERSATION_REPLACEMENT_SUSTAINED_MS);
-      expect(supervisor.handleExit('session-2', fourth)).toEqual({ kind: 'replace' });
-    } finally {
-      vi.useRealTimers();
+      expect(supervisor.acceptSpawn('session-1', token!, pty)).toBe(true);
+
+      const decision = supervisor.handleExit('session-1', pty);
+      if (attempt < MAX_CONVERSATION_RESUME_REPLACEMENTS) {
+        expect(decision).toEqual({ kind: 'replace', mode: 'resume' });
+        nextMode = 'resume';
+      } else {
+        expect(decision).toEqual({ kind: 'replace', mode: 'fresh' });
+      }
     }
   });
 
-  it('clears the replacement failure window after a spawn failure', () => {
+  it('resets the resume exit count after a fresh spawn', () => {
     const supervisor = new ConversationSessionSupervisor();
     const first = fakePty();
-    const firstToken = supervisor.beginStart('session-1');
+    const firstToken = supervisor.beginStart('session-1', { mode: 'resume' });
     expect(supervisor.acceptSpawn('session-1', firstToken!, first)).toBe(true);
 
-    expect(supervisor.handleExit('session-1', first)).toEqual({ kind: 'replace' });
-    const failedToken = supervisor.beginStart('session-1', {
-      requireDesired: true,
+    expect(supervisor.handleExit('session-1', first)).toEqual({
+      kind: 'replace',
+      mode: 'resume',
     });
-    expect(failedToken).toBeDefined();
-    supervisor.failSpawn('session-1', failedToken!);
+
+    const fresh = fakePty();
+    const freshToken = supervisor.beginStart('session-1', {
+      requireDesired: true,
+      mode: 'fresh',
+    });
+    expect(supervisor.acceptSpawn('session-1', freshToken!, fresh)).toBe(true);
+    expect(supervisor.handleExit('session-1', fresh)).toEqual({
+      kind: 'replace',
+      mode: 'resume',
+    });
 
     const retry = fakePty();
     const retryToken = supervisor.beginStart('session-1', {
       requireDesired: true,
+      mode: 'resume',
     });
     expect(supervisor.acceptSpawn('session-1', retryToken!, retry)).toBe(true);
-    expect(supervisor.handleExit('session-1', retry)).toEqual({ kind: 'replace' });
+    expect(supervisor.handleExit('session-1', retry)).toEqual({
+      kind: 'replace',
+      mode: 'resume',
+    });
   });
 });

--- a/src/main/core/conversations/conversation-session-supervisor.test.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { Pty } from '@main/core/pty/pty';
 import {
+  CONVERSATION_FRESH_RECOVERY_GRACE_MS,
   MAX_CONVERSATION_RESUME_ATTEMPTS,
   ConversationSessionSupervisor,
 } from './conversation-session-supervisor';
@@ -52,7 +53,7 @@ describe('ConversationSessionSupervisor', () => {
     }
   });
 
-  it('resets the resume exit count after a fresh spawn', () => {
+  it('fails when a fresh recovery exits before the startup grace period', () => {
     const supervisor = new ConversationSessionSupervisor();
     const first = fakePty();
     const firstToken = supervisor.beginStart('session-1', { mode: 'resume' });
@@ -66,14 +67,39 @@ describe('ConversationSessionSupervisor', () => {
       mode: 'fresh',
     });
     expect(supervisor.acceptSpawn('session-1', freshToken!, fresh)).toBe(true);
-    expect(supervisor.handleExit('session-1', fresh)).toEqual({ kind: 'respawnResume' });
+    expect(supervisor.handleExit('session-1', fresh)).toEqual({ kind: 'failed' });
+    expect(supervisor.isDesired('session-1')).toBe(false);
+  });
 
-    const retry = fakePty();
-    const retryToken = supervisor.beginStart('session-1', {
-      requireDesired: true,
-      mode: 'resume',
-    });
-    expect(supervisor.acceptSpawn('session-1', retryToken!, retry)).toBe(true);
-    expect(supervisor.handleExit('session-1', retry)).toEqual({ kind: 'respawnFresh' });
+  it('resets recovery after a fresh replacement survives the startup grace period', () => {
+    vi.useFakeTimers();
+    try {
+      const supervisor = new ConversationSessionSupervisor();
+      const first = fakePty();
+      const firstToken = supervisor.beginStart('session-1', { mode: 'resume' });
+      expect(supervisor.acceptSpawn('session-1', firstToken!, first)).toBe(true);
+
+      expect(supervisor.handleExit('session-1', first)).toEqual({ kind: 'respawnFresh' });
+
+      const fresh = fakePty();
+      const freshToken = supervisor.beginStart('session-1', {
+        requireDesired: true,
+        mode: 'fresh',
+      });
+      expect(supervisor.acceptSpawn('session-1', freshToken!, fresh)).toBe(true);
+
+      vi.advanceTimersByTime(CONVERSATION_FRESH_RECOVERY_GRACE_MS);
+      expect(supervisor.handleExit('session-1', fresh)).toEqual({ kind: 'respawnResume' });
+
+      const retry = fakePty();
+      const retryToken = supervisor.beginStart('session-1', {
+        requireDesired: true,
+        mode: 'resume',
+      });
+      expect(supervisor.acceptSpawn('session-1', retryToken!, retry)).toBe(true);
+      expect(supervisor.handleExit('session-1', retry)).toEqual({ kind: 'respawnFresh' });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/src/main/core/conversations/conversation-session-supervisor.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.ts
@@ -18,7 +18,7 @@ type ConversationRuntime = {
   consecutiveResumeExits: number;
 };
 
-export const MAX_CONVERSATION_RESUME_REPLACEMENTS = 3;
+export const MAX_CONVERSATION_RESUME_ATTEMPTS = 1;
 
 export type ExitDecision =
   | { kind: 'stale' }
@@ -89,7 +89,7 @@ export class ConversationSessionSupervisor {
 
     if (exitedMode === 'resume') {
       runtime.consecutiveResumeExits += 1;
-      if (runtime.consecutiveResumeExits >= MAX_CONVERSATION_RESUME_REPLACEMENTS) {
+      if (runtime.consecutiveResumeExits >= MAX_CONVERSATION_RESUME_ATTEMPTS) {
         runtime.consecutiveResumeExits = 0;
         return { kind: 'respawnFresh' };
       }

--- a/src/main/core/conversations/conversation-session-supervisor.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.ts
@@ -1,10 +1,10 @@
 import type { Pty } from '@main/core/pty/pty';
 
-export type ConversationSpawnToken = {
+type ConversationSpawnToken = {
   mode: ConversationSpawnMode;
 };
 
-export type ConversationSpawnMode = 'fresh' | 'resume';
+type ConversationSpawnMode = 'fresh' | 'resume';
 
 type ActiveConversationPty = {
   pty: Pty;
@@ -23,7 +23,8 @@ export const MAX_CONVERSATION_RESUME_REPLACEMENTS = 3;
 export type ExitDecision =
   | { kind: 'stale' }
   | { kind: 'stopped' }
-  | { kind: 'replace'; mode: ConversationSpawnMode };
+  | { kind: 'respawnFresh' }
+  | { kind: 'respawnResume' };
 
 export class ConversationSessionSupervisor {
   private runtimes = new Map<string, ConversationRuntime>();
@@ -90,13 +91,13 @@ export class ConversationSessionSupervisor {
       runtime.consecutiveResumeExits += 1;
       if (runtime.consecutiveResumeExits >= MAX_CONVERSATION_RESUME_REPLACEMENTS) {
         runtime.consecutiveResumeExits = 0;
-        return { kind: 'replace', mode: 'fresh' };
+        return { kind: 'respawnFresh' };
       }
-      return { kind: 'replace', mode: 'resume' };
+      return { kind: 'respawnResume' };
     }
 
     runtime.consecutiveResumeExits = 0;
-    return { kind: 'replace', mode: 'resume' };
+    return { kind: 'respawnResume' };
   }
 
   forget(sessionId: string): void {

--- a/src/main/core/conversations/conversation-session-supervisor.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.ts
@@ -1,61 +1,62 @@
 import type { Pty } from '@main/core/pty/pty';
 
 export type ConversationSpawnToken = {
-  generation: number;
+  mode: ConversationSpawnMode;
+};
+
+export type ConversationSpawnMode = 'fresh' | 'resume';
+
+type ActiveConversationPty = {
+  pty: Pty;
+  mode: ConversationSpawnMode;
 };
 
 type ConversationRuntime = {
   desired: boolean;
-  pty?: Pty;
-  spawnInFlightGeneration?: number;
-  replacementGeneration: number;
-  replacementAttemptedInWindow: boolean;
-  stableTimer?: ReturnType<typeof setTimeout>;
+  active?: ActiveConversationPty;
+  spawnInFlight?: ConversationSpawnToken;
+  consecutiveResumeExits: number;
 };
 
-export const CONVERSATION_REPLACEMENT_SUSTAINED_MS = 5_000;
+export const MAX_CONVERSATION_RESUME_REPLACEMENTS = 3;
 
 export type ExitDecision =
   | { kind: 'stale' }
   | { kind: 'stopped' }
-  | { kind: 'replace' }
-  | { kind: 'failed' };
+  | { kind: 'replace'; mode: ConversationSpawnMode };
 
 export class ConversationSessionSupervisor {
   private runtimes = new Map<string, ConversationRuntime>();
 
   beginStart(
     sessionId: string,
-    options: { requireDesired?: boolean } = {}
+    options: { requireDesired?: boolean; mode?: ConversationSpawnMode } = {}
   ): ConversationSpawnToken | undefined {
     const runtime = this.getOrCreateRuntime(sessionId);
-    if (runtime.pty || runtime.spawnInFlightGeneration !== undefined) return undefined;
+    if (runtime.active || runtime.spawnInFlight) return undefined;
     if (options.requireDesired === true && !runtime.desired) return undefined;
 
     runtime.desired = true;
-    runtime.replacementGeneration += 1;
-    runtime.spawnInFlightGeneration = runtime.replacementGeneration;
-
-    return { generation: runtime.replacementGeneration };
+    const token = { mode: options.mode ?? 'fresh' };
+    runtime.spawnInFlight = token;
+    return token;
   }
 
   acceptSpawn(sessionId: string, token: ConversationSpawnToken, pty: Pty): boolean {
     const runtime = this.runtimes.get(sessionId);
-    if (!runtime || runtime.spawnInFlightGeneration !== token.generation) return false;
+    if (!runtime || runtime.spawnInFlight !== token) return false;
 
-    runtime.spawnInFlightGeneration = undefined;
-    if (!runtime.desired || runtime.replacementGeneration !== token.generation) return false;
+    runtime.spawnInFlight = undefined;
+    if (!runtime.desired) return false;
 
-    runtime.pty = pty;
-    this.armStableTimer(runtime);
+    runtime.active = { pty, mode: token.mode };
     return true;
   }
 
   failSpawn(sessionId: string, token: ConversationSpawnToken): void {
     const runtime = this.runtimes.get(sessionId);
-    if (!runtime || runtime.spawnInFlightGeneration !== token.generation) return;
-    runtime.spawnInFlightGeneration = undefined;
-    runtime.replacementAttemptedInWindow = false;
+    if (!runtime || runtime.spawnInFlight !== token) return;
+    runtime.spawnInFlight = undefined;
   }
 
   stop(sessionId: string): Pty | undefined {
@@ -63,13 +64,11 @@ export class ConversationSessionSupervisor {
     if (!runtime) return undefined;
 
     runtime.desired = false;
-    runtime.replacementGeneration += 1;
-    runtime.spawnInFlightGeneration = undefined;
-    this.clearStableTimer(runtime);
+    runtime.spawnInFlight = undefined;
 
-    const pty = runtime.pty;
-    runtime.pty = undefined;
-    runtime.replacementAttemptedInWindow = false;
+    const pty = runtime.active?.pty;
+    runtime.active = undefined;
+    runtime.consecutiveResumeExits = 0;
     return pty;
   }
 
@@ -79,27 +78,28 @@ export class ConversationSessionSupervisor {
 
   handleExit(sessionId: string, pty: Pty): ExitDecision {
     const runtime = this.runtimes.get(sessionId);
-    if (!runtime || runtime.pty !== pty) return { kind: 'stale' };
+    if (!runtime || runtime.active?.pty !== pty) return { kind: 'stale' };
 
-    runtime.pty = undefined;
-    runtime.spawnInFlightGeneration = undefined;
-    this.clearStableTimer(runtime);
+    const exitedMode = runtime.active.mode;
+    runtime.active = undefined;
+    runtime.spawnInFlight = undefined;
 
     if (!runtime.desired) return { kind: 'stopped' };
 
-    if (runtime.replacementAttemptedInWindow) {
-      runtime.desired = false;
-      runtime.replacementAttemptedInWindow = false;
-      return { kind: 'failed' };
+    if (exitedMode === 'resume') {
+      runtime.consecutiveResumeExits += 1;
+      if (runtime.consecutiveResumeExits >= MAX_CONVERSATION_RESUME_REPLACEMENTS) {
+        runtime.consecutiveResumeExits = 0;
+        return { kind: 'replace', mode: 'fresh' };
+      }
+      return { kind: 'replace', mode: 'resume' };
     }
 
-    runtime.replacementAttemptedInWindow = true;
-    return { kind: 'replace' };
+    runtime.consecutiveResumeExits = 0;
+    return { kind: 'replace', mode: 'resume' };
   }
 
   forget(sessionId: string): void {
-    const runtime = this.runtimes.get(sessionId);
-    if (runtime) this.clearStableTimer(runtime);
     this.runtimes.delete(sessionId);
   }
 
@@ -108,26 +108,10 @@ export class ConversationSessionSupervisor {
     if (!runtime) {
       runtime = {
         desired: false,
-        replacementGeneration: 0,
-        replacementAttemptedInWindow: false,
+        consecutiveResumeExits: 0,
       };
       this.runtimes.set(sessionId, runtime);
     }
     return runtime;
-  }
-
-  private armStableTimer(runtime: ConversationRuntime): void {
-    this.clearStableTimer(runtime);
-    runtime.stableTimer = setTimeout(() => {
-      runtime.replacementAttemptedInWindow = false;
-      runtime.stableTimer = undefined;
-    }, CONVERSATION_REPLACEMENT_SUSTAINED_MS);
-  }
-
-  private clearStableTimer(runtime: ConversationRuntime): void {
-    if (runtime.stableTimer !== undefined) {
-      clearTimeout(runtime.stableTimer);
-      runtime.stableTimer = undefined;
-    }
   }
 }

--- a/src/main/core/conversations/conversation-session-supervisor.ts
+++ b/src/main/core/conversations/conversation-session-supervisor.ts
@@ -2,6 +2,7 @@ import type { Pty } from '@main/core/pty/pty';
 
 type ConversationSpawnToken = {
   mode: ConversationSpawnMode;
+  freshRecovery: boolean;
 };
 
 type ConversationSpawnMode = 'fresh' | 'resume';
@@ -9,6 +10,7 @@ type ConversationSpawnMode = 'fresh' | 'resume';
 type ActiveConversationPty = {
   pty: Pty;
   mode: ConversationSpawnMode;
+  freshRecovery: boolean;
 };
 
 type ConversationRuntime = {
@@ -16,13 +18,16 @@ type ConversationRuntime = {
   active?: ActiveConversationPty;
   spawnInFlight?: ConversationSpawnToken;
   consecutiveResumeExits: number;
+  recoveryGraceTimer?: ReturnType<typeof setTimeout>;
 };
 
 export const MAX_CONVERSATION_RESUME_ATTEMPTS = 1;
+export const CONVERSATION_FRESH_RECOVERY_GRACE_MS = 5_000;
 
 export type ExitDecision =
   | { kind: 'stale' }
   | { kind: 'stopped' }
+  | { kind: 'failed' }
   | { kind: 'respawnFresh' }
   | { kind: 'respawnResume' };
 
@@ -38,7 +43,12 @@ export class ConversationSessionSupervisor {
     if (options.requireDesired === true && !runtime.desired) return undefined;
 
     runtime.desired = true;
-    const token = { mode: options.mode ?? 'fresh' };
+    const mode = options.mode ?? 'fresh';
+    const token = {
+      mode,
+      freshRecovery:
+        mode === 'fresh' && runtime.consecutiveResumeExits >= MAX_CONVERSATION_RESUME_ATTEMPTS,
+    };
     runtime.spawnInFlight = token;
     return token;
   }
@@ -50,7 +60,14 @@ export class ConversationSessionSupervisor {
     runtime.spawnInFlight = undefined;
     if (!runtime.desired) return false;
 
-    runtime.active = { pty, mode: token.mode };
+    runtime.active = {
+      pty,
+      mode: token.mode,
+      freshRecovery: token.freshRecovery,
+    };
+    if (token.freshRecovery) {
+      this.scheduleRecoveryReset(sessionId, runtime, pty);
+    }
     return true;
   }
 
@@ -66,6 +83,7 @@ export class ConversationSessionSupervisor {
 
     runtime.desired = false;
     runtime.spawnInFlight = undefined;
+    this.clearRecoveryGraceTimer(runtime);
 
     const pty = runtime.active?.pty;
     runtime.active = undefined;
@@ -82,18 +100,26 @@ export class ConversationSessionSupervisor {
     if (!runtime || runtime.active?.pty !== pty) return { kind: 'stale' };
 
     const exitedMode = runtime.active.mode;
+    const freshRecovery = runtime.active.freshRecovery;
     runtime.active = undefined;
     runtime.spawnInFlight = undefined;
+    this.clearRecoveryGraceTimer(runtime);
 
     if (!runtime.desired) return { kind: 'stopped' };
 
     if (exitedMode === 'resume') {
       runtime.consecutiveResumeExits += 1;
       if (runtime.consecutiveResumeExits >= MAX_CONVERSATION_RESUME_ATTEMPTS) {
-        runtime.consecutiveResumeExits = 0;
+        runtime.consecutiveResumeExits = MAX_CONVERSATION_RESUME_ATTEMPTS;
         return { kind: 'respawnFresh' };
       }
       return { kind: 'respawnResume' };
+    }
+
+    if (freshRecovery && runtime.consecutiveResumeExits >= MAX_CONVERSATION_RESUME_ATTEMPTS) {
+      runtime.desired = false;
+      runtime.consecutiveResumeExits = 0;
+      return { kind: 'failed' };
     }
 
     runtime.consecutiveResumeExits = 0;
@@ -101,7 +127,30 @@ export class ConversationSessionSupervisor {
   }
 
   forget(sessionId: string): void {
+    const runtime = this.runtimes.get(sessionId);
+    if (runtime) this.clearRecoveryGraceTimer(runtime);
     this.runtimes.delete(sessionId);
+  }
+
+  private scheduleRecoveryReset(sessionId: string, runtime: ConversationRuntime, pty: Pty): void {
+    this.clearRecoveryGraceTimer(runtime);
+    runtime.recoveryGraceTimer = setTimeout(() => {
+      if (this.runtimes.get(sessionId) !== runtime) return;
+      if (runtime.active?.pty !== pty || !runtime.active.freshRecovery) return;
+
+      runtime.active = {
+        ...runtime.active,
+        freshRecovery: false,
+      };
+      runtime.consecutiveResumeExits = 0;
+      runtime.recoveryGraceTimer = undefined;
+    }, CONVERSATION_FRESH_RECOVERY_GRACE_MS);
+  }
+
+  private clearRecoveryGraceTimer(runtime: ConversationRuntime): void {
+    if (!runtime.recoveryGraceTimer) return;
+    clearTimeout(runtime.recoveryGraceTimer);
+    runtime.recoveryGraceTimer = undefined;
   }
 
   private getOrCreateRuntime(sessionId: string): ConversationRuntime {

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -296,7 +296,7 @@ describe('conversation provider respawn state', () => {
     expect(wireAgentClassifier).not.toHaveBeenCalled();
   });
 
-  it('replaces a local conversation after clean exit by resuming the same provider session', async () => {
+  it('starts a local conversation fresh after a resumed session exits', async () => {
     vi.useFakeTimers();
     try {
       const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
@@ -316,14 +316,14 @@ describe('conversation provider respawn state', () => {
 
       expect(spawnLocalPty).toHaveBeenCalledTimes(2);
       expect(buildAgentSessionCommand).toHaveBeenLastCalledWith(
-        expect.objectContaining({ isResuming: true })
+        expect.objectContaining({ isResuming: false })
       );
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('replaces an SSH conversation after clean exit by resuming the same provider session', async () => {
+  it('starts an SSH conversation fresh after a resumed session exits', async () => {
     vi.useFakeTimers();
     try {
       const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
@@ -343,7 +343,7 @@ describe('conversation provider respawn state', () => {
 
       expect(openSsh2Pty).toHaveBeenCalledTimes(2);
       expect(buildAgentSessionCommand).toHaveBeenLastCalledWith(
-        expect.objectContaining({ isResuming: true })
+        expect.objectContaining({ isResuming: false })
       );
     } finally {
       vi.useRealTimers();
@@ -438,7 +438,7 @@ describe('conversation provider respawn state', () => {
     }
   });
 
-  it('starts a local conversation fresh after three resume replacements exit', async () => {
+  it('starts a local conversation fresh after one resume replacement exits', async () => {
     vi.useFakeTimers();
     try {
       const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
@@ -452,21 +452,21 @@ describe('conversation provider respawn state', () => {
 
       await provider.startSession(item);
 
-      for (let index = 0; index < 4; index += 1) {
+      for (let index = 0; index < 2; index += 1) {
         for (const handler of exitHandlers[index] ?? []) handler({ exitCode: 1 });
         await vi.advanceTimersByTimeAsync(500);
       }
 
-      expect(spawnLocalPty).toHaveBeenCalledTimes(5);
+      expect(spawnLocalPty).toHaveBeenCalledTimes(3);
       expect(
         vi.mocked(buildAgentSessionCommand).mock.calls.map(([args]) => args.isResuming)
-      ).toEqual([false, true, true, true, false]);
+      ).toEqual([false, true, false]);
     } finally {
       vi.useRealTimers();
     }
   });
 
-  it('starts an SSH conversation fresh after three resume replacements exit', async () => {
+  it('starts an SSH conversation fresh after one resume replacement exits', async () => {
     vi.useFakeTimers();
     try {
       const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
@@ -480,15 +480,15 @@ describe('conversation provider respawn state', () => {
 
       await provider.startSession(item);
 
-      for (let index = 0; index < 4; index += 1) {
+      for (let index = 0; index < 2; index += 1) {
         for (const handler of exitHandlers[index] ?? []) handler({ exitCode: 1 });
         await vi.advanceTimersByTimeAsync(500);
       }
 
-      expect(openSsh2Pty).toHaveBeenCalledTimes(5);
+      expect(openSsh2Pty).toHaveBeenCalledTimes(3);
       expect(
         vi.mocked(buildAgentSessionCommand).mock.calls.map(([args]) => args.isResuming)
-      ).toEqual([false, true, true, true, false]);
+      ).toEqual([false, true, false]);
     } finally {
       vi.useRealTimers();
     }

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -694,6 +694,41 @@ describe('conversation provider respawn state', () => {
     }
   });
 
+  it('resets SSH supervisor state after a shell refresh retry also exits missing-command', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
+      openSsh2Pty.mockImplementation(() => {
+        const handlers: Array<(info: PtyExitInfo) => void> = [];
+        exitHandlers.push(handlers);
+        return Promise.resolve({ success: true, data: fakePty(handlers) });
+      });
+      const proxy = {
+        getRemoteShellProfile: vi.fn(async () => ({})),
+        refreshRemoteShellProfile: vi.fn(async () => ({})),
+      };
+      const provider = sshProvider(proxy);
+      const item = conversation();
+
+      await provider.startSession(item, undefined, true);
+      for (const handler of exitHandlers[0] ?? []) handler({ exitCode: 127 });
+      await vi.advanceTimersByTimeAsync(500);
+      for (const handler of exitHandlers[1] ?? []) handler({ exitCode: 127 });
+
+      await provider.startSession(item);
+      for (const handler of exitHandlers[2] ?? []) handler({ exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(proxy.refreshRemoteShellProfile).toHaveBeenCalledTimes(1);
+      expect(openSsh2Pty).toHaveBeenCalledTimes(4);
+      expect(
+        vi.mocked(buildAgentSessionCommand).mock.calls.map(([args]) => args.isResuming)
+      ).toEqual([true, true, false, true]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not refresh the SSH shell profile after explicit stop cancels a missing-command retry', async () => {
     vi.useFakeTimers();
     try {

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -438,7 +438,7 @@ describe('conversation provider respawn state', () => {
     }
   });
 
-  it('does not loop if the replacement exits inside the failure window', async () => {
+  it('starts a local conversation fresh after three resume replacements exit', async () => {
     vi.useFakeTimers();
     try {
       const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
@@ -452,14 +452,15 @@ describe('conversation provider respawn state', () => {
 
       await provider.startSession(item);
 
-      for (const handler of exitHandlers[0] ?? []) handler({ exitCode: 1 });
-      await vi.advanceTimersByTimeAsync(500);
-      expect(spawnLocalPty).toHaveBeenCalledTimes(2);
+      for (let index = 0; index < 4; index += 1) {
+        for (const handler of exitHandlers[index] ?? []) handler({ exitCode: 1 });
+        await vi.advanceTimersByTimeAsync(500);
+      }
 
-      for (const handler of exitHandlers[1] ?? []) handler({ exitCode: 1 });
-      await vi.advanceTimersByTimeAsync(500);
-
-      expect(spawnLocalPty).toHaveBeenCalledTimes(2);
+      expect(spawnLocalPty).toHaveBeenCalledTimes(5);
+      expect(
+        vi.mocked(buildAgentSessionCommand).mock.calls.map(([args]) => args.isResuming)
+      ).toEqual([false, true, true, true, false]);
     } finally {
       vi.useRealTimers();
     }

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -466,6 +466,34 @@ describe('conversation provider respawn state', () => {
     }
   });
 
+  it('starts an SSH conversation fresh after three resume replacements exit', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
+      openSsh2Pty.mockImplementation(() => {
+        const handlers: Array<(info: PtyExitInfo) => void> = [];
+        exitHandlers.push(handlers);
+        return Promise.resolve({ success: true, data: fakePty(handlers) });
+      });
+      const provider = sshProvider();
+      const item = conversation();
+
+      await provider.startSession(item);
+
+      for (let index = 0; index < 4; index += 1) {
+        for (const handler of exitHandlers[index] ?? []) handler({ exitCode: 1 });
+        await vi.advanceTimersByTimeAsync(500);
+      }
+
+      expect(openSsh2Pty).toHaveBeenCalledTimes(5);
+      expect(
+        vi.mocked(buildAgentSessionCommand).mock.calls.map(([args]) => args.isResuming)
+      ).toEqual([false, true, true, true, false]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('does not loop when local replacement spawn fails', async () => {
     vi.useFakeTimers();
     try {

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CONVERSATION_FRESH_RECOVERY_GRACE_MS } from '@main/core/conversations/conversation-session-supervisor';
 import type { Pty, PtyExitInfo } from '@main/core/pty/pty';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import type { Conversation } from '@shared/conversations';
@@ -317,6 +318,65 @@ describe('conversation provider respawn state', () => {
       expect(spawnLocalPty).toHaveBeenCalledTimes(2);
       expect(buildAgentSessionCommand).toHaveBeenLastCalledWith(
         expect.objectContaining({ isResuming: false })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops local recovery when a fresh fallback exits before the startup grace period', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
+      spawnLocalPty.mockImplementation(() => {
+        const handlers: Array<(info: PtyExitInfo) => void> = [];
+        exitHandlers.push(handlers);
+        return fakePty(handlers);
+      });
+      const provider = localProvider();
+      const item = conversation();
+
+      await provider.startSession(item, undefined, true);
+      for (const handler of exitHandlers[0] ?? []) handler({ exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(500);
+      for (const handler of exitHandlers[1] ?? []) handler({ exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(spawnLocalPty).toHaveBeenCalledTimes(2);
+      expect(events.emit).toHaveBeenCalledWith(
+        agentSessionExitedChannel,
+        expect.objectContaining({
+          conversationId: item.id,
+          taskId: item.taskId,
+        })
+      );
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('starts a new local recovery cycle after fresh fallback survives the startup grace period', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<Array<(info: PtyExitInfo) => void>> = [];
+      spawnLocalPty.mockImplementation(() => {
+        const handlers: Array<(info: PtyExitInfo) => void> = [];
+        exitHandlers.push(handlers);
+        return fakePty(handlers);
+      });
+      const provider = localProvider();
+      const item = conversation();
+
+      await provider.startSession(item, undefined, true);
+      for (const handler of exitHandlers[0] ?? []) handler({ exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(500);
+      await vi.advanceTimersByTimeAsync(CONVERSATION_FRESH_RECOVERY_GRACE_MS);
+      for (const handler of exitHandlers[1] ?? []) handler({ exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(spawnLocalPty).toHaveBeenCalledTimes(3);
+      expect(buildAgentSessionCommand).toHaveBeenLastCalledWith(
+        expect.objectContaining({ isResuming: true })
       );
     } finally {
       vi.useRealTimers();

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -723,7 +723,7 @@ describe('conversation provider respawn state', () => {
       expect(openSsh2Pty).toHaveBeenCalledTimes(4);
       expect(
         vi.mocked(buildAgentSessionCommand).mock.calls.map(([args]) => args.isResuming)
-      ).toEqual([true, true, false, true]);
+      ).toEqual([true, false, false, true]);
     } finally {
       vi.useRealTimers();
     }

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -3,7 +3,10 @@ import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
 import { wireAgentClassifier } from '@main/core/agent-hooks/classifier-wiring';
 import { HookConfigWriter } from '@main/core/agent-hooks/hook-config';
 import { workspaceTrustService } from '@main/core/agent-hooks/workspace-trust-service';
-import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
+import {
+  type ConversationSpawnMode,
+  ConversationSessionSupervisor,
+} from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
@@ -110,7 +113,11 @@ export class LocalConversationProvider implements ConversationProvider {
     this.knownSessionIds.add(sessionId);
 
     const spawnSize = ptySessionRegistry.getLastSize(sessionId) ?? initialSize;
-    const spawnToken = this.supervisor.beginStart(sessionId, { requireDesired });
+    const spawnMode: ConversationSpawnMode = isResuming ? 'resume' : 'fresh';
+    const spawnToken = this.supervisor.beginStart(sessionId, {
+      requireDesired,
+      mode: spawnMode,
+    });
     if (!spawnToken) return;
 
     try {
@@ -235,10 +242,6 @@ export class LocalConversationProvider implements ConversationProvider {
           taskId: conversation.taskId,
         });
 
-        if (decision.kind === 'failed') {
-          return;
-        }
-
         if (this.tmux) {
           return;
         }
@@ -247,6 +250,7 @@ export class LocalConversationProvider implements ConversationProvider {
           this.scheduleReplacement({
             conversation,
             initialSize: replacementSize,
+            mode: decision.mode,
           });
         }
       });
@@ -386,12 +390,20 @@ export class LocalConversationProvider implements ConversationProvider {
   private scheduleReplacement({
     conversation,
     initialSize,
+    mode,
   }: {
     conversation: Conversation;
     initialSize: { cols: number; rows: number };
+    mode: ConversationSpawnMode;
   }): void {
     setTimeout(() => {
-      this.startSessionInternal(conversation, initialSize, true, undefined, true).catch((e) => {
+      this.startSessionInternal(
+        conversation,
+        initialSize,
+        mode === 'resume',
+        undefined,
+        true
+      ).catch((e) => {
         log.error('LocalConversationProvider: replacement failed', {
           conversationId: conversation.id,
           error: String(e),

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -3,10 +3,7 @@ import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
 import { wireAgentClassifier } from '@main/core/agent-hooks/classifier-wiring';
 import { HookConfigWriter } from '@main/core/agent-hooks/hook-config';
 import { workspaceTrustService } from '@main/core/agent-hooks/workspace-trust-service';
-import {
-  type ConversationSpawnMode,
-  ConversationSessionSupervisor,
-} from '@main/core/conversations/conversation-session-supervisor';
+import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
@@ -113,10 +110,9 @@ export class LocalConversationProvider implements ConversationProvider {
     this.knownSessionIds.add(sessionId);
 
     const spawnSize = ptySessionRegistry.getLastSize(sessionId) ?? initialSize;
-    const spawnMode: ConversationSpawnMode = isResuming ? 'resume' : 'fresh';
     const spawnToken = this.supervisor.beginStart(sessionId, {
       requireDesired,
-      mode: spawnMode,
+      mode: isResuming ? 'resume' : 'fresh',
     });
     if (!spawnToken) return;
 
@@ -250,7 +246,7 @@ export class LocalConversationProvider implements ConversationProvider {
           this.scheduleReplacement({
             conversation,
             initialSize: replacementSize,
-            mode: decision.mode,
+            isResuming: decision.kind === 'respawnResume',
           });
         }
       });
@@ -390,25 +386,21 @@ export class LocalConversationProvider implements ConversationProvider {
   private scheduleReplacement({
     conversation,
     initialSize,
-    mode,
+    isResuming,
   }: {
     conversation: Conversation;
     initialSize: { cols: number; rows: number };
-    mode: ConversationSpawnMode;
+    isResuming: boolean;
   }): void {
     setTimeout(() => {
-      this.startSessionInternal(
-        conversation,
-        initialSize,
-        mode === 'resume',
-        undefined,
-        true
-      ).catch((e) => {
-        log.error('LocalConversationProvider: replacement failed', {
-          conversationId: conversation.id,
-          error: String(e),
-        });
-      });
+      this.startSessionInternal(conversation, initialSize, isResuming, undefined, true).catch(
+        (e) => {
+          log.error('LocalConversationProvider: replacement failed', {
+            conversationId: conversation.id,
+            error: String(e),
+          });
+        }
+      );
     }, RESPAWN_DELAY_MS);
   }
 }

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -228,6 +228,7 @@ export class SshConversationProvider implements ConversationProvider {
         }
 
         if (options.shellRefreshRetried && exitCode === 127) {
+          this.supervisor.stop(sessionId);
           events.emit(agentSessionExitedChannel, {
             conversationId: conversation.id,
             taskId: conversation.taskId,

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -1,9 +1,6 @@
 import { wireAgentClassifier } from '@main/core/agent-hooks/classifier-wiring';
 import { workspaceTrustService } from '@main/core/agent-hooks/workspace-trust-service';
-import {
-  type ConversationSpawnMode,
-  ConversationSessionSupervisor,
-} from '@main/core/conversations/conversation-session-supervisor';
+import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
@@ -103,10 +100,9 @@ export class SshConversationProvider implements ConversationProvider {
     this.knownSessionIds.add(sessionId);
 
     const spawnSize = ptySessionRegistry.getLastSize(sessionId) ?? initialSize;
-    const spawnMode: ConversationSpawnMode = isResuming ? 'resume' : 'fresh';
     const spawnToken = this.supervisor.beginStart(sessionId, {
       requireDesired,
-      mode: spawnMode,
+      mode: isResuming ? 'resume' : 'fresh',
     });
     if (!spawnToken) return;
 
@@ -240,7 +236,7 @@ export class SshConversationProvider implements ConversationProvider {
           this.scheduleReplacement({
             conversation,
             initialSize: replacementSize,
-            mode: decision.mode,
+            isResuming: decision.kind === 'respawnResume',
           });
         }
       });
@@ -391,14 +387,14 @@ export class SshConversationProvider implements ConversationProvider {
   private scheduleReplacement({
     conversation,
     initialSize,
-    mode,
+    isResuming,
   }: {
     conversation: Conversation;
     initialSize: { cols: number; rows: number };
-    mode: ConversationSpawnMode;
+    isResuming: boolean;
   }): void {
     setTimeout(() => {
-      this.startSessionInternal(conversation, initialSize, mode === 'resume', undefined, true, {
+      this.startSessionInternal(conversation, initialSize, isResuming, undefined, true, {
         shellRefreshRetried: false,
       }).catch((e) => {
         log.error('SshConversationProvider: replacement failed', {

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -200,6 +200,14 @@ export class SshConversationProvider implements ConversationProvider {
         this.sessions.delete(sessionId);
         if (decision.kind === 'stopped') return;
 
+        if (decision.kind === 'failed') {
+          events.emit(agentSessionExitedChannel, {
+            conversationId: conversation.id,
+            taskId: conversation.taskId,
+          });
+          return;
+        }
+
         if (this.tmux) {
           events.emit(agentSessionExitedChannel, {
             conversationId: conversation.id,

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -221,7 +221,7 @@ export class SshConversationProvider implements ConversationProvider {
             conversation,
             sessionId,
             initialSize: replacementSize,
-            isResuming,
+            isResuming: decision.kind === 'respawnResume',
             initialPrompt,
           });
           return;

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -1,6 +1,9 @@
 import { wireAgentClassifier } from '@main/core/agent-hooks/classifier-wiring';
 import { workspaceTrustService } from '@main/core/agent-hooks/workspace-trust-service';
-import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
+import {
+  type ConversationSpawnMode,
+  ConversationSessionSupervisor,
+} from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import type { IExecutionContext } from '@main/core/execution-context/types';
@@ -100,7 +103,11 @@ export class SshConversationProvider implements ConversationProvider {
     this.knownSessionIds.add(sessionId);
 
     const spawnSize = ptySessionRegistry.getLastSize(sessionId) ?? initialSize;
-    const spawnToken = this.supervisor.beginStart(sessionId, { requireDesired });
+    const spawnMode: ConversationSpawnMode = isResuming ? 'resume' : 'fresh';
+    const spawnToken = this.supervisor.beginStart(sessionId, {
+      requireDesired,
+      mode: spawnMode,
+    });
     if (!spawnToken) return;
 
     try {
@@ -197,14 +204,6 @@ export class SshConversationProvider implements ConversationProvider {
         this.sessions.delete(sessionId);
         if (decision.kind === 'stopped') return;
 
-        if (decision.kind === 'failed') {
-          events.emit(agentSessionExitedChannel, {
-            conversationId: conversation.id,
-            taskId: conversation.taskId,
-          });
-          return;
-        }
-
         if (this.tmux) {
           events.emit(agentSessionExitedChannel, {
             conversationId: conversation.id,
@@ -224,6 +223,14 @@ export class SshConversationProvider implements ConversationProvider {
           return;
         }
 
+        if (options.shellRefreshRetried && exitCode === 127) {
+          events.emit(agentSessionExitedChannel, {
+            conversationId: conversation.id,
+            taskId: conversation.taskId,
+          });
+          return;
+        }
+
         events.emit(agentSessionExitedChannel, {
           conversationId: conversation.id,
           taskId: conversation.taskId,
@@ -233,6 +240,7 @@ export class SshConversationProvider implements ConversationProvider {
           this.scheduleReplacement({
             conversation,
             initialSize: replacementSize,
+            mode: decision.mode,
           });
         }
       });
@@ -383,12 +391,14 @@ export class SshConversationProvider implements ConversationProvider {
   private scheduleReplacement({
     conversation,
     initialSize,
+    mode,
   }: {
     conversation: Conversation;
     initialSize: { cols: number; rows: number };
+    mode: ConversationSpawnMode;
   }): void {
     setTimeout(() => {
-      this.startSessionInternal(conversation, initialSize, true, undefined, true, {
+      this.startSessionInternal(conversation, initialSize, mode === 'resume', undefined, true, {
         shellRefreshRetried: false,
       }).catch((e) => {
         log.error('SshConversationProvider: replacement failed', {

--- a/src/main/core/pty/pty-session-registry.test.ts
+++ b/src/main/core/pty/pty-session-registry.test.ts
@@ -150,15 +150,26 @@ describe('PtySessionRegistry', () => {
     expect(registry.getLastSize('session-1')).toBeUndefined();
   });
 
-  it('emits a monotonically increasing epoch for every registered PTY', () => {
+  it('emits a start event for every registered PTY', () => {
     const registry = new PtySessionRegistry();
 
     registry.register('session-1', fakePty());
     registry.register('session-1', fakePty());
     registry.register('session-2', fakePty());
 
-    expect(events.emit).toHaveBeenCalledWith(ptyStartedChannel, { id: 'session-1', epoch: 1 });
-    expect(events.emit).toHaveBeenCalledWith(ptyStartedChannel, { id: 'session-1', epoch: 2 });
-    expect(events.emit).toHaveBeenCalledWith(ptyStartedChannel, { id: 'session-2', epoch: 3 });
+    expect(events.emit).toHaveBeenCalledWith(ptyStartedChannel, { id: 'session-1' });
+    expect(events.emit).toHaveBeenCalledWith(ptyStartedChannel, { id: 'session-2' });
+    expect(
+      vi
+        .mocked(events.emit)
+        .mock.calls.filter(
+          ([channel, event]) =>
+            channel === ptyStartedChannel &&
+            typeof event === 'object' &&
+            event !== null &&
+            'id' in event &&
+            event.id === 'session-1'
+        )
+    ).toHaveLength(2);
   });
 });

--- a/src/main/core/pty/pty-session-registry.ts
+++ b/src/main/core/pty/pty-session-registry.ts
@@ -21,7 +21,6 @@ export class PtySessionRegistry {
   private metadata: Map<string, PtySessionMetadata> = new Map();
   private lastSizes: Map<string, { cols: number; rows: number }> = new Map();
   private pendingFlushes: Map<string, () => void> = new Map();
-  private epoch = 0;
 
   register(
     sessionId: string,
@@ -40,8 +39,6 @@ export class PtySessionRegistry {
     if (options?.metadata) this.metadata.set(sessionId, options.metadata);
 
     this.ptyMap.set(sessionId, pty);
-    this.epoch += 1;
-    const epoch = this.epoch;
 
     let buffer = '';
     let flushTimer: ReturnType<typeof setTimeout> | null = null;
@@ -103,7 +100,7 @@ export class PtySessionRegistry {
     );
 
     this.ptyInputSubscriptions.set(sessionId, off);
-    events.emit(ptyStartedChannel, { id: sessionId, epoch });
+    events.emit(ptyStartedChannel, { id: sessionId });
   }
 
   unregister(sessionId: string, options: { pty?: Pty; exitInfo?: PtyExitInfo } = {}): void {

--- a/src/renderer/features/tasks/conversations/conversation-manager.ts
+++ b/src/renderer/features/tasks/conversations/conversation-manager.ts
@@ -287,7 +287,8 @@ export class ConversationManagerStore implements IDisposable {
       makePtySessionId(conversation.projectId, conversation.taskId, conversation.id),
       undefined,
       handlers.onOpenFile,
-      handlers.onOpenExternal
+      handlers.onOpenExternal,
+      { clearOnBackendStart: true }
     );
   }
 }

--- a/src/renderer/features/tasks/stores/lifecycle-scripts.ts
+++ b/src/renderer/features/tasks/stores/lifecycle-scripts.ts
@@ -47,8 +47,7 @@ export class LifecycleScriptStore {
           type: data.type,
         }),
       undefined,
-      undefined,
-      { replaceFrontendOnBackendStart: false }
+      undefined
     );
     this.offStatus = events.on(lifecycleScriptStatusChannel, (event) => {
       if (

--- a/src/renderer/features/tasks/terminals/terminal-manager.ts
+++ b/src/renderer/features/tasks/terminals/terminal-manager.ts
@@ -191,8 +191,7 @@ export class TerminalManagerStore implements IDisposable {
       makePtySessionId(terminal.projectId, terminal.taskId, terminal.id),
       () => this.hydrateTerminal(terminal.id),
       handlers.onOpenFile,
-      handlers.onOpenExternal,
-      { replaceFrontendOnBackendStart: false }
+      handlers.onOpenExternal
     );
   }
 }

--- a/src/renderer/lib/pty/pty-session.test.ts
+++ b/src/renderer/lib/pty/pty-session.test.ts
@@ -209,4 +209,29 @@ describe('PtySession', () => {
     expect(session.pty).toBe(initialPty);
     expect(session.status).toBe('ready');
   });
+
+  it('does not clear when multiple backend starts arrive during initial connect', async () => {
+    const firstConnect = deferred<void>();
+    frontendConnect.mockReturnValueOnce(firstConnect.promise);
+
+    const session = new PtySession('session-1', undefined, undefined, undefined, {
+      clearOnBackendStart: true,
+    });
+    const firstConnectPromise = session.connect();
+    await Promise.resolve();
+    expect(session.status).toBe('connecting');
+
+    for (const listener of ptyStartedListeners()) listener({ id: 'session-1' });
+    for (const listener of ptyStartedListeners()) listener({ id: 'session-1' });
+    await Promise.resolve();
+
+    expect(frontendClear).not.toHaveBeenCalled();
+
+    firstConnect.resolve();
+    await firstConnectPromise;
+    expect(session.status).toBe('ready');
+
+    for (const listener of ptyStartedListeners()) listener({ id: 'session-1' });
+    expect(frontendClear).toHaveBeenCalledTimes(1);
+  });
 });

--- a/src/renderer/lib/pty/pty-session.test.ts
+++ b/src/renderer/lib/pty/pty-session.test.ts
@@ -137,6 +137,31 @@ describe('PtySession', () => {
     expect(session.status).toBe('ready');
   });
 
+  it('treats the first backend start after dispose and reconnect as initial', async () => {
+    const reconnect = deferred<void>();
+    frontendConnect.mockResolvedValueOnce(undefined).mockReturnValueOnce(reconnect.promise);
+    const session = new PtySession('session-1', undefined, undefined, undefined, {
+      clearOnBackendStart: true,
+    });
+
+    await session.connect();
+    session.dispose();
+    const reconnectPromise = session.connect();
+    await Promise.resolve();
+
+    for (const listener of ptyStartedListeners()) {
+      listener({ id: 'session-1' });
+    }
+
+    expect(frontendClear).not.toHaveBeenCalled();
+    expect(frontendDispose).toHaveBeenCalledTimes(1);
+    expect(frontendInstances).toHaveLength(2);
+
+    reconnect.resolve();
+    await reconnectPromise;
+    expect(session.status).toBe('ready');
+  });
+
   it('does not recreate for the first backend start that arrives during initial connect', async () => {
     const connect = deferred<void>();
     frontendConnect.mockReturnValue(connect.promise);

--- a/src/renderer/lib/pty/pty-session.test.ts
+++ b/src/renderer/lib/pty/pty-session.test.ts
@@ -4,6 +4,7 @@ import { ptyStartedChannel } from '@shared/events/appEvents';
 import { PtySession } from './pty-session';
 
 const frontendConnect = vi.hoisted(() => vi.fn());
+const frontendClear = vi.hoisted(() => vi.fn());
 const frontendDispose = vi.hoisted(() => vi.fn());
 const frontendInstances = vi.hoisted(() => [] as Array<{ sessionId: string }>);
 const frontendConnectedSessionIds = vi.hoisted(() => [] as string[]);
@@ -24,6 +25,7 @@ vi.mock('@renderer/lib/pty/pty', () => ({
       frontendConnectedSessionIds.push(this.sessionId);
       return frontendConnect();
     };
+    clear = frontendClear;
     dispose = frontendDispose;
   },
 }));
@@ -42,12 +44,13 @@ function ptyStartedListeners() {
   return vi
     .mocked(events.on)
     .mock.calls.filter(([channel]) => channel === ptyStartedChannel)
-    .map(([, listener]) => listener as (event: { id: string; epoch: number }) => void);
+    .map(([, listener]) => listener as (event: { id: string }) => void);
 }
 
 describe('PtySession', () => {
   beforeEach(() => {
     frontendConnect.mockReset();
+    frontendClear.mockReset();
     frontendDispose.mockReset();
     frontendInstances.length = 0;
     frontendConnectedSessionIds.length = 0;
@@ -91,7 +94,7 @@ describe('PtySession', () => {
     expect(offPtyStarted).toHaveBeenCalledTimes(1);
   });
 
-  it('recreates the frontend PTY when the backend starts a newer epoch for the session', async () => {
+  it('keeps the frontend PTY when the backend starts again for the session', async () => {
     frontendConnect.mockResolvedValue(undefined);
     const session = new PtySession('session-1');
 
@@ -100,28 +103,7 @@ describe('PtySession', () => {
     expect(initialPty).not.toBeNull();
 
     for (const listener of ptyStartedListeners()) {
-      listener({ id: 'session-1', epoch: 2 });
-    }
-    await Promise.resolve();
-
-    expect(frontendDispose).toHaveBeenCalledTimes(1);
-    expect(frontendInstances).toHaveLength(2);
-    expect(session.pty).not.toBe(initialPty);
-    expect(session.status).toBe('ready');
-  });
-
-  it('keeps the frontend PTY when backend replacement is configured to preserve scrollback', async () => {
-    frontendConnect.mockResolvedValue(undefined);
-    const session = new PtySession('session-1', undefined, undefined, undefined, {
-      replaceFrontendOnBackendStart: false,
-    });
-
-    await session.connect();
-    const initialPty = session.pty;
-    expect(initialPty).not.toBeNull();
-
-    for (const listener of ptyStartedListeners()) {
-      listener({ id: 'session-1', epoch: 2 });
+      listener({ id: 'session-1' });
     }
     await Promise.resolve();
 
@@ -133,7 +115,29 @@ describe('PtySession', () => {
     expect(session.status).toBe('ready');
   });
 
-  it('does not recreate for the first backend epoch that arrives during initial connect', async () => {
+  it('clears the frontend PTY when backend replacement is configured to preserve the instance', async () => {
+    frontendConnect.mockResolvedValue(undefined);
+    const session = new PtySession('session-1', undefined, undefined, undefined, {
+      clearOnBackendStart: true,
+    });
+
+    await session.connect();
+    const initialPty = session.pty;
+    expect(initialPty).not.toBeNull();
+
+    for (const listener of ptyStartedListeners()) {
+      listener({ id: 'session-1' });
+    }
+    await Promise.resolve();
+
+    expect(frontendClear).toHaveBeenCalledTimes(1);
+    expect(frontendDispose).not.toHaveBeenCalled();
+    expect(frontendInstances).toHaveLength(1);
+    expect(session.pty).toBe(initialPty);
+    expect(session.status).toBe('ready');
+  });
+
+  it('does not recreate for the first backend start that arrives during initial connect', async () => {
     const connect = deferred<void>();
     frontendConnect.mockReturnValue(connect.promise);
 
@@ -143,7 +147,7 @@ describe('PtySession', () => {
     const initialPty = session.pty;
 
     for (const listener of ptyStartedListeners()) {
-      listener({ id: 'session-1', epoch: 42 });
+      listener({ id: 'session-1' });
     }
     await Promise.resolve();
 
@@ -156,12 +160,9 @@ describe('PtySession', () => {
     expect(session.status).toBe('ready');
   });
 
-  it('lets backend replacement win over an in-flight connect for an older frontend PTY', async () => {
+  it('does not recreate when multiple backend starts arrive during initial connect', async () => {
     const firstConnect = deferred<void>();
-    const secondConnect = deferred<void>();
-    frontendConnect
-      .mockReturnValueOnce(firstConnect.promise)
-      .mockReturnValueOnce(secondConnect.promise);
+    frontendConnect.mockReturnValueOnce(firstConnect.promise);
 
     const session = new PtySession('session-1');
     const firstConnectPromise = session.connect();
@@ -170,21 +171,17 @@ describe('PtySession', () => {
     expect(initialPty).not.toBeNull();
     expect(session.status).toBe('connecting');
 
-    for (const listener of ptyStartedListeners()) listener({ id: 'session-1', epoch: 42 });
-    for (const listener of ptyStartedListeners()) listener({ id: 'session-1', epoch: 43 });
+    for (const listener of ptyStartedListeners()) listener({ id: 'session-1' });
+    for (const listener of ptyStartedListeners()) listener({ id: 'session-1' });
     await Promise.resolve();
-    const replacementPty = session.pty;
-    expect(replacementPty).not.toBe(initialPty);
-    expect(frontendDispose).toHaveBeenCalledTimes(1);
+
+    expect(frontendDispose).not.toHaveBeenCalled();
+    expect(frontendInstances).toHaveLength(1);
+    expect(session.pty).toBe(initialPty);
 
     firstConnect.resolve();
     await firstConnectPromise;
-    expect(session.pty).toBe(replacementPty);
-    expect(session.status).toBe('connecting');
-
-    secondConnect.resolve();
-    await Promise.resolve();
-    expect(session.pty).toBe(replacementPty);
+    expect(session.pty).toBe(initialPty);
     expect(session.status).toBe('ready');
   });
 });

--- a/src/renderer/lib/pty/pty-session.ts
+++ b/src/renderer/lib/pty/pty-session.ts
@@ -71,6 +71,7 @@ export class PtySession {
   dispose() {
     this.version++;
     this.pty?.dispose();
+    this.hasSeenBackendStart = false;
     runInAction(() => {
       this.pty = null;
       this.status = 'disconnected';

--- a/src/renderer/lib/pty/pty-session.ts
+++ b/src/renderer/lib/pty/pty-session.ts
@@ -6,7 +6,7 @@ import { ptyStartedChannel } from '@shared/events/appEvents';
 export type PtySessionStatus = 'disconnected' | 'connecting' | 'ready';
 
 export type PtySessionOptions = {
-  replaceFrontendOnBackendStart?: boolean;
+  clearOnBackendStart?: boolean;
 };
 
 export class PtySession {
@@ -14,9 +14,9 @@ export class PtySession {
   status: PtySessionStatus = 'disconnected';
   private connectPromise: Promise<void> | null = null;
   private version = 0;
-  private lastSeenEpoch = 0;
+  private hasSeenBackendStart = false;
   private offPtyStarted: (() => void) | null = null;
-  private readonly replaceFrontendOnBackendStart: boolean;
+  private readonly clearOnBackendStart: boolean;
 
   constructor(
     readonly sessionId: string,
@@ -25,13 +25,13 @@ export class PtySession {
     private readonly onOpenExternal?: (filePath: string) => void,
     options: PtySessionOptions = {}
   ) {
-    this.replaceFrontendOnBackendStart = options.replaceFrontendOnBackendStart ?? true;
+    this.clearOnBackendStart = options.clearOnBackendStart ?? false;
     makeAutoObservable(this, {
       pty: false,
     });
     this.offPtyStarted = events.on(ptyStartedChannel, (event) => {
       if (event.id !== this.sessionId) return;
-      void this.handleBackendStarted(event.epoch);
+      this.handleBackendStarted();
     });
     // Lazy connect: auto-connects the first time any observer reads status.
     // Sessions are created at data-load time without connecting; this fires
@@ -57,7 +57,7 @@ export class PtySession {
       });
       await pty.connect();
       if (version !== this.version || this.pty !== pty) return;
-      if (this.lastSeenEpoch === 0) this.lastSeenEpoch = 1;
+      this.hasSeenBackendStart = true;
       runInAction(() => {
         this.status = 'ready';
       });
@@ -83,46 +83,12 @@ export class PtySession {
     this.offPtyStarted = null;
   }
 
-  private async handleBackendStarted(epoch: number): Promise<void> {
-    if (epoch <= this.lastSeenEpoch) return;
-    if (this.lastSeenEpoch === 0 && (this.status === 'connecting' || this.pty === null)) {
-      this.lastSeenEpoch = epoch;
-      return;
-    }
-    if (!this.pty && this.status === 'disconnected') {
-      this.lastSeenEpoch = epoch;
+  private handleBackendStarted(): void {
+    if (!this.hasSeenBackendStart) {
+      this.hasSeenBackendStart = true;
       return;
     }
 
-    this.lastSeenEpoch = epoch;
-    if (!this.replaceFrontendOnBackendStart) return;
-
-    this.version++;
-    this.connectPromise = null;
-    this.pty?.dispose();
-
-    const version = this.version;
-    const pty = new FrontendPty(this.sessionId, undefined, this.onOpenFile, this.onOpenExternal);
-    runInAction(() => {
-      this.pty = pty;
-      this.status = 'connecting';
-    });
-
-    try {
-      await pty.connect();
-      if (version === this.version && this.pty === pty) {
-        runInAction(() => {
-          this.status = 'ready';
-        });
-      }
-    } catch {
-      if (version === this.version && this.pty === pty) {
-        pty.dispose();
-        runInAction(() => {
-          this.pty = null;
-          this.status = 'disconnected';
-        });
-      }
-    }
+    if (this.clearOnBackendStart) this.pty?.clear();
   }
 }

--- a/src/renderer/lib/pty/pty-session.ts
+++ b/src/renderer/lib/pty/pty-session.ts
@@ -85,6 +85,8 @@ export class PtySession {
   }
 
   private handleBackendStarted(): void {
+    if (this.status !== 'ready') return;
+
     if (!this.hasSeenBackendStart) {
       this.hasSeenBackendStart = true;
       return;

--- a/src/renderer/lib/pty/pty.ts
+++ b/src/renderer/lib/pty/pty.ts
@@ -146,6 +146,11 @@ export class FrontendPty {
     this.terminal.options.theme = buildTheme(this.theme);
   }
 
+  clear(): void {
+    this.terminal.clear();
+    this.terminal.clearSelection();
+  }
+
   /**
    * Subscribe to the session: fetches the ring buffer from the main process,
    * writes it directly to xterm, then sets up a live IPC listener for future

--- a/src/shared/events/appEvents.ts
+++ b/src/shared/events/appEvents.ts
@@ -28,7 +28,6 @@ export const notificationFocusTaskChannel = defineEvent<{
 
 export const ptyStartedChannel = defineEvent<{
   id: string;
-  epoch: number;
 }>('pty:started');
 
 export type PlanEvent = {


### PR DESCRIPTION
  - replaces broad respawn window heuristics with explicit fresh and resume supervisor decisions
  - keeps /exit and ctrl+c on the automatic recovery path so exited agents come back by design
  - falls back from resume to fresh after one failed resume attempt to handle missing or invalid provider sessions
  - treats fresh fallback as recovered after a short startup grace period so later exits start a new recovery cycle
  - stops recovery when fresh fallback exits before the grace period to avoid endless loops for broken commands or missing binaries
  - preserves frontend ptys on backend restart and clears conversation scrollback in place to avoid flicker
  - resets PtySession backend-start tracking on dispose so reconnects keep first-start semantics
  - emits the ssh session-exited event before missing-command retry handling when recovery has already failed