### PR TITLE
fix(telemetry): register task lifecycle tracking

### DIFF
--- a/apps/emdash-desktop/src/main/core/telemetry/task-telemetry.test.ts
+++ b/apps/emdash-desktop/src/main/core/telemetry/task-telemetry.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+type TaskCreatedHandler = (
+  task: { id: string; projectId: string },
+  params: {
+    workspaceConfig: { git: { kind: string } };
+    taskConfig: {
+      linkedIssue?: { provider: 'linear' };
+      initialConversation?: {
+        provider: 'claude-code';
+        initialPrompt?: string;
+        initialQueue?: Array<{ text: string }>;
+      };
+    };
+  }
+) => void;
+
+type TaskProvisionedHandler = (info: { projectId: string; taskId: string }) => void;
+
+const mocks = vi.hoisted(() => ({
+  capture: vi.fn(),
+  taskServiceOn: vi.fn(),
+  taskSessionOn: vi.fn(),
+}));
+
+vi.mock('@main/lib/telemetry', () => ({
+  telemetryService: { capture: mocks.capture },
+}));
+
+vi.mock('../tasks/task-service', () => ({
+  taskService: { on: mocks.taskServiceOn },
+}));
+
+vi.mock('../tasks/task-session-manager', () => ({
+  taskSessionManager: { hooks: { on: mocks.taskSessionOn } },
+}));
+
+await import('./task-telemetry');
+
+function getTaskCreatedHandler() {
+  return mocks.taskServiceOn.mock.calls.find(([event]) => event === 'task:created')?.[1] as
+    | TaskCreatedHandler
+    | undefined;
+}
+
+function getTaskProvisionedHandler() {
+  return mocks.taskSessionOn.mock.calls.find(([event]) => event === 'task:provisioned')?.[1] as
+    | TaskProvisionedHandler
+    | undefined;
+}
+
+describe('task telemetry', () => {
+  beforeEach(() => {
+    mocks.capture.mockClear();
+  });
+
+  it('registers task lifecycle listeners when loaded', () => {
+    expect(getTaskCreatedHandler()).toBeTypeOf('function');
+    expect(getTaskProvisionedHandler()).toBeTypeOf('function');
+  });
+
+  it('captures task creation and linked issue properties', () => {
+    const handler = getTaskCreatedHandler();
+    expect(handler).toBeTypeOf('function');
+
+    handler?.(
+      { id: 'task-1', projectId: 'project-1' },
+      {
+        workspaceConfig: { git: { kind: 'new-branch' } },
+        taskConfig: {
+          linkedIssue: { provider: 'linear' },
+          initialConversation: {
+            provider: 'claude-code',
+            initialQueue: [{ text: 'Investigate ENG-1876' }],
+          },
+        },
+      }
+    );
+
+    expect(mocks.capture).toHaveBeenNthCalledWith(1, 'task_created', {
+      strategy: 'issue',
+      has_initial_prompt: true,
+      has_issue: 'linear',
+      provider: 'claude-code',
+      project_id: 'project-1',
+      task_id: 'task-1',
+    });
+    expect(mocks.capture).toHaveBeenNthCalledWith(2, 'issue_linked_to_task', {
+      provider: 'linear',
+      project_id: 'project-1',
+      task_id: 'task-1',
+    });
+  });
+
+  it('captures task provisioning', () => {
+    const handler = getTaskProvisionedHandler();
+    expect(handler).toBeTypeOf('function');
+
+    handler?.({ projectId: 'project-1', taskId: 'task-1' });
+
+    expect(mocks.capture).toHaveBeenCalledWith('task_provisioned', {
+      project_id: 'project-1',
+      task_id: 'task-1',
+    });
+  });
+});

--- a/apps/emdash-desktop/src/main/index.ts
+++ b/apps/emdash-desktop/src/main/index.ts
@@ -1,5 +1,6 @@
 import './app/configure-app-identity';
 import './core/telemetry/automation-telemetry';
+import './core/telemetry/task-telemetry';
 import { join } from 'node:path';
 import { config as dotenvConfig } from 'dotenv';
 import { app, BrowserWindow, dialog, ipcMain, systemPreferences } from 'electron';


### PR DESCRIPTION
### Description

Register the existing task telemetry module from the Electron main-process entry point. Without this side-effect import, its lifecycle listeners were never installed, so current releases stopped sending `task_created`, initial `issue_linked_to_task`, and `task_provisioned` events.

Add focused regression coverage for listener registration and all three event paths.

### Related issues

[ENG-1876](https://linear.app/general-action/issue/ENG-1876/investigate-posthog-issue-tracker-usage-drop-off-and-create-task-modal)

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] Docs are not required for this internal telemetry registration fix
- [x] I added or updated tests when behavior changed
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit and PR title

</details>