### PR TITLE
fix(hooks): dedupe agent status sounds

### DIFF
--- a/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
@@ -75,6 +75,7 @@ async function handleSessionEvent(
 
 class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHookServiceHooks> {
   private server = new HookServer();
+  private readonly observedStatuses = new Map<string, AgentStatus>();
   private readonly _hooks = new HookCore<AgentHookServiceHooks>((name, e) =>
     log.error(`AgentHookService: ${String(name)} hook error`, e)
   );
@@ -165,10 +166,22 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
     );
 
     // Persist agent status to DB and emit simplified IPC for renderer.
-    this.on('agent:event', async (event) => {
+    this.on('agent:event', async (event, appFocused) => {
       const status = deriveAgentStatus(event);
       if (!status) return;
       const seen = status === 'idle' || status === 'working' ? 1 : 0;
+
+      const previousObservedStatus = this.observedStatuses.get(event.conversationId);
+      this.observedStatuses.set(event.conversationId, status);
+      const [current] =
+        previousObservedStatus === undefined
+          ? await db
+              .select({ agentStatus: conversations.agentStatus })
+              .from(conversations)
+              .where(eq(conversations.id, event.conversationId))
+              .limit(1)
+          : [];
+      const previousStatus = previousObservedStatus ?? current?.agentStatus;
 
       await db
         .update(conversations)
@@ -181,7 +194,8 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
         projectId: event.projectId,
         status,
         seen: seen === 1,
-        soundEvent: determineSoundEvent(event, status),
+        appFocused,
+        soundEvent: previousStatus === status ? undefined : determineSoundEvent(event, status),
       });
     });
 
@@ -203,6 +217,7 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
             .update(conversations)
             .set({ agentStatus: 'idle', agentStatusSeen: 1 })
             .where(eq(conversations.id, conversationId));
+          this.observedStatuses.set(conversationId, 'idle');
 
           events.emit(conversationAgentStatusChangedChannel, {
             conversationId,
@@ -210,6 +225,7 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
             projectId: row.projectId,
             status: 'idle',
             seen: true,
+            appFocused: isAppFocused(),
             soundEvent: undefined,
           });
         } catch (error) {

--- a/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
@@ -76,6 +76,7 @@ async function handleSessionEvent(
 class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHookServiceHooks> {
   private server = new HookServer();
   private readonly observedStatuses = new Map<string, AgentStatus>();
+  private readonly disposers: Array<() => void> = [];
   private readonly _hooks = new HookCore<AgentHookServiceHooks>((name, e) =>
     log.error(`AgentHookService: ${String(name)} hook error`, e)
   );
@@ -120,49 +121,57 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
       this.emitAgentEvent(event, appFocused);
     });
 
-    conversationEvents.on(
-      'conversation:input-submitted',
-      ({ projectId, taskId, conversationId, providerId }) => {
-        // Only synthesise a 'start' event when the plugin does not supply its own
-        // start hook (e.g. UserPromptSubmit). Providers with start-capable hooks
-        // get 'working' from the real hook event instead.
-        const plugin = getPlugin(providerId);
-        const hooksDesc = plugin?.capabilities.hooks;
-        const supportedEvents =
-          hooksDesc && hooksDesc.kind !== 'none' ? hooksDesc.supportedEvents : [];
-        const hasStartHook = supportedEvents.includes('start');
+    this.disposers.push(
+      conversationEvents.on('conversation:deleted', (conversationId) => {
+        this.observedStatuses.delete(conversationId);
+      })
+    );
 
-        if (!hasStartHook) {
-          const agentEvent: AgentEvent = {
-            type: 'start',
-            source: 'input',
-            providerId,
-            projectId,
-            taskId,
-            conversationId,
-            timestamp: Date.now(),
-            payload: {},
-          };
-          this.emitAgentEvent(agentEvent, isAppFocused());
-        }
+    this.disposers.push(
+      conversationEvents.on(
+        'conversation:input-submitted',
+        ({ projectId, taskId, conversationId, providerId }) => {
+          // Only synthesise a 'start' event when the plugin does not supply its own
+          // start hook (e.g. UserPromptSubmit). Providers with start-capable hooks
+          // get 'working' from the real hook event instead.
+          const plugin = getPlugin(providerId);
+          const hooksDesc = plugin?.capabilities.hooks;
+          const supportedEvents =
+            hooksDesc && hooksDesc.kind !== 'none' ? hooksDesc.supportedEvents : [];
+          const hasStartHook = supportedEvents.includes('start');
 
-        telemetryService.capture('agent_run_started', {
-          provider: providerId,
-          project_id: projectId,
-          task_id: taskId,
-          conversation_id: conversationId,
-        });
+          if (!hasStartHook) {
+            const agentEvent: AgentEvent = {
+              type: 'start',
+              source: 'input',
+              providerId,
+              projectId,
+              taskId,
+              conversationId,
+              timestamp: Date.now(),
+              payload: {},
+            };
+            this.emitAgentEvent(agentEvent, isAppFocused());
+          }
 
-        const now = new Date().toISOString();
-        void touchConversation(conversationId, now).then(() => {
-          events.emit(conversationChangedChannel, {
-            conversationId,
-            taskId,
-            projectId,
-            changes: { lastInteractedAt: now },
+          telemetryService.capture('agent_run_started', {
+            provider: providerId,
+            project_id: projectId,
+            task_id: taskId,
+            conversation_id: conversationId,
           });
-        });
-      }
+
+          const now = new Date().toISOString();
+          void touchConversation(conversationId, now).then(() => {
+            events.emit(conversationChangedChannel, {
+              conversationId,
+              taskId,
+              projectId,
+              changes: { lastInteractedAt: now },
+            });
+          });
+        }
+      )
     );
 
     // Persist agent status to DB and emit simplified IPC for renderer.
@@ -239,6 +248,10 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
   }
 
   dispose(): void {
+    for (const dispose of this.disposers.splice(0)) {
+      dispose();
+    }
+    this.observedStatuses.clear();
     this.server.stop();
   }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/conversation-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/conversation-manager.ts
@@ -122,7 +122,7 @@ export class ConversationManagerStore implements IDisposable {
       });
 
       if (payload.soundEvent) {
-        soundPlayer.play(payload.soundEvent, true);
+        soundPlayer.play(payload.soundEvent, payload.appFocused, payload.conversationId);
       }
     });
   }

