### PR TITLE
fix(acp): apply provider env vars from settings to ACP sessions

### DIFF
--- a/apps/emdash-desktop/src/main/core/acp/runtime-process/host.ts
+++ b/apps/emdash-desktop/src/main/core/acp/runtime-process/host.ts
@@ -61,14 +61,16 @@ function decorateAcpRuntimeHandle(handle: WorkerHandle<AcpApiContract>): AcpRunt
  * Injects the user's per-provider environment variables (configured in Settings and
  * stored in the app DB) into ACP session-start inputs. The ACP runtime worker has no
  * DB access, so this main-process choke point resolves the config and threads it to
- * the provider spawn. User-configured values take precedence over any inline env.
+ * the provider spawn. Any env on the incoming (renderer-facing) input is discarded and
+ * replaced, so the spawn environment can only come from trusted main-process settings.
  */
 function withProviderEnv(client: AcpRuntimeClient): AcpRuntimeClient {
   const enrich = async <T extends { input: AcpStartInputWire }>(input: T): Promise<T> => {
     const providerConfig = await providerOverrideSettings.getItem(input.input.providerId);
-    const customEnv = providerConfig?.env;
-    if (!customEnv || Object.keys(customEnv).length === 0) return input;
-    return { ...input, input: { ...input.input, env: { ...input.input.env, ...customEnv } } };
+    // Spawn env must originate solely from the trusted main-process settings. Overwrite
+    // (never merge) any env supplied by the renderer-facing caller so the renderer cannot
+    // inject variables such as PATH/HOME/proxy vars into provider process spawning.
+    return { ...input, input: { ...input.input, env: providerConfig?.env } };
   };
   return {
     ...client,

--- a/apps/emdash-desktop/src/main/core/acp/runtime-process/host.ts
+++ b/apps/emdash-desktop/src/main/core/acp/runtime-process/host.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { acpApiContract, type AcpApiContract } from '@emdash/core/acp';
+import { acpApiContract, type AcpApiContract, type AcpStartInputWire } from '@emdash/core/acp';
 import {
   exposeWireToWindows,
   forwardController,
@@ -10,6 +10,7 @@ import { lazyWorker, type WorkerHandle } from '@emdash/wire/worker';
 import { app, ipcMain, MessageChannelMain } from 'electron';
 import { appScope } from '@main/app/app-scope';
 import { setSessionId } from '@main/core/conversations/set-session-id';
+import { providerOverrideSettings } from '@main/core/settings/provider-settings-service';
 import { log } from '@main/lib/logger';
 import { desktopWorkerPath } from '@main/worker-manifest';
 
@@ -31,7 +32,8 @@ const acpWorker = lazyWorker(
     },
   }),
   {
-    onSpawned: (handle) => installRendererWire(withSessionIdPersistence(handle.client)),
+    onSpawned: (handle) =>
+      installRendererWire(withSessionIdPersistence(withProviderEnv(handle.client))),
   }
 );
 
@@ -52,7 +54,27 @@ export async function disposeAcpRuntimeProcess(): Promise<void> {
 }
 
 function decorateAcpRuntimeHandle(handle: WorkerHandle<AcpApiContract>): AcpRuntimeHandle {
-  return { ...handle, client: withSessionIdPersistence(handle.client) };
+  return { ...handle, client: withSessionIdPersistence(withProviderEnv(handle.client)) };
+}
+
+/**
+ * Injects the user's per-provider environment variables (configured in Settings and
+ * stored in the app DB) into ACP session-start inputs. The ACP runtime worker has no
+ * DB access, so this main-process choke point resolves the config and threads it to
+ * the provider spawn. User-configured values take precedence over any inline env.
+ */
+function withProviderEnv(client: AcpRuntimeClient): AcpRuntimeClient {
+  const enrich = async <T extends { input: AcpStartInputWire }>(input: T): Promise<T> => {
+    const providerConfig = await providerOverrideSettings.getItem(input.input.providerId);
+    const customEnv = providerConfig?.env;
+    if (!customEnv || Object.keys(customEnv).length === 0) return input;
+    return { ...input, input: { ...input.input, env: { ...input.input.env, ...customEnv } } };
+  };
+  return {
+    ...client,
+    startSession: async (input, meta) => client.startSession(await enrich(input), meta),
+    resumeSession: async (input, meta) => client.resumeSession(await enrich(input), meta),
+  };
 }
 
 function withSessionIdPersistence(client: AcpRuntimeClient): AcpRuntimeClient {

--- a/packages/core/src/acp/api/commands.ts
+++ b/packages/core/src/acp/api/commands.ts
@@ -13,6 +13,7 @@ export const acpStartInputSchema = z.object({
   sessionId: z.string().nullable(),
   model: z.string().nullable(),
   initialQueue: z.array(promptInputSchema).optional(),
+  env: z.record(z.string(), z.string()).optional(),
 });
 export type AcpStartInputWire = z.infer<typeof acpStartInputSchema>;
 

--- a/packages/core/src/agents/plugins/plugin-host.test.ts
+++ b/packages/core/src/agents/plugins/plugin-host.test.ts
@@ -137,6 +137,41 @@ describe('AgentPluginHost', () => {
     });
   });
 
