### PR TITLE
docs(readme): point installer links to GitHub Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,9 +40,9 @@ already use: Claude Code, Codex, OpenCode, Gemini, Amp, and more.
 
 | Platform | Install |
 | --- | --- |
-| macOS | `brew install --cask emdash` · [Apple Silicon](https://releases.emdash.sh/emdash-arm64.dmg) · [Intel](https://releases.emdash.sh/emdash-x64.dmg) |
-| Windows | [Installer](https://releases.emdash.sh/emdash-x64.msi) · [Portable](https://releases.emdash.sh/emdash-x64.exe) |
-| Linux | [AppImage](https://releases.emdash.sh/emdash-x86_64.AppImage) · [Debian package](https://releases.emdash.sh/emdash-amd64.deb) |
+| macOS | `brew install --cask emdash` · [Apple Silicon](https://github.com/generalaction/emdash/releases/latest/download/emdash-arm64.dmg) · [Intel](https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.dmg) |
+| Windows | [Installer](https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.msi) · [Portable](https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.exe) |
+| Linux | [AppImage](https://github.com/generalaction/emdash/releases/latest/download/emdash-x86_64.AppImage) · [Debian package](https://github.com/generalaction/emdash/releases/latest/download/emdash-amd64.deb) |
 
 See the [latest release](https://github.com/generalaction/emdash/releases/latest) for
 all desktop builds.


### PR DESCRIPTION
## Summary

Updates the README installer links to use GitHub Releases asset URLs instead of the R2 mirror.

We are already moving manual downloads back to GitHub Releases with this change, and the next step is switching production release asset hosting/publishing back to GitHub Releases while keeping the R2 update path available for existing users.

## Notes

- Keeps the existing latest release page link unchanged.
- Does not change updater behavior or release workflows.
- Helps README/manual downloads count toward GitHub Release download totals.

### Description

Give a short summary of what changed, why it's needed, and any important implementation notes.

### Related issues

Link related issues. If this PR fixes an issue, mention it like: Fixes #123.

### Testing

List the checks you ran, for example `pnpm run format`, `pnpm run lint`,
`pnpm run typecheck`, `pnpm run test`, and any manual testing.

### Screenshot/Recording (if applicable)

Attach a screenshot, GIF, or recording of the change. This is optional, but helps reviewers
understand UI or workflow changes.

<details>
<summary>Checklist</summary>

- [ ] I kept this PR small and focused
- [ ] I ran a self-review before opening this PR
- [ ] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [ ] I added or updated tests when behavior changed, or explained why not
- [ ] I only added comments where the logic is not obvious
- [ ] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
