### PR TITLE
feat(pi): add ACP integration

### DIFF
--- a/agents/integrations/providers.md
+++ b/agents/integrations/providers.md
@@ -7,13 +7,13 @@
 - `src/main/core/dependencies/dependency-managers.ts`
 - `src/main/core/pty/`
 
-## Current Providers (35)
+## Current Providers (34)
 
-codex, claude, grok, devin, qwen, qoder, droid, gemini, antigravity, cursor, copilot, amp, commandcode, opencode, hermes, charm, auggie, goose, kimi, kilocode, kiro, rovo, cline, continue, codebuff, freebuff, mistral, jules, junie, oh-my-pi, pi, autohand, letta, mimocode, zero
+codex, claude, grok, devin, qwen, qoder, droid, antigravity, cursor, copilot, amp, commandcode, opencode, hermes, charm, auggie, goose, kimi, kilocode, kiro, rovo, cline, continue, codebuff, freebuff, mistral, jules, junie, oh-my-pi, pi, autohand, letta, mimocode, zero
 
 ## Current ACP-Capable Providers (22)
 
-codex, claude, opencode, grok, devin, qwen, qoder, droid, gemini, cursor, copilot, hermes, auggie, goose, kimi, kilocode, kiro, cline, mistral, junie, mimocode, oh-my-pi
+codex, claude, opencode, grok, devin, qwen, qoder, droid, cursor, copilot, hermes, auggie, goose, kimi, kilocode, kiro, cline, mistral, junie, mimocode, oh-my-pi, pi
 
 ## Provider Metadata Includes
 

--- a/packages/plugins/package.json
+++ b/packages/plugins/package.json
@@ -56,6 +56,7 @@
     "asana": "^3.1.12",
     "featurebase-node": "^0.14.0",
     "jira.js": "^5.4.0",
+    "pi-acp": "^0.0.31",
     "smol-toml": "^1.6.0",
     "trello.js": "^2.1.4",
     "zod": "^4.4.3"

--- a/packages/plugins/src/agents/impl/claude/acp.test.ts
+++ b/packages/plugins/src/agents/impl/claude/acp.test.ts
@@ -30,7 +30,9 @@ describe('claude acp capability', () => {
       'kiro',
       'mimocode',
       'mistral',
+      'oh-my-pi',
       'opencode',
+      'pi',
       'qoder',
       'qwen',
     ]);

