### PR TITLE
fix(pi): use official extension API type

### DIFF
--- a/packages/plugins/src/agents/impl/pi/plugin-file.ts
+++ b/packages/plugins/src/agents/impl/pi/plugin-file.ts
@@ -1,9 +1,6 @@
 // Verbatim source of the Pi emdash extension, embedded as a string constant.
 export const PI_EXTENSION_CONTENT = `\
-type ExtensionAPI = {
-  on(event: 'agent_end', handler: () => unknown): void;
-  on(event: 'session_shutdown', handler: (event: { reason: string }) => unknown): void;
-};
+import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 async function notifyEmdash(
   eventType: 'stop' | 'error' | 'notification',


### PR DESCRIPTION
### Description
- use pi's official `ExtensionAPI` type import per docs https://pi.dev/docs/latest/extensions 
- hook behavior is unchanged

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
