### PR TITLE
fix(tabs): keep tab trigger full height

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tabs/tab-bar/tab-context-menu.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tabs/tab-bar/tab-context-menu.tsx
@@ -82,7 +82,7 @@ export const TabContextMenu = observer(function TabContextMenu({
 
   return (
     <ContextMenu>
-      <ContextMenuTrigger>{children}</ContextMenuTrigger>
+      <ContextMenuTrigger className="flex h-full">{children}</ContextMenuTrigger>
       <ContextMenuContent finalFocus={false}>
         {visibleEngine.map((cmd) => (
           <ContextMenuItem key={cmd.id} onClick={() => void cmd.run()}>


### PR DESCRIPTION
### Description
fixes the border issue in the topbar 

### Screenshot/Recording (if applicable)
before:
<img width="351" height="50" alt="Screenshot 2026-07-03 at 19 08 32" src="https://github.com/user-attachments/assets/73d6865d-0b6b-4bfa-bf27-39499bbd1f8e" />

after:
<img width="343" height="56" alt="Screenshot 2026-07-03 at 19 08 28" src="https://github.com/user-attachments/assets/82d7e9d1-233c-4140-99bc-e372320bfbce" />

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
