### PR TITLE
feat(settings): add/update default worktree directory

### DIFF
--- a/apps/emdash-desktop/src/main/core/projects/settings/local-worktree-directory.ts
+++ b/apps/emdash-desktop/src/main/core/projects/settings/local-worktree-directory.ts
@@ -1,0 +1,56 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { err, type Result } from '@emdash/shared';
+import type { UpdateProjectSettingsError } from '@shared/projects';
+import {
+  normalizeWorktreeDirectory,
+  resolveAndValidateWorktreeDirectory,
+  type PathPlatform,
+} from './worktree-directory';
+
+const localPathPlatform: PathPlatform = process.platform === 'win32' ? 'win32' : 'posix';
+
+const localWorktreeDirectoryFs = {
+  mkdir: async (p: string, options?: { recursive?: boolean }) => {
+    await fs.promises.mkdir(p, options);
+  },
+  realPath: async (p: string) => fs.promises.realpath(p),
+};
+
+export function resolveAndValidateLocalWorktreeDirectory(
+  worktreeDirectory: string | undefined
+): Promise<Result<string | undefined, UpdateProjectSettingsError>> {
+  return resolveAndValidateWorktreeDirectory(worktreeDirectory, {
+    pathApi: path,
+    pathPlatform: localPathPlatform,
+    fs: localWorktreeDirectoryFs,
+    homeDirectory: os.homedir(),
+  });
+}
+
+export function normalizeStoredLocalWorktreeDirectory(
+  worktreeDirectory: string
+): Promise<Result<string, UpdateProjectSettingsError>> {
+  return normalizeWorktreeDirectory(worktreeDirectory, {
+    pathApi: path,
+    pathPlatform: localPathPlatform,
+    homeDirectory: os.homedir(),
+  });
+}
+
+export async function normalizeExistingLocalWorktreeDirectory(
+  worktreeDirectory: string | undefined
+): Promise<Result<string, UpdateProjectSettingsError>> {
+  const trimmed = worktreeDirectory?.trim();
+  if (!trimmed) return err({ type: 'invalid-worktree-directory' });
+
+  const normalized = await normalizeStoredLocalWorktreeDirectory(trimmed);
+  if (!normalized.success) return normalized;
+
+  try {
+    return { success: true, data: await fs.promises.realpath(normalized.data) };
+  } catch {
+    return normalized;
+  }
+}

