### PR TITLE
feat(browser): add in-app page annotations

### DIFF
--- a/BROWSER_ANNOTATIONS_DESIGN.md
+++ b/BROWSER_ANNOTATIONS_DESIGN.md
@@ -1,0 +1,211 @@
+# Browser Annotations Design
+
+## Objective
+
+Let users leave structured comments on rendered elements inside Emdash's in-app browser and send those annotations to the active task agent by pasting into the active terminal, with optional submit.
+
+This should feel like in-app browser comments: the user points at the rendered UI, writes concise feedback, and the agent receives enough structured context to locate and fix the relevant code.
+
+The implementation must meet the same quality bar as the surrounding Emdash code. It should fit the existing browser, task, conversation, typed RPC, MobX store, and PTY prompt-injection patterns instead of creating parallel systems.
+
+## Non-Goals
+
+- Computed styles in v1.
+- MCP or webhook sync.
+- DB-backed annotation history.
+- Bidirectional agent resolve/acknowledge lifecycle.
+- Requiring users to install Agentation into their app.
+- Broad browser automation or full CDP developer mode.
+- Refactoring unrelated task, terminal, or browser architecture.
+
+## User Workflow
+
+1. User opens a task browser tab.
+2. User toggles Annotation mode from the browser toolbar.
+3. User clicks a rendered element, selects text, or drags a rectangular area.
+4. Emdash opens a trusted annotation composer outside the untrusted page.
+5. User enters feedback and saves the annotation.
+6. The annotation appears as pending task context.
+7. User applies browser annotations to the active agent session, with an option to submit immediately.
+8. Emdash pastes formatted annotation context into the active terminal.
+9. If paste/send succeeds, consumed annotations are cleared.
+
+## UI And UX Requirements
+
+The UI must feel native to Emdash.
+
+- Match existing browser toolbar density, icon button sizing, menu behavior, spacing, border treatment, text sizing, and disabled/loading states.
+- Use existing shared UI primitives where they fit: `Button`, `Tooltip`, popover/menu/dialog primitives, text inputs, and related controls.
+- Use lucide icons that match the surrounding browser toolbar style.
+- Keep annotation controls compact and task-oriented; do not introduce a marketing-style panel or large instructional surface.
+- Annotation mode should have a clear active state in the toolbar.
+- Hovered, focused, and selected page targets should use restrained blue accents: a blue outline or translucent blue overlay, with enough contrast to identify the target without obscuring the page.
+- Area selections should show a blue selection rectangle with stable dimensions during drag.
+- The annotation composer should be small, polished, keyboard-friendly, and anchored near the selected target when practical.
+- The composer should support save, cancel, and optional immediate send without forcing the user through a modal unless the existing UI pattern strongly favors one.
+- Pending annotations should be visible through a count, compact list, or existing context-action affordance without crowding the browser chrome.
+- Keyboard behavior should be predictable: Escape exits annotation/selection/composer state, Enter saves where appropriate, and focus returns to the browser or active terminal after send.
+- Text must fit inside controls at normal desktop sizes and not overlap toolbar or page overlay elements.
+- Blue accents should be limited to annotation target focus/selection states and not become the dominant page palette.
+
+## Data Model
+
+Create Emdash-owned shared types while keeping Agentation AFS v1.1 naming where practical.
+
+```ts
+type BrowserAnnotationKind = 'element' | 'text' | 'area';
+type BrowserAnnotationStatus = 'pending' | 'sent' | 'dismissed';
+
+type BrowserAnnotation = {
+  id: string;
+  taskId: string;
+  browserId: string;
+  kind: BrowserAnnotationKind;
+  status: BrowserAnnotationStatus;
+  comment: string;
+  url: string;
+  title?: string;
+  elementPath: string;
+  element: string;
+  cssClasses?: string;
+  nearbyText?: string;
+  selectedText?: string;
+  x: number;
+  y: number;
+  boundingBox: {
+    x: number;
+    y: number;
+    width: number;
+    height: number;
+  };
+  createdAt: string;
+  updatedAt: string;
+};
+```
+
+Computed styles should not be included in v1, but the model should leave a clean extension point for them.
+
+## Architecture
+
+### Browser Feature
+
+Own these pieces under `apps/emdash-desktop/src/renderer/features/browser/`:
+
+- Annotation mode toolbar control.
+- Trusted overlay mounted around `BrowserPane`, not inside the page.
+- Hover/click/drag interaction state.
+- Annotation composer UI.
+- Pending annotation display or count.
+- Browser annotation store or browser-facing store adapter.
+
+### Shared Types And Formatting
+
+Add shared browser annotation types and formatter near existing shared browser/task context code:
+
+- Prefer a dedicated shared module if `src/shared/browser.ts` becomes too broad.
+- Formatter should produce concise agent-readable context, similar in spirit to `src/shared/lineComments.ts`.
+- The output should clearly separate annotations and include URL, selector/path, element, classes, text context, bounding box, and feedback.
+
+### Main Browser Domain
+
+Use `apps/emdash-desktop/src/main/core/browser/` if element capture needs bound `WebContents`.
+
+Expected direction:
+
+- Add typed RPC methods to `src/main/core/browser/controller.ts` only if needed.
+- Reuse `browserWebContentsRegistry` for browserId to `WebContents` lookup.
+- Execute only static inspection JavaScript.
+- Return structured JSON data to trusted renderer UI.
+- Do not expose app APIs or Node primitives to the page.
+
+### Task Context And Agent Assignment
+
+Integrate with the existing task context flow:
+
+- Extend `src/renderer/features/tasks/conversations/context-actions.ts` with a browser-annotations action.
+- Extend `src/renderer/features/tasks/conversations/context-bar.tsx` so browser annotations can be pasted into the active PTY session and optionally submitted.
+- Reuse `pastePromptInjection` and `rpc.pty.sendInput`.
+- Consume annotations only after successful paste/send.
+
+This should not create a parallel "send to agent" architecture.
+
+## Code Quality Requirements
+
+- Preserve existing file ownership boundaries.
+- Prefer small modules inside the browser feature over large mixed-responsibility files.
+- Keep shared types and formatters framework-free and testable.
+- Keep controller handlers thin; put browser capture logic in a focused helper or service if it grows.
+- Do not weaken existing webview security, URL validation, profile partitioning, shortcut routing, screenshot behavior, or DevTools behavior.
+- Do not use `any`; keep browser/Electron type escapes narrow and documented when unavoidable.
+- Do not use non-null assertions for task/project readiness helpers.
+- Do not add persistence, migrations, or settings unless required for the approved behavior.
+- Preserve existing tests and add focused tests that match nearby test style.
+
+## Relevant Files
+
+- `apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx`
+- `apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.tsx`
+- `apps/emdash-desktop/src/renderer/features/browser/browser-webview-types.ts`
+- `apps/emdash-desktop/src/renderer/features/browser/browser-session-store.ts`
+- `apps/emdash-desktop/src/renderer/features/browser/browser-tab-provider.tsx`
+- `apps/emdash-desktop/src/main/core/browser/controller.ts`
+- `apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts`
+- `apps/emdash-desktop/src/shared/browser.ts`
+- `apps/emdash-desktop/src/shared/events/browserEvents.ts`
+- `apps/emdash-desktop/src/renderer/features/tasks/conversations/context-actions.ts`
+- `apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx`
+- `apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/draft-comments-store.ts`
+- `apps/emdash-desktop/src/shared/lineComments.ts`
+- `apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts`
+- `apps/emdash-desktop/src/renderer/features/tasks/task-view-context.tsx`
+- `apps/emdash-desktop/src/main/rpc.ts`
+
+## Security Requirements
+
+- Treat page content and returned DOM text as untrusted.
+- Do not inject dynamic user-authored JavaScript.
+- Do not expose Node, Electron, filesystem, RPC, PTY, or app internals to the page.
+- Keep annotation UI outside the webview page context.
+- Sanitize or escape annotation output when formatting for the agent.
+- Preserve existing webview hardening and navigation restrictions.
+
+## Edge Cases
+
+- No active browser session.
+- Webview not ready or navigation in progress.
+- Annotation mode active while page navigates.
+- Element removed between hover and click.
+- Cross-origin iframes that cannot be inspected.
+- Shadow DOM elements.
+- Text selection spanning multiple nodes.
+- Very small or offscreen elements.
+- Page zoom and scroll offsets.
+- Browser tab hidden but session still mounted.
+- No active agent session.
+- Terminal paste succeeds but submit fails.
+- Annotation limit reached.
+- User clears or dismisses annotations before sending.
+
+## Testing Plan
+
+Add focused tests for:
+
+- Annotation formatter escaping and output shape.
+- Browser annotation store add/update/delete/consume behavior.
+- Context action inclusion, count, and text generation.
+- Successful context apply consumes browser annotations.
+- Failed context apply does not consume browser annotations.
+- Browser toolbar Annotation mode control state.
+- Element capture helper behavior for representative DOM nodes.
+- Existing browser navigation, screenshot, and webview event tests remain green.
+
+## Validation Commands
+
+Run from the repo root:
+
+```bash
+pnpm run format
+pnpm run lint
+pnpm run typecheck
+pnpm run test
+```

