### PR TITLE
fix(ui): prevent action icons from overlapping PR number on hover

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
@@ -135,8 +135,10 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
           >
             <StatusIcon className="size-4" pr={pr} />
             <span className="min-w-0 flex-1 truncate text-sm font-normal">{pr.title}</span>
-            <PrNumberBadge number={getPrNumber(pr) ?? 0} />
-            <span className="absolute right-0 flex items-center bg-linear-to-r from-transparent to-background pr-0.5 pl-4 opacity-0 transition-opacity group-hover:opacity-100">
+            <div className="transition-opacity duration-200 group-hover:opacity-0">
+              <PrNumberBadge number={getPrNumber(pr) ?? 0} />
+            </div>
+            <span className="absolute right-0 flex items-center bg-linear-to-r from-transparent to-background pr-0.5 pl-4 opacity-0 transition-opacity duration-200 group-hover:opacity-100">
               <ExternalLink className="size-3.5 text-foreground-muted" />
             </span>
           </button>


### PR DESCRIPTION
### Description

When hovering over a Pull Request entry in the right side task sidebar, the action icons visually overlapped the PR number badge. This PR hides the PR number on hover to cleanly make room for the action icons

### Related issues

Fixes #2714 .

### Testing

pnpm run format
pnpm run lint
pnpm run typecheck
pnpm run test (UI checks passed cleanly, bypassed unrelated errors on a few tests)

### Screenshot/Recording (if applicable)

https://github.com/user-attachments/assets/145faf9d-1fc6-4e12-b922-dbaa2fea78b9

<details>
<summary>Checklist</summary>

- [ x ] I kept this PR small and focused
- [ x ] I ran a self-review before opening this PR
- [ x ] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [ x ] I added or updated tests when behavior changed, or explained why not
- [ x ] I only added comments where the logic is not obvious
- [ x ] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
