### PR TITLE
fix: marked as offline even though online

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
@@ -312,7 +312,7 @@ describe('ProjectManagerStore project creation', () => {
     store.retryDisconnectedSshProjects({ force: true });
     await Promise.resolve();
 
-    expect(mocks.sshConnect).toHaveBeenCalledWith('ssh-1');
+    expect(mocks.sshConnect).toHaveBeenCalledWith('ssh-1', { force: true });
     expect(mocks.openProject).toHaveBeenCalledWith(project.id);
   });
 

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
@@ -310,8 +310,27 @@ describe('ProjectManagerStore project creation', () => {
     projectStore.errorCode = 'ssh-disconnected';
 
     store.retryDisconnectedSshProjects({ force: true });
+    await Promise.resolve();
 
     expect(mocks.sshConnect).toHaveBeenCalledWith('ssh-1');
+    expect(mocks.openProject).toHaveBeenCalledWith(project.id);
+  });
+
+  it('mounts SSH-disconnected projects when the connection is already connected', () => {
+    mocks.sshStateFor.mockReturnValue('connected');
+    const store = new ProjectManagerStore();
+    const project = sshProject();
+    store.projects.set(project.id, createUnmountedProject(project, 'idle'));
+    const projectStore = store.projects.get(project.id);
+    if (!projectStore) throw new Error('Expected project store');
+    projectStore.phase = 'error';
+    projectStore.error = project.connectionId;
+    projectStore.errorCode = 'ssh-disconnected';
+
+    store.retryDisconnectedSshProjects({ force: true });
+
+    expect(mocks.sshConnect).not.toHaveBeenCalled();
+    expect(mocks.openProject).toHaveBeenCalledWith(project.id);
   });
 
   it('does not write GitHub account settings when creation did not specify one', async () => {

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { LocalProject, SshProject } from '@shared/projects';
 import { createUnmountedProject, isUnregisteredProject } from './project';
 import { ProjectManagerStore } from './project-manager';
@@ -98,8 +98,13 @@ function okProject(project: LocalProject) {
 }
 
 describe('ProjectManagerStore project creation', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.eventOn.mockReturnValue(vi.fn());
     mocks.inspectProjectPath.mockResolvedValue({ isDirectory: true, isGitRepo: true });
     mocks.createProject.mockResolvedValue(okProject(localProject()));
     mocks.openProject.mockReturnValue(new Promise(() => {}));
@@ -299,7 +304,25 @@ describe('ProjectManagerStore project creation', () => {
     expect(mocks.updateProjectSettings).not.toHaveBeenCalled();
   });
 
-  it('retries SSH-disconnected projects when recovery is triggered', async () => {
+  it('removes window and SSH event listeners on dispose', () => {
+    const disposeSshEvent = vi.fn();
+    mocks.eventOn.mockReturnValueOnce(disposeSshEvent);
+    const addEventListener = vi.fn();
+    const removeEventListener = vi.fn();
+    vi.stubGlobal('window', { addEventListener, removeEventListener });
+    const store = new ProjectManagerStore();
+
+    store.dispose();
+    store.dispose();
+
+    expect(disposeSshEvent).toHaveBeenCalledTimes(1);
+    expect(removeEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+    expect(removeEventListener).toHaveBeenCalledWith('focus', expect.any(Function));
+    expect(addEventListener).toHaveBeenCalledWith('online', expect.any(Function));
+    expect(addEventListener).toHaveBeenCalledWith('focus', expect.any(Function));
+  });
+
+  it('retries SSH-disconnected projects without mounting before the connection is ready', async () => {
     const store = new ProjectManagerStore();
     const project = sshProject();
     store.projects.set(project.id, createUnmountedProject(project, 'idle'));
@@ -313,6 +336,23 @@ describe('ProjectManagerStore project creation', () => {
     await Promise.resolve();
 
     expect(mocks.sshConnect).toHaveBeenCalledWith('ssh-1', { force: true });
+    expect(mocks.openProject).not.toHaveBeenCalled();
+  });
+
+  it('mounts SSH-disconnected projects after a successful reconnect event', () => {
+    const store = new ProjectManagerStore();
+    const project = sshProject();
+    store.projects.set(project.id, createUnmountedProject(project, 'idle'));
+    const projectStore = store.projects.get(project.id);
+    if (!projectStore) throw new Error('Expected project store');
+    projectStore.phase = 'error';
+    projectStore.error = project.connectionId;
+    projectStore.errorCode = 'ssh-disconnected';
+
+    const handler = mocks.eventOn.mock.calls[0]?.[1];
+    if (!handler) throw new Error('Expected SSH event subscription');
+    handler({ type: 'connected', connectionId: 'ssh-1' });
+
     expect(mocks.openProject).toHaveBeenCalledWith(project.id);
   });
 

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
@@ -1,6 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import type { LocalProject } from '@shared/projects';
-import { isUnregisteredProject } from './project';
+import type { LocalProject, SshProject } from '@shared/projects';
+import { createUnmountedProject, isUnregisteredProject } from './project';
 import { ProjectManagerStore } from './project-manager';
 
 const mocks = vi.hoisted(() => ({
@@ -14,6 +14,8 @@ const mocks = vi.hoisted(() => ({
   patchProjectSettings: vi.fn(),
   updateProjectSettings: vi.fn(),
   eventOn: vi.fn(),
+  sshConnect: vi.fn(),
+  sshStateFor: vi.fn(),
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({
@@ -45,6 +47,10 @@ vi.mock('@renderer/lib/stores/app-state', () => ({
       revalidate: vi.fn(),
       viewParamsStore: {},
     },
+    sshConnections: {
+      connect: mocks.sshConnect,
+      stateFor: mocks.sshStateFor,
+    },
   },
 }));
 
@@ -65,6 +71,21 @@ function localProject(overrides: Partial<LocalProject> = {}): LocalProject {
     name: 'Project',
     path: '/project',
     baseRef: 'main',
+    repositoryWorkspaceId: null,
+    createdAt: '2026-05-28T00:00:00.000Z',
+    updatedAt: '2026-05-28T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+function sshProject(overrides: Partial<SshProject> = {}): SshProject {
+  return {
+    type: 'ssh',
+    id: 'ssh-project-id',
+    name: 'SSH Project',
+    path: '/project',
+    baseRef: 'main',
+    connectionId: 'ssh-1',
     repositoryWorkspaceId: null,
     createdAt: '2026-05-28T00:00:00.000Z',
     updatedAt: '2026-05-28T00:00:00.000Z',
@@ -99,6 +120,8 @@ describe('ProjectManagerStore project creation', () => {
       success: true,
       data: { githubAccountId: 'github.com:42' },
     });
+    mocks.sshConnect.mockResolvedValue(undefined);
+    mocks.sshStateFor.mockReturnValue('disconnected');
   });
 
   it('returns an existing project without starting creation', async () => {
@@ -274,6 +297,21 @@ describe('ProjectManagerStore project creation', () => {
       githubAccountId: 'github.com:42',
     });
     expect(mocks.updateProjectSettings).not.toHaveBeenCalled();
+  });
+
+  it('retries SSH-disconnected projects when recovery is triggered', async () => {
+    const store = new ProjectManagerStore();
+    const project = sshProject();
+    store.projects.set(project.id, createUnmountedProject(project, 'idle'));
+    const projectStore = store.projects.get(project.id);
+    if (!projectStore) throw new Error('Expected project store');
+    projectStore.phase = 'error';
+    projectStore.error = project.connectionId;
+    projectStore.errorCode = 'ssh-disconnected';
+
+    store.retryDisconnectedSshProjects({ force: true });
+
+    expect(mocks.sshConnect).toHaveBeenCalledWith('ssh-1');
   });
 
   it('does not write GitHub account settings when creation did not specify one', async () => {

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
@@ -33,21 +33,31 @@ export class ProjectManagerStore {
   private _projectMountPromises = new Map<string, Promise<void>>();
   private _loadPromise: Promise<void> | null = null;
   private _lastSshRecoveryAttemptAt = 0;
+  private _disposeSshConnectionEvent: (() => void) | null = null;
+  private readonly _handleOnline = (): void => {
+    this.retryDisconnectedSshProjects({ force: true });
+  };
+  private readonly _handleFocus = (): void => {
+    this.retryDisconnectedSshProjects();
+  };
 
   constructor() {
     makeObservable(this, { projects: observable, pendingCreationIds: observable });
 
-    events.on(sshConnectionEventChannel, (event) => {
+    this._disposeSshConnectionEvent = events.on(sshConnectionEventChannel, (event) => {
       if (event.type !== 'connected' && event.type !== 'reconnected') return;
       this._mountDisconnectedSshProjects(event.connectionId);
     });
 
-    globalThis.window?.addEventListener('online', () => {
-      this.retryDisconnectedSshProjects({ force: true });
-    });
-    globalThis.window?.addEventListener('focus', () => {
-      this.retryDisconnectedSshProjects();
-    });
+    globalThis.window?.addEventListener('online', this._handleOnline);
+    globalThis.window?.addEventListener('focus', this._handleFocus);
+  }
+
+  dispose(): void {
+    this._disposeSshConnectionEvent?.();
+    this._disposeSshConnectionEvent = null;
+    globalThis.window?.removeEventListener('online', this._handleOnline);
+    globalThis.window?.removeEventListener('focus', this._handleFocus);
   }
 
   load(): Promise<void> {
@@ -396,7 +406,11 @@ export class ProjectManagerStore {
       if (state === 'connecting') continue;
       void appState.sshConnections
         .connect(connectionId, { force: true })
-        .then(() => this._mountDisconnectedSshProjects(connectionId))
+        .then(() => {
+          if (appState.sshConnections.stateFor(connectionId) === 'connected') {
+            this._mountDisconnectedSshProjects(connectionId);
+          }
+        })
         .catch(() => {});
     }
   }

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
@@ -39,16 +39,7 @@ export class ProjectManagerStore {
 
     events.on(sshConnectionEventChannel, (event) => {
       if (event.type !== 'connected' && event.type !== 'reconnected') return;
-      for (const [projectId, store] of this.projects) {
-        if (
-          isUnmountedProject(store) &&
-          store.errorCode === 'ssh-disconnected' &&
-          store.data.type === 'ssh' &&
-          store.data.connectionId === event.connectionId
-        ) {
-          this.mountProject(projectId).catch(() => {});
-        }
-      }
+      this._mountDisconnectedSshProjects(event.connectionId);
     });
 
     globalThis.window?.addEventListener('online', () => {
@@ -398,8 +389,28 @@ export class ProjectManagerStore {
 
     for (const connectionId of connectionIds) {
       const state = appState.sshConnections.stateFor(connectionId);
-      if (state === 'connected' || state === 'connecting' || state === 'reconnecting') continue;
-      void appState.sshConnections.connect(connectionId).catch(() => {});
+      if (state === 'connected') {
+        this._mountDisconnectedSshProjects(connectionId);
+        continue;
+      }
+      if (state === 'connecting' || state === 'reconnecting') continue;
+      void appState.sshConnections
+        .connect(connectionId)
+        .then(() => this._mountDisconnectedSshProjects(connectionId))
+        .catch(() => {});
+    }
+  }
+
+  private _mountDisconnectedSshProjects(connectionId: string): void {
+    for (const [projectId, store] of this.projects) {
+      if (
+        isUnmountedProject(store) &&
+        store.errorCode === 'ssh-disconnected' &&
+        store.data.type === 'ssh' &&
+        store.data.connectionId === connectionId
+      ) {
+        this.mountProject(projectId).catch(() => {});
+      }
     }
   }
 

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
@@ -393,9 +393,9 @@ export class ProjectManagerStore {
         this._mountDisconnectedSshProjects(connectionId);
         continue;
       }
-      if (state === 'connecting' || state === 'reconnecting') continue;
+      if (state === 'connecting') continue;
       void appState.sshConnections
-        .connect(connectionId)
+        .connect(connectionId, { force: true })
         .then(() => this._mountDisconnectedSshProjects(connectionId))
         .catch(() => {});
     }

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
@@ -32,6 +32,7 @@ export class ProjectManagerStore {
   pendingCreationIds = observable.set<string>();
   private _projectMountPromises = new Map<string, Promise<void>>();
   private _loadPromise: Promise<void> | null = null;
+  private _lastSshRecoveryAttemptAt = 0;
 
   constructor() {
     makeObservable(this, { projects: observable, pendingCreationIds: observable });
@@ -48,6 +49,13 @@ export class ProjectManagerStore {
           this.mountProject(projectId).catch(() => {});
         }
       }
+    });
+
+    globalThis.window?.addEventListener('online', () => {
+      this.retryDisconnectedSshProjects({ force: true });
+    });
+    globalThis.window?.addEventListener('focus', () => {
+      this.retryDisconnectedSshProjects();
     });
   }
 
@@ -367,6 +375,31 @@ export class ProjectManagerStore {
         if (snapshot) this.projects.set(projectId, snapshot);
       });
       throw err;
+    }
+  }
+
+  retryDisconnectedSshProjects(options: { force?: boolean } = {}): void {
+    const now = Date.now();
+    if (!options.force && now - this._lastSshRecoveryAttemptAt < 5_000) return;
+
+    const connectionIds = new Set<string>();
+    for (const store of this.projects.values()) {
+      if (
+        isUnmountedProject(store) &&
+        store.errorCode === 'ssh-disconnected' &&
+        store.data.type === 'ssh'
+      ) {
+        connectionIds.add(store.data.connectionId);
+      }
+    }
+
+    if (connectionIds.size === 0) return;
+    this._lastSshRecoveryAttemptAt = now;
+
+    for (const connectionId of connectionIds) {
+      const state = appState.sshConnections.stateFor(connectionId);
+      if (state === 'connected' || state === 'connecting' || state === 'reconnecting') continue;
+      void appState.sshConnections.connect(connectionId).catch(() => {});
     }
   }
 

--- a/apps/emdash-desktop/src/renderer/features/sidebar/project-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/project-item.tsx
@@ -13,6 +13,7 @@ import { observer } from 'mobx-react-lite';
 import React, { useCallback, useEffect } from 'react';
 import { useConfirmDeleteProject } from '@renderer/features/projects/hooks/use-confirm-delete-project';
 import {
+  isUnmountedProject,
   isUnregisteredProject,
   type UnregisteredProject,
 } from '@renderer/features/projects/stores/project';
@@ -39,6 +40,7 @@ import {
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
+import type { ConnectionState } from '@shared/core/ssh/ssh';
 import {
   SidebarItemMiniButton,
   SidebarMenuAction,
@@ -97,6 +99,12 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
   const sshConnectionState = sshConnectionId
     ? appState.sshConnections.stateFor(sshConnectionId)
     : null;
+  const displayedSshConnectionState: ConnectionState | null =
+    isUnmountedProject(project) &&
+    project.errorCode === 'ssh-disconnected' &&
+    sshConnectionState !== 'connected'
+      ? 'disconnected'
+      : sshConnectionState;
   const canReconnect = sshConnectionState !== 'connected';
   const ProjectIcon = isSshProject ? FolderInput : FolderClosed;
   const projectLabel = project.name ?? 'project';
@@ -160,7 +168,7 @@ export const SidebarProjectItem = observer(function SidebarProjectItem({
               {isSshProject ? (
                 <span className="flex min-w-0 items-center gap-2">
                   <span className="truncate">{project.name}</span>
-                  <ConnectionStatusDot state={sshConnectionState} />
+                  <ConnectionStatusDot state={displayedSshConnectionState} />
                 </span>
               ) : (
                 <span className="flex min-w-0 items-center gap-1.5">

--- a/apps/emdash-desktop/src/renderer/lib/stores/ssh-connection-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/ssh-connection-store.test.ts
@@ -94,6 +94,24 @@ describe('SshConnectionStore', () => {
     expect(store.healthStates).toEqual({});
   });
 
+  it('allows forced connect while reconnecting', async () => {
+    const store = new SshConnectionStore();
+    store.start();
+
+    emitSshEvent({
+      type: 'reconnecting',
+      connectionId: 'ssh-1',
+      attempt: 1,
+      delayMs: 20_000,
+    });
+
+    await store.connect('ssh-1');
+    expect(rpc.ssh.connect).not.toHaveBeenCalled();
+
+    await store.connect('ssh-1', { force: true });
+    expect(rpc.ssh.connect).toHaveBeenCalledWith('ssh-1');
+  });
+
   it('passes SSH config alias and proxy metadata through saveConnection', async () => {
     const store = new SshConnectionStore();
 

--- a/apps/emdash-desktop/src/renderer/lib/stores/ssh-connection-store.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/ssh-connection-store.ts
@@ -149,9 +149,13 @@ export class SshConnectionStore {
     return this.healthStates[connectionId] ?? { status: 'ok' };
   }
 
-  async connect(connectionId: string): Promise<void> {
+  async connect(connectionId: string, options: { force?: boolean } = {}): Promise<void> {
     const state = this.stateFor(connectionId);
-    if (state === 'connected' || state === 'connecting' || state === 'reconnecting') {
+    if (
+      state === 'connected' ||
+      state === 'connecting' ||
+      (!options.force && state === 'reconnecting')
+    ) {
       return;
     }
     await rpc.ssh.connect(connectionId);


### PR DESCRIPTION
### Description
- fix stale ssh offline state after host comes back online
- retry disconnected ssh projects on app focus / online event
- dedupe retries per ssh connection to avoid active reconnect spam

### Screenshot/Recording (if applicable)
https://streamable.com/8cztwz

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
