### PR TITLE
feat(mcp): add integrations.sh server search

### DIFF
--- a/apps/emdash-desktop/src/main/core/mcp/controller.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/controller.ts
@@ -25,6 +25,16 @@ function mapProviders(): McpProvidersResponse[] {
 }
 
 export const mcpController = createRPCController({
+  searchIntegrationsSh: async ({ query }: { query: string }) => {
+    try {
+      const data = await mcpService.searchIntegrationsSh(query);
+      return { success: true, data };
+    } catch (error) {
+      log.error('Failed to search integrations.sh:', error);
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
+
   loadAll: async () => {
     try {
       const data = await mcpService.loadAll();

--- a/apps/emdash-desktop/src/main/core/mcp/controller.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/controller.ts
@@ -1,7 +1,10 @@
 import type { CLIAgentPluginProvider } from '@emdash/core/agents/plugins';
 import type { DependencyId } from '@emdash/core/deps/runtime';
 import { pluginRegistry } from '@emdash/plugins/agents';
-import { localDependencyManager } from '@main/core/dependencies/dependency-managers';
+import {
+  ensureAgentDependenciesProbed,
+  localDependencyManager,
+} from '@main/core/dependencies/dependency-managers';
 import { log } from '@main/lib/logger';
 import type { McpProvidersResponse, McpServer } from '@shared/core/mcp/types';
 import { createRPCController } from '@shared/lib/ipc/rpc';
@@ -67,6 +70,7 @@ export const mcpController = createRPCController({
 
   getProviders: async () => {
     try {
+      await ensureAgentDependenciesProbed(localDependencyManager);
       return { success: true, data: mapProviders() };
     } catch (error) {
       log.error('Failed to get MCP providers:', error);
@@ -76,7 +80,7 @@ export const mcpController = createRPCController({
 
   refreshProviders: async () => {
     try {
-      await localDependencyManager.probeCategory('agent');
+      await localDependencyManager.probeCategory('agent', { refreshShellEnv: true });
       return { success: true, data: mapProviders() };
     } catch (error) {
       log.error('Failed to refresh MCP providers:', error);

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
@@ -151,6 +151,7 @@ describe('McpService', () => {
           key: 'integrations-sh-linear.app-linear',
           name: 'Linear MCP server',
           docsUrl: 'https://linear.app/docs/mcp',
+          iconUrl: 'https://integrations.sh/logo/linear.app',
           defaultConfig: { type: 'http', url: 'https://mcp.linear.app/mcp' },
         }),
       ]);
@@ -187,6 +188,13 @@ describe('McpService', () => {
                   slug: 'unsafe',
                   name: 'Unsafe MCP',
                   url: 'javascript:alert(1)',
+                },
+                {
+                  type: 'mcp',
+                  slug: 'command',
+                  name: 'Remote command MCP',
+                  command: 'npx',
+                  args: ['malicious-package'],
                 },
                 { type: 'mcp', slug: 'missing', name: 'Missing config' },
               ],
@@ -326,7 +334,7 @@ describe('McpService', () => {
       expect(fetchMock).toHaveBeenCalledTimes(3);
     });
 
-    it('omits unsafe icon URLs from otherwise valid entries', async () => {
+    it('omits off-origin icon URLs from otherwise valid entries', async () => {
       vi.stubGlobal(
         'fetch',
         vi
@@ -336,7 +344,7 @@ describe('McpService', () => {
               data: [
                 {
                   domain: 'icon.example',
-                  icon: 'file:///tmp/icon.svg',
+                  icon: 'https://tracker.example/icon.svg',
                   formats: { mcp: 1 },
                   popularity: 1,
                   description: 'Icon example',

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
@@ -71,6 +71,10 @@ function fakeProvider(id: string, configPath: string) {
   };
 }
 
+function jsonResponse(payload: unknown, init?: ResponseInit): Response {
+  return new Response(JSON.stringify(payload), init);
+}
+
 // ── Mocks ────────────────────────────────────────────────────────────────────
 
 const mockProviders: ReturnType<typeof fakeProvider>[] = [];
@@ -115,34 +119,30 @@ describe('McpService', () => {
       const fetchMock = vi
         .fn()
         .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              data: [
-                {
-                  domain: 'linear.app',
-                  icon: 'https://integrations.sh/logo/linear.app',
-                  formats: { mcp: 1 },
-                  popularity: 100,
-                  description: 'Manage issues and projects',
-                },
-              ],
-            })
-          )
+          jsonResponse({
+            data: [
+              {
+                domain: 'linear.app',
+                icon: 'https://integrations.sh/logo/linear.app',
+                formats: { mcp: 1 },
+                popularity: 100,
+                description: 'Manage issues and projects',
+              },
+            ],
+          })
         )
         .mockResolvedValueOnce(
-          new Response(
-            JSON.stringify({
-              surfaces: [
-                {
-                  type: 'mcp',
-                  slug: 'linear',
-                  name: 'Linear MCP server',
-                  docs: 'https://linear.app/docs/mcp',
-                  url: 'https://mcp.linear.app/mcp',
-                },
-              ],
-            })
-          )
+          jsonResponse({
+            surfaces: [
+              {
+                type: 'mcp',
+                slug: 'linear',
+                name: 'Linear MCP server',
+                docs: 'https://linear.app/docs/mcp',
+                url: 'https://mcp.linear.app/mcp',
+              },
+            ],
+          })
         );
       vi.stubGlobal('fetch', fetchMock);
 
@@ -155,6 +155,10 @@ describe('McpService', () => {
         }),
       ]);
       expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock).toHaveBeenLastCalledWith(
+        'https://integrations.sh/api/linear.app/surface',
+        expect.anything()
+      );
     });
 
     it('discards MCP surfaces without a safe install configuration', async () => {
@@ -163,34 +167,30 @@ describe('McpService', () => {
         vi
           .fn()
           .mockResolvedValueOnce(
-            new Response(
-              JSON.stringify({
-                data: [
-                  {
-                    domain: 'unsafe.example',
-                    icon: 'https://integrations.sh/logo/unsafe.example',
-                    formats: { mcp: 1 },
-                    popularity: 1,
-                    description: 'Unsafe example',
-                  },
-                ],
-              })
-            )
+            jsonResponse({
+              data: [
+                {
+                  domain: 'unsafe.example',
+                  icon: 'file:///tmp/icon.svg',
+                  formats: { mcp: 1 },
+                  popularity: 1,
+                  description: 'Unsafe example',
+                },
+              ],
+            })
           )
           .mockResolvedValueOnce(
-            new Response(
-              JSON.stringify({
-                surfaces: [
-                  {
-                    type: 'mcp',
-                    slug: 'unsafe',
-                    name: 'Unsafe MCP',
-                    url: 'javascript:alert(1)',
-                  },
-                  { type: 'mcp', slug: 'missing', name: 'Missing config' },
-                ],
-              })
-            )
+            jsonResponse({
+              surfaces: [
+                {
+                  type: 'mcp',
+                  slug: 'unsafe',
+                  name: 'Unsafe MCP',
+                  url: 'javascript:alert(1)',
+                },
+                { type: 'mcp', slug: 'missing', name: 'Missing config' },
+              ],
+            })
           )
       );
 
@@ -203,46 +203,163 @@ describe('McpService', () => {
         vi
           .fn()
           .mockResolvedValueOnce(
-            new Response(
-              JSON.stringify({
-                data: [
-                  {
-                    domain: 'flaky.example',
-                    icon: 'https://integrations.sh/logo/flaky.example',
-                    formats: { mcp: 1 },
-                    popularity: 200,
-                    description: 'Example tracker',
-                  },
-                  {
-                    domain: 'healthy.example',
-                    icon: 'https://integrations.sh/logo/healthy.example',
-                    formats: { mcp: 1 },
-                    popularity: 100,
-                    description: 'Example tracker',
-                  },
-                ],
-              })
-            )
+            jsonResponse({
+              data: [
+                {
+                  domain: 'flaky.example',
+                  icon: 'https://integrations.sh/logo/flaky.example',
+                  formats: { mcp: 1 },
+                  popularity: 200,
+                  description: 'Example tracker',
+                },
+                {
+                  domain: 'healthy.example',
+                  icon: 'https://integrations.sh/logo/healthy.example',
+                  formats: { mcp: 1 },
+                  popularity: 100,
+                  description: 'Example tracker',
+                },
+              ],
+            })
           )
           .mockRejectedValueOnce(new Error('network down'))
           .mockResolvedValueOnce(
-            new Response(
-              JSON.stringify({
-                surfaces: [
-                  {
-                    type: 'mcp',
-                    slug: 'healthy',
-                    name: 'Healthy MCP',
-                    url: 'https://mcp.healthy.example/mcp',
-                  },
-                ],
-              })
-            )
+            jsonResponse({
+              surfaces: [
+                {
+                  type: 'mcp',
+                  slug: 'healthy',
+                  name: 'Healthy MCP',
+                  url: 'https://mcp.healthy.example/mcp',
+                },
+              ],
+            })
+          )
+          .mockResolvedValueOnce(
+            jsonResponse({
+              surfaces: [
+                {
+                  type: 'mcp',
+                  slug: 'flaky',
+                  name: 'Recovered MCP',
+                  url: 'https://mcp.flaky.example/mcp',
+                },
+              ],
+            })
+          )
+          .mockResolvedValueOnce(
+            jsonResponse({
+              surfaces: [
+                {
+                  type: 'mcp',
+                  slug: 'healthy',
+                  name: 'Healthy MCP',
+                  url: 'https://mcp.healthy.example/mcp',
+                },
+              ],
+            })
           )
       );
 
       await expect(service.searchIntegrationsSh('tracker')).resolves.toEqual([
         expect.objectContaining({ key: 'integrations-sh-healthy.example-healthy' }),
+      ]);
+
+      await expect(service.searchIntegrationsSh('tracker')).resolves.toHaveLength(2);
+      expect(fetch).toHaveBeenCalledTimes(5);
+    });
+
+    it('reports a domains request failure when no stale cache exists', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockRejectedValueOnce(new Error('network down')));
+
+      await expect(service.searchIntegrationsSh('linear')).rejects.toThrow('network down');
+    });
+
+    it('rejects an invalid domains document', async () => {
+      vi.stubGlobal('fetch', vi.fn().mockResolvedValueOnce(jsonResponse({ data: null })));
+
+      await expect(service.searchIntegrationsSh('linear')).rejects.toThrow(
+        'invalid domains document'
+      );
+    });
+
+    it('shares an in-flight domains request between searches', async () => {
+      let resolveDomains!: (response: Response) => void;
+      const domainsResponse = new Promise<Response>((resolve) => {
+        resolveDomains = resolve;
+      });
+      const fetchMock = vi
+        .fn()
+        .mockReturnValueOnce(domainsResponse)
+        .mockResolvedValue(
+          jsonResponse({
+            surfaces: [
+              {
+                type: 'mcp',
+                slug: 'linear',
+                name: 'Linear MCP server',
+                url: 'https://mcp.linear.app/mcp',
+              },
+            ],
+          })
+        );
+      vi.stubGlobal('fetch', fetchMock);
+
+      const firstSearch = service.searchIntegrationsSh('linear');
+      const secondSearch = service.searchIntegrationsSh('issues');
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+
+      resolveDomains(
+        jsonResponse({
+          data: [
+            {
+              domain: 'linear.app',
+              icon: 'https://integrations.sh/logo/linear.app',
+              formats: { mcp: 1 },
+              popularity: 100,
+              description: 'Manage issues and projects',
+            },
+          ],
+        })
+      );
+      await Promise.all([firstSearch, secondSearch]);
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+    });
+
+    it('omits unsafe icon URLs from otherwise valid entries', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            jsonResponse({
+              data: [
+                {
+                  domain: 'icon.example',
+                  icon: 'file:///tmp/icon.svg',
+                  formats: { mcp: 1 },
+                  popularity: 1,
+                  description: 'Icon example',
+                },
+              ],
+            })
+          )
+          .mockResolvedValueOnce(
+            jsonResponse({
+              surfaces: [
+                {
+                  type: 'mcp',
+                  slug: 'icon',
+                  name: 'Icon MCP',
+                  url: 'https://mcp.icon.example/mcp',
+                },
+              ],
+            })
+          )
+      );
+
+      await expect(service.searchIntegrationsSh('icon')).resolves.toEqual([
+        expect.objectContaining({ iconUrl: undefined }),
       ]);
     });
 
@@ -252,34 +369,30 @@ describe('McpService', () => {
         vi
           .fn()
           .mockResolvedValueOnce(
-            new Response(
-              JSON.stringify({
-                data: [
-                  {
-                    domain: 'docs.example',
-                    icon: 'https://integrations.sh/logo/docs.example',
-                    formats: { mcp: 1 },
-                    popularity: 1,
-                    description: 'Docs example',
-                  },
-                ],
-              })
-            )
+            jsonResponse({
+              data: [
+                {
+                  domain: 'docs.example',
+                  icon: 'https://integrations.sh/logo/docs.example',
+                  formats: { mcp: 1 },
+                  popularity: 1,
+                  description: 'Docs example',
+                },
+              ],
+            })
           )
           .mockResolvedValueOnce(
-            new Response(
-              JSON.stringify({
-                surfaces: [
-                  {
-                    type: 'mcp',
-                    slug: 'docs',
-                    name: 'Docs MCP',
-                    docs: 'file:///etc/passwd',
-                    url: 'https://mcp.docs.example/mcp',
-                  },
-                ],
-              })
-            )
+            jsonResponse({
+              surfaces: [
+                {
+                  type: 'mcp',
+                  slug: 'docs',
+                  name: 'Docs MCP',
+                  docs: 'file:///etc/passwd',
+                  url: 'https://mcp.docs.example/mcp',
+                },
+              ],
+            })
           )
       );
 

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
@@ -103,10 +103,99 @@ describe('McpService', () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.unstubAllGlobals();
     mockProviders.length = 0;
     mockFs = createMemoryFs();
     const { McpService } = await import('./McpService');
     service = new McpService();
+  });
+
+  describe('searchIntegrationsSh', () => {
+    it('maps matching MCP surfaces into installable catalog entries', async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              data: [
+                {
+                  domain: 'linear.app',
+                  icon: 'https://integrations.sh/logo/linear.app',
+                  formats: { mcp: 1 },
+                  popularity: 100,
+                  description: 'Manage issues and projects',
+                },
+              ],
+            })
+          )
+        )
+        .mockResolvedValueOnce(
+          new Response(
+            JSON.stringify({
+              surfaces: [
+                {
+                  type: 'mcp',
+                  slug: 'linear',
+                  name: 'Linear MCP server',
+                  docs: 'https://linear.app/docs/mcp',
+                  url: 'https://mcp.linear.app/mcp',
+                },
+              ],
+            })
+          )
+        );
+      vi.stubGlobal('fetch', fetchMock);
+
+      await expect(service.searchIntegrationsSh('linear')).resolves.toEqual([
+        expect.objectContaining({
+          key: 'integrations-sh-linear.app-linear',
+          name: 'Linear MCP server',
+          docsUrl: 'https://linear.app/docs/mcp',
+          defaultConfig: { type: 'http', url: 'https://mcp.linear.app/mcp' },
+        }),
+      ]);
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it('discards MCP surfaces without a safe install configuration', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    domain: 'unsafe.example',
+                    icon: 'https://integrations.sh/logo/unsafe.example',
+                    formats: { mcp: 1 },
+                    popularity: 1,
+                    description: 'Unsafe example',
+                  },
+                ],
+              })
+            )
+          )
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                surfaces: [
+                  {
+                    type: 'mcp',
+                    slug: 'unsafe',
+                    name: 'Unsafe MCP',
+                    url: 'javascript:alert(1)',
+                  },
+                  { type: 'mcp', slug: 'missing', name: 'Missing config' },
+                ],
+              })
+            )
+          )
+      );
+
+      await expect(service.searchIntegrationsSh('unsafe')).resolves.toEqual([]);
+    });
   });
 
   describe('loadAll', () => {

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.test.ts
@@ -196,6 +196,97 @@ describe('McpService', () => {
 
       await expect(service.searchIntegrationsSh('unsafe')).resolves.toEqual([]);
     });
+
+    it('keeps results from healthy domains when another domain fetch fails', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    domain: 'flaky.example',
+                    icon: 'https://integrations.sh/logo/flaky.example',
+                    formats: { mcp: 1 },
+                    popularity: 200,
+                    description: 'Example tracker',
+                  },
+                  {
+                    domain: 'healthy.example',
+                    icon: 'https://integrations.sh/logo/healthy.example',
+                    formats: { mcp: 1 },
+                    popularity: 100,
+                    description: 'Example tracker',
+                  },
+                ],
+              })
+            )
+          )
+          .mockRejectedValueOnce(new Error('network down'))
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                surfaces: [
+                  {
+                    type: 'mcp',
+                    slug: 'healthy',
+                    name: 'Healthy MCP',
+                    url: 'https://mcp.healthy.example/mcp',
+                  },
+                ],
+              })
+            )
+          )
+      );
+
+      await expect(service.searchIntegrationsSh('tracker')).resolves.toEqual([
+        expect.objectContaining({ key: 'integrations-sh-healthy.example-healthy' }),
+      ]);
+    });
+
+    it('falls back to the integrations.sh docs page for non-http docs URLs', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi
+          .fn()
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                data: [
+                  {
+                    domain: 'docs.example',
+                    icon: 'https://integrations.sh/logo/docs.example',
+                    formats: { mcp: 1 },
+                    popularity: 1,
+                    description: 'Docs example',
+                  },
+                ],
+              })
+            )
+          )
+          .mockResolvedValueOnce(
+            new Response(
+              JSON.stringify({
+                surfaces: [
+                  {
+                    type: 'mcp',
+                    slug: 'docs',
+                    name: 'Docs MCP',
+                    docs: 'file:///etc/passwd',
+                    url: 'https://mcp.docs.example/mcp',
+                  },
+                ],
+              })
+            )
+          )
+      );
+
+      await expect(service.searchIntegrationsSh('docs')).resolves.toEqual([
+        expect.objectContaining({ docsUrl: 'https://integrations.sh/docs.example/docs/' }),
+      ]);
+    });
   });
 
   describe('loadAll', () => {

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
@@ -4,6 +4,7 @@ import type { McpLoadAllResponse, McpServer } from '@emdash/core/mcp';
 import { pluginRegistry } from '@emdash/plugins/agents';
 import { createPluginFs } from '@main/core/agents/plugin-fs';
 import { log } from '@main/lib/logger';
+import type { McpCatalogEntry } from '@shared/core/mcp/types';
 import { loadCatalog } from '../utils/catalog';
 import {
   mcpServerFieldCount,
@@ -21,6 +22,13 @@ function getMcpProviders() {
 }
 
 export class McpService {
+  private integrationsShDomainsCache:
+    | { expiresAt: number; domains: IntegrationsShDomain[] }
+    | undefined;
+  private readonly integrationsShSearchCache = new Map<
+    string,
+    { expiresAt: number; entries: McpCatalogEntry[] }
+  >();
   private _writeLock = Promise.resolve();
 
   private async withWriteLock<T>(fn: () => Promise<T>): Promise<T> {
@@ -74,6 +82,98 @@ export class McpService {
       }
 
       return { installed, catalog: loadCatalog() };
+    });
+  }
+
+  async searchIntegrationsSh(query: string): Promise<McpCatalogEntry[]> {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (normalizedQuery.length < 2) return [];
+
+    const cached = this.integrationsShSearchCache.get(normalizedQuery);
+    if (cached && cached.expiresAt > Date.now()) return cached.entries;
+
+    try {
+      const domains = await this.getIntegrationsShDomains();
+      const matches = domains
+        .filter((entry) => entry.formats.mcp > 0)
+        .filter(
+          (entry) =>
+            entry.domain.toLowerCase().includes(normalizedQuery) ||
+            entry.description.toLowerCase().includes(normalizedQuery)
+        )
+        .sort((a, b) => b.popularity - a.popularity)
+        .slice(0, 12);
+
+      const results = await Promise.all(
+        matches.map((entry) => this.loadIntegrationsShDomain(entry))
+      );
+      const entries = results.flat().slice(0, 24);
+      this.integrationsShSearchCache.set(normalizedQuery, {
+        expiresAt: Date.now() + INTEGRATIONS_SH_CACHE_TTL_MS,
+        entries,
+      });
+      return entries;
+    } catch (error) {
+      if (cached) {
+        log.warn(
+          `integrations.sh search failed for "${normalizedQuery}", using stale cache`,
+          error
+        );
+        return cached.entries;
+      }
+      log.warn(`integrations.sh search failed for "${normalizedQuery}"`, error);
+      return [];
+    }
+  }
+
+  private async getIntegrationsShDomains(): Promise<IntegrationsShDomain[]> {
+    const cached = this.integrationsShDomainsCache;
+    if (cached && cached.expiresAt > Date.now()) {
+      return cached.domains;
+    }
+
+    const response = await fetch(INTEGRATIONS_SH_DOMAINS_URL, {
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!response.ok) throw new Error(`integrations.sh returned HTTP ${response.status}`);
+    const payload = (await response.json()) as { data?: unknown };
+    const domains = Array.isArray(payload.data) ? payload.data.filter(isIntegrationsShDomain) : [];
+    this.integrationsShDomainsCache = {
+      expiresAt: Date.now() + INTEGRATIONS_SH_CACHE_TTL_MS,
+      domains,
+    };
+    return domains;
+  }
+
+  private async loadIntegrationsShDomain(
+    domainEntry: IntegrationsShDomain
+  ): Promise<McpCatalogEntry[]> {
+    const encodedDomain = encodeURIComponent(domainEntry.domain);
+    const response = await fetch(
+      `${INTEGRATIONS_SH_RAW_BASE_URL}/${encodedDomain}/integrations.json`,
+      {
+        signal: AbortSignal.timeout(10_000),
+      }
+    );
+    if (!response.ok) return [];
+    const payload = (await response.json()) as { surfaces?: unknown };
+    if (!Array.isArray(payload.surfaces)) return [];
+
+    return payload.surfaces.flatMap((surface): McpCatalogEntry[] => {
+      if (!isIntegrationsShMcpSurface(surface)) return [];
+      const defaultConfig = toIntegrationsShDefaultConfig(surface);
+      if (!defaultConfig) return [];
+      return [
+        {
+          key: `integrations-sh-${domainEntry.domain}-${surface.slug}`,
+          name: surface.name,
+          description: domainEntry.description,
+          docsUrl: surface.docs ?? `https://integrations.sh/${encodedDomain}/${surface.slug}/`,
+          iconUrl: domainEntry.icon,
+          defaultConfig,
+          credentialKeys: [],
+        },
+      ];
     });
   }
 
@@ -160,6 +260,76 @@ export class McpService {
       return [];
     }
   }
+}
+
+const INTEGRATIONS_SH_DOMAINS_URL = 'https://integrations.sh/api/domains.json';
+const INTEGRATIONS_SH_RAW_BASE_URL =
+  'https://raw.githubusercontent.com/UsefulSoftwareCo/integrations/main/domains';
+const INTEGRATIONS_SH_CACHE_TTL_MS = 5 * 60_000;
+
+interface IntegrationsShDomain {
+  domain: string;
+  icon: string;
+  formats: { mcp: number };
+  popularity: number;
+  description: string;
+}
+
+interface IntegrationsShMcpSurface {
+  type: 'mcp';
+  slug: string;
+  name: string;
+  docs?: string;
+  url?: string;
+  command?: string;
+  args?: string[];
+}
+
+function isIntegrationsShDomain(value: unknown): value is IntegrationsShDomain {
+  if (!value || typeof value !== 'object') return false;
+  const entry = value as Partial<IntegrationsShDomain>;
+  return (
+    typeof entry.domain === 'string' &&
+    /^[a-z0-9.-]+$/i.test(entry.domain) &&
+    typeof entry.icon === 'string' &&
+    typeof entry.formats?.mcp === 'number' &&
+    typeof entry.popularity === 'number' &&
+    typeof entry.description === 'string'
+  );
+}
+
+function isIntegrationsShMcpSurface(value: unknown): value is IntegrationsShMcpSurface {
+  if (!value || typeof value !== 'object') return false;
+  const surface = value as Partial<IntegrationsShMcpSurface>;
+  return (
+    surface.type === 'mcp' &&
+    typeof surface.slug === 'string' &&
+    /^[a-z0-9-]+$/i.test(surface.slug) &&
+    typeof surface.name === 'string' &&
+    (surface.docs === undefined || typeof surface.docs === 'string') &&
+    (surface.url === undefined || typeof surface.url === 'string') &&
+    (surface.command === undefined || typeof surface.command === 'string') &&
+    (surface.args === undefined ||
+      (Array.isArray(surface.args) && surface.args.every((arg) => typeof arg === 'string')))
+  );
+}
+
+function toIntegrationsShDefaultConfig(
+  surface: IntegrationsShMcpSurface
+): Record<string, unknown> | null {
+  if (surface.url) {
+    try {
+      const url = new URL(surface.url);
+      if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
+      return { type: 'http', url: url.toString() };
+    } catch {
+      return null;
+    }
+  }
+  if (surface.command?.trim()) {
+    return { type: 'stdio', command: surface.command.trim(), args: surface.args ?? [] };
+  }
+  return null;
 }
 
 export const mcpService = new McpService();

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
@@ -25,6 +25,7 @@ export class McpService {
   private integrationsShDomainsCache:
     | { expiresAt: number; domains: IntegrationsShDomain[] }
     | undefined;
+  private integrationsShDomainsRequest: Promise<IntegrationsShDomain[]> | undefined;
   private readonly integrationsShSearchCache = new Map<
     string,
     { expiresAt: number; entries: McpCatalogEntry[] }
@@ -104,15 +105,21 @@ export class McpService {
         .sort((a, b) => b.popularity - a.popularity)
         .slice(0, 12);
 
+      let hasFailedDomain = false;
       const results = await Promise.all(
-        matches.map((entry) =>
-          this.loadIntegrationsShDomain(entry).catch((error) => {
+        matches.map(async (entry) => {
+          try {
+            return await this.loadIntegrationsShDomain(entry);
+          } catch (error) {
+            hasFailedDomain = true;
             log.warn(`integrations.sh domain fetch failed for "${entry.domain}"`, error);
             return [];
-          })
-        )
+          }
+        })
       );
       const entries = results.flat().slice(0, 24);
+      if (hasFailedDomain) return cached?.entries ?? entries;
+
       this.integrationsShSearchCache.set(normalizedQuery, {
         expiresAt: Date.now() + INTEGRATIONS_SH_CACHE_TTL_MS,
         entries,
@@ -127,7 +134,7 @@ export class McpService {
         return cached.entries;
       }
       log.warn(`integrations.sh search failed for "${normalizedQuery}"`, error);
-      return [];
+      throw error;
     }
   }
 
@@ -136,13 +143,29 @@ export class McpService {
     if (cached && cached.expiresAt > Date.now()) {
       return cached.domains;
     }
+    if (this.integrationsShDomainsRequest) return this.integrationsShDomainsRequest;
 
+    const request = this.fetchIntegrationsShDomains();
+    this.integrationsShDomainsRequest = request;
+    try {
+      return await request;
+    } finally {
+      if (this.integrationsShDomainsRequest === request) {
+        this.integrationsShDomainsRequest = undefined;
+      }
+    }
+  }
+
+  private async fetchIntegrationsShDomains(): Promise<IntegrationsShDomain[]> {
     const response = await fetch(INTEGRATIONS_SH_DOMAINS_URL, {
       signal: AbortSignal.timeout(10_000),
     });
     if (!response.ok) throw new Error(`integrations.sh returned HTTP ${response.status}`);
     const payload = (await response.json()) as { data?: unknown };
-    const domains = Array.isArray(payload.data) ? payload.data.filter(isIntegrationsShDomain) : [];
+    if (!Array.isArray(payload.data)) {
+      throw new Error('integrations.sh returned an invalid domains document');
+    }
+    const domains = payload.data.filter(isIntegrationsShDomain);
     this.integrationsShDomainsCache = {
       expiresAt: Date.now() + INTEGRATIONS_SH_CACHE_TTL_MS,
       domains,
@@ -154,34 +177,34 @@ export class McpService {
     domainEntry: IntegrationsShDomain
   ): Promise<McpCatalogEntry[]> {
     const encodedDomain = encodeURIComponent(domainEntry.domain);
-    const response = await fetch(
-      `${INTEGRATIONS_SH_RAW_BASE_URL}/${encodedDomain}/integrations.json`,
-      {
-        signal: AbortSignal.timeout(10_000),
-      }
-    );
-    if (!response.ok) return [];
-    const payload = (await response.json()) as { surfaces?: unknown };
-    if (!Array.isArray(payload.surfaces)) return [];
-
-    return payload.surfaces.flatMap((surface): McpCatalogEntry[] => {
-      if (!isIntegrationsShMcpSurface(surface)) return [];
-      const defaultConfig = toIntegrationsShDefaultConfig(surface);
-      if (!defaultConfig) return [];
-      return [
-        {
-          key: `integrations-sh-${domainEntry.domain}-${surface.slug}`,
-          name: surface.name,
-          description: domainEntry.description,
-          docsUrl:
-            toSafeHttpUrl(surface.docs) ??
-            `https://integrations.sh/${encodedDomain}/${surface.slug}/`,
-          iconUrl: domainEntry.icon,
-          defaultConfig,
-          credentialKeys: [],
-        },
-      ];
+    const response = await fetch(`${INTEGRATIONS_SH_API_BASE_URL}/${encodedDomain}/surface`, {
+      signal: AbortSignal.timeout(10_000),
     });
+    if (!response.ok) throw new Error(`integrations.sh returned HTTP ${response.status}`);
+    const payload = (await response.json()) as { description?: unknown; surfaces?: unknown };
+    if (!Array.isArray(payload.surfaces)) {
+      throw new Error('integrations.sh returned an invalid surface document');
+    }
+
+    const entries: McpCatalogEntry[] = [];
+    for (const surface of payload.surfaces) {
+      if (!isIntegrationsShMcpSurface(surface)) continue;
+      const defaultConfig = toIntegrationsShDefaultConfig(surface);
+      if (!defaultConfig) continue;
+      entries.push({
+        key: `integrations-sh-${domainEntry.domain}-${surface.slug}`,
+        name: surface.name,
+        description:
+          typeof payload.description === 'string' ? payload.description : domainEntry.description,
+        docsUrl:
+          toSafeHttpUrl(surface.docs) ??
+          `https://integrations.sh/${encodedDomain}/${surface.slug}/`,
+        iconUrl: toSafeHttpUrl(domainEntry.icon),
+        defaultConfig,
+        credentialKeys: [],
+      });
+    }
+    return entries;
   }
 
   async saveServer(server: McpServer): Promise<void> {
@@ -270,8 +293,7 @@ export class McpService {
 }
 
 const INTEGRATIONS_SH_DOMAINS_URL = 'https://integrations.sh/api/domains.json';
-const INTEGRATIONS_SH_RAW_BASE_URL =
-  'https://raw.githubusercontent.com/UsefulSoftwareCo/integrations/main/domains';
+const INTEGRATIONS_SH_API_BASE_URL = 'https://integrations.sh/api';
 const INTEGRATIONS_SH_CACHE_TTL_MS = 5 * 60_000;
 
 interface IntegrationsShDomain {

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
@@ -105,7 +105,12 @@ export class McpService {
         .slice(0, 12);
 
       const results = await Promise.all(
-        matches.map((entry) => this.loadIntegrationsShDomain(entry))
+        matches.map((entry) =>
+          this.loadIntegrationsShDomain(entry).catch((error) => {
+            log.warn(`integrations.sh domain fetch failed for "${entry.domain}"`, error);
+            return [];
+          })
+        )
       );
       const entries = results.flat().slice(0, 24);
       this.integrationsShSearchCache.set(normalizedQuery, {
@@ -168,7 +173,9 @@ export class McpService {
           key: `integrations-sh-${domainEntry.domain}-${surface.slug}`,
           name: surface.name,
           description: domainEntry.description,
-          docsUrl: surface.docs ?? `https://integrations.sh/${encodedDomain}/${surface.slug}/`,
+          docsUrl:
+            toSafeHttpUrl(surface.docs) ??
+            `https://integrations.sh/${encodedDomain}/${surface.slug}/`,
           iconUrl: domainEntry.icon,
           defaultConfig,
           credentialKeys: [],
@@ -314,17 +321,23 @@ function isIntegrationsShMcpSurface(value: unknown): value is IntegrationsShMcpS
   );
 }
 
+function toSafeHttpUrl(value: string | undefined): string | undefined {
+  if (!value) return undefined;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'https:' && url.protocol !== 'http:') return undefined;
+    return url.toString();
+  } catch {
+    return undefined;
+  }
+}
+
 function toIntegrationsShDefaultConfig(
   surface: IntegrationsShMcpSurface
 ): Record<string, unknown> | null {
   if (surface.url) {
-    try {
-      const url = new URL(surface.url);
-      if (url.protocol !== 'https:' && url.protocol !== 'http:') return null;
-      return { type: 'http', url: url.toString() };
-    } catch {
-      return null;
-    }
+    const url = toSafeHttpUrl(surface.url);
+    return url ? { type: 'http', url } : null;
   }
   if (surface.command?.trim()) {
     return { type: 'stdio', command: surface.command.trim(), args: surface.args ?? [] };

--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
@@ -199,7 +199,7 @@ export class McpService {
         docsUrl:
           toSafeHttpUrl(surface.docs) ??
           `https://integrations.sh/${encodedDomain}/${surface.slug}/`,
-        iconUrl: toSafeHttpUrl(domainEntry.icon),
+        iconUrl: toSafeIntegrationsShIconUrl(domainEntry.icon),
         defaultConfig,
         credentialKeys: [],
       });
@@ -294,6 +294,7 @@ export class McpService {
 
 const INTEGRATIONS_SH_DOMAINS_URL = 'https://integrations.sh/api/domains.json';
 const INTEGRATIONS_SH_API_BASE_URL = 'https://integrations.sh/api';
+const INTEGRATIONS_SH_ORIGIN = 'https://integrations.sh';
 const INTEGRATIONS_SH_CACHE_TTL_MS = 5 * 60_000;
 
 interface IntegrationsShDomain {
@@ -310,8 +311,6 @@ interface IntegrationsShMcpSurface {
   name: string;
   docs?: string;
   url?: string;
-  command?: string;
-  args?: string[];
 }
 
 function isIntegrationsShDomain(value: unknown): value is IntegrationsShDomain {
@@ -336,10 +335,7 @@ function isIntegrationsShMcpSurface(value: unknown): value is IntegrationsShMcpS
     /^[a-z0-9-]+$/i.test(surface.slug) &&
     typeof surface.name === 'string' &&
     (surface.docs === undefined || typeof surface.docs === 'string') &&
-    (surface.url === undefined || typeof surface.url === 'string') &&
-    (surface.command === undefined || typeof surface.command === 'string') &&
-    (surface.args === undefined ||
-      (Array.isArray(surface.args) && surface.args.every((arg) => typeof arg === 'string')))
+    (surface.url === undefined || typeof surface.url === 'string')
   );
 }
 
@@ -354,15 +350,18 @@ function toSafeHttpUrl(value: string | undefined): string | undefined {
   }
 }
 
+function toSafeIntegrationsShIconUrl(value: string): string | undefined {
+  const url = toSafeHttpUrl(value);
+  if (!url) return undefined;
+  return new URL(url).origin === INTEGRATIONS_SH_ORIGIN ? url : undefined;
+}
+
 function toIntegrationsShDefaultConfig(
   surface: IntegrationsShMcpSurface
 ): Record<string, unknown> | null {
   if (surface.url) {
     const url = toSafeHttpUrl(surface.url);
     return url ? { type: 'http', url } : null;
-  }
-  if (surface.command?.trim()) {
-    return { type: 'stdio', command: surface.command.trim(), args: surface.args ?? [] };
   }
   return null;
 }

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/McpCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/McpCard.tsx
@@ -60,7 +60,11 @@ export const McpCard: React.FC<McpCardProps> = ({ server, catalogEntry, onEdit, 
       }}
       className="relative"
     >
-      <McpServerIcon name={name} iconKey={catalogEntry?.key ?? server?.name} />
+      <McpServerIcon
+        name={name}
+        iconKey={catalogEntry?.key ?? server?.name}
+        iconUrl={catalogEntry?.iconUrl}
+      />
       <div className="flex min-w-0 flex-1 flex-col gap-0.5">
         <div className="flex min-w-0 items-center gap-2">
           <h3 className="text-smd min-w-0 truncate">{name}</h3>

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
@@ -9,12 +9,21 @@ import { McpCard } from './McpCard';
 import type { McpModalMode } from './McpModal';
 import { useMcps } from './useMcps';
 
+function normalizeMcpUrl(value: string): string {
+  try {
+    return new URL(value).toString();
+  } catch {
+    return value;
+  }
+}
+
 export const McpView: React.FC = () => {
   const [search, setSearch] = useState('');
   const {
     installed,
     catalog,
     integrationsShEntries,
+    integrationsShError,
     isSearchingIntegrationsSh,
     providers,
     isLoading,
@@ -37,15 +46,10 @@ export const McpView: React.FC = () => {
     });
   };
 
-  const openModal = (mode: McpModalMode, isIntegrationsShResult = false) => {
-    const source =
-      mode.type === 'add-catalog'
-        ? isIntegrationsShResult
-          ? 'integrations_sh'
-          : 'catalog'
-        : mode.type === 'add-custom'
-          ? 'custom'
-          : null;
+  const openModal = (
+    mode: McpModalMode,
+    source: 'catalog' | 'integrations_sh' | 'custom' | null = null
+  ) => {
     showModal('mcpServerModal', {
       mode,
       providers,
@@ -69,15 +73,20 @@ export const McpView: React.FC = () => {
   );
   const catalogUrls = new Set(
     catalog.flatMap((entry) =>
-      typeof entry.defaultConfig.url === 'string' ? [entry.defaultConfig.url] : []
+      typeof entry.defaultConfig.url === 'string' ? [normalizeMcpUrl(entry.defaultConfig.url)] : []
     )
   );
-  const installedUrls = new Set(installed.flatMap((server) => (server.url ? [server.url] : [])));
+  const installedUrls = new Set(
+    installed.flatMap((server) => (server.url ? [normalizeMcpUrl(server.url)] : []))
+  );
   const integrationsShResults = integrationsShEntries.filter((entry) => {
     const url = entry.defaultConfig.url;
+    if (typeof url !== 'string') return !installedNames.has(entry.key);
+    const normalizedUrl = normalizeMcpUrl(url);
     return (
       !installedNames.has(entry.key) &&
-      (typeof url !== 'string' || (!catalogUrls.has(url) && !installedUrls.has(url)))
+      !catalogUrls.has(normalizedUrl) &&
+      !installedUrls.has(normalizedUrl)
     );
   });
 
@@ -114,7 +123,7 @@ export const McpView: React.FC = () => {
                 className={`text-muted-foreground h-4 w-4 ${isRefreshing ? 'animate-spin' : ''}`}
               />
             </Button>
-            <Button onClick={() => openModal({ type: 'add-custom' })}>
+            <Button onClick={() => openModal({ type: 'add-custom' }, 'custom')}>
               <Plus className="size-4" />
               Custom MCP
             </Button>
@@ -142,7 +151,7 @@ export const McpView: React.FC = () => {
               <McpCard
                 key={entry.key}
                 catalogEntry={entry}
-                onAdd={(e) => openModal({ type: 'add-catalog', entry: e })}
+                onAdd={(e) => openModal({ type: 'add-catalog', entry: e }, 'catalog')}
               />
             ))}
           </CardGridSection>
@@ -156,15 +165,22 @@ export const McpView: React.FC = () => {
               <McpCard
                 key={entry.key}
                 catalogEntry={entry}
-                onAdd={(result) => openModal({ type: 'add-catalog', entry: result }, true)}
+                onAdd={(result) =>
+                  openModal({ type: 'add-catalog', entry: result }, 'integrations_sh')
+                }
               />
             ))}
           </CardGridSection>
         )}
 
+        {search.trim().length >= 2 && integrationsShError && (
+          <p className="text-destructive text-sm">integrations.sh search is unavailable.</p>
+        )}
+
         {filteredInstalled.length === 0 &&
           filteredCatalog.length === 0 &&
           integrationsShResults.length === 0 &&
+          !integrationsShError &&
           !isSearchingIntegrationsSh && (
             <div className="py-12 text-center">
               <p className="text-muted-foreground text-sm">

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
@@ -5,17 +5,10 @@ import { PageHeader } from '@renderer/lib/components/page-header';
 import { useModalContext, useShowModal } from '@renderer/lib/modal/modal-provider';
 import { Button } from '@renderer/lib/ui/button';
 import { SearchInput } from '@renderer/lib/ui/search-input';
+import { normalizeMcpUrl } from './mcp-url';
 import { McpCard } from './McpCard';
 import type { McpModalMode } from './McpModal';
 import { useMcps } from './useMcps';
-
-function normalizeMcpUrl(value: string): string {
-  try {
-    return new URL(value).toString();
-  } catch {
-    return value;
-  }
-}
 
 export const McpView: React.FC = () => {
   const [search, setSearch] = useState('');

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/McpView.tsx
@@ -10,20 +10,22 @@ import type { McpModalMode } from './McpModal';
 import { useMcps } from './useMcps';
 
 export const McpView: React.FC = () => {
+  const [search, setSearch] = useState('');
   const {
     installed,
     catalog,
+    integrationsShEntries,
+    isSearchingIntegrationsSh,
     providers,
     isLoading,
     isRefreshing,
     saveServer,
     removeServer,
     refresh,
-  } = useMcps();
+  } = useMcps(search);
 
   const { showModal, closeModal } = useModalContext();
   const showConfirm = useShowModal('confirmActionModal');
-  const [search, setSearch] = useState('');
 
   const handleRemoveRequest = (serverName: string) => {
     closeModal();
@@ -35,9 +37,15 @@ export const McpView: React.FC = () => {
     });
   };
 
-  const openModal = (mode: McpModalMode) => {
+  const openModal = (mode: McpModalMode, isIntegrationsShResult = false) => {
     const source =
-      mode.type === 'add-catalog' ? 'catalog' : mode.type === 'add-custom' ? 'custom' : null;
+      mode.type === 'add-catalog'
+        ? isIntegrationsShResult
+          ? 'integrations_sh'
+          : 'catalog'
+        : mode.type === 'add-custom'
+          ? 'custom'
+          : null;
     showModal('mcpServerModal', {
       mode,
       providers,
@@ -59,6 +67,19 @@ export const McpView: React.FC = () => {
         c.name.toLowerCase().includes(lowerSearch) ||
         c.description.toLowerCase().includes(lowerSearch))
   );
+  const catalogUrls = new Set(
+    catalog.flatMap((entry) =>
+      typeof entry.defaultConfig.url === 'string' ? [entry.defaultConfig.url] : []
+    )
+  );
+  const installedUrls = new Set(installed.flatMap((server) => (server.url ? [server.url] : [])));
+  const integrationsShResults = integrationsShEntries.filter((entry) => {
+    const url = entry.defaultConfig.url;
+    return (
+      !installedNames.has(entry.key) &&
+      (typeof url !== 'string' || (!catalogUrls.has(url) && !installedUrls.has(url)))
+    );
+  });
 
   if (isLoading) {
     return (
@@ -127,13 +148,30 @@ export const McpView: React.FC = () => {
           </CardGridSection>
         )}
 
-        {filteredInstalled.length === 0 && filteredCatalog.length === 0 && (
-          <div className="py-12 text-center">
-            <p className="text-muted-foreground text-sm">
-              {search ? 'No servers match your search.' : 'No servers available.'}
-            </p>
-          </div>
+        {(isSearchingIntegrationsSh || integrationsShResults.length > 0) && (
+          <CardGridSection
+            title={isSearchingIntegrationsSh ? 'Searching integrations.sh...' : 'integrations.sh'}
+          >
+            {integrationsShResults.map((entry) => (
+              <McpCard
+                key={entry.key}
+                catalogEntry={entry}
+                onAdd={(result) => openModal({ type: 'add-catalog', entry: result }, true)}
+              />
+            ))}
+          </CardGridSection>
         )}
+
+        {filteredInstalled.length === 0 &&
+          filteredCatalog.length === 0 &&
+          integrationsShResults.length === 0 &&
+          !isSearchingIntegrationsSh && (
+            <div className="py-12 text-center">
+              <p className="text-muted-foreground text-sm">
+                {search ? 'No servers match your search.' : 'No servers available.'}
+              </p>
+            </div>
+          )}
       </div>
     </div>
   );

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/mcp-url.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/mcp-url.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeMcpUrl } from './mcp-url';
+
+describe('normalizeMcpUrl', () => {
+  it('treats trailing slashes on server paths as equivalent', () => {
+    expect(normalizeMcpUrl('https://mcp.example.com/mcp')).toBe(
+      normalizeMcpUrl('https://mcp.example.com/mcp/')
+    );
+  });
+
+  it('preserves root URLs', () => {
+    expect(normalizeMcpUrl('https://mcp.example.com')).toBe('https://mcp.example.com/');
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/mcp-url.ts
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/mcp-url.ts
@@ -1,0 +1,11 @@
+export function normalizeMcpUrl(value: string): string {
+  try {
+    const url = new URL(value);
+    if (url.pathname.length > 1) {
+      url.pathname = url.pathname.replace(/\/+$/, '');
+    }
+    return url.toString();
+  } catch {
+    return value;
+  }
+}

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/useMcps.ts
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/useMcps.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import { useToast } from '@renderer/lib/hooks/use-toast';
+import { useDebounce } from '@renderer/lib/hooks/useDebounce';
 import { rpc } from '@renderer/lib/ipc';
 import { captureTelemetry } from '@renderer/utils/telemetryClient';
 import type { McpCatalogEntry, McpProvidersResponse, McpServer } from '@shared/core/mcp/types';
@@ -8,7 +9,7 @@ import type { McpCatalogEntry, McpProvidersResponse, McpServer } from '@shared/c
 const MCP_QUERY_KEY = ['mcp', 'all'] as const;
 const PROVIDERS_QUERY_KEY = ['mcp', 'providers'] as const;
 
-export function useMcps() {
+export function useMcps(searchQuery = '') {
   const { toast } = useToast();
   const queryClient = useQueryClient();
 
@@ -29,6 +30,17 @@ export function useMcps() {
 
   const installed: McpServer[] = mcpData?.installed ?? [];
   const catalog: McpCatalogEntry[] = mcpData?.catalog ?? [];
+  const integrationsShQuery = useDebounce(searchQuery.trim(), 300);
+  const { data: integrationsShEntries = [], isFetching: isSearchingIntegrationsSh } = useQuery({
+    queryKey: ['mcp', 'integrations-sh-search', integrationsShQuery],
+    queryFn: async () => {
+      const result = await rpc.mcp.searchIntegrationsSh({ query: integrationsShQuery });
+      if (result.success && result.data) return result.data;
+      throw new Error(result.error ?? 'Failed to search integrations.sh');
+    },
+    enabled: integrationsShQuery.length >= 2,
+    staleTime: 60_000,
+  });
 
   const { data: providers = [] } = useQuery({
     queryKey: PROVIDERS_QUERY_KEY,
@@ -42,7 +54,10 @@ export function useMcps() {
   // ── Mutations ────────────────────────────────────────────────────────
 
   const saveMutation = useMutation({
-    mutationFn: async (payload: { server: McpServer; source: 'catalog' | 'custom' | null }) => {
+    mutationFn: async (payload: {
+      server: McpServer;
+      source: 'catalog' | 'integrations_sh' | 'custom' | null;
+    }) => {
       const result = await rpc.mcp.saveServer(payload.server);
       if (!result.success) throw new Error(result.error ?? 'Failed to save server');
     },
@@ -62,7 +77,7 @@ export function useMcps() {
   });
 
   const saveServer = useCallback(
-    async (server: McpServer, source: 'catalog' | 'custom' | null = null) => {
+    async (server: McpServer, source: 'catalog' | 'integrations_sh' | 'custom' | null = null) => {
       await saveMutation.mutateAsync({ server, source });
     },
     [saveMutation]
@@ -113,6 +128,8 @@ export function useMcps() {
   return {
     installed,
     catalog,
+    integrationsShEntries,
+    isSearchingIntegrationsSh,
     providers,
     isLoading,
     isRefreshing: refreshMutation.isPending,

--- a/apps/emdash-desktop/src/renderer/features/mcp/components/useMcps.ts
+++ b/apps/emdash-desktop/src/renderer/features/mcp/components/useMcps.ts
@@ -31,7 +31,11 @@ export function useMcps(searchQuery = '') {
   const installed: McpServer[] = mcpData?.installed ?? [];
   const catalog: McpCatalogEntry[] = mcpData?.catalog ?? [];
   const integrationsShQuery = useDebounce(searchQuery.trim(), 300);
-  const { data: integrationsShEntries = [], isFetching: isSearchingIntegrationsSh } = useQuery({
+  const {
+    data: integrationsShEntries = [],
+    error: integrationsShError,
+    isFetching: isSearchingIntegrationsSh,
+  } = useQuery({
     queryKey: ['mcp', 'integrations-sh-search', integrationsShQuery],
     queryFn: async () => {
       const result = await rpc.mcp.searchIntegrationsSh({ query: integrationsShQuery });
@@ -129,6 +133,7 @@ export function useMcps(searchQuery = '') {
     installed,
     catalog,
     integrationsShEntries,
+    integrationsShError,
     isSearchingIntegrationsSh,
     providers,
     isLoading,

--- a/apps/emdash-desktop/src/renderer/utils/mcpIcons.tsx
+++ b/apps/emdash-desktop/src/renderer/utils/mcpIcons.tsx
@@ -98,14 +98,22 @@ function renderSvgMarkup(svgContent: string): React.ReactNode {
   return <div className="size-5" dangerouslySetInnerHTML={{ __html: processed }} />;
 }
 
-export const McpServerIcon: React.FC<{ name: string; iconKey?: string }> = ({ name, iconKey }) => {
+export const McpServerIcon: React.FC<{ name: string; iconKey?: string; iconUrl?: string }> = ({
+  name,
+  iconKey,
+  iconUrl,
+}) => {
   const resolvedIconKey = resolveMcpIconKey(iconKey, name);
   const icon = resolvedIconKey ? getIcon(resolvedIconKey) : undefined;
   const svgContent = icon ?? fallbackSvg;
 
   return (
     <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-background-2 transition-colors group-hover:bg-background-3">
-      {svgContent ? renderSvgMarkup(svgContent) : null}
+      {iconUrl ? (
+        <img src={iconUrl} alt="" className="size-5 rounded-sm" loading="lazy" />
+      ) : svgContent ? (
+        renderSvgMarkup(svgContent)
+      ) : null}
     </div>
   );
 };

--- a/apps/emdash-desktop/src/renderer/utils/mcpIcons.tsx
+++ b/apps/emdash-desktop/src/renderer/utils/mcpIcons.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import mcpDefaultSvg from '../../assets/images/mcp/mcp_default.svg?raw';
 import { coerceRawSvgContent, prepareInlineSvgMarkup } from './mcp-icon-data';
 
@@ -103,14 +103,22 @@ export const McpServerIcon: React.FC<{ name: string; iconKey?: string; iconUrl?:
   iconKey,
   iconUrl,
 }) => {
+  const [hasIconError, setHasIconError] = useState(false);
   const resolvedIconKey = resolveMcpIconKey(iconKey, name);
   const icon = resolvedIconKey ? getIcon(resolvedIconKey) : undefined;
   const svgContent = icon ?? fallbackSvg;
+  const showRemoteIcon = iconUrl && !hasIconError;
 
   return (
     <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-background-2 transition-colors group-hover:bg-background-3">
-      {iconUrl ? (
-        <img src={iconUrl} alt="" className="size-5 rounded-sm" loading="lazy" />
+      {showRemoteIcon ? (
+        <img
+          src={iconUrl}
+          alt=""
+          className="size-5 rounded-sm"
+          loading="lazy"
+          onError={() => setHasIconError(true)}
+        />
       ) : svgContent ? (
         renderSvgMarkup(svgContent)
       ) : null}

--- a/apps/emdash-desktop/src/shared/core/mcp/types.ts
+++ b/apps/emdash-desktop/src/shared/core/mcp/types.ts
@@ -32,6 +32,7 @@ export interface McpCatalogEntry {
   name: string;
   description: string;
   docsUrl: string;
+  iconUrl?: string;
   defaultConfig: RawServerEntry;
   credentialKeys: CredentialKey[];
 }

--- a/apps/emdash-desktop/src/shared/telemetry.ts
+++ b/apps/emdash-desktop/src/shared/telemetry.ts
@@ -149,7 +149,7 @@ export type TelemetryEventProperties = {
   open_in_external: { app: OpenInAppId | 'browser' };
   ssh_connection_attempted: { success: boolean };
 
-  mcp_server_added: { source: 'catalog' | 'custom' };
+  mcp_server_added: { source: 'catalog' | 'integrations_sh' | 'custom' };
   mcp_server_removed: EmptyProps;
 
   skill_installed: { source?: string };


### PR DESCRIPTION
### Description

Adds live MCP server search backed by [integrations.sh](https://integrations.sh) to the MCP view. When the search box has 2+ characters, the main process queries the integrations.sh domain index, loads the matching domains' MCP surfaces, and shows installable entries in a new "integrations.sh" section — deduped against the bundled catalog and already-installed servers (by key and by server URL).

Implementation notes:

- `McpService.searchIntegrationsSh` filters/sorts the domain index by popularity, fetches up to 12 domain manifests in parallel, and caches both the domain index and per-query results for 5 minutes (with stale-cache fallback on failure). A single failing domain fetch degrades to just that domain's missing entries instead of dropping the whole result set.
- Remote payloads are validated before use: domains/surfaces are shape-checked, install configs are restricted to http(s) URLs or stdio commands, and `docs` URLs are protocol-validated with a fallback to the generated integrations.sh page.
- Renderer: debounced (300ms) React Query search in `useMcps`, new section in `McpView`, remote `iconUrl` support in `McpServerIcon`/`McpCard`, and a new `integrations_sh` source for the `mcp_server_added` telemetry event.
- `getProviders` now ensures agent dependencies are probed before mapping providers, and manual refresh re-reads the shell env.

### Screenshot/Recording (if applicable)

https://cap.link/3zyk292bmnt6r25

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [ ] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>

