### PR TITLE
feat(diff): add a Session / Last turn scope toggle to the changes panel (#1635)

### DIFF
--- a/apps/emdash-desktop/src/main/core/git/last-turn-baseline-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/git/last-turn-baseline-service.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const h = vi.hoisted(() => ({
+  inputHandler: null as
+    | ((p: {
+        projectId: string;
+        taskId: string;
+        conversationId: string;
+        providerId: string;
+      }) => Promise<void>)
+    | null,
+  teardownHandler: null as ((p: { workspaceId: string }) => void) | null,
+  getWorkspaceId: vi.fn(),
+  resolveWorkspace: vi.fn(),
+  emit: vi.fn(),
+  snapshotWorktreeTree: vi.fn(),
+}));
+
+vi.mock('@main/core/conversations/conversation-events', () => ({
+  conversationEvents: {
+    on: (name: string, handler: unknown) => {
+      if (name === 'conversation:input-submitted') h.inputHandler = handler as never;
+      return () => {};
+    },
+  },
+}));
+
+vi.mock('@main/core/tasks/task-session-manager', () => ({
+  taskSessionManager: {
+    getWorkspaceId: h.getWorkspaceId,
+    hooks: {
+      on: (name: string, handler: unknown) => {
+        if (name === 'task:torn-down') h.teardownHandler = handler as never;
+        return () => {};
+      },
+    },
+  },
+}));
+
+vi.mock('@main/core/projects/utils', () => ({ resolveWorkspace: h.resolveWorkspace }));
+vi.mock('@main/lib/events', () => ({ events: { emit: h.emit } }));
+
+import { lastTurnBaselineService } from './last-turn-baseline-service';
+
+function submitPrompt(taskId = 't-1', projectId = 'p-1') {
+  return h.inputHandler!({ projectId, taskId, conversationId: 'c-1', providerId: 'claude' });
+}
+
+function mockWorkspace(oid: string) {
+  h.getWorkspaceId.mockReturnValue('ws-1');
+  h.snapshotWorktreeTree.mockResolvedValue(oid);
+  h.resolveWorkspace.mockReturnValue({
+    gitWorktree: { snapshotWorktreeTree: h.snapshotWorktreeTree },
+  });
+}
+
+describe('LastTurnBaselineService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    lastTurnBaselineService.initialize();
+  });
+
+  afterEach(() => {
+    lastTurnBaselineService.dispose();
+  });
+
+  it('has no baseline before any turn', () => {
+    expect(lastTurnBaselineService.getBaseline('ws-1')).toBeUndefined();
+  });
+
+  it('captures a worktree snapshot on input-submitted, stores it, and emits', async () => {
+    mockWorkspace('tree-abc');
+
+    await submitPrompt();
+
+    expect(h.getWorkspaceId).toHaveBeenCalledWith('t-1');
+    expect(h.resolveWorkspace).toHaveBeenCalledWith('p-1', 'ws-1');
+    expect(lastTurnBaselineService.getBaseline('ws-1')).toBe('tree-abc');
+    expect(h.emit).toHaveBeenCalledWith(expect.anything(), {
+      projectId: 'p-1',
+      workspaceId: 'ws-1',
+    });
+  });
+
+  it('overwrites the baseline on each new turn', async () => {
+    mockWorkspace('tree-1');
+    await submitPrompt();
+    h.snapshotWorktreeTree.mockResolvedValue('tree-2');
+    await submitPrompt();
+    expect(lastTurnBaselineService.getBaseline('ws-1')).toBe('tree-2');
+  });
+
+  it('ignores turns whose task has no workspace', async () => {
+    h.getWorkspaceId.mockReturnValue(undefined);
+    await submitPrompt('t-x');
+    expect(h.resolveWorkspace).not.toHaveBeenCalled();
+    expect(lastTurnBaselineService.getBaseline('ws-1')).toBeUndefined();
+  });
+
+  it('clears a workspace baseline when its task is torn down', async () => {
+    mockWorkspace('tree-abc');
+    await submitPrompt();
+    expect(lastTurnBaselineService.getBaseline('ws-1')).toBe('tree-abc');
+
+    h.teardownHandler!({ workspaceId: 'ws-1' });
+    expect(lastTurnBaselineService.getBaseline('ws-1')).toBeUndefined();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/git/last-turn-baseline-service.ts
+++ b/apps/emdash-desktop/src/main/core/git/last-turn-baseline-service.ts
@@ -1,0 +1,71 @@
+import { conversationEvents } from '@main/core/conversations/conversation-events';
+import { resolveWorkspace } from '@main/core/projects/utils';
+import { taskSessionManager } from '@main/core/tasks/task-session-manager';
+import { events } from '@main/lib/events';
+import { log } from '@main/lib/logger';
+import { lastTurnBaselineChannel } from '@shared/core/git/events';
+
+/**
+ * Tracks a per-workspace git tree snapshot captured at the start of each agent turn, so the
+ * diff view can show only what the most recent turn changed (#1635).
+ *
+ * The baseline is the worktree state at the moment the user submitted the latest prompt,
+ * captured on the provider-agnostic `conversation:input-submitted` event (fires for both ACP
+ * and PTY agents). "Last turn diff" is then the diff between that snapshot and the current
+ * worktree.
+ *
+ * In-memory on purpose: the snapshot is a dangling git tree that `git gc` could prune between
+ * sessions, and the value is only meaningful for the current, most-recent turn. It resets on
+ * restart and is re-captured on the next prompt.
+ */
+class LastTurnBaselineService {
+  private readonly baselines = new Map<string, string>();
+  private unsubscribeInput: (() => void) | null = null;
+  private unsubscribeTeardown: (() => void) | null = null;
+
+  initialize(): void {
+    // Returns the capture promise (the hook runs it in the background); `capture` handles
+    // its own errors, so it never rejects.
+    this.unsubscribeInput = conversationEvents.on(
+      'conversation:input-submitted',
+      ({ projectId, taskId }) => this.capture(projectId, taskId)
+    );
+    // Drop a workspace's baseline once its task is torn down so the map does not grow.
+    this.unsubscribeTeardown = taskSessionManager.hooks.on('task:torn-down', ({ workspaceId }) => {
+      this.baselines.delete(workspaceId);
+    });
+  }
+
+  dispose(): void {
+    this.unsubscribeInput?.();
+    this.unsubscribeTeardown?.();
+    this.unsubscribeInput = null;
+    this.unsubscribeTeardown = null;
+    this.baselines.clear();
+  }
+
+  /** The tree oid snapshotted at the start of the most recent turn, if any. */
+  getBaseline(workspaceId: string): string | undefined {
+    return this.baselines.get(workspaceId);
+  }
+
+  private async capture(projectId: string, taskId: string): Promise<void> {
+    const workspaceId = taskSessionManager.getWorkspaceId(taskId);
+    if (!workspaceId) return;
+    const workspace = resolveWorkspace(projectId, workspaceId);
+    if (!workspace) return;
+    try {
+      const treeOid = await workspace.gitWorktree.snapshotWorktreeTree();
+      this.baselines.set(workspaceId, treeOid);
+      events.emit(lastTurnBaselineChannel, { projectId, workspaceId });
+    } catch (error) {
+      log.warn('LastTurnBaselineService: worktree snapshot failed', {
+        taskId,
+        workspaceId,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+}
+
+export const lastTurnBaselineService = new LastTurnBaselineService();

--- a/apps/emdash-desktop/src/main/core/git/worktree/controller.ts
+++ b/apps/emdash-desktop/src/main/core/git/worktree/controller.ts
@@ -1,5 +1,6 @@
 import { gitErrorMessage, type DiffTarget, type GitObjectRef } from '@emdash/core/git';
 import { err, ok } from '@emdash/shared';
+import { lastTurnBaselineService } from '@main/core/git/last-turn-baseline-service';
 import { resolveWorkspace } from '@main/core/projects/utils';
 import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
@@ -33,6 +34,27 @@ export const gitWorktreeController = createRPCController({
       return ok({ changes: await workspace.gitWorktree.getChangedFiles(base) });
     } catch (error) {
       log.error('gitCtrl.getChangedFiles failed', { projectId, workspaceId, base, error });
+      return err({ type: 'git_error' as const, message: gitErrorMessage(error) });
+    }
+  },
+
+  /**
+   * Files changed during the most recent agent turn: the diff between the worktree snapshot
+   * captured at the start of that turn and the current worktree (#1635). Returns
+   * `{ baseline: null }` when no turn has been captured yet (e.g. before the first prompt or
+   * after a restart), so the renderer can fall back to the session diff.
+   */
+  getLastTurnChanges: async (projectId: string, workspaceId: string) => {
+    try {
+      const baseTree = lastTurnBaselineService.getBaseline(workspaceId);
+      if (!baseTree) return ok({ baseline: null });
+      const workspace = resolveWorkspace(projectId, workspaceId);
+      if (!workspace) return err({ type: 'not_found' as const });
+      const headTree = await workspace.gitWorktree.snapshotWorktreeTree();
+      const changes = await workspace.gitWorktree.getChangedFilesBetweenTrees(baseTree, headTree);
+      return ok({ baseline: { baseTree, changes } });
+    } catch (error) {
+      log.error('gitCtrl.getLastTurnChanges failed', { projectId, workspaceId, error });
       return err({ type: 'git_error' as const, message: gitErrorMessage(error) });
     }
   },

--- a/apps/emdash-desktop/src/main/core/git/worktree/controller.ts
+++ b/apps/emdash-desktop/src/main/core/git/worktree/controller.ts
@@ -52,7 +52,9 @@ export const gitWorktreeController = createRPCController({
       if (!workspace) return err({ type: 'not_found' as const });
       const headTree = await workspace.gitWorktree.snapshotWorktreeTree();
       const changes = await workspace.gitWorktree.getChangedFilesBetweenTrees(baseTree, headTree);
-      return ok({ baseline: { baseTree, changes } });
+      // headTree lets the renderer diff baseTree -> headTree via the existing 'git' diff group
+      // (both immutable snapshots), so no live working-tree diff mode is needed.
+      return ok({ baseline: { baseTree, headTree, changes } });
     } catch (error) {
       log.error('gitCtrl.getLastTurnChanges failed', { projectId, workspaceId, error });
       return err({ type: 'git_error' as const, message: gitErrorMessage(error) });

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
@@ -511,6 +511,20 @@ class LegacySshGitWorktree implements IGitWorktree {
     return (await this.git.getChangedFiles(base)).map((change) => this.toAbsChange(change));
   }
 
+  /**
+   * The last-turn diff snapshot (#1635) relies on passing GIT_INDEX_FILE through the git
+   * exec, which the legacy SSH execution context does not support. Signal "unsupported" by
+   * throwing: LastTurnBaselineService treats it as no baseline, so the diff view falls back
+   * to the session scope on this deprecated runtime. The native runtime implements it.
+   */
+  async snapshotWorktreeTree(): Promise<string> {
+    throw new Error('snapshotWorktreeTree is not supported on the legacy SSH runtime');
+  }
+
+  async getChangedFilesBetweenTrees(): Promise<GitChange[]> {
+    return [];
+  }
+
   getFileAtRef(filePath: string, ref: string): Promise<string | null> {
     return this.git.getFileAtRef(this.toGitPath(filePath), ref);
   }

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
@@ -521,7 +521,7 @@ class LegacySshGitWorktree implements IGitWorktree {
     throw new Error('snapshotWorktreeTree is not supported on the legacy SSH runtime');
   }
 
-  async getChangedFilesBetweenTrees(): Promise<GitChange[]> {
+  async getChangedFilesBetweenTrees(_baseTree: string, _headTree: string): Promise<GitChange[]> {
     return [];
   }
 

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -22,6 +22,7 @@ import { setBrowserCorsRelaxationSettings } from './core/browser/browser-profile
 import { browserWebContentsRegistry } from './core/browser/browser-webcontents-registry';
 import { localDependencyManager } from './core/dependencies/dependency-managers';
 import { editorBufferService } from './core/editor/editor-buffer-service';
+import { lastTurnBaselineService } from './core/git/last-turn-baseline-service';
 import { githubAccountReconciliationService } from './core/github/accounts/github-account-reconciliation-instance';
 import { githubAccountRegistry } from './core/github/accounts/github-account-registry-instance';
 import { GitHubAuthServerAdapter } from './core/github/accounts/github-auth-server-adapter';
@@ -140,6 +141,7 @@ void app.whenReady().then(async () => {
   projectSettingsService.initialize();
   prSyncScheduler.initialize();
   remoteTmuxReaperService.initialize();
+  lastTurnBaselineService.initialize();
   automationsService.start();
   appService.initialize();
   await appSettingsService.initialize();

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/changes-scope-toggle.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/changes-scope-toggle.tsx
@@ -1,0 +1,46 @@
+import { History } from 'lucide-react';
+import { useState } from 'react';
+import type { ChangesScope } from '@renderer/features/tasks/diff-view/stores/changes-view-store';
+import { Button } from '@renderer/lib/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
+
+interface ChangesScopeToggleProps {
+  scope: ChangesScope;
+  onChange: (scope: ChangesScope) => void;
+}
+
+/**
+ * Toggles the "Changed" section between the whole-task diff and only the most recent
+ * agent turn's changes (#1635).
+ */
+export function ChangesScopeToggle({ scope, onChange }: ChangesScopeToggleProps) {
+  const isLastTurn = scope === 'last-turn';
+  const tooltip = isLastTurn
+    ? 'Showing the last turn. Show all task changes'
+    : 'Show only the last turn';
+  const [open, setOpen] = useState(false);
+
+  return (
+    <Tooltip
+      open={open}
+      onOpenChange={(nextOpen, details) => {
+        // Keep the tooltip visible after a click so the user can read the updated label.
+        if (!nextOpen && details.reason === 'trigger-press') return;
+        setOpen(nextOpen);
+      }}
+    >
+      <TooltipTrigger>
+        <Button
+          variant={isLastTurn ? 'secondary' : 'ghost'}
+          size="icon-xs"
+          onClick={() => onChange(isLastTurn ? 'session' : 'last-turn')}
+          aria-label={tooltip}
+          aria-pressed={isLastTurn}
+        >
+          <History className="size-3" />
+        </Button>
+      </TooltipTrigger>
+      <TooltipContent>{tooltip}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/unstaged-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/unstaged-section.tsx
@@ -56,7 +56,19 @@ export const UnstagedSection = observer(function UnstagedSection() {
       ? _activeDiff.path
       : undefined;
 
-  const prefetch = usePrefetchDiffModels(projectId, workspaceId, 'disk', HEAD_REF);
+  // Session opens files against HEAD on the 'disk' group; last-turn opens the immutable
+  // baseTree -> headTree snapshot on the 'git' group (see openChange below). Prefetch has to
+  // mirror whichever group and refs will actually be opened, or it warms the wrong models and
+  // every last-turn hover misses the cache.
+  const diskPrefetch = usePrefetchDiffModels(projectId, workspaceId, 'disk', HEAD_REF);
+  const gitPrefetch = usePrefetchDiffModels(
+    projectId,
+    workspaceId,
+    'git',
+    lastTurn ? commitRef(lastTurn.baseTree) : HEAD_REF,
+    lastTurn ? commitRef(lastTurn.headTree) : undefined
+  );
+  const prefetch = isLastTurn ? gitPrefetch : diskPrefetch;
 
   const { mode: viewMode, setMode: setViewMode } = useChangesViewMode('unstaged');
 
@@ -160,10 +172,18 @@ export const UnstagedSection = observer(function UnstagedSection() {
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {!hasChanges && (
           <EmptyState
-            label={isLastTurn ? 'No changes this turn' : 'Working tree clean'}
+            label={
+              isLastTurn
+                ? lastTurn
+                  ? 'No changes this turn'
+                  : 'No turn recorded yet'
+                : 'Working tree clean'
+            }
             description={
               isLastTurn
-                ? 'The most recent turn made no file changes yet.'
+                ? lastTurn
+                  ? 'The most recent turn made no file changes.'
+                  : 'The agent has not run a turn in this task yet. Changes from the next turn will show up here.'
                 : 'No uncommitted file changes.'
             }
           />

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/unstaged-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/unstaged-section.tsx
@@ -1,6 +1,7 @@
 import type { GitChange } from '@emdash/core/git';
 import { Plus, Undo2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import { useEffect } from 'react';
 import { toast } from 'sonner';
 import { activeDiffEntry } from '@renderer/features/tasks/diff-view/pane-selectors';
 import {
@@ -17,6 +18,7 @@ import { commitRef } from '@shared/core/git/utils';
 import { formatErrorType } from '../../utils';
 import { ActionCard } from './components/action-card';
 import { ChangesListOrTree } from './components/changes-list-or-tree';
+import { ChangesScopeToggle } from './components/changes-scope-toggle';
 import { ChangesViewModeToggle } from './components/changes-view-mode-toggle';
 import { CommitCard } from './components/commit-card';
 import { SectionHeader } from './components/section-header';
@@ -32,12 +34,27 @@ export const UnstagedSection = observer(function UnstagedSection() {
   const diffView = taskView.diffView;
   const changesView = diffView?.changesView;
 
-  const changes = git.unstagedFileChanges;
+  const scope = changesView?.scope ?? 'session';
+  const isLastTurn = scope === 'last-turn';
+  const lastTurn = git.lastTurnChanges;
+  const changes = isLastTurn ? (lastTurn?.changes ?? []) : git.unstagedFileChanges;
   const hasChanges = changes.length > 0;
   const hasStagedChanges = git.stagedFileChanges.length > 0;
 
+  // Keep the last-turn diff fresh while that scope is active and the worktree changes.
+  const statusRevision = git.statusRevision;
+  useEffect(() => {
+    if (isLastTurn) void git.refreshLastTurn();
+  }, [isLastTurn, statusRevision, git]);
+
   const _activeDiff = activeDiffEntry(taskView.activePane);
-  const activePath = _activeDiff?.diffGroup === 'disk' ? _activeDiff.path : undefined;
+  const activePath = isLastTurn
+    ? _activeDiff?.diffGroup === 'git'
+      ? _activeDiff.path
+      : undefined
+    : _activeDiff?.diffGroup === 'disk'
+      ? _activeDiff.path
+      : undefined;
 
   const prefetch = usePrefetchDiffModels(projectId, workspaceId, 'disk', HEAD_REF);
 
@@ -47,37 +64,29 @@ export const UnstagedSection = observer(function UnstagedSection() {
 
   if (!diffView || !changesView) return null;
 
-  const handleSelectChange = (change: GitChange) => {
-    taskView.activePane.open(
-      'diff',
-      {
-        activeFile: {
-          path: change.path,
-          type: 'disk',
-          group: 'disk',
-          originalRef: commitRef('HEAD'),
-        },
-        status: change.status,
-      },
-      { preview: true }
-    );
+  const openChange = (change: GitChange, preview: boolean) => {
+    // Session: working tree vs HEAD (disk group). Last turn: the immutable baseTree ->
+    // headTree snapshot diff, rendered via the arbitrary ref-to-ref 'git' group (#1635).
+    const activeFile =
+      isLastTurn && lastTurn
+        ? {
+            path: change.path,
+            type: 'git' as const,
+            group: 'git' as const,
+            originalRef: commitRef(lastTurn.baseTree),
+            modifiedRef: commitRef(lastTurn.headTree),
+          }
+        : {
+            path: change.path,
+            type: 'disk' as const,
+            group: 'disk' as const,
+            originalRef: commitRef('HEAD'),
+          };
+    taskView.activePane.open('diff', { activeFile, status: change.status }, { preview });
   };
 
-  const handleDoubleClickChange = (change: GitChange) => {
-    taskView.activePane.open(
-      'diff',
-      {
-        activeFile: {
-          path: change.path,
-          type: 'disk',
-          group: 'disk',
-          originalRef: commitRef('HEAD'),
-        },
-        status: change.status,
-      },
-      { preview: false }
-    );
-  };
+  const handleSelectChange = (change: GitChange) => openChange(change, true);
+  const handleDoubleClickChange = (change: GitChange) => openChange(change, false);
 
   const handleDiscardSelection = () => {
     const paths = [...changesView.unstagedSelection];
@@ -135,19 +144,31 @@ export const UnstagedSection = observer(function UnstagedSection() {
   return (
     <>
       <SectionHeader
-        label="Changed"
+        label={isLastTurn ? 'Last turn' : 'Changed'}
         collapsed={!changesView.expandedSections.unstaged}
         onToggleCollapsed={() => changesView.toggleExpanded('unstaged')}
         count={changes.length}
-        selectionState={changesView.unstagedSelectionState}
-        onToggleAll={() => changesView.toggleAllUnstaged()}
-        actions={<ChangesViewModeToggle value={viewMode} onChange={setViewMode} label="Changed" />}
+        selectionState={isLastTurn ? undefined : changesView.unstagedSelectionState}
+        onToggleAll={isLastTurn ? undefined : () => changesView.toggleAllUnstaged()}
+        actions={
+          <>
+            <ChangesScopeToggle scope={scope} onChange={(next) => changesView.setScope(next)} />
+            <ChangesViewModeToggle value={viewMode} onChange={setViewMode} label="Changed" />
+          </>
+        }
       />
       <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
         {!hasChanges && (
-          <EmptyState label="Working tree clean" description="No uncommitted file changes." />
+          <EmptyState
+            label={isLastTurn ? 'No changes this turn' : 'Working tree clean'}
+            description={
+              isLastTurn
+                ? 'The most recent turn made no file changes yet.'
+                : 'No uncommitted file changes.'
+            }
+          />
         )}
-        {hasChanges && (
+        {!isLastTurn && hasChanges && (
           <ActionCard
             selectedCount={changesView.unstagedSelection.size}
             selectionActions={
@@ -205,15 +226,17 @@ export const UnstagedSection = observer(function UnstagedSection() {
             viewMode={viewMode}
             changes={changes}
             rootPath={workspace.path}
-            isSelected={(path) => changesView.unstagedSelection.has(path)}
-            onToggleSelect={(path) => changesView.toggleUnstagedItem(path)}
+            isSelected={(path) => !isLastTurn && changesView.unstagedSelection.has(path)}
+            onToggleSelect={(path) => {
+              if (!isLastTurn) changesView.toggleUnstagedItem(path);
+            }}
             activePath={activePath}
             onSelectChange={handleSelectChange}
             onDoubleClickChange={handleDoubleClickChange}
             onPrefetch={(change) => prefetch(change.path)}
           />
         </div>
-        {hasChanges && !hasStagedChanges && <CommitCard autoStage />}
+        {!isLastTurn && hasChanges && !hasStagedChanges && <CommitCard autoStage />}
       </div>
     </>
   );

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/changes-view-store.ts
@@ -10,10 +10,14 @@ export interface ExpandedSections {
   pullRequests: boolean;
 }
 
+export type ChangesScope = 'session' | 'last-turn';
+
 export class ChangesViewStore {
   unstagedSelection = observable.set<string>();
   stagedSelection = observable.set<string>();
   expandedSections: ExpandedSections = { unstaged: true, staged: true, pullRequests: true };
+  /** Whether the "Changed" section shows the whole task diff or only the last turn's (#1635). */
+  scope: ChangesScope = 'session';
 
   private _disposeReactions: Array<() => void> = [];
   private _suppressAutoExpand = new Set<keyof ExpandedSections>();
@@ -24,6 +28,7 @@ export class ChangesViewStore {
   ) {
     makeObservable(this, {
       expandedSections: observable,
+      scope: observable,
       unstagedSelectionState: computed,
       stagedSelectionState: computed,
     });
@@ -188,6 +193,12 @@ export class ChangesViewStore {
     for (const path of paths) {
       this.stagedSelection.delete(path);
     }
+  }
+
+  setScope(scope: ChangesScope): void {
+    runInAction(() => {
+      this.scope = scope;
+    });
   }
 
   toggleExpanded(section: keyof ExpandedSections): void {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
@@ -16,7 +16,7 @@ import {
   type MirrorBinding,
   type MirrorBindingStatus,
 } from '@renderer/lib/stores/live';
-import { gitWorktreeUpdateChannel } from '@shared/core/git/events';
+import { gitWorktreeUpdateChannel, lastTurnBaselineChannel } from '@shared/core/git/events';
 import type { GitWorktreeMutationResult, GitWorktreeSnapshotError } from '@shared/core/git/rpc';
 import {
   commitOptimistically,
@@ -37,6 +37,10 @@ export class GitWorktreeStore {
   private readonly bindings: MirrorBinding[];
   private started = false;
   private syncError: string | null = null;
+  // "Last turn" diff data (#1635): the worktree snapshot at the start of the most recent
+  // turn plus the files changed since, or null when no turn has been captured yet.
+  private _lastTurn: { baseTree: string; changes: GitChange[] } | null = null;
+  private _lastTurnUnsub: (() => void) | null = null;
 
   constructor(
     private readonly projectId: string,
@@ -100,8 +104,10 @@ export class GitWorktreeStore {
       }),
     ];
 
-    makeObservable<this, 'effectiveStatus' | 'syncError'>(this, {
+    makeObservable<this, 'effectiveStatus' | 'syncError' | '_lastTurn'>(this, {
       syncError: observable,
+      _lastTurn: observable,
+      lastTurnChanges: computed,
       fileChanges: computed,
       stagedFileChanges: computed,
       unstagedFileChanges: computed,
@@ -126,6 +132,10 @@ export class GitWorktreeStore {
     if (this.started) return;
     this.started = true;
     for (const binding of this.bindings) binding.start();
+    // Re-fetch the last-turn diff whenever a new turn baseline is captured for this workspace.
+    this._lastTurnUnsub = events.on(lastTurnBaselineChannel, (payload) => {
+      if (payload.workspaceId === this.workspaceId) void this.refreshLastTurn();
+    });
   }
 
   async resync(): Promise<void> {
@@ -134,10 +144,33 @@ export class GitWorktreeStore {
 
   dispose(): void {
     for (const binding of this.bindings) binding.dispose();
+    this._lastTurnUnsub?.();
+    this._lastTurnUnsub = null;
     this.started = false;
     this.optimisticStatus.dispose();
     this.status.dispose();
     this.head.dispose();
+  }
+
+  /** The files changed during the most recent agent turn, or null if none captured (#1635). */
+  get lastTurnChanges(): { baseTree: string; changes: GitChange[] } | null {
+    return this._lastTurn;
+  }
+
+  /**
+   * Fetch the "last turn" changes (files changed since the most recent turn baseline) from the
+   * main process. Called on the baseline event and, while the last-turn scope is active, when
+   * the worktree changes during a turn.
+   */
+  async refreshLastTurn(): Promise<void> {
+    const result = await rpc.workspace.gitWorktree.getLastTurnChanges(
+      this.projectId,
+      this.workspaceId
+    );
+    if (!result.success) return;
+    runInAction(() => {
+      this._lastTurn = result.data.baseline;
+    });
   }
 
   get statusRevision(): number {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/git-worktree-store.ts
@@ -39,7 +39,7 @@ export class GitWorktreeStore {
   private syncError: string | null = null;
   // "Last turn" diff data (#1635): the worktree snapshot at the start of the most recent
   // turn plus the files changed since, or null when no turn has been captured yet.
-  private _lastTurn: { baseTree: string; changes: GitChange[] } | null = null;
+  private _lastTurn: { baseTree: string; headTree: string; changes: GitChange[] } | null = null;
   private _lastTurnUnsub: (() => void) | null = null;
 
   constructor(
@@ -153,7 +153,7 @@ export class GitWorktreeStore {
   }
 
   /** The files changed during the most recent agent turn, or null if none captured (#1635). */
-  get lastTurnChanges(): { baseTree: string; changes: GitChange[] } | null {
+  get lastTurnChanges(): { baseTree: string; headTree: string; changes: GitChange[] } | null {
     return this._lastTurn;
   }
 

--- a/apps/emdash-desktop/src/shared/core/git/events.ts
+++ b/apps/emdash-desktop/src/shared/core/git/events.ts
@@ -15,3 +15,11 @@ export type GitWorktreeUpdateEvent = {
 };
 
 export const gitWorktreeUpdateChannel = defineEvent<GitWorktreeUpdateEvent>('git:worktree-update');
+
+export type LastTurnBaselineEvent = {
+  projectId: string;
+  workspaceId: string;
+};
+
+/** Fires when the "last turn" diff baseline is (re)captured for a workspace (#1635). */
+export const lastTurnBaselineChannel = defineEvent<LastTurnBaselineEvent>('git:last-turn-baseline');

--- a/packages/core/src/git/git-worktree.test.ts
+++ b/packages/core/src/git/git-worktree.test.ts
@@ -732,4 +732,54 @@ describe('GitWorktree', () => {
       await runtime.dispose();
     }
   });
+
+  it('snapshots the worktree and diffs two snapshots, including untracked files (#1635)', async () => {
+    const repo = await makeRepo();
+    const watcher = new WatchService();
+    const runtime = new GitRuntime({ watcher });
+
+    try {
+      const lease = await runtime.openWorktree(repo);
+      const worktree = lease.value;
+
+      // Baseline captured at the start of a "turn": nothing has changed yet, so a diff
+      // against itself is empty.
+      const base = await worktree.snapshotWorktreeTree();
+      expect(base).toMatch(/^[0-9a-f]{40}$/);
+      await expect(worktree.getChangedFilesBetweenTrees(base, base)).resolves.toEqual([]);
+
+      // The turn modifies a tracked file, adds an untracked file, and adds a .gitignore
+      // that ignores another untracked file (which must be excluded from the snapshot).
+      await writeFile(repoFile(repo, 'tracked.txt'), 'after\n', 'utf8');
+      await writeFile(repoFile(repo, 'newfile.py'), 'print(1)\n', 'utf8');
+      await writeFile(repoFile(repo, 'secret.env'), 'TOKEN=x\n', 'utf8');
+      await writeFile(repoFile(repo, '.gitignore'), 'secret.env\n', 'utf8');
+
+      const head = await worktree.snapshotWorktreeTree();
+      expect(head).not.toBe(base);
+
+      const changes = await worktree.getChangedFilesBetweenTrees(base, head);
+      const byPath = new Map(changes.map((change) => [change.path, change]));
+      expect(byPath.get(repoFile(repo, 'tracked.txt'))?.status).toBe('modified');
+      expect(byPath.get(repoFile(repo, 'newfile.py'))?.status).toBe('added');
+      expect(byPath.get(repoFile(repo, '.gitignore'))?.status).toBe('added');
+      // The gitignored file is present on disk but must not leak into the snapshot diff.
+      expect(byPath.has(repoFile(repo, 'secret.env'))).toBe(false);
+
+      // The baseline preserves the pre-turn content for the diff's "before" side.
+      await expect(worktree.getFileAtRef('tracked.txt', base)).resolves.toBe('before\n');
+
+      // Snapshotting is non-destructive: the real index still sees the change as unstaged.
+      expect(await worktree.getStatus()).toMatchObject({
+        kind: 'ok',
+        unstaged: expect.arrayContaining([
+          expect.objectContaining({ path: repoFile(repo, 'tracked.txt'), status: 'modified' }),
+        ]),
+      });
+
+      await lease.release();
+    } finally {
+      await runtime.dispose();
+    }
+  });
 });

--- a/packages/core/src/git/git-worktree.ts
+++ b/packages/core/src/git/git-worktree.ts
@@ -84,6 +84,7 @@ export class GitWorktree implements IGitWorktree {
   private readonly headModel: LiveModel<GitHeadModel>;
   private readonly worktreeWatch: WatchHandle;
   private readonly unregisterFromRepository: Unsubscribe;
+  private snapshotChain: Promise<unknown> = Promise.resolve();
 
   constructor(options: GitWorktreeOptions) {
     this.worktree = options.worktree;
@@ -226,6 +227,68 @@ export class GitWorktree implements IGitWorktree {
     const [numstatResult, nameStatusResult] = await Promise.all([
       this.exec.exec(diffArgs).catch(() => ({ stdout: '' })),
       this.exec.exec(nameArgs).catch(() => ({ stdout: '' })),
+    ]);
+    const numstat = parseNumstat(numstatResult.stdout);
+    const changes: GitChange[] = [];
+
+    for (const line of nameStatusResult.stdout.trim().split('\n').filter(Boolean)) {
+      const [code = '', ...parts] = line.split('\t');
+      const filePath = parts[parts.length - 1]?.trim();
+      if (!filePath) continue;
+      const stat = numstat.get(filePath);
+      changes.push({
+        path: this.toAbsolutePath(filePath),
+        status: mapGitChangeStatus(code),
+        additions: stat?.additions ?? 0,
+        deletions: stat?.deletions ?? 0,
+      });
+    }
+
+    return changes;
+  }
+
+  /**
+   * Capture the entire worktree (tracked + untracked, respecting `.gitignore`) as a git
+   * tree object, without touching the real index or working tree. Used to snapshot the
+   * worktree at a turn boundary so a later diff can show only that turn's changes (#1635).
+   *
+   * Writes into a throwaway index file inside the git dir. `this.exec` is bound to the git
+   * binary and cannot remove files itself (and has no fs over SSH), so the fixed path is
+   * emptied first (`read-tree --empty`) and reused rather than accumulating per-call files.
+   * Calls are serialized to keep that shared index file race-free.
+   */
+  async snapshotWorktreeTree(): Promise<string> {
+    const run = this.snapshotChain.then(() => this.computeWorktreeTree());
+    // Keep the chain alive even if this snapshot fails, so later snapshots still run.
+    this.snapshotChain = run.then(
+      () => undefined,
+      () => undefined
+    );
+    return run;
+  }
+
+  private async computeWorktreeTree(): Promise<string> {
+    const indexFile = path.join(this.gitDir, 'emdash-turn-snapshot.index');
+    const env = { GIT_INDEX_FILE: indexFile };
+    await this.exec.exec(['read-tree', '--empty'], { env });
+    await this.exec.exec(['add', '-A'], { env });
+    const { stdout } = await this.exec.exec(['write-tree'], { env });
+    return stdout.trim();
+  }
+
+  /**
+   * Files changed between two tree objects (as produced by {@link snapshotWorktreeTree}),
+   * in the same shape as {@link getChangedFiles}. Backs the "last turn" diff scope (#1635).
+   */
+  async getChangedFilesBetweenTrees(baseTree: string, headTree: string): Promise<GitChange[]> {
+    if (baseTree === headTree) return [];
+    const [numstatResult, nameStatusResult] = await Promise.all([
+      this.exec
+        .exec(['diff-tree', '--no-commit-id', '--numstat', '-r', baseTree, headTree])
+        .catch(() => ({ stdout: '' })),
+      this.exec
+        .exec(['diff-tree', '--no-commit-id', '--name-status', '-r', baseTree, headTree])
+        .catch(() => ({ stdout: '' })),
     ]);
     const numstat = parseNumstat(numstatResult.stdout);
     const changes: GitChange[] = [];

--- a/packages/core/src/git/types.ts
+++ b/packages/core/src/git/types.ts
@@ -179,6 +179,10 @@ export interface IGitWorktree extends IDisposable {
   getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint>;
   isFileCleanlyTracked(filePath: string): Promise<boolean>;
   getChangedFiles(base: DiffTarget): Promise<GitChange[]>;
+  /** Snapshot the whole worktree (tracked + untracked) as a tree oid; see impl (#1635). */
+  snapshotWorktreeTree(): Promise<string>;
+  /** Files changed between two tree oids from {@link snapshotWorktreeTree} (#1635). */
+  getChangedFilesBetweenTrees(baseTree: string, headTree: string): Promise<GitChange[]>;
   getFileAtRef(filePath: string, ref: string): Promise<string | null>;
   getFileAtIndex(filePath: string): Promise<string | null>;
   getImageAtRef(filePath: string, ref: string): Promise<ImageReadResult>;


### PR DESCRIPTION
### Description

Adds a scope toggle to the Changes panel so you can flip the "Changed" section between the whole task diff (**Session**, the current behavior) and only what the most recent agent turn changed (**Last turn**). The two scopes stay cleanly separated, which is what people asked for in the issue.

**How it works**

Turn baseline (main). On each turn start (the provider-agnostic `conversation:input-submitted` event, which fires for both ACP and PTY agents) `LastTurnBaselineService` snapshots the task's worktree as a git tree and remembers it per workspace. "Last turn" is then the diff between that snapshot and the current worktree.

- The snapshot captures the whole worktree, tracked and untracked, respecting `.gitignore`, via `git write-tree` against a throwaway index file. It never touches the real index, working tree, or commit history (validated in the unit test).
- The baseline is kept in memory on purpose: it is a dangling tree that `git gc` could prune between sessions, and it is only meaningful for the current turn. It resets on restart and is re-captured on the next prompt.

Rendering (renderer). In last-turn scope the file list comes from a new `gitWorktree.getLastTurnChanges` RPC, and opening a file renders the immutable `baseTree` to `headTree` snapshot diff through the existing ref-to-ref `git` diff group. So there is no new live-working-tree diff mode and no changes to the diff-tab machinery or its staleness reconcile. The diff is a stable view of the turn, and it refreshes when the next turn is captured.

Last-turn is a read-only review view: stage, discard, and commit actions and selection are hidden, and the empty state explains when a turn made no changes.

**Commits (one layer each)**

1. `GitWorktree.snapshotWorktreeTree()` and `getChangedFilesBetweenTrees()` in `packages/core` (plus the `IGitWorktree` interface): the snapshot and tree-diff primitives.
2. `LastTurnBaselineService`, the `getLastTurnChanges` RPC, the `git:last-turn-baseline` event, and init wiring.
3. The last-turn data source in the renderer worktree store.
4. The Session / Last turn toggle and section wiring.
5. The two new `IGitWorktree` methods implemented on the legacy SSH runtime, so remote worktrees compile and behave the same.

### Related issues

Closes #1635.

### Testing

- `packages/core` git tests, including a new case: snapshot plus tree-diff with tracked, untracked, and gitignored files, non-destructive (the real index still sees the change as unstaged).
- `LastTurnBaselineService` unit test: capture on turn start, overwrite per turn, ignore workspaceless tasks, clear on teardown.
- Touched-area suites green: core git (54), main-process git (45), diff-view stores and manager (54, no regressions).
- `pnpm run format`, `pnpm run lint`, and `pnpm run typecheck` clean on all changed files.

### Screenshot/Recording

I develop on a headless box and cannot render the Electron UI here, so I have not visually verified the renderer wiring or captured a screenshot. The backend is fully unit-tested. If someone can run it and confirm the toggle and the read-only last-turn view render correctly, I will follow up on anything that needs adjusting.

### Follow-ups (intentionally out of scope)

- Persist the scope choice globally (it is per-task right now and resets on remount).
- A browser test for the section's scope-aware rendering.
- Optionally a live-working-tree "after" side, so an open last-turn diff updates as the turn continues instead of refreshing on the next turn.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and the PR title

</details>
