### PR TITLE
fix(antigravity): use prompt flag for initial messages

### DIFF
--- a/packages/plugins/src/agents/impl/antigravity/index.test.ts
+++ b/packages/plugins/src/agents/impl/antigravity/index.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'agy',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-session-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+describe('antigravity provider', () => {
+  it('starts a fresh prompted session with -p (not -i, which requires a TTY)', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      initialPrompt: 'say hello',
+    });
+
+    expect(command).toEqual({
+      command: 'agy',
+      args: ['--conversation=emdash-session-id', '-p', 'say hello'],
+      env: {},
+    });
+  });
+
+  it('injects --dangerously-skip-permissions for auto-approve', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      autoApprove: true,
+      initialPrompt: 'say hello',
+    });
+
+    expect(command.args).toContain('--dangerously-skip-permissions');
+  });
+
+  it('injects --conversation= on resume as well as fresh sessions', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      isResuming: true,
+    });
+
+    expect(command).toEqual({
+      command: 'agy',
+      args: ['--conversation=emdash-session-id'],
+      env: {},
+    });
+  });
+
+  it('injects --model when ctx.model is set', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      model: 'Gemini 3.1 Pro (High)',
+    });
+
+    expect(command.args).toContain('--model');
+    const modelIdx = command.args.indexOf('--model');
+    expect(command.args[modelIdx + 1]).toBe('Gemini 3.1 Pro (High)');
+  });
+});

--- a/packages/plugins/src/agents/impl/antigravity/index.ts
+++ b/packages/plugins/src/agents/impl/antigravity/index.ts
@@ -80,7 +80,7 @@ export const plugin = definePlugin(
     },
     prompt: {
       kind: 'argv',
-      flag: '-i',
+      flag: '-p',
     },
     sessions: {
       kind: 'resumable',
@@ -94,7 +94,7 @@ export const provider = registerPluginBehavior(plugin, {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
         autoApproveFlag: '--dangerously-skip-permissions',
-        initialPromptFlag: '-i',
+        initialPromptFlag: '-p',
         sessionIdFlag: '--conversation=',
         sessionIdAlways: true,
         modelFlag: '--model',

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -217,7 +217,7 @@ describe('pluginRegistry', () => {
       '--dangerously-skip-permissions',
       '--model',
       'Claude Opus 4.6 (Thinking)',
-      '-i',
+      '-p',
       'Fix the bug',
     ]);
   });


### PR DESCRIPTION
Uses `-p` when launching Antigravity with an initial prompt, because `-i` requires a TTY.
