### PR TITLE
fix(codex): track activity after prompt submission

### DIFF
--- a/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.test.ts
@@ -5,7 +5,7 @@ vi.mock('@main/core/agents/plugin-registry', () => ({
   getPlugin: vi.fn((id: string) => ({
     capabilities: {
       hooks:
-        id === 'amp'
+        id === 'amp' || id === 'codex'
           ? { kind: 'plugin', scope: 'workspace', supportedEvents: ['start', 'stop', 'session'] }
           : {
               kind: 'config',
@@ -24,9 +24,10 @@ vi.mock('@main/db/client', () => ({
 describe('providerSupportsNativeStartHook', () => {
   it('detects providers that emit native start hooks', () => {
     expect(providerSupportsNativeStartHook('amp')).toBe(true);
+    expect(providerSupportsNativeStartHook('codex')).toBe(true);
   });
 
   it('does not treat other hook support as native start support', () => {
-    expect(providerSupportsNativeStartHook('codex')).toBe(false);
+    expect(providerSupportsNativeStartHook('other')).toBe(false);
   });
 });

--- a/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.test.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.test.ts
@@ -5,13 +5,19 @@ vi.mock('@main/core/agents/plugin-registry', () => ({
   getPlugin: vi.fn((id: string) => ({
     capabilities: {
       hooks:
-        id === 'amp' || id === 'codex'
+        id === 'amp'
           ? { kind: 'plugin', scope: 'workspace', supportedEvents: ['start', 'stop', 'session'] }
-          : {
-              kind: 'config',
-              scope: 'global',
-              supportedEvents: ['notification', 'stop', 'session'],
-            },
+          : id === 'codex'
+            ? {
+                kind: 'config',
+                scope: 'global',
+                supportedEvents: ['start', 'notification', 'stop', 'session'],
+              }
+            : {
+                kind: 'config',
+                scope: 'global',
+                supportedEvents: ['notification', 'stop', 'session'],
+              },
     },
   })),
   isValidProviderId: vi.fn((value: unknown) => typeof value === 'string'),

--- a/apps/emdash-desktop/src/main/core/conversations/createConversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/createConversation.ts
@@ -13,7 +13,10 @@ import {
   type Conversation,
   type CreateConversationParams,
 } from '@shared/core/conversations/conversations';
-import { agentHookService } from '../agent-hooks/agent-hook-service';
+import {
+  agentHookService,
+  providerSupportsNativeStartHook,
+} from '../agent-hooks/agent-hook-service';
 import { isAppFocused } from '../agent-hooks/notification';
 import { resolveTask } from '../projects/utils';
 import { conversationEvents } from './conversation-events';
@@ -25,7 +28,7 @@ function emitInitialPromptStarted(
   conversation: Conversation,
   params: CreateConversationParams
 ): void {
-  if (!params.initialPrompt?.trim()) return;
+  if (!params.initialPrompt?.trim() || providerSupportsNativeStartHook(params.provider)) return;
 
   const agentEvent: AgentEvent = {
     type: 'start',

--- a/apps/emdash-desktop/src/main/core/tasks/operations/createTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/createTask.ts
@@ -1,7 +1,10 @@
 import crypto from 'node:crypto';
 import { err, ok, type Result } from '@emdash/shared';
 import { eq, sql } from 'drizzle-orm';
-import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
+import {
+  agentHookService,
+  providerSupportsNativeStartHook,
+} from '@main/core/agent-hooks/agent-hook-service';
 import { isAppFocused } from '@main/core/agent-hooks/notification';
 import { mapConversationRowToConversation } from '@main/core/conversations/utils';
 import { projectManager } from '@main/core/projects/project-manager';
@@ -28,7 +31,13 @@ function emitInitialPtyPromptStarted(
   prepared: PreparedCreateTask
 ): void {
   const initialConversation = prepared.params.taskConfig.initialConversation;
-  if (conversation.type !== 'pty' || !initialConversation?.initialPrompt?.trim()) return;
+  if (
+    conversation.type !== 'pty' ||
+    !initialConversation?.initialPrompt?.trim() ||
+    providerSupportsNativeStartHook(conversation.providerId)
+  ) {
+    return;
+  }
 
   const agentEvent: AgentEvent = {
     type: 'start',

--- a/packages/plugins/src/agents/impl/codex/hooks.test.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.test.ts
@@ -67,6 +67,8 @@ describe('buildCodexHookConfig', () => {
     expect(config).toContain('model = "gpt-5"');
     expect(config).toContain('echo user-stop');
     expect(config).toContain('echo user-prompt');
+    expect(config).toContain('UserPromptSubmit');
+    expect(config).toContain('X-Emdash-Event-Type: start');
     expect(config).toContain('notification_type');
     expect(config).toContain('session-start');
   });

--- a/packages/plugins/src/agents/impl/codex/hooks.test.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.test.ts
@@ -28,6 +28,12 @@ function createMemoryFs(initial: Record<string, string> = {}): PluginFs & {
 }
 
 describe('buildCodexHookConfig', () => {
+  it('parses the configured start hook event', () => {
+    const hooks = buildCodexHookConfig();
+
+    expect(hooks.parseHookEvent('start', {})).toEqual({ kind: 'status', type: 'start' });
+  });
+
   it('writes Codex hooks to config.toml and removes legacy hooks.json', async () => {
     const fs = createMemoryFs({
       [CODEX_CONFIG_PATH]: 'model = "gpt-5"\n',

--- a/packages/plugins/src/agents/impl/codex/hooks.ts
+++ b/packages/plugins/src/agents/impl/codex/hooks.ts
@@ -7,6 +7,7 @@ import {
   filterUserHooks,
   makeHookPostCommand,
   makeNotificationHookCommand,
+  makeStdinHookCommand,
   readJsonConfig,
   readTomlConfig,
   writeJsonConfig,
@@ -65,7 +66,7 @@ function getHooks(config: Record<string, unknown>): Record<string, unknown[]> {
 }
 
 function hasCodexEmdashHooks(hooks: Record<string, unknown[]>): boolean {
-  return ['Stop', 'PermissionRequest', 'SessionStart'].some((k) => {
+  return ['UserPromptSubmit', 'Stop', 'PermissionRequest', 'SessionStart'].some((k) => {
     const entries = Array.isArray(hooks[k]) ? hooks[k] : [];
     return entries.some((e) => JSON.stringify(e).includes(EMDASH_MARKER));
   });
@@ -133,6 +134,7 @@ function parseCodexHookEvent(eventType: string, body: Record<string, unknown>): 
 }
 
 export function buildCodexHookConfig() {
+  const startCmd = makeStdinHookCommand('start');
   const stopCmd = makeNotificationHookCommand('idle_prompt');
   const permCmd = makeNotificationHookCommand('permission_prompt');
   const sessionCmd = makeCodexSessionStartCommand();
@@ -154,6 +156,7 @@ export function buildCodexHookConfig() {
       const cleanupLegacy = await migrateLegacyHooks(fs, hooks);
 
       for (const [key, cmd] of [
+        ['UserPromptSubmit', startCmd],
         ['Stop', stopCmd],
         ['PermissionRequest', permCmd],
         ['SessionStart', sessionCmd],

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -89,7 +89,7 @@ export const plugin = definePlugin(
     hooks: {
       kind: 'config',
       scope: 'global',
-      supportedEvents: ['notification', 'stop', 'session'],
+      supportedEvents: ['start', 'notification', 'stop', 'session'],
     },
     hostDependency: npmDependency({
       id: 'codex',


### PR DESCRIPTION
### Description

Fixes Codex remaining marked as active when its update prompt appears before the user's prompt is submitted.

Codex now installs a `UserPromptSubmit` start hook and declares native start-hook support. Providers with native start hooks no longer receive the synthetic initial working event when a task or conversation is created, so an update prompt cannot leave activity stuck in the working state. Existing user-defined Codex hooks remain preserved.

### Related issues

ENG-1805

### Screenshot/Recording (if applicable)

[Screen recording](https://cap.link/q4q1z7ng85c2hcp)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not required for this behavior fix
- [x] I added or updated tests for the changed behavior
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for the commit message and PR title

</details>
