### PR TITLE
fix(amp): correct MCP config and model options

### DIFF
--- a/packages/core/src/agents/plugins/helpers/mcp.test.ts
+++ b/packages/core/src/agents/plugins/helpers/mcp.test.ts
@@ -2,6 +2,7 @@ import { parse as parseTOML } from 'smol-toml';
 import { describe, expect, it } from 'vitest';
 import type { PluginFs } from '../../runtime/fs';
 import {
+  ampMcpAdapter,
   codexMcpAdapter,
   createMcpAdapter,
   crushMcpAdapter,
@@ -231,6 +232,81 @@ describe('droidMcpAdapter', () => {
     const result = await adapter.readServers(fs);
 
     expect(result.map((server) => server.name).sort()).toEqual(['droidLegacy', 'factoryLegacy']);
+  });
+});
+
+// ── Amp adapter ─────────────────────────────────────────────────────────────
+
+describe('ampMcpAdapter', () => {
+  const adapter = ampMcpAdapter();
+
+  it('writes MCP servers to the literal amp.mcpServers key and preserves user settings', async () => {
+    const fs = createMemoryFs({
+      '.config/amp/settings.json': jsonFile({
+        'amp.commands.allowlist': ['pnpm'],
+        'amp.tools.disable': ['web_search'],
+        'amp.mcpServers': { existing: { command: 'existing-server' } },
+      }),
+    });
+
+    await adapter.writeServers(fs, [
+      { name: 'filesystem', command: 'npx', args: ['-y', '@mcp/server'] },
+    ]);
+
+    const raw = await fs.read('.config/amp/settings.json');
+    const parsed = JSON.parse(raw!) as Record<string, unknown>;
+
+    expect(parsed['amp.commands.allowlist']).toEqual(['pnpm']);
+    expect(parsed['amp.tools.disable']).toEqual(['web_search']);
+    expect(parsed.amp).toBeUndefined();
+    expect(parsed['amp.mcpServers']).toEqual({
+      filesystem: { command: 'npx', args: ['-y', '@mcp/server'] },
+    });
+  });
+
+  it('reads MCP servers from the literal amp.mcpServers key', async () => {
+    const fs = createMemoryFs({
+      '.config/amp/settings.json': jsonFile({
+        'amp.mcpServers': { docs: { url: 'https://example.com/mcp', type: 'http' } },
+      }),
+    });
+
+    await expect(adapter.readServers(fs)).resolves.toEqual([
+      { name: 'docs', url: 'https://example.com/mcp', type: 'http' },
+    ]);
+  });
+
+  it('reads MCP servers from the legacy mcpServers key', async () => {
+    const fs = createMemoryFs({
+      '.amp/config.json': jsonFile({
+        mcpServers: { legacy: { command: 'legacy-server' } },
+      }),
+    });
+
+    await expect(adapter.readServers(fs)).resolves.toEqual([
+      { name: 'legacy', command: 'legacy-server' },
+    ]);
+  });
+
+  it('removes MCP servers from canonical and legacy keys', async () => {
+    const fs = createMemoryFs({
+      '.config/amp/settings.json': jsonFile({
+        'amp.mcpServers': { gone: { command: 'canonical-server' } },
+      }),
+      '.amp/config.json': jsonFile({
+        mcpServers: { gone: { command: 'legacy-server' } },
+      }),
+    });
+
+    await adapter.removeServer(fs, 'gone');
+
+    const canonical = JSON.parse((await fs.read('.config/amp/settings.json'))!) as Record<
+      string,
+      unknown
+    >;
+    const legacy = JSON.parse((await fs.read('.amp/config.json'))!) as Record<string, unknown>;
+    expect(canonical['amp.mcpServers']).toEqual({});
+    expect(legacy.mcpServers).toEqual({});
   });
 });
 

