### PR TITLE
feat(settings): restore agent and model defaults

### DIFF
--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
@@ -326,6 +326,83 @@ describe('executeTaskCreate', () => {
     );
   });
 
+  it('uses automation default agent and model when the automation has no provider or model', async () => {
+    vi.mocked(appSettingsService.get).mockImplementation(async (key) => {
+      if (key === 'defaultAutomationAgent') return 'codex' as never;
+      if (key === 'defaultAutomationModel') return 'gpt-5-codex' as never;
+      return null as never;
+    });
+
+    await executeTaskCreate(
+      {
+        ...automation,
+        conversationConfig: { prompt: 'Check things', provider: '', autoApprove: false },
+      },
+      run,
+      noopStep
+    );
+
+    expect(createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'codex',
+        model: 'gpt-5-codex',
+      })
+    );
+  });
+
+  it('keeps an automation-specific model ahead of the automation default model', async () => {
+    vi.mocked(appSettingsService.get).mockImplementation(async (key) => {
+      if (key === 'defaultAutomationAgent') return 'claude' as never;
+      if (key === 'defaultAutomationModel') return 'claude-default' as never;
+      return null as never;
+    });
+
+    await executeTaskCreate(
+      {
+        ...automation,
+        conversationConfig: {
+          prompt: 'Check things',
+          provider: 'claude',
+          autoApprove: false,
+          model: 'claude-specific',
+        },
+      },
+      run,
+      noopStep
+    );
+
+    expect(createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'claude',
+        model: 'claude-specific',
+      })
+    );
+  });
+
+  it('does not apply a later automation default model to an automation with an explicit provider', async () => {
+    vi.mocked(appSettingsService.get).mockImplementation(async (key) => {
+      if (key === 'defaultAutomationAgent') return 'claude' as never;
+      if (key === 'defaultAutomationModel') return 'claude-default' as never;
+      return null as never;
+    });
+
+    await executeTaskCreate(
+      {
+        ...automation,
+        conversationConfig: { prompt: 'Check things', provider: 'claude', autoApprove: false },
+      },
+      run,
+      noopStep
+    );
+
+    expect(createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'claude',
+        model: undefined,
+      })
+    );
+  });
+
   it('creates ACP conversations with an initial queue and eagerly starts the session', async () => {
     await executeTaskCreate(
       {
@@ -345,6 +422,53 @@ describe('executeTaskCreate', () => {
     expect(createConversation).toHaveBeenCalledWith(
       expect.objectContaining({
         provider: 'claude',
+        model: 'sonnet',
+        initialQueue: [{ text: 'Check things' }],
+        isInitialConversation: true,
+        type: 'acp',
+      })
+    );
+    expect(vi.mocked(createConversation).mock.calls[0]?.[0].initialPrompt).toBeUndefined();
+    expect(acpRuntimeProcedures.startSession).toHaveBeenCalledWith({
+      input: expect.objectContaining({
+        conversationId: expect.any(String),
+        projectId: 'project-1',
+        taskId: expect.any(String),
+        providerId: 'claude',
+        workspaceId: 'workspace-1',
+        cwd: '/tmp/task',
+        sessionId: null,
+        model: 'sonnet',
+        initialQueue: [{ text: 'Check things' }],
+      }),
+    });
+  });
+
+  it('passes automation default model to ACP startup when no provider is configured', async () => {
+    vi.mocked(appSettingsService.get).mockImplementation(async (key) => {
+      if (key === 'defaultAutomationAgent') return 'claude' as never;
+      if (key === 'defaultAutomationModel') return 'sonnet' as never;
+      return null as never;
+    });
+
+    await executeTaskCreate(
+      {
+        ...automation,
+        conversationConfig: {
+          prompt: 'Check things',
+          provider: '',
+          autoApprove: false,
+          type: 'acp',
+        },
+      },
+      run,
+      noopStep
+    );
+
+    expect(createConversation).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provider: 'claude',
+        model: 'sonnet',
         initialQueue: [{ text: 'Check things' }],
         isInitialConversation: true,
         type: 'acp',

--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
@@ -5,7 +5,6 @@ import { createConversation } from '@main/core/conversations/createConversation'
 import { issueController } from '@main/core/issues/controller';
 import { openProject } from '@main/core/projects/operations/openProject';
 import { projectManager } from '@main/core/projects/project-manager';
-import { DEFAULT_AGENT_ID } from '@main/core/settings/settings-registry';
 import { appSettingsService } from '@main/core/settings/settings-service';
 import { generateRandom } from '@main/core/tasks/name-generation/generateTaskName';
 import {
@@ -130,9 +129,18 @@ export async function executeTaskCreate(
     }
     const workspaceConfig = scopeWorkspaceConfigToRun(taskConfig.workspaceConfig, taskName);
 
-    const provider = (automation.conversationConfig?.provider ||
-      (await appSettingsService.get('defaultAgent')) ||
-      DEFAULT_AGENT_ID) as AgentProviderId;
+    // appSettingsService.get() resolves unset keys to registry defaults, so the automation
+    // agent default is never empty and needs no further fallback here.
+    const configuredProvider = automation.conversationConfig?.provider || null;
+    const provider = (configuredProvider ||
+      (await appSettingsService.get('defaultAutomationAgent'))) as AgentProviderId;
+    // Automation model defaults are intentionally independent from task/conversation defaults.
+    // They only apply when the automation has no explicit provider, so later default changes do
+    // not alter automations that were already configured with a specific agent.
+    const defaultAutomationModel = configuredProvider
+      ? null
+      : await appSettingsService.get('defaultAutomationModel');
+    const model = automation.conversationConfig?.model || defaultAutomationModel || undefined;
     const conversationType = automation.conversationConfig?.type ?? 'pty';
     const initialQueue =
       conversationType === 'acp'
@@ -239,7 +247,7 @@ export async function executeTaskCreate(
           provider,
           automation.conversationConfig?.autoApprove
         ),
-        model: automation.conversationConfig?.model || undefined,
+        model,
         ...(conversationType === 'acp' ? { initialQueue } : { initialPrompt: prompt }),
         isInitialConversation: true,
         type: conversationType,
@@ -254,7 +262,7 @@ export async function executeTaskCreate(
             workspaceId: provision.data.workspaceId,
             cwd: provision.data.path,
             sessionId: null,
-            model: automation.conversationConfig?.model || null,
+            model: model ?? null,
             initialQueue,
           },
         });

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -57,6 +57,7 @@ export const themeSchema = z
   .default(null);
 
 export const defaultAgentSchema = z.optional(z.enum(AGENT_PROVIDER_IDS)).default(DEFAULT_AGENT_ID);
+export const defaultModelSchema = z.string().nullable().optional().default(null);
 
 export const keyboardSettingsSchema = z
   .optional(
@@ -137,6 +138,9 @@ export const APP_SETTINGS_SCHEMA_MAP = {
   project: projectSettingsSchema,
   tasks: taskSettingsSchema,
   defaultAgent: defaultAgentSchema,
+  defaultModel: defaultModelSchema,
+  defaultAutomationAgent: defaultAgentSchema,
+  defaultAutomationModel: defaultModelSchema,
   keyboard: keyboardSettingsSchema,
   notifications: notificationSettingsSchema,
   theme: themeSchema,
@@ -154,6 +158,9 @@ export const appSettingsSchema = z.object({
   project: projectSettingsSchema,
   tasks: taskSettingsSchema,
   defaultAgent: defaultAgentSchema,
+  defaultModel: defaultModelSchema,
+  defaultAutomationAgent: defaultAgentSchema,
+  defaultAutomationModel: defaultModelSchema,
   keyboard: keyboardSettingsSchema,
   notifications: notificationSettingsSchema,
   theme: themeSchema,

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -47,6 +47,9 @@ export const SETTINGS_DEFAULTS = {
   },
   theme: null,
   defaultAgent: DEFAULT_AGENT_ID,
+  defaultModel: null,
+  defaultAutomationAgent: DEFAULT_AGENT_ID,
+  defaultAutomationModel: null,
   keyboard: {},
   openIn: {
     default: 'terminal' as const,

--- a/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
@@ -103,6 +103,9 @@ export function useAutomationFormState(
 
   const initialConversation = useInitialConversationState(effectiveProjectId, seedProvider, false, {
     resetPromptOnProjectChange: false,
+    defaultAgentSettingKey: 'defaultAutomationAgent',
+    defaultModelSettingKey: 'defaultAutomationModel',
+    applyDefaultModel: !seed,
   });
 
   const [promptSeeded, setPromptSeeded] = useState(false);

--- a/apps/emdash-desktop/src/renderer/features/automations/useAutomationSettingsAutoSave.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/useAutomationSettingsAutoSave.ts
@@ -16,6 +16,7 @@ export function useAutomationSettingsAutoSave(automation: Automation) {
     effectiveProjectId,
     prompt,
     provider,
+    model,
     triggerConfig,
     cronTz,
     canSave,
@@ -23,13 +24,14 @@ export function useAutomationSettingsAutoSave(automation: Automation) {
     name,
     workspaceConfig,
   } = formState;
+  const useChatUi = formState.initialConversation.useChatUi;
 
   function buildConversationConfig(): ConversationConfig {
-    const useChatUi = formState.initialConversation.useChatUi;
     return {
       prompt: prompt.trim(),
       provider,
       autoApprove: false,
+      model: model ?? undefined,
       type: useChatUi ? 'acp' : 'pty',
     };
   }
@@ -70,9 +72,9 @@ export function useAutomationSettingsAutoSave(automation: Automation) {
       return;
     }
     if (canSave) savePatch();
-    // We intentionally only track provider here; other fields use action-at-change-site.
+    // We intentionally only track provider/model/type here; other fields use action-at-change-site.
     // oxlint-disable-next-line react/exhaustive-deps
-  }, [provider]);
+  }, [provider, model, useChatUi]);
 
   // Workspace config changes (preset, branch name, sandbox toggle, etc.) are not
   // interceptable at the setter level because they go through useWorkspaceConfig

--- a/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
@@ -1,7 +1,8 @@
 import { observer } from 'mobx-react-lite';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { conversationRegistry } from '@renderer/features/conversations/stores/conversation-registry';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 // TODO(conversations-extraction): Pass task settings into the modal instead of importing task hooks.
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
@@ -40,7 +41,8 @@ export const CreateConversationModal = observer(function CreateConversationModal
   taskId: string;
 }) {
   const connectionId = getProjectSshConnectionId(projectId);
-  const { providerId, setProviderOverride, createDisabled } = useEffectiveProvider(connectionId);
+  const { providerId, defaultProviderId, setProviderOverride, createDisabled } =
+    useEffectiveProvider(connectionId);
   const conversationMgr = conversationRegistry.get(taskId);
   const taskSettings = useTaskSettings();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -48,13 +50,21 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [useAcpOverride, setUseAcpOverride] = useState(false);
+  const [modelTouched, setModelTouched] = useState(false);
   const chatUiEnabled = useFeatureFlag('chat-ui');
   useCloseGuard(isSubmitting);
 
   const { data: agents } = useAgents();
+  const { value: defaultModelValue } = useAppSettingsKey('defaultModel');
   const modelsCapability = agents?.find((a) => a.id === providerId)?.capabilities.models;
   const modelOptions =
     modelsCapability?.kind === 'selectable' ? modelsCapability.modelOptions : null;
+  const defaultModel =
+    providerId === defaultProviderId &&
+    typeof defaultModelValue === 'string' &&
+    modelOptions?.[defaultModelValue]
+      ? defaultModelValue
+      : null;
 
   const showAutoApproveToggle = providerId ? providerSupportsAutoApprove(providerId) : false;
   const showAcpToggle = chatUiEnabled && providerId ? providerSupportsAcp(providerId) : false;
@@ -73,9 +83,14 @@ export const CreateConversationModal = observer(function CreateConversationModal
       setProviderOverride(next);
       setSelectedModel(null);
       setUseAcpOverride(false);
+      setModelTouched(false);
     },
     [setProviderOverride]
   );
+
+  useEffect(() => {
+    if (!modelTouched) setSelectedModel(defaultModel);
+  }, [defaultModel, modelTouched]);
 
   const handleCreateConversation = useCallback(async () => {
     if (createDisabled || isSubmitting || !conversationMgr || !providerId) return;
@@ -135,7 +150,10 @@ export const CreateConversationModal = observer(function CreateConversationModal
               <FieldLabel>Model</FieldLabel>
               <Select
                 value={selectedModel ?? ''}
-                onValueChange={(val) => setSelectedModel(val || null)}
+                onValueChange={(val) => {
+                  setModelTouched(true);
+                  setSelectedModel(val || null);
+                }}
               >
                 <SelectTrigger>
                   <SelectValue placeholder="Default model">

--- a/apps/emdash-desktop/src/renderer/features/conversations/use-effective-provider.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/use-effective-provider.ts
@@ -9,19 +9,21 @@ import { resolveConversationProviderSelection } from './provider-selection';
 
 export type EffectiveProvider = {
   providerId: AgentProviderId | null;
+  defaultProviderId: AgentProviderId;
   setProviderOverride: (id: AgentProviderId | null) => void;
   createDisabled: boolean;
 };
 
 export function useEffectiveProvider(
   connectionId?: string,
-  initialOverride?: AgentProviderId
+  initialOverride?: AgentProviderId,
+  defaultAgentSettingKey: 'defaultAgent' | 'defaultAutomationAgent' = 'defaultAgent'
 ): EffectiveProvider {
   const [providerOverride, setProviderOverride] = useState<AgentProviderId | null>(
     initialOverride ?? null
   );
 
-  const { value: defaultAgentValue } = useAppSettingsKey('defaultAgent');
+  const { value: defaultAgentValue } = useAppSettingsKey(defaultAgentSettingKey);
   const defaultProviderId: AgentProviderId = isValidProviderId(defaultAgentValue)
     ? defaultAgentValue
     : 'claude';
@@ -42,5 +44,5 @@ export function useEffectiveProvider(
     availabilityKnown,
   });
 
-  return { providerId, setProviderOverride, createDisabled };
+  return { providerId, defaultProviderId, setProviderOverride, createDisabled };
 }

--- a/apps/emdash-desktop/src/renderer/features/settings/agents-page/AgentsSettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/agents-page/AgentsSettingsPage.tsx
@@ -6,6 +6,7 @@ import { Button } from '@renderer/lib/ui/button';
 import { SearchInput } from '@renderer/lib/ui/search-input';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
 import { CliAgentsList, type AgentFilter } from './CliAgentsList';
+import { DefaultAgentSelector } from './DefaultAgentSelector';
 
 export function AgentsSettingsPage() {
   const [searchQuery, setSearchQuery] = useState('');
@@ -23,7 +24,6 @@ export function AgentsSettingsPage() {
   return (
     <>
       <PageHeader sticky title="Agents" description="Manage agents and model configurations.">
-        {/* <DefaultAgentSelector /> */}
         <div className="flex items-center justify-between gap-2">
           <ToggleGroup
             multiple={false}
@@ -56,6 +56,7 @@ export function AgentsSettingsPage() {
         </div>
       </PageHeader>
       <div className="flex flex-col gap-3">
+        <DefaultAgentSelector />
         <CliAgentsList searchQuery={searchQuery} filter={filter} onFilterChange={setFilter} />
       </div>
     </>

--- a/apps/emdash-desktop/src/renderer/features/settings/agents-page/DefaultAgentSelector.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/agents-page/DefaultAgentSelector.tsx
@@ -1,46 +1,121 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { ResetToDefaultButton } from '@renderer/features/settings/components/ResetToDefaultButton';
+import { SettingRow } from '@renderer/features/settings/components/SettingRow';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
+import { useAgents } from '@renderer/lib/stores/use-agents';
+import { Separator } from '@renderer/lib/ui/separator';
+import type { AgentModelOption } from '@shared/core/agents/agent-payload';
 import {
   isValidProviderId,
   type AgentProviderId,
 } from '@shared/core/agents/agent-provider-registry';
-import type { AppSettings } from '@shared/core/app-settings';
+import type { AppSettings, AppSettingsKey } from '@shared/core/app-settings';
+import { DefaultModelSelect, type ModelDefaultKey } from './DefaultModelSelect';
 
 const DEFAULT_AGENT: AgentProviderId = 'claude';
 
-export const DefaultAgentSelector: React.FC = () => {
+type AgentDefaultKey = Extract<AppSettingsKey, 'defaultAgent' | 'defaultAutomationAgent'>;
+type AgentDefaultValue = AppSettings[AgentDefaultKey];
+type ModelDefaultValue = AppSettings[ModelDefaultKey];
+
+type DefaultAgentModelRowProps = {
+  title: string;
+  description: string;
+  agentSettingKey: AgentDefaultKey;
+  modelSettingKey: ModelDefaultKey;
+};
+
+function modelOptionsForAgent(
+  agentId: AgentProviderId,
+  agents: ReturnType<typeof useAgents>['data']
+): Record<string, AgentModelOption> | null {
+  const models = agents?.find((agent) => agent.id === agentId)?.capabilities.models;
+  return models?.kind === 'selectable' ? models.modelOptions : null;
+}
+
+function DefaultAgentModelRow({
+  title,
+  description,
+  agentSettingKey,
+  modelSettingKey,
+}: DefaultAgentModelRowProps) {
   const {
     value: defaultAgentValue,
-    update,
-    isLoading,
-    isSaving,
-  } = useAppSettingsKey('defaultAgent');
+    update: updateDefaultAgent,
+    reset: resetDefaultAgent,
+    isLoading: isAgentLoading,
+    isSaving: isAgentSaving,
+    isOverridden: isAgentOverridden,
+  } = useAppSettingsKey(agentSettingKey);
+  const { update: updateDefaultModel } = useAppSettingsKey(modelSettingKey);
+  const { data: agents } = useAgents();
 
   const defaultAgent: AgentProviderId = isValidProviderId(defaultAgentValue)
     ? (defaultAgentValue as AgentProviderId)
     : DEFAULT_AGENT;
+  const modelOptions = useMemo(
+    () => modelOptionsForAgent(defaultAgent, agents),
+    [agents, defaultAgent]
+  );
 
-  const handleChange = (agent: AgentProviderId) => {
-    update(agent as AppSettings['defaultAgent']);
+  const handleAgentChange = (agent: AgentProviderId) => {
+    updateDefaultAgent(agent as AgentDefaultValue);
+    updateDefaultModel(null as ModelDefaultValue);
   };
 
+  const isDisabled = isAgentLoading || isAgentSaving;
+
   return (
-    <div className="flex items-center justify-between gap-4 rounded-lg border bg-background-1 p-3 px-4">
-      <div className="flex flex-col gap-1">
-        <span className="text-sm text-foreground">Default agent</span>
-        <span className="text-xs text-foreground-muted">
-          Selected by default when creating a new task.
-        </span>
-      </div>
-      <div className="w-44 shrink-0">
-        <AgentSelector
-          value={defaultAgent}
-          onChange={handleChange}
-          disabled={isLoading || isSaving}
-          className="w-full"
-        />
-      </div>
-    </div>
+    <SettingRow
+      title={title}
+      description={description}
+      control={
+        <div className="flex min-w-0 flex-wrap justify-end gap-2">
+          <div className="flex items-center gap-1">
+            <ResetToDefaultButton
+              visible={isAgentOverridden}
+              defaultLabel="Claude Code"
+              onReset={resetDefaultAgent}
+              disabled={isDisabled}
+            />
+            <AgentSelector
+              value={defaultAgent}
+              onChange={handleAgentChange}
+              disabled={isDisabled}
+              className="h-8 w-44"
+            />
+          </div>
+          <DefaultModelSelect
+            agentId={defaultAgent}
+            modelSettingKey={modelSettingKey}
+            modelOptions={modelOptions}
+          />
+        </div>
+      }
+    />
   );
-};
+}
+
+export const DefaultAgentSelector: React.FC = () => (
+  <section className="flex flex-col gap-3 pt-3">
+    <div className="px-3">
+      <h3 className="text-sm font-normal text-foreground">Defaults</h3>
+    </div>
+    <div className="flex flex-col gap-3 rounded-lg border border-border bg-background-1 p-4">
+      <DefaultAgentModelRow
+        title="Default agent"
+        description="Used by default when creating new tasks and conversations."
+        agentSettingKey="defaultAgent"
+        modelSettingKey="defaultModel"
+      />
+      <Separator />
+      <DefaultAgentModelRow
+        title="Automation default agent"
+        description="Used when an automation does not have a specific agent or model saved."
+        agentSettingKey="defaultAutomationAgent"
+        modelSettingKey="defaultAutomationModel"
+      />
+    </div>
+  </section>
+);

--- a/apps/emdash-desktop/src/renderer/features/settings/agents-page/DefaultModelSelect.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/agents-page/DefaultModelSelect.tsx
@@ -1,0 +1,109 @@
+import { ChevronDownIcon } from 'lucide-react';
+import { useEffect } from 'react';
+import { ResetToDefaultButton } from '@renderer/features/settings/components/ResetToDefaultButton';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@renderer/lib/ui/select';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
+import { cn } from '@renderer/utils/utils';
+import type { AgentModelOption } from '@shared/core/agents/agent-payload';
+import type { AgentProviderId } from '@shared/core/agents/agent-provider-registry';
+import type { AppSettings, AppSettingsKey } from '@shared/core/app-settings';
+
+export type ModelDefaultKey = Extract<AppSettingsKey, 'defaultModel' | 'defaultAutomationModel'>;
+type ModelDefaultValue = AppSettings[ModelDefaultKey];
+
+export function DefaultModelSelect({
+  agentId,
+  modelSettingKey,
+  modelOptions,
+  disabled = false,
+  className,
+}: {
+  agentId: AgentProviderId;
+  modelSettingKey: ModelDefaultKey;
+  modelOptions: Record<string, AgentModelOption> | null;
+  disabled?: boolean;
+  className?: string;
+}) {
+  const {
+    value: defaultModelValue,
+    update,
+    reset,
+    isLoading,
+    isSaving,
+    isOverridden,
+  } = useAppSettingsKey(modelSettingKey);
+
+  const defaultModel =
+    typeof defaultModelValue === 'string' && modelOptions && defaultModelValue in modelOptions
+      ? defaultModelValue
+      : null;
+
+  useEffect(() => {
+    if (
+      modelOptions &&
+      typeof defaultModelValue === 'string' &&
+      !(defaultModelValue in modelOptions)
+    ) {
+      update(null as ModelDefaultValue);
+    }
+  }, [defaultModelValue, modelOptions, update]);
+
+  if (!modelOptions) {
+    return (
+      <div className={cn('flex min-w-0 items-center gap-1', className)}>
+        <span aria-hidden="true" className="h-7 w-7 shrink-0" />
+        <TooltipProvider delay={150}>
+          <Tooltip>
+            <TooltipTrigger>
+              <div
+                aria-disabled="true"
+                className="flex h-8 w-44 cursor-not-allowed items-center justify-between gap-1.5 rounded-md border border-border bg-transparent px-2.5 py-1 text-sm text-foreground-muted opacity-50 outline-none"
+              >
+                <span className="truncate">Default model</span>
+                <ChevronDownIcon className="size-4 shrink-0" />
+              </div>
+            </TooltipTrigger>
+            <TooltipContent side="top">This agent does not support model selection.</TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
+      </div>
+    );
+  }
+
+  return (
+    <div className={cn('flex min-w-0 items-center gap-1', className)}>
+      <ResetToDefaultButton
+        visible={isOverridden}
+        defaultLabel="Default model"
+        onReset={reset}
+        disabled={disabled || isLoading || isSaving}
+      />
+      <Select
+        value={defaultModel ?? ''}
+        onValueChange={(val) => update((val || null) as ModelDefaultValue)}
+        disabled={disabled || isLoading || isSaving}
+      >
+        <SelectTrigger className="w-44">
+          <SelectValue placeholder="Default model">
+            {defaultModel ? (modelOptions[defaultModel]?.name ?? defaultModel) : 'Default model'}
+          </SelectValue>
+        </SelectTrigger>
+        <SelectContent className="min-w-44">
+          <SelectItem value="">Default model</SelectItem>
+          {Object.entries(modelOptions).map(([id, opt]) => (
+            <SelectItem key={`${agentId}:${id}`} value={id}>
+              {opt.name}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -18,6 +18,13 @@ const mocks = vi.hoisted(() => ({
   getProjectSshConnectionId: vi.fn(),
   setProviderOverride: vi.fn(),
   chatUiFeature: true,
+  defaultModelValue: null as string | null,
+  agents: [] as Array<{
+    id: string;
+    capabilities: {
+      models?: { kind: 'selectable'; modelOptions: Record<string, { name: string }> };
+    };
+  }>,
   editorText: '',
   editorApi: {
     focus: vi.fn(),
@@ -88,7 +95,11 @@ vi.mock('../context-bar/add-context-popover', () => ({
 }));
 
 vi.mock('@renderer/lib/stores/use-agents', () => ({
-  useAgents: () => ({ data: [] }),
+  useAgents: () => ({ data: mocks.agents }),
+}));
+
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: () => ({ value: mocks.defaultModelValue }),
 }));
 
 vi.mock('@renderer/lib/hooks/useFeatureFlag', () => ({
@@ -111,6 +122,7 @@ vi.mock('@renderer/utils/logger', () => ({
 vi.mock('@renderer/features/conversations/use-effective-provider', () => ({
   useEffectiveProvider: () => ({
     providerId: 'claude',
+    defaultProviderId: 'claude',
     setProviderOverride: mocks.setProviderOverride,
     createDisabled: false,
   }),
@@ -128,6 +140,25 @@ function Probe({
   options?: InitialConversationOptions;
 }) {
   latestState = useInitialConversationState(projectId, undefined, false, options);
+  return null;
+}
+
+function SeedModelProbe({
+  projectId,
+  options,
+  model,
+}: {
+  projectId: string;
+  options?: InitialConversationOptions;
+  model: string;
+}) {
+  const [seeded, setSeeded] = React.useState(false);
+  const state = useInitialConversationState(projectId, undefined, false, options);
+  latestState = state;
+  if (!seeded) {
+    setSeeded(true);
+    state.setModel(model);
+  }
   return null;
 }
 
@@ -166,6 +197,8 @@ describe('useInitialConversationState', () => {
     mocks.editorText = '';
     mocks.lastChatComposerProps = null;
     mocks.getProjectSshConnectionId.mockReturnValue(undefined);
+    mocks.defaultModelValue = null;
+    mocks.agents = [];
 
     dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
       url: 'http://localhost',
@@ -195,6 +228,17 @@ describe('useInitialConversationState', () => {
     });
   }
 
+  async function renderSeedModelProbe(
+    projectId: string,
+    model: string,
+    options?: InitialConversationOptions
+  ) {
+    await act(async () => {
+      root.render(React.createElement(SeedModelProbe, { projectId, model, options }));
+    });
+    await act(async () => {});
+  }
+
   async function setPrompt(prompt: string) {
     await act(async () => {
       latestState?.setPrompt(prompt);
@@ -221,6 +265,66 @@ describe('useInitialConversationState', () => {
     await renderProbe('project-2', { resetPromptOnProjectChange: false });
 
     expect(latestState?.prompt).toBe('Keep this automation prompt');
+  });
+
+  it('applies the configured default model when default model application is enabled', async () => {
+    mocks.defaultModelValue = 'claude-sonnet';
+    mocks.agents = [
+      {
+        id: 'claude',
+        capabilities: {
+          models: {
+            kind: 'selectable',
+            modelOptions: { 'claude-sonnet': { name: 'Claude Sonnet' } },
+          },
+        },
+      },
+    ];
+
+    await renderProbe('project-1');
+
+    expect(latestState?.model).toBe('claude-sonnet');
+  });
+
+  it('does not apply the configured default model when default model application is disabled', async () => {
+    mocks.defaultModelValue = 'claude-sonnet';
+    mocks.agents = [
+      {
+        id: 'claude',
+        capabilities: {
+          models: {
+            kind: 'selectable',
+            modelOptions: { 'claude-sonnet': { name: 'Claude Sonnet' } },
+          },
+        },
+      },
+    ];
+
+    await renderProbe('project-1', { applyDefaultModel: false });
+
+    expect(latestState?.model).toBeNull();
+  });
+
+  it('preserves a seeded model when default model application is disabled', async () => {
+    mocks.defaultModelValue = 'claude-sonnet';
+    mocks.agents = [
+      {
+        id: 'claude',
+        capabilities: {
+          models: {
+            kind: 'selectable',
+            modelOptions: {
+              'claude-haiku': { name: 'Claude Haiku' },
+              'claude-sonnet': { name: 'Claude Sonnet' },
+            },
+          },
+        },
+      },
+    ];
+
+    await renderSeedModelProbe('project-1', 'claude-haiku', { applyDefaultModel: false });
+
+    expect(latestState?.model).toBe('claude-haiku');
   });
 
   it('defaults chat UI on when the provider supports ACP', async () => {
@@ -254,6 +358,8 @@ describe('InitialConversationField', () => {
     mocks.editorText = '';
     mocks.lastChatComposerProps = null;
     mocks.getProjectSshConnectionId.mockReturnValue(undefined);
+    mocks.defaultModelValue = null;
+    mocks.agents = [];
 
     dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
       url: 'http://localhost',

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -13,6 +13,7 @@ import { useEffectiveProvider } from '@renderer/features/conversations/use-effec
 import { IntegrationIcon } from '@renderer/features/integrations/integration-icon';
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
 import { useFeatureFlag } from '@renderer/lib/hooks/useFeatureFlag';
 import { useLocalStorage } from '@renderer/lib/hooks/useLocalStorage';
@@ -56,6 +57,9 @@ export type InitialConversationState = {
 
 interface InitialConversationStateOptions {
   resetPromptOnProjectChange?: boolean;
+  defaultAgentSettingKey?: 'defaultAgent' | 'defaultAutomationAgent';
+  defaultModelSettingKey?: 'defaultModel' | 'defaultAutomationModel';
+  applyDefaultModel?: boolean;
 }
 
 export function useInitialConversationState(
@@ -64,20 +68,39 @@ export function useInitialConversationState(
   autoApproveByDefault = false,
   options: InitialConversationStateOptions = {}
 ): InitialConversationState {
-  const { resetPromptOnProjectChange = true } = options;
+  const {
+    resetPromptOnProjectChange = true,
+    defaultAgentSettingKey = 'defaultAgent',
+    defaultModelSettingKey = 'defaultModel',
+    applyDefaultModel = true,
+  } = options;
   const connectionId = projectId ? getProjectSshConnectionId(projectId) : undefined;
-  const { providerId, setProviderOverride } = useEffectiveProvider(connectionId, initialProvider);
+  const { providerId, defaultProviderId, setProviderOverride } = useEffectiveProvider(
+    connectionId,
+    initialProvider,
+    defaultAgentSettingKey
+  );
+  const { value: defaultModelValue } = useAppSettingsKey(defaultModelSettingKey);
   const chatUiFeatureEnabled = useFeatureFlag('chat-ui');
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
   const [issueContextEditorOpen, setIssueContextEditorOpen] = useState(false);
   const [model, setModel] = useState<string | null>(null);
+  const [modelTouched, setModelTouched] = useState(false);
   const [issueMentionContexts, setIssueMentionContexts] = useState<Record<string, string>>({});
   const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
     'initial-conversation:chat-ui-enabled',
     true
   );
+  const modelOptions = useModelOptions(providerId);
+  const defaultModel =
+    applyDefaultModel &&
+    providerId === defaultProviderId &&
+    typeof defaultModelValue === 'string' &&
+    modelOptions?.[defaultModelValue]
+      ? defaultModelValue
+      : null;
 
   const [prevProjectId, setPrevProjectId] = useState(projectId);
   const [prevProviderId, setPrevProviderId] = useState(providerId);
@@ -94,16 +117,27 @@ export function useInitialConversationState(
     setAutoApproveOverride(null);
     setIssueContextEditorOpen(false);
     setModel(null);
+    setModelTouched(false);
     setIssueMentionContexts({});
   } else if (providerChanged) {
     setPrevProviderId(providerId);
     setModel(null);
+    setModelTouched(false);
   }
+
+  useEffect(() => {
+    if (!applyDefaultModel) return;
+    if (!modelTouched) setModel(defaultModel);
+  }, [applyDefaultModel, defaultModel, modelTouched]);
 
   const autoApproveSupported = providerId ? providerSupportsAutoApprove(providerId) : false;
   const autoApprove = autoApproveSupported && (autoApproveOverride ?? autoApproveByDefault);
   const acpSupported = chatUiFeatureEnabled && providerId ? providerSupportsAcp(providerId) : false;
   const useChatUi = acpSupported && useChatUiPreference;
+  const setSelectedModel = (nextModel: string | null) => {
+    setModelTouched(true);
+    setModel(nextModel);
+  };
 
   return {
     provider: providerId,
@@ -118,7 +152,7 @@ export function useInitialConversationState(
     issueContextEditorOpen,
     setIssueContextEditorOpen,
     model,
-    setModel,
+    setModel: setSelectedModel,
     connectionId,
     useChatUi,
     setUseChatUi: setUseChatUiPreference,

--- a/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-info-card.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-info-card.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from 'lucide-react';
 import React from 'react';
+import { DefaultModelSelect } from '@renderer/features/settings/agents-page/DefaultModelSelect';
 import { InstallSection } from '@renderer/features/settings/agents-page/InstallSection';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
@@ -37,6 +38,10 @@ export const AgentInfoCard: React.FC<Props> = ({ id, connectionId }) => {
 
   const isInstalled = (statusData?.status ?? payload?.status) === 'available';
   const isDefaultAgent = defaultAgent === id;
+  const modelOptions =
+    payload?.capabilities.models.kind === 'selectable'
+      ? payload.capabilities.models.modelOptions
+      : null;
 
   function handleSetDefaultAgent(checked: boolean) {
     if (!checked || isDefaultAgent) return;
@@ -67,20 +72,34 @@ export const AgentInfoCard: React.FC<Props> = ({ id, connectionId }) => {
         <p className="mb-2 text-xs leading-relaxed text-foreground-muted">{description}</p>
       ) : null}
 
-      <div className="mb-3 flex items-center justify-between gap-3 rounded-md border border-border bg-background-1 px-2.5 py-2">
-        <label
-          htmlFor={`set-default-agent-${id}`}
-          className="min-w-0 flex-1 text-xs text-foreground"
-        >
-          Set as the default agent
-        </label>
-        <Switch
-          id={`set-default-agent-${id}`}
-          size="sm"
-          checked={isDefaultAgent}
-          disabled={!isInstalled || isDefaultAgentLoading || isDefaultAgentSaving}
-          onCheckedChange={handleSetDefaultAgent}
-        />
+      <div className="mb-3 flex flex-col gap-2 rounded-md border border-border bg-background-1 px-2.5 py-2">
+        <div className="flex items-center justify-between gap-3">
+          <label
+            htmlFor={`set-default-agent-${id}`}
+            className="min-w-0 flex-1 text-xs text-foreground"
+          >
+            Set as the default agent
+          </label>
+          <Switch
+            id={`set-default-agent-${id}`}
+            size="sm"
+            checked={isDefaultAgent}
+            disabled={!isInstalled || isDefaultAgentLoading || isDefaultAgentSaving}
+            onCheckedChange={handleSetDefaultAgent}
+          />
+        </div>
+        {isDefaultAgent && modelOptions ? (
+          <div className="flex items-center justify-between gap-3">
+            <span className="min-w-0 flex-1 text-xs text-foreground">Default model</span>
+            <DefaultModelSelect
+              agentId={id}
+              modelSettingKey="defaultModel"
+              modelOptions={modelOptions}
+              disabled={!isInstalled}
+              className="shrink-0"
+            />
+          </div>
+        ) : null}
       </div>
 
       {payload && (


### PR DESCRIPTION
## Summary
- Restore global default agent and default model settings in the Agents settings tab.
- Add separate automation defaults for agent and model without changing the automation creation flow.
- Apply saved defaults when creating tasks, conversations, and automation runs, while preserving per-flow overrides.
- Keep the model selector slot stable for agents without selectable models and explain the disabled state in a tooltip.

## Why
Automations and repeated task creation need predictable defaults for both the harness and the underlying model. This brings those settings back in the central Agents settings page and keeps the hover-card shortcut aligned with the same app setting.

Linear: https://linear.app/general-action/issue/ENG-1687/bring-back-default-agent-and-default-underlying-model-settings

## Screenshot
<img width="1488" height="1113" alt="CleanShot 2026-06-30 at 12 17 59" src="https://github.com/user-attachments/assets/93e05e60-7502-493f-a08e-e1d1128e751d" />

## Validation
- corepack pnpm run typecheck
- corepack pnpm exec vitest run --project node src/main/core/automations/actions/taskCreate.test.ts src/renderer/tests/conversation-provider-selection.test.ts
- focused oxlint and oxfmt checks