### PR TITLE
fix: harden Windows implementation gaps

### DIFF
--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -137,7 +137,8 @@ jobs:
             echo "has_signing=true" >> "$GITHUB_OUTPUT"
           else
             echo "has_signing=false" >> "$GITHUB_OUTPUT"
-            echo "::warning::Azure Trusted Signing secrets not configured. Windows build will be unsigned."
+            echo "::error::Azure Trusted Signing secrets are required for production Windows releases."
+            exit 1
           fi
 
       - name: Build Windows packages

--- a/.github/workflows/windows-beta-build.yml
+++ b/.github/workflows/windows-beta-build.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           set -euo pipefail
           ELECTRON_VERSION=$(node -p "require('electron/package.json').version")
-          npm_config_build_from_source=true pnpm exec electron-rebuild -f -a x64 -v "$ELECTRON_VERSION" -o sqlite3,node-pty
+          npm_config_build_from_source=true pnpm exec electron-rebuild -f -a x64 -v "$ELECTRON_VERSION" -o better-sqlite3,node-pty,@parcel/watcher
 
       - name: Package Windows (NSIS + MSI) (no publish)
         shell: bash

--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -39,7 +39,7 @@
     "package:linux": "pnpm run build && electron-builder --linux --publish never --config electron-builder.config.ts",
     "package:win": "pnpm run build && electron-builder --win --publish never --config electron-builder.config.ts",
     "postinstall": "node --experimental-strip-types scripts/postinstall.ts",
-    "rebuild": "electron-rebuild -f -v 40.7.0 --only=better-sqlite3,node-pty",
+    "rebuild": "electron-rebuild -f --only=better-sqlite3,node-pty,@parcel/watcher",
     "run:docker-ssh": "docker compose up --build -d",
     "clean": "rm -rf node_modules dist",
     "reset": "pnpm run clean && pnpm install",

--- a/apps/emdash-desktop/scripts/native-modules.ts
+++ b/apps/emdash-desktop/scripts/native-modules.ts
@@ -1,0 +1,1 @@
+export const NATIVE_MODULES = ['better-sqlite3', 'node-pty', '@parcel/watcher'];

--- a/apps/emdash-desktop/scripts/postinstall.ts
+++ b/apps/emdash-desktop/scripts/postinstall.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { NATIVE_MODULES } from './native-modules.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -67,8 +68,11 @@ const disablePty = process.env.EMDASH_DISABLE_PTY === '1';
 const disableNativeDb = process.env.EMDASH_DISABLE_NATIVE_DB === '1';
 
 const nativeModules: string[] = [];
