### PR TITLE
feat(providers): expand native CLI capabilities

### DIFF
--- a/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/services/McpService.ts
@@ -6,6 +6,7 @@ import { createPluginFs } from '@main/core/agents/plugin-fs';
 import { log } from '@main/lib/logger';
 import { loadCatalog } from '../utils/catalog';
 import {
+  mergeMcpServerRegistration,
   mcpServerFieldCount,
   mcpServerToRegistration,
   registrationToMcpServer,
@@ -100,7 +101,7 @@ export class McpService {
         if (selectedProviders.has(agentId)) {
           const toWrite = mcpServerToRegistration(server);
           if (idx >= 0) {
-            regs[idx] = toWrite;
+            regs[idx] = mergeMcpServerRegistration(regs[idx], server);
           } else {
             regs.push(toWrite);
           }

--- a/apps/emdash-desktop/src/main/core/mcp/utils/registration.test.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/utils/registration.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  mergeMcpServerRegistration,
   mcpServerFieldCount,
   mcpServerToRegistration,
   registrationToMcpServer,
@@ -53,5 +54,36 @@ describe('MCP registration conversion', () => {
 
     expect(mcpServerFieldCount(explicitDefault)).toBe(mcpServerFieldCount(implicitDefault));
     expect(mcpServerFieldCount(disabled)).toBeGreaterThan(mcpServerFieldCount(implicitDefault));
+  });
+
+  it('retains provider-native fields while updating canonical fields', () => {
+    const merged = mergeMcpServerRegistration(
+      {
+        name: 'remote',
+        transport: 'http',
+        url: 'https://old.example.com/mcp',
+        auth: { type: 'oauth', scopes: ['tools:read'] },
+        disabled: true,
+        startup_timeout_sec: 15,
+        envFile: '~/.continue/mcp.env',
+      },
+      {
+        name: 'remote',
+        transport: 'http',
+        url: 'https://new.example.com/mcp',
+        providers: ['mistral'],
+      }
+    );
+
+    expect(merged).toMatchObject({
+      name: 'remote',
+      transport: 'http',
+      type: 'http',
+      url: 'https://new.example.com/mcp',
+      auth: { type: 'oauth', scopes: ['tools:read'] },
+      disabled: true,
+      startup_timeout_sec: 15,
+      envFile: '~/.continue/mcp.env',
+    });
   });
 });

--- a/apps/emdash-desktop/src/main/core/mcp/utils/registration.ts
+++ b/apps/emdash-desktop/src/main/core/mcp/utils/registration.ts
@@ -1,4 +1,5 @@
 export {
+  mergeMcpServerRegistration,
   mcpServerFieldCount,
   mcpServerToRegistration,
   registrationToMcpServer,

--- a/packages/core/src/agents/plugins/helpers/mcp.test.ts
+++ b/packages/core/src/agents/plugins/helpers/mcp.test.ts
@@ -1,5 +1,6 @@
 import { parse as parseTOML } from 'smol-toml';
 import { describe, expect, it } from 'vitest';
+import { mcpServerToRegistration, registrationToMcpServer } from '../../../mcp/registration';
 import type { PluginFs } from '../../runtime/fs';
 import {
   codexMcpAdapter,
@@ -8,6 +9,7 @@ import {
   droidMcpAdapter,
   grokMcpAdapter,
   mimocodeMcpAdapter,
+  mistralMcpAdapter,
   opencodeMcpAdapter,
   passthroughMcpAdapter,
 } from './mcp';
@@ -79,6 +81,134 @@ describe('createMcpAdapter (single path)', () => {
     await adapter.removeServer(fs, 'gone');
     const result = await adapter.readServers(fs);
     expect(result.map((r) => r.name)).toEqual(['keep']);
+  });
+});
+
+// ── Mistral Vibe adapter ────────────────────────────────────────────────────
+
+describe('mistralMcpAdapter', () => {
+  const adapter = mistralMcpAdapter('.vibe/config.toml');
+
+  it('writes Vibe MCP servers as TOML array entries without replacing other config', async () => {
+    const fs = createMemoryFs({
+      '.vibe/config.toml': 'active_model = "mistral-medium-3.5"\n',
+    });
+
+    await adapter.writeServers(fs, [
+      {
+        name: 'local',
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem'],
+      },
+      {
+        name: 'remote',
+        transport: 'http',
+        type: 'http',
+        url: 'https://example.com/mcp',
+      },
+    ]);
+
+    const parsed = parseTOML((await fs.read('.vibe/config.toml'))!) as Record<string, unknown>;
+    expect(parsed.active_model).toBe('mistral-medium-3.5');
+    expect(parsed.mcp_servers).toEqual([
+      {
+        name: 'local',
+        transport: 'stdio',
+        command: 'npx',
+        args: ['-y', '@modelcontextprotocol/server-filesystem'],
+      },
+      {
+        name: 'remote',
+        transport: 'streamable-http',
+        url: 'https://example.com/mcp',
+      },
+    ]);
+  });
+
+  it('reads native streamable HTTP entries and preserves their transport on a round trip', async () => {
+    const fs = createMemoryFs({
+      '.vibe/config.toml': [
+        '[[mcp_servers]]',
+        'name = "remote"',
+        'transport = "streamable-http"',
+        'url = "https://example.com/mcp"',
+        '',
+      ].join('\n'),
+    });
+
+    const servers = await adapter.readServers(fs);
+    expect(servers).toEqual([
+      {
+        name: 'remote',
+        transport: 'http',
+        type: 'streamable-http',
+        url: 'https://example.com/mcp',
+      },
+    ]);
+
+    const canonicalRegistrations = servers.map((server) =>
+      mcpServerToRegistration(registrationToMcpServer(server, ['mistral']))
+    );
+    await adapter.writeServers(fs, canonicalRegistrations);
+
+    const parsed = parseTOML((await fs.read('.vibe/config.toml'))!) as Record<string, unknown>;
+    expect(parsed.mcp_servers).toEqual([
+      {
+        name: 'remote',
+        transport: 'streamable-http',
+        url: 'https://example.com/mcp',
+      },
+    ]);
+  });
+
+  it('preserves an existing native HTTP transport through the canonical save path', async () => {
+    const fs = createMemoryFs({
+      '.vibe/config.toml': [
+        '[[mcp_servers]]',
+        'name = "legacy-http"',
+        'transport = "http"',
+        'url = "https://example.com/mcp"',
+        '',
+      ].join('\n'),
+    });
+
+    const servers = await adapter.readServers(fs);
+    const canonicalRegistrations = servers.map((server) =>
+      mcpServerToRegistration(registrationToMcpServer(server, ['mistral']))
+    );
+    await adapter.writeServers(fs, canonicalRegistrations);
+
+    const parsed = parseTOML((await fs.read('.vibe/config.toml'))!) as Record<string, unknown>;
+    expect(parsed.mcp_servers).toEqual([
+      {
+        name: 'legacy-http',
+        transport: 'http',
+        url: 'https://example.com/mcp',
+      },
+    ]);
+  });
+
+  it('removes only the requested Vibe MCP server', async () => {
+    const fs = createMemoryFs({
+      '.vibe/config.toml': [
+        '[[mcp_servers]]',
+        'name = "keep"',
+        'transport = "stdio"',
+        'command = "node"',
+        '',
+        '[[mcp_servers]]',
+        'name = "gone"',
+        'transport = "stdio"',
+        'command = "npx"',
+        '',
+      ].join('\n'),
+    });
+
+    await adapter.removeServer(fs, 'gone');
+    await expect(adapter.readServers(fs)).resolves.toEqual([
+      { name: 'keep', transport: 'stdio', command: 'node' },
+    ]);
   });
 });
 

--- a/packages/core/src/agents/plugins/helpers/mcp.test.ts
+++ b/packages/core/src/agents/plugins/helpers/mcp.test.ts
@@ -1,9 +1,10 @@
 import { parse as parseTOML } from 'smol-toml';
 import { describe, expect, it } from 'vitest';
-import { mcpServerToRegistration, registrationToMcpServer } from '../../../mcp/registration';
+import { mergeMcpServerRegistration, registrationToMcpServer } from '../../../mcp/registration';
 import type { PluginFs } from '../../runtime/fs';
 import {
   codexMcpAdapter,
+  continueMcpAdapter,
   createMcpAdapter,
   crushMcpAdapter,
   droidMcpAdapter,
@@ -133,6 +134,16 @@ describe('mistralMcpAdapter', () => {
         'name = "remote"',
         'transport = "streamable-http"',
         'url = "https://example.com/mcp"',
+        'prompt = "Use the remote tools"',
+        'disabled = true',
+        'startup_timeout_sec = 15',
+        'tool_timeout_sec = 120',
+        'sampling_enabled = false',
+        'disabled_tools = ["delete_record"]',
+        '',
+        '[mcp_servers.auth]',
+        'type = "oauth"',
+        'scopes = ["tools:read"]',
         '',
       ].join('\n'),
     });
@@ -144,11 +155,18 @@ describe('mistralMcpAdapter', () => {
         transport: 'http',
         type: 'streamable-http',
         url: 'https://example.com/mcp',
+        prompt: 'Use the remote tools',
+        disabled: true,
+        startup_timeout_sec: 15,
+        tool_timeout_sec: 120,
+        sampling_enabled: false,
+        disabled_tools: ['delete_record'],
+        auth: { type: 'oauth', scopes: ['tools:read'] },
       },
     ]);
 
     const canonicalRegistrations = servers.map((server) =>
-      mcpServerToRegistration(registrationToMcpServer(server, ['mistral']))
+      mergeMcpServerRegistration(server, registrationToMcpServer(server, ['mistral']))
     );
     await adapter.writeServers(fs, canonicalRegistrations);
 
