### PR TITLE
fix(conversations): clear closed agent status

### DIFF
--- a/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it, vi } from 'vitest';
-import { providerSupportsNativeStartHook } from './agent-hook-service';
+import {
+  providerSupportsNativeStartHook,
+  shouldResetAgentStatusOnSessionExit,
+} from './agent-hook-service';
 
 vi.mock('@main/core/agents/plugin-registry', () => ({
   getPlugin: vi.fn((id: string) => ({
@@ -20,6 +23,14 @@ vi.mock('@main/db/client', () => ({
   db: {},
 }));
 
+vi.mock('@main/db/schema', () => ({
+  conversations: {
+    id: 'id',
+    agentStatus: 'agentStatus',
+    projectId: 'projectId',
+  },
+}));
+
 describe('providerSupportsNativeStartHook', () => {
   it('detects providers that emit native start hooks', () => {
     expect(providerSupportsNativeStartHook('amp')).toBe(true);
@@ -27,5 +38,19 @@ describe('providerSupportsNativeStartHook', () => {
 
   it('does not treat other hook support as native start support', () => {
     expect(providerSupportsNativeStartHook('codex')).toBe(false);
+  });
+});
+
+describe('shouldResetAgentStatusOnSessionExit', () => {
+  it('resets statuses that imply a live agent session', () => {
+    expect(shouldResetAgentStatusOnSessionExit('working')).toBe(true);
+    expect(shouldResetAgentStatusOnSessionExit('awaiting-input')).toBe(true);
+  });
+
+  it('keeps terminal and unseen-result statuses intact', () => {
+    expect(shouldResetAgentStatusOnSessionExit('idle')).toBe(false);
+    expect(shouldResetAgentStatusOnSessionExit('completed')).toBe(false);
+    expect(shouldResetAgentStatusOnSessionExit('error')).toBe(false);
+    expect(shouldResetAgentStatusOnSessionExit(null)).toBe(false);
   });
 });

--- a/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
@@ -51,6 +51,12 @@ function determineSoundEvent(
   return undefined;
 }
 
+const EXIT_RESETTABLE_AGENT_STATUSES = new Set<AgentStatus>(['working', 'awaiting-input']);
+
+export function shouldResetAgentStatusOnSessionExit(status: AgentStatus | null): boolean {
+  return status !== null && EXIT_RESETTABLE_AGENT_STATUSES.has(status);
+}
+
 export function providerSupportsNativeStartHook(providerId: string): boolean {
   const hooks = getPlugin(providerId).capabilities.hooks;
   return hooks.kind !== 'none' && hooks.supportedEvents.includes('start');
@@ -204,9 +210,9 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
       });
     });
 
-    // Reset a stuck 'working' status to 'idle' when the agent PTY exits.
+    // Reset active statuses to 'idle' when the agent PTY exits.
     // This handles the case where the user interrupts/kills the agent before
-    // a 'stop' or 'error' hook fires.
+    // a 'stop' or 'error' hook fires, or closes a tab while it is awaiting input.
     events.on(agentSessionExitedChannel, ({ conversationId, taskId }) => {
       void (async () => {
         try {
@@ -216,7 +222,9 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
             .where(eq(conversations.id, conversationId))
             .limit(1);
 
-          if (!row || row.agentStatus !== 'working') return;
+          if (!row || !shouldResetAgentStatusOnSessionExit(row.agentStatus as AgentStatus | null)) {
+            return;
+          }
 
           await db
             .update(conversations)
@@ -234,7 +242,7 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
             soundEvent: undefined,
           });
         } catch (error) {
-          log.warn('AgentHookService: failed to reset stuck working status on exit', {
+          log.warn('AgentHookService: failed to reset active status on exit', {
             conversationId,
             error: String(error),
           });

--- a/apps/emdash-desktop/src/main/core/conversations/dehydrateConversation.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/dehydrateConversation.test.ts
@@ -1,0 +1,51 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { agentSessionExitedChannel } from '@shared/core/agents/agentEvents';
+import { dehydrateConversation } from './dehydrateConversation';
+
+const resolveTask = vi.hoisted(() => vi.fn());
+
+vi.mock('../projects/utils', () => ({
+  resolveTask,
+}));
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    emit: vi.fn(),
+  },
+}));
+
+const { events } = await import('@main/lib/events');
+
+describe('dehydrateConversation', () => {
+  beforeEach(() => {
+    resolveTask.mockReset();
+    vi.mocked(events.emit).mockClear();
+  });
+
+  it('emits agent exit when detaching terminates the agent', async () => {
+    resolveTask.mockReturnValue({
+      conversations: {
+        detachSession: vi.fn(async () => true),
+      },
+    });
+
+    await dehydrateConversation('project-1', 'task-1', 'conversation-1');
+
+    expect(events.emit).toHaveBeenCalledWith(agentSessionExitedChannel, {
+      conversationId: 'conversation-1',
+      taskId: 'task-1',
+    });
+  });
+
+  it('does not emit agent exit when detaching leaves the agent running', async () => {
+    resolveTask.mockReturnValue({
+      conversations: {
+        detachSession: vi.fn(async () => false),
+      },
+    });
+
+    await dehydrateConversation('project-1', 'task-1', 'conversation-1');
+
+    expect(events.emit).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/conversations/dehydrateConversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/dehydrateConversation.ts
@@ -8,8 +8,8 @@ export async function dehydrateConversation(
   conversationId: string
 ): Promise<void> {
   const task = resolveTask(projectId, taskId);
-  await task?.conversations.detachSession(conversationId);
-  if (task) {
+  const terminatedAgent = await task?.conversations.detachSession(conversationId);
+  if (terminatedAgent) {
     events.emit(agentSessionExitedChannel, { conversationId, taskId });
   }
 }

--- a/apps/emdash-desktop/src/main/core/conversations/dehydrateConversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/dehydrateConversation.ts
@@ -1,3 +1,5 @@
+import { events } from '@main/lib/events';
+import { agentSessionExitedChannel } from '@shared/core/agents/agentEvents';
 import { resolveTask } from '../projects/utils';
 
 export async function dehydrateConversation(
@@ -7,4 +9,7 @@ export async function dehydrateConversation(
 ): Promise<void> {
   const task = resolveTask(projectId, taskId);
   await task?.conversations.detachSession(conversationId);
+  if (task) {
+    events.emit(agentSessionExitedChannel, { conversationId, taskId });
+  }
 }

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -289,13 +289,15 @@ export class LocalConversationProvider implements ConversationProvider {
     }
   }
 
-  async detachSession(conversationId: string): Promise<void> {
+  async detachSession(conversationId: string): Promise<boolean> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
     this.detachPty(sessionId);
-    if (!this.tmux) {
-      this.knownSessionIds.delete(sessionId);
-      this.supervisor.forget(sessionId);
+    if (this.tmux) {
+      return false;
     }
+    this.knownSessionIds.delete(sessionId);
+    this.supervisor.forget(sessionId);
+    return true;
   }
 
   async stopSession(conversationId: string): Promise<void> {

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -305,13 +305,15 @@ export class SshConversationProvider implements ConversationProvider {
     }
   }
 
-  async detachSession(conversationId: string): Promise<void> {
+  async detachSession(conversationId: string): Promise<boolean> {
     const sessionId = makePtySessionId(this.projectId, this.taskId, conversationId);
     this.detachPty(sessionId);
-    if (!this.tmux) {
-      this.knownSessionIds.delete(sessionId);
-      this.supervisor.forget(sessionId);
+    if (this.tmux) {
+      return false;
     }
+    this.knownSessionIds.delete(sessionId);
+    this.supervisor.forget(sessionId);
+    return true;
   }
 
   async stopSession(conversationId: string): Promise<void> {

--- a/apps/emdash-desktop/src/main/core/conversations/types.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/types.ts
@@ -7,7 +7,7 @@ export interface ConversationProvider {
     isResuming?: boolean,
     initialPrompt?: string
   ): Promise<void>;
-  detachSession(conversationId: string): Promise<void>;
+  detachSession(conversationId: string): Promise<boolean>;
   stopSession(conversationId: string): Promise<void>;
   destroyAll(): Promise<void>;
   detachAll(): Promise<void>;


### PR DESCRIPTION
### Description
- clears stale agent activity indicators when a closed conversation session is dehydrated
- resets `working` and `awaiting-input` statuses to `idle` on session exit
- keeps completed/error badges intact on unseen results

### Screenshot/Recording (if applicable)
https://streamable.com/oett2n

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
