### PR TITLE
fix(conversations): reset create modal state

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
@@ -5,6 +5,7 @@ import { useAgentAutoApproveDefaults } from '@renderer/features/tasks/hooks/useA
 import { conversationRegistry } from '@renderer/features/tasks/stores/conversation-registry';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
+import { useCloseGuard } from '@renderer/lib/modal/use-close-guard';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
 import {
   DialogContentArea,
@@ -31,6 +32,8 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const autoApproveDefaults = useAgentAutoApproveDefaults();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  useCloseGuard(isSubmitting);
+
   const skipPermissions = providerId ? autoApproveDefaults.getDefault(providerId) : false;
   const titleProviderId = providerId ?? 'claude';
   const title = nextDefaultConversationTitle(
@@ -52,6 +55,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
         provider: providerId,
         title,
       });
+      setIsSubmitting(false);
       onSuccess({ conversationId: id });
     } catch {
       setError('Failed to create conversation');


### PR DESCRIPTION
### Description
- fixes new conversation modal getting stuck on "creating..."

### Screenshot/Recording (if applicable)
https://streamable.com/mt27c3

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
