### PR TITLE
chore: add auggie hooks

### DIFF
--- a/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
@@ -412,7 +412,11 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     versionArgs: ['--version'],
     cli: 'auggie',
     initialPromptFlag: '',
-    resumeFlag: '--continue',
+    resumeFlag: '--resume',
+    sessionIdFlag: '--resume',
+    sessionIdOnResumeOnly: true,
+    resumeWithoutSessionFlag: '--continue',
+    supportsHooks: true,
     // otherwise user is prompted each time before prompt is passed
     defaultArgs: ['--allow-indexing'],
     icon: 'Auggie.svg',

--- a/packages/plugins/src/agents/impl/auggie/hooks.ts
+++ b/packages/plugins/src/agents/impl/auggie/hooks.ts
@@ -1,0 +1,18 @@
+import {
+  buildNestedJsonHookConfig,
+  makeStdinHookCommand,
+} from '@emdash/core/agents/plugins/helpers';
+
+export const AUGGIE_HOOKS_PATH = '.augment/settings.json';
+
+export function buildAuggieHookConfig() {
+  return buildNestedJsonHookConfig(AUGGIE_HOOKS_PATH, [
+    { hookKey: 'SessionStart', command: makeStdinHookCommand('session') },
+    { hookKey: 'PromptSubmit', command: makeStdinHookCommand('start') },
+    { hookKey: 'PreToolUse', command: makeStdinHookCommand('start') },
+    { hookKey: 'PostToolUse', command: makeStdinHookCommand('tool-use') },
+    { hookKey: 'Stop', command: makeStdinHookCommand('stop') },
+    { hookKey: 'SessionEnd', command: makeStdinHookCommand('stop') },
+    { hookKey: 'Notification', command: makeStdinHookCommand('notification') },
+  ]);
+}

--- a/packages/plugins/src/agents/impl/auggie/hooks.ts
+++ b/packages/plugins/src/agents/impl/auggie/hooks.ts
@@ -10,7 +10,7 @@ export function buildAuggieHookConfig() {
     { hookKey: 'SessionStart', command: makeStdinHookCommand('session') },
     { hookKey: 'PromptSubmit', command: makeStdinHookCommand('start') },
     { hookKey: 'PreToolUse', command: makeStdinHookCommand('start') },
-    { hookKey: 'PostToolUse', command: makeStdinHookCommand('tool-use') },
+    { hookKey: 'PostToolUse', command: makeStdinHookCommand('start') },
     { hookKey: 'Stop', command: makeStdinHookCommand('stop') },
     { hookKey: 'SessionEnd', command: makeStdinHookCommand('stop') },
     { hookKey: 'Notification', command: makeStdinHookCommand('notification') },

--- a/packages/plugins/src/agents/impl/auggie/index.test.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.test.ts
@@ -1,0 +1,98 @@
+import type { PluginFs } from '@emdash/core/agents/plugins';
+import { buildNestedEntry, makeStdinHookCommand } from '@emdash/core/agents/plugins/helpers';
+import { describe, expect, it } from 'vitest';
+import { AUGGIE_HOOKS_PATH } from './hooks';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'auggie',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-session-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+function createMemoryFs(files = new Map<string, string>()): PluginFs {
+  return {
+    read: async (path) => files.get(path) ?? null,
+    write: async (path, content) => {
+      files.set(path, content);
+    },
+    delete: async (path) => {
+      files.delete(path);
+    },
+    exists: async (path) => files.has(path),
+    list: async () => [],
+  };
+}
+
+describe('auggie provider', () => {
+  it('resumes a stored provider session id with --resume', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      providerSessionId: 'auggie-session-id',
+      isResuming: true,
+    });
+
+    expect(command).toEqual({
+      command: 'auggie',
+      args: ['--allow-indexing', '--resume', 'auggie-session-id'],
+      env: {},
+    });
+  });
+
+  it('falls back to the most recent Auggie session before hooks report a session id', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      isResuming: true,
+    });
+
+    expect(command).toEqual({
+      command: 'auggie',
+      args: ['--allow-indexing', '--continue'],
+      env: {},
+    });
+  });
+
+  it('installs Auggie workspace hooks using the native settings schema', async () => {
+    const files = new Map<string, string>();
+    const fs = createMemoryFs(files);
+
+    await provider.behavior.hooks!.writeHooks(fs, []);
+
+    const settings = JSON.parse(files.get(AUGGIE_HOOKS_PATH)!);
+    expect(settings.hooks.SessionStart).toEqual([
+      buildNestedEntry(makeStdinHookCommand('session')),
+    ]);
+    expect(settings.hooks.PromptSubmit).toEqual([buildNestedEntry(makeStdinHookCommand('start'))]);
+    expect(settings.hooks.PostToolUse).toEqual([
+      buildNestedEntry(makeStdinHookCommand('tool-use')),
+    ]);
+    expect(settings.hooks.Notification).toEqual([
+      buildNestedEntry(makeStdinHookCommand('notification')),
+    ]);
+  });
+
+  it('treats partial hook installs as incomplete', async () => {
+    const fs = createMemoryFs(
+      new Map([
+        [
+          AUGGIE_HOOKS_PATH,
+          JSON.stringify({
+            hooks: {
+              SessionStart: [buildNestedEntry(makeStdinHookCommand('session'))],
+            },
+          }),
+        ],
+      ])
+    );
+
+    await expect(provider.behavior.hooks!.getHooksInstalled(fs)).resolves.toBe(false);
+
+    await provider.behavior.hooks!.writeHooks(fs, []);
+
+    await expect(provider.behavior.hooks!.getHooksInstalled(fs)).resolves.toBe(true);
+  });
+});

