### PR TITLE
chore(desktop): remove stale docs scripts

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -46,9 +46,7 @@
     "lint": "oxlint .",
     "format": "oxfmt",
     "format:check": "oxfmt --check",
-    "typecheck": "tsgo --noEmit && tsgo --noEmit -p scripts/release/tsconfig.json",
-    "docs": "cd docs && pnpm run dev",
-    "docs:build": "cd docs && pnpm run build"
+    "typecheck": "tsgo --noEmit && tsgo --noEmit -p scripts/release/tsconfig.json"
   },
   "dependencies": {
     "@emdash/core": "workspace:*",


### PR DESCRIPTION
## Summary
- remove stale desktop `docs` and `docs:build` scripts that point to a missing `apps/emdash-desktop/docs` directory
- keep the package scripts aligned with the current repository layout

## Test Plan
- [x] `pnpm --filter @emdash/emdash-desktop run format:check`

## Notes
Before this change, `pnpm --filter @emdash/emdash-desktop run docs:build` failed because `apps/emdash-desktop/docs` does not exist.
