### PR TITLE
feat(settings): add editor font controls

### DIFF
--- a/apps/emdash-desktop/src/main/core/settings/editor-settings.test.ts
+++ b/apps/emdash-desktop/src/main/core/settings/editor-settings.test.ts
@@ -1,0 +1,74 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { EDITOR_FONT_SIZE_DEFAULT } from '@shared/core/editor/editor-settings';
+
+const storedSettings = vi.hoisted(() => new Map<string, string>());
+
+vi.mock('drizzle-orm', () => ({
+  eq: vi.fn((column, value) => ({ column, value })),
+}));
+
+vi.mock('@main/db/schema', () => ({
+  appSettings: { key: 'key', value: 'value' },
+}));
+
+vi.mock('@main/db/client', () => ({
+  db: {
+    select: vi.fn(() => ({
+      from: vi.fn(() => ({
+        where: vi.fn((predicate: { value: string }) => ({
+          execute: vi.fn(async () => {
+            const value = storedSettings.get(predicate.value);
+            return value === undefined ? [] : [{ key: predicate.value, value }];
+          }),
+        })),
+      })),
+    })),
+    insert: vi.fn(() => ({
+      values: vi.fn((row: { key: string; value: string }) => ({
+        onConflictDoUpdate: vi.fn(() => ({
+          execute: vi.fn(async () => {
+            storedSettings.set(row.key, row.value);
+          }),
+        })),
+      })),
+    })),
+    delete: vi.fn(() => ({
+      where: vi.fn((predicate: { value: string }) => ({
+        execute: vi.fn(async () => {
+          storedSettings.delete(predicate.value);
+        }),
+      })),
+    })),
+  },
+}));
+
+const { SettingsStore } = await import('./settings-service');
+
+describe('editor settings persistence', () => {
+  beforeEach(() => {
+    storedSettings.clear();
+  });
+
+  it('supplies defaults when upgrading an existing database with no editor row', async () => {
+    const settings = new SettingsStore();
+
+    await expect(settings.getAll()).resolves.toMatchObject({
+      editor: { fontSize: EDITOR_FONT_SIZE_DEFAULT },
+    });
+  });
+
+  it('stores editor preferences independently and removes the row after reset', async () => {
+    const settings = new SettingsStore();
+
+    await settings.update('editor', { fontFamily: 'JetBrains Mono', fontSize: 16 });
+
+    expect(JSON.parse(storedSettings.get('editor') ?? '{}')).toEqual({
+      fontFamily: 'JetBrains Mono',
+      fontSize: 16,
+    });
+
+    await settings.update('editor', { fontSize: EDITOR_FONT_SIZE_DEFAULT });
+
+    expect(storedSettings.has('editor')).toBe(false);
+  });
+});

--- a/apps/emdash-desktop/src/main/core/settings/schema.ts
+++ b/apps/emdash-desktop/src/main/core/settings/schema.ts
@@ -1,6 +1,7 @@
 import type { AgentProviderId } from '@emdash/plugins/agents';
 import z from 'zod';
 import { BROWSER_ISOLATED_PROFILE_ID } from '@shared/browser';
