### PR TITLE
fix(app): use file URLs for app protocol assets

### DIFF
--- a/apps/emdash-desktop/src/main/app/protocol.ts
+++ b/apps/emdash-desktop/src/main/app/protocol.ts
@@ -1,4 +1,5 @@
 import { join, normalize, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { net, protocol } from 'electron';
 import { APP_NAME_LOWER } from '@shared/app-identity';
 
@@ -32,9 +33,9 @@ export function setupAppProtocol(rendererRoot: string): void {
     }
 
     try {
-      return await net.fetch(`file://${resolved}`);
+      return await net.fetch(pathToFileURL(resolved).href);
     } catch {
-      return net.fetch(`file://${join(root, 'index.html')}`);
+      return net.fetch(pathToFileURL(join(root, 'index.html')).href);
     }
   });
 }


### PR DESCRIPTION
### Description
- fixes packaged windows renderer loading
- user proper `file:///C:/...`
- keeps traversal guard unchanged

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
