### PR TITLE
fix(in-app-browser): avoid duplicate navigation reload

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
@@ -1,0 +1,142 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { PaneContext, type PaneContextValue } from '@renderer/features/tabs/pane-context';
+import { BrowserPane } from './browser-pane';
+import { browserSessionStore } from './browser-session-store';
+
+const browserRpc = vi.hoisted(() => ({
+  bindWebContents: vi.fn(),
+  registerSession: vi.fn(),
+  setActiveBrowser: vi.fn(),
+}));
+
+vi.mock('@renderer/features/tasks/task-view-context', () => ({
+  usePreviewServers: () => ({ urls: [] }),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  events: {
+    on: vi.fn(() => () => {}),
+  },
+  rpc: {
+    browser: browserRpc,
+  },
+}));
+
+vi.mock('./browser-toolbar', async () => {
+  const React = await import('react');
+  return {
+    BrowserToolbar: ({ onNavigate }: { onNavigate?: (url: string) => boolean }) =>
+      React.createElement(
+        'button',
+        {
+          type: 'button',
+          onClick: () => onNavigate?.('https://linkedin.com/'),
+        },
+        'Navigate to LinkedIn'
+      ),
+  };
+});
+
+describe('BrowserPane', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Element', dom.window.Element);
+    vi.stubGlobal('Node', dom.window.Node);
+    vi.stubGlobal('Event', dom.window.Event);
+    vi.stubGlobal('MouseEvent', dom.window.MouseEvent);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+    browserSessionStore.clear();
+    browserRpc.bindWebContents.mockReset();
+    browserRpc.registerSession.mockReset();
+    browserRpc.registerSession.mockResolvedValue({ success: true });
+    browserRpc.setActiveBrowser.mockReset();
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    browserSessionStore.clear();
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('does not replay start-page navigation through loadURL after the webview becomes ready', async () => {
+    const session = browserSessionStore.createSession({
+      browserId: 'browser-1',
+      projectId: 'project-1',
+      workspaceId: 'workspace-1',
+      taskId: 'task-1',
+    });
+
+    const paneContextValue = {
+      paneId: 'pane-1',
+      pane: {
+        setNextTabActive: vi.fn(),
+        setPreviousTabActive: vi.fn(),
+      },
+      isFocusedPane: true,
+    } as unknown as PaneContextValue;
+
+    await act(async () => {
+      root.render(
+        React.createElement(
+          PaneContext.Provider,
+          { value: paneContextValue },
+          React.createElement(BrowserPane, { browserId: session.browserId, visible: true })
+        )
+      );
+    });
+
+    await act(async () => {});
+
+    const navigateButton = container.querySelector<HTMLButtonElement>('button');
+    expect(navigateButton).not.toBeNull();
+
+    await act(async () => {
+      navigateButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    const webview = container.querySelector<HTMLElement>('webview');
+    expect(webview).not.toBeNull();
+    expect(webview?.getAttribute('src')).toBe('https://linkedin.com/');
+
+    const loadURL = vi.fn();
+    Object.assign(webview!, {
+      canGoBack: () => false,
+      canGoForward: () => false,
+      getTitle: () => 'LinkedIn',
+      getURL: () => webview?.getAttribute('src') ?? 'about:blank',
+      getWebContentsId: () => 123,
+      goBack: vi.fn(),
+      goForward: vi.fn(),
+      loadURL,
+      reload: vi.fn(),
+      reloadIgnoringCache: vi.fn(),
+      setZoomFactor: vi.fn(),
+      stop: vi.fn(),
+    });
+
+    await act(async () => {
+      webview?.dispatchEvent(new dom.window.Event('dom-ready'));
+    });
+    await act(async () => {});
+
+    expect(loadURL).not.toHaveBeenCalled();
+    expect(browserSessionStore.getSession(session.browserId)).toMatchObject({
+      currentUrl: 'https://linkedin.com/',
+      title: 'LinkedIn',
+    });
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
@@ -2,7 +2,6 @@ import { JSDOM } from 'jsdom';
 import React, { act } from 'react';
 import { createRoot, type Root } from 'react-dom/client';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { PaneContext, type PaneContextValue } from '@renderer/features/tabs/pane-context';
 import { BrowserPane } from './browser-pane';
 import { browserSessionStore } from './browser-session-store';
 
@@ -16,37 +15,32 @@ vi.mock('@renderer/features/tasks/task-view-context', () => ({
   usePreviewServers: () => ({ urls: [] }),
 }));
 
+vi.mock('@renderer/features/tabs/pane-context', () => ({
+  usePaneContext: () => ({
+    pane: { setNextTabActive: vi.fn(), setPreviousTabActive: vi.fn() },
+  }),
+}));
+
 vi.mock('@renderer/lib/ipc', () => ({
-  events: {
-    on: vi.fn(() => () => {}),
-  },
-  rpc: {
-    browser: browserRpc,
-  },
+  events: { on: vi.fn(() => () => {}) },
+  rpc: { browser: browserRpc },
 }));
 
 vi.mock('./browser-toolbar', async () => {
   const React = await import('react');
   return {
     BrowserToolbar: ({ onNavigate }: { onNavigate?: (url: string) => boolean }) =>
-      React.createElement(
-        'button',
-        {
-          type: 'button',
-          onClick: () => onNavigate?.('https://linkedin.com/'),
-        },
-        'Navigate to LinkedIn'
-      ),
+      React.createElement('button', { onClick: () => onNavigate?.('https://linkedin.com/') }),
   };
 });
 
 describe('BrowserPane', () => {
   let dom: JSDOM;
   let root: Root;
-  let container: HTMLDivElement;
+  let container: HTMLElement;
 
   beforeEach(() => {
-    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    dom = new JSDOM('<div id="root"></div>');
     vi.stubGlobal('window', dom.window);
     vi.stubGlobal('document', dom.window.document);
     vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
@@ -55,24 +49,21 @@ describe('BrowserPane', () => {
     vi.stubGlobal('Event', dom.window.Event);
     vi.stubGlobal('MouseEvent', dom.window.MouseEvent);
     vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
-
-    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    container = dom.window.document.getElementById('root')!;
     root = createRoot(container);
     browserSessionStore.clear();
-    browserRpc.bindWebContents.mockReset();
-    browserRpc.registerSession.mockReset();
     browserRpc.registerSession.mockResolvedValue({ success: true });
-    browserRpc.setActiveBrowser.mockReset();
   });
 
   afterEach(() => {
     act(() => root.unmount());
     browserSessionStore.clear();
+    vi.clearAllMocks();
     vi.unstubAllGlobals();
     dom.window.close();
   });
 
-  it('does not replay start-page navigation through loadURL after the webview becomes ready', async () => {
+  it('does not load the submitted URL twice when the webview becomes ready', async () => {
     const session = browserSessionStore.createSession({
       browserId: 'browser-1',
       projectId: 'project-1',
@@ -80,63 +71,30 @@ describe('BrowserPane', () => {
       taskId: 'task-1',
     });
 
-    const paneContextValue = {
-      paneId: 'pane-1',
-      pane: {
-        setNextTabActive: vi.fn(),
-        setPreviousTabActive: vi.fn(),
-      },
-      isFocusedPane: true,
-    } as unknown as PaneContextValue;
-
     await act(async () => {
       root.render(
-        React.createElement(
-          PaneContext.Provider,
-          { value: paneContextValue },
-          React.createElement(BrowserPane, { browserId: session.browserId, visible: true })
-        )
+        React.createElement(BrowserPane, { browserId: session.browserId, visible: true })
       );
     });
-
-    await act(async () => {});
-
-    const navigateButton = container.querySelector<HTMLButtonElement>('button');
-    expect(navigateButton).not.toBeNull();
-
     await act(async () => {
-      navigateButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+      container.querySelector('button')?.dispatchEvent(new MouseEvent('click', { bubbles: true }));
     });
 
-    const webview = container.querySelector<HTMLElement>('webview');
-    expect(webview).not.toBeNull();
-    expect(webview?.getAttribute('src')).toBe('https://linkedin.com/');
-
+    const webview = container.querySelector<HTMLElement>('webview')!;
     const loadURL = vi.fn();
-    Object.assign(webview!, {
+    Object.assign(webview, {
       canGoBack: () => false,
       canGoForward: () => false,
       getTitle: () => 'LinkedIn',
-      getURL: () => webview?.getAttribute('src') ?? 'about:blank',
+      getURL: () => webview.getAttribute('src'),
       getWebContentsId: () => 123,
-      goBack: vi.fn(),
-      goForward: vi.fn(),
       loadURL,
-      reload: vi.fn(),
-      reloadIgnoringCache: vi.fn(),
       setZoomFactor: vi.fn(),
-      stop: vi.fn(),
     });
 
-    await act(async () => {
-      webview?.dispatchEvent(new dom.window.Event('dom-ready'));
-    });
-    await act(async () => {});
+    await act(async () => webview.dispatchEvent(new dom.window.Event('dom-ready')));
 
+    expect(webview.getAttribute('src')).toBe('https://linkedin.com/');
     expect(loadURL).not.toHaveBeenCalled();
-    expect(browserSessionStore.getSession(session.browserId)).toMatchObject({
-      currentUrl: 'https://linkedin.com/',
-      title: 'LinkedIn',
-    });
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
@@ -31,7 +31,6 @@ export const BrowserPane = observer(function BrowserPane({
   const previewServers = usePreviewServers();
   const webviewRef = useRef<BrowserWebviewElement | null>(null);
   const focusUrlRef = useRef<() => void>(() => {});
-  const pendingUrlRef = useRef<string | null>(null);
   const [adapter, setAdapter] = useState<BrowserWebviewAdapter | null>(null);
   const [webviewElement, setWebviewElement] = useState<BrowserWebviewElement | null>(null);
   const [webviewMount, setWebviewMount] = useState<{
@@ -117,7 +116,6 @@ export const BrowserPane = observer(function BrowserPane({
   const loadUrl = useCallback(
     (url: string) => {
       if (!sessionBrowserId) return;
-      pendingUrlRef.current = url;
       browserSessionStore.updateSession(sessionBrowserId, {
         currentUrl: url,
         faviconUrl: null,
@@ -125,7 +123,6 @@ export const BrowserPane = observer(function BrowserPane({
         loadError: null,
       });
       if (adapter) {
-        pendingUrlRef.current = null;
         void adapter.loadUrl(url);
         return;
       }
@@ -219,13 +216,6 @@ export const BrowserPane = observer(function BrowserPane({
       },
     });
   }, [sessionBrowserId, webviewElement]);
-
-  useEffect(() => {
-    if (!adapter || !pendingUrlRef.current) return;
-    const pendingUrl = pendingUrlRef.current;
-    pendingUrlRef.current = null;
-    void adapter.loadUrl(pendingUrl);
-  }, [adapter]);
 
   useEffect(() => {
     if (!sessionBrowserId) return;


### PR DESCRIPTION
### Description
- fixes duplicate browser reload after opening a url
- removed the pending url replay that caused an immediate second `loadURL()`

### Screenshot/Recording (if applicable)
https://streamable.com/2jnvak

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
