### PR TITLE
fix(byoi): support explicit ssh agent forwarding

### DIFF
--- a/src/main/core/workspaces/byoi/byoi-ssh-connect-config.test.ts
+++ b/src/main/core/workspaces/byoi/byoi-ssh-connect-config.test.ts
@@ -1,0 +1,234 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBYOISshConnectConfig,
+  resolveBYOIForwardAgentEnabled,
+  resolveBYOISshConnectConfig,
+} from './byoi-ssh-connect-config';
+
+describe('buildBYOISshConnectConfig', () => {
+  it('forwards the local SSH agent for BYOI task connections', () => {
+    const config = buildBYOISshConnectConfig({
+      output: {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+        port: 2222,
+        username: 'alice',
+        forwardAgent: true,
+      },
+      forwardAgent: true,
+      sshAuthSock: '/tmp/ssh-agent.sock',
+    });
+
+    expect(config).toMatchObject({
+      host: 'remote.example.com',
+      port: 2222,
+      username: 'alice',
+      agent: '/tmp/ssh-agent.sock',
+      agentForward: true,
+    });
+  });
+
+  it('still forwards the local SSH agent when the BYOI host also uses password auth', () => {
+    const config = buildBYOISshConnectConfig({
+      output: {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+        password: 'secret',
+      },
+      forwardAgent: true,
+      sshAuthSock: '/tmp/ssh-agent.sock',
+    });
+
+    expect(config).toMatchObject({
+      host: 'remote.example.com',
+      port: 22,
+      password: 'secret',
+      agent: '/tmp/ssh-agent.sock',
+      agentForward: true,
+    });
+  });
+
+  it('does not request agent forwarding when no local SSH agent socket is available', () => {
+    expect(() =>
+      buildBYOISshConnectConfig({
+        output: {
+          id: 'workspace-1',
+          host: 'remote.example.com',
+        },
+        forwardAgent: true,
+        sshAuthSock: null,
+      })
+    ).toThrow('BYOI requested SSH agent forwarding');
+  });
+
+  it('preserves SSH agent authentication for passwordless BYOI without forwarding', () => {
+    const config = buildBYOISshConnectConfig({
+      output: {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+      },
+      forwardAgent: false,
+      sshAuthSock: '/tmp/ssh-agent.sock',
+    });
+
+    expect(config.agent).toBe('/tmp/ssh-agent.sock');
+    expect(config.agentForward).toBeUndefined();
+  });
+
+  it('allows password auth without an SSH agent when forwarding is disabled', () => {
+    const config = buildBYOISshConnectConfig({
+      output: {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+        password: 'secret',
+      },
+      forwardAgent: false,
+      sshAuthSock: null,
+    });
+
+    expect(config.password).toBe('secret');
+    expect(config.agent).toBeUndefined();
+    expect(config.agentForward).toBeUndefined();
+  });
+
+  it('splits user-qualified hosts for ssh2 connection config', () => {
+    const config = buildBYOISshConnectConfig({
+      output: {
+        id: 'workspace-1',
+        host: 'alice@remote.example.com',
+      },
+      forwardAgent: false,
+      sshAuthSock: null,
+    });
+
+    expect(config.host).toBe('remote.example.com');
+    expect(config.username).toBe('alice');
+  });
+
+  it('lets explicit username override a user-qualified host prefix', () => {
+    const config = buildBYOISshConnectConfig({
+      output: {
+        id: 'workspace-1',
+        host: 'alice@remote.example.com',
+        username: 'bob',
+      },
+      forwardAgent: false,
+      sshAuthSock: null,
+    });
+
+    expect(config.host).toBe('remote.example.com');
+    expect(config.username).toBe('bob');
+  });
+});
+
+describe('BYOI SSH agent forwarding resolution', () => {
+  it('enables forwarding from explicit provision output', () => {
+    const forwardAgent = resolveBYOIForwardAgentEnabled({
+      id: 'workspace-1',
+      host: 'remote.example.com',
+      forwardAgent: true,
+    });
+
+    expect(forwardAgent).toBe(true);
+  });
+
+  it('disables forwarding from explicit provision output', () => {
+    const forwardAgent = resolveBYOIForwardAgentEnabled({
+      id: 'workspace-1',
+      host: 'remote.example.com',
+      forwardAgent: false,
+    });
+
+    expect(forwardAgent).toBe(false);
+  });
+
+  it('treats omitted forwarding as disabled', () => {
+    const forwardAgent = resolveBYOIForwardAgentEnabled({
+      id: 'workspace-1',
+      host: 'remote.example.com',
+    });
+
+    expect(forwardAgent).toBe(false);
+  });
+
+  it('uses injected env for explicit provision output forwarding', () => {
+    const config = resolveBYOISshConnectConfig(
+      {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+        forwardAgent: true,
+      },
+      {
+        env: { SSH_AUTH_SOCK: '/tmp/injected-agent.sock' },
+      }
+    );
+
+    expect(config).toMatchObject({
+      agent: '/tmp/injected-agent.sock',
+      agentForward: true,
+    });
+  });
+
+  it('does not fall back to process env when explicit forwarding uses injected env without a socket', () => {
+    expect(() =>
+      resolveBYOISshConnectConfig(
+        {
+          id: 'workspace-1',
+          host: 'remote.example.com',
+          forwardAgent: true,
+        },
+        {
+          env: {},
+        }
+      )
+    ).toThrow('BYOI requested SSH agent forwarding');
+  });
+
+  it('does not fall back to process env when explicit disabled forwarding uses injected env without a socket', () => {
+    const config = resolveBYOISshConnectConfig(
+      {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+        forwardAgent: false,
+      },
+      {
+        env: {},
+      }
+    );
+
+    expect(config.agent).toBeUndefined();
+    expect(config.agentForward).toBeUndefined();
+  });
+
+  it('preserves injected SSH agent auth when forwarding is omitted', () => {
+    const config = resolveBYOISshConnectConfig(
+      {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+      },
+      {
+        env: { SSH_AUTH_SOCK: '/tmp/injected-agent.sock' },
+      }
+    );
+
+    expect(config).toMatchObject({
+      agent: '/tmp/injected-agent.sock',
+    });
+    expect(config.agentForward).toBeUndefined();
+  });
+
+  it('does not fall back to process env when omitted forwarding uses injected env without a socket', () => {
+    const config = resolveBYOISshConnectConfig(
+      {
+        id: 'workspace-1',
+        host: 'remote.example.com',
+      },
+      {
+        env: {},
+      }
+    );
+
+    expect(config.agent).toBeUndefined();
+    expect(config.agentForward).toBeUndefined();
+  });
+});

