### PR TITLE
feat: add stop all controls

### DIFF
--- a/apps/emdash-desktop/src/main/core/preview-servers/controller.ts
+++ b/apps/emdash-desktop/src/main/core/preview-servers/controller.ts
@@ -6,6 +6,8 @@ export const previewServersController = createRPCController({
   listForWorkspace: async (args: { projectId: string; workspaceId: string }) =>
     previewServerService.listForWorkspace(args),
 
+  listAll: async () => previewServerService.listAll(),
+
   forwardManual: async (request: ManualPreviewServerRequest) =>
     previewServerService.forwardManual(request),
 
@@ -13,6 +15,8 @@ export const previewServersController = createRPCController({
 
   stopForWorkspace: async (args: { projectId: string; workspaceId: string }) =>
     previewServerService.stopForWorkspace(args.projectId, args.workspaceId),
+
+  stopAll: async () => previewServerService.stopAll(),
 
   restart: async (id: string) => previewServerService.restart(id),
 });

--- a/apps/emdash-desktop/src/main/core/preview-servers/controller.ts
+++ b/apps/emdash-desktop/src/main/core/preview-servers/controller.ts
@@ -11,5 +11,8 @@ export const previewServersController = createRPCController({
 
   stop: async (id: string) => previewServerService.stop(id),
 
+  stopForWorkspace: async (args: { projectId: string; workspaceId: string }) =>
+    previewServerService.stopForWorkspace(args.projectId, args.workspaceId),
+
   restart: async (id: string) => previewServerService.restart(id),
 });

--- a/apps/emdash-desktop/src/main/core/preview-servers/preview-server-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/preview-servers/preview-server-service.test.ts
@@ -590,4 +590,40 @@ describe('PreviewServerService', () => {
       'preview:ssh:auto:project-1:workspace-1:connection-1:5173',
     ]);
   });
+
+  it('lists and stops previews across all projects and workspaces', async () => {
+    const context = createService();
+    const local = await context.service.registerDetectedTarget({
+      projectId: 'project-1',
+      workspaceId: 'workspace-1',
+      transport: 'local',
+      source: { kind: 'terminal-output', terminalId: 'terminal-1' },
+      protocol: 'http:',
+      host: 'localhost',
+      port: 5173,
+      urlPath: '/',
+    });
+    const forwarded = await context.service.registerDetectedTarget({
+      projectId: 'project-2',
+      workspaceId: 'workspace-2',
+      connectionId: 'connection-1',
+      transport: 'ssh',
+      proxy: fakeProxy(),
+      source: { kind: 'terminal-output', terminalId: 'terminal-2' },
+      protocol: 'http:',
+      port: 5174,
+      urlPath: '/',
+    });
+
+    expect(context.service.listAll()).toEqual([local, forwarded]);
+
+    await context.service.stopAll();
+
+    expect(context.service.listAll()).toEqual([]);
+    expect(context.events).toContainEqual({ type: 'remove', id: local.id });
+    expect(context.events).toContainEqual({ type: 'remove', id: forwarded.id });
+    expect(context.closedTunnelIds).toEqual([
+      'preview:ssh:auto:project-2:workspace-2:connection-1:5174',
+    ]);
+  });
 });

--- a/apps/emdash-desktop/src/main/core/preview-servers/preview-server-service.ts
+++ b/apps/emdash-desktop/src/main/core/preview-servers/preview-server-service.ts
@@ -182,6 +182,10 @@ export class PreviewServerService {
     );
   }
 
