### PR TITLE
fix(linear): use search result fragment for issue search

### DIFF
--- a/packages/plugins/src/issues/impl/linear/index.test.ts
+++ b/packages/plugins/src/issues/impl/linear/index.test.ts
@@ -105,6 +105,22 @@ describe('linear issues plugin', () => {
       expect.objectContaining({ term: 'GEN-626', limit: 5 })
     );
     expect(rawRequest).toHaveBeenCalledWith(
+      expect.not.stringContaining('state {'),
+      expect.objectContaining({ term: 'GEN-626', limit: 5 })
+    );
+    expect(rawRequest).toHaveBeenCalledWith(
+      expect.not.stringContaining('assignee {'),
+      expect.objectContaining({ term: 'GEN-626', limit: 5 })
+    );
+    expect(rawRequest).toHaveBeenCalledWith(
+      expect.not.stringContaining('project {'),
+      expect.objectContaining({ term: 'GEN-626', limit: 5 })
+    );
+    expect(rawRequest).toHaveBeenCalledWith(
+      expect.not.stringContaining('updatedAt'),
+      expect.objectContaining({ term: 'GEN-626', limit: 5 })
+    );
+    expect(rawRequest).toHaveBeenCalledWith(
       expect.not.stringContaining('comments('),
       expect.objectContaining({ term: 'GEN-626', limit: 5 })
     );
@@ -121,6 +137,11 @@ describe('linear issues plugin', () => {
         }),
       ],
     });
