### PR TITLE
fix: probe remote agents before status reads

### DIFF
--- a/apps/emdash-desktop/src/main/core/agents/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.test.ts
@@ -105,7 +105,7 @@ describe('agentsController agent status manager', () => {
 
     const result = await agentsController.listAgentInstallationStatus('ssh-1');
 
-    expect(mocks.ensureAgentDependenciesProbed).toHaveBeenCalledWith(manager, 'ssh-1');
+    expect(mocks.ensureAgentDependenciesProbed).toHaveBeenCalledWith(manager);
     expect(mocks.getDependencyManager).toHaveBeenCalledWith('ssh-1');
     expect(mocks.getDependencyManager.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.ensureAgentDependenciesProbed.mock.invocationCallOrder[0]
@@ -130,7 +130,7 @@ describe('agentsController agent status manager', () => {
 
     const result = await agentsController.getAgentInstallationStatus('codex', 'ssh-1');
 
-    expect(mocks.ensureAgentDependenciesProbed).toHaveBeenCalledWith(manager, 'ssh-1');
+    expect(mocks.ensureAgentDependenciesProbed).toHaveBeenCalledWith(manager);
     expect(mocks.getDependencyManager).toHaveBeenCalledWith('ssh-1');
     expect(mocks.getDependencyManager.mock.invocationCallOrder[0]).toBeLessThan(
       mocks.ensureAgentDependenciesProbed.mock.invocationCallOrder[0]

--- a/apps/emdash-desktop/src/main/core/agents/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.test.ts
@@ -1,0 +1,151 @@
+import type { DependencyState } from '@emdash/core/deps/runtime';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  ensureAgentDependenciesProbed: vi.fn(),
+  getDependencyManager: vi.fn(),
+  enrichHostDependency: vi.fn((_id: string, hostDep: unknown) => hostDep),
+  refreshLatestVersion: vi.fn(),
+  setSelection: vi.fn(),
+  clearResolvedPathCache: vi.fn(),
+  getItemWithMeta: vi.fn(),
+  getItem: vi.fn(),
+  updateItem: vi.fn(),
+  buildAgentPayloads: vi.fn(),
+  buildAgentPayload: vi.fn(),
+  buildAgentMetadataList: vi.fn(),
+  toAgentInstallationStatus: vi.fn(
+    (id: string, connectionId: string | undefined, state: DependencyState) => ({
+      id,
+      connectionId,
+      status: state.status,
+      version: state.version,
+      latestVersion: null,
+      updateAvailable: false,
+      command: state.path,
+      installations: [],
+      used: { kind: 'auto' },
+      usedId: 'auto',
+      installOptions: [],
+    })
+  ),
+}));
+
+vi.mock('../dependencies/dependency-managers', () => ({
+  ensureAgentDependenciesProbed: mocks.ensureAgentDependenciesProbed,
+  getDependencyManager: mocks.getDependencyManager,
+}));
+
+vi.mock('../dependencies/agent-update-service', () => ({
+  agentUpdateService: {
+    enrichHostDependency: mocks.enrichHostDependency,
+    refreshLatestVersion: mocks.refreshLatestVersion,
+  },
+}));
+
+vi.mock('../dependencies/host-dependency-store', () => ({
+  hostDependencyStore: {
+    setSelection: mocks.setSelection,
+  },
+}));
+
+vi.mock('../conversations/impl/resolve-agent-executable', () => ({
+  clearResolvedPathCache: mocks.clearResolvedPathCache,
+}));
+
+vi.mock('../settings/provider-settings-service', () => ({
+  providerOverrideSettings: {
+    getItemWithMeta: mocks.getItemWithMeta,
+    getItem: mocks.getItem,
+    updateItem: mocks.updateItem,
+  },
+}));
+
+vi.mock('./agent-payload-builder', () => ({
+  buildAgentPayloads: mocks.buildAgentPayloads,
+  buildAgentPayload: mocks.buildAgentPayload,
+  buildAgentMetadataList: mocks.buildAgentMetadataList,
+  toAgentInstallationStatus: mocks.toAgentInstallationStatus,
+}));
+
+const { agentsController } = await import('./controller');
+
+function makeState(values: Partial<DependencyState>): DependencyState {
+  return {
+    id: values.id ?? 'claude',
+    category: values.category ?? 'agent',
+    status: values.status ?? 'available',
+    version: values.version ?? null,
+    path: values.path ?? null,
+    checkedAt: values.checkedAt ?? 1,
+    error: values.error,
+  };
+}
+
+function makeManager(states: DependencyState[]) {
+  return {
+    getAll: vi.fn(() => new Map(states.map((state) => [state.id, state]))),
+    get: vi.fn((id: string) => states.find((state) => state.id === id)),
+    getHostDependency: vi.fn(() => undefined),
+    platform: 'linux',
+  };
+}
+
+describe('agentsController agent status manager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('probes remote agent dependencies before listing installation status', async () => {
+    const manager = makeManager([
+      makeState({ id: 'claude', path: '/usr/local/bin/claude' }),
+      makeState({ id: 'git', category: 'core', path: '/usr/bin/git' }),
+    ]);
+    mocks.getDependencyManager.mockResolvedValue(manager);
+
+    const result = await agentsController.listAgentInstallationStatus('ssh-1');
+
+    expect(mocks.ensureAgentDependenciesProbed).toHaveBeenCalledWith(manager, 'ssh-1');
+    expect(mocks.getDependencyManager).toHaveBeenCalledWith('ssh-1');
+    expect(mocks.getDependencyManager.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.ensureAgentDependenciesProbed.mock.invocationCallOrder[0]
+    );
+    expect(mocks.ensureAgentDependenciesProbed.mock.invocationCallOrder[0]).toBeLessThan(
+      manager.getAll.mock.invocationCallOrder[0]
+    );
+    expect(manager.getAll).toHaveBeenCalledTimes(1);
+    expect(result).toEqual([
+      expect.objectContaining({
+        id: 'claude',
+        connectionId: 'ssh-1',
+        status: 'available',
+        command: '/usr/local/bin/claude',
+      }),
+    ]);
+  });
+
+  it('probes remote agent dependencies before reading a single installation status', async () => {
+    const manager = makeManager([makeState({ id: 'codex', path: '/usr/local/bin/codex' })]);
+    mocks.getDependencyManager.mockResolvedValue(manager);
+
+    const result = await agentsController.getAgentInstallationStatus('codex', 'ssh-1');
+
+    expect(mocks.ensureAgentDependenciesProbed).toHaveBeenCalledWith(manager, 'ssh-1');
+    expect(mocks.getDependencyManager).toHaveBeenCalledWith('ssh-1');
+    expect(mocks.getDependencyManager.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.ensureAgentDependenciesProbed.mock.invocationCallOrder[0]
+    );
+    expect(mocks.ensureAgentDependenciesProbed.mock.invocationCallOrder[0]).toBeLessThan(
+      manager.get.mock.invocationCallOrder[0]
+    );
+    expect(manager.get).toHaveBeenCalledWith('codex');
+    expect(result).toEqual(
+      expect.objectContaining({
+        id: 'codex',
+        connectionId: 'ssh-1',
+        status: 'available',
+        command: '/usr/local/bin/codex',
+      })
+    );
+  });
+});

