### PR TITLE
fix(sidebar): prevent task name clipping

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/task-item.tsx
@@ -102,7 +102,7 @@ export const SidebarTaskItem = observer(function SidebarTaskItem({
     >
       <SidebarMenuRow
         className={cn(
-          'group/row flex items-center justify-between px-1 h-8 gap-1',
+          'group/row flex items-center justify-between px-1 py-1.5 h-8 gap-1',
           rowVariant === 'pinned' ? 'pl-2' : 'pl-8'
         )}
         isActive={isActive}


### PR DESCRIPTION
### Description
- fixes task name clipping in left sidebar 

### Screenshot/Recording (if applicable)
<img width="347" height="327" alt="image" src="https://github.com/user-attachments/assets/679fb9d0-93ac-4e48-ae6f-2862cc5e7402" />


<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
