### PR TITLE
fix(pty): link bare filenames

### DIFF
--- a/apps/emdash-desktop/src/main/core/search/controller.ts
+++ b/apps/emdash-desktop/src/main/core/search/controller.ts
@@ -1,4 +1,8 @@
-import type { CommandPaletteQuery, WorkspaceFileSearchQuery } from '@shared/core/search';
+import type {
+  CommandPaletteQuery,
+  WorkspaceFileNameQuery,
+  WorkspaceFileSearchQuery,
+} from '@shared/core/search';
 import { createRPCController } from '@shared/lib/ipc/rpc';
 import { searchService } from './search-service';
 
@@ -6,4 +10,6 @@ export const searchController = createRPCController({
   commandPalette: (query: CommandPaletteQuery) => searchService.search(query),
   searchWorkspaceFiles: (q: WorkspaceFileSearchQuery) =>
     searchService.searchFiles(q.workspaceId, q.query, q.limit),
+  findWorkspaceFilesByName: (q: WorkspaceFileNameQuery) =>
+    searchService.findFilesByName(q.workspaceId, q.filename),
 });

--- a/apps/emdash-desktop/src/main/core/search/search-service.ts
+++ b/apps/emdash-desktop/src/main/core/search/search-service.ts
@@ -67,6 +67,10 @@ class SearchService {
     return workspaceFileIndexService.searchFiles(workspaceId, query, limit);
   }
 
