### PR TITLE
fix(settings): persist provider flags

### DIFF
--- a/apps/emdash-desktop/src/main/core/agents/agent-payload-builder.test.ts
+++ b/apps/emdash-desktop/src/main/core/agents/agent-payload-builder.test.ts
@@ -145,7 +145,6 @@ describe('buildAgentPayload', () => {
     vi.mocked(getPlugin).mockImplementation(() => {
       throw new Error('No plugin found');
     });
-    vi.mocked(providerOverrideSettings.getItemWithMeta).mockResolvedValue(null);
 
     const { buildAgentPayload } = await import('./agent-payload-builder');
     await expect(buildAgentPayload('unknown-agent')).rejects.toThrow('No plugin found');

--- a/apps/emdash-desktop/src/main/core/agents/agent-payload-builder.ts
+++ b/apps/emdash-desktop/src/main/core/agents/agent-payload-builder.ts
@@ -67,8 +67,6 @@ async function buildOne(
   const settingsMeta = await providerOverrideSettings.getItemWithMeta(id);
   const descriptor = getDependencyDescriptor(id);
 
-  const defaultConfig = settingsMeta?.defaults ?? {};
-
   const rawHostDep = dependencyManager?.getHostDependency(id);
   const hostDep =
     rawHostDep && enrichHostDep ? enrichHostDep(id as DependencyId, rawHostDep) : rawHostDep;
@@ -87,11 +85,7 @@ async function buildOne(
     latestVersion,
     updateAvailable,
     command: usedInst?.pathEntry ?? state?.path ?? null,
-    settings: settingsMeta ?? {
-      value: defaultConfig,
-      defaults: defaultConfig,
-      overrides: {},
-    },
+    settings: settingsMeta,
     installOptions: descriptor ? resolveInstallOptions(descriptor, platform) : [],
     installations: hostDep?.installations ?? [],
     used,

--- a/apps/emdash-desktop/src/main/core/agents/controller.ts
+++ b/apps/emdash-desktop/src/main/core/agents/controller.ts
@@ -99,9 +99,9 @@ export const agentsController = createRPCController({
 
   // ── Settings ─────────────────────────────────────────────────────────────────
 
-  getDefaultSettings: async (id: string): Promise<ProviderCustomConfig | null> => {
+  getDefaultSettings: async (id: string): Promise<ProviderCustomConfig> => {
     const meta = await providerOverrideSettings.getItemWithMeta(id);
-    return meta?.defaults ?? null;
+    return meta.defaults;
   },
 
   getSettings: async (id: string) => {

--- a/apps/emdash-desktop/src/main/core/settings/override-settings.test.ts
+++ b/apps/emdash-desktop/src/main/core/settings/override-settings.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest';
+import z from 'zod';
+
+const store = vi.hoisted(() => new Map<string, string>());
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((column, value) => ({ column, value })),
+}));
+
+vi.mock('@main/db/schema', () => ({
+  appSettings: { key: 'key', value: 'value' },
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn((predicate: { value: string }) => ({
+          execute: vi.fn(async () => {
+            const value = store.get(predicate.value);
+            return value === undefined ? [] : [{ key: predicate.value, value }];
+          }),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((row: { key: string; value: string }) => ({
+        onConflictDoUpdate: vi.fn(() => ({
+          execute: vi.fn(async () => {
+            store.set(row.key, row.value);
+          }),
+        })),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn((predicate: { value: string }) => ({
+        execute: vi.fn(async () => {
+          store.delete(predicate.value);
+        }),
+      })),
+    })),
+  },
+}));
+
+const { OverrideSettings } = await import('./override-settings');
+
+describe('OverrideSettings', () => {
+  it('returns metadata for items that have overrides but no defaults entry', async () => {
+    store.clear();
+    const settings = new OverrideSettings(
+      'providerConfigs',
+      () => ({}),
+      z.object({ extraArgs: z.string().optional() })
+    );
+
+    await settings.updateItem('claude', { extraArgs: '--verbose' });
+
+    expect(await settings.getItemWithMeta('claude')).toEqual({
+      value: { extraArgs: '--verbose' },
+      defaults: {},
+      overrides: { extraArgs: '--verbose' },
+    });
+  });
+
+  it('returns empty metadata for items with neither defaults nor overrides', async () => {
+    store.clear();
+    const settings = new OverrideSettings(
+      'providerConfigs',
+      () => ({}),
+      z.object({ extraArgs: z.string().optional() })
+    );
+
+    expect(await settings.getItemWithMeta('claude')).toEqual({
+      value: {},
+      defaults: {},
+      overrides: {},
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/settings/override-settings.ts
+++ b/apps/emdash-desktop/src/main/core/settings/override-settings.ts
@@ -73,7 +73,7 @@ export class OverrideSettings<TConfig extends object> {
     value: TConfig;
     defaults: TConfig;
     overrides: Partial<TConfig>;
-  } | null> {
+  }> {
     const externalDefaults = this.getExternalDefaults();
     const defaults = (externalDefaults[id] ?? {}) as TConfig;
 

--- a/apps/emdash-desktop/src/main/core/settings/override-settings.ts
+++ b/apps/emdash-desktop/src/main/core/settings/override-settings.ts
@@ -75,8 +75,7 @@ export class OverrideSettings<TConfig extends object> {
     overrides: Partial<TConfig>;
   } | null> {
     const externalDefaults = this.getExternalDefaults();
-    const defaults = externalDefaults[id];
-    if (!defaults) return null;
+    const defaults = (externalDefaults[id] ?? {}) as TConfig;
 
     const storedOverrides = await this.readRawOverrides();
     const itemOverrides = (storedOverrides[id] ?? {}) as Record<string, unknown>;

--- a/apps/emdash-desktop/src/main/core/settings/provider-settings-controller.ts
+++ b/apps/emdash-desktop/src/main/core/settings/provider-settings-controller.ts
@@ -14,7 +14,7 @@ export const providerSettingsController = createRPCController({
     value: ProviderCustomConfig;
     defaults: ProviderCustomConfig;
     overrides: Partial<ProviderCustomConfig>;
-  } | null> => providerOverrideSettings.getItemWithMeta(id),
+  }> => providerOverrideSettings.getItemWithMeta(id),
 
   updateItem: (id: string, config: Partial<ProviderCustomConfig>): Promise<void> =>
     providerOverrideSettings.updateItem(id, config),


### PR DESCRIPTION
### Description
- fixes advanced provider flags not persisting
- handles providers without explicit defaults

### Screenshot/Recording (if applicable)
https://streamable.com/nuic4t

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
