### PR TITLE
feat(terminal): add copy control to external link dialog

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/components/external-link-choice-dialog.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/components/external-link-choice-dialog.test.ts
@@ -1,0 +1,26 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it, vi } from 'vitest';
+import { Dialog } from '@renderer/lib/ui/dialog';
+import { ExternalLinkChoiceDialog } from './external-link-choice-dialog';
+
+describe('ExternalLinkChoiceDialog', () => {
+  it('offers a copy action inside the displayed external link', () => {
+    const html = renderToStaticMarkup(
+      createElement(
+        Dialog,
+        { open: true },
+        createElement(ExternalLinkChoiceDialog, {
+          url: 'https://example.com/docs',
+          canOpenInEmdashBrowser: true,
+          onCopy: vi.fn(() => true),
+          onSuccess: vi.fn(),
+          onClose: vi.fn(),
+        })
+      )
+    );
+
+    expect(html).toContain('https://example.com/docs');
+    expect(html).toContain('aria-label="Copy link"');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/lib/components/external-link-choice-dialog.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/external-link-choice-dialog.tsx
@@ -1,4 +1,5 @@
-import { ExternalLink, Globe } from 'lucide-react';
+import { Check, Copy, ExternalLink, Globe } from 'lucide-react';
+import { useEffect, useRef, useState } from 'react';
 import type { BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
 import {
@@ -7,12 +8,14 @@ import {
   DialogHeader,
   DialogTitle,
 } from '@renderer/lib/ui/dialog';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 
 export type ExternalLinkChoice = 'emdash-browser' | 'external-browser';
 
 export type ExternalLinkChoiceDialogArgs = {
   url: string;
   canOpenInEmdashBrowser: boolean;
+  onCopy: () => boolean | Promise<boolean>;
 };
 
 type Props = BaseModalProps<ExternalLinkChoice> & ExternalLinkChoiceDialogArgs;
@@ -20,9 +23,30 @@ type Props = BaseModalProps<ExternalLinkChoice> & ExternalLinkChoiceDialogArgs;
 export function ExternalLinkChoiceDialog({
   url,
   canOpenInEmdashBrowser,
+  onCopy,
   onSuccess,
   onClose,
 }: Props) {
+  const [copied, setCopied] = useState(false);
+  const copyResetRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
+    },
+    []
+  );
+
+  const handleCopy = async () => {
+    if (!(await onCopy())) return;
+    setCopied(true);
+    if (copyResetRef.current !== null) window.clearTimeout(copyResetRef.current);
+    copyResetRef.current = window.setTimeout(() => {
+      setCopied(false);
+      copyResetRef.current = null;
+    }, 1_500);
+  };
+
   return (
     <>
       <DialogHeader showCloseButton={false}>
@@ -30,8 +54,33 @@ export function ExternalLinkChoiceDialog({
       </DialogHeader>
       <DialogContentArea className="space-y-4 pt-0 text-sm leading-relaxed">
         <p>Choose where to open this link.</p>
-        <div className="bg-muted/50 max-h-32 overflow-y-auto rounded-md border border-border px-3 py-2.5 font-mono text-[13px] leading-relaxed break-all text-foreground">
-          {url}
+        <div className="bg-muted/50 relative rounded-md border border-border">
+          <div className="max-h-32 overflow-y-auto px-3 py-2.5 pr-10 font-mono text-[13px] leading-relaxed break-all text-foreground">
+            {url}
+          </div>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger
+                render={
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon-sm"
+                    className="absolute top-1.5 right-1.5"
+                    aria-label={copied ? 'Link copied' : 'Copy link'}
+                    onClick={() => void handleCopy()}
+                  />
+                }
+              >
+                {copied ? (
+                  <Check className="size-4 text-foreground-success" />
+                ) : (
+                  <Copy className="size-4" />
+                )}
+              </TooltipTrigger>
+              <TooltipContent>{copied ? 'Copied' : 'Copy link'}</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </DialogContentArea>
       <DialogFooter className="flex-col-reverse sm:flex-col-reverse">

--- a/apps/emdash-desktop/src/renderer/lib/open-external-link.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/open-external-link.test.ts
@@ -1,0 +1,94 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { confirmOpenExternalLink } from './open-external-link';
+
+const mocks = vi.hoisted(() => ({
+  clipboardWriteText: vi.fn(),
+  getTaskView: vi.fn(),
+  openExternal: vi.fn(),
+  showModal: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@renderer/features/tasks/stores/task-selectors', () => ({
+  getTaskView: mocks.getTaskView,
+}));
+
+vi.mock('@renderer/lib/hooks/use-toast', () => ({
+  toast: mocks.toast,
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    app: {
+      clipboardWriteText: mocks.clipboardWriteText,
+      openExternal: mocks.openExternal,
+    },
+  },
+}));
+
+vi.mock('@renderer/lib/modal/modal-provider', () => ({
+  showModal: mocks.showModal,
+}));
+
+vi.mock('@renderer/lib/stores/app-state', () => ({
+  appState: {
+    navigation: {
+      currentViewId: 'home',
+      viewParamsStore: { task: undefined },
+    },
+  },
+}));
+
+type ExternalLinkModalArgs = {
+  url: string;
+  onCopy: () => Promise<boolean>;
+};
+
+function getModalArgs(): ExternalLinkModalArgs {
+  return mocks.showModal.mock.calls[0]?.[1] as ExternalLinkModalArgs;
+}
+
+describe('confirmOpenExternalLink', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clipboardWriteText.mockResolvedValue({ success: true });
+  });
+
+  it('copies the normalized link and reports success', async () => {
+    confirmOpenExternalLink('https://example.com/docs).');
+
+    const args = getModalArgs();
+    expect(args.url).toBe('https://example.com/docs');
+
+    await expect(args.onCopy()).resolves.toBe(true);
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith('https://example.com/docs');
+    expect(mocks.toast).toHaveBeenCalledWith({ title: 'Link copied' });
+  });
+
+  it('reports when the native clipboard write fails', async () => {
+    mocks.clipboardWriteText.mockResolvedValue({ success: false, error: 'Clipboard unavailable' });
+
+    confirmOpenExternalLink('https://example.com/docs');
+    await expect(getModalArgs().onCopy()).resolves.toBe(false);
+
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Copy failed',
+      description: 'The link could not be copied to the clipboard.',
+      variant: 'destructive',
+    });
+  });
+
+  it('reports when the clipboard request rejects', async () => {
+    mocks.clipboardWriteText.mockRejectedValue(new Error('IPC unavailable'));
+
+    confirmOpenExternalLink('https://example.com/docs');
+
+    await expect(getModalArgs().onCopy()).resolves.toBe(false);
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Copy failed',
+      description: 'The link could not be copied to the clipboard.',
+      variant: 'destructive',
+    });
+  });
+});

