### PR TITLE
fix(chat): match model picker details with new task

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-chat-panel.tsx
@@ -51,6 +51,7 @@ import { linkedIssueMentionName, type LinkedIssue } from '@shared/core/linked-is
 import type { AcpChatStore, AcpPromptAttachment } from './acp-chat-store';
 import type { AcpChatTabResource } from './acp-chat-tab-resource';
 import { chatViewCommandForShortcut, executeChatViewCommand } from './acp-chat-view-commands';
+import { mergeComposerModelOptions } from './acp-model-options';
 import { buildIssueMentionHiddenContext } from './issue-mention-context';
 
 // ── Helpers ───────────────────────────────────────────────────────────────────
@@ -514,6 +515,14 @@ const ComposerForStore = observer(function ComposerForStore({
   const providerId =
     conversationRegistry.get(store.taskId)?.conversations.get(store.conversationId)?.data
       .providerId ?? null;
+  const availableModelOptions = store.modelOptions;
+  const catalogModels = agents?.find((agent) => agent.id === providerId)?.capabilities.models;
+  const catalogModelOptions =
+    catalogModels?.kind === 'selectable' ? catalogModels.modelOptions : null;
+  const modelOptions = useMemo(
+    () => mergeComposerModelOptions(availableModelOptions, catalogModelOptions),
+    [availableModelOptions, catalogModelOptions]
+  );
   const renderMentionIcon = useCallback(({ id, kind }: { id: string; kind: string }) => {
     if (kind !== 'issue') return null;
     const target = parseIssueMentionToken(id);
@@ -573,7 +582,7 @@ const ComposerForStore = observer(function ComposerForStore({
         onReorderQueuedPrompts={(ids) => store.reorderQueuedPrompts(ids)}
         onSendQueuedPromptNow={handleSendQueuedPromptNow}
         editorApiRef={editorApiRef}
-        modelOptions={store.modelOptions}
+        modelOptions={modelOptions}
         selectedModel={store.model ?? undefined}
         onModelChange={handleModelChange}
         effortOptions={store.effortOptions}

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.test.ts
@@ -3,8 +3,8 @@ import { mergeComposerModelOptions } from './acp-model-options';
 
 describe('mergeComposerModelOptions', () => {
   it.each([
-    ['opus[1m]', 'claude-opus-4-8', 'Claude Opus 4.8', 2, 5],
-    ['claude-fable-5[1m]', 'claude-fable-5', 'Claude Fable 5', 3, 4],
+    ['opus[1m]', 'claude-opus-4-8', 'Claude Opus 4.8', 3, 5],
+    ['claude-fable-5[1m]', 'claude-fable-5', 'Claude Fable 5', 3, 5],
     ['sonnet', 'claude-sonnet-5', 'Claude Sonnet 5', 4, 4],
     ['haiku', 'claude-haiku-4-5', 'Claude Haiku 4.5', 5, 3],
   ])(

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest';
+import { mergeComposerModelOptions } from './acp-model-options';
+
+describe('mergeComposerModelOptions', () => {
+  it.each([
+    ['opus[1m]', 'claude-opus-4-8', 'Claude Opus 4.8', 2, 5],
+    ['claude-fable-5[1m]', 'claude-fable-5', 'Claude Fable 5', 3, 4],
+    ['sonnet', 'claude-sonnet-5', 'Claude Sonnet 5', 4, 4],
+    ['haiku', 'claude-haiku-4-5', 'Claude Haiku 4.5', 5, 3],
+  ])(
+    'resolves ACP model alias %s to the New Task catalog details',
+    (runtimeId, catalogId, name, speed, intelligence) => {
+      const description = `Canonical description for ${name}.`;
+      expect(
+        mergeComposerModelOptions(
+          {
+            [runtimeId]: {
+              name: 'Runtime name',
+              description: 'Runtime description with pricing.',
+            },
+          },
+          {
+            [catalogId]: {
+              name,
+              aliases: [runtimeId],
+              description,
+              modelFeatures: { speed, intelligence },
+            },
+          }
+        )
+      ).toEqual({
+        [runtimeId]: {
+          name,
+          description,
+          modelFeatures: { speed, intelligence },
+        },
+      });
+    }
+  );
+
+  it('uses the same catalog entry directly when ACP and catalog ids match', () => {
+    expect(
+      mergeComposerModelOptions(
+        { 'gpt-5.6-sol': { name: 'GPT-5.6-Sol' } },
+        {
+          'gpt-5.6-sol': {
+            name: 'GPT-5.6 Sol',
+            description: 'Flagship model for the hardest coding workflows.',
+            modelFeatures: { speed: 2, intelligence: 5 },
+          },
+        }
+      )
+    ).toEqual({
+      'gpt-5.6-sol': {
+        name: 'GPT-5.6 Sol',
+        description: 'Flagship model for the hardest coding workflows.',
+        modelFeatures: { speed: 2, intelligence: 5 },
+      },
+    });
+  });
+
+  it('preserves runtime-only models without guessing from their names', () => {
+    const available = { preview: { name: 'Provider Preview' } };
+    expect(mergeComposerModelOptions(available, {})).toEqual(available);
+  });
+});

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.test.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.test.ts
@@ -59,6 +59,27 @@ describe('mergeComposerModelOptions', () => {
     });
   });
 
+  it('preserves runtime metadata omitted from the catalog', () => {
+    expect(
+      mergeComposerModelOptions(
+        {
+          preview: {
+            name: 'Provider Preview',
+            description: 'Runtime description with pricing.',
+            modelFeatures: { speed: 4, intelligence: 3 },
+          },
+        },
+        { preview: { name: 'Preview' } }
+      )
+    ).toEqual({
+      preview: {
+        name: 'Preview',
+        description: 'Runtime description with pricing.',
+        modelFeatures: { speed: 4, intelligence: 3 },
+      },
+    });
+  });
+
   it('preserves runtime-only models without guessing from their names', () => {
     const available = { preview: { name: 'Provider Preview' } };
     expect(mergeComposerModelOptions(available, {})).toEqual(available);

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.ts
@@ -1,0 +1,28 @@
+import type { ComposerModelOption } from '@emdash/ui/react/components';
+import type { AgentModelOption } from '@shared/core/agents/agent-payload';
+
+export function mergeComposerModelOptions(
+  available: Record<string, ComposerModelOption> | null,
+  catalog: Record<string, AgentModelOption> | null
+) {
+  if (!available || !catalog) return available;
+
+  return Object.fromEntries(
+    Object.entries(available).map(([id, option]) => {
+      const metadata = catalog[id] ?? findAliasMatch(catalog, id);
+      if (!metadata) return [id, option];
+      return [
+        id,
+        {
+          name: metadata.name,
+          ...(metadata.description && { description: metadata.description }),
+          ...(metadata.modelFeatures && { modelFeatures: metadata.modelFeatures }),
+        },
+      ];
+    })
+  );
+}
+
+function findAliasMatch(catalog: Record<string, AgentModelOption>, runtimeId: string) {
+  return Object.values(catalog).find((option) => option.aliases?.includes(runtimeId));
+}

--- a/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.ts
+++ b/apps/emdash-desktop/src/renderer/features/conversations/acp/acp-model-options.ts
@@ -14,6 +14,7 @@ export function mergeComposerModelOptions(
       return [
         id,
         {
+          ...option,
           name: metadata.name,
           ...(metadata.description && { description: metadata.description }),
           ...(metadata.modelFeatures && { modelFeatures: metadata.modelFeatures }),

--- a/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/task-config/initial-conversation-section.tsx
@@ -24,6 +24,7 @@ import {
   agentSupportsAcp,
   agentSupportsAutoApprove,
   type AgentCapabilities,
+  type AgentModelOption,
 } from '@shared/core/agents/agent-payload';
 import { extractIssueMentionTargets, issueMentionToken } from '@shared/core/issues/issue-context';
 import type { LinkedIssue } from '@shared/core/linked-issue';
@@ -140,7 +141,7 @@ export function useInitialConversationState(
 
 function useModelOptions(
   providerId: AgentProviderId | null
-): Record<string, { name: string }> | null {
+): Record<string, AgentModelOption> | null {
   const { data: agents } = useAgents();
   if (!providerId) return null;
   const models = agents?.find((a) => a.id === providerId)?.capabilities.models;

--- a/apps/emdash-desktop/src/shared/core/agents/agent-payload.ts
+++ b/apps/emdash-desktop/src/shared/core/agents/agent-payload.ts
@@ -161,6 +161,7 @@ export type AgentHostDependencyInfo = {
 
 export type AgentModelOption = {
   name: string;
+  aliases?: string[];
   description?: string;
   modelFeatures?: {
     contextWindowSize?: number;

--- a/packages/core/src/agents/plugins/capabilities/models.test.ts
+++ b/packages/core/src/agents/plugins/capabilities/models.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { modelOptionSchema } from './models';
+
+describe('modelOptionSchema', () => {
+  it('preserves provider-owned model aliases', () => {
+    expect(
+      modelOptionSchema.parse({
+        name: 'Claude Opus 4.8',
+        aliases: ['opus', 'opus[1m]'],
+        modelFeatures: { speed: 2, intelligence: 5 },
+      })
+    ).toEqual({
+      name: 'Claude Opus 4.8',
+      aliases: ['opus', 'opus[1m]'],
+      modelFeatures: { speed: 2, intelligence: 5 },
+    });
+  });
+});

--- a/packages/core/src/agents/plugins/capabilities/models.ts
+++ b/packages/core/src/agents/plugins/capabilities/models.ts
@@ -3,6 +3,8 @@ import z from 'zod';
 
 export const modelOptionSchema = z.object({
   name: z.string(),
+  /** Provider-owned model identifiers that resolve to this catalog entry. */
+  aliases: z.array(z.string()).optional(),
   description: z.string().optional(),
   modelFeatures: z
     .object({

--- a/packages/plugins/src/agents/impl/claude/index.ts
+++ b/packages/plugins/src/agents/impl/claude/index.ts
@@ -57,18 +57,27 @@ export const plugin = definePlugin(
       modelOptions: {
         'claude-fable-5': {
           name: 'Claude Fable 5',
+          aliases: ['fable', 'claude-fable-5[1m]'],
+          description:
+            'Most capable Claude model for the hardest and longest-running coding tasks.',
           modelFeatures: { intelligence: 4, speed: 3 },
         },
         'claude-opus-4-8': {
           name: 'Claude Opus 4.8',
+          aliases: ['opus', 'opus[1m]'],
+          description: 'Powerful Claude model for everyday complex tasks with a 1M context window.',
           modelFeatures: { intelligence: 5, speed: 2 },
         },
         'claude-sonnet-5': {
           name: 'Claude Sonnet 5',
+          aliases: ['sonnet'],
+          description: 'Efficient Claude model for routine coding tasks.',
           modelFeatures: { intelligence: 4, speed: 4 },
         },
         'claude-haiku-4-5': {
           name: 'Claude Haiku 4.5',
+          aliases: ['haiku'],
+          description: 'Fast Claude model for quick answers and lightweight coding tasks.',
           modelFeatures: { intelligence: 3, speed: 5 },
         },
       },

--- a/packages/plugins/src/agents/impl/claude/index.ts
+++ b/packages/plugins/src/agents/impl/claude/index.ts
@@ -57,16 +57,16 @@ export const plugin = definePlugin(
       modelOptions: {
         'claude-fable-5': {
           name: 'Claude Fable 5',
-          aliases: ['fable', 'claude-fable-5[1m]'],
+          aliases: ['claude-fable-5[1m]', 'fable'],
           description:
             'Most capable Claude model for the hardest and longest-running coding tasks.',
-          modelFeatures: { intelligence: 4, speed: 3 },
+          modelFeatures: { intelligence: 5, speed: 3 },
         },
         'claude-opus-4-8': {
           name: 'Claude Opus 4.8',
-          aliases: ['opus', 'opus[1m]'],
+          aliases: ['opus[1m]', 'opus'],
           description: 'Powerful Claude model for everyday complex tasks with a 1M context window.',
-          modelFeatures: { intelligence: 5, speed: 2 },
+          modelFeatures: { intelligence: 5, speed: 3 },
         },
         'claude-sonnet-5': {
           name: 'Claude Sonnet 5',

--- a/packages/plugins/src/agents/impl/codex/acp.test.ts
+++ b/packages/plugins/src/agents/impl/codex/acp.test.ts
@@ -12,6 +12,29 @@ describe('codex acp capability', () => {
   });
 });
 
+describe('codex model catalog', () => {
+  it('exposes the current selectable Codex models', () => {
+    const models = pluginRegistry.get('codex')!.capabilities.models;
+    expect(models.kind).toBe('selectable');
+    if (models.kind !== 'selectable') throw new Error('Expected selectable Codex models');
+
+    expect(Object.keys(models.modelOptions)).toEqual([
+      'gpt-5.6-sol',
+      'gpt-5.6-terra',
+      'gpt-5.6-luna',
+      'gpt-5.5',
+      'gpt-5.4',
+      'gpt-5.4-mini',
+      'gpt-5.3-codex-spark',
+    ]);
+    expect(models.modelOptions['gpt-5.4']).toEqual({
+      name: 'GPT-5.4',
+      description: 'Strong model for everyday coding.',
+      modelFeatures: { intelligence: 4, speed: 3 },
+    });
+  });
+});
+
 describe('codex acp behavior', () => {
   const codex = () => pluginRegistry.get('codex')!;
   const acpBehavior = () => codex().behavior.acp!;

--- a/packages/plugins/src/agents/impl/codex/index.ts
+++ b/packages/plugins/src/agents/impl/codex/index.ts
@@ -71,8 +71,13 @@ export const plugin = definePlugin(
         },
         'gpt-5.5': {
           name: 'GPT-5.5',
-          description: 'Recommended Codex model for complex coding and agentic workflows.',
+          description: 'Frontier model for complex coding, research, and real-world work.',
           modelFeatures: { intelligence: 5, speed: 3 },
+        },
+        'gpt-5.4': {
+          name: 'GPT-5.4',
+          description: 'Strong model for everyday coding.',
+          modelFeatures: { intelligence: 4, speed: 3 },
         },
         'gpt-5.4-mini': {
           name: 'GPT-5.4 Mini',

--- a/packages/runtime/src/acp-agents/runtime/resolve-initial-model-option.test.ts
+++ b/packages/runtime/src/acp-agents/runtime/resolve-initial-model-option.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { resolveInitialModelOption } from './resolve-initial-model-option';
+
+const catalog = {
+  'claude-opus-4-8': { aliases: ['opus[1m]', 'opus'] },
+  'claude-fable-5': { aliases: ['claude-fable-5[1m]', 'fable'] },
+};
+
+describe('resolveInitialModelOption', () => {
+  it('keeps a requested model when ACP offers that exact id', () => {
+    expect(resolveInitialModelOption('opus', ['default', 'opus'], catalog)).toBe('opus');
+  });
+
+  it('maps a catalog id to the alias offered by ACP', () => {
+    expect(
+      resolveInitialModelOption('claude-opus-4-8', ['default', 'opus', 'opus[1m]'], catalog)
+    ).toBe('opus[1m]');
+    expect(
+      resolveInitialModelOption('claude-fable-5', ['default', 'claude-fable-5[1m]'], catalog)
+    ).toBe('claude-fable-5[1m]');
+  });
+
+  it('does not select a model that the ACP session does not offer', () => {
+    expect(resolveInitialModelOption('claude-opus-4-8', ['default', 'haiku'], catalog)).toBeNull();
+    expect(resolveInitialModelOption('custom-model', ['default'], catalog)).toBeNull();
+  });
+});

--- a/packages/runtime/src/acp-agents/runtime/resolve-initial-model-option.ts
+++ b/packages/runtime/src/acp-agents/runtime/resolve-initial-model-option.ts
@@ -1,0 +1,17 @@
+type ModelCatalog = Record<string, { aliases?: string[] }>;
+
+export function resolveInitialModelOption(
+  requestedModel: string,
+  availableModels: readonly string[],
+  catalog?: ModelCatalog
+) {
+  if (availableModels.includes(requestedModel)) return requestedModel;
+  if (!catalog) return null;
+
+  const catalogEntry =
+    catalog[requestedModel] ??
+    Object.values(catalog).find((option) => option.aliases?.includes(requestedModel));
+  if (!catalogEntry) return null;
+
+  return catalogEntry.aliases?.find((alias) => availableModels.includes(alias)) ?? null;
+}

--- a/packages/runtime/src/acp-agents/runtime/session-manager.ts
+++ b/packages/runtime/src/acp-agents/runtime/session-manager.ts
@@ -67,6 +67,7 @@ import {
   type SessionLiveModels,
   type SessionsListModel,
 } from '../state/live-models';
+import { resolveInitialModelOption } from './resolve-initial-model-option';
 import type { AcpRuntimeDeps, AcpStartInput, SendPromptInput } from './types';
 
 interface SessionRecord {
@@ -163,16 +164,7 @@ export class SessionManager implements InboundRouter {
             modes: response.modes,
             configOptions: response.configOptions,
           });
-          if (input.model) {
-            const modelResult = await record.cell.setConfigOption('model', input.model);
-            if (!modelResult.success) {
-              this.deps.logger.warn('SessionManager: failed to apply initial model', {
-                conversationId: input.conversationId,
-                providerId: input.providerId,
-                error: modelResult.error,
-              });
-            }
-          }
+          await this.applyInitialModel(record);
           const queueResult = this.queueInitialPrompts(record);
           if (!queueResult.success) return queueResult;
           record.cell.endReplay();
@@ -208,16 +200,7 @@ export class SessionManager implements InboundRouter {
           modes: response.modes,
           configOptions: response.configOptions,
         });
-        if (input.model) {
-          const modelResult = await record.cell.setConfigOption('model', input.model);
-          if (!modelResult.success) {
-            this.deps.logger.warn('SessionManager: failed to apply initial model', {
-              conversationId: input.conversationId,
-              providerId: input.providerId,
-              error: modelResult.error,
-            });
-          }
-        }
+        await this.applyInitialModel(record);
         const queueResult = this.queueInitialPrompts(record);
         if (!queueResult.success) return queueResult;
         record.cell.applySessionReady();
@@ -512,6 +495,39 @@ export class SessionManager implements InboundRouter {
       if (!result.success) return result;
     }
     return ok();
+  }
+
+  private async applyInitialModel(record: SessionRecord): Promise<void> {
+    const requestedModel = record.input.model;
+    if (!requestedModel) return;
+
+    const availableModels =
+      record.cell.config.modelOptions?.available.map((model) => model.id) ?? [];
+    const modelsCapability = this.deps.agentHost.get(record.input.providerId)?.capabilities.models;
+    const catalog =
+      modelsCapability?.kind === 'selectable' ? modelsCapability.modelOptions : undefined;
+    const resolvedModel = resolveInitialModelOption(requestedModel, availableModels, catalog);
+
+    if (!resolvedModel) {
+      this.deps.logger.warn('SessionManager: initial model is not available', {
+        conversationId: record.input.conversationId,
+        providerId: record.input.providerId,
+        requestedModel,
+        availableModels,
+      });
+      return;
+    }
+
+    const modelResult = await record.cell.setConfigOption('model', resolvedModel);
+    if (!modelResult.success) {
+      this.deps.logger.warn('SessionManager: failed to apply initial model', {
+        conversationId: record.input.conversationId,
+        providerId: record.input.providerId,
+        requestedModel,
+        resolvedModel,
+        error: modelResult.error,
+      });
+    }
   }
 
   private syncRecord(record: SessionRecord): void {

--- a/packages/ui/src/react/components/chat-composer/chat-composer.stories.tsx
+++ b/packages/ui/src/react/components/chat-composer/chat-composer.stories.tsx
@@ -25,17 +25,17 @@ const MOCK_MODELS: Record<string, ComposerModelOption> = {
   'claude-opus-4': {
     name: 'Claude Opus 4',
     description: 'Most capable model for complex reasoning and nuanced tasks.',
-    modelFeatures: { contextWindowSize: 200_000, speed: 0.4, intelligence: 1 },
+    modelFeatures: { contextWindowSize: 200_000, speed: 2, intelligence: 5 },
   },
   'claude-sonnet-4-5': {
     name: 'Claude Sonnet 4.5',
     description: 'Excellent balance of speed and intelligence for everyday tasks.',
-    modelFeatures: { contextWindowSize: 200_000, speed: 0.75, intelligence: 0.85 },
+    modelFeatures: { contextWindowSize: 200_000, speed: 4, intelligence: 4 },
   },
   'gpt-4o': {
     name: 'GPT-4o',
     description: 'OpenAI flagship multimodal model.',
-    modelFeatures: { contextWindowSize: 128_000, speed: 0.7, intelligence: 0.9 },
+    modelFeatures: { contextWindowSize: 128_000, speed: 4, intelligence: 5 },
   },
 };
 

--- a/packages/ui/src/react/components/chat-composer/index.tsx
+++ b/packages/ui/src/react/components/chat-composer/index.tsx
@@ -23,6 +23,7 @@ import type {
 } from '../prompt-editor/types';
 import { ContextUsageIndicator } from './context-usage-indicator';
 import type { ContextUsage } from './context-usage-indicator';
+import { modelFeatureDotCount } from './model-feature-score';
 import { PermissionBand } from './permission-band';
 import type { ComposerPermissionRequest } from './permission-band';
 import { QueuedPromptsBand } from './queued-prompts-band';
@@ -131,7 +132,9 @@ export interface ComposerModelOption {
   /** Optional capability metadata shown in the hover card detail. */
   modelFeatures?: {
     contextWindowSize?: number;
+    /** Relative provider rating on a 1–5 scale. */
     speed?: number;
+    /** Relative provider rating on a 1–5 scale. */
     intelligence?: number;
   };
 }
@@ -343,7 +346,7 @@ function ModelFeatureRow({ label, value }: { label: string; value: React.ReactNo
 }
 
 function BarMeter({ value }: { value: number }) {
-  const filled = Math.round(Math.max(0, Math.min(1, value)) * 5);
+  const filled = modelFeatureDotCount(value);
   return (
     <span className={styles.barMeter}>
       {Array.from({ length: 5 }, (_, i) => (

--- a/packages/ui/src/react/components/chat-composer/model-feature-score.test.ts
+++ b/packages/ui/src/react/components/chat-composer/model-feature-score.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { modelFeatureDotCount } from './model-feature-score';
+
+describe('modelFeatureDotCount', () => {
+  it.each([
+    [1, 1],
+    [2, 2],
+    [4, 4],
+    [5, 5],
+  ])('renders a %i rating with %i filled dots', (score, expected) => {
+    expect(modelFeatureDotCount(score)).toBe(expected);
+  });
+
+  it('clamps ratings to the five-dot scale', () => {
+    expect(modelFeatureDotCount(-1)).toBe(0);
+    expect(modelFeatureDotCount(6)).toBe(5);
+  });
+});

--- a/packages/ui/src/react/components/chat-composer/model-feature-score.ts
+++ b/packages/ui/src/react/components/chat-composer/model-feature-score.ts
@@ -1,0 +1,3 @@
+export function modelFeatureDotCount(score: number) {
+  return Math.round(Math.max(0, Math.min(5, score)));
+}

--- a/packages/ui/src/react/examples/chat-panel.stories.tsx
+++ b/packages/ui/src/react/examples/chat-panel.stories.tsx
@@ -89,32 +89,32 @@ const MOCK_MODELS: Record<string, ComposerModelOption> = {
   'claude-opus-4': {
     name: 'Claude Opus 4',
     description: 'Most capable model for complex reasoning and nuanced tasks.',
-    modelFeatures: { contextWindowSize: 200_000, speed: 0.4, intelligence: 1.0 },
+    modelFeatures: { contextWindowSize: 200_000, speed: 2, intelligence: 5 },
   },
   'claude-sonnet-4-5': {
     name: 'Claude Sonnet 4.5',
     description: 'Excellent balance of speed and intelligence for everyday tasks.',
-    modelFeatures: { contextWindowSize: 200_000, speed: 0.75, intelligence: 0.85 },
+    modelFeatures: { contextWindowSize: 200_000, speed: 4, intelligence: 4 },
   },
   'claude-haiku-4': {
     name: 'Claude Haiku 4',
     description: 'Fast and efficient, great for high-volume straightforward tasks.',
-    modelFeatures: { contextWindowSize: 200_000, speed: 0.95, intelligence: 0.65 },
+    modelFeatures: { contextWindowSize: 200_000, speed: 5, intelligence: 3 },
   },
   'gpt-4o': {
     name: 'GPT-4o',
     description: 'OpenAI flagship multimodal model.',
-    modelFeatures: { contextWindowSize: 128_000, speed: 0.7, intelligence: 0.9 },
+    modelFeatures: { contextWindowSize: 128_000, speed: 4, intelligence: 5 },
   },
   'gpt-4o-mini': {
     name: 'GPT-4o Mini',
     description: 'Lightweight, cost-efficient GPT-4o variant.',
-    modelFeatures: { contextWindowSize: 128_000, speed: 0.9, intelligence: 0.7 },
+    modelFeatures: { contextWindowSize: 128_000, speed: 5, intelligence: 4 },
   },
   'gemini-2.5-pro': {
     name: 'Gemini 2.5 Pro',
     description: "Google's most capable model with a 1M context window.",
-    modelFeatures: { contextWindowSize: 1_000_000, speed: 0.6, intelligence: 0.95 },
+    modelFeatures: { contextWindowSize: 1_000_000, speed: 3, intelligence: 5 },
   },
 };
 


### PR DESCRIPTION
### Description

- Uses the same canonical names, descriptions, speed, and intelligence details in the Chat and New Task model pickers.
- Aligns the selectable Claude and Codex catalogs, including current aliases and GPT-5.4.
- Resolves canonical New Task model IDs to the IDs offered by the live ACP session before starting Chat.

This fixes the drift where Chat displayed less model information and could expose different model identifiers than New Task.

### Related issues

ENG-1853

### Screenshot/Recording (if applicable)

https://cap.link/wx48g22tpzwgfn4

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks or explained why not
- [x] I updated docs when behavior or setup changed (not applicable)
- [x] I added or updated tests when behavior changed, or explained why not
- [x] I only added comments where the logic is not obvious
- [x] I used [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/) for commit
  messages and, when possible, the PR title

</details>
