### PR TITLE
feat(project-settings): add lifecycle script auto-run toggles

### DIFF
--- a/src/main/core/workspaces/workspace-factory.ts
+++ b/src/main/core/workspaces/workspace-factory.ts
@@ -182,25 +182,48 @@ export function createWorkspaceFactory(
         }
         statusPoller?.start();
         void workspaceFileIndexService.onWorkspaceCreated(workspaceId, ws);
-        if (scripts?.setup) {
-          void runLifecycleScriptWithPolicy({
-            workspace: ws,
-            projectId: context.projectId,
-            taskId: context.task.id,
-            workspaceId,
-            type: 'setup',
-            script: scripts.setup,
-            shellSetup,
-            origin: 'auto-setup',
-            policy: {
-              respawnAfterExit: true,
-              logFailure: true,
-              surfaceFailure: true,
-              continueOnFailure: true,
-            },
-            logPrefix,
-          });
-        }
+        void (async () => {
+          if (scripts?.setup && (projectSettings.autoRunSetupScriptOnTaskCreation ?? true)) {
+            const setupResult = await runLifecycleScriptWithPolicy({
+              workspace: ws,
+              projectId: context.projectId,
+              taskId: context.task.id,
+              workspaceId,
+              type: 'setup',
+              script: scripts.setup,
+              shellSetup,
+              origin: 'auto-setup',
+              policy: {
+                respawnAfterExit: true,
+                logFailure: true,
+                surfaceFailure: true,
+                continueOnFailure: true,
+              },
+              logPrefix,
+            });
+            if (setupResult.kind !== 'succeeded') return;
+          }
+
+          if (scripts?.run && (projectSettings.autoRunRunScriptOnTaskCreation ?? false)) {
+            await runLifecycleScriptWithPolicy({
+              workspace: ws,
+              projectId: context.projectId,
+              taskId: context.task.id,
+              workspaceId,
+              type: 'run',
+              script: scripts.run,
+              shellSetup,
+              origin: 'auto-run',
+              policy: {
+                respawnAfterExit: true,
+                logFailure: true,
+                surfaceFailure: true,
+                continueOnFailure: true,
+              },
+              logPrefix,
+            });
+          }
+        })();
       },
 
       onCreate: context.extraHooks?.onCreate,

--- a/src/renderer/features/automations/components/AutomationPanelHeader.tsx
+++ b/src/renderer/features/automations/components/AutomationPanelHeader.tsx
@@ -110,14 +110,14 @@ export function AutomationPanelHeader({
           ) : null}
         </div>
       ) : null}
-              <button
-          type="button"
-          onClick={onClose}
-          aria-label="Close panel"
-          className="text-muted-foreground hover:bg-muted rounded-md p-1 transition-colors hover:text-foreground"
-        >
-          <X className="size-4" />
-        </button>
+      <button
+        type="button"
+        onClick={onClose}
+        aria-label="Close panel"
+        className="text-muted-foreground hover:bg-muted rounded-md p-1 transition-colors hover:text-foreground"
+      >
+        <X className="size-4" />
+      </button>
     </div>
   );
 }

--- a/src/renderer/features/automations/components/AutomationsHeader.tsx
+++ b/src/renderer/features/automations/components/AutomationsHeader.tsx
@@ -1,8 +1,7 @@
 import { Plus } from 'lucide-react';
+import { PageHeader } from '@renderer/lib/components/page-header';
 import { Button } from '@renderer/lib/ui/button';
 import { SearchInput } from '@renderer/lib/ui/search-input';
-import { cn } from '@renderer/utils/utils';
-import { PageHeader } from '@renderer/lib/components/page-header';
 
 interface AutomationsHeaderProps {
   title: string;
@@ -22,7 +21,6 @@ export function AutomationsHeader({
   subtitle,
   showActions,
   showNewButton,
-  panelOpen,
   search,
   onSearchChange,
   searchPlaceholder,
@@ -51,7 +49,6 @@ export function AutomationsHeader({
           ) : null}
         </div>
       )}
-
     </PageHeader>
   );
 }

