### PR TITLE
fix(pty): reap setsid()-detached descendants on kill

### DIFF
--- a/apps/emdash-desktop/src/main/core/pty/local-pty.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/local-pty.test.ts
@@ -1,9 +1,19 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocalPtySession } from './local-pty';
+import { collectLocalDescendantPidsAsync } from './process-tree';
 
 vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
+
+vi.mock('./process-tree', () => ({
+  collectLocalDescendantPidsAsync: vi.fn(() => Promise.resolve([])),
+}));
+
+/** Let the async descendant snapshot (a resolved promise + its .then) settle. */
+async function flushSnapshot(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
 
 describe('LocalPtySession', () => {
   type MockPtyProcess = ConstructorParameters<typeof LocalPtySession>[1];
@@ -19,8 +29,20 @@ describe('LocalPtySession', () => {
     });
   }
 
+  /** Register an onExit handler and return a trigger for the captured callback. */
+  function captureExit(): () => void {
+    let exitHandler: ((info: { exitCode: number; signal: number }) => void) | undefined;
+    vi.mocked(mockProc.onExit).mockImplementation((handler) => {
+      exitHandler = handler;
+      return { dispose: vi.fn() };
+    });
+    pty.onExit(() => {});
+    return () => exitHandler?.({ exitCode: 0, signal: 0 });
+  }
+
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([]);
     vi.useFakeTimers();
 
     mockProc = {
@@ -44,37 +66,34 @@ describe('LocalPtySession', () => {
     }
   });
 
-  it('kill() sends SIGTERM to process group on POSIX', () => {
+  it('kill() sends SIGTERM to the process group on POSIX', async () => {
     setPlatform('linux');
 
     pty.kill();
+    await flushSnapshot();
 
     expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGTERM');
     expect(mockProc.kill).toHaveBeenCalled();
   });
 
-  it('kill() follows up with SIGKILL after 2 seconds if not exited', () => {
+  it('kill() escalates the group to SIGKILL after 2 seconds if not exited', async () => {
     setPlatform('linux');
 
     pty.kill();
+    await flushSnapshot();
     expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
 
     vi.advanceTimersByTime(2000);
     expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGKILL');
   });
 
-  it('kill() does not send SIGKILL if process exits before timeout', () => {
+  it('kill() does not send the group SIGKILL if the shell exits before the timeout', async () => {
     setPlatform('linux');
+    const triggerExit = captureExit();
 
-    let exitHandler: ((info: { exitCode: number; signal: number }) => void) | undefined;
-    vi.mocked(mockProc.onExit).mockImplementation((handler) => {
-      exitHandler = handler;
-      return { dispose: vi.fn() };
-    });
-
-    pty.onExit(() => {});
     pty.kill();
-    exitHandler?.({ exitCode: 0, signal: 0 });
+    await flushSnapshot();
+    triggerExit();
 
     vi.advanceTimersByTime(2000);
     expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
@@ -85,17 +104,72 @@ describe('LocalPtySession', () => {
 
     pty.kill();
 
+    expect(collectLocalDescendantPidsAsync).not.toHaveBeenCalled();
     expect(process.kill).not.toHaveBeenCalledWith(-1234, expect.any(String));
     expect(mockProc.kill).toHaveBeenCalled();
   });
 
-  it('kill() is idempotent', () => {
+  it('kill() is idempotent', async () => {
     setPlatform('linux');
 
     pty.kill();
     pty.kill();
+    await flushSnapshot();
 
-    expect(process.kill).toHaveBeenCalledTimes(1);
+    expect(collectLocalDescendantPidsAsync).toHaveBeenCalledTimes(1);
     expect(mockProc.kill).toHaveBeenCalledTimes(1);
+  });
+
+  it('kill() SIGTERMs setsid()-detached descendants individually', async () => {
+    setPlatform('linux');
+    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678, 9012]);
+
+    pty.kill();
+    await flushSnapshot();
+
+    expect(collectLocalDescendantPidsAsync).toHaveBeenCalledWith(1234);
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGTERM');
+    expect(process.kill).toHaveBeenCalledWith(9012, 'SIGTERM');
+  });
+
+  it('kill() escalates surviving descendants to SIGKILL after 2 seconds', async () => {
+    setPlatform('linux');
+    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678]);
+
+    pty.kill();
+    await flushSnapshot();
+    expect(process.kill).not.toHaveBeenCalledWith(5678, 'SIGKILL');
+
+    vi.advanceTimersByTime(2000);
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL');
+  });
+
+  it('kill() still SIGKILLs detached descendants even when the shell exits first', async () => {
+    setPlatform('linux');
+    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678]);
+    const triggerExit = captureExit();
+
+    pty.kill();
+    await flushSnapshot();
+    // The shell exits right after SIGTERM, while watchman/ts-checker daemons keep running.
+    triggerExit();
+
+    vi.advanceTimersByTime(2000);
+    // The dead group's SIGKILL is cancelled...
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+    // ...but the detached descendant is still force-killed — this is the bug the
+    // independent descendant timer fixes.
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL');
+  });
+
+  it('kill() snapshots descendants once and reuses the snapshot for both passes', async () => {
+    setPlatform('linux');
+    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678]);
+
+    pty.kill();
+    await flushSnapshot();
+    vi.advanceTimersByTime(2000);
+
+    expect(collectLocalDescendantPidsAsync).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/local-pty.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/local-pty.test.ts
@@ -1,25 +1,17 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocalPtySession } from './local-pty';
-import { collectLocalDescendantPidsAsync } from './process-tree';
+import type { PosixPtyTerminator } from './posix-pty-terminator';
 
 vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
-
-vi.mock('./process-tree', () => ({
-  collectLocalDescendantPidsAsync: vi.fn(() => Promise.resolve([])),
-}));
-
-/** Let the async descendant snapshot (a resolved promise + its .then) settle. */
-async function flushSnapshot(): Promise<void> {
-  for (let i = 0; i < 5; i++) await Promise.resolve();
-}
 
 describe('LocalPtySession', () => {
   type MockPtyProcess = ConstructorParameters<typeof LocalPtySession>[1];
 
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
   let mockProc: MockPtyProcess;
+  let posixTerminator: Pick<PosixPtyTerminator, 'kill' | 'markExited'>;
   let pty: LocalPtySession;
 
   function setPlatform(platform: NodeJS.Platform): void {
@@ -29,147 +21,91 @@ describe('LocalPtySession', () => {
     });
   }
 
-  /** Register an onExit handler and return a trigger for the captured callback. */
-  function captureExit(): () => void {
-    let exitHandler: ((info: { exitCode: number; signal: number }) => void) | undefined;
-    vi.mocked(mockProc.onExit).mockImplementation((handler) => {
-      exitHandler = handler;
-      return { dispose: vi.fn() };
-    });
-    pty.onExit(() => {});
-    return () => exitHandler?.({ exitCode: 0, signal: 0 });
-  }
-
-  beforeEach(() => {
-    vi.clearAllMocks();
-    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([]);
-    vi.useFakeTimers();
-
+  function createPty(pid = 1234): void {
     mockProc = {
-      pid: 1234,
+      pid,
       write: vi.fn(),
       resize: vi.fn(),
       kill: vi.fn(),
       onData: vi.fn(),
       onExit: vi.fn(),
     } as unknown as MockPtyProcess;
-    pty = new LocalPtySession('test-id', mockProc);
+    posixTerminator = {
+      kill: vi.fn(),
+      markExited: vi.fn(),
+    };
+    pty = new LocalPtySession('test-id', mockProc, posixTerminator);
+  }
 
-    vi.spyOn(process, 'kill').mockImplementation(() => true);
+  beforeEach(() => {
+    vi.clearAllMocks();
+    createPty();
   });
 
   afterEach(() => {
-    vi.useRealTimers();
     vi.restoreAllMocks();
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform);
     }
   });
 
-  it('kill() sends SIGTERM to the process group on POSIX', async () => {
+  it('kill() delegates POSIX process-tree termination', () => {
     setPlatform('linux');
 
     pty.kill();
-    await flushSnapshot();
 
-    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGTERM');
-    expect(mockProc.kill).toHaveBeenCalled();
+    expect(posixTerminator.kill).toHaveBeenCalledTimes(1);
+    const [pid, killPty] = vi.mocked(posixTerminator.kill).mock.calls[0]!;
+    expect(pid).toBe(1234);
+    expect(mockProc.kill).not.toHaveBeenCalled();
+
+    killPty();
+    expect(mockProc.kill).toHaveBeenCalledTimes(1);
   });
 
-  it('kill() escalates the group to SIGKILL after 2 seconds if not exited', async () => {
-    setPlatform('linux');
-
-    pty.kill();
-    await flushSnapshot();
-    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
-
-    vi.advanceTimersByTime(2000);
-    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGKILL');
-  });
-
-  it('kill() does not send the group SIGKILL if the shell exits before the timeout', async () => {
-    setPlatform('linux');
-    const triggerExit = captureExit();
-
-    pty.kill();
-    await flushSnapshot();
-    triggerExit();
-
-    vi.advanceTimersByTime(2000);
-    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
-  });
-
-  it('kill() does not use process groups on Windows', () => {
+  it('kill() does not use POSIX termination on Windows', () => {
     setPlatform('win32');
 
     pty.kill();
 
-    expect(collectLocalDescendantPidsAsync).not.toHaveBeenCalled();
-    expect(process.kill).not.toHaveBeenCalledWith(-1234, expect.any(String));
-    expect(mockProc.kill).toHaveBeenCalled();
-  });
-
-  it('kill() is idempotent', async () => {
-    setPlatform('linux');
-
-    pty.kill();
-    pty.kill();
-    await flushSnapshot();
-
-    expect(collectLocalDescendantPidsAsync).toHaveBeenCalledTimes(1);
+    expect(posixTerminator.kill).not.toHaveBeenCalled();
     expect(mockProc.kill).toHaveBeenCalledTimes(1);
   });
 
-  it('kill() SIGTERMs setsid()-detached descendants individually', async () => {
+  it('kill() falls back to node-pty when pid is unavailable', () => {
     setPlatform('linux');
-    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678, 9012]);
+    createPty(0);
 
     pty.kill();
-    await flushSnapshot();
 
-    expect(collectLocalDescendantPidsAsync).toHaveBeenCalledWith(1234);
-    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGTERM');
-    expect(process.kill).toHaveBeenCalledWith(9012, 'SIGTERM');
+    expect(posixTerminator.kill).not.toHaveBeenCalled();
+    expect(mockProc.kill).toHaveBeenCalledTimes(1);
   });
 
-  it('kill() escalates surviving descendants to SIGKILL after 2 seconds', async () => {
+  it('kill() is idempotent', () => {
     setPlatform('linux');
-    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678]);
 
     pty.kill();
-    await flushSnapshot();
-    expect(process.kill).not.toHaveBeenCalledWith(5678, 'SIGKILL');
+    pty.kill();
 
-    vi.advanceTimersByTime(2000);
-    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL');
+    expect(posixTerminator.kill).toHaveBeenCalledTimes(1);
+    expect(mockProc.kill).not.toHaveBeenCalled();
   });
 
-  it('kill() still SIGKILLs detached descendants even when the shell exits first', async () => {
-    setPlatform('linux');
-    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678]);
-    const triggerExit = captureExit();
+  it('onExit() marks the POSIX terminator exited before forwarding exit info', () => {
+    let exitHandler: ((info: { exitCode: number; signal: number }) => void) | undefined;
+    vi.mocked(mockProc.onExit).mockImplementation((handler) => {
+      exitHandler = handler;
+      return { dispose: vi.fn() };
+    });
+    const handler = vi.fn();
 
-    pty.kill();
-    await flushSnapshot();
-    // The shell exits right after SIGTERM, while watchman/ts-checker daemons keep running.
-    triggerExit();
+    pty.onExit(handler);
+    exitHandler?.({ exitCode: 143, signal: 15 });
 
-    vi.advanceTimersByTime(2000);
-    // The dead group's SIGKILL is cancelled...
-    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
-    // ...but the detached descendant is still force-killed — this is the bug the
-    // independent descendant timer fixes.
-    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL');
-  });
-
-  it('kill() snapshots descendants once and reuses the snapshot for both passes', async () => {
-    setPlatform('linux');
-    vi.mocked(collectLocalDescendantPidsAsync).mockResolvedValue([5678]);
-
-    pty.kill();
-    await flushSnapshot();
-    vi.advanceTimersByTime(2000);
-
-    expect(collectLocalDescendantPidsAsync).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(posixTerminator.markExited).mock.invocationCallOrder[0]).toBeLessThan(
+      handler.mock.invocationCallOrder[0]!
+    );
+    expect(handler).toHaveBeenCalledWith({ exitCode: 143, signal: 'SIGTERM' });
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/local-pty.ts
+++ b/apps/emdash-desktop/src/main/core/pty/local-pty.ts
@@ -3,6 +3,7 @@ import type { IPty } from 'node-pty';
 import { log } from '@main/lib/logger';
 import { normalizeSignal } from './exit-signals';
 import { suppressExpectedNodePtyErrors } from './node-pty-errors';
+import { collectLocalDescendantPidsAsync } from './process-tree';
 import type { Pty, PtyDimensions, PtyExitInfo } from './pty';
 
 export interface LocalSpawnOptions extends PtyDimensions {
@@ -15,6 +16,18 @@ export interface LocalSpawnOptions extends PtyDimensions {
 
 const MIN_COLS = 2;
 const MIN_ROWS = 1;
+
+/** Grace period between the SIGTERM and the SIGKILL escalation. */
+const KILL_GRACE_MS = 2000;
+
+/** SIGTERM/SIGKILL individual pids, ignoring any that are already gone. */
+function signalPids(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {}
+  }
+}
 
 export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
   const { id, command, args, cwd, env, cols, rows } = options;
@@ -47,6 +60,7 @@ export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
 export class LocalPtySession implements Pty {
   readonly id: string;
   private killTimer: ReturnType<typeof setTimeout> | null = null;
+  private descendantKillTimer: ReturnType<typeof setTimeout> | null = null;
   private killed = false;
 
   constructor(
@@ -79,16 +93,50 @@ export class LocalPtySession implements Pty {
     this.killed = true;
 
     const pid = this.proc.pid;
-    if (process.platform !== 'win32' && Number.isInteger(pid) && pid > 0) {
+    if (process.platform === 'win32' || !Number.isInteger(pid) || pid <= 0) {
       try {
-        process.kill(-pid, 'SIGTERM');
+        this.proc.kill();
       } catch {}
-      this.killTimer = setTimeout(() => {
-        try {
-          process.kill(-pid, 'SIGKILL');
-        } catch {}
-        this.killTimer = null;
-      }, 2000);
+      return;
+    }
+
+    // Snapshot detached descendants BEFORE any signal. Children that called
+    // setsid() (the watchman daemon, ts-checker-rspack-plugin workers, sudo'd
+    // processes) form their own process group and escape a kill() aimed at the
+    // PTY's foreground group. The snapshot must precede the kill: once the shell
+    // dies the survivors are reparented to init and the parent links that
+    // identify them are gone. Async so spawning `ps` never blocks the Electron
+    // main-process event loop. See issue #2110.
+    void collectLocalDescendantPidsAsync(pid).then(
+      (descendants) => this.terminate(pid, descendants),
+      () => this.terminate(pid, [])
+    );
+  }
+
+  private terminate(pid: number, descendants: number[]): void {
+    // Foreground process group: SIGTERM now, SIGKILL after a grace period —
+    // unless the shell exits cleanly first (onExit clears killTimer), since the
+    // group dies with it and a late SIGKILL could hit a reused pid.
+    try {
+      process.kill(-pid, 'SIGTERM');
+    } catch {}
+    this.killTimer = setTimeout(() => {
+      try {
+        process.kill(-pid, 'SIGKILL');
+      } catch {}
+      this.killTimer = null;
+    }, KILL_GRACE_MS);
+
+    // Detached descendants outlive the shell, so their SIGKILL escalation must
+    // NOT be cancelled by onExit. Daemons like watchman ignore SIGTERM and only
+    // die on SIGKILL — without this independent pass they would survive the
+    // shell's quick exit, defeating the reaping entirely.
+    if (descendants.length > 0) {
+      signalPids(descendants, 'SIGTERM');
+      this.descendantKillTimer = setTimeout(() => {
+        signalPids(descendants, 'SIGKILL');
+        this.descendantKillTimer = null;
+      }, KILL_GRACE_MS);
     }
 
     try {
@@ -102,6 +150,11 @@ export class LocalPtySession implements Pty {
 
   onExit(handler: (info: PtyExitInfo) => void): void {
     this.proc.onExit(({ exitCode, signal }) => {
+      // Cancel only the group SIGKILL — the foreground group dies with the shell,
+      // so a late SIGKILL is pointless and risks hitting a reused pid. The
+      // descendant escalation (descendantKillTimer) is intentionally left running:
+      // setsid()-detached descendants survive the shell and may have ignored
+      // SIGTERM, so they still need the SIGKILL pass.
       if (this.killTimer) {
         clearTimeout(this.killTimer);
         this.killTimer = null;

--- a/apps/emdash-desktop/src/main/core/pty/local-pty.ts
+++ b/apps/emdash-desktop/src/main/core/pty/local-pty.ts
@@ -3,7 +3,7 @@ import type { IPty } from 'node-pty';
 import { log } from '@main/lib/logger';
 import { normalizeSignal } from './exit-signals';
 import { suppressExpectedNodePtyErrors } from './node-pty-errors';
-import { collectLocalDescendantPidsAsync } from './process-tree';
+import { PosixPtyTerminator } from './posix-pty-terminator';
 import type { Pty, PtyDimensions, PtyExitInfo } from './pty';
 
 export interface LocalSpawnOptions extends PtyDimensions {
@@ -16,18 +16,6 @@ export interface LocalSpawnOptions extends PtyDimensions {
 
 const MIN_COLS = 2;
 const MIN_ROWS = 1;
-
-/** Grace period between the SIGTERM and the SIGKILL escalation. */
-const KILL_GRACE_MS = 2000;
-
-/** SIGTERM/SIGKILL individual pids, ignoring any that are already gone. */
-function signalPids(pids: number[], signal: NodeJS.Signals): void {
-  for (const pid of pids) {
-    try {
-      process.kill(pid, signal);
-    } catch {}
-  }
-}
 
 export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
   const { id, command, args, cwd, env, cols, rows } = options;
@@ -59,13 +47,15 @@ export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
 
 export class LocalPtySession implements Pty {
   readonly id: string;
-  private killTimer: ReturnType<typeof setTimeout> | null = null;
-  private descendantKillTimer: ReturnType<typeof setTimeout> | null = null;
   private killed = false;
 
   constructor(
     id: string,
-    private readonly proc: IPty
+    private readonly proc: IPty,
+    private readonly posixTerminator: Pick<
+      PosixPtyTerminator,
+      'kill' | 'markExited'
+    > = new PosixPtyTerminator()
   ) {
     this.id = id;
   }
@@ -94,51 +84,14 @@ export class LocalPtySession implements Pty {
 
     const pid = this.proc.pid;
     if (process.platform === 'win32' || !Number.isInteger(pid) || pid <= 0) {
-      try {
-        this.proc.kill();
-      } catch {}
+      this.killPty();
       return;
     }
 
-    // Snapshot detached descendants BEFORE any signal. Children that called
-    // setsid() (the watchman daemon, ts-checker-rspack-plugin workers, sudo'd
-    // processes) form their own process group and escape a kill() aimed at the
-    // PTY's foreground group. The snapshot must precede the kill: once the shell
-    // dies the survivors are reparented to init and the parent links that
-    // identify them are gone. Async so spawning `ps` never blocks the Electron
-    // main-process event loop. See issue #2110.
-    void collectLocalDescendantPidsAsync(pid).then(
-      (descendants) => this.terminate(pid, descendants),
-      () => this.terminate(pid, [])
-    );
+    this.posixTerminator.kill(pid, () => this.killPty());
   }
 
-  private terminate(pid: number, descendants: number[]): void {
-    // Foreground process group: SIGTERM now, SIGKILL after a grace period —
-    // unless the shell exits cleanly first (onExit clears killTimer), since the
-    // group dies with it and a late SIGKILL could hit a reused pid.
-    try {
-      process.kill(-pid, 'SIGTERM');
-    } catch {}
-    this.killTimer = setTimeout(() => {
-      try {
-        process.kill(-pid, 'SIGKILL');
-      } catch {}
-      this.killTimer = null;
-    }, KILL_GRACE_MS);
-
-    // Detached descendants outlive the shell, so their SIGKILL escalation must
-    // NOT be cancelled by onExit. Daemons like watchman ignore SIGTERM and only
-    // die on SIGKILL — without this independent pass they would survive the
-    // shell's quick exit, defeating the reaping entirely.
-    if (descendants.length > 0) {
-      signalPids(descendants, 'SIGTERM');
-      this.descendantKillTimer = setTimeout(() => {
-        signalPids(descendants, 'SIGKILL');
-        this.descendantKillTimer = null;
-      }, KILL_GRACE_MS);
-    }
-
+  private killPty(): void {
     try {
       this.proc.kill();
     } catch {}
@@ -150,15 +103,7 @@ export class LocalPtySession implements Pty {
 
   onExit(handler: (info: PtyExitInfo) => void): void {
     this.proc.onExit(({ exitCode, signal }) => {
-      // Cancel only the group SIGKILL — the foreground group dies with the shell,
-      // so a late SIGKILL is pointless and risks hitting a reused pid. The
-      // descendant escalation (descendantKillTimer) is intentionally left running:
-      // setsid()-detached descendants survive the shell and may have ignored
-      // SIGTERM, so they still need the SIGKILL pass.
-      if (this.killTimer) {
-        clearTimeout(this.killTimer);
-        this.killTimer = null;
-      }
+      this.posixTerminator.markExited();
       handler({ exitCode, signal: normalizeSignal(signal) });
     });
   }

--- a/apps/emdash-desktop/src/main/core/pty/posix-pty-terminator.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/posix-pty-terminator.test.ts
@@ -1,0 +1,196 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PosixPtyTerminator } from './posix-pty-terminator';
+import {
+  collectLocalProcessInfosByPidAsync,
+  collectLocalProcessTreeAsync,
+  type ProcessInfo,
+  type ProcessTreeSnapshot,
+} from './process-tree';
+
+vi.mock('./process-tree', () => ({
+  collectLocalProcessInfosByPidAsync: vi.fn(() => Promise.resolve(new Map())),
+  collectLocalProcessTreeAsync: vi.fn(() => Promise.resolve({ descendants: [] })),
+}));
+
+/** Let the async descendant snapshot (a resolved promise + its .then) settle. */
+async function flushSnapshot(): Promise<void> {
+  for (let i = 0; i < 5; i++) await Promise.resolve();
+}
+
+describe('PosixPtyTerminator', () => {
+  const rootProcess: ProcessInfo = {
+    pid: 1234,
+    ppid: 1,
+    pgid: 1234,
+    sessionId: 1234,
+    startTime: 'root-start',
+  };
+  let terminator: PosixPtyTerminator;
+  let killPty: () => void;
+
+  function processInfo(pid: number, overrides: Partial<ProcessInfo> = {}): ProcessInfo {
+    return {
+      pid,
+      ppid: 1234,
+      pgid: pid,
+      sessionId: pid,
+      startTime: `start-${pid}`,
+      ...overrides,
+    };
+  }
+
+  function treeSnapshot(descendants: ProcessInfo[] = []): ProcessTreeSnapshot {
+    return {
+      root: rootProcess,
+      descendants,
+    };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(collectLocalProcessTreeAsync).mockResolvedValue(treeSnapshot());
+    vi.mocked(collectLocalProcessInfosByPidAsync).mockImplementation(async (pids) => {
+      return new Map(pids.map((pid) => [pid, processInfo(pid)]));
+    });
+    vi.useFakeTimers();
+
+    terminator = new PosixPtyTerminator();
+    killPty = vi.fn();
+    vi.spyOn(process, 'kill').mockImplementation(() => true);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('sends SIGTERM to the root process group', async () => {
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+
+    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGTERM');
+    expect(killPty).toHaveBeenCalled();
+  });
+
+  it('escalates the root process group to SIGKILL after 2 seconds if not exited', async () => {
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+
+    vi.advanceTimersByTime(2000);
+    expect(process.kill).toHaveBeenCalledWith(-1234, 'SIGKILL');
+  });
+
+  it('does not send the root group SIGKILL if the shell exits before the timeout', async () => {
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+    terminator.markExited();
+
+    vi.advanceTimersByTime(2000);
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+  });
+
+  it('SIGTERMs descendants individually', async () => {
+    vi.mocked(collectLocalProcessTreeAsync).mockResolvedValue(
+      treeSnapshot([processInfo(5678), processInfo(9012)])
+    );
+
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+
+    expect(collectLocalProcessTreeAsync).toHaveBeenCalledWith(1234);
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGTERM');
+    expect(process.kill).toHaveBeenCalledWith(9012, 'SIGTERM');
+  });
+
+  it('escalates escaped descendants to SIGKILL after 2 seconds', async () => {
+    vi.mocked(collectLocalProcessTreeAsync).mockResolvedValue(treeSnapshot([processInfo(5678)]));
+
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+    expect(process.kill).not.toHaveBeenCalledWith(5678, 'SIGKILL');
+
+    vi.advanceTimersByTime(2000);
+    await flushSnapshot();
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL');
+  });
+
+  it('still SIGKILLs escaped descendants even when the shell exits first', async () => {
+    vi.mocked(collectLocalProcessTreeAsync).mockResolvedValue(treeSnapshot([processInfo(5678)]));
+
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+    // The shell exits right after SIGTERM, while watchman/ts-checker daemons keep running.
+    terminator.markExited();
+
+    vi.advanceTimersByTime(2000);
+    await flushSnapshot();
+    // The dead group's SIGKILL is cancelled...
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+    // ...but the detached descendant is still force-killed — this is the bug the
+    // independent descendant timer fixes.
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL');
+  });
+
+  it('snapshots descendants once and reuses the snapshot for both passes', async () => {
+    vi.mocked(collectLocalProcessTreeAsync).mockResolvedValue(treeSnapshot([processInfo(5678)]));
+
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+    vi.advanceTimersByTime(2000);
+
+    expect(collectLocalProcessTreeAsync).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not schedule group signals if the shell exits before the snapshot resolves', async () => {
+    let resolveSnapshot: (snapshot: ProcessTreeSnapshot) => void = () => {};
+    vi.mocked(collectLocalProcessTreeAsync).mockReturnValue(
+      new Promise((resolve) => {
+        resolveSnapshot = resolve;
+      })
+    );
+
+    terminator.kill(1234, killPty);
+    terminator.markExited();
+    resolveSnapshot(treeSnapshot([processInfo(5678)]));
+    await flushSnapshot();
+
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGTERM');
+    expect(killPty).not.toHaveBeenCalled();
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGTERM');
+
+    vi.advanceTimersByTime(2000);
+    await flushSnapshot();
+    expect(process.kill).not.toHaveBeenCalledWith(-1234, 'SIGKILL');
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGKILL');
+  });
+
+  it('does not independently SIGKILL same-session descendants', async () => {
+    vi.mocked(collectLocalProcessTreeAsync).mockResolvedValue(
+      treeSnapshot([processInfo(5678, { pgid: 5678, sessionId: 1234 })])
+    );
+
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+    vi.advanceTimersByTime(2000);
+    await flushSnapshot();
+
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGTERM');
+    expect(process.kill).not.toHaveBeenCalledWith(5678, 'SIGKILL');
+  });
+
+  it('skips descendant SIGKILL if the pid identity changed before escalation', async () => {
+    vi.mocked(collectLocalProcessTreeAsync).mockResolvedValue(treeSnapshot([processInfo(5678)]));
+    vi.mocked(collectLocalProcessInfosByPidAsync).mockResolvedValue(
+      new Map([[5678, processInfo(5678, { startTime: 'different-start' })]])
+    );
+
+    terminator.kill(1234, killPty);
+    await flushSnapshot();
+    vi.advanceTimersByTime(2000);
+    await flushSnapshot();
+
+    expect(process.kill).toHaveBeenCalledWith(5678, 'SIGTERM');
+    expect(process.kill).not.toHaveBeenCalledWith(5678, 'SIGKILL');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pty/posix-pty-terminator.ts
+++ b/apps/emdash-desktop/src/main/core/pty/posix-pty-terminator.ts
@@ -1,0 +1,112 @@
+import {
+  collectLocalProcessInfosByPidAsync,
+  collectLocalProcessTreeAsync,
+  type ProcessInfo,
+  type ProcessTreeSnapshot,
+} from './process-tree';
+
+const KILL_GRACE_MS = 2000;
+
+function signalPids(pids: number[], signal: NodeJS.Signals): void {
+  for (const pid of pids) {
+    try {
+      process.kill(pid, signal);
+    } catch {}
+  }
+}
+
+function pidsOf(processes: ProcessInfo[]): number[] {
+  return processes.map(({ pid }) => pid);
+}
+
+function isKnownPositiveInteger(value: number | undefined): value is number {
+  return value !== undefined && Number.isInteger(value) && value > 0;
+}
+
+function isEscapedDescendant(root: ProcessInfo | undefined, descendant: ProcessInfo): boolean {
+  if (!root) return true;
+
+  if (isKnownPositiveInteger(root.sessionId) && isKnownPositiveInteger(descendant.sessionId)) {
+    return descendant.sessionId !== root.sessionId;
+  }
+
+  if (isKnownPositiveInteger(root.pgid) && isKnownPositiveInteger(descendant.pgid)) {
+    return descendant.pgid !== root.pgid;
+  }
+
+  return true;
+}
+
+function isSameProcessIdentity(expected: ProcessInfo, current: ProcessInfo | undefined): boolean {
+  if (!current || current.pid !== expected.pid) return false;
+  if (expected.startTime && current.startTime) return current.startTime === expected.startTime;
+  return true;
+}
+
+async function signalMatchingProcessIdentities(
+  processes: ProcessInfo[],
+  signal: NodeJS.Signals
+): Promise<void> {
+  const currentByPid = await collectLocalProcessInfosByPidAsync(pidsOf(processes));
+  const matchingPids = processes
+    .filter((processInfo) => isSameProcessIdentity(processInfo, currentByPid.get(processInfo.pid)))
+    .map(({ pid }) => pid);
+  signalPids(matchingPids, signal);
+}
+
+export class PosixPtyTerminator {
+  private rootKillTimer: ReturnType<typeof setTimeout> | null = null;
+  private descendantKillTimer: ReturnType<typeof setTimeout> | null = null;
+  private exited = false;
+
+  kill(rootPid: number, killPty: () => void): void {
+    void collectLocalProcessTreeAsync(rootPid).then(
+      (snapshot) => this.terminate(rootPid, snapshot, killPty),
+      () => this.terminate(rootPid, { descendants: [] }, killPty)
+    );
+  }
+
+  markExited(): void {
+    this.exited = true;
+    if (this.rootKillTimer) {
+      clearTimeout(this.rootKillTimer);
+      this.rootKillTimer = null;
+    }
+  }
+
+  private terminate(rootPid: number, snapshot: ProcessTreeSnapshot, killPty: () => void): void {
+    if (!this.exited) {
+      try {
+        process.kill(-rootPid, 'SIGTERM');
+      } catch {}
+      if (!this.exited) {
+        this.rootKillTimer = setTimeout(() => {
+          try {
+            process.kill(-rootPid, 'SIGKILL');
+          } catch {}
+          this.rootKillTimer = null;
+        }, KILL_GRACE_MS);
+      }
+    }
+
+    const descendants = snapshot.descendants;
+    if (descendants.length > 0) {
+      signalPids(pidsOf(descendants), 'SIGTERM');
+    }
+
+    const escapedDescendants = descendants.filter((descendant) =>
+      isEscapedDescendant(snapshot.root, descendant)
+    );
+    if (escapedDescendants.length > 0) {
+      this.descendantKillTimer = setTimeout(() => {
+        void signalMatchingProcessIdentities(escapedDescendants, 'SIGKILL').finally(() => {
+          this.descendantKillTimer = null;
+        });
+      }, KILL_GRACE_MS);
+    }
+
+    if (!this.exited) {
+      killPty();
+    }
+  }
+}

--- a/apps/emdash-desktop/src/main/core/pty/process-tree.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/process-tree.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+import { collectDescendantPids, parsePidPpidPairs } from './process-tree';
+
+describe('parsePidPpidPairs', () => {
+  it('parses `ps -o pid=,ppid=` output', () => {
+    const output = '  1 0\n  2 1\n 100 2\n';
+    expect(parsePidPpidPairs(output)).toEqual([
+      { pid: 1, ppid: 0 },
+      { pid: 2, ppid: 1 },
+      { pid: 100, ppid: 2 },
+    ]);
+  });
+
+  it('skips blank lines and non-numeric rows (e.g. a stray header)', () => {
+    const output = 'PID PPID\n\n  10   3\n garbage line\n  11   10\n';
+    expect(parsePidPpidPairs(output)).toEqual([
+      { pid: 10, ppid: 3 },
+      { pid: 11, ppid: 10 },
+    ]);
+  });
+
+  it('returns [] for empty output', () => {
+    expect(parsePidPpidPairs('')).toEqual([]);
+  });
+});
+
+describe('collectDescendantPids', () => {
+  it('collects the transitive descendant tree, excluding the root', () => {
+    // 100 -> 200 -> 400, 100 -> 300; 999 is unrelated.
+    const pairs = [
+      { pid: 200, ppid: 100 },
+      { pid: 300, ppid: 100 },
+      { pid: 400, ppid: 200 },
+      { pid: 999, ppid: 1 },
+    ];
+    expect(collectDescendantPids(pairs, [100]).sort((a, b) => a - b)).toEqual([200, 300, 400]);
+  });
+
+  it('returns [] when the root has no children', () => {
+    const pairs = [{ pid: 200, ppid: 100 }];
+    expect(collectDescendantPids(pairs, [999])).toEqual([]);
+  });
+
+  it('supports multiple roots and never reports a root as its own descendant', () => {
+    // 2 is both a root and a child of root 1: it stays excluded (it is a root),
+    // while its subtree (4) and the other child (3) are collected once.
+    const pairs = [
+      { pid: 2, ppid: 1 },
+      { pid: 3, ppid: 1 },
+      { pid: 4, ppid: 2 },
+    ];
+    expect(collectDescendantPids(pairs, [1, 2]).sort((a, b) => a - b)).toEqual([3, 4]);
+  });
+
+  it('is cycle-safe (does not loop on a parent/child cycle)', () => {
+    // Pathological snapshot where 100 <-> 200 reference each other.
+    const pairs = [
+      { pid: 200, ppid: 100 },
+      { pid: 100, ppid: 200 },
+    ];
+    expect(collectDescendantPids(pairs, [100])).toEqual([200]);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pty/process-tree.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/process-tree.test.ts
@@ -1,5 +1,36 @@
 import { describe, expect, it } from 'vitest';
-import { collectDescendantPids, parsePidPpidPairs } from './process-tree';
+import {
+  collectDescendantPids,
+  collectDescendantProcesses,
+  parsePidPpidPairs,
+  parseProcessTable,
+} from './process-tree';
+
+describe('parseProcessTable', () => {
+  it('parses process identity columns from `ps` output', () => {
+    const output = '  1 0 1 1 Fri Jun 19 18:28:25 2026\n  2 1 2 2 Tue Jun 23 10:04:18 2026\n';
+    expect(parseProcessTable(output)).toEqual([
+      {
+        pid: 1,
+        ppid: 0,
+        pgid: 1,
+        sessionId: 1,
+        startTime: 'Fri Jun 19 18:28:25 2026',
+      },
+      {
+        pid: 2,
+        ppid: 1,
+        pgid: 2,
+        sessionId: 2,
+        startTime: 'Tue Jun 23 10:04:18 2026',
+      },
+    ]);
+  });
+
+  it('tolerates output with only pid and ppid', () => {
+    expect(parseProcessTable('  10   3\n')).toEqual([{ pid: 10, ppid: 3 }]);
+  });
+});
 
 describe('parsePidPpidPairs', () => {
   it('parses `ps -o pid=,ppid=` output', () => {
@@ -24,7 +55,16 @@ describe('parsePidPpidPairs', () => {
   });
 });
 
-describe('collectDescendantPids', () => {
+describe('collectDescendantProcesses', () => {
+  it('preserves process metadata while collecting descendants', () => {
+    const processes = [
+      { pid: 200, ppid: 100, pgid: 100, sessionId: 100, startTime: 'a' },
+      { pid: 300, ppid: 200, pgid: 300, sessionId: 300, startTime: 'b' },
+    ];
+
+    expect(collectDescendantProcesses(processes, [100])).toEqual(processes);
+  });
+
   it('collects the transitive descendant tree, excluding the root', () => {
     // 100 -> 200 -> 400, 100 -> 300; 999 is unrelated.
     const pairs = [
@@ -33,12 +73,12 @@ describe('collectDescendantPids', () => {
       { pid: 400, ppid: 200 },
       { pid: 999, ppid: 1 },
     ];
-    expect(collectDescendantPids(pairs, [100]).sort((a, b) => a - b)).toEqual([200, 300, 400]);
+    expect(collectDescendantProcesses(pairs, [100]).map(({ pid }) => pid)).toEqual([200, 300, 400]);
   });
 
   it('returns [] when the root has no children', () => {
     const pairs = [{ pid: 200, ppid: 100 }];
-    expect(collectDescendantPids(pairs, [999])).toEqual([]);
+    expect(collectDescendantProcesses(pairs, [999])).toEqual([]);
   });
 
   it('supports multiple roots and never reports a root as its own descendant', () => {
@@ -49,7 +89,7 @@ describe('collectDescendantPids', () => {
       { pid: 3, ppid: 1 },
       { pid: 4, ppid: 2 },
     ];
-    expect(collectDescendantPids(pairs, [1, 2]).sort((a, b) => a - b)).toEqual([3, 4]);
+    expect(collectDescendantProcesses(pairs, [1, 2]).map(({ pid }) => pid)).toEqual([3, 4]);
   });
 
   it('is cycle-safe (does not loop on a parent/child cycle)', () => {
@@ -58,6 +98,20 @@ describe('collectDescendantPids', () => {
       { pid: 200, ppid: 100 },
       { pid: 100, ppid: 200 },
     ];
-    expect(collectDescendantPids(pairs, [100])).toEqual([200]);
+    expect(collectDescendantProcesses(pairs, [100]).map(({ pid }) => pid)).toEqual([200]);
+  });
+});
+
+describe('collectDescendantPids', () => {
+  it('projects collected descendants to pid values', () => {
+    expect(
+      collectDescendantPids(
+        [
+          { pid: 200, ppid: 100 },
+          { pid: 300, ppid: 200 },
+        ],
+        [100]
+      )
+    ).toEqual([200, 300]);
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/process-tree.ts
+++ b/apps/emdash-desktop/src/main/core/pty/process-tree.ts
@@ -144,16 +144,6 @@ export async function collectLocalProcessTreeAsync(rootPid: number): Promise<Pro
 }
 
 /**
- * Snapshot the local process table and resolve the transitive descendant pids
- * of `rootPid`. Best-effort: resolves `[]` if `ps` is unavailable or fails.
- */
-export async function collectLocalDescendantPidsAsync(rootPid: number): Promise<number[]> {
-  return collectLocalProcessTreeAsync(rootPid).then(({ descendants }) =>
-    descendants.map(({ pid }) => pid)
-  );
-}
-
-/**
  * Snapshot specific pids for delayed signal identity checks. Missing pids are
  * omitted from the returned map.
  */

--- a/apps/emdash-desktop/src/main/core/pty/process-tree.ts
+++ b/apps/emdash-desktop/src/main/core/pty/process-tree.ts
@@ -1,0 +1,84 @@
+import { execFile } from 'node:child_process';
+import { log } from '@main/lib/logger';
+
+export interface PidPpidPair {
+  pid: number;
+  ppid: number;
+}
+
+/**
+ * Parse the output of `ps -o pid=,ppid=` into (pid, ppid) pairs.
+ * Lines that do not start with two integers are skipped, so the parser is
+ * tolerant of a stray header row or platform formatting quirks.
+ */
+export function parsePidPpidPairs(output: string): PidPpidPair[] {
+  const pairs: PidPpidPair[] = [];
+  for (const line of output.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) continue;
+    const pid = Number(parts[0]);
+    const ppid = Number(parts[1]);
+    if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
+    pairs.push({ pid, ppid });
+  }
+  return pairs;
+}
+
+/**
+ * Given a process-table snapshot and a set of root pids, return every
+ * transitive descendant pid (excluding the roots themselves). Cycle-safe.
+ */
+export function collectDescendantPids(pairs: PidPpidPair[], roots: number[]): number[] {
+  const childrenByParent = new Map<number, number[]>();
+  for (const { pid, ppid } of pairs) {
+    const existing = childrenByParent.get(ppid);
+    if (existing) existing.push(pid);
+    else childrenByParent.set(ppid, [pid]);
+  }
+
+  const seen = new Set<number>(roots);
+  const descendants: number[] = [];
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const parent = queue.shift()!;
+    const children = childrenByParent.get(parent);
+    if (!children) continue;
+    for (const child of children) {
+      if (seen.has(child)) continue;
+      seen.add(child);
+      descendants.push(child);
+      queue.push(child);
+    }
+  }
+  return descendants;
+}
+
+/**
+ * Snapshot the local process table and resolve the transitive descendant pids
+ * of `rootPid`. Best-effort: resolves `[]` if `ps` is unavailable or fails.
+ *
+ * Asynchronous on purpose — this runs on the Electron main process, so spawning
+ * `ps` must not block the event loop. POSIX only; callers guard the platform.
+ * `ps -A -o pid=,ppid=` is supported by both Linux (procps) and macOS (BSD) `ps`.
+ */
+export function collectLocalDescendantPidsAsync(rootPid: number): Promise<number[]> {
+  return new Promise((resolve) => {
+    execFile(
+      'ps',
+      ['-A', '-o', 'pid=,ppid='],
+      { encoding: 'utf8', maxBuffer: 8 * 1024 * 1024, timeout: 2000 },
+      (error, stdout) => {
+        if (error) {
+          log.debug('collectLocalDescendantPidsAsync: ps snapshot failed', {
+            error: String(error),
+          });
+          resolve([]);
+          return;
+        }
+        resolve(collectDescendantPids(parsePidPpidPairs(stdout), [rootPid]));
+      }
+    );
+  });
+}

--- a/apps/emdash-desktop/src/main/core/pty/process-tree.ts
+++ b/apps/emdash-desktop/src/main/core/pty/process-tree.ts
@@ -6,13 +6,26 @@ export interface PidPpidPair {
   ppid: number;
 }
 
+export interface ProcessInfo extends PidPpidPair {
+  pgid?: number;
+  sessionId?: number;
+  startTime?: string;
+}
+
+export interface ProcessTreeSnapshot {
+  root?: ProcessInfo;
+  descendants: ProcessInfo[];
+}
+
+const PS_TREE_COLUMNS = 'pid=,ppid=,pgid=,sess=,lstart=';
+
 /**
- * Parse the output of `ps -o pid=,ppid=` into (pid, ppid) pairs.
- * Lines that do not start with two integers are skipped, so the parser is
- * tolerant of a stray header row or platform formatting quirks.
+ * Parse process-table output into process identity records. The first two
+ * columns (`pid`, `ppid`) are required; `pgid`, `sess`, and the start-time tail
+ * are optional so tests and platform-specific `ps` variants can reuse this.
  */
-export function parsePidPpidPairs(output: string): PidPpidPair[] {
-  const pairs: PidPpidPair[] = [];
+export function parseProcessTable(output: string): ProcessInfo[] {
+  const processes: ProcessInfo[] = [];
   for (const line of output.split('\n')) {
     const trimmed = line.trim();
     if (!trimmed) continue;
@@ -21,9 +34,60 @@ export function parsePidPpidPairs(output: string): PidPpidPair[] {
     const pid = Number(parts[0]);
     const ppid = Number(parts[1]);
     if (!Number.isInteger(pid) || !Number.isInteger(ppid)) continue;
-    pairs.push({ pid, ppid });
+
+    const pgid = Number(parts[2]);
+    const sessionId = Number(parts[3]);
+    const startTime = parts.slice(4).join(' ').trim();
+    processes.push({
+      pid,
+      ppid,
+      ...(Number.isInteger(pgid) ? { pgid } : {}),
+      ...(Number.isInteger(sessionId) ? { sessionId } : {}),
+      ...(startTime ? { startTime } : {}),
+    });
   }
-  return pairs;
+  return processes;
+}
+
+/**
+ * Parse the output of `ps -o pid=,ppid=` into (pid, ppid) pairs.
+ * Lines that do not start with two integers are skipped, so the parser is
+ * tolerant of a stray header row or platform formatting quirks.
+ */
+export function parsePidPpidPairs(output: string): PidPpidPair[] {
+  return parseProcessTable(output).map(({ pid, ppid }) => ({ pid, ppid }));
+}
+
+/**
+ * Given a process-table snapshot and a set of root pids, return every
+ * transitive descendant process (excluding the roots themselves). Cycle-safe.
+ */
+export function collectDescendantProcesses<T extends PidPpidPair>(
+  processes: T[],
+  roots: number[]
+): T[] {
+  const childrenByParent = new Map<number, T[]>();
+  for (const processInfo of processes) {
+    const existing = childrenByParent.get(processInfo.ppid);
+    if (existing) existing.push(processInfo);
+    else childrenByParent.set(processInfo.ppid, [processInfo]);
+  }
+
+  const seen = new Set<number>(roots);
+  const descendants: T[] = [];
+  const queue = [...roots];
+  while (queue.length > 0) {
+    const parent = queue.shift()!;
+    const children = childrenByParent.get(parent);
+    if (!children) continue;
+    for (const child of children) {
+      if (seen.has(child.pid)) continue;
+      seen.add(child.pid);
+      descendants.push(child);
+      queue.push(child.pid);
+    }
+  }
+  return descendants;
 }
 
 /**
@@ -31,54 +95,79 @@ export function parsePidPpidPairs(output: string): PidPpidPair[] {
  * transitive descendant pid (excluding the roots themselves). Cycle-safe.
  */
 export function collectDescendantPids(pairs: PidPpidPair[], roots: number[]): number[] {
-  const childrenByParent = new Map<number, number[]>();
-  for (const { pid, ppid } of pairs) {
-    const existing = childrenByParent.get(ppid);
-    if (existing) existing.push(pid);
-    else childrenByParent.set(ppid, [pid]);
-  }
-
-  const seen = new Set<number>(roots);
-  const descendants: number[] = [];
-  const queue = [...roots];
-  while (queue.length > 0) {
-    const parent = queue.shift()!;
-    const children = childrenByParent.get(parent);
-    if (!children) continue;
-    for (const child of children) {
-      if (seen.has(child)) continue;
-      seen.add(child);
-      descendants.push(child);
-      queue.push(child);
-    }
-  }
-  return descendants;
+  return collectDescendantProcesses(pairs, roots).map(({ pid }) => pid);
 }
 
-/**
- * Snapshot the local process table and resolve the transitive descendant pids
- * of `rootPid`. Best-effort: resolves `[]` if `ps` is unavailable or fails.
- *
- * Asynchronous on purpose — this runs on the Electron main process, so spawning
- * `ps` must not block the event loop. POSIX only; callers guard the platform.
- * `ps -A -o pid=,ppid=` is supported by both Linux (procps) and macOS (BSD) `ps`.
- */
-export function collectLocalDescendantPidsAsync(rootPid: number): Promise<number[]> {
+function snapshotLocalProcesses(args: string[]): Promise<ProcessInfo[]> {
   return new Promise((resolve) => {
     execFile(
       'ps',
-      ['-A', '-o', 'pid=,ppid='],
+      args,
       { encoding: 'utf8', maxBuffer: 8 * 1024 * 1024, timeout: 2000 },
       (error, stdout) => {
-        if (error) {
-          log.debug('collectLocalDescendantPidsAsync: ps snapshot failed', {
+        if (error && !stdout) {
+          log.debug('process-tree: ps snapshot failed', {
+            args,
             error: String(error),
           });
           resolve([]);
           return;
         }
-        resolve(collectDescendantPids(parsePidPpidPairs(stdout), [rootPid]));
+        if (error) {
+          log.debug('process-tree: ps snapshot partially failed', {
+            args,
+            error: String(error),
+          });
+        }
+        resolve(parseProcessTable(stdout));
       }
     );
   });
+}
+
+/**
+ * Snapshot the local process table and resolve the root plus transitive
+ * descendants of `rootPid`. Best-effort: resolves an empty descendant list if
+ * `ps` is unavailable or fails.
+ *
+ * Asynchronous on purpose — this runs on the Electron main process, so spawning
+ * `ps` must not block the event loop. POSIX only; callers guard the platform.
+ * `ps -A -o pid=,ppid=,pgid=,sess=,lstart=` is supported by both Linux
+ * (procps) and macOS (BSD) `ps`.
+ */
+export async function collectLocalProcessTreeAsync(rootPid: number): Promise<ProcessTreeSnapshot> {
+  const processes = await snapshotLocalProcesses(['-A', '-o', PS_TREE_COLUMNS]);
+  return {
+    root: processes.find(({ pid }) => pid === rootPid),
+    descendants: collectDescendantProcesses(processes, [rootPid]),
+  };
+}
+
+/**
+ * Snapshot the local process table and resolve the transitive descendant pids
+ * of `rootPid`. Best-effort: resolves `[]` if `ps` is unavailable or fails.
+ */
+export async function collectLocalDescendantPidsAsync(rootPid: number): Promise<number[]> {
+  return collectLocalProcessTreeAsync(rootPid).then(({ descendants }) =>
+    descendants.map(({ pid }) => pid)
+  );
+}
+
+/**
+ * Snapshot specific pids for delayed signal identity checks. Missing pids are
+ * omitted from the returned map.
+ */
+export async function collectLocalProcessInfosByPidAsync(
+  pids: number[]
+): Promise<Map<number, ProcessInfo>> {
+  const uniquePids = [...new Set(pids.filter((pid) => Number.isInteger(pid) && pid > 0))];
+  if (uniquePids.length === 0) return new Map();
+
+  const processes = await snapshotLocalProcesses([
+    '-p',
+    uniquePids.join(','),
+    '-o',
+    PS_TREE_COLUMNS,
+  ]);
+  return new Map(processes.map((processInfo) => [processInfo.pid, processInfo]));
 }


### PR DESCRIPTION
## Problem

`LocalPtySession.kill()` only signals the PTY's **foreground process group** (`process.kill(-pid, …)`). Descendants that call `setsid()` form their own session/process group and escape that signal, so they survive task deletion. In practice this leaves the **watchman** daemon, **ts-checker-rspack-plugin** workers (rsbuild/rspack dev servers), and `sudo`'d children running — often for days, frequently holding ports — across worktree sessions.

Fixes #2110.

## Fix

Snapshot the descendant pid tree **before** signalling — once the shell dies the survivors are reparented to `init` and the parent links that identify them are gone — then SIGTERM the foreground group *and* every descendant individually, escalating to SIGKILL after the existing 2s grace.

- New `process-tree.ts`: `parsePidPpidPairs()` + cycle-safe `collectDescendantPids()` (pure), and `collectLocalDescendantPids()` which snapshots via `ps -A -o pid=,ppid=` (supported by both Linux/procps and macOS/BSD `ps`). Best-effort: returns `[]` if `ps` is unavailable, so the kill path never throws.
- `local-pty.ts`: snapshot + `signalProcessTree()` for the SIGTERM and SIGKILL passes.
- **Windows is unchanged** — node-pty's job object already tears down the tree there.

The helper is transport-agnostic and is reused by the companion remote-tmux reaping fix (#2580).

## Testing

`pnpm run format && pnpm run lint && pnpm run typecheck` clean; full `node` Vitest project green. New unit tests cover the parser, the BFS (multi-root, cycle-safe), and the kill path (descendant SIGTERM/SIGKILL, single snapshot reused, Windows no-op).