### PR TITLE
fix(ssh): prevent crashes during remote task teardown

### DIFF
--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-file-tree.test.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-file-tree.test.ts
@@ -192,4 +192,42 @@ describe('LegacySshFilesRuntime file tree', () => {
     await opened.data.release();
     await runtime.dispose();
   });
+
+  it('settles an in-flight directory load when the remote tree is disposed', async () => {
+    let markDirectoryLoadStarted: (() => void) | undefined;
+    const directoryLoadStarted = new Promise<void>((resolve) => {
+      markDirectoryLoadStarted = resolve;
+    });
+    let finishDirectoryLoad: (() => void) | undefined;
+    const directoryLoadFinished = new Promise<void>((resolve) => {
+      finishDirectoryLoad = resolve;
+    });
+
+    vi.spyOn(SshFileSystem.prototype, 'list').mockImplementation(async (dirPath = '/repo') => {
+      if (dirPath === '/repo') return listResult([dirEntry('/repo/src')]);
+      markDirectoryLoadStarted?.();
+      await directoryLoadFinished;
+      return listResult([]);
+    });
+
+    const runtime = new LegacySshFilesRuntime({} as never);
+    const opened = await runtime.openTree('/repo');
+    expect(opened.success).toBe(true);
+    if (!opened.success) return;
+
+    const snapshot = await opened.data.value.getSnapshot();
+    expect(snapshot.success).toBe(true);
+    if (!snapshot.success) return;
+    const src = snapshot.data.entries.find(([, node]) => node.path === '/repo/src')?.[1];
+    expect(src).toBeDefined();
+    if (!src) return;
+
+    const loading = opened.data.value.registerDir(src.id);
+    await directoryLoadStarted;
+    await opened.data.release();
+    finishDirectoryLoad?.();
+
+    await expect(loading).resolves.toEqual({ success: true, data: {} });
+    await runtime.dispose();
+  });
 });

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-files.ts
@@ -471,9 +471,10 @@ class LegacySshFileTree implements IFileTree {
 
     const loading = this.loadDirectoryScopeInternal(scope);
     this.scopeLoads.set(scope, loading);
-    void loading.finally(() => {
+    const clearLoading = () => {
       if (this.scopeLoads.get(scope) === loading) this.scopeLoads.delete(scope);
-    });
+    };
+    void loading.then(clearLoading, clearLoading);
     return loading;
   }
 
@@ -489,6 +490,7 @@ class LegacySshFileTree implements IFileTree {
     const dirPath = dirNode?.path ?? this.rootPath;
     const listed = await this.listChildren(dirPath);
     if (!listed.success) return listed;
+    if (this.disposed) return ok({});
 
     const listedPaths = new Set(listed.data.map((entry) => entry.path));
     let sequence = this.removeMissingChildren(scope, listedPaths);
@@ -499,6 +501,7 @@ class LegacySshFileTree implements IFileTree {
       ok(nodes.map((node) => [node.id, node] as const))
     );
     if (!loaded.success) return loaded;
+    if (this.disposed) return ok({});
     sequence = Math.max(sequence, loaded.data);
 
     if (dirNode && !dirNode.childrenLoaded) {

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-legacy-fs.test.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-legacy-fs.test.ts
@@ -313,4 +313,34 @@ describe('SshFileSystem.watch', () => {
     expect(events).toEqual([{ type: 'create', entryType: 'symlink', path: 'linked' }]);
     watcher.close();
   });
+
+  it('does not overlap polls or emit after the watcher closes', async () => {
+    vi.useFakeTimers();
+
+    let finishDelayedPoll: (() => void) | undefined;
+    const delayedPoll = new Promise<void>((resolve) => {
+      finishDelayedPoll = resolve;
+    });
+    const fs = new SshFileSystem({} as never, '/repo');
+    const list = vi.spyOn(fs, 'list').mockImplementation(async () => {
+      if (list.mock.calls.length === 1) {
+        return listResult([fileEntry('notes.md', 1_000)]);
+      }
+      await delayedPoll;
+      return listResult([fileEntry('notes.md', 2_000)]);
+    });
+
+    const events: Array<{ type: string; entryType: string; path: string }> = [];
+    const watcher = fs.watch((batch) => events.push(...batch), { debounceMs: 10 });
+    watcher.update(['']);
+
+    await vi.advanceTimersByTimeAsync(10);
+    await vi.advanceTimersByTimeAsync(40);
+    watcher.close();
+    finishDelayedPoll?.();
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(list).toHaveBeenCalledTimes(2);
+    expect(events).toEqual([]);
+  });
 });

--- a/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-legacy-fs.ts
+++ b/apps/emdash-desktop/src/main/core/runtime/legacy/ssh-legacy-fs.ts
@@ -8,6 +8,7 @@ import type { FileSymlinkInfo, FileSymlinkTargetType } from '@emdash/core/files'
 import type { SFTPWrapper } from 'ssh2';
 import { buildRemoteShellCommand } from '@main/core/ssh/lifecycle/remote-shell-profile';
 import type { SshClientProxy } from '@main/core/ssh/lifecycle/ssh-client-proxy';
