### PR TITLE
feat: bring back always auto approve toggle in settings

### DIFF
--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.test.ts
@@ -271,7 +271,7 @@ describe('portLegacySettings', () => {
       settingsStore: createSettingsStoreStub(appSqlite),
     });
 
-    expect(summary.imported).toEqual(['agentAutoApproveDefaults']);
+    expect(summary.imported).toEqual([]);
     expect(readRawSetting(appSqlite, 'agentAutoApproveDefaults')).toBeNull();
   });
 

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.test.ts
@@ -252,6 +252,29 @@ describe('portLegacySettings', () => {
     expect(readRawSetting(appSqlite, 'browserPreview')).toBe(null);
   });
 
+  it('keeps legacy disabled auto-approve on the canonical default', async () => {
+    const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legacy-settings-port-disabled-'));
+    tempDirs.push(userDataDir);
+
+    fs.writeFileSync(
+      path.join(userDataDir, 'settings.json'),
+      JSON.stringify({ tasks: { autoApproveByDefault: false } }),
+      'utf8'
+    );
+
+    const { appSqlite, appDb } = createSettingsDb();
+    openDbs.push(appSqlite);
+
+    const summary = await portLegacySettings(userDataDir, {
+      appDb,
+      appSqlite,
+      settingsStore: createSettingsStoreStub(appSqlite),
+    });
+
+    expect(summary.imported).toEqual(['agentAutoApproveDefaults']);
+    expect(readRawSetting(appSqlite, 'agentAutoApproveDefaults')).toBeNull();
+  });
+
   it('skips when settings.json is missing or invalid', async () => {
     const userDataDir = fs.mkdtempSync(path.join(os.tmpdir(), 'legacy-settings-port-missing-'));
     tempDirs.push(userDataDir);

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.test.ts
@@ -6,6 +6,7 @@ import Database from 'better-sqlite3';
 import { afterEach, describe, expect, it } from 'vitest';
 import { getDefaultForKey } from '@main/core/settings/settings-registry';
 import { computeDelta, isPlainObject, mergeDeep } from '@main/core/settings/utils';
+import { buildGlobalAutoApproveDefaults } from '@shared/core/agents/agent-auto-approve-defaults';
 import type { AppSettings, AppSettingsKey } from '@shared/core/app-settings';
 import type { PromptLibraryPrompt } from '@shared/prompt-library';
 import { createDrizzleClient } from '../../../drizzleClient';
@@ -190,8 +191,8 @@ describe('portLegacySettings', () => {
       'project.branchPrefix',
       'project.pushOnCreate',
       'tasks.autoGenerateName',
-      'tasks.autoApproveByDefault',
       'tasks.autoTrustWorktrees',
+      'agentAutoApproveDefaults',
       'notifications.enabled',
       'notifications.sound',
       'notifications.osNotifications',
@@ -210,9 +211,11 @@ describe('portLegacySettings', () => {
 
     expect(readRawSetting(appSqlite, 'tasks')).toEqual({
       autoGenerateName: false,
-      autoApproveByDefault: true,
       autoTrustWorktrees: false,
     });
+    expect(readRawSetting(appSqlite, 'agentAutoApproveDefaults')).toEqual(
+      buildGlobalAutoApproveDefaults(true)
+    );
     expect(readRawSetting(appSqlite, 'notifications')).toEqual({
       enabled: false,
       sound: false,

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import type Database from 'better-sqlite3';
 import { getDefaultForKey } from '@main/core/settings/settings-registry';
 import { isPlainObject, mergeDeep } from '@main/core/settings/utils';
+import { buildGlobalAutoApproveDefaults } from '@shared/core/agents/agent-auto-approve-defaults';
 import { isValidProviderId } from '@shared/core/agents/agent-provider-registry';
 import type { AppSettings, AppSettingsKey } from '@shared/core/app-settings';
 import { tableExists } from '../../sqlite-utils';
@@ -153,10 +154,6 @@ export async function portLegacySettings(
       patch.autoGenerateName = autoGenerateName;
       summary.imported.push('tasks.autoGenerateName');
     }
-    if (autoApproveByDefault !== null) {
-      patch.autoApproveByDefault = autoApproveByDefault;
-      summary.imported.push('tasks.autoApproveByDefault');
-    }
     if (autoTrustWorktrees !== null) {
       patch.autoTrustWorktrees = autoTrustWorktrees;
       summary.imported.push('tasks.autoTrustWorktrees');
@@ -167,6 +164,18 @@ export async function portLegacySettings(
         await updateObjectSetting(settingsStore, 'tasks', patch);
       } catch {
         summary.skipped.push('tasks:validation-failed');
+      }
+    }
+
+    if (autoApproveByDefault !== null) {
+      try {
+        await settingsStore.update(
+          'agentAutoApproveDefaults',
+          buildGlobalAutoApproveDefaults(autoApproveByDefault)
+        );
+        summary.imported.push('agentAutoApproveDefaults');
+      } catch {
+        summary.skipped.push('agentAutoApproveDefaults:validation-failed');
       }
     }
   }

--- a/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/importers/settings/importer.ts
@@ -167,7 +167,7 @@ export async function portLegacySettings(
       }
     }
 
-    if (autoApproveByDefault !== null) {
+    if (autoApproveByDefault === true) {
       try {
         await settingsStore.update(
           'agentAutoApproveDefaults',

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -15,6 +15,7 @@ import ResourceMonitorSettingsCard from './ResourceMonitorSettingsCard';
 import SidebarMetadataSettingsCard from './SidebarMetadataSettingsCard';
 import { SshConnectionsSettingsCard } from './SshConnectionsSettingsCard';
 import {
+  AutoApproveByDefaultRow,
   AutoGenerateTaskNamesRow,
   AutoTrustWorktreesRow,
   CreateBranchAndWorktreeRow,
@@ -53,6 +54,7 @@ function GeneralSettingsPage() {
       <UpdateCard />
       <TelemetryCard />
       <AutoGenerateTaskNamesRow />
+      <AutoApproveByDefaultRow />
       <AutoTrustWorktreesRow />
       <CreateBranchAndWorktreeRow />
       <PreserveTaskNameCapitalizationRow />

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
@@ -1,6 +1,7 @@
 import { Info } from 'lucide-react';
 import React from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import { useAgentAutoApproveDefaults } from '@renderer/features/tasks/hooks/useAgentAutoApproveDefaults';
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
 import { Switch } from '@renderer/lib/ui/switch';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
@@ -27,6 +28,32 @@ function InfoTooltip({ label, content }: { label: string; content: React.ReactNo
     </TooltipProvider>
   );
 }
+
+export const AutoApproveByDefaultRow: React.FC = () => {
+  const autoApproveDefaults = useAgentAutoApproveDefaults();
+
+  return (
+    <SettingRow
+      title="Auto-approve by default"
+      description="Skips permission prompts for supported agents when creating new tasks."
+      control={
+        <>
+          <ResetToDefaultButton
+            visible={autoApproveDefaults.isOverridden}
+            defaultLabel="off"
+            onReset={autoApproveDefaults.resetGlobalAutoApprove}
+            disabled={autoApproveDefaults.loading || autoApproveDefaults.saving}
+          />
+          <Switch
+            checked={autoApproveDefaults.globalAutoApproveEnabled}
+            disabled={autoApproveDefaults.loading || autoApproveDefaults.saving}
+            onCheckedChange={autoApproveDefaults.setGlobalAutoApprove}
+          />
+        </>
+      }
+    />
+  );
+};
 
 export const AutoGenerateTaskNamesRow: React.FC = () => {
   const taskSettings = useTaskSettings();

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
@@ -8,14 +8,6 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@rende
 import { ResetToDefaultButton } from './ResetToDefaultButton';
 import { SettingRow } from './SettingRow';
 
-function getAutoApproveDescription(state: 'none' | 'partial' | 'all') {
-  if (state === 'partial') {
-    return 'Skips permission prompts for supported agents when creating new tasks. Enabled for some agents; reset to turn all off or switch on to enable all supported agents.';
-  }
-
-  return 'Skips permission prompts for supported agents when creating new tasks.';
-}
-
 function InfoTooltip({ label, content }: { label: string; content: React.ReactNode }) {
   return (
     <TooltipProvider delay={150}>
@@ -39,12 +31,11 @@ function InfoTooltip({ label, content }: { label: string; content: React.ReactNo
 
 export const AutoApproveByDefaultRow: React.FC = () => {
   const autoApproveDefaults = useAgentAutoApproveDefaults();
-  const { globalAutoApproveState } = autoApproveDefaults;
 
   return (
     <SettingRow
       title="Auto-approve by default"
-      description={getAutoApproveDescription(globalAutoApproveState)}
+      description="Skips permission prompts for supported agents when creating new tasks."
       control={
         <>
           <ResetToDefaultButton

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
@@ -8,6 +8,14 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@rende
 import { ResetToDefaultButton } from './ResetToDefaultButton';
 import { SettingRow } from './SettingRow';
 
+function getAutoApproveDescription(state: 'none' | 'partial' | 'all') {
+  if (state === 'partial') {
+    return 'Skips permission prompts for supported agents when creating new tasks. Enabled for some agents; reset to turn all off or switch on to enable all supported agents.';
+  }
+
+  return 'Skips permission prompts for supported agents when creating new tasks.';
+}
+
 function InfoTooltip({ label, content }: { label: string; content: React.ReactNode }) {
   return (
     <TooltipProvider delay={150}>
@@ -31,11 +39,12 @@ function InfoTooltip({ label, content }: { label: string; content: React.ReactNo
 
 export const AutoApproveByDefaultRow: React.FC = () => {
   const autoApproveDefaults = useAgentAutoApproveDefaults();
+  const { globalAutoApproveState } = autoApproveDefaults;
 
   return (
     <SettingRow
       title="Auto-approve by default"
-      description="Skips permission prompts for supported agents when creating new tasks."
+      description={getAutoApproveDescription(globalAutoApproveState)}
       control={
         <>
           <ResetToDefaultButton

--- a/apps/emdash-desktop/src/renderer/features/settings/use-app-settings-key.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/use-app-settings-key.tsx
@@ -75,7 +75,7 @@ export function useAppSettingsKey<K extends AppSettingsKey>(key: K) {
     defaults: data?.defaults,
     overrides: data?.overrides,
     isLoading,
-    isSaving: updateMutation.isPending,
+    isSaving: updateMutation.isPending || resetMutation.isPending || resetFieldMutation.isPending,
     isOverridden: !!(data?.overrides && Object.keys(data.overrides).length > 0),
     isFieldOverridden: (field: keyof AppSettings[K]) =>
       !!(data?.overrides && field in data.overrides),

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@renderer/lib/ui/dialog';
 import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
 import { Switch } from '@renderer/lib/ui/switch';
+import { providerSupportsAutoApprove } from '@shared/core/agents/agent-auto-approve-defaults';
 import { nextDefaultConversationTitle } from './conversation-title-utils';
 import { useEffectiveProvider } from './use-effective-provider';
 
@@ -32,6 +33,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const skipPermissions = providerId ? autoApproveDefaults.getDefault(providerId) : false;
+  const showAutoApproveToggle = providerId ? providerSupportsAutoApprove(providerId) : false;
   const titleProviderId = providerId ?? 'claude';
   const title = nextDefaultConversationTitle(
     titleProviderId,
@@ -85,18 +87,22 @@ export const CreateConversationModal = observer(function CreateConversationModal
               connectionId={connectionId}
             />
           </Field>
-          <Field>
-            <div className="flex items-center gap-2">
-              <Switch
-                checked={skipPermissions}
-                disabled={!providerId || autoApproveDefaults.loading || autoApproveDefaults.saving}
-                onCheckedChange={(checked) => {
-                  if (providerId) autoApproveDefaults.setDefault(providerId, checked);
-                }}
-              />
-              <FieldLabel>Auto-approve permissions</FieldLabel>
-            </div>
-          </Field>
+          {showAutoApproveToggle ? (
+            <Field>
+              <div className="flex items-center gap-2">
+                <Switch
+                  checked={skipPermissions}
+                  disabled={
+                    !providerId || autoApproveDefaults.loading || autoApproveDefaults.saving
+                  }
+                  onCheckedChange={(checked) => {
+                    if (providerId) autoApproveDefaults.setDefault(providerId, checked);
+                  }}
+                />
+                <FieldLabel>Auto-approve permissions</FieldLabel>
+              </div>
+            </Field>
+          ) : null}
           {error && <p className="text-destructive text-xs">{error}</p>}
         </FieldGroup>
       </DialogContentArea>

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -10,6 +10,7 @@ import { Popover, PopoverContent, PopoverTrigger } from '@renderer/lib/ui/popove
 import { Textarea } from '@renderer/lib/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
+import { providerSupportsAutoApprove } from '@shared/core/agents/agent-auto-approve-defaults';
 import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
 import type { LinkedIssue } from '@shared/core/linked-issue';
 import { ProviderLogo } from '../components/issue-selector/issue-selector';
@@ -92,6 +93,9 @@ export function InitialConversationField({
   }, [includeIssueContextByDefault, linkedIssue?.identifier, linkedIssue?.provider]);
 
   const autoApprove = state.provider ? autoApproveDefaults.getDefault(state.provider) : false;
+  const showAutoApproveToggle = state.provider
+    ? providerSupportsAutoApprove(state.provider)
+    : false;
 
   const handleToggleAutoApprove = () => {
     if (!state.provider) return;
@@ -138,21 +142,23 @@ export function InitialConversationField({
                 </Button>
               )}
             />
-            <Tooltip>
-              <TooltipTrigger>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={handleToggleAutoApprove}
-                  disabled={!state.provider}
-                  data-active={autoApprove || undefined}
-                  className="transition-colors data-active:bg-background-destructive data-active:text-foreground-destructive"
-                >
-                  <CheckCheckIcon className="size-4" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent>Auto approve</TooltipContent>
-            </Tooltip>
+            {showAutoApproveToggle ? (
+              <Tooltip>
+                <TooltipTrigger>
+                  <Button
+                    variant="ghost"
+                    size="icon-xs"
+                    onClick={handleToggleAutoApprove}
+                    disabled={!state.provider}
+                    data-active={autoApprove || undefined}
+                    className="transition-colors data-active:bg-background-destructive data-active:text-foreground-destructive"
+                  >
+                    <CheckCheckIcon className="size-4" />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>Auto approve</TooltipContent>
+              </Tooltip>
+            ) : null}
           </div>
         </div>
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/hooks/useAgentAutoApproveDefaults.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/hooks/useAgentAutoApproveDefaults.ts
@@ -2,6 +2,7 @@ import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-
 import {
   buildGlobalAutoApproveDefaults,
   getAgentAutoApproveDefault,
+  getGlobalAutoApproveState,
   isGlobalAutoApproveEnabled,
 } from '@shared/core/agents/agent-auto-approve-defaults';
 import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
@@ -11,12 +12,14 @@ export function useAgentAutoApproveDefaults() {
     'agentAutoApproveDefaults'
   );
   const defaults = value ?? {};
+  const globalAutoApproveState = getGlobalAutoApproveState(defaults);
 
   return {
     defaults,
     loading: isLoading,
     saving: isSaving,
     isOverridden,
+    globalAutoApproveState,
     globalAutoApproveEnabled: isGlobalAutoApproveEnabled(defaults),
     getDefault: (providerId: AgentProviderId) => getAgentAutoApproveDefault(defaults, providerId),
     setDefault: (providerId: AgentProviderId, enabled: boolean) =>

--- a/apps/emdash-desktop/src/renderer/features/tasks/hooks/useAgentAutoApproveDefaults.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/hooks/useAgentAutoApproveDefaults.ts
@@ -2,7 +2,6 @@ import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-
 import {
   buildGlobalAutoApproveDefaults,
   getAgentAutoApproveDefault,
-  getGlobalAutoApproveState,
   isGlobalAutoApproveEnabled,
 } from '@shared/core/agents/agent-auto-approve-defaults';
 import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
@@ -12,14 +11,12 @@ export function useAgentAutoApproveDefaults() {
     'agentAutoApproveDefaults'
   );
   const defaults = value ?? {};
-  const globalAutoApproveState = getGlobalAutoApproveState(defaults);
 
   return {
     defaults,
     loading: isLoading,
     saving: isSaving,
     isOverridden,
-    globalAutoApproveState,
     globalAutoApproveEnabled: isGlobalAutoApproveEnabled(defaults),
     getDefault: (providerId: AgentProviderId) => getAgentAutoApproveDefault(defaults, providerId),
     setDefault: (providerId: AgentProviderId, enabled: boolean) =>

--- a/apps/emdash-desktop/src/renderer/features/tasks/hooks/useAgentAutoApproveDefaults.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/hooks/useAgentAutoApproveDefaults.ts
@@ -1,17 +1,33 @@
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
-import { getAgentAutoApproveDefault } from '@shared/core/agents/agent-auto-approve-defaults';
+import {
+  buildGlobalAutoApproveDefaults,
+  getAgentAutoApproveDefault,
+  isGlobalAutoApproveEnabled,
+} from '@shared/core/agents/agent-auto-approve-defaults';
 import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
 
 export function useAgentAutoApproveDefaults() {
-  const { value, isLoading, isSaving, update } = useAppSettingsKey('agentAutoApproveDefaults');
+  const { value, isLoading, isSaving, isOverridden, update, reset } = useAppSettingsKey(
+    'agentAutoApproveDefaults'
+  );
   const defaults = value ?? {};
 
   return {
     defaults,
     loading: isLoading,
     saving: isSaving,
+    isOverridden,
+    globalAutoApproveEnabled: isGlobalAutoApproveEnabled(defaults),
     getDefault: (providerId: AgentProviderId) => getAgentAutoApproveDefault(defaults, providerId),
     setDefault: (providerId: AgentProviderId, enabled: boolean) =>
       update({ [providerId]: enabled }),
+    setGlobalAutoApprove: (enabled: boolean) => {
+      if (enabled) {
+        update(buildGlobalAutoApproveDefaults(true));
+        return;
+      }
+      reset();
+    },
+    resetGlobalAutoApprove: () => reset(),
   };
 }

--- a/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.test.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.test.ts
@@ -2,7 +2,6 @@ import { describe, expect, it } from 'vitest';
 import {
   buildGlobalAutoApproveDefaults,
   getAgentAutoApproveDefault,
-  getGlobalAutoApproveState,
   isGlobalAutoApproveEnabled,
   providerSupportsAutoApprove,
   resolveAgentAutoApprove,
@@ -18,20 +17,16 @@ describe('agent-auto-approve-defaults', () => {
     const enabled = buildGlobalAutoApproveDefaults(true);
     expect(getAgentAutoApproveDefault(enabled, 'claude')).toBe(true);
     expect(getAgentAutoApproveDefault(enabled, 'jules')).toBe(false);
-    expect(getGlobalAutoApproveState(enabled)).toBe('all');
     expect(isGlobalAutoApproveEnabled(enabled)).toBe(true);
   });
 
   it('uses the empty canonical default when global auto-approve is disabled', () => {
     expect(buildGlobalAutoApproveDefaults(false)).toEqual({});
-    expect(getGlobalAutoApproveState(undefined)).toBe('none');
-    expect(getGlobalAutoApproveState({})).toBe('none');
     expect(isGlobalAutoApproveEnabled(undefined)).toBe(false);
     expect(isGlobalAutoApproveEnabled({})).toBe(false);
   });
 
-  it('distinguishes partial auto-approve defaults from globally enabled', () => {
-    expect(getGlobalAutoApproveState({ claude: true })).toBe('partial');
+  it('does not treat per-agent defaults as globally enabled', () => {
     expect(isGlobalAutoApproveEnabled({ claude: true })).toBe(false);
   });
 

--- a/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.test.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   buildGlobalAutoApproveDefaults,
   getAgentAutoApproveDefault,
+  getGlobalAutoApproveState,
   isGlobalAutoApproveEnabled,
   providerSupportsAutoApprove,
   resolveAgentAutoApprove,
@@ -17,12 +18,21 @@ describe('agent-auto-approve-defaults', () => {
     const enabled = buildGlobalAutoApproveDefaults(true);
     expect(getAgentAutoApproveDefault(enabled, 'claude')).toBe(true);
     expect(getAgentAutoApproveDefault(enabled, 'jules')).toBe(false);
+    expect(getGlobalAutoApproveState(enabled)).toBe('all');
     expect(isGlobalAutoApproveEnabled(enabled)).toBe(true);
   });
 
-  it('treats empty defaults as global auto-approve disabled', () => {
+  it('uses the empty canonical default when global auto-approve is disabled', () => {
+    expect(buildGlobalAutoApproveDefaults(false)).toEqual({});
+    expect(getGlobalAutoApproveState(undefined)).toBe('none');
+    expect(getGlobalAutoApproveState({})).toBe('none');
     expect(isGlobalAutoApproveEnabled(undefined)).toBe(false);
     expect(isGlobalAutoApproveEnabled({})).toBe(false);
+  });
+
+  it('distinguishes partial auto-approve defaults from globally enabled', () => {
+    expect(getGlobalAutoApproveState({ claude: true })).toBe('partial');
+    expect(isGlobalAutoApproveEnabled({ claude: true })).toBe(false);
   });
 
   it('resolves explicit auto-approve over stored defaults', () => {

--- a/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.test.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildGlobalAutoApproveDefaults,
+  getAgentAutoApproveDefault,
+  isGlobalAutoApproveEnabled,
+  providerSupportsAutoApprove,
+  resolveAgentAutoApprove,
+} from './agent-auto-approve-defaults';
+
+describe('agent-auto-approve-defaults', () => {
+  it('detects providers that support auto-approve', () => {
+    expect(providerSupportsAutoApprove('claude')).toBe(true);
+    expect(providerSupportsAutoApprove('jules')).toBe(false);
+  });
+
+  it('builds global defaults for all capable providers', () => {
+    const enabled = buildGlobalAutoApproveDefaults(true);
+    expect(getAgentAutoApproveDefault(enabled, 'claude')).toBe(true);
+    expect(getAgentAutoApproveDefault(enabled, 'jules')).toBe(false);
+    expect(isGlobalAutoApproveEnabled(enabled)).toBe(true);
+  });
+
+  it('treats empty defaults as global auto-approve disabled', () => {
+    expect(isGlobalAutoApproveEnabled(undefined)).toBe(false);
+    expect(isGlobalAutoApproveEnabled({})).toBe(false);
+  });
+
+  it('resolves explicit auto-approve over stored defaults', () => {
+    expect(resolveAgentAutoApprove(true, {}, 'claude')).toBe(true);
+    expect(resolveAgentAutoApprove(undefined, { claude: true }, 'claude')).toBe(true);
+    expect(resolveAgentAutoApprove(undefined, {}, 'claude')).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.ts
@@ -1,10 +1,39 @@
-import { getProvider, isValidProviderId, type AgentProviderId } from './agent-provider-registry';
+import {
+  AGENT_PROVIDER_IDS,
+  getProvider,
+  isValidProviderId,
+  type AgentProviderId,
+} from './agent-provider-registry';
 
 export type AgentAutoApproveDefaults = Partial<Record<AgentProviderId, boolean>>;
 
 export function providerSupportsAutoApprove(providerId: AgentProviderId): boolean {
   const provider = getProvider(providerId);
   return Boolean(provider?.autoApproveFlag || provider?.autoApproveViaEnv);
+}
+
+export function getAutoApproveCapableProviderIds(): AgentProviderId[] {
+  return AGENT_PROVIDER_IDS.filter(providerSupportsAutoApprove);
+}
+
+export function getAutoApproveCapableProviderLabels(): string[] {
+  return getAutoApproveCapableProviderIds()
+    .map((id) => getProvider(id)?.name ?? id)
+    .sort((a, b) => a.localeCompare(b));
+}
+
+export function isGlobalAutoApproveEnabled(
+  defaults: AgentAutoApproveDefaults | undefined
+): boolean {
+  const capableProviderIds = getAutoApproveCapableProviderIds();
+  if (capableProviderIds.length === 0) return false;
+  return capableProviderIds.every((id) => getAgentAutoApproveDefault(defaults, id));
+}
+
+export function buildGlobalAutoApproveDefaults(enabled: boolean): AgentAutoApproveDefaults {
+  return Object.fromEntries(
+    getAutoApproveCapableProviderIds().map((id) => [id, enabled])
+  ) as AgentAutoApproveDefaults;
 }
 
 export function getAgentAutoApproveDefault(

--- a/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.ts
@@ -6,7 +6,6 @@ import {
 } from './agent-provider-registry';
 
 export type AgentAutoApproveDefaults = Partial<Record<AgentProviderId, boolean>>;
-export type GlobalAutoApproveState = 'none' | 'partial' | 'all';
 
 export function providerSupportsAutoApprove(providerId: AgentProviderId): boolean {
   const provider = getProvider(providerId);
@@ -23,23 +22,12 @@ export function getAutoApproveCapableProviderLabels(): string[] {
     .sort((a, b) => a.localeCompare(b));
 }
 
-export function getGlobalAutoApproveState(
-  defaults: AgentAutoApproveDefaults | undefined
-): GlobalAutoApproveState {
-  const capableProviderIds = getAutoApproveCapableProviderIds();
-  const enabledCount = capableProviderIds.filter((id) =>
-    getAgentAutoApproveDefault(defaults, id)
-  ).length;
-
-  if (enabledCount === 0) return 'none';
-  if (enabledCount === capableProviderIds.length) return 'all';
-  return 'partial';
-}
-
 export function isGlobalAutoApproveEnabled(
   defaults: AgentAutoApproveDefaults | undefined
 ): boolean {
-  return getGlobalAutoApproveState(defaults) === 'all';
+  const capableProviderIds = getAutoApproveCapableProviderIds();
+  if (capableProviderIds.length === 0) return false;
+  return capableProviderIds.every((id) => getAgentAutoApproveDefault(defaults, id));
 }
 
 export function buildGlobalAutoApproveDefaults(enabled: boolean): AgentAutoApproveDefaults {

--- a/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-auto-approve-defaults.ts
@@ -6,6 +6,7 @@ import {
 } from './agent-provider-registry';
 
 export type AgentAutoApproveDefaults = Partial<Record<AgentProviderId, boolean>>;
+export type GlobalAutoApproveState = 'none' | 'partial' | 'all';
 
 export function providerSupportsAutoApprove(providerId: AgentProviderId): boolean {
   const provider = getProvider(providerId);
@@ -22,17 +23,30 @@ export function getAutoApproveCapableProviderLabels(): string[] {
     .sort((a, b) => a.localeCompare(b));
 }
 
+export function getGlobalAutoApproveState(
+  defaults: AgentAutoApproveDefaults | undefined
+): GlobalAutoApproveState {
+  const capableProviderIds = getAutoApproveCapableProviderIds();
+  const enabledCount = capableProviderIds.filter((id) =>
+    getAgentAutoApproveDefault(defaults, id)
+  ).length;
+
+  if (enabledCount === 0) return 'none';
+  if (enabledCount === capableProviderIds.length) return 'all';
+  return 'partial';
+}
+
 export function isGlobalAutoApproveEnabled(
   defaults: AgentAutoApproveDefaults | undefined
 ): boolean {
-  const capableProviderIds = getAutoApproveCapableProviderIds();
-  if (capableProviderIds.length === 0) return false;
-  return capableProviderIds.every((id) => getAgentAutoApproveDefault(defaults, id));
+  return getGlobalAutoApproveState(defaults) === 'all';
 }
 
 export function buildGlobalAutoApproveDefaults(enabled: boolean): AgentAutoApproveDefaults {
+  if (!enabled) return {};
+
   return Object.fromEntries(
-    getAutoApproveCapableProviderIds().map((id) => [id, enabled])
+    getAutoApproveCapableProviderIds().map((id) => [id, true])
   ) as AgentAutoApproveDefaults;
 }
 


### PR DESCRIPTION
### Description
- restored settings auto-approve toggle
- mgirated legacy auto approve toggle

### Screenshot/Recording (if applicable)
https://streamable.com/7q9fim

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
