### PR TITLE
fix(tasks): keep agent input focused after sidebar switch

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -1,5 +1,6 @@
 import { makeObservable, observable, runInAction } from 'mobx';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { PtySession } from '@renderer/lib/pty/pty-session';
 import type { Conversation } from '@shared/core/conversations/conversations';
 import type { Task } from '@shared/core/tasks/tasks';
 import type { Terminal } from '@shared/core/terminals/terminals';
@@ -259,6 +260,31 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 });
 
 describe('WorkspaceViewModel default conversation tab', () => {
+  it('refocuses the active conversation terminal when returning to the conversations sidebar', () => {
+    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    const viewModel = makeViewModel();
+    const focus = vi.fn();
+
+    runInAction(() => {
+      addConversation(conversations, { id: 'conversation-1' });
+      viewModel.tabManager.openConversation('conversation-1');
+      conversations.sessions.set('conversation-1', {
+        pty: { terminal: { focus } },
+        destroy: vi.fn(),
+      } as unknown as PtySession);
+    });
+
+    viewModel.setFocusedRegion('main');
+    viewModel.setSidebarTab('files');
+    expect(focus).not.toHaveBeenCalled();
+
+    viewModel.setSidebarTab('conversations');
+
+    expect(focus).toHaveBeenCalledTimes(1);
+
+    viewModel.dispose();
+  });
+
   it('opens the initial conversation for a new task without restored tab state', async () => {
     const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
     const viewModel = makeViewModel();

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -282,6 +282,11 @@ describe('WorkspaceViewModel default conversation tab', () => {
 
     expect(focus).toHaveBeenCalledTimes(1);
 
+    viewModel.setFocusedRegion('bottom');
+    viewModel.setSidebarTab('files');
+    viewModel.setSidebarTab('conversations');
+    expect(focus).toHaveBeenCalledTimes(1);
+
     viewModel.dispose();
   });
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -412,6 +412,9 @@ export class WorkspaceViewModel implements ILifecycle {
 
   setSidebarTab(v: SidebarTab): void {
     this.sidebarTab = v;
+    if (v === 'conversations' && this.focusedRegion === 'main') {
+      this.focusActiveConversationTerminal();
+    }
   }
 
   setSidebarCollapsed(collapsed: boolean): void {
@@ -439,6 +442,12 @@ export class WorkspaceViewModel implements ILifecycle {
 
   setTerminalDrawerActiveItem(item: TerminalDrawerActiveItem): void {
     this.terminalDrawerActiveItem = item;
+  }
+
+  focusActiveConversationTerminal(): void {
+    const conversationId = this.tabManager.activeConversationId;
+    if (!conversationId) return;
+    conversationRegistry.get(this.taskId)?.sessions.get(conversationId)?.pty?.terminal.focus();
   }
 
   /** Opens the terminal drawer and always creates a new terminal session. */

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -444,7 +444,7 @@ export class WorkspaceViewModel implements ILifecycle {
     this.terminalDrawerActiveItem = item;
   }
 
-  focusActiveConversationTerminal(): void {
+  private focusActiveConversationTerminal(): void {
     const conversationId = this.tabManager.activeConversationId;
     if (!conversationId) return;
     conversationRegistry.get(this.taskId)?.sessions.get(conversationId)?.pty?.terminal.focus();


### PR DESCRIPTION
### Description
- keep agent input focused after switching back to conversation in sidebar
- refocuses the active conversation pty onyl when main content has focus

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
