### PR TITLE
fix(tasks): make delete confirmation quicker

### DIFF
--- a/apps/emdash-desktop/src/main/core/tasks/operations/delete-preflight-status.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/delete-preflight-status.test.ts
@@ -1,0 +1,38 @@
+import type { GitStatusModel } from '@emdash/core/git';
+import { describe, expect, it } from 'vitest';
+import { hasUncommittedStatusChanges } from './delete-preflight-status';
+
+const cleanStatus: GitStatusModel = {
+  kind: 'ok',
+  staged: [],
+  unstaged: [],
+  stagedAdded: 0,
+  stagedDeleted: 0,
+};
+
+describe('hasUncommittedStatusChanges', () => {
+  it('detects staged or unstaged changes', () => {
+    expect(
+      hasUncommittedStatusChanges({
+        ...cleanStatus,
+        unstaged: [{ path: 'src/app.ts', status: 'modified', additions: 1, deletions: 0 }],
+      })
+    ).toBe(true);
+
+    expect(
+      hasUncommittedStatusChanges({
+        ...cleanStatus,
+        staged: [{ path: 'src/app.ts', status: 'modified', additions: 1, deletions: 0 }],
+      })
+    ).toBe(true);
+  });
+
+  it('treats clean and error statuses as not dirty', () => {
+    expect(hasUncommittedStatusChanges(cleanStatus)).toBe(false);
+    expect(hasUncommittedStatusChanges({ kind: 'error', message: 'git failed' })).toBe(false);
+  });
+
+  it('treats too-many-files as dirty', () => {
+    expect(hasUncommittedStatusChanges({ kind: 'too-many-files' })).toBe(true);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/tasks/operations/delete-preflight-status.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/delete-preflight-status.ts
@@ -1,0 +1,8 @@
+import type { GitStatusModel } from '@emdash/core/git';
+
+export function hasUncommittedStatusChanges(status: GitStatusModel): boolean {
+  if (status.kind === 'too-many-files') return true;
+  if (status.kind !== 'ok') return false;
+
+  return status.staged.length > 0 || status.unstaged.length > 0;
+}

--- a/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/getDeletePreflight.ts
@@ -6,6 +6,7 @@ import { db } from '@main/db/client';
 import { tasks, workspaces } from '@main/db/schema';
 import { log } from '@main/lib/logger';
 import type { DeletePreflightResult, TaskDeletePreflightItem } from '@shared/core/tasks/tasks';
+import { hasUncommittedStatusChanges } from './delete-preflight-status';
 
 async function getTaskPreflight(
   projectId: string,
@@ -60,11 +61,9 @@ async function getTaskPreflight(
                   taskId,
                   error: status.message,
                 });
+              } else {
+                hasUncommittedChanges = hasUncommittedStatusChanges(status);
               }
-              if (status.kind === 'ok') {
-                hasUncommittedChanges = status.staged.length > 0 || status.unstaged.length > 0;
-              }
-              hasUncommittedChanges = status.kind === 'too-many-files';
             } finally {
               worktreeLease.release();
             }

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
@@ -5,8 +5,10 @@ import { observer } from 'mobx-react-lite';
 import { useRef } from 'react';
 import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
-import { getTaskKnownGitChanges } from '@renderer/features/tasks/components/task-git-diff-stats';
-import { getTaskManagerStore } from '@renderer/features/tasks/stores/task-selectors';
+import {
+  getTaskManagerStore,
+  taskHasKnownExclusiveWorkspaceChanges,
+} from '@renderer/features/tasks/stores/task-selectors';
 import { ListPopoverCard } from '@renderer/lib/components/list-popover-card';
 import {
   getEffectiveHotkey,
@@ -178,7 +180,7 @@ export const TaskList = observer(function TaskList() {
       .map((t) => ({
         taskId: t.data.id,
         taskName: t.data.name,
-        hasKnownChanges: getTaskKnownGitChanges(t),
+        hasKnownUncommittedChanges: taskHasKnownExclusiveWorkspaceChanges(t),
       }));
 
     if (selectedTasks.length === 0) return;

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
@@ -5,6 +5,7 @@ import { observer } from 'mobx-react-lite';
 import { useRef } from 'react';
 import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import { getTaskKnownGitChanges } from '@renderer/features/tasks/components/task-git-diff-stats';
 import { getTaskManagerStore } from '@renderer/features/tasks/stores/task-selectors';
 import { ListPopoverCard } from '@renderer/lib/components/list-popover-card';
 import {
@@ -174,7 +175,11 @@ export const TaskList = observer(function TaskList() {
     const selectedTasks = [...taskView.selectedIds]
       .map((id) => taskManager?.tasks.get(id))
       .filter((t): t is ReadyTask => !!t)
-      .map((t) => ({ taskId: t.data.id, taskName: t.data.name }));
+      .map((t) => ({
+        taskId: t.data.id,
+        taskName: t.data.name,
+        hasKnownChanges: getTaskKnownGitChanges(t),
+      }));
 
     if (selectedTasks.length === 0) return;
 

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row.tsx
@@ -2,7 +2,10 @@ import { observer } from 'mobx-react-lite';
 import { useRef } from 'react';
 import { AgentStatusIndicator } from '@renderer/features/tasks/components/agent-status-indicator';
 import { TaskContextMenu } from '@renderer/features/tasks/components/task-context-menu';
-import { TaskGitDiffStats } from '@renderer/features/tasks/components/task-git-diff-stats';
+import {
+  getTaskKnownGitChanges,
+  TaskGitDiffStats,
+} from '@renderer/features/tasks/components/task-git-diff-stats';
 import {
   getTaskGitWorktreeStore,
   getTaskManagerStore,
@@ -42,7 +45,13 @@ export const TaskRow = observer(function TaskRow({
   const handleDelete = () =>
     showDeleteTask({
       projectId: task.data.projectId,
-      tasks: [{ taskId: task.data.id, taskName: task.data.name }],
+      tasks: [
+        {
+          taskId: task.data.id,
+          taskName: task.data.name,
+          hasKnownChanges: getTaskKnownGitChanges(task),
+        },
+      ],
       onSuccess: ({ deleteWorktree, deleteBranch }) =>
         void taskManager?.deleteTasks([task.data.id], { deleteWorktree, deleteBranch }),
     });

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-row.tsx
@@ -2,13 +2,11 @@ import { observer } from 'mobx-react-lite';
 import { useRef } from 'react';
 import { AgentStatusIndicator } from '@renderer/features/tasks/components/agent-status-indicator';
 import { TaskContextMenu } from '@renderer/features/tasks/components/task-context-menu';
-import {
-  getTaskKnownGitChanges,
-  TaskGitDiffStats,
-} from '@renderer/features/tasks/components/task-git-diff-stats';
+import { TaskGitDiffStats } from '@renderer/features/tasks/components/task-git-diff-stats';
 import {
   getTaskGitWorktreeStore,
   getTaskManagerStore,
+  taskHasKnownExclusiveWorkspaceChanges,
   taskAgentStatus,
 } from '@renderer/features/tasks/stores/task-selectors';
 import { type TaskStore } from '@renderer/features/tasks/stores/task-store';
@@ -49,7 +47,7 @@ export const TaskRow = observer(function TaskRow({
         {
           taskId: task.data.id,
           taskName: task.data.name,
-          hasKnownChanges: getTaskKnownGitChanges(task),
+          hasKnownUncommittedChanges: taskHasKnownExclusiveWorkspaceChanges(task),
         },
       ],
       onSuccess: ({ deleteWorktree, deleteBranch }) =>

--- a/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
@@ -1,15 +1,13 @@
 import { observer } from 'mobx-react-lite';
 import { TaskSidebarTrailingSlot } from '@renderer/features/sidebar/task-sidebar-agent-status';
 import { TaskContextMenu } from '@renderer/features/tasks/components/task-context-menu';
-import {
-  getTaskKnownGitChanges,
-  TaskGitDiffStats,
-} from '@renderer/features/tasks/components/task-git-diff-stats';
+import { TaskGitDiffStats } from '@renderer/features/tasks/components/task-git-diff-stats';
 import {
   getTaskGitWorktreeStore,
   getTaskManagerStore,
   getTaskStore,
   getWorkspaceForTask,
+  taskHasKnownExclusiveWorkspaceChanges,
 } from '@renderer/features/tasks/stores/task-selectors';
 import { type TaskStore } from '@renderer/features/tasks/stores/task-store';
 import {
@@ -71,7 +69,13 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
   const handleDelete = () =>
     showDeleteTask({
       projectId,
-      tasks: [{ taskId, taskName, hasKnownChanges: getTaskKnownGitChanges(task) }],
+      tasks: [
+        {
+          taskId,
+          taskName,
+          hasKnownUncommittedChanges: taskHasKnownExclusiveWorkspaceChanges(task),
+        },
+      ],
       onSuccess: ({ deleteWorktree, deleteBranch }) => {
         void taskManager?.deleteTasks([taskId], { deleteWorktree, deleteBranch });
         if (isActive) navigate('project', { projectId });

--- a/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
@@ -1,7 +1,10 @@
 import { observer } from 'mobx-react-lite';
 import { TaskSidebarTrailingSlot } from '@renderer/features/sidebar/task-sidebar-agent-status';
 import { TaskContextMenu } from '@renderer/features/tasks/components/task-context-menu';
-import { TaskGitDiffStats } from '@renderer/features/tasks/components/task-git-diff-stats';
+import {
+  getTaskKnownGitChanges,
+  TaskGitDiffStats,
+} from '@renderer/features/tasks/components/task-git-diff-stats';
 import {
   getTaskGitWorktreeStore,
   getTaskManagerStore,
@@ -68,7 +71,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
   const handleDelete = () =>
     showDeleteTask({
       projectId,
-      tasks: [{ taskId, taskName }],
+      tasks: [{ taskId, taskName, hasKnownChanges: getTaskKnownGitChanges(task) }],
       onSuccess: ({ deleteWorktree, deleteBranch }) => {
         void taskManager?.deleteTasks([taskId], { deleteWorktree, deleteBranch });
         if (isActive) navigate('project', { projectId });

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/task-git-diff-stats.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/task-git-diff-stats.tsx
@@ -21,6 +21,17 @@ export function useTaskGitDiffStats(task: TaskStore): {
   return { linesAdded, linesDeleted, visible };
 }
 
+export function getTaskKnownGitChanges(task: TaskStore): boolean {
+  const projectId = isRegistered(task) ? task.data.projectId : undefined;
+  const git = projectId ? getTaskGitWorktreeStore(projectId, task.data.id) : undefined;
+  if (git) {
+    return !git.error && git.fileChanges.length > 0;
+  }
+
+  const cachedGit = isRegistered(task) ? task.data.workspaceGit : undefined;
+  return !!cachedGit && (cachedGit.linesAdded > 0 || cachedGit.linesDeleted > 0);
+}
+
 /**
  * Working-tree line add/remove totals for a task.
  * Uses live GitWorktreeStore data when the task is provisioned; falls back to the

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/task-git-diff-stats.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/task-git-diff-stats.tsx
@@ -21,17 +21,6 @@ export function useTaskGitDiffStats(task: TaskStore): {
   return { linesAdded, linesDeleted, visible };
 }
 
-export function getTaskKnownGitChanges(task: TaskStore): boolean {
-  const projectId = isRegistered(task) ? task.data.projectId : undefined;
-  const git = projectId ? getTaskGitWorktreeStore(projectId, task.data.id) : undefined;
-  if (git) {
-    return !git.error && git.fileChanges.length > 0;
-  }
-
-  const cachedGit = isRegistered(task) ? task.data.workspaceGit : undefined;
-  return !!cachedGit && (cachedGit.linesAdded > 0 || cachedGit.linesDeleted > 0);
-}
-
 /**
  * Working-tree line add/remove totals for a task.
  * Uses live GitWorktreeStore data when the task is provisioned; falls back to the

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
@@ -34,6 +34,19 @@ vi.mock('@renderer/lib/ui/dialog', async () => {
   };
 });
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((res) => {
+    resolve = res;
+  });
+  return { promise, resolve };
+}
+
+async function flushPromises() {
+  await Promise.resolve();
+  await Promise.resolve();
+}
+
 describe('DeleteTaskModal', () => {
   let dom: JSDOM;
   let root: Root;
@@ -58,8 +71,9 @@ describe('DeleteTaskModal', () => {
     dom.window.close();
   });
 
-  it('allows confirming before delete preflight finishes', () => {
-    mocks.getDeletePreflight.mockReturnValue(new Promise(() => {}));
+  it('keeps delete enabled and completes once pending preflight is clean', async () => {
+    const pendingPreflight = deferred<{ tasks: [] }>();
+    mocks.getDeletePreflight.mockReturnValue(pendingPreflight.promise);
     const onSuccess = vi.fn();
 
     act(() => {
@@ -86,6 +100,14 @@ describe('DeleteTaskModal', () => {
       deleteButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
     });
 
+    expect(onSuccess).not.toHaveBeenCalled();
+
+    await act(async () => {
+      pendingPreflight.resolve({ tasks: [] });
+      await pendingPreflight.promise;
+      await flushPromises();
+    });
+
     expect(onSuccess).toHaveBeenCalledWith({ deleteWorktree: true, deleteBranch: false });
   });
 
@@ -106,5 +128,70 @@ describe('DeleteTaskModal', () => {
     expect(container.textContent).toContain(
       '"Dirty task" has uncommitted changes that will be lost.'
     );
+  });
+
+  it('requires a second confirm when pending preflight discovers dirty changes', async () => {
+    const pendingPreflight = deferred<{
+      tasks: [
+        {
+          taskId: string;
+          hasWorktree: boolean;
+          hasUncommittedChanges: boolean;
+          hasDeletableBranch: boolean;
+        },
+      ];
+    }>();
+    mocks.getDeletePreflight.mockReturnValue(pendingPreflight.promise);
+    const onSuccess = vi.fn();
+
+    act(() => {
+      root.render(
+        React.createElement(DeleteTaskModal, {
+          projectId: 'project-1',
+          tasks: [{ taskId: 'task-1', taskName: 'Late dirty task' }],
+          onSuccess,
+          onClose: vi.fn(),
+        })
+      );
+    });
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Delete')
+    );
+
+    act(() => {
+      deleteButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    await act(async () => {
+      pendingPreflight.resolve({
+        tasks: [
+          {
+            taskId: 'task-1',
+            hasWorktree: true,
+            hasUncommittedChanges: true,
+            hasDeletableBranch: false,
+          },
+        ],
+      });
+      await pendingPreflight.promise;
+      await flushPromises();
+    });
+
+    expect(onSuccess).not.toHaveBeenCalled();
+    expect(container.textContent).toContain(
+      '"Late dirty task" has uncommitted changes that will be lost.'
+    );
+    expect(container.textContent).toContain('Delete anyway');
+
+    const deleteAnywayButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Delete anyway')
+    );
+
+    act(() => {
+      deleteAnywayButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith({ deleteWorktree: true, deleteBranch: false });
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
@@ -113,13 +113,14 @@ describe('DeleteTaskModal', () => {
 
   it('shows known dirty changes before delete preflight finishes', () => {
     mocks.getDeletePreflight.mockReturnValue(new Promise(() => {}));
+    const onSuccess = vi.fn();
 
     act(() => {
       root.render(
         React.createElement(DeleteTaskModal, {
           projectId: 'project-1',
           tasks: [{ taskId: 'task-1', taskName: 'Dirty task', hasKnownUncommittedChanges: true }],
-          onSuccess: vi.fn(),
+          onSuccess,
           onClose: vi.fn(),
         })
       );
@@ -128,6 +129,17 @@ describe('DeleteTaskModal', () => {
     expect(container.textContent).toContain(
       '"Dirty task" has uncommitted changes that will be lost.'
     );
+    expect(container.textContent).toContain('Delete anyway');
+
+    const deleteAnywayButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Delete anyway')
+    );
+
+    act(() => {
+      deleteAnywayButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith({ deleteWorktree: true, deleteBranch: false });
   });
 
   it('requires a second confirm when pending preflight discovers dirty changes', async () => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
@@ -86,4 +86,23 @@ describe('DeleteTaskModal', () => {
 
     expect(onSuccess).toHaveBeenCalledWith({ deleteWorktree: true, deleteBranch: false });
   });
+
+  it('shows known dirty changes before delete preflight finishes', () => {
+    mocks.getDeletePreflight.mockReturnValue(new Promise(() => {}));
+
+    act(() => {
+      root.render(
+        React.createElement(DeleteTaskModal, {
+          projectId: 'project-1',
+          tasks: [{ taskId: 'task-1', taskName: 'Dirty task', hasKnownChanges: true }],
+          onSuccess: vi.fn(),
+          onClose: vi.fn(),
+        })
+      );
+    });
+
+    expect(container.textContent).toContain(
+      '"Dirty task" has uncommitted changes that will be lost.'
+    );
+  });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
@@ -1,0 +1,89 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { DeleteTaskModal } from './delete-task-modal';
+
+const mocks = vi.hoisted(() => ({
+  getDeletePreflight: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    tasks: {
+      getDeletePreflight: mocks.getDeletePreflight,
+    },
+  },
+}));
+
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: () => ({ value: undefined }),
+}));
+
+vi.mock('@renderer/lib/ui/dialog', async () => {
+  const React = await import('react');
+  return {
+    DialogContentArea: ({ children, ...props }: React.ComponentProps<'div'>) =>
+      React.createElement('div', props, children),
+    DialogFooter: ({ children, ...props }: React.ComponentProps<'div'>) =>
+      React.createElement('div', props, children),
+    DialogHeader: ({ children, ...props }: React.ComponentProps<'div'>) =>
+      React.createElement('div', props, children),
+    DialogTitle: ({ children, ...props }: React.ComponentProps<'h2'>) =>
+      React.createElement('h2', props, children),
+  };
+});
+
+describe('DeleteTaskModal', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('MouseEvent', dom.window.MouseEvent);
+    vi.stubGlobal('KeyboardEvent', dom.window.KeyboardEvent);
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+    mocks.getDeletePreflight.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('allows confirming before delete preflight finishes', () => {
+    mocks.getDeletePreflight.mockReturnValue(new Promise(() => {}));
+    const onSuccess = vi.fn();
+
+    act(() => {
+      root.render(
+        React.createElement(DeleteTaskModal, {
+          projectId: 'project-1',
+          tasks: [{ taskId: 'task-1', taskName: 'Slow task' }],
+          onSuccess,
+          onClose: vi.fn(),
+        })
+      );
+    });
+
+    const deleteButton = Array.from(container.querySelectorAll('button')).find((button) =>
+      button.textContent?.includes('Delete')
+    );
+
+    expect(deleteButton).toBeDefined();
+    expect(deleteButton?.hasAttribute('disabled')).toBe(false);
+
+    act(() => {
+      deleteButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onSuccess).toHaveBeenCalledWith({ deleteWorktree: true, deleteBranch: false });
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
@@ -94,7 +94,7 @@ describe('DeleteTaskModal', () => {
       root.render(
         React.createElement(DeleteTaskModal, {
           projectId: 'project-1',
-          tasks: [{ taskId: 'task-1', taskName: 'Dirty task', hasKnownChanges: true }],
+          tasks: [{ taskId: 'task-1', taskName: 'Dirty task', hasKnownUncommittedChanges: true }],
           onSuccess: vi.fn(),
           onClose: vi.fn(),
         })

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
@@ -79,7 +79,8 @@ describe('DeleteTaskModal', () => {
 
     expect(deleteButton).toBeDefined();
     expect(deleteButton?.hasAttribute('disabled')).toBe(false);
-    expect(container.textContent).toContain('Checking for uncommitted changes…');
+    expect(container.textContent).toContain('Delete worktree');
+    expect(container.textContent).not.toContain('Checking');
 
     act(() => {
       deleteButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.test.ts
@@ -79,6 +79,7 @@ describe('DeleteTaskModal', () => {
 
     expect(deleteButton).toBeDefined();
     expect(deleteButton?.hasAttribute('disabled')).toBe(false);
+    expect(container.textContent).toContain('Checking for uncommitted changes…');
 
     act(() => {
       deleteButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -1,3 +1,4 @@
+import { AnimatePresence, motion } from 'framer-motion';
 import { TriangleAlert } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { rpc } from '@renderer/lib/ipc';
@@ -89,10 +90,19 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   })();
 
   const dirtyWarningNode = showDirtyWarning && dirtyWarning && (
-    <div className="flex items-start gap-1.5 rounded-md bg-background-warning px-3 py-2 text-xs text-foreground-warning">
-      <TriangleAlert className="mt-px size-3.5 shrink-0" />
-      <span>{dirtyWarning}</span>
-    </div>
+    <motion.div
+      key="dirty-warning"
+      initial={{ height: 0, opacity: 0, y: -4 }}
+      animate={{ height: 'auto', opacity: 1, y: 0 }}
+      exit={{ height: 0, opacity: 0, y: -4 }}
+      transition={{ duration: 0.16, ease: 'easeOut' }}
+      className="overflow-hidden"
+    >
+      <div className="flex items-start gap-1.5 rounded-md bg-background-warning px-3 py-2 text-xs text-foreground-warning">
+        <TriangleAlert className="mt-px size-3.5 shrink-0" />
+        <span>{dirtyWarning}</span>
+      </div>
+    </motion.div>
   );
 
   return (
@@ -116,7 +126,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
             {isLoading ? (isBulk ? 'Delete worktrees' : 'Delete worktree') : worktreeLabel}
           </label>
 
-          {dirtyWarningNode}
+          <AnimatePresence initial={false}>{dirtyWarningNode}</AnimatePresence>
 
           <label
             className="flex items-center gap-2 text-sm aria-disabled:cursor-default aria-disabled:text-foreground-muted"

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -88,6 +88,18 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
     return `${dirtyTasks.length} ${dirtyTasks.length === 1 ? 'task has' : 'tasks have'} uncommitted changes that will be lost: ${names}`;
   })();
 
+  const dirtyWarningNode = showDirtyWarning && dirtyWarning && (
+    <div className="flex items-start gap-1.5 rounded-md bg-background-warning px-3 py-2 text-xs text-foreground-warning">
+      <TriangleAlert className="mt-px size-3.5 shrink-0" />
+      <span>{dirtyWarning}</span>
+    </div>
+  );
+
+  const noWorktreeLabel = isBulk
+    ? 'No separate worktrees to delete'
+    : 'No separate worktree to delete';
+  const noBranchLabel = isBulk ? 'No branches to delete' : 'No branch to delete';
+
   return (
     <>
       <DialogHeader showCloseButton={false}>
@@ -96,42 +108,64 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
       <DialogContentArea className="flex flex-col gap-4 pt-0">
         <p className="text-sm text-foreground-muted">{description}</p>
 
-        {(showWorktreeCheckbox || showBranchCheckbox || showDirtyWarning) && (
-          <div className="flex flex-col gap-3">
-            {showWorktreeCheckbox && (
-              <div className="flex flex-col gap-2">
-                <label className="flex cursor-pointer items-center gap-2 text-sm">
-                  <Checkbox
-                    checked={deleteWorktree}
-                    onCheckedChange={(checked) => handleWorktreeChange(Boolean(checked))}
-                  />
-                  {worktreeLabel}
-                </label>
-              </div>
-            )}
-
-            {showDirtyWarning && dirtyWarning && (
-              <div className="flex items-start gap-1.5 rounded-md bg-background-warning px-3 py-2 text-xs text-foreground-warning">
-                <TriangleAlert className="mt-px size-3.5 shrink-0" />
-                <span>{dirtyWarning}</span>
-              </div>
-            )}
-
-            {showBranchCheckbox && (
-              <label
-                className="flex cursor-pointer items-center gap-2 text-sm aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-                aria-disabled={!deleteWorktree}
-              >
+        <div className="flex flex-col gap-3" aria-live="polite">
+          {isLoading ? (
+            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
+              <Checkbox checked={deleteWorktree} disabled />
+              {isBulk ? 'Delete worktrees' : 'Delete worktree'}
+              <span className="ml-auto text-xs text-foreground-tertiary-muted">Checking…</span>
+            </label>
+          ) : showWorktreeCheckbox ? (
+            <div className="flex flex-col gap-2">
+              <label className="flex cursor-pointer items-center gap-2 text-sm">
                 <Checkbox
-                  checked={deleteBranch}
-                  onCheckedChange={(checked) => setDeleteBranch(Boolean(checked))}
-                  disabled={!deleteWorktree}
+                  checked={deleteWorktree}
+                  onCheckedChange={(checked) => handleWorktreeChange(Boolean(checked))}
                 />
-                {branchLabel}
+                {worktreeLabel}
               </label>
-            )}
-          </div>
-        )}
+            </div>
+          ) : (
+            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
+              <Checkbox checked={false} disabled />
+              {noWorktreeLabel}
+            </label>
+          )}
+
+          {dirtyWarningNode || (
+            <div className="flex items-start gap-1.5 rounded-md bg-background-1 px-3 py-2 text-xs text-foreground-muted">
+              <TriangleAlert className="mt-px size-3.5 shrink-0 opacity-50" />
+              <span>
+                {isLoading ? 'Checking for uncommitted changes…' : 'No uncommitted changes found'}
+              </span>
+            </div>
+          )}
+
+          {isLoading ? (
+            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
+              <Checkbox checked={false} disabled />
+              {isBulk ? 'Delete branches' : 'Delete branch'}
+              <span className="ml-auto text-xs text-foreground-tertiary-muted">Checking…</span>
+            </label>
+          ) : showBranchCheckbox ? (
+            <label
+              className="flex cursor-pointer items-center gap-2 text-sm aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
+              aria-disabled={!deleteWorktree}
+            >
+              <Checkbox
+                checked={deleteBranch}
+                onCheckedChange={(checked) => setDeleteBranch(Boolean(checked))}
+                disabled={!deleteWorktree}
+              />
+              {branchLabel}
+            </label>
+          ) : (
+            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
+              <Checkbox checked={false} disabled />
+              {noBranchLabel}
+            </label>
+          )}
+        </div>
       </DialogContentArea>
       <DialogFooter>
         <Button variant="outline" onClick={onClose}>

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -133,10 +133,9 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
         </Button>
         <ConfirmButton
           variant="destructive"
-          disabled={isLoading}
           onClick={() => onSuccess({ deleteWorktree, deleteBranch })}
         >
-          {isLoading ? 'Loading...' : isBulk ? `Delete ${count} tasks` : 'Delete'}
+          {isBulk ? `Delete ${count} tasks` : 'Delete'}
         </ConfirmButton>
       </DialogFooter>
     </>

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -15,7 +15,7 @@ import type { TaskDeletePreflightItem } from '@shared/core/tasks/tasks';
 
 export type DeleteTaskModalArgs = {
   projectId: string;
-  tasks: Array<{ taskId: string; taskName: string; hasKnownChanges?: boolean }>;
+  tasks: Array<{ taskId: string; taskName: string; hasKnownUncommittedChanges?: boolean }>;
 };
 
 export type DeleteTaskModalResult = {
@@ -47,7 +47,9 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   const isLoading = preflight === null;
 
   const worktreeTasks = preflight?.filter((t) => t.hasWorktree) ?? [];
-  const dirtyTaskIds = new Set(tasks.filter((t) => t.hasKnownChanges).map((t) => t.taskId));
+  const dirtyTaskIds = new Set(
+    tasks.filter((t) => t.hasKnownUncommittedChanges).map((t) => t.taskId)
+  );
   for (const task of preflight ?? []) {
     if (task.hasUncommittedChanges) dirtyTaskIds.add(task.taskId);
   }

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -1,6 +1,6 @@
 import { AnimatePresence, motion } from 'framer-motion';
 import { TriangleAlert } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useEffect, useMemo, useRef, useState } from 'react';
 import { rpc } from '@renderer/lib/ipc';
 import type { BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
@@ -30,6 +30,9 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   const [preflight, setPreflight] = useState<TaskDeletePreflightItem[] | null>(null);
   const [deleteWorktree, setDeleteWorktree] = useState(true);
   const [deleteBranch, setDeleteBranch] = useState(false);
+  const [isResolvingDelete, setIsResolvingDelete] = useState(false);
+  const [needsDirtyConfirm, setNeedsDirtyConfirm] = useState(false);
+  const preflightPromiseRef = useRef<Promise<TaskDeletePreflightItem[]> | null>(null);
 
   const count = tasks.length;
   const isBulk = count > 1;
@@ -38,23 +41,28 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   const taskIds = useMemo(() => tasks.map((t) => t.taskId), [tasks]);
 
   useEffect(() => {
-    rpc.tasks.getDeletePreflight(projectId, taskIds).then(
-      (result) => setPreflight(result.tasks),
-      // On error, allow the modal to proceed without preflight info (no checkboxes shown).
-      () => setPreflight([])
+    const promise = rpc.tasks.getDeletePreflight(projectId, taskIds).then(
+      (result) => result.tasks,
+      // On error, allow the modal to proceed without preflight info.
+      () => []
     );
+    preflightPromiseRef.current = promise;
+    void promise.then((items) => setPreflight(items));
   }, [projectId, taskIds]);
 
   const isLoading = preflight === null;
 
   const worktreeTasks = preflight?.filter((t) => t.hasWorktree) ?? [];
-  const dirtyTaskIds = new Set(
-    tasks.filter((t) => t.hasKnownUncommittedChanges).map((t) => t.taskId)
-  );
-  for (const task of preflight ?? []) {
-    if (task.hasUncommittedChanges) dirtyTaskIds.add(task.taskId);
-  }
-  const dirtyTasks = tasks.filter((t) => dirtyTaskIds.has(t.taskId));
+  const dirtyTasksFor = (items: TaskDeletePreflightItem[] | null) => {
+    const dirtyTaskIds = new Set(
+      tasks.filter((t) => t.hasKnownUncommittedChanges).map((t) => t.taskId)
+    );
+    for (const task of items ?? []) {
+      if (task.hasUncommittedChanges) dirtyTaskIds.add(task.taskId);
+    }
+    return tasks.filter((t) => dirtyTaskIds.has(t.taskId));
+  };
+  const dirtyTasks = dirtyTasksFor(preflight);
   const branchTasks = preflight?.filter((t) => t.hasDeletableBranch) ?? [];
 
   const showWorktreeCheckbox = !isLoading && worktreeTasks.length > 0;
@@ -63,7 +71,29 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
 
   const handleWorktreeChange = (checked: boolean) => {
     setDeleteWorktree(checked);
+    setNeedsDirtyConfirm(false);
     if (!checked) setDeleteBranch(false);
+  };
+
+  const handleConfirm = async () => {
+    if (isResolvingDelete) return;
+
+    if (!deleteWorktree || dirtyTasks.length > 0 || preflight !== null) {
+      onSuccess({ deleteWorktree, deleteBranch });
+      return;
+    }
+
+    setIsResolvingDelete(true);
+    const items = await (preflightPromiseRef.current ?? Promise.resolve([]));
+    setIsResolvingDelete(false);
+    setPreflight(items);
+
+    if (dirtyTasksFor(items).length > 0) {
+      setNeedsDirtyConfirm(true);
+      return;
+    }
+
+    onSuccess({ deleteWorktree, deleteBranch });
   };
 
   const title = isBulk ? `Delete ${count} tasks` : 'Delete task';
@@ -147,9 +177,16 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
         </Button>
         <ConfirmButton
           variant="destructive"
-          onClick={() => onSuccess({ deleteWorktree, deleteBranch })}
+          disabled={isResolvingDelete}
+          onClick={() => void handleConfirm()}
         >
-          {isBulk ? `Delete ${count} tasks` : 'Delete'}
+          {isResolvingDelete
+            ? 'Verifying…'
+            : needsDirtyConfirm && showDirtyWarning
+              ? 'Delete anyway'
+              : isBulk
+                ? `Delete ${count} tasks`
+                : 'Delete'}
         </ConfirmButton>
       </DialogFooter>
     </>

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -95,11 +95,6 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
     </div>
   );
 
-  const noWorktreeLabel = isBulk
-    ? 'No separate worktrees to delete'
-    : 'No separate worktree to delete';
-  const noBranchLabel = isBulk ? 'No branches to delete' : 'No branch to delete';
-
   return (
     <>
       <DialogHeader showCloseButton={false}>
@@ -109,62 +104,31 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
         <p className="text-sm text-foreground-muted">{description}</p>
 
         <div className="flex flex-col gap-3" aria-live="polite">
-          {isLoading ? (
-            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
-              <Checkbox checked={deleteWorktree} disabled />
-              {isBulk ? 'Delete worktrees' : 'Delete worktree'}
-              <span className="ml-auto text-xs text-foreground-tertiary-muted">Checking…</span>
-            </label>
-          ) : showWorktreeCheckbox ? (
-            <div className="flex flex-col gap-2">
-              <label className="flex cursor-pointer items-center gap-2 text-sm">
-                <Checkbox
-                  checked={deleteWorktree}
-                  onCheckedChange={(checked) => handleWorktreeChange(Boolean(checked))}
-                />
-                {worktreeLabel}
-              </label>
-            </div>
-          ) : (
-            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
-              <Checkbox checked={false} disabled />
-              {noWorktreeLabel}
-            </label>
-          )}
+          <label
+            className="flex items-center gap-2 text-sm aria-disabled:cursor-default aria-disabled:text-foreground-muted"
+            aria-disabled={isLoading || !showWorktreeCheckbox}
+          >
+            <Checkbox
+              checked={isLoading ? deleteWorktree : showWorktreeCheckbox && deleteWorktree}
+              onCheckedChange={(checked) => handleWorktreeChange(Boolean(checked))}
+              disabled={isLoading || !showWorktreeCheckbox}
+            />
+            {isLoading ? (isBulk ? 'Delete worktrees' : 'Delete worktree') : worktreeLabel}
+          </label>
 
-          {dirtyWarningNode || (
-            <div className="flex items-start gap-1.5 rounded-md bg-background-1 px-3 py-2 text-xs text-foreground-muted">
-              <TriangleAlert className="mt-px size-3.5 shrink-0 opacity-50" />
-              <span>
-                {isLoading ? 'Checking for uncommitted changes…' : 'No uncommitted changes found'}
-              </span>
-            </div>
-          )}
+          {dirtyWarningNode}
 
-          {isLoading ? (
-            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
-              <Checkbox checked={false} disabled />
-              {isBulk ? 'Delete branches' : 'Delete branch'}
-              <span className="ml-auto text-xs text-foreground-tertiary-muted">Checking…</span>
-            </label>
-          ) : showBranchCheckbox ? (
-            <label
-              className="flex cursor-pointer items-center gap-2 text-sm aria-disabled:cursor-not-allowed aria-disabled:opacity-50"
-              aria-disabled={!deleteWorktree}
-            >
-              <Checkbox
-                checked={deleteBranch}
-                onCheckedChange={(checked) => setDeleteBranch(Boolean(checked))}
-                disabled={!deleteWorktree}
-              />
-              {branchLabel}
-            </label>
-          ) : (
-            <label className="flex cursor-default items-center gap-2 text-sm text-foreground-muted">
-              <Checkbox checked={false} disabled />
-              {noBranchLabel}
-            </label>
-          )}
+          <label
+            className="flex items-center gap-2 text-sm aria-disabled:cursor-default aria-disabled:text-foreground-muted"
+            aria-disabled={isLoading || !showBranchCheckbox || !deleteWorktree}
+          >
+            <Checkbox
+              checked={!isLoading && showBranchCheckbox && deleteBranch}
+              onCheckedChange={(checked) => setDeleteBranch(Boolean(checked))}
+              disabled={isLoading || !showBranchCheckbox || !deleteWorktree}
+            />
+            {isLoading ? (isBulk ? 'Delete branches' : 'Delete branch') : branchLabel}
+          </label>
         </div>
       </DialogContentArea>
       <DialogFooter>

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -15,7 +15,7 @@ import type { TaskDeletePreflightItem } from '@shared/core/tasks/tasks';
 
 export type DeleteTaskModalArgs = {
   projectId: string;
-  tasks: Array<{ taskId: string; taskName: string }>;
+  tasks: Array<{ taskId: string; taskName: string; hasKnownChanges?: boolean }>;
 };
 
 export type DeleteTaskModalResult = {
@@ -47,11 +47,16 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   const isLoading = preflight === null;
 
   const worktreeTasks = preflight?.filter((t) => t.hasWorktree) ?? [];
-  const dirtyTasks = preflight?.filter((t) => t.hasUncommittedChanges) ?? [];
+  const dirtyTaskIds = new Set(tasks.filter((t) => t.hasKnownChanges).map((t) => t.taskId));
+  for (const task of preflight ?? []) {
+    if (task.hasUncommittedChanges) dirtyTaskIds.add(task.taskId);
+  }
+  const dirtyTasks = tasks.filter((t) => dirtyTaskIds.has(t.taskId));
   const branchTasks = preflight?.filter((t) => t.hasDeletableBranch) ?? [];
 
   const showWorktreeCheckbox = !isLoading && worktreeTasks.length > 0;
   const showBranchCheckbox = !isLoading && branchTasks.length > 0;
+  const showDirtyWarning = deleteWorktree && dirtyTasks.length > 0;
 
   const handleWorktreeChange = (checked: boolean) => {
     setDeleteWorktree(checked);
@@ -75,11 +80,9 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   const dirtyWarning = (() => {
     if (dirtyTasks.length === 0) return null;
     if (!isBulk) {
-      return `"${tasks[0]!.taskName}" has uncommitted changes that will be lost.`;
+      return `"${dirtyTasks[0]?.taskName ?? tasks[0]!.taskName}" has uncommitted changes that will be lost.`;
     }
-    const names = dirtyTasks
-      .map((t) => `"${tasks.find((task) => task.taskId === t.taskId)?.taskName ?? t.taskId}"`)
-      .join(', ');
+    const names = dirtyTasks.map((t) => `"${t.taskName}"`).join(', ');
     return `${dirtyTasks.length} ${dirtyTasks.length === 1 ? 'task has' : 'tasks have'} uncommitted changes that will be lost: ${names}`;
   })();
 
@@ -91,7 +94,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
       <DialogContentArea className="flex flex-col gap-4 pt-0">
         <p className="text-sm text-foreground-muted">{description}</p>
 
-        {(showWorktreeCheckbox || showBranchCheckbox) && (
+        {(showWorktreeCheckbox || showBranchCheckbox || showDirtyWarning) && (
           <div className="flex flex-col gap-3">
             {showWorktreeCheckbox && (
               <div className="flex flex-col gap-2">
@@ -102,12 +105,13 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
                   />
                   {worktreeLabel}
                 </label>
-                {deleteWorktree && dirtyWarning && (
-                  <div className="flex items-start gap-1.5 rounded-md bg-background-warning px-3 py-2 text-xs text-foreground-warning">
-                    <TriangleAlert className="mt-px size-3.5 shrink-0" />
-                    <span>{dirtyWarning}</span>
-                  </div>
-                )}
+              </div>
+            )}
+
+            {showDirtyWarning && dirtyWarning && (
+              <div className="flex items-start gap-1.5 rounded-md bg-background-warning px-3 py-2 text-xs text-foreground-warning">
+                <TriangleAlert className="mt-px size-3.5 shrink-0" />
+                <span>{dirtyWarning}</span>
               </div>
             )}
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -31,7 +31,6 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   const [deleteWorktree, setDeleteWorktree] = useState(true);
   const [deleteBranch, setDeleteBranch] = useState(false);
   const [isResolvingDelete, setIsResolvingDelete] = useState(false);
-  const [needsDirtyConfirm, setNeedsDirtyConfirm] = useState(false);
   const preflightPromiseRef = useRef<Promise<TaskDeletePreflightItem[]> | null>(null);
 
   const count = tasks.length;
@@ -71,7 +70,6 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
 
   const handleWorktreeChange = (checked: boolean) => {
     setDeleteWorktree(checked);
-    setNeedsDirtyConfirm(false);
     if (!checked) setDeleteBranch(false);
   };
 
@@ -88,10 +86,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
     setIsResolvingDelete(false);
     setPreflight(items);
 
-    if (dirtyTasksFor(items).length > 0) {
-      setNeedsDirtyConfirm(true);
-      return;
-    }
+    if (dirtyTasksFor(items).length > 0) return;
 
     onSuccess({ deleteWorktree, deleteBranch });
   };
@@ -145,7 +140,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
 
         <div className="flex flex-col gap-3" aria-live="polite">
           <label
-            className="flex items-center gap-2 text-sm aria-disabled:cursor-default aria-disabled:text-foreground-muted"
+            className="flex cursor-pointer items-center gap-2 text-sm aria-disabled:cursor-default aria-disabled:text-foreground-muted"
             aria-disabled={isLoading || !showWorktreeCheckbox}
           >
             <Checkbox
@@ -159,7 +154,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
           <AnimatePresence initial={false}>{dirtyWarningNode}</AnimatePresence>
 
           <label
-            className="flex items-center gap-2 text-sm aria-disabled:cursor-default aria-disabled:text-foreground-muted"
+            className="flex cursor-pointer items-center gap-2 text-sm aria-disabled:cursor-default aria-disabled:text-foreground-muted"
             aria-disabled={isLoading || !showBranchCheckbox || !deleteWorktree}
           >
             <Checkbox
@@ -182,7 +177,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
         >
           {isResolvingDelete
             ? 'Verifying…'
-            : needsDirtyConfirm && showDirtyWarning
+            : showDirtyWarning
               ? 'Delete anyway'
               : isBulk
                 ? `Delete ${count} tasks`

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.test.ts
@@ -114,6 +114,34 @@ describe('GitWorktreeStore', () => {
     store.dispose();
   });
 
+  it('exposes known changes for normal and too-large dirty statuses', async () => {
+    mocks.getWorktreeSnapshot.mockResolvedValue(snapshot(status(['src/a.ts'])));
+
+    const store = createStore();
+    store.start();
+
+    await vi.waitFor(() => expect(store.hasKnownChanges).toBe(true));
+
+    for (const handler of worktreeHandlers) {
+      handler({
+        projectId: 'project-1',
+        workspaceId: 'workspace-1',
+        update: { kind: 'status', model: status(), sequence: 2, generation: 1 },
+      });
+    }
+    expect(store.hasKnownChanges).toBe(false);
+
+    for (const handler of worktreeHandlers) {
+      handler({
+        projectId: 'project-1',
+        workspaceId: 'workspace-1',
+        update: { kind: 'status', model: { kind: 'too-many-files' }, sequence: 3, generation: 1 },
+      });
+    }
+    expect(store.hasKnownChanges).toBe(true);
+    store.dispose();
+  });
+
   it('ignores pushed updates for another workspace', async () => {
     mocks.getWorktreeSnapshot.mockResolvedValue(snapshot(status(['src/a.ts'])));
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
@@ -107,6 +107,7 @@ export class GitWorktreeStore {
       unstagedFileChanges: computed,
       totalLinesAdded: computed,
       totalLinesDeleted: computed,
+      hasKnownChanges: computed,
       hasData: computed,
       isLoading: computed,
       error: computed,
@@ -200,6 +201,13 @@ export class GitWorktreeStore {
     return (
       status.stagedDeleted + status.unstaged.reduce((sum, change) => sum + change.deletions, 0)
     );
+  }
+
+  get hasKnownChanges(): boolean {
+    const status = this.effectiveStatus;
+    if (status?.kind === 'too-many-files') return true;
+    if (status?.kind !== 'ok') return false;
+    return status.staged.length > 0 || status.unstaged.length > 0;
   }
 
   get hasData(): boolean {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
@@ -82,7 +82,7 @@ export function taskHasKnownExclusiveWorkspaceChanges(store: TaskStore): boolean
 
   const git = getTaskGitWorktreeStore(store.data.projectId, store.data.id);
   if (git) {
-    return !git.error && git.fileChanges.length > 0;
+    return git.hasKnownChanges;
   }
 
   const cachedGit = store.data.workspaceGit;

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
@@ -7,6 +7,7 @@ import type { Task } from '@shared/core/tasks/tasks';
 import { conversationRegistry } from './conversation-registry';
 import type { TaskManagerStore } from './task-manager';
 import {
+  isRegistered,
   isProvisioned,
   isUnprovisioned,
   isUnregistered,
@@ -57,6 +58,35 @@ export function getTaskGitWorktreeStore(projectId: string, taskId: string) {
   const store = getTaskStore(projectId, taskId);
   if (!store?.workspaceId) return undefined;
   return workspaceRegistry.get(projectId, store.workspaceId)?.gitWorktree;
+}
+
+function registeredWorkspaceId(store: TaskStore): string | undefined {
+  if (!isRegistered(store)) return undefined;
+  return store.workspaceId ?? store.data.workspaceId;
+}
+
+export function taskHasKnownExclusiveWorkspaceChanges(store: TaskStore): boolean {
+  if (!isRegistered(store)) return false;
+
+  const workspaceId = registeredWorkspaceId(store);
+  if (!workspaceId) return false;
+
+  const taskManager = getTaskManagerStore(store.data.projectId);
+  if (!taskManager) return false;
+
+  let workspaceTaskCount = 0;
+  for (const task of taskManager.tasks.values()) {
+    if (registeredWorkspaceId(task) === workspaceId) workspaceTaskCount += 1;
+    if (workspaceTaskCount > 1) return false;
+  }
+
+  const git = getTaskGitWorktreeStore(store.data.projectId, store.data.id);
+  if (git) {
+    return !git.error && git.fileChanges.length > 0;
+  }
+
+  const cachedGit = store.data.workspaceGit;
+  return !!cachedGit && (cachedGit.linesAdded > 0 || cachedGit.linesDeleted > 0);
 }
 
 export function taskAgentStatus(store: TaskStore): AgentStatus | null {


### PR DESCRIPTION
### Description
- makes task deletion clickable immediately while preflight loads
- centralize dirty-status detectionby showing known warnings upfront
- keeps dirty-worktree warnings, inc the "delete anyway" confirmation 

### Screenshot/Recording (if applicable)
https://streamable.com/jy8h4n

when im quicker/my macbook is lagging:
https://streamable.com/gomles

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
