### PR TITLE
feat: add model selection to conversation creation

### DIFF
--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
@@ -188,6 +188,7 @@ export async function executeTaskCreate(
           provider,
           automation.conversationConfig?.autoApprove
         ),
+        model: automation.conversationConfig?.model || undefined,
         initialPrompt: prompt,
         isInitialConversation: true,
       });

--- a/apps/emdash-desktop/src/main/core/conversations/createConversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/createConversation.ts
@@ -7,6 +7,7 @@ import { events } from '@main/lib/events';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import { type AgentEvent } from '@shared/core/agents/agentEvents';
+import { type ConversationConfig } from '@shared/core/conversations/conversation-config';
 import { conversationCreatedChannel } from '@shared/core/conversations/conversationEvents';
 import {
   type Conversation,
@@ -50,7 +51,10 @@ export async function createConversation(
     .where(eq(conversations.taskId, params.taskId))
     .limit(1);
 
-  const config = params.autoApprove === undefined ? undefined : { autoApprove: params.autoApprove };
+  const configObj: ConversationConfig = {};
+  if (params.autoApprove !== undefined) configObj.autoApprove = params.autoApprove;
+  if (params.model) configObj.model = params.model;
+  const config = Object.keys(configObj).length > 0 ? configObj : undefined;
 
   const [row] = await database
     .insert(conversations)

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -159,7 +159,7 @@ export class LocalConversationProvider implements ConversationProvider {
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.providerSessionId ?? undefined,
         isResuming: agentSession.isResuming,
-        model: '',
+        model: conversation.model ?? '',
       });
 
       const customEnv = providerConfig?.env ?? {};

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -144,7 +144,7 @@ export class SshConversationProvider implements ConversationProvider {
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.providerSessionId ?? undefined,
         isResuming: agentSession.isResuming,
-        model: '',
+        model: conversation.model ?? '',
       });
 
       const customEnv = providerConfig?.env ?? {};

