### PR TITLE
feat(tasks): add archive shortcut

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/command-palette/command-icons.ts
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/command-icons.ts
@@ -1,4 +1,5 @@
 import {
+  Archive,
   ArrowDownToLine,
   ArrowLeft,
   ArrowRight,
@@ -62,6 +63,7 @@ export const COMMAND_ICONS = {
   'arrow-down-to-line': ArrowDownToLine,
   'arrow-up-to-line': ArrowUpToLine,
   pin: Pin,
+  archive: Archive,
   'chevron-down': ChevronDown,
   'chevron-up': ChevronUp,
 } satisfies Record<string, LucideIcon>;

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
@@ -327,8 +327,8 @@ describe('createTaskCommandProvider', () => {
     expect(taskView.setTerminalDrawerOpen).not.toHaveBeenCalled();
   });
 
-  it('archives the current task and returns to the project view', () => {
-    const archiveTask = vi.fn();
+  it('archives the current task and returns to the project view', async () => {
+    const archiveTask = vi.fn(() => Promise.resolve());
     mocks.getTaskManagerStore.mockReturnValue({ archiveTask });
     const provider = createTaskCommandProvider('project-1', 'task-1');
 
@@ -337,9 +337,42 @@ describe('createTaskCommandProvider', () => {
     expect(command?.shortcutKey).toBe('archiveTask');
     expect(command?.enabled).toBe(true);
     command?.execute();
+    await Promise.resolve();
 
     expect(mocks.navigate).toHaveBeenCalledWith('project', { projectId: 'project-1' });
     expect(archiveTask).toHaveBeenCalledWith('task-1');
+  });
+
+  it('keeps archived tasks from running the archive command', () => {
+    mocks.getRegisteredTaskData.mockReturnValue({
+      id: 'task-1',
+      isPinned: false,
+      archivedAt: '2026-07-09T00:00:00.000Z',
+    });
+    const provider = createTaskCommandProvider('project-1', 'task-1');
+
+    const command = provider.getCommands().find((candidate) => candidate.id === 'task.archive');
+
+    expect(command?.enabled).toBe(false);
+  });
+
+  it('shows an error and stays on the task when archiving fails', async () => {
+    const archiveTask = vi.fn(() => Promise.reject(new Error('archive failed')));
+    mocks.getTaskManagerStore.mockReturnValue({ archiveTask });
+    const provider = createTaskCommandProvider('project-1', 'task-1');
+
+    const command = provider.getCommands().find((candidate) => candidate.id === 'task.archive');
+
+    command?.execute();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(archiveTask).toHaveBeenCalledWith('task-1');
+    expect(mocks.navigate).not.toHaveBeenCalled();
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Could not archive task',
+      variant: 'destructive',
+    });
   });
 
   it('navigates to the next visible task across project boundaries', () => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.test.ts
@@ -40,6 +40,7 @@ const mocks = vi.hoisted(() => ({
   focusUrl: vi.fn(),
   getRegisteredTaskData: vi.fn(),
   getTaskGitWorktreeStore: vi.fn(),
+  getTaskManagerStore: vi.fn(),
   getTaskStore: vi.fn(),
   getTaskView: vi.fn(),
   goBack: vi.fn(),
@@ -74,6 +75,7 @@ vi.mock('@renderer/features/browser/browser-controls-registry', () => ({
 vi.mock('@renderer/features/tasks/stores/task-selectors', () => ({
   getRegisteredTaskData: mocks.getRegisteredTaskData,
   getTaskGitWorktreeStore: mocks.getTaskGitWorktreeStore,
+  getTaskManagerStore: mocks.getTaskManagerStore,
   getTaskStore: mocks.getTaskStore,
   getTaskView: mocks.getTaskView,
 }));
@@ -139,6 +141,9 @@ describe('createTaskCommandProvider', () => {
     mocks.getTaskStore.mockReturnValue({
       state: 'provisioned',
       setPinned: vi.fn(),
+    });
+    mocks.getTaskManagerStore.mockReturnValue({
+      archiveTask: vi.fn(),
     });
     mocks.getTaskView.mockReturnValue({
       isSidebarCollapsed: false,
@@ -320,6 +325,21 @@ describe('createTaskCommandProvider', () => {
     expect(taskView.openNewTerminal).toHaveBeenCalledWith();
     expect(taskView.paneLayout.open).not.toHaveBeenCalled();
     expect(taskView.setTerminalDrawerOpen).not.toHaveBeenCalled();
+  });
+
+  it('archives the current task and returns to the project view', () => {
+    const archiveTask = vi.fn();
+    mocks.getTaskManagerStore.mockReturnValue({ archiveTask });
+    const provider = createTaskCommandProvider('project-1', 'task-1');
+
+    const command = provider.getCommands().find((candidate) => candidate.id === 'task.archive');
+
+    expect(command?.shortcutKey).toBe('archiveTask');
+    expect(command?.enabled).toBe(true);
+    command?.execute();
+
+    expect(mocks.navigate).toHaveBeenCalledWith('project', { projectId: 'project-1' });
+    expect(archiveTask).toHaveBeenCalledWith('task-1');
   });
 
   it('navigates to the next visible task across project boundaries', () => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
@@ -444,8 +444,14 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
           group: archiveDef.group,
           enabled: taskData != null && !taskData.archivedAt,
           execute() {
-            appState.navigation.navigate('project', { projectId });
-            void taskManager?.archiveTask(taskId);
+            void (async () => {
+              try {
+                await taskManager?.archiveTask(taskId);
+                appState.navigation.navigate('project', { projectId });
+              } catch {
+                toast({ title: 'Could not archive task', variant: 'destructive' });
+              }
+            })();
           },
         },
         // ── Navigation ─────────────────────────────────────────────────────

--- a/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/commands.ts
@@ -5,6 +5,7 @@ import type { ResolvedTab } from '@renderer/features/tabs/core/tab-provider';
 import {
   getRegisteredTaskData,
   getTaskGitWorktreeStore,
+  getTaskManagerStore,
   getTaskStore,
   getTaskView,
 } from '@renderer/features/tasks/stores/task-selectors';
@@ -46,6 +47,7 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
         (entry) => entry.projectId === projectId && entry.taskId === taskId
       );
 
+      const taskManager = getTaskManagerStore(projectId);
       const git = getTaskGitWorktreeStore(projectId, taskId);
       const repository = git ? getGitRepositoryStore(projectId) : undefined;
       const taskData = getRegisteredTaskData(projectId, taskId);
@@ -75,6 +77,7 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
       const gitPullDef = taskDef('task.gitPull');
       const gitPushDef = taskDef('task.gitPush');
       const pinDef = taskDef('task.pin');
+      const archiveDef = taskDef('task.archive');
       const nextTaskDef = taskDef('task.nextTask');
       const prevTaskDef = taskDef('task.prevTask');
 
@@ -431,6 +434,18 @@ export function createTaskCommandProvider(projectId: string, taskId: string): Co
           enabled: taskData != null,
           execute() {
             if (taskData) void taskStore?.setPinned(!taskData.isPinned);
+          },
+        },
+        {
+          id: archiveDef.id,
+          label: archiveDef.label,
+          description: archiveDef.description,
+          shortcutKey: archiveDef.shortcutKey,
+          group: archiveDef.group,
+          enabled: taskData != null && !taskData.archivedAt,
+          execute() {
+            appState.navigation.navigate('project', { projectId });
+            void taskManager?.archiveTask(taskId);
           },
         },
         // ── Navigation ─────────────────────────────────────────────────────

--- a/apps/emdash-desktop/src/shared/commands.ts
+++ b/apps/emdash-desktop/src/shared/commands.ts
@@ -264,6 +264,15 @@ export const TASK_COMMAND_DEFS = defineCommandDefs([
     iconKey: 'pin',
   },
   {
+    id: 'task.archive',
+    label: 'Archive Task',
+    description: 'Archive the current task',
+    scope: 'task',
+    shortcutKey: 'archiveTask',
+    group: 'Task',
+    iconKey: 'archive',
+  },
+  {
     id: 'task.convertAutomation',
     label: 'Convert to Regular Task',
     description: 'Detach this task from its automation run',

--- a/apps/emdash-desktop/src/shared/shortcuts.ts
+++ b/apps/emdash-desktop/src/shared/shortcuts.ts
@@ -146,7 +146,7 @@ export const APP_SHORTCUTS = defineShortcuts({
     category: 'Navigation',
   },
   archiveTask: {
-    defaultHotkey: 'Mod+Shift+Backspace',
+    defaultHotkey: 'Mod+Shift+E',
     label: 'Archive Task',
     description: 'Archive the current task',
     category: 'Task View',

--- a/apps/emdash-desktop/src/shared/shortcuts.ts
+++ b/apps/emdash-desktop/src/shared/shortcuts.ts
@@ -150,6 +150,7 @@ export const APP_SHORTCUTS = defineShortcuts({
     label: 'Archive Task',
     description: 'Archive the current task',
     category: 'Task View',
+    ignoreWhenMonacoFocused: true,
   },
   newProject: {
     defaultHotkey: 'Mod+Shift+N',

--- a/apps/emdash-desktop/src/shared/shortcuts.ts
+++ b/apps/emdash-desktop/src/shared/shortcuts.ts
@@ -145,6 +145,12 @@ export const APP_SHORTCUTS = defineShortcuts({
     description: 'Delete the selected tasks',
     category: 'Navigation',
   },
+  archiveTask: {
+    defaultHotkey: 'Mod+Shift+Backspace',
+    label: 'Archive Task',
+    description: 'Archive the current task',
+    category: 'Task View',
+  },
   newProject: {
     defaultHotkey: 'Mod+Shift+N',
     label: 'New Project',


### PR DESCRIPTION
### Description

Adds a task-scoped `Archive Task` command with a configurable keyboard shortcut.

- Adds `Archive Task` to keyboard shortcut settings with default `Mod+Shift+Backspace`
- Exposes `task.archive` in the task command provider / command palette
- Archives the current task and returns to the project view
- Prevents the shortcut from firing while Monaco is focused to avoid editor conflicts

### Related issues

ENG-1793

### Screenshot/Recording

Screen recording: https://cap.link/by67ep2778855qr

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
