### PR TITLE
fix(codex): update model selector

### DIFF
--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -48,7 +48,7 @@ export const plugin = definePlugin(
         'gpt-5.3-codex-spark': {
           name: 'GPT-5.3 Codex Spark',
           description: 'Research-preview Codex model optimized for near-instant iteration.',
-          modelFeatures: { intelligence: 4, speed: 5 },
+          modelFeatures: { intelligence: 2, speed: 5 },
         },
       },
     },

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -35,17 +35,20 @@ export const plugin = definePlugin(
     models: {
       kind: 'selectable',
       modelOptions: {
-        'codex-mini-latest': {
-          name: 'Codex Mini',
-          modelFeatures: { intelligence: 3, speed: 5 },
+        'gpt-5.5': {
+          name: 'GPT-5.5',
+          description: 'Recommended Codex model for complex coding and agentic workflows.',
+          modelFeatures: { intelligence: 5, speed: 3 },
         },
-        'o4-mini': {
-          name: 'o4-mini',
-          modelFeatures: { intelligence: 4, speed: 4 },
+        'gpt-5.4-mini': {
+          name: 'GPT-5.4 Mini',
+          description: 'Faster Codex model for lighter coding tasks and subagents.',
+          modelFeatures: { intelligence: 4, speed: 5 },
         },
-        o3: {
-          name: 'o3',
-          modelFeatures: { intelligence: 5, speed: 2 },
+        'gpt-5.3-codex-spark': {
+          name: 'GPT-5.3 Codex Spark',
+          description: 'Research-preview Codex model optimized for near-instant iteration.',
+          modelFeatures: { intelligence: 4, speed: 5 },
         },
       },
     },

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -144,24 +144,6 @@ describe('pluginRegistry', () => {
     });
   });
 
-  it('exposes current Codex models instead of deprecated o-series defaults', () => {
-    const codex = pluginRegistry.get('codex')!;
-
-    expect(codex.capabilities.models).toMatchObject({
-      kind: 'selectable',
-      modelOptions: {
-        'gpt-5.5': { name: 'GPT-5.5' },
-        'gpt-5.4-mini': { name: 'GPT-5.4 Mini' },
-        'gpt-5.3-codex-spark': { name: 'GPT-5.3 Codex Spark' },
-      },
-    });
-    expect(codex.capabilities.models.kind).toBe('selectable');
-    if (codex.capabilities.models.kind !== 'selectable') return;
-    expect(codex.capabilities.models.modelOptions).not.toHaveProperty('codex-mini-latest');
-    expect(codex.capabilities.models.modelOptions).not.toHaveProperty('o4-mini');
-    expect(codex.capabilities.models.modelOptions).not.toHaveProperty('o3');
-  });
-
   it('uses current Grok docs, npm release source, Windows install, and model flag', () => {
     const grok = pluginRegistry.get('grok')!;
 

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -144,6 +144,24 @@ describe('pluginRegistry', () => {
     });
   });
 
+  it('exposes current Codex models instead of deprecated o-series defaults', () => {
+    const codex = pluginRegistry.get('codex')!;
+
+    expect(codex.capabilities.models).toMatchObject({
+      kind: 'selectable',
+      modelOptions: {
+        'gpt-5.5': { name: 'GPT-5.5' },
+        'gpt-5.4-mini': { name: 'GPT-5.4 Mini' },
+        'gpt-5.3-codex-spark': { name: 'GPT-5.3 Codex Spark' },
+      },
+    });
+    expect(codex.capabilities.models.kind).toBe('selectable');
+    if (codex.capabilities.models.kind !== 'selectable') return;
+    expect(codex.capabilities.models.modelOptions).not.toHaveProperty('codex-mini-latest');
+    expect(codex.capabilities.models.modelOptions).not.toHaveProperty('o4-mini');
+    expect(codex.capabilities.models.modelOptions).not.toHaveProperty('o3');
+  });
+
   it('uses current Grok docs, npm release source, Windows install, and model flag', () => {
     const grok = pluginRegistry.get('grok')!;
 


### PR DESCRIPTION
### Description
- update codex model selector to current models
- remove old/deprecated models: codex-mini-latest,o4-mini,o3
- new options: gpt-5.5,gpt-5.4-mini,gpt-5.3-codex-spark

### Screenshot/Recording (if applicable)
https://cap.link/65tkx6y8n2e4pzg

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