+  it('builds ACP spawn with allowlisted env merged under caller env', async () => {
+    const buildSpawn = vi.fn(({ cwd, cli }: { cwd: string; cli: string }) => ({
+      command: cli,
+      args: [],
+      cwd,
+      env: { SPAWN_ENV: 'base', ANTHROPIC_API_KEY: 'plugin-default' },
+    }));
+    const host = createHost([
+      plugin({
+        acp: { kind: 'supported' },
+        behavior: { acp: { buildSpawn } as unknown as IAcpBehavior },
+      }),
+    ]);
+
+    const result = await host.buildAcpSpawn('test', {
+      cwd: '/work',
+      env: { ANTHROPIC_API_KEY: 'user-key', ANTHROPIC_BASE_URL: 'https://proxy' },
+    });
+
+    expect(result).toMatchObject({
+      success: true,
+      data: {
+        cwd: '/work',
+        env: expect.objectContaining({
+          HOME: '/home/test',
+          PATH: '/bin',
+          SPAWN_ENV: 'base',
+          ANTHROPIC_BASE_URL: 'https://proxy',
+          // caller (user settings) env wins over allowlist and plugin defaults
+          ANTHROPIC_API_KEY: 'user-key',
+        }),
+      },
+    });
+  });
+
   it('binds machine dependencies for auth status checks', async () => {
     const checkStatus = vi.fn(async () => ({ kind: 'authenticated' as const, account: 'ada' }));
     const host = createHost([

--- a/packages/core/src/agents/plugins/plugin-host.ts
+++ b/packages/core/src/agents/plugins/plugin-host.ts
@@ -251,7 +251,7 @@ export class AgentPluginHost {
 
   async buildAcpSpawn(
     providerId: string,
-    ctx: { cwd: string }
+    ctx: { cwd: string; env?: Record<string, string> }
   ): Promise<Result<AgentHostAcpSpawn, AgentHostError>> {
     const provider = this.resolveAcp(providerId);
     if (!provider) return err({ type: 'capability-unsupported', providerId, capability: 'acp' });
@@ -264,7 +264,9 @@ export class AgentPluginHost {
     });
     return ok({
       ...spawn,
-      env: { ...spawnContext.data.agentEnv, ...spawn.env },
+      // User-configured provider env (from Settings) wins over the allowlisted
+      // agent env and any plugin defaults, mirroring the PTY path's providerVars.
+      env: { ...spawnContext.data.agentEnv, ...spawn.env, ...(ctx.env ?? {}) },
       cwd: ctx.cwd,
     });
   }

--- a/packages/runtime/src/acp-agents/connection/source.ts
+++ b/packages/runtime/src/acp-agents/connection/source.ts
@@ -44,6 +44,7 @@ export interface AcquireAcpConnectionInput {
   providerId: string;
   workspaceId: string;
   cwd: string;
+  env?: Record<string, string>;
   behavior: IAcpBehavior;
   buildClient: (agent: AcpAgentApi, context: AcpConnectionContext) => Client;
 }
@@ -90,7 +91,10 @@ async function provisionAcpConnection(
   input: AcquireAcpConnectionInput,
   scope: Scope
 ): Promise<PooledAcpProcess> {
-  const spawn = await deps.agentHost.buildAcpSpawn(input.providerId, { cwd: input.cwd });
+  const spawn = await deps.agentHost.buildAcpSpawn(input.providerId, {
+    cwd: input.cwd,
+    env: input.env,
+  });
   if (!spawn.success) {
     throw acpErr.spawnFailed(toSerializedError(new Error(agentHostErrorMessage(spawn.error))))
       .error;

--- a/packages/runtime/src/acp-agents/runtime/session-manager.ts
+++ b/packages/runtime/src/acp-agents/runtime/session-manager.ts
@@ -133,6 +133,7 @@ export class SessionManager implements InboundRouter {
         providerId: input.providerId,
         workspaceId: input.workspaceId,
         cwd: input.cwd,
+        env: input.env,
         behavior: binding.behavior,
         buildClient: (_agent, context): Client => buildAgentClient(context, this, this.ports),
       },


### PR DESCRIPTION
### Description

The new ACP-based chat UI ignored the per-provider environment variables configured in **Settings** (`providerConfigs`), so prompts failed for anyone relying on custom vars (e.g. `CLAUDE_CONFIG_DIR`, `ANTHROPIC_BASE_URL`).

Root cause: the ACP path built the provider process environment only from an allowlist of the runtime worker's `process.env` (`buildAllowlistedAgentEnv`) and never read the user's provider config from the DB — unlike the PTY path, which reads `providerOverrideSettings` and injects it via `providerVars` (`pty-env.ts`). The ACP runtime worker has no DB access, so the values never reached the spawned CLI.

Fix: thread the user's provider env from the main process (the only choke point with DB access) through the ACP start input into `buildAcpSpawn`, merging it **last** so it takes precedence over the allowlisted agent env and plugin defaults — mirroring the PTY `providerVars` behaviour. Secrets stay in the main process and never round-trip through the renderer.

Notable changes:
- `packages/core/src/agents/plugins/plugin-host.ts` — `buildAcpSpawn` accepts and merges caller-supplied `env` last.
- `packages/core/src/acp/api/commands.ts` — add optional `env` to `acpStartInputSchema`.
- `packages/runtime/src/acp-agents/connection/source.ts` + `runtime/session-manager.ts` — thread `env` through connection acquisition into the spawn.
- `apps/emdash-desktop/src/main/core/acp/runtime-process/host.ts` — resolve `providerOverrideSettings` in the main process and inject the provider env into ACP `startSession`/`resumeSession` inputs.

### Related issues

_None linked._

### Testing

- `pnpm --filter @emdash/core --filter @emdash/runtime run typecheck` — pass
- `pnpm --filter @emdash/emdash-desktop run typecheck` — pass
- `pnpm --filter @emdash/core --filter @emdash/runtime run lint` + `oxfmt` on changed files — pass
- `pnpm --filter @emdash/core run test src/agents/plugins/plugin-host.test.ts` — pass (added a test asserting user env wins over allowlist/plugin defaults in `buildAcpSpawn`)
- Manual: ran the desktop dev build against a snapshot of a real prod DB (`EMDASH_DB_FILE=… pnpm run dev`) with `CLAUDE_CONFIG_DIR` configured in Settings — the ACP chat session now applies it and prompts succeed.

### Screenshot/Recording (if applicable)
Claude Additional Settings
<img width="511" height="228" alt="Bildschirmfoto 2026-07-14 um 14 04 34" src="https://github.com/user-attachments/assets/b1a29f1e-6b4d-44f4-ad49-0ff56296bc35" />

Dont get respected by new chat UI
<img width="1558" height="164" alt="Bildschirmfoto 2026-07-14 um 14 04 19" src="https://github.com/user-attachments/assets/0c707292-f516-486a-b926-6dfa74089cae" />

After the fix
<img width="820" height="258" alt="Bildschirmfoto 2026-07-14 um 14 19 55" src="https://github.com/user-attachments/assets/8a6e9088-f5ae-4413-818e-e24e291a8725" />



<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>