### PR TITLE
fix(diff-view): avoid hidden changes panel layout

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
@@ -14,6 +14,10 @@ export const ChangesPanel = observer(function ChangesPanel() {
   const diffView = taskView.diffView;
   const changesView = diffView?.changesView;
 
+  // Must match the ShowHide conditions in TaskSidebar — the panel stays mounted
+  // under display: none whenever this is false.
+  const isPanelVisible = !taskView.isSidebarCollapsed && taskView.sidebarTab === 'changes';
+
   const {
     expanded,
     toggleExpanded,
@@ -23,12 +27,13 @@ export const ChangesPanel = observer(function ChangesPanel() {
     stagedRef,
     prRef,
     spacerRef,
-  } = usePanelLayout(changesView ?? null);
+    containerRef,
+  } = usePanelLayout(changesView ?? null, isPanelVisible);
 
   if (!diffView || !changesView || !workspace.git.hasData) return null;
 
   return (
-    <div className="flex h-full flex-col">
+    <div ref={containerRef} className="flex h-full flex-col">
       <ResizablePanelGroup
         orientation="vertical"
         className="min-h-0 flex-1"

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
@@ -14,10 +14,6 @@ export const ChangesPanel = observer(function ChangesPanel() {
   const diffView = taskView.diffView;
   const changesView = diffView?.changesView;
 
-  // Must match the ShowHide conditions in TaskSidebar — the panel stays mounted
-  // under display: none whenever this is false.
-  const isPanelVisible = !taskView.isSidebarCollapsed && taskView.sidebarTab === 'changes';
-
   const {
     expanded,
     toggleExpanded,
@@ -28,7 +24,7 @@ export const ChangesPanel = observer(function ChangesPanel() {
     prRef,
     spacerRef,
     containerRef,
-  } = usePanelLayout(changesView ?? null, isPanelVisible);
+  } = usePanelLayout(changesView ?? null, taskView.isChangesPanelVisible);
 
   if (!diffView || !changesView || !workspace.git.hasData) return null;
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
@@ -63,6 +63,9 @@ export function usePanelLayout(
     // cannot replace the flag here: Chromium delivers no resize event when an ancestor toggles
     // display:none. The offsetHeight check covers hide paths the flag does not know about, and
     // skipping already-applied states keeps user drag-resizes intact across hide/show.
+    // Reference equality is intentional: ChangesViewStore replaces the whole expandedSections
+    // object on every mutation, so a stable reference means "nothing changed". Returning fresh
+    // object literals per render here would re-apply the layout on every reveal and reset drags.
     if (!isVisible || appliedExpanded.current === expanded) return;
     if ((containerRef.current?.offsetHeight ?? 0) === 0) return;
     appliedExpanded.current = expanded;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
@@ -56,16 +56,6 @@ export function usePanelLayout(
   const appliedExpanded = useRef<ExpandedSections | null>(null);
 
   useLayoutEffect(() => {
-    // The panel stays mounted under `display: none` while the sidebar is hidden, and imperative
-    // resize/collapse calls against a zero-size group make react-resizable-panels compute NaN
-    // percentages that survive reopening (ENG-1559). Only apply the layout while visible; a state
-    // change that arrives while hidden is applied when isVisible flips back. A ResizeObserver
-    // cannot replace the flag here: Chromium delivers no resize event when an ancestor toggles
-    // display:none. The offsetHeight check covers hide paths the flag does not know about, and
-    // skipping already-applied states keeps user drag-resizes intact across hide/show.
-    // Reference equality is intentional: ChangesViewStore replaces the whole expandedSections
-    // object on every mutation, so a stable reference means "nothing changed". Returning fresh
-    // object literals per render here would re-apply the layout on every reveal and reset drags.
     if (!isVisible || appliedExpanded.current === expanded) return;
     if ((containerRef.current?.offsetHeight ?? 0) === 0) return;
     appliedExpanded.current = expanded;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
@@ -1,4 +1,4 @@
-import { useLayoutEffect, useState } from 'react';
+import { useLayoutEffect, useRef, useState } from 'react';
 import { usePanelRef } from 'react-resizable-panels';
 import type {
   ChangesViewStore,
@@ -26,9 +26,13 @@ type usePanelLayoutReturn = {
   stagedRef: ReturnType<typeof usePanelRef>;
   prRef: ReturnType<typeof usePanelRef>;
   spacerRef: ReturnType<typeof usePanelRef>;
+  containerRef: React.RefObject<HTMLDivElement | null>;
 };
 
-export function usePanelLayout(changesView: ChangesViewStore | null): usePanelLayoutReturn {
+export function usePanelLayout(
+  changesView: ChangesViewStore | null,
+  isVisible: boolean
+): usePanelLayoutReturn {
   const unstagedRef = usePanelRef();
   const stagedRef = usePanelRef();
   const prRef = usePanelRef();
@@ -48,7 +52,21 @@ export function usePanelLayout(changesView: ChangesViewStore | null): usePanelLa
 
   const expanded = changesView?.expandedSections ?? DEFAULT_EXPANDED;
 
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const appliedExpanded = useRef<ExpandedSections | null>(null);
+
   useLayoutEffect(() => {
+    // The panel stays mounted under `display: none` while the sidebar is hidden, and imperative
+    // resize/collapse calls against a zero-size group make react-resizable-panels compute NaN
+    // percentages that survive reopening (ENG-1559). Only apply the layout while visible; a state
+    // change that arrives while hidden is applied when isVisible flips back. A ResizeObserver
+    // cannot replace the flag here: Chromium delivers no resize event when an ancestor toggles
+    // display:none. The offsetHeight check covers hide paths the flag does not know about, and
+    // skipping already-applied states keeps user drag-resizes intact across hide/show.
+    if (!isVisible || appliedExpanded.current === expanded) return;
+    if ((containerRef.current?.offsetHeight ?? 0) === 0) return;
+    appliedExpanded.current = expanded;
+
     const sections = [
       { key: 'unstaged' as const, ref: unstagedRef },
       { key: 'staged' as const, ref: stagedRef },
@@ -67,7 +85,7 @@ export function usePanelLayout(changesView: ChangesViewStore | null): usePanelLa
         ref.current?.collapse();
       }
     });
-  }, [expanded, unstagedRef, stagedRef, prRef, spacerRef]);
+  }, [expanded, isVisible, unstagedRef, stagedRef, prRef, spacerRef]);
 
   return {
     expanded,
@@ -79,5 +97,6 @@ export function usePanelLayout(changesView: ChangesViewStore | null): usePanelLa
     stagedRef,
     prRef,
     spacerRef,
+    containerRef,
   };
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -418,6 +418,13 @@ export class WorkspaceViewModel implements ILifecycle {
     this.isSidebarCollapsed = collapsed;
   }
 
+  // Single source of truth for whether the changes panel is actually visible. TaskSidebar
+  // hides it via ShowHide (display: none) based on this, and usePanelLayout must defer
+  // imperative panel resizes to exactly the same condition (ENG-1559).
+  get isChangesPanelVisible(): boolean {
+    return !this.isSidebarCollapsed && this.sidebarTab === 'changes';
+  }
+
   setFocusedRegion(region: 'main' | 'bottom'): void {
     if (this.focusedRegion !== region) {
       focusTracker.transition({ focusedRegion: region }, 'region_switch');

--- a/apps/emdash-desktop/src/renderer/features/tasks/view/task-sidebar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/view/task-sidebar.tsx
@@ -17,7 +17,7 @@ export const TaskSidebar = observer(function TaskSidebar() {
       <ShowHide visible={activeTab === 'conversations'}>
         <SidebarConversationsList />
       </ShowHide>
-      <ShowHide visible={!isSidebarCollapsed && activeTab === 'changes'} lazy>
+      <ShowHide visible={taskView.isChangesPanelVisible} lazy>
         <ChangesPanel />
       </ShowHide>
       <ShowHide visible={activeTab === 'files'}>


### PR DESCRIPTION
### Description
- fix changed files list showing empty 
- section layout is now applied when panel becomes visible, hidden state chnages are applied on reveal

### Screenshot/Recording (if applicable)
https://streamable.com/zc7yv3

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
