### PR TITLE
feat(search): make file indexer gitignore-aware and configurable

### DIFF
--- a/apps/emdash-desktop/src/main/core/git/legacy/git-service.ts
+++ b/apps/emdash-desktop/src/main/core/git/legacy/git-service.ts
@@ -199,6 +199,17 @@ export class GitService implements IDisposable {
     }
   }
 
+  async listIndexableFiles(): Promise<string[]> {
+    const { stdout } = await this.ctx.exec('git', [
+      'ls-files',
+      '-z',
+      '--cached',
+      '--others',
+      '--exclude-standard',
+    ]);
+    return stdout.split('\0').filter((entry) => entry.length > 0);
+  }
+
   private async _loadFullStatus(): Promise<FullGitStatus> {
     try {
       const parser = new StatusParser();

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-git.ts
@@ -507,6 +507,10 @@ class LegacySshGitWorktree implements IGitWorktree {
     return this.git.isFileCleanlyTracked(this.toGitPath(filePath));
   }
 
+  listIndexableFiles(): Promise<string[]> {
+    return this.git.listIndexableFiles();
+  }
+
   async getChangedFiles(base: DiffTarget): Promise<GitChange[]> {
     return (await this.git.getChangedFiles(base)).map((change) => this.toAbsChange(change));
   }

--- a/apps/emdash-desktop/src/main/core/search/search-index-exclusions.test.ts
+++ b/apps/emdash-desktop/src/main/core/search/search-index-exclusions.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   createSearchIndexExclusion,
   isSearchIndexExcludedInsideRoot,
+  SEARCH_INDEX_EXCLUDED_PATH_SEGMENTS,
 } from './search-index-exclusions';
 
 describe('search index exclusions', () => {
@@ -19,5 +20,19 @@ describe('search index exclusions', () => {
 
     expect(exclude('/repo/dist/bundle.js')).toBe(true);
     expect(exclude('/repo/src/index.ts')).toBe(false);
+  });
+});
+
+describe('createSearchIndexExclusion extra segments', () => {
+  it('excludes .tox by default', () => {
+    expect(SEARCH_INDEX_EXCLUDED_PATH_SEGMENTS).toContain('.tox');
+    const exclude = createSearchIndexExclusion('/repo');
+    expect(exclude('/repo/.tox/py311/lib/foo.py')).toBe(true);
+  });
+
+  it('excludes user-supplied additional segments', () => {
+    const exclude = createSearchIndexExclusion('/repo', { additionalSegments: ['generated'] });
+    expect(exclude('/repo/src/generated/schema.ts')).toBe(true);
+    expect(exclude('/repo/src/app.ts')).toBe(false);
   });
 });

--- a/apps/emdash-desktop/src/main/core/search/search-index-exclusions.ts
+++ b/apps/emdash-desktop/src/main/core/search/search-index-exclusions.ts
@@ -23,6 +23,7 @@ export const SEARCH_INDEX_EXCLUDED_PATH_SEGMENTS = [
   '.idea',
   '__pycache__',
   '.pytest_cache',
+  '.tox',
   'venv',
   '.venv',
   'target',
@@ -48,11 +49,26 @@ export const SEARCH_INDEX_EXCLUDED_PATH_SEGMENTS = [
 
 const SEARCH_INDEX_EXCLUDED_PATH_SEGMENT_SET = new Set<string>(SEARCH_INDEX_EXCLUDED_PATH_SEGMENTS);
 
-export function createSearchIndexExclusion(rootPath: string): FileExclusionPredicate {
-  return (absPath) => isSearchIndexExcludedInsideRoot(rootPath, absPath);
+export type SearchIndexExclusionOptions = {
+  additionalSegments?: readonly string[];
+};
+
+export function createSearchIndexExclusion(
+  rootPath: string,
+  options: SearchIndexExclusionOptions = {}
+): FileExclusionPredicate {
+  const extra = options.additionalSegments ?? [];
+  const segments = extra.length
+    ? new Set<string>([...SEARCH_INDEX_EXCLUDED_PATH_SEGMENT_SET, ...extra])
+    : SEARCH_INDEX_EXCLUDED_PATH_SEGMENT_SET;
+  return (absPath) => isSearchIndexExcludedInsideRoot(rootPath, absPath, segments);
 }
 
-export function isSearchIndexExcludedInsideRoot(rootPath: string, absPath: string): boolean {
+export function isSearchIndexExcludedInsideRoot(
+  rootPath: string,
+  absPath: string,
+  segments: ReadonlySet<string> = SEARCH_INDEX_EXCLUDED_PATH_SEGMENT_SET
+): boolean {
   const relativeToRoot = path.relative(rootPath, absPath);
   if (
     !relativeToRoot ||
@@ -66,5 +82,5 @@ export function isSearchIndexExcludedInsideRoot(rootPath: string, absPath: strin
   return relativeToRoot
     .replace(/\\/g, '/')
     .split('/')
-    .some((segment) => SEARCH_INDEX_EXCLUDED_PATH_SEGMENT_SET.has(segment));
+    .some((segment) => segments.has(segment));
 }

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.test.ts
@@ -6,6 +6,10 @@ import type {
   IWorkspaceFileIndexStore,
 } from './workspace-file-index-store';
 
+vi.mock('@main/core/settings/settings-service', () => ({
+  appSettingsService: { get: vi.fn(async () => ({ additionalExcludedSegments: [] })) },
+}));
+
 vi.mock('./workspace-file-index-store', () => ({
   WorkspaceFileIndexStore: class {},
 }));
@@ -230,11 +234,59 @@ describe('WorkspaceFileIndexService', () => {
     expect([...store.pathSet('ws-1')].sort()).toEqual(['/repo/a.ts', '/repo/b.ts']);
     expect(store.operations).toEqual([]);
   });
+
+  it('uses listGitFiles as the enumeration source when present', async () => {
+    const store = new FakeStore();
+    const service = await createService(store);
+
+    await service.onWorkspaceActivated('ws-1', {
+      rootPath: '/repo',
+      enumerate: enumerator(() => {
+        throw new Error('should not walk when git listing is available');
+      }),
+      listGitFiles: async () => ['/repo/src/app.ts', '/repo/.tox/junk.py'],
+    });
+
+    expect([...store.pathSet('ws-1')]).toEqual(['/repo/src/app.ts']); // .tox filtered by segments
+  });
+
+  it('falls back to the filesystem walk when listGitFiles throws', async () => {
+    const store = new FakeStore();
+    const service = await createService(store);
+
+    await service.onWorkspaceActivated('ws-1', {
+      rootPath: '/repo',
+      enumerate: enumerator(() => ['/repo/fresh.ts']),
+      listGitFiles: async () => {
+        throw new Error('not a git repo');
+      },
+    });
+
+    expect([...store.pathSet('ws-1')]).toEqual(['/repo/fresh.ts']);
+  });
+
+  it('applies configured extra excluded segments during reindex', async () => {
+    const store = new FakeStore();
+    const service = await createService(store, {
+      getExtraExcludedSegments: async () => ['generated'],
+    });
+
+    await service.onWorkspaceActivated('ws-1', {
+      rootPath: '/repo',
+      enumerate: enumerator(() => ['/repo/keep.ts', '/repo/generated/out.ts']),
+    });
+
+    expect([...store.pathSet('ws-1')]).toEqual(['/repo/keep.ts']);
+  });
 });
 
 async function createService(
   store: FakeStore,
-  options: { maxFiles?: number; reindexDebounceMs?: number } = {}
+  options: {
+    maxFiles?: number;
+    reindexDebounceMs?: number;
+    getExtraExcludedSegments?: () => Promise<string[]>;
+  } = {}
 ) {
   const { WorkspaceFileIndexService } = await import('./workspace-file-index-service');
   return new WorkspaceFileIndexService({ store, ...options });

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
@@ -5,6 +5,7 @@ import {
   type FileError,
 } from '@emdash/core/files';
 import type { Result } from '@emdash/shared';
+import { appSettingsService } from '@main/core/settings/settings-service';
 import { log } from '@main/lib/logger';
 import { collectWithBudget } from './collect-with-budget';
 import { createSearchIndexExclusion } from './search-index-exclusions';
@@ -27,6 +28,7 @@ export type WorkspaceFileEnumerator = (
 export type WorkspaceFileIndexSource = {
   rootPath: string;
   enumerate: WorkspaceFileEnumerator;
+  listGitFiles?: () => Promise<string[]>;
 };
 
 export type WorkspaceFileIndexServiceOptions = {
@@ -35,6 +37,7 @@ export type WorkspaceFileIndexServiceOptions = {
   reindexTimeoutMs?: number;
   reindexDebounceMs?: number;
   now?: () => number;
+  getExtraExcludedSegments?: () => Promise<string[]>;
 };
 
 export class WorkspaceFileIndexService {
@@ -43,6 +46,7 @@ export class WorkspaceFileIndexService {
   private pendingReindex = new Set<string>();
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private activeSources = new Map<string, WorkspaceFileIndexSource>();
+  private extraSegments: string[] = [];
 
   constructor(private readonly options: WorkspaceFileIndexServiceOptions = {}) {
     this.store = options.store ?? new WorkspaceFileIndexStore();
@@ -75,6 +79,7 @@ export class WorkspaceFileIndexService {
 
   async onWorkspaceActivated(workspaceId: string, source: WorkspaceFileIndexSource): Promise<void> {
     this.activeSources.set(workspaceId, source);
+    this.extraSegments = await this.loadExtraSegments();
     const meta = this.store.getMeta(workspaceId);
 
     if (meta && meta.rootPath !== source.rootPath) {
@@ -103,6 +108,12 @@ export class WorkspaceFileIndexService {
     this.store.deleteIndex(workspaceId);
   }
 
+  reindexActiveWorkspaces(): void {
+    for (const workspaceId of this.activeSources.keys()) {
+      this.scheduleReindex(workspaceId);
+    }
+  }
+
   searchFiles(workspaceId: string, query: string, limit = 20): FileHit[] {
     return this.store.searchFiles(workspaceId, query, limit);
   }
@@ -125,17 +136,14 @@ export class WorkspaceFileIndexService {
         const source = this.activeSources.get(workspaceId);
         if (!source) return;
 
-        const exclude = createSearchIndexExclusion(source.rootPath);
-        const enumeration = source.enumerate(source.rootPath, { exclude });
-        if (!enumeration.success) {
-          log.warn('WorkspaceFileIndexService: enumerate failed to start', {
-            workspaceId,
-            error: enumeration.error,
-          });
-          return;
-        }
+        this.extraSegments = await this.loadExtraSegments();
+        const exclude = createSearchIndexExclusion(source.rootPath, {
+          additionalSegments: this.extraSegments,
+        });
+        const iterable = await this.enumerateSource(workspaceId, source, exclude);
+        if (!iterable) return;
 
-        const result = await collectWithBudget(filterExcluded(enumeration.data, exclude), {
+        const result = await collectWithBudget(filterExcluded(iterable, exclude), {
           maxFiles: this.maxFiles,
           timeoutMs: this.reindexTimeoutMs,
           now: this.options.now,
@@ -174,7 +182,9 @@ export class WorkspaceFileIndexService {
   private applyChanges(workspaceId: string, changes: FileChange[]): void {
     let needsReindex = false;
     const rootPath = this.metaRootPath(workspaceId);
-    const exclude = createSearchIndexExclusion(rootPath);
+    const exclude = createSearchIndexExclusion(rootPath, {
+      additionalSegments: this.extraSegments,
+    });
     try {
       this.store.transaction(() => {
         let indexedFileCount = this.store.countIndexedFiles(workspaceId);
@@ -299,6 +309,37 @@ export class WorkspaceFileIndexService {
       ''
     );
   }
+
+  private loadExtraSegments(): Promise<string[]> {
+    return this.options.getExtraExcludedSegments?.() ?? Promise.resolve([]);
+  }
+
+  private async enumerateSource(
+    workspaceId: string,
+    source: WorkspaceFileIndexSource,
+    exclude: (absPath: string) => boolean
+  ): Promise<AsyncIterable<string> | null> {
+    if (source.listGitFiles) {
+      try {
+        const files = await source.listGitFiles();
+        return toAsyncIterable(files);
+      } catch (e) {
+        log.warn('WorkspaceFileIndexService: git listing failed, falling back to walk', {
+          workspaceId,
+          error: String(e),
+        });
+      }
+    }
+    const enumeration = source.enumerate(source.rootPath, { exclude });
+    if (!enumeration.success) {
+      log.warn('WorkspaceFileIndexService: enumerate failed to start', {
+        workspaceId,
+        error: enumeration.error,
+      });
+      return null;
+    }
+    return enumeration.data;
+  }
 }
 
 async function* filterExcluded(
@@ -310,6 +351,12 @@ async function* filterExcluded(
   }
 }
 
+async function* toAsyncIterable(items: string[]): AsyncIterable<string> {
+  for (const item of items) yield item;
+}
+
 export const workspaceFileIndexService = new WorkspaceFileIndexService({
   store: new WorkspaceFileIndexStore(),
+  getExtraExcludedSegments: async () =>
+    (await appSettingsService.get('indexer')).additionalExcludedSegments,
 });

--- a/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
+++ b/apps/emdash-desktop/src/main/core/search/workspace-file-index-service.ts
@@ -46,6 +46,9 @@ export class WorkspaceFileIndexService {
   private pendingReindex = new Set<string>();
   private debounceTimers = new Map<string, ReturnType<typeof setTimeout>>();
   private activeSources = new Map<string, WorkspaceFileIndexSource>();
+  // Cached extra excluded segments, shared across workspaces. Safe as a single
+  // field only because the `indexer` setting is global; if it ever becomes
+  // per-project, key this by workspaceId.
   private extraSegments: string[] = [];
 
   constructor(private readonly options: WorkspaceFileIndexServiceOptions = {}) {
@@ -182,6 +185,11 @@ export class WorkspaceFileIndexService {
   private applyChanges(workspaceId: string, changes: FileChange[]): void {
     let needsReindex = false;
     const rootPath = this.metaRootPath(workspaceId);
+    // Incremental changes are filtered only by the segment predicate, not by
+    // gitignore. A newly-created gitignored file (not under a new directory and
+    // not matching an excluded segment) can briefly enter the index; it
+    // self-heals on the next reindex. Directory creates set needsReindex below,
+    // so the expensive cases (e.g. .tox/ appearing) re-list via git and stay clean.
     const exclude = createSearchIndexExclusion(rootPath, {
       additionalSegments: this.extraSegments,
     });

--- a/apps/emdash-desktop/src/main/core/settings/controller.ts
+++ b/apps/emdash-desktop/src/main/core/settings/controller.ts
@@ -1,6 +1,7 @@
 import { setBrowserCorsRelaxationSettings } from '@main/core/browser/browser-profile-session';
 import { browserWebContentsRegistry } from '@main/core/browser/browser-webcontents-registry';
 import { reconcileResourceSampler } from '@main/core/resource-monitor/resource-sampler';
+import { workspaceFileIndexService } from '@main/core/search/workspace-file-index-service';
 import { createRPCController } from '@shared/lib/ipc/rpc';
 import { appSettingsService, type AppSettings, type AppSettingsKey } from './settings-service';
 
@@ -12,6 +13,9 @@ async function reconcileSettingsRuntimeState(key: AppSettingsKey): Promise<void>
   }
   if (key === 'browser') {
     setBrowserCorsRelaxationSettings(await appSettingsService.get('browser'));
+  }
+  if (key === 'indexer') {
+    workspaceFileIndexService.reindexActiveWorkspaces();
   }
 }
 

--- a/apps/emdash-desktop/src/main/core/settings/schema.test.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.test.ts
@@ -12,4 +12,13 @@ describe('indexerSettingsSchema', () => {
     });
     expect(() => indexerSettingsSchema.parse({ additionalExcludedSegments: [''] })).toThrow();
   });
+
+  it('rejects segments containing path separators', () => {
+    expect(() =>
+      indexerSettingsSchema.parse({ additionalExcludedSegments: ['some/folder'] })
+    ).toThrow();
+    expect(() =>
+      indexerSettingsSchema.parse({ additionalExcludedSegments: ['some\\folder'] })
+    ).toThrow();
+  });
 });

--- a/apps/emdash-desktop/src/main/core/settings/schema.test.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.test.ts
@@ -1,0 +1,15 @@
+import { describe, expect, it } from 'vitest';
+import { indexerSettingsSchema } from './schema';
+
+describe('indexerSettingsSchema', () => {
+  it('defaults additionalExcludedSegments to an empty array', () => {
+    expect(indexerSettingsSchema.parse({})).toEqual({ additionalExcludedSegments: [] });
+  });
+
+  it('trims segments and rejects empty strings', () => {
+    expect(indexerSettingsSchema.parse({ additionalExcludedSegments: ['  .tox  '] })).toEqual({
+      additionalExcludedSegments: ['.tox'],
+    });
+    expect(() => indexerSettingsSchema.parse({ additionalExcludedSegments: [''] })).toThrow();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -132,7 +132,17 @@ export const browserSettingsSchema = z
 export const resourceMonitorSettingsSchema = z.object({ enabled: z.boolean() });
 
 export const indexerSettingsSchema = z.object({
-  additionalExcludedSegments: z.array(z.string().trim().min(1)).default([]),
+  additionalExcludedSegments: z
+    .array(
+      z
+        .string()
+        .trim()
+        .min(1)
+        .refine((s) => !s.includes('/') && !s.includes('\\'), {
+          message: 'Segment must not contain path separators',
+        })
+    )
+    .default([]),
 });
 
 export const openInSettingsSchema = z.object({

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -131,6 +131,10 @@ export const browserSettingsSchema = z
 
 export const resourceMonitorSettingsSchema = z.object({ enabled: z.boolean() });
 
+export const indexerSettingsSchema = z.object({
+  additionalExcludedSegments: z.array(z.string().trim().min(1)).default([]),
+});
+
 export const openInSettingsSchema = z.object({
   default: openInAppIdSchema,
   hidden: z.array(openInAppIdSchema),
@@ -151,6 +155,7 @@ export const APP_SETTINGS_SCHEMA_MAP = {
   browser: browserSettingsSchema,
   resourceMonitor: resourceMonitorSettingsSchema,
   changesViewMode: changesViewModeSchema,
+  indexer: indexerSettingsSchema,
 } as const;
 
 export const appSettingsSchema = z.object({
@@ -168,4 +173,5 @@ export const appSettingsSchema = z.object({
   browser: browserSettingsSchema,
   resourceMonitor: resourceMonitorSettingsSchema,
   changesViewMode: changesViewModeSchema,
+  indexer: indexerSettingsSchema,
 });

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -77,6 +77,9 @@ export const SETTINGS_DEFAULTS = {
     staged: 'flat' as const,
     pr: 'flat' as const,
   },
+  indexer: {
+    additionalExcludedSegments: [],
+  },
 } satisfies SettingsDefaultsMap;
 
 export function getDefaultForKey<K extends AppSettingsKey>(key: K): AppSettings[K] {

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
@@ -197,8 +197,12 @@ export function createWorkspaceFactory(
             return fs.success ? fs.data.enumerate(root, options) : fs;
           },
           listGitFiles: async () => {
+            // SSH remote roots are POSIX regardless of the host OS, so join with
+            // path.posix there; a native path.join on a Windows host would emit
+            // backslash paths that never match the SSH watcher's POSIX change events.
+            const joinIndexPath = type.kind === 'ssh' ? path.posix.join : path.join;
             const relativePaths = await ws.gitWorktree.listIndexableFiles();
-            return relativePaths.map((relativePath) => path.join(ws.path, relativePath));
+            return relativePaths.map((relativePath) => joinIndexPath(ws.path, relativePath));
           },
         });
         unsubscribeGitUpdates = ws.gitWorktree.subscribe((update) =>

--- a/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
+++ b/apps/emdash-desktop/src/main/core/workspaces/workspace-factory.ts
@@ -1,3 +1,4 @@
+import path from 'node:path';
 import { LocalConversationProvider } from '@main/core/conversations/impl/local-conversation';
 import { SshConversationProvider } from '@main/core/conversations/impl/ssh-conversation';
 import type { ConversationProvider } from '@main/core/conversations/types';
@@ -194,6 +195,10 @@ export function createWorkspaceFactory(
           enumerate: (root, options) => {
             const fs = filesRuntime.fileSystem();
             return fs.success ? fs.data.enumerate(root, options) : fs;
+          },
+          listGitFiles: async () => {
+            const relativePaths = await ws.gitWorktree.listIndexableFiles();
+            return relativePaths.map((relativePath) => path.join(ws.path, relativePath));
           },
         });
         unsubscribeGitUpdates = ws.gitWorktree.subscribe((update) =>

--- a/apps/emdash-desktop/src/renderer/features/settings/components/IndexerSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/IndexerSettingsCard.tsx
@@ -27,7 +27,10 @@ const IndexerSettingsCard: React.FC = () => {
         text
           .split('\n')
           .map((line) => line.trim())
-          .filter((line) => line.length > 0)
+          // Segments are matched per path component, so a value containing a
+          // separator would never match; drop them so the field self-heals
+          // instead of tripping the schema's refine on save.
+          .filter((line) => line.length > 0 && !line.includes('/') && !line.includes('\\'))
       )
     );
     update({ additionalExcludedSegments: parsed });

--- a/apps/emdash-desktop/src/renderer/features/settings/components/IndexerSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/IndexerSettingsCard.tsx
@@ -1,0 +1,62 @@
+import React, { useEffect, useState } from 'react';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import { Textarea } from '@renderer/lib/ui/textarea';
+import { ResetToDefaultButton } from './ResetToDefaultButton';
+import { SettingRow } from './SettingRow';
+
+const IndexerSettingsCard: React.FC = () => {
+  const {
+    value,
+    update,
+    isLoading: loading,
+    isSaving: saving,
+    isFieldOverridden,
+    resetField,
+  } = useAppSettingsKey('indexer');
+
+  const segmentsKey = (value?.additionalExcludedSegments ?? []).join('\n');
+  const [text, setText] = useState(segmentsKey);
+
+  useEffect(() => {
+    setText(segmentsKey);
+  }, [segmentsKey]);
+
+  const commit = () => {
+    const parsed = Array.from(
+      new Set(
+        text
+          .split('\n')
+          .map((line) => line.trim())
+          .filter((line) => line.length > 0)
+      )
+    );
+    update({ additionalExcludedSegments: parsed });
+  };
+
+  return (
+    <div className="flex flex-col gap-2">
+      <SettingRow
+        title="Extra excluded folders"
+        description="Folder names to skip when indexing files for search and @-mentions, in addition to the built-in list and your .gitignore. One name per line."
+        control={
+          <ResetToDefaultButton
+            visible={isFieldOverridden('additionalExcludedSegments')}
+            defaultLabel="none"
+            onReset={() => resetField('additionalExcludedSegments')}
+            disabled={loading || saving}
+          />
+        }
+      />
+      <Textarea
+        className="min-h-24 font-mono text-sm"
+        value={text}
+        disabled={loading || saving}
+        placeholder={'.tox\n.mypy_cache'}
+        onChange={(event) => setText(event.target.value)}
+        onBlur={commit}
+      />
+    </div>
+  );
+};
+
+export default IndexerSettingsCard;

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -6,6 +6,7 @@ import { AgentsSettingsPage } from '../agents-page/AgentsSettingsPage';
 import { AccountTab } from './AccountTab';
 import { BrowserSettingsCard } from './BrowserSettingsCard';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
+import IndexerSettingsCard from './IndexerSettingsCard';
 import IntegrationsCard from './IntegrationsCard';
 import InterfaceSettingsCard from './InterfaceSettingsCard';
 import KeyboardSettingsCard from './KeyboardSettingsCard';
@@ -124,6 +125,7 @@ function InterfaceSettingsPage() {
       <TerminalSettingsCard />
       <SidebarMetadataSettingsCard />
       <ResourceMonitorSettingsCard />
+      <IndexerSettingsCard />
       <InterfaceSettingsCard />
       <div className="flex flex-col gap-3">
         <h3 className="text-sm font-normal text-foreground">Keyboard shortcuts</h3>

--- a/packages/core/src/git/git-worktree.test.ts
+++ b/packages/core/src/git/git-worktree.test.ts
@@ -1,5 +1,5 @@
 import { execFile } from 'node:child_process';
-import { chmod, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { promisify } from 'node:util';
@@ -730,6 +730,28 @@ describe('GitWorktree', () => {
       await lease.release();
     } finally {
       await runtime.dispose();
+    }
+  });
+
+  it('listIndexableFiles returns tracked and untracked files but skips gitignored paths', async () => {
+    const repo = await makeRepo();
+    const runtime = new GitRuntime();
+    try {
+      await writeFile(path.join(repo, '.gitignore'), '.tox/\n', 'utf8');
+      await execFileAsync('git', ['add', '.gitignore'], { cwd: repo });
+      await mkdir(path.join(repo, '.tox'), { recursive: true });
+      await writeFile(path.join(repo, '.tox', 'junk.txt'), 'x', 'utf8');
+      await writeFile(path.join(repo, 'untracked.ts'), 'y', 'utf8');
+
+      const lease = await runtime.openWorktree(repo);
+      const files = await lease.value.listIndexableFiles();
+
+      expect(files).toContain('tracked.txt');
+      expect(files).toContain('.gitignore');
+      expect(files).toContain('untracked.ts');
+      expect(files.some((entry) => entry.startsWith('.tox/'))).toBe(false);
+    } finally {
+      await rm(repo, { recursive: true, force: true });
     }
   });
 });

--- a/packages/core/src/git/git-worktree.ts
+++ b/packages/core/src/git/git-worktree.ts
@@ -190,6 +190,17 @@ export class GitWorktree implements IGitWorktree {
     }
   }
 
+  async listIndexableFiles(): Promise<string[]> {
+    const { stdout } = await this.exec.exec([
+      'ls-files',
+      '-z',
+      '--cached',
+      '--others',
+      '--exclude-standard',
+    ]);
+    return stdout.split('\0').filter((entry) => entry.length > 0);
+  }
+
   async getFileAtRef(filePath: string, ref: string): Promise<string | null> {
     return this.repository.readBlobAtRef(ref, this.toRelativePath(filePath));
   }

--- a/packages/core/src/git/types.ts
+++ b/packages/core/src/git/types.ts
@@ -178,6 +178,7 @@ export interface IGitWorktree extends IDisposable {
   /** Worktree git operations. */
   getStatusFingerprint(untracked: GitStatusUntrackedMode): Promise<GitStatusFingerprint>;
   isFileCleanlyTracked(filePath: string): Promise<boolean>;
+  listIndexableFiles(): Promise<string[]>;
   getChangedFiles(base: DiffTarget): Promise<GitChange[]>;
   getFileAtRef(filePath: string, ref: string): Promise<string | null>;
   getFileAtIndex(filePath: string): Promise<string | null>;


### PR DESCRIPTION
### Description

The workspace file index (backing the `@`-mention file picker and command-palette file search) enumerated the whole worktree with a raw filesystem walk, filtered only by a hardcoded segment list that ignored `.gitignore` and was missing `.tox`. On tox-based Python repos this indexed the entire `.tox/` tree (100k+ files per worktree), hit the 50k truncation cap, looped the FSEvents watcher (~99% CPU, UI hang), and bloated the SQLite FTS DB persistently across restarts.

This switches enumeration to `git ls-files --cached --others --exclude-standard` (local and SSH), so only files git considers yours get indexed and gitignored junk like `.tox/` is skipped; the raw filesystem walk remains a fallback for non-git workspaces. It also adds `.tox` to the built-in segment list and a global `indexer.additionalExcludedSegments` setting, editable from a Settings card, that reindexes active workspaces on change.

Security-sensitive area: adds a read-only `listIndexableFiles()` to `GitWorktree`, the `IGitWorktree` interface, and the SSH implementer (`LegacySshGitWorktree`/`GitService`). The git command is a fixed argument array with no shell interpolation; no existing quoting/escaping changed.

### Related issues

Internal bug report: file indexer misses `.tox`, causing ~99% CPU / UI hang and FTS DB bloat on tox-based Python repos. No linked GitHub issue.

### Testing

- `pnpm run format`, `pnpm run lint`, `pnpm run typecheck` — pass (repo-wide)
- `pnpm run test` — 2163/2163 unit tests pass.
- Added unit tests: exclusion predicate (`.tox` + extra segments), `GitWorktree.listIndexableFiles` (real temp repo), settings schema, and the index service (git source, raw-walk fallback, extra segments).


### Screenshot/Recording (if applicable)
New settings field, for ignoring files/folders

<img width="788" height="196" alt="Bildschirmfoto 2026-07-10 um 07 31 33" src="https://github.com/user-attachments/assets/352f9dd5-0281-4d44-bb73-adc6fbf4f72a" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>