### PR TITLE
fix(ssh): clarify duplicate connection errors

### DIFF
--- a/apps/emdash-desktop/src/main/core/ssh/controller.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/controller.db.test.ts
@@ -62,7 +62,7 @@ async function insertRemoteWorkspace(db: AppDb): Promise<void> {
   });
 }
 
-describe('sshController.deleteConnection', () => {
+describe('sshController', () => {
   let fixture: Awaited<ReturnType<typeof openFixture>>;
 
   beforeEach(async () => {
@@ -78,6 +78,39 @@ describe('sshController.deleteConnection', () => {
   afterEach(() => {
     fixture.close();
     mocks.db = undefined;
+  });
+
+  it('rejects duplicate connection names with a user-facing error', async () => {
+    await insertSshConnection(fixture.db);
+
+    await expect(
+      sshController.saveConnection({
+        name: 'Existing SSH',
+        host: 'other.example.com',
+        port: 22,
+        username: 'jona',
+        authType: 'agent',
+        useAgent: true,
+      })
+    ).rejects.toThrow(
+      'An SSH connection named “Existing SSH” already exists. Choose a different name.'
+    );
+  });
+
+  it('allows saving an existing connection without renaming it', async () => {
+    await insertSshConnection(fixture.db);
+
+    await expect(
+      sshController.saveConnection({
+        id: 'ssh-1',
+        name: 'Existing SSH',
+        host: 'example.org',
+        port: 22,
+        username: 'jona',
+        authType: 'agent',
+        useAgent: true,
+      })
+    ).resolves.toMatchObject({ id: 'ssh-1', name: 'Existing SSH', host: 'example.org' });
   });
 
   it('deletes an unused connection even when an orphan workspace still references it', async () => {

--- a/apps/emdash-desktop/src/main/core/ssh/controller.ts
+++ b/apps/emdash-desktop/src/main/core/ssh/controller.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from 'node:crypto';
-import { eq } from 'drizzle-orm';
+import { and, eq, ne } from 'drizzle-orm';
 import { db } from '@main/db/client';
 import {
   projects,
@@ -82,6 +82,21 @@ export const sshController = createRPCController({
       Omit<SshConfig, 'id'> & { password?: string; passphrase?: string }
   ): Promise<SshConfig> => {
     const connectionId = config.id ?? randomUUID();
+    const existingConnectionWithName = await db
+      .select({ id: sshConnectionsTable.id })
+      .from(sshConnectionsTable)
+      .where(
+        config.id
+          ? and(eq(sshConnectionsTable.name, config.name), ne(sshConnectionsTable.id, connectionId))
+          : eq(sshConnectionsTable.name, config.name)
+      )
+      .limit(1);
+
+    if (existingConnectionWithName.length > 0) {
+      throw new Error(
+        `An SSH connection named “${config.name}” already exists. Choose a different name.`
+      );
+    }
 
     // Only update stored credentials when a non-empty value is provided.
     // On edits, leaving a field blank means "keep the existing credential".

--- a/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -130,6 +130,12 @@ export function AddSshConnModal({
     initialConfig?.sshConfigAlias ?? ''
   );
 
+  const findDuplicateConnection = (name: string) =>
+    sshConnections.connections.find(
+      (connection) =>
+        connection.name === name && (!initialConfig || connection.id !== initialConfig.id)
+    );
+
   const form = useForm({
     defaultValues: {
       name: initialConfig?.name ?? '',
@@ -152,11 +158,7 @@ export function AddSshConnModal({
     onSubmit: async ({ value }) => {
       setIsSubmitting(true);
       try {
-        const duplicateConnection = sshConnections.connections.find(
-          (connection) =>
-            connection.name === value.name && (!initialConfig || connection.id !== initialConfig.id)
-        );
-        if (duplicateConnection) {
+        if (findDuplicateConnection(value.name)) {
           setTestState('idle');
           setTestResult(null);
           return;
@@ -329,19 +331,18 @@ export function AddSshConnModal({
                 Cancel
               </Button>
             )}
-            <form.Subscribe selector={(state) => state.values.name}>
-              {(name) => {
-                const duplicateConnection = sshConnections.connections.find(
-                  (connection) =>
-                    connection.name === name &&
-                    (!initialConfig || connection.id !== initialConfig.id)
-                );
-
+            <form.Subscribe
+              selector={(state) => ({
+                canSubmit: state.canSubmit,
+                name: state.values.name,
+              })}
+            >
+              {({ canSubmit, name }) => {
                 return (
                   <ConfirmButton
                     type="submit"
                     form="add-ssh-conn-form"
-                    disabled={isSubmitting || !!duplicateConnection}
+                    disabled={isSubmitting || !canSubmit || !!findDuplicateConnection(name)}
                   >
                     {isSubmitting ? (
                       <>
@@ -372,12 +373,7 @@ export function AddSshConnModal({
               {/* Connection name */}
               <form.Field name="name">
                 {(field) => {
-                  const duplicateConnection = sshConnections.connections.find(
-                    (connection) =>
-                      connection.name === field.state.value &&
-                      (!initialConfig || connection.id !== initialConfig.id)
-                  );
-                  const isDuplicate = field.state.meta.isTouched && !!duplicateConnection;
+                  const isDuplicate = !!findDuplicateConnection(field.state.value);
                   const isInvalid =
                     (field.state.meta.isTouched && !field.state.meta.isValid) || isDuplicate;
                   return (

--- a/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -55,13 +55,15 @@ export interface AddSshConnModalProps extends BaseModalProps<{ connectionId: str
 type TestState = 'idle' | 'testing' | 'success' | 'error';
 const MANUAL_CONNECTION_VALUE = '__manual__';
 const EMPTY_SSH_CONFIG_HOSTS: SshConfigHost[] = [];
+const DUPLICATE_CONNECTION_NAME_ERROR =
+  'An SSH connection with this name already exists. Choose a different name.';
 
 function formatSshConnectionError(error: unknown): string {
   const message = error instanceof Error ? error.message : String(error);
   const withoutIpcPrefix = message.replace(/^Error invoking remote method 'ssh\.[^']+':\s*/, '');
 
   if (/UNIQUE constraint failed: ssh_connections\.name/.test(withoutIpcPrefix)) {
-    return 'An SSH connection with this name already exists. Choose a different name.';
+    return DUPLICATE_CONNECTION_NAME_ERROR;
   }
 
   return withoutIpcPrefix;
@@ -155,11 +157,8 @@ export function AddSshConnModal({
             connection.name === value.name && (!initialConfig || connection.id !== initialConfig.id)
         );
         if (duplicateConnection) {
-          setTestState('error');
-          setTestResult({
-            success: false,
-            error: 'An SSH connection with this name already exists. Choose a different name.',
-          });
+          setTestState('idle');
+          setTestResult(null);
           return;
         }
 
@@ -330,16 +329,32 @@ export function AddSshConnModal({
                 Cancel
               </Button>
             )}
-            <ConfirmButton type="submit" form="add-ssh-conn-form" disabled={isSubmitting}>
-              {isSubmitting ? (
-                <>
-                  <LoaderCircle className="size-4 animate-spin" />
-                  Saving…
-                </>
-              ) : (
-                'Save'
-              )}
-            </ConfirmButton>
+            <form.Subscribe selector={(state) => state.values.name}>
+              {(name) => {
+                const duplicateConnection = sshConnections.connections.find(
+                  (connection) =>
+                    connection.name === name &&
+                    (!initialConfig || connection.id !== initialConfig.id)
+                );
+
+                return (
+                  <ConfirmButton
+                    type="submit"
+                    form="add-ssh-conn-form"
+                    disabled={isSubmitting || !!duplicateConnection}
+                  >
+                    {isSubmitting ? (
+                      <>
+                        <LoaderCircle className="size-4 animate-spin" />
+                        Saving…
+                      </>
+                    ) : (
+                      'Save'
+                    )}
+                  </ConfirmButton>
+                );
+              }}
+            </form.Subscribe>
           </div>
         </DialogFooter>
       }
@@ -380,11 +395,7 @@ export function AddSshConnModal({
                       {field.state.meta.isTouched && !field.state.meta.isValid && (
                         <FieldError errors={field.state.meta.errors} />
                       )}
-                      {isDuplicate && (
-                        <FieldError>
-                          An SSH connection with this name already exists. Choose a different name.
-                        </FieldError>
-                      )}
+                      {isDuplicate && <FieldError>{DUPLICATE_CONNECTION_NAME_ERROR}</FieldError>}
                     </Field>
                   );
                 }}

--- a/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/add-ssh-conn-modal.tsx
@@ -56,6 +56,17 @@ type TestState = 'idle' | 'testing' | 'success' | 'error';
 const MANUAL_CONNECTION_VALUE = '__manual__';
 const EMPTY_SSH_CONFIG_HOSTS: SshConfigHost[] = [];
 
+function formatSshConnectionError(error: unknown): string {
+  const message = error instanceof Error ? error.message : String(error);
+  const withoutIpcPrefix = message.replace(/^Error invoking remote method 'ssh\.[^']+':\s*/, '');
+
+  if (/UNIQUE constraint failed: ssh_connections\.name/.test(withoutIpcPrefix)) {
+    return 'An SSH connection with this name already exists. Choose a different name.';
+  }
+
+  return withoutIpcPrefix;
+}
+
 function FieldInfoTooltip({ label, children }: { label: string; children: ReactNode }) {
   return (
     <Tooltip>
@@ -139,6 +150,19 @@ export function AddSshConnModal({
     onSubmit: async ({ value }) => {
       setIsSubmitting(true);
       try {
+        const duplicateConnection = sshConnections.connections.find(
+          (connection) =>
+            connection.name === value.name && (!initialConfig || connection.id !== initialConfig.id)
+        );
+        if (duplicateConnection) {
+          setTestState('error');
+          setTestResult({
+            success: false,
+            error: 'An SSH connection with this name already exists. Choose a different name.',
+          });
+          return;
+        }
+
         const isAliasBacked = value.sshConfigAlias.trim().length > 0;
         const proxyJump = value.proxyJump.trim();
         const username = value.username || value.sshConfigAlias || value.host;
@@ -164,7 +188,7 @@ export function AddSshConnModal({
         onSuccess({ connectionId: saved.id });
       } catch (err) {
         setTestState('error');
-        setTestResult({ success: false, error: err instanceof Error ? err.message : String(err) });
+        setTestResult({ success: false, error: formatSshConnectionError(err) });
       } finally {
         setIsSubmitting(false);
       }
@@ -262,7 +286,7 @@ export function AddSshConnModal({
       setTestState(result.success ? 'success' : 'error');
     } catch (err) {
       setTestState('error');
-      setTestResult({ success: false, error: String(err) });
+      setTestResult({ success: false, error: formatSshConnectionError(err) });
     }
   };
 
@@ -333,7 +357,14 @@ export function AddSshConnModal({
               {/* Connection name */}
               <form.Field name="name">
                 {(field) => {
-                  const isInvalid = field.state.meta.isTouched && !field.state.meta.isValid;
+                  const duplicateConnection = sshConnections.connections.find(
+                    (connection) =>
+                      connection.name === field.state.value &&
+                      (!initialConfig || connection.id !== initialConfig.id)
+                  );
+                  const isDuplicate = field.state.meta.isTouched && !!duplicateConnection;
+                  const isInvalid =
+                    (field.state.meta.isTouched && !field.state.meta.isValid) || isDuplicate;
                   return (
                     <Field data-invalid={isInvalid}>
                       <FieldLabel htmlFor={field.name}>Connection Name</FieldLabel>
@@ -346,7 +377,14 @@ export function AddSshConnModal({
                         aria-invalid={isInvalid}
                         placeholder="My Server"
                       />
-                      {isInvalid && <FieldError errors={field.state.meta.errors} />}
+                      {field.state.meta.isTouched && !field.state.meta.isValid && (
+                        <FieldError errors={field.state.meta.errors} />
+                      )}
+                      {isDuplicate && (
+                        <FieldError>
+                          An SSH connection with this name already exists. Choose a different name.
+                        </FieldError>
+                      )}
                     </Field>
                   );
                 }}


### PR DESCRIPTION
### Description
- clarifies duplicate ssh connection errors
- blocks saving duplicate connection names

### Screenshot/Recording (if applicable)
https://cap.link/b1xa9ta279attrr

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