+  listAll(): PreviewServer[] {
+    return Array.from(this.servers.values());
+  }
+
   async handleTerminalSourceClosed(input: TerminalSourceClosedInput): Promise<void> {
     if (input.transport === 'local') {
       await this.stopForTerminal(input);
@@ -367,6 +371,11 @@ export class PreviewServerService {
     const ids = Array.from(this.servers.values())
       .filter((server) => server.projectId === projectId)
       .map((server) => server.id);
+    await Promise.all(ids.map((id) => this.stop(id)));
+  }
+
+  async stopAll(): Promise<void> {
+    const ids = Array.from(this.servers.keys());
     await Promise.all(ids.map((id) => this.stop(id)));
   }
 

--- a/apps/emdash-desktop/src/renderer/features/settings/components/PreviewServersSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/PreviewServersSettingsCard.tsx
@@ -1,0 +1,225 @@
+import { ExternalLinkIcon, GlobeIcon, SquareIcon } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import type { ReactNode } from 'react';
+import { useEffect, useState } from 'react';
+import {
+  getProjectStore,
+  projectDisplayName,
+} from '@renderer/features/projects/stores/project-selectors';
+import {
+  formatPreviewServerLabel,
+  previewServerStatusLabel,
+} from '@renderer/features/tasks/components/preview-servers/preview-server-format';
+import {
+  asProvisioned,
+  getTaskManagerStore,
+  taskDisplayName,
+} from '@renderer/features/tasks/stores/task-selectors';
+import { events, rpc } from '@renderer/lib/ipc';
+import { Badge } from '@renderer/lib/ui/badge';
+import { Button } from '@renderer/lib/ui/button';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
+import { cn } from '@renderer/utils/utils';
+import { previewServerEventChannel } from '@shared/core/preview-servers/events';
+import type { PreviewServer } from '@shared/core/preview-servers/types';
+import { previewServerUrl } from '@shared/core/preview-servers/types';
+
+export const PreviewServersSettingsCard = observer(function PreviewServersSettingsCard() {
+  const [servers, setServers] = useState<PreviewServer[]>([]);
+
+  useEffect(() => {
+    let disposed = false;
+    void rpc.previewServers.listAll().then((list) => {
+      if (!disposed) setServers(sortServers(list));
+    });
+    const unsubscribe = events.on(previewServerEventChannel, (event) => {
+      setServers((current) => {
+        const next = new Map(current.map((server) => [server.id, server]));
+        if (event.type === 'upsert') {
+          next.set(event.server.id, event.server);
+        } else {
+          next.delete(event.id);
+        }
+        return sortServers(Array.from(next.values()));
+      });
+    });
+    return () => {
+      disposed = true;
+      unsubscribe();
+    };
+  }, []);
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex min-w-0 flex-col gap-0.5">
+          <h3 className="text-sm font-normal text-foreground">Preview servers</h3>
+          <p className="text-xs text-foreground-passive">
+            Detected servers and port forwards across all projects and tasks.
+          </p>
+        </div>
+        {servers.length > 0 ? (
+          <Button
+            type="button"
+            variant="ghost"
+            className="hover:bg-destructive/10 text-foreground-destructive hover:text-foreground-destructive"
+            onClick={() => void rpc.previewServers.stopAll()}
+          >
+            <SquareIcon className="size-3 fill-current" />
+            Stop all
+          </Button>
+        ) : null}
+      </div>
+
+      {servers.length === 0 ? (
+        <div className="bg-muted/10 flex min-h-32 flex-col items-center justify-center rounded-lg border border-border p-8 text-center">
+          <GlobeIcon className="mb-3 size-8 text-foreground-passive" />
+          <div className="text-sm text-foreground">No preview servers running</div>
+          <p className="mt-1 max-w-sm text-xs text-foreground-passive">
+            Servers detected in task terminals and SSH port forwards show up here.
+          </p>
+        </div>
+      ) : (
+        <div className="flex flex-col gap-3">
+          {servers.map((server) => (
+            <PreviewServerSettingsRow key={server.id} server={server} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+});
+
+function ServerActionButton({
+  label,
+  children,
+  disabled,
+  className,
+  onClick,
+}: {
+  label: string;
+  children: ReactNode;
+  disabled?: boolean;
+  className?: string;
+  onClick: () => void;
+}) {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger
+          render={
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              className={className}
+              onClick={onClick}
+              disabled={disabled}
+              aria-label={label}
+            >
+              {children}
+            </Button>
+          }
+        />
+        <TooltipContent>{label}</TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}
+
+function PreviewServerStatusBadge({ server }: { server: PreviewServer }) {
+  const kind = server.status.kind;
+  const isBusy = kind === 'starting' || kind === 'reconnecting';
+
+  return (
+    <Badge
+      variant={kind === 'failed' ? 'destructive' : 'secondary'}
+      className={cn(
+        'gap-1.5',
+        kind === 'ready' && 'text-foreground-success',
+        isBusy && 'text-foreground-warning'
+      )}
+    >
+      <span
+        className={cn(
+          'size-1.5 rounded-full bg-foreground-muted',
+          kind === 'ready' && 'bg-foreground-success',
+          isBusy && 'bg-foreground-warning',
+          kind === 'failed' && 'bg-destructive'
+        )}
+      />
+      {previewServerStatusLabel(server)}
+    </Badge>
+  );
+}
+
+const PreviewServerSettingsRow = observer(function PreviewServerSettingsRow({
+  server,
+}: {
+  server: PreviewServer;
+}) {
+  const url = previewServerUrl(server);
+  const canOpen = server.status.kind === 'ready' && url !== null;
+  const projectName = projectDisplayName(getProjectStore(server.projectId));
+  const taskName = taskNameForWorkspace(server.projectId, server.workspaceId);
+  const usedBy = [projectName, taskName].filter(Boolean).join(' · ');
+  const label = formatPreviewServerLabel(server);
+
+  return (
+    <div className="flex min-w-0 items-start gap-4 rounded-lg border border-border bg-background p-4">
+      <div className="bg-muted flex size-9 shrink-0 items-center justify-center rounded-md text-foreground-muted">
+        <GlobeIcon className="size-4" />
+      </div>
+      <div className="grid min-w-0 flex-1 gap-2">
+        <div className="flex min-w-0 flex-wrap items-center gap-2">
+          <h4 className="min-w-0 truncate text-sm font-medium text-foreground">{label}</h4>
+          <PreviewServerStatusBadge server={server} />
+        </div>
+        <div className="min-w-0 space-y-1 text-xs text-foreground-passive">
+          <p className="truncate">{url ?? 'No local URL'}</p>
+          {usedBy !== '' ? <p className="truncate">Used by: {usedBy}</p> : null}
+          {server.status.kind === 'failed' ? (
+            <p className="truncate text-foreground-destructive">{server.status.message}</p>
+          ) : null}
+        </div>
+      </div>
+      <div className="flex shrink-0 items-center gap-1">
+        <ServerActionButton
+          label="Open in browser"
+          disabled={!canOpen}
+          onClick={() => {
+            if (canOpen) void rpc.app.openExternal(url);
+          }}
+        >
+          <ExternalLinkIcon className="size-4" />
+        </ServerActionButton>
+        <ServerActionButton
+          label={`Stop ${label}`}
+          className="hover:bg-destructive/10 text-foreground-destructive hover:text-foreground-destructive"
+          onClick={() => void rpc.previewServers.stop(server.id)}
+        >
+          <SquareIcon className="size-3 fill-current" />
+        </ServerActionButton>
+      </div>
+    </div>
+  );
+});
+
+function taskNameForWorkspace(projectId: string, workspaceId: string): string | undefined {
+  const manager = getTaskManagerStore(projectId);
+  if (!manager) return undefined;
+  for (const store of manager.tasks.values()) {
+    if (asProvisioned(store)?.workspaceId === workspaceId) return taskDisplayName(store);
+  }
+  return undefined;
+}
+
+function sortServers(servers: PreviewServer[]): PreviewServer[] {
+  return [...servers].sort((a, b) => {
+    if (a.projectId !== b.projectId) return a.projectId.localeCompare(b.projectId);
+    const aPort = a.kind === 'forwarded' ? a.remotePort : a.port;
+    const bPort = b.kind === 'forwarded' ? b.remotePort : b.port;
+    if (aPort !== bPort) return aPort - bPort;
+    return a.id.localeCompare(b.id);
+  });
+}

--- a/apps/emdash-desktop/src/renderer/features/settings/components/PreviewServersSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/PreviewServersSettingsCard.tsx
@@ -15,6 +15,7 @@ import {
   getTaskManagerStore,
   taskDisplayName,
 } from '@renderer/features/tasks/stores/task-selectors';
+import { useToast } from '@renderer/lib/hooks/use-toast';
 import { events, rpc } from '@renderer/lib/ipc';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Badge } from '@renderer/lib/ui/badge';
@@ -28,6 +29,7 @@ import { previewServerUrl } from '@shared/core/preview-servers/types';
 export const PreviewServersSettingsCard = observer(function PreviewServersSettingsCard() {
   const [servers, setServers] = useState<PreviewServer[]>([]);
   const showConfirm = useShowModal('confirmActionModal');
+  const { toast } = useToast();
 
   useEffect(() => {
     let disposed = false;
@@ -73,7 +75,13 @@ export const PreviewServersSettingsCard = observer(function PreviewServersSettin
                 confirmLabel: 'Stop',
                 variant: 'destructive',
                 onSuccess: () => {
-                  void rpc.previewServers.stopAll();
+                  void rpc.previewServers.stopAll().catch((error: unknown) => {
+                    toast({
+                      title: 'Failed to stop preview servers',
+                      description: String(error),
+                      variant: 'destructive',
+                    });
+                  });
                 },
               });
             }}

--- a/apps/emdash-desktop/src/renderer/features/settings/components/PreviewServersSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/PreviewServersSettingsCard.tsx
@@ -16,6 +16,7 @@ import {
   taskDisplayName,
 } from '@renderer/features/tasks/stores/task-selectors';
 import { events, rpc } from '@renderer/lib/ipc';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Badge } from '@renderer/lib/ui/badge';
 import { Button } from '@renderer/lib/ui/button';
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
@@ -26,6 +27,7 @@ import { previewServerUrl } from '@shared/core/preview-servers/types';
 
 export const PreviewServersSettingsCard = observer(function PreviewServersSettingsCard() {
   const [servers, setServers] = useState<PreviewServer[]>([]);
+  const showConfirm = useShowModal('confirmActionModal');
 
   useEffect(() => {
     let disposed = false;
@@ -63,7 +65,18 @@ export const PreviewServersSettingsCard = observer(function PreviewServersSettin
             type="button"
             variant="ghost"
             className="hover:bg-destructive/10 text-foreground-destructive hover:text-foreground-destructive"
-            onClick={() => void rpc.previewServers.stopAll()}
+            onClick={() => {
+              const count = servers.length;
+              showConfirm({
+                title: 'Stop preview servers',
+                description: `This will stop ${count === 1 ? 'the running preview server' : `all ${count} running preview servers`}.`,
+                confirmLabel: 'Stop',
+                variant: 'destructive',
+                onSuccess: () => {
+                  void rpc.previewServers.stopAll();
+                },
+              });
+            }}
           >
             <SquareIcon className="size-3 fill-current" />
             Stop all

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -10,6 +10,7 @@ import IntegrationsCard from './IntegrationsCard';
 import InterfaceSettingsCard from './InterfaceSettingsCard';
 import KeyboardSettingsCard from './KeyboardSettingsCard';
 import NotificationSettingsCard from './NotificationSettingsCard';
+import { PreviewServersSettingsCard } from './PreviewServersSettingsCard';
 import RepositorySettingsCard from './RepositorySettingsCard';
 import ResourceMonitorSettingsCard from './ResourceMonitorSettingsCard';
 import SidebarMetadataSettingsCard from './SidebarMetadataSettingsCard';
@@ -89,9 +90,10 @@ function ConnectionsSettingsPage() {
       <PageHeader
         sticky
         title="Connections"
-        description="Manage reusable SSH connections for remote projects."
+        description="Manage reusable SSH connections and running preview servers."
       />
       <SshConnectionsSettingsCard />
+      <PreviewServersSettingsCard />
     </div>
   );
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-format.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-format.ts
@@ -1,4 +1,4 @@
-import type { PreviewServer } from '@shared/core/preview-servers/types';
+import type { PreviewServer, PreviewServerStatus } from '@shared/core/preview-servers/types';
 
 export function formatPreviewUrl(url: string): string {
   try {
@@ -32,7 +32,11 @@ export function previewServerStatusLabel(server: PreviewServer): string {
 }
 
 export function previewServerStatusClasses(server: PreviewServer): string {
-  switch (server.status.kind) {
+  return previewServerStatusKindClasses(server.status.kind);
+}
+
+export function previewServerStatusKindClasses(kind: PreviewServerStatus['kind']): string {
+  switch (kind) {
     case 'ready':
       return 'bg-background-info text-foreground-info hover:bg-background-info-hover';
     case 'starting':
@@ -41,4 +45,13 @@ export function previewServerStatusClasses(server: PreviewServer): string {
     case 'failed':
       return 'bg-background-destructive text-foreground-destructive hover:bg-destructive/20';
   }
+}
+
+export function previewServersSummaryStatusKind(
+  servers: PreviewServer[]
+): PreviewServerStatus['kind'] {
+  if (servers.some((server) => server.status.kind === 'failed')) return 'failed';
+  if (servers.some((server) => server.status.kind === 'reconnecting')) return 'reconnecting';
+  if (servers.some((server) => server.status.kind === 'starting')) return 'starting';
+  return 'ready';
 }

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-menu-items.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-menu-items.tsx
@@ -1,0 +1,82 @@
+import { Clipboard, ExternalLink, Globe, RefreshCcw, Square } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import {
+  usePreviewServers,
+  useWorkspaceViewModel,
+} from '@renderer/features/tasks/task-view-context';
+import { rpc } from '@renderer/lib/ipc';
+import { DropdownMenuItem, DropdownMenuSeparator } from '@renderer/lib/ui/dropdown-menu';
+import { MicroLabel } from '@renderer/lib/ui/label';
+import type { PreviewServer } from '@shared/core/preview-servers/types';
+import { previewServerUrl } from '@shared/core/preview-servers/types';
+
+export const PreviewServerMenuItems = observer(function PreviewServerMenuItems({
+  server,
+}: {
+  server: PreviewServer;
+}) {
+  const previews = usePreviewServers();
+  const taskView = useWorkspaceViewModel();
+  const url = previewServerUrl(server);
+  const hasUrl = url !== null;
+  const canOpen = server.status.kind === 'ready' && hasUrl;
+
+  return (
+    <>
+      <div className="px-2 py-1.5">
+        <MicroLabel className="mb-1 flex items-center">Preview</MicroLabel>
+        <div className="truncate text-xs text-foreground-muted" title={url ?? undefined}>
+          {url ?? 'No local URL'}
+        </div>
+        {server.kind === 'forwarded' ? (
+          <div className="mt-1 text-xs text-foreground-passive">
+            {server.localPort === undefined
+              ? `Remote ${server.remotePort}`
+              : `Remote ${server.remotePort} to local ${server.localPort}`}
+          </div>
+        ) : null}
+        {server.status.kind === 'failed' ? (
+          <div className="mt-1 text-xs text-foreground-destructive">{server.status.message}</div>
+        ) : null}
+      </div>
+      <DropdownMenuSeparator />
+      <DropdownMenuItem
+        disabled={!canOpen}
+        onClick={() => {
+          if (canOpen && url) {
+            taskView.paneLayout.open('browser', { initialUrl: url });
+            taskView.setFocusedRegion('main');
+          }
+        }}
+      >
+        <Globe className="size-3.5" />
+        Open in Emdash Browser
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        disabled={!canOpen}
+        onClick={() => canOpen && url && void rpc.app.openExternal(url)}
+      >
+        <ExternalLink className="size-3.5" />
+        Open in System Browser
+      </DropdownMenuItem>
+      <DropdownMenuItem
+        disabled={!hasUrl}
+        onClick={() => url && void rpc.app.clipboardWriteText(url)}
+      >
+        <Clipboard className="size-3.5" />
+        Copy URL
+      </DropdownMenuItem>
+      <DropdownMenuSeparator />
+      {server.kind === 'forwarded' ? (
+        <DropdownMenuItem onClick={() => void previews.restart(server.id)}>
+          <RefreshCcw className="size-3.5" />
+          Restart Forward
+        </DropdownMenuItem>
+      ) : null}
+      <DropdownMenuItem variant="destructive" onClick={() => void previews.stop(server.id)}>
+        <Square className="size-3.5" />
+        Stop
+      </DropdownMenuItem>
+    </>
+  );
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-pill.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-pill.tsx
@@ -1,26 +1,10 @@
-import {
-  ChevronDown,
-  Clipboard,
-  ExternalLink,
-  Globe,
-  Loader2,
-  RefreshCcw,
-  Square,
-} from 'lucide-react';
+import { ChevronDown, Globe, Loader2 } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import {
-  usePreviewServers,
-  useWorkspaceViewModel,
-} from '@renderer/features/tasks/task-view-context';
-import { rpc } from '@renderer/lib/ipc';
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@renderer/lib/ui/dropdown-menu';
-import { MicroLabel } from '@renderer/lib/ui/label';
 import { cn } from '@renderer/utils/utils';
 import type { PreviewServer } from '@shared/core/preview-servers/types';
 import { previewServerUrl } from '@shared/core/preview-servers/types';
@@ -29,20 +13,18 @@ import {
   previewServerStatusClasses,
   previewServerStatusLabel,
 } from './preview-server-format';
+import { PreviewServerMenuItems } from './preview-server-menu-items';
 
 export const PreviewServerPill = observer(function PreviewServerPill({
   server,
 }: {
   server: PreviewServer;
 }) {
-  const previews = usePreviewServers();
-  const taskView = useWorkspaceViewModel();
   const url = previewServerUrl(server);
-  const hasUrl = url !== null;
-  const canOpen = server.status.kind === 'ready' && hasUrl;
-  const title = hasUrl
-    ? `${previewServerStatusLabel(server)} at ${url}`
-    : `${previewServerStatusLabel(server)} for ${formatPreviewServerLabel(server)}`;
+  const title =
+    url !== null
+      ? `${previewServerStatusLabel(server)} at ${url}`
+      : `${previewServerStatusLabel(server)} for ${formatPreviewServerLabel(server)}`;
 
   return (
     <DropdownMenu>
@@ -68,60 +50,7 @@ export const PreviewServerPill = observer(function PreviewServerPill({
         <ChevronDown className="size-3 shrink-0" />
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="min-w-56">
-        <div className="px-2 py-1.5">
-          <MicroLabel className="mb-1 flex items-center">Preview</MicroLabel>
-          <div className="truncate text-xs text-foreground-muted" title={url ?? undefined}>
-            {url ?? 'No local URL'}
-          </div>
-          {server.kind === 'forwarded' ? (
-            <div className="mt-1 text-xs text-foreground-passive">
-              {server.localPort === undefined
-                ? `Remote ${server.remotePort}`
-                : `Remote ${server.remotePort} to local ${server.localPort}`}
-            </div>
-          ) : null}
-          {server.status.kind === 'failed' ? (
-            <div className="mt-1 text-xs text-foreground-destructive">{server.status.message}</div>
-          ) : null}
-        </div>
-        <DropdownMenuSeparator />
-        <DropdownMenuItem
-          disabled={!canOpen}
-          onClick={() => {
-            if (canOpen && url) {
-              taskView.paneLayout.open('browser', { initialUrl: url });
-              taskView.setFocusedRegion('main');
-            }
-          }}
-        >
-          <Globe className="size-3.5" />
-          Open in Emdash Browser
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          disabled={!canOpen}
-          onClick={() => canOpen && url && void rpc.app.openExternal(url)}
-        >
-          <ExternalLink className="size-3.5" />
-          Open in System Browser
-        </DropdownMenuItem>
-        <DropdownMenuItem
-          disabled={!hasUrl}
-          onClick={() => url && void rpc.app.clipboardWriteText(url)}
-        >
-          <Clipboard className="size-3.5" />
-          Copy URL
-        </DropdownMenuItem>
-        <DropdownMenuSeparator />
-        {server.kind === 'forwarded' ? (
-          <DropdownMenuItem onClick={() => void previews.restart(server.id)}>
-            <RefreshCcw className="size-3.5" />
-            Restart Forward
-          </DropdownMenuItem>
-        ) : null}
-        <DropdownMenuItem variant="destructive" onClick={() => void previews.stop(server.id)}>
-          <Square className="size-3.5" />
-          Stop
-        </DropdownMenuItem>
+        <PreviewServerMenuItems server={server} />
       </DropdownMenuContent>
     </DropdownMenu>
   );

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-pills.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-server-pills.tsx
@@ -2,6 +2,7 @@ import { observer } from 'mobx-react-lite';
 import { usePreviewServers, useWorkspace } from '@renderer/features/tasks/task-view-context';
 import { ManualForwardButton } from './manual-forward-button';
 import { PreviewServerPill } from './preview-server-pill';
+import { PreviewServersBadge } from './preview-servers-badge';
 
 export const PreviewServerPills = observer(function PreviewServerPills() {
   const previews = usePreviewServers();
@@ -13,9 +14,11 @@ export const PreviewServerPills = observer(function PreviewServerPills() {
 
   return (
     <>
-      {servers.map((server) => (
-        <PreviewServerPill key={server.id} server={server} />
-      ))}
+      {servers.length > 1 ? (
+        <PreviewServersBadge servers={servers} />
+      ) : (
+        servers.map((server) => <PreviewServerPill key={server.id} server={server} />)
+      )}
       {isRemoteWorkspace ? <ManualForwardButton /> : null}
     </>
   );

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-servers-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-servers-badge.tsx
@@ -1,6 +1,8 @@
 import { ChevronDown, Globe, Loader2, Square } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { usePreviewServers } from '@renderer/features/tasks/task-view-context';
+import { useToast } from '@renderer/lib/hooks/use-toast';
+import { useShowModal } from '@renderer/lib/modal/modal-provider';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -27,6 +29,8 @@ export const PreviewServersBadge = observer(function PreviewServersBadge({
   servers: PreviewServer[];
 }) {
   const previews = usePreviewServers();
+  const showConfirm = useShowModal('confirmActionModal');
+  const { toast } = useToast();
   const summaryKind = previewServersSummaryStatusKind(servers);
   const isBusy = summaryKind === 'starting' || summaryKind === 'reconnecting';
 
@@ -79,7 +83,27 @@ export const PreviewServersBadge = observer(function PreviewServersBadge({
           </DropdownMenuSub>
         ))}
         <DropdownMenuSeparator />
-        <DropdownMenuItem variant="destructive" onClick={() => void previews.stopAll()}>
+        <DropdownMenuItem
+          variant="destructive"
+          onClick={() => {
+            const count = servers.length;
+            showConfirm({
+              title: 'Stop workspace preview servers?',
+              description: `This will stop ${count === 1 ? 'the running preview server' : `all ${count} running preview servers`} in this workspace.`,
+              confirmLabel: 'Stop All',
+              variant: 'destructive',
+              onSuccess: () => {
+                void previews.stopAll().catch((error: unknown) => {
+                  toast({
+                    title: 'Failed to stop preview servers',
+                    description: String(error),
+                    variant: 'destructive',
+                  });
+                });
+              },
+            });
+          }}
+        >
           <Square className="size-3.5" />
           Stop All Servers
         </DropdownMenuItem>

--- a/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-servers-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/components/preview-servers/preview-servers-badge.tsx
@@ -1,0 +1,89 @@
+import { ChevronDown, Globe, Loader2, Square } from 'lucide-react';
+import { observer } from 'mobx-react-lite';
+import { usePreviewServers } from '@renderer/features/tasks/task-view-context';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger,
+  DropdownMenuTrigger,
+} from '@renderer/lib/ui/dropdown-menu';
+import { MicroLabel } from '@renderer/lib/ui/label';
+import { cn } from '@renderer/utils/utils';
+import type { PreviewServer } from '@shared/core/preview-servers/types';
+import {
+  formatPreviewServerLabel,
+  previewServersSummaryStatusKind,
+  previewServerStatusKindClasses,
+} from './preview-server-format';
+import { PreviewServerMenuItems } from './preview-server-menu-items';
+
+export const PreviewServersBadge = observer(function PreviewServersBadge({
+  servers,
+}: {
+  servers: PreviewServer[];
+}) {
+  const previews = usePreviewServers();
+  const summaryKind = previewServersSummaryStatusKind(servers);
+  const isBusy = summaryKind === 'starting' || summaryKind === 'reconnecting';
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger
+        render={
+          <button
+            type="button"
+            className={cn(
+              'flex h-7 items-center gap-1.5 rounded-lg px-2 text-xs transition-colors',
+              previewServerStatusKindClasses(summaryKind)
+            )}
+            aria-label={`${servers.length} preview servers`}
+            title={`${servers.length} preview servers running`}
+          />
+        }
+      >
+        {isBusy ? (
+          <Loader2 className="size-3 shrink-0 animate-spin" />
+        ) : (
+          <Globe className="size-3 shrink-0" />
+        )}
+        <span>{servers.length} servers</span>
+        <ChevronDown className="size-3 shrink-0" />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end" className="min-w-56">
+        <div className="px-2 py-1.5">
+          <MicroLabel className="flex items-center">Preview Servers</MicroLabel>
+        </div>
+        <DropdownMenuSeparator />
+        {servers.map((server) => (
+          <DropdownMenuSub key={server.id}>
+            <DropdownMenuSubTrigger>
+              {server.status.kind === 'starting' || server.status.kind === 'reconnecting' ? (
+                <Loader2 className="size-3.5 animate-spin" />
+              ) : (
+                <Globe
+                  className={cn(
+                    'size-3.5',
+                    server.status.kind === 'failed' && 'text-foreground-destructive'
+                  )}
+                />
+              )}
+              <span className="truncate">{formatPreviewServerLabel(server)}</span>
+            </DropdownMenuSubTrigger>
+            <DropdownMenuSubContent className="min-w-56">
+              <PreviewServerMenuItems server={server} />
+            </DropdownMenuSubContent>
+          </DropdownMenuSub>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem variant="destructive" onClick={() => void previews.stopAll()}>
+          <Square className="size-3.5" />
+          Stop All Servers
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/preview-server-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/preview-server-store.test.ts
@@ -14,6 +14,7 @@ const rpcMocks = vi.hoisted(() => ({
   forwardManual: vi.fn(),
   restart: vi.fn(),
   stop: vi.fn(),
+  stopForWorkspace: vi.fn(),
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({
@@ -70,6 +71,7 @@ describe('PreviewServerStore', () => {
     rpcMocks.forwardManual.mockReset();
     rpcMocks.restart.mockReset();
     rpcMocks.stop.mockReset();
+    rpcMocks.stopForWorkspace.mockReset();
   });
 
   it('loads preview servers for a workspace and exposes addressable URLs', async () => {
@@ -178,6 +180,31 @@ describe('PreviewServerStore', () => {
     });
 
     expect(rpcMocks.forwardManual).not.toHaveBeenCalled();
+    store.dispose();
+  });
+
+  it('stops all servers for the workspace and clears local state', async () => {
+    rpcMocks.listForWorkspace.mockResolvedValueOnce([
+      directServer(),
+      forwardedServer({ id: 'forwarded-1' }),
+    ]);
+    rpcMocks.stopForWorkspace.mockResolvedValueOnce(undefined);
+
+    const store = new PreviewServerStore({
+      projectId: 'project-1',
+      workspaceId: 'workspace-1',
+    });
+    await store.serversResource.load();
+    expect(store.servers).toHaveLength(2);
+
+    await store.stopAll();
+
+    expect(rpcMocks.stopForWorkspace).toHaveBeenCalledWith({
+      projectId: 'project-1',
+      workspaceId: 'workspace-1',
+    });
+    expect(store.servers).toEqual([]);
+
     store.dispose();
   });
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/preview-server-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/preview-server-store.ts
@@ -114,6 +114,14 @@ export class PreviewServerStore implements IDisposable {
     this.serversResource.setValue(next);
   }
 
+  async stopAll(): Promise<void> {
+    await rpc.previewServers.stopForWorkspace({
+      projectId: this.projectId,
+      workspaceId: this.workspaceId,
+    });
+    this.serversResource.setValue(new Map());
+  }
+
   dispose(): void {
     this.serversResource.dispose();
   }

--- a/apps/emdash-desktop/src/renderer/lib/commands/app-commands.ts
+++ b/apps/emdash-desktop/src/renderer/lib/commands/app-commands.ts
@@ -1,5 +1,6 @@
 import { applyHistoryEntry } from '@renderer/lib/components/nav-buttons';
 import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
 import { toggleSettingsView } from '@renderer/lib/layout/settings-toggle';
 import { showModal } from '@renderer/lib/modal/modal-provider';
 import { appState } from '@renderer/lib/stores/app-state';
@@ -87,6 +88,29 @@ function createAppCommandProvider(): CommandProvider {
         group: giveFeedbackDef.group,
         execute() {
           showModal('feedbackModal', {});
+        },
+      });
+
+      const stopAllPreviewServersDef = appDef('app.stopAllPreviewServers');
+      commands.push({
+        id: stopAllPreviewServersDef.id,
+        label: stopAllPreviewServersDef.label,
+        description: stopAllPreviewServersDef.description,
+        shortcutKey: stopAllPreviewServersDef.shortcutKey,
+        group: stopAllPreviewServersDef.group,
+        execute() {
+          void rpc.previewServers
+            .stopAll()
+            .then(() => {
+              toast({ title: 'Stopped all preview servers' });
+            })
+            .catch((error: unknown) => {
+              toast({
+                title: 'Failed to stop preview servers',
+                description: String(error),
+                variant: 'destructive',
+              });
+            });
         },
       });
 

--- a/apps/emdash-desktop/src/shared/commands.ts
+++ b/apps/emdash-desktop/src/shared/commands.ts
@@ -65,6 +65,14 @@ export const APP_COMMAND_DEFS = defineCommandDefs([
     iconKey: 'message-square-share',
   },
   {
+    id: 'app.stopAllPreviewServers',
+    label: 'Stop All Preview Servers',
+    description: 'Stop preview servers and port forwards across all projects and tasks',
+    scope: 'app',
+    group: 'App',
+    iconKey: 'globe',
+  },
+  {
     id: 'app.toggleTheme',
     label: 'Toggle Theme',
     description: 'Switch between light and dark themes',


### PR DESCRIPTION
### Description
adds the ability to see and stop preview servers beyond a single pill. 

- adds a global "stop all servers" to the connection settings
- settings -> connections card listing every server across all projects/tasks

### Screenshot/Recording (if applicable)
https://cap.link/0xmcmymtrcdwfkb

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
