### PR TITLE
fix(mimocode): use native install command

### DIFF
--- a/packages/plugins/src/agents/impl/mimocode/index.test.ts
+++ b/packages/plugins/src/agents/impl/mimocode/index.test.ts
@@ -3,24 +3,31 @@ import { describe, expect, it } from 'vitest';
 import { pluginRegistry } from '../../registry';
 
 const mimocode = pluginRegistry.get('mimocode')!;
+const hostDependency = mimocode.capabilities.hostDependency;
 
 function build(ctx: CommandContext) {
   return mimocode.behavior.prompt!.buildCommand(ctx);
 }
 
 describe('mimocode plugin', () => {
-  it('registers the native installer as recommended with npm as a fallback', () => {
-    expect(mimocode.metadata.websiteUrl).toBe('https://github.com/XiaomiMiMo/MiMo-Code');
-    expect(mimocode.capabilities.hostDependency.binaryNames).toEqual(['mimo']);
+  it.each([
+    ['macos', 'curl -fsSL https://mimo.xiaomi.com/install | bash'],
+    ['linux', 'curl -fsSL https://mimo.xiaomi.com/install | bash'],
+    ['windows', 'powershell -ep Bypass -c "irm https://mimo.xiaomi.com/install.ps1 | iex"'],
+  ] as const)('registers the native %s installer as recommended', (platform, command) => {
     expect(
-      mimocode.capabilities.hostDependency.installCommands.macos?.find(
-        (option) => option.recommended
-      )?.command
-    ).toBe('curl -fsSL https://mimo.xiaomi.com/install | bash');
-    expect(mimocode.capabilities.hostDependency.installCommands.macos?.[0]?.command).toBe(
-      'npm install -g @mimo-ai/cli'
-    );
-    expect(mimocode.capabilities.hostDependency.updates).toMatchObject({
+      hostDependency.installCommands[platform]?.find((option) => option.recommended)
+    ).toMatchObject({
+      command,
+      uninstallCommand: 'mimo uninstall --keep-config --keep-data --force',
+    });
+  });
+
+  it('keeps npm as an install and update fallback', () => {
+    expect(mimocode.metadata.websiteUrl).toBe('https://github.com/XiaomiMiMo/MiMo-Code');
+    expect(hostDependency.binaryNames).toEqual(['mimo']);
+    expect(hostDependency.installCommands.macos?.[0]?.command).toBe('npm install -g @mimo-ai/cli');
+    expect(hostDependency.updates).toMatchObject({
       kind: 'supported',
       releaseSource: { kind: 'npm', package: '@mimo-ai/cli' },
     });

--- a/packages/plugins/src/agents/impl/mimocode/index.test.ts
+++ b/packages/plugins/src/agents/impl/mimocode/index.test.ts
@@ -12,34 +12,13 @@ describe('mimocode plugin', () => {
   it('registers the native installer as recommended with npm as a fallback', () => {
     expect(mimocode.metadata.websiteUrl).toBe('https://github.com/XiaomiMiMo/MiMo-Code');
     expect(mimocode.capabilities.hostDependency.binaryNames).toEqual(['mimo']);
-    expect(mimocode.capabilities.hostDependency.installCommands).toMatchObject({
-      macos: [
-        { method: 'npm', command: 'npm install -g @mimo-ai/cli' },
-        {
-          method: 'curl',
-          command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
-          recommended: true,
-        },
-      ],
-      linux: [
-        { method: 'npm', command: 'npm install -g @mimo-ai/cli' },
-        {
-          method: 'curl',
-          command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
-          recommended: true,
-        },
-      ],
-      windows: [
-        { method: 'npm', command: 'npm install -g @mimo-ai/cli' },
-        {
-          method: 'powershell',
-          command: 'powershell -ep Bypass -c "irm https://mimo.xiaomi.com/install.ps1 | iex"',
-          recommended: true,
-        },
-      ],
-    });
-    expect(mimocode.capabilities.hostDependency.installCommands.macos?.[0]?.recommended).toBe(
-      undefined
+    expect(
+      mimocode.capabilities.hostDependency.installCommands.macos?.find(
+        (option) => option.recommended
+      )?.command
+    ).toBe('curl -fsSL https://mimo.xiaomi.com/install | bash');
+    expect(mimocode.capabilities.hostDependency.installCommands.macos?.[0]?.command).toBe(
+      'npm install -g @mimo-ai/cli'
     );
     expect(mimocode.capabilities.hostDependency.updates).toMatchObject({
       kind: 'supported',

--- a/packages/plugins/src/agents/impl/mimocode/index.test.ts
+++ b/packages/plugins/src/agents/impl/mimocode/index.test.ts
@@ -9,11 +9,37 @@ function build(ctx: CommandContext) {
 }
 
 describe('mimocode plugin', () => {
-  it('registers current install metadata and binary name', () => {
+  it('registers the native installer as recommended with npm as a fallback', () => {
     expect(mimocode.metadata.websiteUrl).toBe('https://github.com/XiaomiMiMo/MiMo-Code');
     expect(mimocode.capabilities.hostDependency.binaryNames).toEqual(['mimo']);
-    expect(mimocode.capabilities.hostDependency.installCommands.macos?.[0]?.command).toBe(
-      'npm install -g @mimo-ai/cli'
+    expect(mimocode.capabilities.hostDependency.installCommands).toMatchObject({
+      macos: [
+        { method: 'npm', command: 'npm install -g @mimo-ai/cli' },
+        {
+          method: 'curl',
+          command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
+          recommended: true,
+        },
+      ],
+      linux: [
+        { method: 'npm', command: 'npm install -g @mimo-ai/cli' },
+        {
+          method: 'curl',
+          command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
+          recommended: true,
+        },
+      ],
+      windows: [
+        { method: 'npm', command: 'npm install -g @mimo-ai/cli' },
+        {
+          method: 'powershell',
+          command: 'powershell -ep Bypass -c "irm https://mimo.xiaomi.com/install.ps1 | iex"',
+          recommended: true,
+        },
+      ],
+    });
+    expect(mimocode.capabilities.hostDependency.installCommands.macos?.[0]?.recommended).toBe(
+      undefined
     );
     expect(mimocode.capabilities.hostDependency.updates).toMatchObject({
       kind: 'supported',

--- a/packages/plugins/src/agents/impl/mimocode/index.ts
+++ b/packages/plugins/src/agents/impl/mimocode/index.ts
@@ -36,7 +36,35 @@ export const plugin = definePlugin(
       scope: 'workspace',
       supportedEvents: ['notification', 'stop', 'session'],
     },
-    hostDependency: npmDependency({ id: 'mimo', package: '@mimo-ai/cli' }),
+    hostDependency: npmDependency({
+      id: 'mimo',
+      package: '@mimo-ai/cli',
+      recommended: false,
+      installDocs: 'https://github.com/XiaomiMiMo/MiMo-Code#quick-start',
+      extraOptions: {
+        macos: [
+          {
+            method: 'curl',
+            command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
+            recommended: true,
+          },
+        ],
+        linux: [
+          {
+            method: 'curl',
+            command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
+            recommended: true,
+          },
+        ],
+        windows: [
+          {
+            method: 'powershell',
+            command: 'powershell -ep Bypass -c "irm https://mimo.xiaomi.com/install.ps1 | iex"',
+            recommended: true,
+          },
+        ],
+      },
+    }),
     mcp: {
       kind: 'supported',
       scope: 'global',

--- a/packages/plugins/src/agents/impl/mimocode/index.ts
+++ b/packages/plugins/src/agents/impl/mimocode/index.ts
@@ -46,6 +46,7 @@ export const plugin = definePlugin(
           {
             method: 'curl',
             command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
+            uninstallCommand: 'mimo uninstall --keep-config --keep-data --force',
             recommended: true,
           },
         ],
@@ -53,6 +54,7 @@ export const plugin = definePlugin(
           {
             method: 'curl',
             command: 'curl -fsSL https://mimo.xiaomi.com/install | bash',
+            uninstallCommand: 'mimo uninstall --keep-config --keep-data --force',
             recommended: true,
           },
         ],
@@ -60,6 +62,7 @@ export const plugin = definePlugin(
           {
             method: 'powershell',
             command: 'powershell -ep Bypass -c "irm https://mimo.xiaomi.com/install.ps1 | iex"',
+            uninstallCommand: 'mimo uninstall --keep-config --keep-data --force',
             recommended: true,
           },
         ],


### PR DESCRIPTION
### Description

Use MiMo Code's official native installer as the recommended installation method on macOS, Linux, and Windows. Keep `npm install -g @mimo-ai/cli` available as a fallback and link to the upstream quick-start documentation.

This avoids relying on the npm package's postinstall path for the default setup and matches MiMo Code's current installation guidance.

### Related issues

[ENG-1808](https://linear.app/general-action/issue/ENG-1808/install-command-for-mimo-code-does-not-work)

### Testing

- Manual macOS lifecycle test:
  - removed the existing `~/.mimocode/bin/mimo` binary and verified `mimo` was no longer on `PATH`
  - ran `curl -fsSL https://mimo.xiaomi.com/install | bash`
  - verified the installer placed `mimo` at `~/.mimocode/bin/mimo`
  - verified `mimo --version` reports `0.1.5`
  - verified `mimo --help` completes successfully

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
