### PR TITLE
fix: skip letta version probe

### DIFF
--- a/src/main/core/dependencies/dependency-manager.test.ts
+++ b/src/main/core/dependencies/dependency-manager.test.ts
@@ -246,6 +246,32 @@ describe('DependencyManager install', () => {
     expect(ctx.refreshShellEnv).toHaveBeenCalledTimes(1);
   });
 
+  it('skips version probes for dependencies configured as path-only', async () => {
+    const ctx = makeCtx(async (command, args = []) => {
+      if (command === 'which' && args[0] === 'letta') {
+        return { stdout: '/bin/letta\n', stderr: '' };
+      }
+      if (command === '/bin/letta') {
+        throw new Error('letta should not be executed during dependency probing');
+      }
+      throw new Error('missing');
+    });
+    const manager = new DependencyManager(ctx, { emitEvents: false });
+
+    const result = await manager.probe('letta');
+
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'letta',
+        status: 'available',
+        path: '/bin/letta',
+        version: null,
+      })
+    );
+    expect(ctx.exec).toHaveBeenCalledTimes(1);
+    expect(ctx.exec).toHaveBeenCalledWith('which', ['letta'], { timeout: 5000 });
+  });
+
   it('emits dependency updates with the SSH connection id', async () => {
     const manager = new DependencyManager(availableCtx, {
       connectionId: 'ssh-1',

--- a/src/main/core/dependencies/dependency-manager.ts
+++ b/src/main/core/dependencies/dependency-manager.ts
@@ -142,7 +142,7 @@ export class DependencyManager implements IInitializable {
     const pathState = dependencyStateFromProbeResult(descriptor, resolvedPath, null);
     this.updateState(pathState);
 
-    if (pathState.status === 'missing') {
+    if (pathState.status === 'missing' || descriptor.skipVersionProbe) {
       return pathState;
     }
 

--- a/src/main/core/dependencies/registry.ts
+++ b/src/main/core/dependencies/registry.ts
@@ -80,6 +80,7 @@ function buildAgentDependencies(): DependencyDescriptor[] {
     category: 'agent' as const,
     commands: provider.commands ?? [provider.cli ?? provider.id],
     versionArgs: provider.versionArgs ?? ['--version'],
+    skipVersionProbe: provider.skipVersionProbe,
     docUrl: provider.docUrl,
     installHint: provider.installCommand ? `Run: ${provider.installCommand}` : undefined,
     installCommand: provider.installCommand,

--- a/src/main/core/dependencies/types.ts
+++ b/src/main/core/dependencies/types.ts
@@ -17,6 +17,11 @@ export interface DependencyDescriptor {
   commands: string[];
   /** Args passed when probing for a version string. Defaults to ['--version']. */
   versionArgs?: string[];
+  /**
+   * Skip executing the CLI after resolving its path.
+   * Use for CLIs whose version command has project-local side effects.
+   */
+  skipVersionProbe?: boolean;
   docUrl?: string;
   /** Human-readable installation hint shown in UI. */
   installHint?: string;

--- a/src/shared/agent-provider-registry.ts
+++ b/src/shared/agent-provider-registry.ts
@@ -604,7 +604,6 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     docUrl: 'https://docs.letta.com/letta-code/cli',
     installCommand: 'npm install -g @letta-ai/letta-code',
     commands: ['letta'],
-    versionArgs: ['--version'],
     skipVersionProbe: true,
     cli: 'letta',
     autoApproveFlag: '--yolo',

--- a/src/shared/agent-provider-registry.ts
+++ b/src/shared/agent-provider-registry.ts
@@ -42,6 +42,8 @@ export type AgentProviderDefinition = {
   installCommand?: string;
   commands?: string[];
   versionArgs?: string[];
+  /** Skip running the CLI for dependency version detection. */
+  skipVersionProbe?: boolean;
   detectable?: boolean;
   cli?: string;
   autoApproveFlag?: string;
@@ -603,6 +605,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     installCommand: 'npm install -g @letta-ai/letta-code',
     commands: ['letta'],
     versionArgs: ['--version'],
+    skipVersionProbe: true,
     cli: 'letta',
     autoApproveFlag: '--yolo',
     initialPromptFlag: '',


### PR DESCRIPTION
# summary
- dont do "letta --version" it will ALWAYS create a .lettaignore nomatter what; checked the "which letta" should hopefully be enough for a lively check

Recreated from latest main 2157