### PR TITLE
fix: chat ui msg misalignment

### DIFF
--- a/packages/chat-ui/src/ChatRoot.tsx
+++ b/packages/chat-ui/src/ChatRoot.tsx
@@ -80,6 +80,7 @@ import {
   heroSlotVisibleClass,
   outerClip,
   pinnedOverlay,
+  pinnedOverlayColumn,
   scrollContainer,
   unitRowWrapper,
   widthProbeClass,
@@ -358,6 +359,16 @@ export function ChatRoot(props: ChatRootProps) {
   const [scrollVelocity, setScrollVelocity] = createSignal(0);
   const [viewHeight, setViewHeight] = createSignal(600);
   const [containerWidth, setContainerWidth] = createSignal(0);
+  const [contentColumnLeft, setContentColumnLeft] = createSignal(0);
+
+  const updateContentColumnGeometry = () => {
+    if (!widthProbeEl || !outerEl) return;
+    const probeRect = widthProbeEl.getBoundingClientRect();
+    const outerRect = outerEl.getBoundingClientRect();
+    if (probeRect.width <= 0) return;
+    setContainerWidth(probeRect.width);
+    setContentColumnLeft(probeRect.left - outerRect.left);
+  };
 
   const updateSlotPadBottom = () => {
     if (props.composer !== 'slot' || effectiveComposerPlacement() === 'center') {
@@ -1517,15 +1528,16 @@ export function ChatRoot(props: ChatRootProps) {
     roHeight.observe(el);
     onCleanup(() => roHeight.disconnect());
 
-    // Target the zero-height width probe (carries contentClass / max-width cap)
-    // instead of canvasEl so this observer only fires on genuine layout-width
-    // changes and not on the canvas height mutations from streaming/tween updates.
+    // Target geometry ancestors instead of canvasEl so this observer only fires
+    // on genuine column geometry changes and not on canvas height mutations from
+    // streaming/tween updates. Observing outer/scroll catches a centered max-width
+    // column moving horizontally even when the probe's own width is unchanged.
     if (widthProbeEl) {
-      const roWidth = new ResizeObserver((entries) => {
-        const w = entries[0]?.contentRect.width;
-        if (w && w > 0) setContainerWidth(w);
-      });
+      const roWidth = new ResizeObserver(() => updateContentColumnGeometry());
       roWidth.observe(widthProbeEl);
+      roWidth.observe(el);
+      if (outerEl) roWidth.observe(outerEl);
+      updateContentColumnGeometry();
       onCleanup(() => roWidth.disconnect());
     }
 
@@ -1667,6 +1679,7 @@ export function ChatRoot(props: ChatRootProps) {
                     ref={(el) => {
                       widthProbeEl = el;
                     }}
+                    data-chat-width-probe
                     aria-hidden="true"
                     class={`${widthProbeClass} ${contentClass()}`}
                   />
@@ -1745,11 +1758,18 @@ export function ChatRoot(props: ChatRootProps) {
                             aria-hidden="true"
                             style={{ transform: `translateY(${ps().overlayTop}px)` }}
                           >
-                            {/* Inner centered column carries the max-width cap so
-                                the pinned card matches the inline rows' width. The
-                                gutter padding lives on the outer overlay (above),
-                                mirroring the composer slot's two-level structure. */}
-                            <div class={contentClass()}>
+                            {/* Position from the scroll-container width probe so
+                                classic scrollbar gutters cannot offset the pinned
+                                copy from the inline transcript row underneath. */}
+                            <div
+                              class={`${pinnedOverlayColumn} ${contentClass()}`}
+                              style={{
+                                'margin-left': `${contentColumnLeft()}px`,
+                                'margin-right': '0px',
+                                width: `${containerWidth()}px`,
+                                'max-width': 'none',
+                              }}
+                            >
                               <PinnedUserMessage
                                 item={item()}
                                 rowWidth={containerWidth()}

--- a/packages/chat-ui/src/chat-root.css.ts
+++ b/packages/chat-ui/src/chat-root.css.ts
@@ -88,10 +88,15 @@ export const pinnedOverlay = style({
   top: 0,
   zIndex: 10,
   willChange: 'transform',
-  // Match the scroll container gutter so the pinned card aligns with the
-  // scrolled rows instead of jumping 16px when a user message pins.
-  paddingLeft: CONTENT_GUTTER,
-  paddingRight: CONTENT_GUTTER,
+});
+
+/**
+ * Pinned overlay column. ChatRoot positions this from the width probe's actual
+ * rect so it shares the scroll container's content geometry, including any
+ * scrollbar gutter reserved by the browser.
+ */
+export const pinnedOverlayColumn = style({
+  position: 'relative',
 });
 
 /**

--- a/packages/chat-ui/src/chat-view.contract.test.tsx
+++ b/packages/chat-ui/src/chat-view.contract.test.tsx
@@ -19,6 +19,15 @@ import { createChatState } from '@/state/chat-state';
 const nextPaint = (): Promise<void> =>
   new Promise((resolve) => requestAnimationFrame(() => requestAnimationFrame(() => resolve())));
 
+async function waitFor<T>(fn: () => T | null, frames = 10): Promise<T | null> {
+  for (let i = 0; i < frames; i++) {
+    const value = fn();
+    if (value) return value;
+    await nextPaint();
+  }
+  return null;
+}
+
 // ── Tests ─────────────────────────────────────────────────────────────────────
 
 describe('createChatView', () => {
@@ -65,6 +74,39 @@ describe('createChatView', () => {
     view.scrollToTop();
     await nextPaint();
     expect(scrollEl!.scrollTop).toBe(0);
+
+    view.dispose();
+    ctx.dispose();
+    state.dispose();
+    document.body.removeChild(host);
+  });
+
+  it('aligns pinned user messages with the measured transcript column', async () => {
+    const ctx = createChatContext({ theme: DEFAULT_THEME });
+    const state = createChatState(ctx);
+    state.transcript.history.seed(generateMockTranscript(80, 11));
+
+    const host = document.createElement('div');
+    host.style.cssText = 'position:fixed;top:0;left:0;width:800px;height:320px;';
+    document.body.appendChild(host);
+
+    const view = createChatView({ context: ctx, state, parent: host, pinUserMessages: true });
+    await nextPaint();
+
+    view.scrollToBottom();
+    const pinnedCard = await waitFor(
+      () => host.querySelector('[aria-hidden="true"] [data-user-card]') as HTMLElement | null
+    );
+
+    expect(pinnedCard).not.toBeNull();
+
+    const probe = host.querySelector('[data-chat-width-probe]') as HTMLElement | null;
+    expect(probe).not.toBeNull();
+
+    const pinRect = pinnedCard!.getBoundingClientRect();
+    const probeRect = probe!.getBoundingClientRect();
+    expect(Math.abs(pinRect.left - probeRect.left)).toBeLessThan(1);
+    expect(Math.abs(pinRect.width - probeRect.width)).toBeLessThan(1);
 
     view.dispose();
     ctx.dispose();


### PR DESCRIPTION
the scrollbar on devices that have a mouse connected lead to a misalignment between the transcript messages and the sticky messages in the chat ui
