### PR TITLE
fix(tasks): render icons for every issue mention

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.test.ts
@@ -330,4 +330,31 @@ describe('InitialConversationField', () => {
       })
     );
   });
+
+  it('renders provider icons for every issue mention', async () => {
+    const linkedIssue: LinkedIssue = {
+      provider: 'linear',
+      identifier: 'ENG-123',
+      displayIdentifier: 'ENG-123',
+      title: 'Fix flaky tests',
+      url: 'https://linear.app/emdash/issue/ENG-123/fix-flaky-tests',
+    };
+
+    await renderField({ linkedIssue, includeIssueContextByDefault: true });
+
+    const renderMentionIcon = chatComposerProps().renderMentionIcon;
+    const firstIcon = renderMentionIcon?.({
+      id: 'issue:linear:ENG-123',
+      label: 'issue:linear:ENG-123',
+      kind: 'issue',
+    });
+    const secondIcon = renderMentionIcon?.({
+      id: 'issue:linear:ENG-456',
+      label: 'issue:linear:ENG-456',
+      kind: 'issue',
+    });
+
+    expect(firstIcon).toMatchObject({ props: { provider: 'linear' } });
+    expect(secondIcon).toMatchObject({ props: { provider: 'linear' } });
+  });
 });

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -25,7 +25,11 @@ import {
   agentSupportsAutoApprove,
   type AgentCapabilities,
 } from '@shared/core/agents/agent-payload';
-import { extractIssueMentionTargets, issueMentionToken } from '@shared/core/issues/issue-context';
+import {
+  extractIssueMentionTargets,
+  issueMentionToken,
+  parseIssueMentionToken,
+} from '@shared/core/issues/issue-context';
 import type { LinkedIssue } from '@shared/core/linked-issue';
 import { buildIssueContextText } from '../context-bar/context-actions';
 import { appendInitialConversationText } from '../create-task-modal/initial-conversation-text';
@@ -251,16 +255,12 @@ export function InitialConversationField({
     }
   }, [linkedIssueMention, state.issueContext, state.prompt]);
 
-  const renderMentionIcon = useCallback<RenderMentionIcon>(
-    ({ id, kind }) => {
-      if (kind !== 'issue') return null;
-      if (!linkedIssue || id !== issueMentionToken(linkedIssue.provider, linkedIssue.identifier)) {
-        return null;
-      }
-      return <IntegrationIcon provider={linkedIssue.provider} size={12} />;
-    },
-    [linkedIssue]
-  );
+  const renderMentionIcon = useCallback<RenderMentionIcon>(({ id, kind }) => {
+    if (kind !== 'issue') return null;
+    const target = parseIssueMentionToken(id);
+    if (!target) return null;
+    return <IntegrationIcon provider={target.provider} size={12} />;
+  }, []);
 
   const querySlashItems = useCallback(
     async (query: string): Promise<CommandItem[]> => {


### PR DESCRIPTION
### Description

Render the provider icon for every canonical issue mention in the initial conversation field. The resolver previously recognized only the primary linked issue, so a second Linear issue fell back to the generic issue icon

### Related issues

[ENG-1857](https://linear.app/general-action/issue/ENG-1857/second-issue-icon-renders-incorrectly-with-two-issues-in-chat-context)

### Screenshot
<img width="410" height="115" alt="image" src="https://github.com/user-attachments/assets/fa3af952-8b34-4ae0-8010-14e3cdfeabc4" />

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not affected
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>
