### PR TITLE
fix(amp): update hook plugin api

### DIFF
--- a/packages/plugins/src/agents/impl/amp/plugin-file.ts
+++ b/packages/plugins/src/agents/impl/amp/plugin-file.ts
@@ -2,12 +2,7 @@
 // This file is intentionally kept as plain TypeScript so it can be inlined at runtime
 // without a bundler asset pipeline.
 export const AMP_PLUGIN_CONTENT = `\
-// @i-know-the-amp-plugin-api-is-wip-and-very-experimental-right-now
-
-type AmpPluginAPI = {
-  on(event: 'agent.start', handler: () => unknown): void;
-  on(event: 'agent.end', handler: () => unknown): void;
-};
+import type { PluginAPI } from '@ampcode/plugin';
 
 async function notifyEmdash(eventType: 'start' | 'stop', body: Record<string, unknown> = {}) {
   const port = process.env.EMDASH_HOOK_PORT;
@@ -32,7 +27,7 @@ async function notifyEmdash(eventType: 'start' | 'stop', body: Record<string, un
   }
 }
 
-export default function (amp: AmpPluginAPI) {
+export default function (amp: PluginAPI) {
   amp.on('agent.start', async () => {
     await notifyEmdash('start');
   });


### PR DESCRIPTION
### Description
- update amp hook plugin to current `PluginAPI`
- remove obsolete WIP comment
- hook is unchaged otherwise

docs: https://ampcode.com/manual/plugin-api

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
