### PR TITLE
feat: resource monitor loading spinner 

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-view.tsx
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-view.tsx
@@ -5,6 +5,7 @@ import { getTaskView } from '@renderer/features/tasks/stores/task-selectors';
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
 import { rpc } from '@renderer/lib/ipc';
 import { appState } from '@renderer/lib/stores/app-state';
+import { Spinner } from '@renderer/lib/ui/spinner';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { formatBytes } from '@renderer/utils/formatBytes';
 import { cn } from '@renderer/utils/utils';
@@ -29,6 +30,7 @@ export const ResourceMonitorView = observer(function ResourceMonitorView({
 }) {
   const store = appState.resourceMonitor;
   const snapshot = store.snapshot;
+  const isLoading = store.isLoadingInitialSnapshot;
   const memLabel = formatBytes(store.totalMemoryBytes);
   const cpuLabel = `${store.totalCpuPercent.toFixed(1)}%`;
 
@@ -58,33 +60,52 @@ export const ResourceMonitorView = observer(function ResourceMonitorView({
       </div>
 
       <div className="max-h-[24rem] min-h-[14rem] overflow-y-auto px-1.5 py-1.5">
-        {hasProcesses && (
-          <Section heading="Application">
-            <div className="flex flex-col">
-              {processes.map((p) => (
-                <ProcessRow key={p.pid} process={p} cpuCount={snapshot?.cpuCount} />
-              ))}
-            </div>
-          </Section>
-        )}
+        {isLoading ? (
+          <ResourceMonitorLoadingState />
+        ) : (
+          <>
+            {hasProcesses && (
+              <Section heading="Application">
+                <div className="flex flex-col">
+                  {processes.map((p) => (
+                    <ProcessRow key={p.pid} process={p} cpuCount={snapshot?.cpuCount} />
+                  ))}
+                </div>
+              </Section>
+            )}
 
-        <Section heading="Active sessions">
-          {hasProjects ? (
-            <div className="flex flex-col gap-1">
-              {groups.map((g) => (
-                <ProjectRow key={g.projectId} group={g} />
-              ))}
-            </div>
-          ) : (
-            <div className="rounded-md py-6 text-center text-xs text-foreground/40">
-              No active sessions
-            </div>
-          )}
-        </Section>
+            <Section heading="Active sessions">
+              {hasProjects ? (
+                <div className="flex flex-col gap-1">
+                  {groups.map((g) => (
+                    <ProjectRow key={g.projectId} group={g} />
+                  ))}
+                </div>
+              ) : (
+                <div className="rounded-md py-6 text-center text-xs text-foreground/40">
+                  No active sessions
+                </div>
+              )}
+            </Section>
+          </>
+        )}
       </div>
     </>
   );
 });
+
+function ResourceMonitorLoadingState() {
+  return (
+    <div
+      className="flex min-h-[13rem] flex-col items-center justify-center gap-2 text-xs text-foreground/50"
+      role="status"
+      aria-label="Loading resource monitor data"
+    >
+      <Spinner size="sm" className="text-foreground/60" />
+      <span>Loading resource data...</span>
+    </div>
+  );
+}
 
 function Stat({ label, value }: { label: string; value: string }) {
   return (

--- a/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.test.ts
@@ -34,6 +34,11 @@ function snapshot(timestamp: number): ResourceSnapshot {
   };
 }
 
+async function flushPromises(): Promise<void> {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('ResourceMonitorStore', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -67,7 +72,7 @@ describe('ResourceMonitorStore', () => {
     store.start();
 
     expect(store.isLoadingInitialSnapshot).toBe(true);
-    await Promise.resolve();
+    await flushPromises();
 
     expect(store.snapshot).toBeNull();
     expect(store.isLoadingInitialSnapshot).toBe(false);
@@ -84,8 +89,58 @@ describe('ResourceMonitorStore', () => {
     const store = new ResourceMonitorStore();
     store.start();
     snapshotHandler?.(snapshot(2));
+    await flushPromises();
 
     expect(store.snapshot?.timestamp).toBe(2);
+    expect(store.isLoadingInitialSnapshot).toBe(false);
+  });
+
+  it('does not let a null fetched snapshot clear a newer event snapshot', async () => {
+    const { ResourceMonitorStore } = await import('./resource-monitor-store');
+    const { rpc } = await import('@renderer/lib/ipc');
+    vi.mocked(rpc.resourceMonitor.getSnapshot).mockResolvedValue({ success: true, data: null });
+
+    const store = new ResourceMonitorStore();
+    store.start();
+    snapshotHandler?.(snapshot(2));
+    await flushPromises();
+
+    expect(store.snapshot?.timestamp).toBe(2);
+    expect(store.isLoadingInitialSnapshot).toBe(false);
+  });
+
+  it('ignores stale initial fetches from a previous open', async () => {
+    const { ResourceMonitorStore } = await import('./resource-monitor-store');
+    const { rpc } = await import('@renderer/lib/ipc');
+    let resolveFirst!: (value: { success: true; data: ResourceSnapshot | null }) => void;
+    let resolveSecond!: (value: { success: true; data: ResourceSnapshot | null }) => void;
+    vi.mocked(rpc.resourceMonitor.getSnapshot)
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveFirst = resolve;
+        })
+      )
+      .mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveSecond = resolve;
+        })
+      );
+
+    const store = new ResourceMonitorStore();
+    store.start();
+    store.dispose();
+    store.start();
+
+    resolveFirst({ success: true, data: snapshot(1) });
+    await flushPromises();
+
+    expect(store.snapshot).toBeNull();
+    expect(store.isLoadingInitialSnapshot).toBe(true);
+
+    resolveSecond({ success: true, data: null });
+    await flushPromises();
+
+    expect(store.snapshot).toBeNull();
     expect(store.isLoadingInitialSnapshot).toBe(false);
   });
 
@@ -100,7 +155,7 @@ describe('ResourceMonitorStore', () => {
     const store = new ResourceMonitorStore();
     store.start();
     snapshotHandler?.(snapshot(2));
-    await Promise.resolve();
+    await flushPromises();
 
     expect(store.snapshot?.timestamp).toBe(2);
   });

--- a/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.test.ts
@@ -58,6 +58,37 @@ describe('ResourceMonitorStore', () => {
     expect(setOpen).toHaveBeenNthCalledWith(2, clientId, subscriptionId, false, 2);
   });
 
+  it('tracks initial loading until the first fetch resolves', async () => {
+    const { ResourceMonitorStore } = await import('./resource-monitor-store');
+    const { rpc } = await import('@renderer/lib/ipc');
+    vi.mocked(rpc.resourceMonitor.getSnapshot).mockResolvedValue({ success: true, data: null });
+
+    const store = new ResourceMonitorStore();
+    store.start();
+
+    expect(store.isLoadingInitialSnapshot).toBe(true);
+    await Promise.resolve();
+
+    expect(store.snapshot).toBeNull();
+    expect(store.isLoadingInitialSnapshot).toBe(false);
+  });
+
+  it('stops initial loading when an event snapshot arrives first', async () => {
+    const { ResourceMonitorStore } = await import('./resource-monitor-store');
+    const { rpc } = await import('@renderer/lib/ipc');
+    vi.mocked(rpc.resourceMonitor.getSnapshot).mockResolvedValue({
+      success: true,
+      data: snapshot(1),
+    });
+
+    const store = new ResourceMonitorStore();
+    store.start();
+    snapshotHandler?.(snapshot(2));
+
+    expect(store.snapshot?.timestamp).toBe(2);
+    expect(store.isLoadingInitialSnapshot).toBe(false);
+  });
+
   it('does not let an older fetched snapshot overwrite a newer event snapshot', async () => {
     const { ResourceMonitorStore } = await import('./resource-monitor-store');
     const { rpc } = await import('@renderer/lib/ipc');

--- a/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.ts
@@ -60,8 +60,10 @@ export class ResourceMonitorStore {
   start(): void {
     if (this.started) return;
     this.started = true;
-    this.snapshot = null;
-    this.isLoadingInitialSnapshot = true;
+    runInAction(() => {
+      this.snapshot = null;
+      this.isLoadingInitialSnapshot = true;
+    });
     const requestId = ++this.requestId;
     const subscriptionId = crypto.randomUUID();
     this.subscriptionId = subscriptionId;
@@ -98,7 +100,9 @@ export class ResourceMonitorStore {
     this.offSnapshot?.();
     this.offSnapshot = null;
     this.started = false;
-    this.isLoadingInitialSnapshot = false;
+    runInAction(() => {
+      this.isLoadingInitialSnapshot = false;
+    });
     this.subscriptionId = null;
     if (subscriptionId) {
       void rpc.resourceMonitor.setOpen(this.clientId, subscriptionId, false, ++this.sequence);

--- a/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.ts
@@ -10,6 +10,7 @@ export class ResourceMonitorStore {
   private offSnapshot: (() => void) | null = null;
   private clientId = crypto.randomUUID();
   private sequence = 0;
+  private requestId = 0;
   private subscriptionId: string | null = null;
 
   constructor() {
@@ -59,11 +60,14 @@ export class ResourceMonitorStore {
   start(): void {
     if (this.started) return;
     this.started = true;
-    this.isLoadingInitialSnapshot = this.snapshot === null;
+    this.snapshot = null;
+    this.isLoadingInitialSnapshot = true;
+    const requestId = ++this.requestId;
     const subscriptionId = crypto.randomUUID();
     this.subscriptionId = subscriptionId;
     void rpc.resourceMonitor.setOpen(this.clientId, subscriptionId, true, ++this.sequence);
     this.offSnapshot = events.on(resourceSnapshotChannel, (snap) => {
+      if (!this.isCurrentRequest(requestId)) return;
       runInAction(() => {
         this.snapshot = snap;
         this.isLoadingInitialSnapshot = false;
@@ -72,18 +76,16 @@ export class ResourceMonitorStore {
     rpc.resourceMonitor
       .getSnapshot()
       .then((res) => {
-        if (!res?.success) {
-          runInAction(() => {
-            this.isLoadingInitialSnapshot = false;
-          });
-          return;
-        }
+        if (!this.isCurrentRequest(requestId)) return;
         runInAction(() => {
-          this.applyFetchedSnapshot(res.data);
+          if (res?.success && res.data) {
+            this.applyFetchedSnapshot(res.data);
+          }
           this.isLoadingInitialSnapshot = false;
         });
       })
       .catch(() => {
+        if (!this.isCurrentRequest(requestId)) return;
         runInAction(() => {
           this.isLoadingInitialSnapshot = false;
         });
@@ -105,15 +107,19 @@ export class ResourceMonitorStore {
 
   async refresh(): Promise<void> {
     const res = await rpc.resourceMonitor.getSnapshot();
-    if (!res?.success) return;
+    if (!res?.success || !res.data) return;
     runInAction(() => {
       this.applyFetchedSnapshot(res.data);
     });
   }
 
-  private applyFetchedSnapshot(snap: ResourceSnapshot | null): void {
-    if (snap && this.snapshot && this.snapshot.timestamp > snap.timestamp) return;
+  private applyFetchedSnapshot(snap: ResourceSnapshot): void {
+    if (this.snapshot && this.snapshot.timestamp > snap.timestamp) return;
     this.snapshot = snap;
+  }
+
+  private isCurrentRequest(requestId: number): boolean {
+    return this.started && this.requestId === requestId;
   }
 
   /** Normalized CPU% (relative to all cores) for a single entry. */

--- a/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.ts
+++ b/apps/emdash-desktop/src/renderer/lib/stores/resource-monitor-store.ts
@@ -5,6 +5,7 @@ import type { ResourcePtyEntry, ResourceSnapshot } from '@shared/resource-monito
 
 export class ResourceMonitorStore {
   snapshot: ResourceSnapshot | null = null;
+  isLoadingInitialSnapshot = false;
   private started = false;
   private offSnapshot: (() => void) | null = null;
   private clientId = crypto.randomUUID();
@@ -14,6 +15,7 @@ export class ResourceMonitorStore {
   constructor() {
     makeObservable(this, {
       snapshot: observable,
+      isLoadingInitialSnapshot: observable,
       totalCpuPercent: computed,
       totalMemoryBytes: computed,
       appMemoryBytes: computed,
@@ -57,23 +59,35 @@ export class ResourceMonitorStore {
   start(): void {
     if (this.started) return;
     this.started = true;
+    this.isLoadingInitialSnapshot = this.snapshot === null;
     const subscriptionId = crypto.randomUUID();
     this.subscriptionId = subscriptionId;
     void rpc.resourceMonitor.setOpen(this.clientId, subscriptionId, true, ++this.sequence);
     this.offSnapshot = events.on(resourceSnapshotChannel, (snap) => {
       runInAction(() => {
         this.snapshot = snap;
+        this.isLoadingInitialSnapshot = false;
       });
     });
     rpc.resourceMonitor
       .getSnapshot()
       .then((res) => {
-        if (!res?.success || !res.data) return;
+        if (!res?.success) {
+          runInAction(() => {
+            this.isLoadingInitialSnapshot = false;
+          });
+          return;
+        }
         runInAction(() => {
           this.applyFetchedSnapshot(res.data);
+          this.isLoadingInitialSnapshot = false;
         });
       })
-      .catch(() => {});
+      .catch(() => {
+        runInAction(() => {
+          this.isLoadingInitialSnapshot = false;
+        });
+      });
   }
 
   dispose(): void {
@@ -82,6 +96,7 @@ export class ResourceMonitorStore {
     this.offSnapshot?.();
     this.offSnapshot = null;
     this.started = false;
+    this.isLoadingInitialSnapshot = false;
     this.subscriptionId = null;
     if (subscriptionId) {
       void rpc.resourceMonitor.setOpen(this.clientId, subscriptionId, false, ++this.sequence);


### PR DESCRIPTION
### Description
- adds loading spinner for resource monitor
- fixes stale snapshot updates after reopen
- preserves newer live resource data

### Screenshot/Recording (if applicable)
https://streamable.com/0vaxdr

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