-if (!disableNativeDb) nativeModules.push('better-sqlite3');
-if (!disablePty) nativeModules.push('node-pty');
+for (const nativeModule of NATIVE_MODULES) {
+  if (nativeModule === 'better-sqlite3' && disableNativeDb) continue;
+  if (nativeModule === 'node-pty' && disablePty) continue;
+  nativeModules.push(nativeModule);
+}
 
 if (nativeModules.length === 0) {
   process.exit(0);

--- a/apps/emdash-desktop/scripts/release/build.ts
+++ b/apps/emdash-desktop/scripts/release/build.ts
@@ -66,10 +66,14 @@ if (isCanary) {
 step('Creating deployment directory with production dependencies');
 const workspaceRoot = resolve(process.cwd(), '../..');
 const deployDir = mkdtempSync(join(workspaceRoot, '.emdash-deploy-'));
-execFile('pnpm', ['--filter', '@emdash/emdash-desktop', 'deploy', '--legacy', '--prod', deployDir], {
-  cwd: workspaceRoot,
-  echo: true,
-});
+execFile(
+  'pnpm',
+  ['--filter', '@emdash/emdash-desktop', 'deploy', '--legacy', '--prod', deployDir],
+  {
+    cwd: workspaceRoot,
+    echo: true,
+  }
+);
 
 step('Copying built assets into deployment directory');
 cpSync('out', join(deployDir, 'out'), { recursive: true });

--- a/apps/emdash-desktop/scripts/release/build.ts
+++ b/apps/emdash-desktop/scripts/release/build.ts
@@ -7,7 +7,7 @@ import { Arch, Platform, build as electronBuild } from 'electron-builder';
 import type { Configuration } from 'electron-builder';
 import { duplicateChannelManifests, resolvePublishChannels } from './lib/artifacts.ts';
 import { GITHUB_OWNER, GITHUB_REPO } from './lib/config.ts';
-import { exec } from './lib/exec.ts';
+import { exec, execFile } from './lib/exec.ts';
 import { fail, info, step, warn } from './lib/log.ts';
 import { resolveReleaseVersion } from './lib/version.ts';
 import type { ReleaseChannel } from './lib/version.ts';
@@ -66,7 +66,7 @@ if (isCanary) {
 step('Creating deployment directory with production dependencies');
 const workspaceRoot = resolve(process.cwd(), '../..');
 const deployDir = mkdtempSync(join(workspaceRoot, '.emdash-deploy-'));
-exec(`pnpm --filter @emdash/emdash-desktop deploy --legacy --prod ${deployDir}`, {
+execFile('pnpm', ['--filter', '@emdash/emdash-desktop', 'deploy', '--legacy', '--prod', deployDir], {
   cwd: workspaceRoot,
   echo: true,
 });
@@ -86,8 +86,16 @@ try {
   for (const arch of archs) {
     step(`Building ${platform} ${targetList.join(' ')} for ${arch}`);
 
-    exec(
-      `node --experimental-strip-types scripts/release/rebuild-native.ts --arch ${arch} --deploy-dir ${deployDir}`,
+    execFile(
+      'node',
+      [
+        '--experimental-strip-types',
+        'scripts/release/rebuild-native.ts',
+        '--arch',
+        arch,
+        '--deploy-dir',
+        deployDir,
+      ],
       { echo: true }
     );
 

--- a/apps/emdash-desktop/scripts/release/lib/artifacts.test.ts
+++ b/apps/emdash-desktop/scripts/release/lib/artifacts.test.ts
@@ -1,6 +1,6 @@
 import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { basename, join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import { duplicateChannelManifests, findManifests, resolvePublishChannels } from './artifacts.ts';
 
@@ -24,9 +24,7 @@ describe('duplicateChannelManifests', () => {
     const created = duplicateChannelManifests('latest', 'v1-stable', dir);
 
     expect(created).toHaveLength(3);
-    const names = created
-      .map((f) => f.split('/').pop())
-      .sort((a, b) => (a ?? '').localeCompare(b ?? ''));
+    const names = created.map((f) => basename(f)).sort((a, b) => a.localeCompare(b));
     expect(names).toEqual(['v1-stable-linux.yml', 'v1-stable-mac.yml', 'v1-stable.yml']);
   });
 
@@ -68,9 +66,7 @@ describe('duplicateChannelManifests', () => {
     const created = duplicateChannelManifests('canary', 'v1-canary', dir);
 
     expect(created).toHaveLength(3);
-    const names = created
-      .map((f) => f.split('/').pop())
-      .sort((a, b) => (a ?? '').localeCompare(b ?? ''));
+    const names = created.map((f) => basename(f)).sort((a, b) => a.localeCompare(b));
     expect(names).toEqual(['v1-canary-linux.yml', 'v1-canary-mac.yml', 'v1-canary.yml']);
   });
 });

--- a/apps/emdash-desktop/scripts/release/lib/config.ts
+++ b/apps/emdash-desktop/scripts/release/lib/config.ts
@@ -6,9 +6,9 @@ export {
   R2_BASE_URL,
   UPDATE_CHANNEL,
 } from '../../../src/shared/app-identity.ts';
+export { NATIVE_MODULES } from '../../native-modules.ts';
 
 export const RELEASE_DIR = 'release';
-export const NATIVE_MODULES = ['better-sqlite3', 'node-pty', '@parcel/watcher'];
 export const GITHUB_OWNER = 'generalaction';
 export const GITHUB_REPO = 'emdash';
 

--- a/apps/emdash-desktop/scripts/release/lib/exec.ts
+++ b/apps/emdash-desktop/scripts/release/lib/exec.ts
@@ -1,4 +1,9 @@
-import { execSync, type ExecSyncOptions } from 'node:child_process';
+import {
+  execFileSync,
+  execSync,
+  type ExecFileSyncOptions,
+  type ExecSyncOptions,
+} from 'node:child_process';
 
 export interface ExecOptions {
   cwd?: string;
@@ -25,6 +30,27 @@ export function exec(cmd: string, opts?: ExecOptions): string {
     const stdout = typeof e.stdout === 'string' ? e.stdout.trim() : '';
     const output = [stdout, stderr].filter(Boolean).join('\n');
     throw new Error(`Command failed (exit ${e.status ?? '?'}): ${cmd}\n${output}`);
+  }
+}
+
+export function execFile(file: string, args: string[], opts?: ExecOptions): string {
+  if (opts?.echo) {
+    console.log(`$ ${[file, ...args].map((part) => JSON.stringify(part)).join(' ')}`);
+  }
+  const execOpts: ExecFileSyncOptions = {
+    encoding: 'utf-8',
+    stdio: ['inherit', 'pipe', 'pipe'],
+    ...(opts?.cwd && { cwd: opts.cwd }),
+    ...(opts?.env && { env: { ...process.env, ...opts.env } }),
+  };
+  try {
+    return (execFileSync(file, args, execOpts) as string).trim();
+  } catch (error: unknown) {
+    const e = error as { stderr?: string; stdout?: string; status?: number };
+    const stderr = typeof e.stderr === 'string' ? e.stderr.trim() : '';
+    const stdout = typeof e.stdout === 'string' ? e.stdout.trim() : '';
+    const output = [stdout, stderr].filter(Boolean).join('\n');
+    throw new Error(`Command failed (exit ${e.status ?? '?'}): ${file}\n${output}`);
   }
 }
 

--- a/apps/emdash-desktop/scripts/release/verify-win.ts
+++ b/apps/emdash-desktop/scripts/release/verify-win.ts
@@ -1,7 +1,7 @@
 import { readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { ARTIFACT_PREFIX, RELEASE_DIR } from './lib/config.ts';
-import { exec } from './lib/exec.ts';
+import { execFile } from './lib/exec.ts';
 import { fail, info, step } from './lib/log.ts';
 
 if (process.platform !== 'win32') {
@@ -25,11 +25,19 @@ for (const f of files) {
   const fullPath = join(RELEASE_DIR, f);
   info(`Verifying signature on ${f}...`);
   try {
-    const output = exec(
-      `powershell -Command "` +
-        `$sig = Get-AuthenticodeSignature -FilePath '${fullPath}'; ` +
-        `if ($sig.Status -ne 'Valid') { Write-Error \\"Invalid: $($sig.Status) - $($sig.StatusMessage)\\"; exit 1 } ` +
-        `Write-Host \\"Status: $($sig.Status)\\"; Write-Host \\"Subject: $($sig.SignerCertificate.Subject)\\""`
+    const output = execFile(
+      'powershell',
+      [
+        '-NoProfile',
+        '-Command',
+        [
+          '$sig = Get-AuthenticodeSignature -FilePath $env:EMDASH_SIGNED_ARTIFACT;',
+          "if ($sig.Status -ne 'Valid') { Write-Error \"Invalid: $($sig.Status) - $($sig.StatusMessage)\"; exit 1 }",
+          'Write-Host "Status: $($sig.Status)";',
+          'Write-Host "Subject: $($sig.SignerCertificate.Subject)"',
+        ].join(' '),
+      ],
+      { env: { EMDASH_SIGNED_ARTIFACT: fullPath } }
     );
     info(output);
   } catch {

--- a/apps/emdash-desktop/scripts/release/verify-win.ts
+++ b/apps/emdash-desktop/scripts/release/verify-win.ts
@@ -32,7 +32,7 @@ for (const f of files) {
         '-Command',
         [
           '$sig = Get-AuthenticodeSignature -FilePath $env:EMDASH_SIGNED_ARTIFACT;',
-          "if ($sig.Status -ne 'Valid') { Write-Error \"Invalid: $($sig.Status) - $($sig.StatusMessage)\"; exit 1 }",
+          'if ($sig.Status -ne \'Valid\') { Write-Error "Invalid: $($sig.Status) - $($sig.StatusMessage)"; exit 1 }',
           'Write-Host "Status: $($sig.Status)";',
           'Write-Host "Subject: $($sig.SignerCertificate.Subject)"',
         ].join(' '),

--- a/apps/emdash-desktop/src/main/app/protocol.test.ts
+++ b/apps/emdash-desktop/src/main/app/protocol.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  net: {
+    fetch: vi.fn(),
+  },
+  protocol: {
+    handle: vi.fn(),
+    registerSchemesAsPrivileged: vi.fn(),
+  },
+}));
+
+const { fileUrlForPath } = await import('./protocol');
+
+describe('app protocol paths', () => {
+  it('formats Windows file paths as valid file URLs', () => {
+    expect(fileUrlForPath('C:\\Users\\Jan\\My App\\index.html')).toBe(
+      'file:///C:/Users/Jan/My%20App/index.html'
+    );
+  });
+});

--- a/apps/emdash-desktop/src/main/app/protocol.ts
+++ b/apps/emdash-desktop/src/main/app/protocol.ts
@@ -1,9 +1,14 @@
 import { join, normalize, sep } from 'node:path';
+import { pathToFileURL } from 'node:url';
 import { net, protocol } from 'electron';
 import { APP_NAME_LOWER } from '@shared/app-identity';
 
 export const APP_SCHEME = 'app';
 export const APP_ORIGIN = `${APP_SCHEME}://${APP_NAME_LOWER}`;
+
+export function fileUrlForPath(filePath: string): string {
+  return pathToFileURL(filePath).toString();
+}
 
 export function registerAppScheme(): void {
   protocol.registerSchemesAsPrivileged([
@@ -32,9 +37,9 @@ export function setupAppProtocol(rendererRoot: string): void {
     }
 
     try {
-      return await net.fetch(`file://${resolved}`);
+      return await net.fetch(fileUrlForPath(resolved));
     } catch {
-      return net.fetch(`file://${join(root, 'index.html')}`);
+      return net.fetch(fileUrlForPath(join(root, 'index.html')));
     }
   });
 }

--- a/apps/emdash-desktop/src/main/core/app/service.test.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.test.ts
@@ -114,6 +114,30 @@ describe('AppService.openIn', () => {
     expect(mocks.openPath).toHaveBeenCalledWith(target);
     expect(mocks.exec).not.toHaveBeenCalled();
   });
+
+  it('escapes Windows cmd metacharacters in quoted launcher paths', async () => {
+    const target = 'C:\\Users\\Qwenzy\\Desktop\\work & notes %USERNAME%^';
+
+    await appService.openIn({ app: 'vscode', path: target });
+
+    expect(mocks.exec).toHaveBeenCalledWith(
+      'code "C:\\Users\\Qwenzy\\Desktop\\work ^& notes ^%USERNAME^%^^" || code-insiders "C:\\Users\\Qwenzy\\Desktop\\work ^& notes ^%USERNAME^%^^"',
+      expect.objectContaining({ cwd: target }),
+      expect.any(Function)
+    );
+  });
+
+  it('uses cwd instead of nested cd commands for Windows terminal fallback', async () => {
+    const target = 'C:\\Users\\Qwenzy\\Desktop\\work & notes %USERNAME%^';
+
+    await appService.openIn({ app: 'terminal', path: target });
+
+    expect(mocks.exec).toHaveBeenCalledWith(
+      'wt -d "C:\\Users\\Qwenzy\\Desktop\\work ^& notes ^%USERNAME^%^^" || start "" cmd /K',
+      expect.objectContaining({ cwd: target }),
+      expect.any(Function)
+    );
+  });
 });
 
 describe('AppService.showTerminalContextMenu', () => {

--- a/apps/emdash-desktop/src/main/core/app/service.test.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.test.ts
@@ -3,6 +3,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 const mocks = vi.hoisted(() => ({
   exec: vi.fn(),
   getVersion: vi.fn(() => '1.1.27'),
+  homedir: vi.fn(() => 'C:\\Users\\Jan'),
+  realpath: vi.fn(async (path: string) => path),
   openExternal: vi.fn(),
   openPath: vi.fn(),
   menuPopup: vi.fn(),
@@ -17,6 +19,22 @@ const mocks = vi.hoisted(() => ({
 vi.mock('node:child_process', () => ({
   exec: mocks.exec,
 }));
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  return {
+    ...actual,
+    realpath: mocks.realpath,
+  };
+});
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:os')>();
+  return {
+    ...actual,
+    homedir: mocks.homedir,
+  };
+});
 
 vi.mock('electron', () => ({
   app: {
@@ -83,6 +101,8 @@ describe('AppService.openIn', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     setPlatform('win32');
+    mocks.homedir.mockReturnValue('C:\\Users\\Jan');
+    mocks.realpath.mockImplementation(async (path: string) => path);
     mocks.openPath.mockResolvedValue('');
     mocks.exec.mockImplementation(
       (_command: string, _options: object, callback: (error: Error | null) => void) => {
@@ -137,6 +157,26 @@ describe('AppService.openIn', () => {
       expect.objectContaining({ cwd: target }),
       expect.any(Function)
     );
+  });
+
+  it('opens home-relative Windows paths with a backslash after tilde', async () => {
+    mocks.realpath.mockImplementation(async (path: string) =>
+      path === 'C:\\Users\\Jan' ? 'C:\\Users\\Jan' : 'C:\\Users\\Jan\\notes.txt'
+    );
+
+    await appService.openPath('~\\notes.txt');
+
+    expect(mocks.openPath).toHaveBeenCalledWith('C:\\Users\\Jan\\notes.txt');
+  });
+
+  it('allows Windows home-contained paths with different drive casing', async () => {
+    mocks.realpath.mockImplementation(async (path: string) =>
+      path === 'C:\\Users\\Jan' ? 'C:\\Users\\Jan' : 'c:\\Users\\Jan\\notes.txt'
+    );
+
+    await appService.openPath('c:\\Users\\Jan\\notes.txt');
+
+    expect(mocks.openPath).toHaveBeenCalledWith('c:\\Users\\Jan\\notes.txt');
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/app/service.test.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.test.ts
@@ -21,7 +21,7 @@ vi.mock('node:child_process', () => ({
 }));
 
 vi.mock('node:fs/promises', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:fs/promises')>();
+  const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
     realpath: mocks.realpath,
@@ -29,7 +29,7 @@ vi.mock('node:fs/promises', async (importOriginal) => {
 });
 
 vi.mock('node:os', async (importOriginal) => {
-  const actual = await importOriginal<typeof import('node:os')>();
+  const actual = await importOriginal<Record<string, unknown>>();
   return {
     ...actual,
     homedir: mocks.homedir,

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -57,6 +57,15 @@ const AUDIO_MIME_TYPES: Record<string, string> = {
   '.webm': 'audio/webm',
 };
 
+function escapeWindowsCmdValue(value: string): string {
+  return value.replace(/\^/g, '^^').replace(/[&|<>%!]/g, '^$&');
+}
+
+function quoteShellArg(value: string): string {
+  if (process.platform === 'win32') return `"${escapeWindowsCmdValue(value)}"`;
+  return `'${value.replace(/'/g, "'\\''")}'`;
+}
+
 function expandAbsoluteOrTildePath(rawPath: string): string {
   if (!rawPath || typeof rawPath !== 'string') throw new Error('Invalid path');
   const expanded = rawPath.startsWith('~/') ? join(homedir(), rawPath.slice(2)) : rawPath;
@@ -539,11 +548,15 @@ class AppService implements IInitializable, IDisposable {
       );
     }
 
-    const quoted = (p: string) =>
-      process.platform !== 'win32' ? `'${p.replace(/'/g, "'\\''")}'` : `"${p.replace(/"/g, '""')}"`;
+    const pathRaw = process.platform === 'win32' ? escapeWindowsCmdValue(target) : target;
     const commands: string[] = platformConfig?.openCommands ?? [];
     const command = commands
-      .map((cmd) => cmd.replace('{{path}}', quoted(target)).replace('{{path_raw}}', target))
+      .map((cmd) =>
+        cmd
+          .replaceAll('{{path_url}}', encodeURIComponent(target))
+          .replaceAll('{{path_raw}}', pathRaw)
+          .replaceAll('{{path}}', quoteShellArg(target))
+      )
       .join(' || ');
 
     if (!command) throw new Error('Unsupported platform or app');

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -1,7 +1,7 @@
 import { exec } from 'node:child_process';
 import { readFile, realpath, stat } from 'node:fs/promises';
 import { homedir } from 'node:os';
-import { extname, isAbsolute, join, resolve, sep } from 'node:path';
+import { extname, isAbsolute, join, relative, resolve } from 'node:path';
 import type { IDisposable, IInitializable } from '@emdash/shared';
 import { eq } from 'drizzle-orm';
 import { app, clipboard, dialog, Menu, shell } from 'electron';
@@ -68,8 +68,11 @@ function quoteShellArg(value: string): string {
 
 function expandAbsoluteOrTildePath(rawPath: string): string {
   if (!rawPath || typeof rawPath !== 'string') throw new Error('Invalid path');
-  const expanded = rawPath.startsWith('~/') ? join(homedir(), rawPath.slice(2)) : rawPath;
-  if (!isAbsolute(expanded)) throw new Error('Path must be absolute or start with ~/');
+  const expanded =
+    rawPath.startsWith('~/') || rawPath.startsWith('~\\')
+      ? join(homedir(), rawPath.slice(2))
+      : rawPath;
+  if (!isAbsolute(expanded)) throw new Error('Path must be absolute or start with ~/ or ~\\');
   return expanded;
 }
 
@@ -77,8 +80,8 @@ async function resolveHomeJailedPath(rawPath: string): Promise<string> {
   const expanded = expandAbsoluteOrTildePath(rawPath);
   const realPath = await realpath(expanded);
   const realHome = await realpath(homedir());
-  const realHomeWithSep = realHome.endsWith(sep) ? realHome : realHome + sep;
-  if (realPath !== realHome && !realPath.startsWith(realHomeWithSep)) {
+  const relativePath = relative(realHome, realPath);
+  if (relativePath.startsWith('..') || isAbsolute(relativePath)) {
     throw new Error('Path must be inside the user home directory');
   }
   return realPath;

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -612,8 +612,8 @@ class AppService implements IInitializable, IDisposable {
 
     const resolvedPath = await realpath(resolve(filePath));
     const resolvedHome = resolve(homedir());
-    const homePrefix = resolvedHome.endsWith(sep) ? resolvedHome : `${resolvedHome}${sep}`;
-    if (!resolvedPath.startsWith(homePrefix) && resolvedPath !== resolvedHome) {
+    const homeRelativePath = relative(resolvedHome, resolvedPath);
+    if (homeRelativePath.startsWith('..') || isAbsolute(homeRelativePath)) {
       throw new Error('Audio file must be located within the user home directory');
     }
 

--- a/apps/emdash-desktop/src/main/core/fs/impl/local-fs.test.ts
+++ b/apps/emdash-desktop/src/main/core/fs/impl/local-fs.test.ts
@@ -1,9 +1,16 @@
 import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { FileSystemError } from '../types';
 import { LocalFileSystem } from './local-fs';
+
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    error: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
 
 describe('LocalFileSystem', () => {
   let tempDir: string;
@@ -460,6 +467,19 @@ describe('LocalFileSystem', () => {
 
       expect(result.success).toBe(false);
       expect(result.error).toContain('too large');
+    });
+  });
+
+  describe('saveAttachment', () => {
+    it('returns a slash-normalized relative attachment path', async () => {
+      const srcPath = path.join(tempDir, 'source.png');
+      fs.writeFileSync(srcPath, Buffer.from([0x89, 0x50, 0x4e, 0x47]));
+
+      const result = await fsService.saveAttachment(srcPath);
+
+      expect(result.success).toBe(true);
+      expect(result.relPath).toBe('.emdash/attachments/source.png');
+      expect(result.relPath).not.toContain('\\');
     });
   });
 

--- a/apps/emdash-desktop/src/main/core/fs/impl/local-fs.ts
+++ b/apps/emdash-desktop/src/main/core/fs/impl/local-fs.ts
@@ -652,7 +652,7 @@ export class LocalFileSystem implements FileSystemProvider {
       }
 
       await fs.copyFile(srcPath, destAbs);
-      const relPath = relative(this.projectPath, destAbs);
+      const relPath = this.relPath(destAbs);
       return { success: true, absPath: destAbs, relPath, fileName: destName };
     } catch (err: unknown) {
       return { success: false, error: err instanceof Error ? err.message : String(err) };

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/worktree-host.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/hosts/worktree-host.ts
@@ -1,7 +1,7 @@
 import type path from 'node:path';
 import type { FileEntry } from '@main/core/fs/types';
 
-export type WorktreeHostPathApi = Pick<typeof path, 'dirname' | 'join'>;
+export type WorktreeHostPathApi = Pick<typeof path, 'dirname' | 'isAbsolute' | 'join' | 'relative'>;
 
 export interface WorktreeHost {
   readonly pathApi: WorktreeHostPathApi;

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -489,6 +489,21 @@ describe('WorktreeService', () => {
       if (!result.success) throw new Error('expected success');
       expect(fs.readFileSync(path.join(result.data, '.env'), 'utf8')).toBe('SECRET=abc');
     });
+
+    it('does not copy case-varied shared config files as preserved files', async () => {
+      fs.writeFileSync(path.join(repoDir, '.EMDASH.JSON'), '{"preservePatterns":["*"]}');
+      await git(['branch', 'task/skip-shared-config'], { cwd: repoDir });
+      const svc = makeService({ projectSettings: makeSettings(['.EMDASH.JSON']) });
+
+      const result = await svc.checkoutBranchWorktree(
+        { type: 'local', branch: 'main' },
+        'task/skip-shared-config'
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(fs.existsSync(path.join(result.data, '.EMDASH.JSON'))).toBe(false);
+    });
   });
 
   describe('removeWorktree', () => {

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.test.ts
@@ -11,6 +11,14 @@ import { LocalWorktreeHost } from './hosts/local-worktree-host';
 import type { WorktreeHost } from './hosts/worktree-host';
 import { WorktreeService } from './worktree-service';
 
+vi.mock('@main/lib/logger', () => ({
+  log: {
+    error: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+  },
+}));
+
 async function git(
   args: string[],
   opts: { cwd: string }
@@ -92,7 +100,10 @@ describe('WorktreeService', () => {
       copyFileAbsolute: vi.fn().mockResolvedValue(undefined),
       statAbsolute: vi.fn().mockResolvedValue(null),
       pathApi: {
+        isAbsolute: (input: string) => path.posix.isAbsolute(input.replace(/^host:/, '')),
         join: (...segments: string[]) => `host:${path.posix.join(...segments)}`,
+        relative: (from: string, to: string) =>
+          path.posix.relative(from.replace(/^host:/, ''), to.replace(/^host:/, '')),
         dirname: (input: string) => `host-dir:${path.posix.dirname(input.replace(/^host:/, ''))}`,
       },
     };
@@ -175,6 +186,62 @@ describe('WorktreeService', () => {
       await expect(svc.getWorktree(branchName)).resolves.toBeUndefined();
 
       expect(fakeHost.removeAbsolute).toHaveBeenCalledWith(targetPath, { recursive: true });
+    });
+
+    it('matches worktree-list entries inside the Windows pool without prefix false positives', async () => {
+      const branchName = 'task/windows-pool';
+      const realPoolPath = 'C:\\worktrees\\repo';
+      const prefixSiblingPath = 'C:\\worktrees\\repo-other\\task\\windows-pool';
+      const casedPoolPath = 'c:\\worktrees\\repo\\task\\windows-pool';
+      const expectedPath = path.win32.join(realPoolPath, branchName);
+      const exec = vi.fn(async (_command: string, args: string[] = []) => {
+        if (args[0] === 'worktree' && args[1] === 'list') {
+          return {
+            stderr: '',
+            stdout: [
+              `worktree ${prefixSiblingPath}`,
+              `branch refs/heads/${branchName}`,
+              '',
+              `worktree ${casedPoolPath}`,
+              `branch refs/heads/${branchName}`,
+              '',
+            ].join('\n'),
+          };
+        }
+        if (args.includes('rev-parse')) return { stdout: 'true\n', stderr: '' };
+        return { stdout: '', stderr: '' };
+      });
+      const fakeHost: WorktreeHost = {
+        pathApi: path.win32,
+        existsAbsolute: vi.fn(async (absPath: string) => absPath === `${casedPoolPath}\\.git`),
+        mkdirAbsolute: vi.fn(async () => {}),
+        removeAbsolute: vi.fn(async () => ({ success: true })),
+        realPathAbsolute: vi.fn(async () => realPoolPath),
+        globAbsolute: vi.fn(async () => []),
+        readFileAbsolute: vi.fn(async () => ''),
+        copyFileAbsolute: vi.fn(async () => {}),
+        statAbsolute: vi.fn(async () => null),
+      };
+      const ctx: IExecutionContext = {
+        root: 'C:\\repo',
+        supportsLocalSpawn: false,
+        exec,
+        execStreaming: async () => {},
+        dispose: () => {},
+      };
+      const svc = new WorktreeService({
+        repoPath: 'C:\\repo',
+        ctx,
+        host: fakeHost,
+        projectSettings: makeSettings(),
+        resolveWorktreePoolPath: async () => realPoolPath,
+      });
+
+      await expect(svc.getWorktree(branchName)).resolves.toBe(casedPoolPath);
+
+      expect(fakeHost.existsAbsolute).toHaveBeenCalledWith(expectedPath);
+      expect(fakeHost.existsAbsolute).not.toHaveBeenCalledWith(`${prefixSiblingPath}\\.git`);
+      expect(fakeHost.existsAbsolute).toHaveBeenCalledWith(`${casedPoolPath}\\.git`);
     });
 
     it('creates a worktree from an existing local source branch', async () => {

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -14,6 +14,10 @@ export type ServeWorktreeError =
   | { type: 'worktree-setup-failed'; cause: SerializedError }
   | { type: 'branch-not-found'; branch: string };
 
+function isSharedConfigPath(relPath: string): boolean {
+  return relPath.replace(/\\/g, '/').toLowerCase() === '.emdash.json';
+}
+
 export class WorktreeService {
   private gitOpQueue: Promise<unknown> = Promise.resolve();
   private readonly resolveWorktreePoolPath: () => Promise<string>;
@@ -447,7 +451,7 @@ export class WorktreeService {
         dot: true,
       });
       for (const relPath of matches) {
-        if (relPath === '.emdash.json' || (await this.isTrackedSourcePath(relPath))) continue;
+        if (isSharedConfigPath(relPath) || (await this.isTrackedSourcePath(relPath))) continue;
         const src = this.host.pathApi.join(this.repoPath, relPath);
         const stat = await this.host.statAbsolute(src).catch(() => null);
         if (!stat || stat.type !== 'file') continue;

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -6,6 +6,7 @@ import type { FileSystemProvider } from '@main/core/fs/types';
 import { log } from '@main/lib/logger';
 import { DEFAULT_REMOTE_NAME } from '@shared/core/git/types';
 import { getEffectiveTaskSettings } from '../settings/effective-task-settings';
+import { isPathInsideRoot } from './hosts/local-worktree-host';
 import type { ProjectSettingsProvider } from '../settings/provider';
 import type { WorktreeHost } from './hosts/worktree-host';
 
@@ -132,7 +133,8 @@ export class WorktreeService {
         const candidatePath = match?.[1];
         if (!candidatePath) continue;
         if (await this.isValidWorktree(candidatePath)) {
-          return candidatePath;
+          if (!this.ctx.supportsLocalSpawn) return candidatePath;
+          return fsPromises.realpath(candidatePath).catch(() => candidatePath);
         }
         await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
       }
@@ -214,7 +216,12 @@ export class WorktreeService {
         if (block.split('\n').some((line) => line === branchLine)) {
           const match = /^worktree (.+)$/m.exec(block);
           const candidatePath = match?.[1];
-          if (!candidatePath?.startsWith(realPoolPath)) continue;
+          if (
+            !candidatePath ||
+            !isPathInsideRoot(candidatePath, realPoolPath, { pathApi: this.host.pathApi })
+          ) {
+            continue;
+          }
           if (await this.isValidWorktree(candidatePath)) return candidatePath;
           await this.ctx.exec('git', ['worktree', 'prune']).catch(() => {});
         }

--- a/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
+++ b/apps/emdash-desktop/src/main/core/projects/worktrees/worktree-service.ts
@@ -6,8 +6,8 @@ import type { FileSystemProvider } from '@main/core/fs/types';
 import { log } from '@main/lib/logger';
 import { DEFAULT_REMOTE_NAME } from '@shared/core/git/types';
 import { getEffectiveTaskSettings } from '../settings/effective-task-settings';
-import { isPathInsideRoot } from './hosts/local-worktree-host';
 import type { ProjectSettingsProvider } from '../settings/provider';
+import { isPathInsideRoot } from './hosts/local-worktree-host';
 import type { WorktreeHost } from './hosts/worktree-host';
 
 export type ServeWorktreeError =

--- a/apps/emdash-desktop/src/main/core/workspaces/setup-steps/copy-preserved-files.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/setup-steps/copy-preserved-files.ts
@@ -27,6 +27,10 @@ async function isTrackedSourcePath(relPath: string, ctx: StepContext): Promise<b
   }
 }
 
+function isSharedConfigPath(relPath: string): boolean {
+  return relPath.replace(/\\/g, '/').toLowerCase() === '.emdash.json';
+}
+
 export async function execute(
   _args: Step.Args,
   ctx: StepContext
@@ -50,7 +54,7 @@ export async function execute(
         dot: true,
       });
       for (const relPath of matches) {
-        if (relPath === '.emdash.json' || (await isTrackedSourcePath(relPath, ctx))) continue;
+        if (isSharedConfigPath(relPath) || (await isTrackedSourcePath(relPath, ctx))) continue;
         const src = ctx.host.pathApi.join(ctx.repoPath, relPath);
         const stat = await ctx.host.statAbsolute(src).catch(() => null);
         if (!stat || stat.type !== 'file') continue;

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
@@ -2,7 +2,7 @@ import type { ILink } from '@xterm/xterm';
 
 // Lookbehind on `:` keeps URLs (`https://...`) with WebLinksAddon.
 const FILE_PATH_PATTERN =
-  '(?<![\\w\\-./@:])(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
+  '(?<![\\w\\-./@:])(?:[a-zA-Z]:[\\\\/]|~[\\\\/]|[\\\\/]|\\.{1,2}[\\\\/])?(?:[\\w\\-.@]+[\\\\/])+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
 const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
 const MAX_WRAPPED_LINE_LENGTH = 4096;
 
@@ -30,7 +30,11 @@ type LogicalLine = {
 
 export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): FileLinkMatch[] {
   const logicalLine = getWrappedLogicalLine(buffer, bufferLineNumber - 1);
-  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('/') === -1) {
+  if (
+    !logicalLine ||
+    !logicalLine.text ||
+    (logicalLine.text.indexOf('/') === -1 && logicalLine.text.indexOf('\\') === -1)
+  ) {
     return [];
   }
 
@@ -53,11 +57,15 @@ export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): Fil
       links.push({
         range: linkRange,
         text: matched,
-        isExternal: matched.startsWith('~/') || matched.startsWith('/'),
+        isExternal: isExternalPath(matched),
       });
     }
   }
   return links;
+}
+
+function isExternalPath(path: string): boolean {
+  return /^[a-zA-Z]:[\\/]/.test(path) || path.startsWith('~/') || path.startsWith('~\\') || path.startsWith('/');
 }
 
 function isEmbeddedInUrl(text: string, startCol: number): boolean {
@@ -156,12 +164,15 @@ function expandHardLineBreakPathContinuations(
 
 function endsWithPathContinuation(text: string): boolean {
   const fragment = trailingToken(text);
-  return fragment.includes('/') && !isEmbeddedInUrl(text, text.length - fragment.length);
+  return (
+    (fragment.includes('/') || fragment.includes('\\')) &&
+    !isEmbeddedInUrl(text, text.length - fragment.length)
+  );
 }
 
 function startsWithPathContinuation(text: string): boolean {
   const trimmed = trimPathContinuationStart(text);
-  return /^[\w.\-@]+(?:\/|[\w.\-@]*\.[a-zA-Z][a-zA-Z0-9]{0,9}\b)/.test(trimmed);
+  return /^[\w.\-@]+(?:[\\/]|[\w.\-@]*\.[a-zA-Z][a-zA-Z0-9]{0,9}\b)/.test(trimmed);
 }
 
 function trimPathContinuationStart(text: string): string {

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
@@ -65,7 +65,12 @@ export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): Fil
 }
 
 function isExternalPath(path: string): boolean {
-  return /^[a-zA-Z]:[\\/]/.test(path) || path.startsWith('~/') || path.startsWith('~\\') || path.startsWith('/');
+  return (
+    /^[a-zA-Z]:[\\/]/.test(path) ||
+    path.startsWith('~/') ||
+    path.startsWith('~\\') ||
+    path.startsWith('/')
+  );
 }
 
 function isEmbeddedInUrl(text: string, startCol: number): boolean {

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-provider.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-provider.ts
@@ -105,7 +105,7 @@ export class FileLinkProvider implements ILinkProvider {
 }
 
 function normalizeFilePath(filePath: string): string {
-  return filePath.replace(/^\.\//, '');
+  return filePath.replace(/^\.[\\/]/, '').replace(/\\/g, '/');
 }
 
 function setDecorations(decorations: LinkDecorations, enabled: boolean): void {

--- a/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
@@ -122,6 +122,39 @@ describe('file link provider', () => {
     ]);
   });
 
+  it('detects Windows relative and absolute paths', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('open src\\main\\app.ts .\\src\\index.ts C:\\repo\\src\\main.ts'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([
+      {
+        range: {
+          start: { x: 6, y: 1 },
+          end: { x: 20, y: 1 },
+        },
+        text: 'src\\main\\app.ts',
+        isExternal: false,
+      },
+      {
+        range: {
+          start: { x: 22, y: 1 },
+          end: { x: 35, y: 1 },
+        },
+        text: '.\\src\\index.ts',
+        isExternal: false,
+      },
+      {
+        range: {
+          start: { x: 37, y: 1 },
+          end: { x: 55, y: 1 },
+        },
+        text: 'C:\\repo\\src\\main.ts',
+        isExternal: true,
+      },
+    ]);
+  });
+
   it('keeps URL paths delegated to the web links addon', () => {
     const buffer = makeBuffer([new MockBufferLine('see https://example.com/src/file.ts')]);
 
@@ -167,7 +200,7 @@ describe('file link provider', () => {
   it('only opens links when the activation modifier is pressed', () => {
     const openedFiles: string[] = [];
     const openedExternal: string[] = [];
-    const buffer = makeBuffer([new MockBufferLine('open ./src/app.ts and /tmp/report.md')]);
+    const buffer = makeBuffer([new MockBufferLine('open .\\src\\app.ts and /tmp/report.md')]);
     const provider = new FileLinkProvider(
       { buffer: { active: buffer } } as never,
       (filePath) => openedFiles.push(filePath),

--- a/apps/emdash-desktop/src/shared/openInApps.test.ts
+++ b/apps/emdash-desktop/src/shared/openInApps.test.ts
@@ -42,7 +42,7 @@ describe('OPEN_IN_APPS', () => {
       'alacritty --working-directory {{path}}',
     ]);
     expect(OPEN_IN_APPS.alacritty.platforms.win32?.openCommands).toContain(
-      'start "" alacritty --working-directory "{{path_raw}}"'
+      'start "" alacritty --working-directory {{path}}'
     );
   });
 
@@ -64,7 +64,26 @@ describe('OPEN_IN_APPS', () => {
     expect(OPEN_IN_APPS.athas.platforms.darwin?.openCommands).toContain(
       'open -n -b com.code.athas --args {{path}}'
     );
-    expect(OPEN_IN_APPS.athas.platforms.win32?.openCommands).toEqual(['athas "{{path_raw}}"']);
+    expect(OPEN_IN_APPS.athas.platforms.win32?.openCommands).toEqual(['athas {{path}}']);
     expect(OPEN_IN_APPS.athas.platforms.linux?.openCommands).toEqual(['athas {{path}}']);
+  });
+
+  it('does not use raw path placeholders in Windows launch commands', () => {
+    for (const app of Object.values(OPEN_IN_APPS)) {
+      for (const command of app.platforms.win32?.openCommands ?? []) {
+        expect(command, app.id).not.toContain('{{path_raw}}');
+      }
+    }
+  });
+
+  it('uses URL-encoded path placeholders in URL launch templates', () => {
+    for (const app of Object.values(OPEN_IN_APPS)) {
+      for (const platformConfig of Object.values(app.platforms)) {
+        for (const url of platformConfig?.openUrls ?? []) {
+          expect(url, app.id).toContain('{{path_url}}');
+          expect(url, app.id).not.toContain('{{path}}');
+        }
+      }
+    }
   });
 });

--- a/apps/emdash-desktop/src/shared/openInApps.ts
+++ b/apps/emdash-desktop/src/shared/openInApps.ts
@@ -206,7 +206,7 @@ const _OPEN_IN_APPS = {
     platforms: {
       darwin: { openCommands: ['open -a Terminal {{path}}'] },
       win32: {
-        openCommands: ['wt -d {{path}}', 'start cmd /K "cd /d {{path_raw}}"'],
+        openCommands: ['wt -d {{path}}', 'start "" cmd /K'],
       },
       linux: {
         openCommands: [
@@ -255,8 +255,8 @@ const _OPEN_IN_APPS = {
       },
       win32: {
         openCommands: [
-          'start "" alacritty --working-directory "{{path_raw}}"',
-          'alacritty --working-directory "{{path_raw}}"',
+          'start "" alacritty --working-directory {{path}}',
+          'alacritty --working-directory {{path}}',
         ],
         checkCommands: ['alacritty'],
       },
@@ -399,7 +399,7 @@ const _OPEN_IN_APPS = {
         appNames: ['Athas'],
       },
       win32: {
-        openCommands: ['athas "{{path_raw}}"'],
+        openCommands: ['athas {{path}}'],
         checkCommands: ['athas'],
       },
       linux: {
@@ -472,7 +472,7 @@ const _OPEN_IN_APPS = {
         appNames: ['Trae'],
       },
       win32: {
-        openCommands: ['trae "{{path_raw}}"'],
+        openCommands: ['trae {{path}}'],
         checkCommands: ['trae'],
       },
       linux: {
@@ -496,7 +496,7 @@ const _OPEN_IN_APPS = {
         appNames: ['Trae Solo'],
       },
       win32: {
-        openCommands: ['trae-solo "{{path_raw}}"'],
+        openCommands: ['trae-solo {{path}}'],
         checkCommands: ['trae-solo'],
       },
       linux: {

--- a/apps/emdash-desktop/src/shared/path-name.test.ts
+++ b/apps/emdash-desktop/src/shared/path-name.test.ts
@@ -34,6 +34,14 @@ describe('path-name helpers', () => {
     it('falls back for Windows reserved device names', () => {
       expect(safePathSegment('NUL', 'project-id')).toBe('project-id');
       expect(safePathSegment('com1', 'project-id')).toBe('project-id');
+      expect(safePathSegment('CON.txt', 'project-id')).toBe('project-id');
+      expect(safePathSegment('aux.', 'project-id')).toBe('project-id');
+    });
+
+    it('removes Windows-invalid trailing dots and spaces', () => {
+      expect(safePathSegment('project.')).toBe('project');
+      expect(safePathSegment('project  ')).toBe('project');
+      expect(safePathSegment('...', 'project-id')).toBe('project-id');
     });
   });
 });

--- a/apps/emdash-desktop/src/shared/path-name.ts
+++ b/apps/emdash-desktop/src/shared/path-name.ts
@@ -14,12 +14,14 @@ export function basenameFromAnyPath(input: string): string {
 export function safePathSegment(input: string, fallback = 'project'): string {
   const segment = basenameFromAnyPath(input)
     .replace(/[<>:"/\\|?*\x00-\x1f]/g, '-')
+    .replace(/[. ]+$/g, '')
     .trim();
+  const stem = segment.split('.')[0] ?? '';
   if (
     !segment ||
     segment === '.' ||
     segment === '..' ||
-    WINDOWS_RESERVED_DEVICE_NAME.test(segment)
+    WINDOWS_RESERVED_DEVICE_NAME.test(stem)
   ) {
     return fallback;
   }

--- a/apps/emdash-desktop/src/shared/path-name.ts
+++ b/apps/emdash-desktop/src/shared/path-name.ts
@@ -17,12 +17,7 @@ export function safePathSegment(input: string, fallback = 'project'): string {
     .replace(/[. ]+$/g, '')
     .trim();
   const stem = segment.split('.')[0] ?? '';
-  if (
-    !segment ||
-    segment === '.' ||
-    segment === '..' ||
-    WINDOWS_RESERVED_DEVICE_NAME.test(stem)
-  ) {
+  if (!segment || segment === '.' || segment === '..' || WINDOWS_RESERVED_DEVICE_NAME.test(stem)) {
     return fallback;
   }
   return segment;


### PR DESCRIPTION
﻿## Summary
- audit and fix Windows path handling across app launchers, file links, worktree safety, protocol URLs, and attachment paths
- harden Windows release/build scripts for native rebuilds, artifact paths, deploy path quoting, and signing requirements
- add focused Windows regression coverage for the fixed areas

## Validation
- pnpm --filter @emdash/core --filter @emdash/plugins --filter @emdash/ui --filter @emdash/chat-ui build
- pnpm exec tsgo --noEmit
- pnpm exec tsgo --noEmit -p scripts/release/tsconfig.json
- pnpm exec vitest run --project node src/main/core/app/service.test.ts src/shared/openInApps.test.ts src/shared/path-name.test.ts src/main/core/fs/impl/local-fs.test.ts src/main/core/projects/worktrees/worktree-service.test.ts src/main/app/protocol.test.ts src/renderer/tests/file-link-provider.test.ts --project scripts scripts/release/lib/artifacts.test.ts
- pnpm exec oxlint .