+  findFilesByName(workspaceId: string, filename: string): WorkspaceFileHit[] {
+    return workspaceFileIndexService.findFilesByName(workspaceId, filename);
+  }
+
   search({ query, context }: CommandPaletteQuery): SearchItem[] {
     if (!query.trim()) return this.recents(context);
 

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.test.ts
@@ -19,6 +19,7 @@ describe('WorkspaceFileIndexService', () => {
     const store = new FakeStore();
     store.searchResults = [{ path: '/repo/src/index.ts', filename: 'index.ts' }];
     store.searchFilesResults = [{ path: '/repo/src/app.ts', filename: 'app.ts' }];
+    store.findFilesByNameResults = [{ path: '/repo/README.md', filename: 'README.md' }];
     const service = await createService(store);
 
     service.initialize();
@@ -30,8 +31,12 @@ describe('WorkspaceFileIndexService', () => {
     expect(service.searchFiles('ws-1', 'ap', 5)).toEqual([
       { path: '/repo/src/app.ts', filename: 'app.ts' },
     ]);
+    expect(service.findFilesByName('ws-1', 'README.md')).toEqual([
+      { path: '/repo/README.md', filename: 'README.md' },
+    ]);
     expect(store.operations).toContain('search:index');
     expect(store.operations).toContain('searchFiles:ap:5');
+    expect(store.operations).toContain('findFilesByName:README.md');
   });
 
   it('refreshes complete metadata on activation without enumerating', async () => {
@@ -258,6 +263,7 @@ class FakeStore implements IWorkspaceFileIndexStore {
   evictedDays: number | undefined;
   searchResults: FileHit[] = [];
   searchFilesResults: FileHit[] = [];
+  findFilesByNameResults: FileHit[] = [];
 
   transaction<T>(fn: () => T): T {
     this.operations.push('transaction');
@@ -318,6 +324,11 @@ class FakeStore implements IWorkspaceFileIndexStore {
   searchFiles(_workspaceId: string, query: string, limit: number): FileHit[] {
     this.operations.push(`searchFiles:${query}:${limit}`);
     return this.searchFilesResults;
+  }
+
+  findFilesByName(_workspaceId: string, filename: string): FileHit[] {
+    this.operations.push(`findFilesByName:${filename}`);
+    return this.findFilesByNameResults;
   }
 
   deleteIndex(workspaceId: string): void {

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
@@ -107,6 +107,10 @@ export class WorkspaceFileIndexService {
     return this.store.searchFiles(workspaceId, query, limit);
   }
 
+  findFilesByName(workspaceId: string, filename: string): FileHit[] {
+    return this.store.findFilesByName(workspaceId, filename);
+  }
+
   search(workspaceId: string, query: string): FileHit[] {
     return this.store.search(workspaceId, query);
   }

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.db.test.ts
@@ -72,6 +72,21 @@ describe('WorkspaceFileIndexStore', () => {
     expect(store.search('ws-1', 'in')).toEqual([]);
   });
 
+  it('finds exact filenames without relevance ranking', async () => {
+    loadedStore = await loadStore();
+    const { store } = loadedStore;
+
+    store.syncRows(
+      'ws-1',
+      paths(['/repo/deep/nested/Notes.md', '/repo/Notes.md', '/repo/other/README.md'])
+    );
+
+    expect(store.findFilesByName('ws-1', 'Notes.md')).toEqual([
+      { path: '/repo/Notes.md', filename: 'Notes.md' },
+      { path: '/repo/deep/nested/Notes.md', filename: 'Notes.md' },
+    ]);
+  });
+
   it('deletes exact paths and escaped subtrees', async () => {
     loadedStore = await loadStore();
     const { store, sqlite } = loadedStore;

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-store.ts
@@ -23,6 +23,7 @@ export interface IWorkspaceFileIndexStore {
   deleteSubtree(workspaceId: string, path: string): void;
   countIndexedFiles(workspaceId: string): number;
   searchFiles(workspaceId: string, query: string, limit: number): FileHit[];
+  findFilesByName(workspaceId: string, filename: string): FileHit[];
   search(workspaceId: string, query: string): FileHit[];
   deleteIndex(workspaceId: string): void;
   evict(staleDays: number): void;
@@ -196,6 +197,26 @@ export class WorkspaceFileIndexStore implements IWorkspaceFileIndexStore {
     }
 
     return this.searchFts(workspaceId, trimmed, limit, 'searchFiles (FTS)');
+  }
+
+  findFilesByName(workspaceId: string, filename: string): FileHit[] {
+    try {
+      return sqlite
+        .prepare(
+          `SELECT path, filename
+           FROM workspace_file_index
+           WHERE workspace_id = ?
+             AND filename = ?
+           ORDER BY length(path) - length(replace(path, '/', '')), path`
+        )
+        .all(workspaceId, filename) as FileHit[];
+    } catch (e) {
+      log.warn('WorkspaceFileIndexStore: findFilesByName failed', {
+        workspaceId,
+        error: String(e),
+      });
+      return [];
+    }
   }
 
   search(workspaceId: string, query: string): FileHit[] {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/open-file-in-file-editor.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/open-file-in-file-editor.ts
@@ -82,13 +82,8 @@ async function findWorkspaceFileByName(
   workspaceId: string,
   filename: string
 ): Promise<string | null> {
-  const hits = await rpc.search.searchWorkspaceFiles({ workspaceId, query: filename, limit: 50 });
-  const exact = hits.filter((h) => h.filename === filename);
-  if (exact.length === 0) return null;
-  exact.sort(
-    (a, b) => a.path.split('/').length - b.path.split('/').length || a.path.localeCompare(b.path)
-  );
-  return exact[0].path;
+  const hits = await rpc.search.findWorkspaceFilesByName({ workspaceId, filename });
+  return hits[0]?.path ?? null;
 }
 
 /**

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/open-file-in-file-editor.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/open-file-in-file-editor.ts
@@ -51,13 +51,44 @@ export async function openFileInTaskEditor(
     provisioned.workspaceId,
     resolvedPath
   );
+  let openPath = resolvedPath;
   if (!exists.success || !exists.data.exists) {
-    toast.error(`File not found in workspace: ${filePath}`);
-    return;
+    // Agents often reference files by bare name (`Notes.md`) without the
+    // directory — fall back to a workspace file-index lookup.
+    const indexed = isBareFilename(filePath)
+      ? await findWorkspaceFileByName(provisioned.workspaceId, filePath)
+      : null;
+    if (indexed === null) {
+      toast.error(`File not found in workspace: ${filePath}`);
+      return;
+    }
+    openPath = resolveWorkspacePath(workspace.path, indexed);
   }
 
   focusTracker.transition({ mainPanel: 'editor' }, 'panel_switch');
-  provisioned.viewModel?.activePane.open('file', { path: resolvedPath }, { preview: false });
+  provisioned.viewModel?.activePane.open('file', { path: openPath }, { preview: false });
+}
+
+function isBareFilename(filePath: string): boolean {
+  return !filePath.includes('/') && !filePath.includes('\\');
+}
+
+/**
+ * Resolves a bare filename against the workspace file index. Returns the
+ * workspace-relative path of the shallowest exact-name match, or null when
+ * the name is unknown (e.g. a false-positive terminal link like `Node.js`).
+ */
+async function findWorkspaceFileByName(
+  workspaceId: string,
+  filename: string
+): Promise<string | null> {
+  const hits = await rpc.search.searchWorkspaceFiles({ workspaceId, query: filename, limit: 50 });
+  const exact = hits.filter((h) => h.filename === filename);
+  if (exact.length === 0) return null;
+  exact.sort(
+    (a, b) => a.path.split('/').length - b.path.split('/').length || a.path.localeCompare(b.path)
+  );
+  return exact[0].path;
 }
 
 /**

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
@@ -7,6 +7,17 @@ import type { ILink } from '@xterm/xterm';
 const FILE_PATH_PATTERN =
   '(?<![\\w\\-./@:])(?:(?:~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+|[\\w\\-@][\\w\\-.@]+)\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
 const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+const COMMON_NON_FILE_BARE_NAMES = new Set([
+  'Angular.js',
+  'Express.js',
+  'Next.js',
+  'Node.js',
+  'Nuxt.js',
+  'React.jsx',
+  'Remix.js',
+  'Svelte.js',
+  'Vue.js',
+]);
 const MAX_WRAPPED_LINE_LENGTH = 4096;
 
 export type BufferLineLike = {
@@ -44,6 +55,7 @@ export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): Fil
   while ((match = regex.exec(logicalLine.text)) !== null) {
     const matched = match[0];
     const startOffset = match.index;
+    if (isCommonNonFileBareName(matched)) continue;
     if (isEmbeddedInUrl(logicalLine.text, startOffset)) continue;
     const endOffset = startOffset + matched.length;
     const range = mapOffsetRangeToBufferRange(logicalLine, startOffset, endOffset);
@@ -61,6 +73,10 @@ export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): Fil
     }
   }
   return links;
+}
+
+function isCommonNonFileBareName(value: string): boolean {
+  return !value.includes('/') && !value.includes('\\') && COMMON_NON_FILE_BARE_NAMES.has(value);
 }
 
 function isEmbeddedInUrl(text: string, startCol: number): boolean {

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-detection.ts
@@ -1,8 +1,11 @@
 import type { ILink } from '@xterm/xterm';
 
 // Lookbehind on `:` keeps URLs (`https://...`) with WebLinksAddon.
+// Matches pathful references (`src/foo.ts`) and bare filenames (`Notes.md`).
+// Bare filenames require a stem of at least two characters so sentence
+// abbreviations like `e.g` or `i.e` never linkify.
 const FILE_PATH_PATTERN =
-  '(?<![\\w\\-./@:])(~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
+  '(?<![\\w\\-./@:])(?:(?:~/|/|\\.{1,2}/)?(?:[\\w\\-.@]+/)+[\\w\\-.@]+|[\\w\\-@][\\w\\-.@]+)\\.[a-zA-Z][a-zA-Z0-9]{0,9}\\b';
 const URL_PROTOCOL_PATTERN = /[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
 const MAX_WRAPPED_LINE_LENGTH = 4096;
 
@@ -30,7 +33,7 @@ type LogicalLine = {
 
 export function findFileLinks(buffer: BufferLike, bufferLineNumber: number): FileLinkMatch[] {
   const logicalLine = getWrappedLogicalLine(buffer, bufferLineNumber - 1);
-  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('/') === -1) {
+  if (!logicalLine || !logicalLine.text || logicalLine.text.indexOf('.') === -1) {
     return [];
   }
 

--- a/apps/emdash-desktop/src/renderer/lib/pty/file-link-provider.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/file-link-provider.ts
@@ -12,6 +12,7 @@ type NavigatorWithUserAgentData = Navigator & {
 
 export class ActivationModifierTracker {
   private hoveredDecorations: LinkDecorations | null = null;
+  private hoveredRefresh: (() => void) | null = null;
   private pressed = false;
 
   constructor(private readonly isMac = isMacPlatform()) {}
@@ -24,8 +25,14 @@ export class ActivationModifierTracker {
   }
 
   update(event: ActivationModifierEvent): boolean {
-    this.pressed = this.isPressed(event);
+    const next = this.isPressed(event);
+    const changed = next !== this.pressed;
+    this.pressed = next;
     this.syncHoveredDecorations();
+    // xterm only re-reads link decorations on pointer events, so toggling the
+    // modifier while the pointer sits still needs an explicit repaint to
+    // show/hide the underline on the already-hovered link.
+    if (changed) this.hoveredRefresh?.();
     return this.pressed;
   }
 
@@ -33,14 +40,16 @@ export class ActivationModifierTracker {
     return isActivationModifierPressed(event, this.isMac);
   }
 
-  hover(decorations: LinkDecorations, event: ActivationModifierEvent): void {
+  hover(decorations: LinkDecorations, event: ActivationModifierEvent, refresh?: () => void): void {
     this.hoveredDecorations = decorations;
+    this.hoveredRefresh = refresh ?? null;
     this.update(event);
   }
 
   leave(decorations: LinkDecorations): void {
     if (this.hoveredDecorations === decorations) {
       this.hoveredDecorations = null;
+      this.hoveredRefresh = null;
     }
     setDecorations(decorations, false);
   }
@@ -48,6 +57,7 @@ export class ActivationModifierTracker {
   reset(): void {
     this.pressed = false;
     this.syncHoveredDecorations();
+    this.hoveredRefresh?.();
   }
 
   private syncHoveredDecorations(): void {
@@ -75,6 +85,10 @@ export class FileLinkProvider implements ILinkProvider {
     callback(links.length > 0 ? links : undefined);
   }
 
+  private refreshViewport(): void {
+    this.terminal.refresh(0, this.terminal.rows - 1);
+  }
+
   private toXtermLink(match: FileLinkMatch): ILink {
     const decorations = this.tracker.decorations();
     const link: ILink = {
@@ -82,7 +96,7 @@ export class FileLinkProvider implements ILinkProvider {
       text: match.text,
       decorations,
       hover: (event) => {
-        this.tracker.hover(link.decorations ?? decorations, event);
+        this.tracker.hover(link.decorations ?? decorations, event, () => this.refreshViewport());
       },
       leave: () => {
         this.tracker.leave(link.decorations ?? decorations);

--- a/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
@@ -94,7 +94,48 @@ describe('file link provider', () => {
       new MockBufferLine('  baz.ts'),
     ]);
 
-    expect(findFileLinks(buffer, 3)).toEqual([]);
+    // Only the bare filename on the last line — never the joined path.
+    expect(findFileLinks(buffer, 3)).toEqual([
+      {
+        range: {
+          start: { x: 3, y: 3 },
+          end: { x: 8, y: 3 },
+        },
+        text: 'baz.ts',
+        isExternal: false,
+      },
+    ]);
+  });
+
+  it('detects bare filenames without a directory segment', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('Search Qin Liu in UZH_Silicon_Valley_Attendees_LinkedIn.md'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([
+      {
+        range: {
+          start: { x: 19, y: 1 },
+          end: { x: 58, y: 1 },
+        },
+        text: 'UZH_Silicon_Valley_Attendees_LinkedIn.md',
+        isExternal: false,
+      },
+    ]);
+  });
+
+  it('ignores single-letter abbreviations like e.g. and i.e.', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('use a helper, e.g. one from utils, i.e. the shared one'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('keeps bare domains inside URLs delegated to the web links addon', () => {
+    const buffer = makeBuffer([new MockBufferLine('deployed to https://emdash.sh just now')]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
   });
 
   it('classifies absolute and home-relative paths as external', () => {
@@ -162,6 +203,41 @@ describe('file link provider', () => {
 
     tracker.update({ metaKey: false, ctrlKey: false });
     expect(decorations).toEqual({ pointerCursor: false, underline: false });
+  });
+
+  it('repaints the hovered link when the modifier toggles without mouse movement', () => {
+    const tracker = new ActivationModifierTracker(true);
+    const decorations = tracker.decorations();
+    let refreshes = 0;
+
+    tracker.hover(decorations, { metaKey: false, ctrlKey: false }, () => {
+      refreshes += 1;
+    });
+    expect(refreshes).toBe(0);
+
+    tracker.update({ metaKey: true, ctrlKey: false });
+    expect(refreshes).toBe(1);
+
+    tracker.update({ metaKey: false, ctrlKey: false });
+    expect(refreshes).toBe(2);
+
+    // No change in pressed state must not trigger redundant repaints.
+    tracker.update({ metaKey: false, ctrlKey: false });
+    expect(refreshes).toBe(2);
+  });
+
+  it('stops repainting once the pointer leaves the link', () => {
+    const tracker = new ActivationModifierTracker(true);
+    const decorations = tracker.decorations();
+    let refreshes = 0;
+
+    tracker.hover(decorations, { metaKey: false, ctrlKey: false }, () => {
+      refreshes += 1;
+    });
+    tracker.leave(decorations);
+
+    tracker.update({ metaKey: true, ctrlKey: false });
+    expect(refreshes).toBe(0);
   });
 
   it('only opens links when the activation modifier is pressed', () => {

--- a/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/file-link-provider.test.ts
@@ -132,6 +132,37 @@ describe('file link provider', () => {
     expect(findFileLinks(buffer, 1)).toEqual([]);
   });
 
+  it('ignores common framework names that look like bare filenames', () => {
+    const buffer = makeBuffer([
+      new MockBufferLine('Detected Node.js, React.jsx, Vue.js, and Express.js versions'),
+    ]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([]);
+  });
+
+  it('still detects pathful filenames that use common framework names', () => {
+    const buffer = makeBuffer([new MockBufferLine('open docs/Node.js and examples/React.jsx')]);
+
+    expect(findFileLinks(buffer, 1)).toEqual([
+      {
+        range: {
+          start: { x: 6, y: 1 },
+          end: { x: 17, y: 1 },
+        },
+        text: 'docs/Node.js',
+        isExternal: false,
+      },
+      {
+        range: {
+          start: { x: 23, y: 1 },
+          end: { x: 40, y: 1 },
+        },
+        text: 'examples/React.jsx',
+        isExternal: false,
+      },
+    ]);
+  });
+
   it('keeps bare domains inside URLs delegated to the web links addon', () => {
     const buffer = makeBuffer([new MockBufferLine('deployed to https://emdash.sh just now')]);
 

--- a/apps/emdash-desktop/src/shared/core/search.ts
+++ b/apps/emdash-desktop/src/shared/core/search.ts
@@ -25,6 +25,11 @@ export interface WorkspaceFileSearchQuery {
   limit?: number;
 }
 
+export interface WorkspaceFileNameQuery {
+  workspaceId: string;
+  filename: string;
+}
+
 export interface WorkspaceFileHit {
   path: string;
   filename: string;


### PR DESCRIPTION
### Description
- links bare filenames in pty output, not just paths with folders

### Screenshot/Recording (if applicable)
https://cap.link/6y6qk1r7k2f56r8

<details>
<summary>Checklist</summary>

- [X] I kept this PR small and focused
- [X] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [X] I only added comments where the logic is not obvious
- [X] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
