### PR TITLE
refactor(git): extract shared git runtime package

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -51,6 +51,7 @@
     "docs:build": "cd docs && pnpm run build"
   },
   "dependencies": {
+    "@emdash/shared": "workspace:*",
     "@gitbeaker/rest": "^43.8.0",
     "@linear/sdk": "^77.0.0",
     "@llamaduck/forgejo-ts": "^14.0.3",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,48 @@
+{
+  "name": "@emdash/shared",
+  "version": "1.0.0",
+  "description": "Transport-agnostic shared runtime primitives for Emdash",
+  "license": "Apache-2.0",
+  "author": {
+    "name": "Emdash Contributors",
+    "email": "support@emdash.sh"
+  },
+  "files": [
+    "src"
+  ],
+  "type": "module",
+  "exports": {
+    "./exec": {
+      "types": "./src/exec/index.ts",
+      "import": "./src/exec/index.ts"
+    },
+    "./fs": {
+      "types": "./src/fs/index.ts",
+      "import": "./src/fs/index.ts"
+    },
+    "./git": {
+      "types": "./src/git/index.ts",
+      "import": "./src/git/index.ts"
+    },
+    "./lib": {
+      "types": "./src/lib/index.ts",
+      "import": "./src/lib/index.ts"
+    },
+    "./package.json": "./package.json"
+  },
+  "scripts": {
+    "test": "vitest run",
+    "lint": "sh -c 'root=$(cd ../.. && pwd); cd \"$root/apps/emdash-desktop\" && pnpm exec oxlint --config .oxlintrc.json \"$root/packages/shared\"'",
+    "format": "oxfmt",
+    "format:check": "oxfmt --check",
+    "typecheck": "tsgo --noEmit -p tsconfig.json"
+  },
+  "dependencies": {
+    "@parcel/watcher": "^2.5.6"
+  },
+  "devDependencies": {
+    "@types/node": "^20.19.42",
+    "@typescript/native-preview": "7.0.0-dev.20260609.1",
+    "vitest": "^4.1.0"
+  }
+}

--- a/packages/shared/src/exec/bound-exec.test.ts
+++ b/packages/shared/src/exec/bound-exec.test.ts
@@ -1,0 +1,109 @@
+import { chmod, mkdtemp, readFile, realpath, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { createBoundExec, ExecError } from './index';
+
+describe('BoundExec', () => {
+  it('runs a configured executable from a fixed cwd', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'emdash-shared-exec-'));
+    const result = await createBoundExec({ file: process.execPath, cwd }).exec([
+      '-e',
+      'console.log(process.cwd())',
+    ]);
+
+    await expect(realpath(result.stdout.trim())).resolves.toBe(await realpath(cwd));
+    expect(result.stderr).toBe('');
+  });
+
+  it('streams stdout and lets the consumer stop early', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'emdash-shared-exec-stream-'));
+    const chunks: string[] = [];
+
+    await createBoundExec({ file: process.execPath, cwd }).execStreaming(
+      ['-e', "console.log('one'); console.log('two');"],
+      (chunk) => {
+        chunks.push(chunk);
+        return false;
+      }
+    );
+
+    expect(chunks.join('')).toContain('one');
+  });
+
+  it('throws ExecError with serializable process details on non-zero exit', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'emdash-shared-exec-error-'));
+    await expect(
+      createBoundExec({ file: 'git', cwd }).exec(['rev-parse', '--not-a-real-flag'])
+    ).rejects.toMatchObject({
+      exitCode: 128,
+      file: 'git',
+      args: ['rev-parse', '--not-a-real-flag'],
+    });
+  });
+
+  it('uses the configured executable path', async () => {
+    const dir = await mkdtemp(path.join(tmpdir(), 'emdash-shared-exec-bin-'));
+    const executable = path.join(dir, 'tool.sh');
+    const logPath = path.join(dir, 'calls.log');
+    await writeFile(
+      executable,
+      ['#!/bin/sh', `printf '%s\\n' "$1" >> ${JSON.stringify(logPath)}`, 'exit 7', ''].join('\n'),
+      'utf8'
+    );
+    await chmod(executable, 0o755);
+
+    await expect(
+      createBoundExec({ file: executable, cwd: dir }).exec(['hello'])
+    ).rejects.toBeInstanceOf(ExecError);
+    await expect(readFile(logPath, 'utf8')).resolves.toBe('hello\n');
+  });
+
+  it('rejects timed-out processes with an ExecError', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'emdash-shared-exec-timeout-'));
+
+    await expect(
+      createBoundExec({ file: process.execPath, cwd }).exec(
+        ['-e', 'setTimeout(() => {}, 10_000);'],
+        { timeoutMs: 50 }
+      )
+    ).rejects.toMatchObject({
+      file: process.execPath,
+      args: ['-e', 'setTimeout(() => {}, 10_000);'],
+      stderr: 'Timed out after 50ms',
+    });
+  });
+
+  it('escalates timed-out processes that ignore SIGTERM', async () => {
+    const cwd = await mkdtemp(path.join(tmpdir(), 'emdash-shared-exec-timeout-kill-'));
+    const pidPath = path.join(cwd, 'child.pid');
+
+    await expect(
+      createBoundExec({ file: process.execPath, cwd }).exec(
+        [
+          '-e',
+          [
+            "const fs = require('node:fs');",
+            `fs.writeFileSync(${JSON.stringify(pidPath)}, String(process.pid));`,
+            "process.on('SIGTERM', () => {});",
+            'setInterval(() => {}, 10_000);',
+          ].join(' '),
+        ],
+        { timeoutMs: 250 }
+      )
+    ).rejects.toBeInstanceOf(ExecError);
+
+    const pid = Number.parseInt(await readFile(pidPath, 'utf8'), 10);
+    await new Promise((resolve) => setTimeout(resolve, 1_500));
+    expect(isProcessAlive(pid)).toBe(false);
+  });
+});
+
+function isProcessAlive(pid: number): boolean {
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/shared/src/exec/bound-exec.ts
+++ b/packages/shared/src/exec/bound-exec.ts
@@ -27,11 +27,15 @@ type StdoutSink =
   | { kind: 'stream'; onStdout: (chunk: string) => boolean | void };
 
 class ProcessBoundExec implements BoundExec {
-  constructor(
-    readonly file: string,
-    readonly cwd: string,
-    readonly env?: NodeJS.ProcessEnv
-  ) {}
+  readonly file: string;
+  readonly cwd: string;
+  readonly env?: NodeJS.ProcessEnv;
+
+  constructor(file: string, cwd: string, env?: NodeJS.ProcessEnv) {
+    this.file = file;
+    this.cwd = cwd;
+    this.env = env;
+  }
 
   async exec(args: string[], options: ExecOptions = {}): Promise<ExecResult> {
     const chunks: string[] = [];

--- a/packages/shared/src/exec/bound-exec.ts
+++ b/packages/shared/src/exec/bound-exec.ts
@@ -1,0 +1,185 @@
+import { spawn } from 'node:child_process';
+import type { SpawnOptionsWithoutStdio } from 'node:child_process';
+import {
+  ExecError,
+  type BoundExec,
+  type ExecBufferResult,
+  type ExecOptions,
+  type ExecResult,
+} from './types';
+
+const DEFAULT_MAX_BUFFER = 10 * 1024 * 1024;
+const TIMEOUT_KILL_GRACE_MS = 1_000;
+
+export type CreateBoundExecOptions = {
+  file: string;
+  cwd: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+export function createBoundExec(options: CreateBoundExecOptions): BoundExec {
+  return new ProcessBoundExec(options.file, options.cwd, options.env);
+}
+
+type StdoutSink =
+  | { kind: 'text'; chunks: string[] }
+  | { kind: 'buffer'; chunks: Buffer[] }
+  | { kind: 'stream'; onStdout: (chunk: string) => boolean | void };
+
+class ProcessBoundExec implements BoundExec {
+  constructor(
+    readonly file: string,
+    readonly cwd: string,
+    readonly env?: NodeJS.ProcessEnv
+  ) {}
+
+  async exec(args: string[], options: ExecOptions = {}): Promise<ExecResult> {
+    const chunks: string[] = [];
+    const { stderr } = await this.run(args, options, { kind: 'text', chunks });
+    return { stdout: chunks.join(''), stderr };
+  }
+
+  async execStreaming(
+    args: string[],
+    onStdout: (chunk: string) => boolean | void,
+    options: ExecOptions = {}
+  ): Promise<void> {
+    await this.run(args, options, { kind: 'stream', onStdout });
+  }
+
+  async execBuffer(args: string[], options: ExecOptions = {}): Promise<ExecBufferResult> {
+    const chunks: Buffer[] = [];
+    const { stderr } = await this.run(args, options, { kind: 'buffer', chunks });
+    return { stdout: Buffer.concat(chunks), stderr };
+  }
+
+  withCwd(cwd: string): BoundExec {
+    return new ProcessBoundExec(this.file, cwd, this.env);
+  }
+
+  private run(args: string[], options: ExecOptions, sink: StdoutSink): Promise<{ stderr: string }> {
+    return new Promise((resolve, reject) => {
+      const spawnOptions: SpawnOptionsWithoutStdio = {
+        cwd: options.cwd ?? this.cwd,
+        env: composeEnv(this.env, options.env),
+        signal: options.signal,
+      };
+      const child = spawn(this.file, args, spawnOptions);
+      const maxBuffer = options.maxBuffer ?? DEFAULT_MAX_BUFFER;
+      let stderr = '';
+      let stdoutBytes = 0;
+      let stderrBytes = 0;
+      let settled = false;
+      let stopped = false;
+
+      const stdoutText = (): string => {
+        if (sink.kind === 'text') return sink.chunks.join('');
+        if (sink.kind === 'buffer') return Buffer.concat(sink.chunks).toString('utf8');
+        return '';
+      };
+      const fail = (error: unknown): void => {
+        if (settled) return;
+        settled = true;
+        reject(error);
+      };
+      const failExec = (exitCode: number | null, stderrOverride?: string): void => {
+        fail(new ExecError(this.file, args, exitCode, stdoutText(), stderrOverride ?? stderr));
+      };
+
+      const timeout = createTimeout(child, options, () => {
+        failExec(null, `Timed out after ${options.timeoutMs}ms`);
+      });
+
+      if (sink.kind !== 'buffer') child.stdout?.setEncoding('utf8');
+      child.stderr?.setEncoding('utf8');
+
+      child.stdout?.on('data', (chunk: string | Buffer) => {
+        if (sink.kind === 'stream') {
+          const shouldContinue = sink.onStdout(chunk as string);
+          if (shouldContinue === false && !stopped) {
+            stopped = true;
+            child.kill();
+          }
+          return;
+        }
+        stdoutBytes += sink.kind === 'buffer' ? (chunk as Buffer).length : Buffer.byteLength(chunk);
+        if (stdoutBytes > maxBuffer) {
+          child.kill();
+          failExec(null, 'stdout exceeded maxBuffer');
+          return;
+        }
+        if (sink.kind === 'buffer') sink.chunks.push(chunk as Buffer);
+        else sink.chunks.push(chunk as string);
+      });
+
+      child.stderr?.on('data', (chunk: string) => {
+        stderrBytes += Buffer.byteLength(chunk);
+        if (stderrBytes > maxBuffer) {
+          child.kill();
+          failExec(null, 'stderr exceeded maxBuffer');
+          return;
+        }
+        stderr += chunk;
+      });
+
+      child.on('error', (error) => {
+        clearExecTimeout(timeout);
+        if (error.name === 'AbortError') {
+          fail(error);
+          return;
+        }
+        failExec(null);
+      });
+
+      child.on('close', (code) => {
+        clearExecTimeout(timeout);
+        if (settled) return;
+        settled = true;
+        const exitCode = code ?? 0;
+        if (exitCode === 0 || (sink.kind === 'stream' && stopped)) {
+          resolve({ stderr });
+          return;
+        }
+        reject(new ExecError(this.file, args, exitCode, stdoutText(), stderr));
+      });
+    });
+  }
+}
+
+function composeEnv(
+  base: NodeJS.ProcessEnv | undefined,
+  overlay: NodeJS.ProcessEnv | undefined
+): NodeJS.ProcessEnv | undefined {
+  if (!base && !overlay) return undefined;
+  if (!base) return { ...process.env, ...overlay };
+  return overlay ? { ...base, ...overlay } : base;
+}
+
+type TimeoutHandle = {
+  timeout: ReturnType<typeof setTimeout>;
+  killTimeout?: ReturnType<typeof setTimeout>;
+};
+
+function createTimeout(
+  child: ReturnType<typeof spawn>,
+  options: ExecOptions,
+  onTimeout: () => void
+): TimeoutHandle | undefined {
+  if (!options.timeoutMs) return undefined;
+  const handle: TimeoutHandle = {
+    timeout: setTimeout(() => {
+      child.kill();
+      handle.killTimeout = setTimeout(() => {
+        child.kill('SIGKILL');
+      }, TIMEOUT_KILL_GRACE_MS);
+      onTimeout();
+    }, options.timeoutMs),
+  };
+  return handle;
+}
+
+function clearExecTimeout(handle: TimeoutHandle | undefined): void {
+  if (!handle) return;
+  clearTimeout(handle.timeout);
+  if (handle.killTimeout) clearTimeout(handle.killTimeout);
+}

--- a/packages/shared/src/exec/bound-exec.ts
+++ b/packages/shared/src/exec/bound-exec.ts
@@ -27,15 +27,11 @@ type StdoutSink =
   | { kind: 'stream'; onStdout: (chunk: string) => boolean | void };
 
 class ProcessBoundExec implements BoundExec {
-  readonly file: string;
-  readonly cwd: string;
-  readonly env?: NodeJS.ProcessEnv;
-
-  constructor(file: string, cwd: string, env?: NodeJS.ProcessEnv) {
-    this.file = file;
-    this.cwd = cwd;
-    this.env = env;
-  }
+  constructor(
+    readonly file: string,
+    readonly cwd: string,
+    readonly env?: NodeJS.ProcessEnv
+  ) {}
 
   async exec(args: string[], options: ExecOptions = {}): Promise<ExecResult> {
     const chunks: string[] = [];

--- a/packages/shared/src/exec/index.ts
+++ b/packages/shared/src/exec/index.ts
@@ -1,0 +1,8 @@
+export { createBoundExec, type CreateBoundExecOptions } from './bound-exec';
+export {
+  ExecError,
+  type BoundExec,
+  type ExecBufferResult,
+  type ExecOptions,
+  type ExecResult,
+} from './types';

--- a/packages/shared/src/exec/types.ts
+++ b/packages/shared/src/exec/types.ts
@@ -1,0 +1,44 @@
+export type ExecOptions = {
+  cwd?: string;
+  env?: NodeJS.ProcessEnv;
+  maxBuffer?: number;
+  signal?: AbortSignal;
+  timeoutMs?: number;
+};
+
+export type ExecResult = {
+  stdout: string;
+  stderr: string;
+};
+
+export type ExecBufferResult = {
+  stdout: Buffer;
+  stderr: string;
+};
+
+export class ExecError extends Error {
+  constructor(
+    readonly file: string,
+    readonly args: readonly string[],
+    readonly exitCode: number | null,
+    readonly stdout: string,
+    readonly stderr: string
+  ) {
+    super(`${file} ${args.join(' ')} failed (exit ${exitCode ?? 'unknown'})`);
+    this.name = 'ExecError';
+  }
+}
+
+export type BoundExec = {
+  readonly file: string;
+  readonly cwd: string;
+  readonly env?: NodeJS.ProcessEnv;
+  exec(args: string[], options?: ExecOptions): Promise<ExecResult>;
+  execStreaming(
+    args: string[],
+    onStdout: (chunk: string) => boolean | void,
+    options?: ExecOptions
+  ): Promise<void>;
+  execBuffer(args: string[], options?: ExecOptions): Promise<ExecBufferResult>;
+  withCwd(cwd: string): BoundExec;
+};

--- a/packages/shared/src/fs/file-watch-service.ts
+++ b/packages/shared/src/fs/file-watch-service.ts
@@ -1,0 +1,253 @@
+import { realpathSync } from 'node:fs';
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import parcelWatcher from '@parcel/watcher';
+import { type IDisposable, ResourceMap } from '../lib';
+import type { FileWatchOptions, IFileWatchService, RawFileEvent, WatchHandle } from './types';
+
+const RESUBSCRIBE_DELAY_MS = 250;
+
+export type FileWatchServiceOptions = {
+  /** Receives background failures (resubscribe attempts, teardown). */
+  onError?: (context: string, error: unknown) => void;
+};
+
+type WatchConsumer = {
+  onEvents: (events: RawFileEvent[]) => void;
+  onResync?: () => void;
+  debounceMs: number;
+  pending: RawFileEvent[];
+  timer: ReturnType<typeof setTimeout> | null;
+};
+
+function normalizeIgnore(ignore: string[] | undefined): string[] {
+  return [...(ignore ?? [])].sort();
+}
+
+function watchKey(root: string, ignore: string[]): string {
+  return JSON.stringify({ root, ignore });
+}
+
+function toRawFileEvent(event: parcelWatcher.Event): RawFileEvent {
+  return {
+    kind: event.type,
+    path: event.path,
+  };
+}
+
+/**
+ * One native subscription per (root, ignore set), shared across consumers.
+ * Owns the resubscribe-with-retry reliability logic; after a successful resubscribe it
+ * signals resync (events may have been lost in the gap).
+ */
+class NativeWatch implements IDisposable {
+  private subscription: Promise<parcelWatcher.AsyncSubscription> | null = null;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(
+    readonly root: string,
+    readonly ignore: string[],
+    private readonly deliver: (events: RawFileEvent[]) => void,
+    private readonly resync: () => void,
+    private readonly onError: (context: string, error: unknown) => void
+  ) {
+    this.subscription = this.subscribe();
+    this.subscription.catch(() => {});
+  }
+
+  async ready(): Promise<void> {
+    if (!this.subscription) throw new Error(`Watcher is not subscribed for ${this.root}`);
+    await this.subscription;
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+    this.retryTimer = null;
+    const subscription = await this.subscription?.catch(() => null);
+    await subscription?.unsubscribe();
+  }
+
+  private async subscribe(): Promise<parcelWatcher.AsyncSubscription> {
+    await fs.stat(this.root);
+    return parcelWatcher.subscribe(
+      this.root,
+      (err, events) => {
+        if (err) {
+          this.onError(`watch ${this.root}`, err);
+          this.scheduleResubscribe();
+          return;
+        }
+        if (events.length === 0) return;
+        this.deliver(events.map(toRawFileEvent));
+      },
+      { ignore: this.ignore }
+    );
+  }
+
+  private scheduleResubscribe(): void {
+    if (this.retryTimer || this.disposed) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      if (this.disposed) return;
+      const previous = this.subscription;
+      this.subscription = this.subscribe();
+      this.subscription.then(
+        () => this.resync(),
+        (error) => {
+          this.onError(`resubscribe ${this.root}`, error);
+          this.scheduleResubscribe();
+        }
+      );
+      void previous?.then((subscription) => subscription.unsubscribe()).catch(() => {});
+    }, RESUBSCRIBE_DELAY_MS);
+  }
+}
+
+export class FileWatchService implements IFileWatchService, IDisposable {
+  private readonly consumers = new Map<string, Set<WatchConsumer>>();
+  private readonly natives = new Map<string, NativeWatch>();
+  private readonly subscriptions: ResourceMap<NativeWatch>;
+  private readonly onError: (context: string, error: unknown) => void;
+  private disposed = false;
+
+  constructor(options: FileWatchServiceOptions = {}) {
+    this.onError = options.onError ?? (() => {});
+    this.subscriptions = new ResourceMap<NativeWatch>({
+      teardown: async (key, native) => {
+        this.natives.delete(key);
+        await native.dispose();
+      },
+      onError: this.onError,
+    });
+  }
+
+  watch(
+    root: string,
+    onEvents: (events: RawFileEvent[]) => void,
+    options: FileWatchOptions = {}
+  ): WatchHandle {
+    if (this.disposed) throw new Error('FileWatchService disposed');
+    const normalizedRoot = realpathOrResolve(root);
+    const ignore = normalizeIgnore(options.ignore);
+    const key = watchKey(normalizedRoot, ignore);
+
+    const consumer: WatchConsumer = {
+      onEvents,
+      onResync: options.onResync,
+      debounceMs: options.debounceMs ?? 0,
+      pending: [],
+      timer: null,
+    };
+    let consumerSet = this.consumers.get(key);
+    if (!consumerSet) {
+      consumerSet = new Set();
+      this.consumers.set(key, consumerSet);
+    }
+    consumerSet.add(consumer);
+
+    const lease = this.subscriptions.acquire(key, async () => {
+      const native = new NativeWatch(
+        normalizedRoot,
+        ignore,
+        (events) => this.deliver(key, events),
+        () => this.resyncConsumers(key),
+        this.onError
+      );
+      try {
+        await native.ready();
+      } catch (error) {
+        await native.dispose();
+        throw error;
+      }
+      this.natives.set(key, native);
+      return native;
+    });
+    lease.catch(() => {});
+
+    let closed = false;
+    return {
+      ready: async () => {
+        await lease;
+      },
+      release: () => {
+        if (closed) return;
+        closed = true;
+        this.removeConsumer(key, consumer);
+        void lease.then((acquired) => acquired.release()).catch(() => {});
+      },
+    };
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.subscriptions.dispose();
+    for (const consumerSet of this.consumers.values()) {
+      for (const consumer of consumerSet) clearConsumer(consumer);
+    }
+    this.consumers.clear();
+    const natives = [...this.natives.values()];
+    this.natives.clear();
+    await Promise.all(natives.map((native) => native.dispose()));
+  }
+
+  private deliver(key: string, events: RawFileEvent[]): void {
+    const consumerSet = this.consumers.get(key);
+    if (!consumerSet) return;
+    for (const consumer of consumerSet) {
+      deliverEvents(consumer, events);
+    }
+  }
+
+  private resyncConsumers(key: string): void {
+    const consumerSet = this.consumers.get(key);
+    if (!consumerSet) return;
+    for (const consumer of consumerSet) {
+      consumer.onResync?.();
+    }
+  }
+
+  private removeConsumer(key: string, consumer: WatchConsumer): void {
+    const consumerSet = this.consumers.get(key);
+    if (!consumerSet) return;
+    consumerSet.delete(consumer);
+    clearConsumer(consumer);
+    if (consumerSet.size === 0) this.consumers.delete(key);
+  }
+}
+
+function deliverEvents(consumer: WatchConsumer, events: RawFileEvent[]): void {
+  if (consumer.debounceMs <= 0) {
+    consumer.onEvents(events);
+    return;
+  }
+  consumer.pending.push(...events);
+  if (consumer.timer) return;
+  consumer.timer = setTimeout(() => {
+    consumer.timer = null;
+    const pending = consumer.pending;
+    consumer.pending = [];
+    if (pending.length > 0) consumer.onEvents(pending);
+  }, consumer.debounceMs);
+}
+
+function clearConsumer(consumer: WatchConsumer): void {
+  if (consumer.timer) clearTimeout(consumer.timer);
+  consumer.timer = null;
+  consumer.pending = [];
+}
+
+function realpathOrResolve(root: string): string {
+  try {
+    return realpathSync.native(root);
+  } catch {
+    try {
+      return realpathSync(root);
+    } catch {
+      return path.resolve(root);
+    }
+  }
+}

--- a/packages/shared/src/fs/file-watch-service.ts
+++ b/packages/shared/src/fs/file-watch-service.ts
@@ -1,11 +1,8 @@
-import { realpathSync } from 'node:fs';
-import fs from 'node:fs/promises';
-import path from 'node:path';
-import parcelWatcher from '@parcel/watcher';
-import { type IDisposable, ResourceMap } from '../lib';
+import type { IDisposable } from '../lib';
+import { ResourceMap } from '../lib';
+import { NativeWatch } from './native-watch';
+import { realpathOrResolve } from './paths';
 import type { FileWatchOptions, IFileWatchService, RawFileEvent, WatchHandle } from './types';
-
-const RESUBSCRIBE_DELAY_MS = 250;
 
 export type FileWatchServiceOptions = {
   /** Receives background failures (resubscribe attempts, teardown). */
@@ -26,84 +23,6 @@ function normalizeIgnore(ignore: string[] | undefined): string[] {
 
 function watchKey(root: string, ignore: string[]): string {
   return JSON.stringify({ root, ignore });
-}
-
-function toRawFileEvent(event: parcelWatcher.Event): RawFileEvent {
-  return {
-    kind: event.type,
-    path: event.path,
-  };
-}
-
-/**
- * One native subscription per (root, ignore set), shared across consumers.
- * Owns the resubscribe-with-retry reliability logic; after a successful resubscribe it
- * signals resync (events may have been lost in the gap).
- */
-class NativeWatch implements IDisposable {
-  private subscription: Promise<parcelWatcher.AsyncSubscription> | null = null;
-  private retryTimer: ReturnType<typeof setTimeout> | null = null;
-  private disposed = false;
-
-  constructor(
-    readonly root: string,
-    readonly ignore: string[],
-    private readonly deliver: (events: RawFileEvent[]) => void,
-    private readonly resync: () => void,
-    private readonly onError: (context: string, error: unknown) => void
-  ) {
-    this.subscription = this.subscribe();
-    this.subscription.catch(() => {});
-  }
-
-  async ready(): Promise<void> {
-    if (!this.subscription) throw new Error(`Watcher is not subscribed for ${this.root}`);
-    await this.subscription;
-  }
-
-  async dispose(): Promise<void> {
-    if (this.disposed) return;
-    this.disposed = true;
-    if (this.retryTimer) clearTimeout(this.retryTimer);
-    this.retryTimer = null;
-    const subscription = await this.subscription?.catch(() => null);
-    await subscription?.unsubscribe();
-  }
-
-  private async subscribe(): Promise<parcelWatcher.AsyncSubscription> {
-    await fs.stat(this.root);
-    return parcelWatcher.subscribe(
-      this.root,
-      (err, events) => {
-        if (err) {
-          this.onError(`watch ${this.root}`, err);
-          this.scheduleResubscribe();
-          return;
-        }
-        if (events.length === 0) return;
-        this.deliver(events.map(toRawFileEvent));
-      },
-      { ignore: this.ignore }
-    );
-  }
-
-  private scheduleResubscribe(): void {
-    if (this.retryTimer || this.disposed) return;
-    this.retryTimer = setTimeout(() => {
-      this.retryTimer = null;
-      if (this.disposed) return;
-      const previous = this.subscription;
-      this.subscription = this.subscribe();
-      this.subscription.then(
-        () => this.resync(),
-        (error) => {
-          this.onError(`resubscribe ${this.root}`, error);
-          this.scheduleResubscribe();
-        }
-      );
-      void previous?.then((subscription) => subscription.unsubscribe()).catch(() => {});
-    }, RESUBSCRIBE_DELAY_MS);
-  }
 }
 
 export class FileWatchService implements IFileWatchService, IDisposable {
@@ -238,16 +157,4 @@ function clearConsumer(consumer: WatchConsumer): void {
   if (consumer.timer) clearTimeout(consumer.timer);
   consumer.timer = null;
   consumer.pending = [];
-}
-
-function realpathOrResolve(root: string): string {
-  try {
-    return realpathSync.native(root);
-  } catch {
-    try {
-      return realpathSync(root);
-    } catch {
-      return path.resolve(root);
-    }
-  }
 }

--- a/packages/shared/src/fs/fs-service.test.ts
+++ b/packages/shared/src/fs/fs-service.test.ts
@@ -1,0 +1,147 @@
+import { mkdir, mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { FileWatchService, FsService, type RawFileEvent } from './index';
+
+async function eventually<T>(
+  read: () => T | undefined,
+  timeoutMs = 5_000,
+  intervalMs = 50
+): Promise<T> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const value = read();
+    if (value !== undefined) return value;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+describe('FsService', () => {
+  it('reads, stats, checks, and removes real files', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-shared-fs-'));
+    const nested = path.join(root, 'nested');
+    const file = path.join(nested, 'note.txt');
+    await mkdir(nested);
+    await writeFile(file, 'hello shared runtime\n', 'utf8');
+
+    const service = new FsService();
+    await expect(service.exists(file)).resolves.toBe(true);
+
+    const stat = await service.stat(file);
+    expect(stat).toEqual({
+      type: 'file',
+      size: Buffer.byteLength('hello shared runtime\n'),
+      mtimeMs: expect.any(Number),
+    });
+    await expect(service.stat(path.join(root, 'missing.txt'))).resolves.toBeNull();
+
+    await expect(service.read(file)).resolves.toMatchObject({
+      content: 'hello shared runtime\n',
+      truncated: false,
+      totalSize: Buffer.byteLength('hello shared runtime\n'),
+    });
+    await expect(service.read(file, { maxBytes: 5 })).resolves.toMatchObject({
+      content: 'hello',
+      truncated: true,
+      totalSize: Buffer.byteLength('hello shared runtime\n'),
+    });
+
+    await service.remove(file);
+    await expect(service.exists(file)).resolves.toBe(false);
+    await service.remove(nested, { recursive: true });
+    await expect(service.exists(nested)).resolves.toBe(false);
+  });
+});
+
+describe('FileWatchService', () => {
+  it('emits real file events through ref-counted leases', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-shared-watch-'));
+    const watch = new FileWatchService();
+    const firstEvents: RawFileEvent[] = [];
+    const secondEvents: RawFileEvent[] = [];
+
+    try {
+      const first = watch.watch(root, (events) => firstEvents.push(...events));
+      const second = watch.watch(root, (events) => secondEvents.push(...events));
+      await Promise.all([first.ready(), second.ready()]);
+
+      const file = path.join(root, 'created.txt');
+      await writeFile(file, 'watch me\n', 'utf8');
+
+      await eventually(() =>
+        firstEvents.some((event) => path.basename(event.path) === 'created.txt') ? true : undefined
+      );
+      expect(secondEvents.some((event) => path.basename(event.path) === 'created.txt')).toBe(true);
+      const createdEvent = firstEvents.find((event) => path.basename(event.path) === 'created.txt');
+      expect(createdEvent).toMatchObject({
+        kind: 'create',
+        path: expect.any(String),
+      });
+      expect(path.isAbsolute(createdEvent?.path ?? '')).toBe(true);
+      expect(firstEvents[0]).not.toHaveProperty('type');
+      expect(firstEvents[0]).not.toHaveProperty('entryType');
+
+      first.release();
+      const secondOnlyFile = path.join(root, 'second-only.txt');
+      await writeFile(secondOnlyFile, 'still watching\n', 'utf8');
+      await eventually(() =>
+        secondEvents.some((event) => path.basename(event.path) === 'second-only.txt')
+          ? true
+          : undefined
+      );
+      expect(firstEvents.some((event) => path.basename(event.path) === 'second-only.txt')).toBe(
+        false
+      );
+
+      second.release();
+    } finally {
+      await watch.dispose();
+    }
+  });
+
+  it('keeps the shared subscription alive across concurrent release/re-watch', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-shared-watch-relock-'));
+    const watch = new FileWatchService();
+    const events: RawFileEvent[] = [];
+
+    try {
+      const first = watch.watch(root, () => {});
+      await first.ready();
+      // Release the only consumer and immediately re-watch: the new consumer must wait for
+      // the in-flight native teardown and then provision a fresh subscription.
+      first.release();
+      const second = watch.watch(root, (incoming) => events.push(...incoming));
+      await second.ready();
+
+      await writeFile(path.join(root, 'after-rewatch.txt'), 'hi\n', 'utf8');
+      await eventually(() =>
+        events.some((event) => path.basename(event.path) === 'after-rewatch.txt') ? true : undefined
+      );
+      second.release();
+    } finally {
+      await watch.dispose();
+    }
+  });
+
+  it('surfaces watcher subscription failures through ready()', async () => {
+    const root = path.join(tmpdir(), `emdash-shared-watch-missing-${Date.now()}`);
+    const watch = new FileWatchService();
+
+    try {
+      const handle = watch.watch(root, () => {});
+
+      await expect(handle.ready()).rejects.toThrow();
+      handle.release();
+
+      // A failed subscription is evicted: creating the root and re-watching recovers.
+      await mkdir(root, { recursive: true });
+      const recovered = watch.watch(root, () => {});
+      await expect(recovered.ready()).resolves.toBeUndefined();
+      recovered.release();
+    } finally {
+      await watch.dispose();
+    }
+  });
+});

--- a/packages/shared/src/fs/fs-service.ts
+++ b/packages/shared/src/fs/fs-service.ts
@@ -46,10 +46,6 @@ export class FsService implements IFsService {
     };
   }
 
-  async remove(filePath: string, options: { recursive?: boolean } = {}): Promise<void> {
-    await fs.rm(filePath, { force: true, recursive: options.recursive ?? false });
-  }
-
   async exists(filePath: string): Promise<boolean> {
     try {
       await fs.access(filePath, constants.F_OK);
@@ -57,5 +53,9 @@ export class FsService implements IFsService {
     } catch {
       return false;
     }
+  }
+
+  async remove(filePath: string, options: { recursive?: boolean } = {}): Promise<void> {
+    await fs.rm(filePath, { force: true, recursive: options.recursive ?? false });
   }
 }

--- a/packages/shared/src/fs/fs-service.ts
+++ b/packages/shared/src/fs/fs-service.ts
@@ -1,0 +1,61 @@
+import { constants } from 'node:fs';
+import fs from 'node:fs/promises';
+import type { FileReadResult, FileStat, IFsService } from './types';
+
+export class FsService implements IFsService {
+  async read(filePath: string, options: { maxBytes?: number } = {}): Promise<FileReadResult> {
+    const stat = await fs.stat(filePath);
+    const maxBytes = options.maxBytes;
+    if (maxBytes === undefined) {
+      const content = await fs.readFile(filePath, 'utf8');
+      return {
+        content,
+        truncated: false,
+        totalSize: stat.size,
+      };
+    }
+
+    const handle = await fs.open(filePath, 'r');
+    try {
+      const buffer = Buffer.alloc(maxBytes + 1);
+      const { bytesRead } = await handle.read(buffer, 0, maxBytes + 1, 0);
+      const truncated = bytesRead > maxBytes;
+      const slice = buffer.subarray(0, truncated ? maxBytes : bytesRead);
+      return {
+        content: slice.toString('utf8'),
+        truncated,
+        totalSize: stat.size,
+      };
+    } finally {
+      await handle.close();
+    }
+  }
+
+  async stat(filePath: string): Promise<FileStat | null> {
+    let stat;
+    try {
+      stat = await fs.lstat(filePath);
+    } catch {
+      return null;
+    }
+    if (!stat.isFile() && !stat.isDirectory()) return null;
+    return {
+      type: stat.isDirectory() ? 'dir' : 'file',
+      size: stat.size,
+      mtimeMs: stat.mtimeMs,
+    };
+  }
+
+  async remove(filePath: string, options: { recursive?: boolean } = {}): Promise<void> {
+    await fs.rm(filePath, { force: true, recursive: options.recursive ?? false });
+  }
+
+  async exists(filePath: string): Promise<boolean> {
+    try {
+      await fs.access(filePath, constants.F_OK);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/shared/src/fs/index.ts
+++ b/packages/shared/src/fs/index.ts
@@ -1,5 +1,6 @@
 export { FileWatchService, type FileWatchServiceOptions } from './file-watch-service';
 export { FsService } from './fs-service';
+export { realpathOrResolve } from './paths';
 export type {
   FileReadResult,
   FileStat,

--- a/packages/shared/src/fs/index.ts
+++ b/packages/shared/src/fs/index.ts
@@ -1,0 +1,12 @@
+export { FileWatchService, type FileWatchServiceOptions } from './file-watch-service';
+export { FsService } from './fs-service';
+export type {
+  FileReadResult,
+  FileStat,
+  FileChangeKind,
+  FileWatchOptions,
+  IFileWatchService,
+  IFsService,
+  RawFileEvent,
+  WatchHandle,
+} from './types';

--- a/packages/shared/src/fs/native-watch.ts
+++ b/packages/shared/src/fs/native-watch.ts
@@ -1,0 +1,94 @@
+import fs from 'node:fs/promises';
+import parcelWatcher from '@parcel/watcher';
+import type { IDisposable } from '../lib';
+import type { RawFileEvent } from './types';
+
+const RESUBSCRIBE_DELAY_MS = 250;
+
+function toRawFileEvent(event: parcelWatcher.Event): RawFileEvent {
+  return {
+    kind: event.type,
+    path: event.path,
+  };
+}
+
+/**
+ * One native subscription per (root, ignore set), shared across consumers.
+ * Owns the resubscribe-with-retry reliability logic; after a successful resubscribe it
+ * signals resync (events may have been lost in the gap).
+ */
+export class NativeWatch implements IDisposable {
+  readonly root: string;
+  readonly ignore: string[];
+  private readonly deliver: (events: RawFileEvent[]) => void;
+  private readonly resync: () => void;
+  private readonly onError: (context: string, error: unknown) => void;
+  private subscription: Promise<parcelWatcher.AsyncSubscription> | null = null;
+  private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private disposed = false;
+
+  constructor(
+    root: string,
+    ignore: string[],
+    deliver: (events: RawFileEvent[]) => void,
+    resync: () => void,
+    onError: (context: string, error: unknown) => void
+  ) {
+    this.root = root;
+    this.ignore = ignore;
+    this.deliver = deliver;
+    this.resync = resync;
+    this.onError = onError;
+    this.subscription = this.subscribe();
+    this.subscription.catch(() => {});
+  }
+
+  async ready(): Promise<void> {
+    if (!this.subscription) throw new Error(`Watcher is not subscribed for ${this.root}`);
+    await this.subscription;
+  }
+
+  async dispose(): Promise<void> {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.retryTimer) clearTimeout(this.retryTimer);
+    this.retryTimer = null;
+    const subscription = await this.subscription?.catch(() => null);
+    await subscription?.unsubscribe();
+  }
+
+  private async subscribe(): Promise<parcelWatcher.AsyncSubscription> {
+    await fs.stat(this.root);
+    return parcelWatcher.subscribe(
+      this.root,
+      (err, events) => {
+        if (err) {
+          this.onError(`watch ${this.root}`, err);
+          this.scheduleResubscribe();
+          return;
+        }
+        if (events.length === 0) return;
+        this.deliver(events.map(toRawFileEvent));
+      },
+      { ignore: this.ignore }
+    );
+  }
+
+  private scheduleResubscribe(): void {
+    if (this.retryTimer || this.disposed) return;
+    this.retryTimer = setTimeout(() => {
+      this.retryTimer = null;
+      if (this.disposed) return;
+      const previous = this.subscription;
+      this.subscription = this.subscribe();
+      this.subscription.then(
+        () => this.resync(),
+        (error) => {
+          this.onError(`resubscribe ${this.root}`, error);
+          this.scheduleResubscribe();
+        }
+      );
+      void previous?.then((subscription) => subscription.unsubscribe()).catch(() => {});
+    }, RESUBSCRIBE_DELAY_MS);
+  }
+}

--- a/packages/shared/src/fs/paths.ts
+++ b/packages/shared/src/fs/paths.ts
@@ -1,0 +1,14 @@
+import { realpathSync } from 'node:fs';
+import path from 'node:path';
+
+export function realpathOrResolve(filePath: string): string {
+  try {
+    return realpathSync.native(filePath);
+  } catch {
+    try {
+      return realpathSync(filePath);
+    } catch {
+      return path.resolve(filePath);
+    }
+  }
+}

--- a/packages/shared/src/fs/types.ts
+++ b/packages/shared/src/fs/types.ts
@@ -1,0 +1,63 @@
+export type FileChangeKind = 'create' | 'update' | 'delete';
+
+export type RawFileEvent = {
+  kind: FileChangeKind;
+  path: string;
+};
+
+export type FileWatchOptions = {
+  /**
+   * Native-level ignore globs, a property of the shared root subscription: consumers watching
+   * the same root should agree on the ignore set to share one native watcher (different sets
+   * create separate subscriptions). Relevance filtering beyond ignores belongs in consumers.
+   */
+  ignore?: string[];
+  debounceMs?: number;
+  /**
+   * Called after the native watcher recovered from an error (resubscribe). Events may have
+   * been lost in the gap; consumers should treat all derived state as stale and resync.
+   */
+  onResync?: () => void;
+};
+
+export type WatchHandle = {
+  ready(): Promise<void>;
+  release(): void;
+};
+
+export type IFileWatchService = {
+  watch(
+    root: string,
+    onEvents: (events: RawFileEvent[]) => void,
+    options?: FileWatchOptions
+  ): WatchHandle;
+  dispose(): Promise<void>;
+};
+
+export type FileReadResult = {
+  content: string;
+  truncated: boolean;
+  totalSize: number;
+};
+
+export type FileStat = {
+  type: 'file' | 'dir';
+  size: number;
+  mtimeMs: number;
+};
+
+/**
+ * Stateless filesystem operations on absolute paths. No events, no lifecycle, no caching;
+ * watching is a separate service (`IFileWatchService`).
+ *
+ * Intended extension set (additive, as consumers need them):
+ * `list`, `write`, `glob`, `mkdir`, `copyFile`, `realPath`, `search`, `readImage`.
+ * Workspace-scoping (root-relative paths + escape validation) is a wrapper layered on top,
+ * not part of this interface.
+ */
+export type IFsService = {
+  read(absPath: string, options?: { maxBytes?: number }): Promise<FileReadResult>;
+  stat(absPath: string): Promise<FileStat | null>;
+  remove(absPath: string, options?: { recursive?: boolean }): Promise<void>;
+  exists(absPath: string): Promise<boolean>;
+};

--- a/packages/shared/src/git/cat-file-batch.test.ts
+++ b/packages/shared/src/git/cat-file-batch.test.ts
@@ -1,0 +1,34 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { CatFileBatch } from './cat-file-batch';
+import { createGitExec } from './git-env';
+
+const execFileAsync = promisify(execFile);
+
+async function makeRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), 'emdash-shared-catfile-'));
+  await execFileAsync('git', ['init'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repo });
+  await writeFile(path.join(repo, 'a.txt'), 'hello\n', 'utf8');
+  await execFileAsync('git', ['add', 'a.txt'], { cwd: repo });
+  await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repo });
+  return repo;
+}
+
+describe('CatFileBatch', () => {
+  it('reads real git objects through one persistent batch process', async () => {
+    const repo = await makeRepo();
+    const batch = new CatFileBatch({ exec: createGitExec({ cwd: repo }) });
+    try {
+      await expect(batch.readText('HEAD:a.txt')).resolves.toBe('hello\n');
+      await expect(batch.readText('HEAD:missing.txt')).resolves.toBeNull();
+    } finally {
+      batch.dispose();
+    }
+  });
+});

--- a/packages/shared/src/git/cat-file-batch.ts
+++ b/packages/shared/src/git/cat-file-batch.ts
@@ -15,6 +15,7 @@ export type CatFileBatchOptions = {
 };
 
 export class CatFileBatch implements IDisposable {
+  private readonly exec: BoundExec;
   private disposed = false;
   private proc: ChildProcessWithoutNullStreams | null = null;
   private buffer = Buffer.alloc(0);
@@ -22,10 +23,20 @@ export class CatFileBatch implements IDisposable {
   private queue: Pending[] = [];
   private processing = false;
   private readAborted: Error | null = null;
-  private readonly exec: BoundExec;
 
   constructor(options: CatFileBatchOptions) {
     this.exec = options.exec;
+  }
+
+  readText(query: string): Promise<string | null> {
+    return new Promise((resolve, reject) => {
+      if (this.disposed) {
+        reject(new Error('CatFileBatch disposed'));
+        return;
+      }
+      this.queue.push({ query, resolve, reject });
+      if (!this.processing) void this.next();
+    });
   }
 
   dispose(): void {
@@ -45,17 +56,6 @@ export class CatFileBatch implements IDisposable {
     for (const item of queue) {
       item.reject(this.readAborted);
     }
-  }
-
-  readText(query: string): Promise<string | null> {
-    return new Promise((resolve, reject) => {
-      if (this.disposed) {
-        reject(new Error('CatFileBatch disposed'));
-        return;
-      }
-      this.queue.push({ query, resolve, reject });
-      if (!this.processing) void this.next();
-    });
   }
 
   private ensureProc(): ChildProcessWithoutNullStreams {
@@ -87,13 +87,6 @@ export class CatFileBatch implements IDisposable {
 
     this.proc = child;
     return this.proc;
-  }
-
-  private recordProcDeath(error: Error): void {
-    this.proc = null;
-    this.readAborted = error;
-    this.buffer = Buffer.alloc(0);
-    this.wake?.();
   }
 
   private async next(): Promise<void> {
@@ -143,6 +136,13 @@ export class CatFileBatch implements IDisposable {
       this.queue.shift();
       void this.next();
     }
+  }
+
+  private recordProcDeath(error: Error): void {
+    this.proc = null;
+    this.readAborted = error;
+    this.buffer = Buffer.alloc(0);
+    this.wake?.();
   }
 
   private waitForData(): Promise<void> {

--- a/packages/shared/src/git/cat-file-batch.ts
+++ b/packages/shared/src/git/cat-file-batch.ts
@@ -1,0 +1,176 @@
+import { spawn, type ChildProcessWithoutNullStreams } from 'node:child_process';
+import type { BoundExec } from '../exec';
+import type { IDisposable } from '../lib';
+
+const REQUEST_TIMEOUT_MS = 5_000;
+
+type Pending = {
+  query: string;
+  resolve: (value: string | null) => void;
+  reject: (error: Error) => void;
+};
+
+export type CatFileBatchOptions = {
+  exec: BoundExec;
+};
+
+export class CatFileBatch implements IDisposable {
+  private disposed = false;
+  private proc: ChildProcessWithoutNullStreams | null = null;
+  private buffer = Buffer.alloc(0);
+  private wake: (() => void) | null = null;
+  private queue: Pending[] = [];
+  private processing = false;
+  private readAborted: Error | null = null;
+  private readonly exec: BoundExec;
+
+  constructor(options: CatFileBatchOptions) {
+    this.exec = options.exec;
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    try {
+      this.proc?.stdin.end();
+      this.proc?.kill();
+    } catch {}
+    this.proc = null;
+    this.buffer = Buffer.alloc(0);
+    this.readAborted = new Error('CatFileBatch disposed');
+    this.wake?.();
+    this.wake = null;
+    this.processing = false;
+    const queue = this.queue;
+    this.queue = [];
+    for (const item of queue) {
+      item.reject(this.readAborted);
+    }
+  }
+
+  readText(query: string): Promise<string | null> {
+    return new Promise((resolve, reject) => {
+      if (this.disposed) {
+        reject(new Error('CatFileBatch disposed'));
+        return;
+      }
+      this.queue.push({ query, resolve, reject });
+      if (!this.processing) void this.next();
+    });
+  }
+
+  private ensureProc(): ChildProcessWithoutNullStreams {
+    if (this.disposed) throw new Error('CatFileBatch disposed');
+    if (this.proc) return this.proc;
+
+    this.readAborted = null;
+    const child = spawn(this.exec.file, ['cat-file', '--batch'], {
+      cwd: this.exec.cwd,
+      env: this.exec.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    child.stderr.resume();
+
+    child.stdout.on('data', (chunk: Buffer) => {
+      this.buffer = Buffer.concat([this.buffer, chunk]);
+      this.wake?.();
+    });
+    child.stdout.on('end', () => {
+      this.readAborted = new Error('git cat-file stdout ended');
+      this.wake?.();
+    });
+    child.on('error', () => {
+      this.recordProcDeath(new Error('git cat-file process error'));
+    });
+    child.on('close', () => {
+      this.recordProcDeath(new Error('git cat-file process exited'));
+    });
+
+    this.proc = child;
+    return this.proc;
+  }
+
+  private recordProcDeath(error: Error): void {
+    this.proc = null;
+    this.readAborted = error;
+    this.buffer = Buffer.alloc(0);
+    this.wake?.();
+  }
+
+  private async next(): Promise<void> {
+    if (this.queue.length === 0) {
+      this.processing = false;
+      return;
+    }
+
+    this.processing = true;
+    const item = this.queue[0]!;
+    let timeoutId: ReturnType<typeof setTimeout> | undefined;
+
+    try {
+      const proc = this.ensureProc();
+      proc.stdin.write(`${item.query}\n`);
+
+      timeoutId = setTimeout(() => {
+        try {
+          this.proc?.kill();
+        } catch {}
+      }, REQUEST_TIMEOUT_MS);
+
+      const line = await this.readLine();
+      clearTimeout(timeoutId);
+      timeoutId = undefined;
+
+      if (line.endsWith(' missing') || line === 'missing' || line.endsWith(' ambiguous')) {
+        item.resolve(null);
+      } else {
+        const parts = line.split(' ');
+        const size = Number.parseInt(parts[parts.length - 1] ?? '', 10);
+        if (Number.isNaN(size)) {
+          proc.kill();
+          throw new Error(`Unexpected cat-file header: ${line}`);
+        }
+        const body = await this.readBytes(size + 1);
+        item.resolve(body.subarray(0, -1).toString('utf8'));
+      }
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      item.reject(err);
+      try {
+        this.proc?.kill();
+      } catch {}
+    } finally {
+      if (timeoutId) clearTimeout(timeoutId);
+      this.queue.shift();
+      void this.next();
+    }
+  }
+
+  private waitForData(): Promise<void> {
+    return new Promise((resolve) => {
+      this.wake = resolve;
+    });
+  }
+
+  private async readLine(): Promise<string> {
+    while (true) {
+      if (this.readAborted) throw this.readAborted;
+      const newline = this.buffer.indexOf(0x0a);
+      if (newline !== -1) {
+        const line = this.buffer.subarray(0, newline).toString('utf8');
+        this.buffer = this.buffer.subarray(newline + 1);
+        return line;
+      }
+      await this.waitForData();
+    }
+  }
+
+  private async readBytes(count: number): Promise<Buffer> {
+    while (this.buffer.length < count) {
+      if (this.readAborted) throw this.readAborted;
+      await this.waitForData();
+    }
+    const output = this.buffer.subarray(0, count);
+    this.buffer = this.buffer.subarray(count);
+    return output;
+  }
+}

--- a/packages/shared/src/git/errors.ts
+++ b/packages/shared/src/git/errors.ts
@@ -38,19 +38,9 @@ export type FetchPrForReviewError =
   | { type: 'not-found'; prNumber: number; message: string }
   | GitCommandError;
 
-export type RenameBranchError =
-  | { type: 'already-exists'; branch: string; message: string }
-  | { type: 'not-found'; branch: string; message: string }
-  | GitCommandError;
-
 export type DeleteBranchError =
   | { type: 'not-found'; branch: string; message: string }
   | { type: 'not-merged'; branch: string; message: string }
-  | GitCommandError;
-
-export type SoftResetError =
-  | { type: 'initial-commit'; message: string }
-  | { type: 'already-pushed'; message: string }
   | GitCommandError;
 
 export function gitErrorMessage(error: unknown): string {
@@ -156,22 +146,6 @@ export function classifyCreateBranchError(
   return commandError;
 }
 
-export function classifyRenameBranchError(
-  error: unknown,
-  oldBranch: string,
-  newBranch: string
-): RenameBranchError {
-  const commandError = toGitCommandError(error);
-  const stderr = commandError.stderr ?? '';
-  if (stderr.includes('already exists')) {
-    return { type: 'already-exists', branch: newBranch, message: commandError.message };
-  }
-  if (stderr.includes('No branch named')) {
-    return { type: 'not-found', branch: oldBranch, message: commandError.message };
-  }
-  return commandError;
-}
-
 export function classifyDeleteBranchError(error: unknown, branch: string): DeleteBranchError {
   const commandError = toGitCommandError(error);
   const stderr = commandError.stderr ?? '';
@@ -182,8 +156,4 @@ export function classifyDeleteBranchError(error: unknown, branch: string): Delet
     return { type: 'not-merged', branch, message: commandError.message };
   }
   return commandError;
-}
-
-export function classifySoftResetError(error: unknown): SoftResetError {
-  return toGitCommandError(error);
 }

--- a/packages/shared/src/git/errors.ts
+++ b/packages/shared/src/git/errors.ts
@@ -1,0 +1,189 @@
+import { ExecError } from '../exec';
+
+export type GitCommandError = {
+  type: 'git-error';
+  message: string;
+  stderr?: string;
+};
+
+export type FetchError =
+  | { type: 'remote-not-found'; remote?: string; message: string }
+  | { type: 'auth-failed'; message: string }
+  | GitCommandError;
+
+export type CommitError =
+  | { type: 'nothing-to-commit'; message: string }
+  | { type: 'empty-message'; message: string }
+  | GitCommandError;
+
+export type PushError =
+  | { type: 'no-upstream'; message: string }
+  | { type: 'rejected'; message: string }
+  | { type: 'auth-failed'; message: string }
+  | GitCommandError;
+
+export type PullError =
+  | { type: 'conflict'; message: string }
+  | { type: 'auth-failed'; message: string }
+  | GitCommandError;
+
+export type CreateBranchError =
+  | { type: 'already-exists'; branch: string; message: string }
+  | { type: 'invalid-name'; branch: string; message: string }
+  | { type: 'invalid-base'; branch: string; from: string; message: string }
+  | { type: 'fetch-failed'; remote: string; branch: string; error: FetchError }
+  | GitCommandError;
+
+export type FetchPrForReviewError =
+  | { type: 'not-found'; prNumber: number; message: string }
+  | GitCommandError;
+
+export type RenameBranchError =
+  | { type: 'already-exists'; branch: string; message: string }
+  | { type: 'not-found'; branch: string; message: string }
+  | GitCommandError;
+
+export type DeleteBranchError =
+  | { type: 'not-found'; branch: string; message: string }
+  | { type: 'not-merged'; branch: string; message: string }
+  | GitCommandError;
+
+export type SoftResetError =
+  | { type: 'initial-commit'; message: string }
+  | { type: 'already-pushed'; message: string }
+  | GitCommandError;
+
+export function gitErrorMessage(error: unknown): string {
+  if (error instanceof ExecError) {
+    return error.stderr.trim() || error.stdout.trim() || error.message;
+  }
+  return error instanceof Error ? error.message : String(error);
+}
+
+export function toGitCommandError(error: unknown): GitCommandError {
+  return {
+    type: 'git-error',
+    message: gitErrorMessage(error),
+    stderr: error instanceof ExecError ? error.stderr : undefined,
+  };
+}
+
+export function classifyFetchError(error: unknown, remote: string | undefined): FetchError {
+  const commandError = toGitCommandError(error);
+  const message = commandError.message.toLowerCase();
+  if (message.includes('authentication') || message.includes('permission denied')) {
+    return { type: 'auth-failed', message: commandError.message };
+  }
+  if (message.includes('does not appear to be a git repository') || message.includes('not found')) {
+    return { type: 'remote-not-found', remote, message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifyFetchPrForReviewError(
+  error: unknown,
+  prNumber: number
+): FetchPrForReviewError {
+  const commandError = toGitCommandError(error);
+  const message = commandError.message.toLowerCase();
+  if (
+    message.includes('not found') ||
+    message.includes("couldn't find remote ref") ||
+    message.includes('unknown revision')
+  ) {
+    return { type: 'not-found', prNumber, message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifyCommitError(error: unknown): CommitError {
+  const commandError = toGitCommandError(error);
+  const message = commandError.message.toLowerCase();
+  if (message.includes('nothing to commit')) {
+    return { type: 'nothing-to-commit', message: commandError.message };
+  }
+  if (message.includes('empty commit message')) {
+    return { type: 'empty-message', message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifyPushError(error: unknown): PushError {
+  const commandError = toGitCommandError(error);
+  const message = commandError.message.toLowerCase();
+  if (message.includes('no upstream') || message.includes('no configured push destination')) {
+    return { type: 'no-upstream', message: commandError.message };
+  }
+  if (message.includes('rejected') || message.includes('non-fast-forward')) {
+    return { type: 'rejected', message: commandError.message };
+  }
+  if (message.includes('authentication') || message.includes('permission denied')) {
+    return { type: 'auth-failed', message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifyPullError(error: unknown): PullError {
+  const commandError = toGitCommandError(error);
+  const message = commandError.message.toLowerCase();
+  if (message.includes('conflict')) return { type: 'conflict', message: commandError.message };
+  if (message.includes('authentication') || message.includes('permission denied')) {
+    return { type: 'auth-failed', message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifyCreateBranchError(
+  error: unknown,
+  branch: string,
+  from: string
+): CreateBranchError {
+  const commandError = toGitCommandError(error);
+  const stderr = commandError.stderr ?? '';
+  if (stderr.includes('already exists')) {
+    return { type: 'already-exists', branch, message: commandError.message };
+  }
+  if (
+    stderr.includes('not a valid object name') ||
+    stderr.includes('Not a valid object name') ||
+    stderr.includes('invalid reference')
+  ) {
+    return { type: 'invalid-base', branch, from, message: commandError.message };
+  }
+  if (stderr.includes('not a valid branch name')) {
+    return { type: 'invalid-name', branch, message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifyRenameBranchError(
+  error: unknown,
+  oldBranch: string,
+  newBranch: string
+): RenameBranchError {
+  const commandError = toGitCommandError(error);
+  const stderr = commandError.stderr ?? '';
+  if (stderr.includes('already exists')) {
+    return { type: 'already-exists', branch: newBranch, message: commandError.message };
+  }
+  if (stderr.includes('No branch named')) {
+    return { type: 'not-found', branch: oldBranch, message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifyDeleteBranchError(error: unknown, branch: string): DeleteBranchError {
+  const commandError = toGitCommandError(error);
+  const stderr = commandError.stderr ?? '';
+  if (stderr.includes('not found')) {
+    return { type: 'not-found', branch, message: commandError.message };
+  }
+  if (stderr.includes('not fully merged')) {
+    return { type: 'not-merged', branch, message: commandError.message };
+  }
+  return commandError;
+}
+
+export function classifySoftResetError(error: unknown): SoftResetError {
+  return toGitCommandError(error);
+}

--- a/packages/shared/src/git/git-env.test.ts
+++ b/packages/shared/src/git/git-env.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import { gitEnv } from './git-env';
+
+describe('gitEnv', () => {
+  it('pins git output locale for stable parsing and error classification', () => {
+    expect(gitEnv({ LC_ALL: 'de_DE.UTF-8', LANG: 'de_DE.UTF-8' })).toMatchObject({
+      LC_ALL: 'C',
+      LANG: 'C',
+      LANGUAGE: 'C',
+      GIT_TERMINAL_PROMPT: '0',
+    });
+  });
+});

--- a/packages/shared/src/git/git-env.ts
+++ b/packages/shared/src/git/git-env.ts
@@ -1,0 +1,34 @@
+import { createBoundExec, type BoundExec } from '../exec';
+
+export type CreateGitExecOptions = {
+  cwd: string;
+  executable?: string;
+  env?: NodeJS.ProcessEnv;
+};
+
+/**
+ * Full child environment for git invocations. Git needs the process env (PATH, HOME,
+ * SSH_AUTH_SOCK, credential helpers), so it is composed in deliberately — exec itself
+ * never merges `process.env`.
+ */
+export function gitEnv(extra?: NodeJS.ProcessEnv): NodeJS.ProcessEnv {
+  return {
+    ...process.env,
+    ...extra,
+    LC_ALL: 'C',
+    LANG: 'C',
+    LANGUAGE: 'C',
+    GIT_TERMINAL_PROMPT: '0',
+    GCM_INTERACTIVE: 'never',
+    GIT_ASKPASS: '',
+    SSH_ASKPASS: '',
+  };
+}
+
+export function createGitExec(options: CreateGitExecOptions): BoundExec {
+  return createBoundExec({
+    file: options.executable ?? 'git',
+    cwd: options.cwd,
+    env: gitEnv(options.env),
+  });
+}

--- a/packages/shared/src/git/git-repository.test.ts
+++ b/packages/shared/src/git/git-repository.test.ts
@@ -100,7 +100,7 @@ describe('GitRepository', () => {
         ]),
       });
 
-      const created = await repository.createBranch('feature', 'main');
+      const created = await repository.createBranch({ name: 'feature', from: 'main' });
       expect(created).toMatchObject({
         success: true,
         data: { seqs: { refs: expect.any(Number) } },

--- a/packages/shared/src/git/git-repository.test.ts
+++ b/packages/shared/src/git/git-repository.test.ts
@@ -1,0 +1,257 @@
+import { execFile } from 'node:child_process';
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { FileWatchService } from '../fs';
+import { GitRuntime, type GitRepoUpdate } from './index';
+
+const execFileAsync = promisify(execFile);
+
+async function makeRepoWithRemote(): Promise<{ repo: string; remote: string }> {
+  const remote = await mkdtemp(path.join(tmpdir(), 'emdash-shared-remote-'));
+  await execFileAsync('git', ['init', '--bare'], { cwd: remote });
+
+  const repo = await mkdtemp(path.join(tmpdir(), 'emdash-shared-repo-'));
+  await execFileAsync('git', ['init', '-b', 'main'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repo });
+  await writeFile(path.join(repo, 'a.txt'), 'hello\n', 'utf8');
+  await execFileAsync('git', ['add', 'a.txt'], { cwd: repo });
+  await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repo });
+  await execFileAsync('git', ['remote', 'add', 'origin', remote], { cwd: repo });
+  await execFileAsync('git', ['push', '-u', 'origin', 'main'], { cwd: repo });
+  return { repo, remote };
+}
+
+async function pushRemoteBranch(remote: string): Promise<void> {
+  const clone = await mkdtemp(path.join(tmpdir(), 'emdash-shared-remote-work-'));
+  await execFileAsync('git', ['clone', remote, clone]);
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: clone });
+  await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: clone });
+  await execFileAsync('git', ['checkout', '-b', 'remote-feature'], { cwd: clone });
+  await writeFile(path.join(clone, 'remote.txt'), 'remote\n', 'utf8');
+  await execFileAsync('git', ['add', 'remote.txt'], { cwd: clone });
+  await execFileAsync('git', ['commit', '-m', 'remote branch'], { cwd: clone });
+  await execFileAsync('git', ['push', 'origin', 'remote-feature'], { cwd: clone });
+}
+
+async function exposeRemoteBranchAsPullRef(remote: string, prNumber: number): Promise<void> {
+  await pushRemoteBranch(remote);
+  await execFileAsync(
+    'git',
+    ['update-ref', `refs/pull/${prNumber}/head`, 'refs/heads/remote-feature'],
+    { cwd: remote }
+  );
+}
+
+async function eventually<T>(
+  read: () => T | undefined,
+  timeoutMs = 5_000,
+  intervalMs = 50
+): Promise<T> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const value = read();
+    if (value !== undefined) return value;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+describe('GitRepository', () => {
+  it('reads repository facts and emits updates after real git mutations', async () => {
+    const { repo, remote } = await makeRepoWithRemote();
+    const watch = new FileWatchService();
+    const runtime = new GitRuntime({ watch });
+    const updates: GitRepoUpdate[] = [];
+
+    try {
+      const lease = await runtime.openRepository(repo);
+      const repository = lease.value;
+      repository.subscribe((update) => updates.push(update));
+
+      await expect(repository.getRemotes()).resolves.toEqual({
+        remotes: [{ name: 'origin', url: remote }],
+      });
+      await expect(repository.getSnapshot()).resolves.toMatchObject({
+        refs: {
+          seq: expect.any(Number),
+          value: expect.objectContaining({ branches: expect.any(Array) }),
+        },
+        remotes: { seq: expect.any(Number), value: { remotes: [{ name: 'origin', url: remote }] } },
+      });
+      const subscribed = await repository.subscribeWithSnapshot((update) => updates.push(update));
+      expect(subscribed.snapshot).toMatchObject({
+        refs: { value: expect.objectContaining({ branches: expect.any(Array) }) },
+        remotes: { value: { remotes: [{ name: 'origin', url: remote }] } },
+      });
+      await expect(repository.readBlobAtRef('HEAD', 'a.txt')).resolves.toBe('hello\n');
+
+      expect(await repository.getRefs()).toMatchObject({
+        branches: expect.arrayContaining([
+          expect.objectContaining({ type: 'local', branch: 'main' }),
+          expect.objectContaining({
+            type: 'remote',
+            branch: 'main',
+            remote: { name: 'origin', url: remote },
+          }),
+        ]),
+      });
+
+      const created = await repository.createBranch('feature', 'main');
+      expect(created).toMatchObject({
+        success: true,
+        data: { seqs: { refs: expect.any(Number) } },
+      });
+      const snapshotAfterBranch = await repository.getSnapshot();
+      expect(snapshotAfterBranch.refs.seq).toBeGreaterThanOrEqual(1);
+      expect((await repository.getRefs()).branches).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'local', branch: 'feature' })])
+      );
+      expect(updates.some((update) => update.kind === 'refs')).toBe(true);
+
+      await pushRemoteBranch(remote);
+      await expect(repository.fetch('origin')).resolves.toMatchObject({ success: true });
+      expect((await repository.getRefs()).branches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'remote',
+            branch: 'remote-feature',
+            remote: { name: 'origin', url: remote },
+          }),
+        ])
+      );
+      expect(updates.some((update) => update.kind === 'refs')).toBe(true);
+      subscribed.unsubscribe();
+
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watch.dispose();
+    }
+  });
+
+  it('emits refs updates for external git mutations under the common dir', async () => {
+    const { repo } = await makeRepoWithRemote();
+    const watch = new FileWatchService();
+    const runtime = new GitRuntime({ watch });
+    const updates: GitRepoUpdate[] = [];
+
+    try {
+      const lease = await runtime.openRepository(repo);
+      lease.value.subscribe((update) => updates.push(update));
+
+      await execFileAsync('git', ['branch', 'external-change'], { cwd: repo });
+
+      // Subscribe pushes an initial refs model too, so wait for one containing the branch.
+      await eventually(() =>
+        updates.some(
+          (update) =>
+            update.kind === 'refs' &&
+            update.model.branches.some(
+              (branch) => branch.type === 'local' && branch.branch === 'external-change'
+            )
+        )
+          ? true
+          : undefined
+      );
+      expect((await lease.value.getRefs()).branches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ type: 'local', branch: 'external-change' }),
+        ])
+      );
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watch.dispose();
+    }
+  });
+
+  it('resolves the default branch and creates branches from refreshed remote refs', async () => {
+    const { repo, remote } = await makeRepoWithRemote();
+    await pushRemoteBranch(remote);
+    const runtime = new GitRuntime();
+
+    try {
+      const lease = await runtime.openRepository(repo);
+      const repository = lease.value;
+
+      await expect(repository.getDefaultBranch('origin')).resolves.toBe('main');
+      await expect(
+        repository.createBranch({
+          name: 'from-remote',
+          from: 'remote-feature',
+          remote: 'origin',
+          syncWithRemote: true,
+        })
+      ).resolves.toMatchObject({ success: true });
+      expect((await repository.getRefs()).branches).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'local', branch: 'from-remote' })])
+      );
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it('publishes a branch and refreshes remote refs', async () => {
+    const { repo, remote } = await makeRepoWithRemote();
+    await execFileAsync('git', ['checkout', '-b', 'publish-me'], { cwd: repo });
+    await writeFile(path.join(repo, 'published.txt'), 'published\n', 'utf8');
+    await execFileAsync('git', ['add', 'published.txt'], { cwd: repo });
+    await execFileAsync('git', ['commit', '-m', 'publish me'], { cwd: repo });
+    const runtime = new GitRuntime();
+
+    try {
+      const lease = await runtime.openRepository(repo);
+
+      await expect(lease.value.publishBranch('publish-me', 'origin')).resolves.toMatchObject({
+        success: true,
+      });
+      await expect(
+        execFileAsync('git', ['rev-parse', '--verify', 'refs/heads/publish-me'], { cwd: remote })
+      ).resolves.toMatchObject({ stdout: expect.stringMatching(/^[0-9a-f]{40}\n$/) });
+      expect((await lease.value.getRefs()).branches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            type: 'remote',
+            branch: 'publish-me',
+            remote: { name: 'origin', url: remote },
+          }),
+        ])
+      );
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it('fetches a pull request head into a review branch', async () => {
+    const { repo, remote } = await makeRepoWithRemote();
+    await exposeRemoteBranchAsPullRef(remote, 7);
+    const runtime = new GitRuntime();
+
+    try {
+      const lease = await runtime.openRepository(repo);
+
+      await expect(
+        lease.value.fetchPrForReview({
+          prNumber: 7,
+          headRefName: 'remote-feature',
+          headRepositoryUrl: remote,
+          localBranch: 'pr-7',
+          isFork: false,
+          configuredRemote: 'origin',
+        })
+      ).resolves.toMatchObject({ success: true });
+      expect((await lease.value.getRefs()).branches).toEqual(
+        expect.arrayContaining([expect.objectContaining({ type: 'local', branch: 'pr-7' })])
+      );
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+});

--- a/packages/shared/src/git/git-repository.test.ts
+++ b/packages/shared/src/git/git-repository.test.ts
@@ -63,8 +63,8 @@ async function eventually<T>(
 describe('GitRepository', () => {
   it('reads repository facts and emits updates after real git mutations', async () => {
     const { repo, remote } = await makeRepoWithRemote();
-    const watch = new FileWatchService();
-    const runtime = new GitRuntime({ watch });
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
     const updates: GitRepoUpdate[] = [];
 
     try {
@@ -129,14 +129,14 @@ describe('GitRepository', () => {
       lease.release();
     } finally {
       await runtime.dispose();
-      await watch.dispose();
+      await watcher.dispose();
     }
   });
 
   it('emits refs updates for external git mutations under the common dir', async () => {
     const { repo } = await makeRepoWithRemote();
-    const watch = new FileWatchService();
-    const runtime = new GitRuntime({ watch });
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
     const updates: GitRepoUpdate[] = [];
 
     try {
@@ -165,7 +165,7 @@ describe('GitRepository', () => {
       lease.release();
     } finally {
       await runtime.dispose();
-      await watch.dispose();
+      await watcher.dispose();
     }
   });
 

--- a/packages/shared/src/git/git-repository.ts
+++ b/packages/shared/src/git/git-repository.ts
@@ -1,6 +1,8 @@
 import type { BoundExec } from '../exec';
 import type { IFileWatchService, WatchHandle } from '../fs';
+import { realpathOrResolve } from '../fs';
 import { err, LiveModel, ok, type Result, type Unsubscribe } from '../lib';
+import type { KeyedMutex } from '../lib';
 import { CatFileBatch } from './cat-file-batch';
 import {
   classifyCreateBranchError,
@@ -50,8 +52,10 @@ export type GitRepositoryOptions = {
   gitCommonDir: string;
   objectStoreDir: string;
   exec: BoundExec;
-  watch: IFileWatchService;
-  runObjectStoreWrite: <T>(objectStoreDir: string, fn: () => Promise<T>) => Promise<T>;
+  /** Injected file-watch service; disposed by the injector, not this class. */
+  watcher: IFileWatchService;
+  /** Serializes concurrent fetch operations on the same object store directory. */
+  objectStoreMutex: KeyedMutex;
   onError?: GitOnError;
 };
 
@@ -59,10 +63,7 @@ export class GitRepository implements IGitRepository {
   readonly gitCommonDir: string;
   readonly objectStoreDir: string;
   private readonly exec: BoundExec;
-  private readonly runObjectStoreWrite: <T>(
-    objectStoreDir: string,
-    fn: () => Promise<T>
-  ) => Promise<T>;
+  private readonly objectStoreMutex: KeyedMutex;
   private readonly onError: GitOnError;
   private readonly refsModel: LiveModel<GitRefsModel>;
   private readonly remotesModel: LiveModel<GitRemotesModel>;
@@ -74,7 +75,7 @@ export class GitRepository implements IGitRepository {
     this.gitCommonDir = options.gitCommonDir;
     this.objectStoreDir = options.objectStoreDir;
     this.exec = options.exec;
-    this.runObjectStoreWrite = options.runObjectStoreWrite;
+    this.objectStoreMutex = options.objectStoreMutex;
     this.onError = options.onError ?? (() => {});
 
     this.refsModel = new LiveModel<GitRefsModel>({
@@ -90,7 +91,7 @@ export class GitRepository implements IGitRepository {
       onError: (error) => this.onError(`remotes ${this.gitCommonDir}`, error),
     });
 
-    this.commonDirWatch = options.watch.watch(
+    this.commonDirWatch = options.watcher.watch(
       this.gitCommonDir,
       (events) => {
         const classification = classifyGitWatchEvents(events, this.layout());
@@ -117,13 +118,6 @@ export class GitRepository implements IGitRepository {
     await this.commonDirWatch.ready();
   }
 
-  registerWorktree(id: string, registration: WorktreeWatchRegistration): Unsubscribe {
-    this.worktrees.set(id, registration);
-    return () => {
-      if (this.worktrees.get(id) === registration) this.worktrees.delete(id);
-    };
-  }
-
   async getRefs(): Promise<GitRefsModel> {
     return (await this.refsModel.get()).value;
   }
@@ -135,43 +129,6 @@ export class GitRepository implements IGitRepository {
   async getSnapshot(): Promise<GitRepoSnapshot> {
     const [refs, remotes] = await Promise.all([this.refsModel.get(), this.remotesModel.get()]);
     return { refs, remotes };
-  }
-
-  async refresh(): Promise<GitRepoSnapshot> {
-    const [refs, remotes] = await Promise.all([
-      this.refsModel.refresh(),
-      this.remotesModel.refresh(),
-    ]);
-    return { refs, remotes };
-  }
-
-  async refreshRefs(): Promise<number> {
-    return (await this.refsModel.refresh()).seq;
-  }
-
-  subscribe(cb: (update: GitRepoUpdate) => void): Unsubscribe {
-    const unsubscribeRefs = this.refsModel.subscribe(({ value, seq }) =>
-      cb({ kind: 'refs', model: value, seq })
-    );
-    const unsubscribeRemotes = this.remotesModel.subscribe(({ value, seq }) =>
-      cb({ kind: 'remotes', model: value, seq })
-    );
-    return () => {
-      unsubscribeRefs();
-      unsubscribeRemotes();
-    };
-  }
-
-  async subscribeWithSnapshot(
-    cb: (update: GitRepoUpdate) => void
-  ): Promise<SubscribedSnapshot<GitRepoSnapshot>> {
-    const unsubscribe = this.subscribe(cb);
-    try {
-      return { snapshot: await this.getSnapshot(), unsubscribe };
-    } catch (error) {
-      unsubscribe();
-      throw error;
-    }
   }
 
   async getDefaultBranch(remote = 'origin'): Promise<string> {
@@ -201,9 +158,68 @@ export class GitRepository implements IGitRepository {
     return 'main';
   }
 
+  async readBlobAtRef(ref: string, filePath: string): Promise<string | null> {
+    this.catFile ??= new CatFileBatch({ exec: this.exec });
+    try {
+      return await this.catFile.readText(`${ref}:${filePath}`);
+    } catch {
+      try {
+        const { stdout } = await this.exec.exec(['show', `${ref}:${filePath}`]);
+        return stdout;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  subscribe(cb: (update: GitRepoUpdate) => void): Unsubscribe {
+    const unsubscribeRefs = this.refsModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'refs', model: value, seq })
+    );
+    const unsubscribeRemotes = this.remotesModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'remotes', model: value, seq })
+    );
+    return () => {
+      unsubscribeRefs();
+      unsubscribeRemotes();
+    };
+  }
+
+  async subscribeWithSnapshot(
+    cb: (update: GitRepoUpdate) => void
+  ): Promise<SubscribedSnapshot<GitRepoSnapshot>> {
+    const unsubscribe = this.subscribe(cb);
+    try {
+      return { snapshot: await this.getSnapshot(), unsubscribe };
+    } catch (error) {
+      unsubscribe();
+      throw error;
+    }
+  }
+
+  registerWorktree(id: string, registration: WorktreeWatchRegistration): Unsubscribe {
+    this.worktrees.set(id, registration);
+    return () => {
+      if (this.worktrees.get(id) === registration) this.worktrees.delete(id);
+    };
+  }
+
+  async refresh(): Promise<GitRepoSnapshot> {
+    const [refs, remotes] = await Promise.all([
+      this.refsModel.refresh(),
+      this.remotesModel.refresh(),
+    ]);
+    return { refs, remotes };
+  }
+
+  async refreshRefs(): Promise<number> {
+    return (await this.refsModel.refresh()).seq;
+  }
+
   async fetch(remote?: string): Promise<Result<{ seqs: GitSeqs }, FetchError>> {
     try {
-      await this.runObjectStoreWrite(this.objectStoreDir, async () => {
+      const key = realpathOrResolve(this.objectStoreDir);
+      await this.objectStoreMutex.runExclusive(key, async () => {
         await this.exec.exec(['fetch', ...(remote ? [remote] : [])]);
       });
       return ok({ seqs: { refs: await this.refreshRefs() } });
@@ -356,20 +372,6 @@ export class GitRepository implements IGitRepository {
       });
     } catch (error) {
       return err(classifyPushError(error));
-    }
-  }
-
-  async readBlobAtRef(ref: string, filePath: string): Promise<string | null> {
-    this.catFile ??= new CatFileBatch({ exec: this.exec });
-    try {
-      return await this.catFile.readText(`${ref}:${filePath}`);
-    } catch {
-      try {
-        const { stdout } = await this.exec.exec(['show', `${ref}:${filePath}`]);
-        return stdout;
-      } catch {
-        return null;
-      }
     }
   }
 

--- a/packages/shared/src/git/git-repository.ts
+++ b/packages/shared/src/git/git-repository.ts
@@ -10,7 +10,6 @@ import {
   classifyFetchError,
   classifyFetchPrForReviewError,
   classifyPushError,
-  classifyRenameBranchError,
   toGitCommandError,
   type CreateBranchError,
   type DeleteBranchError,
@@ -18,7 +17,6 @@ import {
   type FetchPrForReviewError,
   type GitCommandError,
   type PushError,
-  type RenameBranchError,
 } from './errors';
 import type { GitBranch, GitRefsModel, GitRemote, GitRemotesModel } from './models/refs';
 import type {
@@ -259,18 +257,6 @@ export class GitRepository implements IGitRepository {
       return ok({ seqs: { refs: await this.refreshRefs() } });
     } catch (error) {
       return err(classifyCreateBranchError(error, name, from));
-    }
-  }
-
-  async renameBranch(
-    oldBranch: string,
-    newBranch: string
-  ): Promise<Result<{ seqs: GitSeqs }, RenameBranchError>> {
-    try {
-      await this.exec.exec(['branch', '-m', oldBranch, newBranch]);
-      return ok({ seqs: { refs: await this.refreshRefs() } });
-    } catch (error) {
-      return err(classifyRenameBranchError(error, oldBranch, newBranch));
     }
   }
 

--- a/packages/shared/src/git/git-repository.ts
+++ b/packages/shared/src/git/git-repository.ts
@@ -240,24 +240,7 @@ export class GitRepository implements IGitRepository {
 
   async createBranch(
     options: CreateBranchOptions
-  ): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
-  async createBranch(
-    name: string,
-    from?: string
-  ): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
-  async createBranch(
-    input: string | CreateBranchOptions,
-    fallbackFrom = 'HEAD'
   ): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>> {
-    const options =
-      typeof input === 'string'
-        ? { name: input, from: fallbackFrom, syncWithRemote: false, remote: undefined }
-        : {
-            name: input.name,
-            from: input.from ?? 'HEAD',
-            syncWithRemote: input.syncWithRemote ?? false,
-            remote: input.remote ?? 'origin',
-          };
     const name = options.name;
     const from = options.from ?? 'HEAD';
 

--- a/packages/shared/src/git/git-repository.ts
+++ b/packages/shared/src/git/git-repository.ts
@@ -1,0 +1,489 @@
+import type { BoundExec } from '../exec';
+import type { IFileWatchService, WatchHandle } from '../fs';
+import { err, LiveModel, ok, type Result, type Unsubscribe } from '../lib';
+import { CatFileBatch } from './cat-file-batch';
+import {
+  classifyCreateBranchError,
+  classifyDeleteBranchError,
+  classifyFetchError,
+  classifyFetchPrForReviewError,
+  classifyPushError,
+  classifyRenameBranchError,
+  toGitCommandError,
+  type CreateBranchError,
+  type DeleteBranchError,
+  type FetchError,
+  type FetchPrForReviewError,
+  type GitCommandError,
+  type PushError,
+  type RenameBranchError,
+} from './errors';
+import type { GitBranch, GitRefsModel, GitRemote, GitRemotesModel } from './models/refs';
+import type {
+  CreateBranchOptions,
+  FetchPrForReviewOptions,
+  GitRepoSnapshot,
+  GitRepoUpdate,
+  GitSeqs,
+  IGitRepository,
+  SubscribedSnapshot,
+} from './types';
+import { classifyGitWatchEvents, type WorktreeWatchEffects } from './watch/classifier';
+
+const WATCH_DEBOUNCE_MS = 100;
+const REVALIDATE_INTERVAL_MS = 5 * 60_000;
+
+export type GitOnError = (context: string, error: unknown) => void;
+
+/**
+ * Registration for worktrees served by this repository's `.git` watch. The repository owns
+ * the single commonDir watcher (linked-worktree git dirs live inside it, and the main
+ * worktree's git dir *is* it) and routes classified head/status effects to each worktree.
+ */
+export type WorktreeWatchRegistration = {
+  gitDir: string;
+  workTree: string;
+  onEffects: (effects: WorktreeWatchEffects) => void;
+};
+
+export type GitRepositoryOptions = {
+  gitCommonDir: string;
+  objectStoreDir: string;
+  exec: BoundExec;
+  watch: IFileWatchService;
+  runObjectStoreWrite: <T>(objectStoreDir: string, fn: () => Promise<T>) => Promise<T>;
+  onError?: GitOnError;
+};
+
+export class GitRepository implements IGitRepository {
+  readonly gitCommonDir: string;
+  readonly objectStoreDir: string;
+  private readonly exec: BoundExec;
+  private readonly runObjectStoreWrite: <T>(
+    objectStoreDir: string,
+    fn: () => Promise<T>
+  ) => Promise<T>;
+  private readonly onError: GitOnError;
+  private readonly refsModel: LiveModel<GitRefsModel>;
+  private readonly remotesModel: LiveModel<GitRemotesModel>;
+  private readonly commonDirWatch: WatchHandle;
+  private readonly worktrees = new Map<string, WorktreeWatchRegistration>();
+  private catFile: CatFileBatch | null = null;
+
+  constructor(options: GitRepositoryOptions) {
+    this.gitCommonDir = options.gitCommonDir;
+    this.objectStoreDir = options.objectStoreDir;
+    this.exec = options.exec;
+    this.runObjectStoreWrite = options.runObjectStoreWrite;
+    this.onError = options.onError ?? (() => {});
+
+    this.refsModel = new LiveModel<GitRefsModel>({
+      compute: () => this.computeRefs(),
+      debounceMs: WATCH_DEBOUNCE_MS,
+      revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
+      onError: (error) => this.onError(`refs ${this.gitCommonDir}`, error),
+    });
+    this.remotesModel = new LiveModel<GitRemotesModel>({
+      compute: () => this.computeRemotes(),
+      debounceMs: WATCH_DEBOUNCE_MS,
+      revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
+      onError: (error) => this.onError(`remotes ${this.gitCommonDir}`, error),
+    });
+
+    this.commonDirWatch = options.watch.watch(
+      this.gitCommonDir,
+      (events) => {
+        const classification = classifyGitWatchEvents(events, this.layout());
+        if (classification.repo.refs) this.refsModel.invalidate();
+        if (classification.repo.remotes) this.remotesModel.invalidate();
+        for (const [id, effects] of classification.worktrees) {
+          this.worktrees.get(id)?.onEffects(effects);
+        }
+      },
+      {
+        ignore: ['objects/**'],
+        onResync: () => {
+          this.refsModel.invalidate();
+          this.remotesModel.invalidate();
+          for (const registration of this.worktrees.values()) {
+            registration.onEffects({ status: true, head: true });
+          }
+        },
+      }
+    );
+  }
+
+  async ready(): Promise<void> {
+    await this.commonDirWatch.ready();
+  }
+
+  registerWorktree(id: string, registration: WorktreeWatchRegistration): Unsubscribe {
+    this.worktrees.set(id, registration);
+    return () => {
+      if (this.worktrees.get(id) === registration) this.worktrees.delete(id);
+    };
+  }
+
+  async getRefs(): Promise<GitRefsModel> {
+    return (await this.refsModel.get()).value;
+  }
+
+  async getRemotes(): Promise<GitRemotesModel> {
+    return (await this.remotesModel.get()).value;
+  }
+
+  async getSnapshot(): Promise<GitRepoSnapshot> {
+    const [refs, remotes] = await Promise.all([this.refsModel.get(), this.remotesModel.get()]);
+    return { refs, remotes };
+  }
+
+  async refresh(): Promise<GitRepoSnapshot> {
+    const [refs, remotes] = await Promise.all([
+      this.refsModel.refresh(),
+      this.remotesModel.refresh(),
+    ]);
+    return { refs, remotes };
+  }
+
+  async refreshRefs(): Promise<number> {
+    return (await this.refsModel.refresh()).seq;
+  }
+
+  subscribe(cb: (update: GitRepoUpdate) => void): Unsubscribe {
+    const unsubscribeRefs = this.refsModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'refs', model: value, seq })
+    );
+    const unsubscribeRemotes = this.remotesModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'remotes', model: value, seq })
+    );
+    return () => {
+      unsubscribeRefs();
+      unsubscribeRemotes();
+    };
+  }
+
+  async subscribeWithSnapshot(
+    cb: (update: GitRepoUpdate) => void
+  ): Promise<SubscribedSnapshot<GitRepoSnapshot>> {
+    const unsubscribe = this.subscribe(cb);
+    try {
+      return { snapshot: await this.getSnapshot(), unsubscribe };
+    } catch (error) {
+      unsubscribe();
+      throw error;
+    }
+  }
+
+  async getDefaultBranch(remote = 'origin'): Promise<string> {
+    try {
+      const { stdout } = await this.exec.exec([
+        'symbolic-ref',
+        `refs/remotes/${remote}/HEAD`,
+        '--short',
+      ]);
+      const ref = stdout.trim();
+      if (ref) {
+        const slash = ref.indexOf('/');
+        return slash === -1 ? ref : ref.slice(slash + 1);
+      }
+    } catch {}
+
+    try {
+      const { stdout } = await this.exec.exec(['remote', 'show', remote]);
+      const match = /HEAD branch:\s*(\S+)/.exec(stdout);
+      if (match?.[1]) return match[1];
+    } catch {}
+
+    for (const candidate of ['main', 'master', 'develop', 'trunk']) {
+      if (await this.branchExistsLocally(candidate)) return candidate;
+    }
+
+    return 'main';
+  }
+
+  async fetch(remote?: string): Promise<Result<{ seqs: GitSeqs }, FetchError>> {
+    try {
+      await this.runObjectStoreWrite(this.objectStoreDir, async () => {
+        await this.exec.exec(['fetch', ...(remote ? [remote] : [])]);
+      });
+      return ok({ seqs: { refs: await this.refreshRefs() } });
+    } catch (error) {
+      return err(classifyFetchError(error, remote));
+    }
+  }
+
+  async addRemote(name: string, url: string): Promise<Result<{ seqs: GitSeqs }, GitCommandError>> {
+    try {
+      await this.exec.exec(['remote', 'add', name, url]);
+      const remotes = await this.remotesModel.refresh();
+      return ok({ seqs: { remotes: remotes.seq } });
+    } catch (error) {
+      return err(toGitCommandError(error));
+    }
+  }
+
+  async createBranch(
+    options: CreateBranchOptions
+  ): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
+  async createBranch(
+    name: string,
+    from?: string
+  ): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
+  async createBranch(
+    input: string | CreateBranchOptions,
+    fallbackFrom = 'HEAD'
+  ): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>> {
+    const options =
+      typeof input === 'string'
+        ? { name: input, from: fallbackFrom, syncWithRemote: false, remote: undefined }
+        : {
+            name: input.name,
+            from: input.from ?? 'HEAD',
+            syncWithRemote: input.syncWithRemote ?? false,
+            remote: input.remote ?? 'origin',
+          };
+    const name = options.name;
+    const from = options.from ?? 'HEAD';
+
+    if (options.syncWithRemote) {
+      const remote = options.remote ?? 'origin';
+      const fetchResult = await this.fetch(remote);
+      if (!fetchResult.success) {
+        return err({ type: 'fetch-failed', remote, branch: from, error: fetchResult.error });
+      }
+    }
+
+    const base = options.syncWithRemote ? `${options.remote ?? 'origin'}/${from}` : from;
+    try {
+      await this.exec.exec(['branch', '--no-track', name, base]);
+      await this.setBranchBaseConfig(name, base);
+      return ok({ seqs: { refs: await this.refreshRefs() } });
+    } catch (error) {
+      return err(classifyCreateBranchError(error, name, from));
+    }
+  }
+
+  async renameBranch(
+    oldBranch: string,
+    newBranch: string
+  ): Promise<Result<{ seqs: GitSeqs }, RenameBranchError>> {
+    try {
+      await this.exec.exec(['branch', '-m', oldBranch, newBranch]);
+      return ok({ seqs: { refs: await this.refreshRefs() } });
+    } catch (error) {
+      return err(classifyRenameBranchError(error, oldBranch, newBranch));
+    }
+  }
+
+  async deleteBranch(
+    branch: string,
+    force = false
+  ): Promise<Result<{ seqs: GitSeqs }, DeleteBranchError>> {
+    try {
+      await this.exec.exec(['branch', force ? '-D' : '-d', branch]);
+      return ok({ seqs: { refs: await this.refreshRefs() } });
+    } catch (error) {
+      return err(classifyDeleteBranchError(error, branch));
+    }
+  }
+
+  async fetchPrForReview(
+    options: FetchPrForReviewOptions
+  ): Promise<Result<{ seqs: GitSeqs }, FetchPrForReviewError>> {
+    try {
+      if (options.isFork) {
+        const forkRemote = remoteNameForRepositoryUrl(options.headRepositoryUrl);
+        const remotes = await this.exec.exec(['remote']).catch(() => ({ stdout: '' }));
+        const names = remotes.stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+        if (names.includes(forkRemote)) {
+          await this.exec.exec(['remote', 'set-url', forkRemote, options.headRepositoryUrl]);
+        } else {
+          await this.exec.exec(['remote', 'add', forkRemote, options.headRepositoryUrl]);
+        }
+        await this.exec.exec([
+          'fetch',
+          forkRemote,
+          `${options.headRefName}:refs/heads/${options.localBranch}`,
+          '--force',
+        ]);
+        await this.exec
+          .exec([
+            'branch',
+            `--set-upstream-to=${forkRemote}/${options.headRefName}`,
+            options.localBranch,
+          ])
+          .catch(() => ({ stdout: '', stderr: '' }));
+        const [refs, remotes2] = await Promise.all([
+          this.refsModel.refresh(),
+          this.remotesModel.refresh(),
+        ]);
+        return ok({ seqs: { refs: refs.seq, remotes: remotes2.seq } });
+      }
+
+      const remote = options.configuredRemote ?? 'origin';
+      await this.exec.exec([
+        'fetch',
+        remote,
+        `refs/pull/${options.prNumber}/head:refs/heads/${options.localBranch}`,
+        '--force',
+      ]);
+      await this.exec
+        .exec(['branch', `--set-upstream-to=${remote}/${options.headRefName}`, options.localBranch])
+        .catch(() => ({ stdout: '', stderr: '' }));
+      return ok({ seqs: { refs: await this.refreshRefs() } });
+    } catch (error) {
+      return err(classifyFetchPrForReviewError(error, options.prNumber));
+    }
+  }
+
+  async publishBranch(
+    branchName: string,
+    remote = 'origin'
+  ): Promise<Result<{ output: string; seqs: GitSeqs }, PushError>> {
+    try {
+      const { stdout, stderr } = await this.exec.exec([
+        'push',
+        '--set-upstream',
+        remote,
+        branchName,
+      ]);
+      return ok({
+        output: (stdout || stderr).trim(),
+        seqs: { refs: await this.refreshRefs() },
+      });
+    } catch (error) {
+      return err(classifyPushError(error));
+    }
+  }
+
+  async readBlobAtRef(ref: string, filePath: string): Promise<string | null> {
+    this.catFile ??= new CatFileBatch({ exec: this.exec });
+    try {
+      return await this.catFile.readText(`${ref}:${filePath}`);
+    } catch {
+      try {
+        const { stdout } = await this.exec.exec(['show', `${ref}:${filePath}`]);
+        return stdout;
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  dispose(): void {
+    this.commonDirWatch.release();
+    this.refsModel.dispose();
+    this.remotesModel.dispose();
+    this.worktrees.clear();
+    this.catFile?.dispose();
+    this.catFile = null;
+  }
+
+  private layout() {
+    return {
+      gitCommonDir: this.gitCommonDir,
+      worktrees: [...this.worktrees.entries()].map(([id, registration]) => ({
+        id,
+        gitDir: registration.gitDir,
+        workTree: registration.workTree,
+      })),
+    };
+  }
+
+  private async computeRefs(): Promise<GitRefsModel> {
+    const remotes = await this.getRemotes();
+    const remoteByName = new Map(remotes.remotes.map((remote) => [remote.name, remote]));
+    const { stdout } = await this.exec.exec([
+      'branch',
+      '-a',
+      '--format=%(refname)|%(refname:short)|%(upstream:short)|%(upstream:track)',
+    ]);
+    const branches: GitBranch[] = [];
+
+    for (const line of stdout.trim().split('\n').filter(Boolean)) {
+      const [fullRef, shortRef, upstreamRef, upstreamTrack] = line.split('|');
+      if (!fullRef || !shortRef) continue;
+      if (fullRef.startsWith('refs/remotes/')) {
+        const remoteBranch = fullRef.slice('refs/remotes/'.length);
+        if (remoteBranch.endsWith('/HEAD')) continue;
+        const slash = remoteBranch.indexOf('/');
+        if (slash === -1) continue;
+        const remoteName = remoteBranch.slice(0, slash);
+        const branch = remoteBranch.slice(slash + 1);
+        branches.push({
+          type: 'remote',
+          branch,
+          remote: remoteByName.get(remoteName) ?? { name: remoteName, url: '' },
+        });
+        continue;
+      }
+
+      if (!fullRef.startsWith('refs/heads/')) continue;
+      const branch: GitBranch = { type: 'local', branch: shortRef };
+      if (upstreamRef) {
+        const slash = upstreamRef.indexOf('/');
+        const remoteName = slash === -1 ? upstreamRef : upstreamRef.slice(0, slash);
+        branch.remote = remoteByName.get(remoteName) ?? { name: remoteName, url: '' };
+      }
+      const divergence = parseDivergence(upstreamTrack ?? '');
+      if (divergence) {
+        Object.assign(branch, { divergence });
+      }
+      branches.push(branch);
+    }
+
+    return { branches };
+  }
+
+  private async computeRemotes(): Promise<GitRemotesModel> {
+    const { stdout } = await this.exec.exec(['remote', '-v']);
+    const seen = new Set<string>();
+    const remotes: GitRemote[] = [];
+
+    for (const line of stdout.trim().split('\n').filter(Boolean)) {
+      const match = /^(\S+)\s+(\S+)\s+\((fetch|push)\)$/.exec(line);
+      if (!match || match[3] !== 'fetch') continue;
+      const name = match[1]!;
+      if (seen.has(name)) continue;
+      seen.add(name);
+      remotes.push({ name, url: match[2]! });
+    }
+
+    return { remotes };
+  }
+
+  private async branchExistsLocally(branch: string): Promise<boolean> {
+    try {
+      await this.exec.exec(['rev-parse', '--verify', `refs/heads/${branch}`]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  private async setBranchBaseConfig(branchName: string, baseRef: string): Promise<void> {
+    try {
+      await this.exec.exec(['config', `branch.${branchName}.base`, baseRef]);
+    } catch {}
+  }
+}
+
+function remoteNameForRepositoryUrl(url: string): string {
+  const withoutSuffix = url.replace(/\.git$/, '');
+  const tail = withoutSuffix.split(/[/:]/).filter(Boolean).slice(-2).join('-');
+  return `fork-${tail || 'remote'}`.replace(/[^A-Za-z0-9._-]/g, '-');
+}
+
+function parseDivergence(upstreamTrack: string): { ahead: number; behind: number } | undefined {
+  if (!upstreamTrack) return undefined;
+  const ahead = /ahead (\d+)/.exec(upstreamTrack)?.[1];
+  const behind = /behind (\d+)/.exec(upstreamTrack)?.[1];
+  if (!ahead && !behind) return undefined;
+  return {
+    ahead: ahead ? Number.parseInt(ahead, 10) : 0,
+    behind: behind ? Number.parseInt(behind, 10) : 0,
+  };
+}

--- a/packages/shared/src/git/git-repository.ts
+++ b/packages/shared/src/git/git-repository.ts
@@ -44,7 +44,7 @@ export type GitOnError = (context: string, error: unknown) => void;
  */
 export type WorktreeWatchRegistration = {
   gitDir: string;
-  workTree: string;
+  worktree: string;
   onEffects: (effects: WorktreeWatchEffects) => void;
 };
 
@@ -373,7 +373,7 @@ export class GitRepository implements IGitRepository {
       worktrees: [...this.worktrees.entries()].map(([id, registration]) => ({
         id,
         gitDir: registration.gitDir,
-        workTree: registration.workTree,
+        worktree: registration.worktree,
       })),
     };
   }

--- a/packages/shared/src/git/git-runtime.test.ts
+++ b/packages/shared/src/git/git-runtime.test.ts
@@ -38,8 +38,8 @@ describe('GitRuntime', () => {
     const linked = await mkdtemp(path.join(tmpdir(), 'emdash-shared-runtime-linked-'));
     await execFileAsync('git', ['worktree', 'add', linked, '-b', 'feature'], { cwd: repo });
 
-    const watch = new FileWatchService();
-    const runtime = new GitRuntime({ watch });
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
     try {
       const repoLease = await runtime.openRepository(repo);
       const worktreeLease = await runtime.openWorktree(linked);
@@ -52,7 +52,7 @@ describe('GitRuntime', () => {
       repoLease.release();
     } finally {
       await runtime.dispose();
-      await watch.dispose();
+      await watcher.dispose();
     }
   });
 

--- a/packages/shared/src/git/git-runtime.test.ts
+++ b/packages/shared/src/git/git-runtime.test.ts
@@ -1,0 +1,74 @@
+import { execFile } from 'node:child_process';
+import { chmod, mkdtemp, readFile, realpath, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { FileWatchService } from '../fs';
+import { GitRuntime } from './index';
+
+const execFileAsync = promisify(execFile);
+
+async function makeRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), 'emdash-shared-runtime-'));
+  await execFileAsync('git', ['init', '-b', 'main'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repo });
+  return repo;
+}
+
+async function makeRecordingGitExecutable(): Promise<{ executable: string; logPath: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'emdash-shared-runtime-git-bin-'));
+  const executable = path.join(dir, 'git-wrapper.sh');
+  const logPath = path.join(dir, 'git-calls.log');
+  await writeFile(
+    executable,
+    ['#!/bin/sh', `printf '%s\\n' "$*" >> ${JSON.stringify(logPath)}`, 'exec git "$@"', ''].join(
+      '\n'
+    ),
+    'utf8'
+  );
+  await chmod(executable, 0o755);
+  return { executable, logPath };
+}
+
+describe('GitRuntime', () => {
+  it('deduplicates repositories by common git dir and releases them by lease', async () => {
+    const repo = await makeRepo();
+    const linked = await mkdtemp(path.join(tmpdir(), 'emdash-shared-runtime-linked-'));
+    await execFileAsync('git', ['worktree', 'add', linked, '-b', 'feature'], { cwd: repo });
+
+    const watch = new FileWatchService();
+    const runtime = new GitRuntime({ watch });
+    try {
+      const repoLease = await runtime.openRepository(repo);
+      const worktreeLease = await runtime.openWorktree(linked);
+      const commonDir = await realpath(path.join(repo, '.git'));
+
+      expect(repoLease.value.gitCommonDir).toBe(commonDir);
+      expect(worktreeLease.value.repository).toBe(repoLease.value);
+
+      worktreeLease.release();
+      repoLease.release();
+    } finally {
+      await runtime.dispose();
+      await watch.dispose();
+    }
+  });
+
+  it('resolves git identity once when opening a cold worktree', async () => {
+    const repo = await makeRepo();
+    const { executable, logPath } = await makeRecordingGitExecutable();
+    const runtime = new GitRuntime({ executable });
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+
+    const calls = (await readFile(logPath, 'utf8')).trim().split('\n').filter(Boolean);
+    expect(calls.filter((call) => call.startsWith('rev-parse '))).toHaveLength(4);
+  });
+});

--- a/packages/shared/src/git/git-runtime.ts
+++ b/packages/shared/src/git/git-runtime.ts
@@ -1,8 +1,13 @@
-import { realpathSync } from 'node:fs';
 import path from 'node:path';
 import type { BoundExec } from '../exec';
-import { FileWatchService, FsService, type IFileWatchService, type IFsService } from '../fs';
-import { ResourceMap, type Lease } from '../lib';
+import {
+  FileWatchService,
+  FsService,
+  realpathOrResolve,
+  type IFileWatchService,
+  type IFsService,
+} from '../fs';
+import { KeyedMutex, ResourceMap, type Lease } from '../lib';
 import { createGitExec } from './git-env';
 import { GitRepository, type GitOnError } from './git-repository';
 import { GitWorktree } from './git-worktree';
@@ -22,7 +27,11 @@ type GitIdentity = {
 
 export type GitRuntimeOptions = {
   fs?: IFsService;
-  watch?: IFileWatchService;
+  /**
+   * File-watch service to use. Injected services are disposed by the injector;
+   * when omitted, the runtime creates and disposes its own service.
+   */
+  watcher?: IFileWatchService;
   executable?: string;
   env?: NodeJS.ProcessEnv;
   exec?: BoundExec;
@@ -32,20 +41,20 @@ export type GitRuntimeOptions = {
 export class GitRuntime implements IGitRuntime {
   private readonly repositories: ResourceMap<GitRepository>;
   private readonly worktrees: ResourceMap<WorktreeResource>;
-  private readonly objectStoreLocks = new Map<string, Promise<unknown>>();
+  private readonly mutex: KeyedMutex;
   private readonly exec: BoundExec;
   private readonly fs: IFsService;
-  private readonly watch: IFileWatchService;
-  private readonly ownedWatch: FileWatchService | null;
+  private readonly watcher: IFileWatchService;
+  private readonly ownsWatcher: boolean;
   private readonly onError: GitOnError;
   private disposeRequested = false;
 
   constructor(options: GitRuntimeOptions = {}) {
     this.onError = options.onError ?? (() => {});
-    const ownedWatch = options.watch ? null : new FileWatchService({ onError: this.onError });
-    this.ownedWatch = ownedWatch;
-    this.watch = options.watch ?? (ownedWatch as FileWatchService);
+    this.ownsWatcher = !options.watcher;
+    this.watcher = options.watcher ?? new FileWatchService({ onError: this.onError });
     this.fs = options.fs ?? new FsService();
+    this.mutex = new KeyedMutex();
     this.exec =
       options.exec ??
       createGitExec({
@@ -93,7 +102,7 @@ export class GitRuntime implements IGitRuntime {
           repository: repositoryLease.value,
           exec: this.exec.withCwd(identity.topLevel),
           fs: this.fs,
-          watch: this.watch,
+          watcher: this.watcher,
           onError: this.onError,
         });
         try {
@@ -124,8 +133,8 @@ export class GitRuntime implements IGitRuntime {
         gitCommonDir: identity.gitCommonDir,
         objectStoreDir: identity.objectStoreDir,
         exec: this.exec.withCwd(identity.topLevel),
-        watch: this.watch,
-        runObjectStoreWrite: (objectStoreDir, fn) => this.runObjectStoreWrite(objectStoreDir, fn),
+        watcher: this.watcher,
+        objectStoreMutex: this.mutex,
         onError: this.onError,
       });
       try {
@@ -136,28 +145,6 @@ export class GitRuntime implements IGitRuntime {
       }
       return repository;
     });
-  }
-
-  private async runObjectStoreWrite<T>(objectStoreDir: string, fn: () => Promise<T>): Promise<T> {
-    const key = realpathOrResolve(objectStoreDir);
-    const previous = this.objectStoreLocks.get(key) ?? Promise.resolve();
-
-    let release: () => void = () => {};
-    const current = new Promise<void>((resolve) => {
-      release = resolve;
-    });
-    const chained = previous.catch(() => {}).then(() => current);
-    this.objectStoreLocks.set(key, chained);
-
-    await previous.catch(() => {});
-    try {
-      return await fn();
-    } finally {
-      release();
-      if (this.objectStoreLocks.get(key) === chained) {
-        this.objectStoreLocks.delete(key);
-      }
-    }
   }
 
   private async resolveIdentity(pathInsideRepo: string): Promise<GitIdentity> {
@@ -193,19 +180,6 @@ export class GitRuntime implements IGitRuntime {
   private async disposeIfIdle(): Promise<void> {
     if (!this.disposeRequested) return;
     if (!this.worktrees.idle || !this.repositories.idle) return;
-    this.objectStoreLocks.clear();
-    await this.ownedWatch?.dispose();
-  }
-}
-
-function realpathOrResolve(filePath: string): string {
-  try {
-    return realpathSync.native(filePath);
-  } catch {
-    try {
-      return realpathSync(filePath);
-    } catch {
-      return path.resolve(filePath);
-    }
+    if (this.ownsWatcher) await this.watcher.dispose();
   }
 }

--- a/packages/shared/src/git/git-runtime.ts
+++ b/packages/shared/src/git/git-runtime.ts
@@ -97,7 +97,7 @@ export class GitRuntime implements IGitRuntime {
       const repositoryLease = await this.acquireRepository(identity);
       try {
         const worktree = new GitWorktree({
-          workTree: identity.topLevel,
+          worktree: identity.topLevel,
           gitDir: identity.gitDir,
           repository: repositoryLease.value,
           exec: this.exec.withCwd(identity.topLevel),

--- a/packages/shared/src/git/git-runtime.ts
+++ b/packages/shared/src/git/git-runtime.ts
@@ -1,0 +1,211 @@
+import { realpathSync } from 'node:fs';
+import path from 'node:path';
+import type { BoundExec } from '../exec';
+import { FileWatchService, FsService, type IFileWatchService, type IFsService } from '../fs';
+import { ResourceMap, type Lease } from '../lib';
+import { createGitExec } from './git-env';
+import { GitRepository, type GitOnError } from './git-repository';
+import { GitWorktree } from './git-worktree';
+import type { IGitRuntime, RepoLease, WorktreeLease } from './types';
+
+type WorktreeResource = {
+  worktree: GitWorktree;
+  repositoryLease: Lease<GitRepository>;
+};
+
+type GitIdentity = {
+  topLevel: string;
+  gitDir: string;
+  gitCommonDir: string;
+  objectStoreDir: string;
+};
+
+export type GitRuntimeOptions = {
+  fs?: IFsService;
+  watch?: IFileWatchService;
+  executable?: string;
+  env?: NodeJS.ProcessEnv;
+  exec?: BoundExec;
+  onError?: GitOnError;
+};
+
+export class GitRuntime implements IGitRuntime {
+  private readonly repositories: ResourceMap<GitRepository>;
+  private readonly worktrees: ResourceMap<WorktreeResource>;
+  private readonly objectStoreLocks = new Map<string, Promise<unknown>>();
+  private readonly exec: BoundExec;
+  private readonly fs: IFsService;
+  private readonly watch: IFileWatchService;
+  private readonly ownedWatch: FileWatchService | null;
+  private readonly onError: GitOnError;
+  private disposeRequested = false;
+
+  constructor(options: GitRuntimeOptions = {}) {
+    this.onError = options.onError ?? (() => {});
+    const ownedWatch = options.watch ? null : new FileWatchService({ onError: this.onError });
+    this.ownedWatch = ownedWatch;
+    this.watch = options.watch ?? (ownedWatch as FileWatchService);
+    this.fs = options.fs ?? new FsService();
+    this.exec =
+      options.exec ??
+      createGitExec({
+        cwd: process.cwd(),
+        executable: options.executable,
+        env: options.env,
+      });
+
+    this.repositories = new ResourceMap<GitRepository>({
+      teardown: (_key, repository) => {
+        repository.dispose();
+      },
+      onError: this.onError,
+      onEmpty: () => {
+        void this.disposeIfIdle();
+      },
+    });
+    this.worktrees = new ResourceMap<WorktreeResource>({
+      teardown: (_key, resource) => {
+        resource.worktree.dispose();
+        resource.repositoryLease.release();
+      },
+      onError: this.onError,
+      onEmpty: () => {
+        void this.disposeIfIdle();
+      },
+    });
+  }
+
+  async openRepository(pathInsideRepo: string): Promise<RepoLease> {
+    this.assertOpen();
+    const identity = await this.resolveIdentity(pathInsideRepo);
+    return this.acquireRepository(identity);
+  }
+
+  async openWorktree(worktreePath: string): Promise<WorktreeLease> {
+    this.assertOpen();
+    const identity = await this.resolveIdentity(worktreePath);
+    const lease = await this.worktrees.acquire(identity.topLevel, async () => {
+      const repositoryLease = await this.acquireRepository(identity);
+      try {
+        const worktree = new GitWorktree({
+          workTree: identity.topLevel,
+          gitDir: identity.gitDir,
+          repository: repositoryLease.value,
+          exec: this.exec.withCwd(identity.topLevel),
+          fs: this.fs,
+          watch: this.watch,
+          onError: this.onError,
+        });
+        try {
+          await worktree.ready();
+        } catch (error) {
+          worktree.dispose();
+          throw error;
+        }
+        return { worktree, repositoryLease };
+      } catch (error) {
+        repositoryLease.release();
+        throw error;
+      }
+    });
+    return { value: lease.value.worktree, release: lease.release };
+  }
+
+  async dispose(): Promise<void> {
+    this.disposeRequested = true;
+    this.repositories.dispose();
+    this.worktrees.dispose();
+    await this.disposeIfIdle();
+  }
+
+  private async acquireRepository(identity: GitIdentity): Promise<Lease<GitRepository>> {
+    return this.repositories.acquire(identity.gitCommonDir, async () => {
+      const repository = new GitRepository({
+        gitCommonDir: identity.gitCommonDir,
+        objectStoreDir: identity.objectStoreDir,
+        exec: this.exec.withCwd(identity.topLevel),
+        watch: this.watch,
+        runObjectStoreWrite: (objectStoreDir, fn) => this.runObjectStoreWrite(objectStoreDir, fn),
+        onError: this.onError,
+      });
+      try {
+        await repository.ready();
+      } catch (error) {
+        repository.dispose();
+        throw error;
+      }
+      return repository;
+    });
+  }
+
+  private async runObjectStoreWrite<T>(objectStoreDir: string, fn: () => Promise<T>): Promise<T> {
+    const key = realpathOrResolve(objectStoreDir);
+    const previous = this.objectStoreLocks.get(key) ?? Promise.resolve();
+
+    let release: () => void = () => {};
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const chained = previous.catch(() => {}).then(() => current);
+    this.objectStoreLocks.set(key, chained);
+
+    await previous.catch(() => {});
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.objectStoreLocks.get(key) === chained) {
+        this.objectStoreLocks.delete(key);
+      }
+    }
+  }
+
+  private async resolveIdentity(pathInsideRepo: string): Promise<GitIdentity> {
+    const cwd = path.resolve(pathInsideRepo);
+    const exec = this.exec.withCwd(cwd);
+    const [topLevel, gitDir, gitCommonDir, objectStoreDir] = await Promise.all([
+      exec.exec(['rev-parse', '--show-toplevel']).then((result) => result.stdout.trim()),
+      exec
+        .exec(['rev-parse', '--path-format=absolute', '--git-dir'])
+        .then((result) => result.stdout.trim()),
+      exec
+        .exec(['rev-parse', '--path-format=absolute', '--git-common-dir'])
+        .then((result) => result.stdout.trim()),
+      exec
+        .exec(['rev-parse', '--path-format=absolute', '--git-path', 'objects'])
+        .then((result) => result.stdout.trim()),
+    ]);
+
+    return {
+      topLevel: realpathOrResolve(topLevel),
+      gitDir: realpathOrResolve(gitDir),
+      gitCommonDir: realpathOrResolve(gitCommonDir),
+      objectStoreDir: realpathOrResolve(objectStoreDir),
+    };
+  }
+
+  private assertOpen(): void {
+    if (this.disposeRequested) {
+      throw new Error('GitRuntime disposed');
+    }
+  }
+
+  private async disposeIfIdle(): Promise<void> {
+    if (!this.disposeRequested) return;
+    if (!this.worktrees.idle || !this.repositories.idle) return;
+    this.objectStoreLocks.clear();
+    await this.ownedWatch?.dispose();
+  }
+}
+
+function realpathOrResolve(filePath: string): string {
+  try {
+    return realpathSync.native(filePath);
+  } catch {
+    try {
+      return realpathSync(filePath);
+    } catch {
+      return path.resolve(filePath);
+    }
+  }
+}

--- a/packages/shared/src/git/git-worktree.test.ts
+++ b/packages/shared/src/git/git-worktree.test.ts
@@ -106,13 +106,6 @@ describe('GitWorktree', () => {
       expect(changedStatus).not.toHaveProperty('headKind');
       expect(changedStatus).not.toHaveProperty('shortHash');
 
-      const diff = await worktree.getFileDiff('tracked.txt');
-      expect(diff.lines).toEqual(
-        expect.arrayContaining([
-          { left: 'before', type: 'del' },
-          { right: 'after', type: 'add' },
-        ])
-      );
       await expect(worktree.getFileAtRef('tracked.txt', 'HEAD')).resolves.toBe('before\n');
       await expect(worktree.getChangedFiles({ kind: 'head' })).resolves.toEqual([
         expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
@@ -131,10 +124,7 @@ describe('GitWorktree', () => {
       });
       expect(await worktree.getStatus()).not.toHaveProperty('totalAdded');
       expect(await worktree.getStatus()).not.toHaveProperty('totalDeleted');
-      await expect(worktree.getFileDiff('tracked.txt', 'STAGED')).resolves.toMatchObject({
-        originalContent: 'before',
-        modifiedContent: 'after',
-      });
+      await expect(worktree.getFileAtIndex('tracked.txt')).resolves.toBe('after\n');
       await expect(worktree.getChangedFiles({ kind: 'staged' })).resolves.toEqual([
         expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
       ]);
@@ -168,12 +158,6 @@ describe('GitWorktree', () => {
       await expect(worktree.getCommitFiles(commit.data.hash)).resolves.toEqual([
         expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
       ]);
-      await expect(
-        worktree.getCommitFileDiff(commit.data.hash, 'tracked.txt')
-      ).resolves.toMatchObject({
-        originalContent: 'before',
-        modifiedContent: 'after',
-      });
 
       expect(updates.some((update) => update.kind === 'head')).toBe(true);
       expect(repoUpdates.some((update) => update.kind === 'refs')).toBe(true);
@@ -431,35 +415,6 @@ describe('GitWorktree', () => {
       await expect(readFile(path.join(repo, 'untracked.txt'), 'utf8')).rejects.toThrow();
       await expect(readFile(path.join(repo, 'extra.txt'), 'utf8')).rejects.toThrow();
 
-      lease.release();
-    } finally {
-      await runtime.dispose();
-    }
-  });
-
-  it('soft-resets the latest unpushed commit and returns its message', async () => {
-    const repo = await makeRepo();
-    const runtime = new GitRuntime();
-
-    try {
-      const lease = await runtime.openWorktree(repo);
-      await writeFile(path.join(repo, 'tracked.txt'), 'soft reset\n', 'utf8');
-      await lease.value.stage(['tracked.txt']);
-      const commit = await lease.value.commit('soft reset me\n\nbody text');
-      expect(commit.success).toBe(true);
-
-      await expect(lease.value.softReset()).resolves.toMatchObject({
-        success: true,
-        data: {
-          subject: 'soft reset me',
-          body: 'body text',
-          seqs: { status: expect.any(Number), head: expect.any(Number), refs: expect.any(Number) },
-        },
-      });
-      await expect(lease.value.getStatus()).resolves.toMatchObject({
-        kind: 'ok',
-        staged: [expect.objectContaining({ path: 'tracked.txt', status: 'modified' })],
-      });
       lease.release();
     } finally {
       await runtime.dispose();

--- a/packages/shared/src/git/git-worktree.test.ts
+++ b/packages/shared/src/git/git-worktree.test.ts
@@ -353,6 +353,90 @@ describe('GitWorktree', () => {
     }
   });
 
+  it('stageAll, unstageAll, and revertAll mutate the full worktree state', async () => {
+    const repo = await makeRepo();
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      const worktree = lease.value;
+
+      await writeFile(path.join(repo, 'tracked.txt'), 'modified\n', 'utf8');
+      await writeFile(path.join(repo, 'untracked.txt'), 'new\n', 'utf8');
+      await writeFile(path.join(repo, 'to-delete.txt'), 'gone\n', 'utf8');
+      await execFileAsync('git', ['add', 'to-delete.txt'], { cwd: repo });
+      await execFileAsync('git', ['commit', '-m', 'add to-delete'], { cwd: repo });
+      await rm(path.join(repo, 'to-delete.txt'));
+
+      const stageAllSeqs = await worktree.stageAll();
+      expect(stageAllSeqs.status).toBeGreaterThanOrEqual(1);
+      expect(await worktree.getStatus()).toMatchObject({
+        kind: 'ok',
+        staged: expect.arrayContaining([
+          expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
+          expect.objectContaining({ path: 'untracked.txt', status: 'added' }),
+          expect.objectContaining({ path: 'to-delete.txt', status: 'deleted' }),
+        ]),
+        unstaged: [],
+      });
+
+      const unstageAllSeqs = await worktree.unstageAll();
+      expect(unstageAllSeqs.status).toBeGreaterThanOrEqual(1);
+      expect(await worktree.getStatus()).toMatchObject({
+        kind: 'ok',
+        staged: [],
+        unstaged: expect.arrayContaining([
+          expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
+          expect.objectContaining({ path: 'untracked.txt', status: 'added' }),
+          expect.objectContaining({ path: 'to-delete.txt', status: 'deleted' }),
+        ]),
+      });
+
+      const revertAllSeqs = await worktree.revertAll();
+      expect(revertAllSeqs.status).toBeGreaterThanOrEqual(1);
+      expect(await worktree.getStatus()).toMatchObject({
+        kind: 'ok',
+        staged: [],
+        unstaged: [],
+      });
+      expect(await readFile(path.join(repo, 'tracked.txt'), 'utf8')).toBe('before\n');
+      expect(await readFile(path.join(repo, 'to-delete.txt'), 'utf8')).toBe('gone\n');
+      await expect(readFile(path.join(repo, 'untracked.txt'), 'utf8')).rejects.toThrow();
+
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watcher.dispose();
+    }
+  });
+
+  it('unstageAll and revertAll tolerate unborn HEAD', async () => {
+    const repo = await mkdtemp(path.join(tmpdir(), 'emdash-shared-worktree-unborn-'));
+    await execFileAsync('git', ['init', '-b', 'main'], { cwd: repo });
+    await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+    await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repo });
+    await writeFile(path.join(repo, 'untracked.txt'), 'new\n', 'utf8');
+
+    const runtime = new GitRuntime();
+    try {
+      const lease = await runtime.openWorktree(repo);
+      await writeFile(path.join(repo, 'extra.txt'), 'bar\n', 'utf8');
+
+      const unstageSeqs = await lease.value.unstageAll();
+      expect(unstageSeqs.status).toBeGreaterThanOrEqual(1);
+
+      const revertSeqs = await lease.value.revertAll();
+      expect(revertSeqs.status).toBeGreaterThanOrEqual(1);
+      await expect(readFile(path.join(repo, 'untracked.txt'), 'utf8')).rejects.toThrow();
+      await expect(readFile(path.join(repo, 'extra.txt'), 'utf8')).rejects.toThrow();
+
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
   it('soft-resets the latest unpushed commit and returns its message', async () => {
     const repo = await makeRepo();
     const runtime = new GitRuntime();

--- a/packages/shared/src/git/git-worktree.test.ts
+++ b/packages/shared/src/git/git-worktree.test.ts
@@ -1,0 +1,384 @@
+import { execFile } from 'node:child_process';
+import { chmod, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { promisify } from 'node:util';
+import { describe, expect, it } from 'vitest';
+import { FileWatchService } from '../fs';
+import { GitRuntime, type GitRepoUpdate, type GitWorktreeUpdate } from './index';
+
+const execFileAsync = promisify(execFile);
+
+async function eventually<T>(
+  read: () => T | undefined,
+  timeoutMs = 5_000,
+  intervalMs = 50
+): Promise<T> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const value = read();
+    if (value !== undefined) return value;
+    await new Promise((resolve) => setTimeout(resolve, intervalMs));
+  }
+  throw new Error('Timed out waiting for condition');
+}
+
+async function makeRepo(): Promise<string> {
+  const repo = await mkdtemp(path.join(tmpdir(), 'emdash-shared-worktree-'));
+  await execFileAsync('git', ['init', '-b', 'main'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
+  await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repo });
+  await writeFile(path.join(repo, 'tracked.txt'), 'before\n', 'utf8');
+  await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repo });
+  await execFileAsync('git', ['commit', '-m', 'init'], { cwd: repo });
+  return repo;
+}
+
+async function makeRepoWithRemote(): Promise<{ repo: string; remote: string }> {
+  const remote = await mkdtemp(path.join(tmpdir(), 'emdash-shared-worktree-remote-'));
+  await execFileAsync('git', ['init', '--bare'], { cwd: remote });
+  const repo = await makeRepo();
+  await execFileAsync('git', ['remote', 'add', 'origin', remote], { cwd: repo });
+  await execFileAsync('git', ['push', '-u', 'origin', 'main'], { cwd: repo });
+  return { repo, remote };
+}
+
+async function makeRecordingGitExecutable(): Promise<{ executable: string; logPath: string }> {
+  const dir = await mkdtemp(path.join(tmpdir(), 'emdash-shared-git-bin-'));
+  const executable = path.join(dir, 'git-wrapper.sh');
+  const logPath = path.join(dir, 'git-calls.log');
+  await writeFile(
+    executable,
+    ['#!/bin/sh', `printf '%s\\n' "$1" >> ${JSON.stringify(logPath)}`, 'exec git "$@"', ''].join(
+      '\n'
+    ),
+    'utf8'
+  );
+  await chmod(executable, 0o755);
+  return { executable, logPath };
+}
+
+describe('GitWorktree', () => {
+  it('refreshes and emits worktree facts for real file and git mutations', async () => {
+    const repo = await makeRepo();
+    const watch = new FileWatchService();
+    const runtime = new GitRuntime({ watch });
+    const updates: GitWorktreeUpdate[] = [];
+    const repoUpdates: GitRepoUpdate[] = [];
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      const worktree = lease.value;
+      worktree.subscribe((update) => updates.push(update));
+      worktree.repository.subscribe((update) => repoUpdates.push(update));
+
+      await expect(worktree.getHead()).resolves.toEqual({ kind: 'branch', name: 'main' });
+      await expect(worktree.getSnapshot()).resolves.toMatchObject({
+        status: { seq: expect.any(Number), value: expect.objectContaining({ kind: 'ok' }) },
+        head: { seq: expect.any(Number), value: { kind: 'branch', name: 'main' } },
+      });
+      await expect(worktree.getStatusFingerprint('normal')).resolves.toMatchObject({
+        byteLength: expect.any(Number),
+        hash: expect.stringMatching(/^[0-9a-f]{64}$/),
+      });
+      await expect(worktree.isFileCleanlyTracked('tracked.txt')).resolves.toBe(true);
+      await writeFile(path.join(repo, 'tracked.txt'), 'after\n', 'utf8');
+
+      // Wait for a pushed status model that reflects the modification (subscribe also
+      // pushes an initial clean status, so matching on kind alone would race).
+      await eventually(() =>
+        updates.some(
+          (update) =>
+            update.kind === 'status' &&
+            update.model.kind === 'ok' &&
+            update.model.unstaged.some((change) => change.path === 'tracked.txt')
+        )
+          ? true
+          : undefined
+      );
+      await expect(worktree.isFileCleanlyTracked('tracked.txt')).resolves.toBe(false);
+      const changedStatus = await worktree.getStatus();
+      expect(changedStatus).toMatchObject({
+        kind: 'ok',
+        unstaged: [expect.objectContaining({ path: 'tracked.txt', status: 'modified' })],
+      });
+      expect(changedStatus).not.toHaveProperty('currentBranch');
+      expect(changedStatus).not.toHaveProperty('headKind');
+      expect(changedStatus).not.toHaveProperty('shortHash');
+
+      const diff = await worktree.getFileDiff('tracked.txt');
+      expect(diff.lines).toEqual(
+        expect.arrayContaining([
+          { left: 'before', type: 'del' },
+          { right: 'after', type: 'add' },
+        ])
+      );
+      await expect(worktree.getFileAtRef('tracked.txt', 'HEAD')).resolves.toBe('before\n');
+      await expect(worktree.getChangedFiles({ kind: 'head' })).resolves.toEqual([
+        expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
+      ]);
+
+      const stageSeqs = await worktree.stage(['tracked.txt']);
+      expect(stageSeqs.status).toBeGreaterThanOrEqual(1);
+      const snapshotAfterStage = await worktree.getSnapshot();
+      expect(snapshotAfterStage.status.seq).toBeGreaterThanOrEqual(stageSeqs.status!);
+      expect(await worktree.getStatus()).toMatchObject({
+        kind: 'ok',
+        staged: [expect.objectContaining({ path: 'tracked.txt', status: 'modified' })],
+        unstaged: [],
+        stagedAdded: 1,
+        stagedDeleted: 1,
+      });
+      expect(await worktree.getStatus()).not.toHaveProperty('totalAdded');
+      expect(await worktree.getStatus()).not.toHaveProperty('totalDeleted');
+      await expect(worktree.getFileDiff('tracked.txt', 'STAGED')).resolves.toMatchObject({
+        originalContent: 'before',
+        modifiedContent: 'after',
+      });
+      await expect(worktree.getChangedFiles({ kind: 'staged' })).resolves.toEqual([
+        expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
+      ]);
+
+      const commit = await worktree.commit('change tracked');
+      expect(commit.success).toBe(true);
+      if (!commit.success) throw new Error(commit.error.message);
+      expect(commit.data.hash).toMatch(/^[0-9a-f]{40}$/);
+      expect(commit.data.seqs).toMatchObject({
+        status: expect.any(Number),
+        head: expect.any(Number),
+        refs: expect.any(Number),
+      });
+      await execFileAsync('git', ['tag', 'v-change', commit.data.hash], { cwd: repo });
+      expect(await worktree.getStatus()).toMatchObject({
+        kind: 'ok',
+        staged: [],
+        unstaged: [],
+      });
+      await expect(worktree.getLog({ maxCount: 1 })).resolves.toMatchObject({
+        aheadCount: 0,
+        commits: [
+          expect.objectContaining({
+            hash: commit.data.hash,
+            isPushed: false,
+            subject: 'change tracked',
+            tags: ['v-change'],
+          }),
+        ],
+      });
+      await expect(worktree.getCommitFiles(commit.data.hash)).resolves.toEqual([
+        expect.objectContaining({ path: 'tracked.txt', status: 'modified' }),
+      ]);
+      await expect(
+        worktree.getCommitFileDiff(commit.data.hash, 'tracked.txt')
+      ).resolves.toMatchObject({
+        originalContent: 'before',
+        modifiedContent: 'after',
+      });
+
+      expect(updates.some((update) => update.kind === 'head')).toBe(true);
+      expect(repoUpdates.some((update) => update.kind === 'refs')).toBe(true);
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watch.dispose();
+    }
+  });
+
+  it('computes pushed log state and refreshes refs after push', async () => {
+    const { repo } = await makeRepoWithRemote();
+    await writeFile(path.join(repo, 'tracked.txt'), 'pushed\n', 'utf8');
+    await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repo });
+
+    const watch = new FileWatchService();
+    const runtime = new GitRuntime({ watch });
+    const repoUpdates: string[] = [];
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      lease.value.repository.subscribe((update) => repoUpdates.push(update.kind));
+      const commit = await lease.value.commit('push me');
+      expect(commit.success).toBe(true);
+      if (!commit.success) throw new Error(commit.error.message);
+
+      expect((await lease.value.repository.getRefs()).branches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            branch: 'main',
+            divergence: { ahead: 1, behind: 0 },
+            type: 'local',
+          }),
+        ])
+      );
+
+      repoUpdates.length = 0;
+      await expect(lease.value.push()).resolves.toMatchObject({ success: true });
+      expect(repoUpdates).toContain('refs');
+      await expect(lease.value.getLog({ maxCount: 1 })).resolves.toMatchObject({
+        aheadCount: 0,
+        commits: [expect.objectContaining({ hash: commit.data.hash, isPushed: true })],
+      });
+      expect((await lease.value.repository.getRefs()).branches).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            branch: 'main',
+            type: 'local',
+          }),
+        ])
+      );
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watch.dispose();
+    }
+  });
+
+  it('keeps leased worktrees usable when runtime disposal is requested', async () => {
+    const repo = await makeRepo();
+    const runtime = new GitRuntime();
+    const lease = await runtime.openWorktree(repo);
+
+    await runtime.dispose();
+
+    await expect(lease.value.getStatus()).resolves.toMatchObject({ kind: 'ok' });
+    await expect(runtime.openWorktree(repo)).rejects.toThrow('GitRuntime disposed');
+    lease.release();
+  });
+
+  it('reads image bytes from git refs as serializable data URLs', async () => {
+    const repo = await makeRepo();
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+      'base64'
+    );
+    await writeFile(path.join(repo, 'pixel.png'), png);
+    await execFileAsync('git', ['add', 'pixel.png'], { cwd: repo });
+    await execFileAsync('git', ['commit', '-m', 'add pixel'], { cwd: repo });
+
+    const watch = new FileWatchService();
+    const runtime = new GitRuntime({ watch });
+    try {
+      const lease = await runtime.openWorktree(repo);
+      await expect(lease.value.getImageAtRef('pixel.png', 'HEAD')).resolves.toMatchObject({
+        kind: 'image',
+        image: {
+          mimeType: 'image/png',
+          size: png.length,
+          dataUrl: expect.stringContaining('data:image/png;base64,'),
+        },
+      });
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watch.dispose();
+    }
+  });
+
+  it('uses the host-provided git executable for runtime and binary Git operations', async () => {
+    const repo = await makeRepo();
+    const png = Buffer.from(
+      'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mP8/x8AAwMCAO+/p9sAAAAASUVORK5CYII=',
+      'base64'
+    );
+    await writeFile(path.join(repo, 'pixel.png'), png);
+    await execFileAsync('git', ['add', 'pixel.png'], { cwd: repo });
+    await execFileAsync('git', ['commit', '-m', 'add pixel'], { cwd: repo });
+    const { executable, logPath } = await makeRecordingGitExecutable();
+
+    const watch = new FileWatchService();
+    const runtime = new GitRuntime({ watch, executable });
+    try {
+      const lease = await runtime.openWorktree(repo);
+      await expect(lease.value.getFileAtRef('tracked.txt', 'HEAD')).resolves.toBe('before\n');
+      await expect(lease.value.getImageAtRef('pixel.png', 'HEAD')).resolves.toMatchObject({
+        kind: 'image',
+      });
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watch.dispose();
+    }
+
+    const calls = (await readFile(logPath, 'utf8')).trim().split('\n');
+    expect(calls).toEqual(expect.arrayContaining(['rev-parse', 'cat-file']));
+  });
+
+  it('models unexpected status failures instead of reporting a clean tree', async () => {
+    const repo = await makeRepo();
+    const runtime = new GitRuntime();
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      await rm(path.join(repo, '.git'), { force: true, recursive: true });
+
+      await expect(lease.value.getStatus()).resolves.toMatchObject({
+        kind: 'error',
+        message: expect.stringContaining('not a git repository'),
+      });
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it('computes log metadata without per-commit tag or branch lookups', async () => {
+    const repo = await makeRepo();
+    await writeFile(path.join(repo, 'tracked.txt'), 'second\n', 'utf8');
+    await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repo });
+    await execFileAsync('git', ['commit', '-m', 'second'], { cwd: repo });
+    await execFileAsync('git', ['tag', 'v-second'], { cwd: repo });
+    const { executable, logPath } = await makeRecordingGitExecutable();
+    const runtime = new GitRuntime({ executable });
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      await writeFile(logPath, '', 'utf8');
+
+      await expect(lease.value.getLog({ maxCount: 2, skip: 0 })).resolves.toMatchObject({
+        aheadCount: 0,
+        commits: [
+          expect.objectContaining({
+            subject: 'second',
+            tags: ['v-second'],
+          }),
+          expect.objectContaining({ subject: 'init' }),
+        ],
+      });
+
+      const calls = (await readFile(logPath, 'utf8')).trim().split('\n').filter(Boolean);
+      expect(calls).not.toContain('tag');
+      expect(calls).not.toContain('branch');
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it('soft-resets the latest unpushed commit and returns its message', async () => {
+    const repo = await makeRepo();
+    const runtime = new GitRuntime();
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      await writeFile(path.join(repo, 'tracked.txt'), 'soft reset\n', 'utf8');
+      await lease.value.stage(['tracked.txt']);
+      const commit = await lease.value.commit('soft reset me\n\nbody text');
+      expect(commit.success).toBe(true);
+
+      await expect(lease.value.softReset()).resolves.toMatchObject({
+        success: true,
+        data: {
+          subject: 'soft reset me',
+          body: 'body text',
+          seqs: { status: expect.any(Number), head: expect.any(Number), refs: expect.any(Number) },
+        },
+      });
+      await expect(lease.value.getStatus()).resolves.toMatchObject({
+        kind: 'ok',
+        staged: [expect.objectContaining({ path: 'tracked.txt', status: 'modified' })],
+      });
+      lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
+});

--- a/packages/shared/src/git/git-worktree.test.ts
+++ b/packages/shared/src/git/git-worktree.test.ts
@@ -61,8 +61,8 @@ async function makeRecordingGitExecutable(): Promise<{ executable: string; logPa
 describe('GitWorktree', () => {
   it('refreshes and emits worktree facts for real file and git mutations', async () => {
     const repo = await makeRepo();
-    const watch = new FileWatchService();
-    const runtime = new GitRuntime({ watch });
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
     const updates: GitWorktreeUpdate[] = [];
     const repoUpdates: GitRepoUpdate[] = [];
 
@@ -180,7 +180,7 @@ describe('GitWorktree', () => {
       lease.release();
     } finally {
       await runtime.dispose();
-      await watch.dispose();
+      await watcher.dispose();
     }
   });
 
@@ -189,8 +189,8 @@ describe('GitWorktree', () => {
     await writeFile(path.join(repo, 'tracked.txt'), 'pushed\n', 'utf8');
     await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repo });
 
-    const watch = new FileWatchService();
-    const runtime = new GitRuntime({ watch });
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
     const repoUpdates: string[] = [];
 
     try {
@@ -228,7 +228,7 @@ describe('GitWorktree', () => {
       lease.release();
     } finally {
       await runtime.dispose();
-      await watch.dispose();
+      await watcher.dispose();
     }
   });
 
@@ -254,8 +254,8 @@ describe('GitWorktree', () => {
     await execFileAsync('git', ['add', 'pixel.png'], { cwd: repo });
     await execFileAsync('git', ['commit', '-m', 'add pixel'], { cwd: repo });
 
-    const watch = new FileWatchService();
-    const runtime = new GitRuntime({ watch });
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
     try {
       const lease = await runtime.openWorktree(repo);
       await expect(lease.value.getImageAtRef('pixel.png', 'HEAD')).resolves.toMatchObject({
@@ -269,7 +269,7 @@ describe('GitWorktree', () => {
       lease.release();
     } finally {
       await runtime.dispose();
-      await watch.dispose();
+      await watcher.dispose();
     }
   });
 
@@ -284,8 +284,8 @@ describe('GitWorktree', () => {
     await execFileAsync('git', ['commit', '-m', 'add pixel'], { cwd: repo });
     const { executable, logPath } = await makeRecordingGitExecutable();
 
-    const watch = new FileWatchService();
-    const runtime = new GitRuntime({ watch, executable });
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher, executable });
     try {
       const lease = await runtime.openWorktree(repo);
       await expect(lease.value.getFileAtRef('tracked.txt', 'HEAD')).resolves.toBe('before\n');
@@ -295,7 +295,7 @@ describe('GitWorktree', () => {
       lease.release();
     } finally {
       await runtime.dispose();
-      await watch.dispose();
+      await watcher.dispose();
     }
 
     const calls = (await readFile(logPath, 'utf8')).trim().split('\n');

--- a/packages/shared/src/git/git-worktree.ts
+++ b/packages/shared/src/git/git-worktree.ts
@@ -7,25 +7,23 @@ import {
   classifyCommitError,
   classifyPullError,
   classifyPushError,
-  classifySoftResetError,
   gitErrorMessage,
   type CommitError,
   type PullError,
   type PushError,
-  type SoftResetError,
 } from './errors';
 import type { GitOnError, GitRepository } from './git-repository';
-import type { DiffResult, ImageReadResult } from './models/diff';
+import type { ImageReadResult } from './models/diff';
 import { toRangeString, toRefString, type DiffTarget } from './models/diff-target';
 import type { GitHeadModel } from './models/head';
-import type { Commit, CommitFile, GitLogResult } from './models/log';
+import type { CommitFile, GitLogResult } from './models/log';
 import type {
   GitChange,
   GitStatusFingerprint,
   GitStatusModel,
   GitStatusUntrackedMode,
 } from './models/status';
-import { mapGitChangeStatus, parseDiffLines } from './parsers/diff-parser';
+import { mapGitChangeStatus } from './parsers/diff-parser';
 import {
   MAX_STATUS_FILES,
   StatusParser,
@@ -43,7 +41,6 @@ import type {
 import { classifyGitWatchEvents } from './watch/classifier';
 
 const MAX_DIFF_CONTENT_BYTES = 512 * 1024;
-const MAX_DIFF_OUTPUT_BYTES = 10 * 1024 * 1024;
 const MAX_IMAGE_BLOB_BYTES = 10 * 1024 * 1024;
 const WATCH_DEBOUNCE_MS = 100;
 const REVALIDATE_INTERVAL_MS = 5 * 60_000;
@@ -190,73 +187,8 @@ export class GitWorktree implements IGitWorktree {
     }
   }
 
-  async getFileDiff(filePath: string, base = 'HEAD'): Promise<DiffResult> {
-    const staged = base === 'STAGED' || base === 'staged';
-    const diffArgs = staged
-      ? ['diff', '--no-color', '--unified=2000', '--cached', '--', filePath]
-      : ['diff', '--no-color', '--unified=2000', base, '--', filePath];
-    let diffStdout: string | undefined;
-    try {
-      const { stdout } = await this.exec.exec(diffArgs, { maxBuffer: MAX_DIFF_OUTPUT_BYTES });
-      diffStdout = stdout;
-    } catch {}
-
-    const getOriginalContent = async (): Promise<string | undefined> => {
-      const content = await this.repository.readBlobAtRef(staged ? 'HEAD' : base, filePath);
-      return content === null ? undefined : stripTrailingNewline(content);
-    };
-    const getModifiedContent = async (): Promise<string | undefined> => {
-      if (staged) {
-        const content = await this.getFileAtIndex(filePath);
-        return content === null ? undefined : stripTrailingNewline(content);
-      }
-      try {
-        const result = await this.fs.read(path.join(this.worktree, filePath), {
-          maxBytes: MAX_DIFF_CONTENT_BYTES,
-        });
-        if (result.truncated) return undefined;
-        return stripTrailingNewline(result.content);
-      } catch {
-        return undefined;
-      }
-    };
-
-    if (diffStdout !== undefined) {
-      const { lines, isBinary } = parseDiffLines(diffStdout);
-      if (isBinary) return { lines: [], isBinary: true };
-      const [originalContent, modifiedContent] = await Promise.all([
-        getOriginalContent(),
-        getModifiedContent(),
-      ]);
-      return { lines, originalContent, modifiedContent };
-    }
-
-    const [originalContent, modifiedContent] = await Promise.all([
-      getOriginalContent(),
-      getModifiedContent(),
-    ]);
-    if (modifiedContent !== undefined) {
-      return {
-        lines: modifiedContent.split('\n').map((line) => ({ right: line, type: 'add' as const })),
-        originalContent,
-        modifiedContent,
-      };
-    }
-    if (originalContent !== undefined) {
-      return {
-        lines: originalContent.split('\n').map((line) => ({ left: line, type: 'del' as const })),
-        originalContent,
-      };
-    }
-    return { lines: [] };
-  }
-
   async getFileAtRef(filePath: string, ref: string): Promise<string | null> {
     return this.repository.readBlobAtRef(ref, filePath);
-  }
-
-  async getFileAtHead(filePath: string): Promise<string | null> {
-    return this.getFileAtRef(filePath, 'HEAD');
   }
 
   async getFileAtIndex(filePath: string): Promise<string | null> {
@@ -308,67 +240,6 @@ export class GitWorktree implements IGitWorktree {
     return changes;
   }
 
-  async getCommitFileDiff(commitHash: string, filePath: string): Promise<DiffResult> {
-    const getContentAt = async (ref: string): Promise<string | undefined> => {
-      const content = await this.repository.readBlobAtRef(ref, filePath);
-      return content === null ? undefined : stripTrailingNewline(content);
-    };
-
-    let hasParent = true;
-    try {
-      await this.exec.exec(['rev-parse', '--verify', `${commitHash}~1`]);
-    } catch {
-      hasParent = false;
-    }
-
-    if (!hasParent) {
-      const modifiedContent = await getContentAt(commitHash);
-      if (modifiedContent === undefined) return { lines: [] };
-      return {
-        lines: modifiedContent
-          ? modifiedContent.split('\n').map((line) => ({ right: line, type: 'add' as const }))
-          : [],
-        modifiedContent,
-      };
-    }
-
-    let diffStdout: string | undefined;
-    try {
-      const { stdout } = await this.exec.exec(
-        ['diff', '--no-color', '--unified=2000', `${commitHash}~1`, commitHash, '--', filePath],
-        { maxBuffer: MAX_DIFF_OUTPUT_BYTES }
-      );
-      diffStdout = stdout;
-    } catch {}
-
-    const [originalContent, modifiedContent] = await Promise.all([
-      getContentAt(`${commitHash}~1`),
-      getContentAt(commitHash),
-    ]);
-
-    if (diffStdout !== undefined) {
-      const { lines, isBinary } = parseDiffLines(diffStdout);
-      if (isBinary) return { lines: [], isBinary: true };
-      if (lines.length > 0) return { lines, originalContent, modifiedContent };
-    }
-
-    if (modifiedContent !== undefined && modifiedContent !== '') {
-      return {
-        lines: modifiedContent.split('\n').map((line) => ({ right: line, type: 'add' as const })),
-        originalContent,
-        modifiedContent,
-      };
-    }
-    if (originalContent !== undefined) {
-      return {
-        lines: originalContent.split('\n').map((line) => ({ left: line, type: 'del' as const })),
-        originalContent,
-        modifiedContent,
-      };
-    }
-    return { lines: [], originalContent, modifiedContent };
-  }
-
   async getLog(options: GitLogOptions = {}): Promise<GitLogResult> {
     const maxCount =
       typeof options.maxCount === 'number'
@@ -418,11 +289,6 @@ export class GitWorktree implements IGitWorktree {
         };
       });
     return { commits, aheadCount };
-  }
-
-  async getLatestCommit(): Promise<Commit | null> {
-    const { commits } = await this.getLog({ maxCount: 1 });
-    return commits[0] ?? null;
   }
 
   async getCommitFiles(hash: string): Promise<CommitFile[]> {
@@ -541,36 +407,6 @@ export class GitWorktree implements IGitWorktree {
       return ok({ output: stdout || stderr, seqs: await this.refreshAfterHistoryChange() });
     } catch (error) {
       return err(classifyPullError(error));
-    }
-  }
-
-  async softReset(): Promise<
-    Result<{ subject: string; body: string; seqs: GitSeqs }, SoftResetError>
-  > {
-    try {
-      await this.exec.exec(['rev-parse', '--verify', 'HEAD~1']);
-    } catch (error) {
-      return err({ type: 'initial-commit', message: gitErrorMessage(error) });
-    }
-
-    const latest = await this.getLatestCommit();
-    if (latest?.isPushed) {
-      return err({ type: 'already-pushed', message: 'Latest commit is already pushed' });
-    }
-
-    try {
-      const [{ stdout: subject }, { stdout: body }] = await Promise.all([
-        this.exec.exec(['log', '-1', '--pretty=format:%s']),
-        this.exec.exec(['log', '-1', '--pretty=format:%b']),
-      ]);
-      await this.exec.exec(['reset', '--soft', 'HEAD~1']);
-      return ok({
-        subject: subject.trim(),
-        body: body.trim(),
-        seqs: await this.refreshAfterHistoryChange(),
-      });
-    } catch (error) {
-      return err(classifySoftResetError(error));
     }
   }
 
@@ -808,10 +644,6 @@ function parseDecoratedTags(decorations: string): string[] {
     .filter((decoration) => decoration.startsWith('tag: '))
     .map((decoration) => decoration.slice('tag: '.length).replace(/^refs\/tags\//, ''))
     .filter(Boolean);
-}
-
-function stripTrailingNewline(value: string): string {
-  return value.endsWith('\n') ? value.slice(0, -1) : value;
 }
 
 function imageMimeForPath(filePath: string): string | null {

--- a/packages/shared/src/git/git-worktree.ts
+++ b/packages/shared/src/git/git-worktree.ts
@@ -66,7 +66,7 @@ const IMAGE_MIME_BY_EXT: Record<string, string> = {
 type Numstat = Map<string, { additions: number; deletions: number }>;
 
 export type GitWorktreeOptions = {
-  workTree: string;
+  worktree: string;
   gitDir: string;
   repository: GitRepository;
   exec: BoundExec;
@@ -77,18 +77,18 @@ export type GitWorktreeOptions = {
 };
 
 export class GitWorktree implements IGitWorktree {
-  readonly workTree: string;
+  readonly worktree: string;
   readonly gitDir: string;
   readonly repository: GitRepository;
   private readonly exec: BoundExec;
   private readonly fs: IFsService;
   private readonly statusModel: LiveModel<GitStatusModel>;
   private readonly headModel: LiveModel<GitHeadModel>;
-  private readonly workTreeWatch: WatchHandle;
+  private readonly worktreeWatch: WatchHandle;
   private readonly unregisterFromRepository: Unsubscribe;
 
   constructor(options: GitWorktreeOptions) {
-    this.workTree = options.workTree;
+    this.worktree = options.worktree;
     this.gitDir = options.gitDir;
     this.repository = options.repository;
     this.exec = options.exec;
@@ -99,31 +99,31 @@ export class GitWorktree implements IGitWorktree {
       compute: () => this.computeStatus(),
       debounceMs: WATCH_DEBOUNCE_MS,
       revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
-      onError: (error) => onError(`status ${this.workTree}`, error),
+      onError: (error) => onError(`status ${this.worktree}`, error),
     });
     this.headModel = new LiveModel<GitHeadModel>({
       compute: () => this.computeHead(),
       debounceMs: WATCH_DEBOUNCE_MS,
       revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
-      onError: (error) => onError(`head ${this.workTree}`, error),
+      onError: (error) => onError(`head ${this.worktree}`, error),
     });
 
     // The repository owns the `.git` (commonDir) watch and routes classified HEAD/index
     // effects here; this watch only covers working-tree file changes.
-    this.unregisterFromRepository = this.repository.registerWorktree(this.workTree, {
+    this.unregisterFromRepository = this.repository.registerWorktree(this.worktree, {
       gitDir: this.gitDir,
-      workTree: this.workTree,
+      worktree: this.worktree,
       onEffects: (effects) => {
         if (effects.status) this.statusModel.invalidate();
         if (effects.head) this.headModel.invalidate();
       },
     });
-    this.workTreeWatch = options.watcher.watch(
-      this.workTree,
+    this.worktreeWatch = options.watcher.watch(
+      this.worktree,
       (events) => {
         const classification = classifyGitWatchEvents(events, {
           gitCommonDir: this.repository.gitCommonDir,
-          worktrees: [{ id: 'self', gitDir: this.gitDir, workTree: this.workTree }],
+          worktrees: [{ id: 'self', gitDir: this.gitDir, worktree: this.worktree }],
         });
         const effects = classification.worktrees.get('self');
         if (effects?.status) this.statusModel.invalidate();
@@ -140,7 +140,7 @@ export class GitWorktree implements IGitWorktree {
   }
 
   async ready(): Promise<void> {
-    await this.workTreeWatch.ready();
+    await this.worktreeWatch.ready();
   }
 
   async getStatus(): Promise<GitStatusModel> {
@@ -211,7 +211,7 @@ export class GitWorktree implements IGitWorktree {
         return content === null ? undefined : stripTrailingNewline(content);
       }
       try {
-        const result = await this.fs.read(path.join(this.workTree, filePath), {
+        const result = await this.fs.read(path.join(this.worktree, filePath), {
           maxBytes: MAX_DIFF_CONTENT_BYTES,
         });
         if (result.truncated) return undefined;
@@ -556,7 +556,7 @@ export class GitWorktree implements IGitWorktree {
 
   dispose(): void {
     this.unregisterFromRepository();
-    this.workTreeWatch.release();
+    this.worktreeWatch.release();
     this.statusModel.dispose();
     this.headModel.dispose();
   }
@@ -658,7 +658,7 @@ export class GitWorktree implements IGitWorktree {
       const deletions = unstagedNumstat.get(filePath)?.deletions ?? 0;
       if (additions === 0 && deletions === 0 && isUntracked) {
         try {
-          const result = await this.fs.read(path.join(this.workTree, filePath), {
+          const result = await this.fs.read(path.join(this.worktree, filePath), {
             maxBytes: MAX_DIFF_CONTENT_BYTES,
           });
           if (!result.truncated) additions = (result.content.match(/\n/g) ?? []).length;

--- a/packages/shared/src/git/git-worktree.ts
+++ b/packages/shared/src/git/git-worktree.ts
@@ -71,7 +71,8 @@ export type GitWorktreeOptions = {
   repository: GitRepository;
   exec: BoundExec;
   fs: IFsService;
-  watch: IFileWatchService;
+  /** Injected file-watch service; disposed by the injector, not this class. */
+  watcher: IFileWatchService;
   onError?: GitOnError;
 };
 
@@ -117,7 +118,7 @@ export class GitWorktree implements IGitWorktree {
         if (effects.head) this.headModel.invalidate();
       },
     });
-    this.workTreeWatch = options.watch.watch(
+    this.workTreeWatch = options.watcher.watch(
       this.workTree,
       (events) => {
         const classification = classifyGitWatchEvents(events, {
@@ -155,36 +156,37 @@ export class GitWorktree implements IGitWorktree {
     return { status, head };
   }
 
-  async refresh(): Promise<GitWorktreeSnapshot> {
-    const [status, head] = await Promise.all([
-      this.statusModel.refresh(),
-      this.headModel.refresh(),
-    ]);
-    return { status, head };
-  }
-
-  subscribe(cb: (update: GitWorktreeUpdate) => void): Unsubscribe {
-    const unsubscribeStatus = this.statusModel.subscribe(({ value, seq }) =>
-      cb({ kind: 'status', model: value, seq })
-    );
-    const unsubscribeHead = this.headModel.subscribe(({ value, seq }) =>
-      cb({ kind: 'head', model: value, seq })
-    );
-    return () => {
-      unsubscribeStatus();
-      unsubscribeHead();
-    };
-  }
-
-  async subscribeWithSnapshot(
-    cb: (update: GitWorktreeUpdate) => void
-  ): Promise<SubscribedSnapshot<GitWorktreeSnapshot>> {
-    const unsubscribe = this.subscribe(cb);
+  async getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint> {
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), STATUS_FINGERPRINT_TIMEOUT_MS[untracked]);
     try {
-      return { snapshot: await this.getSnapshot(), unsubscribe };
-    } catch (error) {
-      unsubscribe();
-      throw error;
+      const { stdout } = await this.exec.exec(
+        [
+          '--no-optional-locks',
+          'status',
+          '--porcelain=v1',
+          '-z',
+          untracked === 'normal' ? '--untracked-files=normal' : '-uno',
+        ],
+        { signal: abort.signal }
+      );
+      return {
+        hash: createHash('sha256').update(stdout).digest('hex'),
+        byteLength: Buffer.byteLength(stdout),
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async isFileCleanlyTracked(filePath: string): Promise<boolean> {
+    try {
+      await this.exec.exec(['ls-files', '--error-unmatch', '--', filePath]);
+      await this.exec.exec(['diff', '--quiet', '--', filePath]);
+      await this.exec.exec(['diff', '--cached', '--quiet', '--', filePath]);
+      return true;
+    } catch {
+      return false;
     }
   }
 
@@ -272,40 +274,6 @@ export class GitWorktree implements IGitWorktree {
 
   async getImageAtIndex(filePath: string): Promise<ImageReadResult> {
     return this.getImageBlob(filePath, `:${filePath}`);
-  }
-
-  async getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint> {
-    const abort = new AbortController();
-    const timeout = setTimeout(() => abort.abort(), STATUS_FINGERPRINT_TIMEOUT_MS[untracked]);
-    try {
-      const { stdout } = await this.exec.exec(
-        [
-          '--no-optional-locks',
-          'status',
-          '--porcelain=v1',
-          '-z',
-          untracked === 'normal' ? '--untracked-files=normal' : '-uno',
-        ],
-        { signal: abort.signal }
-      );
-      return {
-        hash: createHash('sha256').update(stdout).digest('hex'),
-        byteLength: Buffer.byteLength(stdout),
-      };
-    } finally {
-      clearTimeout(timeout);
-    }
-  }
-
-  async isFileCleanlyTracked(filePath: string): Promise<boolean> {
-    try {
-      await this.exec.exec(['ls-files', '--error-unmatch', '--', filePath]);
-      await this.exec.exec(['diff', '--quiet', '--', filePath]);
-      await this.exec.exec(['diff', '--cached', '--quiet', '--', filePath]);
-      return true;
-    } catch {
-      return false;
-    }
   }
 
   async getChangedFiles(base: DiffTarget): Promise<GitChange[]> {
@@ -475,6 +443,39 @@ export class GitWorktree implements IGitWorktree {
       additions: stat.additions,
       deletions: stat.deletions,
     }));
+  }
+
+  subscribe(cb: (update: GitWorktreeUpdate) => void): Unsubscribe {
+    const unsubscribeStatus = this.statusModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'status', model: value, seq })
+    );
+    const unsubscribeHead = this.headModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'head', model: value, seq })
+    );
+    return () => {
+      unsubscribeStatus();
+      unsubscribeHead();
+    };
+  }
+
+  async subscribeWithSnapshot(
+    cb: (update: GitWorktreeUpdate) => void
+  ): Promise<SubscribedSnapshot<GitWorktreeSnapshot>> {
+    const unsubscribe = this.subscribe(cb);
+    try {
+      return { snapshot: await this.getSnapshot(), unsubscribe };
+    } catch (error) {
+      unsubscribe();
+      throw error;
+    }
+  }
+
+  async refresh(): Promise<GitWorktreeSnapshot> {
+    const [status, head] = await Promise.all([
+      this.statusModel.refresh(),
+      this.headModel.refresh(),
+    ]);
+    return { status, head };
   }
 
   async stage(paths: string[]): Promise<GitSeqs> {

--- a/packages/shared/src/git/git-worktree.ts
+++ b/packages/shared/src/git/git-worktree.ts
@@ -1,0 +1,804 @@
+import { createHash } from 'node:crypto';
+import path from 'node:path';
+import { ExecError, type BoundExec } from '../exec';
+import type { IFileWatchService, IFsService, WatchHandle } from '../fs';
+import { err, LiveModel, ok, type Result, type Unsubscribe } from '../lib';
+import {
+  classifyCommitError,
+  classifyPullError,
+  classifyPushError,
+  classifySoftResetError,
+  gitErrorMessage,
+  type CommitError,
+  type PullError,
+  type PushError,
+  type SoftResetError,
+} from './errors';
+import type { GitOnError, GitRepository } from './git-repository';
+import type { DiffResult, ImageReadResult } from './models/diff';
+import type { GitHeadModel } from './models/head';
+import type { Commit, CommitFile, GitLogResult } from './models/log';
+import { toRangeString, toRefString, type DiffTarget } from './models/refs';
+import type {
+  GitChange,
+  GitStatusFingerprint,
+  GitStatusModel,
+  GitStatusUntrackedMode,
+} from './models/status';
+import { mapGitChangeStatus, parseDiffLines } from './parsers/diff-parser';
+import {
+  MAX_STATUS_FILES,
+  StatusParser,
+  TooManyFilesChangedError,
+  type FileStatus,
+} from './parsers/status-parser';
+import type {
+  GitLogOptions,
+  GitSeqs,
+  GitWorktreeSnapshot,
+  GitWorktreeUpdate,
+  IGitWorktree,
+  SubscribedSnapshot,
+} from './types';
+import { classifyGitWatchEvents } from './watch/classifier';
+
+const MAX_DIFF_CONTENT_BYTES = 512 * 1024;
+const MAX_DIFF_OUTPUT_BYTES = 10 * 1024 * 1024;
+const MAX_IMAGE_BLOB_BYTES = 10 * 1024 * 1024;
+const WATCH_DEBOUNCE_MS = 100;
+const REVALIDATE_INTERVAL_MS = 5 * 60_000;
+const STATUS_FINGERPRINT_TIMEOUT_MS: Record<GitStatusUntrackedMode, number> = {
+  no: 5_000,
+  normal: 10_000,
+};
+const LFS_POINTER_PREFIX = Buffer.from('version https://git-lfs.github.com/spec/');
+const IMAGE_MIME_BY_EXT: Record<string, string> = {
+  png: 'image/png',
+  jpg: 'image/jpeg',
+  jpeg: 'image/jpeg',
+  gif: 'image/gif',
+  webp: 'image/webp',
+  bmp: 'image/bmp',
+  ico: 'image/x-icon',
+  svg: 'image/svg+xml',
+};
+
+type Numstat = Map<string, { additions: number; deletions: number }>;
+
+export type GitWorktreeOptions = {
+  workTree: string;
+  gitDir: string;
+  repository: GitRepository;
+  exec: BoundExec;
+  fs: IFsService;
+  watch: IFileWatchService;
+  onError?: GitOnError;
+};
+
+export class GitWorktree implements IGitWorktree {
+  readonly workTree: string;
+  readonly gitDir: string;
+  readonly repository: GitRepository;
+  private readonly exec: BoundExec;
+  private readonly fs: IFsService;
+  private readonly statusModel: LiveModel<GitStatusModel>;
+  private readonly headModel: LiveModel<GitHeadModel>;
+  private readonly workTreeWatch: WatchHandle;
+  private readonly unregisterFromRepository: Unsubscribe;
+
+  constructor(options: GitWorktreeOptions) {
+    this.workTree = options.workTree;
+    this.gitDir = options.gitDir;
+    this.repository = options.repository;
+    this.exec = options.exec;
+    this.fs = options.fs;
+    const onError = options.onError ?? (() => {});
+
+    this.statusModel = new LiveModel<GitStatusModel>({
+      compute: () => this.computeStatus(),
+      debounceMs: WATCH_DEBOUNCE_MS,
+      revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
+      onError: (error) => onError(`status ${this.workTree}`, error),
+    });
+    this.headModel = new LiveModel<GitHeadModel>({
+      compute: () => this.computeHead(),
+      debounceMs: WATCH_DEBOUNCE_MS,
+      revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
+      onError: (error) => onError(`head ${this.workTree}`, error),
+    });
+
+    // The repository owns the `.git` (commonDir) watch and routes classified HEAD/index
+    // effects here; this watch only covers working-tree file changes.
+    this.unregisterFromRepository = this.repository.registerWorktree(this.workTree, {
+      gitDir: this.gitDir,
+      workTree: this.workTree,
+      onEffects: (effects) => {
+        if (effects.status) this.statusModel.invalidate();
+        if (effects.head) this.headModel.invalidate();
+      },
+    });
+    this.workTreeWatch = options.watch.watch(
+      this.workTree,
+      (events) => {
+        const classification = classifyGitWatchEvents(events, {
+          gitCommonDir: this.repository.gitCommonDir,
+          worktrees: [{ id: 'self', gitDir: this.gitDir, workTree: this.workTree }],
+        });
+        const effects = classification.worktrees.get('self');
+        if (effects?.status) this.statusModel.invalidate();
+        if (effects?.head) this.headModel.invalidate();
+      },
+      {
+        ignore: ['.git/**'],
+        onResync: () => {
+          this.statusModel.invalidate();
+          this.headModel.invalidate();
+        },
+      }
+    );
+  }
+
+  async ready(): Promise<void> {
+    await this.workTreeWatch.ready();
+  }
+
+  async getStatus(): Promise<GitStatusModel> {
+    return (await this.statusModel.get()).value;
+  }
+
+  async getHead(): Promise<GitHeadModel> {
+    return (await this.headModel.get()).value;
+  }
+
+  async getSnapshot(): Promise<GitWorktreeSnapshot> {
+    const [status, head] = await Promise.all([this.statusModel.get(), this.headModel.get()]);
+    return { status, head };
+  }
+
+  async refresh(): Promise<GitWorktreeSnapshot> {
+    const [status, head] = await Promise.all([
+      this.statusModel.refresh(),
+      this.headModel.refresh(),
+    ]);
+    return { status, head };
+  }
+
+  subscribe(cb: (update: GitWorktreeUpdate) => void): Unsubscribe {
+    const unsubscribeStatus = this.statusModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'status', model: value, seq })
+    );
+    const unsubscribeHead = this.headModel.subscribe(({ value, seq }) =>
+      cb({ kind: 'head', model: value, seq })
+    );
+    return () => {
+      unsubscribeStatus();
+      unsubscribeHead();
+    };
+  }
+
+  async subscribeWithSnapshot(
+    cb: (update: GitWorktreeUpdate) => void
+  ): Promise<SubscribedSnapshot<GitWorktreeSnapshot>> {
+    const unsubscribe = this.subscribe(cb);
+    try {
+      return { snapshot: await this.getSnapshot(), unsubscribe };
+    } catch (error) {
+      unsubscribe();
+      throw error;
+    }
+  }
+
+  async getFileDiff(filePath: string, base = 'HEAD'): Promise<DiffResult> {
+    const staged = base === 'STAGED' || base === 'staged';
+    const diffArgs = staged
+      ? ['diff', '--no-color', '--unified=2000', '--cached', '--', filePath]
+      : ['diff', '--no-color', '--unified=2000', base, '--', filePath];
+    let diffStdout: string | undefined;
+    try {
+      const { stdout } = await this.exec.exec(diffArgs, { maxBuffer: MAX_DIFF_OUTPUT_BYTES });
+      diffStdout = stdout;
+    } catch {}
+
+    const getOriginalContent = async (): Promise<string | undefined> => {
+      const content = await this.repository.readBlobAtRef(staged ? 'HEAD' : base, filePath);
+      return content === null ? undefined : stripTrailingNewline(content);
+    };
+    const getModifiedContent = async (): Promise<string | undefined> => {
+      if (staged) {
+        const content = await this.getFileAtIndex(filePath);
+        return content === null ? undefined : stripTrailingNewline(content);
+      }
+      try {
+        const result = await this.fs.read(path.join(this.workTree, filePath), {
+          maxBytes: MAX_DIFF_CONTENT_BYTES,
+        });
+        if (result.truncated) return undefined;
+        return stripTrailingNewline(result.content);
+      } catch {
+        return undefined;
+      }
+    };
+
+    if (diffStdout !== undefined) {
+      const { lines, isBinary } = parseDiffLines(diffStdout);
+      if (isBinary) return { lines: [], isBinary: true };
+      const [originalContent, modifiedContent] = await Promise.all([
+        getOriginalContent(),
+        getModifiedContent(),
+      ]);
+      return { lines, originalContent, modifiedContent };
+    }
+
+    const [originalContent, modifiedContent] = await Promise.all([
+      getOriginalContent(),
+      getModifiedContent(),
+    ]);
+    if (modifiedContent !== undefined) {
+      return {
+        lines: modifiedContent.split('\n').map((line) => ({ right: line, type: 'add' as const })),
+        originalContent,
+        modifiedContent,
+      };
+    }
+    if (originalContent !== undefined) {
+      return {
+        lines: originalContent.split('\n').map((line) => ({ left: line, type: 'del' as const })),
+        originalContent,
+      };
+    }
+    return { lines: [] };
+  }
+
+  async getFileAtRef(filePath: string, ref: string): Promise<string | null> {
+    return this.repository.readBlobAtRef(ref, filePath);
+  }
+
+  async getFileAtHead(filePath: string): Promise<string | null> {
+    return this.getFileAtRef(filePath, 'HEAD');
+  }
+
+  async getFileAtIndex(filePath: string): Promise<string | null> {
+    try {
+      const { stdout } = await this.exec.exec(['show', `:${filePath}`]);
+      return stdout;
+    } catch {
+      return null;
+    }
+  }
+
+  async getImageAtRef(filePath: string, ref: string): Promise<ImageReadResult> {
+    return this.getImageBlob(filePath, `${ref}:${filePath}`);
+  }
+
+  async getImageAtIndex(filePath: string): Promise<ImageReadResult> {
+    return this.getImageBlob(filePath, `:${filePath}`);
+  }
+
+  async getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint> {
+    const abort = new AbortController();
+    const timeout = setTimeout(() => abort.abort(), STATUS_FINGERPRINT_TIMEOUT_MS[untracked]);
+    try {
+      const { stdout } = await this.exec.exec(
+        [
+          '--no-optional-locks',
+          'status',
+          '--porcelain=v1',
+          '-z',
+          untracked === 'normal' ? '--untracked-files=normal' : '-uno',
+        ],
+        { signal: abort.signal }
+      );
+      return {
+        hash: createHash('sha256').update(stdout).digest('hex'),
+        byteLength: Buffer.byteLength(stdout),
+      };
+    } finally {
+      clearTimeout(timeout);
+    }
+  }
+
+  async isFileCleanlyTracked(filePath: string): Promise<boolean> {
+    try {
+      await this.exec.exec(['ls-files', '--error-unmatch', '--', filePath]);
+      await this.exec.exec(['diff', '--quiet', '--', filePath]);
+      await this.exec.exec(['diff', '--cached', '--quiet', '--', filePath]);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async getChangedFiles(base: DiffTarget): Promise<GitChange[]> {
+    const resolved = resolveDiffTarget(base);
+    const diffArgs = resolved.cached
+      ? ['diff', '--numstat', '--cached']
+      : ['diff', '--numstat', resolved.ref];
+    const nameArgs = resolved.cached
+      ? ['diff', '--name-status', '--cached']
+      : ['diff', '--name-status', resolved.ref];
+
+    const [numstatResult, nameStatusResult] = await Promise.all([
+      this.exec.exec(diffArgs).catch(() => ({ stdout: '' })),
+      this.exec.exec(nameArgs).catch(() => ({ stdout: '' })),
+    ]);
+    const numstat = parseNumstat(numstatResult.stdout);
+    const changes: GitChange[] = [];
+
+    for (const line of nameStatusResult.stdout.trim().split('\n').filter(Boolean)) {
+      const [code = '', ...parts] = line.split('\t');
+      const filePath = parts[parts.length - 1]?.trim();
+      if (!filePath) continue;
+      const stat = numstat.get(filePath);
+      changes.push({
+        path: filePath,
+        status: mapGitChangeStatus(code),
+        additions: stat?.additions ?? 0,
+        deletions: stat?.deletions ?? 0,
+      });
+    }
+
+    return changes;
+  }
+
+  async getCommitFileDiff(commitHash: string, filePath: string): Promise<DiffResult> {
+    const getContentAt = async (ref: string): Promise<string | undefined> => {
+      const content = await this.repository.readBlobAtRef(ref, filePath);
+      return content === null ? undefined : stripTrailingNewline(content);
+    };
+
+    let hasParent = true;
+    try {
+      await this.exec.exec(['rev-parse', '--verify', `${commitHash}~1`]);
+    } catch {
+      hasParent = false;
+    }
+
+    if (!hasParent) {
+      const modifiedContent = await getContentAt(commitHash);
+      if (modifiedContent === undefined) return { lines: [] };
+      return {
+        lines: modifiedContent
+          ? modifiedContent.split('\n').map((line) => ({ right: line, type: 'add' as const }))
+          : [],
+        modifiedContent,
+      };
+    }
+
+    let diffStdout: string | undefined;
+    try {
+      const { stdout } = await this.exec.exec(
+        ['diff', '--no-color', '--unified=2000', `${commitHash}~1`, commitHash, '--', filePath],
+        { maxBuffer: MAX_DIFF_OUTPUT_BYTES }
+      );
+      diffStdout = stdout;
+    } catch {}
+
+    const [originalContent, modifiedContent] = await Promise.all([
+      getContentAt(`${commitHash}~1`),
+      getContentAt(commitHash),
+    ]);
+
+    if (diffStdout !== undefined) {
+      const { lines, isBinary } = parseDiffLines(diffStdout);
+      if (isBinary) return { lines: [], isBinary: true };
+      if (lines.length > 0) return { lines, originalContent, modifiedContent };
+    }
+
+    if (modifiedContent !== undefined && modifiedContent !== '') {
+      return {
+        lines: modifiedContent.split('\n').map((line) => ({ right: line, type: 'add' as const })),
+        originalContent,
+        modifiedContent,
+      };
+    }
+    if (originalContent !== undefined) {
+      return {
+        lines: originalContent.split('\n').map((line) => ({ left: line, type: 'del' as const })),
+        originalContent,
+        modifiedContent,
+      };
+    }
+    return { lines: [], originalContent, modifiedContent };
+  }
+
+  async getLog(options: GitLogOptions = {}): Promise<GitLogResult> {
+    const maxCount =
+      typeof options.maxCount === 'number'
+        ? Math.max(1, Math.floor(options.maxCount))
+        : typeof options.limit === 'number'
+          ? Math.max(1, Math.floor(options.limit))
+          : 50;
+    const skip = typeof options.skip === 'number' ? Math.max(0, Math.floor(options.skip)) : 0;
+    const head = options.head ? toRefString(options.head) : 'HEAD';
+    const range = options.base ? `${toRefString(options.base)}..${head}` : head;
+    const aheadCount = await this.getAheadCount(options, head);
+    const fieldSep = '\x1f';
+    const recordSep = '\x1e';
+    const { stdout } = await this.exec.exec([
+      'log',
+      `--max-count=${maxCount}`,
+      `--skip=${skip}`,
+      '--decorate=full',
+      `--format=%H${fieldSep}%P${fieldSep}%s${fieldSep}%b${fieldSep}%an${fieldSep}%aI${fieldSep}%D${recordSep}`,
+      range,
+      '--',
+    ]);
+    const remoteReachable = await this.getRemoteReachableCommits();
+    const commits = stdout
+      .split(recordSep)
+      .map((record) => record.replace(/^\n/, '').trimEnd())
+      .filter(Boolean)
+      .map((record) => {
+        const [
+          hash = '',
+          parents = '',
+          subject = '',
+          body = '',
+          author = '',
+          date = '',
+          decorations = '',
+        ] = record.split(fieldSep);
+        return {
+          hash,
+          parents: parents ? parents.split(' ').filter(Boolean) : [],
+          subject,
+          body: body.trim(),
+          author,
+          date,
+          isPushed: remoteReachable.has(hash),
+          tags: parseDecoratedTags(decorations),
+        };
+      });
+    return { commits, aheadCount };
+  }
+
+  async getLatestCommit(): Promise<Commit | null> {
+    const { commits } = await this.getLog({ maxCount: 1 });
+    return commits[0] ?? null;
+  }
+
+  async getCommitFiles(hash: string): Promise<CommitFile[]> {
+    const [numstatRes, nameStatusRes] = await Promise.all([
+      this.exec.exec(['diff-tree', '--root', '--no-commit-id', '--numstat', '-r', hash]),
+      this.exec.exec(['diff-tree', '--root', '--no-commit-id', '--name-status', '-r', hash]),
+    ]);
+    const numstat = parseNumstat(numstatRes.stdout);
+    const statusByPath = new Map<string, ReturnType<typeof mapGitChangeStatus>>();
+    for (const line of nameStatusRes.stdout.trim().split('\n').filter(Boolean)) {
+      const [code = '', ...parts] = line.split('\t');
+      const filePath = parts[parts.length - 1];
+      if (filePath) statusByPath.set(filePath, mapGitChangeStatus(code));
+    }
+    return [...numstat.entries()].map(([filePath, stat]) => ({
+      path: filePath,
+      status: statusByPath.get(filePath) ?? 'modified',
+      additions: stat.additions,
+      deletions: stat.deletions,
+    }));
+  }
+
+  async stage(paths: string[]): Promise<GitSeqs> {
+    if (paths.length === 0) return {};
+    await this.exec.exec(['add', '--', ...paths]);
+    return this.refreshStatus();
+  }
+
+  async unstage(paths: string[]): Promise<GitSeqs> {
+    if (paths.length === 0) return {};
+    await this.exec.exec(['reset', 'HEAD', '--', ...paths]);
+    return this.refreshStatus();
+  }
+
+  async revert(paths: string[]): Promise<GitSeqs> {
+    if (paths.length === 0) return {};
+    await this.exec.exec(['checkout', 'HEAD', '--', ...paths]);
+    return this.refreshStatus();
+  }
+
+  async commit(message: string): Promise<Result<{ hash: string; seqs: GitSeqs }, CommitError>> {
+    try {
+      await this.exec.exec(['commit', '-m', message]);
+      const { stdout } = await this.exec.exec(['rev-parse', 'HEAD']);
+      return ok({ hash: stdout.trim(), seqs: await this.refreshAfterHistoryChange() });
+    } catch (error) {
+      return err(classifyCommitError(error));
+    }
+  }
+
+  async push(remote?: string): Promise<Result<{ output: string; seqs: GitSeqs }, PushError>> {
+    try {
+      const { stdout, stderr } = await this.exec.exec(['push', ...(remote ? [remote] : [])]);
+      return ok({ output: stdout || stderr, seqs: await this.refreshAfterHistoryChange() });
+    } catch (error) {
+      return err(classifyPushError(error));
+    }
+  }
+
+  async pull(): Promise<Result<{ output: string; seqs: GitSeqs }, PullError>> {
+    try {
+      const { stdout, stderr } = await this.exec.exec(['pull']);
+      return ok({ output: stdout || stderr, seqs: await this.refreshAfterHistoryChange() });
+    } catch (error) {
+      return err(classifyPullError(error));
+    }
+  }
+
+  async softReset(): Promise<
+    Result<{ subject: string; body: string; seqs: GitSeqs }, SoftResetError>
+  > {
+    try {
+      await this.exec.exec(['rev-parse', '--verify', 'HEAD~1']);
+    } catch (error) {
+      return err({ type: 'initial-commit', message: gitErrorMessage(error) });
+    }
+
+    const latest = await this.getLatestCommit();
+    if (latest?.isPushed) {
+      return err({ type: 'already-pushed', message: 'Latest commit is already pushed' });
+    }
+
+    try {
+      const [{ stdout: subject }, { stdout: body }] = await Promise.all([
+        this.exec.exec(['log', '-1', '--pretty=format:%s']),
+        this.exec.exec(['log', '-1', '--pretty=format:%b']),
+      ]);
+      await this.exec.exec(['reset', '--soft', 'HEAD~1']);
+      return ok({
+        subject: subject.trim(),
+        body: body.trim(),
+        seqs: await this.refreshAfterHistoryChange(),
+      });
+    } catch (error) {
+      return err(classifySoftResetError(error));
+    }
+  }
+
+  dispose(): void {
+    this.unregisterFromRepository();
+    this.workTreeWatch.release();
+    this.statusModel.dispose();
+    this.headModel.dispose();
+  }
+
+  /** Status never throws: failures are encoded in the model so subscribers see them. */
+  private async computeStatus(): Promise<GitStatusModel> {
+    try {
+      const parser = new StatusParser();
+      const [, stagedRes, unstagedRes] = await Promise.all([
+        this.runStatusZ(parser),
+        this.exec.exec(['diff', '--numstat', '--cached']).catch(() => ({ stdout: '' })),
+        this.exec.exec(['diff', '--numstat']).catch(() => ({ stdout: '' })),
+      ]);
+
+      if (parser.status.length > MAX_STATUS_FILES || parser.tooManyFiles) {
+        return { kind: 'too-many-files' };
+      }
+
+      return await this.buildStatus(
+        parser.status,
+        parseNumstat(stagedRes.stdout),
+        parseNumstat(unstagedRes.stdout)
+      );
+    } catch (error) {
+      if (error instanceof TooManyFilesChangedError) return { kind: 'too-many-files' };
+      return {
+        kind: 'error',
+        message: gitErrorMessage(error),
+      };
+    }
+  }
+
+  private async computeHead(): Promise<GitHeadModel> {
+    try {
+      const { stdout } = await this.exec.exec(['symbolic-ref', '--short', 'HEAD']);
+      const name = stdout.trim();
+      try {
+        await this.exec.exec(['rev-parse', '--verify', 'HEAD']);
+        return { kind: 'branch', name };
+      } catch {
+        return { kind: 'unborn', name };
+      }
+    } catch {
+      const { stdout } = await this.exec.exec(['rev-parse', '--short', 'HEAD']);
+      return { kind: 'detached', shortHash: stdout.trim() };
+    }
+  }
+
+  private async refreshStatus(): Promise<GitSeqs> {
+    const status = await this.statusModel.refresh();
+    return { status: status.seq };
+  }
+
+  private async refreshAfterHistoryChange(): Promise<GitSeqs> {
+    const [status, head, refs] = await Promise.all([
+      this.statusModel.refresh(),
+      this.headModel.refresh(),
+      this.repository.refreshRefs(),
+    ]);
+    return { status: status.seq, head: head.seq, refs };
+  }
+
+  private async runStatusZ(parser: StatusParser): Promise<void> {
+    await this.exec.execStreaming(['--no-optional-locks', 'status', '-z', '-uall'], (chunk) => {
+      parser.update(chunk);
+      return !parser.tooManyFiles;
+    });
+    if (parser.tooManyFiles) throw new TooManyFilesChangedError();
+  }
+
+  private async buildStatus(
+    entries: FileStatus[],
+    stagedNumstat: Numstat,
+    unstagedNumstat: Numstat
+  ): Promise<GitStatusModel> {
+    const staged: GitChange[] = [];
+    const unstaged: GitChange[] = [];
+
+    for (const entry of entries) {
+      const code = `${entry.x}${entry.y}`;
+      const filePath = entry.path;
+      const status = mapGitChangeStatus(code);
+
+      if (entry.x !== ' ' && entry.x !== '?') {
+        const stat = stagedNumstat.get(filePath);
+        staged.push({
+          path: filePath,
+          status,
+          additions: stat?.additions ?? 0,
+          deletions: stat?.deletions ?? 0,
+        });
+      }
+
+      const isUntracked = code === '??';
+      const hasUnstaged = entry.y !== ' ' && entry.y !== '?';
+      if (!isUntracked && !hasUnstaged) continue;
+
+      let additions = unstagedNumstat.get(filePath)?.additions ?? 0;
+      const deletions = unstagedNumstat.get(filePath)?.deletions ?? 0;
+      if (additions === 0 && deletions === 0 && isUntracked) {
+        try {
+          const result = await this.fs.read(path.join(this.workTree, filePath), {
+            maxBytes: MAX_DIFF_CONTENT_BYTES,
+          });
+          if (!result.truncated) additions = (result.content.match(/\n/g) ?? []).length;
+        } catch {}
+      }
+
+      unstaged.push({ path: filePath, status, additions, deletions });
+    }
+
+    const stagedAdded = staged.reduce((sum, change) => sum + change.additions, 0);
+    const stagedDeleted = staged.reduce((sum, change) => sum + change.deletions, 0);
+    return {
+      kind: 'ok',
+      staged,
+      unstaged,
+      stagedAdded,
+      stagedDeleted,
+    };
+  }
+
+  private async getImageBlob(filePath: string, spec: string): Promise<ImageReadResult> {
+    const mimeType = imageMimeForPath(filePath);
+    if (!mimeType) return { kind: 'unavailable', reason: 'unsupported' };
+
+    let buffer: Buffer;
+    try {
+      const result = await this.exec.execBuffer(['cat-file', '--filters', spec], {
+        maxBuffer: MAX_IMAGE_BLOB_BYTES,
+      });
+      buffer = result.stdout;
+    } catch (error) {
+      if (error instanceof ExecError && error.stderr.includes('maxBuffer')) {
+        return { kind: 'unavailable', reason: 'too-large' };
+      }
+      const exitCode = error instanceof ExecError ? error.exitCode : null;
+      return exitCode === 128 ? { kind: 'missing' } : { kind: 'unavailable', reason: 'git-error' };
+    }
+
+    if (buffer.length === 0) {
+      return { kind: 'unavailable', reason: 'git-error' };
+    }
+    if (looksLikeLfsPointer(buffer)) {
+      return { kind: 'unavailable', reason: 'lfs-pointer' };
+    }
+    return {
+      kind: 'image',
+      image: {
+        dataUrl: `data:${mimeType};base64,${buffer.toString('base64')}`,
+        mimeType,
+        size: buffer.length,
+      },
+    };
+  }
+
+  private async getAheadCount(options: GitLogOptions, head: string): Promise<number> {
+    if (typeof options.knownAheadCount === 'number') return Math.max(0, options.knownAheadCount);
+    if (options.base) {
+      try {
+        const { stdout } = await this.exec.exec([
+          'rev-list',
+          '--count',
+          `${toRefString(options.base)}..${head}`,
+        ]);
+        return Number.parseInt(stdout.trim(), 10) || 0;
+      } catch {
+        return 0;
+      }
+    }
+
+    const remote = options.preferredRemote?.trim() || 'origin';
+    try {
+      const { stdout } = await this.exec.exec(['rev-list', '--count', '@{upstream}..HEAD']);
+      return Number.parseInt(stdout.trim(), 10) || 0;
+    } catch {}
+
+    try {
+      const { stdout: branchOut } = await this.exec.exec(['rev-parse', '--abbrev-ref', 'HEAD']);
+      const branch = branchOut.trim();
+      if (!branch || branch === 'HEAD') return 0;
+      const { stdout } = await this.exec.exec(['rev-list', '--count', `${remote}/${branch}..HEAD`]);
+      return Number.parseInt(stdout.trim(), 10) || 0;
+    } catch {
+      return 0;
+    }
+  }
+
+  private async getRemoteReachableCommits(): Promise<Set<string>> {
+    try {
+      const { stdout } = await this.exec.exec(['rev-list', '--remotes', '--max-count=10000']);
+      return new Set(
+        stdout
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean)
+      );
+    } catch {
+      return new Set();
+    }
+  }
+}
+
+function parseNumstat(stdout: string): Numstat {
+  const map: Numstat = new Map();
+  for (const line of stdout.trim().split('\n').filter(Boolean)) {
+    const [addStr, delStr, ...pathParts] = line.split('\t');
+    const filePath = pathParts.join('\t');
+    if (!filePath) continue;
+    const current = map.get(filePath) ?? { additions: 0, deletions: 0 };
+    current.additions += addStr === '-' ? 0 : Number.parseInt(addStr ?? '0', 10) || 0;
+    current.deletions += delStr === '-' ? 0 : Number.parseInt(delStr ?? '0', 10) || 0;
+    map.set(filePath, current);
+  }
+  return map;
+}
+
+function resolveDiffTarget(base: DiffTarget): { cached: boolean; ref: string } {
+  if ('base' in base) return { cached: false, ref: toRangeString(base) };
+  if (base.kind === 'staged') return { cached: true, ref: '--cached' };
+  if (base.kind === 'head') return { cached: false, ref: 'HEAD' };
+  return { cached: false, ref: toRefString(base) };
+}
+
+function parseDecoratedTags(decorations: string): string[] {
+  return decorations
+    .split(',')
+    .map((decoration) => decoration.trim())
+    .filter((decoration) => decoration.startsWith('tag: '))
+    .map((decoration) => decoration.slice('tag: '.length).replace(/^refs\/tags\//, ''))
+    .filter(Boolean);
+}
+
+function stripTrailingNewline(value: string): string {
+  return value.endsWith('\n') ? value.slice(0, -1) : value;
+}
+
+function imageMimeForPath(filePath: string): string | null {
+  const ext = filePath.split('.').pop()?.toLowerCase();
+  return ext ? (IMAGE_MIME_BY_EXT[ext] ?? null) : null;
+}
+
+function looksLikeLfsPointer(buffer: Buffer): boolean {
+  if (buffer.length > 1024) return false;
+  return buffer.subarray(0, LFS_POINTER_PREFIX.length).equals(LFS_POINTER_PREFIX);
+}

--- a/packages/shared/src/git/git-worktree.ts
+++ b/packages/shared/src/git/git-worktree.ts
@@ -16,9 +16,9 @@ import {
 } from './errors';
 import type { GitOnError, GitRepository } from './git-repository';
 import type { DiffResult, ImageReadResult } from './models/diff';
+import { toRangeString, toRefString, type DiffTarget } from './models/diff-target';
 import type { GitHeadModel } from './models/head';
 import type { Commit, CommitFile, GitLogResult } from './models/log';
-import { toRangeString, toRefString, type DiffTarget } from './models/refs';
 import type {
   GitChange,
   GitStatusFingerprint,

--- a/packages/shared/src/git/git-worktree.ts
+++ b/packages/shared/src/git/git-worktree.ts
@@ -484,15 +484,35 @@ export class GitWorktree implements IGitWorktree {
     return this.refreshStatus();
   }
 
+  async stageAll(): Promise<GitSeqs> {
+    await this.exec.exec(['add', '-A']);
+    return this.refreshStatus();
+  }
+
   async unstage(paths: string[]): Promise<GitSeqs> {
     if (paths.length === 0) return {};
     await this.exec.exec(['reset', 'HEAD', '--', ...paths]);
     return this.refreshStatus();
   }
 
+  async unstageAll(): Promise<GitSeqs> {
+    try {
+      await this.exec.exec(['reset', 'HEAD']);
+    } catch {}
+    return this.refreshStatus();
+  }
+
   async revert(paths: string[]): Promise<GitSeqs> {
     if (paths.length === 0) return {};
     await this.exec.exec(['checkout', 'HEAD', '--', ...paths]);
+    return this.refreshStatus();
+  }
+
+  async revertAll(): Promise<GitSeqs> {
+    try {
+      await this.exec.exec(['reset', '--hard', 'HEAD']);
+    } catch {}
+    await this.exec.exec(['clean', '-fd']);
     return this.refreshStatus();
   }
 

--- a/packages/shared/src/git/index.test.ts
+++ b/packages/shared/src/git/index.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, it } from 'vitest';
+import * as git from './index';
+
+describe('@emdash/shared/git public exports', () => {
+  it('does not export concrete repository or worktree classes', () => {
+    const exported = git as Record<string, unknown>;
+
+    expect(exported.GitRuntime).toBeTypeOf('function');
+    expect(exported.GitRepository).toBeUndefined();
+    expect(exported.GitWorktree).toBeUndefined();
+  });
+});

--- a/packages/shared/src/git/index.ts
+++ b/packages/shared/src/git/index.ts
@@ -8,16 +8,8 @@ export type {
   GitCommandError,
   PullError,
   PushError,
-  RenameBranchError,
-  SoftResetError,
 } from './errors';
-export type {
-  DiffLine,
-  DiffResult,
-  ImageBlob,
-  ImageReadResult,
-  ImageUnavailableReason,
-} from './models/diff';
+export type { ImageBlob, ImageReadResult, ImageUnavailableReason } from './models/diff';
 export type { GitHeadModel } from './models/head';
 export type { Commit, CommitFile, GitLogResult } from './models/log';
 export type { DiffMode, DiffTarget, GitObjectRef, MergeBaseRange } from './models/diff-target';

--- a/packages/shared/src/git/index.ts
+++ b/packages/shared/src/git/index.ts
@@ -1,0 +1,62 @@
+export { GitRuntime, type GitRuntimeOptions } from './git-runtime';
+export type {
+  CommitError,
+  CreateBranchError,
+  DeleteBranchError,
+  FetchError,
+  FetchPrForReviewError,
+  GitCommandError,
+  PullError,
+  PushError,
+  RenameBranchError,
+  SoftResetError,
+} from './errors';
+export type {
+  DiffLine,
+  DiffResult,
+  ImageBlob,
+  ImageReadResult,
+  ImageUnavailableReason,
+} from './models/diff';
+export type { GitHeadModel } from './models/head';
+export type { Commit, CommitFile, GitLogResult } from './models/log';
+export type {
+  DiffMode,
+  DiffTarget,
+  GitBranch,
+  GitObjectRef,
+  GitRefsModel,
+  GitRemote,
+  GitRemotesModel,
+  MergeBaseRange,
+} from './models/refs';
+export type {
+  GitChange,
+  GitChangeStatus,
+  GitStatusData,
+  GitStatusError,
+  GitStatusFingerprint,
+  GitStatusModel,
+  GitStatusUntrackedMode,
+} from './models/status';
+export type {
+  CreateBranchOptions,
+  FetchPrForReviewOptions,
+  GitLogOptions,
+  GitModelByKind,
+  GitModelKind,
+  GitModelUpdate,
+  GitRepoModelKind,
+  GitRepoSnapshot,
+  GitRepoUpdate,
+  GitSeqs,
+  GitWorktreeModelKind,
+  GitWorktreeSnapshot,
+  GitWorktreeUpdate,
+  IGitRepository,
+  IGitRuntime,
+  IGitWorktree,
+  RepoLease,
+  SubscribedSnapshot,
+  WorktreeLease,
+} from './types';

--- a/packages/shared/src/git/index.ts
+++ b/packages/shared/src/git/index.ts
@@ -20,16 +20,8 @@ export type {
 } from './models/diff';
 export type { GitHeadModel } from './models/head';
 export type { Commit, CommitFile, GitLogResult } from './models/log';
-export type {
-  DiffMode,
-  DiffTarget,
-  GitBranch,
-  GitObjectRef,
-  GitRefsModel,
-  GitRemote,
-  GitRemotesModel,
-  MergeBaseRange,
-} from './models/refs';
+export type { DiffMode, DiffTarget, GitObjectRef, MergeBaseRange } from './models/diff-target';
+export type { GitBranch, GitRefsModel, GitRemote, GitRemotesModel } from './models/refs';
 export type {
   GitChange,
   GitChangeStatus,

--- a/packages/shared/src/git/models/diff-target.ts
+++ b/packages/shared/src/git/models/diff-target.ts
@@ -1,0 +1,32 @@
+import type { GitBranch } from './refs';
+
+export type DiffMode = { kind: 'head' } | { kind: 'staged' };
+
+export type GitObjectRef =
+  | { kind: 'branch'; branch: GitBranch }
+  | { kind: 'commit'; sha: string }
+  | { kind: 'tag'; name: string };
+
+export type MergeBaseRange = {
+  base: GitObjectRef;
+  head: GitObjectRef;
+};
+
+export type DiffTarget = DiffMode | GitObjectRef | MergeBaseRange;
+
+export function toRefString(ref: GitObjectRef): string {
+  switch (ref.kind) {
+    case 'branch':
+      return ref.branch.type === 'remote'
+        ? `${ref.branch.remote.name}/${ref.branch.branch}`
+        : ref.branch.branch;
+    case 'commit':
+      return ref.sha;
+    case 'tag':
+      return ref.name;
+  }
+}
+
+export function toRangeString(range: MergeBaseRange): string {
+  return `${toRefString(range.base)}...${toRefString(range.head)}`;
+}

--- a/packages/shared/src/git/models/diff.ts
+++ b/packages/shared/src/git/models/diff.ts
@@ -1,0 +1,25 @@
+export type DiffLine = {
+  left?: string;
+  right?: string;
+  type: 'context' | 'add' | 'del';
+};
+
+export type ImageBlob = {
+  dataUrl: string;
+  mimeType: string;
+  size: number;
+};
+
+export type ImageUnavailableReason = 'unsupported' | 'too-large' | 'lfs-pointer' | 'git-error';
+
+export type ImageReadResult =
+  | { kind: 'image'; image: ImageBlob }
+  | { kind: 'missing' }
+  | { kind: 'unavailable'; reason: ImageUnavailableReason };
+
+export type DiffResult = {
+  lines: DiffLine[];
+  isBinary?: boolean;
+  originalContent?: string;
+  modifiedContent?: string;
+};

--- a/packages/shared/src/git/models/diff.ts
+++ b/packages/shared/src/git/models/diff.ts
@@ -1,9 +1,3 @@
-export type DiffLine = {
-  left?: string;
-  right?: string;
-  type: 'context' | 'add' | 'del';
-};
-
 export type ImageBlob = {
   dataUrl: string;
   mimeType: string;
@@ -16,10 +10,3 @@ export type ImageReadResult =
   | { kind: 'image'; image: ImageBlob }
   | { kind: 'missing' }
   | { kind: 'unavailable'; reason: ImageUnavailableReason };
-
-export type DiffResult = {
-  lines: DiffLine[];
-  isBinary?: boolean;
-  originalContent?: string;
-  modifiedContent?: string;
-};

--- a/packages/shared/src/git/models/head.ts
+++ b/packages/shared/src/git/models/head.ts
@@ -1,0 +1,4 @@
+export type GitHeadModel =
+  | { kind: 'branch'; name: string }
+  | { kind: 'detached'; shortHash: string }
+  | { kind: 'unborn'; name: string };

--- a/packages/shared/src/git/models/log.ts
+++ b/packages/shared/src/git/models/log.ts
@@ -1,0 +1,24 @@
+import type { GitChangeStatus } from './status';
+
+export type Commit = {
+  hash: string;
+  parents: string[];
+  subject: string;
+  body: string;
+  author: string;
+  date: string;
+  isPushed: boolean;
+  tags: string[];
+};
+
+export type CommitFile = {
+  path: string;
+  status: GitChangeStatus;
+  additions: number;
+  deletions: number;
+};
+
+export type GitLogResult = {
+  commits: Commit[];
+  aheadCount: number;
+};

--- a/packages/shared/src/git/models/refs.ts
+++ b/packages/shared/src/git/models/refs.ts
@@ -19,34 +19,3 @@ export type GitRefsModel = {
 export type GitRemotesModel = {
   remotes: GitRemote[];
 };
-
-export type DiffMode = { kind: 'head' } | { kind: 'staged' };
-
-export type GitObjectRef =
-  | { kind: 'branch'; branch: GitBranch }
-  | { kind: 'commit'; sha: string }
-  | { kind: 'tag'; name: string };
-
-export type MergeBaseRange = {
-  base: GitObjectRef;
-  head: GitObjectRef;
-};
-
-export type DiffTarget = DiffMode | GitObjectRef | MergeBaseRange;
-
-export function toRefString(ref: GitObjectRef): string {
-  switch (ref.kind) {
-    case 'branch':
-      return ref.branch.type === 'remote'
-        ? `${ref.branch.remote.name}/${ref.branch.branch}`
-        : ref.branch.branch;
-    case 'commit':
-      return ref.sha;
-    case 'tag':
-      return ref.name;
-  }
-}
-
-export function toRangeString(range: MergeBaseRange): string {
-  return `${toRefString(range.base)}...${toRefString(range.head)}`;
-}

--- a/packages/shared/src/git/models/refs.ts
+++ b/packages/shared/src/git/models/refs.ts
@@ -1,0 +1,52 @@
+export type GitRemote = {
+  name: string;
+  url: string;
+};
+
+export type GitBranch =
+  | {
+      type: 'local';
+      branch: string;
+      remote?: GitRemote;
+      divergence?: { ahead: number; behind: number };
+    }
+  | { type: 'remote'; branch: string; remote: GitRemote };
+
+export type GitRefsModel = {
+  branches: GitBranch[];
+};
+
+export type GitRemotesModel = {
+  remotes: GitRemote[];
+};
+
+export type DiffMode = { kind: 'head' } | { kind: 'staged' };
+
+export type GitObjectRef =
+  | { kind: 'branch'; branch: GitBranch }
+  | { kind: 'commit'; sha: string }
+  | { kind: 'tag'; name: string };
+
+export type MergeBaseRange = {
+  base: GitObjectRef;
+  head: GitObjectRef;
+};
+
+export type DiffTarget = DiffMode | GitObjectRef | MergeBaseRange;
+
+export function toRefString(ref: GitObjectRef): string {
+  switch (ref.kind) {
+    case 'branch':
+      return ref.branch.type === 'remote'
+        ? `${ref.branch.remote.name}/${ref.branch.branch}`
+        : ref.branch.branch;
+    case 'commit':
+      return ref.sha;
+    case 'tag':
+      return ref.name;
+  }
+}
+
+export function toRangeString(range: MergeBaseRange): string {
+  return `${toRefString(range.base)}...${toRefString(range.head)}`;
+}

--- a/packages/shared/src/git/models/status.ts
+++ b/packages/shared/src/git/models/status.ts
@@ -1,0 +1,30 @@
+export type GitChangeStatus = 'added' | 'modified' | 'deleted' | 'renamed' | 'conflicted';
+
+export type GitChange = {
+  path: string;
+  status: GitChangeStatus;
+  additions: number;
+  deletions: number;
+};
+
+export type GitStatusData = {
+  kind: 'ok';
+  staged: GitChange[];
+  unstaged: GitChange[];
+  stagedAdded: number;
+  stagedDeleted: number;
+};
+
+export type GitStatusError = {
+  kind: 'error';
+  message: string;
+};
+
+export type GitStatusModel = GitStatusData | { kind: 'too-many-files' } | GitStatusError;
+
+export type GitStatusUntrackedMode = 'no' | 'normal';
+
+export type GitStatusFingerprint = {
+  hash: string;
+  byteLength: number;
+};

--- a/packages/shared/src/git/parsers/diff-parser.test.ts
+++ b/packages/shared/src/git/parsers/diff-parser.test.ts
@@ -1,37 +1,8 @@
 import { describe, expect, it } from 'vitest';
-import { mapGitChangeStatus, parseDiffLines } from './diff-parser';
+import { mapGitChangeStatus } from './diff-parser';
 
 describe('diff parser', () => {
-  it('parses text diff hunks while skipping git headers', () => {
-    const diff = [
-      'diff --git a/a.txt b/a.txt',
-      'index 1111111..2222222 100644',
-      '--- a/a.txt',
-      '+++ b/a.txt',
-      '@@ -1,2 +1,2 @@',
-      ' unchanged',
-      '-old',
-      '+new',
-      '\\ No newline at end of file',
-      '',
-    ].join('\n');
-
-    expect(parseDiffLines(diff)).toEqual({
-      isBinary: false,
-      lines: [
-        { left: 'unchanged', right: 'unchanged', type: 'context' },
-        { left: 'old', type: 'del' },
-        { right: 'new', type: 'add' },
-      ],
-    });
-  });
-
-  it('detects binary diffs and maps git status codes', () => {
-    expect(parseDiffLines('Binary files a/image.png and b/image.png differ\n')).toEqual({
-      isBinary: true,
-      lines: [],
-    });
-
+  it('maps git status codes', () => {
     expect(mapGitChangeStatus('??')).toBe('added');
     expect(mapGitChangeStatus(' D')).toBe('deleted');
     expect(mapGitChangeStatus('R100')).toBe('renamed');

--- a/packages/shared/src/git/parsers/diff-parser.test.ts
+++ b/packages/shared/src/git/parsers/diff-parser.test.ts
@@ -1,0 +1,41 @@
+import { describe, expect, it } from 'vitest';
+import { mapGitChangeStatus, parseDiffLines } from './diff-parser';
+
+describe('diff parser', () => {
+  it('parses text diff hunks while skipping git headers', () => {
+    const diff = [
+      'diff --git a/a.txt b/a.txt',
+      'index 1111111..2222222 100644',
+      '--- a/a.txt',
+      '+++ b/a.txt',
+      '@@ -1,2 +1,2 @@',
+      ' unchanged',
+      '-old',
+      '+new',
+      '\\ No newline at end of file',
+      '',
+    ].join('\n');
+
+    expect(parseDiffLines(diff)).toEqual({
+      isBinary: false,
+      lines: [
+        { left: 'unchanged', right: 'unchanged', type: 'context' },
+        { left: 'old', type: 'del' },
+        { right: 'new', type: 'add' },
+      ],
+    });
+  });
+
+  it('detects binary diffs and maps git status codes', () => {
+    expect(parseDiffLines('Binary files a/image.png and b/image.png differ\n')).toEqual({
+      isBinary: true,
+      lines: [],
+    });
+
+    expect(mapGitChangeStatus('??')).toBe('added');
+    expect(mapGitChangeStatus(' D')).toBe('deleted');
+    expect(mapGitChangeStatus('R100')).toBe('renamed');
+    expect(mapGitChangeStatus('UU')).toBe('conflicted');
+    expect(mapGitChangeStatus(' M')).toBe('modified');
+  });
+});

--- a/packages/shared/src/git/parsers/diff-parser.ts
+++ b/packages/shared/src/git/parsers/diff-parser.ts
@@ -1,20 +1,4 @@
-import type { DiffLine } from '../models/diff';
 import type { GitChangeStatus } from '../models/status';
-
-const DIFF_HEADER_PREFIXES = [
-  'diff ',
-  'index ',
-  '--- ',
-  '+++ ',
-  '@@',
-  'new file mode',
-  'old file mode',
-  'deleted file mode',
-  'similarity index',
-  'rename from',
-  'rename to',
-  'Binary files',
-];
 
 export function mapGitChangeStatus(code: string): GitChangeStatus {
   if (code.includes('U') || code === 'AA' || code === 'DD') return 'conflicted';
@@ -22,31 +6,4 @@ export function mapGitChangeStatus(code: string): GitChangeStatus {
   if (code.includes('D')) return 'deleted';
   if (code.includes('R')) return 'renamed';
   return 'modified';
-}
-
-export function parseDiffLines(stdout: string): { lines: DiffLine[]; isBinary: boolean } {
-  const lines: DiffLine[] = [];
-
-  for (const line of stdout.split('\n')) {
-    if (!line) continue;
-    if (DIFF_HEADER_PREFIXES.some((prefix) => line.startsWith(prefix))) continue;
-
-    const prefix = line[0];
-    const content = line.slice(1);
-    if (prefix === '\\') continue;
-    if (prefix === ' ') {
-      lines.push({ left: content, right: content, type: 'context' });
-    } else if (prefix === '-') {
-      lines.push({ left: content, type: 'del' });
-    } else if (prefix === '+') {
-      lines.push({ right: content, type: 'add' });
-    } else {
-      lines.push({ left: line, right: line, type: 'context' });
-    }
-  }
-
-  return {
-    lines,
-    isBinary: lines.length === 0 && stdout.includes('Binary files'),
-  };
 }

--- a/packages/shared/src/git/parsers/diff-parser.ts
+++ b/packages/shared/src/git/parsers/diff-parser.ts
@@ -1,0 +1,52 @@
+import type { DiffLine } from '../models/diff';
+import type { GitChangeStatus } from '../models/status';
+
+const DIFF_HEADER_PREFIXES = [
+  'diff ',
+  'index ',
+  '--- ',
+  '+++ ',
+  '@@',
+  'new file mode',
+  'old file mode',
+  'deleted file mode',
+  'similarity index',
+  'rename from',
+  'rename to',
+  'Binary files',
+];
+
+export function mapGitChangeStatus(code: string): GitChangeStatus {
+  if (code.includes('U') || code === 'AA' || code === 'DD') return 'conflicted';
+  if (code.includes('A') || code.includes('?')) return 'added';
+  if (code.includes('D')) return 'deleted';
+  if (code.includes('R')) return 'renamed';
+  return 'modified';
+}
+
+export function parseDiffLines(stdout: string): { lines: DiffLine[]; isBinary: boolean } {
+  const lines: DiffLine[] = [];
+
+  for (const line of stdout.split('\n')) {
+    if (!line) continue;
+    if (DIFF_HEADER_PREFIXES.some((prefix) => line.startsWith(prefix))) continue;
+
+    const prefix = line[0];
+    const content = line.slice(1);
+    if (prefix === '\\') continue;
+    if (prefix === ' ') {
+      lines.push({ left: content, right: content, type: 'context' });
+    } else if (prefix === '-') {
+      lines.push({ left: content, type: 'del' });
+    } else if (prefix === '+') {
+      lines.push({ right: content, type: 'add' });
+    } else {
+      lines.push({ left: line, right: line, type: 'context' });
+    }
+  }
+
+  return {
+    lines,
+    isBinary: lines.length === 0 && stdout.includes('Binary files'),
+  };
+}

--- a/packages/shared/src/git/parsers/status-parser.test.ts
+++ b/packages/shared/src/git/parsers/status-parser.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest';
+import { MAX_STATUS_FILES, StatusParser } from './status-parser';
+
+describe('StatusParser', () => {
+  it('parses porcelain v1 NUL-delimited status entries', () => {
+    const parser = new StatusParser();
+
+    parser.update(' M src/foo.ts\0R  new.ts\0old.ts\0?? untracked.ts\0UU conflict.ts\0');
+
+    expect(parser.status).toEqual([
+      { x: ' ', y: 'M', path: 'src/foo.ts' },
+      { x: 'R', y: ' ', rename: 'new.ts', path: 'old.ts' },
+      { x: '?', y: '?', path: 'untracked.ts' },
+      { x: 'U', y: 'U', path: 'conflict.ts' },
+    ]);
+  });
+
+  it('buffers split entries and skips nested git repository directory markers', () => {
+    const parser = new StatusParser();
+
+    parser.update(' M src/');
+    parser.update('foo.ts\0?? vendor/sub/\0');
+
+    expect(parser.status).toEqual([{ x: ' ', y: 'M', path: 'src/foo.ts' }]);
+  });
+
+  it('marks the stream as too large once the status file limit is exceeded', () => {
+    const parser = new StatusParser();
+    let chunk = '';
+    for (let i = 0; i < MAX_STATUS_FILES + 2; i++) {
+      chunk += ` M f${i}.ts\0`;
+    }
+
+    parser.update(chunk);
+
+    expect(parser.tooManyFiles).toBe(true);
+    expect(parser.status.length).toBeGreaterThanOrEqual(MAX_STATUS_FILES);
+  });
+});

--- a/packages/shared/src/git/parsers/status-parser.ts
+++ b/packages/shared/src/git/parsers/status-parser.ts
@@ -1,0 +1,76 @@
+export const MAX_STATUS_FILES = 10_000;
+
+export class TooManyFilesChangedError extends Error {
+  override readonly name = 'TooManyFilesChangedError';
+
+  constructor() {
+    super('Too many changed files');
+  }
+}
+
+export type FileStatus = {
+  x: string;
+  y: string;
+  rename?: string;
+  path: string;
+};
+
+export class StatusParser {
+  private lastRaw = '';
+  private result: FileStatus[] = [];
+  tooManyFiles = false;
+
+  get status(): FileStatus[] {
+    return this.result;
+  }
+
+  update(chunk: string): void {
+    let raw = this.lastRaw + chunk;
+    let index = 0;
+    let nextIndex: number | undefined;
+
+    while ((nextIndex = this.parseEntry(raw, index)) !== undefined) {
+      index = nextIndex;
+      if (this.result.length > MAX_STATUS_FILES) {
+        this.tooManyFiles = true;
+        raw = '';
+        index = 0;
+        break;
+      }
+    }
+
+    this.lastRaw = raw.slice(index);
+  }
+
+  reset(): void {
+    this.lastRaw = '';
+    this.result = [];
+    this.tooManyFiles = false;
+  }
+
+  private parseEntry(raw: string, index: number): number | undefined {
+    if (index + 4 > raw.length) return undefined;
+
+    const x = raw.charAt(index++);
+    const y = raw.charAt(index++);
+    index += 1;
+
+    let rename: string | undefined;
+    if (x === 'R' || y === 'R' || x === 'C') {
+      const renameEnd = raw.indexOf('\0', index);
+      if (renameEnd === -1) return undefined;
+      rename = raw.substring(index, renameEnd);
+      index = renameEnd + 1;
+    }
+
+    const pathEnd = raw.indexOf('\0', index);
+    if (pathEnd === -1) return undefined;
+
+    const filePath = raw.substring(index, pathEnd);
+    if (filePath.length > 0 && filePath[filePath.length - 1] !== '/') {
+      this.result.push({ x, y, rename, path: filePath });
+    }
+
+    return pathEnd + 1;
+  }
+}

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -104,7 +104,6 @@ export interface IGitRepository extends IDisposable {
   getRefs(): Promise<GitRefsModel>;
   getRemotes(): Promise<GitRemotesModel>;
   getSnapshot(): Promise<GitRepoSnapshot>;
-  /** Force-recompute all repository models and push to subscribers (manual refresh). */
   refresh(): Promise<GitRepoSnapshot>;
   subscribe(cb: (update: GitRepoUpdate) => void): Unsubscribe;
   subscribeWithSnapshot(
@@ -114,7 +113,6 @@ export interface IGitRepository extends IDisposable {
   fetch(remote?: string): Promise<Result<{ seqs: GitSeqs }, FetchError>>;
   addRemote(name: string, url: string): Promise<Result<{ seqs: GitSeqs }, GitCommandError>>;
   createBranch(options: CreateBranchOptions): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
-  createBranch(name: string, from?: string): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
   renameBranch(
     oldBranch: string,
     newBranch: string
@@ -139,7 +137,6 @@ export interface IGitWorktree extends IDisposable {
   getStatus(): Promise<GitStatusModel>;
   getHead(): Promise<GitHeadModel>;
   getSnapshot(): Promise<GitWorktreeSnapshot>;
-  /** Force-recompute all worktree models and push to subscribers (manual refresh). */
   refresh(): Promise<GitWorktreeSnapshot>;
   subscribe(cb: (update: GitWorktreeUpdate) => void): Unsubscribe;
   subscribeWithSnapshot(

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -101,14 +101,20 @@ export type WorktreeLease = Lease<IGitWorktree>;
 export interface IGitRepository extends IDisposable {
   readonly gitCommonDir: string;
   readonly objectStoreDir: string;
+
+  /** Read models for the repository. */
   getRefs(): Promise<GitRefsModel>;
   getRemotes(): Promise<GitRemotesModel>;
+
+  /** Repository lifecycle operations. */
   getSnapshot(): Promise<GitRepoSnapshot>;
   refresh(): Promise<GitRepoSnapshot>;
   subscribe(cb: (update: GitRepoUpdate) => void): Unsubscribe;
   subscribeWithSnapshot(
     cb: (update: GitRepoUpdate) => void
   ): Promise<SubscribedSnapshot<GitRepoSnapshot>>;
+
+  /** Repository git operations. */
   getDefaultBranch(remote?: string): Promise<string>;
   fetch(remote?: string): Promise<Result<{ seqs: GitSeqs }, FetchError>>;
   addRemote(name: string, url: string): Promise<Result<{ seqs: GitSeqs }, GitCommandError>>;
@@ -134,14 +140,20 @@ export interface IGitRepository extends IDisposable {
 export interface IGitWorktree extends IDisposable {
   readonly worktree: string;
   readonly repository: IGitRepository;
+
+  /** Read models for the worktree. */
   getStatus(): Promise<GitStatusModel>;
   getHead(): Promise<GitHeadModel>;
+
+  /** Worktree lifecycle operations. */
   getSnapshot(): Promise<GitWorktreeSnapshot>;
   refresh(): Promise<GitWorktreeSnapshot>;
   subscribe(cb: (update: GitWorktreeUpdate) => void): Unsubscribe;
   subscribeWithSnapshot(
     cb: (update: GitWorktreeUpdate) => void
   ): Promise<SubscribedSnapshot<GitWorktreeSnapshot>>;
+
+  /** Worktree git operations. */
   getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint>;
   isFileCleanlyTracked(filePath: string): Promise<boolean>;
   getChangedFiles(base: DiffTarget): Promise<GitChange[]>;

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -168,8 +168,11 @@ export interface IGitWorktree extends IDisposable {
   getLatestCommit(): Promise<Commit | null>;
   getCommitFiles(hash: string): Promise<CommitFile[]>;
   stage(paths: string[]): Promise<GitSeqs>;
+  stageAll(): Promise<GitSeqs>;
   unstage(paths: string[]): Promise<GitSeqs>;
+  unstageAll(): Promise<GitSeqs>;
   revert(paths: string[]): Promise<GitSeqs>;
+  revertAll(): Promise<GitSeqs>;
   commit(message: string): Promise<Result<{ hash: string; seqs: GitSeqs }, CommitError>>;
   push(remote?: string): Promise<Result<{ output: string; seqs: GitSeqs }, PushError>>;
   pull(): Promise<Result<{ output: string; seqs: GitSeqs }, PullError>>;

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -1,0 +1,172 @@
+import type { IDisposable, Lease, LiveValue, Unsubscribe } from '../lib';
+import type { Result } from '../lib/result';
+import type {
+  CommitError,
+  CreateBranchError,
+  DeleteBranchError,
+  FetchError,
+  FetchPrForReviewError,
+  GitCommandError,
+  PullError,
+  PushError,
+  RenameBranchError,
+  SoftResetError,
+} from './errors';
+import type { DiffResult, ImageReadResult } from './models/diff';
+import type { GitHeadModel } from './models/head';
+import type { Commit, CommitFile, GitLogResult } from './models/log';
+import type { DiffTarget, GitRefsModel, GitRemotesModel } from './models/refs';
+import type {
+  GitChange,
+  GitStatusFingerprint,
+  GitStatusModel,
+  GitStatusUntrackedMode,
+} from './models/status';
+
+export type GitRepoModelKind = 'refs' | 'remotes';
+export type GitWorktreeModelKind = 'status' | 'head';
+
+export type GitModelKind = GitRepoModelKind | GitWorktreeModelKind;
+
+export type GitModelByKind = {
+  status: GitStatusModel;
+  head: GitHeadModel;
+  refs: GitRefsModel;
+  remotes: GitRemotesModel;
+};
+
+export type GitModelUpdate<K extends GitModelKind = GitModelKind> = {
+  [Kind in K]: {
+    kind: Kind;
+    seq: number;
+    model: GitModelByKind[Kind];
+  };
+}[K];
+
+export type GitWorktreeUpdate = GitModelUpdate<GitWorktreeModelKind>;
+export type GitRepoUpdate = GitModelUpdate<GitRepoModelKind>;
+
+/**
+ * Seqs of the models a mutation refreshed (read-your-writes): a client applying pushed
+ * updates knows its cache caught up with this mutation once it has seen these seqs.
+ */
+export type GitSeqs = Partial<Record<GitModelKind, number>>;
+
+export type GitWorktreeSnapshot = {
+  status: LiveValue<GitStatusModel>;
+  head: LiveValue<GitHeadModel>;
+};
+
+export type GitRepoSnapshot = {
+  refs: LiveValue<GitRefsModel>;
+  remotes: LiveValue<GitRemotesModel>;
+};
+
+export type SubscribedSnapshot<Snapshot> = {
+  snapshot: Snapshot;
+  unsubscribe: Unsubscribe;
+};
+
+export type CreateBranchOptions = {
+  name: string;
+  from?: string;
+  syncWithRemote?: boolean;
+  remote?: string;
+};
+
+export type FetchPrForReviewOptions = {
+  prNumber: number;
+  headRefName: string;
+  headRepositoryUrl: string;
+  localBranch: string;
+  isFork: boolean;
+  configuredRemote?: string;
+};
+
+export type GitLogOptions = {
+  maxCount?: number;
+  limit?: number;
+  skip?: number;
+  knownAheadCount?: number;
+  preferredRemote?: string;
+  base?: Extract<DiffTarget, { kind: 'branch' | 'commit' | 'tag' }>;
+  head?: Extract<DiffTarget, { kind: 'branch' | 'commit' | 'tag' }>;
+};
+
+export type RepoLease = Lease<IGitRepository>;
+
+export type WorktreeLease = Lease<IGitWorktree>;
+
+export interface IGitRepository extends IDisposable {
+  readonly gitCommonDir: string;
+  readonly objectStoreDir: string;
+  getRefs(): Promise<GitRefsModel>;
+  getRemotes(): Promise<GitRemotesModel>;
+  getSnapshot(): Promise<GitRepoSnapshot>;
+  /** Force-recompute all repository models and push to subscribers (manual refresh). */
+  refresh(): Promise<GitRepoSnapshot>;
+  subscribe(cb: (update: GitRepoUpdate) => void): Unsubscribe;
+  subscribeWithSnapshot(
+    cb: (update: GitRepoUpdate) => void
+  ): Promise<SubscribedSnapshot<GitRepoSnapshot>>;
+  getDefaultBranch(remote?: string): Promise<string>;
+  fetch(remote?: string): Promise<Result<{ seqs: GitSeqs }, FetchError>>;
+  addRemote(name: string, url: string): Promise<Result<{ seqs: GitSeqs }, GitCommandError>>;
+  createBranch(options: CreateBranchOptions): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
+  createBranch(name: string, from?: string): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
+  renameBranch(
+    oldBranch: string,
+    newBranch: string
+  ): Promise<Result<{ seqs: GitSeqs }, RenameBranchError>>;
+  deleteBranch(
+    branch: string,
+    force?: boolean
+  ): Promise<Result<{ seqs: GitSeqs }, DeleteBranchError>>;
+  fetchPrForReview(
+    options: FetchPrForReviewOptions
+  ): Promise<Result<{ seqs: GitSeqs }, FetchPrForReviewError>>;
+  publishBranch(
+    branchName: string,
+    remote?: string
+  ): Promise<Result<{ output: string; seqs: GitSeqs }, PushError>>;
+  readBlobAtRef(ref: string, filePath: string): Promise<string | null>;
+}
+
+export interface IGitWorktree extends IDisposable {
+  readonly workTree: string;
+  readonly repository: IGitRepository;
+  getStatus(): Promise<GitStatusModel>;
+  getHead(): Promise<GitHeadModel>;
+  getSnapshot(): Promise<GitWorktreeSnapshot>;
+  /** Force-recompute all worktree models and push to subscribers (manual refresh). */
+  refresh(): Promise<GitWorktreeSnapshot>;
+  subscribe(cb: (update: GitWorktreeUpdate) => void): Unsubscribe;
+  subscribeWithSnapshot(
+    cb: (update: GitWorktreeUpdate) => void
+  ): Promise<SubscribedSnapshot<GitWorktreeSnapshot>>;
+  getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint>;
+  isFileCleanlyTracked(filePath: string): Promise<boolean>;
+  getChangedFiles(base: DiffTarget): Promise<GitChange[]>;
+  getFileDiff(filePath: string, base?: string): Promise<DiffResult>;
+  getFileAtHead(filePath: string): Promise<string | null>;
+  getFileAtRef(filePath: string, ref: string): Promise<string | null>;
+  getFileAtIndex(filePath: string): Promise<string | null>;
+  getImageAtRef(filePath: string, ref: string): Promise<ImageReadResult>;
+  getImageAtIndex(filePath: string): Promise<ImageReadResult>;
+  getCommitFileDiff(commitHash: string, filePath: string): Promise<DiffResult>;
+  getLog(options?: GitLogOptions): Promise<GitLogResult>;
+  getLatestCommit(): Promise<Commit | null>;
+  getCommitFiles(hash: string): Promise<CommitFile[]>;
+  stage(paths: string[]): Promise<GitSeqs>;
+  unstage(paths: string[]): Promise<GitSeqs>;
+  revert(paths: string[]): Promise<GitSeqs>;
+  commit(message: string): Promise<Result<{ hash: string; seqs: GitSeqs }, CommitError>>;
+  push(remote?: string): Promise<Result<{ output: string; seqs: GitSeqs }, PushError>>;
+  pull(): Promise<Result<{ output: string; seqs: GitSeqs }, PullError>>;
+  softReset(): Promise<Result<{ subject: string; body: string; seqs: GitSeqs }, SoftResetError>>;
+}
+
+export interface IGitRuntime extends IDisposable {
+  openRepository(pathInsideRepo: string): Promise<RepoLease>;
+  openWorktree(worktreePath: string): Promise<WorktreeLease>;
+}

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -132,7 +132,7 @@ export interface IGitRepository extends IDisposable {
 }
 
 export interface IGitWorktree extends IDisposable {
-  readonly workTree: string;
+  readonly worktree: string;
   readonly repository: IGitRepository;
   getStatus(): Promise<GitStatusModel>;
   getHead(): Promise<GitHeadModel>;

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -13,9 +13,10 @@ import type {
   SoftResetError,
 } from './errors';
 import type { DiffResult, ImageReadResult } from './models/diff';
+import type { DiffTarget } from './models/diff-target';
 import type { GitHeadModel } from './models/head';
 import type { Commit, CommitFile, GitLogResult } from './models/log';
-import type { DiffTarget, GitRefsModel, GitRemotesModel } from './models/refs';
+import type { GitRefsModel, GitRemotesModel } from './models/refs';
 import type {
   GitChange,
   GitStatusFingerprint,

--- a/packages/shared/src/git/types.ts
+++ b/packages/shared/src/git/types.ts
@@ -9,13 +9,11 @@ import type {
   GitCommandError,
   PullError,
   PushError,
-  RenameBranchError,
-  SoftResetError,
 } from './errors';
-import type { DiffResult, ImageReadResult } from './models/diff';
+import type { ImageReadResult } from './models/diff';
 import type { DiffTarget } from './models/diff-target';
 import type { GitHeadModel } from './models/head';
-import type { Commit, CommitFile, GitLogResult } from './models/log';
+import type { CommitFile, GitLogResult } from './models/log';
 import type { GitRefsModel, GitRemotesModel } from './models/refs';
 import type {
   GitChange,
@@ -119,10 +117,6 @@ export interface IGitRepository extends IDisposable {
   fetch(remote?: string): Promise<Result<{ seqs: GitSeqs }, FetchError>>;
   addRemote(name: string, url: string): Promise<Result<{ seqs: GitSeqs }, GitCommandError>>;
   createBranch(options: CreateBranchOptions): Promise<Result<{ seqs: GitSeqs }, CreateBranchError>>;
-  renameBranch(
-    oldBranch: string,
-    newBranch: string
-  ): Promise<Result<{ seqs: GitSeqs }, RenameBranchError>>;
   deleteBranch(
     branch: string,
     force?: boolean
@@ -157,15 +151,11 @@ export interface IGitWorktree extends IDisposable {
   getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint>;
   isFileCleanlyTracked(filePath: string): Promise<boolean>;
   getChangedFiles(base: DiffTarget): Promise<GitChange[]>;
-  getFileDiff(filePath: string, base?: string): Promise<DiffResult>;
-  getFileAtHead(filePath: string): Promise<string | null>;
   getFileAtRef(filePath: string, ref: string): Promise<string | null>;
   getFileAtIndex(filePath: string): Promise<string | null>;
   getImageAtRef(filePath: string, ref: string): Promise<ImageReadResult>;
   getImageAtIndex(filePath: string): Promise<ImageReadResult>;
-  getCommitFileDiff(commitHash: string, filePath: string): Promise<DiffResult>;
   getLog(options?: GitLogOptions): Promise<GitLogResult>;
-  getLatestCommit(): Promise<Commit | null>;
   getCommitFiles(hash: string): Promise<CommitFile[]>;
   stage(paths: string[]): Promise<GitSeqs>;
   stageAll(): Promise<GitSeqs>;
@@ -176,7 +166,6 @@ export interface IGitWorktree extends IDisposable {
   commit(message: string): Promise<Result<{ hash: string; seqs: GitSeqs }, CommitError>>;
   push(remote?: string): Promise<Result<{ output: string; seqs: GitSeqs }, PushError>>;
   pull(): Promise<Result<{ output: string; seqs: GitSeqs }, PullError>>;
-  softReset(): Promise<Result<{ subject: string; body: string; seqs: GitSeqs }, SoftResetError>>;
 }
 
 export interface IGitRuntime extends IDisposable {

--- a/packages/shared/src/git/watch/classifier.test.ts
+++ b/packages/shared/src/git/watch/classifier.test.ts
@@ -1,0 +1,27 @@
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { classifyGitWatchEvents } from './classifier';
+
+describe('classifyGitWatchEvents', () => {
+  it('treats config changes as refs and remotes staleness', () => {
+    const gitCommonDir = path.join(path.sep, 'repo', '.git');
+
+    const classification = classifyGitWatchEvents(
+      [{ kind: 'update', path: path.join(gitCommonDir, 'config') }],
+      { gitCommonDir, worktrees: [] }
+    );
+
+    expect(classification.repo).toEqual({ refs: true, remotes: true });
+  });
+
+  it('ignores object database writes for repo facts', () => {
+    const gitCommonDir = path.join(path.sep, 'repo', '.git');
+
+    const classification = classifyGitWatchEvents(
+      [{ kind: 'create', path: path.join(gitCommonDir, 'objects', 'aa', 'bbbb') }],
+      { gitCommonDir, worktrees: [] }
+    );
+
+    expect(classification.repo).toEqual({ refs: false, remotes: false });
+  });
+});

--- a/packages/shared/src/git/watch/classifier.ts
+++ b/packages/shared/src/git/watch/classifier.ts
@@ -1,0 +1,96 @@
+import path from 'node:path';
+import type { RawFileEvent } from '../../fs';
+
+export type RepoWatchEffects = {
+  refs: boolean;
+  remotes: boolean;
+};
+
+export type WorktreeWatchEffects = {
+  status: boolean;
+  head: boolean;
+};
+
+export type GitLayout = {
+  gitCommonDir: string;
+  worktrees: { id: string; gitDir: string; workTree: string }[];
+};
+
+export type GitWatchClassification = {
+  repo: RepoWatchEffects;
+  worktrees: Map<string, WorktreeWatchEffects>;
+};
+
+export function classifyGitWatchEvents(
+  events: RawFileEvent[],
+  layout: GitLayout
+): GitWatchClassification {
+  const repo: RepoWatchEffects = { refs: false, remotes: false };
+  const worktrees = new Map<string, WorktreeWatchEffects>();
+  const gitCommonDir = normalize(layout.gitCommonDir);
+  const normalizedWorktrees = layout.worktrees.map((worktree) => ({
+    ...worktree,
+    gitDir: normalize(worktree.gitDir),
+    workTree: normalize(worktree.workTree),
+  }));
+
+  const addWorktreeEffect = (id: string, effect: keyof WorktreeWatchEffects) => {
+    const current = worktrees.get(id) ?? { status: false, head: false };
+    current[effect] = true;
+    worktrees.set(id, current);
+  };
+
+  for (const event of events) {
+    const eventPath = normalize(event.path);
+    const commonRel = relativeInside(gitCommonDir, eventPath);
+    if (commonRel !== null) {
+      classifyCommonGitPath(commonRel, repo);
+    }
+
+    for (const worktree of normalizedWorktrees) {
+      const gitRel = relativeInside(worktree.gitDir, eventPath);
+      if (gitRel !== null) {
+        if (gitRel === 'HEAD') addWorktreeEffect(worktree.id, 'head');
+        if (gitRel === 'index') addWorktreeEffect(worktree.id, 'status');
+      }
+
+      const workTreeRel = relativeInside(worktree.workTree, eventPath);
+      if (workTreeRel !== null && !isDotGitPath(workTreeRel)) {
+        addWorktreeEffect(worktree.id, 'status');
+      }
+    }
+  }
+
+  return { repo, worktrees };
+}
+
+function classifyCommonGitPath(rel: string, repo: RepoWatchEffects): void {
+  if (rel.startsWith('refs/heads/') || rel === 'HEAD') {
+    repo.refs = true;
+  }
+  if (rel.startsWith('refs/remotes/')) {
+    repo.refs = true;
+  }
+  if (rel === 'packed-refs') {
+    repo.refs = true;
+  }
+  if (rel === 'config') {
+    repo.refs = true;
+    repo.remotes = true;
+  }
+}
+
+function relativeInside(root: string, child: string): string | null {
+  const rel = path.relative(root, child).replace(/\\/g, '/');
+  if (rel === '') return '';
+  if (rel.startsWith('../') || rel === '..' || path.isAbsolute(rel)) return null;
+  return rel;
+}
+
+function normalize(filePath: string): string {
+  return path.resolve(filePath);
+}
+
+function isDotGitPath(rel: string): boolean {
+  return rel === '.git' || rel.startsWith('.git/');
+}

--- a/packages/shared/src/git/watch/classifier.ts
+++ b/packages/shared/src/git/watch/classifier.ts
@@ -13,7 +13,7 @@ export type WorktreeWatchEffects = {
 
 export type GitLayout = {
   gitCommonDir: string;
-  worktrees: { id: string; gitDir: string; workTree: string }[];
+  worktrees: { id: string; gitDir: string; worktree: string }[];
 };
 
 export type GitWatchClassification = {
@@ -31,7 +31,7 @@ export function classifyGitWatchEvents(
   const normalizedWorktrees = layout.worktrees.map((worktree) => ({
     ...worktree,
     gitDir: normalize(worktree.gitDir),
-    workTree: normalize(worktree.workTree),
+    worktree: normalize(worktree.worktree),
   }));
 
   const addWorktreeEffect = (id: string, effect: keyof WorktreeWatchEffects) => {
@@ -54,8 +54,8 @@ export function classifyGitWatchEvents(
         if (gitRel === 'index') addWorktreeEffect(worktree.id, 'status');
       }
 
-      const workTreeRel = relativeInside(worktree.workTree, eventPath);
-      if (workTreeRel !== null && !isDotGitPath(workTreeRel)) {
+      const worktreeRel = relativeInside(worktree.worktree, eventPath);
+      if (worktreeRel !== null && !isDotGitPath(worktreeRel)) {
         addWorktreeEffect(worktree.id, 'status');
       }
     }

--- a/packages/shared/src/git/watch/index.ts
+++ b/packages/shared/src/git/watch/index.ts
@@ -1,0 +1,7 @@
+export {
+  classifyGitWatchEvents,
+  type GitLayout,
+  type RepoWatchEffects,
+  type GitWatchClassification,
+  type WorktreeWatchEffects,
+} from './classifier';

--- a/packages/shared/src/lib/emitter.test.ts
+++ b/packages/shared/src/lib/emitter.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import { Emitter } from './emitter';
+
+describe('Emitter', () => {
+  it('delivers values to all subscribers and supports unsubscribe', () => {
+    const emitter = new Emitter<number>();
+    const first: number[] = [];
+    const second: number[] = [];
+
+    const unsubFirst = emitter.subscribe((value) => first.push(value));
+    emitter.subscribe((value) => second.push(value));
+    expect(emitter.size).toBe(2);
+
+    emitter.emit(1);
+    unsubFirst();
+    emitter.emit(2);
+
+    expect(first).toEqual([1]);
+    expect(second).toEqual([1, 2]);
+    expect(emitter.size).toBe(1);
+  });
+
+  it('tolerates unsubscribe during emit', () => {
+    const emitter = new Emitter<string>();
+    const seen: string[] = [];
+    const unsubscribe = emitter.subscribe(() => {
+      unsubscribe();
+    });
+    emitter.subscribe((value) => seen.push(value));
+
+    emitter.emit('a');
+    emitter.emit('b');
+
+    expect(seen).toEqual(['a', 'b']);
+    expect(emitter.size).toBe(1);
+  });
+
+  it('clears all subscribers', () => {
+    const emitter = new Emitter<number>();
+    const seen: number[] = [];
+    emitter.subscribe((value) => seen.push(value));
+
+    emitter.clear();
+    emitter.emit(1);
+
+    expect(seen).toEqual([]);
+    expect(emitter.size).toBe(0);
+  });
+});

--- a/packages/shared/src/lib/emitter.ts
+++ b/packages/shared/src/lib/emitter.ts
@@ -7,17 +7,17 @@ export class Emitter<T> {
     return this.subscribers.size;
   }
 
-  emit(value: T): void {
-    for (const subscriber of [...this.subscribers]) {
-      subscriber(value);
-    }
-  }
-
   subscribe(cb: (value: T) => void): Unsubscribe {
     this.subscribers.add(cb);
     return () => {
       this.subscribers.delete(cb);
     };
+  }
+
+  emit(value: T): void {
+    for (const subscriber of [...this.subscribers]) {
+      subscriber(value);
+    }
   }
 
   clear(): void {

--- a/packages/shared/src/lib/emitter.ts
+++ b/packages/shared/src/lib/emitter.ts
@@ -1,0 +1,26 @@
+import type { Unsubscribe } from './lifecycle';
+
+export class Emitter<T> {
+  private readonly subscribers = new Set<(value: T) => void>();
+
+  get size(): number {
+    return this.subscribers.size;
+  }
+
+  emit(value: T): void {
+    for (const subscriber of [...this.subscribers]) {
+      subscriber(value);
+    }
+  }
+
+  subscribe(cb: (value: T) => void): Unsubscribe {
+    this.subscribers.add(cb);
+    return () => {
+      this.subscribers.delete(cb);
+    };
+  }
+
+  clear(): void {
+    this.subscribers.clear();
+  }
+}

--- a/packages/shared/src/lib/index.ts
+++ b/packages/shared/src/lib/index.ts
@@ -1,0 +1,14 @@
+export { Emitter } from './emitter';
+export type { IDisposable, Lease, Unsubscribe } from './lifecycle';
+export { LiveModel, type LiveModelOptions, type LiveValue } from './live-model';
+export { ResourceMap, type ResourceMapOptions } from './resource-map';
+export {
+  err,
+  ok,
+  withAbort,
+  withTimeout,
+  type BaseError,
+  type Err,
+  type Ok,
+  type Result,
+} from './result';

--- a/packages/shared/src/lib/index.ts
+++ b/packages/shared/src/lib/index.ts
@@ -1,4 +1,5 @@
 export { Emitter } from './emitter';
+export { KeyedMutex } from './keyed-mutex';
 export type { IDisposable, Lease, Unsubscribe } from './lifecycle';
 export { LiveModel, type LiveModelOptions, type LiveValue } from './live-model';
 export { ResourceMap, type ResourceMapOptions } from './resource-map';

--- a/packages/shared/src/lib/keyed-mutex.test.ts
+++ b/packages/shared/src/lib/keyed-mutex.test.ts
@@ -1,0 +1,81 @@
+import { describe, expect, it } from 'vitest';
+import { KeyedMutex } from './keyed-mutex';
+
+describe('KeyedMutex', () => {
+  it('serializes concurrent calls on the same key', async () => {
+    const mutex = new KeyedMutex();
+    const order: number[] = [];
+
+    let resolveFirst!: () => void;
+    const first = mutex.runExclusive('k', () => {
+      return new Promise<void>((resolve) => {
+        resolveFirst = resolve;
+        order.push(1);
+      });
+    });
+
+    const second = mutex.runExclusive('k', async () => {
+      order.push(2);
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(order).toEqual([1]);
+
+    resolveFirst();
+    await first;
+    await second;
+    expect(order).toEqual([1, 2]);
+  });
+
+  it('runs calls on different keys in parallel', async () => {
+    const mutex = new KeyedMutex();
+    const running: string[] = [];
+
+    let resolveA!: () => void;
+    let resolveB!: () => void;
+
+    const a = mutex.runExclusive('a', () => {
+      return new Promise<void>((resolve) => {
+        resolveA = resolve;
+        running.push('a');
+      });
+    });
+
+    const b = mutex.runExclusive('b', () => {
+      return new Promise<void>((resolve) => {
+        resolveB = resolve;
+        running.push('b');
+      });
+    });
+
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(running).toContain('a');
+    expect(running).toContain('b');
+
+    resolveA();
+    resolveB();
+    await Promise.all([a, b]);
+  });
+
+  it('does not block subsequent calls on the same key after a rejection', async () => {
+    const mutex = new KeyedMutex();
+    const results: string[] = [];
+
+    await expect(mutex.runExclusive('k', () => Promise.reject(new Error('boom')))).rejects.toThrow(
+      'boom'
+    );
+
+    await mutex.runExclusive('k', async () => {
+      results.push('recovered');
+    });
+
+    expect(results).toEqual(['recovered']);
+  });
+
+  it('propagates return values', async () => {
+    const mutex = new KeyedMutex();
+
+    const result = await mutex.runExclusive('k', async () => 42);
+    expect(result).toBe(42);
+  });
+});

--- a/packages/shared/src/lib/keyed-mutex.ts
+++ b/packages/shared/src/lib/keyed-mutex.ts
@@ -1,0 +1,30 @@
+export class KeyedMutex {
+  private readonly locks = new Map<string, Promise<unknown>>();
+
+  /**
+   * Runs `fn` exclusively for `key`: concurrent calls on the same key are serialized
+   * (each waits for the previous to finish before starting). Concurrent calls on
+   * different keys run in parallel. A rejected `fn` does not block subsequent calls on
+   * the same key.
+   */
+  async runExclusive<T>(key: string, fn: () => Promise<T>): Promise<T> {
+    const previous = this.locks.get(key) ?? Promise.resolve();
+
+    let release: () => void = () => {};
+    const current = new Promise<void>((resolve) => {
+      release = resolve;
+    });
+    const chained = previous.catch(() => {}).then(() => current);
+    this.locks.set(key, chained);
+
+    await previous.catch(() => {});
+    try {
+      return await fn();
+    } finally {
+      release();
+      if (this.locks.get(key) === chained) {
+        this.locks.delete(key);
+      }
+    }
+  }
+}

--- a/packages/shared/src/lib/lifecycle.ts
+++ b/packages/shared/src/lib/lifecycle.ts
@@ -1,0 +1,10 @@
+export type Unsubscribe = () => void;
+
+export interface IDisposable {
+  dispose(): void | Promise<void>;
+}
+
+export interface Lease<T> {
+  readonly value: T;
+  release(): void;
+}

--- a/packages/shared/src/lib/live-model.test.ts
+++ b/packages/shared/src/lib/live-model.test.ts
@@ -1,0 +1,192 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { LiveModel, type LiveValue } from './live-model';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('LiveModel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('computes lazily on first get and serves the cache afterwards', async () => {
+    let computes = 0;
+    const model = new LiveModel({ compute: async () => ++computes });
+
+    await expect(model.get()).resolves.toEqual({ value: 1, seq: 1 });
+    await expect(model.get()).resolves.toEqual({ value: 1, seq: 1 });
+    expect(computes).toBe(1);
+    expect(model.getCached()).toEqual({ value: 1, seq: 1 });
+  });
+
+  it('only marks dirty on invalidate without subscribers, recomputes on next get', async () => {
+    let computes = 0;
+    const model = new LiveModel({ compute: async () => ++computes });
+
+    await model.get();
+    model.invalidate();
+    await vi.runAllTimersAsync();
+    expect(computes).toBe(1); // no subscriber: no background recompute
+
+    await expect(model.get()).resolves.toEqual({ value: 2, seq: 2 });
+  });
+
+  it('recomputes and pushes on invalidate while subscribed, with debounce coalescing', async () => {
+    let computes = 0;
+    const model = new LiveModel({ compute: async () => ++computes, debounceMs: 50 });
+    const pushed: LiveValue<number>[] = [];
+
+    model.subscribe((update) => pushed.push(update));
+    await vi.runAllTimersAsync();
+    expect(pushed).toEqual([{ value: 1, seq: 1 }]); // initial compute on first subscribe
+
+    model.invalidate();
+    model.invalidate();
+    model.invalidate();
+    await vi.runAllTimersAsync();
+
+    expect(computes).toBe(2); // three invalidations coalesced
+    expect(pushed).toEqual([
+      { value: 1, seq: 1 },
+      { value: 2, seq: 2 },
+    ]);
+  });
+
+  it('queues exactly one trailing run when refreshed during an in-flight compute', async () => {
+    const gates: Array<ReturnType<typeof deferred<number>>> = [];
+    const model = new LiveModel({
+      compute: () => {
+        const gate = deferred<number>();
+        gates.push(gate);
+        return gate.promise;
+      },
+    });
+
+    const first = model.refresh();
+    const second = model.refresh();
+    const third = model.refresh();
+    expect(gates).toHaveLength(1);
+
+    gates[0]!.resolve(10);
+    await first;
+    await vi.runAllTimersAsync();
+    expect(gates).toHaveLength(2);
+
+    gates[1]!.resolve(20);
+    await expect(second).resolves.toEqual({ value: 20, seq: 2 });
+    await expect(third).resolves.toEqual({ value: 20, seq: 2 });
+    await expect(first).resolves.toEqual({ value: 10, seq: 1 });
+  });
+
+  it('runs again after a compute that was invalidated mid-flight (subscribed)', async () => {
+    const gates: Array<ReturnType<typeof deferred<number>>> = [];
+    const model = new LiveModel({
+      compute: () => {
+        const gate = deferred<number>();
+        gates.push(gate);
+        return gate.promise;
+      },
+    });
+    const pushed: number[] = [];
+    model.subscribe((update) => pushed.push(update.value));
+    expect(gates).toHaveLength(1);
+
+    model.invalidate(); // arrives mid-compute
+    gates[0]!.resolve(1);
+    await vi.runAllTimersAsync();
+    expect(gates).toHaveLength(2);
+
+    gates[1]!.resolve(2);
+    await vi.runAllTimersAsync();
+    expect(pushed).toEqual([1, 2]);
+  });
+
+  it('keeps last-good cache and stays dirty after a failed recompute', async () => {
+    let fail = false;
+    let computes = 0;
+    const errors: unknown[] = [];
+    const model = new LiveModel({
+      compute: async () => {
+        computes += 1;
+        if (fail) throw new Error('boom');
+        return computes;
+      },
+      onError: (error) => errors.push(error),
+    });
+    const pushed: number[] = [];
+    model.subscribe((update) => pushed.push(update.value));
+    await vi.runAllTimersAsync();
+
+    fail = true;
+    model.invalidate();
+    await vi.runAllTimersAsync();
+
+    expect(errors).toHaveLength(1);
+    expect(model.getCached()).toEqual({ value: 1, seq: 1 });
+    expect(pushed).toEqual([1]);
+
+    await expect(model.refresh()).rejects.toThrow('boom');
+
+    fail = false;
+    await expect(model.get()).resolves.toEqual({ value: 4, seq: 2 }); // dirty: recomputes
+  });
+
+  it('revalidates on the configured interval while subscribed', async () => {
+    let computes = 0;
+    const model = new LiveModel({ compute: async () => ++computes, revalidateIntervalMs: 1_000 });
+
+    const unsubscribe = model.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(computes).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(computes).toBe(2);
+    await vi.advanceTimersByTimeAsync(1_000);
+    expect(computes).toBe(3);
+
+    unsubscribe();
+    await vi.advanceTimersByTimeAsync(5_000);
+    expect(computes).toBe(3); // no subscribers: no revalidation
+  });
+
+  it('resets the revalidation timer on any recompute', async () => {
+    let computes = 0;
+    const model = new LiveModel({ compute: async () => ++computes, revalidateIntervalMs: 1_000 });
+    model.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+    expect(computes).toBe(1);
+
+    await vi.advanceTimersByTimeAsync(900);
+    await model.refresh();
+    expect(computes).toBe(2);
+
+    await vi.advanceTimersByTimeAsync(900);
+    expect(computes).toBe(2); // timer was reset by refresh
+    await vi.advanceTimersByTimeAsync(100);
+    expect(computes).toBe(3);
+  });
+
+  it('rejects get/refresh/subscribe after dispose and stops timers', async () => {
+    let computes = 0;
+    const model = new LiveModel({ compute: async () => ++computes, revalidateIntervalMs: 1_000 });
+    model.subscribe(() => {});
+    await vi.advanceTimersByTimeAsync(0);
+
+    model.dispose();
+    await vi.advanceTimersByTimeAsync(10_000);
+    expect(computes).toBe(1);
+    await expect(model.get()).rejects.toThrow('LiveModel disposed');
+    expect(() => model.subscribe(() => {})).toThrow('LiveModel disposed');
+  });
+});

--- a/packages/shared/src/lib/live-model.ts
+++ b/packages/shared/src/lib/live-model.ts
@@ -1,0 +1,178 @@
+import { Emitter } from './emitter';
+import type { IDisposable, Unsubscribe } from './lifecycle';
+
+export type LiveValue<T> = {
+  value: T;
+  seq: number;
+};
+
+export type LiveModelOptions<T> = {
+  /** Compute the latest value. */
+  compute: () => Promise<T>;
+  /** Debounce window for invalidation-triggered recomputes. Defaults to 0 (next tick). */
+  debounceMs?: number;
+  /** While subscribed, recompute at this interval even without invalidation. */
+  revalidateIntervalMs?: number;
+  /** Receives errors from background recomputes (invalidation, revalidation). */
+  onError?: (error: unknown) => void;
+};
+
+/**
+ * A cached, invalidation-driven model.
+ *
+ * - Holds the latest computed value with a monotonic seq.
+ * - Recomputes are single-flight; a `refresh()` during an in-flight compute queues exactly
+ *   one trailing run and resolves with its result.
+ * - Demand-gated: `invalidate()` only marks dirty while there are no subscribers; the next
+ *   `get()`/`subscribe()` computes lazily. With subscribers, invalidation triggers a debounced
+ *   recompute whose result is pushed to all subscribers.
+ * - Stale-while-revalidate: the cached value outlives subscribers; a failed recompute keeps
+ *   the last-good value, leaves the model dirty, and pushes nothing.
+ */
+export class LiveModel<T> implements IDisposable {
+  private cached: LiveValue<T> | undefined;
+  private seq = 0;
+  private dirty = true;
+  private disposed = false;
+  private inFlight: Promise<LiveValue<T>> | null = null;
+  private inFlightToken: object | null = null;
+  private queued: Promise<LiveValue<T>> | null = null;
+  private debounceTimer: ReturnType<typeof setTimeout> | null = null;
+  private revalidateTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly emitter = new Emitter<LiveValue<T>>();
+
+  constructor(private readonly options: LiveModelOptions<T>) {}
+
+  get subscriberCount(): number {
+    return this.emitter.size;
+  }
+
+  getCached(): LiveValue<T> | undefined {
+    return this.cached;
+  }
+
+  async get(): Promise<LiveValue<T>> {
+    this.assertNotDisposed();
+    if (this.cached && !this.dirty) return this.cached;
+    if (this.inFlight) return this.inFlight;
+    return this.schedule();
+  }
+
+  async refresh(): Promise<LiveValue<T>> {
+    this.assertNotDisposed();
+    return this.schedule();
+  }
+
+  invalidate(): void {
+    if (this.disposed) return;
+    this.dirty = true;
+    if (this.emitter.size === 0) return;
+    this.scheduleDebounced();
+  }
+
+  subscribe(cb: (update: LiveValue<T>) => void): Unsubscribe {
+    this.assertNotDisposed();
+    const unsubscribe = this.emitter.subscribe(cb);
+    if (this.dirty || !this.cached) {
+      this.scheduleBackground();
+    } else {
+      this.armRevalidate();
+    }
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      unsubscribe();
+      if (this.emitter.size === 0) this.clearTimers();
+    };
+  }
+
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    this.clearTimers();
+    this.emitter.clear();
+  }
+
+  private schedule(): Promise<LiveValue<T>> {
+    if (this.inFlight) {
+      this.queued ??= this.inFlight.then(
+        () => this.runNow(),
+        () => this.runNow()
+      );
+      return this.queued;
+    }
+    return this.runNow();
+  }
+
+  private runNow(): Promise<LiveValue<T>> {
+    this.queued = null;
+    if (this.debounceTimer) {
+      clearTimeout(this.debounceTimer);
+      this.debounceTimer = null;
+    }
+    const token = {};
+    this.inFlightToken = token;
+    const run = (async () => {
+      this.dirty = false;
+      let succeeded = false;
+      try {
+        const value = await this.options.compute();
+        succeeded = true;
+        const update: LiveValue<T> = { value, seq: ++this.seq };
+        this.cached = update;
+        if (!this.disposed) this.emitter.emit(update);
+        return update;
+      } catch (error) {
+        this.dirty = true;
+        throw error;
+      } finally {
+        if (this.inFlightToken === token) {
+          this.inFlightToken = null;
+          this.inFlight = null;
+        }
+        this.armRevalidate();
+        if (succeeded && this.dirty && !this.queued && this.emitter.size > 0) {
+          this.scheduleDebounced();
+        }
+      }
+    })();
+    this.inFlight = run;
+    return run;
+  }
+
+  private scheduleDebounced(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = setTimeout(() => {
+      this.debounceTimer = null;
+      if (!this.dirty || this.disposed) return;
+      this.scheduleBackground();
+    }, this.options.debounceMs ?? 0);
+  }
+
+  private scheduleBackground(): void {
+    void this.schedule().catch((error) => this.options.onError?.(error));
+  }
+
+  private armRevalidate(): void {
+    const interval = this.options.revalidateIntervalMs;
+    if (!interval || this.disposed || this.emitter.size === 0) return;
+    if (this.revalidateTimer) clearTimeout(this.revalidateTimer);
+    this.revalidateTimer = setTimeout(() => {
+      this.revalidateTimer = null;
+      if (this.disposed || this.emitter.size === 0) return;
+      this.scheduleBackground();
+    }, interval);
+  }
+
+  private clearTimers(): void {
+    if (this.debounceTimer) clearTimeout(this.debounceTimer);
+    this.debounceTimer = null;
+    if (this.revalidateTimer) clearTimeout(this.revalidateTimer);
+    this.revalidateTimer = null;
+  }
+
+  private assertNotDisposed(): void {
+    if (this.disposed) throw new Error('LiveModel disposed');
+  }
+}

--- a/packages/shared/src/lib/live-model.ts
+++ b/packages/shared/src/lib/live-model.ts
@@ -58,18 +58,6 @@ export class LiveModel<T> implements IDisposable {
     return this.schedule();
   }
 
-  async refresh(): Promise<LiveValue<T>> {
-    this.assertNotDisposed();
-    return this.schedule();
-  }
-
-  invalidate(): void {
-    if (this.disposed) return;
-    this.dirty = true;
-    if (this.emitter.size === 0) return;
-    this.scheduleDebounced();
-  }
-
   subscribe(cb: (update: LiveValue<T>) => void): Unsubscribe {
     this.assertNotDisposed();
     const unsubscribe = this.emitter.subscribe(cb);
@@ -85,6 +73,18 @@ export class LiveModel<T> implements IDisposable {
       unsubscribe();
       if (this.emitter.size === 0) this.clearTimers();
     };
+  }
+
+  async refresh(): Promise<LiveValue<T>> {
+    this.assertNotDisposed();
+    return this.schedule();
+  }
+
+  invalidate(): void {
+    if (this.disposed) return;
+    this.dirty = true;
+    if (this.emitter.size === 0) return;
+    this.scheduleDebounced();
   }
 
   dispose(): void {

--- a/packages/shared/src/lib/resource-map.test.ts
+++ b/packages/shared/src/lib/resource-map.test.ts
@@ -1,0 +1,141 @@
+import { describe, expect, it } from 'vitest';
+import { ResourceMap } from './resource-map';
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('ResourceMap', () => {
+  it('shares one provision across concurrent acquires of the same key', async () => {
+    let provisions = 0;
+    const torndown: string[] = [];
+    const map = new ResourceMap<string>({
+      teardown: (key) => {
+        torndown.push(key);
+      },
+    });
+
+    const gate = deferred<string>();
+    const provision = () => {
+      provisions += 1;
+      return gate.promise;
+    };
+    const [a, b] = [map.acquire('k', provision), map.acquire('k', provision)];
+    gate.resolve('value');
+    const [leaseA, leaseB] = await Promise.all([a, b]);
+
+    expect(provisions).toBe(1);
+    expect(leaseA.value).toBe('value');
+    expect(leaseB.value).toBe('value');
+
+    leaseA.release();
+    leaseA.release(); // idempotent
+    expect(torndown).toEqual([]);
+    leaseB.release();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(torndown).toEqual(['k']);
+    expect(map.idle).toBe(true);
+  });
+
+  it('rejects all waiters and evicts the entry when provisioning fails', async () => {
+    const map = new ResourceMap<string>({ teardown: () => {} });
+    const failing = () => Promise.reject(new Error('provision failed'));
+
+    await expect(map.acquire('k', failing)).rejects.toThrow('provision failed');
+    expect(map.idle).toBe(true);
+
+    // A fresh acquire provisions again rather than reusing the poisoned entry.
+    const lease = await map.acquire('k', async () => 'recovered');
+    expect(lease.value).toBe('recovered');
+    lease.release();
+  });
+
+  it('waits for an in-flight teardown before re-provisioning the same key', async () => {
+    const order: string[] = [];
+    const teardownGate = deferred<void>();
+    const map = new ResourceMap<string>({
+      teardown: async () => {
+        order.push('teardown:start');
+        await teardownGate.promise;
+        order.push('teardown:end');
+      },
+    });
+
+    const first = await map.acquire('k', async () => 'one');
+    first.release();
+
+    const second = map.acquire('k', async () => {
+      order.push('provision:two');
+      return 'two';
+    });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(order).toEqual(['teardown:start']);
+
+    teardownGate.resolve();
+    const lease = await second;
+    expect(order).toEqual(['teardown:start', 'teardown:end', 'provision:two']);
+    expect(lease.value).toBe('two');
+    lease.release();
+  });
+
+  it('tears down when the last lease releases while provisioning succeeded late', async () => {
+    const torndown: string[] = [];
+    const map = new ResourceMap<string>({
+      teardown: (_key, value) => {
+        torndown.push(value);
+      },
+    });
+    const gate = deferred<string>();
+
+    const pending = map.acquire('k', () => gate.promise);
+    gate.resolve('late');
+    const lease = await pending;
+    lease.release();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(torndown).toEqual(['late']);
+  });
+
+  it('reports teardown errors through onError', async () => {
+    const errors: Array<{ context: string; error: unknown }> = [];
+    const map = new ResourceMap<string>({
+      teardown: () => {
+        throw new Error('teardown failed');
+      },
+      onError: (context, error) => errors.push({ context, error }),
+    });
+
+    const lease = await map.acquire('k', async () => 'value');
+    lease.release();
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(errors).toHaveLength(1);
+    expect(errors[0]!.context).toBe('teardown k');
+  });
+
+  it('rejects new acquires after dispose while existing leases stay usable', async () => {
+    let emptied = 0;
+    const map = new ResourceMap<string>({
+      teardown: () => {},
+      onEmpty: () => {
+        emptied += 1;
+      },
+    });
+
+    const lease = await map.acquire('k', async () => 'value');
+    map.dispose();
+
+    expect(lease.value).toBe('value');
+    await expect(map.acquire('other', async () => 'x')).rejects.toThrow('ResourceMap disposed');
+
+    lease.release();
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(emptied).toBe(1);
+    expect(map.idle).toBe(true);
+  });
+});

--- a/packages/shared/src/lib/resource-map.ts
+++ b/packages/shared/src/lib/resource-map.ts
@@ -1,0 +1,111 @@
+import type { IDisposable, Lease } from './lifecycle';
+
+export type ResourceMapOptions<T> = {
+  /** Tears down a provisioned value after its last lease is released. */
+  teardown: (key: string, value: T) => void | Promise<void>;
+  /** Receives teardown failures (provision failures propagate to acquirers). */
+  onError?: (context: string, error: unknown) => void;
+  /** Fired whenever the map becomes empty (no entries, no in-flight teardowns). */
+  onEmpty?: () => void;
+};
+
+type Entry<T> = {
+  refs: number;
+  promise: Promise<T>;
+};
+
+/**
+ * Keyed, ref-counted async resources with single-flight provisioning.
+ *
+ * - Concurrent `acquire`s of the same key share one provision; each gets its own lease.
+ * - A failed provision rejects every waiting acquirer and evicts the entry.
+ * - The last `release()` tears the value down; releases are idempotent and concurrency-safe.
+ * - Acquiring a key that is tearing down waits for the teardown, then provisions fresh.
+ * - `dispose()` refuses new acquires; teardown still happens when the last lease releases.
+ */
+export class ResourceMap<T> implements IDisposable {
+  private readonly entries = new Map<string, Entry<T>>();
+  private readonly teardowns = new Map<string, Promise<void>>();
+  private disposeRequested = false;
+
+  constructor(private readonly options: ResourceMapOptions<T>) {}
+
+  get size(): number {
+    return this.entries.size;
+  }
+
+  get idle(): boolean {
+    return this.entries.size === 0 && this.teardowns.size === 0;
+  }
+
+  async acquire(key: string, provision: () => Promise<T>): Promise<Lease<T>> {
+    this.assertOpen();
+    while (this.teardowns.has(key)) {
+      await this.teardowns.get(key);
+      this.assertOpen();
+    }
+
+    let entry = this.entries.get(key);
+    if (!entry) {
+      entry = { refs: 0, promise: provision() };
+      entry.promise.catch(() => {});
+      this.entries.set(key, entry);
+    }
+    entry.refs += 1;
+
+    let value: T;
+    try {
+      value = await entry.promise;
+    } catch (error) {
+      this.releaseRef(key, entry);
+      throw error;
+    }
+    return this.createLease(key, entry, value);
+  }
+
+  dispose(): void {
+    this.disposeRequested = true;
+    if (this.idle) this.options.onEmpty?.();
+  }
+
+  private createLease(key: string, entry: Entry<T>, value: T): Lease<T> {
+    let released = false;
+    return {
+      value,
+      release: () => {
+        if (released) return;
+        released = true;
+        this.releaseRef(key, entry);
+      },
+    };
+  }
+
+  private releaseRef(key: string, entry: Entry<T>): void {
+    entry.refs -= 1;
+    if (entry.refs > 0) return;
+    if (this.entries.get(key) !== entry) return;
+    this.entries.delete(key);
+
+    const teardown = (async () => {
+      let value: T;
+      try {
+        value = await entry.promise;
+      } catch {
+        return;
+      }
+      try {
+        await this.options.teardown(key, value);
+      } catch (error) {
+        this.options.onError?.(`teardown ${key}`, error);
+      }
+    })().finally(() => {
+      this.teardowns.delete(key);
+      if (this.idle) this.options.onEmpty?.();
+    });
+    this.teardowns.set(key, teardown);
+  }
+
+  private assertOpen(): void {
+    if (this.disposeRequested) throw new Error('ResourceMap disposed');
+  }
+}

--- a/packages/shared/src/lib/result.ts
+++ b/packages/shared/src/lib/result.ts
@@ -1,0 +1,28 @@
+export type Ok<T> = { readonly success: true; readonly data: T };
+export type Err<E> = { readonly success: false; readonly error: E };
+export type Result<T, E = string> = Ok<T> | Err<E>;
+
+export const ok = <T>(data: T = undefined as T): Ok<T> => ({ success: true, data });
+export const err = <E>(error: E): Err<E> => ({ success: false, error });
+
+export type BaseError<T extends string = string, M extends string = string> = {
+  type: T;
+  message?: M;
+  cause?: unknown;
+};
+
+export function withAbort<T>(promise: Promise<T>, signal: AbortSignal): Promise<T> {
+  if (signal.aborted) return Promise.reject(signal.reason);
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    promise.then(resolve, reject).finally(() => signal.removeEventListener('abort', onAbort));
+  });
+}
+
+export function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`Operation timed out after ${ms}ms`)), ms);
+    promise.then(resolve, reject).finally(() => clearTimeout(timer));
+  });
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "isolatedModules": true,
+    "declaration": true,
+    "noEmit": true,
+    "forceConsistentCasingInFileNames": true,
+    "lib": ["ES2022"],
+    "types": ["node"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -291,6 +291,22 @@ importers:
         specifier: ^2.1.0
         version: 2.2.0(@types/react-dom@19.2.3(@types/react@19.2.17))(@types/react@19.2.17)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)(vitest@4.1.8)
 
+  packages/shared:
+    dependencies:
+      '@parcel/watcher':
+        specifier: ^2.5.6
+        version: 2.5.6
+    devDependencies:
+      '@types/node':
+        specifier: ^20.19.42
+        version: 20.19.42
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260609.1
+        version: 7.0.0-dev.20260609.1
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.8(@types/node@20.19.42)(@vitest/browser-playwright@4.1.8)(@vitest/browser-preview@4.1.8)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@6.4.3(@types/node@20.19.42)(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.9.0))
+
 packages:
 
   '@antfu/install-pkg@1.1.0':
@@ -2228,6 +2244,53 @@ packages:
 
   '@types/yauzl@2.10.3':
     resolution: {integrity: sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-Yf/zHEadP/yUiWUdM/mZVfEVFJuGMf6nhRSFif0vp+FwtfGU4jmlpNF7BTJJdOHrrcWkwEJKzAoMCtEtyxhuyQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-z4dYWI57CPHs0wV/FWFth8fWmqYH7iOm7THOfZ5Fv0jo/SWK6kE1kEUIqIAExqo7ueRNqSrCw0I8U1J4TJszAw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-OxNVWH9IhrMAzNlDyDit1dPO64GFIDPOUKoruIkJ9A1ZEONfIHXG5f+V3si9jtuNmuomiz9FjpbzOqLsgaxt+w==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-mEtN8BbAgVtBu/5MVomYquXNvgok2C0KG6V0D4SV1jfBJNtlcqbp0WuIqT0bnM9DA4TgzcHvnFMpwGSK/dqI5A==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-KO8WO1gBIC09T3255RlTY42TGu8en5mEkLPQu2wkMn+dX2T8KYL64zXrCeLeUWa0NvmVdJUeyWu3pFOn3zKemw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-+8q19LWjnMKK6SF3PLeMEalbfWDYWHs0AU8kSFCBCke/RLoDG4FjQzVtLgUo+KWhsmZMosiEyqEnZmSlED2tIQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-qNPcss+6yRoNFfFIKQbPwJWYxDfOZwyL8JBJh4J+yMLOad/+/AOjsO4EtZsIpv5PMCjpnD75coBoDkw+5NkItw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260609.1':
+    resolution: {integrity: sha512-1HOuH/u/451O3hx4Z9fesNqarpeit6UfkgwK96sCVWi5p69F0N3v+6bI969lLIjF7K9dbYQNiWUaZ6Wik87iKg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
@@ -6665,6 +6728,37 @@ snapshots:
     dependencies:
       '@types/node': 20.19.42
     optional: true
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260609.1':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260609.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260609.1':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260609.1':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260609.1':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260609.1':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260609.1':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260609.1':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260609.1
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260609.1
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260609.1
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260609.1
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260609.1
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260609.1
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260609.1
 
   '@ungap/structured-clone@1.3.1': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -10,6 +10,9 @@ importers:
 
   apps/emdash-desktop:
     dependencies:
+      '@emdash/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
       '@gitbeaker/rest':
         specifier: ^43.8.0
         version: 43.8.0


### PR DESCRIPTION
- adds packages/shared as a transport-agnostic runtime package with exec, fs, git and lib entrypoints
- introduces GitRuntime with leased repositories and worktrees that share file watchers and lifecycle cleanup
- splits git state into live read models for refs, remotes, status and head with snapshot subscriptions and sequence tracking
- adds GitRepository and GitWorktree operations for branch remote pr review staging commit push pull log diff and file reads
- adds fs primitives for bounded file reads path resolution and shared native file watching with resync handling
- adds git parsers and watch classification for status diff and common-dir or worktree events
- adds shared lifecycle utilities including LiveModel, ResourceMap, Emitter, KeyedMutex and Result