### PR TITLE
fix(tasks): clear running status when agent session exits

### DIFF
--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -812,6 +812,7 @@ describe('conversation provider respawn state', () => {
 
     await provider.startSession(item);
     await provider.detachSession(item.id);
+    vi.mocked(events.emit).mockClear();
     await provider.stopSession(item.id);
 
     expect(ctx.exec).toHaveBeenCalledWith('tmux', [
@@ -819,6 +820,10 @@ describe('conversation provider respawn state', () => {
       '-t',
       expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
     ]);
+    expect(events.emit).toHaveBeenCalledWith(agentSessionExitedChannel, {
+      conversationId: item.id,
+      taskId: item.taskId,
+    });
     expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
   });
 
@@ -837,6 +842,7 @@ describe('conversation provider respawn state', () => {
 
     await provider.startSession(item);
     await provider.detachSession(item.id);
+    vi.mocked(events.emit).mockClear();
     await provider.stopSession(item.id);
 
     expect(ctx.exec).toHaveBeenCalledWith('tmux', [
@@ -844,6 +850,10 @@ describe('conversation provider respawn state', () => {
       '-t',
       expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
     ]);
+    expect(events.emit).toHaveBeenCalledWith(agentSessionExitedChannel, {
+      conversationId: item.id,
+      taskId: item.taskId,
+    });
     expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
   });
 

--- a/src/main/core/conversations/impl/local-conversation.ts
+++ b/src/main/core/conversations/impl/local-conversation.ts
@@ -313,7 +313,7 @@ export class LocalConversationProvider implements ConversationProvider {
     }
   }
 
-  private detachPty(sessionId: string): void {
+  private detachPty(sessionId: string): boolean {
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
     ptySessionRegistry.unregister(sessionId);
@@ -327,11 +327,18 @@ export class LocalConversationProvider implements ConversationProvider {
         });
       }
     }
+    return pty !== undefined;
   }
 
   async detachSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.detachPty(sessionId);
+    const detached = this.detachPty(sessionId);
+    if (detached && !this.tmux) {
+      events.emit(agentSessionExitedChannel, {
+        conversationId,
+        taskId: this.taskId,
+      });
+    }
     if (!this.tmux) {
       this.knownSessionIds.delete(sessionId);
       this.supervisor.forget(sessionId);
@@ -340,7 +347,7 @@ export class LocalConversationProvider implements ConversationProvider {
 
   async stopSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.knownSessionIds.delete(sessionId);
+    const wasKnownSession = this.knownSessionIds.delete(sessionId);
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
     ptySessionRegistry.unregister(sessionId);
@@ -357,6 +364,12 @@ export class LocalConversationProvider implements ConversationProvider {
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
+    if (pty || (this.tmux && wasKnownSession)) {
+      events.emit(agentSessionExitedChannel, {
+        conversationId,
+        taskId: this.taskId,
+      });
+    }
     this.supervisor.forget(sessionId);
   }
 
@@ -365,6 +378,12 @@ export class LocalConversationProvider implements ConversationProvider {
     await this.detachAll();
     if (this.tmux) {
       await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
+      for (const sessionId of sessionIds) {
+        events.emit(agentSessionExitedChannel, {
+          conversationId: sessionId.slice(`${this.projectId}:${this.taskId}:`.length),
+          taskId: this.taskId,
+        });
+      }
     }
     for (const sessionId of sessionIds) {
       this.supervisor.forget(sessionId);
@@ -374,11 +393,18 @@ export class LocalConversationProvider implements ConversationProvider {
 
   async detachAll(): Promise<void> {
     for (const [sessionId, pty] of this.sessions) {
+      const conversationId = sessionId.slice(`${this.projectId}:${this.taskId}:`.length);
       this.supervisor.stop(sessionId);
       try {
         pty.kill();
       } catch {}
       ptySessionRegistry.unregister(sessionId);
+      if (!this.tmux) {
+        events.emit(agentSessionExitedChannel, {
+          conversationId,
+          taskId: this.taskId,
+        });
+      }
     }
     this.sessions.clear();
   }

--- a/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/src/main/core/conversations/impl/ssh-conversation.ts
@@ -286,7 +286,7 @@ export class SshConversationProvider implements ConversationProvider {
     }
   }
 
-  private detachPty(sessionId: string): void {
+  private detachPty(sessionId: string): boolean {
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
     ptySessionRegistry.unregister(sessionId);
@@ -300,11 +300,18 @@ export class SshConversationProvider implements ConversationProvider {
         });
       }
     }
+    return pty !== undefined;
   }
 
   async detachSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.detachPty(sessionId);
+    const detached = this.detachPty(sessionId);
+    if (detached && !this.tmux) {
+      events.emit(agentSessionExitedChannel, {
+        conversationId,
+        taskId: this.taskId,
+      });
+    }
     if (!this.tmux) {
       this.knownSessionIds.delete(sessionId);
       this.supervisor.forget(sessionId);
@@ -313,7 +320,7 @@ export class SshConversationProvider implements ConversationProvider {
 
   async stopSession(conversationId: string): Promise<void> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
-    this.knownSessionIds.delete(sessionId);
+    const wasKnownSession = this.knownSessionIds.delete(sessionId);
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
     ptySessionRegistry.unregister(sessionId);
@@ -330,6 +337,12 @@ export class SshConversationProvider implements ConversationProvider {
     if (this.tmux) {
       await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
     }
+    if (pty || (this.tmux && wasKnownSession)) {
+      events.emit(agentSessionExitedChannel, {
+        conversationId,
+        taskId: this.taskId,
+      });
+    }
     this.supervisor.forget(sessionId);
   }
 
@@ -338,6 +351,12 @@ export class SshConversationProvider implements ConversationProvider {
     await this.detachAll();
     if (this.tmux) {
       await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
+      for (const sessionId of sessionIds) {
+        events.emit(agentSessionExitedChannel, {
+          conversationId: sessionId.slice(`${this.projectId}:${this.taskId}:`.length),
+          taskId: this.taskId,
+        });
+      }
     }
     for (const sessionId of sessionIds) {
       this.supervisor.forget(sessionId);
@@ -347,11 +366,18 @@ export class SshConversationProvider implements ConversationProvider {
 
   async detachAll(): Promise<void> {
     for (const [sessionId, pty] of this.sessions) {
+      const conversationId = sessionId.slice(`${this.projectId}:${this.taskId}:`.length);
       this.supervisor.stop(sessionId);
       try {
         pty.kill();
       } catch {}
       ptySessionRegistry.unregister(sessionId);
+      if (!this.tmux) {
+        events.emit(agentSessionExitedChannel, {
+          conversationId,
+          taskId: this.taskId,
+        });
+      }
     }
     this.sessions.clear();
   }

--- a/src/renderer/features/tasks/conversations/conversation-manager.test.ts
+++ b/src/renderer/features/tasks/conversations/conversation-manager.test.ts
@@ -1,10 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { agentSessionExitedChannel } from '@shared/events/agentEvents';
 import { ConversationManagerStore } from './conversation-manager';
 
 const hydrateConversation = vi.hoisted(() => vi.fn());
 const dehydrateConversation = vi.hoisted(() => vi.fn());
 const frontendConnect = vi.hoisted(() => vi.fn());
 const frontendDispose = vi.hoisted(() => vi.fn());
+const eventHandlers = vi.hoisted(() => new Map<unknown, Array<(event: unknown) => void>>());
 
 vi.mock('@renderer/features/tasks/stores/open-file-in-file-editor', () => ({
   makeFileLinkHandlers: () => ({
@@ -14,7 +16,17 @@ vi.mock('@renderer/features/tasks/stores/open-file-in-file-editor', () => ({
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({
-  events: { on: () => () => {} },
+  events: {
+    on: (channel: unknown, handler: (event: unknown) => void) => {
+      const handlers = eventHandlers.get(channel) ?? [];
+      handlers.push(handler);
+      eventHandlers.set(channel, handlers);
+      return () => {
+        const next = (eventHandlers.get(channel) ?? []).filter((h) => h !== handler);
+        eventHandlers.set(channel, next);
+      };
+    },
+  },
   rpc: {
     conversations: {
       dehydrateConversation,
@@ -39,6 +51,7 @@ describe('ConversationManagerStore session hydration', () => {
     dehydrateConversation.mockReset();
     frontendConnect.mockReset();
     frontendDispose.mockReset();
+    eventHandlers.clear();
 
     hydrateConversation.mockResolvedValue(undefined);
     dehydrateConversation.mockResolvedValue(undefined);
@@ -65,6 +78,31 @@ describe('ConversationManagerStore session hydration', () => {
 
     expect(hydrateConversation).not.toHaveBeenCalled();
     expect(frontendConnect).toHaveBeenCalledTimes(1);
+
+    store.dispose();
+  });
+
+  it('clears working task status when an agent session exits', () => {
+    const store = new ConversationManagerStore('project-1', 'task-1', [
+      {
+        id: 'conversation-1',
+        projectId: 'project-1',
+        taskId: 'task-1',
+        providerId: 'codex',
+        title: 'Conversation 1',
+        lastInteractedAt: null,
+        isInitialConversation: false,
+      },
+    ]);
+
+    store.conversations.get('conversation-1')?.setWorking();
+    expect(store.taskStatus).toBe('working');
+
+    for (const handler of eventHandlers.get(agentSessionExitedChannel) ?? []) {
+      handler({ conversationId: 'conversation-1', taskId: 'task-1' });
+    }
+
+    expect(store.taskStatus).toBeNull();
 
     store.dispose();
   });


### PR DESCRIPTION
### Description
- emit agent session exit event when local/ssh sessions are detached/closed
- clear sidebar task running state when underlying agent session closes

### Screenshot/Recording (if applicable)
https://streamable.com/eaqqlm

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
