### PR TITLE
chore: deduplicate agent flags

### DIFF
--- a/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.test.ts
@@ -178,19 +178,6 @@ describe('resolveAgentSessionCommandArgs', () => {
     expect(result.args).toEqual(['resume', 'provider-session-1']);
   });
 
-  it('does not pass Codex hook trust bypass more than once', () => {
-    const result = pluginRegistry.get('codex')!.behavior.prompt!.buildCommand({
-      cli: 'codex',
-      autoApprove: true,
-      extraArgs: ['--dangerously-bypass-hook-trust'],
-      model: '',
-      sessionId: 'conv-1',
-      isResuming: false,
-    });
-
-    expect(result.args.filter((arg) => arg === '--dangerously-bypass-hook-trust')).toHaveLength(1);
-  });
-
   it('builds an Amp replacement resume command from the stored provider thread id', () => {
     const conversation = makeConversation({
       id: '6fac6620-9fa8-4604-b7e0-1fe361589104',

--- a/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.test.ts
@@ -178,6 +178,19 @@ describe('resolveAgentSessionCommandArgs', () => {
     expect(result.args).toEqual(['resume', 'provider-session-1']);
   });
 
+  it('does not pass Codex hook trust bypass more than once', () => {
+    const result = pluginRegistry.get('codex')!.behavior.prompt!.buildCommand({
+      cli: 'codex',
+      autoApprove: true,
+      extraArgs: ['--dangerously-bypass-hook-trust'],
+      model: '',
+      sessionId: 'conv-1',
+      isResuming: false,
+    });
+
+    expect(result.args.filter((arg) => arg === '--dangerously-bypass-hook-trust')).toHaveLength(1);
+  });
+
   it('builds an Amp replacement resume command from the stored provider thread id', () => {
     const conversation = makeConversation({
       id: '6fac6620-9fa8-4604-b7e0-1fe361589104',

--- a/packages/core/src/agents/plugins/helpers/standard-command.test.ts
+++ b/packages/core/src/agents/plugins/helpers/standard-command.test.ts
@@ -100,4 +100,25 @@ describe('buildStandardCommand', () => {
     expect(mIdx).toBeGreaterThanOrEqual(0);
     expect(result.args[mIdx + 1]).toBe('gpt-5-codex');
   });
+
+  it('deduplicates singleton flags across generated and user extra args', () => {
+    const result = buildStandardCommand(
+      {
+        cli: 'codex',
+        autoApprove: true,
+        extraArgs: ['--dangerously-bypass-hook-trust', '--verbose'],
+        sessionId: 'conv-1',
+        isResuming: false,
+        model: '',
+      },
+      {
+        autoApproveFlag:
+          '-c approval_policy="never" -c sandbox_mode="danger-full-access" --dangerously-bypass-hook-trust',
+        deduplicateFlags: ['--dangerously-bypass-hook-trust'],
+      }
+    );
+
+    expect(result.args.filter((arg) => arg === '--dangerously-bypass-hook-trust')).toHaveLength(1);
+    expect(result.args).toContain('--verbose');
+  });
 });

--- a/packages/plugins/src/agents/impl/amp/index.ts
+++ b/packages/plugins/src/agents/impl/amp/index.ts
@@ -61,6 +61,7 @@ export const provider = registerPluginBehavior(plugin, {
         resumeFlag: 'threads continue',
         sessionIdFlag: 'threads continue',
         sessionIdOnResumeOnly: true,
+        deduplicateFlags: ['--dangerously-allow-all'],
       }),
   },
   mcp: ampMcpAdapter(),

--- a/packages/plugins/src/agents/impl/antigravity/index.ts
+++ b/packages/plugins/src/agents/impl/antigravity/index.ts
@@ -60,6 +60,7 @@ export const provider = registerPluginBehavior(plugin, {
         initialPromptFlag: '-i',
         sessionIdFlag: '--conversation=',
         sessionIdAlways: true,
+        deduplicateFlags: ['--dangerously-skip-permissions'],
       }),
   },
 });

--- a/packages/plugins/src/agents/impl/auggie/index.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.ts
@@ -30,6 +30,7 @@ export const provider = registerPluginBehavior(plugin, {
         defaultArgs: ['--allow-indexing'],
         initialPromptFlag: '',
         resumeFlag: '--continue',
+        deduplicateFlags: ['--allow-indexing'],
       }),
   },
 });

--- a/packages/plugins/src/agents/impl/autohand/index.ts
+++ b/packages/plugins/src/agents/impl/autohand/index.ts
@@ -32,6 +32,7 @@ export const provider = registerPluginBehavior(plugin, {
       buildStandardCommand(ctx, {
         autoApproveFlag: '--unrestricted',
         initialPromptFlag: '-p',
+        deduplicateFlags: ['--unrestricted'],
       }),
   },
 });

--- a/packages/plugins/src/agents/impl/claude/index.ts
+++ b/packages/plugins/src/agents/impl/claude/index.ts
@@ -110,6 +110,7 @@ export const provider = registerPluginBehavior(plugin, {
         resumeFlag: '--resume',
         sessionIdFlag: '--session-id',
         modelFlag: '--model',
+        deduplicateFlags: ['--dangerously-skip-permissions'],
       }),
   },
   hooks: buildClaudeHookConfig(),

