### PR TITLE
refactor(plugins): make plugin capabilities optional

### DIFF
--- a/packages/core/src/agents/plugins/capabilities/auto-approve.ts
+++ b/packages/core/src/agents/plugins/capabilities/auto-approve.ts
@@ -11,5 +11,6 @@ export const autoApproveCapability = definePluginCapability()(
   'auto-approve',
   z.object({
     kind: z.enum(['supported', 'none']),
-  })
+  }),
+  { kind: 'none' }
 );

--- a/packages/core/src/agents/plugins/capabilities/effort.ts
+++ b/packages/core/src/agents/plugins/capabilities/effort.ts
@@ -24,5 +24,6 @@ export const effortCapability = definePluginCapability()(
     z.object({
       kind: z.literal('none'),
     }),
-  ])
+  ]),
+  { kind: 'none' }
 );

--- a/packages/core/src/agents/plugins/capabilities/hooks.ts
+++ b/packages/core/src/agents/plugins/capabilities/hooks.ts
@@ -45,5 +45,6 @@ export const hooksCapability = definePluginCapability<IHooksBehavior>()(
       ),
     }),
     z.object({ kind: z.literal('none') }),
-  ])
+  ]),
+  { kind: 'none' }
 );

--- a/packages/core/src/agents/plugins/capabilities/mcp.ts
+++ b/packages/core/src/agents/plugins/capabilities/mcp.ts
@@ -33,5 +33,6 @@ export const mcpCapability = definePluginCapability<IMcpBehavior>()(
     z.object({
       kind: z.literal('none'),
     }),
-  ])
+  ]),
+  { kind: 'none' }
 );

--- a/packages/core/src/agents/plugins/capabilities/models.ts
+++ b/packages/core/src/agents/plugins/capabilities/models.ts
@@ -27,5 +27,6 @@ export const modelsCapability = definePluginCapability()(
       modelOptions: z.record(z.string(), modelOptionSchema),
     }),
     z.object({ kind: z.literal('none') }),
-  ])
+  ]),
+  { kind: 'none' }
 );

--- a/packages/core/src/agents/plugins/capabilities/plugins.ts
+++ b/packages/core/src/agents/plugins/capabilities/plugins.ts
@@ -29,5 +29,6 @@ export const pluginsCapability = definePluginCapability<IPlugins>()(
     }),
     z.object({ kind: z.literal('cli') }),
     z.object({ kind: z.literal('none') }),
-  ])
+  ]),
+  { kind: 'none' }
 );

--- a/packages/core/src/lib/plugins/capability.ts
+++ b/packages/core/src/lib/plugins/capability.ts
@@ -9,13 +9,30 @@ import type z from 'zod';
  *
  *   const hooksCapability = definePluginCapability<IHooksBehavior>()('hooks', schema);
  *   const autoApprove = definePluginCapability()('auto-approve', schema); // no behavior
