### PR TITLE
fix(tasks): stop spinner after provisioning error

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
@@ -46,11 +46,6 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
   const task = getTaskStore(projectId, taskId)!;
   const taskManager = getTaskManagerStore(projectId);
 
-  const isBootstrapping =
-    task.state === 'unregistered' ||
-    (task.state === 'unprovisioned' &&
-      (task.phase === 'provision' || task.phase === 'provision-error'));
-
   const taskName = task.data.name;
 
   const handleProvision = () => {
@@ -121,7 +116,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
           <span
             className={cn(
               'min-w-0 truncate text-left transition-colors',
-              isBootstrapping && 'text-foreground/40'
+              task.isBootstrapping && 'text-foreground/40'
             )}
           >
             {taskName}

--- a/apps/emdash-desktop/src/renderer/features/sidebar/task-sidebar-agent-status.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/task-sidebar-agent-status.tsx
@@ -2,11 +2,7 @@ import { observer } from 'mobx-react-lite';
 import { AgentStatusIndicator } from '@renderer/features/tasks/components/agent-status-indicator';
 import { CLISpinner } from '@renderer/features/tasks/components/cliSpinner';
 import { taskAgentStatus } from '@renderer/features/tasks/stores/task-selectors';
-import {
-  isUnprovisioned,
-  isUnregistered,
-  type TaskStore,
-} from '@renderer/features/tasks/stores/task-store';
+import { type TaskStore } from '@renderer/features/tasks/stores/task-store';
 import { useDelayedBoolean } from '@renderer/lib/hooks/use-delay-boolean';
 import { sidebarStore } from '@renderer/lib/stores/app-state';
 import { RelativeTime } from '@renderer/lib/ui/relative-time';
@@ -31,10 +27,7 @@ export const TaskSidebarTrailingSlot = observer(function TaskSidebarTrailingSlot
   task: TaskStore;
   showTimestamp: boolean;
 }) {
-  const isBootstrapping =
-    isUnregistered(task) ||
-    (isUnprovisioned(task) && (task.phase === 'provision' || task.phase === 'provision-error'));
-  const delayedIsBootstrapping = useDelayedBoolean(isBootstrapping, 500);
+  const delayedIsBootstrapping = useDelayedBoolean(task.isBootstrapping, 500);
 
   if (delayedIsBootstrapping) {
     return (

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
@@ -57,11 +57,11 @@ export class TaskStore {
     return this.data.name;
   }
 
+  /** True only while creation/provisioning is actively running — error phases are settled, not busy. */
   get isBootstrapping(): boolean {
     return (
-      this.state === 'unregistered' ||
-      (this.state === 'unprovisioned' &&
-        (this.phase === 'provision' || this.phase === 'provision-error'))
+      (this.state === 'unregistered' && this.phase === 'creating') ||
+      (this.state === 'unprovisioned' && this.phase === 'provision')
     );
   }
 


### PR DESCRIPTION
### Description
- stop activity indicator when workspace creation fails

### Screenshot/Recording (if applicable)
https://streamable.com/9kizfv

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
