### PR TITLE
fix(tasks): avoid reopening closed session tab

### DIFF
--- a/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -4,6 +4,7 @@ import type { Conversation } from '@shared/conversations';
 import type { Task } from '@shared/tasks';
 import type { Terminal } from '@shared/terminals';
 import type { TaskViewSnapshot } from '@shared/view-state';
+import { ConversationStore } from '../conversations/conversation-manager';
 import type { TerminalManagerStore, TerminalStore } from '../terminals/terminal-manager';
 import { conversationRegistry } from './conversation-registry';
 import type { TaskStore } from './task-store';
@@ -238,6 +239,180 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
     await Promise.resolve();
 
     expect(terminals.createDefaultTerminal).not.toHaveBeenCalled();
+
+    viewModel.dispose();
+  });
+});
+
+describe('WorkspaceViewModel default conversation tab', () => {
+  it('opens the initial conversation for a new task without restored tab state', async () => {
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    const viewModel = makeViewModel();
+
+    runInAction(() => {
+      conversations.conversations.set(
+        'conversation-1',
+        new ConversationStore(
+          makeConversation({ id: 'conversation-1', isInitialConversation: true })
+        )
+      );
+    });
+    await Promise.resolve();
+
+    expect(
+      viewModel.tabManager.resolvedTabs.map((tab) =>
+        tab.kind === 'conversation' ? tab.conversationId : null
+      )
+    ).toEqual(['conversation-1']);
+
+    viewModel.dispose();
+  });
+
+  it('does not reopen a closed initial conversation when a later conversation is created', async () => {
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    const viewModel = makeViewModel();
+
+    runInAction(() => {
+      conversations.conversations.set(
+        'conversation-1',
+        new ConversationStore(
+          makeConversation({ id: 'conversation-1', isInitialConversation: true })
+        )
+      );
+      viewModel.tabManager.openConversation('conversation-1');
+    });
+    await Promise.resolve();
+
+    viewModel.tabManager.closeTab(viewModel.tabManager.resolvedActiveTabId!);
+    expect(viewModel.tabManager.resolvedTabs).toHaveLength(0);
+
+    runInAction(() => {
+      conversations.conversations.set(
+        'conversation-2',
+        new ConversationStore(makeConversation({ id: 'conversation-2', title: 'Conversation 2' }))
+      );
+    });
+    await Promise.resolve();
+
+    expect(viewModel.tabManager.resolvedTabs).toHaveLength(0);
+
+    viewModel.tabManager.openConversation('conversation-2');
+
+    expect(
+      viewModel.tabManager.resolvedTabs.map((tab) =>
+        tab.kind === 'conversation' ? tab.conversationId : null
+      )
+    ).toEqual(['conversation-2']);
+
+    viewModel.dispose();
+  });
+
+  it('preserves a restored empty tab state instead of opening the initial conversation', async () => {
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', [
+      makeConversation({ id: 'conversation-1', isInitialConversation: true }),
+    ]);
+    const viewModel = makeViewModel();
+    viewModel.restoreSnapshot({
+      focusedRegion: 'main',
+      tabGroups: {
+        groups: [
+          {
+            groupId: 'group-1',
+            tabManager: {
+              tabs: [],
+              activeTabId: undefined,
+            },
+          },
+        ],
+        activeGroupId: 'group-1',
+        paneSizes: [100],
+      },
+    });
+    await Promise.resolve();
+
+    expect(viewModel.tabManager.resolvedTabs).toHaveLength(0);
+
+    runInAction(() => {
+      conversations.conversations.set(
+        'conversation-2',
+        new ConversationStore(makeConversation({ id: 'conversation-2', title: 'Conversation 2' }))
+      );
+    });
+    await Promise.resolve();
+
+    expect(viewModel.tabManager.resolvedTabs).toHaveLength(0);
+
+    viewModel.dispose();
+  });
+
+  it('opens the initial conversation after restoring legacy UI state without tab state', async () => {
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    const viewModel = makeViewModel();
+
+    viewModel.restoreSnapshot({
+      focusedRegion: 'bottom',
+      isTerminalDrawerOpen: true,
+    });
+
+    runInAction(() => {
+      conversations.conversations.set(
+        'conversation-1',
+        new ConversationStore(
+          makeConversation({ id: 'conversation-1', isInitialConversation: true })
+        )
+      );
+    });
+    await Promise.resolve();
+
+    expect(
+      viewModel.tabManager.resolvedTabs.map((tab) =>
+        tab.kind === 'conversation' ? tab.conversationId : null
+      )
+    ).toEqual(['conversation-1']);
+
+    viewModel.dispose();
+  });
+
+  it('does not reopen a closed initial conversation if provision finishes during the next create flow', async () => {
+    workspaceRegistry.acquire(
+      'project-1',
+      'workspace-1',
+      '/tmp/emdash-test-workspace',
+      { settings: {} } as never,
+      'main'
+    );
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
+    vi.spyOn(conversations, 'dehydrateConversation').mockResolvedValue();
+    const viewModel = makeProvisionedViewModel();
+
+    runInAction(() => {
+      conversations.conversations.set(
+        'conversation-1',
+        new ConversationStore(
+          makeConversation({ id: 'conversation-1', isInitialConversation: true })
+        )
+      );
+      viewModel.tabManager.openConversation('conversation-1');
+    });
+    await Promise.resolve();
+
+    viewModel.tabManager.closeTab(viewModel.tabManager.resolvedActiveTabId!);
+
+    runInAction(() => {
+      conversations.conversations.set(
+        'conversation-2',
+        new ConversationStore(makeConversation({ id: 'conversation-2', title: 'Conversation 2' }))
+      );
+    });
+    viewModel.initialize();
+    viewModel.tabManager.openConversation('conversation-2');
+
+    expect(
+      viewModel.tabManager.resolvedTabs.map((tab) =>
+        tab.kind === 'conversation' ? tab.conversationId : null
+      )
+    ).toEqual(['conversation-2']);
 
     viewModel.dispose();
   });

