### PR TITLE
feat(agent-selector): bring back default agent switch

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-info-card.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-info-card.tsx
@@ -1,16 +1,19 @@
 import { ExternalLink } from 'lucide-react';
 import React from 'react';
 import { InstallSection } from '@renderer/features/settings/agents-page/InstallSection';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
 import { useAgentInstallationStatus } from '@renderer/lib/stores/use-agent-installation-statuses';
 import { useAgent } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
+import { Switch } from '@renderer/lib/ui/switch';
 import {
   getDescriptionForProvider,
   getDocUrlForProvider,
   getProvider,
   type AgentProviderId,
 } from '@shared/core/agents/agent-provider-registry';
+import type { AppSettings } from '@shared/core/app-settings';
 
 type Props = {
   id: AgentProviderId;
@@ -25,8 +28,20 @@ export const AgentInfoCard: React.FC<Props> = ({ id, connectionId }) => {
 
   const { data: payload } = useAgent(id, connectionId);
   const { data: statusData } = useAgentInstallationStatus(id, connectionId);
+  const {
+    value: defaultAgent,
+    update: updateDefaultAgent,
+    isLoading: isDefaultAgentLoading,
+    isSaving: isDefaultAgentSaving,
+  } = useAppSettingsKey('defaultAgent');
 
   const isInstalled = (statusData?.status ?? payload?.status) === 'available';
+  const isDefaultAgent = defaultAgent === id;
+
+  function handleSetDefaultAgent(checked: boolean) {
+    if (!checked || isDefaultAgent) return;
+    updateDefaultAgent(id as AppSettings['defaultAgent']);
+  }
 
   return (
     <div className="w-96 bg-background-quaternary p-3">
@@ -51,6 +66,22 @@ export const AgentInfoCard: React.FC<Props> = ({ id, connectionId }) => {
       {description ? (
         <p className="mb-2 text-xs leading-relaxed text-foreground-muted">{description}</p>
       ) : null}
+
+      <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-border bg-background-1 px-2.5 py-2">
+        <label
+          htmlFor={`set-default-agent-${id}`}
+          className="min-w-0 flex-1 text-xs text-foreground"
+        >
+          Set as the default agent
+        </label>
+        <Switch
+          id={`set-default-agent-${id}`}
+          size="sm"
+          checked={isDefaultAgent}
+          disabled={!isInstalled || isDefaultAgentLoading || isDefaultAgentSaving}
+          onCheckedChange={handleSetDefaultAgent}
+        />
+      </div>
 
       {payload && (
         <InstallSection


### PR DESCRIPTION
## Summary
- Add a switch to the agent selector hover card for setting the hovered agent as the default.
- Reuse the existing defaultAgent app setting and disable the switch while unavailable or saving.

## Validation
- pnpm exec oxlint src/renderer/lib/components/agent-selector/agent-info-card.tsx
- pnpm exec oxfmt --check src/renderer/lib/components/agent-selector/agent-info-card.tsx
- pnpm exec tsgo --noEmit

Linear: ENG-1643