### PR TITLE
fix(git): refresh status when head refs change

### DIFF
--- a/packages/shared/src/git/git-worktree.test.ts
+++ b/packages/shared/src/git/git-worktree.test.ts
@@ -186,6 +186,124 @@ describe('GitWorktree', () => {
     }
   });
 
+  it('refreshes staged status when an external commit advances the branch ref', async () => {
+    const repo = await makeRepo();
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
+    const updates: GitWorktreeUpdate[] = [];
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      const worktree = lease.value;
+      worktree.subscribe((update) => updates.push(update));
+
+      await writeFile(path.join(repo, 'tracked.txt'), 'external\n', 'utf8');
+      await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repo });
+
+      await eventually(() =>
+        updates.some(
+          (update) =>
+            update.kind === 'status' &&
+            update.model.kind === 'ok' &&
+            update.model.staged.some((change) => change.path === 'tracked.txt')
+        )
+          ? true
+          : undefined
+      );
+      updates.length = 0;
+
+      await execFileAsync('git', ['commit', '-m', 'external commit'], { cwd: repo });
+
+      await eventually(() =>
+        updates.some(
+          (update) =>
+            update.kind === 'status' &&
+            update.model.kind === 'ok' &&
+            update.model.staged.length === 0 &&
+            update.model.unstaged.length === 0
+        )
+          ? true
+          : undefined
+      );
+
+      await expect(worktree.getStatus()).resolves.toMatchObject({
+        kind: 'ok',
+        staged: [],
+        unstaged: [],
+      });
+
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watcher.dispose();
+    }
+  });
+
+  it('refreshes staged status when an external merge continuation commits resolved files', async () => {
+    const repo = await makeRepo();
+    await execFileAsync('git', ['checkout', '-b', 'feature'], { cwd: repo });
+    await writeFile(path.join(repo, 'tracked.txt'), 'feature\n', 'utf8');
+    await execFileAsync('git', ['commit', '-am', 'feature edit'], { cwd: repo });
+    await execFileAsync('git', ['checkout', 'main'], { cwd: repo });
+    await writeFile(path.join(repo, 'tracked.txt'), 'main\n', 'utf8');
+    await execFileAsync('git', ['commit', '-am', 'main edit'], { cwd: repo });
+    await execFileAsync('git', ['checkout', 'feature'], { cwd: repo });
+
+    const watcher = new FileWatchService();
+    const runtime = new GitRuntime({ watcher });
+    const updates: GitWorktreeUpdate[] = [];
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      const worktree = lease.value;
+      worktree.subscribe((update) => updates.push(update));
+
+      await expect(execFileAsync('git', ['merge', 'main'], { cwd: repo })).rejects.toThrow();
+      await writeFile(path.join(repo, 'tracked.txt'), 'resolved\n', 'utf8');
+      await execFileAsync('git', ['add', 'tracked.txt'], { cwd: repo });
+
+      await eventually(() =>
+        updates.some(
+          (update) =>
+            update.kind === 'status' &&
+            update.model.kind === 'ok' &&
+            update.model.staged.some((change) => change.path === 'tracked.txt')
+        )
+          ? true
+          : undefined
+      );
+      updates.length = 0;
+
+      await execFileAsync('git', ['merge', '--continue'], {
+        cwd: repo,
+        env: { ...process.env, GIT_EDITOR: 'true' },
+      });
+
+      await eventually(() =>
+        updates.some(
+          (update) =>
+            update.kind === 'status' &&
+            update.model.kind === 'ok' &&
+            update.model.staged.length === 0 &&
+            update.model.unstaged.length === 0
+        )
+          ? true
+          : undefined
+      );
+
+      await expect(worktree.getStatus()).resolves.toMatchObject({
+        kind: 'ok',
+        staged: [],
+        unstaged: [],
+      });
+
+      lease.release();
+    } finally {
+      await runtime.dispose();
+      await watcher.dispose();
+    }
+  });
+
   it('computes pushed log state and refreshes refs after push', async () => {
     const { repo } = await makeRepoWithRemote();
     await writeFile(path.join(repo, 'tracked.txt'), 'pushed\n', 'utf8');

--- a/packages/shared/src/git/watch/classifier.test.ts
+++ b/packages/shared/src/git/watch/classifier.test.ts
@@ -38,6 +38,35 @@ describe('classifyGitWatchEvents', () => {
     expect(classification.worktrees.get('main')).toEqual({ status: true, head: true });
   });
 
+  it('does not treat packed refs as worktree head or status staleness', () => {
+    const gitCommonDir = path.join(path.sep, 'repo', '.git');
+    const worktree = path.join(path.sep, 'repo');
+
+    const classification = classifyGitWatchEvents(
+      [{ kind: 'update', path: path.join(gitCommonDir, 'packed-refs') }],
+      { gitCommonDir, worktrees: [{ id: 'main', gitDir: gitCommonDir, worktree }] }
+    );
+
+    expect(classification.repo).toEqual({ refs: true, remotes: false });
+    expect(classification.worktrees.size).toBe(0);
+  });
+
+  it('does not treat reflog writes as worktree head or status staleness', () => {
+    const gitCommonDir = path.join(path.sep, 'repo', '.git');
+    const worktree = path.join(path.sep, 'repo');
+
+    const classification = classifyGitWatchEvents(
+      [
+        { kind: 'update', path: path.join(gitCommonDir, 'logs', 'HEAD') },
+        { kind: 'update', path: path.join(gitCommonDir, 'logs', 'refs', 'heads', 'main') },
+      ],
+      { gitCommonDir, worktrees: [{ id: 'main', gitDir: gitCommonDir, worktree }] }
+    );
+
+    expect(classification.repo).toEqual({ refs: false, remotes: false });
+    expect(classification.worktrees.size).toBe(0);
+  });
+
   it('treats direct HEAD changes as status staleness', () => {
     const gitCommonDir = path.join(path.sep, 'repo', '.git');
     const worktree = path.join(path.sep, 'repo');

--- a/packages/shared/src/git/watch/classifier.test.ts
+++ b/packages/shared/src/git/watch/classifier.test.ts
@@ -24,4 +24,29 @@ describe('classifyGitWatchEvents', () => {
 
     expect(classification.repo).toEqual({ refs: false, remotes: false });
   });
+
+  it('treats branch ref changes as worktree head and status staleness', () => {
+    const gitCommonDir = path.join(path.sep, 'repo', '.git');
+    const worktree = path.join(path.sep, 'repo');
+
+    const classification = classifyGitWatchEvents(
+      [{ kind: 'update', path: path.join(gitCommonDir, 'refs', 'heads', 'main') }],
+      { gitCommonDir, worktrees: [{ id: 'main', gitDir: gitCommonDir, worktree }] }
+    );
+
+    expect(classification.repo).toEqual({ refs: true, remotes: false });
+    expect(classification.worktrees.get('main')).toEqual({ status: true, head: true });
+  });
+
+  it('treats direct HEAD changes as status staleness', () => {
+    const gitCommonDir = path.join(path.sep, 'repo', '.git');
+    const worktree = path.join(path.sep, 'repo');
+
+    const classification = classifyGitWatchEvents(
+      [{ kind: 'update', path: path.join(gitCommonDir, 'HEAD') }],
+      { gitCommonDir, worktrees: [{ id: 'main', gitDir: gitCommonDir, worktree }] }
+    );
+
+    expect(classification.worktrees.get('main')).toEqual({ status: true, head: true });
+  });
 });

--- a/packages/shared/src/git/watch/classifier.ts
+++ b/packages/shared/src/git/watch/classifier.ts
@@ -39,18 +39,33 @@ export function classifyGitWatchEvents(
     current[effect] = true;
     worktrees.set(id, current);
   };
+  const addAllWorktreeEffects = (effects: Partial<WorktreeWatchEffects>) => {
+    for (const worktree of normalizedWorktrees) {
+      const current = worktrees.get(worktree.id) ?? { status: false, head: false };
+      worktrees.set(worktree.id, {
+        status: current.status || effects.status === true,
+        head: current.head || effects.head === true,
+      });
+    }
+  };
 
   for (const event of events) {
     const eventPath = normalize(event.path);
     const commonRel = relativeInside(gitCommonDir, eventPath);
     if (commonRel !== null) {
       classifyCommonGitPath(commonRel, repo);
+      if (commonGitPathAffectsWorktreeHead(commonRel)) {
+        addAllWorktreeEffects({ status: true, head: true });
+      }
     }
 
     for (const worktree of normalizedWorktrees) {
       const gitRel = relativeInside(worktree.gitDir, eventPath);
       if (gitRel !== null) {
-        if (gitRel === 'HEAD') addWorktreeEffect(worktree.id, 'head');
+        if (gitRel === 'HEAD') {
+          addWorktreeEffect(worktree.id, 'head');
+          addWorktreeEffect(worktree.id, 'status');
+        }
         if (gitRel === 'index') addWorktreeEffect(worktree.id, 'status');
       }
 
@@ -78,6 +93,16 @@ function classifyCommonGitPath(rel: string, repo: RepoWatchEffects): void {
     repo.refs = true;
     repo.remotes = true;
   }
+}
+
+function commonGitPathAffectsWorktreeHead(rel: string): boolean {
+  return (
+    rel.startsWith('refs/heads/') ||
+    rel === 'packed-refs' ||
+    rel === 'HEAD' ||
+    rel === 'logs/HEAD' ||
+    rel.startsWith('logs/refs/heads/')
+  );
 }
 
 function relativeInside(root: string, child: string): string | null {

--- a/packages/shared/src/git/watch/classifier.ts
+++ b/packages/shared/src/git/watch/classifier.ts
@@ -55,6 +55,8 @@ export function classifyGitWatchEvents(
     if (commonRel !== null) {
       classifyCommonGitPath(commonRel, repo);
       if (commonGitPathAffectsWorktreeHead(commonRel)) {
+        // Shared branch refs do not identify which registered worktree is on that branch.
+        // Fan out conservatively until GitLayout carries current-branch metadata.
         addAllWorktreeEffects({ status: true, head: true });
       }
     }
@@ -96,13 +98,7 @@ function classifyCommonGitPath(rel: string, repo: RepoWatchEffects): void {
 }
 
 function commonGitPathAffectsWorktreeHead(rel: string): boolean {
-  return (
-    rel.startsWith('refs/heads/') ||
-    rel === 'packed-refs' ||
-    rel === 'HEAD' ||
-    rel === 'logs/HEAD' ||
-    rel.startsWith('logs/refs/heads/')
-  );
+  return rel.startsWith('refs/heads/') || rel === 'HEAD';
 }
 
 function relativeInside(root: string, child: string): string | null {


### PR DESCRIPTION
- refresh git status when branch refs or HEAD changes so staged files clear after external commits and merge continuation
- add targeted worktree status and head invalidation
- cover external commit and merge continuation flows that previously leave stale staged changes in the sidebar