### PR TITLE
fix(workspaces): submit lifecycle scripts on Windows

### DIFF
--- a/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/impl/local-terminal-provider.ts
@@ -127,6 +127,12 @@ export class LocalTerminalProvider implements TerminalProvider {
     );
   }
 
+  async getLifecycleScriptShellFamily(terminalId: string) {
+    const sessionId = makePtySessionId(this.projectId, this.scopeId, terminalId);
+    const shellProfile = await this.getSessionShellProfile(sessionId, 'system');
+    return shellProfile.family;
+  }
+
   private async spawnWithPolicy(
     terminal: Terminal,
     initialSize: { cols: number; rows: number },

--- a/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { lifecycleScriptStatusChannel } from '@shared/core/tasks/taskEvents';
 import type { Pty, PtyExitInfo } from '../pty/pty';
@@ -14,6 +14,7 @@ import {
 
 const emit = vi.hoisted(() => vi.fn());
 const logError = vi.hoisted(() => vi.fn());
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 
 vi.mock('@main/lib/events', () => ({
   events: {
@@ -103,6 +104,10 @@ function makeWorkspace(runLifecycleScript = vi.fn()) {
   } as never;
 }
 
+function mockPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
 function baseArgs(runLifecycleScript = vi.fn()) {
   return {
     workspace: makeWorkspace(runLifecycleScript),
@@ -122,6 +127,10 @@ function baseArgs(runLifecycleScript = vi.fn()) {
 }
 
 describe('runLifecycleScriptWithPolicy', () => {
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
   beforeEach(() => {
     emit.mockClear();
     logError.mockClear();
@@ -304,7 +313,8 @@ describe('runLifecycleScriptWithPolicy', () => {
   });
 
   it('runs a manual respawn policy script again after the first PTY exits', async () => {
-    const { provider, spawned, requests } = makeTerminalProvider();
+    mockPlatform('win32');
+    const { provider, spawned } = makeTerminalProvider();
     const projectId = 'project-rerun';
     const workspaceId = 'workspace-rerun';
     const service = new LifecycleScriptService({
@@ -331,15 +341,13 @@ describe('runLifecycleScriptWithPolicy', () => {
     };
 
     const firstRun = runLifecycleScriptWithPolicy(args);
-    await expect.poll(() => requests[0]?.command).toBe('pnpm dev');
-    expect(spawned[0].writes).toEqual([]);
+    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev\rexit\r']);
     spawned[0].emitExit({ exitCode: 0 });
     await expect(firstRun).resolves.toMatchObject({ kind: 'succeeded' });
     await expect.poll(() => spawned.length).toBe(2);
-    expect(requests[1].command).toBeUndefined();
 
     const secondRun = runLifecycleScriptWithPolicy(args);
-    await expect.poll(() => spawned[1]?.writes).toEqual(['pnpm dev; exit\r']);
+    await expect.poll(() => spawned[1]?.writes).toEqual(['pnpm dev\rexit\r']);
     spawned[1].emitExit({ exitCode: 0 });
     await expect(secondRun).resolves.toMatchObject({ kind: 'succeeded' });
     await expect.poll(() => spawned.length).toBe(3);

--- a/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.test.ts
@@ -88,6 +88,9 @@ function makeTerminalProvider(): {
         preserveBufferOnExit: true,
       });
     },
+    async getLifecycleScriptShellFamily() {
+      return 'windows-cmd';
+    },
     async killTerminal() {},
     async destroyAll() {},
     async detachAll() {},

--- a/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.test.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/lifecycle-script-coordinator.test.ts
@@ -304,7 +304,7 @@ describe('runLifecycleScriptWithPolicy', () => {
   });
 
   it('runs a manual respawn policy script again after the first PTY exits', async () => {
-    const { provider, spawned } = makeTerminalProvider();
+    const { provider, spawned, requests } = makeTerminalProvider();
     const projectId = 'project-rerun';
     const workspaceId = 'workspace-rerun';
     const service = new LifecycleScriptService({
@@ -331,13 +331,15 @@ describe('runLifecycleScriptWithPolicy', () => {
     };
 
     const firstRun = runLifecycleScriptWithPolicy(args);
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev; exit\n']);
+    await expect.poll(() => requests[0]?.command).toBe('pnpm dev');
+    expect(spawned[0].writes).toEqual([]);
     spawned[0].emitExit({ exitCode: 0 });
     await expect(firstRun).resolves.toMatchObject({ kind: 'succeeded' });
     await expect.poll(() => spawned.length).toBe(2);
+    expect(requests[1].command).toBeUndefined();
 
     const secondRun = runLifecycleScriptWithPolicy(args);
-    await expect.poll(() => spawned[1]?.writes).toEqual(['pnpm dev; exit\n']);
+    await expect.poll(() => spawned[1]?.writes).toEqual(['pnpm dev; exit\r']);
     spawned[1].emitExit({ exitCode: 0 });
     await expect(secondRun).resolves.toMatchObject({ kind: 'succeeded' });
     await expect.poll(() => spawned.length).toBe(3);

--- a/apps/emdash-desktop/src/main/core/terminals/terminal-provider.ts
+++ b/apps/emdash-desktop/src/main/core/terminals/terminal-provider.ts
@@ -1,4 +1,7 @@
-import type { TerminalShellId } from '@shared/core/terminals/terminal-settings';
+import type {
+  TerminalShellFamily,
+  TerminalShellId,
+} from '@shared/core/terminals/terminal-settings';
 import type { Terminal } from '@shared/core/terminals/terminals';
 
 export type LifecycleScriptSpawnRequest = {
@@ -24,6 +27,7 @@ export interface TerminalProvider {
     options?: TerminalSpawnOptions
   ): Promise<void>;
   spawnLifecycleScript(request: LifecycleScriptSpawnRequest): Promise<void>;
+  getLifecycleScriptShellFamily?(terminalId: string): Promise<TerminalShellFamily | undefined>;
   killTerminal(terminalId: string): Promise<void>;
   destroyAll(): Promise<void>;
   detachAll(): Promise<void>;

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
@@ -1,11 +1,9 @@
-import { afterEach, describe, expect, it, vi } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { createLifecycleScriptTerminalId } from '@shared/core/terminals/terminals';
 import type { Pty, PtyExitInfo } from '../pty/pty';
 import type { LifecycleScriptSpawnRequest, TerminalProvider } from '../terminals/terminal-provider';
 import { LifecycleScriptService } from './workspace-lifecycle-service';
-
-const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 
 vi.mock('@main/lib/events', () => ({
   events: {
@@ -51,10 +49,6 @@ class FakePty implements Pty {
   }
 }
 
-function mockPlatform(platform: NodeJS.Platform): void {
-  Object.defineProperty(process, 'platform', { value: platform });
-}
-
 function makeTerminalProvider(): {
   provider: TerminalProvider;
   spawned: FakePty[];
@@ -83,12 +77,7 @@ function makeTerminalProvider(): {
 }
 
 describe('WorkspaceLifecycleService', () => {
-  afterEach(() => {
-    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
-  });
-
   it('respawns an interactive lifecycle shell after an exit-backed script finishes', async () => {
-    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-1',
@@ -101,7 +90,8 @@ describe('WorkspaceLifecycleService', () => {
 
     expect(spawned).toHaveLength(1);
     expect(requests[0].terminal.id).toBe(createLifecycleScriptTerminalId('run'));
-    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r']);
+    expect(requests[0].command).toBeUndefined();
+    expect(spawned[0].writes).toEqual(['pnpm dev; exit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -125,7 +115,6 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('keeps the same lifecycle PTY when the script text changes', async () => {
-    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-2',
@@ -139,7 +128,8 @@ describe('WorkspaceLifecycleService', () => {
     expect(spawned).toHaveLength(1);
     expect(requests).toHaveLength(1);
     expect(requests[0].terminal.id).toBe(createLifecycleScriptTerminalId('run'));
-    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r', 'pnpm start\rexit\r']);
+    expect(requests[0].command).toBe('pnpm dev');
+    expect(spawned[0].writes).toEqual(['pnpm start; exit\r']);
   });
 
   it('respawns with the latest shell setup after repeated exit-backed runs', async () => {
@@ -167,8 +157,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('resolves waitForExit when an exit-backed script exits successfully', async () => {
-    mockPlatform('win32');
-    const { provider, spawned } = makeTerminalProvider();
+    const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-4',
       workspaceId: 'branch:feature',
@@ -180,7 +169,9 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install\rexit\r']);
+    await expect.poll(() => spawned).toHaveLength(1);
+    expect(requests[0].command).toBe('pnpm install');
+    expect(spawned[0].writes).toEqual([]);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -194,7 +185,6 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('does not attach another awaited execution to a PTY that is already running', async () => {
-    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-concurrent',
@@ -207,7 +197,8 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install\rexit\r']);
+    await expect.poll(() => spawned).toHaveLength(1);
+    expect(spawned[0].writes).toEqual([]);
 
     await expect(
       service.runLifecycleScript(
@@ -215,14 +206,13 @@ describe('WorkspaceLifecycleService', () => {
         { exit: true, waitForExit: true }
       )
     ).resolves.toEqual({ kind: 'already-running' });
-    expect(spawned[0].writes).toEqual(['pnpm install\rexit\r']);
+    expect(spawned[0].writes).toEqual([]);
 
     spawned[0].emitExit({ exitCode: 0 });
     await expect(firstRun).resolves.toMatchObject({ kind: 'exited', exitCode: 0 });
   });
 
   it('can restore an interactive lifecycle shell after an awaited script exits', async () => {
-    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-6',
@@ -235,7 +225,8 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true, respawnAfterExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev\rexit\r']);
+    await expect.poll(() => spawned).toHaveLength(1);
+    expect(spawned[0].writes).toEqual([]);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -248,7 +239,6 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('can restore an interactive lifecycle shell after an awaited script is stopped', async () => {
-    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-7',
@@ -261,7 +251,8 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true, respawnAfterExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev\rexit\r']);
+    await expect.poll(() => spawned).toHaveLength(1);
+    expect(spawned[0].writes).toEqual([]);
 
     spawned[0].kill();
 
@@ -274,7 +265,6 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('returns the output tail when an exit-backed script fails', async () => {
-    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-5',
@@ -287,7 +277,8 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install\rexit\r']);
+    await expect.poll(() => spawned).toHaveLength(1);
+    expect(spawned[0].writes).toEqual([]);
 
     spawned[0].emitData('\u001b[31mdependency failed\u001b[0m\r\n');
     spawned[0].emitExit({ exitCode: 1 });
@@ -299,53 +290,17 @@ describe('WorkspaceLifecycleService', () => {
     });
   });
 
-  it('submits multiline lifecycle scripts with terminal carriage returns', async () => {
+  it('submits scripts to an existing lifecycle shell with terminal carriage returns', async () => {
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
-      projectId: 'project-multiline',
+      projectId: 'project-existing-shell',
       workspaceId: 'branch:feature',
       terminals: provider,
     });
 
-    await service.runLifecycleScript(
-      { type: 'setup', script: 'echo one\necho two' },
-      { exit: false }
-    );
+    await service.prepareLifecycleScript({ type: 'setup', script: 'echo one' });
+    await service.runLifecycleScript({ type: 'setup', script: 'echo one' }, { exit: false });
 
-    expect(spawned[0].writes).toEqual(['echo one\recho two\r']);
-  });
-
-  it('preserves same-line exit semantics outside local Windows shells', async () => {
-    mockPlatform('linux');
-    const { provider, spawned } = makeTerminalProvider();
-    const service = new LifecycleScriptService({
-      projectId: 'project-posix',
-      workspaceId: 'branch:feature',
-      terminals: provider,
-    });
-
-    await service.runLifecycleScript(
-      { type: 'setup', script: 'pnpm install' },
-      { exit: true }
-    );
-
-    expect(spawned[0].writes).toEqual(['pnpm install; exit\r']);
-  });
-
-  it('trims trailing script newlines before appending same-line exit', async () => {
-    mockPlatform('linux');
-    const { provider, spawned } = makeTerminalProvider();
-    const service = new LifecycleScriptService({
-      projectId: 'project-posix-trailing-newline',
-      workspaceId: 'branch:feature',
-      terminals: provider,
-    });
-
-    await service.runLifecycleScript(
-      { type: 'setup', script: 'pnpm install\n' },
-      { exit: true }
-    );
-
-    expect(spawned[0].writes).toEqual(['pnpm install; exit\r']);
+    expect(spawned[0].writes).toEqual(['echo one\r']);
   });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { createLifecycleScriptTerminalId } from '@shared/core/terminals/terminals';
 import type { Pty, PtyExitInfo } from '../pty/pty';
 import type { LifecycleScriptSpawnRequest, TerminalProvider } from '../terminals/terminal-provider';
 import { LifecycleScriptService } from './workspace-lifecycle-service';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 
 vi.mock('@main/lib/events', () => ({
   events: {
@@ -49,6 +51,10 @@ class FakePty implements Pty {
   }
 }
 
+function mockPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
 function makeTerminalProvider(): {
   provider: TerminalProvider;
   spawned: FakePty[];
@@ -77,7 +83,12 @@ function makeTerminalProvider(): {
 }
 
 describe('WorkspaceLifecycleService', () => {
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
   it('respawns an interactive lifecycle shell after an exit-backed script finishes', async () => {
+    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-1',
@@ -90,7 +101,7 @@ describe('WorkspaceLifecycleService', () => {
 
     expect(spawned).toHaveLength(1);
     expect(requests[0].terminal.id).toBe(createLifecycleScriptTerminalId('run'));
-    expect(spawned[0].writes).toEqual(['pnpm dev; exit\n']);
+    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -114,6 +125,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('keeps the same lifecycle PTY when the script text changes', async () => {
+    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-2',
@@ -127,7 +139,7 @@ describe('WorkspaceLifecycleService', () => {
     expect(spawned).toHaveLength(1);
     expect(requests).toHaveLength(1);
     expect(requests[0].terminal.id).toBe(createLifecycleScriptTerminalId('run'));
-    expect(spawned[0].writes).toEqual(['pnpm dev; exit\n', 'pnpm start; exit\n']);
+    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r', 'pnpm start\rexit\r']);
   });
 
   it('respawns with the latest shell setup after repeated exit-backed runs', async () => {
@@ -155,6 +167,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('resolves waitForExit when an exit-backed script exits successfully', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-4',
@@ -167,7 +180,7 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install; exit\n']);
+    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install\rexit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -181,6 +194,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('does not attach another awaited execution to a PTY that is already running', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-concurrent',
@@ -193,7 +207,7 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install; exit\n']);
+    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install\rexit\r']);
 
     await expect(
       service.runLifecycleScript(
@@ -201,13 +215,14 @@ describe('WorkspaceLifecycleService', () => {
         { exit: true, waitForExit: true }
       )
     ).resolves.toEqual({ kind: 'already-running' });
-    expect(spawned[0].writes).toEqual(['pnpm install; exit\n']);
+    expect(spawned[0].writes).toEqual(['pnpm install\rexit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
     await expect(firstRun).resolves.toMatchObject({ kind: 'exited', exitCode: 0 });
   });
 
   it('can restore an interactive lifecycle shell after an awaited script exits', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-6',
@@ -220,7 +235,7 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true, respawnAfterExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev; exit\n']);
+    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev\rexit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -233,6 +248,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('can restore an interactive lifecycle shell after an awaited script is stopped', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-7',
@@ -245,7 +261,7 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true, respawnAfterExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev; exit\n']);
+    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm dev\rexit\r']);
 
     spawned[0].kill();
 
@@ -258,6 +274,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('returns the output tail when an exit-backed script fails', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-5',
@@ -270,7 +287,7 @@ describe('WorkspaceLifecycleService', () => {
       { exit: true, waitForExit: true }
     );
 
-    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install; exit\n']);
+    await expect.poll(() => spawned[0]?.writes).toEqual(['pnpm install\rexit\r']);
 
     spawned[0].emitData('\u001b[31mdependency failed\u001b[0m\r\n');
     spawned[0].emitExit({ exitCode: 1 });
@@ -280,5 +297,55 @@ describe('WorkspaceLifecycleService', () => {
       exitCode: 1,
       outputTail: 'dependency failed\n',
     });
+  });
+
+  it('submits multiline lifecycle scripts with terminal carriage returns', async () => {
+    const { provider, spawned } = makeTerminalProvider();
+    const service = new LifecycleScriptService({
+      projectId: 'project-multiline',
+      workspaceId: 'branch:feature',
+      terminals: provider,
+    });
+
+    await service.runLifecycleScript(
+      { type: 'setup', script: 'echo one\necho two' },
+      { exit: false }
+    );
+
+    expect(spawned[0].writes).toEqual(['echo one\recho two\r']);
+  });
+
+  it('preserves same-line exit semantics outside local Windows shells', async () => {
+    mockPlatform('linux');
+    const { provider, spawned } = makeTerminalProvider();
+    const service = new LifecycleScriptService({
+      projectId: 'project-posix',
+      workspaceId: 'branch:feature',
+      terminals: provider,
+    });
+
+    await service.runLifecycleScript(
+      { type: 'setup', script: 'pnpm install' },
+      { exit: true }
+    );
+
+    expect(spawned[0].writes).toEqual(['pnpm install; exit\r']);
+  });
+
+  it('trims trailing script newlines before appending same-line exit', async () => {
+    mockPlatform('linux');
+    const { provider, spawned } = makeTerminalProvider();
+    const service = new LifecycleScriptService({
+      projectId: 'project-posix-trailing-newline',
+      workspaceId: 'branch:feature',
+      terminals: provider,
+    });
+
+    await service.runLifecycleScript(
+      { type: 'setup', script: 'pnpm install\n' },
+      { exit: true }
+    );
+
+    expect(spawned[0].writes).toEqual(['pnpm install; exit\r']);
   });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
+import type { TerminalShellFamily } from '@shared/core/terminals/terminal-settings';
 import { createLifecycleScriptTerminalId } from '@shared/core/terminals/terminals';
 import type { Pty, PtyExitInfo } from '../pty/pty';
 import type { LifecycleScriptSpawnRequest, TerminalProvider } from '../terminals/terminal-provider';
@@ -57,7 +58,7 @@ function mockPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', { value: platform });
 }
 
-function makeTerminalProvider(): {
+function makeTerminalProvider(shellFamily: TerminalShellFamily = 'windows-cmd'): {
   provider: TerminalProvider;
   spawned: FakePty[];
   requests: LifecycleScriptSpawnRequest[];
@@ -75,6 +76,9 @@ function makeTerminalProvider(): {
       ptySessionRegistry.register(`${terminal.projectId}:${terminal.taskId}:${terminal.id}`, pty, {
         preserveBufferOnExit: true,
       });
+    },
+    async getLifecycleScriptShellFamily() {
+      return shellFamily;
     },
     async killTerminal() {},
     async destroyAll() {},
@@ -147,6 +151,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('respawns with the latest shell setup after repeated exit-backed runs', async () => {
+    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-3',
@@ -333,10 +338,21 @@ describe('WorkspaceLifecycleService', () => {
       terminals: provider,
     });
 
-    await service.runLifecycleScript(
-      { type: 'setup', script: 'pnpm install' },
-      { exit: true }
-    );
+    await service.runLifecycleScript({ type: 'setup', script: 'pnpm install' }, { exit: true });
+
+    expect(spawned[0].writes).toEqual(['pnpm install; exit\r']);
+  });
+
+  it('preserves same-line exit semantics for local WSL shells on Windows', async () => {
+    mockPlatform('win32');
+    const { provider, spawned } = makeTerminalProvider('wsl');
+    const service = new LifecycleScriptService({
+      projectId: 'project-wsl',
+      workspaceId: 'branch:feature',
+      terminals: provider,
+    });
+
+    await service.runLifecycleScript({ type: 'setup', script: 'pnpm install' }, { exit: true });
 
     expect(spawned[0].writes).toEqual(['pnpm install; exit\r']);
   });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.test.ts
@@ -1,9 +1,11 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import { ptySessionRegistry } from '@main/core/pty/pty-session-registry';
 import { createLifecycleScriptTerminalId } from '@shared/core/terminals/terminals';
 import type { Pty, PtyExitInfo } from '../pty/pty';
 import type { LifecycleScriptSpawnRequest, TerminalProvider } from '../terminals/terminal-provider';
 import { LifecycleScriptService } from './workspace-lifecycle-service';
+
+const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform');
 
 vi.mock('@main/lib/events', () => ({
   events: {
@@ -15,10 +17,12 @@ vi.mock('@main/lib/events', () => ({
 
 class FakePty implements Pty {
   writes: string[] = [];
+  writeExitHandlerCounts: number[] = [];
   private dataHandlers: Array<(data: string) => void> = [];
   private exitHandlers: Array<(info: PtyExitInfo) => void> = [];
 
   write(data: string): void {
+    this.writeExitHandlerCounts.push(this.exitHandlers.length);
     this.writes.push(data);
   }
 
@@ -49,6 +53,10 @@ class FakePty implements Pty {
   }
 }
 
+function mockPlatform(platform: NodeJS.Platform): void {
+  Object.defineProperty(process, 'platform', { value: platform });
+}
+
 function makeTerminalProvider(): {
   provider: TerminalProvider;
   spawned: FakePty[];
@@ -77,7 +85,12 @@ function makeTerminalProvider(): {
 }
 
 describe('WorkspaceLifecycleService', () => {
+  afterEach(() => {
+    if (originalPlatform) Object.defineProperty(process, 'platform', originalPlatform);
+  });
+
   it('respawns an interactive lifecycle shell after an exit-backed script finishes', async () => {
+    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-1',
@@ -91,7 +104,7 @@ describe('WorkspaceLifecycleService', () => {
     expect(spawned).toHaveLength(1);
     expect(requests[0].terminal.id).toBe(createLifecycleScriptTerminalId('run'));
     expect(requests[0].command).toBeUndefined();
-    expect(spawned[0].writes).toEqual(['pnpm dev; exit\r']);
+    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -115,6 +128,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('keeps the same lifecycle PTY when the script text changes', async () => {
+    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-2',
@@ -128,8 +142,8 @@ describe('WorkspaceLifecycleService', () => {
     expect(spawned).toHaveLength(1);
     expect(requests).toHaveLength(1);
     expect(requests[0].terminal.id).toBe(createLifecycleScriptTerminalId('run'));
-    expect(requests[0].command).toBe('pnpm dev');
-    expect(spawned[0].writes).toEqual(['pnpm start; exit\r']);
+    expect(requests[0].command).toBeUndefined();
+    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r', 'pnpm start\rexit\r']);
   });
 
   it('respawns with the latest shell setup after repeated exit-backed runs', async () => {
@@ -157,6 +171,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('resolves waitForExit when an exit-backed script exits successfully', async () => {
+    mockPlatform('win32');
     const { provider, spawned, requests } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-4',
@@ -170,8 +185,9 @@ describe('WorkspaceLifecycleService', () => {
     );
 
     await expect.poll(() => spawned).toHaveLength(1);
-    expect(requests[0].command).toBe('pnpm install');
-    expect(spawned[0].writes).toEqual([]);
+    expect(requests[0].command).toBeUndefined();
+    expect(spawned[0].writes).toEqual(['pnpm install\rexit\r']);
+    expect(spawned[0].writeExitHandlerCounts[0]).toBeGreaterThan(1);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -185,6 +201,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('does not attach another awaited execution to a PTY that is already running', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-concurrent',
@@ -198,7 +215,7 @@ describe('WorkspaceLifecycleService', () => {
     );
 
     await expect.poll(() => spawned).toHaveLength(1);
-    expect(spawned[0].writes).toEqual([]);
+    expect(spawned[0].writes).toEqual(['pnpm install\rexit\r']);
 
     await expect(
       service.runLifecycleScript(
@@ -206,13 +223,14 @@ describe('WorkspaceLifecycleService', () => {
         { exit: true, waitForExit: true }
       )
     ).resolves.toEqual({ kind: 'already-running' });
-    expect(spawned[0].writes).toEqual([]);
+    expect(spawned[0].writes).toEqual(['pnpm install\rexit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
     await expect(firstRun).resolves.toMatchObject({ kind: 'exited', exitCode: 0 });
   });
 
   it('can restore an interactive lifecycle shell after an awaited script exits', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-6',
@@ -226,7 +244,7 @@ describe('WorkspaceLifecycleService', () => {
     );
 
     await expect.poll(() => spawned).toHaveLength(1);
-    expect(spawned[0].writes).toEqual([]);
+    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r']);
 
     spawned[0].emitExit({ exitCode: 0 });
 
@@ -239,6 +257,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('can restore an interactive lifecycle shell after an awaited script is stopped', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-7',
@@ -252,7 +271,7 @@ describe('WorkspaceLifecycleService', () => {
     );
 
     await expect.poll(() => spawned).toHaveLength(1);
-    expect(spawned[0].writes).toEqual([]);
+    expect(spawned[0].writes).toEqual(['pnpm dev\rexit\r']);
 
     spawned[0].kill();
 
@@ -265,6 +284,7 @@ describe('WorkspaceLifecycleService', () => {
   });
 
   it('returns the output tail when an exit-backed script fails', async () => {
+    mockPlatform('win32');
     const { provider, spawned } = makeTerminalProvider();
     const service = new LifecycleScriptService({
       projectId: 'project-5',
@@ -278,7 +298,7 @@ describe('WorkspaceLifecycleService', () => {
     );
 
     await expect.poll(() => spawned).toHaveLength(1);
-    expect(spawned[0].writes).toEqual([]);
+    expect(spawned[0].writes).toEqual(['pnpm install\rexit\r']);
 
     spawned[0].emitData('\u001b[31mdependency failed\u001b[0m\r\n');
     spawned[0].emitExit({ exitCode: 1 });
@@ -302,5 +322,22 @@ describe('WorkspaceLifecycleService', () => {
     await service.runLifecycleScript({ type: 'setup', script: 'echo one' }, { exit: false });
 
     expect(spawned[0].writes).toEqual(['echo one\r']);
+  });
+
+  it('preserves same-line exit semantics outside local Windows shells', async () => {
+    mockPlatform('linux');
+    const { provider, spawned } = makeTerminalProvider();
+    const service = new LifecycleScriptService({
+      projectId: 'project-posix',
+      workspaceId: 'branch:feature',
+      terminals: provider,
+    });
+
+    await service.runLifecycleScript(
+      { type: 'setup', script: 'pnpm install' },
+      { exit: true }
+    );
+
+    expect(spawned[0].writes).toEqual(['pnpm install; exit\r']);
   });
 });

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -20,6 +20,11 @@ type LifecycleRespawnRequest = {
   initialSize: { cols: number; rows: number };
 };
 
+type PreparedLifecycleScript = {
+  pty: Pty;
+  spawnedWithCommand: boolean;
+};
+
 export type LifecycleScriptExecutionResult =
   | { kind: 'started' }
   | { kind: 'already-running' }
@@ -43,11 +48,11 @@ function appendOutputTail(current: string, chunk: string): string {
   return next.length > OUTPUT_TAIL_CAP ? next.slice(-OUTPUT_TAIL_CAP) : next;
 }
 
-function terminalInputForScript(script: string, exit: boolean, windowsCmdExit: boolean): string {
+function terminalInputForScript(script: string, exit: boolean): string {
   const normalizedScript = script.replace(/\r?\n/g, '\r');
   if (!exit) return `${normalizedScript}\r`;
   const scriptBeforeExit = normalizedScript.replace(/\r+$/, '');
-  return windowsCmdExit ? `${scriptBeforeExit}\rexit\r` : `${scriptBeforeExit}; exit\r`;
+  return `${scriptBeforeExit}; exit\r`;
 }
 
 export class LifecycleScriptService implements IDisposable {
@@ -114,11 +119,12 @@ export class LifecycleScriptService implements IDisposable {
 
   async prepareLifecycleScript(
     script: LifecycleScript,
-    options: { initialSize?: { cols: number; rows: number } } = {}
-  ): Promise<void> {
+    options: { initialSize?: { cols: number; rows: number }; command?: string } = {}
+  ): Promise<PreparedLifecycleScript | null> {
     const { initialSize = { cols: DEFAULT_COLS, rows: DEFAULT_ROWS } } = options;
     const { terminalId, sessionId } = this.resolveIds(script);
-    if (ptySessionRegistry.get(sessionId)) return;
+    const existingPty = ptySessionRegistry.get(sessionId);
+    if (existingPty) return { pty: existingPty, spawnedWithCommand: false };
 
     await this.terminals.spawnLifecycleScript({
       terminal: {
@@ -128,12 +134,16 @@ export class LifecycleScriptService implements IDisposable {
         shellId: 'system',
         name: script.type,
       },
+      command: options.command,
       shellSetup: script.shellSetup,
       initialSize,
       respawnOnExit: false,
       preserveBufferOnExit: true,
       watchDevServer: script.type === 'run',
     });
+
+    const pty = ptySessionRegistry.get(sessionId);
+    return pty ? { pty, spawnedWithCommand: options.command !== undefined } : null;
   }
 
   async runLifecycleScript(
@@ -154,16 +164,16 @@ export class LifecycleScriptService implements IDisposable {
 
     const { sessionId } = this.resolveIds(script);
 
-    if (!ptySessionRegistry.get(sessionId)) {
-      await this.prepareLifecycleScript(script, { initialSize });
-    }
-
-    const pty = ptySessionRegistry.get(sessionId);
-    if (!pty) {
+    const prepared = await this.prepareLifecycleScript(script, {
+      initialSize,
+      command: exit && !ptySessionRegistry.get(sessionId) ? script.script : undefined,
+    });
+    if (!prepared) {
       throw new Error(
         `Lifecycle script session unavailable for ${script.type} in workspace ${this.workspaceId}`
       );
     }
+    const { pty, spawnedWithCommand } = prepared;
 
     if (waitForExit) {
       if (this.sessionsWaitingForExit.has(sessionId)) {
@@ -187,13 +197,9 @@ export class LifecycleScriptService implements IDisposable {
           })
         : null;
 
-      pty.write(
-        terminalInputForScript(
-          script.script,
-          exit,
-          this.terminals.kind === 'local' && process.platform === 'win32'
-        )
-      );
+      if (!spawnedWithCommand) {
+        pty.write(terminalInputForScript(script.script, exit));
+      }
 
       if (!exitPromise) {
         return { kind: 'started' };

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -112,6 +112,12 @@ export class LifecycleScriptService implements IDisposable {
     return { terminalId, sessionId };
   }
 
+  private async shouldUseWindowsCommandExit(terminalId: string): Promise<boolean> {
+    if (this.terminals.kind !== 'local' || process.platform !== 'win32') return false;
+    const shellFamily = await this.terminals.getLifecycleScriptShellFamily?.(terminalId);
+    return shellFamily === 'windows-cmd' || shellFamily === 'powershell';
+  }
+
   async prepareLifecycleScript(
     script: LifecycleScript,
     options: { initialSize?: { cols: number; rows: number } } = {}
@@ -155,7 +161,7 @@ export class LifecycleScriptService implements IDisposable {
       initialSize = { cols: DEFAULT_COLS, rows: DEFAULT_ROWS },
     } = options;
 
-    const { sessionId } = this.resolveIds(script);
+    const { terminalId, sessionId } = this.resolveIds(script);
 
     const pty = await this.prepareLifecycleScript(script, { initialSize });
     if (!pty) {
@@ -190,7 +196,7 @@ export class LifecycleScriptService implements IDisposable {
         terminalInputForScript(
           script.script,
           exit,
-          this.terminals.kind === 'local' && process.platform === 'win32'
+          await this.shouldUseWindowsCommandExit(terminalId)
         )
       );
 

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -20,11 +20,6 @@ type LifecycleRespawnRequest = {
   initialSize: { cols: number; rows: number };
 };
 
-type PreparedLifecycleScript = {
-  pty: Pty;
-  spawnedWithCommand: boolean;
-};
-
 export type LifecycleScriptExecutionResult =
   | { kind: 'started' }
   | { kind: 'already-running' }
@@ -48,11 +43,11 @@ function appendOutputTail(current: string, chunk: string): string {
   return next.length > OUTPUT_TAIL_CAP ? next.slice(-OUTPUT_TAIL_CAP) : next;
 }
 
-function terminalInputForScript(script: string, exit: boolean): string {
+function terminalInputForScript(script: string, exit: boolean, windowsCmdExit: boolean): string {
   const normalizedScript = script.replace(/\r?\n/g, '\r');
   if (!exit) return `${normalizedScript}\r`;
   const scriptBeforeExit = normalizedScript.replace(/\r+$/, '');
-  return `${scriptBeforeExit}; exit\r`;
+  return windowsCmdExit ? `${scriptBeforeExit}\rexit\r` : `${scriptBeforeExit}; exit\r`;
 }
 
 export class LifecycleScriptService implements IDisposable {
@@ -119,12 +114,12 @@ export class LifecycleScriptService implements IDisposable {
 
   async prepareLifecycleScript(
     script: LifecycleScript,
-    options: { initialSize?: { cols: number; rows: number }; command?: string } = {}
-  ): Promise<PreparedLifecycleScript | null> {
+    options: { initialSize?: { cols: number; rows: number } } = {}
+  ): Promise<Pty | null> {
     const { initialSize = { cols: DEFAULT_COLS, rows: DEFAULT_ROWS } } = options;
     const { terminalId, sessionId } = this.resolveIds(script);
     const existingPty = ptySessionRegistry.get(sessionId);
-    if (existingPty) return { pty: existingPty, spawnedWithCommand: false };
+    if (existingPty) return existingPty;
 
     await this.terminals.spawnLifecycleScript({
       terminal: {
@@ -134,7 +129,6 @@ export class LifecycleScriptService implements IDisposable {
         shellId: 'system',
         name: script.type,
       },
-      command: options.command,
       shellSetup: script.shellSetup,
       initialSize,
       respawnOnExit: false,
@@ -142,8 +136,7 @@ export class LifecycleScriptService implements IDisposable {
       watchDevServer: script.type === 'run',
     });
 
-    const pty = ptySessionRegistry.get(sessionId);
-    return pty ? { pty, spawnedWithCommand: options.command !== undefined } : null;
+    return ptySessionRegistry.get(sessionId) ?? null;
   }
 
   async runLifecycleScript(
@@ -164,16 +157,12 @@ export class LifecycleScriptService implements IDisposable {
 
     const { sessionId } = this.resolveIds(script);
 
-    const prepared = await this.prepareLifecycleScript(script, {
-      initialSize,
-      command: exit && !ptySessionRegistry.get(sessionId) ? script.script : undefined,
-    });
-    if (!prepared) {
+    const pty = await this.prepareLifecycleScript(script, { initialSize });
+    if (!pty) {
       throw new Error(
         `Lifecycle script session unavailable for ${script.type} in workspace ${this.workspaceId}`
       );
     }
-    const { pty, spawnedWithCommand } = prepared;
 
     if (waitForExit) {
       if (this.sessionsWaitingForExit.has(sessionId)) {
@@ -197,9 +186,13 @@ export class LifecycleScriptService implements IDisposable {
           })
         : null;
 
-      if (!spawnedWithCommand) {
-        pty.write(terminalInputForScript(script.script, exit));
-      }
+      pty.write(
+        terminalInputForScript(
+          script.script,
+          exit,
+          this.terminals.kind === 'local' && process.platform === 'win32'
+        )
+      );
 
       if (!exitPromise) {
         return { kind: 'started' };

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-lifecycle-service.ts
@@ -43,6 +43,13 @@ function appendOutputTail(current: string, chunk: string): string {
   return next.length > OUTPUT_TAIL_CAP ? next.slice(-OUTPUT_TAIL_CAP) : next;
 }
 
+function terminalInputForScript(script: string, exit: boolean, windowsCmdExit: boolean): string {
+  const normalizedScript = script.replace(/\r?\n/g, '\r');
+  if (!exit) return `${normalizedScript}\r`;
+  const scriptBeforeExit = normalizedScript.replace(/\r+$/, '');
+  return windowsCmdExit ? `${scriptBeforeExit}\rexit\r` : `${scriptBeforeExit}; exit\r`;
+}
+
 export class LifecycleScriptService implements IDisposable {
   private readonly projectId: string;
   private readonly workspaceId: string;
@@ -180,8 +187,13 @@ export class LifecycleScriptService implements IDisposable {
           })
         : null;
 
-      const command = exit ? `${script.script}; exit` : script.script;
-      pty.write(`${command}\n`);
+      pty.write(
+        terminalInputForScript(
+          script.script,
+          exit,
+          this.terminals.kind === 'local' && process.platform === 'win32'
+        )
+      );
 
       if (!exitPromise) {
         return { kind: 'started' };


### PR DESCRIPTION
### Description

Fix workspace lifecycle script submission on Windows by sending terminal carriage returns to interactive lifecycle shells. Exit-backed scripts now register exit/data listeners before submitting input, avoiding missed fast exits.

The Windows exit format is now shell-family-aware: local `cmd` and PowerShell lifecycle shells receive `script` followed by `exit` on the next terminal line, while POSIX-like shells such as WSL/Git Bash and remote shells keep `script; exit` semantics.

### Related issues
Discord 08.07.2026 15:03 MESC

### Screenshot/Recording (if applicable)
https://cap.link/49d6tp60rh4wabj

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>