--- a/BROWSER_ANNOTATIONS_GOAL.md
+++ b/BROWSER_ANNOTATIONS_GOAL.md
@@ -1,0 +1,52 @@
+# Browser Annotations Goal
+
+Use this as the `/goal` text for the implementation agent.
+
+```text
+/goal Fully implement browser annotations in Emdash's in-app task browser, with code and UI that fit the existing cleanliness, architecture, structure, state boundaries, naming, test style, and interaction patterns of this codebase. Verify with focused unit/browser tests plus format, lint, typecheck, and test passing, while preserving existing browser navigation, screenshot, profile, task context, and terminal prompt-injection behavior.
+
+Build the full v1 feature:
+- Users can toggle Annotation mode in an in-app browser tab.
+- Users can annotate rendered page elements, selected text, and rectangular areas.
+- Annotations are task-scoped and browser-session aware.
+- Annotations capture structured Agentation-style context: id, comment, url, title, element/tag, selector/path, cssClasses, nearbyText or selectedText, viewport/document coordinates, boundingBox, status, createdAt, and updatedAt.
+- Computed styles are explicitly out of v1 and should be left as a clean extension point.
+- Users can paste browser annotations into the active agent terminal and optionally submit.
+- Sent annotations are consumed only after successful paste/send.
+- Page content remains untrusted; do not expose Node or app internals to the page.
+- Prefer static page-inspection JavaScript through the existing browser/webContents boundary, with structured data returned to trusted Emdash UI.
+
+Use existing Emdash patterns:
+- Read AGENTS.md and relevant agents docs first.
+- Keep browser interaction UI under src/renderer/features/browser.
+- Use typed RPC/events for main-process browser operations.
+- Reuse the task context/action and PTY prompt-injection flow rather than inventing a parallel agent-send path.
+- Avoid database persistence unless needed; task-lifetime state is acceptable if consistent with existing draft comments.
+- Avoid unrelated refactors.
+- Do not create parallel state systems, parallel IPC, parallel agent-send flows, or broad abstractions that collide with existing browser/task/conversation architecture.
+- Keep types explicit, shared boundaries clean, and tests colocated with comparable existing tests.
+
+UI and UX quality bar:
+- The browser annotation UI must feel native to Emdash, not bolted on.
+- Match existing toolbar density, spacing, icons, popovers, buttons, text sizing, disabled states, and keyboard behavior.
+- Focused, hovered, and selected page targets should use restrained blue accents so the annotated area is clear without overwhelming the page.
+- Annotation composer and pending annotation UI should be compact, polished, keyboard-friendly, and consistent with existing Emdash controls.
+- Do not add explanatory in-app copy beyond what the workflow needs.
+
+Between iterations:
+- Inspect current browser/task/conversation code before editing.
+- Make the smallest coherent vertical slice, test it, then continue.
+- Keep a running list of changed files, tests added, and remaining gaps.
+
+Stop as blocked only if:
+- Electron webview limitations prevent safe element capture without a different architecture.
+- The active-agent send path cannot be reused without broader conversation subsystem changes.
+- Required behavior conflicts with repo security constraints.
+
+Completion evidence:
+- Focused tests cover annotation formatting, store behavior, context action inclusion/consumption, browser annotation controls, and browser capture behavior.
+- pnpm run format
+- pnpm run lint
+- pnpm run typecheck
+- pnpm run test
+```

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
@@ -260,10 +260,10 @@ describe('BrowserWebContentsRegistry', () => {
     webContents.emitEvent('before-input-event', keyEvent, {
       type: 'keyDown',
       key: 'K',
-      control: false,
+      control: process.platform !== 'darwin',
       shift: false,
       alt: false,
-      meta: true,
+      meta: process.platform === 'darwin',
     });
 
     expect(keyEvent.preventDefault).toHaveBeenCalled();

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from 'vitest';
+import {
+  buildBrowserAnnotationCaptureScript,
+  parseBrowserAnnotationCaptureResult,
+  withAreaBoundingBox,
+} from './browser-annotation-capture';
+
+describe('parseBrowserAnnotationCaptureResult', () => {
+  it('accepts a valid capture payload', () => {
+    const result = parseBrowserAnnotationCaptureResult({
+      kind: 'element',
+      url: 'http://localhost:3000',
+      title: 'Home',
+      elementPath: 'main > button',
+      element: 'button',
+      cssClasses: 'primary',
+      nearbyText: 'Save',
+      x: 10,
+      y: 20,
+      boundingBox: { x: 8, y: 16, width: 100, height: 32 },
+    });
+
+    expect(result).toEqual({
+      kind: 'element',
+      url: 'http://localhost:3000',
+      title: 'Home',
+      elementPath: 'main > button',
+      element: 'button',
+      cssClasses: 'primary',
+      nearbyText: 'Save',
+      selectedText: undefined,
+      x: 10,
+      y: 20,
+      boundingBox: { x: 8, y: 16, width: 100, height: 32 },
+    });
+  });
+
+  it('rejects incomplete payloads', () => {
+    expect(parseBrowserAnnotationCaptureResult({ kind: 'element' })).toBeNull();
+    expect(
+      parseBrowserAnnotationCaptureResult({
+        kind: 'element',
+        url: 'http://localhost:3000',
+        elementPath: 'main',
+        element: 'main',
+        x: 0,
+        y: 0,
+        boundingBox: { x: 0, y: 0, width: Number.NaN, height: 1 },
+      })
+    ).toBeNull();
+  });
+});
+
+describe('withAreaBoundingBox', () => {
+  it('overrides the kind and box while preserving page metadata', () => {
+    const target = parseBrowserAnnotationCaptureResult({
+      kind: 'element',
+      url: 'http://localhost:3000',
+      elementPath: 'main > section',
+      element: 'section',
+      x: 5,
+      y: 5,
+      boundingBox: { x: 0, y: 0, width: 10, height: 10 },
+    });
+
+    expect(target).not.toBeNull();
+    if (!target) throw new Error('Expected valid capture target');
+    expect(withAreaBoundingBox(target, { x: 10, y: 20, width: 30, height: 40 })).toMatchObject({
+      kind: 'area',
+      url: 'http://localhost:3000',
+      elementPath: 'main > section',
+      x: 25,
+      y: 40,
+      boundingBox: { x: 10, y: 20, width: 30, height: 40 },
+    });
+  });
+});
+
+describe('buildBrowserAnnotationCaptureScript', () => {
+  it('embeds sanitized coordinates and fallback kind', () => {
+    const script = buildBrowserAnnotationCaptureScript(12.8, Number.POSITIVE_INFINITY, 'area');
+
+    expect(script).toContain('const pointX = 13;');
+    expect(script).toContain('const pointY = 0;');
+    expect(script).toContain('const fallbackKind = "area";');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   buildBrowserAnnotationCaptureScript,
+  buildBrowserAnnotationScrollScript,
   parseBrowserAnnotationCaptureResult,
   withAreaBoundingBox,
 } from './browser-annotation-capture';
@@ -83,5 +84,23 @@ describe('buildBrowserAnnotationCaptureScript', () => {
     expect(script).toContain('const pointX = 13;');
     expect(script).toContain('const pointY = 0;');
     expect(script).toContain('const fallbackKind = "area";');
+  });
+});
+
+describe('buildBrowserAnnotationScrollScript', () => {
+  it('embeds sanitized coordinates and wheel deltas', () => {
+    const script = buildBrowserAnnotationScrollScript(
+      19.2,
+      Number.NEGATIVE_INFINITY,
+      Number.NaN,
+      120.4
+    );
+
+    expect(script).toContain('const pointX = 19;');
+    expect(script).toContain('const pointY = 0;');
+    expect(script).toContain('const deltaX = 0;');
+    expect(script).toContain('const deltaY = 120;');
+    expect(script).toContain('document.elementFromPoint(pointX, pointY)');
+    expect(script).toContain('scrollBy({ top: deltaY');
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.ts
@@ -146,3 +146,46 @@ export function buildBrowserAnnotationCaptureScript(
   };
 })()`;
 }
+
+export function buildBrowserAnnotationScrollScript(
+  x: number,
+  y: number,
+  deltaX: number,
+  deltaY: number
+): string {
+  const safeX = Math.round(Number.isFinite(x) ? x : 0);
+  const safeY = Math.round(Number.isFinite(y) ? y : 0);
+  const safeDeltaX = Math.round(Number.isFinite(deltaX) ? deltaX : 0);
+  const safeDeltaY = Math.round(Number.isFinite(deltaY) ? deltaY : 0);
+
+  return `(() => {
+  const pointX = ${safeX};
+  const pointY = ${safeY};
+  const deltaX = ${safeDeltaX};
+  const deltaY = ${safeDeltaY};
+  const canScroll = (element, axis) => {
+    if (!element) return false;
+    const style = window.getComputedStyle(element);
+    if (axis === 'x') {
+      if (!/(auto|scroll|overlay)/.test(style.overflowX)) return false;
+      return element.scrollWidth > element.clientWidth;
+    }
+    if (!/(auto|scroll|overlay)/.test(style.overflowY)) return false;
+    return element.scrollHeight > element.clientHeight;
+  };
+  const scrollableAncestor = (element, axis) => {
+    let current = element;
+    while (current && current !== document.documentElement) {
+      if (canScroll(current, axis)) return current;
+      current = current.parentElement;
+    }
+    return document.scrollingElement || document.documentElement;
+  };
+  const start = document.elementFromPoint(pointX, pointY) || document.documentElement;
+  const targetX = scrollableAncestor(start, 'x');
+  const targetY = scrollableAncestor(start, 'y');
+  if (deltaX && targetX) targetX.scrollBy({ left: deltaX, behavior: 'auto' });
+  if (deltaY && targetY) targetY.scrollBy({ top: deltaY, behavior: 'auto' });
+  return true;
+})()`;
+}

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-capture.ts
@@ -1,0 +1,148 @@
+import type {
+  BrowserAnnotationBoundingBox,
+  BrowserAnnotationKind,
+  BrowserAnnotationTarget,
+} from '@shared/browserAnnotations';
+
+export type BrowserAnnotationCaptureResult = BrowserAnnotationTarget;
+
+function numeric(value: unknown): number | null {
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+function stringValue(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value : undefined;
+}
+
+function isBoundingBox(value: unknown): value is BrowserAnnotationBoundingBox {
+  if (!value || typeof value !== 'object') return false;
+  const box = value as Record<string, unknown>;
+  return (
+    numeric(box.x) !== null &&
+    numeric(box.y) !== null &&
+    numeric(box.width) !== null &&
+    numeric(box.height) !== null
+  );
+}
+
+export function parseBrowserAnnotationCaptureResult(
+  value: unknown
+): BrowserAnnotationCaptureResult | null {
+  if (!value || typeof value !== 'object') return null;
+  const record = value as Record<string, unknown>;
+  const kind = record.kind;
+  const x = numeric(record.x);
+  const y = numeric(record.y);
+  const boundingBox = record.boundingBox;
+  const url = stringValue(record.url);
+  const elementPath = stringValue(record.elementPath);
+  const element = stringValue(record.element);
+
+  if (
+    (kind !== 'element' && kind !== 'text' && kind !== 'area') ||
+    x === null ||
+    y === null ||
+    !isBoundingBox(boundingBox) ||
+    !url ||
+    !elementPath ||
+    !element
+  ) {
+    return null;
+  }
+
+  return {
+    kind,
+    url,
+    title: stringValue(record.title),
+    elementPath,
+    element,
+    cssClasses: stringValue(record.cssClasses),
+    nearbyText: stringValue(record.nearbyText),
+    selectedText: stringValue(record.selectedText),
+    x,
+    y,
+    boundingBox,
+  };
+}
+
+export function withAreaBoundingBox(
+  target: BrowserAnnotationCaptureResult,
+  boundingBox: BrowserAnnotationBoundingBox
+): BrowserAnnotationCaptureResult {
+  return {
+    ...target,
+    kind: 'area',
+    x: Math.round(boundingBox.x + boundingBox.width / 2),
+    y: Math.round(boundingBox.y + boundingBox.height / 2),
+    boundingBox: {
+      x: Math.round(boundingBox.x),
+      y: Math.round(boundingBox.y),
+      width: Math.round(boundingBox.width),
+      height: Math.round(boundingBox.height),
+    },
+  };
+}
+
+export function buildBrowserAnnotationCaptureScript(
+  x: number,
+  y: number,
+  fallbackKind: BrowserAnnotationKind = 'element'
+): string {
+  const safeX = Math.round(Number.isFinite(x) ? x : 0);
+  const safeY = Math.round(Number.isFinite(y) ? y : 0);
+  const safeKind = fallbackKind === 'area' ? 'area' : fallbackKind === 'text' ? 'text' : 'element';
+
+  return `(() => {
+  const pointX = ${safeX};
+  const pointY = ${safeY};
+  const fallbackKind = ${JSON.stringify(safeKind)};
+  const normalizeText = (value) => String(value || '').replace(/\\s+/g, ' ').trim().slice(0, 500);
+  const escapeIdentifier = (value) => {
+    if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
+    return String(value).replace(/[^a-zA-Z0-9_-]/g, '\\\\$&');
+  };
+  const elementSegment = (element) => {
+    const tag = element.tagName.toLowerCase();
+    if (element.id) return tag + '#' + escapeIdentifier(element.id);
+    const parent = element.parentElement;
+    if (!parent) return tag;
+    const siblings = Array.from(parent.children).filter((child) => child.tagName === element.tagName);
+    if (siblings.length <= 1) return tag;
+    return tag + ':nth-of-type(' + (siblings.indexOf(element) + 1) + ')';
+  };
+  const elementPath = (element) => {
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.documentElement) {
+      parts.unshift(elementSegment(current));
+      if (current.id) break;
+      current = current.parentElement;
+    }
+    return parts.length ? parts.join(' > ') : 'html';
+  };
+  const selection = window.getSelection();
+  const selectedText = selection && !selection.isCollapsed ? normalizeText(selection.toString()) : '';
+  const element = document.elementFromPoint(pointX, pointY) || document.documentElement;
+  const rect = element.getBoundingClientRect();
+  const classes = element.classList ? Array.from(element.classList).join(' ') : '';
+  const nearbyText = normalizeText(selectedText || element.innerText || element.textContent || '');
+  return {
+    kind: selectedText ? 'text' : fallbackKind,
+    url: window.location.href,
+    title: document.title || '',
+    elementPath: elementPath(element),
+    element: element.tagName.toLowerCase(),
+    cssClasses: classes,
+    nearbyText,
+    selectedText,
+    x: pointX,
+    y: pointY,
+    boundingBox: {
+      x: Math.round(rect.x),
+      y: Math.round(rect.y),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    },
+  };
+})()`;
+}

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.test.ts
@@ -1,0 +1,197 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { BrowserAnnotationOverlay } from './browser-annotation-overlay';
+import type { BrowserAnnotationsStore } from './browser-annotations-store';
+import type { BrowserWebviewAdapter } from './browser-webview-types';
+
+const mocks = vi.hoisted(() => ({
+  captureTelemetry: vi.fn(),
+}));
+
+vi.mock('@renderer/utils/telemetryClient', () => ({
+  captureTelemetry: mocks.captureTelemetry,
+}));
+
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: () => ({ value: undefined }),
+}));
+
+function createAdapter(overrides: Partial<BrowserWebviewAdapter> = {}): BrowserWebviewAdapter {
+  return {
+    canGoBack: () => false,
+    canGoForward: () => false,
+    currentUrl: () => 'http://localhost:3000',
+    title: () => 'Local app',
+    goBack: vi.fn(),
+    goForward: vi.fn(),
+    reload: vi.fn(),
+    reloadIgnoringCache: vi.fn(),
+    stop: vi.fn(),
+    loadUrl: vi.fn(),
+    setZoomFactor: vi.fn(),
+    executeJavaScript: vi.fn().mockResolvedValue(null),
+    focus: vi.fn(),
+    ...overrides,
+  };
+}
+
+describe('BrowserAnnotationOverlay', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    dom = new JSDOM('<div id="root"></div>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Element', dom.window.Element);
+    vi.stubGlobal('Node', dom.window.Node);
+    vi.stubGlobal('Event', dom.window.Event);
+    vi.stubGlobal('MouseEvent', dom.window.MouseEvent);
+    vi.stubGlobal('WheelEvent', dom.window.WheelEvent);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'setPointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'releasePointerCapture', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'attachEvent', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    Object.defineProperty(dom.window.HTMLElement.prototype, 'detachEvent', {
+      configurable: true,
+      value: vi.fn(),
+    });
+    container = dom.window.document.getElementById('root')!;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  async function renderOverlay(
+    adapter: BrowserWebviewAdapter,
+    store: Partial<BrowserAnnotationsStore> = {}
+  ) {
+    await act(async () => {
+      root.render(
+        React.createElement(BrowserAnnotationOverlay, {
+          active: true,
+          adapter,
+          browserId: 'browser-1',
+          store: {
+            pendingCount: 0,
+            addAnnotation: vi.fn(),
+            ...store,
+          } as unknown as BrowserAnnotationsStore,
+          onClose: vi.fn(),
+        })
+      );
+    });
+    const overlay = container.querySelector('[aria-label="Browser annotation overlay"]');
+    if (!(overlay instanceof dom.window.HTMLElement)) {
+      throw new Error('Expected annotation overlay');
+    }
+    Object.defineProperty(overlay, 'getBoundingClientRect', {
+      value: () => ({ left: 0, top: 0, width: 800, height: 600, right: 800, bottom: 600 }),
+    });
+    return overlay;
+  }
+
+  it('does not throw when hover capture script execution fails', async () => {
+    const adapter = createAdapter({
+      executeJavaScript: vi.fn().mockRejectedValue(new Error('webview navigated')),
+    });
+    const overlay = await renderOverlay(adapter);
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new dom.window.MouseEvent('pointermove', {
+          bubbles: true,
+          clientX: 100,
+          clientY: 120,
+        })
+      );
+      await new Promise((resolve) => window.setTimeout(resolve, 100));
+    });
+
+    expect(adapter.executeJavaScript).toHaveBeenCalledOnce();
+  });
+
+  it('does not throw when forwarded wheel scroll script execution fails', async () => {
+    const adapter = createAdapter({
+      executeJavaScript: vi.fn().mockRejectedValue(new Error('webview destroyed')),
+    });
+    const overlay = await renderOverlay(adapter);
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new dom.window.WheelEvent('wheel', {
+          bubbles: true,
+          cancelable: true,
+          clientX: 100,
+          clientY: 120,
+          deltaY: 80,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(adapter.executeJavaScript).toHaveBeenCalledOnce();
+  });
+
+  it('renders the save shortcut in the annotation composer', async () => {
+    const addAnnotation = vi.fn();
+    const adapter = createAdapter({
+      executeJavaScript: vi.fn().mockResolvedValue({
+        kind: 'element',
+        url: 'http://localhost:3000/settings',
+        title: 'Settings',
+        elementPath: 'main > button',
+        element: 'button',
+        nearbyText: 'Save changes',
+        selectedText: 'Private selected text',
+        x: 100,
+        y: 120,
+        boundingBox: { x: 90, y: 110, width: 120, height: 32 },
+      }),
+    });
+    const overlay = await renderOverlay(adapter, { pendingCount: 1, addAnnotation });
+
+    await act(async () => {
+      overlay.dispatchEvent(
+        new dom.window.MouseEvent('pointerdown', {
+          bubbles: true,
+          clientX: 100,
+          clientY: 120,
+        })
+      );
+      await Promise.resolve();
+    });
+    await act(async () => {
+      overlay.dispatchEvent(
+        new dom.window.MouseEvent('pointerup', {
+          bubbles: true,
+          clientX: 100,
+          clientY: 120,
+        })
+      );
+      await Promise.resolve();
+    });
+
+    expect(container.textContent).toContain('Save');
+    expect(container.querySelector('[data-slot="shortcut"]')).not.toBeNull();
+    expect(addAnnotation).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.tsx
@@ -1,0 +1,352 @@
+import { MousePointer2, X } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import { Badge } from '@renderer/lib/ui/badge';
+import { Button } from '@renderer/lib/ui/button';
+import { Textarea } from '@renderer/lib/ui/textarea';
+import { cn } from '@renderer/utils/utils';
+import type {
+  BrowserAnnotationBoundingBox,
+  BrowserAnnotationTarget,
+} from '@shared/browserAnnotations';
+import {
+  buildBrowserAnnotationCaptureScript,
+  parseBrowserAnnotationCaptureResult,
+  withAreaBoundingBox,
+} from './browser-annotation-capture';
+import type { BrowserAnnotationsStore } from './browser-annotations-store';
+import type { BrowserWebviewAdapter } from './browser-webview-types';
+
+type Point = {
+  x: number;
+  y: number;
+};
+
+type DraftSelection = {
+  origin: Point;
+  current: Point;
+};
+
+type ComposerState = {
+  target: BrowserAnnotationTarget;
+  anchor: Point;
+};
+
+const MIN_AREA_SIZE = 8;
+const HOVER_CAPTURE_DELAY_MS = 80;
+
+export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverlay({
+  active,
+  adapter,
+  browserId,
+  store,
+  onClose,
+}: {
+  active: boolean;
+  adapter: BrowserWebviewAdapter | null;
+  browserId: string;
+  store: BrowserAnnotationsStore | null;
+  onClose: () => void;
+}) {
+  const overlayRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  const [draft, setDraft] = useState<DraftSelection | null>(null);
+  const [hoverTarget, setHoverTarget] = useState<BrowserAnnotationTarget | null>(null);
+  const [composer, setComposer] = useState<ComposerState | null>(null);
+  const [comment, setComment] = useState('');
+  const [isCapturing, setIsCapturing] = useState(false);
+  const hoverTimerRef = useRef<number | null>(null);
+  const hoverSequenceRef = useRef(0);
+
+  const clearHoverTimer = useCallback(() => {
+    if (hoverTimerRef.current === null) return;
+    window.clearTimeout(hoverTimerRef.current);
+    hoverTimerRef.current = null;
+  }, []);
+
+  useEffect(() => {
+    if (!active) {
+      clearHoverTimer();
+      setDraft(null);
+      setHoverTarget(null);
+      setComposer(null);
+      setComment('');
+    }
+  }, [active, clearHoverTimer]);
+
+  useEffect(() => () => clearHoverTimer(), [clearHoverTimer]);
+
+  useEffect(() => {
+    if (!composer) return;
+    const timer = window.setTimeout(() => textareaRef.current?.focus(), 0);
+    return () => window.clearTimeout(timer);
+  }, [composer]);
+
+  useEffect(() => {
+    if (!active) return;
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key !== 'Escape') return;
+      if (composer) {
+        closeComposer();
+        return;
+      }
+      onClose();
+    };
+    window.addEventListener('keydown', handleKeyDown);
+    return () => window.removeEventListener('keydown', handleKeyDown);
+  }, [active, composer, onClose]);
+
+  const pendingCount = store?.pendingCount ?? 0;
+
+  const draftBox = useMemo(
+    () => (draft ? normalizeBox(draft.origin, draft.current) : null),
+    [draft]
+  );
+
+  const inspectPoint = useCallback(
+    async (point: Point, kind: BrowserAnnotationTarget['kind'] = 'element') => {
+      if (!adapter) return null;
+      const script = buildBrowserAnnotationCaptureScript(point.x, point.y, kind);
+      const result = await adapter.executeJavaScript(script);
+      return parseBrowserAnnotationCaptureResult(result);
+    },
+    [adapter]
+  );
+
+  const pointFromEvent = (event: React.PointerEvent<HTMLDivElement>): Point => {
+    const rect = event.currentTarget.getBoundingClientRect();
+    return {
+      x: Math.round(Math.max(0, Math.min(rect.width, event.clientX - rect.left))),
+      y: Math.round(Math.max(0, Math.min(rect.height, event.clientY - rect.top))),
+    };
+  };
+
+  const updateHoverTarget = useCallback(
+    async (point: Point) => {
+      if (!active || composer || draft || isCapturing) return;
+      const sequence = ++hoverSequenceRef.current;
+      const target = await inspectPoint(point);
+      if (sequence === hoverSequenceRef.current) {
+        setHoverTarget(target);
+      }
+    },
+    [active, composer, draft, inspectPoint, isCapturing]
+  );
+
+  const scheduleHoverTargetUpdate = useCallback(
+    (point: Point) => {
+      clearHoverTimer();
+      if (!active || composer || draft || isCapturing) return;
+      hoverTimerRef.current = window.setTimeout(() => {
+        hoverTimerRef.current = null;
+        void updateHoverTarget(point);
+      }, HOVER_CAPTURE_DELAY_MS);
+    },
+    [active, clearHoverTimer, composer, draft, isCapturing, updateHoverTarget]
+  );
+
+  const handlePointerMove = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!active || !adapter || composer) return;
+    const point = pointFromEvent(event);
+    if (draft) {
+      setDraft({ ...draft, current: point });
+      return;
+    }
+    scheduleHoverTargetUpdate(point);
+  };
+
+  const handlePointerDown = (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!active || !adapter || event.button !== 0 || composer) return;
+    event.preventDefault();
+    event.currentTarget.setPointerCapture(event.pointerId);
+    clearHoverTimer();
+    const point = pointFromEvent(event);
+    setDraft({ origin: point, current: point });
+    setHoverTarget(null);
+  };
+
+  const handlePointerUp = async (event: React.PointerEvent<HTMLDivElement>) => {
+    if (!active || !adapter || !draft || composer) return;
+    event.preventDefault();
+    event.currentTarget.releasePointerCapture(event.pointerId);
+    const point = pointFromEvent(event);
+    const box = normalizeBox(draft.origin, point);
+    setDraft(null);
+    setIsCapturing(true);
+    try {
+      const isArea = box.width >= MIN_AREA_SIZE || box.height >= MIN_AREA_SIZE;
+      const capturePoint = isArea
+        ? { x: Math.round(box.x + box.width / 2), y: Math.round(box.y + box.height / 2) }
+        : point;
+      const captured = await inspectPoint(capturePoint, isArea ? 'area' : 'element');
+      if (!captured) return;
+      const target = isArea ? withAreaBoundingBox(captured, box) : captured;
+      openComposer(target, capturePoint);
+    } finally {
+      setIsCapturing(false);
+    }
+  };
+
+  const openComposer = (target: BrowserAnnotationTarget, anchor: Point) => {
+    setComposer({ target, anchor });
+    setComment('');
+    setHoverTarget(null);
+  };
+
+  const closeComposer = () => {
+    setComposer(null);
+    setComment('');
+  };
+
+  const saveAnnotation = () => {
+    const content = comment.trim();
+    if (!composer || !store || !content) return;
+    store.addAnnotation({
+      ...composer.target,
+      browserId,
+      comment: content,
+    });
+    closeComposer();
+  };
+
+  if (!active) return null;
+
+  const selectedTarget = composer?.target ?? hoverTarget;
+  const composerStyle = composerPositionStyle(composer?.anchor, overlayRef.current);
+
+  return (
+    <div
+      ref={overlayRef}
+      className={cn(
+        'absolute inset-0 z-10 cursor-crosshair overflow-hidden bg-transparent',
+        isCapturing && 'cursor-progress'
+      )}
+      onPointerMove={handlePointerMove}
+      onPointerDown={handlePointerDown}
+      onPointerUp={handlePointerUp}
+      aria-label="Browser annotation overlay"
+    >
+      <div className="pointer-events-none absolute top-2 left-2 flex items-center gap-1.5 rounded-md border border-blue-500/30 bg-background/95 px-2 py-1 text-xs text-foreground shadow-sm">
+        <MousePointer2 className="size-3.5 text-blue-500" />
+        <span>Annotation mode</span>
+        {pendingCount > 0 && (
+          <Badge
+            variant="secondary"
+            className="h-4 border-blue-500/20 bg-blue-500/10 text-blue-600"
+          >
+            {pendingCount}
+          </Badge>
+        )}
+      </div>
+
+      {selectedTarget && <TargetBox box={selectedTarget.boundingBox} active={Boolean(composer)} />}
+      {draftBox && (draftBox.width >= MIN_AREA_SIZE || draftBox.height >= MIN_AREA_SIZE) && (
+        <TargetBox box={draftBox} active />
+      )}
+
+      {composer && (
+        <div
+          className="absolute z-20 flex w-80 max-w-[calc(100%-1rem)] flex-col gap-2 rounded-md border border-border bg-background p-2 shadow-xl"
+          style={composerStyle}
+          onPointerDown={(event) => event.stopPropagation()}
+          onPointerUp={(event) => event.stopPropagation()}
+          onPointerMove={(event) => event.stopPropagation()}
+        >
+          <div className="flex min-w-0 items-center justify-between gap-2">
+            <div className="min-w-0 truncate text-xs font-medium text-foreground">
+              {targetLabel(composer.target)}
+            </div>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label="Cancel annotation"
+              onClick={closeComposer}
+            >
+              <X className="size-3.5" />
+            </Button>
+          </div>
+          <Textarea
+            ref={textareaRef}
+            value={comment}
+            onChange={(event) => setComment(event.currentTarget.value)}
+            onKeyDown={(event) => {
+              if ((event.metaKey || event.ctrlKey) && event.key === 'Enter') {
+                event.preventDefault();
+                saveAnnotation();
+              }
+              if (event.key === 'Escape') {
+                event.preventDefault();
+                closeComposer();
+              }
+            }}
+            className="min-h-20 resize-none text-sm"
+            placeholder="Describe the change"
+          />
+          <div className="flex items-center justify-end gap-1.5">
+            <Button type="button" variant="ghost" size="sm" onClick={closeComposer}>
+              Cancel
+            </Button>
+            <Button
+              type="button"
+              size="sm"
+              disabled={!comment.trim() || !store}
+              onClick={saveAnnotation}
+            >
+              Save
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+});
+
+function normalizeBox(a: Point, b: Point): BrowserAnnotationBoundingBox {
+  const x = Math.min(a.x, b.x);
+  const y = Math.min(a.y, b.y);
+  return {
+    x,
+    y,
+    width: Math.abs(a.x - b.x),
+    height: Math.abs(a.y - b.y),
+  };
+}
+
+function TargetBox({ box, active }: { box: BrowserAnnotationBoundingBox; active: boolean }) {
+  return (
+    <div
+      className={cn(
+        'pointer-events-none absolute rounded-[3px] border bg-blue-500/10 shadow-[0_0_0_1px_rgba(59,130,246,0.18)]',
+        active ? 'border-blue-500/80' : 'border-blue-500/55'
+      )}
+      style={{
+        left: box.x,
+        top: box.y,
+        width: Math.max(1, box.width),
+        height: Math.max(1, box.height),
+      }}
+    />
+  );
+}
+
+function composerPositionStyle(
+  anchor: Point | undefined,
+  container: HTMLDivElement | null
+): CSSProperties {
+  if (!anchor || !container) return { left: 8, top: 8 };
+  const width = container.clientWidth;
+  const height = container.clientHeight;
+  const left = Math.max(8, Math.min(width - 328, anchor.x + 12));
+  const top = Math.max(8, Math.min(height - 220, anchor.y + 12));
+  return { left, top };
+}
+
+function targetLabel(target: BrowserAnnotationTarget): string {
+  if (target.kind === 'area') return 'Area annotation';
+  if (target.kind === 'text') return 'Text annotation';
+  const classes = target.cssClasses
+    ? `.${target.cssClasses.split(/\s+/).slice(0, 2).join('.')}`
+    : '';
+  return `${target.element}${classes}`;
+}

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.tsx
@@ -1,6 +1,14 @@
 import { MousePointer2, X } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties } from 'react';
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type WheelEvent,
+} from 'react';
 import { Badge } from '@renderer/lib/ui/badge';
 import { Button } from '@renderer/lib/ui/button';
 import { Textarea } from '@renderer/lib/ui/textarea';
@@ -11,6 +19,7 @@ import type {
 } from '@shared/browserAnnotations';
 import {
   buildBrowserAnnotationCaptureScript,
+  buildBrowserAnnotationScrollScript,
   parseBrowserAnnotationCaptureResult,
   withAreaBoundingBox,
 } from './browser-annotation-capture';
@@ -34,6 +43,7 @@ type ComposerState = {
 
 const MIN_AREA_SIZE = 8;
 const HOVER_CAPTURE_DELAY_MS = 80;
+const WHEEL_LINE_HEIGHT_PX = 40;
 
 export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverlay({
   active,
@@ -113,7 +123,9 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
     [adapter]
   );
 
-  const pointFromEvent = (event: React.PointerEvent<HTMLDivElement>): Point => {
+  const pointFromEvent = (
+    event: React.PointerEvent<HTMLDivElement> | WheelEvent<HTMLDivElement>
+  ): Point => {
     const rect = event.currentTarget.getBoundingClientRect();
     return {
       x: Math.round(Math.max(0, Math.min(rect.width, event.clientX - rect.left))),
@@ -187,6 +199,26 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
     }
   };
 
+  const handleWheel = (event: WheelEvent<HTMLDivElement>) => {
+    if (!active || !adapter || composer || draft) return;
+    event.preventDefault();
+    event.stopPropagation();
+    clearHoverTimer();
+    setHoverTarget(null);
+
+    const point = pointFromEvent(event);
+    const scale = event.deltaMode === 1 ? WHEEL_LINE_HEIGHT_PX : 1;
+    const rawDeltaX = event.deltaX * scale;
+    const rawDeltaY = event.deltaY * scale;
+    const deltaX = event.shiftKey && rawDeltaX === 0 ? rawDeltaY : rawDeltaX;
+    const deltaY = event.shiftKey && rawDeltaX === 0 ? 0 : rawDeltaY;
+    const script = buildBrowserAnnotationScrollScript(point.x, point.y, deltaX, deltaY);
+
+    void adapter.executeJavaScript(script).then(() => {
+      scheduleHoverTargetUpdate(point);
+    });
+  };
+
   const openComposer = (target: BrowserAnnotationTarget, anchor: Point) => {
     setComposer({ target, anchor });
     setComment('');
@@ -224,6 +256,7 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
       onPointerMove={handlePointerMove}
       onPointerDown={handlePointerDown}
       onPointerUp={handlePointerUp}
+      onWheel={handleWheel}
       aria-label="Browser annotation overlay"
     >
       <div className="pointer-events-none absolute top-2 left-2 flex items-center gap-1.5 rounded-md border border-blue-500/30 bg-background/95 px-2 py-1 text-xs text-foreground shadow-sm">
@@ -251,6 +284,7 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
           onPointerDown={(event) => event.stopPropagation()}
           onPointerUp={(event) => event.stopPropagation()}
           onPointerMove={(event) => event.stopPropagation()}
+          onWheel={(event) => event.stopPropagation()}
         >
           <div className="flex min-w-0 items-center justify-between gap-2">
             <div className="min-w-0 truncate text-xs font-medium text-foreground">

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotation-overlay.tsx
@@ -11,7 +11,9 @@ import {
 } from 'react';
 import { Badge } from '@renderer/lib/ui/badge';
 import { Button } from '@renderer/lib/ui/button';
+import { Shortcut } from '@renderer/lib/ui/shortcut';
 import { Textarea } from '@renderer/lib/ui/textarea';
+import { captureTelemetry } from '@renderer/utils/telemetryClient';
 import { cn } from '@renderer/utils/utils';
 import type {
   BrowserAnnotationBoundingBox,
@@ -117,8 +119,12 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
     async (point: Point, kind: BrowserAnnotationTarget['kind'] = 'element') => {
       if (!adapter) return null;
       const script = buildBrowserAnnotationCaptureScript(point.x, point.y, kind);
-      const result = await adapter.executeJavaScript(script);
-      return parseBrowserAnnotationCaptureResult(result);
+      try {
+        const result = await adapter.executeJavaScript(script);
+        return parseBrowserAnnotationCaptureResult(result);
+      } catch {
+        return null;
+      }
     },
     [adapter]
   );
@@ -214,9 +220,12 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
     const deltaY = event.shiftKey && rawDeltaX === 0 ? 0 : rawDeltaY;
     const script = buildBrowserAnnotationScrollScript(point.x, point.y, deltaX, deltaY);
 
-    void adapter.executeJavaScript(script).then(() => {
-      scheduleHoverTargetUpdate(point);
-    });
+    void adapter
+      .executeJavaScript(script)
+      .catch(() => null)
+      .then(() => {
+        scheduleHoverTargetUpdate(point);
+      });
   };
 
   const openComposer = (target: BrowserAnnotationTarget, anchor: Point) => {
@@ -237,6 +246,11 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
       ...composer.target,
       browserId,
       comment: content,
+    });
+    captureTelemetry('browser_annotation_created', {
+      kind: composer.target.kind,
+      pending_count: store.pendingCount,
+      has_selected_text: Boolean(composer.target.selectedText),
     });
     closeComposer();
   };
@@ -327,7 +341,8 @@ export const BrowserAnnotationOverlay = observer(function BrowserAnnotationOverl
               disabled={!comment.trim() || !store}
               onClick={saveAnnotation}
             >
-              Save
+              <span>Save</span>
+              <Shortcut hotkey="Mod+Enter" variant="keycaps" />
             </Button>
           </div>
         </div>

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotations-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotations-store.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import type { BrowserAnnotationTarget } from '@shared/browserAnnotations';
+import { BrowserAnnotationsStore } from './browser-annotations-store';
+
+function makeTarget(overrides: Partial<BrowserAnnotationTarget> = {}): BrowserAnnotationTarget {
+  return {
+    kind: 'element',
+    url: 'http://localhost:3000/settings',
+    title: 'Settings',
+    elementPath: 'main > button',
+    element: 'button',
+    cssClasses: 'primary',
+    nearbyText: 'Save changes',
+    selectedText: undefined,
+    x: 120,
+    y: 80,
+    boundingBox: { x: 100, y: 64, width: 180, height: 40 },
+    ...overrides,
+  };
+}
+
+describe('BrowserAnnotationsStore', () => {
+  it('adds pending annotations and formats them for the agent', () => {
+    const store = new BrowserAnnotationsStore('task-1');
+    const id = store.addAnnotation({
+      ...makeTarget(),
+      browserId: 'browser-1',
+      comment: 'Make this button clearer.',
+    });
+
+    expect(store.pendingCount).toBe(1);
+    expect(store.annotations[0]?.id).toBe(id);
+    expect(store.formattedForAgent).toContain('Make this button clearer.');
+  });
+
+  it('updates, dismisses, and deletes annotations', () => {
+    const store = new BrowserAnnotationsStore('task-1');
+    const id = store.addAnnotation({
+      ...makeTarget(),
+      browserId: 'browser-1',
+      comment: 'Initial comment.',
+    });
+
+    expect(store.updateAnnotation(id, 'Updated comment.')).toBe(true);
+    expect(store.annotations[0]?.comment).toBe('Updated comment.');
+    expect(store.dismissAnnotation(id)).toBe(true);
+    expect(store.pendingCount).toBe(0);
+    expect(store.deleteAnnotation(id)).toBe(true);
+    expect(store.count).toBe(0);
+  });
+
+  it('consumePending returns formatted context and clears only pending annotations', () => {
+    const store = new BrowserAnnotationsStore('task-1');
+    const pendingId = store.addAnnotation({
+      ...makeTarget(),
+      browserId: 'browser-1',
+      comment: 'Pending comment.',
+    });
+    const dismissedId = store.addAnnotation({
+      ...makeTarget(),
+      browserId: 'browser-1',
+      comment: 'Dismissed comment.',
+    });
+    store.dismissAnnotation(dismissedId);
+
+    const formatted = store.consumePending();
+
+    expect(formatted).toContain('Pending comment.');
+    expect(formatted).not.toContain('Dismissed comment.');
+    expect(store.annotationsById.has(pendingId)).toBe(false);
+    expect(store.annotationsById.has(dismissedId)).toBe(true);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-annotations-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-annotations-store.ts
@@ -1,0 +1,108 @@
+import { makeAutoObservable } from 'mobx';
+import {
+  formatBrowserAnnotationsForAgent,
+  type BrowserAnnotation,
+  type BrowserAnnotationTarget,
+} from '@shared/browserAnnotations';
+
+const MAX_BROWSER_ANNOTATIONS_PER_TASK = 200;
+
+type CreateBrowserAnnotationInput = BrowserAnnotationTarget & {
+  browserId: string;
+  comment: string;
+};
+
+function byCreatedAt(a: BrowserAnnotation, b: BrowserAnnotation): number {
+  return a.createdAt.localeCompare(b.createdAt);
+}
+
+export class BrowserAnnotationsStore {
+  readonly annotationsById = new Map<string, BrowserAnnotation>();
+
+  constructor(readonly taskId: string) {
+    makeAutoObservable(this, {}, { autoBind: true });
+  }
+
+  get annotations(): BrowserAnnotation[] {
+    return Array.from(this.annotationsById.values()).sort(byCreatedAt);
+  }
+
+  get pendingAnnotations(): BrowserAnnotation[] {
+    return this.annotations.filter((annotation) => annotation.status === 'pending');
+  }
+
+  get count(): number {
+    return this.annotationsById.size;
+  }
+
+  get pendingCount(): number {
+    return this.pendingAnnotations.length;
+  }
+
+  get formattedForAgent(): string {
+    return formatBrowserAnnotationsForAgent(this.pendingAnnotations, { includeIntro: false });
+  }
+
+  addAnnotation(input: CreateBrowserAnnotationInput): string {
+    if (this.annotationsById.size >= MAX_BROWSER_ANNOTATIONS_PER_TASK) {
+      console.warn(
+        `BrowserAnnotationsStore: reached ${MAX_BROWSER_ANNOTATIONS_PER_TASK} annotation limit for task ${this.taskId}`
+      );
+      return crypto.randomUUID();
+    }
+
+    const now = new Date().toISOString();
+    const id = crypto.randomUUID();
+    this.annotationsById.set(id, {
+      ...input,
+      id,
+      taskId: this.taskId,
+      status: 'pending',
+      createdAt: now,
+      updatedAt: now,
+    });
+    return id;
+  }
+
+  updateAnnotation(id: string, comment: string): boolean {
+    const existing = this.annotationsById.get(id);
+    if (!existing) return false;
+    this.annotationsById.set(id, {
+      ...existing,
+      comment,
+      updatedAt: new Date().toISOString(),
+    });
+    return true;
+  }
+
+  dismissAnnotation(id: string): boolean {
+    const existing = this.annotationsById.get(id);
+    if (!existing) return false;
+    this.annotationsById.set(id, {
+      ...existing,
+      status: 'dismissed',
+      updatedAt: new Date().toISOString(),
+    });
+    return true;
+  }
+
+  deleteAnnotation(id: string): boolean {
+    return this.annotationsById.delete(id);
+  }
+
+  consumePending(): string {
+    const formatted = this.formattedForAgent;
+    for (const annotation of this.pendingAnnotations) {
+      this.annotationsById.delete(annotation.id);
+    }
+    return formatted;
+  }
+
+  clear(): void {
+    this.annotationsById.clear();
+  }
+
+  dispose(): void {
+    this.clear();
+  }
+}

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
@@ -13,6 +13,17 @@ const browserRpc = vi.hoisted(() => ({
 
 vi.mock('@renderer/features/tasks/task-view-context', () => ({
   usePreviewServers: () => ({ urls: [] }),
+  useTaskViewContext: () => ({
+    projectId: 'project-1',
+    taskId: 'task-1',
+    workspaceId: 'workspace-1',
+  }),
+}));
+
+vi.mock('@renderer/features/tasks/stores/task-selectors', () => ({
+  getTaskStore: () => ({
+    browserAnnotations: { pendingCount: 0 },
+  }),
 }));
 
 vi.mock('@renderer/features/tabs/pane-context', () => ({
@@ -90,6 +101,7 @@ describe('BrowserPane', () => {
       getWebContentsId: () => 123,
       loadURL,
       setZoomFactor: vi.fn(),
+      executeJavaScript: vi.fn(),
     });
 
     await act(async () => webview.dispatchEvent(new dom.window.Event('dom-ready')));

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
@@ -2,12 +2,14 @@ import { ExternalLink, RotateCcw } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePaneContext } from '@renderer/features/tabs/pane-context';
-import { usePreviewServers } from '@renderer/features/tasks/task-view-context';
+import { getTaskStore } from '@renderer/features/tasks/stores/task-selectors';
+import { usePreviewServers, useTaskViewContext } from '@renderer/features/tasks/task-view-context';
 import { EmdashLogo } from '@renderer/lib/emdash-logo';
 import { events, rpc } from '@renderer/lib/ipc';
 import { Button } from '@renderer/lib/ui/button';
 import { normalizeBrowserUrl, normalizeBrowserZoomFactor } from '@shared/browser';
 import { tabNavigationShortcutChannel } from '@shared/events/appEvents';
+import { BrowserAnnotationOverlay } from './browser-annotation-overlay';
 import { browserControlsRegistry } from './browser-controls-registry';
 import {
   browserLoadErrorCode,
@@ -38,11 +40,14 @@ export const BrowserPane = observer(function BrowserPane({
 }) {
   const session = browserSessionStore.getSession(browserId);
   const { pane } = usePaneContext();
+  const { projectId, taskId } = useTaskViewContext();
   const previewServers = usePreviewServers();
+  const browserAnnotations = getTaskStore(projectId, taskId)?.browserAnnotations ?? null;
   const webviewRef = useRef<BrowserWebviewElement | null>(null);
   const focusUrlRef = useRef<() => void>(() => {});
   const [adapter, setAdapter] = useState<BrowserWebviewAdapter | null>(null);
   const [webviewElement, setWebviewElement] = useState<BrowserWebviewElement | null>(null);
+  const [annotationMode, setAnnotationMode] = useState(false);
   const [webviewMount, setWebviewMount] = useState<{
     browserId: string;
     partition: string;
@@ -62,6 +67,9 @@ export const BrowserPane = observer(function BrowserPane({
   const canOpenLoadErrorExternal = useMemo(
     () => (loadError ? canOpenBrowserUrlExternally(loadErrorUrl) : false),
     [loadError, loadErrorUrl]
+  );
+  const canAnnotate = Boolean(
+    adapter && session && !session.isLoading && !showStartPage && !loadError
   );
 
   useEffect(() => {
@@ -136,6 +144,7 @@ export const BrowserPane = observer(function BrowserPane({
   const loadUrl = useCallback(
     (url: string) => {
       if (!sessionBrowserId) return;
+      setAnnotationMode(false);
       browserSessionStore.updateSession(sessionBrowserId, {
         currentUrl: url,
         faviconUrl: null,
@@ -238,6 +247,12 @@ export const BrowserPane = observer(function BrowserPane({
   }, [sessionBrowserId, webviewElement]);
 
   useEffect(() => {
+    if (!canAnnotate && annotationMode) {
+      setAnnotationMode(false);
+    }
+  }, [annotationMode, canAnnotate]);
+
+  useEffect(() => {
     if (!sessionBrowserId) return;
     return browserControlsRegistry.register(sessionBrowserId, {
       adapter,
@@ -265,11 +280,15 @@ export const BrowserPane = observer(function BrowserPane({
         onReload={reload}
         onForceReload={forceReload}
         onSetZoomFactor={setZoomFactor}
+        annotationMode={annotationMode}
+        annotationCount={browserAnnotations?.pendingCount ?? 0}
+        annotationDisabled={!canAnnotate}
+        onToggleAnnotationMode={() => setAnnotationMode((value) => !value)}
         onFocusUrl={(focus) => {
           focusUrlRef.current = focus;
         }}
       />
-      <div className="emlight min-h-0 flex-1 bg-background">
+      <div className="emlight relative min-h-0 flex-1 bg-background">
         {loadError && loadErrorPresentation ? (
           <BrowserLoadErrorView
             url={loadErrorUrl}
@@ -282,12 +301,21 @@ export const BrowserPane = observer(function BrowserPane({
         ) : showStartPage ? (
           <BrowserStartPage devServerUrls={previewServers.urls} onOpenUrl={navigateTo} />
         ) : webviewProps && isRegistered ? (
-          <webview
-            key={`${webviewMount?.browserId ?? 'browser'}:${webviewMount?.partition ?? 'partition'}:${webviewMount?.revision ?? 0}`}
-            ref={attachWebview}
-            {...webviewProps}
-            className="h-full w-full bg-background"
-          />
+          <>
+            <webview
+              key={`${webviewMount?.browserId ?? 'browser'}:${webviewMount?.partition ?? 'partition'}:${webviewMount?.revision ?? 0}`}
+              ref={attachWebview}
+              {...webviewProps}
+              className="h-full w-full bg-background"
+            />
+            <BrowserAnnotationOverlay
+              active={annotationMode && canAnnotate}
+              adapter={adapter}
+              browserId={browserId}
+              store={browserAnnotations}
+              onClose={() => setAnnotationMode(false)}
+            />
+          </>
         ) : (
           <div className="flex h-full items-center justify-center text-sm text-foreground-muted">
             Preparing browser session

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
@@ -7,6 +7,7 @@ import { usePreviewServers, useTaskViewContext } from '@renderer/features/tasks/
 import { EmdashLogo } from '@renderer/lib/emdash-logo';
 import { events, rpc } from '@renderer/lib/ipc';
 import { Button } from '@renderer/lib/ui/button';
+import { captureTelemetry } from '@renderer/utils/telemetryClient';
 import { normalizeBrowserUrl, normalizeBrowserZoomFactor } from '@shared/browser';
 import { tabNavigationShortcutChannel } from '@shared/events/appEvents';
 import { BrowserAnnotationOverlay } from './browser-annotation-overlay';
@@ -219,6 +220,17 @@ export const BrowserPane = observer(function BrowserPane({
     [adapter, sessionBrowserId]
   );
 
+  const toggleAnnotationMode = useCallback(() => {
+    setAnnotationMode((value) => {
+      const enabled = !value;
+      captureTelemetry('browser_annotation_mode_toggled', {
+        enabled,
+        pending_count: browserAnnotations?.pendingCount ?? 0,
+      });
+      return enabled;
+    });
+  }, [browserAnnotations?.pendingCount]);
+
   // Must stay referentially stable: React re-invokes inline ref callbacks with
   // null + node on every render, which would wipe the adapter until the next
   // dom-ready and break everything adapter-backed (zoom, stop, force reload).
@@ -283,7 +295,7 @@ export const BrowserPane = observer(function BrowserPane({
         annotationMode={annotationMode}
         annotationCount={browserAnnotations?.pendingCount ?? 0}
         annotationDisabled={!canAnnotate}
-        onToggleAnnotationMode={() => setAnnotationMode((value) => !value)}
+        onToggleAnnotationMode={toggleAnnotationMode}
         onFocusUrl={(focus) => {
           focusUrlRef.current = focus;
         }}

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.test.ts
@@ -1,0 +1,112 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { BrowserSessionSnapshot } from '@shared/browser';
+import { BrowserToolbar } from './browser-toolbar';
+
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: () => ({ value: undefined }),
+}));
+
+vi.mock('@renderer/lib/layout/navigation-provider', () => ({
+  useNavigate: () => ({ navigate: vi.fn() }),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    browser: {
+      openDevTools: vi.fn(),
+    },
+  },
+}));
+
+function session(overrides: Partial<BrowserSessionSnapshot> = {}): BrowserSessionSnapshot {
+  return {
+    browserId: 'browser-1',
+    projectId: 'project-1',
+    workspaceId: 'workspace-1',
+    taskId: 'task-1',
+    profileId: 'default',
+    partition: 'persist:emdash-browser-profile',
+    currentUrl: 'https://example.com/',
+    title: 'Example',
+    isLoading: false,
+    canGoBack: false,
+    canGoForward: false,
+    zoomFactor: 1,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe('BrowserToolbar annotation control', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLElement;
+
+  beforeEach(() => {
+    dom = new JSDOM('<div id="root"></div>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Element', dom.window.Element);
+    vi.stubGlobal('Node', dom.window.Node);
+    vi.stubGlobal('Event', dom.window.Event);
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    container = dom.window.document.getElementById('root')!;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('shows active state and count, and toggles annotation mode', async () => {
+    const onToggleAnnotationMode = vi.fn();
+
+    await act(async () => {
+      root.render(
+        React.createElement(BrowserToolbar, {
+          session: session(),
+          adapter: null,
+          annotationMode: true,
+          annotationCount: 12,
+          onToggleAnnotationMode,
+        })
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Annotation mode"]'
+    );
+    expect(button?.getAttribute('aria-pressed')).toBe('true');
+    expect(button?.textContent).toContain('9+');
+
+    await act(async () => {
+      button?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(onToggleAnnotationMode).toHaveBeenCalledTimes(1);
+  });
+
+  it('can disable annotation mode', async () => {
+    await act(async () => {
+      root.render(
+        React.createElement(BrowserToolbar, {
+          session: session(),
+          adapter: null,
+          annotationDisabled: true,
+        })
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      'button[aria-label="Annotation mode"]'
+    );
+    expect(button?.disabled).toBe(true);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-toolbar.tsx
@@ -6,6 +6,7 @@ import {
   Globe,
   Loader2,
   Minus,
+  MousePointer2,
   Plus,
   RefreshCw,
   RotateCcw,
@@ -71,6 +72,10 @@ export function BrowserToolbar({
   onReload,
   onForceReload,
   onSetZoomFactor,
+  annotationMode,
+  annotationCount,
+  annotationDisabled,
+  onToggleAnnotationMode,
   onFocusUrl,
 }: {
   session: BrowserSessionSnapshot;
@@ -82,6 +87,10 @@ export function BrowserToolbar({
   onReload?: () => void;
   onForceReload?: () => void;
   onSetZoomFactor?: (factor: number) => void;
+  annotationMode?: boolean;
+  annotationCount?: number;
+  annotationDisabled?: boolean;
+  onToggleAnnotationMode?: () => void;
   onFocusUrl?: (focus: () => void) => void;
 }) {
   const [urlText, setUrlText] = useState(browserUrlInputText(session.currentUrl));
@@ -234,6 +243,21 @@ export function BrowserToolbar({
           )}
         />
       </ToolbarIconButton>
+      <ToolbarIconButton
+        label="Annotation mode"
+        disabled={annotationDisabled}
+        active={Boolean(annotationMode)}
+        onClick={() => onToggleAnnotationMode?.()}
+      >
+        <span className="relative">
+          <MousePointer2 className="size-4" />
+          {annotationCount ? (
+            <span className="absolute -top-1.5 -right-1.5 flex h-3.5 min-w-3.5 items-center justify-center rounded-full border border-background bg-blue-500 px-0.5 text-[9px] leading-none text-white">
+              {annotationCount > 9 ? '9+' : annotationCount}
+            </span>
+          ) : null}
+        </span>
+      </ToolbarIconButton>
       <DropdownMenu>
         <DropdownMenuTrigger
           render={
@@ -375,11 +399,13 @@ function useTransientFlag(durationMs: number): [boolean, () => void] {
 function ToolbarIconButton({
   label,
   disabled,
+  active,
   onClick,
   children,
 }: {
   label: string;
   disabled?: boolean;
+  active?: boolean;
   onClick: () => void;
   children: ReactNode;
 }) {
@@ -391,9 +417,13 @@ function ToolbarIconButton({
             type="button"
             variant="ghost"
             size="icon"
-            className="size-7 shrink-0"
+            className={cn(
+              'size-7 shrink-0',
+              active && 'border-blue-500/30 bg-blue-500/10 text-blue-600 hover:bg-blue-500/15'
+            )}
             disabled={disabled}
             aria-label={label}
+            aria-pressed={active || undefined}
             onClick={onClick}
           >
             {children}

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-webview-types.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-webview-types.ts
@@ -23,6 +23,7 @@ export type BrowserWebviewElement = HTMLElement & {
   stop(): void;
   loadURL(url: string): Promise<void> | void;
   setZoomFactor(factor: number): void;
+  executeJavaScript(code: string): Promise<unknown>;
   addEventListener<K extends keyof BrowserWebviewEventMap>(
     type: K,
     listener: (event: BrowserWebviewEventMap[K]) => void
@@ -45,6 +46,7 @@ export type BrowserWebviewAdapter = {
   stop(): void;
   loadUrl(url: string): Promise<void>;
   setZoomFactor(factor: number): void;
+  executeJavaScript(code: string): Promise<unknown>;
   focus(): void;
 };
 
@@ -63,6 +65,7 @@ export function createBrowserWebviewAdapter(webview: BrowserWebviewElement): Bro
       await webview.loadURL(url);
     },
     setZoomFactor: (factor: number) => webview.setZoomFactor(factor),
+    executeJavaScript: (code: string) => webview.executeJavaScript(code),
     focus: () => webview.focus(),
   };
 }

--- a/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/projects/stores/project-manager.test.ts
@@ -62,6 +62,14 @@ vi.mock('@renderer/lib/stores/view-state-cache', () => ({
   },
 }));
 
+vi.mock('@renderer/features/tasks/acp/acp-chat-store', () => ({
+  AcpChatStore: class {},
+}));
+
+vi.mock('@renderer/features/tasks/acp/acp-chat-panel', () => ({
+  AcpChatPanel: () => null,
+}));
+
 vi.mock('@renderer/utils/telemetryClient', () => ({
   captureTelemetry: vi.fn(),
 }));

--- a/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/sidebar-store.test.ts
@@ -14,6 +14,14 @@ vi.mock('@renderer/lib/stores/app-state', () => ({
   appState: {},
 }));
 
+vi.mock('@renderer/features/tasks/acp/acp-chat-store', () => ({
+  AcpChatStore: class {},
+}));
+
+vi.mock('@renderer/features/tasks/acp/acp-chat-panel', () => ({
+  AcpChatPanel: () => null,
+}));
+
 function projectManager(projects: { id: string; createdAt: string }[]): SidebarProjectManager {
   return {
     projects: new Map(projects.map((p) => [p.id, { ...p, mountedProject: null }])),

--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-layout-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-layout-store.test.ts
@@ -8,6 +8,11 @@ vi.mock('@renderer/lib/ipc', () => ({
   rpc: {
     app: { readUserFile: vi.fn() },
     browser: { unregisterSession: vi.fn() },
+    ssh: {
+      getConnections: vi.fn(async () => []),
+      getConnectionState: vi.fn(async () => ({})),
+      getHealthStates: vi.fn(async () => ({})),
+    },
   },
 }));
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/add-context-popover.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/add-context-popover.tsx
@@ -1,5 +1,5 @@
 import { useHotkey, type Hotkey } from '@tanstack/react-hotkeys';
-import { ChevronDown, ChevronUp, MessageSquare, TextInitial } from 'lucide-react';
+import { ChevronDown, ChevronUp, MessageSquare, MousePointer2, TextInitial } from 'lucide-react';
 import { useMemo, useRef, useState, type ReactNode } from 'react';
 import {
   Combobox,
@@ -60,6 +60,14 @@ export function ActionItemRow({ action }: { action: ContextAction }) {
           text={`${action.commentCount} comment${action.commentCount !== 1 ? 's' : ''} in ${action.fileCount} file${action.fileCount !== 1 ? 's' : ''}`}
         />
       );
+    case 'browser-annotations':
+      return (
+        <ActionItemBaseRow
+          icon={<MousePointer2 className="size-3.5 shrink-0 text-foreground-muted" />}
+          label="Browser annotations"
+          text={`${action.annotationCount} annotation${action.annotationCount !== 1 ? 's' : ''} on ${action.pageCount} page${action.pageCount !== 1 ? 's' : ''}`}
+        />
+      );
     case 'prompt':
       return (
         <ActionItemBaseRow
@@ -118,6 +126,8 @@ export function AddContextPopover({
           );
         case 'draft-comments':
           return 'line comments'.includes(q);
+        case 'browser-annotations':
+          return 'browser annotations'.includes(q);
         case 'prompt':
           return (
             action.prompt.title.toLowerCase().includes(q) ||

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-actions.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-actions.ts
@@ -1,3 +1,7 @@
+import {
+  formatBrowserAnnotationsForAgent,
+  type BrowserAnnotation,
+} from '@shared/browserAnnotations';
 import type { LinkedIssue } from '@shared/core/linked-issue';
 import { formatCommentsForAgent } from '@shared/lineComments';
 import type { PromptLibraryPrompt } from '@shared/prompt-library';
@@ -5,7 +9,11 @@ import type { DraftComment } from '../diff-view/stores/draft-comments-store';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
-export type ContextActionKind = 'linked-issue' | 'draft-comments' | 'prompt';
+export type ContextActionKind =
+  | 'linked-issue'
+  | 'draft-comments'
+  | 'browser-annotations'
+  | 'prompt';
 
 export interface IssueContextAction {
   id: string;
@@ -22,13 +30,25 @@ export interface DraftCommentsContextAction {
   fileCount: number;
 }
 
+export interface BrowserAnnotationsContextAction {
+  id: string;
+  kind: 'browser-annotations';
+  annotations: BrowserAnnotation[];
+  annotationCount: number;
+  pageCount: number;
+}
+
 export interface PromptContextAction {
   id: string;
   kind: 'prompt';
   prompt: PromptLibraryPrompt;
 }
 
-export type ContextAction = IssueContextAction | DraftCommentsContextAction | PromptContextAction;
+export type ContextAction =
+  | IssueContextAction
+  | DraftCommentsContextAction
+  | BrowserAnnotationsContextAction
+  | PromptContextAction;
 
 // ─── Text building ───────────────────────────────────────────────────────────
 
@@ -76,6 +96,8 @@ export function buildContextActionText(action: ContextAction): string {
       return buildIssueContextText(action.issue);
     case 'draft-comments':
       return formatCommentsForAgent(action.comments, { includeIntro: false });
+    case 'browser-annotations':
+      return formatBrowserAnnotationsForAgent(action.annotations, { includeIntro: false });
     case 'prompt':
       return action.prompt.prompt;
   }
@@ -107,6 +129,21 @@ export function buildDraftCommentsContextAction(
   };
 }
 
+export function buildBrowserAnnotationsContextAction(
+  annotations: BrowserAnnotation[]
+): BrowserAnnotationsContextAction | null {
+  const pendingAnnotations = annotations.filter((annotation) => annotation.status === 'pending');
+  if (pendingAnnotations.length === 0) return null;
+  const pageCount = new Set(pendingAnnotations.map((annotation) => annotation.url)).size;
+  return {
+    id: 'browser-annotations',
+    kind: 'browser-annotations',
+    annotations: pendingAnnotations,
+    annotationCount: pendingAnnotations.length,
+    pageCount,
+  };
+}
+
 export function buildPromptLibraryContextActions(
   prompts: PromptLibraryPrompt[]
 ): PromptContextAction[] {
@@ -122,11 +159,13 @@ export function buildPromptLibraryContextActions(
 export function buildTaskContextActions(
   issue: LinkedIssue | undefined,
   comments: DraftComment[],
+  browserAnnotations: BrowserAnnotation[],
   prompts: PromptLibraryPrompt[]
 ): ContextAction[] {
   return [
     buildLinkedIssueContextAction(issue),
     buildDraftCommentsContextAction(comments),
+    buildBrowserAnnotationsContextAction(browserAnnotations),
     ...buildPromptLibraryContextActions(prompts),
   ].filter((a): a is ContextAction => a !== null);
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.test.ts
@@ -1,0 +1,186 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AddContextPopoverProps } from './add-context-popover';
+import type { ContextAction } from './context-actions';
+import { ContextBar } from './context-bar';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => ({
+  activeSession: {
+    sessionId: 'session-1',
+    pty: { terminal: { focus: vi.fn() } },
+  },
+  browserAnnotations: {
+    annotations: [
+      {
+        id: 'annotation-1',
+        taskId: 'task-1',
+        browserId: 'browser-1',
+        kind: 'element',
+        status: 'pending',
+        comment: 'Fix this button',
+        url: 'http://localhost:3000/settings',
+        title: 'Settings',
+        elementPath: 'main > button:nth-child(1)',
+        element: 'button',
+        cssClasses: 'primary',
+        nearbyText: 'Save changes',
+        x: 12,
+        y: 24,
+        boundingBox: { x: 10, y: 20, width: 100, height: 32 },
+        createdAt: '2026-01-01T00:00:00.000Z',
+        updatedAt: '2026-01-01T00:00:00.000Z',
+      },
+    ],
+    consumePending: vi.fn(),
+  },
+  conversations: {
+    sessions: new Map(),
+    conversations: new Map(),
+  },
+  getRegisteredTaskData: vi.fn(),
+  getTaskStore: vi.fn(),
+  pastePromptInjection: vi.fn(),
+  sendInput: vi.fn(),
+  updateInterfaceSettings: vi.fn(),
+}));
+
+vi.mock('@renderer/features/library/prompts/use-prompt-library', () => ({
+  usePromptLibrary: () => ({ value: [], isSaving: false }),
+}));
+
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: () => ({ update: mocks.updateInterfaceSettings, isSaving: false }),
+}));
+
+vi.mock('@renderer/features/tabs/pane-context', () => ({
+  usePaneContext: () => ({ paneId: 'pane-1' }),
+}));
+
+vi.mock('@renderer/features/tasks/stores/task-selectors', () => ({
+  getRegisteredTaskData: mocks.getRegisteredTaskData,
+  getTaskStore: mocks.getTaskStore,
+}));
+
+vi.mock('@renderer/features/tasks/task-view-context', () => ({
+  useTaskViewContext: () => ({ projectId: 'project-1', taskId: 'task-1' }),
+  useWorkspaceViewModel: () => ({ paneLayout: { activePaneId: 'pane-1' } }),
+  useConversations: () => mocks.conversations,
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    pty: {
+      sendInput: mocks.sendInput,
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/pty/prompt-injection', () => ({
+  pastePromptInjection: mocks.pastePromptInjection,
+}));
+
+let latestPopoverProps: AddContextPopoverProps | undefined;
+
+vi.mock('./add-context-popover', () => ({
+  AddContextPopover: (props: AddContextPopoverProps) => {
+    latestPopoverProps = props;
+    return null;
+  },
+}));
+
+describe('ContextBar browser annotations', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    latestPopoverProps = undefined;
+    mocks.activeSession.pty.terminal.focus.mockClear();
+    mocks.browserAnnotations.consumePending.mockClear();
+    mocks.getRegisteredTaskData.mockReturnValue({ linkedIssue: undefined });
+    mocks.getTaskStore.mockReturnValue({
+      draftComments: { comments: [] },
+      browserAnnotations: mocks.browserAnnotations,
+    });
+    mocks.conversations.sessions = new Map([['conversation-1', mocks.activeSession]]);
+    mocks.conversations.conversations = new Map([
+      ['conversation-1', { data: { providerId: 'claude' } }],
+    ]);
+    mocks.pastePromptInjection.mockImplementation(async ({ sendInput }) => {
+      await sendInput('pasted annotation context');
+    });
+    mocks.sendInput.mockResolvedValue(undefined);
+
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  async function renderContextBar() {
+    await act(async () => {
+      root.render(
+        React.createElement(ContextBar, { conversationId: 'conversation-1', hideTrigger: true })
+      );
+    });
+  }
+
+  function getBrowserAnnotationAction(): ContextAction {
+    const action = latestPopoverProps?.actions.find((item) => item.kind === 'browser-annotations');
+    if (!action) throw new Error('Expected browser annotations action');
+    return action;
+  }
+
+  it('pastes browser annotations into the active terminal, submits, and consumes after success', async () => {
+    await renderContextBar();
+
+    const action = getBrowserAnnotationAction();
+    await act(async () => {
+      await latestPopoverProps?.onApplyAction('<browser_annotations />', action, { andSend: true });
+    });
+
+    expect(mocks.pastePromptInjection).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providerId: 'claude',
+        text: '<browser_annotations />',
+        forceBracketedPaste: true,
+      })
+    );
+    expect(mocks.sendInput).toHaveBeenNthCalledWith(1, 'session-1', 'pasted annotation context');
+    expect(mocks.sendInput).toHaveBeenNthCalledWith(2, 'session-1', '\r');
+    expect(mocks.browserAnnotations.consumePending).toHaveBeenCalledOnce();
+    expect(mocks.activeSession.pty.terminal.focus).toHaveBeenCalledOnce();
+  });
+
+  it('does not consume browser annotations when paste fails', async () => {
+    mocks.pastePromptInjection.mockRejectedValueOnce(new Error('paste failed'));
+
+    await renderContextBar();
+    const action = getBrowserAnnotationAction();
+
+    await expect(
+      latestPopoverProps?.onApplyAction('<browser_annotations />', action)
+    ).rejects.toThrow('paste failed');
+
+    expect(mocks.browserAnnotations.consumePending).not.toHaveBeenCalled();
+    expect(mocks.activeSession.pty.terminal.focus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.test.ts
@@ -47,6 +47,7 @@ const mocks = vi.hoisted(() => ({
   getTaskStore: vi.fn(),
   pastePromptInjection: vi.fn(),
   sendInput: vi.fn(),
+  captureTelemetry: vi.fn(),
   updateInterfaceSettings: vi.fn(),
 }));
 
@@ -83,6 +84,10 @@ vi.mock('@renderer/lib/ipc', () => ({
 
 vi.mock('@renderer/lib/pty/prompt-injection', () => ({
   pastePromptInjection: mocks.pastePromptInjection,
+}));
+
+vi.mock('@renderer/utils/telemetryClient', () => ({
+  captureTelemetry: mocks.captureTelemetry,
 }));
 
 let latestPopoverProps: AddContextPopoverProps | undefined;
@@ -166,6 +171,12 @@ describe('ContextBar browser annotations', () => {
     );
     expect(mocks.sendInput).toHaveBeenNthCalledWith(1, 'session-1', 'pasted annotation context');
     expect(mocks.sendInput).toHaveBeenNthCalledWith(2, 'session-1', '\r');
+    expect(mocks.captureTelemetry).toHaveBeenCalledWith('browser_annotations_assigned', {
+      annotation_count: 1,
+      page_count: 1,
+      and_send: true,
+      provider: 'claude',
+    });
     expect(mocks.browserAnnotations.consumePending).toHaveBeenCalledOnce();
     expect(mocks.activeSession.pty.terminal.focus).toHaveBeenCalledOnce();
   });
@@ -181,6 +192,10 @@ describe('ContextBar browser annotations', () => {
     ).rejects.toThrow('paste failed');
 
     expect(mocks.browserAnnotations.consumePending).not.toHaveBeenCalled();
+    expect(mocks.captureTelemetry).not.toHaveBeenCalledWith(
+      'browser_annotations_assigned',
+      expect.anything()
+    );
     expect(mocks.activeSession.pty.terminal.focus).not.toHaveBeenCalled();
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
@@ -20,6 +20,7 @@ import {
   ContextMenuItem,
   ContextMenuTrigger,
 } from '@renderer/lib/ui/context-menu';
+import { captureTelemetry } from '@renderer/utils/telemetryClient';
 import { AddContextPopover } from './add-context-popover';
 import { buildTaskContextActions, type ContextAction } from './context-actions';
 
@@ -89,6 +90,12 @@ export const ContextBar = observer(function ContextBar({
       draftComments?.consumeAll();
     }
     if (action.kind === 'browser-annotations') {
+      captureTelemetry('browser_annotations_assigned', {
+        annotation_count: action.annotationCount,
+        page_count: action.pageCount,
+        and_send: Boolean(opts?.andSend),
+        provider: activeConversationStore?.data.providerId ?? null,
+      });
       browserAnnotations?.consumePending();
     }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/context-bar.tsx
@@ -39,7 +39,9 @@ export const ContextBar = observer(function ContextBar({
   const { update: updateInterfaceSettings, isSaving: isSavingInterfaceSettings } =
     useAppSettingsKey('interface');
   const task = getRegisteredTaskData(projectId, taskId);
-  const draftComments = getTaskStore(projectId, taskId)?.draftComments;
+  const taskStore = getTaskStore(projectId, taskId);
+  const draftComments = taskStore?.draftComments;
+  const browserAnnotations = taskStore?.browserAnnotations;
   const { value: promptLibrary, isSaving: isSavingPromptLibrary } = usePromptLibrary();
   const activeSession = conversationId ? conversations.sessions.get(conversationId) : undefined;
   const activeConversationStore = conversationId
@@ -51,8 +53,14 @@ export const ContextBar = observer(function ContextBar({
   const [menuOpen, setMenuOpen] = useState(false);
 
   const actions = useMemo(
-    () => buildTaskContextActions(task?.linkedIssue, draftComments?.comments ?? [], promptLibrary),
-    [task?.linkedIssue, draftComments?.comments, promptLibrary]
+    () =>
+      buildTaskContextActions(
+        task?.linkedIssue,
+        draftComments?.comments ?? [],
+        browserAnnotations?.annotations ?? [],
+        promptLibrary
+      ),
+    [task?.linkedIssue, draftComments?.comments, browserAnnotations?.annotations, promptLibrary]
   );
 
   const isActivePane = taskView.paneLayout.activePaneId === paneId;
@@ -73,12 +81,15 @@ export const ContextBar = observer(function ContextBar({
       sendInput: (data) => rpc.pty.sendInput(activeSessionId, data),
     });
 
+    if (opts?.andSend) {
+      await rpc.pty.sendInput(activeSessionId, '\r');
+    }
+
     if (action.kind === 'draft-comments') {
       draftComments?.consumeAll();
     }
-
-    if (opts?.andSend) {
-      await rpc.pty.sendInput(activeSessionId, '\r');
+    if (action.kind === 'browser-annotations') {
+      browserAnnotations?.consumePending();
     }
 
     activeSession?.pty?.terminal.focus();

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.test.ts
@@ -24,8 +24,16 @@ vi.mock('@renderer/features/library/prompts/use-prompt-library', () => ({
   usePromptLibrary: () => ({ value: [] }),
 }));
 
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: () => ({ value: undefined }),
+}));
+
 vi.mock('@renderer/lib/components/agent-selector/agent-selector', () => ({
   AgentSelector: () => null,
+}));
+
+vi.mock('@renderer/lib/ui/shortcut', () => ({
+  Shortcut: () => null,
 }));
 
 vi.mock('../components/issue-selector/issue-selector', () => ({

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -143,7 +143,7 @@ export function InitialConversationField({
 }: InitialConversationFieldProps) {
   const { value: promptLibrary } = usePromptLibrary();
   const contextActions = useMemo(
-    () => buildTaskContextActions(linkedIssue, [], promptLibrary),
+    () => buildTaskContextActions(linkedIssue, [], [], promptLibrary),
     [linkedIssue, promptLibrary]
   );
   const modelOptions = useModelOptions(state.provider);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
@@ -1,5 +1,6 @@
 import { err, type Result } from '@emdash/shared';
 import { makeAutoObservable, observable, runInAction } from 'mobx';
+import { BrowserAnnotationsStore } from '@renderer/features/browser/browser-annotations-store';
 import type { GitRepositoryStore } from '@renderer/features/projects/stores/git-repository-store';
 import { DraftCommentsStore } from '@renderer/features/tasks/diff-view/stores/draft-comments-store';
 import { rpc } from '@renderer/lib/ipc';
@@ -52,6 +53,8 @@ export class TaskStore {
   viewModel: WorkspaceViewModel | null = null;
   /** Task-lifetime store for draft code-review comments. Null while unregistered. */
   draftComments: DraftCommentsStore | null = null;
+  /** Task-lifetime store for browser annotations. Null while unregistered. */
+  browserAnnotations: BrowserAnnotationsStore | null = null;
 
   get displayName(): string {
     return this.data.name;
@@ -92,6 +95,9 @@ export class TaskStore {
     if (!this.draftComments) {
       this.draftComments = new DraftCommentsStore(taskData.id);
     }
+    if (!this.browserAnnotations) {
+      this.browserAnnotations = new BrowserAnnotationsStore(taskData.id);
+    }
     if (!this.viewModel) {
       this.viewModel = new WorkspaceViewModel(this);
     }
@@ -128,7 +134,9 @@ export class TaskStore {
     this.provisionProgressMessage = null;
 
     // Create stable stores on first registration (when transitioning from unregistered).
-    if (!this.draftComments || !this.viewModel) this.ensureRegisteredStores();
+    if (!this.draftComments || !this.browserAnnotations || !this.viewModel) {
+      this.ensureRegisteredStores();
+    }
   }
 
   transitionToDryUnprovisioned(data: Task, phase: UnprovisionedTaskPhase = 'idle'): void {
@@ -170,6 +178,8 @@ export class TaskStore {
     }
     this.draftComments?.dispose();
     this.draftComments = null;
+    this.browserAnnotations?.dispose();
+    this.browserAnnotations = null;
   }
 
   get conversationStats(): Record<string, number> {

--- a/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-manager.test.ts
@@ -14,6 +14,14 @@ vi.mock('@renderer/features/settings/app-settings-client', () => ({
   getAppSettingValueSnapshot,
 }));
 
+vi.mock('@renderer/features/tasks/acp/acp-chat-store', () => ({
+  AcpChatStore: class {},
+}));
+
+vi.mock('@renderer/features/tasks/acp/acp-chat-panel', () => ({
+  AcpChatPanel: () => null,
+}));
+
 vi.mock('@renderer/lib/ipc', () => ({
   events: { on: () => () => {} },
   rpc: {

--- a/apps/emdash-desktop/src/renderer/tests/context-actions.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/context-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildBrowserAnnotationsContextAction,
   buildDraftCommentsContextAction,
   buildIssueContextText,
   buildLinkedIssueContextAction,
@@ -7,6 +8,7 @@ import {
   buildTaskContextActions,
 } from '@renderer/features/tasks/conversations/context-actions';
 import type { DraftComment } from '@renderer/features/tasks/diff-view/stores/draft-comments-store';
+import type { BrowserAnnotation } from '@shared/browserAnnotations';
 import type { LinkedIssue } from '@shared/core/linked-issue';
 import { getDraftCommentTargetKey, type DraftCommentTarget } from '@shared/lineComments';
 
@@ -41,6 +43,29 @@ function makeDraftComment(overrides: Partial<DraftComment> = {}): DraftComment {
     lineNumber: 10,
     lineContent: 'const x = 1;',
     content: 'This looks wrong.',
+    createdAt: new Date().toISOString(),
+    updatedAt: new Date().toISOString(),
+    ...overrides,
+  };
+}
+
+function makeBrowserAnnotation(overrides: Partial<BrowserAnnotation> = {}): BrowserAnnotation {
+  return {
+    id: crypto.randomUUID(),
+    taskId: 'task-1',
+    browserId: 'browser-1',
+    kind: 'element',
+    status: 'pending',
+    comment: 'This button is hard to see.',
+    url: 'http://localhost:3000/settings',
+    title: 'Settings',
+    elementPath: 'body > main > button:nth-of-type(1)',
+    element: 'button',
+    cssClasses: 'primary',
+    nearbyText: 'Save changes',
+    x: 120,
+    y: 80,
+    boundingBox: { x: 100, y: 64, width: 180, height: 40 },
     createdAt: new Date().toISOString(),
     updatedAt: new Date().toISOString(),
     ...overrides,
@@ -166,24 +191,53 @@ describe('buildDraftCommentsContextAction', () => {
   });
 });
 
+describe('buildBrowserAnnotationsContextAction', () => {
+  it('returns null when there are no pending annotations', () => {
+    expect(buildBrowserAnnotationsContextAction([])).toBeNull();
+    expect(
+      buildBrowserAnnotationsContextAction([makeBrowserAnnotation({ status: 'dismissed' })])
+    ).toBeNull();
+  });
+
+  it('builds an action with annotationCount and pageCount for pending annotations', () => {
+    const annotations = [
+      makeBrowserAnnotation({ url: 'http://localhost:3000/a' }),
+      makeBrowserAnnotation({ url: 'http://localhost:3000/a' }),
+      makeBrowserAnnotation({ url: 'http://localhost:3000/b' }),
+      makeBrowserAnnotation({ url: 'http://localhost:3000/c', status: 'dismissed' }),
+    ];
+    const action = buildBrowserAnnotationsContextAction(annotations);
+
+    expect(action).not.toBeNull();
+    expect(action?.id).toBe('browser-annotations');
+    expect(action?.kind).toBe('browser-annotations');
+    expect(action?.annotationCount).toBe(3);
+    expect(action?.pageCount).toBe(2);
+    expect(action?.annotations).toEqual(annotations.slice(0, 3));
+  });
+});
+
 describe('buildTaskContextActions', () => {
-  it('includes linked issue context, draft comments, then prompt library actions', () => {
+  it('includes linked issue context, draft comments, browser annotations, then prompts', () => {
     const comments = [makeDraftComment()];
-    const actions = buildTaskContextActions(makeIssue(), comments, [
+    const annotations = [makeBrowserAnnotation()];
+    const actions = buildTaskContextActions(makeIssue(), comments, annotations, [
       { id: 'review-prompt', title: 'Review prompt', prompt: 'Review this worktree.' },
       { id: 'custom', title: 'Perf review', prompt: 'Look for slow paths.' },
     ]);
 
-    expect(actions).toHaveLength(4);
+    expect(actions).toHaveLength(5);
     expect(actions[0]?.id).toBe('linked-issue:github:EMD-123');
     expect(actions[1]?.id).toBe('draft-comments');
-    expect(actions[2]?.id).toBe('prompt:review-prompt');
-    expect(actions[3]?.id).toBe('prompt:custom');
+    expect(actions[2]?.id).toBe('browser-annotations');
+    expect(actions[3]?.id).toBe('prompt:review-prompt');
+    expect(actions[4]?.id).toBe('prompt:custom');
   });
 
   it('omits the linked issue action when issue is undefined', () => {
     const actions = buildTaskContextActions(
       undefined,
+      [],
       [],
       [{ id: 'p', title: 'P', prompt: 'Do it.' }]
     );
@@ -192,7 +246,7 @@ describe('buildTaskContextActions', () => {
   });
 
   it('omits the draft-comments action when comments array is empty', () => {
-    const actions = buildTaskContextActions(makeIssue(), [], []);
+    const actions = buildTaskContextActions(makeIssue(), [], [], []);
     expect(actions).toHaveLength(1);
     expect(actions[0]?.kind).toBe('linked-issue');
   });

--- a/apps/emdash-desktop/src/shared/browserAnnotations.test.ts
+++ b/apps/emdash-desktop/src/shared/browserAnnotations.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import { formatBrowserAnnotationsForAgent, type BrowserAnnotation } from './browserAnnotations';
+
+function makeAnnotation(overrides: Partial<BrowserAnnotation> = {}): BrowserAnnotation {
+  return {
+    id: 'annotation-1',
+    taskId: 'task-1',
+    browserId: 'browser-1',
+    kind: 'element',
+    status: 'pending',
+    comment: 'Make this clearer.',
+    url: 'http://localhost:3000/settings',
+    title: 'Settings',
+    elementPath: 'main > button:nth-of-type(1)',
+    element: 'button',
+    cssClasses: 'primary large',
+    nearbyText: 'Save changes',
+    selectedText: undefined,
+    x: 120,
+    y: 80,
+    boundingBox: { x: 100, y: 64, width: 180, height: 40 },
+    createdAt: '2026-06-30T00:00:00.000Z',
+    updatedAt: '2026-06-30T00:00:00.000Z',
+    ...overrides,
+  };
+}
+
+describe('formatBrowserAnnotationsForAgent', () => {
+  it('formats pending browser annotations for agent context', () => {
+    const output = formatBrowserAnnotationsForAgent([
+      makeAnnotation({ comment: 'Button overflows on mobile.' }),
+    ]);
+
+    expect(output).toContain('<browser_annotations>');
+    expect(output).toContain('kind="element"');
+    expect(output).toContain('url="http://localhost:3000/settings"');
+    expect(output).toContain('elementPath="main &gt; button:nth-of-type(1)"');
+    expect(output).toContain('<comment>Button overflows on mobile.</comment>');
+    expect(output).toContain('<nearby_text>Save changes</nearby_text>');
+  });
+
+  it('omits dismissed and sent annotations', () => {
+    const output = formatBrowserAnnotationsForAgent([
+      makeAnnotation({ status: 'dismissed' }),
+      makeAnnotation({ status: 'sent' }),
+    ]);
+
+    expect(output).toBe('');
+  });
+
+  it('escapes user and page-provided text', () => {
+    const output = formatBrowserAnnotationsForAgent([
+      makeAnnotation({
+        comment: 'Use <strong> text & spacing',
+        selectedText: '"Danger" <button>',
+        nearbyText: 'A & B',
+      }),
+    ]);
+
+    expect(output).toContain('<comment>Use &lt;strong&gt; text &amp; spacing</comment>');
+    expect(output).toContain('<selected_text>"Danger" &lt;button&gt;</selected_text>');
+    expect(output).toContain('<nearby_text>A &amp; B</nearby_text>');
+  });
+});

--- a/apps/emdash-desktop/src/shared/browserAnnotations.ts
+++ b/apps/emdash-desktop/src/shared/browserAnnotations.ts
@@ -1,0 +1,118 @@
+export type BrowserAnnotationKind = 'element' | 'text' | 'area';
+
+export type BrowserAnnotationStatus = 'pending' | 'sent' | 'dismissed';
+
+export type BrowserAnnotationBoundingBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type BrowserAnnotationTarget = {
+  kind: BrowserAnnotationKind;
+  url: string;
+  title?: string;
+  elementPath: string;
+  element: string;
+  cssClasses?: string;
+  nearbyText?: string;
+  selectedText?: string;
+  x: number;
+  y: number;
+  boundingBox: BrowserAnnotationBoundingBox;
+};
+
+export type BrowserAnnotation = BrowserAnnotationTarget & {
+  id: string;
+  taskId: string;
+  browserId: string;
+  status: BrowserAnnotationStatus;
+  comment: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+type FormatOptions = {
+  includeIntro?: boolean;
+  leadingNewline?: boolean;
+};
+
+function escapeXmlText(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+}
+
+function escapeXmlAttribute(value: string | number): string {
+  return String(value)
+    .replaceAll('&', '&amp;')
+    .replaceAll('"', '&quot;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function optionalAttribute(name: string, value: string | number | undefined): string {
+  if (value === undefined || value === '') return '';
+  return ` ${name}="${escapeXmlAttribute(value)}"`;
+}
+
+function annotationAttributes(annotation: BrowserAnnotation): string {
+  const { boundingBox } = annotation;
+  return [
+    `id="${escapeXmlAttribute(annotation.id)}"`,
+    `kind="${escapeXmlAttribute(annotation.kind)}"`,
+    `status="${escapeXmlAttribute(annotation.status)}"`,
+    `url="${escapeXmlAttribute(annotation.url)}"`,
+    optionalAttribute('title', annotation.title),
+    `elementPath="${escapeXmlAttribute(annotation.elementPath)}"`,
+    `element="${escapeXmlAttribute(annotation.element)}"`,
+    optionalAttribute('cssClasses', annotation.cssClasses),
+    `x="${escapeXmlAttribute(annotation.x)}"`,
+    `y="${escapeXmlAttribute(annotation.y)}"`,
+    `box="${escapeXmlAttribute(
+      `${boundingBox.x},${boundingBox.y},${boundingBox.width},${boundingBox.height}`
+    )}"`,
+  ]
+    .filter(Boolean)
+    .join(' ');
+}
+
+function annotationBlock(annotation: BrowserAnnotation): string {
+  const selectedText = annotation.selectedText
+    ? `\n    <selected_text>${escapeXmlText(annotation.selectedText)}</selected_text>`
+    : '';
+  const nearbyText = annotation.nearbyText
+    ? `\n    <nearby_text>${escapeXmlText(annotation.nearbyText)}</nearby_text>`
+    : '';
+
+  return `  <annotation ${annotationAttributes(annotation)}>
+    <comment>${escapeXmlText(annotation.comment)}</comment>${selectedText}${nearbyText}
+  </annotation>`;
+}
+
+const ANNOTATIONS_WRAPPER = (
+  blocks: string[]
+) => `The user has left the following annotations on rendered browser pages:
+
+<browser_annotations>
+${blocks.join('\n')}
+</browser_annotations>`;
+
+export function formatBrowserAnnotationsForAgent(
+  annotations: BrowserAnnotation[],
+  { includeIntro = false, leadingNewline = false }: FormatOptions = {}
+): string {
+  const pending = annotations.filter((annotation) => annotation.status === 'pending');
+  if (!pending.length) return '';
+
+  const prefix = leadingNewline ? '\n' : '';
+  const blocks = pending
+    .slice()
+    .sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+    .map(annotationBlock);
+
+  if (includeIntro) {
+    return `${prefix}${ANNOTATIONS_WRAPPER(blocks)}`;
+  }
+
+  return `${prefix}<browser_annotations>\n${blocks.join('\n')}\n</browser_annotations>`;
+}

