### PR TITLE
fix(settings): standardize update card button heights

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/settings/components/UpdateCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/UpdateCard.tsx
@@ -40,13 +40,12 @@ export const UpdateCard = observer(function UpdateCard(): React.JSX.Element {
                 type="button"
                 variant="outline"
                 size="icon"
-                className="h-8 w-8"
                 onClick={() => update.check()}
                 disabled={update.state.status === 'checking'}
                 aria-label="Check for updates"
               >
                 <RefreshCw
-                  className={`h-3 w-3 ${update.state.status === 'checking' ? 'animate-spin' : ''}`}
+                  className={`size-4 ${update.state.status === 'checking' ? 'animate-spin' : ''}`}
                 />
               </Button>
             )}
@@ -143,42 +142,32 @@ export const UpdateCard = observer(function UpdateCard(): React.JSX.Element {
     switch (update.state.status) {
       case 'available':
         return (
-          <Button
-            size="sm"
-            variant="default"
-            onClick={() => update.download()}
-            className="h-7 text-xs"
-          >
-            <Download className="mr-1.5 h-3 w-3" />
+          <Button variant="default" onClick={() => update.download()}>
+            <Download className="size-4" />
             Download
           </Button>
         );
 
       case 'downloading':
         return (
-          <Button size="sm" variant="outline" disabled className="h-7 text-xs">
-            <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+          <Button variant="outline" disabled>
+            <Loader2 className="size-4 animate-spin" />
             Downloading
           </Button>
         );
 
       case 'downloaded':
         return (
-          <Button
-            size="sm"
-            variant="default"
-            onClick={() => update.install()}
-            className="h-7 text-xs"
-          >
-            <RefreshCw className="mr-1.5 h-3 w-3" />
+          <Button variant="default" onClick={() => update.install()}>
+            <RefreshCw className="size-4" />
             Restart
           </Button>
         );
 
       case 'installing':
         return (
-          <Button size="sm" variant="outline" disabled className="h-7 text-xs">
-            <Loader2 className="mr-1.5 h-3 w-3 animate-spin" />
+          <Button variant="outline" disabled>
+            <Loader2 className="size-4 animate-spin" />
             Installing
           </Button>
         );


### PR DESCRIPTION
## What

The update card on the General settings page mixed two button heights:

- the **refresh** button used `size="icon"` → **32px** (plus a redundant `h-8 w-8`)
- the **Download / Restart / Downloading / Installing** buttons used `size="sm"` → **28px** (plus a redundant `h-7 text-xs`)

So the action buttons rendered ~4px shorter than the refresh button, and shorter than the page's other primary controls (`Choose file…`, the selects), which all use the default 32px size.

## Change

Remove the ad-hoc inline height/size overrides and let height come entirely from the shared `Button` variants:

- text buttons → default size (`h-8`, 32px)
- refresh button → `size="icon"` (`size-8`)
- leading glyphs normalized to `size-4`

No behavioral change — purely visual/standardization. This also lines the card up with how the new `@emdash/ui` Button variants are meant to own sizing.

## Test

- `pnpm exec oxfmt --check` clean
- Verified against `Choose file…` / select trigger which are both 32px (`size="default"` / `data-[size=default]:h-8`)