### PR TITLE
build(pty): restore bundled ConPTY after rebuild

### DIFF
--- a/.github/workflows/windows-beta-build.yml
+++ b/.github/workflows/windows-beta-build.yml
@@ -80,6 +80,7 @@ jobs:
           set -euo pipefail
           ELECTRON_VERSION=$(node -p "require('electron/package.json').version")
           npm_config_build_from_source=true pnpm exec electron-rebuild -f -a x64 -v "$ELECTRON_VERSION" -o sqlite3,node-pty
+          node --experimental-strip-types apps/emdash-desktop/scripts/copy-conpty-dll.ts --arch x64
 
       - name: Package Windows (NSIS + MSI) (no publish)
         shell: bash

--- a/.github/workflows/windows-beta-build.yml
+++ b/.github/workflows/windows-beta-build.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           set -euo pipefail
           ELECTRON_VERSION=$(node -p "require('electron/package.json').version")
-          npm_config_build_from_source=true pnpm exec electron-rebuild -f -a x64 -v "$ELECTRON_VERSION" -o sqlite3,node-pty
+          npm_config_build_from_source=true pnpm exec electron-rebuild -f -a x64 -v "$ELECTRON_VERSION" -o better-sqlite3,node-pty
           node --experimental-strip-types apps/emdash-desktop/scripts/copy-conpty-dll.ts --arch x64
 
       - name: Package Windows (NSIS + MSI) (no publish)

--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -39,7 +39,7 @@
     "package:linux": "pnpm run build && electron-builder --linux --publish never --config electron-builder.config.ts",
     "package:win": "pnpm run build && electron-builder --win --publish never --config electron-builder.config.ts",
     "postinstall": "node --experimental-strip-types scripts/postinstall.ts",
-    "rebuild": "electron-rebuild -f -v 40.7.0 --only=better-sqlite3,node-pty",
+    "rebuild": "electron-rebuild -f -v 40.7.0 --only=better-sqlite3,node-pty && node --experimental-strip-types scripts/copy-conpty-dll.ts",
     "run:docker-ssh": "docker compose up --build -d",
     "clean": "rm -rf node_modules dist",
     "reset": "pnpm run clean && pnpm install",

--- a/apps/emdash-desktop/scripts/copy-conpty-dll.test.ts
+++ b/apps/emdash-desktop/scripts/copy-conpty-dll.test.ts
@@ -83,6 +83,28 @@ describe('copyConptyDll', () => {
       expect(copyConptyDll({ nodePtyRoot, arch: 'x64' })).toBe(false);
     });
 
