### PR TITLE
feat(diff-view): add Branch section for full-branch diff vs default

### DIFF
--- a/apps/emdash-desktop/src/main/core/git/legacy/git-service.ts
+++ b/apps/emdash-desktop/src/main/core/git/legacy/git-service.ts
@@ -661,6 +661,20 @@ export class GitService implements IDisposable {
     return changes;
   }
 
+  async getMergeBase(base: GitObjectRef, head: GitObjectRef): Promise<string | null> {
+    try {
+      const { stdout } = await this.ctx.exec('git', [
+        'merge-base',
+        toRefString(base),
+        toRefString(head),
+      ]);
+      const sha = stdout.trim();
+      return sha.length > 0 ? sha : null;
+    } catch {
+      return null;
+    }
+  }
+
   async getCommitFiles(commitHash: string): Promise<CommitFile[]> {
     const { stdout } = await this.ctx.exec('git', [
       'diff-tree',

--- a/apps/emdash-desktop/src/main/core/git/worktree/controller.ts
+++ b/apps/emdash-desktop/src/main/core/git/worktree/controller.ts
@@ -37,6 +37,22 @@ export const gitWorktreeController = createRPCController({
     }
   },
 
+  getMergeBase: async (
+    projectId: string,
+    workspaceId: string,
+    base: GitObjectRef,
+    head: GitObjectRef
+  ) => {
+    try {
+      const workspace = resolveWorkspace(projectId, workspaceId);
+      if (!workspace) return err({ type: 'not_found' as const });
+      return ok({ sha: await workspace.gitWorktree.getMergeBase(base, head) });
+    } catch (error) {
+      log.error('gitCtrl.getMergeBase failed', { projectId, workspaceId, base, head, error });
+      return err({ type: 'git_error' as const, message: gitErrorMessage(error) });
+    }
+  },
+
   getFileAtRef: async (projectId: string, workspaceId: string, filePath: string, ref: string) => {
     try {
       const workspace = resolveWorkspace(projectId, workspaceId);

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
@@ -35,7 +35,7 @@ import type {
   SubscribedSnapshot,
 } from '@emdash/core/git';
 import type { ImageReadResult } from '@emdash/core/git';
-import type { DiffTarget } from '@emdash/core/git';
+import type { DiffTarget, GitObjectRef } from '@emdash/core/git';
 import type { CommitFile, GitLogResult } from '@emdash/core/git';
 import type { GitRefsModel, GitRemote, GitRemotesModel } from '@emdash/core/git';
 import type { GitHeadModel } from '@emdash/core/git';
@@ -491,6 +491,10 @@ class LegacySshGitWorktree implements IGitWorktree {
 
   getChangedFiles(base: DiffTarget): Promise<GitChange[]> {
     return this.git.getChangedFiles(base) as Promise<GitChange[]>;
+  }
+
+  getMergeBase(base: GitObjectRef, head: GitObjectRef): Promise<string | null> {
+    return this.git.getMergeBase(base, head) as Promise<string | null>;
   }
 
   getFileAtRef(filePath: string, ref: string): Promise<string | null> {

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -92,6 +92,7 @@ export const interfaceSettingsSchema = z.object({
 export const changesViewModeSchema = z.object({
   unstaged: z.enum(['flat', 'tree']),
   staged: z.enum(['flat', 'tree']),
+  branch: z.enum(['flat', 'tree']),
   pr: z.enum(['flat', 'tree']),
 });
 

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -74,6 +74,7 @@ export const SETTINGS_DEFAULTS = {
   changesViewMode: {
     unstaged: 'flat' as const,
     staged: 'flat' as const,
+    branch: 'flat' as const,
     pr: 'flat' as const,
   },
 } satisfies SettingsDefaultsMap;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/branch-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/branch-section.tsx
@@ -26,10 +26,16 @@ export const BranchSection = observer(function BranchSection() {
   const { mode: viewMode, setMode: setViewMode } = useChangesViewMode('branch');
 
   // Always call usePrefetchDiffModels unconditionally (React hooks rules).
-  // When defaultBranchRef is null, we fall back to HEAD_REF; this is harmless
-  // because the component returns null for 'no-default-branch' before any list
-  // is rendered, so the prefetch callback is never actually invoked.
-  const baseRef = branchDiff?.defaultBranchRef ?? HEAD_REF;
+  // When originalRef is null (initial merge-base resolution in flight), we fall
+  // back to HEAD_REF for the prefetch target; this is harmless because openDiff
+  // gates on the same null check and refuses to attach a tab in that window.
+  //
+  // The left side of every Branch diff tab is pinned to the merge-base. In
+  // Committed mode this avoids the empty-diff-after-squash-merge bug; in All
+  // mode it makes the file list a strict superset of Committed and means files
+  // don't disappear when main independently catches up to the same content.
+  const originalRef = branchDiff?.originalRef ?? null;
+  const baseRef = originalRef ?? HEAD_REF;
   const modifiedRef =
     branchDiff?.compareMode === 'committed'
       ? (branchDiff.currentBranchRef ?? undefined)
@@ -43,7 +49,7 @@ export const BranchSection = observer(function BranchSection() {
   const activePath = _activeDiff?.diffGroup === 'branch' ? _activeDiff.path : undefined;
 
   const openDiff = (change: GitChange, preview: boolean) => {
-    if (!branchDiff.defaultBranchRef) return;
+    if (!originalRef) return;
     taskView.activePane.open(
       'diff',
       {
@@ -51,7 +57,7 @@ export const BranchSection = observer(function BranchSection() {
           path: change.path,
           type: 'git',
           group: 'branch',
-          originalRef: branchDiff.defaultBranchRef,
+          originalRef,
           modifiedRef,
         },
         status: change.status,

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/branch-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/branch-section.tsx
@@ -1,6 +1,6 @@
 import type { GitChange } from '@emdash/core/git';
-import { type ReactNode } from 'react';
 import { observer } from 'mobx-react-lite';
+import { type ReactNode } from 'react';
 import { activeDiffEntry } from '@renderer/features/tasks/diff-view/pane-selectors';
 import type { BranchEmptyState } from '@renderer/features/tasks/diff-view/stores/branch-diff-store';
 import {
@@ -30,9 +30,10 @@ export const BranchSection = observer(function BranchSection() {
   // because the component returns null for 'no-default-branch' before any list
   // is rendered, so the prefetch callback is never actually invoked.
   const baseRef = branchDiff?.defaultBranchRef ?? HEAD_REF;
-  const modifiedRef = branchDiff?.compareMode === 'committed'
-    ? (branchDiff.currentBranchRef ?? undefined)
-    : undefined;
+  const modifiedRef =
+    branchDiff?.compareMode === 'committed'
+      ? (branchDiff.currentBranchRef ?? undefined)
+      : undefined;
   const prefetch = usePrefetchDiffModels(projectId, workspaceId, 'branch', baseRef, modifiedRef);
 
   if (!branchDiff || !changesView) return null;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/branch-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/branch-section.tsx
@@ -1,0 +1,140 @@
+import type { GitChange } from '@emdash/core/git';
+import { type ReactNode } from 'react';
+import { observer } from 'mobx-react-lite';
+import { activeDiffEntry } from '@renderer/features/tasks/diff-view/pane-selectors';
+import type { BranchEmptyState } from '@renderer/features/tasks/diff-view/stores/branch-diff-store';
+import {
+  useTaskViewContext,
+  useWorkspaceId,
+  useWorkspaceViewModel,
+} from '@renderer/features/tasks/task-view-context';
+import { EmptyState } from '@renderer/lib/ui/empty-state';
+import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
+import { HEAD_REF } from '@shared/core/git/types';
+import { ChangesListOrTree } from './components/changes-list-or-tree';
+import { ChangesViewModeToggle } from './components/changes-view-mode-toggle';
+import { SectionHeader } from './components/section-header';
+import { useChangesViewMode } from './hooks/use-changes-view-mode';
+import { usePrefetchDiffModels } from './hooks/use-prefetch-diff-models';
+
+export const BranchSection = observer(function BranchSection() {
+  const { projectId } = useTaskViewContext();
+  const workspaceId = useWorkspaceId();
+  const taskView = useWorkspaceViewModel();
+  const branchDiff = taskView.diffView?.branchDiff;
+  const changesView = taskView.diffView?.changesView;
+  const { mode: viewMode, setMode: setViewMode } = useChangesViewMode('branch');
+
+  // Always call usePrefetchDiffModels unconditionally (React hooks rules).
+  // When defaultBranchRef is null, we fall back to HEAD_REF; this is harmless
+  // because the component returns null for 'no-default-branch' before any list
+  // is rendered, so the prefetch callback is never actually invoked.
+  const baseRef = branchDiff?.defaultBranchRef ?? HEAD_REF;
+  const modifiedRef = branchDiff?.compareMode === 'committed'
+    ? (branchDiff.currentBranchRef ?? undefined)
+    : undefined;
+  const prefetch = usePrefetchDiffModels(projectId, workspaceId, 'branch', baseRef, modifiedRef);
+
+  if (!branchDiff || !changesView) return null;
+  if (branchDiff.emptyState?.kind === 'no-default-branch') return null;
+
+  const _activeDiff = activeDiffEntry(taskView.activePane);
+  const activePath = _activeDiff?.diffGroup === 'branch' ? _activeDiff.path : undefined;
+
+  const openDiff = (change: GitChange, preview: boolean) => {
+    if (!branchDiff.defaultBranchRef) return;
+    taskView.activePane.open(
+      'diff',
+      {
+        activeFile: {
+          path: change.path,
+          type: 'git',
+          group: 'branch',
+          originalRef: branchDiff.defaultBranchRef,
+          modifiedRef,
+        },
+        status: change.status,
+      },
+      { preview }
+    );
+  };
+
+  return (
+    <>
+      <SectionHeader
+        label="Branch"
+        collapsed={!changesView.expandedSections.branch}
+        onToggleCollapsed={() => changesView.toggleExpanded('branch')}
+        count={branchDiff.files.length}
+        actions={
+          <>
+            <ChangesViewModeToggle value={viewMode} onChange={setViewMode} label="Branch" />
+            <ToggleGroup
+              size="sm"
+              multiple={false}
+              value={[branchDiff.compareMode]}
+              onValueChange={([value]) => {
+                if (value === 'committed' || value === 'all') branchDiff.setCompareMode(value);
+              }}
+            >
+              <ToggleGroupItem value="committed">Committed</ToggleGroupItem>
+              <ToggleGroupItem value="all">All</ToggleGroupItem>
+            </ToggleGroup>
+          </>
+        }
+      />
+      <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+        {branchDiff.emptyState ? (
+          renderEmptyState(branchDiff.emptyState)
+        ) : (
+          <div className="min-h-0 flex-1 px-1">
+            <ChangesListOrTree
+              viewMode={viewMode}
+              changes={[...branchDiff.files]}
+              activePath={activePath}
+              onSelectChange={(c) => openDiff(c, true)}
+              onDoubleClickChange={(c) => openDiff(c, false)}
+              onPrefetch={(c) => prefetch(c.path)}
+            />
+          </div>
+        )}
+      </div>
+    </>
+  );
+});
+
+function renderEmptyState(state: BranchEmptyState): ReactNode {
+  switch (state.kind) {
+    case 'no-default-branch':
+      // Shouldn't reach here — component returns null above for this case.
+      return null;
+    case 'default-not-resolved':
+      return (
+        <EmptyState
+          label="Fetch default branch"
+          description="The default branch is not present locally. Fetch the remote to compare."
+        />
+      );
+    case 'on-default-branch':
+      return (
+        <EmptyState
+          label="On default branch"
+          description="This worktree matches the default branch — nothing to compare."
+        />
+      );
+    case 'unborn':
+      return (
+        <EmptyState
+          label="No commits yet"
+          description="Create your first commit to compare against the default branch."
+        />
+      );
+    case 'no-changes':
+      return (
+        <EmptyState
+          label="No branch changes"
+          description="This branch is identical to the default branch."
+        />
+      );
+  }
+}

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react-lite';
 import { useWorkspace, useWorkspaceViewModel } from '@renderer/features/tasks/task-view-context';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@renderer/lib/ui/resizable';
 import { cn } from '@renderer/utils/utils';
+import { BranchSection } from './branch-section';
 import { GitStatusSection } from './git-status-section';
 import { SECTION_HEADER_HEIGHT, usePanelLayout } from './hooks/use-panel-layout';
 import { PullRequestsSection } from './pr-section';
@@ -21,6 +22,7 @@ export const ChangesPanel = observer(function ChangesPanel() {
     pointerHandlers,
     unstagedRef,
     stagedRef,
+    branchRef,
     prRef,
     spacerRef,
     containerRef,
@@ -43,7 +45,7 @@ export const ChangesPanel = observer(function ChangesPanel() {
           collapsedSize={SECTION_HEADER_HEIGHT}
           minSize="150px"
           maxSize="100%"
-          defaultSize="33%"
+          defaultSize="25%"
           className={cn('flex flex-col overflow-hidden', panelTransitionClass)}
         >
           <UnstagedSection />
@@ -56,15 +58,25 @@ export const ChangesPanel = observer(function ChangesPanel() {
           collapsedSize={SECTION_HEADER_HEIGHT}
           minSize="150px"
           maxSize="100%"
-          defaultSize="33%"
+          defaultSize="25%"
           className={cn('flex flex-col overflow-hidden', panelTransitionClass)}
         >
           <StagedSection />
         </ResizablePanel>
-        <ResizableHandle
-          disabled={!expanded.staged || !expanded.pullRequests}
-          {...pointerHandlers}
-        />
+        <ResizableHandle disabled={!expanded.staged || !expanded.branch} {...pointerHandlers} />
+        <ResizablePanel
+          id="changes-branch"
+          panelRef={branchRef}
+          collapsible
+          collapsedSize={SECTION_HEADER_HEIGHT}
+          minSize="150px"
+          maxSize="100%"
+          defaultSize="25%"
+          className={cn('flex flex-col overflow-hidden', panelTransitionClass)}
+        >
+          <BranchSection />
+        </ResizablePanel>
+        <ResizableHandle disabled={!expanded.branch || !expanded.pullRequests} {...pointerHandlers} />
         <ResizablePanel
           id="changes-pr"
           panelRef={prRef}
@@ -72,7 +84,7 @@ export const ChangesPanel = observer(function ChangesPanel() {
           collapsedSize={SECTION_HEADER_HEIGHT}
           minSize="150px"
           maxSize="100%"
-          defaultSize="33%"
+          defaultSize="25%"
           className={cn('flex flex-col overflow-hidden', panelTransitionClass)}
         >
           <PullRequestsSection

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/changes-panel.tsx
@@ -76,7 +76,10 @@ export const ChangesPanel = observer(function ChangesPanel() {
         >
           <BranchSection />
         </ResizablePanel>
-        <ResizableHandle disabled={!expanded.branch || !expanded.pullRequests} {...pointerHandlers} />
+        <ResizableHandle
+          disabled={!expanded.branch || !expanded.pullRequests}
+          {...pointerHandlers}
+        />
         <ResizablePanel
           id="changes-pr"
           panelRef={prRef}

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/commit-card.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/commit-card.tsx
@@ -76,7 +76,7 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
     setCommitMessage('');
     setDescription('');
     if (!autoStage) {
-      changesView.setExpanded({ unstaged: true, staged: false, pullRequests: hasPRs });
+      changesView.setExpanded({ unstaged: true, staged: false, branch: true, pullRequests: hasPRs });
     }
     setPhase('commit-only-done');
     setTimeout(() => setPhase('idle'), 3000);
@@ -94,7 +94,7 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
     setCommitMessage('');
     setDescription('');
     if (!autoStage) {
-      changesView.setExpanded({ unstaged: true, staged: false, pullRequests: hasPRs });
+      changesView.setExpanded({ unstaged: true, staged: false, branch: true, pullRequests: hasPRs });
     }
     setPhase('committed');
     await new Promise((r) => setTimeout(r, 1000));
@@ -121,7 +121,7 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
     setCommitMessage('');
     setDescription('');
     if (!autoStage) {
-      changesView.setExpanded({ unstaged: true, staged: false, pullRequests: hasPRs });
+      changesView.setExpanded({ unstaged: true, staged: false, branch: true, pullRequests: hasPRs });
     }
     setPhase('opening-pr');
     await new Promise((r) => setTimeout(r, 500));

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/commit-card.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/commit-card.tsx
@@ -76,7 +76,12 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
     setCommitMessage('');
     setDescription('');
     if (!autoStage) {
-      changesView.setExpanded({ unstaged: true, staged: false, branch: true, pullRequests: hasPRs });
+      changesView.setExpanded({
+        unstaged: true,
+        staged: false,
+        branch: true,
+        pullRequests: hasPRs,
+      });
     }
     setPhase('commit-only-done');
     setTimeout(() => setPhase('idle'), 3000);
@@ -94,7 +99,12 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
     setCommitMessage('');
     setDescription('');
     if (!autoStage) {
-      changesView.setExpanded({ unstaged: true, staged: false, branch: true, pullRequests: hasPRs });
+      changesView.setExpanded({
+        unstaged: true,
+        staged: false,
+        branch: true,
+        pullRequests: hasPRs,
+      });
     }
     setPhase('committed');
     await new Promise((r) => setTimeout(r, 1000));
@@ -121,7 +131,12 @@ export const CommitCard = observer(function CommitCard({ autoStage = false }: Co
     setCommitMessage('');
     setDescription('');
     if (!autoStage) {
-      changesView.setExpanded({ unstaged: true, staged: false, branch: true, pullRequests: hasPRs });
+      changesView.setExpanded({
+        unstaged: true,
+        staged: false,
+        branch: true,
+        pullRequests: hasPRs,
+      });
     }
     setPhase('opening-pr');
     await new Promise((r) => setTimeout(r, 500));

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
@@ -7,7 +7,7 @@ import type {
 
 // Unreachable in practice: callers guard with `if (!changesView) return null` before calling this
 // hook, so changesView is always non-null here. React Hooks rules prevent a conditional call.
-const DEFAULT_EXPANDED: ExpandedSections = { unstaged: true, staged: true, pullRequests: true };
+const DEFAULT_EXPANDED: ExpandedSections = { unstaged: true, staged: true, branch: true, pullRequests: true };
 
 // Matches the SectionHeader height: outer py-2 (8+8px) + button p-2 (8+8px) + size-4 icon (16px) = 48px
 export const SECTION_HEADER_HEIGHT = '40px';

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
@@ -24,6 +24,7 @@ type usePanelLayoutReturn = {
   };
   unstagedRef: ReturnType<typeof usePanelRef>;
   stagedRef: ReturnType<typeof usePanelRef>;
+  branchRef: ReturnType<typeof usePanelRef>;
   prRef: ReturnType<typeof usePanelRef>;
   spacerRef: ReturnType<typeof usePanelRef>;
   containerRef: React.RefObject<HTMLDivElement | null>;
@@ -35,6 +36,7 @@ export function usePanelLayout(
 ): usePanelLayoutReturn {
   const unstagedRef = usePanelRef();
   const stagedRef = usePanelRef();
+  const branchRef = usePanelRef();
   const prRef = usePanelRef();
   const spacerRef = usePanelRef();
 
@@ -63,6 +65,7 @@ export function usePanelLayout(
     const sections = [
       { key: 'unstaged' as const, ref: unstagedRef },
       { key: 'staged' as const, ref: stagedRef },
+      { key: 'branch' as const, ref: branchRef },
       { key: 'pullRequests' as const, ref: prRef },
     ];
 
@@ -78,7 +81,7 @@ export function usePanelLayout(
         ref.current?.collapse();
       }
     });
-  }, [expanded, isVisible, unstagedRef, stagedRef, prRef, spacerRef]);
+  }, [expanded, isVisible, unstagedRef, stagedRef, branchRef, prRef, spacerRef]);
 
   return {
     expanded,
@@ -88,6 +91,7 @@ export function usePanelLayout(
     pointerHandlers,
     unstagedRef,
     stagedRef,
+    branchRef,
     prRef,
     spacerRef,
     containerRef,

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-panel-layout.ts
@@ -7,7 +7,12 @@ import type {
 
 // Unreachable in practice: callers guard with `if (!changesView) return null` before calling this
 // hook, so changesView is always non-null here. React Hooks rules prevent a conditional call.
-const DEFAULT_EXPANDED: ExpandedSections = { unstaged: true, staged: true, branch: true, pullRequests: true };
+const DEFAULT_EXPANDED: ExpandedSections = {
+  unstaged: true,
+  staged: true,
+  branch: true,
+  pullRequests: true,
+};
 
 // Matches the SectionHeader height: outer py-2 (8+8px) + button p-2 (8+8px) + size-4 icon (16px) = 48px
 export const SECTION_HEADER_HEIGHT = '40px';

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/hooks/use-prefetch-diff-models.ts
@@ -20,7 +20,7 @@ interface PrefetchEntry {
 export function usePrefetchDiffModels(
   projectId: string,
   workspaceId: string,
-  group: 'disk' | 'staged' | 'git' | 'pr',
+  group: 'disk' | 'staged' | 'git' | 'pr' | 'branch',
   originalRef: GitRef,
   modifiedRef?: GitRef
 ) {
@@ -65,9 +65,21 @@ export function usePrefetchDiffModels(
           modelRegistry.toGitUri(uri, HEAD_REF),
           modelRegistry.toGitUri(uri, STAGED_REF),
         ];
+      } else if (group === 'branch' && modifiedRef === undefined) {
+        // All mode: original is git/defaultBranch, modified is working tree (disk).
+        void modelRegistry
+          .registerModel(projectId, workspaceId, root, filePath, language, 'git', originalRef)
+          .catch(() => {});
+        void modelRegistry
+          .registerModel(projectId, workspaceId, root, filePath, language, 'disk')
+          .catch(() => {});
+        entry.diskUri = modelRegistry.toDiskUri(uri);
+        entry.gitUris = [modelRegistry.toGitUri(uri, originalRef)];
       } else {
         const effectiveModifiedRef =
-          (group === 'git' || group === 'pr') && modifiedRef ? modifiedRef : HEAD_REF;
+          (group === 'git' || group === 'pr' || group === 'branch') && modifiedRef
+            ? modifiedRef
+            : HEAD_REF;
         void modelRegistry
           .registerModel(projectId, workspaceId, root, filePath, language, 'git', originalRef)
           .catch(() => {});

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/diff-tab-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/diff-tab-item.tsx
@@ -19,6 +19,8 @@ export function diffGroupSuffix(diffGroup: DiffTabResource['diffGroup']): string
       return '(PR)';
     case 'git':
       return '(Git)';
+    case 'branch':
+      return '(Branch)';
   }
 }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/diff-tab-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/diff-tab-provider.tsx
@@ -104,5 +104,7 @@ export function diffGroupSuffix(diffGroup: DiffPayload['diffGroup']): string {
       return '(PR)';
     case 'git':
       return '(Git)';
+    case 'branch':
+      return '(Branch)';
   }
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -115,7 +115,7 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
     if (tab.diffGroup === 'disk') {
       return modelRegistry.toGitUri(uri, STAGED_REF);
     }
-    if (tab.diffGroup === 'git' || tab.diffGroup === 'pr') {
+    if (tab.diffGroup === 'git' || tab.diffGroup === 'pr' || tab.diffGroup === 'branch') {
       return modelRegistry.toGitUri(uri, tab.originalRef);
     }
     return modelRegistry.toGitUri(uri, HEAD_REF);
@@ -128,6 +128,9 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
     }
     if (tab.diffGroup === 'git') {
       return modelRegistry.toGitUri(uri, tab.modifiedRef ?? HEAD_REF);
+    }
+    if (tab.diffGroup === 'branch') {
+      return tab.modifiedRef ? modelRegistry.toGitUri(uri, tab.modifiedRef) : uri;
     }
     return uri;
   })();
@@ -178,6 +181,51 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
       void modelRegistry
         .registerModel(projectId, workspaceId, root, tab.path, language, 'git', STAGED_REF)
         .catch(() => {});
+    } else if (tab.diffGroup === 'branch') {
+      void modelRegistry
+        .registerModel(projectId, workspaceId, root, tab.path, language, 'git', tab.originalRef)
+        .catch(() => {});
+
+      if (tab.modifiedRef) {
+        // Committed mode: modified side is also a git ref (current branch).
+        void modelRegistry
+          .registerModel(projectId, workspaceId, root, tab.path, language, 'git', tab.modifiedRef)
+          .catch(() => {});
+      } else {
+        // All mode: modified side is the working tree — same as 'disk' branch.
+        const diskUri = modelRegistry.toDiskUri(uri);
+        void (async () => {
+          if (tab.status !== 'deleted') {
+            try {
+              await modelRegistry.registerModel(
+                projectId,
+                workspaceId,
+                root,
+                tab.path,
+                language,
+                'disk'
+              );
+            } catch (err) {
+              if (!isMissingFileError(err)) throw err;
+            }
+          }
+          if (disposed) {
+            modelRegistry.unregisterModel(diskUri);
+            return;
+          }
+          await modelRegistry.registerModel(
+            projectId,
+            workspaceId,
+            root,
+            tab.path,
+            language,
+            'buffer'
+          );
+          if (disposed) {
+            modelRegistry.unregisterModel(modifiedUri);
+          }
+        })().catch(() => {});
+      }
     } else {
       void modelRegistry
         .registerModel(projectId, workspaceId, root, tab.path, language, 'git', tab.originalRef)
@@ -200,7 +248,7 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
       disposed = true;
       modelRegistry.unregisterModel(originalUri);
       modelRegistry.unregisterModel(modifiedUri);
-      if (tab.diffGroup === 'disk') {
+      if (tab.diffGroup === 'disk' || (tab.diffGroup === 'branch' && !tab.modifiedRef)) {
         modelRegistry.unregisterModel(modelRegistry.toDiskUri(uri));
       }
     };

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-toolbar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-toolbar.tsx
@@ -18,6 +18,7 @@ export const DiffToolbar = observer(function DiffToolbar({ tab }: DiffToolbarPro
     if (tab.diffGroup === 'disk') return 'Changed';
     if (tab.diffGroup === 'pr') return 'PR';
     if (tab.diffGroup === 'git') return 'Git';
+    if (tab.diffGroup === 'branch') return 'Branch';
     return undefined;
   })();
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/image-diff-view.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/image-diff-view.tsx
@@ -130,6 +130,10 @@ function loadModified(
         activeFile.path,
         activeFile.modifiedRef ?? HEAD_REF
       );
+    case 'branch':
+      return activeFile.modifiedRef
+        ? loadFromRef(projectId, workspaceId, activeFile.path, activeFile.modifiedRef)
+        : loadFromDisk(projectId, workspaceId, activeFile.path);
   }
 }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.test.ts
@@ -1,0 +1,180 @@
+import type { GitChange, GitObjectRef } from '@emdash/core/git';
+import { autorun, makeAutoObservable } from 'mobx';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { rpc } from '@renderer/lib/ipc';
+import type { GitRepositoryStore } from '@renderer/features/projects/stores/git-repository-store';
+import type { GitWorktreeStore } from '@renderer/features/tasks/stores/git-worktree-store';
+import { BranchDiffStore } from './branch-diff-store';
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    workspace: {
+      gitWorktree: {
+        getChangedFiles: vi.fn(),
+      },
+    },
+  },
+  events: {
+    on: vi.fn(() => () => {}),
+  },
+}));
+
+class FakeGitRepositoryStore {
+  defaultBranch: { type: 'local'; branch: string } | undefined = {
+    type: 'local',
+    branch: 'main',
+  };
+  constructor() {
+    makeAutoObservable(this);
+  }
+}
+
+class FakeGitWorktreeStore {
+  branchName: string | null = 'feature/x';
+  headKind: 'branch' | 'detached' | 'unborn' = 'branch';
+  // Head OID is read via a method to mirror the real store's mirror-model accessor.
+  currentHeadOid(): string | null {
+    return this.headKind === 'unborn' ? null : 'aaaa1111';
+  }
+  constructor() {
+    makeAutoObservable(this);
+  }
+}
+
+const change = (path: string): GitChange => ({
+  path,
+  status: 'modified',
+  additions: 1,
+  deletions: 0,
+});
+
+function createStore(overrides?: {
+  defaultBranch?: FakeGitRepositoryStore['defaultBranch'];
+  head?: FakeGitWorktreeStore;
+}) {
+  const repo = new FakeGitRepositoryStore();
+  if (overrides && 'defaultBranch' in overrides) repo.defaultBranch = overrides.defaultBranch;
+  const worktree = overrides?.head ?? new FakeGitWorktreeStore();
+  const store = new BranchDiffStore(
+    'proj-1',
+    'ws-1',
+    repo as unknown as GitRepositoryStore,
+    worktree as unknown as GitWorktreeStore,
+  );
+  return { repo, worktree, store };
+}
+
+describe('BranchDiffStore', () => {
+  beforeEach(() => {
+    vi.mocked(rpc.workspace.gitWorktree.getChangedFiles).mockResolvedValue({
+      success: true,
+      data: { changes: [change('a.ts'), change('b.ts')] },
+    });
+  });
+
+  it('defaults to committed mode', () => {
+    // arrange / act
+    const { store } = createStore();
+
+    // assert
+    expect(store.compareMode).toBe('committed');
+  });
+
+  it('exposes isAvailable=true when defaultBranch is resolvable', () => {
+    // arrange / act
+    const { store } = createStore();
+
+    // assert
+    expect(store.isAvailable).toBe(true);
+  });
+
+  it('returns emptyState no-default-branch when defaultBranch is undefined', () => {
+    // arrange / act
+    const { store } = createStore({ defaultBranch: undefined });
+
+    // assert
+    expect(store.isAvailable).toBe(false);
+    expect(store.emptyState).toEqual({ kind: 'no-default-branch' });
+  });
+
+  it('returns emptyState on-default-branch when current branch equals default', () => {
+    // arrange
+    const head = new FakeGitWorktreeStore();
+    head.branchName = 'main';
+
+    // act
+    const { store } = createStore({ head });
+
+    // assert
+    expect(store.emptyState).toEqual({ kind: 'on-default-branch' });
+  });
+
+  it('returns emptyState unborn when HEAD is unborn', () => {
+    // arrange
+    const head = new FakeGitWorktreeStore();
+    head.headKind = 'unborn';
+    head.branchName = null;
+
+    // act
+    const { store } = createStore({ head });
+
+    // assert
+    expect(store.emptyState).toEqual({ kind: 'unborn' });
+  });
+
+  it('produces a commit-ref for currentBranchRef when HEAD is detached', () => {
+    // arrange
+    const head = new FakeGitWorktreeStore();
+    head.headKind = 'detached';
+    head.branchName = null;
+
+    // act
+    const { store } = createStore({ head });
+    const ref = store.currentBranchRef;
+
+    // assert
+    expect(ref).toEqual({ kind: 'commit', sha: 'aaaa1111' } satisfies GitObjectRef);
+  });
+
+  it('switches compareMode via setCompareMode', () => {
+    // arrange
+    const { store } = createStore();
+
+    // act
+    store.setCompareMode('all');
+
+    // assert
+    expect(store.compareMode).toBe('all');
+  });
+
+  it('files computed reflects new resource data after compareMode changes', async () => {
+    // arrange
+    vi.clearAllMocks();
+    vi.mocked(rpc.workspace.gitWorktree.getChangedFiles)
+      .mockResolvedValueOnce({ success: true, data: { changes: [change('a.ts')] } })
+      .mockResolvedValueOnce({ success: true, data: { changes: [change('b.ts')] } });
+
+    const { store } = createStore();
+
+    // Subscribe to store.files via autorun to make it an observed computed.
+    // Without observable.ref on _resource, the computed would never re-evaluate
+    // after _rebuildResource swaps the resource, so filesSnapshots would only
+    // ever contain the stale initial value.
+    const filesSnapshots: string[][] = [];
+    const disposeAutorun = autorun(() => {
+      filesSnapshots.push(store.files.map((f) => f.path));
+    });
+
+    // wait for the initial resource load triggered by fireImmediately reaction
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    // act
+    store.setCompareMode('all');
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    disposeAutorun();
+
+    // assert: files eventually reflected b.ts (the second mock response)
+    expect(filesSnapshots).toContainEqual(['b.ts']);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.test.ts
@@ -1,9 +1,9 @@
 import type { GitChange, GitObjectRef } from '@emdash/core/git';
 import { autorun, makeAutoObservable } from 'mobx';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { rpc } from '@renderer/lib/ipc';
 import type { GitRepositoryStore } from '@renderer/features/projects/stores/git-repository-store';
 import type { GitWorktreeStore } from '@renderer/features/tasks/stores/git-worktree-store';
+import { rpc } from '@renderer/lib/ipc';
 import { BranchDiffStore } from './branch-diff-store';
 
 vi.mock('@renderer/lib/ipc', () => ({
@@ -59,7 +59,7 @@ function createStore(overrides?: {
     'proj-1',
     'ws-1',
     repo as unknown as GitRepositoryStore,
-    worktree as unknown as GitWorktreeStore,
+    worktree as unknown as GitWorktreeStore
   );
   return { repo, worktree, store };
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.test.ts
@@ -11,6 +11,7 @@ vi.mock('@renderer/lib/ipc', () => ({
     workspace: {
       gitWorktree: {
         getChangedFiles: vi.fn(),
+        getMergeBase: vi.fn(),
       },
     },
   },
@@ -19,8 +20,12 @@ vi.mock('@renderer/lib/ipc', () => ({
   },
 }));
 
+type FakeBranchRef =
+  | { type: 'local'; branch: string }
+  | { type: 'remote'; branch: string; remote: { name: string; url: string } };
+
 class FakeGitRepositoryStore {
-  defaultBranch: { type: 'local'; branch: string } | undefined = {
+  defaultBranch: FakeBranchRef | undefined = {
     type: 'local',
     branch: 'main',
   };
@@ -70,6 +75,10 @@ describe('BranchDiffStore', () => {
       success: true,
       data: { changes: [change('a.ts'), change('b.ts')] },
     });
+    vi.mocked(rpc.workspace.gitWorktree.getMergeBase).mockResolvedValue({
+      success: true,
+      data: { sha: null },
+    });
   });
 
   it('defaults to committed mode', () => {
@@ -106,6 +115,27 @@ describe('BranchDiffStore', () => {
     const { store } = createStore({ head });
 
     // assert
+    expect(store.emptyState).toEqual({ kind: 'on-default-branch' });
+  });
+
+  it('returns emptyState on-default-branch when default is a remote ref of the same branch name', () => {
+    // arrange — worktree on local `main`, project's defaultBranch configured as `origin/main`
+    const head = new FakeGitWorktreeStore();
+    head.branchName = 'main';
+
+    // act
+    const { store } = createStore({
+      head,
+      defaultBranch: {
+        type: 'remote',
+        branch: 'main',
+        remote: { name: 'origin', url: 'https://github.com/example/repo.git' },
+      },
+    });
+
+    // assert — without the local↔remote-name match in isOnDefaultBranch, this
+    // would fall through to a Branch comparison against the live ref instead
+    // of the empty state.
     expect(store.emptyState).toEqual({ kind: 'on-default-branch' });
   });
 
@@ -147,6 +177,76 @@ describe('BranchDiffStore', () => {
     expect(store.compareMode).toBe('all');
   });
 
+  it('resolves mergeBaseRef to a commit ref after the rpc returns a sha', async () => {
+    // arrange
+    vi.mocked(rpc.workspace.gitWorktree.getMergeBase).mockResolvedValueOnce({
+      success: true,
+      data: { sha: 'cafebabe1234' },
+    });
+    const { store } = createStore();
+    const snapshots: Array<GitObjectRef | null> = [];
+    const dispose = autorun(() => {
+      snapshots.push(store.mergeBaseRef);
+    });
+
+    // act — wait for the async resource to settle
+    await new Promise<void>((r) => setTimeout(r, 0));
+    dispose();
+
+    // assert — autorun should have observed the transition null -> commit ref
+    expect(snapshots).toContainEqual({
+      kind: 'commit',
+      sha: 'cafebabe1234',
+    } satisfies GitObjectRef);
+    expect(store.mergeBaseRef).toEqual({
+      kind: 'commit',
+      sha: 'cafebabe1234',
+    } satisfies GitObjectRef);
+  });
+
+  it('leaves mergeBaseRef null when the rpc reports no common ancestor', async () => {
+    // arrange
+    vi.mocked(rpc.workspace.gitWorktree.getMergeBase).mockResolvedValueOnce({
+      success: true,
+      data: { sha: null },
+    });
+    const { store } = createStore();
+
+    // act
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    // assert
+    expect(store.mergeBaseRef).toBeNull();
+  });
+
+  it('All mode requests the file list against the merge-base commit, not the default branch tip', async () => {
+    // arrange
+    vi.clearAllMocks();
+    vi.mocked(rpc.workspace.gitWorktree.getMergeBase).mockResolvedValue({
+      success: true,
+      data: { sha: 'deadbeef9999' },
+    });
+    vi.mocked(rpc.workspace.gitWorktree.getChangedFiles).mockResolvedValue({
+      success: true,
+      data: { changes: [] },
+    });
+
+    const { store } = createStore();
+    store.setCompareMode('all');
+
+    // act
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    // assert — the last getChangedFiles call must use the merge-base commit
+    // ref as the diff target, not the live defaultBranch ref. Without this the
+    // diff loses files whenever main independently catches up to the same
+    // content (e.g. after a squash merge or a parallel PR).
+    const calls = vi.mocked(rpc.workspace.gitWorktree.getChangedFiles).mock.calls;
+    expect(calls.length).toBeGreaterThan(0);
+    const [, , target] = calls[calls.length - 1]!;
+    expect(target).toEqual({ kind: 'commit', sha: 'deadbeef9999' } satisfies GitObjectRef);
+  });
+
   it('files computed reflects new resource data after compareMode changes', async () => {
     // arrange
     vi.clearAllMocks();
@@ -176,5 +276,106 @@ describe('BranchDiffStore', () => {
 
     // assert: files eventually reflected b.ts (the second mock response)
     expect(filesSnapshots).toContainEqual(['b.ts']);
+  });
+
+  it('originalRef stays null while the first merge-base resolution is in flight', async () => {
+    // arrange — block the getMergeBase response so we can observe the loading window
+    vi.clearAllMocks();
+    let resolveMb: (value: { success: true; data: { sha: string | null } }) => void = () => {};
+    vi.mocked(rpc.workspace.gitWorktree.getMergeBase).mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveMb = resolve;
+        })
+    );
+    vi.mocked(rpc.workspace.gitWorktree.getChangedFiles).mockResolvedValue({
+      success: true,
+      data: { changes: [] },
+    });
+
+    const { store } = createStore();
+
+    // act / assert — during the pending RPC, originalRef must be null so click
+    // handlers can't accidentally open a Branch diff tab pinned to the live
+    // default-branch tip.
+    expect(store.originalRef).toBeNull();
+
+    resolveMb({ success: true, data: { sha: 'feedface5678' } });
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    // After resolution it returns the merge-base commit ref.
+    expect(store.originalRef).toEqual({
+      kind: 'commit',
+      sha: 'feedface5678',
+    } satisfies GitObjectRef);
+  });
+
+  it('originalRef falls back to defaultBranchRef only after merge-base settles with no common ancestor', async () => {
+    // arrange — orphan-branches case: getMergeBase resolves to sha: null
+    vi.clearAllMocks();
+    vi.mocked(rpc.workspace.gitWorktree.getMergeBase).mockResolvedValueOnce({
+      success: true,
+      data: { sha: null },
+    });
+    vi.mocked(rpc.workspace.gitWorktree.getChangedFiles).mockResolvedValue({
+      success: true,
+      data: { changes: [] },
+    });
+
+    const { store } = createStore();
+
+    // act
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    // assert — after settle with no ancestor, defaultBranchRef is the only
+    // meaningful base. Before settle it would have been null (covered above).
+    expect(store.originalRef).toEqual({
+      kind: 'branch',
+      branch: { type: 'local', branch: 'main' },
+    } satisfies GitObjectRef);
+  });
+
+  it('drops a stale merge-base response when a newer fetch has superseded it', async () => {
+    // arrange — first getMergeBase is slow, second is fast and lands first
+    vi.clearAllMocks();
+    let resolveSlow: (value: { success: true; data: { sha: string | null } }) => void = () => {};
+    vi.mocked(rpc.workspace.gitWorktree.getMergeBase)
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveSlow = resolve;
+          })
+      )
+      .mockResolvedValueOnce({
+        success: true,
+        data: { sha: 'newnewnewnewnew0' },
+      });
+    vi.mocked(rpc.workspace.gitWorktree.getChangedFiles).mockResolvedValue({
+      success: true,
+      data: { changes: [] },
+    });
+
+    const { store } = createStore();
+
+    // act — fire a compareMode change to spawn fetch #2 before fetch #1 returns
+    store.setCompareMode('all');
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    // sanity: fetch #2 has settled
+    expect(store.mergeBaseRef).toEqual({
+      kind: 'commit',
+      sha: 'newnewnewnewnew0',
+    } satisfies GitObjectRef);
+
+    // now let fetch #1 (the superseded one) return — its callback must be
+    // dropped by the generation check, otherwise it would clobber the newer
+    // SHA and the diff tab's left side would point at the wrong base.
+    resolveSlow({ success: true, data: { sha: 'oldoldoldoldold0' } });
+    await new Promise<void>((r) => setTimeout(r, 0));
+
+    expect(store.mergeBaseRef).toEqual({
+      kind: 'commit',
+      sha: 'newnewnewnewnew0',
+    } satisfies GitObjectRef);
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.ts
@@ -20,7 +20,25 @@ export class BranchDiffStore {
   compareMode: BranchCompareMode = 'committed';
 
   private _resource: Resource<readonly GitChange[]> | null = null;
+  private _mergeBaseSha: string | null = null;
+  /**
+   * True after at least one `getMergeBase` response has been processed.
+   * Distinguishes "never fetched yet" from "fetched, no common ancestor"
+   * so consumers can avoid opening Branch diff tabs while the very first
+   * resolution is still in flight (which would otherwise fall back to
+   * the live default-branch tip and defeat the merge-base pin).
+   */
+  private _mergeBaseResolved = false;
   private _disposeReactions: Array<() => void> = [];
+  /**
+   * Incremented on every `_rebuildResource` call so late-arriving callbacks
+   * from a superseded fetch don't overwrite state owned by a newer one.
+   * Without this, a slow `getMergeBase` from compareMode-change #1 can land
+   * after compareMode-change #2's faster response and leave `_mergeBaseSha`
+   * pointing at the wrong commit (file list comes from the new base, merge-
+   * base from the old).
+   */
+  private _loadGeneration = 0;
 
   constructor(
     private readonly projectId: string,
@@ -28,11 +46,15 @@ export class BranchDiffStore {
     private readonly gitRepository: GitRepositoryStore,
     private readonly gitWorktree: GitWorktreeStore
   ) {
-    makeObservable<this, '_resource'>(this, {
+    makeObservable<this, '_resource' | '_mergeBaseSha' | '_mergeBaseResolved'>(this, {
       _resource: observable.ref,
+      _mergeBaseSha: observable,
+      _mergeBaseResolved: observable,
       compareMode: observable,
       defaultBranchRef: computed,
       currentBranchRef: computed,
+      mergeBaseRef: computed,
+      originalRef: computed,
       isAvailable: computed,
       files: computed,
       isLoading: computed,
@@ -72,6 +94,36 @@ export class BranchDiffStore {
     return this.gitWorktree.branchName ? localRef(this.gitWorktree.branchName) : null;
   }
 
+  /**
+   * Commit ref of `merge-base(defaultBranch, currentBranch)` — the point this
+   * branch diverged from the default branch. Pinned client-side so the diff view
+   * matches the file list's three-dot semantics even after the branch's PR has
+   * been squash-merged into the default (where the two branch tips would
+   * otherwise be content-equal).
+   *
+   * Null until resolved, or when defaultBranchRef/currentBranchRef are missing.
+   */
+  get mergeBaseRef(): GitObjectRef | null {
+    return this._mergeBaseSha ? commitRef(this._mergeBaseSha) : null;
+  }
+
+  /**
+   * The ref to use as the original (left) side of a Branch diff tab. Resolves
+   * to the merge-base commit when available, and to the default-branch tip
+   * only AFTER the first merge-base resolution has settled with no common
+   * ancestor (orphan branches — a pathological case where any base is wrong).
+   *
+   * Returns null while the very first resolution is still in flight so callers
+   * don't accidentally open a tab pinned to the live default branch tip, which
+   * would defeat the merge-base pin (the empty-diff-after-squash-merge bug
+   * this whole flow is designed to avoid).
+   */
+  get originalRef(): GitObjectRef | null {
+    if (this._mergeBaseSha) return commitRef(this._mergeBaseSha);
+    if (this._mergeBaseResolved) return this.defaultBranchRef;
+    return null;
+  }
+
   get isAvailable(): boolean {
     return this.defaultBranchRef != null;
   }
@@ -87,7 +139,7 @@ export class BranchDiffStore {
   get emptyState(): BranchEmptyState | null {
     if (!this.defaultBranchRef) return { kind: 'no-default-branch' };
     if (this.gitWorktree.headKind === 'unborn') return { kind: 'unborn' };
-    if (this.currentBranchRef && refsEqual(this.defaultBranchRef, this.currentBranchRef)) {
+    if (this.currentBranchRef && isOnDefaultBranch(this.defaultBranchRef, this.currentBranchRef)) {
       return { kind: 'on-default-branch' };
     }
     if (this.files.length > 0) return null;
@@ -105,6 +157,11 @@ export class BranchDiffStore {
     this._disposeReactions = [];
     this._resource?.dispose();
     this._resource = null;
+    this._loadGeneration++;
+    runInAction(() => {
+      this._mergeBaseSha = null;
+      this._mergeBaseResolved = false;
+    });
   }
 
   private _rebuildResource(): void {
@@ -112,23 +169,54 @@ export class BranchDiffStore {
     const base = this.defaultBranchRef;
     const head = this.currentBranchRef;
     if (!base || !head) {
+      this._loadGeneration++;
       runInAction(() => {
         this._resource = null;
+        this._mergeBaseSha = null;
+        this._mergeBaseResolved = false;
       });
       return;
     }
     const mode = this.compareMode;
     const projectId = this.projectId;
     const workspaceId = this.workspaceId;
+    const generation = ++this._loadGeneration;
 
     const resource = new Resource<readonly GitChange[]>(async () => {
-      const target = mode === 'committed' ? mergeBaseRange(base, head) : base;
-      const result = await rpc.workspace.gitWorktree.getChangedFiles(
+      // Resolve merge-base first so both modes can compare against the branch
+      // point. Without that, All would compare working tree against the live
+      // default-branch tip — anything main independently added (e.g. a
+      // squash-merge or a parallel PR that lands the same final content) would
+      // disappear from All while still showing up in Committed, making All
+      // look like a subset of Committed even though it conceptually contains it.
+      const mergeBaseResult = await rpc.workspace.gitWorktree.getMergeBase(
+        projectId,
+        workspaceId,
+        base,
+        head
+      );
+      // Drop this result if a newer _rebuildResource has started — late
+      // returns from a superseded fetch must not overwrite newer state.
+      if (this._loadGeneration !== generation) {
+        return this._resource?.data ?? [];
+      }
+      const mergeBaseSha = mergeBaseResult.success ? mergeBaseResult.data.sha : null;
+      runInAction(() => {
+        this._mergeBaseSha = mergeBaseSha;
+        this._mergeBaseResolved = true;
+      });
+
+      const effectiveBase: GitObjectRef = mergeBaseSha ? commitRef(mergeBaseSha) : base;
+      const target = mode === 'committed' ? mergeBaseRange(effectiveBase, head) : effectiveBase;
+      const filesResult = await rpc.workspace.gitWorktree.getChangedFiles(
         projectId,
         workspaceId,
         target
       );
-      return result.success ? result.data.changes : [];
+      if (this._loadGeneration !== generation) {
+        return this._resource?.data ?? [];
+      }
+      return filesResult.success ? filesResult.data.changes : [];
     }, [
       { kind: 'poll', intervalMs: 60_000, pauseWhenHidden: true, demandGated: true },
       {
@@ -161,4 +249,20 @@ export class BranchDiffStore {
 function refsEqualOrNull(a: GitObjectRef | null, b: GitObjectRef | null): boolean {
   if (a === null || b === null) return a === b;
   return refsEqual(a, b);
+}
+
+/**
+ * "Are we currently checked out on the default branch?" — true when both refs
+ * are branches with the same branch name, regardless of whether the configured
+ * default is a local or a remote-tracking ref (e.g. `main` vs `origin/main`).
+ *
+ * `refsEqual` rejects local↔remote pairs as different `branch.type`, so without
+ * this we'd miss the "On default branch" empty state and instead render a
+ * Branch comparison against the worktree's own ref.
+ */
+function isOnDefaultBranch(defaultRef: GitObjectRef, currentRef: GitObjectRef): boolean {
+  if (defaultRef.kind === 'branch' && currentRef.kind === 'branch') {
+    return defaultRef.branch.branch === currentRef.branch.branch;
+  }
+  return refsEqual(defaultRef, currentRef);
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.ts
@@ -26,7 +26,7 @@ export class BranchDiffStore {
     private readonly projectId: string,
     private readonly workspaceId: string,
     private readonly gitRepository: GitRepositoryStore,
-    private readonly gitWorktree: GitWorktreeStore,
+    private readonly gitWorktree: GitWorktreeStore
   ) {
     makeObservable<this, '_resource'>(this, {
       _resource: observable.ref,
@@ -50,12 +50,10 @@ export class BranchDiffStore {
         () => this._rebuildResource(),
         {
           equals: (a, b) =>
-            a.mode === b.mode &&
-            refsEqualOrNull(a.base, b.base) &&
-            refsEqualOrNull(a.head, b.head),
+            a.mode === b.mode && refsEqualOrNull(a.base, b.base) && refsEqualOrNull(a.head, b.head),
           fireImmediately: true,
-        },
-      ),
+        }
+      )
     );
   }
 
@@ -89,10 +87,7 @@ export class BranchDiffStore {
   get emptyState(): BranchEmptyState | null {
     if (!this.defaultBranchRef) return { kind: 'no-default-branch' };
     if (this.gitWorktree.headKind === 'unborn') return { kind: 'unborn' };
-    if (
-      this.currentBranchRef &&
-      refsEqual(this.defaultBranchRef, this.currentBranchRef)
-    ) {
+    if (this.currentBranchRef && refsEqual(this.defaultBranchRef, this.currentBranchRef)) {
       return { kind: 'on-default-branch' };
     }
     if (this.files.length > 0) return null;
@@ -126,39 +121,36 @@ export class BranchDiffStore {
     const projectId = this.projectId;
     const workspaceId = this.workspaceId;
 
-    const resource = new Resource<readonly GitChange[]>(
-      async () => {
-        const target = mode === 'committed' ? mergeBaseRange(base, head) : base;
-        const result = await rpc.workspace.gitWorktree.getChangedFiles(
-          projectId,
-          workspaceId,
-          target,
-        );
-        return result.success ? result.data.changes : [];
-      },
-      [
-        { kind: 'poll', intervalMs: 60_000, pauseWhenHidden: true, demandGated: true },
-        {
-          kind: 'event',
-          subscribe: (handler) => {
-            const unsubHead = events.on(gitWorktreeUpdateChannel, (p) => {
-              if (p.workspaceId !== workspaceId) return;
-              if (p.update.kind === 'head') handler();
-              if (p.update.kind === 'status' && mode === 'all') handler();
-            });
-            const unsubRefs = events.on(gitRepoUpdateChannel, (p) => {
-              if (p.projectId === projectId && p.update.kind === 'refs') handler();
-            });
-            return () => {
-              unsubHead();
-              unsubRefs();
-            };
-          },
-          onEvent: 'reload',
-          debounceMs: 500,
+    const resource = new Resource<readonly GitChange[]>(async () => {
+      const target = mode === 'committed' ? mergeBaseRange(base, head) : base;
+      const result = await rpc.workspace.gitWorktree.getChangedFiles(
+        projectId,
+        workspaceId,
+        target
+      );
+      return result.success ? result.data.changes : [];
+    }, [
+      { kind: 'poll', intervalMs: 60_000, pauseWhenHidden: true, demandGated: true },
+      {
+        kind: 'event',
+        subscribe: (handler) => {
+          const unsubHead = events.on(gitWorktreeUpdateChannel, (p) => {
+            if (p.workspaceId !== workspaceId) return;
+            if (p.update.kind === 'head') handler();
+            if (p.update.kind === 'status' && mode === 'all') handler();
+          });
+          const unsubRefs = events.on(gitRepoUpdateChannel, (p) => {
+            if (p.projectId === projectId && p.update.kind === 'refs') handler();
+          });
+          return () => {
+            unsubHead();
+            unsubRefs();
+          };
         },
-      ],
-    );
+        onEvent: 'reload',
+        debounceMs: 500,
+      },
+    ]);
     resource.start();
     runInAction(() => {
       this._resource = resource;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/branch-diff-store.ts
@@ -1,0 +1,172 @@
+import type { GitChange, GitObjectRef } from '@emdash/core/git';
+import { action, computed, makeObservable, observable, reaction, runInAction } from 'mobx';
+import type { GitRepositoryStore } from '@renderer/features/projects/stores/git-repository-store';
+import type { GitWorktreeStore } from '@renderer/features/tasks/stores/git-worktree-store';
+import { events, rpc } from '@renderer/lib/ipc';
+import { Resource } from '@renderer/lib/stores/resource';
+import { gitRepoUpdateChannel, gitWorktreeUpdateChannel } from '@shared/core/git/events';
+import { commitRef, localRef, mergeBaseRange, refsEqual } from '@shared/core/git/utils';
+
+export type BranchCompareMode = 'committed' | 'all';
+
+export type BranchEmptyState =
+  | { kind: 'no-default-branch' }
+  | { kind: 'default-not-resolved' }
+  | { kind: 'on-default-branch' }
+  | { kind: 'no-changes' }
+  | { kind: 'unborn' };
+
+export class BranchDiffStore {
+  compareMode: BranchCompareMode = 'committed';
+
+  private _resource: Resource<readonly GitChange[]> | null = null;
+  private _disposeReactions: Array<() => void> = [];
+
+  constructor(
+    private readonly projectId: string,
+    private readonly workspaceId: string,
+    private readonly gitRepository: GitRepositoryStore,
+    private readonly gitWorktree: GitWorktreeStore,
+  ) {
+    makeObservable<this, '_resource'>(this, {
+      _resource: observable.ref,
+      compareMode: observable,
+      defaultBranchRef: computed,
+      currentBranchRef: computed,
+      isAvailable: computed,
+      files: computed,
+      isLoading: computed,
+      emptyState: computed,
+      setCompareMode: action,
+    });
+
+    this._disposeReactions.push(
+      reaction(
+        () => ({
+          mode: this.compareMode,
+          base: this.defaultBranchRef,
+          head: this.currentBranchRef,
+        }),
+        () => this._rebuildResource(),
+        {
+          equals: (a, b) =>
+            a.mode === b.mode &&
+            refsEqualOrNull(a.base, b.base) &&
+            refsEqualOrNull(a.head, b.head),
+          fireImmediately: true,
+        },
+      ),
+    );
+  }
+
+  get defaultBranchRef(): GitObjectRef | null {
+    const branch = this.gitRepository.defaultBranch;
+    if (!branch) return null;
+    return { kind: 'branch', branch };
+  }
+
+  get currentBranchRef(): GitObjectRef | null {
+    if (this.gitWorktree.headKind === 'unborn') return null;
+    if (this.gitWorktree.headKind === 'detached') {
+      const oid = this.gitWorktree.currentHeadOid();
+      return oid ? commitRef(oid) : null;
+    }
+    return this.gitWorktree.branchName ? localRef(this.gitWorktree.branchName) : null;
+  }
+
+  get isAvailable(): boolean {
+    return this.defaultBranchRef != null;
+  }
+
+  get files(): readonly GitChange[] {
+    return this._resource?.data ?? [];
+  }
+
+  get isLoading(): boolean {
+    return this._resource?.loading ?? false;
+  }
+
+  get emptyState(): BranchEmptyState | null {
+    if (!this.defaultBranchRef) return { kind: 'no-default-branch' };
+    if (this.gitWorktree.headKind === 'unborn') return { kind: 'unborn' };
+    if (
+      this.currentBranchRef &&
+      refsEqual(this.defaultBranchRef, this.currentBranchRef)
+    ) {
+      return { kind: 'on-default-branch' };
+    }
+    if (this.files.length > 0) return null;
+    if (this.isLoading) return null;
+    if (this._resource?.error) return { kind: 'default-not-resolved' };
+    return { kind: 'no-changes' };
+  }
+
+  setCompareMode(mode: BranchCompareMode): void {
+    this.compareMode = mode;
+  }
+
+  dispose(): void {
+    for (const d of this._disposeReactions) d();
+    this._disposeReactions = [];
+    this._resource?.dispose();
+    this._resource = null;
+  }
+
+  private _rebuildResource(): void {
+    this._resource?.dispose();
+    const base = this.defaultBranchRef;
+    const head = this.currentBranchRef;
+    if (!base || !head) {
+      runInAction(() => {
+        this._resource = null;
+      });
+      return;
+    }
+    const mode = this.compareMode;
+    const projectId = this.projectId;
+    const workspaceId = this.workspaceId;
+
+    const resource = new Resource<readonly GitChange[]>(
+      async () => {
+        const target = mode === 'committed' ? mergeBaseRange(base, head) : base;
+        const result = await rpc.workspace.gitWorktree.getChangedFiles(
+          projectId,
+          workspaceId,
+          target,
+        );
+        return result.success ? result.data.changes : [];
+      },
+      [
+        { kind: 'poll', intervalMs: 60_000, pauseWhenHidden: true, demandGated: true },
+        {
+          kind: 'event',
+          subscribe: (handler) => {
+            const unsubHead = events.on(gitWorktreeUpdateChannel, (p) => {
+              if (p.workspaceId !== workspaceId) return;
+              if (p.update.kind === 'head') handler();
+              if (p.update.kind === 'status' && mode === 'all') handler();
+            });
+            const unsubRefs = events.on(gitRepoUpdateChannel, (p) => {
+              if (p.projectId === projectId && p.update.kind === 'refs') handler();
+            });
+            return () => {
+              unsubHead();
+              unsubRefs();
+            };
+          },
+          onEvent: 'reload',
+          debounceMs: 500,
+        },
+      ],
+    );
+    resource.start();
+    runInAction(() => {
+      this._resource = resource;
+    });
+  }
+}
+
+function refsEqualOrNull(a: GitObjectRef | null, b: GitObjectRef | null): boolean {
+  if (a === null || b === null) return a === b;
+  return refsEqual(a, b);
+}

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.test.ts
@@ -64,6 +64,7 @@ describe('ChangesViewStore expanded sections', () => {
     expect(store.expandedSections).toEqual({
       unstaged: true,
       staged: false,
+      branch: true,
       pullRequests: false,
     });
   });
@@ -79,6 +80,7 @@ describe('ChangesViewStore expanded sections', () => {
     expect(store.expandedSections).toEqual({
       unstaged: false,
       staged: false,
+      branch: true,
       pullRequests: true,
     });
   });
@@ -92,6 +94,7 @@ describe('ChangesViewStore expanded sections', () => {
     expect(store.expandedSections).toEqual({
       unstaged: false,
       staged: true,
+      branch: true,
       pullRequests: false,
     });
   });
@@ -109,8 +112,20 @@ describe('ChangesViewStore expanded sections', () => {
     expect(store.expandedSections).toEqual({
       unstaged: true,
       staged: true,
+      branch: true,
       pullRequests: false,
     });
+  });
+
+  it('toggles the branch expand-section independently', () => {
+    // arrange
+    const { store } = createStore();
+
+    // act
+    store.toggleExpanded('branch');
+
+    // assert
+    expect(store.expandedSections.branch).toBe(false);
   });
 
   it('removes only completed unstaged paths so newer selections survive', () => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.ts
@@ -7,13 +7,14 @@ export type SelectionState = 'all' | 'none' | 'partial';
 export interface ExpandedSections {
   unstaged: boolean;
   staged: boolean;
+  branch: boolean;
   pullRequests: boolean;
 }
 
 export class ChangesViewStore {
   unstagedSelection = observable.set<string>();
   stagedSelection = observable.set<string>();
-  expandedSections: ExpandedSections = { unstaged: true, staged: true, pullRequests: true };
+  expandedSections: ExpandedSections = { unstaged: true, staged: true, branch: true, pullRequests: true };
 
   private _disposeReactions: Array<() => void> = [];
   private _suppressAutoExpand = new Set<keyof ExpandedSections>();
@@ -63,6 +64,7 @@ export class ChangesViewStore {
             this.expandedSections = {
               unstaged: hasUnstaged || (!hasStaged && !hasUnstaged && !hasPullRequests),
               staged: hasStaged,
+              branch: true,
               pullRequests: hasPullRequests,
             };
           });
@@ -205,8 +207,15 @@ export class ChangesViewStore {
     });
   }
 
-  expandForActiveFileType(group: 'disk' | 'staged' | 'git' | 'pr'): void {
-    const section = group === 'disk' ? 'unstaged' : group === 'staged' ? 'staged' : 'pullRequests';
+  expandForActiveFileType(group: 'disk' | 'staged' | 'git' | 'pr' | 'branch'): void {
+    const section =
+      group === 'disk'
+        ? 'unstaged'
+        : group === 'staged'
+          ? 'staged'
+          : group === 'branch'
+            ? 'branch'
+            : 'pullRequests';
     if (!this.expandedSections[section]) {
       runInAction(() => {
         this.expandedSections = { ...this.expandedSections, [section]: true };

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.ts
@@ -14,7 +14,12 @@ export interface ExpandedSections {
 export class ChangesViewStore {
   unstagedSelection = observable.set<string>();
   stagedSelection = observable.set<string>();
-  expandedSections: ExpandedSections = { unstaged: true, staged: true, branch: true, pullRequests: true };
+  expandedSections: ExpandedSections = {
+    unstaged: true,
+    staged: true,
+    branch: true,
+    pullRequests: true,
+  };
 
   private _disposeReactions: Array<() => void> = [];
   private _suppressAutoExpand = new Set<keyof ExpandedSections>();

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-manager.test.ts
@@ -9,7 +9,7 @@ import { DiffTabManager, getDiffTabManager, releaseDiffTabManager } from './diff
 function makeFakeResource(
   opts: Partial<{
     path: string;
-    diffGroup: 'disk' | 'staged' | 'git' | 'pr';
+    diffGroup: 'disk' | 'staged' | 'git' | 'pr' | 'branch';
     prNumber: number;
     tabId: string;
   }> = {}
@@ -144,6 +144,26 @@ describe('DiffTabManager: staleness reconcile', () => {
 
     runInAction(() => {
       (session.gitWorktree.unstagedFileChanges as ReturnType<typeof observable.array>).replace([]);
+    });
+
+    expect(resource.closeSelf).not.toHaveBeenCalled();
+    manager.dispose();
+  });
+
+  it('does not close branch-group resources when working-tree lists change', () => {
+    // Branch tabs are read-only views of defaultBranch...HEAD. They have no
+    // counterpart in the staged/unstaged lists, so the staleness sweep would
+    // close them on every working-tree event if not excluded.
+    const resource = makeFakeResource({ path: 'src/branch.ts', diffGroup: 'branch' });
+    manager.acquire(resource as never);
+
+    const session = makeFakeSession(['src/other.ts'], []);
+    manager.bindSession(session as never);
+
+    runInAction(() => {
+      (session.gitWorktree.unstagedFileChanges as ReturnType<typeof observable.array>).replace([
+        { path: 'src/different.ts', status: 'M' },
+      ]);
     });
 
     expect(resource.closeSelf).not.toHaveBeenCalled();

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-manager.ts
@@ -88,7 +88,10 @@ export class DiffTabManager {
 
   private _reconcile(session: DiffSession, validKeys: Set<string>): void {
     const stale = [...this._resources].filter(
-      (r) => r.diffGroup !== 'git' && !validKeys.has(`${r.diffGroup}:${r.path}`)
+      (r) =>
+        r.diffGroup !== 'git' &&
+        r.diffGroup !== 'branch' &&
+        !validKeys.has(`${r.diffGroup}:${r.path}`)
     );
 
     for (const resource of stale) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-resource.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-resource.ts
@@ -9,7 +9,7 @@ export type DiffRendererData = { kind: 'text' } | { kind: 'image' } | { kind: 'b
 
 export interface DiffPayload {
   path: string;
-  diffGroup: 'disk' | 'staged' | 'git' | 'pr';
+  diffGroup: 'disk' | 'staged' | 'git' | 'pr' | 'branch';
   originalRef: GitObjectRef;
   modifiedRef?: GitObjectRef;
   prNumber?: number;
@@ -34,7 +34,7 @@ export class DiffTabResource implements TabResource {
 
   path: string;
   renderer: DiffRendererData;
-  diffGroup: 'disk' | 'staged' | 'git' | 'pr';
+  diffGroup: 'disk' | 'staged' | 'git' | 'pr' | 'branch';
   originalRef: GitObjectRef;
   modifiedRef: GitObjectRef | undefined;
   prNumber: number | undefined;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-store.ts
@@ -19,7 +19,7 @@ export class DiffTabStore {
   path: string;
   isPreview: boolean;
   renderer: DiffRendererData;
-  diffGroup: 'disk' | 'staged' | 'git' | 'pr';
+  diffGroup: 'disk' | 'staged' | 'git' | 'pr' | 'branch';
   originalRef: GitObjectRef;
   modifiedRef: GitObjectRef | undefined;
   prNumber: number | undefined;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-view-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-view-store.ts
@@ -48,7 +48,7 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
     workspaceId: string,
     gitRepository: GitRepositoryStore,
     private readonly gitWorktree: GitWorktreeStore,
-    private readonly pr: PrStore,
+    private readonly pr: PrStore
   ) {
     this.branchDiff = new BranchDiffStore(projectId, workspaceId, gitRepository, gitWorktree);
     this.changesView = new ChangesViewStore(gitWorktree, pr);
@@ -80,7 +80,8 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
       reaction(
         () => this.activeFile,
         (file) => {
-          if (!file || file.group === 'git' || file.group === 'pr' || file.group === 'branch') return;
+          if (!file || file.group === 'git' || file.group === 'pr' || file.group === 'branch')
+            return;
           this.changesView.expandForActiveFileType(file.group);
         }
       )
@@ -98,7 +99,8 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
     if (!override) return this._defaultActiveFile;
 
     // git/pr groups cannot be validated against working-tree lists — trust the override
-    if (override.group === 'git' || override.group === 'pr') return override;
+    if (override.group === 'git' || override.group === 'pr' || override.group === 'branch')
+      return override;
 
     const isStaged = override.group === 'staged';
     const ownList = isStaged

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-view-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-view-store.ts
@@ -1,5 +1,7 @@
 import type { GitObjectRef } from '@emdash/core/git';
 import { action, computed, makeObservable, observable, reaction } from 'mobx';
+import type { GitRepositoryStore } from '@renderer/features/projects/stores/git-repository-store';
+import { BranchDiffStore } from '@renderer/features/tasks/diff-view/stores/branch-diff-store';
 import { ChangesViewStore } from '@renderer/features/tasks/diff-view/stores/changes-view-store';
 import type { PrStore } from '@renderer/features/tasks/stores/pr-store';
 import { type Snapshottable } from '@renderer/lib/stores/snapshottable';
@@ -28,6 +30,7 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
   commitAction: CommitAction | null = null;
   prTab: 'files' | 'commits' | 'checks' = 'files';
 
+  readonly branchDiff: BranchDiffStore;
   readonly changesView: ChangesViewStore;
 
   /**
@@ -41,9 +44,13 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
   private _disposeReactions: Array<() => void> = [];
 
   constructor(
+    projectId: string,
+    workspaceId: string,
+    gitRepository: GitRepositoryStore,
     private readonly gitWorktree: GitWorktreeStore,
-    private readonly pr: PrStore
+    private readonly pr: PrStore,
   ) {
+    this.branchDiff = new BranchDiffStore(projectId, workspaceId, gitRepository, gitWorktree);
     this.changesView = new ChangesViewStore(gitWorktree, pr);
 
     makeObservable(this, {
@@ -73,7 +80,7 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
       reaction(
         () => this.activeFile,
         (file) => {
-          if (!file || file.group === 'git' || file.group === 'pr') return;
+          if (!file || file.group === 'git' || file.group === 'pr' || file.group === 'branch') return;
           this.changesView.expandForActiveFileType(file.group);
         }
       )
@@ -147,6 +154,7 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
       activeFile: this.activeFileOverride ?? undefined,
       commitAction: this.commitAction,
       prTab: this.prTab,
+      branchCompareMode: this.branchDiff.compareMode,
     };
   }
 
@@ -163,6 +171,9 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
     // store falls back to _defaultActiveFile automatically.
     if (snapshot.commitAction) this.commitAction = snapshot.commitAction;
     if (snapshot.prTab) this.prTab = snapshot.prTab;
+    if (snapshot.branchCompareMode === 'committed' || snapshot.branchCompareMode === 'all') {
+      this.branchDiff.setCompareMode(snapshot.branchCompareMode);
+    }
   }
 
   get effectiveCommitAction(): CommitAction {
@@ -198,6 +209,7 @@ export class DiffViewStore implements Snapshottable<DiffViewSnapshot> {
   dispose(): void {
     for (const dispose of this._disposeReactions) dispose();
     this._disposeReactions = [];
+    this.branchDiff.dispose();
     this.changesView.dispose();
   }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
@@ -236,6 +236,12 @@ export class GitWorktreeStore {
     return head.kind === 'detached' ? head.shortHash : head.name;
   }
 
+  currentHeadOid(): string | null {
+    const head = this.head.value;
+    if (!head || head.kind === 'unborn') return null;
+    return head.oid;
+  }
+
   get isBranchPublished(): boolean {
     const name = this.branchName;
     return name ? this.gitRepositoryStore.isBranchOnRemote(name) : false;

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -219,7 +219,13 @@ export class WorkspaceViewModel implements ILifecycle {
     );
 
     // Create DiffViewStore with live git/pr references from the workspace.
-    this.diffView = new DiffViewStore(workspace.gitWorktree, this.prStore);
+    this.diffView = new DiffViewStore(
+      taskData.projectId,
+      workspaceId,
+      workspace.gitRepository,
+      workspace.gitWorktree,
+      this.prStore,
+    );
     if (this._savedDiffViewSnapshot) {
       this.diffView.restoreSnapshot(this._savedDiffViewSnapshot);
     }

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -224,7 +224,7 @@ export class WorkspaceViewModel implements ILifecycle {
       workspaceId,
       workspace.gitRepository,
       workspace.gitWorktree,
-      this.prStore,
+      this.prStore
     );
     if (this._savedDiffViewSnapshot) {
       this.diffView.restoreSnapshot(this._savedDiffViewSnapshot);

--- a/apps/emdash-desktop/src/shared/view-state.ts
+++ b/apps/emdash-desktop/src/shared/view-state.ts
@@ -21,7 +21,7 @@ export type TabDescriptor =
       kind: 'diff';
       tabId: string;
       path: string;
-      diffGroup: 'disk' | 'staged' | 'git' | 'pr';
+      diffGroup: 'disk' | 'staged' | 'git' | 'pr' | 'branch';
       originalRef: GitObjectRef;
       modifiedRef?: GitObjectRef;
       prNumber?: number;
@@ -62,6 +62,7 @@ export type DiffViewSnapshot = {
   activeFile?: ActiveFile;
   commitAction: 'commit' | 'commit-push' | 'commit-pr' | null;
   prTab?: 'files' | 'commits' | 'checks';
+  branchCompareMode?: 'committed' | 'all';
 };
 
 export type TerminalDrawerActiveItem =
@@ -80,7 +81,7 @@ export interface ActiveFile {
    *  'staged' = index vs HEAD
    *  'git'    = arbitrary ref-to-ref comparison
    *  'pr'     = PR diff (originalRef is remote-tracking base) */
-  group: 'disk' | 'staged' | 'git' | 'pr';
+  group: 'disk' | 'staged' | 'git' | 'pr' | 'branch';
   originalRef: GitObjectRef;
   /** Fixed modified-side ref for 'git' and 'pr' diffs.
    *  When absent the diff viewer falls back to HEAD_REF. */

--- a/packages/core/src/git/git-worktree.ts
+++ b/packages/core/src/git/git-worktree.ts
@@ -18,7 +18,12 @@ import {
 import { countFileLines } from './file-line-count';
 import type { GitOnError, GitRepository } from './git-repository';
 import type { ImageReadResult } from './models/diff';
-import { toRangeString, toRefString, type DiffTarget } from './models/diff-target';
+import {
+  toRangeString,
+  toRefString,
+  type DiffTarget,
+  type GitObjectRef,
+} from './models/diff-target';
 import type { GitHeadModel } from './models/head';
 import type { CommitFile, GitLogResult } from './models/log';
 import type {
@@ -206,6 +211,15 @@ export class GitWorktree implements IGitWorktree {
 
   async getImageAtIndex(filePath: string): Promise<ImageReadResult> {
     return this.getImageBlob(filePath, `:${filePath}`);
+  }
+
+  async getMergeBase(base: GitObjectRef, head: GitObjectRef): Promise<string | null> {
+    const result = await this.exec
+      .exec(['merge-base', toRefString(base), toRefString(head)])
+      .catch(() => null);
+    if (!result) return null;
+    const sha = result.stdout.trim();
+    return sha.length > 0 ? sha : null;
   }
 
   async getChangedFiles(base: DiffTarget): Promise<GitChange[]> {

--- a/packages/core/src/git/types.ts
+++ b/packages/core/src/git/types.ts
@@ -13,7 +13,7 @@ import type {
   PushError,
 } from './errors';
 import type { ImageReadResult } from './models/diff';
-import type { DiffTarget } from './models/diff-target';
+import type { DiffTarget, GitObjectRef } from './models/diff-target';
 import type { GitHeadModel } from './models/head';
 import type { CommitFile, GitLogResult } from './models/log';
 import type { GitRefsModel, GitRemotesModel } from './models/refs';
@@ -179,6 +179,7 @@ export interface IGitWorktree extends IDisposable {
   getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint>;
   isFileCleanlyTracked(filePath: string): Promise<boolean>;
   getChangedFiles(base: DiffTarget): Promise<GitChange[]>;
+  getMergeBase(base: GitObjectRef, head: GitObjectRef): Promise<string | null>;
   getFileAtRef(filePath: string, ref: string): Promise<string | null>;
   getFileAtIndex(filePath: string): Promise<string | null>;
   getImageAtRef(filePath: string, ref: string): Promise<ImageReadResult>;


### PR DESCRIPTION
### Description

Adds a Branch section to the Changes Panel that shows files differing between the project's default branch and the current task branch, with a `Committed | All` toggle. Committed mode shows `defaultBranch...HEAD` (three-dot via the existing `mergeBaseRange`); All mode shows `git diff defaultBranch` (working tree vs default, includes committed + staged + unstaged). Clicking a file opens a diff tab with the new `diffGroup: 'branch'`. The section is hidden when no default branch is configured.

A separate `getMergeBase` RPC resolves the merge-base SHA so Committed-mode diff tabs are pinned to the branch point. Without that pin, after a squash-merge the default and feature tips become content-equal and Monaco rendered an empty diff even though the file list (which uses three-dot semantics) still showed +N/-N. Branch tabs are read-only — no stage / discard / commit affordances — and the lifecycle store excludes them from the stale-tab sweep so they survive working-tree updates.

### Related issues

None linked.

### Testing

- `pnpm run format` — clean.
- `pnpm run lint` — clean (only pre-existing `no-explicit-any` warnings in `tab-provider-registry.ts` / `task-tab-registry.tsx`).
- `pnpm run typecheck` — clean.
- `pnpm run test` — 65/65 in the diff-view suite (incl. new tests in `branch-diff-store.test.ts`, `diff-tab-manager.test.ts`, and `changes-view-store.test.ts`); 1982/1982 in the wider non-browser suite. 
- Manual: against a workspace snapshot — Branch section appears between Staged and PR, toggling Committed/All re-fetches files, clicking a file opens a `(Branch)` diff tab, default-branch task shows the *On default branch* empty state, branch tabs stay open during working-tree mutations, and merged-PR branches now render the expected red/green diff instead of an empty editor.

### Screenshot/Recording (if applicable)

Before: When PR is open you can see the changed files
<img width="366" height="866" alt="Bildschirmfoto 2026-06-29 um 11 02 24" src="https://github.com/user-attachments/assets/900a7d7f-25a3-479a-9dad-06888234d45c" />

After the PR was merged, you no longer can access changed files
<img width="365" height="346" alt="Bildschirmfoto 2026-06-29 um 11 02 42" src="https://github.com/user-attachments/assets/61f031aa-81da-4ca9-8601-a0712174574b" />

Now there is a branch view, where you can see everything changed on this branch
<img width="562" height="167" alt="Bildschirmfoto 2026-06-29 um 11 43 14" src="https://github.com/user-attachments/assets/d0234acf-4640-47b3-9718-a6012166e6cb" />

<img width="393" height="682" alt="Bildschirmfoto 2026-06-29 um 11 37 59" src="https://github.com/user-attachments/assets/a37339db-ce69-402b-9f10-9f1aa9174b69" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not

- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>