### PR TITLE
feat(tasks): default branch deletion setting

### DIFF
--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -38,6 +38,7 @@ export const taskSettingsSchema = z.object({
   autoApproveByDefault: z.boolean(),
   autoTrustWorktrees: z.boolean(),
   createBranchAndWorktree: z.boolean(),
+  deleteBranchByDefault: z.boolean(),
   preserveNameCapitalization: z.boolean(),
   includeIssueContextByDefault: z.boolean(),
 });

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -30,6 +30,7 @@ export const SETTINGS_DEFAULTS = {
     autoApproveByDefault: false,
     autoTrustWorktrees: true,
     createBranchAndWorktree: true,
+    deleteBranchByDefault: false,
     preserveNameCapitalization: false,
     includeIssueContextByDefault: true,
   },

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -19,6 +19,7 @@ import {
   AutoGenerateTaskNamesRow,
   AutoTrustWorktreesRow,
   CreateBranchAndWorktreeRow,
+  DeleteBranchByDefaultRow,
   EnableTmuxRow,
   IncludeIssueContextByDefaultRow,
   PreserveTaskNameCapitalizationRow,
@@ -57,6 +58,7 @@ function GeneralSettingsPage() {
       <AutoApproveByDefaultRow />
       <AutoTrustWorktreesRow />
       <CreateBranchAndWorktreeRow />
+      <DeleteBranchByDefaultRow />
       <PreserveTaskNameCapitalizationRow />
       <IncludeIssueContextByDefaultRow />
       <EnableTmuxRow />

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TaskSettingsRows.tsx
@@ -140,6 +140,32 @@ export const CreateBranchAndWorktreeRow: React.FC = () => {
   );
 };
 
+export const DeleteBranchByDefaultRow: React.FC = () => {
+  const taskSettings = useTaskSettings();
+
+  return (
+    <SettingRow
+      title="Delete branch by default"
+      description="Preselect the delete branch option when deleting tasks with a deletable task branch."
+      control={
+        <>
+          <ResetToDefaultButton
+            visible={taskSettings.isFieldOverridden('deleteBranchByDefault')}
+            defaultLabel="off"
+            onReset={taskSettings.resetDeleteBranchByDefault}
+            disabled={taskSettings.loading || taskSettings.saving}
+          />
+          <Switch
+            checked={taskSettings.deleteBranchByDefault}
+            disabled={taskSettings.loading || taskSettings.saving}
+            onCheckedChange={taskSettings.updateDeleteBranchByDefault}
+          />
+        </>
+      }
+    />
+  );
+};
+
 export const PreserveTaskNameCapitalizationRow: React.FC = () => {
   const taskSettings = useTaskSettings();
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -38,6 +38,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
 
   const { data: preflight = null } = useQuery({
     queryKey: ['deleteTaskPreflight', projectId, taskIds],
+    staleTime: Infinity,
     queryFn: async () => {
       try {
         return (await rpc.tasks.getDeletePreflight(projectId, taskIds)).tasks;
@@ -56,10 +57,11 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
   const showWorktreeCheckbox = !isLoading && worktreeTasks.length > 0;
   const showBranchCheckbox = !isLoading && branchTasks.length > 0;
   const effectiveDeleteBranch = deleteBranchOverride ?? deleteBranchByDefault;
+  const shouldDeleteBranch = deleteWorktree && effectiveDeleteBranch;
 
   const handleWorktreeChange = (checked: boolean) => {
     setDeleteWorktree(checked);
-    if (!checked) setDeleteBranchOverride(false);
+    if (!checked) setDeleteBranchOverride(undefined);
   };
 
   const title = isBulk ? `Delete ${count} tasks` : 'Delete task';
@@ -121,7 +123,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
                 aria-disabled={!deleteWorktree}
               >
                 <Checkbox
-                  checked={effectiveDeleteBranch}
+                  checked={shouldDeleteBranch}
                   onCheckedChange={(checked) => setDeleteBranchOverride(Boolean(checked))}
                   disabled={!deleteWorktree}
                 />
@@ -141,7 +143,7 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
           onClick={() =>
             onSuccess({
               deleteWorktree,
-              deleteBranch: showBranchCheckbox && effectiveDeleteBranch,
+              deleteBranch: showBranchCheckbox && shouldDeleteBranch,
             })
           }
         >

--- a/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/delete-task-modal.tsx
@@ -1,5 +1,6 @@
+import { useQuery } from '@tanstack/react-query';
 import { TriangleAlert } from 'lucide-react';
-import { useEffect, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 import { rpc } from '@renderer/lib/ipc';
 import type { BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
@@ -11,7 +12,7 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
-import type { TaskDeletePreflightItem } from '@shared/core/tasks/tasks';
+import { useTaskSettings } from './hooks/useTaskSettings';
 
 export type DeleteTaskModalArgs = {
   projectId: string;
@@ -26,23 +27,25 @@ export type DeleteTaskModalResult = {
 type Props = BaseModalProps<DeleteTaskModalResult> & DeleteTaskModalArgs;
 
 export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props) {
-  const [preflight, setPreflight] = useState<TaskDeletePreflightItem[] | null>(null);
+  const { deleteBranchByDefault } = useTaskSettings();
   const [deleteWorktree, setDeleteWorktree] = useState(true);
-  const [deleteBranch, setDeleteBranch] = useState(false);
+  const [deleteBranchOverride, setDeleteBranchOverride] = useState<boolean>();
 
   const count = tasks.length;
   const isBulk = count > 1;
 
-  // Stable taskIds string — props don't change after modal opens.
   const taskIds = useMemo(() => tasks.map((t) => t.taskId), [tasks]);
 
-  useEffect(() => {
-    rpc.tasks.getDeletePreflight(projectId, taskIds).then(
-      (result) => setPreflight(result.tasks),
-      // On error, allow the modal to proceed without preflight info (no checkboxes shown).
-      () => setPreflight([])
-    );
-  }, [projectId, taskIds]);
+  const { data: preflight = null } = useQuery({
+    queryKey: ['deleteTaskPreflight', projectId, taskIds],
+    queryFn: async () => {
+      try {
+        return (await rpc.tasks.getDeletePreflight(projectId, taskIds)).tasks;
+      } catch {
+        return [];
+      }
+    },
+  });
 
   const isLoading = preflight === null;
 
@@ -52,10 +55,11 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
 
   const showWorktreeCheckbox = !isLoading && worktreeTasks.length > 0;
   const showBranchCheckbox = !isLoading && branchTasks.length > 0;
+  const effectiveDeleteBranch = deleteBranchOverride ?? deleteBranchByDefault;
 
   const handleWorktreeChange = (checked: boolean) => {
     setDeleteWorktree(checked);
-    if (!checked) setDeleteBranch(false);
+    if (!checked) setDeleteBranchOverride(false);
   };
 
   const title = isBulk ? `Delete ${count} tasks` : 'Delete task';
@@ -117,8 +121,8 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
                 aria-disabled={!deleteWorktree}
               >
                 <Checkbox
-                  checked={deleteBranch}
-                  onCheckedChange={(checked) => setDeleteBranch(Boolean(checked))}
+                  checked={effectiveDeleteBranch}
+                  onCheckedChange={(checked) => setDeleteBranchOverride(Boolean(checked))}
                   disabled={!deleteWorktree}
                 />
                 {branchLabel}
@@ -134,7 +138,12 @@ export function DeleteTaskModal({ projectId, tasks, onSuccess, onClose }: Props)
         <ConfirmButton
           variant="destructive"
           disabled={isLoading}
-          onClick={() => onSuccess({ deleteWorktree, deleteBranch })}
+          onClick={() =>
+            onSuccess({
+              deleteWorktree,
+              deleteBranch: showBranchCheckbox && effectiveDeleteBranch,
+            })
+          }
         >
           {isLoading ? 'Loading...' : isBulk ? `Delete ${count} tasks` : 'Delete'}
         </ConfirmButton>

--- a/apps/emdash-desktop/src/renderer/features/tasks/hooks/useTaskSettings.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/hooks/useTaskSettings.ts
@@ -5,6 +5,7 @@ export interface TaskSettingsModel {
   autoApproveByDefault: boolean;
   autoTrustWorktrees: boolean;
   createBranchAndWorktree: boolean;
+  deleteBranchByDefault: boolean;
   preserveNameCapitalization: boolean;
   includeIssueContextByDefault: boolean;
   loading: boolean;
@@ -15,6 +16,7 @@ export interface TaskSettingsModel {
       | 'autoApproveByDefault'
       | 'autoTrustWorktrees'
       | 'createBranchAndWorktree'
+      | 'deleteBranchByDefault'
       | 'preserveNameCapitalization'
       | 'includeIssueContextByDefault'
   ) => boolean;
@@ -22,12 +24,14 @@ export interface TaskSettingsModel {
   updateAutoApproveByDefault: (next: boolean) => void;
   updateAutoTrustWorktrees: (next: boolean) => void;
   updateCreateBranchAndWorktree: (next: boolean) => void;
+  updateDeleteBranchByDefault: (next: boolean) => void;
   updatePreserveNameCapitalization: (next: boolean) => void;
   updateIncludeIssueContextByDefault: (next: boolean) => void;
   resetAutoGenerateName: () => void;
   resetAutoApproveByDefault: () => void;
   resetAutoTrustWorktrees: () => void;
   resetCreateBranchAndWorktree: () => void;
+  resetDeleteBranchByDefault: () => void;
   resetPreserveNameCapitalization: () => void;
   resetIncludeIssueContextByDefault: () => void;
 }
@@ -47,6 +51,7 @@ export function useTaskSettings(): TaskSettingsModel {
     autoApproveByDefault: tasks?.autoApproveByDefault ?? false,
     autoTrustWorktrees: tasks?.autoTrustWorktrees ?? false,
     createBranchAndWorktree: tasks?.createBranchAndWorktree ?? true,
+    deleteBranchByDefault: tasks?.deleteBranchByDefault ?? false,
     preserveNameCapitalization: tasks?.preserveNameCapitalization ?? false,
     includeIssueContextByDefault: tasks?.includeIssueContextByDefault ?? true,
     loading,
@@ -56,12 +61,14 @@ export function useTaskSettings(): TaskSettingsModel {
     updateAutoApproveByDefault: (next) => update({ autoApproveByDefault: next }),
     updateAutoTrustWorktrees: (next) => update({ autoTrustWorktrees: next }),
     updateCreateBranchAndWorktree: (next) => update({ createBranchAndWorktree: next }),
+    updateDeleteBranchByDefault: (next) => update({ deleteBranchByDefault: next }),
     updatePreserveNameCapitalization: (next) => update({ preserveNameCapitalization: next }),
     updateIncludeIssueContextByDefault: (next) => update({ includeIssueContextByDefault: next }),
     resetAutoGenerateName: () => resetField('autoGenerateName'),
     resetAutoApproveByDefault: () => resetField('autoApproveByDefault'),
     resetAutoTrustWorktrees: () => resetField('autoTrustWorktrees'),
     resetCreateBranchAndWorktree: () => resetField('createBranchAndWorktree'),
+    resetDeleteBranchByDefault: () => resetField('deleteBranchByDefault'),
     resetPreserveNameCapitalization: () => resetField('preserveNameCapitalization'),
     resetIncludeIssueContextByDefault: () => resetField('includeIssueContextByDefault'),
   };


### PR DESCRIPTION
### Description

Adds a task setting for preselecting "Delete branch" in the delete task modal when the selected task(s) have a deletable branch. The default remains off, so existing behavior is unchanged until users enable the setting.

### Related issues
Refs ENG-1794

### Screenshot/Recording (if applicable)

Screen recording: https://cap.link/zsy8tecghdd4ps7

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>