### PR TITLE
feat(automations): add stop task run action

### DIFF
--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
@@ -228,6 +228,15 @@ describe('executeTaskCreate', () => {
     expect(taskService.launch).toHaveBeenCalled();
   });
 
+  it('does not launch a task when stopping wins the launching transition', async () => {
+    vi.mocked(markRunLaunchingTask).mockResolvedValue(null);
+
+    const result = await executeTaskCreate(automation, run, noopStep);
+
+    expect(result).toEqual({ success: false, error: 'manually_stopped' });
+    expect(taskService.launch).not.toHaveBeenCalled();
+  });
+
   it('does not commit a task when the run is stopped during preparation', async () => {
     vi.mocked(getRun).mockResolvedValue({
       ...run,
@@ -270,6 +279,15 @@ describe('executeTaskCreate', () => {
     expect(result.success).toBe(true);
     expect(markRunCreatingConversation).toHaveBeenCalledWith(run.id, expect.any(Number));
     expect(createConversation).toHaveBeenCalled();
+  });
+
+  it('does not create a conversation when stopping wins the creating transition', async () => {
+    vi.mocked(markRunCreatingConversation).mockResolvedValue(null);
+
+    const result = await executeTaskCreate(automation, run, noopStep);
+
+    expect(result).toEqual({ success: false, error: 'manually_stopped' });
+    expect(createConversation).not.toHaveBeenCalled();
   });
 
   it('marks run failed when conversation creation throws', async () => {

--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
@@ -22,7 +22,8 @@ import {
 } from '../run-transitions';
 import { executeTaskCreate } from './taskCreate';
 
-const { mockAcpStartSession } = vi.hoisted(() => ({
+const { mockAcpCancelTurn, mockAcpStartSession } = vi.hoisted(() => ({
+  mockAcpCancelTurn: vi.fn(),
   mockAcpStartSession: vi.fn(),
 }));
 
@@ -59,14 +60,16 @@ vi.mock('@main/core/tasks/operations/createTask', () => ({
   finalizeCreateTask: vi.fn(),
 }));
 vi.mock('@main/core/tasks/task-service', () => ({
-  taskService: { notifyTaskCreated: vi.fn(), launch: vi.fn() },
+  taskService: { notifyTaskCreated: vi.fn(), launch: vi.fn(), teardown: vi.fn() },
 }));
 vi.mock('@main/lib/events', () => ({ events: { emit: vi.fn() } }));
 vi.mock('@main/lib/logger', () => ({
   log: { error: vi.fn(), warn: vi.fn(), info: vi.fn(), child: vi.fn(() => ({ debug: vi.fn() })) },
 }));
 vi.mock('@main/core/acp/controller', () => ({
-  getAcpRuntimeClient: vi.fn(() => Promise.resolve({ startSession: mockAcpStartSession })),
+  getAcpRuntimeClient: vi.fn(() =>
+    Promise.resolve({ cancelTurn: mockAcpCancelTurn, startSession: mockAcpStartSession })
+  ),
 }));
 vi.mock('@main/core/issues/controller', () => ({
   issueController: { getIssueContext: vi.fn() },
@@ -150,7 +153,9 @@ describe('executeTaskCreate', () => {
       success: true,
       data: { path: '/tmp/task', workspaceId: 'workspace-1' },
     });
+    vi.mocked(taskService.teardown).mockResolvedValue({ success: true, data: undefined });
     vi.mocked(createConversation).mockResolvedValue({} as never);
+    mockAcpCancelTurn.mockResolvedValue({ success: true, data: undefined });
     mockAcpStartSession.mockResolvedValue({
       success: true,
       data: { sessionId: 'acp-session' },
@@ -249,6 +254,45 @@ describe('executeTaskCreate', () => {
     expect(result).toEqual({ success: false, error: 'manually_stopped' });
     expect(commitCreateTask).not.toHaveBeenCalled();
     expect(taskService.launch).not.toHaveBeenCalled();
+  });
+
+  it('tears down a launched task when the run stops during launch', async () => {
+    vi.mocked(getRun)
+      .mockResolvedValueOnce(run)
+      .mockResolvedValueOnce({
+        ...run,
+        status: 'skipped',
+        error: { step: 'queue', code: 'manually_stopped' },
+      });
+
+    const result = await executeTaskCreate(automation, run, noopStep);
+
+    expect(result).toEqual({ success: false, error: 'manually_stopped' });
+    expect(taskService.teardown).toHaveBeenCalledWith(expect.any(String));
+    expect(createConversation).not.toHaveBeenCalled();
+  });
+
+  it('marks the run failed when launched task teardown fails', async () => {
+    vi.mocked(getRun)
+      .mockResolvedValueOnce(run)
+      .mockResolvedValueOnce({
+        ...run,
+        status: 'skipped',
+        error: { step: 'queue', code: 'manually_stopped' },
+      });
+    vi.mocked(taskService.teardown).mockResolvedValue({
+      success: false,
+      error: { type: 'error', message: 'teardown failed' },
+    });
+
+    const result = await executeTaskCreate(automation, run, noopStep);
+
+    expect(result).toEqual({ success: false, error: 'teardown_failed' });
+    expect(markRunFailed).toHaveBeenCalledWith(run.id, {
+      step: 'launch_task',
+      code: 'teardown_failed',
+      message: 'teardown failed',
+    });
   });
 
   it('marks run failed when launch fails', async () => {
@@ -399,6 +443,44 @@ describe('executeTaskCreate', () => {
         model: 'sonnet',
         initialQueue: [{ text: 'Check things' }],
       }),
+    });
+  });
+
+  it('marks the run failed when ACP cancellation fails after a stop', async () => {
+    const stoppedRun: AutomationRun = {
+      ...run,
+      status: 'skipped',
+      error: { step: 'queue', code: 'manually_stopped' },
+    };
+    vi.mocked(getRun)
+      .mockResolvedValueOnce(run)
+      .mockResolvedValueOnce(run)
+      .mockResolvedValueOnce(run)
+      .mockResolvedValueOnce(stoppedRun);
+    mockAcpCancelTurn.mockResolvedValue({
+      success: false,
+      error: { type: 'cancel_failed', message: 'cancel failed' },
+    });
+
+    const result = await executeTaskCreate(
+      {
+        ...automation,
+        conversationConfig: {
+          prompt: 'Check things',
+          provider: 'claude',
+          autoApprove: false,
+          type: 'acp',
+        },
+      },
+      run,
+      noopStep
+    );
+
+    expect(result).toEqual({ success: false, error: 'stop_conversation_failed' });
+    expect(markRunFailed).toHaveBeenCalledWith(run.id, {
+      step: 'create_conversation',
+      code: 'stop_conversation_failed',
+      message: 'cancel failed',
     });
   });
 

--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.test.ts
@@ -13,7 +13,7 @@ import {
 import { taskService } from '@main/core/tasks/task-service';
 import type { Automation } from '@shared/core/automations/automation';
 import type { AutomationRun } from '@shared/core/automations/automation-run';
-import { updateRun } from '../repo';
+import { getRun, updateRun } from '../repo';
 import type { OnStepCompleted } from '../run-transitions';
 import {
   markRunCreatingConversation,
@@ -71,7 +71,7 @@ vi.mock('@main/core/acp/controller', () => ({
 vi.mock('@main/core/issues/controller', () => ({
   issueController: { getIssueContext: vi.fn() },
 }));
-vi.mock('../repo', () => ({ updateRun: vi.fn() }));
+vi.mock('../repo', () => ({ getRun: vi.fn(), updateRun: vi.fn() }));
 vi.mock('../run-transitions', () => ({
   markRunLaunchingTask: vi.fn(),
   markRunCreatingConversation: vi.fn(),
@@ -159,6 +159,7 @@ describe('executeTaskCreate', () => {
       success: false,
       error: { type: 'generic', message: 'not found' },
     });
+    vi.mocked(getRun).mockResolvedValue(run);
     vi.mocked(updateRun).mockImplementation(async (_, values) => ({ ...run, ...values }));
     vi.mocked(markRunLaunchingTask).mockResolvedValue({
       ...run,
@@ -225,6 +226,20 @@ describe('executeTaskCreate', () => {
     expect(commitCreateTask).toHaveBeenCalledWith(preparedData, mockTx);
     expect(markRunLaunchingTask).toHaveBeenCalledWith(run.id, expect.any(Number));
     expect(taskService.launch).toHaveBeenCalled();
+  });
+
+  it('does not commit a task when the run is stopped during preparation', async () => {
+    vi.mocked(getRun).mockResolvedValue({
+      ...run,
+      status: 'skipped',
+      error: { step: 'queue', code: 'manually_stopped' },
+    });
+
+    const result = await executeTaskCreate(automation, run, noopStep);
+
+    expect(result).toEqual({ success: false, error: 'manually_stopped' });
+    expect(commitCreateTask).not.toHaveBeenCalled();
+    expect(taskService.launch).not.toHaveBeenCalled();
   });
 
   it('marks run failed when launch fails', async () => {

--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
@@ -233,7 +233,19 @@ export async function executeTaskCreate(
 
     try {
       const provision = await taskService.launch(taskId);
-      if (await wasManuallyStopped(run.id)) return err('manually_stopped');
+      if (await wasManuallyStopped(run.id)) {
+        const teardown = await taskService.teardown(taskId);
+        if (!teardown.success) {
+          const failed = await markRunFailed(run.id, {
+            step: 'launch_task',
+            code: 'teardown_failed',
+            message: teardown.error.message,
+          });
+          onStepCompleted(failed);
+          return err('teardown_failed');
+        }
+        return err('manually_stopped');
+      }
       if (!provision.success) {
         const msg = provision.error.type === 'setup-failed' ? provision.error.message : undefined;
         const failed = await markRunFailed(run.id, {
@@ -289,7 +301,16 @@ export async function executeTaskCreate(
           throw new Error(startResult.error.message ?? startResult.error.type);
         }
         if (await wasManuallyStopped(run.id)) {
-          await acpClient.cancelTurn({ conversationId });
+          const cancelResult = await acpClient.cancelTurn({ conversationId });
+          if (!cancelResult.success) {
+            const failed = await markRunFailed(run.id, {
+              step: 'create_conversation',
+              code: 'stop_conversation_failed',
+              message: cancelResult.error.message ?? cancelResult.error.type,
+            });
+            onStepCompleted(failed);
+            return err('stop_conversation_failed');
+          }
           return err('manually_stopped');
         }
       }

--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
@@ -7,6 +7,7 @@ import { createConversation } from '@main/core/conversations/createConversation'
 import { issueController } from '@main/core/issues/controller';
 import { openProject } from '@main/core/projects/operations/openProject';
 import { projectManager } from '@main/core/projects/project-manager';
+import { resolveTask } from '@main/core/projects/utils';
 import { DEFAULT_AGENT_ID } from '@main/core/settings/settings-registry';
 import { appSettingsService } from '@main/core/settings/settings-service';
 import { generateRandom } from '@main/core/tasks/name-generation/generateTaskName';
@@ -28,12 +29,18 @@ import {
 } from '@shared/core/issues/issue-context';
 import type { CreateTaskParams } from '@shared/core/tasks/tasks';
 import type { WorkspaceConfig } from '@shared/core/workspaces/workspace-config';
+import { getRun } from '../repo';
 import {
   markRunCreatingConversation,
   markRunFailed,
   markRunLaunchingTask,
   type OnStepCompleted,
 } from '../run-transitions';
+
+async function wasManuallyStopped(runId: string): Promise<boolean> {
+  const current = await getRun(runId);
+  return current?.status === 'skipped' && current.error?.code === 'manually_stopped';
+}
 
 async function ensureProjectOpen(projectId: string) {
   let project = projectManager.getProject(projectId);
@@ -209,6 +216,8 @@ export async function executeTaskCreate(
       return err(error.type);
     }
 
+    if (await wasManuallyStopped(run.id)) return err('manually_stopped');
+
     let taskRow!: TaskRow;
     let convRow: ConversationRow | undefined;
     db.transaction((tx) => {
@@ -223,6 +232,7 @@ export async function executeTaskCreate(
 
     try {
       const provision = await taskService.launch(taskId);
+      if (await wasManuallyStopped(run.id)) return err('manually_stopped');
       if (!provision.success) {
         const msg = provision.error.type === 'setup-failed' ? provision.error.message : undefined;
         const failed = await markRunFailed(run.id, {
@@ -252,6 +262,12 @@ export async function executeTaskCreate(
         isInitialConversation: true,
         type: conversationType,
       });
+      if (await wasManuallyStopped(run.id)) {
+        if (conversationType === 'pty') {
+          await resolveTask(projectId, taskId)?.conversations.stopSession(conversationId);
+        }
+        return err('manually_stopped');
+      }
       if (conversationType === 'acp') {
         const acpClient = await getAcpRuntimeClient();
         const startResult = await acpClient.startSession({
@@ -269,6 +285,10 @@ export async function executeTaskCreate(
         });
         if (!startResult.success) {
           throw new Error(startResult.error.message ?? startResult.error.type);
+        }
+        if (await wasManuallyStopped(run.id)) {
+          await acpClient.cancelTurn({ conversationId });
+          return err('manually_stopped');
         }
       }
     } catch (error) {

--- a/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
+++ b/apps/emdash-desktop/src/main/core/automations/actions/taskCreate.ts
@@ -228,6 +228,7 @@ export async function executeTaskCreate(
     taskService.notifyTaskCreated(createSuccess.task, createTaskParams);
 
     const launching = await markRunLaunchingTask(run.id, Date.now());
+    if (!launching) return err('manually_stopped');
     onStepCompleted(launching);
 
     try {
@@ -245,6 +246,7 @@ export async function executeTaskCreate(
       }
 
       const creatingConv = await markRunCreatingConversation(run.id, Date.now());
+      if (!creatingConv) return err('manually_stopped');
       onStepCompleted(creatingConv);
 
       await createConversation({

--- a/apps/emdash-desktop/src/main/core/automations/automations-service.ts
+++ b/apps/emdash-desktop/src/main/core/automations/automations-service.ts
@@ -1,6 +1,9 @@
 import { and, asc, count, desc, eq, ne, sql } from 'drizzle-orm';
+import { getAcpRuntimeClient } from '@main/core/acp/controller';
+import { agentHookService } from '@main/core/agent-hooks/agent-hook-service';
+import { resolveTask } from '@main/core/projects/utils';
 import { db } from '@main/db/client';
-import { automationRuns, tasks } from '@main/db/schema';
+import { automationRuns, conversations, tasks } from '@main/db/schema';
 import { events } from '@main/lib/events';
 import { HookCore, type Hookable } from '@main/lib/hookable';
 import { log } from '@main/lib/logger';
@@ -231,14 +234,49 @@ export class AutomationsService implements Hookable<AutomationsServiceHooks> {
       run.status === 'launching_task' ||
       run.status === 'creating_conversation'
     ) {
-      // In-progress steps — mark as failed (PTY stop is handled by renderer via run.taskId)
       stopped = await markRunSkipped(runId, { step: 'queue', code: 'manually_stopped' });
+    } else if (run.status === 'done' && run.taskId) {
+      stopped = run;
     } else {
       throw new Error('run_not_stoppable');
     }
+
+    await this.stopRunConversation(stopped);
     this._hooks.callHookBackground('run:stopped', stopped);
     this._hooks.callHookBackground('run:step-completed', stopped);
     return stopped;
+  }
+
+  private async stopRunConversation(run: AutomationRun): Promise<void> {
+    if (!run.taskId) return;
+    const [conversation] = await db
+      .select({
+        id: conversations.id,
+        projectId: conversations.projectId,
+        type: conversations.type,
+      })
+      .from(conversations)
+      .where(
+        and(eq(conversations.taskId, run.taskId), eq(conversations.isInitialConversation, true))
+      )
+      .limit(1);
+    if (!conversation) return;
+
+    if (conversation.type === 'acp') {
+      const client = await getAcpRuntimeClient();
+      const result = await client.cancelTurn({ conversationId: conversation.id });
+      if (!result.success && run.status === 'done') throw new Error('stop_conversation_failed');
+    } else {
+      const task = resolveTask(conversation.projectId, run.taskId);
+      if (!task) throw new Error('task_not_found');
+      await task.conversations.stopSession(conversation.id);
+    }
+
+    await agentHookService.resetToIdle({
+      conversationId: conversation.id,
+      taskId: run.taskId,
+      projectId: conversation.projectId,
+    });
   }
 
   async getRun(runId: string): Promise<AutomationRun | null> {

--- a/apps/emdash-desktop/src/main/core/automations/automations-service.ts
+++ b/apps/emdash-desktop/src/main/core/automations/automations-service.ts
@@ -227,9 +227,8 @@ export class AutomationsService implements Hookable<AutomationsServiceHooks> {
     const run = await getRun(runId);
     if (!run) throw new Error('run_not_found');
     let stopped: AutomationRun;
-    if (run.status === 'queued') {
-      stopped = await markRunSkipped(runId, { step: 'queue', code: 'manually_stopped' });
-    } else if (
+    if (
+      run.status === 'queued' ||
       run.status === 'creating_task' ||
       run.status === 'launching_task' ||
       run.status === 'creating_conversation'

--- a/apps/emdash-desktop/src/main/core/automations/automations-service.ts
+++ b/apps/emdash-desktop/src/main/core/automations/automations-service.ts
@@ -31,7 +31,7 @@ import {
   skipQueuedCronRuns,
   updateAutomationSettings as updateSettingsInRepo,
 } from './repo';
-import { markRunSkipped } from './run-transitions';
+import { markRunManuallyStopped } from './run-transitions';
 import { mapAutomationRunRowToAutomationRun } from './utils';
 
 export type AutomationsServiceHooks = {
@@ -234,7 +234,14 @@ export class AutomationsService implements Hookable<AutomationsServiceHooks> {
       run.status === 'creating_conversation'
     ) {
       await this.stopRunConversation(run);
-      stopped = await markRunSkipped(runId, { step: 'queue', code: 'manually_stopped' });
+      const skipped = await markRunManuallyStopped(runId);
+      if (skipped) {
+        stopped = skipped;
+      } else {
+        const current = await getRun(runId);
+        if (current?.status !== 'done' || !current.taskId) throw new Error('run_not_stoppable');
+        stopped = current;
+      }
     } else if (run.status === 'done' && run.taskId) {
       await this.stopRunConversation(run);
       stopped = run;

--- a/apps/emdash-desktop/src/main/core/automations/automations-service.ts
+++ b/apps/emdash-desktop/src/main/core/automations/automations-service.ts
@@ -233,14 +233,15 @@ export class AutomationsService implements Hookable<AutomationsServiceHooks> {
       run.status === 'launching_task' ||
       run.status === 'creating_conversation'
     ) {
+      await this.stopRunConversation(run);
       stopped = await markRunSkipped(runId, { step: 'queue', code: 'manually_stopped' });
     } else if (run.status === 'done' && run.taskId) {
+      await this.stopRunConversation(run);
       stopped = run;
     } else {
       throw new Error('run_not_stoppable');
     }
 
-    await this.stopRunConversation(stopped);
     this._hooks.callHookBackground('run:stopped', stopped);
     this._hooks.callHookBackground('run:step-completed', stopped);
     return stopped;

--- a/apps/emdash-desktop/src/main/core/automations/automations-service.ts
+++ b/apps/emdash-desktop/src/main/core/automations/automations-service.ts
@@ -265,7 +265,7 @@ export class AutomationsService implements Hookable<AutomationsServiceHooks> {
     if (conversation.type === 'acp') {
       const client = await getAcpRuntimeClient();
       const result = await client.cancelTurn({ conversationId: conversation.id });
-      if (!result.success && run.status === 'done') throw new Error('stop_conversation_failed');
+      if (!result.success) throw new Error('stop_conversation_failed');
     } else {
       const task = resolveTask(conversation.projectId, run.taskId);
       if (!task) throw new Error('task_not_found');

--- a/apps/emdash-desktop/src/main/core/automations/repo.ts
+++ b/apps/emdash-desktop/src/main/core/automations/repo.ts
@@ -647,6 +647,24 @@ export async function updateRun(
   return row ? mapAutomationRunRow(row) : null;
 }
 
+export async function updateRunIfStatus(
+  id: string,
+  expectedStatus: AutomationRunStatus,
+  values: Parameters<typeof updateRun>[1]
+): Promise<AutomationRun | null> {
+  const { error, ...rest } = values;
+  const dbValues = {
+    ...rest,
+    ...(error !== undefined ? { error: error ? JSON.stringify(error) : null } : {}),
+  };
+  const [row] = await db
+    .update(automationRuns)
+    .set(dbValues)
+    .where(and(eq(automationRuns.id, id), eq(automationRuns.status, expectedStatus)))
+    .returning();
+  return row ? mapAutomationRunRow(row) : null;
+}
+
 export async function findRunsStuckInCreatingTask(): Promise<Array<{ id: string }>> {
   const rows = await db
     .select({ id: automationRuns.id, taskId: tasks.id })

--- a/apps/emdash-desktop/src/main/core/automations/repo.ts
+++ b/apps/emdash-desktop/src/main/core/automations/repo.ts
@@ -649,7 +649,7 @@ export async function updateRun(
 
 export async function updateRunIfStatus(
   id: string,
-  expectedStatus: AutomationRunStatus,
+  expectedStatus: AutomationRunStatus | AutomationRunStatus[],
   values: Parameters<typeof updateRun>[1]
 ): Promise<AutomationRun | null> {
   const { error, ...rest } = values;
@@ -660,7 +660,14 @@ export async function updateRunIfStatus(
   const [row] = await db
     .update(automationRuns)
     .set(dbValues)
-    .where(and(eq(automationRuns.id, id), eq(automationRuns.status, expectedStatus)))
+    .where(
+      and(
+        eq(automationRuns.id, id),
+        Array.isArray(expectedStatus)
+          ? inArray(automationRuns.status, expectedStatus)
+          : eq(automationRuns.status, expectedStatus)
+      )
+    )
     .returning();
   return row ? mapAutomationRunRow(row) : null;
 }

--- a/apps/emdash-desktop/src/main/core/automations/run-transitions.ts
+++ b/apps/emdash-desktop/src/main/core/automations/run-transitions.ts
@@ -83,3 +83,15 @@ export async function markRunSkipped(runId: string, error: RunError): Promise<Au
     finishedAt: Date.now(),
   });
 }
+
+export async function markRunManuallyStopped(runId: string): Promise<AutomationRun | null> {
+  return updateRunIfStatus(
+    runId,
+    ['queued', 'creating_task', 'launching_task', 'creating_conversation'],
+    {
+      status: 'skipped',
+      error: { step: 'queue', code: 'manually_stopped' },
+      finishedAt: Date.now(),
+    }
+  );
+}

--- a/apps/emdash-desktop/src/main/core/automations/run-transitions.ts
+++ b/apps/emdash-desktop/src/main/core/automations/run-transitions.ts
@@ -55,6 +55,13 @@ export async function markRunDone(runId: string, finishedAt: number): Promise<Au
   return updateRunOrThrow(runId, { status: 'done', finishedAt });
 }
 
+export async function markRunDoneIfCreatingConversation(
+  runId: string,
+  finishedAt: number
+): Promise<AutomationRun | null> {
+  return updateRunIfStatus(runId, 'creating_conversation', { status: 'done', finishedAt });
+}
+
 /** any step → failed, writes JSON error + finishedAt */
 export async function markRunFailed(
   runId: string,

--- a/apps/emdash-desktop/src/main/core/automations/run-transitions.ts
+++ b/apps/emdash-desktop/src/main/core/automations/run-transitions.ts
@@ -1,6 +1,6 @@
 import { log } from '@main/lib/logger';
 import type { AutomationRun, RunError } from '@shared/core/automations/automation-run';
-import { updateRun } from './repo';
+import { updateRun, updateRunIfStatus } from './repo';
 
 export type OnStepCompleted = (run: AutomationRun) => void;
 
@@ -29,16 +29,25 @@ export async function markRunCreatingTask(runId: string, now: number): Promise<A
 }
 
 /** creating_task → launching_task, writes taskCreatedAt */
-export async function markRunLaunchingTask(runId: string, now: number): Promise<AutomationRun> {
-  return updateRunOrThrow(runId, { status: 'launching_task', taskCreatedAt: now });
+export async function markRunLaunchingTask(
+  runId: string,
+  now: number
+): Promise<AutomationRun | null> {
+  return updateRunIfStatus(runId, 'creating_task', {
+    status: 'launching_task',
+    taskCreatedAt: now,
+  });
 }
 
 /** launching_task → creating_conversation, writes launchedAt */
 export async function markRunCreatingConversation(
   runId: string,
   now: number
-): Promise<AutomationRun> {
-  return updateRunOrThrow(runId, { status: 'creating_conversation', launchedAt: now });
+): Promise<AutomationRun | null> {
+  return updateRunIfStatus(runId, 'launching_task', {
+    status: 'creating_conversation',
+    launchedAt: now,
+  });
 }
 
 /** creating_conversation → done, writes finishedAt */

--- a/apps/emdash-desktop/src/main/core/automations/runtime.test.ts
+++ b/apps/emdash-desktop/src/main/core/automations/runtime.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Automation } from '@shared/core/automations/automation';
 import type { AutomationRun } from '@shared/core/automations/automation-run';
 import { executeTaskCreate } from './actions/taskCreate';
-import { updateRun } from './repo';
+import { getRun, updateRun } from './repo';
 import type { OnStepCompleted } from './run-transitions';
 import { runQueuedAutomation } from './runtime';
 
 vi.mock('@main/lib/logger', () => ({ log: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
 vi.mock('./actions/taskCreate', () => ({ executeTaskCreate: vi.fn() }));
-vi.mock('./repo', () => ({ updateRun: vi.fn() }));
+vi.mock('./repo', () => ({ getRun: vi.fn(), updateRun: vi.fn() }));
 
 const automation: Automation = {
   id: 'automation-1',
@@ -46,6 +46,7 @@ describe('runQueuedAutomation', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     onStepCompleted = vi.fn() as unknown as OnStepCompleted;
+    vi.mocked(getRun).mockResolvedValue(run);
     vi.mocked(updateRun).mockImplementation(async (_, values) => ({ ...run, ...values }));
   });
 
@@ -76,6 +77,23 @@ describe('runQueuedAutomation', () => {
     // updateRun should NOT be called by runtime.ts (taskCreate already handled it)
     expect(updateRun).not.toHaveBeenCalled();
     // onStepCompleted not called by runtime (executeTaskCreate is responsible for step callbacks)
+    expect(onStepCompleted).not.toHaveBeenCalled();
+  });
+
+  it('does not overwrite a manually stopped run with done', async () => {
+    const stoppedRun: AutomationRun = {
+      ...run,
+      status: 'skipped',
+      finishedAt: 2,
+      error: { step: 'queue', code: 'manually_stopped' },
+    };
+    vi.mocked(executeTaskCreate).mockResolvedValue({ success: true, data: { taskId: 'task-1' } });
+    vi.mocked(getRun).mockResolvedValue(stoppedRun);
+
+    const result = await runQueuedAutomation(automation, run, onStepCompleted);
+
+    expect(result).toEqual({ success: true, data: stoppedRun });
+    expect(updateRun).not.toHaveBeenCalled();
     expect(onStepCompleted).not.toHaveBeenCalled();
   });
 

--- a/apps/emdash-desktop/src/main/core/automations/runtime.test.ts
+++ b/apps/emdash-desktop/src/main/core/automations/runtime.test.ts
@@ -2,13 +2,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import type { Automation } from '@shared/core/automations/automation';
 import type { AutomationRun } from '@shared/core/automations/automation-run';
 import { executeTaskCreate } from './actions/taskCreate';
-import { getRun, updateRun } from './repo';
+import { getRun, updateRun, updateRunIfStatus } from './repo';
 import type { OnStepCompleted } from './run-transitions';
 import { runQueuedAutomation } from './runtime';
 
 vi.mock('@main/lib/logger', () => ({ log: { error: vi.fn(), warn: vi.fn(), info: vi.fn() } }));
 vi.mock('./actions/taskCreate', () => ({ executeTaskCreate: vi.fn() }));
-vi.mock('./repo', () => ({ getRun: vi.fn(), updateRun: vi.fn() }));
+vi.mock('./repo', () => ({ getRun: vi.fn(), updateRun: vi.fn(), updateRunIfStatus: vi.fn() }));
 
 const automation: Automation = {
   id: 'automation-1',
@@ -48,6 +48,10 @@ describe('runQueuedAutomation', () => {
     onStepCompleted = vi.fn() as unknown as OnStepCompleted;
     vi.mocked(getRun).mockResolvedValue(run);
     vi.mocked(updateRun).mockImplementation(async (_, values) => ({ ...run, ...values }));
+    vi.mocked(updateRunIfStatus).mockImplementation(async (_, __, values) => ({
+      ...run,
+      ...values,
+    }));
   });
 
   it('marks a successful run as done and notifies the step callback', async () => {
@@ -57,7 +61,7 @@ describe('runQueuedAutomation', () => {
 
     expect(result.success).toBe(true);
     expect(executeTaskCreate).toHaveBeenCalledWith(automation, run, onStepCompleted);
-    expect(updateRun).toHaveBeenCalledWith(run.id, {
+    expect(updateRunIfStatus).toHaveBeenCalledWith(run.id, 'creating_conversation', {
       status: 'done',
       finishedAt: expect.any(Number),
     });
@@ -89,11 +93,15 @@ describe('runQueuedAutomation', () => {
     };
     vi.mocked(executeTaskCreate).mockResolvedValue({ success: true, data: { taskId: 'task-1' } });
     vi.mocked(getRun).mockResolvedValue(stoppedRun);
+    vi.mocked(updateRunIfStatus).mockResolvedValue(null);
 
     const result = await runQueuedAutomation(automation, run, onStepCompleted);
 
     expect(result).toEqual({ success: true, data: stoppedRun });
-    expect(updateRun).not.toHaveBeenCalled();
+    expect(updateRunIfStatus).toHaveBeenCalledWith(run.id, 'creating_conversation', {
+      status: 'done',
+      finishedAt: expect.any(Number),
+    });
     expect(onStepCompleted).not.toHaveBeenCalled();
   });
 

--- a/apps/emdash-desktop/src/main/core/automations/runtime.ts
+++ b/apps/emdash-desktop/src/main/core/automations/runtime.ts
@@ -44,12 +44,12 @@ export async function runQueuedAutomation(
       error: error instanceof Error ? error.message : String(error),
     })
   );
+  const current = await getRun(run.id);
+  if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
+    return ok(current);
+  }
 
   if (!result.success) {
-    const current = await getRun(run.id);
-    if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
-      return ok(current);
-    }
     log.error('Automation task create failed', {
       automationId: automation.id,
       runId: run.id,
@@ -57,11 +57,6 @@ export async function runQueuedAutomation(
     });
     // markRunFailed was already called inside executeTaskCreate
     return err(result.error);
-  }
-
-  const current = await getRun(run.id);
-  if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
-    return ok(current);
   }
 
   run = await markRunDone(run.id, Date.now());

--- a/apps/emdash-desktop/src/main/core/automations/runtime.ts
+++ b/apps/emdash-desktop/src/main/core/automations/runtime.ts
@@ -4,7 +4,11 @@ import type { Automation } from '@shared/core/automations/automation';
 import type { AutomationRun } from '@shared/core/automations/automation-run';
 import { executeTaskCreate } from './actions/taskCreate';
 import { getRun } from './repo';
-import { markRunDone, markRunSkipped, type OnStepCompleted } from './run-transitions';
+import {
+  markRunDoneIfCreatingConversation,
+  markRunSkipped,
+  type OnStepCompleted,
+} from './run-transitions';
 
 export type { OnStepCompleted };
 
@@ -44,12 +48,12 @@ export async function runQueuedAutomation(
       error: error instanceof Error ? error.message : String(error),
     })
   );
-  const current = await getRun(run.id);
-  if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
-    return ok(current);
-  }
 
   if (!result.success) {
+    const current = await getRun(run.id);
+    if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
+      return ok(current);
+    }
     log.error('Automation task create failed', {
       automationId: automation.id,
       runId: run.id,
@@ -59,7 +63,15 @@ export async function runQueuedAutomation(
     return err(result.error);
   }
 
-  run = await markRunDone(run.id, Date.now());
+  const completed = await markRunDoneIfCreatingConversation(run.id, Date.now());
+  if (!completed) {
+    const current = await getRun(run.id);
+    if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
+      return ok(current);
+    }
+    return err('run_update_failed');
+  }
+  run = completed;
   onStepCompleted(run);
   return ok(run);
 }

--- a/apps/emdash-desktop/src/main/core/automations/runtime.ts
+++ b/apps/emdash-desktop/src/main/core/automations/runtime.ts
@@ -3,6 +3,7 @@ import { log } from '@main/lib/logger';
 import type { Automation } from '@shared/core/automations/automation';
 import type { AutomationRun } from '@shared/core/automations/automation-run';
 import { executeTaskCreate } from './actions/taskCreate';
+import { getRun } from './repo';
 import { markRunDone, markRunSkipped, type OnStepCompleted } from './run-transitions';
 
 export type { OnStepCompleted };
@@ -45,6 +46,10 @@ export async function runQueuedAutomation(
   );
 
   if (!result.success) {
+    const current = await getRun(run.id);
+    if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
+      return ok(current);
+    }
     log.error('Automation task create failed', {
       automationId: automation.id,
       runId: run.id,
@@ -52,6 +57,11 @@ export async function runQueuedAutomation(
     });
     // markRunFailed was already called inside executeTaskCreate
     return err(result.error);
+  }
+
+  const current = await getRun(run.id);
+  if (current?.status === 'skipped' && current.error?.code === 'manually_stopped') {
+    return ok(current);
   }
 
   run = await markRunDone(run.id, Date.now());

--- a/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/AutomationRunRow.tsx
@@ -1,3 +1,4 @@
+import { Check, Loader2, Square } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import { useAutomationRunActions } from '@renderer/features/automations/use-automation-run-actions';
 import {
@@ -27,7 +28,8 @@ export const AutomationRunRow = observer(function AutomationRunRow({
   const { navigate } = useNavigate();
   const fetchedRun = useAutomationRun(automationId, runId);
   const run = runProp ?? fetchedRun;
-  const { projectId } = useAutomationRunActions(automationId);
+  const { projectId, canStopRun, stopRun, stopRunPending, stopRunSucceeded } =
+    useAutomationRunActions(automationId, run);
 
   const taskId = run ? run.taskId : null;
   const taskStore = taskId && projectId ? getTaskStore(projectId, taskId) : undefined;
@@ -85,6 +87,32 @@ export const AutomationRunRow = observer(function AutomationRunRow({
         triggerKind={run.triggerKind}
         runStatus={run.status}
         error={run.error}
+        statusAction={
+          stopRunPending ? (
+            <span className="flex items-center gap-1 rounded-md px-1.5 py-0.5 text-xs text-foreground-muted">
+              <Loader2 className="size-3 animate-spin" />
+              Stopping…
+            </span>
+          ) : stopRunSucceeded ? (
+            <span className="flex items-center gap-1 rounded-md bg-background-3 px-1.5 py-0.5 text-xs text-foreground-muted">
+              <Check className="size-3" />
+              Stopped
+            </span>
+          ) : canStopRun ? (
+            <button
+              type="button"
+              className="flex shrink-0 appearance-none items-center gap-1 rounded-md border-0 bg-transparent px-1.5 py-0.5 text-xs text-foreground-destructive outline-none hover:bg-background-destructive active:bg-background-destructive disabled:pointer-events-none"
+              onPointerDown={(event) => event.stopPropagation()}
+              onClick={(event) => {
+                event.stopPropagation();
+                void stopRun();
+              }}
+            >
+              <Square className="size-3 fill-current" />
+              Stop task run
+            </button>
+          ) : undefined
+        }
       />
     </div>
   );

--- a/apps/emdash-desktop/src/renderer/features/automations/components/RunMetaLine.tsx
+++ b/apps/emdash-desktop/src/renderer/features/automations/components/RunMetaLine.tsx
@@ -1,4 +1,6 @@
+import type { ReactNode } from 'react';
 import { AbsoluteTime } from '@renderer/lib/ui/absolute-time';
+import { cn } from '@renderer/utils/utils';
 import type {
   AutomationRun,
   AutomationRunStatus,
@@ -12,9 +14,16 @@ export interface RunMetaLineProps {
   triggerKind: AutomationRunTriggerKind | null;
   runStatus: AutomationRunStatus | null;
   error: AutomationRun['error'];
+  statusAction?: ReactNode;
 }
 
-export function RunMetaLine({ displayTime, triggerKind, runStatus, error }: RunMetaLineProps) {
+export function RunMetaLine({
+  displayTime,
+  triggerKind,
+  runStatus,
+  error,
+  statusAction,
+}: RunMetaLineProps) {
   const triggerLabel = triggerKind ? formatRunTriggerKindLabel(triggerKind) : null;
 
   return (
@@ -32,7 +41,21 @@ export function RunMetaLine({ displayTime, triggerKind, runStatus, error }: RunM
           <span>—</span>
         )}
       </span>
-      <RunStatusBadge status={runStatus} error={error} />
+      <div className="grid shrink-0 items-center justify-items-end">
+        <div
+          className={cn(
+            'col-start-1 row-start-1',
+            statusAction && 'group-focus-within:invisible group-hover:invisible'
+          )}
+        >
+          <RunStatusBadge status={runStatus} error={error} />
+        </div>
+        {statusAction && (
+          <div className="invisible absolute top-1/2 right-2 -translate-y-1/2 group-focus-within:visible group-hover:visible">
+            {statusAction}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
@@ -16,26 +16,24 @@ export function useAutomationRunActions(automationId: string, run?: AutomationRu
   const projectId = automation?.projectId ?? null;
   const taskId = run?.taskId ?? null;
   const conversations = taskId ? conversationRegistry.get(taskId) : undefined;
-  const activeConversation = Array.from(conversations?.conversations.values() ?? []).find(
+  const hasActiveConversation = Array.from(conversations?.conversations.values() ?? []).some(
     (conversation) => conversation.status === 'working' || conversation.status === 'awaiting-input'
   );
 
-  async function stopRun() {
+  function stopRun() {
     if (!run) return;
-    try {
-      await stop.mutateAsync(run.id);
-    } catch (error) {
-      toast({
-        title: 'Failed to stop task run',
-        description: error instanceof Error ? error.message : undefined,
-        variant: 'destructive',
-      });
-    }
+    stop.mutate(run.id, {
+      onError: (error) =>
+        toast({
+          title: 'Failed to stop task run',
+          description: error instanceof Error ? error.message : undefined,
+          variant: 'destructive',
+        }),
+    });
   }
 
   return {
-    canStopRun:
-      activeConversation !== undefined || STOPPABLE_RUN_STATUSES.has(run?.status ?? 'done'),
+    canStopRun: hasActiveConversation || Boolean(run && STOPPABLE_RUN_STATUSES.has(run.status)),
     stopRun,
     stopRunPending: stop.isPending,
     stopRunSucceeded: stop.isSuccess,

--- a/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
+++ b/apps/emdash-desktop/src/renderer/features/automations/use-automation-run-actions.ts
@@ -1,10 +1,44 @@
+import { conversationRegistry } from '@renderer/features/conversations/stores/conversation-registry';
+import { toast } from '@renderer/lib/hooks/use-toast';
+import type { AutomationRun } from '@shared/core/automations/automation-run';
 import { useAutomation, useAutomations } from './use-automations';
 
-export function useAutomationRunActions(automationId: string) {
+const STOPPABLE_RUN_STATUSES = new Set<AutomationRun['status']>([
+  'queued',
+  'creating_task',
+  'launching_task',
+  'creating_conversation',
+]);
+
+export function useAutomationRunActions(automationId: string, run?: AutomationRun) {
   const { stop } = useAutomations();
   const automation = useAutomation(automationId);
+  const projectId = automation?.projectId ?? null;
+  const taskId = run?.taskId ?? null;
+  const conversations = taskId ? conversationRegistry.get(taskId) : undefined;
+  const activeConversation = Array.from(conversations?.conversations.values() ?? []).find(
+    (conversation) => conversation.status === 'working' || conversation.status === 'awaiting-input'
+  );
+
+  async function stopRun() {
+    if (!run) return;
+    try {
+      await stop.mutateAsync(run.id);
+    } catch (error) {
+      toast({
+        title: 'Failed to stop task run',
+        description: error instanceof Error ? error.message : undefined,
+        variant: 'destructive',
+      });
+    }
+  }
+
   return {
-    stopRun: stop.mutate,
-    projectId: automation?.projectId ?? null,
+    canStopRun:
+      activeConversation !== undefined || STOPPABLE_RUN_STATUSES.has(run?.status ?? 'done'),
+    stopRun,
+    stopRunPending: stop.isPending,
+    stopRunSucceeded: stop.isSuccess,
+    projectId,
   };
 }


### PR DESCRIPTION
### Description

Adds a hover action to stop automation task runs from the run overview. The action replaces the run status while hovered, shows explicit `Stopping…` and `Stopped` feedback, and handles both runs that are still launching and already-created tasks with active PTY or ACP conversations.

Stopping an in-progress launch now prevents later automation steps from overwriting the stopped state. Stopping an already-created task terminates its active conversation and resets the stale agent status to idle.

### Related issues

[ENG-1860](https://linear.app/general-action/issue/ENG-1860/add-stop-task-run-action-to-automation-overview)

### Screenshot/Recording (if applicable)
https://cap.link/3zxhrvk94f1ezfn

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not required for this UI change
- [x] I added or updated tests for the changed behavior
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>