### PR TITLE
feat(files): add Show in Finder to file tree context menu

### DIFF
--- a/apps/emdash-desktop/src/main/core/app/controller.ts
+++ b/apps/emdash-desktop/src/main/core/app/controller.ts
@@ -52,6 +52,14 @@ export const appController = createRPCController({
       return { success: false, error: error instanceof Error ? error.message : String(error) };
     }
   },
+  showItemInFolder: async (path: string) => {
+    try {
+      await appService.showItemInFolder(path);
+      return { success: true };
+    } catch (error) {
+      return { success: false, error: error instanceof Error ? error.message : String(error) };
+    }
+  },
   readUserFile: async (path: string) => {
     try {
       const result = await appService.readUserFile(path);

--- a/apps/emdash-desktop/src/main/core/app/service.test.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.test.ts
@@ -1,3 +1,5 @@
+import { realpath } from 'node:fs/promises';
+import { homedir, tmpdir } from 'node:os';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
@@ -5,6 +7,7 @@ const mocks = vi.hoisted(() => ({
   getVersion: vi.fn(() => '1.1.27'),
   openExternal: vi.fn(),
   openPath: vi.fn(),
+  showItemInFolder: vi.fn(),
   menuPopup: vi.fn(),
   menuBuildFromTemplate: vi.fn((template: Electron.MenuItemConstructorOptions[]) => ({
     popup: mocks.menuPopup,
@@ -33,6 +36,7 @@ vi.mock('electron', () => ({
   shell: {
     openExternal: mocks.openExternal,
     openPath: mocks.openPath,
+    showItemInFolder: mocks.showItemInFolder,
   },
   Menu: {
     buildFromTemplate: mocks.menuBuildFromTemplate,
@@ -113,6 +117,25 @@ describe('AppService.openIn', () => {
     );
     expect(mocks.openPath).toHaveBeenCalledWith(target);
     expect(mocks.exec).not.toHaveBeenCalled();
+  });
+});
+
+describe('AppService.showItemInFolder', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('reveals the resolved path with Electron shell.showItemInFolder', async () => {
+    await appService.showItemInFolder(homedir());
+
+    expect(mocks.showItemInFolder).toHaveBeenCalledWith(await realpath(homedir()));
+  });
+
+  it('rejects paths outside the user home directory', async () => {
+    await expect(appService.showItemInFolder(tmpdir())).rejects.toThrow(
+      'Path must be inside the user home directory'
+    );
+    expect(mocks.showItemInFolder).not.toHaveBeenCalled();
   });
 });
 

--- a/apps/emdash-desktop/src/main/core/app/service.ts
+++ b/apps/emdash-desktop/src/main/core/app/service.ts
@@ -223,6 +223,11 @@ class AppService implements IInitializable, IDisposable {
     if (errorMessage) throw new Error(errorMessage);
   }
 
+  async showItemInFolder(rawPath: string): Promise<void> {
+    const realPath = await resolveHomeJailedPath(rawPath);
+    shell.showItemInFolder(realPath);
+  }
+
   /**
    * Restricted to the user home directory: terminal output drives these reads,
    * and AI-injected paths must not be a vector for reading e.g. `/etc/passwd`.

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-file-tree.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-file-tree.tsx
@@ -1,3 +1,4 @@
+import { detectPlatform } from '@tanstack/react-hotkeys';
 import { useVirtualizer } from '@tanstack/react-virtual';
 import {
   ChevronDown,
@@ -51,6 +52,14 @@ import { basenameFromAnyPath } from '@shared/path-name';
 import type { FileTabResource } from './stores/file-tab-resource';
 
 const MAX_COPY_FILE_BYTES = 10 * 1024 * 1024;
+
+const PLATFORM = detectPlatform();
+const REVEAL_LABEL =
+  PLATFORM === 'mac'
+    ? 'Show in Finder'
+    : PLATFORM === 'windows'
+      ? 'Show in File Explorer'
+      : 'Show in File Manager';
 
 type ResultLikeError = { message?: string; type?: string; paths?: readonly string[] };
 
@@ -294,6 +303,21 @@ const FileTreeRow = observer(function FileTreeRow({
     }
   };
 
+  const revealInFileManager = async () => {
+    try {
+      const result = await rpc.workspace.files.getAbsolutePath(projectId, workspaceId, node.path);
+      if (!result.success) throw new Error(resultErrorMessage(result.error));
+      const revealed = await rpc.app.showItemInFolder(result.data.path);
+      if (!revealed.success) throw new Error(revealed.error);
+    } catch (error) {
+      toast({
+        title: 'Show failed',
+        description: error instanceof Error ? error.message : 'The item could not be shown.',
+        variant: 'destructive',
+      });
+    }
+  };
+
   const closeDeletedFileTabs = () => {
     for (const { pane } of taskView.paneLayout.groups) {
       for (const tab of pane.resolvedTabs) {
@@ -486,6 +510,12 @@ const FileTreeRow = observer(function FileTreeRow({
           <Copy className="size-4" />
           Copy relative path
         </ContextMenuItem>
+        {!workspace.sshConnectionId && (
+          <ContextMenuItem onClick={() => void revealInFileManager()}>
+            <FolderOpen className="size-4" />
+            {REVEAL_LABEL}
+          </ContextMenuItem>
+        )}
         <ContextMenuSeparator />
         <ContextMenuItem variant="destructive" onClick={confirmDelete}>
           <Trash2 className="size-4" />


### PR DESCRIPTION
### Description

Adds a platform-aware "Show in Finder" / "Show in File Explorer" / "Show in File Manager" item to the Files tab right-click menu. The renderer resolves the absolute path through the workspace-scoped getAbsolutePath RPC, then a new app.showItemInFolder RPC calls Electron's shell.showItemInFolder behind the same home-jail path validation as openPath. Hidden for SSH workspaces since the file does not exist on the local disk.

This feature is a nice have. I'm often creating report files in md formats and this change allows me to quickly show them in finder allowing for copying, sending them to someone etc.

### Related issues

No issue related

### Testing

- App service unit tests: `vitest run src/main/core/app/service.test.ts` — 6 tests passed, including the 2 new `showItemInFolder` ones
- Full desktop app suite: `@emdash/emdash-desktop` test target (node, main-db, migrations, browser, scripts projects) — 315/315 test files passed
- Full workspace suite: root Nx `pnpm run test` — all packages green except 5 pre-existing failures that also exist on `main` and are unrelated to this change (`@emdash/runtime` session-manager ×2, `@emdash/ui` serialize ×1, `@emdash/plugins` Claude ACP ×2)
- Root Nx `pnpm run typecheck` — 9 projects
- Root Nx `pnpm run lint` — 9 projects
- Root Nx `pnpm run format` — 9 projects
- Manual end-to-end check: launched the dev app and verified "Show in Finder" works. Only on macOS.

### Screenshot/Recording (if applicable)

<img width="2780" height="1798" alt="obraz" src="https://github.com/user-attachments/assets/766b616f-e95c-464a-828a-a64579a34786" />
<img width="358" height="364" alt="obraz" src="https://github.com/user-attachments/assets/328275ae-fc02-4318-ba4e-7ceb9f131667" />


<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
