### PR TITLE
Add JSDoc documentation to ListFilterOption type

### DIFF
--- a/src/renderer/lib/components/list-filters/types.ts
+++ b/src/renderer/lib/components/list-filters/types.ts
@@ -1,3 +1,4 @@
+/** @description Represents a filter option with a generic string value and a display label. @template T - The type of the value, extending string. */
 export type ListFilterOption<T extends string = string> = {
   value: T;
   label: string;


### PR DESCRIPTION
## Problem
The public type `ListFilterOption` in the list filters component lacked JSDoc comments, reducing code readability and documentation. This type is generic and used for filter options, so clear documentation helps developers understand its purpose and usage.

## Changes
- Added a JSDoc comment to `ListFilterOption` type in `src/renderer/lib/components/list-filters/types.ts`, including a `@description` and `@template` tag to explain the type and its generic parameter.

## Verification
- Confirm that TypeScript compilation passes without errors (e.g., by running `tsc --noEmit`).
- Review the JSDoc comment for correctness and consistency with repository style.