### PR TITLE
feat(shortcuts): add zen mode toggle

### DIFF
--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.test.ts
@@ -318,6 +318,28 @@ describe('BrowserWebContentsRegistry', () => {
     expect(events.emit).not.toHaveBeenCalledWith(browserAppShortcutChannel, expect.anything());
   });
 
+  it('does not consume shortcuts ignored in focused browser webContents', () => {
+    const registry = new BrowserWebContentsRegistry();
+    registry.registerSession({ browserId: 'browser-1', partition: PROFILE_PARTITION });
+
+    const webContents = fakeWebContents();
+    registry.handleWebviewAttached(webContents);
+    registry.bindWebContents('browser-1', webContents);
+
+    const keyEvent = { preventDefault: vi.fn() };
+    webContents.emitEvent('before-input-event', keyEvent, {
+      type: 'keyDown',
+      key: 'Z',
+      control: true,
+      shift: false,
+      alt: false,
+      meta: false,
+    });
+
+    expect(keyEvent.preventDefault).not.toHaveBeenCalled();
+    expect(events.emit).not.toHaveBeenCalledWith(browserAppShortcutChannel, expect.anything());
+  });
+
   it('clears storage for a named profile without requiring an open browser', async () => {
     const registry = new BrowserWebContentsRegistry();
 

--- a/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
+++ b/apps/emdash-desktop/src/main/core/browser/browser-webcontents-registry.ts
@@ -450,7 +450,9 @@ function getBrowserShortcuts(
 ): Map<ShortcutSettingsKey, ParsedShortcut> {
   const shortcuts = new Map<ShortcutSettingsKey, ParsedShortcut>();
   for (const shortcutKey of Object.keys(APP_SHORTCUTS) as ShortcutSettingsKey[]) {
-    if (shortcutKey === 'closeModal') continue;
+    if (shortcutKey === 'closeModal' || APP_SHORTCUTS[shortcutKey].ignoreWhenBrowserFocused) {
+      continue;
+    }
 
     const configured = keyboard?.[shortcutKey];
     if (configured === null) continue;

--- a/apps/emdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -1,7 +1,7 @@
 import { useHotkey } from '@tanstack/react-hotkeys';
 import { useObserver } from 'mobx-react-lite';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
-import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-selectors';
+import { getRegisteredTaskData, getTaskView } from '@renderer/features/tasks/stores/task-selectors';
 import {
   getEffectiveHotkey,
   getHotkeyRegistration,
@@ -18,12 +18,13 @@ import { modalStore } from '@renderer/lib/modal/modal-store';
 export function AppKeyboardShortcuts() {
   const { value: keyboard } = useAppSettingsKey('keyboard');
   const showCommandPalette = useShowModal('commandPaletteModal');
-  const { toggleLeft } = useWorkspaceLayoutContext();
+  const { setCollapsed, toggleLeft } = useWorkspaceLayoutContext();
   const { navigate } = useNavigate();
 
   const commandPaletteHotkey = getEffectiveHotkey('commandPalette', keyboard);
   const closeModalHotkey = getEffectiveHotkey('closeModal', keyboard);
   const toggleLeftSidebarHotkey = getEffectiveHotkey('toggleLeftSidebar', keyboard);
+  const zenModeHotkey = getEffectiveHotkey('zenMode', keyboard);
 
   const { currentView, lastNonSettingsView } = useWorkspaceSlots();
   const { params: taskParams } = useParams('task');
@@ -66,6 +67,17 @@ export function AppKeyboardShortcuts() {
   useHotkey(getHotkeyRegistration('toggleLeftSidebar', keyboard), () => toggleLeft(), {
     enabled: toggleLeftSidebarHotkey !== null,
   });
+
+  useHotkey(
+    getHotkeyRegistration('zenMode', keyboard),
+    () => {
+      setCollapsed('left', true);
+      if (currentProjectId && currentTaskId) {
+        getTaskView(currentProjectId, currentTaskId)?.setSidebarCollapsed(true);
+      }
+    },
+    { enabled: zenModeHotkey !== null }
+  );
 
   return null;
 }

--- a/apps/emdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -18,7 +18,7 @@ import { modalStore } from '@renderer/lib/modal/modal-store';
 export function AppKeyboardShortcuts() {
   const { value: keyboard } = useAppSettingsKey('keyboard');
   const showCommandPalette = useShowModal('commandPaletteModal');
-  const { setCollapsed, toggleLeft } = useWorkspaceLayoutContext();
+  const { toggleLeft, toggleZenMode } = useWorkspaceLayoutContext();
   const { navigate } = useNavigate();
 
   const commandPaletteHotkey = getEffectiveHotkey('commandPalette', keyboard);
@@ -71,10 +71,18 @@ export function AppKeyboardShortcuts() {
   useHotkey(
     getHotkeyRegistration('zenMode', keyboard),
     () => {
-      setCollapsed('left', true);
-      if (currentProjectId && currentTaskId) {
-        getTaskView(currentProjectId, currentTaskId)?.setSidebarCollapsed(true);
-      }
+      const taskView =
+        currentProjectId && currentTaskId
+          ? getTaskView(currentProjectId, currentTaskId)
+          : undefined;
+      toggleZenMode(
+        taskView
+          ? {
+              isCollapsed: taskView.isSidebarCollapsed,
+              setCollapsed: (collapsed) => taskView.setSidebarCollapsed(collapsed),
+            }
+          : undefined
+      );
     },
     { enabled: zenModeHotkey !== null }
   );

--- a/apps/emdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/app-keyboard-shortcuts.tsx
@@ -1,5 +1,6 @@
 import { useHotkey } from '@tanstack/react-hotkeys';
 import { useObserver } from 'mobx-react-lite';
+import { useEffect } from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { getRegisteredTaskData, getTaskView } from '@renderer/features/tasks/stores/task-selectors';
 import {
@@ -18,7 +19,7 @@ import { modalStore } from '@renderer/lib/modal/modal-store';
 export function AppKeyboardShortcuts() {
   const { value: keyboard } = useAppSettingsKey('keyboard');
   const showCommandPalette = useShowModal('commandPaletteModal');
-  const { toggleLeft, toggleZenMode } = useWorkspaceLayoutContext();
+  const { exitZenMode, toggleLeft, toggleZenMode } = useWorkspaceLayoutContext();
   const { navigate } = useNavigate();
 
   const commandPaletteHotkey = getEffectiveHotkey('commandPalette', keyboard);
@@ -42,6 +43,8 @@ export function AppKeyboardShortcuts() {
     if (!currentProjectId || !currentTaskId) return undefined;
     return getRegisteredTaskData(currentProjectId, currentTaskId)?.workspaceId ?? undefined;
   });
+
+  useEffect(() => () => exitZenMode(), [currentProjectId, currentTaskId, currentView, exitZenMode]);
 
   useHotkey(
     getHotkeyRegistration('commandPalette', keyboard),
@@ -84,7 +87,7 @@ export function AppKeyboardShortcuts() {
           : undefined
       );
     },
-    { enabled: zenModeHotkey !== null }
+    { enabled: zenModeHotkey !== null, ignoreInputs: true }
   );
 
   return null;

--- a/apps/emdash-desktop/src/renderer/lib/components/browser-app-shortcut-events.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/browser-app-shortcut-events.tsx
@@ -3,7 +3,10 @@ import type { ViewId } from '@renderer/app/view-registry';
 import { getRegisteredTaskData, getTaskView } from '@renderer/features/tasks/stores/task-selectors';
 import { commandRegistry } from '@renderer/lib/commands/registry';
 import { events } from '@renderer/lib/ipc';
-import { useWorkspaceLayoutContext } from '@renderer/lib/layout/layout-provider';
+import {
+  type WorkspaceLayoutContextValue,
+  useWorkspaceLayoutContext,
+} from '@renderer/lib/layout/layout-provider';
 import {
   type NavigateFnTyped,
   type NonSettingsViewId,
@@ -18,7 +21,7 @@ import type { ShortcutSettingsKey } from '@shared/shortcuts';
 
 export function BrowserAppShortcutEvents() {
   const showCommandPalette = useShowModal('commandPaletteModal');
-  const { setCollapsed, toggleLeft } = useWorkspaceLayoutContext();
+  const { toggleLeft, toggleZenMode } = useWorkspaceLayoutContext();
   const { navigate } = useNavigate();
   const { currentView, lastNonSettingsView } = useWorkspaceSlots();
   const { params: taskParams } = useParams('task');
@@ -42,9 +45,9 @@ export function BrowserAppShortcutEvents() {
         currentView,
         lastNonSettingsView,
         navigate,
-        setCollapsed,
         showCommandPalette,
         toggleLeft,
+        toggleZenMode,
       });
     });
   }, [
@@ -53,9 +56,9 @@ export function BrowserAppShortcutEvents() {
     currentView,
     lastNonSettingsView,
     navigate,
-    setCollapsed,
     showCommandPalette,
     toggleLeft,
+    toggleZenMode,
   ]);
 
   return null;
@@ -69,13 +72,13 @@ function dispatchAppOnlyShortcut(
     currentView: ViewId;
     lastNonSettingsView: NonSettingsViewId;
     navigate: NavigateFnTyped;
-    setCollapsed: (side: 'left', collapsed: boolean) => void;
     showCommandPalette: (input: {
       projectId?: string;
       taskId?: string;
       workspaceId?: string;
     }) => void;
     toggleLeft: () => void;
+    toggleZenMode: WorkspaceLayoutContextValue['toggleZenMode'];
   }
 ): void {
   switch (shortcutKey) {
@@ -97,9 +100,19 @@ function dispatchAppOnlyShortcut(
       context.toggleLeft();
       break;
     case 'zenMode':
-      context.setCollapsed('left', true);
-      if (context.currentProjectId && context.currentTaskId) {
-        getTaskView(context.currentProjectId, context.currentTaskId)?.setSidebarCollapsed(true);
+      {
+        const taskView =
+          context.currentProjectId && context.currentTaskId
+            ? getTaskView(context.currentProjectId, context.currentTaskId)
+            : undefined;
+        context.toggleZenMode(
+          taskView
+            ? {
+                isCollapsed: taskView.isSidebarCollapsed,
+                setCollapsed: (collapsed) => taskView.setSidebarCollapsed(collapsed),
+              }
+            : undefined
+        );
       }
       break;
     case 'closeModal':

--- a/apps/emdash-desktop/src/renderer/lib/components/browser-app-shortcut-events.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/browser-app-shortcut-events.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from 'react';
 import type { ViewId } from '@renderer/app/view-registry';
-import { getRegisteredTaskData } from '@renderer/features/tasks/stores/task-selectors';
+import { getRegisteredTaskData, getTaskView } from '@renderer/features/tasks/stores/task-selectors';
 import { commandRegistry } from '@renderer/lib/commands/registry';
 import { events } from '@renderer/lib/ipc';
 import { useWorkspaceLayoutContext } from '@renderer/lib/layout/layout-provider';
@@ -18,7 +18,7 @@ import type { ShortcutSettingsKey } from '@shared/shortcuts';
 
 export function BrowserAppShortcutEvents() {
   const showCommandPalette = useShowModal('commandPaletteModal');
-  const { toggleLeft } = useWorkspaceLayoutContext();
+  const { setCollapsed, toggleLeft } = useWorkspaceLayoutContext();
   const { navigate } = useNavigate();
   const { currentView, lastNonSettingsView } = useWorkspaceSlots();
   const { params: taskParams } = useParams('task');
@@ -42,6 +42,7 @@ export function BrowserAppShortcutEvents() {
         currentView,
         lastNonSettingsView,
         navigate,
+        setCollapsed,
         showCommandPalette,
         toggleLeft,
       });
@@ -52,6 +53,7 @@ export function BrowserAppShortcutEvents() {
     currentView,
     lastNonSettingsView,
     navigate,
+    setCollapsed,
     showCommandPalette,
     toggleLeft,
   ]);
@@ -67,6 +69,7 @@ function dispatchAppOnlyShortcut(
     currentView: ViewId;
     lastNonSettingsView: NonSettingsViewId;
     navigate: NavigateFnTyped;
+    setCollapsed: (side: 'left', collapsed: boolean) => void;
     showCommandPalette: (input: {
       projectId?: string;
       taskId?: string;
@@ -92,6 +95,12 @@ function dispatchAppOnlyShortcut(
     }
     case 'toggleLeftSidebar':
       context.toggleLeft();
+      break;
+    case 'zenMode':
+      context.setCollapsed('left', true);
+      if (context.currentProjectId && context.currentTaskId) {
+        getTaskView(context.currentProjectId, context.currentTaskId)?.setSidebarCollapsed(true);
+      }
       break;
     case 'closeModal':
       if (context.currentView === 'settings' && !modalStore.isOpen) {

--- a/apps/emdash-desktop/src/renderer/lib/layout/layout-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/layout/layout-provider.tsx
@@ -35,7 +35,6 @@ export function useWorkspaceLayoutService() {
   const zenModeSnapshotRef = useRef<{
     leftOpen: boolean;
     rightCollapsed?: boolean;
-    setRightCollapsed?: (collapsed: boolean) => void;
   } | null>(null);
 
   const syncLeftOpenFromPanel = useCallback(() => {
@@ -71,8 +70,8 @@ export function useWorkspaceLayoutService() {
       const snapshot = zenModeSnapshotRef.current;
       if (snapshot) {
         setCollapsed('left', !snapshot.leftOpen);
-        if (snapshot.setRightCollapsed && snapshot.rightCollapsed !== undefined) {
-          snapshot.setRightCollapsed(snapshot.rightCollapsed);
+        if (rightSidebar && snapshot.rightCollapsed !== undefined) {
+          rightSidebar.setCollapsed(snapshot.rightCollapsed);
         }
         zenModeSnapshotRef.current = null;
         return;
@@ -81,7 +80,6 @@ export function useWorkspaceLayoutService() {
       zenModeSnapshotRef.current = {
         leftOpen: isLeftOpen,
         rightCollapsed: rightSidebar?.isCollapsed,
-        setRightCollapsed: rightSidebar?.setCollapsed,
       };
       setCollapsed('left', true);
       rightSidebar?.setCollapsed(true);

--- a/apps/emdash-desktop/src/renderer/lib/layout/layout-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/layout/layout-provider.tsx
@@ -15,6 +15,10 @@ export interface WorkspaceLayoutContextValue {
   syncLeftOpenFromPanel: () => void;
   setCollapsed: (side: 'left', collapsed: boolean) => void;
   toggleLeft: () => void;
+  toggleZenMode: (rightSidebar?: {
+    isCollapsed: boolean;
+    setCollapsed: (collapsed: boolean) => void;
+  }) => void;
 }
 
 const WorkspaceLayoutContext = createContext<WorkspaceLayoutContextValue | undefined>(undefined);
@@ -28,6 +32,11 @@ export function useWorkspaceLayoutService() {
   // programmatic collapse/expand is in flight (state-only concern, no resize
   // suppression needed because the ResizeObserver is now always trusted).
   const programmaticRef = useRef(false);
+  const zenModeSnapshotRef = useRef<{
+    leftOpen: boolean;
+    rightCollapsed?: boolean;
+    setRightCollapsed?: (collapsed: boolean) => void;
+  } | null>(null);
 
   const syncLeftOpenFromPanel = useCallback(() => {
     if (programmaticRef.current) return;
@@ -57,12 +66,36 @@ export function useWorkspaceLayoutService() {
     setCollapsed('left', isLeftOpen);
   }, [setCollapsed, isLeftOpen]);
 
+  const toggleZenMode = useCallback(
+    (rightSidebar?: { isCollapsed: boolean; setCollapsed: (collapsed: boolean) => void }) => {
+      const snapshot = zenModeSnapshotRef.current;
+      if (snapshot) {
+        setCollapsed('left', !snapshot.leftOpen);
+        if (snapshot.setRightCollapsed && snapshot.rightCollapsed !== undefined) {
+          snapshot.setRightCollapsed(snapshot.rightCollapsed);
+        }
+        zenModeSnapshotRef.current = null;
+        return;
+      }
+
+      zenModeSnapshotRef.current = {
+        leftOpen: isLeftOpen,
+        rightCollapsed: rightSidebar?.isCollapsed,
+        setRightCollapsed: rightSidebar?.setCollapsed,
+      };
+      setCollapsed('left', true);
+      rightSidebar?.setCollapsed(true);
+    },
+    [isLeftOpen, setCollapsed]
+  );
+
   return {
     leftPanelRef,
     syncLeftOpenFromPanel,
     isLeftOpen,
     setCollapsed,
     toggleLeft,
+    toggleZenMode,
   };
 }
 

--- a/apps/emdash-desktop/src/renderer/lib/layout/layout-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/layout/layout-provider.tsx
@@ -15,6 +15,7 @@ export interface WorkspaceLayoutContextValue {
   syncLeftOpenFromPanel: () => void;
   setCollapsed: (side: 'left', collapsed: boolean) => void;
   toggleLeft: () => void;
+  exitZenMode: () => void;
   toggleZenMode: (rightSidebar?: {
     isCollapsed: boolean;
     setCollapsed: (collapsed: boolean) => void;
@@ -35,6 +36,7 @@ export function useWorkspaceLayoutService() {
   const zenModeSnapshotRef = useRef<{
     leftOpen: boolean;
     rightCollapsed?: boolean;
+    setRightCollapsed?: (collapsed: boolean) => void;
   } | null>(null);
 
   const syncLeftOpenFromPanel = useCallback(() => {
@@ -65,26 +67,33 @@ export function useWorkspaceLayoutService() {
     setCollapsed('left', isLeftOpen);
   }, [setCollapsed, isLeftOpen]);
 
+  const exitZenMode = useCallback(() => {
+    const snapshot = zenModeSnapshotRef.current;
+    if (!snapshot) return;
+
+    setCollapsed('left', !snapshot.leftOpen);
+    if (snapshot.setRightCollapsed && snapshot.rightCollapsed !== undefined) {
+      snapshot.setRightCollapsed(snapshot.rightCollapsed);
+    }
+    zenModeSnapshotRef.current = null;
+  }, [setCollapsed]);
+
   const toggleZenMode = useCallback(
     (rightSidebar?: { isCollapsed: boolean; setCollapsed: (collapsed: boolean) => void }) => {
-      const snapshot = zenModeSnapshotRef.current;
-      if (snapshot) {
-        setCollapsed('left', !snapshot.leftOpen);
-        if (rightSidebar && snapshot.rightCollapsed !== undefined) {
-          rightSidebar.setCollapsed(snapshot.rightCollapsed);
-        }
-        zenModeSnapshotRef.current = null;
+      if (zenModeSnapshotRef.current) {
+        exitZenMode();
         return;
       }
 
       zenModeSnapshotRef.current = {
         leftOpen: isLeftOpen,
         rightCollapsed: rightSidebar?.isCollapsed,
+        setRightCollapsed: rightSidebar?.setCollapsed,
       };
       setCollapsed('left', true);
       rightSidebar?.setCollapsed(true);
     },
-    [isLeftOpen, setCollapsed]
+    [exitZenMode, isLeftOpen, setCollapsed]
   );
 
   return {
@@ -93,6 +102,7 @@ export function useWorkspaceLayoutService() {
     isLeftOpen,
     setCollapsed,
     toggleLeft,
+    exitZenMode,
     toggleZenMode,
   };
 }

--- a/apps/emdash-desktop/src/renderer/lib/pty/pty-keybindings.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/pty-keybindings.ts
@@ -1,3 +1,5 @@
+import { getDomTabNavigationDirection } from '@shared/shortcuts';
+
 export type KeyEventLike = {
   type: string;
   key: string;
@@ -12,6 +14,25 @@ export const CTRL_J_ASCII = '\x0A';
 
 // Ctrl+U (unix-line-discard) kills from cursor to beginning of line
 export const CTRL_U_ASCII = '\x15';
+
+export function shouldDispatchAppHotkeyFromTerminal(
+  event: KeyEventLike,
+  isMacPlatform: boolean
+): boolean {
+  if (event.type !== 'keydown') return false;
+  if (isMacPlatform) return true;
+
+  return Boolean(
+    getDomTabNavigationDirection({
+      type: event.type,
+      key: event.key,
+      ctrlKey: event.ctrlKey === true,
+      shiftKey: event.shiftKey === true,
+      altKey: event.altKey === true,
+      metaKey: event.metaKey === true,
+    })
+  );
+}
 
 export function shouldMapShiftEnterToCtrlJ(event: KeyEventLike): boolean {
   return (

--- a/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
@@ -8,7 +8,6 @@ import type { AppSettings } from '@shared/core/app-settings';
 import { ptyDataChannel, ptyExitChannel } from '@shared/core/pty/ptyEvents';
 import { TERMINAL_FONT_SIZE_DEFAULT } from '@shared/core/terminals/terminal-settings';
 import { appPasteChannel, terminalContextMenuActionChannel } from '@shared/events/appEvents';
-import { getDomTabNavigationDirection } from '@shared/shortcuts';
 import { usePaneSizingContext } from './pane-sizing-context';
 import type { FrontendPty, SessionTheme } from './pty';
 import { TERMINAL_PADDING_PX } from './pty';
@@ -18,6 +17,7 @@ import {
   CTRL_J_ASCII,
   CTRL_U_ASCII,
   shouldCopySelectionFromTerminal,
+  shouldDispatchAppHotkeyFromTerminal,
   shouldHandleInterruptFromTerminal,
   shouldKillLineFromTerminal,
   shouldMapShiftEnterToCtrlJ,
@@ -32,8 +32,8 @@ const IS_MAC_PLATFORM =
 const IS_WINDOWS_PLATFORM = typeof navigator !== 'undefined' && /Win/.test(navigator.platform);
 const LAST_SELECTION_COPY_GRACE_MS = 2_000;
 
-function dispatchTerminalTabNavigationHotkey(event: KeyboardEvent): boolean {
-  if (!getDomTabNavigationDirection(event)) return false;
+function dispatchTerminalAppHotkey(event: KeyboardEvent): boolean {
+  if (!shouldDispatchAppHotkeyFromTerminal(event, IS_MAC_PLATFORM)) return false;
   return dispatchMatchingHotkeys(event, { dispatch: 'first' });
 }
 
@@ -385,7 +385,9 @@ export function usePty(
         const dialog = document.querySelector('[role="dialog"]');
         if (dialog && !dialog.contains(container)) return false;
 
-        if (dispatchTerminalTabNavigationHotkey(event)) {
+        // xterm handles key events before TanStack's document-level hotkey listeners.
+        // Preserve terminal Ctrl sequences on non-macOS except for tab navigation.
+        if (dispatchTerminalAppHotkey(event)) {
           event.preventDefault();
           event.stopImmediatePropagation();
           event.stopPropagation();

--- a/apps/emdash-desktop/src/renderer/tests/terminalKeybindings.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/terminalKeybindings.test.ts
@@ -4,6 +4,7 @@ import {
   CTRL_J_ASCII,
   CTRL_U_ASCII,
   shouldCopySelectionFromTerminal,
+  shouldDispatchAppHotkeyFromTerminal,
   shouldHandleInterruptFromTerminal,
   shouldKillLineFromTerminal,
   shouldMapShiftEnterToCtrlJ,
@@ -34,6 +35,34 @@ describe('TerminalSessionManager - Shift+Enter to Ctrl+J mapping', () => {
 
   it('uses line feed for Ctrl+J', () => {
     expect(CTRL_J_ASCII).toBe('\n');
+  });
+
+  it('dispatches macOS app shortcuts while preserving non-macOS terminal controls', () => {
+    expect(shouldDispatchAppHotkeyFromTerminal(makeEvent({ key: 'z', ctrlKey: true }), true)).toBe(
+      true
+    );
+
+    for (const key of ['z', 'w', 'k', 'd']) {
+      expect(shouldDispatchAppHotkeyFromTerminal(makeEvent({ key, ctrlKey: true }), false)).toBe(
+        false
+      );
+    }
+
+    expect(
+      shouldDispatchAppHotkeyFromTerminal(makeEvent({ key: 'Tab', ctrlKey: true }), false)
+    ).toBe(true);
+    expect(
+      shouldDispatchAppHotkeyFromTerminal(
+        makeEvent({ key: 'Tab', ctrlKey: true, shiftKey: true }),
+        false
+      )
+    ).toBe(true);
+    expect(
+      shouldDispatchAppHotkeyFromTerminal(
+        makeEvent({ type: 'keyup', key: 'k', metaKey: true }),
+        true
+      )
+    ).toBe(false);
   });
 
   it('detects copy shortcuts with selection', () => {

--- a/apps/emdash-desktop/src/shared/shortcuts.ts
+++ b/apps/emdash-desktop/src/shared/shortcuts.ts
@@ -14,6 +14,7 @@ export interface AppShortcutDef {
   hideFromSettings?: boolean;
   conflictBehavior?: 'prevent' | 'allow';
   ignoreWhenMonacoFocused?: boolean;
+  ignoreWhenBrowserFocused?: boolean;
 }
 
 export type TabNavigationDirection = 'next' | 'previous';
@@ -131,6 +132,8 @@ export const APP_SHORTCUTS = defineShortcuts({
     label: 'Zen Mode',
     description: 'Hide both sidebars',
     category: 'View',
+    ignoreWhenMonacoFocused: true,
+    ignoreWhenBrowserFocused: true,
   },
   closeModal: {
     defaultHotkey: 'Escape',

--- a/apps/emdash-desktop/src/shared/shortcuts.ts
+++ b/apps/emdash-desktop/src/shared/shortcuts.ts
@@ -126,6 +126,12 @@ export const APP_SHORTCUTS = defineShortcuts({
     description: 'Show or hide the right sidebar',
     category: 'View',
   },
+  zenMode: {
+    defaultHotkey: 'Control+Z',
+    label: 'Zen Mode',
+    description: 'Hide both sidebars',
+    category: 'View',
+  },
   closeModal: {
     defaultHotkey: 'Escape',
     label: 'Close Modal',


### PR DESCRIPTION
### Description

Adds a configurable Zen Mode shortcut (`Control+Z`) that hides both sidebars. Pressing the shortcut again exits Zen Mode and restores each sidebar to its previous open or collapsed state.

The shortcut works from both the regular app renderer and embedded browser content.

### Related issues

ENG-1809

### Screenshot/Recording

https://cap.link/78kpfz5nr0x3akw

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs do not need updating for this shortcut-only change
- [x] The behavior was manually verified; no focused shortcut tests exist in this area
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for commit messages and the PR title

</details>