### PR TITLE
fix: github reconnect flow

### DIFF
--- a/apps/emdash-desktop/src/main/core/account/account-errors.ts
+++ b/apps/emdash-desktop/src/main/core/account/account-errors.ts
@@ -1,0 +1,85 @@
+export type AccountInitializeError = AccountSessionPersistenceError;
+
+export type AccountSessionReadError = AccountSessionPersistenceError;
+
+export type AccountSessionValidationError = AccountSessionPersistenceError | AccountAuthServerError;
+
+export type AccountSessionError = AccountSessionReadError | AccountSessionValidationError;
+
+export type AccountSignInError =
+  | AccountInvalidAuthResponseError
+  | AccountOAuthError
+  | AccountSessionPersistenceError
+  | AccountProviderTokenPersistenceError;
+
+export type AccountLinkProviderError =
+  | AccountAuthServerError
+  | AccountInvalidAuthResponseError
+  | AccountNotSignedInError
+  | AccountOAuthError
+  | AccountProviderTokenPersistenceError
+  | AccountSessionExpiredError
+  | AccountSessionPersistenceError
+  | AccountUnsupportedProviderError;
+
+export type AccountSignOutError = AccountSessionPersistenceError;
+
+export type AccountLinkStartError =
+  | AccountAuthServerError
+  | AccountInvalidAuthResponseError
+  | AccountSessionExpiredError;
+
+export type AccountSessionPersistenceError = {
+  type: 'session_persistence_failed';
+  message: string;
+  cause?: unknown;
+};
+
+export type AccountNotSignedInError = {
+  type: 'not_signed_in';
+  message: string;
+};
+
+export type AccountSessionExpiredError = {
+  type: 'session_expired';
+  message: string;
+};
+
+export type AccountUnsupportedProviderError = {
+  type: 'unsupported_provider';
+  provider: string;
+  message: string;
+};
+
+export type AccountAuthServerError = {
+  type: 'auth_server_error';
+  status?: number;
+  message: string;
+  cause?: unknown;
+};
+
+export type AccountInvalidAuthResponseError = {
+  type: 'invalid_auth_response';
+  message: string;
+  cause?: unknown;
+};
+
+export type AccountOAuthError = {
+  type: 'oauth_failed';
+  message: string;
+  cause?: unknown;
+};
+
+export type AccountProviderTokenPersistenceError = {
+  type: 'provider_token_persistence_failed';
+  provider?: string;
+  message: string;
+  cause?: unknown;
+};
+
+export const SESSION_EXPIRED_MESSAGE =
+  'Your Emdash session expired. Sign in again to connect GitHub.';
+
+export function unknownErrorMessage(error: unknown, fallback: string): string {
+  return error instanceof Error ? error.message : fallback;
+}

--- a/apps/emdash-desktop/src/main/core/account/account-errors.ts
+++ b/apps/emdash-desktop/src/main/core/account/account-errors.ts
@@ -4,8 +4,6 @@ export type AccountSessionReadError = AccountSessionPersistenceError;
 
 export type AccountSessionValidationError = AccountSessionPersistenceError | AccountAuthServerError;
 
-export type AccountSessionError = AccountSessionReadError | AccountSessionValidationError;
-
 export type AccountSignInError =
   | AccountInvalidAuthResponseError
   | AccountOAuthError

--- a/apps/emdash-desktop/src/main/core/account/account-types.ts
+++ b/apps/emdash-desktop/src/main/core/account/account-types.ts
@@ -1,0 +1,54 @@
+import type { ProviderAccountPayload } from './provider-token-registry';
+
+export interface AccountUser {
+  userId: string;
+  name?: string;
+  username: string;
+  avatarUrl: string;
+  email: string;
+}
+
+export interface CachedProfile {
+  hasAccount: boolean;
+  userId: string;
+  name?: string;
+  username: string;
+  avatarUrl: string;
+  email: string;
+  lastValidated: string;
+}
+
+export interface SignInResult {
+  user: AccountUser;
+}
+
+export interface LinkProviderAccountResult {
+  provider: string;
+  providerAccountStatus?: 'created' | 'updated';
+  providerAccount?: ProviderAccountPayload;
+}
+
+export interface SessionState {
+  user: AccountUser | null;
+  isSignedIn: boolean;
+  hasAccount: boolean;
+}
+
+export interface AuthProviderToken {
+  accessToken: string;
+  providerId: string;
+  providerAccount?: ProviderAccountPayload;
+}
+
+export interface SignInExchange {
+  sessionToken: string;
+  user: AccountUser;
+  providerToken?: AuthProviderToken;
+}
+
+export interface SessionSnapshot {
+  token: string | null;
+  profile: CachedProfile | null;
+}
+
+export type SessionValidationResult = 'valid' | 'invalid' | 'unknown';