--- a/apps/emdash-desktop/src/renderer/lib/open-external-link.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/open-external-link.tsx
@@ -1,4 +1,5 @@
 import { getTaskView } from '@renderer/features/tasks/stores/task-selectors';
+import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { showModal } from '@renderer/lib/modal/modal-provider';
 import { appState } from '@renderer/lib/stores/app-state';
@@ -18,6 +19,7 @@ export function confirmOpenExternalLink(url: string, onError?: (error: unknown) 
   showModal('confirmExternalLinkModal', {
     url: normalizedUrl,
     canOpenInEmdashBrowser: taskView !== undefined,
+    onCopy: () => copyExternalLink(normalizedUrl),
     onSuccess: (choice) => {
       if (choice === 'emdash-browser') {
         taskView?.paneLayout.open('browser', { initialUrl: normalizedUrl });
@@ -28,6 +30,29 @@ export function confirmOpenExternalLink(url: string, onError?: (error: unknown) 
         onError?.(error);
       });
     },
+  });
+}
+
+async function copyExternalLink(url: string): Promise<boolean> {
+  try {
+    const result = await rpc.app.clipboardWriteText(url);
+    if (!result.success) {
+      showCopyFailure();
+      return false;
+    }
+    toast({ title: 'Link copied' });
+    return true;
+  } catch {
+    showCopyFailure();
+    return false;
+  }
+}
+
+function showCopyFailure(): void {
+  toast({
+    title: 'Copy failed',
+    description: 'The link could not be copied to the clipboard.',
+    variant: 'destructive',
   });
 }
 


### PR DESCRIPTION
### Description

- Add an accessible copy icon inside the URL container in the external-link confirmation dialog.
- Copy normalized links through the native Electron clipboard RPC.
- Show success feedback with a temporary checkmark and toast, and handle returned or rejected clipboard failures.
- Add focused rendering and clipboard behavior coverage.

### Related issues

- [ENG-1813](https://linear.app/general-action/issue/ENG-1813/add-copy-to-clipboard-button-for-terminal-links)

### Testing

- `corepack pnpm exec vitest run --project node` for the external-link dialog, opener, markdown renderer, terminal context link, and file-link provider tests (23 tests)
- `corepack pnpm run format:check`
- `corepack pnpm run lint`
- `corepack pnpm run typecheck`
- `corepack pnpm run build:renderer`
- `git diff --check`

### Screenshot/Recording (if applicable)

Not included. Focused rendering coverage verifies that the accessible copy control is present inside the displayed link container.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Documentation changes are not required for this UI-only behavior
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
