### PR TITLE
fix: backfill workspaces for imported tasks

### DIFF
--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -3,7 +3,7 @@ import { openFixture } from '@tooling/utils/db';
 import { eq } from 'drizzle-orm';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { ProjectProvider } from '@main/core/projects/project-provider';
-import { projects, workspaces } from '@main/db/schema';
+import { projects, tasks, workspaces } from '@main/db/schema';
 import type { Task } from '@shared/core/tasks/tasks';
 import { ok } from '@shared/lib/result';
 import { WorkspaceBootstrapService } from './workspace-bootstrap-service';
@@ -113,6 +113,37 @@ describe('WorkspaceBootstrapService', () => {
       expect(returned).toBe(existingWsId);
       const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
       expect(ws.path).toBeNull();
+    });
+  });
+
+  describe('ensureWorkspaceSetupForTask', () => {
+    it('returns missing-workspace when a task has no workspace id', async () => {
+      await fixture.db.insert(tasks).values({
+        id: 'task-missing-workspace-id',
+        projectId: 'proj-1',
+        name: 'Missing workspace ID',
+        status: 'in_progress',
+      });
+
+      const result = await svc.ensureWorkspaceSetupForTask('task-missing-workspace-id');
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.type).toBe('missing-workspace');
+    });
+
+    it('returns missing-workspace when the workspace row is absent', async () => {
+      await fixture.db.insert(tasks).values({
+        id: 'task-missing-workspace-row',
+        projectId: 'proj-1',
+        name: 'Missing workspace row',
+        status: 'in_progress',
+        workspaceId: 'workspace-missing',
+      });
+
+      const result = await svc.ensureWorkspaceSetupForTask('task-missing-workspace-row');
+
+      expect(result.success).toBe(false);
+      if (!result.success) expect(result.error.type).toBe('missing-workspace');
     });
   });
 

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -264,14 +264,14 @@ export class WorkspaceBootstrapService {
     taskId: string
   ): Promise<Result<WorkspaceBootstrapResult, ProvisionWorkspaceError>> {
     const [row] = await this.db.select().from(tasks).where(eq(tasks.id, taskId)).limit(1);
-    if (!row?.workspaceId) throw new Error(`Task ${taskId} has no workspaceId`);
+    if (!row?.workspaceId) return err({ type: 'missing-workspace' });
 
     const [wsRow] = await this.db
       .select()
       .from(workspaces)
       .where(eq(workspaces.id, row.workspaceId))
       .limit(1);
-    if (!wsRow) throw new Error(`Workspace ${row.workspaceId} not found for task ${taskId}`);
+    if (!wsRow) return err({ type: 'missing-workspace' });
 
     const project = projectManager.getProject(row.projectId);
     if (!project) throw new Error(`Project ${row.projectId} not found`);

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
@@ -6,6 +6,7 @@ import { afterEach, describe, expect, it } from 'vitest';
 import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { makePtySessionId } from '@shared/core/pty/ptySessionId';
 import { createDrizzleClient } from '../../../drizzleClient';
+import { ensureImportedTaskWorkspaces } from '../../task-workspace-backfill';
 import { portConversations } from './conversations';
 import { portProjects } from './projects';
 import { createRemapTables } from './remap';
@@ -67,6 +68,25 @@ function createAppDb(): {
       automation_run_id TEXT
     );
 
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY,
+      key TEXT,
+      type TEXT NOT NULL,
+      data TEXT,
+      path TEXT,
+      lines_added INTEGER,
+      lines_deleted INTEGER,
+      kind TEXT,
+      location TEXT,
+      ssh_connection_id TEXT,
+      config TEXT,
+      branch_name TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE UNIQUE INDEX idx_workspaces_key ON workspaces(key) WHERE key IS NOT NULL;
+
     CREATE TABLE conversations (
       id TEXT PRIMARY KEY,
       project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
@@ -78,7 +98,9 @@ function createAppDb(): {
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       last_interacted_at TEXT,
       is_initial_conversation INTEGER,
-      session_id TEXT
+      session_id TEXT,
+      agent_status TEXT,
+      agent_status_seen INTEGER DEFAULT 1
     );
   `);
 
@@ -169,7 +191,24 @@ describe('legacy-port table passes', () => {
 
     appSqlite
       .prepare(
-        `INSERT INTO tasks (id, project_id, name, status, source_branch, task_branch) VALUES (?, ?, ?, ?, ?, ?)`
+        `INSERT INTO workspaces (id, type, kind, location, branch_name, config) VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'workspace-beta-existing',
+        'local',
+        'worktree',
+        'local',
+        'feature/shared',
+        JSON.stringify({
+          version: '2',
+          git: { kind: 'use-branch', branchName: 'feature/shared' },
+          workspace: { kind: 'new-worktree' },
+        })
+      );
+
+    appSqlite
+      .prepare(
+        `INSERT INTO tasks (id, project_id, name, status, source_branch, task_branch, workspace_id) VALUES (?, ?, ?, ?, ?, ?, ?)`
       )
       .run(
         'task-beta-existing',
@@ -177,7 +216,8 @@ describe('legacy-port table passes', () => {
         'Existing Task',
         'todo',
         JSON.stringify({ type: 'local', branch: 'main' }),
-        'feature/shared'
+        'feature/shared',
+        'workspace-beta-existing'
       );
 
     legacyDb
@@ -250,6 +290,7 @@ describe('legacy-port table passes', () => {
     const sshSummary = await portSshConnections({ appDb, legacyDb, remap });
     const projectsSummary = await portProjects({ appDb, legacyDb, remap });
     const taskResult = await portTasks({ appDb, legacyDb, remap });
+    ensureImportedTaskWorkspaces(appDb);
     const conversationsSummary = await portConversations({
       appDb,
       legacyDb,
@@ -279,13 +320,14 @@ describe('legacy-port table passes', () => {
 
     const insertedTask = appSqlite
       .prepare(
-        `SELECT project_id, status, source_branch, task_branch, status_changed_at, last_interacted_at, is_pinned FROM tasks WHERE id = ?`
+        `SELECT project_id, status, source_branch, task_branch, workspace_id, status_changed_at, last_interacted_at, is_pinned FROM tasks WHERE id = ?`
       )
       .get(insertedTaskId) as {
       project_id: string;
       status: string;
       source_branch: string | null;
       task_branch: string;
+      workspace_id: string;
       status_changed_at: string | null;
       last_interacted_at: string | null;
       is_pinned: number;
@@ -295,9 +337,36 @@ describe('legacy-port table passes', () => {
     expect(insertedTask.status).toBe('in_progress');
     expect(insertedTask.source_branch).toBeNull();
     expect(insertedTask.task_branch).toBe('feature/new-legacy');
+    expect(insertedTask.workspace_id).toBeTruthy();
     expect(insertedTask.status_changed_at).toBe('2026-01-02T12:00:00.000Z');
     expect(insertedTask.last_interacted_at).toBe('2026-01-02T12:00:00.000Z');
     expect(insertedTask.is_pinned).toBe(0);
+
+    const importedWorkspace = appSqlite
+      .prepare(
+        `SELECT kind, location, type, ssh_connection_id, branch_name, config FROM workspaces WHERE id = ?`
+      )
+      .get(insertedTask.workspace_id) as {
+      kind: string;
+      location: string;
+      type: string;
+      ssh_connection_id: string;
+      branch_name: string;
+      config: string;
+    };
+
+    expect(importedWorkspace).toMatchObject({
+      kind: 'worktree',
+      location: 'remote',
+      type: 'project-ssh',
+      ssh_connection_id: 'ssh-beta',
+      branch_name: 'feature/new-legacy',
+    });
+    expect(JSON.parse(importedWorkspace.config)).toEqual({
+      version: '2',
+      git: { kind: 'use-branch', branchName: 'feature/new-legacy' },
+      workspace: { kind: 'new-worktree' },
+    });
 
     expect(conversationsSummary.considered).toBe(2);
     expect(conversationsSummary.skippedDedup).toBe(1);

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/relational/relational.test.ts
@@ -161,6 +161,28 @@ function createLegacyDb(): Database.Database {
   return db;
 }
 
+async function withAtomicDestinationImport<T>(
+  sqlite: Database.Database,
+  action: () => Promise<T>
+): Promise<T> {
+  const foreignKeys = sqlite.pragma('foreign_keys', { simple: true }) as number;
+  sqlite.pragma('foreign_keys = OFF');
+  sqlite.exec('BEGIN IMMEDIATE');
+
+  try {
+    const result = await action();
+    sqlite.exec('COMMIT');
+    return result;
+  } catch (error) {
+    if (sqlite.inTransaction) {
+      sqlite.exec('ROLLBACK');
+    }
+    throw error;
+  } finally {
+    sqlite.pragma(`foreign_keys = ${foreignKeys ? 'ON' : 'OFF'}`);
+  }
+}
+
 describe('legacy-port table passes', () => {
   const openDbs: Database.Database[] = [];
   const tempDirs: string[] = [];
@@ -287,16 +309,21 @@ describe('legacy-port table passes', () => {
       .run('conv-legacy-new', 'task-legacy-new', 'New conversation', 'codex');
 
     const remap = createRemapTables();
-    const sshSummary = await portSshConnections({ appDb, legacyDb, remap });
-    const projectsSummary = await portProjects({ appDb, legacyDb, remap });
-    const taskResult = await portTasks({ appDb, legacyDb, remap });
-    ensureImportedTaskWorkspaces(appDb);
-    const conversationsSummary = await portConversations({
-      appDb,
-      legacyDb,
-      remap,
-      mergedLegacyTaskIds: taskResult.mergedLegacyTaskIds,
-    });
+    const { sshSummary, projectsSummary, taskResult, conversationsSummary } =
+      await withAtomicDestinationImport(appSqlite, async () => {
+        const sshSummary = await portSshConnections({ appDb, legacyDb, remap });
+        const projectsSummary = await portProjects({ appDb, legacyDb, remap });
+        const taskResult = await portTasks({ appDb, legacyDb, remap });
+        ensureImportedTaskWorkspaces(appDb);
+        const conversationsSummary = await portConversations({
+          appDb,
+          legacyDb,
+          remap,
+          mergedLegacyTaskIds: taskResult.mergedLegacyTaskIds,
+        });
+
+        return { sshSummary, projectsSummary, taskResult, conversationsSummary };
+      });
 
     expect(sshSummary.considered).toBe(1);
     expect(sshSummary.skippedDedup).toBe(1);
@@ -383,6 +410,54 @@ describe('legacy-port table passes', () => {
         title: 'New conversation',
       },
     ]);
+  });
+
+  it('rolls back imported rows when workspace backfill fails inside the atomic import', async () => {
+    const { appSqlite, appDb } = createAppDb();
+    const legacyDb = createLegacyDb();
+    openDbs.push(appSqlite, legacyDb);
+
+    appSqlite.exec(`DROP TABLE workspaces;`);
+
+    legacyDb
+      .prepare(
+        `INSERT INTO projects (id, name, path, base_ref, is_remote, remote_path, ssh_connection_id) VALUES (?, ?, ?, ?, ?, ?, ?)`
+      )
+      .run('proj-legacy-local', 'Legacy Local', '/work/repo', 'main', 0, null, null);
+
+    legacyDb
+      .prepare(
+        `INSERT INTO tasks (id, project_id, name, status, branch, updated_at) VALUES (?, ?, ?, ?, ?, ?)`
+      )
+      .run(
+        'task-legacy-new',
+        'proj-legacy-local',
+        'Legacy New Task',
+        'running',
+        'feature/new-legacy',
+        '2026-01-02T12:00:00.000Z'
+      );
+
+    const remap = createRemapTables();
+
+    await expect(
+      withAtomicDestinationImport(appSqlite, async () => {
+        await portSshConnections({ appDb, legacyDb, remap });
+        await portProjects({ appDb, legacyDb, remap });
+        await portTasks({ appDb, legacyDb, remap });
+        ensureImportedTaskWorkspaces(appDb);
+      })
+    ).rejects.toThrow();
+
+    const projectCount = appSqlite.prepare(`SELECT COUNT(*) AS count FROM projects`).get() as {
+      count: number;
+    };
+    const taskCount = appSqlite.prepare(`SELECT COUNT(*) AS count FROM tasks`).get() as {
+      count: number;
+    };
+
+    expect(projectCount.count).toBe(0);
+    expect(taskCount.count).toBe(0);
   });
 
   it('imports direct legacy tasks as source-branch-only when use_worktree is false', async () => {

--- a/apps/emdash-desktop/src/main/db/legacy-port/service.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/service.test.ts
@@ -63,6 +63,25 @@ function createAppDb(): Database.Database {
       automation_run_id TEXT
     );
 
+    CREATE TABLE workspaces (
+      id TEXT PRIMARY KEY,
+      key TEXT,
+      type TEXT NOT NULL,
+      data TEXT,
+      path TEXT,
+      lines_added INTEGER,
+      lines_deleted INTEGER,
+      kind TEXT,
+      location TEXT,
+      ssh_connection_id TEXT,
+      config TEXT,
+      branch_name TEXT,
+      created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
+      updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP
+    );
+
+    CREATE UNIQUE INDEX idx_workspaces_key ON workspaces(key) WHERE key IS NOT NULL;
+
     CREATE TABLE conversations (
       id TEXT PRIMARY KEY,
       project_id TEXT NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
@@ -73,7 +92,9 @@ function createAppDb(): Database.Database {
       created_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       updated_at TEXT NOT NULL DEFAULT CURRENT_TIMESTAMP,
       last_interacted_at TEXT,
-      is_initial_conversation INTEGER
+      is_initial_conversation INTEGER,
+      agent_status TEXT,
+      agent_status_seen INTEGER DEFAULT 1
     );
   `);
   return db;
@@ -228,6 +249,32 @@ describe('runLegacyPort', () => {
 
     expect(projectsAfterFirstRun.count).toBe(1);
     expect(tasksAfterFirstRun.count).toBe(1);
+
+    const importedTask = appDb
+      .prepare(`SELECT workspace_id FROM tasks WHERE id = ?`)
+      .get('legacy-task-1') as { workspace_id: string | null };
+    expect(importedTask.workspace_id).toBeTruthy();
+
+    const importedWorkspace = appDb
+      .prepare(`SELECT kind, location, type, branch_name, config FROM workspaces WHERE id = ?`)
+      .get(importedTask.workspace_id) as {
+      kind: string;
+      location: string;
+      type: string;
+      branch_name: string;
+      config: string;
+    };
+    expect(importedWorkspace).toMatchObject({
+      kind: 'worktree',
+      location: 'local',
+      type: 'local',
+      branch_name: 'feature/legacy-1',
+    });
+    expect(JSON.parse(importedWorkspace.config)).toEqual({
+      version: '2',
+      git: { kind: 'use-branch', branchName: 'feature/legacy-1' },
+      workspace: { kind: 'new-worktree' },
+    });
 
     const legacy = new Database(legacyPath);
     legacy

--- a/apps/emdash-desktop/src/main/db/legacy-port/service.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/service.ts
@@ -28,6 +28,7 @@ import {
 import { clearDestinationDataPreservingSignIn } from './reset';
 import { buildLegacyProjectSelection } from './source-analysis';
 import { createLegacyPortStateStore } from './state-store';
+import { ensureImportedTaskWorkspaces } from './task-workspace-backfill';
 
 type LegacyPortDb = ReturnType<typeof drizzle<typeof schema>>;
 
@@ -214,6 +215,7 @@ export async function runLegacyPort(
         skipLegacyProjectIds: selection.skipLegacyProjectIds,
       });
       const taskResult = await portTasks({ appDb: appTarget.db, legacyDb, remap });
+      ensureImportedTaskWorkspaces(appTarget.db);
       const conversationsSummary = await portConversations({
         appDb: appTarget.db,
         legacyDb,

--- a/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.db.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.db.test.ts
@@ -115,7 +115,7 @@ describe('ensureImportedTaskWorkspaces', () => {
       sshConnectionId: 'ssh-1',
       branchName: 'feature/imported',
       path: null,
-      key: null,
+      key: computeWorkspaceKey('project-ssh', '/srv/remote#feature/imported', 'ssh-1'),
       config: {
         version: '2',
         git: { kind: 'use-branch', branchName: 'feature/imported' },
@@ -127,6 +127,56 @@ describe('ensureImportedTaskWorkspaces', () => {
     ensureImportedTaskWorkspaces(fixture.db);
     const workspaceCountAfterRerun = await fixture.db.select().from(workspaces);
     expect(workspaceCountAfterRerun).toHaveLength(workspaceCount.length);
+
+    await fixture.db.update(tasks).set({ workspaceId: null }).where(eq(tasks.id, 'task-worktree'));
+    ensureImportedTaskWorkspaces(fixture.db);
+
+    const [repairedTask] = await fixture.db
+      .select({ workspaceId: tasks.workspaceId })
+      .from(tasks)
+      .where(eq(tasks.id, 'task-worktree'));
+    const workspaceCountAfterRepair = await fixture.db.select().from(workspaces);
+
+    expect(repairedTask.workspaceId).toBe(worktreeWorkspaceId);
+    expect(workspaceCountAfterRepair).toHaveLength(workspaceCount.length);
+  });
+
+  it('does not reuse worktree workspaces across projects with the same branch', async () => {
+    await fixture.db.insert(projects).values({
+      id: 'project-local-2',
+      name: 'Local Project 2',
+      path: '/repo/local-2',
+      workspaceProvider: 'local',
+    });
+    await fixture.db.insert(tasks).values([
+      {
+        id: 'task-worktree-1',
+        projectId: 'project-local',
+        name: 'Worktree task 1',
+        status: 'in_progress',
+        taskBranch: 'feature/shared',
+      },
+      {
+        id: 'task-worktree-2',
+        projectId: 'project-local-2',
+        name: 'Worktree task 2',
+        status: 'in_progress',
+        taskBranch: 'feature/shared',
+      },
+    ]);
+
+    ensureImportedTaskWorkspaces(fixture.db);
+
+    const importedTasks = await fixture.db
+      .select({ id: tasks.id, workspaceId: tasks.workspaceId })
+      .from(tasks)
+      .orderBy(tasks.id);
+    const workspaceIds = importedTasks.map((task) => task.workspaceId);
+    const workspaceRows = await fixture.db.select().from(workspaces);
+
+    expect(workspaceIds.every(Boolean)).toBe(true);
+    expect(new Set(workspaceIds).size).toBe(2);
+    expect(workspaceRows).toHaveLength(2);
   });
 
   it('reuses an existing repository workspace by key', async () => {

--- a/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.db.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.db.test.ts
@@ -1,0 +1,165 @@
+import { openFixture } from '@tooling/utils/db';
+import { eq } from 'drizzle-orm';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { computeWorkspaceKey } from '@main/core/workspaces/workspace-key';
+import { projects, sshConnections, tasks, workspaces } from '@main/db/schema';
+import { ensureImportedTaskWorkspaces } from './task-workspace-backfill';
+
+describe('ensureImportedTaskWorkspaces', () => {
+  let fixture: Awaited<ReturnType<typeof openFixture>>;
+
+  beforeEach(async () => {
+    fixture = await openFixture('empty');
+
+    await fixture.db.insert(sshConnections).values({
+      id: 'ssh-1',
+      name: 'prod',
+      host: 'example.com',
+      port: 22,
+      username: 'alice',
+    });
+
+    await fixture.db.insert(projects).values([
+      {
+        id: 'project-local',
+        name: 'Local Project',
+        path: '/repo/local',
+        workspaceProvider: 'local',
+      },
+      {
+        id: 'project-remote',
+        name: 'Remote Project',
+        path: '/srv/remote',
+        workspaceProvider: 'ssh',
+        sshConnectionId: 'ssh-1',
+      },
+    ]);
+  });
+
+  afterEach(() => {
+    fixture.close();
+  });
+
+  it('creates worktree and repository workspaces for imported tasks', async () => {
+    await fixture.db.insert(tasks).values([
+      {
+        id: 'task-root-1',
+        projectId: 'project-local',
+        name: 'Root task 1',
+        status: 'in_progress',
+      },
+      {
+        id: 'task-root-2',
+        projectId: 'project-local',
+        name: 'Root task 2',
+        status: 'todo',
+      },
+      {
+        id: 'task-worktree',
+        projectId: 'project-remote',
+        name: 'Worktree task',
+        status: 'in_progress',
+        taskBranch: 'feature/imported',
+      },
+    ]);
+
+    ensureImportedTaskWorkspaces(fixture.db);
+
+    const importedTasks = await fixture.db
+      .select({
+        id: tasks.id,
+        workspaceId: tasks.workspaceId,
+      })
+      .from(tasks)
+      .orderBy(tasks.id);
+
+    const rootWorkspaceId = importedTasks.find((task) => task.id === 'task-root-1')?.workspaceId;
+    expect(rootWorkspaceId).toBeTruthy();
+    if (!rootWorkspaceId) throw new Error('expected root workspace id');
+    expect(importedTasks.find((task) => task.id === 'task-root-2')?.workspaceId).toBe(
+      rootWorkspaceId
+    );
+
+    const [project] = await fixture.db
+      .select({ repositoryWorkspaceId: projects.repositoryWorkspaceId })
+      .from(projects)
+      .where(eq(projects.id, 'project-local'));
+    expect(project.repositoryWorkspaceId).toBe(rootWorkspaceId);
+
+    const [rootWorkspace] = await fixture.db
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.id, rootWorkspaceId));
+    expect(rootWorkspace).toMatchObject({
+      kind: 'project-root',
+      location: 'local',
+      type: 'local',
+      path: '/repo/local',
+      key: computeWorkspaceKey('local', '/repo/local'),
+    });
+
+    const worktreeWorkspaceId = importedTasks.find(
+      (task) => task.id === 'task-worktree'
+    )?.workspaceId;
+    expect(worktreeWorkspaceId).toBeTruthy();
+    if (!worktreeWorkspaceId) throw new Error('expected worktree workspace id');
+
+    const [worktreeWorkspace] = await fixture.db
+      .select()
+      .from(workspaces)
+      .where(eq(workspaces.id, worktreeWorkspaceId));
+    expect(worktreeWorkspace).toMatchObject({
+      kind: 'worktree',
+      location: 'remote',
+      type: 'project-ssh',
+      sshConnectionId: 'ssh-1',
+      branchName: 'feature/imported',
+      path: null,
+      key: null,
+      config: {
+        version: '2',
+        git: { kind: 'use-branch', branchName: 'feature/imported' },
+        workspace: { kind: 'new-worktree' },
+      },
+    });
+
+    const workspaceCount = await fixture.db.select().from(workspaces);
+    ensureImportedTaskWorkspaces(fixture.db);
+    const workspaceCountAfterRerun = await fixture.db.select().from(workspaces);
+    expect(workspaceCountAfterRerun).toHaveLength(workspaceCount.length);
+  });
+
+  it('reuses an existing repository workspace by key', async () => {
+    const key = computeWorkspaceKey('local', '/repo/local');
+    await fixture.db.insert(workspaces).values({
+      id: 'existing-repo-workspace',
+      kind: 'project-root',
+      location: 'local',
+      type: 'local',
+      path: '/repo/local',
+      key,
+    });
+    await fixture.db.insert(tasks).values({
+      id: 'task-root',
+      projectId: 'project-local',
+      name: 'Root task',
+      status: 'in_progress',
+    });
+
+    ensureImportedTaskWorkspaces(fixture.db);
+
+    const [task] = await fixture.db
+      .select({ workspaceId: tasks.workspaceId })
+      .from(tasks)
+      .where(eq(tasks.id, 'task-root'));
+    const [project] = await fixture.db
+      .select({ repositoryWorkspaceId: projects.repositoryWorkspaceId })
+      .from(projects)
+      .where(eq(projects.id, 'project-local'));
+    const workspaceRows = await fixture.db.select().from(workspaces);
+
+    expect(task.workspaceId).toBe('existing-repo-workspace');
+    expect(project.repositoryWorkspaceId).toBe('existing-repo-workspace');
+    expect(workspaceRows).toHaveLength(1);
+  });
+});

--- a/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.ts
@@ -1,0 +1,151 @@
+import { randomUUID } from 'node:crypto';
+import { eq, isNull } from 'drizzle-orm';
+import { computeWorkspaceKey } from '@main/core/workspaces/workspace-key';
+import type { AppDb, DrizzleTx } from '@main/db/client';
+import { projects, tasks, workspaces } from '@main/db/schema';
+import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
+
+type ProjectWorkspaceFields = {
+  projectId: string;
+  projectPath: string;
+  workspaceProvider: string;
+  sshConnectionId: string | null;
+  repositoryWorkspaceId: string | null;
+};
+
+function deriveWorkspaceLocation(project: {
+  workspaceProvider: string;
+  sshConnectionId: string | null;
+}): {
+  location: 'local' | 'remote';
+  type: 'local' | 'project-ssh';
+  sshConnectionId: string | null;
+} {
+  const isRemote = project.workspaceProvider === 'ssh';
+  return {
+    location: isRemote ? 'remote' : 'local',
+    type: isRemote ? 'project-ssh' : 'local',
+    sshConnectionId: isRemote ? project.sshConnectionId : null,
+  };
+}
+
+function buildImportedWorktreeConfig(branchName: string): WorkspaceConfig {
+  return {
+    version: '2',
+    git: { kind: 'use-branch', branchName },
+    workspace: { kind: 'new-worktree' },
+  };
+}
+
+function ensureRepositoryWorkspace(tx: DrizzleTx, project: ProjectWorkspaceFields): string {
+  if (project.repositoryWorkspaceId) {
+    const [existingWorkspace] = tx
+      .select({ id: workspaces.id })
+      .from(workspaces)
+      .where(eq(workspaces.id, project.repositoryWorkspaceId))
+      .limit(1)
+      .all();
+
+    if (existingWorkspace) return existingWorkspace.id;
+  }
+
+  const location = deriveWorkspaceLocation(project);
+  const key = computeWorkspaceKey(
+    location.type,
+    project.projectPath,
+    location.sshConnectionId ?? undefined
+  );
+
+  const [existingByKey] = tx
+    .select({ id: workspaces.id })
+    .from(workspaces)
+    .where(eq(workspaces.key, key))
+    .limit(1)
+    .all();
+
+  const workspaceId = existingByKey?.id ?? randomUUID();
+
+  if (!existingByKey) {
+    tx.insert(workspaces)
+      .values({
+        id: workspaceId,
+        kind: 'project-root',
+        location: location.location,
+        sshConnectionId: location.sshConnectionId,
+        type: location.type,
+        path: project.projectPath,
+        key,
+      })
+      .run();
+  }
+
+  tx.update(projects)
+    .set({ repositoryWorkspaceId: workspaceId })
+    .where(eq(projects.id, project.projectId))
+    .run();
+
+  return workspaceId;
+}
+
+/**
+ * Backfills the v1 workspace model for v0-imported tasks.
+ *
+ * This is intended to run inside the legacy import transaction. It only touches
+ * tasks where `workspaceId` is null, so copied v1-beta tasks and reruns are left
+ * alone.
+ */
+export function ensureImportedTaskWorkspaces(appDb: AppDb): void {
+  appDb.transaction((tx) => {
+    const rows = tx
+      .select({
+        taskId: tasks.id,
+        taskBranch: tasks.taskBranch,
+        projectId: projects.id,
+        projectPath: projects.path,
+        workspaceProvider: projects.workspaceProvider,
+        sshConnectionId: projects.sshConnectionId,
+        repositoryWorkspaceId: projects.repositoryWorkspaceId,
+      })
+      .from(tasks)
+      .innerJoin(projects, eq(tasks.projectId, projects.id))
+      .where(isNull(tasks.workspaceId))
+      .all();
+
+    const repositoryWorkspaceIdByProjectId = new Map<string, string>();
+
+    for (const row of rows) {
+      const project = {
+        projectId: row.projectId,
+        projectPath: row.projectPath,
+        workspaceProvider: row.workspaceProvider,
+        sshConnectionId: row.sshConnectionId,
+        repositoryWorkspaceId:
+          repositoryWorkspaceIdByProjectId.get(row.projectId) ?? row.repositoryWorkspaceId,
+      };
+
+      let workspaceId: string;
+
+      if (row.taskBranch) {
+        workspaceId = randomUUID();
+        const location = deriveWorkspaceLocation(project);
+
+        tx.insert(workspaces)
+          .values({
+            id: workspaceId,
+            kind: 'worktree',
+            location: location.location,
+            sshConnectionId: location.sshConnectionId,
+            type: location.type,
+            branchName: row.taskBranch,
+            config: buildImportedWorktreeConfig(row.taskBranch),
+          })
+          .run();
+      } else {
+        workspaceId = ensureRepositoryWorkspace(tx, project);
+        repositoryWorkspaceIdByProjectId.set(row.projectId, workspaceId);
+      }
+
+      tx.update(tasks).set({ workspaceId }).where(eq(tasks.id, row.taskId)).run();
+    }
+  });
+}

--- a/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/task-workspace-backfill.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { eq, isNull } from 'drizzle-orm';
+import { and, eq, isNull } from 'drizzle-orm';
 import { computeWorkspaceKey } from '@main/core/workspaces/workspace-key';
 import type { AppDb, DrizzleTx } from '@main/db/client';
 import { projects, tasks, workspaces } from '@main/db/schema';
@@ -35,6 +35,18 @@ function buildImportedWorktreeConfig(branchName: string): WorkspaceConfig {
     git: { kind: 'use-branch', branchName },
     workspace: { kind: 'new-worktree' },
   };
+}
+
+function buildImportedWorktreeKey(
+  project: ProjectWorkspaceFields,
+  branchName: string,
+  location: ReturnType<typeof deriveWorkspaceLocation>
+): string {
+  return computeWorkspaceKey(
+    location.type,
+    `${project.projectPath}#${branchName}`,
+    location.sshConnectionId ?? undefined
+  );
 }
 
 function ensureRepositoryWorkspace(tx: DrizzleTx, project: ProjectWorkspaceFields): string {
@@ -87,6 +99,43 @@ function ensureRepositoryWorkspace(tx: DrizzleTx, project: ProjectWorkspaceField
   return workspaceId;
 }
 
+function findExistingWorktreeWorkspace(
+  tx: DrizzleTx,
+  project: ProjectWorkspaceFields,
+  branchName: string,
+  location: ReturnType<typeof deriveWorkspaceLocation>
+): string | undefined {
+  const key = buildImportedWorktreeKey(project, branchName, location);
+  const [existingWorkspaceByKey] = tx
+    .select({ id: workspaces.id })
+    .from(workspaces)
+    .where(eq(workspaces.key, key))
+    .limit(1)
+    .all();
+
+  if (existingWorkspaceByKey) return existingWorkspaceByKey.id;
+
+  const conditions = [
+    eq(workspaces.kind, 'worktree'),
+    eq(workspaces.branchName, branchName),
+    eq(workspaces.location, location.location),
+    eq(workspaces.type, location.type),
+    isNull(workspaces.key),
+    location.sshConnectionId
+      ? eq(workspaces.sshConnectionId, location.sshConnectionId)
+      : isNull(workspaces.sshConnectionId),
+  ];
+
+  const existingWorkspaces = tx
+    .select({ id: workspaces.id })
+    .from(workspaces)
+    .where(and(...conditions))
+    .limit(2)
+    .all();
+
+  return existingWorkspaces.length === 1 ? existingWorkspaces[0]?.id : undefined;
+}
+
 /**
  * Backfills the v1 workspace model for v0-imported tasks.
  *
@@ -126,20 +175,29 @@ export function ensureImportedTaskWorkspaces(appDb: AppDb): void {
       let workspaceId: string;
 
       if (row.taskBranch) {
-        workspaceId = randomUUID();
         const location = deriveWorkspaceLocation(project);
+        const existingWorkspaceId = findExistingWorktreeWorkspace(
+          tx,
+          project,
+          row.taskBranch,
+          location
+        );
+        workspaceId = existingWorkspaceId ?? randomUUID();
 
-        tx.insert(workspaces)
-          .values({
-            id: workspaceId,
-            kind: 'worktree',
-            location: location.location,
-            sshConnectionId: location.sshConnectionId,
-            type: location.type,
-            branchName: row.taskBranch,
-            config: buildImportedWorktreeConfig(row.taskBranch),
-          })
-          .run();
+        if (!existingWorkspaceId) {
+          tx.insert(workspaces)
+            .values({
+              id: workspaceId,
+              kind: 'worktree',
+              location: location.location,
+              sshConnectionId: location.sshConnectionId,
+              type: location.type,
+              key: buildImportedWorktreeKey(project, row.taskBranch, location),
+              branchName: row.taskBranch,
+              config: buildImportedWorktreeConfig(row.taskBranch),
+            })
+            .run();
+        }
       } else {
         workspaceId = ensureRepositoryWorkspace(tx, project);
         repositoryWorkspaceIdByProjectId.set(row.projectId, workspaceId);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -85,6 +85,8 @@ function formatProvisionWorkspaceError(error: ProvisionWorkspaceError): string {
   switch (error.type) {
     case 'no-intent':
       return 'Workspace has no intent and no resolved path — cannot provision.';
+    case 'missing-workspace':
+      return 'This task does not have a workspace record and cannot be opened.';
     case 'setup-failed':
       return `Setup step '${error.stepKind}' failed (${error.stepErrorType})${error.message ? `: ${error.message}` : ''}.`;
   }

--- a/apps/emdash-desktop/src/shared/core/tasks/tasks.ts
+++ b/apps/emdash-desktop/src/shared/core/tasks/tasks.ts
@@ -127,6 +127,7 @@ export type ProvisionTaskResult = {
 
 export type ProvisionWorkspaceError =
   | { type: 'no-intent' }
+  | { type: 'missing-workspace' }
   | { type: 'setup-failed'; stepKind: string; stepErrorType: string; message?: string };
 
 export type DeleteTaskOptions = {


### PR DESCRIPTION
- adds ensureImportedTaskWorkspaces to populate workspace rows for imported worktree and project root tasks
- wires the backfill into legacy import so future migrations open imported tasks without hanging
- returns a missing-workspace provisioning error instead of throwing when a task has no workspace record