### PR TITLE
fix(git): register repository workspace in git watcher for index invalidation

### DIFF
--- a/apps/emdash-desktop/src/main/core/git/git-watcher-registry.ts
+++ b/apps/emdash-desktop/src/main/core/git/git-watcher-registry.ts
@@ -69,6 +69,14 @@ class GitWatcherRegistry implements Hookable<GitWatcherHooks>, IInitializable, I
     }
   }
 
+  /**
+   * Register a workspace for index/HEAD change detection.
+   * Called when the repository workspace is created or discovered.
+   */
+  registerWorkspace(projectId: string, workspaceId: string, relGitDir: string): void {
+    this._worktrees.get(projectId)?.set(workspaceId, relGitDir);
+  }
+
   private async _startWatching(projectId: string, repoPath: string): Promise<void> {
     const gitDir = path.join(repoPath, '.git');
     this._worktrees.set(projectId, new Map());

--- a/apps/emdash-desktop/src/main/core/projects/operations/ensure-repository-workspace.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/ensure-repository-workspace.ts
@@ -1,5 +1,6 @@
 import { randomUUID } from 'node:crypto';
 import { eq } from 'drizzle-orm';
+import { gitWatcherRegistry } from '@main/core/git/git-watcher-registry';
 import { computeWorkspaceKey } from '@main/core/workspaces/workspace-key';
 import { db } from '@main/db/client';
 import { projects, workspaces } from '@main/db/schema';
@@ -25,7 +26,10 @@ export function ensureRepositoryWorkspace(project: LocalProject | SshProject): s
     .limit(1)
     .all();
 
-  if (row?.repositoryWorkspaceId) return row.repositoryWorkspaceId;
+  if (row?.repositoryWorkspaceId) {
+    gitWatcherRegistry.registerWorkspace(project.id, row.repositoryWorkspaceId, '');
+    return row.repositoryWorkspaceId;
+  }
 
   const workspaceId = randomUUID();
   const location = project.type === 'ssh' ? 'remote' : 'local';
@@ -79,6 +83,8 @@ export function ensureRepositoryWorkspace(project: LocalProject | SshProject): s
       workspaceId: resolvedId,
       reusedExisting: !!existingWs,
     });
+
+    gitWatcherRegistry.registerWorkspace(project.id, resolvedId, '');
 
     return resolvedId;
   });


### PR DESCRIPTION
## Summary

Fixes #2439 — diff view showing incorrect content for staged and unstaged changes.

`GitWatcherRegistry` watches `.git/index` for changes and emits invalidation events by matching against its `_worktrees` map. The repository workspace (project-root) was never added to this map — only task worktrees with an explicit `worktreeGitDir` were registered. This meant `.git/index` changes never triggered Monaco model invalidation for the repository workspace, leaving STAGED/HEAD models with stale (empty) content.

**Fix:** Add a `registerWorkspace()` method to `GitWatcherRegistry` and call it from `ensureRepositoryWorkspace` (which runs on every project open) to register the repository workspace with an empty `relGitDir`.

## Test plan

- [x] `pnpm run typecheck` passes
- [x] `pnpm run lint` passes
- [x] Visually verified: unstaged diff now shows only index→working tree delta (not all changes)
- [x] Visually verified: staged diff now shows HEAD→index content (not empty)
- [x] Verified live invalidation works when index changes while diff tab is open
