### PR TITLE
fix(automations): preserve prompt when switching project

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
@@ -86,7 +86,9 @@ export function useAutomationFormState(
     ? seedConversationConfig?.provider
     : undefined;
 
-  const initialConversation = useInitialConversationState(effectiveProjectId, seedProvider);
+  const initialConversation = useInitialConversationState(effectiveProjectId, seedProvider, false, {
+    resetPromptOnProjectChange: false,
+  });
 
   const [promptSeeded, setPromptSeeded] = useState(false);
   if (!promptSeeded && seedPrompt) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.test.ts
@@ -1,0 +1,126 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  useInitialConversationState,
+  type InitialConversationState,
+} from './initial-conversation-section';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  getProjectSshConnectionId: vi.fn(),
+  setProviderOverride: vi.fn(),
+}));
+
+vi.mock('@renderer/features/projects/stores/project-selectors', () => ({
+  getProjectSshConnectionId: mocks.getProjectSshConnectionId,
+}));
+
+vi.mock('@renderer/features/library/prompts/use-prompt-library', () => ({
+  usePromptLibrary: () => ({ value: [] }),
+}));
+
+vi.mock('@renderer/lib/components/agent-selector/agent-selector', () => ({
+  AgentSelector: () => null,
+}));
+
+vi.mock('../components/issue-selector/issue-selector', () => ({
+  ProviderLogo: () => null,
+}));
+
+vi.mock('../create-task-modal/use-prompt-file-drop', () => ({
+  usePromptFileDrop: () => ({ isDragOver: false, dropHandlers: {} }),
+}));
+
+vi.mock('./add-context-popover', () => ({
+  AddContextPopover: () => null,
+}));
+
+vi.mock('./use-effective-provider', () => ({
+  useEffectiveProvider: () => ({
+    providerId: 'claude',
+    setProviderOverride: mocks.setProviderOverride,
+    createDisabled: false,
+  }),
+}));
+
+type InitialConversationOptions = Parameters<typeof useInitialConversationState>[3];
+
+let latestState: InitialConversationState | undefined;
+
+function Probe({
+  projectId,
+  options,
+}: {
+  projectId: string;
+  options?: InitialConversationOptions;
+}) {
+  latestState = useInitialConversationState(projectId, undefined, false, options);
+  return null;
+}
+
+describe('useInitialConversationState', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    latestState = undefined;
+    mocks.getProjectSshConnectionId.mockReturnValue(undefined);
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  async function renderProbe(projectId: string, options?: InitialConversationOptions) {
+    await act(async () => {
+      root.render(React.createElement(Probe, { projectId, options }));
+    });
+  }
+
+  async function setPrompt(prompt: string) {
+    await act(async () => {
+      latestState?.setPrompt(prompt);
+    });
+  }
+
+  it('resets the prompt by default when the project changes', async () => {
+    await renderProbe('project-1');
+    await setPrompt('Keep this for project one');
+
+    expect(latestState?.prompt).toBe('Keep this for project one');
+
+    await renderProbe('project-2');
+
+    expect(latestState?.prompt).toBe('');
+  });
+
+  it('can preserve the prompt when the project changes', async () => {
+    await renderProbe('project-1', { resetPromptOnProjectChange: false });
+    await setPrompt('Keep this automation prompt');
+
+    expect(latestState?.prompt).toBe('Keep this automation prompt');
+
+    await renderProbe('project-2', { resetPromptOnProjectChange: false });
+
+    expect(latestState?.prompt).toBe('Keep this automation prompt');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -32,11 +32,17 @@ export type InitialConversationState = {
   connectionId?: string;
 };
 
+interface InitialConversationStateOptions {
+  resetPromptOnProjectChange?: boolean;
+}
+
 export function useInitialConversationState(
   projectId?: string,
   initialProvider?: AgentProviderId,
-  autoApproveByDefault = false
+  autoApproveByDefault = false,
+  options: InitialConversationStateOptions = {}
 ): InitialConversationState {
+  const { resetPromptOnProjectChange = true } = options;
   const connectionId = projectId ? getProjectSshConnectionId(projectId) : undefined;
   const { providerId, setProviderOverride } = useEffectiveProvider(connectionId, initialProvider);
   const [prompt, setPrompt] = useState('');
@@ -49,7 +55,9 @@ export function useInitialConversationState(
   if (projectChanged) {
     setPrevProjectId(projectId);
     setProviderOverride(null);
-    setPrompt('');
+    if (resetPromptOnProjectChange) {
+      setPrompt('');
+    }
     setIssueContext(null);
     setAutoApproveOverride(null);
   }


### PR DESCRIPTION
## Summary
- Preserve automation prompt text when the selected project changes.
- Keep the existing create-task prompt reset behavior as the default.
- Add regression coverage for both reset and preserve modes.

## Root Cause
The automation form reused `useInitialConversationState`, which clears prompt state whenever the project ID changes. That reset is correct for task creation but was also clearing in-progress automation prompts.

## Validation
- `corepack pnpm vitest run --project node src/renderer/features/tasks/conversations/initial-conversation-section.test.ts`
- `corepack pnpm exec oxfmt --check src/renderer/features/tasks/conversations/initial-conversation-section.tsx src/renderer/features/tasks/conversations/initial-conversation-section.test.ts src/renderer/features/automations/useAutomationFormState.ts`
- `corepack pnpm exec oxlint src/renderer/features/tasks/conversations/initial-conversation-section.tsx src/renderer/features/tasks/conversations/initial-conversation-section.test.ts src/renderer/features/automations/useAutomationFormState.ts`
- `corepack pnpm run typecheck`
