### PR TITLE
fix(core-files): retry transient errors when removing directories

### DIFF
--- a/packages/core/src/files/fs/file-system.ts
+++ b/packages/core/src/files/fs/file-system.ts
@@ -170,7 +170,14 @@ export class FileSystem implements IFileSystem {
             code: 'EISDIR',
           });
         }
-        await fs.rm(validated.data, { recursive: true, force: true });
+        // Retry transient EBUSY/EPERM/ENOTEMPTY failures (e.g. a watcher or
+        // antivirus briefly holding a handle, common on Windows).
+        await fs.rm(validated.data, {
+          recursive: true,
+          force: true,
+          maxRetries: 3,
+          retryDelay: 100,
+        });
         return ok<void>();
       }
 


### PR DESCRIPTION
## What

`FileSystem.remove()` now passes `maxRetries: 3, retryDelay: 100` to `fs.rm` for recursive directory removal.

## Why

Before #2686 migrated worktree cleanup to core/files, the desktop app deleted worktree directories with `fs.rm(path, { recursive: true, force: true, maxRetries: 3, retryDelay: 100 })`. Core's `remove()` did not pass retry options, so a transient `EBUSY`/`EPERM`/`ENOTEMPTY` (a watcher or antivirus briefly holding a handle, most common on Windows) now fails immediately where it previously succeeded on retry, leaving the worktree directory behind.

Retries only trigger on failure, so the success path is unchanged. The worst case is that a permanently undeletable path reports its error ~600ms later.

## Checks

- `pnpm --filter @emdash/core run test` — files/fs tests pass (72/72); the 7 failing workspace-* tests fail identically on clean main
- `pnpm --filter @emdash/core run typecheck`
- `pnpm --filter @emdash/core run lint`
- `pnpm run format`