### PR TITLE
feat(tasks): add prompt and browser options to conversation modal

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
@@ -187,11 +187,12 @@ describe('createTaskCommandProvider', () => {
     });
 
     const modalOptions = mocks.showModal.mock.calls[0][1];
-    modalOptions.onSuccess({ conversationId: 'conversation-1' });
+    modalOptions.onSuccess({ conversationId: 'conversation-1', openBrowserTab: true });
 
     expect(taskView.tabGroupManager.openConversationInRightSplit).toHaveBeenCalledWith(
       'conversation-1'
     );
+    expect(taskView.tabGroupManager.openBrowser).toHaveBeenCalledWith();
     expect(taskView.setFocusedRegion).toHaveBeenCalledWith('main');
   });
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
@@ -89,8 +89,9 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
             showModal('createConversationModal', {
               projectId,
               taskId,
-              onSuccess: ({ conversationId }) => {
+              onSuccess: ({ conversationId, openBrowserTab }) => {
                 taskView?.tabGroupManager.openConversation(conversationId);
+                if (openBrowserTab) taskView?.tabGroupManager.openBrowser();
                 taskView?.setFocusedRegion('main');
               },
             });
@@ -106,8 +107,9 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
             showModal('createConversationModal', {
               projectId,
               taskId,
-              onSuccess: ({ conversationId }) => {
+              onSuccess: ({ conversationId, openBrowserTab }) => {
                 taskView?.tabGroupManager.openConversationInRightSplit(conversationId);
+                if (openBrowserTab) taskView?.tabGroupManager.openBrowser();
                 taskView?.setFocusedRegion('main');
               },
             });

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
@@ -1,11 +1,11 @@
 import { observer } from 'mobx-react-lite';
 import { useCallback, useState } from 'react';
-import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
 import { conversationRegistry } from '@renderer/features/tasks/stores/conversation-registry';
-import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
+import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-selectors';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { useCloseGuard } from '@renderer/lib/modal/use-close-guard';
+import { Checkbox } from '@renderer/lib/ui/checkbox';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
 import {
   DialogContentArea,
@@ -13,32 +13,36 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
-import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
-import { Switch } from '@renderer/lib/ui/switch';
-import { providerSupportsAutoApprove } from '@shared/core/agents/agent-auto-approve';
+import { buildFinalPrompt } from '../create-task-modal/initial-conversation-text';
 import { nextDefaultConversationTitle } from './conversation-title-utils';
-import { useEffectiveProvider } from './use-effective-provider';
+import {
+  InitialConversationField,
+  useInitialConversationState,
+} from './initial-conversation-section';
 
 export const CreateConversationModal = observer(function CreateConversationModal({
   onSuccess,
   projectId,
   taskId,
-}: BaseModalProps<{ conversationId: string }> & {
+}: BaseModalProps<{ conversationId: string; openBrowserTab: boolean }> & {
   projectId: string;
   taskId: string;
 }) {
-  const connectionId = getProjectSshConnectionId(projectId);
-  const { providerId, setProviderOverride, createDisabled } = useEffectiveProvider(connectionId);
   const conversationMgr = conversationRegistry.get(taskId);
-  const taskSettings = useTaskSettings();
+  const task = getRegisteredTaskData(projectId, taskId);
+  const { autoApproveByDefault, includeIssueContextByDefault } = useTaskSettings();
+  const initialConversation = useInitialConversationState(
+    projectId,
+    undefined,
+    autoApproveByDefault
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const [openBrowserTab, setOpenBrowserTab] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
   useCloseGuard(isSubmitting);
 
-  const showAutoApproveToggle = providerId ? providerSupportsAutoApprove(providerId) : false;
-  const skipPermissions =
-    showAutoApproveToggle && (autoApproveOverride ?? taskSettings.autoApproveByDefault);
+  const providerId = initialConversation.provider;
+  const createDisabled = initialConversation.createDisabled;
   const titleProviderId = providerId ?? 'claude';
   const title = nextDefaultConversationTitle(
     titleProviderId,
@@ -48,6 +52,10 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const handleCreateConversation = useCallback(async () => {
     if (createDisabled || isSubmitting || !conversationMgr || !providerId) return;
     const id = crypto.randomUUID();
+    const initialPrompt = buildFinalPrompt(
+      initialConversation.issueContext,
+      initialConversation.prompt
+    );
     setIsSubmitting(true);
     setError(null);
     try {
@@ -55,12 +63,13 @@ export const CreateConversationModal = observer(function CreateConversationModal
         projectId,
         taskId,
         id,
-        autoApprove: skipPermissions,
+        autoApprove: initialConversation.autoApprove,
         provider: providerId,
         title,
+        initialPrompt,
       });
       setIsSubmitting(false);
-      onSuccess({ conversationId: id });
+      onSuccess({ conversationId: id, openBrowserTab });
     } catch {
       setError('Failed to create conversation');
       setIsSubmitting(false);
@@ -68,13 +77,16 @@ export const CreateConversationModal = observer(function CreateConversationModal
   }, [
     conversationMgr,
     createDisabled,
+    initialConversation.issueContext,
+    initialConversation.prompt,
+    initialConversation.autoApprove,
     isSubmitting,
+    openBrowserTab,
     providerId,
     title,
     onSuccess,
     projectId,
     taskId,
-    skipPermissions,
   ]);
 
   return (
@@ -83,30 +95,21 @@ export const CreateConversationModal = observer(function CreateConversationModal
         <DialogTitle>Create Conversation</DialogTitle>
       </DialogHeader>
       <DialogContentArea>
-        <FieldGroup>
-          <Field>
-            <FieldLabel>Agent</FieldLabel>
-            <AgentSelector
-              autoFocus
-              value={providerId}
-              onChange={setProviderOverride}
-              connectionId={connectionId}
+        <div className="flex flex-col gap-3">
+          <InitialConversationField
+            state={initialConversation}
+            linkedIssue={task?.linkedIssue}
+            includeIssueContextByDefault={includeIssueContextByDefault}
+          />
+          <label className="flex w-fit items-center gap-2 text-sm text-foreground-muted">
+            <Checkbox
+              checked={openBrowserTab}
+              onCheckedChange={(checked) => setOpenBrowserTab(checked === true)}
             />
-          </Field>
-          {showAutoApproveToggle ? (
-            <Field>
-              <div className="flex items-center gap-2">
-                <Switch
-                  checked={skipPermissions}
-                  disabled={!providerId || taskSettings.loading || taskSettings.saving}
-                  onCheckedChange={setAutoApproveOverride}
-                />
-                <FieldLabel>Auto-approve permissions</FieldLabel>
-              </div>
-            </Field>
-          ) : null}
+            <span>Open browser tab</span>
+          </label>
           {error && <p className="text-destructive text-xs">{error}</p>}
-        </FieldGroup>
+        </div>
       </DialogContentArea>
       <DialogFooter>
         <ConfirmButton

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -22,6 +22,7 @@ import { useEffectiveProvider } from './use-effective-provider';
 export type InitialConversationState = {
   provider: AgentProviderId | null;
   setProvider: (provider: AgentProviderId | null) => void;
+  createDisabled: boolean;
   projectId?: string;
   prompt: string;
   setPrompt: Dispatch<SetStateAction<string>>;
@@ -44,7 +45,10 @@ export function useInitialConversationState(
 ): InitialConversationState {
   const { resetPromptOnProjectChange = true } = options;
   const connectionId = projectId ? getProjectSshConnectionId(projectId) : undefined;
-  const { providerId, setProviderOverride } = useEffectiveProvider(connectionId, initialProvider);
+  const { providerId, setProviderOverride, createDisabled } = useEffectiveProvider(
+    connectionId,
+    initialProvider
+  );
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
@@ -68,6 +72,7 @@ export function useInitialConversationState(
   return {
     provider: providerId,
     setProvider: setProviderOverride,
+    createDisabled,
     projectId,
     prompt,
     setPrompt,

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/sidebar-conversations-list.tsx
@@ -186,8 +186,9 @@ export const SidebarConversationsList = observer(function SidebarConversationsLi
     showCreateConversationModal({
       projectId,
       taskId,
-      onSuccess: ({ conversationId }) => {
+      onSuccess: ({ conversationId, openBrowserTab }) => {
         tabGroupManager.openConversation(conversationId);
+        if (openBrowserTab) tabGroupManager.openBrowser();
       },
     });
   };

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
@@ -10,6 +10,7 @@ function makeInitialConversationState(
   return {
     provider,
     setProvider: () => {},
+    createDisabled: false,
     prompt: 'Check this',
     setPrompt: () => {},
     issueContext: null,

--- a/apps/emdash-desktop/src/renderer/features/tasks/view/pane-empty-state.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/view/pane-empty-state.tsx
@@ -20,7 +20,10 @@ export function PaneEmptyState() {
       showCreateConversationModal({
         projectId,
         taskId,
-        onSuccess: ({ conversationId }) => tabManager.openConversation(conversationId),
+        onSuccess: ({ conversationId, openBrowserTab }) => {
+          tabManager.openConversation(conversationId);
+          if (openBrowserTab) tabManager.openBrowser();
+        },
       }),
     () => showCommandPalette({ projectId, taskId, workspaceId: workspaceId ?? undefined }),
   ];

--- a/apps/emdash-desktop/src/renderer/features/tasks/view/tab-bar/tab-bar-actions.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/view/tab-bar/tab-bar-actions.tsx
@@ -49,7 +49,10 @@ export const TabBarActions = observer(function TabBarActions() {
               showCreateConversationModal({
                 projectId,
                 taskId,
-                onSuccess: ({ conversationId }) => tabManager.openConversation(conversationId),
+                onSuccess: ({ conversationId, openBrowserTab }) => {
+                  tabManager.openConversation(conversationId);
+                  if (openBrowserTab) tabManager.openBrowser();
+                },
               })
             }
           >


### PR DESCRIPTION
## Summary

- Reuse the existing initial conversation composer in the create-conversation modal.
- Allow additional conversations to start with an optional prompt, including prompt-library insertion.
- Add an option to open a browser tab after creating the conversation and wire it through sidebar, pane, tab bar, and command entry points.

## Impact

Users can configure the new conversation more fully before it is created, while browser tab creation remains owned by the existing task tab managers.

## Validation

- `oxfmt` on touched files
- `oxlint` on touched files
- `vitest run src/renderer/features/tasks/conversations/initial-conversation-section.test.ts src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts src/renderer/features/tasks/commands.test.ts`
- `nx typecheck @emdash/emdash-desktop`