### PR TITLE
fix(desktop): hide Windows menu bar

### DIFF
--- a/apps/emdash-desktop/src/main/app/window.ts
+++ b/apps/emdash-desktop/src/main/app/window.ts
@@ -22,6 +22,7 @@ export function createMainWindow(): BrowserWindow {
     minWidth: 700,
     minHeight: 500,
     title: PRODUCT_NAME,
+    ...(process.platform !== 'darwin' ? { autoHideMenuBar: true } : {}),
     // In production, electron-builder injects the icon from the app bundle.
     ...(import.meta.env.DEV && { icon: appIcon }),
     webPreferences: {
@@ -44,6 +45,10 @@ export function createMainWindow(): BrowserWindow {
       : {}),
     show: false,
   });
+
+  if (process.platform !== 'darwin') {
+    mainWindow.setMenuBarVisibility(false);
+  }
 
   if (import.meta.env.DEV) {
     void mainWindow.loadURL(process.env.ELECTRON_RENDERER_URL!);

--- a/apps/emdash-desktop/src/main/app/window.ts
+++ b/apps/emdash-desktop/src/main/app/window.ts
@@ -22,7 +22,6 @@ export function createMainWindow(): BrowserWindow {
     minWidth: 700,
     minHeight: 500,
     title: PRODUCT_NAME,
-    ...(process.platform !== 'darwin' ? { autoHideMenuBar: true } : {}),
     // In production, electron-builder injects the icon from the app bundle.
     ...(import.meta.env.DEV && { icon: appIcon }),
     webPreferences: {


### PR DESCRIPTION
### Description
- hide native electron menu bar on windwos and linux 
- macos application menu behavior unchanged 

### screenshot 
<img width="4284" height="5712" alt="IMG_4927 2 (1) (1)" src="https://github.com/user-attachments/assets/3918d643-0e7b-45c8-8978-b6cf6031872b" />

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
