### PR TITLE
fix(issue-selector): align provider logo

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/issue-selector/issue-selector.tsx
@@ -71,7 +71,7 @@ export function ProviderLogo({
         className ?? 'h-3.5 w-3.5'
       )}
     >
-      <Icon className="size-[90%]" />
+      <Icon className="size-full" />
     </span>
   );
 }


### PR DESCRIPTION
### Description
- make provider logos fill their container in the issue selector header 

### Screenshot/Recording (if applicable)
just before:
<img width="114" height="33" alt="image" src="https://github.com/user-attachments/assets/6670ed3d-6b8c-48d8-9d11-78ae01adfa33" />

before vs after:
<img width="499" height="74" alt="image" src="https://github.com/user-attachments/assets/ab25cac9-4caf-47ce-a8d3-ae4c96f0f94c" />

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