--- a/apps/emdash-desktop/src/main/core/agents/controller.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.ts
@@ -34,13 +34,13 @@ export const agentsController = createRPCController({
 
   list: async (connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
-    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr);
     return buildAgentPayloads(mgr.platform, mgr, enrichHostDep);
   },
 
   get: async (id: string, connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
-    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr);
     return buildAgentPayload(id, mgr.platform, mgr, enrichHostDep);
   },
 
@@ -48,7 +48,7 @@ export const agentsController = createRPCController({
 
   listAgentInstallationStatus: async (connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
-    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr);
     return Array.from(mgr.getAll().values())
       .filter((s) => s.category === 'agent')
       .map((state) => {
@@ -62,7 +62,7 @@ export const agentsController = createRPCController({
 
   getAgentInstallationStatus: async (id: string, connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
-    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr);
     const state = mgr.get(id as DependencyId);
     if (!state) return null;
     const rawHostDep = mgr.getHostDependency(id as DependencyId);

--- a/apps/emdash-desktop/src/main/core/agents/controller.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.ts
@@ -10,7 +10,10 @@ import type { ProviderCustomConfig } from '@shared/core/app-settings';
 import { createRPCController } from '@shared/lib/ipc/rpc';
 import { clearResolvedPathCache } from '../conversations/impl/resolve-agent-executable';
 import { agentUpdateService } from '../dependencies/agent-update-service';
-import { getDependencyManager } from '../dependencies/dependency-managers';
+import {
+  ensureAgentDependenciesProbed,
+  getDependencyManager,
+} from '../dependencies/dependency-managers';
 import { hostDependencyStore } from '../dependencies/host-dependency-store';
 import { providerOverrideSettings } from '../settings/provider-settings-service';
 import {
@@ -31,11 +34,13 @@ export const agentsController = createRPCController({
 
   list: async (connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
     return buildAgentPayloads(mgr.platform, mgr, enrichHostDep);
   },
 
   get: async (id: string, connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
     return buildAgentPayload(id, mgr.platform, mgr, enrichHostDep);
   },
 
@@ -43,6 +48,7 @@ export const agentsController = createRPCController({
 
   listAgentInstallationStatus: async (connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
     return Array.from(mgr.getAll().values())
       .filter((s) => s.category === 'agent')
       .map((state) => {
@@ -56,6 +62,7 @@ export const agentsController = createRPCController({
 
   getAgentInstallationStatus: async (id: string, connectionId?: string) => {
     const mgr = await getDependencyManager(connectionId);
+    if (connectionId) await ensureAgentDependenciesProbed(mgr, connectionId);
     const state = mgr.get(id as DependencyId);
     if (!state) return null;
     const rawHostDep = mgr.getHostDependency(id as DependencyId);

--- a/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.test.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.test.ts
@@ -131,8 +131,8 @@ describe('ensureAgentDependenciesProbed', () => {
     });
     fakeManager.probeCategory.mockReturnValue(probe);
 
-    const first = ensureAgentDependenciesProbed(manager, undefined);
-    const second = ensureAgentDependenciesProbed(manager, undefined);
+    const first = ensureAgentDependenciesProbed(manager);
+    const second = ensureAgentDependenciesProbed(manager);
     await Promise.resolve();
     await Promise.resolve();
 
@@ -151,8 +151,8 @@ describe('ensureAgentDependenciesProbed', () => {
     const manager = await getDependencyManager();
     const fakeManager = mocks.instances[0]!;
 
-    await ensureAgentDependenciesProbed(manager, undefined);
-    await ensureAgentDependenciesProbed(manager, undefined);
+    await ensureAgentDependenciesProbed(manager);
+    await ensureAgentDependenciesProbed(manager);
 
     expect(fakeManager.probeCategory).toHaveBeenCalledTimes(1);
   });
@@ -169,9 +169,109 @@ describe('ensureAgentDependenciesProbed', () => {
     const remoteManager = await getDependencyManager('ssh-1');
     expect(remoteManager.probeCategory).not.toHaveBeenCalled();
 
-    await ensureAgentDependenciesProbed(remoteManager, 'ssh-1');
+    await ensureAgentDependenciesProbed(remoteManager);
 
     expect(remoteManager.probeCategory).toHaveBeenCalledWith('agent', { refreshShellEnv: true });
     await expect(getDependencyManager('ssh-1')).resolves.toBe(remoteManager);
+  });
+
+  it('deduplicates concurrent remote manager creation', async () => {
+    const { getDependencyManager } = await import('./dependency-managers');
+    let resolveConnect: ((proxy: unknown) => void) | undefined;
+    mocks.connect.mockReturnValue(
+      new Promise((resolve) => {
+        resolveConnect = resolve;
+      })
+    );
+
+    const first = getDependencyManager('ssh-1');
+    const second = getDependencyManager('ssh-1');
+    await Promise.resolve();
+
+    expect(mocks.connect).toHaveBeenCalledTimes(1);
+
+    if (!resolveConnect) throw new Error('Connect did not start');
+    resolveConnect({});
+
+    const [firstManager, secondManager] = await Promise.all([first, second]);
+    expect(firstManager).toBe(secondManager);
+    expect(firstManager).toBe(mocks.instances[1]);
+    expect(mocks.instances).toHaveLength(2);
+  });
+
+  it('does not share in-flight probes across manager instances', async () => {
+    const { clearDependencyManager, ensureAgentDependenciesProbed, getDependencyManager } =
+      await import('./dependency-managers');
+    mocks.connect.mockResolvedValue({});
+
+    const firstManager = await getDependencyManager('ssh-1');
+    const firstFakeManager = mocks.instances[1]!;
+    clearDependencyManager('ssh-1');
+    const secondManager = await getDependencyManager('ssh-1');
+    const secondFakeManager = mocks.instances[2]!;
+
+    let resolveFirstProbe: (() => void) | undefined;
+    let resolveSecondProbe: (() => void) | undefined;
+    firstFakeManager.probeCategory.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveFirstProbe = resolve;
+      })
+    );
+    secondFakeManager.probeCategory.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveSecondProbe = resolve;
+      })
+    );
+
+    const firstProbe = ensureAgentDependenciesProbed(firstManager);
+    const secondProbe = ensureAgentDependenciesProbed(secondManager);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(firstFakeManager.probeCategory).toHaveBeenCalledTimes(1);
+    expect(secondFakeManager.probeCategory).toHaveBeenCalledTimes(1);
+
+    if (!resolveFirstProbe || !resolveSecondProbe) throw new Error('Probes did not start');
+    firstFakeManager.setAgentStates();
+    secondFakeManager.setAgentStates();
+    resolveFirstProbe();
+    resolveSecondProbe();
+    await Promise.all([firstProbe, secondProbe]);
+  });
+
+  it('clears cached remote managers explicitly', async () => {
+    const { clearDependencyManager, getDependencyManager } = await import('./dependency-managers');
+    mocks.connect.mockResolvedValue({});
+
+    const first = await getDependencyManager('ssh-1');
+    clearDependencyManager('ssh-1');
+    const second = await getDependencyManager('ssh-1');
+
+    expect(second).not.toBe(first);
+    expect(mocks.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not cache a remote manager cleared during creation', async () => {
+    const { clearDependencyManager, getDependencyManager } = await import('./dependency-managers');
+    let resolveConnect: ((proxy: unknown) => void) | undefined;
+    mocks.connect.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveConnect = resolve;
+      })
+    );
+
+    const pending = getDependencyManager('ssh-1');
+    await Promise.resolve();
+    clearDependencyManager('ssh-1');
+
+    if (!resolveConnect) throw new Error('Connect did not start');
+    resolveConnect({});
+    const clearedManager = await pending;
+
+    mocks.connect.mockResolvedValue({});
+    const nextManager = await getDependencyManager('ssh-1');
+
+    expect(nextManager).not.toBe(clearedManager);
+    expect(mocks.connect).toHaveBeenCalledTimes(2);
   });
 });

--- a/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.test.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.test.ts
@@ -251,6 +251,33 @@ describe('ensureAgentDependenciesProbed', () => {
     expect(mocks.connect).toHaveBeenCalledTimes(2);
   });
 
+  it('keeps in-flight probes deduped for a manager after cache clear', async () => {
+    const { clearDependencyManager, ensureAgentDependenciesProbed, getDependencyManager } =
+      await import('./dependency-managers');
+    mocks.connect.mockResolvedValue({});
+    const manager = await getDependencyManager('ssh-1');
+    const fakeManager = mocks.instances[1]!;
+    let resolveProbe: (() => void) | undefined;
+    fakeManager.probeCategory.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveProbe = resolve;
+      })
+    );
+
+    const first = ensureAgentDependenciesProbed(manager);
+    await Promise.resolve();
+    await Promise.resolve();
+    clearDependencyManager('ssh-1');
+    const second = ensureAgentDependenciesProbed(manager);
+
+    expect(fakeManager.probeCategory).toHaveBeenCalledTimes(1);
+
+    if (!resolveProbe) throw new Error('Probe did not start');
+    fakeManager.setAgentStates();
+    resolveProbe();
+    await Promise.all([first, second]);
+  });
+
   it('does not cache a remote manager cleared during creation', async () => {
     const { clearDependencyManager, getDependencyManager } = await import('./dependency-managers');
     let resolveConnect: ((proxy: unknown) => void) | undefined;
@@ -273,5 +300,27 @@ describe('ensureAgentDependenciesProbed', () => {
 
     expect(nextManager).not.toBe(clearedManager);
     expect(mocks.connect).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not wire desktop bridges for a remote manager cleared during creation', async () => {
+    const { clearDependencyManager, getDependencyManager } = await import('./dependency-managers');
+    let resolveConnect: ((proxy: unknown) => void) | undefined;
+    mocks.connect.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveConnect = resolve;
+      })
+    );
+
+    const pending = getDependencyManager('ssh-1');
+    await Promise.resolve();
+    clearDependencyManager('ssh-1');
+
+    if (!resolveConnect) throw new Error('Connect did not start');
+    resolveConnect({});
+    const clearedManager = await pending;
+
+    expect(clearedManager).toBe(mocks.instances[1]);
+    expect(mocks.attach).not.toHaveBeenCalledWith(clearedManager, 'ssh-1');
+    expect(clearedManager.onExecutableInvalidated.subscribe).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.test.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.test.ts
@@ -1,0 +1,177 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => {
+  const instances: Array<{
+    get: ReturnType<typeof vi.fn>;
+    probeCategory: ReturnType<typeof vi.fn>;
+    onExecutableInvalidated: { subscribe: ReturnType<typeof vi.fn> };
+    setAgentStates(): void;
+  }> = [];
+
+  class FakeHostDependencyManager {
+    private readonly states = new Map<string, { id: string; category: string }>();
+    readonly get = vi.fn((id: string) => this.states.get(id));
+    readonly probeCategory = vi.fn(async (category: string) => {
+      if (category === 'agent') {
+        this.states.set('claude', { id: 'claude', category: 'agent' });
+        this.states.set('codex', { id: 'codex', category: 'agent' });
+      }
+    });
+    readonly onExecutableInvalidated = { subscribe: vi.fn() };
+
+    setAgentStates(): void {
+      this.states.set('claude', { id: 'claude', category: 'agent' });
+      this.states.set('codex', { id: 'codex', category: 'agent' });
+    }
+
+    constructor() {
+      instances.push(this);
+    }
+  }
+
+  return {
+    instances,
+    FakeHostDependencyManager,
+    attach: vi.fn(),
+    clearResolvedPathCache: vi.fn(),
+    connect: vi.fn(),
+    getSelection: vi.fn(),
+    createLocalInstallCommandRunner: vi.fn(() => vi.fn()),
+    createSshInstallCommandRunner: vi.fn(() => vi.fn()),
+  };
+});
+
+vi.mock('@emdash/core/deps/runtime', () => ({
+  HostDependencyManager: mocks.FakeHostDependencyManager,
+}));
+
+vi.mock('@main/core/conversations/impl/resolve-agent-executable', () => ({
+  clearResolvedPathCache: mocks.clearResolvedPathCache,
+}));
+
+vi.mock('@main/core/execution-context/local-execution-context', () => ({
+  LocalExecutionContext: class {},
+}));
+
+vi.mock('@main/core/execution-context/ssh-execution-context', () => ({
+  SshExecutionContext: class {
+    async exec() {
+      return { stdout: 'Linux\n', stderr: '' };
+    }
+  },
+}));
+
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: {
+    get: vi.fn(async () => ({ defaultShell: null })),
+  },
+}));
+
+vi.mock('@main/core/ssh/lifecycle/production-ssh-connection-manager', () => ({
+  sshConnectionManager: {
+    connect: mocks.connect,
+  },
+}));
+
+vi.mock('@main/core/terminal-shell/resolver', () => ({
+  resolveLocalAutomationShellWithSystemFallback: vi.fn(async () => ({ shell: '/bin/sh' })),
+}));
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    warn: vi.fn(),
+  },
+}));
+
+vi.mock('./agent-update-service', () => ({
+  agentUpdateService: {
+    attach: mocks.attach,
+  },
+}));
+
+vi.mock('./host-dependency-store', () => ({
+  hostDependencyStore: {
+    getSelection: mocks.getSelection,
+  },
+}));
+
+vi.mock('./install-runner', () => ({
+  createLocalInstallCommandRunner: mocks.createLocalInstallCommandRunner,
+  createSshInstallCommandRunner: mocks.createSshInstallCommandRunner,
+}));
+
+vi.mock('./registry', () => ({
+  DEPENDENCIES: [
+    { id: 'claude', category: 'agent' },
+    { id: 'codex', category: 'agent' },
+    { id: 'git', category: 'core' },
+  ],
+  AGENT_DEPENDENCIES: [
+    { id: 'claude', category: 'agent' },
+    { id: 'codex', category: 'agent' },
+  ],
+  getDependencyDescriptor: vi.fn(),
+}));
+
+describe('ensureAgentDependenciesProbed', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mocks.instances.length = 0;
+  });
+
+  it('deduplicates concurrent first-use probes for the same host', async () => {
+    const { ensureAgentDependenciesProbed, getDependencyManager } =
+      await import('./dependency-managers');
+    const manager = await getDependencyManager();
+    const fakeManager = mocks.instances[0]!;
+    let resolveProbe: (() => void) | undefined;
+    const probe = new Promise<void>((resolve) => {
+      resolveProbe = resolve;
+    });
+    fakeManager.probeCategory.mockReturnValue(probe);
+
+    const first = ensureAgentDependenciesProbed(manager, undefined);
+    const second = ensureAgentDependenciesProbed(manager, undefined);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(fakeManager.probeCategory).toHaveBeenCalledTimes(1);
+    expect(fakeManager.probeCategory).toHaveBeenCalledWith('agent', { refreshShellEnv: true });
+
+    if (!resolveProbe) throw new Error('Probe did not start');
+    fakeManager.setAgentStates();
+    resolveProbe();
+    await Promise.all([first, second]);
+  });
+
+  it('does not probe again after the first probe completes', async () => {
+    const { ensureAgentDependenciesProbed, getDependencyManager } =
+      await import('./dependency-managers');
+    const manager = await getDependencyManager();
+    const fakeManager = mocks.instances[0]!;
+
+    await ensureAgentDependenciesProbed(manager, undefined);
+    await ensureAgentDependenciesProbed(manager, undefined);
+
+    expect(fakeManager.probeCategory).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps manager access separate from explicit agent probing', async () => {
+    const { ensureAgentDependenciesProbed, getDependencyManager } =
+      await import('./dependency-managers');
+    const localManager = mocks.instances[0]!;
+
+    await expect(getDependencyManager()).resolves.toBe(localManager);
+    expect(localManager.probeCategory).not.toHaveBeenCalled();
+
+    mocks.connect.mockResolvedValue({});
+    const remoteManager = await getDependencyManager('ssh-1');
+    expect(remoteManager.probeCategory).not.toHaveBeenCalled();
+
+    await ensureAgentDependenciesProbed(remoteManager, 'ssh-1');
+
+    expect(remoteManager.probeCategory).toHaveBeenCalledWith('agent', { refreshShellEnv: true });
+    await expect(getDependencyManager('ssh-1')).resolves.toBe(remoteManager);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.ts
@@ -44,7 +44,8 @@ export const localDependencyManager = new HostDependencyManager(new LocalExecuti
 wireDesktopBridges(localDependencyManager, undefined);
 
 const sshManagers = new Map<string, HostDependencyManager>();
-const agentProbePromises = new Map<string, Promise<void>>();
+const sshManagerPromises = new Map<string, Promise<HostDependencyManager>>();
+const agentProbePromises = new WeakMap<HostDependencyManager, Promise<void>>();
 
 /** Resolve the OS platform of a remote machine via a lightweight `uname -s` probe. */
 async function resolveRemotePlatform(ctx: IExecutionContext): Promise<Platform> {
@@ -60,44 +61,69 @@ async function resolveRemotePlatform(ctx: IExecutionContext): Promise<Platform> 
 
 export async function getDependencyManager(connectionId?: string): Promise<HostDependencyManager> {
   if (!connectionId) return localDependencyManager;
-  let mgr = sshManagers.get(connectionId);
-  if (!mgr) {
-    const proxy = await sshConnectionManager.connect(connectionId);
-    const sshCtx = new SshExecutionContext(proxy);
-    const platform = await resolveRemotePlatform(sshCtx);
-    mgr = new HostDependencyManager(sshCtx, {
-      runInstallCommand: createSshInstallCommandRunner(proxy),
-      connectionId,
-      platform,
-      getSelection: (depId) => hostDependencyStore.getSelection(connectionId, depId),
-      logger: log,
-      dependencies: DEPENDENCIES,
-      getDependencyDescriptor,
+  const existing = sshManagers.get(connectionId);
+  if (existing) return existing;
+
+  const pending = sshManagerPromises.get(connectionId);
+  if (pending) return pending;
+
+  const promise = createSshDependencyManager(connectionId)
+    .then((mgr) => {
+      if (sshManagerPromises.get(connectionId) === promise) {
+        sshManagers.set(connectionId, mgr);
+      }
+      return mgr;
+    })
+    .finally(() => {
+      if (sshManagerPromises.get(connectionId) === promise) {
+        sshManagerPromises.delete(connectionId);
+      }
     });
-    wireDesktopBridges(mgr, connectionId);
-    sshManagers.set(connectionId, mgr);
-  }
+  sshManagerPromises.set(connectionId, promise);
+  return promise;
+}
+
+async function createSshDependencyManager(connectionId: string): Promise<HostDependencyManager> {
+  const proxy = await sshConnectionManager.connect(connectionId);
+  const sshCtx = new SshExecutionContext(proxy);
+  const platform = await resolveRemotePlatform(sshCtx);
+  const mgr = new HostDependencyManager(sshCtx, {
+    runInstallCommand: createSshInstallCommandRunner(proxy),
+    connectionId,
+    platform,
+    getSelection: (depId) => hostDependencyStore.getSelection(connectionId, depId),
+    logger: log,
+    dependencies: DEPENDENCIES,
+    getDependencyDescriptor,
+  });
+  wireDesktopBridges(mgr, connectionId);
   return mgr;
+}
+
+export function clearDependencyManager(connectionId: string): void {
+  const manager = sshManagers.get(connectionId);
+  if (manager) {
+    agentProbePromises.delete(manager);
+  }
+  sshManagers.delete(connectionId);
+  sshManagerPromises.delete(connectionId);
 }
 
 export async function ensureAgentDependenciesProbed(
   manager: HostDependencyManager,
-  connectionId: string | undefined,
   options: DependencyProbeOptions = { refreshShellEnv: true }
 ): Promise<void> {
-  const hostKey = connectionId ?? 'local';
-
   if (AGENT_DEPENDENCIES.every((dependency) => manager.get(dependency.id) !== undefined)) return;
 
-  const existing = agentProbePromises.get(hostKey);
+  const existing = agentProbePromises.get(manager);
   if (existing) {
     await existing;
     return;
   }
 
   const promise = manager.probeCategory('agent', options).finally(() => {
-    agentProbePromises.delete(hostKey);
+    agentProbePromises.delete(manager);
   });
-  agentProbePromises.set(hostKey, promise);
+  agentProbePromises.set(manager, promise);
   await promise;
 }

--- a/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.ts
@@ -70,6 +70,7 @@ export async function getDependencyManager(connectionId?: string): Promise<HostD
   const promise = createSshDependencyManager(connectionId)
     .then((mgr) => {
       if (sshManagerPromises.get(connectionId) === promise) {
+        wireDesktopBridges(mgr, connectionId);
         sshManagers.set(connectionId, mgr);
       }
       return mgr;
@@ -96,15 +97,10 @@ async function createSshDependencyManager(connectionId: string): Promise<HostDep
     dependencies: DEPENDENCIES,
     getDependencyDescriptor,
   });
-  wireDesktopBridges(mgr, connectionId);
   return mgr;
 }
 
 export function clearDependencyManager(connectionId: string): void {
-  const manager = sshManagers.get(connectionId);
-  if (manager) {
-    agentProbePromises.delete(manager);
-  }
   sshManagers.delete(connectionId);
   sshManagerPromises.delete(connectionId);
 }

--- a/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/dependency-managers.ts
@@ -1,5 +1,5 @@
 import type { Platform } from '@emdash/core/deps';
-import { HostDependencyManager } from '@emdash/core/deps/runtime';
+import { HostDependencyManager, type DependencyProbeOptions } from '@emdash/core/deps/runtime';
 import { clearResolvedPathCache } from '@main/core/conversations/impl/resolve-agent-executable';
 import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
 import { SshExecutionContext } from '@main/core/execution-context/ssh-execution-context';
@@ -11,7 +11,7 @@ import { log } from '@main/lib/logger';
 import { agentUpdateService } from './agent-update-service';
 import { hostDependencyStore } from './host-dependency-store';
 import { createLocalInstallCommandRunner, createSshInstallCommandRunner } from './install-runner';
-import { DEPENDENCIES, getDependencyDescriptor } from './registry';
+import { DEPENDENCIES, AGENT_DEPENDENCIES, getDependencyDescriptor } from './registry';
 
 async function resolveLocalInstallShellProfile() {
   const { defaultShell } = await appSettingsService.get('terminal');
@@ -44,6 +44,7 @@ export const localDependencyManager = new HostDependencyManager(new LocalExecuti
 wireDesktopBridges(localDependencyManager, undefined);
 
 const sshManagers = new Map<string, HostDependencyManager>();
+const agentProbePromises = new Map<string, Promise<void>>();
 
 /** Resolve the OS platform of a remote machine via a lightweight `uname -s` probe. */
 async function resolveRemotePlatform(ctx: IExecutionContext): Promise<Platform> {
@@ -77,4 +78,26 @@ export async function getDependencyManager(connectionId?: string): Promise<HostD
     sshManagers.set(connectionId, mgr);
   }
   return mgr;
+}
+
+export async function ensureAgentDependenciesProbed(
+  manager: HostDependencyManager,
+  connectionId: string | undefined,
+  options: DependencyProbeOptions = { refreshShellEnv: true }
+): Promise<void> {
+  const hostKey = connectionId ?? 'local';
+
+  if (AGENT_DEPENDENCIES.every((dependency) => manager.get(dependency.id) !== undefined)) return;
+
+  const existing = agentProbePromises.get(hostKey);
+  if (existing) {
+    await existing;
+    return;
+  }
+
+  const promise = manager.probeCategory('agent', options).finally(() => {
+    agentProbePromises.delete(hostKey);
+  });
+  agentProbePromises.set(hostKey, promise);
+  await promise;
 }

--- a/apps/emdash-desktop/src/main/core/dependencies/registry.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/registry.ts
@@ -68,6 +68,9 @@ function buildAgentDependencies(): DependencyDescriptor[] {
 }
 
 export const DEPENDENCIES: DependencyDescriptor[] = buildAgentDependencies();
+export const AGENT_DEPENDENCIES = DEPENDENCIES.filter(
+  (dependency) => dependency.category === 'agent'
+);
 
 export function getDependencyDescriptor(id: string): DependencyDescriptor | undefined {
   return DEPENDENCIES.find((d) => d.id === id);

--- a/apps/emdash-desktop/src/main/core/ssh/controller.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/controller.ts
@@ -18,6 +18,7 @@ import type {
   SshHealthState,
 } from '@shared/core/ssh/ssh';
 import { createRPCController } from '@shared/lib/ipc/rpc';
+import { clearDependencyManager } from '../dependencies/dependency-managers';
 import {
   mergeSshConnectionMetadata,
   type SshConnectionMetadata,
@@ -167,6 +168,7 @@ export const sshController = createRPCController({
       throw new Error(`SSH connection is used by ${projectNames}`);
     }
 
+    clearDependencyManager(id);
     if (sshConnectionManager.getConnectionState(id) !== 'disconnected') {
       await sshConnectionManager.disconnect(id).catch((e) => {
         log.warn('sshController.deleteConnection: error disconnecting', {
@@ -190,6 +192,7 @@ export const sshController = createRPCController({
 
   /** Intentionally close a connection and stop auto-reconnect. */
   disconnect: async (connectionId: string): Promise<void> => {
+    clearDependencyManager(connectionId);
     await sshConnectionManager.disconnect(connectionId);
   },
 

--- a/apps/emdash-desktop/src/main/core/workspaces/byoi/provision-byoi-task.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/byoi/provision-byoi-task.ts
@@ -1,3 +1,4 @@
+import { clearDependencyManager } from '@main/core/dependencies/dependency-managers';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { ProjectSettingsProvider } from '@main/core/projects/settings/provider';
 import { runtimeManager } from '@main/core/runtime/runtime-manager';
@@ -104,9 +105,11 @@ export async function provisionBYOITask(
           await ctx.exec('/bin/sh', ['-c', cmd]).catch((e) => {
             log.warn(`${logPrefix}: terminate command failed`, { error: String(e) });
           });
+          clearDependencyManager(connectionId);
           await sshConnectionManager.disconnect(connectionId);
         },
         onDetach: async () => {
+          clearDependencyManager(connectionId);
           await sshConnectionManager.disconnect(connectionId);
         },
       },

--- a/apps/emdash-desktop/src/renderer/lib/stores/use-agent-installation-statuses.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/use-agent-installation-statuses.ts
@@ -60,8 +60,10 @@ export function useAgentInstallationStatuses(connectionId?: string) {
       (event: AgentInstallationStatus) => {
         if ((event.connectionId ?? undefined) !== connectionId) return;
         queryClient.setQueryData<AgentInstallationStatus[]>(key, (prev) => {
-          if (!prev) return prev;
-          return prev.map((s) => (s.id === event.id ? event : s));
+          if (!prev) return [event];
+          const existingIndex = prev.findIndex((s) => s.id === event.id);
+          if (existingIndex === -1) return [...prev, event];
+          return prev.map((s, index) => (index === existingIndex ? event : s));
         });
         // Also invalidate the full agents list to keep the combined payload consistent
         void queryClient.invalidateQueries({ queryKey: AGENTS_METADATA_QUERY_KEY });


### PR DESCRIPTION
- restores remote agent probing before remote agent metadata and installation status reads
- keeps getDependencyManager focused on manager access without hidden agent probing
- dedupes concurrent ssh dependency manager creation per connection
- dedupes agent probes by HostDependencyManager identity
- clears cached dependency managers on ssh disconnect, ssh deletion and byoi teardown
- upserts agent installation status events into an empty cache so probe updates can populate the ui