### PR TITLE
fix(workspaces): reuse checked-out PR branches

### DIFF
--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/git-fetch.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/git-fetch.test.ts
@@ -70,4 +70,33 @@ describe('git-fetch setup step', () => {
     if (result.success) throw new Error('expected failure');
     expect(result.error.type).toBe('fetch-failed');
   });
+
+  it('returns the fetch failure when checking worktrees fails', async () => {
+    const fetchError = {
+      stderr:
+        "fatal: refusing to fetch into branch 'refs/heads/feature/pr' checked out at '/worktrees/feature-pr'",
+    };
+    const exec = vi.fn().mockRejectedValueOnce(fetchError).mockRejectedValueOnce({
+      stderr: 'fatal: not a git repository',
+    });
+
+    const result = await execute(
+      {
+        remote: 'origin',
+        refspec: 'refs/pull/123/head:refs/heads/feature/pr',
+        force: true,
+      },
+      makeCtx(exec as StepContext['ctx']['exec'])
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error).toEqual({
+      type: 'fetch-failed',
+      remote: 'origin',
+      refspec: 'refs/pull/123/head:refs/heads/feature/pr',
+      message: fetchError.stderr,
+    });
+    expect(exec).toHaveBeenNthCalledWith(2, 'git', ['worktree', 'list', '--porcelain']);
+  });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/git-fetch.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/git-fetch.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import { execute } from './git-fetch';
+import type { StepContext } from './step-context';
+
+function makeCtx(exec: StepContext['ctx']['exec']): StepContext {
+  return {
+    ctx: { exec } as StepContext['ctx'],
+    repoPath: '/repo',
+    worktreePoolPath: '/repo/.emdash/worktrees',
+    host: {} as StepContext['host'],
+    projectSettings: {} as StepContext['projectSettings'],
+    worktreeService: {} as StepContext['worktreeService'],
+  };
+}
+
+describe('git-fetch setup step', () => {
+  it('treats a checked-out destination branch as already available', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce({
+        stderr:
+          "fatal: refusing to fetch into branch 'refs/heads/feature/pr' checked out at '/worktrees/feature-pr'",
+      })
+      .mockResolvedValueOnce({
+        stdout: 'worktree /worktrees/feature-pr\nHEAD abc123\nbranch refs/heads/feature/pr\n',
+        stderr: '',
+      });
+
+    const result = await execute(
+      {
+        remote: 'origin',
+        refspec: 'refs/pull/123/head:refs/heads/feature/pr',
+        force: true,
+      },
+      makeCtx(exec as StepContext['ctx']['exec'])
+    );
+
+    expect(result.success).toBe(true);
+    expect(exec).toHaveBeenNthCalledWith(1, 'git', [
+      'fetch',
+      'origin',
+      'refs/pull/123/head:refs/heads/feature/pr',
+      '--force',
+    ]);
+    expect(exec).toHaveBeenNthCalledWith(2, 'git', ['worktree', 'list', '--porcelain']);
+  });
+
+  it('returns the fetch failure when the destination branch is not checked out', async () => {
+    const exec = vi
+      .fn()
+      .mockRejectedValueOnce({
+        stderr:
+          "fatal: refusing to fetch into branch 'refs/heads/feature/pr' checked out at '/worktrees/feature-pr'",
+      })
+      .mockResolvedValueOnce({
+        stdout: 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n',
+        stderr: '',
+      });
+
+    const result = await execute(
+      {
+        remote: 'origin',
+        refspec: 'refs/pull/123/head:refs/heads/feature/pr',
+        force: true,
+      },
+      makeCtx(exec as StepContext['ctx']['exec'])
+    );
+
+    expect(result.success).toBe(false);
+    if (result.success) throw new Error('expected failure');
+    expect(result.error.type).toBe('fetch-failed');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/git-fetch.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/git-fetch.ts
@@ -2,6 +2,29 @@ import { err, ok, type Result } from '@emdash/shared';
 import type * as Step from '@shared/core/workspaces/workspace-setup-steps/git-fetch';
 import type { StepContext } from './step-context';
 
+function destinationLocalBranch(refspec: string | undefined): string | undefined {
+  if (!refspec) return undefined;
+  const destination = refspec.split(':')[1];
+  if (!destination?.startsWith('refs/heads/')) return undefined;
+  return destination.slice('refs/heads/'.length);
+}
+
+function isCheckedOutBranchFetchError(message: string): boolean {
+  return /refusing to fetch into branch .+ checked out/i.test(message);
+}
+
+async function isBranchCheckedOut(branchName: string, ctx: StepContext): Promise<boolean> {
+  try {
+    const { stdout } = await ctx.ctx.exec('git', ['worktree', 'list', '--porcelain']);
+    const branchLine = `branch refs/heads/${branchName}`;
+    return stdout
+      .split('\n\n')
+      .some((block) => block.split('\n').some((line) => line === branchLine));
+  } catch {
+    return false;
+  }
+}
+
 export async function execute(
   args: Step.Args,
   ctx: StepContext
@@ -16,6 +39,14 @@ export async function execute(
     return ok({});
   } catch (error: unknown) {
     const message = (error as { stderr?: string })?.stderr ?? String(error);
+    const checkedOutBranch = destinationLocalBranch(refspec);
+    if (
+      checkedOutBranch &&
+      isCheckedOutBranchFetchError(message) &&
+      (await isBranchCheckedOut(checkedOutBranch, ctx))
+    ) {
+      return ok({});
+    }
     return err({ type: 'fetch-failed', remote, refspec, message });
   }
 }


### PR DESCRIPTION
### Description
- fies `Review in Task` for pr branches already checked out in another worktree
- skips the pr fetch failure only when git confirms that branch is checkedo ut 

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
