### PR TITLE
fix(tasks): preserve dirty diff edits

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
@@ -104,7 +104,7 @@ export const EditorProvider = observer(function EditorProvider({
 
     addMonacoKeyboardShortcuts(editor, m, {
       onSave: () => {
-        const path = paneTabManager.activeFilePath;
+        const path = paneTabManager.activeEditablePath;
         if (path) void editorView.saveFile(path);
       },
       onSaveAll: () => {
@@ -159,7 +159,7 @@ export const EditorProvider = observer(function EditorProvider({
         return;
       }
 
-      const path = paneTabManager.activeFilePath;
+      const path = paneTabManager.activeEditablePath;
       if (!path) return;
 
       event.preventDefault();

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
@@ -1,5 +1,6 @@
 import { computed, makeObservable, observable, reaction, runInAction } from 'mobx';
 import type { TabGroupManagerStore } from '@renderer/features/tasks/tabs/tab-group-manager-store';
+import { getEditableBufferPath } from '@renderer/features/tasks/tabs/tab-manager-store';
 import { getFileKind } from '@renderer/lib/editor/fileKind';
 import { rpc } from '@renderer/lib/ipc';
 import { showModal } from '@renderer/lib/modal/modal-provider';
@@ -52,11 +53,13 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
       snapshot: computed,
     });
 
-    // Reactive model lifecycle: register/unregister Monaco models as file tabs open/close
-    // across ALL panes. A model stays registered as long as any pane has the file open.
+    // Reactive model lifecycle: register/unregister Monaco models as editable tabs open/close
+    // across ALL panes. This includes file tabs and working-tree diff tabs so unsaved diff
+    // edits survive renderer unmounts when users switch tabs. A model stays registered as
+    // long as any pane has the editable path open.
     this.disposers.push(
       reaction(
-        () => this.tabGroupManager.allOpenFilePaths,
+        () => this.tabGroupManager.allOpenEditablePaths,
         (current, previous = []) => {
           const prev = new Set(previous);
           const curr = new Set(current);
@@ -82,10 +85,11 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
       for (const { tabManager } of tabGroupManager.groups) {
         const entry = tabManager.entries.get(tabId);
         if (entry !== undefined) {
-          if (entry.kind === 'file') {
-            const uri = buildMonacoModelPath(this.modelRootPath, entry.path);
+          const editablePath = getEditableBufferPath(entry);
+          if (editablePath) {
+            const uri = buildMonacoModelPath(this.modelRootPath, editablePath);
             if (modelRegistry.isDirty(uri)) {
-              const result = await this._confirmClose(entry.path);
+              const result = await this._confirmClose(editablePath);
               if (result === 'cancel') return;
             }
           }
@@ -154,7 +158,7 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
   }
 
   async saveAllFiles(): Promise<void> {
-    const dirtyPaths = this.openFilePaths.filter((path) =>
+    const dirtyPaths = this.tabGroupManager.allOpenEditablePaths.filter((path) =>
       modelRegistry.isDirty(buildMonacoModelPath(this.modelRootPath, path))
     );
     for (const path of dirtyPaths) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
@@ -314,15 +314,15 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
     modelRegistry.unregisterModel(modelRegistry.toDiskUri(uri));
     modelRegistry.unregisterModel(modelRegistry.toGitUri(uri, HEAD_REF));
 
-    if (!this._hasOpenTabForPath(filePath)) {
+    if (!this._hasOpenEditableTabForPath(filePath)) {
       void rpc.workspace.editor.clearBuffer(this.projectId, this.workspaceId, filePath);
     }
   }
 
-  private _hasOpenTabForPath(filePath: string): boolean {
+  private _hasOpenEditableTabForPath(filePath: string): boolean {
     for (const { tabManager } of this.tabGroupManager.groups) {
       for (const entry of tabManager.entries.values()) {
-        if ((entry.kind === 'file' || entry.kind === 'diff') && entry.path === filePath) {
+        if (getEditableBufferPath(entry) === filePath) {
           return true;
         }
       }

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/stores/file-model-lifecycle-store.ts
@@ -313,6 +313,20 @@ export class FileModelLifecycleStore implements Snapshottable<EditorViewSnapshot
     modelRegistry.unregisterModel(uri);
     modelRegistry.unregisterModel(modelRegistry.toDiskUri(uri));
     modelRegistry.unregisterModel(modelRegistry.toGitUri(uri, HEAD_REF));
-    void rpc.workspace.editor.clearBuffer(this.projectId, this.workspaceId, filePath);
+
+    if (!this._hasOpenTabForPath(filePath)) {
+      void rpc.workspace.editor.clearBuffer(this.projectId, this.workspaceId, filePath);
+    }
+  }
+
+  private _hasOpenTabForPath(filePath: string): boolean {
+    for (const { tabManager } of this.tabGroupManager.groups) {
+      for (const entry of tabManager.entries.values()) {
+        if ((entry.kind === 'file' || entry.kind === 'diff') && entry.path === filePath) {
+          return true;
+        }
+      }
+    }
+    return false;
   }
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-group-manager-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-group-manager-store.ts
@@ -56,6 +56,7 @@ export class TabGroupManagerStore {
       paneSizes: observable,
       focusedGroup: computed,
       allOpenFilePaths: computed,
+      allOpenEditablePaths: computed,
       registerCloseHandler: action,
       splitRight: action,
       openConversationInRightSplit: action,
@@ -82,6 +83,16 @@ export class TabGroupManagerStore {
     const seen = new Set<string>();
     for (const { tabManager } of this.groups) {
       for (const path of tabManager.openFilePaths) {
+        seen.add(path);
+      }
+    }
+    return [...seen];
+  }
+
+  get allOpenEditablePaths(): string[] {
+    const seen = new Set<string>();
+    for (const { tabManager } of this.groups) {
+      for (const path of tabManager.openEditablePaths) {
         seen.add(path);
       }
     }

--- a/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.test.ts
@@ -51,6 +51,15 @@ function workingTreeDiff(path = 'src/example.ts') {
   };
 }
 
+function stagedDiff(path = 'src/example.ts') {
+  return {
+    path,
+    type: 'git' as const,
+    group: 'staged' as const,
+    originalRef: ORIGINAL_REF,
+  };
+}
+
 describe('TabManagerStore browser tabs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -236,6 +245,24 @@ describe('TabManagerStore diff tabs', () => {
       path: second.path,
       isPreview: true,
       isDirty: false,
+    });
+  });
+
+  it('does not expose buffer URIs for non-editable diff tabs', () => {
+    const manager = createTabManager();
+    const activeFile = stagedDiff();
+    const bufferUri = buildMonacoModelPath('workspace:workspace-1', activeFile.path);
+
+    manager.openDiff(activeFile);
+    modelRegistry.dirtyUris.add(bufferUri);
+
+    expect(manager.activeEditablePath).toBeNull();
+    expect(manager.openEditablePaths).toEqual([]);
+    expect(manager.resolvedTabs[0]).toMatchObject({
+      kind: 'diff',
+      path: activeFile.path,
+      isDirty: false,
+      bufferUri: '',
     });
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.test.ts
@@ -2,6 +2,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { browserDiagnosticsStore } from '@renderer/features/browser/browser-diagnostics-store';
 import { browserSessionStore } from '@renderer/features/browser/browser-session-store';
 import { events } from '@renderer/lib/ipc';
+import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
+import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
+import type { GitObjectRef } from '@shared/core/git/git';
 import { browserOpenInNewTabChannel } from '@shared/events/browserEvents';
 import { TabManagerStore } from './tab-manager-store';
 
@@ -37,9 +40,24 @@ function createTabManager(): TabManagerStore {
   return new TabManagerStore(() => null, 'workspace-1', 'project-1', 'task-1');
 }
 
+const ORIGINAL_REF: GitObjectRef = { kind: 'commit', sha: 'abc123' };
+
+function workingTreeDiff(path = 'src/example.ts') {
+  return {
+    path,
+    type: 'disk' as const,
+    group: 'disk' as const,
+    originalRef: ORIGINAL_REF,
+  };
+}
+
 describe('TabManagerStore browser tabs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    modelRegistry.dirtyUris.clear();
+    vi.mocked(modelRegistry.isDirty).mockImplementation((uri: string) =>
+      modelRegistry.dirtyUris.has(uri)
+    );
     browserDiagnosticsStore.clear();
     browserSessionStore.clear();
   });
@@ -167,5 +185,57 @@ describe('TabManagerStore browser tabs', () => {
     expect(
       manager.resolvedTabs[1]?.kind === 'browser' ? manager.resolvedTabs[1].session.currentUrl : ''
     ).toBe('https://target.example/path');
+  });
+});
+
+describe('TabManagerStore diff tabs', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    modelRegistry.dirtyUris.clear();
+    vi.mocked(modelRegistry.isDirty).mockImplementation((uri: string) =>
+      modelRegistry.dirtyUris.has(uri)
+    );
+  });
+
+  it('exposes working-tree diff tabs as editable buffers', () => {
+    const manager = createTabManager();
+    const activeFile = workingTreeDiff();
+
+    manager.openDiff(activeFile);
+    const bufferUri = buildMonacoModelPath('workspace:workspace-1', activeFile.path);
+    modelRegistry.dirtyUris.add(bufferUri);
+
+    expect(manager.activeEditablePath).toBe(activeFile.path);
+    expect(manager.openEditablePaths).toEqual([activeFile.path]);
+    expect(manager.resolvedTabs[0]).toMatchObject({
+      kind: 'diff',
+      path: activeFile.path,
+      isDirty: true,
+      bufferUri,
+    });
+  });
+
+  it('keeps a dirty working-tree diff preview instead of replacing it', () => {
+    const manager = createTabManager();
+    const first = workingTreeDiff('src/first.ts');
+    const second = workingTreeDiff('src/second.ts');
+
+    manager.openDiffPreview(first);
+    modelRegistry.dirtyUris.add(buildMonacoModelPath('workspace:workspace-1', first.path));
+    manager.openDiffPreview(second);
+
+    expect(manager.resolvedTabs).toHaveLength(2);
+    expect(manager.resolvedTabs[0]).toMatchObject({
+      kind: 'diff',
+      path: first.path,
+      isPreview: false,
+      isDirty: true,
+    });
+    expect(manager.resolvedTabs[1]).toMatchObject({
+      kind: 'diff',
+      path: second.path,
+      isPreview: true,
+      isDirty: false,
+    });
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.ts
@@ -75,6 +75,12 @@ export class BrowserTabEntry {
 
 export type TabEntry = FileTabStore | DiffTabStore | ConversationTabEntry | BrowserTabEntry;
 
+export function getEditableBufferPath(entry: TabEntry): string | null {
+  if (entry.kind === 'file') return entry.isExternal ? null : entry.path;
+  if (entry.kind === 'diff') return entry.diffGroup === 'disk' ? entry.path : null;
+  return null;
+}
+
 function optionalRefsEqual(left: GitObjectRef | undefined, right: GitObjectRef | undefined) {
   if (left === undefined || right === undefined) return left === right;
   return refsEqual(left, right);
@@ -117,6 +123,8 @@ export type ResolvedDiffTab = {
   kind: 'diff';
   tabId: string;
   path: string;
+  isDirty: boolean;
+  bufferUri: string;
   diffGroup: 'disk' | 'staged' | 'git' | 'pr';
   originalRef: GitObjectRef;
   modifiedRef?: GitObjectRef;
@@ -189,10 +197,12 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
       activeConversationId: computed,
       activeFileEntry: computed,
       activeFilePath: computed,
+      activeEditablePath: computed,
       activeDiffEntry: computed,
       previewFileEntry: computed,
       previewDiffEntry: computed,
       openFilePaths: computed,
+      openEditablePaths: computed,
       resolvedTabs: computed,
       snapshot: computed,
       openConversation: action,
@@ -315,6 +325,11 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
     return this.activeFileEntry?.path ?? null;
   }
 
+  get activeEditablePath(): string | null {
+    const entry = this.activeDescriptor;
+    return entry ? getEditableBufferPath(entry) : null;
+  }
+
   get activeDiffEntry(): DiffTabStore | undefined {
     const desc = this.activeDescriptor;
     return desc?.kind === 'diff' ? desc : undefined;
@@ -351,6 +366,17 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
     return paths;
   }
 
+  get openEditablePaths(): string[] {
+    const paths: string[] = [];
+    for (const id of this.tabOrder) {
+      const entry = this.entries.get(id);
+      if (!entry) continue;
+      const path = getEditableBufferPath(entry);
+      if (path) paths.push(path);
+    }
+    return paths;
+  }
+
   get resolvedTabs(): ResolvedTab[] {
     const result: ResolvedTab[] = [];
     const effectiveActiveId = this.resolvedActiveTabId;
@@ -381,10 +407,13 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
           isActive: effectiveActiveId === entry.tabId,
         });
       } else if (entry.kind === 'diff') {
+        const bufferUri = buildMonacoModelPath(this.modelRootPath, entry.path);
         result.push({
           kind: 'diff',
           tabId: entry.tabId,
           path: entry.path,
+          isDirty: getEditableBufferPath(entry) !== null && modelRegistry.isDirty(bufferUri),
+          bufferUri,
           diffGroup: entry.diffGroup,
           originalRef: entry.originalRef,
           modifiedRef: entry.modifiedRef,
@@ -406,7 +435,7 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
           tabId: entry.tabId,
           path: entry.path,
           isPreview: entry.isPreview,
-          isDirty: entry.isExternal ? false : modelRegistry.dirtyUris.has(bufferUri),
+          isDirty: getEditableBufferPath(entry) !== null && modelRegistry.isDirty(bufferUri),
           bufferUri,
           isActive: effectiveActiveId === entry.tabId,
           isExternal: entry.isExternal,
@@ -612,7 +641,11 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
     }
 
     const previewEntry = this.previewDiffEntry;
-    if (previewEntry) {
+    const previewPath = previewEntry ? getEditableBufferPath(previewEntry) : null;
+    const previewUri = previewPath ? buildMonacoModelPath(this.modelRootPath, previewPath) : null;
+    const canReplace = previewEntry && (!previewUri || !modelRegistry.isDirty(previewUri));
+
+    if (canReplace && previewEntry) {
       // Replace preview in-place: remove old, insert new at same position.
       const idx = this.tabOrder.indexOf(previewEntry.tabId);
       this.entries.delete(previewEntry.tabId);
@@ -622,6 +655,8 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
       this.activeTabId = tab.tabId;
       return;
     }
+
+    if (previewEntry) previewEntry.isPreview = false;
 
     const tab = new DiffTabStore(activeFile, true, undefined, status);
     this.entries.set(tab.tabId, tab);

--- a/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/tabs/tab-manager-store.ts
@@ -407,12 +407,15 @@ export class TabManagerStore implements Snapshottable<TabManagerSnapshot> {
           isActive: effectiveActiveId === entry.tabId,
         });
       } else if (entry.kind === 'diff') {
-        const bufferUri = buildMonacoModelPath(this.modelRootPath, entry.path);
+        const editablePath = getEditableBufferPath(entry);
+        const bufferUri = editablePath
+          ? buildMonacoModelPath(this.modelRootPath, editablePath)
+          : '';
         result.push({
           kind: 'diff',
           tabId: entry.tabId,
           path: entry.path,
-          isDirty: getEditableBufferPath(entry) !== null && modelRegistry.isDirty(bufferUri),
+          isDirty: editablePath !== null && modelRegistry.isDirty(bufferUri),
           bufferUri,
           diffGroup: entry.diffGroup,
           originalRef: entry.originalRef,

--- a/apps/emdash-desktop/src/renderer/features/tasks/view/tab-bar/diff-tab-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/view/tab-bar/diff-tab-item.tsx
@@ -32,6 +32,7 @@ export const DiffTabItem = observer(function DiffTabItem({
 }) {
   const fileName = tab.path.split('/').pop() ?? 'Untitled';
   const suffix = diffGroupSuffix(tab.diffGroup);
+  const hasUnsavedChanges = tab.isDirty;
 
   return (
     <TabItemShell
@@ -57,7 +58,12 @@ export const DiffTabItem = observer(function DiffTabItem({
         onClose={onClose}
         ariaLabel={`Close ${fileName} ${suffix}`}
         statusIndicator={
-          tab.status ? (
+          hasUnsavedChanges ? (
+            <div
+              className="size-2 rounded-full bg-foreground group-hover:opacity-0"
+              title="Unsaved changes"
+            />
+          ) : tab.status ? (
             <span className="transition-opacity group-hover:opacity-0">
               <GitChangeStatusIcon status={tab.status} className="size-4" />
             </span>


### PR DESCRIPTION
### Description
- fix saving edits made in diff tabs
- show dirty state on diff tabs
- keep dirty diff previews open 

### Screenshot/Recording (if applicable)
https://streamable.com/g0c66y

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
