### PR TITLE
fix(tasks): remove duplicate chevron in Default Model select

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -1,4 +1,4 @@
-import { CheckCheckIcon, ChevronDownIcon, PlusIcon, X } from 'lucide-react';
+import { CheckCheckIcon, PlusIcon, X } from 'lucide-react';
 import { useEffect, useMemo, useState, type Dispatch, type SetStateAction } from 'react';
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
@@ -256,7 +256,6 @@ export function InitialConversationField({
                       ? (modelOptions[state.model]?.name ?? state.model)
                       : 'Default model'}
                   </SelectValue>
-                  <ChevronDownIcon className="size-3 opacity-60" />
                 </SelectTrigger>
                 <SelectContent className="min-w-40">
                   <SelectItem value="">Default model</SelectItem>


### PR DESCRIPTION
## Summary

The Create Task modal's **Default Model** select rendered a double chevron. `SelectTrigger` already renders a built-in chevron (its `showChevron` prop defaults to `true`), but the code also manually added a `<ChevronDownIcon>`, producing two chevrons.

This removes the manual `ChevronDownIcon` (and its now-unused import) so only the single built-in chevron renders, matching the other selects in the app (e.g. `pr-selector.tsx`, `issue-selector.tsx`).

## Changes

- Remove the manual `<ChevronDownIcon>` from the Default Model `SelectTrigger` in `initial-conversation-section.tsx`.
- Drop the unused `ChevronDownIcon` import.

## Linear

Fixes ENG-1701