### PR TITLE
feat(browser): simplify load error page

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/browser/browser-load-error.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-load-error.test.ts
@@ -29,10 +29,6 @@ describe('describeBrowserLoadError', () => {
 
     expect(presentation.heading).toBe("This site can't be reached");
     expect(presentation.detail).toBe("sdfg.com's server IP address could not be found.");
-    expect(presentation.suggestions).toEqual([
-      'Checking the connection',
-      'Checking the proxy, firewall, and DNS configuration',
-    ]);
   });
 
   it('maps a refused connection from the numeric code alone', () => {
@@ -51,7 +47,7 @@ describe('describeBrowserLoadError', () => {
     );
 
     expect(presentation.heading).toBe('No internet');
-    expect(presentation.suggestions).toContain('Reconnecting to Wi-Fi');
+    expect(presentation.detail).toBe('You appear to be offline.');
   });
 
   it('falls back to a human description for unknown codes', () => {

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-load-error.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-load-error.ts
@@ -3,7 +3,6 @@ import type { BrowserLoadError } from '@shared/browser';
 export interface BrowserLoadErrorPresentation {
   heading: string;
   detail: string;
-  suggestions: string[];
 }
 
 const ERROR_CONSTANT_PATTERN = /^(?:net::)?(err_[a-z0-9_]+)$/i;
@@ -31,8 +30,6 @@ const ERROR_CODE_CONSTANTS: Record<number, string> = {
   [-501]: 'ERR_INSECURE_RESPONSE',
 };
 
-const CHECK_CONNECTION = 'Checking the connection';
-const CHECK_PROXY = 'Checking the proxy, firewall, and DNS configuration';
 const UNREACHABLE = "This site can't be reached";
 
 export function browserLoadErrorConstant(error: BrowserLoadError): string | null {
@@ -64,20 +61,17 @@ export function describeBrowserLoadError(
       return {
         heading: UNREACHABLE,
         detail: `${host}'s server IP address could not be found.`,
-        suggestions: [CHECK_CONNECTION, CHECK_PROXY],
       };
     case 'ERR_CONNECTION_REFUSED':
       return {
         heading: UNREACHABLE,
         detail: `${host} refused to connect.`,
-        suggestions: [CHECK_CONNECTION, CHECK_PROXY],
       };
     case 'ERR_TIMED_OUT':
     case 'ERR_CONNECTION_TIMED_OUT':
       return {
         heading: UNREACHABLE,
         detail: `${host} took too long to respond.`,
-        suggestions: [CHECK_CONNECTION, CHECK_PROXY],
       };
     case 'ERR_CONNECTION_RESET':
     case 'ERR_CONNECTION_CLOSED':
@@ -85,32 +79,27 @@ export function describeBrowserLoadError(
       return {
         heading: UNREACHABLE,
         detail: `The connection to ${host} was interrupted.`,
-        suggestions: [CHECK_CONNECTION, CHECK_PROXY],
       };
     case 'ERR_ADDRESS_UNREACHABLE':
       return {
         heading: UNREACHABLE,
         detail: `${host} is unreachable.`,
-        suggestions: [CHECK_CONNECTION, CHECK_PROXY],
       };
     case 'ERR_INTERNET_DISCONNECTED':
       return {
         heading: 'No internet',
         detail: 'You appear to be offline.',
-        suggestions: ['Checking the network cables, modem, and router', 'Reconnecting to Wi-Fi'],
       };
     case 'ERR_NETWORK_CHANGED':
       return {
         heading: UNREACHABLE,
         detail: 'Your network connection changed.',
-        suggestions: [CHECK_CONNECTION],
       };
     case 'ERR_SSL_PROTOCOL_ERROR':
     case 'ERR_INSECURE_RESPONSE':
       return {
         heading: "This site can't provide a secure connection",
         detail: `${host} sent an invalid response.`,
-        suggestions: [CHECK_PROXY],
       };
     case 'ERR_CERT_COMMON_NAME_INVALID':
     case 'ERR_CERT_DATE_INVALID':
@@ -118,13 +107,11 @@ export function describeBrowserLoadError(
       return {
         heading: 'Your connection is not private',
         detail: `${host}'s security certificate is not trusted.`,
-        suggestions: [],
       };
     case 'ERR_INVALID_URL':
       return {
         heading: UNREACHABLE,
         detail: "The web address isn't valid.",
-        suggestions: [],
       };
     default: {
       const description = error.description.trim();
@@ -136,7 +123,6 @@ export function describeBrowserLoadError(
       return {
         heading: UNREACHABLE,
         detail,
-        suggestions: [CHECK_CONNECTION, CHECK_PROXY],
       };
     }
   }

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
@@ -97,4 +97,37 @@ describe('BrowserPane', () => {
     expect(webview.getAttribute('src')).toBe('https://linkedin.com/');
     expect(loadURL).not.toHaveBeenCalled();
   });
+
+  it('renders a minimal load error state', async () => {
+    const session = browserSessionStore.createSession({
+      browserId: 'browser-1',
+      projectId: 'project-1',
+      workspaceId: 'workspace-1',
+      taskId: 'task-1',
+      initialUrl: 'https://missing.invalid/',
+    });
+    browserSessionStore.updateSession(session.browserId, {
+      isLoading: false,
+      loadError: {
+        code: -105,
+        description: 'net::ERR_NAME_NOT_RESOLVED',
+        url: 'https://missing.invalid/',
+      },
+    });
+
+    await act(async () => {
+      root.render(
+        React.createElement(BrowserPane, { browserId: session.browserId, visible: true })
+      );
+    });
+
+    expect(container.querySelector('h1')?.textContent).toBe("This site can't be reached");
+    expect(container.querySelector('p')?.textContent).toBe(
+      "missing.invalid's server IP address could not be found. (ERR_NAME_NOT_RESOLVED)"
+    );
+    expect(container.textContent).not.toContain('Try:');
+    expect(
+      Array.from(container.querySelectorAll('button')).map((button) => button.textContent)
+    ).toEqual(['', 'Reload', 'Open externally']);
+  });
 });

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.test.ts
@@ -127,7 +127,9 @@ describe('BrowserPane', () => {
     );
     expect(container.textContent).not.toContain('Try:');
     expect(
-      Array.from(container.querySelectorAll('button')).map((button) => button.textContent)
-    ).toEqual(['', 'Reload', 'Open externally']);
+      Array.from(container.querySelectorAll('button'))
+        .map((button) => button.textContent)
+        .filter(Boolean)
+    ).toEqual(['Reload', 'Open externally']);
   });
 });

--- a/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
+++ b/apps/emdash-desktop/src/renderer/features/browser/browser-pane.tsx
@@ -1,9 +1,7 @@
-import { ExternalLink, RotateCcw } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { usePaneContext } from '@renderer/features/tabs/pane-context';
 import { usePreviewServers } from '@renderer/features/tasks/task-view-context';
-import { EmdashLogo } from '@renderer/lib/emdash-logo';
 import { events, rpc } from '@renderer/lib/ipc';
 import { Button } from '@renderer/lib/ui/button';
 import { normalizeBrowserUrl, normalizeBrowserZoomFactor } from '@shared/browser';
@@ -12,7 +10,6 @@ import { browserControlsRegistry } from './browser-controls-registry';
 import {
   browserLoadErrorCode,
   describeBrowserLoadError,
-  hostLabel,
   type BrowserLoadErrorPresentation,
 } from './browser-load-error';
 import { decideBrowserReload } from './browser-navigation-controls';
@@ -298,31 +295,6 @@ export const BrowserPane = observer(function BrowserPane({
   );
 });
 
-function BrowserLoadErrorDetail({
-  detail,
-  host,
-  url,
-}: {
-  detail: string;
-  host: string;
-  url: string;
-}) {
-  if (detail.startsWith(host)) {
-    return (
-      <p className="text-base leading-relaxed text-foreground-muted" title={url}>
-        <span className="font-medium text-foreground">{host}</span>
-        {detail.slice(host.length)}
-      </p>
-    );
-  }
-
-  return (
-    <p className="text-base leading-relaxed text-foreground-muted" title={url}>
-      {detail}
-    </p>
-  );
-}
-
 function BrowserLoadErrorView({
   presentation,
   code,
@@ -338,45 +310,25 @@ function BrowserLoadErrorView({
   onReload: () => void;
   onOpenExternal: () => void;
 }) {
-  const host = hostLabel(url);
-
   return (
-    <div className="flex h-full min-h-0 items-center justify-center overflow-auto px-10 py-14">
-      <div className="flex w-full max-w-lg flex-col gap-7">
-        <EmdashLogo height={18} className="text-foreground" />
-        <div className="flex flex-col gap-3">
-          <h1 className="text-2xl font-medium tracking-tight text-foreground">
-            {presentation.heading}
-          </h1>
-          <BrowserLoadErrorDetail detail={presentation.detail} host={host} url={url} />
-        </div>
-        {presentation.suggestions.length > 0 && (
-          <div className="flex flex-col gap-2.5">
-            <span className="text-sm font-medium text-foreground">Try:</span>
-            <ul className="flex list-disc flex-col gap-2 pl-5 text-sm leading-relaxed text-foreground-muted marker:text-foreground-tertiary-muted">
-              {presentation.suggestions.map((suggestion) => (
-                <li key={suggestion}>{suggestion}</li>
-              ))}
-            </ul>
-          </div>
-        )}
-        {code && (
-          <div className="font-mono text-xs tracking-wide text-foreground-tertiary-muted">
-            {code}
-          </div>
-        )}
-        <div className="flex flex-wrap items-center gap-2.5 pt-1">
-          <Button type="button" onClick={onReload}>
-            <RotateCcw className="size-4" />
+    <div className="flex h-full min-h-0 items-center justify-center overflow-auto p-8">
+      <div className="flex max-w-sm flex-col items-center gap-2 text-center">
+        <h1 className="text-base font-medium text-foreground">{presentation.heading}</h1>
+        <p className="text-sm text-foreground-muted" title={url}>
+          {presentation.detail}
+          {code && <span className="text-foreground-tertiary-muted"> ({code})</span>}
+        </p>
+        <div className="mt-2 flex flex-wrap items-center justify-center gap-2">
+          <Button type="button" variant="outline" size="sm" onClick={onReload}>
             Reload
           </Button>
           <Button
             type="button"
-            variant="secondary"
+            variant="outline"
+            size="sm"
             disabled={!canOpenExternal}
             onClick={onOpenExternal}
           >
-            <ExternalLink className="size-4" />
             Open externally
           </Button>
         </div>


### PR DESCRIPTION
### Description

Simplifies the in-app browser load error page into a compact centered state with neutral actions. Removes the Emdash logo, troubleshooting list, standalone diagnostic block, and decorative icons while preserving Reload and Open externally behavior.

### Related issues

[ENG-1849](https://linear.app/general-action/issue/ENG-1849/make-the-page-not-found-page-more-basic)

### Screenshot
<img width="1082" height="904" alt="image" src="https://github.com/user-attachments/assets/4d96e57b-90ac-4c11-a41e-0f32398e27b1" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or confirmed none were needed
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>
