### PR TITLE
fix(mermaid): expand preview clicks in place

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/ui/mermaid-diagram-preview.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/ui/mermaid-diagram-preview.tsx
@@ -1,4 +1,5 @@
 import { Expand } from 'lucide-react';
+import type React from 'react';
 import { Button } from '@renderer/lib/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
@@ -10,8 +11,28 @@ interface MermaidDiagramPreviewProps {
 }
 
 export function MermaidDiagramPreview({ svg, compact, onExpand }: MermaidDiagramPreviewProps) {
+  const expandFromInteraction = (event: React.SyntheticEvent) => {
+    event.preventDefault();
+    event.stopPropagation();
+    onExpand();
+  };
+
+  const handleExpand = (event: React.MouseEvent<HTMLButtonElement>) => {
+    expandFromInteraction(event);
+  };
+
+  const handlePreviewClick = (event: React.MouseEvent<HTMLDivElement>) => {
+    expandFromInteraction(event);
+  };
+
+  const handlePreviewKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      expandFromInteraction(event);
+    }
+  };
+
   return (
-    <div className="group relative overflow-x-auto rounded-md border border-border bg-background">
+    <div className="group/mermaid relative overflow-x-auto rounded-md border border-border bg-background">
       <Tooltip>
         <TooltipTrigger
           render={
@@ -20,8 +41,8 @@ export function MermaidDiagramPreview({ svg, compact, onExpand }: MermaidDiagram
               variant="secondary"
               size="icon-xs"
               aria-label="Expand Mermaid diagram"
-              className="absolute top-1 right-1 z-10 opacity-0 shadow-sm ring-1 ring-border/80 transition-opacity group-hover:opacity-100 focus-visible:opacity-100"
-              onClick={onExpand}
+              className="absolute top-1 right-1 z-10 opacity-0 shadow-sm ring-1 ring-border/80 transition-opacity group-hover/mermaid:opacity-100 focus-visible:opacity-100"
+              onClick={handleExpand}
             >
               <Expand className="size-3" />
             </Button>
@@ -32,10 +53,15 @@ export function MermaidDiagramPreview({ svg, compact, onExpand }: MermaidDiagram
         </TooltipContent>
       </Tooltip>
       <div
+        role="button"
+        tabIndex={0}
+        aria-label="Expand Mermaid diagram preview"
         className={cn(
-          'min-w-fit p-2 text-foreground [&_svg]:block [&_svg]:h-auto [&_svg]:max-w-full',
+          'min-w-fit cursor-zoom-in p-2 text-foreground [&_svg]:block [&_svg]:h-auto [&_svg]:max-w-full',
           compact && 'p-1.5'
         )}
+        onClick={handlePreviewClick}
+        onKeyDown={handlePreviewKeyDown}
         dangerouslySetInnerHTML={{ __html: svg }}
       />
     </div>

--- a/apps/emdash-desktop/src/renderer/lib/ui/mermaid-diagram-preview.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/ui/mermaid-diagram-preview.tsx
@@ -17,14 +17,6 @@ export function MermaidDiagramPreview({ svg, compact, onExpand }: MermaidDiagram
     onExpand();
   };
 
-  const handleExpand = (event: React.MouseEvent<HTMLButtonElement>) => {
-    expandFromInteraction(event);
-  };
-
-  const handlePreviewClick = (event: React.MouseEvent<HTMLDivElement>) => {
-    expandFromInteraction(event);
-  };
-
   const handlePreviewKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
     if (event.key === 'Enter' || event.key === ' ') {
       expandFromInteraction(event);
@@ -42,7 +34,7 @@ export function MermaidDiagramPreview({ svg, compact, onExpand }: MermaidDiagram
               size="icon-xs"
               aria-label="Expand Mermaid diagram"
               className="absolute top-1 right-1 z-10 opacity-0 shadow-sm ring-1 ring-border/80 transition-opacity group-hover/mermaid:opacity-100 focus-visible:opacity-100"
-              onClick={handleExpand}
+              onClick={expandFromInteraction}
             >
               <Expand className="size-3" />
             </Button>
@@ -60,7 +52,7 @@ export function MermaidDiagramPreview({ svg, compact, onExpand }: MermaidDiagram
           'min-w-fit cursor-zoom-in p-2 text-foreground [&_svg]:block [&_svg]:h-auto [&_svg]:max-w-full',
           compact && 'p-1.5'
         )}
-        onClick={handlePreviewClick}
+        onClick={expandFromInteraction}
         onKeyDown={handlePreviewKeyDown}
         dangerouslySetInnerHTML={{ __html: svg }}
       />

--- a/apps/emdash-desktop/src/renderer/tests/mermaid-diagram-preview.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/mermaid-diagram-preview.test.ts
@@ -1,0 +1,103 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { MermaidDiagramPreview } from '@renderer/lib/ui/mermaid-diagram-preview';
+
+describe('MermaidDiagramPreview', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Element', dom.window.Element);
+    vi.stubGlobal('SVGElement', dom.window.SVGElement);
+    vi.stubGlobal('Node', dom.window.Node);
+    vi.stubGlobal('MouseEvent', dom.window.MouseEvent);
+    vi.stubGlobal('PointerEvent', dom.window.PointerEvent);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      dom.window.setTimeout(() => callback(Date.now()), 0)
+    );
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => dom.window.clearTimeout(id));
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('expands without triggering parent click handlers', () => {
+    const onExpand = vi.fn();
+    const onParentClick = vi.fn();
+
+    act(() => {
+      root.render(
+        React.createElement(
+          'div',
+          { onClick: onParentClick },
+          React.createElement(MermaidDiagramPreview, {
+            svg: "<svg xmlns='http://www.w3.org/2000/svg' width='120' height='40'></svg>",
+            onExpand,
+          })
+        )
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Expand Mermaid diagram"]'
+    );
+    expect(button).not.toBeNull();
+
+    act(() => {
+      button?.dispatchEvent(
+        new dom.window.MouseEvent('click', { bubbles: true, cancelable: true })
+      );
+    });
+
+    expect(onExpand).toHaveBeenCalledTimes(1);
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+
+  it('expands linked diagram nodes instead of following their SVG anchors', () => {
+    const onExpand = vi.fn();
+    const onParentClick = vi.fn();
+
+    act(() => {
+      root.render(
+        React.createElement(
+          'div',
+          { onClick: onParentClick },
+          React.createElement(MermaidDiagramPreview, {
+            svg: [
+              "<svg xmlns='http://www.w3.org/2000/svg' width='120' height='40'>",
+              "<a href='https://example.com/'><rect width='120' height='40'></rect></a>",
+              '</svg>',
+            ].join(''),
+            onExpand,
+          })
+        )
+      );
+    });
+
+    const linkedNode = container.querySelector<SVGRectElement>('rect');
+    expect(linkedNode).not.toBeNull();
+
+    const event = new dom.window.MouseEvent('click', { bubbles: true, cancelable: true });
+    act(() => {
+      linkedNode?.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+    expect(onParentClick).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/tests/mermaid-diagram-preview.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/mermaid-diagram-preview.test.ts
@@ -100,4 +100,36 @@ describe('MermaidDiagramPreview', () => {
     expect(onExpand).toHaveBeenCalledTimes(1);
     expect(onParentClick).not.toHaveBeenCalled();
   });
+
+  it.each(['Enter', ' '])('expands preview with keyboard key "%s"', (key) => {
+    const onExpand = vi.fn();
+    const onParentKeyDown = vi.fn();
+
+    act(() => {
+      root.render(
+        React.createElement(
+          'div',
+          { onKeyDown: onParentKeyDown },
+          React.createElement(MermaidDiagramPreview, {
+            svg: "<svg xmlns='http://www.w3.org/2000/svg' width='120' height='40'></svg>",
+            onExpand,
+          })
+        )
+      );
+    });
+
+    const preview = container.querySelector<HTMLDivElement>(
+      '[aria-label="Expand Mermaid diagram preview"]'
+    );
+    expect(preview).not.toBeNull();
+
+    const event = new dom.window.KeyboardEvent('keydown', { bubbles: true, cancelable: true, key });
+    act(() => {
+      preview?.dispatchEvent(event);
+    });
+
+    expect(event.defaultPrevented).toBe(true);
+    expect(onExpand).toHaveBeenCalledTimes(1);
+    expect(onParentKeyDown).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
- makes MermaidDiagramPreview own clicks inside generated svg content
- expands diagram previews in place when users click the button or diagram body
- prevents native mermaid svg links from opening separate windows
- aligns mermaid preview behavior with ExpandableImage interaction patterns