### PR TITLE
fix: start update download from sidebar update button

### DIFF
--- a/apps/emdash-desktop/src/main/core/dependencies/agent-update-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/dependencies/agent-update-service.test.ts
@@ -257,7 +257,6 @@ describe('AgentUpdateService', () => {
     const service = new AgentUpdateService();
 
     // Manually prime the cache so we can call enrichHostDependency synchronously
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (service as any).latestVersionCache.set('amp', '2.0.0');
 
     const hostDep = {
@@ -301,7 +300,6 @@ describe('AgentUpdateService', () => {
 
     const service = new AgentUpdateService();
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (service as any).latestVersionCache.set('claude', '2.0.0');
 
     const hostDep = {

--- a/apps/emdash-desktop/src/renderer/features/sidebar/update-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/update-section.tsx
@@ -13,11 +13,14 @@ export const UpdateSection = observer(function UpdateSection() {
       <Button
         variant="outline"
         size="xs"
-        onClick={() =>
+        onClick={() => {
           navigate('settings', {
             tab: 'general',
-          })
-        }
+          });
+          if (update.state.status === 'available') {
+            void update.download();
+          }
+        }}
       >
         Update
       </Button>

--- a/apps/emdash-desktop/src/renderer/features/tabs/core/tab-provider-registry.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/core/tab-provider-registry.ts
@@ -2,7 +2,7 @@ import type { OpenTarget, TabProvider, TabResource } from './tab-provider';
 
 // ── Type aliases ──────────────────────────────────────────────────────────────
 
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
+// oxlint-disable-next-line typescript/no-explicit-any
 export type AnyTabProvider = TabProvider<any, any, any, any>;
 
 /**
@@ -125,7 +125,7 @@ export function createTabRegistry<const P extends readonly AnyTabProvider[]>(
     has(kind: string): boolean {
       return map.has(kind);
     },
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     _providers: providers as any,
   };
   return registry;

--- a/apps/emdash-desktop/src/renderer/features/tabs/core/tab-provider.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/core/tab-provider.ts
@@ -88,7 +88,7 @@ export interface CommandEntry<T> {
    * Execute the command.
    * For rename commands, `args[0]` is the new name string provided by the inline editor.
    */
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  // oxlint-disable-next-line typescript/no-explicit-any
   exec(resource: T, ...args: any[]): void;
   isAvailable?(resource: T): boolean;
   shortcut?: ShortcutSettingsKey | (() => string | undefined);

--- a/apps/emdash-desktop/src/renderer/features/tabs/tab-bar/tab-context-menu.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tabs/tab-bar/tab-context-menu.tsx
@@ -25,7 +25,7 @@ function CmdShortcut({
   if (!shortcut) return null;
   if (typeof shortcut === 'function') {
     const raw = shortcut();
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    // oxlint-disable-next-line typescript/no-explicit-any
     const parsed = raw ? (parseHotkey(raw, _PLATFORM) as any) : null;
     return parsed ? <Shortcut hotkey={parsed} className="ml-auto" /> : null;
   }

--- a/packages/chat-ui/src/state/flatten.test.ts
+++ b/packages/chat-ui/src/state/flatten.test.ts
@@ -67,13 +67,11 @@ function tool(id: string): ChatItem {
 }
 
 const segCtx = {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
   caches: {} as any,
   expanded: () => false,
 };
 
 // Minimal unit-def stubs — only the `margin` field is consulted by flatten.
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 type StubUnitDefs = Record<string, Pick<UnitDef<any>, 'margin'>>;
 
 const STUB_UNIT_DEFS: StubUnitDefs = {

--- a/packages/chat-ui/src/tests/contract.tsx
+++ b/packages/chat-ui/src/tests/contract.tsx
@@ -68,7 +68,7 @@ export function makeContractCtx(opts: {
  * "expanded".
  */
 export async function renderAndMeasureUnit<D>(
-  def: UnitDef<D, any>,
+  def: UnitDef<D, Record<string, number>>,
   data: D,
   ctx: ContractCtx
 ): Promise<{ computed: number; dom: number }> {

--- a/packages/shared/src/result/index.ts
+++ b/packages/shared/src/result/index.ts
@@ -224,9 +224,9 @@ export function gen<T, E>(body: () => Generator<Err<E>, T, any>): Result<T, E> {
   return step.done ? ok(step.value) : step.value;
 }
 
-// oxlint-disable-next-line typescript/no-explicit-any
 export async function* unwrapGenAsync<T, E>(
   r: Result<T, E> | Promise<Result<T, E>>
+  // oxlint-disable-next-line typescript/no-explicit-any
 ): AsyncGenerator<Err<E>, T, any> {
   const awaited = await r;
   if (awaited.success) return awaited.data;
@@ -234,9 +234,8 @@ export async function* unwrapGenAsync<T, E>(
   throw new Error('unreachable');
 }
 
-// oxlint-disable-next-line typescript/no-explicit-any
 export async function genAsync<T, E>(
-  body: () => AsyncGenerator<Err<E>, T, any>
+  body: () => AsyncGenerator<Err<E>, T, any> // oxlint-disable-line typescript/no-explicit-any
 ): Promise<Result<T, E>> {
   const it = body();
   const step = await it.next();


### PR DESCRIPTION
Closes ENG-1766

## Changes

- The sidebar update button now starts the update download immediately, matching the behavior of the update toast. Previously it only navigated to Settings → General.
- Fixes stale/misplaced `no-explicit-any` lint suppressions (ESLint-style comments that oxlint ignores, directives not on the flagged line) and removes unused ones in test files. The workspace now lints with zero warnings.