### PR TITLE
fix(pty): drop tmux attach-probe replies leaking into SSH terminal panes

### DIFF
--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -250,6 +250,7 @@ export class LocalConversationProvider implements ConversationProvider {
         metadata: {
           providerId: conversation.providerId,
           title: conversation.title,
+          tmux: this.tmux,
         },
       });
       this.sessions.set(sessionId, pty);

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -269,6 +269,7 @@ export class SshConversationProvider implements ConversationProvider {
           providerId: conversation.providerId,
           title: conversation.title,
           isRemote: true,
+          tmux: this.tmux,
         },
       });
       this.sessions.set(sessionId, pty);

--- a/apps/emdash-desktop/src/main/core/pty/pty-session-registry.ts
+++ b/apps/emdash-desktop/src/main/core/pty/pty-session-registry.ts
@@ -3,11 +3,19 @@ import type { AgentProviderId } from '@shared/core/agents/agent-provider-registr
 import { ptyDataChannel, ptyExitChannel, ptyInputChannel } from '@shared/core/pty/ptyEvents';
 import { ptyStartedChannel } from '@shared/events/appEvents';
 import type { Pty, PtyExitInfo } from './pty';
+import { stripUnsolicitedTerminalReplies } from './terminal-reply-filter';
 
 export interface PtySessionMetadata {
   providerId?: AgentProviderId;
   title?: string;
   isRemote?: boolean;
+  /**
+   * Session runs under a tmux client. Enables stripping of tmux's attach-time
+   * outer-terminal probe replies (`ESC[?...c` / `ESC[>...c` / XTVERSION) on the
+   * input path, which otherwise leak into the focused pane over SSH. See
+   * {@link stripUnsolicitedTerminalReplies}.
+   */
+  tmux?: boolean;
 }
 
 const FLUSH_INTERVAL_MS = 16; // ~60 fps
