### PR TITLE
fix(tasks): keep task modal open after app blur

### DIFF
--- a/apps/emdash-desktop/src/renderer/app/modal-registry.ts
+++ b/apps/emdash-desktop/src/renderer/app/modal-registry.ts
@@ -30,6 +30,7 @@ export type ModalRegistryEntry<TProps = unknown, TResult = unknown> = {
   component: ModalComponent<TProps, TResult>;
   size?: ModalSize;
   position?: ModalPosition;
+  ignoreOutsidePressAfterWindowBlur?: boolean;
 };
 
 export function createModal<TProps, TResult>(
@@ -41,7 +42,7 @@ export function createModal<TProps, TResult>(
 
 export const modalRegistry = {
   commandPaletteModal: createModal(CommandPaletteModal, { size: 'md' }),
-  taskModal: createModal(CreateTaskModal),
+  taskModal: createModal(CreateTaskModal, { ignoreOutsidePressAfterWindowBlur: true }),
   addProjectModal: createModal(AddProjectModal),
   addSshConnModal: createModal(AddSshConnModal),
   changeProjectConnectionModal: createModal(ChangeProjectConnectionModal, { size: 'sm' }),

--- a/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
@@ -49,15 +49,42 @@ export const ModalRenderer = observer(function ModalRenderer() {
   const DisplayComponent = lastComponentRef.current;
   const displayArgs = lastArgsRef.current;
   const displayEntry = lastEntryRef.current;
+  const activeModalId = modalStore.activeModalId;
+  const ignoreNextOutsidePressRef = useRef(false);
+
+  useEffect(() => {
+    ignoreNextOutsidePressRef.current = false;
+  }, [activeModalId]);
+
+  useEffect(() => {
+    const handleWindowBlur = () => {
+      if (modalStore.isOpen && entry?.ignoreOutsidePressAfterWindowBlur) {
+        ignoreNextOutsidePressRef.current = true;
+      }
+    };
+
+    window.addEventListener('blur', handleWindowBlur);
+    return () => window.removeEventListener('blur', handleWindowBlur);
+  }, [entry?.ignoreOutsidePressAfterWindowBlur]);
 
   const handleOpenChange = (
     open: boolean,
     eventDetails: DialogPrimitive.Root.ChangeEventDetails
   ) => {
     if (!open && modalStore.isOpen) {
-      const isPassiveDismiss =
-        eventDetails.reason === 'outside-press' || eventDetails.reason === 'escape-key';
+      const isOutsidePress = eventDetails.reason === 'outside-press';
+      if (
+        isOutsidePress &&
+        displayEntry?.ignoreOutsidePressAfterWindowBlur &&
+        ignoreNextOutsidePressRef.current
+      ) {
+        ignoreNextOutsidePressRef.current = false;
+        return;
+      }
+
+      const isPassiveDismiss = isOutsidePress || eventDetails.reason === 'escape-key';
       if (modalStore.closeGuardActive && isPassiveDismiss) return;
+      ignoreNextOutsidePressRef.current = false;
       modalStore.closeModal();
     }
   };
@@ -103,6 +130,11 @@ export const ModalRenderer = observer(function ModalRenderer() {
           onKeyDownCapture={(e) => {
             if ((e.metaKey || e.ctrlKey || e.altKey) && e.key === 'Enter') {
               e.preventDefault();
+            }
+          }}
+          onPointerDownCapture={() => {
+            if (displayEntry?.ignoreOutsidePressAfterWindowBlur) {
+              ignoreNextOutsidePressRef.current = false;
             }
           }}
           className={cn(

--- a/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/modal/modal-renderer.tsx
@@ -50,7 +50,10 @@ export const ModalRenderer = observer(function ModalRenderer() {
   const displayArgs = lastArgsRef.current;
   const displayEntry = lastEntryRef.current;
   const activeModalId = modalStore.activeModalId;
+  const activeEntryRef = useRef<ModalRegistryEntry | null>(null);
   const ignoreNextOutsidePressRef = useRef(false);
+
+  activeEntryRef.current = entry;
 
   useEffect(() => {
     ignoreNextOutsidePressRef.current = false;
@@ -58,14 +61,14 @@ export const ModalRenderer = observer(function ModalRenderer() {
 
   useEffect(() => {
     const handleWindowBlur = () => {
-      if (modalStore.isOpen && entry?.ignoreOutsidePressAfterWindowBlur) {
+      if (modalStore.isOpen && activeEntryRef.current?.ignoreOutsidePressAfterWindowBlur) {
         ignoreNextOutsidePressRef.current = true;
       }
     };
 
     window.addEventListener('blur', handleWindowBlur);
     return () => window.removeEventListener('blur', handleWindowBlur);
-  }, [entry?.ignoreOutsidePressAfterWindowBlur]);
+  }, []);
 
   const handleOpenChange = (
     open: boolean,


### PR DESCRIPTION
## summary
- keep the new task modal from dismissing after the app window blurs
- scope the blur/outside-press guard to the task modal

## demo
- https://cap.link/tgrsmhwwcmyvmj2

## testing
- not run; changes were already committed