@@ -158,6 +176,13 @@ describe('mistralMcpAdapter', () => {
         name: 'remote',
         transport: 'streamable-http',
         url: 'https://example.com/mcp',
+        prompt: 'Use the remote tools',
+        disabled: true,
+        startup_timeout_sec: 15,
+        tool_timeout_sec: 120,
+        sampling_enabled: false,
+        disabled_tools: ['delete_record'],
+        auth: { type: 'oauth', scopes: ['tools:read'] },
       },
     ]);
   });
@@ -175,7 +200,7 @@ describe('mistralMcpAdapter', () => {
 
     const servers = await adapter.readServers(fs);
     const canonicalRegistrations = servers.map((server) =>
-      mcpServerToRegistration(registrationToMcpServer(server, ['mistral']))
+      mergeMcpServerRegistration(server, registrationToMcpServer(server, ['mistral']))
     );
     await adapter.writeServers(fs, canonicalRegistrations);
 
@@ -209,6 +234,40 @@ describe('mistralMcpAdapter', () => {
     await expect(adapter.readServers(fs)).resolves.toEqual([
       { name: 'keep', transport: 'stdio', command: 'node' },
     ]);
+  });
+});
+
+// ── Continue adapter ────────────────────────────────────────────────────────
+
+describe('continueMcpAdapter', () => {
+  it('preserves envFile through the canonical save path', async () => {
+    const adapter = continueMcpAdapter('.continue/mcpServers/emdash.json');
+    const fs = createMemoryFs({
+      '.continue/mcpServers/emdash.json': jsonFile({
+        mcpServers: {
+          local: {
+            command: 'node',
+            args: ['server.js'],
+            envFile: '~/.continue/secrets.env',
+          },
+        },
+      }),
+    });
+
+    const servers = await adapter.readServers(fs);
+    const canonicalRegistrations = servers.map((server) =>
+      mergeMcpServerRegistration(server, registrationToMcpServer(server, ['continue']))
+    );
+    await adapter.writeServers(fs, canonicalRegistrations);
+
+    const parsed = JSON.parse((await fs.read('.continue/mcpServers/emdash.json'))!) as {
+      mcpServers: Record<string, Record<string, unknown>>;
+    };
+    expect(parsed.mcpServers.local).toMatchObject({
+      command: 'node',
+      args: ['server.js'],
+      envFile: '~/.continue/secrets.env',
+    });
   });
 });
 

