### PR TITLE
fix(settings): center version badge text

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/settings/components/UpdateCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/UpdateCard.tsx
@@ -16,7 +16,7 @@ export const UpdateCard = observer(function UpdateCard(): React.JSX.Element {
     <div className="flex items-center gap-2">
       Version
       {update.currentVersion && (
-        <Badge variant="outline" className="h-5 px-2 font-mono text-xs">
+        <Badge variant="outline" className="h-5 px-2 font-mono text-xs leading-none">
           v{update.currentVersion}
         </Badge>
       )}


### PR DESCRIPTION
### Description
- center version in badge text in settings

### Screenshot/Recording (if applicable)
before:
<img width="202" height="65" alt="Screenshot 2026-07-04 at 22 25 40" src="https://github.com/user-attachments/assets/c6f94d84-1ca4-4d1f-8114-1071783b9dd9" />

after:
<img width="240" height="90" alt="Screenshot 2026-07-04 at 22 25 20" src="https://github.com/user-attachments/assets/adf9679c-d455-4154-9b7d-74fe9fb64ed8" />

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
