### PR TITLE
fix: pi resume stored sessions

### DIFF
--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -126,7 +126,9 @@ export class SshConversationProvider implements ConversationProvider {
 
       const providerConfig = await providerOverrideSettings.getItem(conversation.providerId);
       const agentSession = resolveAgentSessionCommandArgs(conversation, isResuming, {
-        requireProviderSessionId: conversation.providerId === 'amp' ? undefined : false,
+        requireProviderSessionId: ['amp', 'pi'].includes(conversation.providerId)
+          ? undefined
+          : false,
       });
       const plugin = getPlugin(conversation.providerId);
 

--- a/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.test.ts
@@ -118,6 +118,28 @@ describe('resolveAgentSessionCommandArgs', () => {
     );
   });
 
+  it('uses stored Pi session file when resuming', () => {
+    expect(
+      resolveAgentSessionCommandArgs(
+        makeConversation({
+          providerId: 'pi',
+          sessionId: '/Users/test/.pi/agent/sessions/project/session.jsonl',
+        }),
+        true
+      )
+    ).toEqual({
+      sessionId: '/Users/test/.pi/agent/sessions/project/session.jsonl',
+      isResuming: true,
+    });
+  });
+
+  it('starts fresh when resuming Pi without a stored session file', () => {
+    expect(resolveAgentSessionCommandArgs(makeConversation({ providerId: 'pi' }), true)).toEqual({
+      sessionId: 'conv-1',
+      isResuming: false,
+    });
+  });
+
   it('keeps resume enabled when provider session ids are unavailable', () => {
     expect(
       resolveAgentSessionCommandArgs(makeConversation(), true, { requireProviderSessionId: false })
@@ -196,5 +218,28 @@ describe('resolveAgentSessionCommandArgs', () => {
 
     expect(result.command).toBe('amp');
     expect(result.args).toEqual(['threads', 'continue', 'T-d2fc4acc-dd1d-497f-9609-ed0da22a7c95']);
+  });
+
+  it('builds a Pi replacement resume command from the stored session file', () => {
+    const conversation = makeConversation({
+      id: '6fac6620-9fa8-4604-b7e0-1fe361589104',
+      providerId: 'pi',
+      sessionId: '/Users/test/.pi/agent/sessions/project/session.jsonl',
+    });
+    const spawnPlan = resolveAgentSessionCommandArgs(conversation, true);
+    const result = pluginRegistry.get('pi')!.behavior.prompt!.buildCommand({
+      cli: 'pi',
+      autoApprove: false,
+      model: '',
+      sessionId: spawnPlan.sessionId,
+      providerSessionId: conversation.sessionId ?? undefined,
+      isResuming: spawnPlan.isResuming,
+    });
+
+    expect(result.command).toBe('pi');
+    expect(result.args).toEqual([
+      '--session',
+      '/Users/test/.pi/agent/sessions/project/session.jsonl',
+    ]);
   });
 });

--- a/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/resolve-agent-session-command.ts
@@ -6,6 +6,7 @@ const PROVIDER_SESSION_ID_REQUIRED_FOR_RESUME = new Set([
   'commandcode',
   'droid',
   'goose',
+  'pi',
 ]);
 
 /**

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -212,6 +212,37 @@ describe('pluginRegistry', () => {
     expect(result.args).toEqual(['--dangerously-allow-all', '-m', 'deep']);
   });
 
+  it('resumes Pi with the stored session file instead of the latest session', () => {
+    const pi = pluginRegistry.get('pi')!;
+
+    expect(pi.capabilities.hooks.kind).toBe('plugin');
+    if (pi.capabilities.hooks.kind !== 'plugin') throw new Error('Pi hooks should be plugin hooks');
+    expect(pi.capabilities.hooks.supportedEvents).toContain('session');
+
+    const fresh = pi.behavior.prompt!.buildCommand({
+      cli: 'pi',
+      autoApprove: false,
+      initialPrompt: 'Fix the bug',
+      sessionId: 'conv-1',
+      isResuming: false,
+      model: '',
+    });
+    expect(fresh.args).toEqual(['Fix the bug']);
+
+    const resumed = pi.behavior.prompt!.buildCommand({
+      cli: 'pi',
+      autoApprove: false,
+      sessionId: 'conv-1',
+      providerSessionId: '/Users/test/.pi/agent/sessions/project/session.jsonl',
+      isResuming: true,
+      model: '',
+    });
+    expect(resumed.args).toEqual([
+      '--session',
+      '/Users/test/.pi/agent/sessions/project/session.jsonl',
+    ]);
+  });
+
   it('registers Qoder CLI install metadata and interactive command args', () => {
     const qoder = pluginRegistry.get('qoder')!;
 

--- a/packages/plugins/src/agents/impl/pi/index.ts
+++ b/packages/plugins/src/agents/impl/pi/index.ts
@@ -21,7 +21,7 @@ export const plugin = definePlugin(
     hooks: {
       kind: 'plugin',
       scope: 'workspace',
-      supportedEvents: ['stop'],
+      supportedEvents: ['session', 'stop'],
     },
     hostDependency: npmDependency({
       id: 'pi',
@@ -48,7 +48,9 @@ export const provider = registerPluginBehavior(plugin, {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
         initialPromptFlag: '',
-        resumeFlag: '-c',
+        resumeFlag: '--session',
+        sessionIdFlag: '--session',
+        sessionIdOnResumeOnly: true,
       }),
   },
   plugins: createFileDropPlugin({ relativePath: PI_EXTENSION_PATH, content: PI_EXTENSION_CONTENT }),

--- a/packages/plugins/src/agents/impl/pi/plugin-file.test.ts
+++ b/packages/plugins/src/agents/impl/pi/plugin-file.test.ts
@@ -1,0 +1,44 @@
+import type { PluginFs } from '@emdash/core/agents/plugins';
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+function createMemoryFs(): PluginFs & { files: Map<string, string> } {
+  const files = new Map<string, string>();
+
+  return {
+    files,
+    async read(path) {
+      return files.get(path) ?? null;
+    },
+    async write(path, content) {
+      files.set(path, content);
+    },
+    async delete(path) {
+      files.delete(path);
+    },
+    async exists(path) {
+      return files.has(path);
+    },
+    async list(path) {
+      return [...files.keys()].filter((file) => file.startsWith(path));
+    },
+  };
+}
+
+describe('pi plugin hooks', () => {
+  it('installs a session hook that can report the active Pi session file', async () => {
+    const fs = createMemoryFs();
+
+    const written = await provider.behavior.plugins?.installPlugin(fs, {
+      kind: 'workspace',
+      path: '/workspace',
+    });
+
+    expect(written).toEqual(['.pi/extensions/emdash-hook.ts']);
+    const content = await fs.read('.pi/extensions/emdash-hook.ts');
+    expect(content).toContain("eventType: 'stop' | 'error' | 'notification' | 'session'");
+    expect(content).toContain("pi.on('session_start'");
+    expect(content).toContain('ctx.sessionManager.getSessionFile()');
+    expect(content).toContain("notifyEmdash('session'");
+  });
+});

--- a/packages/plugins/src/agents/impl/pi/plugin-file.ts
+++ b/packages/plugins/src/agents/impl/pi/plugin-file.ts
@@ -3,7 +3,7 @@ export const PI_EXTENSION_CONTENT = `\
 import type { ExtensionAPI } from '@earendil-works/pi-coding-agent';
 
 async function notifyEmdash(
-  eventType: 'stop' | 'error' | 'notification',
+  eventType: 'stop' | 'error' | 'notification' | 'session',
   body: Record<string, unknown> = {}
 ) {
   const port = process.env.EMDASH_HOOK_PORT;

--- a/packages/plugins/src/agents/impl/pi/plugin-file.ts
+++ b/packages/plugins/src/agents/impl/pi/plugin-file.ts
@@ -36,6 +36,12 @@ function errorMessage(error: unknown): string {
 }
 
 export default function (pi: ExtensionAPI) {
+  pi.on('session_start', async (_event, ctx) => {
+    const sessionFile = ctx.sessionManager.getSessionFile();
+    if (!sessionFile) return;
+    await notifyEmdash('session', { providerSessionId: sessionFile });
+  });
+
   pi.on('agent_end', async () => {
     await notifyEmdash('stop', { message: 'Task completed' });
   });


### PR DESCRIPTION
### Description
- fix pi resume to use the stored session file
- persist pi session files via hook

### Screenshot/Recording (if applicable)
https://cap.link/wmwx3sewnwmvy9b

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
