### PR TITLE
fix(codex): skip broken CLI installations

### DIFF
--- a/packages/core/src/agents/plugins/plugin-host.test.ts
+++ b/packages/core/src/agents/plugins/plugin-host.test.ts
@@ -190,15 +190,45 @@ describe('AgentPluginHost', () => {
     await expect(host.readMcpServers('test')).resolves.toEqual({ success: true, data: servers });
     expect(readServers).toHaveBeenCalledWith(expect.any(Object));
   });
+
+  it('skips a broken PATH installation when building an ACP spawn', async () => {
+    const host = createHost(
+      [
+        plugin({
+          acp: { kind: 'supported' },
+          behavior: {
+            acp: {
+              buildSpawn: (ctx) => ({ command: ctx.cli, args: [], env: {} }),
+              connect: vi.fn(),
+            },
+            hostDependency: {
+              resolveStatus: (result) => (result.exitCode === 0 ? 'available' : 'error'),
+            },
+          },
+        }),
+      ],
+      fakeExec({ paths: ['/broken/test', '/working/test'], brokenPaths: ['/broken/test'] })
+    );
+
+    await expect(host.buildAcpSpawn('test', { cwd: '/workspace' })).resolves.toMatchObject({
+      success: true,
+      data: {
+        command: '/working/test',
+      },
+    });
+  });
 });
 