--- a/packages/core/src/agents/plugins/helpers/mcp.ts
+++ b/packages/core/src/agents/plugins/helpers/mcp.ts
@@ -158,6 +158,23 @@ export function passthroughMcpAdapter(configPath: string, legacyReadPaths?: stri
 }
 
 /**
+ * Continue adapter — JSON MCP blocks are discovered from the global
+ * ~/.continue/mcpServers directory. Continue also accepts this canonical
+ * `mcpServers` JSON shape in workspace directories.
+ */
+export function continueMcpAdapter(configPath = '.continue/mcpServers/emdash.json') {
+  return passthroughMcpAdapter(configPath);
+}
+
+/**
+ * Junie adapter — global MCP configuration lives in ~/.junie/mcp/mcp.json and
+ * uses the canonical `mcpServers` JSON shape.
+ */
+export function junieMcpAdapter(configPath = '.junie/mcp/mcp.json') {
+  return passthroughMcpAdapter(configPath);
+}
+
+/**
  * Cursor adapter — HTTP servers drop `type`, but `url` stays.
  * Config: ~/.cursor/mcp.json, key: mcpServers, JSON.
  */
@@ -178,6 +195,111 @@ export function cursorMcpAdapter(configPath = '.cursor/mcp.json') {
       return { name, ...entry } as McpServerRegistration;
     },
   });
