### PR TITLE
docs(providers): fix catalog totals

### DIFF
--- a/agents/integrations/providers.md
+++ b/agents/integrations/providers.md
@@ -7,13 +7,13 @@
 - `src/main/core/dependencies/dependency-managers.ts`
 - `src/main/core/pty/`
 
-## Current Providers (35)
+## Current Providers (34)
 
-codex, claude, grok, devin, qwen, qoder, droid, gemini, antigravity, cursor, copilot, amp, commandcode, opencode, hermes, charm, auggie, goose, kimi, kilocode, kiro, rovo, cline, continue, codebuff, freebuff, mistral, jules, junie, oh-my-pi, pi, autohand, letta, mimocode, zero
+codex, claude, grok, devin, qwen, qoder, droid, antigravity, cursor, copilot, amp, commandcode, opencode, hermes, charm, auggie, goose, kimi, kilocode, kiro, rovo, cline, continue, codebuff, freebuff, mistral, jules, junie, oh-my-pi, pi, autohand, letta, mimocode, zero
 
-## Current ACP-Capable Providers (22)
+## Current ACP-Capable Providers (21)
 
-codex, claude, opencode, grok, devin, qwen, qoder, droid, gemini, cursor, copilot, hermes, auggie, goose, kimi, kilocode, kiro, cline, mistral, junie, mimocode, oh-my-pi
+codex, claude, opencode, grok, devin, qwen, qoder, droid, cursor, copilot, hermes, auggie, goose, kimi, kilocode, kiro, cline, mistral, junie, mimocode, oh-my-pi
 
 ## Provider Metadata Includes
 


### PR DESCRIPTION
## Summary

- correct the provider catalog total from 35 to 34
- remove the unregistered Gemini provider from the provider and ACP lists
- correct the ACP-capable provider total from 22 to 21

## Why

The documentation had drifted from the live plugin registry after the Gemini plugin was removed.
