### PR TITLE
fix: repair restored task worktrees

### DIFF
--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -292,6 +292,9 @@ describe('WorktreeService', () => {
         if (key === 'worktree prune' || key === 'worktree list --porcelain') {
           return { stdout: '', stderr: '' };
         }
+        if (key === `-C ${targetPath} rev-parse --is-inside-work-tree`) {
+          return { stdout: 'true\n', stderr: '' };
+        }
         if (key === `config --get branch.${branchName}.base`) {
           throw Object.assign(new Error('missing config'), { code: 1 });
         }

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -13,12 +13,6 @@ export type ServeWorktreeError =
   | { type: 'worktree-setup-failed'; cause: unknown }
   | { type: 'branch-not-found'; branch: string };
 
-export type ServeBranchWorktreeParams = {
-  branchName: string;
-  sourceBranch?: Branch;
-  copyPreservedFiles?: boolean;
-};
-
 export class WorktreeService {
   private gitOpQueue: Promise<unknown> = Promise.resolve();
   private readonly resolveWorktreePoolPath: () => Promise<string>;
@@ -309,11 +303,11 @@ export class WorktreeService {
     return this.enqueueGitOp(() => this.doCheckoutExistingBranch(branchName, options));
   }
 
-  async serveBranchWorktree({
-    branchName,
-    sourceBranch,
-    copyPreservedFiles,
-  }: ServeBranchWorktreeParams): Promise<Result<string, ServeWorktreeError>> {
+  async serveBranchWorktree(
+    branchName: string,
+    sourceBranch?: Branch,
+    copyPreservedFiles?: boolean
+  ): Promise<Result<string, ServeWorktreeError>> {
     const existing = await this.getWorktree(branchName);
     if (existing) return ok(existing);
 

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -13,6 +13,12 @@ export type ServeWorktreeError =
   | { type: 'worktree-setup-failed'; cause: unknown }
   | { type: 'branch-not-found'; branch: string };
 
+export type ServeBranchWorktreeParams = {
+  branchName: string;
+  sourceBranch?: Branch;
+  copyPreservedFiles?: boolean;
+};
+
 export class WorktreeService {
   private gitOpQueue: Promise<unknown> = Promise.resolve();
   private readonly resolveWorktreePoolPath: () => Promise<string>;
@@ -48,15 +54,30 @@ export class WorktreeService {
     // directory. For local execution we bypass host path-restriction checks and use
     // fs directly so external worktrees (outside allowedRoots) are still detected.
     // For SSH we rely on the host (SshWorktreeHost has no root restrictions).
+    let hasGitFile = false;
     if (this.ctx.supportsLocalSpawn) {
       try {
         await fsPromises.access(this.host.pathApi.join(worktreePath, '.git'));
-        return true;
+        hasGitFile = true;
       } catch {
         return false;
       }
+    } else {
+      hasGitFile = await this.host.existsAbsolute(this.host.pathApi.join(worktreePath, '.git'));
     }
-    return this.host.existsAbsolute(this.host.pathApi.join(worktreePath, '.git'));
+    if (!hasGitFile) return false;
+
+    try {
+      const { stdout } = await this.ctx.exec('git', [
+        '-C',
+        worktreePath,
+        'rev-parse',
+        '--is-inside-work-tree',
+      ]);
+      return stdout.trim() === 'true';
+    } catch {
+      return false;
+    }
   }
 
   /** Returns the resolved path to the worktree pool directory. */
@@ -210,15 +231,19 @@ export class WorktreeService {
 
   async checkoutBranchWorktree(
     sourceBranch: Branch | undefined,
-    branchName: string
+    branchName: string,
+    options: { copyPreservedFiles?: boolean } = {}
   ): Promise<Result<string, ServeWorktreeError>> {
     await this.ensureWorktreePoolDirExists();
-    return this.enqueueGitOp(() => this.doCheckoutBranchWorktree(sourceBranch, branchName));
+    return this.enqueueGitOp(() =>
+      this.doCheckoutBranchWorktree(sourceBranch, branchName, options)
+    );
   }
 
   private async doCheckoutBranchWorktree(
     sourceBranch: Branch | undefined,
-    branchName: string
+    branchName: string,
+    options: { copyPreservedFiles?: boolean }
   ): Promise<Result<string, ServeWorktreeError>> {
     const baseConfigValue = this.getBranchBaseConfigValue(sourceBranch);
     const checkedOutPath = await this.findBranchAnywhere(branchName);
@@ -264,23 +289,44 @@ export class WorktreeService {
       return err({ type: 'worktree-setup-failed', cause });
     }
 
-    await this.copyPreservedFiles(targetPath).catch((e) => {
-      log.warn('WorktreeService: failed to copy preserved files', {
-        targetPath,
-        error: String(e),
+    if (options.copyPreservedFiles ?? true) {
+      await this.copyPreservedFiles(targetPath).catch((e) => {
+        log.warn('WorktreeService: failed to copy preserved files', {
+          targetPath,
+          error: String(e),
+        });
       });
-    });
+    }
 
     return ok(targetPath);
   }
 
-  async checkoutExistingBranch(branchName: string): Promise<Result<string, ServeWorktreeError>> {
+  async checkoutExistingBranch(
+    branchName: string,
+    options: { copyPreservedFiles?: boolean } = {}
+  ): Promise<Result<string, ServeWorktreeError>> {
     await this.ensureWorktreePoolDirExists();
-    return this.enqueueGitOp(() => this.doCheckoutExistingBranch(branchName));
+    return this.enqueueGitOp(() => this.doCheckoutExistingBranch(branchName, options));
+  }
+
+  async serveBranchWorktree({
+    branchName,
+    sourceBranch,
+    copyPreservedFiles,
+  }: ServeBranchWorktreeParams): Promise<Result<string, ServeWorktreeError>> {
+    const existing = await this.getWorktree(branchName);
+    if (existing) return ok(existing);
+
+    if (!sourceBranch || branchName === sourceBranch.branch) {
+      return this.checkoutExistingBranch(branchName, { copyPreservedFiles });
+    }
+
+    return this.checkoutBranchWorktree(sourceBranch, branchName, { copyPreservedFiles });
   }
 
   private async doCheckoutExistingBranch(
-    branchName: string
+    branchName: string,
+    options: { copyPreservedFiles?: boolean }
   ): Promise<Result<string, ServeWorktreeError>> {
     const checkedOutPath = await this.findBranchAnywhere(branchName);
     if (checkedOutPath) {
@@ -341,12 +387,14 @@ export class WorktreeService {
       return err({ type: 'worktree-setup-failed', cause });
     }
 
-    await this.copyPreservedFiles(targetPath).catch((e) => {
-      log.warn('WorktreeService: failed to copy preserved files', {
-        targetPath,
-        error: String(e),
+    if (options.copyPreservedFiles ?? true) {
+      await this.copyPreservedFiles(targetPath).catch((e) => {
+        log.warn('WorktreeService: failed to copy preserved files', {
+          targetPath,
+          error: String(e),
+        });
       });
-    });
+    }
 
     return ok(targetPath);
   }
@@ -420,4 +468,5 @@ export type WorktreeBootstrapOps = Pick<
   | 'findBranchAnywhere'
   | 'checkoutExistingBranch'
   | 'checkoutBranchWorktree'
+  | 'serveBranchWorktree'
 >;

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/add-worktree.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/add-worktree.ts
@@ -7,10 +7,7 @@ export async function execute(
   ctx: StepContext
 ): Promise<Result<Step.Success, Step.Error>> {
   const { branchName } = args;
-  const result = await ctx.worktreeService.serveBranchWorktree({
-    branchName,
-    copyPreservedFiles: false,
-  });
+  const result = await ctx.worktreeService.serveBranchWorktree(branchName, undefined, false);
 
   if (result.success) {
     return ok({ path: result.data });

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/add-worktree.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/add-worktree.ts
@@ -2,79 +2,32 @@ import type * as Step from '@shared/core/workspaces/workspace-setup-steps/add-wo
 import { err, ok, type Result } from '@shared/lib/result';
 import type { StepContext } from './step-context';
 
-async function isValidWorktree(worktreePath: string, ctx: StepContext): Promise<boolean> {
-  const gitFile = ctx.host.pathApi.join(worktreePath, '.git');
-  if (ctx.ctx.supportsLocalSpawn) {
-    try {
-      await ctx.host.existsAbsolute(gitFile);
-      return ctx.host.existsAbsolute(gitFile);
-    } catch {
-      return false;
-    }
-  }
-  return ctx.host.existsAbsolute(gitFile);
-}
-
-async function findBranchAnywhere(
-  branchName: string,
-  ctx: StepContext
-): Promise<string | undefined> {
-  try {
-    const { stdout } = await ctx.ctx.exec('git', ['worktree', 'list', '--porcelain']);
-    const branchLine = `branch refs/heads/${branchName}`;
-    for (const block of stdout.split('\n\n')) {
-      if (!block.split('\n').some((line) => line === branchLine)) continue;
-      const match = /^worktree (.+)$/m.exec(block);
-      const candidatePath = match?.[1];
-      if (!candidatePath) continue;
-      if (await isValidWorktree(candidatePath, ctx)) return candidatePath;
-      await ctx.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
-    }
-  } catch {}
-  return undefined;
-}
-
 export async function execute(
   args: Step.Args,
   ctx: StepContext
 ): Promise<Result<Step.Success, Step.Error>> {
   const { branchName } = args;
-  const targetPath = ctx.host.pathApi.join(ctx.worktreePoolPath, branchName);
+  const result = await ctx.worktreeService.serveBranchWorktree({
+    branchName,
+    copyPreservedFiles: false,
+  });
 
-  // Check if the branch is already checked out in a valid worktree.
-  const existing = await findBranchAnywhere(branchName, ctx);
-  if (existing) {
-    return ok({ path: existing });
+  if (result.success) {
+    return ok({ path: result.data });
   }
 
-  // Pool directory target exists — check validity.
-  if (await ctx.host.existsAbsolute(targetPath)) {
-    if (await isValidWorktree(targetPath, ctx)) {
-      return ok({ path: targetPath });
-    }
-    // Stale directory: worktree add will fail unless it's cleaned up first.
-    return err({ type: 'stale-directory', path: targetPath });
+  if (result.error.type === 'branch-not-found') {
+    return err({
+      type: 'worktree-failed',
+      branchName,
+      message: `Branch "${result.error.branch}" was not found locally or on remote`,
+    });
   }
 
-  // Ensure parent directory exists.
-  await ctx.host.mkdirAbsolute(ctx.host.pathApi.dirname(targetPath), { recursive: true });
-  await ctx.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
-
-  try {
-    await ctx.ctx.exec('git', ['worktree', 'add', targetPath, branchName]);
-    return ok({ path: targetPath });
-  } catch (error: unknown) {
-    const stderr = (error as { stderr?: string })?.stderr ?? String(error);
-
-    if (stderr.includes('already checked out') || stderr.includes('is already used by')) {
-      // Another worktree has this branch checked out but `findBranchAnywhere` missed it.
-      return err({
-        type: 'branch-already-checked-out',
-        branchName,
-        candidatePath: undefined,
-      });
-    }
-
-    return err({ type: 'worktree-failed', branchName, message: stderr });
-  }
+  return err({
+    type: 'worktree-failed',
+    branchName,
+    message:
+      result.error.cause instanceof Error ? result.error.cause.message : String(result.error.cause),
+  });
 }

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/step-context.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/step-context.ts
@@ -1,6 +1,7 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { ProjectSettingsProvider } from '@main/core/projects/settings/provider';
 import type { WorktreeHost } from '@main/core/projects/worktrees/hosts/worktree-host';
+import type { WorktreeService } from '@main/core/projects/worktrees/worktree-service';
 
 /**
  * Context passed to every workspace setup step executor.
@@ -18,6 +19,8 @@ export type StepContext = {
   host: WorktreeHost;
   /** Project settings provider (used by copy-preserved-files). */
   projectSettings: ProjectSettingsProvider;
+  /** Worktree service that owns checkout validation, stale cleanup, and checkout creation. */
+  worktreeService: Pick<WorktreeService, 'serveBranchWorktree'>;
   /**
    * Resolved worktree path from a preceding `add-worktree` step.
    * Populated by the executor after a successful add-worktree step so that

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -2,14 +2,51 @@ import crypto from 'node:crypto';
 import { openFixture } from '@tooling/utils/db';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ProjectProvider } from '@main/core/projects/project-provider';
 import { projects, workspaces } from '@main/db/schema';
+import type { Task } from '@shared/core/tasks/tasks';
+import { ok } from '@shared/lib/result';
 import { WorkspaceBootstrapService } from './workspace-bootstrap-service';
 import { computeWorkspaceKey } from './workspace-key';
+
+const mocks = vi.hoisted(() => ({
+  acquireWorkspace: vi.fn(),
+  releaseWorkspace: vi.fn(),
+  buildTaskFromWorkspace: vi.fn(),
+  emitTaskProvisionProgress: vi.fn(),
+}));
 
 // Prevent the module-level singleton from attempting to open the Electron app DB.
 vi.mock('@main/db/client', () => ({ db: {}, sqlite: {} }));
 
+vi.mock('@main/core/tasks/task-builder', () => ({
+  buildTaskFromWorkspace: mocks.buildTaskFromWorkspace,
+  emitTaskProvisionProgress: mocks.emitTaskProvisionProgress,
+}));
+
+vi.mock('./workspace-registry', () => ({
+  workspaceRegistry: {
+    acquire: mocks.acquireWorkspace,
+    release: mocks.releaseWorkspace,
+  },
+}));
+
 const WS_ID = 'ws-1';
+
+const task: Task = {
+  id: 'task-1',
+  projectId: 'proj-1',
+  name: 'Task 1',
+  status: 'in_progress',
+  createdAt: '2026-01-01T00:00:00.000Z',
+  updatedAt: '2026-01-01T00:00:00.000Z',
+  statusChangedAt: '2026-01-01T00:00:00.000Z',
+  isPinned: false,
+  prs: [],
+  conversations: {},
+  workspaceId: WS_ID,
+  type: 'task',
+};
 
 describe('WorkspaceBootstrapService', () => {
   let fixture: Awaited<ReturnType<typeof openFixture>>;
@@ -21,6 +58,23 @@ describe('WorkspaceBootstrapService', () => {
 
     await fixture.db.insert(projects).values({ id: 'proj-1', name: 'Test Project', path: '/repo' });
     await fixture.db.insert(workspaces).values({ id: WS_ID, type: 'local' });
+
+    mocks.acquireWorkspace.mockResolvedValue({
+      git: {
+        getWorktreeGitDir: vi.fn().mockResolvedValue('worktrees/task-branch'),
+      },
+    });
+    mocks.releaseWorkspace.mockResolvedValue(undefined);
+    mocks.buildTaskFromWorkspace.mockResolvedValue({
+      taskProvider: {
+        taskId: 'task-1',
+        taskBranch: 'task/branch',
+        sourceBranch: { type: 'local', branch: 'main' },
+        taskEnvVars: {},
+        conversations: {},
+        terminals: {},
+      },
+    });
   });
 
   afterEach(() => {
@@ -59,6 +113,68 @@ describe('WorkspaceBootstrapService', () => {
       expect(returned).toBe(existingWsId);
       const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
       expect(ws.path).toBeNull();
+    });
+  });
+
+  describe('ensureWorkspaceSetup', () => {
+    it('repairs persisted branch worktree paths before acquiring the workspace', async () => {
+      const serveBranchWorktree = vi.fn().mockResolvedValue(ok('/worktrees/task-branch'));
+      const existsAbsolute = vi.fn().mockResolvedValue(true);
+      const project = {
+        projectId: 'proj-1',
+        type: 'local',
+        repoPath: '/repo',
+        defaultWorkspaceType: { kind: 'local' },
+        settings: {
+          get: vi.fn(),
+        },
+        repository: {
+          getConfiguredRemotes: vi.fn(),
+        },
+        gitFetchService: {},
+        worktreeHost: {
+          existsAbsolute,
+        },
+        worktreeService: {
+          serveBranchWorktree,
+        },
+      } as unknown as ProjectProvider;
+
+      const result = await svc.ensureWorkspaceSetup(
+        {
+          id: WS_ID,
+          type: 'local',
+          kind: 'worktree',
+          path: '/worktrees/broken-task-branch',
+          branchName: 'task/branch',
+          config: {
+            version: '2',
+            git: {
+              kind: 'create-branch',
+              branchName: 'task/branch',
+              fromBranch: { type: 'local', branch: 'main' },
+            },
+            workspace: { kind: 'new-worktree' },
+          },
+        },
+        { workspaceIntent: null, workspaceProvider: null },
+        task,
+        project
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data.path).toBe('/worktrees/task-branch');
+      expect(serveBranchWorktree).toHaveBeenCalledWith({
+        branchName: 'task/branch',
+        sourceBranch: { type: 'local', branch: 'main' },
+      });
+      expect(existsAbsolute).not.toHaveBeenCalledWith('/worktrees/broken-task-branch');
+      expect(mocks.acquireWorkspace).toHaveBeenCalled();
+
+      const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
+      expect(ws.path).toBe('/worktrees/task-branch');
+      expect(ws.branchName).toBe('task/branch');
     });
   });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -165,9 +165,9 @@ describe('WorkspaceBootstrapService', () => {
       expect(result.success).toBe(true);
       if (!result.success) throw new Error('expected success');
       expect(result.data.path).toBe('/worktrees/task-branch');
-      expect(serveBranchWorktree).toHaveBeenCalledWith({
-        branchName: 'task/branch',
-        sourceBranch: { type: 'local', branch: 'main' },
+      expect(serveBranchWorktree).toHaveBeenCalledWith('task/branch', {
+        type: 'local',
+        branch: 'main',
       });
       expect(existsAbsolute).not.toHaveBeenCalledWith('/worktrees/broken-task-branch');
       expect(mocks.acquireWorkspace).toHaveBeenCalled();

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -80,6 +80,7 @@ export class WorkspaceBootstrapService {
     // Derive branch info from workspace config for passing to task providers.
     const wsConfig = workspaceRow.config;
     const workspaceBranchName = getProvisionedWorkspaceBranch(workspaceRow) ?? undefined;
+    const isWorktreeWorkspace = wsKind === 'worktree' || (!wsKind && !!workspaceBranchName);
     const workspaceSourceBranch: Branch | undefined =
       wsConfig?.git.kind === 'create-branch' ? wsConfig.git.fromBranch : undefined;
     const connectionId =
@@ -104,7 +105,7 @@ export class WorkspaceBootstrapService {
     // Persisted worktree path: resolve through WorktreeService instead of trusting
     // path existence. Archive/delete can leave a partial directory behind; the
     // worktree service knows how to remove stale targets and recreate the checkout.
-    if (workspaceRow.path && workspaceBranchName && !isByoi) {
+    if (workspaceRow.path && workspaceBranchName && isWorktreeWorkspace && !isByoi) {
       const serveResult = await project.worktreeService.serveBranchWorktree(
         workspaceBranchName,
         workspaceSourceBranch

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -105,10 +105,10 @@ export class WorkspaceBootstrapService {
     // path existence. Archive/delete can leave a partial directory behind; the
     // worktree service knows how to remove stale targets and recreate the checkout.
     if (workspaceRow.path && workspaceBranchName && !isByoi) {
-      const serveResult = await project.worktreeService.serveBranchWorktree({
-        branchName: workspaceBranchName,
-        sourceBranch: workspaceSourceBranch,
-      });
+      const serveResult = await project.worktreeService.serveBranchWorktree(
+        workspaceBranchName,
+        workspaceSourceBranch
+      );
       if (!serveResult.success) {
         const provisionError = mapWorktreeErrorToProvisionError(
           workspaceBranchName,

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -3,6 +3,10 @@ import { eq, sql } from 'drizzle-orm';
 import { projectManager } from '@main/core/projects/project-manager';
 import type { ProjectProvider, TaskProvider } from '@main/core/projects/project-provider';
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
+import {
+  formatProvisionTaskError,
+  mapWorktreeErrorToProvisionError,
+} from '@main/core/tasks/provision-task-error';
 import { buildTaskFromWorkspace, emitTaskProvisionProgress } from '@main/core/tasks/task-builder';
 import { mapTaskRowToTask } from '@main/core/tasks/utils/utils';
 import { db as appDb, type AppDb } from '@main/db/client';
@@ -41,8 +45,10 @@ export class WorkspaceBootstrapService {
    * Ensures the workspace for a task is fully set up on disk, acquires the
    * workspace (running lifecycle scripts), and builds task providers.
    *
-   * - **Fast path (idempotent)**: if `workspaceRow.path` is set and the directory
-   *   exists on disk, skips git setup and goes straight to workspace acquisition.
+   * - **Fast path (idempotent)**: if a non-worktree `workspaceRow.path` is set and
+   *   the directory exists on disk, skips git setup and goes straight to workspace
+   *   acquisition. Persisted worktree paths are resolved through `WorktreeService`
+   *   so stale partial directories are repaired before acquisition.
    * - **BYOI workspaces**: delegates to `provisionBYOITask` which runs the
    *   provision script, connects SSH, and acquires the workspace.
    * - **Local/SSH workspaces**: compiles and executes the `WorkspaceSetupSpec`,
@@ -76,6 +82,10 @@ export class WorkspaceBootstrapService {
     const workspaceBranchName = getProvisionedWorkspaceBranch(workspaceRow) ?? undefined;
     const workspaceSourceBranch: Branch | undefined =
       wsConfig?.git.kind === 'create-branch' ? wsConfig.git.fromBranch : undefined;
+    const connectionId =
+      project.defaultWorkspaceType.kind === 'ssh'
+        ? project.defaultWorkspaceType.connectionId
+        : undefined;
 
     // project-root fast-path: use the project repo path directly.
     // Path is set by ensureRepositoryWorkspace at mount time.
@@ -91,7 +101,51 @@ export class WorkspaceBootstrapService {
       );
     }
 
-    // Fast path: path already persisted and still exists on disk.
+    // Persisted worktree path: resolve through WorktreeService instead of trusting
+    // path existence. Archive/delete can leave a partial directory behind; the
+    // worktree service knows how to remove stale targets and recreate the checkout.
+    if (workspaceRow.path && workspaceBranchName && !isByoi) {
+      const serveResult = await project.worktreeService.serveBranchWorktree({
+        branchName: workspaceBranchName,
+        sourceBranch: workspaceSourceBranch,
+      });
+      if (!serveResult.success) {
+        const provisionError = mapWorktreeErrorToProvisionError(
+          workspaceBranchName,
+          serveResult.error
+        );
+        return err({
+          type: 'setup-failed',
+          stepKind: 'worktree',
+          stepErrorType: provisionError.type,
+          message: formatProvisionTaskError(provisionError),
+        });
+      }
+      const resolvedPath = serveResult.data;
+
+      await this.persistPath(
+        workspaceRow.id,
+        resolvedPath,
+        workspaceRow.type,
+        connectionId,
+        workspaceBranchName
+      );
+
+      if (connectionId) {
+        sshConnectionManager.reportChannelRecovered(connectionId);
+      }
+
+      return this._acquireAndBuild(
+        workspaceRow.id,
+        task,
+        project,
+        resolvedPath,
+        workspaceBranchName,
+        workspaceSourceBranch
+      );
+    }
+
+    // Fast path: non-worktree path already persisted and still exists on disk.
     if (workspaceRow.path && !isByoi) {
       const exists = await project.worktreeHost.existsAbsolute(workspaceRow.path);
       if (exists) {
@@ -115,11 +169,6 @@ export class WorkspaceBootstrapService {
     if (!intent) {
       return err({ type: 'no-intent' });
     }
-
-    const connectionId =
-      project.defaultWorkspaceType.kind === 'ssh'
-        ? project.defaultWorkspaceType.connectionId
-        : undefined;
 
     const { baseRemote, pushRemote } = await project.repository.getConfiguredRemotes();
     const spec = compileSetupSpec(intent.git, intent.workspace, { baseRemote, pushRemote });
@@ -158,6 +207,7 @@ export class WorkspaceBootstrapService {
       worktreePoolPath,
       host: project.worktreeHost,
       projectSettings: project.settings,
+      worktreeService: project.worktreeService,
     };
 
     const executor = new LocalWorkspaceSetupExecutor(stepCtx);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Task } from '@shared/core/tasks/tasks';
+import { TaskManagerStore } from './task-manager';
+import { createUnprovisionedTask } from './task-store';
+
+type MockViewModel = {
+  initialize: ReturnType<typeof vi.fn>;
+  suspend: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+  restoreSnapshot: ReturnType<typeof vi.fn>;
+};
+
+type MockDraftComments = {
+  dispose: ReturnType<typeof vi.fn>;
+};
+
+const mocks = vi.hoisted(() => ({
+  archiveTask: vi.fn(),
+  conversationAcquire: vi.fn(),
+  conversationRelease: vi.fn(),
+  draftComments: [] as MockDraftComments[],
+  getConversationsForProject: vi.fn(),
+  getProjectManagerStore: vi.fn(),
+  getPullRequestsForTask: vi.fn(),
+  getTaskGitStore: vi.fn(),
+  getTasks: vi.fn(),
+  mountProject: vi.fn(),
+  provisionWorkspace: vi.fn(),
+  teardownTask: vi.fn(),
+  terminalAcquire: vi.fn(),
+  terminalRelease: vi.fn(),
+  viewModels: [] as MockViewModel[],
+  viewStateGet: vi.fn(),
+  workspaceActivate: vi.fn(),
+  workspaceAcquire: vi.fn(),
+  workspaceRelease: vi.fn(),
+  workspaceSetBootstrapState: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: {
+    on: vi.fn(() => () => {}),
+  },
+  rpc: {
+    conversations: {
+      getConversationsForProject: mocks.getConversationsForProject,
+    },
+    pullRequests: {
+      getPullRequestsForTask: mocks.getPullRequestsForTask,
+    },
+    tasks: {
+      archiveTask: mocks.archiveTask,
+      getTasks: mocks.getTasks,
+      provisionWorkspace: mocks.provisionWorkspace,
+      teardownTask: mocks.teardownTask,
+    },
+  },
+}));
+
+vi.mock('@renderer/features/projects/stores/project-selectors', () => ({
+  getProjectManagerStore: mocks.getProjectManagerStore,
+}));
+
+vi.mock('@renderer/features/tasks/stores/task-selectors', () => ({
+  getTaskGitStore: mocks.getTaskGitStore,
+}));
+
+vi.mock('@renderer/lib/stores/view-state-cache', () => ({
+  viewStateCache: {
+    get: mocks.viewStateGet,
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    error: vi.fn(),
+  },
+}));
+
+vi.mock('@renderer/features/tasks/diff-view/stores/draft-comments-store', () => ({
+  DraftCommentsStore: class {
+    dispose = vi.fn();
+
+    constructor() {
+      mocks.draftComments.push(this);
+    }
+  },
+}));
+
+vi.mock('./workspace-view-model', () => ({
+  WorkspaceViewModel: class {
+    initialize = vi.fn();
+    suspend = vi.fn();
+    dispose = vi.fn();
+    restoreSnapshot = vi.fn();
+
+    constructor() {
+      mocks.viewModels.push(this);
+    }
+  },
+}));
+
+vi.mock('./workspace-registry', () => ({
+  workspaceRegistry: {
+    activate: mocks.workspaceActivate,
+    acquire: mocks.workspaceAcquire,
+    release: mocks.workspaceRelease,
+    setBootstrapState: mocks.workspaceSetBootstrapState,
+  },
+}));
+
+vi.mock('./conversation-registry', () => ({
+  conversationRegistry: {
+    acquire: mocks.conversationAcquire,
+    get: vi.fn(),
+    release: mocks.conversationRelease,
+  },
+}));
+
+vi.mock('./terminal-registry', () => ({
+  terminalRegistry: {
+    acquire: mocks.terminalAcquire,
+    get: vi.fn(),
+    release: mocks.terminalRelease,
+  },
+}));
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    projectId: 'project-1',
+    name: 'Task 1',
+    status: 'todo',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    statusChangedAt: '2026-01-01T00:00:00.000Z',
+    isPinned: false,
+    prs: [],
+    conversations: {},
+    workspaceId: 'workspace-1',
+    type: 'task',
+    ...overrides,
+  };
+}
+
+function makeTaskManager(): TaskManagerStore {
+  return new TaskManagerStore(
+    'project-1',
+    { pullRequestRepositoryUrl: null } as never,
+    { pageData: { invalidate: vi.fn() } } as never,
+    'main'
+  );
+}
+
+describe('TaskManagerStore archive lifecycle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.draftComments.length = 0;
+    mocks.viewModels.length = 0;
+    mocks.archiveTask.mockResolvedValue(undefined);
+    mocks.getConversationsForProject.mockResolvedValue([]);
+    mocks.getProjectManagerStore.mockReturnValue({ mountProject: mocks.mountProject });
+    mocks.getPullRequestsForTask.mockResolvedValue({ success: true, data: { prs: [] } });
+    mocks.getTasks.mockResolvedValue([]);
+    mocks.mountProject.mockResolvedValue(undefined);
+    mocks.provisionWorkspace.mockResolvedValue({
+      success: true,
+      data: {
+        path: '/tmp/workspace-1',
+        workspaceId: 'workspace-1',
+      },
+    });
+    mocks.viewStateGet.mockResolvedValue(undefined);
+  });
+
+  it('archives by disposing frontend runtime instead of soft-tearing down the task', async () => {
+    const manager = makeTaskManager();
+    const task = makeTask();
+    const store = createUnprovisionedTask(task);
+    store.transitionToProvisioned(task, '/tmp/workspace-1', 'workspace-1', {} as never, 'main');
+    const viewModel = mocks.viewModels[0];
+    const draftComments = mocks.draftComments[0];
+    manager.tasks.set(task.id, store);
+
+    await manager.archiveTask(task.id);
+
+    expect(mocks.archiveTask).toHaveBeenCalledWith('project-1', 'task-1');
+    expect(mocks.teardownTask).not.toHaveBeenCalled();
+    expect(mocks.conversationRelease).toHaveBeenCalledWith('task-1');
+    expect(mocks.terminalRelease).toHaveBeenCalledWith('task-1');
+    expect(viewModel.dispose).toHaveBeenCalledOnce();
+    expect(draftComments.dispose).toHaveBeenCalledOnce();
+    expect(store.state).toBe('unprovisioned');
+    expect(store.phase).toBe('idle');
+    expect(store.workspaceId).toBeNull();
+    expect(store.viewModel).toBeNull();
+    expect(store.draftComments).toBeNull();
+    expect((store.data as Task).archivedAt).toBeDefined();
+
+    manager.dispose();
+  });
+
+  it('reacquires frontend managers before provisioning a dry restored task', async () => {
+    const manager = makeTaskManager();
+    const task = makeTask({ archivedAt: undefined });
+    const store = createUnprovisionedTask(task);
+    store.transitionToDryUnprovisioned(task);
+    manager.tasks.set(task.id, store);
+    const snapshot = { sidebarTab: 'conversations' };
+    mocks.viewStateGet.mockResolvedValue(snapshot);
+
+    await manager.provisionTask(task.id);
+
+    expect(mocks.conversationAcquire).toHaveBeenCalledWith('task-1', 'project-1');
+    expect(mocks.terminalAcquire).toHaveBeenCalledWith('task-1', 'project-1');
+    expect(store.state).toBe('provisioned');
+    expect(store.viewModel).toBe(mocks.viewModels[1]);
+    expect(mocks.viewModels[1].restoreSnapshot).toHaveBeenCalledWith(snapshot);
+    expect(mocks.viewModels[1].initialize).toHaveBeenCalledOnce();
+
+    manager.dispose();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -276,6 +276,11 @@ export class TaskManagerStore {
     });
   }
 
+  private _releaseTaskRegistries(taskId: string): void {
+    conversationRegistry.release(taskId);
+    terminalRegistry.release(taskId);
+  }
+
   loadTasks(): Promise<void> {
     if (!this._loadPromise) {
       this._loadPromise = Promise.all([
@@ -471,6 +476,9 @@ export class TaskManagerStore {
     runInAction(() => {
       const current = this.tasks.get(taskId);
       if (current && isUnprovisioned(current)) {
+        conversationRegistry.acquire(taskId, this.projectId);
+        terminalRegistry.acquire(taskId, this.projectId);
+        current.ensureRegisteredStores();
         if (savedSnapshot && current.viewModel) {
           current.viewModel.restoreSnapshot(savedSnapshot);
         }
@@ -499,6 +507,9 @@ export class TaskManagerStore {
     runInAction(() => {
       const current = this.tasks.get(taskId);
       if (current && isUnprovisioned(current)) {
+        conversationRegistry.acquire(taskId, this.projectId);
+        terminalRegistry.acquire(taskId, this.projectId);
+        current.ensureRegisteredStores();
         if (savedSnapshot && current.viewModel) {
           current.viewModel.restoreSnapshot(savedSnapshot);
         }
@@ -578,7 +589,6 @@ export class TaskManagerStore {
         }
       });
       await rpc.tasks.archiveTask(this.projectId, taskId);
-      void this.teardownTask(taskId).catch(() => {});
     } catch (e) {
       runInAction(() => {
         const task = this.tasks.get(taskId);
@@ -588,6 +598,14 @@ export class TaskManagerStore {
       });
       throw e;
     }
+
+    this._releaseTaskRegistries(taskId);
+    runInAction(() => {
+      const task = this.tasks.get(taskId);
+      if (task && isRegistered(task)) {
+        task.transitionToDryUnprovisioned({ ...task.data }, 'idle');
+      }
+    });
   }
 
   async restoreTask(taskId: string): Promise<void> {
@@ -634,8 +652,7 @@ export class TaskManagerStore {
     try {
       // Release conversation and terminal registries before disposing each task.
       removed.forEach((t, id) => {
-        conversationRegistry.release(id);
-        terminalRegistry.release(id);
+        this._releaseTaskRegistries(id);
         t.dispose();
       });
       await rpc.tasks.deleteTasks(this.projectId, taskIds, opts);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.test.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { Task } from '@shared/core/tasks/tasks';
+import { createUnprovisionedTask } from './task-store';
+
+type MockViewModel = {
+  initialize: ReturnType<typeof vi.fn>;
+  suspend: ReturnType<typeof vi.fn>;
+  dispose: ReturnType<typeof vi.fn>;
+  restoreSnapshot: ReturnType<typeof vi.fn>;
+};
+
+type MockDraftComments = {
+  dispose: ReturnType<typeof vi.fn>;
+};
+
+const mocks = vi.hoisted(() => ({
+  draftComments: [] as MockDraftComments[],
+  viewModels: [] as MockViewModel[],
+  workspaceAcquire: vi.fn(),
+  workspaceRelease: vi.fn(),
+}));
+
+vi.mock('@renderer/features/tasks/diff-view/stores/draft-comments-store', () => ({
+  DraftCommentsStore: class {
+    dispose = vi.fn();
+
+    constructor() {
+      mocks.draftComments.push(this);
+    }
+  },
+}));
+
+vi.mock('./workspace-view-model', () => ({
+  WorkspaceViewModel: class {
+    initialize = vi.fn();
+    suspend = vi.fn();
+    dispose = vi.fn();
+    restoreSnapshot = vi.fn();
+
+    constructor() {
+      mocks.viewModels.push(this);
+    }
+  },
+}));
+
+vi.mock('./workspace-registry', () => ({
+  workspaceRegistry: {
+    acquire: mocks.workspaceAcquire,
+    release: mocks.workspaceRelease,
+  },
+}));
+
+vi.mock('./conversation-registry', () => ({
+  conversationRegistry: {
+    get: vi.fn(),
+  },
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: {
+    on: vi.fn(() => () => {}),
+  },
+  rpc: {
+    tasks: {
+      renameTask: vi.fn(),
+      updateTaskStatus: vi.fn(),
+      setTaskPinned: vi.fn(),
+      updateLinkedIssue: vi.fn(),
+      convertAutomationTask: vi.fn(),
+    },
+  },
+}));
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: 'task-1',
+    projectId: 'project-1',
+    name: 'Task 1',
+    status: 'todo',
+    createdAt: '2026-01-01T00:00:00.000Z',
+    updatedAt: '2026-01-01T00:00:00.000Z',
+    statusChangedAt: '2026-01-01T00:00:00.000Z',
+    isPinned: false,
+    prs: [],
+    conversations: {},
+    workspaceId: 'workspace-1',
+    type: 'task',
+    ...overrides,
+  };
+}
+
+describe('TaskStore frontend runtime lifecycle', () => {
+  beforeEach(() => {
+    mocks.draftComments.length = 0;
+    mocks.viewModels.length = 0;
+    mocks.workspaceAcquire.mockReset();
+    mocks.workspaceRelease.mockReset();
+  });
+
+  it('can transition a provisioned task back to a dry unprovisioned state', () => {
+    const task = makeTask();
+    const store = createUnprovisionedTask(task);
+
+    store.transitionToProvisioned(task, '/tmp/workspace-1', 'workspace-1', {} as never, 'main');
+    const viewModel = mocks.viewModels[0];
+    const draftComments = mocks.draftComments[0];
+
+    store.transitionToDryUnprovisioned({ ...task, archivedAt: '2026-01-02T00:00:00.000Z' });
+
+    expect(viewModel.dispose).toHaveBeenCalledOnce();
+    expect(draftComments.dispose).toHaveBeenCalledOnce();
+    expect(mocks.workspaceRelease).toHaveBeenCalledWith('project-1', 'workspace-1');
+    expect(store.state).toBe('unprovisioned');
+    expect(store.phase).toBe('idle');
+    expect(store.workspaceId).toBeNull();
+    expect(store.viewModel).toBeNull();
+    expect(store.draftComments).toBeNull();
+    expect((store.data as Task).archivedAt).toBe('2026-01-02T00:00:00.000Z');
+  });
+
+  it('recreates registered stores before reprovisioning a dry task', () => {
+    const task = makeTask();
+    const store = createUnprovisionedTask(task);
+    const firstViewModel = mocks.viewModels[0];
+
+    store.transitionToDryUnprovisioned(task);
+    expect(store.viewModel).toBeNull();
+
+    store.transitionToProvisioned(task, '/tmp/workspace-1', 'workspace-1', {} as never, 'main');
+
+    expect(mocks.viewModels).toHaveLength(2);
+    expect(store.viewModel).toBe(mocks.viewModels[1]);
+    expect(store.viewModel).not.toBe(firstViewModel);
+    expect(mocks.viewModels[1].initialize).toHaveBeenCalledOnce();
+    expect(store.draftComments).toBe(mocks.draftComments[1]);
+    expect(store.state).toBe('provisioned');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
@@ -82,14 +82,19 @@ export class TaskStore {
 
     // Create stable task-lifetime stores immediately for registered tasks.
     if (state !== 'unregistered') {
-      this._initRegisteredStores();
+      this.ensureRegisteredStores();
     }
   }
 
-  private _initRegisteredStores(): void {
+  ensureRegisteredStores(): void {
+    if (this.state === 'unregistered') return;
     const taskData = this.data as Task;
-    this.draftComments = new DraftCommentsStore(taskData.id);
-    this.viewModel = new WorkspaceViewModel(this);
+    if (!this.draftComments) {
+      this.draftComments = new DraftCommentsStore(taskData.id);
+    }
+    if (!this.viewModel) {
+      this.viewModel = new WorkspaceViewModel(this);
+    }
   }
 
   transitionToProvisioned(
@@ -101,6 +106,7 @@ export class TaskStore {
     sshConnectionId?: string
   ): void {
     this.data = data;
+    this.ensureRegisteredStores();
     workspaceRegistry.acquire(
       data.projectId,
       workspaceId,
@@ -130,7 +136,16 @@ export class TaskStore {
     this.provisionProgressMessage = null;
 
     // Create stable stores on first registration (when transitioning from unregistered).
-    if (!this.draftComments) this._initRegisteredStores();
+    if (!this.draftComments || !this.viewModel) this.ensureRegisteredStores();
+  }
+
+  transitionToDryUnprovisioned(data: Task, phase: UnprovisionedTaskPhase = 'idle'): void {
+    this.disposeFrontendRuntime();
+    this.data = data;
+    this.state = 'unprovisioned';
+    this.phase = phase;
+    this.errorMessage = undefined;
+    this.provisionProgressMessage = null;
   }
 
   transitionToUnregistered(data: UnregisteredTaskData): void {
@@ -153,7 +168,7 @@ export class TaskStore {
     }
   }
 
-  dispose(): void {
+  disposeFrontendRuntime(): void {
     this.viewModel?.dispose();
     this.viewModel = null;
     if (this.workspaceId) {
@@ -163,6 +178,10 @@ export class TaskStore {
     }
     this.draftComments?.dispose();
     this.draftComments = null;
+  }
+
+  dispose(): void {
+    this.disposeFrontendRuntime();
   }
 
   get conversationStats(): Record<string, number> {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
@@ -140,7 +140,7 @@ export class TaskStore {
   }
 
   transitionToDryUnprovisioned(data: Task, phase: UnprovisionedTaskPhase = 'idle'): void {
-    this.disposeFrontendRuntime();
+    this.dispose();
     this.data = data;
     this.state = 'unprovisioned';
     this.phase = phase;
@@ -168,7 +168,7 @@ export class TaskStore {
     }
   }
 
-  disposeFrontendRuntime(): void {
+  dispose(): void {
     this.viewModel?.dispose();
     this.viewModel = null;
     if (this.workspaceId) {
@@ -178,10 +178,6 @@ export class TaskStore {
     }
     this.draftComments?.dispose();
     this.draftComments = null;
-  }
-
-  dispose(): void {
-    this.disposeFrontendRuntime();
   }
 
   get conversationStats(): Record<string, number> {

--- a/packages/shared/src/fs/native-watch.ts
+++ b/packages/shared/src/fs/native-watch.ts
@@ -71,7 +71,10 @@ export class NativeWatch implements IDisposable {
 
   private scheduleResubscribe(): void {
     if (this.retryTimer || this.disposed) return;
-    const delay = Math.min(RESUBSCRIBE_DELAY_MS * 2 ** this.retryAttempts, MAX_RESUBSCRIBE_DELAY_MS);
+    const delay = Math.min(
+      RESUBSCRIBE_DELAY_MS * 2 ** this.retryAttempts,
+      MAX_RESUBSCRIBE_DELAY_MS
+    );
     this.retryAttempts += 1;
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null;


### PR DESCRIPTION
- route restored worktree tasks through WorktreeService before workspace acquisition
- centralize branch worktree serving in serveBranchWorktree
- make setup steps and restore reuse the same worktree validation and repair path
- recreate frontend task stores after archive and restore so restored tasks can provision cleanly

- format the shared native watcher file