### PR TITLE
fix(editor): stop stale external file loading spinner

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-item.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-item.tsx
@@ -8,6 +8,7 @@ import {
 import { FileIcon } from '@renderer/lib/editor/file-icon';
 import { useDelayedBoolean } from '@renderer/lib/hooks/use-delay-boolean';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
+import { isFileTabLoading } from './file-tab-loading';
 import type { FileTabResource } from './stores/file-tab-resource';
 
 function fileTabErrorTooltip(diskStatus: string, diskUri: string): string | undefined {
@@ -37,9 +38,17 @@ export const FileTabBarItem = observer(function FileTabBarItem({
 
   const bufferUri = resource.bufferUri;
   const diskUri = bufferUri ? modelRegistry.toDiskUri(bufferUri) : '';
-  const diskStatus = diskUri ? (modelRegistry.modelStatus.get(diskUri) ?? 'loading') : 'loading';
+  const diskStatus = diskUri ? modelRegistry.modelStatus.get(diskUri) : undefined;
   const hasFileIssue = diskStatus === 'error' || diskStatus === 'too-large';
-  const showSpinner = useDelayedBoolean(isMonacoFile && diskStatus === 'loading', 200);
+  const showSpinner = useDelayedBoolean(
+    isFileTabLoading({
+      isExternal: resource.isExternal,
+      isExternalLoading: resource.isLoading,
+      isMonacoFile,
+      diskStatus,
+    }),
+    200
+  );
 
   const errorTooltip = hasFileIssue ? fileTabErrorTooltip(diskStatus, diskUri) : undefined;
   const tooltip = errorTooltip ? `${resource.path} — ${errorTooltip}` : resource.path;

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-loading.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-loading.test.ts
@@ -52,5 +52,14 @@ describe('isFileTabLoading', () => {
         diskStatus: 'ready',
       })
     ).toBe(false);
+    // Model not yet tracked in the registry (initial open) should still spin.
+    expect(
+      isFileTabLoading({
+        isExternal: false,
+        isExternalLoading: false,
+        isMonacoFile: true,
+        diskStatus: undefined,
+      })
+    ).toBe(true);
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-loading.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-loading.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest';
+import { isFileTabLoading } from './file-tab-loading';
+
+describe('isFileTabLoading', () => {
+  it('stops loading an external file after its content has loaded', () => {
+    expect(
+      isFileTabLoading({
+        isExternal: true,
+        isExternalLoading: false,
+        isMonacoFile: true,
+        diskStatus: undefined,
+      })
+    ).toBe(false);
+  });
+
+  it('shows loading while an external file is being read', () => {
+    expect(
+      isFileTabLoading({
+        isExternal: true,
+        isExternalLoading: true,
+        isMonacoFile: true,
+        diskStatus: undefined,
+      })
+    ).toBe(true);
+  });
+
+  it('does not use the Monaco spinner for external non-Monaco files', () => {
+    expect(
+      isFileTabLoading({
+        isExternal: true,
+        isExternalLoading: true,
+        isMonacoFile: false,
+        diskStatus: undefined,
+      })
+    ).toBe(false);
+  });
+
+  it('uses the Monaco disk status for workspace files', () => {
+    expect(
+      isFileTabLoading({
+        isExternal: false,
+        isExternalLoading: false,
+        isMonacoFile: true,
+        diskStatus: 'loading',
+      })
+    ).toBe(true);
+    expect(
+      isFileTabLoading({
+        isExternal: false,
+        isExternalLoading: false,
+        isMonacoFile: true,
+        diskStatus: 'ready',
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-loading.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/file-tab-loading.ts
@@ -1,0 +1,18 @@
+import type { ModelStatus } from '@renderer/lib/monaco/monaco-model-registry';
+
+interface FileTabLoadingState {
+  isExternal: boolean;
+  isExternalLoading: boolean;
+  isMonacoFile: boolean;
+  diskStatus: ModelStatus | undefined;
+}
+
+export function isFileTabLoading({
+  isExternal,
+  isExternalLoading,
+  isMonacoFile,
+  diskStatus,
+}: FileTabLoadingState): boolean {
+  if (isExternal) return isMonacoFile && isExternalLoading;
+  return isMonacoFile && (diskStatus ?? 'loading') === 'loading';
+}


### PR DESCRIPTION
### Description

Stops the file-tab loading spinner from remaining visible after an external Markdown file has finished loading.

External files now use their resource loading state, while workspace files continue to use the Monaco disk model status. Adds focused coverage for both paths.

### Related issues
ENG-1806

### Screenshot/Recording (if applicable)

https://cap.link/hv9g954ahp6yedg

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>