### PR TITLE
fix(chat): prevent provider name clipping

### DIFF
--- a/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
@@ -200,6 +200,9 @@ export const toolbar = style({
 export const toolbarLeft = style({ display: 'flex', alignItems: 'center', gap: '0.375rem' });
 export const toolbarRight = style({ display: 'flex', alignItems: 'center', gap: '0.25rem' });
 
+// Keep the active provider/model label readable when other toolbar controls are present.
+export const modelTrigger = style({ flexShrink: 0 });
+
 // ── Agent trigger ─────────────────────────────────────────────────────────────
 
 export const agentTrigger = style({

--- a/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
@@ -200,9 +200,6 @@ export const toolbar = style({
 export const toolbarLeft = style({ display: 'flex', alignItems: 'center', gap: '0.375rem' });
 export const toolbarRight = style({ display: 'flex', alignItems: 'center', gap: '0.25rem' });
 
-// Keep the active provider/model label readable when other toolbar controls are present.
-export const modelTrigger = style({ flexShrink: 0 });
-
 // ── Agent trigger ─────────────────────────────────────────────────────────────
 
 export const agentTrigger = style({

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -860,7 +860,7 @@ export function ChatComposer({
                         overflow: 'hidden',
                         textOverflow: 'ellipsis',
                         whiteSpace: 'nowrap',
-                        lineHeight: 1,
+                        lineHeight: 1.25,
                       }}
                     >
                       {selected?.name ?? 'Model…'}

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -835,6 +835,7 @@ export function ChatComposer({
                 disabled={disabled}
                 searchPlaceholder="Search models…"
                 contentStyle={{ minWidth: '12.5rem' }}
+                className={styles.modelTrigger}
                 triggerTitle={() => selectedAgentTitle}
                 renderTrigger={(selected) => (
                   <span

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -835,7 +835,6 @@ export function ChatComposer({
                 disabled={disabled}
                 searchPlaceholder="Search models…"
                 contentStyle={{ minWidth: '12.5rem' }}
-                className={styles.modelTrigger}
                 triggerTitle={() => selectedAgentTitle}
                 renderTrigger={(selected) => (
                   <span


### PR DESCRIPTION
## Summary

Fixes ENG-1832 by keeping the provider/model trigger from shrinking and giving its clipped text label enough line height for descenders.

## Root cause

The model selector could shrink under toolbar pressure, and its text label used a unit line height inside an overflow-clipped span, which cut off descenders such as `g`.

## screenshot
after:
<img width="182" height="29" alt="Screenshot 2026-07-13 at 14 36 27" src="https://github.com/user-attachments/assets/6a9a44c7-6c77-4684-8918-0351d1f9bcd5" />

