### PR TITLE
fix(ssh): support fish as remote default shell

### DIFF
--- a/apps/emdash-desktop/src/main/core/pty/spawn-utils.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/spawn-utils.test.ts
@@ -57,6 +57,21 @@ const bashRemoteProfile: ResolvedShellProfile = {
   remotePathLookup: true,
 };
 
+const fishSystemProfile: ResolvedShellProfile = {
+  id: 'target-default',
+  resolvedShellId: 'fish',
+  resolvedFromSystem: true,
+  executable: '/usr/local/bin/fish',
+  available: true,
+  family: 'posix',
+  interactiveArgs: ['-il'],
+  commandArgs: ['-lc'],
+  envCaptureArgs: ['-ilc'],
+  capturedEnv: {
+    PATH: '/usr/local/bin:/usr/bin',
+  },
+};
+
 const tcshRemoteProfile: ResolvedShellProfile = {
   id: 'tcsh',
   resolvedShellId: 'tcsh',
@@ -160,6 +175,14 @@ describe('resolveSshCommand', () => {
 
     expect(result).toBe(
       `'/bin/zsh' -lc 'export PATH='\\''/Users/jona/.local/bin:/opt/homebrew/bin:/usr/bin'\\''; cd "/workspace" && exec /bin/zsh -il'`
+    );
+  });
+
+  it('launches remote fish system terminals through a sh setup wrapper', () => {
+    const result = resolveSshCommand('general', makeGeneralConfig(), undefined, fishSystemProfile);
+
+    expect(result).toBe(
+      `'/bin/sh' -c 'export PATH='\\''/usr/local/bin:/usr/bin'\\''; cd "/workspace" && exec /usr/local/bin/fish -il'`
     );
   });
 

--- a/apps/emdash-desktop/src/main/core/ssh/lifecycle/remote-shell-profile.test.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/lifecycle/remote-shell-profile.test.ts
@@ -139,6 +139,23 @@ describe('remote shell profile command building', () => {
     }
   );
 
+  it('captures fish login shell env without replacing the profile shell', async () => {
+    const client = makeRemoteShellClient([
+      '/usr/local/bin/fish',
+      'HOME=/Users/jona\nPATH=/usr/local/bin:/usr/bin\n',
+    ]);
+
+    await expect(captureRemoteShellProfile(client)).resolves.toEqual({
+      shell: '/usr/local/bin/fish',
+      env: {
+        HOME: '/Users/jona',
+        PATH: '/Users/jona/.local/bin:/usr/local/bin:/usr/bin',
+      },
+    });
+
+    expect(client.commands[1]).toContain("'/usr/local/bin/fish' -ilc 'env'");
+  });
+
   it('uses csh-compatible environment setup for explicit remote csh path lookup', () => {
     const command = buildRemoteShellCommandWithPathLookup(
       {
@@ -190,9 +207,16 @@ describe('remote shell profile command building', () => {
     expect(normalizeRemoteShell('/bin/tcsh')).toBe('/bin/sh');
   });
 
-  it('falls back to /bin/sh for unsupported remote shells', () => {
-    expect(normalizeRemoteShell('/usr/local/bin/fish')).toBe('/bin/sh');
+  it('preserves fish as a supported remote login shell', () => {
+    expect(normalizeRemoteShell('/usr/local/bin/fish')).toBe('/usr/local/bin/fish');
     expect(buildRemoteShellCommand({ shell: '/usr/local/bin/fish', env: {} }, 'echo ok')).toBe(
+      "'/bin/sh' -c 'echo ok'"
+    );
+  });
+
+  it('falls back to /bin/sh for unsupported remote shells', () => {
+    expect(normalizeRemoteShell('/bin/elvish')).toBe('/bin/sh');
+    expect(buildRemoteShellCommand({ shell: '/bin/elvish', env: {} }, 'echo ok')).toBe(
       "'/bin/sh' -c 'echo ok'"
     );
   });

--- a/apps/emdash-desktop/src/main/core/ssh/lifecycle/remote-shell-profile.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/lifecycle/remote-shell-profile.ts
@@ -24,7 +24,7 @@ export const FALLBACK_REMOTE_SHELL_PROFILE: RemoteShellProfile = {
 const CAPTURE_TIMEOUT_MS = 5_000;
 const SHELL_TIMEOUT_MS = 3_000;
 
-const LOGIN_SHELLS = new Set(['bash', 'ksh', 'zsh']);
+const LOGIN_SHELLS = new Set(['bash', 'fish', 'ksh', 'zsh']);
 const BASIC_POSIX_SHELLS = new Set(['dash', 'sh']);
 const SUPPORTED_REMOTE_SHELLS = new Set([...BASIC_POSIX_SHELLS, ...LOGIN_SHELLS]);
 const VOLATILE_ENV_KEYS = new Set(['_', 'PWD', 'OLDPWD', 'SHLVL', 'COLUMNS', 'LINES']);
@@ -75,7 +75,8 @@ export function buildRemoteShellCommand(
   command: string,
   env: Record<string, string> = {}
 ): string {
-  const shell = normalizeRemoteShell(profile.shell);
+  const profileShell = normalizeRemoteShell(profile.shell);
+  const shell = remoteCommandShell(profileShell);
   const prefix = `${buildRemoteShellEnvPrefix(shell, profile.env)}${buildRemoteShellEnvPrefix(
     shell,
     env
@@ -92,15 +93,23 @@ export function buildRemoteShellCommandWithPathLookup(
   env: Record<string, string> = {}
 ): string {
   const selectedShellEnv = { ...env, SHELL: shellName };
+  const commandShell = remoteCommandShell(shellName);
   const prefix = `${buildRemoteShellEnvPrefix(
-    shellName,
+    commandShell,
     withoutShellEnv(profile.env)
-  )}${buildRemoteShellEnvPrefix(shellName, selectedShellEnv)}`;
+  )}${buildRemoteShellEnvPrefix(commandShell, selectedShellEnv)}`;
   const remotePath = env.PATH ?? profile.env.PATH;
   const pathArg = remotePath ? `${quoteShellArg(`PATH=${remotePath}`)} ` : '';
   return `${quoteShellArg('/usr/bin/env')} ${pathArg}${quoteShellArg(
-    shellName
-  )} ${terminalCommandArgs(shellName).join(' ')} ${quoteShellArg(`${prefix}${command}`)}`;
+    commandShell
+  )} ${terminalCommandArgs(commandShell).join(' ')} ${quoteShellArg(`${prefix}${command}`)}`;
+}
+
+function remoteCommandShell(shell: string): string {
+  // fish is a valid interactive default shell, but it does not understand POSIX
+  // `export KEY=value` prefixes. Run the setup wrapper through sh and let the
+  // terminal command exec fish after cwd/env setup.
+  return terminalShellBasename(shell) === 'fish' ? DEFAULT_REMOTE_SHELL : shell;
 }
 
 export function includeRemoteUserBinDirs(env: Record<string, string>): Record<string, string> {

--- a/apps/emdash-desktop/src/main/core/terminal-shell/resolver.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminal-shell/resolver.test.ts
@@ -440,7 +440,7 @@ describe('terminal shell resolver', () => {
     ).rejects.toBeInstanceOf(ShellUnavailableError);
   });
 
-  it('keeps login-shell args for unknown remote system shells after normalization', async () => {
+  it('keeps fish as the remote system shell after normalization', async () => {
     const profile = await resolveTerminalShell({
       intent: 'system',
       target: {
@@ -451,11 +451,11 @@ describe('terminal shell resolver', () => {
 
     expect(profile).toMatchObject({
       id: 'target-default',
-      resolvedShellId: 'sh',
+      resolvedShellId: 'fish',
       resolvedFromSystem: true,
-      executable: '/bin/sh',
-      interactiveArgs: ['-i'],
-      commandArgs: ['-c'],
+      executable: '/usr/local/bin/fish',
+      interactiveArgs: ['-il'],
+      commandArgs: ['-lc'],
     });
   });
 });


### PR DESCRIPTION
### Description
- support fish as remote shell default
- keep env/setup wrappers POSIX-comptaible with /bin/sh
- preserve existing behavior

### Screenshot/Recording (if applicable)
https://streamable.com/ti2e0y

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
