### PR TITLE
fix(agents): probe remote status before selection

### DIFF
--- a/apps/emdash-desktop/src/main/core/agents/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { agentsController } from './controller';
+
+function createManagerMock() {
+  return {
+    platform: 'macos' as const,
+    getAll: vi.fn(() => new Map()),
+    getHostDependency: vi.fn(),
+    probeCategory: vi.fn(async () => {}),
+  };
+}
+
+const managerMocks = vi.hoisted(() => ({
+  current: {
+    platform: 'macos' as const,
+    getAll: vi.fn(() => new Map()),
+    getHostDependency: vi.fn(),
+    probeCategory: vi.fn(async () => {}),
+  },
+}));
+
+vi.mock('../dependencies/dependency-managers', () => ({
+  getDependencyManager: vi.fn(async () => managerMocks.current),
+}));
+
+vi.mock('../dependencies/agent-update-service', () => ({
+  agentUpdateService: {
+    enrichHostDependency: vi.fn((_id, hostDep) => hostDep),
+  },
+}));
+
+vi.mock('../dependencies/host-dependency-store', () => ({
+  hostDependencyStore: {
+    setSelection: vi.fn(),
+  },
+}));
+
+vi.mock('../settings/provider-settings-service', () => ({
+  providerOverrideSettings: {
+    getItemWithMeta: vi.fn(),
+    updateItem: vi.fn(),
+  },
+}));
+
+vi.mock('../conversations/impl/resolve-agent-executable', () => ({
+  clearResolvedPathCache: vi.fn(),
+}));
+
+describe('agentsController.listAgentInstallationStatus', () => {
+  beforeEach(() => {
+    managerMocks.current = createManagerMock();
+    vi.clearAllMocks();
+  });
+
+  it('does not repeat category probes after an empty agent probe result', async () => {
+    await agentsController.listAgentInstallationStatus();
+    await agentsController.listAgentInstallationStatus();
+
+    expect(managerMocks.current.probeCategory).toHaveBeenCalledTimes(1);
+    expect(managerMocks.current.probeCategory).toHaveBeenCalledWith('agent');
+  });
+
+  it('deduplicates concurrent cold category probes', async () => {
+    let resolveProbe: (() => void) | undefined;
+    managerMocks.current.probeCategory.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveProbe = resolve;
+      })
+    );
+
+    const first = agentsController.listAgentInstallationStatus();
+    const second = agentsController.listAgentInstallationStatus();
+    await Promise.resolve();
+
+    expect(managerMocks.current.probeCategory).toHaveBeenCalledTimes(1);
+
+    resolveProbe?.();
+    await Promise.all([first, second]);
+
+    expect(managerMocks.current.probeCategory).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/agents/controller.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.ts
@@ -26,14 +26,28 @@ const enrichHostDep = (
   hostDep: Parameters<typeof agentUpdateService.enrichHostDependency>[1]
 ) => agentUpdateService.enrichHostDependency(id, hostDep);
 
-async function ensureAgentStatusesLoaded(
-  mgr: Awaited<ReturnType<typeof getDependencyManager>>
-): Promise<void> {
-  const hasAgentSnapshot = Array.from(mgr.getAll().values()).some(
-    (state) => state.category === 'agent'
-  );
-  if (!hasAgentSnapshot) {
-    await mgr.probeCategory('agent');
+type DependencyManager = Awaited<ReturnType<typeof getDependencyManager>>;
+
+const loadedAgentStatusManagers = new WeakSet<DependencyManager>();
+const loadingAgentStatusManagers = new WeakMap<DependencyManager, Promise<void>>();
+
+async function ensureAgentStatusesLoaded(mgr: DependencyManager): Promise<void> {
+  if (loadedAgentStatusManagers.has(mgr)) return;
+
+  const loading = loadingAgentStatusManagers.get(mgr);
+  if (loading) {
+    await loading;
+    return;
+  }
+
+  const probe = mgr.probeCategory('agent').then(() => {
+    loadedAgentStatusManagers.add(mgr);
+  });
+  loadingAgentStatusManagers.set(mgr, probe);
+  try {
+    await probe;
+  } finally {
+    loadingAgentStatusManagers.delete(mgr);
   }
 }
 

--- a/apps/emdash-desktop/src/main/core/agents/controller.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.ts
@@ -26,6 +26,17 @@ const enrichHostDep = (
   hostDep: Parameters<typeof agentUpdateService.enrichHostDependency>[1]
 ) => agentUpdateService.enrichHostDependency(id, hostDep);
 
+async function ensureAgentStatusesLoaded(
+  mgr: Awaited<ReturnType<typeof getDependencyManager>>
+): Promise<void> {
+  const hasAgentSnapshot = Array.from(mgr.getAll().values()).some(
+    (state) => state.category === 'agent'
+  );
+  if (!hasAgentSnapshot) {
+    await mgr.probeCategory('agent');
+  }
+}
+
 export const agentsController = createRPCController({
   // ── Metadata ────────────────────────────────────────────────────────────────
 
@@ -43,6 +54,7 @@ export const agentsController = createRPCController({
 
   listAgentInstallationStatus: async (connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
+    await ensureAgentStatusesLoaded(mgr);
     return Array.from(mgr.getAll().values())
       .filter((s) => s.category === 'agent')
       .map((state) => {
@@ -56,6 +68,9 @@ export const agentsController = createRPCController({
 
   getAgentInstallationStatus: async (id: string, connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
+    if (!mgr.get(id as DependencyId)) {
+      await mgr.probe(id as DependencyId);
+    }
     const state = mgr.get(id as DependencyId);
     if (!state) return null;
     const rawHostDep = mgr.getHostDependency(id as DependencyId);

--- a/apps/emdash-desktop/src/renderer/lib/stores/use-agent-installation-statuses.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/use-agent-installation-statuses.ts
@@ -60,7 +60,9 @@ export function useAgentInstallationStatuses(connectionId?: string) {
       (event: AgentInstallationStatus) => {
         if ((event.connectionId ?? undefined) !== connectionId) return;
         queryClient.setQueryData<AgentInstallationStatus[]>(key, (prev) => {
-          if (!prev) return prev;
+          if (!prev) return [event];
+          const found = prev.some((s) => s.id === event.id);
+          if (!found) return [...prev, event];
           return prev.map((s) => (s.id === event.id ? event : s));
         });
         // Also invalidate the full agents list to keep the combined payload consistent


### PR DESCRIPTION
### Description
- fixes ssh project agent detection for new conversation flow
- ensures agent installation status is probed on requested host before selection
- prevents empty remote status cache from dorpping later probe updates

### Screenshot/Recording (if applicable)
before:
<img width="1085" height="656" alt="Screenshot 2026-06-19 at 20 30 31" src="https://github.com/user-attachments/assets/bb870ff9-06b1-4219-823b-166cd37fdf0b" />

after:
<img width="1000" height="773" alt="Screenshot 2026-06-19 at 20 30 39" src="https://github.com/user-attachments/assets/dfce6655-0242-49de-9747-75329d1387ff" />

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
