### PR TITLE
feat(browser): add link context menu

### DIFF
--- a/apps/emdash-desktop/src/main/app/window.ts
+++ b/apps/emdash-desktop/src/main/app/window.ts
@@ -107,6 +107,6 @@ function registerBrowserWebviewHandlers(win: BrowserWindow): void {
       webContents.close();
       return;
     }
-    browserWebContentsRegistry.attachWebContents(browserId, webContents);
+    browserWebContentsRegistry.attachWebContents(browserId, webContents, win);
   });
 }

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
@@ -50,7 +50,7 @@ function webContentsWithSession(session: object): WebContents {
 }
 
 function attachedWebContents(session: object): WebContents & {
-  emitContextMenu: (linkURL: string) => void;
+  emitContextMenu: (params: string | Partial<Electron.ContextMenuParams>) => void;
   emitCopyUrlShortcut: (input?: Partial<Electron.Input>) => void;
 } {
   const listeners = new Map<
@@ -62,6 +62,7 @@ function attachedWebContents(session: object): WebContents & {
     session,
     getURL: vi.fn(() => 'https://example.com/current'),
     isDestroyed: () => false,
+    executeJavaScript: vi.fn(() => Promise.resolve()),
     loadURL: vi.fn(),
     reload: vi.fn(),
     setWindowOpenHandler: vi.fn(),
@@ -76,8 +77,12 @@ function attachedWebContents(session: object): WebContents & {
       }
     ),
     once: vi.fn(),
-    emitContextMenu: (linkURL: string) => {
-      listeners.get('context-menu')?.({ preventDefault: vi.fn() }, { linkURL } as never);
+    emitContextMenu: (params: string | Partial<Electron.ContextMenuParams>) => {
+      const contextParams =
+        typeof params === 'string'
+          ? { linkURL: params }
+          : { linkURL: '', srcURL: '', mediaType: 'none', ...params };
+      listeners.get('context-menu')?.({ preventDefault: vi.fn() }, contextParams as never);
     },
     emitCopyUrlShortcut: (input = {}) => {
       listeners.get('before-input-event')?.({ preventDefault: vi.fn() }, {
@@ -91,7 +96,7 @@ function attachedWebContents(session: object): WebContents & {
       } as never);
     },
   } as unknown as WebContents & {
-    emitContextMenu: (linkURL: string) => void;
+    emitContextMenu: (params: string | Partial<Electron.ContextMenuParams>) => void;
     emitCopyUrlShortcut: (input?: Partial<Electron.Input>) => void;
   };
 }
@@ -194,6 +199,42 @@ describe('BrowserWebContentsRegistry', () => {
       { type: 'separator' },
       { label: 'Reload' },
     ]);
+  });
+
+  it('shows image context menu actions for image URLs', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    sessionsByPartition.set(partition, webContentsSession);
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitContextMenu({
+      mediaType: 'image',
+      srcURL: 'https://example.com/image.png',
+    });
+
+    expect(mocks.menuBuildFromTemplate).toHaveBeenCalledTimes(1);
+    const template = mocks.menuBuildFromTemplate.mock.calls[0]?.[0] as Array<{ click: () => void }>;
+    expect(template).toMatchObject([
+      { label: 'Copy Image URL', enabled: true },
+      { label: 'Open Image', enabled: true },
+      { label: 'Open Image in New Tab', enabled: true },
+      { type: 'separator' },
+      { label: 'Reload' },
+    ]);
+
+    template[0]?.click();
+    template[1]?.click();
+    template[2]?.click();
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/image.png');
+    expect(webContents.loadURL).toHaveBeenCalledWith('https://example.com/image.png');
+    expect(mocks.eventsEmit).toHaveBeenCalledWith(browserOpenInNewTabChannel, {
+      sourceBrowserId: 'browser-1',
+      url: 'https://example.com/image.png',
+    });
   });
 
   it('copies the current browser URL from the webview shortcut', () => {

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
@@ -237,6 +237,10 @@ describe('BrowserWebContentsRegistry', () => {
     template[2]?.click();
 
     expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/image.png');
+    expect(mocks.eventsEmit).toHaveBeenCalledWith(browserLinkCopiedChannel, {
+      kind: 'image',
+      url: 'https://example.com/image.png',
+    });
     expect(webContents.loadURL).toHaveBeenCalledWith('https://example.com/image.png');
     expect(mocks.eventsEmit).toHaveBeenCalledWith(browserOpenInNewTabChannel, {
       sourceBrowserId: 'browser-1',
@@ -261,6 +265,40 @@ describe('BrowserWebContentsRegistry', () => {
     });
   });
 
+  it('does not copy unsupported webview URLs from the shortcut', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    const webContents = attachedWebContents(webContentsSession);
+    vi.mocked(webContents.getURL).mockReturnValue('about:blank');
+    registry.registerSession({ browserId: 'browser-1', partition });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitCopyUrlShortcut();
+
+    expect(mocks.clipboardWriteText).not.toHaveBeenCalled();
+    expect(mocks.eventsEmit).not.toHaveBeenCalledWith(browserLinkCopiedChannel, expect.any(Object));
+  });
+
+  it('preserves selected text and offers a copy action in the context menu', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitContextMenu({ selectionText: ' selected text ' });
+
+    expect(webContents.executeJavaScript).not.toHaveBeenCalled();
+    const template = mocks.menuBuildFromTemplate.mock.calls[0]?.[0] as Array<{ click: () => void }>;
+    expect(template.slice(0, 2)).toMatchObject([{ label: 'Copy' }, { type: 'separator' }]);
+
+    template[0]?.click();
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith('selected text');
+  });
+
   it('uses the configured webview copy URL shortcut', () => {
     const registry = new BrowserWebContentsRegistry();
     const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
@@ -274,6 +312,20 @@ describe('BrowserWebContentsRegistry', () => {
     webContents.emitCopyUrlShortcut({ key: 'u', meta: false, control: true });
 
     expect(mocks.clipboardWriteText).toHaveBeenCalledTimes(1);
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/current');
+  });
+
+  it('falls back to the default webview copy URL shortcut when configured shortcut is invalid', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+    registry.setKeyboardSettings({ browserCopyUrl: 'Super+Shift+C' });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitCopyUrlShortcut();
+
     expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/current');
   });
 
@@ -323,7 +375,11 @@ describe('BrowserWebContentsRegistry', () => {
     mocks.sessionsByPartition.set(partition, partitionSession);
 
     registry.registerSession({ browserId: 'browser-1', partition });
-    registry.attachWebContents('browser-1', attachedWebContents(partitionSession, image), ownerWindow());
+    registry.attachWebContents(
+      'browser-1',
+      attachedWebContents(partitionSession, image),
+      ownerWindow()
+    );
 
     expect(await registry.captureScreenshotToClipboard('browser-1')).toBe(true);
     expect(mocks.writeImage).toHaveBeenCalledWith(image);

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
@@ -1,10 +1,30 @@
-import type { WebContents } from 'electron';
+import type { BrowserWindow as ElectronBrowserWindow, WebContents } from 'electron';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { browserLinkCopiedChannel, browserOpenInNewTabChannel } from '@shared/events/browserEvents';
 import { BrowserWebContentsRegistry } from './browser-webcontents-registry';
 
 const sessionsByPartition = new Map<string, object>();
+const mocks = vi.hoisted(() => {
+  const menuPopup = vi.fn();
+  return {
+    clipboardWriteText: vi.fn(),
+    menuPopup,
+    menuBuildFromTemplate: vi.fn((template: unknown[]) => ({ popup: menuPopup, template })),
+    eventsEmit: vi.fn(),
+  };
+});
 
 vi.mock('electron', () => ({
+  BrowserWindow: {
+    fromWebContents: vi.fn(() => null),
+    getFocusedWindow: vi.fn(() => null),
+  },
+  clipboard: {
+    writeText: mocks.clipboardWriteText,
+  },
+  Menu: {
+    buildFromTemplate: mocks.menuBuildFromTemplate,
+  },
   session: {
     fromPartition: (partition: string) => {
       let value = sessionsByPartition.get(partition);
@@ -19,7 +39,7 @@ vi.mock('electron', () => ({
 
 vi.mock('@main/lib/events', () => ({
   events: {
-    emit: vi.fn(),
+    emit: mocks.eventsEmit,
   },
 }));
 
@@ -29,9 +49,64 @@ function webContentsWithSession(session: object): WebContents {
   } as WebContents;
 }
 
+function attachedWebContents(session: object): WebContents & {
+  emitContextMenu: (linkURL: string) => void;
+  emitCopyUrlShortcut: (input?: Partial<Electron.Input>) => void;
+} {
+  const listeners = new Map<
+    string,
+    (event: { preventDefault: () => void }, params: never) => void
+  >();
+  return {
+    id: 1,
+    session,
+    getURL: vi.fn(() => 'https://example.com/current'),
+    isDestroyed: () => false,
+    loadURL: vi.fn(),
+    reload: vi.fn(),
+    setWindowOpenHandler: vi.fn(),
+    getOwnerBrowserWindow: () => null,
+    on: vi.fn(
+      (
+        eventName: string,
+        listener: (event: { preventDefault: () => void }, params: never) => void
+      ) => {
+        listeners.set(eventName, listener);
+        return undefined;
+      }
+    ),
+    once: vi.fn(),
+    emitContextMenu: (linkURL: string) => {
+      listeners.get('context-menu')?.({ preventDefault: vi.fn() }, { linkURL } as never);
+    },
+    emitCopyUrlShortcut: (input = {}) => {
+      listeners.get('before-input-event')?.({ preventDefault: vi.fn() }, {
+        type: 'keyDown',
+        key: 'c',
+        shift: true,
+        meta: process.platform === 'darwin',
+        control: process.platform !== 'darwin',
+        alt: false,
+        ...input,
+      } as never);
+    },
+  } as unknown as WebContents & {
+    emitContextMenu: (linkURL: string) => void;
+    emitCopyUrlShortcut: (input?: Partial<Electron.Input>) => void;
+  };
+}
+
+function ownerWindow() {
+  return {} as ElectronBrowserWindow;
+}
+
 describe('BrowserWebContentsRegistry', () => {
   beforeEach(() => {
     sessionsByPartition.clear();
+    mocks.clipboardWriteText.mockClear();
+    mocks.menuPopup.mockClear();
+    mocks.menuBuildFromTemplate.mockClear();
+    mocks.eventsEmit.mockClear();
   });
 
   it('resolves the browser id from the attached webContents session', () => {
@@ -65,5 +140,107 @@ describe('BrowserWebContentsRegistry', () => {
     });
 
     expect(registry.getBrowserIdForWebContents(webContentsWithSession({}))).toBeUndefined();
+  });
+
+  it('shows link context menu with copy and open in new tab actions', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    sessionsByPartition.set(partition, webContentsSession);
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitContextMenu('https://example.com/docs');
+
+    expect(mocks.menuBuildFromTemplate).toHaveBeenCalledTimes(1);
+    const template = mocks.menuBuildFromTemplate.mock.calls[0]?.[0] as Array<{ click: () => void }>;
+    template[0]?.click();
+    template[1]?.click();
+    template[2]?.click();
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/docs');
+    expect(mocks.eventsEmit).toHaveBeenCalledWith(browserLinkCopiedChannel, {
+      kind: 'link',
+      url: 'https://example.com/docs',
+    });
+    expect(webContents.loadURL).toHaveBeenCalledWith('https://example.com/docs');
+    expect(mocks.eventsEmit).toHaveBeenCalledWith(browserOpenInNewTabChannel, {
+      sourceBrowserId: 'browser-1',
+      url: 'https://example.com/docs',
+    });
+    expect(mocks.menuPopup).toHaveBeenCalledWith({
+      window: expect.any(Object),
+      x: undefined,
+      y: undefined,
+    });
+  });
+
+  it('shows disabled link actions for unsupported URLs', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitContextMenu('javascript:alert(1)');
+
+    expect(mocks.menuBuildFromTemplate).toHaveBeenCalledTimes(1);
+    expect(mocks.menuBuildFromTemplate.mock.calls[0]?.[0]).toMatchObject([
+      { label: 'Copy Link', enabled: false },
+      { label: 'Open Link', enabled: false },
+      { label: 'Open Link in New Tab', enabled: false },
+      { type: 'separator' },
+      { label: 'Reload' },
+    ]);
+  });
+
+  it('copies the current browser URL from the webview shortcut', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitCopyUrlShortcut();
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/current');
+    expect(mocks.eventsEmit).toHaveBeenCalledWith(browserLinkCopiedChannel, {
+      kind: 'url',
+      url: 'https://example.com/current',
+    });
+  });
+
+  it('uses the configured webview copy URL shortcut', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+    registry.setKeyboardSettings({ browserCopyUrl: 'Control+Shift+U' });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitCopyUrlShortcut();
+    webContents.emitCopyUrlShortcut({ key: 'u', meta: false, control: true });
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledTimes(1);
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/current');
+  });
+
+  it('does not copy from the webview when the copy URL shortcut is cleared', () => {
+    const registry = new BrowserWebContentsRegistry();
+    const partition = 'persist:emdash-browser-project-workspace-task-browser-1';
+    const webContentsSession = { partition };
+    const webContents = attachedWebContents(webContentsSession);
+    registry.registerSession({ browserId: 'browser-1', partition });
+    registry.setKeyboardSettings({ browserCopyUrl: null });
+
+    registry.attachWebContents('browser-1', webContents, ownerWindow());
+    webContents.emitCopyUrlShortcut();
+
+    expect(mocks.clipboardWriteText).not.toHaveBeenCalled();
+    expect(mocks.eventsEmit).not.toHaveBeenCalledWith(browserLinkCopiedChannel, expect.any(Object));
   });
 });

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
@@ -91,31 +91,37 @@ export class BrowserWebContentsRegistry {
       }
     });
 
-    webContents.on('context-menu', (_event, params) => {
-      const linkUrl = isExternalHttpUrl(params.linkURL) ? params.linkURL : null;
+    webContents.on('context-menu', (event, params) => {
+      event.preventDefault();
+      clearWebviewSelection(webContents);
+
+      const target = getBrowserContextTarget(params);
       const template: MenuItemConstructorOptions[] = [
         {
-          label: 'Copy Link',
-          enabled: linkUrl !== null,
+          label: target?.kind === 'image' ? 'Copy Image URL' : 'Copy Link',
+          enabled: target !== null,
           click: () => {
-            if (!linkUrl) return;
-            clipboard.writeText(linkUrl);
-            events.emit(browserLinkCopiedChannel, { kind: 'link', url: linkUrl });
+            if (!target) return;
+            clipboard.writeText(target.url);
+            events.emit(browserLinkCopiedChannel, { kind: 'link', url: target.url });
           },
         },
         {
-          label: 'Open Link',
-          enabled: linkUrl !== null,
+          label: target?.kind === 'image' ? 'Open Image' : 'Open Link',
+          enabled: target !== null,
           click: () => {
-            if (linkUrl) void webContents.loadURL(linkUrl);
+            if (target) void webContents.loadURL(target.url);
           },
         },
         {
-          label: 'Open Link in New Tab',
-          enabled: linkUrl !== null,
+          label: target?.kind === 'image' ? 'Open Image in New Tab' : 'Open Link in New Tab',
+          enabled: target !== null,
           click: () => {
-            if (linkUrl) {
-              events.emit(browserOpenInNewTabChannel, { sourceBrowserId: browserId, url: linkUrl });
+            if (target) {
+              events.emit(browserOpenInNewTabChannel, {
+                sourceBrowserId: browserId,
+                url: target.url,
+              });
             }
           },
         },
@@ -180,6 +186,16 @@ function isExternalHttpUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+function getBrowserContextTarget(
+  params: Electron.ContextMenuParams
+): { kind: 'link' | 'image'; url: string } | null {
+  if (params.mediaType === 'image' && isExternalHttpUrl(params.srcURL)) {
+    return { kind: 'image', url: params.srcURL };
+  }
+  if (isExternalHttpUrl(params.linkURL)) return { kind: 'link', url: params.linkURL };
+  return null;
 }
 
 function getBrowserCopyUrlShortcut(keyboard?: AppSettings['keyboard']): string | null {
@@ -259,4 +275,11 @@ function parseShortcut(shortcut: string): {
 
 function normalizeInputKey(key: string): string {
   return key.toLowerCase();
+}
+
+function clearWebviewSelection(webContents: WebContents): void {
+  if (webContents.isDestroyed()) return;
+  void webContents
+    .executeJavaScript('window.getSelection()?.removeAllRanges();', true)
+    .catch(() => {});
 }

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
@@ -1,7 +1,16 @@
-import { session, type WebContents } from 'electron';
+import {
+  clipboard,
+  Menu,
+  session,
+  type BrowserWindow,
+  type MenuItemConstructorOptions,
+  type WebContents,
+} from 'electron';
 import { events } from '@main/lib/events';
 import { normalizeBrowserUrl } from '@shared/browser';
-import { browserOpenInNewTabChannel } from '@shared/events/browserEvents';
+import type { AppSettings } from '@shared/core/app-settings';
+import { browserLinkCopiedChannel, browserOpenInNewTabChannel } from '@shared/events/browserEvents';
+import { APP_SHORTCUTS, resolveDefaultHotkey } from '@shared/shortcuts';
 
 type RegisteredBrowserSession = {
   browserId: string;
@@ -13,6 +22,7 @@ export class BrowserWebContentsRegistry {
   private readonly browserIdByPartition = new Map<string, string>();
   private readonly webContentsByBrowserId = new Map<string, WebContents>();
   private activeBrowserId: string | null = null;
+  private copyBrowserUrlShortcut = getBrowserCopyUrlShortcut();
 
   registerSession(input: RegisteredBrowserSession): void {
     this.sessionsByBrowserId.set(input.browserId, input);
@@ -29,6 +39,10 @@ export class BrowserWebContentsRegistry {
     if (this.activeBrowserId === browserId) {
       this.activeBrowserId = null;
     }
+  }
+
+  setKeyboardSettings(keyboard: AppSettings['keyboard']): void {
+    this.copyBrowserUrlShortcut = getBrowserCopyUrlShortcut(keyboard);
   }
 
   get registeredPartitions(): ReadonlySet<string> {
@@ -48,7 +62,7 @@ export class BrowserWebContentsRegistry {
     return undefined;
   }
 
-  attachWebContents(browserId: string, webContents: WebContents): void {
+  attachWebContents(browserId: string, webContents: WebContents, ownerWindow: BrowserWindow): void {
     if (!this.sessionsByBrowserId.has(browserId)) return;
 
     this.webContentsByBrowserId.set(browserId, webContents);
@@ -61,10 +75,62 @@ export class BrowserWebContentsRegistry {
       return { action: 'deny' };
     });
 
+    webContents.on('before-input-event', (event, input) => {
+      if (!isCopyBrowserUrlShortcut(input, this.copyBrowserUrlShortcut)) return;
+
+      const url = webContents.getURL();
+      if (!url) return;
+      event.preventDefault();
+      clipboard.writeText(url);
+      events.emit(browserLinkCopiedChannel, { kind: 'url', url });
+    });
+
     webContents.on('will-navigate', (event, url) => {
       if (!isSupportedBrowserNavigationUrl(url)) {
         event.preventDefault();
       }
+    });
+
+    webContents.on('context-menu', (_event, params) => {
+      const linkUrl = isExternalHttpUrl(params.linkURL) ? params.linkURL : null;
+      const template: MenuItemConstructorOptions[] = [
+        {
+          label: 'Copy Link',
+          enabled: linkUrl !== null,
+          click: () => {
+            if (!linkUrl) return;
+            clipboard.writeText(linkUrl);
+            events.emit(browserLinkCopiedChannel, { kind: 'link', url: linkUrl });
+          },
+        },
+        {
+          label: 'Open Link',
+          enabled: linkUrl !== null,
+          click: () => {
+            if (linkUrl) void webContents.loadURL(linkUrl);
+          },
+        },
+        {
+          label: 'Open Link in New Tab',
+          enabled: linkUrl !== null,
+          click: () => {
+            if (linkUrl) {
+              events.emit(browserOpenInNewTabChannel, { sourceBrowserId: browserId, url: linkUrl });
+            }
+          },
+        },
+        { type: 'separator' },
+        {
+          label: 'Reload',
+          click: () => webContents.reload(),
+        },
+      ];
+
+      Menu.buildFromTemplate(template).popup({
+        window: ownerWindow,
+        x: params.x,
+        y: params.y,
+      });
     });
 
     webContents.once('destroyed', () => {
@@ -114,4 +180,83 @@ function isExternalHttpUrl(url: string): boolean {
   } catch {
     return false;
   }
+}
+
+function getBrowserCopyUrlShortcut(keyboard?: AppSettings['keyboard']): string | null {
+  const configured = keyboard?.browserCopyUrl;
+  if (configured === null) return null;
+  return configured ?? resolveDefaultHotkey(APP_SHORTCUTS.browserCopyUrl) ?? null;
+}
+
+function isCopyBrowserUrlShortcut(input: Electron.Input, shortcut: string | null): boolean {
+  if (shortcut === null) return false;
+  const parsed = parseShortcut(shortcut);
+  if (!parsed) return false;
+
+  return (
+    input.type === 'keyDown' &&
+    normalizeInputKey(input.key) === parsed.key &&
+    Boolean(input.shift) === parsed.shift &&
+    Boolean(input.alt) === parsed.alt &&
+    Boolean(input.meta) === parsed.meta &&
+    Boolean(input.control) === parsed.control
+  );
+}
+
+function parseShortcut(shortcut: string): {
+  key: string;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+  control: boolean;
+} | null {
+  const parts = shortcut
+    .split('+')
+    .map((part) => part.trim())
+    .filter(Boolean);
+  const key = parts.pop();
+  if (!key) return null;
+
+  const modifiers = {
+    shift: false,
+    alt: false,
+    meta: false,
+    control: false,
+  };
+
+  for (const part of parts) {
+    switch (part.toLowerCase()) {
+      case 'shift':
+        modifiers.shift = true;
+        break;
+      case 'alt':
+      case 'option':
+        modifiers.alt = true;
+        break;
+      case 'meta':
+      case 'cmd':
+      case 'command':
+        modifiers.meta = true;
+        break;
+      case 'ctrl':
+      case 'control':
+        modifiers.control = true;
+        break;
+      case 'mod':
+        if (process.platform === 'darwin') {
+          modifiers.meta = true;
+        } else {
+          modifiers.control = true;
+        }
+        break;
+      default:
+        return null;
+    }
+  }
+
+  return { key: normalizeInputKey(key), ...modifiers };
+}
+
+function normalizeInputKey(key: string): string {
+  return key.toLowerCase();
 }

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
@@ -7,6 +7,7 @@ import {
   type WebContents,
 } from 'electron';
 import { events } from '@main/lib/events';
+import { log } from '@main/lib/logger';
 import { normalizeBrowserUrl, type BrowserDataClearKind } from '@shared/browser';
 import type { AppSettings } from '@shared/core/app-settings';
 import { browserLinkCopiedChannel, browserOpenInNewTabChannel } from '@shared/events/browserEvents';
@@ -78,11 +79,11 @@ export class BrowserWebContentsRegistry {
     webContents.on('before-input-event', (event, input) => {
       if (!isCopyBrowserUrlShortcut(input, this.copyBrowserUrlShortcut)) return;
 
-      const url = webContents.getURL();
-      if (!url) return;
+      const normalized = normalizeBrowserUrl(webContents.getURL(), { allowSearchQueries: false });
+      if (!normalized.ok || !isExternalHttpUrl(normalized.url)) return;
       event.preventDefault();
-      clipboard.writeText(url);
-      events.emit(browserLinkCopiedChannel, { kind: 'url', url });
+      clipboard.writeText(normalized.url);
+      events.emit(browserLinkCopiedChannel, { kind: 'url', url: normalized.url });
     });
 
     webContents.on('will-navigate', (event, url) => {
@@ -93,17 +94,29 @@ export class BrowserWebContentsRegistry {
 
     webContents.on('context-menu', (event, params) => {
       event.preventDefault();
-      clearWebviewSelection(webContents);
+      const selectionText = (params.selectionText ?? '').trim();
+      if (!selectionText) {
+        clearWebviewSelection(webContents);
+      }
 
       const target = getBrowserContextTarget(params);
       const template: MenuItemConstructorOptions[] = [
+        ...(selectionText
+          ? [
+              {
+                label: 'Copy',
+                click: () => clipboard.writeText(selectionText),
+              },
+              { type: 'separator' as const },
+            ]
+          : []),
         {
           label: target?.kind === 'image' ? 'Copy Image URL' : 'Copy Link',
           enabled: target !== null,
           click: () => {
             if (!target) return;
             clipboard.writeText(target.url);
-            events.emit(browserLinkCopiedChannel, { kind: 'link', url: target.url });
+            events.emit(browserLinkCopiedChannel, { kind: target.kind, url: target.url });
           },
         },
         {
@@ -225,7 +238,14 @@ function getBrowserContextTarget(
 function getBrowserCopyUrlShortcut(keyboard?: AppSettings['keyboard']): string | null {
   const configured = keyboard?.browserCopyUrl;
   if (configured === null) return null;
-  return configured ?? resolveDefaultHotkey(APP_SHORTCUTS.browserCopyUrl) ?? null;
+  const fallback = resolveDefaultHotkey(APP_SHORTCUTS.browserCopyUrl) ?? null;
+  if (configured && !parseShortcut(configured)) {
+    log.warn('Invalid browser copy URL shortcut, falling back to default', {
+      shortcut: configured,
+    });
+    return fallback;
+  }
+  return configured ?? fallback;
 }
 
 function isCopyBrowserUrlShortcut(input: Electron.Input, shortcut: string | null): boolean {

--- a/apps/emdash-desktop/src/main/core/settings/controller.ts
+++ b/apps/emdash-desktop/src/main/core/settings/controller.ts
@@ -1,3 +1,4 @@
+import { browserWebContentsRegistry } from '@main/core/browser/browser-webcontents-registry';
 import { reconcileResourceSampler } from '@main/core/resource-monitor/resource-sampler';
 import { createRPCController } from '@shared/lib/ipc/rpc';
 import { appSettingsService, type AppSettings, type AppSettingsKey } from './settings-service';
@@ -18,15 +19,23 @@ export const appSettingsController = createRPCController({
   update: async <T extends AppSettingsKey>(key: T, value: AppSettings[T]): Promise<void> => {
     await appSettingsService.update(key, value);
     if (key === 'resourceMonitor') await reconcileResourceSampler();
+    if (key === 'keyboard')
+      browserWebContentsRegistry.setKeyboardSettings(value as AppSettings['keyboard']);
   },
 
   reset: async <T extends AppSettingsKey>(key: T): Promise<void> => {
     await appSettingsService.reset(key);
     if (key === 'resourceMonitor') await reconcileResourceSampler();
+    if (key === 'keyboard') {
+      browserWebContentsRegistry.setKeyboardSettings(await appSettingsService.get('keyboard'));
+    }
   },
 
   resetField: async <T extends AppSettingsKey>(key: T, field: string): Promise<void> => {
     await appSettingsService.resetField(key, field as keyof AppSettings[T]);
     if (key === 'resourceMonitor') await reconcileResourceSampler();
+    if (key === 'keyboard') {
+      browserWebContentsRegistry.setKeyboardSettings(await appSettingsService.get('keyboard'));
+    }
   },
 });

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -14,6 +14,7 @@ import { emdashAccountService } from './core/account/services/emdash-account-ser
 import { agentHookService } from './core/agent-hooks/agent-hook-service';
 import { appService } from './core/app/service';
 import { automationsService } from './core/automations/automations-service';
+import { browserWebContentsRegistry } from './core/browser/browser-webcontents-registry';
 import { localDependencyManager } from './core/dependencies/dependency-manager';
 import { editorBufferService } from './core/editor/editor-buffer-service';
 import { gitWatcherRegistry } from './core/git/git-watcher-registry';
@@ -132,6 +133,7 @@ void app.whenReady().then(async () => {
   automationsService.start();
   appService.initialize();
   await appSettingsService.initialize();
+  browserWebContentsRegistry.setKeyboardSettings(await appSettingsService.get('keyboard'));
   await promptLibraryService.initialize();
 
   agentHookService.initialize().catch((e) => {

--- a/apps/emdash-desktop/src/renderer/app/app-menu-events.tsx
+++ b/apps/emdash-desktop/src/renderer/app/app-menu-events.tsx
@@ -52,7 +52,13 @@ export function AppMenuEvents({ onOpenSettings }: { onOpenSettings?: () => boole
 
   useEffect(() => {
     return events.on(browserLinkCopiedChannel, ({ kind }) => {
-      toast({ title: kind === 'url' ? 'Browser URL copied' : 'Link copied' });
+      const title =
+        kind === 'url'
+          ? 'Browser URL copied'
+          : kind === 'image'
+            ? 'Image URL copied'
+            : 'Link copied';
+      toast({ title });
     });
   }, []);
 

--- a/apps/emdash-desktop/src/renderer/app/app-menu-events.tsx
+++ b/apps/emdash-desktop/src/renderer/app/app-menu-events.tsx
@@ -1,6 +1,7 @@
 import { when } from 'mobx';
 import { useEffect } from 'react';
 import { getTaskView } from '@renderer/features/tasks/stores/task-selectors';
+import { toast } from '@renderer/lib/hooks/use-toast';
 import { events, rpc } from '@renderer/lib/ipc';
 import { useNavigate, useWorkspaceSlots } from '@renderer/lib/layout/navigation-provider';
 import { toggleSettingsView } from '@renderer/lib/layout/settings-toggle';
@@ -11,6 +12,7 @@ import {
   menuQuitRequestedChannel,
   notificationFocusTaskChannel,
 } from '@shared/events/appEvents';
+import { browserLinkCopiedChannel } from '@shared/events/browserEvents';
 
 export function AppMenuEvents({ onOpenSettings }: { onOpenSettings?: () => boolean | void }) {
   const { navigate } = useNavigate();
@@ -47,6 +49,12 @@ export function AppMenuEvents({ onOpenSettings }: { onOpenSettings?: () => boole
       showFeedbackModal({});
     });
   }, [showFeedbackModal]);
+
+  useEffect(() => {
+    return events.on(browserLinkCopiedChannel, ({ kind }) => {
+      toast({ title: kind === 'url' ? 'Browser URL copied' : 'Link copied' });
+    });
+  }, []);
 
   useEffect(() => {
     const disposers = new Set<() => void>();

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
@@ -13,7 +13,9 @@ const mocks = vi.hoisted(() => ({
   openExternal: vi.fn(),
   reload: vi.fn(),
   showModal: vi.fn(),
+  toast: vi.fn(),
   visibleTaskIdsForProject: vi.fn(),
+  writeText: vi.fn(() => Promise.resolve()),
 }));
 
 vi.mock('@renderer/features/browser/browser-controls-registry', () => ({
@@ -48,6 +50,10 @@ vi.mock('@renderer/lib/ipc', () => ({
       openExternal: mocks.openExternal,
     },
   },
+}));
+
+vi.mock('@renderer/lib/hooks/use-toast', () => ({
+  toast: mocks.toast,
 }));
 
 vi.mock('@renderer/lib/stores/app-state', () => ({
@@ -117,6 +123,12 @@ describe('createTaskCommandProvider', () => {
     mocks.getRegisteredTaskData.mockReturnValue({
       id: 'task-1',
       isPinned: false,
+    });
+    Object.defineProperty(navigator, 'clipboard', {
+      configurable: true,
+      value: {
+        writeText: mocks.writeText,
+      },
     });
   });
 
@@ -196,9 +208,14 @@ describe('createTaskCommandProvider', () => {
       .getCommands()
       .find((candidate) => candidate.id === 'task.browserOpenExternal')
       ?.execute();
+    provider
+      .getCommands()
+      .find((candidate) => candidate.id === 'task.browserCopyUrl')
+      ?.execute();
 
     expect(mocks.reload).toHaveBeenCalledWith();
     expect(mocks.focusUrl).toHaveBeenCalledWith();
     expect(mocks.openExternal).toHaveBeenCalledWith('https://example.com/');
+    expect(mocks.writeText).toHaveBeenCalledWith('https://example.com/');
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
@@ -7,6 +7,7 @@ import {
 } from '@renderer/features/tasks/stores/task-selectors';
 import { closeActiveTabWithConfirm } from '@renderer/features/tasks/tabs/close-tab-with-confirm';
 import type { CommandProvider } from '@renderer/lib/commands/types';
+import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { showModal } from '@renderer/lib/modal/modal-provider';
 import { appState, sidebarStore } from '@renderer/lib/stores/app-state';
@@ -45,6 +46,8 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
       const activeBrowserTab = tabManager?.resolvedTabs.find(
         (tab) => tab.isActive && tab.kind === 'browser'
       );
+      const activeBrowserSession =
+        activeBrowserTab?.kind === 'browser' ? activeBrowserTab.session : null;
 
       const newConversationDef = taskDef('task.newConversation');
       const newConversationSplitRightDef = taskDef('task.newConversationSplitRight');
@@ -59,6 +62,7 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
       const browserReloadDef = taskDef('task.browserReload');
       const browserFocusUrlDef = taskDef('task.browserFocusUrl');
       const browserOpenExternalDef = taskDef('task.browserOpenExternal');
+      const browserCopyUrlDef = taskDef('task.browserCopyUrl');
       const gitFetchDef = taskDef('task.gitFetch');
       const gitPullDef = taskDef('task.gitPull');
       const gitPushDef = taskDef('task.gitPush');
@@ -231,6 +235,31 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
             }
           },
         },
+        ...(activeBrowserSession
+          ? [
+              {
+                id: browserCopyUrlDef.id,
+                label: browserCopyUrlDef.label,
+                description: browserCopyUrlDef.description,
+                shortcutKey: browserCopyUrlDef.shortcutKey,
+                group: browserCopyUrlDef.group,
+                execute() {
+                  const normalized = normalizeBrowserUrl(activeBrowserSession.currentUrl, {
+                    allowSearchQueries: false,
+                  });
+                  if (!normalized.ok) return;
+                  void navigator.clipboard
+                    .writeText(normalized.url)
+                    .then(() => {
+                      toast({ title: 'Browser URL copied' });
+                    })
+                    .catch(() => {
+                      toast({ title: 'Could not copy browser URL', variant: 'destructive' });
+                    });
+                },
+              },
+            ]
+          : []),
 
         // ── Tab management ─────────────────────────────────────────────────
         {

--- a/apps/emdash-desktop/src/shared/commands.ts
+++ b/apps/emdash-desktop/src/shared/commands.ts
@@ -207,6 +207,15 @@ export const TASK_COMMAND_DEFS = defineCommandDefs([
     iconKey: 'external-link',
   },
   {
+    id: 'task.browserCopyUrl',
+    label: 'Copy Browser URL',
+    description: 'Copy the active browser URL',
+    scope: 'task',
+    shortcutKey: 'browserCopyUrl',
+    group: 'Browser',
+    iconKey: 'copy',
+  },
+  {
     id: 'task.gitFetch',
     label: 'Git Fetch',
     description: 'Fetch latest changes from remote',

--- a/apps/emdash-desktop/src/shared/events/browserEvents.ts
+++ b/apps/emdash-desktop/src/shared/events/browserEvents.ts
@@ -5,6 +5,7 @@ export const browserOpenInNewTabChannel = defineEvent<{
   url: string;
 }>('browser:open-in-new-tab');
 
-export const browserLinkCopiedChannel = defineEvent<{ kind: 'link' | 'url'; url: string }>(
-  'browser:link-copied'
-);
+export const browserLinkCopiedChannel = defineEvent<{
+  kind: 'image' | 'link' | 'url';
+  url: string;
+}>('browser:link-copied');

--- a/apps/emdash-desktop/src/shared/events/browserEvents.ts
+++ b/apps/emdash-desktop/src/shared/events/browserEvents.ts
@@ -4,3 +4,7 @@ export const browserOpenInNewTabChannel = defineEvent<{
   sourceBrowserId: string;
   url: string;
 }>('browser:open-in-new-tab');
+
+export const browserLinkCopiedChannel = defineEvent<{ kind: 'link' | 'url'; url: string }>(
+  'browser:link-copied'
+);

--- a/apps/emdash-desktop/src/shared/shortcuts.ts
+++ b/apps/emdash-desktop/src/shared/shortcuts.ts
@@ -150,6 +150,12 @@ export const APP_SHORTCUTS = defineShortcuts({
     description: 'Open an in-app browser in the current task',
     category: 'Task View',
   },
+  browserCopyUrl: {
+    defaultHotkey: 'Mod+Shift+C',
+    label: 'Copy Browser URL',
+    description: 'Copy the current in-app browser URL',
+    category: 'Task View',
+  },
   toggleTerminalDrawer: {
     defaultHotkey: 'Mod+J',
     label: 'Toggle Terminal Drawer',


### PR DESCRIPTION
### Description
- add in app browser context meun for copying and opening links
- opening links or images in a new browser tab from the webview ontext meun
- image specific context menu
- cmd+c to copy current url in the in app browser (configurable)

### Screenshot/Recording (if applicable)
https://streamable.com/17tszl

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