+import { EDITOR_FONT_SIZE_MAX, EDITOR_FONT_SIZE_MIN } from '@shared/core/editor/editor-settings';
 import {
   TERMINAL_FONT_SIZE_MAX,
   TERMINAL_FONT_SIZE_MIN,
@@ -49,6 +50,11 @@ export const terminalSettingsSchema = z.object({
   autoCopyOnSelection: z.boolean(),
   macOptionIsMeta: z.boolean(),
   defaultShell: z.enum(TERMINAL_SHELL_IDS),
+});
+
+export const editorSettingsSchema = z.object({
+  fontFamily: z.string().optional(),
+  fontSize: z.number().min(EDITOR_FONT_SIZE_MIN).max(EDITOR_FONT_SIZE_MAX),
 });
 
 export const themeSchema = z
@@ -148,6 +154,7 @@ export const APP_SETTINGS_SCHEMA_MAP = {
   openIn: openInSettingsSchema,
   interface: interfaceSettingsSchema,
   terminal: terminalSettingsSchema,
+  editor: editorSettingsSchema,
   browserPreview: browserPreviewSettingsSchema,
   browser: browserSettingsSchema,
   resourceMonitor: resourceMonitorSettingsSchema,
@@ -165,6 +172,7 @@ export const appSettingsSchema = z.object({
   openIn: openInSettingsSchema,
   interface: interfaceSettingsSchema,
   terminal: terminalSettingsSchema,
+  editor: editorSettingsSchema,
   browserPreview: browserPreviewSettingsSchema,
   browser: browserSettingsSchema,
   resourceMonitor: resourceMonitorSettingsSchema,

--- a/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
+++ b/apps/emdash-desktop/src/main/core/settings/settings-registry.ts
@@ -3,6 +3,7 @@ import { join } from 'node:path';
 import { asAgentProviderId } from '@emdash/plugins/agents/types';
 import { DEFAULT_BROWSER_PROFILE_ID, DEFAULT_BROWSER_PROFILES } from '@shared/browser';
 import type { AppSettings, AppSettingsKey } from '@shared/core/app-settings';
+import { EDITOR_FONT_SIZE_DEFAULT } from '@shared/core/editor/editor-settings';
 import { TERMINAL_FONT_SIZE_DEFAULT } from '@shared/core/terminals/terminal-settings';
 import type { OpenInAppId } from '@shared/openInApps';
 import { getDefaultLocalWorktreeDirectory } from './worktree-defaults';
@@ -46,6 +47,9 @@ export const SETTINGS_DEFAULTS = {
     autoCopyOnSelection: false,
     macOptionIsMeta: false,
     defaultShell: 'system' as const,
+  },
+  editor: {
+    fontSize: EDITOR_FONT_SIZE_DEFAULT,
   },
   theme: null,
   defaultAgent: DEFAULT_AGENT_ID,

--- a/apps/emdash-desktop/src/renderer/features/settings/components/EditorSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/EditorSettingsCard.tsx
@@ -1,0 +1,55 @@
+import { useCallback } from 'react';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
+import {
+  EDITOR_FONT_SIZE_DEFAULT,
+  EDITOR_FONT_SIZE_MAX,
+  EDITOR_FONT_SIZE_MIN,
+} from '@shared/core/editor/editor-settings';
+import { FontFamilySettingRow, FontSizeSettingRow } from './FontSettingsRows';
+
+export function EditorSettingsCard() {
+  const { value: editor, update, isLoading, isSaving } = useAppSettingsKey('editor');
+
+  const fontFamily = editor?.fontFamily ?? '';
+  const fontSize = editor?.fontSize ?? EDITOR_FONT_SIZE_DEFAULT;
+
+  const applyFontFamily = useCallback(
+    (next: string) => {
+      update({ fontFamily: next.trim() || undefined });
+    },
+    [update]
+  );
+
+  const applyFontSize = useCallback(
+    (next: number) => {
+      update({
+        fontSize: Math.min(EDITOR_FONT_SIZE_MAX, Math.max(EDITOR_FONT_SIZE_MIN, next)),
+      });
+    },
+    [update]
+  );
+
+  return (
+    <div className="flex flex-col gap-4">
+      <FontFamilySettingRow
+        title="File preview font"
+        description="Choose the font family used for text files and diffs."
+        value={fontFamily}
+        defaultLabel="Default (Monaco editor)"
+        defaultPreviewFontFamily="monospace"
+        disabled={isLoading || isSaving}
+        onChange={applyFontFamily}
+      />
+      <FontSizeSettingRow
+        title="File preview font size"
+        description="Adjust the font size used for text files and diffs."
+        value={fontSize}
+        min={EDITOR_FONT_SIZE_MIN}
+        max={EDITOR_FONT_SIZE_MAX}
+        controlLabel="file preview font size"
+        disabled={isLoading || isSaving}
+        onChange={applyFontSize}
+      />
+    </div>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/settings/components/FontSettingsRows.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/FontSettingsRows.tsx
@@ -1,0 +1,263 @@
+import { ChevronsUpDownIcon, LoaderCircle, Minus, Plus } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { useInstalledFonts } from '@renderer/features/settings/use-installed-fonts';
+import { Button } from '@renderer/lib/ui/button';
+import {
+  Combobox,
+  ComboboxCollection,
+  ComboboxContent,
+  ComboboxEmpty,
+  ComboboxGroup,
+  ComboboxInput,
+  ComboboxItem,
+  ComboboxLabel,
+  ComboboxList,
+  ComboboxTrigger,
+  ComboboxValue,
+} from '@renderer/lib/ui/combobox';
+import { SettingRow } from './SettingRow';
+
+type FontOption = {
+  value: string;
+  label: string;
+};
+
+type FontGroup = {
+  value: 'popular' | 'installed';
+  label: string;
+  items: FontOption[];
+};
+
+const POPULAR_FONTS = [
+  'Menlo',
+  'SF Mono',
+  'JetBrains Mono',
+  'Fira Code',
+  'Cascadia Code',
+  'Iosevka',
+  'Source Code Pro',
+  'MesloLGS NF',
+];
+
+interface FontFamilySettingRowProps {
+  title: string;
+  description: string;
+  value: string;
+  defaultLabel: string;
+  defaultPreviewFontFamily?: string;
+  disabled?: boolean;
+  onChange: (fontFamily: string) => void;
+}
+
+export function FontFamilySettingRow({
+  title,
+  description,
+  value,
+  defaultLabel,
+  defaultPreviewFontFamily,
+  disabled = false,
+  onChange,
+}: FontFamilySettingRowProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const { fonts: installedFonts, isLoading: loadingFonts } = useInstalledFonts();
+
+  const defaultOption = useMemo<FontOption>(
+    () => ({ value: '', label: defaultLabel }),
+    [defaultLabel]
+  );
+
+  const groups = useMemo<FontGroup[]>(() => {
+    const popularSet = new Set(POPULAR_FONTS.map((font) => font.toLowerCase()));
+    const installedSet = new Set(installedFonts.map((font) => font.toLowerCase()));
+    const popularItems: FontOption[] = [defaultOption];
+
+    for (const font of POPULAR_FONTS) {
+      if (installedSet.has(font.toLowerCase())) {
+        popularItems.push({ value: font, label: font });
+      }
+    }
+
+    const installedItems: FontOption[] = [];
+    for (const font of installedFonts) {
+      if (popularSet.has(font.toLowerCase())) continue;
+      installedItems.push({ value: font, label: font });
+    }
+
+    return [
+      { value: 'popular', label: 'Popular', items: popularItems },
+      { value: 'installed', label: 'Installed', items: installedItems },
+    ];
+  }, [defaultOption, installedFonts]);
+
+  const visibleGroups = useMemo<FontGroup[]>(() => {
+    const normalizedQuery = query.trim().toLowerCase();
+    if (!normalizedQuery) return groups.filter((group) => group.items.length > 0);
+
+    return groups
+      .map((group) => ({
+        ...group,
+        items: group.items.filter((item) => item.label.toLowerCase().includes(normalizedQuery)),
+      }))
+      .filter((group) => group.items.length > 0);
+  }, [groups, query]);
+
+  const selectedOption = useMemo<FontOption>(() => {
+    if (!value) return defaultOption;
+
+    for (const group of groups) {
+      const match = group.items.find(
+        (option) => option.value.toLowerCase() === value.toLowerCase()
+      );
+      if (match) return match;
+    }
+
+    return { value, label: value };
+  }, [defaultOption, groups, value]);
+
+  return (
+    <SettingRow
+      title={title}
+      description={description}
+      control={
+        <div className="w-[183px] flex-shrink-0">
+          <Combobox
+            items={visibleGroups}
+            value={selectedOption}
+            onValueChange={(option: FontOption | null) => {
+              if (option) onChange(option.value);
+            }}
+            open={pickerOpen}
+            onOpenChange={(open) => {
+              setPickerOpen(open);
+              if (!open) setQuery('');
+            }}
+            inputValue={query}
+            onInputValueChange={(next: string, { reason }: { reason: string }) => {
+              if (reason !== 'item-press') setQuery(next);
+            }}
+            isItemEqualToValue={(a: FontOption, b: FontOption) => a.value === b.value}
+            filter={null}
+            autoHighlight
+          >
+            <ComboboxTrigger
+              render={
+                <button
+                  type="button"
+                  disabled={disabled}
+                  className="flex h-9 w-full items-center justify-between rounded-md border border-border bg-transparent px-2.5 py-1 text-left text-sm font-normal outline-none disabled:opacity-50"
+                >
+                  <ComboboxValue placeholder={defaultLabel} />
+                  <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 text-foreground-muted" />
+                </button>
+              }
+            />
+            <ComboboxContent>
+              <ComboboxInput
+                showTrigger={false}
+                placeholder="Search or type custom font"
+                onKeyDown={(event) => {
+                  if (event.key !== 'Enter') return;
+                  const typed = event.currentTarget.value.trim();
+                  if (!typed) return;
+                  event.preventDefault();
+                  onChange(typed);
+                  setPickerOpen(false);
+                }}
+              />
+              <ComboboxList>
+                {(group: FontGroup) => (
+                  <ComboboxGroup key={group.value} items={group.items}>
+                    <ComboboxLabel>{group.label}</ComboboxLabel>
+                    <ComboboxCollection>
+                      {(item: FontOption) => (
+                        <ComboboxItem key={item.value || '__default__'} value={item}>
+                          <span
+                            style={{
+                              fontFamily: item.value ? `"${item.value}"` : defaultPreviewFontFamily,
+                            }}
+                          >
+                            {item.label}
+                          </span>
+                        </ComboboxItem>
+                      )}
+                    </ComboboxCollection>
+                  </ComboboxGroup>
+                )}
+              </ComboboxList>
+              {loadingFonts ? (
+                <div className="px-1 pb-1">
+                  <div className="px-2 py-1.5 text-xs text-foreground-muted">Installed</div>
+                  <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground-muted">
+                    <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
+                    <span className="truncate">Loading fonts...</span>
+                  </div>
+                </div>
+              ) : null}
+              <ComboboxEmpty>No fonts found.</ComboboxEmpty>
+            </ComboboxContent>
+          </Combobox>
+        </div>
+      }
+    />
+  );
+}
+
+interface FontSizeSettingRowProps {
+  title: string;
+  description: string;
+  value: number;
+  min: number;
+  max: number;
+  controlLabel: string;
+  disabled?: boolean;
+  onChange: (fontSize: number) => void;
+}
+
+export function FontSizeSettingRow({
+  title,
+  description,
+  value,
+  min,
+  max,
+  controlLabel,
+  disabled = false,
+  onChange,
+}: FontSizeSettingRowProps) {
+  const applyValue = (next: number) => onChange(Math.min(max, Math.max(min, next)));
+
+  return (
+    <SettingRow
+      title={title}
+      description={description}
+      control={
+        <div className="flex h-9 w-[183px] flex-shrink-0 items-center justify-between rounded-md border border-border bg-background px-1 shadow-xs">
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            disabled={disabled || value <= min}
+            onClick={() => applyValue(value - 1)}
+            aria-label={`Decrease ${controlLabel}`}
+          >
+            <Minus />
+          </Button>
+          <div className="flex min-w-14 items-baseline justify-center gap-1 text-sm text-foreground tabular-nums">
+            <span>{value}</span>
+            <span className="text-muted-foreground text-xs">px</span>
+          </div>
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            disabled={disabled || value >= max}
+            onClick={() => applyValue(value + 1)}
+            aria-label={`Increase ${controlLabel}`}
+          >
+            <Plus />
+          </Button>
+        </div>
+      }
+    />
+  );
+}

--- a/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/SettingsPage.tsx
@@ -5,6 +5,7 @@ import { rpc } from '@renderer/lib/ipc';
 import { AgentsSettingsPage } from '../agents-page/AgentsSettingsPage';
 import { AccountTab } from './AccountTab';
 import { BrowserSettingsCard } from './BrowserSettingsCard';
+import { EditorSettingsCard } from './EditorSettingsCard';
 import HiddenToolsSettingsCard from './HiddenToolsSettingsCard';
 import IntegrationsCard from './IntegrationsCard';
 import InterfaceSettingsCard from './InterfaceSettingsCard';
@@ -126,6 +127,7 @@ function InterfaceSettingsPage() {
       />
       <ThemeCard />
       <TerminalSettingsCard />
+      <EditorSettingsCard />
       <SidebarMetadataSettingsCard />
       <ResourceMonitorSettingsCard />
       <InterfaceSettingsCard />

--- a/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/TerminalSettingsCard.tsx
@@ -1,27 +1,11 @@
 import { detectPlatform } from '@tanstack/react-hotkeys';
-import { ChevronsUpDownIcon, LoaderCircle, Minus, Plus } from 'lucide-react';
-import React, { useCallback, useMemo, useState } from 'react';
+import React, { useCallback, useMemo } from 'react';
 import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
-import { useInstalledFonts } from '@renderer/features/settings/use-installed-fonts';
 import { TerminalShellOptionLabel } from '@renderer/lib/components/terminal-shell-option-label';
 import {
   DEFAULT_TERMINAL_SHELL_AVAILABILITY,
   useTerminalShellAvailability,
 } from '@renderer/lib/hooks/use-terminal-shell-availability';
-import { Button } from '@renderer/lib/ui/button';
-import {
-  Combobox,
-  ComboboxCollection,
-  ComboboxContent,
-  ComboboxEmpty,
-  ComboboxGroup,
-  ComboboxInput,
-  ComboboxItem,
-  ComboboxLabel,
-  ComboboxList,
-  ComboboxTrigger,
-  ComboboxValue,
-} from '@renderer/lib/ui/combobox';
 import {
   Select,
   SelectContent,
@@ -36,36 +20,10 @@ import {
   TERMINAL_FONT_SIZE_MIN,
   type TerminalShellId,
 } from '@shared/core/terminals/terminal-settings';
+import { FontFamilySettingRow, FontSizeSettingRow } from './FontSettingsRows';
 import { SettingRow } from './SettingRow';
 
-type FontOption = {
-  value: string;
-  label: string;
-};
-
-type FontGroup = {
-  value: 'popular' | 'installed';
-  label: string;
-  items: FontOption[];
-};
-
-const POPULAR_FONTS = [
-  'Menlo',
-  'SF Mono',
-  'JetBrains Mono',
-  'Fira Code',
-  'Cascadia Code',
-  'Iosevka',
-  'Source Code Pro',
-  'MesloLGS NF',
-];
-
 const DEFAULT_FONT_FAMILY = 'Menlo';
-
-const DEFAULT_OPTION: FontOption = {
-  value: '',
-  label: `Default (${DEFAULT_FONT_FAMILY})`,
-};
 
 const clampFontSize = (size: number) =>
   Math.min(TERMINAL_FONT_SIZE_MAX, Math.max(TERMINAL_FONT_SIZE_MIN, size));
@@ -79,9 +37,6 @@ const TerminalSettingsCard: React.FC = () => {
     isLoading: loading,
     isSaving: saving,
   } = useAppSettingsKey('terminal');
-  const [pickerOpen, setPickerOpen] = useState<boolean>(false);
-  const [query, setQuery] = useState<string>('');
-  const { fonts: installedFonts, isLoading: loadingFonts } = useInstalledFonts();
   const { data: localShellAvailability = DEFAULT_TERMINAL_SHELL_AVAILABILITY } =
     useTerminalShellAvailability(undefined);
 
@@ -100,50 +55,6 @@ const TerminalSettingsCard: React.FC = () => {
       },
     [defaultShell, localShellAvailability]
   );
-
-  const groups = useMemo<FontGroup[]>(() => {
-    const popularSet = new Set(POPULAR_FONTS.map((f) => f.toLowerCase()));
-
-    const installedSet = new Set(installedFonts.map((font) => font.toLowerCase()));
-    const popularItems: FontOption[] = [DEFAULT_OPTION];
-    for (const font of POPULAR_FONTS) {
-      if (installedSet.has(font.toLowerCase())) {
-        popularItems.push({ value: font, label: font });
-      }
-    }
-
-    const installedItems: FontOption[] = [];
-    for (const font of installedFonts) {
-      const lower = font.toLowerCase();
-      if (popularSet.has(lower)) continue;
-      installedItems.push({ value: font, label: font });
-    }
-
-    return [
-      { value: 'popular', label: 'Popular', items: popularItems },
-      { value: 'installed', label: 'Installed', items: installedItems },
-    ];
-  }, [installedFonts]);
-
-  const visibleGroups = useMemo<FontGroup[]>(() => {
-    const q = query.trim().toLowerCase();
-    if (!q) return groups.filter((group) => group.items.length > 0);
-    return groups
-      .map((group) => ({
-        ...group,
-        items: group.items.filter((item) => item.label.toLowerCase().includes(q)),
-      }))
-      .filter((group) => group.items.length > 0);
-  }, [groups, query]);
-
-  const selectedOption = useMemo<FontOption | null>(() => {
-    if (!fontFamily) return DEFAULT_OPTION;
-    for (const group of groups) {
-      const match = group.items.find((o) => o.value.toLowerCase() === fontFamily.toLowerCase());
-      if (match) return match;
-    }
-    return { value: fontFamily, label: fontFamily };
-  }, [fontFamily, groups]);
 
   const applyFont = useCallback(
     (next: string) => {
@@ -227,121 +138,24 @@ const TerminalSettingsCard: React.FC = () => {
           </Select>
         }
       />
-      <SettingRow
+      <FontFamilySettingRow
         title="Terminal font"
         description="Choose the font family for the terminal."
-        control={
-          <div className="w-[183px] flex-shrink-0">
-            <Combobox
-              items={visibleGroups}
-              value={selectedOption}
-              onValueChange={(opt: FontOption | null) => {
-                if (opt) applyFont(opt.value);
-              }}
-              open={pickerOpen}
-              onOpenChange={(open) => {
-                setPickerOpen(open);
-                if (!open) setQuery('');
-              }}
-              inputValue={query}
-              onInputValueChange={(val: string, { reason }: { reason: string }) => {
-                if (reason !== 'item-press') setQuery(val);
-              }}
-              isItemEqualToValue={(a: FontOption, b: FontOption) => a.value === b.value}
-              filter={null}
-              autoHighlight
-            >
-              <ComboboxTrigger
-                render={
-                  <button
-                    type="button"
-                    disabled={loading || saving}
-                    className="flex h-9 w-full items-center justify-between rounded-md border border-border bg-transparent px-2.5 py-1 text-left text-sm font-normal outline-none disabled:opacity-50"
-                  >
-                    <ComboboxValue placeholder="Default (Menlo)" />
-                    <ChevronsUpDownIcon className="ml-2 size-4 shrink-0 text-foreground-muted" />
-                  </button>
-                }
-              />
-              <ComboboxContent>
-                <ComboboxInput
-                  showTrigger={false}
-                  placeholder="Search or type custom font"
-                  onKeyDown={(e) => {
-                    if (e.key !== 'Enter') return;
-                    const typed = e.currentTarget.value.trim();
-                    if (!typed) return;
-                    e.preventDefault();
-                    applyFont(typed);
-                    setPickerOpen(false);
-                  }}
-                />
-                <ComboboxList>
-                  {(group: FontGroup) => (
-                    <ComboboxGroup key={group.value} items={group.items}>
-                      <ComboboxLabel>{group.label}</ComboboxLabel>
-                      <ComboboxCollection>
-                        {(item: FontOption) => (
-                          <ComboboxItem key={item.value || '__default__'} value={item}>
-                            <span
-                              style={{
-                                fontFamily: item.value ? `"${item.value}"` : DEFAULT_FONT_FAMILY,
-                              }}
-                            >
-                              {item.label}
-                            </span>
-                          </ComboboxItem>
-                        )}
-                      </ComboboxCollection>
-                    </ComboboxGroup>
-                  )}
-                </ComboboxList>
-                {loadingFonts ? (
-                  <div className="px-1 pb-1">
-                    <div className="px-2 py-1.5 text-xs text-foreground-muted">Installed</div>
-                    <div className="flex items-center gap-2 rounded-sm px-2 py-1.5 text-sm text-foreground-muted">
-                      <LoaderCircle className="size-3.5 shrink-0 animate-spin" />
-                      <span className="truncate">Loading fonts...</span>
-                    </div>
-                  </div>
-                ) : null}
-                <ComboboxEmpty>No fonts found.</ComboboxEmpty>
-              </ComboboxContent>
-            </Combobox>
-          </div>
-        }
+        value={fontFamily}
+        defaultLabel={`Default (${DEFAULT_FONT_FAMILY})`}
+        defaultPreviewFontFamily={DEFAULT_FONT_FAMILY}
+        disabled={loading || saving}
+        onChange={applyFont}
       />
-      <SettingRow
+      <FontSizeSettingRow
         title="Terminal font size"
         description="Adjust the font size used by terminal sessions and CLI agents."
-        control={
-          <div className="flex h-9 w-[183px] flex-shrink-0 items-center justify-between rounded-md border border-border bg-background px-1 shadow-xs">
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              disabled={loading || saving || fontSize <= TERMINAL_FONT_SIZE_MIN}
-              onClick={() => applyFontSize(fontSize - 1)}
-              aria-label="Decrease terminal font size"
-            >
-              <Minus />
-            </Button>
-            <div className="flex min-w-14 items-baseline justify-center gap-1 text-sm text-foreground tabular-nums">
-              <span>{fontSize}</span>
-              <span className="text-muted-foreground text-xs">px</span>
-            </div>
-            <Button
-              type="button"
-              variant="ghost"
-              size="icon-xs"
-              disabled={loading || saving || fontSize >= TERMINAL_FONT_SIZE_MAX}
-              onClick={() => applyFontSize(fontSize + 1)}
-              aria-label="Increase terminal font size"
-            >
-              <Plus />
-            </Button>
-          </div>
-        }
+        value={fontSize}
+        min={TERMINAL_FONT_SIZE_MIN}
+        max={TERMINAL_FONT_SIZE_MAX}
+        controlLabel="terminal font size"
+        disabled={loading || saving}
+        onChange={applyFontSize}
       />
       <SettingRow
         title="Auto-copy selected text"

--- a/apps/emdash-desktop/src/renderer/features/settings/components/font-settings-cards.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/settings/components/font-settings-cards.test.ts
@@ -1,0 +1,320 @@
+import { QueryClientProvider } from '@tanstack/react-query';
+import { JSDOM } from 'jsdom';
+import React, { act, type ReactNode } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { queryClient } from '@renderer/lib/query-client';
+import {
+  EDITOR_FONT_SIZE_DEFAULT,
+  EDITOR_FONT_SIZE_MAX,
+} from '@shared/core/editor/editor-settings';
+import {
+  TERMINAL_FONT_SIZE_DEFAULT,
+  TERMINAL_FONT_SIZE_MAX,
+} from '@shared/core/terminals/terminal-settings';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+type SettingsValue = Record<string, unknown>;
+
+const mocks = vi.hoisted(() => ({
+  values: {} as Record<string, SettingsValue>,
+  getWithMeta: vi.fn(),
+  update: vi.fn(),
+  reset: vi.fn(),
+  resetField: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    appSettings: {
+      getWithMeta: mocks.getWithMeta,
+      update: mocks.update,
+      reset: mocks.reset,
+      resetField: mocks.resetField,
+    },
+  },
+}));
+
+vi.mock('@tanstack/react-hotkeys', () => ({ detectPlatform: () => 'linux' }));
+
+vi.mock('@renderer/lib/hooks/use-terminal-shell-availability', () => ({
+  DEFAULT_TERMINAL_SHELL_AVAILABILITY: [],
+  useTerminalShellAvailability: () => ({
+    data: [
+      {
+        id: 'system',
+        label: 'System default',
+        isSystemDefault: true,
+        available: true,
+      },
+    ],
+  }),
+}));
+
+vi.mock('@renderer/lib/components/terminal-shell-option-label', async () => {
+  const { createElement } = await import('react');
+  return {
+    TerminalShellOptionLabel: ({ entry }: { entry: { label: string } }) =>
+      createElement('span', null, entry.label),
+  };
+});
+
+vi.mock('@renderer/lib/ui/select', async () => {
+  const { createElement } = await import('react');
+  const Wrapper = ({ children }: { children?: ReactNode }) => createElement('div', null, children);
+  return {
+    Select: Wrapper,
+    SelectContent: Wrapper,
+    SelectItem: Wrapper,
+    SelectTrigger: Wrapper,
+    SelectValue: Wrapper,
+  };
+});
+
+vi.mock('@renderer/lib/ui/switch', async () => {
+  const { createElement } = await import('react');
+  return {
+    Switch: ({ checked }: { checked?: boolean }) =>
+      createElement('button', { type: 'button', 'aria-pressed': checked }),
+  };
+});
+
+vi.mock('./FontSettingsRows', async () => {
+  const { createElement } = await import('react');
+
+  interface FamilyProps {
+    title: string;
+    value: string;
+    defaultLabel: string;
+    defaultPreviewFontFamily?: string;
+    disabled?: boolean;
+    onChange: (value: string) => void;
+  }
+
+  interface SizeProps {
+    title: string;
+    value: number;
+    max: number;
+    disabled?: boolean;
+    onChange: (value: number) => void;
+  }
+
+  const slug = (title: string) => title.toLowerCase().replaceAll(' ', '-');
+
+  return {
+    FontFamilySettingRow: (props: FamilyProps) =>
+      createElement(
+        'div',
+        {
+          'data-testid': `${slug(props.title)}-family-row`,
+          'data-value': props.value,
+          'data-default-label': props.defaultLabel,
+          'data-default-preview': props.defaultPreviewFontFamily,
+        },
+        createElement(
+          'button',
+          {
+            type: 'button',
+            disabled: props.disabled,
+            'aria-label': `Choose custom ${props.title}`,
+            onClick: () => props.onChange('  Fira Code  '),
+          },
+          'Custom'
+        ),
+        createElement(
+          'button',
+          {
+            type: 'button',
+            disabled: props.disabled,
+            'aria-label': `Choose default ${props.title}`,
+            onClick: () => props.onChange(''),
+          },
+          'Default'
+        )
+      ),
+    FontSizeSettingRow: (props: SizeProps) =>
+      createElement(
+        'div',
+        {
+          'data-testid': `${slug(props.title)}-size-row`,
+          'data-value': String(props.value),
+        },
+        createElement(
+          'button',
+          {
+            type: 'button',
+            disabled: props.disabled,
+            'aria-label': `Increase ${props.title}`,
+            onClick: () => props.onChange(props.value + 1),
+          },
+          'Increase'
+        ),
+        createElement(
+          'button',
+          {
+            type: 'button',
+            disabled: props.disabled,
+            'aria-label': `Exceed ${props.title} maximum`,
+            onClick: () => props.onChange(props.max + 5),
+          },
+          'Exceed maximum'
+        )
+      ),
+  };
+});
+
+const { EditorSettingsCard } = await import('./EditorSettingsCard');
+const { default: TerminalSettingsCard } = await import('./TerminalSettingsCard');
+
+async function flushUpdates(): Promise<void> {
+  await Promise.resolve();
+  await new Promise<void>((resolve) => setTimeout(resolve, 0));
+  await Promise.resolve();
+}
+
+describe('font settings cards', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    mocks.values = {
+      editor: { fontSize: EDITOR_FONT_SIZE_DEFAULT },
+      terminal: {
+        fontFamily: 'JetBrains Mono',
+        fontSize: TERMINAL_FONT_SIZE_DEFAULT,
+        autoCopyOnSelection: false,
+        macOptionIsMeta: false,
+        defaultShell: 'system',
+      },
+    };
+    mocks.getWithMeta.mockImplementation(async (key: string) => ({
+      value: mocks.values[key],
+      defaults: mocks.values[key],
+      overrides: {},
+    }));
+    mocks.update.mockImplementation(async (key: string, value: SettingsValue) => {
+      mocks.values[key] = value;
+    });
+    mocks.reset.mockResolvedValue(undefined);
+    mocks.resetField.mockResolvedValue(undefined);
+
+    queryClient.clear();
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('Event', dom.window.Event);
+    vi.stubGlobal('MouseEvent', dom.window.MouseEvent);
+    vi.stubGlobal('CustomEvent', dom.window.CustomEvent);
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(async () => {
+    await queryClient.cancelQueries();
+    await act(async () => {
+      root.unmount();
+      await flushUpdates();
+    });
+    queryClient.clear();
+    vi.unstubAllGlobals();
+    vi.clearAllMocks();
+    dom.window.close();
+  });
+
+  async function render(component: ReactNode): Promise<void> {
+    await act(async () => {
+      root.render(React.createElement(QueryClientProvider, { client: queryClient }, component));
+    });
+    await act(async () => {
+      await flushUpdates();
+    });
+  }
+
+  async function click(ariaLabel: string): Promise<void> {
+    const button = container.querySelector<HTMLButtonElement>(`[aria-label="${ariaLabel}"]`);
+    expect(button).not.toBeNull();
+    act(() => {
+      button?.dispatchEvent(new dom.window.MouseEvent('click', { bubbles: true }));
+    });
+    await act(async () => {
+      await flushUpdates();
+    });
+  }
+
+  it('sends normalized editor preference payloads through the persistence hook', async () => {
+    await render(React.createElement(EditorSettingsCard));
+
+    const familyRow = container.querySelector<HTMLElement>(
+      '[data-testid="file-preview-font-family-row"]'
+    );
+    expect(familyRow?.dataset.defaultLabel).toBe('Default (Monaco editor)');
+    expect(familyRow?.dataset.defaultPreview).toBe('monospace');
+
+    await click('Choose custom File preview font');
+    expect(mocks.update).toHaveBeenLastCalledWith('editor', {
+      fontFamily: 'Fira Code',
+      fontSize: EDITOR_FONT_SIZE_DEFAULT,
+    });
+    expect(familyRow?.dataset.value).toBe('Fira Code');
+
+    await click('Choose default File preview font');
+    expect(mocks.update).toHaveBeenLastCalledWith('editor', {
+      fontFamily: undefined,
+      fontSize: EDITOR_FONT_SIZE_DEFAULT,
+    });
+    expect(familyRow?.dataset.value).toBe('');
+
+    await click('Exceed File preview font size maximum');
+    expect(mocks.update).toHaveBeenLastCalledWith('editor', {
+      fontFamily: undefined,
+      fontSize: EDITOR_FONT_SIZE_MAX,
+    });
+  });
+
+  it('preserves terminal font selection and size callback behavior after the shared-row refactor', async () => {
+    const fontEvents: Array<{ fontFamily?: string; fontSize?: number }> = [];
+    window.addEventListener('terminal-font-changed', (event) => {
+      fontEvents.push((event as CustomEvent<{ fontFamily?: string; fontSize?: number }>).detail);
+    });
+
+    await render(React.createElement(TerminalSettingsCard));
+
+    const familyRow = container.querySelector<HTMLElement>(
+      '[data-testid="terminal-font-family-row"]'
+    );
+    expect(familyRow?.dataset.value).toBe('JetBrains Mono');
+
+    await click('Choose custom Terminal font');
+    expect(mocks.update).toHaveBeenLastCalledWith(
+      'terminal',
+      expect.objectContaining({ fontFamily: 'Fira Code' })
+    );
+    expect(fontEvents.at(-1)).toEqual({ fontFamily: 'Fira Code' });
+
+    await click('Choose default Terminal font');
+    expect(mocks.update).toHaveBeenLastCalledWith(
+      'terminal',
+      expect.objectContaining({ fontFamily: '' })
+    );
+    expect(fontEvents.at(-1)).toEqual({ fontFamily: '' });
+
+    await click('Increase Terminal font size');
+    expect(mocks.update).toHaveBeenLastCalledWith(
+      'terminal',
+      expect.objectContaining({ fontSize: TERMINAL_FONT_SIZE_DEFAULT + 1 })
+    );
+    expect(fontEvents.at(-1)).toEqual({ fontSize: TERMINAL_FONT_SIZE_DEFAULT + 1 });
+
+    await click('Exceed Terminal font size maximum');
+    expect(mocks.update).toHaveBeenLastCalledWith(
+      'terminal',
+      expect.objectContaining({ fontSize: TERMINAL_FONT_SIZE_MAX })
+    );
+    expect(fontEvents.at(-1)).toEqual({ fontSize: TERMINAL_FONT_SIZE_MAX });
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/editor/editor-provider.tsx
@@ -2,12 +2,17 @@ import { autorun } from 'mobx';
 import { observer } from 'mobx-react-lite';
 import type * as monacoNS from 'monaco-editor';
 import { createContext, useCallback, useContext, useEffect, useRef, type ReactNode } from 'react';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { usePaneContext } from '@renderer/features/tabs/pane-context';
 import { useWorkspaceViewModel } from '@renderer/features/tasks/task-view-context';
 import { registerActiveCodeEditor } from '@renderer/lib/editor/activeCodeEditor';
 import { DEFAULT_EDITOR_OPTIONS } from '@renderer/lib/editor/utils';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import { useShowModal } from '@renderer/lib/modal/modal-provider';
+import {
+  updateCodeEditorFontOptions,
+  type EditorFontDefaults,
+} from '@renderer/lib/monaco/editor-font-settings';
 import { monacoBootstrap } from '@renderer/lib/monaco/monaco-bootstrap';
 import {
   addMonacoKeyboardShortcuts,
@@ -49,12 +54,14 @@ export const EditorProvider = observer(function EditorProvider({
   const { paneId, pane: paneTabManager } = usePaneContext();
   const { effectiveTheme } = useTheme();
   const isActive = useIsActiveTask(taskId);
+  const { value: editorSettings } = useAppSettingsKey('editor');
 
   // Conflict dialog — shown when editorView.pendingConflictUri is set.
   const showConflictModal = useShowModal('conflictDialog');
 
   // The directly-created Monaco editor for this pane.
   const editorRef = useRef<monacoNS.editor.IStandaloneCodeEditor | null>(null);
+  const editorFontDefaultsRef = useRef<EditorFontDefaults | null>(null);
   // The container <div> appended to the pane's host element.
   const containerRef = useRef<HTMLDivElement | null>(null);
   const focusPendingRef = useRef(false);
@@ -90,6 +97,9 @@ export const EditorProvider = observer(function EditorProvider({
 
     const editor = m.editor.create(container, { ...DEFAULT_EDITOR_OPTIONS, glyphMargin: true });
     editorRef.current = editor;
+    editorFontDefaultsRef.current = {
+      fontFamily: editor.getOption(m.editor.EditorOption.fontFamily),
+    };
 
     configureMonacoEditor(editor);
 
@@ -127,10 +137,20 @@ export const EditorProvider = observer(function EditorProvider({
       editor.dispose();
       container.remove();
       editorRef.current = null;
+      editorFontDefaultsRef.current = null;
       containerRef.current = null;
     };
     // oxlint-disable-next-line react/exhaustive-deps
   }, []);
+
+  // Apply persisted editor typography and keep the mounted Monaco instance in
+  // sync with optimistic settings updates without remounting its models.
+  useEffect(() => {
+    const editor = editorRef.current;
+    const defaults = editorFontDefaultsRef.current;
+    if (!editor || !defaults) return;
+    updateCodeEditorFontOptions(editor, editorSettings, defaults);
+  }, [editorSettings]);
 
   // ---------------------------------------------------------------------------
   // Save shortcut — handle at the task-pane level so preview/source transitions

--- a/apps/emdash-desktop/src/renderer/lib/editor/utils.ts
+++ b/apps/emdash-desktop/src/renderer/lib/editor/utils.ts
@@ -1,3 +1,5 @@
+import { EDITOR_FONT_SIZE_DEFAULT } from '@shared/core/editor/editor-settings';
+
 const MARKDOWN_EXTENSIONS = ['md', 'mdx'];
 
 /** Returns true if the file path points to a markdown file. */
@@ -16,7 +18,7 @@ export const isMarkdownFile = isMarkdownPath;
 /** Default Monaco editor options shared across all editor instances. */
 export const DEFAULT_EDITOR_OPTIONS = {
   minimap: { enabled: true },
-  fontSize: 13,
+  fontSize: EDITOR_FONT_SIZE_DEFAULT,
   padding: { top: 12, bottom: 12 },
   lineNumbers: 'on' as const,
   rulers: [],

--- a/apps/emdash-desktop/src/renderer/lib/monaco/editor-font-settings.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/editor-font-settings.ts
@@ -1,0 +1,51 @@
+import type { editor } from 'monaco-editor';
+import type { EditorSettings } from '@shared/core/app-settings';
+import { EDITOR_FONT_SIZE_DEFAULT } from '@shared/core/editor/editor-settings';
+
+export interface EditorFontDefaults {
+  fontFamily: string;
+  /** Diff editors historically pin 20px at the default 13px font size. */
+  lineHeight?: number;
+}
+
+export interface EditorFontOptions {
+  fontFamily: string;
+  fontSize: number;
+  lineHeight?: number;
+}
+
+export function buildEditorFontOptions(
+  settings: EditorSettings | undefined,
+  defaults: EditorFontDefaults
+): EditorFontOptions {
+  const fontSize = settings?.fontSize ?? EDITOR_FONT_SIZE_DEFAULT;
+  const configuredFontFamily = settings?.fontFamily?.trim();
+  const options: EditorFontOptions = {
+    fontFamily: configuredFontFamily || defaults.fontFamily,
+    fontSize,
+  };
+
+  if (defaults.lineHeight !== undefined) {
+    // Keep the existing diff spacing at the default size. Let Monaco derive an
+    // appropriate line height for custom sizes so larger fonts are not clipped.
+    options.lineHeight = fontSize === EDITOR_FONT_SIZE_DEFAULT ? defaults.lineHeight : 0;
+  }
+
+  return options;
+}
+
+export function updateCodeEditorFontOptions(
+  target: Pick<editor.IStandaloneCodeEditor, 'updateOptions'>,
+  settings: EditorSettings | undefined,
+  defaults: EditorFontDefaults
+): void {
+  target.updateOptions(buildEditorFontOptions(settings, defaults));
+}
+
+export function updateDiffEditorFontOptions(
+  target: Pick<editor.IStandaloneDiffEditor, 'updateOptions'>,
+  settings: EditorSettings | undefined,
+  defaults: EditorFontDefaults
+): void {
+  target.updateOptions(buildEditorFontOptions(settings, defaults));
+}

--- a/apps/emdash-desktop/src/renderer/lib/monaco/editorConfig.ts
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/editorConfig.ts
@@ -1,9 +1,10 @@
 import type { editor } from 'monaco-editor';
+import { EDITOR_FONT_SIZE_DEFAULT } from '@shared/core/editor/editor-settings';
 
 /** Shared options for all DiffEditor instances in the diff viewer. */
 export const DIFF_EDITOR_BASE_OPTIONS: editor.IDiffEditorConstructionOptions = {
   originalEditable: false,
-  fontSize: 13,
+  fontSize: EDITOR_FONT_SIZE_DEFAULT,
   lineHeight: 20,
   minimap: { enabled: false },
   scrollBeyondLastLine: false,

--- a/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/monaco/sticky-diff-editor.tsx
@@ -1,9 +1,11 @@
 import { autorun, observable, runInAction } from 'mobx';
 import type * as monaco from 'monaco-editor';
 import { useEffect, useRef } from 'react';
+import { useAppSettingsKey } from '@renderer/features/settings/use-app-settings-key';
 import { useTheme } from '@renderer/lib/hooks/useTheme';
 import { monacoBootstrap } from '@renderer/lib/monaco/monaco-bootstrap';
 import { modelRegistry } from '@renderer/lib/monaco/monaco-model-registry';
+import { updateDiffEditorFontOptions, type EditorFontDefaults } from './editor-font-settings';
 import { DIFF_EDITOR_BASE_OPTIONS } from './editorConfig';
 
 export interface StickyDiffEditorProps {
@@ -41,6 +43,8 @@ export function StickyDiffEditor({
   onEditorChangeRef.current = onEditorChange;
 
   const { effectiveTheme } = useTheme();
+  const { value: editorSettings } = useAppSettingsKey('editor');
+  const editorFontDefaultsRef = useRef<EditorFontDefaults | null>(null);
 
   // Create editor once on mount, dispose on unmount.
   // Monaco is guaranteed ready because monacoBootstrap.init() is awaited in main.tsx.
@@ -56,6 +60,10 @@ export function StickyDiffEditor({
     onEditorChangeRef.current?.(editor);
 
     const modifiedEditor = editor.getModifiedEditor();
+    editorFontDefaultsRef.current = {
+      fontFamily: modifiedEditor.getOption(m.editor.EditorOption.fontFamily),
+      lineHeight: modifiedEditor.getOption(m.editor.EditorOption.lineHeight),
+    };
     modifiedEditor.addCommand(m.KeyMod.CtrlCmd | m.KeyCode.KeyS, () => {
       const uri = modifiedUriRef.current;
       if (!uri.startsWith('file://')) return;
@@ -77,9 +85,19 @@ export function StickyDiffEditor({
       heightDisposable.dispose();
       runInAction(() => editorBox.set(null));
       editor.dispose();
+      editorFontDefaultsRef.current = null;
     };
     // oxlint-disable-next-line react/exhaustive-deps
   }, []);
+
+  // Keep both sides of an already-mounted diff editor in sync with persisted
+  // typography settings. Monaco's diff-level update applies to both children.
+  useEffect(() => {
+    const editor = editorBox.get();
+    const defaults = editorFontDefaultsRef.current;
+    if (!editor || !defaults) return;
+    updateDiffEditorFontOptions(editor, editorSettings, defaults);
+  }, [editorBox, editorSettings]);
 
   // Sync diffStyle changes to the mounted editor.
   useEffect(() => {

--- a/apps/emdash-desktop/src/renderer/main.tsx
+++ b/apps/emdash-desktop/src/renderer/main.tsx
@@ -46,6 +46,7 @@ async function bootstrap() {
     appState.projects.load(),
     prefetchAppSettingsKey('interface'),
     prefetchAppSettingsKey('browser'),
+    prefetchAppSettingsKey('editor'),
   ]);
 
   viewStateCache.populate(allViewState as Record<string, unknown>);

--- a/apps/emdash-desktop/src/renderer/tests/editor-config.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/editor-config.test.ts
@@ -1,5 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+import {
+  buildEditorFontOptions,
+  updateCodeEditorFontOptions,
+  updateDiffEditorFontOptions,
+} from '@renderer/lib/monaco/editor-font-settings';
 import { DIFF_EDITOR_BASE_OPTIONS } from '@renderer/lib/monaco/editorConfig';
+import { EDITOR_FONT_SIZE_DEFAULT } from '@shared/core/editor/editor-settings';
 
 describe('DIFF_EDITOR_BASE_OPTIONS', () => {
   it('keeps unchanged diff regions visible for large text selection', () => {
@@ -8,5 +14,62 @@ describe('DIFF_EDITOR_BASE_OPTIONS', () => {
 
   it('renders +/- gutter indicators for added and removed lines', () => {
     expect(DIFF_EDITOR_BASE_OPTIONS.renderIndicators).toBe(true);
+  });
+});
+
+describe('editor font options', () => {
+  const monacoDefaults = {
+    fontFamily: "Menlo, Monaco, 'Courier New', monospace",
+  };
+
+  it('preserves Monaco font defaults when no preference is configured', () => {
+    expect(buildEditorFontOptions(undefined, monacoDefaults)).toEqual({
+      fontFamily: monacoDefaults.fontFamily,
+      fontSize: EDITOR_FONT_SIZE_DEFAULT,
+    });
+  });
+
+  it('updates an open code editor with the configured family and size', () => {
+    const target = { updateOptions: vi.fn() };
+
+    updateCodeEditorFontOptions(
+      target,
+      { fontFamily: 'JetBrains Mono', fontSize: 16 },
+      monacoDefaults
+    );
+
+    expect(target.updateOptions).toHaveBeenCalledWith({
+      fontFamily: 'JetBrains Mono',
+      fontSize: 16,
+    });
+  });
+
+  it('updates an open diff editor and lets Monaco scale custom line heights', () => {
+    const target = { updateOptions: vi.fn() };
+
+    updateDiffEditorFontOptions(
+      target,
+      { fontFamily: 'Fira Code', fontSize: 18 },
+      { ...monacoDefaults, lineHeight: 20 }
+    );
+
+    expect(target.updateOptions).toHaveBeenCalledWith({
+      fontFamily: 'Fira Code',
+      fontSize: 18,
+      lineHeight: 0,
+    });
+  });
+
+  it('restores the captured Monaco family and diff spacing when reset', () => {
+    expect(
+      buildEditorFontOptions(
+        { fontSize: EDITOR_FONT_SIZE_DEFAULT },
+        { ...monacoDefaults, lineHeight: 20 }
+      )
+    ).toEqual({
+      fontFamily: monacoDefaults.fontFamily,
+      fontSize: EDITOR_FONT_SIZE_DEFAULT,
+      lineHeight: 20,
+    });
   });
 });

--- a/apps/emdash-desktop/src/renderer/tests/editor-font-live-update.test.ts
+++ b/apps/emdash-desktop/src/renderer/tests/editor-font-live-update.test.ts
@@ -1,0 +1,240 @@
+import { JSDOM } from 'jsdom';
+import React, { act } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { EditorSettings } from '@shared/core/app-settings';
+import { EDITOR_FONT_SIZE_DEFAULT } from '@shared/core/editor/editor-settings';
+
+(
+  globalThis as typeof globalThis & { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const mocks = vi.hoisted(() => {
+  const codeEditor = {
+    updateOptions: vi.fn(),
+    getOption: vi.fn(() => "Menlo, Monaco, 'Courier New', monospace"),
+    onDidFocusEditorWidget: vi.fn(() => ({ dispose: vi.fn() })),
+    getModel: vi.fn(() => null),
+    setModel: vi.fn(),
+    focus: vi.fn(),
+    layout: vi.fn(),
+    dispose: vi.fn(),
+  };
+  const modifiedEditor = {
+    getOption: vi.fn((option: string) =>
+      option === 'lineHeight' ? 20 : "Menlo, Monaco, 'Courier New', monospace"
+    ),
+    addCommand: vi.fn(),
+    onDidContentSizeChange: vi.fn(() => ({ dispose: vi.fn() })),
+    getContentHeight: vi.fn(() => 120),
+  };
+  const diffEditor = {
+    updateOptions: vi.fn(),
+    getModifiedEditor: vi.fn(() => modifiedEditor),
+    getModel: vi.fn(() => null),
+    setModel: vi.fn(),
+    layout: vi.fn(),
+    dispose: vi.fn(),
+  };
+
+  return {
+    editorSettings: undefined as EditorSettings | undefined,
+    codeEditor,
+    modifiedEditor,
+    diffEditor,
+    createCodeEditor: vi.fn(() => codeEditor),
+    createDiffEditor: vi.fn(() => diffEditor),
+    setTheme: vi.fn(),
+    cleanupActiveEditor: vi.fn(),
+    restoreBuffers: vi.fn(async () => undefined),
+  };
+});
+
+vi.mock('@renderer/features/settings/use-app-settings-key', () => ({
+  useAppSettingsKey: (key: string) => ({
+    value: key === 'editor' ? mocks.editorSettings : undefined,
+  }),
+}));
+
+vi.mock('@renderer/features/tabs/pane-context', () => ({
+  usePaneContext: () => ({ paneId: 'pane-1', pane: {} }),
+}));
+
+vi.mock('@renderer/features/tasks/task-view-context', () => {
+  const taskView = {
+    editorView: {
+      modelRootPath: 'workspace:test',
+      pendingConflictUri: null,
+      openFilePaths: [],
+      saveFile: vi.fn(),
+      saveAllFiles: vi.fn(),
+      restoreBuffers: mocks.restoreBuffers,
+      resolveConflict: vi.fn(),
+    },
+    paneLayout: {
+      activePaneId: 'pane-1',
+      setActiveGroup: vi.fn(),
+    },
+    focusedRegion: null,
+    setFocusedRegion: vi.fn(),
+  };
+
+  return {
+    useTaskViewContext: () => ({ taskId: 'task-1' }),
+    useWorkspaceViewModel: () => taskView,
+  };
+});
+
+vi.mock('@renderer/features/tasks/hooks/use-is-active-task', () => ({
+  useIsActiveTask: () => false,
+}));
+
+vi.mock('@renderer/lib/hooks/useTheme', () => ({
+  useTheme: () => ({ effectiveTheme: 'emdark' }),
+}));
+
+vi.mock('@renderer/lib/modal/modal-provider', () => ({
+  useShowModal: () => vi.fn(),
+}));
+
+vi.mock('@renderer/lib/editor/activeCodeEditor', () => ({
+  registerActiveCodeEditor: () => mocks.cleanupActiveEditor,
+}));
+
+vi.mock('@renderer/lib/monaco/monaco-config', () => ({
+  addMonacoKeyboardShortcuts: vi.fn(),
+  configureMonacoEditor: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/monaco/monaco-bootstrap', () => ({
+  monacoBootstrap: {
+    getMonaco: () => ({
+      editor: {
+        create: mocks.createCodeEditor,
+        createDiffEditor: mocks.createDiffEditor,
+        EditorOption: {
+          fontFamily: 'fontFamily',
+          lineHeight: 'lineHeight',
+        },
+      },
+      KeyMod: { CtrlCmd: 1 },
+      KeyCode: { KeyS: 2 },
+    }),
+    setTheme: mocks.setTheme,
+  },
+}));
+
+vi.mock('@renderer/lib/monaco/monaco-model-registry', () => ({
+  modelRegistry: {
+    modelStatus: new Map<string, string>(),
+    attach: vi.fn(),
+    detach: vi.fn(),
+    filePathForUri: vi.fn(() => undefined),
+    getModelByUri: vi.fn(() => undefined),
+    restoreDiffViewState: vi.fn(),
+    saveDiffViewState: vi.fn(),
+    saveFileToDisk: vi.fn(),
+  },
+}));
+
+vi.mock('@renderer/lib/monaco/monacoModelPath', () => ({
+  buildMonacoModelPath: vi.fn(() => 'file:///workspace/test.ts'),
+}));
+
+vi.mock('@renderer/features/tasks/editor/pane-selectors', () => ({
+  activeFileEntry: () => null,
+  activeFilePath: () => null,
+}));
+
+const { EditorProvider } = await import('@renderer/features/tasks/editor/editor-provider');
+const { StickyDiffEditor } = await import('@renderer/lib/monaco/sticky-diff-editor');
+
+describe('mounted editor font updates', () => {
+  let dom: JSDOM;
+  let root: Root;
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    mocks.editorSettings = undefined;
+    vi.clearAllMocks();
+    dom = new JSDOM('<!doctype html><html><body><div id="root"></div></body></html>');
+    vi.stubGlobal('window', dom.window);
+    vi.stubGlobal('document', dom.window.document);
+    vi.stubGlobal('HTMLElement', dom.window.HTMLElement);
+    vi.stubGlobal('KeyboardEvent', dom.window.KeyboardEvent);
+    container = dom.window.document.getElementById('root') as HTMLDivElement;
+    root = createRoot(container);
+  });
+
+  afterEach(() => {
+    act(() => root.unmount());
+    vi.unstubAllGlobals();
+    dom.window.close();
+  });
+
+  it('updates the mounted code editor when editor settings change', () => {
+    act(() => {
+      root.render(
+        React.createElement(
+          EditorProvider,
+          null,
+          React.createElement('span', null, 'initial settings')
+        )
+      );
+    });
+
+    expect(mocks.createCodeEditor).toHaveBeenCalledTimes(1);
+    expect(mocks.codeEditor.updateOptions).toHaveBeenLastCalledWith({
+      fontFamily: "Menlo, Monaco, 'Courier New', monospace",
+      fontSize: EDITOR_FONT_SIZE_DEFAULT,
+    });
+
+    mocks.editorSettings = { fontFamily: 'JetBrains Mono', fontSize: 16 };
+    act(() => {
+      root.render(
+        React.createElement(
+          EditorProvider,
+          null,
+          React.createElement('span', null, 'updated settings')
+        )
+      );
+    });
+
+    expect(mocks.createCodeEditor).toHaveBeenCalledTimes(1);
+    expect(mocks.codeEditor.updateOptions).toHaveBeenLastCalledWith({
+      fontFamily: 'JetBrains Mono',
+      fontSize: 16,
+    });
+  });
+
+  it('updates the mounted diff editor when editor settings change', () => {
+    const props = {
+      originalUri: 'git:///workspace/test.ts',
+      modifiedUri: 'file:///workspace/test.ts',
+      diffStyle: 'split' as const,
+    };
+
+    act(() => {
+      root.render(React.createElement(StickyDiffEditor, props));
+    });
+
+    expect(mocks.createDiffEditor).toHaveBeenCalledTimes(1);
+    expect(mocks.diffEditor.updateOptions).toHaveBeenCalledWith({
+      fontFamily: "Menlo, Monaco, 'Courier New', monospace",
+      fontSize: EDITOR_FONT_SIZE_DEFAULT,
+      lineHeight: 20,
+    });
+
+    mocks.editorSettings = { fontFamily: 'Fira Code', fontSize: 18 };
+    act(() => {
+      root.render(React.createElement(StickyDiffEditor, props));
+    });
+
+    expect(mocks.createDiffEditor).toHaveBeenCalledTimes(1);
+    expect(mocks.diffEditor.updateOptions).toHaveBeenLastCalledWith({
+      fontFamily: 'Fira Code',
+      fontSize: 18,
+      lineHeight: 0,
+    });
+  });
+});

--- a/apps/emdash-desktop/src/shared/core/app-settings.ts
+++ b/apps/emdash-desktop/src/shared/core/app-settings.ts
@@ -3,6 +3,7 @@ import {
   appSettingsSchema,
   type browserSettingsSchema,
   type changesViewModeSchema,
+  type editorSettingsSchema,
   type interfaceSettingsSchema,
   type localProjectSettingsSchema,
   type notificationSettingsSchema,
@@ -18,6 +19,7 @@ export type ProjectSettings = z.infer<typeof projectSettingsSchema>;
 export type NotificationSettings = z.infer<typeof notificationSettingsSchema>;
 export type TaskSettings = z.infer<typeof taskSettingsSchema>;
 export type TerminalSettings = z.infer<typeof terminalSettingsSchema>;
+export type EditorSettings = z.infer<typeof editorSettingsSchema>;
 export type Theme = z.infer<typeof themeSchema>;
 
 export type InterfaceSettings = z.infer<typeof interfaceSettingsSchema>;

--- a/apps/emdash-desktop/src/shared/core/editor/editor-settings.ts
+++ b/apps/emdash-desktop/src/shared/core/editor/editor-settings.ts
@@ -1,0 +1,3 @@
+export const EDITOR_FONT_SIZE_DEFAULT = 13;
+export const EDITOR_FONT_SIZE_MIN = 8;
+export const EDITOR_FONT_SIZE_MAX = 32;


### PR DESCRIPTION
### Description

Add persistent font family and font size controls for Monaco-backed text previews and diffs.

- Adds an independent `editor` app setting with the current 13px behavior as its default.
- Reuses the terminal font picker and size controls without coupling terminal and editor preferences.
- Applies changes live to existing code editor and diff editor instances, restoring Monaco's captured default font when reset.
- Stores the setting in the existing key-value settings table, so no database migration is required.

This is functionally independent from #2876/#2807, but the branches overlap in four small editor/settings files. I verified the combined result in a temporary integration worktree; whichever PR lands second will need a small rebase. If #2876 lands first, resetting the preference will use its updated Monaco default stack.

### Related issues

Fixes #2818.

### Testing

- `pnpm exec vitest run --project node src/main/core/settings/editor-settings.test.ts src/renderer/tests/editor-config.test.ts src/renderer/features/settings/components/font-settings-cards.test.ts src/renderer/tests/editor-font-live-update.test.ts` (12/12)
- `pnpm run lint`
- `pnpm run format:check`
- `pnpm run typecheck`
- `pnpm run build:renderer`
- Combined #2876 + #2877 integration: 19 focused tests, desktop lint/typecheck/format, and full workspace build passed.
- Broader desktop node suite: one unrelated `IssueSelector` canvas timeout under concurrent load; the failing test passed when rerun in isolation.
- `git diff --check`

### Screenshot/Recording (if applicable)

Not included. The settings interactions and live Monaco updates are covered by mounted component tests.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed, or docs were not needed
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit messages and, when possible, the PR title

</details>