+}
+
+/**
+ * Mistral Vibe adapter — TOML with an array of `[[mcp_servers]]` tables.
+ * Config: .vibe/config.toml, key: mcp_servers.
+ *
+ * Unlike the map-shaped configs used by the other TOML adapters, Vibe keeps the
+ * server name inside each array element. Its `streamable-http` transport is
+ * represented as HTTP in Emdash while retaining the native transport value for
+ * a lossless read/write round-trip.
+ */
+export function mistralMcpAdapter(configPath = '.vibe/config.toml') {
+  function parse(content: string): Record<string, unknown> {
+    return parseTOML(content) as Record<string, unknown>;
+  }
+
+  function toNative(
+    server: McpServerRegistration,
+    existingTransport?: unknown
+  ): Record<string, unknown> {
+    const entry = deepClone(server) as Record<string, unknown>;
+    const isHttp =
+      entry.transport === 'http' ||
+      entry.type === 'http' ||
+      entry.type === 'streamable-http' ||
+      (typeof entry.url === 'string' && typeof entry.command !== 'string');
+    const httpTransport =
+      entry.type === 'streamable-http' || existingTransport === 'streamable-http'
+        ? 'streamable-http'
+        : existingTransport === 'http'
+          ? 'http'
+          : 'streamable-http';
+    const transport = isHttp ? httpTransport : (entry.transport ?? entry.type ?? 'stdio');
+
+    delete entry.type;
+    entry.transport = transport;
+    return entry;
+  }
+
+  function fromNative(raw: Record<string, unknown>): McpServerRegistration {
+    const entry = deepClone(raw) as Record<string, unknown>;
+    if (entry.transport === 'streamable-http') {
+      entry.transport = 'http';
+      entry.type = 'streamable-http';
+    }
+    return entry as McpServerRegistration;
+  }
+
+  async function readConfig(fs: PluginFs): Promise<Record<string, unknown> | null> {
+    const content = await fs.read(configPath);
+    if (!content) return null;
+    try {
+      return parse(content);
+    } catch {
+      return null;
+    }
+  }
+
+  return {
+    async readServers(fs: PluginFs): Promise<McpServerRegistration[]> {
+      const config = await readConfig(fs);
+      if (!config || !Array.isArray(config.mcp_servers)) return [];
+      return config.mcp_servers
+        .filter(
+          (server): server is Record<string, unknown> =>
+            typeof server === 'object' && server !== null && typeof server.name === 'string'
+        )
+        .map(fromNative);
+    },
+    async writeServers(fs: PluginFs, servers: McpServerRegistration[]): Promise<void> {
+      const content = await fs.read(configPath);
+      const config = content ? parse(content) : {};
+      const existingTransports = new Map<string, unknown>();
+      if (Array.isArray(config.mcp_servers)) {
+        for (const server of config.mcp_servers) {
+          if (typeof server !== 'object' || server === null) continue;
+          const { name, transport } = server as { name?: unknown; transport?: unknown };
+          if (typeof name === 'string') existingTransports.set(name, transport);
+        }
+      }
+      config.mcp_servers = servers.map((server) =>
+        toNative(server, existingTransports.get(server.name))
+      );
+      await fs.write(configPath, stringifyTOML(config));
+    },
+    async removeServer(fs: PluginFs, name: string): Promise<void> {
+      const content = await fs.read(configPath);
+      if (!content) return;
+      try {
+        const config = parse(content);
+        if (!Array.isArray(config.mcp_servers)) return;
+        const filtered = config.mcp_servers.filter(
+          (server) =>
+            typeof server !== 'object' ||
+            server === null ||
+            (server as { name?: unknown }).name !== name
+        );
+        if (filtered.length === config.mcp_servers.length) return;
+        config.mcp_servers = filtered;
+        await fs.write(configPath, stringifyTOML(config));
+      } catch {
+        // A malformed provider config must not be overwritten while removing a server.
+      }
+    },
+  };
 }
 
 /**

--- a/packages/core/src/mcp/registration.ts
+++ b/packages/core/src/mcp/registration.ts
@@ -53,6 +53,14 @@ export function mcpServerToRegistration(server: McpServer): McpServerRegistratio
   };
 }
 
+/** Update canonical fields while retaining provider-native fields Emdash does not model. */
+export function mergeMcpServerRegistration(
+  existing: McpServerRegistration,
+  server: McpServer
+): McpServerRegistration {
+  return { ...existing, ...mcpServerToRegistration(server) };
+}
+
 export function mcpServerFieldCount(server: McpServer): number {
   let n = 0;
   if (server.command) n += 10;

--- a/packages/plugins/src/agents/impl/auggie/index.test.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.test.ts
@@ -29,6 +29,23 @@ function createMemoryFs(files = new Map<string, string>()): PluginFs {
 }
 
 describe('auggie provider', () => {
+  it('supports documented Auggie models and the MCP settings transports Emdash can represent', () => {
+    expect(provider.capabilities.models).toMatchObject({
+      kind: 'selectable',
+      modelOptions: {
+        'prism-a': expect.any(Object),
+        'opus4.8': expect.any(Object),
+        'gpt5.5': expect.any(Object),
+      },
+    });
+    expect(provider.capabilities.mcp).toEqual({
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    });
+    expect(provider.behavior.mcp).toBeDefined();
+  });
+
   it('resumes a stored provider session id with --resume', () => {
     const command = provider.behavior.prompt!.buildCommand({
       ...baseContext,
@@ -52,6 +69,20 @@ describe('auggie provider', () => {
     expect(command).toEqual({
       command: 'auggie',
       args: ['--allow-indexing', '--continue'],
+      env: {},
+    });
+  });
+
+  it('passes the documented Auggie model short name with --model', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      initialPrompt: 'Fix the type errors',
+      model: 'opus4.8',
+    });
+
+    expect(command).toEqual({
+      command: 'auggie',
+      args: ['--allow-indexing', '--model', 'opus4.8', 'Fix the type errors'],
       env: {},
     });
   });

--- a/packages/plugins/src/agents/impl/auggie/index.ts
+++ b/packages/plugins/src/agents/impl/auggie/index.ts
@@ -1,5 +1,9 @@
 import { definePlugin, registerPluginBehavior } from '@emdash/core/agents/plugins';
-import { buildStandardCommand, npmDependency } from '@emdash/core/agents/plugins/helpers';
+import {
+  buildStandardCommand,
+  npmDependency,
+  passthroughMcpAdapter,
+} from '@emdash/core/agents/plugins/helpers';
 import { createNativeAcpBehavior } from '../../helpers/acp-stdio';
 import { buildAuggieHookConfig } from './hooks';
 import { icon } from './icon';
@@ -22,6 +26,51 @@ export const plugin = definePlugin(
       supportedEvents: ['notification', 'stop', 'session', 'start'],
     },
     hostDependency: npmDependency({ id: 'auggie', package: '@augmentcode/auggie' }),
+    mcp: {
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    },
+    models: {
+      kind: 'selectable',
+      modelOptions: {
+        'prism-a': {
+          name: 'Prism (Claude + Gemini)',
+          description: 'Automatically routes between Claude and Gemini models.',
+          modelFeatures: { intelligence: 5, speed: 4 },
+        },
+        'prism-b': {
+          name: 'Prism (GPT + Kimi)',
+          description: 'Automatically routes between GPT and Kimi models.',
+          modelFeatures: { intelligence: 5, speed: 4 },
+        },
+        'opus4.8': {
+          name: 'Claude Opus 4.8',
+          description: 'Auggie model option for complex, multi-step agentic work.',
+          modelFeatures: { intelligence: 5, speed: 2 },
+        },
+        'sonnet4.6': {
+          name: 'Claude Sonnet 4.6',
+          description: 'Auggie model option for everyday coding tasks.',
+          modelFeatures: { intelligence: 4, speed: 4 },
+        },
+        'gemini-3.1-pro-preview': {
+          name: 'Gemini 3.1 Pro',
+          description: 'Auggie model option for complex tasks at a lower cost tier.',
+          modelFeatures: { intelligence: 4, speed: 4 },
+        },
+        'gpt5.5': {
+          name: 'GPT-5.5',
+          description: 'Auggie model option for complex planning and implementation work.',
+          modelFeatures: { intelligence: 5, speed: 3 },
+        },
+        'kimi-k2.7': {
+          name: 'Kimi K2.7 Code',
+          description: 'Auggie coding-focused model option with a lower cost tier.',
+          modelFeatures: { intelligence: 4, speed: 4 },
+        },
+      },
+    },
     prompt: {
       kind: 'argv',
       flag: '',
@@ -49,7 +98,9 @@ export const provider = registerPluginBehavior(plugin, {
         sessionIdFlag: '--resume',
         sessionIdOnResumeOnly: true,
         resumeWithoutSessionFlag: '--continue',
+        modelFlag: '--model',
       }),
   },
   hooks: buildAuggieHookConfig(),
+  mcp: passthroughMcpAdapter('.augment/settings.json'),
 });

--- a/packages/plugins/src/agents/impl/charm/index.test.ts
+++ b/packages/plugins/src/agents/impl/charm/index.test.ts
@@ -16,7 +16,7 @@ describe('charm provider', () => {
     expect(provider.capabilities.autoApprove).toEqual({ kind: 'none' });
   });
 
-  it('supports Crush MCP configuration', () => {
+  it('supports Crush MCP configuration through the transports Emdash can represent', () => {
     expect(provider.capabilities.mcp).toEqual({
       kind: 'supported',
       scope: 'global',
@@ -39,6 +39,20 @@ describe('charm provider', () => {
     });
   });
 
+  it('passes a selected model to Crush run with the documented --model flag', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      initialPrompt: 'implement the task',
+      model: 'openai/gpt-5.4',
+    });
+
+    expect(command).toEqual({
+      command: 'crush',
+      args: ['run', '--model', 'openai/gpt-5.4', 'implement the task'],
+      env: {},
+    });
+  });
+
   it('starts an empty fresh session in interactive mode', () => {
     const command = provider.behavior.prompt!.buildCommand(baseContext);
 
@@ -49,7 +63,7 @@ describe('charm provider', () => {
     });
   });
 
-  it('does not pass Emdash ids as Crush session ids', () => {
+  it('continues the most recent Crush session when no native session id is stored', () => {
     const command = provider.behavior.prompt!.buildCommand({
       ...baseContext,
       isResuming: true,
@@ -57,7 +71,21 @@ describe('charm provider', () => {
 
     expect(command).toEqual({
       command: 'crush',
-      args: [],
+      args: ['--continue'],
+      env: {},
+    });
+  });
+
+  it('resumes a stored native Crush session with --session', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      isResuming: true,
+      providerSessionId: 'b78e4cf1-27ee-4ef5-a58c-d7480a7c9a22',
+    });
+
+    expect(command).toEqual({
+      command: 'crush',
+      args: ['--session', 'b78e4cf1-27ee-4ef5-a58c-d7480a7c9a22'],
       env: {},
     });
   });

--- a/packages/plugins/src/agents/impl/charm/index.ts
+++ b/packages/plugins/src/agents/impl/charm/index.ts
@@ -11,6 +11,11 @@ function buildCharmCommand(ctx: CommandContext) {
   return buildStandardCommand(ctx, {
     defaultArgs: ctx.initialPrompt && !ctx.isResuming ? ['run'] : undefined,
     initialPromptFlag: '',
+    modelFlag: '--model',
+    resumeFlag: '--session',
+    sessionIdFlag: '--session',
+    sessionIdOnResumeOnly: true,
+    resumeWithoutSessionFlag: '--continue',
   });
 }
 
@@ -36,6 +41,8 @@ export const plugin = definePlugin(
       supportedTransports: ['stdio', 'http'],
     },
     models: {
+      // Crush discovers models from the configured provider catalog, so a static
+      // picker could advertise models unavailable in a user's configuration.
       kind: 'none',
     },
     plugins: {
@@ -46,7 +53,7 @@ export const plugin = definePlugin(
       flag: '',
     },
     sessions: {
-      kind: 'stateless',
+      kind: 'resumable',
     },
   },
   { icon }

--- a/packages/plugins/src/agents/impl/continue/index.test.ts
+++ b/packages/plugins/src/agents/impl/continue/index.test.ts
@@ -22,7 +22,7 @@ describe('Continue provider', () => {
 
     expect(command).toEqual({
       command: 'cn',
-      args: ['--auto', '--model', 'anthropic/claude-4-sonnet', '-p', 'Fix the test suite'],
+      args: ['--auto', '--model', 'anthropic/claude-4-sonnet', '--prompt', 'Fix the test suite'],
       env: {},
     });
   });

--- a/packages/plugins/src/agents/impl/continue/index.test.ts
+++ b/packages/plugins/src/agents/impl/continue/index.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'cn',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-session-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+describe('Continue provider', () => {
+  it('uses Continue headless flags for a prompt, model, and all-tools approval', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      autoApprove: true,
+      initialPrompt: 'Fix the test suite',
+      model: 'anthropic/claude-4-sonnet',
+    });
+
+    expect(command).toEqual({
+      command: 'cn',
+      args: ['--auto', '--model', 'anthropic/claude-4-sonnet', '-p', 'Fix the test suite'],
+      env: {},
+    });
+  });
+
+  it('resumes the provider-selected most recent session without passing an Emdash UUID', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      isResuming: true,
+    });
+
+    expect(command).toEqual({ command: 'cn', args: ['--resume'], env: {} });
+  });
+
+  it('writes supported MCP transports to Continue global configuration', () => {
+    expect(provider.capabilities.mcp).toEqual({
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    });
+    expect(provider.behavior.mcp).toBeDefined();
+  });
+});

