### PR TITLE
fix: prevent triage icon clipping

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/components/issue-status-indicator.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/issue-status-indicator.tsx
@@ -141,7 +141,7 @@ export function IssueStatusIndicator({
     case 'triage':
       return (
         <svg
-          viewBox="0 0 14 14"
+          viewBox="-0.5 -0.5 15 15"
           role="img"
           focusable="false"
           aria-hidden="true"


### PR DESCRIPTION
## summary
- Fix triage status icon clipping by expanding its SVG viewBox

## screenshot
<img width="410" height="93" alt="Screenshot 2026-07-07 at 14 40 56" src="https://github.com/user-attachments/assets/66663e9c-71ec-41bf-a07f-414db50180a6" />
