### PR TITLE
feat(chat-ui): enable chat UI for all ACP-capable users

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
@@ -5,7 +5,6 @@ import { getProjectSshConnectionId } from '@renderer/features/projects/stores/pr
 // TODO(conversations-extraction): Pass task settings into the modal instead of importing task hooks.
 import { useTaskSettings } from '@renderer/features/tasks/hooks/useTaskSettings';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
-import { useFeatureFlag } from '@renderer/lib/hooks/useFeatureFlag';
 import { useLocalStorage } from '@renderer/lib/hooks/useLocalStorage';
 import { type BaseModalProps } from '@renderer/lib/modal/modal-provider';
 import { useCloseGuard } from '@renderer/lib/modal/use-close-guard';
@@ -51,7 +50,6 @@ export const CreateConversationModal = observer(function CreateConversationModal
     'initial-conversation:chat-ui-enabled',
     true
   );
-  const chatUiEnabled = useFeatureFlag('chat-ui');
   useCloseGuard(isSubmitting);
 
   const { data: agents } = useAgents();
@@ -61,7 +59,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
     modelsCapability?.kind === 'selectable' ? modelsCapability.modelOptions : null;
 
   const showAutoApproveToggle = agentSupportsAutoApprove(selectedAgent?.capabilities);
-  const showAcpToggle = chatUiEnabled && agentSupportsAcp(selectedAgent?.capabilities);
+  const showAcpToggle = agentSupportsAcp(selectedAgent?.capabilities);
   const useAcp = showAcpToggle && useChatUiPreference;
   const skipPermissions =
     showAutoApproveToggle && (autoApproveOverride ?? taskSettings.autoApproveByDefault);

--- a/apps/emdash-desktop/src/renderer/features/settings/agents-page/AgentRow.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/agents-page/AgentRow.tsx
@@ -1,7 +1,6 @@
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
 import { getAgentUpdateActionState } from '@renderer/lib/components/agent-selector/agent-install';
 import { AgentUiBadge } from '@renderer/lib/components/agent-ui-badge';
-import { useFeatureFlag } from '@renderer/lib/hooks/useFeatureFlag';
 import { agentSupportsAcp, type AgentPayload } from '@shared/core/agents/agent-payload';
 import { InstalledBadge, UninstalledBadge, UpdateAvailableBadge } from './agent-status-badge';
 