--- a/packages/plugins/src/agents/impl/continue/index.ts
+++ b/packages/plugins/src/agents/impl/continue/index.ts
@@ -1,5 +1,5 @@
 import { definePlugin, registerPluginBehavior } from '@emdash/core/agents/plugins';
-import { buildStandardCommand } from '@emdash/core/agents/plugins/helpers';
+import { buildStandardCommand, continueMcpAdapter } from '@emdash/core/agents/plugins/helpers';
 import { icon } from './icon';
 
 export const plugin = definePlugin(
@@ -48,9 +48,14 @@ export const plugin = definePlugin(
         },
       },
     },
+    mcp: {
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    },
     prompt: {
       kind: 'argv',
-      flag: '',
+      flag: '-p',
     },
     sessions: {
       kind: 'resumable',
@@ -64,8 +69,10 @@ export const provider = registerPluginBehavior(plugin, {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
         autoApproveFlag: '--auto',
-        initialPromptFlag: '',
+        initialPromptFlag: '-p',
+        modelFlag: '--model',
         resumeFlag: '--resume',
       }),
   },
+  mcp: continueMcpAdapter(),
 });

--- a/packages/plugins/src/agents/impl/continue/index.ts
+++ b/packages/plugins/src/agents/impl/continue/index.ts
@@ -55,7 +55,7 @@ export const plugin = definePlugin(
     },
     prompt: {
       kind: 'argv',
-      flag: '-p',
+      flag: '--prompt',
     },
     sessions: {
       kind: 'resumable',
@@ -69,7 +69,7 @@ export const provider = registerPluginBehavior(plugin, {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
         autoApproveFlag: '--auto',
-        initialPromptFlag: '-p',
+        initialPromptFlag: '--prompt',
         modelFlag: '--model',
         resumeFlag: '--resume',
       }),

--- a/packages/plugins/src/agents/impl/cursor/index.test.ts
+++ b/packages/plugins/src/agents/impl/cursor/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'cursor-agent',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-session-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+describe('Cursor provider', () => {
+  it('advertises Cursor CLI model, MCP, and resumable-session support', () => {
+    expect(provider.capabilities.models).toMatchObject({
+      kind: 'selectable',
+      modelOptions: { 'gpt-5': { name: 'GPT-5' } },
+    });
+    expect(provider.capabilities.mcp).toEqual({
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    });
+    expect(provider.capabilities.sessions).toEqual({ kind: 'resumable' });
+  });
+
+  it('auto-approves commands and MCP servers for a new Cursor session', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      model: 'gpt-5',
+    });
+
+    expect(command).toEqual({
+      command: 'cursor-agent',
+      args: ['--force', '--approve-mcps', '--model', 'gpt-5', 'Fix the bug'],
+      env: {},
+    });
+  });
+
+  it('resumes a stored Cursor chat with its native id', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      providerSessionId: 'cursor-chat-id',
+      isResuming: true,
+    });
+
+    expect(command).toEqual({
+      command: 'cursor-agent',
+      args: ['--resume', 'cursor-chat-id'],
+      env: {},
+    });
+  });
+
+  it('uses Cursor resume when the native chat id is not yet known', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      isResuming: true,
+    });
+
+    expect(command).toEqual({ command: 'cursor-agent', args: ['resume'], env: {} });
+  });
+});

