### PR TITLE
ci(release): add arm64 deb and rpm builds to release workflows

### DIFF
--- a/.github/workflows/release-canary.yml
+++ b/.github/workflows/release-canary.yml
@@ -43,6 +43,7 @@ jobs:
         run: node --experimental-strip-types scripts/release/prepare-release.ts --channel canary
 
   release-linux:
+    if: github.event.inputs.arch != 'arm64'
     needs: [prepare-release]
     runs-on: ubuntu-latest
     container: ubuntu:22.04
@@ -87,6 +88,68 @@ jobs:
         run: >
           node --experimental-strip-types scripts/release/build.ts
           --platform linux --arch x64
+          --config electron-builder.canary.config.ts
+          --channel canary
+
+      - name: Verify Linux native modules
+        working-directory: apps/emdash-desktop
+        run: node --experimental-strip-types scripts/release/verify-linux.ts
+
+      - uses: ./.github/actions/upload-r2
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.R2_BUCKET }}
+          channel: v1-canary
+          prefix: emdash-canary
+
+  release-linux-arm:
+    if: github.event.inputs.arch != 'x64'
+    needs: [prepare-release]
+    runs-on: ubuntu-22.04-arm
+    container: ubuntu:22.04
+    permissions:
+      contents: write
+    environment: release
+    steps:
+      - name: Install system build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: >
+          apt-get update &&
+          apt-get install -y
+          build-essential
+          ca-certificates
+          curl
+          git
+          libsecret-1-dev
+          pkg-config
+          python-is-python3
+          python3
+          python3-setuptools
+          python3-wheel
+          rpm
+          xz-utils
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          posthog-host: ${{ secrets.POSTHOG_HOST }}
+          build-variant: canary
+          setup-python: 'false'
+
+      - run: pnpm run build
+
+      - run: echo "NODE_OPTIONS=${NODE_OPTIONS:-not set}" && node --version
+
+      - name: Build Linux ARM packages
+        working-directory: apps/emdash-desktop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          node --experimental-strip-types scripts/release/build.ts
+          --platform linux --arch arm64 --targets deb,rpm
           --config electron-builder.canary.config.ts
           --channel canary
 
@@ -230,7 +293,8 @@ jobs:
           prefix: emdash-canary
 
   finalize-release:
-    needs: [release-linux, release-win, release-mac]
+    needs: [prepare-release, release-linux, release-linux-arm, release-win, release-mac]
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/release-prod.yml
+++ b/.github/workflows/release-prod.yml
@@ -44,7 +44,9 @@ jobs:
         run: node --experimental-strip-types scripts/release/prepare-release.ts
 
   release-linux:
-    if: startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch'
+    if: >-
+      (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') &&
+      github.event.inputs.arch != 'arm64'
     needs: [prepare-release]
     runs-on: ubuntu-latest
     container: ubuntu:22.04
@@ -88,6 +90,65 @@ jobs:
         run: >
           node --experimental-strip-types scripts/release/build.ts
           --platform linux --arch x64
+
+      - name: Verify Linux native modules
+        working-directory: apps/emdash-desktop
+        run: node --experimental-strip-types scripts/release/verify-linux.ts
+
+      - uses: ./.github/actions/upload-r2
+        with:
+          r2-account-id: ${{ secrets.R2_ACCOUNT_ID }}
+          r2-access-key-id: ${{ secrets.R2_ACCESS_KEY_ID }}
+          r2-secret-access-key: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          r2-bucket: ${{ secrets.R2_BUCKET }}
+
+  release-linux-arm:
+    if: >-
+      (startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch') &&
+      github.event.inputs.arch != 'x64'
+    needs: [prepare-release]
+    runs-on: ubuntu-22.04-arm
+    container: ubuntu:22.04
+    permissions:
+      contents: write
+    environment: release
+    steps:
+      - name: Install system build dependencies
+        env:
+          DEBIAN_FRONTEND: noninteractive
+        run: >
+          apt-get update &&
+          apt-get install -y
+          build-essential
+          ca-certificates
+          curl
+          git
+          libsecret-1-dev
+          pkg-config
+          python-is-python3
+          python3
+          python3-setuptools
+          python3-wheel
+          rpm
+          xz-utils
+      - uses: actions/checkout@v4
+      - uses: ./.github/actions/setup-build
+        with:
+          posthog-key: ${{ secrets.POSTHOG_PROJECT_API_KEY }}
+          posthog-host: ${{ secrets.POSTHOG_HOST }}
+          setup-python: 'false'
+
+      - run: pnpm run build
+
+      - run: echo "NODE_OPTIONS=${NODE_OPTIONS:-not set}" && node --version
+
+      - name: Build Linux ARM packages
+        working-directory: apps/emdash-desktop
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: >
+          node --experimental-strip-types scripts/release/build.ts
+          --platform linux --arch arm64 --targets deb,rpm
 
       - name: Verify Linux native modules
         working-directory: apps/emdash-desktop
@@ -219,7 +280,8 @@ jobs:
           r2-bucket: ${{ secrets.R2_BUCKET }}
 
   finalize-release:
-    needs: [release-linux, release-win, release-mac]
+    needs: [prepare-release, release-linux, release-linux-arm, release-win, release-mac]
+    if: ${{ !cancelled() && !failure() }}
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
### Description

Adds arm64 `.deb` and `.rpm` packages to the production and canary release workflows.

A new `release-linux-arm` job is added to both `release-prod.yml` and `release-canary.yml`. It mirrors the existing `release-linux` job but:

- Runs on a **native arm64 runner** (`ubuntu-22.04-arm`) rather than cross-compiling — the native modules (`better-sqlite3`, `node-pty`, `@parcel/watcher`) are rebuilt from source and cross-compiling them on x64 is unreliable.
- Keeps `container: ubuntu:22.04` for GLIBC parity (matches the `verify-linux.ts` ≤ 2.35 gate used by the x64 job).
- Builds the deb and rpm targets: `--platform linux --arch arm64 --targets deb,rpm`.

It also makes the existing `arch` workflow input actually control the Linux builds (previously the Linux job was hardcoded to x64 and ignored the input):

- `release-linux` (x64) runs unless `arch == 'arm64'`
- `release-linux-arm` runs unless `arch == 'x64'`
- `both` (the default) and tag pushes build both.

`finalize-release` now depends on `prepare-release` plus the build jobs and uses `if: ${{ !cancelled() && !failure() }}`, so a build job skipped by arch filtering no longer blocks finalization, while a failed `prepare-release` (or any failed build) still suppresses it.

No electron-builder config changes were needed: `build.ts` passes an explicit `createTarget(...)` map to electron-builder, which overrides the `linux.target` arch arrays in the config, so the release path is driven entirely by the `--arch`/`--targets` flags. Touching those arrays would have been dead code for releases and would have broken local `pnpm run package:linux` on x64 dev machines.

### Related issues

_None._

### Testing

- Validated both workflow YAML files parse and confirmed the job graph, `needs`, and `if` conditions.
- No unit/type/lint surface (workflow YAML only); `actionlint` was not available in the environment.
- Not yet exercised end-to-end — dispatching the release workflow requires release credentials and the org's arm64 hosted runners to be enabled.

### Notes for reviewers

- The arm64 deb/rpm upload to the GitHub draft (via electron-builder `publish: always`) and to R2. They are downloadable packages only — no auto-update manifest, which is appropriate for deb/rpm.
- **Infra prerequisite:** `ubuntu-22.04-arm` hosted runners must be available to the org (free for public repos; requires enablement for private repos).