### PR TITLE
fix(tasks): prevent clipped create task toggle focus rings

### DIFF
--- a/src/renderer/features/tasks/create-task-modal/linked-entity-section.tsx
+++ b/src/renderer/features/tasks/create-task-modal/linked-entity-section.tsx
@@ -27,7 +27,7 @@ export function LinkedEntitySection({
       >
         <span className="shrink-0 text-sm text-foreground-muted">Based on</span>
         <ToggleGroup
-          className="gap-1! border-none bg-transparent p-0!"
+          className="gap-1! border-none bg-transparent p-1!"
           value={state.linkedType ? [state.linkedType] : []}
           onValueChange={([v]) => {
             state.setLinkedType((v as LinkedType) ?? null);

--- a/src/renderer/features/tasks/create-task-modal/section-tabs-panel.tsx
+++ b/src/renderer/features/tasks/create-task-modal/section-tabs-panel.tsx
@@ -36,7 +36,7 @@ export function SectionTabsPanel({
     <div className="flex flex-col gap-2">
       <div className="flex w-full items-center justify-between gap-2">
         <ToggleGroup
-          className="w-full shrink-0 gap-1 border-none bg-transparent"
+          className="w-full shrink-0 gap-1 border-none bg-transparent p-1"
           value={[sectionTab]}
           onValueChange={([v]) => {
             if (v) setSectionTab(v as SectionTab);


### PR DESCRIPTION
## Summary
- Add a small focus-ring gutter around the create-task modal linked-entity toggle group.
- Add the same gutter around the create-task modal section tab toggle group.
- Keep the fix scoped to the modal so compact labels do not get squeezed by inset rings.

## Screenshots
before: <img width="438" height="222" alt="CleanShot 2026-06-02 at 19 30 04@2x" src="https://github.com/user-attachments/assets/6e9726d8-b578-439e-a763-d0abe51a831c" />
after: <img width="360" height="156" alt="CleanShot 2026-06-02 at 19 39 31@2x" src="https://github.com/user-attachments/assets/95adb8a0-674f-430e-8fc8-fec7699c3d5e" />
before: <img width="512" height="166" alt="CleanShot 2026-06-02 at 19 30 18@2x" src="https://github.com/user-attachments/assets/0002faf7-5cfa-422a-aa25-cb31241106cd" />
after: <img width="620" height="182" alt="CleanShot 2026-06-02 at 19 39 35@2x" src="https://github.com/user-attachments/assets/a456cef7-ba49-4b36-aed8-360a136997bc" />


## Focus audit
- The direct clipping issue appears specific to these compact create-task modal toggle groups: the selected/focused ring had no surrounding gutter inside clipped modal layout.
- There are broader focus-style inconsistencies in the app: primitives and custom feature controls mix ring widths/colors (`ring-[3px] ring-ring/50`, `ring-2 ring-primary/30`, `ring-1 ring-ring`) and several feature-level controls intentionally suppress rings with `focus-visible:ring-0` or `focus:ring-0`.
- I kept this PR narrow to avoid changing focus behavior across unrelated surfaces.