--- a/packages/plugins/src/agents/impl/cursor/index.ts
+++ b/packages/plugins/src/agents/impl/cursor/index.ts
@@ -51,6 +51,16 @@ export const plugin = definePlugin(
       scope: 'global',
       supportedTransports: ['stdio', 'http'],
     },
+    models: {
+      kind: 'selectable',
+      modelOptions: {
+        'gpt-5': {
+          name: 'GPT-5',
+          description: 'Cursor CLI documents gpt-5 as a model value for agent sessions.',
+          modelFeatures: { intelligence: 5, speed: 4 },
+        },
+      },
+    },
     prompt: {
       kind: 'argv',
       flag: '',
@@ -72,9 +82,13 @@ export const provider = registerPluginBehavior(plugin, {
   prompt: {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
-        autoApproveFlag: '-f --approve-mcps',
+        autoApproveFlag: '--force --approve-mcps',
         initialPromptFlag: '',
         resumeFlag: '--resume',
+        sessionIdFlag: '--resume',
+        sessionIdOnResumeOnly: true,
+        resumeWithoutSessionFlag: 'resume',
+        modelFlag: '--model',
       }),
   },
   mcp: cursorMcpAdapter(),

--- a/packages/plugins/src/agents/impl/index.test.ts
+++ b/packages/plugins/src/agents/impl/index.test.ts
@@ -281,7 +281,7 @@ describe('pluginRegistry', () => {
 
     expect(result).toEqual({
       command: 'vibe',
-      args: ['--agent', 'auto-approve', 'Fix the bug'],
+      args: ['--auto-approve', '--prompt', 'Fix the bug'],
       env: { VIBE_ACTIVE_MODEL: 'mistral-medium-3.5' },
     });
   });

--- a/packages/plugins/src/agents/impl/junie/index.test.ts
+++ b/packages/plugins/src/agents/impl/junie/index.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'junie',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'session-251209-172932-1ze8',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+describe('Junie provider', () => {
+  it('starts an interactive session with the documented prompt and model flags', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      initialPrompt: 'Fix the test suite',
+      model: 'gpt-codex',
+    });
+
+    expect(command).toEqual({
+      command: 'junie',
+      args: [
+        '--session-id',
+        'session-251209-172932-1ze8',
+        '--model',
+        'gpt-codex',
+        '--prompt',
+        'Fix the test suite',
+      ],
+      env: {},
+    });
+  });
+
+  it('reopens the named native session with --session-id', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      isResuming: true,
+    });
+
+    expect(command).toEqual({
+      command: 'junie',
+      args: ['--session-id', 'session-251209-172932-1ze8'],
+      env: {},
+    });
+  });
+
+  it('exposes documented model aliases and global JSON MCP configuration', () => {
+    expect(provider.capabilities.models).toMatchObject({
+      kind: 'selectable',
+      modelOptions: {
+        sonnet: { name: 'Claude Sonnet' },
+        'gpt-codex': { name: 'GPT Codex' },
+        'gemini-pro': { name: 'Gemini Pro' },
+      },
+    });
+    expect(provider.capabilities.mcp).toEqual({
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    });
+    expect(provider.behavior.mcp).toBeDefined();
+  });
+});

