### PR TITLE
docs(readme): simplify README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,206 +1,80 @@
-<img alt="Emdash banner" src="https://github.com/user-attachments/assets/a2ecaf3c-9d84-40ca-9a8e-d4f612cc1c6f" />
+<img alt="Emdash" src="https://github.com/user-attachments/assets/a2ecaf3c-9d84-40ca-9a8e-d4f612cc1c6f" />
 
+<div align="center">
 
-<div align="center" style="margin:24px 0;">
-  
-<br />
-
-[![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-555555.svg?labelColor=333333&color=666666)](./LICENSE.md)
-[![Downloads](https://img.shields.io/github/downloads/generalaction/emdash/total?labelColor=333333&color=666666)](https://github.com/generalaction/emdash/releases)
-[![GitHub Stars](https://img.shields.io/github/stars/generalaction/emdash?labelColor=333333&color=666666)](https://github.com/generalaction/emdash)
-[![Last Commit](https://img.shields.io/github/last-commit/generalaction/emdash?labelColor=333333&color=666666)](https://github.com/generalaction/emdash/commits/main)
-[![Commit Activity](https://img.shields.io/github/commit-activity/m/generalaction/emdash?labelColor=333333&color=666666)](https://github.com/generalaction/emdash/graphs/commit-activity)
-<br>
-[![Discord](https://img.shields.io/badge/Discord-join-%235462eb?labelColor=%235462eb&logo=discord&logoColor=%23f5f5f5)](https://discord.gg/f2fv7YxuR2)
-<a href="https://www.ycombinator.com"><img src="https://img.shields.io/badge/Y%20Combinator-W26-orange" alt="Y Combinator W26"></a>
-[![Follow @emdashsh on X](https://img.shields.io/twitter/follow/emdashsh?logo=X&color=%23f5f5f5)](https://twitter.com/intent/follow?screen_name=emdashsh)
-
-<br />
-
-  <a href="https://emdash.sh/download" style="display:inline-block; margin-right:8px; text-decoration:none; outline:none; border:none;">
-    <img src="https://emdash.sh/media/readme/downloadforwindows.png" alt="Download for Windows" height="40">
-  </a>
-  <a href="https://emdash.sh/download" style="display:inline-block; margin-right:8px; text-decoration:none; outline:none; border:none;">
-    <img src="https://emdash.sh/media/readme/downloadformacos.png" alt="Download for macOS" height="40">
-  </a>
-  <a href="https://emdash.sh/download" style="display:inline-block; text-decoration:none; outline:none; border:none;">
-    <img src="https://emdash.sh/media/readme/downloadforlinux.png" alt="Download for Linux" height="40">
-  </a>
+[Download](https://emdash.sh/download) · [Docs](https://emdash.sh/docs) · [Releases](https://github.com/generalaction/emdash/releases/latest) · [Discord](https://discord.gg/f2fv7YxuR2) · [Contributing](CONTRIBUTING.md)
 
 </div>
 
-<br />
+Emdash is a desktop app for running AI coding agents in parallel. Each task runs in its
+own Git worktree, so you can explore multiple fixes or features at once, review the
+diffs, and merge what works.
 
-Emdash is a provider-agnostic desktop app that lets you run multiple coding agents in parallel, each isolated in its own git worktree, either locally or over SSH on a remote machine. We call it an Agentic Development Environment (ADE).
+It works with local projects and remote machines over SSH. Bring the CLI agents you
+already use: Claude Code, Codex, OpenCode, Gemini, Amp, and more.
 
-Emdash supports 27 CLI agents, including Claude Code, Codex, OpenCode, Gemini and Amp. Users can directly pass Linear, GitHub, Jira, Asana, Featurebase, or Monday.com tickets to an agent, review diffs, test changes, create PRs, see CI/CD checks, and merge.
+<img alt="Emdash product screenshot" src="https://emdash.sh/media/blog/public-v1-beta/v1beta.jpg" />
 
-**Develop on remote servers via SSH**
+## What You Can Do
 
-Connect to remote machines via SSH/SFTP to work with remote codebases. Emdash supports SSH agent and key authentication, with secure credential storage in your OS keychain. Run agents on remote projects using the same parallel workflow as local development. [Learn more](https://www.emdash.sh/cloud)
+- Run multiple coding agents at once without juggling terminals.
+- Keep every agent isolated in its own Git worktree and branch.
+- Send issues and tickets from Linear, GitHub, Jira, GitLab, Asana, Featurebase,
+  Monday.com, Forgejo, or Plain into an agent.
+- Review diffs, create pull requests, inspect CI checks, and merge from one place.
+- Work locally or on your own remote machines over SSH/SFTP.
 
-<div align="center" style="margin:24px 0;">
+## Installation
 
-[Installation](#installation) • [Providers](#providers) • [Contributing](#contributing) • [FAQ](#faq)
+| Platform | Install |
+| --- | --- |
+| macOS | `brew install --cask emdash` · [Apple Silicon](https://releases.emdash.sh/emdash-arm64.dmg) · [Intel](https://releases.emdash.sh/emdash-x64.dmg) |
+| Windows | [Installer](https://releases.emdash.sh/emdash-x64.msi) · [Portable](https://releases.emdash.sh/emdash-x64.exe) |
+| Linux | [AppImage](https://releases.emdash.sh/emdash-x86_64.AppImage) · [Debian package](https://releases.emdash.sh/emdash-amd64.deb) |
 
-</div>
+See the [latest release](https://github.com/generalaction/emdash/releases/latest) for
+all desktop builds.
 
-<img alt="Emdash product" src="https://emdash.sh/media/blog/public-v1-beta/v1beta.jpg" />
+## Agents
 
-# Installation
+Emdash detects installed provider CLIs automatically. It supports agents like Claude
+Code, Codex, Cursor, OpenCode, Gemini, Amp, Devin, Qwen Code, Droid, and GitHub
+Copilot.
 
-### macOS
-- Homebrew: `brew install --cask emdash`
-- Apple Silicon: https://releases.emdash.sh/emdash-arm64.dmg
-- Intel x64: https://releases.emdash.sh/emdash-x64.dmg
+See [Providers](https://emdash.sh/docs/providers) for the full list, setup commands,
+and provider-specific behavior.
 
-### Windows
-- Installer (x64): https://releases.emdash.sh/emdash-x64.msi
-- Portable (x64): https://releases.emdash.sh/emdash-x64.exe
+## Remote Projects
 
-### Linux
-- AppImage (x64): https://releases.emdash.sh/emdash-x86_64.AppImage
-- Debian package (x64): https://releases.emdash.sh/emdash-amd64.deb
+Connect to remote machines with SSH/SFTP and run the same parallel workflow on remote
+codebases. Emdash supports SSH agent, key, and password authentication, with credentials
+stored in your OS keychain.
 
-### Release Overview
+See [Remote Projects](https://emdash.sh/docs/remote-projects) and
+[Bring Your Own Infrastructure](https://emdash.sh/docs/bring-your-own-infrastructure)
+for setup details.
 
-**[Latest Releases (macOS • Windows • Linux)](https://github.com/generalaction/emdash/releases/latest)**
+## Privacy
 
-# Providers
+Emdash is local-first. App state is stored in a local SQLite database, and Emdash does
+not send your code or chats to Emdash servers.
 
-<img alt="Providers banner" src="https://github.com/user-attachments/assets/c7b32a3e-452c-4209-91ef-71bcd895e2df" />
+Agent CLIs may send code, prompts, and context to their own providers. Their data
+handling depends on the provider you choose.
 
-### Supported CLI Providers
+Telemetry is optional and can be disabled in Settings or by launching with:
 
-Emdash currently supports 27 CLI providers, and we are adding new ones regularly. If you miss one, let us know or create a PR.
+```bash
+TELEMETRY_ENABLED=false
+```
 
-| CLI Provider | Status | Install / Setup |
-| ----------- | ------ | ----------- |
-| [Amp](https://ampcode.com/manual#install) | ✅ Supported | <code>npm install -g @sourcegraph/amp@latest</code> |
-| [Auggie](https://docs.augmentcode.com/cli/overview) | ✅ Supported | <code>npm install -g @augmentcode/auggie</code> |
-| [Autohand Code](https://autohand.ai/code/) | ✅ Supported | <code>npm install -g autohand-cli</code> |
-| [Charm](https://github.com/charmbracelet/crush) | ✅ Supported | <code>npm install -g @charmland/crush</code> |
-| [Claude Code](https://docs.anthropic.com/claude/docs/claude-code) | ✅ Supported | <code>curl -fsSL https://claude.ai/install.sh &#124; bash</code> |
-| [Cline](https://docs.cline.bot/cline-cli/overview) | ✅ Supported | <code>npm install -g cline</code> |
-| [Codebuff](https://www.codebuff.com/docs/help/quick-start) | ✅ Supported | <code>npm install -g codebuff</code> |
-| [Codex](https://github.com/openai/codex) | ✅ Supported | <code>npm install -g @openai/codex</code> |
-| [Continue](https://docs.continue.dev/guides/cli) | ✅ Supported | <code>npm i -g @continuedev/cli</code> |
-| [Cursor](https://cursor.com/cli) | ✅ Supported | <code>curl https://cursor.com/install -fsS &#124; bash</code> |
-| [Devin](https://cli.devin.ai/docs) | ✅ Supported | <code>curl -fsSL https://cli.devin.ai/install.sh &#124; bash</code> |
-| [Droid](https://docs.factory.ai/cli/getting-started/quickstart) | ✅ Supported | <code>curl -fsSL https://app.factory.ai/cli &#124; sh</code> |
-| [Gemini](https://github.com/google-gemini/gemini-cli) | ✅ Supported | <code>npm install -g @google/gemini-cli</code> |
-| [GitHub Copilot](https://docs.github.com/en/copilot/how-tos/set-up/install-copilot-cli) | ✅ Supported | <code>npm install -g @github/copilot</code> |
-| [Goose](https://block.github.io/goose/docs/quickstart/) | ✅ Supported | <code>curl -fsSL https://github.com/block/goose/releases/download/stable/download_cli.sh &#124; bash</code> |
-| [Hermes Agent](https://hermes-agent.nousresearch.com/docs/) | ✅ Supported | <code>curl -fsSL https://raw.githubusercontent.com/NousResearch/hermes-agent/main/scripts/install.sh &#124; bash</code> |
-| [Jules](https://jules.google/docs/cli/reference/) | ✅ Supported | <code>npm install -g @google/jules</code> |
-| [Junie](https://junie.jetbrains.com/docs/junie-cli.html) | ✅ Supported | <code>curl -fsSL https://junie.jetbrains.com/install.sh &#124; bash</code> |
-| [Kilocode](https://kilo.ai/docs/cli) | ✅ Supported | <code>npm install -g @kilocode/cli</code> |
-| [Kimi](https://www.kimi.com/code/docs/en/kimi-cli/guides/getting-started.html) | ✅ Supported | <code>uv tool install kimi-cli</code> |
-| [Kiro (AWS)](https://kiro.dev/docs/cli/) | ✅ Supported | <code>curl -fsSL https://cli.kiro.dev/install &#124; bash</code> |
-| [Letta](https://docs.letta.com/letta-code/cli) | ✅ Supported | <code>npm install -g @letta-ai/letta-code</code> |
-| [Mistral Vibe](https://github.com/mistralai/mistral-vibe) | ✅ Supported | <code>curl -LsSf https://mistral.ai/vibe/install.sh &#124; bash</code> |
-| [OpenCode](https://opencode.ai/docs/cli/) | ✅ Supported | <code>npm install -g opencode-ai</code> |
-| [Pi](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | ✅ Supported | <code>npm install -g @mariozechner/pi-coding-agent</code> |
-| [Qwen Code](https://github.com/QwenLM/qwen-code) | ✅ Supported | <code>npm install -g @qwen-code/qwen-code</code> |
-| [Rovo Dev](https://support.atlassian.com/rovo/docs/install-and-run-rovo-dev-cli-on-your-device/) | ✅ Supported | <code>acli rovodev auth login</code> |
+See [Telemetry](https://emdash.sh/docs/telemetry) for details.
 
-### Issues
+## Contributing
 
-Emdash allows you to pass issues, tickets, and support threads straight to your coding agent.
+Contributions are welcome. Read the [Contributing Guide](CONTRIBUTING.md), open an
+issue, or join the [Discord](https://discord.gg/f2fv7YxuR2).
 
-| Tool | Status | Authentication |
-| ----------- | ------ | ----------- |
-| [Linear](https://linear.app) | ✅ Supported | Connect with a Linear API key. |
-| [Jira](https://www.atlassian.com/software/jira) | ✅ Supported | Provide your site URL, email, and Atlassian API token. |
-| [GitHub Issues](https://docs.github.com/en/issues) | ✅ Supported | Connect your GitHub account or authenticate via GitHub CLI (`gh auth login`). |
-| [GitLab Issues](https://docs.gitlab.com/user/project/issues/) | ✅ Supported | Provide your GitLab instance URL and a personal access token with `read_api` scope. |
-| [Asana](https://asana.com/) | ✅ Supported | Connect with an Asana personal access token. |
-| [Featurebase](https://www.featurebase.app/) | ✅ Supported | Connect with a Featurebase API key. |
-| [Monday.com](https://monday.com/) | ✅ Supported | Connect with a Monday.com API token and optional board URLs. |
-| [Forgejo Issues](https://forgejo.org/) | ✅ Supported | Provide your Forgejo instance URL and API token. |
-| [Plain Threads](https://www.plain.com/) | ✅ Supported | Connect with a Plain API key. |
+## License
 
-# Contributing
-
-Contributions welcome! See the [Contributing Guide](CONTRIBUTING.md) to get started, and join our [Discord](https://discord.gg/f2fv7YxuR2) to discuss.
-
-# FAQ
-
-<details>
-<summary><b>What telemetry do you collect and can I disable it?</b></summary>
-
-> We send **anonymous, allow‑listed events** (app start/close, feature usage names, app/platform versions) to PostHog.  
-> We **do not** send code, file paths, repo names, prompts, or PII.
->
-> **Disable telemetry:**
->
-> - In the app: **Settings → General → Privacy & Telemetry** (toggle off)
-> - Or via env var before launch:
->
-> ```bash
-> TELEMETRY_ENABLED=false
-> ```
->
-> Full details: see [Telemetry](https://emdash.sh/docs/telemetry).
-</details>
-
-<details>
-<summary><b>Where is my data stored?</b></summary>
-
-> **App data is local‑first**. We store app state in a local **SQLite** database:
->
-> ```
-> macOS:   ~/Library/Application Support/emdash/emdash.db
-> Windows: %APPDATA%\emdash\emdash.db
-> Linux:   ~/.config/emdash/emdash.db
-> ```
->
-> **Privacy Note:** While Emdash itself stores data locally, **when you use any coding agent (Claude Code, Codex, Qwen, etc.), your code and prompts are sent to that provider's cloud API servers** for processing. Each provider has their own data handling and retention policies.
->
-> You can reset the local DB by deleting it (quit the app first). The file is recreated on next launch.
-</details>
-
-<details>
-<summary><b>How do I add a new provider?</b></summary>
-
-> Emdash is **provider‑agnostic** and built to add CLIs quickly.
->
-> - Open a PR following the **Contributing Guide** (`CONTRIBUTING.md`).
-> - Include: provider name, how it’s invoked (CLI command), auth notes, and minimal setup steps.
-> - We’ll add it to the **Providers table** and wire up provider selection in the UI.
->
-> If you’re unsure where to start, open an issue with the CLI’s link and typical commands.
-</details>
-
-<details>
-<summary><b>What permissions does Emdash need?</b></summary>
-
-> - **Filesystem/Git:** to read/write your repo and create **Git worktrees** for isolation.  
-> - **Network:** only for provider CLIs you choose to use (e.g., Codex, Claude) and optional GitHub actions.  
-> - **Local DB:** to store your app state in SQLite on your machine.
->
-> Emdash itself does **not** send your code or chats to any servers. Third‑party CLIs may transmit data per their policies.
-</details>
-
-
-<details>
-<summary><b>Can I work with remote projects over SSH?</b></summary>
-
-> **Yes!** Emdash supports remote development via SSH.
->
-> **Setup:**
-> 1. Go to **Settings → SSH Connections** and add your server details
-> 2. Choose authentication: SSH agent (recommended), private key, or password
-> 3. Add a remote project and specify the path on the server
->
-> **Requirements:**
-> - SSH access to the remote server
-> - Git installed on the remote server
-> - For agent auth: SSH agent running with your key loaded (`ssh-add -l`)
->
-> See [Remote Projects](https://emdash.sh/docs/remote-projects) for detailed setup instructions and [Bring Your Own Infrastructure](https://emdash.sh/docs/bring-your-own-infrastructure) for technical details.
-</details>
-
-[![Follow @emdashsh](https://img.shields.io/twitter/follow/emdashsh?style=social&label=Follow%20%40emdashsh)](https://x.com/emdashsh)
-[![Follow @rabanspiegel](https://img.shields.io/twitter/follow/rabanspiegel?style=social&label=Follow%20%40rabanspiegel)](https://x.com/rabanspiegel)
-[![Follow @arnestrickmann](https://img.shields.io/twitter/follow/arnestrickmann?style=social&label=Follow%20%40arnestrickmann)](https://x.com/arnestrickmann)
+Licensed under the [Apache-2.0 license](LICENSE.md).

--- a/README.md
+++ b/README.md
@@ -4,6 +4,18 @@
 
 [Download](https://emdash.sh/download) · [Docs](https://emdash.sh/docs) · [Releases](https://github.com/generalaction/emdash/releases/latest) · [Discord](https://discord.gg/f2fv7YxuR2) · [Contributing](CONTRIBUTING.md)
 
+<br />
+
+[![Apache 2.0 License](https://img.shields.io/badge/License-Apache_2.0-555555.svg?labelColor=333333&color=666666)](./LICENSE.md)
+[![Downloads](https://img.shields.io/github/downloads/generalaction/emdash/total?labelColor=333333&color=666666)](https://github.com/generalaction/emdash/releases)
+[![GitHub Stars](https://img.shields.io/github/stars/generalaction/emdash?labelColor=333333&color=666666&logo=github)](https://github.com/generalaction/emdash)
+[![Last Commit](https://img.shields.io/github/last-commit/generalaction/emdash?labelColor=333333&color=666666)](https://github.com/generalaction/emdash/commits/main)
+[![Commit Activity](https://img.shields.io/github/commit-activity/m/generalaction/emdash?labelColor=333333&color=666666)](https://github.com/generalaction/emdash/graphs/commit-activity)
+
+[![Discord](https://img.shields.io/badge/Discord-join-%235462eb?labelColor=%235462eb&logo=discord&logoColor=%23f5f5f5)](https://discord.gg/f2fv7YxuR2)
+<a href="https://www.ycombinator.com"><img src="https://img.shields.io/badge/Y%20Combinator-W26-orange" alt="Y Combinator W26"></a>
+[![Follow @emdashsh on X](https://img.shields.io/twitter/follow/emdashsh?logo=X&color=%23f5f5f5)](https://twitter.com/intent/follow?screen_name=emdashsh)
+
 </div>
 
 Emdash is a desktop app for running AI coding agents in parallel. Each task runs in its


### PR DESCRIPTION
## Summary
- simplify the README around a cleaner top navigation and shorter product intro
- keep one main product screenshot and a compact install table
- replace the long provider matrix and FAQ with concise sections that link to docs

## Verification
- pnpm run format:check
- git diff --check