### PR TITLE
fix(workspaces): recover legacy task branch worktrees

### DIFF
--- a/apps/emdash-desktop/src/main/core/tasks/resolve-workspace-intent.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/resolve-workspace-intent.ts
@@ -22,9 +22,11 @@ export function deriveBranchName(git: GitSetup): string | null {
 type TaskRow = {
   workspaceIntent: string | null | undefined;
   workspaceProvider: string | null | undefined;
+  taskBranch?: string | null | undefined;
 };
 
 type WorkspaceRow = {
+  kind?: string | null | undefined;
   type: WorkspaceType;
   path: string | null | undefined;
   config?: WorkspaceConfig | null | undefined;
@@ -102,9 +104,14 @@ function inferLegacyIntent(taskRow: TaskRow, workspaceRow: WorkspaceRow): Worksp
   }
 
   const host = workspaceRow.type === 'project-ssh' ? 'project-ssh' : 'local';
+  const branchName = workspaceRow.branchName ?? taskRow.taskBranch ?? null;
 
-  // If a path is already stored, the workspace exists at that location.
-  if (workspaceRow.path) {
+  if (workspaceRow.kind === 'worktree' && !branchName) {
+    return null;
+  }
+
+  // If a non-branch path is already stored, the workspace exists at that location.
+  if (workspaceRow.path && workspaceRow.kind !== 'worktree' && !branchName) {
     return {
       git: { kind: 'none' },
       workspace: { host, path: workspaceRow.path },
@@ -112,14 +119,12 @@ function inferLegacyIntent(taskRow: TaskRow, workspaceRow: WorkspaceRow): Worksp
   }
 
   // No branchName means the task uses the project root.
-  if (!workspaceRow.branchName) {
+  if (!branchName) {
     return {
       git: { kind: 'none' },
       workspace: { host },
     };
   }
-
-  const branchName = workspaceRow.branchName;
 
   // For legacy rows we can only infer use-branch since we no longer store sourceBranch.
   return {

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -117,7 +117,7 @@ describe('WorkspaceBootstrapService', () => {
       expect(ws.path).toBeNull();
     });
 
-    it('backfills branch name when reusing an existing workspace by key', async () => {
+    it('does not mutate branch metadata when reusing an existing workspace by key', async () => {
       const existingWsId = crypto.randomUUID();
       const conflictPath = '/worktrees/taken';
       const conflictKey = computeWorkspaceKey('local', conflictPath);
@@ -143,7 +143,7 @@ describe('WorkspaceBootstrapService', () => {
         .select()
         .from(workspaces)
         .where(eq(workspaces.id, existingWsId));
-      expect(existing.branchName).toBe('task/branch');
+      expect(existing.branchName).toBeNull();
     });
   });
 

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.db.test.ts
@@ -53,6 +53,8 @@ describe('WorkspaceBootstrapService', () => {
   let svc: WorkspaceBootstrapService;
 
   beforeEach(async () => {
+    vi.clearAllMocks();
+
     fixture = await openFixture('empty');
     svc = new WorkspaceBootstrapService(fixture.db);
 
@@ -113,6 +115,35 @@ describe('WorkspaceBootstrapService', () => {
       expect(returned).toBe(existingWsId);
       const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
       expect(ws.path).toBeNull();
+    });
+
+    it('backfills branch name when reusing an existing workspace by key', async () => {
+      const existingWsId = crypto.randomUUID();
+      const conflictPath = '/worktrees/taken';
+      const conflictKey = computeWorkspaceKey('local', conflictPath);
+      await fixture.db.insert(workspaces).values({
+        id: existingWsId,
+        type: 'local',
+        kind: 'worktree',
+        path: conflictPath,
+        key: conflictKey,
+        branchName: null,
+      });
+
+      const returned = await svc.persistPath(
+        WS_ID,
+        conflictPath,
+        'local',
+        undefined,
+        'task/branch'
+      );
+
+      expect(returned).toBe(existingWsId);
+      const [existing] = await fixture.db
+        .select()
+        .from(workspaces)
+        .where(eq(workspaces.id, existingWsId));
+      expect(existing.branchName).toBe('task/branch');
     });
   });
 
@@ -199,6 +230,173 @@ describe('WorkspaceBootstrapService', () => {
         branch: 'main',
       });
       expect(existsAtAbsolutePath).not.toHaveBeenCalledWith('/worktrees/broken-task-branch');
+      expect(mocks.acquireWorkspace).toHaveBeenCalled();
+
+      const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
+      expect(ws.path).toBe('/worktrees/task-branch');
+      expect(ws.branchName).toBe('task/branch');
+    });
+
+    it('does not acquire an explicit worktree from a stale path without branch intent', async () => {
+      const serveBranchWorktree = vi.fn();
+      const existsAtAbsolutePath = vi.fn().mockResolvedValue(false);
+      const project = {
+        projectId: 'proj-1',
+        type: 'local',
+        repoPath: '/repo',
+        defaultWorkspaceType: { kind: 'local' },
+        settings: {
+          get: vi.fn(),
+        },
+        gitRepository: {
+          getConfiguredRemotes: vi.fn(),
+        },
+        gitRepositoryFetchService: {},
+        worktreeService: {
+          existsAtAbsolutePath,
+          serveBranchWorktree,
+        },
+      } as unknown as ProjectProvider;
+
+      const result = await svc.ensureWorkspaceSetup(
+        {
+          id: WS_ID,
+          type: 'local',
+          kind: 'worktree',
+          path: '/worktrees/missing-task-branch',
+          branchName: null,
+          config: null,
+        },
+        { workspaceIntent: null, workspaceProvider: null },
+        task,
+        project
+      );
+
+      expect(result.success).toBe(false);
+      if (result.success) throw new Error('expected failure');
+      expect(result.error.type).toBe('no-intent');
+      expect(existsAtAbsolutePath).not.toHaveBeenCalled();
+      expect(serveBranchWorktree).not.toHaveBeenCalled();
+      expect(mocks.acquireWorkspace).not.toHaveBeenCalled();
+    });
+
+    it('recovers an explicit worktree from legacy task branch intent', async () => {
+      const serveBranchWorktree = vi.fn();
+      const existsAtAbsolutePath = vi.fn().mockResolvedValue(false);
+      const getWorktreePoolPath = vi.fn().mockResolvedValue('/worktrees');
+      const runWorkspaceSetup = vi.fn().mockResolvedValue(ok({ path: '/worktrees/task-branch' }));
+      const project = {
+        projectId: 'proj-1',
+        type: 'local',
+        repoPath: '/repo',
+        defaultWorkspaceType: { kind: 'local' },
+        settings: {
+          get: vi.fn(),
+        },
+        gitRepository: {
+          getConfiguredRemotes: vi.fn().mockResolvedValue({
+            baseRemote: 'origin',
+            pushRemote: 'origin',
+          }),
+        },
+        gitRepositoryFetchService: {},
+        worktreeService: {
+          existsAtAbsolutePath,
+          serveBranchWorktree,
+          getWorktreePoolPath,
+        },
+        runWorkspaceSetup,
+      } as unknown as ProjectProvider;
+
+      const result = await svc.ensureWorkspaceSetup(
+        {
+          id: WS_ID,
+          type: 'local',
+          kind: 'worktree',
+          path: '/worktrees/missing-task-branch',
+          branchName: null,
+          config: null,
+        },
+        {
+          workspaceIntent: null,
+          workspaceProvider: null,
+          taskBranch: 'task/branch',
+        },
+        task,
+        project
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data.path).toBe('/worktrees/task-branch');
+      expect(existsAtAbsolutePath).not.toHaveBeenCalled();
+      expect(serveBranchWorktree).not.toHaveBeenCalled();
+      expect(runWorkspaceSetup).toHaveBeenCalledWith(
+        expect.arrayContaining([{ kind: 'add-worktree', args: { branchName: 'task/branch' } }]),
+        '/worktrees'
+      );
+      expect(mocks.acquireWorkspace).toHaveBeenCalled();
+
+      const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));
+      expect(ws.path).toBe('/worktrees/task-branch');
+      expect(ws.branchName).toBe('task/branch');
+    });
+
+    it('recovers a legacy workspace with stale path from task branch intent', async () => {
+      const serveBranchWorktree = vi.fn();
+      const existsAtAbsolutePath = vi.fn().mockResolvedValue(false);
+      const getWorktreePoolPath = vi.fn().mockResolvedValue('/worktrees');
+      const runWorkspaceSetup = vi.fn().mockResolvedValue(ok({ path: '/worktrees/task-branch' }));
+      const project = {
+        projectId: 'proj-1',
+        type: 'local',
+        repoPath: '/repo',
+        defaultWorkspaceType: { kind: 'local' },
+        settings: {
+          get: vi.fn(),
+        },
+        gitRepository: {
+          getConfiguredRemotes: vi.fn().mockResolvedValue({
+            baseRemote: 'origin',
+            pushRemote: 'origin',
+          }),
+        },
+        gitRepositoryFetchService: {},
+        worktreeService: {
+          existsAtAbsolutePath,
+          serveBranchWorktree,
+          getWorktreePoolPath,
+        },
+        runWorkspaceSetup,
+      } as unknown as ProjectProvider;
+
+      const result = await svc.ensureWorkspaceSetup(
+        {
+          id: WS_ID,
+          type: 'local',
+          kind: null,
+          path: '/worktrees/missing-task-branch',
+          branchName: null,
+          config: null,
+        },
+        {
+          workspaceIntent: null,
+          workspaceProvider: null,
+          taskBranch: 'task/branch',
+        },
+        task,
+        project
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) throw new Error('expected success');
+      expect(result.data.path).toBe('/worktrees/task-branch');
+      expect(existsAtAbsolutePath).toHaveBeenCalledWith('/worktrees/missing-task-branch');
+      expect(serveBranchWorktree).not.toHaveBeenCalled();
+      expect(runWorkspaceSetup).toHaveBeenCalledWith(
+        expect.arrayContaining([{ kind: 'add-worktree', args: { branchName: 'task/branch' } }]),
+        '/worktrees'
+      );
       expect(mocks.acquireWorkspace).toHaveBeenCalled();
 
       const [ws] = await fixture.db.select().from(workspaces).where(eq(workspaces.id, WS_ID));

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -67,6 +67,7 @@ export class WorkspaceBootstrapService {
     taskRow: {
       workspaceIntent: string | null;
       workspaceProvider: string | null;
+      taskBranch?: string | null;
     },
     task: Task,
     project: ProjectProvider
@@ -144,7 +145,7 @@ export class WorkspaceBootstrapService {
     }
 
     // Fast path: non-worktree path already persisted and still exists on disk.
-    if (workspaceRow.path && !isByoi) {
+    if (workspaceRow.path && !isByoi && !isWorktreeWorkspace) {
       const exists = await project.worktreeService.existsAtAbsolutePath(workspaceRow.path);
       if (exists) {
         return this._acquireAndBuild(
@@ -278,6 +279,12 @@ export class WorkspaceBootstrapService {
     if (key) {
       const [existing] = await this.db.select().from(workspaces).where(eq(workspaces.key, key));
       if (existing && existing.id !== workspaceId) {
+        if (branchName && !existing.branchName) {
+          await this.db
+            .update(workspaces)
+            .set({ branchName, updatedAt: sql`CURRENT_TIMESTAMP` })
+            .where(eq(workspaces.id, existing.id));
+        }
         return existing.id;
       }
     }

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-bootstrap-service.ts
@@ -279,12 +279,6 @@ export class WorkspaceBootstrapService {
     if (key) {
       const [existing] = await this.db.select().from(workspaces).where(eq(workspaces.key, key));
       if (existing && existing.id !== workspaceId) {
-        if (branchName && !existing.branchName) {
-          await this.db
-            .update(workspaces)
-            .set({ branchName, updatedAt: sql`CURRENT_TIMESTAMP` })
-            .where(eq(workspaces.id, existing.id));
-        }
         return existing.id;
       }
     }

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.test.ts
@@ -13,7 +13,7 @@ vi.mock('@main/db/client', () => ({
 }));
 
 vi.mock('@main/db/schema', () => ({
-  workspaces: { id: 'id', branchName: 'branch_name', config: 'config' },
+  workspaces: { id: 'id', branchName: 'branch_name', config: 'config', kind: 'kind' },
 }));
 
 vi.mock('@main/lib/logger', () => ({
@@ -50,7 +50,7 @@ describe('refreshWorkspaceCurrentBranchCache', () => {
   });
 
   it('writes the cache and reports changed when the branch differs', async () => {
-    queueSelect([{ branchName: 'old-branch', config: { version: '2' } }]);
+    queueSelect([{ branchName: 'old-branch', config: { version: '2' }, kind: 'worktree' }]);
     const update = mockUpdate();
 
     const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
@@ -62,7 +62,7 @@ describe('refreshWorkspaceCurrentBranchCache', () => {
   });
 
   it('does not write and reports unchanged when the branch matches', async () => {
-    queueSelect([{ branchName: 'same-branch', config: { version: '2' } }]);
+    queueSelect([{ branchName: 'same-branch', config: { version: '2' }, kind: 'worktree' }]);
 
     const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
       Promise.resolve('same-branch')
@@ -73,7 +73,7 @@ describe('refreshWorkspaceCurrentBranchCache', () => {
   });
 
   it('persists a null branch for configured rows when HEAD is detached', async () => {
-    queueSelect([{ branchName: 'old-branch', config: { version: '2' } }]);
+    queueSelect([{ branchName: 'old-branch', config: { version: '2' }, kind: 'worktree' }]);
     const update = mockUpdate();
 
     const result = await refreshWorkspaceCurrentBranchCache('ws-1', () => Promise.resolve(null));
@@ -83,12 +83,24 @@ describe('refreshWorkspaceCurrentBranchCache', () => {
   });
 
   it('does not overwrite legacy branch intent when HEAD is detached', async () => {
-    queueSelect([{ branchName: 'old-branch', config: null }]);
+    queueSelect([{ branchName: 'old-branch', config: null, kind: null }]);
 
     const result = await refreshWorkspaceCurrentBranchCache('ws-1', () => Promise.resolve(null));
 
     expect(result).toEqual({ branchName: 'old-branch', changed: false });
     expect(dbMocks.update).not.toHaveBeenCalled();
+  });
+
+  it('updates configless project-root branch cache', async () => {
+    queueSelect([{ branchName: 'old-branch', config: null, kind: 'project-root' }]);
+    const update = mockUpdate();
+
+    const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
+      Promise.resolve('new-branch')
+    );
+
+    expect(result).toEqual({ branchName: 'new-branch', changed: true });
+    expect(update.set).toHaveBeenCalledWith({ branchName: 'new-branch' });
   });
 
   it('returns undefined when the workspace is not found', async () => {

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.test.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.test.ts
@@ -13,7 +13,7 @@ vi.mock('@main/db/client', () => ({
 }));
 
 vi.mock('@main/db/schema', () => ({
-  workspaces: { id: 'id', branchName: 'branch_name' },
+  workspaces: { id: 'id', branchName: 'branch_name', config: 'config' },
 }));
 
 vi.mock('@main/lib/logger', () => ({
@@ -50,7 +50,7 @@ describe('refreshWorkspaceCurrentBranchCache', () => {
   });
 
   it('writes the cache and reports changed when the branch differs', async () => {
-    queueSelect([{ branchName: 'old-branch' }]);
+    queueSelect([{ branchName: 'old-branch', config: { version: '2' } }]);
     const update = mockUpdate();
 
     const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
@@ -62,7 +62,7 @@ describe('refreshWorkspaceCurrentBranchCache', () => {
   });
 
   it('does not write and reports unchanged when the branch matches', async () => {
-    queueSelect([{ branchName: 'same-branch' }]);
+    queueSelect([{ branchName: 'same-branch', config: { version: '2' } }]);
 
     const result = await refreshWorkspaceCurrentBranchCache('ws-1', () =>
       Promise.resolve('same-branch')
@@ -72,14 +72,23 @@ describe('refreshWorkspaceCurrentBranchCache', () => {
     expect(dbMocks.update).not.toHaveBeenCalled();
   });
 
-  it('persists a null branch (detached HEAD) when previously set', async () => {
-    queueSelect([{ branchName: 'old-branch' }]);
+  it('persists a null branch for configured rows when HEAD is detached', async () => {
+    queueSelect([{ branchName: 'old-branch', config: { version: '2' } }]);
     const update = mockUpdate();
 
     const result = await refreshWorkspaceCurrentBranchCache('ws-1', () => Promise.resolve(null));
 
     expect(result).toEqual({ branchName: null, changed: true });
     expect(update.set).toHaveBeenCalledWith({ branchName: null });
+  });
+
+  it('does not overwrite legacy branch intent when HEAD is detached', async () => {
+    queueSelect([{ branchName: 'old-branch', config: null }]);
+
+    const result = await refreshWorkspaceCurrentBranchCache('ws-1', () => Promise.resolve(null));
+
+    expect(result).toEqual({ branchName: 'old-branch', changed: false });
+    expect(dbMocks.update).not.toHaveBeenCalled();
   });
 
   it('returns undefined when the workspace is not found', async () => {

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.ts
@@ -17,7 +17,7 @@ export async function refreshWorkspaceCurrentBranchCache(
   try {
     const branchName = await readCurrentBranch();
     const [workspace] = await db
-      .select({ branchName: workspaces.branchName })
+      .select({ branchName: workspaces.branchName, config: workspaces.config })
       .from(workspaces)
       .where(eq(workspaces.id, workspaceId))
       .limit(1);
@@ -27,6 +27,10 @@ export async function refreshWorkspaceCurrentBranchCache(
         workspaceId,
       });
       return undefined;
+    }
+
+    if (!workspace.config) {
+      return { branchName: workspace.branchName, changed: false };
     }
 
     if (workspace.branchName === branchName) {

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-current-branch-cache.ts
@@ -17,7 +17,11 @@ export async function refreshWorkspaceCurrentBranchCache(
   try {
     const branchName = await readCurrentBranch();
     const [workspace] = await db
-      .select({ branchName: workspaces.branchName, config: workspaces.config })
+      .select({
+        branchName: workspaces.branchName,
+        config: workspaces.config,
+        kind: workspaces.kind,
+      })
       .from(workspaces)
       .where(eq(workspaces.id, workspaceId))
       .limit(1);
@@ -29,7 +33,7 @@ export async function refreshWorkspaceCurrentBranchCache(
       return undefined;
     }
 
-    if (!workspace.config) {
+    if (!workspace.config && workspace.kind !== 'project-root') {
       return { branchName: workspace.branchName, changed: false };
     }
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -90,7 +90,7 @@ function formatProvisionWorkspaceError(error: ProvisionWorkspaceError): string {
   return match(error)
     .with(
       { type: 'no-intent' },
-      () => 'Workspace has no intent and no resolved path — cannot provision.'
+      () => 'Workspace is missing recoverable setup intent and cannot be provisioned.'
     )
     .with(
       { type: 'missing-workspace' },


### PR DESCRIPTION
- prevents detached head reads from clearing legacy workspace branch intent
- recovers legacy workspaces with stale paths by using the task branch when workspace metadata is missing
- backfills missing workspace branch names when reusing an existing workspace by path
- shows a clearer error when a workspace has no recoverable setup intent
- verifies the recovery path with focused workspace bootstrap and branch cache coverage