### PR TITLE
fix(sidebar): show open folder icon for expanded projects

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/sidebar/project-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/project-item.tsx
@@ -3,6 +3,7 @@ import {
   ChevronRight,
   FolderClosed,
   FolderInput,
+  FolderOpen,
   Loader2,
   Plus,
   RotateCcw,
@@ -106,7 +107,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
       ? 'disconnected'
       : sshConnectionState;
   const canReconnect = sshConnectionState !== 'connected';
-  const ProjectIcon = isSshProject ? FolderInput : FolderClosed;
+  const ProjectIcon = isSshProject ? FolderInput : isExpanded ? FolderOpen : FolderClosed;
   const projectLabel = project.name ?? 'project';
   const openProject = () => navigate('project', { projectId });
 


### PR DESCRIPTION
### Description

If you have many projects open, it's hard to understand if the project doesn't have any tasks or if it's actually collapsed. This change uses `FolderOpen` to indicate if that the project is actually open

### Related issues

N/A

### Testing

- `pnpm run format`
- `pnpm run lint`
- `pnpm run typecheck`
- Manual: toggled project expand/collapse in the sidebar and confirmed the icon switches between open and closed folder.

### Screenshot/Recording (if applicable)

| Before | After | 
| -- | -- |
| <img width="233" height="150" alt="image" src="https://github.com/user-attachments/assets/3cb81190-b649-4c36-8815-4b7f907e79a5" /> |  <img width="219" height="148" alt="image" src="https://github.com/user-attachments/assets/f01ab05a-6c26-4fec-8d50-c20ec4445cb5" /> |

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
