### PR TITLE
fix(secrets): force libsecret backend so safeStorage works on non-GNOME/KDE Linux

### DIFF
--- a/apps/emdash-desktop/src/main/app/linux-secret-storage.test.ts
+++ b/apps/emdash-desktop/src/main/app/linux-secret-storage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { shouldForceLibsecretBackend } from './linux-secret-storage';
+
+const BUS = 'unix:path=/run/user/1000/bus';
+
+describe('shouldForceLibsecretBackend', () => {
+  it('forces libsecret on an unrecognized desktop with a session bus (Hyprland/sway/…)', () => {
+    expect(
+      shouldForceLibsecretBackend({
+        DBUS_SESSION_BUS_ADDRESS: BUS,
+        XDG_CURRENT_DESKTOP: 'Hyprland',
+      })
+    ).toBe(true);
+  });
+
+  it('forces libsecret when no desktop is advertised but a session bus exists', () => {
+    expect(shouldForceLibsecretBackend({ DBUS_SESSION_BUS_ADDRESS: BUS })).toBe(true);
+  });
+
+  it('returns true on GNOME (harmless — Chromium already selects libsecret there)', () => {
+    expect(
+      shouldForceLibsecretBackend({
+        DBUS_SESSION_BUS_ADDRESS: BUS,
+        XDG_CURRENT_DESKTOP: 'ubuntu:GNOME',
+      })
+    ).toBe(true);
+  });
+
+  it('leaves KDE to its native kwallet backend', () => {
+    expect(
+      shouldForceLibsecretBackend({ DBUS_SESSION_BUS_ADDRESS: BUS, XDG_CURRENT_DESKTOP: 'KDE' })
+    ).toBe(false);
+    expect(
+      shouldForceLibsecretBackend({
+        DBUS_SESSION_BUS_ADDRESS: BUS,
+        XDG_CURRENT_DESKTOP: 'plasma:KDE',
+      })
+    ).toBe(false);
+  });
+
+  it('does nothing without a usable session bus (no Secret Service to reach)', () => {
+    expect(shouldForceLibsecretBackend({ XDG_CURRENT_DESKTOP: 'Hyprland' })).toBe(false);
+    expect(shouldForceLibsecretBackend({ DBUS_SESSION_BUS_ADDRESS: '   ' })).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/main/app/linux-secret-storage.test.ts
+++ b/apps/emdash-desktop/src/main/app/linux-secret-storage.test.ts
@@ -38,6 +38,18 @@ describe('shouldForceLibsecretBackend', () => {
     ).toBe(false);
   });
 
+  it('does not override an explicit password-store switch', () => {
+    expect(
+      shouldForceLibsecretBackend(
+        {
+          DBUS_SESSION_BUS_ADDRESS: BUS,
+          XDG_CURRENT_DESKTOP: 'Hyprland',
+        },
+        { passwordStoreSwitchPresent: true }
+      )
+    ).toBe(false);
+  });
+
   it('does nothing without a usable session bus (no Secret Service to reach)', () => {
     expect(shouldForceLibsecretBackend({ XDG_CURRENT_DESKTOP: 'Hyprland' })).toBe(false);
     expect(shouldForceLibsecretBackend({ DBUS_SESSION_BUS_ADDRESS: '   ' })).toBe(false);

--- a/apps/emdash-desktop/src/main/app/linux-secret-storage.ts
+++ b/apps/emdash-desktop/src/main/app/linux-secret-storage.ts
@@ -18,7 +18,11 @@ export const LIBSECRET_PASSWORD_STORE = 'gnome-libsecret';
  * there is no Secret Service to reach, so forcing would not help. On GNOME the
  * switch is a harmless no-op (Chromium already picks libsecret there).
  */
-export function shouldForceLibsecretBackend(env: NodeJS.ProcessEnv = process.env): boolean {
+export function shouldForceLibsecretBackend(
+  env: NodeJS.ProcessEnv = process.env,
+  options: { passwordStoreSwitchPresent?: boolean } = {}
+): boolean {
+  if (options.passwordStoreSwitchPresent) return false;
   if (!env.DBUS_SESSION_BUS_ADDRESS?.trim()) return false;
   const desktop = (env.XDG_CURRENT_DESKTOP ?? '').toLowerCase();
   if (desktop.includes('kde')) return false;

--- a/apps/emdash-desktop/src/main/app/linux-secret-storage.ts
+++ b/apps/emdash-desktop/src/main/app/linux-secret-storage.ts
@@ -1,0 +1,26 @@
+/** Chromium password-store backend that routes `safeStorage` through the Secret Service. */
+export const LIBSECRET_PASSWORD_STORE = 'gnome-libsecret';
+
+/**
+ * Decide whether to force Chromium's libsecret (Secret Service) backend for
+ * `safeStorage` on Linux.
+ *
+ * Chromium only auto-selects a Secret Service backend when `XDG_CURRENT_DESKTOP`
+ * names a desktop it recognizes (GNOME, KDE, Unity, Cinnamon, …). On Hyprland,
+ * sway, i3, dwm and other compositors — a growing slice of the Linux desktop —
+ * it falls back to the plaintext `basic_text` backend even when a working Secret
+ * Service is on the session bus, which breaks every encrypted-secret feature
+ * (account sign-in, cached GitHub/Linear tokens, SSH credentials, …). See #1875.
+ *
+ * Force `gnome-libsecret` when a session bus is present (a Secret Service can
+ * only live on D-Bus) and the desktop is not KDE — KDE is left to its native
+ * kwallet auto-detection. With no session bus we leave the default untouched:
+ * there is no Secret Service to reach, so forcing would not help. On GNOME the
+ * switch is a harmless no-op (Chromium already picks libsecret there).
+ */
+export function shouldForceLibsecretBackend(env: NodeJS.ProcessEnv = process.env): boolean {
+  if (!env.DBUS_SESSION_BUS_ADDRESS?.trim()) return false;
+  const desktop = (env.XDG_CURRENT_DESKTOP ?? '').toLowerCase();
+  if (desktop.includes('kde')) return false;
+  return true;
+}

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -52,7 +52,11 @@ if (import.meta.env.DEV) {
 
 if (process.platform === 'linux') {
   app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
-  if (shouldForceLibsecretBackend(process.env)) {
+  if (
+    shouldForceLibsecretBackend(process.env, {
+      passwordStoreSwitchPresent: app.commandLine.hasSwitch('password-store'),
+    })
+  ) {
     app.commandLine.appendSwitch('password-store', LIBSECRET_PASSWORD_STORE);
   }
 }

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -7,6 +7,7 @@ import devIcon from '@/assets/images/emdash/emdash-dev.png?asset';
 import { PRODUCT_NAME } from '@shared/app-identity';
 import { githubAccountsChangedChannel } from '@shared/events/githubEvents';
 import { registerRPCRouter } from '@shared/lib/ipc/rpc';
+import { LIBSECRET_PASSWORD_STORE, shouldForceLibsecretBackend } from './app/linux-secret-storage';
 import { setupApplicationMenu } from './app/menu';
 import { registerAppScheme, setupAppProtocol } from './app/protocol';
 import { registerQuitHandler } from './app/shutdown';
@@ -51,6 +52,9 @@ if (import.meta.env.DEV) {
 
 if (process.platform === 'linux') {
   app.commandLine.appendSwitch('ozone-platform-hint', 'auto');
+  if (shouldForceLibsecretBackend(process.env)) {
+    app.commandLine.appendSwitch('password-store', LIBSECRET_PASSWORD_STORE);
+  }
 }
 
 registerAppScheme();


### PR DESCRIPTION
## Problem

On Linux where `XDG_CURRENT_DESKTOP` isn't a desktop Chromium recognizes (Hyprland, sway, i3, dwm, headless sessions), `safeStorage` falls back to the plaintext `basic_text` backend even when a working Secret Service is on the session bus. `EncryptedAppSecretsStore.assertSecureStorageAvailable()` rightly refuses `basic_text`, so account sign-in, cached GitHub/Linear tokens, SSH credential storage, etc. all break with "Secure secret storage is unavailable".

Fixes #1875.

## Fix

Force Chromium's `gnome-libsecret` backend (the Secret Service) via `app.commandLine.appendSwitch('password-store', …)` before app ready, gated so it only applies where it can help and won't regress:

- requires a session bus (`DBUS_SESSION_BUS_ADDRESS`) — with no bus there's no Secret Service to reach, so the default is left untouched;
- skips KDE, which is left to its native `kwallet` auto-detection;
- on GNOME the switch is a no-op (Chromium already selects libsecret there).

The decision lives in a pure, unit-tested helper (`shouldForceLibsecretBackend`).

## Testing

`format` / `lint` / `typecheck` clean; unit tests cover the gating matrix (unrecognized desktop, no desktop, GNOME, KDE, no bus).

The helper logic is unit-tested, but I can't validate Chromium's actual backend selection on an affected desktop from here — a sanity check on Hyprland/sway with a running Secret Service would be welcome.