### PR TITLE
fix(automations): restore automation deletion

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/automations/components/AutomationsView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/AutomationsView.tsx
@@ -17,6 +17,7 @@ export function AutomationsView() {
   const [search, setSearch] = useState('');
   const [creating, setCreating] = useState(false);
   const [initialTemplate, setInitialTemplate] = useState<BuiltinAutomationTemplate | undefined>();
+  const [pendingDelete, setPendingDelete] = useState<Automation | null>(null);
   const showConfirm = useShowModal('confirmActionModal');
   const { navigate } = useNavigate();
   const { params, setParams } = useParams('automations');
@@ -50,13 +51,27 @@ export function AutomationsView() {
   }
 
   function handleDelete(automation: Automation) {
+    setPendingDelete(automation);
+    closeSheet();
+  }
+
+  function handleSheetOpenChangeComplete(open: boolean) {
+    if (open || !pendingDelete) return;
+
+    // The sheet is modal and makes sibling portals inert. Wait until it has fully closed before
+    // opening the global confirmation dialog so that the dialog remains interactive.
+    const automation = pendingDelete;
+    setPendingDelete(null);
     showConfirm({
       title: 'Delete automation',
       description: `"${automation.name}" will be permanently deleted. Run history will be preserved.`,
       confirmLabel: 'Delete',
       onSuccess: () => {
-        void destroy.mutateAsync(automation.id).then(() => closeSheet());
+        void destroy
+          .mutateAsync(automation.id)
+          .catch(() => setParams({ automationId: automation.id }));
       },
+      onClose: () => setParams({ automationId: automation.id }),
     });
   }
 
@@ -94,6 +109,7 @@ export function AutomationsView() {
       <Sheet
         open={liveAutomation !== null || creating}
         onOpenChange={(open) => !open && closeSheet()}
+        onOpenChangeComplete={handleSheetOpenChangeComplete}
       >
         <SheetContent showCloseButton={false}>
           {creating && (


### PR DESCRIPTION
### Description

Restore automation deletion by closing the modal detail sheet before opening the global confirmation dialog. The sheet previously made sibling portals inert, preventing interaction with the confirmation action.

The selected automation is retained while the sheet closes, and its details reopen if confirmation is cancelled or the delete request fails.

### Related issues

[ENG-1682: Cannot delete automations](https://linear.app/general-action/issue/ENG-1682/cannot-delete-automations)

### Testing

- Desktop typecheck
- Desktop lint
- Desktop format check
- Full desktop build
- Manual Electron verification of delete and cancel flows
- git diff --check

### Screenshot/Recording (if applicable)

Not included; the change restores the existing deletion interaction.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

No automated test was added because the regression depends on interaction between separately portaled Base UI modal layers; the behavior was verified in the Electron app.

</details>