### PR TITLE
fix(tasks): reap tmux session when archiving a task (#2689)

### DIFF
--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
@@ -43,7 +43,7 @@ describe('archiveTask', () => {
     mocks.updateWhere.mockResolvedValue(undefined);
   });
 
-  it('archives by detaching runtime without deleting workspace assets', async () => {
+  it('archives by reaping the runtime without deleting workspace assets', async () => {
     mocks.selectLimit.mockResolvedValueOnce([
       {
         id: 'task-1',
@@ -65,7 +65,7 @@ describe('archiveTask', () => {
     expect(updatePayload).not.toHaveProperty('status');
     expect(updatePayload).not.toHaveProperty('statusChangedAt');
 
-    expect(mocks.teardownTask).toHaveBeenCalledWith('task-1', 'detach');
+    expect(mocks.teardownTask).toHaveBeenCalledWith('task-1', 'archive');
     expect(mocks.capture).toHaveBeenCalledWith('task_archived', {
       project_id: 'project-1',
       task_id: 'task-1',

--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
@@ -18,7 +18,10 @@ export async function archiveTask(projectId: string, taskId: string): Promise<vo
     .where(eq(tasks.id, taskId));
   telemetryService.capture('task_archived', { project_id: projectId, task_id: taskId });
 
-  const teardownResult = await taskSessionManager.teardownTask(taskId, 'detach').catch((e) => {
+  // 'archive' reaps the tmux session + agent process but keeps the worktree and the
+  // persisted session id, so Restore can resume. Plain 'detach' would leak the tmux
+  // session indefinitely (#2689).
+  const teardownResult = await taskSessionManager.teardownTask(taskId, 'archive').catch((e) => {
     log.warn('archiveTask: teardown failed', { taskId, error: String(e) });
     return null;
   });

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TaskProvider } from '../projects/project-provider';
+import { executeTeardown } from './task-session-manager';
+
+const teardown = vi.fn();
+
+vi.mock('@main/core/workspaces/workspace-registry', () => ({
+  workspaceRegistry: {
+    teardown: (...args: unknown[]) => teardown(...args),
+  },
+}));
+
+// session-targets pulls in the real DB client; it is only used by the fallback path,
+// not by executeTeardown, so a stub keeps this unit test free of a SQLite import.
+vi.mock('@main/core/tasks/session-targets', () => ({
+  getTaskSessionLeafIds: vi.fn(),
+}));
+
+function makeTask() {
+  const conversations = { detachAll: vi.fn(), destroyAll: vi.fn() };
+  const terminals = { detachAll: vi.fn(), destroyAll: vi.fn() };
+  const task = { conversations, terminals } as unknown as TaskProvider;
+  return { task, conversations, terminals };
+}
+
+describe('executeTeardown', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('detach keeps tmux + agent running and keeps the workspace', async () => {
+    const { task, conversations, terminals } = makeTask();
+    await executeTeardown(task, 'workspace-1', 'detach');
+
+    expect(conversations.detachAll).toHaveBeenCalledTimes(1);
+    expect(terminals.detachAll).toHaveBeenCalledTimes(1);
+    expect(conversations.destroyAll).not.toHaveBeenCalled();
+    expect(terminals.destroyAll).not.toHaveBeenCalled();
+    expect(teardown).toHaveBeenCalledWith('workspace-1', 'detach');
+  });
+
+  it('terminate reaps tmux + agent and destroys the workspace', async () => {
+    const { task, conversations, terminals } = makeTask();
+    await executeTeardown(task, 'workspace-1', 'terminate');
+
+    expect(conversations.destroyAll).toHaveBeenCalledTimes(1);
+    expect(terminals.destroyAll).toHaveBeenCalledTimes(1);
+    expect(conversations.detachAll).not.toHaveBeenCalled();
+    expect(terminals.detachAll).not.toHaveBeenCalled();
+    expect(teardown).toHaveBeenCalledWith('workspace-1', 'terminate');
+  });
+
+  // The regression for #2689: archive must reap the tmux session + agent process
+  // (destroyAll), but keep the workspace/worktree (detach-level teardown) so Restore works.
+  it('archive reaps tmux + agent but keeps the workspace', async () => {
+    const { task, conversations, terminals } = makeTask();
+    await executeTeardown(task, 'workspace-1', 'archive');
+
+    expect(conversations.destroyAll).toHaveBeenCalledTimes(1);
+    expect(terminals.destroyAll).toHaveBeenCalledTimes(1);
+    expect(conversations.detachAll).not.toHaveBeenCalled();
+    expect(terminals.detachAll).not.toHaveBeenCalled();
+    // crucially NOT 'terminate', which would run onDestroy and remove the worktree.
+    expect(teardown).toHaveBeenCalledWith('workspace-1', 'detach');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
@@ -48,19 +48,38 @@ export type TaskManagerHooks = {
   }) => void | Promise<void>;
 };
 
-async function executeTeardown(
+/**
+ * Task-level teardown intent. Wider than {@link TeardownMode} because archive needs to
+ * reap the running agent like `terminate` while keeping the workspace like `detach`:
+ *
+ * - `detach`: leave tmux sessions and agent processes running so the task can be
+ *   remounted later (used on app/project shutdown when tmux is enabled).
+ * - `terminate`: reap tmux sessions + agent processes and destroy the workspace
+ *   (worktree removal, teardown script). Used by delete.
+ * - `archive`: reap tmux sessions + agent processes like `terminate`, but keep the
+ *   workspace/worktree (and the persisted `conversations.session_id`) so the task stays
+ *   restorable. Without this, archiving a tmux-backed task leaked its session and agent
+ *   process indefinitely (#2689).
+ */
+export type TaskTeardownMode = TeardownMode | 'archive';
+
+export async function executeTeardown(
   task: TaskProvider,
   workspaceId: string,
-  mode: TeardownMode
+  mode: TaskTeardownMode
 ): Promise<void> {
   if (mode === 'detach') {
+    // Keep the tmux sessions and agent processes alive for a later remount.
     await task.conversations.detachAll();
     await task.terminals.detachAll();
   } else {
+    // 'terminate' and 'archive' both reap the tmux sessions and agent processes.
     await task.conversations.destroyAll();
     await task.terminals.destroyAll();
   }
-  await workspaceRegistry.teardown(workspaceId, mode);
+  // Only 'terminate' destroys the workspace (worktree + teardown script). 'archive'
+  // keeps the worktree alive, same as 'detach', so Restore can resume the task.
+  await workspaceRegistry.teardown(workspaceId, mode === 'terminate' ? 'terminate' : 'detach');
 }
 
 async function cleanupDetachedSessions(
@@ -138,7 +157,7 @@ class TaskSessionManager {
 
   async teardownTask(
     taskId: string,
-    mode: TeardownMode = 'terminate'
+    mode: TaskTeardownMode = 'terminate'
   ): Promise<Result<void, TeardownTaskError>> {
     const result = this._lifecycle.teardown(
       taskId,


### PR DESCRIPTION
## What

Archiving a task on a tmux-backed setup leaks its tmux session and the agent process behind it. Delete reaps the session correctly, but Archive does not, so an archived task keeps a `claude` (or other agent) process and a port-holding tmux session alive indefinitely.

Closes #2689.

## Root cause

`archiveTask` tore down with mode `'detach'`, while `deleteTask` uses `'terminate'`. In `executeTeardown`:

- `'detach'` runs `conversations.detachAll()` / `terminals.detachAll()`, which only kill the foreground PTY. They never call `killTmuxSession`.
- `'terminate'` runs `destroyAll()`, which loops the known session ids and reaps each tmux session.

So with tmux enabled, archive closed the pipe but left the tmux server holding the agent process.

## Fix

Add a third task-level teardown mode, `'archive'`, that:

- reaps the tmux sessions and agent processes like `'terminate'` (`destroyAll`), and
- keeps the workspace and worktree like `'detach'` (the workspace teardown stays in detach mode).

The persisted `conversations.session_id` is never touched by either path, so Restore still resumes via `--session-id ... --resume`. This makes archive behave like a non-tmux setup: no lingering process, still fully restorable. This matches the expectation in #2689 and the note in #2592.

Flipping archive straight to `'terminate'` was not viable: at the workspace level `'terminate'` runs `onDestroy`, which stops the preview server and runs the user's `teardown` lifecycle script, and the worktree gets removed. Archive has to keep the worktree for Restore, hence the dedicated mode.

The change lives in `executeTeardown`, so it covers both local and SSH transports.

## Tests

- New `task-session-manager.test.ts` locks the mode to behavior mapping for all three modes. The `archive` case asserts `destroyAll` is called (tmux reaped) while the workspace teardown receives `'detach'` (worktree kept).
- Updated `archiveTask.test.ts` to expect the `'archive'` mode.

```
pnpm exec vitest run --project node src/main/core/tasks/   ->  9 files, 35 tests passed
```

format, lint and typecheck are clean.