### PR TITLE
fix(linux): set desktopFileName for GNOME Wayland dock icon association

### DIFF
--- a/apps/emdash-desktop/src/main/app/configure-app-identity.ts
+++ b/apps/emdash-desktop/src/main/app/configure-app-identity.ts
@@ -1,12 +1,19 @@
 import { join } from 'node:path';
 import { app } from 'electron';
-import { APP_NAME_LOWER, PRODUCT_NAME, USER_DATA_DIR_NAME } from '@shared/app-identity';
+import {
+  APP_NAME_LOWER,
+  IS_CANARY,
+  PRODUCT_NAME,
+  USER_DATA_DIR_NAME,
+} from '@shared/app-identity';
 
 app.setName(PRODUCT_NAME);
 app.setPath('userData', join(app.getPath('appData'), USER_DATA_DIR_NAME));
 
-// Associate the running window with the installed .desktop file so GNOME Wayland
-// can display the correct dock icon and group windows with the launcher entry.
+// Must match the .desktop filename produced by electron-builder: stable uses
+// PRODUCT_NAME (executableName defaults to productName), canary overrides
+// linux.executableName to APP_NAME_LOWER.
 if (process.platform === 'linux') {
-  app.desktopFileName = `${APP_NAME_LOWER}.desktop`;
+  const desktopName = IS_CANARY ? APP_NAME_LOWER : PRODUCT_NAME;
+  app.desktopFileName = `${desktopName}.desktop`;
 }

--- a/apps/emdash-desktop/src/main/app/configure-app-identity.ts
+++ b/apps/emdash-desktop/src/main/app/configure-app-identity.ts
@@ -1,6 +1,12 @@
 import { join } from 'node:path';
 import { app } from 'electron';
-import { PRODUCT_NAME, USER_DATA_DIR_NAME } from '@shared/app-identity';
+import { APP_NAME_LOWER, PRODUCT_NAME, USER_DATA_DIR_NAME } from '@shared/app-identity';
 
 app.setName(PRODUCT_NAME);
 app.setPath('userData', join(app.getPath('appData'), USER_DATA_DIR_NAME));
+
+// Associate the running window with the installed .desktop file so GNOME Wayland
+// can display the correct dock icon and group windows with the launcher entry.
+if (process.platform === 'linux') {
+  app.desktopFileName = `${APP_NAME_LOWER}.desktop`;
+}


### PR DESCRIPTION
## Summary

On GNOME Wayland, the desktop environment matches running windows to `.desktop` files using the Wayland `app_id`. Without an explicit `desktopFileName`, Electron cannot associate the window with the installed launcher entry — causing an incorrect or generic dock icon and preventing window grouping (window shows as `<untracked>` in GNOME Looking Glass).

## Changes

Set `app.desktopFileName` in `configure-app-identity.ts` so Electron reports the correct `app_id` matching the installed `.desktop` file. This uses the existing `APP_NAME_LOWER` constant for consistency across stable/canary builds.

The change is guarded by `process.platform === 'linux'` — no effect on macOS or Windows.

## Testing

This is a platform-specific runtime behavior (Wayland compositor ↔ desktop file association). Verification requires running on GNOME Wayland and observing the dock icon behavior. The Electron `app.desktopFileName` API is stable and documented since Electron 28.

Closes #2881

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.