@@ -9,8 +8,7 @@ export const AgentRow = ({ agent, onClick }: { agent: AgentPayload; onClick?: ()
   const isInstalled = agent.status === 'available';
   const isClickable = !!onClick;
   const Tag = isClickable ? 'button' : 'div';
-  const chatUiFeatureEnabled = useFeatureFlag('chat-ui');
-  const showUiBadge = chatUiFeatureEnabled && agentSupportsAcp(agent.capabilities);
+  const showUiBadge = agentSupportsAcp(agent.capabilities);
 
   const updates = agent.capabilities.hostDependency.updates;
   const updateStrategyKind = updates.kind === 'supported' ? updates.update.kind : 'none';

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -17,7 +17,6 @@ import {
 const mocks = vi.hoisted(() => ({
   getProjectSshConnectionId: vi.fn(),
   setProviderOverride: vi.fn(),
-  chatUiFeature: true,
   editorText: '',
   editorApi: {
     focus: vi.fn(),
@@ -100,10 +99,6 @@ vi.mock('@renderer/lib/stores/use-agents', () => ({
       },
     ],
   }),
-}));
-
-vi.mock('@renderer/lib/hooks/useFeatureFlag', () => ({
-  useFeatureFlag: () => mocks.chatUiFeature,
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -15,7 +15,6 @@ import { IntegrationIcon } from '@renderer/features/integrations/integration-ico
 import { usePromptLibrary } from '@renderer/features/library/prompts/use-prompt-library';
 import { getProjectSshConnectionId } from '@renderer/features/projects/stores/project-selectors';
 import { AgentSelector } from '@renderer/lib/components/agent-selector/agent-selector';
-import { useFeatureFlag } from '@renderer/lib/hooks/useFeatureFlag';
 import { useLocalStorage } from '@renderer/lib/hooks/useLocalStorage';
 import { useAgents } from '@renderer/lib/stores/use-agents';
 import { Field } from '@renderer/lib/ui/field';
@@ -70,7 +69,6 @@ export function useInitialConversationState(
   const { resetPromptOnProjectChange = true } = options;
   const connectionId = projectId ? getProjectSshConnectionId(projectId) : undefined;
   const { providerId, setProviderOverride } = useEffectiveProvider(connectionId, initialProvider);
-  const chatUiFeatureEnabled = useFeatureFlag('chat-ui');
   const { data: agents } = useAgents();
   const [prompt, setPrompt] = useState('');
   const [issueContext, setIssueContext] = useState<string | null>(null);
@@ -107,7 +105,7 @@ export function useInitialConversationState(
   const capabilities = agents?.find((agent) => agent.id === providerId)?.capabilities;
   const autoApproveSupported = agentSupportsAutoApprove(capabilities);
   const autoApprove = autoApproveSupported && (autoApproveOverride ?? autoApproveByDefault);
-  const acpSupported = chatUiFeatureEnabled && agentSupportsAcp(capabilities);
+  const acpSupported = agentSupportsAcp(capabilities);
   const useChatUi = acpSupported && useChatUiPreference;
 
   return {
@@ -213,8 +211,7 @@ export function InitialConversationField({
 
   const capabilities = useAgentCapabilities(state.provider);
   const canToggleAutoApprove = agentSupportsAutoApprove(capabilities);
-  const chatUiFeatureEnabled = useFeatureFlag('chat-ui');
-  const canToggleChatUi = chatUiFeatureEnabled && agentSupportsAcp(capabilities);
+  const canToggleChatUi = agentSupportsAcp(capabilities);
 
   const { isDragOver, dropHandlers } = usePromptFileDrop({
     // Local paths would not exist on the remote host of an SSH project.

--- a/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-selector.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/agent-selector/agent-selector.tsx
@@ -5,7 +5,6 @@ import { observer } from 'mobx-react-lite';
 import React, { useMemo, useState } from 'react';
 import { AgentIcon } from '@renderer/lib/components/agent-icon';
 import { AgentUiBadge } from '@renderer/lib/components/agent-ui-badge';
-import { useFeatureFlag } from '@renderer/lib/hooks/useFeatureFlag';
 import {
   Combobox,
   ComboboxCollection,
@@ -52,7 +51,6 @@ export const AgentSelector: React.FC<AgentSelectorProps> = observer(
     const [open, setOpen] = useState(false);
     const [anchorEl, setAnchorEl] = useState<HTMLElement | null>(null);
     const hoverCard = useAgentHoverCard();
-    const chatUiFeatureEnabled = useFeatureFlag('chat-ui');
     const { groups } = useAgentAvailability({
       connectionId,
       value,
@@ -150,7 +148,7 @@ export const AgentSelector: React.FC<AgentSelectorProps> = observer(
                         >
                           {item.label}
                         </span>
-                        {chatUiFeatureEnabled && item.supportsAcp && <AgentUiBadge />}
+                        {item.supportsAcp && <AgentUiBadge />}
                       </ComboboxItem>
                     );
                   }}


### PR DESCRIPTION
### Description

Remove the `chat-ui` PostHog feature flag gate from task creation, conversation creation,
and agent badges. Chat UI availability now depends only on whether the selected agent
supports ACP, so users can access it without signing in to an Emdash account.

Preserve the existing local opt-out preference, which defaults chat UI to enabled for
users who have not previously changed the toggle.

### Related issues

None.

### Testing

- `pnpm exec vitest run --project node src/renderer/features/tasks/task-config/initial-conversation-section.test.ts`
- `pnpm exec nx typecheck @emdash/emdash-desktop`
- Touched-file formatting and linting
- `git diff --check`
- Structured self-review with no actionable findings

### Screenshot/Recording (if applicable)

Not attached; this changes feature availability without changing the existing layout.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks
- [x] Documentation is not required for this feature-flag graduation
- [x] I updated the affected test setup and ran the focused test
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
