### PR TITLE
feat(settings): add hook injection opt-out

### DIFF
--- a/apps/emdash-desktop/src/main/core/agent-hooks/hook-config-service.ts
+++ b/apps/emdash-desktop/src/main/core/agent-hooks/hook-config-service.ts
@@ -39,8 +39,9 @@ async function ensureGitIgnoreEntries(taskPath: string, entries: string[]): Prom
  * conversation spawn. Writes are idempotent (small-file merges), so re-writing
  * before every spawn removes the "config got cleaned mid-task" failure mode.
  *
- * Returns true if hooks are available for this provider (i.e. hook env vars
- * should be injected into the PTY spawn).
+ * Keeps the user's injection preference separate from installation success.
+ * A failed refresh must not change the default-on spawn environment, while an
+ * explicit opt-out must disable config writes and runtime hook injection.
  */
 export async function ensureHooksInstalled({
   providerId,
@@ -48,9 +49,14 @@ export async function ensureHooksInstalled({
 }: {
   providerId: string;
   taskPath: string;
-}): Promise<boolean> {
+}): Promise<{ hooksAvailable: boolean; injectionEnabled: boolean }> {
+  let injectionEnabled = true;
+
   try {
     const localProjectSettings = await appSettingsService.get('localProject');
+    injectionEnabled = localProjectSettings.injectAgentNotificationHooks ?? true;
+    if (!injectionEnabled) return { hooksAvailable: false, injectionEnabled };
+
     const writeGitIgnoreEntries = localProjectSettings.writeAgentConfigToGitIgnore ?? true;
 
     const plugin = getPlugin(providerId);
@@ -82,13 +88,13 @@ export async function ensureHooksInstalled({
       await ensureGitIgnoreEntries(taskPath, writtenPaths);
     }
 
-    return hooksAvailable;
+    return { hooksAvailable, injectionEnabled };
   } catch (error) {
     log.warn('HookConfigService: failed to ensure hooks installed', {
       providerId,
       taskPath,
       error: String(error),
     });
-    return false;
+    return { hooksAvailable: false, injectionEnabled };
   }
 }

--- a/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/conversation-provider-respawn.test.ts
@@ -50,7 +50,9 @@ vi.mock('@main/core/agents/plugin-registry', () => ({
       hooks:
         id === 'opencode'
           ? { kind: 'plugin', scope: 'workspace', supportedEvents: [] }
-          : { kind: 'none' },
+          : id === 'claude'
+            ? { kind: 'config', scope: 'workspace', supportedEvents: [] }
+            : { kind: 'none' },
       prompt: { kind: 'argv', flag: '' },
     },
     behavior: {
@@ -144,6 +146,7 @@ vi.mock('@main/core/settings/settings-service', () => ({
         : {
             defaultProjectsDirectory: '',
             defaultWorktreeDirectory: '',
+            injectAgentNotificationHooks: true,
             writeAgentConfigToGitIgnore: true,
           }
     ),
@@ -232,12 +235,17 @@ function fakePty(exitHandlers: Array<(info: PtyExitInfo) => void>): Pty {
   };
 }
 
-function mockSettings(): void {
+function mockSettings({
+  injectAgentNotificationHooks = true,
+}: {
+  injectAgentNotificationHooks?: boolean;
+} = {}): void {
   vi.mocked(appSettingsService.get).mockImplementation(async (key) => {
     if (key === 'localProject') {
       return {
         defaultProjectsDirectory: '',
         defaultWorktreeDirectory: '',
+        injectAgentNotificationHooks,
         writeAgentConfigToGitIgnore: true,
       } as never;
     }
@@ -351,6 +359,84 @@ describe('conversation provider respawn state', () => {
       kind: 'workspace',
       path: '/tmp/task-1',
     });
+  });
+
+  it('installs config hooks and injects hook environment variables by default', async () => {
+    vi.mocked(agentHookService.getPort).mockReturnValue(4321);
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+    const item = { ...conversation(), providerId: 'claude' as const };
+
+    await localProvider().startSession(item);
+
+    expect(writeHooksMock).toHaveBeenCalled();
+    expect(buildCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ injectAgentNotificationHooks: true })
+    );
+    const request = spawnLocalPty.mock.calls[0][0] as { env: Record<string, string> };
+    expect(request.env).toMatchObject({
+      EMDASH_HOOK_PORT: '4321',
+      EMDASH_HOOK_NONCE: 'token',
+      EMDASH_HOOK_TOKEN: 'token',
+      EMDASH_PTY_ID: 'claude-conv-conversation-1',
+    });
+  });
+
+  it('preserves the default hook environment when hook installation fails', async () => {
+    vi.mocked(agentHookService.getPort).mockReturnValue(4321);
+    writeHooksMock.mockRejectedValueOnce(new Error('read-only config'));
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+    const item = { ...conversation(), providerId: 'claude' as const };
+
+    await localProvider().startSession(item);
+
+    const request = spawnLocalPty.mock.calls[0][0] as { env: Record<string, string> };
+    expect(request.env).toMatchObject({
+      EMDASH_HOOK_PORT: '4321',
+      EMDASH_HOOK_NONCE: 'token',
+      EMDASH_HOOK_TOKEN: 'token',
+      EMDASH_PTY_ID: 'claude-conv-conversation-1',
+    });
+  });
+
+  it('skips hook installation and hook environment variables when hook injection is disabled', async () => {
+    mockSettings({ injectAgentNotificationHooks: false });
+    vi.mocked(agentHookService.getPort).mockReturnValue(4321);
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+    const item = { ...conversation(), providerId: 'claude' as const };
+
+    await localProvider().startSession(item);
+
+    expect(writeHooksMock).not.toHaveBeenCalled();
+    expect(installPluginMock).not.toHaveBeenCalled();
+    const request = spawnLocalPty.mock.calls[0][0] as { env: Record<string, string> };
+    expect(request.env).not.toHaveProperty('EMDASH_HOOK_PORT');
+    expect(request.env).not.toHaveProperty('EMDASH_HOOK_NONCE');
+    expect(request.env).not.toHaveProperty('EMDASH_HOOK_TOKEN');
+    expect(request.env).not.toHaveProperty('EMDASH_PTY_ID');
+    expect(buildCommandMock).toHaveBeenCalledWith(
+      expect.objectContaining({ injectAgentNotificationHooks: false })
+    );
+  });
+
+  it('skips plugin installation when hook injection is disabled', async () => {
+    mockSettings({ injectAgentNotificationHooks: false });
+    vi.mocked(agentHookService.getPort).mockReturnValue(4321);
+    const exitHandlers: Array<(info: PtyExitInfo) => void> = [];
+    spawnLocalPty.mockReturnValue(fakePty(exitHandlers));
+    const item = { ...conversation(), providerId: 'opencode' as const };
+
+    await localProvider().startSession(item);
+
+    expect(installPluginMock).not.toHaveBeenCalled();
+    expect(writeHooksMock).not.toHaveBeenCalled();
+    const request = spawnLocalPty.mock.calls[0][0] as { env: Record<string, string> };
+    expect(request.env).not.toHaveProperty('EMDASH_HOOK_PORT');
+    expect(request.env).not.toHaveProperty('EMDASH_HOOK_NONCE');
+    expect(request.env).not.toHaveProperty('EMDASH_HOOK_TOKEN');
+    expect(request.env).not.toHaveProperty('EMDASH_PTY_ID');
   });
 
   it('starts a local conversation fresh after a resumed session exits', async () => {

--- a/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
+++ b/apps/emdash-desktop/src/main/core/conversations/impl/local-conversation.ts
@@ -123,7 +123,7 @@ export class LocalConversationProvider implements ConversationProvider {
         host: { kind: 'local', homedir: homedir() },
         force: conversation.autoApprove === true,
       });
-      await ensureHooksInstalled({
+      const hookSetup = await ensureHooksInstalled({
         providerId: conversation.providerId,
         taskPath: this.taskPath,
       });
@@ -159,6 +159,7 @@ export class LocalConversationProvider implements ConversationProvider {
         sessionId: agentSession.sessionId,
         providerSessionId: conversation.sessionId ?? undefined,
         isResuming: agentSession.isResuming,
+        injectAgentNotificationHooks: hookSetup.injectionEnabled,
         model: conversation.model ?? '',
       });
 
@@ -196,7 +197,7 @@ export class LocalConversationProvider implements ConversationProvider {
         cwd: resolved.cwd,
         env: {
           ...buildAgentEnv({
-            hook: port > 0 ? { port, ptyId, token } : undefined,
+            hook: hookSetup.injectionEnabled && port > 0 ? { port, ptyId, token } : undefined,
             providerVars,
             shellProfile: this.shellProfile,
           }),

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -22,6 +22,7 @@ export const projectSettingsSchema = z.object({
 export const localProjectSettingsSchema = z.object({
   defaultProjectsDirectory: z.string(),
   defaultWorktreeDirectory: z.string(),
+  injectAgentNotificationHooks: z.boolean(),
   writeAgentConfigToGitIgnore: z.boolean(),
 });
 

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -23,6 +23,7 @@ export const SETTINGS_DEFAULTS = {
   localProject: () => ({
     defaultProjectsDirectory: join(homedir(), 'emdash', 'repositories'),
     defaultWorktreeDirectory: getDefaultLocalWorktreeDirectory(),
+    injectAgentNotificationHooks: true,
     writeAgentConfigToGitIgnore: true,
   }),
   tasks: {

--- a/apps/emdash-desktop/src/renderer/features/settings/components/RepositorySettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/RepositorySettingsCard.tsx
@@ -27,6 +27,7 @@ const RepositorySettingsCard: React.FC = () => {
   const branchPrefix = project?.branchPrefix ?? '';
   const appendRandomBranchSuffix = project?.appendRandomBranchSuffix ?? true;
   const pushOnCreate = project?.pushOnCreate ?? true;
+  const injectAgentNotificationHooks = localProject?.injectAgentNotificationHooks ?? true;
   const writeAgentConfigToGitIgnore = localProject?.writeAgentConfigToGitIgnore ?? true;
   const projectBusy = projectLoading || projectSaving;
   const localProjectBusy = localProjectLoading || localProjectSaving;
@@ -97,6 +98,29 @@ const RepositorySettingsCard: React.FC = () => {
               onCheckedChange={(checked) => updateProject({ pushOnCreate: checked })}
               disabled={projectBusy}
               aria-label="Enable automatic push on create"
+            />
+          </>
+        }
+      />
+      <SettingRow
+        title="Agent notification hooks"
+        description="Allow Emdash to install and inject notification hooks when starting a local task."
+        control={
+          <>
+            <ResetToDefaultButton
+              visible={isLocalProjectFieldOverridden('injectAgentNotificationHooks')}
+              defaultLabel="on"
+              ariaLabel="Reset agent notification hooks to default"
+              onReset={() => resetLocalProjectField('injectAgentNotificationHooks')}
+              disabled={localProjectBusy}
+            />
+            <Switch
+              checked={injectAgentNotificationHooks}
+              onCheckedChange={(checked) =>
+                updateLocalProject({ injectAgentNotificationHooks: checked })
+              }
+              disabled={localProjectBusy}
+              aria-label="Enable automatic agent notification hook injection"
             />
           </>
         }

--- a/apps/emdash-desktop/src/renderer/features/settings/components/ResetToDefaultButton.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/ResetToDefaultButton.tsx
@@ -6,6 +6,7 @@ import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@rende
 interface ResetToDefaultButtonProps {
   /** Optional label shown in the tooltip: "Reset to default: <label>" */
   defaultLabel?: string;
+  ariaLabel?: string;
   onReset: () => void;
   disabled?: boolean;
   visible?: boolean;
@@ -13,6 +14,7 @@ interface ResetToDefaultButtonProps {
 
 export const ResetToDefaultButton: React.FC<ResetToDefaultButtonProps> = ({
   defaultLabel,
+  ariaLabel = 'Reset to default',
   onReset,
   disabled,
   visible = true,
@@ -32,7 +34,7 @@ export const ResetToDefaultButton: React.FC<ResetToDefaultButtonProps> = ({
             className="text-muted-foreground h-7 w-7 shrink-0 hover:text-foreground"
             onClick={onReset}
             disabled={disabled}
-            aria-label="Reset to default"
+            aria-label={ariaLabel}
           >
             <RotateCcw className="h-3.5 w-3.5" />
           </Button>

--- a/packages/core/src/agents/plugins/capabilities/prompt.ts
+++ b/packages/core/src/agents/plugins/capabilities/prompt.ts
@@ -14,6 +14,8 @@ export type CommandContext = {
    * codex, droid). Undefined means the provider has not yet emitted a session ID. */
   providerSessionId?: string;
   isResuming?: boolean;
+  /** Whether Emdash-managed hooks may be added to provider command config. Defaults to true. */
+  injectAgentNotificationHooks?: boolean;
   model: string;
 };
 

--- a/packages/plugins/src/agents/impl/kimi/index.test.ts
+++ b/packages/plugins/src/agents/impl/kimi/index.test.ts
@@ -1,0 +1,37 @@
+import type { CommandContext } from '@emdash/core/agents/plugins';
+import { describe, expect, it } from 'vitest';
+import { provider } from './index';
+
+const baseContext = {
+  cli: 'kimi',
+  autoApprove: false,
+  initialPrompt: undefined,
+  sessionId: 'emdash-conversation-id',
+  providerSessionId: undefined,
+  isResuming: false,
+  model: '',
+} satisfies CommandContext;
+
+describe('kimi provider', () => {
+  it('injects hooks into inline config by default', () => {
+    const inlineConfig = JSON.stringify({ theme: 'dark' });
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      extraArgs: [`--config=${inlineConfig}`],
+    });
+
+    expect(command.args.join(' ')).toContain('EMDASH_HOOK_PORT');
+  });
+
+  it('preserves inline config when hook injection is disabled', () => {
+    const inlineConfig = JSON.stringify({ theme: 'dark' });
+    const command = provider.behavior.prompt!.buildCommand({
+      ...baseContext,
+      extraArgs: [`--config=${inlineConfig}`],
+      injectAgentNotificationHooks: false,
+    });
+
+    expect(command.args).toContain(`--config=${inlineConfig}`);
+    expect(command.args.join(' ')).not.toContain('EMDASH_HOOK_PORT');
+  });
+});

--- a/packages/plugins/src/agents/impl/kimi/index.ts
+++ b/packages/plugins/src/agents/impl/kimi/index.ts
@@ -23,6 +23,7 @@ function buildKimiCommand(ctx: CommandContext): AgentCommand {
     resumeWithoutSessionFlag: '-C',
     omitAutoApproveOnResume: true,
   });
+  if (ctx.injectAgentNotificationHooks === false) return cmd;
   return { ...cmd, args: injectKimiHooksIntoInlineConfig(cmd.args) };
 }
 import { icon } from './icon';


### PR DESCRIPTION
## Description

Adds a default-on repository setting that lets users opt out of Emdash-managed agent notification hooks for local tasks.

When disabled, Emdash skips persistent config/plugin and `.gitignore` writes, does not modify Kimi's inline `--config`, and omits `EMDASH_HOOK_*` plus `EMDASH_PTY_ID` from the spawned agent environment. Existing managed entries are left untouched, so toggling the setting does not destructively rewrite user config.

The injection preference is kept separate from installation success: default-on sessions retain the previous environment behavior even if refreshing a hook file fails.

## Related issues

Closes #1944

## Testing

- Desktop Node suite: 1,981/1,981 passed.
- Local conversation regression suite: 33/33 passed.
- Kimi command tests: 2/2 passed.
- Desktop, core, and plugins typecheck, lint, and format checks passed.
- `git diff --check` passed.
- A concurrent full-app run had one unrelated `IssueSelector` 5-second timeout; that test passed immediately when rerun alone.

## Screenshot/Recording

Not included; the change adds one repository settings row and is covered by build/type checks.

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added tests that prove the fix is effective
- [x] I have run the relevant checks locally
- [x] I have searched for existing pull requests and found no duplicate