--- a/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -135,6 +135,20 @@ function makeConversation(overrides: Partial<Conversation> = {}): Conversation {
   };
 }
 
+function addConversation(
+  conversations: ReturnType<typeof conversationRegistry.acquire>,
+  overrides: Partial<Conversation> = {}
+): void {
+  const conversation = makeConversation(overrides);
+  conversations.conversations.set(conversation.id, new ConversationStore(conversation));
+}
+
+function conversationTabIds(viewModel: WorkspaceViewModel): string[] {
+  return viewModel.tabManager.resolvedTabs.flatMap((tab) =>
+    tab.kind === 'conversation' ? [tab.conversationId] : []
+  );
+}
+
 function makeViewModel(): WorkspaceViewModel {
   return new WorkspaceViewModel({ data: makeTask() } as unknown as TaskStore);
 }
@@ -250,20 +264,11 @@ describe('WorkspaceViewModel default conversation tab', () => {
     const viewModel = makeViewModel();
 
     runInAction(() => {
-      conversations.conversations.set(
-        'conversation-1',
-        new ConversationStore(
-          makeConversation({ id: 'conversation-1', isInitialConversation: true })
-        )
-      );
+      addConversation(conversations, { id: 'conversation-1', isInitialConversation: true });
     });
     await Promise.resolve();
 
-    expect(
-      viewModel.tabManager.resolvedTabs.map((tab) =>
-        tab.kind === 'conversation' ? tab.conversationId : null
-      )
-    ).toEqual(['conversation-1']);
+    expect(conversationTabIds(viewModel)).toEqual(['conversation-1']);
 
     viewModel.dispose();
   });
@@ -273,12 +278,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
     const viewModel = makeViewModel();
 
     runInAction(() => {
-      conversations.conversations.set(
-        'conversation-1',
-        new ConversationStore(
-          makeConversation({ id: 'conversation-1', isInitialConversation: true })
-        )
-      );
+      addConversation(conversations, { id: 'conversation-1', isInitialConversation: true });
       viewModel.tabManager.openConversation('conversation-1');
     });
     await Promise.resolve();
