### PR TITLE
ADE-0: add WebStorm New UI as a selectable color theme

### DIFF
--- a/apps/emdash-desktop/src/main/core/pty/terminal-color-scheme.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/terminal-color-scheme.test.ts
@@ -29,6 +29,11 @@ describe('resolveEffectiveTheme', () => {
     expect(resolveEffectiveTheme('emdark', false)).toBe('emdark');
   });
 
+  it('returns emdark when theme is emwebstorm (a dark variant)', () => {
+    expect(resolveEffectiveTheme('emwebstorm', true)).toBe('emdark');
+    expect(resolveEffectiveTheme('emwebstorm', false)).toBe('emdark');
+  });
+
   it('follows shouldUseDarkColors when theme is null (system)', () => {
     expect(resolveEffectiveTheme(null, true)).toBe('emdark');
     expect(resolveEffectiveTheme(null, false)).toBe('emlight');
@@ -48,6 +53,12 @@ describe('getTerminalColorEnv', () => {
 
   it('returns COLORFGBG 15;0 for dark app theme', async () => {
     vi.mocked(appSettingsService.get).mockResolvedValue('emdark');
+    const result = await getTerminalColorEnv();
+    expect(result).toEqual({ COLORFGBG: '15;0' });
+  });
+
+  it('returns COLORFGBG 15;0 for the WebStorm theme', async () => {
+    vi.mocked(appSettingsService.get).mockResolvedValue('emwebstorm');
     const result = await getTerminalColorEnv();
     expect(result).toEqual({ COLORFGBG: '15;0' });
   });

--- a/apps/emdash-desktop/src/main/core/pty/terminal-color-scheme.ts
+++ b/apps/emdash-desktop/src/main/core/pty/terminal-color-scheme.ts
@@ -7,6 +7,7 @@ type EffectiveTheme = 'emlight' | 'emdark';
 
 export function resolveEffectiveTheme(theme: Theme, shouldUseDarkColors: boolean): EffectiveTheme {
   if (theme === 'emlight' || theme === 'emdark') return theme;
+  if (theme === 'emwebstorm') return 'emdark';
   return shouldUseDarkColors ? 'emdark' : 'emlight';
 }
 

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -53,9 +53,9 @@ export const terminalSettingsSchema = z.object({
 });
 
 export const themeSchema = z
-  .enum(['emlight', 'emdark'])
+  .enum(['emlight', 'emdark', 'emwebstorm'])
   .nullable()
-  .catch(null)
+  .catch(null) // Unknown / future-version theme values degrade gracefully to system (null).
   .optional()
   .default(null);
 

--- a/apps/emdash-desktop/src/renderer/app/home-view.tsx
+++ b/apps/emdash-desktop/src/renderer/app/home-view.tsx
@@ -4,6 +4,7 @@ import { EmdashShimmerLogo } from '@renderer/lib/emdash-shimmer-logo';
 import { useArrowKeyNavigation } from '@renderer/lib/hooks/use-arrow-key-navigation';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { isDarkTheme } from '@renderer/lib/theme/is-dark-theme';
 import { ActionListItem } from '@renderer/lib/ui/action-list-item';
 
 const PROJECT_ACTIONS = [
@@ -40,7 +41,7 @@ export function HomeMainPanel() {
     (index) => showAddProjectModal(PROJECT_ACTIONS[index].modalArgs)
   );
   const { effectiveTheme } = useTheme();
-  const isDark = effectiveTheme === 'emdark';
+  const isDark = isDarkTheme(effectiveTheme);
 
   return (
     <motion.div

--- a/apps/emdash-desktop/src/renderer/app/welcome.tsx
+++ b/apps/emdash-desktop/src/renderer/app/welcome.tsx
@@ -6,6 +6,7 @@ import YTBanner from '@/assets/images/ytbanner.webp';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { getEffectiveHotkey } from '@renderer/lib/hooks/useKeyboardShortcuts';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
+import { isDarkTheme } from '@renderer/lib/theme/is-dark-theme';
 import { Button } from '@renderer/lib/ui/button';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 
@@ -137,7 +138,7 @@ export function WelcomeScreen({ onGetStarted }: WelcomeScreenProps) {
               onClick={handleGetStarted}
               size="sm"
               className={
-                effectiveTheme === 'emdark' ? 'bg-gray-200 text-gray-900 hover:bg-gray-300' : ''
+                isDarkTheme(effectiveTheme) ? 'bg-gray-200 text-gray-900 hover:bg-gray-300' : ''
               }
             >
               <span className="flex items-center gap-2">

--- a/apps/emdash-desktop/src/renderer/features/settings/components/IntegrationRow.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/IntegrationRow.tsx
@@ -1,6 +1,7 @@
 import { Check, Copy, ExternalLink, Trash2 } from 'lucide-react';
 import React, { useEffect, useRef, useState } from 'react';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
+import { isDarkTheme } from '@renderer/lib/theme/is-dark-theme';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 
 type IntegrationStatus =
@@ -83,7 +84,7 @@ const IntegrationRow: React.FC<IntegrationRowProps> = ({
   installCommand,
 }) => {
   const { effectiveTheme } = useTheme();
-  const isDark = effectiveTheme === 'emdark';
+  const isDark = isDarkTheme(effectiveTheme);
   const themedLogoSrc = isDark && logoSrcDark ? logoSrcDark : logoSrc;
   const shouldInvertLogo = isDark && !!invertInDark && !logoSrcDark;
   const resolvedStatus = STATUS_CLASSES[status] ? status : 'disconnected';

--- a/apps/emdash-desktop/src/renderer/features/settings/components/ThemeCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/ThemeCard.tsx
@@ -1,4 +1,4 @@
-import { Monitor, Moon, Sun } from 'lucide-react';
+import { Code2, Monitor, Moon, Sun } from 'lucide-react';
 import React from 'react';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import { captureTelemetry } from '@renderer/utils/telemetryClient';
@@ -56,6 +56,16 @@ const ThemeCard: React.FC = () => {
         >
           <Moon className="h-4 w-4 shrink-0" aria-hidden="true" />
           <span className="text-center">Emdash Dark</span>
+        </button>
+        <button
+          type="button"
+          onClick={() => handleSetTheme('emwebstorm')}
+          className={`${buttonBase} ${theme === 'emwebstorm' ? activeClass : inactiveClass}`}
+          aria-pressed={theme === 'emwebstorm'}
+          aria-label="Set theme to WebStorm New UI"
+        >
+          <Code2 className="h-4 w-4 shrink-0" aria-hidden="true" />
+          <span className="text-center">WebStorm</span>
         </button>
       </div>
     </div>

--- a/apps/emdash-desktop/src/renderer/features/skills/components/SkillIconRenderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/skills/components/SkillIconRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
+import { isDarkTheme } from '@renderer/lib/theme/is-dark-theme';
 import type { CatalogSkill } from '@shared/core/skills/types';
 import { resolveSkillIcon } from './skillIcons';
 
@@ -16,7 +17,7 @@ interface SkillIconRendererProps {
 export const SkillIconRenderer: React.FC<SkillIconRendererProps> = ({ skill }) => {
   const [imgError, setImgError] = useState(false);
   const { effectiveTheme } = useTheme();
-  const isDark = effectiveTheme === 'emdark';
+  const isDark = isDarkTheme(effectiveTheme);
 
   const letter = skill.displayName.charAt(0).toUpperCase();
 

--- a/apps/emdash-desktop/src/renderer/index.css
+++ b/apps/emdash-desktop/src/renderer/index.css
@@ -7,6 +7,7 @@
 @custom-variant dark-black (&:is(.dark-black *));
 @custom-variant emlight (&:is(.emlight *));
 @custom-variant emdark (&:is(.emdark *));
+@custom-variant emwebstorm (&:is(.emwebstorm *));
 
 @theme inline {
   --font-sans:
@@ -726,6 +727,70 @@
 
     --foreground-conflict: var(--orange-9);
     --foreground-merged: var(--purple-9);
+  }
+
+  /* ── WebStorm New UI (Dark) ──────────────────────────────────
+   * Layered on top of .emdark (the renderer adds BOTH classes), so every
+   * semantic token that resolves through the neutral/blue ramps is retuned
+   * automatically — only WebStorm-specific values are overridden below.
+   * Palette sampled from the JetBrains "New UI" Dark theme.
+   */
+  .emwebstorm {
+    /* Neutral ramp — WebStorm greys (1 = darkest … 12 = lightest text) */
+    --neutral-1: #1e1f22; /* app / editor background */
+    --neutral-2: #2b2d30; /* tool windows / panels */
+    --neutral-3: #303236;
+    --neutral-4: #393b40;
+    --neutral-5: #3c3f44;
+    --neutral-6: #43454a; /* borders / dividers */
+    --neutral-7: #4e5157;
+    --neutral-8: #5a5d63;
+    --neutral-9: #6f737a; /* passive text */
+    --neutral-10: #868a91;
+    --neutral-11: #9da0a8; /* muted text */
+    --neutral-12: #dfe1e5; /* primary text */
+
+    /* Blue ramp — WebStorm accent / links / info */
+    --blue-3: #1d2c4a;
+    --blue-4: #20355c;
+    --blue-6: #2e436e;
+    --blue-7: #345088;
+    --blue-9: #3574f0; /* accent */
+    --blue-10: #4280ef;
+    --blue-11: #6b9bfa; /* links */
+    --blue-12: #cdd6f4;
+
+    /* Diff / status accents */
+    --green-9: #5fad65;
+    --green-10: #73bd79;
+    --red-9: #db5c5c;
+    --red-10: #e06c6c;
+    --amber-11: #f2c55c;
+
+    /* Primary button — WebStorm blue (overrides emdark's jade) */
+    --primary-button-background: #3574f0;
+    --primary-button-background-hover: #4280ef;
+    --primary-button-foreground: #ffffff;
+    --primary-button-border: transparent;
+
+    /* Selection — muted navy, not the bright accent */
+    --selection: #2e436e;
+    --selection-foreground: #dfe1e5;
+
+    /* Monaco editor */
+    --monaco-bg: #1e1f22;
+    --monaco-fg: #bcbec4;
+    --monaco-line-highlight: #26282e;
+    --monaco-line-number: #4b4d51;
+    --monaco-gutter: #1e1f22;
+    --monaco-selection-bg: #214283;
+    --monaco-selection-fg: #dfe1e5;
+
+    /* xterm terminal */
+    --xterm-bg: #1e1f22;
+    --xterm-fg: #bcbec4;
+    --xterm-cursor: #bcbec4;
+    --xterm-cursor-accent: #1e1f22;
   }
 }
 

--- a/apps/emdash-desktop/src/renderer/lib/components/agent-icon.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/agent-icon.tsx
@@ -1,3 +1,4 @@
+import { isDarkTheme } from '@renderer/lib/theme/is-dark-theme';
 import { cn } from '@renderer/utils/utils';
 import { useTheme } from '../hooks/useTheme';
 import { useAgentIcon } from '../stores/use-agents';
@@ -14,7 +15,7 @@ interface AgentIconProps {
 
 export function AgentIcon({ id, size = 16, className, grayscale }: AgentIconProps) {
   const { effectiveTheme } = useTheme();
-  const mode = effectiveTheme === 'emdark' ? 'dark' : 'light';
+  const mode = isDarkTheme(effectiveTheme) ? 'dark' : 'light';
   const icon = useAgentIcon(id);
 
   if (!icon) return null;

--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-themes.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-themes.ts
@@ -9,7 +9,7 @@ type MonacoColors = Record<string, string>;
  * token map. Entries where the variable is not defined for that theme are
  * omitted.
  */
-function readMonacoVarsForTheme(cssClass: 'emlight' | 'emdark'): MonacoColors {
+function readMonacoVarsForTheme(cssClass: string): MonacoColors {
   const el = document.createElement('div');
   el.className = cssClass;
   el.style.cssText = 'position:absolute;visibility:hidden;pointer-events:none;';
@@ -64,8 +64,18 @@ export function defineMonacoThemes(monaco: Monaco): void {
     rules: [],
     colors: readMonacoVarsForTheme('emlight'),
   });
+
+  // WebStorm is layered on the dark base, so read both classes together.
+  monaco.editor.defineTheme('custom-webstorm', {
+    base: 'vs-dark',
+    inherit: true,
+    rules: [],
+    colors: readMonacoVarsForTheme('emdark emwebstorm'),
+  });
 }
 
 export function getMonacoTheme(effectiveTheme: string): string {
-  return effectiveTheme === 'emlight' ? 'custom-light' : 'custom-dark';
+  if (effectiveTheme === 'emlight') return 'custom-light';
+  if (effectiveTheme === 'emwebstorm') return 'custom-webstorm';
+  return 'custom-dark';
 }

--- a/apps/emdash-desktop/src/renderer/lib/providers/theme-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/providers/theme-provider.tsx
@@ -11,7 +11,7 @@ import { applyThemeToAll } from '@renderer/lib/pty/pty';
 import { getNextTheme } from '@renderer/lib/theme/theme-toggle-model';
 import type { Theme } from '@shared/core/app-settings';
 
-type EffectiveTheme = 'emlight' | 'emdark';
+export type EffectiveTheme = 'emlight' | 'emdark' | 'emwebstorm';
 
 function getSystemTheme(): EffectiveTheme {
   if (typeof window === 'undefined') return 'emlight';
@@ -27,8 +27,16 @@ function subscribeToSystemTheme(onChange: () => void) {
 function applyTheme(effective: EffectiveTheme) {
   if (typeof document === 'undefined') return;
   const root = document.documentElement;
-  root.classList.remove('emlight', 'emdark');
-  root.classList.add(effective);
+  root.classList.remove('emlight', 'emdark', 'emwebstorm');
+  // WebStorm adds BOTH emdark and emwebstorm so that:
+  //   (a) .emwebstorm{} CSS vars cascade on top of .emdark{} vars (same @layer, later wins), and
+  //   (b) `emdark:` Tailwind variant utilities (emdark:invert, emdark:text-foreground, …) keep
+  //       firing for descendants. Do not drop the emdark class here.
+  if (effective === 'emwebstorm') {
+    root.classList.add('emdark', 'emwebstorm');
+  } else {
+    root.classList.add(effective);
+  }
 }
 
 interface ThemeContextType {

--- a/apps/emdash-desktop/src/renderer/lib/theme/is-dark-theme.ts
+++ b/apps/emdash-desktop/src/renderer/lib/theme/is-dark-theme.ts
@@ -1,0 +1,10 @@
+import type { EffectiveTheme } from '@renderer/lib/providers/theme-provider';
+
+/**
+ * Themes that render against a dark background. WebStorm New UI ('emwebstorm')
+ * is a variant layered on the dark base, so it counts as dark here. Use this
+ * instead of comparing `effectiveTheme === 'emdark'` directly.
+ */
+export function isDarkTheme(effectiveTheme: EffectiveTheme): boolean {
+  return effectiveTheme === 'emdark' || effectiveTheme === 'emwebstorm';
+}

--- a/apps/emdash-desktop/src/renderer/lib/theme/theme-toggle-model.ts
+++ b/apps/emdash-desktop/src/renderer/lib/theme/theme-toggle-model.ts
@@ -5,5 +5,7 @@ export function getNextTheme(
   fallbackEffectiveTheme: NonNullable<Theme>
 ): NonNullable<Theme> {
   const effectiveTheme = current ?? fallbackEffectiveTheme;
+  // Binary dark-side <-> light shortcut: any non-emlight theme (including emwebstorm)
+  // toggles to emlight. WebStorm is reachable only via the settings picker, not this toggle.
   return effectiveTheme === 'emlight' ? 'emdark' : 'emlight';
 }

--- a/apps/emdash-desktop/src/renderer/lib/theme/theme-toggle.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/theme/theme-toggle.test.ts
@@ -10,6 +10,10 @@ describe('getNextTheme', () => {
     expect(getNextTheme('emdark', 'emdark')).toBe('emlight');
   });
 
+  it('toggles WebStorm (a dark variant) to light', () => {
+    expect(getNextTheme('emwebstorm', 'emwebstorm')).toBe('emlight');
+  });
+
   it('uses system light when no explicit theme is selected', () => {
     expect(getNextTheme(null, 'emlight')).toBe('emdark');
   });

--- a/apps/emdash-desktop/src/renderer/lib/ui/markdown-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/ui/markdown-renderer.tsx
@@ -11,6 +11,7 @@ import remarkMath from 'remark-math';
 import type { PluggableList } from 'unified';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import { confirmOpenExternalLink } from '@renderer/lib/open-external-link';
+import { isDarkTheme } from '@renderer/lib/theme/is-dark-theme';
 import { cn } from '@renderer/utils/utils';
 import { ExpandableImage } from './expandable-image';
 import { normalizeLatexDelimiters } from './markdown-latex';
@@ -393,7 +394,7 @@ export const MarkdownRenderer: React.FC<MarkdownRendererProps> = ({
   resolveImage,
 }) => {
   const { effectiveTheme } = useTheme();
-  const isDark = effectiveTheme === 'emdark';
+  const isDark = isDarkTheme(effectiveTheme);
 
   const fullComponents = useFullComponents(isDark, resolveImage);
   const compactComponents = useCompactComponents(isDark);


### PR DESCRIPTION
The app shipped only Emdash Light and Dark. This adds a third selectable theme that mirrors the JetBrains "New UI" Dark look. A VSCode theme file can't be loaded directly, so the palette is ported into the existing Tailwind custom-property token system.

The theme is layered on the dark base: the renderer applies both the emdark and emwebstorm classes, so it inherits every dark token and only overrides the WebStorm-specific surfaces, accent, selection, editor, and terminal colors — keeping it low-maintenance and leaving no token undefined. A new isDarkTheme() helper centralizes the dark-variant check that several components previously made by comparing against 'emdark' directly, so they now treat WebStorm as dark too.

Selectable from Settings -> Color mode. The keyboard light/dark toggle stays binary by design and is documented as such.

### Description

Give a short summary of what changed, why it's needed, and any important implementation notes.

### Related issues

Link related issues. If this PR fixes an issue, mention it like: Fixes #123.

### Testing

List the checks you ran, for example `pnpm run format`, `pnpm run lint`,
`pnpm run typecheck`, `pnpm run test`, and any manual testing.

### Screenshot/Recording (if applicable)

Attach a screenshot, GIF, or recording of the change. This is optional, but helps reviewers
understand UI or workflow changes.

<details>
<summary>Checklist</summary>

- [ ] I kept this PR small and focused
- [ ] I ran a self-review before opening this PR
- [ ] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [ ] I added or updated tests when behavior changed, or explained why not
- [ ] I only added comments where the logic is not obvious
- [ ] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
