### PR TITLE
feat(diff): preview markdown and html

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -137,8 +137,7 @@ const TextDiffRenderer = observer(function TextDiffRenderer({ tab }: DiffFileRen
     return uri;
   })();
 
-  const previewContentUri =
-    tab.diffGroup === 'disk' ? modelRegistry.toDiskUri(uri) : modifiedUri;
+  const previewContentUri = tab.diffGroup === 'disk' ? modelRegistry.toDiskUri(uri) : modifiedUri;
 
   useEffect(() => {
     let disposed = false;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -137,6 +137,9 @@ const TextDiffRenderer = observer(function TextDiffRenderer({ tab }: DiffFileRen
     return uri;
   })();
 
+  const previewContentUri =
+    tab.diffGroup === 'disk' ? modelRegistry.toDiskUri(uri) : modifiedUri;
+
   useEffect(() => {
     let disposed = false;
 
@@ -230,7 +233,7 @@ const TextDiffRenderer = observer(function TextDiffRenderer({ tab }: DiffFileRen
     return (
       <DiffContentPreview
         tab={tab}
-        contentUri={modifiedUri}
+        contentUri={previewContentUri}
         previewKind={tab.renderer.previewKind}
       />
     );

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -2,6 +2,7 @@ import type { GitObjectRef } from '@emdash/core/git';
 import { observer } from 'mobx-react-lite';
 import type * as monaco from 'monaco-editor';
 import { useCallback, useEffect, useState } from 'react';
+import { usePaneContext } from '@renderer/features/tabs/pane-context';
 import { useDiffEditorComments } from '@renderer/features/tasks/diff-view/comments/use-diff-editor-comments';
 import { ImageDiffView } from '@renderer/features/tasks/diff-view/main-panel/image-diff-view';
 import { isMissingFileError } from '@renderer/features/tasks/diff-view/main-panel/missing-file-error';
@@ -9,12 +10,19 @@ import type { DiffTabResource } from '@renderer/features/tasks/diff-view/stores/
 import { getTaskStore } from '@renderer/features/tasks/stores/task-selectors';
 import {
   useTaskViewContext,
+  useWorkspace,
   useWorkspaceId,
   useWorkspaceViewModel,
 } from '@renderer/features/tasks/task-view-context';
+import { HtmlContentRenderer } from '@renderer/lib/editor/html-renderer';
+import { resolveWorkspaceResourcePath } from '@renderer/lib/editor/workspace-resource-path';
+import { rpc } from '@renderer/lib/ipc';
+import { ModelStatusOverlay } from '@renderer/lib/monaco/model-status-overlay';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
 import { buildMonacoModelPath } from '@renderer/lib/monaco/monacoModelPath';
 import { StickyDiffEditor } from '@renderer/lib/monaco/sticky-diff-editor';
+import { useModelStatus } from '@renderer/lib/monaco/use-model';
+import { MarkdownRenderer } from '@renderer/lib/ui/markdown-renderer';
 import { getLanguageFromPath } from '@renderer/utils/languageUtils';
 import { HEAD_REF, STAGED_REF } from '@shared/core/git/types';
 import { gitRefToString } from '@shared/core/git/utils';
@@ -35,7 +43,7 @@ export const DiffFileRenderer = observer(function DiffFileRenderer({ tab }: Diff
 
   switch (tab.renderer.kind) {
     case 'text':
-      return <MonacoDiffRenderer tab={tab} />;
+      return <TextDiffRenderer tab={tab} />;
     case 'image': {
       const activeFile = tabToActiveFile(tab);
       return (
@@ -56,11 +64,8 @@ export const DiffFileRenderer = observer(function DiffFileRenderer({ tab }: Diff
   }
 });
 
-/**
- * Renders a text diff using the Monaco diff editor.
- * Owns model registration, URI computation, and draft comment wiring.
- */
-const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFileRendererProps) {
+/** Owns text diff model registration, preview rendering, and draft comment wiring. */
+const TextDiffRenderer = observer(function TextDiffRenderer({ tab }: DiffFileRendererProps) {
   const { projectId, taskId } = useTaskViewContext();
   const workspaceId = useWorkspaceId();
   const diffView = useWorkspaceViewModel().diffView;
@@ -221,6 +226,16 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
 
   if (!diffView) return null;
 
+  if (tab.viewMode === 'preview' && tab.renderer.kind === 'text' && tab.renderer.previewKind) {
+    return (
+      <DiffContentPreview
+        tab={tab}
+        contentUri={modifiedUri}
+        previewKind={tab.renderer.previewKind}
+      />
+    );
+  }
+
   return (
     <div className="file-diff-view flex h-full flex-col">
       <div className="relative min-h-0 flex-1">
@@ -231,6 +246,81 @@ const MonacoDiffRenderer = observer(function MonacoDiffRenderer({ tab }: DiffFil
           onEditorChange={setEditor}
         />
       </div>
+    </div>
+  );
+});
+
+interface DiffContentPreviewProps {
+  tab: DiffTabResource;
+  contentUri: string;
+  previewKind: 'markdown' | 'html';
+}
+
+const DiffContentPreview = observer(function DiffContentPreview({
+  tab,
+  contentUri,
+  previewKind,
+}: DiffContentPreviewProps) {
+  const { projectId } = useTaskViewContext();
+  const workspaceId = useWorkspaceId();
+  const workspacePath = useWorkspace().path;
+  const { pane } = usePaneContext();
+  const status = useModelStatus(contentUri);
+  void modelRegistry.bufferVersions.get(contentUri);
+
+  if (tab.status === 'deleted') {
+    return (
+      <div className="text-muted-foreground flex h-full items-center justify-center text-sm">
+        Deleted file — no preview available
+      </div>
+    );
+  }
+
+  if (status !== 'ready') {
+    return (
+      <div className="relative h-full bg-background-secondary-1">
+        <ModelStatusOverlay status={status} />
+      </div>
+    );
+  }
+
+  const content = modelRegistry.getModelByUri(contentUri)?.getValue() ?? '';
+
+  if (previewKind === 'html') {
+    return <HtmlContentRenderer filePath={tab.path} rawContent={content} />;
+  }
+
+  const resolveImage = async (src: string): Promise<string | null> => {
+    const imagePath = resolveWorkspaceResourcePath({
+      workspacePath,
+      containingFilePath: tab.path,
+      resourcePath: src,
+    });
+    if (!imagePath) return null;
+    const result = await rpc.workspace.files.readImage(projectId, workspaceId, imagePath);
+    return result.success && result.data?.success ? result.data.dataUrl : null;
+  };
+
+  const openWorkspaceLink = (href: string): boolean => {
+    const target = resolveWorkspaceResourcePath({
+      workspacePath,
+      containingFilePath: tab.path,
+      resourcePath: href,
+    });
+    if (!target) return false;
+    pane.open('file', { path: target }, { preview: false });
+    return true;
+  };
+
+  return (
+    <div className="relative h-full overflow-y-auto bg-background-secondary-1">
+      <MarkdownRenderer
+        content={content}
+        variant="full"
+        className="w-full max-w-3xl px-8 py-8"
+        resolveImage={resolveImage}
+        onOpenLink={openWorkspaceLink}
+      />
     </div>
   );
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-file-renderer.tsx
@@ -137,7 +137,7 @@ const TextDiffRenderer = observer(function TextDiffRenderer({ tab }: DiffFileRen
     return uri;
   })();
 
-  const previewContentUri = tab.diffGroup === 'disk' ? modelRegistry.toDiskUri(uri) : modifiedUri;
+  const previewContentUri = modifiedUri;
 
   useEffect(() => {
     let disposed = false;

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-toolbar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/main-panel/diff-toolbar.tsx
@@ -12,6 +12,7 @@ interface DiffToolbarProps {
 export const DiffToolbar = observer(function DiffToolbar({ tab }: DiffToolbarProps) {
   const diffView = useWorkspaceViewModel().diffView;
   const diffStyle = diffView?.diffStyle;
+  const canPreview = tab.renderer.kind === 'text' && tab.renderer.previewKind !== undefined;
 
   const diffSourceLabel = (() => {
     if (tab.diffGroup === 'staged') return 'Staged';
@@ -29,23 +30,42 @@ export const DiffToolbar = observer(function DiffToolbar({ tab }: DiffToolbarPro
         {diffSourceLabel && <MicroLabel>{diffSourceLabel}</MicroLabel>}
       </div>
       <div className="flex items-center gap-2">
-        <ToggleGroup
-          size="sm"
-          multiple={false}
-          value={[diffStyle]}
-          onValueChange={([value]) => {
-            if (value) {
-              diffView.setDiffStyle(value as 'unified' | 'split');
-            }
-          }}
-        >
-          <ToggleGroupItem value="unified">
-            <AlignJustify className="h-3.5 w-3.5" />
-          </ToggleGroupItem>
-          <ToggleGroupItem value="split">
-            <Columns2 className="h-3.5 w-3.5" />
-          </ToggleGroupItem>
-        </ToggleGroup>
+        {canPreview && (
+          <ToggleGroup
+            size="sm"
+            multiple={false}
+            value={[tab.viewMode]}
+            onValueChange={([value]) => {
+              if (value === 'diff' || value === 'preview') tab.setViewMode(value);
+            }}
+          >
+            <ToggleGroupItem value="diff" className="text-xs">
+              Diff
+            </ToggleGroupItem>
+            <ToggleGroupItem value="preview" className="text-xs">
+              Preview
+            </ToggleGroupItem>
+          </ToggleGroup>
+        )}
+        {tab.viewMode === 'diff' && (
+          <ToggleGroup
+            size="sm"
+            multiple={false}
+            value={[diffStyle]}
+            onValueChange={([value]) => {
+              if (value) {
+                diffView.setDiffStyle(value as 'unified' | 'split');
+              }
+            }}
+          >
+            <ToggleGroupItem value="unified">
+              <AlignJustify className="h-3.5 w-3.5" />
+            </ToggleGroupItem>
+            <ToggleGroupItem value="split">
+              <Columns2 className="h-3.5 w-3.5" />
+            </ToggleGroupItem>
+          </ToggleGroup>
+        )}
       </div>
     </div>
   );

--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-resource.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/stores/diff-tab-resource.ts
@@ -5,7 +5,12 @@ import { getFileKind } from '@renderer/lib/editor/fileKind';
 import type { ActiveFile } from '@shared/view-state';
 import type { DiffTabManager } from './diff-tab-manager';
 
-export type DiffRendererData = { kind: 'text' } | { kind: 'image' } | { kind: 'binary' };
+export type DiffViewMode = 'diff' | 'preview';
+export type DiffPreviewKind = 'markdown' | 'html';
+export type DiffRendererData =
+  | { kind: 'text'; previewKind?: DiffPreviewKind }
+  | { kind: 'image' }
+  | { kind: 'binary' };
 
 export interface DiffPayload {
   path: string;
@@ -33,6 +38,7 @@ export class DiffTabResource implements TabResource {
   readonly tabId: string;
 
   path: string;
+  viewMode: DiffViewMode = 'diff';
   renderer: DiffRendererData;
   diffGroup: 'disk' | 'staged' | 'git' | 'pr';
   originalRef: GitObjectRef;
@@ -65,6 +71,7 @@ export class DiffTabResource implements TabResource {
 
     makeObservable(this, {
       path: observable,
+      viewMode: observable,
       renderer: observable,
       diffGroup: observable,
       originalRef: observable,
@@ -75,6 +82,7 @@ export class DiffTabResource implements TabResource {
       commitOriginalSha: observable,
       commitModifiedSha: observable,
       status: observable,
+      setViewMode: action,
       transition: action,
       updateStatus: action,
     });
@@ -94,6 +102,10 @@ export class DiffTabResource implements TabResource {
 
   dispose(): void {
     this._manager?.release(this);
+  }
+
+  setViewMode(viewMode: DiffViewMode): void {
+    this.viewMode = viewMode;
   }
 
   /**
@@ -140,6 +152,7 @@ export class DiffTabResource implements TabResource {
 
 function resolveDiffRenderer(path: string): DiffRendererData {
   const kind = getFileKind(path);
+  if (kind === 'markdown' || kind === 'html') return { kind: 'text', previewKind: kind };
   if (kind === 'image' || kind === 'svg') return { kind: 'image' };
   if (kind === 'binary') return { kind: 'binary' };
   return { kind: 'text' };

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/file-content-toolbar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/file-content-toolbar.tsx
@@ -9,7 +9,7 @@ interface FileContentToolbarProps {
   canToggle: boolean;
 }
 
-/** Top bar shown on every file tab: file path on the left, Preview/Source tabs on the right. */
+/** Top bar shown on every file tab: file path on the left, Raw/Preview tabs on the right. */
 export const FileContentToolbar = observer(function FileContentToolbar({
   tab,
   canToggle,
@@ -30,11 +30,11 @@ export const FileContentToolbar = observer(function FileContentToolbar({
             if (value === 'preview' || value === 'source') tab.setViewMode(value);
           }}
         >
+          <ToggleGroupItem value="source" className="text-xs">
+            Raw
+          </ToggleGroupItem>
           <ToggleGroupItem value="preview" className="text-xs">
             Preview
-          </ToggleGroupItem>
-          <ToggleGroupItem value="source" className="text-xs">
-            Source
           </ToggleGroupItem>
         </ToggleGroup>
       )}

--- a/apps/emdash-desktop/src/renderer/lib/editor/html-renderer.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/editor/html-renderer.tsx
@@ -17,6 +17,11 @@ interface HtmlRendererProps {
   filePath: string;
 }
 
+interface HtmlContentRendererProps {
+  filePath: string;
+  rawContent: string;
+}
+
 const LINK_INTERCEPT_MESSAGE_TYPE = 'emdash-html-link';
 
 const LINK_INTERCEPT_SCRIPT = `
@@ -40,17 +45,25 @@ const LINK_INTERCEPT_SCRIPT = `
  * The source/preview toggle lives in the FileContent container above this component.
  */
 export const HtmlRenderer = observer(function HtmlRenderer({ filePath }: HtmlRendererProps) {
-  const { projectId } = useTaskViewContext();
-  const workspaceId = useWorkspaceId();
-  const workspacePath = useWorkspace().path;
   const { editorView } = useWorkspaceViewModel();
-  const { pane } = usePaneContext();
   const bufferUri = buildMonacoModelPath(editorView.modelRootPath, filePath);
 
   // Touch bufferVersions so this observer re-renders when the buffer is first
   // populated — otherwise the preview can stick on stale content.
   void modelRegistry.bufferVersions.get(bufferUri);
   const rawContent = modelRegistry.getValue(bufferUri) ?? '';
+
+  return <HtmlContentRenderer filePath={filePath} rawContent={rawContent} />;
+});
+
+export const HtmlContentRenderer = observer(function HtmlContentRenderer({
+  filePath,
+  rawContent,
+}: HtmlContentRendererProps) {
+  const { projectId } = useTaskViewContext();
+  const workspaceId = useWorkspaceId();
+  const workspacePath = useWorkspace().path;
+  const { pane } = usePaneContext();
   const fileName = filePath.split('/').pop() ?? filePath;
 
   const [processedHtml, setProcessedHtml] = useState<string | null>(null);


### PR DESCRIPTION
### Description

Adds a Diff/Preview toggle for markdown and HTML files in the diff viewer. Preview mode renders the modified file content using the existing markdown and HTML preview renderers, while non-previewable files keep the existing diff-only behavior.

### Related issues

ENG-1780

### Screenshot/Recording (if applicable)

Demo: https://cap.link/np1qae0eyns8359

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [X] I ran the relevant local checks or explained why not
- [X] I updated docs when behavior or setup changed
- [X] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>