### PR TITLE
feat(projects): add setup command suggestion

### DIFF
--- a/apps/emdash-desktop/src/main/core/projects/controller.ts
+++ b/apps/emdash-desktop/src/main/core/projects/controller.ts
@@ -6,12 +6,16 @@ import { openProject } from './operations/openProject';
 import { updateProjectConnection } from './operations/updateProjectConnection';
 import { countProjectsUsingGithubAccount } from './settings/count-projects-using-github-account';
 import { projectSettingsService } from './settings/project-settings-service';
+import { suggestSetupScript } from './setup-suggestion/suggest-setup-script';
 
 export const projectController = createRPCController({
   createProject,
   inspectProjectPath,
   getProjects,
   deleteProject,
+  suggestSetupScript,
+  applySetupScript: (projectId: string, command: string) =>
+    projectSettingsService.setSetupScript(projectId, command),
   getProjectSettingsPage: (projectId: string) =>
     projectSettingsService.getProjectSettingsPage(projectId),
   updateProjectSettings: (projectId, settings) =>

--- a/apps/emdash-desktop/src/main/core/projects/settings/project-settings-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/settings/project-settings-service.ts
@@ -74,6 +74,34 @@ export class ProjectSettingsService implements Hookable<ProjectSettingsHooks>, I
     return ok(updatedSettings);
   }
 
+  /**
+   * Set the lifecycle setup script for a project. Reads the current settings
+   * server-side and writes back the merged result, so callers only need to pass
+   * the command — avoiding a full settings round-trip from the renderer.
+   */
+  async setSetupScript(
+    projectId: string,
+    command: string
+  ): Promise<Result<ProjectSettings, UpdateProjectSettingsError>> {
+    const project = this.requireProject(projectId);
+    if (!project.success) return project;
+
+    const current = await project.data.settings.get();
+    if (current.scripts?.setup?.trim()) {
+      return err({ type: 'setup-script-already-configured' });
+    }
+
+    const result = await project.data.settings.update({
+      ...current,
+      scripts: { ...current.scripts, setup: command },
+    });
+    if (!result.success) return result;
+
+    const updatedSettings = await project.data.settings.get();
+    this.emitSettingsChanged(projectId, updatedSettings);
+    return ok(updatedSettings);
+  }
+
   async patchProjectSettings(
     projectId: string,
     patch: ProjectSettingsPatch

--- a/apps/emdash-desktop/src/main/core/projects/setup-suggestion/detect-setup-suggestion.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/setup-suggestion/detect-setup-suggestion.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest';
+import { detectSetupSuggestion } from './detect-setup-suggestion';
+
+function fsWith(files: string[], opts: { throwOn?: string } = {}) {
+  const present = new Set(files);
+  return {
+    exists: (path: string): Promise<boolean> => {
+      if (opts.throwOn && path === opts.throwOn) {
+        return Promise.reject(new Error('boom'));
+      }
+      return Promise.resolve(present.has(path));
+    },
+  };
+}
+
+describe('detectSetupSuggestion', () => {
+  it('suggests bun install for a bun lockfile', async () => {
+    const result = await detectSetupSuggestion(fsWith(['bun.lock', 'package.json']));
+    expect(result).toEqual({ tool: 'bun', displayName: 'Bun', command: 'bun install' });
+  });
+
+  it('prefers a pinned package manager over a bare package.json', async () => {
+    const result = await detectSetupSuggestion(fsWith(['pnpm-lock.yaml', 'package.json']));
+    expect(result?.command).toBe('pnpm install');
+  });
+
+  it('falls back to npm install for a bare package.json', async () => {
+    const result = await detectSetupSuggestion(fsWith(['package.json']));
+    expect(result).toEqual({ tool: 'node', displayName: 'Node.js', command: 'npm install' });
+  });
+
+  it('detects non-JS ecosystems', async () => {
+    expect((await detectSetupSuggestion(fsWith(['Cargo.toml'])))?.command).toBe('cargo build');
+    expect((await detectSetupSuggestion(fsWith(['go.mod'])))?.command).toBe('go mod download');
+    expect((await detectSetupSuggestion(fsWith(['Gemfile'])))?.command).toBe('bundle install');
+  });
+
+  it('returns null when no known tooling is present', async () => {
+    expect(await detectSetupSuggestion(fsWith(['README.md']))).toBeNull();
+  });
+
+  it('treats a failing exists() check as not present', async () => {
+    const result = await detectSetupSuggestion(fsWith([], { throwOn: 'bun.lockb' }));
+    expect(result).toBeNull();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/projects/setup-suggestion/detect-setup-suggestion.ts
+++ b/apps/emdash-desktop/src/main/core/projects/setup-suggestion/detect-setup-suggestion.ts
@@ -29,7 +29,7 @@ const SETUP_SUGGESTION_RULES: readonly SetupSuggestionRule[] = [
     command: 'pip install -r requirements.txt',
     anyOf: ['requirements.txt'],
   },
-  { tool: 'python', displayName: 'Python', command: 'pip install -e .', anyOf: ['pyproject.toml'] },
+  { tool: 'python', displayName: 'Python', command: 'pip install .', anyOf: ['pyproject.toml'] },
   { tool: 'bundler', displayName: 'Bundler', command: 'bundle install', anyOf: ['Gemfile'] },
   {
     tool: 'composer',

--- a/apps/emdash-desktop/src/main/core/projects/setup-suggestion/detect-setup-suggestion.ts
+++ b/apps/emdash-desktop/src/main/core/projects/setup-suggestion/detect-setup-suggestion.ts
@@ -1,0 +1,84 @@
+import type { FileSystemProvider } from '@main/core/fs/types';
+import { log } from '@main/lib/logger';
+import type { SetupScriptSuggestion } from '@shared/core/projects/setup-suggestion';
+
+type SetupSuggestionRule = SetupScriptSuggestion & {
+  /** Root-relative marker files; the rule matches if any of them exists. */
+  anyOf: string[];
+};
+
+/**
+ * Ordered detection rules. The first rule with a matching marker file wins, so
+ * more specific signals (lockfiles that pin a package manager) come before the
+ * generic fallbacks (a bare `package.json`).
+ */
+const SETUP_SUGGESTION_RULES: readonly SetupSuggestionRule[] = [
+  { tool: 'bun', displayName: 'Bun', command: 'bun install', anyOf: ['bun.lockb', 'bun.lock'] },
+  { tool: 'pnpm', displayName: 'pnpm', command: 'pnpm install', anyOf: ['pnpm-lock.yaml'] },
+  { tool: 'yarn', displayName: 'Yarn', command: 'yarn install', anyOf: ['yarn.lock'] },
+  { tool: 'npm', displayName: 'npm', command: 'npm install', anyOf: ['package-lock.json'] },
+  { tool: 'node', displayName: 'Node.js', command: 'npm install', anyOf: ['package.json'] },
+  { tool: 'cargo', displayName: 'Cargo', command: 'cargo build', anyOf: ['Cargo.toml'] },
+  { tool: 'go', displayName: 'Go', command: 'go mod download', anyOf: ['go.mod'] },
+  { tool: 'uv', displayName: 'uv', command: 'uv sync', anyOf: ['uv.lock'] },
+  { tool: 'poetry', displayName: 'Poetry', command: 'poetry install', anyOf: ['poetry.lock'] },
+  { tool: 'pipenv', displayName: 'Pipenv', command: 'pipenv install', anyOf: ['Pipfile'] },
+  {
+    tool: 'pip',
+    displayName: 'pip',
+    command: 'pip install -r requirements.txt',
+    anyOf: ['requirements.txt'],
+  },
+  { tool: 'python', displayName: 'Python', command: 'pip install -e .', anyOf: ['pyproject.toml'] },
+  { tool: 'bundler', displayName: 'Bundler', command: 'bundle install', anyOf: ['Gemfile'] },
+  {
+    tool: 'composer',
+    displayName: 'Composer',
+    command: 'composer install',
+    anyOf: ['composer.json'],
+  },
+  {
+    tool: 'gradle',
+    displayName: 'Gradle',
+    command: './gradlew build',
+    anyOf: ['build.gradle', 'build.gradle.kts'],
+  },
+  { tool: 'maven', displayName: 'Maven', command: 'mvn install', anyOf: ['pom.xml'] },
+  { tool: 'mix', displayName: 'Mix', command: 'mix deps.get', anyOf: ['mix.exs'] },
+  {
+    tool: 'swift',
+    displayName: 'Swift',
+    command: 'swift package resolve',
+    anyOf: ['Package.swift'],
+  },
+  { tool: 'dart', displayName: 'Dart', command: 'dart pub get', anyOf: ['pubspec.yaml'] },
+];
+
+async function markerExists(
+  fs: Pick<FileSystemProvider, 'exists'>,
+  path: string
+): Promise<boolean> {
+  try {
+    return await fs.exists(path);
+  } catch (error) {
+    log.warn('detectSetupSuggestion: exists() check failed', { path, error });
+    return false;
+  }
+}
+
+/**
+ * Inspect the project root for known tooling markers and return a single best
+ * setup-command suggestion, or null when nothing recognizable is found.
+ */
+export async function detectSetupSuggestion(
+  fs: Pick<FileSystemProvider, 'exists'>
+): Promise<SetupScriptSuggestion | null> {
+  for (const rule of SETUP_SUGGESTION_RULES) {
+    for (const marker of rule.anyOf) {
+      if (await markerExists(fs, marker)) {
+        return { tool: rule.tool, displayName: rule.displayName, command: rule.command };
+      }
+    }
+  }
+  return null;
+}

--- a/apps/emdash-desktop/src/main/core/projects/setup-suggestion/suggest-setup-script.ts
+++ b/apps/emdash-desktop/src/main/core/projects/setup-suggestion/suggest-setup-script.ts
@@ -1,0 +1,32 @@
+import { log } from '@main/lib/logger';
+import type { SetupScriptSuggestion } from '@shared/core/projects/setup-suggestion';
+import { projectManager } from '../project-manager';
+import { detectSetupSuggestion } from './detect-setup-suggestion';
+
+/**
+ * Suggest a setup (lifecycle) command for a project based on the tooling detected
+ * in its repository root. Returns null when the project is unknown, already has a
+ * `scripts.setup` configured, or no recognizable tooling is present.
+ */
+export async function suggestSetupScript(projectId: string): Promise<SetupScriptSuggestion | null> {
+  const project = projectManager.getProject(projectId);
+  if (!project) return null;
+
+  // Don't nag if the user already configured a setup script.
+  try {
+    const settings = await project.settings.get();
+    if (settings.scripts?.setup && settings.scripts.setup.trim().length > 0) {
+      return null;
+    }
+  } catch (error) {
+    log.warn('suggestSetupScript: failed to read project settings', { projectId, error });
+    // Fall through — a suggestion is still useful even if settings are unreadable.
+  }
+
+  try {
+    return await detectSetupSuggestion(project.fs);
+  } catch (error) {
+    log.warn('suggestSetupScript: detection failed', { projectId, error });
+    return null;
+  }
+}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/main-panel/active-project.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/main-panel/active-project.tsx
@@ -1,6 +1,7 @@
 import { observer } from 'mobx-react-lite';
 import { PullRequestView } from '@renderer/features/projects/components/pr-view/pr-view';
 import { SettingsPanel } from '@renderer/features/projects/components/settings-view/settings-panel';
+import { SetupSuggestionToast } from '@renderer/features/projects/components/setup-suggestion/setup-suggestion-toast';
 import { TaskList } from '@renderer/features/projects/components/task-view/task-list';
 import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import type { ProjectView } from '@renderer/features/projects/stores/project-view';
@@ -74,6 +75,7 @@ export const ActiveProject = observer(function ActiveProject() {
           </div>
         </div>
       </div>
+      <SetupSuggestionToast projectId={projectId} />
     </div>
   );
 });

--- a/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-state.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-state.ts
@@ -1,0 +1,43 @@
+const eligibilityKey = (projectId: string) => `emdash:setup-suggestion-eligible:${projectId}`;
+const dismissKey = (projectId: string) => `emdash:setup-suggestion-dismissed:${projectId}`;
+
+function readFlag(key: string): boolean {
+  try {
+    return localStorage.getItem(key) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function writeFlag(key: string): void {
+  try {
+    localStorage.setItem(key, 'true');
+  } catch {
+    // ignore — localStorage is best-effort UI state
+  }
+}
+
+function removeFlag(key: string): void {
+  try {
+    localStorage.removeItem(key);
+  } catch {
+    // ignore — localStorage is best-effort UI state
+  }
+}
+
+export function markSetupSuggestionEligible(projectId: string): void {
+  writeFlag(eligibilityKey(projectId));
+}
+
+export function shouldShowSetupSuggestion(projectId: string): boolean {
+  return readFlag(eligibilityKey(projectId)) && !readFlag(dismissKey(projectId));
+}
+
+export function dismissSetupSuggestion(projectId: string): void {
+  writeFlag(dismissKey(projectId));
+  removeFlag(eligibilityKey(projectId));
+}
+
+export function clearSetupSuggestionEligibility(projectId: string): void {
+  removeFlag(eligibilityKey(projectId));
+}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-toast.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-toast.tsx
@@ -1,6 +1,6 @@
 import { X } from 'lucide-react';
 import { AnimatePresence, motion } from 'motion/react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { CLISpinner } from '@renderer/features/tasks/components/cliSpinner';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
@@ -27,8 +27,10 @@ const MIN_APPLYING_MS = 450;
 export function SetupSuggestionToast({ projectId }: { projectId: string }) {
   const [suggestion, setSuggestion] = useState<SetupScriptSuggestion | null>(null);
   const [phase, setPhase] = useState<Phase>('hidden');
+  const applyTokenRef = useRef(0);
 
   useEffect(() => {
+    applyTokenRef.current += 1;
     setSuggestion(null);
     setPhase('hidden');
     if (!shouldShowSetupSuggestion(projectId)) return;
@@ -56,18 +58,22 @@ export function SetupSuggestionToast({ projectId }: { projectId: string }) {
   }, [projectId]);
 
   const handleDismiss = useCallback(() => {
+    applyTokenRef.current += 1;
     dismissSetupSuggestion(projectId);
     setPhase('hidden');
   }, [projectId]);
 
   const handleApply = useCallback(async () => {
     if (!suggestion) return;
+    const applyToken = (applyTokenRef.current += 1);
+    const isCurrentApply = () => applyTokenRef.current === applyToken;
     setPhase('applying');
     const minVisible = new Promise<void>((resolve) => window.setTimeout(resolve, MIN_APPLYING_MS));
 
     try {
       const result = await rpc.projects.applySetupScript(projectId, suggestion.command);
       await minVisible;
+      if (!isCurrentApply()) return;
       if (!result.success) {
         if (result.error.type === 'setup-script-already-configured') {
           setPhase('hidden');
@@ -79,9 +85,12 @@ export function SetupSuggestionToast({ projectId }: { projectId: string }) {
       }
       dismissSetupSuggestion(projectId);
       setPhase('applied');
-      window.setTimeout(() => setPhase('hidden'), 1800);
+      window.setTimeout(() => {
+        if (isCurrentApply()) setPhase('hidden');
+      }, 1800);
     } catch {
       await minVisible;
+      if (!isCurrentApply()) return;
       toast({ title: 'Could not add setup script', variant: 'destructive' });
       setPhase('visible');
     }

--- a/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-toast.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-toast.tsx
@@ -1,0 +1,179 @@
+import { X } from 'lucide-react';
+import { AnimatePresence, motion } from 'motion/react';
+import { useCallback, useEffect, useState } from 'react';
+import { CLISpinner } from '@renderer/features/tasks/components/cliSpinner';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+import { Button } from '@renderer/lib/ui/button';
+import { cn } from '@renderer/utils/utils';
+import type { SetupScriptSuggestion } from '@shared/core/projects/setup-suggestion';
+
+type Phase = 'hidden' | 'visible' | 'applying' | 'applied';
+
+/** Keep the spinner visible long enough to read as deliberate feedback, not a flicker. */
+const MIN_APPLYING_MS = 450;
+
+const dismissKey = (projectId: string) => `emdash:setup-suggestion-dismissed:${projectId}`;
+
+function isDismissed(projectId: string): boolean {
+  try {
+    return localStorage.getItem(dismissKey(projectId)) === 'true';
+  } catch {
+    return false;
+  }
+}
+
+function persistDismiss(projectId: string): void {
+  try {
+    localStorage.setItem(dismissKey(projectId), 'true');
+  } catch {
+    // ignore — dismissal persistence is best-effort
+  }
+}
+
+/**
+ * A minimal, dismissible suggestion anchored bottom-right of the project view.
+ * When a user enters a project that has no `scripts.setup` configured, we detect
+ * its tooling (Bun, pnpm, Cargo, …) and offer the matching install command as a
+ * one-click lifecycle setup script.
+ */
+export function SetupSuggestionToast({ projectId }: { projectId: string }) {
+  const [suggestion, setSuggestion] = useState<SetupScriptSuggestion | null>(null);
+  const [phase, setPhase] = useState<Phase>('hidden');
+
+  useEffect(() => {
+    setSuggestion(null);
+    setPhase('hidden');
+    if (isDismissed(projectId)) return;
+
+    let cancelled = false;
+    void rpc.projects
+      .suggestSetupScript(projectId)
+      .then((result) => {
+        if (cancelled || !result) return;
+        setSuggestion(result);
+        setPhase('visible');
+      })
+      .catch(() => {
+        // Detection is best-effort; stay silent on failure.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [projectId]);
+
+  const handleDismiss = useCallback(() => {
+    persistDismiss(projectId);
+    setPhase('hidden');
+  }, [projectId]);
+
+  const handleApply = useCallback(async () => {
+    if (!suggestion) return;
+    setPhase('applying');
+    const minVisible = new Promise<void>((resolve) => window.setTimeout(resolve, MIN_APPLYING_MS));
+
+    try {
+      const result = await rpc.projects.applySetupScript(projectId, suggestion.command);
+      await minVisible;
+      if (!result.success) {
+        if (result.error.type === 'setup-script-already-configured') {
+          setPhase('hidden');
+          return;
+        }
+        toast({ title: 'Could not add setup script', variant: 'destructive' });
+        setPhase('visible');
+        return;
+      }
+      persistDismiss(projectId);
+      setPhase('applied');
+      window.setTimeout(() => setPhase('hidden'), 1800);
+    } catch {
+      await minVisible;
+      toast({ title: 'Could not add setup script', variant: 'destructive' });
+      setPhase('visible');
+    }
+  }, [projectId, suggestion]);
+
+  const open = phase !== 'hidden' && suggestion !== null;
+
+  return (
+    <AnimatePresence>
+      {open && suggestion && (
+        <motion.div
+          initial={{ opacity: 0, y: 8 }}
+          animate={{ opacity: 1, y: 0 }}
+          exit={{ opacity: 0, y: 8 }}
+          transition={{ duration: 0.18, ease: 'easeOut' }}
+          className="fixed right-4 bottom-4 z-50 w-[320px] rounded-xl border border-border bg-background-quaternary p-4 shadow-md"
+          role="status"
+        >
+          <button
+            type="button"
+            onClick={handleDismiss}
+            aria-label="Dismiss suggestion"
+            className="absolute top-2.5 right-2.5 rounded p-1 text-foreground-tertiary-muted transition-colors hover:text-foreground-tertiary"
+          >
+            <X className="size-3.5" />
+          </button>
+
+          <p className="pr-5 text-sm font-semibold text-foreground">
+            Set up your {suggestion.displayName} project
+          </p>
+
+          {phase === 'applied' ? (
+            <p className="mt-1.5 text-xs leading-relaxed text-foreground-muted">
+              Added as a setup script — runs on every new task.
+            </p>
+          ) : (
+            <>
+              <p className="mt-1.5 text-xs leading-relaxed text-foreground-muted">
+                Run{' '}
+                <code className="rounded bg-background-quaternary-1 px-1 py-0.5 font-mono text-[11px] text-foreground">
+                  {suggestion.command}
+                </code>{' '}
+                automatically whenever you create a new task.
+              </p>
+              <div className="mt-3 flex justify-end gap-2">
+                <Button
+                  size="sm"
+                  variant="ghost"
+                  onClick={handleDismiss}
+                  disabled={phase === 'applying'}
+                >
+                  Not now
+                </Button>
+                <Button
+                  size="sm"
+                  onClick={handleApply}
+                  disabled={phase === 'applying'}
+                  className="justify-center"
+                >
+                  <span className="grid items-center">
+                    <span
+                      className={cn(
+                        'col-start-1 row-start-1 flex items-center justify-center gap-1 transition-opacity duration-150',
+                        phase === 'applying' ? 'opacity-100' : 'opacity-0'
+                      )}
+                    >
+                      {phase === 'applying' && <CLISpinner className="text-current" />}
+                      Adding
+                    </span>
+                    <span
+                      className={cn(
+                        'col-start-1 row-start-1 transition-opacity duration-150',
+                        phase === 'applying' ? 'opacity-0' : 'opacity-100'
+                      )}
+                    >
+                      Add setup script
+                    </span>
+                  </span>
+                </Button>
+              </div>
+            </>
+          )}
+        </motion.div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-toast.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/setup-suggestion/setup-suggestion-toast.tsx
@@ -7,35 +7,22 @@ import { rpc } from '@renderer/lib/ipc';
 import { Button } from '@renderer/lib/ui/button';
 import { cn } from '@renderer/utils/utils';
 import type { SetupScriptSuggestion } from '@shared/core/projects/setup-suggestion';
+import {
+  clearSetupSuggestionEligibility,
+  dismissSetupSuggestion,
+  shouldShowSetupSuggestion,
+} from './setup-suggestion-state';
 
 type Phase = 'hidden' | 'visible' | 'applying' | 'applied';
 
 /** Keep the spinner visible long enough to read as deliberate feedback, not a flicker. */
 const MIN_APPLYING_MS = 450;
 
-const dismissKey = (projectId: string) => `emdash:setup-suggestion-dismissed:${projectId}`;
-
-function isDismissed(projectId: string): boolean {
-  try {
-    return localStorage.getItem(dismissKey(projectId)) === 'true';
-  } catch {
-    return false;
-  }
-}
-
-function persistDismiss(projectId: string): void {
-  try {
-    localStorage.setItem(dismissKey(projectId), 'true');
-  } catch {
-    // ignore — dismissal persistence is best-effort
-  }
-}
-
 /**
  * A minimal, dismissible suggestion anchored bottom-right of the project view.
- * When a user enters a project that has no `scripts.setup` configured, we detect
- * its tooling (Bun, pnpm, Cargo, …) and offer the matching install command as a
- * one-click lifecycle setup script.
+ * After a project is added for the first time, we detect its tooling (Bun, pnpm,
+ * Cargo, …) and offer the matching install command as a one-click lifecycle setup
+ * script if no `scripts.setup` is configured yet.
  */
 export function SetupSuggestionToast({ projectId }: { projectId: string }) {
   const [suggestion, setSuggestion] = useState<SetupScriptSuggestion | null>(null);
@@ -44,18 +31,23 @@ export function SetupSuggestionToast({ projectId }: { projectId: string }) {
   useEffect(() => {
     setSuggestion(null);
     setPhase('hidden');
-    if (isDismissed(projectId)) return;
+    if (!shouldShowSetupSuggestion(projectId)) return;
 
     let cancelled = false;
     void rpc.projects
       .suggestSetupScript(projectId)
       .then((result) => {
-        if (cancelled || !result) return;
+        if (cancelled) return;
+        if (!result) {
+          clearSetupSuggestionEligibility(projectId);
+          return;
+        }
         setSuggestion(result);
         setPhase('visible');
       })
       .catch(() => {
         // Detection is best-effort; stay silent on failure.
+        clearSetupSuggestionEligibility(projectId);
       });
 
     return () => {
@@ -64,7 +56,7 @@ export function SetupSuggestionToast({ projectId }: { projectId: string }) {
   }, [projectId]);
 
   const handleDismiss = useCallback(() => {
-    persistDismiss(projectId);
+    dismissSetupSuggestion(projectId);
     setPhase('hidden');
   }, [projectId]);
 
@@ -85,7 +77,7 @@ export function SetupSuggestionToast({ projectId }: { projectId: string }) {
         setPhase('visible');
         return;
       }
-      persistDismiss(projectId);
+      dismissSetupSuggestion(projectId);
       setPhase('applied');
       window.setTimeout(() => setPhase('hidden'), 1800);
     } catch {
@@ -156,7 +148,7 @@ export function SetupSuggestionToast({ projectId }: { projectId: string }) {
                         phase === 'applying' ? 'opacity-100' : 'opacity-0'
                       )}
                     >
-                      {phase === 'applying' && <CLISpinner className="text-current" />}
+                      {phase === 'applying' && <CLISpinner />}
                       Adding
                     </span>
                     <span

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
@@ -1,4 +1,5 @@
 import { makeObservable, observable, runInAction } from 'mobx';
+import { markSetupSuggestionEligible } from '@renderer/features/projects/components/setup-suggestion/setup-suggestion-state';
 import { events, rpc } from '@renderer/lib/ipc';
 import { appState } from '@renderer/lib/stores/app-state';
 import { viewStateCache } from '@renderer/lib/stores/view-state-cache';
@@ -394,6 +395,7 @@ export class ProjectManagerStore {
   }
 
   private _setAndOpenProject(id: string, project: LocalProject | SshProject): void {
+    markSetupSuggestionEligible(id);
     runInAction(() => {
       const current = this.projects.get(id);
       if (current) {

--- a/apps/emdash-desktop/src/shared/core/projects/setup-suggestion.ts
+++ b/apps/emdash-desktop/src/shared/core/projects/setup-suggestion.ts
@@ -1,0 +1,13 @@
+/**
+ * A suggested setup (lifecycle) command derived from the tooling detected in a
+ * project's repository root. Surfaced to the user when they enter a project that
+ * has no `scripts.setup` configured yet, so they can adopt it in one click.
+ */
+export type SetupScriptSuggestion = {
+  /** Stable identifier of the detected ecosystem, e.g. 'bun', 'pnpm', 'cargo'. */
+  tool: string;
+  /** Human-friendly ecosystem name shown in the UI, e.g. 'Bun', 'Cargo'. */
+  displayName: string;
+  /** Suggested command to populate `scripts.setup`, e.g. 'bun install'. */
+  command: string;
+};

--- a/apps/emdash-desktop/src/shared/projects.ts
+++ b/apps/emdash-desktop/src/shared/projects.ts
@@ -79,6 +79,7 @@ export type UpdateProjectSettingsError =
   | { type: 'project-not-found' }
   | { type: 'invalid-settings' }
   | { type: 'invalid-worktree-directory' }
+  | { type: 'setup-script-already-configured' }
   | { type: 'write-config-failed'; message: string }
   | { type: 'error' };
 


### PR DESCRIPTION
### Description
- adds setup command suggestions for projects without scripts.setup
- detects common tooling from root markers like lockfiles and manifests
- show a dismissable toast

### Screenshot/Recording (if applicable)
https://streamable.com/p9tsc1

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