+ *
+ * An optional third argument supplies a default descriptor value. Capabilities
+ * with a default become optional in definePlugin — plugins may omit them and the
+ * default is filled in at definition time so all downstream consumers still see a
+ * fully-populated capabilities object:
+ *
+ *   const effortCapability = definePluginCapability()('effort', schema, { kind: 'none' });
  */
 export function definePluginCapability<TBehavior = never>() {
-  return <TId extends string, TSchema extends z.ZodType>(id: TId, descriptorSchema: TSchema) => ({
+  return <
+    TId extends string,
+    TSchema extends z.ZodType,
+    TDefault extends z.input<TSchema> | undefined = undefined,
+  >(
+    id: TId,
+    descriptorSchema: TSchema,
+    defaultDescriptor?: TDefault
+  ) => ({
     id,
     descriptorSchema,
+    defaultDescriptor,
     _descriptor: undefined as z.output<TSchema>,
     _behavior: undefined as unknown as TBehavior,
+    _hasDefault: (defaultDescriptor !== undefined) as [TDefault] extends [undefined] ? false : true,
   });
 }
 
@@ -23,8 +40,10 @@ export function definePluginCapability<TBehavior = never>() {
 export type AnyPluginCapability = {
   id: string;
   descriptorSchema: z.ZodType;
+  defaultDescriptor?: unknown;
   _descriptor: unknown;
   _behavior: unknown;
+  _hasDefault: boolean;
 };
 
 export type CapabilityMap = Record<string, AnyPluginCapability>;
@@ -41,8 +60,24 @@ export type InferPluginBehaviorType<TCapability> = TCapability extends {
   ? TBehavior
   : never;
 
-/** What definePlugin accepts: every capability slot, declaratively. */
+type DefaultedKeys<TCaps extends CapabilityMap> = {
+  [K in keyof TCaps]: TCaps[K]['_hasDefault'] extends true ? K : never;
+}[keyof TCaps];
+
+type RequiredKeys<TCaps extends CapabilityMap> = Exclude<keyof TCaps, DefaultedKeys<TCaps>>;
+
+/**
+ * What definePlugin accepts: required capabilities must be present; defaulted
+ * capabilities (those declared with a defaultDescriptor) are optional.
+ */
 export type CapabilityDescriptors<TCaps extends CapabilityMap> = {
+  [K in RequiredKeys<TCaps>]: TCaps[K]['_descriptor'];
+} & {
+  [K in DefaultedKeys<TCaps>]?: TCaps[K]['_descriptor'];
+};
+
+/** All capability slots after defaults are resolved — always fully populated. */
+export type ResolvedCapabilityDescriptors<TCaps extends CapabilityMap> = {
   [K in keyof TCaps]: TCaps[K]['_descriptor'];
 };
 

--- a/packages/core/src/lib/plugins/framework.ts
+++ b/packages/core/src/lib/plugins/framework.ts
@@ -1,6 +1,11 @@
 import type z from 'zod';
 import type { AssetDescriptors, AssetMap } from './asset';
-import type { CapabilityBehaviors, CapabilityDescriptors, CapabilityMap } from './capability';
+import type {
+  CapabilityBehaviors,
+  CapabilityDescriptors,
+  CapabilityMap,
+  ResolvedCapabilityDescriptors,
+} from './capability';
 
 /**
  * Create a plugin framework bound to a fixed capability map, metadata schema,
@@ -23,16 +28,23 @@ export function createPluginFramework<
     capabilities: CapabilityDescriptors<TCaps>,
     assets: AssetDescriptors<TAssets>
   ) {
+    const resolved = {} as ResolvedCapabilityDescriptors<TCaps>;
+    for (const key of Object.keys(capabilityMap) as (keyof TCaps)[]) {
+      const provided = (capabilities as Record<keyof TCaps, unknown>)[key];
+      (resolved as Record<keyof TCaps, unknown>)[key] =
+        provided !== undefined ? provided : capabilityMap[key].defaultDescriptor;
+    }
+
     return {
       metadata,
-      capabilities,
+      capabilities: resolved,
       assets,
       validate(): z.ZodError[] {
         const metaResult = metadataSchema.safeParse(metadata);
         if (!metaResult.success) return [metaResult.error];
         return [
           ...Object.entries(capabilityMap).flatMap(([key, cap]) => {
-            const result = cap.descriptorSchema.safeParse(capabilities[key as keyof TCaps]);
+            const result = cap.descriptorSchema.safeParse(resolved[key as keyof TCaps]);
             return result.success ? [] : [result.error];
           }),
           ...Object.entries(assetMap).flatMap(([key, asset]) => {

--- a/packages/plugins/src/agents/impl/amp/index.ts
+++ b/packages/plugins/src/agents/impl/amp/index.ts
@@ -22,9 +22,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'plugin',
       scope: 'workspace',
@@ -39,9 +36,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
     },
     plugins: {
       kind: 'file-drop',

--- a/packages/plugins/src/agents/impl/antigravity/index.ts
+++ b/packages/plugins/src/agents/impl/antigravity/index.ts
@@ -14,12 +14,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: {
       id: 'antigravity',
       binaryNames: ['agy', 'antigravity'],
@@ -46,15 +40,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/auggie/index.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.ts
@@ -11,25 +11,7 @@ export const plugin = definePlugin(
     websiteUrl: 'https://docs.augmentcode.com/cli/overview',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({ id: 'auggie', package: '@augmentcode/auggie' }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'argv',
       flag: '',

--- a/packages/plugins/src/agents/impl/autohand/index.ts
+++ b/packages/plugins/src/agents/impl/autohand/index.ts
@@ -14,22 +14,7 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({ id: 'autohand', package: 'autohand-cli' }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'argv',
       flag: '-p',

--- a/packages/plugins/src/agents/impl/charm/index.ts
+++ b/packages/plugins/src/agents/impl/charm/index.ts
@@ -13,26 +13,11 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({
       id: 'charm',
       package: '@charmland/crush',
       binaryNames: ['crush'],
     }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'argv',
       flag: '',

--- a/packages/plugins/src/agents/impl/claude/index.ts
+++ b/packages/plugins/src/agents/impl/claude/index.ts
@@ -19,9 +19,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -75,12 +72,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/cline/index.ts
+++ b/packages/plugins/src/agents/impl/cline/index.ts
@@ -14,22 +14,7 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({ id: 'cline', package: 'cline' }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'argv',
       flag: '',

--- a/packages/plugins/src/agents/impl/codebuff/index.ts
+++ b/packages/plugins/src/agents/impl/codebuff/index.ts
@@ -11,25 +11,7 @@ export const plugin = definePlugin(
     websiteUrl: 'https://www.codebuff.com/docs/help/quick-start',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({ id: 'codebuff', package: 'codebuff' }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'argv',
       flag: '',

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -20,9 +20,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'global',
@@ -49,12 +46,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/commandcode/index.ts
+++ b/packages/plugins/src/agents/impl/commandcode/index.ts
@@ -15,9 +15,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -29,15 +26,6 @@ export const plugin = definePlugin(
       binaryNames: ['command-code', 'commandcode', 'cmdc'],
       versionSuffix: '@latest',
     }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'argv',
       flag: '',

--- a/packages/plugins/src/agents/impl/continue/index.ts
+++ b/packages/plugins/src/agents/impl/continue/index.ts
@@ -14,12 +14,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: {
       id: 'continue',
       binaryNames: ['cn'],
@@ -53,15 +47,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/copilot/index.ts
+++ b/packages/plugins/src/agents/impl/copilot/index.ts
@@ -19,9 +19,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -32,12 +29,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/cursor/index.ts
+++ b/packages/plugins/src/agents/impl/cursor/index.ts
@@ -14,12 +14,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: {
       id: 'cursor',
       binaryNames: ['cursor-agent'],
@@ -51,12 +45,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/devin/index.ts
+++ b/packages/plugins/src/agents/impl/devin/index.ts
@@ -15,9 +15,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -49,15 +46,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/droid/index.ts
+++ b/packages/plugins/src/agents/impl/droid/index.ts
@@ -11,12 +11,6 @@ export const plugin = definePlugin(
     websiteUrl: 'https://docs.factory.ai/cli/getting-started/quickstart',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -53,12 +47,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/freebuff/index.ts
+++ b/packages/plugins/src/agents/impl/freebuff/index.ts
@@ -11,25 +11,7 @@ export const plugin = definePlugin(
     websiteUrl: 'https://freebuff.com',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({ id: 'freebuff', package: 'freebuff' }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'argv',
       flag: '',

--- a/packages/plugins/src/agents/impl/gemini/index.ts
+++ b/packages/plugins/src/agents/impl/gemini/index.ts
@@ -18,23 +18,11 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({ id: 'gemini', package: '@google/gemini-cli' }),
     mcp: {
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/goose/index.ts
+++ b/packages/plugins/src/agents/impl/goose/index.ts
@@ -10,15 +10,6 @@ export const plugin = definePlugin(
     websiteUrl: 'https://goose-docs.ai/docs/quickstart/',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: {
       id: 'goose',
       binaryNames: ['goose'],
@@ -48,15 +39,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/grok/index.ts
+++ b/packages/plugins/src/agents/impl/grok/index.ts
@@ -15,9 +15,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'global',
@@ -49,15 +46,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/hermes/index.ts
+++ b/packages/plugins/src/agents/impl/hermes/index.ts
@@ -14,12 +14,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: {
       id: 'hermes',
       binaryNames: ['hermes'],
@@ -46,15 +40,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'keystroke',

--- a/packages/plugins/src/agents/impl/jules/index.ts
+++ b/packages/plugins/src/agents/impl/jules/index.ts
@@ -11,29 +11,11 @@ export const plugin = definePlugin(
     websiteUrl: 'https://jules.google/docs/cli/reference/',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({
       id: 'jules',
       package: '@google/jules',
       versionArgs: ['version'],
     }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'keystroke',
     },

--- a/packages/plugins/src/agents/impl/junie/index.ts
+++ b/packages/plugins/src/agents/impl/junie/index.ts
@@ -11,15 +11,6 @@ export const plugin = definePlugin(
     websiteUrl: 'https://junie.jetbrains.com/docs/junie-cli.html',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: {
       id: 'junie',
       binaryNames: ['junie'],
@@ -46,15 +37,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/kilocode/index.ts
+++ b/packages/plugins/src/agents/impl/kilocode/index.ts
@@ -21,9 +21,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'plugin',
       scope: 'workspace',
@@ -34,12 +31,6 @@ export const plugin = definePlugin(
       package: '@kilocode/cli',
       binaryNames: ['kilo'],
     }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
     plugins: {
       kind: 'file-drop',
       scope: 'workspace',

--- a/packages/plugins/src/agents/impl/kimi/index.ts
+++ b/packages/plugins/src/agents/impl/kimi/index.ts
@@ -38,9 +38,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'global',
@@ -73,15 +70,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'keystroke',

--- a/packages/plugins/src/agents/impl/kiro/index.ts
+++ b/packages/plugins/src/agents/impl/kiro/index.ts
@@ -15,9 +15,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -49,15 +46,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/letta/index.ts
+++ b/packages/plugins/src/agents/impl/letta/index.ts
@@ -14,26 +14,11 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: npmDependency({
       id: 'letta',
       package: '@letta-ai/letta-code',
       skipVersionProbe: true,
     }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
-    },
     prompt: {
       kind: 'keystroke',
     },

--- a/packages/plugins/src/agents/impl/mistral/index.ts
+++ b/packages/plugins/src/agents/impl/mistral/index.ts
@@ -15,9 +15,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -50,15 +47,6 @@ export const plugin = definePlugin(
           kind: 'package-manager',
         },
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/opencode/index.ts
+++ b/packages/plugins/src/agents/impl/opencode/index.ts
@@ -23,9 +23,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'plugin',
       scope: 'workspace',
@@ -36,9 +33,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
     },
     plugins: {
       kind: 'file-drop',

--- a/packages/plugins/src/agents/impl/pi/index.ts
+++ b/packages/plugins/src/agents/impl/pi/index.ts
@@ -18,12 +18,6 @@ export const plugin = definePlugin(
     websiteUrl: 'https://github.com/earendil-works/pi/tree/main/packages/coding-agent',
   },
   {
-    autoApprove: {
-      kind: 'none',
-    },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'plugin',
       scope: 'workspace',
@@ -34,12 +28,6 @@ export const plugin = definePlugin(
       package: '@earendil-works/pi-coding-agent',
       installFlags: '--ignore-scripts',
     }),
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
     plugins: {
       kind: 'file-drop',
       scope: 'workspace',

--- a/packages/plugins/src/agents/impl/qwen/index.ts
+++ b/packages/plugins/src/agents/impl/qwen/index.ts
@@ -19,9 +19,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -32,12 +29,6 @@ export const plugin = definePlugin(
       kind: 'supported',
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',

--- a/packages/plugins/src/agents/impl/rovo/index.ts
+++ b/packages/plugins/src/agents/impl/rovo/index.ts
@@ -15,12 +15,6 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
-    effort: {
-      kind: 'none',
-    },
-    hooks: {
-      kind: 'none',
-    },
     hostDependency: {
       id: 'rovo',
       binaryNames: ['rovodev', 'acli'],
@@ -41,15 +35,6 @@ export const plugin = definePlugin(
       updates: {
         kind: 'none',
       },
-    },
-    mcp: {
-      kind: 'none',
-    },
-    models: {
-      kind: 'none',
-    },
-    plugins: {
-      kind: 'none',
     },
     prompt: {
       kind: 'argv',


### PR DESCRIPTION
This PR makes it possible to define optional plugin capabilities removing the need to declare the absence of a capability in every plugin implementation