### PR TITLE
fix(tasks): wait for teardown before archive cleanup

### DIFF
--- a/src/main/core/tasks/operations/archiveTask.test.ts
+++ b/src/main/core/tasks/operations/archiveTask.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { archiveTask } from './archiveTask';
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  deleteIndex: vi.fn(),
+  getProject: vi.fn(),
+  selectLimit: vi.fn(),
+  teardownTask: vi.fn(),
+  updateWhere: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: mocks.selectLimit,
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: mocks.updateWhere,
+      }),
+    }),
+  },
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: {
+    getProject: mocks.getProject,
+  },
+}));
+
+vi.mock('@main/core/tasks/task-session-manager', () => ({
+  taskSessionManager: {
+    teardownTask: mocks.teardownTask,
+  },
+}));
+
+vi.mock('@main/core/search/workspace-file-index-service', () => ({
+  workspaceFileIndexService: {
+    deleteIndex: mocks.deleteIndex,
+  },
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: {
+    capture: mocks.capture,
+  },
+}));
+
+describe('archiveTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateWhere.mockResolvedValue(undefined);
+  });
+
+  it('waits for teardown before removing the worktree', async () => {
+    const order: string[] = [];
+    let resolveTeardown: (value: { success: true }) => void = () => {};
+    const teardownPromise = new Promise<{ success: true }>((resolve) => {
+      resolveTeardown = resolve;
+    });
+    const removeTaskWorktree = vi.fn(async () => {
+      order.push('remove-worktree');
+    });
+
+    mocks.selectLimit
+      .mockResolvedValueOnce([
+        {
+          id: 'task-1',
+          workspaceId: 'workspace-1',
+        },
+      ])
+      .mockResolvedValueOnce([{ id: 'workspace-1', branchName: 'emdash/task-1' }])
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([]);
+    mocks.getProject.mockReturnValue({ removeTaskWorktree });
+    mocks.updateWhere.mockImplementation(async () => {
+      order.push('archive-update');
+    });
+    mocks.teardownTask.mockImplementation(() => {
+      order.push('teardown-start');
+      return teardownPromise;
+    });
+
+    const archivePromise = archiveTask('project-1', 'task-1');
+    await vi.waitFor(() => expect(mocks.teardownTask).toHaveBeenCalledTimes(1));
+
+    expect(removeTaskWorktree).not.toHaveBeenCalled();
+
+    resolveTeardown({ success: true });
+    await archivePromise;
+
+    expect(removeTaskWorktree).toHaveBeenCalledWith('emdash/task-1');
+    expect(order).toEqual(['archive-update', 'teardown-start', 'remove-worktree']);
+  });
+});

--- a/src/main/core/tasks/operations/archiveTask.ts
+++ b/src/main/core/tasks/operations/archiveTask.ts
@@ -26,16 +26,14 @@ export async function archiveTask(projectId: string, taskId: string): Promise<vo
 
   if (!project) return;
 
-  void taskSessionManager
-    .teardownTask(taskId, 'terminate')
-    .then((teardownResult) => {
-      if (!teardownResult.success) {
-        log.warn('archiveTask: teardown failed', { taskId, error: teardownResult.error.message });
-      }
-    })
-    .catch((e: unknown) => {
-      log.warn('archiveTask: teardown failed', { taskId, error: String(e) });
-    });
+  const teardownResult = await taskSessionManager.teardownTask(taskId, 'terminate').catch((e) => {
+    log.warn('archiveTask: teardown failed', { taskId, error: String(e) });
+    return null;
+  });
+
+  if (teardownResult && !teardownResult.success) {
+    log.warn('archiveTask: teardown failed', { taskId, error: teardownResult.error.message });
+  }
 
   let wsRow: { id: string; branchName: string | null } | undefined;
   if (task.workspaceId) {


### PR DESCRIPTION
### Description

Archive now waits for task teardown before continuing with workspace cleanup.

Previously, `archiveTask` marked the task archived, started teardown in the background, and then immediately checked whether the worktree could be removed. That meant a configured `.emdash.json` `scripts.teardown` command could race with worktree removal, which made teardown unreliable and hard to verify.

This changes archive to await `taskSessionManager.teardownTask(...)` before removing the worktree or deleting the workspace file index. Teardown failures are still logged and do not block archive cleanup, matching the existing delete-task behavior.

A focused regression test covers the ordering: worktree removal must not happen until the archive-triggered teardown promise resolves.

### Related issues

Fixes #2418

### Testing

- `pnpm exec vitest run --project node src/main/core/tasks/operations/archiveTask.test.ts`
- `pnpm exec oxfmt --check src/main/core/tasks/operations/archiveTask.ts src/main/core/tasks/operations/archiveTask.test.ts`
- `pnpm exec oxlint src/main/core/tasks/operations/archiveTask.ts src/main/core/tasks/operations/archiveTask.test.ts`
- `pnpm run typecheck`

Full `pnpm run test` was not run.

### Screenshot/Recording (if applicable)

Using the minimum repo (https://github.com/kchung/emdash-archive-teardown-repro), I was able to get the logs to show up during archive

```
$ cat /tmp/emdash-archive-teardown-repro.log
START 2026-06-08T07:44:25-0700
task=mighty-windows-switch
pid=2757
worktree=/Users/kevin/emdash/worktrees/emdash-archive-teardown-repro/mighty-windows-switch
sleep_seconds=5
worktree_exists_at_start=yes
----
END 2026-06-08T07:44:30-0700
worktree_exists_at_end=yes
```

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or this was not needed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>