### PR TITLE
fix(watch): serialize native watcher restarts

### DIFF
--- a/packages/core/src/watch/native-watch.test.ts
+++ b/packages/core/src/watch/native-watch.test.ts
@@ -136,7 +136,9 @@ describe('NativeWatch', () => {
 
     callbacks[1](new Error('Replacement failed immediately'), []);
     replacement.resolve({ unsubscribe: unsubscribes[1] });
-    await vi.advanceTimersByTimeAsync(500);
+    await vi.advanceTimersByTimeAsync(249);
+    expect(watcherMock.subscribe).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
     await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(3));
 
     expect(unsubscribes[1]).toHaveBeenCalledOnce();
@@ -160,6 +162,20 @@ describe('NativeWatch', () => {
     expect(firstUnsubscribe).toHaveBeenCalledOnce();
     await watch.dispose();
     expect(finalUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('does not unsubscribe twice when stopping the previous subscription fails', async () => {
+    const unsubscribe = vi.fn().mockRejectedValue(new Error('Failed to stop watcher'));
+    queueSubscription({ unsubscribe });
+    const watch = await openWatch();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce());
+
+    await expect(watch.dispose()).resolves.toBeUndefined();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(watcherMock.subscribe).toHaveBeenCalledOnce();
   });
 
   it('does not create a replacement when disposed during unsubscribe', async () => {

--- a/packages/core/src/watch/native-watch.test.ts
+++ b/packages/core/src/watch/native-watch.test.ts
@@ -1,0 +1,242 @@
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import type parcelWatcher from '@parcel/watcher';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NativeWatch } from './native-watch';
+
+const watcherMock = vi.hoisted(() => ({
+  subscribe: vi.fn<typeof parcelWatcher.subscribe>(),
+}));
+
+vi.mock('@parcel/watcher', () => ({
+  default: {
+    subscribe: watcherMock.subscribe,
+  },
+}));
+
+type SubscribeCallback = Parameters<typeof parcelWatcher.subscribe>[1];
+
+function deferred(): {
+  promise: Promise<void>;
+  resolve: () => void;
+} {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
+
+describe('NativeWatch', () => {
+  let root: string;
+  let callbacks: SubscribeCallback[];
+
+  beforeEach(async () => {
+    vi.useFakeTimers();
+    root = await mkdtemp(path.join(tmpdir(), 'emdash-native-watch-'));
+    callbacks = [];
+    watcherMock.subscribe.mockReset();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('coalesces dropped-event errors into a resync without replacing the subscription', async () => {
+    const unsubscribe = vi.fn(async () => {});
+    watcherMock.subscribe.mockImplementation(async (_root, callback) => {
+      callbacks.push(callback);
+      return { unsubscribe };
+    });
+    const resync = vi.fn();
+    const onError = vi.fn();
+    const watch = new NativeWatch(root, [], vi.fn(), resync, onError);
+    await watch.ready();
+
+    const dropped = new Error(
+      'Events were dropped by the FSEvents client. File system must be re-scanned.'
+    );
+    callbacks[0](dropped, []);
+    callbacks[0](dropped, []);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(onError).toHaveBeenCalledTimes(2);
+    expect(resync).toHaveBeenCalledOnce();
+    expect(watcherMock.subscribe).toHaveBeenCalledOnce();
+    expect(unsubscribe).not.toHaveBeenCalled();
+
+    await watch.dispose();
+  });
+
+  it('unsubscribes the previous subscription before starting a replacement', async () => {
+    const stopped = deferred();
+    const firstUnsubscribe = vi.fn(() => stopped.promise);
+    const secondUnsubscribe = vi.fn(async () => {});
+    watcherMock.subscribe
+      .mockImplementationOnce(async (_root, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: firstUnsubscribe };
+      })
+      .mockImplementationOnce(async (_root, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: secondUnsubscribe };
+      });
+    const resync = vi.fn();
+    const watch = new NativeWatch(root, [], vi.fn(), resync, vi.fn());
+    await watch.ready();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+
+    expect(firstUnsubscribe).toHaveBeenCalledOnce();
+    expect(watcherMock.subscribe).toHaveBeenCalledOnce();
+
+    callbacks[0](new Error('Late failure during unsubscribe'), []);
+    stopped.resolve();
+    await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(500);
+    expect(watcherMock.subscribe).toHaveBeenCalledTimes(2);
+    expect(resync).toHaveBeenCalledOnce();
+
+    await watch.dispose();
+    expect(secondUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('ignores errors delivered by a stale subscription callback', async () => {
+    const subscriptions = [vi.fn(async () => {}), vi.fn(async () => {})];
+    watcherMock.subscribe.mockImplementation(async (_root, callback) => {
+      callbacks.push(callback);
+      const unsubscribe = subscriptions[callbacks.length - 1];
+      if (!unsubscribe) throw new Error('Unexpected subscription');
+      return { unsubscribe };
+    });
+    const watch = new NativeWatch(root, [], vi.fn(), vi.fn(), vi.fn());
+    await watch.ready();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(2));
+
+    callbacks[0](new Error('Late failure from old watcher'), []);
+    await vi.advanceTimersByTimeAsync(30_000);
+
+    expect(watcherMock.subscribe).toHaveBeenCalledTimes(2);
+    await watch.dispose();
+  });
+
+  it('retries an error reported while the replacement subscription is starting', async () => {
+    let resolveReplacement!: (subscription: parcelWatcher.AsyncSubscription) => void;
+    const replacement = new Promise<parcelWatcher.AsyncSubscription>((resolve) => {
+      resolveReplacement = resolve;
+    });
+    const unsubscribes = [vi.fn(async () => {}), vi.fn(async () => {}), vi.fn(async () => {})];
+    watcherMock.subscribe
+      .mockImplementationOnce(async (_root, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: unsubscribes[0] };
+      })
+      .mockImplementationOnce((_root, callback) => {
+        callbacks.push(callback);
+        return replacement;
+      })
+      .mockImplementationOnce(async (_root, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: unsubscribes[2] };
+      });
+    const watch = new NativeWatch(root, [], vi.fn(), vi.fn(), vi.fn());
+    await watch.ready();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(2));
+
+    callbacks[1](new Error('Replacement failed immediately'), []);
+    resolveReplacement({ unsubscribe: unsubscribes[1] });
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(3));
+
+    expect(unsubscribes[1]).toHaveBeenCalledOnce();
+    await watch.dispose();
+  });
+
+  it('retries when creating the replacement subscription fails', async () => {
+    const firstUnsubscribe = vi.fn(async () => {});
+    const finalUnsubscribe = vi.fn(async () => {});
+    watcherMock.subscribe
+      .mockImplementationOnce(async (_root, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: firstUnsubscribe };
+      })
+      .mockRejectedValueOnce(new Error('Replacement setup failed'))
+      .mockImplementationOnce(async (_root, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: finalUnsubscribe };
+      });
+    const watch = new NativeWatch(root, [], vi.fn(), vi.fn(), vi.fn());
+    await watch.ready();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(2));
+    await vi.advanceTimersByTimeAsync(500);
+    await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(3));
+
+    expect(firstUnsubscribe).toHaveBeenCalledOnce();
+    await watch.dispose();
+    expect(finalUnsubscribe).toHaveBeenCalledOnce();
+  });
+
+  it('does not create a replacement when disposed during unsubscribe', async () => {
+    const stopped = deferred();
+    const unsubscribe = vi.fn(() => stopped.promise);
+    watcherMock.subscribe.mockImplementationOnce(async (_root, callback) => {
+      callbacks.push(callback);
+      return { unsubscribe };
+    });
+    const resync = vi.fn();
+    const watch = new NativeWatch(root, [], vi.fn(), resync, vi.fn());
+    await watch.ready();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    const disposed = watch.dispose();
+    stopped.resolve();
+    await disposed;
+
+    expect(watcherMock.subscribe).toHaveBeenCalledOnce();
+    expect(unsubscribe).toHaveBeenCalledOnce();
+    expect(resync).not.toHaveBeenCalled();
+  });
+
+  it('disposes a replacement that finishes subscribing during disposal', async () => {
+    let resolveReplacement!: (subscription: parcelWatcher.AsyncSubscription) => void;
+    const replacement = new Promise<parcelWatcher.AsyncSubscription>((resolve) => {
+      resolveReplacement = resolve;
+    });
+    const replacementUnsubscribe = vi.fn(async () => {});
+    watcherMock.subscribe
+      .mockImplementationOnce(async (_root, callback) => {
+        callbacks.push(callback);
+        return { unsubscribe: vi.fn(async () => {}) };
+      })
+      .mockImplementationOnce((_root, callback) => {
+        callbacks.push(callback);
+        return replacement;
+      });
+    const resync = vi.fn();
+    const watch = new NativeWatch(root, [], vi.fn(), resync, vi.fn());
+    await watch.ready();
+
+    callbacks[0](new Error('Watcher failed'), []);
+    await vi.advanceTimersByTimeAsync(250);
+    await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(2));
+    const disposed = watch.dispose();
+    resolveReplacement({ unsubscribe: replacementUnsubscribe });
+    await disposed;
+
+    expect(replacementUnsubscribe).toHaveBeenCalledOnce();
+    expect(watcherMock.subscribe).toHaveBeenCalledTimes(2);
+    expect(resync).not.toHaveBeenCalled();
+  });
+});

