### PR TITLE
fix(ssh): reap orphaned remote tmux sessions and their dev servers

### DIFF
--- a/apps/emdash-desktop/src/main/app/shutdown.ts
+++ b/apps/emdash-desktop/src/main/app/shutdown.ts
@@ -1,6 +1,7 @@
 import { app } from 'electron';
 import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
 import { automationsService } from '@main/core/automations/automations-service';
+import { remoteTmuxReaperService } from '@main/core/pty/remote-tmux-reaper-service';
 import { prSyncScheduler } from '@main/core/pull-requests/pr-sync-scheduler';
 import { stopResourceSampler } from '@main/core/resource-monitor/resource-sampler';
 import { runtimeManager } from '@main/core/runtime/runtime-manager';
@@ -42,6 +43,7 @@ export async function runQuitCleanup(): Promise<void> {
   stopResourceSampler();
   updateService.dispose();
   prSyncScheduler.dispose();
+  remoteTmuxReaperService.dispose();
 
   // critical phase
   const criticalSteps: Array<[string, () => Promise<void>]> = [

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -11,7 +11,8 @@ import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
-import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionTree } from '@main/core/pty/tmux-reaper';
+import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import { events } from '@main/lib/events';
@@ -331,7 +332,7 @@ export class SshConversationProvider implements ConversationProvider {
       }
     }
     if (this.tmux) {
-      await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
+      await killTmuxSessionTree(this.ctx, makeTmuxSessionName(sessionId));
     }
     this.supervisor.forget(sessionId);
   }
