### PR TITLE
fix(agents): harden install failures for agents

### DIFF
--- a/apps/emdash-desktop/src/main/core/dependencies/install-runner.test.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/install-runner.test.ts
@@ -3,6 +3,8 @@ import type { LocalSpawnOptions } from '@main/core/pty/local-pty';
 import type { Pty } from '@main/core/pty/pty';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import {
+  INSTALL_COMMAND_OUTPUT_LIMIT,
+  INSTALL_COMMAND_TIMEOUT_MS,
   classifyInstallCommandFailure,
   createLocalInstallCommandRunner,
   createSshInstallCommandRunner,
@@ -44,6 +46,16 @@ function createSuccessfulPty(): Pty {
     kill: vi.fn(),
     onData: vi.fn(),
     onExit: vi.fn((handler) => handler({ exitCode: 0 })),
+  };
+}
+
+function createHangingPty(chunks: string[] = []): Pty {
+  return {
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn((handler) => chunks.forEach((chunk) => handler(chunk))),
+    onExit: vi.fn(),
   };
 }
 
@@ -161,6 +173,27 @@ describe('runLocalInstallCommand', () => {
         command: 'C:\\Program Files\\PowerShell\\7\\pwsh.exe',
       })
     );
+  });
+
+  it('kills hung install PTYs and returns bounded timeout output', async () => {
+    setPlatform('win32');
+    vi.useFakeTimers();
+    const pty = createHangingPty(['a'.repeat(INSTALL_COMMAND_OUTPUT_LIMIT + 100)]);
+    mocks.spawnLocalPty.mockReturnValueOnce(pty);
+
+    const resultPromise = runLocalInstallCommand('npm install -g @openai/codex', pwshProfile);
+    await vi.advanceTimersByTimeAsync(INSTALL_COMMAND_TIMEOUT_MS);
+    const result = await resultPromise;
+
+    expect(pty.kill).toHaveBeenCalledWith();
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      expect(result.error.type).toBe('install-timed-out');
+      if (result.error.type === 'install-timed-out') {
+        expect(result.error.output).toHaveLength(INSTALL_COMMAND_OUTPUT_LIMIT);
+      }
+    }
+    vi.useRealTimers();
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/dependencies/install-runner.test.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/install-runner.test.ts
@@ -87,6 +87,7 @@ beforeEach(() => {
 });
 
 afterEach(() => {
+  vi.useRealTimers();
   process.env = { ...originalEnv };
   if (originalPlatform) {
     Object.defineProperty(process, 'platform', originalPlatform);
@@ -193,7 +194,6 @@ describe('runLocalInstallCommand', () => {
         expect(result.error.output).toHaveLength(INSTALL_COMMAND_OUTPUT_LIMIT);
       }
     }
-    vi.useRealTimers();
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/dependencies/install-runner.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/install-runner.ts
@@ -84,6 +84,7 @@ function waitForInstallPty(pty: Pty): Promise<Result<void, InstallCommandError>>
     }, INSTALL_COMMAND_TIMEOUT_MS);
 
     pty.onData((chunk: string) => {
+      if (settled) return;
       output = appendBoundedOutput(output, chunk);
     });
     pty.onExit(({ exitCode }) => {

--- a/apps/emdash-desktop/src/main/core/dependencies/install-runner.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/install-runner.ts
@@ -18,6 +18,18 @@ export type InstallCommandRunner<TData = void, TError = InstallCommandError> = (
 type ShellProfileResolver = () => Promise<ResolvedShellProfile>;
 
 const ANSI_RE = /\u001b\[[0-?]*[ -/]*[@-~]/g;
+export const INSTALL_COMMAND_TIMEOUT_MS = 5 * 60 * 1000;
+export const INSTALL_COMMAND_OUTPUT_LIMIT = 8_000;
+
+function appendBoundedOutput(output: string, chunk: string): string {
+  const next = output + chunk;
+  if (next.length <= INSTALL_COMMAND_OUTPUT_LIMIT) return next;
+  return next.slice(next.length - INSTALL_COMMAND_OUTPUT_LIMIT);
+}
+
+function cleanInstallOutput(output: string): string {
+  return output.replace(ANSI_RE, '').trim();
+}
 
 export function classifyInstallCommandFailure({
   exitCode,
@@ -26,7 +38,7 @@ export function classifyInstallCommandFailure({
   exitCode: number | undefined;
   output: string;
 }): InstallCommandError {
-  const cleanOutput = output.replace(ANSI_RE, '').trim();
+  const cleanOutput = cleanInstallOutput(output);
   if (/\bEACCES\b|permission denied|not have the permissions/i.test(cleanOutput)) {
     return {
       type: 'permission-denied',
@@ -46,18 +58,47 @@ export function classifyInstallCommandFailure({
 
 function waitForInstallPty(pty: Pty): Promise<Result<void, InstallCommandError>> {
   return new Promise((resolve) => {
-    const chunks: string[] = [];
-    pty.onData((chunk: string) => chunks.push(chunk));
+    let output = '';
+    let settled = false;
+    const timeout = setTimeout(() => {
+      if (settled) return;
+      settled = true;
+      const cleanOutput = cleanInstallOutput(output);
+      log.error(`[DependencyManager] Install timed out`, {
+        timeoutMs: INSTALL_COMMAND_TIMEOUT_MS,
+        output: cleanOutput,
+      });
+      try {
+        pty.kill();
+      } catch (error) {
+        log.warn(`[DependencyManager] Failed to kill timed out install PTY`, { error });
+      }
+      resolve(
+        err({
+          type: 'install-timed-out',
+          message: 'Install command timed out.',
+          output: cleanOutput,
+          timeoutMs: INSTALL_COMMAND_TIMEOUT_MS,
+        })
+      );
+    }, INSTALL_COMMAND_TIMEOUT_MS);
+
+    pty.onData((chunk: string) => {
+      output = appendBoundedOutput(output, chunk);
+    });
     pty.onExit(({ exitCode }) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timeout);
       if (exitCode === 0) {
         log.info(`[DependencyManager] Install succeeded`);
         resolve(ok());
         return;
       }
 
-      const output = chunks.join('').trim();
-      log.error(`[DependencyManager] Install failed`, { exitCode, output });
-      resolve(err(classifyInstallCommandFailure({ exitCode, output })));
+      const cleanOutput = cleanInstallOutput(output);
+      log.error(`[DependencyManager] Install failed`, { exitCode, output: cleanOutput });
+      resolve(err(classifyInstallCommandFailure({ exitCode, output: cleanOutput })));
     });
   });
 }

--- a/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-install.ts
+++ b/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-install.ts
@@ -15,6 +15,8 @@ export function getAgentInstallErrorMessage(error: DependencyInstallError): stri
       return error.message;
     case 'command-failed':
       return error.output ? `${error.message} ${error.output}` : error.message;
+    case 'install-timed-out':
+      return error.output ? `${error.message} ${error.output}` : error.message;
     case 'pty-open-failed':
       return error.message;
     case 'unknown-dependency':

--- a/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-install.ts
+++ b/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-install.ts
@@ -16,7 +16,7 @@ export function getAgentInstallErrorMessage(error: DependencyInstallError): stri
     case 'command-failed':
       return error.output ? `${error.message} ${error.output}` : error.message;
     case 'install-timed-out':
-      return error.output ? `${error.message} ${error.output}` : error.message;
+      return error.message;
     case 'pty-open-failed':
       return error.message;
     case 'unknown-dependency':

--- a/apps/emdash-desktop/src/renderer/lib/components/agent-selector/use-agent-availability.ts
+++ b/apps/emdash-desktop/src/renderer/lib/components/agent-selector/use-agent-availability.ts
@@ -44,17 +44,26 @@ export function useAgentAvailability({
 
   async function installAgent(agentId: AgentProviderId): Promise<void> {
     if (appState.dependencies.isInstalling(agentId, connectionId)) return;
-    const result = await appState.dependencies.install(agentId, connectionId);
-    if (!result.success) {
+    try {
+      const result = await appState.dependencies.install(agentId, connectionId);
+      if (!result.success) {
+        toast({
+          title: 'Install failed',
+          description: getAgentInstallErrorMessage(result.error),
+          variant: 'destructive',
+        });
+        return;
+      }
+
+      toast({ title: 'Agent installed', description: `${agentConfig[agentId].name} is ready.` });
+    } catch (error) {
+      const description = error instanceof Error ? error.message : 'The install request failed.';
       toast({
         title: 'Install failed',
-        description: getAgentInstallErrorMessage(result.error),
+        description,
         variant: 'destructive',
       });
-      return;
     }
-
-    toast({ title: 'Agent installed', description: `${agentConfig[agentId].name} is ready.` });
   }
 
   return {

--- a/apps/emdash-desktop/src/shared/core/dependencies.ts
+++ b/apps/emdash-desktop/src/shared/core/dependencies.ts
@@ -30,6 +30,7 @@ export type DependencyStatusUpdatedEvent = {
 export type InstallCommandError =
   | { type: 'permission-denied'; message: string; output: string; exitCode?: number }
   | { type: 'command-failed'; message: string; output: string; exitCode?: number }
+  | { type: 'install-timed-out'; message: string; output: string; timeoutMs: number }
   | { type: 'pty-open-failed'; message: string };
 
 export type DependencyInstallError =


### PR DESCRIPTION
### Description
- added timeout handling for agent installs ptys and terminate hung installs
- limit capture install output 
- error toast

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
