### PR TITLE
fix(sidebar): align conversation icons

### DIFF
--- a/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
+++ b/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
@@ -112,14 +112,14 @@ const ConversationRow = observer(function ConversationRow({
           )}
         >
           {config ? (
-            <span className="shrink-0">
+            <span className="flex size-4 shrink-0 items-center justify-center">
               <AgentLogo
                 logo={config.logo}
                 logoDark={config.logoDark}
                 alt={config.alt}
                 isSvg={config.isSvg}
                 invertInDark={config.invertInDark}
-                className="size-4"
+                className="block size-4"
               />
             </span>
           ) : null}


### PR DESCRIPTION
### Description
- align icons in conversation sidbear

### Screenshot/Recording (if applicable)
before:
<img width="318" height="570" alt="image" src="https://github.com/user-attachments/assets/ee99b69a-5ad7-4785-996d-1645632d0e9d" />

after:
<img width="544" height="514" alt="image" src="https://github.com/user-attachments/assets/8ea6e22e-a57c-4c6f-b5c3-014ffbd25088" />

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
