### PR TITLE
fix(browser): polish navigation state

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
@@ -184,6 +184,7 @@ export const BrowserPane = observer(function BrowserPane({ browserId }: { browse
       <BrowserToolbar
         session={session}
         adapter={adapter}
+        autoFocusUrl={showStartPage}
         onNavigate={navigateTo}
         onReload={reload}
         onFocusUrl={(focus) => {

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.tsx
@@ -22,12 +22,14 @@ import type { BrowserWebviewAdapter } from './browser-webview-types';
 export function BrowserToolbar({
   session,
   adapter,
+  autoFocusUrl,
   onNavigate,
   onReload,
   onFocusUrl,
 }: {
   session: BrowserSessionSnapshot;
   adapter: BrowserWebviewAdapter | null;
+  autoFocusUrl?: boolean;
   onNavigate?: (url: string) => boolean;
   onReload?: () => void;
   onFocusUrl?: (focus: () => void) => void;
@@ -53,6 +55,15 @@ export function BrowserToolbar({
       urlInputRef.current?.select();
     });
   }, [onFocusUrl]);
+
+  useEffect(() => {
+    if (!autoFocusUrl) return;
+    const timer = window.setTimeout(() => {
+      urlInputRef.current?.focus();
+      urlInputRef.current?.select();
+    }, 0);
+    return () => window.clearTimeout(timer);
+  }, [autoFocusUrl]);
 
   const navigate = () => {
     navigateTo(urlText);


### PR DESCRIPTION
## Summary
- Clear stale favicon state when a submitted URL or webview navigation starts loading.
- Focus and select the URL input when opening a blank in-app browser tab, including via the browser shortcut.
- Add focused coverage for favicon clearing behavior.

## Verification
- pnpm --filter @emdash/emdash-desktop exec vitest run src/renderer/features/browser/browser-session-store.test.ts src/renderer/features/browser/browser-webview-events.test.ts --project node
- pnpm --filter @emdash/emdash-desktop run typecheck
- pnpm --filter @emdash/emdash-desktop run format