### PR TITLE
fix(acp): restore prompt queueing during active turns

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -291,7 +291,7 @@ const ComposerForStore = observer(function ComposerForStore({
       setAttachments([]);
       editorApiRef.current?.clear();
       const hiddenContext = await buildHiddenIssueContext(value);
-      store.submitPrompt(value, promptAttachments, hiddenContext);
+      store.queuePrompt(value, promptAttachments, hiddenContext);
     },
     [store, buildPromptAttachments, buildHiddenIssueContext]
   );

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-store.ts
@@ -101,6 +101,7 @@ export class AcpChatStore {
       affordances: computed,
       isEmpty: computed,
       submitPrompt: action,
+      queuePrompt: action,
       stop: action,
       setModel: action,
       setMode: action,
@@ -301,6 +302,20 @@ export class AcpChatStore {
         if (!result.success) this._toastError('Failed to send message', result.error);
       })
       .catch((error: unknown) => this._toastError('Failed to send message', error));
+  }
+
+  queuePrompt(text: string, attachments: AcpPromptAttachment[] = [], hiddenContext?: string): void {
+    const promptAttachments = attachments.map((attachment) => attachment.ref);
+    void this.session
+      ?.queuePrompt({
+        text,
+        ...(hiddenContext ? { hiddenContext } : {}),
+        ...(promptAttachments.length > 0 ? { attachments: promptAttachments } : {}),
+      })
+      .then((result) => {
+        if (!result.success) this._toastError('Failed to queue message', result.error);
+      })
+      .catch((error: unknown) => this._toastError('Failed to queue message', error));
   }
 
   setDraftText(text: string): void {

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -604,9 +604,9 @@ export function ChatComposer({
     const hasImages = attachments.some((a) => a.kind === 'image');
     if (!text.trim() && !hasImages) return;
     // While the agent is actively working, route to the host's conflict handler
-    // (e.g. a "cancel turn and send" confirmation modal) instead of submitting.
-    if (isWorking && onSubmitWhileWorking) {
-      onSubmitWhileWorking(text);
+    // (e.g. queueing or a cancel-and-send confirmation) instead of submitting.
+    if (isWorking) {
+      onSubmitWhileWorking?.(text);
       return;
     }
     if (disabled || !canSubmit) return;
@@ -708,6 +708,7 @@ export function ChatComposer({
     !!onSendQueuedPromptNow;
   // The permission band takes priority over the notice band.
   const hasBand = canShowQueuedPrompts || !!(permissionRequest ?? notice);
+  const shouldHandleSubmitAttempt = !disabled && (isWorking ? !!onSubmitWhileWorking : canSubmit);
   const resolvedPlaceholder = disabled
     ? 'Session closed'
     : isWorking
@@ -801,7 +802,7 @@ export function ChatComposer({
             placeholder={resolvedPlaceholder}
             disabled={disabled}
             onChange={onInputChange}
-            onSubmit={canSubmit ? handleSubmit : undefined}
+            onSubmit={shouldHandleSubmitAttempt ? handleSubmit : undefined}
             onMentionInsert={onMentionInsert}
             mentionProvider={mentionProvider}
             renderMentionIcon={renderMentionIcon}


### PR DESCRIPTION
- keeps composer submit attempts wired while an agent is working so follow up messages reach the working-submit handler
- routes ACP follow up submits through queuePrompt instead of the normal send path
- adds AcpChatStore.queuePrompt to call the existing live session queue api
- preserves normal submit behavior for idle sessions and blocks unsupported working-submit attempts