### PR TITLE
fix: hide pr template placeholder guidance

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,20 +1,28 @@
 ### Description
 
+<!--
 Give a short summary of what changed, why it's needed, and any important implementation notes.
+-->
 
 ### Related issues
 
-Link related issues. If this PR fixes an issue, mention it like: Fixes #123.
+<!--
+Link related issues. If this PR fixes an issue, mention it like: Fixes #123
+-->
 
 ### Testing
 
+<!--
 List the checks you ran, for example `pnpm run format`, `pnpm run lint`,
 `pnpm run typecheck`, `pnpm run test`, and any manual testing.
+-->
 
 ### Screenshot/Recording (if applicable)
 
+<!--
 Attach a screenshot, GIF, or recording of the change. This is optional, but helps reviewers
 understand UI or workflow changes.
+-->
 
 <details>
 <summary>Checklist</summary>


### PR DESCRIPTION
### Description
- update pr template

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
