### PR TITLE
feat(codex): enable HTTP MCP transport

### DIFF
--- a/agents/integrations/mcp.md
+++ b/agents/integrations/mcp.md
@@ -14,10 +14,6 @@
 - provider-specific config formats are handled through adapters in `src/main/core/mcp/utils/`
 - the renderer MCP UI manages installed servers and catalog entries
 
-## Important Constraint
-
-- Codex currently supports stdio MCP servers only
-
 ## Rules
 
 - do not assume all providers support the same MCP transport types

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -48,7 +48,7 @@ export const plugin = definePlugin(
     mcp: {
       kind: 'supported',
       scope: 'global',
-      supportedTransports: ['stdio'],
+      supportedTransports: ['stdio', 'http'],
     },
     models: {
       kind: 'none',

--- a/packages/shared/src/agents/plugins/helpers/mcp.test.ts
+++ b/packages/shared/src/agents/plugins/helpers/mcp.test.ts
@@ -1,6 +1,7 @@
+import { parse as parseTOML } from 'smol-toml';
 import { describe, expect, it } from 'vitest';
 import type { PluginFs } from '../../runtime/fs';
-import { createMcpAdapter, passthroughMcpAdapter } from './mcp';
+import { codexMcpAdapter, createMcpAdapter, passthroughMcpAdapter } from './mcp';
 
 // ── In-memory PluginFs ───────────────────────────────────────────────────────
 
@@ -192,5 +193,62 @@ describe('createMcpAdapter with multiple legacyReadPaths', () => {
       const parsed = JSON.parse(content) as Record<string, unknown>;
       expect((parsed.mcpServers as Record<string, unknown>).gone).toBeUndefined();
     }
+  });
+});
+
+// ── Codex TOML adapter ──────────────────────────────────────────────────────
+
+describe('codexMcpAdapter', () => {
+  const adapter = codexMcpAdapter('.codex/config.toml');
+
+  it('maps HTTP headers to Codex http_headers on write', async () => {
+    const fs = createMemoryFs({
+      '.codex/config.toml': 'model = "gpt-5"\n',
+    });
+
+    await adapter.writeServers(fs, [
+      {
+        name: 'docs',
+        transport: 'http',
+        type: 'http',
+        url: 'https://example.com/mcp',
+        headers: { Authorization: 'Bearer token' },
+      },
+    ]);
+
+    const raw = await fs.read('.codex/config.toml');
+    const parsed = parseTOML(raw!) as Record<string, unknown>;
+    const servers = parsed.mcp_servers as Record<string, Record<string, unknown>>;
+
+    expect(parsed.model).toBe('gpt-5');
+    expect(servers.docs.url).toBe('https://example.com/mcp');
+    expect(servers.docs.type).toBeUndefined();
+    expect(servers.docs.transport).toBeUndefined();
+    expect(servers.docs.headers).toBeUndefined();
+    expect(servers.docs.http_headers).toEqual({ Authorization: 'Bearer token' });
+  });
+
+  it('reads Codex HTTP headers into the canonical headers field', async () => {
+    const fs = createMemoryFs({
+      '.codex/config.toml': [
+        '[mcp_servers.docs]',
+        'url = "https://example.com/mcp"',
+        '',
+        '[mcp_servers.docs.http_headers]',
+        'Authorization = "Bearer token"',
+      ].join('\n'),
+    });
+
+    const result = await adapter.readServers(fs);
+
+    expect(result).toHaveLength(1);
+    expect(result[0]).toMatchObject({
+      name: 'docs',
+      transport: 'http',
+      type: 'http',
+      url: 'https://example.com/mcp',
+      headers: { Authorization: 'Bearer token' },
+    });
+    expect(result[0].http_headers).toBeUndefined();
   });
 });

--- a/packages/shared/src/agents/plugins/helpers/mcp.ts
+++ b/packages/shared/src/agents/plugins/helpers/mcp.ts
@@ -181,7 +181,7 @@ export function cursorMcpAdapter(configPath = '.cursor/mcp.json') {
 }
 
 /**
- * Codex adapter — TOML file, stdio-only (HTTP servers are dropped).
+ * Codex adapter — TOML file with stdio and streamable HTTP servers.
  * Config: ~/.codex/config.toml, key: mcp_servers.
  */
 export function codexMcpAdapter(configPath = '.codex/config.toml') {
@@ -191,13 +191,36 @@ export function codexMcpAdapter(configPath = '.codex/config.toml') {
     serversKey: 'mcp_servers',
     toNative(s) {
       const entry = deepClone(s) as Record<string, unknown>;
-      // Codex only supports stdio; type field is omitted
+      const isHttp =
+        entry.transport === 'http' ||
+        entry.type === 'http' ||
+        (typeof entry.url === 'string' && typeof entry.command !== 'string');
+
       delete entry.name;
+      delete entry.transport;
       delete entry.type;
+
+      if (isHttp && entry.headers && !entry.http_headers) {
+        entry.http_headers = entry.headers;
+        delete entry.headers;
+      }
+
       return entry;
     },
     fromNative(name, raw) {
-      return { name, ...deepClone(raw) } as McpServerRegistration;
+      const entry = deepClone(raw) as Record<string, unknown>;
+      const isHttp = typeof entry.url === 'string' && typeof entry.command !== 'string';
+
+      if (isHttp) {
+        if (entry.http_headers && !entry.headers) {
+          entry.headers = entry.http_headers;
+        }
+        delete entry.http_headers;
+        entry.transport = 'http';
+        entry.type = 'http';
+      }
+
+      return { name, ...entry } as McpServerRegistration;
     },
   });
 }


### PR DESCRIPTION
## Summary
- Enable HTTP MCP transport support for the Codex provider
- Map Emdash HTTP headers to Codex http_headers in the MCP adapter
- Remove the stale Codex stdio-only MCP note

## Tests
- pnpm --filter @emdash/shared exec vitest run src/agents/plugins/helpers/mcp.test.ts
- pnpm --filter @emdash/plugins exec vitest run src/agents/impl/index.test.ts
- pnpm --filter @emdash/shared run typecheck
- pnpm --filter @emdash/plugins run typecheck
- git diff --check