### PR TITLE
feat(pr-overview): add copy PR URL button

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
@@ -1,4 +1,4 @@
-import { ExternalLink } from 'lucide-react';
+import { Check, Copy, ExternalLink } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useState } from 'react';
 import {
@@ -12,6 +12,7 @@ import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { type SplitButtonAction } from '@renderer/lib/ui/split-button';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
 import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
 import { PrChecksList } from './checks-list';
@@ -54,6 +55,23 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
   const [isMerging, setIsMerging] = useState(false);
   const [isMarkingReady, setIsMarkingReady] = useState(false);
   const [bypassRequirements, setBypassRequirements] = useState(false);
+  const [justCopied, setJustCopied] = useState(false);
+
+  const handleCopyPrUrl = async (e: React.MouseEvent) => {
+    e.stopPropagation();
+    try {
+      await navigator.clipboard.writeText(pr.url);
+      setJustCopied(true);
+      toast({ title: 'PR URL copied' });
+      window.setTimeout(() => setJustCopied(false), 1500);
+    } catch {
+      toast({
+        title: 'Copy failed',
+        description: 'The PR URL could not be copied to the clipboard.',
+        variant: 'destructive',
+      });
+    }
+  };
   if (!diffView) return null;
   const tab = diffView.effectivePrTab;
   const isOpen = pr.status === 'open';
@@ -107,7 +125,7 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
       <div className="flex w-full flex-col gap-2 p-2.5">
         <div className="flex items-center justify-between gap-2">
           <button
-            className="group relative flex min-w-0 items-center gap-2"
+            className="group relative flex min-w-0 flex-1 items-center gap-2"
             onClick={() => rpc.app.openExternal(pr.url)}
           >
             <StatusIcon className="size-4" pr={pr} />
@@ -117,6 +135,23 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
               <ExternalLink className="size-3.5 text-foreground-muted" />
             </span>
           </button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <button
+                    type="button"
+                    aria-label="Copy PR URL"
+                    onClick={handleCopyPrUrl}
+                    className="hover:bg-muted flex shrink-0 items-center justify-center rounded p-1 text-foreground-muted hover:text-foreground"
+                  >
+                    {justCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                  </button>
+                }
+              />
+              <TooltipContent>{justCopied ? 'Copied!' : 'Copy PR URL'}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
         <PrMergeLine pr={pr} />
       </div>

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
@@ -1,6 +1,6 @@
 import { Check, Copy, ExternalLink } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useState } from 'react';
