### PR TITLE
fix(ui): use sentence case in chat composer copy

### DIFF
--- a/packages/ui/src/react/components/chat-composer/context-usage-indicator.tsx
+++ b/packages/ui/src/react/components/chat-composer/context-usage-indicator.tsx
@@ -84,7 +84,7 @@ export function ContextUsageIndicator({
       />
       <Popover.Content align="end" side="top">
         <Popover.Header>
-          <Popover.Title>Context Usage</Popover.Title>
+          <Popover.Title>Context usage</Popover.Title>
         </Popover.Header>
         <div className={styles.usagePopoverBody}>
           <div className={styles.usageStatsRow}>

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -713,7 +713,7 @@ export function ChatComposer({
     ? 'Session closed'
     : isWorking
       ? 'Add a follow-up'
-      : (placeholder ?? 'Send a Message, tag @files or use /commands');
+      : (placeholder ?? 'Send a message, tag @files or use /commands');
 
   return (
     <div className={cx(styles.composerRoot, className)}>


### PR DESCRIPTION
## Summary
- update chat composer placeholder copy to sentence case
- update context usage popover title to sentence case

## Tests
- Not run (copy-only change).