### PR TITLE
chore(release): bump desktop version to 1.1.34

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emdash/emdash-desktop",
-  "version": "1.1.33",
+  "version": "1.1.34",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",


### PR DESCRIPTION
## Summary
- Bumps the Electron desktop app package version from 1.1.33 to 1.1.34.

## Impact
- Updates the app manifest version used by desktop packaging and release metadata.

## Validation
- `git diff --check`
- `node -e "JSON.parse(require('fs').readFileSync('apps/emdash-desktop/package.json','utf8')); console.log('package json valid')"`
- `./node_modules/.bin/oxfmt --check apps/emdash-desktop/package.json`

Note: `pnpm run format:check` was attempted but the active global pnpm is 8.13.1 while this repo requires >=10.28.0; the touched file was validated with the local formatter binary instead.