### PR TITLE
fix(sidebar): persist manual order in sidebar

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -148,6 +148,29 @@ describe('SidebarStore project ordering', () => {
     });
   });
 
+  it('requests an immediate save after applying a sort', () => {
+    const saveSnapshotNow = vi.fn();
+    const store = new SidebarStore(
+      projectManagerWithTasks([
+        {
+          id: 'project-1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          taskIds: ['task-1a', 'task-1b'],
+        },
+      ]),
+      saveSnapshotNow
+    );
+
+    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
+    saveSnapshotNow.mockClear();
+
+    store.applySort('updated-at');
+
+    expect(saveSnapshotNow).toHaveBeenCalledOnce();
+    expect(store.snapshot.taskSortBy).toBe('updated-at');
+    expect(store.snapshot.taskOrderByProject).toEqual({});
+  });
+
   it('returns visible task entries in rendered project-tree order', () => {
     const store = new SidebarStore(
       projectManagerWithTasks([

--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -85,6 +85,69 @@ describe('SidebarStore project ordering', () => {
     expect(store.orderedProjects.map((project) => project.id)).toEqual(['new', 'manual', 'old']);
   });
 
+  it('restores saved manual project and task order', () => {
+    const store = new SidebarStore(
+      projectManagerWithTasks([
+        {
+          id: 'project-1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          taskIds: ['task-1a', 'task-1b'],
+        },
+        {
+          id: 'project-2',
+          createdAt: '2026-01-02T00:00:00.000Z',
+          taskIds: ['task-2a'],
+        },
+      ])
+    );
+
+    store.restoreSnapshot({
+      expandedProjectIds: ['project-1', 'project-2'],
+      projectOrder: ['project-1', 'project-2'],
+      taskOrderByProject: { 'project-1': ['task-1a', 'task-1b'] },
+    });
+
+    expect(store.orderedProjects.map((project) => project.id)).toEqual(['project-1', 'project-2']);
+    expect(store.visibleTaskIdsForProject('project-1')).toEqual(['task-1a', 'task-1b']);
+  });
+
+  it('requests an immediate save after manual project order changes', () => {
+    const saveSnapshotNow = vi.fn();
+    const store = new SidebarStore(
+      projectManager([
+        { id: 'old', createdAt: '2026-01-01T00:00:00.000Z' },
+        { id: 'new', createdAt: '2026-01-02T00:00:00.000Z' },
+      ]),
+      saveSnapshotNow
+    );
+
+    store.setProjectOrder(['old', 'new']);
+
+    expect(saveSnapshotNow).toHaveBeenCalledOnce();
+    expect(store.snapshot.projectOrder).toEqual(['old', 'new']);
+  });
+
+  it('requests an immediate save after manual task order changes', () => {
+    const saveSnapshotNow = vi.fn();
+    const store = new SidebarStore(
+      projectManagerWithTasks([
+        {
+          id: 'project-1',
+          createdAt: '2026-01-01T00:00:00.000Z',
+          taskIds: ['task-1a', 'task-1b'],
+        },
+      ]),
+      saveSnapshotNow
+    );
+
+    store.setTaskOrder('project-1', ['task-1b', 'task-1a']);
+
+    expect(saveSnapshotNow).toHaveBeenCalledOnce();
+    expect(store.snapshot.taskOrderByProject).toEqual({
+      'project-1': ['task-1b', 'task-1a'],
+    });
+  });
+
   it('returns visible task entries in rendered project-tree order', () => {
     const store = new SidebarStore(
       projectManagerWithTasks([

--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.ts
@@ -43,7 +43,10 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   expandedProjectIds = observable.set<string>();
   taskSortBy: SidebarTaskSortBy = 'created-at';
 
-  constructor(private readonly projectManager: ProjectManagerStore) {
+  constructor(
+    private readonly projectManager: ProjectManagerStore,
+    private readonly saveSnapshotNow: (() => void) | undefined = undefined
+  ) {
     makeAutoObservable(this, {
       expandedProjectIds: false,
       sidebarRows: computed,
@@ -214,10 +217,12 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
   applySort(sortBy: SidebarTaskSortBy): void {
     this.taskSortBy = sortBy;
     this.taskOrderByProject = {};
+    this.saveSnapshotNow?.();
   }
 
   setProjectOrder(ids: string[]): void {
     this.projectOrder = ids;
+    this.saveSnapshotNow?.();
   }
 
   mergeTaskOrder(projectId: string, tasks: TaskStore[]): TaskStore[] {
@@ -242,6 +247,7 @@ export class SidebarStore implements Snapshottable<SidebarSnapshot> {
 
   setTaskOrder(projectId: string, orderedIds: string[]): void {
     this.taskOrderByProject = { ...this.taskOrderByProject, [projectId]: orderedIds };
+    this.saveSnapshotNow?.();
   }
 
   private compareSidebarTasks(a: TaskStore, b: TaskStore): number {

--- a/apps/emdash-desktop/src/renderer/lib/stores/app-state.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/app-state.ts
@@ -21,7 +21,9 @@ class AppState {
     this.snapshots = snapshotRegistry;
     this.update = new UpdateStore();
     this.projects = new ProjectManagerStore();
-    this.sidebar = new SidebarStore(this.projects);
+    this.sidebar = new SidebarStore(this.projects, () => {
+      this.snapshots.saveNow('sidebar', this.sidebar.snapshot);
+    });
     this.history = new NavigationHistoryStore();
     this.navigation = new NavigationStore();
     this.sshConnections = new SshConnectionStore({

--- a/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.test.ts
@@ -1,0 +1,60 @@
+import { observable, runInAction } from 'mobx';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { rpc } from '@renderer/lib/ipc';
+import { SnapshotRegistry } from './snapshot-registry';
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    viewState: {
+      get: vi.fn(),
+      save: vi.fn(),
+    },
+  },
+}));
+
+const saveViewState = vi.mocked(rpc.viewState.save);
+
+describe('SnapshotRegistry', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    saveViewState.mockClear();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('persists debounced snapshot changes without saveNow', async () => {
+    const registry = new SnapshotRegistry();
+    const state = observable.box({ order: ['a'] });
+    const dispose = registry.register('sidebar', () => state.get());
+
+    state.set({ order: ['b'] });
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(saveViewState).toHaveBeenCalledOnce();
+    expect(saveViewState).toHaveBeenCalledWith('sidebar', { order: ['b'] });
+
+    dispose();
+  });
+
+  it('skips the debounced write after saveNow saves the same snapshot', async () => {
+    const registry = new SnapshotRegistry();
+    const state = observable.box({ order: ['a'] });
+    const dispose = registry.register('sidebar', () => state.get());
+
+    runInAction(() => {
+      state.set({ order: ['b'] });
+      registry.saveNow('sidebar', state.get());
+    });
+
+    expect(saveViewState).toHaveBeenCalledOnce();
+    expect(saveViewState).toHaveBeenCalledWith('sidebar', { order: ['b'] });
+
+    await vi.advanceTimersByTimeAsync(1000);
+
+    expect(saveViewState).toHaveBeenCalledOnce();
+
+    dispose();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
@@ -43,6 +43,11 @@ export class SnapshotRegistry {
       this.disposers.delete(key);
     };
   }
+
+  saveNow(key: string, snapshot: unknown): void {
+    viewStateCache.set(key, snapshot);
+    void rpc.viewState.save(key, snapshot);
+  }
 }
 
 export const snapshotRegistry = new SnapshotRegistry();

--- a/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/snapshot-registry.ts
@@ -4,6 +4,7 @@ import { viewStateCache } from './view-state-cache';
 
 export class SnapshotRegistry {
   private readonly disposers = new Map<string, () => void>();
+  private readonly lastSavedSnapshots = new Map<string, unknown>();
 
   /**
    * Register an entity's snapshot with the registry.
@@ -30,7 +31,13 @@ export class SnapshotRegistry {
       () => getSnapshot(),
       (snapshot) => {
         viewStateCache.set(key, snapshot);
-        void rpc.viewState.save(key, snapshot);
+        if (
+          this.lastSavedSnapshots.has(key) &&
+          comparer.structural(this.lastSavedSnapshots.get(key), snapshot)
+        ) {
+          return;
+        }
+        this.persistSnapshot(key, snapshot);
       },
       { equals: comparer.structural, delay: 1000, fireImmediately: false }
     );
@@ -40,12 +47,18 @@ export class SnapshotRegistry {
     return () => {
       disposer();
       viewStateCache.delete(key);
+      this.lastSavedSnapshots.delete(key);
       this.disposers.delete(key);
     };
   }
 
   saveNow(key: string, snapshot: unknown): void {
     viewStateCache.set(key, snapshot);
+    this.persistSnapshot(key, snapshot);
+  }
+
+  private persistSnapshot(key: string, snapshot: unknown): void {
+    this.lastSavedSnapshots.set(key, snapshot);
     void rpc.viewState.save(key, snapshot);
   }
 }


### PR DESCRIPTION
### Description
- persist manual sidebar order after drag-and-drop
- save sidebar snapshots immediatel on reorder

### Screenshot/Recording (if applicable)
https://streamable.com/4eyw09

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
