### PR TITLE
fix(pty): write SSH image attachments into .emdash, not the worktree root

### DIFF
--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { conversationEvents } from '@main/core/conversations/conversation-events';
+import { taskSessionManager } from '../tasks/task-session-manager';
+import { workspaceRegistry } from '../workspaces/workspace-registry';
 import { ptySessionRegistry } from './pty-session-registry';
 
 vi.mock('./persist-dropped-blob', () => ({
@@ -65,5 +67,40 @@ describe('ptyController', () => {
     });
 
     ptySessionRegistry.unregister(sessionId);
+  });
+
+  it('uploads remote attachments into the git-ignored .emdash dir, not the worktree root (#2680)', async () => {
+    const mkdir = vi.fn().mockResolvedValue(undefined);
+    const copyLocalFile = vi.fn().mockResolvedValue(undefined);
+    const workspace = { path: '/remote/worktree', fs: { mkdir, copyLocalFile } };
+
+    const taskMgr = taskSessionManager as unknown as {
+      getTask: (id: string) => unknown;
+      getWorkspaceId: (id: string) => string;
+    };
+    taskMgr.getTask = vi.fn(() => ({}));
+    taskMgr.getWorkspaceId = vi.fn(() => 'ws-1');
+    const wsReg = workspaceRegistry as unknown as { get: (id: string) => unknown };
+    wsReg.get = vi.fn(() => workspace);
+
+    const result = await ptyController.uploadFiles({
+      sessionId: 'proj-1:task-1:conv-1',
+      localPaths: ['/local/tmp/emdash-drop-abc-image.png'],
+    });
+
+    expect(result.success).toBe(true);
+    expect(mkdir).toHaveBeenCalledWith('.emdash/uploads', { recursive: true });
+    expect(copyLocalFile).toHaveBeenCalledTimes(1);
+
+    const [src, destRel] = copyLocalFile.mock.calls[0]!;
+    expect(src).toBe('/local/tmp/emdash-drop-abc-image.png');
+    expect(destRel).toMatch(/^\.emdash\/uploads\/[0-9a-f-]+-emdash-drop-abc-image\.png$/);
+
+    if (result.success) {
+      // Lands under the git-ignored .emdash dir, never directly in the worktree root.
+      expect(result.data.remotePaths[0]).toMatch(
+        /^\/remote\/worktree\/\.emdash\/uploads\/[0-9a-f-]+-emdash-drop-abc-image\.png$/
+      );
+    }
   });
 });

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { conversationEvents } from '@main/core/conversations/conversation-events';
 import { taskSessionManager } from '../tasks/task-session-manager';
 import { workspaceRegistry } from '../workspaces/workspace-registry';
@@ -46,6 +46,15 @@ function makePty(write = vi.fn()) {
 describe('ptyController', () => {
   beforeEach(() => {
     emitSpy.mockClear();
+  });
+
+  afterEach(() => {
+    // Tests below mutate the shared mock singletons; reset them so a later test
+    // still sees the empty `{}` the vi.mock factories return.
+    const taskMgr = taskSessionManager as unknown as Record<string, unknown>;
+    delete taskMgr.getTask;
+    delete taskMgr.getWorkspaceId;
+    delete (workspaceRegistry as unknown as Record<string, unknown>).get;
   });
 
   it('emits input-submitted for remote agent PTYs on enter', () => {

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -5,6 +5,7 @@ import { conversationEvents } from '@main/core/conversations/conversation-events
 import { log } from '@main/lib/logger';
 import { parsePtySessionId } from '@shared/core/pty/ptySessionId';
 import { createRPCController } from '@shared/lib/ipc/rpc';
+import { SSH_PROJECT_STATE_DIR_NAME } from '../settings/worktree-defaults';
 import { taskSessionManager } from '../tasks/task-session-manager';
 import { workspaceRegistry } from '../workspaces/workspace-registry';
 import {
@@ -155,11 +156,17 @@ export const ptyController = createRPCController({
       const workspace = workspaceRegistry.get(workspaceId);
       if (!workspace?.fs.copyLocalFile) return err({ type: 'not_ssh' as const });
 
+      // Upload into the git-ignored .emdash runtime dir, not the worktree root.
+      // Writing to the root left every attached image behind as an untracked file
+      // that dirtied `git status` and never got cleaned up (#2680).
+      const uploadDir = `${SSH_PROJECT_STATE_DIR_NAME}/uploads`;
+      await workspace.fs.mkdir(uploadDir, { recursive: true });
+
       const remotePaths = await Promise.all(
         args.localPaths.map(async (localPath) => {
-          const remoteName = `${randomUUID()}-${basename(localPath)}`;
-          await workspace.fs.copyLocalFile!(localPath, remoteName);
-          return `${workspace.path}/${remoteName}`;
+          const remoteRelPath = `${uploadDir}/${randomUUID()}-${basename(localPath)}`;
+          await workspace.fs.copyLocalFile!(localPath, remoteRelPath);
+          return `${workspace.path}/${remoteRelPath}`;
         })
       );
       return ok({ remotePaths });


### PR DESCRIPTION
## What

On remote SSH projects, attaching an image (paste or drag and drop) to an agent left an untracked `<uuid>-<name>` file in the worktree root every time, and it was never cleaned up. After a few attachments `git status` is full of orphaned `*-image.png` files. Fixes #2680.

This is not Claude specific: the upload runs in the shared PTY layer (`pty.uploadFiles`), so it affects every agent used over SSH.

## Root cause

`apps/emdash-desktop/src/main/core/pty/controller.ts` (`uploadFiles`) copied the local file straight into the workspace root:

```ts
const remoteName = `${randomUUID()}-${basename(localPath)}`;
await workspace.fs.copyLocalFile!(localPath, remoteName);
return `${workspace.path}/${remoteName}`;
```

`copyLocalFile` writes relative to `workspace.path` (the worktree root) and nothing ever removed the file. The local (non SSH) path does not have this problem: there images go to the OS temp dir with `will-quit` and age based cleanup (`persist-dropped-blob.ts`).

## The fix

Upload into the git-ignored `.emdash/uploads` directory instead of the worktree root. `.emdash` is already emdash's per-project runtime state dir (it holds the SSH worktree pool via `getDefaultSshWorktreeDirectory` and attachments via `saveAttachment`), so attachments no longer show up in `git status`. The directory is created with `mkdir({ recursive: true })` before the transfer.

## Testing

- New unit test in `controller.test.ts` asserts the upload creates `.emdash/uploads` and that both the destination relative path and the returned remote path live under `.emdash/uploads`, never directly in the worktree root.
- format, lint, typecheck and tests pass.

## Note

This stops the pollution of the tracked tree. Bounding disk usage of `.emdash/uploads` over time (a TTL sweep like the local `cleanupExpiredDroppedBlobs`) would be a reasonable follow up.
