### PR TITLE
feat(chat-ui): make first-time use opt-in

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
@@ -48,7 +48,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
   const [selectedModel, setSelectedModel] = useState<string | null>(null);
   const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
     'initial-conversation:chat-ui-enabled',
-    true
+    false
   );
   useCloseGuard(isSubmitting);
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -229,24 +229,26 @@ describe('useInitialConversationState', () => {
     expect(latestState?.prompt).toBe('Keep this automation prompt');
   });
 
-  it('defaults chat UI on when the provider supports ACP', async () => {
+  it('defaults chat UI off when the provider supports ACP', async () => {
     await renderProbe('project-1');
 
-    expect(latestState?.useChatUi).toBe(true);
+    expect(latestState?.useChatUi).toBe(false);
   });
 
-  it('persists when chat UI is disabled', async () => {
+  it('persists after the user enables chat UI', async () => {
     await renderProbe('project-1');
 
     await act(async () => {
-      latestState?.setUseChatUi(false);
+      latestState?.setUseChatUi(true);
     });
 
-    expect(dom.window.localStorage.getItem('initial-conversation:chat-ui-enabled')).toBe('false');
+    expect(dom.window.localStorage.getItem('initial-conversation:chat-ui-enabled')).toBe('true');
 
+    await act(async () => root.unmount());
+    root = createRoot(container);
     await renderProbe('project-2');
 
-    expect(latestState?.useChatUi).toBe(false);
+    expect(latestState?.useChatUi).toBe(true);
   });
 });
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -78,7 +78,7 @@ export function useInitialConversationState(
   const [issueMentionContexts, setIssueMentionContexts] = useState<Record<string, string>>({});
   const [useChatUiPreference, setUseChatUiPreference] = useLocalStorage(
     'initial-conversation:chat-ui-enabled',
-    true
+    false
   );
 
   const [prevProjectId, setPrevProjectId] = useState(projectId);


### PR DESCRIPTION
### Description

Make chat UI opt-in for first-time users. When no local preference exists, the chat UI
toggle now starts disabled in both task creation and new-conversation creation.

Once a user enables chat UI, the shared local preference remains enabled for future tasks
and conversations. Existing saved `true` and `false` preferences continue to be respected.

### Related issues

Follow-up to #2856.

### Testing

- `pnpm exec vitest run --project node src/renderer/features/tasks/task-config/initial-conversation-section.test.ts`
- `pnpm exec nx typecheck @emdash/emdash-desktop`
- Touched-file formatting and linting
- `git diff --check`
- Structured self-review with no actionable findings

### Screenshot/Recording (if applicable)

Not attached; this changes the toggle's initial state without changing its layout.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks
- [x] Documentation is not required for this default-state change
- [x] I updated tests for the new default and persisted opt-in behavior
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
