### PR TITLE
fix: preserve workspace assets when archiving

### DIFF
--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
@@ -212,8 +212,7 @@ class WorkspaceFileIndexService {
           `SELECT m.workspace_id
            FROM workspace_file_index_meta m
            LEFT JOIN workspaces w ON w.id = m.workspace_id
-           LEFT JOIN tasks t ON t.workspace_id = m.workspace_id AND t.archived_at IS NULL
-           WHERE w.id IS NULL OR t.id IS NULL`
+           WHERE w.id IS NULL`
         )
         .all() as Array<{ workspace_id: string }>;
 

--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
@@ -3,10 +3,9 @@ import { archiveTask } from './archiveTask';
 
 const mocks = vi.hoisted(() => ({
   capture: vi.fn(),
-  deleteIndex: vi.fn(),
-  getProject: vi.fn(),
   selectLimit: vi.fn(),
   teardownTask: vi.fn(),
+  updateSet: vi.fn(),
   updateWhere: vi.fn(),
 }));
 
@@ -20,28 +19,14 @@ vi.mock('@main/db/client', () => ({
       }),
     }),
     update: () => ({
-      set: () => ({
-        where: mocks.updateWhere,
-      }),
+      set: mocks.updateSet,
     }),
-  },
-}));
-
-vi.mock('@main/core/projects/project-manager', () => ({
-  projectManager: {
-    getProject: mocks.getProject,
   },
 }));
 
 vi.mock('@main/core/tasks/task-session-manager', () => ({
   taskSessionManager: {
     teardownTask: mocks.teardownTask,
-  },
-}));
-
-vi.mock('@main/core/search/workspace-file-index-service', () => ({
-  workspaceFileIndexService: {
-    deleteIndex: mocks.deleteIndex,
   },
 }));
 
@@ -54,47 +39,37 @@ vi.mock('@main/lib/telemetry', () => ({
 describe('archiveTask', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.updateSet.mockReturnValue({ where: mocks.updateWhere });
     mocks.updateWhere.mockResolvedValue(undefined);
   });
 
-  it('waits for teardown before removing the worktree', async () => {
-    const order: string[] = [];
-    let resolveTeardown: (value: { success: true }) => void = () => {};
-    const teardownPromise = new Promise<{ success: true }>((resolve) => {
-      resolveTeardown = resolve;
+  it('archives by detaching runtime without deleting workspace assets', async () => {
+    mocks.selectLimit.mockResolvedValueOnce([
+      {
+        id: 'task-1',
+        workspaceId: 'workspace-1',
+        status: 'done',
+      },
+    ]);
+    mocks.teardownTask.mockResolvedValue({ success: true });
+
+    await archiveTask('project-1', 'task-1');
+
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        archivedAt: expect.anything(),
+        updatedAt: expect.anything(),
+      })
+    );
+    const updatePayload = mocks.updateSet.mock.calls[0]?.[0];
+    expect(updatePayload).not.toHaveProperty('status');
+    expect(updatePayload).not.toHaveProperty('statusChangedAt');
+
+    expect(mocks.teardownTask).toHaveBeenCalledWith('task-1', 'detach');
+    expect(mocks.capture).toHaveBeenCalledWith('task_archived', {
+      project_id: 'project-1',
+      task_id: 'task-1',
     });
-    const removeTaskWorktree = vi.fn(async () => {
-      order.push('remove-worktree');
-    });
-
-    mocks.selectLimit
-      .mockResolvedValueOnce([
-        {
-          id: 'task-1',
-          workspaceId: 'workspace-1',
-        },
-      ])
-      .mockResolvedValueOnce([{ id: 'workspace-1', branchName: 'emdash/task-1' }])
-      .mockResolvedValueOnce([])
-      .mockResolvedValueOnce([]);
-    mocks.getProject.mockReturnValue({ removeTaskWorktree });
-    mocks.updateWhere.mockImplementation(async () => {
-      order.push('archive-update');
-    });
-    mocks.teardownTask.mockImplementation(() => {
-      order.push('teardown-start');
-      return teardownPromise;
-    });
-
-    const archivePromise = archiveTask('project-1', 'task-1');
-    await vi.waitFor(() => expect(mocks.teardownTask).toHaveBeenCalledTimes(1));
-
-    expect(removeTaskWorktree).not.toHaveBeenCalled();
-
-    resolveTeardown({ success: true });
-    await archivePromise;
-
-    expect(removeTaskWorktree).toHaveBeenCalledWith('emdash/task-1');
-    expect(order).toEqual(['archive-update', 'teardown-start', 'remove-worktree']);
+    expect(mocks.selectLimit).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
@@ -1,68 +1,29 @@
 import { eq, sql } from 'drizzle-orm';
-import { projectManager } from '@main/core/projects/project-manager';
 import { taskSessionManager } from '@main/core/tasks/task-session-manager';
 import { db } from '@main/db/client';
-import { tasks, workspaces } from '@main/db/schema';
+import { tasks } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
-import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
-import { deleteIndexIfUnused, removeWorktreeIfUnused } from './task-lifecycle-utils';
 
 export async function archiveTask(projectId: string, taskId: string): Promise<void> {
   const [task] = await db.select().from(tasks).where(eq(tasks.id, taskId)).limit(1);
   if (!task) return;
 
-  const project = projectManager.getProject(projectId);
-
   await db
     .update(tasks)
     .set({
-      status: 'archived',
       archivedAt: sql`CURRENT_TIMESTAMP`,
       updatedAt: sql`CURRENT_TIMESTAMP`,
-      statusChangedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(tasks.id, taskId));
   telemetryService.capture('task_archived', { project_id: projectId, task_id: taskId });
 
-  if (!project) return;
-
-  const teardownResult = await taskSessionManager.teardownTask(taskId, 'terminate').catch((e) => {
+  const teardownResult = await taskSessionManager.teardownTask(taskId, 'detach').catch((e) => {
     log.warn('archiveTask: teardown failed', { taskId, error: String(e) });
     return null;
   });
 
   if (teardownResult && !teardownResult.success) {
     log.warn('archiveTask: teardown failed', { taskId, error: teardownResult.error.message });
-  }
-
-  let wsRow:
-    | {
-        id: string;
-        kind: 'worktree' | 'project-root' | 'byoi' | null;
-        branchName: string | null;
-        config: WorkspaceConfig | null;
-      }
-    | undefined;
-  if (task.workspaceId) {
-    const [ws] = await db
-      .select({
-        id: workspaces.id,
-        kind: workspaces.kind,
-        branchName: workspaces.branchName,
-        config: workspaces.config,
-      })
-      .from(workspaces)
-      .where(eq(workspaces.id, task.workspaceId))
-      .limit(1);
-    if (ws) wsRow = ws;
-  }
-
-  if (wsRow) {
-    await removeWorktreeIfUnused(wsRow, project, true);
-  }
-
-  if (task.workspaceId) {
-    await deleteIndexIfUnused(task.workspaceId);
   }
 }

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { deleteTask } from './deleteTask';
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  deleteIndex: vi.fn(),
+  deleteWhere: vi.fn(),
+  getProject: vi.fn(),
+  selectLimit: vi.fn(),
+  teardownTask: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: mocks.selectLimit,
+        }),
+      }),
+    }),
+    delete: () => ({
+      where: mocks.deleteWhere,
+    }),
+  },
+}));
+
+vi.mock('@main/core/projects/project-manager', () => ({
+  projectManager: {
+    getProject: mocks.getProject,
+  },
+}));
+
+vi.mock('@main/core/tasks/task-session-manager', () => ({
+  taskSessionManager: {
+    teardownTask: mocks.teardownTask,
+  },
+}));
+
+vi.mock('@main/core/view-state/view-state-service', () => ({
+  viewStateService: {
+    del: vi.fn(),
+  },
+}));
+
+vi.mock('@main/core/search/workspace-file-index-service', () => ({
+  workspaceFileIndexService: {
+    deleteIndex: mocks.deleteIndex,
+  },
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: {
+    capture: mocks.capture,
+  },
+}));
+
+describe('deleteTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.deleteWhere.mockResolvedValue(undefined);
+    mocks.getProject.mockReturnValue(undefined);
+  });
+
+  it('deletes the workspace file index after deleting the last non-archived task', async () => {
+    mocks.selectLimit
+      .mockResolvedValueOnce([{ id: 'task-1', workspaceId: 'workspace-1' }])
+      .mockResolvedValueOnce([
+        { id: 'workspace-1', kind: 'worktree', branchName: null, config: null },
+      ])
+      .mockResolvedValueOnce([{ id: 'workspace-1', kind: 'worktree' }])
+      .mockResolvedValueOnce([{ id: 'archived-sibling' }])
+      .mockResolvedValueOnce([]);
+
+    await deleteTask('project-1', 'task-1', { deleteWorktree: false });
+
+    expect(mocks.deleteIndex).toHaveBeenCalledWith('workspace-1');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
@@ -62,18 +62,17 @@ describe('deleteTask', () => {
     mocks.getProject.mockReturnValue(undefined);
   });
 
-  it('deletes the workspace file index after deleting the last non-archived task', async () => {
+  it('preserves the workspace file index when an archived sibling still references the workspace', async () => {
     mocks.selectLimit
       .mockResolvedValueOnce([{ id: 'task-1', workspaceId: 'workspace-1' }])
       .mockResolvedValueOnce([
         { id: 'workspace-1', kind: 'worktree', branchName: null, config: null },
       ])
       .mockResolvedValueOnce([{ id: 'workspace-1', kind: 'worktree' }])
-      .mockResolvedValueOnce([{ id: 'archived-sibling' }])
-      .mockResolvedValueOnce([]);
+      .mockResolvedValueOnce([{ id: 'archived-sibling' }]);
 
     await deleteTask('project-1', 'task-1', { deleteWorktree: false });
 
-    expect(mocks.deleteIndex).toHaveBeenCalledWith('workspace-1');
+    expect(mocks.deleteIndex).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
@@ -9,11 +9,7 @@ import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import type { DeleteTaskOptions } from '@shared/core/tasks/tasks';
 import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
-import {
-  deleteIndexIfUnused,
-  deleteWorkspaceIfUnused,
-  removeWorktreeIfUnused,
-} from './task-lifecycle-utils';
+import { deleteWorkspaceIfUnused, removeWorktreeIfUnused } from './task-lifecycle-utils';
 
 export async function deleteTask(
   projectId: string,
@@ -58,9 +54,6 @@ export async function deleteTask(
   }
 
   await db.delete(tasks).where(eq(tasks.id, taskId));
-  if (task.workspaceId) {
-    await deleteIndexIfUnused(task.workspaceId);
-  }
   void viewStateService.del(`task:${taskId}`);
   telemetryService.capture('task_deleted', { project_id: projectId, task_id: taskId });
 

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
@@ -9,7 +9,11 @@ import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import type { DeleteTaskOptions } from '@shared/core/tasks/tasks';
 import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
-import { deleteWorkspaceIfUnused, removeWorktreeIfUnused } from './task-lifecycle-utils';
+import {
+  deleteIndexIfUnused,
+  deleteWorkspaceIfUnused,
+  removeWorktreeIfUnused,
+} from './task-lifecycle-utils';
 
 export async function deleteTask(
   projectId: string,
@@ -54,6 +58,9 @@ export async function deleteTask(
   }
 
   await db.delete(tasks).where(eq(tasks.id, taskId));
+  if (task.workspaceId) {
+    await deleteIndexIfUnused(task.workspaceId);
+  }
   void viewStateService.del(`task:${taskId}`);
   telemetryService.capture('task_deleted', { project_id: projectId, task_id: taskId });
 

--- a/apps/emdash-desktop/src/main/core/tasks/operations/restoreTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/restoreTask.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { restoreTask } from './restoreTask';
+
+const mocks = vi.hoisted(() => ({
+  returning: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    update: () => ({
+      set: mocks.updateSet,
+    }),
+  },
+}));
+
+describe('restoreTask', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateSet.mockReturnValue({ where: mocks.updateWhere });
+    mocks.updateWhere.mockReturnValue({ returning: mocks.returning });
+  });
+
+  it('restores by clearing archivedAt without changing lifecycle status', async () => {
+    mocks.returning.mockResolvedValueOnce([
+      {
+        id: 'task-1',
+        projectId: 'project-1',
+        name: 'Task 1',
+        status: 'done',
+        linkedIssue: null,
+        archivedAt: null,
+        lastInteractedAt: null,
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-02T00:00:00.000Z',
+        statusChangedAt: '2026-01-01T00:00:00.000Z',
+        isPinned: 0,
+        workspaceId: 'workspace-1',
+        type: 'task',
+        automationRunId: null,
+      },
+    ]);
+
+    const task = await restoreTask('task-1');
+
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        archivedAt: null,
+        updatedAt: expect.anything(),
+      })
+    );
+    const updatePayload = mocks.updateSet.mock.calls[0]?.[0];
+    expect(updatePayload).not.toHaveProperty('status');
+    expect(updatePayload).not.toHaveProperty('statusChangedAt');
+    expect(task?.status).toBe('done');
+    expect(task?.archivedAt).toBeUndefined();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/tasks/operations/restoreTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/restoreTask.ts
@@ -9,9 +9,7 @@ export async function restoreTask(id: string): Promise<Task | undefined> {
     .update(tasks)
     .set({
       archivedAt: null,
-      status: 'in_progress',
       updatedAt: sql`CURRENT_TIMESTAMP`,
-      statusChangedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(tasks.id, id))
     .returning();

--- a/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.test.ts
@@ -1,8 +1,9 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
-import { removeWorktreeIfUnused } from './task-lifecycle-utils';
+import { deleteWorkspaceIfUnused, removeWorktreeIfUnused } from './task-lifecycle-utils';
 
 const mocks = vi.hoisted(() => ({
+  deleteWhere: vi.fn(),
   selectLimit: vi.fn(),
   deleteIndex: vi.fn(),
 }));
@@ -16,6 +17,9 @@ vi.mock('@main/db/client', () => ({
         }),
       }),
     }),
+    delete: () => ({
+      where: mocks.deleteWhere,
+    }),
   },
 }));
 
@@ -28,6 +32,7 @@ vi.mock('@main/core/search/workspace-file-index-service', () => ({
 describe('task lifecycle workspace cleanup', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.deleteWhere.mockResolvedValue(undefined);
   });
 
   it('does not remove a project-root workspace when branchName is a current-branch cache', async () => {
@@ -79,5 +84,27 @@ describe('task lifecycle workspace cleanup', () => {
     ).resolves.toBe(true);
 
     expect(project.removeTaskWorktree).toHaveBeenCalledWith('task/provisioned');
+  });
+
+  it('deletes the workspace index when deleting the unreferenced workspace row', async () => {
+    mocks.selectLimit
+      .mockResolvedValueOnce([{ id: 'workspace-1', kind: 'worktree' }])
+      .mockResolvedValueOnce([]);
+
+    await deleteWorkspaceIfUnused('workspace-1', 'task-1');
+
+    expect(mocks.deleteWhere).toHaveBeenCalledOnce();
+    expect(mocks.deleteIndex).toHaveBeenCalledWith('workspace-1');
+  });
+
+  it('preserves the workspace index while an archived sibling still references the workspace', async () => {
+    mocks.selectLimit
+      .mockResolvedValueOnce([{ id: 'workspace-1', kind: 'worktree' }])
+      .mockResolvedValueOnce([{ id: 'archived-sibling' }]);
+
+    await deleteWorkspaceIfUnused('workspace-1', 'task-1');
+
+    expect(mocks.deleteWhere).not.toHaveBeenCalled();
+    expect(mocks.deleteIndex).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.ts
@@ -8,10 +8,11 @@ import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
 import type { ProjectProvider } from '../../projects/project-provider';
 
 /**
- * Removes the worktree when no remaining sibling tasks share the same workspace.
+ * Removes the worktree for destructive task deletion when no remaining sibling task shares the
+ * same workspace.
  *
- * `excludeArchived = true`  — only non-archived siblings block removal (use for archiveTask).
- * `excludeArchived = false` — any remaining sibling blocks removal (use for deleteTask).
+ * `excludeArchived = false` means any remaining sibling blocks removal. Archive intentionally
+ * preserves workspace assets and does not call this helper.
  *
  * Returns `true` if the worktree was removed (no siblings found), `false` otherwise.
  */

--- a/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.ts
@@ -49,7 +49,7 @@ export async function removeWorktreeIfUnused(
 }
 
 /**
- * Deletes the workspace row only when no other task still references it.
+ * Deletes the workspace row and its derived file index only when no other task still references it.
  *
  * Tasks are deduplicated onto a single workspace row per resolved path (see
  * `WorkspaceBootstrapService.persistPath`), so for `no-worktree` tasks every task in a
@@ -78,28 +78,13 @@ export async function deleteWorkspaceIfUnused(
     .limit(1);
   if (sibling) return;
 
-  await db
-    .delete(workspaces)
-    .where(eq(workspaces.id, workspaceId))
-    .catch((e) => {
-      log.warn('deleteWorkspaceIfUnused: workspace row deletion failed', {
-        workspaceId,
-        error: String(e),
-      });
-    });
-}
-
-/**
- * Deletes the workspace file index when no non-archived sibling task shares the workspace.
- */
-export async function deleteIndexIfUnused(workspaceId: string): Promise<void> {
-  const siblings = await db
-    .select({ id: tasks.id })
-    .from(tasks)
-    .where(and(eq(tasks.workspaceId, workspaceId), isNull(tasks.archivedAt)))
-    .limit(1);
-
-  if (siblings.length === 0) {
+  try {
+    await db.delete(workspaces).where(eq(workspaces.id, workspaceId));
     workspaceFileIndexService.deleteIndex(workspaceId);
+  } catch (e) {
+    log.warn('deleteWorkspaceIfUnused: workspace row deletion failed', {
+      workspaceId,
+      error: String(e),
+    });
   }
 }


### PR DESCRIPTION
- archive detaches task runtime instead of terminating and deleting worktree assets
- archive keeps workspace rows and file indexes intact for later restore
- restore clears archived state without changing the task lifecycle status
- ask archive behavior now matches close and reopen semantics more closely