### PR TITLE
fix(lifecycle): await runtime watcher cleanup on quit

### DIFF
--- a/apps/emdash-desktop/src/main/app/shutdown.ts
+++ b/apps/emdash-desktop/src/main/app/shutdown.ts
@@ -1,0 +1,84 @@
+import { app } from 'electron';
+import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
+import { automationsService } from '@main/core/automations/automations-service';
+import { prSyncScheduler } from '@main/core/pull-requests/pr-sync-scheduler';
+import { stopResourceSampler } from '@main/core/resource-monitor/resource-sampler';
+import { runtimeManager } from '@main/core/runtime/runtime-manager';
+import { updateService } from '@main/core/updates/update-service';
+import { log } from '@main/lib/logger';
+import { telemetryService } from '@main/lib/telemetry';
+import { projectManager } from '../core/projects/project-manager';
+
+/* Maximum time (ms) to wait for the critical shutdown phase to complete. */
+const CRITICAL_DEADLINE_MS = 5_000;
+/* Grace window (ms) given to best-effort teardown before the force-exit fires. */
+const GRACE_WINDOW_MS = 400;
+/* Hard outer deadline (ms) for the entire quit sequence. */
+const HARD_DEADLINE_MS = 8_000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function withDeadline<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: ReturnType<typeof setTimeout>;
+  const timeout = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`Timed out after ${ms}ms`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+/**
+ * two phase shutdown sequence:
+ * - critical phase — awaited, bounded by CRITICAL_DEADLINE_MS
+ * - best effort phase — voided, abandoned after GRACE_WINDOW_MS
+ */
+export async function runQuitCleanup(): Promise<void> {
+  telemetryService.capture('app_closed');
+
+  // synchronous stops
+  automationsService.stop();
+  agentHookService.dispose();
+  stopResourceSampler();
+  updateService.dispose();
+  prSyncScheduler.dispose();
+
+  // critical phase
+  const criticalSteps: Array<() => Promise<void>> = [
+    () => projectManager.release(),
+    () => runtimeManager.dispose(),
+    () => telemetryService.dispose(),
+  ];
+  await withDeadline(
+    (async () => {
+      for (const step of criticalSteps) await step();
+    })(),
+    CRITICAL_DEADLINE_MS
+  ).catch((e: unknown) => {
+    log.error('quit: critical cleanup failed or timed out', e);
+  });
+
+  // best effort phase
+  const bestEffortSteps: Array<() => void | Promise<void>> = [() => projectManager.dispose()];
+  const graceful = Promise.allSettled(bestEffortSteps.map((fn) => Promise.resolve().then(fn)));
+  await Promise.race([graceful, delay(GRACE_WINDOW_MS)]);
+}
+
+export function registerQuitHandler(): void {
+  let started = false;
+  app.on('before-quit', (event) => {
+    event.preventDefault();
+    if (started) return;
+    started = true;
+
+    const forceExit = setTimeout(() => {
+      log.warn('quit: hard deadline reached, forcing exit');
+      app.exit(0);
+    }, HARD_DEADLINE_MS);
+
+    void runQuitCleanup().finally(() => {
+      clearTimeout(forceExit);
+      app.exit(0);
+    });
+  });
+}

--- a/apps/emdash-desktop/src/main/app/shutdown.ts
+++ b/apps/emdash-desktop/src/main/app/shutdown.ts
@@ -44,14 +44,20 @@ export async function runQuitCleanup(): Promise<void> {
   prSyncScheduler.dispose();
 
   // critical phase
-  const criticalSteps: Array<() => Promise<void>> = [
-    () => projectManager.release(),
-    () => runtimeManager.dispose(),
-    () => telemetryService.dispose(),
+  const criticalSteps: Array<[string, () => Promise<void>]> = [
+    ['projectManager.release', () => projectManager.release()],
+    ['runtimeManager.dispose', () => runtimeManager.dispose()],
+    ['telemetryService.dispose', () => telemetryService.dispose()],
   ];
   await withDeadline(
     (async () => {
-      for (const step of criticalSteps) await step();
+      for (const [name, step] of criticalSteps) {
+        try {
+          await step();
+        } catch (e) {
+          log.error(`quit: critical step ${name} failed`, e);
+        }
+      }
     })(),
     CRITICAL_DEADLINE_MS
   ).catch((e: unknown) => {

--- a/apps/emdash-desktop/src/main/core/project-setup/repository-setup.ts
+++ b/apps/emdash-desktop/src/main/core/project-setup/repository-setup.ts
@@ -89,7 +89,7 @@ export async function cloneProjectRepository(
     }
     return { success: true };
   } finally {
-    runtimeLease.release();
+    await runtimeLease.release();
   }
 }
 
@@ -121,9 +121,9 @@ export async function initializeProjectRepository(
       if (!commitResult.success) return { success: false, error: commitResult.error.message };
       return await pushInitialBranch(worktreeLease.value);
     } finally {
-      worktreeLease.release();
+      await worktreeLease.release();
     }
   } finally {
-    runtimeLease.release();
+    await runtimeLease.release();
   }
 }

--- a/apps/emdash-desktop/src/main/core/projects/create-project-provider.ts
+++ b/apps/emdash-desktop/src/main/core/projects/create-project-provider.ts
@@ -80,11 +80,11 @@ async function createLocalProvider(project: LocalProject): Promise<ProjectProvid
       await backfillGitHubAccount(provider);
       return provider;
     } catch (error) {
-      repoLease.release();
+      await repoLease.release();
       throw error;
     }
   } catch (error) {
-    runtimeLease.release();
+    await runtimeLease.release();
     throw error;
   }
 }
@@ -124,7 +124,9 @@ async function createSshProvider(project: SshProject): Promise<ProjectProvider> 
           void provider?.gitRepositoryFetchService.fetch();
         }
       };
-      const dispose = () => sshConnectionManager.off('connection-event', handler);
+      const dispose = () => {
+        sshConnectionManager.off('connection-event', handler);
+      };
 
       const repoLease = await runtimeLease.value.git.openRepository(project.path);
       try {
@@ -153,11 +155,11 @@ async function createSshProvider(project: SshProject): Promise<ProjectProvider> 
 
         return provider;
       } catch (error) {
-        repoLease.release();
+        await repoLease.release();
         throw error;
       }
     } catch (error) {
-      runtimeLease.release();
+      await runtimeLease.release();
       throw error;
     }
   } catch (error) {
@@ -179,7 +181,7 @@ async function runLegacyProjectSettingsMigration(
   try {
     await settings.ensure({ git: lease.value });
   } finally {
-    lease.release();
+    await lease.release();
   }
 }
 
@@ -205,7 +207,7 @@ function buildProvider(
   settings: ProjectSettingsProvider,
   worktreeHost: WorktreeHost,
   resolveWorktreePoolPath: () => Promise<string>,
-  dispose: () => void,
+  dispose: () => void | Promise<void>,
   runtimeLease: Lease<MachineRuntime>,
   repoLease: Lease<IGitRepository>
 ): ProjectProvider {
@@ -234,10 +236,10 @@ function buildProvider(
     events.emit(gitRepoUpdateChannel, { projectId, update });
   });
 
-  const releaseGitRuntime = () => {
+  const releaseGitRuntime = async () => {
     unsubscribeRepoUpdates();
-    repoLease.release();
-    runtimeLease.release();
+    await repoLease.release();
+    await runtimeLease.release();
   };
 
   return new ProjectProvider(
@@ -248,10 +250,9 @@ function buildProvider(
     worktreeService,
     gitRepositoryFetchService,
     runtimeLease.value.git,
-    () => {
-      gitRepositoryFetchService.stop();
-      releaseGitRuntime();
-      dispose();
+    async () => {
+      await releaseGitRuntime();
+      await dispose();
     }
   );
 }

--- a/apps/emdash-desktop/src/main/core/projects/create-project-provider.ts
+++ b/apps/emdash-desktop/src/main/core/projects/create-project-provider.ts
@@ -236,7 +236,7 @@ function buildProvider(
     events.emit(gitRepoUpdateChannel, { projectId, update });
   });
 
-  const releaseGitRuntime = async () => {
+  const releaseProjectLeases = async () => {
     unsubscribeRepoUpdates();
     await repoLease.release();
     await runtimeLease.release();
@@ -251,7 +251,7 @@ function buildProvider(
     gitRepositoryFetchService,
     runtimeLease.value.git,
     async () => {
-      await releaseGitRuntime();
+      await releaseProjectLeases();
       await dispose();
     }
   );

--- a/apps/emdash-desktop/src/main/core/projects/operations/create-local-project.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/create-local-project.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { err, ok } from '@emdash/shared';
+import { err, ok, withLease } from '@emdash/shared';
 import { sql } from 'drizzle-orm';
 import { projectEvents } from '@main/core/projects/project-events';
 import { projectManager } from '@main/core/projects/project-manager';
@@ -38,12 +38,9 @@ export async function createLocalProject(
     });
   }
 
-  const runtimeLease = await runtimeManager.acquire({ kind: 'local' });
-  const repositoryResult = await ensureProjectRepository(
-    runtimeLease.value.git,
-    params.path,
-    params.initGitRepository
-  ).finally(() => runtimeLease.release());
+  const repositoryResult = await withLease(runtimeManager.acquire({ kind: 'local' }), (runtime) =>
+    ensureProjectRepository(runtime.git, params.path, params.initGitRepository)
+  );
   if (!repositoryResult.success) return repositoryResult;
   const gitInfo = repositoryResult.data;
 
@@ -111,6 +108,6 @@ export async function getLocalProjectPathStatus(path: string): Promise<ProjectPa
     }
     return { isDirectory: true, isGitRepo: inspection.kind === 'repository' };
   } finally {
-    runtimeLease.release();
+    await runtimeLease.release();
   }
 }

--- a/apps/emdash-desktop/src/main/core/projects/operations/create-project-utils.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/create-project-utils.ts
@@ -62,6 +62,6 @@ export async function ensureProjectRepository(
     const baseRef = await resolveProjectBaseRef(repoLease.value, ensured.data.baseRef);
     return ok({ rootPath: ensured.data.rootPath, baseRef });
   } finally {
-    repoLease.release();
+    await repoLease.release();
   }
 }