+import { log } from '@main/lib/logger';
 import { quoteShellArg } from '@main/utils/shellEscape';
 import type { FileWatchEvent } from '@shared/core/fs/fs';
 import {
@@ -749,65 +750,82 @@ export class SshFileSystem implements LegacySshFileOperations {
   ): FileWatcher {
     const interval = options.debounceMs ?? 4000;
     let watched: string[] = [];
+    let closed = false;
+    let pollInFlight = false;
     // Map from dirPath → previous entries (keyed by relative entry path)
     const snapshots = new Map<string, Map<string, FileEntry>>();
 
     const poll = async () => {
-      for (const dirPath of watched) {
-        let result: FileListResult | null = null;
-        try {
-          result = await this.list(dirPath, { includeHidden: true });
-        } catch {
-          continue;
-        }
+      if (closed || pollInFlight) return;
+      pollInFlight = true;
+      try {
+        for (const dirPath of watched) {
+          if (closed) return;
+          let result: FileListResult | null = null;
+          try {
+            result = await this.list(dirPath, { includeHidden: true });
+          } catch {
+            continue;
+          }
+          if (closed) return;
 
-        const currMap = new Map(result.entries.map((e) => [e.path, e]));
-        const prevMap = snapshots.get(dirPath);
-        snapshots.set(dirPath, currMap);
+          const currMap = new Map(result.entries.map((e) => [e.path, e]));
+          const prevMap = snapshots.get(dirPath);
+          snapshots.set(dirPath, currMap);
 
-        if (!prevMap) continue;
+          if (!prevMap) continue;
 
-        const evts: FileWatchEvent[] = [];
-        for (const [p, e] of currMap) {
-          const prev = prevMap.get(p);
-          if (!prev)
-            evts.push({
-              type: 'create',
-              entryType: fileWatchEntryType(e),
-              path: p,
-            });
-          else if (fileEntryMetadataChanged(prev, e))
-            evts.push({
-              type: 'modify',
-              entryType: fileWatchEntryType(e),
-              path: p,
-            });
+          const evts: FileWatchEvent[] = [];
+          for (const [p, e] of currMap) {
+            const prev = prevMap.get(p);
+            if (!prev)
+              evts.push({
+                type: 'create',
+                entryType: fileWatchEntryType(e),
+                path: p,
+              });
+            else if (fileEntryMetadataChanged(prev, e))
+              evts.push({
+                type: 'modify',
+                entryType: fileWatchEntryType(e),
+                path: p,
+              });
+          }
+          for (const [p, e] of prevMap) {
+            if (!currMap.has(p))
+              evts.push({
+                type: 'delete',
+                entryType: fileWatchEntryType(e),
+                path: p,
+              });
+          }
+          if (evts.length) callback(evts);
         }
-        for (const [p, e] of prevMap) {
-          if (!currMap.has(p))
-            evts.push({
-              type: 'delete',
-              entryType: fileWatchEntryType(e),
-              path: p,
-            });
-        }
-        if (evts.length) callback(evts);
+      } finally {
+        pollInFlight = false;
       }
     };
 
     const timer = setInterval(() => {
-      void poll();
+      void poll().catch((error) => {
+        log.warn('SshFileSystem: watcher poll failed', { error: String(error) });
+      });
     }, interval);
 
     return {
       update(paths: string[]) {
+        if (closed) return;
         watched = paths;
         for (const p of snapshots.keys()) {
           if (!paths.includes(p)) snapshots.delete(p);
         }
       },
       close() {
+        if (closed) return;
+        closed = true;
         clearInterval(timer);
+        watched = [];
+        snapshots.clear();
       },
     };
   }

--- a/packages/core/src/files/tree/file-tree.ts
+++ b/packages/core/src/files/tree/file-tree.ts
@@ -233,9 +233,10 @@ export class FileTree implements IFileTree {
 
     const loading = this.loadDirectoryScopeInternal(scope);
     this.scopeLoads.set(scope, loading);
-    void loading.finally(() => {
+    const clearLoading = () => {
       if (this.scopeLoads.get(scope) === loading) this.scopeLoads.delete(scope);
-    });
+    };
+    void loading.then(clearLoading, clearLoading);
     return loading;
   }
 
@@ -254,6 +255,7 @@ export class FileTree implements IFileTree {
       sort: true,
     });
     if (!listed.success) return listed;
+    if (this.disposed) return ok({});
     const listedEntries = listed.data.kind === 'entries' ? listed.data.entries : [];
 
     const listedPaths = new Set(listedEntries.map((entry) => entry.path));
@@ -279,10 +281,12 @@ export class FileTree implements IFileTree {
         return annotated;
       })
     );
+    if (this.disposed) return ok({});
     const loaded = await this.collection.loadScope(scope, async () =>
       ok(nodes.map((node) => [node.id, node] as const))
     );
     if (!loaded.success) return loaded;
+    if (this.disposed) return ok({});
     sequence = Math.max(sequence, loaded.data);
 
     if (dirNode && !dirNode.childrenLoaded) {


### PR DESCRIPTION
- makes file tree load cleanup safe when disposal races with asynchronous directory reads
- prevents remote task deletion from updating disposed file tree collections
- serializes ssh watcher polling and suppresses events after closure
- catches and logs watcher failures to prevent unhandled promise rejections