### PR TITLE
feat(automations): add stop task run action

### DIFF
--- a/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/agent-hook-service.ts
@@ -240,10 +240,10 @@ class AgentHookService implements IInitializable, IDisposable, Hookable<AgentHoo
     // Reset a stuck 'working' status to 'idle' when the agent PTY exits.
     // This handles the case where the user interrupts/kills the agent before
     // a 'stop' or 'error' hook fires.
-    events.on(agentSessionExitedChannel, ({ conversationId, taskId }) => {
+    events.on(agentSessionExitedChannel, ({ conversationId, projectId, taskId }) => {
       void (async () => {
         try {
-          await this.resetToIdle({ conversationId, taskId });
+          await this.resetToIdle({ conversationId, projectId, taskId });
         } catch (error) {
           log.warn('AgentHookService: failed to reset stuck working status on exit', {
             conversationId,

--- a/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -668,12 +668,42 @@ describe('conversation provider respawn state', () => {
       });
       const provider = localProvider();
       const item = conversation();
+      const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
 
       await provider.startSession(item);
       for (const handler of exitHandlers) handler({ exitCode: 0 });
       await vi.advanceTimersByTimeAsync(500);
 
       expect(spawnLocalPty).toHaveBeenCalledTimes(2);
+      expect(ptySessionRegistry.hasStopHandler(sessionId)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears the stop handler when an SSH replacement fails', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+      openSsh2Pty
+        .mockResolvedValueOnce({
+          success: true,
+          data: fakePty(exitHandlers),
+        })
+        .mockResolvedValueOnce({
+          success: false,
+          error: new Error('spawn failed'),
+        });
+      const provider = sshProvider();
+      const item = conversation();
+      const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+      await provider.startSession(item);
+      for (const handler of exitHandlers) handler({ exitCode: 0 });
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(openSsh2Pty).toHaveBeenCalledTimes(2);
+      expect(ptySessionRegistry.hasStopHandler(sessionId)).toBe(false);
     } finally {
       vi.useRealTimers();
     }
@@ -686,6 +716,7 @@ describe('conversation provider respawn state', () => {
       spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
       const provider = localProvider();
       const item = conversation();
+      const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
 
       await provider.startSession(item);
       for (const handler of exitHandlers) handler({ exitCode: 0 });
@@ -693,9 +724,145 @@ describe('conversation provider respawn state', () => {
       await vi.advanceTimersByTimeAsync(500);
 
       expect(spawnLocalPty).toHaveBeenCalledTimes(1);
+      expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it('does not respawn a local conversation stopped through the PTY registry', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+      spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+      const provider = localProvider();
+      const item = conversation();
+      const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+      await provider.startSession(item);
+      for (const handler of exitHandlers) handler({ exitCode: 0 });
+      expect(await ptySessionRegistry.stop(sessionId)).toBe(true);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(spawnLocalPty).toHaveBeenCalledTimes(1);
+      expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not respawn an SSH conversation stopped through the PTY registry', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+      openSsh2Pty.mockResolvedValue({
+        success: true,
+        data: fakePty(exitHandlers),
+      });
+      const provider = sshProvider();
+      const item = conversation();
+      const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+      await provider.startSession(item);
+      for (const handler of exitHandlers) handler({ exitCode: 0 });
+      expect(await ptySessionRegistry.stop(sessionId)).toBe(true);
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(openSsh2Pty).toHaveBeenCalledTimes(1);
+      expect((provider as unknown as RespawnState).knownSessionIds.has(sessionId)).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears a local respawn-gap stop handler when the provider is destroyed', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+      spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+      const provider = localProvider();
+      const item = conversation();
+      const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+      await provider.startSession(item);
+      for (const handler of exitHandlers) handler({ exitCode: 0 });
+      await provider.destroyAll();
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(ptySessionRegistry.hasStopHandler(sessionId)).toBe(false);
+      expect(spawnLocalPty).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('clears an SSH respawn-gap stop handler when the provider is destroyed', async () => {
+    vi.useFakeTimers();
+    try {
+      const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+      openSsh2Pty.mockResolvedValue({
+        success: true,
+        data: fakePty(exitHandlers),
+      });
+      const provider = sshProvider();
+      const item = conversation();
+      const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+      await provider.startSession(item);
+      for (const handler of exitHandlers) handler({ exitCode: 0 });
+      await provider.destroyAll();
+      await vi.advanceTimersByTimeAsync(500);
+
+      expect(ptySessionRegistry.hasStopHandler(sessionId)).toBe(false);
+      expect(openSsh2Pty).toHaveBeenCalledTimes(1);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops a detached local tmux conversation through the PTY registry', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+    const ctx = {
+      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
+    };
+    const provider = localProvider({ tmux: true, ctx: ctx as never });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    for (const handler of exitHandlers) handler({ exitCode: 0 });
+    expect(await ptySessionRegistry.stop(sessionId)).toBe(true);
+
+    expect(ctx.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
+    ]);
+  });
+
+  it('stops a detached SSH tmux conversation through the PTY registry', async () => {
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    openSsh2Pty.mockResolvedValue({
+      success: true,
+      data: fakePty(exitHandlers),
+    });
+    const ctx = {
+      exec: vi.fn(async () => ({ stdout: '', stderr: '' })),
+    };
+    const provider = sshProvider(undefined, { tmux: true, ctx: ctx as never });
+    const item = conversation();
+    const sessionId = makePtySessionId(item.projectId, item.taskId, item.id);
+
+    await provider.startSession(item);
+    for (const handler of exitHandlers) handler({ exitCode: 0 });
+    expect(await ptySessionRegistry.stop(sessionId)).toBe(true);
+
+    expect(ctx.exec).toHaveBeenCalledWith('tmux', [
+      'kill-session',
+      '-t',
+      expect.stringContaining(Buffer.from(sessionId, 'utf8').toString('base64url')),
+    ]);
   });
 
   it('does not replace a local tmux attachment after it exits', async () => {

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -45,6 +45,7 @@ export class LocalConversationProvider implements ConversationProvider {
   private sessions = new Map<string, Pty>();
   private knownSessionIds = new Set<string>();
   private supervisor = new ConversationSessionSupervisor();
+  private readonly registryOwner = {};
   private readonly projectId: string;
   private readonly taskPath: string;
   private readonly taskId: string;
@@ -214,7 +215,12 @@ export class LocalConversationProvider implements ConversationProvider {
         if (decision.kind === 'stale') return;
         const replacementSize = ptySessionRegistry.getLastSize(sessionId) ?? spawnSize;
 
-        ptySessionRegistry.unregister(sessionId, { pty, exitInfo: info });
+        ptySessionRegistry.unregister(sessionId, {
+          pty,
+          exitInfo: info,
+          preserveStopHandler: this.supervisor.isDesired(sessionId),
+          owner: this.registryOwner,
+        });
         this.sessions.delete(sessionId);
         if (decision.kind === 'stopped') return;
 
@@ -242,7 +248,7 @@ export class LocalConversationProvider implements ConversationProvider {
           pty.kill();
         } catch {}
         if (ptySessionRegistry.get(sessionId) === pty) {
-          ptySessionRegistry.unregister(sessionId);
+          ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
         }
         return;
       }
@@ -252,6 +258,8 @@ export class LocalConversationProvider implements ConversationProvider {
           providerId: conversation.providerId,
           title: conversation.title,
         },
+        stop: () => this.stopSession(conversation.id),
+        owner: this.registryOwner,
       });
       this.sessions.set(sessionId, pty);
       scheduleInitialPromptInjection({
@@ -270,6 +278,9 @@ export class LocalConversationProvider implements ConversationProvider {
       // No PTY was created (or its onExit never fired), so clean up the temp file here.
       void spill?.cleanup();
       this.supervisor.failSpawn(sessionId, spawnToken);
+      if (!ptySessionRegistry.get(sessionId)) {
+        ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
+      }
       throw error;
     }
   }
@@ -277,7 +288,7 @@ export class LocalConversationProvider implements ConversationProvider {
   private detachPty(sessionId: string): void {
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
-    ptySessionRegistry.unregister(sessionId);
+    ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     if (pty) {
       try {
         pty.kill();
@@ -304,7 +315,7 @@ export class LocalConversationProvider implements ConversationProvider {
     this.knownSessionIds.delete(sessionId);
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
-    ptySessionRegistry.unregister(sessionId);
+    ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     if (pty) {
       try {
         pty.kill();
@@ -329,6 +340,7 @@ export class LocalConversationProvider implements ConversationProvider {
     }
     for (const sessionId of sessionIds) {
       this.supervisor.forget(sessionId);
+      ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     }
     this.knownSessionIds.clear();
   }
@@ -339,7 +351,7 @@ export class LocalConversationProvider implements ConversationProvider {
       try {
         pty.kill();
       } catch {}
-      ptySessionRegistry.unregister(sessionId);
+      ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     }
     this.sessions.clear();
   }
@@ -354,6 +366,12 @@ export class LocalConversationProvider implements ConversationProvider {
     isResuming: boolean;
   }): void {
     setTimeout(() => {
+      const sessionId = makePtySessionId(
+        conversation.projectId,
+        conversation.taskId,
+        conversation.id
+      );
+      if (!this.supervisor.isDesired(sessionId)) return;
       this.startSessionInternal(conversation, initialSize, isResuming, undefined, true).catch(
         (e) => {
           log.error('LocalConversationProvider: replacement failed', {

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -220,6 +220,7 @@ export class LocalConversationProvider implements ConversationProvider {
 
         events.emit(agentSessionExitedChannel, {
           conversationId: conversation.id,
+          projectId: conversation.projectId,
           taskId: conversation.taskId,
         });
 

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -197,6 +197,7 @@ export class SshConversationProvider implements ConversationProvider {
         this.supervisor.failSpawn(sessionId, spawnToken);
         events.emit(agentSessionExitedChannel, {
           conversationId: conversation.id,
+          projectId: conversation.projectId,
           taskId: conversation.taskId,
         });
         return;
@@ -217,6 +218,7 @@ export class SshConversationProvider implements ConversationProvider {
         if (decision.kind === 'failed') {
           events.emit(agentSessionExitedChannel, {
             conversationId: conversation.id,
+            projectId: conversation.projectId,
             taskId: conversation.taskId,
           });
           return;
@@ -225,6 +227,7 @@ export class SshConversationProvider implements ConversationProvider {
         if (this.tmux) {
           events.emit(agentSessionExitedChannel, {
             conversationId: conversation.id,
+            projectId: conversation.projectId,
             taskId: conversation.taskId,
           });
           return;
@@ -245,6 +248,7 @@ export class SshConversationProvider implements ConversationProvider {
           this.supervisor.stop(sessionId);
           events.emit(agentSessionExitedChannel, {
             conversationId: conversation.id,
+            projectId: conversation.projectId,
             taskId: conversation.taskId,
           });
           return;
@@ -252,6 +256,7 @@ export class SshConversationProvider implements ConversationProvider {
 
         events.emit(agentSessionExitedChannel, {
           conversationId: conversation.id,
+          projectId: conversation.projectId,
           taskId: conversation.taskId,
         });
 

--- a/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/ssh-conversation.ts
@@ -38,6 +38,7 @@ export class SshConversationProvider implements ConversationProvider {
   private sessions = new Map<string, Pty>();
   private knownSessionIds = new Set<string>();
   private supervisor = new ConversationSessionSupervisor();
+  private readonly registryOwner = {};
   private readonly projectId: string;
   private readonly taskPath: string;
   private readonly taskId: string;
@@ -195,6 +196,7 @@ export class SshConversationProvider implements ConversationProvider {
           error: result.error.message,
         });
         this.supervisor.failSpawn(sessionId, spawnToken);
+        ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
         events.emit(agentSessionExitedChannel, {
           conversationId: conversation.id,
           projectId: conversation.projectId,
@@ -211,7 +213,12 @@ export class SshConversationProvider implements ConversationProvider {
         if (decision.kind === 'stale') return;
         const replacementSize = ptySessionRegistry.getLastSize(sessionId) ?? spawnSize;
 
-        ptySessionRegistry.unregister(sessionId, { pty, exitInfo: info });
+        ptySessionRegistry.unregister(sessionId, {
+          pty,
+          exitInfo: info,
+          preserveStopHandler: this.supervisor.isDesired(sessionId),
+          owner: this.registryOwner,
+        });
         this.sessions.delete(sessionId);
         if (decision.kind === 'stopped') return;
 
@@ -246,6 +253,7 @@ export class SshConversationProvider implements ConversationProvider {
 
         if (options.shellRefreshRetried && exitCode === 127) {
           this.supervisor.stop(sessionId);
+          ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
           events.emit(agentSessionExitedChannel, {
             conversationId: conversation.id,
             projectId: conversation.projectId,
@@ -274,7 +282,7 @@ export class SshConversationProvider implements ConversationProvider {
           pty.kill();
         } catch {}
         if (ptySessionRegistry.get(sessionId) === pty) {
-          ptySessionRegistry.unregister(sessionId);
+          ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
         }
         return;
       }
@@ -285,6 +293,8 @@ export class SshConversationProvider implements ConversationProvider {
           title: conversation.title,
           isRemote: true,
         },
+        stop: () => this.stopSession(conversation.id),
+        owner: this.registryOwner,
       });
       this.sessions.set(sessionId, pty);
       scheduleInitialPromptInjection({
@@ -301,6 +311,9 @@ export class SshConversationProvider implements ConversationProvider {
       });
     } catch (error) {
       this.supervisor.failSpawn(sessionId, spawnToken);
+      if (!ptySessionRegistry.get(sessionId)) {
+        ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
+      }
       throw error;
     }
   }
@@ -308,7 +321,7 @@ export class SshConversationProvider implements ConversationProvider {
   private detachPty(sessionId: string): void {
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
-    ptySessionRegistry.unregister(sessionId);
+    ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     if (pty) {
       try {
         pty.kill();
@@ -335,7 +348,7 @@ export class SshConversationProvider implements ConversationProvider {
     this.knownSessionIds.delete(sessionId);
     const pty = this.supervisor.stop(sessionId) ?? this.sessions.get(sessionId);
     this.sessions.delete(sessionId);
-    ptySessionRegistry.unregister(sessionId);
+    ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     if (pty) {
       try {
         pty.kill();
@@ -362,6 +375,7 @@ export class SshConversationProvider implements ConversationProvider {
     }
     for (const sessionId of sessionIds) {
       this.supervisor.forget(sessionId);
+      ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     }
     this.knownSessionIds.clear();
   }
@@ -372,7 +386,7 @@ export class SshConversationProvider implements ConversationProvider {
       try {
         pty.kill();
       } catch {}
-      ptySessionRegistry.unregister(sessionId);
+      ptySessionRegistry.unregister(sessionId, { owner: this.registryOwner });
     }
     this.sessions.clear();
   }
@@ -424,6 +438,12 @@ export class SshConversationProvider implements ConversationProvider {
     isResuming: boolean;
   }): void {
     setTimeout(() => {
+      const sessionId = makePtySessionId(
+        conversation.projectId,
+        conversation.taskId,
+        conversation.id
+      );
+      if (!this.supervisor.isDesired(sessionId)) return;
       this.startSessionInternal(conversation, initialSize, isResuming, undefined, true, {
         shellRefreshRetried: false,
       }).catch((e) => {

--- a/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.test.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.test.ts
@@ -77,6 +77,7 @@ describe('deleteProject', () => {
   it('closes a mounted project before deleting its database row', async () => {
     await deleteProject('project-1');
 
+    expect(mocks.teardownTask).toHaveBeenCalledWith('project-1', 'task-1');
     expect(mocks.closeProject).toHaveBeenCalledWith('project-1');
     expect(mocks.deleteWhere).toHaveBeenCalledTimes(1);
     const closeOrder = mocks.closeProject.mock.invocationCallOrder[0];

--- a/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.ts
+++ b/apps/emdash-desktop/src/main/core/projects/operations/deleteProject.ts
@@ -14,7 +14,7 @@ export async function deleteProject(id: string): Promise<void> {
   if (provider) {
     const projectTasks = await getTasks(id);
     await Promise.allSettled([
-      ...projectTasks.map((t) => taskSessionManager.teardownTask(t.id)),
+      ...projectTasks.map((t) => taskSessionManager.teardownTask(id, t.id)),
       ...projectTasks.map((t) => viewStateService.del(`task:${t.id}`)),
     ]);
     await projectManager.closeProject(id);

--- a/apps/emdash-desktop/src/main/core/projects/utils.ts
+++ b/apps/emdash-desktop/src/main/core/projects/utils.ts
@@ -1,8 +1,8 @@
 import { workspaceRegistry } from '@main/core/workspaces/workspace-registry';
 import { taskSessionManager } from '../tasks/task-session-manager';
 
-export function resolveTask(_projectId: string, taskId: string) {
-  return taskSessionManager.getTask(taskId) ?? null;
+export function resolveTask(projectId: string, taskId: string) {
+  return taskSessionManager.getTask(projectId, taskId) ?? null;
 }
 
 export function resolveWorkspace(_projectId: string, workspaceId: string) {

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -143,29 +143,30 @@ describe('ptyController', () => {
     ptySessionRegistry.unregister(sessionId);
   });
 
-  it('does not raw-kill a conversation PTY when its project provider is unavailable', async () => {
+  it('cleans up an orphaned conversation PTY and resets its status', async () => {
     const pty = makePty();
+    const stop = vi.fn(async () => {
+      ptySessionRegistry.unregister('proj-2:task-1:conv-1');
+      pty.kill();
+    });
     const sessionId = 'proj-2:task-1:conv-1';
     mocks.getTask.mockReturnValue(undefined);
     ptySessionRegistry.register(sessionId, pty, {
       metadata: { providerId: 'amp', isRemote: false },
+      stop,
     });
 
     const result = await ptyController.stopSession(sessionId);
 
     expect(mocks.getTask).toHaveBeenCalledWith('proj-2', 'task-1');
-    expect(result).toEqual({
-      success: false,
-      error: {
-        type: 'stop_failed',
-        message: 'Conversation provider is unavailable',
-      },
+    expect(result.success).toBe(true);
+    expect(stop).toHaveBeenCalledOnce();
+    expect(pty.kill).toHaveBeenCalledOnce();
+    expect(ptySessionRegistry.get(sessionId)).toBeUndefined();
+    expect(mocks.resetToIdle).toHaveBeenCalledWith({
+      conversationId: 'conv-1',
+      taskId: 'task-1',
     });
-    expect(pty.kill).not.toHaveBeenCalled();
-    expect(ptySessionRegistry.get(sessionId)).toBe(pty);
-    expect(mocks.resetToIdle).not.toHaveBeenCalled();
-
-    ptySessionRegistry.unregister(sessionId);
   });
 
   it('uploads remote attachments into the git-ignored .emdash dir, not the worktree root (#2680)', async () => {

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -113,8 +113,8 @@ describe('ptyController', () => {
     const result = await ptyController.stopSession(sessionId);
 
     expect(result.success).toBe(true);
-    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-1', 'task-1');
     expect(stopSession).toHaveBeenCalledWith('conv-1');
+    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-1', 'task-1');
     expect(mocks.resetToIdle).toHaveBeenCalledWith({
       conversationId: 'conv-1',
       taskId: 'task-1',
@@ -135,6 +135,7 @@ describe('ptyController', () => {
     const result = await ptyController.stopSession(sessionId);
 
     expect(result.success).toBe(true);
+    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-1', 'task-1');
     expect(stopSession).toHaveBeenCalledWith('conv-1');
     expect(mocks.resetToIdle).toHaveBeenCalledWith({
       conversationId: 'conv-1',
@@ -142,6 +143,25 @@ describe('ptyController', () => {
     });
 
     ptySessionRegistry.unregister(sessionId);
+  });
+
+  it('falls back to killing the PTY when the task does not belong to the parsed project', async () => {
+    const wrongProjectStopSession = vi.fn();
+    const pty = makePty();
+    const sessionId = 'proj-2:task-1:conv-1';
+    mocks.getTask.mockReturnValue({ conversations: { stopSession: wrongProjectStopSession } });
+    mocks.getTaskForProject.mockReturnValue(undefined);
+    ptySessionRegistry.register(sessionId, pty, {
+      metadata: { providerId: 'amp', isRemote: false },
+    });
+
+    const result = await ptyController.stopSession(sessionId);
+
+    expect(result.success).toBe(true);
+    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-2', 'task-1');
+    expect(wrongProjectStopSession).not.toHaveBeenCalled();
+    expect(pty.kill).toHaveBeenCalledOnce();
+    expect(ptySessionRegistry.get(sessionId)).toBeUndefined();
   });
 
   it('uploads remote attachments into the git-ignored .emdash dir, not the worktree root (#2680)', async () => {

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -6,6 +6,7 @@ import { ptySessionRegistry } from './pty-session-registry';
 
 const mocks = vi.hoisted(() => ({
   getTask: vi.fn(),
+  getTaskForProject: vi.fn(),
   getWorkspace: vi.fn(),
   getWorkspaceId: vi.fn(),
   resetToIdle: vi.fn(),
@@ -49,6 +50,7 @@ vi.mock('@main/lib/events', () => ({
 vi.mock('../tasks/task-session-manager', () => ({
   taskSessionManager: {
     getTask: mocks.getTask,
+    getTaskForProject: mocks.getTaskForProject,
     getWorkspaceId: mocks.getWorkspaceId,
   },
 }));
@@ -103,7 +105,7 @@ describe('ptyController', () => {
   it('resets agent status after intentionally stopping a conversation PTY', async () => {
     const stopSession = vi.fn().mockResolvedValue(undefined);
     const sessionId = 'proj-1:task-1:conv-1';
-    mocks.getTask.mockReturnValue({ conversations: { stopSession } });
+    mocks.getTaskForProject.mockReturnValue({ conversations: { stopSession } });
     ptySessionRegistry.register(sessionId, makePty(), {
       metadata: { providerId: 'amp', isRemote: false },
     });
@@ -111,6 +113,7 @@ describe('ptyController', () => {
     const result = await ptyController.stopSession(sessionId);
 
     expect(result.success).toBe(true);
+    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-1', 'task-1');
     expect(stopSession).toHaveBeenCalledWith('conv-1');
     expect(mocks.resetToIdle).toHaveBeenCalledWith({
       conversationId: 'conv-1',
@@ -123,7 +126,7 @@ describe('ptyController', () => {
   it('reports success when status reset fails after stopping a conversation PTY', async () => {
     const stopSession = vi.fn().mockResolvedValue(undefined);
     const sessionId = 'proj-1:task-1:conv-1';
-    mocks.getTask.mockReturnValue({ conversations: { stopSession } });
+    mocks.getTaskForProject.mockReturnValue({ conversations: { stopSession } });
     mocks.resetToIdle.mockRejectedValueOnce(new Error('reset failed'));
     ptySessionRegistry.register(sessionId, makePty(), {
       metadata: { providerId: 'amp', isRemote: false },

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -6,7 +6,6 @@ import { ptySessionRegistry } from './pty-session-registry';
 
 const mocks = vi.hoisted(() => ({
   getTask: vi.fn(),
-  getTaskForProject: vi.fn(),
   getWorkspace: vi.fn(),
   getWorkspaceId: vi.fn(),
   resetToIdle: vi.fn(),
@@ -50,7 +49,6 @@ vi.mock('@main/lib/events', () => ({
 vi.mock('../tasks/task-session-manager', () => ({
   taskSessionManager: {
     getTask: mocks.getTask,
-    getTaskForProject: mocks.getTaskForProject,
     getWorkspaceId: mocks.getWorkspaceId,
   },
 }));
@@ -105,7 +103,7 @@ describe('ptyController', () => {
   it('resets agent status after intentionally stopping a conversation PTY', async () => {
     const stopSession = vi.fn().mockResolvedValue(undefined);
     const sessionId = 'proj-1:task-1:conv-1';
-    mocks.getTaskForProject.mockReturnValue({ conversations: { stopSession } });
+    mocks.getTask.mockReturnValue({ conversations: { stopSession } });
     ptySessionRegistry.register(sessionId, makePty(), {
       metadata: { providerId: 'amp', isRemote: false },
     });
@@ -114,7 +112,7 @@ describe('ptyController', () => {
 
     expect(result.success).toBe(true);
     expect(stopSession).toHaveBeenCalledWith('conv-1');
-    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-1', 'task-1');
+    expect(mocks.getTask).toHaveBeenCalledWith('proj-1', 'task-1');
     expect(mocks.resetToIdle).toHaveBeenCalledWith({
       conversationId: 'conv-1',
       taskId: 'task-1',
@@ -126,7 +124,7 @@ describe('ptyController', () => {
   it('reports success when status reset fails after stopping a conversation PTY', async () => {
     const stopSession = vi.fn().mockResolvedValue(undefined);
     const sessionId = 'proj-1:task-1:conv-1';
-    mocks.getTaskForProject.mockReturnValue({ conversations: { stopSession } });
+    mocks.getTask.mockReturnValue({ conversations: { stopSession } });
     mocks.resetToIdle.mockRejectedValueOnce(new Error('reset failed'));
     ptySessionRegistry.register(sessionId, makePty(), {
       metadata: { providerId: 'amp', isRemote: false },
@@ -135,7 +133,7 @@ describe('ptyController', () => {
     const result = await ptyController.stopSession(sessionId);
 
     expect(result.success).toBe(true);
-    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-1', 'task-1');
+    expect(mocks.getTask).toHaveBeenCalledWith('proj-1', 'task-1');
     expect(stopSession).toHaveBeenCalledWith('conv-1');
     expect(mocks.resetToIdle).toHaveBeenCalledWith({
       conversationId: 'conv-1',
@@ -146,19 +144,16 @@ describe('ptyController', () => {
   });
 
   it('does not raw-kill a conversation PTY when its project provider is unavailable', async () => {
-    const wrongProjectStopSession = vi.fn();
     const pty = makePty();
     const sessionId = 'proj-2:task-1:conv-1';
-    mocks.getTask.mockReturnValue({ conversations: { stopSession: wrongProjectStopSession } });
-    mocks.getTaskForProject.mockReturnValue(undefined);
+    mocks.getTask.mockReturnValue(undefined);
     ptySessionRegistry.register(sessionId, pty, {
       metadata: { providerId: 'amp', isRemote: false },
     });
 
     const result = await ptyController.stopSession(sessionId);
 
-    expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-2', 'task-1');
-    expect(wrongProjectStopSession).not.toHaveBeenCalled();
+    expect(mocks.getTask).toHaveBeenCalledWith('proj-2', 'task-1');
     expect(result).toEqual({
       success: false,
       error: {
@@ -197,6 +192,8 @@ describe('ptyController', () => {
         remotePaths: ['/remote/worktree/.emdash/uploads/upload-id-emdash-drop-abc-image.png'],
       },
     });
+    expect(mocks.getTask).toHaveBeenCalledWith('proj-1', 'task-1');
+    expect(mocks.getWorkspaceId).toHaveBeenCalledWith('proj-1', 'task-1');
     expect(mkdir).toHaveBeenCalledWith('/remote/worktree/.emdash/uploads', { recursive: true });
     expect(writeBytes).toHaveBeenCalledWith(
       '/remote/worktree/.emdash/uploads/upload-id-emdash-drop-abc-image.png',

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -120,6 +120,27 @@ describe('ptyController', () => {
     ptySessionRegistry.unregister(sessionId);
   });
 
+  it('reports success when status reset fails after stopping a conversation PTY', async () => {
+    const stopSession = vi.fn().mockResolvedValue(undefined);
+    const sessionId = 'proj-1:task-1:conv-1';
+    mocks.getTask.mockReturnValue({ conversations: { stopSession } });
+    mocks.resetToIdle.mockRejectedValueOnce(new Error('reset failed'));
+    ptySessionRegistry.register(sessionId, makePty(), {
+      metadata: { providerId: 'amp', isRemote: false },
+    });
+
+    const result = await ptyController.stopSession(sessionId);
+
+    expect(result.success).toBe(true);
+    expect(stopSession).toHaveBeenCalledWith('conv-1');
+    expect(mocks.resetToIdle).toHaveBeenCalledWith({
+      conversationId: 'conv-1',
+      taskId: 'task-1',
+    });
+
+    ptySessionRegistry.unregister(sessionId);
+  });
+
   it('uploads remote attachments into the git-ignored .emdash dir, not the worktree root (#2680)', async () => {
     const bytes = Buffer.from('content');
     const mkdir = vi.fn().mockResolvedValue({ success: true });

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   getTask: vi.fn(),
   getWorkspace: vi.fn(),
   getWorkspaceId: vi.fn(),
+  resetToIdle: vi.fn(),
   randomUUID: vi.fn(),
   readFile: vi.fn(),
 }));
@@ -30,6 +31,12 @@ vi.mock('./persist-dropped-blob', () => ({
 
 vi.mock('@main/db/client', () => ({
   db: {},
+}));
+
+vi.mock('@main/core/agent-hooks/agent-hook-service', () => ({
+  agentHookService: {
+    resetToIdle: mocks.resetToIdle,
+  },
 }));
 
 vi.mock('@main/lib/events', () => ({
@@ -88,6 +95,26 @@ describe('ptyController', () => {
       taskId: 'task-1',
       conversationId: 'conv-1',
       providerId: 'amp',
+    });
+
+    ptySessionRegistry.unregister(sessionId);
+  });
+
+  it('resets agent status after intentionally stopping a conversation PTY', async () => {
+    const stopSession = vi.fn().mockResolvedValue(undefined);
+    const sessionId = 'proj-1:task-1:conv-1';
+    mocks.getTask.mockReturnValue({ conversations: { stopSession } });
+    ptySessionRegistry.register(sessionId, makePty(), {
+      metadata: { providerId: 'amp', isRemote: false },
+    });
+
+    const result = await ptyController.stopSession(sessionId);
+
+    expect(result.success).toBe(true);
+    expect(stopSession).toHaveBeenCalledWith('conv-1');
+    expect(mocks.resetToIdle).toHaveBeenCalledWith({
+      conversationId: 'conv-1',
+      taskId: 'task-1',
     });
 
     ptySessionRegistry.unregister(sessionId);

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -145,7 +145,7 @@ describe('ptyController', () => {
     ptySessionRegistry.unregister(sessionId);
   });
 
-  it('falls back to killing the PTY when the task does not belong to the parsed project', async () => {
+  it('does not raw-kill a conversation PTY when its project provider is unavailable', async () => {
     const wrongProjectStopSession = vi.fn();
     const pty = makePty();
     const sessionId = 'proj-2:task-1:conv-1';
@@ -157,11 +157,20 @@ describe('ptyController', () => {
 
     const result = await ptyController.stopSession(sessionId);
 
-    expect(result.success).toBe(true);
     expect(mocks.getTaskForProject).toHaveBeenCalledWith('proj-2', 'task-1');
     expect(wrongProjectStopSession).not.toHaveBeenCalled();
-    expect(pty.kill).toHaveBeenCalledOnce();
-    expect(ptySessionRegistry.get(sessionId)).toBeUndefined();
+    expect(result).toEqual({
+      success: false,
+      error: {
+        type: 'stop_failed',
+        message: 'Conversation provider is unavailable',
+      },
+    });
+    expect(pty.kill).not.toHaveBeenCalled();
+    expect(ptySessionRegistry.get(sessionId)).toBe(pty);
+    expect(mocks.resetToIdle).not.toHaveBeenCalled();
+
+    ptySessionRegistry.unregister(sessionId);
   });
 
   it('uploads remote attachments into the git-ignored .emdash dir, not the worktree root (#2680)', async () => {

--- a/apps/emdash-desktop/src/main/core/pty/controller.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.test.ts
@@ -133,12 +133,6 @@ describe('ptyController', () => {
     const result = await ptyController.stopSession(sessionId);
 
     expect(result.success).toBe(true);
-    expect(mocks.getTask).toHaveBeenCalledWith('proj-1', 'task-1');
-    expect(stopSession).toHaveBeenCalledWith('conv-1');
-    expect(mocks.resetToIdle).toHaveBeenCalledWith({
-      conversationId: 'conv-1',
-      taskId: 'task-1',
-    });
 
     ptySessionRegistry.unregister(sessionId);
   });

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -109,7 +109,6 @@ export const ptyController = createRPCController({
       try {
         if (isConversation) {
           await task.conversations.stopSession(leafId);
-          await agentHookService.resetToIdle({ conversationId: leafId, taskId: scopeId });
         } else {
           await task.terminals.killTerminal(leafId);
         }
@@ -119,6 +118,17 @@ export const ptyController = createRPCController({
           error: String(e),
         });
         return err({ type: 'stop_failed' as const, message: String((e as Error)?.message || e) });
+      }
+
+      if (isConversation) {
+        try {
+          await agentHookService.resetToIdle({ conversationId: leafId, taskId: scopeId });
+        } catch (e) {
+          log.warn('ptyController.stopSession: error resetting conversation status', {
+            sessionId,
+            error: String(e),
+          });
+        }
       }
       return ok();
     }

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -2,6 +2,7 @@ import { randomUUID } from 'node:crypto';
 import { readFile } from 'node:fs/promises';
 import { basename } from 'node:path';
 import { err, ok } from '@emdash/shared';
+import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
 import { conversationEvents } from '@main/core/conversations/conversation-events';
 import { joinMachinePath } from '@main/core/files/path-utils';
 import { log } from '@main/lib/logger';
@@ -108,6 +109,7 @@ export const ptyController = createRPCController({
       try {
         if (isConversation) {
           await task.conversations.stopSession(leafId);
+          await agentHookService.resetToIdle({ conversationId: leafId, taskId: scopeId });
         } else {
           await task.terminals.killTerminal(leafId);
         }

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -98,12 +98,11 @@ export const ptyController = createRPCController({
   stopSession: async (sessionId: string) => {
     const parsed = parsePtySessionId(sessionId);
     if (!parsed) return err({ type: 'invalid_session' as const });
-    const { scopeId, leafId } = parsed;
+    const { projectId, scopeId, leafId } = parsed;
 
-    // Agents and terminals are scoped by task id, so the task lookup resolves
-    // the owning provider. Conversation PTYs carry a providerId in their
-    // registry metadata; plain terminals do not — that distinguishes the two.
-    const task = taskSessionManager.getTask(scopeId);
+    // Conversation PTYs carry a providerId in their registry metadata; plain
+    // terminals do not — that distinguishes the two.
+    const task = taskSessionManager.getTaskForProject(projectId, scopeId);
     if (task) {
       const isConversation = ptySessionRegistry.getMetadata(sessionId)?.providerId !== undefined;
       try {

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -103,7 +103,7 @@ export const ptyController = createRPCController({
     // Conversation PTYs carry a providerId in their registry metadata; plain
     // terminals do not — that distinguishes the two.
     const isConversation = ptySessionRegistry.getMetadata(sessionId)?.providerId !== undefined;
-    const task = taskSessionManager.getTaskForProject(projectId, scopeId);
+    const task = taskSessionManager.getTask(projectId, scopeId);
     if (task) {
       try {
         if (isConversation) {
@@ -168,12 +168,12 @@ export const ptyController = createRPCController({
       if (!parsed) {
         return err({ type: 'invalid_session' as const });
       }
-      const { scopeId } = parsed;
+      const { projectId, scopeId } = parsed;
 
-      const taskProvider = taskSessionManager.getTask(scopeId);
+      const taskProvider = taskSessionManager.getTask(projectId, scopeId);
       if (!taskProvider) return err({ type: 'not_ssh' as const });
 
-      const workspaceId = taskSessionManager.getWorkspaceId(scopeId) ?? '';
+      const workspaceId = taskSessionManager.getWorkspaceId(projectId, scopeId) ?? '';
       const workspace = workspaceRegistry.get(workspaceId);
       if (!workspace) return err({ type: 'not_ssh' as const });
 

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -102,9 +102,9 @@ export const ptyController = createRPCController({
 
     // Conversation PTYs carry a providerId in their registry metadata; plain
     // terminals do not — that distinguishes the two.
+    const isConversation = ptySessionRegistry.getMetadata(sessionId)?.providerId !== undefined;
     const task = taskSessionManager.getTaskForProject(projectId, scopeId);
     if (task) {
-      const isConversation = ptySessionRegistry.getMetadata(sessionId)?.providerId !== undefined;
       try {
         if (isConversation) {
           await task.conversations.stopSession(leafId);
@@ -130,6 +130,14 @@ export const ptyController = createRPCController({
         }
       }
       return ok();
+    }
+
+    if (isConversation) {
+      log.warn('ptyController.stopSession: conversation provider unavailable', { sessionId });
+      return err({
+        type: 'stop_failed' as const,
+        message: 'Conversation provider is unavailable',
+      });
     }
 
     // Lifecycle scripts are scoped by workspace id (no task match) and never

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -22,6 +22,17 @@ void cleanupExpiredDroppedBlobs().catch((error) => {
   log.warn('pty:cleanupExpiredDroppedBlobs failed', { error });
 });
 
+async function resetConversationToIdle(sessionId: string, conversationId: string, taskId: string) {
+  try {
+    await agentHookService.resetToIdle({ conversationId, taskId });
+  } catch (e) {
+    log.warn('ptyController.stopSession: error resetting conversation status', {
+      sessionId,
+      error: String(e),
+    });
+  }
+}
+
 export const ptyController = createRPCController({
   /** Send raw input data to a PTY session. */
   sendInput: (sessionId: string, data: string) => {
@@ -100,8 +111,7 @@ export const ptyController = createRPCController({
     if (!parsed) return err({ type: 'invalid_session' as const });
     const { projectId, scopeId, leafId } = parsed;
 
-    // Conversation PTYs carry a providerId in their registry metadata; plain
-    // terminals do not — that distinguishes the two.
+    // The stop handler remains available while a conversation is between PTY respawns.
     const isConversation =
       ptySessionRegistry.getMetadata(sessionId)?.providerId !== undefined ||
       ptySessionRegistry.hasStopHandler(sessionId);
@@ -122,14 +132,7 @@ export const ptyController = createRPCController({
       }
 
       if (isConversation) {
-        try {
-          await agentHookService.resetToIdle({ conversationId: leafId, taskId: scopeId });
-        } catch (e) {
-          log.warn('ptyController.stopSession: error resetting conversation status', {
-            sessionId,
-            error: String(e),
-          });
-        }
+        await resetConversationToIdle(sessionId, leafId, scopeId);
       }
       return ok();
     }
@@ -152,14 +155,7 @@ export const ptyController = createRPCController({
         return err({ type: 'stop_failed' as const, message: String((e as Error)?.message || e) });
       }
 
-      try {
-        await agentHookService.resetToIdle({ conversationId: leafId, taskId: scopeId });
-      } catch (e) {
-        log.warn('ptyController.stopSession: error resetting orphaned conversation status', {
-          sessionId,
-          error: String(e),
-        });
-      }
+      await resetConversationToIdle(sessionId, leafId, scopeId);
       return ok();
     }
 

--- a/apps/emdash-desktop/src/main/core/pty/controller.ts
+++ b/apps/emdash-desktop/src/main/core/pty/controller.ts
@@ -102,7 +102,9 @@ export const ptyController = createRPCController({
 
     // Conversation PTYs carry a providerId in their registry metadata; plain
     // terminals do not — that distinguishes the two.
-    const isConversation = ptySessionRegistry.getMetadata(sessionId)?.providerId !== undefined;
+    const isConversation =
+      ptySessionRegistry.getMetadata(sessionId)?.providerId !== undefined ||
+      ptySessionRegistry.hasStopHandler(sessionId);
     const task = taskSessionManager.getTask(projectId, scopeId);
     if (task) {
       try {
@@ -133,11 +135,32 @@ export const ptyController = createRPCController({
     }
 
     if (isConversation) {
-      log.warn('ptyController.stopSession: conversation provider unavailable', { sessionId });
-      return err({
-        type: 'stop_failed' as const,
-        message: 'Conversation provider is unavailable',
-      });
+      try {
+        const stopped = await ptySessionRegistry.stop(sessionId);
+        if (!stopped) {
+          log.warn('ptyController.stopSession: conversation provider unavailable', { sessionId });
+          return err({
+            type: 'stop_failed' as const,
+            message: 'Conversation provider is unavailable',
+          });
+        }
+      } catch (e) {
+        log.warn('ptyController.stopSession: error stopping orphaned conversation PTY', {
+          sessionId,
+          error: String(e),
+        });
+        return err({ type: 'stop_failed' as const, message: String((e as Error)?.message || e) });
+      }
+
+      try {
+        await agentHookService.resetToIdle({ conversationId: leafId, taskId: scopeId });
+      } catch (e) {
+        log.warn('ptyController.stopSession: error resetting orphaned conversation status', {
+          sessionId,
+          error: String(e),
+        });
+      }
+      return ok();
     }
 
     // Lifecycle scripts are scoped by workspace id (no task match) and never

--- a/apps/emdash-desktop/src/main/core/pty/pty-session-registry.test.ts
+++ b/apps/emdash-desktop/src/main/core/pty/pty-session-registry.test.ts
@@ -126,6 +126,40 @@ describe('PtySessionRegistry', () => {
     expect(events.emit).not.toHaveBeenCalledWith(ptyExitChannel, exitInfo, 'session-1');
   });
 
+  it('can stop a session while its provider is waiting to respawn it', async () => {
+    const registry = new PtySessionRegistry();
+    const pty = fakePty();
+    const stop = vi.fn().mockResolvedValue(undefined);
+
+    registry.register('session-1', pty, { stop });
+    registry.unregister('session-1', { pty, preserveStopHandler: true });
+
+    expect(registry.hasStopHandler('session-1')).toBe(true);
+    expect(await registry.stop('session-1')).toBe(true);
+    expect(stop).toHaveBeenCalledOnce();
+  });
+
+  it('does not let a stale provider unregister a replacement provider', async () => {
+    const registry = new PtySessionRegistry();
+    const firstOwner = {};
+    const secondOwner = {};
+    const secondPty = fakePty();
+    const secondStop = vi.fn().mockResolvedValue(undefined);
+
+    registry.register('session-1', fakePty(), {
+      owner: firstOwner,
+      stop: vi.fn().mockResolvedValue(undefined),
+    });
+    registry.unregister('session-1', { owner: firstOwner, preserveStopHandler: true });
+    registry.register('session-1', secondPty, { owner: secondOwner, stop: secondStop });
+
+    registry.unregister('session-1', { owner: firstOwner });
+
+    expect(registry.get('session-1')).toBe(secondPty);
+    expect(await registry.stop('session-1')).toBe(true);
+    expect(secondStop).toHaveBeenCalledOnce();
+  });
+
   it('records resize dimensions before forwarding to the current PTY', () => {
     const registry = new PtySessionRegistry();
     const pty = fakePty();

--- a/apps/emdash-desktop/src/main/core/pty/pty-session-registry.ts
+++ b/apps/emdash-desktop/src/main/core/pty/pty-session-registry.ts
@@ -16,6 +16,8 @@ const RING_BUFFER_CAP = 64 * 1024; // 64 KB per session
 export class PtySessionRegistry {
   private ptyMap: Map<string, Pty> = new Map();
   private ptyInputSubscriptions: Map<string, () => void> = new Map();
+  private stopHandlers: Map<string, () => Promise<void>> = new Map();
+  private sessionOwners: Map<string, object> = new Map();
   private ringBuffers: Map<string, string> = new Map();
   private activeConsumers: Set<string> = new Set();
   private metadata: Map<string, PtySessionMetadata> = new Map();
@@ -25,7 +27,12 @@ export class PtySessionRegistry {
   register(
     sessionId: string,
     pty: Pty,
-    options?: { preserveBufferOnExit?: boolean; metadata?: PtySessionMetadata }
+    options?: {
+      preserveBufferOnExit?: boolean;
+      metadata?: PtySessionMetadata;
+      stop?: () => Promise<void>;
+      owner?: object;
+    }
   ): void {
     const preserveBufferOnExit = options?.preserveBufferOnExit ?? false;
 
@@ -36,7 +43,11 @@ export class PtySessionRegistry {
     this.ringBuffers.delete(sessionId);
     this.activeConsumers.delete(sessionId);
     this.metadata.delete(sessionId);
+    this.stopHandlers.delete(sessionId);
+    this.sessionOwners.delete(sessionId);
     if (options?.metadata) this.metadata.set(sessionId, options.metadata);
+    if (options?.stop) this.stopHandlers.set(sessionId, options.stop);
+    if (options?.owner) this.sessionOwners.set(sessionId, options.owner);
 
     this.ptyMap.set(sessionId, pty);
 
@@ -85,6 +96,8 @@ export class PtySessionRegistry {
         this.ptyInputSubscriptions.get(sessionId)?.();
         this.ptyInputSubscriptions.delete(sessionId);
         this.pendingFlushes.delete(sessionId);
+        this.stopHandlers.delete(sessionId);
+        this.sessionOwners.delete(sessionId);
         this.lastSizes.delete(sessionId);
       } else {
         this.unregister(sessionId);
@@ -103,8 +116,17 @@ export class PtySessionRegistry {
     events.emit(ptyStartedChannel, { id: sessionId });
   }
 
-  unregister(sessionId: string, options: { pty?: Pty; exitInfo?: PtyExitInfo } = {}): void {
+  unregister(
+    sessionId: string,
+    options: {
+      pty?: Pty;
+      exitInfo?: PtyExitInfo;
+      preserveStopHandler?: boolean;
+      owner?: object;
+    } = {}
+  ): void {
     if (options.pty !== undefined && this.ptyMap.get(sessionId) !== options.pty) return;
+    if (options.owner !== undefined && this.sessionOwners.get(sessionId) !== options.owner) return;
     this.pendingFlushes.get(sessionId)?.();
     if (options.exitInfo !== undefined) {
       events.emit(ptyExitChannel, options.exitInfo, sessionId);
@@ -116,6 +138,10 @@ export class PtySessionRegistry {
     this.ringBuffers.delete(sessionId);
     this.activeConsumers.delete(sessionId);
     this.metadata.delete(sessionId);
+    if (!options.preserveStopHandler) {
+      this.stopHandlers.delete(sessionId);
+      this.sessionOwners.delete(sessionId);
+    }
     this.lastSizes.delete(sessionId);
   }
 
@@ -145,6 +171,17 @@ export class PtySessionRegistry {
 
   getMetadata(sessionId: string): PtySessionMetadata | undefined {
     return this.metadata.get(sessionId);
+  }
+
+  hasStopHandler(sessionId: string): boolean {
+    return this.stopHandlers.has(sessionId);
+  }
+
+  async stop(sessionId: string): Promise<boolean> {
+    const stop = this.stopHandlers.get(sessionId);
+    if (!stop) return false;
+    await stop();
+    return true;
   }
 
   resize(sessionId: string, cols: number, rows: number): boolean {

--- a/apps/emdash-desktop/src/main/core/storage/operations/list-task-storage-usage.ts
+++ b/apps/emdash-desktop/src/main/core/storage/operations/list-task-storage-usage.ts
@@ -49,7 +49,7 @@ async function measureRow(row: TaskStorageRow): Promise<TaskStorageUsage> {
   });
   const worktree = isWorktreeRow(row);
   const localWorkspace = isLocalTaskWorkspace(row);
-  const isActive = !!taskSessionManager.getTask(row.taskId);
+  const isActive = !!taskSessionManager.getTask(row.projectId, row.taskId);
   const canDelete =
     row.projectType === 'local' && row.workspaceKind !== 'byoi' && (!worktree || localWorkspace);
 

--- a/apps/emdash-desktop/src/main/core/tasks/controller.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/controller.ts
@@ -49,8 +49,8 @@ export const taskController = createRPCController({
   async getProjectWorkspaces(projectId: string) {
     return getProjectWorkspaces(projectId);
   },
-  async teardownTask(_projectId: string, taskId: string) {
-    return taskService.teardown(taskId, 'terminate');
+  async teardownTask(projectId: string, taskId: string) {
+    return taskService.teardown(projectId, taskId, 'terminate');
   },
   async provisionWorkspace(taskId: string) {
     return taskService.provisionWorkspace(taskId);

--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.test.ts
@@ -65,7 +65,7 @@ describe('archiveTask', () => {
     expect(updatePayload).not.toHaveProperty('status');
     expect(updatePayload).not.toHaveProperty('statusChangedAt');
 
-    expect(mocks.teardownTask).toHaveBeenCalledWith('task-1', 'archive');
+    expect(mocks.teardownTask).toHaveBeenCalledWith('project-1', 'task-1', 'archive');
     expect(mocks.capture).toHaveBeenCalledWith('task_archived', {
       project_id: 'project-1',
       task_id: 'task-1',

--- a/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/archiveTask.ts
@@ -21,10 +21,12 @@ export async function archiveTask(projectId: string, taskId: string): Promise<vo
   // 'archive' reaps the tmux session + agent process but keeps the worktree and the
   // persisted session id, so Restore can resume. Plain 'detach' would leak the tmux
   // session indefinitely (#2689).
-  const teardownResult = await taskSessionManager.teardownTask(taskId, 'archive').catch((e) => {
-    log.warn('archiveTask: teardown failed', { taskId, error: String(e) });
-    return null;
-  });
+  const teardownResult = await taskSessionManager
+    .teardownTask(projectId, taskId, 'archive')
+    .catch((e) => {
+      log.warn('archiveTask: teardown failed', { taskId, error: String(e) });
+      return null;
+    });
 
   if (teardownResult && !teardownResult.success) {
     log.warn('archiveTask: teardown failed', { taskId, error: teardownResult.error.message });

--- a/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/operations/deleteTask.ts
@@ -29,10 +29,12 @@ export async function deleteTask(
   const project = projectManager.getProject(projectId);
 
   if (project) {
-    const teardownResult = await taskSessionManager.teardownTask(taskId, 'terminate').catch((e) => {
-      log.warn('deleteTask: teardown failed', { taskId, error: String(e) });
-      return null;
-    });
+    const teardownResult = await taskSessionManager
+      .teardownTask(projectId, taskId, 'terminate')
+      .catch((e) => {
+        log.warn('deleteTask: teardown failed', { taskId, error: String(e) });
+        return null;
+      });
 
     if (teardownResult && !teardownResult.success) {
       log.warn('deleteTask: teardown failed', { taskId, error: teardownResult.error.message });

--- a/apps/emdash-desktop/src/main/core/tasks/task-service.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-service.ts
@@ -39,7 +39,7 @@ import { setTaskPinned } from './operations/setTaskPinned';
 import { updateLinkedIssue } from './operations/updateLinkedIssue';
 import { updateTaskStatus } from './operations/updateTaskStatus';
 import type { TeardownTaskError } from './provision-task-error';
-import { taskSessionManager } from './task-session-manager';
+import { taskSessionManager, type TaskTeardownMode } from './task-session-manager';
 import { mapTaskRowToTask } from './utils/utils';
 
 type ProvisionResult = ProvisionTaskResult & { sshConnectionId?: string };
@@ -92,9 +92,9 @@ export class TaskService implements Hookable<TaskLifecycleHooks> {
     const { projectId } = row;
 
     // Idempotency: task is already live — return current state.
-    const existingTask = taskSessionManager.getTask(taskId);
+    const existingTask = taskSessionManager.getTask(projectId, taskId);
     if (existingTask) {
-      const pd = taskSessionManager.getPersistData(taskId);
+      const pd = taskSessionManager.getPersistData(projectId, taskId);
       const wsId = pd?.workspaceId ?? '';
       const provisionResult: ProvisionResult = {
         path: workspaceRegistry.get(wsId)?.path ?? '',
@@ -159,10 +159,11 @@ export class TaskService implements Hookable<TaskLifecycleHooks> {
   }
 
   async teardown(
+    projectId: string,
     taskId: string,
-    mode: Parameters<typeof taskSessionManager.teardownTask>[1] = 'terminate'
+    mode: TaskTeardownMode = 'terminate'
   ): Promise<Result<void, TeardownTaskError>> {
-    return taskSessionManager.teardownTask(taskId, mode);
+    return taskSessionManager.teardownTask(projectId, taskId, mode);
   }
 
   async getDeletePreflight(projectId: string, taskIds: string[]) {

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { IExecutionContext } from '@main/core/execution-context/types';
+import type { WorkspaceBootstrapResult } from '@main/core/workspaces/workspace-bootstrap-service';
 import type { TaskProvider } from '../projects/project-provider';
-import { executeTeardown } from './task-session-manager';
+import { executeTeardown, TaskSessionManager } from './task-session-manager';
 
 const teardown = vi.fn();
 
@@ -21,6 +23,13 @@ function makeTask() {
   const terminals = { detachAll: vi.fn(), destroyAll: vi.fn() };
   const task = { conversations, terminals } as unknown as TaskProvider;
   return { task, conversations, terminals };
+}
+
+function makeBootstrapResult(taskProvider: TaskProvider, workspaceId: string) {
+  return {
+    taskProvider,
+    workspaceId,
+  } as WorkspaceBootstrapResult;
 }
 
 describe('executeTeardown', () => {
@@ -62,5 +71,51 @@ describe('executeTeardown', () => {
     expect(terminals.detachAll).not.toHaveBeenCalled();
     // crucially NOT 'terminate', which would run onDestroy and remove the worktree.
     expect(teardown).toHaveBeenCalledWith('workspace-1', 'detach');
+  });
+});
+
+describe('TaskSessionManager', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('keeps identical task ids in different projects independent', async () => {
+    const manager = new TaskSessionManager();
+    const first = makeTask();
+    const second = makeTask();
+    const tornDown: Array<{ projectId: string; taskId: string; workspaceId: string }> = [];
+    manager.hooks.on('task:torn-down', (info) => tornDown.push(info));
+
+    await manager.registerTask(
+      'shared-task',
+      makeBootstrapResult(first.task, 'workspace-1'),
+      'project-1',
+      {} as IExecutionContext
+    );
+    await manager.registerTask(
+      'shared-task',
+      makeBootstrapResult(second.task, 'workspace-2'),
+      'project-2',
+      {} as IExecutionContext
+    );
+
+    expect(manager.getTask('project-1', 'shared-task')).toBe(first.task);
+    expect(manager.getTask('project-2', 'shared-task')).toBe(second.task);
+    expect(manager.getWorkspaceId('project-1', 'shared-task')).toBe('workspace-1');
+    expect(manager.getWorkspaceId('project-2', 'shared-task')).toBe('workspace-2');
+
+    await manager.teardownTask('project-1', 'shared-task');
+
+    expect(first.conversations.destroyAll).toHaveBeenCalledOnce();
+    expect(first.terminals.destroyAll).toHaveBeenCalledOnce();
+    expect(second.conversations.destroyAll).not.toHaveBeenCalled();
+    expect(second.terminals.destroyAll).not.toHaveBeenCalled();
+    expect(manager.getTask('project-1', 'shared-task')).toBeUndefined();
+    expect(manager.getTask('project-2', 'shared-task')).toBe(second.task);
+    expect(tornDown).toEqual([
+      { projectId: 'project-1', taskId: 'shared-task', workspaceId: 'workspace-1' },
+    ]);
+
+    await manager.teardownTask('project-2', 'shared-task');
   });
 });

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.test.ts
@@ -84,7 +84,9 @@ describe('TaskSessionManager', () => {
     const first = makeTask();
     const second = makeTask();
     const tornDown: Array<{ projectId: string; taskId: string; workspaceId: string }> = [];
-    manager.hooks.on('task:torn-down', (info) => tornDown.push(info));
+    manager.hooks.on('task:torn-down', (info) => {
+      tornDown.push(info);
+    });
 
     await manager.registerTask(
       'shared-task',

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
@@ -31,7 +31,15 @@ export type WorkspaceHint = {
   path?: string;
 };
 
-type StoredTask = ProvisionResult & { projectId: string; ctx: IExecutionContext };
+type StoredTask = ProvisionResult & {
+  projectId: string;
+  taskId: string;
+  ctx: IExecutionContext;
+};
+
+function taskLifecycleKey(projectId: string, taskId: string) {
+  return JSON.stringify([projectId, taskId]);
+}
 
 export type TaskManagerHooks = {
   'task:provisioned': (info: {
@@ -96,17 +104,17 @@ async function cleanupDetachedSessions(
   );
 }
 
-class TaskSessionManager {
+export class TaskSessionManager {
   private readonly _hooks = new HookCore<TaskManagerHooks>((name, e) =>
     log.error(`TaskManager: ${String(name)} hook error`, e)
   );
   private readonly _lifecycle = new LifecycleMap<StoredTask, ProvisionTaskError, TeardownTaskError>(
     {
-      postTeardown: (taskId, stored) => {
-        this._tasksByProject.get(stored.projectId)?.delete(taskId);
+      postTeardown: (_key, stored) => {
+        this._tasksByProject.get(stored.projectId)?.delete(stored.taskId);
         this._hooks.callHookBackground('task:torn-down', {
           projectId: stored.projectId,
-          taskId,
+          taskId: stored.taskId,
           workspaceId: stored.persistData.workspaceId,
         });
       },
@@ -136,11 +144,12 @@ class TaskSessionManager {
         workspaceProviderData: result.workspaceProviderData as WorkspaceProviderData | undefined,
       },
       projectId,
+      taskId,
       ctx,
     };
 
     // Use provision() for deduplication: if already active, returns existing immediately.
-    await this._lifecycle.provision(taskId, async () => ok(stored));
+    await this._lifecycle.provision(taskLifecycleKey(projectId, taskId), async () => ok(stored));
 
     const byProject = this._tasksByProject.get(projectId) ?? new Set<string>();
     byProject.add(taskId);
@@ -156,12 +165,13 @@ class TaskSessionManager {
   }
 
   async teardownTask(
+    projectId: string,
     taskId: string,
     mode: TaskTeardownMode = 'terminate'
   ): Promise<Result<void, TeardownTaskError>> {
     const result = this._lifecycle.teardown(
-      taskId,
-      async ({ taskProvider, persistData, projectId, ctx }) => {
+      taskLifecycleKey(projectId, taskId),
+      async ({ taskProvider, persistData, ctx }) => {
         try {
           await withTimeout(
             executeTeardown(taskProvider, persistData.workspaceId, mode),
@@ -191,7 +201,7 @@ class TaskSessionManager {
       // workspaceRegistry.teardownAllForProject to handle workspace teardown.
       await Promise.all(
         taskIds.flatMap((id) => {
-          const stored = this._lifecycle.get(id);
+          const stored = this._lifecycle.get(taskLifecycleKey(projectId, id));
           if (!stored) return [];
           return [
             stored.taskProvider.conversations.detachAll(),
@@ -202,40 +212,39 @@ class TaskSessionManager {
       // Remove entries from lifecycle maps without running workspace teardown.
       this._tasksByProject.delete(projectId);
       await Promise.all(
-        taskIds.map((id) => this._lifecycle.teardown(id, async () => ok()) ?? Promise.resolve(ok()))
+        taskIds.map(
+          (id) =>
+            this._lifecycle.teardown(taskLifecycleKey(projectId, id), async () => ok()) ??
+            Promise.resolve(ok())
+        )
       );
     } else {
       // teardownTask handles _tasksByProject cleanup in onFinally.
-      await Promise.all(taskIds.map((id) => this.teardownTask(id, 'terminate')));
+      await Promise.all(taskIds.map((id) => this.teardownTask(projectId, id, 'terminate')));
     }
   }
 
-  getTask(taskId: string): TaskProvider | undefined {
-    return this._lifecycle.get(taskId)?.taskProvider;
+  getTask(projectId: string, taskId: string): TaskProvider | undefined {
+    return this._lifecycle.get(taskLifecycleKey(projectId, taskId))?.taskProvider;
   }
 
-  getTaskForProject(projectId: string, taskId: string): TaskProvider | undefined {
-    const stored = this._lifecycle.get(taskId);
-    return stored?.projectId === projectId ? stored.taskProvider : undefined;
+  getWorkspaceId(projectId: string, taskId: string): string | undefined {
+    return this._lifecycle.get(taskLifecycleKey(projectId, taskId))?.persistData.workspaceId;
   }
 
-  getWorkspaceId(taskId: string): string | undefined {
-    return this._lifecycle.get(taskId)?.persistData.workspaceId;
+  getPersistData(projectId: string, taskId: string): ProvisionResult['persistData'] | undefined {
+    return this._lifecycle.get(taskLifecycleKey(projectId, taskId))?.persistData;
   }
 
-  getPersistData(taskId: string): ProvisionResult['persistData'] | undefined {
-    return this._lifecycle.get(taskId)?.persistData;
-  }
-
-  getBootstrapStatus(taskId: string): TaskBootstrapStatus {
-    const s = this._lifecycle.bootstrapStatus(taskId);
+  getBootstrapStatus(projectId: string, taskId: string): TaskBootstrapStatus {
+    const s = this._lifecycle.bootstrapStatus(taskLifecycleKey(projectId, taskId));
     if (s.status === 'error')
       return { status: 'error', message: formatProvisionTaskError(s.error) };
     return s;
   }
 
-  getTeardownStatus(taskId: string): TaskBootstrapStatus {
-    const s = this._lifecycle.teardownStatus(taskId);
+  getTeardownStatus(projectId: string, taskId: string): TaskBootstrapStatus {
+    const s = this._lifecycle.teardownStatus(taskLifecycleKey(projectId, taskId));
     if (s.status === 'error') return { status: 'error', message: formatTeardownTaskError(s.error) };
     return s;
   }

--- a/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
+++ b/apps/emdash-desktop/src/main/core/tasks/task-session-manager.ts
@@ -214,6 +214,11 @@ class TaskSessionManager {
     return this._lifecycle.get(taskId)?.taskProvider;
   }
 
+  getTaskForProject(projectId: string, taskId: string): TaskProvider | undefined {
+    const stored = this._lifecycle.get(taskId);
+    return stored?.projectId === projectId ? stored.taskProvider : undefined;
+  }
+
   getWorkspaceId(taskId: string): string | undefined {
     return this._lifecycle.get(taskId)?.persistData.workspaceId;
   }

--- a/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { isAutomationTaskRunning } from './automation-run-stop';
+import { isAutomationConversationRunning, isAutomationTaskRunning } from './automation-run-stop';
 
 describe('automation run stop availability', () => {
   it.each(['working', 'awaiting-input'] as const)(
@@ -15,4 +15,8 @@ describe('automation run stop availability', () => {
       expect(isAutomationTaskRunning(status)).toBe(false);
     }
   );
+
+  it('keeps an acknowledged awaiting-input conversation stoppable', () => {
+    expect(isAutomationConversationRunning({ status: 'awaiting-input', seen: true })).toBe(true);
+  });
 });

--- a/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { isAutomationTaskRunning } from './automation-run-stop';
+
+describe('automation run stop availability', () => {
+  it.each(['working', 'awaiting-input'] as const)(
+    'allows stopping a task whose agent is %s',
+    (status) => {
+      expect(isAutomationTaskRunning(status)).toBe(true);
+    }
+  );
+
+  it.each(['idle', 'completed', 'error', null] as const)(
+    'does not stop a task whose agent status is %s',
+    (status) => {
+      expect(isAutomationTaskRunning(status)).toBe(false);
+    }
+  );
+});

--- a/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.ts
@@ -1,0 +1,5 @@
+import type { AgentStatus } from '@shared/core/agents/agentEvents';
+
+export function isAutomationTaskRunning(status: AgentStatus | null) {
+  return status === 'working' || status === 'awaiting-input';
+}

--- a/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/automation-run-stop.ts
@@ -3,3 +3,10 @@ import type { AgentStatus } from '@shared/core/agents/agentEvents';
 export function isAutomationTaskRunning(status: AgentStatus | null) {
   return status === 'working' || status === 'awaiting-input';
 }
+
+export function isAutomationConversationRunning(conversation: {
+  status: AgentStatus;
+  seen: boolean;
+}) {
+  return isAutomationTaskRunning(conversation.status);
+}

--- a/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
@@ -40,7 +40,8 @@ export const AutomationRunRow = observer(function AutomationRunRow({
 
   const interactive = Boolean(taskId && task && !task.archivedAt);
   const agentStatus = taskStore ? taskAgentStatus(taskStore) : null;
-  const conversations = taskId ? getConversationsForTask(taskId)?.conversations.values() : null;
+  const conversations =
+    taskId && projectId ? getConversationsForTask(projectId, taskId)?.conversations.values() : null;
   const canStop = conversations
     ? Array.from(conversations).some(isAutomationConversationRunning)
     : false;

--- a/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
@@ -1,8 +1,9 @@
 import { Square } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { isAutomationTaskRunning } from '@renderer/features/automations/automation-run-stop';
+import { isAutomationConversationRunning } from '@renderer/features/automations/automation-run-stop';
 import { useAutomationRunActions } from '@renderer/features/automations/use-automation-run-actions';
 import {
+  getConversationsForTask,
   getRegisteredTaskData,
   getTaskStore,
   taskAgentStatus,
@@ -39,7 +40,10 @@ export const AutomationRunRow = observer(function AutomationRunRow({
 
   const interactive = Boolean(taskId && task && !task.archivedAt);
   const agentStatus = taskStore ? taskAgentStatus(taskStore) : null;
-  const canStop = isAutomationTaskRunning(agentStatus);
+  const conversations = taskId ? getConversationsForTask(taskId)?.conversations.values() : null;
+  const canStop = conversations
+    ? Array.from(conversations).some(isAutomationConversationRunning)
+    : false;
 
   const displayTime = run ? (run.startedAt ?? run.finishedAt) : null;
   const missedDeadline = run?.error?.code === 'deadline_exceeded';
@@ -70,6 +74,7 @@ export const AutomationRunRow = observer(function AutomationRunRow({
       onKeyDown={
         interactive
           ? (e) => {
+              if (e.target !== e.currentTarget) return;
               if (e.key !== 'Enter' && e.key !== ' ') return;
               e.preventDefault();
               handleOpenTask();

--- a/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
@@ -1,4 +1,6 @@
+import { Square } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
+import { isAutomationTaskRunning } from '@renderer/features/automations/automation-run-stop';
 import { useAutomationRunActions } from '@renderer/features/automations/use-automation-run-actions';
 import {
   getRegisteredTaskData,
@@ -6,6 +8,8 @@ import {
   taskAgentStatus,
 } from '@renderer/features/tasks/stores/task-selectors';
 import { useNavigate } from '@renderer/lib/layout/navigation-provider';
+import { Button } from '@renderer/lib/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
 import type { AutomationRun } from '@shared/core/automations/automation-run';
 import { useAutomationRun } from '../use-automations';
@@ -27,7 +31,7 @@ export const AutomationRunRow = observer(function AutomationRunRow({
   const { navigate } = useNavigate();
   const fetchedRun = useAutomationRun(automationId, runId);
   const run = runProp ?? fetchedRun;
-  const { projectId } = useAutomationRunActions(automationId);
+  const { projectId, stopTaskRun, stopPending } = useAutomationRunActions(automationId);
 
   const taskId = run ? run.taskId : null;
   const taskStore = taskId && projectId ? getTaskStore(projectId, taskId) : undefined;
@@ -35,6 +39,7 @@ export const AutomationRunRow = observer(function AutomationRunRow({
 
   const interactive = Boolean(taskId && task && !task.archivedAt);
   const agentStatus = taskStore ? taskAgentStatus(taskStore) : null;
+  const canStop = isAutomationTaskRunning(agentStatus);
 
   const displayTime = run ? (run.startedAt ?? run.finishedAt) : null;
   const missedDeadline = run?.error?.code === 'deadline_exceeded';
@@ -44,6 +49,11 @@ export const AutomationRunRow = observer(function AutomationRunRow({
   function handleOpenTask() {
     if (!taskId || !projectId || !interactive) return;
     navigate('task', { projectId, taskId });
+  }
+
+  function handleStop() {
+    if (!run || stopPending) return;
+    void stopTaskRun(run);
   }
 
   if (!run) return null;
@@ -76,7 +86,12 @@ export const AutomationRunRow = observer(function AutomationRunRow({
       aria-disabled={!interactive}
     >
       {taskStore ? (
-        <TaskDataLine task={taskStore} agentStatus={agentStatus} missedDeadline={missedDeadline} />
+        <TaskDataLine
+          task={taskStore}
+          agentStatus={agentStatus}
+          missedDeadline={missedDeadline}
+          hideTrailingOnRowInteraction={canStop}
+        />
       ) : (
         <TaskPlaceholder name={displayName} />
       )}
@@ -85,7 +100,35 @@ export const AutomationRunRow = observer(function AutomationRunRow({
         triggerKind={run.triggerKind}
         runStatus={run.status}
         error={run.error}
+        hideStatusOnRowInteraction={canStop}
       />
+      {canStop && (
+        <div className="pointer-events-none absolute inset-y-0 right-2 flex items-center opacity-0 transition-opacity group-focus-within:pointer-events-auto group-focus-within:opacity-100 group-hover:pointer-events-auto group-hover:opacity-100">
+          <Tooltip>
+            <TooltipTrigger
+              render={
+                <Button
+                  type="button"
+                  variant="outline"
+                  size="sm"
+                  className="hover:border-border-destructive hover:bg-background-destructive hover:text-foreground-destructive"
+                  aria-label="Stop task run"
+                  disabled={stopPending}
+                  onClick={(event) => {
+                    event.stopPropagation();
+                    handleStop();
+                  }}
+                  onPointerDown={(event) => event.stopPropagation()}
+                />
+              }
+            >
+              <Square className="size-3" />
+              Stop task
+            </TooltipTrigger>
+            <TooltipContent>Stop task run</TooltipContent>
+          </Tooltip>
+        </div>
+      )}
     </div>
   );
 });

--- a/apps/emdash-desktop/src/renderer/features/automations/components/RunMetaLine.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/RunMetaLine.tsx
@@ -1,4 +1,5 @@
 import { AbsoluteTime } from '@renderer/lib/ui/absolute-time';
+import { cn } from '@renderer/utils/utils';
 import type {
   AutomationRun,
   AutomationRunStatus,
@@ -12,9 +13,16 @@ export interface RunMetaLineProps {
   triggerKind: AutomationRunTriggerKind | null;
   runStatus: AutomationRunStatus | null;
   error: AutomationRun['error'];
+  hideStatusOnRowInteraction?: boolean;
 }
 
-export function RunMetaLine({ displayTime, triggerKind, runStatus, error }: RunMetaLineProps) {
+export function RunMetaLine({
+  displayTime,
+  triggerKind,
+  runStatus,
+  error,
+  hideStatusOnRowInteraction,
+}: RunMetaLineProps) {
   const triggerLabel = triggerKind ? formatRunTriggerKindLabel(triggerKind) : null;
 
   return (
@@ -32,7 +40,15 @@ export function RunMetaLine({ displayTime, triggerKind, runStatus, error }: RunM
           <span>—</span>
         )}
       </span>
-      <RunStatusBadge status={runStatus} error={error} />
+      <div
+        className={cn(
+          'shrink-0',
+          hideStatusOnRowInteraction &&
+            'transition-opacity group-focus-within:pointer-events-none group-focus-within:opacity-0 group-hover:pointer-events-none group-hover:opacity-0'
+        )}
+      >
+        <RunStatusBadge status={runStatus} error={error} />
+      </div>
     </div>
   );
 }

--- a/apps/emdash-desktop/src/renderer/features/automations/components/TaskDataLine.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/TaskDataLine.tsx
@@ -9,12 +9,14 @@ export interface TaskDataLineProps {
   task: TaskStore;
   agentStatus: AgentStatus | null;
   missedDeadline: boolean;
+  hideTrailingOnRowInteraction?: boolean;
 }
 
 export const TaskDataLine = observer(function TaskDataLine({
   task,
   agentStatus,
   missedDeadline,
+  hideTrailingOnRowInteraction,
 }: TaskDataLineProps) {
   return (
     <div className="flex h-6 min-w-0 items-center justify-between gap-2 pr-1">
@@ -29,7 +31,14 @@ export const TaskDataLine = observer(function TaskDataLine({
         </span>
         <AgentStatusIndicator status={agentStatus} />
       </div>
-      <TaskGitDiffStats task={task} />
+      <div
+        className={cn(
+          hideTrailingOnRowInteraction &&
+            'transition-opacity group-focus-within:pointer-events-none group-focus-within:opacity-0 group-hover:pointer-events-none group-hover:opacity-0'
+        )}
+      >
+        <TaskGitDiffStats task={task} />
+      </div>
     </div>
   );
 });

--- a/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
@@ -5,7 +5,7 @@ import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import type { AutomationRun } from '@shared/core/automations/automation-run';
 import { makePtySessionId } from '@shared/core/pty/ptySessionId';
-import { isAutomationTaskRunning } from './automation-run-stop';
+import { isAutomationConversationRunning } from './automation-run-stop';
 import { useAutomation } from './use-automations';
 
 export function useAutomationRunActions(automationId: string) {
@@ -19,9 +19,7 @@ export function useAutomationRunActions(automationId: string) {
 
     const conversations = conversationRegistry.get(taskId)?.conversations.values();
     const activeConversations = conversations
-      ? Array.from(conversations).filter((conversation) =>
-          isAutomationTaskRunning(conversation.status)
-        )
+      ? Array.from(conversations).filter(isAutomationConversationRunning)
       : [];
 
     setStopPending(true);
@@ -30,7 +28,7 @@ export function useAutomationRunActions(automationId: string) {
         activeConversations.map(async (conversation) => {
           if (conversation.data.type === 'acp') {
             const client = await getAcpRuntimeClient();
-            const result = await client.cancelTurn({ conversationId: conversation.data.id });
+            const result = await client.stopSession({ conversationId: conversation.data.id });
             if (!result.success) throw new Error(formatStopError(result.error));
             return;
           }

--- a/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
@@ -1,10 +1,67 @@
-import { useAutomation, useAutomations } from './use-automations';
+import { useState } from 'react';
+import { conversationRegistry } from '@renderer/features/conversations/stores/conversation-registry';
+import { getAcpRuntimeClient } from '@renderer/lib/acp/runtime-client';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+import type { AutomationRun } from '@shared/core/automations/automation-run';
+import { makePtySessionId } from '@shared/core/pty/ptySessionId';
+import { isAutomationTaskRunning } from './automation-run-stop';
+import { useAutomation } from './use-automations';
 
 export function useAutomationRunActions(automationId: string) {
-  const { stop } = useAutomations();
   const automation = useAutomation(automationId);
+  const [stopPending, setStopPending] = useState(false);
+
+  async function stopTaskRun(run: AutomationRun) {
+    const projectId = automation?.projectId;
+    const taskId = run.taskId;
+    if (!taskId || !projectId || stopPending) return;
+
+    const conversations = conversationRegistry.get(taskId)?.conversations.values();
+    const activeConversations = conversations
+      ? Array.from(conversations).filter((conversation) =>
+          isAutomationTaskRunning(conversation.status)
+        )
+      : [];
+
+    setStopPending(true);
+    try {
+      await Promise.all(
+        activeConversations.map(async (conversation) => {
+          if (conversation.data.type === 'acp') {
+            const client = await getAcpRuntimeClient();
+            const result = await client.cancelTurn({ conversationId: conversation.data.id });
+            if (!result.success) throw new Error(formatStopError(result.error));
+            return;
+          }
+
+          const result = await rpc.pty.stopSession(
+            makePtySessionId(projectId, taskId, conversation.data.id)
+          );
+          if (!result.success) throw new Error(formatStopError(result.error));
+        })
+      );
+    } catch (error) {
+      toast({
+        title: 'Failed to stop task run',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    } finally {
+      setStopPending(false);
+    }
+  }
+
   return {
-    stopRun: stop.mutate,
+    stopTaskRun,
+    stopPending,
     projectId: automation?.projectId ?? null,
   };
+}
+
+function formatStopError(error: unknown) {
+  if (typeof error !== 'object' || error === null) return String(error);
+  if ('message' in error && typeof error.message === 'string') return error.message;
+  if ('type' in error && typeof error.type === 'string') return error.type;
+  return 'Unknown error';
 }

--- a/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
@@ -1,5 +1,5 @@
 import { useState } from 'react';
-import { conversationRegistry } from '@renderer/features/conversations/stores/conversation-registry';
+import { getConversationsForTask } from '@renderer/features/tasks/stores/task-selectors';
 import { getAcpRuntimeClient } from '@renderer/lib/acp/runtime-client';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
@@ -17,7 +17,7 @@ export function useAutomationRunActions(automationId: string) {
     const taskId = run.taskId;
     if (!taskId || !projectId || stopPending) return;
 
-    const conversations = conversationRegistry.get(taskId)?.conversations.values();
+    const conversations = getConversationsForTask(projectId, taskId)?.conversations.values();
     const activeConversations = conversations
       ? Array.from(conversations).filter(isAutomationConversationRunning)
       : [];

--- a/apps/emdash-desktop/src/renderer/features/command-palette/command-palette-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/command-palette-modal.tsx
@@ -381,7 +381,9 @@ export function CommandPaletteModal({
                 }
               }
               if (item.kind === 'conversation' && item.projectId && item.taskId) {
-                const convStore = conversationRegistry.get(item.taskId)?.conversations.get(item.id);
+                const convStore = conversationRegistry
+                  .get(item.projectId, item.taskId)
+                  ?.conversations.get(item.id);
                 if (convStore) {
                   return (
                     <PaletteConversationItem
@@ -462,9 +464,12 @@ export function CommandPaletteModal({
             {taskId && conversationResults.length > 0 && (
               <Command.Group heading="Recent Conversations" className={GROUP_CLASS}>
                 {conversationResults.slice(0, 5).map((item) => {
-                  const convStore = item.taskId
-                    ? conversationRegistry.get(item.taskId)?.conversations.get(item.id)
-                    : undefined;
+                  const convStore =
+                    item.projectId && item.taskId
+                      ? conversationRegistry
+                          .get(item.projectId, item.taskId)
+                          ?.conversations.get(item.id)
+                      : undefined;
                   return convStore ? (
                     <PaletteConversationItem
                       key={item.id}

--- a/apps/emdash-desktop/src/renderer/features/command-palette/palette-notifications-group.tsx
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/palette-notifications-group.tsx
@@ -46,7 +46,7 @@ export function PaletteNotificationsGroup({
 
       for (const [tid, taskStore] of mounted.taskManager.tasks) {
         if (!isRegistered(taskStore)) continue;
-        const conversations = conversationRegistry.get(tid);
+        const conversations = conversationRegistry.get(pid, tid);
         if (!conversations) continue;
 
         const status = conversations.taskStatus;

--- a/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-utils.ts
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-utils.ts
@@ -155,7 +155,7 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
         const conv = getConversationsForTask(entry.projectId, taskId)?.conversations.get(
           entry.leafId
         );
-        const terminal = getTerminalsForTask(taskId)?.terminals.get(entry.leafId);
+        const terminal = getTerminalsForTask(entry.projectId, taskId)?.terminals.get(entry.leafId);
         providerId = conv?.data.providerId;
         displayTitle = conv?.data.title ?? terminal?.data.name;
       }

--- a/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-utils.ts
+++ b/apps/emdash-desktop/src/renderer/features/command-palette/resource-monitor-utils.ts
@@ -152,7 +152,9 @@ export function buildGroups(entries: ResourcePtyEntry[]): Group[] {
       if (task) {
         bucketKey = taskId;
         taskName = task.displayName;
-        const conv = getConversationsForTask(taskId)?.conversations.get(entry.leafId);
+        const conv = getConversationsForTask(entry.projectId, taskId)?.conversations.get(
+          entry.leafId
+        );
         const terminal = getTerminalsForTask(taskId)?.terminals.get(entry.leafId);
         providerId = conv?.data.providerId;
         displayTitle = conv?.data.title ?? terminal?.data.name;

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -512,8 +512,8 @@ const ComposerForStore = observer(function ComposerForStore({
   );
 
   const providerId =
-    conversationRegistry.get(store.taskId)?.conversations.get(store.conversationId)?.data
-      .providerId ?? null;
+    conversationRegistry.get(store.projectId, store.taskId)?.conversations.get(store.conversationId)
+      ?.data.providerId ?? null;
   const renderMentionIcon = useCallback(({ id, kind }: { id: string; kind: string }) => {
     if (kind !== 'issue') return null;
     const target = parseIssueMentionToken(id);
@@ -676,7 +676,9 @@ export const AcpChatPanel = observer(function AcpChatPanel() {
   // where the same tab stays active and onActivate() does not re-fire.
   const conversationStore = useObserver(() =>
     store
-      ? conversationRegistry.get(store.taskId)?.conversations.get(store.conversationId)
+      ? conversationRegistry
+          .get(store.projectId, store.taskId)
+          ?.conversations.get(store.conversationId)
       : undefined
   );
   const conversationSeen = conversationStore?.seen;

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-resource-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-resource-manager.ts
@@ -1,3 +1,4 @@
+import { conversationRegistryKey } from '../stores/conversation-registry';
 import { AcpChatStore } from './acp-chat-store';
 
 const GRACE_MS = 5_000;
@@ -70,19 +71,21 @@ export class AcpChatResourceManager {
 const _registry = new Map<string, AcpChatResourceManager>();
 
 export function getAcpChatResourceManager(
-  taskId: string,
-  projectId: string
+  projectId: string,
+  taskId: string
 ): AcpChatResourceManager {
-  const existing = _registry.get(taskId);
+  const key = conversationRegistryKey(projectId, taskId);
+  const existing = _registry.get(key);
   if (existing) return existing;
   const manager = new AcpChatResourceManager(projectId, taskId);
-  _registry.set(taskId, manager);
+  _registry.set(key, manager);
   return manager;
 }
 
-export function releaseAcpChatResourceManager(taskId: string): void {
-  const manager = _registry.get(taskId);
+export function releaseAcpChatResourceManager(projectId: string, taskId: string): void {
+  const key = conversationRegistryKey(projectId, taskId);
+  const manager = _registry.get(key);
   if (!manager) return;
   manager.dispose();
-  _registry.delete(taskId);
+  _registry.delete(key);
 }

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-store.ts
@@ -473,7 +473,7 @@ export class AcpChatStore {
 
   private _startInput() {
     const conversation = conversationRegistry
-      .get(this.taskId)
+      .get(this.projectId, this.taskId)
       ?.conversations.get(this.conversationId)?.data;
     if (!conversation) throw new Error('Conversation not found');
 

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-tab-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-tab-provider.tsx
@@ -37,7 +37,7 @@ export const AcpChatTabBarItem = observer(function AcpChatTabBarItem({
 }: TabBarItemProps<AcpChatTabResource>) {
   const store = tab.resource.store;
   const conversation = conversationRegistry
-    .get(store.taskId)
+    .get(store.projectId, store.taskId)
     ?.conversations.get(store.conversationId);
   const providerId = conversation?.data.providerId ?? '';
   const rawTitle = conversation?.data.title ?? '';
@@ -81,7 +81,7 @@ export const AcpChatTabBarItemDragPreview = observer(function AcpChatTabBarItemD
 }) {
   const store = tab.resource.store;
   const conversation = conversationRegistry
-    .get(store.taskId)
+    .get(store.projectId, store.taskId)
     ?.conversations.get(store.conversationId);
   const providerId = conversation?.data.providerId ?? '';
   const label = conversation
@@ -120,14 +120,14 @@ export const acpChatTabProvider: TabProvider<
     ctx: TabViewContext
   ): AcpChatTabResource {
     const taskCtx = ctx as TaskTabContext;
-    const manager = getAcpChatResourceManager(taskCtx.taskId, taskCtx.projectId);
+    const manager = getAcpChatResourceManager(taskCtx.projectId, taskCtx.taskId);
     const store = manager.acquire(entry.state.conversationId);
     return new AcpChatTabResource(store);
   },
 
   dispose(entry: TabEntry<AcpChatState>, _resource: AcpChatTabResource, ctx: TabViewContext): void {
     const taskCtx = ctx as TaskTabContext;
-    getAcpChatResourceManager(taskCtx.taskId, taskCtx.projectId).release(
+    getAcpChatResourceManager(taskCtx.projectId, taskCtx.taskId).release(
       entry.state.conversationId
     );
   },

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-tab-resource.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-tab-resource.ts
@@ -27,14 +27,14 @@ export class AcpChatTabResource implements TabResource {
     // Mirror ConversationTabResource: clear the notification indicator when
     // the user opens this tab.
     const conversation = conversationRegistry
-      .get(this.store.taskId)
+      .get(this.store.projectId, this.store.taskId)
       ?.conversations.get(this.store.conversationId);
     if (conversation && !conversation.seen) conversation.markSeen();
   }
 
   rename(name: string): void {
     void conversationRegistry
-      .get(this.store.taskId)
+      .get(this.store.projectId, this.store.taskId)
       ?.renameConversation(this.store.conversationId, name);
   }
 }

--- a/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.test.ts
@@ -1,10 +1,17 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  agentSessionExitedChannel,
+  type AgentSessionExited,
+} from '@shared/core/agents/agentEvents';
 import { ConversationManagerStore } from './conversation-manager';
 
 const hydrateConversation = vi.hoisted(() => vi.fn());
 const dehydrateConversation = vi.hoisted(() => vi.fn());
 const frontendConnect = vi.hoisted(() => vi.fn());
 const frontendDispose = vi.hoisted(() => vi.fn());
+const eventsOn = vi.hoisted(() =>
+  vi.fn((_channel: unknown, _listener: (event: AgentSessionExited) => void) => () => {})
+);
 
 vi.mock('@renderer/features/tasks/stores/open-file-in-file-editor', () => ({
   makeFileLinkHandlers: () => ({
@@ -14,7 +21,7 @@ vi.mock('@renderer/features/tasks/stores/open-file-in-file-editor', () => ({
 }));
 
 vi.mock('@renderer/lib/ipc', () => ({
-  events: { on: () => () => {} },
+  events: { on: eventsOn },
   rpc: {
     conversations: {
       dehydrateConversation,
@@ -39,6 +46,7 @@ describe('ConversationManagerStore session hydration', () => {
     dehydrateConversation.mockReset();
     frontendConnect.mockReset();
     frontendDispose.mockReset();
+    eventsOn.mockClear();
 
     hydrateConversation.mockResolvedValue(undefined);
     dehydrateConversation.mockResolvedValue(undefined);
@@ -67,5 +75,36 @@ describe('ConversationManagerStore session hydration', () => {
     expect(frontendConnect).toHaveBeenCalledTimes(1);
 
     store.dispose();
+  });
+
+  it('ignores session exits from another project with the same task id', () => {
+    const conversation = {
+      id: 'conversation-1',
+      taskId: 'task-1',
+      providerId: 'codex',
+      title: 'Conversation 1',
+      lastInteractedAt: null,
+      isInitialConversation: false,
+      agentStatus: 'working' as const,
+    };
+    const first = new ConversationManagerStore('project-1', 'task-1', [
+      { ...conversation, projectId: 'project-1' },
+    ]);
+    const second = new ConversationManagerStore('project-2', 'task-1', [
+      { ...conversation, projectId: 'project-2' },
+    ]);
+    const exitListeners = eventsOn.mock.calls
+      .filter(([channel]) => channel === agentSessionExitedChannel)
+      .map(([, listener]) => listener);
+
+    for (const listener of exitListeners) {
+      listener({ conversationId: 'conversation-1', projectId: 'project-1', taskId: 'task-1' });
+    }
+
+    expect(first.conversations.get('conversation-1')?.status).toBe('idle');
+    expect(second.conversations.get('conversation-1')?.status).toBe('working');
+
+    first.dispose();
+    second.dispose();
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.ts
@@ -129,7 +129,7 @@ export class ConversationManagerStore implements IDisposable {
 
   private listenToSessionExited(): () => void {
     return events.on(agentSessionExitedChannel, (event) => {
-      if (event.taskId !== this.taskId) return;
+      if (event.projectId !== this.projectId || event.taskId !== this.taskId) return;
       const conversationStore = this.conversations.get(event.conversationId);
       if (!conversationStore) return;
       conversationStore.clearWorking();

--- a/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.ts
@@ -37,7 +37,7 @@ export class ConversationManagerStore implements IDisposable {
   sessions = observable.map<string, PtySession>();
 
   constructor(
-    readonly projectId: string,
+    private readonly projectId: string,
     private readonly taskId: string,
     preloaded?: Conversation[]
   ) {
@@ -109,7 +109,7 @@ export class ConversationManagerStore implements IDisposable {
 
   private listenToAgentStatusChanged(): () => void {
     return events.on(conversationAgentStatusChangedChannel, (payload) => {
-      if (payload.taskId !== this.taskId) return;
+      if (payload.projectId !== this.projectId || payload.taskId !== this.taskId) return;
       const conversationStore = this.conversations.get(payload.conversationId);
       if (!conversationStore) return;
 
@@ -147,7 +147,7 @@ export class ConversationManagerStore implements IDisposable {
 
   private listenToConversationChanges(): () => void {
     return events.on(conversationChangedChannel, (event) => {
-      if (event.taskId !== this.taskId) return;
+      if (event.projectId !== this.projectId || event.taskId !== this.taskId) return;
       const store = this.conversations.get(event.conversationId);
       if (!store) return;
       runInAction(() => {

--- a/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/conversation-manager.ts
@@ -37,7 +37,7 @@ export class ConversationManagerStore implements IDisposable {
   sessions = observable.map<string, PtySession>();
 
   constructor(
-    private readonly projectId: string,
+    readonly projectId: string,
     private readonly taskId: string,
     preloaded?: Conversation[]
   ) {

--- a/apps/emdash-desktop/src/renderer/features/conversations/conversation-tab-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/conversation-tab-provider.tsx
@@ -48,7 +48,7 @@ export const conversationTabProvider: TabProvider<
     ctx: TabViewContext
   ): ConversationTabResource {
     const taskCtx = ctx as TaskTabContext;
-    const sessionManager = getConversationSessionManager(taskCtx.taskId);
+    const sessionManager = getConversationSessionManager(taskCtx.projectId, taskCtx.taskId);
     const store = sessionManager.acquire(entry.state.conversationId);
     if (!store) {
       // Conversation not found; return a dummy resource that will auto-close.
@@ -72,7 +72,9 @@ export const conversationTabProvider: TabProvider<
     ctx: TabViewContext
   ): void {
     const taskCtx = ctx as TaskTabContext;
-    getConversationSessionManager(taskCtx.taskId).release(entry.state.conversationId);
+    getConversationSessionManager(taskCtx.projectId, taskCtx.taskId).release(
+      entry.state.conversationId
+    );
   },
 
   commands: {

--- a/apps/emdash-desktop/src/renderer/features/conversations/conversation-tab-resource.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/conversation-tab-resource.ts
@@ -16,18 +16,22 @@ import { conversationRegistry } from './stores/conversation-registry';
  */
 export class ConversationTabResource implements TabResource {
   readonly store: ConversationStore;
+  private readonly _projectId: string;
   private readonly _taskId: string;
   private readonly _disposers: (() => void)[];
 
   constructor(store: ConversationStore, taskId: string, handle: TabHandle) {
     this.store = store;
+    this._projectId = store.data.projectId;
     this._taskId = taskId;
     const conversationId = store.data.id;
 
     this._disposers = [
       // Auto-close this tab when the conversation is deleted.
       reaction(
-        () => conversationRegistry.get(taskId)?.conversations.has(conversationId) ?? false,
+        () =>
+          conversationRegistry.get(this._projectId, taskId)?.conversations.has(conversationId) ??
+          false,
         (exists) => {
           if (!exists) void handle.close();
         }
@@ -49,6 +53,8 @@ export class ConversationTabResource implements TabResource {
   }
 
   rename(name: string): void {
-    void conversationRegistry.get(this._taskId)?.renameConversation(this.store.data.id, name);
+    void conversationRegistry
+      .get(this._projectId, this._taskId)
+      ?.renameConversation(this.store.data.id, name);
   }
 }

--- a/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/create-conversation-modal.tsx
@@ -40,7 +40,7 @@ export const CreateConversationModal = observer(function CreateConversationModal
 }) {
   const connectionId = getProjectSshConnectionId(projectId);
   const { providerId, setProviderOverride, createDisabled } = useEffectiveProvider(connectionId);
-  const conversationMgr = conversationRegistry.get(taskId);
+  const conversationMgr = conversationRegistry.get(projectId, taskId);
   const taskSettings = useTaskSettings();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);

--- a/apps/emdash-desktop/src/renderer/features/conversations/default-conversation-seeder.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/default-conversation-seeder.ts
@@ -17,11 +17,12 @@ export class DefaultConversationSeeder {
   private _disposer: () => void;
 
   constructor(
+    private readonly projectId: string,
     private readonly taskId: string,
     private readonly paneLayout: PaneLayoutStore
   ) {
     this._disposer = reaction(
-      () => conversationRegistry.get(this.taskId)?.conversations.size ?? 0,
+      () => conversationRegistry.get(this.projectId, this.taskId)?.conversations.size ?? 0,
       (size) => {
         if (size === 0) return;
         this.seed();
@@ -38,7 +39,7 @@ export class DefaultConversationSeeder {
   /** Opens the initial conversation tab for a fresh task, exactly once. */
   seed(): void {
     if (this._consumed) return;
-    const conversations = conversationRegistry.get(this.taskId);
+    const conversations = conversationRegistry.get(this.projectId, this.taskId);
     if (!conversations || conversations.conversations.size === 0) return;
 
     this._consumed = true;

--- a/apps/emdash-desktop/src/renderer/features/conversations/sidebar-conversations-list.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/sidebar-conversations-list.tsx
@@ -97,7 +97,7 @@ const ConversationRow = observer(function ConversationRow({
   };
 
   const handleExport = (kind: 'parsed' | 'raw') => {
-    const store = getAcpChatResourceManager(taskId, projectId).get(conversationId);
+    const store = getAcpChatResourceManager(projectId, taskId).get(conversationId);
     if (!store) {
       toast({
         title: 'Failed to export transcript',

--- a/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-registry.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-registry.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it, vi } from 'vitest';
+import { ConversationRegistry } from './conversation-registry';
+
+vi.mock('@renderer/features/conversations/conversation-manager', () => ({
+  ConversationManagerStore: class {
+    dispose() {}
+  },
+}));
+
+describe('ConversationRegistry', () => {
+  it('keeps stores for the same task id in different projects independent', () => {
+    const registry = new ConversationRegistry();
+    const first = registry.acquire('project-1', 'shared-task', []);
+    const second = registry.acquire('project-2', 'shared-task', []);
+
+    expect(second).not.toBe(first);
+    expect(registry.get('project-1', 'shared-task')).toBe(first);
+    expect(registry.get('project-2', 'shared-task')).toBe(second);
+
+    registry.release('project-1', 'shared-task');
+    expect(registry.get('project-2', 'shared-task')).toBe(second);
+    registry.release('project-2', 'shared-task');
+  });
+
+  it('does not collide when ids contain delimiters', () => {
+    const registry = new ConversationRegistry();
+    const first = registry.acquire('project:one', 'task', []);
+    const second = registry.acquire('project', 'one:task', []);
+
+    expect(second).not.toBe(first);
+    expect(registry.get('project:one', 'task')).toBe(first);
+    expect(registry.get('project', 'one:task')).toBe(second);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-registry.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-registry.ts
@@ -4,29 +4,30 @@ import type { Conversation } from '@shared/core/conversations/conversations';
 export class ConversationRegistry {
   private readonly entries = new Map<string, ConversationManagerStore>();
 
-  acquire(taskId: string, projectId: string, preloaded?: Conversation[]): ConversationManagerStore {
-    const existing = this.entries.get(taskId);
+  acquire(projectId: string, taskId: string, preloaded?: Conversation[]): ConversationManagerStore {
+    const key = conversationRegistryKey(projectId, taskId);
+    const existing = this.entries.get(key);
     if (existing) return existing;
     const store = new ConversationManagerStore(projectId, taskId, preloaded);
-    this.entries.set(taskId, store);
+    this.entries.set(key, store);
     return store;
   }
 
-  get(taskId: string): ConversationManagerStore | undefined {
-    return this.entries.get(taskId);
+  get(projectId: string, taskId: string): ConversationManagerStore | undefined {
+    return this.entries.get(conversationRegistryKey(projectId, taskId));
   }
 
-  getForProject(projectId: string, taskId: string): ConversationManagerStore | undefined {
-    const store = this.entries.get(taskId);
-    return store?.projectId === projectId ? store : undefined;
-  }
-
-  release(taskId: string): void {
-    const store = this.entries.get(taskId);
+  release(projectId: string, taskId: string): void {
+    const key = conversationRegistryKey(projectId, taskId);
+    const store = this.entries.get(key);
     if (!store) return;
     store.dispose();
-    this.entries.delete(taskId);
+    this.entries.delete(key);
   }
+}
+
+export function conversationRegistryKey(projectId: string, taskId: string) {
+  return JSON.stringify([projectId, taskId]);
 }
 
 export const conversationRegistry = new ConversationRegistry();

--- a/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-registry.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-registry.ts
@@ -16,6 +16,11 @@ export class ConversationRegistry {
     return this.entries.get(taskId);
   }
 
+  getForProject(projectId: string, taskId: string): ConversationManagerStore | undefined {
+    const store = this.entries.get(taskId);
+    return store?.projectId === projectId ? store : undefined;
+  }
+
   release(taskId: string): void {
     const store = this.entries.get(taskId);
     if (!store) return;

--- a/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-session-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/stores/conversation-session-manager.ts
@@ -1,7 +1,7 @@
 import { log } from '@renderer/utils/logger';
 import type { ConversationStore } from '../conversation-manager';
 import { ConversationHydrationReconciler } from './conversation-hydration-reconciler';
-import { conversationRegistry } from './conversation-registry';
+import { conversationRegistry, conversationRegistryKey } from './conversation-registry';
 
 /**
  * Per-task manager that controls conversation PTY-session lifecycle via acquire/release.
@@ -21,10 +21,13 @@ export class ConversationSessionManager {
   /** Ref counts per conversationId — session stays alive while count > 0. */
   private readonly _refCounts = new Map<string, number>();
 
-  constructor(private readonly taskId: string) {
+  constructor(
+    private readonly projectId: string,
+    private readonly taskId: string
+  ) {
     this._reconciler = new ConversationHydrationReconciler({
       taskId,
-      getConversations: () => conversationRegistry.get(taskId),
+      getConversations: () => conversationRegistry.get(projectId, taskId),
       log,
     });
   }
@@ -36,7 +39,7 @@ export class ConversationSessionManager {
   acquire(conversationId: string): ConversationStore | undefined {
     this._refCounts.set(conversationId, (this._refCounts.get(conversationId) ?? 0) + 1);
     this._reconciler.sync(new Set(this._refCounts.keys()));
-    return conversationRegistry.get(this.taskId)?.conversations.get(conversationId);
+    return conversationRegistry.get(this.projectId, this.taskId)?.conversations.get(conversationId);
   }
 
   /**
@@ -62,17 +65,22 @@ export class ConversationSessionManager {
 
 const _registry = new Map<string, ConversationSessionManager>();
 
-export function getConversationSessionManager(taskId: string): ConversationSessionManager {
-  const existing = _registry.get(taskId);
+export function getConversationSessionManager(
+  projectId: string,
+  taskId: string
+): ConversationSessionManager {
+  const key = conversationRegistryKey(projectId, taskId);
+  const existing = _registry.get(key);
   if (existing) return existing;
-  const manager = new ConversationSessionManager(taskId);
-  _registry.set(taskId, manager);
+  const manager = new ConversationSessionManager(projectId, taskId);
+  _registry.set(key, manager);
   return manager;
 }
 
-export function releaseConversationSessionManager(taskId: string): void {
-  const manager = _registry.get(taskId);
+export function releaseConversationSessionManager(projectId: string, taskId: string): void {
+  const key = conversationRegistryKey(projectId, taskId);
+  const manager = _registry.get(key);
   if (!manager) return;
   manager.dispose();
-  _registry.delete(taskId);
+  _registry.delete(key);
 }

--- a/apps/emdash-desktop/src/renderer/features/tabs/core/task-tab-context.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/core/task-tab-context.ts
@@ -10,7 +10,7 @@ import type { TabViewContext } from '@renderer/features/tabs/core/tab-provider';
  * TaskTabContext to access the domain fields:
  *
  *   const taskCtx = ctx as TaskTabContext;
- *   conversationRegistry.get(taskCtx.taskId);
+ *   conversationRegistry.get(taskCtx.projectId, taskCtx.taskId);
  */
 export interface TaskTabContext extends TabViewContext {
   projectId: string;

--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-layout-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-layout-store.test.ts
@@ -65,7 +65,10 @@ vi.mock('@renderer/utils/logger', () => ({
 }));
 
 import { browserSessionStore } from '@renderer/features/browser/browser-session-store';
-import { terminalRegistry } from '@renderer/features/tasks/stores/terminal-registry';
+import {
+  terminalRegistry,
+  terminalRegistryKey,
+} from '@renderer/features/tasks/stores/terminal-registry';
 import { taskTabView } from '@renderer/features/tasks/task-tab-registry';
 import type {
   TerminalManagerStore,
@@ -258,7 +261,7 @@ describe('PaneLayoutStore: single-mount explicit target opens', () => {
     vi.clearAllMocks();
     browserSessionStore.clear();
     terminalRegistryEntries().set(
-      'task-1',
+      terminalRegistryKey('project-1', 'task-1'),
       new FakeTerminalManagerStore({
         terminalIds: ['terminal-1'],
         isLoaded: true,
@@ -267,8 +270,8 @@ describe('PaneLayoutStore: single-mount explicit target opens', () => {
   });
 
   afterEach(() => {
-    terminalRegistry.release('task-1');
-    terminalRegistryEntries().delete('task-1');
+    terminalRegistry.release('project-1', 'task-1');
+    terminalRegistryEntries().delete(terminalRegistryKey('project-1', 'task-1'));
   });
 
   it('moves an existing single-mount tab to an explicit target pane', () => {

--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-layout-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-layout-store.test.ts
@@ -116,14 +116,14 @@ class FakeTerminalManagerStore {
 }
 
 function terminalRegistryEntries(): {
-  set(taskId: string, manager: TerminalManagerStore): void;
-  delete(taskId: string): boolean;
+  set(key: string, manager: TerminalManagerStore): void;
+  delete(key: string): boolean;
 } {
   return (
     terminalRegistry as unknown as {
       entries: {
-        set(taskId: string, manager: TerminalManagerStore): void;
-        delete(taskId: string): boolean;
+        set(key: string, manager: TerminalManagerStore): void;
+        delete(key: string): boolean;
       };
     }
   ).entries;

--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-store.test.ts
@@ -88,7 +88,10 @@ vi.mock('@renderer/features/conversations/acp/acp-chat-panel', () => ({
 }));
 
 import type { BrowserTabResource } from '@renderer/features/browser/browser-tab-resource';
-import { terminalRegistry } from '@renderer/features/tasks/stores/terminal-registry';
+import {
+  terminalRegistry,
+  terminalRegistryKey,
+} from '@renderer/features/tasks/stores/terminal-registry';
 import { taskTabView } from '@renderer/features/tasks/task-tab-registry';
 import type {
   TerminalManagerStore,
@@ -162,8 +165,8 @@ describe('PaneStore browser tabs', () => {
   });
 
   afterEach(() => {
-    terminalRegistry.release('task-1');
-    terminalRegistryEntries().delete('task-1');
+    terminalRegistry.release('project-1', 'task-1');
+    terminalRegistryEntries().delete(terminalRegistryKey('project-1', 'task-1'));
   });
 
   it('opens browser tabs backed by the default browser profile session', () => {
@@ -292,7 +295,7 @@ describe('PaneStore terminal tabs', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     terminalRegistryEntries().set(
-      'task-1',
+      terminalRegistryKey('project-1', 'task-1'),
       new FakeTerminalManagerStore({
         terminalIds: ['terminal-1'],
         isLoaded: true,
@@ -301,8 +304,8 @@ describe('PaneStore terminal tabs', () => {
   });
 
   afterEach(() => {
-    terminalRegistry.release('task-1');
-    terminalRegistryEntries().delete('task-1');
+    terminalRegistry.release('project-1', 'task-1');
+    terminalRegistryEntries().delete(terminalRegistryKey('project-1', 'task-1'));
   });
 
   it('opens and snapshots an existing terminal as a task tab', () => {
@@ -341,7 +344,7 @@ describe('PaneStore terminal tabs', () => {
       tabId: 'tab-terminal-1',
       isActive: true,
     });
-    expect(terminalRegistry.get('task-1')?.terminals.has('terminal-1')).toBe(true);
+    expect(terminalRegistry.get('project-1', 'task-1')?.terminals.has('terminal-1')).toBe(true);
   });
 
   it('closing a terminal task tab only closes the tab view', () => {
@@ -351,7 +354,7 @@ describe('PaneStore terminal tabs', () => {
     manager.closeTab(manager.resolvedTabs[0]?.tabId ?? '');
 
     expect(manager.resolvedTabs).toEqual([]);
-    expect(terminalRegistry.get('task-1')?.terminals.has('terminal-1')).toBe(true);
+    expect(terminalRegistry.get('project-1', 'task-1')?.terminals.has('terminal-1')).toBe(true);
   });
 
   it('stale-closes terminal tabs when the drawer-owned terminal is removed', async () => {
@@ -359,7 +362,7 @@ describe('PaneStore terminal tabs', () => {
     manager.open('terminal', { terminalId: 'terminal-1' });
 
     runInAction(() => {
-      terminalRegistry.get('task-1')?.terminals.delete('terminal-1');
+      terminalRegistry.get('project-1', 'task-1')?.terminals.delete('terminal-1');
     });
     await new Promise((resolve) => setTimeout(resolve, 0));
 
@@ -367,7 +370,10 @@ describe('PaneStore terminal tabs', () => {
   });
 
   it('stale-closes restored terminal tabs after initialization finishes', async () => {
-    const terminals = terminalRegistry.get('task-1') as unknown as FakeTerminalManagerStore;
+    const terminals = terminalRegistry.get(
+      'project-1',
+      'task-1'
+    ) as unknown as FakeTerminalManagerStore;
     runInAction(() => {
       terminals.terminals.clear();
       terminals.isLoaded = true;

--- a/apps/emdash-desktop/src/renderer/features/tabs/pane-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tabs/pane-store.test.ts
@@ -144,14 +144,14 @@ class FakeTerminalManagerStore {
 }
 
 function terminalRegistryEntries(): {
-  set(taskId: string, manager: TerminalManagerStore): void;
-  delete(taskId: string): boolean;
+  set(key: string, manager: TerminalManagerStore): void;
+  delete(key: string): boolean;
 } {
   return (
     terminalRegistry as unknown as {
       entries: {
-        set(taskId: string, manager: TerminalManagerStore): void;
-        delete(taskId: string): boolean;
+        set(key: string, manager: TerminalManagerStore): void;
+        delete(key: string): boolean;
       };
     }
   ).entries;

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
@@ -186,7 +186,7 @@ describe('TaskManagerStore archive lifecycle', () => {
 
     expect(mocks.archiveTask).toHaveBeenCalledWith('project-1', 'task-1');
     expect(mocks.teardownTask).not.toHaveBeenCalled();
-    expect(mocks.conversationRelease).toHaveBeenCalledWith('task-1');
+    expect(mocks.conversationRelease).toHaveBeenCalledWith('project-1', 'task-1');
     expect(mocks.terminalRelease).toHaveBeenCalledWith('task-1');
     expect(viewModel.dispose).toHaveBeenCalledOnce();
     expect(draftComments.dispose).toHaveBeenCalledOnce();
@@ -211,7 +211,7 @@ describe('TaskManagerStore archive lifecycle', () => {
 
     await manager.provisionTask(task.id);
 
-    expect(mocks.conversationAcquire).toHaveBeenCalledWith('task-1', 'project-1');
+    expect(mocks.conversationAcquire).toHaveBeenCalledWith('project-1', 'task-1');
     expect(mocks.terminalAcquire).toHaveBeenCalledWith('task-1', 'project-1');
     expect(store.state).toBe('provisioned');
     expect(store.viewModel).toBe(mocks.viewModels[1]);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.test.ts
@@ -187,7 +187,7 @@ describe('TaskManagerStore archive lifecycle', () => {
     expect(mocks.archiveTask).toHaveBeenCalledWith('project-1', 'task-1');
     expect(mocks.teardownTask).not.toHaveBeenCalled();
     expect(mocks.conversationRelease).toHaveBeenCalledWith('project-1', 'task-1');
-    expect(mocks.terminalRelease).toHaveBeenCalledWith('task-1');
+    expect(mocks.terminalRelease).toHaveBeenCalledWith('project-1', 'task-1');
     expect(viewModel.dispose).toHaveBeenCalledOnce();
     expect(draftComments.dispose).toHaveBeenCalledOnce();
     expect(store.state).toBe('unprovisioned');
@@ -212,7 +212,7 @@ describe('TaskManagerStore archive lifecycle', () => {
     await manager.provisionTask(task.id);
 
     expect(mocks.conversationAcquire).toHaveBeenCalledWith('project-1', 'task-1');
-    expect(mocks.terminalAcquire).toHaveBeenCalledWith('task-1', 'project-1');
+    expect(mocks.terminalAcquire).toHaveBeenCalledWith('project-1', 'task-1');
     expect(store.state).toBe('provisioned');
     expect(store.viewModel).toBe(mocks.viewModels[1]);
     expect(mocks.viewModels[1].restoreSnapshot).toHaveBeenCalledWith(snapshot);

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -156,7 +156,7 @@ export class TaskManagerStore {
         // Acquire conversation/terminal managers inside the same action so the
         // WorkspaceViewModel's reaction on `conversations.size` registers the
         // manager's observable map as a dependency on its first evaluation.
-        conversationRegistry.acquire(task.id, this.projectId, []);
+        conversationRegistry.acquire(this.projectId, task.id, []);
         terminalRegistry.acquire(task.id, this.projectId);
       });
     });
@@ -289,7 +289,7 @@ export class TaskManagerStore {
   }
 
   private _releaseTaskRegistries(taskId: string): void {
-    conversationRegistry.release(taskId);
+    conversationRegistry.release(this.projectId, taskId);
     terminalRegistry.release(taskId);
   }
 
@@ -321,8 +321,8 @@ export class TaskManagerStore {
               this.tasks.set(t.id, createUnprovisionedTask(t));
               // Preload conversations for each task so sidebar badges are available immediately.
               conversationRegistry.acquire(
-                t.id,
                 this.projectId,
+                t.id,
                 conversationsByTask.get(t.id) ?? []
               );
               terminalRegistry.acquire(t.id, this.projectId);
@@ -373,9 +373,9 @@ export class TaskManagerStore {
           isInitialConversation: true,
           type: ic.type ?? 'pty',
         };
-        conversationRegistry.acquire(params.id, this.projectId, [optimistic]);
+        conversationRegistry.acquire(this.projectId, params.id, [optimistic]);
       } else {
-        conversationRegistry.acquire(params.id, this.projectId, []);
+        conversationRegistry.acquire(this.projectId, params.id, []);
       }
       terminalRegistry.acquire(params.id, this.projectId);
     });
@@ -487,7 +487,7 @@ export class TaskManagerStore {
     runInAction(() => {
       const current = this.tasks.get(taskId);
       if (current && isUnprovisioned(current)) {
-        conversationRegistry.acquire(taskId, this.projectId);
+        conversationRegistry.acquire(this.projectId, taskId);
         terminalRegistry.acquire(taskId, this.projectId);
         current.transitionToProvisioned(
           { ...current.data, lastInteractedAt: new Date().toISOString() },
@@ -514,7 +514,7 @@ export class TaskManagerStore {
     runInAction(() => {
       const current = this.tasks.get(taskId);
       if (current && isUnprovisioned(current)) {
-        conversationRegistry.acquire(taskId, this.projectId);
+        conversationRegistry.acquire(this.projectId, taskId);
         terminalRegistry.acquire(taskId, this.projectId);
         current.transitionToProvisioned(
           { ...current.data, lastInteractedAt: new Date().toISOString() },

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-manager.ts
@@ -157,7 +157,7 @@ export class TaskManagerStore {
         // WorkspaceViewModel's reaction on `conversations.size` registers the
         // manager's observable map as a dependency on its first evaluation.
         conversationRegistry.acquire(this.projectId, task.id, []);
-        terminalRegistry.acquire(task.id, this.projectId);
+        terminalRegistry.acquire(this.projectId, task.id);
       });
     });
 
@@ -290,7 +290,7 @@ export class TaskManagerStore {
 
   private _releaseTaskRegistries(taskId: string): void {
     conversationRegistry.release(this.projectId, taskId);
-    terminalRegistry.release(taskId);
+    terminalRegistry.release(this.projectId, taskId);
   }
 
   private _removeTaskLocally(taskId: string): void {
@@ -325,7 +325,7 @@ export class TaskManagerStore {
                 t.id,
                 conversationsByTask.get(t.id) ?? []
               );
-              terminalRegistry.acquire(t.id, this.projectId);
+              terminalRegistry.acquire(this.projectId, t.id);
             }
           });
           const reloadPromises = tasks.flatMap((t) => {
@@ -377,7 +377,7 @@ export class TaskManagerStore {
       } else {
         conversationRegistry.acquire(this.projectId, params.id, []);
       }
-      terminalRegistry.acquire(params.id, this.projectId);
+      terminalRegistry.acquire(this.projectId, params.id);
     });
 
     const result = await rpc.tasks
@@ -488,7 +488,7 @@ export class TaskManagerStore {
       const current = this.tasks.get(taskId);
       if (current && isUnprovisioned(current)) {
         conversationRegistry.acquire(this.projectId, taskId);
-        terminalRegistry.acquire(taskId, this.projectId);
+        terminalRegistry.acquire(this.projectId, taskId);
         current.transitionToProvisioned(
           { ...current.data, lastInteractedAt: new Date().toISOString() },
           result.data.path,
@@ -515,7 +515,7 @@ export class TaskManagerStore {
       const current = this.tasks.get(taskId);
       if (current && isUnprovisioned(current)) {
         conversationRegistry.acquire(this.projectId, taskId);
-        terminalRegistry.acquire(taskId, this.projectId);
+        terminalRegistry.acquire(this.projectId, taskId);
         current.transitionToProvisioned(
           { ...current.data, lastInteractedAt: new Date().toISOString() },
           path,

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
@@ -140,8 +140,8 @@ export function getConversationsForTask(projectId: string, taskId: string) {
   return conversationRegistry.get(projectId, taskId);
 }
 
-export function getTerminalsForTask(taskId: string) {
-  return terminalRegistry.get(taskId);
+export function getTerminalsForTask(projectId: string, taskId: string) {
+  return terminalRegistry.get(projectId, taskId);
 }
 
 /** Returns the display name from any task store variant. */

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
@@ -134,8 +134,8 @@ export function getWorkspaceViewModel(
   return getTaskStore(projectId, taskId)?.viewModel ?? undefined;
 }
 
-export function getConversationsForTask(taskId: string) {
-  return conversationRegistry.get(taskId);
+export function getConversationsForTask(projectId: string, taskId: string) {
+  return conversationRegistry.getForProject(projectId, taskId);
 }
 
 export function getTerminalsForTask(taskId: string) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-selectors.ts
@@ -57,7 +57,9 @@ export function getTaskGitWorktreeStore(projectId: string, taskId: string) {
 }
 
 export function taskAgentStatus(store: TaskStore): AgentStatus | null {
-  const mgr = conversationRegistry.get(store.data.id);
+  const task = registeredTaskData(store);
+  if (!task) return null;
+  const mgr = conversationRegistry.get(task.projectId, task.id);
   return mgr?.taskStatus ?? null;
 }
 
@@ -135,7 +137,7 @@ export function getWorkspaceViewModel(
 }
 
 export function getConversationsForTask(projectId: string, taskId: string) {
-  return conversationRegistry.getForProject(projectId, taskId);
+  return conversationRegistry.get(projectId, taskId);
 }
 
 export function getTerminalsForTask(taskId: string) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
@@ -180,7 +180,7 @@ export class TaskStore {
       return {};
     }
     if (this.state === 'provisioned') {
-      const mgr = conversationRegistry.get(this.data.id);
+      const mgr = conversationRegistry.get(this.data.projectId, this.data.id);
       if (mgr) {
         const counts: Record<string, number> = {};
         for (const conv of mgr.conversations.values()) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/task-store.ts
@@ -180,7 +180,9 @@ export class TaskStore {
       return {};
     }
     if (this.state === 'provisioned') {
-      const mgr = conversationRegistry.get(this.data.projectId, this.data.id);
+      const task = registeredTaskData(this);
+      if (!task) return {};
+      const mgr = conversationRegistry.get(task.projectId, task.id);
       if (mgr) {
         const counts: Record<string, number> = {};
         for (const conv of mgr.conversations.values()) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/terminal-registry.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/terminal-registry.ts
@@ -4,24 +4,30 @@ import { TerminalManagerStore } from '@renderer/features/tasks/terminals/termina
 export class TerminalRegistry {
   private readonly entries = observable.map<string, TerminalManagerStore>();
 
-  acquire(taskId: string, projectId: string): TerminalManagerStore {
-    const existing = this.entries.get(taskId);
+  acquire(projectId: string, taskId: string): TerminalManagerStore {
+    const key = terminalRegistryKey(projectId, taskId);
+    const existing = this.entries.get(key);
     if (existing) return existing;
     const store = new TerminalManagerStore(projectId, taskId);
-    this.entries.set(taskId, store);
+    this.entries.set(key, store);
     return store;
   }
 
-  get(taskId: string): TerminalManagerStore | undefined {
-    return this.entries.get(taskId);
+  get(projectId: string, taskId: string): TerminalManagerStore | undefined {
+    return this.entries.get(terminalRegistryKey(projectId, taskId));
   }
 
-  release(taskId: string): void {
-    const store = this.entries.get(taskId);
+  release(projectId: string, taskId: string): void {
+    const key = terminalRegistryKey(projectId, taskId);
+    const store = this.entries.get(key);
     if (!store) return;
     store.dispose();
-    this.entries.delete(taskId);
+    this.entries.delete(key);
   }
+}
+
+export function terminalRegistryKey(projectId: string, taskId: string) {
+  return JSON.stringify([projectId, taskId]);
 }
 
 export const terminalRegistry = new TerminalRegistry();

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -11,7 +11,7 @@ import type { Terminal } from '@shared/core/terminals/terminals';
 import type { TaskViewSnapshot } from '@shared/view-state';
 import type { TerminalManagerStore, TerminalStore } from '../terminals/terminal-manager';
 import type { TaskStore } from './task-store';
-import { terminalRegistry } from './terminal-registry';
+import { terminalRegistry, terminalRegistryKey } from './terminal-registry';
 import { workspaceRegistry } from './workspace-registry';
 import { WorkspaceViewModel } from './workspace-view-model';
 
@@ -226,8 +226,8 @@ afterEach(() => {
   // Release the session manager first so the reconciler disposes cleanly.
   releaseConversationSessionManager('project-1', 'task-1');
   conversationRegistry.release('project-1', 'task-1');
-  terminalRegistry.release('task-1');
-  terminalRegistryEntries().delete('task-1');
+  terminalRegistry.release('project-1', 'task-1');
+  terminalRegistryEntries().delete(terminalRegistryKey('project-1', 'task-1'));
   workspaceRegistry.release('project-1', 'workspace-1');
   // Clear cache keys written by TaskTabViewPersistor so tests don't pollute each other.
   viewStateCache.delete('task:task-1:tabs');
@@ -253,7 +253,7 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 
   it('does not auto-create a terminal when stale restored tabs are empty but terminal records load', async () => {
     const terminals = makeTerminalManager({ terminalIds: ['terminal-1'], isLoaded: false });
-    terminalRegistryEntries().set('task-1', terminals);
+    terminalRegistryEntries().set(terminalRegistryKey('project-1', 'task-1'), terminals);
     workspaceRegistry.acquire('project-1', 'workspace-1', '/tmp/emdash-test-workspace', {
       settings: {},
     } as never);
@@ -282,7 +282,7 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 
   it('closes a restored empty terminal drawer after terminal state is loaded', async () => {
     const terminals = makeTerminalManager({ terminalIds: [], isLoaded: true });
-    terminalRegistryEntries().set('task-1', terminals);
+    terminalRegistryEntries().set(terminalRegistryKey('project-1', 'task-1'), terminals);
     workspaceRegistry.acquire(
       'project-1',
       'workspace-1',
@@ -314,7 +314,7 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 
   it('closes a restored empty terminal drawer when empty terminal state finishes loading', async () => {
     const terminals = makeTerminalManager({ terminalIds: [], isLoaded: false });
-    terminalRegistryEntries().set('task-1', terminals);
+    terminalRegistryEntries().set(terminalRegistryKey('project-1', 'task-1'), terminals);
     workspaceRegistry.acquire(
       'project-1',
       'workspace-1',
@@ -350,7 +350,7 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 
   it('closes the terminal drawer after the user closes the last terminal', async () => {
     const terminals = makeTerminalManager({ terminalIds: ['terminal-1'], isLoaded: true });
-    terminalRegistryEntries().set('task-1', terminals);
+    terminalRegistryEntries().set(terminalRegistryKey('project-1', 'task-1'), terminals);
     workspaceRegistry.acquire(
       'project-1',
       'workspace-1',

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -224,8 +224,8 @@ function terminalRegistryEntries(): {
 
 afterEach(() => {
   // Release the session manager first so the reconciler disposes cleanly.
-  releaseConversationSessionManager('task-1');
-  conversationRegistry.release('task-1');
+  releaseConversationSessionManager('project-1', 'task-1');
+  conversationRegistry.release('project-1', 'task-1');
   terminalRegistry.release('task-1');
   terminalRegistryEntries().delete('task-1');
   workspaceRegistry.release('project-1', 'workspace-1');
@@ -386,7 +386,7 @@ describe('WorkspaceViewModel terminal drawer snapshot', () => {
 
 describe('WorkspaceViewModel default conversation tab', () => {
   it('opens the initial conversation for a new task without restored tab state', async () => {
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', []);
     const viewModel = makeViewModel();
 
     runInAction(() => {
@@ -400,7 +400,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
   });
 
   it('does not reopen a closed initial conversation when a later conversation is created', async () => {
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', []);
     const viewModel = makeViewModel();
 
     runInAction(() => {
@@ -435,7 +435,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
   });
 
   it('preserves a restored empty tab state instead of opening the initial conversation', async () => {
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', [
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', [
       makeConversation({ id: 'conversation-1', isInitialConversation: true }),
     ]);
     const viewModel = makeViewModel();
@@ -473,7 +473,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
     workspaceRegistry.acquire('project-1', 'workspace-1', '/tmp/emdash-test-workspace', {
       settings: {},
     } as never);
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', []);
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', []);
     vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
     vi.spyOn(conversations, 'dehydrateConversation').mockResolvedValue();
     const viewModel = makeProvisionedViewModel();
@@ -509,7 +509,7 @@ describe('WorkspaceViewModel default conversation tab', () => {
 describe('WorkspaceViewModel conversation hydration', () => {
   it('hydrates an opened conversation exactly once', async () => {
     const viewModel = makeViewModel();
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', [makeConversation()]);
     const hydrateConversation = vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
     vi.spyOn(conversations, 'dehydrateConversation').mockResolvedValue();
 
@@ -538,7 +538,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
 
   it('dehydrates the last closed conversation and preview replacement', async () => {
     const viewModel = makeViewModel();
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', [
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', [
       makeConversation({ id: 'conversation-1', title: 'Conversation 1' }),
       makeConversation({ id: 'conversation-2', title: 'Conversation 2' }),
     ]);
@@ -578,7 +578,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
 
   it('keeps a conversation hydrated while it remains open in another pane', async () => {
     const viewModel = makeViewModel();
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', [makeConversation()]);
     const hydrateConversation = vi.spyOn(conversations, 'hydrateConversation').mockResolvedValue();
     const dehydrateConversation = vi
       .spyOn(conversations, 'dehydrateConversation')
@@ -643,7 +643,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
 
   it('dehydrates all hydrated conversations on suspend', async () => {
     const viewModel = makeViewModel();
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', [
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', [
       makeConversation({ id: 'conversation-1', title: 'Conversation 1' }),
       makeConversation({ id: 'conversation-2', title: 'Conversation 2' }),
     ]);
@@ -680,7 +680,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
 
   it('dehydrates a stale conversation when its hydrate finishes after the tab closed', async () => {
     const viewModel = makeViewModel();
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', [makeConversation()]);
     const hydrate = deferred();
     vi.spyOn(conversations, 'hydrateConversation').mockReturnValue(hydrate.promise);
     const dehydrateConversation = vi
@@ -716,7 +716,7 @@ describe('WorkspaceViewModel conversation hydration', () => {
 
   it('does not mark failed hydrations as hydrated and can retry', async () => {
     const viewModel = makeViewModel();
-    const conversations = conversationRegistry.acquire('task-1', 'project-1', [makeConversation()]);
+    const conversations = conversationRegistry.acquire('project-1', 'task-1', [makeConversation()]);
     const hydrateConversation = vi
       .spyOn(conversations, 'hydrateConversation')
       .mockRejectedValueOnce(new Error('hydrate failed'))
@@ -785,7 +785,7 @@ describe('WorkspaceViewModel tab persistence adapter', () => {
   });
 
   it('gates default-conversation auto-open when tab state is restored', () => {
-    const conversations = conversationRegistry.acquire(PERSISTOR_TASK_ID, 'project-1', [
+    const conversations = conversationRegistry.acquire('project-1', PERSISTOR_TASK_ID, [
       makeConversation({
         id: 'conversation-1',
         isInitialConversation: true,
@@ -820,7 +820,7 @@ describe('WorkspaceViewModel tab persistence adapter', () => {
 
     expect(conversationTabIds(viewModel)).toHaveLength(0);
     viewModel.dispose();
-    conversationRegistry.release(PERSISTOR_TASK_ID);
+    conversationRegistry.release('project-1', PERSISTOR_TASK_ID);
   });
 
   it('eager-writes dedicated tabs key when migrating from legacy aggregate', () => {

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.test.ts
@@ -209,14 +209,14 @@ function makeTerminalManager({
 }
 
 function terminalRegistryEntries(): {
-  set(taskId: string, manager: TerminalManagerStore): void;
-  delete(taskId: string): boolean;
+  set(key: string, manager: TerminalManagerStore): void;
+  delete(key: string): boolean;
 } {
   return (
     terminalRegistry as unknown as {
       entries: {
-        set(taskId: string, manager: TerminalManagerStore): void;
-        delete(taskId: string): boolean;
+        set(key: string, manager: TerminalManagerStore): void;
+        delete(key: string): boolean;
       };
     }
   ).entries;

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -115,7 +115,7 @@ export class WorkspaceViewModel implements ILifecycle {
         });
       },
     });
-    this._seeder = new DefaultConversationSeeder(this.taskId, this.paneLayout);
+    this._seeder = new DefaultConversationSeeder(projectId, this.taskId, this.paneLayout);
     this.terminalTabs = new TerminalTabViewStore(() => terminalRegistry.get(this.taskId) ?? null);
     this.editorView = new EditorViewStore(this.paneLayout, taskData.projectId, workspaceId);
 

--- a/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/stores/workspace-view-model.tsx
@@ -116,7 +116,9 @@ export class WorkspaceViewModel implements ILifecycle {
       },
     });
     this._seeder = new DefaultConversationSeeder(projectId, this.taskId, this.paneLayout);
-    this.terminalTabs = new TerminalTabViewStore(() => terminalRegistry.get(this.taskId) ?? null);
+    this.terminalTabs = new TerminalTabViewStore(
+      () => terminalRegistry.get(projectId, this.taskId) ?? null
+    );
     this.editorView = new EditorViewStore(this.paneLayout, taskData.projectId, workspaceId);
 
     makeAutoObservable(this, {
@@ -258,7 +260,7 @@ export class WorkspaceViewModel implements ILifecycle {
 
     const closeEmptyTerminalDrawerDisposer = reaction(
       () => {
-        const terminals = terminalRegistry.get(this.taskId);
+        const terminals = terminalRegistry.get(taskData.projectId, this.taskId);
         return {
           isDrawerOpen: this.isTerminalDrawerOpen,
           isCreatingTerminal: this._isCreatingTerminal,
@@ -425,7 +427,10 @@ export class WorkspaceViewModel implements ILifecycle {
 
     this._isCreatingTerminal = true;
     try {
-      const terminal = await terminalRegistry.get(this.taskId)?.createDefaultTerminal(shell);
+      const projectId = (this._taskStore.data as Task).projectId;
+      const terminal = await terminalRegistry
+        .get(projectId, this.taskId)
+        ?.createDefaultTerminal(shell);
       if (!terminal) return undefined;
       return terminal.id;
     } catch (error) {

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-view-context.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-view-context.tsx
@@ -93,8 +93,8 @@ export function useWorkspaceViewModel(): WorkspaceViewModel {
 
 /** Returns the ConversationManagerStore for the task. Throws if not registered. */
 export function useConversations(): ConversationManagerStore {
-  const { taskId } = useTaskViewContext();
-  const mgr = getConversationsForTask(taskId);
+  const { projectId, taskId } = useTaskViewContext();
+  const mgr = getConversationsForTask(projectId, taskId);
   if (!mgr) {
     throw new Error('useConversations: task is not registered (no conversation manager)');
   }

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-view-context.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-view-context.tsx
@@ -103,8 +103,8 @@ export function useConversations(): ConversationManagerStore {
 
 /** Returns the TerminalManagerStore for the task. Throws if not registered. */
 export function useTerminals(): TerminalManagerStore {
-  const { taskId } = useTaskViewContext();
-  const mgr = getTerminalsForTask(taskId);
+  const { projectId, taskId } = useTaskViewContext();
+  const mgr = getTerminalsForTask(projectId, taskId);
   if (!mgr) {
     throw new Error('useTerminals: task is not registered (no terminal manager)');
   }

--- a/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-provider.tsx
@@ -128,7 +128,7 @@ const TerminalTabBarItemDragPreview = observer(function TerminalTabBarItemDragPr
 
 const TerminalTabContent = observer(function TerminalTabContent({ host, ctx }: TabContentProps) {
   const taskCtx = ctx as TaskTabContext;
-  const terminalManager = terminalRegistry.get(taskCtx.taskId);
+  const terminalManager = terminalRegistry.get(taskCtx.projectId, taskCtx.taskId);
   const terminalTabs = host.resolvedTabs.filter(
     (tab): tab is ResolvedTab<TerminalTabResourceView> => tab.kind === 'terminal'
   );
@@ -175,7 +175,7 @@ export const terminalTabProvider: TabProvider<
 
   onBeforeOpen(args: TerminalTabOpenArgs, ctx: TabViewContext): TerminalTabState | null {
     const taskCtx = ctx as TaskTabContext;
-    const terminalManager = terminalRegistry.get(taskCtx.taskId);
+    const terminalManager = terminalRegistry.get(taskCtx.projectId, taskCtx.taskId);
     if (!terminalManager) return null;
     return { terminalId: args.terminalId };
   },
@@ -186,7 +186,7 @@ export const terminalTabProvider: TabProvider<
     ctx: TabViewContext
   ): TerminalTabResourceView {
     const taskCtx = ctx as TaskTabContext;
-    const terminalManager = terminalRegistry.get(taskCtx.taskId);
+    const terminalManager = terminalRegistry.get(taskCtx.projectId, taskCtx.taskId);
     if (!terminalManager) {
       setTimeout(() => void handle.close({ force: true }), 0);
       return new MissingTerminalTabResource(entry.state.terminalId);

--- a/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
@@ -1,12 +1,18 @@
 import { observable, runInAction } from 'mobx';
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { terminalRegistry } from '@renderer/features/tasks/stores/terminal-registry';
+import {
+  TerminalRegistry,
+  terminalRegistry,
+  terminalRegistryKey,
+} from '@renderer/features/tasks/stores/terminal-registry';
 import type { Terminal } from '@shared/core/terminals/terminals';
 import type { TerminalManagerStore, TerminalStore } from './terminal-manager';
 import { TerminalTabViewStore } from './terminal-tab-view-store';
 
 vi.mock('./terminal-manager', () => ({
-  TerminalManagerStore: class {},
+  TerminalManagerStore: class {
+    dispose() {}
+  },
 }));
 
 function makeTerminal(id: string, name = 'Terminal 1'): TerminalStore {
@@ -49,18 +55,36 @@ function registryEntries(): {
   ).entries;
 }
 
+describe('TerminalRegistry', () => {
+  it('keeps stores for the same task id in different projects independent', () => {
+    const registry = new TerminalRegistry();
+    const first = registry.acquire('project-1', 'shared-task');
+    const second = registry.acquire('project-2', 'shared-task');
+
+    expect(second).not.toBe(first);
+    expect(registry.get('project-1', 'shared-task')).toBe(first);
+    expect(registry.get('project-2', 'shared-task')).toBe(second);
+
+    registry.release('project-1', 'shared-task');
+    expect(registry.get('project-2', 'shared-task')).toBe(second);
+    registry.release('project-2', 'shared-task');
+  });
+});
+
 describe('TerminalTabViewStore', () => {
   afterEach(() => {
-    terminalRegistry.release('task-1');
-    registryEntries().delete('task-1');
+    terminalRegistry.release('project-1', 'task-1');
+    registryEntries().delete(terminalRegistryKey('project-1', 'task-1'));
   });
 
   it('syncs terminal ids when the terminal manager becomes available after construction', () => {
     const terminals = observable.map<string, TerminalStore>();
-    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    const view = new TerminalTabViewStore(
+      () => terminalRegistry.get('project-1', 'task-1') ?? null
+    );
 
     runInAction(() => {
-      registryEntries().set('task-1', makeManager(terminals));
+      registryEntries().set(terminalRegistryKey('project-1', 'task-1'), makeManager(terminals));
       terminals.set('terminal-2', makeTerminal('terminal-2', 'Terminal 2'));
     });
 
@@ -73,9 +97,11 @@ describe('TerminalTabViewStore', () => {
     const terminals = observable.map<string, TerminalStore>();
     terminals.set('terminal-1', makeTerminal('terminal-1', 'Terminal 1'));
     terminals.set('terminal-2', makeTerminal('terminal-2', 'Terminal 2'));
-    registryEntries().set('task-1', makeManager(terminals));
+    registryEntries().set(terminalRegistryKey('project-1', 'task-1'), makeManager(terminals));
 
-    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    const view = new TerminalTabViewStore(
+      () => terminalRegistry.get('project-1', 'task-1') ?? null
+    );
     view.restoreSnapshot({
       tabOrder: ['terminal-2'],
       activeTabId: 'terminal-2',
@@ -91,9 +117,11 @@ describe('TerminalTabViewStore', () => {
     const terminals = observable.map<string, TerminalStore>();
     terminals.set('terminal-1', makeTerminal('terminal-1', 'Terminal 1'));
     terminals.set('terminal-2', makeTerminal('terminal-2', 'Terminal 2'));
-    registryEntries().set('task-1', makeManager(terminals));
+    registryEntries().set(terminalRegistryKey('project-1', 'task-1'), makeManager(terminals));
 
-    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    const view = new TerminalTabViewStore(
+      () => terminalRegistry.get('project-1', 'task-1') ?? null
+    );
     view.restoreSnapshot({
       tabOrder: ['deleted-terminal'],
       activeTabId: 'deleted-terminal',
@@ -106,7 +134,9 @@ describe('TerminalTabViewStore', () => {
   });
 
   it('reconciles a restored snapshot after the terminal manager loads later', () => {
-    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    const view = new TerminalTabViewStore(
+      () => terminalRegistry.get('project-1', 'task-1') ?? null
+    );
     view.restoreSnapshot({
       tabOrder: ['deleted-terminal'],
       activeTabId: 'deleted-terminal',
@@ -116,7 +146,7 @@ describe('TerminalTabViewStore', () => {
     terminals.set('terminal-1', makeTerminal('terminal-1', 'Terminal 1'));
 
     runInAction(() => {
-      registryEntries().set('task-1', makeManager(terminals));
+      registryEntries().set(terminalRegistryKey('project-1', 'task-1'), makeManager(terminals));
     });
 
     expect(view.tabOrder).toEqual(['terminal-1']);
@@ -128,9 +158,11 @@ describe('TerminalTabViewStore', () => {
   it('clears stale restored ids when an empty terminal list finishes loading', () => {
     const terminals = observable.map<string, TerminalStore>();
     const manager = makeLoadingManager(terminals);
-    registryEntries().set('task-1', manager);
+    registryEntries().set(terminalRegistryKey('project-1', 'task-1'), manager);
 
-    const view = new TerminalTabViewStore(() => terminalRegistry.get('task-1') ?? null);
+    const view = new TerminalTabViewStore(
+      () => terminalRegistry.get('project-1', 'task-1') ?? null
+    );
     view.restoreSnapshot({
       tabOrder: ['deleted-terminal'],
       activeTabId: 'deleted-terminal',

--- a/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/terminals/terminal-tab-view-store.test.ts
@@ -42,14 +42,14 @@ function makeLoadingManager(terminals: TerminalManagerStore['terminals']): Termi
 }
 
 function registryEntries(): {
-  set(taskId: string, manager: TerminalManagerStore): void;
-  delete(taskId: string): boolean;
+  set(key: string, manager: TerminalManagerStore): void;
+  delete(key: string): boolean;
 } {
   return (
     terminalRegistry as unknown as {
       entries: {
-        set(taskId: string, manager: TerminalManagerStore): void;
-        delete(taskId: string): boolean;
+        set(key: string, manager: TerminalManagerStore): void;
+        delete(key: string): boolean;
       };
     }
   ).entries;

--- a/apps/emdash-desktop/src/shared/core/agents/agentEvents.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agentEvents.ts
@@ -41,8 +41,9 @@ export type SoundEvent = 'needs_attention' | 'task_complete';
 
 export interface AgentSessionExited {
   conversationId: string;
+  projectId: string;
   taskId: string;
 }
 
-/** Emitted when an agent PTY session exits. Topic = taskId. */
+/** Emitted when an agent PTY session exits. */
 export const agentSessionExitedChannel = defineEvent<AgentSessionExited>('agent:session-exited');


### PR DESCRIPTION
### Description

Add a hover action to stop active task runs from the automation overview. ACP sessions are stopped through the runtime client so queued prompts cannot resume, while PTY sessions are stopped through the existing session controller and reset to an idle status.

### Checks

- `pnpm run format:check`
- `pnpm run lint`
- `pnpm run typecheck`
- Focused Vitest coverage: 40 tests passed across the automation stop action, PTY controller, and ACP queue/state-machine behavior

The workspace-wide `pnpm run test` still reports failures in untouched runtime, UI, plugins, and chat UI paths; the branch-focused suites above pass.

### Related issues

ENG-1860

### Screenshot/Recording (if applicable)

https://cap.link/vh3qntxc91drz1j

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>
