### PR TITLE
fix(pty): link bare file paths

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
@@ -12,13 +12,10 @@ const BARE_FILE_PATTERN = '[\\w\\-.]+\\.[a-zA-Z][a-zA-Z0-9]{1,9}(?!/)';
 // Lookbehind on `:` keeps URLs (`https://...`) with WebLinksAddon.
 const FILE_PATH_PATTERN = `(?<![\\w\\-./@:])(?:${DIR_PATH_PATTERN}|${BARE_FILE_PATTERN})\\b`;
 const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
-// A bare `name.ext` token is ambiguous: `notes.md` is a file but `paris.fr` is a
-// domain. Rather than chase an ever-growing blocklist of (country-code) TLDs —
-// many of which (`.rs`, `.sh`, `.pl`, `.ml`) are also real source extensions —
-// we only treat a bare token as a file when its extension is a known file type.
-// Tokens containing a `/` keep permissive matching via DIR_PATH_PATTERN, so
-// uncommon extensions stay linkable when written as a path. The trade-off is
-// conservative: an unlisted extension simply needs a path to be clickable.
+// A bare `name.ext` is ambiguous: `notes.md` is a file, `paris.fr` a domain.
+// Allowlisting known file extensions is more robust than blocklisting TLDs (many
+// ccTLDs like `.rs`/`.sh` are also real source extensions). Paths with a `/` skip
+// this gate, so uncommon extensions stay linkable when written as a path.
 const BARE_FILE_EXTENSIONS = new Set([
   // Source code
   'ts',
@@ -245,9 +242,6 @@ function isEmbeddedInUrl(text: string, startCol: number): boolean {
   return URL_PROTOCOL_PATTERN.test(prefix.slice(tokenStart));
 }
 
-// Bare filenames (no `/`) are only linked when their extension is a known file
-// type, which keeps domains like `paris.fr` out. Paths with a separator are
-// matched permissively and skip this gate.
 function isUnsupportedBareFile(text: string): boolean {
   if (text.includes('/')) return false;
   const extension = text.slice(text.lastIndexOf('.') + 1).toLowerCase();

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
@@ -4,35 +4,183 @@ import type { ILink } from '@xterm/xterm';
 // allowed because the surrounding `/` segments already make these unambiguous.
 const DIR_PATH_PATTERN = '(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}';
 // Bare filenames with no directory (e.g. `notes.md`). The extension must be at
-// least two characters so common prose abbreviations ("e.g", "i.e", "U.S") that
-// only have a single trailing letter are not mistaken for files.
+// least two characters so common prose abbreviations ("e.g", "i.e", "U.S", "a.m")
+// that only have a single trailing letter are not mistaken for files. This
+// deliberately excludes single-char source extensions (`.c`, `.h`, `.m`, `.s`):
+// those files are still linkable when written with a directory (`src/main.c`).
 const BARE_FILE_PATTERN = '[\\w\\-.]+\\.[a-zA-Z][a-zA-Z0-9]{1,9}(?!/)';
 // Lookbehind on `:` keeps URLs (`https://...`) with WebLinksAddon.
 const FILE_PATH_PATTERN = `(?<![\\w\\-./@:])(?:${DIR_PATH_PATTERN}|${BARE_FILE_PATTERN})\\b`;
 const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
-const WEB_DOMAIN_EXTENSIONS = new Set([
-  'ai',
-  'app',
-  'biz',
-  'cloud',
-  'co',
-  'com',
-  'dev',
-  'edu',
-  'gov',
-  'info',
-  'io',
-  'me',
-  'mil',
-  'net',
-  'org',
-  'page',
-  'site',
-  'tech',
-  'to',
-  'uk',
-  'us',
-  'xyz',
+// A bare `name.ext` token is ambiguous: `notes.md` is a file but `paris.fr` is a
+// domain. Rather than chase an ever-growing blocklist of (country-code) TLDs —
+// many of which (`.rs`, `.sh`, `.pl`, `.ml`) are also real source extensions —
+// we only treat a bare token as a file when its extension is a known file type.
+// Tokens containing a `/` keep permissive matching via DIR_PATH_PATTERN, so
+// uncommon extensions stay linkable when written as a path. The trade-off is
+// conservative: an unlisted extension simply needs a path to be clickable.
+const BARE_FILE_EXTENSIONS = new Set([
+  // Source code
+  'ts',
+  'tsx',
+  'js',
+  'jsx',
+  'mjs',
+  'cjs',
+  'mts',
+  'cts',
+  'py',
+  'pyi',
+  'pyw',
+  'ipynb',
+  'rb',
+  'erb',
+  'rake',
+  'gemspec',
+  'go',
+  'rs',
+  'swift',
+  'dart',
+  'jl',
+  'zig',
+  'nim',
+  'asm',
+  'java',
+  'kt',
+  'kts',
+  'scala',
+  'groovy',
+  'clj',
+  'cljs',
+  'cljc',
+  'cpp',
+  'cxx',
+  'cc',
+  'hpp',
+  'hxx',
+  'hh',
+  'cs',
+  'php',
+  'lua',
+  'pl',
+  'pm',
+  'hs',
+  'ml',
+  'mli',
+  'ex',
+  'exs',
+  'erl',
+  'sh',
+  'bash',
+  'zsh',
+  'fish',
+  'ps1',
+  'psm1',
+  'bat',
+  'cmd',
+  'sql',
+  'prisma',
+  'vue',
+  'svelte',
+  'astro',
+  'sol',
+  'proto',
+  'graphql',
+  'gql',
+  // Config & data
+  'json',
+  'jsonc',
+  'json5',
+  'yaml',
+  'yml',
+  'toml',
+  'ini',
+  'cfg',
+  'conf',
+  'env',
+  'properties',
+  'csv',
+  'tsv',
+  'lock',
+  'gradle',
+  'plist',
+  'tf',
+  'tfvars',
+  'hcl',
+  'nix',
+  'cmake',
+  'mk',
+  'bzl',
+  // Markup, style & web
+  'html',
+  'htm',
+  'xhtml',
+  'css',
+  'scss',
+  'sass',
+  'less',
+  'styl',
+  'xml',
+  'xsl',
+  'xslt',
+  'svg',
+  // Docs
+  'md',
+  'mdx',
+  'markdown',
+  'txt',
+  'rst',
+  'adoc',
+  'tex',
+  'bib',
+  'rtf',
+  'pdf',
+  'doc',
+  'docx',
+  'ppt',
+  'pptx',
+  'xls',
+  'xlsx',
+  // Assets
+  'png',
+  'jpg',
+  'jpeg',
+  'gif',
+  'bmp',
+  'webp',
+  'ico',
+  'tiff',
+  'tif',
+  'mp3',
+  'mp4',
+  'wav',
+  'ogg',
+  'webm',
+  'mov',
+  'avi',
+  'mkv',
+  'woff',
+  'woff2',
+  'ttf',
+  'otf',
+  'eot',
+  // Misc
+  'log',
+  'diff',
+  'patch',
+  'snap',
+  'map',
+  'db',
+  'sqlite',
+  'sqlite3',
+  'zip',
+  'tar',
+  'gz',
+  'tgz',
+  'bz2',
+  'xz',
+  'bin',
+  'dat',
 ]);
 const MAX_WRAPPED_LINE_LENGTH = 4096;
 
@@ -72,7 +220,7 @@ export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): Fil
   while ((match = regex.exec(logicalLine.text)) !== null) {
     const matched = match[0];
     const startOffset = match.index;
-    if (isEmbeddedInUrl(logicalLine.text, startOffset) || isLikelyBareDomain(matched)) continue;
+    if (isEmbeddedInUrl(logicalLine.text, startOffset) || isUnsupportedBareFile(matched)) continue;
     const endOffset = startOffset + matched.length;
     const range = mapOffsetRangeToBufferRange(logicalLine, startOffset, endOffset);
     if (!range) continue;
@@ -97,10 +245,13 @@ function isEmbeddedInUrl(text: string, startCol: number): boolean {
   return URL_PROTOCOL_PATTERN.test(prefix.slice(tokenStart));
 }
 
-function isLikelyBareDomain(text: string): boolean {
+// Bare filenames (no `/`) are only linked when their extension is a known file
+// type, which keeps domains like `paris.fr` out. Paths with a separator are
+// matched permissively and skip this gate.
+function isUnsupportedBareFile(text: string): boolean {
   if (text.includes('/')) return false;
   const extension = text.slice(text.lastIndexOf('.') + 1).toLowerCase();
-  return WEB_DOMAIN_EXTENSIONS.has(extension);
+  return !BARE_FILE_EXTENSIONS.has(extension);
 }
 
 function getWrappedLogicalLine(buffer: BufferLike, bufferIndex: number): LogicalLine | null {

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
@@ -1,9 +1,39 @@
 import type { ILink } from '@xterm/xterm';
 
+// Paths containing at least one directory separator. Any extension length is
+// allowed because the surrounding `/` segments already make these unambiguous.
+const DIR_PATH_PATTERN = '(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}';
+// Bare filenames with no directory (e.g. `notes.md`). The extension must be at
+// least two characters so common prose abbreviations ("e.g", "i.e", "U.S") that
+// only have a single trailing letter are not mistaken for files.
+const BARE_FILE_PATTERN = '[\\w\\-.]+\\.[a-zA-Z][a-zA-Z0-9]{1,9}(?!/)';
 // Lookbehind on `:` keeps URLs (`https://...`) with WebLinksAddon.
-const FILE_PATH_PATTERN =
-  '(?<![\\w\\-./@:])(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
+const FILE_PATH_PATTERN = `(?<![\\w\\-./@:])(?:${DIR_PATH_PATTERN}|${BARE_FILE_PATTERN})\\b`;
 const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+const WEB_DOMAIN_EXTENSIONS = new Set([
+  'ai',
+  'app',
+  'biz',
+  'cloud',
+  'co',
+  'com',
+  'dev',
+  'edu',
+  'gov',
+  'info',
+  'io',
+  'me',
+  'mil',
+  'net',
+  'org',
+  'page',
+  'site',
+  'tech',
+  'to',
+  'uk',
+  'us',
+  'xyz',
+]);
 const MAX_WRAPPED_LINE_LENGTH = 4096;
 
 export type BufferLineLike = {
@@ -30,7 +60,8 @@ type LogicalLine = {
 
 export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): FileLinkMatch[] {
   const logicalLine = getWrappedLogicalLine(buffer, bufferLineNumber - 1);
-  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('/') === -1) {
+  // Every file reference has an extension dot; bail cheaply when there's none.
+  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('.') === -1) {
     return [];
   }
 
@@ -41,7 +72,7 @@ export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): Fil
   while ((match = regex.exec(logicalLine.text)) !== null) {
     const matched = match[0];
     const startOffset = match.index;
-    if (isEmbeddedInUrl(logicalLine.text, startOffset)) continue;
+    if (isEmbeddedInUrl(logicalLine.text, startOffset) || isLikelyBareDomain(matched)) continue;
     const endOffset = startOffset + matched.length;
     const range = mapOffsetRangeToBufferRange(logicalLine, startOffset, endOffset);
     if (!range) continue;
@@ -64,6 +95,12 @@ function isEmbeddedInUrl(text: string, startCol: number): boolean {
   const prefix = text.slice(0, startCol);
   const tokenStart = Math.max(prefix.lastIndexOf(' '), prefix.lastIndexOf('\t'), -1) + 1;
   return URL_PROTOCOL_PATTERN.test(prefix.slice(tokenStart));
+}
+
+function isLikelyBareDomain(text: string): boolean {
+  if (text.includes('/')) return false;
+  const extension = text.slice(text.lastIndexOf('.') + 1).toLowerCase();
+  return WEB_DOMAIN_EXTENSIONS.has(extension);
 }
 
 function getWrappedLogicalLine(buffer: BufferLike, bufferIndex: number): LogicalLine | null {

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-provider.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-provider.ts
@@ -11,6 +11,7 @@ type NavigatorWithUserAgentData = Navigator & {
 
 export class ActivationModifierTracker {
   private hoveredDecorations: LinkDecorations | null = null;
+  private hoveredRefresh: (() => void) | null = null;
   private pressed = false;
 
   constructor(private readonly isMac = isMacPlatform()) {}
@@ -23,8 +24,14 @@ export class ActivationModifierTracker {
   }
 
   update(event: ActivationModifierEvent): boolean {
-    this.pressed = this.isPressed(event);
+    const next = this.isPressed(event);
+    const changed = next !== this.pressed;
+    this.pressed = next;
     this.syncHoveredDecorations();
+    // xterm only re-reads link decorations on pointer events, so toggling the
+    // modifier while the pointer sits still needs an explicit repaint to
+    // show/hide the underline on the already-hovered link.
+    if (changed) this.hoveredRefresh?.();
     return this.pressed;
   }
 
@@ -32,14 +39,16 @@ export class ActivationModifierTracker {
     return isActivationModifierPressed(event, this.isMac);
   }
 
-  hover(decorations: LinkDecorations, event: ActivationModifierEvent): void {
+  hover(decorations: LinkDecorations, event: ActivationModifierEvent, refresh?: () => void): void {
     this.hoveredDecorations = decorations;
+    this.hoveredRefresh = refresh ?? null;
     this.update(event);
   }
 
   leave(decorations: LinkDecorations): void {
     if (this.hoveredDecorations === decorations) {
       this.hoveredDecorations = null;
+      this.hoveredRefresh = null;
     }
     setDecorations(decorations, false);
   }
@@ -47,6 +56,7 @@ export class ActivationModifierTracker {
   reset(): void {
     this.pressed = false;
     this.syncHoveredDecorations();
+    this.hoveredRefresh?.();
   }
 
   private syncHoveredDecorations(): void {
@@ -74,6 +84,10 @@ export class FileLinkProvider implements ILinkProvider {
     callback(links.length > 0 ? links : undefined);
   }
 
+  private refreshViewport(): void {
+    this.terminal.refresh(0, this.terminal.rows - 1);
+  }
+
   private toXtermLink(match: FileLinkMatch): ILink {
     const decorations = this.tracker.decorations();
     const link: ILink = {
@@ -81,7 +95,7 @@ export class FileLinkProvider implements ILinkProvider {
       text: match.text,
       decorations,
       hover: (event) => {
-        this.tracker.hover(link.decorations ?? decorations, event);
+        this.tracker.hover(link.decorations ?? decorations, event, () => this.refreshViewport());
       },
       leave: () => {
         this.tracker.leave(link.decorations ?? decorations);

--- a/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
@@ -234,6 +234,41 @@ describe('file link provider', () => {
     expect(decorations).toEqual({ pointerCursor: false, underline: false });
   });
 
+  it('repaints the hovered link when the modifier toggles without mouse movement', () => {
+    const tracker = new ActivationModifierTracker(true);
+    const decorations = tracker.decorations();
+    let refreshes = 0;
+
+    tracker.hover(decorations, { metaKey: false, ctrlKey: false }, () => {
+      refreshes += 1;
+    });
+    expect(refreshes).toBe(0);
+
+    tracker.update({ metaKey: true, ctrlKey: false });
+    expect(refreshes).toBe(1);
+
+    tracker.update({ metaKey: false, ctrlKey: false });
+    expect(refreshes).toBe(2);
+
+    // No change in pressed state must not trigger redundant repaints.
+    tracker.update({ metaKey: false, ctrlKey: false });
+    expect(refreshes).toBe(2);
+  });
+
+  it('stops repainting once the pointer leaves the link', () => {
+    const tracker = new ActivationModifierTracker(true);
+    const decorations = tracker.decorations();
+    let refreshes = 0;
+
+    tracker.hover(decorations, { metaKey: false, ctrlKey: false }, () => {
+      refreshes += 1;
+    });
+    tracker.leave(decorations);
+
+    tracker.update({ metaKey: true, ctrlKey: false });
+    expect(refreshes).toBe(0);
+  });
+
   it('only opens links when the activation modifier is pressed', () => {
     const openedFiles: string[] = [];
     const openedExternal: string[] = [];

--- a/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
@@ -93,7 +93,11 @@ describe('file link provider', () => {
       new MockBufferLine('  baz.ts'),
     ]);
 
-    expect(findFileLinks(buffer, 3)).toEqual([]);
+    // The bare filename is linked on its own, but it must not be joined backward
+    // into the preceding `src/foo/bar/` fragment.
+    const links = findFileLinks(buffer, 3);
+    expect(links).toHaveLength(1);
+    expect(links[0]?.text).toBe('baz.ts');
   });
 
   it('classifies absolute and home-relative paths as external', () => {
@@ -123,6 +127,57 @@ describe('file link provider', () => {
 
   it('keeps URL paths delegated to the web links addon', () => {
     const buffer = makeBuffer([new MockBufferLine('see https://example.com/src/file.ts')]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('detects bare filenames without a directory prefix', () => {
+    const buffer = makeBuffer([new MockBufferLine('UZH_Silicon_Valley_Attendees_LinkedIn.md')]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([
+      {
+        range: {
+          start: { x: 1, y: 1 },
+          end: { x: 40, y: 1 },
+        },
+        text: 'UZH_Silicon_Valley_Attendees_LinkedIn.md',
+        isExternal: false,
+      },
+    ]);
+  });
+
+  it('detects a bare filename embedded in a sentence', () => {
+    const buffer = makeBuffer([new MockBufferLine('I updated package.json for you')]);
+
+    const links = findFileLinks(buffer, 1);
+    expect(links).toHaveLength(1);
+    expect(links[0]).toMatchObject({ text: 'package.json', isExternal: false });
+  });
+
+  it('ignores prose abbreviations with single-letter extensions', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('e.g. update it, i.e. the file, etc. and the U.S. office'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('ignores version numbers without a file extension', () => {
+    const buffer = makeBuffer([new MockBufferLine('upgrade to v1.2.3 today')]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('ignores bare domains and email addresses', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('visit example.com or github.com/org/repo, email jane@example.com'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('does not link dotted directory prefixes as bare filenames', () => {
+    const buffer = makeBuffer([new MockBufferLine('read docs.v2/README before editing')]);
 
     expect(findFileLinks(buffer, 1)).toEqual([]);
   });

--- a/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
@@ -176,6 +176,28 @@ describe('file link provider', () => {
     expect(findFileLinks(buffer, 1)).toEqual([]);
   });
 
+  it('ignores bare country-code domains in prose', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('see paris.fr, hello.de, news.nl, site.ca and foo.it'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('links source files whose extension collides with a country-code TLD', () => {
+    const buffer = makeBuffer([new MockBufferLine('open main.rs and build.sh')]);
+
+    expect(findFileLinks(buffer, 1).map((link) => link.text)).toEqual(['main.rs', 'build.sh']);
+  });
+
+  it('links single-char extensions only with a directory, not bare', () => {
+    const bare = makeBuffer([new MockBufferLine('edit main.c and stdio.h')]);
+    expect(findFileLinks(bare, 1)).toEqual([]);
+
+    const withDir = makeBuffer([new MockBufferLine('edit src/main.c now')]);
+    expect(findFileLinks(withDir, 1).map((link) => link.text)).toEqual(['src/main.c']);
+  });
+
   it('does not link dotted directory prefixes as bare filenames', () => {
     const buffer = makeBuffer([new MockBufferLine('read docs.v2/README before editing')]);
 


### PR DESCRIPTION
### Description
- bare filenames are now clickable too (e.g. package.json) not just paths with `/`

### Screenshot/Recording (if applicable)
https://streamable.com/puv97j

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