--- a/packages/plugins/src/agents/impl/junie/index.ts
+++ b/packages/plugins/src/agents/impl/junie/index.ts
@@ -1,5 +1,5 @@
 import { definePlugin, registerPluginBehavior } from '@emdash/core/agents/plugins';
-import { buildStandardCommand } from '@emdash/core/agents/plugins/helpers';
+import { buildStandardCommand, junieMcpAdapter } from '@emdash/core/agents/plugins/helpers';
 import { createNativeAcpBehavior } from '../../helpers/acp-stdio';
 import { icon } from './icon';
 
@@ -42,9 +42,54 @@ export const plugin = definePlugin(
         },
       },
     },
+    mcp: {
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    },
+    models: {
+      kind: 'selectable',
+      modelOptions: {
+        sonnet: {
+          name: 'Claude Sonnet',
+          description: 'Junie alias for Claude Sonnet 4.6.',
+          modelFeatures: { intelligence: 4, speed: 4 },
+        },
+        opus: {
+          name: 'Claude Opus',
+          description: 'Junie alias for Claude Opus 4.8.',
+          modelFeatures: { intelligence: 5, speed: 2 },
+        },
+        gpt: {
+          name: 'GPT',
+          description: 'Junie alias for GPT-5.4.',
+          modelFeatures: { intelligence: 5, speed: 4 },
+        },
+        'gpt-codex': {
+          name: 'GPT Codex',
+          description: 'Junie alias for GPT-5.3-Codex.',
+          modelFeatures: { intelligence: 5, speed: 4 },
+        },
+        'gemini-pro': {
+          name: 'Gemini Pro',
+          description: 'Junie alias for Gemini 3.1 Pro Preview.',
+          modelFeatures: { intelligence: 5, speed: 3 },
+        },
+        'gemini-flash': {
+          name: 'Gemini Flash',
+          description: 'Junie alias for Gemini 3 Flash.',
+          modelFeatures: { intelligence: 4, speed: 5 },
+        },
+        grok: {
+          name: 'Grok',
+          description: 'Junie alias for Grok 4.3.',
+          modelFeatures: { intelligence: 4, speed: 4 },
+        },
+      },
+    },
     prompt: {
       kind: 'argv',
-      flag: '--task',
+      flag: '--prompt',
     },
     sessions: {
       kind: 'resumable',
@@ -60,8 +105,11 @@ export const provider = registerPluginBehavior(plugin, {
   prompt: {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
-        initialPromptFlag: '--task',
+        initialPromptFlag: '--prompt',
+        modelFlag: '--model',
         sessionIdFlag: '--session-id',
+        sessionIdAlways: true,
       }),
   },
+  mcp: junieMcpAdapter(),
 });