--- a/apps/emdash-desktop/src/main/core/projects/operations/create-ssh-project.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/create-ssh-project.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { err, ok } from '@emdash/shared';
+import { err, ok, withLease } from '@emdash/shared';
 import { sql } from 'drizzle-orm';
 import { SshFileSystem } from '@main/core/fs/impl/ssh-fs';
 import { projectEvents } from '@main/core/projects/project-events';
@@ -35,15 +35,13 @@ export async function createSshProject(
       message: 'Invalid directory',
     });
   }
-  const runtimeLease = await runtimeManager.acquire({
-    kind: 'ssh',
-    connectionId: params.connectionId,
-  });
-  const repositoryResult = await ensureProjectRepository(
-    runtimeLease.value.git,
-    params.path,
-    params.initGitRepository
-  ).finally(() => runtimeLease.release());
+  const repositoryResult = await withLease(
+    runtimeManager.acquire({
+      kind: 'ssh',
+      connectionId: params.connectionId,
+    }),
+    (runtime) => ensureProjectRepository(runtime.git, params.path, params.initGitRepository)
+  );
   if (!repositoryResult.success) return repositoryResult;
   const gitInfo = repositoryResult.data;
 
@@ -112,7 +110,7 @@ export async function getSshProjectPathStatus(
       }
       return { isDirectory: true, isGitRepo: inspection.kind === 'repository' };
     } finally {
-      runtimeLease.release();
+      await runtimeLease.release();
     }
   } catch {
     return { isDirectory: false, isGitRepo: false };

--- a/apps/emdash-desktop/src/main/core/projects/project-manager.ts
+++ b/apps/emdash-desktop/src/main/core/projects/project-manager.ts
@@ -1,5 +1,4 @@
-import { err, ok, type Result } from '@emdash/shared';
-import type { IDisposable } from '@emdash/shared';
+import { err, ok, type IDisposable, type IReleasable, type Result } from '@emdash/shared';
 import { HookCore, type Hookable } from '@main/lib/hookable';
 import { LifecycleMap } from '@main/lib/lifecycle-map';
 import { log } from '@main/lib/logger';
@@ -31,7 +30,9 @@ function toTeardownError(e: unknown): ProviderLifecycleError {
   return { type: 'error', message: e instanceof Error ? e.message : String(e) };
 }
 
-class ProjectSessionManager implements Hookable<ProjectSessionManagerHooks>, IDisposable {
+class ProjectSessionManager
+  implements Hookable<ProjectSessionManagerHooks>, IReleasable, IDisposable
+{
   private readonly _hooks = new HookCore<ProjectSessionManagerHooks>((name, e) =>
     log.error(`ProjectManager: ${String(name)} hook error`, e)
   );
@@ -100,6 +101,16 @@ class ProjectSessionManager implements Hookable<ProjectSessionManagerHooks>, IDi
         });
       }
     }
+  }
+
+  async release(): Promise<void> {
+    const providers = Array.from(this._lifecycle.values());
+    const results = await Promise.allSettled(providers.map((provider) => provider.release()));
+    const failures = results.filter((result) => result.status === 'rejected');
+    for (const failure of failures) {
+      log.error('ProjectManager: failed to release', failure.reason);
+    }
+    if (failures.length > 0) throw failures[0].reason;
   }
 }
 

--- a/apps/emdash-desktop/src/main/core/projects/project-provider.ts
+++ b/apps/emdash-desktop/src/main/core/projects/project-provider.ts
@@ -85,7 +85,7 @@ export class ProjectProvider implements IDisposable {
     worktreeService: WorktreeService,
     gitRepositoryFetchService: GitRepositoryFetchService,
     private readonly _gitRuntime: IGitRuntime,
-    private readonly _dispose: () => void
+    private readonly _dispose: () => void | Promise<void>
   ) {
     this.type = transport.kind;
     this.projectId = projectId;
@@ -130,17 +130,20 @@ export class ProjectProvider implements IDisposable {
     try {
       return await lease.value.getHead();
     } finally {
-      lease.release();
+      await lease.release();
     }
   }
 
   async dispose(): Promise<void> {
-    this._dispose();
-    this.gitRepositoryFetchService.stop();
-    const projectSettings = await this.settings.get();
-    const mode = projectSettings.tmux ? 'detach' : 'terminate';
-    await taskSessionManager.teardownAllForProject(this.projectId, mode);
-    await workspaceRegistry.releaseAllForProject(this.projectId, mode);
-    await previewServerService.stopForProject(this.projectId);
+    try {
+      this.gitRepositoryFetchService.stop();
+      const projectSettings = await this.settings.get();
+      const mode = projectSettings.tmux ? 'detach' : 'terminate';
+      await taskSessionManager.teardownAllForProject(this.projectId, mode);
+      await workspaceRegistry.releaseAllForProject(this.projectId, mode);
+      await previewServerService.stopForProject(this.projectId);
+    } finally {
+      await this._dispose();
+    }
   }
 }

--- a/apps/emdash-desktop/src/main/core/projects/project-provider.ts
+++ b/apps/emdash-desktop/src/main/core/projects/project-provider.ts
@@ -5,8 +5,7 @@ import type {
   GitSequences,
   IGitRuntime,
 } from '@emdash/core/git';
-import type { Result } from '@emdash/shared';
-import type { IDisposable } from '@emdash/shared';
+import type { IDisposable, IReleasable, Result } from '@emdash/shared';
 import type { IExecutionContext } from '@main/core/execution-context/types';
 import type { FileSystemProvider } from '@main/core/fs/types';
 import type { GitRepositoryFetchService } from '@main/core/git/repository/fetch-service';
@@ -60,7 +59,7 @@ export type ProjectProviderTransport = {
   readonly worktreeHost: WorktreeHost;
 };
 
