### PR TITLE
fix(diff): refresh stale git diff models

### DIFF
--- a/apps/emdash-desktop/src/main/core/git/impl/git-service.ts
+++ b/apps/emdash-desktop/src/main/core/git/impl/git-service.ts
@@ -500,19 +500,15 @@ export class GitService implements GitProvider, IDisposable {
   }
 
   async getFileAtIndex(filePath: string): Promise<string | null> {
-    const cf = this._getCatFile();
-    if (cf) {
-      try {
-        return await cf.read(`:0:${filePath}`);
-      } catch {
-        // Fall back
-      }
-    }
+    // Must NOT go through the persistent cat-file --batch channel: git caches
+    // the in-core index on the first `:0:<path>` read and never re-reads it,
+    // so a long-lived batch process keeps serving stale staged content after
+    // the index changes (git add / commit). A one-shot process is always fresh.
     try {
-      const { stdout } = await this.ctx.exec('git', ['show', `:0:${filePath}`], {
+      const { stdout } = await this.ctx.exec('git', ['cat-file', 'blob', `:0:${filePath}`], {
         maxBuffer: MAX_DIFF_CONTENT_BYTES,
       });
-      return stripTrailingNewline(stdout);
+      return stdout;
     } catch {
       return null;
     }

--- a/apps/emdash-desktop/src/renderer/lib/monaco/invalidation-bridges.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/invalidation-bridges.ts
@@ -58,6 +58,14 @@ export function wireModelRegistryInvalidation(registry: MonacoModelRegistry): ()
   // Local/remote ref changes → invalidate matching git:// models (exact ref when known).
   const unsubRefs = events.on(gitRefChangedChannel, ({ projectId, kind, changedRefs }) => {
     if (kind === 'config') return;
+    // A commit moves the local branch ref but never touches the worktree HEAD
+    // file, so no workspace-level 'head' event fires — refresh HEAD models on
+    // any local ref change to keep HEAD-based diffs in sync after commits.
+    if (kind === 'local-refs') {
+      for (const uri of registry.findGitUris({ projectId, ref: HEAD_REF })) {
+        void registry.invalidateModel(uri);
+      }
+    }
     if (changedRefs) {
       for (const ref of changedRefs) {
         for (const uri of registry.findGitUris({ projectId, ref })) {


### PR DESCRIPTION
### Description
- fix code editor showing already commited diff 
- invalidate head based monaco models on local ref changes

### Screenshot/Recording (if applicable)
https://streamable.com/z06c7i

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