@@ -340,7 +341,9 @@ export class SshConversationProvider implements ConversationProvider {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
     if (this.tmux) {
-      await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
+      await Promise.all(
+        sessionIds.map((id) => killTmuxSessionTree(this.ctx, makeTmuxSessionName(id)))
+      );
     }
     for (const sessionId of sessionIds) {
       this.supervisor.forget(sessionId);

--- a/apps/emdash-desktop/src/main/core/pty/remote-tmux-reaper-service.ts
+++ b/apps/emdash-desktop/src/main/core/pty/remote-tmux-reaper-service.ts
@@ -1,0 +1,42 @@
+import type { IDisposable, IInitializable } from '@emdash/shared';
+import { projectManager } from '@main/core/projects/project-manager';
+import type { ProjectProvider } from '@main/core/projects/project-provider';
+import { log } from '@main/lib/logger';
+import { reconcileProjectTmuxSessions } from './tmux-reconcile';
+
+/**
+ * Reaps orphaned `emdash-*` tmux sessions on a remote host when an SSH project
+ * is mounted. These accumulate when conversations/terminals are deleted while
+ * detached, or when the app restarts and loses the in-memory session tracking
+ * that the explicit Stop/Delete paths rely on (issue #2580).
+ *
+ * Runs once per SSH project open, in the background, and never blocks the mount.
+ * Preserve-on-close resumability is untouched: only sessions that no longer map
+ * to any DB entity are removed.
+ */
+export class RemoteTmuxReaperService implements IInitializable, IDisposable {
+  private _unsubscribe: (() => void) | null = null;
+
+  initialize(): void {
+    this._unsubscribe = projectManager.on('projectOpened', (_projectId, provider) => {
+      this.onProjectMounted(provider);
+    });
+  }
+
+  dispose(): void {
+    this._unsubscribe?.();
+    this._unsubscribe = null;
+  }
+
+  private onProjectMounted(provider: ProjectProvider): void {
+    if (provider.type !== 'ssh') return;
+    void reconcileProjectTmuxSessions(provider.ctx, provider.projectId).catch((err) => {
+      log.warn('RemoteTmuxReaperService: reconcile failed', {
+        projectId: provider.projectId,
+        error: String(err),
+      });
+    });
+  }
+}
+
+export const remoteTmuxReaperService = new RemoteTmuxReaperService();

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reaper.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reaper.test.ts
@@ -1,0 +1,121 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecResult, IExecutionContext } from '@main/core/execution-context/types';
+import { makePtySessionId } from '@shared/core/pty/ptySessionId';
+import { killTmuxSessionTree, listEmdashTmuxSessions } from './tmux-reaper';
+import { makeTmuxSessionName } from './tmux-session-name';
+
+type ExecCall = { command: string; args: string[] };
+type ExecHandler = (command: string, args: string[]) => ExecResult;
+
+function makeCtx(handler: ExecHandler): { ctx: IExecutionContext; calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  const ctx = {
+    root: undefined,
+    supportsLocalSpawn: false,
+    exec: vi.fn(async (command: string, args: string[] = []) => {
+      calls.push({ command, args });
+      return handler(command, args);
+    }),
+    execStreaming: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as IExecutionContext;
+  return { ctx, calls };
+}
+
+/** Handler with one pane pid (4242) owning one detached child (9999). */
+function treeHandler(): ExecHandler {
+  return (command, args) => {
+    if (command === 'tmux' && args[0] === 'list-panes') return { stdout: '4242\n', stderr: '' };
+    if (command === 'ps') return { stdout: '4242 1\n9999 4242\n', stderr: '' };
+    return { stdout: '', stderr: '' };
+  };
+}
+
+function killSessionTargets(calls: ExecCall[]): string[] {
+  return calls
+    .filter((c) => c.command === 'tmux' && c.args[0] === 'kill-session')
+    .map((c) => c.args[2]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('listEmdashTmuxSessions', () => {
+  it('returns only emdash-prefixed session names', async () => {
+    const { ctx } = makeCtx((command, args) =>
+      command === 'tmux' && args[0] === 'list-sessions'
+        ? { stdout: 'emdash-a\nother-session\nemdash-b\n', stderr: '' }
+        : { stdout: '', stderr: '' }
+    );
+    expect(await listEmdashTmuxSessions(ctx)).toEqual(['emdash-a', 'emdash-b']);
+  });
+
+  it('returns [] when tmux has no server / errors out', async () => {
+    const ctx = {
+      exec: vi.fn(async () => {
+        throw new Error('no server running');
+      }),
+    } as unknown as IExecutionContext;
+    expect(await listEmdashTmuxSessions(ctx)).toEqual([]);
+  });
+});
+
+describe('killTmuxSessionTree', () => {
+  it('snapshots the pane tree before kill-session, then SIGKILLs the escaped descendants', async () => {
+    const name = makeTmuxSessionName(makePtySessionId('p', 't', 'c'));
+    const { ctx, calls } = makeCtx(treeHandler());
+
+    await killTmuxSessionTree(ctx, name);
+
+    const seq = calls.map((c) => `${c.command} ${c.args[0] ?? ''}`.trim());
+    const killIdx = seq.indexOf('tmux kill-session');
+    expect(seq.indexOf('tmux list-panes')).toBeLessThan(killIdx);
+    expect(seq.indexOf('ps -A')).toBeLessThan(killIdx);
+
+    const reap = calls.find((c) => c.command === 'sh');
+    expect(reap).toBeDefined();
+    // Only the escaped descendant is reaped — the pane pid (4242) is left to
+    // kill-session, since it is likely dead and its pid may have been recycled.
+    expect(reap?.args[1]).toContain('9999');
+    expect(reap?.args[1]).not.toContain('4242');
+    // SIGKILL only — no pointless ungraced SIGTERM.
+    expect(reap?.args[1]).toContain('kill -KILL');
+    expect(reap?.args[1]).not.toContain('-TERM');
+  });
+
+  it('does not reap when ps is unavailable (cannot identify escaped descendants)', async () => {
+    const { ctx, calls } = makeCtx((command, args) => {
+      if (command === 'tmux' && args[0] === 'list-panes') return { stdout: '4242\n', stderr: '' };
+      if (command === 'ps') throw new Error('ps: command not found');
+      return { stdout: '', stderr: '' };
+    });
+
+    await killTmuxSessionTree(ctx, 'emdash-x');
+
+    expect(killSessionTargets(calls)).toEqual(['emdash-x']);
+    expect(calls.find((c) => c.command === 'sh')).toBeUndefined();
+  });
+
+  it('still kills the session but skips reaping when there are no panes', async () => {
+    const { ctx, calls } = makeCtx((command, args) =>
+      command === 'tmux' && args[0] === 'list-panes'
+        ? { stdout: '\n', stderr: '' }
+        : { stdout: '', stderr: '' }
+    );
+
+    await killTmuxSessionTree(ctx, 'emdash-x');
+
+    expect(killSessionTargets(calls)).toEqual(['emdash-x']);
+    expect(calls.find((c) => c.command === 'sh')).toBeUndefined();
+  });
+
+  it('never throws when the remote commands fail', async () => {
+    const ctx = {
+      exec: vi.fn(async () => {
+        throw new Error('connection dropped');
+      }),
+    } as unknown as IExecutionContext;
+    await expect(killTmuxSessionTree(ctx, 'emdash-x')).resolves.toBeUndefined();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reaper.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reaper.ts
@@ -1,0 +1,106 @@
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import { log } from '@main/lib/logger';
+import { collectDescendantPids, parsePidPpidPairs } from './process-tree';
+import { killTmuxSession, TMUX_SESSION_PREFIX } from './tmux-session-name';
+
+// NOTE: this module must stay free of DB imports. It is loaded by the SSH
+// conversation/terminal providers (for killTmuxSessionTree); pulling in the DB
+// client here would break their unit tests, which run without Electron's `app`.
+// DB-dependent reconciliation lives in ./tmux-reconcile.
+
+/**
+ * List the names of all `emdash-*` tmux sessions on the context's host.
+ * Returns `[]` when no tmux server is running (tmux exits non-zero), tmux is
+ * absent, or the command otherwise fails — callers treat that as "nothing to do".
+ */
+export async function listEmdashTmuxSessions(ctx: IExecutionContext): Promise<string[]> {
+  try {
+    const { stdout } = await ctx.exec('tmux', ['list-sessions', '-F', '#{session_name}']);
+    return stdout
+      .split('\n')
+      .map((line) => line.trim())
+      .filter((name) => name.startsWith(TMUX_SESSION_PREFIX));
+  } catch (err) {
+    log.debug('listEmdashTmuxSessions: no tmux sessions', { error: String(err) });
+    return [];
+  }
+}
+
+/**
+ * Snapshot the transitive descendants of a tmux session's panes on the context's
+ * host. Must be called BEFORE `kill-session`: once the panes die the survivors
+ * are reparented to init and become unreachable.
+ *
+ * Returns only the descendants, NOT the pane pids themselves — `kill-session`
+ * already signals the panes, so by the time we reap they are likely dead and
+ * their pids may have been recycled to unrelated processes. The escaped
+ * descendants (the setsid() dev servers we are after) survive `kill-session`, so
+ * they are still alive and safe to target. Resolves `[]` if `ps` is unavailable.
+ */
+async function collectSessionDescendantPids(
+  ctx: IExecutionContext,
+  sessionName: string
+): Promise<number[]> {
+  let panePids: number[];
+  try {
+    const { stdout } = await ctx.exec('tmux', [
+      'list-panes',
+      '-s',
+      '-t',
+      sessionName,
+      '-F',
+      '#{pane_pid}',
+    ]);
+    panePids = stdout
+      .split('\n')
+      .map((line) => Number(line.trim()))
+      .filter((pid) => Number.isInteger(pid) && pid > 1);
+  } catch {
+    return [];
+  }
+  if (panePids.length === 0) return [];
+
+  try {
+    const { stdout } = await ctx.exec('ps', ['-A', '-o', 'pid=,ppid=']);
+    return collectDescendantPids(parsePidPpidPairs(stdout), panePids);
+  } catch {
+    // No process table — we cannot identify the escaped descendants. The panes
+    // themselves are handled by kill-session, so there is nothing else to reap.
+    return [];
+  }
+}
+
+/**
+ * Force-reap remote orphan pids with SIGKILL. These are setsid() escapees that
+ * outlived `kill-session`'s SIGHUP; graceful shutdown is not a goal (the OS frees
+ * their ports on death either way), so a SIGTERM grace would only add latency.
+ * The pids are validated integers, so embedding them in the script is safe.
+ */
+async function reapPids(ctx: IExecutionContext, pids: number[]): Promise<void> {
+  const list = pids.filter((pid) => Number.isInteger(pid) && pid > 1).join(' ');
+  if (!list) return;
+  const script = `kill -KILL ${list} 2>/dev/null || true`;
+  try {
+    await ctx.exec('sh', ['-c', script]);
+  } catch (err) {
+    log.debug('reapPids: remote kill failed', { error: String(err) });
+  }
+}
+
+/**
+ * Kill a tmux session AND its orphaned descendant processes. `tmux kill-session`
+ * only sends SIGHUP to the pane processes; dev servers (vite/metro/expo,
+ * watchman) double-fork / setsid and survive as port-holding orphans. We
+ * snapshot the pane process trees first, kill the session, then reap the
+ * surviving descendants. Best-effort and never throws. See issue #2580.
+ */
+export async function killTmuxSessionTree(
+  ctx: IExecutionContext,
+  sessionName: string
+): Promise<void> {
+  const descendants = await collectSessionDescendantPids(ctx, sessionName);
+  await killTmuxSession(ctx, sessionName);
+  if (descendants.length > 0) {
+    await reapPids(ctx, descendants);
+  }
+}

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ExecResult, IExecutionContext } from '@main/core/execution-context/types';
+import { getProjectSessionLeafIds } from '@main/core/tasks/session-targets';
+import { makePtySessionId } from '@shared/core/pty/ptySessionId';
+import { createLifecycleScriptTerminalId } from '@shared/core/terminals/terminals';
+import { reconcileProjectTmuxSessions } from './tmux-reconcile';
+import { makeTmuxSessionName } from './tmux-session-name';
+
+vi.mock('@main/core/tasks/session-targets', () => ({
+  getProjectSessionLeafIds: vi.fn(),
+}));
+
+type ExecCall = { command: string; args: string[] };
+type ExecHandler = (command: string, args: string[]) => ExecResult;
+
+function makeCtx(handler: ExecHandler): { ctx: IExecutionContext; calls: ExecCall[] } {
+  const calls: ExecCall[] = [];
+  const ctx = {
+    root: undefined,
+    supportsLocalSpawn: false,
+    exec: vi.fn(async (command: string, args: string[] = []) => {
+      calls.push({ command, args });
+      return handler(command, args);
+    }),
+    execStreaming: vi.fn(),
+    dispose: vi.fn(),
+  } as unknown as IExecutionContext;
+  return { ctx, calls };
+}
+
+/** Lists the given sessions; every session reports one pane (4242) + one child (9999). */
+function reconcileHandler(sessions: string[]): ExecHandler {
+  return (command, args) => {
+    if (command === 'tmux' && args[0] === 'list-sessions') {
+      return { stdout: `${sessions.join('\n')}\n`, stderr: '' };
+    }
+    if (command === 'tmux' && args[0] === 'list-panes') return { stdout: '4242\n', stderr: '' };
+    if (command === 'ps') return { stdout: '4242 1\n9999 4242\n', stderr: '' };
+    return { stdout: '', stderr: '' };
+  };
+}
+
+function killSessionTargets(calls: ExecCall[]): string[] {
+  return calls
+    .filter((c) => c.command === 'tmux' && c.args[0] === 'kill-session')
+    .map((c) => c.args[2]);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('reconcileProjectTmuxSessions', () => {
+  const projectId = 'projA';
+  const liveConversation = makeTmuxSessionName(makePtySessionId(projectId, 't1', 'conv-live'));
+  const liveTerminal = makeTmuxSessionName(makePtySessionId(projectId, 't1', 'term-live'));
+  const deadConversation = makeTmuxSessionName(makePtySessionId(projectId, 't1', 'conv-dead'));
+  const lifecycleSession = makeTmuxSessionName(
+    makePtySessionId(projectId, 'ws1', createLifecycleScriptTerminalId('run'))
+  );
+  const otherProjectSession = makeTmuxSessionName(makePtySessionId('projB', 't1', 'conv-x'));
+  const unparseableSession = 'emdash-not*base64url';
+
+  it('reaps only this project orphans, preserving live, lifecycle and foreign sessions', async () => {
+    vi.mocked(getProjectSessionLeafIds).mockResolvedValue({
+      conversationIds: ['conv-live'],
+      terminalIds: ['term-live'],
+    });
+    const { ctx, calls } = makeCtx(
+      reconcileHandler([
+        liveConversation,
+        liveTerminal,
+        deadConversation,
+        lifecycleSession,
+        otherProjectSession,
+        unparseableSession,
+      ])
+    );
+
+    await reconcileProjectTmuxSessions(ctx, projectId);
+
+    expect(killSessionTargets(calls)).toEqual([deadConversation]);
+  });
+
+  it('does no DB lookup or kills when the host has no emdash sessions', async () => {
+    const { ctx, calls } = makeCtx(() => ({ stdout: '', stderr: '' }));
+
+    await reconcileProjectTmuxSessions(ctx, projectId);
+
+    expect(getProjectSessionLeafIds).not.toHaveBeenCalled();
+    expect(killSessionTargets(calls)).toEqual([]);
+  });
+
+  it('does no DB lookup when every listed session belongs to another project', async () => {
+    const { ctx, calls } = makeCtx(reconcileHandler([otherProjectSession, unparseableSession]));
+
+    await reconcileProjectTmuxSessions(ctx, projectId);
+
+    expect(getProjectSessionLeafIds).not.toHaveBeenCalled();
+    expect(killSessionTargets(calls)).toEqual([]);
+  });
+
+  it('reaps nothing when every session is still wanted', async () => {
+    vi.mocked(getProjectSessionLeafIds).mockResolvedValue({
+      conversationIds: ['conv-live'],
+      terminalIds: ['term-live'],
+    });
+    const { ctx, calls } = makeCtx(reconcileHandler([liveConversation, liveTerminal]));
+
+    await reconcileProjectTmuxSessions(ctx, projectId);
+
+    expect(killSessionTargets(calls)).toEqual([]);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-reconcile.ts
@@ -1,0 +1,59 @@
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import { getProjectSessionLeafIds } from '@main/core/tasks/session-targets';
+import { log } from '@main/lib/logger';
+import { parsePtySessionId } from '@shared/core/pty/ptySessionId';
+import { LIFECYCLE_SCRIPT_TERMINAL_ID_PREFIX } from '@shared/core/terminals/terminals';
+import { killTmuxSessionTree, listEmdashTmuxSessions } from './tmux-reaper';
+import { decodeTmuxSessionName } from './tmux-session-name';
+
+/**
+ * Reap orphaned emdash tmux sessions for `projectId` on the context's host.
+ *
+ * A session is reaped only when its leaf entity (conversation or terminal) no
+ * longer exists in the DB. To stay safe on a tmux server shared by several
+ * projects / hosts, only sessions whose encoded `projectId` matches are even
+ * considered, and workspace lifecycle-script sessions (not DB-tracked) are
+ * always preserved. Detached-but-still-tracked sessions are kept, so
+ * preserve-on-close resumability (PR #2281) is unaffected.
+ *
+ * Imports the DB (via getProjectSessionLeafIds), so keep it out of any module
+ * loaded by the SSH providers — see the note in ./tmux-reaper.
+ */
+export async function reconcileProjectTmuxSessions(
+  ctx: IExecutionContext,
+  projectId: string
+): Promise<void> {
+  const sessionNames = await listEmdashTmuxSessions(ctx);
+  if (sessionNames.length === 0) return;
+
+  // Resolve this project's reapable sessions BEFORE touching the DB: only
+  // sessions that decode to this projectId, excluding lifecycle-script terminals
+  // (which create tmux sessions but have no DB row). On a tmux server shared by
+  // several projects this avoids a DB round-trip on every project mount when
+  // nothing on the host belongs to the project being opened.
+  const candidates: Array<{ name: string; leafId: string }> = [];
+  for (const name of sessionNames) {
+    const sessionId = decodeTmuxSessionName(name);
+    if (!sessionId) continue;
+    const parsed = parsePtySessionId(sessionId);
+    if (!parsed || parsed.projectId !== projectId) continue;
+    if (parsed.leafId.startsWith(LIFECYCLE_SCRIPT_TERMINAL_ID_PREFIX)) continue;
+    candidates.push({ name, leafId: parsed.leafId });
+  }
+  if (candidates.length === 0) return;
+
+  const { conversationIds, terminalIds } = await getProjectSessionLeafIds(projectId);
+  const wantedLeafIds = new Set([...conversationIds, ...terminalIds]);
+
+  const orphans = candidates
+    .filter(({ leafId }) => !wantedLeafIds.has(leafId))
+    .map(({ name }) => name);
+
+  if (orphans.length === 0) return;
+
+  log.info('reconcileProjectTmuxSessions: reaping orphaned tmux sessions', {
+    projectId,
+    count: orphans.length,
+  });
+  await Promise.all(orphans.map((name) => killTmuxSessionTree(ctx, name)));
+}

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest';
-import { buildTmuxShellLine } from './tmux-session-name';
+import { makePtySessionId } from '@shared/core/pty/ptySessionId';
+import {
+  buildTmuxShellLine,
+  decodeTmuxSessionName,
+  makeTmuxSessionName,
+} from './tmux-session-name';
 
 describe('buildTmuxShellLine', () => {
   it('enables tmux mouse scrolling and deep history before attach', () => {
@@ -15,5 +20,26 @@ describe('buildTmuxShellLine', () => {
     expect(result).toContain('tmux -u attach-session -t \\"agent-session\\"');
     expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
     expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
+  });
+});
+
+describe('decodeTmuxSessionName', () => {
+  it('round-trips a PTY session id through make/decode', () => {
+    const sessionId = makePtySessionId('proj-1', 'task-2', 'conv-3');
+    const name = makeTmuxSessionName(sessionId);
+    expect(decodeTmuxSessionName(name)).toBe(sessionId);
+  });
+
+  it('returns null for a name without the emdash- prefix', () => {
+    expect(decodeTmuxSessionName('other-abc')).toBeNull();
+  });
+
+  it('returns null for the bare prefix', () => {
+    expect(decodeTmuxSessionName('emdash-')).toBeNull();
+  });
+
+  it('returns null when the suffix does not re-encode to the same name', () => {
+    // Contains characters that base64url-decode lossily, so the round-trip guard rejects it.
+    expect(decodeTmuxSessionName('emdash-not*base64url')).toBeNull();
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
@@ -1,7 +1,7 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import { log } from '@main/lib/logger';
 
-const TMUX_SESSION_PREFIX = 'emdash-';
+export const TMUX_SESSION_PREFIX = 'emdash-';
 const TMUX_HISTORY_LIMIT = 100_000;
 
 export function buildTmuxShellLine(sessionName: string, commandLine: string): string {
@@ -23,6 +23,25 @@ export function buildTmuxShellLine(sessionName: string, commandLine: string): st
 export function makeTmuxSessionName(sessionId: string): string {
   const encoded = Buffer.from(sessionId, 'utf8').toString('base64url');
   return `${TMUX_SESSION_PREFIX}${encoded}`;
+}
+
+/**
+ * Inverse of {@link makeTmuxSessionName}. Returns the encoded PTY session id, or
+ * `null` if the name is not a well-formed emdash tmux session name. The
+ * round-trip guard rejects anything that does not re-encode to exactly the same
+ * name, so unrelated `emdash-*` sessions are never misread as ours.
+ */
+export function decodeTmuxSessionName(sessionName: string): string | null {
+  if (!sessionName.startsWith(TMUX_SESSION_PREFIX)) return null;
+  const encoded = sessionName.slice(TMUX_SESSION_PREFIX.length);
+  if (!encoded) return null;
+  try {
+    const sessionId = Buffer.from(encoded, 'base64url').toString('utf8');
+    if (makeTmuxSessionName(sessionId) !== sessionName) return null;
+    return sessionId;
+  } catch {
+    return null;
+  }
 }
 
 export async function killTmuxSession(ctx: IExecutionContext, sessionName: string): Promise<void> {

--- a/apps/emdash-desktop/src/main/core/tasks/session-targets.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/session-targets.ts
@@ -27,3 +27,25 @@ export async function getTaskSessionLeafIds(
     terminalIds: terminalRows.map((row) => row.id),
   };
 }
+
+/**
+ * All conversation and terminal leaf ids for a project, across every task.
+ * Used by the tmux reaper to compute the set of PTY sessions that are still
+ * "wanted" — a tmux session whose leaf id is absent here no longer maps to any
+ * DB-tracked entity and is safe to reap. No archived filter on purpose: keep the
+ * wanted set as broad as possible so a still-resumable session is never reaped.
+ */
+export async function getProjectSessionLeafIds(projectId: string): Promise<TaskSessionLeafIds> {
+  const [conversationRows, terminalRows] = await Promise.all([
+    db
+      .select({ id: conversations.id })
+      .from(conversations)
+      .where(eq(conversations.projectId, projectId)),
+    db.select({ id: terminals.id }).from(terminals).where(eq(terminals.projectId, projectId)),
+  ]);
+
+  return {
+    conversationIds: conversationRows.map((row) => row.id),
+    terminalIds: terminalRows.map((row) => row.id),
+  };
+}

--- a/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -7,7 +7,8 @@ import { ptySessionRegistry, type PtySessionMetadata } from '@main/core/pty/pty-
 import { resolveSshCommand } from '@main/core/pty/spawn-utils';
 import { openSsh2Pty } from '@main/core/pty/ssh2-pty';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
-import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { killTmuxSessionTree } from '@main/core/pty/tmux-reaper';
+import { makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
 import { sshConnectionManager } from '@main/core/ssh/lifecycle/production-ssh-connection-manager';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
 import type { SshConnectionManagerEvent } from '@main/core/ssh/lifecycle/ssh-connection-manager';
@@ -346,7 +347,7 @@ export class SshTerminalProvider implements TerminalProvider {
     this.terminals.delete(terminalId);
     this.shellProfiles.delete(sessionId);
     if (this.tmux) {
-      await killTmuxSession(this.ctx, makeTmuxSessionName(sessionId));
+      await killTmuxSessionTree(this.ctx, makeTmuxSessionName(sessionId));
     }
   }
 
@@ -355,7 +356,9 @@ export class SshTerminalProvider implements TerminalProvider {
     const sessionIds = Array.from(this.knownSessionIds);
     await this.detachAll();
     if (this.tmux) {
-      await Promise.all(sessionIds.map((id) => killTmuxSession(this.ctx, makeTmuxSessionName(id))));
+      await Promise.all(
+        sessionIds.map((id) => killTmuxSessionTree(this.ctx, makeTmuxSessionName(id)))
+      );
     }
     this.knownSessionIds.clear();
     this.terminals.clear();

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -26,6 +26,7 @@ import { githubAccountRegistry } from './core/github/accounts/github-account-reg
 import { GitHubAuthServerAdapter } from './core/github/accounts/github-auth-server-adapter';
 import { projectSettingsService } from './core/projects/settings/project-settings-service';
 import { promptLibraryService } from './core/prompt-library/service';
+import { remoteTmuxReaperService } from './core/pty/remote-tmux-reaper-service';
 import { prSyncScheduler } from './core/pull-requests/pr-sync-scheduler';
 import { reconcileResourceSampler } from './core/resource-monitor/resource-sampler';
 import { searchService } from './core/search/search-service';
@@ -129,6 +130,7 @@ void app.whenReady().then(async () => {
 
   projectSettingsService.initialize();
   prSyncScheduler.initialize();
+  remoteTmuxReaperService.initialize();
   automationsService.start();
   appService.initialize();
   await appSettingsService.initialize();

--- a/apps/emdash-desktop/src/shared/core/terminals/terminals.ts
+++ b/apps/emdash-desktop/src/shared/core/terminals/terminals.ts
@@ -18,6 +18,9 @@ export type CreateTerminalParams = {
   initialSize?: { cols: number; rows: number };
 };
 
+/** Prefix for the synthetic terminal ids of workspace lifecycle scripts. */
+export const LIFECYCLE_SCRIPT_TERMINAL_ID_PREFIX = 'script-lifecycle-';
+
 export function createLifecycleScriptTerminalId(type: 'setup' | 'run' | 'teardown') {
-  return `script-lifecycle-${type}`;
+  return `${LIFECYCLE_SCRIPT_TERMINAL_ID_PREFIX}${type}`;
 }


### PR DESCRIPTION
## Problem

SSH remote agents run in detached tmux sessions on the host (`emdash-<base64url(sessionId)>`). Closing a conversation tab only **detaches** (preserve-on-close, #2281) — intentional, for resumability — but nothing ever reconciles tmux against live state, so:

- sessions for **deleted** conversations/terminals, and **every** session left behind by an app restart (in-memory tracking lost), accumulate on the host indefinitely; and
- `tmux kill-session` only SIGHUPs the pane processes, so dev servers (vite/metro/expo, watchman) that double-fork / `setsid()` survive as **port-holding orphans**.

Fixes #2580.

## Fix

- **Reconcile on SSH project mount** (`RemoteTmuxReaperService`, wired to `projectManager` `projectOpened`): list the host's `emdash-*` sessions and reap the orphans — those whose leaf entity (conversation/terminal) is gone from the DB. Safety constraints so a tmux server shared by several projects/hosts is never mis-reaped:
  - scoped to the **mounted project only** (the `projectId` is decoded from the session name);
  - **lifecycle-script** sessions (setup/run/teardown — they create tmux sessions but have no DB row) are always preserved;
  - **detached-but-still-tracked** sessions are kept, so resumability is unaffected.
  This also handles the app-restart case the issue calls out.
- **`killTmuxSessionTree`**: snapshot the pane process trees (`list-panes` + remote `ps`) **before** `kill-session`, then SIGTERM/SIGKILL the detached descendants. Wired into the explicit SSH Stop/Destroy paths and the reconciler. Reuses the `process-tree` helper from #2110.
- DB-dependent reconciliation is split from the DB-free kill helpers so the SSH providers don't transitively load the database.

## Stacked on #2591

This branch is stacked on #2591 (the `process-tree` helper). Until that merges, the diff here includes its commit — **review only the second commit** (`fix(ssh): …`). Once #2591 lands I'll rebase this onto `main`.

## Testing

`pnpm run format && pnpm run lint && pnpm run typecheck` clean; full `node` Vitest project green (255 files / 1874 tests). New unit tests cover session-name decode round-trip, `list`/tree-kill ordering, and orphan selection (live / lifecycle / foreign-project / unparseable all preserved).