### PR TITLE
fix(windows): sync title bar with app theme

### DIFF
--- a/apps/emdash-desktop/src/main/app/window.ts
+++ b/apps/emdash-desktop/src/main/app/window.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { BrowserWindow } from 'electron';
+import { BrowserWindow, nativeTheme } from 'electron';
 import devIcon from '@/assets/images/emdash/emdash-dev.png?asset';
 import { browserWebContentsRegistry } from '@main/core/browser/browser-webcontents-registry';
 import {
@@ -12,10 +12,15 @@ import { log } from '@main/lib/logger';
 import { telemetryService } from '@main/lib/telemetry';
 import { registerExternalLinkHandlers } from '@main/utils/externalLinks';
 import { PRODUCT_NAME } from '@shared/app-identity';
+import type { Theme } from '@shared/core/app-settings';
 import { windowMaximizeChangedChannel } from '@shared/events/appEvents';
 import { APP_ORIGIN } from './protocol';
 
 let mainWindow: BrowserWindow | null = null;
+
+export function applyNativeTheme(theme: Theme): void {
+  nativeTheme.themeSource = theme === 'emdark' ? 'dark' : theme === 'emlight' ? 'light' : 'system';
+}
 
 export function createMainWindow(): BrowserWindow {
   mainWindow = new BrowserWindow({

--- a/apps/emdash-desktop/src/main/app/window.ts
+++ b/apps/emdash-desktop/src/main/app/window.ts
@@ -19,6 +19,7 @@ import { APP_ORIGIN } from './protocol';
 let mainWindow: BrowserWindow | null = null;
 
 export function applyNativeTheme(theme: Theme): void {
+  if (process.platform !== 'win32') return;
   nativeTheme.themeSource = theme === 'emdark' ? 'dark' : theme === 'emlight' ? 'light' : 'system';
 }
 

--- a/apps/emdash-desktop/src/main/core/settings/controller.ts
+++ b/apps/emdash-desktop/src/main/core/settings/controller.ts
@@ -1,3 +1,4 @@
+import { applyNativeTheme } from '@main/app/window';
 import { setBrowserCorsRelaxationSettings } from '@main/core/browser/browser-profile-session';
 import { browserWebContentsRegistry } from '@main/core/browser/browser-webcontents-registry';
 import { reconcileResourceSampler } from '@main/core/resource-monitor/resource-sampler';
@@ -5,6 +6,7 @@ import { createRPCController } from '@shared/lib/ipc/rpc';
 import { appSettingsService, type AppSettings, type AppSettingsKey } from './settings-service';
 
 async function reconcileSettingsRuntimeState(key: AppSettingsKey): Promise<void> {
+  if (key === 'theme') applyNativeTheme(await appSettingsService.get('theme'));
   if (key === 'resourceMonitor') await reconcileResourceSampler();
   if (key === 'keyboard') {
     // Re-read the effective settings so runtime state observes service-side defaults or merges.

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -11,7 +11,7 @@ import { LIBSECRET_PASSWORD_STORE, shouldForceLibsecretBackend } from './app/lin
 import { setupApplicationMenu } from './app/menu';
 import { registerAppScheme, setupAppProtocol } from './app/protocol';
 import { registerQuitHandler } from './app/shutdown';
-import { createMainWindow } from './app/window';
+import { applyNativeTheme, createMainWindow } from './app/window';
 import { providerTokenRegistry } from './core/account/provider-token-registry';
 import { emdashAccountService } from './core/account/services/emdash-account-service';
 import { acpAgentStatusBridge } from './core/acp/agent-status-bridge';
@@ -148,6 +148,7 @@ void app.whenReady().then(async () => {
   automationsService.start();
   appService.initialize();
   await appSettingsService.initialize();
+  applyNativeTheme(await appSettingsService.get('theme'));
   browserWebContentsRegistry.setKeyboardSettings(await appSettingsService.get('keyboard'));
   setBrowserCorsRelaxationSettings(await appSettingsService.get('browser'));
   await promptLibraryService.initialize();


### PR DESCRIPTION
### Description

Synchronizes Electron's native theme with the selected Emdash theme so the Windows title bar no longer stays light while the app is in dark mode.

The native theme is applied during startup and reconciled immediately when the theme setting changes. System theme mode continues to follow the operating-system preference.

### Related issues
ENG-1815

### Screenshot/Recording (if applicable)


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not needed for this behavior fix
- [x] No automated test was added because this behavior is provided by Electron's native Windows window decoration
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>