### PR TITLE
fix: large linear issue descriptions crash kilo cli

### DIFF
--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -16,6 +16,7 @@ import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/pty-spawn-platform';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
+import { spillLargePrompt } from '@main/core/conversations/spill-large-prompt';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { events } from '@main/lib/events';
@@ -138,11 +139,19 @@ export class LocalConversationProvider implements ConversationProvider {
         cachedStatePath,
       });
 
+      // Very large prompts (e.g. a full Linear issue + activity context) can blow
+      // past OS argument limits and crash the underlying CLI. Spill them to a temp
+      // markdown file and hand the agent a short pointer message instead (ENG-1546).
+      const effectiveInitialPrompt =
+        !agentSession.isResuming && initialPrompt
+          ? await spillLargePrompt(initialPrompt)
+          : initialPrompt;
+
       const agentCommand = plugin.behavior.prompt!.buildCommand({
         cli: executableCli,
         extraArgs: parseExtraArgs(providerConfig?.extraArgs),
         autoApprove: conversation.autoApprove ?? false,
-        initialPrompt: agentSession.isResuming ? undefined : initialPrompt,
+        initialPrompt: agentSession.isResuming ? undefined : effectiveInitialPrompt,
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.providerSessionId ?? undefined,
         isResuming: agentSession.isResuming,
@@ -241,7 +250,7 @@ export class LocalConversationProvider implements ConversationProvider {
       scheduleInitialPromptInjection({
         pty,
         conversation,
-        initialPrompt,
+        initialPrompt: effectiveInitialPrompt,
         isResuming: agentSession.isResuming,
       });
       telemetryService.capture('agent_run_started', {

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -5,7 +5,10 @@ import { workspaceTrustService } from '@main/core/agent-hooks/workspace-trust-se
 import { getPlugin } from '@main/core/agents/plugin-registry';
 import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
-import { spillLargePrompt } from '@main/core/conversations/spill-large-prompt';
+import {
+  type SpillLargePromptResult,
+  spillLargePrompt,
+} from '@main/core/conversations/spill-large-prompt';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import { localDependencyManager } from '@main/core/dependencies/dependency-managers';
 import { hostDependencyStore } from '@main/core/dependencies/host-dependency-store';
@@ -112,6 +115,7 @@ export class LocalConversationProvider implements ConversationProvider {
     });
     if (!spawnToken) return;
 
+    let spill: SpillLargePromptResult | undefined;
     try {
       await workspaceTrustService.maybeAutoTrustLocal({
         providerId: conversation.providerId,
@@ -142,10 +146,10 @@ export class LocalConversationProvider implements ConversationProvider {
       // Very large prompts (e.g. a full Linear issue + activity context) can blow
       // past OS argument limits and crash the underlying CLI. Spill them to a temp
       // markdown file and hand the agent a short pointer message instead (ENG-1546).
-      const effectiveInitialPrompt =
-        !agentSession.isResuming && initialPrompt
-          ? await spillLargePrompt(initialPrompt)
-          : initialPrompt;
+      if (!agentSession.isResuming && initialPrompt) {
+        spill = await spillLargePrompt(initialPrompt);
+      }
+      const effectiveInitialPrompt = spill?.prompt ?? initialPrompt;
 
       const agentCommand = plugin.behavior.prompt!.buildCommand({
         cli: executableCli,
@@ -204,6 +208,8 @@ export class LocalConversationProvider implements ConversationProvider {
       });
 
       pty.onExit((info) => {
+        // The spilled context file is only needed while this process runs.
+        void spill?.cleanup();
         const decision = this.supervisor.handleExit(sessionId, pty);
         if (decision.kind === 'stale') return;
         const replacementSize = ptySessionRegistry.getLastSize(sessionId) ?? spawnSize;
@@ -260,6 +266,8 @@ export class LocalConversationProvider implements ConversationProvider {
         conversation_id: conversation.id,
       });
     } catch (error) {
+      // No PTY was created (or its onExit never fired), so clean up the temp file here.
+      void spill?.cleanup();
       this.supervisor.failSpawn(sessionId, spawnToken);
       throw error;
     }

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -5,6 +5,7 @@ import { workspaceTrustService } from '@main/core/agent-hooks/workspace-trust-se
 import { getPlugin } from '@main/core/agents/plugin-registry';
 import { ConversationSessionSupervisor } from '@main/core/conversations/conversation-session-supervisor';
 import { resolveAgentSessionCommandArgs } from '@main/core/conversations/resolve-agent-session-command';
+import { spillLargePrompt } from '@main/core/conversations/spill-large-prompt';
 import type { ConversationProvider } from '@main/core/conversations/types';
 import { localDependencyManager } from '@main/core/dependencies/dependency-managers';
 import { hostDependencyStore } from '@main/core/dependencies/host-dependency-store';
@@ -16,7 +17,6 @@ import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { logLocalPtySpawnWarnings, resolveLocalPtySpawn } from '@main/core/pty/pty-spawn-platform';
 import { getTerminalColorEnv } from '@main/core/pty/terminal-color-scheme';
 import { killTmuxSession, makeTmuxSessionName } from '@main/core/pty/tmux-session-name';
-import { spillLargePrompt } from '@main/core/conversations/spill-large-prompt';
 import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import type { ResolvedShellProfile } from '@main/core/terminal-shell/types';
 import { events } from '@main/lib/events';

--- a/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.test.ts
@@ -7,15 +7,23 @@ import {
 } from './spill-large-prompt';
 
 describe('spillLargePrompt', () => {
-  it('returns the prompt unchanged when below the threshold', async () => {
+  it('returns the prompt unchanged with a no-op cleanup when below the threshold', async () => {
     const createTempDir = vi.fn();
     const writeContextFile = vi.fn();
+    const removeTempDir = vi.fn();
 
-    const result = await spillLargePrompt('short prompt', { createTempDir, writeContextFile });
+    const result = await spillLargePrompt('short prompt', {
+      createTempDir,
+      writeContextFile,
+      removeTempDir,
+    });
 
-    expect(result).toBe('short prompt');
+    expect(result.prompt).toBe('short prompt');
     expect(createTempDir).not.toHaveBeenCalled();
     expect(writeContextFile).not.toHaveBeenCalled();
+
+    await result.cleanup();
+    expect(removeTempDir).not.toHaveBeenCalled();
   });
 
   it('returns the prompt unchanged when exactly at the threshold', async () => {
@@ -27,12 +35,13 @@ describe('spillLargePrompt', () => {
       writeContextFile,
     });
 
-    expect(result).toBe(prompt);
+    expect(result.prompt).toBe(prompt);
     expect(writeContextFile).not.toHaveBeenCalled();
   });
 
-  it('spills oversized prompts to a file and returns a pointer message', async () => {
+  it('spills oversized prompts to a file and returns a pointer message + cleanup', async () => {
     const prompt = 'y'.repeat(MAX_INLINE_PROMPT_CHARS + 1);
+    const removeTempDir = vi.fn(async () => {});
     let writtenPath = '';
     let writtenContents = '';
 
@@ -42,40 +51,49 @@ describe('spillLargePrompt', () => {
         writtenPath = filePath;
         writtenContents = contents;
       },
+      removeTempDir,
     });
 
     expect(writtenPath).toBe('/tmp/emdash-prompt-abc/task-context.md');
     expect(writtenContents).toBe(prompt);
-    expect(result).toBe(buildPromptPointerMessage('/tmp/emdash-prompt-abc/task-context.md'));
-    expect(result).toContain('/tmp/emdash-prompt-abc/task-context.md');
+    expect(result.prompt).toBe(buildPromptPointerMessage('/tmp/emdash-prompt-abc/task-context.md'));
+
+    await result.cleanup();
+    expect(removeTempDir).toHaveBeenCalledWith('/tmp/emdash-prompt-abc');
   });
 
-  it('falls back to the inline prompt and reports when writing fails', async () => {
+  it('cleans up the temp dir and falls back to inline when writing fails', async () => {
     const prompt = 'z'.repeat(MAX_INLINE_PROMPT_CHARS + 1);
     const onError = vi.fn();
+    const removeTempDir = vi.fn(async () => {});
 
     const result = await spillLargePrompt(prompt, {
       createTempDir: async () => '/tmp/emdash-prompt-fail',
       writeContextFile: async () => {
         throw new Error('disk full');
       },
+      removeTempDir,
       onError,
     });
 
-    expect(result).toBe(prompt);
+    expect(result.prompt).toBe(prompt);
+    expect(removeTempDir).toHaveBeenCalledWith('/tmp/emdash-prompt-fail');
     expect(onError).toHaveBeenCalledOnce();
     expect(onError.mock.calls[0]?.[1]).toBe(prompt.length);
   });
 
-  it('writes a readable file on disk with the default dependencies', async () => {
+  it('writes a readable file on disk and removes it on cleanup', async () => {
     const prompt = `# Context\n${'paragraph '.repeat(2000)}`;
 
     const result = await spillLargePrompt(prompt);
 
-    const match = result.match(/Read the file at (.+task-context\.md) and/);
+    const match = result.prompt.match(/Read the file at (.+task-context\.md) and/);
     expect(match).not.toBeNull();
     const filePath = match![1];
     await expect(readFile(filePath, 'utf8')).resolves.toBe(prompt);
+
+    await result.cleanup();
+    await expect(readFile(filePath, 'utf8')).rejects.toThrow();
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.test.ts
@@ -1,0 +1,88 @@
+import { readFile } from 'node:fs/promises';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildPromptPointerMessage,
+  MAX_INLINE_PROMPT_CHARS,
+  spillLargePrompt,
+} from './spill-large-prompt';
+
+describe('spillLargePrompt', () => {
+  it('returns the prompt unchanged when below the threshold', async () => {
+    const createTempDir = vi.fn();
+    const writeContextFile = vi.fn();
+
+    const result = await spillLargePrompt('short prompt', { createTempDir, writeContextFile });
+
+    expect(result).toBe('short prompt');
+    expect(createTempDir).not.toHaveBeenCalled();
+    expect(writeContextFile).not.toHaveBeenCalled();
+  });
+
+  it('returns the prompt unchanged when exactly at the threshold', async () => {
+    const writeContextFile = vi.fn();
+    const prompt = 'x'.repeat(MAX_INLINE_PROMPT_CHARS);
+
+    const result = await spillLargePrompt(prompt, {
+      createTempDir: async () => '/tmp/emdash-prompt-xyz',
+      writeContextFile,
+    });
+
+    expect(result).toBe(prompt);
+    expect(writeContextFile).not.toHaveBeenCalled();
+  });
+
+  it('spills oversized prompts to a file and returns a pointer message', async () => {
+    const prompt = 'y'.repeat(MAX_INLINE_PROMPT_CHARS + 1);
+    let writtenPath = '';
+    let writtenContents = '';
+
+    const result = await spillLargePrompt(prompt, {
+      createTempDir: async () => '/tmp/emdash-prompt-abc',
+      writeContextFile: async (filePath, contents) => {
+        writtenPath = filePath;
+        writtenContents = contents;
+      },
+    });
+
+    expect(writtenPath).toBe('/tmp/emdash-prompt-abc/task-context.md');
+    expect(writtenContents).toBe(prompt);
+    expect(result).toBe(buildPromptPointerMessage('/tmp/emdash-prompt-abc/task-context.md'));
+    expect(result).toContain('/tmp/emdash-prompt-abc/task-context.md');
+  });
+
+  it('falls back to the inline prompt and reports when writing fails', async () => {
+    const prompt = 'z'.repeat(MAX_INLINE_PROMPT_CHARS + 1);
+    const onError = vi.fn();
+
+    const result = await spillLargePrompt(prompt, {
+      createTempDir: async () => '/tmp/emdash-prompt-fail',
+      writeContextFile: async () => {
+        throw new Error('disk full');
+      },
+      onError,
+    });
+
+    expect(result).toBe(prompt);
+    expect(onError).toHaveBeenCalledOnce();
+    expect(onError.mock.calls[0]?.[1]).toBe(prompt.length);
+  });
+
+  it('writes a readable file on disk with the default dependencies', async () => {
+    const prompt = `# Context\n${'paragraph '.repeat(2000)}`;
+
+    const result = await spillLargePrompt(prompt);
+
+    const match = result.match(/Read the file at (.+task-context\.md) and/);
+    expect(match).not.toBeNull();
+    const filePath = match![1];
+    await expect(readFile(filePath, 'utf8')).resolves.toBe(prompt);
+  });
+});
+
+describe('buildPromptPointerMessage', () => {
+  it('references the file path and instructs the agent to read it', () => {
+    const message = buildPromptPointerMessage('/tmp/ctx/task-context.md');
+    expect(message).toContain('/tmp/ctx/task-context.md');
+    expect(message.toLowerCase()).toContain('read the file');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.ts
@@ -1,0 +1,75 @@
+import { mkdtemp, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { log } from '@main/lib/logger';
+
+/**
+ * Maximum initial-prompt length (in characters) we pass directly on the command
+ * line. Beyond this we spill the prompt to a temporary markdown file and hand the
+ * agent a short pointer message instead.
+ *
+ * Large prompts (e.g. a Linear issue description plus its full comment/activity
+ * context) can blow past OS argument limits and crash the underlying CLI — see
+ * ENG-1546, where Kilo Code interpreted the prompt as a path and threw
+ * ENAMETOOLONG. Spilling to a file keeps the invocation small regardless of the
+ * agent, and the agent simply reads the file to recover the full context.
+ */
+export const MAX_INLINE_PROMPT_CHARS = 16_384;
+
+const TEMP_DIR_PREFIX = 'emdash-prompt-';
+const CONTEXT_FILE_NAME = 'task-context.md';
+
+/** Build the short pointer message handed to the agent in place of a huge prompt. */
+export function buildPromptPointerMessage(filePath: string): string {
+  return (
+    `The full task context was too large to pass on the command line, so it has ` +
+    `been written to a file. Read the file at ${filePath} and complete the task ` +
+    `described in it.`
+  );
+}
+
+export type SpillLargePromptDeps = {
+  /** Threshold above which the prompt is written to a file. */
+  maxChars?: number;
+  /** Creates a unique temporary directory and returns its absolute path. */
+  createTempDir?: () => Promise<string>;
+  /** Writes the prompt contents to the given absolute file path. */
+  writeContextFile?: (filePath: string, contents: string) => Promise<void>;
+  /** Reports a failure to spill so we can fall back to passing the prompt inline. */
+  onError?: (error: unknown, promptLength: number) => void;
+};
+
+const defaultDeps: Required<SpillLargePromptDeps> = {
+  maxChars: MAX_INLINE_PROMPT_CHARS,
+  createTempDir: () => mkdtemp(join(tmpdir(), TEMP_DIR_PREFIX)),
+  writeContextFile: (filePath, contents) => writeFile(filePath, contents, 'utf8'),
+  onError: (error, promptLength) =>
+    log.warn('Failed to spill large prompt to file; passing it inline instead', {
+      error: String(error),
+      promptLength,
+    }),
+};
+
+/**
+ * If `prompt` is larger than the configured threshold, write it to a temporary
+ * markdown file and return a short pointer message instructing the agent to read
+ * that file. Otherwise (or if writing fails) return the prompt unchanged.
+ */
+export async function spillLargePrompt(
+  prompt: string,
+  deps: SpillLargePromptDeps = {}
+): Promise<string> {
+  const { maxChars, createTempDir, writeContextFile, onError } = { ...defaultDeps, ...deps };
+
+  if (prompt.length <= maxChars) return prompt;
+
+  try {
+    const dir = await createTempDir();
+    const filePath = join(dir, CONTEXT_FILE_NAME);
+    await writeContextFile(filePath, prompt);
+    return buildPromptPointerMessage(filePath);
+  } catch (error) {
+    onError(error, prompt.length);
+    return prompt;
+  }
+}

--- a/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.ts
@@ -29,13 +29,9 @@ export function buildPromptPointerMessage(filePath: string): string {
 }
 
 export type SpillLargePromptDeps = {
-  /** Threshold above which the prompt is written to a file. */
   maxChars?: number;
-  /** Creates a unique temporary directory and returns its absolute path. */
   createTempDir?: () => Promise<string>;
-  /** Writes the prompt contents to the given absolute file path. */
   writeContextFile?: (filePath: string, contents: string) => Promise<void>;
-  /** Reports a failure to spill so we can fall back to passing the prompt inline. */
   onError?: (error: unknown, promptLength: number) => void;
 };
 

--- a/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/spill-large-prompt.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, writeFile } from 'node:fs/promises';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { log } from '@main/lib/logger';
@@ -32,13 +32,24 @@ export type SpillLargePromptDeps = {
   maxChars?: number;
   createTempDir?: () => Promise<string>;
   writeContextFile?: (filePath: string, contents: string) => Promise<void>;
+  removeTempDir?: (dir: string) => Promise<void>;
   onError?: (error: unknown, promptLength: number) => void;
 };
+
+export type SpillLargePromptResult = {
+  /** Either the original prompt or a short pointer message to the spilled file. */
+  prompt: string;
+  /** Removes the temp file once the session no longer needs it (no-op if not spilled). */
+  cleanup: () => Promise<void>;
+};
+
+const noopCleanup = (): Promise<void> => Promise.resolve();
 
 const defaultDeps: Required<SpillLargePromptDeps> = {
   maxChars: MAX_INLINE_PROMPT_CHARS,
   createTempDir: () => mkdtemp(join(tmpdir(), TEMP_DIR_PREFIX)),
   writeContextFile: (filePath, contents) => writeFile(filePath, contents, 'utf8'),
+  removeTempDir: (dir) => rm(dir, { recursive: true, force: true }),
   onError: (error, promptLength) =>
     log.warn('Failed to spill large prompt to file; passing it inline instead', {
       error: String(error),
@@ -49,23 +60,33 @@ const defaultDeps: Required<SpillLargePromptDeps> = {
 /**
  * If `prompt` is larger than the configured threshold, write it to a temporary
  * markdown file and return a short pointer message instructing the agent to read
- * that file. Otherwise (or if writing fails) return the prompt unchanged.
+ * that file, plus a `cleanup` that deletes the temp dir once the session ends.
+ * Otherwise (or if writing fails) return the prompt unchanged with a no-op cleanup.
  */
 export async function spillLargePrompt(
   prompt: string,
   deps: SpillLargePromptDeps = {}
-): Promise<string> {
-  const { maxChars, createTempDir, writeContextFile, onError } = { ...defaultDeps, ...deps };
+): Promise<SpillLargePromptResult> {
+  const { maxChars, createTempDir, writeContextFile, removeTempDir, onError } = {
+    ...defaultDeps,
+    ...deps,
+  };
 
-  if (prompt.length <= maxChars) return prompt;
+  if (prompt.length <= maxChars) return { prompt, cleanup: noopCleanup };
 
+  let dir: string | undefined;
   try {
-    const dir = await createTempDir();
+    dir = await createTempDir();
     const filePath = join(dir, CONTEXT_FILE_NAME);
     await writeContextFile(filePath, prompt);
-    return buildPromptPointerMessage(filePath);
+    const createdDir = dir;
+    return {
+      prompt: buildPromptPointerMessage(filePath),
+      cleanup: () => removeTempDir(createdDir),
+    };
   } catch (error) {
+    if (dir) await removeTempDir(dir).catch(() => {});
     onError(error, prompt.length);
-    return prompt;
+    return { prompt, cleanup: noopCleanup };
   }
 }

--- a/packages/plugins/src/agents/impl/freebuff/index.ts
+++ b/packages/plugins/src/agents/impl/freebuff/index.ts
@@ -31,8 +31,9 @@ export const plugin = definePlugin(
       kind: 'none',
     },
     prompt: {
-      kind: 'argv',
-      flag: '',
+      // The freebuff CLI takes no prompt positional/flag (its only positional is
+      // the `login` command); the initial prompt is typed into the interactive TUI.
+      kind: 'keystroke',
     },
     sessions: {
       kind: 'stateless',
@@ -43,9 +44,6 @@ export const plugin = definePlugin(
 
 export const provider = registerPluginBehavior(plugin, {
   prompt: {
-    buildCommand: (ctx) =>
-      buildStandardCommand(ctx, {
-        initialPromptFlag: '',
-      }),
+    buildCommand: (ctx) => buildStandardCommand(ctx, {}),
   },
 });

--- a/packages/plugins/src/agents/impl/jules/index.ts
+++ b/packages/plugins/src/agents/impl/jules/index.ts
@@ -46,9 +46,8 @@ export const plugin = definePlugin(
 
 export const provider = registerPluginBehavior(plugin, {
   prompt: {
-    buildCommand: (ctx) =>
-      buildStandardCommand(ctx, {
-        initialPromptFlag: '',
-      }),
+    // The prompt is delivered via keystroke injection into the `jules` TUI, not
+    // as a CLI argument — `jules <text>` would be parsed as an unknown subcommand.
+    buildCommand: (ctx) => buildStandardCommand(ctx, {}),
   },
 });

--- a/packages/plugins/src/agents/impl/kilocode/index.ts
+++ b/packages/plugins/src/agents/impl/kilocode/index.ts
@@ -46,7 +46,10 @@ export const plugin = definePlugin(
     },
     prompt: {
       kind: 'argv',
-      flag: '',
+      // `kilo <positional>` is interpreted as the project directory and gets
+      // realpath()'d, which throws ENAMETOOLONG on large prompts (ENG-1546).
+      // The interactive TUI accepts the initial prompt via `--prompt` instead.
+      flag: '--prompt',
     },
     sessions: {
       kind: 'resumable',
@@ -60,7 +63,7 @@ export const provider = registerPluginBehavior(plugin, {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
         autoApproveFlag: '--auto',
-        initialPromptFlag: '',
+        initialPromptFlag: '--prompt',
         resumeFlag: '--continue',
       }),
   },

--- a/packages/plugins/src/agents/impl/prompt-delivery.test.ts
+++ b/packages/plugins/src/agents/impl/prompt-delivery.test.ts
@@ -1,0 +1,53 @@
+import type { CommandContext } from '@emdash/core/agents/plugins';
+import { describe, expect, it } from 'vitest';
+import { pluginRegistry } from '../registry';
+
+const PROMPT_TOKEN = 'PROMPT_TOKEN_eng1546';
+
+function freshCtx(overrides: Partial<CommandContext> = {}): CommandContext {
+  return {
+    cli: 'agent',
+    autoApprove: true,
+    initialPrompt: PROMPT_TOKEN,
+    sessionId: 'conv-1',
+    isResuming: false,
+    model: '',
+    ...overrides,
+  };
+}
+
+function buildArgs(id: string, ctx: CommandContext): string[] {
+  const plugin = pluginRegistry.get(id);
+  if (!plugin) throw new Error(`missing plugin: ${id}`);
+  return plugin.behavior.prompt!.buildCommand(ctx).args;
+}
+
+describe('prompt delivery (ENG-1546 regression)', () => {
+  it('kilocode passes the prompt via --prompt, never as a bare positional path', () => {
+    const plugin = pluginRegistry.get('kilocode')!;
+    expect(plugin.capabilities.prompt).toMatchObject({ kind: 'argv', flag: '--prompt' });
+
+    const args = buildArgs('kilocode', freshCtx());
+    const flagIndex = args.indexOf('--prompt');
+    expect(flagIndex).toBeGreaterThanOrEqual(0);
+    expect(args[flagIndex + 1]).toBe(PROMPT_TOKEN);
+    // The prompt must appear exactly once, and only as the value of --prompt.
+    expect(args.filter((a) => a === PROMPT_TOKEN)).toHaveLength(1);
+  });
+
+  it('does not pass the prompt positionally on resume for kilocode', () => {
+    const args = buildArgs('kilocode', freshCtx({ initialPrompt: undefined, isResuming: true }));
+    expect(args).toContain('--continue');
+    expect(args).not.toContain('--prompt');
+  });
+
+  // Keystroke agents deliver the prompt by typing into the TUI; it must never leak
+  // into argv (their CLIs reject/parse a bare positional differently).
+  it.each(['jules', 'freebuff'])('%s uses keystroke delivery and no argv prompt', (id) => {
+    const plugin = pluginRegistry.get(id)!;
+    expect(plugin.capabilities.prompt.kind).toBe('keystroke');
+
+    const args = buildArgs(id, freshCtx());
+    expect(args).not.toContain(PROMPT_TOKEN);
+  });
+});


### PR DESCRIPTION
### Description
- large prompts crashed kilo, now passed via --prompt
- prompt >16k chars split into a temp file and passed to agent with instruction to read
- also i found: jules & freebuff leaked prompts into argv, now using keystroke delivery

### Screenshot/Recording (if applicable)
https://streamable.com/woqmf7

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
