### PR TITLE
fix(tasks): Create from Issue always redirects to Integrations for github.com repos

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list-empty-state.tsx
+++ b/apps/emdash-desktop/src/renderer/features/projects/components/task-view/task-list-empty-state.tsx
@@ -24,8 +24,15 @@ export const TaskListEmptyState = observer(function TaskListEmptyState({
 }) {
   const showTaskModal = useShowModal('taskModal');
   const { navigate } = useNavigate();
-  const { hasAnyIssueIntegration } = useConnectedIssueProviders();
   const repositoryStore = getGitRepositoryStore(projectId);
+  // Pass the repository URL as context so repository-scoped issue providers
+  // (e.g. GitHub on github.com, which declares requiresRepositoryUrl) are
+  // considered usable here. Without it, isProviderUsable() rejects them and
+  // "Create from Issue" always routes to Integrations settings even when the
+  // provider is connected. Mirrors create-task-modal.tsx.
+  const repositoryUrl =
+    repositoryStore?.canonicalRepositoryUrl ?? repositoryStore?.pullRequestRepositoryUrl;
+  const { hasAnyIssueIntegration } = useConnectedIssueProviders({ repositoryUrl });
   const supportsPullRequests = Boolean(repositoryStore?.pullRequestRepositoryUrl);
   const supportsGhesIssues = Boolean(
     repositoryStore?.issueRepositoryUrl &&


### PR DESCRIPTION
## Problem

For a repository hosted on **github.com**, the **"Create from Issue"** action in the empty task list (`TaskListEmptyState`) always routes to Settings → Integrations instead of opening the task modal — even when GitHub is connected and issues are accessible. No GitHub API request is made; the redirect is decided entirely in the renderer.

"Create from Pull Request" is unaffected (it uses a separate repo-based flag), which is why the two behave differently.

## Root cause

`TaskListEmptyState` calls `useConnectedIssueProviders()` **without a context**:

```ts
const { hasAnyIssueIntegration } = useConnectedIssueProviders();
```

`isProviderUsable` (in `provider-utils.ts`) rejects any provider that requires a repository URL when none is supplied:

```ts
if (status.capabilities.requiresRepositoryUrl && !context.repositoryUrl) return false;
```

The GitHub issue provider declares `requiredInputs: ["repositoryUrl"]`, so it is filtered out and `hasAnyIssueIntegration` is always `false`. The only fallback, `supportsGhesIssues`, is gated on `!isGitHubDotComHost(...)` — GitHub **Enterprise** only. Net result: **github.com** repos never qualify and the button always redirects.

`create-task-modal.tsx` calls the same hook **correctly**, passing the repo URL, which is why the issue flow works once the modal is open.

## Fix

Derive `repositoryUrl` from the repository store and pass it as context, mirroring `create-task-modal.tsx`:

```ts
const repositoryUrl =
  repositoryStore?.canonicalRepositoryUrl ?? repositoryStore?.pullRequestRepositoryUrl;
const { hasAnyIssueIntegration } = useConnectedIssueProviders({ repositoryUrl });
```

The `supportsGhesIssues` fallback is left intact.

## How to reproduce

1. Connect a GitHub account (github.com; e.g. via `gh` CLI import).
2. Open a project whose remote is a github.com repo, with an empty task list.
3. Click **Create from Issue** → redirected to Integrations (expected: the "from issue" modal opens and lists open issues).

Found on v1.1.38.