-export class ProjectProvider implements IDisposable {
+export class ProjectProvider implements IReleasable, IDisposable {
   readonly type: string;
   readonly projectId: string;
   readonly repoPath: string;
@@ -85,7 +84,7 @@ export class ProjectProvider implements IDisposable {
     worktreeService: WorktreeService,
     gitRepositoryFetchService: GitRepositoryFetchService,
     private readonly _gitRuntime: IGitRuntime,
-    private readonly _dispose: () => void | Promise<void>
+    private readonly _releaseProjectLeases: () => void | Promise<void>
   ) {
     this.type = transport.kind;
     this.projectId = projectId;
@@ -134,16 +133,26 @@ export class ProjectProvider implements IDisposable {
     }
   }
 
+  async release(): Promise<void> {
+    this.gitRepositoryFetchService.stop();
+    const results = await Promise.allSettled([
+      workspaceRegistry.releaseLeasesForProject(this.projectId),
+      this._releaseProjectLeases(),
+    ]);
+    const failure = results.find((result) => result.status === 'rejected');
+    if (failure?.status === 'rejected') throw failure.reason;
+  }
+
   async dispose(): Promise<void> {
     try {
       this.gitRepositoryFetchService.stop();
       const projectSettings = await this.settings.get();
       const mode = projectSettings.tmux ? 'detach' : 'terminate';
       await taskSessionManager.teardownAllForProject(this.projectId, mode);
-      await workspaceRegistry.releaseAllForProject(this.projectId, mode);
+      await workspaceRegistry.teardownAllForProject(this.projectId, mode);
       await previewServerService.stopForProject(this.projectId);
     } finally {
-      await this._dispose();
+      await this.release();
     }
   }
 }

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
@@ -83,9 +83,9 @@ export class LegacySshGitRuntime implements IGitRuntime {
       }),
   });
   private readonly worktrees = new ResourceMap<LegacyWorktreeResource>({
-    teardown: (_key, resource) => {
-      resource.worktree.dispose();
-      resource.repositoryLease.release();
+    teardown: async (_key, resource) => {
+      await resource.worktree.dispose();
+      await resource.repositoryLease.release();
     },
     onError: (context, error) =>
       log.warn('LegacySshGitRuntime: worktree teardown failed', { context, error: String(error) }),
@@ -190,9 +190,11 @@ export class LegacySshGitRuntime implements IGitRuntime {
     };
   }
 
-  dispose(): void {
-    this.worktrees.dispose();
-    this.repositories.dispose();
+  async dispose(): Promise<void> {
+    const worktreesDisposed = this.worktrees.dispose();
+    const repositoriesDisposed = this.repositories.dispose();
+    await worktreesDisposed;
+    await repositoriesDisposed;
   }
 
   /**
@@ -590,7 +592,7 @@ class LegacySshGitWorktree implements IGitWorktree {
     return ok({ output: result.data.output, sequences: await this.refreshAfterHistoryChange() });
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     for (const timer of this.timers) clearInterval(timer);
     this.statusModel.dispose();
     this.headModel.dispose();

--- a/apps/emdash-desktop/src/main/core/runtime/runtime-manager.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/runtime-manager.ts
@@ -15,8 +15,8 @@ class LocalMachineRuntime implements MachineRuntime {
   });
   readonly health = new ConstantHealthSource();
 
-  dispose(): void {
-    void this.git.dispose();
+  async dispose(): Promise<void> {
+    await this.git.dispose();
   }
 }
 
@@ -33,8 +33,8 @@ class SshMachineRuntime implements MachineRuntime {
     this.git = new LegacySshGitRuntime(proxy);
   }
 
-  dispose(): void {
-    this.git.dispose();
+  async dispose(): Promise<void> {
+    await this.git.dispose();
   }
 }
 
@@ -53,9 +53,9 @@ class DefaultRuntimeManager implements RuntimeManager {
     });
   }
 
-  dispose(): void {
-    this.runtimes.dispose();
+  async dispose(): Promise<void> {
+    await this.runtimes.dispose();
   }
 }
 
-export const runtimeManager: RuntimeManager = new DefaultRuntimeManager();
+export const runtimeManager = new DefaultRuntimeManager();

--- a/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.ts
@@ -66,10 +66,10 @@ async function getTaskPreflight(
               }
               hasUncommittedChanges = status.kind === 'too-many-files';
             } finally {
-              worktreeLease.release();
+              await worktreeLease.release();
             }
           } finally {
-            runtimeLease.release();
+            await runtimeLease.release();
           }
         }
       } catch (e) {

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
@@ -60,7 +60,7 @@ async function executeTeardown(
     await task.conversations.destroyAll();
     await task.terminals.destroyAll();
   }
-  await workspaceRegistry.release(workspaceId, mode);
+  await workspaceRegistry.teardown(workspaceId, mode);
 }
 
 async function cleanupDetachedSessions(
@@ -169,7 +169,7 @@ class TaskSessionManager {
     const taskIds = Array.from(this._tasksByProject.get(projectId) ?? []);
     if (mode === 'detach') {
       // Detach sessions but leave workspaces alive; provider.cleanup() will call
-      // workspaceRegistry.releaseAllForProject to handle workspace teardown.
+      // workspaceRegistry.teardownAllForProject to handle workspace teardown.
       await Promise.all(
         taskIds.flatMap((id) => {
           const stored = this._lifecycle.get(id);

--- a/apps/emdash-desktop/src/main/core/workspaces/byoi/provision-byoi-task.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/byoi/provision-byoi-task.ts
@@ -143,7 +143,7 @@ export async function provisionBYOITask(
     };
   } finally {
     if (!provisionSucceeded) {
-      await workspaceRegistry.release(workspace.id, 'terminate').catch(() => {});
+      await workspaceRegistry.teardown(workspace.id, 'terminate').catch(() => {});
     }
   }
 }

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -398,7 +398,7 @@ export class WorkspaceBootstrapService {
       });
     } finally {
       if (!buildSucceeded) {
-        await workspaceRegistry.release(workspaceId, 'terminate').catch(() => {});
+        await workspaceRegistry.teardown(workspaceId, 'terminate').catch(() => {});
       }
     }
   }

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
@@ -153,11 +153,11 @@ export function createWorkspaceFactory(
       lifecycleService,
       gitRepository,
       gitRepositoryFetchService,
-      dispose: () => {
+      dispose: async () => {
         unsubscribeGitUpdates?.();
         unsubscribeGitUpdates = undefined;
-        worktreeLease.release();
-        runtimeLease.release();
+        await worktreeLease.release();
+        await runtimeLease.release();
       },
     };
 

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-registry.test.ts
@@ -74,19 +74,19 @@ describe('WorkspaceRegistry', () => {
     await registry.acquire('branch:main', 'test-project', factory);
     await registry.acquire('branch:main', 'test-project', factory);
 
-    await registry.release('branch:main');
+    await registry.teardown('branch:main');
     expect(dispose).not.toHaveBeenCalled();
     expect(gitDispose).not.toHaveBeenCalled();
     expect(registry.refCount('branch:main')).toBe(1);
 
-    await registry.release('branch:main');
+    await registry.teardown('branch:main');
     expect(gitDispose).toHaveBeenCalledTimes(1);
     expect(dispose).toHaveBeenCalledTimes(1);
     expect(registry.get('branch:main')).toBeUndefined();
     expect(registry.refCount('branch:main')).toBe(0);
   });
 
-  it('releaseAll disposes each workspace once and clears the registry', async () => {
+  it('teardownAll disposes each workspace once and clears the registry', async () => {
     const registry = new WorkspaceRegistry();
     const first = makeWorkspace('branch:main');
     const second = makeWorkspace('root:');
@@ -99,7 +99,7 @@ describe('WorkspaceRegistry', () => {
     }));
     await registry.acquire('root:', 'test-project', async () => ({ workspace: second.workspace }));
 
-    await registry.releaseAll();
+    await registry.teardownAll();
 
     expect(first.gitDispose).toHaveBeenCalledTimes(1);
     expect(first.dispose).toHaveBeenCalledTimes(1);
@@ -109,9 +109,9 @@ describe('WorkspaceRegistry', () => {
     expect(registry.refCount('root:')).toBe(0);
   });
 
-  it('ignores release for unknown keys', async () => {
+  it('ignores teardown for unknown keys', async () => {
     const registry = new WorkspaceRegistry();
-    await expect(registry.release('missing')).resolves.toBeUndefined();
+    await expect(registry.teardown('missing')).resolves.toBeUndefined();
   });
 
   it('calls onCreateSideEffect once on first acquire and not on re-acquire', async () => {
@@ -161,7 +161,7 @@ describe('WorkspaceRegistry', () => {
     expect(onCreate).toHaveBeenCalledTimes(1);
   });
 
-  it('calls onDestroy once at final release, not on earlier releases', async () => {
+  it('calls onDestroy once at final teardown, not on earlier teardowns', async () => {
     const registry = new WorkspaceRegistry();
     const { workspace } = makeWorkspace('branch:main');
     const onDestroy = vi.fn(async () => {});
@@ -170,10 +170,10 @@ describe('WorkspaceRegistry', () => {
     await registry.acquire('branch:main', 'test-project', factory);
     await registry.acquire('branch:main', 'test-project', factory);
 
-    await registry.release('branch:main');
+    await registry.teardown('branch:main');
     expect(onDestroy).not.toHaveBeenCalled();
 
-    await registry.release('branch:main');
+    await registry.teardown('branch:main');
     expect(onDestroy).toHaveBeenCalledTimes(1);
     expect(onDestroy).toHaveBeenCalledWith(workspace);
   });
@@ -198,12 +198,12 @@ describe('WorkspaceRegistry', () => {
     const factory = vi.fn(async () => ({ workspace, onDestroy }));
 
     await registry.acquire('branch:main', 'test-project', factory);
-    await registry.release('branch:main');
+    await registry.teardown('branch:main');
 
     expect(order).toEqual(['onDestroy', 'gitDispose', 'lifecycleDispose']);
   });
 
-  it('calls onDestroy for each entry in releaseAll', async () => {
+  it('calls onDestroy for each entry in teardownAll', async () => {
     const registry = new WorkspaceRegistry();
     const first = makeWorkspace('branch:main');
     const second = makeWorkspace('root:');
@@ -219,7 +219,7 @@ describe('WorkspaceRegistry', () => {
       onDestroy: onDestroySecond,
     }));
 
-    await registry.releaseAll();
+    await registry.teardownAll();
 
     expect(onDestroyFirst).toHaveBeenCalledTimes(1);
     expect(onDestroyFirst).toHaveBeenCalledWith(first.workspace);
@@ -227,7 +227,7 @@ describe('WorkspaceRegistry', () => {
     expect(onDestroySecond).toHaveBeenCalledWith(second.workspace);
   });
 
-  it('calls onDetach (not onDestroy) when releasing with detach mode', async () => {
+  it('calls onDetach (not onDestroy) when tearing down with detach mode', async () => {
     const registry = new WorkspaceRegistry();
     const { workspace } = makeWorkspace('branch:main');
     const onDestroy = vi.fn(async () => {});
@@ -235,14 +235,14 @@ describe('WorkspaceRegistry', () => {
     const factory = vi.fn(async () => ({ workspace, onDestroy, onDetach }));
 
     await registry.acquire('branch:main', 'test-project', factory);
-    await registry.release('branch:main', 'detach');
+    await registry.teardown('branch:main', 'detach');
 
     expect(onDetach).toHaveBeenCalledTimes(1);
     expect(onDetach).toHaveBeenCalledWith(workspace);
     expect(onDestroy).not.toHaveBeenCalled();
   });
 
-  it('calls onDestroy (not onDetach) when releasing with terminate mode', async () => {
+  it('calls onDestroy (not onDetach) when tearing down with terminate mode', async () => {
     const registry = new WorkspaceRegistry();
     const { workspace } = makeWorkspace('branch:main');
     const onDestroy = vi.fn(async () => {});
@@ -250,7 +250,7 @@ describe('WorkspaceRegistry', () => {
     const factory = vi.fn(async () => ({ workspace, onDestroy, onDetach }));
 
     await registry.acquire('branch:main', 'test-project', factory);
-    await registry.release('branch:main', 'terminate');
+    await registry.teardown('branch:main', 'terminate');
 
     expect(onDestroy).toHaveBeenCalledTimes(1);
     expect(onDestroy).toHaveBeenCalledWith(workspace);
@@ -266,14 +266,14 @@ describe('WorkspaceRegistry', () => {
     await registry.acquire('branch:main', 'test-project', factory);
     await registry.acquire('branch:main', 'test-project', factory);
 
-    await registry.release('branch:main', 'detach');
+    await registry.teardown('branch:main', 'detach');
     expect(onDetach).not.toHaveBeenCalled();
 
-    await registry.release('branch:main', 'detach');
+    await registry.teardown('branch:main', 'detach');
     expect(onDetach).toHaveBeenCalledTimes(1);
   });
 
-  it('releaseAllForProject passes detach mode to hooks', async () => {
+  it('teardownAllForProject passes detach mode to hooks', async () => {
     const registry = new WorkspaceRegistry();
     const { workspace } = makeWorkspace('branch:main');
     const onDestroy = vi.fn(async () => {});
@@ -285,9 +285,37 @@ describe('WorkspaceRegistry', () => {
       onDetach,
     }));
 
-    await registry.releaseAllForProject('test-project', 'detach');
+    await registry.teardownAllForProject('test-project', 'detach');
 
     expect(onDetach).toHaveBeenCalledTimes(1);
     expect(onDestroy).not.toHaveBeenCalled();
+  });
+
+  it('releases leases for a project without running teardown hooks', async () => {
+    const registry = new WorkspaceRegistry();
+    const { workspace, dispose, gitDispose } = makeWorkspace('branch:main');
+    const onDestroy = vi.fn(async () => {});
+    const onDetach = vi.fn(async () => {});
+
+    await registry.acquire('branch:main', 'test-project', async () => ({
+      workspace,
+      onDestroy,
+      onDetach,
+    }));
+
+    await registry.releaseLeasesForProject('test-project');
+
+    expect(gitDispose).toHaveBeenCalledTimes(1);
+    expect(dispose).not.toHaveBeenCalled();
+    expect(onDestroy).not.toHaveBeenCalled();
+    expect(onDetach).not.toHaveBeenCalled();
+    expect(registry.refCount('branch:main')).toBe(1);
+
+    await registry.teardownAllForProject('test-project');
+
+    expect(gitDispose).toHaveBeenCalledTimes(1);
+    expect(dispose).toHaveBeenCalledTimes(1);
+    expect(onDestroy).toHaveBeenCalledTimes(1);
+    expect(onDetach).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-registry.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-registry.ts
@@ -1,3 +1,4 @@
+import { once } from '@emdash/shared';
 import type { Workspace } from './workspace';
 
 export type TeardownMode = 'detach' | 'terminate';
@@ -17,6 +18,8 @@ type WorkspaceEntry = {
   projectId: string;
   onDestroy?: (workspace: Workspace) => Promise<void>;
   onDetach?: (workspace: Workspace) => Promise<void>;
+  /** Single-flight release of the workspace's native leases. */
+  release: () => Promise<void>;
 };
 
 export class WorkspaceRegistry {
@@ -44,16 +47,21 @@ export class WorkspaceRegistry {
 
     const pending = factory()
       .then(async (result) => {
+        const workspace = result.workspace;
         this.entries.set(key, {
-          workspace: result.workspace,
+          workspace,
           refCount: 1,
           projectId,
           onDestroy: result.onDestroy,
           onDetach: result.onDetach,
+          release: once(async () => {
+            await workspace.dispose?.();
+            if (!workspace.dispose) await workspace.gitWorktree.dispose();
+          }),
         });
-        result.onCreateSideEffect?.(result.workspace);
-        await result.onCreate?.(result.workspace);
-        return result.workspace;
+        result.onCreateSideEffect?.(workspace);
+        await result.onCreate?.(workspace);
+        return workspace;
       })
       .finally(() => {
         this.acquiring.delete(key);
@@ -63,13 +71,13 @@ export class WorkspaceRegistry {
     return pending;
   }
 
-  async release(key: string, mode: TeardownMode = 'terminate'): Promise<void> {
+  async teardown(key: string, mode: TeardownMode = 'terminate'): Promise<void> {
     const entry = this.entries.get(key);
     if (!entry) {
       const inFlight = this.acquiring.get(key);
       if (inFlight) {
         await inFlight;
-        await this.release(key, mode);
+        await this.teardown(key, mode);
       }
       return;
     }
@@ -83,8 +91,7 @@ export class WorkspaceRegistry {
     if (mode === 'terminate') {
       await entry.onDestroy?.(entry.workspace);
     }
-    await entry.workspace.dispose?.();
-    if (!entry.workspace.dispose) await entry.workspace.gitWorktree.dispose();
+    await entry.release();
     await entry.workspace.lifecycleService.dispose();
     if (mode === 'detach') {
       await entry.onDetach?.(entry.workspace);
@@ -105,14 +112,14 @@ export class WorkspaceRegistry {
     return this.entries.get(key)?.refCount ?? 0;
   }
 
-  async releaseAllForProject(projectId: string, mode: TeardownMode = 'terminate'): Promise<void> {
+  async teardownAllForProject(projectId: string, mode: TeardownMode = 'terminate'): Promise<void> {
     const keys = Array.from(this.entries.entries())
       .filter(([, e]) => e.projectId === projectId)
       .map(([k]) => k);
-    await Promise.all(keys.map((k) => this.release(k, mode)));
+    await Promise.all(keys.map((k) => this.teardown(k, mode)));
   }
 
-  async releaseAll(mode: TeardownMode = 'terminate'): Promise<void> {
+  async teardownAll(mode: TeardownMode = 'terminate'): Promise<void> {
     const entries = Array.from(this.entries.values());
     this.entries.clear();
     await Promise.all(
@@ -120,14 +127,20 @@ export class WorkspaceRegistry {
         if (mode === 'terminate') {
           await entry.onDestroy?.(entry.workspace);
         }
-        await entry.workspace.dispose?.();
-        if (!entry.workspace.dispose) await entry.workspace.gitWorktree.dispose();
+        await entry.release();
         await entry.workspace.lifecycleService.dispose();
         if (mode === 'detach') {
           await entry.onDetach?.(entry.workspace);
         }
       })
     );
+  }
+
+  async releaseLeasesForProject(projectId: string): Promise<void> {
+    const entries = Array.from(this.entries.values()).filter(
+      (entry) => entry.projectId === projectId
+    );
+    await Promise.all(entries.map((entry) => entry.release()));
   }
 }
 

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -9,6 +9,7 @@ import { githubAccountsChangedChannel } from '@shared/events/githubEvents';
 import { registerRPCRouter } from '@shared/lib/ipc/rpc';
 import { setupApplicationMenu } from './app/menu';
 import { registerAppScheme, setupAppProtocol } from './app/protocol';
+import { registerQuitHandler } from './app/shutdown';
 import { createMainWindow } from './app/window';
 import { providerTokenRegistry } from './core/account/provider-token-registry';
 import { emdashAccountService } from './core/account/services/emdash-account-service';
@@ -23,15 +24,10 @@ import { editorBufferService } from './core/editor/editor-buffer-service';
 import { githubAccountReconciliationService } from './core/github/accounts/github-account-reconciliation-instance';
 import { githubAccountRegistry } from './core/github/accounts/github-account-registry-instance';
 import { GitHubAuthServerAdapter } from './core/github/accounts/github-auth-server-adapter';
-import { projectManager } from './core/projects/project-manager';
 import { projectSettingsService } from './core/projects/settings/project-settings-service';
 import { promptLibraryService } from './core/prompt-library/service';
 import { prSyncScheduler } from './core/pull-requests/pr-sync-scheduler';
-import {
-  reconcileResourceSampler,
-  stopResourceSampler,
-} from './core/resource-monitor/resource-sampler';
-import { runtimeManager } from './core/runtime/runtime-manager';
+import { reconcileResourceSampler } from './core/resource-monitor/resource-sampler';
 import { searchService } from './core/search/search-service';
 import { workspaceFileIndexService } from './core/search/workspace-file-index-service';
 import { appSettingsService } from './core/settings/settings-service';
@@ -190,35 +186,4 @@ void app.whenReady().then(async () => {
   }
 });
 
-async function runQuitCleanup(): Promise<void> {
-  telemetryService.capture('app_closed');
-
-  automationsService.stop();
-  agentHookService.dispose();
-  stopResourceSampler();
-  updateService.dispose();
-  prSyncScheduler.dispose();
-
-  void projectManager.dispose().catch((e) => {
-    log.error('Failed to shutdown project manager:', e);
-  });
-
-  const results = await Promise.allSettled([telemetryService.dispose(), runtimeManager.dispose()]);
-
-  for (const result of results) {
-    if (result.status === 'rejected') {
-      log.error('Failed during quit cleanup:', result.reason);
-    }
-  }
-}
-
-let quitCleanupStarted = false;
-
-app.on('before-quit', (event) => {
-  event.preventDefault();
-  if (quitCleanupStarted) return;
-  quitCleanupStarted = true;
-  void runQuitCleanup().finally(() => {
-    app.exit(0);
-  });
-});
+registerQuitHandler();

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -203,10 +203,7 @@ async function runQuitCleanup(): Promise<void> {
     log.error('Failed to shutdown project manager:', e);
   });
 
-  const results = await Promise.allSettled([
-    telemetryService.dispose(),
-    runtimeManager.dispose(),
-  ]);
+  const results = await Promise.allSettled([telemetryService.dispose(), runtimeManager.dispose()]);
 
   for (const result of results) {
     if (result.status === 'rejected') {

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -31,6 +31,7 @@ import {
   reconcileResourceSampler,
   stopResourceSampler,
 } from './core/resource-monitor/resource-sampler';
+import { runtimeManager } from './core/runtime/runtime-manager';
 import { searchService } from './core/search/search-service';
 import { workspaceFileIndexService } from './core/search/workspace-file-index-service';
 import { appSettingsService } from './core/settings/settings-service';
@@ -189,18 +190,40 @@ void app.whenReady().then(async () => {
   }
 });
 
+async function runQuitCleanup(): Promise<void> {
+  telemetryService.capture('app_closed');
+
+  automationsService.stop();
+  agentHookService.dispose();
+  stopResourceSampler();
+  updateService.dispose();
+  prSyncScheduler.dispose();
+
+  const results = await Promise.allSettled([
+    telemetryService.dispose(),
+    (async () => {
+      try {
+        await projectManager.dispose();
+      } finally {
+        await runtimeManager.dispose();
+      }
+    })(),
+  ]);
+
+  for (const result of results) {
+    if (result.status === 'rejected') {
+      log.error('Failed during quit cleanup:', result.reason);
+    }
+  }
+}
+
+let quitCleanupStarted = false;
+
 app.on('before-quit', (event) => {
   event.preventDefault();
-  telemetryService.capture('app_closed');
-  void telemetryService.dispose().finally(() => {
-    automationsService.stop();
-    agentHookService.dispose();
-    stopResourceSampler();
-    updateService.dispose();
-    prSyncScheduler.dispose();
-    void projectManager.dispose().catch((e) => {
-      log.error('Failed to shutdown project manager:', e);
-    });
+  if (quitCleanupStarted) return;
+  quitCleanupStarted = true;
+  void runQuitCleanup().finally(() => {
     app.exit(0);
   });
 });

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -199,15 +199,13 @@ async function runQuitCleanup(): Promise<void> {
   updateService.dispose();
   prSyncScheduler.dispose();
 
+  void projectManager.dispose().catch((e) => {
+    log.error('Failed to shutdown project manager:', e);
+  });
+
   const results = await Promise.allSettled([
     telemetryService.dispose(),
-    (async () => {
-      try {
-        await projectManager.dispose();
-      } finally {
-        await runtimeManager.dispose();
-      }
-    })(),
+    runtimeManager.dispose(),
   ]);
 
   for (const result of results) {

--- a/packages/core/src/file-tree/file-tree-runtime.ts
+++ b/packages/core/src/file-tree/file-tree-runtime.ts
@@ -43,19 +43,19 @@ export class FileTreeRuntime implements IFileTreeRuntime {
     try {
       const ready = await lease.value.ready();
       if (!ready.success) {
-        lease.release();
+        await lease.release();
         return err(ready.error);
       }
       return ok(lease);
     } catch (error) {
-      lease.release();
+      await lease.release();
       throw error;
     }
   }
 
   async dispose(): Promise<void> {
     this.disposeRequested = true;
-    this.trees.dispose();
+    await this.trees.dispose();
     await this.disposeIfIdle();
   }
 

--- a/packages/core/src/file-tree/file-tree.test.ts
+++ b/packages/core/src/file-tree/file-tree.test.ts
@@ -27,7 +27,7 @@ class ManualWatchService implements IFileWatchService {
     this.readyCalls += 1;
     return {
       ready: async () => {},
-      release: () => {
+      release: async () => {
         this.releaseCalls += 1;
         this.consumers = this.consumers.filter((consumer) => consumer !== onEvents);
       },
@@ -75,7 +75,7 @@ describe('FileTree', () => {
     const expanded = await nodes(tree);
     expect(paths(expanded)).toEqual(['src', 'README.md', 'src/nested']);
     expect(nodeByPath(expanded, 'src').childrenLoaded).toBe(true);
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('hard-excludes noisy directories in core', async () => {
@@ -90,7 +90,7 @@ describe('FileTree', () => {
     unwrap(await tree.ready());
 
     expect(paths(await nodes(tree))).toEqual(['src']);
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('reveals a nested path by loading each parent scope', async () => {
@@ -107,7 +107,7 @@ describe('FileTree', () => {
     });
 
     expect(paths(await nodes(tree))).toEqual(['src', 'src/a', 'src/a/file.ts']);
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('returns not-found when revealPath cannot find a loaded path component', async () => {
@@ -121,7 +121,7 @@ describe('FileTree', () => {
       success: false,
       error: { type: 'not-found', path: 'src/missing' },
     });
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('does not cache a rejected ready promise after unexpected load failures', async () => {
@@ -144,7 +144,7 @@ describe('FileTree', () => {
       expect(calls).toBe(2);
     } finally {
       patched.loadDirectoryScope = originalLoadDirectoryScope;
-      tree.dispose();
+      await tree.dispose();
     }
   });
 
@@ -172,7 +172,7 @@ describe('FileTree', () => {
     const after = await nodes(tree);
     expect(nodeByPath(after, 'b.txt').id).toBe(before.id);
     expect(after.some((node) => node.path === 'a.txt')).toBe(false);
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('reuses directory and descendant ids when a loaded directory is renamed', async () => {
@@ -200,7 +200,7 @@ describe('FileTree', () => {
     expect(nodeByPath(after, 'lib').id).toBe(src.id);
     expect(nodeByPath(after, 'lib/nested').id).toBe(nested.id);
     expect(nodeByPath(after, 'lib/nested/a.ts').id).toBe(file.id);
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('cascades loaded descendants when a directory disappears', async () => {
@@ -218,7 +218,7 @@ describe('FileTree', () => {
     await waitForPaths(tree, []);
 
     expect(paths(await nodes(tree))).toEqual([]);
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('cascades loaded descendants during refresh when a directory disappeared', async () => {
@@ -234,7 +234,7 @@ describe('FileTree', () => {
     unwrap(await tree.refresh());
 
     expect(paths(await nodes(tree))).toEqual([]);
-    tree.dispose();
+    await tree.dispose();
   });
 
   it('runtime leases share one tree per resolved root', async () => {
@@ -250,8 +250,8 @@ describe('FileTree', () => {
     expect(firstLease.value).toBe(secondLease.value);
     expect(watcher.watchCount).toBe(1);
 
-    firstLease.release();
-    secondLease.release();
+    await firstLease.release();
+    await secondLease.release();
     await runtime.dispose();
   });
 

--- a/packages/core/src/file-tree/file-tree.ts
+++ b/packages/core/src/file-tree/file-tree.ts
@@ -177,11 +177,11 @@ export class FileTree implements IFileTree {
     return ok(sequences);
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
     if (this.revalidateTimer) clearInterval(this.revalidateTimer);
-    this.watch.release();
+    await this.watch.release();
     this.collection.dispose();
   }
 

--- a/packages/core/src/file-tree/types.ts
+++ b/packages/core/src/file-tree/types.ts
@@ -24,7 +24,7 @@ export interface IFileTree {
   expandDir(dirId: NodeId | null): Promise<Result<FileTreeSequences, FileTreeError>>;
   revealPath(path: string): Promise<Result<FileTreeSequences, FileTreeError>>;
   refresh(): Promise<Result<FileTreeSnapshot, FileTreeError>>;
-  dispose(): void;
+  dispose(): Promise<void>;
 }
 
 export type FileTreeLease = Lease<IFileTree>;

--- a/packages/core/src/fs/file-watch-service.test.ts
+++ b/packages/core/src/fs/file-watch-service.test.ts
@@ -46,7 +46,7 @@ describe('FileWatchService', () => {
       expect(firstEvents[0]).not.toHaveProperty('type');
       expect(firstEvents[0]).not.toHaveProperty('entryType');
 
-      first.release();
+      await first.release();
       const secondOnlyFile = path.join(root, 'second-only.txt');
       await writeFile(secondOnlyFile, 'still watching\n', 'utf8');
       await eventually(() =>
@@ -58,7 +58,7 @@ describe('FileWatchService', () => {
         false
       );
 
-      second.release();
+      await second.release();
     } finally {
       await watch.dispose();
     }
@@ -74,7 +74,7 @@ describe('FileWatchService', () => {
       await first.ready();
       // Release the only consumer and immediately re-watch: the new consumer must wait for
       // the in-flight native teardown and then provision a fresh subscription.
-      first.release();
+      await first.release();
       const second = watch.watch(root, (incoming) => events.push(...incoming));
       await second.ready();
 
@@ -82,7 +82,7 @@ describe('FileWatchService', () => {
       await eventually(() =>
         events.some((event) => path.basename(event.path) === 'after-rewatch.txt') ? true : undefined
       );
-      second.release();
+      await second.release();
     } finally {
       await watch.dispose();
     }
@@ -96,15 +96,25 @@ describe('FileWatchService', () => {
       const handle = watch.watch(root, () => {});
 
       await expect(handle.ready()).rejects.toThrow();
-      handle.release();
+      await handle.release();
 
       // A failed subscription is evicted: creating the root and re-watching recovers.
       await mkdir(root, { recursive: true });
       const recovered = watch.watch(root, () => {});
       await expect(recovered.ready()).resolves.toBeUndefined();
-      recovered.release();
+      await recovered.release();
     } finally {
       await watch.dispose();
     }
+  });
+
+  it('disposes active handles by releasing their shared native subscription', async () => {
+    const root = await mkdtemp(path.join(tmpdir(), 'emdash-shared-watch-dispose-'));
+    const watch = new FileWatchService();
+    const handle = watch.watch(root, () => {});
+
+    await handle.ready();
+    await expect(watch.dispose()).resolves.toBeUndefined();
+    await expect(handle.release()).resolves.toBeUndefined();
   });
 });

--- a/packages/core/src/fs/file-watch-service.ts
+++ b/packages/core/src/fs/file-watch-service.ts
@@ -1,4 +1,4 @@
-import type { IDisposable } from '@emdash/shared';
+import { toPendingLease, type IDisposable } from '@emdash/shared';
 import { ResourceMap } from '../lib';
 import { NativeWatch } from './native-watch';
 import { realpathOrResolve } from './paths';
@@ -12,6 +12,7 @@ export type FileWatchServiceOptions = {
 type WatchConsumer = {
   onEvents: (events: RawFileEvent[]) => void;
   onResync?: () => void;
+  releaseResource: () => Promise<void>;
   debounceMs: number;
   pending: RawFileEvent[];
   timer: ReturnType<typeof setTimeout> | null;
@@ -53,49 +54,45 @@ export class FileWatchService implements IFileWatchService, IDisposable {
     const ignore = normalizeIgnore(options.ignore);
     const key = watchKey(normalizedRoot, ignore);
 
+    const lease = toPendingLease(
+      this.subscriptions.acquire(key, async () => {
+        const native = new NativeWatch(
+          normalizedRoot,
+          ignore,
+          (events) => this.deliver(key, events),
+          () => this.resyncConsumers(key),
+          this.onError
+        );
+        try {
+          await native.ready();
+        } catch (error) {
+          await native.dispose();
+          throw error;
+        }
+        this.natives.set(key, native);
+        return native;
+      })
+    );
+
     const consumer: WatchConsumer = {
       onEvents,
       onResync: options.onResync,
+      releaseResource: () => lease.release(),
       debounceMs: options.debounceMs ?? 0,
       pending: [],
       timer: null,
     };
-    let consumerSet = this.consumers.get(key);
-    if (!consumerSet) {
-      consumerSet = new Set();
-      this.consumers.set(key, consumerSet);
-    }
+    const consumerSet = this.consumers.get(key) ?? new Set<WatchConsumer>();
+    this.consumers.set(key, consumerSet);
     consumerSet.add(consumer);
 
-    const lease = this.subscriptions.acquire(key, async () => {
-      const native = new NativeWatch(
-        normalizedRoot,
-        ignore,
-        (events) => this.deliver(key, events),
-        () => this.resyncConsumers(key),
-        this.onError
-      );
-      try {
-        await native.ready();
-      } catch (error) {
-        await native.dispose();
-        throw error;
-      }
-      this.natives.set(key, native);
-      return native;
-    });
-    lease.catch(() => {});
-
-    let closed = false;
     return {
       ready: async () => {
-        await lease;
+        await lease.ready();
       },
       release: () => {
-        if (closed) return;
-        closed = true;
         this.removeConsumer(key, consumer);
-        void lease.then((acquired) => acquired.release()).catch(() => {});
+        return lease.release();
       },
     };
   }
@@ -103,14 +100,18 @@ export class FileWatchService implements IFileWatchService, IDisposable {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
-    this.subscriptions.dispose();
+    const idle = this.subscriptions.dispose();
+    const releases: Array<Promise<void>> = [];
     for (const consumerSet of this.consumers.values()) {
-      for (const consumer of consumerSet) clearConsumer(consumer);
+      for (const consumer of consumerSet) {
+        clearConsumer(consumer);
+        releases.push(consumer.releaseResource());
+      }
     }
     this.consumers.clear();
-    const natives = [...this.natives.values()];
+    await Promise.allSettled(releases);
+    await idle;
     this.natives.clear();
-    await Promise.all(natives.map((native) => native.dispose()));
   }
 
   private deliver(key: string, events: RawFileEvent[]): void {

--- a/packages/core/src/fs/types.ts
+++ b/packages/core/src/fs/types.ts
@@ -22,7 +22,7 @@ export type FileWatchOptions = {
 
 export type WatchHandle = {
   ready(): Promise<void>;
-  release(): void;
+  release(): Promise<void>;
 };
 
 export type IFileWatchService = {

--- a/packages/core/src/git/git-repository.test.ts
+++ b/packages/core/src/git/git-repository.test.ts
@@ -129,7 +129,7 @@ describe('GitRepository', () => {
       expect(updates.some((update) => update.kind === 'refs')).toBe(true);
       subscribed.unsubscribe();
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -165,7 +165,7 @@ describe('GitRepository', () => {
           expect.objectContaining({ type: 'local', branch: 'external-change' }),
         ])
       );
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -192,7 +192,7 @@ describe('GitRepository', () => {
       expect(after.refs.sequence).toBeGreaterThan(before.refs.sequence);
       expect(afterOid).toMatch(/^[0-9a-f]{40}$/);
       expect(afterOid).not.toBe(beforeOid);
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -219,7 +219,7 @@ describe('GitRepository', () => {
       expect((await repository.getRefs()).branches).toEqual(
         expect.arrayContaining([expect.objectContaining({ type: 'local', branch: 'from-remote' })])
       );
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -251,7 +251,7 @@ describe('GitRepository', () => {
           }),
         ])
       );
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -278,7 +278,7 @@ describe('GitRepository', () => {
       expect((await lease.value.getRefs()).branches).toEqual(
         expect.arrayContaining([expect.objectContaining({ type: 'local', branch: 'pr-7' })])
       );
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }

--- a/packages/core/src/git/git-repository.ts
+++ b/packages/core/src/git/git-repository.ts
@@ -359,8 +359,8 @@ export class GitRepository implements IGitRepository {
     }
   }
 
-  dispose(): void {
-    this.commonDirWatch.release();
+  async dispose(): Promise<void> {
+    await this.commonDirWatch.release();
     this.refsModel.dispose();
     this.remotesModel.dispose();
     this.worktrees.clear();

--- a/packages/core/src/git/git-runtime.test.ts
+++ b/packages/core/src/git/git-runtime.test.ts
@@ -36,11 +36,21 @@ async function makeRecordingGitExecutable(): Promise<{ executable: string; logPa
   return { executable, logPath };
 }
 
+function deferred<T>() {
+  let resolve!: (value: T | PromiseLike<T>) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
 function createNoopWatcher(): IFileWatchService {
   return {
     watch: () => ({
       ready: async () => {},
-      release: () => {},
+      release: async () => {},
     }),
     dispose: async () => {},
   };
@@ -213,12 +223,47 @@ describe('GitRuntime', () => {
       expect(repoLease.value.gitCommonDir).toBe(commonDir);
       expect(worktreeLease.value.repository).toBe(repoLease.value);
 
-      worktreeLease.release();
-      repoLease.release();
+      await worktreeLease.release();
+      await repoLease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
     }
+  });
+
+  it('waits for repository watcher release during dispose', async () => {
+    const repo = await makeRepo();
+    const releaseGate = deferred<void>();
+    let releaseStarted = 0;
+    const watcher: IFileWatchService = {
+      watch: () => ({
+        ready: async () => {},
+        release: async () => {
+          releaseStarted += 1;
+          await releaseGate.promise;
+        },
+      }),
+      dispose: async () => {},
+    };
+    const runtime = new GitRuntime({ watcher });
+
+    const lease = await runtime.openRepository(repo);
+    const release = lease.release();
+
+    const dispose = runtime.dispose();
+    let disposed = false;
+    void dispose.then(() => {
+      disposed = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(releaseStarted).toBe(1);
+    expect(disposed).toBe(false);
+
+    releaseGate.resolve();
+    await release;
+    await dispose;
+    expect(disposed).toBe(true);
   });
 
   it('resolves git identity once when opening a cold worktree', async () => {
@@ -228,7 +273,7 @@ describe('GitRuntime', () => {
 
     try {
       const lease = await runtime.openWorktree(repo);
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }

--- a/packages/core/src/git/git-runtime.ts
+++ b/packages/core/src/git/git-runtime.ts
@@ -67,8 +67,8 @@ export class GitRuntime implements IGitRuntime {
       });
 
     this.repositories = new ResourceMap<GitRepository>({
-      teardown: (_key, repository) => {
-        repository.dispose();
+      teardown: async (_key, repository) => {
+        await repository.dispose();
       },
       onError: this.onError,
       onEmpty: () => {
@@ -76,9 +76,9 @@ export class GitRuntime implements IGitRuntime {
       },
     });
     this.worktrees = new ResourceMap<WorktreeResource>({
-      teardown: (_key, resource) => {
-        resource.worktree.dispose();
-        resource.repositoryLease.release();
+      teardown: async (_key, resource) => {
+        await resource.worktree.dispose();
+        await resource.repositoryLease.release();
       },
       onError: this.onError,
       onEmpty: () => {
@@ -177,12 +177,12 @@ export class GitRuntime implements IGitRuntime {
         try {
           await worktree.ready();
         } catch (error) {
-          worktree.dispose();
+          await worktree.dispose();
           throw error;
         }
         return { worktree, repositoryLease };
       } catch (error) {
-        repositoryLease.release();
+        await repositoryLease.release();
         throw error;
       }
     });
@@ -191,8 +191,10 @@ export class GitRuntime implements IGitRuntime {
 
   async dispose(): Promise<void> {
     this.disposeRequested = true;
-    this.repositories.dispose();
-    this.worktrees.dispose();
+    const repositoriesDisposed = this.repositories.dispose();
+    const worktreesDisposed = this.worktrees.dispose();
+    await worktreesDisposed;
+    await repositoriesDisposed;
     await this.disposeIfIdle();
   }
 
@@ -209,7 +211,7 @@ export class GitRuntime implements IGitRuntime {
       try {
         await repository.ready();
       } catch (error) {
-        repository.dispose();
+        await repository.dispose();
         throw error;
       }
       return repository;

--- a/packages/core/src/git/git-worktree.test.ts
+++ b/packages/core/src/git/git-worktree.test.ts
@@ -187,7 +187,7 @@ describe('GitWorktree', () => {
 
       expect(updates.some((update) => update.kind === 'head')).toBe(true);
       expect(repoUpdates.some((update) => update.kind === 'refs')).toBe(true);
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -240,7 +240,7 @@ describe('GitWorktree', () => {
         unstaged: [],
       });
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -305,7 +305,7 @@ describe('GitWorktree', () => {
         unstaged: [],
       });
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -353,7 +353,7 @@ describe('GitWorktree', () => {
           }),
         ])
       );
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -365,11 +365,12 @@ describe('GitWorktree', () => {
     const runtime = new GitRuntime();
     const lease = await runtime.openWorktree(repo);
 
-    await runtime.dispose();
+    const dispose = runtime.dispose();
 
     await expect(lease.value.getStatus()).resolves.toMatchObject({ kind: 'ok' });
     await expect(runtime.openWorktree(repo)).rejects.toThrow('GitRuntime disposed');
-    lease.release();
+    await lease.release();
+    await dispose;
   });
 
   it('reads image bytes from git refs as serializable data URLs', async () => {
@@ -394,7 +395,7 @@ describe('GitWorktree', () => {
           dataUrl: expect.stringContaining('data:image/png;base64,'),
         },
       });
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -420,7 +421,7 @@ describe('GitWorktree', () => {
       await expect(lease.value.getImageAtRef('pixel.png', 'HEAD')).resolves.toMatchObject({
         kind: 'image',
       });
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -442,7 +443,7 @@ describe('GitWorktree', () => {
         kind: 'error',
         message: expect.stringContaining('not a git repository'),
       });
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -475,7 +476,7 @@ describe('GitWorktree', () => {
       const calls = (await readFile(logPath, 'utf8')).trim().split('\n').filter(Boolean);
       expect(calls).not.toContain('tag');
       expect(calls).not.toContain('branch');
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -537,7 +538,7 @@ describe('GitWorktree', () => {
       expect(await readFile(path.join(repo, 'to-delete.txt'), 'utf8')).toBe('gone\n');
       await expect(readFile(path.join(repo, 'untracked.txt'), 'utf8')).rejects.toThrow();
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
       await watcher.dispose();
@@ -564,7 +565,7 @@ describe('GitWorktree', () => {
         ]),
       });
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -592,7 +593,7 @@ describe('GitWorktree', () => {
       await expect(readFile(path.join(repo, 'tracked.txt'), 'utf8')).resolves.toBe('before\n');
       await expect(readFile(path.join(repo, 'untracked.txt'), 'utf8')).rejects.toThrow();
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -620,7 +621,7 @@ describe('GitWorktree', () => {
         unstaged: [],
       });
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -646,7 +647,7 @@ describe('GitWorktree', () => {
         unstaged: [],
       });
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -690,7 +691,7 @@ describe('GitWorktree', () => {
       expect(secondChange?.indexOid).not.toBe(firstChange?.indexOid);
       await expect(worktree.getFileAtIndex('tracked.txt')).resolves.toBe('too\n');
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }
@@ -716,7 +717,7 @@ describe('GitWorktree', () => {
       await expect(readFile(path.join(repo, 'untracked.txt'), 'utf8')).rejects.toThrow();
       await expect(readFile(path.join(repo, 'extra.txt'), 'utf8')).rejects.toThrow();
 
-      lease.release();
+      await lease.release();
     } finally {
       await runtime.dispose();
     }

--- a/packages/core/src/git/git-worktree.ts
+++ b/packages/core/src/git/git-worktree.ts
@@ -452,9 +452,9 @@ export class GitWorktree implements IGitWorktree {
     }
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     this.unregisterFromRepository();
-    this.worktreeWatch.release();
+    await this.worktreeWatch.release();
     this.statusModel.dispose();
     this.headModel.dispose();
   }

--- a/packages/core/src/lib/resource-map.test.ts
+++ b/packages/core/src/lib/resource-map.test.ts
@@ -35,11 +35,45 @@ describe('ResourceMap', () => {
     expect(leaseB.value).toBe('value');
 
     await leaseA.release();
-    await leaseA.release(); // idempotent
+    await leaseA.release(); // idempotent - second call does not double-decrement
     expect(torndown).toEqual([]);
     await leaseB.release();
     await new Promise((resolve) => setImmediate(resolve));
     expect(torndown).toEqual(['k']);
+    expect(map.idle).toBe(true);
+  });
+
+  it('concurrent release() calls on the same lease are single-flight', async () => {
+    const teardownGate = deferred<void>();
+    let teardownCount = 0;
+    const map = new ResourceMap<string>({
+      teardown: async () => {
+        teardownCount += 1;
+        await teardownGate.promise;
+      },
+    });
+
+    const lease = await map.acquire('k', async () => 'value');
+
+    // Fire two concurrent release() calls before the teardown completes.
+    const r1 = lease.release();
+    const r2 = lease.release();
+
+    // Neither resolves until teardown completes.
+    let r1Settled = false;
+    let r2Settled = false;
+    r1.then(() => (r1Settled = true));
+    r2.then(() => (r2Settled = true));
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(r1Settled).toBe(false);
+    expect(r2Settled).toBe(false);
+
+    teardownGate.resolve();
+    await Promise.all([r1, r2]);
+
+    // Teardown ran exactly once even though release() was called twice.
+    expect(teardownCount).toBe(1);
     expect(map.idle).toBe(true);
   });
 
@@ -142,6 +176,38 @@ describe('ResourceMap', () => {
 
     expect(errors).toHaveLength(1);
     expect(errors[0]!.context).toBe('teardown k');
+  });
+
+  it('dispose() does not free held leases — release is a precondition for dispose resolving', async () => {
+    // This test encodes the critical shutdown ordering invariant:
+    // runtimeManager.dispose() (a ResourceMap.dispose()) only resolves after
+    // all holders have explicitly called lease.release(). Callers must always
+    // IReleasable.release() before relying on dispose() completing.
+    let teardownCalled = false;
+    const map = new ResourceMap<string>({
+      teardown: () => {
+        teardownCalled = true;
+      },
+    });
+
+    const lease = await map.acquire('k', async () => 'value');
+
+    let disposeResolved = false;
+    const disposing = map.dispose().then(() => {
+      disposeResolved = true;
+    });
+
+    // Yield to confirm dispose has not resolved with a live lease outstanding.
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(disposeResolved).toBe(false);
+    expect(teardownCalled).toBe(false);
+
+    // Releasing the lease lets dispose() resolve.
+    await lease.release();
+    await disposing;
+
+    expect(teardownCalled).toBe(true);
+    expect(disposeResolved).toBe(true);
   });
 
   it('rejects new acquires after dispose while existing leases stay usable', async () => {

--- a/packages/core/src/lib/resource-map.test.ts
+++ b/packages/core/src/lib/resource-map.test.ts
@@ -34,10 +34,10 @@ describe('ResourceMap', () => {
     expect(leaseA.value).toBe('value');
     expect(leaseB.value).toBe('value');
 
-    leaseA.release();
-    leaseA.release(); // idempotent
+    await leaseA.release();
+    await leaseA.release(); // idempotent
     expect(torndown).toEqual([]);
-    leaseB.release();
+    await leaseB.release();
     await new Promise((resolve) => setImmediate(resolve));
     expect(torndown).toEqual(['k']);
     expect(map.idle).toBe(true);
@@ -53,7 +53,7 @@ describe('ResourceMap', () => {
     // A fresh acquire provisions again rather than reusing the poisoned entry.
     const lease = await map.acquire('k', async () => 'recovered');
     expect(lease.value).toBe('recovered');
-    lease.release();
+    await lease.release();
   });
 
   it('waits for an in-flight teardown before re-provisioning the same key', async () => {
@@ -68,7 +68,7 @@ describe('ResourceMap', () => {
     });
 
     const first = await map.acquire('k', async () => 'one');
-    first.release();
+    const firstRelease = first.release();
 
     const second = map.acquire('k', async () => {
       order.push('provision:two');
@@ -78,10 +78,36 @@ describe('ResourceMap', () => {
     expect(order).toEqual(['teardown:start']);
 
     teardownGate.resolve();
+    await firstRelease;
     const lease = await second;
     expect(order).toEqual(['teardown:start', 'teardown:end', 'provision:two']);
     expect(lease.value).toBe('two');
-    lease.release();
+    await lease.release();
+  });
+
+  it('waits for all in-flight teardowns during dispose', async () => {
+    const teardownGate = deferred<void>();
+    const map = new ResourceMap<string>({
+      teardown: async () => {
+        await teardownGate.promise;
+      },
+    });
+
+    const lease = await map.acquire('k', async () => 'value');
+    const release = lease.release();
+
+    let disposed = false;
+    const dispose = map.dispose().then(() => {
+      disposed = true;
+    });
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(disposed).toBe(false);
+
+    teardownGate.resolve();
+    await release;
+    await dispose;
+    expect(disposed).toBe(true);
   });
 
   it('tears down when the last lease releases while provisioning succeeded late', async () => {
@@ -96,7 +122,7 @@ describe('ResourceMap', () => {
     const pending = map.acquire('k', () => gate.promise);
     gate.resolve('late');
     const lease = await pending;
-    lease.release();
+    await lease.release();
     await new Promise((resolve) => setImmediate(resolve));
     expect(torndown).toEqual(['late']);
   });
@@ -111,7 +137,7 @@ describe('ResourceMap', () => {
     });
 
     const lease = await map.acquire('k', async () => 'value');
-    lease.release();
+    await lease.release();
     await new Promise((resolve) => setImmediate(resolve));
 
     expect(errors).toHaveLength(1);
@@ -128,13 +154,13 @@ describe('ResourceMap', () => {
     });
 
     const lease = await map.acquire('k', async () => 'value');
-    map.dispose();
+    const disposed = map.dispose();
 
     expect(lease.value).toBe('value');
     await expect(map.acquire('other', async () => 'x')).rejects.toThrow('ResourceMap disposed');
 
-    lease.release();
-    await new Promise((resolve) => setImmediate(resolve));
+    await lease.release();
+    await disposed;
     expect(emptied).toBe(1);
     expect(map.idle).toBe(true);
   });

--- a/packages/core/src/lib/resource-map.ts
+++ b/packages/core/src/lib/resource-map.ts
@@ -1,3 +1,4 @@
+import { once } from '@emdash/shared';
 import type { IDisposable, Lease } from '@emdash/shared';
 
 export type ResourceMapOptions<T> = {
@@ -19,7 +20,8 @@ type Entry<T> = {
  *
  * - Concurrent `acquire`s of the same key share one provision; each gets its own lease.
  * - A failed provision rejects every waiting acquirer and evicts the entry.
- * - The last `release()` tears the value down; releases are idempotent and concurrency-safe.
+ * - The last `release()` tears the value down; releases are single-flight: every caller
+ *   awaits the same teardown completion.
  * - Acquiring a key that is tearing down waits for the teardown, then provisions fresh.
  * - `dispose()` refuses new acquires and resolves once no entries or teardowns remain.
  */
@@ -71,15 +73,7 @@ export class ResourceMap<T> implements IDisposable {
   }
 
   private createLease(key: string, entry: Entry<T>, value: T): Lease<T> {
-    let released = false;
-    return {
-      value,
-      release: async () => {
-        if (released) return;
-        released = true;
-        await this.releaseRef(key, entry);
-      },
-    };
+    return { value, release: once(() => this.releaseRef(key, entry)) };
   }
 
   private releaseRef(key: string, entry: Entry<T>): Promise<void> {

--- a/packages/core/src/lib/resource-map.ts
+++ b/packages/core/src/lib/resource-map.ts
@@ -21,11 +21,12 @@ type Entry<T> = {
  * - A failed provision rejects every waiting acquirer and evicts the entry.
  * - The last `release()` tears the value down; releases are idempotent and concurrency-safe.
  * - Acquiring a key that is tearing down waits for the teardown, then provisions fresh.
- * - `dispose()` refuses new acquires; teardown still happens when the last lease releases.
+ * - `dispose()` refuses new acquires and resolves once no entries or teardowns remain.
  */
 export class ResourceMap<T> implements IDisposable {
   private readonly entries = new Map<string, Entry<T>>();
   private readonly teardowns = new Map<string, Promise<void>>();
+  private idleWaiters: Array<() => void> = [];
   private disposeRequested = false;
 
   constructor(private readonly options: ResourceMapOptions<T>) {}
@@ -57,33 +58,34 @@ export class ResourceMap<T> implements IDisposable {
     try {
       value = await entry.promise;
     } catch (error) {
-      this.releaseRef(key, entry);
+      await this.releaseRef(key, entry);
       throw error;
     }
     return this.createLease(key, entry, value);
   }
 
-  dispose(): void {
+  async dispose(): Promise<void> {
     this.disposeRequested = true;
-    if (this.idle) this.options.onEmpty?.();
+    this.notifyIdle();
+    await this.waitForIdle();
   }
 
   private createLease(key: string, entry: Entry<T>, value: T): Lease<T> {
     let released = false;
     return {
       value,
-      release: () => {
+      release: async () => {
         if (released) return;
         released = true;
-        this.releaseRef(key, entry);
+        await this.releaseRef(key, entry);
       },
     };
   }
 
-  private releaseRef(key: string, entry: Entry<T>): void {
+  private releaseRef(key: string, entry: Entry<T>): Promise<void> {
     entry.refs -= 1;
-    if (entry.refs > 0) return;
-    if (this.entries.get(key) !== entry) return;
+    if (entry.refs > 0) return Promise.resolve();
+    if (this.entries.get(key) !== entry) return Promise.resolve();
     this.entries.delete(key);
 
     const teardown = (async () => {
@@ -100,9 +102,25 @@ export class ResourceMap<T> implements IDisposable {
       }
     })().finally(() => {
       this.teardowns.delete(key);
-      if (this.idle) this.options.onEmpty?.();
+      this.notifyIdle();
     });
     this.teardowns.set(key, teardown);
+    return teardown;
+  }
+
+  private async waitForIdle(): Promise<void> {
+    if (this.idle) return;
+    await new Promise<void>((resolve) => {
+      this.idleWaiters.push(resolve);
+    });
+  }
+
+  private notifyIdle(): void {
+    if (!this.idle) return;
+    this.options.onEmpty?.();
+    const waiters = this.idleWaiters;
+    this.idleWaiters = [];
+    for (const resolve of waiters) resolve();
   }
 
   private assertOpen(): void {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,12 +10,13 @@ export {
 } from './result';
 export { Emitter } from './emitter';
 export { isDeepEqual } from './deep-equal';
-export { toPendingLease, withLease } from './lifecycle';
+export { once, toPendingLease, withLease } from './lifecycle';
 export type {
   PendingLease,
   IDisposable,
   IInitializable,
   ILifecycle,
+  IReleasable,
   Lease,
   Unsubscribe,
 } from './lifecycle';

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,4 +10,12 @@ export {
 } from './result';
 export { Emitter } from './emitter';
 export { isDeepEqual } from './deep-equal';
-export type { IDisposable, IInitializable, ILifecycle, Lease, Unsubscribe } from './lifecycle';
+export { toPendingLease, withLease } from './lifecycle';
+export type {
+  PendingLease,
+  IDisposable,
+  IInitializable,
+  ILifecycle,
+  Lease,
+  Unsubscribe,
+} from './lifecycle';

--- a/packages/shared/src/lifecycle.test.ts
+++ b/packages/shared/src/lifecycle.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { toPendingLease, withLease, type Lease } from './lifecycle';
+import { once, toPendingLease, withLease, type Lease } from './lifecycle';
 
 function leaseFor<T>(value: T, onRelease: () => void | Promise<void>): Lease<T> {
   return {
@@ -9,6 +9,77 @@ function leaseFor<T>(value: T, onRelease: () => void | Promise<void>): Lease<T> 
     },
   };
 }
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+describe('once', () => {
+  it('runs the producer exactly once across sequential calls', async () => {
+    let calls = 0;
+    const fn = once(async () => {
+      calls += 1;
+      return calls;
+    });
+
+    const r1 = await fn();
+    const r2 = await fn();
+    const r3 = await fn();
+
+    expect(calls).toBe(1);
+    expect(r1).toBe(1);
+    expect(r2).toBe(1);
+    expect(r3).toBe(1);
+  });
+
+  it('all concurrent callers await the same completion', async () => {
+    const gate = deferred<number>();
+    let calls = 0;
+    const fn = once(async () => {
+      calls += 1;
+      return gate.promise;
+    });
+
+    const p1 = fn();
+    const p2 = fn();
+    const p3 = fn();
+
+    let p1Settled = false;
+    let p2Settled = false;
+    p1.then(() => (p1Settled = true));
+    p2.then(() => (p2Settled = true));
+
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(calls).toBe(1);
+    expect(p1Settled).toBe(false);
+    expect(p2Settled).toBe(false);
+
+    gate.resolve(42);
+    const [r1, r2, r3] = await Promise.all([p1, p2, p3]);
+    expect(r1).toBe(42);
+    expect(r2).toBe(42);
+    expect(r3).toBe(42);
+    expect(calls).toBe(1);
+  });
+
+  it('memoizes rejection — failed run is not retried', async () => {
+    let calls = 0;
+    const fn = once(async () => {
+      calls += 1;
+      throw new Error('fail');
+    });
+
+    await expect(fn()).rejects.toThrow('fail');
+    await expect(fn()).rejects.toThrow('fail');
+    expect(calls).toBe(1);
+  });
+});
 
 describe('withLease', () => {
   it('releases the lease after a successful operation', async () => {
@@ -71,5 +142,48 @@ describe('toPendingLease', () => {
 
     await expect(lease.ready()).resolves.toBe('value');
     await expect(lease.release()).resolves.toBeUndefined();
+  });
+
+  it('release is idempotent — underlying release called exactly once on repeated calls', async () => {
+    let releaseCount = 0;
+    const lease = toPendingLease(
+      Promise.resolve(
+        leaseFor('value', () => {
+          releaseCount += 1;
+        })
+      )
+    );
+
+    await lease.release();
+    await lease.release();
+    await lease.release();
+
+    expect(releaseCount).toBe(1);
+  });
+
+  it('release is safe to call before the backing lease resolves and is still idempotent', async () => {
+    let releaseCount = 0;
+    let resolve!: (lease: Lease<string>) => void;
+    const leasePromise = new Promise<Lease<string>>((res) => {
+      resolve = res;
+    });
+
+    const pending = toPendingLease(leasePromise);
+
+    // Start two releases before the lease is ready.
+    const r1 = pending.release();
+    const r2 = pending.release();
+
+    resolve(
+      leaseFor('value', () => {
+        releaseCount += 1;
+      })
+    );
+
+    await r1;
+    await r2;
+    await pending.release(); // one more after resolution
+
+    expect(releaseCount).toBe(1);
   });
 });

--- a/packages/shared/src/lifecycle.test.ts
+++ b/packages/shared/src/lifecycle.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest';
+import { toPendingLease, withLease, type Lease } from './lifecycle';
+
+function leaseFor<T>(value: T, onRelease: () => void | Promise<void>): Lease<T> {
+  return {
+    value,
+    release: async () => {
+      await onRelease();
+    },
+  };
+}
+
+describe('withLease', () => {
+  it('releases the lease after a successful operation', async () => {
+    let released = false;
+
+    const result = await withLease(
+      leaseFor('value', () => {
+        released = true;
+      }),
+      (value) => value.toUpperCase()
+    );
+
+    expect(result).toBe('VALUE');
+    expect(released).toBe(true);
+  });
+
+  it('releases the lease when the operation throws', async () => {
+    let released = false;
+
+    await expect(
+      withLease(
+        Promise.resolve(
+          leaseFor('value', () => {
+            released = true;
+          })
+        ),
+        () => {
+          throw new Error('failed');
+        }
+      )
+    ).rejects.toThrow('failed');
+
+    expect(released).toBe(true);
+  });
+});
+
+describe('toPendingLease', () => {
+  it('supports releasing before the lease promise resolves', async () => {
+    let resolve!: (lease: Lease<string>) => void;
+    let released = false;
+    const leasePromise = new Promise<Lease<string>>((res) => {
+      resolve = res;
+    });
+
+    const lease = toPendingLease(leasePromise);
+    const release = lease.release();
+
+    resolve(
+      leaseFor('value', () => {
+        released = true;
+      })
+    );
+
+    await release;
+    expect(released).toBe(true);
+  });
+
+  it('exposes readiness separately from release', async () => {
+    const lease = toPendingLease(Promise.resolve(leaseFor('value', () => {})));
+
+    await expect(lease.ready()).resolves.toBe('value');
+    await expect(lease.release()).resolves.toBeUndefined();
+  });
+});

--- a/packages/shared/src/lifecycle.ts
+++ b/packages/shared/src/lifecycle.ts
@@ -10,6 +10,10 @@ export interface IDisposable {
 
 export interface ILifecycle extends IInitializable, IDisposable {}
 
+export interface IReleasable {
+  release(): Promise<void>;
+}
+
 export interface Lease<T> {
   readonly value: T;
   release(): Promise<void>;
@@ -20,32 +24,21 @@ export interface PendingLease<T> {
   release(): Promise<void>;
 }
 
-class PendingLeaseAdapter<T> implements PendingLease<T> {
-  private releasePromise: Promise<void> | null = null;
-
-  constructor(private readonly lease: Promise<Lease<T>>) {
-    this.lease.catch(() => {});
-  }
-
-  async ready(): Promise<T> {
-    return (await this.lease).value;
-  }
-
-  release(): Promise<void> {
-    this.releasePromise ??= this.releaseOnce();
-    return this.releasePromise;
-  }
-
-  private async releaseOnce(): Promise<void> {
-    try {
-      const lease = await this.lease;
-      await lease.release();
-    } catch {}
-  }
+export function once<T>(fn: () => Promise<T>): () => Promise<T> {
+  let promise: Promise<T> | undefined;
+  return () => (promise ??= fn());
 }
 
-export function toPendingLease<T>(lease: Promise<Lease<T>>): PendingLease<T> {
-  return new PendingLeaseAdapter(lease);
+export function toPendingLease<T>(leasePromise: Promise<Lease<T>>): PendingLease<T> {
+  leasePromise.catch(() => {});
+  return {
+    ready: async () => (await leasePromise).value,
+    release: once(async () => {
+      try {
+        await (await leasePromise).release();
+      } catch {}
+    }),
+  };
 }
 
 export async function withLease<T, R>(

--- a/packages/shared/src/lifecycle.ts
+++ b/packages/shared/src/lifecycle.ts
@@ -12,5 +12,50 @@ export interface ILifecycle extends IInitializable, IDisposable {}
 
 export interface Lease<T> {
   readonly value: T;
-  release(): void;
+  release(): Promise<void>;
+}
+
+export interface PendingLease<T> {
+  ready(): Promise<T>;
+  release(): Promise<void>;
+}
+
+class PendingLeaseAdapter<T> implements PendingLease<T> {
+  private releasePromise: Promise<void> | null = null;
+
+  constructor(private readonly lease: Promise<Lease<T>>) {
+    this.lease.catch(() => {});
+  }
+
+  async ready(): Promise<T> {
+    return (await this.lease).value;
+  }
+
+  release(): Promise<void> {
+    this.releasePromise ??= this.releaseOnce();
+    return this.releasePromise;
+  }
+
+  private async releaseOnce(): Promise<void> {
+    try {
+      const lease = await this.lease;
+      await lease.release();
+    } catch {}
+  }
+}
+
+export function toPendingLease<T>(lease: Promise<Lease<T>>): PendingLease<T> {
+  return new PendingLeaseAdapter(lease);
+}
+
+export async function withLease<T, R>(
+  leaseOrPromise: Lease<T> | Promise<Lease<T>>,
+  run: (value: T, lease: Lease<T>) => R | Promise<R>
+): Promise<R> {
+  const lease = await leaseOrPromise;
+  try {
+    return await run(lease.value, lease);
+  } finally {
+    await lease.release();
+  }
 }


### PR DESCRIPTION
- makes shared leases async so resource owners can await native cleanup
- adds PendingLease and withLease for safer lease handling during async setup
- updates ResourceMap to resolve dispose only after active teardowns finish
- wires core file watchers through async lease release so Parcel subscriptions close before runtime teardown completes
- updates git and file tree runtimes to propagate async dispose through their resource chains
- keeps project teardown best-effort during app quit so Cmd+Q stays responsive
- awaits runtime cleanup during quit so core watcher teardown gets a chance to finish
