### PR TITLE
fix(sidebar): remove automations beta badge

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
@@ -7,7 +7,6 @@ import {
   useWorkspaceSlots,
 } from '@renderer/lib/layout/navigation-provider';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
-import { Badge } from '@renderer/lib/ui/badge';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { cn } from '@renderer/utils/utils';
 import { SidebarPinnedTaskList } from './pinned-task-list';
@@ -77,9 +76,6 @@ export const LeftSidebar: React.FC = observer(function LeftSidebar() {
                 <Clock className="h-5 w-5 shrink-0 sm:h-4 sm:w-4" />
                 <span className="truncate">Automations</span>
               </span>
-              <Badge variant="secondary" className="h-4 px-1.5 text-[9px] tracking-wide uppercase">
-                Beta
-              </Badge>
             </SidebarMenuButton>
             <SidebarMenuButton
               isActive={


### PR DESCRIPTION
## Summary

- Removed the Beta badge from the Automations item in the left sidebar.
- Cleaned up the unused badge import left behind by the UI change.

## Impact

- Automations now appears as a regular sidebar navigation item without a beta label.

## Validation

- corepack pnpm --filter @emdash/emdash-desktop run format:check
- corepack pnpm --filter @emdash/emdash-desktop run typecheck
- corepack pnpm --filter @emdash/emdash-desktop run lint

Note: lint completed with an existing warning in src/renderer/features/automations/use-automations.ts unrelated to this change.
