### PR TITLE
feat(tasks): edit issue context templates

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -6,7 +6,6 @@ import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-sel
 import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
 import { Field } from '@renderer/lib/ui/field';
-import { Popover, PopoverContent, PopoverTrigger } from '@renderer/lib/ui/popover';
 import {
   Select,
   SelectContent,
@@ -232,46 +231,53 @@ export function InitialConversationField({
           </div>
         </div>
 
-        {/* Issue context pill */}
+        {/* Issue context pill — click to insert as editable text in the prompt */}
         {state.issueContext && linkedIssue && (
           <div className="px-2 py-1">
-            <Popover>
-              <PopoverTrigger
+            <div
+              role="button"
+              tabIndex={0}
+              onClick={() => {
+                state.setPrompt((current) =>
+                  appendInitialConversationText(current, state.issueContext ?? '')
+                );
+                state.setIssueContext(null);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  state.setPrompt((current) =>
+                    appendInitialConversationText(current, state.issueContext ?? '')
+                  );
+                  state.setIssueContext(null);
+                }
+              }}
+              className={cn(
+                'group relative flex items-center gap-1.5 rounded bg-background-2 py-0.5 pr-6 pl-2 text-xs text-foreground-muted',
+                'hover:bg-background-3 cursor-pointer'
+              )}
+            >
+              <ProviderLogo provider={linkedIssue.provider} className="size-3 shrink-0" />
+              <span className="font-mono">{linkedIssue.identifier}</span>
+              {linkedIssue.title && (
+                <span className="max-w-48 truncate text-foreground-passive">
+                  {linkedIssue.title}
+                </span>
+              )}
+              <button
+                type="button"
+                onClick={(e) => {
+                  e.stopPropagation();
+                  state.setIssueContext(null);
+                }}
                 className={cn(
-                  'group relative flex items-center gap-1.5 rounded bg-background-2 py-0.5 pr-6 pl-2 text-xs text-foreground-muted',
-                  'hover:bg-background-3 cursor-pointer'
+                  'absolute right-1 flex items-center justify-center rounded p-0.5',
+                  'text-foreground-passive opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'
                 )}
               >
-                <ProviderLogo provider={linkedIssue.provider} className="size-3 shrink-0" />
-                <span className="font-mono">{linkedIssue.identifier}</span>
-                {linkedIssue.title && (
-                  <span className="max-w-48 truncate text-foreground-passive">
-                    {linkedIssue.title}
-                  </span>
-                )}
-                <button
-                  type="button"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    state.setIssueContext(null);
-                  }}
-                  className={cn(
-                    'absolute right-1 flex items-center justify-center rounded p-0.5',
-                    'text-foreground-passive opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'
-                  )}
-                >
-                  <X className="size-3" />
-                </button>
-              </PopoverTrigger>
-              <PopoverContent side="bottom" align="start" sideOffset={6} className="w-80 gap-0 p-2">
-                <Textarea
-                  value={state.issueContext ?? ''}
-                  onChange={(e) => state.setIssueContext(e.target.value || null)}
-                  placeholder="Edit the issue context sent to the agent..."
-                  className="max-h-64 min-h-32 resize-none font-mono text-xs"
-                />
-              </PopoverContent>
-            </Popover>
+                <X className="size-3" />
+              </button>
+            </div>
           </div>
         )}
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -147,6 +147,10 @@ export function InitialConversationField({
     [linkedIssue, promptLibrary]
   );
   const modelOptions = useModelOptions(state.provider);
+  const defaultIssueContext = useMemo(
+    () => (linkedIssue ? buildIssueContextText(linkedIssue) : null),
+    [linkedIssue]
+  );
   const issueContextKey =
     state.issueContext && linkedIssue
       ? `${linkedIssue.provider}:${linkedIssue.identifier}:${state.issueContext}`
@@ -155,11 +159,9 @@ export function InitialConversationField({
 
   // Auto-inject issue context whenever the linked issue changes.
   useEffect(() => {
-    state.setIssueContext(
-      includeIssueContextByDefault && linkedIssue ? buildIssueContextText(linkedIssue) : null
-    );
+    state.setIssueContext(includeIssueContextByDefault ? defaultIssueContext : null);
     // oxlint-disable-next-line react/exhaustive-deps
-  }, [includeIssueContextByDefault, linkedIssue?.identifier, linkedIssue?.provider]);
+  }, [defaultIssueContext, includeIssueContextByDefault]);
 
   // Let the issue combobox finish its close animation before mounting the editable context pill.
   useEffect(() => {
@@ -333,7 +335,10 @@ function IssueContextEditButton({
         </button>
         <button
           type="button"
-          onClick={() => state.setIssueContext(null)}
+          onClick={() => {
+            state.setIssueContextEditorOpen(false);
+            state.setIssueContext(null);
+          }}
           className={cn(
             'absolute right-1 flex items-center justify-center rounded p-0.5',
             'text-foreground-passive opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -1,5 +1,5 @@
 import { CheckCheckIcon, ChevronDownIcon, PlusIcon, X } from 'lucide-react';
-import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
@@ -45,6 +45,8 @@ export type InitialConversationState = {
   setIssueContext: (ctx: string | null) => void;
   autoApprove: boolean;
   setAutoApprove: (autoApprove: boolean) => void;
+  issueContextEditorOpen: boolean;
+  setIssueContextEditorOpen: (open: boolean) => void;
   /** Selected model id, or null to use the agent CLI default. */
   model: string | null;
   setModel: (model: string | null) => void;
@@ -67,6 +69,7 @@ export function useInitialConversationState(
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
+  const [issueContextEditorOpen, setIssueContextEditorOpen] = useState(false);
   const [model, setModel] = useState<string | null>(null);
 
   const [prevProjectId, setPrevProjectId] = useState(projectId);
@@ -82,6 +85,7 @@ export function useInitialConversationState(
     }
     setIssueContext(null);
     setAutoApproveOverride(null);
+    setIssueContextEditorOpen(false);
     setModel(null);
   } else if (providerChanged) {
     setPrevProviderId(providerId);
@@ -101,6 +105,8 @@ export function useInitialConversationState(
     setIssueContext,
     autoApprove,
     setAutoApprove: setAutoApproveOverride,
+    issueContextEditorOpen,
+    setIssueContextEditorOpen,
     model,
     setModel,
     connectionId,
@@ -141,6 +147,11 @@ export function InitialConversationField({
     [linkedIssue, promptLibrary]
   );
   const modelOptions = useModelOptions(state.provider);
+  const issueContextKey =
+    state.issueContext && linkedIssue
+      ? `${linkedIssue.provider}:${linkedIssue.identifier}:${state.issueContext}`
+      : null;
+  const [visibleIssueContextKey, setVisibleIssueContextKey] = useState<string | null>(null);
 
   // Auto-inject issue context whenever the linked issue changes.
   useEffect(() => {
@@ -149,6 +160,17 @@ export function InitialConversationField({
     );
     // oxlint-disable-next-line react/exhaustive-deps
   }, [includeIssueContextByDefault, linkedIssue?.identifier, linkedIssue?.provider]);
+
+  // Let the issue combobox finish its close animation before mounting the editable context pill.
+  useEffect(() => {
+    if (!issueContextKey) {
+      setVisibleIssueContextKey(null);
+      return;
+    }
+
+    const timeout = window.setTimeout(() => setVisibleIssueContextKey(issueContextKey), 150);
+    return () => window.clearTimeout(timeout);
+  }, [issueContextKey]);
 
   const canToggleAutoApprove = state.provider ? providerSupportsAutoApprove(state.provider) : false;
 
@@ -241,7 +263,7 @@ export function InitialConversationField({
         </div>
 
         {/* Issue context pill — click to edit in a modal */}
-        {state.issueContext && linkedIssue && (
+        {state.issueContext && linkedIssue && visibleIssueContextKey === issueContextKey && (
           <div className="px-2 py-1">
             <IssueContextEditButton state={state} linkedIssue={linkedIssue} />
           </div>
@@ -281,28 +303,14 @@ function IssueContextEditButton({
   const defaultContext = useMemo(() => buildIssueContextText(linkedIssue), [linkedIssue]);
   const hasChanges = draft !== defaultContext;
   const handleReset = () => setDraft(defaultContext);
+  const handleOpenChange = (nextOpen: boolean) => {
+    setOpen(nextOpen);
+    state.setIssueContextEditorOpen(nextOpen);
+  };
   const handleSave = () => {
     state.setIssueContext(draft.trim() || null);
-    setOpen(false);
+    handleOpenChange(false);
   };
-  const handleSaveRef = useRef(handleSave);
-  handleSaveRef.current = handleSave;
-
-  // Intercept Cmd/Ctrl+Enter while the editor is open so it saves the issue
-  // context instead of triggering the parent dialog's global confirm hotkey.
-  // Capture phase on document runs before the confirm hotkey's bubble listener.
-  useEffect(() => {
-    if (!open) return;
-    const onKeyDown = (e: KeyboardEvent) => {
-      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
-        e.preventDefault();
-        e.stopPropagation();
-        handleSaveRef.current();
-      }
-    };
-    document.addEventListener('keydown', onKeyDown, true);
-    return () => document.removeEventListener('keydown', onKeyDown, true);
-  }, [open]);
 
   return (
     <>
@@ -314,7 +322,7 @@ function IssueContextEditButton({
       >
         <button
           type="button"
-          onClick={() => setOpen(true)}
+          onClick={() => handleOpenChange(true)}
           className={cn('flex flex-1 items-center gap-1.5 cursor-pointer min-w-0 py-0.5')}
         >
           <ProviderLogo provider={linkedIssue.provider} className="size-3 shrink-0" />
@@ -335,7 +343,7 @@ function IssueContextEditButton({
         </button>
       </div>
       {open ? (
-        <Dialog open={open} onOpenChange={setOpen}>
+        <Dialog open={open} onOpenChange={handleOpenChange}>
           <DialogContent className="sm:max-w-2xl">
             <DialogHeader>
               <DialogTitle>Edit issue context</DialogTitle>

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -1,10 +1,11 @@
 import { CheckCheckIcon, ChevronDownIcon, PlusIcon, X } from 'lucide-react';
-import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
+import { useEffect, useMemo, useRef, useState, type Dispatch, type SetStateAction } from 'react';
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
 import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
+import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
 import {
   Dialog,
   DialogContent,
@@ -280,6 +281,28 @@ function IssueContextEditButton({
   const defaultContext = useMemo(() => buildIssueContextText(linkedIssue), [linkedIssue]);
   const hasChanges = draft !== defaultContext;
   const handleReset = () => setDraft(defaultContext);
+  const handleSave = () => {
+    state.setIssueContext(draft.trim() || null);
+    setOpen(false);
+  };
+  const handleSaveRef = useRef(handleSave);
+  handleSaveRef.current = handleSave;
+
+  // Intercept Cmd/Ctrl+Enter while the editor is open so it saves the issue
+  // context instead of triggering the parent dialog's global confirm hotkey.
+  // Capture phase on document runs before the confirm hotkey's bubble listener.
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if ((e.metaKey || e.ctrlKey) && e.key === 'Enter') {
+        e.preventDefault();
+        e.stopPropagation();
+        handleSaveRef.current();
+      }
+    };
+    document.addEventListener('keydown', onKeyDown, true);
+    return () => document.removeEventListener('keydown', onKeyDown, true);
+  }, [open]);
 
   return (
     <>
@@ -331,16 +354,9 @@ function IssueContextEditButton({
                   Reset to default
                 </Button>
               ) : null}
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => {
-                  state.setIssueContext(draft.trim() || null);
-                  setOpen(false);
-                }}
-              >
+              <ConfirmButton size="sm" onClick={handleSave}>
                 Save
-              </Button>
+              </ConfirmButton>
             </DialogFooter>
           </DialogContent>
         </Dialog>

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -12,7 +12,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DialogTrigger,
 } from '@renderer/lib/ui/dialog';
 import { Field } from '@renderer/lib/ui/field';
 import {
@@ -283,26 +282,24 @@ function IssueContextEditButton({
   const handleReset = () => setDraft(defaultContext);
 
   return (
-    <Dialog open={open} onOpenChange={setOpen}>
+    <>
       <div
         className={cn(
           'group relative flex items-center gap-1.5 rounded bg-background-2 py-0.5 pr-6 pl-2 text-xs text-foreground-muted',
           'hover:bg-background-3'
         )}
       >
-        <DialogTrigger
-          render={
-            <div
-              className={cn('flex flex-1 items-center gap-1.5 cursor-pointer', 'min-w-0 py-0.5')}
-            />
-          }
+        <button
+          type="button"
+          onClick={() => setOpen(true)}
+          className={cn('flex flex-1 items-center gap-1.5 cursor-pointer min-w-0 py-0.5')}
         >
           <ProviderLogo provider={linkedIssue.provider} className="size-3 shrink-0" />
           <span className="font-mono">{linkedIssue.identifier}</span>
           {linkedIssue.title && (
             <span className="max-w-48 truncate text-foreground-passive">{linkedIssue.title}</span>
           )}
-        </DialogTrigger>
+        </button>
         <button
           type="button"
           onClick={() => state.setIssueContext(null)}
@@ -314,36 +311,40 @@ function IssueContextEditButton({
           <X className="size-3" />
         </button>
       </div>
-      <DialogContent className="sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>Edit issue context</DialogTitle>
-        </DialogHeader>
-        <DialogContentArea>
-          <Textarea
-            value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            placeholder="Edit the issue context sent to the agent..."
-            className="max-h-[60dvh] min-h-48 resize-none font-mono text-xs"
-          />
-        </DialogContentArea>
-        <DialogFooter>
-          {hasChanges ? (
-            <Button variant="ghost" size="sm" onClick={handleReset}>
-              Reset to default
-            </Button>
-          ) : null}
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => {
-              state.setIssueContext(draft.trim() || null);
-              setOpen(false);
-            }}
-          >
-            Save
-          </Button>
-        </DialogFooter>
-      </DialogContent>
-    </Dialog>
+      {open ? (
+        <Dialog open={open} onOpenChange={setOpen}>
+          <DialogContent className="sm:max-w-2xl">
+            <DialogHeader>
+              <DialogTitle>Edit issue context</DialogTitle>
+            </DialogHeader>
+            <DialogContentArea>
+              <Textarea
+                value={draft}
+                onChange={(e) => setDraft(e.target.value)}
+                placeholder="Edit the issue context sent to the agent..."
+                className="max-h-[60dvh] min-h-48 resize-none font-mono text-xs"
+              />
+            </DialogContentArea>
+            <DialogFooter>
+              {hasChanges ? (
+                <Button variant="ghost" size="sm" onClick={handleReset}>
+                  Reset to default
+                </Button>
+              ) : null}
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => {
+                  state.setIssueContext(draft.trim() || null);
+                  setOpen(false);
+                }}
+              >
+                Save
+              </Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      ) : null}
+    </>
   );
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -5,6 +5,15 @@ import { getProjectSshConnectionId } from '@renderer/features/projects/stores/pr
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
 import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Button } from '@renderer/lib/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogContentArea,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@renderer/lib/ui/dialog';
 import { Field } from '@renderer/lib/ui/field';
 import {
   Select,
@@ -231,53 +240,10 @@ export function InitialConversationField({
           </div>
         </div>
 
-        {/* Issue context pill — click to insert as editable text in the prompt */}
+        {/* Issue context pill — click to edit in a modal */}
         {state.issueContext && linkedIssue && (
           <div className="px-2 py-1">
-            <div
-              role="button"
-              tabIndex={0}
-              onClick={() => {
-                state.setPrompt((current) =>
-                  appendInitialConversationText(current, state.issueContext ?? '')
-                );
-                state.setIssueContext(null);
-              }}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter' || e.key === ' ') {
-                  e.preventDefault();
-                  state.setPrompt((current) =>
-                    appendInitialConversationText(current, state.issueContext ?? '')
-                  );
-                  state.setIssueContext(null);
-                }
-              }}
-              className={cn(
-                'group relative flex items-center gap-1.5 rounded bg-background-2 py-0.5 pr-6 pl-2 text-xs text-foreground-muted',
-                'hover:bg-background-3 cursor-pointer'
-              )}
-            >
-              <ProviderLogo provider={linkedIssue.provider} className="size-3 shrink-0" />
-              <span className="font-mono">{linkedIssue.identifier}</span>
-              {linkedIssue.title && (
-                <span className="max-w-48 truncate text-foreground-passive">
-                  {linkedIssue.title}
-                </span>
-              )}
-              <button
-                type="button"
-                onClick={(e) => {
-                  e.stopPropagation();
-                  state.setIssueContext(null);
-                }}
-                className={cn(
-                  'absolute right-1 flex items-center justify-center rounded p-0.5',
-                  'text-foreground-passive opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'
-                )}
-              >
-                <X className="size-3" />
-              </button>
-            </div>
+            <IssueContextEditButton state={state} linkedIssue={linkedIssue} />
           </div>
         )}
 
@@ -293,5 +259,91 @@ export function InitialConversationField({
         />
       </div>
     </Field>
+  );
+}
+
+function IssueContextEditButton({
+  state,
+  linkedIssue,
+}: {
+  state: InitialConversationState;
+  linkedIssue: LinkedIssue;
+}) {
+  const [open, setOpen] = useState(false);
+  const [draft, setDraft] = useState('');
+
+  // Seed the draft from the current issue context whenever the dialog opens.
+  useEffect(() => {
+    if (open) setDraft(state.issueContext ?? '');
+    // oxlint-disable-next-line react/exhaustive-deps
+  }, [open]);
+
+  const defaultContext = useMemo(() => buildIssueContextText(linkedIssue), [linkedIssue]);
+  const hasChanges = draft !== defaultContext;
+  const handleReset = () => setDraft(defaultContext);
+
+  return (
+    <Dialog open={open} onOpenChange={setOpen}>
+      <div
+        className={cn(
+          'group relative flex items-center gap-1.5 rounded bg-background-2 py-0.5 pr-6 pl-2 text-xs text-foreground-muted',
+          'hover:bg-background-3'
+        )}
+      >
+        <DialogTrigger
+          render={
+            <div
+              className={cn('flex flex-1 items-center gap-1.5 cursor-pointer', 'min-w-0 py-0.5')}
+            />
+          }
+        >
+          <ProviderLogo provider={linkedIssue.provider} className="size-3 shrink-0" />
+          <span className="font-mono">{linkedIssue.identifier}</span>
+          {linkedIssue.title && (
+            <span className="max-w-48 truncate text-foreground-passive">{linkedIssue.title}</span>
+          )}
+        </DialogTrigger>
+        <button
+          type="button"
+          onClick={() => state.setIssueContext(null)}
+          className={cn(
+            'absolute right-1 flex items-center justify-center rounded p-0.5',
+            'text-foreground-passive opacity-0 transition-opacity hover:text-foreground group-hover:opacity-100'
+          )}
+        >
+          <X className="size-3" />
+        </button>
+      </div>
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>Edit issue context</DialogTitle>
+        </DialogHeader>
+        <DialogContentArea>
+          <Textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Edit the issue context sent to the agent..."
+            className="max-h-[60dvh] min-h-48 resize-none font-mono text-xs"
+          />
+        </DialogContentArea>
+        <DialogFooter>
+          {hasChanges ? (
+            <Button variant="ghost" size="sm" onClick={handleReset}>
+              Reset to default
+            </Button>
+          ) : null}
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              state.setIssueContext(draft.trim() || null);
+              setOpen(false);
+            }}
+          >
+            Save
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -263,10 +263,13 @@ export function InitialConversationField({
                   <X className="size-3" />
                 </button>
               </PopoverTrigger>
-              <PopoverContent side="bottom" align="start" sideOffset={6} className="w-80 gap-0 p-0">
-                <pre className="p-3 font-mono text-xs whitespace-pre-wrap text-foreground-passive">
-                  {state.issueContext}
-                </pre>
+              <PopoverContent side="bottom" align="start" sideOffset={6} className="w-80 gap-0 p-2">
+                <Textarea
+                  value={state.issueContext ?? ''}
+                  onChange={(e) => state.setIssueContext(e.target.value || null)}
+                  placeholder="Edit the issue context sent to the agent..."
+                  className="max-h-64 min-h-32 resize-none font-mono text-xs"
+                />
               </PopoverContent>
             </Popover>
           </div>

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
@@ -16,6 +16,8 @@ function makeInitialConversationState(
     setIssueContext: () => {},
     autoApprove,
     setAutoApprove: () => {},
+    issueContextEditorOpen: false,
+    setIssueContextEditorOpen: () => {},
     model: null,
     setModel: () => {},
   };

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -22,7 +22,9 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
+import type { LinkedIssue } from '@shared/core/linked-issue';
 import type { PullRequest } from '@shared/core/pull-requests/pull-requests';
+import { buildIssueContextText } from '../conversations/context-actions';
 import { useInitialConversationState } from '../conversations/initial-conversation-section';
 import { LinkedEntitySection } from './linked-entity-section';
 import { TaskNameField } from './task-name-field';
@@ -104,6 +106,12 @@ export const CreateTaskModal = observer(function CreateTaskModal({
     undefined,
     autoApproveByDefault
   );
+  const handleLinkedIssueChange = (issue: LinkedIssue | null) => {
+    state.setLinkedIssue(issue);
+    initialConversation.setIssueContext(
+      includeIssueContextByDefault && issue ? buildIssueContextText(issue) : null
+    );
+  };
   const isWorkspaceProviderEnabled = useFeatureFlag('workspace-provider');
   const { navigate } = useNavigate();
 
@@ -130,6 +138,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
             projectId={selectedProjectId}
             repositoryUrl={repositoryUrl}
             projectPath={projectPath}
+            onLinkedIssueChange={handleLinkedIssueChange}
           />
           <TaskStateProvider
             workspaceConfig={state.workspaceConfig}

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -22,9 +22,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
-import type { LinkedIssue } from '@shared/core/linked-issue';
 import type { PullRequest } from '@shared/core/pull-requests/pull-requests';
-import { buildIssueContextText } from '../conversations/context-actions';
 import { useInitialConversationState } from '../conversations/initial-conversation-section';
 import { LinkedEntitySection } from './linked-entity-section';
 import { TaskNameField } from './task-name-field';
@@ -106,12 +104,6 @@ export const CreateTaskModal = observer(function CreateTaskModal({
     undefined,
     autoApproveByDefault
   );
-  const handleLinkedIssueChange = (issue: LinkedIssue | null) => {
-    state.setLinkedIssue(issue);
-    initialConversation.setIssueContext(
-      includeIssueContextByDefault && issue ? buildIssueContextText(issue) : null
-    );
-  };
   const isWorkspaceProviderEnabled = useFeatureFlag('workspace-provider');
   const { navigate } = useNavigate();
 
@@ -138,7 +130,6 @@ export const CreateTaskModal = observer(function CreateTaskModal({
             projectId={selectedProjectId}
             repositoryUrl={repositoryUrl}
             projectPath={projectPath}
-            onLinkedIssueChange={handleLinkedIssueChange}
           />
           <TaskStateProvider
             workspaceConfig={state.workspaceConfig}
@@ -170,7 +161,11 @@ export const CreateTaskModal = observer(function CreateTaskModal({
         </div>
       </DialogContentArea>
       <DialogFooter>
-        <ConfirmButton size="sm" onClick={handleCreateTask} disabled={!canCreate}>
+        <ConfirmButton
+          size="sm"
+          onClick={handleCreateTask}
+          disabled={!canCreate || initialConversation.issueContextEditorOpen}
+        >
           Create
         </ConfirmButton>
       </DialogFooter>

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/linked-entity-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/linked-entity-section.tsx
@@ -1,5 +1,4 @@
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
-import type { LinkedIssue } from '@shared/core/linked-issue';
 import { IssueComboboxField } from './issue-combobox-field';
 import { PrComboboxField } from './pr-combobox-field';
 import type { LinkedType, CreateTaskState } from './use-create-task-state';
@@ -11,7 +10,6 @@ interface LinkedEntitySectionProps {
   projectId?: string;
   repositoryUrl?: string;
   projectPath?: string;
-  onLinkedIssueChange?: (issue: LinkedIssue | null) => void;
 }
 
 export function LinkedEntitySection({
@@ -21,7 +19,6 @@ export function LinkedEntitySection({
   projectId,
   repositoryUrl,
   projectPath,
-  onLinkedIssueChange,
 }: LinkedEntitySectionProps) {
   return (
     <div className="flex w-full flex-col justify-between overflow-hidden rounded-lg border">
@@ -55,7 +52,7 @@ export function LinkedEntitySection({
       {state.linkedType === 'issue' && (
         <IssueComboboxField
           value={state.linkedIssue}
-          onValueChange={onLinkedIssueChange ?? state.setLinkedIssue}
+          onValueChange={state.setLinkedIssue}
           projectId={projectId}
           repositoryUrl={repositoryUrl}
           projectPath={projectPath}

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/linked-entity-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/linked-entity-section.tsx
@@ -1,4 +1,5 @@
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
+import type { LinkedIssue } from '@shared/core/linked-issue';
 import { IssueComboboxField } from './issue-combobox-field';
 import { PrComboboxField } from './pr-combobox-field';
 import type { LinkedType, CreateTaskState } from './use-create-task-state';
@@ -10,6 +11,7 @@ interface LinkedEntitySectionProps {
   projectId?: string;
   repositoryUrl?: string;
   projectPath?: string;
+  onLinkedIssueChange?: (issue: LinkedIssue | null) => void;
 }
 
 export function LinkedEntitySection({
@@ -19,6 +21,7 @@ export function LinkedEntitySection({
   projectId,
   repositoryUrl,
   projectPath,
+  onLinkedIssueChange,
 }: LinkedEntitySectionProps) {
   return (
     <div className="flex w-full flex-col justify-between overflow-hidden rounded-lg border">
@@ -52,7 +55,7 @@ export function LinkedEntitySection({
       {state.linkedType === 'issue' && (
         <IssueComboboxField
           value={state.linkedIssue}
-          onValueChange={state.setLinkedIssue}
+          onValueChange={onLinkedIssueChange ?? state.setLinkedIssue}
           projectId={projectId}
           repositoryUrl={repositoryUrl}
           projectPath={projectPath}


### PR DESCRIPTION
## summary
- add an editable issue-context modal for create-task prompts
- keep issue selection stable by deferring the context pill mount
- use the standard confirm shortcut for saving issue context without creating the task

### Screenshot/Recording (if applicable)
https://cap.link/mc6fcxge4hypkj7