### PR TITLE
fix(pty): drop convertEol so tmux/claude TUIs render correctly

### DIFF
--- a/src/renderer/lib/pty/pty.ts
+++ b/src/renderer/lib/pty/pty.ts
@@ -82,7 +82,10 @@ export class FrontendPty {
       cols: 120,
       rows: 32,
       scrollback: SCROLLBACK_LINES,
-      convertEol: true,
+      // NOTE: convertEol must stay false (the default). The PTY/app owns line
+      // discipline; rewriting bare \n to \r\n corrupts raw-mode TUIs (tmux, claude
+      // code) that use \n as "line feed, keep column" — yanking the cursor to
+      // column 0 and mangling column alignment, while leaving plain shells fine.
       fontFamily: buildTerminalFontFamily(),
       fontSize: 13,
       lineHeight: 1.2,


### PR DESCRIPTION
## Problem

Terminal output is consistently corrupted **inside tmux and claude code** (and other raw-mode TUIs) — but **not** in a plain shell. Symptoms:

- Column alignment breaks (e.g. claude's `/`-command menu descriptions don't line up).
- Mid-line characters get scrambled/overlapped (`because lamps` → `becaupeslamps`).
- Stale fragments pile up in the leftmost columns.
- **Resizing the window temporarily fixes it; scrolling or new output re-breaks it.**

## Root cause

`FrontendPty` constructs the xterm `Terminal` with **`convertEol: true`** (`src/renderer/lib/pty/pty.ts`), which rewrites every `\n` into `\r\n` (move down **and** return to column 0).

That's harmless for a plain shell, whose output is already `\r\n`. But raw-mode TUIs like **tmux** and **claude code** emit a bare `\n` to mean *"line feed: move down one row, keep the column."* `convertEol` yanks the cursor back to column 0 on every such newline, mangling column-positioned output — which is exactly why the corruption is scoped to those apps and absent in a plain shell. It also explains the "resize fixes it" behavior: a resize triggers an absolute-cursor full redraw (no bare `\n`), so it looks clean until the next `\n`-based update.

On a live PTY the application/PTY owns line discipline; xterm should not rewrite newlines.

## Fix

Remove `convertEol: true` (the default is `false`). One line.

## Testing

- Reproduced the corruption in tmux and claude code inside emdash, confirmed it disappears with `convertEol` removed (verified in a dev build — note a **new terminal tab** is required, since `FrontendPty` owns its xterm for the session's lifetime).
- Plain-shell rendering is unchanged.
- `pnpm run format` / `lint` / `typecheck` clean; `pnpm run test` → 1566 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)