### PR TITLE
Fix stale diff models after branch state changes

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
@@ -5,6 +5,7 @@ import { MonacoModelRegistry } from './monaco-model-registry';
 const rpcState = vi.hoisted(() => ({
   indexContent: 'base' as string | null,
   refContent: 'base' as string | null,
+  diskContent: 'base' as string,
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({
@@ -23,7 +24,11 @@ vi.mock('@renderer/lib/ipc', () => ({
       fs: {
         readFile: vi.fn(async () => ({
           success: true,
-          data: { content: 'base', truncated: false, totalSize: 4 },
+          data: {
+            content: rpcState.diskContent,
+            truncated: false,
+            totalSize: rpcState.diskContent.length,
+          },
         })),
       },
       editor: {
@@ -105,6 +110,7 @@ describe('MonacoModelRegistry', () => {
   beforeEach(() => {
     rpcState.indexContent = 'base';
     rpcState.refContent = 'base';
+    rpcState.diskContent = 'base';
   });
 
   it('clears a staged git model when the index no longer contains the file', async () => {
@@ -165,5 +171,91 @@ describe('MonacoModelRegistry', () => {
     await registry.invalidateModel(headUri);
 
     expect(registry.getModelByUri(headUri)?.getValue()).toBe('');
+  });
+
+  it('refreshes a pending-eviction git model before reusing it', async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new MonacoModelRegistry();
+      registry.notifyMonacoReady(makeFakeMonaco() as never);
+
+      const projectId = 'project';
+      const workspaceId = 'workspace';
+      const root = `workspace:${workspaceId}`;
+      const filePath = 'file.ts';
+      const language = 'typescript';
+
+      rpcState.refContent = 'branch-a contents';
+      const uri = await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'git',
+        HEAD_REF
+      );
+      const headUri = registry.toGitUri(uri, HEAD_REF);
+      expect(registry.getModelByUri(headUri)?.getValue()).toBe('branch-a contents');
+
+      registry.unregisterModel(headUri);
+      rpcState.refContent = 'branch-b contents';
+
+      await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'git',
+        HEAD_REF
+      );
+
+      expect(registry.getModelByUri(headUri)?.getValue()).toBe('branch-b contents');
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('refreshes a pending-eviction disk model before reseeding a reopened buffer', async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new MonacoModelRegistry();
+      registry.notifyMonacoReady(makeFakeMonaco() as never);
+
+      const projectId = 'project';
+      const workspaceId = 'workspace';
+      const root = `workspace:${workspaceId}`;
+      const filePath = 'file.ts';
+      const language = 'typescript';
+
+      rpcState.diskContent = 'branch-a disk';
+      const uri = await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'disk'
+      );
+      await registry.registerModel(projectId, workspaceId, root, filePath, language, 'buffer');
+      const diskUri = registry.toDiskUri(uri);
+      expect(registry.getDiskValue(uri)).toBe('branch-a disk');
+      expect(registry.getValue(uri)).toBe('branch-a disk');
+
+      registry.unregisterModel(uri);
+      registry.unregisterModel(diskUri);
+      rpcState.diskContent = 'branch-b disk';
+
+      await registry.registerModel(projectId, workspaceId, root, filePath, language, 'disk');
+      await registry.registerModel(projectId, workspaceId, root, filePath, language, 'buffer');
+
+      expect(registry.getDiskValue(uri)).toBe('branch-b disk');
+      expect(registry.getValue(uri)).toBe('branch-b disk');
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
   });
 });

--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
@@ -10,26 +10,31 @@ const rpcState = vi.hoisted(() => ({
   refSuccess: true,
   diskSuccess: true,
   diskTruncated: false,
+  refDelay: null as Promise<void> | null,
+  diskDelay: null as Promise<void> | null,
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({
   rpc: {
     workspace: {
       gitWorktree: {
-        getFileAtIndex: vi.fn(async () =>
-          rpcState.indexSuccess
+        getFileAtIndex: vi.fn(async () => {
+          if (rpcState.refDelay) await rpcState.refDelay;
+          return rpcState.indexSuccess
             ? { success: true, data: { content: rpcState.indexContent } }
-            : { success: false, error: 'index failed' }
-        ),
-        getFileAtRef: vi.fn(async () =>
-          rpcState.refSuccess
+            : { success: false, error: 'index failed' };
+        }),
+        getFileAtRef: vi.fn(async () => {
+          if (rpcState.refDelay) await rpcState.refDelay;
+          return rpcState.refSuccess
             ? { success: true, data: { content: rpcState.refContent } }
-            : { success: false, error: 'ref failed' }
-        ),
+            : { success: false, error: 'ref failed' };
+        }),
       },
       fs: {
-        readFile: vi.fn(async () =>
-          rpcState.diskSuccess
+        readFile: vi.fn(async () => {
+          if (rpcState.diskDelay) await rpcState.diskDelay;
+          return rpcState.diskSuccess
             ? {
                 success: true,
                 data: {
@@ -38,8 +43,8 @@ vi.mock('@renderer/lib/ipc', () => ({
                   totalSize: rpcState.diskContent.length,
                 },
               }
-            : { success: false, error: 'read failed' }
-        ),
+            : { success: false, error: 'read failed' };
+        }),
       },
       editor: {
         saveBuffer: vi.fn(),
@@ -105,7 +110,8 @@ function makeFakeMonaco() {
     },
     editor: {
       getModel(uri: { toString(): string }) {
-        return models.get(uri.toString()) ?? null;
+        const model = models.get(uri.toString());
+        return model && !model.isDisposed() ? model : null;
       },
       createModel(content: string, _language: string, uri: { toString(): string; scheme: string }) {
         const model = new FakeModel(content, uri);
@@ -125,6 +131,8 @@ describe('MonacoModelRegistry', () => {
     rpcState.refSuccess = true;
     rpcState.diskSuccess = true;
     rpcState.diskTruncated = false;
+    rpcState.refDelay = null;
+    rpcState.diskDelay = null;
   });
 
   it('clears a staged git model when the index no longer contains the file', async () => {
@@ -227,6 +235,61 @@ describe('MonacoModelRegistry', () => {
 
       expect(registry.getModelByUri(headUri)?.getValue()).toBe('branch-b contents');
     } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('marks a pending-eviction git model as loading while refresh is in flight', async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new MonacoModelRegistry();
+      registry.notifyMonacoReady(makeFakeMonaco() as never);
+
+      const projectId = 'project';
+      const workspaceId = 'workspace';
+      const root = `workspace:${workspaceId}`;
+      const filePath = 'file.ts';
+      const language = 'typescript';
+
+      rpcState.refContent = 'branch-a contents';
+      const uri = await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'git',
+        HEAD_REF
+      );
+      const headUri = registry.toGitUri(uri, HEAD_REF);
+      registry.unregisterModel(headUri);
+
+      let release!: () => void;
+      rpcState.refDelay = new Promise((resolve) => {
+        release = resolve;
+      });
+      rpcState.refContent = 'branch-b contents';
+
+      const pending = registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'git',
+        HEAD_REF
+      );
+
+      expect(registry.modelStatus.get(headUri)).toBe('loading');
+
+      release();
+      await pending;
+
+      expect(registry.modelStatus.get(headUri)).toBe('ready');
+      expect(registry.getModelByUri(headUri)?.getValue()).toBe('branch-b contents');
+    } finally {
+      rpcState.refDelay = null;
       vi.runOnlyPendingTimers();
       vi.useRealTimers();
     }
@@ -346,6 +409,50 @@ describe('MonacoModelRegistry', () => {
 
       expect(registry.modelStatus.get(diskUri)).toBe('error');
       expect(registry.getDiskValue(uri)).toBe('');
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not silently overwrite a clean pending buffer when disk refresh becomes too large', async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new MonacoModelRegistry();
+      registry.notifyMonacoReady(makeFakeMonaco() as never);
+
+      const projectId = 'project';
+      const workspaceId = 'workspace';
+      const root = `workspace:${workspaceId}`;
+      const filePath = 'file.ts';
+      const language = 'typescript';
+
+      rpcState.diskContent = 'branch-a disk';
+      const uri = await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'disk'
+      );
+      await registry.registerModel(projectId, workspaceId, root, filePath, language, 'buffer');
+      const diskUri = registry.toDiskUri(uri);
+      const oldBufferModel = registry.getModelByUri(uri);
+
+      registry.unregisterModel(uri);
+      registry.unregisterModel(diskUri);
+
+      rpcState.diskContent = 'new oversized content';
+      rpcState.diskTruncated = true;
+      await registry.registerModel(projectId, workspaceId, root, filePath, language, 'disk');
+
+      expect(registry.modelStatus.get(diskUri)).toBe('too-large');
+      expect(oldBufferModel?.isDisposed()).toBe(true);
+
+      await registry.registerModel(projectId, workspaceId, root, filePath, language, 'buffer');
+
+      expect(registry.getValue(uri)).toBe('');
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();

--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.test.ts
@@ -6,30 +6,40 @@ const rpcState = vi.hoisted(() => ({
   indexContent: 'base' as string | null,
   refContent: 'base' as string | null,
   diskContent: 'base' as string,
+  indexSuccess: true,
+  refSuccess: true,
+  diskSuccess: true,
+  diskTruncated: false,
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({
   rpc: {
     workspace: {
       gitWorktree: {
-        getFileAtIndex: vi.fn(async () => ({
-          success: true,
-          data: { content: rpcState.indexContent },
-        })),
-        getFileAtRef: vi.fn(async () => ({
-          success: true,
-          data: { content: rpcState.refContent },
-        })),
+        getFileAtIndex: vi.fn(async () =>
+          rpcState.indexSuccess
+            ? { success: true, data: { content: rpcState.indexContent } }
+            : { success: false, error: 'index failed' }
+        ),
+        getFileAtRef: vi.fn(async () =>
+          rpcState.refSuccess
+            ? { success: true, data: { content: rpcState.refContent } }
+            : { success: false, error: 'ref failed' }
+        ),
       },
       fs: {
-        readFile: vi.fn(async () => ({
-          success: true,
-          data: {
-            content: rpcState.diskContent,
-            truncated: false,
-            totalSize: rpcState.diskContent.length,
-          },
-        })),
+        readFile: vi.fn(async () =>
+          rpcState.diskSuccess
+            ? {
+                success: true,
+                data: {
+                  content: rpcState.diskContent,
+                  truncated: rpcState.diskTruncated,
+                  totalSize: rpcState.diskContent.length,
+                },
+              }
+            : { success: false, error: 'read failed' }
+        ),
       },
       editor: {
         saveBuffer: vi.fn(),
@@ -111,6 +121,10 @@ describe('MonacoModelRegistry', () => {
     rpcState.indexContent = 'base';
     rpcState.refContent = 'base';
     rpcState.diskContent = 'base';
+    rpcState.indexSuccess = true;
+    rpcState.refSuccess = true;
+    rpcState.diskSuccess = true;
+    rpcState.diskTruncated = false;
   });
 
   it('clears a staged git model when the index no longer contains the file', async () => {
@@ -253,6 +267,85 @@ describe('MonacoModelRegistry', () => {
 
       expect(registry.getDiskValue(uri)).toBe('branch-b disk');
       expect(registry.getValue(uri)).toBe('branch-b disk');
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears stale git content when a pending-eviction git model refresh fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new MonacoModelRegistry();
+      registry.notifyMonacoReady(makeFakeMonaco() as never);
+
+      const projectId = 'project';
+      const workspaceId = 'workspace';
+      const root = `workspace:${workspaceId}`;
+      const filePath = 'file.ts';
+      const language = 'typescript';
+
+      rpcState.refContent = 'branch-a contents';
+      const uri = await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'git',
+        HEAD_REF
+      );
+      const headUri = registry.toGitUri(uri, HEAD_REF);
+      registry.unregisterModel(headUri);
+
+      rpcState.refSuccess = false;
+      await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'git',
+        HEAD_REF
+      );
+
+      expect(registry.modelStatus.get(headUri)).toBe('error');
+      expect(registry.getModelByUri(headUri)?.getValue()).toBe('');
+    } finally {
+      vi.runOnlyPendingTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears stale disk content when a pending-eviction disk model refresh fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const registry = new MonacoModelRegistry();
+      registry.notifyMonacoReady(makeFakeMonaco() as never);
+
+      const projectId = 'project';
+      const workspaceId = 'workspace';
+      const root = `workspace:${workspaceId}`;
+      const filePath = 'file.ts';
+      const language = 'typescript';
+
+      rpcState.diskContent = 'branch-a disk';
+      const uri = await registry.registerModel(
+        projectId,
+        workspaceId,
+        root,
+        filePath,
+        language,
+        'disk'
+      );
+      const diskUri = registry.toDiskUri(uri);
+      registry.unregisterModel(diskUri);
+
+      rpcState.diskSuccess = false;
+      await registry.registerModel(projectId, workspaceId, root, filePath, language, 'disk');
+
+      expect(registry.modelStatus.get(diskUri)).toBe('error');
+      expect(registry.getDiskValue(uri)).toBe('');
     } finally {
       vi.runOnlyPendingTimers();
       vi.useRealTimers();

--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
@@ -254,12 +254,14 @@ export class MonacoModelRegistry {
     const existing = this.modelMap.get(diskUri);
 
     if (existing?.type === 'disk') {
+      const wasEvictionPending = existing.refs === 0;
       existing.refs += 1;
       const timer = this.evictionTimers.get(diskUri);
       if (timer !== undefined) {
         clearTimeout(timer);
         this.evictionTimers.delete(diskUri);
       }
+      if (wasEvictionPending) await this.invalidateModel(diskUri);
       return uri;
     }
 
@@ -331,12 +333,14 @@ export class MonacoModelRegistry {
     const existing = this.modelMap.get(gitUri);
 
     if (existing?.type === 'git') {
+      const wasEvictionPending = existing.refs === 0;
       existing.refs += 1;
       const timer = this.evictionTimers.get(gitUri);
       if (timer !== undefined) {
         clearTimeout(timer);
         this.evictionTimers.delete(gitUri);
       }
+      if (wasEvictionPending) await this.invalidateModel(gitUri);
       return uri;
     }
 

--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
@@ -261,7 +261,10 @@ export class MonacoModelRegistry {
         clearTimeout(timer);
         this.evictionTimers.delete(diskUri);
       }
-      if (wasEvictionPending) await this.invalidateModel(diskUri);
+      if (wasEvictionPending) {
+        this.modelStatus.set(diskUri, 'loading');
+        await this.invalidateModel(diskUri);
+      }
       return uri;
     }
 
@@ -340,7 +343,10 @@ export class MonacoModelRegistry {
         clearTimeout(timer);
         this.evictionTimers.delete(gitUri);
       }
-      if (wasEvictionPending) await this.invalidateModel(gitUri);
+      if (wasEvictionPending) {
+        this.modelStatus.set(gitUri, 'loading');
+        await this.invalidateModel(gitUri);
+      }
       return uri;
     }
 
@@ -769,7 +775,7 @@ export class MonacoModelRegistry {
       );
       if (!res.success || res.data.content === null) {
         this.modelStatus.set(uri, 'error');
-        this.applyDiskUpdate(uri, entry, '');
+        this.clearUnavailableDiskEntry(uri, entry);
         return;
       }
       if (res.data.truncated) {
@@ -777,7 +783,7 @@ export class MonacoModelRegistry {
           this.modelStatus.set(uri, 'too-large');
           this.modelTotalSizes.set(uri, res.data.totalSize);
         });
-        this.applyDiskUpdate(uri, entry, '');
+        this.clearUnavailableDiskEntry(uri, entry);
         return;
       }
       this.modelStatus.set(uri, 'ready');
@@ -851,6 +857,42 @@ export class MonacoModelRegistry {
   // ---------------------------------------------------------------------------
   // Disk update helper (used by invalidateModel)
   // ---------------------------------------------------------------------------
+
+  private clearUnavailableDiskEntry(diskUri: string, entry: DiskModelEntry): void {
+    entry.model.setValue('');
+
+    // Do not propagate a synthetic empty string through applyDiskUpdate(). A normal
+    // first registration for a missing/too-large file never seeds the writable
+    // buffer, so a pending-eviction refresh should not silently overwrite a clean
+    // buffer with empty content either. If a clean buffer is only being kept alive
+    // by the eviction cache, evict it now so a subsequent registerBuffer() follows
+    // the normal seed-from-disk path.
+    const bufferUri = diskUri.replace(/^disk:\/\//, 'file://');
+    const bufEntry = this.modelMap.get(bufferUri);
+    if (bufEntry?.type !== 'buffer' || bufEntry.refs > 0 || this.dirtyUris.has(bufferUri)) return;
+
+    const timer = this.evictionTimers.get(bufferUri);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      this.evictionTimers.delete(bufferUri);
+    }
+    if (!bufEntry.model.isDisposed()) bufEntry.model.dispose();
+    this.modelMap.delete(bufferUri);
+    this.modelStatus.delete(bufferUri);
+    this.bufferContentDisposables.get(bufferUri)?.dispose();
+    this.bufferContentDisposables.delete(bufferUri);
+    const autosaveTimer = this.bufferAutosaveTimers.get(bufferUri);
+    if (autosaveTimer !== undefined) {
+      clearTimeout(autosaveTimer);
+      this.bufferAutosaveTimers.delete(bufferUri);
+    }
+    this.bufferReadyCallbacks.delete(bufferUri);
+    this.pendingConflicts.delete(bufferUri);
+    runInAction(() => {
+      this.dirtyUris.delete(bufferUri);
+      this.bufferVersions.delete(bufferUri);
+    });
+  }
 
   private applyDiskUpdate(diskUri: string, entry: DiskModelEntry, newContent: string): void {
     const bufferUri = diskUri.replace(/^disk:\/\//, 'file://');

--- a/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/monaco-model-registry.ts
@@ -767,7 +767,21 @@ export class MonacoModelRegistry {
         entry.workspaceId,
         entry.filePath
       );
-      if (res.success) this.applyDiskUpdate(uri, entry, res.data.content);
+      if (!res.success || res.data.content === null) {
+        this.modelStatus.set(uri, 'error');
+        this.applyDiskUpdate(uri, entry, '');
+        return;
+      }
+      if (res.data.truncated) {
+        runInAction(() => {
+          this.modelStatus.set(uri, 'too-large');
+          this.modelTotalSizes.set(uri, res.data.totalSize);
+        });
+        this.applyDiskUpdate(uri, entry, '');
+        return;
+      }
+      this.modelStatus.set(uri, 'ready');
+      this.applyDiskUpdate(uri, entry, res.data.content);
     } else if (entry.type === 'git') {
       const res =
         entry.ref.kind === 'staged'
@@ -782,9 +796,13 @@ export class MonacoModelRegistry {
               entry.filePath,
               gitRefToString(entry.ref)
             );
-      if (res.success) {
-        entry.model.setValue(res.data.content ?? '');
+      if (!res.success) {
+        this.modelStatus.set(uri, 'error');
+        entry.model.setValue('');
+        return;
       }
+      this.modelStatus.set(uri, 'ready');
+      entry.model.setValue(res.data.content ?? '');
     }
   }
 


### PR DESCRIPTION
Fixes #2576.

## Summary

- refresh `disk://` and `git://` Monaco models when they are re-opened from the pending-eviction cache (`refs === 0`)
- this avoids reusing stale HEAD/staged/disk contents when the same file path is opened again shortly after branch/worktree state changed
- add regression coverage for pending-eviction git and disk/buffer model reuse

## Why

Diff tabs/models are retained for the 60s eviction window after close. If a file is closed and then re-opened on another branch before eviction, `registerDisk` / `registerGit` previously cancelled the eviction and returned the cached model without re-fetching. That can leave the diff panel showing stale content from the prior branch for the same path.

## Tests

```bash
pnpm exec oxfmt src/renderer/lib/monaco/monaco-model-registry.ts src/renderer/lib/monaco/monaco-model-registry.test.ts
pnpm exec oxlint src/renderer/lib/monaco/monaco-model-registry.ts src/renderer/lib/monaco/monaco-model-registry.test.ts
pnpm exec vitest run --project node src/renderer/lib/monaco/monaco-model-registry.test.ts
```

Result: `4 passed`.