--- a/src/main/core/workspaces/byoi/byoi-ssh-connect-config.ts
+++ b/src/main/core/workspaces/byoi/byoi-ssh-connect-config.ts
@@ -1,0 +1,94 @@
+import type { ConnectConfig } from 'ssh2';
+import { detectSshAuthSock } from '@main/utils/shellEnv';
+import type { ProvisionOutput } from './provision-output';
+
+type BYOIForwardAgentOptions = {
+  env?: Record<string, string | undefined>;
+};
+
+function splitUserQualifiedHost(host: string): { host: string; username?: string } {
+  const atIndex = host.lastIndexOf('@');
+  if (atIndex <= 0 || atIndex === host.length - 1) {
+    return { host };
+  }
+  return {
+    host: host.slice(atIndex + 1),
+    username: host.slice(0, atIndex),
+  };
+}
+
+export interface BYOIForwardAgentResolution {
+  enabled: boolean;
+  sshAuthSock?: string | null;
+}
+
+export function resolveBYOIForwardAgent(
+  output: ProvisionOutput,
+  options: BYOIForwardAgentOptions = {}
+): BYOIForwardAgentResolution {
+  const enabled = output.forwardAgent === true;
+  const sshAuthSock =
+    options.env !== undefined
+      ? (options.env.SSH_AUTH_SOCK ?? null)
+      : enabled
+        ? (detectSshAuthSock() ?? null)
+        : undefined;
+
+  return {
+    enabled,
+    sshAuthSock,
+  };
+}
+
+export function buildBYOISshConnectConfig({
+  output,
+  forwardAgent,
+  sshAuthSock = detectSshAuthSock(),
+}: {
+  output: ProvisionOutput;
+  forwardAgent: boolean;
+  sshAuthSock?: string | null | undefined;
+}): ConnectConfig {
+  const host = splitUserQualifiedHost(output.host);
+  const config: ConnectConfig = {
+    host: host.host,
+    port: output.port ?? 22,
+    username: output.username ?? host.username ?? process.env['USER'],
+  };
+
+  if (output.password) {
+    config.password = output.password;
+  }
+
+  if (sshAuthSock && (!output.password || forwardAgent)) {
+    config.agent = sshAuthSock;
+  }
+
+  if (forwardAgent) {
+    if (!sshAuthSock) {
+      throw new Error('BYOI requested SSH agent forwarding, but no SSH agent socket is available');
+    }
+    config.agentForward = true;
+  }
+
+  return config;
+}
+
+export function resolveBYOISshConnectConfig(
+  output: ProvisionOutput,
+  options: BYOIForwardAgentOptions = {}
+): ConnectConfig {
+  const forwardAgent = resolveBYOIForwardAgent(output, options);
+  return buildBYOISshConnectConfig({
+    output,
+    forwardAgent: forwardAgent.enabled,
+    sshAuthSock: forwardAgent.sshAuthSock,
+  });
+}
+
+export function resolveBYOIForwardAgentEnabled(
+  output: ProvisionOutput,
+  options: BYOIForwardAgentOptions = {}
+): boolean {
+  return resolveBYOIForwardAgent(output, options).enabled;
+}