@@ -287,10 +287,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
     expect(viewModel.tabManager.resolvedTabs).toHaveLength(0);
 
     runInAction(() => {
-      conversations.conversations.set(
-        'conversation-2',
-        new ConversationStore(makeConversation({ id: 'conversation-2', title: 'Conversation 2' }))
-      );
+      addConversation(conversations, { id: 'conversation-2', title: 'Conversation 2' });
     });
     await Promise.resolve();
 
@@ -298,11 +295,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
 
     viewModel.tabManager.openConversation('conversation-2');
 
-    expect(
-      viewModel.tabManager.resolvedTabs.map((tab) =>
-        tab.kind === 'conversation' ? tab.conversationId : null
-      )
-    ).toEqual(['conversation-2']);
+    expect(conversationTabIds(viewModel)).toEqual(['conversation-2']);
 
     viewModel.dispose();
   });
@@ -333,42 +326,11 @@ describe('WorkspaceViewModel default conversation tab', () => {
     expect(viewModel.tabManager.resolvedTabs).toHaveLength(0);
 
     runInAction(() => {
-      conversations.conversations.set(
-        'conversation-2',
-        new ConversationStore(makeConversation({ id: 'conversation-2', title: 'Conversation 2' }))
-      );
+      addConversation(conversations, { id: 'conversation-2', title: 'Conversation 2' });
     });
     await Promise.resolve();
 
     expect(viewModel.tabManager.resolvedTabs).toHaveLength(0);
-
-    viewModel.dispose();
-  });
-
-  it('opens the initial conversation after restoring legacy UI state without tab state', async () => {
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
-    const viewModel = makeViewModel();
-
-    viewModel.restoreSnapshot({
-      focusedRegion: 'bottom',
-      isTerminalDrawerOpen: true,
-    });
-
-    runInAction(() => {
-      conversations.conversations.set(
-        'conversation-1',
-        new ConversationStore(
-          makeConversation({ id: 'conversation-1', isInitialConversation: true })
-        )
-      );
-    });
-    await Promise.resolve();
-
-    expect(
-      viewModel.tabManager.resolvedTabs.map((tab) =>
-        tab.kind === 'conversation' ? tab.conversationId : null
-      )
-    ).toEqual(['conversation-1']);
 
     viewModel.dispose();
   });
@@ -387,12 +349,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
     const viewModel = makeProvisionedViewModel();
 
     runInAction(() => {
-      conversations.conversations.set(
-        'conversation-1',
-        new ConversationStore(
-          makeConversation({ id: 'conversation-1', isInitialConversation: true })
-        )
-      );
+      addConversation(conversations, { id: 'conversation-1', isInitialConversation: true });
       viewModel.tabManager.openConversation('conversation-1');
     });
     await Promise.resolve();
@@ -400,19 +357,12 @@ describe('WorkspaceViewModel default conversation tab', () => {
     viewModel.tabManager.closeTab(viewModel.tabManager.resolvedActiveTabId!);
 
     runInAction(() => {
-      conversations.conversations.set(
-        'conversation-2',
-        new ConversationStore(makeConversation({ id: 'conversation-2', title: 'Conversation 2' }))
-      );
+      addConversation(conversations, { id: 'conversation-2', title: 'Conversation 2' });
     });
     viewModel.initialize();
     viewModel.tabManager.openConversation('conversation-2');
 
-    expect(
-      viewModel.tabManager.resolvedTabs.map((tab) =>
-        tab.kind === 'conversation' ? tab.conversationId : null
-      )
-    ).toEqual(['conversation-2']);
+    expect(conversationTabIds(viewModel)).toEqual(['conversation-2']);
 
     viewModel.dispose();
   });

--- a/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -69,6 +69,7 @@ export class WorkspaceViewModel implements ILifecycle {
   /** Saved whenever suspend() is called, restored in next initialize(). */
   private _savedDiffViewSnapshot: DiffViewSnapshot | undefined;
   private _isCreatingTerminal = false;
+  private _hasConsumedDefaultConversationAutoOpen = false;
   private readonly _conversationHydration: ConversationHydrationReconciler;
 
   readonly taskId: string;
@@ -111,14 +112,15 @@ export class WorkspaceViewModel implements ILifecycle {
       activeRenderer: computed,
     });
 