--- a/src/renderer/features/projects/components/settings-view/project-settings-form-model.test.ts
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form-model.test.ts
@@ -19,6 +19,8 @@ function makeForm(overrides: Partial<FormState> = {}): FormState {
     preservePatterns: '',
     shellSetup: '',
     tmux: false,
+    autoRunSetupScriptOnTaskCreation: true,
+    autoRunRunScriptOnTaskCreation: false,
     scriptSetup: '',
     scriptRun: '',
     scriptTeardown: '',
@@ -39,6 +41,8 @@ describe('project settings form model', () => {
         preservePatterns: ['.env', '.env.local'],
         shellSetup: 'source .envrc',
         tmux: true,
+        autoRunSetupScriptOnTaskCreation: false,
+        autoRunRunScriptOnTaskCreation: true,
         scripts: {
           setup: 'pnpm install',
           run: 'pnpm dev',
@@ -62,6 +66,8 @@ describe('project settings form model', () => {
       preservePatterns: '.env\n.env.local',
       shellSetup: 'source .envrc',
       tmux: true,
+      autoRunSetupScriptOnTaskCreation: false,
+      autoRunRunScriptOnTaskCreation: true,
       scriptSetup: 'pnpm install',
       scriptRun: 'pnpm dev',
       scriptTeardown: 'docker compose down',
@@ -100,6 +106,8 @@ describe('project settings form model', () => {
           preservePatterns: ' .env \n\n.env.local ',
           shellSetup: 'source .envrc',
           tmux: true,
+          autoRunSetupScriptOnTaskCreation: false,
+          autoRunRunScriptOnTaskCreation: true,
           scriptRun: 'pnpm dev',
           worktreeDirectory: '../worktrees',
           defaultBranch: { type: 'remote', branch: 'main', remote: origin },
@@ -113,6 +121,8 @@ describe('project settings form model', () => {
       preservePatterns: ['.env', '.env.local'],
       shellSetup: 'source .envrc',
       tmux: true,
+      autoRunSetupScriptOnTaskCreation: false,
+      autoRunRunScriptOnTaskCreation: true,
       scripts: {
         setup: undefined,
         run: 'pnpm dev',
@@ -127,6 +137,11 @@ describe('project settings form model', () => {
         terminateCommand: './terminate.sh',
       },
     });
+  });
+
+  it('omits default auto-run lifecycle settings from persisted form settings', () => {
+    expect(formToSettings(makeForm())).not.toHaveProperty('autoRunSetupScriptOnTaskCreation');
+    expect(formToSettings(makeForm())).not.toHaveProperty('autoRunRunScriptOnTaskCreation');
   });
 
   it('requires workspace provider commands to be filled together', () => {

--- a/src/renderer/features/projects/components/settings-view/project-settings-form-model.ts
+++ b/src/renderer/features/projects/components/settings-view/project-settings-form-model.ts
@@ -11,6 +11,8 @@ export type FormState = {
   preservePatterns: string;
   shellSetup: string;
   tmux: boolean;
+  autoRunSetupScriptOnTaskCreation: boolean;
+  autoRunRunScriptOnTaskCreation: boolean;
   scriptSetup: string;
   scriptRun: string;
   scriptTeardown: string;
@@ -52,6 +54,8 @@ export function settingsToForm(
     preservePatterns: (s.preservePatterns ?? []).join('\n'),
     shellSetup: s.shellSetup ?? '',
     tmux: s.tmux ?? false,
+    autoRunSetupScriptOnTaskCreation: s.autoRunSetupScriptOnTaskCreation ?? true,
+    autoRunRunScriptOnTaskCreation: s.autoRunRunScriptOnTaskCreation ?? false,
     scriptSetup: normalizeScript(s.scripts?.setup),
     scriptRun: normalizeScript(s.scripts?.run),
     scriptTeardown: normalizeScript(s.scripts?.teardown),
@@ -88,6 +92,8 @@ export function formToSettings(f: FormState): ProjectSettings {
     preservePatterns: preservePatterns.length > 0 ? preservePatterns : undefined,
     shellSetup: blankToUndefined(f.shellSetup),
     tmux: f.tmux,
+    ...(f.autoRunSetupScriptOnTaskCreation ? {} : { autoRunSetupScriptOnTaskCreation: false }),
+    ...(f.autoRunRunScriptOnTaskCreation ? { autoRunRunScriptOnTaskCreation: true } : {}),
     scripts: hasScripts ? scripts : undefined,
     worktreeDirectory: blankToUndefined(f.worktreeDirectory),
     defaultBranch,

--- a/src/renderer/features/projects/components/settings-view/sections/shareable-project-settings-section.tsx
+++ b/src/renderer/features/projects/components/settings-view/sections/shareable-project-settings-section.tsx
@@ -1,28 +1,29 @@
-import { Fragment } from 'react';
-import { rpc } from '@renderer/lib/ipc';
-import { Button } from '@renderer/lib/ui/button';
-import { Field, FieldDescription, FieldTitle } from '@renderer/lib/ui/field';
-import { Input } from '@renderer/lib/ui/input';
-import { Separator } from '@renderer/lib/ui/separator';
-import { Textarea } from '@renderer/lib/ui/textarea';
+import { Fragment } from "react";
+import { rpc } from "@renderer/lib/ipc";
+import { Button } from "@renderer/lib/ui/button";
+import { Field, FieldDescription, FieldTitle } from "@renderer/lib/ui/field";
+import { Input } from "@renderer/lib/ui/input";
+import { Separator } from "@renderer/lib/ui/separator";
+import { Switch } from "@renderer/lib/ui/switch";
+import { Textarea } from "@renderer/lib/ui/textarea";
 import type {
   ProjectConfigMigration,
   ProjectSettingsOverrideState,
   ShareableProjectSettingsWriteField,
-} from '@shared/project-settings';
-import { ConfigMigrationNotice } from '../config-migration-notice';
-import type { FormState, FormUpdate } from '../project-settings-form-model';
+} from "@shared/project-settings";
+import { ConfigMigrationNotice } from "../config-migration-notice";
+import type { FormState, FormUpdate } from "../project-settings-form-model";
 import {
   SHAREABLE_FIELD_DESCRIPTORS,
   type ShareableFieldDescriptor,
-} from '../shareable-project-settings-fields';
-import { ShareableSettingTitle } from '../shareable-setting-title';
+} from "../shareable-project-settings-fields";
+import { ShareableSettingTitle } from "../shareable-setting-title";
 
 type ShareableSettingsSectionProps = {
   form: FormState;
   update: FormUpdate;
   getOverrideSources: (
-    field: ShareableProjectSettingsWriteField
+    field: ShareableProjectSettingsWriteField,
   ) => ProjectSettingsOverrideState[ShareableProjectSettingsWriteField];
   configMigrations: ProjectConfigMigration[];
   importDisabled: boolean;
@@ -38,29 +39,34 @@ function ShareableField({
   form,
   update,
   getOverrideSources,
+  beforeInput,
 }: {
   descriptor: ShareableFieldDescriptor;
   form: FormState;
   update: FormUpdate;
-  getOverrideSources: ShareableSettingsSectionProps['getOverrideSources'];
+  getOverrideSources: ShareableSettingsSectionProps["getOverrideSources"];
+  beforeInput?: React.ReactNode;
 }) {
   return (
     <Field>
       <ShareableSettingTitle
         leafLabel={descriptor.leafLabel}
         overrideSources={getOverrideSources(descriptor.id)}
-        onRestore={() => update(descriptor.formKey, '')}
+        onRestore={() => update(descriptor.formKey, "")}
       >
-        {descriptor.group ? titleCase(descriptor.leafLabel) : descriptor.modalLabel}
+        {descriptor.group
+          ? titleCase(descriptor.leafLabel)
+          : descriptor.modalLabel}
       </ShareableSettingTitle>
       {descriptor.description ? (
         <FieldDescription className="text-foreground-muted">
           {descriptor.description}
         </FieldDescription>
       ) : null}
+      {beforeInput}
       {descriptor.multiline ? (
         <Textarea
-          rows={descriptor.id === 'preservePatterns' ? 5 : 3}
+          rows={descriptor.id === "preservePatterns" ? 5 : 3}
           placeholder={descriptor.placeholder}
           value={form[descriptor.formKey]}
           onChange={(e) => update(descriptor.formKey, e.target.value)}
@@ -76,6 +82,23 @@ function ShareableField({
   );
 }
 
+function AutoRunToggle({
+  label,
+  checked,
+  onCheckedChange,
+}: {
+  label: string;
+  checked: boolean;
+  onCheckedChange: (checked: boolean) => void;
+}) {
+  return (
+    <div className="flex items-center justify-between">
+      <span className="text-foreground-muted text-sm">{label}</span>
+      <Switch checked={checked} onCheckedChange={onCheckedChange} />
+    </div>
+  );
+}
+
 export function ShareableSettingsSection({
   form,
   update,
@@ -84,9 +107,11 @@ export function ShareableSettingsSection({
   importDisabled,
   openImportConfigModal,
 }: ShareableSettingsSectionProps) {
-  const topLevelFields = SHAREABLE_FIELD_DESCRIPTORS.filter((descriptor) => !descriptor.group);
+  const topLevelFields = SHAREABLE_FIELD_DESCRIPTORS.filter(
+    (descriptor) => !descriptor.group,
+  );
   const lifecycleFields = SHAREABLE_FIELD_DESCRIPTORS.filter(
-    (descriptor) => descriptor.group === 'lifecycle'
+    (descriptor) => descriptor.group === "lifecycle",
   );
 
   return (
@@ -111,14 +136,20 @@ export function ShareableSettingsSection({
         <div className="flex flex-col gap-1">
           <FieldTitle>Lifecycle scripts</FieldTitle>
           <FieldDescription className="text-foreground-muted">
-            Shell commands run at each stage of the worktree lifecycle. One command per line.
+            Shell commands run at each stage of the worktree lifecycle. One
+            command per line. When both are set to auto-run, the Run script
+            waits for Setup to complete.
             <span> See </span>
             <Button
               type="button"
               variant="link"
               size="sm"
               className="group text-muted-foreground inline-flex h-auto cursor-pointer items-center gap-1 px-0 text-sm font-normal hover:text-foreground hover:no-underline focus-visible:ring-0 focus-visible:outline-none"
-              onClick={() => rpc.app.openExternal('https://www.emdash.sh/docs/project-config')}
+              onClick={() =>
+                rpc.app.openExternal(
+                  "https://www.emdash.sh/docs/project-config",
+                )
+              }
             >
               <span className="font-mono text-xs transition-colors group-hover:text-foreground">
                 docs
@@ -138,6 +169,25 @@ export function ShareableSettingsSection({
             form={form}
             update={update}
             getOverrideSources={getOverrideSources}
+            beforeInput={
+              descriptor.id === "scripts.setup" ? (
+                <AutoRunToggle
+                  label="Auto-run on task creation"
+                  checked={form.autoRunSetupScriptOnTaskCreation}
+                  onCheckedChange={(checked) =>
+                    update("autoRunSetupScriptOnTaskCreation", checked)
+                  }
+                />
+              ) : descriptor.id === "scripts.run" ? (
+                <AutoRunToggle
+                  label="Auto-run on task creation"
+                  checked={form.autoRunRunScriptOnTaskCreation}
+                  onCheckedChange={(checked) =>
+                    update("autoRunRunScriptOnTaskCreation", checked)
+                  }
+                />
+              ) : undefined
+            }
           />
         ))}
 

--- a/src/renderer/features/projects/components/settings-view/sections/shareable-project-settings-section.tsx
+++ b/src/renderer/features/projects/components/settings-view/sections/shareable-project-settings-section.tsx
@@ -1,29 +1,29 @@
-import { Fragment } from "react";
-import { rpc } from "@renderer/lib/ipc";
-import { Button } from "@renderer/lib/ui/button";
-import { Field, FieldDescription, FieldTitle } from "@renderer/lib/ui/field";
-import { Input } from "@renderer/lib/ui/input";
-import { Separator } from "@renderer/lib/ui/separator";
-import { Switch } from "@renderer/lib/ui/switch";
-import { Textarea } from "@renderer/lib/ui/textarea";
+import { Fragment } from 'react';
+import { rpc } from '@renderer/lib/ipc';
+import { Button } from '@renderer/lib/ui/button';
+import { Field, FieldDescription, FieldTitle } from '@renderer/lib/ui/field';
+import { Input } from '@renderer/lib/ui/input';
+import { Separator } from '@renderer/lib/ui/separator';
+import { Switch } from '@renderer/lib/ui/switch';
+import { Textarea } from '@renderer/lib/ui/textarea';
 import type {
   ProjectConfigMigration,
   ProjectSettingsOverrideState,
   ShareableProjectSettingsWriteField,
-} from "@shared/project-settings";
-import { ConfigMigrationNotice } from "../config-migration-notice";
-import type { FormState, FormUpdate } from "../project-settings-form-model";
+} from '@shared/project-settings';
+import { ConfigMigrationNotice } from '../config-migration-notice';
+import type { FormState, FormUpdate } from '../project-settings-form-model';
 import {
   SHAREABLE_FIELD_DESCRIPTORS,
   type ShareableFieldDescriptor,
-} from "../shareable-project-settings-fields";
-import { ShareableSettingTitle } from "../shareable-setting-title";
+} from '../shareable-project-settings-fields';
+import { ShareableSettingTitle } from '../shareable-setting-title';
 
 type ShareableSettingsSectionProps = {
   form: FormState;
   update: FormUpdate;
   getOverrideSources: (
-    field: ShareableProjectSettingsWriteField,
+    field: ShareableProjectSettingsWriteField
   ) => ProjectSettingsOverrideState[ShareableProjectSettingsWriteField];
   configMigrations: ProjectConfigMigration[];
   importDisabled: boolean;
@@ -44,7 +44,7 @@ function ShareableField({
   descriptor: ShareableFieldDescriptor;
   form: FormState;
   update: FormUpdate;
-  getOverrideSources: ShareableSettingsSectionProps["getOverrideSources"];
+  getOverrideSources: ShareableSettingsSectionProps['getOverrideSources'];
   beforeInput?: React.ReactNode;
 }) {
   return (
@@ -52,11 +52,9 @@ function ShareableField({
       <ShareableSettingTitle
         leafLabel={descriptor.leafLabel}
         overrideSources={getOverrideSources(descriptor.id)}
-        onRestore={() => update(descriptor.formKey, "")}
+        onRestore={() => update(descriptor.formKey, '')}
       >
-        {descriptor.group
-          ? titleCase(descriptor.leafLabel)
-          : descriptor.modalLabel}
+        {descriptor.group ? titleCase(descriptor.leafLabel) : descriptor.modalLabel}
       </ShareableSettingTitle>
       {descriptor.description ? (
         <FieldDescription className="text-foreground-muted">
@@ -66,7 +64,7 @@ function ShareableField({
       {beforeInput}
       {descriptor.multiline ? (
         <Textarea
-          rows={descriptor.id === "preservePatterns" ? 5 : 3}
+          rows={descriptor.id === 'preservePatterns' ? 5 : 3}
           placeholder={descriptor.placeholder}
           value={form[descriptor.formKey]}
           onChange={(e) => update(descriptor.formKey, e.target.value)}
@@ -93,7 +91,7 @@ function AutoRunToggle({
 }) {
   return (
     <div className="flex items-center justify-between">
-      <span className="text-foreground-muted text-sm">{label}</span>
+      <span className="text-sm text-foreground-muted">{label}</span>
       <Switch checked={checked} onCheckedChange={onCheckedChange} />
     </div>
   );
@@ -107,11 +105,9 @@ export function ShareableSettingsSection({
   importDisabled,
   openImportConfigModal,
 }: ShareableSettingsSectionProps) {
-  const topLevelFields = SHAREABLE_FIELD_DESCRIPTORS.filter(
-    (descriptor) => !descriptor.group,
-  );
+  const topLevelFields = SHAREABLE_FIELD_DESCRIPTORS.filter((descriptor) => !descriptor.group);
   const lifecycleFields = SHAREABLE_FIELD_DESCRIPTORS.filter(
-    (descriptor) => descriptor.group === "lifecycle",
+    (descriptor) => descriptor.group === 'lifecycle'
   );
 
   return (
@@ -136,20 +132,15 @@ export function ShareableSettingsSection({
         <div className="flex flex-col gap-1">
           <FieldTitle>Lifecycle scripts</FieldTitle>
           <FieldDescription className="text-foreground-muted">
-            Shell commands run at each stage of the worktree lifecycle. One
-            command per line. When both are set to auto-run, the Run script
-            waits for Setup to complete.
+            Shell commands run at each stage of the worktree lifecycle. One command per line. When
+            both are set to auto-run, the Run script waits for Setup to complete.
             <span> See </span>
             <Button
               type="button"
               variant="link"
               size="sm"
               className="group text-muted-foreground inline-flex h-auto cursor-pointer items-center gap-1 px-0 text-sm font-normal hover:text-foreground hover:no-underline focus-visible:ring-0 focus-visible:outline-none"
-              onClick={() =>
-                rpc.app.openExternal(
-                  "https://www.emdash.sh/docs/project-config",
-                )
-              }
+              onClick={() => rpc.app.openExternal('https://www.emdash.sh/docs/project-config')}
             >
               <span className="font-mono text-xs transition-colors group-hover:text-foreground">
                 docs
@@ -170,21 +161,17 @@ export function ShareableSettingsSection({
             update={update}
             getOverrideSources={getOverrideSources}
             beforeInput={
-              descriptor.id === "scripts.setup" ? (
+              descriptor.id === 'scripts.setup' ? (
                 <AutoRunToggle
                   label="Auto-run on task creation"
                   checked={form.autoRunSetupScriptOnTaskCreation}
-                  onCheckedChange={(checked) =>
-                    update("autoRunSetupScriptOnTaskCreation", checked)
-                  }
+                  onCheckedChange={(checked) => update('autoRunSetupScriptOnTaskCreation', checked)}
                 />
-              ) : descriptor.id === "scripts.run" ? (
+              ) : descriptor.id === 'scripts.run' ? (
                 <AutoRunToggle
                   label="Auto-run on task creation"
                   checked={form.autoRunRunScriptOnTaskCreation}
-                  onCheckedChange={(checked) =>
-                    update("autoRunRunScriptOnTaskCreation", checked)
-                  }
+                  onCheckedChange={(checked) => update('autoRunRunScriptOnTaskCreation', checked)}
                 />
               ) : undefined
             }

--- a/src/shared/events/taskEvents.ts
+++ b/src/shared/events/taskEvents.ts
@@ -33,7 +33,7 @@ export const taskProvisionProgressChannel = defineEvent<{
 }>('task:provision-progress');
 
 export type LifecycleScriptType = 'setup' | 'run' | 'teardown';
-export type LifecycleScriptOrigin = 'auto-setup' | 'manual' | 'workspace-destroy';
+export type LifecycleScriptOrigin = 'auto-setup' | 'auto-run' | 'manual' | 'workspace-destroy';
 
 export type LifecycleScriptStatusEvent = {
   taskId: string;

--- a/src/shared/project-settings.ts
+++ b/src/shared/project-settings.ts
@@ -46,6 +46,8 @@ export const baseProjectSettingsSchema = z.object({
   baseRemote: z.string().optional(),
   pushRemote: z.string().optional(),
   tmux: z.boolean().optional(),
+  autoRunSetupScriptOnTaskCreation: z.boolean().optional(),
+  autoRunRunScriptOnTaskCreation: z.boolean().optional(),
   workspaceProvider: z
     .object({
       type: z.literal('script'),


### PR DESCRIPTION
- adds project-level toggles for auto-running setup and run lifecycle scripts on task creation
- keeps setup auto-run enabled by default and makes run auto-run opt-in
- places the toggles next to the lifecycle script configuration in project settings
- starts run only after setup succeeds when both auto-run toggles are enabled
- logs lifecycle script failures without blocking task creation
<img width="789" height="368" alt="Screenshot 2026-06-03 at 10 30 35" src="https://github.com/user-attachments/assets/99469802-f8c8-46d0-ba6e-8acb0e415915" />
