### PR TITLE
fix(codex): store hooks in config toml; migrate from json 

### DIFF
--- a/packages/plugins/src/agents/impl/codex/hooks.test.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.test.ts
@@ -1,8 +1,6 @@
 import type { PluginFs } from '@emdash/core/agents/plugins';
 import { describe, expect, it } from 'vitest';
-import { CODEX_CONFIG_PATH, buildCodexHookConfig } from './hooks';
-
-const CODEX_LEGACY_HOOKS_PATH = '.codex/hooks.json';
+import { CODEX_CONFIG_PATH, CODEX_LEGACY_HOOKS_PATH, buildCodexHookConfig } from './hooks';
 
 function createMemoryFs(initial: Record<string, string> = {}): PluginFs & {
   files: Map<string, string>;
@@ -71,6 +69,34 @@ describe('buildCodexHookConfig', () => {
     expect(config).toContain('echo user-prompt');
     expect(config).toContain('notification_type');
     expect(config).toContain('session-start');
+  });
+
+  it('keeps legacy hooks.json when writing config.toml fails', async () => {
+    const legacyHooks = JSON.stringify({
+      hooks: {
+        Stop: [
+          {
+            hooks: [{ type: 'command', command: 'echo user-stop' }],
+          },
+        ],
+      },
+    });
+    const fs = createMemoryFs({
+      [CODEX_CONFIG_PATH]: 'model = "gpt-5"\n',
+      [CODEX_LEGACY_HOOKS_PATH]: legacyHooks,
+    });
+    const write = fs.write.bind(fs);
+    fs.write = async (path, content) => {
+      if (path === CODEX_CONFIG_PATH) {
+        throw new Error('permission denied');
+      }
+      await write(path, content);
+    };
+    const hooks = buildCodexHookConfig();
+
+    await expect(hooks.writeHooks(fs, [])).rejects.toThrow('permission denied');
+
+    await expect(fs.read(CODEX_LEGACY_HOOKS_PATH)).resolves.toBe(legacyHooks);
   });
 
   it('deletes Emdash hooks from both current and legacy Codex hook config', async () => {

--- a/packages/plugins/src/agents/impl/codex/hooks.test.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.test.ts
@@ -1,0 +1,112 @@
+import type { PluginFs } from '@emdash/core/agents/plugins';
+import { describe, expect, it } from 'vitest';
+import { CODEX_CONFIG_PATH, buildCodexHookConfig } from './hooks';
+
+const CODEX_LEGACY_HOOKS_PATH = '.codex/hooks.json';
+
+function createMemoryFs(initial: Record<string, string> = {}): PluginFs & {
+  files: Map<string, string>;
+} {
+  const files = new Map(Object.entries(initial));
+
+  return {
+    files,
+    async read(path) {
+      return files.get(path) ?? null;
+    },
+    async write(path, content) {
+      files.set(path, content);
+    },
+    async delete(path) {
+      files.delete(path);
+    },
+    async exists(path) {
+      return files.has(path);
+    },
+    async list(path) {
+      return [...files.keys()].filter((file) => file.startsWith(path));
+    },
+  };
+}
+
+describe('buildCodexHookConfig', () => {
+  it('writes Codex hooks to config.toml and removes legacy hooks.json', async () => {
+    const fs = createMemoryFs({
+      [CODEX_CONFIG_PATH]: 'model = "gpt-5"\n',
+      [CODEX_LEGACY_HOOKS_PATH]: JSON.stringify(
+        {
+          hooks: {
+            Stop: [
+              {
+                hooks: [
+                  {
+                    type: 'command',
+                    command: 'curl http://127.0.0.1:$EMDASH_HOOK_PORT/hook',
+                  },
+                ],
+              },
+              {
+                hooks: [{ type: 'command', command: 'echo user-stop' }],
+              },
+            ],
+            UserPromptSubmit: [
+              {
+                hooks: [{ type: 'command', command: 'echo user-prompt' }],
+              },
+            ],
+          },
+        },
+        null,
+        2
+      ),
+    });
+    const hooks = buildCodexHookConfig();
+
+    await expect(hooks.writeHooks(fs, [])).resolves.toEqual([CODEX_CONFIG_PATH]);
+
+    await expect(fs.exists(CODEX_LEGACY_HOOKS_PATH)).resolves.toBe(false);
+    const config = await fs.read(CODEX_CONFIG_PATH);
+    expect(config).toContain('model = "gpt-5"');
+    expect(config).toContain('echo user-stop');
+    expect(config).toContain('echo user-prompt');
+    expect(config).toContain('notification_type');
+    expect(config).toContain('session-start');
+  });
+
+  it('deletes Emdash hooks from both current and legacy Codex hook config', async () => {
+    const emdashHook = {
+      hooks: [
+        {
+          type: 'command',
+          command: 'curl http://127.0.0.1:$EMDASH_HOOK_PORT/hook',
+        },
+      ],
+    };
+    const userHook = {
+      hooks: [{ type: 'command', command: 'echo user-stop' }],
+    };
+    const fs = createMemoryFs({
+      [CODEX_CONFIG_PATH]: `[[hooks.Stop]]
+hooks = [{ type = "command", command = "curl http://127.0.0.1:$EMDASH_HOOK_PORT/hook" }]
+
+[[hooks.Stop]]
+hooks = [{ type = "command", command = "echo user-toml" }]
+`,
+      [CODEX_LEGACY_HOOKS_PATH]: JSON.stringify({
+        hooks: {
+          Stop: [emdashHook, userHook],
+        },
+      }),
+    });
+    const hooks = buildCodexHookConfig();
+
+    await hooks.deleteHooks(fs);
+
+    const config = await fs.read(CODEX_CONFIG_PATH);
+    expect(config).not.toContain('EMDASH_HOOK_PORT');
+    expect(config).toContain('echo user-toml');
+    const legacy = await fs.read(CODEX_LEGACY_HOOKS_PATH);
+    expect(legacy).toContain('echo user-stop');
+    expect(legacy).not.toContain('EMDASH_HOOK_PORT');
+  });
+});

--- a/packages/plugins/src/agents/impl/codex/hooks.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.ts
@@ -14,9 +14,8 @@ import {
 } from '@emdash/core/agents/plugins/helpers';
 import * as toml from 'smol-toml';
 
-export const CODEX_HOOKS_PATH = '.codex/config.toml';
-const CODEX_LEGACY_HOOKS_PATH = '.codex/hooks.json';
-export const CODEX_CONFIG_PATH = CODEX_HOOKS_PATH;
+export const CODEX_CONFIG_PATH = '.codex/config.toml';
+export const CODEX_LEGACY_HOOKS_PATH = '.codex/hooks.json';
 
 const LEGACY_CODEX_NOTIFY_COMMAND = [
   'bash',
@@ -77,7 +76,10 @@ async function readLegacyHooks(fs: PluginFs): Promise<Record<string, unknown[]>>
   return getHooks(config);
 }
 
-async function migrateLegacyHooks(fs: PluginFs, hooks: Record<string, unknown[]>): Promise<void> {
+async function migrateLegacyHooks(
+  fs: PluginFs,
+  hooks: Record<string, unknown[]>
+): Promise<() => Promise<void>> {
   const legacyHooks = await readLegacyHooks(fs);
 
   for (const [key, entries] of Object.entries(legacyHooks)) {
@@ -90,7 +92,9 @@ async function migrateLegacyHooks(fs: PluginFs, hooks: Record<string, unknown[]>
     hooks[key] = [...filterUserHooks(existing as Record<string, unknown>[]), ...userEntries];
   }
 
-  await fs.delete(CODEX_LEGACY_HOOKS_PATH).catch(() => {});
+  return async () => {
+    await fs.delete(CODEX_LEGACY_HOOKS_PATH).catch(() => {});
+  };
 }
 
 function makeCodexSessionStartCommand(): string {
@@ -147,7 +151,7 @@ export function buildCodexHookConfig() {
     async writeHooks(fs: PluginFs, _hooks: HookRegistration[]): Promise<string[]> {
       const config = await readTomlConfig(fs, CODEX_CONFIG_PATH);
       const hooks = getHooks(config);
-      await migrateLegacyHooks(fs, hooks);
+      const cleanupLegacy = await migrateLegacyHooks(fs, hooks);
 
       for (const [key, cmd] of [
         ['Stop', stopCmd],
@@ -161,6 +165,7 @@ export function buildCodexHookConfig() {
         ];
       }
       await writeTomlConfig(fs, CODEX_CONFIG_PATH, { ...config, hooks });
+      await cleanupLegacy();
       await removeLegacyCodexNotify(fs).catch(() => {});
       return [CODEX_CONFIG_PATH];
     },

--- a/packages/plugins/src/agents/impl/codex/hooks.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.ts
@@ -8,12 +8,15 @@ import {
   makeHookPostCommand,
   makeNotificationHookCommand,
   readJsonConfig,
+  readTomlConfig,
   writeJsonConfig,
+  writeTomlConfig,
 } from '@emdash/core/agents/plugins/helpers';
 import * as toml from 'smol-toml';
 
-export const CODEX_HOOKS_PATH = '.codex/hooks.json';
-const CODEX_CONFIG_PATH = '.codex/config.toml';
+export const CODEX_HOOKS_PATH = '.codex/config.toml';
+const CODEX_LEGACY_HOOKS_PATH = '.codex/hooks.json';
+export const CODEX_CONFIG_PATH = CODEX_HOOKS_PATH;
 
 const LEGACY_CODEX_NOTIFY_COMMAND = [
   'bash',
@@ -58,6 +61,38 @@ async function removeLegacyCodexNotify(fs: PluginFs): Promise<void> {
   await fs.write(CODEX_CONFIG_PATH, toml.stringify(config));
 }
 
+function getHooks(config: Record<string, unknown>): Record<string, unknown[]> {
+  return (config.hooks ?? {}) as Record<string, unknown[]>;
+}
+
+function hasCodexEmdashHooks(hooks: Record<string, unknown[]>): boolean {
+  return ['Stop', 'PermissionRequest', 'SessionStart'].some((k) => {
+    const entries = Array.isArray(hooks[k]) ? hooks[k] : [];
+    return entries.some((e) => JSON.stringify(e).includes(EMDASH_MARKER));
+  });
+}
+
+async function readLegacyHooks(fs: PluginFs): Promise<Record<string, unknown[]>> {
+  const config = await readJsonConfig(fs, CODEX_LEGACY_HOOKS_PATH);
+  return getHooks(config);
+}
+
+async function migrateLegacyHooks(fs: PluginFs, hooks: Record<string, unknown[]>): Promise<void> {
+  const legacyHooks = await readLegacyHooks(fs);
+
+  for (const [key, entries] of Object.entries(legacyHooks)) {
+    if (!Array.isArray(entries)) continue;
+
+    const userEntries = filterUserHooks(entries as Record<string, unknown>[]);
+    if (!userEntries.length) continue;
+
+    const existing = Array.isArray(hooks[key]) ? hooks[key] : [];
+    hooks[key] = [...filterUserHooks(existing as Record<string, unknown>[]), ...userEntries];
+  }
+
+  await fs.delete(CODEX_LEGACY_HOOKS_PATH).catch(() => {});
+}
+
 function makeCodexSessionStartCommand(): string {
   const post = makeHookPostCommand('session-start', 'stdin', {});
   if (process.platform === 'win32') return post;
@@ -100,17 +135,20 @@ export function buildCodexHookConfig() {
 
   return {
     async readHooks(fs: PluginFs): Promise<HookRegistration[]> {
-      const config = await readJsonConfig(fs, CODEX_HOOKS_PATH);
-      const hooks = (config.hooks ?? {}) as Record<string, unknown[]>;
-      const installed = ['Stop', 'PermissionRequest', 'SessionStart'].some((k) => {
-        const entries = Array.isArray(hooks[k]) ? hooks[k] : [];
-        return entries.some((e) => JSON.stringify(e).includes(EMDASH_MARKER));
-      });
-      return installed ? [{ event: 'emdash', command: EMDASH_MARKER }] : [];
+      const config = await readTomlConfig(fs, CODEX_CONFIG_PATH);
+      if (hasCodexEmdashHooks(getHooks(config))) {
+        return [{ event: 'emdash', command: EMDASH_MARKER }];
+      }
+
+      return hasCodexEmdashHooks(await readLegacyHooks(fs))
+        ? [{ event: 'emdash', command: EMDASH_MARKER }]
+        : [];
     },
     async writeHooks(fs: PluginFs, _hooks: HookRegistration[]): Promise<string[]> {
-      const config = await readJsonConfig(fs, CODEX_HOOKS_PATH);
-      const hooks = (config.hooks ?? {}) as Record<string, unknown[]>;
+      const config = await readTomlConfig(fs, CODEX_CONFIG_PATH);
+      const hooks = getHooks(config);
+      await migrateLegacyHooks(fs, hooks);
+
       for (const [key, cmd] of [
         ['Stop', stopCmd],
         ['PermissionRequest', permCmd],
@@ -122,25 +160,34 @@ export function buildCodexHookConfig() {
           buildNestedEntry(cmd),
         ];
       }
-      await writeJsonConfig(fs, CODEX_HOOKS_PATH, { ...config, hooks });
+      await writeTomlConfig(fs, CODEX_CONFIG_PATH, { ...config, hooks });
       await removeLegacyCodexNotify(fs).catch(() => {});
-      return [CODEX_HOOKS_PATH];
+      return [CODEX_CONFIG_PATH];
     },
     async deleteHooks(fs: PluginFs): Promise<void> {
-      const config = await readJsonConfig(fs, CODEX_HOOKS_PATH);
-      const hooks = (config.hooks ?? {}) as Record<string, unknown[]>;
+      const config = await readTomlConfig(fs, CODEX_CONFIG_PATH);
+      const hooks = getHooks(config);
       for (const key of Object.keys(hooks)) {
         hooks[key] = filterUserHooks(hooks[key] as Record<string, unknown>[]);
       }
-      await writeJsonConfig(fs, CODEX_HOOKS_PATH, { ...config, hooks });
+      await writeTomlConfig(fs, CODEX_CONFIG_PATH, { ...config, hooks });
+
+      const legacyConfig = await readJsonConfig(fs, CODEX_LEGACY_HOOKS_PATH);
+      const legacyHooks = getHooks(legacyConfig);
+      for (const key of Object.keys(legacyHooks)) {
+        legacyHooks[key] = filterUserHooks(legacyHooks[key] as Record<string, unknown>[]);
+      }
+      if (Object.values(legacyHooks).some((entries) => Array.isArray(entries) && entries.length)) {
+        await writeJsonConfig(fs, CODEX_LEGACY_HOOKS_PATH, { ...legacyConfig, hooks: legacyHooks });
+      } else {
+        await fs.delete(CODEX_LEGACY_HOOKS_PATH).catch(() => {});
+      }
     },
     async getHooksInstalled(fs: PluginFs): Promise<boolean> {
-      const config = await readJsonConfig(fs, CODEX_HOOKS_PATH);
-      const hooks = (config.hooks ?? {}) as Record<string, unknown[]>;
-      return ['Stop', 'PermissionRequest', 'SessionStart'].some((k) => {
-        const entries = Array.isArray(hooks[k]) ? hooks[k] : [];
-        return entries.some((e) => JSON.stringify(e).includes(EMDASH_MARKER));
-      });
+      const config = await readTomlConfig(fs, CODEX_CONFIG_PATH);
+      return (
+        hasCodexEmdashHooks(getHooks(config)) || hasCodexEmdashHooks(await readLegacyHooks(fs))
+      );
     },
     parseHookEvent: parseCodexHookEvent,
   };


### PR DESCRIPTION
### Description
- move codex hook installation to .codex/config.toml
- treat .codex/hooks.json as legacy
- preserve user defined hooks while replacing emdash-managed hooks

### Screenshot/Recording (if applicable)
https://streamable.com/2xsedp

before i always got this warning/error:
<img width="847" height="56" alt="image" src="https://github.com/user-attachments/assets/8a15f942-74f8-415e-b0e7-30c52fd7267a" />


<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