--- a/packages/plugins/src/agents/impl/pi/acp.test.ts
+++ b/packages/plugins/src/agents/impl/pi/acp.test.ts
@@ -26,7 +26,7 @@ describe('pi acp behavior', () => {
 
     expect(result.command).toBe(process.execPath);
     expect(result.args).toHaveLength(1);
-    expect(result.args[0]).toContain('pi-acp');
+    expect(result.args[0]).toMatch(/pi-acp[/\\]dist[/\\]index\.js$/);
     expect(result.env).toEqual({
       ELECTRON_RUN_AS_NODE: '1',
       PI_ACP_PI_COMMAND: '/usr/local/bin/pi',

--- a/packages/plugins/src/agents/impl/pi/acp.test.ts
+++ b/packages/plugins/src/agents/impl/pi/acp.test.ts
@@ -1,0 +1,51 @@
+import { Readable, Writable } from 'node:stream';
+import type { Agent } from '@agentclientprotocol/sdk';
+import type { AcpClientFactory } from '@emdash/core/agents/plugins';
+import { describe, expect, it, vi } from 'vitest';
+import { pluginRegistry } from '../../registry';
+
+describe('pi acp capability', () => {
+  it('declares acp: { kind: supported }', () => {
+    const pi = pluginRegistry.get('pi');
+
+    expect(pi).toBeDefined();
+    expect(pi!.capabilities.acp.kind).toBe('supported');
+  });
+});
+
+describe('pi acp behavior', () => {
+  const pi = () => pluginRegistry.get('pi')!;
+  const acpBehavior = () => pi().behavior.acp!;
+
+  it('runs the bundled adapter against the resolved Pi executable', () => {
+    const result = acpBehavior().buildSpawn({
+      cwd: '/home/user/worktrees/task-1',
+      env: {},
+      cli: '/usr/local/bin/pi',
+    });
+
+    expect(result.command).toBe(process.execPath);
+    expect(result.args).toHaveLength(1);
+    expect(result.args[0]).toContain('pi-acp');
+    expect(result.env).toEqual({
+      ELECTRON_RUN_AS_NODE: '1',
+      PI_ACP_PI_COMMAND: '/usr/local/bin/pi',
+      PI_ACP_QUIET_STARTUP: 'true',
+    });
+  });
+
+  it('connects the adapter stdio to an ACP client', () => {
+    const stdin = new Writable({ write: (_chunk, _encoding, callback) => callback() });
+    const stdout = new Readable({ read: () => {} });
+    const toClient: AcpClientFactory = () => ({
+      requestPermission: vi.fn(),
+      sessionUpdate: vi.fn(),
+    });
+
+    const agentApi = acpBehavior().connect({ stdin, stdout }, toClient);
+
+    expect(typeof (agentApi as Agent).initialize).toBe('function');
+    expect(typeof (agentApi as Agent).newSession).toBe('function');
+    expect(typeof (agentApi as Agent).prompt).toBe('function');
+  });
+});

--- a/packages/plugins/src/agents/impl/pi/index.ts
+++ b/packages/plugins/src/agents/impl/pi/index.ts
@@ -1,4 +1,5 @@
 import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
 import { definePlugin, registerPluginBehavior } from '@emdash/core/agents/plugins';
 import {
   buildStandardCommand,
@@ -14,7 +15,7 @@ import { icon } from './icon';
 const _require = createRequire(import.meta.url);
 
 function resolvePiAcpEntry(): string {
-  return _require.resolve('pi-acp');
+  return join(dirname(_require.resolve('pi-acp/package.json')), 'dist/index.js');
 }
 
 export const plugin = definePlugin(

--- a/packages/plugins/src/agents/impl/pi/index.ts
+++ b/packages/plugins/src/agents/impl/pi/index.ts
@@ -1,13 +1,21 @@
+import { createRequire } from 'node:module';
 import { definePlugin, registerPluginBehavior } from '@emdash/core/agents/plugins';
 import {
   buildStandardCommand,
   createFileDropPlugin,
   npmDependency,
 } from '@emdash/core/agents/plugins/helpers';
+import { connectStdioAcp } from '../../helpers/acp-stdio';
 import { PI_EXTENSION_CONTENT } from './plugin-file';
 
 const PI_EXTENSION_PATH = '.pi/extensions/emdash-hook.ts';
 import { icon } from './icon';
+
+const _require = createRequire(import.meta.url);
+
+function resolvePiAcpEntry(): string {
+  return _require.resolve('pi-acp');
+}
 
 export const plugin = definePlugin(
   {
@@ -18,6 +26,9 @@ export const plugin = definePlugin(
     websiteUrl: 'https://github.com/earendil-works/pi/tree/main/packages/coding-agent',
   },
   {
+    acp: {
+      kind: 'supported',
+    },
     hooks: {
       kind: 'plugin',
       scope: 'workspace',
@@ -44,6 +55,20 @@ export const plugin = definePlugin(
 );
 
 export const provider = registerPluginBehavior(plugin, {
+  acp: {
+    buildSpawn: (ctx) => ({
+      command: process.execPath,
+      args: [resolvePiAcpEntry()],
+      env: {
+        ELECTRON_RUN_AS_NODE: '1',
+        PI_ACP_PI_COMMAND: ctx.cli,
+        // Patched into pi-acp so Emdash can suppress its synthetic prelude without
+        // changing the user's global or project-level Pi settings.
+        PI_ACP_QUIET_STARTUP: 'true',
+      },
+    }),
+    connect: connectStdioAcp,
+  },
   prompt: {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {

--- a/patches/pi-acp@0.0.31.patch
+++ b/patches/pi-acp@0.0.31.patch
@@ -1,0 +1,12 @@
+diff --git a/dist/index.js b/dist/index.js
+index d67c4b8f48ac37dfeaa5f18ec60c5aedda8d37e5..3cc77d6f5ffdc7606b6f47d08ba51098118e1066 100755
+--- a/dist/index.js
++++ b/dist/index.js
+@@ -1606,6 +1606,7 @@ function getEnableSkillCommands(cwd) {
+   return true;
+ }
+ function getQuietStartup(cwd) {
++  if (process.env.PI_ACP_QUIET_STARTUP === "true") return true;
+   const merged = getMergedSettings(cwd);
+   const direct = merged.quietStartup;
+   if (typeof direct === "boolean") return direct;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,11 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+patchedDependencies:
+  pi-acp@0.0.31:
+    hash: 7c34f8f3b2a1e8c4fbaab390b1d3438555e4fc1f63170f2347f3c0707da6a945
+    path: patches/pi-acp@0.0.31.patch
+
 importers:
 
   .:
@@ -594,6 +599,9 @@ importers:
       jira.js:
         specifier: ^5.4.0
         version: 5.4.0
+      pi-acp:
+        specifier: ^0.0.31
+        version: 0.0.31(patch_hash=7c34f8f3b2a1e8c4fbaab390b1d3438555e4fc1f63170f2347f3c0707da6a945)
       smol-toml:
         specifier: ^1.6.0
         version: 1.6.1
@@ -853,6 +861,11 @@ packages:
   '@agentclientprotocol/codex-acp@1.0.2':
     resolution: {integrity: sha512-4CxkkqyeX62TBzv4RW5N3TI/4oy7QaWWzOBnwH5VGWa2UdhIg7qwvudyKFv0aOdJfWHcRSNZ3y8c0idaUquZfQ==}
     hasBin: true
+
+  '@agentclientprotocol/sdk@0.26.0':
+    resolution: {integrity: sha512-ialrcI+RzKOYe+fw+TfpyTdRmEoqIkXLlwbTi6XgaXXfdhNcdod7TmE1VsTnG3yTlox8TMTSMQgWbLLbz3r86Q==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
 
   '@agentclientprotocol/sdk@1.1.0':
     resolution: {integrity: sha512-NT2KqphUJ3w6EksUL51ZhJgIYgq/ZLGcBPkyMKgRSO5PMVwe9DnKKX+Htnvk6KHh6dUuh34UHK4gKp+4te1Mdg==}
@@ -7451,6 +7464,11 @@ packages:
   pend@1.2.0:
     resolution: {integrity: sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==}
 
+  pi-acp@0.0.31:
+    resolution: {integrity: sha512-LZm1EUV/ax27V+m3pjvK2QvhCfHNTFZsKLNwplVlFuyaSKOFTVdh3IRwfbtM5xqaDe0wmToosI6g3DgScx5aGA==}
+    engines: {node: '>=20'}
+    hasBin: true
+
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
 
@@ -9188,6 +9206,9 @@ packages:
   zod@3.24.4:
     resolution: {integrity: sha512-OdqJE9UDRPwWsrHjLN2F8bPxvwJBK22EHLWtanu0LSYr5YqzsaaW3RMgmjwr8Rypg5k+meEJdSPXJZXE/yqOMg==}
 
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
@@ -9231,6 +9252,10 @@ snapshots:
       open: 11.0.0
       vscode-jsonrpc: 8.2.1
       zod: 4.4.3
+
+  '@agentclientprotocol/sdk@0.26.0(zod@3.25.76)':
+    dependencies:
+      zod: 3.25.76
 
   '@agentclientprotocol/sdk@1.1.0(zod@4.4.3)':
     dependencies:
@@ -16302,6 +16327,11 @@ snapshots:
 
   pend@1.2.0: {}
 
+  pi-acp@0.0.31(patch_hash=7c34f8f3b2a1e8c4fbaab390b1d3438555e4fc1f63170f2347f3c0707da6a945):
+    dependencies:
+      '@agentclientprotocol/sdk': 0.26.0(zod@3.25.76)
+      zod: 3.25.76
+
   picocolors@1.1.1: {}
 
   picomatch-browser@2.2.6: {}
@@ -18184,6 +18214,8 @@ snapshots:
       zod: 4.4.3
 
   zod@3.24.4: {}
+
+  zod@3.25.76: {}
 
   zod@4.4.3: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,3 +1,6 @@
 packages:
   - 'apps/*'
   - 'packages/**'
+
+patchedDependencies:
+  pi-acp@0.0.31: patches/pi-acp@0.0.31.patch


### PR DESCRIPTION
### Description

Adds ACP support for Pi by launching the bundled `pi-acp` adapter under Electron's Node runtime and wiring its stdio to Emdash's ACP client. The adapter is configured to invoke the discovered Pi CLI.

This PR includes a targeted `patches/pi-acp@0.0.31.patch`: it adds the `PI_ACP_QUIET_STARTUP` environment override so Emdash can suppress Pi ACP's synthetic startup prelude without changing a user's global or project Pi settings.

### Related issues

None.

### Testing

- `pnpm --filter @emdash/plugins exec vitest run src/agents/impl/pi/acp.test.ts src/agents/impl/claude/acp.test.ts`
- `pnpm --filter @emdash/plugins run typecheck`
- `pnpm --filter @emdash/plugins run format:check`
- `pnpm --filter @emdash/plugins run lint`

### Screenshot/Recording (if applicable)

https://cap.link/b6z4zzc0es76smd

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
