### PR TITLE
fix(pty): force tmux UTF-8 mode to fix broken glyphs in agent sessions

### DIFF
--- a/apps/emdash-desktop/src/main/core/pty/spawn-utils.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/spawn-utils.test.ts
@@ -149,8 +149,8 @@ describe('resolveSshCommand', () => {
     );
 
     expect(result).toContain('tmux has-session -t \\"agent-session\\"');
-    expect(result).toContain('tmux new-session -d -s \\"agent-session\\"');
-    expect(result).toContain('tmux attach-session -t \\"agent-session\\"');
+    expect(result).toContain('tmux -u new-session -d -s \\"agent-session\\"');
+    expect(result).toContain('tmux -u attach-session -t \\"agent-session\\"');
     expect(result).toContain('/bin/sh -c');
     expect(result).toContain("'\\''claude'\\'' '\\''--resume'\\'' '\\''conv-1'\\''");
   });

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
@@ -7,10 +7,12 @@ describe('buildTmuxShellLine', () => {
 
     expect(result).toMatch(/^\/bin\/sh -c /);
     expect(result).toContain('tmux has-session -t \\"agent-session\\"');
-    expect(result).toContain('tmux new-session -d -s \\"agent-session\\" \\"exec /bin/zsh -il\\"');
+    expect(result).toContain(
+      'tmux -u new-session -d -s \\"agent-session\\" \\"exec /bin/zsh -il\\"'
+    );
     expect(result).toContain('tmux set-option -t \\"agent-session\\" mouse on');
     expect(result).toContain('tmux set-option -t \\"agent-session\\" history-limit 100000');
-    expect(result).toContain('tmux attach-session -t \\"agent-session\\"');
+    expect(result).toContain('tmux -u attach-session -t \\"agent-session\\"');
     expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
     expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
   });

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
@@ -7,12 +7,15 @@ const TMUX_HISTORY_LIMIT = 100_000;
 export function buildTmuxShellLine(sessionName: string, commandLine: string): string {
   const quotedName = JSON.stringify(sessionName);
   const quotedCmd = JSON.stringify(commandLine);
+  // `-u` forces tmux into UTF-8 mode regardless of the inherited locale. GUI-launched
+  // apps (e.g. Electron on macOS) often have no LANG set, so without this tmux assumes a
+  // non-UTF-8 locale and mangles multibyte glyphs like Nerd-font/box-drawing characters.
   const checkExists = `tmux has-session -t ${quotedName} 2>/dev/null`;
-  const newSession = `tmux new-session -d -s ${quotedName} ${quotedCmd}`;
+  const newSession = `tmux -u new-session -d -s ${quotedName} ${quotedCmd}`;
   const enableMouse = `tmux set-option -t ${quotedName} mouse on 2>/dev/null || true`;
   const setHistoryLimit = `tmux set-option -t ${quotedName} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
   const configure = `(${enableMouse}) && (${setHistoryLimit})`;
-  const attach = `tmux attach-session -t ${quotedName}`;
+  const attach = `tmux -u attach-session -t ${quotedName}`;
   const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
   return `/bin/sh -c ${JSON.stringify(script)}`;
 }


### PR DESCRIPTION
## What

Adds the `-u` flag to the tmux `new-session` and `attach-session` commands in `buildTmuxShellLine`.

## Why

When an agent runs inside a tmux session, multibyte glyphs — such as the Nerd-font / box-drawing characters in the Claude minion display — render as broken characters (see #2492).

tmux infers UTF-8 support from the locale. GUI-launched apps (Electron on macOS) often start with no `LANG` set, so tmux assumes a non-UTF-8 locale and mangles those glyphs. The `-u` flag forces tmux into UTF-8 mode regardless of the inherited locale, which is the canonical fix for this symptom.

## How to test

1. Enable tmux for a project (Project → Settings → tmux).
2. Create a task, choose Claude, and start a conversation.
3. The Claude minion / Nerd-font glyphs render correctly instead of as broken characters.

Before screenshots are in #2492, after:
<img width="1120" height="460" alt="image" src="https://github.com/user-attachments/assets/f8283166-99c2-447d-8c52-968a53a15de1" />


## Tests

- Updated `tmux-session-name.test.ts` and `spawn-utils.test.ts` to assert the `-u` flag.
- Local gate passing: `pnpm run format`, `pnpm run lint`, `pnpm run typecheck`, and the affected `pnpm run test` suites (11 PTY tests green).

Closes #2492