### PR TITLE
fix(ssh): apply write backpressure on the SSH PTY channel

### DIFF
--- a/apps/emdash-desktop/src/main/core/pty/ssh2-pty.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/ssh2-pty.test.ts
@@ -6,10 +6,12 @@ class FakeClientChannel extends EventEmitter {
   writes: string[] = [];
   windows: Array<{ rows: number; cols: number; height: number; width: number }> = [];
   closed = false;
+  /** When false, `write()` returns false to simulate a full send buffer. */
+  acceptWrites = true;
 
   write(data: string): boolean {
     this.writes.push(data);
-    return true;
+    return this.acceptWrites;
   }
 
   setWindow(rows: number, cols: number, height: number, width: number): void {
@@ -41,5 +43,55 @@ describe('Ssh2PtySession', () => {
     expect(dataHandler).toHaveBeenCalledWith('remote output');
     expect(channel.closed).toBe(true);
     expect(exitHandler).toHaveBeenCalledWith({ exitCode: 0, signal: undefined });
+  });
+
+  it('defers writes while the channel buffer is full and flushes them on drain, in order', () => {
+    const channel = new FakeClientChannel();
+    const session = new Ssh2PtySession('s', channel as never);
+
+    channel.acceptWrites = false; // buffer over high-water mark
+    session.write('a'); // buffered by ssh2, returns false -> start draining
+    session.write('b'); // deferred
+    session.write('c'); // deferred
+    expect(channel.writes).toEqual(['a']);
+
+    channel.acceptWrites = true;
+    channel.emit('drain');
+    expect(channel.writes).toEqual(['a', 'b', 'c']);
+    expect(channel.listenerCount('drain')).toBe(0);
+  });
+
+  it('keeps deferring across multiple drains while the channel stays full', () => {
+    const channel = new FakeClientChannel();
+    const session = new Ssh2PtySession('s', channel as never);
+
+    channel.acceptWrites = false;
+    session.write('a'); // draining
+    session.write('b'); // deferred
+    channel.emit('drain'); // still full: 'b' is buffered but write returns false again
+    expect(channel.writes).toEqual(['a', 'b']);
+
+    channel.acceptWrites = true;
+    session.write('c'); // still deferred (draining re-armed)
+    channel.emit('drain');
+    expect(channel.writes).toEqual(['a', 'b', 'c']);
+  });
+
+  it('drops deferred writes and removes the drain listener on kill()', () => {
+    const channel = new FakeClientChannel();
+    const session = new Ssh2PtySession('s', channel as never);
+
+    channel.acceptWrites = false;
+    session.write('a'); // draining
+    session.write('b'); // deferred
+    session.kill();
+
+    expect(channel.closed).toBe(true);
+    expect(channel.listenerCount('drain')).toBe(0);
+
+    channel.acceptWrites = true;
+    channel.emit('drain'); // no-op, listener removed
+    session.write('c'); // ignored, session closed
+    expect(channel.writes).toEqual(['a']);
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/ssh2-pty.ts
+++ b/apps/emdash-desktop/src/main/core/pty/ssh2-pty.ts
@@ -17,6 +17,15 @@ export interface Ssh2SpawnOptions extends PtyDimensions {
 
 export class Ssh2PtySession implements Pty {
   readonly id: string;
+  /**
+   * Input deferred while the ssh2 channel's send buffer is full. Without this,
+   * `write()` ignored `channel.write()`'s return value and kept blasting the
+   * channel — a tmux mouse drag floods SGR reports faster than the remote can
+   * drain, freezing the panel and the remote tmux server. See issue #1994.
+   */
+  private readonly pendingWrites: string[] = [];
+  private draining = false;
+  private closed = false;
 
   constructor(
     id: string,
@@ -26,8 +35,30 @@ export class Ssh2PtySession implements Pty {
   }
 
   write(data: string): void {
-    this.channel.write(data);
+    if (this.closed) return;
+    if (this.draining) {
+      this.pendingWrites.push(data);
+      return;
+    }
+    // `write()` returning false means the buffer is over its high-water mark:
+    // the data is still queued by ssh2, but we must stop writing until `drain`.
+    if (!this.channel.write(data)) {
+      this.draining = true;
+      this.channel.once('drain', this.onDrain);
+    }
   }
+
+  private readonly onDrain = (): void => {
+    this.draining = false;
+    while (!this.closed && this.pendingWrites.length > 0) {
+      const chunk = this.pendingWrites.shift()!;
+      if (!this.channel.write(chunk)) {
+        this.draining = true;
+        this.channel.once('drain', this.onDrain);
+        return;
+      }
+    }
+  };
 
   resize(cols: number, rows: number): void {
     try {
@@ -42,6 +73,9 @@ export class Ssh2PtySession implements Pty {
   }
 
   kill(): void {
+    this.closed = true;
+    this.pendingWrites.length = 0;
+    this.channel.removeListener('drain', this.onDrain);
     try {
       this.channel.close();
     } catch {}


### PR DESCRIPTION
## Problem

`Ssh2PtySession.write()` ignored the boolean returned by ssh2's `channel.write()`, so it kept writing even when the channel's send buffer was over its high-water mark. A tmux mouse drag (mouse mode is on by default) floods SGR mouse reports faster than the remote can drain; with no backpressure this froze the PTY panel and the remote tmux server, requiring an app restart.

Fixes #1994.

## Fix

Respect the stream contract in `Ssh2PtySession`:

- when `channel.write()` returns `false` (buffer over high-water mark), defer further input and flush it on the next `drain` event, in order;
- the normal path (`write()` returns `true`) is unchanged — no queueing, no added latency;
- `kill()` drops any deferred input and detaches the `drain` listener so nothing is written to a closed channel.

## Testing

`format` / `lint` / `typecheck` clean; unit tests cover the deferral/flush ordering, repeated drains while still full, and the kill-while-draining path (plus the existing wrap-semantics test).

The fix targets the missing-backpressure root cause called out in the issue. I couldn't reproduce the exact freeze locally — it needs a GUI mouse drag over SSH, and triggering it risks hanging a shared tmux server — so confirmation from the reporter would be welcome.