### PR TITLE
fix(grok): pass prompt via argv for grok cli 

### DIFF
--- a/agents/integrations/providers.md
+++ b/agents/integrations/providers.md
@@ -31,7 +31,8 @@ or notify an inferred status for that event.
 ## Provider Runtime Notes
 
 - Claude uses deterministic `--session-id` values for conversation isolation.
-- Agents with no CLI prompt flag (e.g., Amp, OpenCode) use keystroke injection — Emdash types the prompt into the TUI after startup.
+- Agents that cannot receive an interactive initial prompt via argv or stdin use keystroke
+  injection — Emdash types the prompt into the TUI after startup.
 - `src/main/core/agent-hooks/service.ts` forwards hook events to renderer windows and can show OS notifications. It also writes hook config files for hook-capable providers, including `.claude/settings.local.json`, `.qwen/settings.json`, and provider-specific global hook files.
 - Qwen Code hooks use the documented Qwen settings schema in `.qwen/settings.json`. Emdash installs command hooks for permission requests and session end/stop events while preserving unrelated user hooks.
 

--- a/apps/emdash-desktop/src/main/core/conversations/impl/keystroke-injection.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/keystroke-injection.test.ts
@@ -112,6 +112,20 @@ describe('scheduleInitialPromptInjection', () => {
     expect(write).not.toHaveBeenCalled();
   });
 
+  it('does nothing for Grok because its initial prompt is passed as a positional arg', () => {
+    const { pty, write, emitData } = makePty();
+    scheduleInitialPromptInjection({
+      pty,
+      conversation: makeConversation('grok'),
+      initialPrompt: 'Fix the bug',
+      isResuming: false,
+    });
+
+    emitData('ready');
+    vi.advanceTimersByTime(20_000);
+    expect(write).not.toHaveBeenCalled();
+  });
+
   it('does nothing for providers without keystroke injection', () => {
     const { pty, write, emitData } = makePty();
     scheduleInitialPromptInjection({

--- a/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
@@ -153,7 +153,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     versionArgs: ['--version'],
     cli: 'grok',
     autoApproveFlag: '--always-approve',
-    useKeystrokeInjection: true,
+    initialPromptFlag: '',
     resumeFlag: '-r',
     sessionIdFlag: '-r',
     sessionIdOnResumeOnly: true,

--- a/packages/plugins/src/agents/impl/grok/index.ts
+++ b/packages/plugins/src/agents/impl/grok/index.ts
@@ -60,7 +60,8 @@ export const plugin = definePlugin(
       kind: 'none',
     },
     prompt: {
-      kind: 'keystroke',
+      kind: 'argv',
+      flag: '',
     },
     sessions: {
       kind: 'resumable',
@@ -74,6 +75,7 @@ export const provider = registerPluginBehavior(plugin, {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
         autoApproveFlag: '--always-approve',
+        initialPromptFlag: '',
         resumeFlag: '-r',
         sessionIdFlag: '-r',
         sessionIdOnResumeOnly: true,

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -125,4 +125,21 @@ describe('pluginRegistry', () => {
       expect(typeof p.behavior.prompt?.buildCommand).toBe('function');
     }
   });
+
+  it('passes Grok initial prompts as positional argv for interactive sessions', () => {
+    const result = pluginRegistry.get('grok')!.behavior.prompt!.buildCommand({
+      cli: 'grok',
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+      isResuming: false,
+      model: '',
+    });
+
+    expect(result).toEqual({
+      command: 'grok',
+      args: ['--always-approve', 'Fix the bug'],
+      env: {},
+    });
+  });
 });


### PR DESCRIPTION
### Description
- pass grok initoal prompt as positional argv, not pty keystrokes
- clarify provider docs around when keystrokes injection is used 

Docs: https://docs.x.ai/build/cli/headless-scripting 

### Screenshot/Recording (if applicable)
https://streamable.com/h41sqa

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