@@ -94,6 +102,17 @@ export class PtySessionRegistry {
     const off = events.on(
       ptyInputChannel,
       (data) => {
+        if (this.metadata.get(sessionId)?.tmux) {
+          // Drop tmux's attach-time outer-terminal probe replies that xterm.js
+          // auto-generates; they would otherwise leak into the focused pane as
+          // `1;2c0;276;0c`. tmux already has these capabilities pre-declared via
+          // `terminal-features` (see buildTmuxShellLine), so the replies are
+          // redundant. Returns '' only for pure-reply chunks; real input is
+          // forwarded unchanged.
+          const filtered = stripUnsolicitedTerminalReplies(data);
+          if (filtered) pty.write(filtered);
+          return;
+        }
         pty.write(data);
       },
       sessionId

--- a/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.test.ts
@@ -41,6 +41,10 @@ describe('stripUnsolicitedTerminalReplies', () => {
     expect(stripUnsolicitedTerminalReplies('\x1b[c')).toBe('\x1b[c');
   });
 
+  it('forwards the bare DA2 query (ESC[>c) unchanged — it has no params, so it is not a reply', () => {
+    expect(stripUnsolicitedTerminalReplies('\x1b[>c')).toBe('\x1b[>c');
+  });
+
   it('does not touch a cursor-position (CPR) reply', () => {
     expect(stripUnsolicitedTerminalReplies('\x1b[6;10R')).toBe('\x1b[6;10R');
   });

--- a/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { stripUnsolicitedTerminalReplies } from './terminal-reply-filter';
+
+// Background: tmux probes the outer terminal (xterm.js) on every client attach
+// with DA1 (`ESC[c`), DA2 (`ESC[>c`) and XTVERSION (`ESC[>q`). Over SSH the
+// reply round-trips slowly and lands after tmux's read window, so tmux forwards
+// it to the focused pane and the shell echoes garbage like `1;2c0;276;0c`.
+// This filter drops those replies on the renderer -> remote input path.
+
+const DA1_REPLY = '\x1b[?1;2c'; // visible tail: 1;2c
+const DA2_REPLY = '\x1b[>0;276;0c'; // visible tail: 0;276;0c — xterm.js firmware 276
+const XTVERSION_REPLY = '\x1bP>|XTerm(380)\x1b\\';
+
+describe('stripUnsolicitedTerminalReplies', () => {
+  it('drops a standalone DA1 reply', () => {
+    expect(stripUnsolicitedTerminalReplies(DA1_REPLY)).toBe('');
+  });
+
+  it('drops a standalone DA2 reply (xterm.js >0;276;0c)', () => {
+    expect(stripUnsolicitedTerminalReplies(DA2_REPLY)).toBe('');
+  });
+
+  it('drops a combined DA1+DA2 chunk — the exact leaked pattern', () => {
+    expect(stripUnsolicitedTerminalReplies(DA1_REPLY + DA2_REPLY)).toBe('');
+  });
+
+  it('drops the repeated leaked pattern seen at the prompt', () => {
+    const leaked = (DA1_REPLY + DA2_REPLY).repeat(4);
+    expect(stripUnsolicitedTerminalReplies(leaked)).toBe('');
+  });
+
+  it('drops an XTVERSION DCS reply', () => {
+    expect(stripUnsolicitedTerminalReplies(XTVERSION_REPLY)).toBe('');
+  });
+
+  it('forwards ordinary typed input unchanged', () => {
+    expect(stripUnsolicitedTerminalReplies('ls -la\r')).toBe('ls -la\r');
+  });
+
+  it('forwards a real DA query (ESC[c) unchanged — only replies are dropped', () => {
+    expect(stripUnsolicitedTerminalReplies('\x1b[c')).toBe('\x1b[c');
+  });
+
+  it('does not touch a cursor-position (CPR) reply', () => {
+    expect(stripUnsolicitedTerminalReplies('\x1b[6;10R')).toBe('\x1b[6;10R');
+  });
+
+  it('never corrupts a mixed chunk that also carries real input', () => {
+    const mixed = 'echo hi' + DA1_REPLY;
+    expect(stripUnsolicitedTerminalReplies(mixed)).toBe(mixed);
+  });
+
+  it('passes empty input straight through', () => {
+    expect(stripUnsolicitedTerminalReplies('')).toBe('');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.ts
+++ b/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.ts
@@ -1,0 +1,31 @@
+// Device-Attributes / version reply sequences that xterm.js (the renderer's
+// terminal) auto-generates when something queries it:
+//   - DA1 reply:  ESC [ ? <params> c     e.g. ESC[?1;2c   (visible tail: 1;2c)
+//   - DA2 reply:  ESC [ > <params> c     e.g. ESC[>0;276;0c (visible tail: 0;276;0c)
+//   - XTVERSION:  ESC P > | <text> ST    e.g. ESC P >|XTerm(380) ESC \
+// `ST` is either `ESC \` or the single-byte `0x9c`.
+const DA_REPLY = /\x1b\[[?>][0-9;]*c/g;
+const XTVERSION_REPLY = /\x1bP>\|[^\x1b\x9c]*(?:\x1b\\|\x9c)/g;
+
+/**
+ * Returns the terminal input that should actually be forwarded to a tmux-backed
+ * remote PTY, with *unsolicited* Device-Attributes / version replies removed.
+ *
+ * Why this exists: tmux probes the outer terminal on every client attach
+ * (DA1/DA2/XTVERSION). Over SSH the reply round-trips through the renderer's
+ * xterm.js and back slowly enough to miss tmux's post-attach read window, so
+ * tmux forwards it to the focused pane and the shell echoes garbage like
+ * `1;2c0;276;0c`. emdash pre-declares the terminal's capabilities to tmux via
+ * `terminal-features` (see {@link buildTmuxShellLine}), so these replies are
+ * redundant and safe to drop. Apply only to tmux-backed sessions: outside tmux
+ * a remote app may legitimately query DA and need the reply.
+ *
+ * Conservative by design: a chunk is dropped only when it is composed *entirely*
+ * of reply sequences. A chunk that also carries real typed input is forwarded
+ * unchanged, so genuine keystrokes are never altered.
+ */
+export function stripUnsolicitedTerminalReplies(data: string): string {
+  if (!data) return data;
+  const stripped = data.replace(DA_REPLY, '').replace(XTVERSION_REPLY, '');
+  return stripped.length === 0 ? '' : data;
+}

--- a/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.ts
+++ b/apps/emdash-desktop/src/main/core/pty/terminal-reply-filter.ts
@@ -4,7 +4,11 @@
 //   - DA2 reply:  ESC [ > <params> c     e.g. ESC[>0;276;0c (visible tail: 0;276;0c)
 //   - XTVERSION:  ESC P > | <text> ST    e.g. ESC P >|XTerm(380) ESC \
 // `ST` is either `ESC \` or the single-byte `0x9c`.
-const DA_REPLY = /\x1b\[[?>][0-9;]*c/g;
+// Require at least one parameter (`[0-9;]+`, not `*`): a real DA reply always
+// carries params, whereas the bare DA2 *query* `ESC[>c` has none. Using `*` would
+// also match that query and wrongly drop it (the DA1 query `ESC[c` lacks the
+// `?`/`>` leader, so it never matched either way).
+const DA_REPLY = /\x1b\[[?>][0-9;]+c/g;
 const XTVERSION_REPLY = /\x1bP>\|[^\x1b\x9c]*(?:\x1b\\|\x9c)/g;
 
 /**

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.test.ts
@@ -21,6 +21,14 @@ describe('buildTmuxShellLine', () => {
     expect(result.indexOf('mouse on')).toBeLessThan(result.indexOf('attach-session'));
     expect(result.indexOf('history-limit')).toBeLessThan(result.indexOf('attach-session'));
   });
+
+  it('pre-declares the terminal capabilities before attach so tmux skips the probe reply', () => {
+    const result = buildTmuxShellLine('agent-session', 'exec /bin/zsh -il');
+
+    // Server option (no `-t`), appended (`-a`), keyed by TERM, includes RGB/256.
+    expect(result).toContain('tmux set-option -as terminal-features ,xterm-256color:RGB:256:');
+    expect(result.indexOf('terminal-features')).toBeLessThan(result.indexOf('attach-session'));
+  });
 });
 
 describe('decodeTmuxSessionName', () => {

--- a/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
+++ b/apps/emdash-desktop/src/main/core/pty/tmux-session-name.ts
@@ -3,6 +3,12 @@ import { log } from '@main/lib/logger';
 
 export const TMUX_SESSION_PREFIX = 'emdash-';
 const TMUX_HISTORY_LIMIT = 100_000;
+// Capabilities the renderer terminal (xterm.js) actually supports, declared to
+// tmux so it never needs its attach-time probe reply (see buildTmuxShellLine).
+// Leading `,` + `set -a` appends a TERM-keyed entry. Only shell-neutral chars
+// (`,` `:` `-`), so it needs no quoting.
+const TMUX_TERMINAL_FEATURES =
+  ',xterm-256color:RGB:256:mouse:extkeys:strikethrough:focus:clipboard:ccolour:cstyle:title';
 
 export function buildTmuxShellLine(sessionName: string, commandLine: string): string {
   const quotedName = JSON.stringify(sessionName);
@@ -14,7 +20,14 @@ export function buildTmuxShellLine(sessionName: string, commandLine: string): st
   const newSession = `tmux -u new-session -d -s ${quotedName} ${quotedCmd}`;
   const enableMouse = `tmux set-option -t ${quotedName} mouse on 2>/dev/null || true`;
   const setHistoryLimit = `tmux set-option -t ${quotedName} history-limit ${TMUX_HISTORY_LIMIT} 2>/dev/null || true`;
-  const configure = `(${enableMouse}) && (${setHistoryLimit})`;
+  // Pre-declare the renderer terminal's (xterm.js) capabilities so tmux does not
+  // depend on the reply to its attach-time probe (DA1/DA2/XTVERSION). Over SSH
+  // that reply round-trips slowly and leaks into the focused pane as
+  // `1;2c0;276;0c`; the PTY input filter (terminal-reply-filter.ts) drops it, and
+  // this declaration keeps truecolor/256/mouse/etc. intact without the probe.
+  // `terminal-features` is a server option (no `-t`); `-a` appends, keyed by TERM.
+  const declareFeatures = `tmux set-option -as terminal-features ${TMUX_TERMINAL_FEATURES} 2>/dev/null || true`;
+  const configure = `(${enableMouse}) && (${setHistoryLimit}) && (${declareFeatures})`;
   const attach = `tmux -u attach-session -t ${quotedName}`;
   const script = `(${checkExists} || ${newSession}) && ${configure} && ${attach}`;
   return `/bin/sh -c ${JSON.stringify(script)}`;

--- a/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.test.ts
@@ -89,7 +89,7 @@ describe('LocalTerminalProvider', () => {
     expect(ptySessionRegistry.register).toHaveBeenCalledWith(
       sessionId,
       expect.anything(),
-      expect.objectContaining({ metadata: { title: terminal.name } })
+      expect.objectContaining({ metadata: expect.objectContaining({ title: terminal.name }) })
     );
   });
 

--- a/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -264,7 +264,7 @@ export class LocalTerminalProvider implements TerminalProvider {
 
     ptySessionRegistry.register(sessionId, pty, {
       preserveBufferOnExit: policy.preserveBufferOnExit,
-      metadata,
+      metadata: { ...metadata, tmux: this.tmux },
     });
     this.sessions.set(sessionId, pty);
   }

--- a/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.test.ts
@@ -113,7 +113,9 @@ describe('SshTerminalProvider', () => {
     expect(ptySessionRegistry.register).toHaveBeenCalledWith(
       sessionId,
       expect.anything(),
-      expect.objectContaining({ metadata: { title: terminal.name, isRemote: true } })
+      expect.objectContaining({
+        metadata: expect.objectContaining({ title: terminal.name, isRemote: true }),
+      })
     );
   });
 

--- a/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/ssh-terminal-provider.ts
@@ -286,7 +286,7 @@ export class SshTerminalProvider implements TerminalProvider {
 
     ptySessionRegistry.register(sessionId, pty, {
       preserveBufferOnExit: policy.preserveBufferOnExit,
-      metadata,
+      metadata: { ...metadata, tmux: this.tmux },
     });
     this.sessions.set(sessionId, pty);
   }


### PR DESCRIPTION
> Addresses #2720. Ready for review; the open questions for maintainers below are still open for input.

## Problem

On the SSH provider, stray bytes like `1;2c0;276;0c` (often repeated) appear at the
shell prompt of a tmux-backed terminal/agent pane, out of nowhere. They are
**terminal Device-Attributes replies** with the `ESC[` prefix consumed:

- `1;2c` = DA1 reply `ESC[?1;2c`
- `0;276;0c` = DA2 reply `ESC[>0;276;0c` (firmware 276 = xterm.js)

Full analysis in #2720.

## Root cause

tmux probes the outer terminal on **every client attach** with DA1 (`ESC[c`),
DA2 (`ESC[>c`) and XTVERSION (`ESC[>q`). The reply is generated by the renderer's
xterm.js and round-trips renderer → main → ssh2 → remote. Over SSH that path is
slow enough to land *after* tmux's post-attach read window, so tmux forwards the
late reply to the focused pane and the shell echoes it. One leaked set appears per
attach / `refresh-client`, hence the repetition.

Verified locally with a pty harness on tmux 3.5a: every attach sends DA1+DA2+
XTVERSION unconditionally (pre-setting `terminal-features` does **not** stop it).

## Fix (two coordinated parts)

**1. Strip the unsolicited replies on the input path** — `terminal-reply-filter.ts`
drops chunks composed entirely of DA1/DA2/XTVERSION reply sequences, wired into
`PtySessionRegistry` and gated on a new `PtySessionMetadata.tmux` flag set at all
four register sites (terminal + conversation, local + ssh). It is scoped to
tmux-backed sessions on purpose: inside tmux only tmux itself queries the outer
terminal, so these replies are never wanted by a pane; outside tmux a remote app
may legitimately query DA, so those sessions are untouched. The filter is
conservative — a chunk that also carries real typed input is forwarded unchanged.

**2. Pre-declare the terminal's capabilities** — `buildTmuxShellLine` now runs
`tmux set-option -as terminal-features ,xterm-256color:RGB:256:...` before attach.
Measured: dropping the probe reply alone costs `RGB`, `256`, `mouse`, `extkeys`,
`strikethrough`; pre-declaring restores the **full** feature set with zero probe
replies (`client_termfeatures` identical to the baseline). So the filter is
lossless.

## Verification

- `terminal-reply-filter.test.ts` — 10 cases (RED→GREEN), incl. the exact leaked
  `(?1;2c)(>0;276;0c)×4` pattern, DA query passthrough, CPR untouched, mixed-chunk
  safety.
- `buildTmuxShellLine` test asserts the capability declaration precedes attach.
- Provider metadata assertions updated for the new `tmux` field.
- Targeted `node`-project tests pass on current `main`.
- Full `format`/`lint`/`typecheck`/`test` gate intended via CI.

## Open questions for maintainers

- `terminal-features` is a **server-global** option (keyed by TERM). On a shared
  tmux server it also declares these caps to other `xterm-256color` clients — only
  *adds* capabilities, but a dedicated TERM/override could scope it tighter.
- An end-to-end integration test of the registry input path (driving the event bus)
  isn't included; the true leak is timing/SSH-dependent. Happy to add one if useful.
- Alternative considered: synthesize the probe reply locally on the remote so it
  never round-trips. More invasive; this PR favors the smaller filter + declaration.