+    if (!result.success) throw new Error('expected Linear search to succeed');
+    expect(result.data[0]).not.toHaveProperty('status');
+    expect(result.data[0]).not.toHaveProperty('assignees');
+    expect(result.data[0]).not.toHaveProperty('project');
+    expect(result.data[0]).not.toHaveProperty('updatedAt');
   });
 
   it('returns a generic error when Linear search fails', async () => {

--- a/packages/plugins/src/issues/impl/linear/index.test.ts
+++ b/packages/plugins/src/issues/impl/linear/index.test.ts
@@ -97,6 +97,14 @@ describe('linear issues plugin', () => {
       expect.objectContaining({ term: 'GEN-626', limit: 5 })
     );
     expect(rawRequest).toHaveBeenCalledWith(
+      expect.stringContaining('fragment IssueSearchSummary on IssueSearchResult'),
+      expect.objectContaining({ term: 'GEN-626', limit: 5 })
+    );
+    expect(rawRequest).toHaveBeenCalledWith(
+      expect.not.stringContaining('fragment IssueSummary on Issue'),
+      expect.objectContaining({ term: 'GEN-626', limit: 5 })
+    );
+    expect(rawRequest).toHaveBeenCalledWith(
       expect.not.stringContaining('comments('),
       expect.objectContaining({ term: 'GEN-626', limit: 5 })
     );

--- a/packages/plugins/src/issues/impl/linear/index.ts
+++ b/packages/plugins/src/issues/impl/linear/index.ts
@@ -15,7 +15,7 @@ import type {
   IssueSearchOpts,
 } from '../../types';
 import { getLinearIssueDetails } from './context';
-import { toIssueData, toIssueDetail } from './mapper';
+import { toIssueData, toIssueDetail, toIssueSearchData } from './mapper';
 import { queryLinearIssues, queryLinearIssueWithActivity, searchLinearIssues } from './queries';
 
 export async function listIssues(
@@ -47,7 +47,7 @@ export async function searchIssues(
   const sanitizedLimit = clampIssueLimit(opts.limit, 20, 200);
   try {
     const issues = await searchLinearIssues(client, term, sanitizedLimit);
-    return ok(issues.map(toIssueData));
+    return ok(issues.map(toIssueSearchData));
   } catch (error) {
     host.log.warn('Linear searchIssues failed', { error });
     return err(toLinearIntegrationError(error, 'Unable to search Linear issues.'));

--- a/packages/plugins/src/issues/impl/linear/mapper.ts
+++ b/packages/plugins/src/issues/impl/linear/mapper.ts
@@ -1,18 +1,28 @@
 import type { IssueData, IssueDetail } from '../../types';
-import type { LinearIssueSummaryNode } from './queries';
+import type { LinearIssueSearchNode, LinearIssueSummaryNode } from './queries';
 
-export function toIssueData(raw: LinearIssueSummaryNode): IssueData {
+function toIssueBaseData(raw: LinearIssueSearchNode): IssueData {
   return {
     identifier: raw.identifier,
     title: raw.title,
     url: raw.url,
     description: raw.description ?? undefined,
     branchName: raw.branchName ?? undefined,
+  };
+}
+
+export function toIssueData(raw: LinearIssueSummaryNode): IssueData {
+  return {
+    ...toIssueBaseData(raw),
     status: raw.state?.name ?? undefined,
     assignees: raw.assignee ? [raw.assignee.name || raw.assignee.displayName] : undefined,
     project: raw.project?.name ?? undefined,
     updatedAt: raw.updatedAt,
   };
+}
+
+export function toIssueSearchData(raw: LinearIssueSearchNode): IssueData {
+  return toIssueBaseData(raw);
 }
 
 export function toIssueDetail(

--- a/packages/plugins/src/issues/impl/linear/queries.ts
+++ b/packages/plugins/src/issues/impl/linear/queries.ts
@@ -64,19 +64,29 @@ export type LinearIssueWithActivity = LinearIssueSummaryNode & LinearIssueActivi
 
 const ACTIVITY_PAGE_SIZE = 50;
 
+const ISSUE_SUMMARY_FIELDS = `
+  id
+  identifier
+  title
+  description
+  url
+  branchName
+  state { name type color }
+  team { name key }
+  project { name }
+  assignee { displayName name }
+  updatedAt
+`;
+
 const ISSUE_SUMMARY_FRAGMENT = `
   fragment IssueSummary on Issue {
-    id
-    identifier
-    title
-    description
-    url
-    branchName
-    state { name type color }
-    team { name key }
-    project { name }
-    assignee { displayName name }
-    updatedAt
+    ${ISSUE_SUMMARY_FIELDS}
+  }
+`;
+
+const ISSUE_SEARCH_SUMMARY_FRAGMENT = `
+  fragment IssueSearchSummary on IssueSearchResult {
+    ${ISSUE_SUMMARY_FIELDS}
   }
 `;
 
@@ -138,12 +148,12 @@ const ISSUES_QUERY = `
 `;
 
 const SEARCH_QUERY = `
-  ${ISSUE_SUMMARY_FRAGMENT}
+  ${ISSUE_SEARCH_SUMMARY_FRAGMENT}
 
   query SearchIssues($term: String!, $limit: Int!) {
     searchIssues(term: $term, first: $limit) {
       nodes {
-        ...IssueSummary
+        ...IssueSearchSummary
       }
     }
   }

--- a/packages/plugins/src/issues/impl/linear/queries.ts
+++ b/packages/plugins/src/issues/impl/linear/queries.ts
@@ -14,6 +14,15 @@ export type LinearIssueSummaryNode = {
   updatedAt: string;
 };
 
+export type LinearIssueSearchNode = {
+  id: string;
+  identifier: string;
+  title: string;
+  description: string | null;
+  url: string;
+  branchName: string | null;
+};
+
 export type LinearCommentNode = {
   id: string;
   body: string;
@@ -86,7 +95,12 @@ const ISSUE_SUMMARY_FRAGMENT = `
 
 const ISSUE_SEARCH_SUMMARY_FRAGMENT = `
   fragment IssueSearchSummary on IssueSearchResult {
-    ${ISSUE_SUMMARY_FIELDS}
+    id
+    identifier
+    title
+    description
+    url
+    branchName
   }
 `;
 
@@ -208,9 +222,9 @@ export async function searchLinearIssues(
   client: LinearClient,
   term: string,
   limit: number
-): Promise<LinearIssueSummaryNode[]> {
+): Promise<LinearIssueSearchNode[]> {
   const { data } = await client.client.rawRequest<
-    { searchIssues: { nodes: LinearIssueSummaryNode[] } },
+    { searchIssues: { nodes: LinearIssueSearchNode[] } },
     { term: string; limit: number }
   >(SEARCH_QUERY, { term, limit });
 


### PR DESCRIPTION
- fixes linear issue search by using a search-result-specific graphql fragment
- keeps one shared field selection across list get and search
- guards against the invalid fragment shape that surfaces as a linear graphql validation error