### PR TITLE
fix(git): authenticate git transport with the project's linked GitHub account

### DIFF
--- a/apps/emdash-desktop/src/main/core/execution-context/github-auth-execution-context.test.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/github-auth-execution-context.test.ts
@@ -26,6 +26,18 @@ function fakeBase() {
 
 const AUTH: GitHubGitAuth = { host: 'github.com', token: 'tok' };
 
+/** Find the extraheader key/value pair regardless of which GIT_CONFIG index it landed on. */
+function extraHeader(env: Record<string, string> | undefined) {
+  if (!env) return undefined;
+  const keyEntry = Object.entries(env).find(
+    ([name, value]) =>
+      name.startsWith('GIT_CONFIG_KEY_') && value === 'http.https://github.com/.extraheader'
+  );
+  if (!keyEntry) return undefined;
+  const index = keyEntry[0].slice('GIT_CONFIG_KEY_'.length);
+  return { count: env.GIT_CONFIG_COUNT, value: env[`GIT_CONFIG_VALUE_${index}`] };
+}
+
 describe('GitHubAuthExecutionContext', () => {
   it('injects host-scoped auth env for git network operations', async () => {
     const { base, exec } = fakeBase();
@@ -34,8 +46,9 @@ describe('GitHubAuthExecutionContext', () => {
     await ctx.exec('git', ['fetch', 'origin']);
 
     const opts = exec.mock.calls[0][2] as ExecOptions;
-    expect(opts.env?.GIT_CONFIG_KEY_0).toBe('http.https://github.com/.extraheader');
-    expect(opts.env?.GIT_CONFIG_VALUE_0).toContain('Authorization: Basic ');
+    const header = extraHeader(opts.env);
+    expect(header?.count).toBeDefined();
+    expect(header?.value).toContain('Authorization: Basic ');
   });
 
   it('does not inject for local git operations', async () => {
@@ -78,7 +91,7 @@ describe('GitHubAuthExecutionContext', () => {
 
     const opts = exec.mock.calls[0][2] as ExecOptions;
     expect(opts.env?.FOO).toBe('bar');
-    expect(opts.env?.GIT_CONFIG_COUNT).toBe('1');
+    expect(extraHeader(opts.env)?.value).toContain('Authorization: Basic ');
   });
 
   it('delegates root, supportsLocalSpawn and dispose to the base context', () => {

--- a/apps/emdash-desktop/src/main/core/execution-context/github-auth-execution-context.test.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/github-auth-execution-context.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  GitHubAuthExecutionContext,
+  type GitHubGitAuth,
+} from './github-auth-execution-context';
+import type { ExecOptions, ExecResult, IExecutionContext } from './types';
+
+function fakeBase() {
+  const exec = vi.fn(
+    async (_command: string, _args: string[] = [], _opts: ExecOptions = {}): Promise<ExecResult> => ({
+      stdout: '',
+      stderr: '',
+    })
+  );
+  const execStreaming = vi.fn(async () => {});
+  const dispose = vi.fn();
+  const base: IExecutionContext = {
+    root: '/repo',
+    supportsLocalSpawn: true,
+    exec,
+    execStreaming,
+    dispose,
+  };
+  return { base, exec, execStreaming, dispose };
+}
+
+const AUTH: GitHubGitAuth = { host: 'github.com', token: 'tok' };
+
+describe('GitHubAuthExecutionContext', () => {
+  it('injects host-scoped auth env for git network operations', async () => {
+    const { base, exec } = fakeBase();
+    const ctx = new GitHubAuthExecutionContext(base, async () => AUTH);
+
+    await ctx.exec('git', ['fetch', 'origin']);
+
+    const opts = exec.mock.calls[0][2] as ExecOptions;
+    expect(opts.env?.GIT_CONFIG_KEY_0).toBe('http.https://github.com/.extraheader');
+    expect(opts.env?.GIT_CONFIG_VALUE_0).toContain('Authorization: Basic ');
+  });
+
+  it('does not inject for local git operations', async () => {
+    const { base, exec } = fakeBase();
+    const ctx = new GitHubAuthExecutionContext(base, async () => AUTH);
+
+    await ctx.exec('git', ['worktree', 'list']);
+
+    const opts = (exec.mock.calls[0][2] ?? {}) as ExecOptions;
+    expect(opts.env).toBeUndefined();
+  });
+
+  it('does not inject for non-git commands', async () => {
+    const { base, exec } = fakeBase();
+    const ctx = new GitHubAuthExecutionContext(base, async () => AUTH);
+
+    await ctx.exec('gh', ['api', 'user']);
+
+    const opts = (exec.mock.calls[0][2] ?? {}) as ExecOptions;
+    expect(opts.env).toBeUndefined();
+  });
+
+  it('falls back to ambient credentials when no account is linked', async () => {
+    const { base, exec } = fakeBase();
+    const resolver = vi.fn(async () => null);
+    const ctx = new GitHubAuthExecutionContext(base, resolver);
+
+    await ctx.exec('git', ['fetch', 'origin']);
+
+    expect(resolver).toHaveBeenCalledOnce();
+    const opts = (exec.mock.calls[0][2] ?? {}) as ExecOptions;
+    expect(opts.env).toBeUndefined();
+  });
+
+  it('preserves caller-provided env alongside injected auth env', async () => {
+    const { base, exec } = fakeBase();
+    const ctx = new GitHubAuthExecutionContext(base, async () => AUTH);
+
+    await ctx.exec('git', ['fetch', 'origin'], { env: { FOO: 'bar' } });
+
+    const opts = exec.mock.calls[0][2] as ExecOptions;
+    expect(opts.env?.FOO).toBe('bar');
+    expect(opts.env?.GIT_CONFIG_COUNT).toBe('1');
+  });
+
+  it('delegates root, supportsLocalSpawn and dispose to the base context', () => {
+    const { base, dispose } = fakeBase();
+    const ctx = new GitHubAuthExecutionContext(base, async () => AUTH);
+
+    expect(ctx.root).toBe('/repo');
+    expect(ctx.supportsLocalSpawn).toBe(true);
+    ctx.dispose();
+    expect(dispose).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/emdash-desktop/src/main/core/execution-context/github-auth-execution-context.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/github-auth-execution-context.ts
@@ -1,0 +1,76 @@
+import { buildGitHubAuthEnv, isNetworkGitCommand } from './github-auth-git-env';
+import type { ExecOptions, ExecResult, IExecutionContext } from './types';
+
+/** Resolved GitHub credential for git transport. */
+export type GitHubGitAuth = { host: string; token: string };
+
+/**
+ * Resolves the credential to use for a git network operation, or null when
+ * there is no usable linked account (callers then fall back to the ambient
+ * git credential helper). Invoked per network operation so the token is always
+ * current and account/project changes take effect without recreating the ctx.
+ */
+export type GitHubGitAuthResolver = () => Promise<GitHubGitAuth | null>;
+
+/**
+ * Wraps an execution context so git network operations (fetch/push/clone/
+ * ls-remote) authenticate with a specific GitHub account's token via a
+ * per-invocation, host-scoped `http.extraheader`, instead of relying on the
+ * machine's ambient credential helper (which serves whichever `gh` account is
+ * currently active).
+ *
+ * Everything else — non-git commands, local git commands, streaming — passes
+ * through untouched. When the resolver returns null the call is a plain
+ * passthrough, preserving the previous ambient-credential behavior. This makes
+ * the wrapper strictly additive: it can only add auth where there was none.
+ */
+export class GitHubAuthExecutionContext implements IExecutionContext {
+  constructor(
+    private readonly base: IExecutionContext,
+    private readonly resolveAuth: GitHubGitAuthResolver
+  ) {}
+
+  get root(): string | undefined {
+    return this.base.root;
+  }
+
+  get supportsLocalSpawn(): boolean {
+    return this.base.supportsLocalSpawn;
+  }
+
+  private async gitAuthEnv(
+    command: string,
+    args: string[]
+  ): Promise<Record<string, string> | undefined> {
+    if (!isNetworkGitCommand(command, args)) return undefined;
+    const auth = await this.resolveAuth();
+    if (!auth) return undefined;
+    return buildGitHubAuthEnv(auth.host, auth.token);
+  }
+
+  async exec(command: string, args: string[] = [], opts: ExecOptions = {}): Promise<ExecResult> {
+    const authEnv = await this.gitAuthEnv(command, args);
+    if (!authEnv) return this.base.exec(command, args, opts);
+    return this.base.exec(command, args, { ...opts, env: { ...opts.env, ...authEnv } });
+  }
+
+  execStreaming(
+    command: string,
+    args: string[],
+    onChunk: (chunk: string) => boolean,
+    opts: { signal?: AbortSignal } = {}
+  ): Promise<void> {
+    // Streaming git operations are not network-authenticated in this iteration:
+    // workspace setup fetch/push (the flows this targets) go through exec().
+    // Streamed network ops (if any are added) are a documented follow-up.
+    return this.base.execStreaming(command, args, onChunk, opts);
+  }
+
+  async refreshShellEnv(): Promise<void> {
+    await this.base.refreshShellEnv?.();
+  }
+
+  dispose(): void {
+    this.base.dispose();
+  }
+}

--- a/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.test.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.test.ts
@@ -9,8 +9,19 @@ describe('isNetworkGitCommand', () => {
     expect(isNetworkGitCommand('git', ['ls-remote', 'origin'])).toBe(true);
   });
 
-  it('ignores leading flags when finding the subcommand', () => {
+  it('skips global options that take a separate value', () => {
+    // The option value (foo=bar, /repo) must not be mistaken for the subcommand.
     expect(isNetworkGitCommand('git', ['-c', 'foo=bar', 'fetch', 'origin'])).toBe(true);
+    expect(isNetworkGitCommand('git', ['-C', '/repo', 'push', 'origin', 'main'])).toBe(true);
+    expect(
+      isNetworkGitCommand('git', ['-c', 'a=b', '-C', '/repo', 'ls-remote', 'origin'])
+    ).toBe(true);
+    expect(isNetworkGitCommand('git', ['--git-dir', '/repo/.git', 'fetch'])).toBe(true);
+  });
+
+  it('handles --opt=value global options', () => {
+    expect(isNetworkGitCommand('git', ['--git-dir=/repo/.git', 'fetch'])).toBe(true);
+    expect(isNetworkGitCommand('git', ['-c', 'foo=bar', 'status'])).toBe(false);
   });
 
   it('is false for local subcommands', () => {
@@ -28,7 +39,7 @@ describe('isNetworkGitCommand', () => {
 
 describe('buildGitHubAuthEnv', () => {
   it('builds a host-scoped extraheader via GIT_CONFIG_* env', () => {
-    const env = buildGitHubAuthEnv('github.com', 'ghs_secret');
+    const env = buildGitHubAuthEnv('github.com', 'ghs_secret', {});
     expect(env.GIT_CONFIG_COUNT).toBe('1');
     expect(env.GIT_CONFIG_KEY_0).toBe('http.https://github.com/.extraheader');
     const expected = Buffer.from('x-access-token:ghs_secret').toString('base64');
@@ -36,7 +47,21 @@ describe('buildGitHubAuthEnv', () => {
   });
 
   it('normalizes the host and scopes the header to it (GHES)', () => {
-    const env = buildGitHubAuthEnv('ghe.example.com', 'tok');
+    const env = buildGitHubAuthEnv('ghe.example.com', 'tok', {});
     expect(env.GIT_CONFIG_KEY_0).toBe('http.https://ghe.example.com/.extraheader');
+  });
+
+  it('appends after existing GIT_CONFIG_* entries instead of overwriting them', () => {
+    const env = buildGitHubAuthEnv('github.com', 'tok', { GIT_CONFIG_COUNT: '2' });
+    // Our entry goes at index 2, and the count is bumped to 3, preserving 0 and 1.
+    expect(env.GIT_CONFIG_COUNT).toBe('3');
+    expect(env.GIT_CONFIG_KEY_2).toBe('http.https://github.com/.extraheader');
+    expect(env.GIT_CONFIG_VALUE_2).toContain('Authorization: Basic ');
+    expect(env.GIT_CONFIG_KEY_0).toBeUndefined();
+  });
+
+  it('treats an invalid GIT_CONFIG_COUNT as zero', () => {
+    expect(buildGitHubAuthEnv('github.com', 'tok', { GIT_CONFIG_COUNT: 'nope' }).GIT_CONFIG_COUNT).toBe('1');
+    expect(buildGitHubAuthEnv('github.com', 'tok', { GIT_CONFIG_COUNT: '-4' }).GIT_CONFIG_COUNT).toBe('1');
   });
 });

--- a/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.test.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest';
+import { buildGitHubAuthEnv, isNetworkGitCommand } from './github-auth-git-env';
+
+describe('isNetworkGitCommand', () => {
+  it('is true for network subcommands', () => {
+    expect(isNetworkGitCommand('git', ['fetch', 'origin'])).toBe(true);
+    expect(isNetworkGitCommand('git', ['push', '-u', 'origin', 'branch'])).toBe(true);
+    expect(isNetworkGitCommand('git', ['clone', 'https://example', 'dir'])).toBe(true);
+    expect(isNetworkGitCommand('git', ['ls-remote', 'origin'])).toBe(true);
+  });
+
+  it('ignores leading flags when finding the subcommand', () => {
+    expect(isNetworkGitCommand('git', ['-c', 'foo=bar', 'fetch', 'origin'])).toBe(true);
+  });
+
+  it('is false for local subcommands', () => {
+    expect(isNetworkGitCommand('git', ['worktree', 'list'])).toBe(false);
+    expect(isNetworkGitCommand('git', ['status'])).toBe(false);
+    expect(isNetworkGitCommand('git', ['remote', 'get-url', 'origin'])).toBe(false);
+    expect(isNetworkGitCommand('git', [])).toBe(false);
+  });
+
+  it('is false for non-git commands', () => {
+    expect(isNetworkGitCommand('gh', ['api', 'user'])).toBe(false);
+    expect(isNetworkGitCommand('node', ['fetch'])).toBe(false);
+  });
+});
+
+describe('buildGitHubAuthEnv', () => {
+  it('builds a host-scoped extraheader via GIT_CONFIG_* env', () => {
+    const env = buildGitHubAuthEnv('github.com', 'ghs_secret');
+    expect(env.GIT_CONFIG_COUNT).toBe('1');
+    expect(env.GIT_CONFIG_KEY_0).toBe('http.https://github.com/.extraheader');
+    const expected = Buffer.from('x-access-token:ghs_secret').toString('base64');
+    expect(env.GIT_CONFIG_VALUE_0).toBe(`Authorization: Basic ${expected}`);
+  });
+
+  it('normalizes the host and scopes the header to it (GHES)', () => {
+    const env = buildGitHubAuthEnv('ghe.example.com', 'tok');
+    expect(env.GIT_CONFIG_KEY_0).toBe('http.https://ghe.example.com/.extraheader');
+  });
+});

--- a/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.ts
@@ -1,0 +1,43 @@
+import { normalizeRepositoryHost } from '@shared/repository-ref';
+
+/**
+ * git subcommands that contact a remote and therefore need credentials.
+ * Local-only subcommands (worktree, branch, config, status, ...) are excluded
+ * so we never attach a token to a process that has no reason to see it.
+ */
+const NETWORK_GIT_SUBCOMMANDS = new Set(['fetch', 'push', 'clone', 'ls-remote']);
+
+/** True when `command`/`args` is a git invocation whose subcommand hits the network. */
+export function isNetworkGitCommand(command: string, args: readonly string[]): boolean {
+  if (command !== 'git') return false;
+  // The subcommand is the first non-flag token (e.g. `-c foo=bar fetch` -> `fetch`).
+  const subcommand = args.find((arg) => !arg.startsWith('-'));
+  return subcommand !== undefined && NETWORK_GIT_SUBCOMMANDS.has(subcommand);
+}
+
+/**
+ * Build environment variables that make a single git invocation send a GitHub
+ * token as an Authorization header, scoped to `host`.
+ *
+ * Uses GIT_CONFIG_COUNT / GIT_CONFIG_KEY_n / GIT_CONFIG_VALUE_n (git >= 2.31) to
+ * set `http.https://<host>/.extraheader`, so the token:
+ *   - never appears in argv (unlike `-c http.extraheader=...`),
+ *   - never touches disk (unlike a credential-helper script),
+ *   - applies only to requests to `host` (unlike an unscoped extraheader).
+ *
+ * This mirrors the mechanism used by actions/checkout. GitHub accepts the token
+ * as the Basic-auth password with the `x-access-token` username.
+ *
+ * NOTE: emdash does not otherwise set GIT_CONFIG_* env vars, so overwriting
+ * index 0 here is safe. If that ever changes, this must merge with the existing
+ * count rather than assume a single entry.
+ */
+export function buildGitHubAuthEnv(host: string, token: string): Record<string, string> {
+  const normalizedHost = normalizeRepositoryHost(host) || 'github.com';
+  const basicAuth = Buffer.from(`x-access-token:${token}`).toString('base64');
+  return {
+    GIT_CONFIG_COUNT: '1',
+    GIT_CONFIG_KEY_0: `http.https://${normalizedHost}/.extraheader`,
+    GIT_CONFIG_VALUE_0: `Authorization: Basic ${basicAuth}`,
+  };
+}

--- a/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/github-auth-git-env.ts
@@ -7,12 +7,44 @@ import { normalizeRepositoryHost } from '@shared/repository-ref';
  */
 const NETWORK_GIT_SUBCOMMANDS = new Set(['fetch', 'push', 'clone', 'ls-remote']);
 
+/**
+ * Global git options (before the subcommand) that consume a *separate* value,
+ * e.g. `git -C <path> fetch` or `git -c key=val push`. Their values must be
+ * skipped so they are not mistaken for the subcommand. The `--opt=value` forms
+ * are handled generically by the leading-dash check below.
+ */
+const GLOBAL_OPTIONS_WITH_VALUE = new Set([
+  '-C',
+  '-c',
+  '--git-dir',
+  '--work-tree',
+  '--namespace',
+  '--exec-path',
+  '--super-prefix',
+  '--config-env',
+]);
+
 /** True when `command`/`args` is a git invocation whose subcommand hits the network. */
 export function isNetworkGitCommand(command: string, args: readonly string[]): boolean {
   if (command !== 'git') return false;
-  // The subcommand is the first non-flag token (e.g. `-c foo=bar fetch` -> `fetch`).
-  const subcommand = args.find((arg) => !arg.startsWith('-'));
-  return subcommand !== undefined && NETWORK_GIT_SUBCOMMANDS.has(subcommand);
+  for (let index = 0; index < args.length; index += 1) {
+    const arg = args[index];
+    if (GLOBAL_OPTIONS_WITH_VALUE.has(arg)) {
+      index += 1; // skip this option's separate value
+      continue;
+    }
+    if (arg.startsWith('-')) continue; // flag, or `--opt=value` form
+    // First bare token is the subcommand.
+    return NETWORK_GIT_SUBCOMMANDS.has(arg);
+  }
+  return false;
+}
+
+/** Parse a valid, positive GIT_CONFIG_COUNT from an env, or 0 when absent/invalid. */
+function existingGitConfigCount(env: NodeJS.ProcessEnv): number {
+  const raw = env.GIT_CONFIG_COUNT;
+  const parsed = raw ? Number.parseInt(raw, 10) : 0;
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : 0;
 }
 
 /**
@@ -28,16 +60,21 @@ export function isNetworkGitCommand(command: string, args: readonly string[]): b
  * This mirrors the mechanism used by actions/checkout. GitHub accepts the token
  * as the Basic-auth password with the `x-access-token` username.
  *
- * NOTE: emdash does not otherwise set GIT_CONFIG_* env vars, so overwriting
- * index 0 here is safe. If that ever changes, this must merge with the existing
- * count rather than assume a single entry.
+ * The extraheader is *appended* after any GIT_CONFIG_* entries already present
+ * in `baseEnv` (proxy, safe.directory, protocol config, ...) rather than
+ * overwriting index 0, so pre-existing git config from the environment survives.
  */
-export function buildGitHubAuthEnv(host: string, token: string): Record<string, string> {
+export function buildGitHubAuthEnv(
+  host: string,
+  token: string,
+  baseEnv: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
   const normalizedHost = normalizeRepositoryHost(host) || 'github.com';
   const basicAuth = Buffer.from(`x-access-token:${token}`).toString('base64');
+  const index = existingGitConfigCount(baseEnv);
   return {
-    GIT_CONFIG_COUNT: '1',
-    GIT_CONFIG_KEY_0: `http.https://${normalizedHost}/.extraheader`,
-    GIT_CONFIG_VALUE_0: `Authorization: Basic ${basicAuth}`,
+    GIT_CONFIG_COUNT: String(index + 1),
+    [`GIT_CONFIG_KEY_${index}`]: `http.https://${normalizedHost}/.extraheader`,
+    [`GIT_CONFIG_VALUE_${index}`]: `Authorization: Basic ${basicAuth}`,
   };
 }

--- a/apps/emdash-desktop/src/main/core/execution-context/local-execution-context.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/local-execution-context.ts
@@ -10,10 +10,11 @@ import type { ExecOptions, ExecResult, IExecutionContext } from './types';
 
 const execFileAsync = promisify(execFile);
 
-function buildNonInteractiveGitEnv(): NodeJS.ProcessEnv {
+function buildNonInteractiveGitEnv(extraEnv?: Record<string, string>): NodeJS.ProcessEnv {
   return {
     ...process.env,
     ...NON_INTERACTIVE_GIT_ENV,
+    ...extraEnv,
   };
 }
 
@@ -41,7 +42,7 @@ export class LocalExecutionContext implements IExecutionContext {
     const { timeout, maxBuffer } = opts;
     return execFileAsync(this.resolveCommand(command), args, {
       cwd: this.root || undefined,
-      env: command === 'git' ? buildNonInteractiveGitEnv() : undefined,
+      env: command === 'git' ? buildNonInteractiveGitEnv(opts.env) : undefined,
       timeout,
       maxBuffer,
       signal: this._signal(opts.signal),

--- a/apps/emdash-desktop/src/main/core/execution-context/types.ts
+++ b/apps/emdash-desktop/src/main/core/execution-context/types.ts
@@ -10,6 +10,12 @@ export interface ExecOptions {
   timeout?: number;
   maxBuffer?: number;
   signal?: AbortSignal;
+  /**
+   * Extra environment variables merged into the child process env. Applied to
+   * `git` commands (used to inject a scoped credential for network operations).
+   * Merged after the non-interactive git env, so it can override those defaults.
+   */
+  env?: Record<string, string>;
 }
 
 /**

--- a/apps/emdash-desktop/src/main/core/github/services/project-github-git-auth.ts
+++ b/apps/emdash-desktop/src/main/core/github/services/project-github-git-auth.ts
@@ -1,0 +1,48 @@
+import {
+  GITHUB_PROVIDER_ID,
+  toGitHubAccount,
+} from '@main/core/github/accounts/github-accounts';
+import { providerAccountRegistry } from '@main/core/provider-accounts/provider-account-registry-instance';
+import type { GitHubGitAuth } from '@main/core/execution-context/github-auth-execution-context';
+import { githubApiAuthService } from './github-api-auth-service-instance';
+import { resolveProjectGitHubAuthContext } from './project-github-auth-context';
+
+/**
+ * Resolve the GitHub credential to use for git transport for a project, based
+ * on the account linked to that project.
+ *
+ * Returns null when there is no usable linked account — unconfigured, disabled
+ * (`githubAccountId: null`), an unknown account id, or a missing token — in
+ * which case the caller falls back to the ambient git credential helper,
+ * preserving the previous behavior.
+ *
+ * The account's own host is used (not the git remote's), so the returned
+ * `host`-scoped credential only takes effect for requests to the linked
+ * account's host; if the remote is on a different host or uses SSH, the
+ * credential simply does not apply.
+ */
+export async function resolveProjectGitHubGitAuth(
+  projectId: string
+): Promise<GitHubGitAuth | null> {
+  const authContext = await resolveProjectGitHubAuthContext(projectId);
+  if (!authContext.success) return null;
+
+  const { accountId } = authContext.data;
+  const accounts = (await providerAccountRegistry.listAccounts(GITHUB_PROVIDER_ID)).map(
+    toGitHubAccount
+  );
+
+  let account = accountId ? accounts.find((candidate) => candidate.id === accountId) : undefined;
+  if (!account && !accountId) {
+    const defaultAccountId = await providerAccountRegistry.getDefaultAccountId(GITHUB_PROVIDER_ID);
+    account = defaultAccountId
+      ? accounts.find((candidate) => candidate.id === defaultAccountId)
+      : undefined;
+  }
+  if (!account) return null;
+
+  const token = await githubApiAuthService.getToken(account.host, { accountId: account.id });
+  if (!token.success) return null;
+
+  return { host: account.host, token: token.data };
+}

--- a/apps/emdash-desktop/src/main/core/projects/create-project-provider.ts
+++ b/apps/emdash-desktop/src/main/core/projects/create-project-provider.ts
@@ -1,8 +1,10 @@
 import type { IFileSystem } from '@emdash/core/files';
 import type { IGitRepository, IGitRuntime } from '@emdash/core/git';
 import { err, ok, type Lease, type Result } from '@emdash/shared';
+import { GitHubAuthExecutionContext } from '@main/core/execution-context/github-auth-execution-context';
 import { LocalExecutionContext } from '@main/core/execution-context/local-execution-context';
 import { SshExecutionContext } from '@main/core/execution-context/ssh-execution-context';
+import { resolveProjectGitHubGitAuth } from '@main/core/github/services/project-github-git-auth';
 import { GitRepositoryFetchService } from '@main/core/git/repository/fetch-service';
 import { GitRepositoryService } from '@main/core/git/repository/service';
 import { projectGitHubAccountBackfillService } from '@main/core/github/services/project-github-account-backfill-instance';
@@ -40,7 +42,14 @@ export async function createProvider(
 async function createLocalProvider(
   project: LocalProject
 ): Promise<Result<ProjectProvider, CreateProviderError>> {
-  const ctx = new LocalExecutionContext({ root: project.path });
+  const baseCtx = new LocalExecutionContext({ root: project.path });
+  // Authenticate git network operations with the project's linked GitHub
+  // account instead of the machine's ambient credential helper (which serves
+  // whichever `gh` account is currently active). Falls back to ambient
+  // credentials when no account is linked.
+  const ctx = new GitHubAuthExecutionContext(baseCtx, () =>
+    resolveProjectGitHubGitAuth(project.id)
+  );
   const projectMachine: MachineRef = { kind: 'local' };
   const runtimeLease = await runtimeManager.acquire(projectMachine);
 


### PR DESCRIPTION
## Problem

Git network operations (`fetch`/`push`/`clone`/`ls-remote`) run through the project's execution context, which sets `GIT_ASKPASS=''` and injects **no credentials** (see `local-execution-context.ts` / `non-interactive-git-env.ts`). They therefore fall back to the machine's ambient credential helper (`gh auth git-credential`), which serves whichever `gh` account is **currently active**.

When the active `gh` account differs from the account **linked to the project** (`githubAccountId`) — e.g. after switching `gh` accounts — git operations against a private repo fail with:

```
remote: Repository not found.
fatal: repository 'https://github.com/<org>/<repo>.git/' not found
```

…even though the linked account has access. The per-project linked account governed only octokit API calls (issues/PRs), never git transport. "Create from Pull Request" is unaffected because PRs are served from cache.

## Fix

Wrap the project's local execution context in a `GitHubAuthExecutionContext`. For git **network** subcommands it resolves the project's linked account token and injects it as a **host-scoped** `http.extraheader` via `GIT_CONFIG_COUNT`/`GIT_CONFIG_KEY_0`/`GIT_CONFIG_VALUE_0` (git ≥ 2.31). This:

- keeps the token out of argv (unlike `-c http.extraheader=…`) and off disk (unlike a credential-helper script),
- applies only to requests to the linked account's host,
- is the same mechanism `actions/checkout` uses.

When there is **no usable linked account** (unconfigured, disabled, unknown account, missing token), the wrapper is a plain passthrough — so behavior is unchanged for existing setups and the change is strictly additive (it can only add auth where there was none).

## Changes

- `execution-context/github-auth-git-env.ts` (new) — `isNetworkGitCommand` + `buildGitHubAuthEnv` (pure).
- `execution-context/github-auth-execution-context.ts` (new) — `IExecutionContext` decorator; injects auth env for network git ops, passes everything else through.
- `github/services/project-github-git-auth.ts` (new) — resolves `{ host, token }` from the project's linked account (reuses `resolveProjectGitHubAuthContext` + `GitHubApiAuthService`).
- `execution-context/types.ts` — add optional `env` to `ExecOptions` (additive).
- `execution-context/local-execution-context.ts` — merge `opts.env` into the git env.
- `projects/create-project-provider.ts` — wrap the local ctx (`createLocalProvider`).
- Unit tests for the env builder and the decorator.

## Scope / follow-ups

- **Local execution contexts only.** SSH-executed projects (`SshExecutionContext`) are intentionally **unchanged** — injecting a token into a remote host's git process is a separate security decision. Deferred.
- **`exec` only.** Workspace-setup network ops (fetch/push) go through `exec`. If any git network op is ever routed through `execStreaming` (e.g. a streamed clone), extending injection there is a small follow-up.
- Requires git ≥ 2.31 for the `GIT_CONFIG_*` env form.

## Testing

- Added unit tests: `github-auth-git-env.test.ts`, `github-auth-execution-context.test.ts` (injection for network subcommands; passthrough for local/non-git; ambient fallback when no account; caller env preserved; delegation of root/supportsLocalSpawn/dispose).
- Manual repro: with the active `gh` account set to one **without** access to a private repo, task-workspace `git fetch` fails on `main`; with this change it succeeds using the project's linked account.

> Note: developed against the source but not yet run through the local build/test toolchain — CI on this PR is the authoritative check.
