### PR TITLE
fix(secrets): explain Linux basic_text storage fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,11 @@ already use: Claude Code, Codex, OpenCode, Gemini, Amp, and more.
 | Windows | [Installer](https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.msi) · [Portable](https://github.com/generalaction/emdash/releases/latest/download/emdash-x64.exe) |
 | Linux | [AppImage](https://github.com/generalaction/emdash/releases/latest/download/emdash-x86_64.AppImage) · [Debian package](https://github.com/generalaction/emdash/releases/latest/download/emdash-amd64.deb) |
 
+On Linux, Emdash requires Electron secure storage to use an encrypted keyring backend for
+credentials. If your desktop environment falls back to `basic_text`, install/configure a
+secure keyring such as GNOME libsecret or launch Emdash with
+`--password-store=gnome-libsecret`.
+
 See the [latest release](https://github.com/generalaction/emdash/releases/latest) for
 all desktop builds.
 

--- a/apps/emdash-desktop/src/main/core/secrets/encrypted-app-secrets-store.test.ts
+++ b/apps/emdash-desktop/src/main/core/secrets/encrypted-app-secrets-store.test.ts
@@ -22,19 +22,42 @@ vi.mock('@main/db/schema', () => ({
 
 import { EncryptedAppSecretsStore } from './encrypted-app-secrets-store';
 
+function createBasicTextSafeStorage() {
+  return {
+    isEncryptionAvailable: () => true,
+    encryptString: vi.fn((value: string) => Buffer.from(value)),
+    decryptString: vi.fn((value: Buffer) => value.toString('utf8')),
+    getSelectedStorageBackend: () => 'basic_text',
+  };
+}
+
 describe('EncryptedAppSecretsStore', () => {
-  it('explains how to fix Linux basic_text secure storage fallback', async () => {
-    const safeStorageApi = {
-      isEncryptionAvailable: () => true,
-      encryptString: vi.fn((value: string) => Buffer.from(value)),
-      decryptString: vi.fn((value: Buffer) => value.toString('utf8')),
-      getSelectedStorageBackend: () => 'basic_text',
-    };
+  it('explains how to fix Linux basic_text secure storage fallback before writing secrets', async () => {
+    const safeStorageApi = createBasicTextSafeStorage();
     const store = new EncryptedAppSecretsStore({} as never, safeStorageApi as never, 'linux');
 
     await expect(store.setSecret('token', 'secret')).rejects.toThrow(
       '--password-store=gnome-libsecret'
     );
     expect(safeStorageApi.encryptString).not.toHaveBeenCalled();
+  });
+
+  it('explains how to fix Linux basic_text secure storage fallback before reading secrets', async () => {
+    const safeStorageApi = createBasicTextSafeStorage();
+    const limit = vi.fn(async () => [{ secret: Buffer.from('stored-secret').toString('base64') }]);
+    const db = {
+      select: vi.fn(() => ({
+        from: vi.fn(() => ({
+          where: vi.fn(() => ({
+            limit,
+          })),
+        })),
+      })),
+    };
+    const store = new EncryptedAppSecretsStore(db as never, safeStorageApi as never, 'linux');
+
+    await expect(store.getSecret('token')).rejects.toThrow('--password-store=gnome-libsecret');
+    expect(limit).toHaveBeenCalledWith(1);
+    expect(safeStorageApi.decryptString).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/main/core/secrets/encrypted-app-secrets-store.test.ts
+++ b/apps/emdash-desktop/src/main/core/secrets/encrypted-app-secrets-store.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(value),
+    decryptString: (value: Buffer) => value.toString('utf8'),
+    getSelectedStorageBackend: () => 'os_crypt',
+  },
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {},
+}));
+
+vi.mock('@main/db/schema', () => ({
+  appSecrets: {
+    key: 'key',
+    secret: 'secret',
+  },
+}));
+
+import { EncryptedAppSecretsStore } from './encrypted-app-secrets-store';
+
+describe('EncryptedAppSecretsStore', () => {
+  it('explains how to fix Linux basic_text secure storage fallback', async () => {
+    const safeStorageApi = {
+      isEncryptionAvailable: () => true,
+      encryptString: vi.fn((value: string) => Buffer.from(value)),
+      decryptString: vi.fn((value: Buffer) => value.toString('utf8')),
+      getSelectedStorageBackend: () => 'basic_text',
+    };
+    const store = new EncryptedAppSecretsStore({} as never, safeStorageApi as never, 'linux');
+
+    await expect(store.setSecret('token', 'secret')).rejects.toThrow(
+      '--password-store=gnome-libsecret'
+    );
+    expect(safeStorageApi.encryptString).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/secrets/encrypted-app-secrets-store.ts
+++ b/apps/emdash-desktop/src/main/core/secrets/encrypted-app-secrets-store.ts
@@ -60,7 +60,9 @@ export class EncryptedAppSecretsStore {
     const backend = this.safeStorageApi.getSelectedStorageBackend?.();
     if (backend === 'basic_text') {
       throw new Error(
-        'Secure secret storage is unavailable: Linux safeStorage backend is basic_text.'
+        'Secure secret storage is unavailable: Linux safeStorage backend is basic_text. ' +
+          'Install a secure keyring backend such as GNOME libsecret, or launch Emdash ' +
+          'with --password-store=gnome-libsecret.'
       );
     }
   }


### PR DESCRIPTION
## Summary
- make the Linux `basic_text` secure-storage failure actionable by pointing users to GNOME libsecret / `--password-store=gnome-libsecret`
- document the Linux secure keyring requirement in the README installation section
- add a focused regression test for the `basic_text` failure path

Refs #1875

## Test Plan
- [x] `pnpm --dir apps/emdash-desktop exec vitest run --project node src/main/core/secrets/encrypted-app-secrets-store.test.ts`
- [x] `pnpm --filter @emdash/emdash-desktop run format:check`
- [x] `pnpm --filter @emdash/emdash-desktop run typecheck`