--- a/apps/emdash-desktop/src/main/core/projects/settings/project-settings.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/settings/project-settings.test.ts
@@ -12,6 +12,7 @@ import { SshProjectSettingsProvider } from './providers/ssh-project-settings-pro
 
 const storageMockState = vi.hoisted(() => ({
   storage: undefined as ProjectSettingsStorage | undefined,
+  defaultWorktreeDirectory: '/tmp/emdash/worktrees',
 }));
 
 function makeTrackingGit(isFileCleanlyTracked: boolean) {
@@ -25,7 +26,7 @@ vi.mock('@main/core/settings/settings-service', () => ({
     get: vi.fn().mockImplementation((key: string) => {
       if (key === 'project') return Promise.resolve({ tmuxByDefault: false });
       return Promise.resolve({
-        defaultWorktreeDirectory: '/tmp/emdash/worktrees',
+        defaultWorktreeDirectory: storageMockState.defaultWorktreeDirectory,
       });
     }),
   },
@@ -76,6 +77,7 @@ describe('ProjectSettingsProvider worktreeDirectory validation', () => {
 
   beforeEach(() => {
     storageMockState.storage = createStorage();
+    storageMockState.defaultWorktreeDirectory = '/tmp/emdash/worktrees';
   });
 
   afterEach(() => {
@@ -271,6 +273,32 @@ describe('ProjectSettingsProvider worktreeDirectory validation', () => {
     const expectedOverride = fs.realpathSync(expectedOverridePath);
     await expect(provider.get()).resolves.toMatchObject({ worktreeDirectory: expectedOverride });
     await expect(provider.getDefaultWorktreeDirectory()).resolves.toBe('/tmp/emdash/worktrees');
+    await expect(provider.getWorktreeDirectory()).resolves.toBe(expectedOverride);
+  });
+
+  it('uses updated app-level default without replacing project worktreeDirectory overrides', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-local-'));
+    const defaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-default-'));
+    tempDirs.push(projectPath, defaultPath);
+    const provider = new LocalProjectSettingsProvider(projectId(), projectPath, 'main');
+    await expect(provider.getWorktreeDirectory()).resolves.toBe('/tmp/emdash/worktrees');
+
+    storageMockState.defaultWorktreeDirectory = defaultPath;
+    await expect(provider.get()).resolves.not.toHaveProperty('worktreeDirectory');
+    await expect(provider.getDefaultWorktreeDirectory()).resolves.toBe(defaultPath);
+    await expect(provider.getWorktreeDirectory()).resolves.toBe(defaultPath);
+
+    const overridePath = path.join(projectPath, 'worktrees');
+    const result = await provider.update({ preservePatterns: [], worktreeDirectory: overridePath });
+    expect(result.success).toBe(true);
+    const expectedOverride = fs.realpathSync(overridePath);
+
+    const nextDefaultPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-settings-default-'));
+    tempDirs.push(nextDefaultPath);
+    storageMockState.defaultWorktreeDirectory = nextDefaultPath;
+
+    await expect(provider.getDefaultWorktreeDirectory()).resolves.toBe(nextDefaultPath);
+    await expect(provider.get()).resolves.toMatchObject({ worktreeDirectory: expectedOverride });
     await expect(provider.getWorktreeDirectory()).resolves.toBe(expectedOverride);
   });
 

--- a/apps/emdash-desktop/src/main/core/projects/settings/providers/local-project-settings-provider.ts
+++ b/apps/emdash-desktop/src/main/core/projects/settings/providers/local-project-settings-provider.ts
@@ -1,13 +1,12 @@
 import fs from 'node:fs';
-import os from 'node:os';
 import path from 'node:path';
 import type { Result } from '@emdash/shared';
 import { appSettingsService } from '@main/core/settings/settings-service';
 import type { UpdateProjectSettingsError } from '@shared/projects';
 import {
-  normalizeWorktreeDirectory,
-  resolveAndValidateWorktreeDirectory,
-} from '../worktree-directory';
+  normalizeStoredLocalWorktreeDirectory,
+  resolveAndValidateLocalWorktreeDirectory,
+} from '../local-worktree-directory';
 import {
   DbProjectSettingsProvider,
   type DbProjectSettingsProviderOptions,
@@ -16,8 +15,6 @@ import {
 async function getLocalDefaultWorktreeDirectory(): Promise<string> {
   return (await appSettingsService.get('localProject')).defaultWorktreeDirectory;
 }
-
-const localPathPlatform = process.platform === 'win32' ? 'win32' : 'posix';
 
 export class LocalProjectSettingsProvider extends DbProjectSettingsProvider {
   constructor(
@@ -48,26 +45,12 @@ export class LocalProjectSettingsProvider extends DbProjectSettingsProvider {
   protected validateWorktreeDirectory(
     worktreeDirectory: string | undefined
   ): Promise<Result<string | undefined, UpdateProjectSettingsError>> {
-    return resolveAndValidateWorktreeDirectory(worktreeDirectory, {
-      pathApi: path,
-      pathPlatform: localPathPlatform,
-      fs: {
-        mkdir: async (p, options) => {
-          await fs.promises.mkdir(p, options);
-        },
-        realPath: async (p) => fs.promises.realpath(p),
-      },
-      homeDirectory: os.homedir(),
-    });
+    return resolveAndValidateLocalWorktreeDirectory(worktreeDirectory);
   }
 
   protected normalizeStoredWorktreeDirectory(
     worktreeDirectory: string
   ): Promise<Result<string, UpdateProjectSettingsError>> {
-    return normalizeWorktreeDirectory(worktreeDirectory, {
-      pathApi: path,
-      pathPlatform: localPathPlatform,
-      homeDirectory: os.homedir(),
-    });
+    return normalizeStoredLocalWorktreeDirectory(worktreeDirectory);
   }
 }

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.test.ts
@@ -75,6 +75,31 @@ describe('LocalWorktreeHost', () => {
     expect(fs.existsSync(target)).toBe(true);
   });
 
+  it('allows the exact missing parent for a target inside an allowed root', async () => {
+    const host = await makeHost();
+    const target = path.join(worktreeDir, 'deep', 'nested', 'task-1');
+
+    await host.allowPath(target);
+    await host.mkdirAbsolute(target, { recursive: true });
+
+    expect(fs.existsSync(target)).toBe(true);
+    expect(fs.existsSync(path.dirname(target))).toBe(true);
+  });
+
+  it('does not allow a broad ancestor for a missing external target path', async () => {
+    const host = await makeHost();
+    const target = path.join(outsideDir, 'deep', 'nested', 'task-1');
+    const sibling = path.join(outsideDir, 'deep', 'sibling');
+
+    await host.allowPath(target);
+    await host.mkdirAbsolute(target, { recursive: true });
+
+    expect(fs.existsSync(target)).toBe(true);
+    await expect(host.mkdirAbsolute(sibling, { recursive: true })).rejects.toMatchObject({
+      code: FileSystemErrorCodes.PATH_ESCAPE,
+    });
+  });
+
   it('rejects symlink escapes outside the allowed roots', async () => {
     if (process.platform === 'win32') {
       return;

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
@@ -60,6 +60,22 @@ export class LocalWorktreeHost implements WorktreeHost {
     }
   }
 
+  async allowPath(targetPath: string): Promise<void> {
+    const resolved = this.assertAbsolute(targetPath);
+    let allowedRoot: string;
+    try {
+      allowedRoot = await fs.realpath(resolved);
+    } catch (error) {
+      if (!isNotFound(error)) throw error;
+      const { realAncestor } = await this.nearestExistingPath(resolved);
+      allowedRoot = realAncestor;
+    }
+
+    if (!this.roots.some((existing) => existing === allowedRoot)) {
+      this.roots.push(allowedRoot);
+    }
+  }
+
   private assertAbsolute(input: string): string {
     const resolved = path.resolve(input);
     if (!path.isAbsolute(input)) {

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
@@ -62,12 +62,13 @@ export class LocalWorktreeHost implements WorktreeHost {
 
   async allowPath(targetPath: string): Promise<void> {
     const resolved = this.assertAbsolute(targetPath);
+    const parent = path.dirname(resolved);
     let allowedRoot: string;
     try {
-      allowedRoot = await fs.realpath(resolved);
+      allowedRoot = await fs.realpath(parent);
     } catch (error) {
       if (!isNotFound(error)) throw error;
-      const { realAncestor } = await this.nearestExistingPath(resolved);
+      const { realAncestor } = await this.nearestExistingPath(parent);
       allowedRoot = realAncestor;
     }
 

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/local-worktree-host.ts
@@ -68,8 +68,10 @@ export class LocalWorktreeHost implements WorktreeHost {
       allowedRoot = await fs.realpath(parent);
     } catch (error) {
       if (!isNotFound(error)) throw error;
-      const { realAncestor } = await this.nearestExistingPath(parent);
-      allowedRoot = realAncestor;
+      const { realAncestor, unresolvedSegments } = await this.nearestExistingPath(parent);
+      const parentTarget = path.join(realAncestor, ...unresolvedSegments);
+      await fs.mkdir(parentTarget, { recursive: true });
+      allowedRoot = await fs.realpath(parentTarget);
     }
 
     if (!this.roots.some((existing) => existing === allowedRoot)) {
@@ -138,7 +140,6 @@ export class LocalWorktreeHost implements WorktreeHost {
     }
 
     const { realAncestor, unresolvedSegments } = await this.nearestExistingPath(resolved);
-    this.assertInsideAllowedRoots(realAncestor, input);
     const target = path.join(realAncestor, ...unresolvedSegments);
     this.assertInsideAllowedRoots(target, input);
     return target;

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/worktree-host.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/worktree-host.ts
@@ -5,6 +5,7 @@ export type WorktreeHostPathApi = Pick<typeof path, 'dirname' | 'join'>;
 
 export interface WorktreeHost {
   readonly pathApi: WorktreeHostPathApi;
+  allowPath?(path: string): Promise<void>;
   existsAbsolute(path: string): Promise<boolean>;
   mkdirAbsolute(path: string, options?: { recursive?: boolean }): Promise<void>;
   removeAbsolute(

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -284,6 +284,45 @@ describe('WorktreeService', () => {
       expect(fs.existsSync(result.data)).toBe(true);
     });
 
+    it('creates a resumed worktree at the persisted path outside the current pool', async () => {
+      const branchName = 'task/resume-persisted';
+      await git(['branch', branchName], { cwd: repoDir });
+      const persistedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-persisted-'));
+      const persistedPath = path.join(persistedRoot, 'task', 'resume-persisted');
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data).toBe(persistedPath);
+      expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(true);
+      expect(fs.existsSync(path.join(poolDir, 'task', 'resume-persisted'))).toBe(false);
+
+      fs.rmSync(persistedRoot, { recursive: true, force: true });
+    });
+
+    it('moves a branch from the current pool back to the persisted resume path', async () => {
+      const branchName = 'task/resume-move-back';
+      await git(['branch', branchName], { cwd: repoDir });
+      const persistedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-persisted-'));
+      const persistedPath = path.join(persistedRoot, 'task', 'resume-move-back');
+      const svc = makeService();
+      const currentPoolResult = await svc.checkoutExistingBranch(branchName);
+      expect(currentPoolResult.success).toBe(true);
+      if (!currentPoolResult.success) throw new Error('expected success');
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data).toBe(persistedPath);
+      expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(true);
+      expect(fs.existsSync(currentPoolResult.data)).toBe(false);
+
+      fs.rmSync(persistedRoot, { recursive: true, force: true });
+    });
+
     it('records base metadata before returning an existing valid target worktree', async () => {
       const branchName = 'task/existing-target';
       const targetPath = path.join(poolDir, branchName);

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -361,6 +361,23 @@ describe('WorktreeService', () => {
       await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
     });
 
+    it('creates the pool directory before resuming a stored worktree path', async () => {
+      const branchName = 'task/resume-missing-pool';
+      await git(['branch', branchName], { cwd: repoDir });
+      fs.rmSync(poolDir, { recursive: true, force: true });
+      const persistedPath = path.join(poolDir, 'task', 'resume-missing-pool');
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data).toBe(persistedPath);
+      expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(true);
+
+      await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
+    });
+
     it('does not remove a stale persisted directory inside the current pool when it contains user files', async () => {
       const branchName = 'task/resume-stale-pool-with-changes';
       await git(['branch', branchName], { cwd: repoDir });

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -58,8 +58,8 @@ describe('WorktreeService', () => {
   });
 
   afterEach(() => {
-    fs.rmSync(repoDir, { recursive: true, force: true });
-    fs.rmSync(poolDir, { recursive: true, force: true });
+    fs.rmSync(repoDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
+    fs.rmSync(poolDir, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 });
   });
 
   function makeService(
@@ -303,11 +303,29 @@ describe('WorktreeService', () => {
       fs.rmSync(persistedRoot, { recursive: true, force: true });
     });
 
-    it('repairs a stale persisted directory outside the current pool', async () => {
+    it('does not remove a stale persisted directory outside the current pool', async () => {
       const branchName = 'task/resume-stale-persisted';
       await git(['branch', branchName], { cwd: repoDir });
       const persistedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-persisted-'));
       const persistedPath = path.join(persistedRoot, 'task', 'resume-stale-persisted');
+      fs.mkdirSync(path.join(persistedPath, 'node_modules'), { recursive: true });
+      fs.writeFileSync(path.join(persistedPath, 'node_modules', 'stale.txt'), 'stale');
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected failure');
+      expect(result.error.type).toBe('worktree-setup-failed');
+      expect(fs.existsSync(path.join(persistedPath, 'node_modules', 'stale.txt'))).toBe(true);
+
+      fs.rmSync(persistedRoot, { recursive: true, force: true });
+    });
+
+    it('repairs a stale persisted directory inside the current pool', async () => {
+      const branchName = 'task/resume-stale-pool';
+      await git(['branch', branchName], { cwd: repoDir });
+      const persistedPath = path.join(poolDir, 'task', 'resume-stale-pool');
       fs.mkdirSync(path.join(persistedPath, 'node_modules'), { recursive: true });
       fs.writeFileSync(path.join(persistedPath, 'node_modules', 'stale.txt'), 'stale');
       const svc = makeService();
@@ -319,6 +337,46 @@ describe('WorktreeService', () => {
       expect(result.data).toBe(persistedPath);
       expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(true);
       expect(fs.existsSync(path.join(persistedPath, 'node_modules'))).toBe(false);
+
+      await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
+    });
+
+    it('does not remove a stale persisted directory inside the current pool when it contains user files', async () => {
+      const branchName = 'task/resume-stale-pool-with-changes';
+      await git(['branch', branchName], { cwd: repoDir });
+      const persistedPath = path.join(poolDir, 'task', 'resume-stale-pool-with-changes');
+      const userFile = path.join(persistedPath, 'notes.txt');
+      fs.mkdirSync(persistedPath, { recursive: true });
+      fs.writeFileSync(userFile, 'do not delete');
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected failure');
+      expect(result.error.type).toBe('worktree-setup-failed');
+      expect(fs.readFileSync(userFile, 'utf8')).toBe('do not delete');
+      expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(false);
+
+      fs.rmSync(persistedPath, { recursive: true, force: true });
+    });
+
+    it('keeps uncommitted changes in a valid persisted worktree', async () => {
+      const branchName = 'task/resume-valid-with-changes';
+      await git(['branch', branchName], { cwd: repoDir });
+      const persistedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-persisted-'));
+      const persistedPath = path.join(persistedRoot, 'task', 'resume-valid-with-changes');
+      await git(['worktree', 'add', persistedPath, branchName], { cwd: repoDir });
+      const changedFile = path.join(persistedPath, 'notes.txt');
+      fs.writeFileSync(changedFile, 'keep me');
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data).toBe(persistedPath);
+      expect(fs.readFileSync(changedFile, 'utf8')).toBe('keep me');
 
       await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
       fs.rmSync(persistedRoot, { recursive: true, force: true });

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -341,6 +341,26 @@ describe('WorktreeService', () => {
       await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
     });
 
+    it('repairs a stale persisted pool directory that only contains git-generated entries', async () => {
+      const branchName = 'task/resume-stale-git-file';
+      await git(['branch', branchName], { cwd: repoDir });
+      const persistedPath = path.join(poolDir, 'task', 'resume-stale-git-file');
+      fs.mkdirSync(persistedPath, { recursive: true });
+      fs.writeFileSync(path.join(persistedPath, '.git'), 'gitdir: stale');
+      fs.writeFileSync(path.join(persistedPath, '.gitignore'), 'node_modules\n');
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data).toBe(persistedPath);
+      expect(fs.readFileSync(path.join(persistedPath, '.git'), 'utf8')).toContain('gitdir:');
+      expect(fs.existsSync(path.join(persistedPath, '.gitignore'))).toBe(false);
+
+      await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
+    });
+
     it('does not remove a stale persisted directory inside the current pool when it contains user files', async () => {
       const branchName = 'task/resume-stale-pool-with-changes';
       await git(['branch', branchName], { cwd: repoDir });

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -299,6 +299,28 @@ describe('WorktreeService', () => {
       expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(true);
       expect(fs.existsSync(path.join(poolDir, 'task', 'resume-persisted'))).toBe(false);
 
+      await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
+      fs.rmSync(persistedRoot, { recursive: true, force: true });
+    });
+
+    it('repairs a stale persisted directory outside the current pool', async () => {
+      const branchName = 'task/resume-stale-persisted';
+      await git(['branch', branchName], { cwd: repoDir });
+      const persistedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-persisted-'));
+      const persistedPath = path.join(persistedRoot, 'task', 'resume-stale-persisted');
+      fs.mkdirSync(path.join(persistedPath, 'node_modules'), { recursive: true });
+      fs.writeFileSync(path.join(persistedPath, 'node_modules', 'stale.txt'), 'stale');
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data).toBe(persistedPath);
+      expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(true);
+      expect(fs.existsSync(path.join(persistedPath, 'node_modules'))).toBe(false);
+
+      await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
       fs.rmSync(persistedRoot, { recursive: true, force: true });
     });
 
@@ -320,6 +342,30 @@ describe('WorktreeService', () => {
       expect(fs.existsSync(path.join(persistedPath, '.git'))).toBe(true);
       expect(fs.existsSync(currentPoolResult.data)).toBe(false);
 
+      await git(['worktree', 'remove', '--force', persistedPath], { cwd: repoDir });
+      fs.rmSync(persistedRoot, { recursive: true, force: true });
+    });
+
+    it('does not move a branch from an unrelated external worktree to the persisted path', async () => {
+      const branchName = 'task/resume-external';
+      await git(['branch', branchName], { cwd: repoDir });
+      const externalRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-external-'));
+      const persistedRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'wt-persisted-'));
+      const externalPath = path.join(externalRoot, 'task', 'resume-external');
+      const persistedPath = path.join(persistedRoot, 'task', 'resume-external');
+      await git(['worktree', 'add', externalPath, branchName], { cwd: repoDir });
+      const svc = makeService();
+
+      const result = await svc.serveBranchWorktreeAtPath(branchName, undefined, persistedPath);
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected failure');
+      expect(result.error.type).toBe('worktree-setup-failed');
+      expect(fs.existsSync(path.join(externalPath, '.git'))).toBe(true);
+      expect(fs.existsSync(persistedPath)).toBe(false);
+
+      await git(['worktree', 'remove', '--force', externalPath], { cwd: repoDir });
+      fs.rmSync(externalRoot, { recursive: true, force: true });
       fs.rmSync(persistedRoot, { recursive: true, force: true });
     });
 

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -157,6 +157,19 @@ export class WorktreeService {
     return undefined;
   }
 
+  private async isInCurrentWorktreePool(candidatePath: string): Promise<boolean> {
+    try {
+      const realPoolPath = await this.host.realPathAbsolute(await this.resolveWorktreePoolPath());
+      return (
+        candidatePath === realPoolPath ||
+        candidatePath.startsWith(`${realPoolPath}/`) ||
+        candidatePath.startsWith(`${realPoolPath}\\`)
+      );
+    } catch {
+      return false;
+    }
+  }
+
   private async resolveSourceBaseRef(
     sourceBranch: GitBranchRef | undefined
   ): Promise<string | undefined> {
@@ -397,6 +410,15 @@ export class WorktreeService {
 
     const checkedOutPath = await this.findBranchAnywhere(branchName);
     if (!checkedOutPath) return ok({ kind: 'create' });
+
+    if (!(await this.isInCurrentWorktreePool(checkedOutPath))) {
+      return err({
+        type: 'worktree-setup-failed',
+        cause: new Error(
+          `Branch "${branchName}" is already checked out at "${checkedOutPath}", outside the stored workspace path`
+        ),
+      });
+    }
 
     try {
       await this.host.mkdirAbsolute(this.host.pathApi.dirname(targetPath), { recursive: true });

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -117,6 +117,18 @@ export class WorktreeService {
     }
   }
 
+  private async assertStaleTargetSafeForReuse(targetPath: string): Promise<void> {
+    const allowedGeneratedDirectories = new Set(['node_modules']);
+    const entries = await this.host.globAbsolute('*', { cwd: targetPath, dot: true });
+    for (const entry of entries) {
+      const stat = await this.host.statAbsolute(this.host.pathApi.join(targetPath, entry));
+      if (stat?.type === 'dir' && allowedGeneratedDirectories.has(entry)) continue;
+      throw new Error(
+        `Refusing to remove stale worktree directory "${targetPath}" because it contains "${entry}"`
+      );
+    }
+  }
+
   private async getRemoteCandidates(): Promise<string[]> {
     const baseRemote = (await this.projectSettings.getBaseRemote().catch(() => '')).trim();
     if (!baseRemote || baseRemote === DEFAULT_REMOTE_NAME) {
@@ -160,10 +172,11 @@ export class WorktreeService {
   private async isInCurrentWorktreePool(candidatePath: string): Promise<boolean> {
     try {
       const realPoolPath = await this.host.realPathAbsolute(await this.resolveWorktreePoolPath());
+      const realCandidatePath = await this.host.realPathAbsolute(candidatePath);
       return (
-        candidatePath === realPoolPath ||
-        candidatePath.startsWith(`${realPoolPath}/`) ||
-        candidatePath.startsWith(`${realPoolPath}\\`)
+        realCandidatePath === realPoolPath ||
+        realCandidatePath.startsWith(`${realPoolPath}/`) ||
+        realCandidatePath.startsWith(`${realPoolPath}\\`)
       );
     } catch {
       return false;
@@ -296,6 +309,7 @@ export class WorktreeService {
         return ok(targetPath);
       }
       try {
+        await this.assertStaleTargetSafeForReuse(targetPath);
         await this.removePathForReuse(targetPath);
         await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
       } catch (cause) {
@@ -384,6 +398,7 @@ export class WorktreeService {
     baseConfigValue?: string
   ): Promise<Result<{ kind: 'ready'; path: string } | { kind: 'create' }, ServeWorktreeError>> {
     await this.host.allowPath?.(targetPath);
+    const targetIsInCurrentPool = await this.isInCurrentWorktreePool(targetPath);
 
     if (await this.host.existsAbsolute(targetPath)) {
       if (await this.isValidBranchWorktree(targetPath, branchName)) {
@@ -400,7 +415,17 @@ export class WorktreeService {
         });
       }
 
+      if (!targetIsInCurrentPool) {
+        return err({
+          type: 'worktree-setup-failed',
+          cause: new Error(
+            `Stored worktree path "${targetPath}" exists but is not an Emdash-managed worktree path`
+          ),
+        });
+      }
+
       try {
+        await this.assertStaleTargetSafeForReuse(targetPath);
         await this.removePathForReuse(targetPath);
         await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
       } catch (cause) {
@@ -452,6 +477,7 @@ export class WorktreeService {
       if (await this.host.existsAbsolute(targetPath)) {
         if (await this.isValidWorktree(targetPath)) return ok(targetPath);
         try {
+          await this.assertStaleTargetSafeForReuse(targetPath);
           await this.removePathForReuse(targetPath);
           await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
         } catch (cause) {

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -74,6 +74,23 @@ export class WorktreeService {
     }
   }
 
+  private async isValidBranchWorktree(worktreePath: string, branchName: string): Promise<boolean> {
+    if (!(await this.isValidWorktree(worktreePath))) return false;
+
+    try {
+      const { stdout } = await this.ctx.exec('git', [
+        '-C',
+        worktreePath,
+        'rev-parse',
+        '--abbrev-ref',
+        'HEAD',
+      ]);
+      return stdout.trim() === branchName;
+    } catch {
+      return false;
+    }
+  }
+
   /** Returns the resolved path to the worktree pool directory. */
   getWorktreePoolPath(): Promise<string> {
     return this.resolveWorktreePoolPath();
@@ -237,16 +254,29 @@ export class WorktreeService {
   private async doCheckoutBranchWorktree(
     sourceBranch: GitBranchRef | undefined,
     branchName: string,
-    options: { copyPreservedFiles?: boolean }
+    options: { copyPreservedFiles?: boolean; targetPath?: string }
   ): Promise<Result<string, ServeWorktreeError>> {
     const baseConfigValue = this.getBranchBaseConfigValue(sourceBranch);
-    const checkedOutPath = await this.findBranchAnywhere(branchName);
-    if (checkedOutPath) {
-      await this.ensureBranchBaseConfig(branchName, baseConfigValue);
-      return ok(checkedOutPath);
+    const targetPath =
+      options.targetPath ??
+      this.host.pathApi.join(await this.resolveWorktreePoolPath(), branchName);
+
+    if (options.targetPath) {
+      const prepared = await this.prepareExplicitWorktreeTarget(
+        branchName,
+        targetPath,
+        baseConfigValue
+      );
+      if (!prepared.success) return prepared;
+      if (prepared.data.kind === 'ready') return ok(prepared.data.path);
+    } else {
+      const checkedOutPath = await this.findBranchAnywhere(branchName);
+      if (checkedOutPath) {
+        await this.ensureBranchBaseConfig(branchName, baseConfigValue);
+        return ok(checkedOutPath);
+      }
     }
 
-    const targetPath = this.host.pathApi.join(await this.resolveWorktreePoolPath(), branchName);
     if (await this.host.existsAbsolute(targetPath)) {
       if (await this.isValidWorktree(targetPath)) {
         await this.ensureBranchBaseConfig(branchName, baseConfigValue);
@@ -318,25 +348,93 @@ export class WorktreeService {
     return this.checkoutBranchWorktree(sourceBranch, branchName, { copyPreservedFiles });
   }
 
-  private async doCheckoutExistingBranch(
+  async serveBranchWorktreeAtPath(
     branchName: string,
-    options: { copyPreservedFiles?: boolean }
+    sourceBranch: GitBranchRef | undefined,
+    targetPath: string,
+    copyPreservedFiles?: boolean
   ): Promise<Result<string, ServeWorktreeError>> {
-    const checkedOutPath = await this.findBranchAnywhere(branchName);
-    if (checkedOutPath) {
-      return ok(checkedOutPath);
-    }
+    return this.enqueueGitOp(() => {
+      if (!sourceBranch || branchName === sourceBranch.branch) {
+        return this.doCheckoutExistingBranch(branchName, { copyPreservedFiles, targetPath });
+      }
+      return this.doCheckoutBranchWorktree(sourceBranch, branchName, {
+        copyPreservedFiles,
+        targetPath,
+      });
+    });
+  }
 
-    const targetPath = this.host.pathApi.join(await this.resolveWorktreePoolPath(), branchName);
-    const remoteCandidates = await this.getRemoteCandidates();
+  private async prepareExplicitWorktreeTarget(
+    branchName: string,
+    targetPath: string,
+    baseConfigValue?: string
+  ): Promise<Result<{ kind: 'ready'; path: string } | { kind: 'create' }, ServeWorktreeError>> {
+    await this.host.allowPath?.(targetPath);
 
     if (await this.host.existsAbsolute(targetPath)) {
-      if (await this.isValidWorktree(targetPath)) return ok(targetPath);
+      if (await this.isValidBranchWorktree(targetPath, branchName)) {
+        await this.ensureBranchBaseConfig(branchName, baseConfigValue);
+        return ok({ kind: 'ready', path: targetPath });
+      }
+
+      if (await this.isValidWorktree(targetPath)) {
+        return err({
+          type: 'worktree-setup-failed',
+          cause: new Error(
+            `Stored worktree path "${targetPath}" is already a valid worktree for another branch`
+          ),
+        });
+      }
+
       try {
         await this.removePathForReuse(targetPath);
         await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
       } catch (cause) {
         return err({ type: 'worktree-setup-failed', cause });
+      }
+    }
+
+    const checkedOutPath = await this.findBranchAnywhere(branchName);
+    if (!checkedOutPath) return ok({ kind: 'create' });
+
+    try {
+      await this.host.mkdirAbsolute(this.host.pathApi.dirname(targetPath), { recursive: true });
+      await this.ctx.exec('git', ['worktree', 'move', checkedOutPath, targetPath]);
+      await this.ensureBranchBaseConfig(branchName, baseConfigValue);
+      return ok({ kind: 'ready', path: targetPath });
+    } catch (cause) {
+      return err({ type: 'worktree-setup-failed', cause });
+    }
+  }
+
+  private async doCheckoutExistingBranch(
+    branchName: string,
+    options: { copyPreservedFiles?: boolean; targetPath?: string }
+  ): Promise<Result<string, ServeWorktreeError>> {
+    const targetPath =
+      options.targetPath ??
+      this.host.pathApi.join(await this.resolveWorktreePoolPath(), branchName);
+    const remoteCandidates = await this.getRemoteCandidates();
+
+    if (options.targetPath) {
+      const prepared = await this.prepareExplicitWorktreeTarget(branchName, targetPath);
+      if (!prepared.success) return prepared;
+      if (prepared.data.kind === 'ready') return ok(prepared.data.path);
+    } else {
+      const checkedOutPath = await this.findBranchAnywhere(branchName);
+      if (checkedOutPath) {
+        return ok(checkedOutPath);
+      }
+
+      if (await this.host.existsAbsolute(targetPath)) {
+        if (await this.isValidWorktree(targetPath)) return ok(targetPath);
+        try {
+          await this.removePathForReuse(targetPath);
+          await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
+        } catch (cause) {
+          return err({ type: 'worktree-setup-failed', cause });
+        }
       }
     }
 
@@ -463,4 +561,5 @@ export type WorktreeBootstrapOps = Pick<
   | 'checkoutExistingBranch'
   | 'checkoutBranchWorktree'
   | 'serveBranchWorktree'
+  | 'serveBranchWorktreeAtPath'
 >;

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -383,6 +383,7 @@ export class WorktreeService {
     targetPath: string,
     copyPreservedFiles?: boolean
   ): Promise<Result<string, ServeWorktreeError>> {
+    await this.ensureWorktreePoolDirExists();
     return this.enqueueGitOp(() => {
       if (!sourceBranch || branchName === sourceBranch.branch) {
         return this.doCheckoutExistingBranch(branchName, { copyPreservedFiles, targetPath });

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -119,10 +119,12 @@ export class WorktreeService {
 
   private async assertStaleTargetSafeForReuse(targetPath: string): Promise<void> {
     const allowedGeneratedDirectories = new Set(['node_modules']);
+    const allowedGeneratedFiles = new Set(['.git', '.gitignore']);
     const entries = await this.host.globAbsolute('*', { cwd: targetPath, dot: true });
     for (const entry of entries) {
       const stat = await this.host.statAbsolute(this.host.pathApi.join(targetPath, entry));
       if (stat?.type === 'dir' && allowedGeneratedDirectories.has(entry)) continue;
+      if (stat?.type === 'file' && allowedGeneratedFiles.has(entry)) continue;
       throw new Error(
         `Refusing to remove stale worktree directory "${targetPath}" because it contains "${entry}"`
       );

--- a/apps/emdash-desktop/src/main/core/settings/settings-normalizers.test.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-normalizers.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import type { LocalProjectSettings } from '@shared/core/app-settings';
+import { normalizeSettingValueForStorage } from './settings-normalizers';
+
+const invalidLocalProjectSettings: LocalProjectSettings = {
+  defaultProjectsDirectory: '/tmp/emdash/repositories',
+  defaultWorktreeDirectory: 'relative-worktrees',
+  writeAgentConfigToGitIgnore: true,
+};
+
+describe('settings normalizers', () => {
+  it('does not revalidate unchanged localProject defaultWorktreeDirectory when saving another field', async () => {
+    const next = {
+      ...invalidLocalProjectSettings,
+      writeAgentConfigToGitIgnore: false,
+    };
+
+    await expect(
+      normalizeSettingValueForStorage('localProject', next, invalidLocalProjectSettings)
+    ).resolves.toEqual(next);
+  });
+
+  it('rejects invalid changed localProject defaultWorktreeDirectory values', async () => {
+    await expect(
+      normalizeSettingValueForStorage('localProject', invalidLocalProjectSettings, {
+        ...invalidLocalProjectSettings,
+        defaultWorktreeDirectory: '/tmp/emdash/worktrees',
+      })
+    ).rejects.toThrow('Invalid default worktree directory');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/settings/settings-normalizers.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-normalizers.ts
@@ -1,0 +1,98 @@
+import {
+  normalizeExistingLocalWorktreeDirectory,
+  resolveAndValidateLocalWorktreeDirectory,
+} from '@main/core/projects/settings/local-worktree-directory';
+import type { AppSettings, AppSettingsKey, LocalProjectSettings } from '@shared/core/app-settings';
+
+type SettingStorageNormalizer<K extends AppSettingsKey> = (
+  value: AppSettings[K],
+  previousValue: AppSettings[K] | undefined
+) => Promise<AppSettings[K]>;
+
+type SettingReadNormalizer<K extends AppSettingsKey> = (
+  value: AppSettings[K],
+  defaults: AppSettings[K]
+) => Promise<AppSettings[K]>;
+
+type SettingStorageNormalizers = {
+  [K in AppSettingsKey]?: SettingStorageNormalizer<K>;
+};
+
+type SettingReadNormalizers = {
+  [K in AppSettingsKey]?: SettingReadNormalizer<K>;
+};
+
+async function normalizeLocalProjectSettingsForStorage(
+  value: LocalProjectSettings,
+  previousValue: LocalProjectSettings | undefined
+) {
+  if (value.defaultWorktreeDirectory === previousValue?.defaultWorktreeDirectory) {
+    return value;
+  }
+
+  const defaultWorktreeDirectory = await resolveAndValidateLocalWorktreeDirectory(
+    value.defaultWorktreeDirectory
+  );
+  if (!defaultWorktreeDirectory.success || !defaultWorktreeDirectory.data) {
+    throw new Error('Invalid default worktree directory');
+  }
+
+  return {
+    ...value,
+    defaultWorktreeDirectory: defaultWorktreeDirectory.data,
+  };
+}
+
+async function normalizeLocalProjectSettingsForRead(
+  value: LocalProjectSettings,
+  defaults: LocalProjectSettings
+) {
+  const fallbackDefaultWorktreeDirectoryPromise = normalizeExistingLocalWorktreeDirectory(
+    defaults.defaultWorktreeDirectory
+  );
+  const defaultWorktreeDirectoryPromise =
+    value.defaultWorktreeDirectory === defaults.defaultWorktreeDirectory
+      ? fallbackDefaultWorktreeDirectoryPromise
+      : normalizeExistingLocalWorktreeDirectory(value.defaultWorktreeDirectory);
+  const [defaultWorktreeDirectory, fallbackDefaultWorktreeDirectory] = await Promise.all([
+    defaultWorktreeDirectoryPromise,
+    fallbackDefaultWorktreeDirectoryPromise,
+  ]);
+
+  const fallback = fallbackDefaultWorktreeDirectory.success
+    ? fallbackDefaultWorktreeDirectory.data
+    : defaults.defaultWorktreeDirectory;
+
+  return {
+    ...value,
+    defaultWorktreeDirectory: defaultWorktreeDirectory.success
+      ? defaultWorktreeDirectory.data
+      : fallback,
+  };
+}
+
+const storageNormalizers: SettingStorageNormalizers = {
+  localProject: normalizeLocalProjectSettingsForStorage,
+};
+
+const readNormalizers: SettingReadNormalizers = {
+  localProject: normalizeLocalProjectSettingsForRead,
+};
+
+export async function normalizeSettingValueForStorage<K extends AppSettingsKey>(
+  key: K,
+  value: AppSettings[K],
+  previousValue?: AppSettings[K]
+): Promise<AppSettings[K]> {
+  const normalizer = storageNormalizers[key];
+  return normalizer ? normalizer(value, previousValue) : value;
+}
+
+export async function normalizeSettingValueForRead<K extends AppSettingsKey>(
+  key: K,
+  value: AppSettings[K],
+  defaults: AppSettings[K]
+): Promise<AppSettings[K]> {
+  const normalizer = readNormalizers[key];
+  return normalizer ? normalizer(value, defaults) : value;
+}

--- a/apps/emdash-desktop/src/main/core/settings/settings-service.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-service.ts
@@ -5,6 +5,10 @@ import { db } from '@main/db/client';
 import { appSettings } from '@main/db/schema';
 import { AppSettingsKeys, type AppSettings, type AppSettingsKey } from '@shared/core/app-settings';
 import { APP_SETTINGS_SCHEMA_MAP } from './schema';
+import {
+  normalizeSettingValueForRead,
+  normalizeSettingValueForStorage,
+} from './settings-normalizers';
 import { getDefaultForKey } from './settings-registry';
 import { computeDelta, computeTrueOverrides, isPlainObject, mergeDeep } from './utils';
 
@@ -52,6 +56,7 @@ export class SettingsStore implements IInitializable {
       value = raw as AppSettings[K];
     }
 
+    value = await normalizeSettingValueForRead(key, value, defaults);
     this.cache[key] = value;
     return value;
   }
@@ -63,7 +68,8 @@ export class SettingsStore implements IInitializable {
     defaults: AppSettings[K];
     overrides: Partial<AppSettings[K]>;
   }> {
-    const defaults = getDefaultForKey(key);
+    const rawDefaults = getDefaultForKey(key);
+    const defaults = await normalizeSettingValueForRead(key, rawDefaults, rawDefaults);
     const raw = await this.readRaw(key);
 
     if (raw === null || raw === undefined) {
@@ -73,34 +79,52 @@ export class SettingsStore implements IInitializable {
     let value: AppSettings[K];
     let overrides: Partial<AppSettings[K]>;
 
-    if (isPlainObject(raw) && isPlainObject(defaults)) {
-      value = mergeDeep(defaults as Record<string, unknown>, raw) as AppSettings[K];
-      overrides = computeTrueOverrides(raw, defaults as Record<string, unknown>) as Partial<
-        AppSettings[K]
-      >;
+    if (isPlainObject(raw) && isPlainObject(rawDefaults)) {
+      value = mergeDeep(rawDefaults as Record<string, unknown>, raw) as AppSettings[K];
     } else {
       value = raw as AppSettings[K];
-      overrides = (isDeepEqual(raw, defaults) ? {} : raw) as Partial<AppSettings[K]>;
+    }
+
+    value = await normalizeSettingValueForRead(key, value, rawDefaults);
+
+    if (isPlainObject(value) && isPlainObject(defaults)) {
+      overrides = computeTrueOverrides(
+        value as Record<string, unknown>,
+        defaults as Record<string, unknown>
+      ) as Partial<AppSettings[K]>;
+    } else {
+      overrides = (isDeepEqual(value, defaults) ? {} : value) as Partial<AppSettings[K]>;
     }
 
     return { value, defaults, overrides };
   }
 
   async update<K extends AppSettingsKey>(key: K, value: AppSettings[K]): Promise<void> {
-    const validated = APP_SETTINGS_SCHEMA_MAP[key].parse(value) as AppSettings[K];
+    const parsed = APP_SETTINGS_SCHEMA_MAP[key].parse(value) as AppSettings[K];
     const defaults = getDefaultForKey(key);
+    const raw = await this.readRaw(key);
+    const previousValue =
+      isPlainObject(raw) && isPlainObject(defaults)
+        ? (mergeDeep(defaults as Record<string, unknown>, raw) as AppSettings[K])
+        : raw === null || raw === undefined
+          ? defaults
+          : (raw as AppSettings[K]);
+    const [validated, normalizedDefaults] = await Promise.all([
+      normalizeSettingValueForStorage(key, parsed, previousValue),
+      normalizeSettingValueForRead(key, defaults, defaults),
+    ]);
 
     if (isPlainObject(validated) && isPlainObject(defaults)) {
       const delta = computeDelta(
         validated as Record<string, unknown>,
-        defaults as Record<string, unknown>
+        normalizedDefaults as Record<string, unknown>
       );
       if (Object.keys(delta).length === 0) {
         await this.deleteRow(key);
       } else {
         await this.storeRaw(key, delta);
       }
-    } else if (isDeepEqual(validated, defaults)) {
+    } else if (isDeepEqual(validated, normalizedDefaults)) {
       await this.deleteRow(key);
     } else {
       await this.storeRaw(key, validated);

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -148,8 +148,8 @@ describe('WorkspaceBootstrapService', () => {
   });
 
   describe('ensureWorkspaceSetup', () => {
-    it('repairs persisted branch worktree paths before acquiring the workspace', async () => {
-      const serveBranchWorktree = vi.fn().mockResolvedValue(ok('/worktrees/task-branch'));
+    it('repairs persisted branch worktree paths at the stored path before acquiring', async () => {
+      const serveBranchWorktreeAtPath = vi.fn().mockResolvedValue(ok('/worktrees/stored-task'));
       const existsAbsolute = vi.fn().mockResolvedValue(true);
       const project = {
         projectId: 'proj-1',
@@ -167,7 +167,7 @@ describe('WorkspaceBootstrapService', () => {
           existsAbsolute,
         },
         worktreeService: {
-          serveBranchWorktree,
+          serveBranchWorktreeAtPath,
         },
       } as unknown as ProjectProvider;
 
@@ -176,7 +176,7 @@ describe('WorkspaceBootstrapService', () => {
           id: WS_ID,
           type: 'local',
           kind: 'worktree',
-          path: '/worktrees/broken-task-branch',
+          path: '/worktrees/stored-task',
           branchName: 'task/branch',
           config: {
             version: '2',
@@ -195,16 +195,20 @@ describe('WorkspaceBootstrapService', () => {
 
       expect(result.success).toBe(true);
       if (!result.success) throw new Error('expected success');
-      expect(result.data.path).toBe('/worktrees/task-branch');
-      expect(serveBranchWorktree).toHaveBeenCalledWith('task/branch', {
-        type: 'local',
-        branch: 'main',
-      });
-      expect(existsAbsolute).not.toHaveBeenCalledWith('/worktrees/broken-task-branch');
+      expect(result.data.path).toBe('/worktrees/stored-task');
+      expect(serveBranchWorktreeAtPath).toHaveBeenCalledWith(
+        'task/branch',
+        {
+          type: 'local',
+          branch: 'main',
+        },
+        '/worktrees/stored-task'
+      );
+      expect(existsAbsolute).not.toHaveBeenCalledWith('/worktrees/stored-task');
       expect(mocks.acquireWorkspace).toHaveBeenCalled();
 
       const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
-      expect(ws.path).toBe('/worktrees/task-branch');
+      expect(ws.path).toBe('/worktrees/stored-task');
       expect(ws.branchName).toBe('task/branch');
     });
   });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -105,9 +105,10 @@ export class WorkspaceBootstrapService {
     // path existence. Archive/delete can leave a partial directory behind; the
     // worktree service knows how to remove stale targets and recreate the checkout.
     if (workspaceRow.path && workspaceBranchName && isWorktreeWorkspace && !isByoi) {
-      const serveResult = await project.worktreeService.serveBranchWorktree(
+      const serveResult = await project.worktreeService.serveBranchWorktreeAtPath(
         workspaceBranchName,
-        workspaceSourceBranch
+        workspaceSourceBranch,
+        workspaceRow.path
       );
       if (!serveResult.success) {
         const provisionError = mapWorktreeErrorToProvisionError(

--- a/apps/emdash-desktop/src/renderer/features/settings/components/RepositorySettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/RepositorySettingsCard.tsx
@@ -1,5 +1,9 @@
+import { Folder } from 'lucide-react';
 import React from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+import { Button } from '@renderer/lib/ui/button';
 import { Input } from '@renderer/lib/ui/input';
 import { Switch } from '@renderer/lib/ui/switch';
 import { normalizeBranchPrefix } from '@shared/util/branch-prefix';
@@ -18,18 +22,66 @@ const RepositorySettingsCard: React.FC = () => {
   const {
     value: localProject,
     update: updateLocalProject,
+    updateAsync: updateLocalProjectAsync,
     isLoading: localProjectLoading,
     isSaving: localProjectSaving,
     isFieldOverridden: isLocalProjectFieldOverridden,
     resetField: resetLocalProjectField,
   } = useAppSettingsKey('localProject');
+  const [isBrowsingWorktreeDirectory, setIsBrowsingWorktreeDirectory] = React.useState(false);
+  const [defaultWorktreeDirectoryError, setDefaultWorktreeDirectoryError] = React.useState<
+    string | null
+  >(null);
 
   const branchPrefix = project?.branchPrefix ?? '';
   const appendRandomBranchSuffix = project?.appendRandomBranchSuffix ?? true;
   const pushOnCreate = project?.pushOnCreate ?? true;
+  const defaultWorktreeDirectory = localProject?.defaultWorktreeDirectory ?? '';
   const writeAgentConfigToGitIgnore = localProject?.writeAgentConfigToGitIgnore ?? true;
   const projectBusy = projectLoading || projectSaving;
   const localProjectBusy = localProjectLoading || localProjectSaving;
+  const defaultWorktreeDirectoryBusy = localProjectBusy || isBrowsingWorktreeDirectory;
+
+  const updateDefaultWorktreeDirectory = async (next: string) => {
+    const trimmed = next.trim();
+    if (!trimmed) {
+      setDefaultWorktreeDirectoryError('Enter an absolute directory path.');
+      return;
+    }
+    if (trimmed === defaultWorktreeDirectory) {
+      setDefaultWorktreeDirectoryError(null);
+      return;
+    }
+
+    try {
+      await updateLocalProjectAsync({ defaultWorktreeDirectory: trimmed });
+      setDefaultWorktreeDirectoryError(null);
+    } catch {
+      const message = 'Choose an absolute directory that Emdash can create and access.';
+      setDefaultWorktreeDirectoryError(message);
+      toast({
+        title: 'Could not update default worktree directory',
+        description: message,
+        variant: 'destructive',
+      });
+    }
+  };
+
+  const chooseDefaultWorktreeDirectory = async () => {
+    if (isBrowsingWorktreeDirectory) return;
+
+    setIsBrowsingWorktreeDirectory(true);
+    try {
+      const result = await rpc.app.openSelectDirectoryDialog({
+        title: 'Select default worktree directory',
+        message: 'Choose the default directory where new project worktrees should be created.',
+        defaultPath: defaultWorktreeDirectory,
+      });
+      if (result) await updateDefaultWorktreeDirectory(result);
+    } finally {
+      setIsBrowsingWorktreeDirectory(false);
+    }
+  };
 
   return (
     <div className="grid gap-8">
@@ -101,6 +153,53 @@ const RepositorySettingsCard: React.FC = () => {
           </>
         }
       />
+      <div className="grid min-w-0 gap-2">
+        <div className="grid gap-0.5">
+          <div className="text-sm break-words text-foreground">Default worktree directory</div>
+          <div className="text-xs break-words text-foreground-passive">
+            Used for new worktrees unless a project has its own worktree directory.
+          </div>
+        </div>
+        <div className="flex max-w-3xl min-w-0 items-center gap-2">
+          <Input
+            key={defaultWorktreeDirectory}
+            defaultValue={defaultWorktreeDirectory}
+            onBlur={(e) => {
+              void updateDefaultWorktreeDirectory(e.currentTarget.value);
+            }}
+            placeholder="Default worktree directory"
+            aria-label="Default worktree directory"
+            aria-invalid={defaultWorktreeDirectoryError ? true : undefined}
+            disabled={defaultWorktreeDirectoryBusy}
+            className="min-w-0 flex-1"
+          />
+          <Button
+            type="button"
+            variant="outline"
+            size="icon"
+            disabled={defaultWorktreeDirectoryBusy}
+            onClick={chooseDefaultWorktreeDirectory}
+            aria-label="Choose default worktree directory"
+            title="Choose default worktree directory"
+          >
+            <Folder className="size-4" />
+          </Button>
+          <ResetToDefaultButton
+            visible={isLocalProjectFieldOverridden('defaultWorktreeDirectory')}
+            defaultLabel="default"
+            onReset={() => {
+              setDefaultWorktreeDirectoryError(null);
+              resetLocalProjectField('defaultWorktreeDirectory');
+            }}
+            disabled={defaultWorktreeDirectoryBusy}
+          />
+        </div>
+        {defaultWorktreeDirectoryError ? (
+          <div className="max-w-3xl text-xs text-foreground-error">
+            {defaultWorktreeDirectoryError}
+          </div>
+        ) : null}
+      </div>
       <SettingRow
         title="Auto-update .gitignore"
         description="When Emdash writes CLI hook configs, also add their paths to .gitignore."


### PR DESCRIPTION
### Description
- add default worktree directory setting with picker ui 
- resume workspaces at their stored worktree path
- repair stale stored worktree directories when resuming
- block moving branches from unrelated external worktrees

### Screenshot/Recording (if applicable)
https://streamable.com/58h2ve

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
