### PR TITLE
fix(terminal): dispatch app keybinds before PTY input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,3 +101,4 @@ packages/plugins/src/agents/impl/*/fixtures/acp-transcript.json
 # Nx local cache and workspace data
 .nx/cache
 .nx/workspace-data
+.amp/plugins/emdash-hook.ts

--- a/apps/emdash-desktop/src/renderer/lib/pty/pty-keybindings.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/pty-keybindings.ts
@@ -1,3 +1,5 @@
+import { getDomTabNavigationDirection } from '@shared/shortcuts';
+
 export type KeyEventLike = {
   type: string;
   key: string;
@@ -12,6 +14,25 @@ export const CTRL_J_ASCII = '\x0A';
 
 // Ctrl+U (unix-line-discard) kills from cursor to beginning of line
 export const CTRL_U_ASCII = '\x15';
+
+export function shouldDispatchAppHotkeyFromTerminal(
+  event: KeyEventLike,
+  isMacPlatform: boolean
+): boolean {
+  if (event.type !== 'keydown') return false;
+  if (isMacPlatform) return true;
+
+  return Boolean(
+    getDomTabNavigationDirection({
+      type: event.type,
+      key: event.key,
+      ctrlKey: event.ctrlKey === true,
+      shiftKey: event.shiftKey === true,
+      altKey: event.altKey === true,
+      metaKey: event.metaKey === true,
+    })
+  );
+}
 
 export function shouldMapShiftEnterToCtrlJ(event: KeyEventLike): boolean {
   return (

--- a/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
@@ -17,6 +17,7 @@ import {
   CTRL_J_ASCII,
   CTRL_U_ASCII,
   shouldCopySelectionFromTerminal,
+  shouldDispatchAppHotkeyFromTerminal,
   shouldHandleInterruptFromTerminal,
   shouldKillLineFromTerminal,
   shouldMapShiftEnterToCtrlJ,
@@ -32,7 +33,7 @@ const IS_WINDOWS_PLATFORM = typeof navigator !== 'undefined' && /Win/.test(navig
 const LAST_SELECTION_COPY_GRACE_MS = 2_000;
 
 function dispatchTerminalAppHotkey(event: KeyboardEvent): boolean {
-  if (event.type !== 'keydown') return false;
+  if (!shouldDispatchAppHotkeyFromTerminal(event, IS_MAC_PLATFORM)) return false;
   return dispatchMatchingHotkeys(event, { dispatch: 'first' });
 }
 
@@ -384,9 +385,8 @@ export function usePty(
         const dialog = document.querySelector('[role="dialog"]');
         if (dialog && !dialog.contains(container)) return false;
 
-        // xterm handles key events before TanStack's document-level hotkey
-        // listeners can see them. Dispatch any active app shortcut here first;
-        // unmatched shortcuts continue to the CLI unchanged.
+        // xterm handles key events before TanStack's document-level hotkey listeners.
+        // Preserve terminal Ctrl sequences on non-macOS except for tab navigation.
         if (dispatchTerminalAppHotkey(event)) {
           event.preventDefault();
           event.stopImmediatePropagation();

--- a/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/use-pty.ts
@@ -8,7 +8,6 @@ import type { AppSettings } from '@shared/core/app-settings';
 import { ptyDataChannel, ptyExitChannel } from '@shared/core/pty/ptyEvents';
 import { TERMINAL_FONT_SIZE_DEFAULT } from '@shared/core/terminals/terminal-settings';
 import { appPasteChannel, terminalContextMenuActionChannel } from '@shared/events/appEvents';
-import { getDomTabNavigationDirection } from '@shared/shortcuts';
 import { usePaneSizingContext } from './pane-sizing-context';
 import type { FrontendPty, SessionTheme } from './pty';
 import { TERMINAL_PADDING_PX } from './pty';
@@ -32,8 +31,8 @@ const IS_MAC_PLATFORM =
 const IS_WINDOWS_PLATFORM = typeof navigator !== 'undefined' && /Win/.test(navigator.platform);
 const LAST_SELECTION_COPY_GRACE_MS = 2_000;
 
-function dispatchTerminalTabNavigationHotkey(event: KeyboardEvent): boolean {
-  if (!getDomTabNavigationDirection(event)) return false;
+function dispatchTerminalAppHotkey(event: KeyboardEvent): boolean {
+  if (event.type !== 'keydown') return false;
   return dispatchMatchingHotkeys(event, { dispatch: 'first' });
 }
 
@@ -385,7 +384,10 @@ export function usePty(
         const dialog = document.querySelector('[role="dialog"]');
         if (dialog && !dialog.contains(container)) return false;
 
-        if (dispatchTerminalTabNavigationHotkey(event)) {
+        // xterm handles key events before TanStack's document-level hotkey
+        // listeners can see them. Dispatch any active app shortcut here first;
+        // unmatched shortcuts continue to the CLI unchanged.
+        if (dispatchTerminalAppHotkey(event)) {
           event.preventDefault();
           event.stopImmediatePropagation();
           event.stopPropagation();

--- a/apps/emdash-desktop/src/renderer/tests/terminalKeybindings.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/terminalKeybindings.test.ts
@@ -4,6 +4,7 @@ import {
   CTRL_J_ASCII,
   CTRL_U_ASCII,
   shouldCopySelectionFromTerminal,
+  shouldDispatchAppHotkeyFromTerminal,
   shouldHandleInterruptFromTerminal,
   shouldKillLineFromTerminal,
   shouldMapShiftEnterToCtrlJ,
@@ -34,6 +35,33 @@ describe('TerminalSessionManager - Shift+Enter to Ctrl+J mapping', () => {
 
   it('uses line feed for Ctrl+J', () => {
     expect(CTRL_J_ASCII).toBe('\n');
+  });
+
+  it('preserves non-macOS terminal controls while dispatching app shortcuts on macOS', () => {
+    for (const key of ['w', 'k', 'd']) {
+      expect(shouldDispatchAppHotkeyFromTerminal(makeEvent({ key, ctrlKey: true }), false)).toBe(
+        false
+      );
+    }
+
+    expect(shouldDispatchAppHotkeyFromTerminal(makeEvent({ key: 'k', metaKey: true }), true)).toBe(
+      true
+    );
+    expect(
+      shouldDispatchAppHotkeyFromTerminal(makeEvent({ key: 'Tab', ctrlKey: true }), false)
+    ).toBe(true);
+    expect(
+      shouldDispatchAppHotkeyFromTerminal(
+        makeEvent({ key: 'Tab', ctrlKey: true, shiftKey: true }),
+        false
+      )
+    ).toBe(true);
+    expect(
+      shouldDispatchAppHotkeyFromTerminal(
+        makeEvent({ type: 'keyup', key: 'k', metaKey: true }),
+        true
+      )
+    ).toBe(false);
   });
 
   it('detects copy shortcuts with selection', () => {


### PR DESCRIPTION
### Description

Dispatch active app shortcuts from the PTY custom key handler before xterm forwards input to the CLI. This prevents app keybinds from being swallowed inside terminal sessions while allowing unmatched key events to continue unchanged.

Also ignores the local Amp hook file.

### Related issues
ENG-1694

### Screenshot/Recording (if applicable)

Not applicable.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable)
- [x] I added or updated tests when behavior changed, or explained why not (not added; existing hotkey dispatch path is reused)
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>