### PR TITLE
fix(core): handle thrown live model background errors

### DIFF
--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
@@ -254,10 +254,14 @@ class LegacySshGitRepository implements IGitRepository {
     this.refsModel = new LiveModel<GitRefsModel>({
       compute: async () => ok(await this.computeRefs()),
       onError: (error) => log.warn('LegacySshGitRepository: refs refresh failed', { error }),
+      onUnexpectedError: (error) =>
+        log.warn('LegacySshGitRepository: refs refresh failed', { error }),
     });
     this.remotesModel = new LiveModel<GitRemotesModel>({
       compute: async () => ok(await this.computeRemotes()),
       onError: (error) => log.warn('LegacySshGitRepository: remotes refresh failed', { error }),
+      onUnexpectedError: (error) =>
+        log.warn('LegacySshGitRepository: remotes refresh failed', { error }),
     });
     this.timers = [
       setInterval(() => this.refsModel.invalidate(), REFS_POLL_MS),
@@ -429,10 +433,14 @@ class LegacySshGitWorktree implements IGitWorktree {
     this.statusModel = new LiveModel<GitStatusModel>({
       compute: async () => ok(await this.computeStatus()),
       onError: (error) => log.warn('LegacySshGitWorktree: status refresh failed', { error }),
+      onUnexpectedError: (error) =>
+        log.warn('LegacySshGitWorktree: status refresh failed', { error }),
     });
     this.headModel = new LiveModel<GitHeadModel>({
       compute: async () => ok(await this.computeHead()),
       onError: (error) => log.warn('LegacySshGitWorktree: head refresh failed', { error }),
+      onUnexpectedError: (error) =>
+        log.warn('LegacySshGitWorktree: head refresh failed', { error }),
     });
     this.timers = [
       setInterval(() => void this.pollStatus('no'), STATUS_POLL_MS),

--- a/packages/core/src/git/git-repository.ts
+++ b/packages/core/src/git/git-repository.ts
@@ -82,12 +82,14 @@ export class GitRepository implements IGitRepository {
       debounceMs: WATCH_DEBOUNCE_MS,
       revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
       onError: (error) => this.onError(`refs ${this.gitCommonDir}`, error),
+      onUnexpectedError: (error) => this.onError(`refs ${this.gitCommonDir}`, error),
     });
     this.remotesModel = new LiveModel<GitRemotesModel>({
       compute: async () => ok(await this.computeRemotes()),
       debounceMs: WATCH_DEBOUNCE_MS,
       revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
       onError: (error) => this.onError(`remotes ${this.gitCommonDir}`, error),
+      onUnexpectedError: (error) => this.onError(`remotes ${this.gitCommonDir}`, error),
     });
 
     this.commonDirWatch = options.watcher.watch(

--- a/packages/core/src/git/git-worktree.ts
+++ b/packages/core/src/git/git-worktree.ts
@@ -97,12 +97,14 @@ export class GitWorktree implements IGitWorktree {
       debounceMs: WATCH_DEBOUNCE_MS,
       revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
       onError: (error) => onError(`status ${this.worktree}`, error),
+      onUnexpectedError: (error) => onError(`status ${this.worktree}`, error),
     });
     this.headModel = new LiveModel<GitHeadModel>({
       compute: async () => ok(await this.computeHead()),
       debounceMs: WATCH_DEBOUNCE_MS,
       revalidateIntervalMs: REVALIDATE_INTERVAL_MS,
       onError: (error) => onError(`head ${this.worktree}`, error),
+      onUnexpectedError: (error) => onError(`head ${this.worktree}`, error),
     });
 
     // The repository owns the `.git` (commonDir) watch and routes classified HEAD/index

--- a/packages/core/src/lib/live-model.test.ts
+++ b/packages/core/src/lib/live-model.test.ts
@@ -153,14 +153,16 @@ describe('LiveModel', () => {
 
   it('reports thrown background recompute errors without rethrowing them', async () => {
     const unexpected = new Error('SSH connection is not available');
-    const errors: unknown[] = [];
+    const returnedErrors: string[] = [];
+    const unexpectedErrors: unknown[] = [];
     let fail = false;
-    const model = new LiveModel<number>({
+    const model = new LiveModel<number, string>({
       compute: async () => {
         if (fail) throw unexpected;
         return ok(1);
       },
-      onError: (error) => errors.push(error),
+      onError: (error) => returnedErrors.push(error.toUpperCase()),
+      onUnexpectedError: (error) => unexpectedErrors.push(error),
     });
     const pushed: number[] = [];
 
@@ -173,11 +175,43 @@ describe('LiveModel', () => {
       model.invalidate();
       await vi.runAllTimersAsync();
 
-      expect(errors).toEqual([unexpected]);
+      expect(returnedErrors).toEqual([]);
+      expect(unexpectedErrors).toEqual([unexpected]);
       expect(model.getCached()).toEqual(lv(1, 1));
       expect(pushed).toEqual([1]);
       expect(queueMicrotaskSpy).not.toHaveBeenCalled();
     } finally {
+      queueMicrotaskSpy.mockRestore();
+    }
+  });
+
+  it('logs thrown background recompute errors when no handler is configured', async () => {
+    const unexpected = new Error('SSH connection is not available');
+    let fail = false;
+    const model = new LiveModel<number, string>({
+      compute: async () => {
+        if (fail) throw unexpected;
+        return ok(1);
+      },
+    });
+
+    model.subscribe(() => {});
+    await vi.runAllTimersAsync();
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+    const queueMicrotaskSpy = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation(() => {});
+    try {
+      fail = true;
+      model.invalidate();
+      await vi.runAllTimersAsync();
+
+      expect(consoleErrorSpy).toHaveBeenCalledWith(
+        'LiveModel background recompute threw unexpectedly',
+        unexpected
+      );
+      expect(queueMicrotaskSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
       queueMicrotaskSpy.mockRestore();
     }
   });

--- a/packages/core/src/lib/live-model.test.ts
+++ b/packages/core/src/lib/live-model.test.ts
@@ -151,6 +151,37 @@ describe('LiveModel', () => {
     await expect(model.get()).resolves.toEqual(lv(4, 2)); // dirty: recomputes
   });
 
+  it('reports thrown background recompute errors without rethrowing them', async () => {
+    const unexpected = new Error('SSH connection is not available');
+    const errors: unknown[] = [];
+    let fail = false;
+    const model = new LiveModel<number>({
+      compute: async () => {
+        if (fail) throw unexpected;
+        return ok(1);
+      },
+      onError: (error) => errors.push(error),
+    });
+    const pushed: number[] = [];
+
+    model.subscribe((update) => pushed.push(update.value));
+    await vi.runAllTimersAsync();
+
+    const queueMicrotaskSpy = vi.spyOn(globalThis, 'queueMicrotask').mockImplementation(() => {});
+    try {
+      fail = true;
+      model.invalidate();
+      await vi.runAllTimersAsync();
+
+      expect(errors).toEqual([unexpected]);
+      expect(model.getCached()).toEqual(lv(1, 1));
+      expect(pushed).toEqual([1]);
+      expect(queueMicrotaskSpy).not.toHaveBeenCalled();
+    } finally {
+      queueMicrotaskSpy.mockRestore();
+    }
+  });
+
   it('rejects direct refresh after an unexpected thrown compute error', async () => {
     const unexpected = new Error('boom');
     const model = new LiveModel<number>({

--- a/packages/core/src/lib/live-model.ts
+++ b/packages/core/src/lib/live-model.ts
@@ -28,8 +28,10 @@ export type LiveModelOptions<T, E = unknown> = {
   revalidateIntervalMs?: number;
   /** Used to suppress no-op updates. */
   isEqual?: (a: T, b: T) => boolean;
-  /** Receives errors returned or thrown by background recomputes. */
+  /** Receives errors returned by background recomputes. */
   onError?: (error: E) => void;
+  /** Receives unexpected errors thrown by background recomputes. */
+  onUnexpectedError?: (error: unknown) => void;
 };
 
 /**
@@ -204,7 +206,11 @@ export class LiveModel<T, E = unknown> implements IDisposable {
         if (!result.success) this.options.onError?.(result.error);
       },
       (error: unknown) => {
-        this.options.onError?.(error as E);
+        if (this.options.onUnexpectedError) {
+          this.options.onUnexpectedError(error);
+          return;
+        }
+        console.error('LiveModel background recompute threw unexpectedly', error);
       }
     );
   }

--- a/packages/core/src/lib/live-model.ts
+++ b/packages/core/src/lib/live-model.ts
@@ -28,7 +28,7 @@ export type LiveModelOptions<T, E = unknown> = {
   revalidateIntervalMs?: number;
   /** Used to suppress no-op updates. */
   isEqual?: (a: T, b: T) => boolean;
-  /** Receives errors returned by background recomputes. */
+  /** Receives errors returned or thrown by background recomputes. */
   onError?: (error: E) => void;
 };
 
@@ -199,15 +199,14 @@ export class LiveModel<T, E = unknown> implements IDisposable {
   }
 
   private scheduleBackground(): void {
-    void this.schedule()
-      .then((result) => {
+    void this.schedule().then(
+      (result) => {
         if (!result.success) this.options.onError?.(result.error);
-      })
-      .catch((error) => {
-        queueMicrotask(() => {
-          throw error;
-        });
-      });
+      },
+      (error: unknown) => {
+        this.options.onError?.(error as E);
+      }
+    );
   }
 
   private armRevalidate(): void {


### PR DESCRIPTION
- route thrown LiveModel background recompute errors through onError instead of rethrowing them
- prevent wake-time ssh disconnects from escalating background git refresh failures into process fatal exceptions