### PR TITLE
fix: automation branch not respecetd

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/useAutomationFormState.ts
@@ -1,4 +1,3 @@
-import type { GitBranchRef } from '@emdash/core/git';
 import { useMemo, useState } from 'react';
 import { DEFAULT_CRON_STATE, toCron } from '@renderer/lib/CronPicker/cron-utils';
 import { isValidProviderId } from '@shared/core/agents/agent-provider-registry';
@@ -26,7 +25,7 @@ const DEFAULT_CRON = toCron(DEFAULT_CRON_STATE);
  */
 function workspaceInitialFromConfig(
   config: StoredAutomationTaskConfig | null | undefined
-): WorkspaceConfigInitial & { fromBranch?: GitBranchRef; pushBranch?: boolean } {
+): WorkspaceConfigInitial {
   if (!config) return { mode: 'new-worktree', presetId: 'new-worktree' };
   const { git, workspace } = config.workspaceConfig;
 
@@ -38,8 +37,22 @@ function workspaceInitialFromConfig(
     return {
       mode: 'new-worktree',
       presetId: 'new-worktree',
-      fromBranch: git.fromBranch,
-      pushBranch: git.pushBranch,
+      branchSelection: {
+        createBranchAndWorktree: true,
+        branchOverride: git.fromBranch,
+        pushBranch: git.pushBranch,
+      },
+    };
+  }
+
+  if (git.kind === 'use-branch') {
+    return {
+      mode: 'new-worktree',
+      presetId: 'new-worktree',
+      branchSelection: {
+        createBranchAndWorktree: false,
+        branchOverride: { type: 'local', branch: git.branchName },
+      },
     };
   }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-branch-selection.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-branch-selection.ts
@@ -14,7 +14,6 @@ export function useBranchSelection(
   selectedProjectId: string | undefined,
   defaultBranch: GitBranchRef | undefined,
   isUnborn: boolean,
-  currentBranchName?: string | null,
   initial?: BranchSelectionInitial,
   createBranchAndWorktreeByDefault = true
 ) {
@@ -44,11 +43,9 @@ export function useBranchSelection(
   );
 
   const selectedBranch: GitBranchRef | undefined =
-    !createBranchAndWorktree && currentBranchName
-      ? { type: 'local', branch: currentBranchName }
-      : branchOverride !== undefined && branchOverride.projectId === selectedProjectId
-        ? branchOverride.branch
-        : defaultBranch;
+    branchOverride !== undefined && branchOverride.projectId === selectedProjectId
+      ? branchOverride.branch
+      : defaultBranch;
 
   const setSelectedBranch = useCallback(
     (branch: GitBranchRef | undefined) => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-branch-selection.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-branch-selection.ts
@@ -13,6 +13,7 @@ export type BranchSelectionInitial = {
 export function useBranchSelection(
   selectedProjectId: string | undefined,
   defaultBranch: GitBranchRef | undefined,
+  currentBranchName: string | null,
   isUnborn: boolean,
   initial?: BranchSelectionInitial,
   createBranchAndWorktreeByDefault = true
@@ -42,10 +43,17 @@ export function useBranchSelection(
       : undefined
   );
 
+  const fallbackBranch =
+    !createBranchAndWorktree &&
+    currentBranchName &&
+    !(initial?.createBranchAndWorktree === false && initial.branchOverride === undefined)
+      ? ({ type: 'local', branch: currentBranchName } satisfies GitBranchRef)
+      : defaultBranch;
+
   const selectedBranch: GitBranchRef | undefined =
     branchOverride !== undefined && branchOverride.projectId === selectedProjectId
       ? branchOverride.branch
-      : defaultBranch;
+      : fallbackBranch;
 
   const setSelectedBranch = useCallback(
     (branch: GitBranchRef | undefined) => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.test.ts
@@ -77,6 +77,26 @@ describe('useWorkspaceConfig initial branch selection', () => {
     });
   }
 
+  it('uses the configured default branch when checkout mode has no explicit selection', async () => {
+    await renderProbe({
+      mode: 'new-worktree',
+      presetId: 'new-worktree',
+      branchSelection: {
+        createBranchAndWorktree: false,
+      },
+    });
+
+    expect(latestState?.branchSelection.createBranchAndWorktree).toBe(false);
+    expect(latestState?.branchSelection.selectedBranch).toEqual({
+      type: 'local',
+      branch: 'main',
+    });
+    expect(latestState?.resolvedConfig.git).toEqual({
+      kind: 'use-branch',
+      branchName: 'main',
+    });
+  });
+
   it('restores checkout-branch automations as use-branch configs', async () => {
     await renderProbe({
       mode: 'new-worktree',

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.test.ts
@@ -1,0 +1,119 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { WorkspaceConfigState } from './use-workspace-config';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: () => ({ value: { pushOnCreate: true } }),
+}));
+
+vi.mock('@renderer/features/projects/stores/project-selectors', () => ({
+  getGitRepositoryStore: () => undefined,
+}));
+
+vi.mock('@renderer/features/tasks/task-config/existing-workspace-picker', () => ({
+  useProjectWorkspaces: () => ({ data: [] }),
+}));
+
+vi.mock('./use-branch-name', () => ({
+  useBranchName: () => ({
+    branchName: 'generated-task-branch',
+    setBranchName: vi.fn(),
+    branchAlreadyExists: false,
+  }),
+}));
+
+const { useWorkspaceConfig } = await import('./use-workspace-config');
+
+let latestState: WorkspaceConfigState | undefined;
+
+function Probe({ initial }: { initial: Parameters<typeof useWorkspaceConfig>[0]['initial'] }) {
+  latestState = useWorkspaceConfig({
+    projectId: 'project-1',
+    defaultBranch: { type: 'local', branch: 'main' },
+    isUnborn: false,
+    currentBranch: 'current-branch',
+    repositoryWorkspaceId: 'repo-workspace-1',
+    pr: null,
+    taskName: 'Generated task branch',
+    linkedIssue: null,
+    createBranchAndWorktreeDefault: true,
+    resetKey: 'project-1',
+    initial,
+  });
+  return null;
+}
+
+describe('useWorkspaceConfig initial branch selection', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    latestState = undefined;
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  async function renderProbe(initial: Parameters<typeof useWorkspaceConfig>[0]['initial']) {
+    await act(async () => {
+      root.render(React.createElement(Probe, { initial }));
+    });
+  }
+
+  it('restores checkout-branch automations as use-branch configs', async () => {
+    await renderProbe({
+      mode: 'new-worktree',
+      presetId: 'new-worktree',
+      branchSelection: {
+        createBranchAndWorktree: false,
+        branchOverride: { type: 'local', branch: 'release/v2' },
+      },
+    });
+
+    expect(latestState?.branchSelection.createBranchAndWorktree).toBe(false);
+    expect(latestState?.resolvedConfig.git).toEqual({
+      kind: 'use-branch',
+      branchName: 'release/v2',
+    });
+  });
+
+  it('restores create-branch automations with the stored fromBranch', async () => {
+    await renderProbe({
+      mode: 'new-worktree',
+      presetId: 'new-worktree',
+      branchSelection: {
+        createBranchAndWorktree: true,
+        branchOverride: { type: 'local', branch: 'release/v2' },
+        pushBranch: false,
+      },
+    });
+
+    expect(latestState?.branchSelection.selectedBranch).toEqual({
+      type: 'local',
+      branch: 'release/v2',
+    });
+    expect(latestState?.resolvedConfig.git).toEqual({
+      kind: 'create-branch',
+      branchName: 'generated-task-branch',
+      fromBranch: { type: 'local', branch: 'release/v2' },
+      pushBranch: false,
+    });
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.test.ts
@@ -49,7 +49,7 @@ function Probe({ initial }: { initial: Parameters<typeof useWorkspaceConfig>[0][
   return null;
 }
 
-describe('useWorkspaceConfig initial branch selection', () => {
+describe('useWorkspaceConfig branch selection', () => {
   let dom: JSDOM;
   let root: Root;
   let container: HTMLDivElement;
@@ -77,7 +77,25 @@ describe('useWorkspaceConfig initial branch selection', () => {
     });
   }
 
-  it('uses the configured default branch when checkout mode has no explicit selection', async () => {
+  it('uses the current branch when checkout mode is selected without an explicit branch', async () => {
+    await renderProbe(undefined);
+
+    act(() => {
+      latestState?.branchSelection.setCreateBranchAndWorktree(false);
+    });
+
+    expect(latestState?.branchSelection.createBranchAndWorktree).toBe(false);
+    expect(latestState?.branchSelection.selectedBranch).toEqual({
+      type: 'local',
+      branch: 'current-branch',
+    });
+    expect(latestState?.resolvedConfig.git).toEqual({
+      kind: 'use-branch',
+      branchName: 'current-branch',
+    });
+  });
+
+  it('uses the configured default branch when initial checkout mode has no explicit selection', async () => {
     await renderProbe({
       mode: 'new-worktree',
       presetId: 'new-worktree',

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.ts
@@ -11,7 +11,11 @@ import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
 import type { WorkspacePresetId } from '@shared/core/workspaces/workspace-presets';
 import { compileSetupSpec } from '@shared/core/workspaces/workspace-setup-spec';
 import { useBranchName, type BranchNameState } from './use-branch-name';
-import { useBranchSelection, type BranchSelectionState } from './use-branch-selection';
+import {
+  useBranchSelection,
+  type BranchSelectionInitial,
+  type BranchSelectionState,
+} from './use-branch-selection';
 
 // ---------------------------------------------------------------------------
 // Types
@@ -111,6 +115,7 @@ export type WorkspaceConfigInitial = {
   mode?: WorkspaceMode;
   presetId?: WorkspacePresetId;
   selectedWorkspaceId?: string | null;
+  branchSelection?: BranchSelectionInitial;
 };
 
 export function useWorkspaceConfig(opts: {
@@ -190,8 +195,7 @@ export function useWorkspaceConfig(opts: {
     projectId,
     defaultBranch,
     isUnborn,
-    currentBranch,
-    undefined,
+    initial?.branchSelection,
     createBranchAndWorktreeDefault
   );
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/use-workspace-config.ts
@@ -194,6 +194,7 @@ export function useWorkspaceConfig(opts: {
   const branchSelection = useBranchSelection(
     projectId,
     defaultBranch,
+    currentBranch,
     isUnborn,
     initial?.branchSelection,
     createBranchAndWorktreeDefault


### PR DESCRIPTION
### Description
- restores saved automation branch selections for checkout and new branch workflows
- ensures "from branch" is respected when automation settings are reopened or saved

### Screenshot/Recording (if applicable)
https://cap.link/9jz12c3c407bma1

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
