### PR TITLE
feat(codex): add GPT-5.6 model options

### DIFF
--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -54,6 +54,21 @@ export const plugin = definePlugin(
     models: {
       kind: 'selectable',
       modelOptions: {
+        'gpt-5.6-sol': {
+          name: 'GPT-5.6 Sol',
+          description: 'Flagship GPT-5.6 model for the hardest agentic coding workflows.',
+          modelFeatures: { intelligence: 5, speed: 2 },
+        },
+        'gpt-5.6-terra': {
+          name: 'GPT-5.6 Terra',
+          description: 'Balanced GPT-5.6 model for everyday coding work with lower cost.',
+          modelFeatures: { intelligence: 5, speed: 4 },
+        },
+        'gpt-5.6-luna': {
+          name: 'GPT-5.6 Luna',
+          description: 'Fast and cost-efficient GPT-5.6 model for lighter coding tasks.',
+          modelFeatures: { intelligence: 4, speed: 5 },
+        },
         'gpt-5.5': {
           name: 'GPT-5.5',
           description: 'Recommended Codex model for complex coding and agentic workflows.',
@@ -69,6 +84,16 @@ export const plugin = definePlugin(
           description: 'Research-preview Codex model optimized for near-instant iteration.',
           modelFeatures: { intelligence: 2, speed: 5 },
         },
+      },
+    },
+    effort: {
+      kind: 'selectable',
+      effortOptions: {
+        low: { label: 'Low', level: 1 },
+        medium: { label: 'Medium', level: 2 },
+        high: { label: 'High', level: 3 },
+        xhigh: { label: 'Extra high', level: 4 },
+        max: { label: 'Max', level: 5 },
       },
     },
     hooks: {

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -86,16 +86,6 @@ export const plugin = definePlugin(
         },
       },
     },
-    effort: {
-      kind: 'selectable',
-      effortOptions: {
-        low: { label: 'Low', level: 1 },
-        medium: { label: 'Medium', level: 2 },
-        high: { label: 'High', level: 3 },
-        xhigh: { label: 'Extra high', level: 4 },
-        max: { label: 'Max', level: 5 },
-      },
-    },
     hooks: {
       kind: 'config',
       scope: 'global',


### PR DESCRIPTION
## Summary
- Add GPT-5.6 Sol, Terra, and Luna to the Codex provider model selector
- Leave Codex reasoning effort handling unchanged/dynamic; no static max effort option is added in this PR

## Context
OpenAI's GPT-5.6 announcement/help docs list these model IDs:
- `gpt-5.6-sol`
- `gpt-5.6-terra`
- `gpt-5.6-luna`

The announcement also mentions a new `max` reasoning effort, but this PR intentionally does not add static effort metadata. Existing Codex reasoning efforts continue to come from Codex/ACP or local Codex configuration.

Note: local verification with `codex debug models` on Codex CLI 0.143.0 does not yet show GPT-5.6; current local catalog still shows GPT-5.5/GPT-5.4 variants. This change is forward-looking based on the OpenAI source.

## Checks
- `mise exec -- pnpm --filter @emdash/plugins run format:check`
- `mise exec -- pnpm --dir packages/plugins exec vitest run src/agents/impl/index.test.ts src/agents/impl/codex/acp.test.ts`