### PR TITLE
fix(browser): route app shortcuts from webviews

### DIFF
--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
@@ -296,6 +296,28 @@ describe('BrowserWebContentsRegistry', () => {
     expect(events.emit).not.toHaveBeenCalledWith(browserAppShortcutChannel, expect.anything());
   });
 
+  it('does not consume Escape in focused browser webContents', () => {
+    const registry = new BrowserWebContentsRegistry();
+    registry.registerSession({ browserId: 'browser-1', partition: PROFILE_PARTITION });
+
+    const webContents = fakeWebContents();
+    registry.handleWebviewAttached(webContents);
+    registry.bindWebContents('browser-1', webContents);
+
+    const keyEvent = { preventDefault: vi.fn() };
+    webContents.emitEvent('before-input-event', keyEvent, {
+      type: 'keyDown',
+      key: 'Escape',
+      control: false,
+      shift: false,
+      alt: false,
+      meta: false,
+    });
+
+    expect(keyEvent.preventDefault).not.toHaveBeenCalled();
+    expect(events.emit).not.toHaveBeenCalledWith(browserAppShortcutChannel, expect.anything());
+  });
+
   it('clears storage for a named profile without requiring an open browser', async () => {
     const registry = new BrowserWebContentsRegistry();
 

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
@@ -1,7 +1,7 @@
 import type { WebContents } from 'electron';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { events } from '@main/lib/events';
-import { tabNavigationShortcutChannel } from '@shared/events/appEvents';
+import { browserAppShortcutChannel, tabNavigationShortcutChannel } from '@shared/events/appEvents';
 import { BrowserWebContentsRegistry } from './browser-webcontents-registry';
 
 const sessionsByPartition = new Map<string, object>();
@@ -43,6 +43,7 @@ function fakeWebContents(partition: string = PROFILE_PARTITION): FakeWebContents
     windowOpenHandler: null as FakeWebContents['windowOpenHandler'],
     close: vi.fn(),
     isDestroyed: () => false,
+    getURL: () => 'https://example.com',
     getUserAgent: () => 'base-ua',
     setUserAgent: vi.fn(),
     openDevTools: vi.fn(),
@@ -245,6 +246,54 @@ describe('BrowserWebContentsRegistry', () => {
       source: { kind: 'browser', browserId: 'browser-1' },
       direction: 'previous',
     });
+  });
+
+  it('emits app shortcuts from focused browser webContents', () => {
+    const registry = new BrowserWebContentsRegistry();
+    registry.registerSession({ browserId: 'browser-1', partition: PROFILE_PARTITION });
+
+    const webContents = fakeWebContents();
+    registry.handleWebviewAttached(webContents);
+    registry.bindWebContents('browser-1', webContents);
+
+    const keyEvent = { preventDefault: vi.fn() };
+    webContents.emitEvent('before-input-event', keyEvent, {
+      type: 'keyDown',
+      key: 'K',
+      control: false,
+      shift: false,
+      alt: false,
+      meta: true,
+    });
+
+    expect(keyEvent.preventDefault).toHaveBeenCalled();
+    expect(events.emit).toHaveBeenCalledWith(browserAppShortcutChannel, {
+      source: { kind: 'browser', browserId: 'browser-1' },
+      shortcutKey: 'commandPalette',
+    });
+  });
+
+  it('does not emit disabled app shortcuts from focused browser webContents', () => {
+    const registry = new BrowserWebContentsRegistry();
+    registry.setKeyboardSettings({ commandPalette: null });
+    registry.registerSession({ browserId: 'browser-1', partition: PROFILE_PARTITION });
+
+    const webContents = fakeWebContents();
+    registry.handleWebviewAttached(webContents);
+    registry.bindWebContents('browser-1', webContents);
+
+    const keyEvent = { preventDefault: vi.fn() };
+    webContents.emitEvent('before-input-event', keyEvent, {
+      type: 'keyDown',
+      key: 'K',
+      control: false,
+      shift: false,
+      alt: false,
+      meta: true,
+    });
+
+    expect(keyEvent.preventDefault).not.toHaveBeenCalled();
+    expect(events.emit).not.toHaveBeenCalledWith(browserAppShortcutChannel, expect.anything());
   });
 
   it('clears storage for a named profile without requiring an open browser', async () => {

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
@@ -16,12 +16,13 @@ import {
   type BrowserDataClearKind,
 } from '@shared/browser';
 import type { AppSettings } from '@shared/core/app-settings';
-import { tabNavigationShortcutChannel } from '@shared/events/appEvents';
+import { browserAppShortcutChannel, tabNavigationShortcutChannel } from '@shared/events/appEvents';
 import { browserLinkCopiedChannel, browserOpenInNewTabChannel } from '@shared/events/browserEvents';
 import {
   APP_SHORTCUTS,
   getElectronTabNavigationDirection,
   resolveDefaultHotkey,
+  type ShortcutSettingsKey,
 } from '@shared/shortcuts';
 import { isGoogleAuthUrl, userAgentForBrowserUrl } from './browser-user-agent';
 
@@ -52,7 +53,7 @@ export class BrowserWebContentsRegistry {
   private readonly browserIdByWebContentsId = new Map<number, string>();
   private readonly pendingWebContentsIds = new Set<number>();
   private activeBrowserId: string | null = null;
-  private copyBrowserUrlShortcut = getBrowserCopyUrlShortcut();
+  private browserShortcuts = getBrowserShortcuts();
 
   registerSession(input: RegisteredBrowserSession): void {
     this.sessionsByBrowserId.set(input.browserId, input);
@@ -71,7 +72,7 @@ export class BrowserWebContentsRegistry {
   }
 
   setKeyboardSettings(keyboard: AppSettings['keyboard']): void {
-    this.copyBrowserUrlShortcut = getBrowserCopyUrlShortcut(keyboard);
+    this.browserShortcuts = getBrowserShortcuts(keyboard);
   }
 
   get registeredPartitions(): ReadonlySet<string> {
@@ -229,7 +230,19 @@ export class BrowserWebContentsRegistry {
         }
       }
 
-      if (!isCopyBrowserUrlShortcut(input, this.copyBrowserUrlShortcut)) return;
+      const shortcutKey = getBrowserShortcutKey(input, this.browserShortcuts);
+      if (shortcutKey === null) return;
+
+      if (shortcutKey !== 'browserCopyUrl') {
+        const browserId = this.browserIdByWebContentsId.get(webContents.id);
+        if (!browserId) return;
+        event.preventDefault();
+        events.emit(browserAppShortcutChannel, {
+          source: { kind: 'browser', browserId },
+          shortcutKey,
+        });
+        return;
+      }
 
       const normalized = normalizeBrowserUrl(webContents.getURL(), { allowSearchQueries: false });
       if (!normalized.ok || !isExternalHttpUrl(normalized.url)) return;
@@ -377,31 +390,61 @@ function getBrowserContextTarget(
   return null;
 }
 
-function getBrowserCopyUrlShortcut(keyboard?: AppSettings['keyboard']): string | null {
-  const configured = keyboard?.browserCopyUrl;
-  if (configured === null) return null;
-  const fallback = resolveDefaultHotkey(APP_SHORTCUTS.browserCopyUrl) ?? null;
-  if (configured && !parseShortcut(configured)) {
-    log.warn('Invalid browser copy URL shortcut, falling back to default', {
-      shortcut: configured,
-    });
-    return fallback;
+type ParsedShortcut = {
+  key: string;
+  shift: boolean;
+  alt: boolean;
+  meta: boolean;
+  control: boolean;
+};
+
+function getBrowserShortcuts(
+  keyboard?: AppSettings['keyboard']
+): Map<ShortcutSettingsKey, ParsedShortcut> {
+  const shortcuts = new Map<ShortcutSettingsKey, ParsedShortcut>();
+  for (const shortcutKey of Object.keys(APP_SHORTCUTS) as ShortcutSettingsKey[]) {
+    const configured = keyboard?.[shortcutKey];
+    if (configured === null) continue;
+
+    const fallback = resolveDefaultHotkey(APP_SHORTCUTS[shortcutKey]) ?? null;
+    const hotkey = configured ?? fallback;
+    if (hotkey === null) continue;
+
+    const parsed = parseShortcut(hotkey);
+    if (parsed) {
+      shortcuts.set(shortcutKey, parsed);
+      continue;
+    }
+
+    if (configured) {
+      const parsedFallback = fallback ? parseShortcut(fallback) : null;
+      if (parsedFallback) shortcuts.set(shortcutKey, parsedFallback);
+      log.warn('Invalid browser app shortcut, falling back to default', {
+        shortcutKey,
+        shortcut: configured,
+      });
+    }
   }
-  return configured ?? fallback;
+  return shortcuts;
 }
 
-function isCopyBrowserUrlShortcut(input: Electron.Input, shortcut: string | null): boolean {
-  if (shortcut === null) return false;
-  const parsed = parseShortcut(shortcut);
-  if (!parsed) return false;
-  return (
-    input.type === 'keyDown' &&
-    normalizeInputKey(input.key) === parsed.key &&
-    Boolean(input.shift) === parsed.shift &&
-    Boolean(input.alt) === parsed.alt &&
-    Boolean(input.meta) === parsed.meta &&
-    Boolean(input.control) === parsed.control
-  );
+function getBrowserShortcutKey(
+  input: Electron.Input,
+  shortcuts: ReadonlyMap<ShortcutSettingsKey, ParsedShortcut>
+): ShortcutSettingsKey | null {
+  if (input.type !== 'keyDown') return null;
+  for (const [shortcutKey, parsed] of shortcuts) {
+    if (
+      normalizeInputKey(input.key) === parsed.key &&
+      Boolean(input.shift) === parsed.shift &&
+      Boolean(input.alt) === parsed.alt &&
+      Boolean(input.meta) === parsed.meta &&
+      Boolean(input.control) === parsed.control
+    ) {
+      return shortcutKey;
+    }
+  }
+  return null;
 }
 
 function parseShortcut(shortcut: string): {

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
@@ -403,6 +403,8 @@ function getBrowserShortcuts(
 ): Map<ShortcutSettingsKey, ParsedShortcut> {
   const shortcuts = new Map<ShortcutSettingsKey, ParsedShortcut>();
   for (const shortcutKey of Object.keys(APP_SHORTCUTS) as ShortcutSettingsKey[]) {
+    if (shortcutKey === 'closeModal') continue;
+
     const configured = keyboard?.[shortcutKey];
     if (configured === null) continue;
 

--- a/apps/emdash-desktop/src/renderer/app/workspace.tsx
+++ b/apps/emdash-desktop/src/renderer/app/workspace.tsx
@@ -1,6 +1,7 @@
 import { LeftSidebar } from '@renderer/features/sidebar/left-sidebar';
 import { CommandShortcutBinder } from '@renderer/lib/commands/command-shortcut-binder';
 import { AppKeyboardShortcuts } from '@renderer/lib/components/app-keyboard-shortcuts';
+import { BrowserAppShortcutEvents } from '@renderer/lib/components/browser-app-shortcut-events';
 import { MonacoKeyboardBridge } from '@renderer/lib/components/monaco-keyboard-bridge';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import {
@@ -18,6 +19,7 @@ export function Workspace() {
   return (
     <>
       <AppKeyboardShortcuts />
+      <BrowserAppShortcutEvents />
       <CommandShortcutBinder />
       <MonacoKeyboardBridge />
       <WorkspaceLayout

--- a/apps/emdash-desktop/src/renderer/lib/components/browser-app-shortcut-events.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/browser-app-shortcut-events.tsx
@@ -1,0 +1,102 @@
+import { useEffect } from 'react';
+import type { ViewId } from '@renderer/app/view-registry';
+import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-selectors';
+import { commandRegistry } from '@renderer/lib/commands/registry';
+import { events } from '@renderer/lib/ipc';
+import { useWorkspaceLayoutContext } from '@renderer/lib/layout/layout-provider';
+import {
+  type NavigateFnTyped,
+  type NonSettingsViewId,
+  useNavigate,
+  useParams,
+  useWorkspaceSlots,
+} from '@renderer/lib/layout/navigation-provider';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { modalStore } from '@renderer/lib/modal/modal-store';
+import { browserAppShortcutChannel } from '@shared/events/appEvents';
+import type { ShortcutSettingsKey } from '@shared/shortcuts';
+
+export function BrowserAppShortcutEvents() {
+  const showCommandPalette = useShowModal('commandPaletteModal');
+  const { toggleLeft } = useWorkspaceLayoutContext();
+  const { navigate } = useNavigate();
+  const { currentView, lastNonSettingsView } = useWorkspaceSlots();
+  const { params: taskParams } = useParams('task');
+  const { params: projectParams } = useParams('project');
+
+  const currentProjectId =
+    currentView === 'task'
+      ? taskParams.projectId
+      : currentView === 'project'
+        ? projectParams.projectId
+        : undefined;
+  const currentTaskId = currentView === 'task' ? taskParams.taskId : undefined;
+
+  useEffect(() => {
+    return events.on(browserAppShortcutChannel, ({ shortcutKey }) => {
+      if (commandRegistry.dispatch(shortcutKey)) return;
+
+      dispatchAppOnlyShortcut(shortcutKey, {
+        currentProjectId,
+        currentTaskId,
+        currentView,
+        lastNonSettingsView,
+        navigate,
+        showCommandPalette,
+        toggleLeft,
+      });
+    });
+  }, [
+    currentProjectId,
+    currentTaskId,
+    currentView,
+    lastNonSettingsView,
+    navigate,
+    showCommandPalette,
+    toggleLeft,
+  ]);
+
+  return null;
+}
+
+function dispatchAppOnlyShortcut(
+  shortcutKey: ShortcutSettingsKey,
+  context: {
+    currentProjectId: string | undefined;
+    currentTaskId: string | undefined;
+    currentView: ViewId;
+    lastNonSettingsView: NonSettingsViewId;
+    navigate: NavigateFnTyped;
+    showCommandPalette: (input: {
+      projectId?: string;
+      taskId?: string;
+      workspaceId?: string;
+    }) => void;
+    toggleLeft: () => void;
+  }
+): void {
+  switch (shortcutKey) {
+    case 'commandPalette': {
+      const workspaceId =
+        context.currentProjectId && context.currentTaskId
+          ? (getRegisteredTaskData(context.currentProjectId, context.currentTaskId)?.workspaceId ??
+            undefined)
+          : undefined;
+
+      context.showCommandPalette({
+        projectId: context.currentProjectId,
+        taskId: context.currentTaskId,
+        workspaceId,
+      });
+      break;
+    }
+    case 'toggleLeftSidebar':
+      context.toggleLeft();
+      break;
+    case 'closeModal':
+      if (context.currentView === 'settings' && !modalStore.isOpen) {
+        (context.navigate as (viewId: ViewId) => void)(context.lastNonSettingsView);
+      }
+      break;
+  }
+}

--- a/apps/emdash-desktop/src/shared/events/appEvents.ts
+++ b/apps/emdash-desktop/src/shared/events/appEvents.ts
@@ -1,6 +1,6 @@
 import type { AgentInstallationStatus } from '@shared/core/agents/agent-payload';
 import { defineEvent } from '@shared/lib/ipc/events';
-import type { TabNavigationDirection } from '@shared/shortcuts';
+import type { ShortcutSettingsKey, TabNavigationDirection } from '@shared/shortcuts';
 
 // App editing actions (renderer → main, no payload)
 export const appUndoChannel = defineEvent<void>('app:undo');
@@ -24,6 +24,11 @@ export const tabNavigationShortcutChannel = defineEvent<{
   source: { kind: 'browser'; browserId: string };
   direction: TabNavigationDirection;
 }>('tab-navigation:shortcut');
+
+export const browserAppShortcutChannel = defineEvent<{
+  source: { kind: 'browser'; browserId: string };
+  shortcutKey: ShortcutSettingsKey;
+}>('browser:app-shortcut');
 
 export const notificationFocusTaskChannel = defineEvent<{
   projectId: string;


### PR DESCRIPTION
### Description
- fixed app shortcuts not firing when in app browser has focus
- routes browser key events back to the app shortcut handling

### Screenshot/Recording (if applicable)
https://streamable.com/q0di0e

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
