### PR TITLE
feat(tasks): allow conversation rename on double click

### DIFF
--- a/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
+++ b/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
@@ -57,10 +57,23 @@ const ConversationRow = observer(function ConversationRow({
     conversation.data.title
   );
   const rawTitle = conversation.data.title ?? '';
+  const commitRename = (value: string) => {
+    const trimmed = value.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
+    if (trimmed && trimmed !== rawTitle) {
+      handleRenameSubmit(trimmed);
+    } else {
+      setIsEditing(false);
+    }
+  };
 
   const handleRenameSubmit = (newTitle: string) => {
     setIsEditing(false);
     void conversations.renameConversation(conversationId, newTitle);
+  };
+
+  const handleDoubleClick = () => {
+    tabGroupManager.openConversation(conversationId);
+    handleRename();
   };
 
   const handleDelete = () => {
@@ -75,45 +88,20 @@ const ConversationRow = observer(function ConversationRow({
     });
   };
 
-  if (isEditing) {
-    return (
-      <div className="flex h-full w-full items-center px-2">
-        <input
-          ref={handleRenameInputRef}
-          className="w-full rounded bg-background-1 px-1.5 py-0.5 text-sm text-foreground ring-1 ring-foreground/20 outline-none focus:ring-foreground/40"
-          defaultValue={rawTitle}
-          maxLength={MAX_CONVERSATION_TITLE_LENGTH}
-          onBlur={(e) => {
-            const value = e.target.value.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
-            if (value && value !== rawTitle) {
-              handleRenameSubmit(value);
-            } else {
-              setIsEditing(false);
-            }
-          }}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') {
-              const value = e.currentTarget.value.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
-              if (value && value !== rawTitle) {
-                handleRenameSubmit(value);
-              } else {
-                setIsEditing(false);
-              }
-            } else if (e.key === 'Escape') {
-              setIsEditing(false);
-            }
-          }}
-        />
-      </div>
-    );
-  }
-
   return (
     <ContextMenu>
       <ContextMenuTrigger>
-        <button
+        <div
+          role="button"
+          tabIndex={0}
           onClick={() => tabGroupManager.openConversationPreview(conversationId)}
-          onDoubleClick={() => tabGroupManager.openConversation(conversationId)}
+          onDoubleClick={handleDoubleClick}
+          onKeyDown={(e) => {
+            if (e.key === 'Enter' || e.key === ' ') {
+              e.preventDefault();
+              tabGroupManager.openConversationPreview(conversationId);
+            }
+          }}
           className={cn(
             'flex w-full items-center gap-2 h-8 rounded-md px-2 text-left text-sm text-foreground-muted transition-colors hover:bg-background-1 hover:text-foreground',
             isActive && 'bg-background-2 text-foreground hover:bg-background-2'
@@ -131,7 +119,24 @@ const ConversationRow = observer(function ConversationRow({
               />
             </span>
           ) : null}
-          <span className="min-w-0 flex-1 truncate">{displayTitle}</span>
+          {isEditing ? (
+            <input
+              ref={handleRenameInputRef}
+              className="min-w-0 flex-1 rounded bg-background-1 px-1.5 py-0.5 text-sm text-foreground ring-1 ring-foreground/20 outline-none focus:ring-foreground/40"
+              defaultValue={rawTitle}
+              maxLength={MAX_CONVERSATION_TITLE_LENGTH}
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+              onBlur={(e) => commitRename(e.target.value)}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === 'Enter') commitRename(e.currentTarget.value);
+                else if (e.key === 'Escape') setIsEditing(false);
+              }}
+            />
+          ) : (
+            <span className="min-w-0 flex-1 truncate">{displayTitle}</span>
+          )}
           <span className="shrink-0">
             {conversation.indicatorStatus ? (
               <AgentStatusIndicator status={conversation.indicatorStatus} disableTooltip />
@@ -143,7 +148,7 @@ const ConversationRow = observer(function ConversationRow({
               />
             )}
           </span>
-        </button>
+        </div>
       </ContextMenuTrigger>
       <ContextMenuContent finalFocus={false}>
         <ContextMenuItem onClick={handleRename}>

--- a/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
+++ b/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
@@ -33,6 +33,7 @@ const ConversationRow = observer(function ConversationRow({
   conversationId: string;
 }) {
   const [isEditing, setIsEditing] = useState(false);
+  const committedRef = useRef(false);
   const taskView = useWorkspaceViewModel();
   const conversations = useConversations();
   const { tabManager, tabGroupManager } = taskView;
@@ -44,6 +45,7 @@ const ConversationRow = observer(function ConversationRow({
   }, []);
 
   const handleRename = useCallback(() => {
+    committedRef.current = false;
     window.setTimeout(() => setIsEditing(true), 0);
   }, []);
 
@@ -58,6 +60,8 @@ const ConversationRow = observer(function ConversationRow({
   );
   const rawTitle = conversation.data.title ?? '';
   const commitRename = (value: string) => {
+    if (committedRef.current) return;
+    committedRef.current = true;
     const trimmed = value.trim().slice(0, MAX_CONVERSATION_TITLE_LENGTH);
     if (trimmed && trimmed !== rawTitle) {
       handleRenameSubmit(trimmed);
@@ -131,7 +135,10 @@ const ConversationRow = observer(function ConversationRow({
               onKeyDown={(e) => {
                 e.stopPropagation();
                 if (e.key === 'Enter') commitRename(e.currentTarget.value);
-                else if (e.key === 'Escape') setIsEditing(false);
+                else if (e.key === 'Escape') {
+                  committedRef.current = true;
+                  setIsEditing(false);
+                }
               }}
             />
           ) : (

--- a/src/renderer/features/tasks/view/tab-bar/conversation-tab-item.tsx
+++ b/src/renderer/features/tasks/view/tab-bar/conversation-tab-item.tsx
@@ -8,7 +8,6 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@renderer/lib/ui/context-menu';
-import { Separator } from '@renderer/lib/ui/separator';
 import { agentConfig } from '@renderer/utils/agentConfig';
 import { MAX_CONVERSATION_TITLE_LENGTH } from '@shared/conversations';
 import { AgentStatusIndicator } from '../../components/agent-status-indicator';
@@ -37,11 +36,17 @@ export const ConversationTabItem = observer(function ConversationTabItem({
   const config = agentConfig[tab.store.data.providerId];
   const title = formatConversationTitleForDisplay(tab.store.data.providerId, tab.store.data.title);
   const rawTitle = tab.store.data.title ?? '';
+  const renameInputWidth = `${Math.min(Math.max(rawTitle.length || title.length, 8), 24)}ch`;
 
   const handleRename = useCallback(() => {
     committedRef.current = false;
     window.setTimeout(() => setIsEditing(true), 0);
   }, []);
+
+  const handleDoubleClick = useCallback(() => {
+    if (tab.isPreview) onPin();
+    handleRename();
+  }, [handleRename, onPin, tab.isPreview]);
 
   const handleRenameInputRef = useCallback((input: HTMLInputElement | null) => {
     input?.focus();
@@ -58,38 +63,6 @@ export const ConversationTabItem = observer(function ConversationTabItem({
     setIsEditing(false);
   };
 
-  if (isEditing) {
-    return (
-      <div className="flex h-full items-center gap-1.5 bg-background-secondary-1 pr-2 pl-3">
-        {config ? (
-          <AgentLogo
-            logo={config.logo}
-            logoDark={config.logoDark}
-            alt={config.alt}
-            isSvg={config.isSvg}
-            invertInDark={config.invertInDark}
-            className="size-4 shrink-0"
-          />
-        ) : null}
-        <input
-          ref={handleRenameInputRef}
-          className="max-w-24 rounded bg-background-1 px-1 py-0.5 text-sm text-foreground ring-1 ring-foreground/20 outline-none focus:ring-foreground/40"
-          defaultValue={rawTitle}
-          maxLength={MAX_CONVERSATION_TITLE_LENGTH}
-          onBlur={(e) => commitRename(e.target.value)}
-          onKeyDown={(e) => {
-            if (e.key === 'Enter') commitRename(e.currentTarget.value);
-            else if (e.key === 'Escape') {
-              committedRef.current = true;
-              setIsEditing(false);
-            }
-          }}
-        />
-        <Separator orientation="vertical" />
-      </div>
-    );
-  }
-
   return (
     <ContextMenu>
       <ContextMenuTrigger>
@@ -99,6 +72,7 @@ export const ConversationTabItem = observer(function ConversationTabItem({
           title={tab.isPreview ? `${title} (preview — double-click to keep)` : title}
           onSelect={onSelect}
           onPin={onPin}
+          onDoubleClick={handleDoubleClick}
           onClose={onClose}
         >
           {config ? (
@@ -111,9 +85,30 @@ export const ConversationTabItem = observer(function ConversationTabItem({
               className="size-4 shrink-0"
             />
           ) : null}
-          <TabTitle isActive={tab.isActive} isPreview={tab.isPreview} maxWidth="max-w-24">
-            {title}
-          </TabTitle>
+          {isEditing ? (
+            <input
+              ref={handleRenameInputRef}
+              className="my-1 min-w-0 rounded bg-background-1 px-1.5 text-sm text-foreground ring-1 ring-foreground/20 outline-none focus:ring-foreground/40"
+              style={{ width: renameInputWidth }}
+              defaultValue={rawTitle}
+              maxLength={MAX_CONVERSATION_TITLE_LENGTH}
+              onClick={(e) => e.stopPropagation()}
+              onDoubleClick={(e) => e.stopPropagation()}
+              onBlur={(e) => commitRename(e.target.value)}
+              onKeyDown={(e) => {
+                e.stopPropagation();
+                if (e.key === 'Enter') commitRename(e.currentTarget.value);
+                else if (e.key === 'Escape') {
+                  committedRef.current = true;
+                  setIsEditing(false);
+                }
+              }}
+            />
+          ) : (
+            <TabTitle isActive={tab.isActive} isPreview={tab.isPreview} maxWidth="max-w-24">
+              {title}
+            </TabTitle>
+          )}
           <TabCloseButton
             onClose={onClose}
             ariaLabel={`Close ${title}`}

--- a/src/renderer/features/tasks/view/tab-bar/conversation-tab-item.tsx
+++ b/src/renderer/features/tasks/view/tab-bar/conversation-tab-item.tsx
@@ -69,7 +69,7 @@ export const ConversationTabItem = observer(function ConversationTabItem({
         <TabItemShell
           tabId={tab.tabId}
           isActive={tab.isActive}
-          title={tab.isPreview ? `${title} (preview — double-click to keep)` : title}
+          title={tab.isPreview ? `${title} (preview — double-click to keep and rename)` : title}
           onSelect={onSelect}
           onPin={onPin}
           onDoubleClick={handleDoubleClick}

--- a/src/renderer/features/tasks/view/tab-bar/tab-item-shell.tsx
+++ b/src/renderer/features/tasks/view/tab-bar/tab-item-shell.tsx
@@ -19,6 +19,7 @@ export const TabItemShell = observer(function TabItemShell({
   title,
   onSelect,
   onPin,
+  onDoubleClick,
   onClose,
   className,
   innerPaddingRight = 'pr-2',
@@ -29,6 +30,7 @@ export const TabItemShell = observer(function TabItemShell({
   title: string;
   onSelect: () => void;
   onPin: () => void;
+  onDoubleClick?: () => void;
   onClose: () => void;
   className?: string;
   activeClassName?: string;
@@ -41,9 +43,17 @@ export const TabItemShell = observer(function TabItemShell({
 
   return (
     <DraggableTab id={tabId}>
-      <button
+      <div
+        role="button"
+        tabIndex={0}
         onClick={onSelect}
-        onDoubleClick={onPin}
+        onDoubleClick={onDoubleClick ?? onPin}
+        onKeyDown={(e) => {
+          if (e.key === 'Enter' || e.key === ' ') {
+            e.preventDefault();
+            onSelect();
+          }
+        }}
         onMouseDown={(e) => {
           if (e.button === 1) e.preventDefault();
         }}
@@ -65,7 +75,7 @@ export const TabItemShell = observer(function TabItemShell({
         <div className={cn('flex h-full items-center gap-1.5 pl-3', innerPaddingRight)}>
           {children}
         </div>
-      </button>
+      </div>
       <Separator orientation="vertical" />
     </DraggableTab>
   );


### PR DESCRIPTION
### Description
- adds double click on tab names to rename quickly 

### Screenshot/Recording (if applicable)
https://streamable.com/aecsro

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
