### PR TITLE
feat(diff): rendered markdown preview toggle in the diff viewer

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -13,14 +13,22 @@ import {
 } from '@renderer/features/tasks/task-view-context';
 import { getFileKind } from '@renderer/lib/editor/fileKind';
 import { PreviewSourceToggle } from '@renderer/lib/editor/preview-source-toggle';
+import { useDelayedBoolean } from '@renderer/lib/hooks/use-delay-boolean';
 import { rpc } from '@renderer/lib/ipc';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
 import { StickyDiffEditor } from '@renderer/lib/monaco/sticky-diff-editor';
 import { MarkdownRenderer } from '@renderer/lib/ui/markdown-renderer';
 import { ShowHide } from '@renderer/lib/ui/show-hide';
+import { Spinner } from '@renderer/lib/ui/spinner';
 import { getLanguageFromPath } from '@renderer/utils/languageUtils';
-import { gitRefToString, HEAD_REF, STAGED_REF, type GitObjectRef } from '@shared/core/git/git';
+import {
+  gitRefToString,
+  HEAD_REF,
+  STAGED_REF,
+  type GitObjectRef,
+  type GitRef,
+} from '@shared/core/git/git';
 import { getDraftCommentTargetKey, type DraftCommentTarget } from '@shared/lineComments';
 import type { ActiveFile } from '@shared/view-state';
 
@@ -277,35 +285,131 @@ const MarkdownDiffRenderer = observer(function MarkdownDiffRenderer({
   );
 });
 
