### PR TITLE
fix(pr): render changed files in tree view

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.test.ts
@@ -18,4 +18,23 @@ describe('buildChangesTree', () => {
     expect(tree.changeByPath.get('src/index.ts')).toBe(change);
     expect(tree.changeByPath.get('src/index.ts')?.path).toBe('/repo/src/index.ts');
   });
+
+  it('keeps absolute node paths addressable when no root path is provided', () => {
+    const change: GitChange = {
+      path: '/repo/src/index.ts',
+      status: 'modified',
+      additions: 2,
+      deletions: 1,
+    };
+
+    const tree = buildChangesTree([change]);
+    const repo = tree.rootNodes[0];
+    const src = repo?.children[0];
+    const file = src?.children[0];
+    const filePath = file?.path;
+
+    expect(repo?.path).toBe('/repo');
+    expect(filePath).toBe('/repo/src/index.ts');
+    expect(filePath ? tree.changeByPath.get(filePath) : undefined).toBe(change);
+  });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/changes-tree-utils.ts
@@ -27,11 +27,11 @@ export function buildChangesTree(changes: GitChange[], rootPath?: string): Chang
     const parts = displayPath.split('/').filter(Boolean);
     if (parts.length === 0) continue;
 
-    let prefix = '';
+    let prefix = displayPath.startsWith('/') ? '/' : '';
     let parentNode: NestedFileNode | null = null;
     for (let i = 0; i < parts.length; i++) {
       const segment = parts[i]!;
-      prefix = prefix ? `${prefix}/${segment}` : segment;
+      prefix = prefix === '/' ? `/${segment}` : prefix ? `${prefix}/${segment}` : segment;
       const isLeaf = i === parts.length - 1;
       const type = isLeaf ? 'file' : 'directory';
       const key = `${type}:${prefix}`;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/files-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/files-list.tsx
@@ -4,6 +4,7 @@ import { usePrefetchDiffModels } from '@renderer/features/tasks/diff-view/change
 import { activeDiffEntry } from '@renderer/features/tasks/diff-view/pane-selectors';
 import {
   useTaskViewContext,
+  useWorkspace,
   useWorkspaceId,
   useWorkspaceViewModel,
 } from '@renderer/features/tasks/task-view-context';
@@ -15,6 +16,7 @@ import { ChangesListOrTree } from '../changes-list-or-tree';
 export const PrFilesList = observer(function PrFilesList({ pr }: { pr: PullRequest }) {
   const { projectId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
+  const workspace = useWorkspace();
   const taskView = useWorkspaceViewModel();
   const prStore = taskView.prStore!;
   const { mode: viewMode } = useChangesViewMode('pr');
@@ -80,6 +82,7 @@ export const PrFilesList = observer(function PrFilesList({ pr }: { pr: PullReque
       viewMode={viewMode}
       className="py-3"
       changes={prFiles}
+      rootPath={workspace.path}
       activePath={activePath}
       onSelectChange={handleSelectChange}
       onDoubleClickChange={handleDoubleClickChange}


### PR DESCRIPTION
- pass the workspace root into PrFilesList so pr file paths render relative to the repo
- preserve absolute paths in buildChangesTree when no root path is available
- prevent tree rows from becoming blank when file node paths and change lookup keys differ