### PR TITLE
fix(hooks): avoid quoted Windows cmd body

### DIFF
--- a/packages/core/src/agents/plugins/helpers/hooks.test.ts
+++ b/packages/core/src/agents/plugins/helpers/hooks.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import {
+  EMDASH_MARKER,
+  makeNotificationHookCommand,
+  makeStdinHookCommand,
+  makeWindowsPowerShellHookCommand,
+} from './hooks';
+
+describe('hook command helpers', () => {
+  it('builds POSIX stdin hook commands', () => {
+    expect(makeStdinHookCommand('stop', { platform: 'linux' })).toBe(
+      'curl -sf -X POST ' +
+        '-H "Content-Type: application/json" ' +
+        '-H "X-Emdash-Token: $EMDASH_HOOK_TOKEN" ' +
+        '-H "X-Emdash-Pty-Id: $EMDASH_PTY_ID" ' +
+        '-H "X-Emdash-Event-Type: stop" ' +
+        '-d @- ' +
+        '"http://127.0.0.1:$EMDASH_HOOK_PORT/hook" || true'
+    );
+  });
+
+  it('builds Windows hook commands without a quoted cmd.exe body', () => {
+    const command = makeNotificationHookCommand('idle_prompt', { platform: 'win32' });
+
+    expect(command).toMatch(
+      /^cmd\.exe \/d \/c echo EMDASH_HOOK_PORT>NUL&&powershell\.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand [A-Za-z0-9+/]+=*$/
+    );
+    expect(command).toContain(EMDASH_MARKER);
+    expect(command).not.toContain('/c "');
+    expect(command).not.toContain('& powershell.exe');
+  });
+
+  it('keeps the Emdash marker visible to hook config cleanup without PowerShell args', () => {
+    const command = makeWindowsPowerShellHookCommand('Write-Output "ok"');
+
+    expect(command.startsWith(`cmd.exe /d /c echo ${EMDASH_MARKER}>NUL&&powershell.exe `)).toBe(
+      true
+    );
+  });
+});

--- a/packages/core/src/agents/plugins/helpers/hooks.ts
+++ b/packages/core/src/agents/plugins/helpers/hooks.ts
@@ -52,8 +52,15 @@ function makeWindowsHookPostCommand(eventType: string, payload: HookPostPayload)
       `'X-Emdash-Event-Type' = '${eventType}' ` +
       '} -Body $payload | Out-Null } catch { exit 0 }',
   ].join('; ');
+  return makeWindowsPowerShellHookCommand(script);
+}
+
+export function makeWindowsPowerShellHookCommand(script: string): string {
   const encoded = Buffer.from(script, 'utf16le').toString('base64');
-  return `cmd.exe /d /c "echo EMDASH_HOOK_PORT >NUL & powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encoded}"`;
+  return (
+    `cmd.exe /d /c echo ${EMDASH_MARKER}>NUL&&` +
+    `powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encoded}`
+  );
 }
 
 /** Post an event with an arbitrary payload, platform-aware. */

--- a/packages/plugins/src/agents/impl/grok/hooks.ts
+++ b/packages/plugins/src/agents/impl/grok/hooks.ts
@@ -1,4 +1,3 @@
-import { Buffer } from 'node:buffer';
 import type { PluginFs } from '@emdash/core/agents/plugins';
 import type { CanonicalHookEvent, HookRegistration } from '@emdash/core/agents/plugins';
 import {
@@ -6,6 +5,7 @@ import {
   buildNestedEntry,
   defaultHookEventParser,
   filterUserHooks,
+  makeWindowsPowerShellHookCommand,
   makeStdinHookCommand,
   readJsonConfig,
   writeJsonConfig,
@@ -28,8 +28,7 @@ function makeGrokSessionStartCommand(): string {
         "'X-Emdash-Event-Type' = 'session' " +
         '} -Body $payload | Out-Null } catch { exit 0 }',
     ].join('; ');
-    const encoded = Buffer.from(script, 'utf16le').toString('base64');
-    return `cmd.exe /d /c "echo EMDASH_HOOK_PORT >NUL & powershell.exe -NoProfile -ExecutionPolicy Bypass -EncodedCommand ${encoded}"`;
+    return makeWindowsPowerShellHookCommand(script);
   }
   return (
     'curl -sf -X POST ' +


### PR DESCRIPTION
### Description
- fix windwos hook command quoting
- share powershell hook helper

### Screenshot/Recording (if applicable)
(tested on my brothers computer, didnt screenrecord)

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
