### PR TITLE
fix(pull-requests): surface pr sync failures

### DIFF
--- a/apps/emdash-desktop/src/main/core/pull-requests/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/controller.test.ts
@@ -324,6 +324,39 @@ describe('pullRequestController', () => {
     );
   });
 
+  it('forwards force-full PR sync auth failures', async () => {
+    mockProjectGithubContext();
+    mockPrSyncEngine.forceFullSync.mockResolvedValue(
+      err({
+        type: 'auth_required',
+        host: 'github.com',
+        message: 'GitHub auth required',
+      })
+    );
+
+    await expect(pullRequestController.forceFullSyncPullRequests('project-1')).resolves.toEqual(
+      err({
+        type: 'github_auth_required',
+        host: 'github.com',
+        hint: 'Connect GitHub from account settings.',
+      })
+    );
+  });
+
+  it('maps cancelled force-full PR syncs to sync failures', async () => {
+    mockProjectGithubContext();
+    mockPrSyncEngine.forceFullSync.mockResolvedValue(
+      err({
+        type: 'sync_cancelled',
+        message: 'Pull request sync was cancelled.',
+      })
+    );
+
+    await expect(pullRequestController.forceFullSyncPullRequests('project-1')).resolves.toEqual(
+      err({ type: 'sync_failed', message: 'Pull request sync was cancelled.' })
+    );
+  });
+
   it('looks up task pull requests from the cached current workspace branch', async () => {
     mockProviderRepositoryUrl('https://github.com/acme/repo');
     queueDbSelectResult([{ workspaceId: 'workspace-1' }]);

--- a/apps/emdash-desktop/src/main/core/pull-requests/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/controller.test.ts
@@ -129,6 +129,8 @@ describe('pullRequestController', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     dbMocks.select.mockReset();
+    mockPrSyncEngine.forceFullSync.mockResolvedValue(ok());
+    mockPrSyncEngine.sync.mockResolvedValue(ok());
   });
 
   it('rejects cross-host pull request creation before calling GitHub', async () => {
@@ -276,6 +278,35 @@ describe('pullRequestController', () => {
     expect(mockPrSyncEngine.sync).toHaveBeenCalledWith(
       'https://github.com/acme/repo',
       selectedAuthContext
+    );
+  });
+
+  it('forwards project-scoped PR sync failures', async () => {
+    mockProjectGithubContext();
+    mockPrSyncEngine.sync.mockResolvedValue(
+      err({
+        type: 'host_unreachable',
+        host: 'github.com',
+        reason: 'Connect Timeout Error',
+      })
+    );
+
+    await expect(pullRequestController.syncPullRequests('project-1')).resolves.toEqual(
+      err({ type: 'host_unreachable', host: 'github.com', reason: 'Connect Timeout Error' })
+    );
+  });
+
+  it('maps cancelled project-scoped PR syncs to sync failures', async () => {
+    mockProjectGithubContext();
+    mockPrSyncEngine.sync.mockResolvedValue(
+      err({
+        type: 'sync_cancelled',
+        message: 'Pull request sync was cancelled.',
+      })
+    );
+
+    await expect(pullRequestController.syncPullRequests('project-1')).resolves.toEqual(
+      err({ type: 'sync_failed', message: 'Pull request sync was cancelled.' })
     );
   });
 

--- a/apps/emdash-desktop/src/main/core/pull-requests/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/controller.ts
@@ -29,7 +29,8 @@ type PrControllerFailureType =
   | 'files_failed'
   | 'comments_failed'
   | 'refresh_failed'
-  | 'checks_failed';
+  | 'checks_failed'
+  | 'sync_failed';
 
 type CreatePullRequestParams = {
   repositoryUrl: string;
@@ -114,6 +115,8 @@ function mapPrSyncEngineError(
         host: error.host,
         reason: error.reason,
       };
+    case 'sync_cancelled':
+      return { type: fallbackType, message: error.message };
     case 'api_error':
       return { type: fallbackType, message: error.message };
   }
@@ -196,7 +199,13 @@ export const pullRequestController = createRPCController({
       const context = await resolveProjectPullRequestContext(projectId);
       if (!context.success) return err(context.error);
 
-      prSyncEngine.forceFullSync(context.data.repositoryUrl, context.data.authContext);
+      const result = await prSyncEngine.forceFullSync(
+        context.data.repositoryUrl,
+        context.data.authContext
+      );
+      if (!result.success) {
+        return err<PullRequestError>(mapPrSyncEngineError(result.error, 'sync_failed'));
+      }
       return ok();
     } catch (error) {
       log.error('Failed to force full sync:', error);
@@ -223,7 +232,10 @@ export const pullRequestController = createRPCController({
         projectId,
         repositoryUrl: context.data.repositoryUrl,
       });
-      prSyncEngine.sync(context.data.repositoryUrl, context.data.authContext);
+      const result = await prSyncEngine.sync(context.data.repositoryUrl, context.data.authContext);
+      if (!result.success) {
+        return err<PullRequestError>(mapPrSyncEngineError(result.error, 'sync_failed'));
+      }
       return ok();
     } catch (error) {
       log.error('Failed to trigger sync:', error);

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-engine.test.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-engine.test.ts
@@ -91,10 +91,62 @@ describe('PrSyncEngine', () => {
     );
     const engine = new PrSyncEngine(getOctokit);
 
-    engine.sync('https://github.com/acme/repo', { accountId: 'github.com:42' });
+    void engine.sync('https://github.com/acme/repo', { accountId: 'github.com:42' });
     await flushPromises();
 
     expect(getOctokit).toHaveBeenCalledWith('github.com', { accountId: 'github.com:42' });
+  });
+
+  it('returns the in-flight repository sync result to duplicate callers', async () => {
+    let resolveOctokit!: (value: Result<Octokit, GitHubApiAuthError>) => void;
+    const getOctokit = vi.fn<(host: string) => Promise<Result<Octokit, GitHubApiAuthError>>>(
+      () =>
+        new Promise((resolve) => {
+          resolveOctokit = resolve;
+        })
+    );
+    const engine = new PrSyncEngine(getOctokit);
+
+    const first = engine.sync('https://ghe.example.com/acme/repo');
+    await flushPromises();
+    const second = engine.sync('https://ghe.example.com/acme/repo');
+
+    expect(second).toBe(first);
+
+    resolveOctokit(
+      err({
+        type: 'auth_required',
+        host: 'ghe.example.com',
+        message: 'auth required',
+        hint: 'Run: gh auth login --hostname ghe.example.com',
+      })
+    );
+
+    const expected = err({
+      type: 'auth_required',
+      host: 'ghe.example.com',
+      message: 'auth required',
+      hint: 'Run: gh auth login --hostname ghe.example.com',
+    });
+    await expect(first).resolves.toEqual(expected);
+    await expect(second).resolves.toEqual(expected);
+    expect(getOctokit).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns a cancelled result when a repository sync is aborted before completion', async () => {
+    const getOctokit = vi.fn().mockResolvedValue(ok(makeOctokit({})));
+    const engine = new PrSyncEngine(getOctokit);
+
+    const result = engine.sync('https://github.com/acme/repo');
+    engine.cancel('https://github.com/acme/repo');
+
+    await expect(result).resolves.toEqual(
+      err({
+        type: 'sync_cancelled',
+        message: 'Pull request sync was cancelled.',
+      })
+    );
+    expect(getOctokit).not.toHaveBeenCalled();
   });
 
   it('maps post-token PR API repository access failures to not-found-or-no-access errors', async () => {

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-engine.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-engine.ts
@@ -49,6 +49,8 @@ import { assemblePullRequest } from './pr-utils';
 const PR_SYNC_MAX_COUNT = 300;
 const PR_ARCHIVE_AGE_MONTHS = 6;
 
+type RepositorySyncResult = Result<void, PrSyncEngineError>;
+
 type FullSyncCursor = {
   /** The `updatedAt` of the last PR we have seen (pagination cursor). */
   lastUpdatedAt: string;
@@ -74,6 +76,13 @@ type PrSyncAuthContext = Pick<GitHubApiAuthContext, 'accountId'>;
 
 function authContextKey(authContext: PrSyncAuthContext = {}): string {
   return authContext.accountId?.trim() || 'default';
+}
+
+function syncCancelledError(): PrSyncEngineError {
+  return {
+    type: 'sync_cancelled',
+    message: 'Pull request sync was cancelled.',
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -171,7 +180,7 @@ export class PrSyncEngine {
   private readonly kv = new KV<PrKvSchema>('pr');
 
   // Per-repository in-flight promise + AbortController
-  private readonly _inflight = new Map<string, Promise<void>>();
+  private readonly _inflight = new Map<string, Promise<RepositorySyncResult>>();
   private readonly _controllers = new Map<string, AbortController>();
   // Per-operation deduplication for single-PR and check-run syncs
   private readonly _singleInflight = new Map<
@@ -191,15 +200,16 @@ export class PrSyncEngine {
 
   /**
    * Smart sync: resumes a full sync if one is incomplete, otherwise runs an
-   * incremental sync. Deduplicated — no-op if a sync is already in-flight.
+   * incremental sync. Deduplicated — callers share the in-flight result.
    */
-  sync(repositoryUrl: string, authContext: PrSyncAuthContext = {}): void {
+  sync(repositoryUrl: string, authContext: PrSyncAuthContext = {}): Promise<RepositorySyncResult> {
     const key = `sync:${repositoryUrl}:${authContextKey(authContext)}`;
-    if (this._inflight.has(key)) {
+    const existing = this._inflight.get(key);
+    if (existing) {
       log.info('PrSyncEngine: sync already in flight, skipping', {
         repositoryUrl,
       });
-      return;
+      return existing;
     }
 
     const ctrl = new AbortController();
@@ -207,49 +217,60 @@ export class PrSyncEngine {
 
     const promise = this._getFullSyncCursor(repositoryUrl)
       .then((cursor) => {
-        if (ctrl.signal.aborted) return;
+        if (ctrl.signal.aborted) return err(syncCancelledError());
         return cursor?.done
           ? this._runIncrementalSync(repositoryUrl, ctrl.signal, authContext)
           : this._runFullSync(repositoryUrl, ctrl.signal, authContext);
       })
       .catch((e: unknown) => {
-        if ((e as { name?: string }).name !== 'AbortError') {
-          const repository = parseRepositoryRef(repositoryUrl);
-          const error = toPrApiError(
-            e,
-            'Unable to sync pull requests',
-            repository?.host,
-            repository?.nameWithOwner
-          );
-          if (isPrSyncHostUnreachable(error)) {
-            log.warn('PrSyncEngine: sync skipped; GitHub host unreachable', {
-              repositoryUrl,
-              host: error.host,
-              error: error.reason,
-            });
-            return;
-          }
-          log.error('PrSyncEngine: sync failed', {
-            repositoryUrl,
-            error: String(e),
-          });
+        if ((e as { name?: string }).name === 'AbortError') {
+          return err(syncCancelledError());
         }
+        const repository = parseRepositoryRef(repositoryUrl);
+        const error = toPrApiError(
+          e,
+          'Unable to sync pull requests',
+          repository?.host,
+          repository?.nameWithOwner
+        );
+        if (isPrSyncHostUnreachable(error)) {
+          log.warn('PrSyncEngine: sync failed; GitHub host unreachable', {
+            repositoryUrl,
+            host: error.host,
+            error: error.reason,
+          });
+          return err(error);
+        }
+        log.error('PrSyncEngine: sync failed', {
+          repositoryUrl,
+          error: String(e),
+        });
+        return err(error);
       })
       .finally(() => {
-        this._controllers.delete(key);
-        this._inflight.delete(key);
+        if (this._controllers.get(key) === ctrl) {
+          this._controllers.delete(key);
+        }
+        if (this._inflight.get(key) === promise) {
+          this._inflight.delete(key);
+        }
       });
 
     this._inflight.set(key, promise);
+    return promise;
   }
 
   /** Cancel any in-flight sync, wipe both cursors, and start a fresh full sync. */
-  forceFullSync(repositoryUrl: string, authContext: PrSyncAuthContext = {}): void {
+  async forceFullSync(
+    repositoryUrl: string,
+    authContext: PrSyncAuthContext = {}
+  ): Promise<RepositorySyncResult> {
     this.cancel(repositoryUrl);
-    void Promise.all([
+    await Promise.all([
       this.kv.del(`fullsync:${repositoryUrl}`),
       this.kv.del(`incrementalsync:${repositoryUrl}`),
-    ]).then(() => this.sync(repositoryUrl, authContext));
+    ]);
+    return this.sync(repositoryUrl, authContext);
   }
 
   /** Abort and discard any in-flight sync for this repository URL. */
@@ -312,7 +333,7 @@ export class PrSyncEngine {
     repositoryUrl: string,
     signal: AbortSignal,
     authContext: PrSyncAuthContext
-  ): Promise<void> {
+  ): Promise<RepositorySyncResult> {
     log.info('PrSyncEngine: runFullSync start', { repositoryUrl });
     const repository = parseRepositoryRefResult(repositoryUrl);
     if (!repository.success) {
@@ -322,7 +343,7 @@ export class PrSyncEngine {
         status: 'error',
         error: prSyncEngineErrorMessage(repository.error),
       });
-      return;
+      return err(repository.error);
     }
     const { owner, repo } = repository.data;
     const octokit = await this.getOctokit(repository.data.host, authContext);
@@ -337,7 +358,7 @@ export class PrSyncEngine {
         status: 'error',
         error: prSyncEngineErrorMessage(octokit.error),
       });
-      return;
+      return err(octokit.error);
     }
 
     // Resume from an existing cursor if available
@@ -355,7 +376,14 @@ export class PrSyncEngine {
 
     try {
       for (;;) {
-        if (signal.aborted) return;
+        if (signal.aborted) {
+          this._emitProgress({
+            remoteUrl: repositoryUrl,
+            kind: 'full',
+            status: 'cancelled',
+          });
+          return err(syncCancelledError());
+        }
 
         const response = await withRetry(
           () =>
@@ -419,6 +447,7 @@ export class PrSyncEngine {
         status: 'done',
         synced,
       });
+      return ok();
     } catch (e: unknown) {
       if ((e as { name?: string })?.name === 'AbortError') {
         this._emitProgress({
@@ -426,7 +455,7 @@ export class PrSyncEngine {
           kind: 'full',
           status: 'cancelled',
         });
-        return;
+        return err(syncCancelledError());
       }
       const error = toPrApiError(
         e,
@@ -440,7 +469,7 @@ export class PrSyncEngine {
         status: 'error',
         error: prSyncEngineErrorMessage(error),
       });
-      throw e;
+      return err(error);
     }
   }
 
@@ -455,7 +484,7 @@ export class PrSyncEngine {
     repositoryUrl: string,
     signal: AbortSignal,
     authContext: PrSyncAuthContext
-  ): Promise<void> {
+  ): Promise<RepositorySyncResult> {
     log.info('PrSyncEngine: runIncrementalSync started', { repositoryUrl });
 
     const repository = parseRepositoryRefResult(repositoryUrl);
@@ -466,7 +495,7 @@ export class PrSyncEngine {
         status: 'error',
         error: prSyncEngineErrorMessage(repository.error),
       });
-      return;
+      return err(repository.error);
     }
     const { owner, repo } = repository.data;
     const octokit = await this.getOctokit(repository.data.host, authContext);
@@ -481,7 +510,7 @@ export class PrSyncEngine {
         status: 'error',
         error: prSyncEngineErrorMessage(octokit.error),
       });
-      return;
+      return err(octokit.error);
     }
 
     const fullCursor = (await this.kv.get(`fullsync:${repositoryUrl}`)) as FullSyncCursor | null;
@@ -506,7 +535,14 @@ export class PrSyncEngine {
 
     try {
       for (;;) {
-        if (signal.aborted) return;
+        if (signal.aborted) {
+          this._emitProgress({
+            remoteUrl: repositoryUrl,
+            kind: 'incremental',
+            status: 'cancelled',
+          });
+          return err(syncCancelledError());
+        }
 
         const response = await withRetry(
           () =>
@@ -564,7 +600,7 @@ export class PrSyncEngine {
             status: 'done',
             synced,
           });
-          return;
+          return ok();
         }
 
         const done = reachedBoundary || !pageInfo.hasNextPage;
@@ -592,6 +628,7 @@ export class PrSyncEngine {
         status: 'done',
         synced,
       });
+      return ok();
     } catch (e: unknown) {
       if ((e as { name?: string })?.name === 'AbortError') {
         this._emitProgress({
@@ -599,7 +636,7 @@ export class PrSyncEngine {
           kind: 'incremental',
           status: 'cancelled',
         });
-        return;
+        return err(syncCancelledError());
       }
       const error = toPrApiError(
         e,
@@ -613,7 +650,7 @@ export class PrSyncEngine {
         status: 'error',
         error: prSyncEngineErrorMessage(error),
       });
-      throw e;
+      return err(error);
     }
   }
 

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-errors.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-errors.ts
@@ -16,6 +16,11 @@ export type PrSyncApiError = {
   message: string;
 };
 
+export type PrSyncCancelledError = {
+  type: 'sync_cancelled';
+  message: string;
+};
+
 export type PrSyncNotFoundOrNoAccessError = {
   type: 'not_found_or_no_access';
   host: string;
@@ -26,6 +31,7 @@ export type PrSyncEngineError =
   | RepositoryRefParseError
   | GitHubApiAuthError
   | GitHubApiOperationError
+  | PrSyncCancelledError
   | PrSyncApiError;
 
 export function isPrSyncHostUnreachable(
@@ -59,6 +65,7 @@ export function prSyncEngineErrorMessage(error: PrSyncEngineError): string {
       return error.message;
     case 'host_unreachable':
       return `Unable to reach ${error.host}: ${error.reason}`;
+    case 'sync_cancelled':
     case 'api_error':
       return error.message;
   }

--- a/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-scheduler.ts
+++ b/apps/emdash-desktop/src/main/core/pull-requests/pr-sync-scheduler.ts
@@ -181,7 +181,7 @@ export class PrSyncScheduler implements IInitializable, IDisposable {
     const authContext = await this._resolveAuthContext(projectId, remoteUrl);
     if (!authContext) return;
     // sync() routes to full or incremental based on cursor state.
-    prSyncEngine.sync(remoteUrl, authContext);
+    void prSyncEngine.sync(remoteUrl, authContext);
   }
 
   private async _syncRemotes(projectId: string, remoteUrls: string[]): Promise<void> {

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/pr-sync-status-card.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/pr-sync-status-card.test.ts
@@ -1,0 +1,77 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PrSyncStatusCard } from './pr-sync-status-card';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  syncState: undefined as
+    | {
+        status: 'running' | 'done' | 'error' | 'cancelled';
+        kind: 'full' | 'incremental' | 'single';
+        error?: string;
+      }
+    | undefined,
+  retry: vi.fn(),
+  clear: vi.fn(),
+  cancel: vi.fn(),
+}));
+
+vi.mock('@renderer/features/projects/stores/project-selectors', () => ({
+  getPrSyncStore: () => ({
+    getState: () => mocks.syncState,
+    retry: mocks.retry,
+    clear: mocks.clear,
+    cancel: mocks.cancel,
+  }),
+}));
+
+const PROJECT_ID = 'project-1';
+const REPOSITORY_URL = 'https://github.com/acme/repo';
+
+describe('PrSyncStatusCard', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    mocks.syncState = undefined;
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  it('renders manual refresh errors in the sync status card', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(PrSyncStatusCard, {
+          projectId: PROJECT_ID,
+          repositoryUrl: REPOSITORY_URL,
+          manualError: 'GitHub API is disabled for this project.',
+        })
+      );
+    });
+
+    expect(container.textContent).toContain('Sync failed');
+    expect(container.textContent).toContain('GitHub API is disabled for this project.');
+    expect(container.querySelector('.border-border-destructive')).not.toBeNull();
+    expect(container.querySelector('.bg-background-destructive')).not.toBeNull();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/pr-sync-status-card.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/pr-sync-status-card.tsx
@@ -31,14 +31,38 @@ function SyncStatusCard({ icon, label, content, actions, className }: SyncStatus
   );
 }
 
+function SyncErrorStatusCard({
+  error,
+  actions,
+}: {
+  error: string | null | undefined;
+  actions?: ReactNode;
+}) {
+  return (
+    <SyncStatusCard
+      className={'border-border-destructive bg-background-destructive text-foreground-destructive'}
+      icon={<AlertCircle className="size-3.5 shrink-0 text-foreground-destructive" />}
+      label={<span className="font-medium text-foreground-destructive">Sync failed</span>}
+      content={
+        <span className="block truncate text-foreground-destructive/80" title={error ?? undefined}>
+          {error ?? 'Unknown error'}
+        </span>
+      }
+      actions={actions}
+    />
+  );
+}
+
 interface Props {
   projectId: string;
   repositoryUrl: string;
+  manualError?: string | null;
 }
 
 export const PrSyncStatusCard = observer(function PrSyncStatusCard({
   projectId,
   repositoryUrl,
+  manualError,
 }: Props) {
   const prSync = getPrSyncStore(projectId);
   const state = prSync?.getState(repositoryUrl);
@@ -54,6 +78,10 @@ export const PrSyncStatusCard = observer(function PrSyncStatusCard({
       return () => clearTimeout(timer);
     }
   }, [state?.status, prSync, repositoryUrl]);
+
+  if (manualError && (!state || state.status === 'done')) {
+    return <SyncErrorStatusCard error={manualError} />;
+  }
 
   if (showSuccess) {
     return (
@@ -113,14 +141,8 @@ export const PrSyncStatusCard = observer(function PrSyncStatusCard({
 
   // error state
   return (
-    <SyncStatusCard
-      icon={<AlertCircle className="size-3.5 shrink-0 text-foreground-destructive" />}
-      label={<span className="text-destructive font-medium">Sync failed</span>}
-      content={
-        <span className="block truncate" title={state.error}>
-          {state.error ?? 'Unknown error'}
-        </span>
-      }
+    <SyncErrorStatusCard
+      error={state.error}
       actions={
         <>
           <Button

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/pr-view.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/pr-view.tsx
@@ -380,7 +380,11 @@ export const PullRequestView = observer(function PullRequestView() {
         isFetchingNextPage={isFetchingNextPage}
         fetchNextPage={fetchNextPage}
       />
-      <PrSyncStatusCard projectId={projectId} repositoryUrl={repositoryUrl} />
+      <PrSyncStatusCard
+        projectId={projectId}
+        repositoryUrl={repositoryUrl}
+        manualError={prs.length > 0 ? error : null}
+      />
     </div>
   );
 });

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.test.ts
@@ -1,0 +1,180 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePrViewState } from './usePrViewState';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  dataUpdatedAt: 0,
+  forceFullSyncPullRequests: vi.fn(),
+  refresh: vi.fn(),
+  syncState: undefined as
+    | { status: 'running' | 'done' | 'error' | 'cancelled'; error?: string }
+    | undefined,
+}));
+
+vi.mock('@renderer/features/projects/stores/project-selectors', () => ({
+  getPrSyncStore: () => ({
+    getState: () => mocks.syncState,
+    isSyncing: () => false,
+  }),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    pullRequests: {
+      forceFullSyncPullRequests: mocks.forceFullSyncPullRequests,
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/providers/github-context-provider', () => ({
+  useGithubContext: () => ({ user: null }),
+}));
+
+vi.mock('./usePullRequests', () => ({
+  useFilterOptions: () => ({ data: undefined }),
+  usePullRequests: () => ({
+    dataUpdatedAt: mocks.dataUpdatedAt,
+    error: null,
+    fetchNextPage: vi.fn(),
+    hasNextPage: false,
+    isFetchingNextPage: false,
+    loading: false,
+    prs: [],
+    refresh: mocks.refresh,
+  }),
+}));
+
+const PROJECT_ID = 'project-1';
+const REPOSITORY_URL = 'https://github.com/acme/repo';
+
+function Harness() {
+  const viewState = usePrViewState(PROJECT_ID, REPOSITORY_URL);
+  return React.createElement(
+    'div',
+    { 'data-error': viewState.error ?? '', 'data-testid': 'state' },
+    React.createElement(
+      'button',
+      {
+        'data-testid': 'refresh',
+        onClick: () => void viewState.handleRefresh(),
+      },
+      'Refresh'
+    ),
+    React.createElement(
+      'button',
+      {
+        'data-testid': 'force',
+        onClick: () => void viewState.handleForceFullSync(),
+      },
+      'Force'
+    )
+  );
+}
+
+describe('usePrViewState', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    mocks.dataUpdatedAt = 0;
+    mocks.refresh.mockReset();
+    mocks.forceFullSyncPullRequests.mockReset();
+    mocks.forceFullSyncPullRequests.mockResolvedValue({ success: true, data: undefined });
+    mocks.syncState = undefined;
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  async function renderHarness(): Promise<HTMLDivElement> {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Harness)
+        )
+      );
+    });
+
+    const state = container.querySelector('[data-testid="state"]') as HTMLDivElement | null;
+    expect(state).not.toBeNull();
+    return state!;
+  }
+
+  it('clears a manual refresh error after a successful data update', async () => {
+    mocks.refresh.mockRejectedValueOnce(new Error('sync failed'));
+    const state = await renderHarness();
+    const refreshButton = container.querySelector('[data-testid="refresh"]');
+    expect(refreshButton).not.toBeNull();
+
+    await act(async () => {
+      refreshButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => expect(state.getAttribute('data-error')).toBe('sync failed'));
+
+    mocks.dataUpdatedAt = 1;
+    await renderHarness();
+
+    await vi.waitFor(() => expect(state.getAttribute('data-error')).toBe(''));
+  });
+
+  it('hides stale manual refresh errors after sync completion', async () => {
+    mocks.refresh.mockRejectedValueOnce(new Error('sync failed'));
+    const state = await renderHarness();
+    const refreshButton = container.querySelector('[data-testid="refresh"]');
+    expect(refreshButton).not.toBeNull();
+
+    await act(async () => {
+      refreshButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => expect(state.getAttribute('data-error')).toBe('sync failed'));
+
+    mocks.syncState = { status: 'done' };
+    await renderHarness();
+
+    expect(state.getAttribute('data-error')).toBe('');
+  });
+
+  it('surfaces rejected force-full sync RPCs', async () => {
+    mocks.forceFullSyncPullRequests.mockRejectedValueOnce(new Error('transport down'));
+    const state = await renderHarness();
+    const forceButton = container.querySelector('[data-testid="force"]');
+    expect(forceButton).not.toBeNull();
+
+    await act(async () => {
+      forceButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() => expect(state.getAttribute('data-error')).toBe('transport down'));
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.test.ts
@@ -54,6 +54,20 @@ vi.mock('./usePullRequests', () => ({
 const PROJECT_ID = 'project-1';
 const REPOSITORY_URL = 'https://github.com/acme/repo';
 
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+  reject: (reason: unknown) => void;
+} {
+  let resolve!: (value: T) => void;
+  let reject!: (reason: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function Harness() {
   const viewState = usePrViewState(PROJECT_ID, REPOSITORY_URL);
   return React.createElement(
@@ -163,6 +177,28 @@ describe('usePrViewState', () => {
     await renderHarness();
 
     expect(state.getAttribute('data-error')).toBe('');
+  });
+
+  it('keeps fresh manual refresh errors visible when sync completes before rejection', async () => {
+    const refresh = deferred<void>();
+    mocks.syncState = { status: 'running' };
+    mocks.refresh.mockReturnValueOnce(refresh.promise);
+    const state = await renderHarness();
+    const refreshButton = container.querySelector('[data-testid="refresh"]');
+    expect(refreshButton).not.toBeNull();
+
+    await act(async () => {
+      refreshButton!.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    mocks.syncState = { status: 'done' };
+    await renderHarness();
+
+    await act(async () => {
+      refresh.reject(new Error('sync failed'));
+    });
+
+    await vi.waitFor(() => expect(state.getAttribute('data-error')).toBe('sync failed'));
   });
 
   it('surfaces rejected force-full sync RPCs', async () => {

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.ts
@@ -4,13 +4,18 @@ import { getPrSyncStore } from '@renderer/features/projects/stores/project-selec
 import { useDebounce } from '@renderer/lib/hooks/useDebounce';
 import { rpc } from '@renderer/lib/ipc';
 import { useGithubContext } from '@renderer/lib/providers/github-context-provider';
-import type { PrFilters, PrSortField } from '@shared/core/pull-requests/pull-requests';
+import {
+  pullRequestErrorMessage,
+  type PrFilters,
+  type PrSortField,
+} from '@shared/core/pull-requests/pull-requests';
 import { toUserItem, usersWithLoginFirst, type UserItem } from './pr-filter-items';
 import { useFilterOptions, usePullRequests } from './usePullRequests';
 
 export type StatusFilter = 'open' | 'not-open';
 
 export type LabelItem = { value: string; label: string; color?: string };
+type RefreshError = { message: string; syncStatus?: string };
 
 export function usePrViewState(projectId: string, repositoryUrl: string | null) {
   const queryClient = useQueryClient();
@@ -23,6 +28,7 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
   const [query, setQuery] = useState('');
   const debouncedQuery = useDebounce(query, 200);
   const [syncing, setSyncing] = useState(false);
+  const [refreshError, setRefreshError] = useState<RefreshError | null>(null);
 
   const filters: PrFilters = {
     status: statusFilter,
@@ -48,6 +54,7 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
 
   useEffect(() => {
     if (dataUpdatedAt > 0 && repositoryUrl) {
+      setRefreshError(null);
       void queryClient.invalidateQueries({ queryKey: ['pr-filter-options', repositoryUrl] });
     }
   }, [dataUpdatedAt, repositoryUrl, queryClient]);
@@ -94,10 +101,20 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
     if (value) setSortFilter(value as PrSortField);
   };
 
+  function captureRefreshError(error: unknown): void {
+    setRefreshError({
+      message: error instanceof Error ? error.message : String(error),
+      syncStatus: syncState?.status,
+    });
+  }
+
   const handleRefresh = async () => {
     setSyncing(true);
+    setRefreshError(null);
     try {
       await refresh();
+    } catch (error) {
+      captureRefreshError(error);
     } finally {
       setSyncing(false);
     }
@@ -105,9 +122,16 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
 
   const handleForceFullSync = async () => {
     setSyncing(true);
+    setRefreshError(null);
     try {
-      await rpc.pullRequests.forceFullSyncPullRequests(projectId);
+      const result = await rpc.pullRequests.forceFullSyncPullRequests(projectId);
+      if (!result.success) {
+        captureRefreshError(pullRequestErrorMessage(result.error));
+        return;
+      }
       await queryClient.invalidateQueries({ queryKey: ['pull-requests', projectId] });
+    } catch (error) {
+      captureRefreshError(error);
     } finally {
       setSyncing(false);
     }
@@ -120,6 +144,10 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
   const syncState = repositoryUrl ? prSyncStore?.getState(repositoryUrl) : undefined;
   const syncError = syncState?.status === 'error' ? (syncState.error ?? 'Sync failed') : null;
   const isSyncing = syncing || backgroundSyncing;
+  const visibleRefreshError =
+    refreshError && !(syncState?.status === 'done' && refreshError.syncStatus !== 'done')
+      ? refreshError.message
+      : null;
 
   const removeLabel = (name: string) =>
     setSelectedLabelNames((prev) => prev.filter((n) => n !== name));
@@ -146,7 +174,7 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
     // data
     prs,
     loading,
-    error: error ?? syncError,
+    error: visibleRefreshError ?? error ?? syncError,
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePrViewState.ts
@@ -1,5 +1,5 @@
 import { useQueryClient } from '@tanstack/react-query';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { getPrSyncStore } from '@renderer/features/projects/stores/project-selectors';
 import { useDebounce } from '@renderer/lib/hooks/useDebounce';
 import { rpc } from '@renderer/lib/ipc';
@@ -101,10 +101,18 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
     if (value) setSortFilter(value as PrSortField);
   };
 
+  const prSyncStore = getPrSyncStore(projectId);
+  const backgroundSyncing = repositoryUrl
+    ? (prSyncStore?.isSyncing(repositoryUrl) ?? false)
+    : false;
+  const syncState = repositoryUrl ? prSyncStore?.getState(repositoryUrl) : undefined;
+  const syncStateRef = useRef(syncState);
+  syncStateRef.current = syncState;
+
   function captureRefreshError(error: unknown): void {
     setRefreshError({
       message: error instanceof Error ? error.message : String(error),
-      syncStatus: syncState?.status,
+      syncStatus: syncStateRef.current?.status,
     });
   }
 
@@ -137,11 +145,6 @@ export function usePrViewState(projectId: string, repositoryUrl: string | null) 
     }
   };
 
-  const prSyncStore = getPrSyncStore(projectId);
-  const backgroundSyncing = repositoryUrl
-    ? (prSyncStore?.isSyncing(repositoryUrl) ?? false)
-    : false;
-  const syncState = repositoryUrl ? prSyncStore?.getState(repositoryUrl) : undefined;
   const syncError = syncState?.status === 'error' ? (syncState.error ?? 'Sync failed') : null;
   const isSyncing = syncing || backgroundSyncing;
   const visibleRefreshError =

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePullRequests.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePullRequests.test.ts
@@ -1,0 +1,148 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { JSDOM } from 'jsdom';
+import React, { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { usePullRequests } from './usePullRequests';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  listPullRequests: vi.fn(),
+  syncPullRequests: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    pullRequests: {
+      listPullRequests: mocks.listPullRequests,
+      syncPullRequests: mocks.syncPullRequests,
+    },
+  },
+}));
+
+const PROJECT_ID = 'project-1';
+const REPOSITORY_URL = 'https://github.com/acme/repo';
+
+function deferred<T>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
+} {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((r) => {
+    resolve = r;
+  });
+  return { promise, resolve };
+}
+
+function Harness() {
+  const { refresh } = usePullRequests(PROJECT_ID, REPOSITORY_URL);
+  const [error, setError] = useState('');
+
+  return React.createElement(
+    'button',
+    {
+      'data-error': error,
+      'data-testid': 'refresh',
+      onClick: () =>
+        void refresh().catch((e: unknown) => {
+          setError(e instanceof Error ? e.message : String(e));
+        }),
+    },
+    'Refresh'
+  );
+}
+
+describe('usePullRequests', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+  let queryClient: QueryClient;
+
+  beforeEach(() => {
+    mocks.listPullRequests.mockResolvedValue({ success: true, data: { prs: [] } });
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+
+    queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    queryClient.clear();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  async function renderHarness(): Promise<HTMLButtonElement> {
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(Harness)
+        )
+      );
+    });
+
+    await vi.waitFor(() => expect(mocks.listPullRequests).toHaveBeenCalledTimes(1));
+    const button = container.querySelector('[data-testid="refresh"]') as HTMLButtonElement | null;
+    expect(button).not.toBeNull();
+    return button!;
+  }
+
+  it('waits for sync completion before invalidating the list query', async () => {
+    const sync = deferred<{ success: true; data: void }>();
+    mocks.syncPullRequests.mockReturnValue(sync.promise);
+    const button = await renderHarness();
+
+    await act(async () => {
+      button.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(mocks.syncPullRequests).toHaveBeenCalledTimes(1);
+    expect(mocks.listPullRequests).toHaveBeenCalledTimes(1);
+
+    await act(async () => {
+      sync.resolve({ success: true, data: undefined });
+    });
+
+    await vi.waitFor(() => expect(mocks.listPullRequests).toHaveBeenCalledTimes(2));
+  });
+
+  it('surfaces sync errors without invalidating the list query', async () => {
+    mocks.syncPullRequests.mockResolvedValue({
+      success: false,
+      error: {
+        type: 'github_not_found_or_no_access',
+        host: 'github.com',
+        message:
+          'acme/repo on github.com was not found, or the selected GitHub account does not have access.',
+      },
+    });
+    const button = await renderHarness();
+
+    await act(async () => {
+      button.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await vi.waitFor(() =>
+      expect(button.getAttribute('data-error')).toContain(
+        'acme/repo on github.com was not found, or the selected GitHub account does not have access.'
+      )
+    );
+    expect(mocks.listPullRequests).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePullRequests.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/pr-view/usePullRequests.ts
@@ -72,7 +72,10 @@ export function usePullRequests(
 
   const refresh = useCallback(async () => {
     if (!projectId || !repositoryUrl) return;
-    await rpc.pullRequests.syncPullRequests(projectId);
+    const result = await rpc.pullRequests.syncPullRequests(projectId);
+    if (!result.success) {
+      throw new Error(pullRequestErrorMessage(result.error));
+    }
     await queryClient.invalidateQueries({ queryKey: prQueryKeys.list(projectId, repositoryUrl) });
     await queryClient.invalidateQueries({
       queryKey: prQueryKeys.filterOptions(repositoryUrl),

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -200,7 +200,12 @@ export function SettingsPage({
           </div>
           {/* Content container */}
           {currentContent && (
-            <div className="min-h-0 min-w-0 flex-1 justify-center overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]">
+            <div
+              className={cn(
+                'min-h-0 min-w-0 flex-1 justify-center overflow-x-hidden overflow-y-auto',
+                '[scrollbar-gutter:stable]'
+              )}
+            >
               <div className="mx-auto w-full max-w-4xl space-y-8 px-4 py-10">
                 <PageHeader title={currentContent.title} description={currentContent.description} />
                 {currentContent.sections.map((section) => (

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -200,7 +200,7 @@ export function SettingsPage({
           </div>
           {/* Content container */}
           {currentContent && (
-            <div className="min-h-0 min-w-0 flex-1 [scrollbar-gutter:stable] justify-center overflow-x-hidden overflow-y-auto">
+            <div className="min-h-0 min-w-0 flex-1 justify-center overflow-x-hidden overflow-y-auto [scrollbar-gutter:stable]">
               <div className="mx-auto w-full max-w-4xl space-y-8 px-4 py-10">
                 <PageHeader title={currentContent.title} description={currentContent.description} />
                 {currentContent.sections.map((section) => (

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/pr-selector/pr-selector.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/pr-selector/pr-selector.test.ts
@@ -74,6 +74,7 @@ vi.mock('@renderer/lib/ui/combobox', async () => {
   const React = await import('react');
 
   type ComboboxContextValue = {
+    items?: PullRequest[];
     inputValue?: string;
     onInputValueChange?: (value: string, details: { reason: string }) => void;
   };
@@ -103,26 +104,41 @@ vi.mock('@renderer/lib/ui/combobox', async () => {
   return {
     Combobox: ({
       children,
+      items,
       inputValue,
       onInputValueChange,
     }: {
       children: React.ReactNode;
+      items?: PullRequest[];
       inputValue?: string;
       onInputValueChange?: (value: string, details: { reason: string }) => void;
     }) =>
       React.createElement(
         ComboboxContext.Provider,
-        { value: { inputValue, onInputValueChange } },
+        { value: { items, inputValue, onInputValueChange } },
         children
       ),
     ComboboxContent: ({ children }: { children: React.ReactNode }) =>
       React.createElement('div', {}, children),
-    ComboboxEmpty: ({ children }: { children: React.ReactNode }) =>
-      React.createElement('div', {}, children),
+    ComboboxEmpty: ({ children }: { children: React.ReactNode }) => {
+      const { items } = React.useContext(ComboboxContext);
+      return items?.length ? null : React.createElement('div', {}, children);
+    },
     ComboboxInput: MockComboboxInput,
     ComboboxItem: ({ children }: { children: React.ReactNode }) =>
       React.createElement('div', {}, children),
-    ComboboxList: () => React.createElement('div', {}),
+    ComboboxList: ({ children }: { children: React.ReactNode }) => {
+      const { items } = React.useContext(ComboboxContext);
+      return React.createElement(
+        'div',
+        {},
+        items?.map((item) =>
+          typeof children === 'function'
+            ? (children as (item: PullRequest) => React.ReactNode)(item)
+            : children
+        )
+      );
+    },
     ComboboxTrigger: ({ render }: { render: React.ReactElement }) => render,
     ComboboxValue: ({
       children,
@@ -322,6 +338,41 @@ describe('PrSelector', () => {
         'acme/repo on github.com was not found, or the selected GitHub account does not have access.'
       );
     });
+    expect(container.textContent).not.toContain('No open pull requests');
+  });
+
+  it('shows background sync errors above cached pull request results', async () => {
+    mocks.syncPullRequests.mockResolvedValue({
+      success: false,
+      error: {
+        type: 'github_account_disabled',
+        message: 'GitHub API is disabled for this project.',
+      },
+    });
+    mocks.listPullRequests.mockResolvedValue({ success: true, data: { prs: [makePr()] } });
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          QueryClientProvider,
+          { client: queryClient },
+          React.createElement(PrSelector, {
+            value: null,
+            onValueChange: vi.fn(),
+            projectId: PROJECT_ID,
+            repositoryUrl: REPOSITORY_URL,
+          })
+        )
+      );
+    });
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('GitHub API is disabled for this project.');
+    });
+    expect(container.textContent).toContain('Sync failed');
+    expect(container.textContent).toContain('Search PR');
+    expect(container.querySelector('.absolute.right-6.bottom-4.left-6')).not.toBeNull();
+    expect(container.querySelector('.border-border-destructive')).not.toBeNull();
     expect(container.textContent).not.toContain('No open pull requests');
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/pr-selector/pr-selector.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/pr-selector/pr-selector.tsx
@@ -1,5 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
+import { AlertCircle } from 'lucide-react';
 import { type ReactNode, useState } from 'react';
+import { ListPopoverCard } from '@renderer/lib/components/list-popover-card';
 import { StatusIcon } from '@renderer/lib/components/pr-status-icon';
 import { useDebounce } from '@renderer/lib/hooks/useDebounce';
 import { rpc } from '@renderer/lib/ipc';
@@ -203,6 +205,22 @@ export function PrSelector({
               </ComboboxItem>
             )}
           </ComboboxList>
+          {errorMessage && prs.length > 0 && (
+            <ListPopoverCard
+              className={
+                'border-border-destructive bg-background-destructive text-foreground-destructive'
+              }
+            >
+              <AlertCircle className="size-3.5 shrink-0 text-foreground-destructive" />
+              <span className="shrink-0 font-medium text-foreground-destructive">Sync failed</span>
+              <span
+                className="min-w-0 grow truncate text-foreground-destructive/80"
+                title={errorMessage}
+              >
+                {errorMessage}
+              </span>
+            </ListPopoverCard>
+          )}
         </ComboboxContent>
       </Combobox>
     </div>

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/pr-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/pr-section.tsx
@@ -1,6 +1,7 @@
 import { Plus, RefreshCw } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { getPrSyncStore } from '@renderer/features/projects/stores/project-selectors';
+import { useToast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
@@ -8,6 +9,7 @@ import { EmptyState } from '@renderer/lib/ui/empty-state';
 import { SplitButton, type SplitButtonAction } from '@renderer/lib/ui/split-button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
+import { pullRequestErrorMessage } from '@shared/core/pull-requests/pull-requests';
 import { getTaskGitStore } from '../../stores/task-selectors';
 import {
   useTaskViewContext,
@@ -37,6 +39,7 @@ export const PullRequestsSection = observer(function PullRequestsSection({
   const pullRequests = prStore?.pullRequests ?? [];
   const currentPr = prStore?.currentPr;
   const showCreatePrModal = useShowModal('createPrModal');
+  const { toast } = useToast();
   const prSyncStore = getPrSyncStore(projectId);
 
   const hasOpenPr = pullRequests.some((p) => p.status === 'open');
@@ -77,6 +80,25 @@ export const PullRequestsSection = observer(function PullRequestsSection({
     { value: 'create-draft-pr', label: 'Create draft PR', action: () => onCreateDraftPr?.() },
   ];
 
+  const handleRefresh = async () => {
+    try {
+      const result = await rpc.pullRequests.syncPullRequests(projectId);
+      if (!result.success) {
+        toast({
+          title: 'Failed to refresh pull requests',
+          description: pullRequestErrorMessage(result.error),
+          variant: 'destructive',
+        });
+      }
+    } catch (error) {
+      toast({
+        title: 'Failed to refresh pull requests',
+        description: error instanceof Error ? error.message : String(error),
+        variant: 'destructive',
+      });
+    }
+  };
+
   const { mode: viewMode, setMode: setViewMode } = useChangesViewMode('pr');
 
   return (
@@ -112,7 +134,7 @@ export const PullRequestsSection = observer(function PullRequestsSection({
                 <Button
                   variant="outline"
                   size="icon-xs"
-                  onClick={() => void rpc.pullRequests.syncPullRequests(projectId)}
+                  onClick={() => void handleRefresh()}
                   disabled={isRefreshing}
                 >
                   <RefreshCw className={cn('size-3', isRefreshing && 'animate-spin')} />

--- a/apps/emdash-desktop/src/renderer/lib/components/reorder-list.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/reorder-list.tsx
@@ -28,7 +28,7 @@ export function ReorderList<T>({
   children,
 }: ReorderListProps<T>) {
   return (
-    <Reorder.Group<T[], typeof as>
+    <Reorder.Group<T, typeof as>
       as={as}
       axis={axis}
       values={items}

--- a/apps/emdash-desktop/src/renderer/lib/components/reorder-list.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/reorder-list.tsx
@@ -28,7 +28,7 @@ export function ReorderList<T>({
   children,
 }: ReorderListProps<T>) {
   return (
-    <Reorder.Group<T, typeof as>
+    <Reorder.Group
       as={as}
       axis={axis}
       values={items}


### PR DESCRIPTION
- pr refresh waits for sync completion and returns auth or sync failures instead of silently invalidating stale data
- project pr list shows manual refresh failures in the existing sync status card while keeping cached pull requests visible
- task sidebar refresh shows destructive toast errors when sync fails
- pr selector shows sync failures as a floating bottom error card over cached results