### PR TITLE
fix(ssh): use IP-style host placeholder

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -434,7 +434,7 @@ export function AddSshConnModal({
                           onBlur={field.handleBlur}
                           onChange={(e) => field.handleChange(e.target.value)}
                           aria-invalid={isInvalid}
-                          placeholder="example.com"
+                          placeholder="203.0.113.10"
                           disabled={isAliasBacked}
                         />
                         {isInvalid && <FieldError errors={field.state.meta.errors} />}


### PR DESCRIPTION
## Summary

- Update the SSH connection host placeholder from a domain example to an IP-style example.
- Use documentation-range address `203.0.113.10` to avoid implying a real server.

## Validation

- `pnpm exec oxfmt --check apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx`