### PR TITLE
fix(ui): align Ask mode in new issue modal

### DIFF
--- a/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.css.ts
@@ -200,6 +200,11 @@ export const toolbar = style({
 export const toolbarLeft = style({ display: 'flex', alignItems: 'center', gap: '0.375rem' });
 export const toolbarRight = style({ display: 'flex', alignItems: 'center', gap: '0.25rem' });
 
+export const permissionModeTrigger = style({
+  paddingLeft: '0.1875rem',
+  paddingRight: '0.1875rem',
+});
+
 // ── Agent trigger ─────────────────────────────────────────────────────────────
 
 export const agentTrigger = style({

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -699,6 +699,7 @@ export function ChatComposer({
   const permissionModeItems: PermissionModeItem[] = permissionModeOptions
     ? Object.entries(permissionModeOptions).map(([id, opt]) => ({ id, ...opt }))
     : [];
+  const permissionModeIsFirst = modelItems.length === 0 && !agentOptions?.length;
 
   const canShowQueuedPrompts =
     queuedPrompts.length > 0 &&
@@ -825,7 +826,7 @@ export function ChatComposer({
                 disabled={disabled}
               />
             )}
-            {modelItems.length > 0 ? (
+            {modelItems.length > 0 && (
               <ComboboxPopover<ModelItem>
                 items={modelItems}
                 value={selectedModel ?? null}
@@ -912,8 +913,6 @@ export function ChatComposer({
                     : undefined
                 }
               />
-            ) : (
-              <span />
             )}
             {permissionModeItems.length > 0 && (
               <ComboboxPopover<PermissionModeItem>
@@ -924,6 +923,7 @@ export function ChatComposer({
                 itemToLabel={(item) => item.name}
                 disabled={disabled}
                 searchPlaceholder="Search"
+                className={permissionModeIsFirst ? styles.permissionModeTrigger : undefined}
                 contentStyle={{ minWidth: '18rem' }}
                 renderTrigger={(selected) => (
                   <span


### PR DESCRIPTION
### Description

Align the Ask permission-mode control in the new issue modal when no model or agent selector precedes it. This removes the empty model placeholder and gives the first permission trigger balanced horizontal padding, so its icon aligns with the prompt input while the hover surface remains visually centered.

### Related issues

Linear: ENG-1837

### Screenshot/Recording (if applicable)
<img width="420" height="122" alt="Screenshot 2026-07-14 at 12 00 41" src="https://github.com/user-attachments/assets/20b1616d-3afb-445b-a983-6072a8c64b9e" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