-function createHost(plugins: CLIAgentPluginProvider[]): AgentPluginHost {
+function createHost(
+  plugins: CLIAgentPluginProvider[],
+  exec: IExecutionContext = fakeExec()
+): AgentPluginHost {
   const registry = createPluginRegistry<CLIAgentPluginProvider>();
   for (const item of plugins) registry.register(item);
   return new AgentPluginHost({
     scope: createScope({ label: 'test' }),
     registry,
-    exec: fakeExec(),
+    exec,
     fs: memoryFs(),
     env: { HOME: '/home/test', PATH: '/bin', UNSAFE_ENV: 'nope' },
     homeDir: '/home/test',
@@ -250,11 +280,26 @@ function plugin(
   } as unknown as CLIAgentPluginProvider;
 }
 
-function fakeExec(): IExecutionContext {
+function fakeExec({
+  paths = ['test'],
+  brokenPaths = [],
+}: {
+  paths?: string[];
+  brokenPaths?: string[];
+} = {}): IExecutionContext {
   return {
     supportsLocalSpawn: false,
-    async exec() {
-      throw new Error('missing');
+    async exec(command, args) {
+      if (command === 'which' && args?.join(' ') === '-a test') {
+        return { stdout: paths.join('\n'), stderr: '' };
+      }
+      if (brokenPaths.includes(command)) {
+        throw Object.assign(new Error('broken'), { code: 1, stderr: 'missing dependency' });
+      }
+      if (paths.includes(command)) {
+        return { stdout: 'test 1.0.0', stderr: '' };
+      }
+      throw new Error(`Unexpected command: ${command} ${args?.join(' ') ?? ''}`);
     },
     async execStreaming() {},
     dispose() {},

--- a/packages/core/src/agents/plugins/plugin-host.test.ts
+++ b/packages/core/src/agents/plugins/plugin-host.test.ts
@@ -1,6 +1,7 @@
 import { createScope } from '@emdash/wire/util';
 import { describe, expect, it, vi } from 'vitest';
 import type { IExecutionContext } from '../../exec';
+import { resolveActiveInstallation } from '../../host-dependencies/runtime/types';
 import type { IAcpBehavior } from './capabilities/acp';
 import type { IAgentAuthBehavior } from './capabilities/auth';
 import type { CanonicalHookEvent } from './capabilities/hooks';
@@ -216,6 +217,19 @@ describe('AgentPluginHost', () => {
         command: '/working/test',
       },
     });
+    expect(host.dependencies.get('test')).toMatchObject({
+      status: 'available',
+      path: '/working/test',
+    });
+    const hostDependency = host.dependencies.getHostDependency('test')!;
+    expect(hostDependency).toMatchObject({
+      installations: expect.arrayContaining([
+        expect.objectContaining({ pathEntry: '/working/test', status: 'available' }),
+      ]),
+    });
+    expect(
+      resolveActiveInstallation(hostDependency.installations, hostDependency.used)?.pathEntry
+    ).toBe('/working/test');
   });
 });
 

--- a/packages/core/src/agents/plugins/plugin-host.ts
+++ b/packages/core/src/agents/plugins/plugin-host.ts
@@ -274,12 +274,10 @@ export class AgentPluginHost {
       throw new Error(`Provider '${providerId}' was not found`);
     }
 
-    let state = this.dependencies.get(providerId);
-    if (!state?.path) state = await this.dependencies.probe(providerId);
-    if (state.path) return state.path;
+    const path = await this.dependencies.resolveAvailablePath(providerId);
+    if (path) return path;
 
-    const descriptor = this.descriptors.find((candidate) => candidate.id === providerId);
-    return descriptor?.commands[0] ?? providerId;
+    throw new Error(`No working CLI installation found for provider '${providerId}'`);
   }
 
   private async checkAuthStatusUncached(

--- a/packages/core/src/host-dependencies/runtime/host-dependency-manager.ts
+++ b/packages/core/src/host-dependencies/runtime/host-dependency-manager.ts
@@ -240,10 +240,20 @@ export class HostDependencyManager {
     for (const command of descriptor.commands) {
       const paths = await resolveAllCommandPaths(command, this.ctx, this.platform);
       for (const path of paths) {
-        if (descriptor.skipVersionProbe) return path;
+        if (descriptor.skipVersionProbe) {
+          const state = dependencyStateFromProbeResult(descriptor, path, null);
+          this.updateState(state);
+          await this.buildAndStoreHostDependency(id, descriptor, state, null);
+          return path;
+        }
 
         const probe = await runVersionProbe(command, path, versionArgs, this.ctx);
-        if (resolveProbeStatus(descriptor, path, probe) === 'available') return path;
+        const state = dependencyStateFromProbeResult(descriptor, path, probe);
+        if (state.status === 'available') {
+          this.updateState(state);
+          await this.buildAndStoreHostDependency(id, descriptor, state, probe);
+          return path;
+        }
       }
     }
 
@@ -287,6 +297,11 @@ export class HostDependencyManager {
     );
     const fullState = dependencyStateFromProbeResult(descriptor, resolvedPath, probeResult);
     this.updateState(fullState);
+
+    if (fullState.status === 'error') {
+      const availablePath = await this.resolveAvailablePath(id);
+      if (availablePath) return this.state.get(id)!;
+    }
 
     // Phase 3: build HostDependency state.
     await this.buildHostDependencyAfterProbe(id, descriptor, fullState, probeResult);
@@ -357,12 +372,11 @@ export class HostDependencyManager {
       const provenance = await this.detector.detect(realpath);
       const manageable = computeManageable(provenance, descriptor);
 
-      // For the active (first) installation, reuse the already-computed fullState
-      // to avoid a redundant version probe.
+      // Reuse a matching fullState to avoid a redundant version probe.
       let version: string | null = null;
       let status: DependencyStatus = 'available';
 
-      if (isActive && fullState) {
+      if (fullState?.path === pathEntry) {
         version = fullState.version;
         status = fullState.status;
       } else if (!descriptor.skipVersionProbe) {

--- a/packages/core/src/host-dependencies/runtime/host-dependency-manager.ts
+++ b/packages/core/src/host-dependencies/runtime/host-dependency-manager.ts
@@ -229,6 +229,27 @@ export class HostDependencyManager {
     return this.hostState.get(id);
   }
 
+  /** Returns the first installed CLI that passes this dependency's version probe. */
+  async resolveAvailablePath(id: DependencyId): Promise<string | null> {
+    const descriptor = this._getDependencyDescriptor(id);
+    if (!descriptor) {
+      throw new Error(`Unknown dependency id: ${id}`);
+    }
+
+    const versionArgs = descriptor.versionArgs ?? ['--version'];
+    for (const command of descriptor.commands) {
+      const paths = await resolveAllCommandPaths(command, this.ctx, this.platform);
+      for (const path of paths) {
+        if (descriptor.skipVersionProbe) return path;
+
+        const probe = await runVersionProbe(command, path, versionArgs, this.ctx);
+        if (resolveProbeStatus(descriptor, path, probe) === 'available') return path;
+      }
+    }
+
+    return null;
+  }
+
   /**
    * Two-phase probe for a single dependency:
    *   1. Resolve path (fast, ~5ms) — fires onStatusUpdated immediately.

--- a/packages/core/src/host-dependencies/runtime/types.ts
+++ b/packages/core/src/host-dependencies/runtime/types.ts
@@ -246,7 +246,7 @@ export const hostDependencySelectionSchema: z.ZodType<HostDependencySelection> =
  * Resolves the active Installation from a HostDependency based on the used source.
  *
  * Resolution rules:
- *   - auto:    the installation with isActive === true (PATH winner)
+ *   - auto:    the first available installation, falling back to the PATH winner
  *   - pinned:  the installation whose realpath matches selection.realpath
  *   - method:  first manageable installation whose provenance.kind matches
  *   - path:    the path-override installation (id === 'path')
@@ -259,7 +259,11 @@ export function resolveActiveInstallation(
   installations: Installation[],
   used: SelectedSource
 ): Installation | undefined {
-  if (used.kind === 'auto') return installations.find((i) => i.isActive);
+  if (used.kind === 'auto') {
+    return (
+      installations.find((i) => i.status === 'available') ?? installations.find((i) => i.isActive)
+    );
+  }
   if (used.kind === 'pinned') return installations.find((i) => i.realpath === used.realpath);
   if (used.kind === 'method') {
     return installations.find((i) => i.provenance.kind === used.method && i.manageable);

--- a/packages/plugins/src/agents/impl/codex/acp.test.ts
+++ b/packages/plugins/src/agents/impl/codex/acp.test.ts
@@ -62,3 +62,29 @@ describe('codex acp behavior', () => {
     });
   });
 });
+
+describe('codex host dependency behavior', () => {
+  const resolveStatus = pluginRegistry.get('codex')!.behavior.hostDependency!.resolveStatus!;
+  const probeResult = {
+    command: 'codex',
+    path: '/usr/local/bin/codex',
+    stdout: '',
+    stderr: '',
+    exitCode: 0,
+    timedOut: false,
+  };
+
+  it('accepts a successful version probe', () => {
+    expect(resolveStatus(probeResult)).toBe('available');
+  });
+
+  it('rejects a broken installation that prints an error', () => {
+    expect(
+      resolveStatus({
+        ...probeResult,
+        stderr: 'Missing optional dependency @openai/codex-darwin-arm64',
+        exitCode: 1,
+      })
+    ).toBe('error');
+  });
+});

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -138,6 +138,9 @@ export const provider = registerPluginBehavior(plugin, {
       return connectStdioAcp(io, toClient);
     },
   },
+  hostDependency: {
+    resolveStatus: (result) => (result.exitCode === 0 ? 'available' : 'error'),
+  },
   auth: {
     checkStatus: async (ctx) => {
       const envStatus = authenticatedFromEnv(ctx, ['OPENAI_API_KEY']);


### PR DESCRIPTION
### Description

Codex chat could fail even when a working Homebrew installation was selected because the ACP runtime independently resolved the first `codex` entry on `PATH`. A broken workspace-local npm installation could therefore shadow the working Homebrew binary.

This change makes conversation spawn resolution probe discovered CLI installations in PATH order and use the first working candidate. Codex now treats a non-zero version probe as an invalid installation, so a broken local npm package is skipped in favor of a healthy installation such as Homebrew.

### Related issues

[ENG-1866](https://linear.app/general-action/issue/ENG-1866/failed-to-load-chat-due-to-missing-codex-dependency)

### Testing

- `pnpm --filter @emdash/core exec vitest run src/agents/plugins/plugin-host.test.ts`
- `pnpm --filter @emdash/plugins exec vitest run src/agents/impl/codex/acp.test.ts`
- `pnpm --filter @emdash/core run typecheck`
- `pnpm --filter @emdash/core run lint`
- `pnpm --filter @emdash/plugins run lint`
- Focused `oxfmt --check`
- `git diff --check`
- Manually confirmed the workspace-local Codex exits with code 1 while `/opt/homebrew/bin/codex` succeeds, and launched the Electron development app with the updated runtime.

### Screenshot/Recording (if applicable)

Not applicable; this changes CLI resolution behavior without changing the UI.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or no documentation change was needed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>