### PR TITLE
fix(browser): clear stale favicon on navigation

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
@@ -94,6 +94,7 @@ export const BrowserPane = observer(function BrowserPane({ browserId }: { browse
       pendingUrlRef.current = url;
       browserSessionStore.updateSession(sessionBrowserId, {
         currentUrl: url,
+        faviconUrl: null,
         isLoading: true,
         loadError: null,
       });

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-session-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-session-store.test.ts
@@ -41,6 +41,21 @@ describe('BrowserSessionStore', () => {
     });
   });
 
+  it('clears favicon state explicitly', () => {
+    const store = new BrowserSessionStore();
+    store.createSession({
+      browserId: 'browser-1',
+      projectId: 'project-1',
+      workspaceId: 'workspace-1',
+      taskId: 'task-1',
+    });
+
+    store.updateSession('browser-1', { faviconUrl: 'https://example.com/favicon.ico' });
+    store.updateSession('browser-1', { faviconUrl: null });
+
+    expect(store.getSession('browser-1')?.faviconUrl).toBeUndefined();
+  });
+
   it('restores sessions with a derived partition and clears transient load state', () => {
     const store = new BrowserSessionStore();
 

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-session-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-session-store.ts
@@ -18,9 +18,10 @@ export type BrowserSessionCreateInput = {
 };
 
 export type BrowserSessionUpdate = Partial<
-  Pick<BrowserSessionSnapshot, 'canGoBack' | 'canGoForward' | 'faviconUrl' | 'isLoading' | 'title'>
+  Pick<BrowserSessionSnapshot, 'canGoBack' | 'canGoForward' | 'isLoading' | 'title'>
 > & {
   currentUrl?: string;
+  faviconUrl?: string | null;
   loadError?: BrowserLoadError | null;
 };
 
@@ -82,6 +83,8 @@ export class BrowserSessionStore {
           : normalized.ok
             ? normalized.url
             : existing.currentUrl,
+      faviconUrl:
+        update.faviconUrl === null ? undefined : (update.faviconUrl ?? existing.faviconUrl),
       loadError: update.loadError === null ? undefined : (update.loadError ?? existing.loadError),
       updatedAt: Date.now(),
     };

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-webview-events.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-webview-events.test.ts
@@ -113,6 +113,9 @@ describe('bindBrowserWebviewEvents', () => {
       faviconUrl: 'https://example.com/favicon.ico',
     });
 
+    webview.emit('did-start-loading');
+    expect(browserSessionStore.getSession(session.browserId)?.faviconUrl).toBeUndefined();
+
     webview.emit('did-fail-load', {
       errorCode: -105,
       errorDescription: 'Name not resolved',

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-webview-events.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-webview-events.ts
@@ -51,6 +51,7 @@ export function bindBrowserWebviewEvents(
 
   const onStartLoading = () => {
     browserSessionStore.updateSession(browserId, {
+      faviconUrl: null,
       isLoading: true,
       loadError: null,
     });


### PR DESCRIPTION
## Summary
- Clear the browser session favicon immediately when a submitted URL starts loading.
- Clear the favicon on webview load start so link-driven navigations do not show the previous site icon.
- Add focused tests for explicit favicon clearing and load-start behavior.

## Verification
- pnpm --filter @emdash/emdash-desktop exec vitest run src/renderer/features/browser/browser-session-store.test.ts src/renderer/features/browser/browser-webview-events.test.ts --project node
- pnpm --filter @emdash/emdash-desktop run typecheck
- pnpm --filter @emdash/emdash-desktop run format