### PR TITLE
feat(pull-requests): add shared PR URL copy action

### DIFF
--- a/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
+++ b/apps/emdash-desktop/src/renderer/features/tasks/diff-view/changes-panel/components/pr-entry/pr-entry.tsx
@@ -1,6 +1,6 @@
-import { Check, Copy, ExternalLink } from 'lucide-react';
+import { ExternalLink } from 'lucide-react';
 import { observer } from 'mobx-react-lite';
-import { useEffect, useState, type MouseEvent } from 'react';
+import { useState } from 'react';
 import {
   useTaskViewContext,
   useWorkspaceViewModel,
@@ -8,11 +8,11 @@ import {
 import { PrMergeLine } from '@renderer/lib/components/pr-merge-line';
 import { PrNumberBadge } from '@renderer/lib/components/pr-number-badge';
 import { StatusIcon } from '@renderer/lib/components/pr-status-icon';
+import { PrUrlCopyButton } from '@renderer/lib/components/pr-url-copy-button';
 import { toast } from '@renderer/lib/hooks/use-toast';
 import { rpc } from '@renderer/lib/ipc';
 import { type SplitButtonAction } from '@renderer/lib/ui/split-button';
 import { ToggleGroup, ToggleGroupItem } from '@renderer/lib/ui/toggle-group';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
 import { cn } from '@renderer/utils/utils';
 import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
 import { PrChecksList } from './checks-list';
@@ -56,28 +56,6 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
   const [isMerging, setIsMerging] = useState(false);
   const [isMarkingReady, setIsMarkingReady] = useState(false);
   const [bypassRequirements, setBypassRequirements] = useState(false);
-  const [justCopied, setJustCopied] = useState(false);
-
-  useEffect(() => {
-    if (!justCopied) return;
-    const timer = window.setTimeout(() => setJustCopied(false), 1500);
-    return () => window.clearTimeout(timer);
-  }, [justCopied]);
-
-  const handleCopyPrUrl = async (e: MouseEvent) => {
-    e.stopPropagation();
-    try {
-      await navigator.clipboard.writeText(pr.url);
-      setJustCopied(true);
-      toast({ title: 'PR URL copied' });
-    } catch {
-      toast({
-        title: 'Copy failed',
-        description: 'The PR URL could not be copied to the clipboard.',
-        variant: 'destructive',
-      });
-    }
-  };
   if (!diffView) return null;
   const tab = diffView.effectivePrTab;
   const isOpen = pr.status === 'open';
@@ -143,24 +121,10 @@ export const PullRequestEntry = observer(function PullRequestEntry({ pr }: { pr:
               <ExternalLink className="size-3.5 text-foreground-muted" />
             </span>
           </button>
-          <Tooltip>
-            <TooltipTrigger
-              render={
-                <button
-                  type="button"
-                  aria-label={justCopied ? 'PR URL copied' : 'Copy PR URL'}
-                  onClick={handleCopyPrUrl}
-                  className={cn(
-                    'flex shrink-0 items-center justify-center rounded p-1 text-foreground-muted outline-none transition-opacity hover:bg-muted hover:text-foreground focus-visible:opacity-100 focus-visible:ring-3 focus-visible:ring-ring/50 group-hover/header:opacity-100',
-                    justCopied ? 'opacity-100' : 'opacity-0'
-                  )}
-                >
-                  {justCopied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
-                </button>
-              }
-            />
-            <TooltipContent>{justCopied ? 'Copied!' : 'Copy PR URL'}</TooltipContent>
-          </Tooltip>
+          <PrUrlCopyButton
+            url={pr.url}
+            className="opacity-0 group-hover/header:opacity-100 focus-visible:opacity-100"
+          />
         </div>
         <PrMergeLine pr={pr} />
       </div>

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-badge.tsx
@@ -1,5 +1,6 @@
 import { ExternalLink } from 'lucide-react';
 import { PrMergeLine } from '@renderer/lib/components/pr-merge-line';
+import { PrUrlCopyButton } from '@renderer/lib/components/pr-url-copy-button';
 import { Popover, PopoverContent, PopoverTrigger } from '@renderer/lib/ui/popover';
 import { cn } from '@renderer/utils/utils';
 import { getPrNumber, type PullRequest } from '@shared/core/pull-requests/pull-requests';
@@ -71,6 +72,7 @@ export function PrBadge({ variant = 'default', pr, className, hoverDelay }: PrBa
                 </TooltipTrigger>
                 <TooltipContent>Open PR on GitHub</TooltipContent>
               </Tooltip>
+              <PrUrlCopyButton url={pr.url} />
             </div>
             <RelativeTime
               value={pr.createdAt}

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-url-copy-button.tsx
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-url-copy-button.tsx
@@ -1,0 +1,63 @@
+import { Check, Copy } from 'lucide-react';
+import { useEffect, useRef, useState, type MouseEvent } from 'react';
+import { Button } from '@renderer/lib/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@renderer/lib/ui/tooltip';
+import { cn } from '@renderer/utils/utils';
+import { copyPrUrl } from './pr-url-copy';
+
+interface PrUrlCopyButtonProps {
+  url: string;
+  className?: string;
+}
+
+export function PrUrlCopyButton({ url, className }: PrUrlCopyButtonProps) {
+  const [copied, setCopied] = useState(false);
+  const resetTimerRef = useRef<number | null>(null);
+
+  useEffect(
+    () => () => {
+      if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
+    },
+    []
+  );
+
+  const handleCopy = async (event: MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    const copySucceeded = await copyPrUrl(url);
+    if (!copySucceeded) {
+      if (resetTimerRef.current !== null) {
+        window.clearTimeout(resetTimerRef.current);
+        resetTimerRef.current = null;
+      }
+      setCopied(false);
+      return;
+    }
+
+    setCopied(true);
+    if (resetTimerRef.current !== null) window.clearTimeout(resetTimerRef.current);
+    resetTimerRef.current = window.setTimeout(() => {
+      setCopied(false);
+      resetTimerRef.current = null;
+    }, 1500);
+  };
+
+  return (
+    <Tooltip>
+      <TooltipTrigger
+        render={
+          <Button
+            type="button"
+            aria-label={copied ? 'PR URL copied' : 'Copy PR URL'}
+            variant="ghost"
+            size="icon-xs"
+            className={cn('cursor-pointer', className, copied && 'opacity-100')}
+            onClick={handleCopy}
+          >
+            {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
+          </Button>
+        }
+      />
+      <TooltipContent>{copied ? 'Copied!' : 'Copy PR URL'}</TooltipContent>
+    </Tooltip>
+  );
+}

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-url-copy.test.ts
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-url-copy.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { copyPrUrl } from './pr-url-copy';
+
+const mocks = vi.hoisted(() => ({
+  clipboardWriteText: vi.fn(),
+  toast: vi.fn(),
+}));
+
+vi.mock('@renderer/lib/hooks/use-toast', () => ({
+  toast: mocks.toast,
+}));
+
+vi.mock('@renderer/lib/ipc', () => ({
+  rpc: {
+    app: {
+      clipboardWriteText: mocks.clipboardWriteText,
+    },
+  },
+}));
+
+describe('copyPrUrl', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.clipboardWriteText.mockResolvedValue({ success: true });
+  });
+
+  it('copies the PR URL through the app clipboard service and reports success', async () => {
+    await expect(copyPrUrl('https://github.com/emdash/emdash/pull/123')).resolves.toBe(true);
+
+    expect(mocks.clipboardWriteText).toHaveBeenCalledWith(
+      'https://github.com/emdash/emdash/pull/123'
+    );
+    expect(mocks.toast).toHaveBeenCalledWith({ title: 'PR URL copied' });
+  });
+
+  it('reports when the clipboard service returns a failure', async () => {
+    mocks.clipboardWriteText.mockResolvedValue({
+      success: false,
+      error: 'Clipboard unavailable',
+    });
+
+    await expect(copyPrUrl('https://github.com/emdash/emdash/pull/123')).resolves.toBe(false);
+
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Copy failed',
+      description: 'The PR URL could not be copied to the clipboard.',
+      variant: 'destructive',
+    });
+  });
+
+  it('reports when the clipboard request rejects', async () => {
+    mocks.clipboardWriteText.mockRejectedValue(new Error('IPC unavailable'));
+
+    await expect(copyPrUrl('https://github.com/emdash/emdash/pull/123')).resolves.toBe(false);
+
+    expect(mocks.toast).toHaveBeenCalledWith({
+      title: 'Copy failed',
+      description: 'The PR URL could not be copied to the clipboard.',
+      variant: 'destructive',
+    });
+  });
+});

--- a/apps/emdash-desktop/src/renderer/lib/components/pr-url-copy.ts
+++ b/apps/emdash-desktop/src/renderer/lib/components/pr-url-copy.ts
@@ -1,0 +1,26 @@
+import { toast } from '@renderer/lib/hooks/use-toast';
+import { rpc } from '@renderer/lib/ipc';
+
+export async function copyPrUrl(url: string): Promise<boolean> {
+  try {
+    const result = await rpc.app.clipboardWriteText(url);
+    if (!result.success) {
+      showCopyFailure();
+      return false;
+    }
+
+    toast({ title: 'PR URL copied' });
+    return true;
+  } catch {
+    showCopyFailure();
+    return false;
+  }
+}
+
+function showCopyFailure(): void {
+  toast({
+    title: 'Copy failed',
+    description: 'The PR URL could not be copied to the clipboard.',
+    variant: 'destructive',
+  });
+}


### PR DESCRIPTION
<img width="990" height="458" alt="CleanShot 2026-07-15 at 17 52 47@2x" src="https://github.com/user-attachments/assets/0cd22f26-b46b-4f54-bc0b-d65f524d6bef" />

### Description

Add a copy action to pull request hover cards in the left sidebar while keeping the existing right-sidebar action consistent. Both surfaces now use one shared PR URL copy component with accessible tooltip feedback, copied-state reset, and failure handling through the typed Electron clipboard RPC.

### Related issues

None.

### Testing

- `corepack pnpm exec vitest run --project node src/renderer/lib/components/pr-url-copy.test.ts`
- Focused `oxlint` on the touched renderer files
- `corepack pnpm exec tsgo --noEmit`
- Focused `oxfmt --check` on the touched renderer files
- `git diff --check`
- Structured self-review completed with no actionable findings

### Screenshot/Recording (if applicable)

Not attached.

<details>
<summary>Checklist</summary>

- [x] I kept this PR small and focused
- [x] I ran a self-review before opening this PR
- [x] I ran the relevant local checks
- [x] Documentation is not required for this focused UI behavior change
- [x] I added focused tests for clipboard success and failure behavior
- [x] I only added comments where the logic is not obvious
- [x] I used Conventional Commits for the commit message and PR title

</details>