### PR TITLE
feat(codex): install via curl script instead of npm

### DIFF
--- a/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts
@@ -107,7 +107,7 @@ export const AGENT_PROVIDERS: AgentProviderDefinition[] = [
     description:
       'CLI that connects to OpenAI models for project-aware code assistance and terminal workflows.',
     docUrl: 'https://github.com/openai/codex',
-    installCommand: 'npm install -g @openai/codex',
+    installCommand: 'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
     commands: ['codex'],
     versionArgs: ['--version'],
     cli: 'codex',

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -6,7 +6,6 @@ import {
   buildStandardCommand,
   codexMcpAdapter,
   homebrewOption,
-  npmDependency,
 } from '@emdash/core/agents/plugins/helpers';
 import { buildCodexHookConfig } from './hooks';
 import { icon } from './icon';
@@ -54,12 +53,40 @@ export const plugin = definePlugin(
       scope: 'global',
       supportedEvents: ['notification', 'stop', 'session'],
     },
-    hostDependency: npmDependency({
+    hostDependency: {
       id: 'codex',
-      package: '@openai/codex',
-      extraOptions: {
-        macos: [homebrewOption({ formula: 'codex', cask: true })],
-        linux: [homebrewOption({ formula: 'codex', cask: true })],
+      binaryNames: ['codex'],
+      installCommands: {
+        macos: [
+          {
+            method: 'curl',
+            command: 'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
+            updateCommand: 'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
+            recommended: true,
+          },
+          {
+            method: 'npm',
+            command: 'npm install -g @openai/codex',
+            updateCommand: 'npm install -g @openai/codex',
+            uninstallCommand: 'npm uninstall -g @openai/codex',
+          },
+          homebrewOption({ formula: 'codex', cask: true }),
+        ],
+        linux: [
+          {
+            method: 'curl',
+            command: 'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
+            updateCommand: 'curl -fsSL https://chatgpt.com/codex/install.sh | sh',
+            recommended: true,
+          },
+          {
+            method: 'npm',
+            command: 'npm install -g @openai/codex',
+            updateCommand: 'npm install -g @openai/codex',
+            uninstallCommand: 'npm uninstall -g @openai/codex',
+          },
+          homebrewOption({ formula: 'codex', cask: true }),
+        ],
         windows: [
           {
             method: 'powershell',
@@ -67,10 +94,30 @@ export const plugin = definePlugin(
               'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
             updateCommand:
               'powershell -ExecutionPolicy ByPass -c "irm https://chatgpt.com/codex/install.ps1 | iex"',
+            recommended: true,
+          },
+          {
+            method: 'npm',
+            command: 'npm install -g @openai/codex',
+            updateCommand: 'npm install -g @openai/codex',
+            uninstallCommand: 'npm uninstall -g @openai/codex',
           },
         ],
       },
-    }),
+      updates: {
+        kind: 'supported',
+        releaseSource: {
+          kind: 'npm',
+          package: '@openai/codex',
+        },
+        update: {
+          kind: 'package-manager',
+        },
+      },
+      uninstall: {
+        kind: 'package-manager',
+      },
+    },
     mcp: {
       kind: 'supported',
       scope: 'global',


### PR DESCRIPTION
## Summary

Codex was the only shell-installable provider still defaulting to `npm install -g @openai/codex`. OpenAI ships an official install script — the same one already referenced by the existing Windows PowerShell installer (`chatgpt.com/codex/install.ps1`) — so this makes **curl the recommended install method on macOS/Linux**, consistent with `claude`, `grok`, `droid`, and the other curl-based providers.

## Changes

- **`packages/plugins/src/agents/impl/codex/index.ts`** — replaced the `npmDependency(...)` helper with an explicit `hostDependency` descriptor (mirroring the `grok` pattern):
  - macOS/Linux: `curl -fsSL https://chatgpt.com/codex/install.sh | sh` (recommended), with `npm` and the homebrew cask kept as fallbacks
  - Windows: existing PowerShell installer now marked recommended, with `npm` fallback
  - `updates` continue to resolve through the npm release source (`@openai/codex`)
- **`apps/emdash-desktop/src/shared/core/agents/agent-provider-registry.ts`** — updated the flat `installCommand` metadata string to the curl command.

## Checks run

- `@emdash/plugins` typecheck ✅ and tests ✅ (101 passed, incl. the generic install-command validation suite)
- `@emdash/emdash-desktop` typecheck ✅
- `@emdash/core` host-dependencies tests ✅ (80 passed)
- Desktop `dependencies` tests ✅ (34 passed; the `install-runner` suite was skipped locally only because Electron's binary wasn't downloaded in this sandbox — unrelated to the change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)