### PR TITLE
feat(terminal): show HEIC conversion toast

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/pty/terminal-image-injection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/terminal-image-injection.ts
@@ -1,3 +1,4 @@
+import { toast } from 'sonner';
 import { rpc } from '@renderer/lib/ipc';
 import { log } from '@renderer/utils/logger';
 import { isHeicLikeFile, isUnstableDropPath } from './terminal-image-paths';
@@ -6,13 +7,22 @@ const MAX_DROPPED_BLOB_BYTES = 50 * 1024 * 1024;
 
 export async function resolveDroppedFile(file: File): Promise<string | null> {
   const originalPath = window.electronAPI.getPathForFile(file).trim();
-  if (originalPath && !isUnstableDropPath(originalPath) && !isHeicLikeFile(file)) {
+  const isHeicLike = isHeicLikeFile(file);
+  if (originalPath && !isUnstableDropPath(originalPath) && !isHeicLike) {
     return originalPath;
   }
   if (file.size > MAX_DROPPED_BLOB_BYTES) {
     log.warn('Dropped file is too large to persist', { size: file.size, name: file.name });
     return null;
   }
+
+  const conversionToastId = isHeicLike
+    ? toast.loading('Converting HEIC image...', {
+        description: 'Preparing a PNG for the terminal',
+        duration: Infinity,
+      })
+    : null;
+
   try {
     const bytes = new Uint8Array(await file.arrayBuffer());
     const result = await rpc.pty.persistDroppedBlob({
@@ -20,10 +30,26 @@ export async function resolveDroppedFile(file: File): Promise<string | null> {
       name: file.name,
       mimeType: file.type,
     });
-    if (result.success) return result.data.path;
+    if (result.success) {
+      if (conversionToastId !== null) {
+        toast.success('HEIC image converted', {
+          id: conversionToastId,
+          description: 'Ready to send to the agent',
+          duration: 4000,
+        });
+      }
+      return result.data.path;
+    }
     log.warn('Dropped file persist failed', { error: result.error });
   } catch (error) {
     log.warn('Dropped file arrayBuffer failed', { error });
+  }
+  if (conversionToastId !== null) {
+    toast.error('Could not convert HEIC image', {
+      id: conversionToastId,
+      description: 'Try converting it to PNG manually and drop it again.',
+      duration: 5000,
+    });
   }
   return null;
 }

--- a/apps/emdash-desktop/src/renderer/lib/pty/terminal-image-injection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/terminal-image-injection.ts
@@ -13,6 +13,12 @@ export async function resolveDroppedFile(file: File): Promise<string | null> {
   }
   if (file.size > MAX_DROPPED_BLOB_BYTES) {
     log.warn('Dropped file is too large to persist', { size: file.size, name: file.name });
+    if (isHeicLike) {
+      toast.error('HEIC image is too large', {
+        description: 'Use an image under 50 MB or convert it to PNG manually.',
+        duration: 5000,
+      });
+    }
     return null;
   }
 


### PR DESCRIPTION
### Description
- adds heic/heif conversion toast for terminal drops
- normal image drops unchanged

### Screenshot/Recording (if applicable)
https://streamable.com/j66dxc

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