--- a/apps/emdash-desktop/src/renderer/utils/soundPlayer.ts
+++ b/apps/emdash-desktop/src/renderer/utils/soundPlayer.ts
@@ -21,6 +21,14 @@ const recentSounds = new Map<string, number>();
 const NOTIFICATIONS_QUERY_KEY = ['appSettings', 'notifications', 'meta'] as const;
 const SOUND_DEDUPE_WINDOW_MS = 1_000;
 
+function pruneRecentSounds(now: number): void {
+  for (const [key, lastPlayedAt] of recentSounds) {
+    if (now - lastPlayedAt >= SOUND_DEDUPE_WINDOW_MS) {
+      recentSounds.delete(key);
+    }
+  }
+}
+
 function applySettings(nextSettings: NotificationSettings): void {
   const nextCustomSoundPath = nextSettings.customSoundPath?.trim() ?? '';
   const currentCustomSoundPath = settings.customSoundPath?.trim() ?? '';
@@ -175,6 +183,7 @@ export const soundPlayer = {
     if (settings.soundFocusMode === 'unfocused' && appFocused) return;
     if (dedupeKey) {
       const now = Date.now();
+      pruneRecentSounds(now);
       const key = `${event}:${dedupeKey}`;
       const lastPlayedAt = recentSounds.get(key);
       if (lastPlayedAt !== undefined && now - lastPlayedAt < SOUND_DEDUPE_WINDOW_MS) return;

--- a/apps/emdash-desktop/src/renderer/utils/soundPlayer.ts
+++ b/apps/emdash-desktop/src/renderer/utils/soundPlayer.ts
@@ -16,8 +16,10 @@ let activePreviewAudio: HTMLAudioElement | null = null;
 let activePreviewTones: Array<() => void> = [];
 let previewGeneration = 0;
 let unsubscribeSettingsCache: (() => void) | null = null;
+const recentSounds = new Map<string, number>();
 
 const NOTIFICATIONS_QUERY_KEY = ['appSettings', 'notifications', 'meta'] as const;
+const SOUND_DEDUPE_WINDOW_MS = 1_000;
 
 function applySettings(nextSettings: NotificationSettings): void {
   const nextCustomSoundPath = nextSettings.customSoundPath?.trim() ?? '';
@@ -167,10 +169,17 @@ function stopActivePreview(): void {
 }
 
 export const soundPlayer = {
-  play(event: SoundEvent, appFocused?: boolean): void {
+  play(event: SoundEvent, appFocused?: boolean, dedupeKey?: string): void {
     if (!settings.enabled) return;
     if (!settings.sound) return;
     if (settings.soundFocusMode === 'unfocused' && appFocused) return;
+    if (dedupeKey) {
+      const now = Date.now();
+      const key = `${event}:${dedupeKey}`;
+      const lastPlayedAt = recentSounds.get(key);
+      if (lastPlayedAt !== undefined && now - lastPlayedAt < SOUND_DEDUPE_WINDOW_MS) return;
+      recentSounds.set(key, now);
+    }
 
     try {
       const customSoundPath = settings.customSoundPath?.trim() ?? '';

--- a/apps/emdash-desktop/src/shared/core/conversations/conversationEvents.ts
+++ b/apps/emdash-desktop/src/shared/core/conversations/conversationEvents.ts
@@ -19,5 +19,6 @@ export const conversationAgentStatusChangedChannel = defineEvent<{
   projectId: string;
   status: AgentStatus;
   seen: boolean;
+  appFocused: boolean;
   soundEvent?: 'needs_attention' | 'task_complete';
 }>('conversation:agent-status-changed');


### PR DESCRIPTION
### Description
- dedupes repeated agent status sounds per conversation
- avoids replaying sounds whne the status did not change
- passes app focus state through status change events
- uses focus-aware sound playback in the renderer 

### Screenshot/Recording (if applicable)
https://streamable.com/hf1m8g

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
