### PR TITLE
feat(terminal): add Option as Meta key setting for macOS

### DIFF
--- a/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -84,7 +84,12 @@ vi.mock('@main/core/settings/settings-service', () => ({
   appSettingsService: {
     get: vi.fn(async (key: string) =>
       key === 'terminal'
-        ? { autoCopyOnSelection: false, defaultShell: 'system', fontSize: 13 }
+        ? {
+            autoCopyOnSelection: false,
+            macOptionIsMeta: false,
+            defaultShell: 'system',
+            fontSize: 13,
+          }
         : {
             defaultProjectsDirectory: '',
             defaultWorktreeDirectory: '',

--- a/src/main/core/dependencies/dependency-manager.test.ts
+++ b/src/main/core/dependencies/dependency-manager.test.ts
@@ -7,6 +7,7 @@ vi.mock('@main/core/settings/settings-service', () => ({
   appSettingsService: {
     get: vi.fn(async () => ({
       autoCopyOnSelection: false,
+      macOptionIsMeta: false,
       defaultShell: 'system',
       fontSize: 13,
     })),

--- a/src/main/core/settings/schema.ts
+++ b/src/main/core/settings/schema.ts
@@ -47,6 +47,7 @@ export const terminalSettingsSchema = z.object({
   fontFamily: z.string().optional(),
   fontSize: z.number().min(TERMINAL_FONT_SIZE_MIN).max(TERMINAL_FONT_SIZE_MAX).optional(),
   autoCopyOnSelection: z.boolean(),
+  macOptionIsMeta: z.boolean(),
   defaultShell: z.enum(TERMINAL_SHELL_IDS),
 });
 

--- a/src/main/core/settings/settings-registry.ts
+++ b/src/main/core/settings/settings-registry.ts
@@ -41,6 +41,7 @@ export const SETTINGS_DEFAULTS = {
   terminal: {
     fontSize: TERMINAL_FONT_SIZE_DEFAULT,
     autoCopyOnSelection: false,
+    macOptionIsMeta: false,
     defaultShell: 'system' as const,
   },
   theme: null,

--- a/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -1,3 +1,4 @@
+import { detectPlatform } from '@tanstack/react-hotkeys';
 import { ChevronsUpDownIcon, LoaderCircle, Minus, Plus } from 'lucide-react';
 import React, { useCallback, useMemo, useState } from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
@@ -69,6 +70,8 @@ const DEFAULT_OPTION: FontOption = {
 const clampFontSize = (size: number) =>
   Math.min(TERMINAL_FONT_SIZE_MAX, Math.max(TERMINAL_FONT_SIZE_MIN, size));
 
+const isMac = detectPlatform() === 'mac';
+
 const TerminalSettingsCard: React.FC = () => {
   const {
     value: terminal,
@@ -85,6 +88,7 @@ const TerminalSettingsCard: React.FC = () => {
   const fontFamily = terminal?.fontFamily ?? '';
   const fontSize = terminal?.fontSize ?? TERMINAL_FONT_SIZE_DEFAULT;
   const autoCopyOnSelection = terminal?.autoCopyOnSelection ?? false;
+  const macOptionIsMeta = terminal?.macOptionIsMeta ?? false;
   const defaultShell = terminal?.defaultShell ?? 'system';
   const selectedShell = useMemo(
     () =>
@@ -168,6 +172,18 @@ const TerminalSettingsCard: React.FC = () => {
       update({ autoCopyOnSelection: next });
       window.dispatchEvent(
         new CustomEvent('terminal-auto-copy-changed', { detail: { autoCopyOnSelection: next } })
+      );
+    },
+    [update]
+  );
+
+  const toggleMacOptionIsMeta = useCallback(
+    (next: boolean) => {
+      update({ macOptionIsMeta: next });
+      window.dispatchEvent(
+        new CustomEvent('terminal-mac-option-is-meta-changed', {
+          detail: { macOptionIsMeta: next },
+        })
       );
     },
     [update]
@@ -338,6 +354,19 @@ const TerminalSettingsCard: React.FC = () => {
           />
         }
       />
+      {isMac ? (
+        <SettingRow
+          title="Use Option as Meta key"
+          description="Treat the Option key as the Meta key in the terminal."
+          control={
+            <Switch
+              checked={macOptionIsMeta}
+              disabled={loading || saving}
+              onCheckedChange={toggleMacOptionIsMeta}
+            />
+          }
+        />
+      ) : null}
     </div>
   );
 };

--- a/src/renderer/lib/pty/use-pty.ts
+++ b/src/renderer/lib/pty/use-pty.ts
@@ -391,6 +391,7 @@ export function usePty(
             terminalSettings?.fontSize ?? TERMINAL_FONT_SIZE_DEFAULT;
           measureAndResize();
           autoCopyOnSelectionRef.current = terminalSettings?.autoCopyOnSelection ?? false;
+          frontendPty.terminal.options.macOptionIsMeta = terminalSettings?.macOptionIsMeta ?? false;
         }
       );
 
@@ -597,11 +598,21 @@ export function usePty(
         const detail = (e as CustomEvent<{ autoCopyOnSelection?: boolean }>).detail;
         autoCopyOnSelectionRef.current = detail?.autoCopyOnSelection ?? false;
       };
+      const handleMacOptionIsMetaChange = (e: Event) => {
+        const detail = (e as CustomEvent<{ macOptionIsMeta?: boolean }>).detail;
+        terminal.options.macOptionIsMeta = detail?.macOptionIsMeta ?? false;
+      };
       window.addEventListener('terminal-font-changed', handleFontChange);
       window.addEventListener('terminal-auto-copy-changed', handleAutoCopyChange);
+      window.addEventListener('terminal-mac-option-is-meta-changed', handleMacOptionIsMetaChange);
       cleanups.push(
         () => window.removeEventListener('terminal-font-changed', handleFontChange),
-        () => window.removeEventListener('terminal-auto-copy-changed', handleAutoCopyChange)
+        () => window.removeEventListener('terminal-auto-copy-changed', handleAutoCopyChange),
+        () =>
+          window.removeEventListener(
+            'terminal-mac-option-is-meta-changed',
+            handleMacOptionIsMetaChange
+          )
       );
 
       // ── ResizeObserver (observes the mount-target, not the owned container) ─


### PR DESCRIPTION
### Description

On macOS the Option key can act as the Meta key in terminals (as it does in VSCode and Terminal.app). This adds a **Use Option as Meta key** setting (default off, macOS only) and passes it through to xterm.js via [`macOptionIsMeta`](https://xtermjs.org/docs/api/terminal/interfaces/iterminaloptions/#optional-macoptionismeta), so `Option+f` / `Option+b` move by word instead of inserting special characters.

This re-adds the feature originally landed in #1596, which was dropped during the v1 refactor. It has been ported onto the current structure:

- **Schema/default** — `macOptionIsMeta: z.boolean()` on `terminalSettingsSchema` (`src/main/core/settings/schema.ts`) with a `false` default in the settings registry.
- **Settings UI** — a macOS-only toggle in `TerminalSettingsCard`, gated via `detectPlatform() === 'mac'`, dispatching a `terminal-mac-option-is-meta-changed` event.
- **Terminal wiring** — `use-pty.ts` applies `terminal.options.macOptionIsMeta` on settings load and live on the change event, with listener cleanup.

### Related issues

Re-adds the feature from #1596 (dropped in the v1 refactor).

### Testing

- `pnpm run format` ✅
- `pnpm run lint` ✅
- `pnpm run typecheck` ✅
- `pnpm exec vitest run` on the affected suites (settings schema/registry, settings importer, dependency-manager, conversation respawn) — 44 tests ✅
- Manual: on macOS, toggled the setting on and confirmed `Option+f` / `Option+b` move by word in the terminal; toggled off and confirmed default behavior returns

### Screenshot/Recording (if applicable)

<img width="799" height="69" alt="image" src="https://github.com/user-attachments/assets/2cfc9a78-af7d-4d52-9f83-3384e03ade66" />

#### Before
![Kapture 2026-03-25 at 21 58 51](https://github.com/user-attachments/assets/fa1b0be9-f7eb-479a-b744-9f078162f104)

#### After
![Kapture 2026-03-25 at 21 55 55](https://github.com/user-attachments/assets/f9aeb399-4291-4022-b944-e65b6b8ba9c0)


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
