### PR TITLE
feat(telemetry): add automation events

### DIFF
--- a/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
+++ b/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
@@ -53,7 +53,7 @@ automationsService.on('automation:created', (automation) => {
     ...automationTelemetryProps(automation),
     enabled: automation.enabled,
     provider: getProvider(automation),
-    has_initial_prompt: Boolean(automation.conversationConfig?.prompt.trim()),
+    has_initial_prompt: Boolean(automation.conversationConfig?.prompt?.trim()),
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
+++ b/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
@@ -59,19 +59,8 @@ automationsService.on('automation:enabled', (automation) => {
   });
 });
 
-automationsService.on('automation:deleted', (automationId) => {
-  telemetryService.capture('automation_deleted', { automation_id: automationId });
-});
-
 automationsService.on('run:started', (run) => {
   captureRunStarted(run);
-});
-
-automationsService.on('run:stopped', (run) => {
-  telemetryService.capture('automation_run_stopped', {
-    ...runTelemetryProps(run),
-    status: run.status,
-  });
 });
 
 automationsService.on('run:step-completed', (run) => {

--- a/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
+++ b/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
@@ -1,0 +1,92 @@
+import { automationsService } from '@main/core/automations/automations-service';
+import { telemetryService } from '@main/lib/telemetry';
+import {
+  isValidProviderId,
+  type AgentProviderId,
+} from '@shared/core/agents/agent-provider-registry';
+import type { Automation } from '@shared/core/automations/automation';
+import type { AutomationRun, AutomationRunStatus } from '@shared/core/automations/automation-run';
+
+const TERMINAL_RUN_STATUSES = new Set<AutomationRunStatus>(['done', 'failed', 'skipped']);
+const startedRunIds = new Set<string>();
+const completedRunIds = new Set<string>();
+
+function automationTelemetryProps(automation: Automation) {
+  return {
+    automation_id: automation.id,
+    project_id: automation.projectId,
+    trigger_kind: 'cron' as const,
+  };
+}
+
+function runTelemetryProps(run: AutomationRun) {
+  return {
+    automation_id: run.automationId,
+    task_id: run.taskId ?? undefined,
+    trigger_kind: run.triggerKind,
+  };
+}
+
+function getProvider(automation: Automation): AgentProviderId | null {
+  const provider = automation.conversationConfig?.provider;
+  return isValidProviderId(provider) ? provider : null;
+}
+
+function getDurationMs(run: AutomationRun): number | undefined {
+  if (run.startedAt == null || run.finishedAt == null) return undefined;
+  return Math.max(0, run.finishedAt - run.startedAt);
+}
+
+function captureRunStarted(run: AutomationRun): void {
+  if (startedRunIds.has(run.id)) return;
+  startedRunIds.add(run.id);
+  telemetryService.capture('automation_run_started', runTelemetryProps(run));
+}
+
+automationsService.on('automation:created', (automation) => {
+  telemetryService.capture('automation_created', {
+    ...automationTelemetryProps(automation),
+    enabled: automation.enabled,
+    provider: getProvider(automation),
+    has_initial_prompt: Boolean(automation.conversationConfig?.prompt.trim()),
+  });
+});
+
+automationsService.on('automation:enabled', (automation) => {
+  telemetryService.capture('automation_enabled_changed', {
+    ...automationTelemetryProps(automation),
+    enabled: automation.enabled,
+  });
+});
+
+automationsService.on('automation:deleted', (automationId) => {
+  telemetryService.capture('automation_deleted', { automation_id: automationId });
+});
+
+automationsService.on('run:started', (run) => {
+  captureRunStarted(run);
+});
+
+automationsService.on('run:stopped', (run) => {
+  telemetryService.capture('automation_run_stopped', {
+    ...runTelemetryProps(run),
+    status: run.status,
+  });
+});
+
+automationsService.on('run:step-completed', (run) => {
+  if (run.status === 'creating_task') {
+    captureRunStarted(run);
+  }
+
+  if (!TERMINAL_RUN_STATUSES.has(run.status) || completedRunIds.has(run.id)) return;
+  completedRunIds.add(run.id);
+
+  telemetryService.capture('automation_run_completed', {
+    ...runTelemetryProps(run),
+    status: run.status as 'done' | 'failed' | 'skipped',
+    duration_ms: getDurationMs(run),
+    error_step: run.error?.step,
+    error_code: run.error?.code,
+  });
+});

--- a/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
+++ b/apps/emdash-desktop/src/main/core/telemetry/automation-telemetry.ts
@@ -43,6 +43,11 @@ function captureRunStarted(run: AutomationRun): void {
   telemetryService.capture('automation_run_started', runTelemetryProps(run));
 }
 
+function clearRunTelemetryDedupe(runId: string): void {
+  startedRunIds.delete(runId);
+  completedRunIds.delete(runId);
+}
+
 automationsService.on('automation:created', (automation) => {
   telemetryService.capture('automation_created', {
     ...automationTelemetryProps(automation),
@@ -78,4 +83,5 @@ automationsService.on('run:step-completed', (run) => {
     error_step: run.error?.step,
     error_code: run.error?.code,
   });
+  clearRunTelemetryDedupe(run.id);
 });

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -1,4 +1,5 @@
 import './app/configure-app-identity';
+import './core/telemetry/automation-telemetry';
 import { join } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
 import { app, BrowserWindow, dialog, ipcMain } from 'electron';

--- a/apps/emdash-desktop/src/main/lib/telemetry.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.ts
@@ -19,6 +19,9 @@ type TelemetryKVSchema = {
 
 const LIB_NAME = 'emdash';
 const isViteDevBuild = import.meta.env.DEV;
+const MAX_EVENT_TS_MS = 9_999_999_999_999;
+const MAX_DURATION_MS = 30 * 24 * 60 * 60 * 1_000;
+const MAX_GENERIC_NUMBER = 1_000_000;
 
 class TelemetryService implements IInitializable, IDisposable {
   private enabled = true;
@@ -166,9 +169,11 @@ class TelemetryService implements IInitializable, IDisposable {
           sanitized[key] = value.trim().slice(0, maxLength);
         } else if (typeof value === 'number') {
           if (key === 'event_ts_ms') {
-            sanitized[key] = Math.max(0, Math.min(Math.trunc(value), 9_999_999_999_999));
+            sanitized[key] = Math.max(0, Math.min(Math.trunc(value), MAX_EVENT_TS_MS));
+          } else if (key === 'duration_ms') {
+            sanitized[key] = Math.max(0, Math.min(Math.trunc(value), MAX_DURATION_MS));
           } else {
-            sanitized[key] = Math.max(-1_000_000, Math.min(value, 1_000_000));
+            sanitized[key] = Math.max(-MAX_GENERIC_NUMBER, Math.min(value, MAX_GENERIC_NUMBER));
           }
         } else if (typeof value === 'boolean') {
           sanitized[key] = value;

--- a/apps/emdash-desktop/src/main/lib/telemetry.ts
+++ b/apps/emdash-desktop/src/main/lib/telemetry.ts
@@ -143,6 +143,12 @@ class TelemetryService implements IInitializable, IDisposable {
       'terminal_id',
       'was_crash',
       'type',
+      'status',
+      'automation_id',
+      'trigger_kind',
+      'duration_ms',
+      'error_step',
+      'error_code',
     ]);
     const passthroughProps = new Set([
       '$exception_message',

--- a/apps/emdash-desktop/src/shared/telemetry.ts
+++ b/apps/emdash-desktop/src/shared/telemetry.ts
@@ -70,7 +70,6 @@ export type TelemetryEventProperties = {
     has_initial_prompt: boolean;
   };
   automation_enabled_changed: { enabled: boolean; trigger_kind: 'cron' };
-  automation_deleted: EmptyProps;
   automation_run_started: { trigger_kind: AutomationRunTriggerKind };
   automation_run_completed: {
     status: Extract<AutomationRunStatus, 'done' | 'failed' | 'skipped'>;
@@ -80,7 +79,6 @@ export type TelemetryEventProperties = {
     error_step?: string;
     error_code?: string;
   };
-  automation_run_stopped: { status: AutomationRunStatus; trigger_kind: AutomationRunTriggerKind };
 
   project_added: { type: 'local' | 'ssh'; strategy: 'open' | 'create' | 'clone'; success: boolean };
   project_deleted: EmptyProps;

--- a/apps/emdash-desktop/src/shared/telemetry.ts
+++ b/apps/emdash-desktop/src/shared/telemetry.ts
@@ -1,4 +1,8 @@
 import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
+import type {
+  AutomationRunStatus,
+  AutomationRunTriggerKind,
+} from '@shared/core/automations/automation-run';
 import type { PullRequestMergeStrategy } from '@shared/core/pull-requests/pull-requests';
 import type { TaskLifecycleStatus } from '@shared/core/tasks/tasks';
 import type { OpenInAppId } from '@shared/openInApps';
@@ -22,6 +26,7 @@ export type FocusTrigger = 'navigation' | 'panel_switch' | 'region_switch';
 export interface TelemetryEnvelope {
   event_ts_ms?: number;
   session_id?: string;
+  automation_id?: string;
   project_id?: string;
   task_id?: string;
   conversation_id?: string;
@@ -57,6 +62,25 @@ export type TelemetryEventProperties = {
   skills_viewed: { from_view: FocusView | null };
   mcp_viewed: { from_view: FocusView | null };
   automations_viewed: { from_view: FocusView | null };
+
+  automation_created: {
+    enabled: boolean;
+    trigger_kind: 'cron';
+    provider: AgentProviderId | null;
+    has_initial_prompt: boolean;
+  };
+  automation_enabled_changed: { enabled: boolean; trigger_kind: 'cron' };
+  automation_deleted: EmptyProps;
+  automation_run_started: { trigger_kind: AutomationRunTriggerKind };
+  automation_run_completed: {
+    status: Extract<AutomationRunStatus, 'done' | 'failed' | 'skipped'>;
+    trigger_kind: AutomationRunTriggerKind;
+    duration_ms?: number;
+    task_id?: string;
+    error_step?: string;
+    error_code?: string;
+  };
+  automation_run_stopped: { status: AutomationRunStatus; trigger_kind: AutomationRunTriggerKind };
 
   project_added: { type: 'local' | 'ssh'; strategy: 'open' | 'create' | 'clone'; success: boolean };
   project_deleted: EmptyProps;


### PR DESCRIPTION
### Description
- adds posthog telemtry events for: created,enabled/disabled,run started, run completed.
- tracks both manual and cron

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