+    it('ignores entries without the full arch payload instead of picking the first one', () => {
+      makeDir('third_party', 'conpty', '0.0.0-empty');
+      const incomplete = makeDir('third_party', 'conpty', '0.5.0', 'win10-x64');
+      writeFileSync(path.join(incomplete, 'conpty.dll'), 'dll-incomplete');
+      seedThirdParty('x64');
+      seedRebuiltOutput();
+
+      expect(copyConptyDll({ nodePtyRoot, arch: 'x64' })).toBe(true);
+
+      const destDir = path.join(nodePtyRoot, 'build', 'Release', 'conpty');
+      expect(readFileSync(path.join(destDir, 'conpty.dll'), 'utf8')).toBe('dll-x64');
+      expect(readFileSync(path.join(destDir, 'OpenConsole.exe'), 'utf8')).toBe('exe-x64');
+    });
+
+    it('skips without throwing when no version folder has the requested arch', () => {
+      seedThirdParty('x64');
+      seedRebuiltOutput();
+
+      expect(copyConptyDll({ nodePtyRoot, arch: 'arm64' })).toBe(false);
+      expect(existsSync(path.join(nodePtyRoot, 'build', 'Release', 'conpty'))).toBe(false);
+    });
+
     it('skips unsupported architectures', () => {
       seedThirdParty('x64');
       seedRebuiltOutput();

--- a/apps/emdash-desktop/scripts/copy-conpty-dll.test.ts
+++ b/apps/emdash-desktop/scripts/copy-conpty-dll.test.ts
@@ -1,0 +1,93 @@
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { copyConptyDll } from './copy-conpty-dll.ts';
+
+describe('copyConptyDll', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  let nodePtyRoot: string;
+
+  beforeEach(() => {
+    nodePtyRoot = mkdtempSync(path.join(os.tmpdir(), 'emdash-copy-conpty-'));
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform);
+    rmSync(nodePtyRoot, { recursive: true, force: true });
+  });
+
+  function makeDir(...segments: string[]): string {
+    const dir = path.join(nodePtyRoot, ...segments);
+    mkdirSync(dir, { recursive: true });
+    return dir;
+  }
+
+  function seedThirdParty(arch: string): void {
+    const sourceDir = makeDir('third_party', 'conpty', '1.0.0', `win10-${arch}`);
+    writeFileSync(path.join(sourceDir, 'conpty.dll'), `dll-${arch}`);
+    writeFileSync(path.join(sourceDir, 'OpenConsole.exe'), `exe-${arch}`);
+  }
+
+  function seedRebuiltOutput(): void {
+    const release = makeDir('build', 'Release');
+    writeFileSync(path.join(release, 'conpty.node'), '');
+  }
+
+  it('is a no-op on non-Windows platforms', () => {
+    Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'linux' });
+    seedThirdParty('x64');
+    seedRebuiltOutput();
+
+    expect(copyConptyDll({ nodePtyRoot, arch: 'x64' })).toBe(false);
+    expect(existsSync(path.join(nodePtyRoot, 'build', 'Release', 'conpty'))).toBe(false);
+  });
+
+  describe('on Windows', () => {
+    beforeEach(() => {
+      Object.defineProperty(process, 'platform', { ...originalPlatform, value: 'win32' });
+    });
+
+    it('copies the bundled dll next to the rebuilt conpty.node', () => {
+      seedThirdParty('x64');
+      seedRebuiltOutput();
+
+      expect(copyConptyDll({ nodePtyRoot, arch: 'x64' })).toBe(true);
+
+      const destDir = path.join(nodePtyRoot, 'build', 'Release', 'conpty');
+      expect(readFileSync(path.join(destDir, 'conpty.dll'), 'utf8')).toBe('dll-x64');
+      expect(readFileSync(path.join(destDir, 'OpenConsole.exe'), 'utf8')).toBe('exe-x64');
+    });
+
+    it('copies the requested architecture', () => {
+      seedThirdParty('x64');
+      seedThirdParty('arm64');
+      seedRebuiltOutput();
+
+      expect(copyConptyDll({ nodePtyRoot, arch: 'arm64' })).toBe(true);
+
+      const destDir = path.join(nodePtyRoot, 'build', 'Release', 'conpty');
+      expect(readFileSync(path.join(destDir, 'conpty.dll'), 'utf8')).toBe('dll-arm64');
+    });
+
+    it('skips when there is no rebuilt output', () => {
+      seedThirdParty('x64');
+
+      expect(copyConptyDll({ nodePtyRoot, arch: 'x64' })).toBe(false);
+      expect(existsSync(path.join(nodePtyRoot, 'build'))).toBe(false);
+    });
+
+    it('skips when node-pty ships no bundled ConPTY', () => {
+      seedRebuiltOutput();
+
+      expect(copyConptyDll({ nodePtyRoot, arch: 'x64' })).toBe(false);
+    });
+
+    it('skips unsupported architectures', () => {
+      seedThirdParty('x64');
+      seedRebuiltOutput();
+
+      expect(copyConptyDll({ nodePtyRoot, arch: 'ia32' })).toBe(false);
+    });
+  });
+});

--- a/apps/emdash-desktop/scripts/copy-conpty-dll.ts
+++ b/apps/emdash-desktop/scripts/copy-conpty-dll.ts
@@ -32,17 +32,28 @@ export function copyConptyDll(options: { nodePtyRoot: string; arch?: string }): 
     return false;
   }
 
+  const requiredFiles = ['conpty.dll', 'OpenConsole.exe'];
   const conptyBase = path.join(nodePtyRoot, 'third_party', 'conpty');
