### PR TITLE
feat(conversations): allow selecting a saved prompt in the create conversation modal

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
@@ -1,13 +1,9 @@
 import { observer } from 'mobx-react-lite';
 import { useCallback, useState } from 'react';
-import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
-import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
 import { conversationRegistry } from '@renderer/features/tasks/stores/conversation-registry';
-import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { useCloseGuard } from '@renderer/lib/modal/use-close-guard';
-import { useAgents } from '@renderer/lib/stores/use-agents';
 import { ConfirmButton } from '@renderer/lib/ui/confirm-button';
 import {
   DialogContentArea,
@@ -15,20 +11,13 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
-import { Field, FieldGroup, FieldLabel } from '@renderer/lib/ui/field';
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from '@renderer/lib/ui/select';
-import { Switch } from '@renderer/lib/ui/switch';
-import { providerSupportsAcp } from '@shared/core/agents/agent-acp';
-import { providerSupportsAutoApprove } from '@shared/core/agents/agent-auto-approve';
+import { FieldGroup } from '@renderer/lib/ui/field';
 import type { ConversationType } from '@shared/core/conversations/conversations';
 import { nextDefaultConversationTitle } from './conversation-title-utils';
-import { useEffectiveProvider } from './use-effective-provider';
+import {
+  InitialConversationField,
+  useInitialConversationState,
+} from './initial-conversation-section';
 
 export const CreateConversationModal = observer(function CreateConversationModal({
   onSuccess,
@@ -38,65 +27,41 @@ export const CreateConversationModal = observer(function CreateConversationModal
   projectId: string;
   taskId: string;
 }) {
-  const connectionId = getProjectSshConnectionId(projectId);
-  const { providerId, setProviderOverride, createDisabled } = useEffectiveProvider(connectionId);
   const conversationMgr = conversationRegistry.get(taskId);
   const taskSettings = useTaskSettings();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
-  const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
-  const [selectedModel, setSelectedModel] = useState<string | null>(null);
-  const [selectedPromptId, setSelectedPromptId] = useState<string | null>(null);
-  const [useAcpOverride, setUseAcpOverride] = useState(false);
   useCloseGuard(isSubmitting);
 
-  const { value: promptLibrary } = usePromptLibrary();
-  const savedPrompts = promptLibrary.filter((p) => p.prompt.trim().length > 0);
-  const selectedPrompt = savedPrompts.find((p) => p.id === selectedPromptId) ?? null;
+  const state = useInitialConversationState(
+    projectId,
+    undefined,
+    taskSettings.autoApproveByDefault
+  );
 
-  const { data: agents } = useAgents();
-  const modelsCapability = agents?.find((a) => a.id === providerId)?.capabilities.models;
-  const modelOptions =
-    modelsCapability?.kind === 'selectable' ? modelsCapability.modelOptions : null;
-
-  const showAutoApproveToggle = providerId ? providerSupportsAutoApprove(providerId) : false;
-  const showAcpToggle = providerId ? providerSupportsAcp(providerId) : false;
-  const useAcp = showAcpToggle && useAcpOverride;
-  const skipPermissions =
-    showAutoApproveToggle && (autoApproveOverride ?? taskSettings.autoApproveByDefault);
-  const titleProviderId = providerId ?? 'claude';
+  const titleProviderId = state.provider ?? 'claude';
   const title = nextDefaultConversationTitle(
     titleProviderId,
     Array.from(conversationMgr?.conversations.values() ?? [], (conversation) => conversation.data)
   );
 
-  // Reset model and ACP override when the provider changes (ids are provider-specific).
-  const handleProviderChange = useCallback(
-    (next: typeof providerId) => {
-      setProviderOverride(next);
-      setSelectedModel(null);
-      setUseAcpOverride(false);
-    },
-    [setProviderOverride]
-  );
-
   const handleCreateConversation = useCallback(async () => {
-    if (createDisabled || isSubmitting || !conversationMgr || !providerId) return;
+    if (state.createDisabled || isSubmitting || !conversationMgr || !state.provider) return;
     const id = crypto.randomUUID();
     setIsSubmitting(true);
     setError(null);
     try {
-      const conversationType: ConversationType = useAcp ? 'acp' : 'pty';
+      const conversationType: ConversationType = state.useChatUi ? 'acp' : 'pty';
       await conversationMgr.createConversation({
         projectId,
         taskId,
         id,
-        autoApprove: skipPermissions,
-        provider: providerId,
+        autoApprove: state.autoApprove,
+        provider: state.provider,
         title,
-        model: selectedModel ?? undefined,
+        model: state.model ?? undefined,
         type: conversationType,
-        initialPrompt: selectedPrompt?.prompt,
+        initialPrompt: state.prompt.trim() || undefined,
       });
       setIsSubmitting(false);
       onSuccess({ conversationId: id, type: conversationType });
@@ -106,17 +71,17 @@ export const CreateConversationModal = observer(function CreateConversationModal
     }
   }, [
     conversationMgr,
-    createDisabled,
     isSubmitting,
-    providerId,
     title,
     onSuccess,
     projectId,
     taskId,
-    skipPermissions,
-    selectedModel,
-    selectedPrompt,
-    useAcp,
+    state.createDisabled,
+    state.provider,
+    state.useChatUi,
+    state.autoApprove,
+    state.model,
+    state.prompt,
   ]);
 
   return (
@@ -126,95 +91,14 @@ export const CreateConversationModal = observer(function CreateConversationModal
       </DialogHeader>
       <DialogContentArea>
         <FieldGroup>
-          <Field>
-            <FieldLabel>Agent</FieldLabel>
-            <AgentSelector
-              autoFocus
-              value={providerId}
-              onChange={handleProviderChange}
-              connectionId={connectionId}
-            />
-          </Field>
-          {modelOptions ? (
-            <Field>
-              <FieldLabel>Model</FieldLabel>
-              <Select
-                value={selectedModel ?? ''}
-                onValueChange={(val) => setSelectedModel(val || null)}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="Default model">
-                    {selectedModel
-                      ? (modelOptions[selectedModel]?.name ?? selectedModel)
-                      : 'Default model'}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">Default model</SelectItem>
-                  {Object.entries(modelOptions).map(([id, opt]) => (
-                    <SelectItem key={id} value={id}>
-                      {opt.name}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </Field>
-          ) : null}
-          {savedPrompts.length > 0 ? (
-            <Field>
-              <FieldLabel>Prompt</FieldLabel>
-              <Select
-                value={selectedPromptId ?? ''}
-                onValueChange={(val) => setSelectedPromptId(val || null)}
-              >
-                <SelectTrigger>
-                  <SelectValue placeholder="No prompt">
-                    {selectedPrompt ? selectedPrompt.title : 'No prompt'}
-                  </SelectValue>
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="">No prompt</SelectItem>
-                  {savedPrompts.map((prompt) => (
-                    <SelectItem key={prompt.id} value={prompt.id}>
-                      {prompt.title}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-              {selectedPrompt ? (
-                <p className="text-muted-foreground line-clamp-2 text-xs">
-                  {selectedPrompt.prompt}
-                </p>
-              ) : null}
-            </Field>
-          ) : null}
-          {showAutoApproveToggle ? (
-            <Field>
-              <div className="flex items-center gap-2">
-                <Switch
-                  checked={skipPermissions}
-                  disabled={!providerId || taskSettings.loading || taskSettings.saving}
-                  onCheckedChange={setAutoApproveOverride}
-                />
-                <FieldLabel>Auto-approve permissions</FieldLabel>
-              </div>
-            </Field>
-          ) : null}
-          {showAcpToggle ? (
-            <Field>
-              <div className="flex items-center gap-2">
-                <Switch checked={useAcp} onCheckedChange={setUseAcpOverride} />
-                <FieldLabel>Use chat UI</FieldLabel>
-              </div>
-            </Field>
-          ) : null}
+          <InitialConversationField state={state} includeIssueContextByDefault={false} />
           {error && <p className="text-destructive text-xs">{error}</p>}
         </FieldGroup>
       </DialogContentArea>
       <DialogFooter>
         <ConfirmButton
           onClick={() => void handleCreateConversation()}
-          disabled={createDisabled || isSubmitting}
+          disabled={state.createDisabled || isSubmitting}
         >
           {isSubmitting ? 'Creating...' : 'Create'}
         </ConfirmButton>

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/create-conversation-modal.tsx
@@ -1,5 +1,6 @@
 import { observer } from 'mobx-react-lite';
 import { useCallback, useState } from 'react';
+import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
 import { conversationRegistry } from '@renderer/features/tasks/stores/conversation-registry';
@@ -45,8 +46,13 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const [error, setError] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
+  const [selectedPromptId, setSelectedPromptId] = useState<string | null>(null);
   const [useAcpOverride, setUseAcpOverride] = useState(false);
   useCloseGuard(isSubmitting);
+
+  const { value: promptLibrary } = usePromptLibrary();
+  const savedPrompts = promptLibrary.filter((p) => p.prompt.trim().length > 0);
+  const selectedPrompt = savedPrompts.find((p) => p.id === selectedPromptId) ?? null;
 
   const { data: agents } = useAgents();
   const modelsCapability = agents?.find((a) => a.id === providerId)?.capabilities.models;
@@ -90,6 +96,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
         title,
         model: selectedModel ?? undefined,
         type: conversationType,
+        initialPrompt: selectedPrompt?.prompt,
       });
       setIsSubmitting(false);
       onSuccess({ conversationId: id, type: conversationType });
@@ -108,6 +115,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
     taskId,
     skipPermissions,
     selectedModel,
+    selectedPrompt,
     useAcp,
   ]);
 
@@ -150,6 +158,34 @@ export const CreateConversationModal = observer(function CreateConversationModal
                   ))}
                 </SelectContent>
               </Select>
+            </Field>
+          ) : null}
+          {savedPrompts.length > 0 ? (
+            <Field>
+              <FieldLabel>Prompt</FieldLabel>
+              <Select
+                value={selectedPromptId ?? ''}
+                onValueChange={(val) => setSelectedPromptId(val || null)}
+              >
+                <SelectTrigger>
+                  <SelectValue placeholder="No prompt">
+                    {selectedPrompt ? selectedPrompt.title : 'No prompt'}
+                  </SelectValue>
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="">No prompt</SelectItem>
+                  {savedPrompts.map((prompt) => (
+                    <SelectItem key={prompt.id} value={prompt.id}>
+                      {prompt.title}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              {selectedPrompt ? (
+                <p className="text-muted-foreground line-clamp-2 text-xs">
+                  {selectedPrompt.prompt}
+                </p>
+              ) : null}
             </Field>
           ) : null}
           {showAutoApproveToggle ? (

--- a/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/conversations/initial-conversation-section.tsx
@@ -39,6 +39,8 @@ import { useEffectiveProvider } from './use-effective-provider';
 export type InitialConversationState = {
   provider: AgentProviderId | null;
   setProvider: (provider: AgentProviderId | null) => void;
+  /** True when agent availability is known and no provider can be selected. */
+  createDisabled: boolean;
   projectId?: string;
   prompt: string;
   setPrompt: Dispatch<SetStateAction<string>>;
@@ -69,7 +71,10 @@ export function useInitialConversationState(
 ): InitialConversationState {
   const { resetPromptOnProjectChange = true } = options;
   const connectionId = projectId ? getProjectSshConnectionId(projectId) : undefined;
-  const { providerId, setProviderOverride } = useEffectiveProvider(connectionId, initialProvider);
+  const { providerId, setProviderOverride, createDisabled } = useEffectiveProvider(
+    connectionId,
+    initialProvider
+  );
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
   const [autoApproveOverride, setAutoApproveOverride] = useState<boolean | null>(null);
@@ -107,6 +112,7 @@ export function useInitialConversationState(
   return {
     provider: providerId,
     setProvider: setProviderOverride,
+    createDisabled,
     projectId,
     prompt,
     setPrompt,

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/build-create-task-params.test.ts
@@ -10,6 +10,7 @@ function makeInitialConversationState(
   return {
     provider,
     setProvider: () => {},
+    createDisabled: false,
     prompt: 'Check this',
     setPrompt: () => {},
     issueContext: null,


### PR DESCRIPTION
### Description

Adds a **Prompt** select field to the add-conversation modal so users can apply a pre-saved prompt from the prompt library when creating a conversation — previously only agent and model selection were exposed there, while other creation flows (e.g. the create-task modal) already supported saved prompts.

Implementation notes:

- The field lists prompts from the prompt library via `usePromptLibrary()`, defaults to "No prompt", filters out prompts with empty text, and is hidden entirely when the library is empty.
- Selecting a prompt shows a two-line truncated preview of its text under the select.
- The selected prompt's text is passed as `initialPrompt` to `createConversation`. No backend changes were needed: `initialPrompt` is already plumbed through both runtime paths — PTY injects it on session start, and ACP stores it in the conversation config and consumes it on first spawn in `hydrateConversation`.
- Styled to match the existing Model select field for consistency within the modal form.

### Related issues

Fixes ENG-1726 — https://linear.app/general-action/issue/ENG-1726/allow-passing-a-pre-saved-prompt-in-the-add-conversation-modal

### Testing

- `typecheck` for `@emdash/emdash-desktop` — passes
- `lint` for `@emdash/emdash-desktop` — passes (remaining warnings are pre-existing in unrelated files)
- `format:check` for `@emdash/emdash-desktop` — passes
- Conversation-related unit tests (`src/renderer/features/tasks/conversations`, `src/main/core/conversations`): 74 passed. `initial-conversation-section.test.ts` fails with a pre-existing `window is not defined` import error that reproduces identically without this change.

### Screenshot/Recording (if applicable)

N/A

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [ ] I added or updated tests when behavior changed, or explained why not — UI-only wiring of an already-tested code path; no renderer browser test coverage exists for this modal today
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>