--- a/apps/emdash-desktop/src/shared/telemetry.ts
+++ b/apps/emdash-desktop/src/shared/telemetry.ts
@@ -111,6 +111,19 @@ export type TelemetryEventProperties = {
   terminal_created: { terminal_id: string };
   terminal_deleted: { terminal_id: string };
 
+  browser_annotation_mode_toggled: { enabled: boolean; pending_count: number };
+  browser_annotation_created: {
+    kind: 'element' | 'text' | 'area';
+    pending_count: number;
+    has_selected_text: boolean;
+  };
+  browser_annotations_assigned: {
+    annotation_count: number;
+    page_count: number;
+    and_send: boolean;
+    provider: AgentProviderId | null;
+  };
+
   pr_created: { is_draft: boolean };
   pr_creation_failed: { error_type: string };
   pr_merged: {

--- a/packages/core/vitest.config.ts
+++ b/packages/core/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+  },
+});

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+  },
+});

--- a/packages/ui/vitest.config.ts
+++ b/packages/ui/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['**/*.test.ts'],
+  },
+});


### PR DESCRIPTION
## Summary
- add task-scoped browser annotation capture, storage, overlay UI, and toolbar controls
- add browser annotation context actions that paste into the active terminal and optionally submit
- add shared annotation formatting plus focused tests for capture, store, toolbar, context action, and terminal assignment behavior
- add local package Vitest configs and test isolation fixes needed for the suite to run from this worktree

## Validation
- pnpm run format: passed
- pnpm run lint: passed with existing warnings
- pnpm run typecheck: passed
- focused annotation tests: passed, 7 files / 31 tests
- pnpm run test: app/package tests pass except browser-project startup on this host; fallback Chromium installs with PLAYWRIGHT_HOST_PLATFORM_OVERRIDE=ubuntu24.04-x64 but cannot launch because sudo-only system libraries such as libatk-1.0.so.0 and X11/GTK/audio dependencies are missing

## Notes
- Computed styles are intentionally left out of v1.
- Annotation assignment reuses the existing task context and PTY prompt-injection path rather than adding a parallel send flow.