### PR TITLE
fix(ui): center macOS Shift key in shortcut keycaps

### DIFF
--- a/apps/emdash-desktop/src/renderer/lib/ui/shortcut.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/ui/shortcut.tsx
@@ -1,4 +1,5 @@
 import { detectPlatform, parseHotkey, type Hotkey } from '@tanstack/react-hotkeys';
+import { ArrowBigUp } from 'lucide-react';
 import { useMemo } from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import {
@@ -37,6 +38,21 @@ interface ShortcutProps {
   variant?: ShortcutVariant;
 }
 
+function ShortcutKey({ keyName }: { keyName: string }) {
+  if (keyName === 'Shift' && PLATFORM === 'mac') {
+    return <ArrowBigUp aria-hidden="true" className="size-[11px]" strokeWidth={2.25} />;
+  }
+
+  return (
+    <span
+      aria-hidden="true"
+      className={cn('inline-block', getShortcutKeyOpticalAlignClass(keyName))}
+    >
+      {formatShortcutKey(keyName, PLATFORM)}
+    </span>
+  );
+}
+
 /** Display a shortcut when the hotkey string is already resolved. */
 function Shortcut({ hotkey, className, variant = 'text' }: ShortcutProps) {
   const parsed = useMemo(() => {
@@ -66,18 +82,10 @@ function Shortcut({ hotkey, className, variant = 'text' }: ShortcutProps) {
       {keys.map((key, index) =>
         variant === 'keycaps' ? (
           <Kbd key={`${key}-${index}`} aria-hidden="true" className={KEYCAP_KBD_CLASS}>
-            <span className={cn('inline-block', getShortcutKeyOpticalAlignClass(key))}>
-              {formatShortcutKey(key, PLATFORM)}
-            </span>
+            <ShortcutKey keyName={key} />
           </Kbd>
         ) : (
-          <span
-            key={`${key}-${index}`}
-            aria-hidden="true"
-            className={cn('inline-block', getShortcutKeyOpticalAlignClass(key))}
-          >
-            {formatShortcutKey(key, PLATFORM)}
-          </span>
+          <ShortcutKey key={`${key}-${index}`} keyName={key} />
         )
       )}
     </span>


### PR DESCRIPTION
### Description

Replace the font-rendered macOS Shift glyph in shortcuts with a consistently sized Lucide icon. This avoids platform font-metric drift and keeps the Shift symbol optically centered alongside Command and letter keycaps.

The icon remains macOS-only; Windows and Linux continue to render their existing Shift labels.

### Related issues

[ENG-1865](https://linear.app/general-action/issue/ENG-1865/shift-key-is-not-centered-in-keybinds-popover)

### Screenshot/Recording (if applicable)
<img width="67" height="29" alt="Screenshot 2026-07-14 at 18 14 37" src="https://github.com/user-attachments/assets/fe39cfa7-95f1-4193-b535-d0712e843c76" />
<img width="67" height="28" alt="Screenshot 2026-07-14 at 18 14 31" src="https://github.com/user-attachments/assets/62567435-9124-4de9-b450-3508ace5df01" />
<img width="64" height="30" alt="Screenshot 2026-07-14 at 18 14 25" src="https://github.com/user-attachments/assets/0485aef3-f589-4bf6-8279-769f7383f4a2" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are unchanged because this is a visual-only fix
- [x] Existing shortcut-format tests pass; no behavior contract changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>