--- a/packages/plugins/src/agents/impl/cline/index.ts
+++ b/packages/plugins/src/agents/impl/cline/index.ts
@@ -32,6 +32,7 @@ export const provider = registerPluginBehavior(plugin, {
       buildStandardCommand(ctx, {
         autoApproveFlag: '--yolo',
         initialPromptFlag: '',
+        deduplicateFlags: ['--yolo'],
       }),
   },
 });

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -86,7 +86,10 @@ export const provider = registerPluginBehavior(plugin, {
         sessionIdFlag: ' ',
         sessionIdOnResumeOnly: true,
         resumeWithoutSessionFlag: 'resume --last',
-        deduplicateFlags: ['--dangerously-bypass-approvals-and-sandbox'],
+        deduplicateFlags: [
+          '--dangerously-bypass-approvals-and-sandbox',
+          '--dangerously-bypass-hook-trust',
+        ],
         modelFlag: '-m',
       }),
   },

--- a/packages/plugins/src/agents/impl/commandcode/index.ts
+++ b/packages/plugins/src/agents/impl/commandcode/index.ts
@@ -47,6 +47,7 @@ export const provider = registerPluginBehavior(plugin, {
         resumeFlag: '--resume',
         sessionIdFlag: '--resume',
         sessionIdOnResumeOnly: true,
+        deduplicateFlags: ['--trust', '--skip-onboarding', '--yolo'],
       }),
   },
   hooks: buildCommandCodeHookConfig(),

--- a/packages/plugins/src/agents/impl/continue/index.ts
+++ b/packages/plugins/src/agents/impl/continue/index.ts
@@ -66,6 +66,7 @@ export const provider = registerPluginBehavior(plugin, {
         autoApproveFlag: '--auto',
         initialPromptFlag: '',
         resumeFlag: '--resume',
+        deduplicateFlags: ['--auto'],
       }),
   },
 });

--- a/packages/plugins/src/agents/impl/copilot/index.ts
+++ b/packages/plugins/src/agents/impl/copilot/index.ts
@@ -50,6 +50,7 @@ export const provider = registerPluginBehavior(plugin, {
         resumeFlag: '--resume',
         sessionIdFlag: '--resume',
         sessionIdOnResumeOnly: true,
+        deduplicateFlags: ['--allow-all-tools'],
       }),
   },
   hooks: buildCopilotHookConfig(),

--- a/packages/plugins/src/agents/impl/cursor/index.ts
+++ b/packages/plugins/src/agents/impl/cursor/index.ts
@@ -64,6 +64,7 @@ export const provider = registerPluginBehavior(plugin, {
         autoApproveFlag: '-f --approve-mcps',
         initialPromptFlag: '',
         resumeFlag: '--resume',
+        deduplicateFlags: ['-f', '--approve-mcps'],
       }),
   },
   mcp: cursorMcpAdapter(),

--- a/packages/plugins/src/agents/impl/devin/index.ts
+++ b/packages/plugins/src/agents/impl/devin/index.ts
@@ -65,6 +65,7 @@ export const provider = registerPluginBehavior(plugin, {
         autoApproveFlag: '--permission-mode=bypass',
         initialPromptFlag: '--',
         resumeFlag: '--continue',
+        deduplicateFlags: ['--permission-mode=bypass'],
       }),
   },
   hooks: buildDevinHookConfig(),

--- a/packages/plugins/src/agents/impl/gemini/index.ts
+++ b/packages/plugins/src/agents/impl/gemini/index.ts
@@ -43,6 +43,7 @@ export const provider = registerPluginBehavior(plugin, {
         initialPromptFlag: '-i',
         resumeFlag: '--resume',
         extraEnv: ctx.autoApprove ? { GEMINI_CLI_TRUST_WORKSPACE: 'true' } : {},
+        deduplicateFlags: ['--approval-mode=yolo', '--skip-trust'],
       }),
   },
   mcp: geminiMcpAdapter(),

--- a/packages/plugins/src/agents/impl/grok/index.ts
+++ b/packages/plugins/src/agents/impl/grok/index.ts
@@ -68,6 +68,7 @@ export const provider = registerPluginBehavior(plugin, {
         sessionIdFlag: '-r',
         sessionIdOnResumeOnly: true,
         resumeWithoutSessionFlag: '-r',
+        deduplicateFlags: ['--always-approve'],
       }),
   },
   hooks: buildGrokHookConfig(),

--- a/packages/plugins/src/agents/impl/hermes/index.ts
+++ b/packages/plugins/src/agents/impl/hermes/index.ts
@@ -57,6 +57,7 @@ export const provider = registerPluginBehavior(plugin, {
       buildStandardCommand(ctx, {
         autoApproveFlag: '--yolo',
         resumeFlag: '--continue',
+        deduplicateFlags: ['--yolo'],
       }),
   },
 });

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -143,6 +143,43 @@ describe('pluginRegistry', () => {
     });
   });
 
