### PR TITLE
fix(tasks): center PR badges

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
@@ -29,7 +29,7 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
             )}
           >
             <StatusIcon className="size-3" pr={pr} disableTooltip />
-            <span className="shrink-0 text-xs leading-none text-foreground-muted">
+            <span className="shrink-0 font-mono text-xs leading-none tracking-wide text-foreground-muted">
               #{getPrNumber(pr) ?? 0}
             </span>
             <span className="truncate text-xs leading-none text-foreground-muted">{pr.title}</span>

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
@@ -24,18 +24,18 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
         return (
           <div
             className={cn(
-              'flex items-center gap-2 px-1.5 py-0.5 rounded-md bg-background-2 max-w-52',
+              'flex h-5 max-w-52 items-center gap-2 rounded-md bg-background-2 px-1.5 leading-none',
               className
             )}
           >
             <StatusIcon className="size-3" pr={pr} disableTooltip />
-            <PrNumberBadge number={getPrNumber(pr) ?? 0} className="text-[10px]" />
-            <span className="truncate text-xs text-foreground-muted">{pr.title}</span>
+            <PrNumberBadge number={getPrNumber(pr) ?? 0} className="text-[10px] leading-none" />
+            <span className="truncate text-xs leading-none text-foreground-muted">{pr.title}</span>
           </div>
         );
       case 'compact':
         return (
-          <div className={cn('px-1 flex items-center justify-center', className)}>
+          <div className={cn('flex h-5 items-center justify-center px-1 leading-none', className)}>
             <StatusIcon className="size-3" pr={pr} disableTooltip />
           </div>
         );
@@ -44,7 +44,7 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
 
   return (
     <Popover>
-      <PopoverTrigger openOnHover delay={hoverDelay}>
+      <PopoverTrigger className="flex items-center leading-none" openOnHover delay={hoverDelay}>
         {renderBadge()}
       </PopoverTrigger>
       <PopoverContent className="w-auto max-w-sm min-w-72">

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
@@ -24,12 +24,14 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
         return (
           <div
             className={cn(
-              'flex h-5 max-w-52 items-center gap-2 rounded-md bg-background-2 px-1.5 leading-none',
+              'flex h-5 max-w-52 items-center gap-1.5 rounded-md bg-background-2 px-1.5 leading-none',
               className
             )}
           >
             <StatusIcon className="size-3" pr={pr} disableTooltip />
-            <PrNumberBadge number={getPrNumber(pr) ?? 0} className="text-[10px] leading-none" />
+            <span className="shrink-0 text-xs leading-none text-foreground-muted">
+              #{getPrNumber(pr) ?? 0}
+            </span>
             <span className="truncate text-xs leading-none text-foreground-muted">{pr.title}</span>
           </div>
         );


### PR DESCRIPTION
## summary
- align PR badge contents with a fixed badge height and leading-none text
- replace the nested number badge in the default PR badge with inline text for better vertical alignment

## screenshot
before:
<img width="199" height="31" alt="Screenshot 2026-07-07 at 11 28 32" src="https://github.com/user-attachments/assets/7a99f7f4-7e6a-4e25-b49c-fc931d49f0d7" />
after:
<img width="357" height="44" alt="Screenshot 2026-07-07 at 11 27 58" src="https://github.com/user-attachments/assets/a06ea1a0-2f3f-4b18-aa74-303fd8885196" />

