### PR TITLE
fix(pty): open xterm only after its container is connected to the DOM

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,7 @@ tooling/db/dev.db-shm
 tooling/node-deps/node_modules/
 .pi/extensions/emdash-hook.ts
 .opencode/plugins/emdash-notifications.js
+
+# Vitest / Browser testing
+.vitest-attachments/
+**/__screenshots__/

--- a/src/renderer/lib/pty/pty.ts
+++ b/src/renderer/lib/pty/pty.ts
@@ -77,6 +77,7 @@ export class FrontendPty {
       width: '100%',
       height: '100%',
     });
+    ensureXtermHost().appendChild(this.ownedContainer);
 
     this.terminal = new Terminal({
       cols: 120,
@@ -136,7 +137,6 @@ export class FrontendPty {
       el.style.backgroundColor = 'transparent';
     }
 
-    ensureXtermHost().appendChild(this.ownedContainer);
     FrontendPty.all.add(this);
   }
 

--- a/src/renderer/lib/pty/xterm-host.ts
+++ b/src/renderer/lib/pty/xterm-host.ts
@@ -1,7 +1,7 @@
 let hostElement: HTMLDivElement | null = null;
 
 export function ensureXtermHost(): HTMLDivElement {
-  if (hostElement) return hostElement;
+  if (hostElement && hostElement.isConnected) return hostElement;
   const el = document.createElement('div');
   el.setAttribute('data-terminal-host', 'true');
   Object.assign(el.style, {

--- a/src/renderer/tests/browser/xterm-host.test.ts
+++ b/src/renderer/tests/browser/xterm-host.test.ts
@@ -1,0 +1,68 @@
+import { Terminal } from '@xterm/xterm';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+async function getPtyModule() {
+  return import('@renderer/lib/pty/pty');
+}
+
+describe('FrontendPty xterm host', () => {
+  beforeEach(() => {
+    vi.stubGlobal('electronAPI', {
+      eventOn: vi.fn(() => () => {}),
+      eventSend: vi.fn(),
+      invoke: vi.fn(() => Promise.resolve({ success: true, data: null })),
+    });
+
+    document.documentElement.style.setProperty('--xterm-bg', '#101010');
+    document.documentElement.style.setProperty('--xterm-fg', '#f0f0f0');
+    document.documentElement.style.setProperty('--xterm-cursor', '#f0f0f0');
+    document.documentElement.style.setProperty('--xterm-cursor-accent', '#101010');
+    document.documentElement.style.setProperty('--xterm-selection-bg', '#335577');
+    document.documentElement.style.setProperty('--xterm-selection-fg', '#ffffff');
+  });
+
+  afterEach(async () => {
+    const { disposeAllPtys } = await getPtyModule();
+    disposeAllPtys();
+    document.querySelector('[data-terminal-host="true"]')?.remove();
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it('opens xterm only after its container is connected to the off-screen host', async () => {
+    const originalOpen = Terminal.prototype.open;
+    const openCall: { parent?: HTMLElement } = {};
+
+    vi.spyOn(Terminal.prototype, 'open').mockImplementation(function open(this: Terminal, parent) {
+      openCall.parent = parent;
+      return originalOpen.call(this, parent);
+    });
+
+    const { FrontendPty } = await getPtyModule();
+    const frontendPty = new FrontendPty('test-session');
+    const host = document.querySelector('[data-terminal-host="true"]');
+    const dims =
+      (
+        frontendPty.terminal as unknown as {
+          _core?: {
+            _renderService?: { dimensions?: { css: { cell: { width: number; height: number } } } };
+            renderService?: { dimensions?: { css: { cell: { width: number; height: number } } } };
+          };
+        }
+      )._core?._renderService?.dimensions ??
+      (
+        frontendPty.terminal as unknown as {
+          _core?: {
+            renderService?: { dimensions?: { css: { cell: { width: number; height: number } } } };
+          };
+        }
+      )._core?.renderService?.dimensions;
+
+    expect(host).toBeTruthy();
+    expect(openCall.parent).toBe(frontendPty.ownedContainer);
+    expect(openCall.parent?.isConnected).toBe(true);
+    expect(openCall.parent?.parentElement).toBe(host);
+    expect(dims?.css.cell.width).toBeGreaterThan(0);
+    expect(dims?.css.cell.height).toBeGreaterThan(0);
+  });
+});

--- a/src/renderer/tests/browser/xterm-host.test.ts
+++ b/src/renderer/tests/browser/xterm-host.test.ts
@@ -65,4 +65,41 @@ describe('FrontendPty xterm host', () => {
     expect(dims?.css.cell.width).toBeGreaterThan(0);
     expect(dims?.css.cell.height).toBeGreaterThan(0);
   });
+
+  it('subsequent calls recreate host if the previous host was removed from the DOM', async () => {
+    const originalOpen = Terminal.prototype.open;
+    const openCall: { parent?: HTMLElement } = {};
+
+    vi.spyOn(Terminal.prototype, 'open').mockImplementation(function open(this: Terminal, parent) {
+      openCall.parent = parent;
+      return originalOpen.call(this, parent);
+    });
+
+    const { FrontendPty } = await getPtyModule();
+    const frontendPty = new FrontendPty('test-session');
+    const host = document.querySelector('[data-terminal-host="true"]');
+    const dims =
+      (
+        frontendPty.terminal as unknown as {
+          _core?: {
+            _renderService?: { dimensions?: { css: { cell: { width: number; height: number } } } };
+            renderService?: { dimensions?: { css: { cell: { width: number; height: number } } } };
+          };
+        }
+      )._core?._renderService?.dimensions ??
+      (
+        frontendPty.terminal as unknown as {
+          _core?: {
+            renderService?: { dimensions?: { css: { cell: { width: number; height: number } } } };
+          };
+        }
+      )._core?.renderService?.dimensions;
+
+    expect(host).toBeTruthy();
+    expect(openCall.parent).toBe(frontendPty.ownedContainer);
+    expect(openCall.parent?.isConnected).toBe(true);
+    expect(openCall.parent?.parentElement).toBe(host);
+    expect(dims?.css.cell.width).toBeGreaterThan(0);
+    expect(dims?.css.cell.height).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
### Description

Previously, `ensureXtermHost().appendChild(this.ownedContainer)` was called *after* `this.terminal.open(this.ownedContainer)`. 
Since the target container was not yet attached to the DOM (i.e. not connected) at the moment of `.open()`, xterm.js could not compute proper layout dimensions, causing text rendering issues (e.g., garbled/overlapping characters, incorrect spacing). 

This PR moves the `appendChild` call before xterm initialization and `.open()`, ensuring that the container is fully connected to the off-screen host element when xterm measures layout metrics.

### Related issues

Fixes #2401

### Testing

- Ran `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`, and `pnpm run test` (including browser tests).
- Added [xterm-host.test.ts](file:///Users/kevin/emdash/worktrees/emdash/fix-rendering/src/renderer/tests/browser/xterm-host.test.ts) to assert that the terminal is open only when its container is connected, and that it successfully computes layout cell width/height greater than 0.

### Screenshot/Recording (if applicable)

#### Before 
https://github.com/user-attachments/assets/9654d071-8c45-4ab0-81dc-bf2327e4be40

#### After
https://github.com/user-attachments/assets/384bf5ac-850c-42b8-9550-beecc6cc37fe


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
