### PR TITLE
fix(sidebar): keep divider visible with open tabs

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
@@ -1,6 +1,7 @@
 import { Clock, FolderInput, Library, MessageSquareShare, Settings } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
 import React from 'react';
+import { useWorkspaceLayoutContext } from '@renderer/lib/layout/layout-provider';
 import {
   isCurrentView,
   useNavigate,
@@ -29,6 +30,7 @@ import { useSidebarDrop } from './use-sidebar-drop';
 export const LeftSidebar: React.FC = observer(function LeftSidebar() {
   const { navigate } = useNavigate();
   const { currentView } = useWorkspaceSlots();
+  const { isLeftOpen } = useWorkspaceLayoutContext();
 
   const showFeedbackModal = useShowModal('feedbackModal');
   const { isDragOver, onDragOver, onDragEnter, onDragLeave, onDrop } = useSidebarDrop();
@@ -36,7 +38,8 @@ export const LeftSidebar: React.FC = observer(function LeftSidebar() {
   return (
     <div
       className={cn(
-        'relative flex h-full flex-col border-r border-border bg-background-tertiary text-foreground-tertiary-muted transition-colors',
+        'relative flex h-full flex-col bg-background-tertiary text-foreground-tertiary-muted transition-colors',
+        isLeftOpen && 'border-r border-border',
         isDragOver && 'bg-accent/10 ring-2 ring-inset ring-accent/50'
       )}
       onDragOver={onDragOver}

--- a/apps/emdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
+++ b/apps/emdash-desktop/src/renderer/features/sidebar/left-sidebar.tsx
@@ -36,7 +36,7 @@ export const LeftSidebar: React.FC = observer(function LeftSidebar() {
   return (
     <div
       className={cn(
-        'relative flex flex-col h-full bg-background-tertiary text-foreground-tertiary-muted transition-colors',
+        'relative flex h-full flex-col border-r border-border bg-background-tertiary text-foreground-tertiary-muted transition-colors',
         isDragOver && 'bg-accent/10 ring-2 ring-inset ring-accent/50'
       )}
       onDragOver={onDragOver}

--- a/apps/emdash-desktop/src/renderer/lib/layout/workspace-layout.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/layout/workspace-layout.tsx
@@ -43,7 +43,7 @@ export function WorkspaceLayout({ leftSidebar, mainContent }: WorkspaceLayoutPro
       </ResizablePanel>
       <ResizableHandle
         className={cn(
-          'items-center justify-center transition-colors hover:bg-border/80',
+          'items-center justify-center bg-transparent transition-colors hover:bg-border/80',
           isLeftOpen ? 'flex' : 'hidden'
         )}
       />


### PR DESCRIPTION
## Summary

- keep the left sidebar divider visible when tab content is open
- render the divider on the persistent sidebar surface
- keep the adjacent resize handle transparent while preserving its hover state

## Root cause

The divider was rendered by the resize handle between panels, so mounted tab content could
visually cover it. Moving the border onto the sidebar keeps the boundary stable in both empty and
open-tab states.

Fixes ENG-1879.

## Screenshot
<img width="78" height="81" alt="Screenshot 2026-07-15 at 14 57 46" src="https://github.com/user-attachments/assets/3b734f75-8b2a-4acf-93cd-4f3760a618a4" />
<img width="93" height="81" alt="Screenshot 2026-07-15 at 14 57 42" src="https://github.com/user-attachments/assets/e7f519e5-f0cd-4584-8958-d25122df6994" />