+/** Where a rendered side's linked images come from, matching its diff source. */
+type ImageSource = { kind: 'disk' } | { kind: 'index' } | { kind: 'ref'; ref: GitRef };
+
+/**
+ * Resolves which source a rendered side's images come from, mirroring the
+ * original/modified ref selection in computeDiffUris so images stay consistent
+ * with the text being shown: working tree, index, or a specific git ref.
+ */
+function imageSourceForSide(tab: DiffTabStore, side: 'original' | 'modified'): ImageSource {
+  if (side === 'original') {
+    if (tab.diffGroup === 'disk') return { kind: 'index' };
+    if (tab.diffGroup === 'git' || tab.diffGroup === 'pr') {
+      return { kind: 'ref', ref: tab.originalRef };
+    }
+    return { kind: 'ref', ref: HEAD_REF };
+  }
+  if (tab.diffGroup === 'staged') return { kind: 'index' };
+  if (tab.diffGroup === 'git' || tab.diffGroup === 'pr') {
+    return { kind: 'ref', ref: tab.modifiedRef ?? HEAD_REF };
+  }
+  return { kind: 'disk' };
+}
+
+/** Resolves a relative markdown image against the correct side/source of the diff. */
+async function resolveSideImage(
+  tab: DiffTabStore,
+  side: 'original' | 'modified',
+  projectId: string,
+  workspaceId: string,
+  fileDir: string,
+  src: string
+): Promise<string | null> {
+  const imagePath = fileDir ? `${fileDir}/${src}` : src;
+  const source = imageSourceForSide(tab, side);
+  if (source.kind === 'disk') {
+    const res = await rpc.workspace.fs.readImage(projectId, workspaceId, imagePath);
+    return res.success ? (res.data?.dataUrl ?? null) : null;
+  }
+  const res =
+    source.kind === 'index'
+      ? await rpc.workspace.git.getImageAtIndex(projectId, workspaceId, imagePath)
+      : await rpc.workspace.git.getImageAtRef(
+          projectId,
+          workspaceId,
+          imagePath,
+          gitRefToString(source.ref)
+        );
+  if (!res.success) return null;
+  return res.data.result.kind === 'image' ? res.data.result.image.dataUrl : null;
+}
+
 /**
  * Renders the modified ("after") markdown content as a formatted preview. In
  * split mode it shows the original (left) and modified (right) side by side,
  * reusing the diff toolbar's unified/split toggle for consistency.
+ *
+ * Content is read from the Monaco diff models and kept in sync via
+ * onDidChangeContent, so the preview tracks model refreshes (e.g. index/disk
+ * reloads) instead of going stale. Linked images are resolved from the same
+ * source as the side being rendered.
  */
 const MarkdownDiffPreview = observer(function MarkdownDiffPreview({ tab }: DiffFileRendererProps) {
   const { projectId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
   const diffStyle = useWorkspaceViewModel().diffView?.diffStyle ?? 'unified';
-  const { uri, originalUri, modifiedUri } = computeDiffUris(tab, workspaceId);
+  const { originalUri, modifiedUri } = computeDiffUris(tab, workspaceId);
 
-  // Reading the model status / buffer version registers MobX dependencies so this
-  // observer re-renders once the underlying models load or their content changes.
-  const _origStatus = modelRegistry.modelStatus.get(originalUri);
-  const _modStatus = modelRegistry.modelStatus.get(modifiedUri);
-  const _bufferVersion = modelRegistry.bufferVersions.get(uri);
+  // Model load status drives the loading spinner and triggers the content
+  // listeners below to (re)attach once a model becomes available.
+  const originalStatus = modelRegistry.modelStatus.get(originalUri);
+  const modifiedStatus = modelRegistry.modelStatus.get(modifiedUri);
 
-  const newContent = modelRegistry.getModelByUri(modifiedUri)?.getValue() ?? '';
-  const oldContent = modelRegistry.getModelByUri(originalUri)?.getValue() ?? '';
+  const [newContent, setNewContent] = useState('');
+  const [oldContent, setOldContent] = useState('');
+
+  // Read content imperatively and keep it in sync via onDidChangeContent rather
+  // than the file-tab markdown renderer's bufferVersions MobX dependency: the
+  // registry only bumps bufferVersions for the editable buffer model, never for
+  // git/index models, so a bufferVersions dependency would go stale when a
+  // staged/ref/PR diff reloads. onDidChangeContent also fires for those in-place
+  // setValue() refreshes, so it covers every side.
+  useEffect(() => {
+    const model = modelRegistry.getModelByUri(modifiedUri);
+    if (!model) {
+      setNewContent('');
+      return;
+    }
+    setNewContent(model.getValue());
+    const sub = model.onDidChangeContent(() => setNewContent(model.getValue()));
+    return () => sub.dispose();
+  }, [modifiedUri, modifiedStatus]);
+
+  useEffect(() => {
+    const model = modelRegistry.getModelByUri(originalUri);
+    if (!model) {
+      setOldContent('');
+      return;
+    }
+    setOldContent(model.getValue());
+    const sub = model.onDidChangeContent(() => setOldContent(model.getValue()));
+    return () => sub.dispose();
+  }, [originalUri, originalStatus]);
 
   const fileDir = tab.path.includes('/') ? tab.path.substring(0, tab.path.lastIndexOf('/')) : '';
-  const resolveImage = useCallback(
-    async (src: string): Promise<string | null> => {
-      const imagePath = fileDir ? `${fileDir}/${src}` : src;
-      const result = await rpc.workspace.fs.readImage(projectId, workspaceId, imagePath);
-      return result.success ? (result.data?.dataUrl ?? null) : null;
-    },
-    [projectId, workspaceId, fileDir]
+  const resolveModifiedImage = useCallback(
+    (src: string) => resolveSideImage(tab, 'modified', projectId, workspaceId, fileDir, src),
+    [tab, projectId, workspaceId, fileDir]
   );
+  const resolveOriginalImage = useCallback(
+    (src: string) => resolveSideImage(tab, 'original', projectId, workspaceId, fileDir, src),
+    [tab, projectId, workspaceId, fileDir]
+  );
+
+  const modifiedLoading = !modifiedStatus || modifiedStatus === 'loading';
+  const originalLoading = !originalStatus || originalStatus === 'loading';
+  const waiting = diffStyle === 'split' ? modifiedLoading || originalLoading : modifiedLoading;
+  const showSpinner = useDelayedBoolean(waiting, 200);
+
+  if (showSpinner) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-background-secondary-1">
+        <Spinner />
+      </div>
+    );
+  }
 
   if (diffStyle === 'split') {
     return (
@@ -315,7 +419,7 @@ const MarkdownDiffPreview = observer(function MarkdownDiffPreview({ tab }: DiffF
             content={oldContent}
             variant="full"
             className="w-full max-w-3xl px-8 py-8"
-            resolveImage={resolveImage}
+            resolveImage={resolveOriginalImage}
           />
         </div>
         <div className="h-full flex-1 overflow-y-auto bg-background-secondary-1">
@@ -323,7 +427,7 @@ const MarkdownDiffPreview = observer(function MarkdownDiffPreview({ tab }: DiffF
             content={newContent}
             variant="full"
             className="w-full max-w-3xl px-8 py-8"
-            resolveImage={resolveImage}
+            resolveImage={resolveModifiedImage}
           />
         </div>
       </div>
@@ -336,7 +440,7 @@ const MarkdownDiffPreview = observer(function MarkdownDiffPreview({ tab }: DiffF
         content={newContent}
         variant="full"
         className="w-full max-w-3xl px-8 py-8"
-        resolveImage={resolveImage}
+        resolveImage={resolveModifiedImage}
       />
     </div>
   );

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -11,9 +11,14 @@ import {
   useWorkspaceId,
   useWorkspaceViewModel,
 } from '@renderer/features/tasks/task-view-context';
+import { getFileKind } from '@renderer/lib/editor/fileKind';
+import { PreviewSourceToggle } from '@renderer/lib/editor/preview-source-toggle';
+import { rpc } from '@renderer/lib/ipc';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
 import { StickyDiffEditor } from '@renderer/lib/monaco/sticky-diff-editor';
+import { MarkdownRenderer } from '@renderer/lib/ui/markdown-renderer';
+import { ShowHide } from '@renderer/lib/ui/show-hide';
 import { getLanguageFromPath } from '@renderer/utils/languageUtils';
 import { gitRefToString, HEAD_REF, STAGED_REF, type GitObjectRef } from '@shared/core/git/git';
 import { getDraftCommentTargetKey, type DraftCommentTarget } from '@shared/lineComments';
@@ -32,8 +37,15 @@ export const DiffFileRenderer = observer(function DiffFileRenderer({ tab }: Diff
   const workspaceId = useWorkspaceId();
 
   switch (tab.renderer.kind) {
-    case 'text':
+    case 'text': {
+      // Markdown files get a rendered-preview toggle (Eye) alongside the source
+      // diff (Pencil), mirroring the file-tab markdown renderer. Deleted files
+      // have no "after" content to render, so they stay diff-only.
+      if (getFileKind(tab.path) === 'markdown' && tab.status !== 'deleted') {
+        return <MarkdownDiffRenderer tab={tab} />;
+      }
       return <MonacoDiffRenderer tab={tab} />;
+    }
     case 'image': {
       const activeFile = tabToActiveFile(tab);
       return (
@@ -105,30 +117,8 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
     onDeleteComment: handleDeleteComment,
   });
 
-  const root = `workspace:${workspaceId}`;
-  const uri = buildMonacoModelPath(root, tab.path);
   const language = getLanguageFromPath(tab.path);
-
-  const originalUri = (() => {
-    if (tab.diffGroup === 'disk') {
-      return modelRegistry.toGitUri(uri, STAGED_REF);
-    }
-    if (tab.diffGroup === 'git' || tab.diffGroup === 'pr') {
-      return modelRegistry.toGitUri(uri, tab.originalRef);
-    }
-    return modelRegistry.toGitUri(uri, HEAD_REF);
-  })();
-
-  const modifiedUri = (() => {
-    if (tab.diffGroup === 'staged') return modelRegistry.toGitUri(uri, STAGED_REF);
-    if (tab.diffGroup === 'pr') {
-      return modelRegistry.toGitUri(uri, tab.modifiedRef ?? HEAD_REF);
-    }
-    if (tab.diffGroup === 'git') {
-      return modelRegistry.toGitUri(uri, tab.modifiedRef ?? HEAD_REF);
-    }
-    return uri;
-  })();
+  const { root, uri, originalUri, modifiedUri } = computeDiffUris(tab, workspaceId);
 
   useEffect(() => {
     let disposed = false;
@@ -229,6 +219,125 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
           onEditorChange={setEditor}
         />
       </div>
+    </div>
+  );
+});
+
+/**
+ * Computes the original/modified Monaco model URIs for a diff tab. Shared by the
+ * Monaco diff editor and the markdown preview so both read identical content.
+ */
+function computeDiffUris(
+  tab: DiffTabStore,
+  workspaceId: string
+): { root: string; uri: string; originalUri: string; modifiedUri: string } {
+  const root = `workspace:${workspaceId}`;
+  const uri = buildMonacoModelPath(root, tab.path);
+
+  const originalUri = (() => {
+    if (tab.diffGroup === 'disk') return modelRegistry.toGitUri(uri, STAGED_REF);
+    if (tab.diffGroup === 'git' || tab.diffGroup === 'pr') {
+      return modelRegistry.toGitUri(uri, tab.originalRef);
+    }
+    return modelRegistry.toGitUri(uri, HEAD_REF);
+  })();
+
+  const modifiedUri = (() => {
+    if (tab.diffGroup === 'staged') return modelRegistry.toGitUri(uri, STAGED_REF);
+    if (tab.diffGroup === 'pr') return modelRegistry.toGitUri(uri, tab.modifiedRef ?? HEAD_REF);
+    if (tab.diffGroup === 'git') return modelRegistry.toGitUri(uri, tab.modifiedRef ?? HEAD_REF);
+    return uri;
+  })();
+
+  return { root, uri, originalUri, modifiedUri };
+}
+
+/**
+ * Renders a markdown diff tab with a toggle between the source diff (Pencil) and
+ * a rendered markdown preview (Eye), mirroring the file-tab MarkdownEditorRenderer.
+ *
+ * The Monaco diff editor is kept mounted via ShowHide while the preview is shown,
+ * so its models stay registered and the preview can read their content.
+ */
+const MarkdownDiffRenderer = observer(function MarkdownDiffRenderer({
+  tab,
+}: DiffFileRendererProps) {
+  return (
+    <div className="relative h-full w-full overflow-hidden">
+      <ShowHide visible={!tab.showRendered}>
+        <MonacoDiffRenderer tab={tab} />
+      </ShowHide>
+      {tab.showRendered && <MarkdownDiffPreview tab={tab} />}
+      <PreviewSourceToggle
+        activeMode={tab.showRendered ? 'preview' : 'source'}
+        onSwitch={(mode) => tab.setShowRendered(mode === 'preview')}
+        sourceLabel="View diff"
+      />
+    </div>
+  );
+});
+
+/**
+ * Renders the modified ("after") markdown content as a formatted preview. In
+ * split mode it shows the original (left) and modified (right) side by side,
+ * reusing the diff toolbar's unified/split toggle for consistency.
+ */
+const MarkdownDiffPreview = observer(function MarkdownDiffPreview({ tab }: DiffFileRendererProps) {
+  const { projectId } = useTaskViewContext();
+  const workspaceId = useWorkspaceId();
+  const diffStyle = useWorkspaceViewModel().diffView?.diffStyle ?? 'unified';
+  const { uri, originalUri, modifiedUri } = computeDiffUris(tab, workspaceId);
+
+  // Reading the model status / buffer version registers MobX dependencies so this
+  // observer re-renders once the underlying models load or their content changes.
+  const _origStatus = modelRegistry.modelStatus.get(originalUri);
+  const _modStatus = modelRegistry.modelStatus.get(modifiedUri);
+  const _bufferVersion = modelRegistry.bufferVersions.get(uri);
+
+  const newContent = modelRegistry.getModelByUri(modifiedUri)?.getValue() ?? '';
+  const oldContent = modelRegistry.getModelByUri(originalUri)?.getValue() ?? '';
+
+  const fileDir = tab.path.includes('/') ? tab.path.substring(0, tab.path.lastIndexOf('/')) : '';
+  const resolveImage = useCallback(
+    async (src: string): Promise<string | null> => {
+      const imagePath = fileDir ? `${fileDir}/${src}` : src;
+      const result = await rpc.workspace.fs.readImage(projectId, workspaceId, imagePath);
+      return result.success ? (result.data?.dataUrl ?? null) : null;
+    },
+    [projectId, workspaceId, fileDir]
+  );
+
+  if (diffStyle === 'split') {
+    return (
+      <div className="flex h-full w-full">
+        <div className="h-full flex-1 overflow-y-auto border-r border-border bg-background-secondary-1">
+          <MarkdownRenderer
+            content={oldContent}
+            variant="full"
+            className="w-full max-w-3xl px-8 py-8"
+            resolveImage={resolveImage}
+          />
+        </div>
+        <div className="h-full flex-1 overflow-y-auto bg-background-secondary-1">
+          <MarkdownRenderer
+            content={newContent}
+            variant="full"
+            className="w-full max-w-3xl px-8 py-8"
+            resolveImage={resolveImage}
+          />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="h-full w-full overflow-y-auto bg-background-secondary-1">
+      <MarkdownRenderer
+        content={newContent}
+        variant="full"
+        className="w-full max-w-3xl px-8 py-8"
+        resolveImage={resolveImage}
+      />
     </div>
   );
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/tabs/diff-tab-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/tabs/diff-tab-store.test.ts
@@ -1,0 +1,36 @@
+import { reaction } from 'mobx';
+import { describe, expect, it } from 'vitest';
+import type { ActiveFile } from '@shared/view-state';
+import { DiffTabStore } from './diff-tab-store';
+
+function makeActiveFile(path: string): ActiveFile {
+  return {
+    path,
+    type: 'disk',
+    group: 'disk',
+    originalRef: { kind: 'commit', sha: 'deadbeef' },
+  };
+}
+
+describe('DiffTabStore markdown preview toggle', () => {
+  it('defaults to the source diff (showRendered = false)', () => {
+    const tab = new DiffTabStore(makeActiveFile('docs/readme.md'), false);
+    expect(tab.renderer.kind).toBe('text');
+    expect(tab.showRendered).toBe(false);
+  });
+
+  it('setShowRendered toggles the rendered-preview state observably', () => {
+    const tab = new DiffTabStore(makeActiveFile('docs/readme.md'), false);
+    const seen: boolean[] = [];
+    const dispose = reaction(
+      () => tab.showRendered,
+      (value) => seen.push(value)
+    );
+
+    tab.setShowRendered(true);
+    tab.setShowRendered(false);
+    dispose();
+
+    expect(seen).toEqual([true, false]);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/tabs/diff-tab-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/tabs/diff-tab-store.ts
@@ -15,6 +15,12 @@ export class DiffTabStore {
   path: string;
   isPreview: boolean;
   renderer: DiffRendererData;
+  /**
+   * For markdown diff tabs: whether to show the rendered markdown preview
+   * (Eye) instead of the source diff (Pencil). Defaults to the source diff.
+   * Ignored for non-markdown files.
+   */
+  showRendered = false;
   diffGroup: 'disk' | 'staged' | 'git' | 'pr';
   originalRef: GitObjectRef;
   modifiedRef: GitObjectRef | undefined;
@@ -57,8 +63,10 @@ export class DiffTabStore {
       commitOriginalSha: observable,
       commitModifiedSha: observable,
       status: observable,
+      showRendered: observable,
       transition: action,
       pin: action,
+      setShowRendered: action,
     });
   }
 
@@ -85,6 +93,10 @@ export class DiffTabStore {
 
   pin(): void {
     this.isPreview = false;
+  }
+
+  setShowRendered(showRendered: boolean): void {
+    this.showRendered = showRendered;
   }
 }
 

--- a/apps/emdash-desktop/src/renderer/lib/editor/preview-source-toggle.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/editor/preview-source-toggle.tsx
@@ -5,18 +5,25 @@ interface PreviewSourceToggleProps {
   activeMode: 'preview' | 'source';
   onSwitch: (mode: 'preview' | 'source') => void;
   className?: string;
+  /** Accessibility label for the Eye (preview) item. */
+  previewLabel?: string;
+  /** Accessibility label for the Pencil (source) item. */
+  sourceLabel?: string;
 }
 
 const DEFAULT_CLASSNAME = 'absolute right-3 top-3 z-10';
 
 /**
- * Floating Eye/Pencil toggle for switching between a rendered preview and
- * Monaco source view. Used by the HTML renderer pair (preview iframe ↔ Monaco).
+ * Floating Eye/Pencil toggle for switching between a rendered preview and a
+ * Monaco source view. Used by the HTML renderer pair (preview iframe ↔ Monaco)
+ * and the markdown diff renderer (rendered preview ↔ source diff).
  */
 export function PreviewSourceToggle({
   activeMode,
   onSwitch,
   className = DEFAULT_CLASSNAME,
+  previewLabel = 'View rendered',
+  sourceLabel = 'Edit source',
 }: PreviewSourceToggleProps) {
   return (
     <ToggleGroup
@@ -28,10 +35,10 @@ export function PreviewSourceToggle({
       size="sm"
       className={className}
     >
-      <ToggleGroupItem value="preview" aria-label="View rendered">
+      <ToggleGroupItem value="preview" aria-label={previewLabel}>
         <Eye className="h-3.5 w-3.5" />
       </ToggleGroupItem>
-      <ToggleGroupItem value="source" aria-label="Edit source">
+      <ToggleGroupItem value="source" aria-label={sourceLabel}>
         <Pencil className="h-3.5 w-3.5" />
       </ToggleGroupItem>
     </ToggleGroup>


### PR DESCRIPTION
## What
Adds an Eye/Pencil toggle to markdown files opened from the Changes/diff sidebar —
the same toggle (and position) the file editor already uses for markdown — letting
you flip between the source diff and the rendered markdown.

- Pencil (default) → Monaco source diff (unchanged)
- Eye → the modified ("after") content rendered via `MarkdownRenderer`
- Split mode → original rendered (left) ∥ modified rendered (right), reusing the
  diff toolbar's existing unified/split toggle

Deleted markdown files stay diff-only (no "after" content to render).

## Why
The rendered markdown view was only reachable from the file explorer, not when
reviewing changes — so reviewing a `.md` diff meant reading raw source.

## How
- Reuses the shared `PreviewSourceToggle`, `MarkdownRenderer`, and the `ShowHide`
  mount-preservation pattern (keeps Monaco's diff models registered so the preview
  can read their content).
- Extracts a `computeDiffUris()` helper as the single source of truth for the
  original/modified model URIs (shared by the Monaco diff editor and the preview).
- Adds optional `previewLabel`/`sourceLabel` props to `PreviewSourceToggle`
  (defaults preserved).

## Screenshots

**Pencil (default) — source diff:**
<img width="1539" height="984" alt="image" src="https://github.com/user-attachments/assets/4cb71929-73d9-4424-9509-d7aa562266c0" />


**Eye — rendered preview:**
<img width="1539" height="984" alt="image" src="https://github.com/user-attachments/assets/5ebcd86d-8c76-45b9-845b-9af679abb558" />


**Eye + Split — original ∥ modified, rendered:**
<img width="1539" height="984" alt="image" src="https://github.com/user-attachments/assets/ca1390ac-1a72-4373-b8a0-186acde80dd0" />


## Testing
- New unit test for the diff tab's preview-toggle state.
- `pnpm run typecheck`, `lint`, `format:check`, and `test` all pass.
- Manually verified: unified + split, staged and unstaged changes.