### PR TITLE
fix(feedback): replace deleted Discord webhook

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/components/feedback-modal/use-feedback-submit.ts
+++ b/apps/emdash-desktop/src/renderer/lib/components/feedback-modal/use-feedback-submit.ts
@@ -4,7 +4,7 @@ import { log } from '@renderer/utils/logger';
 import { FEEDBACK_EMAIL_SCHEMA } from './schemas/feedback-email';
 
 const DISCORD_WEBHOOK_URL =
-  'https://discord.com/api/webhooks/1473390363388416230/eRIo1UhylapH94KpqUUp5PDzkLhjBvcnjjyE_JezfHiAyfN3QEbRyEIJaSl8QQUz7Mak';
+  'https://discord.com/api/webhooks/1522337356185862194/pwsawgdkELfRDfT8y0dY463cfoAspkyRBVw6zjsS-oof2TJEqKm1igH6u1WFjL0PE0in';
 
 const DISCORD_MAX_FILES = 10;
 const DISCORD_MAX_PAYLOAD_BYTES = 8 * 1024 * 1024;


### PR DESCRIPTION
## Summary
In-app feedback submissions were always failing: the hardcoded Discord webhook was deleted on Discord's side (API returns `10015 Unknown Webhook` / HTTP 404), so every submit threw and showed the generic error toast.

This hotfix swaps in a newly created webhook. The new URL was verified working (HTTP 204 on a test POST).

Note: the webhook URL still ships in the renderer bundle and is extractable — the planned move to Slack (separate PR) should ideally relay through a server endpoint instead.

## Checks
- Verified new webhook accepts POSTs (204)
