### PR TITLE
fix(claude): handle claude hook completion reliably

### DIFF
--- a/src/main/core/agent-hooks/event-enricher.test.ts
+++ b/src/main/core/agent-hooks/event-enricher.test.ts
@@ -49,7 +49,7 @@ describe('enrichEvent', () => {
     expect(event.payload.message).toBe('Done');
   });
 
-  it('treats Claude notifications without an explicit notification type as attention', async () => {
+  it('treats Claude notifications without an explicit notification type as permission_prompt', async () => {
     const event = await enrichEvent({
       ptyId: makePtyId('claude', 'conversation-1'),
       type: 'notification',

--- a/src/main/core/agent-hooks/event-enricher.test.ts
+++ b/src/main/core/agent-hooks/event-enricher.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePtyId } from '@shared/ptyId';
+import { enrichEvent } from './event-enricher';
+
+const mockLimit = vi.hoisted(() => vi.fn());
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn(() => ({
+          limit: mockLimit,
+        })),
+      })),
+    })),
+  },
+}));
+
+describe('enrichEvent', () => {
+  beforeEach(() => {
+    mockLimit.mockReset();
+    mockLimit.mockResolvedValue([{ taskId: 'task-1', projectId: 'project-1' }]);
+  });
+
+  it('accepts Claude stop hooks with empty stdin', async () => {
+    const event = await enrichEvent({
+      ptyId: makePtyId('claude', 'conversation-1'),
+      type: 'stop',
+      body: '',
+    });
+
+    expect(event).toMatchObject({
+      type: 'stop',
+      providerId: 'claude',
+      projectId: 'project-1',
+      taskId: 'task-1',
+      conversationId: 'conversation-1',
+      payload: {},
+    });
+  });
+
+  it('accepts Claude hooks with plain text stdin', async () => {
+    const event = await enrichEvent({
+      ptyId: makePtyId('claude', 'conversation-1'),
+      type: 'stop',
+      body: 'Done',
+    });
+
+    expect(event.payload.message).toBe('Done');
+  });
+
+  it('treats Claude notifications without an explicit notification type as attention', async () => {
+    const event = await enrichEvent({
+      ptyId: makePtyId('claude', 'conversation-1'),
+      type: 'notification',
+      body: '{"message":"Claude needs input"}',
+    });
+
+    expect(event.payload).toMatchObject({
+      message: 'Claude needs input',
+      notificationType: 'permission_prompt',
+    });
+  });
+});

--- a/src/main/core/agent-hooks/event-enricher.ts
+++ b/src/main/core/agent-hooks/event-enricher.ts
@@ -24,6 +24,10 @@ function normalizePayload(
     payload.notificationType = 'idle_prompt';
   }
 
+  if (!payload.notificationType && providerId === 'claude' && eventType === 'notification') {
+    payload.notificationType = 'permission_prompt';
+  }
+
   if (!payload.notificationType && providerId === 'grok' && eventType === 'notification') {
     payload.notificationType = 'permission_prompt';
   }
@@ -40,6 +44,16 @@ function normalizePayload(
   return payload;
 }
 