--- a/apps/emdash-desktop/src/main/core/account/controller.ts
+++ b/apps/emdash-desktop/src/main/core/account/controller.ts
@@ -5,70 +5,78 @@ import { emdashAccountService } from './services/emdash-account-service';
 
 export const accountController = createRPCController({
   getSession: async () => {
-    try {
-      return await emdashAccountService.getSession();
-    } catch (error) {
-      log.error('Failed to get account session:', error);
+    const result = await emdashAccountService.getSession();
+    if (!result.success) {
+      log.error('Failed to get account session:', result.error);
       return { user: null, isSignedIn: false, hasAccount: false };
     }
+    return result.data;
+  },
+
+  getValidatedSession: async () => {
+    const result = await emdashAccountService.getValidatedSession();
+    if (!result.success) {
+      log.error('Failed to get validated account session:', result.error);
+      return { user: null, isSignedIn: false, hasAccount: false };
+    }
+    return result.data;
   },
 
   signIn: async (provider?: string) => {
-    try {
-      const result = await emdashAccountService.signIn(provider);
-      telemetryService.capture('user_signed_in');
-      return { success: true, user: result.user };
-    } catch (error) {
-      log.error('Account sign-in failed:', error);
+    const result = await emdashAccountService.signIn(provider);
+    if (!result.success) {
+      log.error('Account sign-in failed:', result.error);
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Sign-in failed',
+        code: result.error.type,
+        error: result.error.message,
       };
     }
+
+    telemetryService.capture('user_signed_in');
+    return { success: true, user: result.data.user };
   },
 
   linkProviderAccount: async (provider?: string) => {
-    try {
-      const result = await emdashAccountService.linkProviderAccount(provider);
-      telemetryService.capture('integration_connected', { provider: result.provider });
-      return {
-        success: true,
-        provider: result.provider,
-        providerAccount: result.providerAccount,
-      };
-    } catch (error) {
-      log.error('Provider account link failed:', error);
+    const result = await emdashAccountService.linkProviderAccount(provider);
+    if (!result.success) {
+      if (result.error.type !== 'session_expired') {
+        log.error('Provider account link failed:', result.error);
+      }
       return {
         success: false,
-        error: error instanceof Error ? error.message : 'Account link failed',
+        code: result.error.type,
+        error: result.error.message,
       };
     }
+
+    telemetryService.capture('integration_connected', { provider: result.data.provider });
+    return {
+      success: true,
+      provider: result.data.provider,
+      providerAccountStatus: result.data.providerAccountStatus,
+      providerAccount: result.data.providerAccount,
+    };
   },
 
   signOut: async () => {
-    try {
-      await emdashAccountService.signOut();
-      telemetryService.capture('user_signed_out');
-      return { success: true };
-    } catch (error) {
-      log.error('Account sign-out failed:', error);
-      return { success: false, error: 'Sign-out failed' };
+    const result = await emdashAccountService.signOut();
+    if (!result.success) {
+      log.error('Account sign-out failed:', result.error);
+      return { success: false, code: result.error.type, error: result.error.message };
     }
+
+    telemetryService.capture('user_signed_out');
+    return { success: true };
   },
 
   checkHealth: async () => {
-    try {
-      return await emdashAccountService.checkServerHealth();
-    } catch {
-      return false;
-    }
+    return await emdashAccountService.checkServerHealth();
   },
 
   validateSession: async () => {
-    try {
-      return await emdashAccountService.validateSession();
-    } catch {
-      return false;
-    }
+    const result = await emdashAccountService.validateSession();
+    if (!result.success) return false;
+    return result.data !== 'invalid';
   },
 });

--- a/apps/emdash-desktop/src/main/core/account/controller.ts
+++ b/apps/emdash-desktop/src/main/core/account/controller.ts
@@ -13,15 +13,6 @@ export const accountController = createRPCController({
     return result.data;
   },
 
-  getValidatedSession: async () => {
-    const result = await emdashAccountService.getValidatedSession();
-    if (!result.success) {
-      log.error('Failed to get validated account session:', result.error);
-      return { user: null, isSignedIn: false, hasAccount: false };
-    }
-    return result.data;
-  },
-
   signIn: async (provider?: string) => {
     const result = await emdashAccountService.signIn(provider);
     if (!result.success) {

--- a/apps/emdash-desktop/src/main/core/account/provider-token-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/account/provider-token-registry.test.ts
@@ -49,6 +49,32 @@ describe('providerTokenRegistry', () => {
     ]);
   });
 
+  it('returns handler dispatch results', async () => {
+    providerTokenRegistry.register('github', async (payload) => ({
+      providerAccountStatus: 'created',
+      providerAccount: payload.providerAccount,
+    }));
+
+    await expect(
+      providerTokenRegistry.dispatch('github', {
+        accessToken: 'ghp_token123',
+        providerAccount: {
+          providerId: 'github',
+          providerAccountId: '42',
+          host: 'github.com',
+          login: 'monalisa',
+          avatarUrl: 'https://avatars.githubusercontent.com/u/42',
+        },
+      })
+    ).resolves.toMatchObject({
+      providerAccountStatus: 'created',
+      providerAccount: {
+        providerId: 'github',
+        providerAccountId: '42',
+      },
+    });
+  });
+
   it('is a no-op when no handler is registered for the provider', async () => {
     await expect(
       providerTokenRegistry.dispatch('gitlab', { accessToken: 'token' })

--- a/apps/emdash-desktop/src/main/core/account/provider-token-registry.ts
+++ b/apps/emdash-desktop/src/main/core/account/provider-token-registry.ts
@@ -11,7 +11,14 @@ export type ProviderTokenPayload = {
   providerAccount?: ProviderAccountPayload;
 };
 
-type ProviderTokenHandler = (payload: ProviderTokenPayload) => Promise<void>;
+export type ProviderTokenDispatchResult = {
+  providerAccountStatus?: 'created' | 'updated';
+  providerAccount?: ProviderAccountPayload;
+};
+
+type ProviderTokenHandler = (
+  payload: ProviderTokenPayload
+) => Promise<ProviderTokenDispatchResult | void>;
 
 const handlers = new Map<string, ProviderTokenHandler>();
 
@@ -20,10 +27,13 @@ export const providerTokenRegistry = {
     handlers.set(provider, handler);
   },
 
-  async dispatch(provider: string, payload: ProviderTokenPayload): Promise<void> {
+  async dispatch(
+    provider: string,
+    payload: ProviderTokenPayload
+  ): Promise<ProviderTokenDispatchResult | undefined> {
     const handler = handlers.get(provider);
-    if (!handler) return;
-    await handler(payload);
+    if (!handler) return undefined;
+    return (await handler(payload)) ?? undefined;
   },
 
   /** For testing only — removes all registered handlers. */

--- a/apps/emdash-desktop/src/main/core/account/services/account-auth-response-parser.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/account-auth-response-parser.ts
@@ -1,0 +1,96 @@
+import { err, ok, type Result } from '@shared/lib/result';
+import type { AccountInvalidAuthResponseError } from '../account-errors';
+import type { AccountUser, AuthProviderToken, SignInExchange } from '../account-types';
+import type { ProviderAccountPayload } from '../provider-token-registry';
+
+export function parseSignInResponse(
+  raw: Record<string, unknown>
+): Result<SignInExchange, AccountInvalidAuthResponseError> {
+  const sessionToken = typeof raw.sessionToken === 'string' ? raw.sessionToken : undefined;
+  const user = parseAccountUser(raw.user);
+
+  if (!sessionToken || !user) {
+    return err({
+      type: 'invalid_auth_response',
+      message: 'Invalid sign-in response: missing sessionToken or user',
+    });
+  }
+
+  return ok({
+    sessionToken,
+    user,
+    providerToken: parseOptionalProviderToken(raw),
+  });
+}
+
+export function parseRequiredProviderTokenResponse(
+  raw: Record<string, unknown>
+): Result<AuthProviderToken, AccountInvalidAuthResponseError> {
+  const providerToken = parseOptionalProviderToken(raw);
+  if (!providerToken) {
+    return err({
+      type: 'invalid_auth_response',
+      message: 'Invalid account link response: missing provider token',
+    });
+  }
+
+  return ok(providerToken);
+}
+
+function parseAccountUser(raw: unknown): AccountUser | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+
+  const candidate = raw as Record<string, unknown>;
+  if (
+    typeof candidate.userId !== 'string' ||
+    typeof candidate.username !== 'string' ||
+    typeof candidate.avatarUrl !== 'string' ||
+    typeof candidate.email !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return {
+    userId: candidate.userId,
+    name: typeof candidate.name === 'string' ? candidate.name : undefined,
+    username: candidate.username,
+    avatarUrl: candidate.avatarUrl,
+    email: candidate.email,
+  };
+}
+
+function parseOptionalProviderToken(raw: Record<string, unknown>): AuthProviderToken | undefined {
+  const accessToken = typeof raw.accessToken === 'string' ? raw.accessToken : undefined;
+  const providerId = typeof raw.providerId === 'string' ? raw.providerId : undefined;
+  if (!accessToken || !providerId) return undefined;
+
+  return {
+    accessToken,
+    providerId,
+    providerAccount: parseProviderAccountPayload(raw.providerAccount),
+  };
+}
+
+function parseProviderAccountPayload(raw: unknown): ProviderAccountPayload | undefined {
+  if (typeof raw !== 'object' || raw === null) return undefined;
+
+  const candidate = raw as Record<string, unknown>;
+  if (
+    typeof candidate.providerId !== 'string' ||
+    typeof candidate.providerAccountId !== 'string' ||
+    candidate.providerAccountId.length === 0 ||
+    typeof candidate.host !== 'string' ||
+    typeof candidate.login !== 'string' ||
+    typeof candidate.avatarUrl !== 'string'
+  ) {
+    return undefined;
+  }
+
+  return {
+    providerId: candidate.providerId,
+    providerAccountId: candidate.providerAccountId,
+    host: candidate.host,
+    login: candidate.login,
+    avatarUrl: candidate.avatarUrl,
+  };
+}

--- a/apps/emdash-desktop/src/main/core/account/services/account-auth-server-client.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/account-auth-server-client.ts
@@ -1,0 +1,98 @@
+import { err, ok, type Result } from '@shared/lib/result';
+import {
+  SESSION_EXPIRED_MESSAGE,
+  type AccountAuthServerError,
+  type AccountLinkStartError,
+  type AccountSessionValidationError,
+  unknownErrorMessage,
+} from '../account-errors';
+import type { SessionValidationResult } from '../account-types';
+import { ACCOUNT_CONFIG } from '../config';
+
+export class AccountAuthServerClient {
+  async checkHealth(): Promise<boolean> {
+    const { baseUrl } = ACCOUNT_CONFIG.authServer;
+    try {
+      const response = await fetch(`${baseUrl}/health`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
+  }
+
+  async validateSession(
+    token: string
+  ): Promise<Result<SessionValidationResult, AccountSessionValidationError>> {
+    const { baseUrl } = ACCOUNT_CONFIG.authServer;
+    try {
+      const response = await fetch(`${baseUrl}/api/auth/get-session`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}` },
+        signal: AbortSignal.timeout(3000),
+      });
+
+      return ok(response.ok ? 'valid' : 'invalid');
+    } catch {
+      return ok('unknown');
+    }
+  }
+
+  async startAccountLink(sessionToken: string): Promise<Result<string, AccountLinkStartError>> {
+    const { baseUrl } = ACCOUNT_CONFIG.authServer;
+    let response: Response;
+
+    try {
+      response = await fetch(`${baseUrl}/api/v1/auth/electron/account-link/start`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${sessionToken}`,
+        },
+        signal: AbortSignal.timeout(ACCOUNT_CONFIG.authServer.authTimeoutMs),
+      });
+    } catch (error) {
+      return err({
+        type: 'auth_server_error',
+        message: unknownErrorMessage(error, 'Account link start failed'),
+        cause: error,
+      });
+    }
+
+    if (!response.ok) {
+      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
+      if (response.status === 401 || payload?.error === 'No active session') {
+        return err({
+          type: 'session_expired',
+          message: SESSION_EXPIRED_MESSAGE,
+        });
+      }
+
+      return err({
+        type: 'auth_server_error',
+        status: response.status,
+        message: payload?.error || `Account link start failed (${response.status})`,
+      } satisfies AccountAuthServerError);
+    }
+
+    let payload: { accountLinkState?: unknown };
+    try {
+      payload = (await response.json()) as { accountLinkState?: unknown };
+    } catch (error) {
+      return err({
+        type: 'invalid_auth_response',
+        message: 'Invalid account link start response',
+        cause: error,
+      });
+    }
+
+    if (typeof payload.accountLinkState !== 'string' || payload.accountLinkState.length === 0) {
+      return err({
+        type: 'invalid_auth_response',
+        message: 'Invalid account link start response: missing accountLinkState',
+      });
+    }
+
+    return ok(payload.accountLinkState);
+  }
+}

--- a/apps/emdash-desktop/src/main/core/account/services/account-auth-server-client.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/account-auth-server-client.ts
@@ -10,18 +10,6 @@ import type { SessionValidationResult } from '../account-types';
 import { ACCOUNT_CONFIG } from '../config';
 
 export class AccountAuthServerClient {
-  async checkHealth(): Promise<boolean> {
-    const { baseUrl } = ACCOUNT_CONFIG.authServer;
-    try {
-      const response = await fetch(`${baseUrl}/health`, {
-        signal: AbortSignal.timeout(3000),
-      });
-      return response.ok;
-    } catch {
-      return false;
-    }
-  }
-
   async validateSession(
     token: string
   ): Promise<Result<SessionValidationResult, AccountSessionValidationError>> {
@@ -94,5 +82,17 @@ export class AccountAuthServerClient {
     }
 
     return ok(payload.accountLinkState);
+  }
+
+  async checkHealth(): Promise<boolean> {
+    const { baseUrl } = ACCOUNT_CONFIG.authServer;
+    try {
+      const response = await fetch(`${baseUrl}/health`, {
+        signal: AbortSignal.timeout(3000),
+      });
+      return response.ok;
+    } catch {
+      return false;
+    }
   }
 }

--- a/apps/emdash-desktop/src/main/core/account/services/account-oauth-client.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/account-oauth-client.ts
@@ -1,0 +1,57 @@
+import { executeOAuthFlow } from '@main/core/shared/oauth-flow';
+import { err, ok, type Result } from '@shared/lib/result';
+import { type AccountOAuthError, unknownErrorMessage } from '../account-errors';
+import { ACCOUNT_CONFIG } from '../config';
+
+export class AccountOAuthClient {
+  async signIn(provider: string): Promise<Result<Record<string, unknown>, AccountOAuthError>> {
+    const { baseUrl } = ACCOUNT_CONFIG.authServer;
+    const extraParams: Record<string, string> = {};
+
+    if (provider) {
+      extraParams.provider_id = provider;
+    }
+
+    return this.execute({
+      authorizeUrl: `${baseUrl}/sign-in`,
+      exchangeUrl: `${baseUrl}/api/v1/auth/electron/exchange`,
+      successRedirectUrl: `${baseUrl}/auth/success`,
+      errorRedirectUrl: `${baseUrl}/auth/error`,
+      extraParams,
+      timeoutMs: ACCOUNT_CONFIG.authServer.authTimeoutMs,
+    });
+  }
+
+  async linkProviderAccount(
+    provider: string,
+    accountLinkState: string
+  ): Promise<Result<Record<string, unknown>, AccountOAuthError>> {
+    const { baseUrl } = ACCOUNT_CONFIG.authServer;
+
+    return this.execute({
+      authorizeUrl: `${baseUrl}/api/v1/auth/electron/account-link/authorize`,
+      exchangeUrl: `${baseUrl}/api/v1/auth/electron/exchange`,
+      successRedirectUrl: `${baseUrl}/auth/success`,
+      errorRedirectUrl: `${baseUrl}/auth/error`,
+      extraParams: {
+        account_link_state: accountLinkState,
+        provider_id: provider,
+      },
+      timeoutMs: ACCOUNT_CONFIG.authServer.authTimeoutMs,
+    });
+  }
+
+  private async execute(
+    options: Parameters<typeof executeOAuthFlow>[0]
+  ): Promise<Result<Record<string, unknown>, AccountOAuthError>> {
+    try {
+      return ok(await executeOAuthFlow(options));
+    } catch (error) {
+      return err({
+        type: 'oauth_failed',
+        message: unknownErrorMessage(error, 'OAuth flow failed'),
+        cause: error,
+      });
+    }
+  }
+}

--- a/apps/emdash-desktop/src/main/core/account/services/account-session-store.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/account-session-store.ts
@@ -43,6 +43,13 @@ export class AccountSessionStore {
     }
   }
 
+  snapshot(): SessionSnapshot {
+    return {
+      token: this.sessionToken,
+      profile: this.cachedProfile,
+    };
+  }
+
   async ensureTokenLoaded(): Promise<Result<string | null, AccountSessionPersistenceError>> {
     if (this.sessionToken) return ok(this.sessionToken);
 
@@ -128,13 +135,6 @@ export class AccountSessionStore {
     } catch (error) {
       return err(toSessionPersistenceError(error, 'Failed to clear account session'));
     }
-  }
-
-  snapshot(): SessionSnapshot {
-    return {
-      token: this.sessionToken,
-      profile: this.cachedProfile,
-    };
   }
 
   private toSessionState(): SessionState {

--- a/apps/emdash-desktop/src/main/core/account/services/account-session-store.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/account-session-store.ts
@@ -1,0 +1,169 @@
+import { KV } from '@main/db/kv';
+import { err, ok, type Result } from '@shared/lib/result';
+import {
+  type AccountNotSignedInError,
+  type AccountSessionPersistenceError,
+  unknownErrorMessage,
+} from '../account-errors';
+import type { AccountUser, CachedProfile, SessionSnapshot, SessionState } from '../account-types';
+import { accountCredentialStore } from './credential-store';
+
+interface AccountKVSchema extends Record<string, unknown> {
+  profile: CachedProfile;
+}
+
+const accountKV = new KV<AccountKVSchema>('account');
+
+export class AccountSessionStore {
+  private cachedProfile: CachedProfile | null = null;
+  private sessionToken: string | null = null;
+
+  async load(): Promise<Result<SessionSnapshot, AccountSessionPersistenceError>> {
+    try {
+      const [sessionToken, profile] = await Promise.all([
+        accountCredentialStore.get(),
+        accountKV.get('profile'),
+      ]);
+      if (!sessionToken.success) return sessionToken;
+
+      this.sessionToken = sessionToken.data;
+      this.cachedProfile = profile;
+      return ok(this.snapshot());
+    } catch (error) {
+      return err(toSessionPersistenceError(error, 'Failed to load account session'));
+    }
+  }
+
+  async getSession(): Promise<Result<SessionState, AccountSessionPersistenceError>> {
+    try {
+      this.cachedProfile = await accountKV.get('profile');
+      return ok(this.toSessionState());
+    } catch (error) {
+      return err(toSessionPersistenceError(error, 'Failed to read account session'));
+    }
+  }
+
+  async ensureTokenLoaded(): Promise<Result<string | null, AccountSessionPersistenceError>> {
+    if (this.sessionToken) return ok(this.sessionToken);
+
+    try {
+      const sessionToken = await accountCredentialStore.get();
+      if (!sessionToken.success) return sessionToken;
+
+      this.sessionToken = sessionToken.data;
+      return ok(this.sessionToken);
+    } catch (error) {
+      return err(toSessionPersistenceError(error, 'Failed to load account session token'));
+    }
+  }
+
+  async requireToken(): Promise<
+    Result<string, AccountNotSignedInError | AccountSessionPersistenceError>
+  > {
+    const token = await this.ensureTokenLoaded();
+    if (!token.success) return token;
+    if (!token.data) {
+      return err({
+        type: 'not_signed_in',
+        message: 'You must be signed in to link a provider account',
+      });
+    }
+    return ok(token.data);
+  }
+
+  async saveSignedInSession(
+    user: AccountUser,
+    sessionToken: string,
+    lastValidated: string
+  ): Promise<Result<void, AccountSessionPersistenceError>> {
+    const profile: CachedProfile = {
+      hasAccount: true,
+      userId: user.userId,
+      name: user.name,
+      username: user.username,
+      avatarUrl: user.avatarUrl,
+      email: user.email,
+      lastValidated,
+    };
+
+    try {
+      const persistedToken = await accountCredentialStore.set(sessionToken);
+      if (!persistedToken.success) return persistedToken;
+
+      await accountKV.setOrThrow('profile', profile);
+      this.sessionToken = sessionToken;
+      this.cachedProfile = profile;
+      return ok();
+    } catch (error) {
+      return err(toSessionPersistenceError(error, 'Failed to persist account session'));
+    }
+  }
+
+  async markValidated(
+    lastValidated: string
+  ): Promise<Result<void, AccountSessionPersistenceError>> {
+    if (!this.cachedProfile) return ok();
+
+    try {
+      this.cachedProfile = { ...this.cachedProfile, lastValidated };
+      await accountKV.setOrThrow('profile', this.cachedProfile);
+      return ok();
+    } catch (error) {
+      return err(toSessionPersistenceError(error, 'Failed to update account session'));
+    }
+  }
+
+  async clearSessionPreservingAccount(): Promise<Result<void, AccountSessionPersistenceError>> {
+    this.sessionToken = null;
+    const clearedToken = await accountCredentialStore.clear();
+    if (!clearedToken.success) return clearedToken;
+
+    try {
+      const profile = this.cachedProfile ?? (await accountKV.get('profile'));
+      if (!profile) return ok();
+
+      this.cachedProfile = { ...profile, hasAccount: true };
+      await accountKV.setOrThrow('profile', this.cachedProfile);
+      return ok();
+    } catch (error) {
+      return err(toSessionPersistenceError(error, 'Failed to clear account session'));
+    }
+  }
+
+  snapshot(): SessionSnapshot {
+    return {
+      token: this.sessionToken,
+      profile: this.cachedProfile,
+    };
+  }
+
+  private toSessionState(): SessionState {
+    const hasAccount = this.cachedProfile?.hasAccount === true;
+    const isSignedIn = hasAccount && this.sessionToken !== null;
+    return {
+      user:
+        isSignedIn && this.cachedProfile
+          ? {
+              userId: this.cachedProfile.userId,
+              name: this.cachedProfile.name,
+              username: this.cachedProfile.username,
+              avatarUrl: this.cachedProfile.avatarUrl,
+              email: this.cachedProfile.email,
+            }
+          : null,
+      isSignedIn,
+      hasAccount,
+    };
+  }
+}
+
+function toSessionPersistenceError(
+  error: unknown,
+  fallback: string
+): AccountSessionPersistenceError {
+  return {
+    type: 'session_persistence_failed',
+    message: unknownErrorMessage(error, fallback),
+    cause: error,
+  };
+}

--- a/apps/emdash-desktop/src/main/core/account/services/account-session-store.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/account-session-store.ts
@@ -121,9 +121,9 @@ export class AccountSessionStore {
   }
 
   async clearSessionPreservingAccount(): Promise<Result<void, AccountSessionPersistenceError>> {
-    this.sessionToken = null;
     const clearedToken = await accountCredentialStore.clear();
     if (!clearedToken.success) return clearedToken;
+    this.sessionToken = null;
 
     try {
       const profile = this.cachedProfile ?? (await accountKV.get('profile'));

--- a/apps/emdash-desktop/src/main/core/account/services/credential-store.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/credential-store.ts
@@ -1,32 +1,49 @@
 import { encryptedAppSecretsStore } from '@main/core/secrets/encrypted-app-secrets-store';
 import { log } from '@main/lib/logger';
+import { err, ok, type Result } from '@shared/lib/result';
+import { type AccountSessionPersistenceError, unknownErrorMessage } from '../account-errors';
 
 const ACCOUNT_SESSION_SECRET_KEY = 'emdash-account-token';
 
 export class AccountCredentialStore {
-  async get(): Promise<string | null> {
+  async get(): Promise<Result<string | null, AccountSessionPersistenceError>> {
     try {
-      return await encryptedAppSecretsStore.getSecret(ACCOUNT_SESSION_SECRET_KEY);
+      return ok(await encryptedAppSecretsStore.getSecret(ACCOUNT_SESSION_SECRET_KEY));
     } catch (error) {
       log.error('Failed to retrieve session token:', error);
-      return null;
+      return err({
+        type: 'session_persistence_failed',
+        message: unknownErrorMessage(error, 'Failed to retrieve session token'),
+        cause: error,
+      });
     }
   }
 
-  async set(token: string): Promise<void> {
+  async set(token: string): Promise<Result<void, AccountSessionPersistenceError>> {
     try {
       await encryptedAppSecretsStore.setSecret(ACCOUNT_SESSION_SECRET_KEY, token);
+      return ok();
     } catch (error) {
       log.error('Failed to store session token:', error);
-      throw error;
+      return err({
+        type: 'session_persistence_failed',
+        message: unknownErrorMessage(error, 'Failed to store session token'),
+        cause: error,
+      });
     }
   }
 
-  async clear(): Promise<void> {
+  async clear(): Promise<Result<void, AccountSessionPersistenceError>> {
     try {
       await encryptedAppSecretsStore.deleteSecret(ACCOUNT_SESSION_SECRET_KEY);
+      return ok();
     } catch (error) {
       log.error('Failed to clear session token:', error);
+      return err({
+        type: 'session_persistence_failed',
+        message: unknownErrorMessage(error, 'Failed to clear session token'),
+        cause: error,
+      });
     }
   }
 }

--- a/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.test.ts
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { ok, type Result } from '@shared/lib/result';
+import { err, ok, type Result } from '@shared/lib/result';
 import { EmdashAccountService } from './emdash-account-service';
 
 const mockCredGet = vi.fn();
@@ -134,55 +134,6 @@ describe('EmdashAccountService', () => {
       mockCredGet.mockResolvedValue(ok('token-123'));
       unwrapResult(await service.loadSessionToken());
       expect(mockCredGet).toHaveBeenCalled();
-    });
-  });
-
-  describe('getValidatedSession()', () => {
-    it('clears stale local session before reporting session state', async () => {
-      const accountCleared = vi.fn();
-      service.on('accountCleared', accountCleared);
-      mockCredGet.mockResolvedValue(ok('stale-session-token'));
-      mockKvGet.mockResolvedValue({
-        hasAccount: true,
-        userId: 'u1',
-        name: 'Test User',
-        username: 'test',
-        avatarUrl: '',
-        email: 'test@test.com',
-        lastValidated: '2026-01-01',
-      });
-      mockFetch.mockResolvedValue({ ok: false, status: 401 });
-
-      const session = unwrapResult(await service.getValidatedSession());
-      expect(session).toMatchObject({
-        isSignedIn: false,
-        hasAccount: true,
-        user: null,
-      });
-      expect(mockCredClear).toHaveBeenCalled();
-      expect(accountCleared).toHaveBeenCalled();
-    });
-
-    it('keeps a local session on validation network errors', async () => {
-      mockCredGet.mockResolvedValue(ok('session-abc'));
-      mockKvGet.mockResolvedValue({
-        hasAccount: true,
-        userId: 'u1',
-        name: 'Test User',
-        username: 'test',
-        avatarUrl: '',
-        email: 'test@test.com',
-        lastValidated: '2026-01-01',
-      });
-      mockFetch.mockRejectedValue(new Error('network error'));
-
-      const session = unwrapResult(await service.getValidatedSession());
-      expect(session).toMatchObject({
-        isSignedIn: true,
-        hasAccount: true,
-        user: expect.objectContaining({ username: 'test' }),
-      });
-      expect(mockCredClear).not.toHaveBeenCalled();
     });
   });
 
@@ -556,6 +507,39 @@ describe('EmdashAccountService', () => {
       });
       const session = unwrapResult(await service.getSession());
       expect(session.isSignedIn).toBe(false);
+      expect(session.hasAccount).toBe(true);
+    });
+
+    it('keeps the in-memory session token when credential clearing fails', async () => {
+      const exchangeResult = {
+        sessionToken: 'session-abc',
+        accessToken: 'ghp_123',
+        providerId: 'github',
+        user: { userId: 'u1', username: 'test', avatarUrl: '', email: '' },
+      };
+      mockExecuteOAuthFlow.mockResolvedValue(exchangeResult);
+      unwrapResult(await service.signIn());
+      vi.clearAllMocks();
+      mockCredClear.mockResolvedValue(
+        err({
+          type: 'session_persistence_failed',
+          message: 'Failed to clear session token',
+        })
+      );
+
+      const error = unwrapError(await service.signOut());
+      expect(error).toMatchObject({ type: 'session_persistence_failed' });
+      expect(mockKvSet).not.toHaveBeenCalled();
+
+      mockKvGet.mockResolvedValue({
+        hasAccount: true,
+        userId: 'u1',
+        username: 'test',
+        avatarUrl: '',
+        email: '',
+      });
+      const session = unwrapResult(await service.getSession());
+      expect(session.isSignedIn).toBe(true);
       expect(session.hasAccount).toBe(true);
     });
   });

--- a/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ok, type Result } from '@shared/lib/result';
 import { EmdashAccountService } from './emdash-account-service';
 
 const mockCredGet = vi.fn();
@@ -20,6 +21,9 @@ vi.mock('@main/db/kv', () => ({
       return mockKvGet(...args);
     }
     set(...args: unknown[]) {
+      return mockKvSet(...args);
+    }
+    setOrThrow(...args: unknown[]) {
       return mockKvSet(...args);
     }
   },
@@ -46,19 +50,41 @@ vi.mock('../config', () => ({
 const mockFetch = vi.fn();
 vi.stubGlobal('fetch', mockFetch);
 
+function unwrapResult<T, E>(result: Result<T, E>): T {
+  expect(result.success).toBe(true);
+  if (!result.success) {
+    throw new Error(`Expected ok result, got ${JSON.stringify(result.error)}`);
+  }
+  return result.data;
+}
+
+function unwrapError<T, E>(result: Result<T, E>): E {
+  expect(result.success).toBe(false);
+  if (result.success) {
+    throw new Error(`Expected error result, got ${JSON.stringify(result.data)}`);
+  }
+  return result.error;
+}
+
 describe('EmdashAccountService', () => {
   let service: EmdashAccountService;
 
   beforeEach(() => {
     vi.clearAllMocks();
+    mockCredGet.mockResolvedValue(ok(null));
+    mockCredSet.mockResolvedValue(ok());
+    mockCredClear.mockResolvedValue(ok());
     mockKvGet.mockResolvedValue(null);
     mockKvSet.mockResolvedValue(undefined);
+    mockFetch.mockReset();
+    mockExecuteOAuthFlow.mockReset();
+    mockDispatch.mockResolvedValue(undefined);
     service = new EmdashAccountService();
   });
 
   describe('getSession()', () => {
     it('returns no account when profile cache is empty', async () => {
-      const session = await service.getSession();
+      const session = unwrapResult(await service.getSession());
       expect(session).toEqual({ user: null, isSignedIn: false, hasAccount: false });
     });
 
@@ -72,14 +98,14 @@ describe('EmdashAccountService', () => {
         email: 'test@test.com',
         lastValidated: '2026-01-01',
       });
-      const session = await service.getSession();
+      const session = unwrapResult(await service.getSession());
       expect(session.hasAccount).toBe(true);
       expect(session.isSignedIn).toBe(false);
       expect(session.user).toBeNull();
     });
 
     it('returns the cached user name when signed in', async () => {
-      mockCredGet.mockResolvedValue('token-123');
+      mockCredGet.mockResolvedValue(ok('token-123'));
       mockKvGet.mockResolvedValue({
         hasAccount: true,
         userId: 'u1',
@@ -90,8 +116,8 @@ describe('EmdashAccountService', () => {
         lastValidated: '2026-01-01',
       });
 
-      await service.loadSessionToken();
-      const session = await service.getSession();
+      unwrapResult(await service.loadSessionToken());
+      const session = unwrapResult(await service.getSession());
 
       expect(session.user).toEqual({
         userId: 'u1',
@@ -105,9 +131,58 @@ describe('EmdashAccountService', () => {
 
   describe('loadSessionToken()', () => {
     it('loads token from credential store', async () => {
-      mockCredGet.mockResolvedValue('token-123');
-      await service.loadSessionToken();
+      mockCredGet.mockResolvedValue(ok('token-123'));
+      unwrapResult(await service.loadSessionToken());
       expect(mockCredGet).toHaveBeenCalled();
+    });
+  });
+
+  describe('getValidatedSession()', () => {
+    it('clears stale local session before reporting session state', async () => {
+      const accountCleared = vi.fn();
+      service.on('accountCleared', accountCleared);
+      mockCredGet.mockResolvedValue(ok('stale-session-token'));
+      mockKvGet.mockResolvedValue({
+        hasAccount: true,
+        userId: 'u1',
+        name: 'Test User',
+        username: 'test',
+        avatarUrl: '',
+        email: 'test@test.com',
+        lastValidated: '2026-01-01',
+      });
+      mockFetch.mockResolvedValue({ ok: false, status: 401 });
+
+      const session = unwrapResult(await service.getValidatedSession());
+      expect(session).toMatchObject({
+        isSignedIn: false,
+        hasAccount: true,
+        user: null,
+      });
+      expect(mockCredClear).toHaveBeenCalled();
+      expect(accountCleared).toHaveBeenCalled();
+    });
+
+    it('keeps a local session on validation network errors', async () => {
+      mockCredGet.mockResolvedValue(ok('session-abc'));
+      mockKvGet.mockResolvedValue({
+        hasAccount: true,
+        userId: 'u1',
+        name: 'Test User',
+        username: 'test',
+        avatarUrl: '',
+        email: 'test@test.com',
+        lastValidated: '2026-01-01',
+      });
+      mockFetch.mockRejectedValue(new Error('network error'));
+
+      const session = unwrapResult(await service.getValidatedSession());
+      expect(session).toMatchObject({
+        isSignedIn: true,
+        hasAccount: true,
+        user: expect.objectContaining({ username: 'test' }),
+      });
+      expect(mockCredClear).not.toHaveBeenCalled();
     });
   });
 
@@ -127,7 +202,7 @@ describe('EmdashAccountService', () => {
       };
       mockExecuteOAuthFlow.mockResolvedValue(oauthResponse);
 
-      const result = await service.signIn();
+      const result = unwrapResult(await service.signIn());
 
       expect(mockExecuteOAuthFlow).toHaveBeenCalledWith(expect.objectContaining({}));
       expect(mockCredSet).toHaveBeenCalledWith('session-abc');
@@ -149,7 +224,7 @@ describe('EmdashAccountService', () => {
       };
       mockExecuteOAuthFlow.mockResolvedValue(oauthResponse);
 
-      await service.signIn('github');
+      unwrapResult(await service.signIn('github'));
 
       expect(mockExecuteOAuthFlow).toHaveBeenCalledWith(expect.objectContaining({}));
     });
@@ -170,7 +245,7 @@ describe('EmdashAccountService', () => {
       };
       mockExecuteOAuthFlow.mockResolvedValue(oauthResponse);
 
-      await service.signIn();
+      unwrapResult(await service.signIn());
 
       expect(mockDispatch).toHaveBeenCalledWith('github', {
         accessToken: 'ghp_123',
@@ -198,7 +273,7 @@ describe('EmdashAccountService', () => {
       };
       mockExecuteOAuthFlow.mockResolvedValue(oauthResponse);
 
-      await service.signIn();
+      unwrapResult(await service.signIn());
 
       expect(mockDispatch).toHaveBeenCalledWith('github', {
         accessToken: 'ghp_123',
@@ -206,7 +281,7 @@ describe('EmdashAccountService', () => {
       });
     });
 
-    it('throws when provider token persistence fails', async () => {
+    it('returns a typed error when provider token persistence fails', async () => {
       const oauthResponse = {
         sessionToken: 'session-abc',
         accessToken: 'ghp_123',
@@ -216,7 +291,12 @@ describe('EmdashAccountService', () => {
       mockExecuteOAuthFlow.mockResolvedValue(oauthResponse);
       mockDispatch.mockRejectedValueOnce(new Error('secure storage failed'));
 
-      await expect(service.signIn()).rejects.toThrow('secure storage failed');
+      const error = unwrapError(await service.signIn());
+      expect(error).toMatchObject({
+        type: 'provider_token_persistence_failed',
+        provider: 'github',
+        message: 'secure storage failed',
+      });
     });
 
     it('does not dispatch when provider token is absent', async () => {
@@ -226,7 +306,7 @@ describe('EmdashAccountService', () => {
       };
       mockExecuteOAuthFlow.mockResolvedValue(oauthResponse);
 
-      await service.signIn();
+      unwrapResult(await service.signIn());
 
       expect(mockDispatch).not.toHaveBeenCalled();
     });
@@ -234,7 +314,7 @@ describe('EmdashAccountService', () => {
 
   describe('linkProviderAccount()', () => {
     it('starts an account-link transaction and stores the linked provider token', async () => {
-      mockCredGet.mockResolvedValue('session-abc');
+      mockCredGet.mockResolvedValue(ok('session-abc'));
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ accountLinkState: 'account-link-state' }),
@@ -251,8 +331,12 @@ describe('EmdashAccountService', () => {
         },
       };
       mockExecuteOAuthFlow.mockResolvedValue(oauthResponse);
+      mockDispatch.mockResolvedValueOnce({
+        providerAccountStatus: 'created',
+        providerAccount: oauthResponse.providerAccount,
+      });
 
-      const result = await service.linkProviderAccount();
+      const result = unwrapResult(await service.linkProviderAccount());
 
       expect(mockFetch).toHaveBeenCalledWith(
         'https://auth.test.emdash.sh/api/v1/auth/electron/account-link/start',
@@ -285,6 +369,7 @@ describe('EmdashAccountService', () => {
       });
       expect(result).toEqual({
         provider: 'github',
+        providerAccountStatus: 'created',
         providerAccount: {
           providerId: 'github',
           providerAccountId: '84',
@@ -295,64 +380,149 @@ describe('EmdashAccountService', () => {
       });
     });
 
-    it('requires an existing Emdash session', async () => {
-      mockCredGet.mockResolvedValue(null);
+    it('reports when the linked provider account already exists', async () => {
+      mockCredGet.mockResolvedValue(ok('session-abc'));
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ accountLinkState: 'account-link-state' }),
+      });
+      const providerAccount = {
+        providerId: 'github',
+        providerAccountId: '84',
+        host: 'github.com',
+        login: 'octocat',
+        avatarUrl: 'https://avatars.githubusercontent.com/u/84',
+      };
+      mockExecuteOAuthFlow.mockResolvedValue({
+        accessToken: 'ghp_linked',
+        providerId: 'github',
+        providerAccount,
+      });
+      mockDispatch.mockResolvedValueOnce({
+        providerAccountStatus: 'updated',
+        providerAccount,
+      });
 
-      await expect(service.linkProviderAccount()).rejects.toThrow(
-        'You must be signed in to link a provider account'
-      );
+      const result = unwrapResult(await service.linkProviderAccount());
+
+      expect(result).toEqual({
+        provider: 'github',
+        providerAccountStatus: 'updated',
+        providerAccount,
+      });
+    });
+
+    it('requires an existing Emdash session', async () => {
+      mockCredGet.mockResolvedValue(ok(null));
+
+      const error = unwrapError(await service.linkProviderAccount());
+      expect(error).toMatchObject({
+        type: 'not_signed_in',
+        message: 'You must be signed in to link a provider account',
+      });
       expect(mockFetch).not.toHaveBeenCalled();
       expect(mockExecuteOAuthFlow).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
     it('rejects unsupported providers before starting a link transaction', async () => {
-      await expect(service.linkProviderAccount('gitlab')).rejects.toThrow(
-        'Account linking is not supported for provider "gitlab"'
-      );
+      const error = unwrapError(await service.linkProviderAccount('gitlab'));
+      expect(error).toMatchObject({
+        type: 'unsupported_provider',
+        provider: 'gitlab',
+        message: 'Account linking is not supported for provider "gitlab"',
+      });
       expect(mockCredGet).not.toHaveBeenCalled();
       expect(mockFetch).not.toHaveBeenCalled();
       expect(mockExecuteOAuthFlow).not.toHaveBeenCalled();
     });
 
-    it('surfaces account-link start failures from the auth server', async () => {
-      mockCredGet.mockResolvedValue('session-abc');
+    it('clears stale local session when account-link start reports no active session', async () => {
+      const accountCleared = vi.fn();
+      service.on('accountCleared', accountCleared);
+      mockCredGet.mockResolvedValue(ok('session-abc'));
+      mockKvGet.mockResolvedValue({
+        hasAccount: true,
+        userId: 'u1',
+        username: 'test',
+        avatarUrl: '',
+        email: '',
+        lastValidated: '2026-01-01',
+      });
       mockFetch.mockResolvedValueOnce({
         ok: false,
         status: 401,
         json: async () => ({ error: 'No active session' }),
       });
 
-      await expect(service.linkProviderAccount()).rejects.toThrow('No active session');
+      const error = unwrapError(await service.linkProviderAccount());
+      expect(error).toMatchObject({
+        type: 'session_expired',
+        message: 'Your Emdash session expired. Sign in again to connect GitHub.',
+      });
+      expect(mockCredClear).toHaveBeenCalled();
+      expect(mockKvSet).toHaveBeenCalledWith(
+        'profile',
+        expect.objectContaining({ hasAccount: true, username: 'test' })
+      );
+      expect(accountCleared).toHaveBeenCalled();
+      expect(mockExecuteOAuthFlow).not.toHaveBeenCalled();
+      expect(mockDispatch).not.toHaveBeenCalled();
+
+      const session = unwrapResult(await service.getSession());
+      expect(session).toMatchObject({
+        isSignedIn: false,
+        hasAccount: true,
+      });
+    });
+
+    it('surfaces non-session account-link start failures from the auth server', async () => {
+      mockCredGet.mockResolvedValue(ok('session-abc'));
+      mockFetch.mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        json: async () => ({ error: 'Auth server unavailable' }),
+      });
+
+      const error = unwrapError(await service.linkProviderAccount());
+      expect(error).toMatchObject({
+        type: 'auth_server_error',
+        message: 'Auth server unavailable',
+      });
+      expect(mockCredClear).not.toHaveBeenCalled();
       expect(mockExecuteOAuthFlow).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
     it('rejects malformed account-link start responses', async () => {
-      mockCredGet.mockResolvedValue('session-abc');
+      mockCredGet.mockResolvedValue(ok('session-abc'));
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ expiresAt: '2026-01-01T00:00:00.000Z' }),
       });
 
-      await expect(service.linkProviderAccount()).rejects.toThrow(
-        'Invalid account link start response: missing accountLinkState'
-      );
+      const error = unwrapError(await service.linkProviderAccount());
+      expect(error).toMatchObject({
+        type: 'invalid_auth_response',
+        message: 'Invalid account link start response: missing accountLinkState',
+      });
       expect(mockExecuteOAuthFlow).not.toHaveBeenCalled();
       expect(mockDispatch).not.toHaveBeenCalled();
     });
 
     it('rejects account-link exchange responses without a provider token', async () => {
-      mockCredGet.mockResolvedValue('session-abc');
+      mockCredGet.mockResolvedValue(ok('session-abc'));
       mockFetch.mockResolvedValueOnce({
         ok: true,
         json: async () => ({ accountLinkState: 'account-link-state' }),
       });
       mockExecuteOAuthFlow.mockResolvedValue({ providerId: 'github' });
 
-      await expect(service.linkProviderAccount()).rejects.toThrow(
-        'Invalid account link response: missing provider token'
-      );
+      const error = unwrapError(await service.linkProviderAccount());
+      expect(error).toMatchObject({
+        type: 'invalid_auth_response',
+        message: 'Invalid account link response: missing provider token',
+      });
       expect(mockDispatch).not.toHaveBeenCalled();
     });
   });
@@ -366,11 +536,11 @@ describe('EmdashAccountService', () => {
         user: { userId: 'u1', username: 'test', avatarUrl: '', email: '' },
       };
       mockExecuteOAuthFlow.mockResolvedValue(exchangeResult);
-      await service.signIn();
+      unwrapResult(await service.signIn());
       vi.clearAllMocks();
       mockKvSet.mockResolvedValue(undefined);
 
-      await service.signOut();
+      unwrapResult(await service.signOut());
 
       expect(mockCredClear).toHaveBeenCalled();
       expect(mockKvSet).toHaveBeenCalledWith(
@@ -384,7 +554,7 @@ describe('EmdashAccountService', () => {
         avatarUrl: '',
         email: '',
       });
-      const session = await service.getSession();
+      const session = unwrapResult(await service.getSession());
       expect(session.isSignedIn).toBe(false);
       expect(session.hasAccount).toBe(true);
     });
@@ -392,8 +562,8 @@ describe('EmdashAccountService', () => {
 
   describe('validateSession()', () => {
     it('returns false when no session token', async () => {
-      const result = await service.validateSession();
-      expect(result).toBe(false);
+      const result = unwrapResult(await service.validateSession());
+      expect(result).toBe('invalid');
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
@@ -405,14 +575,14 @@ describe('EmdashAccountService', () => {
         user: { userId: 'u1', username: 'test', avatarUrl: '', email: '' },
       };
       mockExecuteOAuthFlow.mockResolvedValue(exchangeResult);
-      await service.signIn();
+      unwrapResult(await service.signIn());
       vi.clearAllMocks();
       mockKvSet.mockResolvedValue(undefined);
 
       mockFetch.mockResolvedValue({ ok: false, status: 401 });
-      const result = await service.validateSession();
+      const result = unwrapResult(await service.validateSession());
 
-      expect(result).toBe(false);
+      expect(result).toBe('invalid');
       expect(mockCredClear).toHaveBeenCalled();
       expect(mockKvSet).toHaveBeenCalledWith(
         'profile',
@@ -428,12 +598,12 @@ describe('EmdashAccountService', () => {
         user: { userId: 'u1', username: 'test', avatarUrl: '', email: '' },
       };
       mockExecuteOAuthFlow.mockResolvedValue(exchangeResult);
-      await service.signIn();
+      unwrapResult(await service.signIn());
       vi.clearAllMocks();
 
       mockFetch.mockRejectedValue(new Error('network error'));
-      const result = await service.validateSession();
-      expect(result).toBe(true);
+      const result = unwrapResult(await service.validateSession());
+      expect(result).toBe('unknown');
     });
   });
 

--- a/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.ts
@@ -84,6 +84,28 @@ export class EmdashAccountService implements Hookable<AccountServiceHooks> {
     return this.getSession();
   }
 
+  async validateSession(): Promise<Result<SessionValidationResult, AccountSessionValidationError>> {
+    const token = await this.sessionStore.ensureTokenLoaded();
+    if (!token.success) return token;
+    if (!token.data) return ok('invalid');
+
+    const validation = await this.authServerClient.validateSession(token.data);
+    if (!validation.success) return validation;
+
+    if (validation.data === 'invalid') {
+      const cleared = await this.clearSessionAndNotify();
+      if (!cleared.success) return cleared;
+      return ok('invalid');
+    }
+
+    if (validation.data === 'valid') {
+      const marked = await this.sessionStore.markValidated(new Date().toISOString());
+      if (!marked.success) return marked;
+    }
+
+    return validation;
+  }
+
   async signIn(provider: string = 'github'): Promise<Result<SignInResult, AccountSignInError>> {
     const raw = await this.oauthClient.signIn(provider);
     if (!raw.success) return raw;
@@ -111,6 +133,10 @@ export class EmdashAccountService implements Hookable<AccountServiceHooks> {
     );
 
     return ok({ user: exchange.data.user });
+  }
+
+  async signOut(): Promise<Result<void, AccountSignOutError>> {
+    return this.clearSessionAndNotify();
   }
 
   async linkProviderAccount(
@@ -157,34 +183,8 @@ export class EmdashAccountService implements Hookable<AccountServiceHooks> {
     return ok(result);
   }
 
-  async signOut(): Promise<Result<void, AccountSignOutError>> {
-    return this.clearSessionAndNotify();
-  }
-
   async checkServerHealth(): Promise<boolean> {
     return this.authServerClient.checkHealth();
-  }
-
-  async validateSession(): Promise<Result<SessionValidationResult, AccountSessionValidationError>> {
-    const token = await this.sessionStore.ensureTokenLoaded();
-    if (!token.success) return token;
-    if (!token.data) return ok('invalid');
-
-    const validation = await this.authServerClient.validateSession(token.data);
-    if (!validation.success) return validation;
-
-    if (validation.data === 'invalid') {
-      const cleared = await this.clearSessionAndNotify();
-      if (!cleared.success) return cleared;
-      return ok('invalid');
-    }
-
-    if (validation.data === 'valid') {
-      const marked = await this.sessionStore.markValidated(new Date().toISOString());
-      if (!marked.success) return marked;
-    }
-
-    return validation;
   }
 
   private async clearSessionAndNotify(): Promise<Result<void, AccountSessionReadError>> {

--- a/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.ts
@@ -4,7 +4,6 @@ import { err, ok, type Result } from '@shared/lib/result';
 import {
   type AccountInitializeError,
   type AccountLinkProviderError,
-  type AccountSessionError,
   type AccountSessionReadError,
   type AccountSessionValidationError,
   type AccountSignInError,
@@ -68,20 +67,6 @@ export class EmdashAccountService implements Hookable<AccountServiceHooks> {
 
   async getSession(): Promise<Result<SessionState, AccountSessionReadError>> {
     return this.sessionStore.getSession();
-  }
-
-  async getValidatedSession(): Promise<Result<SessionState, AccountSessionError>> {
-    const token = await this.sessionStore.ensureTokenLoaded();
-    if (!token.success) return token;
-
-    const session = await this.getSession();
-    if (!session.success) return session;
-    if (!session.data.hasAccount || !session.data.isSignedIn) return session;
-
-    const validation = await this.validateSession();
-    if (!validation.success) return validation;
-
-    return this.getSession();
   }
 
   async validateSession(): Promise<Result<SessionValidationResult, AccountSessionValidationError>> {

--- a/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/emdash-account-service.ts
@@ -1,314 +1,198 @@
-import { executeOAuthFlow } from '@main/core/shared/oauth-flow';
-import { KV } from '@main/db/kv';
 import { HookCore, type Hookable } from '@main/lib/hookable';
 import { log } from '@main/lib/logger';
-import { ACCOUNT_CONFIG } from '../config';
-import { providerTokenRegistry, type ProviderAccountPayload } from '../provider-token-registry';
-import { accountCredentialStore } from './credential-store';
-
-export interface AccountUser {
-  userId: string;
-  name?: string;
-  username: string;
-  avatarUrl: string;
-  email: string;
-}
-
-export interface CachedProfile {
-  hasAccount: boolean;
-  userId: string;
-  name?: string;
-  username: string;
-  avatarUrl: string;
-  email: string;
-  lastValidated: string;
-}
-
-export interface SignInResult {
-  user: AccountUser;
-}
-
-export interface LinkProviderAccountResult {
-  provider: string;
-  providerAccount?: ProviderAccountPayload;
-}
-
-export interface SessionState {
-  user: AccountUser | null;
-  isSignedIn: boolean;
-  hasAccount: boolean;
-}
-
-interface AccountKVSchema extends Record<string, unknown> {
-  profile: CachedProfile;
-}
+import { err, ok, type Result } from '@shared/lib/result';
+import {
+  type AccountInitializeError,
+  type AccountLinkProviderError,
+  type AccountSessionError,
+  type AccountSessionReadError,
+  type AccountSessionValidationError,
+  type AccountSignInError,
+  type AccountSignOutError,
+} from '../account-errors';
+import type {
+  LinkProviderAccountResult,
+  SessionState,
+  SessionValidationResult,
+  SignInResult,
+} from '../account-types';
+import {
+  parseRequiredProviderTokenResponse,
+  parseSignInResponse,
+} from './account-auth-response-parser';
+import { AccountAuthServerClient } from './account-auth-server-client';
+import { AccountOAuthClient } from './account-oauth-client';
+import { AccountSessionStore } from './account-session-store';
+import { ProviderTokenDispatcher } from './provider-token-dispatcher';
 
 type AccountServiceHooks = {
   accountChanged: (username: string, userId: string, email: string) => void | Promise<void>;
   accountCleared: () => void | Promise<void>;
 };
 
-const accountKV = new KV<AccountKVSchema>('account');
-
-function parseProviderAccountPayload(raw: unknown): ProviderAccountPayload | undefined {
-  if (typeof raw !== 'object' || raw === null) return undefined;
-
-  const candidate = raw as Record<string, unknown>;
-  if (
-    typeof candidate.providerId !== 'string' ||
-    typeof candidate.providerAccountId !== 'string' ||
-    candidate.providerAccountId.length === 0 ||
-    typeof candidate.host !== 'string' ||
-    typeof candidate.login !== 'string' ||
-    typeof candidate.avatarUrl !== 'string'
-  ) {
-    return undefined;
-  }
-
-  return {
-    providerId: candidate.providerId,
-    providerAccountId: candidate.providerAccountId,
-    host: candidate.host,
-    login: candidate.login,
-    avatarUrl: candidate.avatarUrl,
-  };
-}
-
-function parseAuthProviderToken(raw: Record<string, unknown>): {
-  accessToken?: string;
-  providerId?: string;
-  providerAccount?: ProviderAccountPayload;
-} {
-  const accessToken = typeof raw.accessToken === 'string' ? raw.accessToken : undefined;
-  const providerId = typeof raw.providerId === 'string' ? raw.providerId : undefined;
-  const providerAccount = parseProviderAccountPayload(raw.providerAccount);
-  return { accessToken, providerId, providerAccount };
-}
-
 export class EmdashAccountService implements Hookable<AccountServiceHooks> {
   private readonly _hooks = new HookCore<AccountServiceHooks>((name, e) =>
     log.error(`EmdashAccountService: ${String(name)} hook error`, e)
   );
-  private cachedProfile: CachedProfile | null = null;
-  private sessionToken: string | null = null;
+
+  constructor(
+    private readonly sessionStore = new AccountSessionStore(),
+    private readonly authServerClient = new AccountAuthServerClient(),
+    private readonly oauthClient = new AccountOAuthClient(),
+    private readonly providerTokenDispatcher = new ProviderTokenDispatcher()
+  ) {}
 
   on<K extends keyof AccountServiceHooks>(name: K, handler: AccountServiceHooks[K]) {
     return this._hooks.on(name, handler);
   }
 
-  async getSession(): Promise<SessionState> {
-    this.cachedProfile = await accountKV.get('profile');
-    const hasAccount = this.cachedProfile?.hasAccount === true;
-    const isSignedIn = hasAccount && this.sessionToken !== null;
-    return {
-      user:
-        isSignedIn && this.cachedProfile
-          ? {
-              userId: this.cachedProfile.userId,
-              name: this.cachedProfile.name,
-              username: this.cachedProfile.username,
-              avatarUrl: this.cachedProfile.avatarUrl,
-              email: this.cachedProfile.email,
-            }
-          : null,
-      isSignedIn,
-      hasAccount,
-    };
-  }
+  async initialize(): Promise<Result<void, AccountInitializeError>> {
+    const session = await this.sessionStore.load();
+    if (!session.success) return session;
 
-  async loadSessionToken(): Promise<void> {
-    [this.sessionToken, this.cachedProfile] = await Promise.all([
-      accountCredentialStore.get(),
-      accountKV.get('profile'),
-    ]);
-    if (this.sessionToken && this.cachedProfile?.hasAccount) {
+    if (session.data.token && session.data.profile?.hasAccount) {
       this._hooks.callHookBackground(
         'accountChanged',
-        this.cachedProfile.username,
-        this.cachedProfile.userId,
-        this.cachedProfile.email
+        session.data.profile.username,
+        session.data.profile.userId,
+        session.data.profile.email
       );
     }
+
+    return ok();
   }
 
-  /**  make provider optional and remove default in case emdash starts supporting more providers */
-  async signIn(provider: string = 'github'): Promise<SignInResult> {
-    const { baseUrl } = ACCOUNT_CONFIG.authServer;
+  async loadSessionToken(): Promise<Result<void, AccountInitializeError>> {
+    return this.initialize();
+  }
 
-    const extraParams: Record<string, string> = {};
+  async getSession(): Promise<Result<SessionState, AccountSessionReadError>> {
+    return this.sessionStore.getSession();
+  }
 
-    if (provider) {
-      extraParams.provider_id = provider;
-    }
+  async getValidatedSession(): Promise<Result<SessionState, AccountSessionError>> {
+    const token = await this.sessionStore.ensureTokenLoaded();
+    if (!token.success) return token;
 
-    const raw = await executeOAuthFlow({
-      authorizeUrl: `${baseUrl}/sign-in`,
-      exchangeUrl: `${baseUrl}/api/v1/auth/electron/exchange`,
-      successRedirectUrl: `${baseUrl}/auth/success`,
-      errorRedirectUrl: `${baseUrl}/auth/error`,
-      extraParams,
-      timeoutMs: ACCOUNT_CONFIG.authServer.authTimeoutMs,
-    });
+    const session = await this.getSession();
+    if (!session.success) return session;
+    if (!session.data.hasAccount || !session.data.isSignedIn) return session;
 
-    const sessionToken = raw.sessionToken as string;
-    const user = raw.user as AccountUser;
-    if (!sessionToken || !user) {
-      throw new Error('Invalid sign-in response: missing sessionToken or user');
-    }
+    const validation = await this.validateSession();
+    if (!validation.success) return validation;
 
-    await accountCredentialStore.set(sessionToken);
-    this.sessionToken = sessionToken;
+    return this.getSession();
+  }
 
-    const profile: CachedProfile = {
-      hasAccount: true,
-      userId: user.userId,
-      name: user.name,
-      username: user.username,
-      avatarUrl: user.avatarUrl,
-      email: user.email,
-      lastValidated: new Date().toISOString(),
-    };
-    this.cachedProfile = profile;
-    await accountKV.set('profile', profile);
+  async signIn(provider: string = 'github'): Promise<Result<SignInResult, AccountSignInError>> {
+    const raw = await this.oauthClient.signIn(provider);
+    if (!raw.success) return raw;
 
-    const { accessToken, providerId, providerAccount } = parseAuthProviderToken(raw);
-    if (accessToken && providerId) {
-      await providerTokenRegistry.dispatch(providerId, {
-        accessToken,
-        providerAccount,
+    const exchange = parseSignInResponse(raw.data);
+    if (!exchange.success) return exchange;
+
+    const saved = await this.sessionStore.saveSignedInSession(
+      exchange.data.user,
+      exchange.data.sessionToken,
+      new Date().toISOString()
+    );
+    if (!saved.success) return saved;
+
+    const providerToken = await this.providerTokenDispatcher.dispatchOptional(
+      exchange.data.providerToken
+    );
+    if (!providerToken.success) return providerToken;
+
+    this._hooks.callHookBackground(
+      'accountChanged',
+      exchange.data.user.username,
+      exchange.data.user.userId,
+      exchange.data.user.email
+    );
+
+    return ok({ user: exchange.data.user });
+  }
+
+  async linkProviderAccount(
+    provider: string = 'github'
+  ): Promise<Result<LinkProviderAccountResult, AccountLinkProviderError>> {
+    if (provider !== 'github') {
+      return err({
+        type: 'unsupported_provider',
+        provider,
+        message: `Account linking is not supported for provider "${provider}"`,
       });
     }
 
-    this._hooks.callHookBackground('accountChanged', user.username, user.userId, user.email);
+    const sessionToken = await this.sessionStore.requireToken();
+    if (!sessionToken.success) return sessionToken;
 
-    return { user };
-  }
-
-  async linkProviderAccount(provider: string = 'github'): Promise<LinkProviderAccountResult> {
-    if (provider !== 'github') {
-      throw new Error(`Account linking is not supported for provider "${provider}"`);
+    const accountLinkState = await this.authServerClient.startAccountLink(sessionToken.data);
+    if (!accountLinkState.success) {
+      if (accountLinkState.error.type === 'session_expired') {
+        const cleared = await this.clearSessionAndNotify();
+        if (!cleared.success) return cleared;
+      }
+      return accountLinkState;
     }
 
-    const sessionToken = await this.requireSessionToken();
-    const { baseUrl } = ACCOUNT_CONFIG.authServer;
-    const accountLinkState = await this.startAccountLink(sessionToken);
+    const raw = await this.oauthClient.linkProviderAccount(provider, accountLinkState.data);
+    if (!raw.success) return raw;
 
-    const raw = await executeOAuthFlow({
-      authorizeUrl: `${baseUrl}/api/v1/auth/electron/account-link/authorize`,
-      exchangeUrl: `${baseUrl}/api/v1/auth/electron/exchange`,
-      successRedirectUrl: `${baseUrl}/auth/success`,
-      errorRedirectUrl: `${baseUrl}/auth/error`,
-      extraParams: {
-        account_link_state: accountLinkState,
-        provider_id: provider,
-      },
-      timeoutMs: ACCOUNT_CONFIG.authServer.authTimeoutMs,
-    });
+    const providerToken = parseRequiredProviderTokenResponse(raw.data);
+    if (!providerToken.success) return providerToken;
 
-    const { accessToken, providerId, providerAccount } = parseAuthProviderToken(raw);
-    if (!accessToken || !providerId) {
-      throw new Error('Invalid account link response: missing provider token');
-    }
-
-    await providerTokenRegistry.dispatch(providerId, {
-      accessToken,
-      providerAccount,
-    });
+    const dispatched = await this.providerTokenDispatcher.dispatchRequired(providerToken.data);
+    if (!dispatched.success) return dispatched;
 
     const result: LinkProviderAccountResult = {
-      provider: providerId,
+      provider: providerToken.data.providerId,
     };
-    if (providerAccount) {
-      result.providerAccount = providerAccount;
+    if (dispatched.data?.providerAccountStatus) {
+      result.providerAccountStatus = dispatched.data.providerAccountStatus;
     }
-    return result;
+    if (providerToken.data.providerAccount) {
+      result.providerAccount = providerToken.data.providerAccount;
+    }
+    return ok(result);
   }
 
-  async signOut(): Promise<void> {
-    this.sessionToken = null;
-    await accountCredentialStore.clear();
-    if (this.cachedProfile) {
-      this.cachedProfile.hasAccount = true;
-      await accountKV.set('profile', this.cachedProfile);
-    }
-    this._hooks.callHookBackground('accountCleared');
+  async signOut(): Promise<Result<void, AccountSignOutError>> {
+    return this.clearSessionAndNotify();
   }
 
   async checkServerHealth(): Promise<boolean> {
-    const { baseUrl } = ACCOUNT_CONFIG.authServer;
-    try {
-      const response = await fetch(`${baseUrl}/health`, {
-        signal: AbortSignal.timeout(3000),
-      });
-      return response.ok;
-    } catch {
-      return false;
-    }
+    return this.authServerClient.checkHealth();
   }
 
-  async validateSession(): Promise<boolean> {
-    const token = this.sessionToken;
-    if (!token) return false;
+  async validateSession(): Promise<Result<SessionValidationResult, AccountSessionValidationError>> {
+    const token = await this.sessionStore.ensureTokenLoaded();
+    if (!token.success) return token;
+    if (!token.data) return ok('invalid');
 
-    const { baseUrl } = ACCOUNT_CONFIG.authServer;
-    try {
-      const response = await fetch(`${baseUrl}/api/auth/get-session`, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-        signal: AbortSignal.timeout(3000),
-      });
+    const validation = await this.authServerClient.validateSession(token.data);
+    if (!validation.success) return validation;
 
-      if (!response.ok) {
-        this.sessionToken = null;
-        await accountCredentialStore.clear();
-        if (this.cachedProfile) {
-          this.cachedProfile.hasAccount = true;
-          await accountKV.set('profile', this.cachedProfile);
-        }
-        return false;
-      }
-
-      if (this.cachedProfile) {
-        this.cachedProfile.lastValidated = new Date().toISOString();
-        await accountKV.set('profile', this.cachedProfile);
-      }
-      return true;
-    } catch {
-      return this.sessionToken !== null;
+    if (validation.data === 'invalid') {
+      const cleared = await this.clearSessionAndNotify();
+      if (!cleared.success) return cleared;
+      return ok('invalid');
     }
+
+    if (validation.data === 'valid') {
+      const marked = await this.sessionStore.markValidated(new Date().toISOString());
+      if (!marked.success) return marked;
+    }
+
+    return validation;
   }
 
-  private async requireSessionToken(): Promise<string> {
-    if (this.sessionToken) return this.sessionToken;
+  private async clearSessionAndNotify(): Promise<Result<void, AccountSessionReadError>> {
+    const cleared = await this.sessionStore.clearSessionPreservingAccount();
+    if (!cleared.success) return cleared;
 
-    const token = await accountCredentialStore.get();
-    if (!token) {
-      throw new Error('You must be signed in to link a provider account');
-    }
-    this.sessionToken = token;
-    return token;
-  }
-
-  private async startAccountLink(sessionToken: string): Promise<string> {
-    const { baseUrl } = ACCOUNT_CONFIG.authServer;
-    const response = await fetch(`${baseUrl}/api/v1/auth/electron/account-link/start`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${sessionToken}`,
-      },
-      signal: AbortSignal.timeout(ACCOUNT_CONFIG.authServer.authTimeoutMs),
-    });
-
-    if (!response.ok) {
-      const payload = (await response.json().catch(() => null)) as { error?: string } | null;
-      throw new Error(payload?.error || `Account link start failed (${response.status})`);
-    }
-
-    const payload = (await response.json()) as { accountLinkState?: unknown };
-    if (typeof payload.accountLinkState !== 'string' || payload.accountLinkState.length === 0) {
-      throw new Error('Invalid account link start response: missing accountLinkState');
-    }
-    return payload.accountLinkState;
+    this._hooks.callHookBackground('accountCleared');
+    return ok();
   }
 }
 

--- a/apps/emdash-desktop/src/main/core/account/services/provider-token-dispatcher.ts
+++ b/apps/emdash-desktop/src/main/core/account/services/provider-token-dispatcher.ts
@@ -1,0 +1,39 @@
+import { err, ok, type Result } from '@shared/lib/result';
+import { type AccountProviderTokenPersistenceError, unknownErrorMessage } from '../account-errors';
+import type { AuthProviderToken } from '../account-types';
+import {
+  providerTokenRegistry,
+  type ProviderTokenDispatchResult,
+} from '../provider-token-registry';
+
+export class ProviderTokenDispatcher {
+  async dispatchOptional(
+    token: AuthProviderToken | undefined
+  ): Promise<
+    Result<ProviderTokenDispatchResult | undefined, AccountProviderTokenPersistenceError>
+  > {
+    if (!token) return ok();
+    return this.dispatchRequired(token);
+  }
+
+  async dispatchRequired(
+    token: AuthProviderToken
+  ): Promise<
+    Result<ProviderTokenDispatchResult | undefined, AccountProviderTokenPersistenceError>
+  > {
+    try {
+      const result = await providerTokenRegistry.dispatch(token.providerId, {
+        accessToken: token.accessToken,
+        providerAccount: token.providerAccount,
+      });
+      return ok(result);
+    } catch (error) {
+      return err({
+        type: 'provider_token_persistence_failed',
+        provider: token.providerId,
+        message: unknownErrorMessage(error, 'Failed to persist provider token'),
+        cause: error,
+      });
+    }
+  }
+}

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-account-backfill.test.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-account-backfill.test.ts
@@ -106,7 +106,7 @@ describe('GitHubAccountBackfillService', () => {
   });
 
   it('does not replace an existing default account', async () => {
-    const existing = await registry.upsertAccount({
+    const { account: existing } = await registry.upsertAccount({
       accessToken: 'gho_octocat',
       credentialSource: 'emdash_oauth',
       providerAccount: {

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-account-backfill.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-account-backfill.ts
@@ -41,7 +41,7 @@ export class GitHubAccountBackfillService {
     const user = await this.identityClient.getAuthenticatedUser(tokenRecord.token, 'github.com');
     if (!user) return null;
 
-    const account = await this.accountRegistry.upsertAccount({
+    const { account } = await this.accountRegistry.upsertAccount({
       accessToken: tokenRecord.token,
       credentialSource: credentialSource(tokenRecord.source),
       providerAccount: providerAccountFromUser(user),

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-account-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-account-registry.test.ts
@@ -63,21 +63,23 @@ describe('GitHubAccountRegistry', () => {
   });
 
   async function upsertAccount(login: string, providerAccountId: string, host = 'github.com') {
-    return registry.upsertAccount({
-      accessToken: `gho_${login}`,
-      credentialSource: 'emdash_oauth',
-      providerAccount: {
-        providerId: 'github',
-        providerAccountId,
-        host,
-        login,
-        avatarUrl: '',
-      },
-    });
+    return (
+      await registry.upsertAccount({
+        accessToken: `gho_${login}`,
+        credentialSource: 'emdash_oauth',
+        providerAccount: {
+          providerId: 'github',
+          providerAccountId,
+          host,
+          login,
+          avatarUrl: '',
+        },
+      })
+    ).account;
   }
 
   it('stores OAuth account metadata separately from the account token', async () => {
-    const account = await registry.upsertAccount({
+    const { account } = await registry.upsertAccount({
       accessToken: 'gho_monalisa',
       credentialSource: 'emdash_oauth',
       providerAccount: {
@@ -117,7 +119,7 @@ describe('GitHubAccountRegistry', () => {
       },
     });
 
-    const updated = await registry.upsertAccount({
+    const { account: updated } = await registry.upsertAccount({
       accessToken: 'new-token',
       credentialSource: 'emdash_oauth',
       providerAccount: {
@@ -139,8 +141,38 @@ describe('GitHubAccountRegistry', () => {
     });
   });
 
+  it('reports whether an upsert created or updated an account', async () => {
+    const created = await registry.upsertAccount({
+      accessToken: 'old-token',
+      credentialSource: 'emdash_oauth',
+      providerAccount: {
+        providerId: 'github',
+        providerAccountId: '42',
+        host: 'github.com',
+        login: 'monalisa',
+        avatarUrl: '',
+      },
+    });
+
+    const updated = await registry.upsertAccount({
+      accessToken: 'new-token',
+      credentialSource: 'emdash_oauth',
+      providerAccount: {
+        providerId: 'github',
+        providerAccountId: '42',
+        host: 'github.com',
+        login: 'monalisa',
+        avatarUrl: '',
+      },
+    });
+
+    expect(created.status).toBe('created');
+    expect(updated.status).toBe('updated');
+    expect(updated.account.id).toBe(created.account.id);
+  });
+
   it('removes account metadata and credentials together', async () => {
-    const account = await registry.upsertAccount({
+    const { account } = await registry.upsertAccount({
       accessToken: 'gho_monalisa',
       credentialSource: 'emdash_oauth',
       providerAccount: {
@@ -159,7 +191,7 @@ describe('GitHubAccountRegistry', () => {
   });
 
   it('records a durable tombstone when a CLI-sourced account is removed', async () => {
-    const account = await registry.upsertAccount({
+    const { account } = await registry.upsertAccount({
       accessToken: 'gho_monalisa',
       credentialSource: 'cli',
       providerAccount: {
@@ -191,7 +223,7 @@ describe('GitHubAccountRegistry', () => {
   });
 
   it('clears a matching CLI tombstone when the account is reconnected', async () => {
-    const account = await registry.upsertAccount({
+    const { account } = await registry.upsertAccount({
       accessToken: 'gho_monalisa',
       credentialSource: 'cli',
       providerAccount: {

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-account-registry.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-account-registry.ts
@@ -34,6 +34,11 @@ export type GitHubAccountUpsert = {
   providerAccount: GitHubProviderAccount;
 };
 
+export type GitHubAccountUpsertResult = {
+  account: GitHubAccount;
+  status: 'created' | 'updated';
+};
+
 export type GitHubAccountMetadataStore = {
   getAccounts(): Promise<GitHubAccount[] | null>;
   setAccounts(accounts: GitHubAccount[]): Promise<void>;
@@ -55,7 +60,7 @@ export class GitHubAccountRegistry {
     private readonly secretStore: GitHubAccountSecretStore
   ) {}
 
-  async upsertAccount(input: GitHubAccountUpsert): Promise<GitHubAccount> {
+  async upsertAccount(input: GitHubAccountUpsert): Promise<GitHubAccountUpsertResult> {
     const now = Date.now();
     const id = this.accountId(input.providerAccount);
     const accounts = await this.listAccounts();
@@ -78,7 +83,10 @@ export class GitHubAccountRegistry {
     await this.metadataStore.setAccounts(nextAccounts);
     await this.clearRemovedCliAccount(id);
     await this.ensureDefaultAccount(nextAccounts);
-    return next;
+    return {
+      account: next,
+      status: existing ? 'updated' : 'created',
+    };
   }
 
   async listAccounts(): Promise<GitHubAccount[]> {

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-account-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-account-service.test.ts
@@ -75,17 +75,19 @@ describe('GitHubAccountService', () => {
   });
 
   async function upsertAccount(login: string, providerAccountId: string, host = 'github.com') {
-    return registry.upsertAccount({
-      accessToken: `token-${host}-${providerAccountId}`,
-      credentialSource: host === 'github.com' ? 'emdash_oauth' : 'cli',
-      providerAccount: {
-        providerId: 'github',
-        providerAccountId,
-        host,
-        login,
-        avatarUrl: `https://${host}/avatars/${providerAccountId}`,
-      },
-    });
+    return (
+      await registry.upsertAccount({
+        accessToken: `token-${host}-${providerAccountId}`,
+        credentialSource: host === 'github.com' ? 'emdash_oauth' : 'cli',
+        providerAccount: {
+          providerId: 'github',
+          providerAccountId,
+          host,
+          login,
+          avatarUrl: `https://${host}/avatars/${providerAccountId}`,
+        },
+      })
+    ).account;
   }
 
   it('lists linked accounts with exactly one default account marker', async () => {
@@ -123,17 +125,19 @@ describe('GitHubAccountService', () => {
   it('imports CLI accounts and returns the refreshed account list', async () => {
     const existing = await upsertAccount('monalisa', '42');
     importCliAccounts = async () => [
-      await registry.upsertAccount({
-        accessToken: 'token-ghe',
-        credentialSource: 'cli',
-        providerAccount: {
-          providerId: 'github',
-          providerAccountId: '168',
-          host: 'ghe.example.com',
-          login: 'enterprise',
-          avatarUrl: 'https://ghe.example.com/avatars/168',
-        },
-      }),
+      (
+        await registry.upsertAccount({
+          accessToken: 'token-ghe',
+          credentialSource: 'cli',
+          providerAccount: {
+            providerId: 'github',
+            providerAccountId: '168',
+            host: 'ghe.example.com',
+            login: 'enterprise',
+            avatarUrl: 'https://ghe.example.com/avatars/168',
+          },
+        })
+      ).account,
     ];
 
     const result = await service.importCliAccounts();

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-auth-server-adapter.test.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-auth-server-adapter.test.ts
@@ -76,9 +76,13 @@ describe('GitHubAuthServerAdapter', () => {
       },
     };
 
-    await adapter.storeOAuthToken(payload);
+    const result = await adapter.storeOAuthToken(payload);
 
     const accounts = await registry.listAccounts();
+    expect(result).toMatchObject({
+      providerAccountStatus: 'created',
+      providerAccount: payload.providerAccount,
+    });
     expect(accounts).toHaveLength(1);
     expect(accounts[0]).toMatchObject({
       id: 'github.com:42',
@@ -100,9 +104,13 @@ describe('GitHubAuthServerAdapter', () => {
       },
     };
 
-    await adapter.storeOAuthToken(payload);
+    const result = await adapter.storeOAuthToken(payload);
 
     const accounts = await registry.listAccounts();
+    expect(result).toMatchObject({
+      providerAccountStatus: 'created',
+      providerAccount: payload.providerAccount,
+    });
     expect(accounts).toHaveLength(1);
     expect(accounts[0]).toMatchObject({
       id: 'github.com:84',
@@ -116,5 +124,30 @@ describe('GitHubAuthServerAdapter', () => {
     await adapter.storeOAuthToken({ accessToken: 'gho_legacy' });
 
     await expect(registry.listAccounts()).resolves.toEqual([]);
+  });
+
+  it('reports updated when the OAuth account already exists', async () => {
+    const payload: ProviderTokenPayload = {
+      accessToken: 'gho_monalisa',
+      providerAccount: {
+        providerId: 'github',
+        providerAccountId: '42',
+        host: 'github.com',
+        login: 'monalisa',
+        avatarUrl: 'https://avatars.githubusercontent.com/u/42',
+      },
+    };
+
+    await adapter.storeOAuthToken(payload);
+    const result = await adapter.storeOAuthToken({
+      ...payload,
+      accessToken: 'gho_refreshed',
+    });
+
+    expect(result).toMatchObject({
+      providerAccountStatus: 'updated',
+      providerAccount: payload.providerAccount,
+    });
+    await expect(registry.resolveToken('github.com:42')).resolves.toBe('gho_refreshed');
   });
 });

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-auth-server-adapter.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-auth-server-adapter.ts
@@ -1,10 +1,15 @@
-import type { ProviderTokenPayload } from '@main/core/account/provider-token-registry';
+import type {
+  ProviderTokenDispatchResult,
+  ProviderTokenPayload,
+} from '@main/core/account/provider-token-registry';
 import type { GitHubAccountRegistry } from './github-account-registry';
 
 export class GitHubAuthServerAdapter {
   constructor(private readonly accountRegistry: GitHubAccountRegistry) {}
 
-  async storeOAuthToken(payload: ProviderTokenPayload): Promise<void> {
+  async storeOAuthToken(
+    payload: ProviderTokenPayload
+  ): Promise<ProviderTokenDispatchResult | void> {
     if (!payload.providerAccount) {
       return;
     }
@@ -13,7 +18,7 @@ export class GitHubAuthServerAdapter {
       return;
     }
 
-    await this.accountRegistry.upsertAccount({
+    const result = await this.accountRegistry.upsertAccount({
       accessToken: payload.accessToken,
       credentialSource: 'emdash_oauth',
       providerAccount: {
@@ -24,5 +29,10 @@ export class GitHubAuthServerAdapter {
         avatarUrl: payload.providerAccount.avatarUrl,
       },
     });
+
+    return {
+      providerAccountStatus: result.status,
+      providerAccount: payload.providerAccount,
+    };
   }
 }

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-cli-account-import.test.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-cli-account-import.test.ts
@@ -254,7 +254,7 @@ describe('GitHubCliAccountImportService', () => {
   });
 
   it('skips tombstoned CLI accounts during startup import', async () => {
-    const account = await registry.upsertAccount({
+    const { account } = await registry.upsertAccount({
       accessToken: 'gho_monalisa',
       credentialSource: 'cli',
       providerAccount: {
@@ -288,7 +288,7 @@ describe('GitHubCliAccountImportService', () => {
   });
 
   it('explicit imports reconnect tombstoned CLI accounts and clear the tombstone', async () => {
-    const account = await registry.upsertAccount({
+    const { account } = await registry.upsertAccount({
       accessToken: 'gho_monalisa',
       credentialSource: 'cli',
       providerAccount: {

--- a/apps/emdash-desktop/src/main/core/github/accounts/github-cli-account-import.ts
+++ b/apps/emdash-desktop/src/main/core/github/accounts/github-cli-account-import.ts
@@ -75,19 +75,18 @@ export class GitHubCliAccountImportService {
       const accountId = `${host}:${String(user.id)}`;
       if (removedAccountIds.has(accountId)) continue;
 
-      imported.push(
-        await this.accountRegistry.upsertAccount({
-          accessToken: token,
-          credentialSource: 'cli',
-          providerAccount: {
-            providerId: 'github',
-            providerAccountId: String(user.id),
-            host,
-            login: user.login,
-            avatarUrl: user.avatar_url,
-          },
-        })
-      );
+      const { account } = await this.accountRegistry.upsertAccount({
+        accessToken: token,
+        credentialSource: 'cli',
+        providerAccount: {
+          providerId: 'github',
+          providerAccountId: String(user.id),
+          host,
+          login: user.login,
+          avatarUrl: user.avatar_url,
+        },
+      });
+      imported.push(account);
     }
     return imported;
   }

--- a/apps/emdash-desktop/src/main/core/github/services/github-api-auth-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/github/services/github-api-auth-service.test.ts
@@ -77,17 +77,19 @@ describe('GitHubApiAuthService', () => {
     login?: string;
     token?: string;
   } = {}) {
-    return registry.upsertAccount({
-      accessToken: token,
-      credentialSource: 'emdash_oauth',
-      providerAccount: {
-        providerId: 'github',
-        providerAccountId,
-        host,
-        login,
-        avatarUrl: '',
-      },
-    });
+    return (
+      await registry.upsertAccount({
+        accessToken: token,
+        credentialSource: 'emdash_oauth',
+        providerAccount: {
+          providerId: 'github',
+          providerAccountId,
+          host,
+          login,
+          avatarUrl: '',
+        },
+      })
+    ).account;
   }
 
   it('uses the selected GitHub.com account token when an account id is provided', async () => {

--- a/apps/emdash-desktop/src/main/core/github/services/github-device-flow-service.ts
+++ b/apps/emdash-desktop/src/main/core/github/services/github-device-flow-service.ts
@@ -77,7 +77,7 @@ export class GitHubDeviceFlowService {
         return { success: false, error: message };
       }
 
-      const account = await this.deps.accountRegistry.upsertAccount({
+      const { account } = await this.deps.accountRegistry.upsertAccount({
         accessToken: token,
         credentialSource: 'device_flow',
         providerAccount: {

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -142,9 +142,16 @@ void app.whenReady().then(async () => {
     log.error('Failed to start agent event service:', e);
   });
 
-  emdashAccountService.loadSessionToken().catch((e) => {
-    log.warn('Failed to load account session token:', e);
-  });
+  emdashAccountService
+    .initialize()
+    .then((result) => {
+      if (!result.success) {
+        log.warn('Failed to load account session token:', result.error);
+      }
+    })
+    .catch((e: unknown) => {
+      log.warn('Account session initialization threw unexpectedly:', e);
+    });
 
   const githubAuthServerAdapter = new GitHubAuthServerAdapter(githubAccountRegistry);
   providerTokenRegistry.register('github', (payload) =>
@@ -155,7 +162,7 @@ void app.whenReady().then(async () => {
 
   void reconcileResourceSampler();
 
-  localDependencyManager.probeAll().catch((e) => {
+  localDependencyManager.probeAll().catch((e: unknown) => {
     log.error('Failed to probe dependencies:', e);
   });
 

--- a/apps/emdash-desktop/src/renderer/features/settings/components/github-connect-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/github-connect-modal.tsx
@@ -69,12 +69,21 @@ export function GithubConnectModal({ onSuccess, onClose }: BaseModalProps<void>)
         return;
       }
 
+      const providerAccount = 'providerAccount' in result ? result.providerAccount : undefined;
+      const providerAccountStatus =
+        'providerAccountStatus' in result ? result.providerAccountStatus : undefined;
+
       toast({
-        title: 'Connected to GitHub',
+        title:
+          providerAccountStatus === 'updated'
+            ? 'GitHub account already connected'
+            : 'Connected to GitHub',
         description:
-          'providerAccount' in result && result.providerAccount
-            ? `Linked @${result.providerAccount.login}.`
-            : 'GitHub is connected.',
+          providerAccountStatus === 'updated' && providerAccount
+            ? `@${providerAccount.login} was already connected.`
+            : providerAccount
+              ? `Linked @${providerAccount.login}.`
+              : 'GitHub is connected.',
       });
       onSuccess();
     } finally {

--- a/apps/emdash-desktop/src/renderer/lib/hooks/useAccount.ts
+++ b/apps/emdash-desktop/src/renderer/lib/hooks/useAccount.ts
@@ -41,6 +41,9 @@ export function useAccountLinkProvider() {
       void queryClient.invalidateQueries({ queryKey: GITHUB_ACCOUNT_STATE_QUERY_KEY });
       void queryClient.invalidateQueries({ queryKey: ISSUE_CONNECTION_STATUS_QUERY_KEY });
     },
+    onSettled: () => {
+      void queryClient.invalidateQueries({ queryKey: [...ACCOUNT_SESSION_KEY] });
+    },
   });
 }
 


### PR DESCRIPTION
- refactors EmdashAccountService into smaller modules for oauth, auth-server calls, session storage and provider-token dispatch
- returns typed results for expected account failures instead of throwing through account flows
- clears stale emdash session state when account-link start reports an expired session
- propagates github account upsert status so existing accounts report "already connected"
- updates the github connect modal to distinguish new links from already connected accounts