### PR TITLE
fix(linux): find capitalized legacy config directory

### DIFF
--- a/apps/emdash-desktop/src/main/db/legacy-port/controller.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/controller.ts
@@ -1,9 +1,7 @@
-import { join } from 'node:path';
 import { count } from 'drizzle-orm';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
 import { app } from 'electron';
 import { db } from '@main/db/client';
-import { PREVIOUS_DB_FILENAME } from '@main/db/default-path';
 import * as schema from '@main/db/schema';
 import { projects, tasks } from '@main/db/schema';
 import { log } from '@main/lib/logger';
@@ -13,7 +11,8 @@ import { openLegacyReadOnly } from './legacy-source/open-readonly';
 import {
   hasBetaDatabaseFile,
   hasLegacyDatabaseFile,
-  resolveLegacyDatabasePath,
+  resolveExistingBetaDatabasePath,
+  resolveExistingLegacyDatabasePath,
 } from './legacy-source/path';
 import { createDefaultLegacyPortStateStore, runLegacyPort } from './service';
 import { createLegacyPortPreview } from './source-analysis';
@@ -41,8 +40,8 @@ export const legacyPortController = createRPCController({
     const userDataPath = app.getPath('userData');
     const hasLegacyDb = hasLegacyDatabaseFile(userDataPath);
     const hasBetaDb = hasBetaDatabaseFile(userDataPath);
-    const legacyPath = resolveLegacyDatabasePath(userDataPath);
-    const betaPath = join(userDataPath, PREVIOUS_DB_FILENAME);
+    const legacyPath = resolveExistingLegacyDatabasePath(userDataPath);
+    const betaPath = resolveExistingBetaDatabasePath(userDataPath);
     let legacyDb;
     let betaSqlite;
     try {

--- a/apps/emdash-desktop/src/main/db/legacy-port/legacy-source/path.test.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/legacy-source/path.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { resolveLegacyUserDataPathCandidates } from './path';
+
+describe('resolveLegacyUserDataPathCandidates', () => {
+  it('checks the capitalized legacy config directory after lowercase emdash on Linux', () => {
+    expect(resolveLegacyUserDataPathCandidates('/home/user/.config/emdash', 'linux')).toEqual([
+      '/home/user/.config/emdash',
+      '/home/user/.config/Emdash',
+    ]);
+  });
+
+  it('does not add a capitalized fallback outside Linux', () => {
+    expect(
+      resolveLegacyUserDataPathCandidates(
+        '/Users/user/Library/Application Support/emdash',
+        'darwin'
+      )
+    ).toEqual(['/Users/user/Library/Application Support/emdash']);
+  });
+
+  it('does not duplicate paths when the configured directory is already capitalized', () => {
+    expect(resolveLegacyUserDataPathCandidates('/home/user/.config/Emdash', 'linux')).toEqual([
+      '/home/user/.config/Emdash',
+    ]);
+  });
+});

--- a/apps/emdash-desktop/src/main/db/legacy-port/legacy-source/path.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/legacy-source/path.ts
@@ -1,19 +1,58 @@
 import { existsSync } from 'node:fs';
-import { join } from 'node:path';
+import { basename, dirname, join } from 'node:path';
 import { PREVIOUS_DB_FILENAME } from '@main/db/default-path';
+
+type Platform = NodeJS.Platform;
+
+export function resolveLegacyUserDataPathCandidates(
+  userDataPath: string,
+  platform: Platform = process.platform
+): string[] {
+  const candidates = [userDataPath];
+
+  if (platform === 'linux' && basename(userDataPath) === 'emdash') {
+    candidates.push(join(dirname(userDataPath), 'Emdash'));
+  }
+
+  return [...new Set(candidates)];
+}
 
 export function resolveLegacyDatabasePath(userDataPath: string): string {
   return join(userDataPath, 'emdash.db');
 }
 
+export function resolveExistingLegacyUserDataPath(userDataPath: string): string {
+  return (
+    resolveLegacyUserDataPathCandidates(userDataPath).find((candidate) =>
+      existsSync(resolveLegacyDatabasePath(candidate))
+    ) ?? userDataPath
+  );
+}
+
+export function resolveExistingLegacyDatabasePath(userDataPath: string): string {
+  return resolveLegacyDatabasePath(resolveExistingLegacyUserDataPath(userDataPath));
+}
+
 export function hasLegacyDatabaseFile(userDataPath: string): boolean {
-  return existsSync(resolveLegacyDatabasePath(userDataPath));
+  return resolveLegacyUserDataPathCandidates(userDataPath).some((candidate) =>
+    existsSync(resolveLegacyDatabasePath(candidate))
+  );
 }
 
 export function resolveBetaDatabasePath(userDataPath: string) {
   return join(userDataPath, PREVIOUS_DB_FILENAME);
 }
 
+export function resolveExistingBetaDatabasePath(userDataPath: string): string {
+  return (
+    resolveLegacyUserDataPathCandidates(userDataPath)
+      .map(resolveBetaDatabasePath)
+      .find((candidate) => existsSync(candidate)) ?? resolveBetaDatabasePath(userDataPath)
+  );
+}
+
 export function hasBetaDatabaseFile(userDataPath: string): boolean {
-  return existsSync(resolveBetaDatabasePath(userDataPath));
+  return resolveLegacyUserDataPathCandidates(userDataPath).some((candidate) =>
+    existsSync(resolveBetaDatabasePath(candidate))
+  );
 }

--- a/apps/emdash-desktop/src/main/db/legacy-port/legacy-source/path.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/legacy-source/path.ts
@@ -14,7 +14,7 @@ export function resolveLegacyUserDataPathCandidates(
     candidates.push(join(dirname(userDataPath), 'Emdash'));
   }
 
-  return [...new Set(candidates)];
+  return candidates;
 }
 
 export function resolveLegacyDatabasePath(userDataPath: string): string {

--- a/apps/emdash-desktop/src/main/db/legacy-port/service.ts
+++ b/apps/emdash-desktop/src/main/db/legacy-port/service.ts
@@ -22,8 +22,9 @@ import { openLegacyReadOnly } from './legacy-source/open-readonly';
 import {
   hasBetaDatabaseFile,
   hasLegacyDatabaseFile,
-  resolveBetaDatabasePath,
-  resolveLegacyDatabasePath,
+  resolveExistingBetaDatabasePath,
+  resolveExistingLegacyDatabasePath,
+  resolveExistingLegacyUserDataPath,
 } from './legacy-source/path';
 import { clearDestinationDataPreservingSignIn } from './reset';
 import { buildLegacyProjectSelection } from './source-analysis';
@@ -135,7 +136,7 @@ export async function runLegacyPort(
   }
 
   if (selectedSources.has('v1-beta') && !selectedSources.has('v0')) {
-    const betaPath = resolveBetaDatabasePath(userDataPath);
+    const betaPath = resolveExistingBetaDatabasePath(userDataPath);
     if (hasBetaDatabaseFile(userDataPath)) {
       importBetaDatabaseIntoDestination(appTarget.sqlite, betaPath);
     } else {
@@ -154,7 +155,8 @@ export async function runLegacyPort(
     return;
   }
 
-  const legacyPath = resolveLegacyDatabasePath(userDataPath);
+  const legacyUserDataPath = resolveExistingLegacyUserDataPath(userDataPath);
+  const legacyPath = resolveExistingLegacyDatabasePath(userDataPath);
   let legacyDb: Database.Database;
 
   try {
@@ -169,7 +171,7 @@ export async function runLegacyPort(
 
   const start = Date.now();
 
-  const betaPath = resolveBetaDatabasePath(userDataPath);
+  const betaPath = resolveExistingBetaDatabasePath(userDataPath);
   const shouldCopyBeta = selectedSources.has('v1-beta') && hasBetaDatabaseFile(userDataPath);
   const runImport = async (): Promise<{
     sshSummary: PortSummary;
@@ -221,7 +223,7 @@ export async function runLegacyPort(
         legacyDb,
         remap,
         mergedLegacyTaskIds: taskResult.mergedLegacyTaskIds,
-        userDataPath,
+        userDataPath: legacyUserDataPath,
         tmuxExec: new LocalExecutionContext(),
       });
 
@@ -239,7 +241,7 @@ export async function runLegacyPort(
     logSummary(conversationsSummary);
 
     try {
-      const settingsSummary = await portLegacySettings(userDataPath, {
+      const settingsSummary = await portLegacySettings(legacyUserDataPath, {
         appDb: appTarget.db,
         appSqlite: appTarget.sqlite,
       });


### PR DESCRIPTION
### Description

Fixes Linux legacy import detection when pre-v1 data lives in the old capitalized config directory (`~/.config/Emdash`) while v1 checks the lowercase userData directory (`~/.config/emdash`).

This adds a Linux-only fallback candidate for legacy import paths and uses the resolved existing legacy/beta database paths in import status, preview, and import execution. When the legacy v0 database is found in the fallback directory, settings and conversation backfill also read from that same legacy userData directory.

### Related issues

Fixes #1789

### Testing

- `pnpm exec vitest run --project main-db src/main/db/legacy-port/legacy-source/path.test.ts`
- `pnpm exec vitest run --project main-db src/main/db/legacy-port`
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run format:check`
- `pnpm run build`

Note: local pnpm prints an engine warning because the shell resolves Node v22.22.3 while the repo wants Node >=24, but the commands above completed successfully.

### Screenshot/Recording (if applicable)

N/A
