### PR TITLE
fix: preserve terminal scroll across focus change

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-content.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-content.tsx
@@ -8,7 +8,7 @@ const CONTENT_FOCUS_SELECTOR = 'textarea, webview, [contenteditable="true"]';
 
 function focusActiveContentElement(container: HTMLElement): void {
   for (const el of container.querySelectorAll<HTMLElement>(CONTENT_FOCUS_SELECTOR)) {
-    el.focus();
+    el.focus({ preventScroll: true });
     if (document.activeElement === el) return;
   }
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
@@ -14,6 +14,7 @@ import {
 } from '@renderer/features/tasks/task-view-context';
 import { rpc } from '@renderer/lib/ipc';
 import { pastePromptInjection } from '@renderer/lib/pty/prompt-injection';
+import { focusTerminalPreservingScroll } from '@renderer/lib/pty/terminal-scroll-viewport';
 import {
   ContextMenu,
   ContextMenuContent,
@@ -81,7 +82,8 @@ export const ContextBar = observer(function ContextBar({
       await rpc.pty.sendInput(activeSessionId, '\r');
     }
 
-    activeSession?.pty?.terminal.focus();
+    const terminal = activeSession?.pty?.terminal;
+    if (terminal) focusTerminalPreservingScroll(terminal);
   };
 
   const hideContextBar = () => {

--- a/apps/emdash-desktop/src/renderer/lib/pty/pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/pty.ts
@@ -8,6 +8,10 @@ import { ptyDataChannel } from '@shared/core/pty/ptyEvents';
 import { FileLinkProvider, isPrimaryMouseButton } from './file-link-provider';
 import { decodeOsc52ClipboardData } from './pty-clipboard';
 import { buildTerminalFontFamily } from './terminal-font';
+import {
+  captureTerminalScrollViewport,
+  restoreTerminalScrollViewport,
+} from './terminal-scroll-viewport';
 import { ensureXtermHost } from './xterm-host';
 
 const SCROLLBACK_LINES = 100_000;
@@ -188,7 +192,9 @@ export class FrontendPty {
       targetDims &&
       (this.terminal.cols !== targetDims.cols || this.terminal.rows !== targetDims.rows)
     ) {
+      const scrollSnapshot = captureTerminalScrollViewport(this.terminal);
       this.terminal.resize(targetDims.cols, targetDims.rows);
+      restoreTerminalScrollViewport(this.terminal, scrollSnapshot);
     }
     mountTarget.appendChild(this.ownedContainer);
     // Force a Canvas2D repaint after reparenting in the DOM.

--- a/apps/emdash-desktop/src/renderer/lib/pty/terminal-scroll-viewport.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/terminal-scroll-viewport.ts
@@ -16,6 +16,10 @@ type ScrollableTerminal = TerminalWithBuffer & {
   scrollToLine: (line: number) => void;
 };
 
+type FocusableTerminal = ScrollableTerminal & {
+  focus: () => void;
+};
+
 export interface TerminalScrollViewportSnapshot {
   bufferType: TerminalBufferType;
   distanceFromBottom: number;
@@ -42,4 +46,10 @@ export function restoreTerminalScrollViewport(
   if (buffer.viewportY !== targetViewportY) {
     terminal.scrollToLine(targetViewportY);
   }
+}
+
+export function focusTerminalPreservingScroll(terminal: FocusableTerminal): void {
+  const scrollSnapshot = captureTerminalScrollViewport(terminal);
+  terminal.focus();
+  restoreTerminalScrollViewport(terminal, scrollSnapshot);
 }

--- a/apps/emdash-desktop/src/renderer/lib/pty/terminal-scroll-viewport.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/terminal-scroll-viewport.ts
@@ -1,0 +1,45 @@
+import type { Terminal } from '@xterm/xterm';
+
+type TerminalBufferType = Terminal['buffer']['active']['type'];
+
+type TerminalWithBuffer = {
+  buffer: {
+    active: {
+      type: TerminalBufferType;
+      baseY: number;
+      viewportY: number;
+    };
+  };
+};
+
+type ScrollableTerminal = TerminalWithBuffer & {
+  scrollToLine: (line: number) => void;
+};
+
+export interface TerminalScrollViewportSnapshot {
+  bufferType: TerminalBufferType;
+  distanceFromBottom: number;
+}
+
+export function captureTerminalScrollViewport(
+  terminal: TerminalWithBuffer
+): TerminalScrollViewportSnapshot {
+  const buffer = terminal.buffer.active;
+  return {
+    bufferType: buffer.type,
+    distanceFromBottom: Math.max(0, buffer.baseY - buffer.viewportY),
+  };
+}
+
+export function restoreTerminalScrollViewport(
+  terminal: ScrollableTerminal,
+  snapshot: TerminalScrollViewportSnapshot
+): void {
+  const buffer = terminal.buffer.active;
+  if (buffer.type !== snapshot.bufferType) return;
+
+  const targetViewportY = Math.max(0, buffer.baseY - snapshot.distanceFromBottom);
+  if (buffer.viewportY !== targetViewportY) {
+    terminal.scrollToLine(targetViewportY);
+  }
+}

--- a/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
@@ -28,6 +28,7 @@ import { getTerminalContextLink } from './terminal-context-link';
 import { buildTerminalFontFamily } from './terminal-font';
 import {
   captureTerminalScrollViewport,
+  focusTerminalPreservingScroll,
   restoreTerminalScrollViewport,
 } from './terminal-scroll-viewport';
 import { getCellMetrics } from './xterm-cell-metrics';
@@ -291,12 +292,7 @@ export function usePty(
     const term = termRef.current;
     if (!term) return;
 
-    const scrollSnapshot = captureTerminalScrollViewport(term);
-    term.focus();
-    restoreTerminalScrollViewport(term, scrollSnapshot);
-    requestAnimationFrame(() => {
-      if (termRef.current === term) restoreTerminalScrollViewport(term, scrollSnapshot);
-    });
+    focusTerminalPreservingScroll(term);
   }, []);
 
   const copySelectionToClipboard = useCallback(() => {

--- a/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
@@ -26,6 +26,10 @@ import {
 import { createResizeScheduler } from './resize-scheduler';
 import { getTerminalContextLink } from './terminal-context-link';
 import { buildTerminalFontFamily } from './terminal-font';
+import {
+  captureTerminalScrollViewport,
+  restoreTerminalScrollViewport,
+} from './terminal-scroll-viewport';
 import { getCellMetrics } from './xterm-cell-metrics';
 
 const PTY_RESIZE_DEBOUNCE_MS = 120;
@@ -246,7 +250,9 @@ export function usePty(
         const { cols: targetCols, rows: targetRows } = dims;
 
         if (term.cols !== targetCols || term.rows !== targetRows) {
+          const scrollSnapshot = captureTerminalScrollViewport(term);
           term.resize(targetCols, targetRows);
+          restoreTerminalScrollViewport(term, scrollSnapshot);
         }
 
         if (pane) {
@@ -282,7 +288,15 @@ export function usePty(
 
   const focus = useCallback(() => {
     if (document.activeElement?.closest('[role="dialog"]')) return;
-    termRef.current?.focus();
+    const term = termRef.current;
+    if (!term) return;
+
+    const scrollSnapshot = captureTerminalScrollViewport(term);
+    term.focus();
+    restoreTerminalScrollViewport(term, scrollSnapshot);
+    requestAnimationFrame(() => {
+      if (termRef.current === term) restoreTerminalScrollViewport(term, scrollSnapshot);
+    });
   }, []);
 
   const copySelectionToClipboard = useCallback(() => {

--- a/apps/emdash-desktop/src/renderer/tests/terminal-scroll-viewport.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/terminal-scroll-viewport.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import {
   captureTerminalScrollViewport,
+  focusTerminalPreservingScroll,
   restoreTerminalScrollViewport,
 } from '@renderer/lib/pty/terminal-scroll-viewport';
 
@@ -9,6 +10,9 @@ function makeTerminal(buffer: { type: 'normal' | 'alternate'; baseY: number; vie
     buffer: {
       active: buffer,
     },
+    focus: vi.fn(() => {
+      buffer.viewportY = 0;
+    }),
     scrollToLine: vi.fn((line: number) => {
       buffer.viewportY = Math.max(0, Math.min(line, buffer.baseY));
     }),
@@ -42,6 +46,17 @@ describe('terminal scroll viewport preservation', () => {
 
     expect(terminal.scrollToLine).toHaveBeenCalledWith(110);
     expect(buffer.viewportY).toBe(110);
+  });
+
+  it('preserves scroll around focus', () => {
+    const buffer = { type: 'normal' as const, baseY: 100, viewportY: 80 };
+    const terminal = makeTerminal(buffer);
+
+    focusTerminalPreservingScroll(terminal);
+
+    expect(terminal.focus).toHaveBeenCalledOnce();
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(80);
+    expect(buffer.viewportY).toBe(80);
   });
 
   it('does not restore after switching terminal buffers', () => {

--- a/apps/emdash-desktop/src/renderer/tests/terminal-scroll-viewport.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/terminal-scroll-viewport.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  captureTerminalScrollViewport,
+  restoreTerminalScrollViewport,
+} from '@renderer/lib/pty/terminal-scroll-viewport';
+
+function makeTerminal(buffer: { type: 'normal' | 'alternate'; baseY: number; viewportY: number }) {
+  return {
+    buffer: {
+      active: buffer,
+    },
+    scrollToLine: vi.fn((line: number) => {
+      buffer.viewportY = Math.max(0, Math.min(line, buffer.baseY));
+    }),
+  };
+}
+
+describe('terminal scroll viewport preservation', () => {
+  it('keeps terminals pinned to the bottom across base changes', () => {
+    const buffer = { type: 'normal' as const, baseY: 100, viewportY: 100 };
+    const terminal = makeTerminal(buffer);
+    const snapshot = captureTerminalScrollViewport(terminal);
+
+    buffer.baseY = 120;
+    buffer.viewportY = 0;
+
+    restoreTerminalScrollViewport(terminal, snapshot);
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(120);
+    expect(buffer.viewportY).toBe(120);
+  });
+
+  it('preserves distance from the bottom when the user is scrolled up', () => {
+    const buffer = { type: 'normal' as const, baseY: 100, viewportY: 80 };
+    const terminal = makeTerminal(buffer);
+    const snapshot = captureTerminalScrollViewport(terminal);
+
+    buffer.baseY = 130;
+    buffer.viewportY = 0;
+
+    restoreTerminalScrollViewport(terminal, snapshot);
+
+    expect(terminal.scrollToLine).toHaveBeenCalledWith(110);
+    expect(buffer.viewportY).toBe(110);
+  });
+
+  it('does not restore after switching terminal buffers', () => {
+    const buffer: { type: 'normal' | 'alternate'; baseY: number; viewportY: number } = {
+      type: 'normal',
+      baseY: 100,
+      viewportY: 80,
+    };
+    const terminal = makeTerminal(buffer);
+    const snapshot = captureTerminalScrollViewport(terminal);
+
+    buffer.type = 'alternate';
+    buffer.viewportY = 0;
+
+    restoreTerminalScrollViewport(terminal, snapshot);
+
+    expect(terminal.scrollToLine).not.toHaveBeenCalled();
+    expect(buffer.viewportY).toBe(0);
+  });
+});


### PR DESCRIPTION
### Description
- prevent terminal scroll jumps when switching tabs/windows
- preserve terminal scroll durgin focus,resize and remount
- reuse scroll-preventing focus from context abr

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- XX] I only added comments where the logic is not obvious
- [ ] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
