### PR TITLE
Add project task Kanban view

### DIFF
--- a/apps/emdash-desktop/src/main/core/tasks/operations/updateTaskStatus.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/updateTaskStatus.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { updateTaskStatus } from './updateTaskStatus';
+
+const mocks = vi.hoisted(() => ({
+  emit: vi.fn(),
+  capture: vi.fn(),
+  selectLimit: vi.fn(),
+  updateSet: vi.fn(),
+  updateWhere: vi.fn(),
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          limit: mocks.selectLimit,
+        }),
+      }),
+    }),
+    update: () => ({
+      set: mocks.updateSet,
+    }),
+  },
+}));
+
+vi.mock('@main/lib/events', () => ({
+  events: {
+    emit: mocks.emit,
+  },
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: {
+    capture: mocks.capture,
+  },
+}));
+
+describe('updateTaskStatus', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.updateSet.mockReturnValue({ where: mocks.updateWhere });
+    mocks.updateWhere.mockResolvedValue(undefined);
+  });
+
+  it('persists the status timestamp and emits a renderer status update event', async () => {
+    mocks.selectLimit.mockResolvedValueOnce([
+      {
+        id: 'task-1',
+        projectId: 'project-1',
+        status: 'todo',
+      },
+    ]);
+
+    await updateTaskStatus('task-1', 'review');
+
+    expect(mocks.updateSet).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'review',
+        updatedAt: expect.anything(),
+        statusChangedAt: expect.anything(),
+      })
+    );
+    expect(mocks.emit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: 'task:status-updated' }),
+      {
+        taskId: 'task-1',
+        projectId: 'project-1',
+        status: 'review',
+      }
+    );
+    expect(mocks.capture).toHaveBeenCalledWith('task_status_changed', {
+      from_status: 'todo',
+      to_status: 'review',
+      project_id: 'project-1',
+      task_id: 'task-1',
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/tasks/operations/updateTaskStatus.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/updateTaskStatus.ts
@@ -1,7 +1,9 @@
 import { eq, sql } from 'drizzle-orm';
 import { db } from '@main/db/client';
 import { tasks } from '@main/db/schema';
+import { events } from '@main/lib/events';
 import { telemetryService } from '@main/lib/telemetry';
+import { taskStatusUpdatedChannel } from '@shared/core/tasks/taskEvents';
 import { type TaskLifecycleStatus } from '@shared/core/tasks/tasks';
 
 export async function updateTaskStatus(taskId: string, status: TaskLifecycleStatus): Promise<void> {
@@ -17,6 +19,12 @@ export async function updateTaskStatus(taskId: string, status: TaskLifecycleStat
       statusChangedAt: sql`CURRENT_TIMESTAMP`,
     })
     .where(eq(tasks.id, taskId));
+
+  events.emit(taskStatusUpdatedChannel, {
+    taskId: row.id,
+    projectId: row.projectId,
+    status,
+  });
 
   telemetryService.capture('task_status_changed', {
     from_status: row.status as TaskLifecycleStatus,

--- a/apps/emdash-desktop/src/renderer/features/projects/components/main-panel/active-project.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/main-panel/active-project.tsx
@@ -56,17 +56,28 @@ export const ActiveProject = observer(function ActiveProject() {
   if (!store) return null;
 
   const activeView = store.view.activeView;
+  const isKanbanTasksView = activeView === 'tasks' && store.view.taskView.mode === 'kanban';
 
   return (
     <div className="flex h-full min-h-0 w-full flex-1 flex-col overflow-hidden">
-      <div className="mx-auto flex h-full min-h-0 w-full max-w-[1060px] flex-col gap-6 px-8">
+      <div
+        className={cn(
+          'mx-auto flex h-full min-h-0 w-full flex-col gap-6 px-8',
+          isKanbanTasksView ? 'max-w-[1800px]' : 'max-w-[1060px]'
+        )}
+      >
         <div className="grid min-h-0 flex-1 grid-cols-[13rem_minmax(0,1fr)] gap-8 overflow-hidden">
           <ProjectViewNav
             activeView={activeView}
             onChange={(view) => store.view.setProjectView(view)}
           />
           <div className="min-h-0 min-w-0 flex-1 overflow-x-hidden overflow-y-auto">
-            <div className="mx-auto flex h-full min-h-0 w-full max-w-4xl flex-col px-1 py-10">
+            <div
+              className={cn(
+                'mx-auto flex h-full min-h-0 w-full flex-col px-1 py-10',
+                isKanbanTasksView ? 'max-w-none' : 'max-w-4xl'
+              )}
+            >
               {activeView === 'tasks' && <TaskList />}
               {activeView === 'pull-request' && <PullRequestView />}
               {activeView === 'settings' && <SettingsPanel />}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/kanban-task-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/kanban-task-model.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from 'vitest';
+import type { Task } from '@shared/core/tasks/tasks';
+import {
+  buildKanbanColumns,
+  KANBAN_STATUS_COLUMNS,
+  type KanbanReadyTask,
+} from './kanban-task-model';
+
+function makeTask(id: string, overrides: Partial<Task> = {}): KanbanReadyTask {
+  return {
+    state: 'unprovisioned',
+    data: {
+      id,
+      projectId: 'project-1',
+      name: id,
+      status: 'todo',
+      createdAt: '2026-01-01T00:00:00.000Z',
+      updatedAt: '2026-01-01T00:00:00.000Z',
+      statusChangedAt: '2026-01-01T00:00:00.000Z',
+      isPinned: false,
+      prs: [],
+      conversations: {},
+      type: 'task',
+      ...overrides,
+    },
+  } as KanbanReadyTask;
+}
+
+describe('kanban task model', () => {
+  it('uses the agent task flow column order', () => {
+    expect(KANBAN_STATUS_COLUMNS.map((column) => column.label)).toEqual([
+      'Backlog',
+      'Prompting',
+      'Working',
+      'PR/Review',
+      'Done',
+      'Cancelled',
+    ]);
+  });
+
+  it('groups active ready tasks by board column while excluding archived and automation tasks', () => {
+    const columns = buildKanbanColumns(
+      [
+        makeTask('todo-a', { status: 'todo' }),
+        makeTask('triage-a', { status: 'triage' }),
+        makeTask('review-a', { status: 'review' }),
+        makeTask('duplicate-a', { status: 'duplicate' }),
+        makeTask('archived', { status: 'todo', archivedAt: '2026-01-03T00:00:00.000Z' }),
+        makeTask('automation', { status: 'todo', type: 'automation-run' }),
+      ],
+      { tab: 'active', query: '' }
+    );
+
+    expect(
+      columns.find((column) => column.id === 'prompting')?.tasks.map((task) => task.data.id)
+    ).toEqual(['todo-a', 'triage-a']);
+    expect(
+      columns.find((column) => column.id === 'pr-review')?.tasks.map((task) => task.data.id)
+    ).toEqual(['review-a']);
+    expect(
+      columns.find((column) => column.id === 'cancelled')?.tasks.map((task) => task.data.id)
+    ).toEqual(['duplicate-a']);
+  });
+
+  it('filters archived tasks and search results the same way as the list view', () => {
+    const columns = buildKanbanColumns(
+      [
+        makeTask('active-match', { name: 'Ship Kanban' }),
+        makeTask('archived-match', {
+          name: 'Archived Kanban',
+          archivedAt: '2026-01-03T00:00:00.000Z',
+        }),
+        makeTask('archived-miss', {
+          name: 'Archived List',
+          archivedAt: '2026-01-03T00:00:00.000Z',
+        }),
+      ],
+      { tab: 'archived', query: 'kanban' }
+    );
+
+    const ids = columns.flatMap((column) => column.tasks.map((task) => task.data.id));
+    expect(ids).toEqual(['archived-match']);
+  });
+
+  it('sorts cards pinned first, then newest status change, then newest update', () => {
+    const columns = buildKanbanColumns(
+      [
+        makeTask('older', {
+          status: 'todo',
+          statusChangedAt: '2026-01-01T00:00:00.000Z',
+          updatedAt: '2026-01-05T00:00:00.000Z',
+        }),
+        makeTask('newer-status', {
+          status: 'todo',
+          statusChangedAt: '2026-01-03T00:00:00.000Z',
+          updatedAt: '2026-01-01T00:00:00.000Z',
+        }),
+        makeTask('same-status-newer-update', {
+          status: 'todo',
+          statusChangedAt: '2026-01-03T00:00:00.000Z',
+          updatedAt: '2026-01-04T00:00:00.000Z',
+        }),
+        makeTask('pinned', {
+          status: 'todo',
+          isPinned: true,
+          statusChangedAt: '2026-01-01T00:00:00.000Z',
+        }),
+      ],
+      { tab: 'active', query: '' }
+    );
+
+    expect(
+      columns.find((column) => column.id === 'prompting')?.tasks.map((task) => task.data.id)
+    ).toEqual(['pinned', 'same-status-newer-update', 'newer-status', 'older']);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/kanban-task-model.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/kanban-task-model.ts
@@ -1,0 +1,99 @@
+import type { Task, TaskLifecycleStatus } from '@shared/core/tasks/tasks';
+
+export type KanbanReadyTask = {
+  data: Task;
+};
+
+export type KanbanColumnMeta = {
+  id: string;
+  label: string;
+  statuses: readonly TaskLifecycleStatus[];
+  targetStatus: TaskLifecycleStatus;
+};
+
+export type KanbanColumn<TTask extends KanbanReadyTask = KanbanReadyTask> = KanbanColumnMeta & {
+  tasks: TTask[];
+};
+
+export const KANBAN_STATUS_COLUMNS = [
+  { id: 'backlog', label: 'Backlog', statuses: ['backlog'], targetStatus: 'backlog' },
+  {
+    id: 'prompting',
+    label: 'Prompting',
+    statuses: ['triage', 'todo'],
+    targetStatus: 'triage',
+  },
+  {
+    id: 'working',
+    label: 'Working',
+    statuses: ['in_progress'],
+    targetStatus: 'in_progress',
+  },
+  { id: 'pr-review', label: 'PR/Review', statuses: ['review'], targetStatus: 'review' },
+  { id: 'done', label: 'Done', statuses: ['done'], targetStatus: 'done' },
+  {
+    id: 'cancelled',
+    label: 'Cancelled',
+    statuses: ['cancelled', 'duplicate'],
+    targetStatus: 'cancelled',
+  },
+] as const satisfies KanbanColumnMeta[];
+
+export const KANBAN_COLUMN_BY_ID = Object.fromEntries(
+  KANBAN_STATUS_COLUMNS.map((column) => [column.id, column])
+) as Record<string, KanbanColumnMeta>;
+
+export const KANBAN_COLUMN_BY_STATUS = KANBAN_STATUS_COLUMNS.reduce(
+  (columnsByStatus, column) => {
+    for (const status of column.statuses) {
+      columnsByStatus[status] = column;
+    }
+    return columnsByStatus;
+  },
+  {} as Record<TaskLifecycleStatus, KanbanColumnMeta>
+);
+
+function timestampValue(value: string | undefined): number {
+  if (!value) return 0;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? 0 : parsed;
+}
+
+function compareTasks(a: KanbanReadyTask, b: KanbanReadyTask): number {
+  if (a.data.isPinned !== b.data.isPinned) return a.data.isPinned ? -1 : 1;
+
+  const statusDelta =
+    timestampValue(b.data.statusChangedAt) - timestampValue(a.data.statusChangedAt);
+  if (statusDelta !== 0) return statusDelta;
+
+  const updatedDelta = timestampValue(b.data.updatedAt) - timestampValue(a.data.updatedAt);
+  if (updatedDelta !== 0) return updatedDelta;
+
+  return a.data.id.localeCompare(b.data.id);
+}
+
+export function buildKanbanColumns<TTask extends KanbanReadyTask>(
+  tasks: TTask[],
+  options: { tab: 'active' | 'archived'; query: string }
+): KanbanColumn<TTask>[] {
+  const query = options.query.trim().toLowerCase();
+  const visibleTasks = tasks
+    .filter((task) => task.data.type !== 'automation-run')
+    .filter((task) =>
+      options.tab === 'active' ? !task.data.archivedAt : Boolean(task.data.archivedAt)
+    )
+    .filter((task) => (query ? task.data.name.toLowerCase().includes(query) : true));
+
+  const tasksByStatus = new Map<TaskLifecycleStatus, TTask[]>(
+    KANBAN_STATUS_COLUMNS.flatMap((column) => column.statuses.map((status) => [status, []]))
+  );
+
+  for (const task of visibleTasks) {
+    tasksByStatus.get(task.data.status)?.push(task);
+  }
+
+  return KANBAN_STATUS_COLUMNS.map((column) => ({
+    ...column,
+    tasks: column.statuses.flatMap((status) => tasksByStatus.get(status) ?? []).sort(compareTasks),
+  }));
+}

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-kanban-board.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-kanban-board.tsx
@@ -1,0 +1,369 @@
+import {
+  DndContext,
+  DragOverlay,
+  PointerSensor,
+  pointerWithin,
+  useDraggable,
+  useDroppable,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import { CSS } from '@dnd-kit/utilities';
+import { ListTodo } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { useRef, useState, type CSSProperties, type KeyboardEvent } from 'react';
+import { AgentStatusIndicator } from '@renderer/features/tasks/components/agent-status-indicator';
+import { TaskContextMenu } from '@renderer/features/tasks/components/task-context-menu';
+import { TaskGitDiffStats } from '@renderer/features/tasks/components/task-git-diff-stats';
+import {
+  getTaskGitWorktreeStore,
+  getTaskManagerStore,
+  taskAgentStatus,
+} from '@renderer/features/tasks/stores/task-selectors';
+import { PrBadge } from '@renderer/lib/components/pr-badge';
+import { StackedAgentLogos } from '@renderer/lib/components/stacked-agent-logos';
+import { useNavigate } from '@renderer/lib/layout/navigation-provider';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import { Badge } from '@renderer/lib/ui/badge';
+import { Button } from '@renderer/lib/ui/button';
+import { Checkbox } from '@renderer/lib/ui/checkbox';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuTrigger,
+} from '@renderer/lib/ui/dropdown-menu';
+import { RelativeTime } from '@renderer/lib/ui/relative-time';
+import { cn } from '@renderer/utils/utils';
+import { selectCurrentPr } from '@shared/core/pull-requests/pull-requests';
+import {
+  KANBAN_COLUMN_BY_ID,
+  KANBAN_COLUMN_BY_STATUS,
+  KANBAN_STATUS_COLUMNS,
+  type KanbanColumn,
+  type KanbanColumnMeta,
+} from './kanban-task-model';
+import type { ReadyTask } from './task-row';
+
+const TASK_DND_PREFIX = 'task:';
+
+function taskDndId(taskId: string): string {
+  return `${TASK_DND_PREFIX}${taskId}`;
+}
+
+function parseTaskDndId(id: string): string | null {
+  return id.startsWith(TASK_DND_PREFIX) ? id.slice(TASK_DND_PREFIX.length) : null;
+}
+
+function getKanbanColumnById(value: string): KanbanColumnMeta | undefined {
+  return KANBAN_COLUMN_BY_ID[value];
+}
+
+function StatusMenu({ task }: { task: ReadyTask }) {
+  const current = KANBAN_COLUMN_BY_STATUS[task.data.status];
+
+  return (
+    <div
+      onClick={(e) => e.stopPropagation()}
+      onPointerDown={(e) => e.stopPropagation()}
+      className="shrink-0"
+    >
+      <DropdownMenu>
+        <DropdownMenuTrigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={`Change status from ${current.label}`}
+            />
+          }
+        >
+          <ListTodo className="size-3.5" />
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="end" className="min-w-44">
+          <DropdownMenuRadioGroup
+            value={current.id}
+            onValueChange={(value) => {
+              const column = getKanbanColumnById(value);
+              if (!column || column.id === current.id) return;
+              void task.updateStatus(column.targetStatus);
+            }}
+          >
+            {KANBAN_STATUS_COLUMNS.map((column) => (
+              <DropdownMenuRadioItem key={column.id} value={column.id}>
+                {column.label}
+              </DropdownMenuRadioItem>
+            ))}
+          </DropdownMenuRadioGroup>
+        </DropdownMenuContent>
+      </DropdownMenu>
+    </div>
+  );
+}
+
+function KanbanTaskCardContent({
+  task,
+  isSelected,
+  onToggleSelect,
+}: {
+  task: ReadyTask;
+  isSelected: boolean;
+  onToggleSelect: (shiftKey: boolean) => void;
+}) {
+  const showRename = useShowModal('renameTaskModal');
+  const showDeleteTask = useShowModal('deleteTaskModal');
+  const taskManager = getTaskManagerStore(task.data.projectId);
+  const shiftKeyRef = useRef(false);
+
+  const isArchived = Boolean(task.data.archivedAt);
+  const agentAttention = taskAgentStatus(task);
+  const currentPr = task.data.prs ? selectCurrentPr(task.data.prs) : undefined;
+  const branchName =
+    getTaskGitWorktreeStore(task.data.projectId, task.data.id)?.branchName ?? undefined;
+
+  const handleArchive = () => void taskManager?.archiveTask(task.data.id);
+  const handleRestore = () => void taskManager?.restoreTask(task.data.id);
+  const handleDelete = () =>
+    showDeleteTask({
+      projectId: task.data.projectId,
+      tasks: [{ taskId: task.data.id, taskName: task.data.name }],
+      onSuccess: ({ deleteWorktree, deleteBranch }) =>
+        void taskManager?.deleteTasks([task.data.id], { deleteWorktree, deleteBranch }),
+    });
+  const handleRename = () =>
+    showRename({
+      projectId: task.data.projectId,
+      taskId: task.data.id,
+      currentName: task.data.name,
+    });
+
+  return (
+    <TaskContextMenu
+      isPinned={task.data.isPinned}
+      canPin
+      isArchived={isArchived}
+      branchName={branchName}
+      onPin={() => void task.setPinned(true)}
+      onUnpin={() => void task.setPinned(false)}
+      onRename={handleRename}
+      onArchive={handleArchive}
+      onRestore={handleRestore}
+      onConvertAutomation={undefined}
+      onDelete={handleDelete}
+    >
+      <div className="flex min-w-0 flex-col gap-2">
+        <div className="flex min-w-0 items-start gap-2">
+          <div
+            onPointerDownCapture={(e) => {
+              e.stopPropagation();
+              shiftKeyRef.current = e.shiftKey;
+            }}
+            onKeyDownCapture={(e) => {
+              shiftKeyRef.current = e.shiftKey;
+            }}
+            onClick={(e) => e.stopPropagation()}
+            className={cn(
+              'pt-0.5 transition-opacity',
+              isSelected ? 'opacity-100' : 'opacity-0 group-hover/card:opacity-100'
+            )}
+          >
+            <Checkbox
+              checked={isSelected}
+              onCheckedChange={() => {
+                const shift = shiftKeyRef.current;
+                shiftKeyRef.current = false;
+                onToggleSelect(shift);
+              }}
+              aria-label="Select task"
+            />
+          </div>
+          <div className="min-w-0 flex-1">
+            <p className="line-clamp-2 text-left text-sm leading-snug text-foreground">
+              {task.data.name}
+            </p>
+          </div>
+          <StatusMenu task={task} />
+        </div>
+        <div className="flex min-w-0 items-center justify-between gap-2">
+          <div className="flex min-w-0 items-center gap-2">
+            <TaskGitDiffStats task={task} className="text-xs" />
+            {currentPr && <PrBadge pr={currentPr} />}
+          </div>
+          <div className="flex shrink-0 items-center gap-1">
+            <StackedAgentLogos stats={task.conversationStats} />
+            {agentAttention ? (
+              <AgentStatusIndicator status={agentAttention} disableTooltip />
+            ) : (
+              <RelativeTime
+                value={task.data.updatedAt}
+                className="font-mono text-xs text-foreground-passive"
+                compact
+              />
+            )}
+          </div>
+        </div>
+      </div>
+    </TaskContextMenu>
+  );
+}
+
+function KanbanTaskCard({
+  task,
+  isSelected,
+  onToggleSelect,
+}: {
+  task: ReadyTask;
+  isSelected: boolean;
+  onToggleSelect: (shiftKey: boolean) => void;
+}) {
+  const { navigate } = useNavigate();
+  const taskManager = getTaskManagerStore(task.data.projectId);
+  const { attributes, listeners, setNodeRef, transform, isDragging } = useDraggable({
+    id: taskDndId(task.data.id),
+  });
+
+  const style: CSSProperties = {
+    transform: CSS.Translate.toString(transform),
+  };
+
+  const openTask = () => {
+    if (task.data.archivedAt) return;
+    void taskManager?.provisionTask(task.data.id);
+    navigate('task', { projectId: task.data.projectId, taskId: task.data.id });
+  };
+
+  const handleKeyDown = (event: KeyboardEvent<HTMLElement>) => {
+    if (event.target !== event.currentTarget) return;
+    if (event.key !== 'Enter' && event.key !== ' ') return;
+    event.preventDefault();
+    openTask();
+  };
+
+  return (
+    <article
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      {...listeners}
+      role="button"
+      tabIndex={task.data.archivedAt ? -1 : 0}
+      onClick={openTask}
+      onKeyDown={handleKeyDown}
+      className={cn(
+        'group/card cursor-pointer rounded-lg border border-border bg-background p-3 text-left shadow-sm transition-colors hover:bg-background-1 focus-visible:ring-2 focus-visible:ring-ring focus-visible:outline-none',
+        task.data.archivedAt && 'cursor-default opacity-80',
+        isDragging && 'opacity-40'
+      )}
+    >
+      <KanbanTaskCardContent task={task} isSelected={isSelected} onToggleSelect={onToggleSelect} />
+    </article>
+  );
+}
+
+function KanbanTaskOverlay({ task }: { task: ReadyTask }) {
+  return (
+    <div className="w-[18rem] rounded-lg border border-border bg-background p-3 text-left shadow-xl">
+      <p className="line-clamp-2 text-sm leading-snug text-foreground">{task.data.name}</p>
+    </div>
+  );
+}
+
+function KanbanColumnView({
+  column,
+  selectedIds,
+  onToggleSelect,
+}: {
+  column: KanbanColumn<ReadyTask>;
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string, shiftKey: boolean) => void;
+}) {
+  const { setNodeRef, isOver } = useDroppable({ id: column.id });
+
+  return (
+    <section
+      ref={setNodeRef}
+      className={cn(
+        'flex h-full min-h-0 w-[18rem] shrink-0 flex-col rounded-lg border border-border bg-background-1 transition-colors',
+        isOver && 'border-ring bg-background-2'
+      )}
+    >
+      <div className="flex h-11 shrink-0 items-center justify-between gap-2 border-b border-border px-3">
+        <h3 className="truncate text-sm font-medium text-foreground">{column.label}</h3>
+        <Badge variant="secondary">{column.tasks.length}</Badge>
+      </div>
+      <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-y-auto p-2">
+        {column.tasks.length === 0 ? (
+          <div className="flex h-20 items-center justify-center rounded-md border border-dashed border-border text-xs text-foreground-passive">
+            No tasks
+          </div>
+        ) : (
+          column.tasks.map((task) => (
+            <KanbanTaskCard
+              key={task.data.id}
+              task={task}
+              isSelected={selectedIds.has(task.data.id)}
+              onToggleSelect={(shiftKey) => onToggleSelect(task.data.id, shiftKey)}
+            />
+          ))
+        )}
+      </div>
+    </section>
+  );
+}
+
+export const TaskKanbanBoard = observer(function TaskKanbanBoard({
+  columns,
+  selectedIds,
+  onToggleSelect,
+}: {
+  columns: KanbanColumn<ReadyTask>[];
+  selectedIds: Set<string>;
+  onToggleSelect: (id: string, shiftKey: boolean) => void;
+}) {
+  const sensors = useSensors(useSensor(PointerSensor, { activationConstraint: { distance: 8 } }));
+  const [activeTaskId, setActiveTaskId] = useState<string | null>(null);
+  const tasksById = new Map(
+    columns.flatMap((column) => column.tasks.map((task) => [task.data.id, task]))
+  );
+
+  const handleDragEnd = (event: DragEndEvent) => {
+    setActiveTaskId(null);
+    const taskId = parseTaskDndId(String(event.active.id));
+    const targetColumn = event.over ? getKanbanColumnById(String(event.over.id)) : undefined;
+    if (!taskId || !targetColumn) return;
+    const task = tasksById.get(taskId);
+    if (!task || KANBAN_COLUMN_BY_STATUS[task.data.status].id === targetColumn.id) return;
+    void task.updateStatus(targetColumn.targetStatus);
+  };
+
+  const activeTask = activeTaskId ? tasksById.get(activeTaskId) : undefined;
+
+  return (
+    <DndContext
+      sensors={sensors}
+      collisionDetection={pointerWithin}
+      onDragStart={(event) => setActiveTaskId(parseTaskDndId(String(event.active.id)))}
+      onDragEnd={handleDragEnd}
+      onDragCancel={() => setActiveTaskId(null)}
+    >
+      <div className="min-h-0 flex-1 overflow-x-auto overflow-y-hidden py-3">
+        <div className="flex h-full min-h-[24rem] w-max gap-3 pr-1">
+          {columns.map((column) => (
+            <KanbanColumnView
+              key={column.id}
+              column={column}
+              selectedIds={selectedIds}
+              onToggleSelect={onToggleSelect}
+            />
+          ))}
+        </div>
+      </div>
+      <DragOverlay dropAnimation={null}>
+        {activeTask ? <KanbanTaskOverlay task={activeTask} /> : null}
+      </DragOverlay>
+    </DndContext>
+  );
+});

--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list.tsx
@@ -1,6 +1,6 @@
 import { useHotkey } from '@tanstack/react-hotkeys';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { Archive, RotateCcw, Trash2, X } from 'lucide-react';
+import { Archive, Columns3, List, RotateCcw, Trash2, X } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useRef } from 'react';
 import { asMounted, getProjectStore } from '@renderer/features/projects/stores/project-selectors';
@@ -20,6 +20,8 @@ import { SearchInput } from '@renderer/lib/ui/search-input';
 import { BoundShortcut } from '@renderer/lib/ui/shortcut';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { cn } from '@renderer/utils/utils';
+import { buildKanbanColumns } from './kanban-task-model';
+import { TaskKanbanBoard } from './task-kanban-board';
 import { TaskListEmptyState } from './task-list-empty-state';
 import { TaskRow, type ReadyTask } from './task-row';
 
@@ -210,21 +212,53 @@ export const TaskList = observer(function TaskList() {
   const filteredTasks = q
     ? displayTasks.filter((t) => t.data.name.toLowerCase().includes(q))
     : displayTasks;
+  const kanbanColumns = buildKanbanColumns(allTasks, {
+    tab: taskView.tab,
+    query: taskView.searchQuery,
+  });
+  const kanbanTasks = kanbanColumns.flatMap((column) => column.tasks);
+  const visibleTasks = taskView.mode === 'kanban' ? kanbanTasks : filteredTasks;
+
+  const toggleSelection = (orderedIds: string[], id: string, shiftKey: boolean) => {
+    if (shiftKey) {
+      taskView.selectRange(orderedIds, id);
+    } else {
+      taskView.toggleSelect(id);
+    }
+  };
 
   return (
     <div className="relative flex h-full min-h-0 w-full flex-col">
       <div className="flex shrink-0 flex-col gap-4 border-b border-border pb-3">
         <div className="flex flex-wrap items-center justify-between gap-2">
-          <ToggleGroup
-            multiple={false}
-            value={[taskView.tab]}
-            onValueChange={([value]) => {
-              if (value) taskView.setTab(value as 'active' | 'archived');
-            }}
-          >
-            <ToggleGroupItem value="active">Active ({activeTasks.length})</ToggleGroupItem>
-            <ToggleGroupItem value="archived">Archived ({archivedTasks.length})</ToggleGroupItem>
-          </ToggleGroup>
+          <div className="flex flex-wrap items-center gap-2">
+            <ToggleGroup
+              multiple={false}
+              value={[taskView.tab]}
+              onValueChange={([value]) => {
+                if (value) taskView.setTab(value as 'active' | 'archived');
+              }}
+            >
+              <ToggleGroupItem value="active">Active ({activeTasks.length})</ToggleGroupItem>
+              <ToggleGroupItem value="archived">Archived ({archivedTasks.length})</ToggleGroupItem>
+            </ToggleGroup>
+            <ToggleGroup
+              multiple={false}
+              value={[taskView.mode]}
+              onValueChange={([value]) => {
+                if (value) taskView.setMode(value as 'list' | 'kanban');
+              }}
+            >
+              <ToggleGroupItem value="list">
+                <List className="size-3.5" />
+                List
+              </ToggleGroupItem>
+              <ToggleGroupItem value="kanban">
+                <Columns3 className="size-3.5" />
+                Kanban
+              </ToggleGroupItem>
+            </ToggleGroup>
+          </div>
           <div className="flex items-center gap-2">
             <SearchInput
               placeholder="Search tasks…"
@@ -239,21 +273,30 @@ export const TaskList = observer(function TaskList() {
         </div>
       </div>
 
-      {filteredTasks.length === 0 && taskView.tab === 'active' ? (
+      {visibleTasks.length === 0 && taskView.tab === 'active' ? (
         <TaskListEmptyState projectId={projectId} />
+      ) : taskView.mode === 'kanban' ? (
+        <TaskKanbanBoard
+          columns={kanbanColumns}
+          selectedIds={taskView.selectedIds}
+          onToggleSelect={(id, shiftKey) =>
+            toggleSelection(
+              kanbanTasks.map((task) => task.data.id),
+              id,
+              shiftKey
+            )
+          }
+        />
       ) : (
         <TaskVirtualList
           tasks={filteredTasks}
           selectedIds={taskView.selectedIds}
           onToggleSelect={(id, shiftKey) => {
-            if (shiftKey) {
-              taskView.selectRange(
-                filteredTasks.map((t) => t.data.id),
-                id
-              );
-            } else {
-              taskView.toggleSelect(id);
-            }
+            toggleSelection(
+              filteredTasks.map((t) => t.data.id),
+              id,
+              shiftKey
+            );
           }}
         />
       )}

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.test.ts
@@ -14,3 +14,22 @@ describe('TaskViewStore range selection', () => {
     expect(store.lastSelectedId).toBe('1');
   });
 });
+
+describe('ProjectViewStore task view mode', () => {
+  it('persists and restores the selected task view mode', () => {
+    const store = new ProjectViewStore();
+
+    store.taskView.setMode('kanban');
+
+    expect(store.snapshot.taskViewMode).toBe('kanban');
+
+    const restored = new ProjectViewStore();
+    restored.restoreSnapshot({
+      activeView: 'tasks',
+      taskViewTab: 'active',
+      taskViewMode: 'kanban',
+    });
+
+    expect(restored.taskView.mode).toBe('kanban');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-view.ts
@@ -4,6 +4,7 @@ import type { IssueProviderType } from '@shared/issue-providers';
 import type { ProjectViewSnapshot } from '@shared/view-state';
 
 export type ProjectView = 'tasks' | 'pull-request' | 'settings';
+export type TaskViewMode = 'list' | 'kanban';
 
 export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
   activeView: ProjectView = 'tasks';
@@ -26,6 +27,7 @@ export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
     return {
       activeView: this.activeView,
       taskViewTab: this.taskView.tab,
+      taskViewMode: this.taskView.mode,
       selectedIssueProvider: this.selectedIssueProvider ?? undefined,
     };
   }
@@ -33,6 +35,7 @@ export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
   restoreSnapshot(snapshot: Partial<ProjectViewSnapshot>): void {
     if (snapshot.activeView) this.activeView = snapshot.activeView as ProjectView;
     if (snapshot.taskViewTab) this.taskView.setTab(snapshot.taskViewTab);
+    if (snapshot.taskViewMode) this.taskView.setMode(snapshot.taskViewMode);
     if (snapshot.selectedIssueProvider)
       this.selectedIssueProvider = snapshot.selectedIssueProvider as IssueProviderType;
   }
@@ -40,6 +43,7 @@ export class ProjectViewStore implements Snapshottable<ProjectViewSnapshot> {
 
 class TaskViewStore {
   tab: 'active' | 'archived' = 'active';
+  mode: TaskViewMode = 'list';
   searchQuery: string = '';
   selectedIds: Set<string> = new Set();
   lastSelectedId: string | null = null;
@@ -50,6 +54,11 @@ class TaskViewStore {
 
   setTab(tab: 'active' | 'archived') {
     this.tab = tab;
+  }
+
+  setMode(mode: TaskViewMode) {
+    this.mode = mode;
+    this.setSelectedIds(new Set());
   }
 
   setSearchQuery(query: string) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -160,7 +160,7 @@ export class TaskManagerStore {
       ({ taskId, projectId: evtProjectId, status }) => {
         if (evtProjectId !== this.projectId) return;
         const store = this.tasks.get(taskId);
-        if (store && isProvisioned(store)) {
+        if (store && isRegistered(store)) {
           runInAction(() => {
             store.data.status = status as TaskLifecycleStatus;
           });

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.test.ts
@@ -71,6 +71,8 @@ vi.mock('@renderer/lib/ipc', () => ({
   },
 }));
 
+const { rpc } = await import('@renderer/lib/ipc');
+
 function makeTask(overrides: Partial<Task> = {}): Task {
   return {
     id: 'task-1',
@@ -134,5 +136,15 @@ describe('TaskStore frontend runtime lifecycle', () => {
     expect(mocks.viewModels[1].initialize).toHaveBeenCalledOnce();
     expect(store.draftComments).toBe(mocks.draftComments[1]);
     expect(store.state).toBe('provisioned');
+  });
+
+  it('rolls back optimistic status updates when persistence fails', async () => {
+    vi.mocked(rpc.tasks.updateTaskStatus).mockRejectedValueOnce(new Error('persist failed'));
+    const store = createUnprovisionedTask(makeTask());
+
+    await expect(store.updateStatus('review')).rejects.toThrow('persist failed');
+
+    expect(store.data.status).toBe('todo');
+    expect(store.data.statusChangedAt).toBe('2026-01-01T00:00:00.000Z');
   });
 });

--- a/apps/emdash-desktop/src/shared/view-state.ts
+++ b/apps/emdash-desktop/src/shared/view-state.ts
@@ -114,6 +114,7 @@ export type TaskViewSnapshot = {
 export type ProjectViewSnapshot = {
   activeView: string;
   taskViewTab: 'active' | 'archived';
+  taskViewMode?: 'list' | 'kanban';
   selectedIssueProvider?: string;
 };
 


### PR DESCRIPTION
## Summary
- Add a List/Kanban mode toggle to each project Tasks view and persist the selected mode in project view state.
- Add an agentic task-flow Kanban board with Backlog, Prompting, Working, PR/Review, Done, and Cancelled columns backed by the existing task lifecycle statuses.
- Support drag-and-drop status updates with @dnd-kit, plus a per-card status menu fallback.
- Broadcast task status updates from the main process so status changes stay consistent across renderer stores.

## Screenshots
- Placeholder: Kanban board screenshot to be added before merge.
- Placeholder: status menu fallback screenshot to be added before merge.

## Tests
- `corepack pnpm -C apps/emdash-desktop exec vitest run --project node src/renderer/features/projects/components/task-view/kanban-task-model.test.ts src/renderer/features/projects/stores/project-view.test.ts src/renderer/features/tasks/stores/task-store.test.ts src/main/core/tasks/operations/updateTaskStatus.test.ts`
- `corepack pnpm -C apps/emdash-desktop run typecheck`