+function parseHookBody(body: string): Record<string, unknown> {
+  if (!body.trim()) return {};
+  try {
+    const parsed = JSON.parse(body);
+    return parsed && typeof parsed === 'object' && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    return { message: body };
+  }
+}
+
 export async function enrichEvent(raw: RawHookRequest): Promise<AgentEvent> {
   const parsed = parsePtyId(raw.ptyId);
   if (!parsed) {
@@ -54,7 +68,7 @@ export async function enrichEvent(raw: RawHookRequest): Promise<AgentEvent> {
 
   const taskId = convRows.taskId;
   const projectId = convRows.projectId;
-  const body = raw.body ? JSON.parse(raw.body) : {};
+  const body = parseHookBody(raw.body);
   const payload = normalizePayload(parsed.providerId, raw.type, body);
 
   return {

--- a/src/main/core/agent-hooks/hook-config.test.ts
+++ b/src/main/core/agent-hooks/hook-config.test.ts
@@ -64,6 +64,50 @@ describe('HookConfigWriter', () => {
     expect(fs.files.has('.gitignore')).toBe(false);
   });
 
+  it('writes Claude hooks with matchers to the project-local settings file', async () => {
+    mockResolveCommandPath.mockResolvedValue('/usr/local/bin/claude');
+    const fs = new MemoryFs();
+    const writer = makeWriter(fs);
+
+    const wroteConfig = await writer.writeForProvider('claude');
+
+    expect(wroteConfig).toBe(true);
+    const config = JSON.parse(fs.files.get('.claude/settings.local.json')!);
+    expect(config.hooks.Notification[0].matcher).toBe('.*');
+    expect(config.hooks.Notification[0].hooks[0].command).toContain(
+      'X-Emdash-Event-Type: notification'
+    );
+    expect(config.hooks.Stop[0].matcher).toBe('.*');
+    expect(config.hooks.Stop[0].hooks[0].command).toContain('X-Emdash-Event-Type: stop');
+    expect(config.hooks.Stop[0].hooks[0].command).toContain('X-Emdash-Pty-Id');
+    expect(fs.files.get('.gitignore')).toBe('.claude/settings.local.json\n');
+  });
+
+  it('preserves unrelated Claude hooks while replacing Emdash-managed entries', async () => {
+    mockResolveCommandPath.mockResolvedValue('/usr/local/bin/claude');
+    const fs = new MemoryFs();
+    fs.files.set(
+      '.claude/settings.local.json',
+      JSON.stringify({
+        hooks: {
+          Stop: [
+            { matcher: '.*', hooks: [{ type: 'command', command: 'echo user hook' }] },
+            { matcher: '.*', hooks: [{ type: 'command', command: 'echo $EMDASH_HOOK_PORT' }] },
+          ],
+        },
+      })
+    );
+    const writer = makeWriter(fs);
+
+    await writer.writeForProvider('claude');
+
+    const config = JSON.parse(fs.files.get('.claude/settings.local.json')!);
+    expect(config.hooks.Stop).toHaveLength(2);
+    expect(config.hooks.Stop[0].hooks[0].command).toBe('echo user hook');
+    expect(config.hooks.Stop[1].matcher).toBe('.*');
+    expect(config.hooks.Stop[1].hooks[0].command).toContain('X-Emdash-Event-Type: stop');
+  });
+
   it('writes Codex hooks to the global user config and does not update gitignore', async () => {
     mockResolveCommandPath.mockResolvedValue('/usr/local/bin/codex');
     const fs = new MemoryFs();

--- a/src/main/core/agent-hooks/hook-config.ts
+++ b/src/main/core/agent-hooks/hook-config.ts
@@ -121,7 +121,7 @@ export class HookConfigWriter {
 
     for (const { eventType, hookKey } of HOOK_EVENT_MAP) {
       const existing = Array.isArray(hooks[hookKey]) ? hooks[hookKey] : [];
-      hooks[hookKey] = this.buildHookEntries(
+      hooks[hookKey] = this.buildClaudeHookEntries(
         existing,
         makeClaudeHookCommand(eventType, { platform: this.platform })
       );
@@ -504,6 +504,11 @@ export class HookConfigWriter {
   private buildHookEntries(existing: unknown[], command: string): unknown[] {
     const userEntries = existing.filter((entry) => !JSON.stringify(entry).includes(EMDASH_MARKER));
     return [...userEntries, { hooks: [{ type: 'command', command }] }];
+  }
+
+  private buildClaudeHookEntries(existing: unknown[], command: string): unknown[] {
+    const userEntries = existing.filter((entry) => !JSON.stringify(entry).includes(EMDASH_MARKER));
+    return [...userEntries, { matcher: '.*', hooks: [{ type: 'command', command }] }];
   }
 
   private buildCopilotHookEntries(existing: unknown[], command: string): unknown[] {

--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -297,6 +297,30 @@ describe('conversation provider respawn state', () => {
     expect(wireAgentClassifier).not.toHaveBeenCalled();
   });
 
+  it('keeps the output classifier as a fallback for Claude when hook config is available', async () => {
+    hookConfigWriteForProvider.mockResolvedValue(true);
+    vi.mocked(agentHookService.getPort).mockReturnValue(1234);
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    const pty = fakePty(exitHandlers);
+    spawnLocalPty.mockReturnValue(pty);
+    const item = { ...conversation(), providerId: 'claude' as const };
+
+    await localProvider().startSession(item);
+
+    expect(hookConfigWriteForProvider).toHaveBeenCalledWith('claude', {
+      writeGitIgnoreEntries: true,
+    });
+    expect(wireAgentClassifier).toHaveBeenCalledWith(
+      expect.objectContaining({
+        pty,
+        providerId: 'claude',
+        projectId: 'project-1',
+        taskId: 'task-1',
+        conversationId: 'conversation-1',
+      })
+    );
+  });
+
   it('starts a local conversation fresh after a resumed session exits', async () => {
     vi.useFakeTimers();
     try {

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -201,15 +201,16 @@ export class LocalConversationProvider implements ConversationProvider {
       });
 
       /*
-       * Codex hooks can be skipped by the CLI in some live-session edge cases.
-       * Amp hooks only cover lifecycle events today, and Grok hook emission is
-       * still early-beta. Keep the output classifier active as a fallback so
-       * the UI can leave "working" and catch prompts.
+       * Codex and Claude hooks can be skipped by the CLI in some live-session
+       * edge cases. Amp hooks only cover lifecycle events today, and Grok hook
+       * emission is still early-beta. Keep the output classifier active as a
+       * fallback so the UI can leave "working" and catch prompts.
        */
       const useHooksOnly =
         hookActive &&
         providerDef?.supportsHooks &&
         hooksAvailable &&
+        conversation.providerId !== 'claude' &&
         conversation.providerId !== 'codex' &&
         conversation.providerId !== 'grok' &&
         conversation.providerId !== 'amp';


### PR DESCRIPTION
### Description
- fixed claude agent is working by keeping the output classifier as a fallback when hooks are active
- claude hook also accpet plan text and or empty as payload

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
