### PR TITLE
feat(context-bar): keep shortcut active when hidden

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/settings/components/InterfaceSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/InterfaceSettingsCard.tsx
@@ -21,7 +21,7 @@ const InterfaceSettingsCard: React.FC = () => {
     <div className="flex flex-col gap-4">
       <SettingRow
         title="Context bar"
-        description="Hide the conversation context actions if they obstruct your viewport."
+        description="Hide the on-screen context trigger. The keyboard shortcut still works."
         control={
           <>
             <ResetToDefaultButton

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/add-context-popover.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/add-context-popover.tsx
@@ -14,6 +14,7 @@ import {
 } from '@renderer/lib/ui/combobox';
 import { Kbd } from '@renderer/lib/ui/kbd';
 import { Shortcut } from '@renderer/lib/ui/shortcut';
+import { cn } from '@renderer/utils/utils';
 import { ProviderLogo } from '../components/issue-selector/issue-selector';
 import { buildContextActionText, type ContextAction } from './context-actions';
 
@@ -76,6 +77,7 @@ export function ActionItemRow({ action }: { action: ContextAction }) {
 export interface AddContextPopoverProps {
   actions: ContextAction[];
   disabled: boolean;
+  hideTrigger?: boolean;
   isActivePane?: boolean;
   onApplyAction: (
     text: string,
@@ -90,6 +92,7 @@ export interface AddContextPopoverProps {
 export function AddContextPopover({
   actions,
   disabled,
+  hideTrigger = false,
   isActivePane = true,
   onApplyAction,
   renderTrigger,
@@ -175,13 +178,17 @@ export function AddContextPopover({
           if (event.button !== 0) blockComboboxOpenForContextMenu();
           blockSyntheticClickAfterContextMenu(event);
         }}
-        className={
-          renderTrigger
-            ? undefined
-            : 'flex h-6 min-w-[160px] items-center justify-between gap-1.5 rounded-lg border-border bg-background-secondary-2 px-2 text-xs font-normal text-foreground-muted transition-colors hover:bg-background-secondary-3 hover:text-foreground disabled:pointer-events-none'
-        }
+        aria-hidden={hideTrigger || undefined}
+        tabIndex={hideTrigger ? -1 : undefined}
+        className={cn(
+          hideTrigger
+            ? 'pointer-events-none absolute bottom-0 left-1/2 size-px -translate-x-1/2 overflow-hidden border-0 p-0 opacity-0'
+            : renderTrigger
+              ? undefined
+              : 'flex h-6 min-w-[160px] items-center justify-between gap-1.5 rounded-lg border-border bg-background-secondary-2 px-2 text-xs font-normal text-foreground-muted transition-colors hover:bg-background-secondary-3 hover:text-foreground disabled:pointer-events-none'
+        )}
       >
-        {renderTrigger ? (
+        {hideTrigger ? null : renderTrigger ? (
           renderTrigger({ open, disabled })
         ) : (
           <>

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/add-context-popover.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/add-context-popover.tsx
@@ -77,7 +77,9 @@ export function ActionItemRow({ action }: { action: ContextAction }) {
 export interface AddContextPopoverProps {
   actions: ContextAction[];
   disabled: boolean;
+  emptyMessage?: string;
   hideTrigger?: boolean;
+  hotkeyEnabled?: boolean;
   isActivePane?: boolean;
   onApplyAction: (
     text: string,
@@ -92,7 +94,9 @@ export interface AddContextPopoverProps {
 export function AddContextPopover({
   actions,
   disabled,
+  emptyMessage = 'No context found',
   hideTrigger = false,
+  hotkeyEnabled,
   isActivePane = true,
   onApplyAction,
   renderTrigger,
@@ -124,7 +128,9 @@ export function AddContextPopover({
     });
   }, [query, actions]);
 
-  useHotkey(ADD_CONTEXT_HOTKEY, () => setOpen((v) => !v), { enabled: !disabled && isActivePane });
+  useHotkey(ADD_CONTEXT_HOTKEY, () => setOpen((v) => !v), {
+    enabled: (hotkeyEnabled ?? !disabled) && isActivePane,
+  });
 
   const handleConfirm = (action: ContextAction | null, opts?: { andSend?: boolean }) => {
     if (!action) return;
@@ -235,7 +241,7 @@ export function AddContextPopover({
           )}
         </ComboboxList>
         <ComboboxEmpty className="flex flex-1 items-center justify-center">
-          No context found
+          {emptyMessage}
         </ComboboxEmpty>
         <div className="flex items-center justify-end border-t px-2 py-1.5">
           <span className="flex items-center gap-1">

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
@@ -25,9 +25,13 @@ import { buildTaskContextActions, type ContextAction } from './context-actions';
 
 interface ContextBarProps {
   conversationId: string | undefined;
+  hideTrigger?: boolean;
 }
 
-export const ContextBar = observer(function ContextBar({ conversationId }: ContextBarProps) {
+export const ContextBar = observer(function ContextBar({
+  conversationId,
+  hideTrigger = false,
+}: ContextBarProps) {
   const { projectId, taskId } = useTaskViewContext();
   const { groupId } = useTabGroupContext();
   const taskView = useWorkspaceViewModel();
@@ -85,17 +89,26 @@ export const ContextBar = observer(function ContextBar({ conversationId }: Conte
     setMenuOpen(false);
   };
 
+  const contextPopover = (
+    <AddContextPopover
+      actions={actions}
+      disabled={!canApplyContext || isSavingPromptLibrary}
+      hideTrigger={hideTrigger}
+      isActivePane={isActivePane}
+      onApplyAction={handleApplyAction}
+      side="top"
+    />
+  );
+
+  if (hideTrigger) {
+    return <div className="relative h-0 w-full overflow-visible">{contextPopover}</div>;
+  }
+
   return (
     <ContextMenu open={menuOpen} onOpenChange={setMenuOpen}>
       <ContextMenuTrigger>
         <div className="flex w-full items-center justify-center bg-background-secondary-1 px-4 pb-2">
-          <AddContextPopover
-            actions={actions}
-            disabled={!canApplyContext || isSavingPromptLibrary}
-            isActivePane={isActivePane}
-            onApplyAction={handleApplyAction}
-            side="top"
-          />
+          {contextPopover}
         </div>
       </ContextMenuTrigger>
       <ContextMenuContent finalFocus={false}>

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
@@ -55,9 +55,9 @@ export const ContextBar = observer(function ContextBar({
     [task?.linkedIssue, draftComments?.comments, promptLibrary]
   );
 
-  if (!draftComments || !hasConversation || actions.length === 0) return null;
-
   const isActivePane = taskView.tabGroupManager.activeGroupId === groupId;
+  const hasVisibleContextBar = Boolean(draftComments && hasConversation && actions.length > 0);
+  const popoverActions = canApplyContext ? actions : [];
 
   const handleApplyAction = async (
     text: string,
@@ -74,7 +74,7 @@ export const ContextBar = observer(function ContextBar({
     });
 
     if (action.kind === 'draft-comments') {
-      draftComments.consumeAll();
+      draftComments?.consumeAll();
     }
 
     if (opts?.andSend) {
@@ -91,9 +91,11 @@ export const ContextBar = observer(function ContextBar({
 
   const contextPopover = (
     <AddContextPopover
-      actions={actions}
+      actions={hideTrigger ? popoverActions : actions}
       disabled={!canApplyContext || isSavingPromptLibrary}
+      emptyMessage={canApplyContext ? undefined : 'No active sessions'}
       hideTrigger={hideTrigger}
+      hotkeyEnabled={hideTrigger ? true : undefined}
       isActivePane={isActivePane}
       onApplyAction={handleApplyAction}
       side="top"
@@ -103,6 +105,8 @@ export const ContextBar = observer(function ContextBar({
   if (hideTrigger) {
     return <div className="relative h-0 w-full overflow-visible">{contextPopover}</div>;
   }
+
+  if (!hasVisibleContextBar) return null;
 
   return (
     <ContextMenu open={menuOpen} onOpenChange={setMenuOpen}>

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/conversations-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/conversations-panel.tsx
@@ -84,7 +84,7 @@ export const ConversationsPanel = observer(function ConversationsPanel() {
   }, [sessionStatus]);
 
   const onInterruptPress = activeConversation ? () => activeConversation.clearWorking() : undefined;
-  const showContextBar = !(interfaceSettings?.hideContextBar ?? false);
+  const hideContextBarTrigger = interfaceSettings?.hideContextBar ?? false;
 
   return (
     <div className="flex h-full flex-col">
@@ -132,7 +132,7 @@ export const ConversationsPanel = observer(function ConversationsPanel() {
           </PaneSizingProvider>
         </div>
       </div>
-      {showContextBar && <ContextBar conversationId={tm.activeConversationId} />}
+      <ContextBar conversationId={tm.activeConversationId} hideTrigger={hideContextBarTrigger} />
     </div>
   );
 });


### PR DESCRIPTION
- keeps ContextBar mounted when the context bar setting hides the visible trigger
- hides only the AddContextPopover trigger while preserving cmd+shift+a behavior
- updates the interface setting copy to clarify that the shortcut still works