### PR TITLE
fix(port-forwards): try IPv6 loopback when the IPv4 target refuses

### DIFF
--- a/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.test.ts
+++ b/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.test.ts
@@ -71,6 +71,40 @@ function makeRejectingProxy(error: Error) {
   };
 }
 
+function makeFamilyAwareProxy(reachableHost: string) {
+  const calls: Array<{ remoteHost: string; remotePort: number }> = [];
+
+  return {
+    calls,
+    proxy: {
+      get isConnected() {
+        return true;
+      },
+      get client() {
+        return {
+          forwardOut(
+            _sourceHost: string,
+            _sourcePort: number,
+            remoteHost: string,
+            remotePort: number,
+            callback: (error: Error | undefined, channel: ClientChannel) => void
+          ) {
+            calls.push({ remoteHost, remotePort });
+            if (remoteHost === reachableHost) {
+              callback(undefined, new EchoChannel() as unknown as ClientChannel);
+              return;
+            }
+            callback(
+              new Error('(SSH) Channel open failure: Connection refused'),
+              undefined as unknown as ClientChannel
+            );
+          },
+        } as SshClientProxy['client'];
+      },
+    } satisfies Pick<SshClientProxy, 'client' | 'isConnected'>,
+  };
+}
+
 function listen(server: net.Server): Promise<number> {
   return new Promise((resolve, reject) => {
     server.once('error', reject);
@@ -169,6 +203,25 @@ describe('openPortForwardTunnel', () => {
     try {
       expect(tunnel.localPort).not.toBe(busyPort);
       await expect(roundTrip(tunnel.localPort, 'ok')).resolves.toBe('remote:ok');
+    } finally {
+      await tunnel.close();
+    }
+  });
+
+  it('falls back to the IPv6 loopback when the IPv4 target refuses', async () => {
+    const { proxy, calls } = makeFamilyAwareProxy('::1');
+
+    const tunnel = await openPortForwardTunnel({
+      proxy,
+      remotePort: 5173,
+    });
+
+    try {
+      await expect(roundTrip(tunnel.localPort, 'ping')).resolves.toBe('remote:ping');
+      expect(calls).toEqual([
+        { remoteHost: '127.0.0.1', remotePort: 5173 },
+        { remoteHost: '::1', remotePort: 5173 },
+      ]);
     } finally {
       await tunnel.close();
     }

--- a/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.test.ts
+++ b/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.test.ts
@@ -16,6 +16,14 @@ class EchoChannel extends Transform {
   }
 }
 
+// ssh2 attaches the RFC 4254 channel-open failure reason code to forwardOut
+// errors. 2 is SSH_OPEN_CONNECT_FAILED (the destination could not be reached).
+function channelOpenError(message: string, reason: number): Error {
+  const error = new Error(message);
+  (error as { reason?: number }).reason = reason;
+  return error;
+}
+
 function makeProxy() {
   const calls: Array<{
     sourceHost: string;
@@ -95,7 +103,37 @@ function makeFamilyAwareProxy(reachableHost: string) {
               return;
             }
             callback(
-              new Error('(SSH) Channel open failure: Connection refused'),
+              channelOpenError('(SSH) Channel open failure: Connection refused', 2),
+              undefined as unknown as ClientChannel
+            );
+          },
+        } as SshClientProxy['client'];
+      },
+    } satisfies Pick<SshClientProxy, 'client' | 'isConnected'>,
+  };
+}
+
+function makePerHostFailingProxy(errors: Record<string, Error>) {
+  const calls: Array<{ remoteHost: string; remotePort: number }> = [];
+
+  return {
+    calls,
+    proxy: {
+      get isConnected() {
+        return true;
+      },
+      get client() {
+        return {
+          forwardOut(
+            _sourceHost: string,
+            _sourcePort: number,
+            remoteHost: string,
+            remotePort: number,
+            callback: (error: Error | undefined, channel: ClientChannel) => void
+          ) {
+            calls.push({ remoteHost, remotePort });
+            callback(
+              errors[remoteHost] ?? channelOpenError('(SSH) Channel open failure: unexpected', 2),
               undefined as unknown as ClientChannel
             );
           },
@@ -227,8 +265,60 @@ describe('openPortForwardTunnel', () => {
     }
   });
 
+  it('does not fall back to the other family when the remote rejects for a non-connect reason', async () => {
+    // Administratively prohibited (reason 1) is not a connect failure, so
+    // retrying the other loopback family is pointless and would mask the cause.
+    const { proxy, calls } = makePerHostFailingProxy({
+      '127.0.0.1': channelOpenError('(SSH) Channel open failure: administratively prohibited', 1),
+    });
+    const connectionErrors: string[] = [];
+
+    const tunnel = await openPortForwardTunnel({
+      proxy,
+      remotePort: 5173,
+      onConnectionError: (error) => connectionErrors.push(error.message),
+    });
+
+    try {
+      await connectUntilClosed(tunnel.localPort);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(calls).toEqual([{ remoteHost: '127.0.0.1', remotePort: 5173 }]);
+      expect(connectionErrors).toEqual(['(SSH) Channel open failure: administratively prohibited']);
+    } finally {
+      await tunnel.close();
+    }
+  });
+
+  it('surfaces the first error when every loopback family fails to connect', async () => {
+    const { proxy, calls } = makePerHostFailingProxy({
+      '127.0.0.1': channelOpenError('(SSH) Channel open failure: Connection refused [ipv4]', 2),
+      '::1': channelOpenError('(SSH) Channel open failure: Connection refused [ipv6]', 2),
+    });
+    const connectionErrors: string[] = [];
+
+    const tunnel = await openPortForwardTunnel({
+      proxy,
+      remotePort: 5173,
+      onConnectionError: (error) => connectionErrors.push(error.message),
+    });
+
+    try {
+      await connectUntilClosed(tunnel.localPort);
+      await new Promise((resolve) => setImmediate(resolve));
+
+      expect(calls).toEqual([
+        { remoteHost: '127.0.0.1', remotePort: 5173 },
+        { remoteHost: '::1', remotePort: 5173 },
+      ]);
+      expect(connectionErrors).toEqual(['(SSH) Channel open failure: Connection refused [ipv4]']);
+    } finally {
+      await tunnel.close();
+    }
+  });
+
   it('closes local sockets without an uncaught exception when the remote port refuses connections', async () => {
-    const error = new Error('(SSH) Channel open failure: Connection refused');
+    const error = channelOpenError('(SSH) Channel open failure: Connection refused', 2);
     const { proxy } = makeRejectingProxy(error);
     const connectionErrors: string[] = [];
     const uncaughtErrors: string[] = [];

--- a/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.ts
+++ b/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.ts
@@ -3,7 +3,12 @@ import type { ClientChannel } from 'ssh2';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 
 const LOCAL_BIND_HOST = '127.0.0.1';
-const REMOTE_TARGET_HOST = '127.0.0.1';
+// A dev server may bind to the IPv4 loopback, the IPv6 loopback, or both. A
+// process started on the default `localhost` host resolves to `::1` first on
+// Node >= 17, so it often listens only on `[::1]`. Dialing a single hardcoded
+// `127.0.0.1` misses it. Try both loopback families per connection, in order,
+// and forward through whichever one the remote accepts.
+const REMOTE_TARGET_HOSTS = ['127.0.0.1', '::1'] as const;
 
 export type PortForwardTunnel = {
   localPort: number;
@@ -85,26 +90,38 @@ function forwardSocket(socket: net.Socket, options: OpenPortForwardTunnelOptions
     return;
   }
 
-  client.forwardOut(
-    LOCAL_BIND_HOST,
-    0,
-    REMOTE_TARGET_HOST,
-    options.remotePort,
-    (error: Error | undefined, channel: ClientChannel) => {
-      if (error) {
-        options.onConnectionError?.(error);
-        socket.destroy();
-        return;
-      }
+  const tryTargetHost = (index: number): void => {
+    const remoteHost = REMOTE_TARGET_HOSTS[index];
+    client.forwardOut(
+      LOCAL_BIND_HOST,
+      0,
+      remoteHost,
+      options.remotePort,
+      (error: Error | undefined, channel: ClientChannel) => {
+        if (error) {
+          // The remote refused this loopback family (e.g. an IPv6-only dev
+          // server rejects the IPv4 target). Fall back to the next candidate
+          // before surfacing the failure.
+          if (index + 1 < REMOTE_TARGET_HOSTS.length) {
+            tryTargetHost(index + 1);
+            return;
+          }
+          options.onConnectionError?.(error);
+          socket.destroy();
+          return;
+        }
 
-      socket.on('error', () => channel.destroy());
-      channel.on('error', (error: Error) => {
-        options.onConnectionError?.(error);
-        socket.destroy();
-      });
-      socket.pipe(channel).pipe(socket);
-    }
-  );
+        socket.on('error', () => channel.destroy());
+        channel.on('error', (error: Error) => {
+          options.onConnectionError?.(error);
+          socket.destroy();
+        });
+        socket.pipe(channel).pipe(socket);
+      }
+    );
+  };
+
+  tryTargetHost(0);
 }
 
 function closeServer(server: net.Server): Promise<void> {

--- a/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.ts
+++ b/apps/emdash-desktop/src/main/core/port-forwards/port-forward-tunnel.ts
@@ -9,6 +9,17 @@ const LOCAL_BIND_HOST = '127.0.0.1';
 // `127.0.0.1` misses it. Try both loopback families per connection, in order,
 // and forward through whichever one the remote accepts.
 const REMOTE_TARGET_HOSTS = ['127.0.0.1', '::1'] as const;
+// ssh2 attaches the SSH channel-open failure reason code (RFC 4254) to the
+// error surfaced from `forwardOut`. `SSH_OPEN_CONNECT_FAILED` means the remote
+// could not connect to the requested destination (e.g. that loopback family is
+// not listening), which is the only case worth retrying on the other family.
+// Other reasons (administratively prohibited, resource shortage, a dropped
+// session) would not be fixed by a retry.
+const SSH_OPEN_CONNECT_FAILED = 2;
+
+function isConnectFailure(error: Error): boolean {
+  return (error as { reason?: number }).reason === SSH_OPEN_CONNECT_FAILED;
+}
 
 export type PortForwardTunnel = {
   localPort: number;
@@ -90,6 +101,8 @@ function forwardSocket(socket: net.Socket, options: OpenPortForwardTunnelOptions
     return;
   }
 
+  let firstError: Error | undefined;
+
   const tryTargetHost = (index: number): void => {
     const remoteHost = REMOTE_TARGET_HOSTS[index];
     client.forwardOut(
@@ -99,21 +112,25 @@ function forwardSocket(socket: net.Socket, options: OpenPortForwardTunnelOptions
       options.remotePort,
       (error: Error | undefined, channel: ClientChannel) => {
         if (error) {
-          // The remote refused this loopback family (e.g. an IPv6-only dev
-          // server rejects the IPv4 target). Fall back to the next candidate
-          // before surfacing the failure.
-          if (index + 1 < REMOTE_TARGET_HOSTS.length) {
+          firstError = firstError ?? error;
+          // Only fall back to the next loopback family when the remote could
+          // not connect to this one (e.g. an IPv6-only dev server refuses the
+          // IPv4 target). Any other failure would not be fixed by a retry, so
+          // surface it instead of masking it behind a second dial.
+          if (index + 1 < REMOTE_TARGET_HOSTS.length && isConnectFailure(error)) {
             tryTargetHost(index + 1);
             return;
           }
-          options.onConnectionError?.(error);
+          // Report the first failure so the primary target's cause is preserved
+          // when every candidate fails.
+          options.onConnectionError?.(firstError);
           socket.destroy();
           return;
         }
 
         socket.on('error', () => channel.destroy());
-        channel.on('error', (error: Error) => {
-          options.onConnectionError?.(error);
+        channel.on('error', (channelError: Error) => {
+          options.onConnectionError?.(channelError);
           socket.destroy();
         });
         socket.pipe(channel).pipe(socket);


### PR DESCRIPTION
### Description

The SSH port-forward tunnel dialed a hardcoded `127.0.0.1` on the remote (`REMOTE_TARGET_HOST` in `port-forward-tunnel.ts`). A dev server started on the default `localhost` host resolves to IPv6 `::1` first on Node >= 17, so it commonly binds only to `[::1]`. The forward then connects to `127.0.0.1`, where nothing is listening, and the preview never loads, even though the URL is detected correctly.

This change makes the remote target dual-stack: per connection, try `127.0.0.1` first and fall back to `::1` if the remote refuses, forwarding through whichever loopback family the server actually listens on. IPv4-only servers keep working exactly as before (first attempt succeeds); `localhost`/IPv6-only servers now work without forcing `--host`.

The fallback is per connection and order-preserving, so there is no stale cached target and no behavior change for servers reachable on `127.0.0.1`.

### Related issues

Fixes #2589

### Testing

From the repo root with the pinned toolchain (Node 24.14.0, pnpm 10.28.2):

- `pnpm run format:check` - pass
- `pnpm run lint` - pass
- `pnpm run typecheck` - pass (after `pnpm run build` to emit workspace package types)
- `pnpm --filter ./apps/emdash-desktop run test` - pass (269 files, 1937 tests), including a new `port-forward-tunnel` test that asserts the IPv4 target is tried first and the connection falls back to `::1` when IPv4 refuses

Note: `pnpm run test` also has an unrelated pre-existing failure in `packages/core` (`git-repository` default-branch test) on machines where git's `init.defaultBranch` is not set to `main`; it is independent of this change.

### Screenshot/Recording (if applicable)

N/A (main-process networking change).
