### PR TITLE
chore: run desktop app on pnpm dev and build its deps first

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -19,6 +19,8 @@
   "main": "./out/main/index.js",
   "scripts": {
     "d": "pnpm install && pnpm run dev",
+    "build:deps": "pnpm --filter \"@emdash/emdash-desktop^...\" build",
+    "predev": "pnpm run build:deps",
     "dev": "electron-vite dev",
     "dev:debug": "VITE_LOG_LEVEL=debug electron-vite dev",
     "dev:main": "electron-vite dev --watch main",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,8 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "pnpm -r run dev",
+    "dev": "pnpm --filter @emdash/emdash-desktop dev",
+    "dev:all": "pnpm -r run dev",
     "build": "pnpm -r run build",
     "test": "pnpm -r run test",
     "lint": "pnpm -r run lint",


### PR DESCRIPTION
Running the desktop dev server crashed on a cold checkout because its workspace deps (`@emdash/plugins`, `@emdash/shared`, `@emdash/ui`) weren't built:

```
ERR_MODULE_NOT_FOUND: @emdash/plugins/dist/agents.mjs
```

**Fix:** a `predev` hook builds those deps automatically before `electron-vite dev`.

**Scripts:**
- root `dev` → runs the desktop app (the common case)
- root `dev:all` → run every package's watcher (previous `pnpm -r run dev`)
- app `build:deps` / `predev` → build the app's workspace deps first

`pnpm dev` now just works.

_Note: `dev:main`/`dev:renderer`/`dev:debug` don't get the hook (pnpm pre-hooks are per-name); run `pnpm dev` once or `pnpm --filter @emdash/emdash-desktop build:deps` first._