### PR TITLE
fix(tasks): preserve create task tab state

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/create-task-modal/create-task-modal.tsx
@@ -144,6 +144,7 @@ export const CreateTaskModal = observer(function CreateTaskModal({
             includeIssueContextByDefault={includeIssueContextByDefault}
           >
             <TaskConfigPanel
+              preserveTabContent
               tabs={[
                 {
                   value: 'conversation',

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.test.ts
@@ -41,10 +41,10 @@ vi.mock('@renderer/lib/ui/panel-tabs', async () => {
 function StatefulContent({ label }: { label: string }) {
   const [value, setValue] = useState('initial');
 
-  return (
-    <button type="button" data-testid={label} onClick={() => setValue('edited')}>
-      {value}
-    </button>
+  return React.createElement(
+    'button',
+    { type: 'button', 'data-testid': label, onClick: () => setValue('edited') },
+    value
   );
 }
 
@@ -76,21 +76,21 @@ describe('TaskConfigPanel', () => {
   it('preserves tab content state when switching tabs', async () => {
     await act(async () => {
       root.render(
-        <TaskConfigPanel
-          preserveTabContent
-          tabs={[
+        React.createElement(TaskConfigPanel, {
+          preserveTabContent: true,
+          tabs: [
             {
               value: 'conversation',
               label: 'Initial Conversation',
-              content: <StatefulContent label="conversation" />,
+              content: React.createElement(StatefulContent, { label: 'conversation' }),
             },
             {
               value: 'workspace',
               label: 'Workspace Settings',
-              content: <div>Workspace</div>,
+              content: React.createElement('div', null, 'Workspace'),
             },
-          ]}
-        />
+          ],
+        })
       );
     });
 
@@ -115,5 +115,44 @@ describe('TaskConfigPanel', () => {
     });
 
     expect(container.querySelector('[data-testid="conversation"]')?.textContent).toBe('edited');
+  });
+
+  it('mounts inactive preserved tabs only after they are visited', async () => {
+    const workspaceMount = vi.fn();
+
+    function WorkspaceContent() {
+      workspaceMount();
+      return React.createElement('div', null, 'Workspace');
+    }
+
+    await act(async () => {
+      root.render(
+        React.createElement(TaskConfigPanel, {
+          preserveTabContent: true,
+          tabs: [
+            {
+              value: 'conversation',
+              label: 'Initial Conversation',
+              content: React.createElement(StatefulContent, { label: 'conversation' }),
+            },
+            {
+              value: 'workspace',
+              label: 'Workspace Settings',
+              content: React.createElement(WorkspaceContent),
+            },
+          ],
+        })
+      );
+    });
+
+    expect(workspaceMount).not.toHaveBeenCalled();
+
+    await act(async () => {
+      container
+        .querySelector('button:nth-of-type(2)')
+        ?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(workspaceMount).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.test.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.test.tsx
@@ -1,0 +1,119 @@
+import { JSDOM } from 'jsdom';
+import React, { act, useState } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TaskConfigPanel } from './task-config-panel';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+vi.mock('@renderer/lib/ui/panel-tabs', async () => {
+  const React = await import('react');
+  return {
+    PanelTabs: ({
+      value,
+      onChange,
+      tabs,
+    }: {
+      value: string;
+      onChange: (value: string) => void;
+      tabs: Array<{ value: string; label: string }>;
+    }) =>
+      React.createElement(
+        'div',
+        { 'data-active-tab': value },
+        tabs.map((tab) =>
+          React.createElement(
+            'button',
+            {
+              key: tab.value,
+              type: 'button',
+              onClick: () => onChange(tab.value),
+            },
+            tab.label
+          )
+        )
+      ),
+  };
+});
+
+function StatefulContent({ label }: { label: string }) {
+  const [value, setValue] = useState('initial');
+
+  return (
+    <button type="button" data-testid={label} onClick={() => setValue('edited')}>
+      {value}
+    </button>
+  );
+}
+
+describe('TaskConfigPanel', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>', {
+      url: 'http://localhost',
+    });
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('preserves tab content state when switching tabs', async () => {
+    await act(async () => {
+      root.render(
+        <TaskConfigPanel
+          preserveTabContent
+          tabs={[
+            {
+              value: 'conversation',
+              label: 'Initial Conversation',
+              content: <StatefulContent label="conversation" />,
+            },
+            {
+              value: 'workspace',
+              label: 'Workspace Settings',
+              content: <div>Workspace</div>,
+            },
+          ]}
+        />
+      );
+    });
+
+    const conversationButton = container.querySelector('[data-testid="conversation"]');
+    expect(conversationButton?.textContent).toBe('initial');
+
+    await act(async () => {
+      conversationButton?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(conversationButton?.textContent).toBe('edited');
+
+    await act(async () => {
+      container
+        .querySelector('button:nth-of-type(2)')
+        ?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      container
+        .querySelector('button:nth-of-type(1)')
+        ?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+
+    expect(container.querySelector('[data-testid="conversation"]')?.textContent).toBe('edited');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.tsx
@@ -20,13 +20,15 @@ export function TaskConfigPanel({
 }: TaskConfigPanelProps) {
   const [activeTab, setActiveTab] = useState<string>(defaultTab ?? tabs[0]?.value ?? '');
   const currentContent = tabs.find((t) => t.value === activeTab)?.content ?? null;
-  const content = preserveTabContent
-    ? tabs.map((tab) => (
-        <div key={tab.value} hidden={tab.value !== activeTab}>
-          {tab.content}
-        </div>
-      ))
-    : <div>{currentContent}</div>;
+  const content = preserveTabContent ? (
+    tabs.map((tab) => (
+      <div key={tab.value} hidden={tab.value !== activeTab}>
+        {tab.content}
+      </div>
+    ))
+  ) : (
+    <div>{currentContent}</div>
+  );
 
   return (
     <div className="flex flex-col gap-2">

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.tsx
@@ -1,10 +1,10 @@
-import { useState } from 'react';
+import { type ReactNode, useState } from 'react';
 import { PanelTabs } from '@renderer/lib/ui/panel-tabs';
 
 interface Tab {
   value: string;
   label: string;
-  content: React.ReactNode;
+  content: ReactNode;
 }
 
 interface TaskConfigPanelProps {
@@ -19,13 +19,20 @@ export function TaskConfigPanel({
   preserveTabContent = false,
 }: TaskConfigPanelProps) {
   const [activeTab, setActiveTab] = useState<string>(defaultTab ?? tabs[0]?.value ?? '');
+  const [mountedTabs, setMountedTabs] = useState<Set<string>>(() => new Set([activeTab]));
   const currentContent = tabs.find((t) => t.value === activeTab)?.content ?? null;
+  const handleTabChange = (tab: string) => {
+    setActiveTab(tab);
+    setMountedTabs((current) => new Set(current).add(tab));
+  };
   const content = preserveTabContent ? (
-    tabs.map((tab) => (
-      <div key={tab.value} hidden={tab.value !== activeTab}>
-        {tab.content}
-      </div>
-    ))
+    tabs
+      .filter((tab) => mountedTabs.has(tab.value))
+      .map((tab) => (
+        <div key={tab.value} hidden={tab.value !== activeTab}>
+          {tab.content}
+        </div>
+      ))
   ) : (
     <div>{currentContent}</div>
   );
@@ -34,7 +41,7 @@ export function TaskConfigPanel({
     <div className="flex flex-col gap-2">
       <PanelTabs
         value={activeTab}
-        onChange={setActiveTab}
+        onChange={handleTabChange}
         tabs={tabs.map(({ value, label }) => ({ value, label }))}
       />
       {content}

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/task-config-panel.tsx
@@ -10,12 +10,23 @@ interface Tab {
 interface TaskConfigPanelProps {
   tabs: Tab[];
   defaultTab?: string;
+  preserveTabContent?: boolean;
 }
 
-export function TaskConfigPanel({ tabs, defaultTab }: TaskConfigPanelProps) {
+export function TaskConfigPanel({
+  tabs,
+  defaultTab,
+  preserveTabContent = false,
+}: TaskConfigPanelProps) {
   const [activeTab, setActiveTab] = useState<string>(defaultTab ?? tabs[0]?.value ?? '');
-
   const currentContent = tabs.find((t) => t.value === activeTab)?.content ?? null;
+  const content = preserveTabContent
+    ? tabs.map((tab) => (
+        <div key={tab.value} hidden={tab.value !== activeTab}>
+          {tab.content}
+        </div>
+      ))
+    : <div>{currentContent}</div>;
 
   return (
     <div className="flex flex-col gap-2">
@@ -24,7 +35,7 @@ export function TaskConfigPanel({ tabs, defaultTab }: TaskConfigPanelProps) {
         onChange={setActiveTab}
         tabs={tabs.map(({ value, label }) => ({ value, label }))}
       />
-      <div>{currentContent}</div>
+      {content}
     </div>
   );
 }


### PR DESCRIPTION
Previously, switching tabs in the create task modal reset draft content; now tab contents stay mounted so edits are preserved.

## summary
- preserve create task modal tab contents when switching tabs
- add coverage for preserving state across task config tab switches

## screenrecording
https://cap.link/j6d15rqppn7td23