--- a/packages/core/src/agents/plugins/helpers/mcp.ts
+++ b/packages/core/src/agents/plugins/helpers/mcp.ts
@@ -50,8 +50,14 @@ type McpConfigShape = {
   configPath: string;
   /** Extra paths read for migration only — never written. */
   legacyReadPaths?: string[];
+  /** Optional server key used only by legacyReadPaths. */
+  legacyServersKey?: string;
+  /** Treat legacyServersKey as a literal key instead of a dot-delimited object path. */
+  legacyServersKeyIsLiteral?: boolean;
   format: 'json' | 'toml';
   serversKey: string;
+  /** Treat serversKey as a literal key instead of a dot-delimited object path. */
+  serversKeyIsLiteral?: boolean;
   toNative(server: McpServerRegistration): Record<string, unknown>;
   fromNative(name: string, raw: Record<string, unknown>): McpServerRegistration;
 };
@@ -63,15 +69,42 @@ function parseMcpFile(content: string, format: 'json' | 'toml'): Record<string, 
 }
 
 export function createMcpAdapter(shape: McpConfigShape) {
+  const getServers = (
+    parsed: Record<string, unknown>,
+    serversKey = shape.serversKey,
+    serversKeyIsLiteral = shape.serversKeyIsLiteral
+  ): unknown => (serversKeyIsLiteral ? parsed[serversKey] : getNestedValue(parsed, serversKey));
+
+  const setServers = (
+    parsed: Record<string, unknown>,
+    servers: unknown,
+    serversKey = shape.serversKey,
+    serversKeyIsLiteral = shape.serversKeyIsLiteral
+  ): void => {
+    if (serversKeyIsLiteral) {
+      parsed[serversKey] = servers;
+      return;
+    }
+    setNestedValue(parsed, serversKey, servers);
+  };
+
+  const legacyServersKey = shape.legacyServersKey ?? shape.serversKey;
+  const legacyServersKeyIsLiteral =
+    shape.legacyServersKey === undefined
+      ? shape.serversKeyIsLiteral
+      : shape.legacyServersKeyIsLiteral;
+
   async function readFromPath(
     fs: PluginFs,
-    filePath: string
+    filePath: string,
+    serversKey = shape.serversKey,
+    serversKeyIsLiteral = shape.serversKeyIsLiteral
   ): Promise<Map<string, McpServerRegistration>> {
     const content = await fs.read(filePath);
     if (!content) return new Map();
     try {
       const parsed = parseMcpFile(content, shape.format);
-      const servers = getNestedValue(parsed, shape.serversKey) ?? {};
+      const servers = getServers(parsed, serversKey, serversKeyIsLiteral) ?? {};
       return new Map(
         Object.entries(servers as Record<string, unknown>).map(([name, raw]) => [
           name,
@@ -83,17 +116,23 @@ export function createMcpAdapter(shape: McpConfigShape) {
     }
   }
 
-  async function removeFromPath(fs: PluginFs, filePath: string, name: string): Promise<void> {
+  async function removeFromPath(
+    fs: PluginFs,
+    filePath: string,
+    name: string,
+    serversKey = shape.serversKey,
+    serversKeyIsLiteral = shape.serversKeyIsLiteral
+  ): Promise<void> {
     const content = await fs.read(filePath);
     if (!content) return;
     try {
       const parsed = parseMcpFile(content, shape.format);
-      const servers = getNestedValue(parsed, shape.serversKey) ?? {};
+      const servers = getServers(parsed, serversKey, serversKeyIsLiteral) ?? {};
       if (!(name in (servers as Record<string, unknown>))) return;
       const filtered = Object.fromEntries(
         Object.entries(servers as Record<string, unknown>).filter(([k]) => k !== name)
       );
-      setNestedValue(parsed, shape.serversKey, filtered);
+      setServers(parsed, filtered, serversKey, serversKeyIsLiteral);
       const output =
         shape.format === 'json' ? JSON.stringify(parsed, null, 2) + '\n' : stringifyTOML(parsed);
       await fs.write(filePath, output);
@@ -107,7 +146,12 @@ export function createMcpAdapter(shape: McpConfigShape) {
       const serverMap = new Map<string, McpServerRegistration>();
       // Legacy paths first (lower priority — canonical wins on name conflict)
       for (const legacyPath of shape.legacyReadPaths ?? []) {
-        for (const [name, reg] of await readFromPath(fs, legacyPath)) {
+        for (const [name, reg] of await readFromPath(
+          fs,
+          legacyPath,
+          legacyServersKey,
+          legacyServersKeyIsLiteral
+        )) {
           if (!serverMap.has(name)) serverMap.set(name, reg);
         }
       }
@@ -122,7 +166,7 @@ export function createMcpAdapter(shape: McpConfigShape) {
       const content = await fs.read(shape.configPath);
       const parsed: Record<string, unknown> = content ? parseMcpFile(content, shape.format) : {};
       const native = Object.fromEntries(servers.map((s) => [s.name, shape.toNative(s)]));
-      setNestedValue(parsed, shape.serversKey, native);
+      setServers(parsed, native);
       const output =
         shape.format === 'json' ? JSON.stringify(parsed, null, 2) + '\n' : stringifyTOML(parsed);
       await fs.write(shape.configPath, output);
@@ -132,7 +176,7 @@ export function createMcpAdapter(shape: McpConfigShape) {
       await removeFromPath(fs, shape.configPath, name);
       // Remove from all legacy paths so a stale copy cannot resurface on next read
       for (const legacyPath of shape.legacyReadPaths ?? []) {
-        await removeFromPath(fs, legacyPath, name);
+        await removeFromPath(fs, legacyPath, name, legacyServersKey, legacyServersKeyIsLiteral);
       }
     },
   };
@@ -425,14 +469,28 @@ export function droidMcpAdapter(
 }
 
 /**
- * Amp adapter — passthrough, uses mcpServers JSON key.
+ * Amp adapter — passthrough, uses the literal `amp.mcpServers` JSON key.
  * Write: ~/.config/amp/settings.json; legacy read: ~/.amp/config.json.
  */
 export function ampMcpAdapter(
   configPath = '.config/amp/settings.json',
   legacyReadPaths = ['.amp/config.json']
 ) {
-  return passthroughMcpAdapter(configPath, legacyReadPaths);
+  return createMcpAdapter({
+    configPath,
+    legacyReadPaths,
+    legacyServersKey: 'mcpServers',
+    format: 'json',
+    serversKey: 'amp.mcpServers',
+    serversKeyIsLiteral: true,
+    toNative(s) {
+      const { name: _n, ...rest } = s;
+      return rest as Record<string, unknown>;
+    },
+    fromNative(name, raw) {
+      return { name, ...raw } as McpServerRegistration;
+    },
+  });
 }
 
 /**

--- a/packages/plugins/src/agents/impl/amp/index.ts
+++ b/packages/plugins/src/agents/impl/amp/index.ts
@@ -42,17 +42,21 @@ export const plugin = definePlugin(
     models: {
       kind: 'selectable',
       modelOptions: {
-        smart: {
-          name: 'Smart',
-          modelFeatures: { intelligence: 4, speed: 4 },
+        low: {
+          name: 'Low',
+          modelFeatures: { intelligence: 2, speed: 5 },
         },
-        rush: {
-          name: 'Rush',
-          modelFeatures: { intelligence: 3, speed: 5 },
+        medium: {
+          name: 'Medium',
+          modelFeatures: { intelligence: 3, speed: 4 },
         },
-        deep: {
-          name: 'Deep',
-          modelFeatures: { intelligence: 5, speed: 3 },
+        high: {
+          name: 'High',
+          modelFeatures: { intelligence: 4, speed: 3 },
+        },
+        ultra: {
+          name: 'Ultra',
+          modelFeatures: { intelligence: 5, speed: 2 },
         },
       },
     },

--- a/packages/plugins/src/agents/impl/amp/index.ts
+++ b/packages/plugins/src/agents/impl/amp/index.ts
@@ -8,6 +8,12 @@ import {
 import { AMP_PLUGIN_CONTENT } from './plugin-file';
 
 const AMP_PLUGIN_PATH = '.amp/plugins/emdash-hook.ts';
+const LEGACY_MODEL_ALIASES: Record<string, string> = {
+  deep: 'ultra',
+  rush: 'low',
+  smart: 'high',
+};
+
 // Amp thread ids are prefixed with 'T-'; only accept those for resume.
 const validateSessionId = (id: string) => id.startsWith('T-');
 import { icon } from './icon';
@@ -77,15 +83,18 @@ export const plugin = definePlugin(
 export const provider = registerPluginBehavior(plugin, {
   prompt: {
     buildCommand: (ctx) =>
-      buildStandardCommand(ctx, {
-        autoApproveFlag: '--dangerously-allow-all',
-        initialPromptViaStdinPipe: true,
-        extraEnv: { PLUGINS: 'all' },
-        resumeFlag: 'threads continue',
-        sessionIdFlag: 'threads continue',
-        sessionIdOnResumeOnly: true,
-        modelFlag: '-m',
-      }),
+      buildStandardCommand(
+        { ...ctx, model: LEGACY_MODEL_ALIASES[ctx.model] ?? ctx.model },
+        {
+          autoApproveFlag: '--dangerously-allow-all',
+          initialPromptViaStdinPipe: true,
+          extraEnv: { PLUGINS: 'all' },
+          resumeFlag: 'threads continue',
+          sessionIdFlag: 'threads continue',
+          sessionIdOnResumeOnly: true,
+          modelFlag: '-m',
+        }
+      ),
   },
   mcp: ampMcpAdapter(),
   plugins: createFileDropPlugin({ relativePath: AMP_PLUGIN_PATH, content: AMP_PLUGIN_CONTENT }),

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -257,6 +257,17 @@ describe('pluginRegistry', () => {
     });
 
     expect(result.args).toEqual(['--dangerously-allow-all', '-m', 'ultra']);
+
+    const legacy = amp.behavior.prompt!.buildCommand({
+      cli: 'amp',
+      autoApprove: true,
+      initialPrompt: '',
+      sessionId: 'conv-1',
+      isResuming: false,
+      model: 'deep',
+    });
+
+    expect(legacy.args).toEqual(['--dangerously-allow-all', '-m', 'ultra']);
   });
 
   it('exposes Mistral Vibe models and passes the selected model through env', () => {

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -240,9 +240,10 @@ describe('pluginRegistry', () => {
     expect(amp.capabilities.models).toMatchObject({
       kind: 'selectable',
       modelOptions: {
-        smart: { name: 'Smart' },
-        rush: { name: 'Rush' },
-        deep: { name: 'Deep' },
+        low: { name: 'Low' },
+        medium: { name: 'Medium' },
+        high: { name: 'High' },
+        ultra: { name: 'Ultra' },
       },
     });
 
@@ -252,10 +253,10 @@ describe('pluginRegistry', () => {
       initialPrompt: '',
       sessionId: 'conv-1',
       isResuming: false,
-      model: 'deep',
+      model: 'ultra',
     });
 
-    expect(result.args).toEqual(['--dangerously-allow-all', '-m', 'deep']);
+    expect(result.args).toEqual(['--dangerously-allow-all', '-m', 'ultra']);
   });
 
   it('exposes Mistral Vibe models and passes the selected model through env', () => {


### PR DESCRIPTION
### Description

Fixes the Amp integration so MCP servers are stored under Amp’s literal `amp.mcpServers` key in `~/.config/amp/settings.json`, rather than being interpreted as a nested JSON path. Existing user settings are preserved, and legacy `~/.amp/config.json` entries remain readable and removable during migration.

Also updates the selectable Amp model options from the obsolete Smart/Rush/Deep presets to Low/Medium/High/Ultra.


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>