### PR TITLE
fix: keep cached workspace branch fresh on HEAD changes

### DIFF
--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.test.ts
@@ -1,0 +1,104 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({
+  select: vi.fn(),
+  update: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: dbMocks.select,
+    update: dbMocks.update,
+  },
+}));
+
+vi.mock('@main/db/schema', () => ({
+  workspaces: { id: 'id', branchName: 'branch_name' },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    warn: vi.fn(),
+  },
+}));
+
+const { refreshWorkspaceCurrentBranchCache } = await import('./workspace-current-branch-cache');
+
+function queueSelect<T>(rows: T[]): void {
+  const query = {
+    from: vi.fn(),
+    where: vi.fn(),
+    limit: vi.fn(),
+  };
+  query.from.mockReturnValue(query);
+  query.where.mockReturnValue(query);
+  query.limit.mockResolvedValue(rows);
+  dbMocks.select.mockReturnValueOnce(query);
+}
+
+function mockUpdate() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  dbMocks.update.mockReturnValue({ set });
+  return { set, where };
+}
+
+describe('refreshWorkspaceCurrentBranchCache', () => {
+  beforeEach(() => {
+    dbMocks.select.mockReset();
+    dbMocks.update.mockReset();
+  });
+
+  it('writes the cache and reports changed when the branch differs', async () => {
+    queueSelect([{ branchName: 'old-branch' }]);
+    const update = mockUpdate();
+
+    const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
+      Promise.resolve('new-branch')
+    );
+
+    expect(result).toEqual({ branchName: 'new-branch', changed: true });
+    expect(update.set).toHaveBeenCalledWith({ branchName: 'new-branch' });
+  });
+
+  it('does not write and reports unchanged when the branch matches', async () => {
+    queueSelect([{ branchName: 'same-branch' }]);
+
+    const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
+      Promise.resolve('same-branch')
+    );
+
+    expect(result).toEqual({ branchName: 'same-branch', changed: false });
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it('persists a null branch (detached HEAD) when previously set', async () => {
+    queueSelect([{ branchName: 'old-branch' }]);
+    const update = mockUpdate();
+
+    const result = await refreshWorkspaceCurrentBranchCache('ws-1', () => Promise.resolve(null));
+
+    expect(result).toEqual({ branchName: null, changed: true });
+    expect(update.set).toHaveBeenCalledWith({ branchName: null });
+  });
+
+  it('returns undefined when the workspace is not found', async () => {
+    queueSelect([]);
+
+    const result = await refreshWorkspaceCurrentBranchCache('missing', () =>
+      Promise.resolve('any')
+    );
+
+    expect(result).toBeUndefined();
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it('returns undefined and swallows errors when reading the branch throws', async () => {
+    const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
+      Promise.reject(new Error('git boom'))
+    );
+
+    expect(result).toBeUndefined();
+    expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
@@ -1,5 +1,3 @@
-import type { GitStatusModel } from '@emdash/shared/git';
-import { eq } from 'drizzle-orm';
 import { LocalConversationProvider } from '@main/core/conversations/impl/local-conversation';
 import { SshConversationProvider } from '@main/core/conversations/impl/ssh-conversation';
 import type { ConversationProvider } from '@main/core/conversations/types';
@@ -22,8 +20,7 @@ import type { TerminalProvider } from '@main/core/terminals/terminal-provider';
 import type { Workspace } from '@main/core/workspaces/workspace';
 import { LifecycleScriptService } from '@main/core/workspaces/workspace-lifecycle-service';
 import { type WorkspaceFactoryResult } from '@main/core/workspaces/workspace-registry';
-import { db } from '@main/db/client';
-import { workspaces as workspacesTable } from '@main/db/schema';
+import { handleGitWorktreeUpdate } from '@main/core/workspaces/workspace-worktree-update';
 import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { gitWorktreeUpdateChannel } from '@shared/core/git/events';
@@ -167,16 +164,15 @@ export function createWorkspaceFactory(
       workspace,
 
       onCreateSideEffect: (ws) => {
-        unsubscribeGitUpdates = ws.gitWorktree.subscribe((update) => {
-          events.emit(gitWorktreeUpdateChannel, {
-            projectId: context.projectId,
-            workspaceId,
-            update,
-          });
-          if (update.kind === 'status' && update.model.kind === 'ok') {
-            void cacheWorkspaceLineStats(workspaceId, update.model);
-          }
-        });
+        unsubscribeGitUpdates = ws.gitWorktree.subscribe((update) =>
+          handleGitWorktreeUpdate(workspaceId, update, (emitted) => {
+            events.emit(gitWorktreeUpdateChannel, {
+              projectId: context.projectId,
+              workspaceId,
+              update: emitted,
+            });
+          })
+        );
 
         if (ownsFetchService) {
           gitRepositoryFetchService.start();
@@ -268,29 +264,6 @@ export function createWorkspaceFactory(
       },
     };
   };
-}
-
-async function cacheWorkspaceLineStats(
-  workspaceId: string,
-  status: Extract<GitStatusModel, { kind: 'ok' }>
-): Promise<void> {
-  let unstagedAdded = 0;
-  let unstagedDeleted = 0;
-  for (const c of status.unstaged) {
-    unstagedAdded += c.additions;
-    unstagedDeleted += c.deletions;
-  }
-  try {
-    await db
-      .update(workspacesTable)
-      .set({
-        linesAdded: status.stagedAdded + unstagedAdded,
-        linesDeleted: status.stagedDeleted + unstagedDeleted,
-      })
-      .where(eq(workspacesTable.id, workspaceId));
-  } catch (e) {
-    log.warn('Failed to cache workspace git status', { workspaceId, error: String(e) });
-  }
 }
 
 type TaskProviderOpts = {

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.test.ts
@@ -1,0 +1,120 @@
+import type { GitHeadModel, GitStatusModel, GitWorktreeUpdate } from '@emdash/shared/git';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const dbMocks = vi.hoisted(() => ({ update: vi.fn() }));
+
+vi.mock('@main/core/workspaces/workspace-current-branch-cache', () => ({
+  refreshWorkspaceCurrentBranchCache: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: { update: dbMocks.update },
+}));
+
+vi.mock('@main/db/schema', () => ({
+  workspaces: { id: 'id' },
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: { warn: vi.fn() },
+}));
+
+const { refreshWorkspaceCurrentBranchCache } =
+  await import('@main/core/workspaces/workspace-current-branch-cache');
+const { handleGitWorktreeUpdate } = await import('./workspace-worktree-update');
+
+function headUpdate(model: GitHeadModel): GitWorktreeUpdate {
+  return { kind: 'head', model, sequence: 1, generation: 1 };
+}
+
+function statusUpdate(model: GitStatusModel): GitWorktreeUpdate {
+  return { kind: 'status', model, sequence: 1, generation: 1 };
+}
+
+function mockUpdateChain() {
+  const where = vi.fn().mockResolvedValue(undefined);
+  const set = vi.fn().mockReturnValue({ where });
+  dbMocks.update.mockReturnValue({ set });
+  return { set, where };
+}
+
+describe('handleGitWorktreeUpdate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refreshes the branch cache before emitting a head update', async () => {
+    const order: string[] = [];
+    let resolveRefresh: () => void = () => {};
+    vi.mocked(refreshWorkspaceCurrentBranchCache).mockReturnValue(
+      new Promise((resolve) => {
+        resolveRefresh = () => {
+          order.push('refresh');
+          resolve({ branchName: 'feature/new', changed: true });
+        };
+      })
+    );
+    const emit = vi.fn(() => order.push('emit'));
+
+    handleGitWorktreeUpdate(
+      'ws-1',
+      headUpdate({ kind: 'branch', name: 'feature/new', oid: 'abc' }),
+      emit
+    );
+
+    // Emit must wait for the cache refresh to settle.
+    expect(emit).not.toHaveBeenCalled();
+    resolveRefresh();
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(1));
+    expect(order).toEqual(['refresh', 'emit']);
+  });
+
+  it('passes the branch name from a branch head to the cache', async () => {
+    vi.mocked(refreshWorkspaceCurrentBranchCache).mockResolvedValue({
+      branchName: 'feature/new',
+      changed: true,
+    });
+
+    handleGitWorktreeUpdate(
+      'ws-1',
+      headUpdate({ kind: 'branch', name: 'feature/new', oid: 'abc' }),
+      vi.fn()
+    );
+
+    const read = vi.mocked(refreshWorkspaceCurrentBranchCache).mock.calls[0][1];
+    await expect(read()).resolves.toBe('feature/new');
+  });
+
+  it('caches a null branch for a detached head', async () => {
+    vi.mocked(refreshWorkspaceCurrentBranchCache).mockResolvedValue({
+      branchName: null,
+      changed: true,
+    });
+
+    handleGitWorktreeUpdate(
+      'ws-1',
+      headUpdate({ kind: 'detached', shortHash: 'abc1234', oid: 'abc' }),
+      vi.fn()
+    );
+
+    const read = vi.mocked(refreshWorkspaceCurrentBranchCache).mock.calls[0][1];
+    await expect(read()).resolves.toBeNull();
+  });
+
+  it('emits status updates immediately and does not touch the branch cache', () => {
+    mockUpdateChain();
+    const emit = vi.fn();
+    const status: GitStatusModel = {
+      kind: 'ok',
+      staged: [],
+      unstaged: [],
+      stagedAdded: 0,
+      stagedDeleted: 0,
+    };
+
+    handleGitWorktreeUpdate('ws-1', statusUpdate(status), emit);
+
+    expect(emit).toHaveBeenCalledTimes(1);
+    expect(refreshWorkspaceCurrentBranchCache).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.test.ts
@@ -21,6 +21,7 @@ vi.mock('@main/lib/logger', () => ({
 
 const { refreshWorkspaceCurrentBranchCache } =
   await import('@main/core/workspaces/workspace-current-branch-cache');
+const { log } = await import('@main/lib/logger');
 const { handleGitWorktreeUpdate } = await import('./workspace-worktree-update');
 
 function headUpdate(model: GitHeadModel): GitWorktreeUpdate {
@@ -101,8 +102,30 @@ describe('handleGitWorktreeUpdate', () => {
     await expect(read()).resolves.toBeNull();
   });
 
-  it('emits status updates immediately and does not touch the branch cache', () => {
-    mockUpdateChain();
+  it('logs head update emit failures', async () => {
+    vi.mocked(refreshWorkspaceCurrentBranchCache).mockResolvedValue({
+      branchName: 'feature/new',
+      changed: true,
+    });
+    const emit = vi.fn(() => {
+      throw new Error('emit failed');
+    });
+
+    handleGitWorktreeUpdate(
+      'ws-1',
+      headUpdate({ kind: 'branch', name: 'feature/new', oid: 'abc' }),
+      emit
+    );
+
+    await vi.waitFor(() => expect(emit).toHaveBeenCalledTimes(1));
+    expect(log.warn).toHaveBeenCalledWith('Failed to emit git worktree head update', {
+      workspaceId: 'ws-1',
+      error: 'Error: emit failed',
+    });
+  });
+
+  it('emits status updates immediately and does not touch the branch cache', async () => {
+    const { set, where } = mockUpdateChain();
     const emit = vi.fn();
     const status: GitStatusModel = {
       kind: 'ok',
@@ -116,5 +139,12 @@ describe('handleGitWorktreeUpdate', () => {
 
     expect(emit).toHaveBeenCalledTimes(1);
     expect(refreshWorkspaceCurrentBranchCache).not.toHaveBeenCalled();
+    await vi.waitFor(() => expect(where).toHaveBeenCalled());
+    expect(set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        linesAdded: 0,
+        linesDeleted: 0,
+      })
+    );
   });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.ts
@@ -1,0 +1,50 @@
+import type { GitHeadModel, GitStatusModel, GitWorktreeUpdate } from '@emdash/shared/git';
+import { eq } from 'drizzle-orm';
+import { refreshWorkspaceCurrentBranchCache } from '@main/core/workspaces/workspace-current-branch-cache';
+import { db } from '@main/db/client';
+import { workspaces as workspacesTable } from '@main/db/schema';
+import { log } from '@main/lib/logger';
+
+function branchNameFromHead(model: GitHeadModel): string | null {
+  return model.kind === 'detached' ? null : model.name;
+}
+
+export function handleGitWorktreeUpdate(
+  workspaceId: string,
+  update: GitWorktreeUpdate,
+  emit: (update: GitWorktreeUpdate) => void
+): void {
+  if (update.kind === 'head') {
+    void refreshWorkspaceCurrentBranchCache(workspaceId, () =>
+      Promise.resolve(branchNameFromHead(update.model))
+    ).finally(() => emit(update));
+    return;
+  }
+  emit(update);
+  if (update.kind === 'status' && update.model.kind === 'ok') {
+    void cacheWorkspaceLineStats(workspaceId, update.model);
+  }
+}
+
+async function cacheWorkspaceLineStats(
+  workspaceId: string,
+  status: Extract<GitStatusModel, { kind: 'ok' }>
+): Promise<void> {
+  let unstagedAdded = 0;
+  let unstagedDeleted = 0;
+  for (const c of status.unstaged) {
+    unstagedAdded += c.additions;
+    unstagedDeleted += c.deletions;
+  }
+  try {
+    await db
+      .update(workspacesTable)
+      .set({
+        linesAdded: status.stagedAdded + unstagedAdded,
+        linesDeleted: status.stagedDeleted + unstagedDeleted,
+      })
+      .where(eq(workspacesTable.id, workspaceId));
+  } catch (e) {
+    log.warn('Failed to cache workspace git status', { workspaceId, error: String(e) });
+  }
+}

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-worktree-update.ts
@@ -17,7 +17,13 @@ export function handleGitWorktreeUpdate(
   if (update.kind === 'head') {
     void refreshWorkspaceCurrentBranchCache(workspaceId, () =>
       Promise.resolve(branchNameFromHead(update.model))
-    ).finally(() => emit(update));
+    ).finally(() => {
+      try {
+        emit(update);
+      } catch (e) {
+        log.warn('Failed to emit git worktree head update', { workspaceId, error: String(e) });
+      }
+    });
     return;
   }
   emit(update);


### PR DESCRIPTION
issue:
- task prs flashed then disappeared after renaming a branch (e.g. git branch -m) because the cached workspaces.branchName was never updated
- getPullRequestsForTask queried PRs by a stale branch and overwrote the PR that the live worktree branch had just matched

fix:
- reconcile the branch cache from gitWorktree HEAD updates before re-emitting the update to the renderer, so PR reloads read a fresh branch
- extract the worktree-update side effects into workspace-worktree-update.ts for a single-responsibility, testable seam