### PR TITLE
fix(droid): support auto-approve flag

### DIFF
--- a/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
@@ -295,6 +295,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     commands: ['droid'],
     versionArgs: ['--version'],
     cli: 'droid',
+    autoApproveFlag: '--auto high',
     initialPromptFlag: '',
     resumeFlag: '--resume',
     /** Value is unused; presence signals that the session ID is passed as an argument to resumeFlag. */

--- a/packages/plugins/src/agents/impl/droid/index.test.ts
+++ b/packages/plugins/src/agents/impl/droid/index.test.ts
@@ -49,4 +49,20 @@ describe('droid provider', () => {
 
     expect(command.args).toEqual(['--resume', '31477a03-961a-4451-82d4-efded56947fc']);
   });
+
+  it('passes --auto high on resume when auto-approve is enabled', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      autoApprove: true,
+      providerSessionId: '31477a03-961a-4451-82d4-efded56947fc',
+      isResuming: true,
+    });
+
+    expect(command.args).toEqual([
+      '--resume',
+      '31477a03-961a-4451-82d4-efded56947fc',
+      '--auto',
+      'high',
+    ]);
+  });
 });

--- a/packages/plugins/src/agents/impl/droid/index.test.ts
+++ b/packages/plugins/src/agents/impl/droid/index.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'droid',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-session-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+describe('droid provider', () => {
+  it('advertises auto-approve support', () => {
+    expect(provider.capabilities.autoApprove).toEqual({ kind: 'supported' });
+  });
+
+  it('passes --auto high when auto-approve is enabled', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+    });
+
+    expect(command).toEqual({
+      command: 'droid',
+      args: ['--auto', 'high', 'Fix the bug'],
+      env: {},
+    });
+  });
+
+  it('omits the autonomy flag when auto-approve is disabled', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      initialPrompt: 'Fix the bug',
+    });
+
+    expect(command.args).not.toContain('--auto');
+    expect(command.args).toEqual(['Fix the bug']);
+  });
+
+  it('resumes a stored provider session id with --resume', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      providerSessionId: '31477a03-961a-4451-82d4-efded56947fc',
+      isResuming: true,
+    });
+
+    expect(command.args).toEqual(['--resume', '31477a03-961a-4451-82d4-efded56947fc']);
+  });
+});

--- a/packages/plugins/src/agents/impl/droid/index.ts
+++ b/packages/plugins/src/agents/impl/droid/index.ts
@@ -15,6 +15,9 @@ export const plugin = definePlugin(
     websiteUrl: 'https://docs.factory.ai/cli/getting-started/quickstart',
   },
   {
+    autoApprove: {
+      kind: 'supported',
+    },
     hooks: {
       kind: 'config',
       scope: 'workspace',
@@ -67,6 +70,10 @@ export const provider = registerPluginBehavior(plugin, {
   prompt: {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
+        // Interactive `droid` only exposes `--auto <level>`; `--skip-permissions-unsafe`
+        // is exclusive to `droid exec`. `high` grants the broadest autonomy the
+        // interactive TUI supports (edits, installs, git push, deploys).
+        autoApproveFlag: '--auto high',
         initialPromptFlag: '',
         resumeFlag: '--resume',
         sessionIdFlag: '--resume',


### PR DESCRIPTION
### Description
- add droid auto-approve support
- use `--auto high` for tui sessions

### Screenshot/Recording (if applicable)
https://cap.link/gv913a0e490593x

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
