### PR TITLE
Fix git inspection errors when adding projects

### DIFF
--- a/apps/emdash-desktop/src/main/core/projects/operations/create-local-project.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/create-local-project.ts
@@ -8,7 +8,7 @@ import { db } from '@main/db/client';
 import { projects } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import type { CreateProjectResult, ProjectPathStatus } from '@shared/projects';
-import { checkIsValidDirectory } from '../path-utils';
+import { getDirectoryStatus } from '../path-utils';
 import { ensureProjectRepository } from './create-project-utils';
 import { ensureRepositoryWorkspace } from './ensure-repository-workspace';
 
@@ -22,8 +22,15 @@ export type CreateLocalProjectParams = {
 export async function createLocalProject(
   params: CreateLocalProjectParams
 ): Promise<CreateProjectResult> {
-  const isValidDirectory = checkIsValidDirectory(params.path);
-  if (!isValidDirectory) {
+  const directoryStatus = getDirectoryStatus(params.path);
+  if (directoryStatus.kind === 'inspect-failed') {
+    return err({
+      type: 'inspect-failed',
+      path: params.path,
+      message: directoryStatus.message,
+    });
+  }
+  if (directoryStatus.kind !== 'directory') {
     return err({
       type: 'invalid-directory',
       path: params.path,
@@ -80,14 +87,28 @@ export async function createLocalProject(
 }
 
 export async function getLocalProjectPathStatus(path: string): Promise<ProjectPathStatus> {
-  const isDirectory = checkIsValidDirectory(path);
-  if (!isDirectory) {
+  const directoryStatus = getDirectoryStatus(path);
+  if (directoryStatus.kind === 'inspect-failed') {
+    return {
+      isDirectory: false,
+      isGitRepo: false,
+      error: { type: 'inspect-failed', path, message: directoryStatus.message },
+    };
+  }
+  if (directoryStatus.kind !== 'directory') {
     return { isDirectory: false, isGitRepo: false };
   }
 
   const runtimeLease = await runtimeManager.acquire({ kind: 'local' });
   try {
     const inspection = await runtimeLease.value.git.inspectPath(path);
+    if (inspection.kind === 'inspect-failed') {
+      return {
+        isDirectory: true,
+        isGitRepo: false,
+        error: { type: 'inspect-failed', path: inspection.path, message: inspection.message },
+      };
+    }
     return { isDirectory: true, isGitRepo: inspection.kind === 'repository' };
   } finally {
     runtimeLease.release();

--- a/apps/emdash-desktop/src/main/core/projects/operations/create-ssh-project.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/create-ssh-project.ts
@@ -103,6 +103,13 @@ export async function getSshProjectPathStatus(
     const runtimeLease = await runtimeManager.acquire({ kind: 'ssh', connectionId });
     try {
       const inspection = await runtimeLease.value.git.inspectPath(path);
+      if (inspection.kind === 'inspect-failed') {
+        return {
+          isDirectory: true,
+          isGitRepo: false,
+          error: { type: 'inspect-failed', path: inspection.path, message: inspection.message },
+        };
+      }
       return { isDirectory: true, isGitRepo: inspection.kind === 'repository' };
     } finally {
       runtimeLease.release();

--- a/apps/emdash-desktop/src/main/core/projects/operations/createProject.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/createProject.test.ts
@@ -3,7 +3,7 @@ import os from 'node:os';
 import path from 'node:path';
 import type { Result } from '@emdash/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { createLocalProject } from './create-local-project';
+import { createLocalProject, getLocalProjectPathStatus } from './create-local-project';
 import { createSshProject, getSshProjectPathStatus } from './create-ssh-project';
 
 const mocks = vi.hoisted(() => ({
@@ -189,6 +189,41 @@ describe('createLocalProject', () => {
     expect(mocks.runtimeReleaseMock).toHaveBeenCalledTimes(1);
   });
 
+  it('surfaces git inspection failures when creating a local project', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-project-'));
+    tempDirs.push(projectPath);
+
+    mocks.ensureRepositoryMock.mockResolvedValueOnce({
+      success: false,
+      error: {
+        type: 'inspect-failed',
+        path: projectPath,
+        message: 'Permission denied',
+      },
+    });
+
+    await expect(
+      createLocalProject({
+        id: 'project-id',
+        name: 'Project',
+        path: projectPath,
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: {
+        type: 'inspect-failed',
+        path: projectPath,
+        message: 'Permission denied',
+      },
+    });
+
+    expect(mocks.ensureRepositoryMock).toHaveBeenCalledWith(projectPath, {
+      initIfMissing: false,
+    });
+    expect(mocks.openRepositoryMock).not.toHaveBeenCalled();
+    expect(mocks.runtimeReleaseMock).toHaveBeenCalledTimes(1);
+  });
+
   it('does not run git init when the folder is already a repository', async () => {
     const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-project-'));
     tempDirs.push(projectPath);
@@ -304,6 +339,50 @@ describe('createLocalProject', () => {
       expect.objectContaining({ baseRef: 'origin/feature/current' })
     );
     expect(created.baseRef).toBe('origin/feature/current');
+  });
+});
+
+describe('getLocalProjectPathStatus', () => {
+  const tempDirs: string[] = [];
+
+  afterEach(() => {
+    for (const dir of tempDirs.splice(0)) {
+      fs.rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('returns git status for existing local directories', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-project-'));
+    tempDirs.push(projectPath);
+    mocks.inspectPathMock.mockResolvedValueOnce({
+      kind: 'repository',
+      rootPath: projectPath,
+      baseRef: 'origin/main',
+    });
+
+    const status = await getLocalProjectPathStatus(projectPath);
+
+    expect(status).toEqual({ isDirectory: true, isGitRepo: true });
+    expect(mocks.inspectPathMock).toHaveBeenCalledWith(projectPath);
+  });
+
+  it('returns inspection failures separately from non-repository status', async () => {
+    const projectPath = fs.mkdtempSync(path.join(os.tmpdir(), 'emdash-project-'));
+    tempDirs.push(projectPath);
+    mocks.inspectPathMock.mockResolvedValueOnce({
+      kind: 'inspect-failed',
+      path: projectPath,
+      message: 'Permission denied',
+    });
+
+    const status = await getLocalProjectPathStatus(projectPath);
+
+    expect(status).toEqual({
+      isDirectory: true,
+      isGitRepo: false,
+      error: { type: 'inspect-failed', path: projectPath, message: 'Permission denied' },
+    });
+    expect(mocks.inspectPathMock).toHaveBeenCalledWith(projectPath);
   });
 });
 
@@ -465,6 +544,23 @@ describe('getSshProjectPathStatus', () => {
     const status = await getSshProjectPathStatus(projectPath, 'connection-id');
 
     expect(status).toEqual({ isDirectory: true, isGitRepo: true });
+    expect(mocks.inspectPathMock).toHaveBeenCalledWith(projectPath);
+  });
+
+  it('returns remote inspection failures separately from non-repository status', async () => {
+    mocks.inspectPathMock.mockResolvedValueOnce({
+      kind: 'inspect-failed',
+      path: projectPath,
+      message: 'Permission denied',
+    });
+
+    const status = await getSshProjectPathStatus(projectPath, 'connection-id');
+
+    expect(status).toEqual({
+      isDirectory: true,
+      isGitRepo: false,
+      error: { type: 'inspect-failed', path: projectPath, message: 'Permission denied' },
+    });
     expect(mocks.inspectPathMock).toHaveBeenCalledWith(projectPath);
   });
 });

--- a/apps/emdash-desktop/src/main/core/projects/path-utils.ts
+++ b/apps/emdash-desktop/src/main/core/projects/path-utils.ts
@@ -1,5 +1,28 @@
 import fs from 'node:fs';
 
+export type DirectoryStatus =
+  | { kind: 'directory' }
+  | { kind: 'not-directory' }
+  | { kind: 'inspect-failed'; message: string };
+
+export function getDirectoryStatus(path: string): DirectoryStatus {
+  try {
+    return fs.statSync(path).isDirectory() ? { kind: 'directory' } : { kind: 'not-directory' };
+  } catch (error) {
+    if (isMissingPathError(error)) return { kind: 'not-directory' };
+    return {
+      kind: 'inspect-failed',
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
 export function checkIsValidDirectory(path: string): boolean {
-  return fs.existsSync(path) && fs.statSync(path).isDirectory();
+  return getDirectoryStatus(path).kind === 'directory';
+}
+
+function isMissingPathError(error: unknown): boolean {
+  if (!error || typeof error !== 'object' || !('code' in error)) return false;
+  const code = (error as { code?: unknown }).code;
+  return code === 'ENOENT' || code === 'ENOTDIR';
 }

--- a/apps/emdash-desktop/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/add-project-modal/add-project-modal.tsx
@@ -250,9 +250,11 @@ export const AddProjectModal = observer(function AddProjectModal({
         : rpc.projects.inspectProjectPath({ type: 'local', path: pickState.path }),
     enabled: shouldCheckPickPathStatus,
   });
+  const pickPathInspectionError = mode === 'pick' ? pickPathStatusQuery.data?.error : undefined;
   const requiresGitInitialization =
     mode === 'pick' &&
     pickPathStatusQuery.data?.isDirectory === true &&
+    !pickPathStatusQuery.data.error &&
     pickPathStatusQuery.data.isGitRepo === false;
   const isCheckingPickPathStatus = shouldCheckPickPathStatus && pickPathStatusQuery.isPending;
 
@@ -260,6 +262,7 @@ export const AddProjectModal = observer(function AddProjectModal({
     activeMode.isValid &&
     (strategy === 'local' || !!selectedConnectionId) &&
     !isCheckingPickPathStatus &&
+    !pickPathInspectionError &&
     (mode !== 'new' || !githubAccountsQuery.isPending) &&
     (mode !== 'pick' || !requiresGitInitialization || !githubAccountsQuery.isPending) &&
     (!requiresGitInitialization || pickState.initGitRepository) &&
@@ -434,6 +437,7 @@ export const AddProjectModal = observer(function AddProjectModal({
             strategy={strategy}
             connectionId={selectedConnectionId}
             state={pickState}
+            inspectionError={pickPathInspectionError?.message}
             showInitializeGitPrompt={requiresGitInitialization}
           />
         )}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/add-project-modal/content.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/add-project-modal/content.tsx
@@ -18,11 +18,13 @@ export function PickExistingPanel({
   strategy,
   connectionId,
   state,
+  inspectionError,
   showInitializeGitPrompt,
 }: {
   strategy: Strategy;
   connectionId?: string;
   state: PickModeState;
+  inspectionError?: string;
   showInitializeGitPrompt: boolean;
 }) {
   const nameId = useId();
@@ -54,6 +56,14 @@ export function PickExistingPanel({
           onChange={(e) => state.handleNameChange(e.target.value)}
         />
       </Field>
+      {inspectionError && (
+        <div className="border-destructive/40 overflow-hidden rounded-md border">
+          <p className="border-destructive/30 bg-destructive/10 text-destructive border-b px-2 py-1 text-xs">
+            Could not inspect this directory.
+          </p>
+          <p className="p-2 text-xs text-foreground-muted">{inspectionError}</p>
+        </div>
+      )}
       {showInitializeGitPrompt && (
         <div className="overflow-hidden rounded-md border border-border">
           <p className="border-b border-border bg-background-1 px-2 py-1 text-xs text-foreground-muted">

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
@@ -427,6 +427,43 @@ describe('ProjectManagerStore project creation', () => {
     }
   });
 
+  it('marks project creation with an inspection failure message', async () => {
+    mocks.createProject.mockResolvedValueOnce({
+      success: false,
+      error: {
+        type: 'inspect-failed',
+        path: '/Volumes/Data/dev/myapp',
+        message: 'Permission denied',
+      },
+    });
+    const store = new ProjectManagerStore();
+
+    const result = await store.startProjectCreation(
+      { type: 'local' },
+      { mode: 'pick', name: 'Project', path: '/Volumes/Data/dev/myapp' },
+      { id: 'optimistic-project' }
+    );
+
+    expect(result.kind).toBe('creating');
+    if (result.kind === 'creating') {
+      await expect(result.completion).resolves.toEqual({
+        success: false,
+        error: {
+          type: 'inspect-failed',
+          path: '/Volumes/Data/dev/myapp',
+          message: 'Permission denied',
+        },
+      });
+    }
+
+    const project = store.projects.get('optimistic-project');
+    expect(project && isUnregisteredProject(project)).toBe(true);
+    if (project && isUnregisteredProject(project)) {
+      expect(project.phase).toBe('error');
+      expect(project.error).toBe('Could not inspect directory: Permission denied');
+    }
+  });
+
   it('persists the default GitHub account after initializing a picked folder', async () => {
     mocks.createProject.mockResolvedValueOnce(
       okProject(localProject({ id: 'optimistic-project' }))

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.ts
@@ -604,7 +604,9 @@ export class ProjectManagerStore {
         store.error =
           error.type === 'not-repository'
             ? 'Directory is not a git repository. Enable "Initialize git repository" to continue.'
-            : error.message;
+            : error.type === 'inspect-failed'
+              ? `Could not inspect directory: ${error.message}`
+              : error.message;
       }
     });
   }

--- a/apps/emdash-desktop/src/renderer/features/sidebar/use-sidebar-drop.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/use-sidebar-drop.ts
@@ -54,6 +54,14 @@ export function useSidebarDrop() {
               type: 'local',
               path: filePath,
             });
+            if (status.error) {
+              toast({
+                title: 'Cannot add project',
+                description: `Could not inspect ${basenameFromAnyPath(filePath)}: ${status.error.message}`,
+                variant: 'destructive',
+              });
+              return null;
+            }
             if (!status.isDirectory) {
               toast({
                 title: 'Cannot add project',

--- a/apps/emdash-desktop/src/shared/projects.ts
+++ b/apps/emdash-desktop/src/shared/projects.ts
@@ -3,6 +3,7 @@ import type { Result } from '@emdash/shared';
 export type ProjectPathStatus = {
   isDirectory: boolean;
   isGitRepo: boolean;
+  error?: { type: 'inspect-failed'; path: string; message: string };
 };
 
 export type LocalProject = {
@@ -54,6 +55,7 @@ export type CreateProjectParams = CreateLocalProjectParams | CreateSshProjectPar
 export type CreateProjectError =
   | { type: 'invalid-directory'; path: string; message: string }
   | { type: 'not-repository'; path: string }
+  | { type: 'inspect-failed'; path: string; message: string }
   | { type: 'init-failed'; path: string; message: string }
   | { type: 'open-repository-failed'; path: string; message: string };
 

--- a/packages/core/src/exec/bound-exec.ts
+++ b/packages/core/src/exec/bound-exec.ts
@@ -128,7 +128,7 @@ class ProcessBoundExec implements BoundExec {
           fail(error);
           return;
         }
-        failExec(null);
+        failExec(null, error instanceof Error ? error.message : String(error));
       });
 
       child.on('close', (code) => {

--- a/packages/core/src/git/git-runtime.test.ts
+++ b/packages/core/src/git/git-runtime.test.ts
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
 import { describe, expect, it } from 'vitest';
+import { ExecError, type BoundExec } from '../exec';
 import type { IFileWatchService } from '../fs';
 import { GitRuntime } from './index';
 
@@ -14,6 +15,9 @@ async function makeRepo(): Promise<string> {
   await execFileAsync('git', ['init', '-b', 'main'], { cwd: repo });
   await execFileAsync('git', ['config', 'user.email', 'test@example.com'], { cwd: repo });
   await execFileAsync('git', ['config', 'user.name', 'Test User'], { cwd: repo });
+  await writeFile(path.join(repo, 'INITIAL.md'), '# Initial\n', 'utf8');
+  await execFileAsync('git', ['add', 'INITIAL.md'], { cwd: repo });
+  await execFileAsync('git', ['commit', '-m', 'initial'], { cwd: repo });
   return repo;
 }
 
@@ -42,6 +46,25 @@ function createNoopWatcher(): IFileWatchService {
   };
 }
 
+function createFailingExec(error: unknown): BoundExec {
+  return {
+    file: 'git',
+    cwd: '/',
+    async exec() {
+      throw error;
+    },
+    async execStreaming() {
+      throw error;
+    },
+    async execBuffer() {
+      throw error;
+    },
+    withCwd() {
+      return this;
+    },
+  };
+}
+
 describe('GitRuntime', () => {
   it('inspects repository and non-repository paths without opening live models', async () => {
     const directory = await mkdtemp(path.join(tmpdir(), 'emdash-shared-runtime-plain-'));
@@ -57,6 +80,49 @@ describe('GitRuntime', () => {
         kind: 'repository',
         rootPath: await realpath(repo),
         baseRef: 'main',
+      });
+    } finally {
+      await runtime.dispose();
+    }
+  });
+
+  it('inspects paths with git -C instead of spawning inside the target directory', async () => {
+    const repo = await makeRepo();
+    const { executable, logPath } = await makeRecordingGitExecutable();
+    const runtime = new GitRuntime({ executable });
+
+    try {
+      await expect(runtime.inspectPath(repo)).resolves.toMatchObject({
+        kind: 'repository',
+        rootPath: await realpath(repo),
+      });
+    } finally {
+      await runtime.dispose();
+    }
+
+    const calls = (await readFile(logPath, 'utf8')).trim().split('\n').filter(Boolean);
+    expect(calls[0]).toBe(`-C ${repo} rev-parse --is-inside-work-tree`);
+  });
+
+  it('does not classify git inspection failures as non-repositories', async () => {
+    const targetPath = '/Volumes/Data/dev/myapp';
+    const error = new ExecError(
+      'git',
+      ['-C', targetPath, 'rev-parse', '--is-inside-work-tree'],
+      128,
+      '',
+      `fatal: cannot change to '${targetPath}': Permission denied`
+    );
+    const runtime = new GitRuntime({
+      exec: createFailingExec(error),
+      watcher: createNoopWatcher(),
+    });
+
+    try {
+      await expect(runtime.inspectPath(targetPath)).resolves.toEqual({
+        kind: 'inspect-failed',
+        path: targetPath,
+        message: `fatal: cannot change to '${targetPath}': Permission denied`,
       });
     } finally {
       await runtime.dispose();

--- a/packages/core/src/git/git-runtime.ts
+++ b/packages/core/src/git/git-runtime.ts
@@ -100,6 +100,9 @@ export class GitRuntime implements IGitRuntime {
     const resolvedPath = path.resolve(pathToInspect);
     const inspected = await this.inspectResolvedPath(resolvedPath);
     if (inspected.kind === 'repository') return ok(inspected);
+    if (inspected.kind === 'inspect-failed') {
+      return err({ type: 'inspect-failed', path: inspected.path, message: inspected.message });
+    }
     if (!options.initIfMissing) {
       return err({ type: 'not-repository', path: inspected.path });
     }
@@ -112,6 +115,13 @@ export class GitRuntime implements IGitRuntime {
 
     const initialized = await this.inspectResolvedPath(resolvedPath);
     if (initialized.kind === 'repository') return ok(initialized);
+    if (initialized.kind === 'inspect-failed') {
+      return err({
+        type: 'inspect-failed',
+        path: initialized.path,
+        message: initialized.message,
+      });
+    }
     return err({
       type: 'init-failed',
       path: resolvedPath,
@@ -135,6 +145,9 @@ export class GitRuntime implements IGitRuntime {
 
     const inspected = await this.inspectResolvedPath(resolvedTargetPath);
     if (inspected.kind === 'repository') return ok(inspected);
+    if (inspected.kind === 'inspect-failed') {
+      return err({ type: 'git_error', message: inspected.message });
+    }
     return err({
       type: 'git_error',
       message: `Cloned path is not a git repository: ${resolvedTargetPath}`,
@@ -228,30 +241,37 @@ export class GitRuntime implements IGitRuntime {
   }
 
   private async inspectResolvedPath(resolvedPath: string): Promise<GitPathInspection> {
-    const exec = this.exec.withCwd(resolvedPath);
+    const exec = (args: string[]) => this.exec.exec(['-C', resolvedPath, ...args]);
     try {
-      const { stdout } = await exec.exec(['rev-parse', '--is-inside-work-tree']);
+      const { stdout } = await exec(['rev-parse', '--is-inside-work-tree']);
       if (stdout.trim() !== 'true') return { kind: 'not-repository', path: resolvedPath };
-    } catch {
-      return { kind: 'not-repository', path: resolvedPath };
+    } catch (error) {
+      if (isNotRepositoryInspectionError(error)) {
+        return { kind: 'not-repository', path: resolvedPath };
+      }
+      return {
+        kind: 'inspect-failed',
+        path: resolvedPath,
+        message: gitErrorMessage(error),
+      };
     }
 
     let remoteName: string | undefined;
     try {
-      const { stdout } = await exec.exec(['remote']);
+      const { stdout } = await exec(['remote']);
       const remotes = stdout.trim().split('\n').filter(Boolean);
       remoteName = remotes.includes('origin') ? 'origin' : remotes[0];
     } catch {}
 
     let branch: string | undefined;
     try {
-      const { stdout } = await exec.exec(['branch', '--show-current']);
+      const { stdout } = await exec(['branch', '--show-current']);
       branch = stdout.trim() || undefined;
     } catch {}
 
     if (!branch && remoteName) {
       try {
-        const { stdout } = await exec.exec(['remote', 'show', remoteName]);
+        const { stdout } = await exec(['remote', 'show', remoteName]);
         const match = /HEAD branch:\s*(\S+)/.exec(stdout);
         branch = match?.[1] ?? undefined;
       } catch {}
@@ -259,7 +279,7 @@ export class GitRuntime implements IGitRuntime {
 
     let rootPath = resolvedPath;
     try {
-      const { stdout } = await exec.exec(['rev-parse', '--show-toplevel']);
+      const { stdout } = await exec(['rev-parse', '--show-toplevel']);
       const trimmed = stdout.trim();
       if (trimmed) rootPath = realpathOrResolve(trimmed);
     } catch {}
@@ -282,4 +302,13 @@ export class GitRuntime implements IGitRuntime {
     if (!this.worktrees.idle || !this.repositories.idle) return;
     if (this.ownsWatcher) await this.watcher.dispose();
   }
+}
+
+function isNotRepositoryInspectionError(error: unknown): boolean {
+  const message = gitErrorMessage(error).toLowerCase();
+  return (
+    message.includes('not a git repository') ||
+    message.includes('not a git directory') ||
+    message.includes('must be run in a work tree')
+  );
 }

--- a/packages/core/src/git/types.ts
+++ b/packages/core/src/git/types.ts
@@ -105,7 +105,10 @@ export type GitRepositoryInfo = {
   baseRef: string;
 };
 
-export type GitPathInspection = GitRepositoryInfo | { kind: 'not-repository'; path: string };
+export type GitPathInspection =
+  | GitRepositoryInfo
+  | { kind: 'not-repository'; path: string }
+  | { kind: 'inspect-failed'; path: string; message: string };
 
 export type EnsureRepositoryOptions = {
   initIfMissing?: boolean;
@@ -113,6 +116,7 @@ export type EnsureRepositoryOptions = {
 
 export type EnsureRepositoryError =
   | { type: 'not-repository'; path: string }
+  | { type: 'inspect-failed'; path: string; message: string }
   | { type: 'init-failed'; path: string; message: string };
 
 export interface IGitRepository extends IDisposable {


### PR DESCRIPTION
Fixes #2635.

This changes project git inspection to use git -C and shows an inspection error when the path cannot be read instead of saying the folder is not a git repository.

Tests:
- pnpm --filter @emdash/core exec vitest run src/git/git-runtime.test.ts src/exec/bound-exec.test.ts
- pnpm exec vitest run --project node src/main/core/projects/operations/createProject.test.ts src/renderer/features/projects/stores/project-manager.test.ts
- pnpm --filter @emdash/core run typecheck
- pnpm --filter @emdash/emdash-desktop run typecheck
- pnpm --filter @emdash/core run lint
- pnpm --filter @emdash/emdash-desktop run lint