### PR TITLE
feat(worktrees): add custom lifecycle commands

### DIFF
--- a/apps/emdash-desktop/src/main/core/projects/project-provider.ts
+++ b/apps/emdash-desktop/src/main/core/projects/project-provider.ts
@@ -17,7 +17,7 @@ import type { TerminalProvider } from '../terminals/terminal-provider';
 import type { WorkspaceType } from '../workspaces/workspace-factory';
 import type { ProjectSettingsProvider } from './settings/provider';
 import type { WorktreeHost } from './worktrees/hosts/worktree-host';
-import type { WorktreeService } from './worktrees/worktree-service';
+import type { WorktreeLifecycleContext, WorktreeService } from './worktrees/worktree-service';
 
 export type { WorkspaceProviderData };
 
@@ -109,10 +109,24 @@ export class ProjectProvider implements IDisposable {
     return this.worktreeService.getWorktree(branchName);
   }
 
-  async removeTaskWorktree(taskBranch: string): Promise<void> {
-    const worktreePath = await this.worktreeService.getWorktree(taskBranch);
+  async hasCustomWorktreeTeardownCommand(): Promise<boolean> {
+    return this.worktreeService.hasCustomTeardownCommand();
+  }
+
+  async removeTaskWorktree(
+    taskBranch: string,
+    options: { worktreePath?: string; lifecycleContext?: WorktreeLifecycleContext } = {}
+  ): Promise<void> {
+    const worktreePath =
+      options.worktreePath ?? (await this.worktreeService.getWorktree(taskBranch));
     if (worktreePath) {
-      await this.worktreeService.removeWorktree(worktreePath);
+      await this.worktreeService.removeWorktree(worktreePath, {
+        projectId: options.lifecycleContext?.projectId ?? this.projectId,
+        taskId: options.lifecycleContext?.taskId ?? '',
+        workspaceId: options.lifecycleContext?.workspaceId ?? '',
+        sourceBranch: options.lifecycleContext?.sourceBranch,
+        branchName: taskBranch,
+      });
     }
   }
 

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/custom-worktree-command.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/custom-worktree-command.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildShellCommandWithEnvironment,
+  buildWorktreeLifecycleEnvironment,
+  truncateOutput,
+  type WorktreeLifecycleCommandVariables,
+} from './custom-worktree-command';
+
+const variables: WorktreeLifecycleCommandVariables = {
+  branchName: "feature/paul's-test",
+  targetDir: "/tmp/worktrees/paul's repo",
+  worktreePath: "/tmp/worktrees/paul's repo",
+  projectId: 'project-1',
+  taskId: 'task-1',
+  workspaceId: 'workspace-1',
+  projectPath: '/repo/main',
+  sourceBranch: 'main',
+};
+
+describe('custom worktree command helpers', () => {
+  it('builds the documented environment variables', () => {
+    expect(buildWorktreeLifecycleEnvironment(variables)).toEqual({
+      EMDASH_BRANCH_NAME: "feature/paul's-test",
+      EMDASH_TARGET_DIR: "/tmp/worktrees/paul's repo",
+      EMDASH_WORKTREE_PATH: "/tmp/worktrees/paul's repo",
+      EMDASH_PROJECT_ID: 'project-1',
+      EMDASH_TASK_ID: 'task-1',
+      EMDASH_WORKSPACE_ID: 'workspace-1',
+      EMDASH_PROJECT_PATH: '/repo/main',
+      EMDASH_SOURCE_BRANCH: 'main',
+    });
+  });
+
+  it('shell-quotes environment variable values', () => {
+    const command = buildShellCommandWithEnvironment(
+      'graft create "$EMDASH_BRANCH_NAME" "$EMDASH_TARGET_DIR"',
+      variables
+    );
+
+    expect(command).toContain("EMDASH_BRANCH_NAME='feature/paul'\\''s-test'");
+    expect(command).toContain("EMDASH_TARGET_DIR='/tmp/worktrees/paul'\\''s repo'");
+    expect(command).toContain('export EMDASH_BRANCH_NAME');
+    expect(command).toContain('graft create "$EMDASH_BRANCH_NAME" "$EMDASH_TARGET_DIR"');
+  });
+
+  it('truncates long command output deterministically', () => {
+    expect(truncateOutput('a'.repeat(4010))).toBe(`${'a'.repeat(4000)}\n[truncated]`);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/custom-worktree-command.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/custom-worktree-command.ts
@@ -1,0 +1,106 @@
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import { log } from '@main/lib/logger';
+import { quoteShellArg } from '@main/utils/shellEscape';
+
+const MAX_OUTPUT_CHARS = 4000;
+
+export type WorktreeLifecycleCommandKind = 'create' | 'teardown';
+
+export type WorktreeLifecycleCommandVariables = {
+  branchName: string;
+  targetDir: string;
+  worktreePath: string;
+  projectId: string;
+  taskId: string;
+  workspaceId: string;
+  projectPath: string;
+  sourceBranch?: string;
+};
+
+export type RunWorktreeLifecycleCommandArgs = {
+  kind: WorktreeLifecycleCommandKind;
+  command: string;
+  variables: WorktreeLifecycleCommandVariables;
+  ctx: IExecutionContext;
+};
+
+export class WorktreeLifecycleCommandError extends Error {
+  readonly kind: WorktreeLifecycleCommandKind;
+  readonly stdout: string;
+  readonly stderr: string;
+
+  constructor(
+    kind: WorktreeLifecycleCommandKind,
+    message: string,
+    output: { stdout?: string; stderr?: string } = {}
+  ) {
+    super(message);
+    this.name = 'WorktreeLifecycleCommandError';
+    this.kind = kind;
+    this.stdout = truncateOutput(output.stdout ?? '');
+    this.stderr = truncateOutput(output.stderr ?? '');
+  }
+}
+
+export function buildWorktreeLifecycleEnvironment(
+  variables: WorktreeLifecycleCommandVariables
+): Record<string, string> {
+  return {
+    EMDASH_BRANCH_NAME: variables.branchName,
+    EMDASH_TARGET_DIR: variables.targetDir,
+    EMDASH_WORKTREE_PATH: variables.worktreePath,
+    EMDASH_PROJECT_ID: variables.projectId,
+    EMDASH_TASK_ID: variables.taskId,
+    EMDASH_WORKSPACE_ID: variables.workspaceId,
+    EMDASH_PROJECT_PATH: variables.projectPath,
+    EMDASH_SOURCE_BRANCH: variables.sourceBranch ?? '',
+  };
+}
+
+export function truncateOutput(output: string): string {
+  if (output.length <= MAX_OUTPUT_CHARS) return output;
+  return `${output.slice(0, MAX_OUTPUT_CHARS)}\n[truncated]`;
+}
+
+export function buildShellCommandWithEnvironment(
+  command: string,
+  variables: WorktreeLifecycleCommandVariables
+): string {
+  const environment = buildWorktreeLifecycleEnvironment(variables);
+  const assignments = Object.entries(environment)
+    .map(([key, value]) => `${key}=${quoteShellArg(value)}`)
+    .join('; ');
+  const exports = Object.keys(environment).join(' ');
+  return `${assignments}; export ${exports}; ${command}`;
+}
+
+export async function runWorktreeLifecycleCommand({
+  kind,
+  command,
+  variables,
+  ctx,
+}: RunWorktreeLifecycleCommandArgs): Promise<void> {
+  const shellCommand = buildShellCommandWithEnvironment(command, variables);
+  try {
+    await ctx.exec('/bin/sh', ['-c', shellCommand], { maxBuffer: MAX_OUTPUT_CHARS * 4 });
+  } catch (error) {
+    const output =
+      error && typeof error === 'object'
+        ? {
+            stdout: 'stdout' in error ? String(error.stdout) : '',
+            stderr: 'stderr' in error ? String(error.stderr) : '',
+          }
+        : {};
+    const stderr = output.stderr?.trim();
+    const message = stderr
+      ? `Custom worktree ${kind} command failed: ${truncateOutput(stderr)}`
+      : `Custom worktree ${kind} command failed: ${error instanceof Error ? error.message : String(error)}`;
+    log.warn('Custom worktree lifecycle command failed', {
+      kind,
+      stdout: output.stdout ? truncateOutput(output.stdout) : undefined,
+      stderr: output.stderr ? truncateOutput(output.stderr) : undefined,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    throw new WorktreeLifecycleCommandError(kind, message, output);
+  }
+}

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -6,6 +6,7 @@ import { ok } from '@emdash/shared';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
 import type { IExecutionContext } from '@main/core/execution-context/types';
+import type { ProjectSettings } from '@shared/core/project-settings/project-settings';
 import type { ProjectSettingsProvider } from '../settings/provider';
 import { LocalWorktreeHost } from './hosts/local-worktree-host';
 import type { WorktreeHost } from './hosts/worktree-host';
@@ -27,9 +28,12 @@ async function initRepo(dir: string): Promise<void> {
   await git(['commit', '--allow-empty', '-m', 'init'], { cwd: dir });
 }
 
-function makeSettings(preservePatterns: string[] = []): ProjectSettingsProvider {
+function makeSettings(
+  preservePatterns: string[] = [],
+  settings: Partial<ProjectSettings> = {}
+): ProjectSettingsProvider {
   return {
-    get: async () => ({ preservePatterns }),
+    get: async () => ({ preservePatterns, ...settings }),
     update: async () => ok(),
     patch: async () => ok(),
     ensure: async () => {},
@@ -422,9 +426,112 @@ describe('WorktreeService', () => {
       if (!result.success) throw new Error('expected success');
       expect(fs.readFileSync(path.join(result.data, '.env'), 'utf8')).toBe('SECRET=abc');
     });
+
+    it('runs a custom create command with documented variables', async () => {
+      const branchName = 'task/custom-create';
+      await git(['branch', branchName], { cwd: repoDir });
+      const logPath = path.join(poolDir, 'create.log');
+      const svc = makeService({
+        projectSettings: makeSettings([], {
+          worktreeLifecycle: {
+            createCommand: [
+              'git worktree add "$EMDASH_TARGET_DIR" "$EMDASH_BRANCH_NAME"',
+              `printf '%s|%s|%s|%s' "$EMDASH_PROJECT_ID" "$EMDASH_TASK_ID" "$EMDASH_WORKSPACE_ID" "$EMDASH_PROJECT_PATH" > ${JSON.stringify(logPath)}`,
+            ].join(' && '),
+          },
+        }),
+      });
+
+      const result = await svc.checkoutExistingBranch(branchName, {
+        lifecycleContext: {
+          projectId: 'project-1',
+          taskId: 'task-1',
+          workspaceId: 'workspace-1',
+        },
+      });
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data).toBe(path.join(poolDir, 'task', 'custom-create'));
+      expect(fs.readFileSync(logPath, 'utf8')).toBe(`project-1|task-1|workspace-1|${repoDir}`);
+    });
+
+    it('returns setup failure when a custom create command does not create a worktree', async () => {
+      const branchName = 'task/custom-create-missing';
+      await git(['branch', branchName], { cwd: repoDir });
+      const svc = makeService({
+        projectSettings: makeSettings([], {
+          worktreeLifecycle: {
+            createCommand: 'true',
+          },
+        }),
+      });
+
+      const result = await svc.checkoutExistingBranch(branchName, {
+        lifecycleContext: {
+          projectId: 'project-1',
+          taskId: 'task-1',
+          workspaceId: 'workspace-1',
+        },
+      });
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected failure');
+      expect(result.error.type).toBe('worktree-setup-failed');
+      if (result.error.type !== 'worktree-setup-failed') throw new Error('expected setup failure');
+      expect(String(result.error.cause)).toContain('was not created');
+    });
   });
 
   describe('removeWorktree', () => {
+    it('runs a custom teardown command with the worktree path', async () => {
+      const branchName = 'task/custom-teardown';
+      await git(['branch', branchName], { cwd: repoDir });
+      const worktreePath = path.join(poolDir, branchName);
+      await git(['worktree', 'add', worktreePath, branchName], { cwd: repoDir });
+      const logPath = path.join(poolDir, 'teardown.log');
+      const svc = makeService({
+        projectSettings: makeSettings([], {
+          worktreeLifecycle: {
+            teardownCommand: `printf '%s|%s' "$EMDASH_BRANCH_NAME" "$EMDASH_WORKTREE_PATH" > ${JSON.stringify(logPath)} && git worktree remove "$EMDASH_WORKTREE_PATH"`,
+          },
+        }),
+      });
+
+      await svc.removeWorktree(worktreePath, {
+        branchName,
+        projectId: 'project-1',
+        taskId: 'task-1',
+        workspaceId: 'workspace-1',
+      });
+
+      expect(fs.existsSync(worktreePath)).toBe(false);
+      expect(fs.readFileSync(logPath, 'utf8')).toBe(`${branchName}|${worktreePath}`);
+    });
+
+    it('fails custom teardown when the command leaves the worktree path behind', async () => {
+      const branchName = 'task/custom-teardown-stuck';
+      await git(['branch', branchName], { cwd: repoDir });
+      const worktreePath = path.join(poolDir, branchName);
+      await git(['worktree', 'add', worktreePath, branchName], { cwd: repoDir });
+      const svc = makeService({
+        projectSettings: makeSettings([], {
+          worktreeLifecycle: {
+            teardownCommand: 'true',
+          },
+        }),
+      });
+
+      await expect(
+        svc.removeWorktree(worktreePath, {
+          branchName,
+          projectId: 'project-1',
+          taskId: 'task-1',
+          workspaceId: 'workspace-1',
+        })
+      ).rejects.toThrow('still exists');
+    });
+
     it('prunes git worktree metadata when directory removal fails', async () => {
       const worktreePath = path.join(poolDir, 'task', 'stuck-remove');
       const exec = vi.fn(async () => ({ stdout: '', stderr: '' }));

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -7,11 +7,23 @@ import { log } from '@main/lib/logger';
 import { DEFAULT_REMOTE_NAME } from '@shared/core/git/types';
 import { getEffectiveTaskSettings } from '../settings/effective-task-settings';
 import type { ProjectSettingsProvider } from '../settings/provider';
+import {
+  runWorktreeLifecycleCommand,
+  WorktreeLifecycleCommandError,
+  type WorktreeLifecycleCommandVariables,
+} from './custom-worktree-command';
 import type { WorktreeHost } from './hosts/worktree-host';
 
 export type ServeWorktreeError =
   | { type: 'worktree-setup-failed'; cause: unknown }
   | { type: 'branch-not-found'; branch: string };
+
+export type WorktreeLifecycleContext = Pick<
+  WorktreeLifecycleCommandVariables,
+  'projectId' | 'taskId' | 'workspaceId'
+> & {
+  sourceBranch?: string;
+};
 
 export class WorktreeService {
   private gitOpQueue: Promise<unknown> = Promise.resolve();
@@ -226,7 +238,7 @@ export class WorktreeService {
   async checkoutBranchWorktree(
     sourceBranch: GitBranchRef | undefined,
     branchName: string,
-    options: { copyPreservedFiles?: boolean } = {}
+    options: { copyPreservedFiles?: boolean; lifecycleContext?: WorktreeLifecycleContext } = {}
   ): Promise<Result<string, ServeWorktreeError>> {
     await this.ensureWorktreePoolDirExists();
     return this.enqueueGitOp(() =>
@@ -237,7 +249,7 @@ export class WorktreeService {
   private async doCheckoutBranchWorktree(
     sourceBranch: GitBranchRef | undefined,
     branchName: string,
-    options: { copyPreservedFiles?: boolean }
+    options: { copyPreservedFiles?: boolean; lifecycleContext?: WorktreeLifecycleContext }
   ): Promise<Result<string, ServeWorktreeError>> {
     const baseConfigValue = this.getBranchBaseConfigValue(sourceBranch);
     const checkedOutPath = await this.findBranchAnywhere(branchName);
@@ -278,7 +290,14 @@ export class WorktreeService {
 
       await this.host.mkdirAbsolute(this.host.pathApi.dirname(targetPath), { recursive: true });
       await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
-      await this.ctx.exec('git', ['worktree', 'add', targetPath, branchName]);
+      await this.addWorktree(branchName, targetPath, {
+        lifecycleContext: options.lifecycleContext
+          ? {
+              ...options.lifecycleContext,
+              sourceBranch: options.lifecycleContext.sourceBranch ?? baseConfigValue,
+            }
+          : { sourceBranch: baseConfigValue },
+      });
     } catch (cause) {
       return err({ type: 'worktree-setup-failed', cause });
     }
@@ -297,7 +316,7 @@ export class WorktreeService {
 
   async checkoutExistingBranch(
     branchName: string,
-    options: { copyPreservedFiles?: boolean } = {}
+    options: { copyPreservedFiles?: boolean; lifecycleContext?: WorktreeLifecycleContext } = {}
   ): Promise<Result<string, ServeWorktreeError>> {
     await this.ensureWorktreePoolDirExists();
     return this.enqueueGitOp(() => this.doCheckoutExistingBranch(branchName, options));
@@ -306,21 +325,25 @@ export class WorktreeService {
   async serveBranchWorktree(
     branchName: string,
     sourceBranch?: GitBranchRef,
-    copyPreservedFiles?: boolean
+    copyPreservedFiles?: boolean,
+    lifecycleContext?: WorktreeLifecycleContext
   ): Promise<Result<string, ServeWorktreeError>> {
     const existing = await this.getWorktree(branchName);
     if (existing) return ok(existing);
 
     if (!sourceBranch || branchName === sourceBranch.branch) {
-      return this.checkoutExistingBranch(branchName, { copyPreservedFiles });
+      return this.checkoutExistingBranch(branchName, { copyPreservedFiles, lifecycleContext });
     }
 
-    return this.checkoutBranchWorktree(sourceBranch, branchName, { copyPreservedFiles });
+    return this.checkoutBranchWorktree(sourceBranch, branchName, {
+      copyPreservedFiles,
+      lifecycleContext,
+    });
   }
 
   private async doCheckoutExistingBranch(
     branchName: string,
-    options: { copyPreservedFiles?: boolean }
+    options: { copyPreservedFiles?: boolean; lifecycleContext?: WorktreeLifecycleContext }
   ): Promise<Result<string, ServeWorktreeError>> {
     const checkedOutPath = await this.findBranchAnywhere(branchName);
     if (checkedOutPath) {
@@ -376,7 +399,9 @@ export class WorktreeService {
       }
 
       await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
-      await this.ctx.exec('git', ['worktree', 'add', targetPath, branchName]);
+      await this.addWorktree(branchName, targetPath, {
+        lifecycleContext: options.lifecycleContext,
+      });
     } catch (cause) {
       return err({ type: 'worktree-setup-failed', cause });
     }
@@ -397,10 +422,100 @@ export class WorktreeService {
     await this.ctx.exec('git', ['worktree', 'move', oldPath, newPath]);
   }
 
-  async removeWorktree(worktreePath: string): Promise<void> {
+  async hasCustomTeardownCommand(): Promise<boolean> {
+    return Boolean((await this.projectSettings.get()).worktreeLifecycle?.teardownCommand?.trim());
+  }
+
+  async removeWorktree(
+    worktreePath: string,
+    lifecycleContext?: WorktreeLifecycleContext & { branchName: string }
+  ): Promise<void> {
+    const teardownCommand = (await this.projectSettings.get()).worktreeLifecycle?.teardownCommand;
+    if (teardownCommand?.trim()) {
+      const variables = this.buildCommandVariables(
+        lifecycleContext?.branchName ?? '',
+        worktreePath,
+        lifecycleContext
+      );
+      await runWorktreeLifecycleCommand({
+        kind: 'teardown',
+        command: teardownCommand,
+        variables,
+        ctx: this.ctx,
+      });
+      if (await this.host.existsAbsolute(worktreePath)) {
+        log.warn('WorktreeService: custom teardown left worktree path behind', {
+          worktreePath,
+        });
+        throw new WorktreeLifecycleCommandError(
+          'teardown',
+          `Custom worktree teardown command finished but "${worktreePath}" still exists`
+        );
+      }
+      await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
+      return;
+    }
+
     await this.removePathForReuse(worktreePath).finally(() => {
       this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
     });
+  }
+
+  private buildCommandVariables(
+    branchName: string,
+    worktreePath: string,
+    lifecycleContext: Partial<WorktreeLifecycleContext> | undefined
+  ): WorktreeLifecycleCommandVariables {
+    return {
+      branchName,
+      targetDir: worktreePath,
+      worktreePath,
+      projectId: lifecycleContext?.projectId ?? '',
+      taskId: lifecycleContext?.taskId ?? '',
+      workspaceId: lifecycleContext?.workspaceId ?? '',
+      projectPath: this.repoPath,
+      sourceBranch: lifecycleContext?.sourceBranch,
+    };
+  }
+
+  private async addWorktree(
+    branchName: string,
+    targetPath: string,
+    options: { lifecycleContext?: Partial<WorktreeLifecycleContext> }
+  ): Promise<void> {
+    const createCommand = (await this.projectSettings.get()).worktreeLifecycle?.createCommand;
+    if (!createCommand?.trim()) {
+      await this.ctx.exec('git', ['worktree', 'add', targetPath, branchName]);
+      return;
+    }
+
+    await runWorktreeLifecycleCommand({
+      kind: 'create',
+      command: createCommand,
+      variables: this.buildCommandVariables(branchName, targetPath, options.lifecycleContext),
+      ctx: this.ctx,
+    });
+
+    if (!(await this.host.existsAbsolute(targetPath))) {
+      log.warn('WorktreeService: custom create did not create target path', {
+        branchName,
+        targetPath,
+      });
+      throw new WorktreeLifecycleCommandError(
+        'create',
+        `Custom worktree create command finished but "${targetPath}" was not created`
+      );
+    }
+    if (!(await this.isValidWorktree(targetPath))) {
+      log.warn('WorktreeService: custom create produced invalid worktree', {
+        branchName,
+        targetPath,
+      });
+      throw new WorktreeLifecycleCommandError(
+        'create',
+        `Custom worktree create command finished but "${targetPath}" is not a valid Git worktree`
+      );
+    }
   }
 
   private taskConfigFs(targetPath: string): Pick<FileSystemProvider, 'exists' | 'read'> {

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.test.ts
@@ -60,6 +60,7 @@ describe('deleteTask', () => {
     vi.clearAllMocks();
     mocks.deleteWhere.mockResolvedValue(undefined);
     mocks.getProject.mockReturnValue(undefined);
+    mocks.teardownTask.mockResolvedValue({ success: true });
   });
 
   it('preserves the workspace file index when an archived sibling still references the workspace', async () => {
@@ -74,5 +75,33 @@ describe('deleteTask', () => {
     await deleteTask('project-1', 'task-1', { deleteWorktree: false });
 
     expect(mocks.deleteIndex).not.toHaveBeenCalled();
+  });
+
+  it('does not delete the task row when custom worktree teardown fails', async () => {
+    const teardownError = new Error('graft remove failed');
+    mocks.getProject.mockReturnValue({
+      projectId: 'project-1',
+      hasCustomWorktreeTeardownCommand: vi.fn().mockResolvedValue(true),
+      removeTaskWorktree: vi.fn().mockRejectedValue(teardownError),
+    });
+    mocks.selectLimit
+      .mockResolvedValueOnce([{ id: 'task-1', workspaceId: 'workspace-1' }])
+      .mockResolvedValueOnce([
+        {
+          id: 'workspace-1',
+          kind: 'worktree',
+          branchName: 'task/custom',
+          path: '/worktrees/task/custom',
+          config: null,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+
+    await expect(deleteTask('project-1', 'task-1', { deleteWorktree: true })).rejects.toThrow(
+      teardownError
+    );
+
+    expect(mocks.deleteWhere).not.toHaveBeenCalled();
+    expect(mocks.capture).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
@@ -40,6 +40,7 @@ export async function deleteTask(
         id: string;
         kind: 'worktree' | 'project-root' | 'byoi' | null;
         branchName: string | null;
+        path: string | null;
         config: WorkspaceConfig | null;
       }
     | undefined;
@@ -50,6 +51,19 @@ export async function deleteTask(
       .where(eq(workspaces.id, task.workspaceId))
       .limit(1);
     if (ws) wsRow = ws;
+  }
+
+  let worktreeRemoved = false;
+  const shouldUseStrictCustomTeardown =
+    project && deleteWorktree && wsRow && (await project.hasCustomWorktreeTeardownCommand());
+  if (project && deleteWorktree && wsRow && shouldUseStrictCustomTeardown) {
+    worktreeRemoved = await removeWorktreeIfUnused(wsRow, project, false, {
+      excludeTaskId: taskId,
+      throwOnFailure: true,
+    });
+  }
+
+  if (task.workspaceId) {
     await deleteWorkspaceIfUnused(task.workspaceId, taskId);
   }
 
@@ -57,8 +71,11 @@ export async function deleteTask(
   void viewStateService.del(`task:${taskId}`);
   telemetryService.capture('task_deleted', { project_id: projectId, task_id: taskId });
 
+  if (project && deleteWorktree && wsRow && !shouldUseStrictCustomTeardown) {
+    worktreeRemoved = await removeWorktreeIfUnused(wsRow, project, false);
+  }
+
   if (project && deleteWorktree && wsRow) {
-    const worktreeRemoved = await removeWorktreeIfUnused(wsRow, project, false);
     const provisionedBranch = getProvisionedWorkspaceBranch(wsRow);
     if (worktreeRemoved && deleteBranch && provisionedBranch) {
       const fromBranch =

--- a/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.test.ts
@@ -67,6 +67,7 @@ describe('task lifecycle workspace cleanup', () => {
     };
     const project = {
       removeTaskWorktree: vi.fn().mockResolvedValue(undefined),
+      projectId: 'project-1',
     };
     mocks.selectLimit.mockResolvedValue([]);
 
@@ -83,7 +84,14 @@ describe('task lifecycle workspace cleanup', () => {
       )
     ).resolves.toBe(true);
 
-    expect(project.removeTaskWorktree).toHaveBeenCalledWith('task/provisioned');
+    expect(project.removeTaskWorktree).toHaveBeenCalledWith('task/provisioned', {
+      worktreePath: undefined,
+      lifecycleContext: {
+        projectId: 'project-1',
+        taskId: '',
+        workspaceId: 'ws-task',
+      },
+    });
   });
 
   it('deletes the workspace index when deleting the unreferenced workspace row', async () => {

--- a/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/task-lifecycle-utils.ts
@@ -21,28 +21,49 @@ export async function removeWorktreeIfUnused(
     id: string;
     kind: 'worktree' | 'project-root' | 'byoi' | null;
     branchName: string | null;
+    path?: string | null;
     config: WorkspaceConfig | null;
   },
   project: ProjectProvider,
-  excludeArchived: boolean
+  excludeArchived: boolean,
+  options: {
+    excludeTaskId?: string;
+    throwOnFailure?: boolean;
+  } = {}
 ): Promise<boolean> {
   const branchName = getProvisionedWorkspaceBranch(workspace);
   if (!branchName) return false;
 
   const where = excludeArchived
-    ? and(eq(tasks.workspaceId, workspace.id), isNull(tasks.archivedAt))
-    : eq(tasks.workspaceId, workspace.id);
+    ? options.excludeTaskId
+      ? and(
+          eq(tasks.workspaceId, workspace.id),
+          isNull(tasks.archivedAt),
+          ne(tasks.id, options.excludeTaskId)
+        )
+      : and(eq(tasks.workspaceId, workspace.id), isNull(tasks.archivedAt))
+    : options.excludeTaskId
+      ? and(eq(tasks.workspaceId, workspace.id), ne(tasks.id, options.excludeTaskId))
+      : eq(tasks.workspaceId, workspace.id);
 
   const siblings = await db.select({ id: tasks.id }).from(tasks).where(where).limit(1);
   if (siblings.length > 0) return false;
 
   try {
-    await project.removeTaskWorktree(branchName);
+    await project.removeTaskWorktree(branchName, {
+      worktreePath: workspace.path ?? undefined,
+      lifecycleContext: {
+        projectId: project.projectId,
+        taskId: options.excludeTaskId ?? '',
+        workspaceId: workspace.id,
+      },
+    });
   } catch (e) {
     log.warn('removeWorktreeIfUnused: worktree removal failed', {
       branchName,
       error: String(e),
     });
+    if (options.throwOnFailure) throw e;
     return false;
   }
   return true;

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/add-worktree.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/add-worktree.ts
@@ -7,7 +7,12 @@ export async function execute(
   ctx: StepContext
 ): Promise<Result<Step.Success, Step.Error>> {
   const { branchName } = args;
-  const result = await ctx.worktreeService.serveBranchWorktree(branchName, undefined, false);
+  const result = await ctx.worktreeService.serveBranchWorktree(
+    branchName,
+    undefined,
+    false,
+    ctx.worktreeLifecycleContext
+  );
 
   if (result.success) {
     return ok({ path: result.data });

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/step-context.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/step-context.ts
@@ -1,7 +1,10 @@
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { ProjectSettingsProvider } from '@main/core/projects/settings/provider';
 import type { WorktreeHost } from '@main/core/projects/worktrees/hosts/worktree-host';
-import type { WorktreeService } from '@main/core/projects/worktrees/worktree-service';
+import type {
+  WorktreeLifecycleContext,
+  WorktreeService,
+} from '@main/core/projects/worktrees/worktree-service';
 
 /**
  * Context passed to every workspace setup step executor.
@@ -21,6 +24,8 @@ export type StepContext = {
   projectSettings: ProjectSettingsProvider;
   /** Worktree service that owns checkout validation, stale cleanup, and checkout creation. */
   worktreeService: Pick<WorktreeService, 'serveBranchWorktree'>;
+  /** Task/workspace identifiers exposed to custom worktree lifecycle commands. */
+  worktreeLifecycleContext?: WorktreeLifecycleContext;
   /**
    * Resolved worktree path from a preceding `add-worktree` step.
    * Populated by the executor after a successful add-worktree step so that

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -14,6 +14,7 @@ const mocks = vi.hoisted(() => ({
   releaseWorkspace: vi.fn(),
   buildTaskFromWorkspace: vi.fn(),
   emitTaskProvisionProgress: vi.fn(),
+  createWorkspaceFactory: vi.fn(),
 }));
 
 // Prevent the module-level singleton from attempting to open the Electron app DB.
@@ -29,6 +30,10 @@ vi.mock('./workspace-registry', () => ({
     acquire: mocks.acquireWorkspace,
     release: mocks.releaseWorkspace,
   },
+}));
+
+vi.mock('./workspace-factory', () => ({
+  createWorkspaceFactory: mocks.createWorkspaceFactory,
 }));
 
 const WS_ID = 'ws-1';
@@ -53,6 +58,7 @@ describe('WorkspaceBootstrapService', () => {
   let svc: WorkspaceBootstrapService;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
     fixture = await openFixture('empty');
     svc = new WorkspaceBootstrapService(fixture.db);
 
@@ -75,6 +81,7 @@ describe('WorkspaceBootstrapService', () => {
         terminals: {},
       },
     });
+    mocks.createWorkspaceFactory.mockReturnValue(vi.fn());
   });
 
   afterEach(() => {
@@ -157,7 +164,7 @@ describe('WorkspaceBootstrapService', () => {
         repoPath: '/repo',
         defaultWorkspaceType: { kind: 'local' },
         settings: {
-          get: vi.fn(),
+          get: vi.fn().mockResolvedValue({}),
         },
         gitRepository: {
           getConfiguredRemotes: vi.fn(),
@@ -196,16 +203,113 @@ describe('WorkspaceBootstrapService', () => {
       expect(result.success).toBe(true);
       if (!result.success) throw new Error('expected success');
       expect(result.data.path).toBe('/worktrees/task-branch');
-      expect(serveBranchWorktree).toHaveBeenCalledWith('task/branch', {
-        type: 'local',
-        branch: 'main',
-      });
+      expect(serveBranchWorktree).toHaveBeenCalledWith(
+        'task/branch',
+        {
+          type: 'local',
+          branch: 'main',
+        },
+        undefined,
+        {
+          projectId: 'proj-1',
+          taskId: 'task-1',
+          workspaceId: WS_ID,
+          sourceBranch: 'main',
+        }
+      );
       expect(existsAbsolute).not.toHaveBeenCalledWith('/worktrees/broken-task-branch');
       expect(mocks.acquireWorkspace).toHaveBeenCalled();
 
       const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
       expect(ws.path).toBe('/worktrees/task-branch');
       expect(ws.branchName).toBe('task/branch');
+    });
+
+    it('uses the configured agent working directory when acquiring the workspace', async () => {
+      const project = {
+        projectId: 'proj-1',
+        type: 'local',
+        repoPath: '/repo',
+        defaultWorkspaceType: { kind: 'local' },
+        defaultWorkspaceMachine: { kind: 'local' },
+        settings: {
+          get: vi.fn().mockResolvedValue({
+            worktreeLifecycle: { workingDirectory: 'services/web' },
+          }),
+        },
+        gitRepository: {},
+        gitRepositoryFetchService: {},
+        worktreeHost: {
+          pathApi: {
+            join: (...segments: string[]) => segments.join('/'),
+          },
+          existsAbsolute: vi.fn().mockResolvedValue(true),
+        },
+      } as unknown as ProjectProvider;
+
+      const result = await svc.ensureWorkspaceSetup(
+        {
+          id: WS_ID,
+          type: 'local',
+          kind: 'project-root',
+          path: '/worktrees/task-branch',
+          branchName: null,
+          config: null,
+        },
+        { workspaceIntent: null, workspaceProvider: null },
+        task,
+        project
+      );
+
+      expect(result.success).toBe(true);
+      expect(mocks.createWorkspaceFactory).toHaveBeenCalledWith(
+        WS_ID,
+        { kind: 'local' },
+        expect.objectContaining({
+          workDir: '/worktrees/task-branch/services/web',
+        })
+      );
+    });
+
+    it('rejects agent working directories that escape the worktree', async () => {
+      const project = {
+        projectId: 'proj-1',
+        type: 'local',
+        repoPath: '/repo',
+        defaultWorkspaceType: { kind: 'local' },
+        settings: {
+          get: vi.fn().mockResolvedValue({
+            worktreeLifecycle: { workingDirectory: '../outside' },
+          }),
+        },
+        worktreeHost: {
+          pathApi: {
+            join: (...segments: string[]) => segments.join('/'),
+          },
+          existsAbsolute: vi.fn(),
+        },
+      } as unknown as ProjectProvider;
+
+      const result = await svc.ensureWorkspaceSetup(
+        {
+          id: WS_ID,
+          type: 'local',
+          kind: 'project-root',
+          path: '/worktrees/task-branch',
+          branchName: null,
+          config: null,
+        },
+        { workspaceIntent: null, workspaceProvider: null },
+        task,
+        project
+      );
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected failure');
+      expect(result.error.type).toBe('setup-failed');
+      if (result.error.type !== 'setup-failed') throw new Error('expected setup failure');
+      expect(result.error.message).toContain('must stay inside the worktree');
+      expect(mocks.acquireWorkspace).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -13,6 +13,7 @@ import { buildTaskFromWorkspace, emitTaskProvisionProgress } from '@main/core/ta
 import { mapTaskRowToTask } from '@main/core/tasks/utils/utils';
 import { db as appDb, type AppDb } from '@main/db/client';
 import { tasks, workspaces } from '@main/db/schema';
+import { isSafeRelativeWorktreeWorkingDirectory } from '@shared/core/project-settings/project-settings';
 import type { Task, ProvisionWorkspaceError } from '@shared/core/tasks/tasks';
 import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
 import type { WorkspaceProviderData } from '@shared/core/workspaces/workspace-provider-data';
@@ -107,7 +108,14 @@ export class WorkspaceBootstrapService {
     if (workspaceRow.path && workspaceBranchName && isWorktreeWorkspace && !isByoi) {
       const serveResult = await project.worktreeService.serveBranchWorktree(
         workspaceBranchName,
-        workspaceSourceBranch
+        workspaceSourceBranch,
+        undefined,
+        {
+          projectId: project.projectId,
+          taskId: task.id,
+          workspaceId: workspaceRow.id,
+          sourceBranch: workspaceSourceBranch?.branch,
+        }
       );
       if (!serveResult.success) {
         const provisionError = mapWorktreeErrorToProvisionError(
@@ -208,6 +216,12 @@ export class WorkspaceBootstrapService {
       host: project.worktreeHost,
       projectSettings: project.settings,
       worktreeService: project.worktreeService,
+      worktreeLifecycleContext: {
+        projectId: project.projectId,
+        taskId: task.id,
+        workspaceId: workspaceRow.id,
+        sourceBranch: intentSourceBranch?.branch,
+      },
     };
 
     const executor = new LocalWorkspaceSetupExecutor(stepCtx);
@@ -325,6 +339,9 @@ export class WorkspaceBootstrapService {
     workspaceSourceBranch?: GitBranchRef
   ): Promise<Result<WorkspaceBootstrapResult, ProvisionWorkspaceError>> {
     const type = project.defaultWorkspaceType;
+    const taskWorkDirResult = await this.resolveTaskWorkDir(project, workDir);
+    if (!taskWorkDirResult.success) return taskWorkDirResult;
+    const taskWorkDir = taskWorkDirResult.data;
 
     emitTaskProvisionProgress({
       taskId: task.id,
@@ -340,7 +357,7 @@ export class WorkspaceBootstrapService {
         project.projectId,
         createWorkspaceFactory(workspaceId, type, {
           task,
-          workDir,
+          workDir: taskWorkDir,
           projectId: project.projectId,
           projectPath: project.repoPath,
           workspaceRuntime: {
@@ -401,6 +418,36 @@ export class WorkspaceBootstrapService {
         await workspaceRegistry.release(workspaceId, 'terminate').catch(() => {});
       }
     }
+  }
+
+  private async resolveTaskWorkDir(
+    project: ProjectProvider,
+    worktreePath: string
+  ): Promise<Result<string, ProvisionWorkspaceError>> {
+    const workingDirectory = (await project.settings.get()).worktreeLifecycle?.workingDirectory;
+    const relativePath = workingDirectory?.trim();
+    if (!relativePath) return ok(worktreePath);
+
+    if (!isSafeRelativeWorktreeWorkingDirectory(relativePath)) {
+      return err({
+        type: 'setup-failed',
+        stepKind: 'workspace-acquire',
+        stepErrorType: 'error',
+        message: 'Configured agent working directory must stay inside the worktree.',
+      });
+    }
+
+    const resolvedPath = project.worktreeHost.pathApi.join(worktreePath, relativePath);
+    if (!(await project.worktreeHost.existsAbsolute(resolvedPath))) {
+      return err({
+        type: 'setup-failed',
+        stepKind: 'workspace-acquire',
+        stepErrorType: 'error',
+        message: `Configured agent working directory does not exist: ${relativePath}`,
+      });
+    }
+
+    return ok(resolvedPath);
   }
 
   /**

--- a/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/project-settings-form-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/project-settings-form-model.test.ts
@@ -8,6 +8,7 @@ import {
   normalizeShareableFieldValue,
   settingsToForm,
   validateWorkspaceProviderCommands,
+  validateWorktreeLifecycleSettings,
   type FormState,
 } from './project-settings-form-model';
 
@@ -31,6 +32,9 @@ function makeForm(overrides: Partial<FormState> = {}): FormState {
     githubAccountId: undefined,
     provisionCommand: '',
     terminateCommand: '',
+    worktreeCreateCommand: '',
+    worktreeTeardownCommand: '',
+    worktreeWorkingDirectory: '',
     ...overrides,
   };
 }
@@ -58,6 +62,11 @@ describe('project settings form model', () => {
           provisionCommand: './provision.sh',
           terminateCommand: './terminate.sh',
         },
+        worktreeLifecycle: {
+          createCommand: 'graft create "$EMDASH_BRANCH_NAME" "$EMDASH_TARGET_DIR"',
+          teardownCommand: 'graft remove "$EMDASH_WORKTREE_PATH"',
+          workingDirectory: 'services/web',
+        },
       },
       'origin',
       [origin, upstream]
@@ -79,6 +88,9 @@ describe('project settings form model', () => {
       githubAccountId: undefined,
       provisionCommand: './provision.sh',
       terminateCommand: './terminate.sh',
+      worktreeCreateCommand: 'graft create "$EMDASH_BRANCH_NAME" "$EMDASH_TARGET_DIR"',
+      worktreeTeardownCommand: 'graft remove "$EMDASH_WORKTREE_PATH"',
+      worktreeWorkingDirectory: 'services/web',
     });
   });
 
@@ -117,6 +129,9 @@ describe('project settings form model', () => {
           pushRemote: '',
           provisionCommand: ' ./provision.sh ',
           terminateCommand: ' ./terminate.sh ',
+          worktreeCreateCommand: ' graft create "$EMDASH_BRANCH_NAME" "$EMDASH_TARGET_DIR" ',
+          worktreeTeardownCommand: ' graft remove "$EMDASH_WORKTREE_PATH" ',
+          worktreeWorkingDirectory: ' services/web ',
         })
       )
     ).toEqual({
@@ -138,7 +153,24 @@ describe('project settings form model', () => {
         provisionCommand: './provision.sh',
         terminateCommand: './terminate.sh',
       },
+      worktreeLifecycle: {
+        createCommand: 'graft create "$EMDASH_BRANCH_NAME" "$EMDASH_TARGET_DIR"',
+        teardownCommand: 'graft remove "$EMDASH_WORKTREE_PATH"',
+        workingDirectory: 'services/web',
+      },
     });
+  });
+
+  it('omits worktree lifecycle settings when custom fields are blank', () => {
+    expect(
+      formToSettings(
+        makeForm({
+          worktreeCreateCommand: ' ',
+          worktreeTeardownCommand: ' ',
+          worktreeWorkingDirectory: ' ',
+        })
+      )
+    ).toEqual({ tmux: false });
   });
 
   it('preserves configured GitHub account ids in form state', () => {
@@ -192,6 +224,22 @@ describe('project settings form model', () => {
         })
       )
     ).toEqual({});
+  });
+
+  it('rejects unsafe worktree working directories', () => {
+    expect(
+      validateWorktreeLifecycleSettings(makeForm({ worktreeWorkingDirectory: 'services/web' }))
+    ).toEqual({});
+    expect(
+      validateWorktreeLifecycleSettings(makeForm({ worktreeWorkingDirectory: '../outside' }))
+    ).toEqual({
+      worktreeWorkingDirectory: 'Use a relative path inside the worktree.',
+    });
+    expect(
+      validateWorktreeLifecycleSettings(makeForm({ worktreeWorkingDirectory: '/tmp/repo' }))
+    ).toEqual({
+      worktreeWorkingDirectory: 'Use a relative path inside the worktree.',
+    });
   });
 
   it('normalizes shareable field values for comparison', () => {

--- a/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/project-settings-form-model.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/project-settings-form-model.ts
@@ -4,6 +4,7 @@ import type {
   ProjectSettings,
   ShareableProjectSettingsWriteField,
 } from '@shared/core/project-settings/project-settings';
+import { isSafeRelativeWorktreeWorkingDirectory } from '@shared/core/project-settings/project-settings';
 import {
   SHAREABLE_FIELD_DESCRIPTOR_BY_ID,
   SHAREABLE_FIELD_DESCRIPTORS,
@@ -26,6 +27,9 @@ export type FormState = {
   githubAccountId: string | null | undefined;
   provisionCommand: string;
   terminateCommand: string;
+  worktreeCreateCommand: string;
+  worktreeTeardownCommand: string;
+  worktreeWorkingDirectory: string;
 };
 
 export type FormUpdate = <K extends keyof FormState>(key: K, value: FormState[K]) => void;
@@ -33,6 +37,8 @@ export type FormUpdate = <K extends keyof FormState>(key: K, value: FormState[K]
 export type WorkspaceProviderValidationErrors = Partial<
   Record<'provisionCommand' | 'terminateCommand', string>
 >;
+
+export type WorktreeLifecycleValidationErrors = Partial<Record<'worktreeWorkingDirectory', string>>;
 
 function normalizeScript(val: string | string[] | undefined): string {
   if (Array.isArray(val)) return val.join('\n');
@@ -76,6 +82,9 @@ export function settingsToForm(
     githubAccountId: Object.hasOwn(s, 'githubAccountId') ? (s.githubAccountId ?? null) : undefined,
     provisionCommand: s.workspaceProvider?.provisionCommand ?? '',
     terminateCommand: s.workspaceProvider?.terminateCommand ?? '',
+    worktreeCreateCommand: s.worktreeLifecycle?.createCommand ?? '',
+    worktreeTeardownCommand: s.worktreeLifecycle?.teardownCommand ?? '',
+    worktreeWorkingDirectory: s.worktreeLifecycle?.workingDirectory ?? '',
   };
 }
 
@@ -98,8 +107,14 @@ export function formToSettings(f: FormState): ProjectSettings {
   };
   const provisionCommand = blankToUndefined(f.provisionCommand);
   const terminateCommand = blankToUndefined(f.terminateCommand);
+  const worktreeCreateCommand = blankToUndefined(f.worktreeCreateCommand);
+  const worktreeTeardownCommand = blankToUndefined(f.worktreeTeardownCommand);
+  const worktreeWorkingDirectory = blankToUndefined(f.worktreeWorkingDirectory);
   const githubAccountId = githubAccountIdToSettings(f.githubAccountId);
   const hasScripts = Object.values(scripts).some((value) => value !== undefined);
+  const hasWorktreeLifecycle = Boolean(
+    worktreeCreateCommand || worktreeTeardownCommand || worktreeWorkingDirectory
+  );
   return {
     preservePatterns: preservePatterns.length > 0 ? preservePatterns : undefined,
     shellSetup: blankToUndefined(f.shellSetup),
@@ -123,6 +138,13 @@ export function formToSettings(f: FormState): ProjectSettings {
             terminateCommand,
           }
         : undefined,
+    worktreeLifecycle: hasWorktreeLifecycle
+      ? {
+          createCommand: worktreeCreateCommand,
+          teardownCommand: worktreeTeardownCommand,
+          workingDirectory: worktreeWorkingDirectory,
+        }
+      : undefined,
   };
 }
 
@@ -141,6 +163,15 @@ export function validateWorkspaceProviderCommands(
     terminateCommand: hasTerminateCommand
       ? undefined
       : 'Terminate command is required when provision command is set.',
+  };
+}
+
+export function validateWorktreeLifecycleSettings(
+  form: FormState
+): WorktreeLifecycleValidationErrors {
+  if (isSafeRelativeWorktreeWorkingDirectory(form.worktreeWorkingDirectory)) return {};
+  return {
+    worktreeWorkingDirectory: 'Use a relative path inside the worktree.',
   };
 }
 

--- a/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/project-settings-form.tsx
@@ -19,6 +19,7 @@ import { ProjectSettingsFooter } from './project-settings-footer';
 import { BaseProjectSettingsSection } from './sections/base-project-settings-section';
 import { ShareableSettingsSection } from './sections/shareable-project-settings-section';
 import { WorkspaceProviderSettingsSection } from './sections/workspace-provider-settings-section';
+import { WorktreeLifecycleSettingsSection } from './sections/worktree-lifecycle-settings-section';
 import { useProjectSettingsForm } from './use-project-settings-form';
 
 export interface ProjectSettingsFormProps {
@@ -85,6 +86,11 @@ export const ProjectSettingsForm = observer(function ProjectSettingsForm({
             projectType={projectType}
             remotes={remotes}
             worktreeDirectoryError={formModel.worktreeDirectoryError}
+            update={formModel.update}
+          />
+          <WorktreeLifecycleSettingsSection
+            form={formModel.form}
+            errors={formModel.worktreeLifecycleErrors}
             update={formModel.update}
           />
           <WorkspaceProviderSettingsSection

--- a/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/sections/worktree-lifecycle-settings-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/sections/worktree-lifecycle-settings-section.tsx
@@ -1,0 +1,125 @@
+import { ChevronDown } from 'lucide-react';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@renderer/lib/ui/collapsible';
+import { Field, FieldDescription, FieldTitle } from '@renderer/lib/ui/field';
+import { Input } from '@renderer/lib/ui/input';
+import { Separator } from '@renderer/lib/ui/separator';
+import { Textarea } from '@renderer/lib/ui/textarea';
+import type {
+  FormState,
+  FormUpdate,
+  WorktreeLifecycleValidationErrors,
+} from '../project-settings-form-model';
+
+type WorktreeLifecycleSettingsSectionProps = {
+  form: FormState;
+  errors: WorktreeLifecycleValidationErrors;
+  update: FormUpdate;
+};
+
+const ENVIRONMENT_VARIABLES = [
+  'EMDASH_BRANCH_NAME',
+  'EMDASH_TARGET_DIR',
+  'EMDASH_WORKTREE_PATH',
+  'EMDASH_PROJECT_ID',
+  'EMDASH_TASK_ID',
+  'EMDASH_WORKSPACE_ID',
+  'EMDASH_PROJECT_PATH',
+  'EMDASH_SOURCE_BRANCH',
+];
+
+export function WorktreeLifecycleSettingsSection({
+  form,
+  errors,
+  update,
+}: WorktreeLifecycleSettingsSectionProps) {
+  const hasCustomLifecycle = Boolean(
+    form.worktreeCreateCommand.trim() ||
+    form.worktreeTeardownCommand.trim() ||
+    form.worktreeWorkingDirectory.trim()
+  );
+
+  return (
+    <>
+      <Separator />
+      <Collapsible defaultOpen={hasCustomLifecycle}>
+        <div className="flex flex-col gap-4">
+          <CollapsibleTrigger className="group flex w-full items-center justify-between gap-3 rounded-md px-0 py-1 text-left">
+            <div className="flex min-w-0 flex-col gap-1">
+              <FieldTitle>Advanced worktree lifecycle</FieldTitle>
+              <FieldDescription className="text-foreground-muted">
+                Leave blank to use Emdash&apos;s default git worktree flow.
+              </FieldDescription>
+            </div>
+            <ChevronDown className="size-4 shrink-0 text-foreground-muted transition-transform group-data-[panel-open]:rotate-180" />
+          </CollapsibleTrigger>
+
+          <CollapsibleContent className="flex flex-col gap-4">
+            <Field>
+              <FieldTitle>Create command</FieldTitle>
+              <FieldDescription className="text-foreground-muted">
+                Runs instead of the built-in worktree creation command for new task worktrees.
+              </FieldDescription>
+              <Textarea
+                rows={3}
+                placeholder={'graft create "$EMDASH_BRANCH_NAME" "$EMDASH_TARGET_DIR"'}
+                value={form.worktreeCreateCommand}
+                onChange={(e) => update('worktreeCreateCommand', e.target.value)}
+              />
+            </Field>
+
+            <Field>
+              <FieldTitle>Delete command</FieldTitle>
+              <FieldDescription className="text-foreground-muted">
+                Runs when deleting a task worktree. Leave blank to use Emdash&apos;s default
+                cleanup.
+              </FieldDescription>
+              <Textarea
+                rows={3}
+                placeholder={'graft remove "$EMDASH_WORKTREE_PATH"'}
+                value={form.worktreeTeardownCommand}
+                onChange={(e) => update('worktreeTeardownCommand', e.target.value)}
+              />
+            </Field>
+
+            <Field>
+              <FieldTitle>Agent working directory</FieldTitle>
+              <FieldDescription className="text-foreground-muted">
+                Optional relative path where agent sessions should start inside each worktree.
+              </FieldDescription>
+              <Input
+                aria-invalid={errors.worktreeWorkingDirectory ? true : undefined}
+                placeholder="services/web"
+                value={form.worktreeWorkingDirectory}
+                onChange={(e) => update('worktreeWorkingDirectory', e.target.value)}
+              />
+              {errors.worktreeWorkingDirectory ? (
+                <p className="text-xs text-foreground-error">{errors.worktreeWorkingDirectory}</p>
+              ) : null}
+            </Field>
+
+            <div className="border-border-muted bg-background-muted/40 flex flex-col gap-2 rounded-md border p-3 text-xs text-foreground-muted">
+              <div className="font-medium text-foreground">Available variables</div>
+              <div className="flex flex-wrap gap-1.5">
+                {ENVIRONMENT_VARIABLES.map((variable) => (
+                  <code
+                    key={variable}
+                    className="border-border-muted rounded border bg-background px-1.5 py-0.5"
+                  >
+                    {variable}
+                  </code>
+                ))}
+              </div>
+              <div>
+                Example sparse checkout setup: create with{' '}
+                <code>
+                  graft create &quot;$EMDASH_BRANCH_NAME&quot; &quot;$EMDASH_TARGET_DIR&quot;
+                </code>{' '}
+                and delete with <code>graft remove &quot;$EMDASH_WORKTREE_PATH&quot;</code>.
+              </div>
+            </div>
+          </CollapsibleContent>
+        </div>
+      </Collapsible>
+    </>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/use-project-settings-form.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/settings-view/use-project-settings-form.ts
@@ -24,7 +24,9 @@ import {
   normalizeShareableFieldValue,
   settingsToForm,
   validateWorkspaceProviderCommands,
+  validateWorktreeLifecycleSettings,
   type FormState,
+  type WorktreeLifecycleValidationErrors,
   type WorkspaceProviderValidationErrors,
 } from './project-settings-form-model';
 import { projectConfigTargetValue } from './share-project-config-modal';
@@ -89,6 +91,8 @@ export function useProjectSettingsForm({
   const [worktreeDirectoryError, setWorktreeDirectoryError] = useState<string | null>(null);
   const [workspaceProviderErrors, setWorkspaceProviderErrors] =
     useState<WorkspaceProviderValidationErrors>({});
+  const [worktreeLifecycleErrors, setWorktreeLifecycleErrors] =
+    useState<WorktreeLifecycleValidationErrors>({});
 
   const resolvedSnapshot = resolveFormSnapshot(formSnapshot, baseline);
   const { form, savedForm } = resolvedSnapshot;
@@ -108,6 +112,7 @@ export function useProjectSettingsForm({
   const baselineResynced = resolvedSnapshot !== formSnapshot && areFormStatesEqual(form, savedForm);
   const visibleWorktreeDirectoryError = baselineResynced ? null : worktreeDirectoryError;
   const visibleWorkspaceProviderErrors = baselineResynced ? {} : workspaceProviderErrors;
+  const visibleWorktreeLifecycleErrors = baselineResynced ? {} : worktreeLifecycleErrors;
 
   const update = useCallback(
     <K extends keyof FormState>(key: K, value: FormState[K]) => {
@@ -121,6 +126,13 @@ export function useProjectSettingsForm({
       }
       if (key === 'provisionCommand' || key === 'terminateCommand') {
         setWorkspaceProviderErrors({});
+      }
+      if (
+        key === 'worktreeCreateCommand' ||
+        key === 'worktreeTeardownCommand' ||
+        key === 'worktreeWorkingDirectory'
+      ) {
+        setWorktreeLifecycleErrors({});
       }
     },
     [form, resolvedSnapshot, visibleWorktreeDirectoryError]
@@ -142,10 +154,19 @@ export function useProjectSettingsForm({
       ...form,
       provisionCommand: form.provisionCommand.trim(),
       terminateCommand: form.terminateCommand.trim(),
+      worktreeCreateCommand: form.worktreeCreateCommand.trim(),
+      worktreeTeardownCommand: form.worktreeTeardownCommand.trim(),
+      worktreeWorkingDirectory: form.worktreeWorkingDirectory.trim(),
     };
     const nextWorkspaceProviderErrors = validateWorkspaceProviderCommands(formAtSubmit);
     if (Object.values(nextWorkspaceProviderErrors).some(Boolean)) {
       setWorkspaceProviderErrors(nextWorkspaceProviderErrors);
+      setSaveStatus('idle');
+      return;
+    }
+    const nextWorktreeLifecycleErrors = validateWorktreeLifecycleSettings(formAtSubmit);
+    if (Object.values(nextWorktreeLifecycleErrors).some(Boolean)) {
+      setWorktreeLifecycleErrors(nextWorktreeLifecycleErrors);
       setSaveStatus('idle');
       return;
     }
@@ -252,6 +273,7 @@ export function useProjectSettingsForm({
     });
     setWorktreeDirectoryError(null);
     setWorkspaceProviderErrors({});
+    setWorktreeLifecycleErrors({});
     if (saveStatus === 'error') setSaveStatus('idle');
   }, [resolvedSnapshot, savedForm, saveStatus]);
 
@@ -266,6 +288,7 @@ export function useProjectSettingsForm({
     configMigrations,
     worktreeDirectoryError: visibleWorktreeDirectoryError,
     workspaceProviderErrors: visibleWorkspaceProviderErrors,
+    worktreeLifecycleErrors: visibleWorktreeLifecycleErrors,
     update,
     getOverrideSources,
     handleSave,

--- a/apps/emdash-desktop/src/shared/core/project-settings/project-settings.ts
+++ b/apps/emdash-desktop/src/shared/core/project-settings/project-settings.ts
@@ -40,6 +40,26 @@ export const shareableProjectSettingsWithDefaultsSchema = shareableProjectSettin
 
 export type ShareableProjectSettings = z.infer<typeof shareableProjectSettingsSchema>;
 
+export function isSafeRelativeWorktreeWorkingDirectory(value: string | undefined): boolean {
+  const trimmed = value?.trim();
+  if (!trimmed) return true;
+  if (trimmed.startsWith('/') || trimmed.startsWith('\\') || /^[A-Za-z]:[\\/]/.test(trimmed)) {
+    return false;
+  }
+  const segments = trimmed.split(/[\\/]+/).filter(Boolean);
+  return segments.every((segment) => segment !== '..');
+}
+
+export const worktreeLifecycleSettingsSchema = z
+  .object({
+    createCommand: z.string().trim().min(1).optional(),
+    teardownCommand: z.string().trim().min(1).optional(),
+    workingDirectory: z.string().trim().optional().refine(isSafeRelativeWorktreeWorkingDirectory, {
+      message: 'Working directory must be a relative path inside the worktree',
+    }),
+  })
+  .optional();
+
 export const baseProjectSettingsSchema = z.object({
   worktreeDirectory: z.string().trim().optional(),
   defaultBranch: defaultBranchSettingSchema.optional(),
@@ -56,6 +76,7 @@ export const baseProjectSettingsSchema = z.object({
       terminateCommand: z.string().min(1),
     })
     .optional(),
+  worktreeLifecycle: worktreeLifecycleSettingsSchema,
 });
 
 export type BaseProjectSettings = z.infer<typeof baseProjectSettingsSchema>;


### PR DESCRIPTION
## Summary
- add opt-in per-project worktree lifecycle settings for custom create/delete commands
- expose documented EMDASH_* environment variables for branch, target path, task/project/workspace ids, project path, and source branch
- run custom create through the existing worktree provisioning path and custom teardown through task deletion cleanup
- add advanced project settings UI and optional agent working directory inside the worktree
- keep default git worktree behavior unchanged when fields are blank

## Testing
- pnpm --filter @emdash/emdash-desktop exec vitest run --project node --project main-db src/main/core/projects/worktrees/custom-worktree-command.test.ts src/main/core/projects/worktrees/worktree-service.test.ts src/main/core/tasks/operations/task-lifecycle-utils.test.ts src/main/core/tasks/operations/deleteTask.test.ts src/main/core/workspaces/workspace-bootstrap-service.db.test.ts src/renderer/features/projects/components/settings-view/project-settings-form-model.test.ts
- pnpm run format:check
- pnpm run lint
- pnpm run typecheck
- pnpm run build
- git diff --check

## Notes
- Full app test suite still has an unrelated existing failure in src/main/core/browser/browser-webcontents-registry.test.ts; rerunning that file alone reproduces the same failure.
- Playwright browser installation cannot complete in this environment because Playwright reports Chromium unsupported on ubuntu26.04-x64.

## User testing scenario
Configure a project with create/delete commands such as:

```sh
git worktree add "$EMDASH_TARGET_DIR" "$EMDASH_BRANCH_NAME"
git worktree remove "$EMDASH_WORKTREE_PATH"
```

Then create a normal task with the new-worktree workflow and delete it with worktree cleanup enabled.