--- a/src/main/core/workspaces/byoi/provision-byoi-task.ts
+++ b/src/main/core/workspaces/byoi/provision-byoi-task.ts
@@ -2,6 +2,7 @@ import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { ProjectSettingsProvider } from '@main/core/projects/settings/provider';
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
 import { buildTaskFromWorkspace, emitTaskProvisionProgress } from '@main/core/tasks/task-builder';
+import { resolveBYOISshConnectConfig } from '@main/core/workspaces/byoi/byoi-ssh-connect-config';
 import { parseProvisionOutput } from '@main/core/workspaces/byoi/provision-output';
 import type { WorkspaceBootstrapResult } from '@main/core/workspaces/workspace-bootstrap-service';
 import { createWorkspaceFactory } from '@main/core/workspaces/workspace-factory';
@@ -59,12 +60,10 @@ export async function provisionBYOITask(
   });
 
   const connectionId = `task:${task.id}`;
-  const proxy = await sshConnectionManager.connectFromConfig(connectionId, {
-    host: output.host,
-    port: output.port ?? 22,
-    username: output.username ?? process.env['USER'],
-    ...(output.password ? { password: output.password } : { agent: process.env['SSH_AUTH_SOCK'] }),
-  });
+  const proxy = await sshConnectionManager.connectFromConfig(
+    connectionId,
+    resolveBYOISshConnectConfig(output)
+  );
 
   emitTaskProvisionProgress({
     taskId: task.id,

--- a/src/main/core/workspaces/byoi/provision-output.test.ts
+++ b/src/main/core/workspaces/byoi/provision-output.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { parseProvisionOutput } from './provision-output';
+
+describe('parseProvisionOutput', () => {
+  it('accepts explicit BYOI SSH agent forwarding intent', () => {
+    const result = parseProvisionOutput(
+      JSON.stringify({
+        id: 'workspace-1',
+        host: 'remote.example.com',
+        forwardAgent: true,
+      })
+    );
+
+    expect(result.success).toBe(true);
+    if (result.success) {
+      expect(result.data.forwardAgent).toBe(true);
+    }
+  });
+
+  it('rejects non-boolean forwardAgent values', () => {
+    const result = parseProvisionOutput(
+      JSON.stringify({
+        id: 'workspace-1',
+        host: 'remote.example.com',
+        forwardAgent: 'true',
+      })
+    );
+
+    expect(result.success).toBe(false);
+  });
+});

--- a/src/main/core/workspaces/byoi/provision-output.ts
+++ b/src/main/core/workspaces/byoi/provision-output.ts
@@ -8,6 +8,7 @@ const provisionOutputSchema = z.object({
   username: z.string().optional(),
   worktreePath: z.string().optional(),
   password: z.string().optional(),
+  forwardAgent: z.boolean().optional(),
 });
 
 export type ProvisionOutput = z.infer<typeof provisionOutputSchema>;

--- a/tooling/byoi/README.md
+++ b/tooling/byoi/README.md
@@ -6,7 +6,7 @@ Each task gets its own Docker container running a full Linux dev environment wit
 ## How it works
 
 1. When you create a task, emdash runs `provision.sh`
-2. The script builds a Docker image (first run only), starts a new container, clones your repo into it, and prints a JSON blob
+2. The script builds a Docker image (first run only), starts a new container, clones your repo into it, and prints a JSON object to stdout
 3. Emdash SSH-connects to the container using password auth and opens the workspace at `/home/devuser/workspace`
 4. When you terminate the task, emdash runs `terminate.sh` which stops and removes the container
 
@@ -40,6 +40,22 @@ Add the project in emdash, then create a task. That's it.
 
 The first provision builds the Docker image (~2-3 minutes, one-time). Subsequent provisions start a new container and clone the repo (~10-20 seconds).
 
+## Provision output
+
+The provision script must print only one JSON object to stdout. Send logs and progress messages to stderr.
+
+This sample prints:
+
+| Field          | Value                          | Notes                                                            |
+| -------------- | ------------------------------ | ---------------------------------------------------------------- |
+| `id`           | Docker container name          | Passed to `terminate.sh` as `REMOTE_WORKSPACE_ID`                |
+| `host`         | `localhost`                    | Host Emdash connects to                                          |
+| `port`         | Random Docker host port for 22 | Must be a JSON number                                            |
+| `username`     | `devuser`                      | SSH username                                                     |
+| `password`     | `devpass`                      | SSH password                                                     |
+| `worktreePath` | `/home/devuser/workspace`      | Repository path inside the container                             |
+| `forwardAgent` | `false`                        | JSON boolean; set the script constant to `"true"` to enable it   |
+
 ## Forwarding API keys
 
 The provision script forwards API keys from your host environment into the container automatically. Just make sure the relevant variables are set in your shell before emdash runs the provision script:
@@ -58,6 +74,12 @@ To add more keys, edit the `docker run` call in `scripts/provision.sh` and the `
 - **Workspace path:** `/home/devuser/workspace`
 
 Change the password in `Dockerfile` (`devuser:devpass`) and `scripts/provision.sh` (`CONTAINER_PASS`) if needed.
+
+## SSH agent forwarding
+
+This sample sets `"forwardAgent"` from the `FORWARD_AGENT` script constant. It defaults to `"false"`.
+
+Change `FORWARD_AGENT` to `"true"` if Git commit signing or nested SSH/Git commands need your local SSH agent inside the container. Only enable forwarding for BYOI hosts you trust.
 
 ## Cleanup
 

--- a/tooling/byoi/scripts/provision.sh
+++ b/tooling/byoi/scripts/provision.sh
@@ -16,6 +16,7 @@ IMAGE_NAME="emdash-byoi-workspace"
 CONTAINER_USER="devuser"
 CONTAINER_PASS="devpass"
 WORKSPACE_PATH="/home/devuser/workspace"
+FORWARD_AGENT="false"
 
 # The Dockerfile lives next to this script (inside testing/byoi/ or wherever
 # you copied these files).
@@ -23,6 +24,11 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 DOCKERFILE_DIR="$(dirname "$SCRIPT_DIR")"
 
 # ── Preflight checks ──────────────────────────────────────────────────────────
+
+if [[ "$FORWARD_AGENT" != "true" && "$FORWARD_AGENT" != "false" ]]; then
+  echo "ERROR: FORWARD_AGENT must be 'true' or 'false' (got: '$FORWARD_AGENT')" >&2
+  exit 1
+fi
 
 if ! command -v docker &>/dev/null; then
   echo "ERROR: docker is not installed or not on PATH" >&2
@@ -94,4 +100,5 @@ jq -n \
   --arg username "$CONTAINER_USER" \
   --arg password "$CONTAINER_PASS" \
   --arg worktreePath "$WORKSPACE_PATH" \
-  '{id: $id, host: $host, port: $port, username: $username, password: $password, worktreePath: $worktreePath}'
+  --argjson forwardAgent "$FORWARD_AGENT" \
+  '{id: $id, host: $host, port: $port, username: $username, password: $password, worktreePath: $worktreePath, forwardAgent: $forwardAgent}'


### PR DESCRIPTION
- adds a "forwardAgent" boolean to byoi provision output
- builds byoi ssh connection config through resolveBYOISshConnectConfig
- enables ssh agent forwarding only when provision output explicitly sets "forwardAgent": true
- keeps omitted "forwardAgent" equivalent to false
- preserves ssh agent authentication for passwordless byoi connections
- handles user-qualified ssh hosts before passing the host to ssh2
- updates the docker byoi sample to emit "forwardAgent": true and documents the stdout json contract