### PR TITLE
chore(release): bump desktop version to 1.1.39

### DIFF
--- a/apps/emdash-desktop/package.json
+++ b/apps/emdash-desktop/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@emdash/emdash-desktop",
-  "version": "1.1.38",
+  "version": "1.1.39",
   "description": "A cross-platform Electron app that orchestrates multiple coding agents in parallel",
   "keywords": [
     "claude",


### PR DESCRIPTION
### Description

Bump the desktop application version from `1.1.38` to `1.1.39` for the next production release.

### Related issues

None.

### Testing

- `git diff --check`
- Parsed `apps/emdash-desktop/package.json` and verified the version is `1.1.39`
- Structured autoreview: clean, with no accepted/actionable findings
- Full test suite not run because this is a version-only manifest change

### Screenshot/Recording (if applicable)

Not applicable; version-only change.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Documentation changes are not required
- [x] Test changes are not required for this version-only update
- [x] I only added comments where the logic is not obvious
- [x] The PR title follows Conventional Commits

</details>