--- a/packages/plugins/src/agents/impl/mistral/index.test.ts
+++ b/packages/plugins/src/agents/impl/mistral/index.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'vibe',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-session-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+};
+
+describe('Mistral Vibe provider', () => {
+  it('advertises Vibe native MCP and resumable-session support', () => {
+    expect(provider.capabilities.mcp).toEqual({
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    });
+    expect(provider.capabilities.sessions).toEqual({ kind: 'resumable' });
+  });
+
+  it('uses Vibe programmatic flags instead of passing the prompt positionally', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      autoApprove: true,
+      initialPrompt: 'Fix the bug',
+      model: 'mistral-medium-3.5',
+    });
+
+    expect(command).toEqual({
+      command: 'vibe',
+      args: ['--auto-approve', '--prompt', 'Fix the bug'],
+      env: { VIBE_ACTIVE_MODEL: 'mistral-medium-3.5' },
+    });
+  });
+
+  it('resumes a stored Vibe session id with --resume', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      providerSessionId: 'abc123',
+      isResuming: true,
+    });
+
+    expect(command).toEqual({ command: 'vibe', args: ['--resume', 'abc123'], env: {} });
+  });
+
+  it('continues the latest Vibe session when no native session id is stored', () => {
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      isResuming: true,
+    });
+
+    expect(command).toEqual({ command: 'vibe', args: ['--continue'], env: {} });
+  });
+});

--- a/packages/plugins/src/agents/impl/mistral/index.ts
+++ b/packages/plugins/src/agents/impl/mistral/index.ts
@@ -1,6 +1,6 @@
 import { dirname, extname, join } from 'node:path';
 import { definePlugin, registerPluginBehavior } from '@emdash/core/agents/plugins';
-import { buildStandardCommand } from '@emdash/core/agents/plugins/helpers';
+import { buildStandardCommand, mistralMcpAdapter } from '@emdash/core/agents/plugins/helpers';
 import { createNativeAcpBehavior } from '../../helpers/acp-stdio';
 import { buildMistralHookConfig } from './hooks';
 import { icon } from './icon';
@@ -73,12 +73,17 @@ export const plugin = definePlugin(
         },
       },
     },
+    mcp: {
+      kind: 'supported',
+      scope: 'global',
+      supportedTransports: ['stdio', 'http'],
+    },
     prompt: {
       kind: 'argv',
-      flag: '',
+      flag: '--prompt',
     },
     sessions: {
-      kind: 'stateless',
+      kind: 'resumable',
     },
   },
   { icon }
@@ -97,9 +102,14 @@ export const provider = registerPluginBehavior(plugin, {
   prompt: {
     buildCommand: (ctx) =>
       buildStandardCommand(ctx, {
-        autoApproveFlag: '--agent auto-approve',
-        initialPromptFlag: '',
+        autoApproveFlag: '--auto-approve',
+        initialPromptFlag: '--prompt',
+        resumeFlag: '--resume',
+        sessionIdFlag: '--resume',
+        sessionIdOnResumeOnly: true,
+        resumeWithoutSessionFlag: '--continue',
         extraEnv: ctx.model ? { VIBE_ACTIVE_MODEL: ctx.model } : undefined,
       }),
   },
+  mcp: mistralMcpAdapter(),
 });

--- a/packages/runtime/src/agent-config/runtime/mcp.ts
+++ b/packages/runtime/src/agent-config/runtime/mcp.ts
@@ -1,4 +1,5 @@
 import {
+  mergeMcpServerRegistration,
   mcpServerFieldCount,
   mcpServerToRegistration,
   registrationToMcpServer,
@@ -47,7 +48,7 @@ export class AgentMcpConfigManager {
           const idx = regs.findIndex((reg) => reg.name === server.name);
           if (selectedProviders.has(agentId)) {
             const next = mcpServerToRegistration(server);
-            if (idx >= 0) regs[idx] = next;
+            if (idx >= 0) regs[idx] = mergeMcpServerRegistration(regs[idx], server);
             else regs = [...regs, next];
           } else if (idx >= 0) {
             regs.splice(idx, 1);


### PR DESCRIPTION
### Description

Expands native provider support for Charm, Auggie, Continue, Cursor, Junie, and Mistral Vibe with documented prompt, model, resume, auto-approval, and MCP behavior, including Continue's current `--prompt` invocation. Adds provider-focused tests and a Vibe TOML adapter that preserves HTTP transport choices, defaults new remote servers to streamable HTTP, and retains provider-native MCP fields during UI saves.

### Related issues

None.

### Testing

Passed the repo-wide typecheck; Core, Runtime, Desktop, and Plugins lint/format checks; and 110 focused tests. The full Plugins suite passes 365/367 tests; two unrelated existing Claude ACP fixture/provider-list tests remain failing.

### Screenshot/Recording (if applicable)

Not applicable; this PR changes provider CLI and MCP configuration behavior.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Documentation changes were not required
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and the PR title

</details>