+import { useEffect, useState, type MouseEvent } from 'react';
 import {
   useTaskViewContext,
   useWorkspaceViewModel,
@@ -12,7 +12,7 @@ import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { type SplitButtonAction } from '@renderer/lib/ui/split-button';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
 import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
 import { PrChecksList } from './checks-list';
@@ -57,13 +57,18 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
   const [bypassRequirements, setBypassRequirements] = useState(false);
   const [justCopied, setJustCopied] = useState(false);
 
-  const handleCopyPrUrl = async (e: React.MouseEvent) => {
+  useEffect(() => {
+    if (!justCopied) return;
+    const timer = window.setTimeout(() => setJustCopied(false), 1500);
+    return () => window.clearTimeout(timer);
+  }, [justCopied]);
+
+  const handleCopyPrUrl = async (e: MouseEvent) => {
     e.stopPropagation();
     try {
       await navigator.clipboard.writeText(pr.url);
       setJustCopied(true);
       toast({ title: 'PR URL copied' });
-      window.setTimeout(() => setJustCopied(false), 1500);
     } catch {
       toast({
         title: 'Copy failed',
@@ -135,23 +140,21 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
               <ExternalLink className="size-3.5 text-foreground-muted" />
             </span>
           </button>
-          <TooltipProvider>
-            <Tooltip>
-              <TooltipTrigger
-                render={
-                  <button
-                    type="button"
-                    aria-label="Copy PR URL"
-                    onClick={handleCopyPrUrl}
-                    className="hover:bg-muted flex shrink-0 items-center justify-center rounded p-1 text-foreground-muted hover:text-foreground"
-                  >
-                    {justCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-                  </button>
-                }
-              />
-              <TooltipContent>{justCopied ? 'Copied!' : 'Copy PR URL'}</TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <button
+                  type="button"
+                  aria-label={justCopied ? 'PR URL copied' : 'Copy PR URL'}
+                  onClick={handleCopyPrUrl}
+                  className="hover:bg-muted focus-visible:ring-ring/50 flex shrink-0 items-center justify-center rounded p-1 text-foreground-muted outline-none hover:text-foreground focus-visible:ring-3"
+                >
+                  {justCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+                </button>
+              }
+            />
+            <TooltipContent>{justCopied ? 'Copied!' : 'Copy PR URL'}</TooltipContent>
+          </Tooltip>
         </div>
         <PrMergeLine pr={pr} />
       </div>

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
@@ -128,7 +128,7 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
   return (
     <div className={cn('flex min-h-0 flex-1 flex-col border-t border-border')}>
       <div className="flex w-full flex-col gap-2 p-2.5">
-        <div className="flex items-center justify-between gap-2">
+        <div className="group/header flex items-center justify-between gap-2">
           <button
             className="group relative flex min-w-0 flex-1 items-center gap-2"
             onClick={() => rpc.app.openExternal(pr.url)}
@@ -147,7 +147,10 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
                   type="button"
                   aria-label={justCopied ? 'PR URL copied' : 'Copy PR URL'}
                   onClick={handleCopyPrUrl}
-                  className="hover:bg-muted focus-visible:ring-ring/50 flex shrink-0 items-center justify-center rounded p-1 text-foreground-muted outline-none hover:text-foreground focus-visible:ring-3"
+                  className={cn(
+                    'flex shrink-0 items-center justify-center rounded p-1 text-foreground-muted outline-none transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:ring-3 focus-visible:ring-ring/50 group-hover/header:opacity-100',
+                    justCopied ? 'opacity-100' : 'opacity-0'
+                  )}
                 >
                   {justCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
                 </button>


### PR DESCRIPTION
### Description

Adds a small icon button next to the PR title in the PR overview that copies the PR URL to the clipboard. Useful when sharing a link with reviewers without having to switch to the browser first.

Implementation notes:
- Lives in `apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx`.
- Uses the existing `navigator.clipboard.writeText` + `toast` pattern already used in `task-context-menu.tsx`.
- Wrapped in the existing `Tooltip` primitive (`render` prop style, consistent with `sidebar/projects-group-label.tsx` and others).
- Click handler calls `e.stopPropagation()` so the surrounding "open externally" title button is not triggered.
- Icon swaps to a `Check` for 1.5s after a successful copy as visual feedback; tooltip label switches to "Copied!" during that window.

### Related issues

_n/a_

### Testing

- `corepack pnpm exec oxlint <file>` — clean
- `corepack pnpm exec oxfmt <file>` — formatted
- `corepack pnpm run typecheck` — no new errors introduced in the touched file (existing unrelated workspace-package errors pre-date this branch)
- Manual: launched the desktop app via `pnpm run dev` from repo root, opened a task with a PR, confirmed the copy icon appears next to the PR number, click copies the URL, toast appears, icon flips to check, then back to copy

### Screenshot/Recording (if applicable)
#### PR-Overview
<img width="287" height="297" alt="Bildschirmfoto 2026-06-18 um 11 31 33" src="https://github.com/user-attachments/assets/ca2800a0-da95-4e28-98e2-e92c54d6cd11" />

#### On hover
<img width="285" height="284" alt="Bildschirmfoto 2026-06-18 um 11 31 38" src="https://github.com/user-attachments/assets/ab6d2859-450d-4077-84c2-f894e30d775e" />

#### Toast after clicking it
<img width="443" height="94" alt="Bildschirmfoto 2026-06-18 um 11 31 43" src="https://github.com/user-attachments/assets/3b4862db-7977-4a23-9794-8e51665c638b" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>