--- a/packages/plugins/src/agents/impl/auggie/index.test.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.test.ts
@@ -67,9 +67,7 @@ describe('auggie provider', () => {
       buildNestedEntry(makeStdinHookCommand('session')),
     ]);
     expect(settings.hooks.PromptSubmit).toEqual([buildNestedEntry(makeStdinHookCommand('start'))]);
-    expect(settings.hooks.PostToolUse).toEqual([
-      buildNestedEntry(makeStdinHookCommand('tool-use')),
-    ]);
+    expect(settings.hooks.PostToolUse).toEqual([buildNestedEntry(makeStdinHookCommand('start'))]);
     expect(settings.hooks.Notification).toEqual([
       buildNestedEntry(makeStdinHookCommand('notification')),
     ]);

--- a/packages/plugins/src/agents/impl/auggie/index.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.ts
@@ -15,7 +15,7 @@ export const plugin = definePlugin(
     hooks: {
       kind: 'config',
       scope: 'workspace',
-      supportedEvents: ['notification', 'stop', 'session', 'start', 'tool-use'],
+      supportedEvents: ['notification', 'stop', 'session', 'start'],
     },
     hostDependency: npmDependency({ id: 'auggie', package: '@augmentcode/auggie' }),
     prompt: {

--- a/packages/plugins/src/agents/impl/auggie/index.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.ts
@@ -1,5 +1,6 @@
 import { definePlugin, registerPluginBehavior } from '@emdash/core/agents/plugins';
 import { buildStandardCommand, npmDependency } from '@emdash/core/agents/plugins/helpers';
+import { buildAuggieHookConfig } from './hooks';
 import { icon } from './icon';
 
 export const plugin = definePlugin(
@@ -11,6 +12,11 @@ export const plugin = definePlugin(
     websiteUrl: 'https://docs.augmentcode.com/cli/overview',
   },
   {
+    hooks: {
+      kind: 'config',
+      scope: 'workspace',
+      supportedEvents: ['notification', 'stop', 'session', 'start', 'tool-use'],
+    },
     hostDependency: npmDependency({ id: 'auggie', package: '@augmentcode/auggie' }),
     prompt: {
       kind: 'argv',
@@ -29,7 +35,11 @@ export const provider = registerPluginBehavior(plugin, {
       buildStandardCommand(ctx, {
         defaultArgs: ['--allow-indexing'],
         initialPromptFlag: '',
-        resumeFlag: '--continue',
+        resumeFlag: '--resume',
+        sessionIdFlag: '--resume',
+        sessionIdOnResumeOnly: true,
+        resumeWithoutSessionFlag: '--continue',
       }),
   },
+  hooks: buildAuggieHookConfig(),
 });


### PR DESCRIPTION
### Description
- fix auggie resume to use `--resume {sessionID}`,  keep `--continue` as fallback
- add auggie hooks

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