+  it.each([
+    ['amp', ['--dangerously-allow-all']],
+    ['antigravity', ['--dangerously-skip-permissions']],
+    ['auggie', ['--allow-indexing']],
+    ['autohand', ['--unrestricted']],
+    ['claude', ['--dangerously-skip-permissions']],
+    ['cline', ['--yolo']],
+    ['codex', ['--dangerously-bypass-hook-trust']],
+    ['commandcode', ['--trust', '--skip-onboarding', '--yolo']],
+    ['continue', ['--auto']],
+    ['copilot', ['--allow-all-tools']],
+    ['cursor', ['-f', '--approve-mcps']],
+    ['devin', ['--permission-mode=bypass']],
+    ['gemini', ['--approval-mode=yolo', '--skip-trust']],
+    ['grok', ['--always-approve']],
+    ['hermes', ['--yolo']],
+    ['kilocode', ['--auto']],
+    ['kimi', ['--yolo']],
+    ['kiro', ['--trust-all-tools']],
+    ['letta', ['--yolo', '--new']],
+    ['qwen', ['--yolo']],
+    ['rovo', ['--yolo']],
+  ])('deduplicates generated singleton flags for %s', (id, flags) => {
+    const result = pluginRegistry.get(id)!.behavior.prompt!.buildCommand({
+      cli: id,
+      autoApprove: true,
+      extraArgs: flags,
+      sessionId: 'conv-1',
+      isResuming: false,
+      model: '',
+    });
+
+    for (const flag of flags) {
+      expect(result.args.filter((arg) => arg === flag), `${id} ${flag}`).toHaveLength(1);
+    }
+  });
+
   it('uses the current Amp npm package for install and updates', () => {
     const amp = pluginRegistry.get('amp')!;
 

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -176,7 +176,10 @@ describe('pluginRegistry', () => {
     });
 
     for (const flag of flags) {
-      expect(result.args.filter((arg) => arg === flag), `${id} ${flag}`).toHaveLength(1);
+      expect(
+        result.args.filter((arg) => arg === flag),
+        `${id} ${flag}`
+      ).toHaveLength(1);
     }
   });
 

--- a/packages/plugins/src/agents/impl/kilocode/index.ts
+++ b/packages/plugins/src/agents/impl/kilocode/index.ts
@@ -56,6 +56,7 @@ export const provider = registerPluginBehavior(plugin, {
         autoApproveFlag: '--auto',
         initialPromptFlag: '--prompt',
         resumeFlag: '--continue',
+        deduplicateFlags: ['--auto'],
       }),
   },
   plugins: createFileDropPlugin({

--- a/packages/plugins/src/agents/impl/kimi/index.ts
+++ b/packages/plugins/src/agents/impl/kimi/index.ts
@@ -21,6 +21,7 @@ function buildKimiCommand(ctx: CommandContext): AgentCommand {
     sessionIdOnResumeOnly: true,
     resumeWithoutSessionFlag: '-C',
     omitAutoApproveOnResume: true,
+    deduplicateFlags: ['--yolo'],
   });
   return { ...cmd, args: injectKimiHooksIntoInlineConfig(cmd.args) };
 }

--- a/packages/plugins/src/agents/impl/kiro/index.ts
+++ b/packages/plugins/src/agents/impl/kiro/index.ts
@@ -69,6 +69,7 @@ export const provider = registerPluginBehavior(plugin, {
         sessionIdFlag: '--resume-id',
         sessionIdOnResumeOnly: true,
         resumeWithoutSessionFlag: '--resume',
+        deduplicateFlags: ['--trust-all-tools'],
       }),
   },
   hooks: buildKiroHookConfig(),

--- a/packages/plugins/src/agents/impl/letta/index.ts
+++ b/packages/plugins/src/agents/impl/letta/index.ts
@@ -35,6 +35,7 @@ export const provider = registerPluginBehavior(plugin, {
       buildStandardCommand(ctx, {
         autoApproveFlag: '--yolo',
         newConversationFlag: '--new',
+        deduplicateFlags: ['--yolo', '--new'],
       }),
   },
 });

--- a/packages/plugins/src/agents/impl/qwen/index.ts
+++ b/packages/plugins/src/agents/impl/qwen/index.ts
@@ -48,6 +48,7 @@ export const provider = registerPluginBehavior(plugin, {
         autoApproveFlag: '--yolo',
         initialPromptFlag: '-i',
         resumeFlag: '--continue',
+        deduplicateFlags: ['--yolo'],
       }),
   },
   hooks: buildQwenHookConfig(),

--- a/packages/plugins/src/agents/impl/rovo/index.ts
+++ b/packages/plugins/src/agents/impl/rovo/index.ts
@@ -52,6 +52,7 @@ export const provider = registerPluginBehavior(plugin, {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
         autoApproveFlag: '--yolo',
+        deduplicateFlags: ['--yolo'],
       }),
   },
 });


### PR DESCRIPTION
### Description
- deduplicates generated singleton approval/trust flags across providers
- prevent user extra flags from causing deduplicated flag errors

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