-    // One-shot: open the initial conversation once conversations first become available.
+    // Fresh tasks get one automatic default conversation tab. Once restored tab
+    // state exists, the restored tab list is authoritative — even when it is empty
+    // because the user closed the tab.
     const initConvDisposer = reaction(
       () => conversationRegistry.get(this.taskId)?.conversations.size ?? 0,
       (size) => {
-        if (size > 0 && this.tabGroupManager.focusedGroup.tabOrder.length === 0) {
-          runInAction(() => this.tabGroupManager.focusedGroup.initializeDefault());
-          initConvDisposer();
-        }
+        if (size === 0) return;
+        this.maybeOpenDefaultConversationForFreshTask();
+        initConvDisposer();
       }
     );
     this._disposers.push(initConvDisposer);
@@ -218,6 +220,12 @@ export class WorkspaceViewModel implements ILifecycle {
    * initialize() so the reaction baseline is correct.
    */
   restoreSnapshot(savedSnapshot: TaskViewSnapshot): void {
+    const hasRestoredTabSnapshot =
+      savedSnapshot.tabGroups !== undefined ||
+      savedSnapshot.tabManager !== undefined ||
+      (savedSnapshot.conversations?.tabOrder?.length ?? 0) > 0;
+    this._hasConsumedDefaultConversationAutoOpen = hasRestoredTabSnapshot;
+
     this.sidebarTab = (savedSnapshot.sidebarTab as SidebarTab) ?? 'conversations';
     this.isSidebarCollapsed = savedSnapshot.isSidebarCollapsed ?? true;
     this.focusedRegion = savedSnapshot.focusedRegion === 'bottom' ? 'bottom' : 'main';
@@ -255,10 +263,6 @@ export class WorkspaceViewModel implements ILifecycle {
         activeGroupId: '',
         paneSizes: [100],
       });
-    }
-
-    if (this.tabGroupManager.focusedGroup.tabOrder.length === 0) {
-      this.tabGroupManager.focusedGroup.initializeDefault();
     }
 
     if (savedSnapshot.terminals) {
@@ -308,12 +312,11 @@ export class WorkspaceViewModel implements ILifecycle {
     // Register snapshot with the persistence layer.
     this._snapshotDisposer = snapshotRegistry.register(`task:${this.taskId}`, () => this.snapshot);
 
-    // Open the initial conversation tab if no tabs were restored from a saved snapshot.
+    // Open the default conversation tab only for fresh task views. If tab state was
+    // restored, even an empty tab list represents the user's persisted choice.
     // This handles the optimistic-conversation case where conversations are already in
     // the manager before provision completes.
-    if (this.tabGroupManager.focusedGroup.tabOrder.length === 0) {
-      runInAction(() => this.tabGroupManager.focusedGroup.initializeDefault());
-    }
+    this.maybeOpenDefaultConversationForFreshTask();
 
     const conversationHydrationDisposer = reaction(
       () => this.openConversationIds,
@@ -450,6 +453,17 @@ export class WorkspaceViewModel implements ILifecycle {
       runInAction(() => {
         this._isCreatingTerminal = false;
       });
+    }
+  }
+
+  private maybeOpenDefaultConversationForFreshTask(): void {
+    if (this._hasConsumedDefaultConversationAutoOpen) return;
+    const conversations = conversationRegistry.get(this.taskId);
+    if (!conversations || conversations.conversations.size === 0) return;
+
+    this._hasConsumedDefaultConversationAutoOpen = true;
+    if (this.tabGroupManager.focusedGroup.tabOrder.length === 0) {
+      runInAction(() => this.tabGroupManager.focusedGroup.initializeDefault());
     }
   }
 


### PR DESCRIPTION
### Description
when a session is created in a new task, closing the first tab and then creating a second session for the same agent reopens the previously closed tab

### Screenshot/Recording (if applicable)
before:
https://streamable.com/oukbl7

after:
https://streamable.com/18v6q8

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
