### PR TITLE
feat: add agent model default settings

### DIFF
--- a/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.test.ts
@@ -573,6 +573,84 @@ describe('buildAgentCommand', () => {
       })
     ).toThrow(/executable command prefixes/);
   });
+
+  it('passes the selected Codex model and reasoning effort before the prompt', () => {
+    const command = buildAgentCommand({
+      providerId: 'codex',
+      providerConfig: providerConfigDefaults.codex,
+      autoApprove: true,
+      initialPrompt: 'Fix the issue',
+      sessionId: 'conv-1',
+      modelSelection: { model: 'gpt-5.5', reasoningEffort: 'high' },
+    });
+
+    expect(command).toEqual({
+      command: 'codex',
+      args: [
+        '-c',
+        'approval_policy=never',
+        '-c',
+        'sandbox_mode=danger-full-access',
+        '--dangerously-bypass-hook-trust',
+        '--model',
+        'gpt-5.5',
+        '-c',
+        'model_reasoning_effort=high',
+        'Fix the issue',
+      ],
+    });
+  });
+
+  it('passes the selected Claude model and effort flags', () => {
+    const command = buildAgentCommand({
+      providerId: 'claude',
+      providerConfig: providerConfigDefaults.claude,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+      modelSelection: { model: 'opus', reasoningEffort: 'high' },
+    });
+
+    expect(command.args).toEqual([
+      '--session-id',
+      'conv-1',
+      '--model',
+      'opus',
+      '--effort',
+      'high',
+      'Fix the bug',
+    ]);
+  });
+
+  it('passes the selected Cursor model and ignores reasoning effort', () => {
+    const command = buildAgentCommand({
+      providerId: 'cursor',
+      providerConfig: providerConfigDefaults.cursor,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+      modelSelection: { model: 'claude-4.5-sonnet-thinking', reasoningEffort: 'high' },
+    });
+
+    expect(command.args).toEqual(['--model', 'claude-4.5-sonnet-thinking', 'Fix the bug']);
+  });
+
+  it('does not apply the model selection when resuming', () => {
+    const baseline = buildAgentCommand({
+      providerId: 'codex',
+      providerConfig: providerConfigDefaults.codex,
+      sessionId: 'conv-1',
+      isResuming: true,
+    });
+
+    const withSelection = buildAgentCommand({
+      providerId: 'codex',
+      providerConfig: providerConfigDefaults.codex,
+      sessionId: 'conv-1',
+      isResuming: true,
+      modelSelection: { model: 'gpt-5.5', reasoningEffort: 'high' },
+    });
+
+    expect(withSelection.args).toEqual(baseline.args);
+  });
 });
 
 describe('wrapAgentCommandWithStdinPipe', () => {
@@ -618,6 +696,25 @@ describe('buildAgentSessionCommand', () => {
     expect(result).toEqual({
       command: 'bash',
       args: ['-c', "printf '%s\\n' 'Fix the bug' | 'amp' '--dangerously-allow-all'"],
+    });
+  });
+
+  it('includes the selected Amp mode in the piped command', () => {
+    const result = buildAgentSessionCommand({
+      providerId: 'amp',
+      providerConfig: providerConfigDefaults.amp,
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+      modelSelection: { model: 'rush' },
+    });
+
+    expect(result).toEqual({
+      command: 'bash',
+      args: [
+        '-c',
+        "printf '%s\\n' 'Fix the bug' | 'amp' '--dangerously-allow-all' '--mode' 'rush'",
+      ],
     });
   });
 

--- a/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.test.ts
@@ -607,14 +607,14 @@ describe('buildAgentCommand', () => {
       providerConfig: providerConfigDefaults.claude,
       initialPrompt: 'Fix the bug',
       sessionId: 'conv-1',
-      modelSelection: { model: 'opus', reasoningEffort: 'high' },
+      modelSelection: { model: 'claude-opus-4-8', reasoningEffort: 'high' },
     });
 
     expect(command.args).toEqual([
       '--session-id',
       'conv-1',
       '--model',
-      'opus',
+      'claude-opus-4-8',
       '--effort',
       'high',
       'Fix the bug',

--- a/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.test.ts
@@ -621,16 +621,16 @@ describe('buildAgentCommand', () => {
     ]);
   });
 
-  it('passes the selected Cursor model and ignores reasoning effort', () => {
+  it('composes the Cursor model id from the base model and reasoning level', () => {
     const command = buildAgentCommand({
       providerId: 'cursor',
       providerConfig: providerConfigDefaults.cursor,
       initialPrompt: 'Fix the bug',
       sessionId: 'conv-1',
-      modelSelection: { model: 'claude-4.5-sonnet-thinking', reasoningEffort: 'high' },
+      modelSelection: { model: 'gpt-5.5', reasoningEffort: 'high' },
     });
 
-    expect(command.args).toEqual(['--model', 'claude-4.5-sonnet-thinking', 'Fix the bug']);
+    expect(command.args).toEqual(['--model', 'gpt-5.5-high', 'Fix the bug']);
   });
 
   it('does not apply the model selection when resuming', () => {
@@ -714,6 +714,25 @@ describe('buildAgentSessionCommand', () => {
       args: [
         '-c',
         "printf '%s\\n' 'Fix the bug' | 'amp' '--dangerously-allow-all' '--mode' 'rush'",
+      ],
+    });
+  });
+
+  it('includes the selected Amp mode and reasoning effort in the piped command', () => {
+    const result = buildAgentSessionCommand({
+      providerId: 'amp',
+      providerConfig: providerConfigDefaults.amp,
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+      modelSelection: { model: 'smart', reasoningEffort: 'high' },
+    });
+
+    expect(result).toEqual({
+      command: 'bash',
+      args: [
+        '-c',
+        "printf '%s\\n' 'Fix the bug' | 'amp' '--dangerously-allow-all' '--mode' 'smart' '--effort' 'high'",
       ],
     });
   });

--- a/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/agent-command.ts
@@ -1,4 +1,5 @@
 import { quoteShellArg } from '@main/utils/shellEscape';
+import { buildAgentModelArgs, type AgentModelSelection } from '@shared/core/agents/agent-models';
 import {
   getProvider,
   isValidProviderSessionId,
@@ -146,6 +147,7 @@ export function buildAgentCommand({
   sessionId,
   providerSessionId,
   isResuming,
+  modelSelection,
 }: {
   providerId: AgentProviderId;
   providerConfig: ProviderCustomConfig | undefined;
@@ -155,6 +157,7 @@ export function buildAgentCommand({
   sessionId: string;
   providerSessionId?: string;
   isResuming?: boolean;
+  modelSelection?: AgentModelSelection;
 }): AgentCommand {
   const providerDef = getProvider(providerId);
   const [command, ...args] = parseCliPrefix(providerConfig?.cli, providerId);
@@ -198,6 +201,14 @@ export function buildAgentCommand({
     args.push(...parseArgField(autoApproveFlag));
   }
 
+  // Apply the configured model/reasoning flags only on a fresh start. On resume,
+  // providers re-attach to an existing session (often via a subcommand such as
+  // `codex resume <id>`) that already carries its model, and appending model
+  // flags there can conflict with the resume argument shape.
+  if (!isResuming) {
+    args.push(...buildAgentModelArgs(providerId, modelSelection));
+  }
+
   if (!isResuming && extraInitialArgs?.length) {
     args.push(...extraInitialArgs);
   } else if (
@@ -237,6 +248,7 @@ export function buildAgentSessionCommand(args: {
   sessionId: string;
   providerSessionId?: string;
   isResuming?: boolean;
+  modelSelection?: AgentModelSelection;
 }): AgentCommand {
   const command = buildAgentCommand(args);
   const prompt = args.initialPrompt?.trim();

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -126,6 +126,8 @@ export class LocalConversationProvider implements ConversationProvider {
 
       const providerConfig = await providerOverrideSettings.getItem(conversation.providerId);
       const providerDef = getProvider(conversation.providerId);
+      const agentModels = await appSettingsService.get('agentModels');
+      const modelSelection = agentModels[conversation.providerId];
       const agentSession = resolveAgentSessionCommandArgs(conversation, isResuming);
       const initialPromptDelivery = createInitialPromptDelivery({
         providerId: conversation.providerId,
@@ -143,6 +145,7 @@ export class LocalConversationProvider implements ConversationProvider {
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.providerSessionId,
         isResuming: agentSession.isResuming,
+        modelSelection,
       });
       const providerEnv = resolveProviderEnv(providerConfig, {
         providerId: conversation.providerId,

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -10,6 +10,7 @@ import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
+import { appSettingsService } from '@main/core/settings/settings-service';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
@@ -115,6 +116,8 @@ export class SshConversationProvider implements ConversationProvider {
       });
 
       const providerConfig = await providerOverrideSettings.getItem(conversation.providerId);
+      const agentModels = await appSettingsService.get('agentModels');
+      const modelSelection = agentModels[conversation.providerId];
       const agentSession = resolveAgentSessionCommandArgs(conversation, isResuming, {
         requireProviderSessionId: false,
       });
@@ -134,6 +137,7 @@ export class SshConversationProvider implements ConversationProvider {
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.providerSessionId,
         isResuming: agentSession.isResuming,
+        modelSelection,
       });
       const providerEnv = resolveProviderEnv(providerConfig, {
         providerId: conversation.providerId,

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -43,6 +43,15 @@ export const agentAutoApproveDefaultsSchema = z
   .partialRecord(z.enum(AGENT_PROVIDER_IDS), z.boolean())
   .default({});
 
+export const agentModelSelectionSchema = z.object({
+  model: z.string().optional(),
+  reasoningEffort: z.string().optional(),
+});
+
+export const agentModelsSchema = z
+  .partialRecord(z.enum(AGENT_PROVIDER_IDS), agentModelSelectionSchema)
+  .default({});
+
 export const terminalSettingsSchema = z.object({
   fontFamily: z.string().optional(),
   fontSize: z.number().min(TERMINAL_FONT_SIZE_MIN).max(TERMINAL_FONT_SIZE_MAX).optional(),
@@ -133,6 +142,7 @@ export const APP_SETTINGS_SCHEMA_MAP = {
   project: projectSettingsSchema,
   tasks: taskSettingsSchema,
   agentAutoApproveDefaults: agentAutoApproveDefaultsSchema,
+  agentModels: agentModelsSchema,
   defaultAgent: defaultAgentSchema,
   keyboard: keyboardSettingsSchema,
   notifications: notificationSettingsSchema,
@@ -150,6 +160,7 @@ export const appSettingsSchema = z.object({
   project: projectSettingsSchema,
   tasks: taskSettingsSchema,
   agentAutoApproveDefaults: agentAutoApproveDefaultsSchema,
+  agentModels: agentModelsSchema,
   defaultAgent: defaultAgentSchema,
   keyboard: keyboardSettingsSchema,
   notifications: notificationSettingsSchema,

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -31,6 +31,7 @@ export const SETTINGS_DEFAULTS = {
     includeIssueContextByDefault: true,
   },
   agentAutoApproveDefaults: {},
+  agentModels: {},
   notifications: {
     enabled: true,
     sound: true,

--- a/apps/emdash-desktop/src/renderer/features/settings/components/ModelsSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/ModelsSettingsCard.tsx
@@ -27,7 +27,7 @@ const DEFAULT_OPTION_VALUE = '__default__';
 const MODEL_DEFAULT_LABEL = 'Model Default';
 const EFFORT_DEFAULT_LABEL = 'Effort Default';
 
-type Option = { id: string; label: string };
+type Option = { id: string; label: string; disabled?: boolean };
 
 function labelForOption(
   options: ReadonlyArray<Option>,
@@ -46,6 +46,8 @@ interface OptionDropdownProps {
   disabled: boolean;
   ariaLabel: string;
   onChange: (value: string | undefined) => void;
+  /** Optional leading icon for an option id (skipped for the default option). */
+  getOptionIcon?: (optionId: string) => React.ReactNode;
 }
 
 function OptionDropdown({
@@ -56,6 +58,7 @@ function OptionDropdown({
   disabled,
   ariaLabel,
   onChange,
+  getOptionIcon,
 }: OptionDropdownProps) {
   const allOptions: ReadonlyArray<Option> = [
     { id: DEFAULT_OPTION_VALUE, label: defaultLabel },
@@ -78,7 +81,10 @@ function OptionDropdown({
           />
         }
       >
-        <span className="truncate">{labelForOption(options, value, defaultLabel)}</span>
+        <span className="flex min-w-0 items-center gap-2">
+          {getOptionIcon?.(selectedId)}
+          <span className="truncate">{labelForOption(options, value, defaultLabel)}</span>
+        </span>
         <ChevronsUpDown className="size-4 shrink-0 text-foreground-muted" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-max">
@@ -86,9 +92,16 @@ function OptionDropdown({
           <DropdownMenuItem
             key={option.id}
             className="justify-between gap-4"
-            onClick={() => onChange(option.id === DEFAULT_OPTION_VALUE ? undefined : option.id)}
+            disabled={option.disabled}
+            onClick={() => {
+              if (option.disabled) return;
+              onChange(option.id === DEFAULT_OPTION_VALUE ? undefined : option.id);
+            }}
           >
-            <span className="truncate">{option.label}</span>
+            <span className="flex min-w-0 items-center gap-2">
+              {getOptionIcon?.(option.id)}
+              <span className="truncate">{option.label}</span>
+            </span>
             {option.id === selectedId && (
               <Check className="size-4 shrink-0 text-foreground-muted" />
             )}
@@ -96,6 +109,55 @@ function OptionDropdown({
         ))}
       </DropdownMenuContent>
     </DropdownMenu>
+  );
+}
+
+/**
+ * Resolve the brand whose logo represents a model option. Single-brand
+ * providers (Codex/Claude/Amp) use their own logo; Cursor mixes vendors, so the
+ * brand is derived from the model id prefix.
+ */
+function modelBrandKey(providerId: AgentProviderId, modelId: string): AgentProviderId | undefined {
+  if (modelId === DEFAULT_OPTION_VALUE) return undefined;
+  switch (providerId) {
+    case 'codex':
+      return 'codex';
+    case 'claude':
+      return 'claude';
+    case 'amp':
+      return 'amp';
+    case 'cursor':
+      if (modelId.startsWith('gpt')) return 'codex';
+      if (modelId.startsWith('claude')) return 'claude';
+      if (modelId.startsWith('gemini')) return 'gemini';
+      if (modelId.startsWith('grok')) return 'grok';
+      if (modelId.startsWith('kimi')) return 'kimi';
+      if (modelId.startsWith('composer') || modelId === 'auto') return 'cursor';
+      return undefined;
+    default:
+      return undefined;
+  }
+}
+
+function ModelBrandIcon({
+  providerId,
+  modelId,
+}: {
+  providerId: AgentProviderId;
+  modelId: string;
+}): React.ReactNode {
+  const key = modelBrandKey(providerId, modelId);
+  if (!key) return null;
+  const brand = agentConfig[key];
+  return (
+    <AgentLogo
+      logo={brand.logo}
+      logoDark={brand.logoDark}
+      alt={brand.alt}
+      isSvg={brand.isSvg}
+      invertInDark={brand.invertInDark}
+      className="h-4 w-4 shrink-0 rounded-sm"
+    />
   );
 }
 
@@ -119,8 +181,11 @@ function ProviderModelRow({
   if (!support) return null;
 
   // Reasoning availability depends on the selected model (Cursor per family,
-  // Amp rush vs smart/deep), so the dropdown is only shown when applicable.
+  // Amp rush vs smart/deep). The dropdown stays in place so the model and
+  // reasoning columns line up across rows; it is disabled when the selected
+  // model exposes no reasoning (e.g. Cursor on "Model Default").
   const reasoningOptions = getReasoningOptions(providerId, model);
+  const reasoningDisabled = disabled || reasoningOptions.length === 0;
 
   const handleModelChange = (nextModel: string | undefined): void => {
     const nextReasoning = getReasoningOptions(providerId, nextModel);
@@ -158,18 +223,19 @@ function ProviderModelRow({
             disabled={disabled}
             ariaLabel={`${config.name} model`}
             onChange={handleModelChange}
+            getOptionIcon={(optionId) => (
+              <ModelBrandIcon providerId={providerId} modelId={optionId} />
+            )}
           />
-          {reasoningOptions.length > 0 && (
-            <OptionDropdown
-              value={reasoningEffort}
-              options={reasoningOptions}
-              defaultLabel={EFFORT_DEFAULT_LABEL}
-              triggerClassName="w-[150px]"
-              disabled={disabled}
-              ariaLabel={`${config.name} reasoning effort`}
-              onChange={(effort) => onSelectionChange({ reasoningEffort: effort })}
-            />
-          )}
+          <OptionDropdown
+            value={reasoningEffort}
+            options={reasoningOptions}
+            defaultLabel={EFFORT_DEFAULT_LABEL}
+            triggerClassName="w-[150px]"
+            disabled={reasoningDisabled}
+            ariaLabel={`${config.name} reasoning effort`}
+            onChange={(effort) => onSelectionChange({ reasoningEffort: effort })}
+          />
         </div>
       }
     />

--- a/apps/emdash-desktop/src/renderer/features/settings/components/ModelsSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/ModelsSettingsCard.tsx
@@ -12,7 +12,9 @@ import { agentConfig } from '@renderer/utils/agentConfig';
 import { cn } from '@renderer/utils/utils';
 import {
   getAgentModelSupport,
+  getReasoningOptions,
   MODEL_SELECTABLE_PROVIDER_IDS,
+  type AgentModelSelection,
 } from '@shared/core/agents/agent-models';
 import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
 import { useAgentModelSettings } from '../use-agent-model-settings';
@@ -102,8 +104,7 @@ interface ProviderModelRowProps {
   disabled: boolean;
   model: string | undefined;
   reasoningEffort: string | undefined;
-  onModelChange: (model: string | undefined) => void;
-  onReasoningChange: (effort: string | undefined) => void;
+  onSelectionChange: (patch: AgentModelSelection) => void;
 }
 
 function ProviderModelRow({
@@ -111,12 +112,26 @@ function ProviderModelRow({
   disabled,
   model,
   reasoningEffort,
-  onModelChange,
-  onReasoningChange,
+  onSelectionChange,
 }: ProviderModelRowProps) {
   const support = getAgentModelSupport(providerId);
   const config = agentConfig[providerId];
   if (!support) return null;
+
+  // Reasoning availability depends on the selected model (Cursor per family,
+  // Amp rush vs smart/deep), so the dropdown is only shown when applicable.
+  const reasoningOptions = getReasoningOptions(providerId, model);
+
+  const handleModelChange = (nextModel: string | undefined): void => {
+    const nextReasoning = getReasoningOptions(providerId, nextModel);
+    const keepEffort =
+      reasoningEffort !== undefined &&
+      nextReasoning.some((option) => option.id === reasoningEffort);
+    onSelectionChange({
+      model: nextModel,
+      reasoningEffort: keepEffort ? reasoningEffort : undefined,
+    });
+  };
 
   return (
     <SettingRow
@@ -142,17 +157,17 @@ function ProviderModelRow({
             triggerClassName="w-[170px]"
             disabled={disabled}
             ariaLabel={`${config.name} model`}
-            onChange={onModelChange}
+            onChange={handleModelChange}
           />
-          {support.reasoning && (
+          {reasoningOptions.length > 0 && (
             <OptionDropdown
               value={reasoningEffort}
-              options={support.reasoning}
+              options={reasoningOptions}
               defaultLabel={EFFORT_DEFAULT_LABEL}
               triggerClassName="w-[150px]"
               disabled={disabled}
               ariaLabel={`${config.name} reasoning effort`}
-              onChange={onReasoningChange}
+              onChange={(effort) => onSelectionChange({ reasoningEffort: effort })}
             />
           )}
         </div>
@@ -162,7 +177,7 @@ function ProviderModelRow({
 }
 
 const ModelsSettingsCard: React.FC = () => {
-  const { getSelection, setModel, setReasoningEffort, loading, saving } = useAgentModelSettings();
+  const { getSelection, setSelection, loading, saving } = useAgentModelSettings();
   const disabled = loading || saving;
 
   return (
@@ -176,8 +191,7 @@ const ModelsSettingsCard: React.FC = () => {
             disabled={disabled}
             model={selection.model}
             reasoningEffort={selection.reasoningEffort}
-            onModelChange={(model) => setModel(providerId, model)}
-            onReasoningChange={(effort) => setReasoningEffort(providerId, effort)}
+            onSelectionChange={(patch) => setSelection(providerId, patch)}
           />
         );
       })}

--- a/apps/emdash-desktop/src/renderer/features/settings/components/ModelsSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/ModelsSettingsCard.tsx
@@ -1,0 +1,188 @@
+import { Check, ChevronsUpDown } from 'lucide-react';
+import React from 'react';
+import AgentLogo from '@renderer/lib/components/agent-logo';
+import { Button } from '@renderer/lib/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@renderer/lib/ui/dropdown-menu';
+import { agentConfig } from '@renderer/utils/agentConfig';
+import { cn } from '@renderer/utils/utils';
+import {
+  getAgentModelSupport,
+  MODEL_SELECTABLE_PROVIDER_IDS,
+} from '@shared/core/agents/agent-models';
+import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
+import { useAgentModelSettings } from '../use-agent-model-settings';
+import { SettingRow } from './SettingRow';
+
+/** Sentinel used by the dropdowns to represent "fall back to the CLI default". */
+const DEFAULT_OPTION_VALUE = '__default__';
+
+/** Labels shown for the "fall back to the CLI default" option in each dropdown. */
+const MODEL_DEFAULT_LABEL = 'Model Default';
+const EFFORT_DEFAULT_LABEL = 'Effort Default';
+
+type Option = { id: string; label: string };
+
+function labelForOption(
+  options: ReadonlyArray<Option>,
+  value: string | undefined,
+  defaultLabel: string
+): string {
+  if (!value) return defaultLabel;
+  return options.find((option) => option.id === value)?.label ?? value;
+}
+
+interface OptionDropdownProps {
+  value: string | undefined;
+  options: ReadonlyArray<Option>;
+  defaultLabel: string;
+  triggerClassName: string;
+  disabled: boolean;
+  ariaLabel: string;
+  onChange: (value: string | undefined) => void;
+}
+
+function OptionDropdown({
+  value,
+  options,
+  defaultLabel,
+  triggerClassName,
+  disabled,
+  ariaLabel,
+  onChange,
+}: OptionDropdownProps) {
+  const allOptions: ReadonlyArray<Option> = [
+    { id: DEFAULT_OPTION_VALUE, label: defaultLabel },
+    ...options,
+  ];
+  const selectedId = value ?? DEFAULT_OPTION_VALUE;
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <Button
+            variant="outline"
+            disabled={disabled}
+            aria-label={ariaLabel}
+            className={cn(
+              'h-8 justify-between gap-2 rounded-md border-border bg-background-1 px-2.5 font-normal text-foreground hover:bg-background-2',
+              triggerClassName
+            )}
+          />
+        }
+      >
+        <span className="truncate">{labelForOption(options, value, defaultLabel)}</span>
+        <ChevronsUpDown className="size-4 shrink-0 text-foreground-muted" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-max">
+        {allOptions.map((option) => (
+          <DropdownMenuItem
+            key={option.id}
+            className="justify-between gap-4"
+            onClick={() => onChange(option.id === DEFAULT_OPTION_VALUE ? undefined : option.id)}
+          >
+            <span className="truncate">{option.label}</span>
+            {option.id === selectedId && (
+              <Check className="size-4 shrink-0 text-foreground-muted" />
+            )}
+          </DropdownMenuItem>
+        ))}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}
+
+interface ProviderModelRowProps {
+  providerId: AgentProviderId;
+  disabled: boolean;
+  model: string | undefined;
+  reasoningEffort: string | undefined;
+  onModelChange: (model: string | undefined) => void;
+  onReasoningChange: (effort: string | undefined) => void;
+}
+
+function ProviderModelRow({
+  providerId,
+  disabled,
+  model,
+  reasoningEffort,
+  onModelChange,
+  onReasoningChange,
+}: ProviderModelRowProps) {
+  const support = getAgentModelSupport(providerId);
+  const config = agentConfig[providerId];
+  if (!support) return null;
+
+  return (
+    <SettingRow
+      title={
+        <span className="flex items-center gap-2">
+          <AgentLogo
+            logo={config.logo}
+            logoDark={config.logoDark}
+            alt={config.alt}
+            isSvg={config.isSvg}
+            invertInDark={config.invertInDark}
+            className="h-4 w-4 shrink-0 rounded-sm"
+          />
+          {config.name}
+        </span>
+      }
+      control={
+        <div className="flex items-center gap-1.5">
+          <OptionDropdown
+            value={model}
+            options={support.models}
+            defaultLabel={MODEL_DEFAULT_LABEL}
+            triggerClassName="w-[170px]"
+            disabled={disabled}
+            ariaLabel={`${config.name} model`}
+            onChange={onModelChange}
+          />
+          {support.reasoning && (
+            <OptionDropdown
+              value={reasoningEffort}
+              options={support.reasoning}
+              defaultLabel={EFFORT_DEFAULT_LABEL}
+              triggerClassName="w-[150px]"
+              disabled={disabled}
+              ariaLabel={`${config.name} reasoning effort`}
+              onChange={onReasoningChange}
+            />
+          )}
+        </div>
+      }
+    />
+  );
+}
+
+const ModelsSettingsCard: React.FC = () => {
+  const { getSelection, setModel, setReasoningEffort, loading, saving } = useAgentModelSettings();
+  const disabled = loading || saving;
+
+  return (
+    <div className="flex flex-col gap-5">
+      {MODEL_SELECTABLE_PROVIDER_IDS.map((providerId) => {
+        const selection = getSelection(providerId);
+        return (
+          <ProviderModelRow
+            key={providerId}
+            providerId={providerId}
+            disabled={disabled}
+            model={selection.model}
+            reasoningEffort={selection.reasoningEffort}
+            onModelChange={(model) => setModel(providerId, model)}
+            onReasoningChange={(effort) => setReasoningEffort(providerId, effort)}
+          />
+        );
+      })}
+    </div>
+  );
+};
+
+export default ModelsSettingsCard;

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -10,6 +10,7 @@ import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
 import IntegrationsCard from './IntegrationsCard';
 import InterfaceSettingsCard from './InterfaceSettingsCard';
 import KeyboardSettingsCard from './KeyboardSettingsCard';
+import ModelsSettingsCard from './ModelsSettingsCard';
 import NotificationSettingsCard from './NotificationSettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
 import ResourceMonitorSettingsCard from './ResourceMonitorSettingsCard';
@@ -32,6 +33,7 @@ export type SettingsPageTab =
   | 'general'
   | 'account'
   | 'clis-models'
+  | 'models'
   | 'integrations'
   | 'connections'
   | 'repository'
@@ -63,6 +65,7 @@ export function SettingsPage({
     { id: 'general', label: 'General' },
     { id: 'account', label: 'Account' },
     { id: 'clis-models', label: 'Agents' },
+    { id: 'models', label: 'Models' },
     { id: 'integrations', label: 'Integrations' },
     { id: 'connections', label: 'Connections' },
     { id: 'repository', label: 'Repository' },
@@ -126,6 +129,12 @@ export function SettingsPage({
           ),
         },
       ],
+    },
+    models: {
+      title: 'Models',
+      description:
+        'Choose the default model and reasoning effort used when starting new conversations with each agent.',
+      sections: [{ component: <ModelsSettingsCard /> }],
     },
     integrations: {
       title: 'Integrations',

--- a/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
+++ b/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
@@ -1,0 +1,32 @@
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import type { AgentModelSelection } from '@shared/core/agents/agent-models';
+import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
+import type { AgentModels } from '@shared/core/app-settings';
+
+/**
+ * Reads and writes the per-provider default model + reasoning-effort selection
+ * (the `agentModels` app setting). Updates merge into the existing provider
+ * entry so changing the model preserves the reasoning effort and vice versa.
+ */
+export function useAgentModelSettings() {
+  const { value, isLoading, isSaving, update } = useAppSettingsKey('agentModels');
+  const selections: AgentModels = value ?? {};
+
+  const setSelection = (providerId: AgentProviderId, patch: AgentModelSelection): void => {
+    const current = selections[providerId] ?? {};
+    const next: AgentModelSelection = { ...current, ...patch };
+    update({ [providerId]: next } as Partial<AgentModels>);
+  };
+
+  return {
+    selections,
+    loading: isLoading,
+    saving: isSaving,
+    getSelection: (providerId: AgentProviderId): AgentModelSelection =>
+      selections[providerId] ?? {},
+    setModel: (providerId: AgentProviderId, model: string | undefined): void =>
+      setSelection(providerId, { model }),
+    setReasoningEffort: (providerId: AgentProviderId, reasoningEffort: string | undefined): void =>
+      setSelection(providerId, { reasoningEffort }),
+  };
+}

--- a/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
+++ b/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
@@ -24,6 +24,7 @@ export function useAgentModelSettings() {
     saving: isSaving,
     getSelection: (providerId: AgentProviderId): AgentModelSelection =>
       selections[providerId] ?? {},
+    setSelection,
     setModel: (providerId: AgentProviderId, model: string | undefined): void =>
       setSelection(providerId, { model }),
     setReasoningEffort: (providerId: AgentProviderId, reasoningEffort: string | undefined): void =>

--- a/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
+++ b/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
@@ -1,5 +1,8 @@
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
-import type { AgentModelSelection } from '@shared/core/agents/agent-models';
+import {
+  sanitizeAgentModelSelection,
+  type AgentModelSelection,
+} from '@shared/core/agents/agent-models';
 import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
 import type { AgentModels } from '@shared/core/app-settings';
 
@@ -14,7 +17,7 @@ export function useAgentModelSettings() {
 
   const setSelection = (providerId: AgentProviderId, patch: AgentModelSelection): void => {
     const current = selections[providerId] ?? {};
-    const next: AgentModelSelection = { ...current, ...patch };
+    const next = sanitizeAgentModelSelection(providerId, { ...current, ...patch });
 
     if (!next.model && !next.reasoningEffort) {
       resetField(providerId);
@@ -29,7 +32,7 @@ export function useAgentModelSettings() {
     loading: isLoading,
     saving: isSaving,
     getSelection: (providerId: AgentProviderId): AgentModelSelection =>
-      selections[providerId] ?? {},
+      sanitizeAgentModelSelection(providerId, selections[providerId]),
     setSelection,
     setModel: (providerId: AgentProviderId, model: string | undefined): void =>
       setSelection(providerId, { model }),

--- a/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
+++ b/apps/emdash-desktop/src/renderer/features/settings/use-agent-model-settings.ts
@@ -9,12 +9,18 @@ import type { AgentModels } from '@shared/core/app-settings';
  * entry so changing the model preserves the reasoning effort and vice versa.
  */
 export function useAgentModelSettings() {
-  const { value, isLoading, isSaving, update } = useAppSettingsKey('agentModels');
+  const { value, isLoading, isSaving, update, resetField } = useAppSettingsKey('agentModels');
   const selections: AgentModels = value ?? {};
 
   const setSelection = (providerId: AgentProviderId, patch: AgentModelSelection): void => {
     const current = selections[providerId] ?? {};
     const next: AgentModelSelection = { ...current, ...patch };
+
+    if (!next.model && !next.reasoningEffort) {
+      resetField(providerId);
+      return;
+    }
+
     update({ [providerId]: next } as Partial<AgentModels>);
   };
 

--- a/apps/emdash-desktop/src/renderer/tests/browser/models-settings-card.test.tsx
+++ b/apps/emdash-desktop/src/renderer/tests/browser/models-settings-card.test.tsx
@@ -1,0 +1,126 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, render } from 'vitest-browser-react';
+/**
+ * Browser-mode tests for the Models settings card.
+ *
+ * The reasoning-effort dropdown always occupies its column (so the model and
+ * reasoning columns line up across rows) but is disabled when the selected
+ * model exposes no reasoning — matching getReasoningOptions():
+ *   - Codex / Claude / Amp: always enabled (model-independent effort flag)
+ *   - Cursor: enabled only for families whose id bakes in a reasoning level
+ *     (disabled on "Model Default", Auto, Composer, …)
+ *   - Amp: disabled only for the rush mode
+ *
+ * The settings hook is mocked so the selection can be driven directly without
+ * the RPC/React-Query stack.
+ */
+import { userEvent } from 'vitest/browser';
+
+type Selections = Record<string, { model?: string; reasoningEffort?: string }>;
+
+const { mockState } = vi.hoisted(() => {
+  // The card transitively imports `@renderer/lib/ipc`, which reads
+  // `window.electronAPI.invoke` at module load. Stub the preload bridge before
+  // any imports are evaluated so that initialization does not throw.
+  window.electronAPI = {
+    invoke: () => Promise.resolve(undefined),
+    eventSend: () => {},
+    eventOn: () => () => {},
+    getPathForFile: () => '',
+  };
+  return { mockState: { selections: {} as Selections } };
+});
+
+vi.mock('@renderer/lib/hooks/useTheme', () => ({
+  useTheme: () => ({ effectiveTheme: 'emlight' }),
+}));
+
+vi.mock('@renderer/features/settings/use-agent-model-settings', () => ({
+  useAgentModelSettings: () => ({
+    selections: mockState.selections,
+    loading: false,
+    saving: false,
+    getSelection: (providerId: string) => mockState.selections[providerId] ?? {},
+    setSelection: () => {},
+    setModel: () => {},
+    setReasoningEffort: () => {},
+  }),
+}));
+
+// Imported after the mock is registered (vi.mock is hoisted above imports).
+import ModelsSettingsCard from '@renderer/features/settings/components/ModelsSettingsCard';
+
+function control(container: HTMLElement, label: string): Element | null {
+  return container.querySelector(`[aria-label="${label}"]`);
+}
+
+function isDisabled(el: Element | null): boolean {
+  if (!el) return false;
+  if (el instanceof HTMLButtonElement && el.disabled) return true;
+  return el.hasAttribute('data-disabled') || el.getAttribute('aria-disabled') === 'true';
+}
+
+beforeEach(() => {
+  mockState.selections = {};
+});
+
+afterEach(async () => {
+  await cleanup();
+});
+
+describe('ModelsSettingsCard reasoning visibility', () => {
+  it('always enables the reasoning dropdown for Codex and Claude', async () => {
+    const { container } = await render(<ModelsSettingsCard />);
+
+    expect(control(container, 'Codex model')).not.toBeNull();
+    expect(isDisabled(control(container, 'Codex reasoning effort'))).toBe(false);
+    expect(isDisabled(control(container, 'Claude Code reasoning effort'))).toBe(false);
+  });
+
+  it('keeps the reasoning column in place but disables it for Cursor on Model Default', async () => {
+    const { container } = await render(<ModelsSettingsCard />);
+
+    // Both columns are always rendered so rows stay aligned.
+    expect(control(container, 'Cursor model')).not.toBeNull();
+    expect(control(container, 'Cursor reasoning effort')).not.toBeNull();
+    // Cursor reasoning is model-dependent → disabled with no model selected.
+    expect(isDisabled(control(container, 'Cursor reasoning effort'))).toBe(true);
+    // Amp's effort flag is model-independent → enabled even at the default mode.
+    expect(isDisabled(control(container, 'Amp reasoning effort'))).toBe(false);
+  });
+
+  it('enables reasoning once a reasoning-capable Cursor model and Amp smart are selected', async () => {
+    mockState.selections = { cursor: { model: 'gpt-5.5' }, amp: { model: 'smart' } };
+
+    const { container } = await render(<ModelsSettingsCard />);
+
+    expect(isDisabled(control(container, 'Cursor reasoning effort'))).toBe(false);
+    expect(isDisabled(control(container, 'Amp reasoning effort'))).toBe(false);
+  });
+
+  it('keeps reasoning disabled for non-reasoning models (Cursor Auto, Amp rush)', async () => {
+    mockState.selections = { cursor: { model: 'auto' }, amp: { model: 'rush' } };
+
+    const { container } = await render(<ModelsSettingsCard />);
+
+    expect(isDisabled(control(container, 'Cursor reasoning effort'))).toBe(true);
+    expect(isDisabled(control(container, 'Amp reasoning effort'))).toBe(true);
+  });
+
+  it('lists Fable 5 as a disabled option in the Claude model dropdown', async () => {
+    const { container } = await render(<ModelsSettingsCard />);
+
+    const trigger = control(container, 'Claude Code model');
+    expect(trigger).not.toBeNull();
+    await userEvent.click(trigger as HTMLElement);
+
+    // The menu renders into a portal on document.body, not inside `container`.
+    const findFable = (): Element | null =>
+      Array.from(document.querySelectorAll('[data-slot="dropdown-menu-item"]')).find((el) =>
+        el.textContent?.includes('Fable 5')
+      ) ?? null;
+
+    await expect.poll(findFable).not.toBeNull();
+    expect(isDisabled(findFable())).toBe(true);
+  });
+});

--- a/apps/emdash-desktop/src/shared/core/agents/agent-model-support.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-model-support.ts
@@ -18,7 +18,8 @@ const CLAUDE_REASONING: AgentReasoningOption[] = [
 ];
 
 // Amp exposes `--effort` for the `smart` and `deep` modes; `rush` has no
-// reasoning. Valid values come from Amp's SDK docs.
+// reasoning. Valid values come from Amp's SDK docs, where `none` is a concrete
+// reasoningEffort value (`'none'` to `'max'`) rather than the default sentinel.
 const AMP_REASONING: AgentReasoningOption[] = [
   { id: 'none', label: 'None' },
   { id: 'low', label: 'Low' },

--- a/apps/emdash-desktop/src/shared/core/agents/agent-model-support.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-model-support.ts
@@ -1,0 +1,191 @@
+import type { AgentModelOption, AgentModelSupport, AgentReasoningOption } from './agent-models';
+import type { AgentProviderId } from './agent-provider-registry';
+
+const CODEX_REASONING: AgentReasoningOption[] = [
+  { id: 'minimal', label: 'Minimal' },
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Extra High' },
+];
+
+const CLAUDE_REASONING: AgentReasoningOption[] = [
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Extra High' },
+  { id: 'max', label: 'Max' },
+];
+
+// Amp exposes `--effort` for the `smart` and `deep` modes; `rush` has no
+// reasoning. Valid values come from Amp's SDK docs.
+const AMP_REASONING: AgentReasoningOption[] = [
+  { id: 'none', label: 'None' },
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Extra High' },
+  { id: 'max', label: 'Max' },
+];
+
+/**
+ * Cursor bakes the reasoning level into the model id, and the suffixes differ
+ * per family (e.g. `gpt-5.5-extra-high` vs `gpt-5.4-xhigh`, plain `gpt-5.2` ==
+ * medium). Each base model therefore maps an effort id to a concrete, verified
+ * `--model` value (from `cursor-agent --list-models`).
+ */
+type CursorReasoningVariant = AgentReasoningOption & { modelId: string };
+type CursorModelDef = {
+  id: string;
+  label: string;
+  /** `--model` value used when no reasoning level is chosen. */
+  defaultModelId: string;
+  variants?: CursorReasoningVariant[];
+};
+
+const CURSOR_MODELS: CursorModelDef[] = [
+  { id: 'auto', label: 'Auto', defaultModelId: 'auto' },
+  { id: 'composer-2.5', label: 'Composer 2.5', defaultModelId: 'composer-2.5' },
+  {
+    id: 'gpt-5.5',
+    label: 'GPT-5.5',
+    defaultModelId: 'gpt-5.5-medium',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.5-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.5-medium' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.5-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.5-extra-high' },
+    ],
+  },
+  {
+    id: 'gpt-5.4',
+    label: 'GPT-5.4',
+    defaultModelId: 'gpt-5.4-medium',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.4-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.4-medium' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.4-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.4-xhigh' },
+    ],
+  },
+  {
+    id: 'gpt-5.2',
+    label: 'GPT-5.2',
+    defaultModelId: 'gpt-5.2',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.2-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.2' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.2-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.2-xhigh' },
+    ],
+  },
+  {
+    id: 'gpt-5.1',
+    label: 'GPT-5.1',
+    defaultModelId: 'gpt-5.1',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.1-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.1' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.1-high' },
+    ],
+  },
+  {
+    id: 'claude-4.5-sonnet',
+    label: 'Sonnet 4.5',
+    defaultModelId: 'claude-4.5-sonnet',
+    variants: [
+      { id: 'standard', label: 'Standard', modelId: 'claude-4.5-sonnet' },
+      { id: 'thinking', label: 'Thinking', modelId: 'claude-4.5-sonnet-thinking' },
+    ],
+  },
+  {
+    id: 'claude-opus-4-8',
+    label: 'Opus 4.8',
+    defaultModelId: 'claude-opus-4-8-high',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'claude-opus-4-8-low' },
+      { id: 'medium', label: 'Medium', modelId: 'claude-opus-4-8-medium' },
+      { id: 'high', label: 'High', modelId: 'claude-opus-4-8-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'claude-opus-4-8-xhigh' },
+      { id: 'max', label: 'Max', modelId: 'claude-opus-4-8-max' },
+      { id: 'thinking', label: 'Thinking', modelId: 'claude-opus-4-8-thinking-high' },
+    ],
+  },
+  { id: 'gemini-3.1-pro', label: 'Gemini 3.1 Pro', defaultModelId: 'gemini-3.1-pro' },
+  { id: 'grok-4.3', label: 'Grok 4.3', defaultModelId: 'grok-4.3' },
+  { id: 'kimi-k2.5', label: 'Kimi K2.5', defaultModelId: 'kimi-k2.5' },
+];
+
+function cursorModelOptions(): AgentModelOption[] {
+  return CURSOR_MODELS.map((model) => ({
+    id: model.id,
+    label: model.label,
+    reasoning: model.variants?.map((variant) => ({ id: variant.id, label: variant.label })) ?? [],
+  }));
+}
+
+function buildCursorArgs(model: string | undefined, effort: string | undefined): string[] {
+  if (!model) return [];
+  const def = CURSOR_MODELS.find((entry) => entry.id === model);
+  if (!def) return [];
+  const variant = effort ? def.variants?.find((entry) => entry.id === effort) : undefined;
+  return ['--model', variant?.modelId ?? def.defaultModelId];
+}
+
+/**
+ * Curated model + reasoning support for providers with predictable model flags.
+ *
+ * Keep this as provider data/translation only. The public model-selection API
+ * lives in `agent-models.ts`, so volatile provider catalogs do not obscure the
+ * validation and settings boundary.
+ */
+export const AGENT_MODEL_SUPPORT = {
+  codex: {
+    models: [
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+      { id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+      { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
+      { id: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
+    ],
+    reasoning: CODEX_REASONING,
+    buildArgs: (model, effort): string[] => {
+      const args: string[] = [];
+      if (model) args.push('--model', model);
+      if (effort) args.push('-c', `model_reasoning_effort=${effort}`);
+      return args;
+    },
+  },
+  claude: {
+    models: [
+      { id: 'opus', label: 'Opus' },
+      { id: 'sonnet', label: 'Sonnet' },
+      { id: 'haiku', label: 'Haiku' },
+    ],
+    reasoning: CLAUDE_REASONING,
+    buildArgs: (model, effort): string[] => {
+      const args: string[] = [];
+      if (model) args.push('--model', model);
+      if (effort) args.push('--effort', effort);
+      return args;
+    },
+  },
+  cursor: {
+    models: cursorModelOptions(),
+    buildArgs: buildCursorArgs,
+  },
+  amp: {
+    models: [
+      { id: 'smart', label: 'Smart' },
+      { id: 'rush', label: 'Rush', reasoning: [] },
+      { id: 'deep', label: 'Deep' },
+    ],
+    reasoning: AMP_REASONING,
+    buildArgs: (model, effort): string[] => {
+      const args: string[] = [];
+      if (model) args.push('--mode', model);
+      if (effort) args.push('--effort', effort);
+      return args;
+    },
+  },
+} satisfies Partial<Record<AgentProviderId, AgentModelSupport>>;

--- a/apps/emdash-desktop/src/shared/core/agents/agent-model-support.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-model-support.ts
@@ -69,33 +69,12 @@ const CURSOR_MODELS: CursorModelDef[] = [
     ],
   },
   {
-    id: 'gpt-5.2',
-    label: 'GPT-5.2',
-    defaultModelId: 'gpt-5.2',
+    id: 'claude-4.6-sonnet',
+    label: 'Sonnet 4.6',
+    defaultModelId: 'claude-4.6-sonnet-medium',
     variants: [
-      { id: 'low', label: 'Low', modelId: 'gpt-5.2-low' },
-      { id: 'medium', label: 'Medium', modelId: 'gpt-5.2' },
-      { id: 'high', label: 'High', modelId: 'gpt-5.2-high' },
-      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.2-xhigh' },
-    ],
-  },
-  {
-    id: 'gpt-5.1',
-    label: 'GPT-5.1',
-    defaultModelId: 'gpt-5.1',
-    variants: [
-      { id: 'low', label: 'Low', modelId: 'gpt-5.1-low' },
-      { id: 'medium', label: 'Medium', modelId: 'gpt-5.1' },
-      { id: 'high', label: 'High', modelId: 'gpt-5.1-high' },
-    ],
-  },
-  {
-    id: 'claude-4.5-sonnet',
-    label: 'Sonnet 4.5',
-    defaultModelId: 'claude-4.5-sonnet',
-    variants: [
-      { id: 'standard', label: 'Standard', modelId: 'claude-4.5-sonnet' },
-      { id: 'thinking', label: 'Thinking', modelId: 'claude-4.5-sonnet-thinking' },
+      { id: 'standard', label: 'Standard', modelId: 'claude-4.6-sonnet-medium' },
+      { id: 'thinking', label: 'Thinking', modelId: 'claude-4.6-sonnet-medium-thinking' },
     ],
   },
   {
@@ -112,6 +91,7 @@ const CURSOR_MODELS: CursorModelDef[] = [
     ],
   },
   { id: 'gemini-3.1-pro', label: 'Gemini 3.1 Pro', defaultModelId: 'gemini-3.1-pro' },
+  { id: 'gemini-3.5-flash', label: 'Gemini 3.5 Flash', defaultModelId: 'gemini-3.5-flash' },
   { id: 'grok-4.3', label: 'Grok 4.3', defaultModelId: 'grok-4.3' },
   { id: 'kimi-k2.5', label: 'Kimi K2.5', defaultModelId: 'kimi-k2.5' },
 ];
@@ -144,9 +124,8 @@ export const AGENT_MODEL_SUPPORT = {
     models: [
       { id: 'gpt-5.5', label: 'GPT-5.5' },
       { id: 'gpt-5.4', label: 'GPT-5.4' },
-      { id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
-      { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
-      { id: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
+      { id: 'gpt-5.4-mini', label: 'GPT-5.4 Mini' },
+      { id: 'gpt-5.3-codex-spark', label: 'GPT-5.3 Codex Spark' },
     ],
     reasoning: CODEX_REASONING,
     buildArgs: (model, effort): string[] => {
@@ -157,10 +136,14 @@ export const AGENT_MODEL_SUPPORT = {
     },
   },
   claude: {
+    // Pinned full model names (Claude Code accepts `--model claude-opus-4-8`).
+    // IDs are the canonical Claude API ids verified against Anthropic's model
+    // overview; `claude-haiku-4-5` is the dateless alias for the 4.5 snapshot.
     models: [
-      { id: 'opus', label: 'Opus' },
-      { id: 'sonnet', label: 'Sonnet' },
-      { id: 'haiku', label: 'Haiku' },
+      { id: 'claude-opus-4-8', label: 'Opus 4.8' },
+      { id: 'claude-sonnet-4-6', label: 'Sonnet 4.6' },
+      { id: 'claude-haiku-4-5', label: 'Haiku 4.5' },
+      { id: 'claude-fable-5', label: 'Fable 5', disabled: true },
     ],
     reasoning: CLAUDE_REASONING,
     buildArgs: (model, effort): string[] => {

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
@@ -96,12 +96,18 @@ describe('buildAgentModelArgs', () => {
   });
 
   it('builds claude model + effort args', () => {
-    expect(buildAgentModelArgs('claude', { model: 'opus', reasoningEffort: 'max' })).toEqual([
-      '--model',
-      'opus',
-      '--effort',
-      'max',
-    ]);
+    expect(
+      buildAgentModelArgs('claude', { model: 'claude-opus-4-8', reasoningEffort: 'max' })
+    ).toEqual(['--model', 'claude-opus-4-8', '--effort', 'max']);
+  });
+
+  it('lists the disabled claude fable model but never passes it to the CLI', () => {
+    const fable = getAgentModelSupport('claude')?.models.find(
+      (option) => option.id === 'claude-fable-5'
+    );
+    expect(fable?.disabled).toBe(true);
+    // A stale stored selection of a disabled model must not reach the agent.
+    expect(buildAgentModelArgs('claude', { model: 'claude-fable-5' })).toEqual([]);
   });
 
   it('builds amp mode args and includes --effort for smart/deep', () => {
@@ -125,14 +131,18 @@ describe('buildAgentModelArgs', () => {
       '--model',
       'gpt-5.5-high',
     ]);
-    // Reasoning suffix differs per family (extra-high vs xhigh).
+    // Reasoning suffix differs per family (gpt-5.5 uses extra-high, gpt-5.4 uses xhigh).
     expect(buildAgentModelArgs('cursor', { model: 'gpt-5.5', reasoningEffort: 'xhigh' })).toEqual([
       '--model',
       'gpt-5.5-extra-high',
     ]);
+    expect(buildAgentModelArgs('cursor', { model: 'gpt-5.4', reasoningEffort: 'xhigh' })).toEqual([
+      '--model',
+      'gpt-5.4-xhigh',
+    ]);
     expect(
-      buildAgentModelArgs('cursor', { model: 'claude-4.5-sonnet', reasoningEffort: 'thinking' })
-    ).toEqual(['--model', 'claude-4.5-sonnet-thinking']);
+      buildAgentModelArgs('cursor', { model: 'claude-4.6-sonnet', reasoningEffort: 'thinking' })
+    ).toEqual(['--model', 'claude-4.6-sonnet-medium-thinking']);
   });
 
   it('uses the cursor default model id when no reasoning level is chosen', () => {

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
@@ -6,6 +6,7 @@ import {
   getReasoningOptions,
   MODEL_SELECTABLE_PROVIDER_IDS,
   providerSupportsModelSelection,
+  sanitizeAgentModelSelection,
   type AgentModelSupport,
 } from './agent-models';
 
@@ -55,6 +56,20 @@ describe('getReasoningOptions', () => {
     expect(getReasoningOptions('amp', 'smart').length).toBeGreaterThan(0);
     expect(getReasoningOptions('amp', 'deep').length).toBeGreaterThan(0);
     expect(getReasoningOptions('amp', undefined).length).toBeGreaterThan(0);
+  });
+});
+
+describe('sanitizeAgentModelSelection', () => {
+  it('clears stale reasoning when the selected model does not support it', () => {
+    expect(
+      sanitizeAgentModelSelection('cursor', { model: 'auto', reasoningEffort: 'high' })
+    ).toEqual({ model: 'auto' });
+  });
+
+  it('clears reasoning-only patches when no reasoning is available for the model', () => {
+    expect(
+      sanitizeAgentModelSelection('cursor', { model: 'composer-2.5', reasoningEffort: 'high' })
+    ).toEqual({ model: 'composer-2.5' });
   });
 });
 
@@ -108,6 +123,9 @@ describe('buildAgentModelArgs', () => {
     expect(fable?.disabled).toBe(true);
     // A stale stored selection of a disabled model must not reach the agent.
     expect(buildAgentModelArgs('claude', { model: 'claude-fable-5' })).toEqual([]);
+    expect(
+      buildAgentModelArgs('claude', { model: 'claude-fable-5', reasoningEffort: 'high' })
+    ).toEqual([]);
   });
 
   it('builds amp mode args and includes --effort for smart/deep', () => {
@@ -116,6 +134,12 @@ describe('buildAgentModelArgs', () => {
       'smart',
       '--effort',
       'high',
+    ]);
+    expect(buildAgentModelArgs('amp', { model: 'smart', reasoningEffort: 'none' })).toEqual([
+      '--mode',
+      'smart',
+      '--effort',
+      'none',
     ]);
   });
 

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
@@ -3,6 +3,7 @@ import {
   AGENT_MODEL_SUPPORT,
   buildAgentModelArgs,
   getAgentModelSupport,
+  getReasoningOptions,
   MODEL_SELECTABLE_PROVIDER_IDS,
   providerSupportsModelSelection,
   type AgentModelSupport,
@@ -21,11 +22,39 @@ describe('agent-models registry', () => {
     expect(providerSupportsModelSelection('gemini')).toBe(false);
   });
 
-  it('only attaches reasoning options when the provider supports an effort flag', () => {
-    expect(getAgentModelSupport('cursor')?.reasoning).toBeUndefined();
-    expect(getAgentModelSupport('amp')?.reasoning).toBeUndefined();
+  it('exposes provider-level reasoning only where reasoning is model-independent', () => {
+    // Codex/Claude/Amp share a single effort flag across models.
     expect(getAgentModelSupport('codex')?.reasoning?.length).toBeGreaterThan(0);
     expect(getAgentModelSupport('claude')?.reasoning?.length).toBeGreaterThan(0);
+    expect(getAgentModelSupport('amp')?.reasoning?.length).toBeGreaterThan(0);
+    // Cursor bakes reasoning into the model id, so there is no provider-level list.
+    expect(getAgentModelSupport('cursor')?.reasoning).toBeUndefined();
+  });
+});
+
+describe('getReasoningOptions', () => {
+  it('returns provider-level reasoning for Codex regardless of model', () => {
+    expect(getReasoningOptions('codex', undefined).length).toBeGreaterThan(0);
+    expect(getReasoningOptions('codex', 'gpt-5.5').length).toBeGreaterThan(0);
+  });
+
+  it('returns per-model reasoning for Cursor and nothing for Default/Auto', () => {
+    expect(getReasoningOptions('cursor', undefined)).toEqual([]);
+    expect(getReasoningOptions('cursor', 'auto')).toEqual([]);
+    expect(getReasoningOptions('cursor', 'composer-2.5')).toEqual([]);
+    expect(getReasoningOptions('cursor', 'gpt-5.5').map((o) => o.id)).toEqual([
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+    ]);
+  });
+
+  it('omits reasoning for Amp rush but offers it for smart/deep/default', () => {
+    expect(getReasoningOptions('amp', 'rush')).toEqual([]);
+    expect(getReasoningOptions('amp', 'smart').length).toBeGreaterThan(0);
+    expect(getReasoningOptions('amp', 'deep').length).toBeGreaterThan(0);
+    expect(getReasoningOptions('amp', undefined).length).toBeGreaterThan(0);
   });
 });
 
@@ -75,29 +104,61 @@ describe('buildAgentModelArgs', () => {
     ]);
   });
 
-  it('builds amp mode args via --mode and ignores any reasoning effort', () => {
+  it('builds amp mode args and includes --effort for smart/deep', () => {
+    expect(buildAgentModelArgs('amp', { model: 'smart', reasoningEffort: 'high' })).toEqual([
+      '--mode',
+      'smart',
+      '--effort',
+      'high',
+    ]);
+  });
+
+  it('ignores reasoning effort for amp rush', () => {
     expect(buildAgentModelArgs('amp', { model: 'rush', reasoningEffort: 'high' })).toEqual([
       '--mode',
       'rush',
     ]);
   });
 
-  it('builds cursor model args and ignores any reasoning effort', () => {
+  it('composes the cursor model id from the base model and reasoning level', () => {
+    expect(buildAgentModelArgs('cursor', { model: 'gpt-5.5', reasoningEffort: 'high' })).toEqual([
+      '--model',
+      'gpt-5.5-high',
+    ]);
+    // Reasoning suffix differs per family (extra-high vs xhigh).
+    expect(buildAgentModelArgs('cursor', { model: 'gpt-5.5', reasoningEffort: 'xhigh' })).toEqual([
+      '--model',
+      'gpt-5.5-extra-high',
+    ]);
     expect(
-      buildAgentModelArgs('cursor', {
-        model: 'claude-4.5-sonnet-thinking',
-        reasoningEffort: 'high',
-      })
+      buildAgentModelArgs('cursor', { model: 'claude-4.5-sonnet', reasoningEffort: 'thinking' })
     ).toEqual(['--model', 'claude-4.5-sonnet-thinking']);
+  });
+
+  it('uses the cursor default model id when no reasoning level is chosen', () => {
+    expect(buildAgentModelArgs('cursor', { model: 'gpt-5.5' })).toEqual([
+      '--model',
+      'gpt-5.5-medium',
+    ]);
+    expect(buildAgentModelArgs('cursor', { model: 'auto', reasoningEffort: 'high' })).toEqual([
+      '--model',
+      'auto',
+    ]);
   });
 
   it('keeps registry model/reasoning ids unique per provider', () => {
     for (const support of Object.values(AGENT_MODEL_SUPPORT) as AgentModelSupport[]) {
-      const modelIds = support.models.map((m) => m.id);
+      const modelIds = support.models.map((model) => model.id);
       expect(new Set(modelIds).size).toBe(modelIds.length);
       if (support.reasoning) {
-        const effortIds = support.reasoning.map((r) => r.id);
+        const effortIds = support.reasoning.map((option) => option.id);
         expect(new Set(effortIds).size).toBe(effortIds.length);
+      }
+      for (const model of support.models) {
+        if (model.reasoning) {
+          const ids = model.reasoning.map((option) => option.id);
+          expect(new Set(ids).size).toBe(ids.length);
+        }
       }
     }
   });

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from 'vitest';
+import {
+  AGENT_MODEL_SUPPORT,
+  buildAgentModelArgs,
+  getAgentModelSupport,
+  MODEL_SELECTABLE_PROVIDER_IDS,
+  providerSupportsModelSelection,
+  type AgentModelSupport,
+} from './agent-models';
+
+describe('agent-models registry', () => {
+  it('exposes only the curated providers as model-selectable', () => {
+    expect(MODEL_SELECTABLE_PROVIDER_IDS.slice().sort()).toEqual([
+      'amp',
+      'claude',
+      'codex',
+      'cursor',
+    ]);
+    expect(providerSupportsModelSelection('codex')).toBe(true);
+    expect(providerSupportsModelSelection('amp')).toBe(true);
+    expect(providerSupportsModelSelection('gemini')).toBe(false);
+  });
+
+  it('only attaches reasoning options when the provider supports an effort flag', () => {
+    expect(getAgentModelSupport('cursor')?.reasoning).toBeUndefined();
+    expect(getAgentModelSupport('amp')?.reasoning).toBeUndefined();
+    expect(getAgentModelSupport('codex')?.reasoning?.length).toBeGreaterThan(0);
+    expect(getAgentModelSupport('claude')?.reasoning?.length).toBeGreaterThan(0);
+  });
+});
+
+describe('buildAgentModelArgs', () => {
+  it('returns no args for providers without model support', () => {
+    expect(buildAgentModelArgs('gemini', { model: 'whatever' })).toEqual([]);
+  });
+
+  it('returns no args for an empty selection', () => {
+    expect(buildAgentModelArgs('codex', undefined)).toEqual([]);
+    expect(buildAgentModelArgs('codex', {})).toEqual([]);
+    expect(buildAgentModelArgs('codex', { model: '   ' })).toEqual([]);
+  });
+
+  it('builds codex model + reasoning effort args', () => {
+    expect(buildAgentModelArgs('codex', { model: 'gpt-5.5', reasoningEffort: 'high' })).toEqual([
+      '--model',
+      'gpt-5.5',
+      '-c',
+      'model_reasoning_effort=high',
+    ]);
+  });
+
+  it('ignores stale or invalid selection values', () => {
+    expect(
+      buildAgentModelArgs('codex', { model: 'old-model', reasoningEffort: 'extreme' })
+    ).toEqual([]);
+    expect(buildAgentModelArgs('codex', { model: 'gpt-5.5', reasoningEffort: 'extreme' })).toEqual([
+      '--model',
+      'gpt-5.5',
+    ]);
+  });
+
+  it('builds codex reasoning-only args when no model is chosen', () => {
+    expect(buildAgentModelArgs('codex', { reasoningEffort: 'minimal' })).toEqual([
+      '-c',
+      'model_reasoning_effort=minimal',
+    ]);
+  });
+
+  it('builds claude model + effort args', () => {
+    expect(buildAgentModelArgs('claude', { model: 'opus', reasoningEffort: 'max' })).toEqual([
+      '--model',
+      'opus',
+      '--effort',
+      'max',
+    ]);
+  });
+
+  it('builds amp mode args via --mode and ignores any reasoning effort', () => {
+    expect(buildAgentModelArgs('amp', { model: 'rush', reasoningEffort: 'high' })).toEqual([
+      '--mode',
+      'rush',
+    ]);
+  });
+
+  it('builds cursor model args and ignores any reasoning effort', () => {
+    expect(
+      buildAgentModelArgs('cursor', {
+        model: 'claude-4.5-sonnet-thinking',
+        reasoningEffort: 'high',
+      })
+    ).toEqual(['--model', 'claude-4.5-sonnet-thinking']);
+  });
+
+  it('keeps registry model/reasoning ids unique per provider', () => {
+    for (const support of Object.values(AGENT_MODEL_SUPPORT) as AgentModelSupport[]) {
+      const modelIds = support.models.map((m) => m.id);
+      expect(new Set(modelIds).size).toBe(modelIds.length);
+      if (support.reasoning) {
+        const effortIds = support.reasoning.map((r) => r.id);
+        expect(new Set(effortIds).size).toBe(effortIds.length);
+      }
+    }
+  });
+});

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
@@ -1,3 +1,4 @@
+import { AGENT_MODEL_SUPPORT } from './agent-model-support';
 import type { AgentProviderId } from './agent-provider-registry';
 
 /** A selectable reasoning-effort level for a provider/model. */
@@ -21,8 +22,8 @@ export type AgentModelOption = {
  * translates a stored selection into the CLI arguments understood by each agent.
  *
  * Only providers with a predictable, documented set of models/flags are listed
- * here (currently Codex, Claude Code, Cursor, and Amp). Other providers fall
- * back to their CLI/config defaults.
+ * in `agent-model-support.ts`. Other providers fall back to their CLI/config
+ * defaults.
  */
 export type AgentModelSupport = {
   /** Selectable models. Users may also choose "Default" (no model flag). */
@@ -45,200 +46,7 @@ export type AgentModelSelection = {
   reasoningEffort?: string;
 };
 
-const CODEX_REASONING: AgentReasoningOption[] = [
-  { id: 'minimal', label: 'Minimal' },
-  { id: 'low', label: 'Low' },
-  { id: 'medium', label: 'Medium' },
-  { id: 'high', label: 'High' },
-  { id: 'xhigh', label: 'Extra High' },
-];
-
-const CLAUDE_REASONING: AgentReasoningOption[] = [
-  { id: 'low', label: 'Low' },
-  { id: 'medium', label: 'Medium' },
-  { id: 'high', label: 'High' },
-  { id: 'xhigh', label: 'Extra High' },
-  { id: 'max', label: 'Max' },
-];
-
-// Amp exposes `--effort` for the `smart` and `deep` modes; `rush` has no
-// reasoning. Valid values come from Amp's SDK docs.
-const AMP_REASONING: AgentReasoningOption[] = [
-  { id: 'none', label: 'None' },
-  { id: 'low', label: 'Low' },
-  { id: 'medium', label: 'Medium' },
-  { id: 'high', label: 'High' },
-  { id: 'xhigh', label: 'Extra High' },
-  { id: 'max', label: 'Max' },
-];
-
-/**
- * Cursor bakes the reasoning level into the model id, and the suffixes differ
- * per family (e.g. `gpt-5.5-extra-high` vs `gpt-5.4-xhigh`, plain `gpt-5.2` ==
- * medium). Each base model therefore maps an effort id to a concrete, verified
- * `--model` value (from `cursor-agent --list-models`).
- */
-type CursorReasoningVariant = AgentReasoningOption & { modelId: string };
-type CursorModelDef = {
-  id: string;
-  label: string;
-  /** `--model` value used when no reasoning level is chosen. */
-  defaultModelId: string;
-  variants?: CursorReasoningVariant[];
-};
-
-const CURSOR_MODELS: CursorModelDef[] = [
-  { id: 'auto', label: 'Auto', defaultModelId: 'auto' },
-  { id: 'composer-2.5', label: 'Composer 2.5', defaultModelId: 'composer-2.5' },
-  {
-    id: 'gpt-5.5',
-    label: 'GPT-5.5',
-    defaultModelId: 'gpt-5.5-medium',
-    variants: [
-      { id: 'low', label: 'Low', modelId: 'gpt-5.5-low' },
-      { id: 'medium', label: 'Medium', modelId: 'gpt-5.5-medium' },
-      { id: 'high', label: 'High', modelId: 'gpt-5.5-high' },
-      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.5-extra-high' },
-    ],
-  },
-  {
-    id: 'gpt-5.4',
-    label: 'GPT-5.4',
-    defaultModelId: 'gpt-5.4-medium',
-    variants: [
-      { id: 'low', label: 'Low', modelId: 'gpt-5.4-low' },
-      { id: 'medium', label: 'Medium', modelId: 'gpt-5.4-medium' },
-      { id: 'high', label: 'High', modelId: 'gpt-5.4-high' },
-      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.4-xhigh' },
-    ],
-  },
-  {
-    id: 'gpt-5.2',
-    label: 'GPT-5.2',
-    defaultModelId: 'gpt-5.2',
-    variants: [
-      { id: 'low', label: 'Low', modelId: 'gpt-5.2-low' },
-      { id: 'medium', label: 'Medium', modelId: 'gpt-5.2' },
-      { id: 'high', label: 'High', modelId: 'gpt-5.2-high' },
-      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.2-xhigh' },
-    ],
-  },
-  {
-    id: 'gpt-5.1',
-    label: 'GPT-5.1',
-    defaultModelId: 'gpt-5.1',
-    variants: [
-      { id: 'low', label: 'Low', modelId: 'gpt-5.1-low' },
-      { id: 'medium', label: 'Medium', modelId: 'gpt-5.1' },
-      { id: 'high', label: 'High', modelId: 'gpt-5.1-high' },
-    ],
-  },
-  {
-    id: 'claude-4.5-sonnet',
-    label: 'Sonnet 4.5',
-    defaultModelId: 'claude-4.5-sonnet',
-    variants: [
-      { id: 'standard', label: 'Standard', modelId: 'claude-4.5-sonnet' },
-      { id: 'thinking', label: 'Thinking', modelId: 'claude-4.5-sonnet-thinking' },
-    ],
-  },
-  {
-    id: 'claude-opus-4-8',
-    label: 'Opus 4.8',
-    defaultModelId: 'claude-opus-4-8-high',
-    variants: [
-      { id: 'low', label: 'Low', modelId: 'claude-opus-4-8-low' },
-      { id: 'medium', label: 'Medium', modelId: 'claude-opus-4-8-medium' },
-      { id: 'high', label: 'High', modelId: 'claude-opus-4-8-high' },
-      { id: 'xhigh', label: 'Extra High', modelId: 'claude-opus-4-8-xhigh' },
-      { id: 'max', label: 'Max', modelId: 'claude-opus-4-8-max' },
-      { id: 'thinking', label: 'Thinking', modelId: 'claude-opus-4-8-thinking-high' },
-    ],
-  },
-  { id: 'gemini-3.1-pro', label: 'Gemini 3.1 Pro', defaultModelId: 'gemini-3.1-pro' },
-  { id: 'grok-4.3', label: 'Grok 4.3', defaultModelId: 'grok-4.3' },
-  { id: 'kimi-k2.5', label: 'Kimi K2.5', defaultModelId: 'kimi-k2.5' },
-];
-
-function cursorModelOptions(): AgentModelOption[] {
-  return CURSOR_MODELS.map((model) => ({
-    id: model.id,
-    label: model.label,
-    reasoning: model.variants?.map((variant) => ({ id: variant.id, label: variant.label })) ?? [],
-  }));
-}
-
-function buildCursorArgs(model: string | undefined, effort: string | undefined): string[] {
-  if (!model) return [];
-  const def = CURSOR_MODELS.find((entry) => entry.id === model);
-  if (!def) return [];
-  const variant = effort ? def.variants?.find((entry) => entry.id === effort) : undefined;
-  return ['--model', variant?.modelId ?? def.defaultModelId];
-}
-
-/**
- * Curated model + reasoning support for the providers with predictable model
- * availability. Lists reflect the CLI versions tested (codex 0.139, claude 2.1,
- * cursor-agent 2026.06, amp 0.x) and are safe to extend over time.
- */
-export const AGENT_MODEL_SUPPORT = {
-  codex: {
-    // Codex takes the model id via `--model` and the reasoning effort separately
-    // via `-c model_reasoning_effort=<level>`.
-    models: [
-      { id: 'gpt-5.5', label: 'GPT-5.5' },
-      { id: 'gpt-5.4', label: 'GPT-5.4' },
-      { id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
-      { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
-      { id: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
-    ],
-    reasoning: CODEX_REASONING,
-    buildArgs: (model, effort): string[] => {
-      const args: string[] = [];
-      if (model) args.push('--model', model);
-      if (effort) args.push('-c', `model_reasoning_effort=${effort}`);
-      return args;
-    },
-  },
-  claude: {
-    // Claude Code takes a model alias (or full name) via `--model` and a separate
-    // reasoning effort via `--effort`.
-    models: [
-      { id: 'opus', label: 'Opus' },
-      { id: 'sonnet', label: 'Sonnet' },
-      { id: 'haiku', label: 'Haiku' },
-    ],
-    reasoning: CLAUDE_REASONING,
-    buildArgs: (model, effort): string[] => {
-      const args: string[] = [];
-      if (model) args.push('--model', model);
-      if (effort) args.push('--effort', effort);
-      return args;
-    },
-  },
-  cursor: {
-    // Cursor has no separate reasoning flag; the level is part of the model id,
-    // so a base model + reasoning level compose a concrete `--model` value.
-    models: cursorModelOptions(),
-    buildArgs: buildCursorArgs,
-  },
-  amp: {
-    // Amp selects the model through its agent "mode" (`--mode`) and exposes
-    // `--effort` for the `smart` and `deep` modes; `rush` has no reasoning.
-    models: [
-      { id: 'smart', label: 'Smart' },
-      { id: 'rush', label: 'Rush', reasoning: [] },
-      { id: 'deep', label: 'Deep' },
-    ],
-    reasoning: AMP_REASONING,
-    buildArgs: (model, effort): string[] => {
-      const args: string[] = [];
-      if (model) args.push('--mode', model);
-      if (effort) args.push('--effort', effort);
-      return args;
-    },
-  },
-} satisfies Partial<Record<AgentProviderId, AgentModelSupport>>;
+export { AGENT_MODEL_SUPPORT };
 
 export type ModelSelectableProviderId = keyof typeof AGENT_MODEL_SUPPORT;
 

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
@@ -1,28 +1,42 @@
 import type { AgentProviderId } from './agent-provider-registry';
 
-/** A selectable model for a provider. */
-export type AgentModelOption = { id: string; label: string };
-
-/** A selectable reasoning-effort level for a provider. */
+/** A selectable reasoning-effort level for a provider/model. */
 export type AgentReasoningOption = { id: string; label: string };
+
+/** A selectable model for a provider. */
+export type AgentModelOption = {
+  id: string;
+  label: string;
+  /**
+   * Reasoning levels available for this specific model. When present (even
+   * empty), it overrides the provider-level {@link AgentModelSupport.reasoning}.
+   * An empty array means the model exposes no reasoning selector. When omitted,
+   * the provider-level reasoning applies.
+   */
+  reasoning?: AgentReasoningOption[];
+};
 
 /**
  * Per-provider model + reasoning metadata. Drives the Models settings UI and
  * translates a stored selection into the CLI arguments understood by each agent.
  *
  * Only providers with a predictable, documented set of models/flags are listed
- * here (currently Codex, Claude Code, and Cursor). Other providers fall back to
- * their CLI/config defaults.
+ * here (currently Codex, Claude Code, Cursor, and Amp). Other providers fall
+ * back to their CLI/config defaults.
  */
 export type AgentModelSupport = {
-  /** Selectable models. Users may also choose "Default" (no `--model` flag). */
+  /** Selectable models. Users may also choose "Default" (no model flag). */
   models: AgentModelOption[];
-  /** Reasoning-effort levels when the provider exposes a dedicated flag. */
+  /**
+   * Reasoning levels shared by all models that do not define their own list
+   * (e.g. Codex and Claude expose a single effort flag independent of model).
+   */
   reasoning?: AgentReasoningOption[];
-  /** argv tokens for an explicit model selection. */
-  toModelArgs: (modelId: string) => string[];
-  /** argv tokens for an explicit reasoning-effort selection. */
-  toReasoningArgs?: (effortId: string) => string[];
+  /**
+   * Build argv tokens for an already-validated `(model, effort)` selection.
+   * Both values are guaranteed to be valid option ids (or `undefined`).
+   */
+  buildArgs: (model: string | undefined, effort: string | undefined) => string[];
 };
 
 /** A user's model + reasoning choice for a single provider. */
@@ -31,10 +45,141 @@ export type AgentModelSelection = {
   reasoningEffort?: string;
 };
 
+const CODEX_REASONING: AgentReasoningOption[] = [
+  { id: 'minimal', label: 'Minimal' },
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Extra High' },
+];
+
+const CLAUDE_REASONING: AgentReasoningOption[] = [
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Extra High' },
+  { id: 'max', label: 'Max' },
+];
+
+// Amp exposes `--effort` for the `smart` and `deep` modes; `rush` has no
+// reasoning. Valid values come from Amp's SDK docs.
+const AMP_REASONING: AgentReasoningOption[] = [
+  { id: 'none', label: 'None' },
+  { id: 'low', label: 'Low' },
+  { id: 'medium', label: 'Medium' },
+  { id: 'high', label: 'High' },
+  { id: 'xhigh', label: 'Extra High' },
+  { id: 'max', label: 'Max' },
+];
+
+/**
+ * Cursor bakes the reasoning level into the model id, and the suffixes differ
+ * per family (e.g. `gpt-5.5-extra-high` vs `gpt-5.4-xhigh`, plain `gpt-5.2` ==
+ * medium). Each base model therefore maps an effort id to a concrete, verified
+ * `--model` value (from `cursor-agent --list-models`).
+ */
+type CursorReasoningVariant = AgentReasoningOption & { modelId: string };
+type CursorModelDef = {
+  id: string;
+  label: string;
+  /** `--model` value used when no reasoning level is chosen. */
+  defaultModelId: string;
+  variants?: CursorReasoningVariant[];
+};
+
+const CURSOR_MODELS: CursorModelDef[] = [
+  { id: 'auto', label: 'Auto', defaultModelId: 'auto' },
+  { id: 'composer-2.5', label: 'Composer 2.5', defaultModelId: 'composer-2.5' },
+  {
+    id: 'gpt-5.5',
+    label: 'GPT-5.5',
+    defaultModelId: 'gpt-5.5-medium',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.5-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.5-medium' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.5-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.5-extra-high' },
+    ],
+  },
+  {
+    id: 'gpt-5.4',
+    label: 'GPT-5.4',
+    defaultModelId: 'gpt-5.4-medium',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.4-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.4-medium' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.4-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.4-xhigh' },
+    ],
+  },
+  {
+    id: 'gpt-5.2',
+    label: 'GPT-5.2',
+    defaultModelId: 'gpt-5.2',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.2-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.2' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.2-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'gpt-5.2-xhigh' },
+    ],
+  },
+  {
+    id: 'gpt-5.1',
+    label: 'GPT-5.1',
+    defaultModelId: 'gpt-5.1',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'gpt-5.1-low' },
+      { id: 'medium', label: 'Medium', modelId: 'gpt-5.1' },
+      { id: 'high', label: 'High', modelId: 'gpt-5.1-high' },
+    ],
+  },
+  {
+    id: 'claude-4.5-sonnet',
+    label: 'Sonnet 4.5',
+    defaultModelId: 'claude-4.5-sonnet',
+    variants: [
+      { id: 'standard', label: 'Standard', modelId: 'claude-4.5-sonnet' },
+      { id: 'thinking', label: 'Thinking', modelId: 'claude-4.5-sonnet-thinking' },
+    ],
+  },
+  {
+    id: 'claude-opus-4-8',
+    label: 'Opus 4.8',
+    defaultModelId: 'claude-opus-4-8-high',
+    variants: [
+      { id: 'low', label: 'Low', modelId: 'claude-opus-4-8-low' },
+      { id: 'medium', label: 'Medium', modelId: 'claude-opus-4-8-medium' },
+      { id: 'high', label: 'High', modelId: 'claude-opus-4-8-high' },
+      { id: 'xhigh', label: 'Extra High', modelId: 'claude-opus-4-8-xhigh' },
+      { id: 'max', label: 'Max', modelId: 'claude-opus-4-8-max' },
+      { id: 'thinking', label: 'Thinking', modelId: 'claude-opus-4-8-thinking-high' },
+    ],
+  },
+  { id: 'gemini-3.1-pro', label: 'Gemini 3.1 Pro', defaultModelId: 'gemini-3.1-pro' },
+  { id: 'grok-4.3', label: 'Grok 4.3', defaultModelId: 'grok-4.3' },
+  { id: 'kimi-k2.5', label: 'Kimi K2.5', defaultModelId: 'kimi-k2.5' },
+];
+
+function cursorModelOptions(): AgentModelOption[] {
+  return CURSOR_MODELS.map((model) => ({
+    id: model.id,
+    label: model.label,
+    reasoning: model.variants?.map((variant) => ({ id: variant.id, label: variant.label })) ?? [],
+  }));
+}
+
+function buildCursorArgs(model: string | undefined, effort: string | undefined): string[] {
+  if (!model) return [];
+  const def = CURSOR_MODELS.find((entry) => entry.id === model);
+  if (!def) return [];
+  const variant = effort ? def.variants?.find((entry) => entry.id === effort) : undefined;
+  return ['--model', variant?.modelId ?? def.defaultModelId];
+}
+
 /**
  * Curated model + reasoning support for the providers with predictable model
  * availability. Lists reflect the CLI versions tested (codex 0.139, claude 2.1,
- * cursor-agent 2026.06) and are safe to extend over time.
+ * cursor-agent 2026.06, amp 0.x) and are safe to extend over time.
  */
 export const AGENT_MODEL_SUPPORT = {
   codex: {
@@ -47,15 +192,13 @@ export const AGENT_MODEL_SUPPORT = {
       { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
       { id: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
     ],
-    reasoning: [
-      { id: 'minimal', label: 'Minimal' },
-      { id: 'low', label: 'Low' },
-      { id: 'medium', label: 'Medium' },
-      { id: 'high', label: 'High' },
-      { id: 'xhigh', label: 'Extra high' },
-    ],
-    toModelArgs: (modelId: string): string[] => ['--model', modelId],
-    toReasoningArgs: (effortId: string): string[] => ['-c', `model_reasoning_effort=${effortId}`],
+    reasoning: CODEX_REASONING,
+    buildArgs: (model, effort): string[] => {
+      const args: string[] = [];
+      if (model) args.push('--model', model);
+      if (effort) args.push('-c', `model_reasoning_effort=${effort}`);
+      return args;
+    },
   },
   claude: {
     // Claude Code takes a model alias (or full name) via `--model` and a separate
@@ -65,39 +208,35 @@ export const AGENT_MODEL_SUPPORT = {
       { id: 'sonnet', label: 'Sonnet' },
       { id: 'haiku', label: 'Haiku' },
     ],
-    reasoning: [
-      { id: 'low', label: 'Low' },
-      { id: 'medium', label: 'Medium' },
-      { id: 'high', label: 'High' },
-      { id: 'xhigh', label: 'Extra high' },
-      { id: 'max', label: 'Max' },
-    ],
-    toModelArgs: (modelId: string): string[] => ['--model', modelId],
-    toReasoningArgs: (effortId: string): string[] => ['--effort', effortId],
+    reasoning: CLAUDE_REASONING,
+    buildArgs: (model, effort): string[] => {
+      const args: string[] = [];
+      if (model) args.push('--model', model);
+      if (effort) args.push('--effort', effort);
+      return args;
+    },
   },
   cursor: {
-    // Cursor bakes the reasoning level into the model id (e.g. `-thinking`,
-    // `-high`), so there is no separate reasoning flag.
-    models: [
-      { id: 'auto', label: 'Auto' },
-      { id: 'composer-2.5', label: 'Composer 2.5' },
-      { id: 'claude-4.5-sonnet', label: 'Sonnet 4.5' },
-      { id: 'claude-4.5-sonnet-thinking', label: 'Sonnet 4.5 Thinking' },
-      { id: 'gpt-5.1', label: 'GPT-5.1' },
-      { id: 'gpt-5.1-high', label: 'GPT-5.1 High' },
-    ],
-    toModelArgs: (modelId: string): string[] => ['--model', modelId],
+    // Cursor has no separate reasoning flag; the level is part of the model id,
+    // so a base model + reasoning level compose a concrete `--model` value.
+    models: cursorModelOptions(),
+    buildArgs: buildCursorArgs,
   },
   amp: {
-    // Amp selects the model through its agent "mode" (`--mode`), which controls
-    // the model, system prompt, and tool selection. Amp also exposes `--effort`,
-    // but its valid values are mode-dependent and undocumented, so it is omitted.
+    // Amp selects the model through its agent "mode" (`--mode`) and exposes
+    // `--effort` for the `smart` and `deep` modes; `rush` has no reasoning.
     models: [
       { id: 'smart', label: 'Smart' },
-      { id: 'rush', label: 'Rush' },
+      { id: 'rush', label: 'Rush', reasoning: [] },
       { id: 'deep', label: 'Deep' },
     ],
-    toModelArgs: (modelId: string): string[] => ['--mode', modelId],
+    reasoning: AMP_REASONING,
+    buildArgs: (model, effort): string[] => {
+      const args: string[] = [];
+      if (model) args.push('--mode', model);
+      if (effort) args.push('--effort', effort);
+      return args;
+    },
   },
 } satisfies Partial<Record<AgentProviderId, AgentModelSupport>>;
 
@@ -117,12 +256,42 @@ export function providerSupportsModelSelection(providerId: AgentProviderId): boo
 }
 
 /**
+ * Resolve the reasoning levels available for a given model selection.
+ *
+ * A model's own reasoning list (when defined) takes precedence over the
+ * provider-level list, so model-specific availability (Cursor per family, Amp
+ * `rush` vs `smart`/`deep`) is honored. Returns an empty array when the
+ * provider/model exposes no reasoning selector.
+ */
+export function reasoningOptionsForModel(
+  support: AgentModelSupport,
+  modelId: string | undefined
+): AgentReasoningOption[] {
+  if (modelId) {
+    const model = support.models.find((option) => option.id === modelId);
+    if (model && model.reasoning !== undefined) return model.reasoning;
+  }
+  return support.reasoning ?? [];
+}
+
+/** Reasoning levels available for a provider + (optional) selected model. */
+export function getReasoningOptions(
+  providerId: AgentProviderId,
+  modelId: string | undefined
+): AgentReasoningOption[] {
+  const support = getAgentModelSupport(providerId);
+  if (!support) return [];
+  return reasoningOptionsForModel(support, modelId);
+}
+
+/**
  * Translate a stored model selection into CLI arguments for the given provider.
  *
  * Returns an empty array when the provider has no curated model support or when
- * the selection is empty. Stored values are checked against the current curated
- * option ids before being passed as discrete argv tokens (never through a shell),
- * so stale settings are ignored instead of breaking new sessions.
+ * the selection is empty. Stored values are validated against the current
+ * curated options (model ids, and reasoning ids for the selected model) before
+ * being passed as discrete argv tokens (never through a shell), so stale
+ * settings are ignored instead of breaking new sessions.
  */
 export function buildAgentModelArgs(
   providerId: AgentProviderId,
@@ -131,21 +300,14 @@ export function buildAgentModelArgs(
   const support = getAgentModelSupport(providerId);
   if (!support || !selection) return [];
 
-  const args: string[] = [];
+  const rawModel = selection.model?.trim();
+  const model =
+    rawModel && support.models.some((option) => option.id === rawModel) ? rawModel : undefined;
 
-  const model = selection.model?.trim();
-  if (model && support.models.some((option) => option.id === model)) {
-    args.push(...support.toModelArgs(model));
-  }
+  const rawEffort = selection.reasoningEffort?.trim();
+  const reasoning = reasoningOptionsForModel(support, model);
+  const effort =
+    rawEffort && reasoning.some((option) => option.id === rawEffort) ? rawEffort : undefined;
 
-  const effort = selection.reasoningEffort?.trim();
-  if (
-    effort &&
-    support.reasoning?.some((option) => option.id === effort) &&
-    support.toReasoningArgs
-  ) {
-    args.push(...support.toReasoningArgs(effort));
-  }
-
-  return args;
+  return support.buildArgs(model, effort);
 }

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
@@ -1,0 +1,151 @@
+import type { AgentProviderId } from './agent-provider-registry';
+
+/** A selectable model for a provider. */
+export type AgentModelOption = { id: string; label: string };
+
+/** A selectable reasoning-effort level for a provider. */
+export type AgentReasoningOption = { id: string; label: string };
+
+/**
+ * Per-provider model + reasoning metadata. Drives the Models settings UI and
+ * translates a stored selection into the CLI arguments understood by each agent.
+ *
+ * Only providers with a predictable, documented set of models/flags are listed
+ * here (currently Codex, Claude Code, and Cursor). Other providers fall back to
+ * their CLI/config defaults.
+ */
+export type AgentModelSupport = {
+  /** Selectable models. Users may also choose "Default" (no `--model` flag). */
+  models: AgentModelOption[];
+  /** Reasoning-effort levels when the provider exposes a dedicated flag. */
+  reasoning?: AgentReasoningOption[];
+  /** argv tokens for an explicit model selection. */
+  toModelArgs: (modelId: string) => string[];
+  /** argv tokens for an explicit reasoning-effort selection. */
+  toReasoningArgs?: (effortId: string) => string[];
+};
+
+/** A user's model + reasoning choice for a single provider. */
+export type AgentModelSelection = {
+  model?: string;
+  reasoningEffort?: string;
+};
+
+/**
+ * Curated model + reasoning support for the providers with predictable model
+ * availability. Lists reflect the CLI versions tested (codex 0.139, claude 2.1,
+ * cursor-agent 2026.06) and are safe to extend over time.
+ */
+export const AGENT_MODEL_SUPPORT = {
+  codex: {
+    // Codex takes the model id via `--model` and the reasoning effort separately
+    // via `-c model_reasoning_effort=<level>`.
+    models: [
+      { id: 'gpt-5.5', label: 'GPT-5.5' },
+      { id: 'gpt-5.4', label: 'GPT-5.4' },
+      { id: 'gpt-5.3-codex', label: 'GPT-5.3 Codex' },
+      { id: 'gpt-5.1-codex-max', label: 'GPT-5.1 Codex Max' },
+      { id: 'gpt-5.1-codex-mini', label: 'GPT-5.1 Codex Mini' },
+    ],
+    reasoning: [
+      { id: 'minimal', label: 'Minimal' },
+      { id: 'low', label: 'Low' },
+      { id: 'medium', label: 'Medium' },
+      { id: 'high', label: 'High' },
+      { id: 'xhigh', label: 'Extra high' },
+    ],
+    toModelArgs: (modelId: string): string[] => ['--model', modelId],
+    toReasoningArgs: (effortId: string): string[] => ['-c', `model_reasoning_effort=${effortId}`],
+  },
+  claude: {
+    // Claude Code takes a model alias (or full name) via `--model` and a separate
+    // reasoning effort via `--effort`.
+    models: [
+      { id: 'opus', label: 'Opus' },
+      { id: 'sonnet', label: 'Sonnet' },
+      { id: 'haiku', label: 'Haiku' },
+    ],
+    reasoning: [
+      { id: 'low', label: 'Low' },
+      { id: 'medium', label: 'Medium' },
+      { id: 'high', label: 'High' },
+      { id: 'xhigh', label: 'Extra high' },
+      { id: 'max', label: 'Max' },
+    ],
+    toModelArgs: (modelId: string): string[] => ['--model', modelId],
+    toReasoningArgs: (effortId: string): string[] => ['--effort', effortId],
+  },
+  cursor: {
+    // Cursor bakes the reasoning level into the model id (e.g. `-thinking`,
+    // `-high`), so there is no separate reasoning flag.
+    models: [
+      { id: 'auto', label: 'Auto' },
+      { id: 'composer-2.5', label: 'Composer 2.5' },
+      { id: 'claude-4.5-sonnet', label: 'Sonnet 4.5' },
+      { id: 'claude-4.5-sonnet-thinking', label: 'Sonnet 4.5 Thinking' },
+      { id: 'gpt-5.1', label: 'GPT-5.1' },
+      { id: 'gpt-5.1-high', label: 'GPT-5.1 High' },
+    ],
+    toModelArgs: (modelId: string): string[] => ['--model', modelId],
+  },
+  amp: {
+    // Amp selects the model through its agent "mode" (`--mode`), which controls
+    // the model, system prompt, and tool selection. Amp also exposes `--effort`,
+    // but its valid values are mode-dependent and undocumented, so it is omitted.
+    models: [
+      { id: 'smart', label: 'Smart' },
+      { id: 'rush', label: 'Rush' },
+      { id: 'deep', label: 'Deep' },
+    ],
+    toModelArgs: (modelId: string): string[] => ['--mode', modelId],
+  },
+} satisfies Partial<Record<AgentProviderId, AgentModelSupport>>;
+
+export type ModelSelectableProviderId = keyof typeof AGENT_MODEL_SUPPORT;
+
+/** Providers that expose a curated model/reasoning selection. */
+export const MODEL_SELECTABLE_PROVIDER_IDS = Object.keys(
+  AGENT_MODEL_SUPPORT
+) as ModelSelectableProviderId[];
+
+export function getAgentModelSupport(providerId: AgentProviderId): AgentModelSupport | undefined {
+  return (AGENT_MODEL_SUPPORT as Partial<Record<AgentProviderId, AgentModelSupport>>)[providerId];
+}
+
+export function providerSupportsModelSelection(providerId: AgentProviderId): boolean {
+  return getAgentModelSupport(providerId) !== undefined;
+}
+
+/**
+ * Translate a stored model selection into CLI arguments for the given provider.
+ *
+ * Returns an empty array when the provider has no curated model support or when
+ * the selection is empty. Stored values are checked against the current curated
+ * option ids before being passed as discrete argv tokens (never through a shell),
+ * so stale settings are ignored instead of breaking new sessions.
+ */
+export function buildAgentModelArgs(
+  providerId: AgentProviderId,
+  selection: AgentModelSelection | undefined
+): string[] {
+  const support = getAgentModelSupport(providerId);
+  if (!support || !selection) return [];
+
+  const args: string[] = [];
+
+  const model = selection.model?.trim();
+  if (model && support.models.some((option) => option.id === model)) {
+    args.push(...support.toModelArgs(model));
+  }
+
+  const effort = selection.reasoningEffort?.trim();
+  if (
+    effort &&
+    support.reasoning?.some((option) => option.id === effort) &&
+    support.toReasoningArgs
+  ) {
+    args.push(...support.toReasoningArgs(effort));
+  }
+
+  return args;
+}

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
@@ -107,23 +107,41 @@ export function getReasoningOptions(
  * being passed as discrete argv tokens (never through a shell), so stale
  * settings are ignored instead of breaking new sessions.
  */
-export function buildAgentModelArgs(
+export function sanitizeAgentModelSelection(
   providerId: AgentProviderId,
   selection: AgentModelSelection | undefined
-): string[] {
+): AgentModelSelection {
   const support = getAgentModelSupport(providerId);
-  if (!support || !selection) return [];
+  if (!support || !selection) return {};
 
   const rawModel = selection.model?.trim();
-  const model =
-    rawModel && support.models.some((option) => option.id === rawModel && !option.disabled)
-      ? rawModel
-      : undefined;
+  const model = rawModel
+    ? support.models.find((option) => option.id === rawModel && !option.disabled)?.id
+    : undefined;
+
+  // If a persisted model id is now invalid/disabled, drop the paired effort too.
+  // Otherwise a provider-level effort could be applied without its intended model.
+  if (rawModel && !model) return {};
 
   const rawEffort = selection.reasoningEffort?.trim();
   const reasoning = reasoningOptionsForModel(support, model);
   const effort =
     rawEffort && reasoning.some((option) => option.id === rawEffort) ? rawEffort : undefined;
 
-  return support.buildArgs(model, effort);
+  return {
+    ...(model ? { model } : {}),
+    ...(effort ? { reasoningEffort: effort } : {}),
+  };
+}
+
+export function buildAgentModelArgs(
+  providerId: AgentProviderId,
+  selection: AgentModelSelection | undefined
+): string[] {
+  const support = getAgentModelSupport(providerId);
+  if (!support) return [];
+
+  const { model, reasoningEffort } = sanitizeAgentModelSelection(providerId, selection);
+
+  return support.buildArgs(model, reasoningEffort);
 }

--- a/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-models.ts
@@ -15,6 +15,12 @@ export type AgentModelOption = {
    * the provider-level reasoning applies.
    */
   reasoning?: AgentReasoningOption[];
+  /**
+   * When true, the model is listed but cannot be selected (e.g. not yet
+   * enabled). It is also ignored when building CLI args, so a stale stored
+   * selection never reaches the agent.
+   */
+  disabled?: boolean;
 };
 
 /**
@@ -110,7 +116,9 @@ export function buildAgentModelArgs(
 
   const rawModel = selection.model?.trim();
   const model =
-    rawModel && support.models.some((option) => option.id === rawModel) ? rawModel : undefined;
+    rawModel && support.models.some((option) => option.id === rawModel && !option.disabled)
+      ? rawModel
+      : undefined;
 
   const rawEffort = selection.reasoningEffort?.trim();
   const reasoning = reasoningOptionsForModel(support, model);

--- a/apps/emdash-desktop/src/shared/core/app-settings.ts
+++ b/apps/emdash-desktop/src/shared/core/app-settings.ts
@@ -2,6 +2,8 @@ import type z from 'zod';
 import {
   appSettingsSchema,
   type agentAutoApproveDefaultsSchema,
+  type agentModelSelectionSchema,
+  type agentModelsSchema,
   type changesViewModeSchema,
   type interfaceSettingsSchema,
   type localProjectSettingsSchema,
@@ -18,6 +20,8 @@ export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
 export type NotificationSettings = z.infer<typeof notificationSettingsSchema>;
 export type TaskSettings = z.infer<typeof taskSettingsSchema>;
 export type AgentAutoApproveDefaults = z.infer<typeof agentAutoApproveDefaultsSchema>;
+export type AgentModels = z.infer<typeof agentModelsSchema>;
+export type AgentModelSelectionSetting = z.infer<typeof agentModelSelectionSchema>;
 export type TerminalSettings = z.infer<typeof terminalSettingsSchema>;
 export type Theme = z.infer<typeof themeSchema>;
 


### PR DESCRIPTION
### Description
- adds per-provider default model/reasoning setting
- applies defaults when starting local and ssh conversations
- adds a new models settings card

### Screenshot/Recording (if applicable)
https://streamable.com/xhw2la

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