--- a/packages/core/src/watch/native-watch.test.ts
+++ b/packages/core/src/watch/native-watch.test.ts
@@ -17,12 +17,12 @@ vi.mock('@parcel/watcher', () => ({
 
 type SubscribeCallback = Parameters<typeof parcelWatcher.subscribe>[1];
 
-function deferred(): {
-  promise: Promise<void>;
-  resolve: () => void;
+function deferred<T = void>(): {
+  promise: Promise<T>;
+  resolve: (value: T) => void;
 } {
-  let resolve!: () => void;
-  const promise = new Promise<void>((done) => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => {
     resolve = done;
   });
   return { promise, resolve };
@@ -39,20 +39,31 @@ describe('NativeWatch', () => {
     watcherMock.subscribe.mockReset();
   });
 
+  function queueSubscription(
+    subscription: parcelWatcher.AsyncSubscription | Promise<parcelWatcher.AsyncSubscription>
+  ): void {
+    watcherMock.subscribe.mockImplementationOnce((_root, callback) => {
+      callbacks.push(callback);
+      return Promise.resolve(subscription);
+    });
+  }
+
+  async function openWatch(resync = vi.fn(), onError = vi.fn()): Promise<NativeWatch> {
+    const watch = new NativeWatch(root, [], vi.fn(), resync, onError);
+    await watch.ready();
+    return watch;
+  }
+
   afterEach(() => {
     vi.useRealTimers();
   });
 
   it('coalesces dropped-event errors into a resync without replacing the subscription', async () => {
     const unsubscribe = vi.fn(async () => {});
-    watcherMock.subscribe.mockImplementation(async (_root, callback) => {
-      callbacks.push(callback);
-      return { unsubscribe };
-    });
+    queueSubscription({ unsubscribe });
     const resync = vi.fn();
     const onError = vi.fn();
-    const watch = new NativeWatch(root, [], vi.fn(), resync, onError);
-    await watch.ready();
+    const watch = await openWatch(resync, onError);
 
     const dropped = new Error(
       'Events were dropped by the FSEvents client. File system must be re-scanned.'
@@ -73,18 +84,10 @@ describe('NativeWatch', () => {
     const stopped = deferred();
     const firstUnsubscribe = vi.fn(() => stopped.promise);
     const secondUnsubscribe = vi.fn(async () => {});
-    watcherMock.subscribe
-      .mockImplementationOnce(async (_root, callback) => {
-        callbacks.push(callback);
-        return { unsubscribe: firstUnsubscribe };
-      })
-      .mockImplementationOnce(async (_root, callback) => {
-        callbacks.push(callback);
-        return { unsubscribe: secondUnsubscribe };
-      });
+    queueSubscription({ unsubscribe: firstUnsubscribe });
+    queueSubscription({ unsubscribe: secondUnsubscribe });
     const resync = vi.fn();
-    const watch = new NativeWatch(root, [], vi.fn(), resync, vi.fn());
-    await watch.ready();
+    const watch = await openWatch(resync);
 
     callbacks[0](new Error('Watcher failed'), []);
     await vi.advanceTimersByTimeAsync(250);
@@ -104,15 +107,9 @@ describe('NativeWatch', () => {
   });
 
   it('ignores errors delivered by a stale subscription callback', async () => {
-    const subscriptions = [vi.fn(async () => {}), vi.fn(async () => {})];
-    watcherMock.subscribe.mockImplementation(async (_root, callback) => {
-      callbacks.push(callback);
-      const unsubscribe = subscriptions[callbacks.length - 1];
-      if (!unsubscribe) throw new Error('Unexpected subscription');
-      return { unsubscribe };
-    });
-    const watch = new NativeWatch(root, [], vi.fn(), vi.fn(), vi.fn());
-    await watch.ready();
+    queueSubscription({ unsubscribe: vi.fn(async () => {}) });
+    queueSubscription({ unsubscribe: vi.fn(async () => {}) });
+    const watch = await openWatch();
 
     callbacks[0](new Error('Watcher failed'), []);
     await vi.advanceTimersByTimeAsync(250);
@@ -126,33 +123,19 @@ describe('NativeWatch', () => {
   });
 
   it('retries an error reported while the replacement subscription is starting', async () => {
-    let resolveReplacement!: (subscription: parcelWatcher.AsyncSubscription) => void;
-    const replacement = new Promise<parcelWatcher.AsyncSubscription>((resolve) => {
-      resolveReplacement = resolve;
-    });
+    const replacement = deferred<parcelWatcher.AsyncSubscription>();
     const unsubscribes = [vi.fn(async () => {}), vi.fn(async () => {}), vi.fn(async () => {})];
-    watcherMock.subscribe
-      .mockImplementationOnce(async (_root, callback) => {
-        callbacks.push(callback);
-        return { unsubscribe: unsubscribes[0] };
-      })
-      .mockImplementationOnce((_root, callback) => {
-        callbacks.push(callback);
-        return replacement;
-      })
-      .mockImplementationOnce(async (_root, callback) => {
-        callbacks.push(callback);
-        return { unsubscribe: unsubscribes[2] };
-      });
-    const watch = new NativeWatch(root, [], vi.fn(), vi.fn(), vi.fn());
-    await watch.ready();
+    queueSubscription({ unsubscribe: unsubscribes[0] });
+    queueSubscription(replacement.promise);
+    queueSubscription({ unsubscribe: unsubscribes[2] });
+    const watch = await openWatch();
 
     callbacks[0](new Error('Watcher failed'), []);
     await vi.advanceTimersByTimeAsync(250);
     await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(2));
 
     callbacks[1](new Error('Replacement failed immediately'), []);
-    resolveReplacement({ unsubscribe: unsubscribes[1] });
+    replacement.resolve({ unsubscribe: unsubscribes[1] });
     await vi.advanceTimersByTimeAsync(500);
     await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(3));
 
@@ -163,18 +146,10 @@ describe('NativeWatch', () => {
   it('retries when creating the replacement subscription fails', async () => {
     const firstUnsubscribe = vi.fn(async () => {});
     const finalUnsubscribe = vi.fn(async () => {});
-    watcherMock.subscribe
-      .mockImplementationOnce(async (_root, callback) => {
-        callbacks.push(callback);
-        return { unsubscribe: firstUnsubscribe };
-      })
-      .mockRejectedValueOnce(new Error('Replacement setup failed'))
-      .mockImplementationOnce(async (_root, callback) => {
-        callbacks.push(callback);
-        return { unsubscribe: finalUnsubscribe };
-      });
-    const watch = new NativeWatch(root, [], vi.fn(), vi.fn(), vi.fn());
-    await watch.ready();
+    queueSubscription({ unsubscribe: firstUnsubscribe });
+    watcherMock.subscribe.mockRejectedValueOnce(new Error('Replacement setup failed'));
+    queueSubscription({ unsubscribe: finalUnsubscribe });
+    const watch = await openWatch();
 
     callbacks[0](new Error('Watcher failed'), []);
     await vi.advanceTimersByTimeAsync(250);
@@ -190,13 +165,9 @@ describe('NativeWatch', () => {
   it('does not create a replacement when disposed during unsubscribe', async () => {
     const stopped = deferred();
     const unsubscribe = vi.fn(() => stopped.promise);
-    watcherMock.subscribe.mockImplementationOnce(async (_root, callback) => {
-      callbacks.push(callback);
-      return { unsubscribe };
-    });
+    queueSubscription({ unsubscribe });
     const resync = vi.fn();
-    const watch = new NativeWatch(root, [], vi.fn(), resync, vi.fn());
-    await watch.ready();
+    const watch = await openWatch(resync);
 
     callbacks[0](new Error('Watcher failed'), []);
     await vi.advanceTimersByTimeAsync(250);
@@ -210,29 +181,18 @@ describe('NativeWatch', () => {
   });
 
   it('disposes a replacement that finishes subscribing during disposal', async () => {
-    let resolveReplacement!: (subscription: parcelWatcher.AsyncSubscription) => void;
-    const replacement = new Promise<parcelWatcher.AsyncSubscription>((resolve) => {
-      resolveReplacement = resolve;
-    });
+    const replacement = deferred<parcelWatcher.AsyncSubscription>();
     const replacementUnsubscribe = vi.fn(async () => {});
-    watcherMock.subscribe
-      .mockImplementationOnce(async (_root, callback) => {
-        callbacks.push(callback);
-        return { unsubscribe: vi.fn(async () => {}) };
-      })
-      .mockImplementationOnce((_root, callback) => {
-        callbacks.push(callback);
-        return replacement;
-      });
+    queueSubscription({ unsubscribe: vi.fn(async () => {}) });
+    queueSubscription(replacement.promise);
     const resync = vi.fn();
-    const watch = new NativeWatch(root, [], vi.fn(), resync, vi.fn());
-    await watch.ready();
+    const watch = await openWatch(resync);
 
     callbacks[0](new Error('Watcher failed'), []);
     await vi.advanceTimersByTimeAsync(250);
     await vi.waitFor(() => expect(watcherMock.subscribe).toHaveBeenCalledTimes(2));
     const disposed = watch.dispose();
-    resolveReplacement({ unsubscribe: replacementUnsubscribe });
+    replacement.resolve({ unsubscribe: replacementUnsubscribe });
     await disposed;
 
     expect(replacementUnsubscribe).toHaveBeenCalledOnce();

--- a/packages/core/src/watch/native-watch.ts
+++ b/packages/core/src/watch/native-watch.ts
@@ -85,7 +85,6 @@ export class NativeWatch implements IDisposable {
           this.scheduleResubscribe();
           return;
         }
-        this.retryAttempts = 0;
         if (events.length === 0) return;
         this.deliver(events.map(toWatchEvent));
       },
@@ -141,14 +140,14 @@ export class NativeWatch implements IDisposable {
     this.activeGeneration = 0;
     const previous = await previousPromise?.catch(() => null);
     if (this.disposed) return false;
+    if (this.subscription === previousPromise) this.subscription = null;
 
     try {
       await previous?.unsubscribe();
     } catch (error) {
       this.onError(`unsubscribe ${this.root}`, error);
-      return !this.disposed;
+      return false;
     }
-    if (this.subscription === previousPromise) this.subscription = null;
     if (this.disposed) return false;
 
     const next = this.subscribe();
@@ -159,12 +158,17 @@ export class NativeWatch implements IDisposable {
       this.onError(`resubscribe ${this.root}`, error);
       return true;
     }
+    this.retryAttempts = 0;
     if (this.disposed) return false;
     this.signalResync();
     return false;
   }
 }
 
+/**
+ * Matches the FSEvents dropped-events error emitted by @parcel/watcher.
+ * Keep this in sync with the upstream message; Parcel exposes no structured error code.
+ */
 function requiresResync(error: Error): boolean {
   return error.message.includes('File system must be re-scanned');
 }

--- a/packages/core/src/watch/native-watch.ts
+++ b/packages/core/src/watch/native-watch.ts
@@ -5,6 +5,7 @@ import type { WatchEvent } from './types';
 
 const RESUBSCRIBE_DELAY_MS = 250;
 const MAX_RESUBSCRIBE_DELAY_MS = 30_000;
+const RESYNC_DELAY_MS = 250;
 
 /**
  * One native subscription per (root, ignore set), shared across consumers.
@@ -19,6 +20,11 @@ export class NativeWatch implements IDisposable {
   private readonly onError: (context: string, error: unknown) => void;
   private subscription: Promise<parcelWatcher.AsyncSubscription> | null = null;
   private retryTimer: ReturnType<typeof setTimeout> | null = null;
+  private resyncTimer: ReturnType<typeof setTimeout> | null = null;
+  private restartPromise: Promise<void> | null = null;
+  private generation = 0;
+  private activeGeneration = 0;
+  private retryRequested = false;
   private retryAttempts = 0;
   private disposed = false;
 
@@ -46,22 +52,40 @@ export class NativeWatch implements IDisposable {
   async dispose(): Promise<void> {
     if (this.disposed) return;
     this.disposed = true;
+    this.activeGeneration = 0;
+    this.retryRequested = false;
     if (this.retryTimer) clearTimeout(this.retryTimer);
     this.retryTimer = null;
+    if (this.resyncTimer) clearTimeout(this.resyncTimer);
+    this.resyncTimer = null;
+    await this.restartPromise;
     const subscription = await this.subscription?.catch(() => null);
+    this.subscription = null;
     await subscription?.unsubscribe();
   }
 
   private async subscribe(): Promise<parcelWatcher.AsyncSubscription> {
     await fs.stat(this.root);
+    const generation = ++this.generation;
+    this.activeGeneration = generation;
     return parcelWatcher.subscribe(
       this.root,
       (err, events) => {
+        if (this.disposed || generation !== this.activeGeneration) return;
         if (err) {
           this.onError(`watch ${this.root}`, err);
+          if (requiresResync(err)) {
+            this.scheduleResync();
+            return;
+          }
+          if (this.restartPromise) {
+            this.retryRequested = true;
+            return;
+          }
           this.scheduleResubscribe();
           return;
         }
+        this.retryAttempts = 0;
         if (events.length === 0) return;
         this.deliver(events.map(toWatchEvent));
       },
@@ -69,8 +93,29 @@ export class NativeWatch implements IDisposable {
     );
   }
 
+  private scheduleResync(): void {
+    if (this.resyncTimer || this.disposed) return;
+    this.resyncTimer = setTimeout(() => {
+      this.resyncTimer = null;
+      this.signalResync();
+    }, RESYNC_DELAY_MS);
+  }
+
+  private signalResync(): void {
+    if (this.disposed) return;
+    try {
+      this.resync();
+    } catch (error) {
+      this.onError(`resync ${this.root}`, error);
+    }
+  }
+
   private scheduleResubscribe(): void {
     if (this.retryTimer || this.disposed) return;
+    if (this.restartPromise) {
+      this.retryRequested = true;
+      return;
+    }
     const delay = Math.min(
       RESUBSCRIBE_DELAY_MS * 2 ** this.retryAttempts,
       MAX_RESUBSCRIBE_DELAY_MS
@@ -79,21 +124,49 @@ export class NativeWatch implements IDisposable {
     this.retryTimer = setTimeout(() => {
       this.retryTimer = null;
       if (this.disposed) return;
-      const previous = this.subscription;
-      this.subscription = this.subscribe();
-      this.subscription.then(
-        () => {
-          this.retryAttempts = 0;
-          this.resync();
-        },
-        (error) => {
-          this.onError(`resubscribe ${this.root}`, error);
-          this.scheduleResubscribe();
-        }
-      );
-      void previous?.then((subscription) => subscription.unsubscribe()).catch(() => {});
+      const restart = this.restart();
+      const tracked = restart.then((shouldRetry) => {
+        const retry = shouldRetry || this.retryRequested;
+        this.retryRequested = false;
+        if (this.restartPromise === tracked) this.restartPromise = null;
+        if (retry) this.scheduleResubscribe();
+      });
+      this.restartPromise = tracked;
+      void tracked;
     }, delay);
   }
+
+  private async restart(): Promise<boolean> {
+    const previousPromise = this.subscription;
+    this.activeGeneration = 0;
+    const previous = await previousPromise?.catch(() => null);
+    if (this.disposed) return false;
+
+    try {
+      await previous?.unsubscribe();
+    } catch (error) {
+      this.onError(`unsubscribe ${this.root}`, error);
+      return !this.disposed;
+    }
+    if (this.subscription === previousPromise) this.subscription = null;
+    if (this.disposed) return false;
+
+    const next = this.subscribe();
+    this.subscription = next;
+    try {
+      await next;
+    } catch (error) {
+      this.onError(`resubscribe ${this.root}`, error);
+      return true;
+    }
+    if (this.disposed) return false;
+    this.signalResync();
+    return false;
+  }
+}
+
+function requiresResync(error: Error): boolean {
+  return error.message.includes('File system must be re-scanned');
 }
 
 function toWatchEvent(event: parcelWatcher.Event): WatchEvent {


### PR DESCRIPTION
### Description

Prevent overlapping `@parcel/watcher` subscription lifetimes during native watcher recovery.

A macOS Canary crash report showed `EXC_BAD_ACCESS` in `watcher.node` (`FSEventsCallback -> DirTree::find`) while application logs repeatedly reported dropped FSEvents requiring a filesystem rescan. The previous recovery path created the replacement subscription before the old subscription had finished unsubscribing, allowing native watcher lifetimes and queued callbacks to overlap.

This change:

- treats Parcel's `File system must be re-scanned` notification as a coalesced consumer resync instead of replacing the native watcher
- waits for the current subscription to unsubscribe before creating its replacement
- ignores callbacks from stale subscription generations
- preserves a pending retry when the replacement reports an error while restart is still in flight
- waits for in-flight restart work during disposal and cleans up a replacement that settles concurrently
- adds focused coverage for restart ordering, stale callbacks, retries, dropped events, and disposal races

Crash report: https://gist.github.com/janburzinski/2a66ec12763630b06e1e696974338ca7

### Related issues

No linked issue.

### Testing

Run with Node.js 24.14.0:

- `pnpm run format` in `packages/core`
- `pnpm exec nx run @emdash/core:typecheck`
- `pnpm exec nx run @emdash/core:lint`
- `pnpm exec vitest run src/watch/native-watch.test.ts src/watch/watch-service.test.ts` — 11/11 tests passed
- `git diff --check`

The full Core suite was also attempted locally. The watcher tests remained green, but unrelated timing-sensitive process/Git tests intermittently exceeded their existing 5-second timeouts under local load; the failing Git test cases varied between runs.

### Screenshot/Recording (if applicable)

Not applicable; this is a native watcher lifecycle fix with no UI changes.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not required for this internal lifecycle correction
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>
