### PR TITLE
fix(automations): prevent search border clipping

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/automations/components/AutomationsView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/AutomationsView.tsx
@@ -62,8 +62,8 @@ export function AutomationsView() {
 
   return (
     <div className="mt-6 h-full overflow-hidden bg-background text-foreground">
-      <div className="mx-auto grid h-full min-h-0 w-full max-w-4xl grid-cols-1 gap-8 px-8">
-        <div className="relative min-h-0 w-full min-w-0 overflow-y-auto">
+      <div className="mx-auto grid h-full min-h-0 w-full max-w-4xl grid-cols-1 gap-8">
+        <div className="relative min-h-0 w-full min-w-0 overflow-y-auto px-8">
           <div className="w-full py-8">
             <AutomationsHeader
               search={search}


### PR DESCRIPTION
### Description
fix search border clipping on automations page

### Screenshot/Recording (if applicable)
<img width="973" height="618" alt="image" src="https://github.com/user-attachments/assets/561629ee-0661-4387-accb-1bd05aa98fe1" />

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