--- a/apps/emdash-desktop/src/main/core/conversations/utils.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/utils.ts
@@ -16,6 +16,7 @@ export function mapConversationRowToConversation(
     providerId: row.provider as AgentProviderId,
     autoApprove: config.autoApprove,
     providerSessionId: config.providerSessionId,
+    model: config.model,
     resume: resume,
     lastInteractedAt: row.lastInteractedAt ?? null,
     isInitialConversation: row.isInitialConversation,

--- a/apps/emdash-desktop/src/main/core/tasks/operations/createTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/createTask.ts
@@ -94,6 +94,7 @@ export async function prepareCreateTask(
     const configObj: ConversationConfig = {};
     if (ic.autoApprove !== undefined) configObj.autoApprove = ic.autoApprove;
     if (ic.initialPrompt?.trim()) configObj.initialPrompt = ic.initialPrompt.trim();
+    if (ic.model) configObj.model = ic.model;
     const config = Object.keys(configObj).length > 0 ? configObj : undefined;
     convInsert = {
       id: ic.id,

--- a/apps/emdash-desktop/src/renderer/features/automations/components/CreateAutomationView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/CreateAutomationView.tsx
@@ -75,6 +75,7 @@ export const CreateAutomationView = observer(function CreateAutomationView({
       prompt: prompt.trim(),
       provider,
       autoApprove: false,
+      model: formState.model ?? undefined,
     };
     try {
       const trimmedName = name.trim();

--- a/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
@@ -86,6 +86,8 @@ export function useAutomationFormState(
     ? seedConversationConfig?.provider
     : undefined;
 
+  const seedModel = seedConversationConfig?.model ?? undefined;
+
   const initialConversation = useInitialConversationState(effectiveProjectId, seedProvider, false, {
     resetPromptOnProjectChange: false,
   });
@@ -94,6 +96,12 @@ export function useAutomationFormState(
   if (!promptSeeded && seedPrompt) {
     setPromptSeeded(true);
     initialConversation.setPrompt(seedPrompt);
+  }
+
+  const [modelSeeded, setModelSeeded] = useState(false);
+  if (!modelSeeded && seedModel) {
+    setModelSeeded(true);
+    initialConversation.setModel(seedModel);
   }
 
   const { defaultBranch, isUnborn, currentBranch, repositoryWorkspaceId } =
@@ -123,6 +131,7 @@ export function useAutomationFormState(
 
   const prompt = initialConversation.prompt;
   const provider = initialConversation.provider ?? 'claude';
+  const model = initialConversation.model;
 
   const canSave =
     name.trim().length > 0 &&
@@ -188,6 +197,7 @@ export function useAutomationFormState(
     currentBranch,
     prompt,
     provider,
+    model,
     canSave,
     triggerConfig,
     applyTemplate,

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
@@ -6,6 +6,7 @@ import { conversationRegistry } from '@renderer/features/tasks/stores/conversati
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { useCloseGuard } from '@renderer/lib/modal/use-close-guard';
+import { useAgents } from '@renderer/lib/stores/use-agents';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
 import {
   DialogContentArea,
@@ -14,6 +15,13 @@ import {
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
 import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/lib/ui/select';
 import { Switch } from '@renderer/lib/ui/switch';
 import { providerSupportsAutoApprove } from '@shared/core/agents/agent-auto-approve';
 import { nextDefaultConversationTitle } from './conversation-title-utils';
@@ -34,7 +42,13 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
+  const [selectedModel, setSelectedModel] = useState<string | null>(null);
   useCloseGuard(isSubmitting);
+
+  const { data: agents } = useAgents();
+  const modelsCapability = agents?.find((a) => a.id === providerId)?.capabilities.models;
+  const modelOptions =
+    modelsCapability?.kind === 'selectable' ? modelsCapability.modelOptions : null;
 
   const showAutoApproveToggle = providerId ? providerSupportsAutoApprove(providerId) : false;
   const skipPermissions =
@@ -43,6 +57,15 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const title = nextDefaultConversationTitle(
     titleProviderId,
     Array.from(conversationMgr?.conversations.values() ?? [], (conversation) => conversation.data)
+  );
+
+  // Reset model when the provider changes (model ids are provider-specific).
+  const handleProviderChange = useCallback(
+    (next: typeof providerId) => {
+      setProviderOverride(next);
+      setSelectedModel(null);
+    },
+    [setProviderOverride]
   );
 
   const handleCreateConversation = useCallback(async () => {
@@ -58,6 +81,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
         autoApprove: skipPermissions,
         provider: providerId,
         title,
+        model: selectedModel ?? undefined,
       });
       setIsSubmitting(false);
       onSuccess({ conversationId: id });
@@ -75,6 +99,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
     projectId,
     taskId,
     skipPermissions,
+    selectedModel,
   ]);
 
   return (
@@ -89,10 +114,35 @@ export const CreateConversationModal = observer(function CreateConversationModal
             <AgentSelector
               autoFocus
               value={providerId}
-              onChange={setProviderOverride}
+              onChange={handleProviderChange}
               connectionId={connectionId}
             />
           </Field>
+          {modelOptions ? (
+            <Field>
+              <FieldLabel>Model</FieldLabel>
+              <Select
+                value={selectedModel ?? ''}
+                onValueChange={(val) => setSelectedModel(val || null)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="Default model">
+                    {selectedModel
+                      ? (modelOptions[selectedModel]?.name ?? selectedModel)
+                      : 'Default model'}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">Default model</SelectItem>
+                  {Object.entries(modelOptions).map(([id, opt]) => (
+                    <SelectItem key={id} value={id}>
+                      {opt.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </Field>
+          ) : null}
           {showAutoApproveToggle ? (
             <Field>
               <div className="flex items-center gap-2">

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.test.ts
@@ -40,6 +40,10 @@ vi.mock('./add-context-popover', () => ({
   AddContextPopover: () => null,
 }));
 
+vi.mock('@renderer/lib/stores/use-agents', () => ({
+  useAgents: () => ({ data: [] }),
+}));
+
 vi.mock('./use-effective-provider', () => ({
   useEffectiveProvider: () => ({
     providerId: 'claude',

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -1,11 +1,19 @@
-import { CheckCheckIcon, PlusIcon, X } from 'lucide-react';
+import { CheckCheckIcon, ChevronDownIcon, PlusIcon, X } from 'lucide-react';
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
+import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
 import { Field } from '@renderer/lib/ui/field';
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/lib/ui/popover';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/lib/ui/select';
 import { Textarea } from '@renderer/lib/ui/textarea';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
@@ -29,6 +37,9 @@ export type InitialConversationState = {
   setIssueContext: (ctx: string | null) => void;
   autoApprove: boolean;
   setAutoApprove: (autoApprove: boolean) => void;
+  /** Selected model id, or null to use the agent CLI default. */
+  model: string | null;
+  setModel: (model: string | null) => void;
   connectionId?: string;
 };
 
@@ -48,9 +59,12 @@ export function useInitialConversationState(
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
+  const [model, setModel] = useState<string | null>(null);
 
   const [prevProjectId, setPrevProjectId] = useState(projectId);
+  const [prevProviderId, setPrevProviderId] = useState(providerId);
   const projectChanged = projectId !== prevProjectId;
+  const providerChanged = providerId !== prevProviderId;
 
   if (projectChanged) {
     setPrevProjectId(projectId);
@@ -60,6 +74,10 @@ export function useInitialConversationState(
     }
     setIssueContext(null);
     setAutoApproveOverride(null);
+    setModel(null);
+  } else if (providerChanged) {
+    setPrevProviderId(providerId);
+    setModel(null);
   }
 
   const autoApproveSupported = providerId ? providerSupportsAutoApprove(providerId) : false;
@@ -75,8 +93,19 @@ export function useInitialConversationState(
     setIssueContext,
     autoApprove,
     setAutoApprove: setAutoApproveOverride,
+    model,
+    setModel,
     connectionId,
   };
+}
+
+function useModelOptions(
+  providerId: AgentProviderId | null
+): Record<string, { name: string }> | null {
+  const { data: agents } = useAgents();
+  if (!providerId) return null;
+  const models = agents?.find((a) => a.id === providerId)?.capabilities.models;
+  return models?.kind === 'selectable' ? models.modelOptions : null;
 }
 
 interface InitialConversationFieldProps {
@@ -103,6 +132,7 @@ export function InitialConversationField({
     () => buildTaskContextActions(linkedIssue, [], promptLibrary),
     [linkedIssue, promptLibrary]
   );
+  const modelOptions = useModelOptions(state.provider);
 
   // Auto-inject issue context whenever the linked issue changes.
   useEffect(() => {
@@ -149,6 +179,29 @@ export function InitialConversationField({
             contentClassName="w-64"
           />
           <div className="flex items-center gap-2">
+            {modelOptions ? (
+              <Select
+                value={state.model ?? ''}
+                onValueChange={(val) => state.setModel(val || null)}
+              >
+                <SelectTrigger className="h-6 gap-1 border-0 px-1 py-0 text-xs shadow-none focus:ring-0">
+                  <SelectValue placeholder="Default model">
+                    {state.model
+                      ? (modelOptions[state.model]?.name ?? state.model)
+                      : 'Default model'}
+                  </SelectValue>
+                  <ChevronDownIcon className="size-3 opacity-60" />
+                </SelectTrigger>
+                <SelectContent className="min-w-40">
+                  <SelectItem value="">Default model</SelectItem>
+                  {Object.entries(modelOptions).map(([id, opt]) => (
+                    <SelectItem key={id} value={id}>
+                      {opt.name}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            ) : null}
             <AddContextPopover
               actions={contextActions}
               disabled={contextActions.length === 0}

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
@@ -16,6 +16,8 @@ function makeInitialConversationState(
     setIssueContext: () => {},
     autoApprove,
     setAutoApprove: () => {},
+    model: null,
+    setModel: () => {},
   };
 }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.ts
@@ -19,6 +19,7 @@ export function buildInitialConversation(
     title: nextDefaultConversationTitle(provider, []),
     initialPrompt: buildFinalPrompt(state.issueContext, state.prompt),
     autoApprove: providerSupportsAutoApprove(provider) && state.autoApprove,
+    model: state.model ?? undefined,
   };
 }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -341,6 +341,7 @@ export class TaskManagerStore {
           title: ic.title ?? '',
           lastInteractedAt: null,
           autoApprove: ic.autoApprove ?? false,
+          model: ic.model,
           isInitialConversation: true,
         };
         const conversationManager = conversationRegistry.acquire(params.id, this.projectId, [

--- a/apps/emdash-desktop/src/shared/core/agents/agent-payload.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-payload.ts
@@ -158,9 +158,23 @@ export type AgentHostDependencyInfo = {
   uninstall?: AgentUninstallStrategy;
 };
 
+export type AgentModelOption = {
+  name: string;
+  description?: string;
+  modelFeatures?: {
+    contextWindowSize?: number;
+    speed?: number;
+    intelligence?: number;
+  };
+};
+
+export type AgentModelsCapability =
+  | { kind: 'none' }
+  | { kind: 'selectable'; modelOptions: Record<string, AgentModelOption> };
+
 export type AgentCapabilities = {
   hostDependency: AgentHostDependencyInfo;
-  models: { kind: string };
+  models: AgentModelsCapability;
   effort: { kind: string };
   prompt: { kind: string };
   sessions: { kind: string };

--- a/apps/emdash-desktop/src/shared/core/automations/config.ts
+++ b/apps/emdash-desktop/src/shared/core/automations/config.ts
@@ -19,6 +19,8 @@ export const conversationConfigSchema = z.object({
   provider: z.string(),
   title: z.string().optional(),
   autoApprove: z.boolean(),
+  /** Model to pass to the agent CLI. Absent or empty string means use the CLI default. */
+  model: z.string().optional(),
 });
 
 export type ConversationConfig = z.infer<typeof conversationConfigSchema>;

--- a/apps/emdash-desktop/src/shared/core/conversations/conversation-config.test.ts
+++ b/apps/emdash-desktop/src/shared/core/conversations/conversation-config.test.ts
@@ -27,6 +27,17 @@ describe('conversation-config', () => {
     expect(conversationConfig.parseJson(json)).toEqual(config);
   });
 
+  it('parses and round-trips model field', () => {
+    const result = conversationConfig.safeParse({ model: 'claude-sonnet-4-5' });
+    expect(result.status).toBe('ok');
+    if (result.status === 'ok') {
+      expect(result.data.model).toBe('claude-sonnet-4-5');
+    }
+    const config = { autoApprove: false, model: 'claude-opus-4-5' };
+    const json = conversationConfig.serialize(config);
+    expect(conversationConfig.parseJson(json)).toEqual(config);
+  });
+
   it('parseJson returns null for invalid JSON', () => {
     expect(conversationConfig.parseJson('not-json')).toBeNull();
   });

--- a/apps/emdash-desktop/src/shared/core/conversations/conversation-config.ts
+++ b/apps/emdash-desktop/src/shared/core/conversations/conversation-config.ts
@@ -13,6 +13,8 @@ const conversationConfigV0Schema = z.object({
   providerSessionId: z.string().optional(),
   /** Initial prompt to deliver on the first spawn; cleared from config after the session starts. */
   initialPrompt: z.string().optional(),
+  /** Model to pass to the agent CLI (e.g. 'claude-sonnet-4-5', 'o4-mini'). Empty string or absent = CLI default. */
+  model: z.string().optional(),
 });
 
 export const conversationConfig = defineVersionedSchema()

--- a/apps/emdash-desktop/src/shared/core/conversations/conversations.ts
+++ b/apps/emdash-desktop/src/shared/core/conversations/conversations.ts
@@ -14,6 +14,8 @@ export type Conversation = {
   autoApprove?: boolean;
   /** Provider-native session id captured at runtime for per-chat resume. */
   providerSessionId?: string;
+  /** Model to pass to the agent CLI. Absent or empty string means use the CLI default. */
+  model?: string;
   isInitialConversation: boolean | null;
   agentStatus?: AgentStatus | null;
   agentStatusSeen?: boolean;
@@ -31,6 +33,8 @@ export type CreateConversationParams = {
   provider: AgentProviderId;
   title: string;
   autoApprove?: boolean;
+  /** Model to pass to the agent CLI. Absent or empty string means use the CLI default. */
+  model?: string;
   isInitialConversation?: boolean;
   initialSize?: { cols: number; rows: number };
   initialPrompt?: string;

--- a/apps/emdash-desktop/src/shared/core/tasks/task-config.ts
+++ b/apps/emdash-desktop/src/shared/core/tasks/task-config.ts
@@ -14,6 +14,7 @@ const v1Schema = z.object({
       title: z.string().optional(),
       autoApprove: z.boolean().optional(),
       initialPrompt: z.string().optional(),
+      model: z.string().optional(),
     })
     .optional(),
   initialStatus: taskLifecycleStatuses.optional(),

--- a/packages/core/src/agents/plugins/helpers/standard-command.test.ts
+++ b/packages/core/src/agents/plugins/helpers/standard-command.test.ts
@@ -41,4 +41,63 @@ describe('buildStandardCommand', () => {
 
     expect(result.args).toEqual(['threads', 'continue', 'T-thread-1']);
   });
+
+  it('injects modelFlag when ctx.model is non-empty', () => {
+    const result = buildStandardCommand(
+      {
+        cli: 'claude',
+        autoApprove: false,
+        sessionId: 'conv-1',
+        isResuming: false,
+        model: 'sonnet',
+      },
+      {
+        modelFlag: '--model',
+        initialPromptFlag: '',
+      }
+    );
+
+    expect(result.args).toContain('--model');
+    expect(result.args).toContain('sonnet');
+    const modelIdx = result.args.indexOf('--model');
+    expect(result.args[modelIdx + 1]).toBe('sonnet');
+  });
+
+  it('does not inject modelFlag when ctx.model is empty', () => {
+    const result = buildStandardCommand(
+      {
+        cli: 'claude',
+        autoApprove: false,
+        sessionId: 'conv-1',
+        isResuming: false,
+        model: '',
+      },
+      {
+        modelFlag: '--model',
+        initialPromptFlag: '',
+      }
+    );
+
+    expect(result.args).not.toContain('--model');
+  });
+
+  it('injects short modelFlag (-m) for codex style', () => {
+    const result = buildStandardCommand(
+      {
+        cli: 'codex',
+        autoApprove: false,
+        sessionId: 'conv-1',
+        isResuming: false,
+        model: 'gpt-5-codex',
+      },
+      {
+        modelFlag: '-m',
+        initialPromptFlag: '',
+      }
+    );
+
+    const mIdx = result.args.indexOf('-m');
+    expect(mIdx).toBeGreaterThanOrEqual(0);
+    expect(result.args[mIdx + 1]).toBe('gpt-5-codex');
+  });
 });

--- a/packages/core/src/agents/plugins/helpers/standard-command.ts
+++ b/packages/core/src/agents/plugins/helpers/standard-command.ts
@@ -61,6 +61,12 @@ export type StandardCommandSpec = {
   validateSessionId?: (id: string) => boolean;
   /** Extra static env vars to inject (on top of ctx env). */
   extraEnv?: Record<string, string>;
+  /**
+   * CLI flag for model selection, e.g. '--model' or '-m'.
+   * When ctx.model is non-empty, appendFlagValue(args, modelFlag, ctx.model) is called.
+   * Supports both '--flag value' and '--flag=value' forms via appendFlagValue.
+   */
+  modelFlag?: string;
 };
 
 /**
@@ -119,6 +125,11 @@ export function buildStandardCommand(ctx: CommandContext, spec: StandardCommandS
   const skipAutoApprove = spec.omitAutoApproveOnResume && ctx.isResuming;
   if (ctx.autoApprove && spec.autoApproveFlag && !skipAutoApprove) {
     args.push(...splitFlag(spec.autoApproveFlag));
+  }
+
+  // Model selection
+  if (spec.modelFlag && ctx.model) {
+    appendFlagValue(args, spec.modelFlag, ctx.model);
   }
 
   // User extra args

--- a/packages/plugins/src/agents/impl/claude/index.ts
+++ b/packages/plugins/src/agents/impl/claude/index.ts
@@ -19,6 +19,23 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
+    models: {
+      kind: 'selectable',
+      modelOptions: {
+        'claude-opus-4-5': {
+          name: 'Claude Opus 4.5',
+          modelFeatures: { intelligence: 5, speed: 2 },
+        },
+        'claude-sonnet-4-5': {
+          name: 'Claude Sonnet 4.5',
+          modelFeatures: { intelligence: 4, speed: 4 },
+        },
+        'claude-haiku-4-5': {
+          name: 'Claude Haiku 4.5',
+          modelFeatures: { intelligence: 3, speed: 5 },
+        },
+      },
+    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -92,6 +109,7 @@ export const provider = registerPluginBehavior(plugin, {
         initialPromptFlag: '',
         resumeFlag: '--resume',
         sessionIdFlag: '--session-id',
+        modelFlag: '--model',
       }),
   },
   hooks: buildClaudeHookConfig(),

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -20,6 +20,23 @@ export const plugin = definePlugin(
     autoApprove: {
       kind: 'supported',
     },
+    models: {
+      kind: 'selectable',
+      modelOptions: {
+        'codex-mini-latest': {
+          name: 'Codex Mini',
+          modelFeatures: { intelligence: 3, speed: 5 },
+        },
+        'o4-mini': {
+          name: 'o4-mini',
+          modelFeatures: { intelligence: 4, speed: 4 },
+        },
+        o3: {
+          name: 'o3',
+          modelFeatures: { intelligence: 5, speed: 2 },
+        },
+      },
+    },
     hooks: {
       kind: 'config',
       scope: 'global',
@@ -70,6 +87,7 @@ export const provider = registerPluginBehavior(plugin, {
         sessionIdOnResumeOnly: true,
         resumeWithoutSessionFlag: 'resume --last',
         deduplicateFlags: ['--dangerously-bypass-approvals-and-sandbox'],
+        modelFlag: '-m',
       }),
   },
   hooks: buildCodexHookConfig(),


### PR DESCRIPTION
This PR adds the ability to select a model when creating a conversation. Currently only Claude Code and Codex are supported.