### PR TITLE
fix(terminals): reconcile restored terminal tabs

### DIFF
--- a/src/renderer/features/tasks/stores/terminal-registry.ts
+++ b/src/renderer/features/tasks/stores/terminal-registry.ts
@@ -1,7 +1,8 @@
+import { observable } from 'mobx';
 import { TerminalManagerStore } from '@renderer/features/tasks/terminals/terminal-manager';
 
 export class TerminalRegistry {
-  private readonly entries = new Map<string, TerminalManagerStore>();
+  private readonly entries = observable.map<string, TerminalManagerStore>();
 
   acquire(taskId: string, projectId: string): TerminalManagerStore {
     const existing = this.entries.get(taskId);

--- a/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -1,9 +1,14 @@
+import { makeObservable, observable, runInAction } from 'mobx';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import type { Conversation } from '@shared/conversations';
 import type { Task } from '@shared/tasks';
+import type { Terminal } from '@shared/terminals';
 import type { TaskViewSnapshot } from '@shared/view-state';
+import type { TerminalManagerStore, TerminalStore } from '../terminals/terminal-manager';
 import { conversationRegistry } from './conversation-registry';
 import type { TaskStore } from './task-store';
+import { terminalRegistry } from './terminal-registry';
+import { workspaceRegistry } from './workspace-registry';
 import { WorkspaceViewModel } from './workspace-view-model';
 
 vi.mock('@renderer/lib/ipc', () => ({
@@ -14,6 +19,45 @@ vi.mock('@renderer/lib/ipc', () => ({
       getConnectionState: async () => ({}),
       getHealthStates: async () => ({}),
     },
+    viewState: {
+      save: vi.fn(),
+    },
+    repository: {
+      getLocalBranches: vi.fn().mockResolvedValue({
+        isUnborn: false,
+        currentBranch: 'main',
+        localBranches: [],
+      }),
+      getRemoteBranches: vi.fn().mockResolvedValue({
+        remoteBranches: [],
+        remotes: [],
+      }),
+      resolveProviderRepository: vi.fn().mockResolvedValue({ success: false }),
+    },
+    workspace: {
+      fs: {
+        listFiles: vi.fn().mockResolvedValue({ success: true, data: [] }),
+        watchSetPaths: vi.fn().mockResolvedValue(undefined),
+        watchStop: vi.fn().mockResolvedValue(undefined),
+      },
+      git: {
+        getFullStatus: vi.fn().mockResolvedValue({
+          success: true,
+          data: {
+            currentBranch: 'main',
+            headKind: 'branch',
+            unstaged: [],
+            staged: [],
+            untracked: [],
+            conflicts: [],
+            totalAdded: 0,
+            totalDeleted: 0,
+            ahead: 0,
+            behind: 0,
+          },
+        }),
+      },
+    },
   },
 }));
 
@@ -21,6 +65,29 @@ type HydrationHarness = {
   openConversationIds: string[];
   syncConversationHydration(openIds: string[]): void;
 };
+
+type FakeTerminalManager = TerminalManagerStore & {
+  isLoaded: boolean;
+  createDefaultTerminal: ReturnType<typeof vi.fn>;
+};
+
+class FakeTerminalManagerStore {
+  terminals = observable.map<string, TerminalStore>();
+  isLoaded: boolean;
+  createDefaultTerminal = vi.fn().mockResolvedValue(undefined);
+  dispose = vi.fn();
+
+  constructor({ terminalIds, isLoaded }: { terminalIds: string[]; isLoaded: boolean }) {
+    this.isLoaded = isLoaded;
+    for (const id of terminalIds) {
+      this.terminals.set(id, makeTerminal(id));
+    }
+    makeObservable(this, {
+      terminals: observable,
+      isLoaded: observable,
+    });
+  }
+}
 
 function deferred<T = void>(): {
   promise: Promise<T>;
@@ -70,12 +137,58 @@ function makeViewModel(): WorkspaceViewModel {
   return new WorkspaceViewModel({ data: makeTask() } as unknown as TaskStore);
 }
 
+function makeProvisionedViewModel(): WorkspaceViewModel {
+  return new WorkspaceViewModel({
+    data: makeTask(),
+    workspaceId: 'workspace-1',
+  } as unknown as TaskStore);
+}
+
+function makeTerminal(id: string, name = 'Terminal 1'): TerminalStore {
+  return {
+    data: {
+      id,
+      projectId: 'project-1',
+      taskId: 'task-1',
+      shellId: 'system',
+      name,
+    } satisfies Terminal,
+  } as TerminalStore;
+}
+
+function makeTerminalManager({
+  terminalIds,
+  isLoaded,
+}: {
+  terminalIds: string[];
+  isLoaded: boolean;
+}): FakeTerminalManager {
+  return new FakeTerminalManagerStore({ terminalIds, isLoaded }) as unknown as FakeTerminalManager;
+}
+
+function terminalRegistryEntries(): {
+  set(taskId: string, manager: TerminalManagerStore): void;
+  delete(taskId: string): boolean;
+} {
+  return (
+    terminalRegistry as unknown as {
+      entries: {
+        set(taskId: string, manager: TerminalManagerStore): void;
+        delete(taskId: string): boolean;
+      };
+    }
+  ).entries;
+}
+
 function asHydrationHarness(viewModel: WorkspaceViewModel): HydrationHarness {
   return viewModel as unknown as HydrationHarness;
 }
 
 afterEach(() => {
   conversationRegistry.release('task-1');
+  terminalRegistry.release('task-1');
+  terminalRegistryEntries().delete('task-1');
+  workspaceRegistry.release('project-1', 'workspace-1');
 });
 
 describe('WorkspaceViewModel terminal drawer snapshot', () => {
@@ -93,6 +206,39 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 
     source.dispose();
     restored.dispose();
+  });
+
+  it('does not auto-create a terminal when stale restored tabs are empty but terminal records load', async () => {
+    const terminals = makeTerminalManager({ terminalIds: ['terminal-1'], isLoaded: false });
+    terminalRegistryEntries().set('task-1', terminals);
+    workspaceRegistry.acquire(
+      'project-1',
+      'workspace-1',
+      '/tmp/emdash-test-workspace',
+      { settings: {} } as never,
+      'main'
+    );
+
+    const viewModel = makeProvisionedViewModel();
+    viewModel.restoreSnapshot({
+      focusedRegion: 'bottom',
+      isTerminalDrawerOpen: true,
+      terminals: {
+        tabOrder: [],
+        activeTabId: undefined,
+      },
+    });
+
+    viewModel.initialize();
+
+    runInAction(() => {
+      terminals.isLoaded = true;
+    });
+    await Promise.resolve();
+
+    expect(terminals.createDefaultTerminal).not.toHaveBeenCalled();
+
+    viewModel.dispose();
   });
 });
 

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -330,7 +330,7 @@ export class WorkspaceViewModel implements ILifecycle {
           this.isTerminalDrawerOpen &&
           !this._isCreatingTerminal &&
           (terminals?.isLoaded ?? false) &&
-          this.terminalTabs.tabs.length === 0
+          (terminals?.terminals.size ?? 0) === 0
         );
       },
       (shouldCreate) => {

--- a/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
+++ b/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
@@ -25,6 +25,16 @@ function makeManager(terminals: TerminalManagerStore['terminals']): TerminalMana
   return { terminals, isLoaded: true, dispose: vi.fn() } as unknown as TerminalManagerStore;
 }
 
+function makeLoadingManager(terminals: TerminalManagerStore['terminals']): TerminalManagerStore & {
+  isLoaded: boolean;
+} {
+  return observable({
+    terminals,
+    isLoaded: false,
+    dispose: vi.fn(),
+  }) as unknown as TerminalManagerStore & { isLoaded: boolean };
+}
+
 function registryEntries(): {
   set(taskId: string, manager: TerminalManagerStore): void;
   delete(taskId: string): boolean;
@@ -111,6 +121,27 @@ describe('TerminalTabViewStore', () => {
 
     expect(view.tabOrder).toEqual(['terminal-1']);
     expect(view.activeTabId).toBe('terminal-1');
+
+    view.dispose();
+  });
+
+  it('clears stale restored ids when an empty terminal list finishes loading', () => {
+    const terminals = observable.map<string, TerminalStore>();
+    const manager = makeLoadingManager(terminals);
+    registryEntries().set('task-1', manager);
+
+    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    view.restoreSnapshot({
+      tabOrder: ['deleted-terminal'],
+      activeTabId: 'deleted-terminal',
+    });
+
+    runInAction(() => {
+      manager.isLoaded = true;
+    });
+
+    expect(view.tabOrder).toEqual([]);
+    expect(view.activeTabId).toBeUndefined();
 
     view.dispose();
   });

--- a/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
+++ b/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
@@ -1,0 +1,117 @@
+import { observable, runInAction } from 'mobx';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { terminalRegistry } from '@renderer/features/tasks/stores/terminal-registry';
+import type { Terminal } from '@shared/terminals';
+import type { TerminalManagerStore, TerminalStore } from './terminal-manager';
+import { TerminalTabViewStore } from './terminal-tab-view-store';
+
+vi.mock('./terminal-manager', () => ({
+  TerminalManagerStore: class {},
+}));
+
+function makeTerminal(id: string, name = 'Terminal 1'): TerminalStore {
+  return {
+    data: {
+      id,
+      projectId: 'project-1',
+      taskId: 'task-1',
+      shellId: 'system',
+      name,
+    } satisfies Terminal,
+  } as TerminalStore;
+}
+
+function makeManager(terminals: TerminalManagerStore['terminals']): TerminalManagerStore {
+  return { terminals, isLoaded: true, dispose: vi.fn() } as unknown as TerminalManagerStore;
+}
+
+function registryEntries(): {
+  set(taskId: string, manager: TerminalManagerStore): void;
+  delete(taskId: string): boolean;
+} {
+  return (
+    terminalRegistry as unknown as {
+      entries: {
+        set(taskId: string, manager: TerminalManagerStore): void;
+        delete(taskId: string): boolean;
+      };
+    }
+  ).entries;
+}
+
+describe('TerminalTabViewStore', () => {
+  afterEach(() => {
+    terminalRegistry.release('task-1');
+    registryEntries().delete('task-1');
+  });
+
+  it('syncs terminal ids when the terminal manager becomes available after construction', () => {
+    const terminals = observable.map<string, TerminalStore>();
+    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+
+    runInAction(() => {
+      registryEntries().set('task-1', makeManager(terminals));
+      terminals.set('terminal-2', makeTerminal('terminal-2', 'Terminal 2'));
+    });
+
+    expect(view.tabOrder).toEqual(['terminal-2']);
+
+    view.dispose();
+  });
+
+  it('reconciles restored snapshots with already-loaded terminal records', () => {
+    const terminals = observable.map<string, TerminalStore>();
+    terminals.set('terminal-1', makeTerminal('terminal-1', 'Terminal 1'));
+    terminals.set('terminal-2', makeTerminal('terminal-2', 'Terminal 2'));
+    registryEntries().set('task-1', makeManager(terminals));
+
+    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    view.restoreSnapshot({
+      tabOrder: ['terminal-2'],
+      activeTabId: 'terminal-2',
+    });
+
+    expect(view.tabOrder).toEqual(['terminal-2', 'terminal-1']);
+    expect(view.activeTabId).toBe('terminal-2');
+
+    view.dispose();
+  });
+
+  it('falls back to the first live terminal when the restored active terminal is stale', () => {
+    const terminals = observable.map<string, TerminalStore>();
+    terminals.set('terminal-1', makeTerminal('terminal-1', 'Terminal 1'));
+    terminals.set('terminal-2', makeTerminal('terminal-2', 'Terminal 2'));
+    registryEntries().set('task-1', makeManager(terminals));
+
+    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    view.restoreSnapshot({
+      tabOrder: ['deleted-terminal'],
+      activeTabId: 'deleted-terminal',
+    });
+
+    expect(view.tabOrder).toEqual(['terminal-1', 'terminal-2']);
+    expect(view.activeTabId).toBe('terminal-1');
+
+    view.dispose();
+  });
+
+  it('reconciles a restored snapshot after the terminal manager loads later', () => {
+    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    view.restoreSnapshot({
+      tabOrder: ['deleted-terminal'],
+      activeTabId: 'deleted-terminal',
+    });
+
+    const terminals = observable.map<string, TerminalStore>();
+    terminals.set('terminal-1', makeTerminal('terminal-1', 'Terminal 1'));
+
+    runInAction(() => {
+      registryEntries().set('task-1', makeManager(terminals));
+    });
+
+    expect(view.tabOrder).toEqual(['terminal-1']);
+    expect(view.activeTabId).toBe('terminal-1');
+
+    view.dispose();
+  });
+});

--- a/src/renderer/features/tasks/terminals/terminal-tab-view-store.ts
+++ b/src/renderer/features/tasks/terminals/terminal-tab-view-store.ts
@@ -1,4 +1,4 @@
-import { action, computed, makeObservable, observable, reaction } from 'mobx';
+import { action, comparer, computed, makeObservable, observable, reaction } from 'mobx';
 import { type TabViewProvider, type TabViewSnapshot } from '@renderer/lib/stores/generic-tab-view';
 import type { Snapshottable } from '@renderer/lib/stores/snapshottable';
 import {
@@ -21,7 +21,7 @@ export class TerminalTabViewStore
 
   constructor(getResource: () => TerminalManagerStore | null) {
     this._getResource = getResource;
-    makeObservable(this, {
+    makeObservable<TerminalTabViewStore, 'syncTerminalIds'>(this, {
       tabOrder: observable,
       activeTabId: observable,
       tabs: computed,
@@ -35,15 +35,23 @@ export class TerminalTabViewStore
       setTabActiveIndex: action,
       setActiveTab: action,
       restoreSnapshot: action,
+      syncTerminalIds: action,
     });
 
     this.disposers.push(
       reaction(
-        () => Array.from(this._getResource()?.terminals.keys() ?? []),
-        action((ids: string[]) => {
+        () => {
+          const resource = this._getResource();
+          return {
+            isLoaded: resource?.isLoaded ?? false,
+            ids: Array.from(resource?.terminals.keys() ?? []),
+          };
+        },
+        action(({ isLoaded, ids }) => {
+          if (!isLoaded) return;
           this.syncTerminalIds(ids);
         }),
-        { fireImmediately: true }
+        { fireImmediately: true, equals: comparer.structural }
       )
     );
   }

--- a/src/renderer/features/tasks/terminals/terminal-tab-view-store.ts
+++ b/src/renderer/features/tasks/terminals/terminal-tab-view-store.ts
@@ -41,28 +41,9 @@ export class TerminalTabViewStore
       reaction(
         () => Array.from(this._getResource()?.terminals.keys() ?? []),
         action((ids: string[]) => {
-          const idSet = new Set(ids);
-          // Remove deleted IDs
-          for (let i = this.tabOrder.length - 1; i >= 0; i--) {
-            if (!idSet.has(this.tabOrder[i])) {
-              this.tabOrder.splice(i, 1);
-            }
-          }
-          // Append new IDs
-          for (const id of ids) {
-            if (!this.tabOrder.includes(id)) {
-              this.tabOrder.push(id);
-            }
-          }
-          // Deselect removed active tab
-          if (this.activeTabId && !idSet.has(this.activeTabId)) {
-            this.activeTabId = this.tabOrder[0];
-          }
-          // Auto-select first if nothing is active
-          if (!this.activeTabId && this.tabOrder.length > 0) {
-            this.activeTabId = this.tabOrder[0];
-          }
-        })
+          this.syncTerminalIds(ids);
+        }),
+        { fireImmediately: true }
       )
     );
   }
@@ -84,6 +65,9 @@ export class TerminalTabViewStore
   restoreSnapshot(snapshot: Partial<TabViewSnapshot>): void {
     if (snapshot.tabOrder) this.tabOrder = snapshot.tabOrder;
     if (snapshot.activeTabId !== undefined) this.activeTabId = snapshot.activeTabId;
+
+    const loadedIds = this.loadedTerminalIds();
+    if (loadedIds) this.syncTerminalIds(loadedIds);
   }
 
   setActiveTab(id: string): void {
@@ -119,5 +103,35 @@ export class TerminalTabViewStore
 
   dispose(): void {
     for (const d of this.disposers) d();
+  }
+
+  private loadedTerminalIds(): string[] | null {
+    const resource = this._getResource();
+    if (!resource?.isLoaded) return null;
+    return Array.from(resource.terminals.keys());
+  }
+
+  private syncTerminalIds(ids: string[]): void {
+    const idSet = new Set(ids);
+    // Remove deleted IDs
+    for (let i = this.tabOrder.length - 1; i >= 0; i--) {
+      if (!idSet.has(this.tabOrder[i])) {
+        this.tabOrder.splice(i, 1);
+      }
+    }
+    // Append new IDs
+    for (const id of ids) {
+      if (!this.tabOrder.includes(id)) {
+        this.tabOrder.push(id);
+      }
+    }
+    // Deselect removed active tab
+    if (this.activeTabId && !idSet.has(this.activeTabId)) {
+      this.activeTabId = this.tabOrder[0];
+    }
+    // Auto-select first if nothing is active
+    if (!this.activeTabId && this.tabOrder.length > 0) {
+      this.activeTabId = this.tabOrder[0];
+    }
   }
 }


### PR DESCRIPTION
- treat terminal records as the source of truth when restoring terminal tab state
- reconcile stale saved tab order with loaded terminal ids so persisted terminals stay visible
- prevent the terminal drawer from auto-creating a new terminal based on stale tab ui state
- keep restored active terminal selection when valid and fall back to the first live terminal when stale