### PR TITLE
chore(release): bump desktop version to 1.1.38

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emdash/emdash-desktop",
-  "version": "1.1.37",
+  "version": "1.1.38",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",


### PR DESCRIPTION
### Description

Bump the desktop application version from `1.1.37` to `1.1.38` for the next production release.

### Related issues

None.

### Testing

- `git diff --check`
- Parsed `apps/emdash-desktop/package.json` and verified the version is `1.1.38`
- The full suite was checked on current `main` and the canary commit: the desktop suite passes (315 files, 2,203 tests), while both revisions share the same five pre-existing assertions in runtime/plugins/UI

### Screenshot/Recording (if applicable)

Not applicable; version-only change.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant checks or explained why not
- [x] Documentation changes are not required
- [x] Test changes are not required for this version-only update
- [x] I only added comments where the logic is not obvious
- [x] The PR title follows Conventional Commits

</details>