-  const versionFolder = existsSync(conptyBase) ? readdirSync(conptyBase)[0] : undefined;
+  // Pick the version folder deterministically and only if it holds the full
+  // payload for this arch — readdir order is not guaranteed and stray entries
+  // (dotfiles, incomplete folders) must not win or crash the copy below.
+  const versionFolder = (existsSync(conptyBase) ? readdirSync(conptyBase).sort() : []).find(
+    (folder) =>
+      requiredFiles.every((file) =>
+        existsSync(path.join(conptyBase, folder, `win10-${arch}`, file))
+      )
+  );
   if (!versionFolder) {
-    console.warn(`copy-conpty-dll: no bundled ConPTY found under ${conptyBase}, skipping`);
+    console.warn(
+      `copy-conpty-dll: no bundled ConPTY for arch ${arch} under ${conptyBase}, skipping`
+    );
     return false;
   }
 
   const sourceDir = path.join(conptyBase, versionFolder, `win10-${arch}`);
   const destDir = path.join(releaseDir, 'conpty');
   mkdirSync(destDir, { recursive: true });
-  for (const file of ['conpty.dll', 'OpenConsole.exe']) {
+  for (const file of requiredFiles) {
     copyFileSync(path.join(sourceDir, file), path.join(destDir, file));
   }
   console.log(`copy-conpty-dll: copied ConPTY ${versionFolder} (win10-${arch}) to ${destDir}`);

--- a/apps/emdash-desktop/scripts/copy-conpty-dll.ts
+++ b/apps/emdash-desktop/scripts/copy-conpty-dll.ts
@@ -1,0 +1,61 @@
+import { copyFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Restore node-pty's bundled ConPTY next to the rebuilt native module.
+ *
+ * node-pty's own postinstall copies `third_party/conpty/<ver>/win10-<arch>/`
+ * into `build/Release/conpty/`, but every electron-rebuild (dev postinstall,
+ * `pnpm run rebuild`, release rebuild-native.ts, CI) runs `node-gyp rebuild`,
+ * which wipes build/Release — and with it the dll that `useConptyDll: true`
+ * (see src/main/core/pty/conpty-dll.ts) resolves relative to conpty.node.
+ * This must therefore run after every electron-rebuild of node-pty.
+ *
+ * Returns true when the dll files were copied, false when skipped (non-win32,
+ * no rebuilt output, or a node-pty version without the bundled dll).
+ */
+export function copyConptyDll(options: { nodePtyRoot: string; arch?: string }): boolean {
+  if (process.platform !== 'win32') return false;
+
+  const { nodePtyRoot } = options;
+  const arch = options.arch ?? process.arch;
+  if (!['x64', 'arm64'].includes(arch)) {
+    console.warn(`copy-conpty-dll: unsupported arch ${arch}, skipping`);
+    return false;
+  }
+
+  const releaseDir = path.join(nodePtyRoot, 'build', 'Release');
+  if (!existsSync(path.join(releaseDir, 'conpty.node'))) {
+    // No rebuilt output — node-pty's prebuilds ship their own conpty/ folder.
+    return false;
+  }
+
+  const conptyBase = path.join(nodePtyRoot, 'third_party', 'conpty');
+  const versionFolder = existsSync(conptyBase) ? readdirSync(conptyBase)[0] : undefined;
+  if (!versionFolder) {
+    console.warn(`copy-conpty-dll: no bundled ConPTY found under ${conptyBase}, skipping`);
+    return false;
+  }
+
+  const sourceDir = path.join(conptyBase, versionFolder, `win10-${arch}`);
+  const destDir = path.join(releaseDir, 'conpty');
+  mkdirSync(destDir, { recursive: true });
+  for (const file of ['conpty.dll', 'OpenConsole.exe']) {
+    copyFileSync(path.join(sourceDir, file), path.join(destDir, file));
+  }
+  console.log(`copy-conpty-dll: copied ConPTY ${versionFolder} (win10-${arch}) to ${destDir}`);
+  return true;
+}
+
+export function resolveNodePtyRoot(): string {
+  const require = createRequire(import.meta.url);
+  return path.dirname(require.resolve('node-pty/package.json'));
+}
+
+if (process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  const archFlagIndex = process.argv.indexOf('--arch');
+  const arch = archFlagIndex === -1 ? undefined : process.argv[archFlagIndex + 1];
+  copyConptyDll({ nodePtyRoot: resolveNodePtyRoot(), arch });
+}

--- a/apps/emdash-desktop/scripts/postinstall.ts
+++ b/apps/emdash-desktop/scripts/postinstall.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { copyConptyDll, resolveNodePtyRoot } from './copy-conpty-dll.ts';
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
@@ -75,3 +76,9 @@ if (nativeModules.length === 0) {
 }
 
 runElectronRebuild(nativeModules);
+
+// node-gyp rebuild wipes node-pty's build/Release, deleting the bundled
+// ConPTY that useConptyDll needs at runtime — restore it (no-op off Windows).
+if (!disablePty) {
+  copyConptyDll({ nodePtyRoot: resolveNodePtyRoot() });
+}

--- a/apps/emdash-desktop/scripts/release/rebuild-native.ts
+++ b/apps/emdash-desktop/scripts/release/rebuild-native.ts
@@ -1,6 +1,8 @@
+import path from 'node:path';
 import { cwd } from 'node:process';
 import { parseArgs } from 'node:util';
 import { rebuild } from '@electron/rebuild';
+import { copyConptyDll } from '../copy-conpty-dll.ts';
 import { NATIVE_MODULES } from './lib/config.ts';
 import { exec } from './lib/exec.ts';
 import { fail, info, step } from './lib/log.ts';
@@ -32,5 +34,9 @@ await rebuild({
   force: true,
   buildFromSource: true,
 });
+
+// node-gyp rebuild wipes node-pty's build/Release, deleting the bundled
+// ConPTY that useConptyDll needs at runtime — restore it for the target arch.
+copyConptyDll({ nodePtyRoot: path.join(buildPath, 'node_modules', 'node-pty'), arch });
 
 info(`Native modules rebuilt for ${arch}`);

--- a/apps/emdash-desktop/src/main/core/pty/conpty-dll.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/conpty-dll.test.ts
@@ -1,0 +1,88 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  conptyDllPresentUnder,
+  resetConptyDllCacheForTests,
+  resolveUseConptyDll,
+} from './conpty-dll';
+
+describe('conpty-dll', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!;
+  let tempRoot: string;
+
+  function setPlatform(platform: NodeJS.Platform): void {
+    Object.defineProperty(process, 'platform', {
+      ...originalPlatform,
+      value: platform,
+    });
+  }
+
+  beforeEach(() => {
+    resetConptyDllCacheForTests();
+    tempRoot = mkdtempSync(path.join(os.tmpdir(), 'emdash-conpty-'));
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform);
+    vi.unstubAllEnvs();
+    resetConptyDllCacheForTests();
+    rmSync(tempRoot, { recursive: true, force: true });
+  });
+
+  describe('resolveUseConptyDll', () => {
+    it('is false on non-Windows platforms', () => {
+      setPlatform('darwin');
+      expect(resolveUseConptyDll()).toBe(false);
+    });
+
+    it('is false when disabled via EMDASH_DISABLE_CONPTY_DLL', () => {
+      setPlatform('win32');
+      vi.stubEnv('EMDASH_DISABLE_CONPTY_DLL', '1');
+      expect(resolveUseConptyDll()).toBe(false);
+    });
+  });
+
+  describe('conptyDllPresentUnder', () => {
+    function makeDir(...segments: string[]): string {
+      const dir = path.join(tempRoot, ...segments);
+      mkdirSync(dir, { recursive: true });
+      return dir;
+    }
+
+    it('is true when the dll sits next to the rebuilt conpty.node', () => {
+      const release = makeDir('build', 'Release');
+      writeFileSync(path.join(release, 'conpty.node'), '');
+      const dllDir = makeDir('build', 'Release', 'conpty');
+      writeFileSync(path.join(dllDir, 'conpty.dll'), '');
+
+      expect(conptyDllPresentUnder(tempRoot)).toBe(true);
+    });
+
+    it('is false when the rebuilt output lacks the dll (electron-rebuild wiped it)', () => {
+      const release = makeDir('build', 'Release');
+      writeFileSync(path.join(release, 'conpty.node'), '');
+      // Prebuilds carry the dll, but build/Release wins node-pty's search order.
+      const prebuilds = makeDir('prebuilds', `${process.platform}-${process.arch}`);
+      writeFileSync(path.join(prebuilds, 'conpty.node'), '');
+      const prebuiltDllDir = makeDir('prebuilds', `${process.platform}-${process.arch}`, 'conpty');
+      writeFileSync(path.join(prebuiltDllDir, 'conpty.dll'), '');
+
+      expect(conptyDllPresentUnder(tempRoot)).toBe(false);
+    });
+
+    it('falls back to prebuilds when no rebuilt output exists', () => {
+      const prebuilds = makeDir('prebuilds', `${process.platform}-${process.arch}`);
+      writeFileSync(path.join(prebuilds, 'conpty.node'), '');
+      const dllDir = makeDir('prebuilds', `${process.platform}-${process.arch}`, 'conpty');
+      writeFileSync(path.join(dllDir, 'conpty.dll'), '');
+
+      expect(conptyDllPresentUnder(tempRoot)).toBe(true);
+    });
+
+    it('is false when no native module exists at all', () => {
+      expect(conptyDllPresentUnder(tempRoot)).toBe(false);
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/core/pty/conpty-dll.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/conpty-dll.test.ts
@@ -56,6 +56,7 @@ describe('conpty-dll', () => {
       writeFileSync(path.join(release, 'conpty.node'), '');
       const dllDir = makeDir('build', 'Release', 'conpty');
       writeFileSync(path.join(dllDir, 'conpty.dll'), '');
+      writeFileSync(path.join(dllDir, 'OpenConsole.exe'), '');
 
       expect(conptyDllPresentUnder(tempRoot)).toBe(true);
     });
@@ -77,6 +78,7 @@ describe('conpty-dll', () => {
       writeFileSync(path.join(prebuilds, 'conpty.node'), '');
       const dllDir = makeDir('prebuilds', `${process.platform}-${process.arch}`, 'conpty');
       writeFileSync(path.join(dllDir, 'conpty.dll'), '');
+      writeFileSync(path.join(dllDir, 'OpenConsole.exe'), '');
 
       expect(conptyDllPresentUnder(tempRoot)).toBe(true);
     });

--- a/apps/emdash-desktop/src/main/core/pty/conpty-dll.ts
+++ b/apps/emdash-desktop/src/main/core/pty/conpty-dll.ts
@@ -68,7 +68,10 @@ export function conptyDllPresentUnder(packageRoot: string): boolean {
   ];
   for (const dir of candidateDirs) {
     if (!existsSync(path.join(dir, 'conpty.node'))) continue;
-    return existsSync(path.join(dir, 'conpty', 'conpty.dll'));
+    return (
+      existsSync(path.join(dir, 'conpty', 'conpty.dll')) &&
+      existsSync(path.join(dir, 'conpty', 'OpenConsole.exe'))
+    );
   }
   return false;
 }

--- a/apps/emdash-desktop/src/main/core/pty/conpty-dll.ts
+++ b/apps/emdash-desktop/src/main/core/pty/conpty-dll.ts
@@ -1,0 +1,74 @@
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import path from 'node:path';
+
+/**
+ * Whether local PTYs should ask node-pty to load its bundled, up-to-date
+ * ConPTY (`useConptyDll: true`) instead of the OS in-box conhost.
+ *
+ * The in-box ConPTY on Windows 10 (and older Windows 11 builds) does not pass
+ * mouse-mode DECSETs (1000/1002/1003/1006) or the alternate-screen switch
+ * through to the attached terminal, and silently drops SGR mouse reports
+ * written to its input pipe. Fullscreen TUIs (opencode, claude, amp) are
+ * unusable with it: no mouse clicks, no wheel scrolling, and xterm.js never
+ * even learns the app entered the alternate screen. The bundled conpty.dll
+ * (from the Windows Terminal project) supports full passthrough in both
+ * directions.
+ *
+ * node-pty resolves the dll as `<dir of conpty.node>/conpty/conpty.dll` and
+ * throws synchronously from spawn when it is missing, so we only opt in when
+ * the dll is actually present next to the native module that will load
+ * (electron-rebuild wipes build/Release; the copy step in
+ * scripts/copy-conpty-dll.ts restores it).
+ */
+export function resolveUseConptyDll(): boolean {
+  if (process.platform !== 'win32') return false;
+  if (process.env.EMDASH_DISABLE_CONPTY_DLL === '1') return false;
+  return conptyDllIsPresent();
+}
+
+let cachedPresence: boolean | null = null;
+
+function conptyDllIsPresent(): boolean {
+  if (cachedPresence !== null) return cachedPresence;
+  try {
+    const require = createRequire(import.meta.url);
+    const packageRoot = path.dirname(require.resolve('node-pty/package.json'));
+    cachedPresence = conptyDllPresentUnder(packageRoot);
+  } catch {
+    cachedPresence = false;
+  }
+  return cachedPresence;
+}
+
+/** Test seam: clears the memoized dll-presence check. */
+export function resetConptyDllCacheForTests(): void {
+  cachedPresence = null;
+}
+
+/**
+ * Stop offering the bundled dll for the rest of the process — called when a
+ * spawn with it failed while the in-box ConPTY worked (AV quarantine, broken
+ * copy), so later spawns skip the doomed attempt.
+ */
+export function markConptyDllUnavailable(): void {
+  cachedPresence = false;
+}
+
+/**
+ * Mirrors node-pty's loadNativeModule() search order (lib/utils.ts): the
+ * first directory containing conpty.node is the one that will load, and the
+ * dll must sit in a `conpty/` folder next to it.
+ */
+export function conptyDllPresentUnder(packageRoot: string): boolean {
+  const candidateDirs = [
+    path.join(packageRoot, 'build', 'Release'),
+    path.join(packageRoot, 'build', 'Debug'),
+    path.join(packageRoot, 'prebuilds', `${process.platform}-${process.arch}`),
+  ];
+  for (const dir of candidateDirs) {
+    if (!existsSync(path.join(dir, 'conpty.node'))) continue;
+    return existsSync(path.join(dir, 'conpty', 'conpty.dll'));
+  }
+  return false;
+}

--- a/apps/emdash-desktop/src/main/core/pty/local-pty.integration.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/local-pty.integration.test.ts
@@ -61,6 +61,37 @@ describe('spawnLocalPty integration', () => {
     expect(exit.exitCode).toBe(7);
   });
 
+  // Fullscreen TUI regression (ENG: mouse/scroll dead in opencode/claude/amp on
+  // Windows): the in-box Windows 10 ConPTY swallows mouse-mode and alt-screen
+  // DECSETs instead of passing them to the attached terminal, so xterm.js never
+  // enters mouse-tracking mode. With node-pty's bundled ConPTY
+  // (useConptyDll, see conpty-dll.ts) the sequences must arrive verbatim.
+  it.runIf(process.platform === 'win32')(
+    'passes mouse-mode DECSETs through to the terminal on Windows',
+    async () => {
+      const pty = spawnLocalPty({
+        id: 'local-mouse-decset-integration',
+        command: process.execPath,
+        args: [
+          '-e',
+          'process.stdout.write("\\x1b[?1049h\\x1b[?1002h\\x1b[?1006hready\\n"); setTimeout(() => process.exit(0), 200);',
+        ],
+        cwd: await tempCwd(),
+        env: { ...process.env, TERM: 'xterm-256color' } as Record<string, string>,
+        cols: 80,
+        rows: 24,
+      });
+
+      const exitPromise = waitForExit((handler) => pty.onExit(handler));
+      const data = await waitForData((handler) => pty.onData(handler), /ready/);
+      await exitPromise;
+
+      expect(data).toContain('\x1b[?1002h');
+      expect(data).toContain('\x1b[?1006h');
+      expect(data).toContain('\x1b[?1049h');
+    }
+  );
+
   it('can kill a real long-running local PTY process', async () => {
     const pty = spawnLocalPty({
       id: 'local-kill-integration',

--- a/apps/emdash-desktop/src/main/core/pty/local-pty.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/local-pty.test.ts
@@ -1,10 +1,28 @@
+import * as nodePty from 'node-pty';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
-import { LocalPtySession } from './local-pty';
+import { markConptyDllUnavailable, resolveUseConptyDll } from './conpty-dll';
+import { LocalPtySession, spawnLocalPty } from './local-pty';
 import type { PosixPtyTerminator } from './posix-pty-terminator';
 
 vi.mock('node-pty', () => ({
   spawn: vi.fn(),
 }));
+
+vi.mock('./conpty-dll', () => ({
+  resolveUseConptyDll: vi.fn(() => false),
+  markConptyDllUnavailable: vi.fn(),
+}));
+
+function makeMockProc(pid = 1234) {
+  return {
+    pid,
+    write: vi.fn(),
+    resize: vi.fn(),
+    kill: vi.fn(),
+    onData: vi.fn(),
+    onExit: vi.fn(),
+  };
+}
 
 describe('LocalPtySession', () => {
   type MockPtyProcess = ConstructorParameters<typeof LocalPtySession>[1];
@@ -22,14 +40,7 @@ describe('LocalPtySession', () => {
   }
 
   function createPty(pid = 1234): void {
-    mockProc = {
-      pid,
-      write: vi.fn(),
-      resize: vi.fn(),
-      kill: vi.fn(),
-      onData: vi.fn(),
-      onExit: vi.fn(),
-    } as unknown as MockPtyProcess;
+    mockProc = makeMockProc(pid) as unknown as MockPtyProcess;
     posixTerminator = {
       kill: vi.fn(),
       markExited: vi.fn(),
@@ -90,6 +101,76 @@ describe('LocalPtySession', () => {
 
     expect(posixTerminator.kill).toHaveBeenCalledTimes(1);
     expect(mockProc.kill).not.toHaveBeenCalled();
+  });
+
+  describe('spawnLocalPty ConPTY selection', () => {
+    const spawnOptions = {
+      id: 'test-id',
+      command: 'cmd.exe',
+      args: [],
+      cwd: 'C:\\',
+      env: {},
+      cols: 80,
+      rows: 24,
+    };
+
+    function fakeProc(): ReturnType<typeof nodePty.spawn> {
+      return makeMockProc(42) as unknown as ReturnType<typeof nodePty.spawn>;
+    }
+
+    it('passes the resolved useConptyDll flag to node-pty', () => {
+      vi.mocked(resolveUseConptyDll).mockReturnValue(true);
+      vi.mocked(nodePty.spawn).mockReturnValue(fakeProc());
+
+      spawnLocalPty(spawnOptions);
+
+      expect(nodePty.spawn).toHaveBeenCalledWith(
+        'cmd.exe',
+        [],
+        expect.objectContaining({ useConptyDll: true })
+      );
+    });
+
+    it('retries with the in-box ConPTY when the bundled dll fails to spawn', () => {
+      vi.mocked(resolveUseConptyDll).mockReturnValue(true);
+      vi.mocked(nodePty.spawn)
+        .mockImplementationOnce(() => {
+          throw new Error('Cannot find conpty.dll');
+        })
+        .mockReturnValueOnce(fakeProc());
+
+      const session = spawnLocalPty(spawnOptions);
+
+      expect(session).toBeInstanceOf(LocalPtySession);
+      expect(nodePty.spawn).toHaveBeenCalledTimes(2);
+      expect(vi.mocked(nodePty.spawn).mock.calls[1]![2]).toMatchObject({ useConptyDll: false });
+      // The in-box fallback worked, so the dll is the problem — later spawns
+      // must skip the doomed bundled-dll attempt.
+      expect(markConptyDllUnavailable).toHaveBeenCalledTimes(1);
+    });
+
+    it('throws when both spawn attempts fail', () => {
+      vi.mocked(resolveUseConptyDll).mockReturnValue(true);
+      vi.mocked(nodePty.spawn).mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      expect(() => spawnLocalPty(spawnOptions)).toThrow('Failed to spawn PTY: boom');
+      expect(nodePty.spawn).toHaveBeenCalledTimes(2);
+      // Both attempts failing means the failure is not dll-specific — keep
+      // the bundled dll enabled for future spawns.
+      expect(markConptyDllUnavailable).not.toHaveBeenCalled();
+    });
+
+    it('does not retry when the bundled dll was not requested', () => {
+      vi.mocked(resolveUseConptyDll).mockReturnValue(false);
+      vi.mocked(nodePty.spawn).mockImplementation(() => {
+        throw new Error('boom');
+      });
+
+      expect(() => spawnLocalPty(spawnOptions)).toThrow('Failed to spawn PTY: boom');
+      expect(nodePty.spawn).toHaveBeenCalledTimes(1);
+    });
   });
 
   it('onExit() marks the POSIX terminator exited before forwarding exit info', () => {

--- a/apps/emdash-desktop/src/main/core/pty/local-pty.ts
+++ b/apps/emdash-desktop/src/main/core/pty/local-pty.ts
@@ -1,6 +1,7 @@
 import * as nodePty from 'node-pty';
 import type { IPty } from 'node-pty';
 import { log } from '@main/lib/logger';
+import { markConptyDllUnavailable, resolveUseConptyDll } from './conpty-dll';
 import { normalizeSignal } from './exit-signals';
 import { suppressExpectedNodePtyErrors } from './node-pty-errors';
 import { PosixPtyTerminator } from './posix-pty-terminator';
@@ -29,20 +30,47 @@ export function spawnLocalPty(options: LocalSpawnOptions): LocalPtySession {
     rows,
   });
 
-  try {
+  const spawn = (useConptyDll: boolean) => {
     const proc = nodePty.spawn(command, args, {
       name: 'xterm-256color',
       cols,
       rows,
       cwd,
       env,
+      useConptyDll,
     });
     suppressExpectedNodePtyErrors(proc);
     return new LocalPtySession(id, proc);
+  };
+
+  const useConptyDll = resolveUseConptyDll();
+  try {
+    return spawn(useConptyDll);
   } catch (e: unknown) {
-    const message = e instanceof Error ? e.message : String(e);
-    throw new Error(`Failed to spawn PTY: ${message}`);
+    if (!useConptyDll) throw spawnError(e);
+
+    // The bundled ConPTY can fail to load (AV quarantine, broken copy step).
+    // A PTY without mouse passthrough beats no PTY at all.
+    log.warn('LocalPtySession: bundled conpty.dll spawn failed, retrying with in-box ConPTY', {
+      id,
+      error: e instanceof Error ? e.message : String(e),
+    });
+    let session: LocalPtySession;
+    try {
+      session = spawn(false);
+    } catch (retryError: unknown) {
+      throw spawnError(retryError);
+    }
+    // The in-box ConPTY succeeded where the bundled dll failed, so the dll is
+    // the problem — stop paying a doomed spawn attempt on every future PTY.
+    markConptyDllUnavailable();
+    return session;
   }
+}
+
+function spawnError(e: unknown): Error {
+  const message = e instanceof Error ? e.message : String(e);
+  return new Error(`Failed to spawn PTY: ${message}`);
 }
 
 export class LocalPtySession implements Pty {


### PR DESCRIPTION
### Description
- fullscreen tuis (openode,cc,amp,etc.) in terminals on win 10 used to get no mouse input, wheel scrolling or usable text selection
- conpty swallos mouse-mode/alt-screen requests and drops mouse reports
- local pty now spawn with node-pty `useConptyDll:true`, loading the bundled upt odate conpty
- use bundled conpty for windows ptys
- restore conpty files after native rebuilds

### Screenshot/Recording (if applicable)
on windows:
https://cap.link/p11pxnh1aefg92x

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
