### PR TITLE
feat(ui): modernize monospaced typography

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -8,6 +8,10 @@ import {
   DEFAULT_TERMINAL_SHELL_AVAILABILITY,
   useTerminalShellAvailability,
 } from '@renderer/lib/hooks/use-terminal-shell-availability';
+import {
+  DEFAULT_MONOSPACE_FONT_FAMILY,
+  DEFAULT_MONOSPACE_FONT_LABEL,
+} from '@renderer/lib/monospace-font';
 import { Button } from '@renderer/lib/ui/button';
 import {
   Combobox,
@@ -60,11 +64,9 @@ const POPULAR_FONTS = [
   'MesloLGS NF',
 ];
 
-const DEFAULT_FONT_FAMILY = 'Menlo';
-
 const DEFAULT_OPTION: FontOption = {
   value: '',
-  label: `Default (${DEFAULT_FONT_FAMILY})`,
+  label: `Default (${DEFAULT_MONOSPACE_FONT_LABEL})`,
 };
 
 const clampFontSize = (size: number) =>
@@ -258,7 +260,7 @@ const TerminalSettingsCard: React.FC = () => {
                     disabled={loading || saving}
                     className="flex h-9 w-full items-center justify-between rounded-md border border-border bg-transparent px-2.5 py-1 text-left text-sm font-normal outline-none disabled:opacity-50"
                   >
-                    <ComboboxValue placeholder="Default (Menlo)" />
+                    <ComboboxValue placeholder={`Default (${DEFAULT_MONOSPACE_FONT_LABEL})`} />
                     <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 text-foreground-muted" />
                   </button>
                 }
@@ -285,7 +287,9 @@ const TerminalSettingsCard: React.FC = () => {
                           <ComboboxItem key={item.value || '__default__'} value={item}>
                             <span
                               style={{
-                                fontFamily: item.value ? `"${item.value}"` : DEFAULT_FONT_FAMILY,
+                                fontFamily: item.value
+                                  ? `"${item.value}"`
+                                  : DEFAULT_MONOSPACE_FONT_FAMILY,
                               }}
                             >
                               {item.label}

--- a/apps/emdash-desktop/src/renderer/index.css
+++ b/apps/emdash-desktop/src/renderer/index.css
@@ -12,7 +12,17 @@
   --font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
-  --font-mono: var(--em-font-mono);
+  --font-mono: var(
+    --em-font-mono,
+    ui-monospace,
+    'SFMono-Regular',
+    Menlo,
+    Monaco,
+    Consolas,
+    'Liberation Mono',
+    'Courier New',
+    monospace
+  );
 
   --text-code: 13px;
   --text-code--line-height: 1.2;
@@ -845,7 +855,7 @@
   --chat-font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
-  --chat-font-mono: var(--em-font-mono);
+  --chat-font-mono: var(--em-font-mono, var(--font-mono));
   --chat-radius-sm: 0.375rem;
   --chat-radius-md: 0.5rem;
   --chat-radius-lg: 0.625rem;
@@ -889,7 +899,7 @@
   --chat-font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
-  --chat-font-mono: var(--em-font-mono);
+  --chat-font-mono: var(--em-font-mono, var(--font-mono));
   --chat-radius-sm: 0.375rem;
   --chat-radius-md: 0.5rem;
   --chat-radius-lg: 0.625rem;

--- a/apps/emdash-desktop/src/renderer/index.css
+++ b/apps/emdash-desktop/src/renderer/index.css
@@ -12,7 +12,7 @@
   --font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
-  --font-mono: Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace;
+  --font-mono: var(--em-font-mono);
 
   --text-code: 13px;
   --text-code--line-height: 1.2;
@@ -845,7 +845,7 @@
   --chat-font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
-  --chat-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', Menlo, Monaco, Consolas, monospace;
+  --chat-font-mono: var(--em-font-mono);
   --chat-radius-sm: 0.375rem;
   --chat-radius-md: 0.5rem;
   --chat-radius-lg: 0.625rem;
@@ -889,7 +889,7 @@
   --chat-font-sans:
     -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Oxygen, Ubuntu, Cantarell, 'Fira Sans',
     'Droid Sans', 'Helvetica Neue', sans-serif;
-  --chat-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', Menlo, Monaco, Consolas, monospace;
+  --chat-font-mono: var(--em-font-mono);
   --chat-radius-sm: 0.375rem;
   --chat-radius-md: 0.5rem;
   --chat-radius-lg: 0.625rem;

--- a/apps/emdash-desktop/src/renderer/lib/editor/utils.ts
+++ b/apps/emdash-desktop/src/renderer/lib/editor/utils.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_MONOSPACE_FONT_FAMILY } from '@renderer/lib/monospace-font';
+
 const MARKDOWN_EXTENSIONS = ['md', 'mdx'];
 
 /** Returns true if the file path points to a markdown file. */
@@ -16,6 +18,7 @@ export const isMarkdownFile = isMarkdownPath;
 /** Default Monaco editor options shared across all editor instances. */
 export const DEFAULT_EDITOR_OPTIONS = {
   minimap: { enabled: true },
+  fontFamily: DEFAULT_MONOSPACE_FONT_FAMILY,
   fontSize: 13,
   padding: { top: 12, bottom: 12 },
   lineNumbers: 'on' as const,

--- a/apps/emdash-desktop/src/renderer/lib/monaco/editorConfig.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/editorConfig.ts
@@ -1,8 +1,10 @@
 import type { editor } from 'monaco-editor';
+import { DEFAULT_MONOSPACE_FONT_FAMILY } from '@renderer/lib/monospace-font';
 
 /** Shared options for all DiffEditor instances in the diff viewer. */
 export const DIFF_EDITOR_BASE_OPTIONS: editor.IDiffEditorConstructionOptions = {
   originalEditable: false,
+  fontFamily: DEFAULT_MONOSPACE_FONT_FAMILY,
   fontSize: 13,
   lineHeight: 20,
   minimap: { enabled: false },

--- a/apps/emdash-desktop/src/renderer/lib/monospace-font.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monospace-font.ts
@@ -1,0 +1,3 @@
+export { DEFAULT_MONOSPACE_FONT_FAMILIES, DEFAULT_MONOSPACE_FONT_FAMILY } from '@emdash/shared';
+
+export const DEFAULT_MONOSPACE_FONT_LABEL = 'System monospace';

--- a/apps/emdash-desktop/src/renderer/lib/pty/terminal-font.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/terminal-font.test.ts
@@ -4,33 +4,37 @@ import { buildTerminalFontFamily } from './terminal-font';
 describe('buildTerminalFontFamily', () => {
   it('quotes font family names that contain spaces', () => {
     expect(buildTerminalFontFamily('SF Mono')).toBe(
-      '"SF Mono", "Menlo", "Monaco", "Consolas", monospace'
+      '"SF Mono", ui-monospace, "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace'
     );
   });
 
   it('escapes quotes in custom font names', () => {
     expect(buildTerminalFontFamily('Font "Name"')).toBe(
-      '"Font \\"Name\\"", "Menlo", "Monaco", "Consolas", monospace'
+      '"Font \\"Name\\"", ui-monospace, "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace'
     );
   });
 
   it('preserves comma-separated custom font family lists', () => {
     expect(buildTerminalFontFamily('SF Mono, Menlo, Monaco')).toBe(
-      '"SF Mono", "Menlo", "Monaco", "Consolas", monospace'
+      '"SF Mono", "Menlo", "Monaco", ui-monospace, "SFMono-Regular", "Consolas", "Liberation Mono", "Courier New", monospace'
     );
   });
 
   it('does not treat quoted CSS lists as a single quoted font name', () => {
     expect(buildTerminalFontFamily('"SF Mono", "Menlo"')).toBe(
-      '"SF Mono", "Menlo", "Monaco", "Consolas", monospace'
+      '"SF Mono", "Menlo", ui-monospace, "SFMono-Regular", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace'
     );
   });
 
   it('keeps generic font families unquoted', () => {
-    expect(buildTerminalFontFamily('monospace')).toBe('monospace, "Menlo", "Monaco", "Consolas"');
+    expect(buildTerminalFontFamily('monospace')).toBe(
+      'monospace, ui-monospace, "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New"'
+    );
   });
 
   it('uses terminal-safe fallbacks when no custom font is set', () => {
-    expect(buildTerminalFontFamily()).toBe('"Menlo", "Monaco", "Consolas", monospace');
+    expect(buildTerminalFontFamily()).toBe(
+      'ui-monospace, "SFMono-Regular", "Menlo", "Monaco", "Consolas", "Liberation Mono", "Courier New", monospace'
+    );
   });
 });

--- a/apps/emdash-desktop/src/renderer/lib/pty/terminal-font.ts
+++ b/apps/emdash-desktop/src/renderer/lib/pty/terminal-font.ts
@@ -1,4 +1,4 @@
-const TERMINAL_FONT_FALLBACKS = ['Menlo', 'Monaco', 'Consolas', 'monospace'];
+import { DEFAULT_MONOSPACE_FONT_FAMILIES } from '@renderer/lib/monospace-font';
 
 const CSS_GENERIC_FAMILIES = new Set([
   'serif',
@@ -52,8 +52,8 @@ const splitFontFamilies = (fontFamily: string) => {
 export const buildTerminalFontFamily = (fontFamily?: string) => {
   const customFontFamily = fontFamily?.trim();
   const families = customFontFamily
-    ? [...splitFontFamilies(customFontFamily), ...TERMINAL_FONT_FALLBACKS]
-    : TERMINAL_FONT_FALLBACKS;
+    ? [...splitFontFamilies(customFontFamily), ...DEFAULT_MONOSPACE_FONT_FAMILIES]
+    : DEFAULT_MONOSPACE_FONT_FAMILIES;
 
   return Array.from(new Set(families.map(quoteFontFamily).filter(Boolean))).join(', ');
 };

--- a/apps/emdash-desktop/src/renderer/tests/editor-config.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/editor-config.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it } from 'vitest';
+import { DEFAULT_EDITOR_OPTIONS } from '@renderer/lib/editor/utils';
 import { DIFF_EDITOR_BASE_OPTIONS } from '@renderer/lib/monaco/editorConfig';
+import { DEFAULT_MONOSPACE_FONT_FAMILY } from '@renderer/lib/monospace-font';
 
 describe('DIFF_EDITOR_BASE_OPTIONS', () => {
   it('keeps unchanged diff regions visible for large text selection', () => {
@@ -8,5 +10,10 @@ describe('DIFF_EDITOR_BASE_OPTIONS', () => {
 
   it('renders +/- gutter indicators for added and removed lines', () => {
     expect(DIFF_EDITOR_BASE_OPTIONS.renderIndicators).toBe(true);
+  });
+
+  it('uses the shared modern monospace stack for file and diff editors', () => {
+    expect(DEFAULT_EDITOR_OPTIONS.fontFamily).toBe(DEFAULT_MONOSPACE_FONT_FAMILY);
+    expect(DIFF_EDITOR_BASE_OPTIONS.fontFamily).toBe(DEFAULT_MONOSPACE_FONT_FAMILY);
   });
 });

--- a/packages/chat-ui/src/components/rows/tools/file-op/file-op.css.ts
+++ b/packages/chat-ui/src/components/rows/tools/file-op/file-op.css.ts
@@ -58,7 +58,7 @@ export const fileOpHeader = style({
 });
 
 export const monoRunning = style({
-  fontFamily: 'monospace',
+  fontFamily: vars.fontMono,
   fontSize: vars.typeBodyFontSize,
   color: vars.fgPassive,
 });

--- a/packages/chat-ui/src/core/config.test.ts
+++ b/packages/chat-ui/src/core/config.test.ts
@@ -5,8 +5,15 @@ import { DEFAULT_CONFIG, toFontConfig } from './config';
 describe('default monospace typography', () => {
   it('uses the shared modern system stack for styling and measurement', () => {
     expect(DEFAULT_CONFIG.fonts.mono).toEqual(DEFAULT_MONOSPACE_FONT_FAMILIES);
-    expect(toFontConfig(DEFAULT_CONFIG).code.font).toContain(
-      DEFAULT_MONOSPACE_FONT_FAMILY.replaceAll("'", '')
+    expect(toFontConfig(DEFAULT_CONFIG).code.font).toBe(
+      `400 13px ${DEFAULT_MONOSPACE_FONT_FAMILY}`
     );
+  });
+
+  it('quotes multi-word font families used for text measurement', () => {
+    const fonts = toFontConfig(DEFAULT_CONFIG);
+
+    expect(fonts.body.font).toContain("'Inter Variable'");
+    expect(fonts.code.font).toContain("'Liberation Mono', 'Courier New'");
   });
 });

--- a/packages/chat-ui/src/core/config.test.ts
+++ b/packages/chat-ui/src/core/config.test.ts
@@ -1,0 +1,12 @@
+import { DEFAULT_MONOSPACE_FONT_FAMILIES, DEFAULT_MONOSPACE_FONT_FAMILY } from '@emdash/shared';
+import { describe, expect, it } from 'vitest';
+import { DEFAULT_CONFIG, toFontConfig } from './config';
+
+describe('default monospace typography', () => {
+  it('uses the shared modern system stack for styling and measurement', () => {
+    expect(DEFAULT_CONFIG.fonts.mono).toEqual(DEFAULT_MONOSPACE_FONT_FAMILIES);
+    expect(toFontConfig(DEFAULT_CONFIG).code.font).toContain(
+      DEFAULT_MONOSPACE_FONT_FAMILY.replaceAll("'", '')
+    );
+  });
+});

--- a/packages/chat-ui/src/core/config.ts
+++ b/packages/chat-ui/src/core/config.ts
@@ -180,8 +180,20 @@ export const DEFAULT_CONFIG: ChatConfig = {
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
 
+function quoteFontFamily(fontFamily: string): string {
+  const isQuoted =
+    (fontFamily.startsWith("'") && fontFamily.endsWith("'")) ||
+    (fontFamily.startsWith('"') && fontFamily.endsWith('"'));
+
+  return fontFamily.includes(' ') && !isQuoted
+    ? `'${fontFamily.replaceAll("'", "\\'")}'`
+    : fontFamily;
+}
+
 function familyCss(config: ChatConfig, family: 'sans' | 'mono'): string {
-  return (family === 'mono' ? config.fonts.mono : config.fonts.sans).join(', ');
+  return (family === 'mono' ? config.fonts.mono : config.fonts.sans)
+    .map(quoteFontFamily)
+    .join(', ');
 }
 
 /** Build a CSS font shorthand string (style? weight size family). */

--- a/packages/chat-ui/src/core/config.ts
+++ b/packages/chat-ui/src/core/config.ts
@@ -20,6 +20,8 @@
  * them — see prose/geometry.ts and engine/row-metrics.ts.
  */
 
+import { DEFAULT_MONOSPACE_FONT_FAMILIES } from '@emdash/shared';
+
 // ── VariantMetrics + FontConfig (measurement-side types) ──────────────────────
 //
 // Defined here (not in core/measure/fonts.ts) to avoid circular imports between
@@ -151,7 +153,7 @@ export type ResolvedTheme = {
 export const DEFAULT_CONFIG: ChatConfig = {
   fonts: {
     sans: ['Inter Variable', 'sans-serif'],
-    mono: ['JetBrains Mono Variable', 'JetBrains Mono', 'Menlo', 'Monaco', 'monospace'],
+    mono: [...DEFAULT_MONOSPACE_FONT_FAMILIES],
   },
   roles: {
     body: { family: 'sans', size: 14, weight: 400, lineHeight: 20 },

--- a/packages/chat-ui/src/core/measure/pretext-cache.ts
+++ b/packages/chat-ui/src/core/measure/pretext-cache.ts
@@ -12,18 +12,13 @@
 export { clearCache as clearPretextInternalCaches } from '@chenglou/pretext';
 
 /**
- * Named font faces to pre-load.  These must exactly match the font-family names
- * used in metrics.ts so `document.fonts.load()` resolves them correctly.
+ * Named webfont faces to pre-load. The default monospace stack uses system
+ * fonts, which are immediately available and do not need an async load.
  */
-const FONT_LOAD_SPECS = [
-  '400 14px "Inter Variable"',
-  '600 14px "Inter Variable"',
-  '400 13px "JetBrains Mono Variable"',
-  '400 12px "JetBrains Mono Variable"',
-];
+const FONT_LOAD_SPECS = ['400 14px "Inter Variable"', '600 14px "Inter Variable"'];
 
 /**
- * Eagerly load the bundled named fonts, then call `onCleared`
+ * Eagerly load the bundled named webfonts, then call `onCleared`
  * (which should invoke `caches.clearTextMeasure()` + `virtualizer.measure()`).
  *
  * Using `document.fonts.load(spec)` instead of `document.fonts.ready` ensures

--- a/packages/chat-ui/src/styles/theme.css.ts
+++ b/packages/chat-ui/src/styles/theme.css.ts
@@ -22,6 +22,7 @@
  */
 
 import { DEFAULT_CONFIG, toThemeVars } from '@core/config';
+import { DEFAULT_MONOSPACE_FONT_FAMILY } from '@emdash/shared';
 import { createGlobalTheme, createGlobalThemeContract } from '@vanilla-extract/css';
 
 // ── Contract (stable public names) ────────────────────────────────────────────
@@ -169,7 +170,7 @@ export const vars = createGlobalThemeContract(
 
 const NON_COLOR_VARS = {
   fontSans: ['Inter Variable', 'sans-serif'].join(', '),
-  fontMono: "'JetBrains Mono Variable', 'JetBrains Mono', Menlo, Monaco, monospace",
+  fontMono: DEFAULT_MONOSPACE_FONT_FAMILY,
   radiusSm: '0.375rem',
   radiusMd: '0.5rem',
   radiusLg: '0.625rem',

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -50,3 +50,4 @@ export type {
   Unsubscribe,
 } from './lifecycle';
 export { LifecycleMap, type LifecycleHooks, type LifecycleStatus } from './lifecycle-map';
+export { DEFAULT_MONOSPACE_FONT_FAMILIES, DEFAULT_MONOSPACE_FONT_FAMILY } from './monospace-font';

--- a/packages/shared/src/monospace-font.ts
+++ b/packages/shared/src/monospace-font.ts
@@ -1,0 +1,16 @@
+export const DEFAULT_MONOSPACE_FONT_FAMILIES = [
+  'ui-monospace',
+  'SFMono-Regular',
+  'Menlo',
+  'Monaco',
+  'Consolas',
+  'Liberation Mono',
+  'Courier New',
+  'monospace',
+] as const;
+
+const formatCssFontFamily = (fontFamily: string) =>
+  fontFamily.includes(' ') ? `'${fontFamily}'` : fontFamily;
+
+export const DEFAULT_MONOSPACE_FONT_FAMILY =
+  DEFAULT_MONOSPACE_FONT_FAMILIES.map(formatCssFontFamily).join(', ');

--- a/packages/ui/src/react/chat-ui/chat-theme.css
+++ b/packages/ui/src/react/chat-ui/chat-theme.css
@@ -7,7 +7,7 @@
  * desktop app's visual language.
  *
  * Theming model:
- *   chat-ui default (theme.css.ts :where())   — self-contained, Inter + JetBrains Mono
+ *   chat-ui default (theme.css.ts :where())   — self-contained typography defaults
  *   └── this file (.emlight / .emdark rules)  — overrides fonts/colors for desktop
  *       └── --chat-font-sans: var(--em-font-sans) — system sans (not Inter) on desktop
  *
@@ -86,7 +86,7 @@
   /* ── Non-color design tokens ─────────────────────────────────────────────── */
   /* Mirror @emdash/ui/theme/theme.base.css so chat-ui inherits the app radius scale. */
   --chat-font-sans: var(--em-font-sans);
-  --chat-font-mono: 'JetBrains Mono Variable', 'JetBrains Mono', Menlo, Monaco, monospace;
+  --chat-font-mono: var(--em-font-mono);
   --chat-radius-sm: 0.375rem;
   --chat-radius-md: 0.5rem;
   --chat-radius-lg: 0.625rem;

--- a/packages/ui/src/theme/tokens.css.ts
+++ b/packages/ui/src/theme/tokens.css.ts
@@ -15,6 +15,7 @@
  * into another and cannot be represented in the VE typed-vars map.
  */
 
+import { DEFAULT_MONOSPACE_FONT_FAMILY } from '@emdash/shared';
 import { nsName } from '@theme/core/contract/namespace';
 import { createGlobalThemeContract, globalStyle } from '@vanilla-extract/css';
 
@@ -77,7 +78,7 @@ globalStyle(':root', {
   vars: {
     // Font families
     [tokenVars.fontSans]: "'Inter Variable', sans-serif",
-    [tokenVars.fontMono]: "'JetBrains Mono Variable', 'JetBrains Mono', Menlo, Monaco, monospace",
+    [tokenVars.fontMono]: DEFAULT_MONOSPACE_FONT_FAMILY,
 
     // Font weight scale
     [tokenVars.fontWeightNormal]: '400',


### PR DESCRIPTION
## Description

Modernizes and unifies Emdash's default monospaced typography with the system-first stack proposed in the issue:

`ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, 'Liberation Mono', 'Courier New', monospace`

The ordered family list now has one TypeScript source in `@emdash/shared`. Desktop Tailwind utilities, design-system tokens, chat styling and text measurement, terminal fallbacks, and both Monaco editor variants use the same default. A user-selected terminal font remains first, followed by the modern fallback stack.

Because the default mono families are system fonts, chat startup no longer waits for the bundled JetBrains Mono face before clearing text-measurement caches. Inter webfont loading remains unchanged.

Compatibility note: #2877 is functionally independent but overlaps this branch in four small editor/settings files. I verified the combined result in a temporary integration worktree; whichever PR lands second will need a small rebase to preserve both changes.

## Related issues

Closes #2807

## Testing

- Desktop focused terminal/editor tests: 9/9 passed.
- Desktop app suite: 315 files, 2,210 tests passed.
- Chat UI suite: 17 files, 230 tests passed.
- Shared suite: 14 files, 159 tests passed.
- Affected desktop/chat/shared/UI typecheck, lint, and format checks passed.
- Chat library build and desktop renderer production build passed.
- Combined #2876 + #2877 integration: 19 focused tests, desktop lint/typecheck/format, and full workspace build passed.
- `git diff --check` passed.

The repository-wide package suite still has five unrelated existing failures in runtime, UI mention serialization, and plugin allowlist/snapshot tests; the affected packages and desktop application pass independently.

## Screenshot/Recording

Not included. The selected system font is platform-dependent (SF Mono on current macOS, with native fallbacks on Windows/Linux).

## Checklist

- [x] I have read the contributing guidelines
- [x] I have added regression coverage for the shared editor/terminal defaults
- [x] I have run the relevant tests and production builds locally
- [x] I have searched for existing pull requests and found no duplicate
